### PR TITLE
fix(guest-agent): classify oversized codex turn inputs

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -748,6 +748,9 @@ pub mod webhooks {
                 /// The model context window was exceeded.
                 #[serde(rename = "context_window_exceeded")]
                 ContextWindowExceeded,
+                /// The Codex app-server input limit was exceeded.
+                #[serde(rename = "input_too_large")]
+                InputTooLarge,
                 /// The provider output-token limit was reached.
                 #[serde(rename = "output_token_limit")]
                 OutputTokenLimit,

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -40,6 +40,8 @@ const TURN_NOTIFICATION_LABEL: &str = "turn notification";
 const TURN_INTERRUPT_GRACE: Duration = Duration::from_secs(5);
 const API_TO_CODEX_OUTPUT_ITEM_STARTED: &str = "api_to_codex_output_item_started";
 const API_TO_CODEX_AGENT_MESSAGE_ITEM_STARTED: &str = "api_to_codex_agent_message_item_started";
+const INVALID_PARAMS_RPC_CODE: i64 = -32602;
+const INPUT_TOO_LARGE_ERROR_CODE: &str = "input_too_large";
 
 struct NotificationIngestResult {
     emitted_thread_started: bool,
@@ -1106,8 +1108,35 @@ async fn ingest_run_notification(
     Ok(result)
 }
 
-fn app_server_error(masker: &SecretMasker, error: impl std::fmt::Display) -> AgentError {
+fn app_server_error(masker: &SecretMasker, error: CodexAppServerError) -> AgentError {
+    if let Some((actual_chars, max_chars)) = codex_input_too_large_counts(&error) {
+        return AgentError::CodexInputTooLarge {
+            actual_chars,
+            max_chars,
+        };
+    }
     AgentError::Execution(masker.mask_string(&error.to_string()))
+}
+
+fn codex_input_too_large_counts(error: &CodexAppServerError) -> Option<(u64, u64)> {
+    let CodexAppServerError::Rpc {
+        method,
+        error: rpc_error,
+        ..
+    } = error
+    else {
+        return None;
+    };
+    if method != "turn/start" || rpc_error.code != INVALID_PARAMS_RPC_CODE {
+        return None;
+    }
+    let data = rpc_error.data.as_ref()?.as_object()?;
+    if data.get("input_error_code")?.as_str()? != INPUT_TOO_LARGE_ERROR_CODE {
+        return None;
+    }
+    let actual_chars = data.get("actual_chars")?.as_u64()?;
+    let max_chars = data.get("max_chars")?.as_u64()?;
+    (max_chars > 0 && actual_chars > max_chars).then_some((actual_chars, max_chars))
 }
 
 async fn wait_for_heartbeat(

--- a/crates/guest-agent/src/complete.rs
+++ b/crates/guest-agent/src/complete.rs
@@ -257,8 +257,8 @@ mod tests {
         let payload = CompletePayload {
             run_id: "run-123",
             exit_code: 1,
-            failure_reason: Some(FailureReason::ProviderRateLimited.into()),
-            error: Some("rate limited"),
+            failure_reason: Some(FailureReason::InputTooLarge.into()),
+            error: Some("Codex input exceeded the app-server limit"),
             last_event_sequence: None,
             sandbox_id: None,
             sandbox_reuse_result: None,
@@ -268,7 +268,7 @@ mod tests {
         };
 
         let json = serde_json::to_value(&payload).unwrap();
-        assert_eq!(json["failureReason"], "provider_rate_limited");
+        assert_eq!(json["failureReason"], "input_too_large");
     }
 
     /// Completion metadata fields must be skipped independently so one absent

--- a/crates/guest-agent/src/error.rs
+++ b/crates/guest-agent/src/error.rs
@@ -28,6 +28,18 @@ pub enum AgentError {
     #[error("execution: {0}")]
     Execution(String),
 
+    /// Codex rejected an app-server turn because its text input exceeded the
+    /// authoritative character limit reported in the structured RPC response.
+    #[error(
+        "execution: Codex input is too large: {actual_chars} characters provided, maximum is {max_chars} characters. Reduce the input and try again."
+    )]
+    CodexInputTooLarge {
+        /// Aggregate Unicode scalar count reported by Codex.
+        actual_chars: u64,
+        /// Maximum Unicode scalar count reported by Codex.
+        max_chars: u64,
+    },
+
     /// Checkpoint, session-history, or artifact snapshot workflow failure inside
     /// the guest-agent; this does not refer to Firecracker/rootfs snapshots.
     #[error("checkpoint: {0}")]

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -7,6 +7,7 @@
 
 use crate::cli;
 use crate::env;
+use crate::error::AgentError;
 use crate::failure_patterns;
 use crate::paths;
 use crate::session_history;
@@ -53,6 +54,19 @@ pub fn base_failure_diagnostic_for_config(
         framework,
         PromptMetadata::from_prompt(&config.prompt),
     )
+}
+
+/// Build the diagnostic for a CLI execution boundary error.
+pub fn cli_execution_error_for_config(
+    config: &env::GuestConfig,
+    error: &AgentError,
+) -> FailureDiagnostic {
+    let diagnostic = base_failure_diagnostic_for_config(config, FailureClass::CliExecutionError);
+    if matches!(error, AgentError::CodexInputTooLarge { .. }) {
+        diagnostic.with_failure_reason(FailureReason::InputTooLarge)
+    } else {
+        diagnostic
+    }
 }
 
 /// Build the diagnostic for a CLI control-path failure.

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -592,9 +592,8 @@ async fn execute(
                 1,
                 1,
                 msg,
-                Some(failure_diagnostics::base_failure_diagnostic_for_config(
-                    config,
-                    FailureClass::CliExecutionError,
+                Some(failure_diagnostics::cli_execution_error_for_config(
+                    config, &e,
                 )),
                 false,
             )

--- a/crates/guest-agent/tests/codex_app_server_backend_structured_errors.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_structured_errors.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use guest_agent::error::AgentError;
 use guest_agent::masker::SecretMasker;
 use guest_contracts::diagnostics::FailureReason;
 use std::time::Duration;
@@ -12,6 +13,11 @@ use std::time::Duration;
 struct StructuredErrorCase {
     scenario: &'static str,
     expected_reason: Option<FailureReason>,
+}
+
+struct TurnStartErrorCase {
+    scenario: &'static str,
+    expected_input_too_large: bool,
 }
 
 #[tokio::test]
@@ -88,6 +94,135 @@ async fn codex_app_server_classifies_supported_structured_errors()
             "scenario: {}",
             case.scenario
         );
+
+        drop(run_files);
+        std::env::set_current_dir(&original_directory)?;
+    }
+
+    assert_exact_oversized_turn_start_classification().await?;
+
+    Ok(())
+}
+
+async fn assert_exact_oversized_turn_start_classification() -> Result<(), Box<dyn std::error::Error>>
+{
+    const PROMPT_SENTINEL: &str = "do-not-expose-oversized-prompt";
+    const UPSTREAM_ERROR_SENTINEL: &str = "do-not-expose-upstream-input-limit-message";
+
+    let mock = common::build_and_locate_mock_codex()?;
+    let original_directory = std::env::current_dir()?;
+    let cases = [
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large",
+            expected_input_too_large: true,
+        },
+        TurnStartErrorCase {
+            scenario: "thread-start-input-too-large",
+            expected_input_too_large: false,
+        },
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large-wrong-code",
+            expected_input_too_large: false,
+        },
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large-wrong-discriminator",
+            expected_input_too_large: false,
+        },
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large-missing-data",
+            expected_input_too_large: false,
+        },
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large-missing-max-chars",
+            expected_input_too_large: false,
+        },
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large-missing-actual-chars",
+            expected_input_too_large: false,
+        },
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large-string-actual-chars",
+            expected_input_too_large: false,
+        },
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large-fractional-actual-chars",
+            expected_input_too_large: false,
+        },
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large-negative-max-chars",
+            expected_input_too_large: false,
+        },
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large-zero-max-chars",
+            expected_input_too_large: false,
+        },
+        TurnStartErrorCase {
+            scenario: "turn-start-input-too-large-not-exceeded",
+            expected_input_too_large: false,
+        },
+    ];
+
+    for (index, case) in cases.iter().enumerate() {
+        let tmp = tempfile::tempdir()?;
+        let run_id = format!("codex-turn-start-error-{index}");
+        unsafe {
+            common::setup_codex_app_server_env(
+                &mock,
+                tmp.path(),
+                common::CodexAppServerEnvConfig {
+                    run_id: &run_id,
+                    prompt: PROMPT_SENTINEL,
+                    scenario: Some(case.scenario),
+                    resume_session_id: None,
+                },
+            )?;
+        }
+        let runtime = common::guest_runtime_from_process_env()?;
+        let run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+        let error = tokio::time::timeout(
+            Duration::from_secs(5),
+            common::execute_cli_for_runtime(
+                &runtime,
+                &SecretMasker::from_raw(""),
+                common::spawn_dummy_heartbeat(),
+            ),
+        )
+        .await?;
+        let error = match error {
+            Ok(result) => {
+                return Err(std::io::Error::other(format!(
+                    "turn/start RPC rejection returned exit code {} for scenario {}",
+                    result.exit_code, case.scenario
+                ))
+                .into());
+            }
+            Err(error) => error,
+        };
+
+        match (&error, case.expected_input_too_large) {
+            (
+                AgentError::CodexInputTooLarge {
+                    actual_chars,
+                    max_chars,
+                },
+                true,
+            ) => {
+                assert_eq!((*actual_chars, *max_chars), (101, 100));
+                let message = error.to_string();
+                assert!(message.contains("101 characters provided"));
+                assert!(message.contains("maximum is 100 characters"));
+                assert!(!message.contains(PROMPT_SENTINEL));
+                assert!(!message.contains(UPSTREAM_ERROR_SENTINEL));
+            }
+            (AgentError::Execution(_), false) => {}
+            _ => {
+                return Err(std::io::Error::other(format!(
+                    "unexpected classification for scenario {}: {error:?}",
+                    case.scenario
+                ))
+                .into());
+            }
+        }
 
         drop(run_files);
         std::env::set_current_dir(&original_directory)?;

--- a/crates/guest-agent/tests/codex_input_too_large_failure.rs
+++ b/crates/guest-agent/tests/codex_input_too_large_failure.rs
@@ -1,0 +1,115 @@
+//! Entry-point coverage for oversized Codex app-server turn input failures.
+
+mod common;
+
+use guest_contracts::diagnostics::{
+    AgentFramework, FailureClass, FailureDiagnostic, FailureReason,
+};
+use std::time::Duration;
+use tokio::process::Command;
+
+const PROMPT_SENTINEL: &str = "do-not-expose-oversized-prompt";
+const UPSTREAM_ERROR_SENTINEL: &str = "do-not-expose-upstream-input-limit-message";
+
+#[tokio::test]
+async fn oversized_codex_input_writes_actionable_structured_failure()
+-> Result<(), Box<dyn std::error::Error>> {
+    common::ensure_canonical_workspace_for_test()?;
+    let mock_codex = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let home = tmp.path().join("home");
+    let runtime_dir = tmp.path().join("runtime");
+    std::fs::create_dir_all(&home)?;
+    let run_payload_file = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: PROMPT_SENTINEL.to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
+
+    let output = common::command_output_with_timeout(
+        Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+            .env_clear()
+            .env(
+                "PATH",
+                std::env::var("PATH")
+                    .unwrap_or_else(|_| "/usr/local/bin:/usr/bin:/bin".to_string()),
+            )
+            .env("SHELL", "/bin/sh")
+            .env("HOME", &home)
+            .env(guest_contracts::env::RUN_ID_ENV, "codex-input-too-large")
+            .env(
+                guest_contracts::env::CANONICAL_API_URL_ENV,
+                "http://127.0.0.1:1",
+            )
+            .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "")
+            .env(
+                guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
+                "00000000-0000-4000-8000-000000000abc",
+            )
+            .env(
+                guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,
+                "reused",
+            )
+            .env(guest_contracts::env::CLI_AGENT_TYPE_ENV, "codex")
+            .env("OKOU_TEST_CODEX_HOME_DIR", home.join(".codex"))
+            .env(guest_contracts::env::USE_MOCK_CODEX_ENV, "true")
+            .env(
+                guest_contracts::env::CANONICAL_MOCK_CODEX_PATH_ENV,
+                &mock_codex,
+            )
+            .env(
+                "MOCK_CODEX_APP_SERVER_SCENARIO",
+                "turn-start-input-too-large",
+            )
+            .env(
+                guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV,
+                &run_payload_file,
+            )
+            .env(
+                guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
+                &runtime_dir,
+            ),
+        Duration::from_secs(20),
+        "guest-agent did not finish an oversized-input rejection promptly",
+    )
+    .await?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "guest-agent output:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir);
+    let error = std::fs::read_to_string(paths.checkpoint_error_file())?;
+    assert!(error.contains("101 characters provided"));
+    assert!(error.contains("maximum is 100 characters"));
+    assert!(error.contains("Reduce the input and try again"));
+    assert!(!error.contains(PROMPT_SENTINEL));
+    assert!(!error.contains(UPSTREAM_ERROR_SENTINEL));
+
+    let diagnostic_bytes = std::fs::read(paths.failure_diagnostic_file())?;
+    let diagnostic: FailureDiagnostic = serde_json::from_slice(&diagnostic_bytes)?;
+    assert_eq!(diagnostic.failure_class, FailureClass::CliExecutionError);
+    assert_eq!(diagnostic.framework, AgentFramework::Codex);
+    assert_eq!(
+        diagnostic.failure_reason,
+        Some(FailureReason::InputTooLarge)
+    );
+    assert_eq!(diagnostic.failure_detail_source, None);
+
+    for output_text in [
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&diagnostic_bytes),
+    ] {
+        assert!(!output_text.contains(PROMPT_SENTINEL));
+        assert!(!output_text.contains(UPSTREAM_ERROR_SENTINEL));
+    }
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_input_too_large_failure.rs
+++ b/crates/guest-agent/tests/codex_input_too_large_failure.rs
@@ -5,6 +5,8 @@ mod common;
 use guest_contracts::diagnostics::{
     AgentFramework, FailureClass, FailureDiagnostic, FailureReason,
 };
