### PR TITLE
chore(desktop): retire the zero product on the build side

### DIFF
--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -23,8 +23,8 @@ ruby -e '
 
   canonical_signing_identity = "OKOU_DESKTOP_SIGNING_IDENTITY"
   canonical_writer_counts = {
-    "OKOU_DESKTOP_PRODUCT" => [8, 2],
-    "OKOU_DESKTOP_PLATFORM_URL" => [11, 2],
+    "OKOU_DESKTOP_PRODUCT" => [6, 2],
+    "OKOU_DESKTOP_PLATFORM_URL" => [9, 2],
     canonical_signing_identity => [0, 5],
   }
   canonical_writer_counts.each do |name, expected_counts|
@@ -51,6 +51,15 @@ ruby -e '
   detector_run = detector.fetch("steps").find { |step| step["id"] == "version" }.fetch("run")
   raise "version detector must compare Desktop package versions" unless detector_run.include?("resolve-desktop-version-change.sh")
 
+  default_build = build.fetch("steps").find { |step| step["id"] == "build-prod" }
+  raise "Desktop CI must build the default configuration" unless default_build
+  raise "Default CI build must not select a product" if default_build.fetch("env").key?("OKOU_DESKTOP_PRODUCT")
+  raise "Default CI build must not select a platform URL" if default_build.fetch("env").key?("OKOU_DESKTOP_PLATFORM_URL")
+
+  default_verify = build.fetch("steps").find { |step| step["name"] == "Verify default-configuration artifact" }.fetch("run")
+  raise "Default CI build must package the Okou identity" unless default_verify.include?("ai.okou.desktop")
+  raise "Default CI build must stay free of a baked-in runtime config" unless default_verify.include?("should not contain desktop runtime config")
+
   okou_build = build.fetch("steps").find { |step| step["id"] == "build-okou-prod" }
   raise "Desktop CI must build the Okou product" unless okou_build
   raise "Okou CI build must select the Okou product" unless okou_build.fetch("env").fetch("OKOU_DESKTOP_PRODUCT") == "okou"
@@ -59,6 +68,7 @@ ruby -e '
 
   okou_verify = build.fetch("steps").find { |step| step["name"] == "Verify Okou production artifact" }.fetch("run")
   raise "Okou artifact must verify its bundle ID" unless okou_verify.include?("ai.okou.desktop")
+  raise "Okou artifact must verify its packaged runtime config" unless okou_verify.include?("desktop-runtime-config.json")
   raise "Okou artifact must verify side-by-side installation" unless okou_verify.include?("Zero and Okou should remain installable side by side")
 
   preview = build.fetch("steps").find { |step| step["id"] == "preview" }
@@ -74,7 +84,11 @@ ruby -e '
   build_step = deploy.fetch("steps").find { |step| step["name"] == "Build canonical unsigned Desktop app" }
   raise "canonical Desktop build must skip signing" unless build_step.fetch("env").fetch("OKOU_DESKTOP_SKIP_SIGNING") == "true"
   raise "canonical Desktop build must package Okou" unless build_step.fetch("run").include?("Okou.app")
-  raise "canonical Okou build must target app.okou.ai" unless build_step.fetch("run").include?("OKOU_DESKTOP_PLATFORM_URL=https://app.okou.ai")
+  raise "canonical Okou build must select the Okou product" unless build_step.fetch("env").fetch("OKOU_DESKTOP_PRODUCT") == "okou"
+  raise "canonical Okou build must target app.okou.ai" unless build_step.fetch("env").fetch("OKOU_DESKTOP_PLATFORM_URL") == "https://app.okou.ai"
+  raise "canonical Desktop build must package exactly one runtime config" unless build_step.fetch("run").include?("must contain exactly one Desktop runtime config")
+  raise "canonical Desktop build must verify the packaged runtime config contents" unless build_step.fetch("run").include?("Unexpected canonical Desktop runtime config")
+  raise "canonical Desktop build must package the app once" unless build_step.fetch("run").scan("electron-forge package").length == 1
 
   artifact_build = deploy.fetch("steps").find { |step| step["name"] == "Create canonical Desktop artifact" }.fetch("run")
   raise "canonical artifact must contain the Okou app" unless artifact_build.include?("Okou-darwin-arm64/Okou.app")

--- a/.github/scripts/tests/okou-desktop-artifact-test.sh
+++ b/.github/scripts/tests/okou-desktop-artifact-test.sh
@@ -109,11 +109,11 @@ const forgeConfig = require(path.join(
   "turbo/apps/desktop/forge.config.js",
 ));
 
-if (forgeConfig.packagerConfig.name !== "Zero Computer Use") {
-  throw new Error("Default build must preserve the Zero display name");
+if (forgeConfig.packagerConfig.name !== "Okou") {
+  throw new Error("Default build must use the Okou display name");
 }
-if (forgeConfig.packagerConfig.appBundleId !== "ai.vm0.zero.desktop") {
-  throw new Error("Default build must preserve the Zero bundle ID");
+if (forgeConfig.packagerConfig.appBundleId !== "ai.okou.desktop") {
+  throw new Error("Default build must use the Okou bundle ID");
 }
 
 forgeConfig.hooks
@@ -122,6 +122,25 @@ forgeConfig.hooks
     console.error(error);
     process.exit(1);
   });
