### PR TITLE
chore(guest-contracts): rename run-payload field labels to okou

### DIFF
--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -37,16 +37,16 @@ pub const CANONICAL_SANDBOX_REUSE_RESULT_ENV: &str = "OKOU_SANDBOX_REUSE_RESULT"
 pub const CANONICAL_WORKSPACE_REUSE_RESULT_ENV: &str = "OKOU_WORKSPACE_REUSE_RESULT";
 
 /// Logical run-payload field name for the user prompt.
-pub const PROMPT_RUN_PAYLOAD_FIELD: &str = "VM0_PROMPT";
+pub const PROMPT_RUN_PAYLOAD_FIELD: &str = "OKOU_PROMPT";
 
 /// Logical run-payload field name for optional extra system prompt text.
 ///
 /// Unset or empty means there is no extra system prompt.
-pub const APPEND_SYSTEM_PROMPT_RUN_PAYLOAD_FIELD: &str = "VM0_APPEND_SYSTEM_PROMPT";
+pub const APPEND_SYSTEM_PROMPT_RUN_PAYLOAD_FIELD: &str = "OKOU_APPEND_SYSTEM_PROMPT";
 
 /// Sensitive Vercel protection bypass secret for guest API calls.
 ///
-/// This runner-owned bootstrap key intentionally does not use the `VM0_`
+/// This runner-owned bootstrap key intentionally does not use the `OKOU_`
 /// prefix because the guest-agent HTTP client uses this established name to
 /// attach the Vercel bypass header. The runner omits this key when no bypass
 /// secret is configured.
@@ -78,30 +78,30 @@ pub const CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV: &str = "OKOU_AGENT_EXECUTI
 /// The payload is a comma-separated list of base64-encoded secret values, not
 /// secret names. The runner includes the sandbox token so event payloads and
 /// CLI diagnostics can redact it.
-pub const SECRET_VALUES_RUN_PAYLOAD_FIELD: &str = "VM0_SECRET_VALUES";
+pub const SECRET_VALUES_RUN_PAYLOAD_FIELD: &str = "OKOU_SECRET_VALUES";
 
 /// Logical run-payload field name for comma-separated Claude Code tool names
 /// that should be disallowed.
 ///
 /// Unset or empty means there is no explicit deny list.
-pub const DISALLOWED_TOOLS_RUN_PAYLOAD_FIELD: &str = "VM0_DISALLOWED_TOOLS";
+pub const DISALLOWED_TOOLS_RUN_PAYLOAD_FIELD: &str = "OKOU_DISALLOWED_TOOLS";
 
 /// Logical run-payload field name for comma-separated Claude Code tool names
 /// that should be allowed.
 ///
 /// Unset or empty means there is no explicit allow list.
-pub const TOOLS_RUN_PAYLOAD_FIELD: &str = "VM0_TOOLS";
+pub const TOOLS_RUN_PAYLOAD_FIELD: &str = "OKOU_TOOLS";
 
 /// Logical run-payload field name for the raw Claude Code settings payload
 /// passed to the guest-agent.
 ///
 /// The runner treats this as an opaque string. Unset or empty means there is no
 /// settings override.
-pub const SETTINGS_RUN_PAYLOAD_FIELD: &str = "VM0_SETTINGS";
+pub const SETTINGS_RUN_PAYLOAD_FIELD: &str = "OKOU_SETTINGS";
 
 /// CLI framework selector, for example `claude-code` or `codex`.
 ///
-/// This runner-owned bootstrap key intentionally does not use the `VM0_`
+/// This runner-owned bootstrap key intentionally does not use the `OKOU_`
 /// prefix because the runner and guest-agent framework selection contract uses
 /// this exact name.
 pub const CLI_AGENT_TYPE_ENV: &str = "CLI_AGENT_TYPE";
@@ -152,7 +152,7 @@ pub const RUN_PAYLOAD_FILENAME: &str = "payload.json";
 /// Each entry uses camelCase wire keys: `name`, `mountPath`, `storageId`,
 /// `versionId`, and optional `missingRootPolicy`. Unset or empty means there
 /// are no artifact mounts.
