### PR TITLE
perf(python): bound websocket handshake header work

### DIFF
--- a/crates/runner/mitm-addon/src/http_header_syntax.py
+++ b/crates/runner/mitm-addon/src/http_header_syntax.py
@@ -40,30 +40,83 @@ def has_forbidden_header_value_control(value: str) -> bool:
     )
 
 
-def header_values_contain_token(values: Sequence[str], expected: str) -> bool:
+def header_values_contain_token(
+    values: Sequence[str],
+    expected: str,
+    *,
+    max_work_units: int,
+) -> bool:
     """Return whether any field value contains ``expected`` as a list token.
 
-    Each field value is split on commas. Each resulting token has only HTTP OWS
-    (SP and HTAB) stripped from its edges, then is lowercased before comparison.
-    Callers must provide ``expected`` in the desired lowercase comparison form;
-    this helper does not normalize that argument or apply other whitespace or
-    token validation.
+    Matching consumes one work unit per field value and one per inspected
+    character. It stops at ``max_work_units`` and fails closed without scanning
+    the remaining input. A complete early match returns before an irrelevant
+    suffix. Only HTTP OWS (SP and HTAB) is ignored at token edges, and comparison
+    is ASCII case-insensitive. Callers must provide ``expected`` in lowercase
+    ASCII and choose a work limit for their trust boundary.
     """
-    return any(
-        token.strip(_HTTP_OWS_CHARS).lower() == expected
-        for value in values
-        for token in value.split(",")
-    )
+    expected_upper = expected.upper()
+    work_units = 0
+
+    for value in values:
+        if work_units >= max_work_units:
+            return False
+        work_units += 1
+        token_matches = True
+        matched_chars = 0
+
+        value_index = 0
+        while value_index < len(value):
+            if work_units >= max_work_units:
+                return False
+            char = value[value_index]
+            value_index += 1
+            work_units += 1
+
+            if char == ",":
+                if token_matches and matched_chars == len(expected):
+                    return True
+                token_matches = True
+                matched_chars = 0
+                continue
+
+            if not token_matches:
+                continue
+            if matched_chars == 0 and char in _HTTP_OWS_CHARS:
+                continue
+            if matched_chars == len(expected):
+                if char not in _HTTP_OWS_CHARS:
+                    token_matches = False
+                continue
+            expected_char = expected[matched_chars]
+            if char == expected_char or char == expected_upper[matched_chars]:
+                matched_chars += 1
+            else:
+                token_matches = False
+
+        if token_matches and matched_chars == len(expected):
+            return True
+
+    return False
 
 
-def single_header_value(values: Sequence[str]) -> str | None:
+def single_header_value(
+    values: Sequence[str],
+    *,
+    max_value_chars: int,
+) -> str | None:
     """Return one header value with HTTP OWS stripped, or ``None`` if not singleton.
 
     ``None`` represents missing or repeated field values: ``values`` must contain
-    exactly one item. Only SP and HTAB are stripped from that item, so a blank
-    singleton returns an empty string and other whitespace is preserved. Callers
-    remain responsible for validating the returned value's content.
+    exactly one item. Values above ``max_value_chars`` are rejected before
+    stripping, which bounds the possible copy. Only SP and HTAB are stripped
+    from the item, so a blank singleton returns an empty string and other
+    whitespace is preserved. Callers remain responsible for validating the
+    returned value's content.
     """
     if len(values) != 1:
         return None