+NODE
+
+OKOU_DESKTOP_SKIP_SIGNING=true \
+OKOU_DESKTOP_PRODUCT=zero \
+node - "$repo_root" <<'NODE'
+const path = require("node:path");
+
+const repoRoot = process.argv[2];
+const forgeConfig = require(path.join(
+  repoRoot,
+  "turbo/apps/desktop/forge.config.js",
+));
+
+if (forgeConfig.packagerConfig.name !== "Zero Computer Use") {
+  throw new Error("Zero build must keep the Zero display name");
+}
+if (forgeConfig.packagerConfig.appBundleId !== "ai.vm0.zero.desktop") {
+  throw new Error("Zero build must keep the Zero bundle ID");
+}
 NODE
 
 OKOU_DESKTOP_SKIP_SIGNING=true \

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -132,7 +132,10 @@ jobs:
           echo "platform-url=${platform_url}" >> "$GITHUB_OUTPUT"
           echo "PR preview desktop URL: ${platform_url}"
 
-      - name: Build unsigned production macOS artifact
+      # This build selects no product and writes no runtime config, so it is
+      # what an unconfigured build produces and the only packaged evidence
+      # that the default product is Okou.
+      - name: Build unsigned default-configuration macOS artifact
         id: build-prod
         env:
           SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
@@ -153,8 +156,8 @@ jobs:
 
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")
-          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero Computer Use-darwin-arm64-$version.zip"
-          artifact_path="apps/desktop/out/Zero-darwin-arm64.zip"
+          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Okou-darwin-arm64-$version.zip"
+          artifact_path="apps/desktop/out/Okou-default-darwin-arm64.zip"
 
           if [ ! -f "$forge_zip" ]; then
             echo "No Forge zip artifact found: $forge_zip"
@@ -165,10 +168,10 @@ jobs:
           cp "$forge_zip" "$artifact_path"
           echo "path=$artifact_path" >> "$GITHUB_OUTPUT"
 
-      - name: Verify production artifact
+      - name: Verify default-configuration artifact
         run: |
-          artifact_path="apps/desktop/out/Zero-darwin-arm64.zip"
-          app_dir="apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
+          artifact_path="apps/desktop/out/Okou-default-darwin-arm64.zip"
+          app_dir="apps/desktop/out/Okou-darwin-arm64/Okou.app"
           plist="$app_dir/Contents/Info.plist"
           if [ ! -f "$artifact_path" ]; then
             echo "No desktop zip artifact found"
@@ -206,7 +209,7 @@ jobs:
             exit 1
           fi
           if [ -e "$app_dir/Contents/Resources/app/desktop-runtime-config.json" ]; then
-            echo "Production artifact should not contain desktop runtime config"
+            echo "Default-configuration artifact should not contain desktop runtime config"
             exit 1
           fi
 
@@ -215,36 +218,38 @@ jobs:
             echo "::error::Expected LSMinimumSystemVersion 14.0, found ${minimum_system_version:-missing}"
             exit 1
           fi
-          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero Computer Use"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero Computer Use"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero Computer Use"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.vm0.zero.desktop"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Okou"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Okou"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Okou"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.okou.desktop"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIconFile" "$plist" | grep -qx "icon.icns"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Zero Desktop Auth"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.vm0.zero.desktop"
-          file "$app_dir/Contents/MacOS/Zero Computer Use" | grep -q "arm64"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Okou Auth"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.okou.desktop"
+          file "$app_dir/Contents/MacOS/Okou" | grep -q "arm64"
           file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "arm64"
           cmp -s apps/desktop/assets/icon.icns "$app_dir/Contents/Resources/icon.icns"
           cmp -s apps/desktop/assets/icon.png "$app_dir/Contents/Resources/app/assets/icon.png"
 
-          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/MacOS/Zero Computer Use"
-          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/Resources/icon.icns"
-          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/Resources/native/computer-use-helper"
-          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/Resources/app/dist/main.js"
-          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/Resources/app/dist/bootstrap.js"
-          unzip -l "$artifact_path" | grep -q "Zero Computer Use.app/Contents/Resources/app/assets/icon.png"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/MacOS/Okou"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/icon.icns"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/native/computer-use-helper"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/app/dist/main.js"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/app/dist/bootstrap.js"
+          unzip -l "$artifact_path" | grep -q "Okou.app/Contents/Resources/app/assets/icon.png"
 
-      - name: Smoke test production artifact launch
+      - name: Smoke test default-configuration artifact launch
         run: node apps/desktop/scripts/smoke-test-packaged-app.js
 
-      - name: Upload unsigned macOS artifact
+      - name: Upload unsigned default-configuration macOS artifact
         uses: actions/upload-artifact@v7
         with:
-          name: zero-desktop-macos-arm64-unsigned
+          name: okou-desktop-macos-arm64-default-unsigned
           path: turbo/${{ steps.build-prod.outputs.path }}
           if-no-files-found: error
           retention-days: 14
 
+      # The shipping configuration: the same product selected explicitly,
+      # through the runtime config that the release build bakes in.
       - name: Build unsigned Okou production macOS artifact
         id: build-okou-prod
         env:
@@ -260,6 +265,11 @@ jobs:
             rm -f apps/desktop/desktop-runtime-config.json
           }
           trap cleanup_runtime_config EXIT
+
+          # Both builds now package the same identity into
+          # out/Okou-darwin-arm64, so start from an empty output directory to
+          # keep this artifact's runtime-config assertions unambiguous.
+          rm -rf apps/desktop/out
 
           node <<'NODE'
           const fs = require("node:fs");
@@ -301,7 +311,6 @@ jobs:
         run: |
           artifact_path="apps/desktop/out/Okou-darwin-arm64.zip"
           app_dir="apps/desktop/out/Okou-darwin-arm64/Okou.app"
-          zero_app_dir="apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
           plist="$app_dir/Contents/Info.plist"
           runtime_config="$app_dir/Contents/Resources/app/desktop-runtime-config.json"
           if [ ! -f "$artifact_path" ]; then
@@ -311,11 +320,6 @@ jobs:
           fi
           if [ ! -d "$app_dir" ]; then
             echo "No packaged Okou app found: $app_dir"