-pub const ARTIFACTS_RUN_PAYLOAD_FIELD: &str = "VM0_ARTIFACTS";
+pub const ARTIFACTS_RUN_PAYLOAD_FIELD: &str = "OKOU_ARTIFACTS";
 
 /// One artifact mount in the runner-to-guest run payload.
 ///
@@ -188,21 +188,31 @@ pub enum RunArtifactMissingRootPolicy {
 /// enabled states.
 ///
 /// Unset or empty means there are no feature flags.
-pub const FEATURE_FLAGS_RUN_PAYLOAD_FIELD: &str = "VM0_FEATURE_FLAGS";
+pub const FEATURE_FLAGS_RUN_PAYLOAD_FIELD: &str = "OKOU_FEATURE_FLAGS";
 
 /// Logical run-payload field name for API-owned Codex runtime metadata.
-pub const CODEX_RUNTIME_CONFIG_RUN_PAYLOAD_FIELD: &str = "VM0_CODEX_RUNTIME_CONFIG";
+pub const CODEX_RUNTIME_CONFIG_RUN_PAYLOAD_FIELD: &str = "OKOU_CODEX_RUNTIME_CONFIG";
 
-/// Logical run-payload field name for the schema-v2 Pi launch config marker.
+/// Runner-owned bootstrap key reserved for the schema-v2 Pi launch config
+/// marker.
 ///
 /// The value is the serialized `{"schemaVersion":2}` version marker. Pi's
 /// runtime resources are discovered from canonical filesystem locations by the
 /// official loader. The value never reaches the Pi CLI child as an environment
 /// value; the guest-agent republishes it through
-/// [`PI_LAUNCH_PAYLOAD_FILE_ENV`]. See `piLaunchConfigSchema` in
+/// [`PI_LAUNCH_PAYLOAD_FILE_ENV`]. The name is still classified as an env key
+/// so user env carrying it is scrubbed before the guest-agent starts. See
+/// `piLaunchConfigSchema` in
 /// `turbo/packages/api-contracts/src/contracts/runners.ts` for the canonical
 /// wire schema.
 pub const PI_LAUNCH_CONFIG_ENV: &str = "OKOU_PI_LAUNCH_CONFIG";
+
+/// Logical run-payload field name for the schema-v2 Pi launch config marker.
+///
+/// Same spelling as the reserved bootstrap key [`PI_LAUNCH_CONFIG_ENV`]; this
+/// alias names the [`RunPayload::fields`] role so diagnostics read as payload
+/// fields rather than environment keys.
+pub const PI_LAUNCH_CONFIG_RUN_PAYLOAD_FIELD: &str = PI_LAUNCH_CONFIG_ENV;
 
 /// Path to the private guest-agent-owned Pi launch payload JSON file.
 ///
@@ -218,11 +228,27 @@ pub const PI_LAUNCH_PAYLOAD_PRIVATE_DIR_NAME: &str = "pi-launch-payload";
 /// Private runtime filename used by [`PI_LAUNCH_PAYLOAD_FILE_ENV`].
 pub const PI_LAUNCH_PAYLOAD_FILENAME: &str = "payload.json";
 
-/// Logical run-payload field name for non-secret Pi model metadata.
+/// Runner-owned bootstrap key carrying non-secret Pi model metadata into the
+/// Pi CLI child environment.
 pub const PI_MODEL_CONFIG_ENV: &str = "OKOU_PI_MODEL_CONFIG";
 
-/// Logical run-payload field name for the Chat Thread-owned Pi session id.
+/// Logical run-payload field name for non-secret Pi model metadata.
+///
+/// Same spelling as the bootstrap key [`PI_MODEL_CONFIG_ENV`]; this alias
+/// names the [`RunPayload::fields`] role so diagnostics read as payload fields
+/// rather than environment keys.
+pub const PI_MODEL_CONFIG_RUN_PAYLOAD_FIELD: &str = PI_MODEL_CONFIG_ENV;
+
+/// Runner-owned bootstrap key carrying the Chat Thread-owned Pi session id
+/// into the Pi CLI child environment.
 pub const PI_SESSION_ID_ENV: &str = "OKOU_PI_SESSION_ID";
+
+/// Logical run-payload field name for the Chat Thread-owned Pi session id.
+///
+/// Same spelling as the bootstrap key [`PI_SESSION_ID_ENV`]; this alias names
+/// the [`RunPayload::fields`] role so diagnostics read as payload fields
+/// rather than environment keys.
+pub const PI_SESSION_ID_RUN_PAYLOAD_FIELD: &str = PI_SESSION_ID_ENV;
 
 /// Runner-owned variable-length run payload sent through
 /// [`CANONICAL_RUN_PAYLOAD_FILE_ENV`].
@@ -333,15 +359,15 @@ impl RunPayload {
                 value: codex_runtime_config,
             },
             RunPayloadField {
-                name: PI_LAUNCH_CONFIG_ENV,
+                name: PI_LAUNCH_CONFIG_RUN_PAYLOAD_FIELD,
                 value: pi_launch_config,
             },
             RunPayloadField {
-                name: PI_MODEL_CONFIG_ENV,
+                name: PI_MODEL_CONFIG_RUN_PAYLOAD_FIELD,
                 value: pi_model_config,
             },
             RunPayloadField {
-                name: PI_SESSION_ID_ENV,
+                name: PI_SESSION_ID_RUN_PAYLOAD_FIELD,
                 value: pi_session_id,
             },
         ]