-    return values[0].strip(_HTTP_OWS_CHARS)
+    value = values[0]
+    if len(value) > max_value_chars:
+        return None
+    return value.strip(_HTTP_OWS_CHARS)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -153,6 +153,8 @@ _STALE_FIREWALL_AUTHORIZATION_METADATA_KEYS = (
 _AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD"))
 _HTTP_RESPONSE_BODYLESS_METHODS = frozenset(("CONNECT", "HEAD"))
 _WEBSOCKET_KEY_BYTES = 16
+_WEBSOCKET_KEY_BASE64_CHARS = 24
+_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT = 8 * 1024
 _BufferedRequestBodyCheckKind = Literal["ok", "too_large", "length_required"]
 
 
@@ -1500,9 +1502,15 @@ def _maybe_normalize_accept_encoding_for_body_inspection(
     allow: matching.FirewallAllow,
     sandbox_info: dict,
 ) -> None:
-    if _is_websocket_upgrade_request(flow):
+    is_websocket_upgrade = _is_websocket_upgrade_request(flow)
+    if is_websocket_upgrade:
         flow.metadata[metadata_keys.WEBSOCKET_UPGRADE_REQUEST] = True
-    if _expects_http_response_body_usage_inspection(flow, allow, sandbox_info):
+    if _expects_http_response_body_usage_inspection(
+        flow,
+        allow,
+        sandbox_info,
+        is_websocket_upgrade=is_websocket_upgrade,
+    ):
         flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = (
             response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(
                 flow.request.headers
@@ -1514,10 +1522,12 @@ def _expects_http_response_body_usage_inspection(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
     sandbox_info: dict,
+    *,
+    is_websocket_upgrade: bool,
 ) -> bool:
     if flow.request.method.upper() in _HTTP_RESPONSE_BODYLESS_METHODS:
         return False
-    if _is_websocket_upgrade_request(flow):
+    if is_websocket_upgrade:
         return False
     if allow.name.startswith("model-provider:") and is_billable_firewall(allow.name, sandbox_info):
         return True
@@ -1532,26 +1542,34 @@ def _is_websocket_upgrade_request(flow: http.HTTPFlow) -> bool:
     if flow.request.http_version != "HTTP/1.1":
         return False
     if not http_header_syntax.header_values_contain_token(
-        flow.request.headers.get_all("Upgrade"), "websocket"
+        flow.request.headers.get_all("Upgrade"),
+        "websocket",
+        max_work_units=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
     ):
         return False
     websocket_key = http_header_syntax.single_header_value(
-        flow.request.headers.get_all("Sec-WebSocket-Key")
+        flow.request.headers.get_all("Sec-WebSocket-Key"),
+        max_value_chars=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
     )
     if websocket_key is None or not _is_valid_websocket_key(websocket_key):
         return False
     websocket_version = http_header_syntax.single_header_value(
-        flow.request.headers.get_all("Sec-WebSocket-Version")
+        flow.request.headers.get_all("Sec-WebSocket-Version"),
+        max_value_chars=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
     )
     if websocket_version != "13":
         return False
 
     return http_header_syntax.header_values_contain_token(
-        flow.request.headers.get_all("Connection"), "upgrade"
+        flow.request.headers.get_all("Connection"),
+        "upgrade",
+        max_work_units=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
     )
 
 
 def _is_valid_websocket_key(value: str) -> bool:
+    if len(value) != _WEBSOCKET_KEY_BASE64_CHARS:
+        return False
     try:
         decoded = base64.b64decode(value, validate=True)
     except (binascii.Error, ValueError):
@@ -1571,7 +1589,10 @@ def responseheaders(flow: http.HTTPFlow) -> None:
         return
     if connector_diagnostics.install_response_stream_if_needed(flow):
         return
-    response_streaming.configure_response_stream(flow)
+    response_streaming.configure_response_stream(
+        flow,
+        websocket_header_work_limit=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
+    )
     codex_model_catalog_cache.wrap_response_stream(flow)
 
 
@@ -1696,7 +1717,10 @@ def websocket_end(flow: http.HTTPFlow) -> None:
 
 
 def _should_retain_model_websocket_tracking(flow: http.HTTPFlow) -> bool:
-    return response_streaming.is_confirmed_websocket_upgrade_response(flow) and (
+    return response_streaming.is_confirmed_websocket_upgrade_response(
+        flow,
+        websocket_header_work_limit=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
+    ) and (
         model_websocket_usage.is_enabled(flow)
         or model_provider_failure.should_observe_websocket_server_event(flow)
     )
@@ -1847,7 +1871,10 @@ def _finish_response_handling(
         not flow.metadata.get(metadata_keys.MODEL_JSON_USAGE_FINALIZED)
         and not flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
         and stream_buf
-        and response_streaming.uses_model_json_fallback(flow)
+        and response_streaming.uses_model_json_fallback(
+            flow,
+            websocket_header_work_limit=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
+        )
     ):
         model_protocol = response_streaming.model_usage_protocol(flow)
         json_usage, json_error = usage.extract_model_usage_with_error_from_json(

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -39,6 +39,8 @@ _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
 _HTTP_STATUS_OK_MIN = 200
 _HTTP_STATUS_REDIRECT_MIN = 300
 _HTTP_STATUS_BAD_GATEWAY = 502
+_WEBSOCKET_KEY_BASE64_CHARS = 24
+_WEBSOCKET_ACCEPT_BASE64_CHARS = 28
 
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
@@ -91,7 +93,11 @@ def model_usage_protocol(flow: http.HTTPFlow) -> usage.ModelUsageProtocol:
     return "anthropic_messages"
 
 
-def uses_model_json_fallback(flow: http.HTTPFlow) -> bool:
+def uses_model_json_fallback(
+    flow: http.HTTPFlow,
+    *,
+    websocket_header_work_limit: int,
+) -> bool:
     """Return whether terminal model usage may parse a buffered JSON body."""
     response = flow.response
     if (
@@ -102,7 +108,10 @@ def uses_model_json_fallback(flow: http.HTTPFlow) -> bool:
         return False
     if http_response_classification.has_event_stream_media_type(response):
         return False
-    return not is_confirmed_websocket_upgrade_response(flow)
+    return not is_confirmed_websocket_upgrade_response(
+        flow,
+        websocket_header_work_limit=websocket_header_work_limit,
+    )
 
 
 def _make_response_decode_session(
@@ -180,6 +189,8 @@ def _log_response_encoding_fail_closed(
 def _configure_response_inspection_stream(
     flow: http.HTTPFlow,
     failure_observer: model_provider_failure.HttpResponseFailureObserver | None,
+    *,
+    websocket_header_work_limit: int,
 ) -> _ResponseStreamSetup:
     # Set up model inspection or connector usage extraction for response classes
     # that need it. Parsers consume chunks separately from the optional buffer.
@@ -200,7 +211,10 @@ def _configure_response_inspection_stream(
     if (
         is_billable_model_provider
         and model_protocol == "openai_responses"
-        and is_confirmed_websocket_upgrade_response(flow)
+        and is_confirmed_websocket_upgrade_response(
+            flow,
+            websocket_header_work_limit=websocket_header_work_limit,
+        )
     ):
         model_websocket_usage.activate(flow)
         return _ResponseStreamSetup(None, False)
@@ -347,7 +361,13 @@ def _configure_response_inspection_stream(
                 response.headers
             ) and (
                 failure_observer is not None
-                or (is_billable_model_provider and uses_model_json_fallback(flow))
+                or (
+                    is_billable_model_provider
+                    and uses_model_json_fallback(
+                        flow,
+                        websocket_header_work_limit=websocket_header_work_limit,
+                    )
+                )
             )
             if not needs_buffered_fallback:
                 if failure_observer is not None:
@@ -467,7 +487,11 @@ def _configure_response_inspection_stream(
     return _ResponseStreamSetup(None, False)
 
 
-def is_confirmed_websocket_upgrade_response(flow: http.HTTPFlow) -> bool:
+def is_confirmed_websocket_upgrade_response(
+    flow: http.HTTPFlow,
+    *,
+    websocket_header_work_limit: int,
+) -> bool:
     """Return whether ``flow`` completed a confirmed WebSocket upgrade.
 
     Confirmation requires a response with status 101, the exact ``True``
@@ -491,21 +515,32 @@ def is_confirmed_websocket_upgrade_response(flow: http.HTTPFlow) -> bool:
     if flow.metadata.get(metadata_keys.WEBSOCKET_UPGRADE_REQUEST) is not True:
         return False
     if not http_header_syntax.header_values_contain_token(
-        response.headers.get_all("Upgrade"), "websocket"
+        response.headers.get_all("Upgrade"),
+        "websocket",
+        max_work_units=websocket_header_work_limit,
     ):
         return False
     if not http_header_syntax.header_values_contain_token(
-        response.headers.get_all("Connection"), "upgrade"
+        response.headers.get_all("Connection"),
+        "upgrade",
+        max_work_units=websocket_header_work_limit,
     ):
         return False
 
     request_key = http_header_syntax.single_header_value(
-        flow.request.headers.get_all("Sec-WebSocket-Key")
+        flow.request.headers.get_all("Sec-WebSocket-Key"),
+        max_value_chars=websocket_header_work_limit,
     )
     response_accept = http_header_syntax.single_header_value(
-        response.headers.get_all("Sec-WebSocket-Accept")
+        response.headers.get_all("Sec-WebSocket-Accept"),
+        max_value_chars=websocket_header_work_limit,
     )
-    if request_key is None or response_accept is None:
+    if (
+        request_key is None
+        or len(request_key) != _WEBSOCKET_KEY_BASE64_CHARS
+        or response_accept is None
+        or len(response_accept) != _WEBSOCKET_ACCEPT_BASE64_CHARS
+    ):
         return False
     try:
         expected_accept = generate_accept_token(request_key.encode("ascii")).decode("ascii")
@@ -528,7 +563,11 @@ def _reject_uninspectable_response(flow: http.HTTPFlow) -> None:
     flow.response.stream = _discard_uninspectable_response_body
 
 
-def configure_response_stream(flow: http.HTTPFlow) -> None:
+def configure_response_stream(
+    flow: http.HTTPFlow,
+    *,
+    websocket_header_work_limit: int,
+) -> None:
     """Enable pass-through response streaming and body consumers.
 
     Every configured response records exact streamed bytes. A capped raw-wire
@@ -540,7 +579,11 @@ def configure_response_stream(flow: http.HTTPFlow) -> None:
 
     metrics = {"total_bytes": 0}
     failure_observer = model_provider_failure.configure_response_observer(flow)
-    setup = _configure_response_inspection_stream(flow, failure_observer)
+    setup = _configure_response_inspection_stream(
+        flow,
+        failure_observer,
+        websocket_header_work_limit=websocket_header_work_limit,
+    )
     if setup.reject_uninspectable:
         _log_response_encoding_fail_closed(flow, flow.response)
         _reject_uninspectable_response(flow)

--- a/crates/runner/mitm-addon/tests/test_http_header_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_http_header_syntax.py
@@ -13,6 +13,26 @@ import http_header_syntax
 # independent of http_header_syntax._HTTP_TOKEN_CHARS so mutations are caught.
 _TCHAR = frozenset("!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 _ASCII_CODE_POINTS = range(128)
+_TEST_HEADER_WORK_LIMIT = 256
+
+
+class _EarlyMatchSuffixGuard(str):
+    def __getitem__(self, key: int | slice) -> str:
+        if isinstance(key, int) and key >= len("websocket,"):
+            raise AssertionError("token matcher inspected the irrelevant suffix")
+        return super().__getitem__(key)
+
+
+class _WorkLimitGuard(str):
+    def __getitem__(self, key: int | slice) -> str:
+        if isinstance(key, int) and key >= 8:
+            raise AssertionError("token matcher read beyond its work budget")
+        return super().__getitem__(key)
+
+
+class _StripGuard(str):
+    def strip(self, chars: str | None = None) -> str:
+        raise AssertionError("oversized singleton was stripped")
 
 
 def _is_forbidden_value_control(char: str) -> bool:
@@ -128,7 +148,34 @@ def test_header_values_contain_token(
     *,
     contains_token: bool,
 ) -> None:
-    assert http_header_syntax.header_values_contain_token(values, expected_token) is contains_token
+    assert (
+        http_header_syntax.header_values_contain_token(
+            values,
+            expected_token,
+            max_work_units=_TEST_HEADER_WORK_LIMIT,
+        )
+        is contains_token
+    )
+
+
+def test_header_values_contain_token_stops_before_matched_suffix() -> None:
+    value = _EarlyMatchSuffixGuard("websocket," + "x" * 10_000)
+
+    assert http_header_syntax.header_values_contain_token(
+        (value,),
+        "websocket",
+        max_work_units=_TEST_HEADER_WORK_LIMIT,
+    )
+
+
+def test_header_values_contain_token_stops_at_work_limit() -> None:
+    value = _WorkLimitGuard("x" * 10_000)
+
+    assert not http_header_syntax.header_values_contain_token(
+        (value,),
+        "websocket",
+        max_work_units=9,
+    )
 
 
 @pytest.mark.parametrize(
@@ -153,4 +200,16 @@ def test_single_header_value(
     values: tuple[str, ...],
     expected_value: str | None,
 ) -> None:
-    assert http_header_syntax.single_header_value(values) == expected_value
+    assert (
+        http_header_syntax.single_header_value(
+            values,
+            max_value_chars=_TEST_HEADER_WORK_LIMIT,
+        )
+        == expected_value
+    )
+
+
+def test_single_header_value_rejects_oversized_value_before_strip() -> None:
+    value = _StripGuard("  value  ")
+
+    assert http_header_syntax.single_header_value((value,), max_value_chars=8) is None

--- a/crates/runner/mitm-addon/tests/test_http_header_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_http_header_syntax.py
@@ -16,23 +16,29 @@ _ASCII_CODE_POINTS = range(128)
 _TEST_HEADER_WORK_LIMIT = 256
 
 
-class _EarlyMatchSuffixGuard(str):
+class _FullValueOperationGuard(str):
+    def split(self, sep: str | None = None, maxsplit: int = -1) -> list[str]:
+        raise AssertionError(f"guarded header was split with sep={sep!r}, maxsplit={maxsplit}")
+
+    def lower(self) -> str:
+        raise AssertionError("guarded header was lowercased")
+
+    def strip(self, chars: str | None = None) -> str:
+        raise AssertionError(f"guarded header was stripped with chars={chars!r}")
+
+
+class _EarlyMatchSuffixGuard(_FullValueOperationGuard):
     def __getitem__(self, key: int | slice) -> str:
         if isinstance(key, int) and key >= len("websocket,"):
             raise AssertionError("token matcher inspected the irrelevant suffix")
         return super().__getitem__(key)
 
 
-class _WorkLimitGuard(str):
+class _WorkLimitGuard(_FullValueOperationGuard):
     def __getitem__(self, key: int | slice) -> str:
         if isinstance(key, int) and key >= 8:
             raise AssertionError("token matcher read beyond its work budget")
         return super().__getitem__(key)
-
-
-class _StripGuard(str):
-    def strip(self, chars: str | None = None) -> str:
-        raise AssertionError("oversized singleton was stripped")
 
 
 def _is_forbidden_value_control(char: str) -> bool:
@@ -210,6 +216,6 @@ def test_single_header_value(
 
 
 def test_single_header_value_rejects_oversized_value_before_strip() -> None:
-    value = _StripGuard("  value  ")
+    value = _FullValueOperationGuard("  value  ")
 
     assert http_header_syntax.single_header_value((value,), max_value_chars=8) is None

--- a/crates/runner/mitm-addon/tests/test_http_header_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_http_header_syntax.py
@@ -30,14 +30,14 @@ class _FullValueOperationGuard(str):
 class _EarlyMatchSuffixGuard(_FullValueOperationGuard):
     def __getitem__(self, key: int | slice) -> str:
         if isinstance(key, int) and key >= len("websocket,"):
-            raise AssertionError("token matcher inspected the irrelevant suffix")
+            raise IndexError("token matcher inspected the irrelevant suffix")
         return super().__getitem__(key)
 
 
 class _WorkLimitGuard(_FullValueOperationGuard):
     def __getitem__(self, key: int | slice) -> str:
         if isinstance(key, int) and key >= 8:
-            raise AssertionError("token matcher read beyond its work budget")
+            raise IndexError("token matcher read beyond its work budget")
         return super().__getitem__(key)
 
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_parser_setup.py
@@ -54,7 +54,10 @@ class TestResponseHeadersModelJsonParser:
 
         mitm_addon.responseheaders(flow)
 
-        assert response_streaming.uses_model_json_fallback(flow)
+        assert response_streaming.uses_model_json_fallback(
+            flow,
+            websocket_header_work_limit=8 * 1024,
+        )
         assert "model_json_usage_finish" in flow.metadata
         assert "model_sse_usage_finish" not in flow.metadata
         body = b'{"model":"gpt-5.5","usage":{"input_tokens":12,"output_tokens":7}}'

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_lifecycle.py
@@ -51,6 +51,21 @@ def _write_openai_model_websocket_registry(tmp_path: Path) -> Path:
 class TestModelProviderWebSocketLifecycle:
     """Tests for HTTP upgrade and terminal in-flight lifecycle behavior."""
 
+    @pytest.mark.parametrize(
+        "response_headers",
+        [
+            pytest.param(
+                make_openai_responses_websocket_response_headers(),
+                id="standard",
+            ),
+            pytest.param(
+                make_openai_responses_websocket_response_headers(
+                    connection="Upgrade," + "x" * 10_000,
+                ),
+                id="connection-token-before-oversized-suffix",
+            ),
+        ],
+    )
     async def test_model_websocket_response_keeps_usage_flow_tracked_until_end(
         self,
         tmp_path,
@@ -59,6 +74,7 @@ class TestModelProviderWebSocketLifecycle:
         fake_firewall_headers,
         usage_webhook_server,
         sync_usage_executor,
+        response_headers: http.Headers,
     ):
         """The HTTP 101 response hook must not complete the WebSocket usage lifecycle."""
         pending_path = tmp_path / "usage-pending"
@@ -83,7 +99,7 @@ class TestModelProviderWebSocketLifecycle:
 
             flow.response = tutils.tresp(
                 status_code=101,
-                headers=make_openai_responses_websocket_response_headers(),
+                headers=response_headers,
             )
             mitm_addon.responseheaders(flow)
             mitm_addon.response(flow)
@@ -197,6 +213,14 @@ class TestModelProviderWebSocketLifecycle:
             pytest.param(
                 make_openai_responses_websocket_response_headers(accept="wrong"),
                 id="wrong-accept",
+            ),
+            pytest.param(
+                make_openai_responses_websocket_response_headers(upgrade="x" * (8 * 1024 + 1)),
+                id="upgrade-token-work-limit",
+            ),
+            pytest.param(
+                make_openai_responses_websocket_response_headers(accept="x" * (8 * 1024 + 1)),
+                id="accept-work-limit",
             ),
         ],
     )

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -20,6 +20,8 @@ _X_FIREWALL_NAME = "x"
 _X_HOST = "api.x.com"
 _X_PATH = "/2/users/by"
 _ACCEPT_ENCODING = "Accept-Encoding"
+_WEBSOCKET_HEADER_WORK_LIMIT = 8 * 1024
+_WEBSOCKET_KEY = "dGhlIHNhbXBsZSBub25jZQ=="
 _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) HeadlessChrome/126.0.0.0 Safari/537.36"
@@ -768,6 +770,27 @@ async def test_header_phase_websocket_auth_fallback_restores_upgrade_marker(
             ),
             id="repeated-upgrade-header",
         ),
+        pytest.param(
+            (
+                ("Connection", "Upgrade," + "x" * 10_000),
+                ("Upgrade", "websocket"),
+                ("Sec-WebSocket-Key", _WEBSOCKET_KEY),
+                ("Sec-WebSocket-Version", "13"),
+            ),
+            id="connection-token-before-oversized-suffix",
+        ),
+        pytest.param(
+            (
+                ("Connection", "Upgrade"),
+                ("Upgrade", "websocket"),
+                (
+                    "Sec-WebSocket-Key",
+                    " " * (_WEBSOCKET_HEADER_WORK_LIMIT - len(_WEBSOCKET_KEY)) + _WEBSOCKET_KEY,
+                ),
+                ("Sec-WebSocket-Version", "13"),
+            ),
+            id="websocket-key-at-raw-work-boundary",
+        ),
     ],
 )
 async def test_model_provider_websocket_upgrade_injects_auth_and_keeps_accept_encoding(
@@ -966,6 +989,27 @@ async def test_response_bodyless_usage_inspected_methods_keep_accept_encoding(
             ),
             id="unsupported-websocket-version",
         ),
+        pytest.param(
+            (
+                ("Connection", "Upgrade"),
+                ("Upgrade", "x" * (_WEBSOCKET_HEADER_WORK_LIMIT + 1)),
+                ("Sec-WebSocket-Key", _WEBSOCKET_KEY),
+                ("Sec-WebSocket-Version", "13"),
+            ),
+            id="upgrade-token-work-limit",
+        ),
+        pytest.param(
+            (
+                ("Connection", "Upgrade"),
+                ("Upgrade", "websocket"),
+                (
+                    "Sec-WebSocket-Key",
+                    " " * (_WEBSOCKET_HEADER_WORK_LIMIT + 1) + _WEBSOCKET_KEY,
+                ),
+                ("Sec-WebSocket-Version", "13"),
+            ),
+            id="websocket-key-raw-work-limit",
+        ),
     ],
 )
 async def test_invalid_websocket_upgrade_normalizes_accept_encoding(
@@ -1061,6 +1105,15 @@ async def test_invalid_websocket_upgrade_http_version_normalizes_accept_encoding
         await mitm_addon.request(flow)
 
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, br"
+
+
+def test_oversized_websocket_key_is_rejected_before_base64_decode(monkeypatch) -> None:
+    def fail_decode(_value: str, *, validate: bool) -> bytes:
+        raise AssertionError(f"oversized key reached Base64 decoder with validate={validate}")
+
+    monkeypatch.setattr(mitm_addon.base64, "b64decode", fail_decode)
+
+    assert not mitm_addon._is_valid_websocket_key("A" * 25)
 
 
 async def test_browser_passthrough_keeps_accept_encoding_for_parser_connector(


### PR DESCRIPTION
## Summary

- replace eager comma splitting/lowercasing with a budgeted ASCII token scanner that stops at an early match
- bound singleton OWS trimming, WebSocket key decoding, and response accept generation with one 8,192-unit handshake policy
- reuse request upgrade classification for metadata and response-body inspection negotiation
- cover parser boundaries plus real request and response lifecycle behavior

## Behavior

- Normal repeated fields, comma lists, ASCII casing, SP/HTAB trimming, version `13`, valid 16-byte nonces, and confirmed `101` responses remain supported.
- Work-budget exhaustion fails closed as ordinary HTTP classification; it does not reject the HTTP request.
- A matching token before a large suffix returns without inspecting the suffix.

## Exclusions

- This does not add a mitmproxy request-head limit or bypass `Headers.get_all()` string materialization.
- No API, database, queue payload, migration, feature switch, or persisted-state change is included.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_http_header_syntax.py tests/test_response_encoding_negotiation.py tests/test_model_provider_websocket_lifecycle.py tests/test_model_provider_response_parser_setup.py` (407 passed)
- `uv run --no-sync python -m pytest tests/` (7,304 passed)
- 100,000 generated ASCII compatibility cases matched the previous token semantics below the budget

On the issue's 8 MiB shapes, the new helper's median was 0.001 ms for an early match and 0.399 ms for a bounded no-match, with 64 bytes peak traced helper allocation in both cases.

Closes #31319