-            find apps/desktop/out -maxdepth 4 -type d -print || true
-            exit 1
-          fi
-          if [ ! -d "$zero_app_dir" ]; then
-            echo "Zero and Okou should remain installable side by side"
             find apps/desktop/out -maxdepth 4 -type d -print || true
             exit 1
           fi
@@ -355,10 +359,19 @@ jobs:
           cmp -s apps/desktop/assets/icon.icns "$app_dir/Contents/Resources/icon.icns"
           cmp -s apps/desktop/assets/icon.png "$app_dir/Contents/Resources/app/assets/icon.png"
 
-          zero_bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$zero_app_dir/Contents/Info.plist")
+          # Zero and Okou must stay installable side by side so an existing
+          # Zero installation can adopt Okou. Only Okou is packaged now, so
+          # compare the packaged identity against the Zero identity that an
+          # explicit Zero-product build would use.
+          identities="apps/desktop/src/desktop-identities.json"
+          zero_bundle_id="$(jq -er '.zero.production.bundleId' "$identities")"
           okou_bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist")
           if [ "$zero_bundle_id" = "$okou_bundle_id" ]; then
-            echo "Zero and Okou must use independent bundle identifiers"
+            echo "Zero and Okou should remain installable side by side: bundle identifiers collide"
+            exit 1
+          fi
+          if [ "$(jq -er '.zero.production.userDataDirectoryName' "$identities")" = "$(jq -er '.okou.production.userDataDirectoryName' "$identities")" ]; then
+            echo "Zero and Okou should remain installable side by side: user data directories collide"
             exit 1
           fi
 
@@ -423,8 +436,8 @@ jobs:
 
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")
-          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero CU Dev-darwin-arm64-$version.zip"
-          artifact_path="apps/desktop/out/ZeroCUDev-darwin-arm64-preview.zip"
+          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Okou Dev-darwin-arm64-$version.zip"
+          artifact_path="apps/desktop/out/OkouDev-darwin-arm64-preview.zip"
 
           if [ ! -f "$forge_zip" ]; then
             echo "No Forge preview zip artifact found: $forge_zip"
@@ -440,8 +453,8 @@ jobs:
         env:
           EXPECTED_PLATFORM_URL: ${{ steps.preview.outputs.platform-url }}
         run: |
-          artifact_path="apps/desktop/out/ZeroCUDev-darwin-arm64-preview.zip"
-          app_dir="apps/desktop/out/Zero CU Dev-darwin-arm64/Zero CU Dev.app"
+          artifact_path="apps/desktop/out/OkouDev-darwin-arm64-preview.zip"
+          app_dir="apps/desktop/out/Okou Dev-darwin-arm64/Okou Dev.app"
           plist="$app_dir/Contents/Info.plist"
           runtime_config="$app_dir/Contents/Resources/app/desktop-runtime-config.json"
           if [ ! -f "$artifact_path" ]; then
@@ -503,25 +516,25 @@ jobs:
             echo "::error::Expected LSMinimumSystemVersion 14.0, found ${minimum_system_version:-missing}"
             exit 1
           fi
-          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Zero CU Dev"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero CU Dev"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero CU Dev"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.vm0.zero.desktop.dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist" | grep -qx "Okou Dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Okou Dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Okou Dev"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.okou.desktop.dev"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIconFile" "$plist" | grep -qx "icon.icns"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Zero CU Dev Desktop Auth"
-          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.vm0.zero.desktop.dev"
-          file "$app_dir/Contents/MacOS/Zero CU Dev" | grep -q "arm64"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Okou Dev Auth"
+          /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.okou.desktop.dev"
+          file "$app_dir/Contents/MacOS/Okou Dev" | grep -q "arm64"
           file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "arm64"
           cmp -s apps/desktop/assets/icon.icns "$app_dir/Contents/Resources/icon.icns"
           cmp -s apps/desktop/assets/icon.png "$app_dir/Contents/Resources/app/assets/icon.png"
 
-          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/MacOS/Zero CU Dev"
-          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/icon.icns"
-          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/native/computer-use-helper"
-          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/app/dist/main.js"
-          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/app/dist/bootstrap.js"
-          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/app/assets/icon.png"
-          unzip -l "$artifact_path" | grep -q "Zero CU Dev.app/Contents/Resources/app/desktop-runtime-config.json"
+          unzip -l "$artifact_path" | grep -q "Okou Dev.app/Contents/MacOS/Okou Dev"
+          unzip -l "$artifact_path" | grep -q "Okou Dev.app/Contents/Resources/icon.icns"
+          unzip -l "$artifact_path" | grep -q "Okou Dev.app/Contents/Resources/native/computer-use-helper"
+          unzip -l "$artifact_path" | grep -q "Okou Dev.app/Contents/Resources/app/dist/main.js"
+          unzip -l "$artifact_path" | grep -q "Okou Dev.app/Contents/Resources/app/dist/bootstrap.js"
+          unzip -l "$artifact_path" | grep -q "Okou Dev.app/Contents/Resources/app/assets/icon.png"
+          unzip -l "$artifact_path" | grep -q "Okou Dev.app/Contents/Resources/app/desktop-runtime-config.json"
 
       - name: Smoke test PR preview artifact launch
         if: github.event_name == 'pull_request'
@@ -533,7 +546,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
-          name: zero-desktop-macos-arm64-preview-unsigned
+          name: okou-desktop-macos-arm64-preview-unsigned
           path: turbo/${{ steps.build-preview.outputs.path }}
           if-no-files-found: error
           retention-days: 14
