### PR TITLE
perf(api): overlap request and session storage preparation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3538,6 +3538,146 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestClaimRunnerJob(true, failed.runId, [404]);
   });
 
+  it("overlaps request and session storage preparation while preserving request errors", async () => {
+    const api = createRunsApi(context);
+    const storages = createStoragesBddApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    await api.heartbeatRunner(runnerGroup);
+
+    const initialRun = await api.createDirectRun(actor, {
+      ...zeroBackedDirectRunBody({
+        agentId,
+        prompt: "establish canonical storage for overlap",
+      }),
+    });
+    const initialClaim = await api.claimRunnerJob(initialRun.runId);
+    const initialMemory = expectCanonicalStorageManifest(
+      initialClaim.storageManifest,
+    )?.storageMounts.find((mount) => {
+      return mount.name === "memory";
+    });
+    if (!initialMemory) {
+      throw new Error("Expected the canonical memory mount");
+    }
+
+    const memoryFile = storageTextFile(
+      "MEMORY.md",
+      `session overlap ${initialRun.runId}`,
+    );
+    const preparedMemory = await storages.prepareStorage(actor, {
+      storageName: "memory",
+      storageOwner: "user",
+      files: [memoryFile],
+    });
+    const sessionArchiveKey = preparedMemory.uploads?.archive.key;
+    if (!sessionArchiveKey) {
+      throw new Error("Expected a session memory archive upload");
+    }
+    await storages.commitStorage(actor, {
+      storageName: "memory",
+      storageOwner: "user",
+      versionId: preparedMemory.versionId,
+      files: [memoryFile],
+    });
+    await webhooks.requestAgentComplete(
+      {
+        runId: initialRun.runId,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "claude-code",
+          cliAgentSessionId: `bdd-storage-overlap-${initialRun.runId}`,
+          cliAgentSessionHistoryDisposition: "discarded_oversized",
+          artifactSnapshots: [
+            {
+              name: initialMemory.name,
+              version: preparedMemory.versionId,
+              mountPath: initialMemory.mountPath,
+              ...(initialMemory.missingRootPolicy === undefined
+                ? {}
+                : { missingRootPolicy: initialMemory.missingRootPolicy }),
+            },
+          ],
+        },
+      },
+      { authorization: `Bearer ${initialClaim.sandboxToken}` },
+      [200],
+    );
+
+    const requestStorageName = `bdd-request-overlap-${randomUUID().slice(0, 8)}`;
+    const requestFile = storageTextFile(
+      "request.txt",
+      `request overlap ${requestStorageName}`,
+    );
+    const preparedRequest = await storages.prepareStorage(actor, {
+      storageName: requestStorageName,
+      storageOwner: "organization",
+      files: [requestFile],
+    });
+    const requestArchiveKey = preparedRequest.uploads?.archive.key;
+    if (!requestArchiveKey) {
+      throw new Error("Expected a request storage archive upload");
+    }
+    await storages.commitStorage(actor, {
+      storageName: requestStorageName,
+      storageOwner: "organization",
+      versionId: preparedRequest.versionId,
+      files: [requestFile],
+    });
+
+    const requestPresignStarted = createDeferredPromise<void>(context.signal);
+    const sessionPresignStarted = createDeferredPromise<void>(context.signal);
+    const releaseRequestPresign = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!releaseRequestPresign.settled()) {
+        releaseRequestPresign.resolve(undefined);
+      }
+    });
+    const requestError = new Error("request storage presign failed");
+    const sessionError = new Error("session storage presign failed");
+    context.mocks.s3.getSignedUrl.mockImplementation(
+      async (_client: unknown, command: unknown) => {
+        const key = s3CommandKey(command);
+        if (key === requestArchiveKey) {
+          if (!requestPresignStarted.settled()) {
+            requestPresignStarted.resolve(undefined);
+          }
+          await releaseRequestPresign.promise;
+          throw requestError;
+        }
+        if (key === sessionArchiveKey) {
+          if (!sessionPresignStarted.settled()) {
+            sessionPresignStarted.resolve(undefined);
+          }
+          throw sessionError;
+        }
+        return "https://r2.example.com/storage/archive.tar.gz?sig=bdd";
+      },
+    );
+
+    const continuedRunPromise = api.createDirectRun(actor, {
+      sessionId: initialRun.sessionId,
+      prompt: "overlap request and canonical session storage",
+      secrets: { OKOU_TOKEN: "bdd-okou-direct-token" },
+      additionalVolumes: [
+        {
+          name: requestStorageName,
+          version: preparedRequest.versionId,
+          mountPath: "/request-overlap",
+        },
+      ],
+    });
+    await Promise.all([
+      requestPresignStarted.promise,
+      sessionPresignStarted.promise,
+    ]);
+    releaseRequestPresign.resolve(undefined);
+
+    const failed = await continuedRunPromise;
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toBe(requestError.message);
+  });
+
   it("emits bucketed storage manifest shape dimensions without leaking storage identifiers", async () => {
     const api = createRunsApi(context);
     const storages = createStoragesBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3655,7 +3655,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       },
     );
 
