### PR TITLE
refactor: remove obsolete vm0 migration tombstones

### DIFF
--- a/turbo/apps/api/src/__tests__/env-stub.ts
+++ b/turbo/apps/api/src/__tests__/env-stub.ts
@@ -10,12 +10,6 @@ export function stubTestWebUrlEnvironment(webUrl: string | undefined): void {
   vi.stubEnv("OKOU_WEB_URL", webUrl);
 }
 
-export function stubRetiredTestWebUrlEnvironment(
-  webUrl: string | undefined,
-): void {
-  vi.stubEnv("VM0_WEB_URL", webUrl);
-}
-
 function stubTestDatabaseUrl(): void {
   const vitestWorkerId = process.env.VITEST_WORKER_ID;
   if (!vitestWorkerId) {

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -8,7 +8,6 @@ import { testContext } from "../../__tests__/test-context";
 const { axiom, axiomLogging, console: consoleOutput } = testContext().mocks;
 
 const CANONICAL_DEBUG_KEY = "OKOU_DEBUG";
-const LEGACY_DEBUG_KEY = "VM0_DEBUG";
 function configureDebug(value: string | undefined): void {
   mockEnv(CANONICAL_DEBUG_KEY, value);
 }
@@ -74,24 +73,6 @@ describe("debug environment", () => {
     for (const name of disabled) {
       expect(logger(name).level).toBe("info");
     }
-  });
-
-  it("ignores a retired legacy-only input", () => {
-    configureDebug(undefined);
-    mockOptionalEnv(LEGACY_DEBUG_KEY, "legacy-only-target");
-
-    expect(logger("legacy-only-target").level).toBe("info");
-  });
-
-  it("does not let a retired legacy value override or conflict with canonical", () => {
-    configureDebug("canonical:*");
-    mockOptionalEnv(LEGACY_DEBUG_KEY, "legacy:*");
-
-    expect(() => {
-      logger("canonical:child");
-    }).not.toThrow();
-    expect(logger("canonical:child").level).toBe("debug");
-    expect(logger("legacy:child").level).toBe("info");
   });
 
   it("does not emit the canonical environment value to logs", () => {

--- a/turbo/apps/api/src/lib/__tests__/web-url.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/web-url.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import {
-  stubRetiredTestWebUrlEnvironment,
-  stubTestWebUrlEnvironment,
-} from "../../__tests__/env-stub";
+import { stubTestWebUrlEnvironment } from "../../__tests__/env-stub";
 import { mockEnv } from "../env";
 import {
   getOAuthApiOrigin,
@@ -25,7 +22,6 @@ async function importEnvWithRawWebUrl(
 describe("web URL", () => {
   afterEach(() => {
     stubTestWebUrlEnvironment("http://localhost:3001");
-    stubRetiredTestWebUrlEnvironment(undefined);
     vi.resetModules();
   });
 
@@ -43,14 +39,6 @@ describe("web URL", () => {
     await expect(
       importEnvWithRawWebUrl("https://configured.example.test/path"),
     ).resolves.toBeUndefined();
-  });
-
-  it("requires canonical raw input when only the retired key is present", async () => {
-    stubRetiredTestWebUrlEnvironment("https://legacy-only.example.test/path");
-
-    await expect(importEnvWithRawWebUrl(undefined)).rejects.toThrow(
-      /Invalid environment variables/u,
-    );
   });
 
   it("preserves Web URL bytes and OAuth origins", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -11128,7 +11128,6 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(fastClaim.claim.cliAgentType).toBe("codex");
     expect(environment.OPENAI_MODEL).toBe("gpt-5.6-sol");
     expect(environment.OKOU_CODEX_SERVICE_TIER).toBe("fast");
-    expect(environment.VM0_CODEX_SERVICE_TIER).toBeUndefined();
     expect(environment.OPENAI_API_KEY).toBeTruthy();
     expect(environment.CHATGPT_ACCESS_TOKEN).toBeUndefined();
     await cancelChatRun(actor, fast.runId, fastClaim.sandboxHeaders);
@@ -11233,7 +11232,6 @@ describe("CHAT-02: model-first provider policies", () => {
     const standardEnvironment = claimEnvironment(standardClaim);
     expect(standardEnvironment.OPENAI_MODEL).toBe("gpt-5.6-luna");
     expect(standardEnvironment.OKOU_CODEX_SERVICE_TIER).toBeUndefined();
-    expect(standardEnvironment.VM0_CODEX_SERVICE_TIER).toBeUndefined();
     await cancelChatRun(actor, standard.runId);
 
     const rejectedThreadId = randomUUID();
@@ -11326,7 +11324,6 @@ describe("CHAT-02: model-first provider policies", () => {
     );
     expect(environment.OPENAI_MODEL).toBe("gpt-5.6-luna");
     expect(environment.OKOU_CODEX_SERVICE_TIER).toBe("fast");
-    expect(environment.VM0_CODEX_SERVICE_TIER).toBeUndefined();
     expect(
       (await readThreadProjection(actor, first.threadId)).serviceTier,
     ).toBe("priority");

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -4373,7 +4373,6 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const fastClaim = await runs.claimRunnerJob(fastRunId);
     expect(fastClaim.cliAgentType).toBe("codex");
     expect(fastClaim.platformEnvironment.OKOU_CODEX_SERVICE_TIER).toBe("fast");
-    expect(fastClaim.environment?.VM0_CODEX_SERVICE_TIER).toBeUndefined();
     const fastOkouToken = fastClaim.platformEnvironment.OKOU_TOKEN;
     if (!fastOkouToken) {
       throw new Error("Expected the Slack Fast run to expose OKOU_TOKEN");
@@ -5493,7 +5492,6 @@ describe("INT-02: Telegram integration", () => {
     const claim = await runs.claimRunnerJob(runId);
     expect(claim.cliAgentType).toBe("codex");
     expect(claim.platformEnvironment.OKOU_CODEX_SERVICE_TIER).toBe("fast");
-    expect(claim.environment?.VM0_CODEX_SERVICE_TIER).toBeUndefined();
     const okouToken = claim.platformEnvironment.OKOU_TOKEN;
     if (!okouToken) {
       throw new Error("Expected the Telegram Fast run to expose OKOU_TOKEN");

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -15190,7 +15190,6 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       name: "OKOU_TOKEN",
       value: "***",
     });
-    expect(claim.environment?.VM0_APP_URL).toBeUndefined();
     expect(claim.environment?.APP_URL).toBeUndefined();
     expect(claim.environment ?? {}).not.toHaveProperty(
       "ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED",

--- a/turbo/apps/cli/src/commands/model/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/model/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import chalk from "chalk";
 import { server } from "../../../mocks/server";
-import { modelCommand } from "../index";
+import { switchCommand, modelCommand } from "../index";
 
 const MODEL_POLICIES_RESPONSE = {
   workspaceDefaultModel: "claude-sonnet-4-6",
@@ -81,5 +81,13 @@ describe("okou model command", () => {
     expect(logCalls).toContain("provider: api key");
     expect(logCalls).not.toContain("price tier: $$$");
     expect(logCalls).toContain("okou model-provider set --help");
+  });
+
+  it("should show Web switching guidance", async () => {
+    await switchCommand.parseAsync(["node", "cli"]);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      "Open https://app.okou.ai and switch models from the model selector next to the input box.",
+    );
   });
 });

--- a/turbo/apps/cli/src/commands/model/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/model/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import chalk from "chalk";
 import { server } from "../../../mocks/server";
-import { switchCommand, modelCommand } from "../index";
+import { modelCommand } from "../index";
 
 const MODEL_POLICIES_RESPONSE = {
   workspaceDefaultModel: "claude-sonnet-4-6",
@@ -81,18 +81,5 @@ describe("okou model command", () => {
     expect(logCalls).toContain("provider: api key");
     expect(logCalls).not.toContain("price tier: $$$");
     expect(logCalls).toContain("okou model-provider set --help");
-  });
-
-  it("should ignore the inherited legacy prompt when showing switch guidance", async () => {
-    vi.stubEnv(
-      "VM0_APPEND_SYSTEM_PROMPT",
-      "You are currently running inside: Telegram",
-    );
-
-    await switchCommand.parseAsync(["node", "cli"]);
-
-    expect(mockConsoleLog).toHaveBeenCalledWith(
-      "Open https://app.okou.ai and switch models from the model selector next to the input box.",
-    );
   });
 });

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -684,7 +684,7 @@ describe("sandbox Pi agent loop", () => {
       catalogModel: "deepseek-v4-flash",
       api: "openai-responses",
       apiKeyEnv: "OPENAI_API_KEY",
-      credentialSecretName: "VM0_MODEL_PROVIDER_API_KEY",
+      credentialSecretName: "CUSTOM_GATEWAY_API_KEY",
       credentialHeader: {
         name: "x-api-key",
         valueTemplate: "Key {{secret}}",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -384,7 +384,7 @@ describe("Pi sandbox execution contract", () => {
         catalogModel: "deepseek-v4-flash",
         api: "openai-responses",
         apiKeyEnv: "OPENAI_API_KEY",
-        credentialSecretName: "VM0_MODEL_PROVIDER_API_KEY",
+        credentialSecretName: "CUSTOM_GATEWAY_API_KEY",
         credentialHeader: {
           name: "x-api-key",
           valueTemplate: "Key {{secret}}",
@@ -411,7 +411,7 @@ describe("Pi sandbox execution contract", () => {
           catalogModel: "deepseek-v4-flash",
           api: "openai-responses",
           apiKeyEnv: "OPENAI_API_KEY",
-          credentialSecretName: "VM0_MODEL_PROVIDER_API_KEY",
+          credentialSecretName: "CUSTOM_GATEWAY_API_KEY",
           credentialHeader: { name: "x-api-key", valueTemplate },
         }).success,
       ).toBe(false);

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/test-oauth.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/test-oauth.test.ts
@@ -120,36 +120,6 @@ describe("test-oauth provider URLs", () => {
     expect(authorizationUrl.origin).toBe("https://pr-12962-api.vm6.ai");
   });
 
-  it("ignores the retired Web URL input with or without canonical config", () => {
-    vi.stubEnv("VM0_WEB_URL", "https://legacy-web.example.test");
-    vi.stubEnv("APP_URL", "https://app-fallback.example.test");
-
-    const fallbackAuthorizationUrl = new URL(
-      buildTestOAuthAuthorizationUrl(
-        authCodeGrant(),
-        "test-client",
-        "https://app.vm0.ai/callback",
-        "state-123",
-      ),
-    );
-    expect(fallbackAuthorizationUrl.origin).toBe(
-      "https://app-fallback.example.test",
-    );
-
-    vi.stubEnv("OKOU_WEB_URL", "https://canonical-web.example.test");
-    const canonicalAuthorizationUrl = new URL(
-      buildTestOAuthAuthorizationUrl(
-        authCodeGrant(),
-        "test-client",
-        "https://app.vm0.ai/callback",
-        "state-123",
-      ),
-    );
-    expect(canonicalAuthorizationUrl.origin).toBe(
-      "https://canonical-web.example.test",
-    );
-  });
-
   it("sends both Vercel and internal preview bypass headers on refresh", async () => {
     vi.stubEnv("OKOU_API_BACKEND_URL", "https://pr-12962-www.vm6.ai");
     vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret");


### PR DESCRIPTION
Closes #31369

## Summary

- remove pure non-credential TypeScript/JavaScript migration tombstones for retired `VM0_*` environment names outside Desktop
- replace arbitrary `VM0_MODEL_PROVIDER_API_KEY` fixture values with the neutral `CUSTOM_GATEWAY_API_KEY` name while preserving current schema coverage
- preserve canonical `OKOU_*` behavior, every `ZERO_*` protocol test, and the `VM0_TOKEN` fail-closed credential test and CLI testing guide
- keep production readers, routes, schemas, serializers, generated contracts, Desktop, docs, and workflow/action definitions unchanged

## Verification

- Prettier 3.8.1 check on all 10 changed files
- `pnpm -F api lint`
- `pnpm -F @okouai/cli lint`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/connectors lint`
- package-scoped `check-types` for the same four packages
- focused API utility Vitest: 2 files, 53 tests passed
- focused affected BDD Vitest: 3 files, 5 tests passed
- focused CLI Vitest, including the retained fail-closed credential test: 3 files, 35 tests passed
- focused API contracts Vitest: 1 file, 102 tests passed
- focused connectors Vitest: 1 file, 8 tests passed
- `git diff origin/main...HEAD --check`

## Inventory

The exact non-Desktop TypeScript/JavaScript `VM0_*` inventory moves from 29 files / 91 matching lines to 20 files / 78 matching lines.

Removed to zero: `VM0_APPEND_SYSTEM_PROMPT` (1), `VM0_APP_URL` (1), `VM0_CODEX_SERVICE_TIER` (5), `VM0_DEBUG` (1), `VM0_MODEL_PROVIDER_API_KEY` (3), and `VM0_WEB_URL` (2).

All 78 retained lines are current credential boundaries or ordinary branded schema, fixture, sentinel, and diagnostic identifiers. In particular, the three TypeScript `VM0_TOKEN` references remain unchanged, and the focused CLI test proves the legacy credential cannot be selected.

The final fully paginated audit reconciled 35 open PRs and 865/865 changed files with zero mismatch. The exact-path overlaps in #31333, #29948, and #25722 touch unrelated hunks and are not correctness dependencies. #31383 is the separate #31371 shell/Desktop slice and has no exact-path overlap.
