### PR TITLE
refactor(api): require exact connector ids for credential loading

### DIFF
--- a/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-credential-runtime.service.ts
@@ -129,21 +129,13 @@ function connectorStoredValueRef(valueRef: string): ConnectorStoredValueRef {
 }
 
 export async function loadConnectorCredentialConnection(args: {
-  readonly connectorId?: string;
+  readonly connectorId: string;
   readonly connectorSlug: string;
   readonly db: ReadonlyDb;
   readonly orgId: string;
   readonly snapshot: ConnectorRuntimeSnapshot;
   readonly userId: string;
 }): Promise<ConnectorCredentialConnectionResult> {
-  const conditions = [
-    eq(connectors.orgId, args.orgId),
-    eq(connectors.userId, args.userId),
-    eq(connectors.connectorSlug, args.connectorSlug),
-  ];
-  if (args.connectorId !== undefined) {
-    conditions.push(eq(connectors.id, args.connectorId));
-  }
   const [row] = await args.db
     .select({
       authMethod: connectors.authMethod,
@@ -158,7 +150,14 @@ export async function loadConnectorCredentialConnection(args: {
       tokenExpiresAt: connectors.tokenExpiresAt,
     })
     .from(connectors)
-    .where(and(...conditions))
+    .where(
+      and(
+        eq(connectors.id, args.connectorId),
+        eq(connectors.orgId, args.orgId),
+        eq(connectors.userId, args.userId),
+        eq(connectors.connectorSlug, args.connectorSlug),
+      ),
+    )
     .limit(1);
   if (!row) {
     return { kind: "missing" };

--- a/turbo/apps/api/src/signals/services/gmail-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-automation-event.service.ts
@@ -281,7 +281,7 @@ async function resolveGmailAccess(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
-    readonly connectorId?: string;
+    readonly connectorId: string;
     readonly refreshExpiredToken?: boolean;
   },
   signal: AbortSignal,
@@ -295,9 +295,7 @@ async function resolveGmailAccess(
     orgId: args.orgId,
     userId: args.userId,
     connectorSlug: "gmail",
-    ...(args.connectorId === undefined
-      ? {}
-      : { connectorId: args.connectorId }),
+    connectorId: args.connectorId,
   });
   signal.throwIfAborted();
   if (loaded.kind === "missing") {

--- a/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-meet-automation-event.service.ts
@@ -250,7 +250,7 @@ async function resolveGoogleMeetAccess(
     readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
-    readonly connectorId?: string;
+    readonly connectorId: string;
     readonly refreshExpiredToken?: boolean;
   },
   signal: AbortSignal,
@@ -264,9 +264,7 @@ async function resolveGoogleMeetAccess(
     orgId: args.orgId,
     userId: args.userId,
     connectorSlug: "google-meet",
-    ...(args.connectorId === undefined
-      ? {}
-      : { connectorId: args.connectorId }),
+    connectorId: args.connectorId,
   });
   signal.throwIfAborted();
   if (loaded.kind === "missing") {


### PR DESCRIPTION
## Summary

- require an exact connector ID when loading connector credentials
- keep exact ID, organization, user, and connector-slug validation in the shared query
- require Gmail and Google Meet access helpers to forward the exact account identity

This removes the dormant owner/slug-only unordered `LIMIT 1` path. All existing callers already carry an exact connector ID, so valid runtime behavior is unchanged and future source-less callers fail at type checking.

## Scope

- Closes #31388
- Parent context: #30585
- Leaves deterministic single-account and old-version compatibility behavior tracked by #29777 unchanged
- No API, schema, persisted-state, queue, runner, frontend, or provider-protocol changes

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/connector-credential-runtime.service.ts apps/api/src/signals/services/gmail-automation-event.service.ts apps/api/src/signals/services/google-meet-automation-event.service.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-gmail.test.ts src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts --silent=passed-only` (29 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- pre-commit: full Turbo type checking, full Knip, Prettier, file-size check, and commitlint
