### PR TITLE
ci(runner): synchronize process containment pressure completion

### DIFF
--- a/.github/scripts/runner-behavior-process-containment-remote.sh
+++ b/.github/scripts/runner-behavior-process-containment-remote.sh
@@ -370,11 +370,11 @@ PRESSURE_SESSION_ID="e2e-process-containment-pressure"
 PRESSURE_SUBMIT_OUTPUT=$(mktemp)
 # The mock's readiness result is gated on the first forwarded follow-up, so
 # startup scheduling cannot close active input before the queue is observed.
-# Keep the final input after the pressure command so the mock turn cannot
-# finish first.
+# The final input is sent explicitly after both sideband execs finish so the
+# active turn owns the sandbox until their results are observed.
 exec {PRESSURE_SUBMIT_FD}>"$PRESSURE_SUBMIT_OUTPUT"
 sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
-  --timeout 35 \
+  --timeout 55 \
   --chat-thread-id "$PRESSURE_CHAT_THREAD_ID" \
   --session-id "$PRESSURE_SESSION_ID" \
   --feature-flag sandboxReuse=true \
@@ -383,7 +383,6 @@ sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
   --active-input 'after=2s,text=cpu-pressure-one' \
   --active-input 'after=4s,text=cpu-pressure-two' \
   --active-input 'after=6s,text=cpu-pressure-three' \
-  --active-input 'after=15s,text=pressure-finish' \
   >&"$PRESSURE_SUBMIT_FD" 2>&1 &
 PRESSURE_SUBMIT_PID=$!
 exec {PRESSURE_SUBMIT_FD}>&-
