### PR TITLE
fix(platform): keep the lightbox open when a drag ends on the backdrop

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/attachment-chips.test.tsx
@@ -711,6 +711,42 @@ describe("zero attachment chips", () => {
     });
   });
 
+  it("closes the attachment lightbox with a deliberate backdrop click", async () => {
+    await setupUploadedImagePreview();
+
+    click(screen.getByLabelText("Open image preview for photo.png"));
+
+    fireEvent.click(await screen.findByTestId("attachment-lightbox-backdrop"));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the attachment lightbox open when a drag ends on the backdrop", async () => {
+    await setupUploadedImagePreview();
+
+    click(screen.getByLabelText("Open image preview for photo.png"));
+
+    // Panning a zoomed image past the panel edge releases the button over the
+    // backdrop, so the browser dispatches the click at the common ancestor of
+    // the two endpoints — the popup, not the backdrop.
+    fireEvent.click(await screen.findByTestId("attachment-lightbox"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("attachment-lightbox-panel"),
+      ).toBeInTheDocument();
+    });
+
+    // The backdrop still dismisses once a press really both starts and ends on it.
+    fireEvent.click(screen.getByTestId("attachment-lightbox-backdrop"));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
   it("pans an uploaded image preview with ordinary wheel events", async () => {
     await setupUploadedImagePreview();
 

--- a/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/okou-page/attachment-chips.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { Button, Dialog, DialogContent, cn } from "@okouai/ui";
 import {
   useGet,
@@ -1425,12 +1425,6 @@ function ArtifactPreviewDialogContent({
     closeArtifactCatalogPreview(rootSignal);
   };
 
-  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      closeWithAnimation();
-    }
-  };
-
   return (
     <Dialog
       open={visible}
@@ -1448,7 +1442,6 @@ function ArtifactPreviewDialogContent({
           "zero-pwa-fixed-cover fixed inset-0 left-0 top-0 flex max-h-none w-auto max-w-none translate-x-0 translate-y-0 items-center justify-center gap-0 overflow-hidden rounded-none border-0 bg-transparent shadow-none",
           fullscreen ? "p-0" : "p-6",
         )}
-        onClick={handleBackdropClick}
         aria-label={t(
           ($) => {
             return $.artifacts.preview.dialogLabel;
@@ -1460,9 +1453,22 @@ function ArtifactPreviewDialogContent({
         <ArtifactDialogImageNavigationKeydown
           navigation={preview.kind === "image" ? imageNavigation : undefined}
         />
+        {/*
+          The popup spans the viewport, so the area around the panel is the
+          backdrop the user sees. Dismissal lives on this dedicated sibling
+          rather than on the popup: a press that starts in the panel and ends
+          outside it — panning a zoomed image past the edge, dragging a text
+          selection out of a document — fires its click at the common ancestor
+          of both endpoints, which is the popup, so this element never sees it.
+        */}
+        <div
+          className="absolute inset-0"
+          onClick={closeWithAnimation}
+          data-testid="attachment-lightbox-backdrop"
+        />
         <div
           className={cn(
-            "flex min-h-0 flex-col overflow-hidden bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)]",
+            "relative flex min-h-0 flex-col overflow-hidden bg-background text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.30)]",
             fullscreen
               ? "zero-fixed-viewport-shell w-dvw rounded-none"
               : "h-[min(700px,86vh)] w-[min(980px,92vw)] rounded-xl",


### PR DESCRIPTION
Fixes #27173

## Problem

Opening an image attachment in the lightbox, panning it, and releasing the mouse button over the surrounding backdrop dismissed the lightbox.

`ArtifactPreviewDialogContent` makes the shared `DialogContent` (Base UI `Dialog.Popup`) span the viewport with `fixed inset-0`, so the area the user perceives as the backdrop *is* the popup. Two consequences:

- Base UI's outside-press handling, which deliberately suppresses a press that starts inside and ends outside, never applies — the release still lands inside the popup.
- The legacy `handleBackdropClick` on the popup closed on any click where `e.target === e.currentTarget`. The browser dispatches `click` at the nearest common ancestor of the `mousedown` and `mouseup` targets, and for a press that starts in the panel and ends over the backdrop that ancestor is exactly the popup — so the end of a drag was read as a clean backdrop click.

The handler predates both the Radix/shadcn and Base UI wrappers ([#5470](https://github.com/vm0-ai/vm0/pull/5470), carried through [#26482](https://github.com/vm0-ai/vm0/pull/26482)); this is legacy lightbox behavior, not a library regression.

## Change

Dismissal moves off the popup and onto a dedicated backdrop sibling rendered behind the panel, so the browser's own event targeting does the work instead of a target-equality check:

- A press that starts in the panel and ends outside it targets its click at the popup, which the backdrop element never sees — the lightbox stays open.
- A press that both starts and ends on the backdrop targets the backdrop directly and still closes.
- The panel gains `relative` so it keeps painting above the absolutely positioned backdrop.

`Escape` and the explicit close button are untouched — they go through `Dialog`'s `onOpenChange` and `DialogIconButton`.

`ArtifactPreviewDialogContent` is shared by every preview kind, so this also fixes dragging a text selection out of a document preview and releasing it over the backdrop.

## Tests

Two regression tests in `attachment-chips.test.tsx`, both verified to fail against the unfixed component:

- a deliberate backdrop click still closes the lightbox;
- a drag that begins inside the viewer and ends over the backdrop leaves it open, and the backdrop still dismisses afterwards.

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/attachment-chips.test.tsx` — 53 passed
- Related suites (`image-annotation`, `artifact-catalog-page`, `thread-sidebar`, `markdown`, `chat-event-action-cards`) — 182 passed
- `pnpm -F @okouai/app run lint`, `tsc --noEmit`, `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)