### PR TITLE
fix(python): revalidate auth.base before forward submission

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -21,6 +21,7 @@ import http_local_responses
 import matching
 from auth_base_forwarder import (
     AuthBaseForwardingSaturatedError,
+    ForwardRequestPreSubmitRejectedError,
     forward_request,
     release_forward_request_admission_from_flow,
     take_forward_request_admission_from_flow,
@@ -1451,6 +1452,7 @@ async def _apply_url_rewrite(
     resolved_query: dict | None,
     firewall_base: str,
     proxy_log_path: str,
+    revalidate_current_firewall_authorization: CurrentFirewallAuthorizationGuard,
 ) -> FirewallAuthHandlingResult:
     # The addon forwards the request itself because mitmproxy's eager
     # connection already connected to the placeholder IP. Setting
@@ -1489,6 +1491,7 @@ async def _apply_url_rewrite(
             req_headers,
             req_body,
             admission=admission,
+            pre_submit_guard=revalidate_current_firewall_authorization,
         )
         is_head_representation = flow.request.method == "HEAD" and not (
             _HTTP_STATUS_INFORMATIONAL_MIN <= status < _HTTP_STATUS_SUCCESS_MIN
@@ -1520,6 +1523,8 @@ async def _apply_url_rewrite(
                 flow.response.headers["Content-Length"] = representation_content_length
         if content_encodings:
             flow.response.headers.set_all("Content-Encoding", content_encodings)
+    except ForwardRequestPreSubmitRejectedError:
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
     except ForwardedRequestTooLargeError:
         _set_auth_base_request_too_large(
             flow,
@@ -1564,6 +1569,7 @@ async def _apply_resolved_firewall_auth(
     resolved_auth: _ResolvedFirewallAuth,
     auth_base_client_headers: list[tuple[str, str]] | None,
     aws_sigv4_body_hash: AwsSigV4BodyHash | None,
+    revalidate_current_firewall_authorization: CurrentFirewallAuthorizationGuard,
 ) -> FirewallAuthHandlingResult:
     """Apply resolved firewall auth and return request ownership outcome."""
     try:
@@ -1583,6 +1589,9 @@ async def _apply_resolved_firewall_auth(
                 resolved_query=resolved_auth.query,
                 firewall_base=context.firewall_base,
                 proxy_log_path=context.proxy_log_path,
+                revalidate_current_firewall_authorization=(
+                    revalidate_current_firewall_authorization
+                ),
             )
 
         release_forward_request_admission_from_flow(flow)
@@ -1733,6 +1742,7 @@ async def handle_firewall_request(
             resolved_auth=resolved_auth,
             auth_base_client_headers=auth_base_client_headers,
             aws_sigv4_body_hash=aws_sigv4_body_hash,
+            revalidate_current_firewall_authorization=(revalidate_current_firewall_authorization),
         )
         if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
             return _finish_firewall_auth_result(flow, auth_result)

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -43,6 +43,8 @@ header_pairs = auth_base_transport.header_pairs
 resolved_auth_header_pairs = auth_base_transport.resolved_auth_header_pairs
 trusted_request_header_pairs = auth_base_transport.trusted_request_header_pairs
 
+type ForwardRequestPreSubmitGuard = Callable[[], bool]
+
 MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
 MAX_ADMITTED_AUTH_BASE_FORWARDS = 16
 MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES = 128 * 1024 * 1024
@@ -189,6 +191,10 @@ def shutdown_forward_request_workers(*, wait: bool) -> None:
 
 class AuthBaseForwardingSaturatedError(Exception):
     """Raised when auth.base forwarding admission is saturated."""
+
+
+class ForwardRequestPreSubmitRejectedError(Exception):
+    """Raised when a caller rejects forwarding after asynchronous preparation."""
 
 
 class _ForwardRequestTerminalState(Enum):
@@ -610,6 +616,7 @@ async def forward_request(
     body: bytes | None,
     *,
     admission: request_body_admission.RequestBodyAdmissionLease | None = None,
+    pre_submit_guard: ForwardRequestPreSubmitGuard | None = None,
 ) -> tuple[int, bytes, http.Headers]:
     """Forward an auth.base request within one absolute worker lifetime.
 
@@ -623,9 +630,11 @@ async def forward_request(
     worker submission, only the worker future's completion callback releases admission and
     concurrency capacity.
 
-    Cancellation before submission creates no worker, while cancelling a pending worker future
-    prevents it from running. Once synchronous work has started, caller cancellation does not stop
-    it; the independent deadline remains armed and the worker retains resources until completion.
+    After asynchronous preparation, an optional synchronous guard runs on the event-loop thread
+    immediately before worker submission. Guard rejection creates no worker. Cancellation before
+    submission also creates no worker, while cancelling a pending worker future prevents it from
+    running. Once synchronous work has started, caller cancellation does not stop it; the
+    independent deadline remains armed and the worker retains resources until completion.
 
     Request body size, admission saturation, shutdown, URL/header/destination validation, upstream
     forwarding, and response processing failures propagate to the caller.
@@ -689,6 +698,11 @@ async def forward_request(
             if abort_handle.terminal_state is _ForwardRequestTerminalState.SHUTDOWN_ABORTED:
                 raise RuntimeError("auth.base forwarding workers are shut down") from None
             raise
+
+        if pre_submit_guard is not None and not pre_submit_guard():
+            raise ForwardRequestPreSubmitRejectedError(
+                "auth.base forwarding rejected before worker submission"
+            )
 
         deadline_timer = loop.call_later(
             auth_base_transport.remaining_deadline_seconds(deadline),

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder_lifecycle.py
@@ -208,6 +208,41 @@ class TestForwardRequestAsyncWrapper:
         assert body == b"ok"
         assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
+    async def test_pre_submit_guard_rejection_after_dns_releases_capacity(self):
+        guard_threads: list[threading.Thread] = []
+
+        def reject_before_submit() -> bool:
+            guard_threads.append(threading.current_thread())
+            return False
+
+        event_loop_thread = threading.current_thread()
+        with fake_forwarder_upstream() as upstream:
+            with pytest.raises(
+                forwarder.ForwardRequestPreSubmitRejectedError,
+                match="rejected before worker submission",
+            ):
+                await forwarder.forward_request(
+                    "https://example.com",
+                    "GET",
+                    [],
+                    None,
+                    pre_submit_guard=reject_before_submit,
+                )
+
+            status, body, _headers = await forwarder.forward_request(
+                "https://example.com",
+                "GET",
+                [],
+                None,
+            )
+
+        assert status == 200
+        assert body == b"ok"
+        assert upstream.resolve_calls == ["example.com", "example.com"]
+        assert len(upstream.socket_calls) == 1
+        assert guard_threads == [event_loop_thread]
+        assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
     async def test_deadline_cancels_async_dns_and_releases_capacity(self):
         lookup_entered = asyncio.Event()
         lookup_cancelled = asyncio.Event()

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -16,7 +16,10 @@ import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
 from body_limits import STREAM_BUFFER_LIMIT
-from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.auth_base_forwarder_helpers import (
+    fake_forwarder_upstream,
+    forwarder_concurrency_harness,
+)
 from tests.firewall_helpers import cancel_pending_task
 from tests.registry_builtin_helpers import write_registry_with_cache
 from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
@@ -729,6 +732,156 @@ async def test_auth_base_registry_change_during_auth_blocks_resolved_forward(
         metadata_keys.AUTH_URL_REWRITE,
     ):
         assert key not in flow.metadata
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+    _assert_current_denial(flow, registry_mutation)
+
+
+@pytest.mark.parametrize(
+    "registry_mutation",
+    ["remove", "replace_run", "revoke_permission"],
+)
+async def test_auth_base_registry_change_while_waiting_for_active_slot_blocks_forward(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+    monkeypatch,
+    registry_mutation: RegistryMutation,
+):
+    registry_path = _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        sandbox_info=_registry_sandbox(tmp_path, auth_base=True),
+    )
+    flow, tls_data = _firewall_flow(real_flow, make_tls_data, auth_base=True)
+    original_path = flow.request.path
+    auth_resolution_entered = asyncio.Event()
+    release_auth_resolution = asyncio.Event()
+
+    async def resolve_auth(*_args, **_kwargs):
+        auth_resolution_entered.set()
+        await release_auth_resolution.wait()
+        return _resolved_firewall_auth(auth_base=True)
+
+    auth_fetch = AsyncMock(side_effect=resolve_auth)
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+
+    request_task: asyncio.Task[None] | None = None
+    monkeypatch.setattr(auth_base_forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1)
+    with mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"):
+        async with forwarder_concurrency_harness() as (scenario, upstream):
+            mitm_addon.tls_clienthello(tls_data)
+            assert mitm_addon.requestheaders(flow) is None
+            blocking_task = scenario.track_task(
+                asyncio.create_task(
+                    auth_base_forwarder.forward_request(
+                        "https://occupied.example.com",
+                        "GET",
+                        [],
+                        None,
+                    )
+                )
+            )
+            assert await scenario.wait_started(1)
+
+            request_task = asyncio.create_task(mitm_addon.request(flow))
+            try:
+                await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+                registry_mutated = asyncio.Event()
+
+                def mutate_registry() -> None:
+                    _mutate_registry(
+                        registry_path,
+                        tmp_path,
+                        registry_mutation,
+                        auth_base=True,
+                    )
+                    registry_mutated.set()
+
+                release_auth_resolution.set()
+                asyncio.get_running_loop().call_soon(mutate_registry)
+                await asyncio.wait_for(registry_mutated.wait(), timeout=1)
+                assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
+                assert flow.metadata["_usage_flow_tracked"] is True
+                scenario.release()
+                await asyncio.gather(request_task, blocking_task)
+            finally:
+                release_auth_resolution.set()
+                scenario.release()
+                await cancel_pending_task(request_task)
+
+            assert scenario.started == 1
+            assert upstream.resolve_calls == ["occupied.example.com", "webhook.example.com"]
+
+    auth_fetch.assert_awaited_once()
+    assert flow.request.headers["Host"] == "placeholder.example.com"
+    assert flow.request.headers.get("Authorization") is None
+    assert flow.request.path == original_path
+    assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+    _assert_current_denial(flow, registry_mutation)
+
+
+@pytest.mark.parametrize(
+    "registry_mutation",
+    ["remove", "replace_run", "revoke_permission"],
+)
+async def test_auth_base_registry_change_while_waiting_for_dns_blocks_forward(
+    tmp_path,
+    real_flow,
+    make_tls_data,
+    mitm_ctx,
+    monkeypatch,
+    registry_mutation: RegistryMutation,
+):
+    registry_path = _write_registry(
+        tmp_path,
+        client_ip=_CLIENT_IP,
+        sandbox_info=_registry_sandbox(tmp_path, auth_base=True),
+    )
+    flow, tls_data = _firewall_flow(real_flow, make_tls_data, auth_base=True)
+    original_path = flow.request.path
+    auth_fetch = AsyncMock(return_value=_resolved_firewall_auth(auth_base=True))
+    monkeypatch.setattr(auth, "get_firewall_headers", auth_fetch)
+    dns_entered = asyncio.Event()
+    release_dns = asyncio.Event()
+
+    async def resolve_after_release(_host: str) -> list[str]:
+        dns_entered.set()
+        await release_dns.wait()
+        return ["93.184.216.34"]
+
+    request_task: asyncio.Task[None] | None = None
+    with (
+        mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
+        fake_forwarder_upstream(lookup_side_effect=resolve_after_release) as upstream,
+    ):
+        mitm_addon.tls_clienthello(tls_data)
+        assert mitm_addon.requestheaders(flow) is None
+        request_task = asyncio.create_task(mitm_addon.request(flow))
+        try:
+            await asyncio.wait_for(dns_entered.wait(), timeout=1)
+            assert flow.metadata["_usage_flow_tracked"] is True
+            _mutate_registry(
+                registry_path,
+                tmp_path,
+                registry_mutation,
+                auth_base=True,
+            )
+            release_dns.set()
+            await asyncio.gather(request_task)
+        finally:
+            release_dns.set()
+            await cancel_pending_task(request_task)
+
+        assert upstream.resolve_calls == ["webhook.example.com"]
+        assert upstream.socket_calls == []
+
+    auth_fetch.assert_awaited_once()
+    assert flow.request.headers["Host"] == "placeholder.example.com"
+    assert flow.request.headers.get("Authorization") is None
+    assert flow.request.path == original_path
+    assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
     assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
     _assert_current_denial(flow, registry_mutation)
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_auth_revalidation.py
@@ -326,6 +326,27 @@ def _assert_current_denial(flow: http.HTTPFlow, mutation: RegistryMutation) -> N
     assert "_usage_flow_tracked" not in flow.metadata
 
 
+def _assert_auth_base_forward_rejected(
+    flow: http.HTTPFlow,
+    *,
+    original_path: str,
+    registry_mutation: RegistryMutation,
+) -> None:
+    assert flow.request.headers["Host"] == "placeholder.example.com"
+    assert flow.request.headers.get("Authorization") is None
+    assert flow.request.path == original_path
+    for key in (
+        metadata_keys.AUTH_RESOLVED_SECRETS,
+        metadata_keys.AUTH_REFRESHED_CONNECTORS,
+        metadata_keys.AUTH_REFRESHED_SECRETS,
+        metadata_keys.AUTH_CACHE_HIT,
+        metadata_keys.AUTH_URL_REWRITE,
+    ):
+        assert key not in flow.metadata
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+    _assert_current_denial(flow, registry_mutation)
+
+
 @pytest.mark.parametrize("hook_phase", ["request", "requestheaders"])
 @pytest.mark.parametrize(
     "registry_mutation",
@@ -721,19 +742,11 @@ async def test_auth_base_registry_change_during_auth_blocks_resolved_forward(
 
     auth_fetch.assert_awaited_once()
     forward_request.assert_not_awaited()
-    assert flow.request.headers["Host"] == "placeholder.example.com"
-    assert flow.request.headers.get("Authorization") is None
-    assert flow.request.path == original_path
-    for key in (
-        metadata_keys.AUTH_RESOLVED_SECRETS,
-        metadata_keys.AUTH_REFRESHED_CONNECTORS,
-        metadata_keys.AUTH_REFRESHED_SECRETS,
-        metadata_keys.AUTH_CACHE_HIT,
-        metadata_keys.AUTH_URL_REWRITE,
-    ):
-        assert key not in flow.metadata
-    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
-    _assert_current_denial(flow, registry_mutation)
+    _assert_auth_base_forward_rejected(
+        flow,
+        original_path=original_path,
+        registry_mutation=registry_mutation,
+    )
 
 
 @pytest.mark.parametrize(
@@ -814,12 +827,11 @@ async def test_auth_base_registry_change_while_waiting_for_active_slot_blocks_fo
             assert upstream.resolve_calls == ["occupied.example.com", "webhook.example.com"]
 
     auth_fetch.assert_awaited_once()
-    assert flow.request.headers["Host"] == "placeholder.example.com"
-    assert flow.request.headers.get("Authorization") is None
-    assert flow.request.path == original_path
-    assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
-    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
-    _assert_current_denial(flow, registry_mutation)
+    _assert_auth_base_forward_rejected(
+        flow,
+        original_path=original_path,
+        registry_mutation=registry_mutation,
+    )
 
 
 @pytest.mark.parametrize(
@@ -878,12 +890,11 @@ async def test_auth_base_registry_change_while_waiting_for_dns_blocks_forward(
         assert upstream.socket_calls == []
 
     auth_fetch.assert_awaited_once()
-    assert flow.request.headers["Host"] == "placeholder.example.com"
-    assert flow.request.headers.get("Authorization") is None
-    assert flow.request.path == original_path
-    assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
-    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
-    _assert_current_denial(flow, registry_mutation)
+    _assert_auth_base_forward_rejected(
+        flow,
+        original_path=original_path,
+        registry_mutation=registry_mutation,
+    )
 
 
 async def test_auth_base_unrelated_policy_change_keeps_equivalent_authorization(


### PR DESCRIPTION
## Summary

- revalidate current auth.base firewall authorization after forwarding capacity and DNS waits
- reject stale requests before worker submission while preserving the canonical fail-closed response
- keep admission, semaphore, abort-handle, deadline, and terminal usage cleanup under their existing owners
- cover registry removal, run replacement, and permission revocation during both pre-send waits

## Behavior and exclusions

The existing post-auth-resolution authorization guard remains as an early gate. Auth.base forwarding now invokes the same caller-owned guard again after validated DNS completes and immediately before starting the synchronous worker. A dedicated non-submission exception prevents the authorization denial from being converted into a generic URL-rewrite 502.

The forwarder callback is optional, so policy-free direct callers are unchanged. Canonical firewall policy remains in the addon request layer and executes on the event-loop thread; the forwarding and transport layers do not interpret registry state.

This change does not modify APIs, databases, persisted state, registry schemas, runner protocols, frontend behavior, feature switches, retries, or destination validation. It closes asynchronous pre-send windows but does not claim globally atomic revocation and socket transmission.

## Validation

- `uv lock --check`
- `uv sync --locked`
- focused auth.base forwarder and request revalidation tests (57 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7,300 passed)
- `lefthook run pre-commit`
- `git diff --check`

Closes #31318
