### PR TITLE
fix(agent): lock default agent avatar

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -30,7 +30,8 @@ const context = testContext();
 const api = createAuthOrgAgentsBddApi(context);
 const bdd = createBddApi(context);
 const runsApi = createRunsApi(context);
-const DEFAULT_AGENT_AVATAR_URL = "svg:r1s0h1c5f4h";
+const DEFAULT_AGENT_AVATAR_URL =
+  "https://static.vm0.io/public/default-agent-avatar-ceb298b79964.svg";
 
 function shortId(): string {
   return randomUUID().replace(/-/g, "").slice(0, 10);
@@ -505,7 +506,7 @@ describe("ORG-03 onboarding status mapping", () => {
     });
   });
 
-  it("projects only the system default assistant by public brand without rewriting storage", async () => {
+  it("projects the system default assistant identity across public brands", async () => {
     const admin = api.user();
     api.acceptAgentStorageWrites();
 
@@ -551,12 +552,17 @@ describe("ORG-03 onboarding status mapping", () => {
     const patched = await api.updateAgentMetadata(
       admin,
       defaultAgentId,
-      { displayName: "Okou", description: "Patched from Okou" },
+      {
+        displayName: "Okou",
+        description: "Patched from Okou",
+        avatarUrl: "preset:4",
+      },
       "okou",
     );
     expect(patched).toMatchObject({
       displayName: "Okou",
       description: "Patched from Okou",
+      avatarUrl: DEFAULT_AGENT_AVATAR_URL,
     });
     await expect(
       api.readAgent(admin, defaultAgentId, "vm0"),
@@ -568,12 +574,17 @@ describe("ORG-03 onboarding status mapping", () => {
     const replaced = await api.updateAgent(
       admin,
       defaultAgentId,
-      { displayName: "Okou", description: "Replaced from Okou" },
+      {
+        displayName: "Okou",
+        description: "Replaced from Okou",
+        avatarUrl: "preset:3",
+      },
       "okou",
     );
     expect(replaced).toMatchObject({
       displayName: "Okou",
       description: "Replaced from Okou",
+      avatarUrl: DEFAULT_AGENT_AVATAR_URL,
     });
     await expect(
       api.readAgent(admin, defaultAgentId, "vm0"),

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -35,7 +35,8 @@ zero-team, and zero-default-agent route tests:
 
 const context = testContext();
 const api = createAuthOrgAgentsBddApi(context);
-const DEFAULT_AGENT_AVATAR_URL = "svg:r1s0h1c5f4h";
+const DEFAULT_AGENT_AVATAR_URL =
+  "https://static.vm0.io/public/default-agent-avatar-ceb298b79964.svg";
 
 class ClerkApiResponseTestError extends Error {
   static readonly kind = "ClerkAPIResponseError";

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -75,7 +75,8 @@ const TERMINAL_RUN_STATUSES = [
 const api = createWebhookCallbackApi(context);
 const store = createStore();
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
-const DEFAULT_AGENT_AVATAR_URL = "svg:r1s0h1c5f4h";
+const DEFAULT_AGENT_AVATAR_URL =
+  "https://static.vm0.io/public/default-agent-avatar-ceb298b79964.svg";
 
 function isUnknownRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/turbo/apps/api/src/signals/routes/agents.ts
+++ b/turbo/apps/api/src/signals/routes/agents.ts
@@ -10,7 +10,10 @@ import {
 } from "@okouai/api-contracts/contracts/agents";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
-import { randomPresetAvatar } from "@okouai/core/agent-avatar";
+import {
+  DEFAULT_AGENT_AVATAR_URL,
+  randomPresetAvatar,
+} from "@okouai/core/agent-avatar";
 import { publicBrandPresentation } from "@okouai/core/public-brand";
 import { agents } from "@okouai/db/schema/agent";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
@@ -136,20 +139,25 @@ function buildAgentUpsertConflictSet(body: AgentUpdateBody, updatedAt: Date) {
   };
 }
 
-function normalizeProjectedDefaultAgentName(
+function normalizeProjectedDefaultAgentProfile(
   body: AgentUpdateBody,
   existing: ExistingAgentForUpdate,
   publicBrand: PublicBrand,
 ): AgentUpdateBody {
+  const normalizedBody =
+    existing.id === existing.defaultAgentId
+      ? { ...body, avatarUrl: DEFAULT_AGENT_AVATAR_URL }
+      : body;
+
   if (
     existing.id !== existing.defaultAgentId ||
     existing.displayName !== DEFAULT_AGENT_DISPLAY_NAME ||
     body.displayName !== publicBrandPresentation(publicBrand).assistantName
   ) {
-    return body;
+    return normalizedBody;
   }
 
-  return { ...body, displayName: DEFAULT_AGENT_DISPLAY_NAME };
+  return { ...normalizedBody, displayName: DEFAULT_AGENT_DISPLAY_NAME };
 }
 
 async function findAgentForUpdate(
@@ -542,7 +550,7 @@ const updateAgentInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     if (!existing) {
       return { response: agentNotFound(params.id) };
     }
-    const updateBody = normalizeProjectedDefaultAgentName(
+    const updateBody = normalizeProjectedDefaultAgentProfile(
       body.data,
       existing,
       publicBrand,
@@ -631,7 +639,7 @@ const updateAgentMetadataInner$ = command(
       if (!existing) {
         return { response: agentNotFound(params.id) };
       }
-      const updateBody = normalizeProjectedDefaultAgentName(
+      const updateBody = normalizeProjectedDefaultAgentProfile(
         body.data,
         existing,
         publicBrand,

--- a/turbo/apps/api/src/signals/services/agent-data.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-data.service.ts
@@ -13,6 +13,7 @@ import { userCustomConnectors } from "@okouai/db/schema/user-custom-connector";
 import { orgCustomConnectors } from "@okouai/db/schema/org-custom-connector";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
 import { and, asc, desc, eq, or } from "drizzle-orm";
+import { agentAvatarUrlForDefaultAgent } from "@okouai/core/agent-avatar";
 import { agentDisplayNameForPublicBrand } from "@okouai/core/public-brand";
 
 import { db$ } from "../external/db";
@@ -44,7 +45,11 @@ export function agentResponse(
     }),
     description: row.description,
     sound: row.sound,
-    avatarUrl: row.avatarUrl,
+    avatarUrl: agentAvatarUrlForDefaultAgent({
+      agentId: row.agentId,
+      defaultAgentId: row.defaultAgentId,
+      avatarUrl: row.avatarUrl,
+    }),
     modelProviderId: null,
     selectedModel: null,
     preferPersonalProvider: false,
@@ -249,7 +254,11 @@ export function teamComposeList(
         }),
         description: row.description,
         sound: row.sound,
-        avatarUrl: row.avatarUrl,
+        avatarUrl: agentAvatarUrlForDefaultAgent({
+          agentId: row.id,
+          defaultAgentId: row.defaultAgentId,
+          avatarUrl: row.avatarUrl,
+        }),
         visibility: row.visibility,
         updatedAt: row.updatedAt.toISOString(),
       };

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -1,6 +1,7 @@
 import { command, computed, type Computed } from "ccstate";
 import type { OnboardingStatusResponse } from "@okouai/api-contracts/contracts/onboarding";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import { agentAvatarUrlForDefaultAgent } from "@okouai/core/agent-avatar";
 import { agentDisplayNameForPublicBrand } from "@okouai/core/public-brand";
 import { isValidTimeZone } from "@okouai/core/timezone";
 import { agents } from "@okouai/db/schema/agent";
@@ -175,8 +176,13 @@ function defaultAgentInfo(
     if (row.sound !== null) {
       metadata.sound = row.sound;
     }
-    if (row.avatarUrl !== null) {
-      metadata.avatarUrl = row.avatarUrl;
+    const avatarUrl = agentAvatarUrlForDefaultAgent({
+      agentId: composeId,
+      defaultAgentId: composeId,
+      avatarUrl: row.avatarUrl,
+    });
+    if (avatarUrl !== null) {
+      metadata.avatarUrl = avatarUrl;
     }
 
     return {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -6,7 +6,10 @@ import {
   agentsByIdContract,
   type AgentResponse,
 } from "@okouai/api-contracts/contracts/agents";
-import { AVATAR_PRESET_COUNT } from "@okouai/core/agent-avatar";
+import {
+  AVATAR_PRESET_COUNT,
+  DEFAULT_AGENT_AVATAR_URL,
+} from "@okouai/core/agent-avatar";
 
 import {
   click,
@@ -161,6 +164,25 @@ function prepareMatchingAgentProfiles(): void {
 }
 
 describe("zero settings tab", () => {
+  it("renders the default agent avatar without customization controls", async () => {
+    context.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
+    prepareAgentProfile(DEFAULT_AGENT_AVATAR_URL);
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}?tab=profile` });
+
+    await findAgentNameInput();
+    const avatarLabel = await screen.findByText("Avatar", { selector: "p" });
+    const avatarRow = avatarLabel.parentElement?.parentElement;
+    if (!avatarRow) {
+      throw new Error("Avatar profile row not found");
+    }
+    const avatarImages = avatarRow.querySelectorAll<HTMLImageElement>("img");
+
+    expect(avatarImages).toHaveLength(1);
+    expect(avatarImages[0]).toHaveAttribute("src", DEFAULT_AGENT_AVATAR_URL);
+    expect(screen.queryByLabelText("Create custom avatar")).toBeNull();
+    expect(screen.queryByLabelText("Customize avatar")).toBeNull();
+  });
+
   it("renders the highest preset the API can assign", async () => {
     prepareAgentProfile(`preset:${AVATAR_PRESET_COUNT - 1}`);
     detachedSetupPage({ context, path: `/agents/${AGENT_ID}?tab=profile` });

--- a/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
@@ -36,10 +36,14 @@ import {
   type AgentDeleteCopyTarget,
 } from "./components/delete-agent-dialog.tsx";
 import { toast } from "@okouai/ui/components/ui/sonner";
-import { serializeAvatarSvgConfig } from "./avatar-svg-utils.ts";
+import {
+  serializeAvatarSvgConfig,
+  type AvatarSvgConfig,
+} from "./avatar-svg-utils.ts";
 import { resolveAvatarSvgConfig } from "./avatar-utils.ts";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
 import { AvatarMaker } from "./avatar-maker.tsx";
+import { AvatarFromUrl } from "./sidebar-shared.tsx";
 import {
   settingsFormDraft$,
   patchSettingsForm$,
@@ -83,6 +87,43 @@ interface SettingsTabProps {
   isDefaultAgent?: boolean;
   /** Callback to delete the agent. */
   onDelete?: () => Promise<void>;
+}
+
+function AvatarSettingsControl({
+  isDefaultAgent,
+  avatarUrl,
+  alt,
+  onConfirm,
+}: {
+  isDefaultAgent: boolean;
+  avatarUrl: string | null;
+  alt: string;
+  onConfirm: (config: AvatarSvgConfig) => Promise<void>;
+}) {
+  if (isDefaultAgent) {
+    return (
+      <AvatarFromUrl
+        avatarUrl={avatarUrl}
+        alt={alt}
+        className="h-12 w-12 shrink-0 rounded-full object-cover object-top"
+      />
+    );
+  }
+
+  const resolved = resolveAvatarSvgConfig(avatarUrl);
+  return (
+    <>
+      {resolved && (
+        <div className="h-12 w-12 shrink-0 rounded-full border-2 border-primary ring-2 ring-primary/20">
+          <AvatarSvgPreview
+            config={resolved}
+            className="h-full w-full rounded-full"
+          />
+        </div>
+      )}
+      <AvatarMaker onConfirm={onConfirm} />
+    </>
+  );
 }
 
 export function SettingsTab({
@@ -244,28 +285,21 @@ export function SettingsTab({
               label={t(($) => {
                 return $.profile.fields.avatar.label;
               })}
-              description={t(($) => {
-                return $.profile.fields.avatar.description;
-              })}
+              description={
+                isDefaultAgent
+                  ? undefined
+                  : t(($) => {
+                      return $.profile.fields.avatar.description;
+                    })
+              }
               wideControls
             >
               <div className="min-w-0 w-full">
                 <div className="flex flex-wrap gap-2 items-center">
-                  {(() => {
-                    const resolved = resolveAvatarSvgConfig(avatarUrl);
-                    if (resolved) {
-                      return (
-                        <div className="h-12 w-12 shrink-0 rounded-full border-2 border-primary ring-2 ring-primary/20">
-                          <AvatarSvgPreview
-                            config={resolved}
-                            className="h-full w-full rounded-full"
-                          />
-                        </div>
-                      );
-                    }
-                    return null;
-                  })()}
-                  <AvatarMaker
+                  <AvatarSettingsControl
+                    isDefaultAgent={isDefaultAgent}
+                    avatarUrl={avatarUrl}
+                    alt={resolvedAgentName}
                     onConfirm={async (cfg) => {
                       const newAvatarUrl = serializeAvatarSvgConfig(cfg);
                       patchForm({

--- a/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
@@ -842,6 +842,7 @@ function AgentHeader({
   activeTab,
   onTabChange,
   showProfileAndInstructions,
+  isDefaultAgent,
 }: {
   displayName: string;
   description: string;
@@ -849,6 +850,7 @@ function AgentHeader({
   activeTab: string;
   onTabChange: (tab: string) => void;
   showProfileAndInstructions: boolean;
+  isDefaultAgent: boolean;
 }) {
   const { t } = useTranslation("agents");
   const nav = useSet(detachedNavigateTo$);
@@ -864,7 +866,7 @@ function AgentHeader({
               alt={displayName}
               className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
             />
-            {showProfileAndInstructions && (
+            {showProfileAndInstructions && !isDefaultAgent && (
               <TooltipProvider delayDuration={200}>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -1181,6 +1183,7 @@ export function JobDetailPage() {
         activeTab={activeTab}
         onTabChange={setActiveTab}
         showProfileAndInstructions={!hideProfileAndInstructions}
+        isDefaultAgent={isDefaultAgent}
       />
       <DetailPageMain>
         <AgentTabContent

--- a/turbo/packages/core/src/agent-avatar.ts
+++ b/turbo/packages/core/src/agent-avatar.ts
@@ -1,7 +1,19 @@
 export const AVATAR_PRESET_PREFIX = "preset:";
 
 /** Avatar used by the default assistant across branded chat surfaces. */
-export const DEFAULT_AGENT_AVATAR_URL = "svg:r1s0h1c5f4h";
+export const DEFAULT_AGENT_AVATAR_URL =
+  "https://static.vm0.io/public/default-agent-avatar-ceb298b79964.svg";
+
+/** Keep the organization default agent on its canonical avatar. */
+export function agentAvatarUrlForDefaultAgent(args: {
+  readonly agentId: string;
+  readonly defaultAgentId: string | null;
+  readonly avatarUrl: string | null;
+}): string | null {
+  return args.agentId === args.defaultAgentId
+    ? DEFAULT_AGENT_AVATAR_URL
+    : args.avatarUrl;
+}
 
 /**
  * Number of built-in preset avatars: `preset:0` through `preset:4`.


### PR DESCRIPTION
## Summary

- use the new immutable static asset for every existing and future default agent
- project and persist the canonical avatar for default agents so older clients cannot replace it
- render the default avatar as read-only and remove both avatar customization entry points

## Dependency

- Requires vm0-ai/static-files#181 to merge before this PR so the immutable URL is published.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for shared packages, platform, and API
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/settings-tab.test.tsx`
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/auth-org-agents.bdd.test.ts`
- focused TEAM-E team-listing and Clerk onboarding webhook tests

## Test note

A supplemental full run of `org-team.bdd.test.ts` passed 10 of 11 tests; the unrelated ORG-TOKEN-G runner-poll test returned no queued job. The focused TEAM-E coverage changed by this PR passed, and CI will re-run the suite in an isolated environment.