@@ -650,6 +663,8 @@ jobs:
           SENTRY_PROJECT_DESKTOP: ${{ vars.SENTRY_PROJECT_DESKTOP }}
           SENTRY_ENVIRONMENT: production
           OKOU_DESKTOP_SKIP_SIGNING: "true"
+          OKOU_DESKTOP_PRODUCT: okou
+          OKOU_DESKTOP_PLATFORM_URL: https://app.okou.ai
         working-directory: turbo
         run: |
           cleanup_runtime_config() {
@@ -660,27 +675,6 @@ jobs:
           cleanup_runtime_config
           rm -rf apps/desktop/out
 
-          pnpm -F @okouai/desktop build
-          pnpm -F @okouai/desktop upload:sentry
-          pnpm --dir apps/desktop exec electron-forge package \
-            --platform darwin \
-            --arch arm64
-
-          app_dir="$PWD/apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
-          if [ ! -d "$app_dir" ]; then
-            echo "No packaged app found: $app_dir"
-            find apps/desktop/out -maxdepth 4 -type d -print || true
-            exit 1
-          fi
-          if [ -e "$app_dir/Contents/Resources/app/desktop-runtime-config.json" ]; then
-            echo "Canonical production artifact must not contain Desktop runtime config"
-            exit 1
-          fi
-
-          node apps/desktop/scripts/smoke-test-packaged-app.js
-
-          OKOU_DESKTOP_PRODUCT=okou \
-          OKOU_DESKTOP_PLATFORM_URL=https://app.okou.ai \
           node <<'NODE'
           const fs = require("node:fs");
 
@@ -697,29 +691,50 @@ jobs:
           );
           NODE
 
-          OKOU_DESKTOP_PRODUCT=okou \
-          OKOU_DESKTOP_PLATFORM_URL=https://app.okou.ai \
           pnpm -F @okouai/desktop build
-          OKOU_DESKTOP_PRODUCT=okou \
-          OKOU_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+          pnpm -F @okouai/desktop upload:sentry
           pnpm --dir apps/desktop exec electron-forge package \
             --platform darwin \
             --arch arm64
 
-          okou_app_dir="$PWD/apps/desktop/out/Okou-darwin-arm64/Okou.app"
-          if [ ! -d "$okou_app_dir" ]; then
-            echo "No packaged Okou app found: $okou_app_dir"
+          app_dir="$PWD/apps/desktop/out/Okou-darwin-arm64/Okou.app"
+          if [ ! -d "$app_dir" ]; then
+            echo "No packaged Okou app found: $app_dir"
             find apps/desktop/out -maxdepth 4 -type d -print || true
             exit 1
           fi
-          okou_runtime_config="$okou_app_dir/Contents/Resources/app/desktop-runtime-config.json"
-          if [ ! -f "$okou_runtime_config" ]; then
+          runtime_config="$app_dir/Contents/Resources/app/desktop-runtime-config.json"
+          if [ ! -f "$runtime_config" ]; then
             echo "Canonical Okou artifact must contain Desktop runtime config"
             exit 1
           fi
 
-          OKOU_DESKTOP_PRODUCT=okou \
-          OKOU_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+          # The published artifact must carry no runtime config beyond the one
+          # written above: exactly one file, holding exactly the canonical
+          # product and platform URL. Anything else is a configuration baked in
+          # somewhere other than this step.
+          runtime_config_count="$(find "$app_dir" -name desktop-runtime-config.json | wc -l | tr -d '[:space:]')"
+          if [ "$runtime_config_count" != "1" ]; then
+            echo "Canonical Okou artifact must contain exactly one Desktop runtime config, found $runtime_config_count"
+            find "$app_dir" -name desktop-runtime-config.json -print || true
+            exit 1
+          fi
+          RUNTIME_CONFIG="$runtime_config" node <<'NODE'
+          const fs = require("node:fs");
+
+          const config = JSON.parse(
+            fs.readFileSync(process.env.RUNTIME_CONFIG, "utf8"),
+          );
+          if (
+            Object.keys(config).sort().join(",") !== "platformUrl,product" ||
+            config.product !== process.env.OKOU_DESKTOP_PRODUCT ||
+            config.platformUrl !== process.env.OKOU_DESKTOP_PLATFORM_URL
+          ) {
+            console.error("Unexpected canonical Desktop runtime config", config);
+            process.exit(1);
+          }
+          NODE
+
           node apps/desktop/scripts/smoke-test-packaged-app.js
 
       - name: Create canonical Desktop artifact

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -38,8 +38,8 @@ with:
 pnpm desktop:dev
 ```
 
-This packages and runs `Zero CU Dev.app` with `OKOU_DESKTOP_PLATFORM_URL` set to
-the local proxy. Set `OKOU_DESKTOP_PRODUCT=okou` to package `Okou Dev.app`
+This packages and runs `Okou Dev.app` with `OKOU_DESKTOP_PLATFORM_URL` set to
+the local proxy. Set `OKOU_DESKTOP_PRODUCT=zero` to package `Zero CU Dev.app`
 instead. Use packaged development apps for sign-in callback, URL scheme, and
 permission testing.
 Non-CI packaged desktop builds require the `Developer ID Application: Max &
@@ -59,20 +59,20 @@ Create a macOS artifact with:
 pnpm desktop:make
 ```
 
-This builds the production `Zero Computer Use.app`, signs it with the local
-Developer ID Application identity, submits it to Apple's notary service, staples the
-notarization ticket, and writes the zip artifact under `apps/desktop/out/make`.
-Build the independent Okou identity with:
+This builds the production `Okou.app` with bundle ID and callback scheme
+`ai.okou.desktop`, signs it with the local Developer ID Application identity,
+submits it to Apple's notary service, staples the notarization ticket, and
+writes the zip artifact under `apps/desktop/out/make`. Development Okou builds
+use `ai.okou.desktop.dev`. Build the independent Zero identity with:
 
 ```bash
