### PR TITLE
fix(runner): preserve claimed cancel markers

### DIFF
--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -144,7 +144,7 @@ impl SubmitQueueEntry {
         }
     }
 
-    /// Clean up submit-owned queue files after timing out while waiting for a result.
+    /// Clean up submit-owned queue files after abandoning the wait for a result.
     fn cleanup_abandoned(&self, marker: Option<&PublishedMarker>) {
         let jobs_removed = local_queue::LocalQueue::new(self.group_dir.clone())
             .remove_job_files_if_present(self.job_id);
@@ -165,6 +165,10 @@ impl SubmitQueueEntry {
     fn abandon(&self, error: &str) {
         let marker = write_abandoned_result_marker(&self.result, self.job_id, error);
         self.cleanup_abandoned(marker.as_ref());
+    }
+
+    fn abandon_cancelled(&self) {
+        self.cleanup_abandoned(None);
     }
 
     fn cleanup_active_inputs(&self) {
@@ -693,14 +697,14 @@ impl SubmitPlan {
                 eprintln!("grace period expired, exiting");
                 // Leave .cancel for the runner to process — don't delete it here
                 // or the cancel request may be lost.
-                self.abandon("local submit cancelled before job completed");
+                self.abandon_cancelled();
                 return SubmitOutcome::Cancelled;
             }
             tokio::select! {
                 () = tokio::time::sleep(POLL_INTERVAL) => {}
                 _ = sigint.recv() => {
                     eprintln!("second interrupt, exiting immediately");
-                    self.abandon("local submit interrupted before job completed");
+                    self.abandon_cancelled();
                     return SubmitOutcome::Cancelled;
                 }
             }
@@ -709,6 +713,10 @@ impl SubmitPlan {
 
     fn abandon(&self, error: &str) {
         self.queue.abandon(error);
+    }
+
+    fn abandon_cancelled(&self) {
+        self.queue.abandon_cancelled();
     }
 
     fn finish_completed(&self, buf: &[u8]) -> RunnerResult<ExitCode> {
@@ -732,6 +740,13 @@ impl SubmitPlan {
             Ok(ExitCode::FAILURE)
         }
     }
+}
+
+#[cfg(test)]
+pub(crate) fn abandon_cancelled_submit_for_test(group_dir: &Path, job_id: RunId) {
+    SubmitQueueEntry::for_job(group_dir, crate::profile::DEFAULT_PROFILE, job_id)
+        .unwrap()
+        .abandon_cancelled();
 }
 
 pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {

--- a/crates/runner/src/cmd/local/submit/tests/abandoned_cleanup.rs
+++ b/crates/runner/src/cmd/local/submit/tests/abandoned_cleanup.rs
@@ -6,7 +6,7 @@ use crate::ids::RunId;
 use crate::local_queue::{self, JobResponse};
 
 #[test]
-fn abandoned_cleanup_preserves_active_claim_state() {
+fn cancelled_abandon_preserves_active_claim_without_result() {
     let dir = tempfile::tempdir().unwrap();
     let group_dir = dir.path();
     let job_id = RunId::new_v4();
@@ -27,15 +27,12 @@ fn abandoned_cleanup_preserves_active_claim_state() {
         })
         .unwrap();
 
-    queue.abandon("timed out");
-    let response: JobResponse =
-        serde_json::from_slice(&std::fs::read(&queue.result).unwrap()).unwrap();
+    queue.abandon_cancelled();
 
-    assert_eq!(response.run_id, queue.job_id);
     assert!(!queue.job.exists());
     assert!(
-        queue.result.exists(),
-        "abandoned cleanup must keep a terminal marker while a runner owns the claim"
+        !queue.result.exists(),
+        "cancelled cleanup must not publish a terminal result while a runner owns the claim"
     );
     assert!(
         queue.cancel.exists(),
@@ -68,7 +65,7 @@ fn abandoned_cleanup_removes_unclaimed_job_without_claim_marker() {
         })
         .unwrap();
 
-    queue.abandon("timed out");
+    queue.abandon_cancelled();
 
     assert!(!queue.job.exists());
     assert!(!queue.result.exists());
@@ -99,7 +96,7 @@ fn abandoned_cleanup_ignores_claim_file_symlink() {
     std::fs::write(&target, b"").unwrap();
     symlink(&target, &queue.claim).unwrap();
 
-    queue.abandon("timed out");
+    queue.abandon_cancelled();
 
     assert!(!queue.job.exists());
     assert!(!queue.result.exists());
@@ -120,7 +117,7 @@ fn abandoned_cleanup_removes_duplicate_unclaimed_jobs() {
 
     std::fs::write(&queue.cancel, b"").unwrap();
 
-    queue.abandon("timed out");
+    queue.abandon_cancelled();
 
     assert!(!default_job.exists());
     assert!(!large_job.exists());
@@ -188,7 +185,7 @@ fn abandoned_cleanup_removes_late_unclaimed_active_inputs_after_job_cleanup() {
     std::fs::write(&queue.job, b"{}").unwrap();
     std::fs::write(&queue.cancel, b"").unwrap();
 
-    queue.abandon("timed out");
+    queue.abandon_cancelled();
     local_queue::LocalQueue::new(group_dir.to_path_buf())
         .write_active_input_sync(&local_queue::ActiveInputEntry {
             run_id: job_id,
@@ -206,7 +203,7 @@ fn abandoned_cleanup_removes_late_unclaimed_active_inputs_after_job_cleanup() {
 }
 
 #[test]
-fn abandoned_cleanup_keeps_marker_when_duplicate_job_cannot_be_removed() {
+fn timeout_abandon_keeps_marker_when_duplicate_job_cannot_be_removed() {
     let dir = tempfile::tempdir().unwrap();
     let group_dir = dir.path();
     let job_id = RunId::new_v4();
@@ -214,10 +211,6 @@ fn abandoned_cleanup_keeps_marker_when_duplicate_job_cannot_be_removed() {
     let default_job = write_queue_job_file(group_dir, crate::profile::DEFAULT_PROFILE, job_id);
     let blocked_job = local_queue::job_path(group_dir, "vm0/large", job_id).unwrap();
     std::fs::create_dir_all(&blocked_job).unwrap();
-    std::fs::create_dir_all(queue.cancel.parent().unwrap()).unwrap();
-
-    std::fs::write(&queue.cancel, b"").unwrap();
-
     queue.abandon("timed out");
 
     assert!(!default_job.exists());
@@ -226,12 +219,12 @@ fn abandoned_cleanup_keeps_marker_when_duplicate_job_cannot_be_removed() {
         queue.result.exists(),
         "terminal marker must remain if any duplicate job path could not be removed"
     );
-    assert!(queue.cancel.exists());
+    assert!(!queue.cancel.exists());
     assert!(!queue.claim.exists());
 }
 
 #[test]
-fn abandoned_cleanup_keeps_marker_when_job_already_absent_but_claimed() {
+fn cancelled_abandon_keeps_claim_when_job_is_already_absent() {
     let dir = tempfile::tempdir().unwrap();
     let group_dir = dir.path();
     let job_id = RunId::new_v4();
@@ -242,9 +235,9 @@ fn abandoned_cleanup_keeps_marker_when_job_already_absent_but_claimed() {
     std::fs::write(&queue.cancel, b"").unwrap();
     std::fs::write(&queue.claim, b"").unwrap();
 
-    queue.abandon("timed out");
+    queue.abandon_cancelled();
 
-    assert!(queue.result.exists());
+    assert!(!queue.result.exists());
     assert!(queue.cancel.exists());
     assert!(queue.claim.exists());
 }
@@ -380,7 +373,7 @@ fn abandoned_cleanup_keeps_completed_result_when_claimed() {
 }
 
 #[test]
-fn abandoned_cleanup_keeps_marker_when_job_cannot_be_removed() {
+fn cancelled_abandon_keeps_unremoved_job_pending() {
     let dir = tempfile::tempdir().unwrap();
     let group_dir = dir.path();
     let job_id = RunId::new_v4();
@@ -390,11 +383,11 @@ fn abandoned_cleanup_keeps_marker_when_job_cannot_be_removed() {
 
     std::fs::write(&queue.cancel, b"").unwrap();
 
-    queue.abandon("timed out");
+    queue.abandon_cancelled();
 
     assert!(
-        queue.result.exists(),
-        "terminal marker must remain if the stale job path could not be removed"
+        !queue.result.exists(),
+        "cancelled cleanup must not publish a terminal result"
     );
     assert!(queue.cancel.exists());
     assert!(!queue.claim.exists());

--- a/crates/runner/src/cmd/local/submit/tests/interrupt.rs
+++ b/crates/runner/src/cmd/local/submit/tests/interrupt.rs
@@ -15,14 +15,23 @@ const INTERRUPT_CHILD_ENV: &str = "OKOU_RUNNER_LOCAL_SUBMIT_INTERRUPT_TEST";
 const INTERRUPT_CHILD_VALUE: &str = "after-job-publication";
 const INTERRUPT_CHILD_TEST: &str =
     "cmd::local::submit::tests::interrupt::sigint_after_job_publication_uses_cancel_cleanup_child";
+const SECOND_INTERRUPT_CHILD_VALUE: &str = "second-interrupt-after-claim";
+const SECOND_INTERRUPT_CHILD_TEST: &str = "cmd::local::submit::tests::interrupt::second_sigint_preserves_claimed_cancel_without_result_child";
 
 pub(super) fn post_publish_test_checkpoint() {
-    if std::env::var_os(INTERRUPT_CHILD_ENV).as_deref() != Some(OsStr::new(INTERRUPT_CHILD_VALUE)) {
+    let value = std::env::var_os(INTERRUPT_CHILD_ENV);
+    if value.as_deref() != Some(OsStr::new(INTERRUPT_CHILD_VALUE))
+        && value.as_deref() != Some(OsStr::new(SECOND_INTERRUPT_CHILD_VALUE))
+    {
         return;
     }
 
+    send_sigint();
+}
+
+fn send_sigint() {
     nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGINT)
-        .expect("send SIGINT after local job publication");
+        .expect("send SIGINT to local submit test process");
 }
 
 #[tokio::test]
@@ -69,25 +78,73 @@ async fn sigint_after_job_publication_uses_cancel_cleanup_child() {
     assert!(!local_queue::result_path(&group_dir, job_id).exists());
 }
 
+#[tokio::test]
+async fn second_sigint_preserves_claimed_cancel_without_result() {
+    run_ignored_child_test(
+        SECOND_INTERRUPT_CHILD_TEST,
+        (INTERRUPT_CHILD_ENV, SECOND_INTERRUPT_CHILD_VALUE),
+        &[],
+        Duration::from_secs(5),
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "spawned by second_sigint_preserves_claimed_cancel_without_result"]
+async fn second_sigint_preserves_claimed_cancel_without_result_child() {
+    if !ignored_child_test_env_guard_enabled((INTERRUPT_CHILD_ENV, SECOND_INTERRUPT_CHILD_VALUE)) {
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().to_path_buf());
+    let group_dir = home.groups_dir().join("test/group");
+    let profile = crate::profile::DEFAULT_PROFILE.to_owned();
+    let claimer = tokio::spawn(claim_and_send_second_interrupt(
+        group_dir.clone(),
+        profile.clone(),
+    ));
+
+    let exit = run_submit_with_home(submit_args_for_test(), home)
+        .await
+        .unwrap();
+    let job_id = claimer.await.unwrap();
+
+    assert_eq!(exit, ExitCode::FAILURE);
+    assert!(
+        !local_queue::job_path(&group_dir, &profile, job_id)
+            .unwrap()
+            .exists(),
+        "interrupted submit must not leave an executable job"
+    );
+    assert!(!local_queue::result_path(&group_dir, job_id).exists());
+    assert!(local_queue::cancel_path(&group_dir, job_id).exists());
+    assert!(local_queue::claim_path(&group_dir, job_id).exists());
+}
+
+async fn claim_and_send_second_interrupt(group_dir: std::path::PathBuf, profile: String) -> RunId {
+    let request = wait_for_job(&group_dir, &profile).await;
+    local_queue::ensure_claims_dir(&group_dir).unwrap();
+    local_queue::create_private_marker(
+        &local_queue::claim_path(&group_dir, request.job_id),
+        "local claim marker",
+    )
+    .unwrap();
+
+    let cancel_path = local_queue::cancel_path(&group_dir, request.job_id);
+    while !local_queue::marker_file_exists(&cancel_path, "local cancel marker").unwrap() {
+        tokio::task::yield_now().await;
+    }
+
+    send_sigint();
+    request.job_id
+}
+
 async fn wait_for_cancel_and_write_failure(
     group_dir: std::path::PathBuf,
     profile: String,
 ) -> RunId {
-    let job_dir = local_queue::profile_jobs_dir(&group_dir, &profile).unwrap();
-    let request = loop {
-        if let Ok(entries) = std::fs::read_dir(&job_dir) {
-            let request = entries.filter_map(Result::ok).find_map(|entry| {
-                let path = entry.path();
-                (path.extension().and_then(|ext| ext.to_str()) == Some("job")).then(|| {
-                    serde_json::from_slice::<JobRequest>(&std::fs::read(path).unwrap()).unwrap()
-                })
-            });
-            if let Some(request) = request {
-                break request;
-            }
-        }
-        tokio::task::yield_now().await;
-    };
+    let request = wait_for_job(&group_dir, &profile).await;
 
     let cancel_path = local_queue::cancel_path(&group_dir, request.job_id);
     while !local_queue::marker_file_exists(&cancel_path, "local cancel marker").unwrap() {
@@ -102,4 +159,22 @@ async fn wait_for_cancel_and_write_failure(
     let result_path = local_queue::result_path(&group_dir, request.job_id);
     std::fs::write(result_path, serde_json::to_vec(&result).unwrap()).unwrap();
     request.job_id
+}
+
+async fn wait_for_job(group_dir: &std::path::Path, profile: &str) -> JobRequest {
+    let job_dir = local_queue::profile_jobs_dir(group_dir, profile).unwrap();
+    loop {
+        if let Ok(entries) = std::fs::read_dir(&job_dir) {
+            let request = entries.filter_map(Result::ok).find_map(|entry| {
+                let path = entry.path();
+                (path.extension().and_then(|ext| ext.to_str()) == Some("job")).then(|| {
+                    serde_json::from_slice::<JobRequest>(&std::fs::read(path).unwrap()).unwrap()
+                })
+            });
+            if let Some(request) = request {
+                return request;
+            }
+        }
+        tokio::task::yield_now().await;
+    }
 }

--- a/crates/runner/src/cmd/mod.rs
+++ b/crates/runner/src/cmd/mod.rs
@@ -24,3 +24,6 @@ pub use service::{ServiceArgs, run_service};
 pub use setup::run_setup;
 pub use start::{StartArgs, run_start};
 pub use workspace_image_cache::{WorkspaceImageCacheArgs, run_workspace_image_cache};
+
+#[cfg(test)]
+pub(crate) use local::submit::abandon_cancelled_submit_for_test;

--- a/crates/runner/src/provider/local/tests/cancellation.rs
+++ b/crates/runner/src/provider/local/tests/cancellation.rs
@@ -1,6 +1,47 @@
 use super::support::*;
 
 #[tokio::test]
+async fn claimed_cancelled_submit_survives_non_owner_scan() {
+    let dir = tempfile::tempdir().unwrap();
+    let owner_tokens = empty_cancel_tokens();
+    let run_id = RunId::new_v4();
+    let registration = insert_cancel_registration(&owner_tokens, run_id).await;
+    let job_token = registration.token();
+    let signals = registration.handle().signals();
+    let owner = default_provider(dir.path(), CancellationToken::new(), owner_tokens);
+    write_job(dir.path(), run_id, "cancel me");
+    let candidate = owner.find_unclaimed_job().unwrap();
+    owner.claim(candidate).await.unwrap();
+
+    let cancel_path = local_queue::cancel_path(dir.path(), run_id);
+    std::fs::create_dir_all(cancel_path.parent().unwrap()).unwrap();
+    std::fs::write(&cancel_path, b"").unwrap();
+    crate::cmd::abandon_cancelled_submit_for_test(dir.path(), run_id);
+
+    assert!(
+        !local_queue::job_path(dir.path(), crate::profile::DEFAULT_PROFILE, run_id)
+            .unwrap()
+            .exists()
+    );
+    assert!(!local_queue::result_path(dir.path(), run_id).exists());
+    assert!(local_queue::claim_path(dir.path(), run_id).exists());
+    assert!(cancel_path.exists());
+
+    let non_owner = default_provider(dir.path(), CancellationToken::new(), empty_cancel_tokens());
+    non_owner.cancel_scanner.scan_cancel_files().await;
+
+    assert!(cancel_path.exists());
+    assert!(!job_token.is_cancelled());
+
+    owner.cancel_scanner.scan_cancel_files().await;
+
+    assert!(job_token.is_cancelled());
+    assert!(signals.hard().is_cancelled());
+    assert!(!signals.cooperative_user().is_cancelled());
+    assert!(!cancel_path.exists());
+}
+
+#[tokio::test]
 async fn cancel_file_triggers_token() {
     let dir = tempfile::tempdir().unwrap();
     let cancel = CancellationToken::new();


### PR DESCRIPTION
## Summary

- stop cancellation grace expiry and second interrupts from publishing a synthetic result before cleaning up submit-owned queue files
- preserve claimed cancellation markers so only the owning runner consumes them
- keep the existing synthetic terminal result barrier for timeout abandonment
- cover the owner/non-owner scanner handoff and the claimed second-interrupt path with real-filesystem regressions

## Scope

- no changes to cancel marker classification, queue protocol, API contracts, or persisted schemas
- no change to timeout abandonment behavior

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test -p runner cmd::local::submit::tests::abandoned_cleanup`
- `cargo test -p runner cmd::local::submit::tests::interrupt`
- `cargo test -p runner provider::local::tests::cancellation`
- `cargo test -p runner cmd::local::submit::tests::result_markers`
- `cargo test -p runner`
- `lefthook run pre-commit`

Closes #31336
