### PR TITLE
feat: seed ppt avatar video skill

### DIFF
--- a/turbo/packages/core/src/seed-skills.ts
+++ b/turbo/packages/core/src/seed-skills.ts
@@ -7,6 +7,7 @@
 export const SEED_SKILLS: readonly string[] = [
   "computer-use",
   "gen",
+  "ppt-avatar-video",
   "workflow-setup",
 ] as const;
 


### PR DESCRIPTION
## Summary

- add `ppt-avatar-video` to the default seed skill set
- make direct PPT/PPTX/PDF-to-presenter-video requests discover the focused static-composition workflow without manual skill installation

The skill source is already published in vm0-ai/vm0-skills#328.

## Validation

- `pnpm exec prettier --check packages/core/src/seed-skills.ts`
- `pnpm -F @okouai/core run lint`
- `pnpm -F @okouai/core run check-types`
- confirmed `ppt-avatar-video/SKILL.md` exists on `vm0-ai/vm0-skills@main`

Per repository guidance, local Vitest was not run; the PR pipeline owns test execution.