@@ -386,7 +412,7 @@ pub const CANONICAL_POST_RESULT_SIGKILL_GRACE_SECS_ENV: &str =
 /// Test/debug bootstrap switch that makes the guest-agent use the mock Claude
 /// binary.
 ///
-/// This runner-owned bootstrap key intentionally does not use the `VM0_`
+/// This runner-owned bootstrap key intentionally does not use the `OKOU_`
 /// prefix because the mock launcher contract uses this exact name. The
 /// guest-agent treats exactly `true` as enabled.
 pub const USE_MOCK_CLAUDE_ENV: &str = "USE_MOCK_CLAUDE";
@@ -394,7 +420,7 @@ pub const USE_MOCK_CLAUDE_ENV: &str = "USE_MOCK_CLAUDE";
 /// Test/debug bootstrap switch that makes the guest-agent use the mock Codex
 /// binary.
 ///
-/// This runner-owned bootstrap key intentionally does not use the `VM0_`
+/// This runner-owned bootstrap key intentionally does not use the `OKOU_`
 /// prefix because the mock launcher contract uses this exact name. The
 /// guest-agent treats `true` or `1` as enabled.
 pub const USE_MOCK_CODEX_ENV: &str = "USE_MOCK_CODEX";
@@ -691,15 +717,15 @@ mod tests {
                     value: r#"{"providerId":"deepseek"}"#
                 },
                 RunPayloadField {
-                    name: PI_LAUNCH_CONFIG_ENV,
+                    name: PI_LAUNCH_CONFIG_RUN_PAYLOAD_FIELD,
                     value: r#"{"schemaVersion":2}"#
                 },
                 RunPayloadField {
-                    name: PI_MODEL_CONFIG_ENV,
+                    name: PI_MODEL_CONFIG_RUN_PAYLOAD_FIELD,
                     value: r#"{"provider":"deepseek"}"#
                 },
                 RunPayloadField {
-                    name: PI_SESSION_ID_ENV,
+                    name: PI_SESSION_ID_RUN_PAYLOAD_FIELD,
                     value: "22222222-2222-4222-8222-222222222222"
                 },
             ]

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -298,7 +298,7 @@ fn execution_context_validation_rejects_prompt_nul_before_sandbox() {
 
     assert!(error.contains("run payload"));
     assert!(error.contains("NUL byte"));
-    assert!(error.contains("VM0_PROMPT"));
+    assert!(error.contains("OKOU_PROMPT"));
     assert!(!error.contains(secret));
 }
 
@@ -312,7 +312,7 @@ fn execution_context_validation_rejects_append_system_prompt_nul_before_sandbox(
 
     assert!(error.contains("run payload"));
     assert!(error.contains("NUL byte"));
-    assert!(error.contains("VM0_APPEND_SYSTEM_PROMPT"));
+    assert!(error.contains("OKOU_APPEND_SYSTEM_PROMPT"));
     assert!(!error.contains(secret));
 }
 