-    const continuedRunPromise = api.createDirectRun(actor, {
+    const continuationBody = {
       sessionId: initialRun.sessionId,
       prompt: "overlap request and canonical session storage",
       secrets: { OKOU_TOKEN: "bdd-okou-direct-token" },
@@ -3666,7 +3666,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           mountPath: "/request-overlap",
         },
       ],
-    });
+    };
+    const continuedRunPromise = api.createDirectRun(actor, continuationBody);
     await Promise.all([
       requestPresignStarted.promise,
       sessionPresignStarted.promise,
@@ -3676,6 +3677,20 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const failed = await continuedRunPromise;
     expect(failed.status).toBe("failed");
     expect(failed.error).toBe(requestError.message);
+
+    context.mocks.s3.getSignedUrl.mockImplementation(
+      (_client: unknown, command: unknown) => {
+        if (s3CommandKey(command) === sessionArchiveKey) {
+          return Promise.reject(sessionError);
+        }
+        return Promise.resolve(
+          "https://r2.example.com/storage/archive.tar.gz?sig=bdd",
+        );
+      },
+    );
+    const sessionFailed = await api.createDirectRun(actor, continuationBody);
+    expect(sessionFailed.status).toBe("failed");
+    expect(sessionFailed.error).toBe(sessionError.message);
   });
 
   it("emits bucketed storage manifest shape dimensions without leaking storage identifiers", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -3167,7 +3167,7 @@ function prepareStorageWithSessionOverlay(
         artifacts,
         persistedStorageMounts: args.persistedStorageMounts,
       });
-    const requestedEntries = await get(
+    const requestedEntriesPromise = get(
       buildPreparedStorageEntriesForRequest(
         args,
         bucket,
@@ -3175,20 +3175,35 @@ function prepareStorageWithSessionOverlay(
         remainingArtifacts,
       ),
     );
-    const entries =
+    const sessionWritebackEntriesPromise =
       canonicalWritebackMounts.length === 0
-        ? requestedEntries
+        ? Promise.resolve(undefined)
+        : get(
+            buildEntriesFromPersistedStorageMounts({
+              db: args.db,
+              bucket,
+              mounts: canonicalWritebackMounts,
+              timing: args.timing,
+              stats: args.stats,
+            }),
+          );
+    const [requestedEntriesResult, sessionWritebackEntriesResult] =
+      await Promise.allSettled([
+        requestedEntriesPromise,
+        sessionWritebackEntriesPromise,
+      ]);
+    if (requestedEntriesResult.status === "rejected") {
+      throw requestedEntriesResult.reason;
+    }
+    if (sessionWritebackEntriesResult.status === "rejected") {
+      throw sessionWritebackEntriesResult.reason;
+    }
+    const entries =
+      sessionWritebackEntriesResult.value === undefined
+        ? requestedEntriesResult.value
         : combinePreparedStorageEntries({
-            requested: requestedEntries,
-            sessionWriteback: await get(
-              buildEntriesFromPersistedStorageMounts({
-                db: args.db,
-                bucket,
-                mounts: canonicalWritebackMounts,
-                timing: args.timing,
-                stats: args.stats,
-              }),
-            ),
+            requested: requestedEntriesResult.value,
+            sessionWriteback: sessionWritebackEntriesResult.value,
           });
     return await finalizePreparedStorage({
       entries,


### PR DESCRIPTION
## Summary

- start ordinary request and canonical session-writeback storage preparation together after their inputs are partitioned
- settle both branches and preserve request-first error precedence when both fail
- cover the overlap through the run/session route integration path with two gated S3 read-presign boundaries

## Boundaries

- keeps artifact ensure-before-index ordering, exact storage resolution, authorization, URL-cache work, mount ordering, and manifest finalization unchanged
- keeps concurrency bounded to the two existing branches
- does not change schemas, API or Runner contracts, queue payloads, persisted state, caches, retries, or per-item concurrency

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "overlaps request and session storage preparation while preserving request errors"`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hook: Prettier, full Knip, full Turbo type checking, file-size check, and commitlint

Closes #31343

Parent context: #24203
