### PR TITLE
fix(platform): stop one tap from blocking auth skeleton

### DIFF
--- a/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
@@ -47,6 +47,7 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
       continuationController,
     );
     let signInSignals: AuthV2SignInSignals | null = null;
+    let initializedSignInSignals: AuthV2SignInSignals | null = null;
     let signUpSignals: AuthV2SignUpSignals | null = null;
     if (mode === "sign-in") {
       const isBaseRoute = location.pathname === ROUTES.signIn;
@@ -115,11 +116,16 @@ function setupAuthV2Page(mode: AuthV2PageMode) {
     if (get(continuationSignals.state$).status === "inactive") {
       if (signInSignals) {
         await set(signInSignals.initialize$, signal);
+        initializedSignInSignals = signInSignals;
       } else if (signUpSignals) {
         await set(signUpSignals.initialize$, signal);
       }
     }
     await set(hideAppSkeleton$, signal);
+    signal.throwIfAborted();
+    if (initializedSignInSignals) {
+      await set(initializedSignInSignals.initializeExternalStrategies$, signal);
+    }
   });
 }
 

--- a/turbo/apps/platform/src/signals/auth-v2/diagnostics.test.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/diagnostics.test.ts
@@ -102,7 +102,7 @@ function createSignInHarness(options?: {
         return Promise.resolve();
       }),
   );
-  const initialize$ = command(
+  const initializeExternalStrategies$ = command(
     async (_context, signal: AbortSignal): Promise<void> => {
       await sourceInitialize();
       signal.throwIfAborted();
@@ -161,7 +161,8 @@ function createSignInHarness(options?: {
       identifier$: computed((get) => {
         return get(identifier$);
       }),
-      initialize$,
+      initialize$: SIGN_IN_ASYNC_NO_OP$,
+      initializeExternalStrategies$,
       newPassword$: computed((get) => {
         return get(newPassword$);
       }),
@@ -410,7 +411,7 @@ describe("auth v2 diagnostic attempt ownership", () => {
     });
 
     const initialization = context.store.set(
-      signals.initialize$,
+      signals.initializeExternalStrategies$,
       context.signal,
     );
     expect(harness.sourceInitialize).toHaveBeenCalledOnce();
@@ -552,8 +553,14 @@ describe("auth v2 diagnostic privacy", () => {
       step: "identifier",
     });
     context.store.get(signals.state$);
-    await context.store.set(signals.initialize$, context.signal);
-    await context.store.set(signals.initialize$, context.signal);
+    await context.store.set(
+      signals.initializeExternalStrategies$,
+      context.signal,
+    );
+    await context.store.set(
+      signals.initializeExternalStrategies$,
+      context.signal,
+    );
 
     expect(capture).not.toHaveBeenCalled();
   });

--- a/turbo/apps/platform/src/signals/auth-v2/diagnostics.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/diagnostics.ts
@@ -600,8 +600,8 @@ function createSignInInstrumentation(
 
   return {
     ...signals,
-    initialize$: createAsyncDiagnosticCommand(
-      signals.initialize$,
+    initializeExternalStrategies$: createAsyncDiagnosticCommand(
+      signals.initializeExternalStrategies$,
       initializeAttempt$,
       finishInitialize$,
       capture,

--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
@@ -173,6 +173,7 @@ export interface AuthV2SignInSignals {
   readonly error$: Computed<AuthV2SignInError | null>;
   readonly identifier$: Computed<string>;
   readonly initialize$: Command<Promise<void>, [AbortSignal]>;
+  readonly initializeExternalStrategies$: Command<Promise<void>, [AbortSignal]>;
   readonly newPassword$: Computed<string>;
   readonly pendingFactorId$: Computed<string | null>;
   readonly password$: Computed<string>;
@@ -1909,14 +1910,6 @@ export function createAuthV2SignInSignals(
     applyResource$,
     dependencies,
   );
-  const initializeWithExternalStrategies$ = command(
-    async ({ set }, signal: AbortSignal): Promise<void> => {
-      await set(initialize$, signal);
-      signal.throwIfAborted();
-      await set(runGoogleOneTap$, signal);
-      signal.throwIfAborted();
-    },
-  );
   return {
     ...formCommands,
     code$: computed((get) => {
@@ -1931,7 +1924,8 @@ export function createAuthV2SignInSignals(
     identifier$: computed((get) => {
       return get(atoms.identifier$);
     }),
-    initialize$: initializeWithExternalStrategies$,
+    initialize$,
+    initializeExternalStrategies$: runGoogleOneTap$,
     newPassword$: computed((get) => {
       return get(atoms.newPassword$);
     }),

--- a/turbo/apps/platform/src/signals/okou-page/auth-v2-add-account-dialog.ts
+++ b/turbo/apps/platform/src/signals/okou-page/auth-v2-add-account-dialog.ts
@@ -109,6 +109,9 @@ export const openAuthV2AddAccountDialog$ = command(
       await set(signInSignals.initialize$, dialogSignal);
       parentSignal.throwIfAborted();
       dialogSignal.throwIfAborted();
+      await set(signInSignals.initializeExternalStrategies$, dialogSignal);
+      parentSignal.throwIfAborted();
+      dialogSignal.throwIfAborted();
     }
   },
 );

--- a/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx
@@ -338,11 +338,18 @@ async function editRestoredIdentifier(): Promise<void> {
 }
 
 describe("auth v2 sign-in flow", () => {
-  it("keeps the bootstrap skeleton until the low-level Clerk resource is ready", async () => {
+  it("hides the bootstrap skeleton after Clerk is ready without waiting for Google One Tap", async () => {
     const clerkLoad = createDeferredPromise<void>(context.signal);
     mockedClerk.load.mockImplementation(() => {
       return clerkLoad.promise;
     });
+    context.mocks.browser.fedCm();
+    mockAuthV2Capabilities({
+      googleOAuth: true,
+      googleOneTapClientId: "google-client-id",
+    });
+    mockGoogleOneTapCredential(null);
+    mockedGoogleOneTap.prompt.mockImplementation(() => {});
     const bootstrapSkeleton = document.createElement("div");
     bootstrapSkeleton.id = "app-bootstrap-skeleton";
     document.body.append(bootstrapSkeleton);
@@ -370,6 +377,9 @@ describe("auth v2 sign-in flow", () => {
     ).resolves.toBeVisible();
     await waitFor(() => {
       expect(bootstrapSkeleton).toHaveAttribute("aria-hidden", "true");
+    });
+    await waitFor(() => {
+      expect(mockedGoogleOneTap.prompt).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## Summary

- split core Clerk/session initialization from optional sign-in strategies
- hide the bootstrap skeleton before awaiting Google One Tap while preserving route-owned cancellation
- keep add-account initialization and auth diagnostics intact, with a regression test for a One Tap prompt that never settles

## Why

The auth v2 route awaited the Google One Tap prompt before hiding the bootstrap skeleton. FedCM can leave that prompt pending for several seconds, so an otherwise-ready sign-in page remained covered by the loading UI.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm --filter @okouai/app lint`
- `pnpm knip`
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/auth-v2/sign-in/__tests__/sign-in-card.test.tsx src/views/auth-v2/sign-in/__tests__/sign-in-diagnostics.test.tsx src/signals/auth-v2-page-setup.test.ts src/signals/auth-v2/diagnostics.test.ts` (82 tests)