@@ -326,7 +326,7 @@ fn execution_context_validation_rejects_claude_settings_nul_before_sandbox() {
 
     assert!(error.contains("run payload"));
     assert!(error.contains("NUL byte"));
-    assert!(error.contains("VM0_SETTINGS"));
+    assert!(error.contains("OKOU_SETTINGS"));
     assert!(!error.contains(secret));
 }
 
@@ -357,7 +357,7 @@ fn execution_context_validation_rejects_tool_nul_before_sandbox() {
 
     let error = validate_context_for_test(&ctx).unwrap_err();
 
-    assert!(error.contains("VM0_TOOLS"));
+    assert!(error.contains("OKOU_TOOLS"));
     assert!(error.contains("NUL"));
 }
 
@@ -1163,7 +1163,7 @@ fn build_run_payload_for_run_rejects_prompt_nul() {
 
     assert!(error.contains("run payload"));
     assert!(error.contains("NUL byte"));
-    assert!(error.contains("VM0_PROMPT"));
+    assert!(error.contains("OKOU_PROMPT"));
     assert!(!error.contains(secret));
 }
 
@@ -1430,7 +1430,7 @@ fn execution_context_validation_rejects_codex_runtime_config_nul() {
 
     assert!(error.contains("run payload"));
     assert!(error.contains("NUL byte"));
-    assert!(error.contains("VM0_CODEX_RUNTIME_CONFIG"));
+    assert!(error.contains("OKOU_CODEX_RUNTIME_CONFIG"));
     assert!(!error.contains(secret));
 }
 
@@ -1446,7 +1446,7 @@ fn execution_context_validation_rejects_codex_runtime_config_catalog_nul() {
 
     assert!(error.contains("run payload"));
     assert!(error.contains("NUL byte"));
-    assert!(error.contains("VM0_CODEX_RUNTIME_CONFIG"));
+    assert!(error.contains("OKOU_CODEX_RUNTIME_CONFIG"));
     assert!(!error.contains(secret));
 }
 
@@ -1736,7 +1736,7 @@ fn build_env_json_rejects_invalid_disallowed_tools_entries() {
         let mut ctx = minimal_context();
         ctx.disallowed_tools = Some(vec![tool.into()]);
         let result = build_run_payload_for_run(&ctx);
-        assert_tool_env_error(result, "VM0_DISALLOWED_TOOLS", expected);
+        assert_tool_env_error(result, "OKOU_DISALLOWED_TOOLS", expected);
     }
 }
 