-OKOU_DESKTOP_PRODUCT=okou \
-OKOU_DESKTOP_PLATFORM_URL=https://app.okou.ai \
+OKOU_DESKTOP_PRODUCT=zero \
+OKOU_DESKTOP_PLATFORM_URL=https://app.vm0.ai \
 pnpm -F @okouai/desktop make
 ```
 
-That build creates `Okou.app` with bundle ID and callback scheme
-`ai.okou.desktop`. Development Okou builds use
-`ai.okou.desktop.dev`.
+That build creates `Zero Computer Use.app` with bundle ID and callback scheme
+`ai.vm0.zero.desktop`.
 Local notarized builds use the `notarytool` Keychain profile
 `vm0-desktop-notary` by default. Set `OKOU_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE` to
 override the profile and `OKOU_DESKTOP_NOTARIZE_KEYCHAIN` to override the
@@ -102,20 +102,21 @@ The `Desktop` GitHub Actions workflow builds macOS artifacts for internal
 testing. Run the workflow manually from GitHub Actions, then download the Apple
 silicon artifact:
 
-- `zero-desktop-macos-arm64-unsigned` for Apple silicon Macs
-- `okou-desktop-macos-arm64-unsigned` for the side-by-side Okou identity
+- `okou-desktop-macos-arm64-unsigned` for the shipping configuration, built the
+  way a release is built: the Okou product selected explicitly, with a packaged
+  runtime config
+- `okou-desktop-macos-arm64-default-unsigned` for the same product built from an
+  unconfigured checkout, with no packaged runtime config
 
-The downloaded GitHub artifact contains `Zero-darwin-arm64.zip`. Unzip both
-layers, then open `Zero Computer Use.app`.
-The Okou artifact contains `Okou-darwin-arm64.zip` and
-`Okou.app`.
+Both contain `Okou-darwin-arm64.zip` and `Okou.app`. Unzip both layers, then
+open the app.
 
 These artifacts are ad-hoc signed, not Developer ID signed, and not notarized.
 macOS Gatekeeper may require right-clicking the app and choosing Open, or
 removing quarantine locally:
 
 ```bash
-xattr -dr com.apple.quarantine "Zero Computer Use.app"
+xattr -dr com.apple.quarantine "Okou.app"
 ```
 
 ## Release artifacts
@@ -126,17 +127,16 @@ Desktop releases are versioned by release-please. Changes under
 `desktop-vX.Y.Z` GitHub Release.
 
 When a release-please merge group changes the Desktop package version, the
-`deploy-desktop` job builds the unsigned production `Zero Computer Use.app` and
-`Okou.app` for Apple silicon Macs and publishes both to R2 under
-`okou-desktop/<commit-sha>/`. The matching release run resolves the same commit
-as `release_target`, downloads and verifies those immutable app artifacts,
-signs them with the Developer ID Application certificate, notarizes them for
-direct distribution outside the Mac App Store, and publishes separate releases:
+`deploy-desktop` job builds the unsigned production `Okou.app` for Apple silicon
+Macs and publishes it to R2 under `okou-desktop/<commit-sha>/`. The matching
+release run resolves the same commit as `release_target`, downloads and verifies
+that immutable app artifact, signs it with the Developer ID Application
+certificate, notarizes it for direct distribution outside the Mac App Store, and
+publishes `okou-desktop-vX.Y.Z` containing `Okou-darwin-arm64-X.Y.Z.zip` and
+`.dmg`.
 
-- `desktop-vX.Y.Z` contains `Zero-darwin-arm64-X.Y.Z.zip` and `.dmg`.
-- `okou-desktop-vX.Y.Z` contains `Okou-darwin-arm64-X.Y.Z.zip` and `.dmg`.
-
-The release workflow then updates the independent Zero and Okou manifests.
+The release workflow then updates the Okou manifest. The Zero manifest is frozen
+at its final bridge release and is no longer produced by any build.
 
 Use the product's DMG for manual installation. It opens with a product-specific
 Finder background, the app on the left, and an `/Applications` symlink on the
@@ -168,8 +168,11 @@ Okou schemes (`ai.okou.desktop` and `ai.okou.desktop.dev`). Desktop
 builds select exactly one product feed and one callback scheme from their
 packaged identity; they do not discover or switch products at runtime.
 
-`OKOU_DESKTOP_PRODUCT` defaults to `zero`, preserving existing local and CI
-builds. Okou production builds package a runtime configuration containing
+`OKOU_DESKTOP_PRODUCT` defaults to `okou`, so an unconfigured local or CI build
+produces `Okou.app`. Zero remains selectable through an explicit
+`OKOU_DESKTOP_PRODUCT=zero` or a runtime config naming that product; only the
+build-side default retired. Okou production builds package a runtime
+configuration containing
 `product: okou` and `https://app.okou.ai`. That app origin routes API calls to
 `api.okou.ai`, while Clerk and OAuth web flows remain canonical on
 `www.vm0.ai`.

--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -2,7 +2,6 @@
   "name": "@okouai/desktop",
   "version": "0.44.4",
   "private": true,
