### PR TITLE
docs(mitm-addon): document sse end-of-stream callbacks

### DIFF
--- a/crates/runner/mitm-addon/src/usage/anthropic_messages.py
+++ b/crates/runner/mitm-addon/src/usage/anthropic_messages.py
@@ -102,8 +102,8 @@ def create_anthropic_messages_sse_usage_extractor(
     that still contain SSE framing to *scanner* (or its ``feed()`` method) and
     retain *usage* as a live mutable accumulator. Usage extracted at a complete
     event boundary updates that same dict in place. After all decoded bytes
-    have been fed, callers must invoke ``scanner.finish()`` to flush a trailing
-    event without a blank-line terminator.
+    have been fed, callers must invoke ``scanner.finish()`` to finalize a
+    captured trailing event when the stream ends without a blank-line terminator.
 
     ``include_usage`` controls both usage extraction and delivery of the
     callbacks described below. When it is ``False``, usage parsing is disabled

--- a/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
+++ b/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
@@ -256,7 +256,15 @@ def create_openai_chat_completions_sse_usage_extractor(
     include_usage: bool = True,
     failure_observer: ModelHttpFailureObserver | None = None,
 ) -> tuple[SseUsageScanner, dict]:
-    """Create an incremental usage parser for Chat Completions SSE bytes."""
+    """Create an incremental usage parser for Chat Completions SSE bytes.
+
+    Returns ``(scanner, usage)``. Callers feed arbitrary byte chunks that still
+    contain SSE framing to the callable *scanner* (or its ``feed()`` method) and
+    retain *usage* as a live mutable accumulator. Usage extracted at a complete
+    event boundary updates that same dict in place. After the final decoded
+    bytes have been fed, callers must invoke ``scanner.finish()`` to finalize a
+    captured trailing event when the stream ends without a blank-line terminator.
+    """
     usage: dict = {}
     parser = SseUsageScanner(
         _OpenAIChatCompletionsSseUsageHandler(

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -718,8 +718,8 @@ def create_openai_responses_sse_usage_extractor(
     contain SSE framing to the callable *scanner* (or its ``feed()`` method) and
     retain *usage* as a live mutable accumulator. Usage extracted at a complete
     event boundary updates that same dict in place. After the final chunk,
-    callers invoke ``scanner.finish()`` to flush an event without a trailing
-    blank line.
+    callers invoke ``scanner.finish()`` to finalize a captured trailing event
+    when the stream ends without a blank-line terminator.
 
     When captured event JSON cannot be parsed or exceeds an extractor bound,
     ``on_parse_error(event_type, error)`` is called only if the final event

--- a/crates/runner/mitm-addon/src/usage/sse.py
+++ b/crates/runner/mitm-addon/src/usage/sse.py
@@ -52,7 +52,11 @@ class SseUsageEventHandler(Protocol):
         """Called between multiple captured data fields in one event."""
 
     def on_event_end(self, event_name: str | None) -> None:
-        """Called when a captured event reaches a blank-line boundary.
+        """Called when a captured event is finalized.
+
+        This happens at a blank-line boundary or when ``SseUsageScanner.finish()``
+        flushes a captured trailing event at end-of-stream without a blank-line
+        terminator.
 
         The value is the final SSE event name if one was seen, or ``None`` if
         the frame ended without an ``event:`` line.
@@ -134,7 +138,7 @@ class SseUsageScanner:
                 i = self._consume_line(chunk, i)
 
     def finish(self) -> None:
-        """Flush a trailing event when the stream ends without a blank line."""
+        """Flush a trailing captured event at end-of-stream without a blank-line terminator."""
 
         self._at_stream_start = False
         if self._state == "data_prefix_space":


### PR DESCRIPTION
## Summary

- Clarify that `SseUsageEventHandler.on_event_end()` runs for both blank-line boundaries and trailing captured events flushed by `SseUsageScanner.finish()` at end-of-stream.
- Align the scanner finalizer wording and the lifecycle guidance in the Anthropic, OpenAI Responses, and OpenAI Chat Completions extractor factories.

## Scope

This is a documentation-only change. It does not alter SSE state transitions, provider parsing, callback signatures, response-stream control flow, or tests.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` — 7311 passed, 43 dependency warnings

Closes #31342
