### PR TITLE
ci: parallelize host cpu fairness tests across available cpus

### DIFF
--- a/.github/scripts/runner-behavior-host-cpu-fairness.sh
+++ b/.github/scripts/runner-behavior-host-cpu-fairness.sh
@@ -53,6 +53,8 @@ ROOTFS_HASH=$2
 EXECUTION_KEY=$3
 BASE_DIR="/var/lib/vm0-runner/host-cpu-fairness/${EXECUTION_KEY}"
 UNIT="vm0-host-cpu-managed-${EXECUTION_KEY}"
+LOCK_DIR="/run/lock/vm0-host-cpu-fairness"
+LOCK_FD=""
 
 case "$EXECUTION_KEY" in
   ''|*[!a-zA-Z0-9._-]*)
@@ -65,8 +67,75 @@ cleanup() {
   sudo systemctl stop "${UNIT}.service" 2>/dev/null || true
   sudo rm -f -- "$TEST_BIN"
   sudo rm -rf -- "$BASE_DIR"
+  if [ -n "$LOCK_FD" ]; then
+    flock --unlock "$LOCK_FD" || true
+    exec {LOCK_FD}>&-
+  fi
 }
 trap cleanup EXIT
+
+CPU_CANDIDATES=()
+load_online_cpus() {
+  local cpu_list=$1
+  local range start end cpu
+  local -a ranges
+
+  if [[ ! "$cpu_list" =~ ^[0-9]+(-[0-9]+)?(,[0-9]+(-[0-9]+)?)*$ ]]; then
+    echo "invalid online CPU list: $cpu_list" >&2
+    exit 1
+  fi
+
+  IFS=',' read -r -a ranges <<< "$cpu_list"
+  for range in "${ranges[@]}"; do
+    if [[ "$range" == *-* ]]; then
+      start=$((10#${range%%-*}))
+      end=$((10#${range#*-}))
+    else
+      start=$((10#$range))
+      end=$start
+    fi
+    if [ "$start" -gt "$end" ]; then
+      echo "invalid online CPU range: $range" >&2
+      exit 1
+    fi
+    for ((cpu = start; cpu <= end; cpu++)); do
+      CPU_CANDIDATES+=("$cpu")
+    done
+  done
+}
+
+load_online_cpus "$(</sys/devices/system/cpu/online)"
+if [ "${#CPU_CANDIDATES[@]}" -gt 1 ]; then
+  NONZERO_CPUS=()
+  for cpu in "${CPU_CANDIDATES[@]}"; do
+    if [ "$cpu" -ne 0 ]; then
+      NONZERO_CPUS+=("$cpu")
+    fi
+  done
+  CPU_CANDIDATES=("${NONZERO_CPUS[@]}")
+fi
+
+read -r SELECTION_HASH _ < <(printf '%s' "$EXECUTION_KEY" | cksum)
+START_INDEX=$((SELECTION_HASH % ${#CPU_CANDIDATES[@]}))
+sudo install -d -m 0755 -o "$(id -u)" -g "$(id -g)" "$LOCK_DIR"
+
+SELECTED_CPU=""
+for ((offset = 0; offset < ${#CPU_CANDIDATES[@]}; offset++)); do
+  candidate_index=$(((START_INDEX + offset) % ${#CPU_CANDIDATES[@]}))
+  candidate_cpu=${CPU_CANDIDATES[$candidate_index]}
+  exec {candidate_lock_fd}>"${LOCK_DIR}/cpu-${candidate_cpu}.lock"
+  if flock --nonblock "$candidate_lock_fd"; then
+    SELECTED_CPU=$candidate_cpu
+    LOCK_FD=$candidate_lock_fd
+    break
+  fi
+  exec {candidate_lock_fd}>&-
+done
+if [ -z "$SELECTED_CPU" ]; then
+  echo "no online host CPU is available for the fairness test" >&2
+  exit 1
+fi
+echo "HOST_CPU_SELECTED_CPU=$SELECTED_CPU"
 
 SYSTEMD_VERSION=$(systemd --version | awk 'NR == 1 { print $2 }')
 case "$SYSTEMD_VERSION" in
@@ -104,7 +173,7 @@ sudo systemd-run \
   --property=Type=exec \
   --property=Delegate=cpu \
   --property=DelegateSubgroup=control \
-  --property=AllowedCPUs=0 \
+  "--property=AllowedCPUs=${SELECTED_CPU}" \
   --property=TimeoutStopSec=60 \
   "--setenv=VM0_HOST_CPU_TEST_FIRECRACKER=${FIRECRACKER}" \
   "--setenv=VM0_HOST_CPU_TEST_KERNEL=${KERNEL}" \

--- a/.github/scripts/runner-behavior-host-cpu-fairness.sh
+++ b/.github/scripts/runner-behavior-host-cpu-fairness.sh
@@ -74,37 +74,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
-CPU_CANDIDATES=()
-load_online_cpus() {
-  local cpu_list=$1
-  local range start end cpu
-  local -a ranges
-
-  if [[ ! "$cpu_list" =~ ^[0-9]+(-[0-9]+)?(,[0-9]+(-[0-9]+)?)*$ ]]; then
-    echo "invalid online CPU list: $cpu_list" >&2
+mapfile -t CPU_CANDIDATES < <(
+  lscpu --parse=CPU,ONLINE | awk -F, '$2 == "Y" { print $1 }'
+)
+if [ "${#CPU_CANDIDATES[@]}" -eq 0 ]; then
+  echo "host has no online CPUs" >&2
+  exit 1
+fi
+for cpu in "${CPU_CANDIDATES[@]}"; do
+  if [[ ! "$cpu" =~ ^[0-9]+$ ]]; then
+    echo "invalid online CPU: $cpu" >&2
     exit 1
   fi
-
-  IFS=',' read -r -a ranges <<< "$cpu_list"
-  for range in "${ranges[@]}"; do
-    if [[ "$range" == *-* ]]; then
-      start=$((10#${range%%-*}))
-      end=$((10#${range#*-}))
-    else
-      start=$((10#$range))
-      end=$start
-    fi
-    if [ "$start" -gt "$end" ]; then
-      echo "invalid online CPU range: $range" >&2
-      exit 1
-    fi
-    for ((cpu = start; cpu <= end; cpu++)); do
-      CPU_CANDIDATES+=("$cpu")
-    done
-  done
-}
-
-load_online_cpus "$(</sys/devices/system/cpu/online)"
+done
 if [ "${#CPU_CANDIDATES[@]}" -gt 1 ]; then
   NONZERO_CPUS=()
   for cpu in "${CPU_CANDIDATES[@]}"; do

--- a/.github/scripts/runner-behavior-host-cpu-fairness.sh
+++ b/.github/scripts/runner-behavior-host-cpu-fairness.sh
@@ -75,7 +75,7 @@ cleanup() {
 trap cleanup EXIT
 
 mapfile -t CPU_CANDIDATES < <(
-  lscpu --parse=CPU,ONLINE | awk -F, '$2 == "Y" { print $1 }'
+  LC_ALL=C lscpu --parse=CPU,ONLINE | awk -F, '$2 == "Y" { print $1 }'
 )
 if [ "${#CPU_CANDIDATES[@]}" -eq 0 ]; then
   echo "host has no online CPUs" >&2

--- a/.github/scripts/tests/crates-detect-workflow-test.sh
+++ b/.github/scripts/tests/crates-detect-workflow-test.sh
@@ -72,12 +72,12 @@ jq -e '
   ) and
   ($host_cpu.needs | sort) == ([
     "detect",
-    "runner-build",
-    "runner-behavior-lane-a",
-    "runner-behavior-lane-b",
-    "runner-behavior-lane-c",
-    "runner-behavior-lane-d"
+    "runner-build"
   ] | sort) and
+  ($host_cpu.if | contains("needs.runner-build.result")) and
+  ($host_cpu.if | contains("needs.runner-behavior-lane-") | not) and
+  ($host_cpu.if | contains("needs.detect.outputs.sandbox-fc-changed")) and
+  ($host_cpu.if | contains("needs.detect.outputs.ci-changed")) and
   ([$lane_a, $lane_b, $lane_c, $lane_d] |
     all(.[]; .needs == ["runner-build"])) and
   behavior_commands($lane_a) == [

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -917,17 +917,9 @@ jobs:
     needs:
       - detect
       - runner-build
-      - runner-behavior-lane-a
-      - runner-behavior-lane-b
-      - runner-behavior-lane-c
-      - runner-behavior-lane-d
     if: |
       !cancelled() &&
-      needs.runner-build.result == 'success' &&
-      needs.runner-behavior-lane-a.result == 'success' &&
-      needs.runner-behavior-lane-b.result == 'success' &&
-      needs.runner-behavior-lane-c.result == 'success' &&
-      needs.runner-behavior-lane-d.result == 'success' && (
+      needs.runner-build.result == 'success' && (
         needs.detect.outputs.sandbox-fc-changed == 'true' ||
         needs.detect.outputs.ci-changed == 'true'
       )


### PR DESCRIPTION
## Summary

- start `host-cpu-fairness-test` after `runner-build` instead of waiting for all four runner behavior lanes
- distribute fairness invocations deterministically across the host's online nonzero CPUs
- hold a non-blocking per-CPU lease through the real-Firecracker execution so concurrent fairness jobs do not select the same CPU
- keep the Crates gate dependent on the fairness job and every behavior lane

## CPU selection

- enumerate online CPU identifiers through `lscpu --parse=CPU,ONLINE` and validate them before arithmetic
- retain CPU 0 only for a single-CPU host
- rotate candidates from the existing execution key for reproducible distribution
- try another candidate immediately when its stable `/run/lock` file is already leased
- log `HOST_CPU_SELECTED_CPU` and use it for systemd `AllowedCPUs`

The lease coordinates fairness jobs only. It does not serialize the host or exclude normal runner workloads.

## Scope

This changes only GitHub Actions scheduling and its real-metal test wrapper. It does not change fairness assertions or thresholds, Firecracker topology, metal host selection, runner behavior lanes, runner protocols, or production behavior.

## Validation

- `bash -n .github/scripts/runner-behavior-host-cpu-fairness.sh .github/scripts/tests/crates-detect-workflow-test.sh`
- `shellcheck .github/scripts/runner-behavior-host-cpu-fairness.sh .github/scripts/tests/crates-detect-workflow-test.sh`
- `yq -o=json '.' .github/workflows/crates.yml`
- `bash .github/scripts/tests/crates-detect-workflow-test.sh`
- `bash .github/scripts/tests/rust-ci-memory-workflow-test.sh`
- `bash .github/scripts/tests/cancel-superseded-merge-group-runs-test.sh`
- `lefthook run pre-commit`

Closes #31347