-  "productName": "Zero Computer Use",
   "description": "Computer Use desktop shell",
   "main": "dist/bootstrap.js",
   "scripts": {

--- a/turbo/apps/desktop/scripts/desktop-build-config.js
+++ b/turbo/apps/desktop/scripts/desktop-build-config.js
@@ -35,7 +35,7 @@ function resolveDesktopBuildConfig(options = {}) {
     options.product?.trim() ||
       readDesktopEnvironment("OKOU_DESKTOP_PRODUCT") ||
       fileConfig?.product ||
-      "zero",
+      "okou",
   );
   const platformUrl = new URL(
     options.platformUrl?.trim() ||

--- a/turbo/apps/desktop/src/config.ts
+++ b/turbo/apps/desktop/src/config.ts
@@ -126,7 +126,7 @@ function configuredProduct(
     rawProduct?.trim() ||
       readDesktopEnvironment("OKOU_DESKTOP_PRODUCT") ||
       fileConfig?.product ||
-      "zero",
+      "okou",
   );
 }
 

--- a/turbo/apps/desktop/src/desktop-environment-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-environment-entry-points.test.ts
@@ -311,9 +311,9 @@ describe("Desktop build configuration entry point", () => {
   const lifecycleCases = [
     {
       name: "uses product defaults when inputs are absent",
-      expectedProduct: "zero",
-      expectedPlatformUrl: "https://app.vm0.ai/",
-      expectedDisplayName: "Zero Computer Use",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
     },
     {
       name: "treats trimmed-empty canonical inputs as absent",
@@ -321,9 +321,9 @@ describe("Desktop build configuration entry point", () => {
         canonicalProduct: " ",
         canonicalPlatformUrl: "\t",
       },
-      expectedProduct: "zero",
-      expectedPlatformUrl: "https://app.vm0.ai/",
-      expectedDisplayName: "Zero Computer Use",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
     },
     {
       name: "trims canonical inputs",
@@ -344,6 +344,20 @@ describe("Desktop build configuration entry point", () => {
       expectedProduct: "okou",
       expectedPlatformUrl: "https://staging-app.omby.ai/",
       expectedDisplayName: "Okou Dev",
+    },
+    {
+      name: "keeps Zero selectable through canonical inputs",
+      environment: { canonicalProduct: "zero" },
+      expectedProduct: "zero",
+      expectedPlatformUrl: "https://app.vm0.ai/",
+      expectedDisplayName: "Zero Computer Use",
+    },
+    {
+      name: "keeps Zero selectable through the runtime file",
+      fileConfig: { product: "zero", platformUrl: "https://app.vm0.ai" },
+      expectedProduct: "zero",
+      expectedPlatformUrl: "https://app.vm0.ai/",
+      expectedDisplayName: "Zero Computer Use",
     },
   ] satisfies readonly (SurfaceCase & { readonly name: string })[];
 
@@ -407,9 +421,9 @@ describe("Desktop build configuration entry point", () => {
         retiredProduct: "okou",
         retiredPlatformUrl: "https://staging-app.omby.ai",
       },
-      expectedProduct: "zero",
-      expectedPlatformUrl: "https://app.vm0.ai/",
-      expectedDisplayName: "Zero Computer Use",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
     });
 
     expectSuccessfulEntryPoint(result);
@@ -436,9 +450,9 @@ describe("installed Desktop configuration entry point", () => {
   const lifecycleCases = [
     {
       name: "uses product defaults when inputs are absent",
-      expectedProduct: "zero",
-      expectedPlatformUrl: "https://app.vm0.ai/",
-      expectedDisplayName: "Zero Computer Use",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
       expectedEnvironment: "production",
     },
     {
@@ -447,9 +461,9 @@ describe("installed Desktop configuration entry point", () => {
         canonicalProduct: " ",
         canonicalPlatformUrl: "\n",
       },
-      expectedProduct: "zero",
-      expectedPlatformUrl: "https://app.vm0.ai/",
-      expectedDisplayName: "Zero Computer Use",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
       expectedEnvironment: "production",
     },
     {
@@ -473,6 +487,22 @@ describe("installed Desktop configuration entry point", () => {
       expectedPlatformUrl: "https://staging-app.omby.ai/",
       expectedDisplayName: "Okou Dev",
       expectedEnvironment: "staging",
+    },
+    {
+      name: "keeps Zero selectable through canonical inputs",
+      environment: { canonicalProduct: "zero" },
+      expectedProduct: "zero",
+      expectedPlatformUrl: "https://app.vm0.ai/",
+      expectedDisplayName: "Zero Computer Use",
+      expectedEnvironment: "production",
+    },
+    {
+      name: "keeps Zero selectable through the runtime file",
+      fileConfig: { product: "zero", platformUrl: "https://app.vm0.ai" },
+      expectedProduct: "zero",
+      expectedPlatformUrl: "https://app.vm0.ai/",
+      expectedDisplayName: "Zero Computer Use",
+      expectedEnvironment: "production",
     },
   ] satisfies readonly (InstalledSurfaceCase & { readonly name: string })[];
 
@@ -556,9 +586,9 @@ describe("installed Desktop configuration entry point", () => {
         retiredProduct: "okou",
         retiredPlatformUrl: "https://staging-app.omby.ai",
       },
-      expectedProduct: "zero",
-      expectedPlatformUrl: "https://app.vm0.ai/",
-      expectedDisplayName: "Zero Computer Use",
+      expectedProduct: "okou",
+      expectedPlatformUrl: "https://app.okou.ai/",
+      expectedDisplayName: "Okou",
       expectedEnvironment: "production",
     });
 
@@ -633,6 +663,17 @@ describe("packaged Desktop wrapper entry points", () => {
         retiredProduct: "okou",
         retiredPlatformUrl: "https://staging-app.omby.ai",
       },
+      "Okou",
+    );
+
+    expectSuccessfulEntryPoint(result);
+    expect(result.trace).toBe("selected\n");
+  });
+
+  it.each(wrappers)("selects the Zero product through %s", (wrapper) => {
+    const result = runWrapper(
+      wrapper,
+      { canonicalProduct: "zero" },
       "Zero Computer Use",
     );
 

--- a/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
@@ -343,7 +343,8 @@ function runForge(
 ): EntryPointResult {
   const harness = createTestHarness();
   const outputPath = join(harness.directory, "forge-output");
-  const appPath = join(outputPath, "Zero Computer Use.app");
+  // forge.config.js names the bundle from the default build product.
+  const appPath = join(outputPath, "Okou.app");
   mkdirSync(appPath, { recursive: true });
   const environment = baseEnvironment(harness);
   if (options.ci === false) {

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -187,6 +187,29 @@ describe("resolveDesktopConfig", () => {
   it("defaults to production", () => {
     const config = resolveDesktopConfig("");
 
+    expect(config.platformUrl.toString()).toBe("https://app.okou.ai/");
+    expect(config.webUrl.toString()).toBe("https://www.vm0.ai/");
+    expect(config.environment).toBe("production");
+    expect(config.identity).toMatchObject({
+      product: "okou",
+      brandName: "Okou",
+      displayName: "Okou",
+      userDataDirectoryName: "Okou",
+      updateLine: "ai-okou-desktop",
+      bundleId: "ai.okou.desktop",
+      authScheme: "ai.okou.desktop",
+    });
+    expect(config.sessionPartition).toBe("persist:vm0-desktop-production");
+    expect([...config.allowedAppOrigins].sort()).toStrictEqual([
+      "https://api.vm0.ai",
+      "https://app.okou.ai",
+      "https://www.vm0.ai",
+    ]);
+  });
+
+  it("keeps the Zero product selectable", () => {
+    const config = resolveDesktopConfig("", "zero");
+
     expect(config.platformUrl.toString()).toBe("https://app.vm0.ai/");
     expect(config.webUrl.toString()).toBe("https://www.vm0.ai/");
     expect(config.environment).toBe("production");
@@ -213,13 +236,13 @@ describe("resolveDesktopConfig", () => {
     expect(config.environment).toBe("staging");
     expect(config.webUrl.toString()).toBe("https://staging-www.omby.ai/");
     expect(config.identity).toMatchObject({
-      product: "zero",
-      brandName: "Zero",
-      displayName: "Zero CU Dev",
-      userDataDirectoryName: "Zero CU Dev",
-      updateLine: "zero",
-      bundleId: "ai.vm0.zero.desktop.dev",
-      authScheme: "ai.vm0.zero.desktop.dev",
+      product: "okou",
+      brandName: "Okou",
+      displayName: "Okou Dev",
+      userDataDirectoryName: "Okou Dev",
+      updateLine: "ai-okou-desktop",
+      bundleId: "ai.okou.desktop.dev",
+      authScheme: "ai.okou.desktop.dev",
     });
     expect(config.sessionPartition).toBe("persist:vm0-desktop-staging");
     expect(config.allowedAppOrigins.has("https://staging-app.omby.ai")).toBe(
@@ -239,13 +262,13 @@ describe("resolveDesktopConfig", () => {
     expect(config.environment).toBe("development");
     expect(config.webUrl.toString()).toBe("https://www.vm7.ai:8443/");
     expect(config.identity).toMatchObject({
-      product: "zero",
-      brandName: "Zero",
-      displayName: "Zero CU Dev",
-      userDataDirectoryName: "Zero CU Dev",
-      updateLine: "zero",
-      bundleId: "ai.vm0.zero.desktop.dev",
-      authScheme: "ai.vm0.zero.desktop.dev",
+      product: "okou",
+      brandName: "Okou",
+      displayName: "Okou Dev",
+      userDataDirectoryName: "Okou Dev",
+      updateLine: "ai-okou-desktop",
+      bundleId: "ai.okou.desktop.dev",
+      authScheme: "ai.okou.desktop.dev",
     });
     expect(config.sessionPartition).toBe("persist:vm0-desktop-development");
     expect(config.allowedAppOrigins.has("https://app.vm7.ai:8443")).toBe(true);
@@ -259,13 +282,13 @@ describe("resolveDesktopConfig", () => {
     expect(config.environment).toBe("development");
     expect(config.webUrl.toString()).toBe("https://pr-123-www.omby.ai/");
     expect(config.identity).toMatchObject({
-      product: "zero",
-      brandName: "Zero",
-      displayName: "Zero CU Dev",
-      userDataDirectoryName: "Zero CU Dev",
-      updateLine: "zero",
-      bundleId: "ai.vm0.zero.desktop.dev",
-      authScheme: "ai.vm0.zero.desktop.dev",
+      product: "okou",
+      brandName: "Okou",
+      displayName: "Okou Dev",
+      userDataDirectoryName: "Okou Dev",
+      updateLine: "ai-okou-desktop",
+      bundleId: "ai.okou.desktop.dev",
+      authScheme: "ai.okou.desktop.dev",
     });
     expect([...config.allowedAppOrigins].sort()).toStrictEqual([
       "https://pr-123-api.vm6.ai",


### PR DESCRIPTION
Closes #31362.

Retires the Zero product on the Desktop **build** side. The Zero update line, the `zero` entry in `desktop-identities.json`, `DESKTOP_UPDATE_LINE_ZERO` and `/api/desktop/migration-policy` are untouched — those four are the forced-upgrade wall for installed Zero Desktop clients.

Guardrails re-derived against production on 2026-09-03 before starting, via `api.okou.ai` and `api.vm0.ai` (both hosts agree):

```
/api/desktop/updates/zero/stable/darwin/arm64/RELEASES.json
  → 0.38.126, pub_date 2026-08-31T01:15:22.517Z        (unchanged, still frozen)
/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64/RELEASES.json
  → 0.44.4,   pub_date 2026-09-03T04:30:46.347Z
/api/desktop/migration-policy
  → {"schemaVersion":1,"mode":"hard"}
```

## What changed

**`scripts/desktop-build-config.js`** — final product fallback `"zero"` → `"okou"`.

**`src/config.ts` — the same fallback, flipped too.** Not named in the issue, but required for coherence rather than optional polish. `bootstrap.ts` resolves the *installed* config at runtime through `resolveDesktopConfig()`, which had its own `|| "zero"`. Flipping only the build side would make an unconfigured build package a bundle named `Okou.app`, with `ai.okou.desktop` in its plist, that at runtime calls `app.setName("Zero Computer Use")`, stores under the Zero user-data directory, points at `app.vm0.ai` and subscribes to the **`zero` update line**. Nothing in CI would have caught it: `smoke-test-packaged-app.js` locates the bundle through the *build* config, so it would have found and launched the app happily. The two fallbacks have to agree. `desktop-environment-entry-points.test.ts` already treats them as one surface and tests them in lockstep.

**`package.json`** — `productName` deleted. Confirmed no reader: `forge.config.js:98` sets `packagerConfig.name` from `desktopIdentity.displayName`; `bootstrap.ts:18-19` calls `app.setName(config.identity.displayName)`; `forge.config.js` requires `./package.json` only for `devDependencies.electron`. electron-forge does not need it — `packagerConfig.name` is always defined because every product/kind in `desktop-identities.json` has a `displayName`.

**`.github/workflows/desktop.yml`** — the 14 `Zero Computer Use` literals, plus **19 more the issue did not count**: the PR preview job also follows the default. Its runtime config writes only `platformUrl`, so `product` falls through to the default and the preview build becomes `Okou Dev.app` / `ai.okou.desktop.dev` / `Okou Dev Auth`. Left default-driven rather than pinned, so it keeps proving the flip for the *development* identity kind alongside the production one.

## Preserving the runtime-config invariant

The publish job built the default product, smoke-tested it, asserted the artifact contained no `desktop-runtime-config.json`, then discarded it and rebuilt as `Okou.app`. With the default flipped both passes package the same identity, so they are collapsed into one `electron-forge package`. The check is not dropped; it is preserved in three places, two of them stronger than the original:

1. **Exactly one runtime config in the published bundle** — `find … -name desktop-runtime-config.json | wc -l` must be `1`.
2. **That one file is exactly the one this step wrote** — keys are precisely `platformUrl,product`, values match `OKOU_DESKTOP_PRODUCT` / `OKOU_DESKTOP_PLATFORM_URL`. Together (1) and (2) are strictly stronger than the old assertion for the *published* artifact: they prove nothing was baked in beyond the deliberate write, rather than only that an unrelated build had none.
3. **The literal original assertion still runs on every PR** in `build-macos` → "Verify default-configuration artifact", against the identical default configuration the discarded first pass used.

`deploy-desktop-workflow-test.sh` now guards all three, including that the step packages exactly once.

## Is one of the two `build-macos` product builds now redundant?

**Neither build is redundant; the artifact *name* was.** After the flip `build-macos` no longer builds two products — it builds one product through the two different configuration sources, and they produce observably different bundles:

- `build-prod` selects no product and writes no runtime config. It is the only packaged evidence anywhere in CI that an unconfigured build is Okou — precisely the behaviour this PR changes. Delete it and nothing packaged would catch the default silently reverting, since `deploy-desktop` pins the product explicitly.
- `build-okou-prod` selects the product through the baked-in runtime config, which is how the release is actually built. It is the only coverage of that path.

So both stay. What did become misleading is the artifact name `zero-desktop-macos-arm64-unsigned`, which no longer describes a Zero build: renamed to `okou-desktop-macos-arm64-default-unsigned`, and `zero-desktop-macos-arm64-preview-unsigned` → `okou-desktop-macos-arm64-preview-unsigned`.

Two consequential adjustments in that job:

- Both builds now write to `out/Okou-darwin-arm64`, so the Okou build starts with `rm -rf apps/desktop/out` to keep its runtime-config assertions unambiguous.
- The "Zero and Okou should remain installable side by side" check compared two packaged apps; only one is packaged now. Rather than drop the invariant, it compares the packaged Okou plist against the Zero identity an explicit Zero build would use, read from `desktop-identities.json` — bundle IDs and user-data directories must differ. Same guarantee, no second Electron pass.

## Coordination with #31361

#31361 says `README.md:105` and `desktop.yml:243` must be renamed together or not at all, and anticipated this issue might delete the artifact instead. Both are renamed here, so that line item is resolved and #31361 should drop it. No other overlap: this PR touches no file under `src/renderer` and neither MCP plugin.

## Verification

- Guardrail endpoints re-derived before and unchanged after — this PR touches nothing that serves them.
- `pnpm -F @okouai/desktop check-types`, `lint`, `knip --workspace apps/desktop`: clean.
- Desktop suite: 493 passing. Two failures in `bootstrap-degraded.test.ts` reproduce identically on unmodified `main` in the same sandbox (Linux); they pass in CI on macOS.
- `deploy-desktop-workflow-test.sh` and `okou-desktop-artifact-test.sh` pass. The latter asserted the default build produced the Zero identity; it now asserts Okou, with a new explicit `OKOU_DESKTOP_PRODUCT=zero` block keeping the Zero build path covered.
- Zero-selectability regression tests added to `window-policy.test.ts` and `desktop-environment-entry-points.test.ts` (canonical env and runtime-config paths, both surfaces, plus the packaged wrappers).
- shellcheck clean on the rewritten `run` blocks.
- **The real proof is the full Desktop workflow on this PR** — bundle names are only observable after packaging. The plist assertions, `unzip -l` checks and smoke tests all now assert the Okou identity on a default-configuration build; if the flip did not take effect they fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
