### PR TITLE
test(api): give exhaustive routes timeout headroom

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
@@ -583,7 +583,7 @@ describe("custom model provider gateway routes", () => {
 
       await runs.requestCancelRun(actor, deepseekRunId, [200]);
     }
-  });
+  }, 15_000);
 
   it("admits an allowlisted DeepSeek custom gateway to Pi execution", async () => {
     const bdd = createBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -678,7 +678,7 @@ describe("registry resource download", () => {
         sha256: archive.sha256,
       });
     }
-  });
+  }, 15_000);
 
   it("rejects registry resources that are not in the private archive allowlist", async () => {
     const response = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -12401,7 +12401,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
 
     await api.requestCancelRun(actor, run.runId, [200]);
-  });
+  }, 15_000);
 
   it("retries reconnect-marked custom OAuth after invalid_grant", async () => {
     const provider = mockCustomConnectorOAuth2Provider(context, {


### PR DESCRIPTION
## Summary

- give three exhaustive API route integration scenarios an explicit 15-second timeout budget
- retain the default timeout for the rest of the API suite
- leave test bodies, assertions, production behavior, worker concurrency, and global Vitest configuration unchanged

Closes #31355

## Validation

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- focused execution of the three affected tests with API coverage enabled
- `pnpm vitest run --project=api --shard=7/8 --coverage.enabled --coverage.reporter=json` (28 files, 457 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit hooks (Prettier, Knip, and repository type checks)
