### PR TITLE
test(python): wait for failure reporter callback cleanup

### DIFF
--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -176,6 +176,7 @@ class _FlowState:
 
 
 _report_lock = threading.Lock()
+_report_condition = threading.Condition(_report_lock)
 _report_api_url = ""
 _report_bearer_credential = ""
 _report_slots = threading.BoundedSemaphore(_MAX_PENDING_REPORTS)
@@ -218,13 +219,18 @@ def reset_for_tests() -> None:
 
 
 def drain_reports_for_tests(timeout: float = 5.0) -> None:
-    """Wait for reports admitted before this call to finish."""
-    with _report_lock:
-        pending = tuple(_report_futures)
-    if pending:
-        _, not_done = wait(pending, timeout=timeout)
-        if not_done:
-            raise TimeoutError(f"{len(not_done)} model-provider failure reports did not finish")
+    """Wait for reports admitted before this call and their callbacks to finish."""
+    with _report_condition:
+        pending = set(_report_futures)
+        callbacks_finished = _report_condition.wait_for(
+            lambda: pending.isdisjoint(_report_futures),
+            timeout=timeout,
+        )
+        if not callbacks_finished:
+            remaining = len(pending.intersection(_report_futures))
+            raise TimeoutError(
+                f"{remaining} model-provider failure report callbacks did not finish"
+            )
 
 
 def admit_flow(flow: http.HTTPFlow) -> None:
@@ -994,9 +1000,10 @@ def _finish_report(future: Future[int], context: _ReportContext) -> None:
                 if not _HTTP_STATUS_SUCCESS_MIN <= status < _HTTP_STATUS_REDIRECT_MIN:
                     _log_report_omitted(context, "http_error", http_status=status)
     finally:
-        with _report_lock:
+        with _report_condition:
+            _report_slots.release()
             _report_futures.discard(future)
-        _report_slots.release()
+            _report_condition.notify_all()
 
 
 def _log_suppressed(flow: http.HTTPFlow, reason: str) -> None:

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -5,7 +5,7 @@ import hashlib
 import json
 import threading
 import zlib
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Literal
 from unittest.mock import patch
@@ -709,6 +709,55 @@ def test_report_transport_failure_logs_omission_and_reclaims_capacity(
         flow_id=flow.id,
         reason="delivery_failed",
         error_type="ConnectionError",
+    )
+
+
+def test_drain_waits_for_completed_report_callback_cleanup(
+    tmp_path,
+    real_flow,
+    model_provider_failure_api,
+):
+    release_delivery = threading.Event()
+    callback_started = threading.Event()
+    release_callback = threading.Event()
+    original_finish_report = model_provider_failure._finish_report
+
+    def hold_callback_cleanup(
+        future: Future[int],
+        context: model_provider_failure._ReportContext,
+    ) -> None:
+        callback_started.set()
+        release_callback.wait()
+        original_finish_report(future, context)
+
+    model_provider_failure_api.queue_response(204, release_event=release_delivery)
+    with patch.object(model_provider_failure, "_finish_report", hold_callback_cleanup):
+        try:
+            _enqueue_provider_unavailable(real_flow, tmp_path / "callback-cleanup.jsonl")
+            assert model_provider_failure_api.wait_for_request_count(1)
+            release_delivery.set()
+            wait_for_event(
+                callback_started,
+                timeout=1,
+                message="failure report callback did not begin cleanup",
+            )
+
+            with pytest.raises(
+                TimeoutError,
+                match="1 model-provider failure report callbacks did not finish",
+            ):
+                model_provider_failure.drain_reports_for_tests(timeout=0)
+        finally:
+            release_delivery.set()
+            release_callback.set()
+            model_provider_failure.drain_reports_for_tests()
+
+    with model_provider_failure._report_lock:
+        assert not model_provider_failure._report_futures
+    _assert_full_report_capacity(
+        real_flow,
+        tmp_path / "callback-cleanup-recovery.jsonl",
+        model_provider_failure_api,
     )
 
 


### PR DESCRIPTION
## Summary

- wait for failure-report callback cleanup through the existing report registry instead of treating a done executor Future as complete
- release report capacity before removing the tracked Future and notifying test drain waiters
- add deterministic regression coverage for a completed Future whose callback cleanup is still blocked, followed by full capacity reuse

## Scope

- preserves the bounded production `shutdown()` behavior
- changes no API, persisted state, dependency, or deployment compatibility contract

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_failure_reporting.py` (100 passed)
- `uv run --no-sync python -m pytest -q tests/` (7312 passed)
- `lefthook run pre-commit`

Closes #31349