@@ -584,6 +583,12 @@ PID_CLEANUP_MS=$(sed -n 's/.*cleanup_ms=\([0-9][0-9]*\).*/\1/p' \
 LEAK_CLEANUP_MS=$PID_CLEANUP_MS
 [ "$LEAK_CLEANUP_MS" -le 2000 ] \
   || fail "mixed-identity descendant cleanup exceeded bounded lifecycle: ${LEAK_CLEANUP_MS}ms"
+
+sudo "$BIN_DIR/runner" local input --group "$GROUP" \
+  --run "$PRESSURE_RUN_ID" \
+  --sequence 5 \
+  --text pressure-finish \
+  || fail "failed to release CPU-pressure submit after sideband execs"
 
 if wait "$PRESSURE_SUBMIT_PID"; then
   PRESSURE_SUBMIT_STATUS=0

--- a/crates/runner/src/cmd/local/input.rs
+++ b/crates/runner/src/cmd/local/input.rs
@@ -1,0 +1,166 @@
+//! `runner local input` — send active input to a running local job via file queue.
+
+use std::process::ExitCode;
+
+use clap::Args;
+
+use crate::active_input::{
+    ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, identified_active_input_payload_len,
+};
+use crate::error::{RunnerError, RunnerResult};
+use crate::ids::RunId;
+use crate::local_queue::{self, ActiveInputEntry};
+use crate::paths::HomePaths;
+
+#[derive(Args)]
+pub struct InputArgs {
+    /// Run ID of the claimed local job
+    #[arg(long)]
+    run: RunId,
+    /// Runner group name
+    #[arg(long)]
+    group: String,
+    /// Monotonically increasing active-input sequence number
+    #[arg(long)]
+    sequence: u64,
+    /// Active-input text
+    #[arg(long)]
+    text: String,
+}
+
+pub fn run_input(args: InputArgs) -> RunnerResult<ExitCode> {
+    run_input_with_home(args, HomePaths::new()?)
+}
+
+fn run_input_with_home(args: InputArgs, home: HomePaths) -> RunnerResult<ExitCode> {
+    crate::group::validate_or_err(&args.group)?;
+    if args.sequence == 0 {
+        return Err(RunnerError::Config(
+            "active-input sequence must be greater than zero".into(),
+        ));
+    }
+    if args.text.is_empty() {
+        return Err(RunnerError::Config(
+            "active-input text must not be empty".into(),
+        ));
+    }
+    let payload_len = identified_active_input_payload_len(&args.text).map_err(|e| {
+        RunnerError::Internal(format!(
+            "serialize active-input payload for validation: {e}"
+        ))
+    })?;
+    if payload_len > ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES {
+        return Err(RunnerError::Config(format!(
+            "active-input serialized payload must be <= {ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES} bytes"
+        )));
+    }
+
+    let group_dir = home.groups_dir().join(&args.group);
+    if !group_dir.is_dir() {
+        return Err(RunnerError::Config(format!(
+            "group directory does not exist: {}",
+            group_dir.display()
+        )));
+    }
+    local_queue::validate_group_dir(&group_dir).map_err(|e| {
+        RunnerError::Config(format!(
+            "invalid group directory {}: {e}",
+            group_dir.display()
+        ))
+    })?;
+
+    let claim_path = local_queue::claim_path(&group_dir, args.run);
+    let claimed = local_queue::marker_file_exists(&claim_path, "local claim marker")
+        .map_err(|e| RunnerError::Config(e.to_string()))?;
+    if !claimed {
+        return Err(RunnerError::Config(format!(
+            "no claimed local job found for {}",
+            args.run
+        )));
+    }
+
+    local_queue::LocalQueue::new(group_dir)
+        .write_active_input_sync(&ActiveInputEntry {
+            run_id: args.run,
+            sequence: args.sequence,
+            text: args.text,
+        })
+        .map_err(|e| RunnerError::Internal(format!("write local active input: {e}")))?;
+
+    eprintln!("active input {} written for {}", args.sequence, args.run);
+    Ok(ExitCode::SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn writes_active_input_for_claimed_job() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let group_dir = home.groups_dir().join("test/group");
+        let run_id = RunId::new_v4();
+        local_queue::ensure_claims_dir(&group_dir).unwrap();
+        local_queue::write_private_marker(
+            &local_queue::claim_path(&group_dir, run_id),
+            "test claim marker",
+        )
+        .unwrap();
+
+        let code = run_input_with_home(
+            InputArgs {
+                run: run_id,
+                group: "test/group".into(),
+                sequence: 5,
+                text: "pressure-finish".into(),
+            },
+            home,
+        )
+        .unwrap();
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        let entries = local_queue::LocalQueue::new(group_dir.clone())
+            .read_active_input_entries_from_sequence_sync(run_id, 0);
+        assert_eq!(
+            entries,
+            vec![ActiveInputEntry {
+                run_id,
+                sequence: 5,
+                text: "pressure-finish".into(),
+            }]
+        );
+        let input_path = local_queue::active_input_path(&group_dir, run_id, 5);
+        assert_eq!(
+            std::fs::metadata(input_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn rejects_input_for_unclaimed_job() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        let group_dir = home.groups_dir().join("test/group");
+        local_queue::ensure_claims_dir(&group_dir).unwrap();
+        let run_id = RunId::new_v4();
+
+        let error = run_input_with_home(
+            InputArgs {
+                run: run_id,
+                group: "test/group".into(),
+                sequence: 1,
+                text: "late-input".into(),
+            },
+            home,
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("no claimed local job found"),
+            "got: {error}"
+        );
+        assert!(!local_queue::run_inputs_dir(&group_dir, run_id).exists());
+    }
+}

--- a/crates/runner/src/cmd/local/mod.rs
+++ b/crates/runner/src/cmd/local/mod.rs
@@ -1,6 +1,7 @@
 //! `runner local` — subcommands for the local file-queue provider.
 
 pub(crate) mod cancel;
+pub(crate) mod input;
 pub(crate) mod submit;
 
 use std::process::ExitCode;
@@ -20,6 +21,8 @@ pub struct LocalArgs {
 enum LocalCommand {
     /// Submit a job to a locally running runner
     Submit(submit::SubmitArgs),
+    /// Send active input to a running local job
+    Input(input::InputArgs),
     /// Cancel a running job
     Cancel(cancel::CancelArgs),
 }
@@ -28,6 +31,7 @@ enum LocalCommand {
 pub async fn run_local(args: LocalArgs) -> RunnerResult<ExitCode> {
     match args.command {
         LocalCommand::Submit(args) => submit::run_submit(args).await,
+        LocalCommand::Input(args) => input::run_input(args),
         LocalCommand::Cancel(args) => cancel::run_cancel(args).await,
     }
 }


### PR DESCRIPTION
## Summary

- add `runner local input` to atomically send active input to a claimed local file-queue job
- keep the process-containment pressure turn alive until both sideband exec checks finish
- replace the fixed 15-second completion input with an explicit release after the assertions

## Behavior

The process-containment lane now establishes a happens-before edge between the CPU/PID sideband exec checks and the mock turn's final active input. This prevents the background submit from finishing and destroying its busy sandbox while the PID evidence exec is still connected.

The submit timeout is raised to 55 seconds only as a failure bound for the nested 30-second and 15-second exec limits; successful runs finish immediately after the explicit release.

## Exclusions

- no sandbox parking or finalization behavior changes
- no API, protocol, or persisted-state changes
- no retries, skipped assertions, or fixed completion sleeps

## Validation

- `bash -n .github/scripts/runner-behavior-process-containment-remote.sh`
- `.github/scripts/tests/runner-behavior-durable-test.sh`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `sudo crates/target/debug/runner local input --help`

Local `shellcheck` and the workflow detector were unavailable because this development image does not include `shellcheck` or `yq`; CI will run them with the repository toolchain.