@@ -1753,7 +1753,7 @@ fn build_env_json_rejects_invalid_tools_entries() {
         let mut ctx = minimal_context();
         ctx.tools = Some(vec![tool.into()]);
         let result = build_run_payload_for_run(&ctx);
-        assert_tool_env_error(result, "VM0_TOOLS", expected);
+        assert_tool_env_error(result, "OKOU_TOOLS", expected);
     }
 }
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1717,7 +1717,7 @@ async fn execute_job_claude_tool_validation_failure_skips_sandbox_create() {
 
     assert_eq!(outcome.exit_code(), 1);
     let error = outcome.error().unwrap();
-    assert!(error.contains("VM0_TOOLS"));
+    assert!(error.contains("OKOU_TOOLS"));
     assert!(error.contains("must not contain commas"));
     assert!(outcome.sandbox.is_none());
     assert!(

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -148,7 +148,7 @@ async fn execute_job_reuse_claude_tool_validation_failure_returns_sandbox() {
 
     assert_eq!(reuse_outcome.exit_code(), 1);
     let error = reuse_outcome.error().unwrap();
-    assert!(error.contains("VM0_DISALLOWED_TOOLS"));
+    assert!(error.contains("OKOU_DISALLOWED_TOOLS"));
     assert!(error.contains("must not be empty"));
     assert!(reuse_outcome.sandbox.is_some());
     assert!(reuse_outcome.network_log_session.is_none());

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -1151,7 +1151,7 @@ const executionContextObjectSchema = z.object({
   platformEnvironment: z.record(z.string(), z.string()),
   resumeSession: resumeSessionSchema.nullable(),
   // Plain secret values used by the runner for redaction. These are values, not
-  // names, and are base64-encoded only when exported through VM0_SECRET_VALUES.
+  // names, and are base64-encoded only when exported through OKOU_SECRET_VALUES.
   secretValues: z.array(z.string()).nullable(),
   // AES-256-GCM encrypted Record<string, string>, passed through to mitm-addon
   // for auth resolution. Keys are runtime secret names used by


### PR DESCRIPTION
Closes #31360. Part of #26701.

## Premise verified independently

The issue's premise holds. Checked before making any change:

- `RunPayload` (`crates/guest-contracts/src/env.rs`) derives `serde::Serialize`/`Deserialize` with `#[serde(rename_all = "camelCase")]`, so the transported field names are `prompt`, `appendSystemPrompt`, `secretValues` and so on. **No `VM0_` string crosses the API/Runner boundary.**
- The nine constants are only ever used as `RunPayloadField.name`. Their sole production consumers are the two NUL-byte diagnostics fed by `first_nul_field`:
  - `crates/guest-agent/src/env.rs:704` — `"{RUN_PAYLOAD_FILE_ENV_KEY} contains NUL byte for {name}"`
  - `crates/runner/src/executor/env.rs:832` — `"run payload contains NUL byte for {name}"`
  - plus `crates/runner/src/executor/env.rs:697,704`, which pass the label as `env_name` into `validate_claude_tool_env_entries` — again a diagnostic string only.
- `crates/guest-agent/src/main.rs:1239` is inside `#[cfg(test)] mod tests` (opens at line 1056; no column-0 `}` between), in the `clear_test_env` helper. Confirmed.
- **None of the nine appears in `EXPLICIT_RUNNER_OWNED_ENV_KEYS`**, in `is_runner_owned_env_key`, or in any read/write of a real environment key. There is no `GUEST_AGENT_TUNING_ENV_KEYS` table in the repo.

So no dual-read, no drain, no cross-version sequencing. Single unstaged PR.

## Renamed all nine

| Constant | From | To |
| --- | --- | --- |
| `PROMPT_RUN_PAYLOAD_FIELD` | `VM0_PROMPT` | `OKOU_PROMPT` |
| `APPEND_SYSTEM_PROMPT_RUN_PAYLOAD_FIELD` | `VM0_APPEND_SYSTEM_PROMPT` | `OKOU_APPEND_SYSTEM_PROMPT` |
| `SECRET_VALUES_RUN_PAYLOAD_FIELD` | `VM0_SECRET_VALUES` | `OKOU_SECRET_VALUES` |
| `DISALLOWED_TOOLS_RUN_PAYLOAD_FIELD` | `VM0_DISALLOWED_TOOLS` | `OKOU_DISALLOWED_TOOLS` |
| `TOOLS_RUN_PAYLOAD_FIELD` | `VM0_TOOLS` | `OKOU_TOOLS` |
| `SETTINGS_RUN_PAYLOAD_FIELD` | `VM0_SETTINGS` | `OKOU_SETTINGS` |
| `ARTIFACTS_RUN_PAYLOAD_FIELD` | `VM0_ARTIFACTS` | `OKOU_ARTIFACTS` |
| `FEATURE_FLAGS_RUN_PAYLOAD_FIELD` | `VM0_FEATURE_FLAGS` | `OKOU_FEATURE_FLAGS` |
| `CODEX_RUNTIME_CONFIG_RUN_PAYLOAD_FIELD` | `VM0_CODEX_RUNTIME_CONFIG` | `OKOU_CODEX_RUNTIME_CONFIG` |

Constant names are unchanged; only the string values move.

## Pi suffixes: aliases added, `_ENV` names kept

The issue asked to rename `PI_LAUNCH_CONFIG_ENV`, `PI_MODEL_CONFIG_ENV` and `PI_SESSION_ID_ENV` to `_RUN_PAYLOAD_FIELD`, with an escape clause for any that is also a genuine environment key. **All three hit that escape clause**, so each keeps its `_ENV` name and gains a payload-field alias used by `RunPayload::fields()`:

- `PI_SESSION_ID_ENV` — written into the Pi CLI child environment at `crates/guest-agent/src/cli/mod.rs:569` and read back by `turbo/apps/cli/src/lib/pi-agent-loop.ts:134` via `requiredEnv`.
- `PI_MODEL_CONFIG_ENV` — written into the Pi CLI child environment at `crates/guest-agent/src/cli/mod.rs:577`, read at `pi-agent-loop.ts:119`.
- `PI_LAUNCH_CONFIG_ENV` — deliberately *not* forwarded to the child, but it is listed in `EXPLICIT_RUNNER_OWNED_ENV_KEYS` and its absence from the child environment is asserted at `crates/guest-agent/src/cli/mod.rs:2446` and `crates/guest-agent/tests/pi_cli_run_id_env.rs:60`. That negative contract is an environment-key role.

There is a second, concrete reason not to rename them outright: the `every_declared_env_key_is_classified_for_user_env_protection` test scans the contract sources for `pub const *_ENV` declarations and asserts each is protected from user-env injection. Renaming these three away from the `_ENV` suffix would silently drop them from that scan and force the `total >= 29` floor down — a real weakening of a security guard, in exchange for a naming preference.

The aliases are defined as `pub const PI_X_RUN_PAYLOAD_FIELD: &str = PI_X_ENV;`, so there is one source of truth per value and no duplicated literal.

## Retained `VM0_` strings in `crates/guest-contracts/src/env.rs`

`rg 'VM0_'` on that file now returns exactly nine hits, all inside `runner_owned_key_detection_covers_terminal_contract`:

`VM0_API_TOKEN`, `VM0_SANDBOX_ID`, `VM0_SANDBOX_REUSE_RESULT`, `VM0_WORKSPACE_REUSE_RESULT`, `VM0_RESUME_SESSION_ID`, `VM0_API_START_TIME`, `VM0_USER_ENV_FILE`, `VM0_RUN_PAYLOAD_FILE`, `VM0_FUTURE_RUNNER_KEY`

These are deliberately retained legacy input names: the test asserts `is_runner_owned_env_key` treats them as **user-owned**, which is what keeps a legacy `VM0_`-prefixed key from being scrubbed as if it were a runner bootstrap control. They are inputs to the predicate, not labels.

Also corrected four stale doc comments in the same file that read "intentionally does not use the `VM0_` prefix" — the runner-owned namespace is `OKOU_`, as the module header already states — and one stale `VM0_SECRET_VALUES` mention in `turbo/packages/api-contracts/src/contracts/runners.ts`.

## Test updates

Assertions that compare against the payload label were updated to `OKOU_`:

- `crates/runner/src/executor/tests/env_tests.rs` — the `first_nul_field` diagnostics (lines 301, 315, 329, 360, 1166, 1433, 1449) and the two `assert_tool_env_error` labels (1739, 1756).
- `crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs:1720` and `reuse.rs:151`.

Deliberately **not** changed:

- `env_tests.rs:281,287` (`execution_context_validation_checks_arbitrary_vm0_user_env_before_sandbox`) supplies `VM0_PROMPT` as an *arbitrary user-supplied env key* and asserts the user-env NUL error names it. That is a user env key, not the payload label, and must stay `VM0_`.
- The `!env.contains_key("VM0_...")` assertions elsewhere in `env_tests.rs` check that no legacy `VM0_` env var is emitted at all. They are independent literals, unrelated to the label.
- Assertions written against the constants (`guest-agent/src/env.rs:1269,1375`, `guest-contracts/src/env.rs` `first_nul_field` cases, `fresh_sandbox.rs:1186-1194`) follow the rename automatically.

The issue pointed at `env.rs:798` and `env.rs:808` for the `first_nul_field` expectations. Those line numbers do not match either file on current `main` — in `guest-contracts/src/env.rs` they land inside `runner_owned_key_detection_covers_terminal_contract`, and in `guest-agent/src/env.rs` inside `validate_private_runtime_file_path_for_runtime`. The actual `first_nul_field` assertions are the ones listed above; the ones in `guest-contracts` and `guest-agent` reference the constants, so they needed no literal edit.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all` — applied
- `cargo test -p guest-contracts` — 138 passed, 0 failed
- `cargo test -p guest-agent --lib` — 629 passed, 0 failed
- `cargo test -p runner env_tests::` — running locally; deferred to the PR pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
