### PR TITLE
fix(api): log morning brief onboarding outcomes

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -228,6 +228,17 @@ export default [
     },
   },
   {
+    files: ["src/signals/services/onboarding.service.ts"],
+    rules: {
+      "api/no-logger-info": [
+        "error",
+        {
+          allowedMessages: ["Morning Brief onboarding provisioning outcome"],
+        },
+      ],
+    },
+  },
+  {
     files: ["src/**/*.ts"],
     ignores: [
       "src/**/__tests__/**",

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -2110,6 +2110,7 @@ describe.sequential("Morning Brief default onboarding", () => {
       }),
     ).resolves.toStrictEqual(activationAt);
 
+    context.mocks.axiomLogging.info.mockClear();
     expect(
       (
         await bdd.completeOnboarding(preActivationActor, {
@@ -2117,10 +2118,31 @@ describe.sequential("Morning Brief default onboarding", () => {
         })
       ).status,
     ).toBe(200);
+    expect(
+      context.mocks.axiomLogging.info.mock.calls.filter(([message]) => {
+        return message === "Morning Brief onboarding provisioning outcome";
+      }),
+    ).toStrictEqual([
+      [
+        "Morning Brief onboarding provisioning outcome",
+        expect.objectContaining({
+          context: "onboarding.service",
+          orgId: preActivationActor.orgId,
+          userId: preActivationActor.userId,
+          firstCompletion: true,
+          timezone: "stored",
+          provisioning: {
+            outcome: "skipped",
+            reason: "not-eligible",
+          },
+        }),
+      ],
+    ]);
     await expect(
       listMorningBriefInstallations(preActivationActor),
     ).resolves.toHaveLength(0);
 
+    context.mocks.axiomLogging.info.mockClear();
     expect(
       (
         await bdd.completeOnboarding(eligibleCreator, {
@@ -2128,6 +2150,26 @@ describe.sequential("Morning Brief default onboarding", () => {
         })
       ).status,
     ).toBe(200);
+    expect(
+      context.mocks.axiomLogging.info.mock.calls.filter(([message]) => {
+        return message === "Morning Brief onboarding provisioning outcome";
+      }),
+    ).toStrictEqual([
+      [
+        "Morning Brief onboarding provisioning outcome",
+        expect.objectContaining({
+          context: "onboarding.service",
+          orgId: eligibleCreator.orgId,
+          userId: eligibleCreator.userId,
+          firstCompletion: true,
+          timezone: "stored",
+          provisioning: {
+            outcome: "installed",
+            workflowId: expect.any(String),
+          },
+        }),
+      ],
+    ]);
     const installations = await listMorningBriefInstallations(eligibleCreator);
     expect(installations).toHaveLength(1);
     const installation = installations[0];

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -265,7 +265,7 @@ export const completeOnboarding$ = command(
       additiveOutcome.ok &&
       additiveOutcome.value.provisioning.outcome !== "failed"
     ) {
-      L.debug("Morning Brief onboarding provisioning outcome", {
+      L.info("Morning Brief onboarding provisioning outcome", {
         orgId: args.orgId,
         userId: args.member.userId,
         ...additiveOutcome.value,

--- a/turbo/packages/eslint-rules/src/api/__tests__/no-logger-info.test.ts
+++ b/turbo/packages/eslint-rules/src/api/__tests__/no-logger-info.test.ts
@@ -22,6 +22,10 @@ ruleTester.run("no-logger-info", noLoggerInfo, {
       filename: "/app/src/__tests__/log.test.ts",
       code: 'const L = logger("Test"); L.info("test-only");',
     },
+    {
+      code: 'const L = logger("Server"); L.info("audited outcome");',
+      options: [{ allowedMessages: ["audited outcome"] }],
+    },
   ],
   invalid: [
     {
@@ -30,6 +34,16 @@ ruleTester.run("no-logger-info", noLoggerInfo, {
     },
     {
       code: 'const L = logger("Server"); L.info("started");',
+      errors: [{ messageId: "noLoggerInfo" }],
+    },
+    {
+      code: 'const L = logger("Server"); L.info("different outcome");',
+      options: [{ allowedMessages: ["audited outcome"] }],
+      errors: [{ messageId: "noLoggerInfo" }],
+    },
+    {
+      code: 'const L = logger("Server"); L.info(message);',
+      options: [{ allowedMessages: ["audited outcome"] }],
       errors: [{ messageId: "noLoggerInfo" }],
     },
   ],

--- a/turbo/packages/eslint-rules/src/api/rules/no-logger-info.ts
+++ b/turbo/packages/eslint-rules/src/api/rules/no-logger-info.ts
@@ -1,6 +1,7 @@
 import type { Rule } from "eslint";
 
 type NodeWithCallee = Rule.Node & {
+  arguments?: readonly Rule.Node[];
   callee?: Rule.Node;
 };
 
@@ -14,6 +15,14 @@ type MemberExpressionNode = Rule.Node & {
   object?: Rule.Node;
   property?: Rule.Node;
 };
+
+type LiteralNode = Rule.Node & {
+  value?: unknown;
+};
+
+interface NoLoggerInfoOptions {
+  readonly allowedMessages?: readonly string[];
+}
 
 function isNamedIdentifier(node: Rule.Node | undefined, name: string): boolean {
   return node?.type === "Identifier" && node.name === name;
@@ -45,20 +54,46 @@ function getInfoObject(node: Rule.Node): Rule.Node | null {
   return null;
 }
 
+function getStaticMessage(node: Rule.Node): string | null {
+  const firstArgument = (node as NodeWithCallee).arguments?.[0] as
+    | LiteralNode
+    | undefined;
+  if (
+    firstArgument?.type === "Literal" &&
+    typeof firstArgument.value === "string"
+  ) {
+    return firstArgument.value;
+  }
+  return null;
+}
+
 export const noLoggerInfo: Rule.RuleModule = {
   meta: {
     type: "problem",
     docs: {
       description:
-        "Disallow info-level API logs; use debug, warn, error, or fatal instead",
+        "Disallow info-level API logs except explicitly allowed static audit messages",
     },
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowedMessages: {
+            type: "array",
+            items: { type: "string" },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       noLoggerInfo:
         "Do not use logger.info() in API source. Use debug for routine diagnostics or warn/error/fatal for actionable issues.",
     },
   },
   create(context) {
+    const options = (context.options[0] ?? {}) as NoLoggerInfoOptions;
+    const allowedMessages = new Set(options.allowedMessages ?? []);
     const filename = context.filename ?? context.getFilename();
     if (filename.includes("/__tests__/")) {
       return {};
@@ -86,6 +121,10 @@ export const noLoggerInfo: Rule.RuleModule = {
           isLoggerCall(object) ||
           (object.type === "Identifier" && loggerVariables.has(object.name))
         ) {
+          const message = getStaticMessage(node);
+          if (message !== null && allowedMessages.has(message)) {
+            return;
+          }
           context.report({
             node,
             messageId: "noLoggerInfo",


### PR DESCRIPTION
## Summary

- promote the bounded non-failure Morning Brief onboarding provisioning outcome from `debug` to `info` without changing its message or structured payload
- assert the expected pre-activation skip and a normal installation at `info`, while retaining the installer-failure `warn` coverage and onboarding 200 semantics
- keep the API info-log guardrail fail-closed by allowing only this static message in `onboarding.service.ts`, with rule coverage for mismatched and dynamic messages

## Validation

- `pnpm exec prettier --check apps/api/eslint.config.mjs apps/api/src/signals/routes/__tests__/official-workflows.test.ts apps/api/src/signals/services/onboarding.service.ts packages/eslint-rules/src/api/__tests__/no-logger-info.test.ts packages/eslint-rules/src/api/rules/no-logger-info.ts`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm --filter @okouai/eslint-rules run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/eslint-rules exec vitest run src/api/__tests__/no-logger-info.test.ts`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres pnpm --filter api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts -t 'Morning Brief default onboarding'`

Fixes #31367

Parent: #31156
