### PR TITLE
fix(pi-memory): reject non-adjacent path collisions

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-archive.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-archive.service.test.ts
@@ -169,6 +169,51 @@ describe("Pi memory Phase 2 archive boundary", () => {
     );
   });
 
+  it("rejects non-adjacent ancestors and accepts valid near prefixes", () => {
+    const collisions = [
+      ["a", "a-", "a/b"],
+      ["E\u0301", "é-", "É/child"],
+    ] as const;
+    for (const paths of collisions) {
+      const prepared = result(
+        paths.map((path, index) => {
+          return { path, content: `collision-${index.toString()}` };
+        }),
+      );
+      for (const files of [prepared.files, [...prepared.files].reverse()]) {
+        expect(() => {
+          validatePiMemoryPhase2PreparedResult(STORAGE_ID, {
+            ...prepared,
+            files,
+          });
+        }).toThrow(
+          expect.objectContaining({
+            name: "PiMemoryPhase2ArchiveError",
+            errorClass: "path_invalid",
+          }),
+        );
+      }
+    }
+
+    const nearPrefixes = result([
+      { path: "a", content: "exact" },
+      { path: "a-/child", content: "hyphen" },
+      { path: "a.b", content: "dot" },
+      { path: "a0/b", content: "suffix" },
+      { path: "E\u0301", content: "decomposed" },
+      { path: "é-/child", content: "normalized hyphen" },
+    ]);
+    const canonical = buildPiMemoryPhase2Archive(STORAGE_ID, nearPrefixes);
+    const reordered = buildPiMemoryPhase2Archive(STORAGE_ID, {
+      ...nearPrefixes,
+      files: [...nearPrefixes.files].reverse(),
+    });
+
+    expect(reordered.versionId).toBe(canonical.versionId);
+    expect(reordered.manifestBytes).toStrictEqual(canonical.manifestBytes);
+    expect(reordered.archiveBytes).toStrictEqual(canonical.archiveBytes);
+  });
+
   it("rejects API-returned path collisions and identity mismatches", () => {
     const collision = result([
       { path: "Topic.md", content: "first" },

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-archive.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-archive.service.ts
@@ -99,26 +99,37 @@ function safePath(path: string): boolean {
   });
 }
 
-function validatePaths(paths: readonly string[]): void {
-  const ordered = [...paths].sort(compareText);
-  const folded = ordered
-    .map((path) => {
-      return path.normalize("NFC").toLocaleLowerCase("en");
-    })
-    .sort(compareText);
-  for (const collection of [ordered, folded]) {
-    for (let index = 0; index < collection.length; index += 1) {
-      const current = collection[index];
-      const previous = collection[index - 1];
-      if (
-        current === undefined ||
-        !safePath(current) ||
-        current === previous ||
-        (previous !== undefined && current.startsWith(`${previous}/`))
-      ) {
+function foldedPath(path: string): string {
+  return path.normalize("NFC").toLocaleLowerCase("en");
+}
+
+function validatePathKeys(paths: readonly string[]): void {
+  const inventory = new Set(paths);
+  if (inventory.size !== paths.length) {
+    fail("path_invalid");
+  }
+  for (const path of paths) {
+    for (
+      let separator = path.indexOf("/");
+      separator !== -1;
+      separator = path.indexOf("/", separator + 1)
+    ) {
+      if (inventory.has(path.slice(0, separator))) {
         fail("path_invalid");
       }
     }
+  }
+}
+
+function validatePaths(paths: readonly string[]): void {
+  const folded = paths.map(foldedPath);
+  for (const collection of [paths, folded]) {
+    for (const path of collection) {
+      if (!safePath(path)) {
+        fail("path_invalid");
+      }
+    }
+    validatePathKeys(collection);
   }
 }
 

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.test.ts
@@ -222,6 +222,52 @@ describe("Pi memory Phase 2 filesystem", () => {
     }
   });
 
+  it("rejects non-adjacent ancestors and accepts valid near prefixes", () => {
+    const collisions = [
+      ["a", "a-", "a/b"],
+      ["E\u0301", "é-", "É/child"],
+    ] as const;
+    for (const paths of collisions) {
+      const files = paths.map((path, index) => {
+        return baseFile(path, `collision-${index.toString()}`);
+      });
+      for (const ordered of [files, [...files].reverse()]) {
+        expect(() => {
+          snapshotPiMemoryPhase2Input(
+            consolidationArgs(ordered),
+            new AbortController().signal,
+          );
+        }).toThrow(Phase2InputInvalidError);
+      }
+    }
+
+    const nearPrefixes = [
+      baseFile("a", "exact"),
+      baseFile("a-/child", "hyphen"),
+      baseFile("a.b", "dot"),
+      baseFile("a0/b", "suffix"),
+      baseFile("E\u0301", "decomposed"),
+      baseFile("é-/child", "normalized hyphen"),
+    ];
+    for (const files of [nearPrefixes, [...nearPrefixes].reverse()]) {
+      const snapshot = snapshotPiMemoryPhase2Input(
+        consolidationArgs(files),
+        new AbortController().signal,
+      );
+      expect(
+        snapshot.baseFiles.map((file) => {
+          return file.path;
+        }),
+      ).toStrictEqual(
+        nearPrefixes
+          .map((file) => {
+            return file.path;
+          })
+          .sort(),
+      );
+    }
+  });
+
   it("preflights file-count, path-byte, per-file, and total bounds before copying bytes", () => {
     const empty = {
       type: "file" as const,

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-filesystem.ts
@@ -163,37 +163,34 @@ function comparePathHash(
   return pathOrder === 0 ? compareText(left.hash, right.hash) : pathOrder;
 }
 
+function foldedPath(path: string): string {
+  return path.normalize("NFC").toLocaleLowerCase("en");
+}
+
+function validatePathKeys(paths: readonly string[]): void {
+  const inventory = new Set(paths);
+  if (inventory.size !== paths.length) {
+    throw new Phase2InputInvalidError();
+  }
+  for (const path of paths) {
+    for (
+      let separator = path.indexOf("/");
+      separator !== -1;
+      separator = path.indexOf("/", separator + 1)
+    ) {
+      if (inventory.has(path.slice(0, separator))) {
+        throw new Phase2InputInvalidError();
+      }
+    }
+  }
+}
+
 function validatePathCollection(paths: readonly string[]): void {
-  const exact = new Set<string>();
-  const folded = new Set<string>();
   for (const path of paths) {
     assertSafeFilePath(path);
-    const lower = path.toLocaleLowerCase("en");
-    if (exact.has(path) || folded.has(lower)) {
-      throw new Phase2InputInvalidError();
-    }
-    exact.add(path);
-    folded.add(lower);
   }
-  const ordered = [...paths].sort(compareText);
-  for (let index = 1; index < ordered.length; index += 1) {
-    const previous = ordered[index - 1];
-    const current = ordered[index];
-    if (previous !== undefined && current?.startsWith(`${previous}/`)) {
-      throw new Phase2InputInvalidError();
-    }
-  }
-  const foldedOrdered = ordered
-    .map((path) => {
-      return path.toLocaleLowerCase("en");
-    })
-    .sort(compareText);
-  for (let index = 1; index < foldedOrdered.length; index += 1) {
-    const previous = foldedOrdered[index - 1];
-    const current = foldedOrdered[index];
-    if (previous !== undefined && current?.startsWith(`${previous}/`)) {
-      throw new Phase2InputInvalidError();
-    }
+  for (const collection of [paths, paths.map(foldedPath)]) {
+    validatePathKeys(collection);
   }
 }
 


### PR DESCRIPTION
## Summary

- reject every exact and folded slash-delimited ancestor against the complete path inventory
- align API and runtime collision keys on Unicode NFC plus English-locale lowercase folding
- cover order-independent non-adjacent collisions and deterministic valid near-prefix controls

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (the new test initially exposed one canonical matcher lint error; fixed and reran both affected package lint commands successfully)
- `pnpm --filter api run lint`
- `pnpm --filter @okouai/pi-agent-runtime run lint`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api run build`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/services/__tests__/pi-memory-phase2-archive.service.test.ts`
- `pnpm --filter @okouai/pi-agent-runtime exec vitest run src/phase2-memory-filesystem.test.ts`
- targeted Prettier check and `git diff --check`

## Scope

- preserves archive ordering, bytes, content identity, public errors, and existing limits
- does not change activation, scheduling, providers, publication, billing, storage semantics, schemas, workflows, or release behavior

Closes #31337
