### PR TITLE
feat(platform): use okou wordmarks across branded surfaces

### DIFF
--- a/turbo/apps/platform/src/lib/static-assets.ts
+++ b/turbo/apps/platform/src/lib/static-assets.ts
@@ -20,6 +20,12 @@ export const platformVm0LogoImg = platformStaticAssetUrl(
 export const platformVm0LogoDarkImg = platformStaticAssetUrl(
   "assets/vm0-logo-dark-f3de8c7713f8.svg",
 );
+export const platformOkouWordmarkDarkImg = platformPublicStaticUrl(
+  "https://static.vm0.io/public/okou-logo-wordmark-dark-40e256bb155e.svg",
+);
+export const platformOkouWordmarkLightImg = platformPublicStaticUrl(
+  "https://static.vm0.io/public/okou-logo-wordmark-light-1ebf9d0e7a50.svg",
+);
 export const platformFeishuAppIconImg = platformStaticAssetUrl(
   "views/zero-page/assets/feishu/app-icon-okou-fefdc683bf5c.png",
 );

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -8,6 +8,8 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import {
+  platformOkouWordmarkDarkImg,
+  platformOkouWordmarkLightImg,
   platformVm0LogoDarkImg,
   platformVm0LogoImg,
 } from "../../../lib/static-assets.ts";
@@ -206,6 +208,31 @@ describe("auth v2 presentation", () => {
     expect(screen.getByRole("status")).toHaveTextContent("Light theme enabled");
   });
 
+  it("switches both Okou wordmarks with the resolved theme", async () => {
+    const user = userEvent.setup();
+    context.mocks.browser.matchMedia(false);
+    setBrowserUrl("https://app.okou.ai/sign-in");
+
+    detachedSetupPage({ context, path: "/sign-in" });
+
+    await screen.findByRole("heading", {
+      name: "Sign in to Okou",
+    });
+    const themeToggle = buttonByLabel("Toggle theme");
+    const homeLogo = screen.getByAltText("Okou");
+    const cardLogo = screen
+      .getByTestId("auth-v2-brand-logo")
+      .querySelector("img");
+    expect(cardLogo).not.toBeNull();
+    expect(homeLogo).toHaveAttribute("src", platformOkouWordmarkDarkImg);
+    expect(cardLogo).toHaveAttribute("src", platformOkouWordmarkDarkImg);
+
+    await user.click(themeToggle);
+
+    expect(homeLogo).toHaveAttribute("src", platformOkouWordmarkLightImg);
+    expect(cardLogo).toHaveAttribute("src", platformOkouWordmarkLightImg);
+  });
+
   it("localizes Okou app copy while keeping document metadata English", async () => {
     useJapaneseLocale();
     setBrowserUrl("https://app.okou.ai/sign-up");
@@ -221,7 +248,9 @@ describe("auth v2 presentation", () => {
       screen.getByRole("region", { name: "アカウントを作成" }),
     ).toHaveAccessibleDescription("ようこそ！始めるには詳細を入力してください");
     expect(linkByLabel("Okou のホームに移動")).toHaveAttribute("href", "/");
-    expect(screen.queryByTestId("auth-v2-brand-logo")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("auth-v2-brand-logo").querySelector("img"),
+    ).toHaveAttribute("src", platformOkouWordmarkDarkImg);
     expect(heading).toBeVisible();
     expect(document.title).toBe("Sign up | Okou");
   });

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -226,6 +226,8 @@ describe("auth v2 presentation", () => {
     expect(cardLogo).not.toBeNull();
     expect(homeLogo).toHaveAttribute("src", platformOkouWordmarkDarkImg);
     expect(cardLogo).toHaveAttribute("src", platformOkouWordmarkDarkImg);
+    expect(homeLogo).not.toHaveAttribute("crossorigin");
+    expect(cardLogo).not.toHaveAttribute("crossorigin");
 
     await user.click(themeToggle);
 

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-shell.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-shell.tsx
@@ -16,6 +16,7 @@ import {
 import { focusAuthV2HeadingRef$ } from "../../signals/auth-v2-presentation.ts";
 import type { AuthBrandContext } from "../../signals/auth.ts";
 import { theme$ } from "../../signals/theme.ts";
+import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 
 const AUTH_V2_TITLE_ID = "auth-v2-title";
 const AUTH_V2_DESCRIPTION_ID = "auth-v2-description";
@@ -78,7 +79,15 @@ export function AuthV2Shell({
               choiceLayout && "px-10 py-8",
             )}
           >
-            {authBrand.brandName === "VM0" ? (
+            {authBrand.brandName === "Okou" ? (
+              <span className="mb-5" data-testid="auth-v2-brand-logo">
+                <ProductBrandMark
+                  brandName={authBrand.brandName}
+                  decorative
+                  size="compact"
+                />
+              </span>
+            ) : (
               <img
                 alt=""
                 aria-hidden="true"
@@ -91,7 +100,7 @@ export function AuthV2Shell({
                 }
                 width={82}
               />
-            ) : null}
+            )}
             <div className="w-full space-y-1">
               <h1
                 className="text-lg font-medium text-foreground outline-none"

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -16,7 +16,7 @@ function setBrowserUrl(url: string): void {
 
 function okouBrandLink(): HTMLElement {
   const link = queryAllByRoleFast("link").find((candidate) => {
-    return candidate.textContent?.trim() === "Okou";
+    return candidate.getAttribute("aria-label") === "Go to Okou home";
   });
   if (!link) {
     throw new Error("Okou brand link not found");

--- a/turbo/apps/platform/src/views/auth/auth-shell.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-shell.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../lib/static-assets.ts";
 import type { AuthBrandContext } from "../../signals/auth.ts";
 import { setTheme$, theme$ } from "../../signals/theme.ts";
+import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 
 interface AuthShellProps {
   readonly authBrand: AuthBrandContext;
@@ -83,9 +84,7 @@ export function AuthShell({ authBrand, children }: AuthShellProps) {
         )}
       >
         {authBrand.brandName === "Okou" ? (
-          <span className="text-xl font-semibold tracking-tight">
-            {authBrand.brandName}
-          </span>
+          <ProductBrandMark brandName={authBrand.brandName} size="compact" />
         ) : (
           <img
             src={theme === "dark" ? platformVm0LogoImg : platformVm0LogoDarkImg}

--- a/turbo/apps/platform/src/views/browser-authorization/__tests__/browser-authorization-page.test.tsx
+++ b/turbo/apps/platform/src/views/browser-authorization/__tests__/browser-authorization-page.test.tsx
@@ -96,7 +96,9 @@ describe("browser authorization page", () => {
     await expect(
       screen.findByRole("heading", { name: "Enable cloud browser" }),
     ).resolves.toBeInTheDocument();
-    expect(screen.getByText("Okou").closest("a")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Okou" }).closest("a"),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("img", { name: "VM0" })).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/components/product-brand-mark.tsx
+++ b/turbo/apps/platform/src/views/components/product-brand-mark.tsx
@@ -1,15 +1,22 @@
 import { useGet } from "ccstate-react";
 
+import {
+  platformOkouWordmarkDarkImg,
+  platformOkouWordmarkLightImg,
+} from "../../lib/static-assets.ts";
 import { brandName$, type BrandName } from "../../signals/branding.ts";
+import { theme$ } from "../../signals/theme.ts";
 
 type ProductBrandMarkSize = "default" | "compact" | "small";
 
 function Vm0BrandMark({
   size,
   label,
+  decorative,
 }: {
   size: ProductBrandMarkSize;
   label: string;
+  decorative: boolean;
 }) {
   const dimensions =
     size === "default"
@@ -26,8 +33,9 @@ function Vm0BrandMark({
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className="text-foreground"
-      role="img"
-      aria-label={label}
+      role={decorative ? undefined : "img"}
+      aria-hidden={decorative || undefined}
+      aria-label={decorative ? undefined : label}
     >
       <path
         d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"
@@ -67,30 +75,43 @@ function Vm0BrandMark({
 
 export function ProductBrandMark({
   brandName: explicitBrandName,
+  decorative = false,
   size = "default",
 }: {
   brandName?: BrandName;
+  decorative?: boolean;
   size?: ProductBrandMarkSize;
 }) {
   const hostnameBrandName = useGet(brandName$);
+  const theme = useGet(theme$);
   const brandName = explicitBrandName ?? hostnameBrandName;
 
   if (brandName === "VM0") {
-    return <Vm0BrandMark size={size} label={brandName} />;
+    return (
+      <Vm0BrandMark decorative={decorative} size={size} label={brandName} />
+    );
   }
 
-  const sizeClassName =
+  const dimensions =
     size === "default"
-      ? "text-xl leading-6"
+      ? { width: 91, height: 24 }
       : size === "compact"
-        ? "text-xl leading-5"
-        : "text-base leading-4";
+        ? { width: 76, height: 20 }
+        : { width: 60, height: 16 };
 
   return (
-    <span
-      className={`${sizeClassName} font-semibold tracking-tight text-foreground`}
-    >
-      {brandName}
-    </span>
+    <img
+      alt={decorative ? "" : brandName}
+      aria-hidden={decorative || undefined}
+      className="block h-auto"
+      crossOrigin="anonymous"
+      height={dimensions.height}
+      src={
+        theme === "dark"
+          ? platformOkouWordmarkLightImg
+          : platformOkouWordmarkDarkImg
+      }
+      width={dimensions.width}
+    />
   );
 }

--- a/turbo/apps/platform/src/views/components/product-brand-mark.tsx
+++ b/turbo/apps/platform/src/views/components/product-brand-mark.tsx
@@ -104,7 +104,6 @@ export function ProductBrandMark({
       alt={decorative ? "" : brandName}
       aria-hidden={decorative || undefined}
       className="block h-auto"
-      crossOrigin="anonymous"
       height={dimensions.height}
       src={
         theme === "dark"

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-page.test.tsx
@@ -7,6 +7,7 @@ import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { platformOkouWordmarkDarkImg } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -84,8 +85,10 @@ describe("shared thread page", () => {
       return link.getAttribute("aria-label") === "Okou";
     });
     expect(brandLink).toBeInTheDocument();
-    expect(brandLink?.textContent).toBe("Okou");
-    expect(screen.getByRole("img", { name: "Okou" })).toBeInTheDocument();
+    expect(brandLink?.querySelector("img")).toHaveAttribute(
+      "src",
+      platformOkouWordmarkDarkImg,
+    );
     expect(screen.queryByText("Agent")).not.toBeInTheDocument();
     expect(screen.queryByText("Owner")).not.toBeInTheDocument();
     expect(


### PR DESCRIPTION
## Summary

- add the published dark and light Okou wordmarks to the platform static asset map
- render the dark wordmark in light mode and the white wordmark in dark mode across every shared product-brand-mark surface
- add the same theme-aware Okou wordmark to both the auth page header and Auth v2 card while preserving VM0 branding unchanged

## Covered surfaces

- sign-in, sign-up, continuation, and add-account auth surfaces
- directed connector and authorization flows
- browser and Computer Use authorization pages
- shared threads, not-found, campaign redemption, email unsubscribe, permission confirmation, and data export pages

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged repo type checks for non-API packages, `@okouai/app`, and `api`
- `auth-v2-presentation.test.tsx` (7 tests)
- `auth-page.test.tsx` (5 tests)
- `browser-authorization-page.test.tsx` (2 tests)
- `shared-thread-page.test.tsx` (3 tests)

Per-PR Okou preview walkthrough and screenshots will be captured from the deployed head.