### PR TITLE
perf(mitm-addon): stream oversized firewall path matching

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -17,7 +17,7 @@ from firewall_matching.patterns import (
     SegmentLiteral,
     SegmentParam,
     _match_compiled_host,
-    _match_compiled_path_prefix,
+    _match_compiled_path_prefix_text,
     _parse_segment,
     _split_path_segments,
 )
@@ -635,13 +635,10 @@ def _match_compiled_base_url_parts(
     base_path = base.parts.path
     clean_url_path = url_parts.path
     if base_path and base_path != "/":
-        url_path_segs = _split_path_segments(clean_url_path)
-        path_result = _match_compiled_path_prefix(url_path_segs, base.path_segments)
+        path_result = _match_compiled_path_prefix_text(clean_url_path, base.path_segments)
         if path_result is None:
             return None
-        path_params, consumed = path_result
-        remaining_segs = url_path_segs[consumed:]
-        rel_path = "/" + "/".join(remaining_segs) if remaining_segs else "/"
+        path_params, rel_path = path_result
         all_params = {**host_params, **path_params}
     else:
         rel_path = clean_url_path or "/"

--- a/crates/runner/mitm-addon/src/firewall_matching/patterns.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/patterns.py
@@ -223,7 +223,12 @@ def _iter_path_segments(path: str) -> Iterator[str]:
 
 def _split_path_segments(path: str) -> list[str]:
     """Split path patterns and request paths without normalizing repeated slashes."""
-    return list(_iter_path_segments(path))
+    if path in ("", "/"):
+        return []
+    path_without_leading_slash = path[1:] if path.startswith("/") else path
+    if path_without_leading_slash == "":
+        return []
+    return path_without_leading_slash.split("/")
 
 
 def _split_path_prefix(path: str, segment_count: int) -> tuple[list[str], str]:

--- a/crates/runner/mitm-addon/src/firewall_matching/patterns.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/patterns.py
@@ -1,5 +1,6 @@
 """Low-level firewall segment, host, and path pattern matching."""
 
+from collections.abc import Iterator
 from typing import NamedTuple
 
 _SEGMENT_ERROR_HINT = 'use "{name}", "prefix{name}", "{name}suffix", or "prefix{name}suffix"'
@@ -205,14 +206,72 @@ def match_path_prefix(path_segs: list[str], pattern_segs: list[str]) -> tuple[di
     return _match_compiled_path_prefix(path_segs, compiled_pattern)
 
 
+def _iter_path_segments(path: str) -> Iterator[str]:
+    """Yield path segments without normalizing repeated slashes."""
+    if path in ("", "/"):
+        return
+
+    segment_start = 1 if path.startswith("/") else 0
+    while True:
+        segment_end = path.find("/", segment_start)
+        if segment_end == -1:
+            yield path[segment_start:]
+            return
+        yield path[segment_start:segment_end]
+        segment_start = segment_end + 1
+
+
 def _split_path_segments(path: str) -> list[str]:
     """Split path patterns and request paths without normalizing repeated slashes."""
+    return list(_iter_path_segments(path))
+
+
+def _split_path_prefix(path: str, segment_count: int) -> tuple[list[str], str]:
+    """Split at most segment_count leading segments and return the remaining path."""
+    if segment_count == 0:
+        return [], path or "/"
     if path in ("", "/"):
-        return []
-    path_without_leading_slash = path[1:] if path.startswith("/") else path
-    if path_without_leading_slash == "":
-        return []
-    return path_without_leading_slash.split("/")
+        return [], "/"
+
+    path_segs: list[str] = []
+    segment_start = 1 if path.startswith("/") else 0
+    while len(path_segs) < segment_count:
+        segment_end = path.find("/", segment_start)
+        if segment_end == -1:
+            path_segs.append(path[segment_start:])
+            return path_segs, "/"
+        path_segs.append(path[segment_start:segment_end])
+        segment_start = segment_end + 1
+
+    return path_segs, path[segment_start - 1 :]
+
+
+def _match_compiled_path_prefix_text(
+    path: str,
+    pattern_segs: tuple[ParsedSegment, ...],
+) -> tuple[dict[str, str], str] | None:
+    """Match a compiled prefix while splitting only its configured segment depth."""
+    if pattern_segs and isinstance(pattern_segs[-1], SegmentParam) and pattern_segs[-1].greedy:
+        leading_pattern_segs = pattern_segs[:-1]
+        path_segs, remaining_path = _split_path_prefix(path, len(leading_pattern_segs))
+        leading_result = _match_compiled_path_prefix(path_segs, leading_pattern_segs)
+        if leading_result is None:
+            return None
+
+        params, _consumed = leading_result
+        greedy_segment = pattern_segs[-1]
+        greedy_value = remaining_path[1:] if remaining_path.startswith("/") else remaining_path
+        if greedy_segment.greedy == "+" and not any(char != "/" for char in greedy_value):
+            return None
+        params[greedy_segment.name] = greedy_value
+        return params, "/"
+
+    path_segs, remaining_path = _split_path_prefix(path, len(pattern_segs))
+    result = _match_compiled_path_prefix(path_segs, pattern_segs)
+    if result is None:
+        return None
+    params, _consumed = result
+    return params, remaining_path
 
 
 def _has_non_empty_segment(path_segs: list[str], start: int) -> bool:

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -9,7 +9,7 @@ parameterized hosts are meaningful only for firewall config bases.
 """
 
 import json
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Literal, NamedTuple
@@ -35,6 +35,7 @@ from firewall_matching.patterns import (
     SegmentError,
     SegmentLiteral,
     _compiled_path_segments_match,
+    _iter_path_segments,
     _match_compiled_path_segments,
     _split_path_segments,
 )
@@ -615,12 +616,17 @@ def _freeze_prefix_trie[T](
 
 def _visit_prefix_trie_values[T](
     root: _CompiledPrefixTrieNode[T],
-    path_segs: list[str],
+    path_segs: Iterable[str],
     visit_values: Callable[[tuple[T, ...]], None],
 ) -> None:
     visit_values(root.values)
     node = root
-    for segment in path_segs:
+    path_iter = iter(path_segs)
+    while node.children:
+        try:
+            segment = next(path_iter)
+        except StopIteration:
+            break
         child = node.children.get(segment)
         if child is None:
             break
@@ -668,7 +674,7 @@ def _indexed_api_candidates(
     if root is not None:
         _visit_prefix_trie_values(
             root,
-            _split_path_segments(url_parts.path),
+            _iter_path_segments(url_parts.path),
             candidates.extend,
         )
     if len(candidates) <= 1:

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_indexed_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_indexed_matching.py
@@ -1009,15 +1009,22 @@ def test_oversized_slash_paths_do_not_materialize_complete_segment_lists(monkeyp
         )
     )
     original_split = firewall_patterns._split_path_segments
+    original_iter = matching._iter_path_segments
 
     def reject_oversized_split(path):
         if len(path) > path_security.MAX_PATH_VALIDATION_CHARACTERS:
             raise AssertionError("oversized request path reached complete segment materialization")
         return original_split(path)
 
+    def reject_oversized_iteration(path):
+        if len(path) > path_security.MAX_PATH_VALIDATION_CHARACTERS:
+            raise AssertionError("static root lookup advanced the oversized path iterator")
+        yield from original_iter(path)
+
     monkeypatch.setattr(firewall_patterns, "_split_path_segments", reject_oversized_split)
     monkeypatch.setattr(firewall_base_url, "_split_path_segments", reject_oversized_split)
     monkeypatch.setattr(matching, "_split_path_segments", reject_oversized_split)
+    monkeypatch.setattr(matching, "_iter_path_segments", reject_oversized_iteration)
 
     oversized_path = "/tenant" + "/" * path_security.MAX_PATH_VALIDATION_CHARACTERS
     static_result = matching.match_compiled_firewall_request(

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_indexed_matching.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_indexed_matching.py
@@ -10,6 +10,9 @@ import pytest
 
 import connector_intent
 import matching
+import path_security
+from firewall_matching import base_url as firewall_base_url
+from firewall_matching import patterns as firewall_patterns
 from tests.firewall_helpers import (
     compile_firewalls_or_fail,
     firewall_api,
@@ -992,6 +995,55 @@ def test_indexed_matching_long_path_does_not_use_prefix_key_helpers(monkeypatch)
 
     assert isinstance(result, matching.FirewallAllow)
     assert result.permission == "files-read"
+
+
+def test_oversized_slash_paths_do_not_materialize_complete_segment_lists(monkeypatch):
+    policies = {"example": network_policy(unknown_policy="allow")}
+    static_firewalls = compile_firewalls_or_fail(
+        wrap_firewalls([firewall_api("https://api.example.com", [])], name="example")
+    )
+    parameterized_firewalls = compile_firewalls_or_fail(
+        wrap_firewalls(
+            [firewall_api("https://api.example.com/{tenant}", [])],
+            name="example",
+        )
+    )
+    original_split = firewall_patterns._split_path_segments
+
+    def reject_oversized_split(path):
+        if len(path) > path_security.MAX_PATH_VALIDATION_CHARACTERS:
+            raise AssertionError("oversized request path reached complete segment materialization")
+        return original_split(path)
+
+    monkeypatch.setattr(firewall_patterns, "_split_path_segments", reject_oversized_split)
+    monkeypatch.setattr(firewall_base_url, "_split_path_segments", reject_oversized_split)
+    monkeypatch.setattr(matching, "_split_path_segments", reject_oversized_split)
+
+    oversized_path = "/tenant" + "/" * path_security.MAX_PATH_VALIDATION_CHARACTERS
+    static_result = matching.match_compiled_firewall_request(
+        "https://api.example.com" + oversized_path,
+        "GET",
+        static_firewalls,
+        policies,
+    )
+    parameterized_result = matching.match_compiled_firewall_request(
+        "https://api.example.com" + oversized_path,
+        "GET",
+        parameterized_firewalls,
+        policies,
+    )
+    unrelated_result = matching.match_compiled_firewall_request(
+        "https://unrelated.example.com" + oversized_path,
+        "GET",
+        parameterized_firewalls,
+        policies,
+    )
+
+    assert isinstance(static_result, matching.FirewallBlock)
+    assert static_result.reason == "unsafe_path"
+    assert isinstance(parameterized_result, matching.FirewallBlock)
+    assert parameterized_result.reason == "unsafe_path"
+    assert unrelated_result is None
 
 
 def test_indexed_matching_handles_deep_static_base_trie():


### PR DESCRIPTION
## Summary

- stream runtime path segments into the compiled static API trie instead of materializing the complete segment list
- bound parameterized base matching to its configured prefix depth while preserving captures, relative paths, repeated slashes, and retained malformed greedy semantics
- add a production-matcher regression covering oversized slash-heavy static and parameterized matches plus unrelated-destination pass-through

## Problem

The compiled firewall matcher applies its existing 64 KiB unsafe-path budget only after indexed candidate selection. Candidate selection previously called `split("/")` on the complete runtime path, so a request guaranteed to return `FirewallBlock(reason="unsafe_path")` could first allocate one list entry per attacker-controlled slash. Parameterized fallback bases repeated the same complete split during base matching.

## Implementation

The existing decision pipeline remains authoritative. This PR changes only how its prefix consumers obtain segments:

- `_iter_path_segments()` preserves the existing segment contract but lets trie traversal stop at the configured depth or first miss.
- `_split_path_segments()` remains available as the materialized compatibility helper for consumers that need every bounded rule segment.
- parameterized base matching splits only the number of leading segments present in the compiled base pattern and derives the exact relative path from the original string boundary.

There is no global request-target limit, API change, persisted-state change, feature switch, or rollout dependency. Oversized requests still block only after a firewall base matches; unrelated destinations continue to pass through.

## Diagnostic

Using the locked Python 3.14.0 environment, one compiled static root API, the production `match_compiled_firewall_request()` entry point, and `tracemalloc` started after URL construction:

| Slash count | Before peak | After peak | Before local time | After local time | Result |
| ---: | ---: | ---: | ---: | ---: | --- |
| 1,000,000 | 9.98 MiB | 1.91 MiB | 6.52 ms | 1.09 ms | `FirewallBlock(unsafe_path)` |
| 5,000,000 | 51.53 MiB | 9.54 MiB | 34.58 ms | 5.22 ms | `FirewallBlock(unsafe_path)` |

Timing is diagnostic, not a test contract. URL parsing, the parsed path string, and exact relative-path slices can still scale with raw input length; the slash-count-amplified complete segment list is removed.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_compiled_firewall_indexed_matching.py tests/test_compiled_firewall_unknown_policy.py tests/test_compiled_firewall_base_path_matching.py tests/test_compiled_firewall_malformed_base.py tests/test_compiled_firewall_base_specificity_precedence.py tests/test_compiled_firewall_rule_specificity_precedence.py tests/test_firewall_semantics_contract.py` — 342 passed
- `uv run --no-sync ruff format --check .` — 360 files already formatted
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` — 0 errors, 0 warnings, 0 notes
- `uv run --no-sync python -m pytest tests/` — 7312 passed
- exhaustive short-path split parity diagnostic against the previous implementation

Closes #31350