+use httpmock::prelude::*;
+use serde_json::json;
 use std::time::Duration;
 use tokio::process::Command;
 
@@ -15,6 +17,7 @@ const UPSTREAM_ERROR_SENTINEL: &str = "do-not-expose-upstream-input-limit-messag
 async fn oversized_codex_input_writes_actionable_structured_failure()
 -> Result<(), Box<dyn std::error::Error>> {
     common::ensure_canonical_workspace_for_test()?;
+    let server = MockServer::start();
     let mock_codex = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
     let home = tmp.path().join("home");
@@ -27,6 +30,39 @@ async fn oversized_codex_input_writes_actionable_structured_failure()
             ..guest_contracts::env::RunPayload::default()
         },
     )?;
+    let _heartbeat = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/heartbeat");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let _events = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/events");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let _telemetry = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/telemetry");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({}));
+    });
+    let prepare_history = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let complete = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(
+                r#"{"runId":"codex-input-too-large","exitCode":1,"failureReason":"input_too_large","error":"execution: Codex input is too large: 101 characters provided, maximum is 100 characters. Reduce the input and try again.","checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            );
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"success": true, "status": "failed"}));
+    });
 
     let output = common::command_output_with_timeout(
         Command::new(env!("CARGO_BIN_EXE_guest-agent"))
@@ -41,9 +77,9 @@ async fn oversized_codex_input_writes_actionable_structured_failure()
             .env(guest_contracts::env::RUN_ID_ENV, "codex-input-too-large")
             .env(
                 guest_contracts::env::CANONICAL_API_URL_ENV,
-                "http://127.0.0.1:1",
+                server.base_url(),
             )
-            .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "")
+            .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, "test-token")
             .env(
                 guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
                 "00000000-0000-4000-8000-000000000abc",
@@ -83,6 +119,8 @@ async fn oversized_codex_input_writes_actionable_structured_failure()
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    prepare_history.assert_calls_async(0).await;
+    complete.assert_calls_async(1).await;
 
     let paths = guest_agent::paths::GuestPaths::from_runtime_dir(runtime_dir);
     let error = std::fs::read_to_string(paths.checkpoint_error_file())?;

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -719,6 +719,8 @@ pub enum FailureReason {
     TermsAcceptanceRequired,
     /// The model context window was exhausted.
     ContextWindowExceeded,
+    /// The Codex app-server input limit was exceeded.
+    InputTooLarge,
     /// The provider stopped because an output-token limit was reached.
     OutputTokenLimit,
     /// The provider rejected the request because of a rate limit.
@@ -752,6 +754,7 @@ impl FailureReason {
             Self::InvalidCredentials => "invalid_credentials",
             Self::TermsAcceptanceRequired => "terms_acceptance_required",
             Self::ContextWindowExceeded => "context_window_exceeded",
+            Self::InputTooLarge => "input_too_large",
             Self::OutputTokenLimit => "output_token_limit",
             Self::ProviderRateLimited => "provider_rate_limited",
             Self::ProviderOverloaded => "provider_overloaded",
@@ -777,6 +780,7 @@ impl From<FailureReason>
             FailureReason::InvalidCredentials => Self::InvalidCredentials,
             FailureReason::TermsAcceptanceRequired => Self::TermsAcceptanceRequired,
             FailureReason::ContextWindowExceeded => Self::ContextWindowExceeded,
+            FailureReason::InputTooLarge => Self::InputTooLarge,
             FailureReason::OutputTokenLimit => Self::OutputTokenLimit,
             FailureReason::ProviderRateLimited => Self::ProviderRateLimited,
             FailureReason::ProviderOverloaded => Self::ProviderOverloaded,
@@ -1467,6 +1471,7 @@ mod tests {
                 FailureReason::ContextWindowExceeded,
                 "context_window_exceeded",
             ),
+            (FailureReason::InputTooLarge, "input_too_large"),
             (FailureReason::OutputTokenLimit, "output_token_limit"),
             (FailureReason::ProviderRateLimited, "provider_rate_limited"),
             (FailureReason::ProviderOverloaded, "provider_overloaded"),

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -5,14 +5,15 @@ use super::messages::{
     secondary_token_usage_notification, server_notification, server_notification_with_index,
     server_request, thread_response, thread_started_notification, turn,
     turn_completed_notification, turn_failed_notification, turn_interrupted_notification,
-    turn_started_notification, warning_notification, write_error, write_json_line,
-    write_malformed_thread_item_notification, write_oversized_delivery_notifications,
-    write_resumed_turn_notifications, write_split_json_line_prefix, write_success,
-    write_thread_item_notifications, write_turn_completion_notifications, write_turn_notifications,
-    write_turn_start_notifications, write_turn_usage_notifications,
+    turn_started_notification, warning_notification, write_error, write_error_with_data,
+    write_json_line, write_malformed_thread_item_notification,
+    write_oversized_delivery_notifications, write_resumed_turn_notifications,
+    write_split_json_line_prefix, write_success, write_thread_item_notifications,
+    write_turn_completion_notifications, write_turn_notifications, write_turn_start_notifications,
+    write_turn_usage_notifications,
 };
 use super::persistence::{InputEventContext, persist_input_events, session_rollout_timestamp};
-use super::scenario::Scenario;
+use super::scenario::{Scenario, TurnStartRpcError};
 use super::{AppServerState, INVALID_REQUEST, PendingResponse, ServerAction, spawn_stderr_holder};
 use guest_contracts::stdout_framing::CODEX_APP_SERVER_STDOUT_MAX_LINE_BYTES;
 use serde_json::{Value, json};
@@ -50,6 +51,8 @@ const SHELL_PROMPT_PREFIX: &str = "@shell@\n";
 const SHELL_PROMPT_END_SEPARATOR: &str = "\n@end-shell@";
 const CHECKPOINTED_SHELL_PROMPT_PREFIX: &str = "@shell-checkpoint@\n";
 const CHECKPOINTED_SHELL_SEPARATOR: &str = "\n@continue@\n";
+const INVALID_PARAMS: i64 = -32602;
+const INPUT_TOO_LARGE_ERROR_MESSAGE: &str = "do-not-expose-upstream-input-limit-message";
 
 enum MockTurnOutput {
     Complete(String),
@@ -120,6 +123,16 @@ impl AppServerState {
     ) -> io::Result<ServerAction> {
         if !self.initialized {
             write_error(output, id, INVALID_REQUEST, "app server is not initialized")?;
+            return Ok(ServerAction::Continue);
+        }
+        if self.scenario == Scenario::ThreadStartInputTooLarge {
+            write_error_with_data(
+                output,
+                id,
+                INVALID_PARAMS,
+                INPUT_TOO_LARGE_ERROR_MESSAGE,
+                input_too_large_data(json!(101), json!(100)),
+            )?;
             return Ok(ServerAction::Continue);
         }
         if self.scenario == Scenario::HangOnThreadStart {
@@ -282,6 +295,10 @@ impl AppServerState {
             loop {
                 thread::park();
             }
+        }
+        if let Some(error) = self.scenario.turn_start_rpc_error() {
+            write_turn_start_rpc_error(output, id, error)?;
+            return Ok(ServerAction::Continue);
         }
 
         let Some(thread_id) = non_empty_string_param(params, "threadId") else {
@@ -732,6 +749,79 @@ impl AppServerState {
         write_success(output, id, json!({ "completed": true }))?;
         Ok(ServerAction::Continue)
     }
+}
+
+fn write_turn_start_rpc_error<W: Write>(
+    output: &mut W,
+    id: Value,
+    error: TurnStartRpcError,
+) -> io::Result<()> {
+    let (code, data) = match error {
+        TurnStartRpcError::InputTooLarge => (
+            INVALID_PARAMS,
+            Some(input_too_large_data(json!(101), json!(100))),
+        ),
+        TurnStartRpcError::WrongRpcCode => {
+            (-32603, Some(input_too_large_data(json!(101), json!(100))))
+        }
+        TurnStartRpcError::WrongDiscriminator => (
+            INVALID_PARAMS,
+            Some(json!({
+                "input_error_code": "invalid_attachment",
+                "actual_chars": 101,
+                "max_chars": 100,
+            })),
+        ),
+        TurnStartRpcError::MissingData => (INVALID_PARAMS, None),
+        TurnStartRpcError::MissingMaxChars => (
+            INVALID_PARAMS,
+            Some(json!({
+                "input_error_code": "input_too_large",
+                "actual_chars": 101,
+            })),
+        ),
+        TurnStartRpcError::MissingActualChars => (
+            INVALID_PARAMS,
+            Some(json!({
+                "input_error_code": "input_too_large",
+                "max_chars": 100,
+            })),
+        ),
+        TurnStartRpcError::StringActualChars => (
+            INVALID_PARAMS,
+            Some(input_too_large_data(json!("101"), json!(100))),
+        ),
+        TurnStartRpcError::FractionalActualChars => (
+            INVALID_PARAMS,
+            Some(input_too_large_data(json!(101.5), json!(100))),
+        ),
+        TurnStartRpcError::NegativeMaxChars => (
+            INVALID_PARAMS,
+            Some(input_too_large_data(json!(101), json!(-1))),
+        ),
+        TurnStartRpcError::ZeroMaxChars => (
+            INVALID_PARAMS,
+            Some(input_too_large_data(json!(101), json!(0))),
+        ),
+        TurnStartRpcError::NotExceeded => (
+            INVALID_PARAMS,
+            Some(input_too_large_data(json!(100), json!(100))),
+        ),
+    };
+    if let Some(data) = data {
+        write_error_with_data(output, id, code, INPUT_TOO_LARGE_ERROR_MESSAGE, data)
+    } else {
+        write_error(output, id, code, INPUT_TOO_LARGE_ERROR_MESSAGE)
+    }
+}
+
+fn input_too_large_data(actual_chars: Value, max_chars: Value) -> Value {
+    json!({
+        "input_error_code": "input_too_large",
+        "actual_chars": actual_chars,
+        "max_chars": max_chars,
+        "additive_field": true,
+    })
 }
 
 fn write_secondary_thread_notifications<W: Write>(

--- a/crates/guest-mock-codex/src/app_server/messages.rs
+++ b/crates/guest-mock-codex/src/app_server/messages.rs
@@ -906,6 +906,26 @@ pub(super) fn write_error<W: Write>(
     )
 }
 
+pub(super) fn write_error_with_data<W: Write>(
+    output: &mut W,
+    id: Value,
+    code: i64,
+    message: &str,
+    data: Value,
+) -> io::Result<()> {
+    write_json_line(
+        output,
+        &json!({
+            "id": id,
+            "error": {
+                "code": code,
+                "message": message,
+                "data": data
+            }
+        }),
+    )
+}
+
 pub(super) fn write_json_line<W: Write>(output: &mut W, value: &Value) -> io::Result<()> {
     serde_json::to_writer(&mut *output, value).map_err(io::Error::other)?;
     writeln!(output)?;

--- a/crates/guest-mock-codex/src/app_server/scenario.rs
+++ b/crates/guest-mock-codex/src/app_server/scenario.rs
@@ -7,6 +7,8 @@ pub(super) enum Scenario {
     ExitOnTurnStart,
     ExitOnTurnStartWithStderrHolder,
     HangOnTurnStart,
+    ThreadStartInputTooLarge,
+    TurnStartRpcError(TurnStartRpcError),
     InterleavedNotification,
     InvalidResponseId,
     MalformedErrorResponse,
@@ -71,6 +73,40 @@ impl Scenario {
                     Ok(Self::ExitOnTurnStartWithStderrHolder)
                 }
                 "hang-on-turn-start" => Ok(Self::HangOnTurnStart),
+                "thread-start-input-too-large" => Ok(Self::ThreadStartInputTooLarge),
+                "turn-start-input-too-large" => {
+                    Ok(Self::TurnStartRpcError(TurnStartRpcError::InputTooLarge))
+                }
+                "turn-start-input-too-large-wrong-code" => {
+                    Ok(Self::TurnStartRpcError(TurnStartRpcError::WrongRpcCode))
+                }
+                "turn-start-input-too-large-wrong-discriminator" => Ok(Self::TurnStartRpcError(
+                    TurnStartRpcError::WrongDiscriminator,
+                )),
+                "turn-start-input-too-large-missing-data" => {
+                    Ok(Self::TurnStartRpcError(TurnStartRpcError::MissingData))
+                }
+                "turn-start-input-too-large-missing-max-chars" => {
+                    Ok(Self::TurnStartRpcError(TurnStartRpcError::MissingMaxChars))
+                }
+                "turn-start-input-too-large-missing-actual-chars" => Ok(Self::TurnStartRpcError(
+                    TurnStartRpcError::MissingActualChars,
+                )),
+                "turn-start-input-too-large-string-actual-chars" => Ok(Self::TurnStartRpcError(
+                    TurnStartRpcError::StringActualChars,
+                )),
+                "turn-start-input-too-large-fractional-actual-chars" => Ok(
+                    Self::TurnStartRpcError(TurnStartRpcError::FractionalActualChars),
+                ),
+                "turn-start-input-too-large-negative-max-chars" => {
+                    Ok(Self::TurnStartRpcError(TurnStartRpcError::NegativeMaxChars))
+                }
+                "turn-start-input-too-large-zero-max-chars" => {
+                    Ok(Self::TurnStartRpcError(TurnStartRpcError::ZeroMaxChars))
+                }
+                "turn-start-input-too-large-not-exceeded" => {
+                    Ok(Self::TurnStartRpcError(TurnStartRpcError::NotExceeded))
+                }
                 "interleaved-notification" => Ok(Self::InterleavedNotification),
                 "invalid-response-id" => Ok(Self::InvalidResponseId),
                 "malformed-error-response" => Ok(Self::MalformedErrorResponse),
@@ -188,6 +224,13 @@ impl Scenario {
         )
     }
 
+    pub(super) const fn turn_start_rpc_error(self) -> Option<TurnStartRpcError> {
+        match self {
+            Self::TurnStartRpcError(error) => Some(error),
+            _ => None,
+        }
+    }
+
     pub(super) const fn turn_failure(self) -> Option<TurnFailure> {
         match self {
             Self::RuntimeTurnFailed => Some(TurnFailure::Generic),
@@ -209,6 +252,21 @@ impl Scenario {
             _ => None,
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum TurnStartRpcError {
+    InputTooLarge,
+    WrongRpcCode,
+    WrongDiscriminator,
+    MissingData,
+    MissingMaxChars,
+    MissingActualChars,
+    StringActualChars,
+    FractionalActualChars,
+    NegativeMaxChars,
+    ZeroMaxChars,
+    NotExceeded,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/runner/src/cmd/start/job_lifecycle.rs
+++ b/crates/runner/src/cmd/start/job_lifecycle.rs
@@ -398,9 +398,9 @@ mod tests {
 
         let _ = CompletionPayload::new(
             run_id,
-            0,
-            Some(RequestFailureReason::ProviderRateLimited),
-            None,
+            1,
+            Some(RequestFailureReason::InputTooLarge),
+            Some("Codex input exceeded the app-server limit".to_string()),
             sandbox_id,
             SandboxReuseResult::PoolMiss,
             CompletionAuth::sandbox_token(run_id, "completion-token".to_string()),
@@ -419,7 +419,7 @@ mod tests {
         );
         assert_eq!(
             *failure_reason.lock().unwrap(),
-            Some(RequestFailureReason::ProviderRateLimited)
+            Some(RequestFailureReason::InputTooLarge)
         );
     }
 

--- a/crates/runner/src/cmd/start/job_terminal_log.rs
+++ b/crates/runner/src/cmd/start/job_terminal_log.rs
@@ -457,6 +457,9 @@ impl From<Option<&WorkloadResourceLimitDiagnostic>> for JobWorkloadResourceLogFi
 
 fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
     match diagnostic.failure_class {
+        FailureClass::CliExecutionError => {
+            diagnostic.failure_reason == Some(FailureReason::InputTooLarge)
+        }
         FailureClass::CliNonzero => matches!(
             diagnostic.failure_reason,
             Some(
@@ -649,6 +652,64 @@ mod tests {
             assert_field_eq(&event, "failure_class", "cli_nonzero");
             assert_field_eq(&event, "failure_framework", "codex");
             assert_field_eq(&event, "failure_detail_source", "codex_jsonl");
+        }
+    }
+
+    #[test]
+    fn oversized_codex_input_logs_cli_execution_failure_at_info() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliExecutionError,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("oversized prompt"),
+        )
+        .with_failure_reason(FailureReason::InputTooLarge)
+        .with_session_history_status(SessionHistoryStatus::NotApplicable);
+        let failure = executor::ExecutionFailure::new(
+            1,
+            "Codex input exceeded the app-server limit",
+            Some(diagnostic),
+        );
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::INFO);
+        assert_field_eq(&event, "failure_class", "cli_execution_error");
+        assert_field_eq(&event, "failure_framework", "codex");
+        assert_field_eq(&event, "failure_reason", "input_too_large");
+        assert!(!event.fields.contains_key("failure_detail_source"));
+    }
+
+    #[test]
+    fn oversized_input_near_misses_remain_error_level() {
+        let diagnostics = [
+            FailureDiagnostic::new(
+                FailureClass::CliExecutionError,
+                AgentFramework::Codex,
+                PromptMetadata::from_prompt("plain prompt"),
+            ),
+            FailureDiagnostic::new(
+                FailureClass::CliNonzero,
+                AgentFramework::Codex,
+                PromptMetadata::from_prompt("plain prompt"),
+            )
+            .with_failure_reason(FailureReason::InputTooLarge),
+            FailureDiagnostic::new(
+                FailureClass::CliExecutionError,
+                AgentFramework::Codex,
+                PromptMetadata::from_prompt("plain prompt"),
+            )
+            .with_failure_reason(FailureReason::ContextWindowExceeded),
+        ];
+
+        for diagnostic in diagnostics {
+            let failure = executor::ExecutionFailure::new(
+                1,
+                "unclassified execution failure",
+                Some(diagnostic),
+            );
+            let event = capture_job_failure_log(&failure);
+
+            assert_eq!(event.level, Level::ERROR);
         }
     }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -2163,6 +2163,29 @@ mod tests {
     }
 
     #[test]
+    fn complete_request_serializes_input_too_large_failure_reason() {
+        let req = CompleteRequest {
+            run_id: "550e8400-e29b-41d4-a716-446655440000"
+                .parse::<RunId>()
+                .unwrap(),
+            exit_code: 1,
+            failure_reason: Some(RequestFailureReason::InputTooLarge),
+            error: Some(
+                "execution: Codex input is too large: 101 characters provided, maximum is 100 characters. Reduce the input and try again."
+                    .into(),
+            ),
+            sandbox_id: None,
+            sandbox_reuse_result: None,
+            workspace_reuse_result: None,
+            active_input_delivery_ids: Vec::new(),
+        };
+
+        let json = serde_json::to_value(&req).unwrap();
+
+        assert_eq!(json["failureReason"], "input_too_large");
+    }
+
+    #[test]
     fn complete_request_with_reuse_fields() {
         let sid: SandboxId = "11111111-2222-3333-4444-555555555555".parse().unwrap();
         let req = CompleteRequest {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -18452,7 +18452,7 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
 });
 
 describe("RUN-03: sandbox completion reports against missing checkpoints and settled runs", () => {
-  it("suppresses only reviewed non-built-in failures from generic completion logs", async () => {
+  it("suppresses reviewed expected failures from generic completion logs", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     await seedVm0BuiltInDefaultModelKey();
@@ -18541,6 +18541,23 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
 
     for (const failureReason of suppressedReasons) {
       const { runId } = await completeFailure({ failureReason });
+      for (const level of axiomLevels) {
+        expect(matchingLogCalls(level, "Run failed", runId)).toHaveLength(0);
+      }
+    }
+
+    const oversizedInputFailures = [
+      await completeFailure({ failureReason: "input_too_large" }),
+      await completeFailure({
+        modelProvider: "built-in",
+        failureReason: "input_too_large",
+      }),
+      await completeFailure({
+        failureReason: "input_too_large",
+        persistedModelProvider: "legacy-unknown-provider",
+      }),
+    ];
+    for (const { runId } of oversizedInputFailures) {
       for (const level of axiomLevels) {
         expect(matchingLogCalls(level, "Run failed", runId)).toHaveLength(0);
       }

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -167,10 +167,14 @@ type CompletionTransactionResult =
 
 const L = logger("webhook:complete");
 
-function isSuppressibleNonBuiltInFailureReason(
-  failureReason: KnownRunFailureReason | undefined,
+function shouldSuppressKnownFailureLog(
+  run: RunRecord,
+  failureReason: KnownRunFailureReason,
 ): boolean {
   switch (failureReason) {
+    case "input_too_large": {
+      return true;
+    }
     case "insufficient_credits":
     case "invalid_api_key":
     case "invalid_credentials":
@@ -185,30 +189,28 @@ function isSuppressibleNonBuiltInFailureReason(
     case "safety_policy_refusal":
     case "reconnect_required":
     case "usage_limit": {
-      return true;
+      const providerType = modelProviderTypeSchema.safeParse(run.modelProvider);
+      return (
+        providerType.success && !isBuiltInModelProviderType(providerType.data)
+      );
     }
     case "session_history_limit":
-    case "unsupported_model":
-    case undefined: {
+    case "unsupported_model": {
       return false;
     }
   }
 }
 
-function shouldSuppressNonBuiltInProviderFailureLog(
+function shouldSuppressFailureLog(
   run: RunRecord,
   failureReason: RunFailureReasonToken | undefined,
 ): boolean {
   const knownFailureReason =
     knownRunFailureReasonSchema.safeParse(failureReason);
-  if (
-    !knownFailureReason.success ||
-    !isSuppressibleNonBuiltInFailureReason(knownFailureReason.data)
-  ) {
+  if (!knownFailureReason.success) {
     return false;
   }
-  const providerType = modelProviderTypeSchema.safeParse(run.modelProvider);
-  return providerType.success && !isBuiltInModelProviderType(providerType.data);
+  return shouldSuppressKnownFailureLog(run, knownFailureReason.data);
 }
 
 function checkpointInputForCompletion(
@@ -951,10 +953,7 @@ export const completeAgentRun$ = command(
           error: commit.transitionError,
         });
       } else if (
-        !shouldSuppressNonBuiltInProviderFailureLog(
-          commit.run,
-          commit.transitionFailureReason,
-        )
+        !shouldSuppressFailureLog(commit.run, commit.transitionFailureReason)
       ) {
         L.warn("Run failed", {
           runId: input.body.runId,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -286,6 +286,7 @@ describe("agent completion failure reasons", () => {
       "invalid_credentials",
       "terms_acceptance_required",
       "context_window_exceeded",
+      "input_too_large",
       "output_token_limit",
       "provider_rate_limited",
       "provider_overloaded",

--- a/turbo/packages/api-contracts/src/contracts/run-failure-reasons.ts
+++ b/turbo/packages/api-contracts/src/contracts/run-failure-reasons.ts
@@ -15,6 +15,7 @@ export const knownRunFailureReasonSchema = z.enum([
   "invalid_credentials",
   "terms_acceptance_required",
   "context_window_exceeded",
+  "input_too_large",
   "output_token_limit",
   "provider_rate_limited",
   "provider_overloaded",

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -597,6 +597,7 @@ export const rustTypeBindings = [
             "The provider requires acceptance of updated terms.",
           ],
           context_window_exceeded: ["The model context window was exceeded."],
+          input_too_large: ["The Codex app-server input limit was exceeded."],
           output_token_limit: ["The provider output-token limit was reached."],
           provider_rate_limited: ["The provider rate limited the request."],
           provider_overloaded: ["The provider reported overload."],


### PR DESCRIPTION
## Summary

- classify only Codex app-server `turn/start` JSON-RPC `-32602` responses whose structured data reports `input_error_code: input_too_large` with valid exceeded character counts
- propagate the dedicated `input_too_large` reason through guest diagnostics, generated completion contracts, guest-first completion, and runner fallback completion
- lower expected oversized-input failures to info-level runner telemetry and suppress the API's generic failure warning while keeping unknown and unrelated failures visible
- return an actionable bounded message containing only Codex-reported counts, without prompt text or the upstream error message

## Scope and compatibility

- does not hard-code Codex's current character limit, add a duplicate preflight, truncate input, or reuse `context_window_exceeded`
- keeps near-miss RPC errors on the existing generic execution-error path
- requires the forward-compatible completion reader from #31305 to be deployed before this writer is promoted

## Validation

- `cd crates && cargo fmt --all`
- `cd crates && cargo clippy -p api-contracts -p guest-contracts -p guest-mock-codex -p guest-agent -p runner --all-targets -- -D warnings`
- `cd crates && RUSTDOCFLAGS='-D warnings' cargo doc -p api-contracts -p guest-contracts -p guest-mock-codex -p guest-agent -p runner --no-deps`
- `cd crates && cargo test -p api-contracts -p guest-contracts -p guest-mock-codex -p guest-agent -p runner`
- `cd turbo && pnpm -F @okouai/api-contracts lint`
- `cd turbo && pnpm -F @okouai/api-contracts check-types`
- `cd turbo && pnpm -F @okouai/api-contracts test`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api test`
- `cd turbo && pnpm knip --workspace api --workspace @okouai/api-contracts`
- pre-commit hooks: repository Prettier, Knip, TypeScript type checks, Cargo fmt/doc/Clippy, and file-size checks

Closes #31287

Parent context: #31273
