### PR TITLE
feat: show when the soonest codex reset credit expires

### DIFF
--- a/turbo/apps/api/src/mocks/handlers/index.ts
+++ b/turbo/apps/api/src/mocks/handlers/index.ts
@@ -18,4 +18,10 @@ export const handlers: readonly HttpHandler[] = [
   http.get("https://chatgpt.com/backend-api/wham/usage", () => {
     return HttpResponse.json({});
   }),
+  http.get(
+    "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits",
+    () => {
+      return HttpResponse.json({ credits: [] });
+    },
+  ),
 ];

--- a/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
@@ -508,12 +508,11 @@ describe("POST /api/me/model-providers (upsert)", () => {
       }),
       [200],
     );
-    const [provider] = listed.body.modelProviders;
-    expect(provider).toMatchObject({
+    expect(listed.body.modelProviders[0]).toMatchObject({
       type: "codex-oauth-token",
       subscriptionResetCredits: 2,
+      subscriptionResetCreditsNextExpiresAt: null,
     });
-    expect(provider?.subscriptionResetCreditsNextExpiresAt ?? null).toBeNull();
   });
 
   it("consumes a Codex subscription reset credit", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/me-model-providers-upsert.test.ts
@@ -370,6 +370,44 @@ describe("POST /api/me/model-providers (upsert)", () => {
           },
         });
       }),
+      http.get(
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits",
+        () => {
+          return HttpResponse.json({
+            available_count: 3,
+            credits: [
+              {
+                id: "credit-later",
+                reset_type: "codex_rate_limits",
+                status: "available",
+                granted_at: "2029-12-01T00:00:00Z",
+                expires_at: "2030-02-01T00:00:00Z",
+              },
+              {
+                id: "credit-soonest",
+                reset_type: "codex_rate_limits",
+                status: "available",
+                granted_at: "2029-12-02T00:00:00Z",
+                expires_at: "2030-01-15T00:00:00Z",
+              },
+              {
+                id: "credit-never-expires",
+                reset_type: "codex_rate_limits",
+                status: "available",
+                granted_at: "2029-12-03T00:00:00Z",
+                expires_at: null,
+              },
+              {
+                id: "credit-redeemed",
+                reset_type: "codex_rate_limits",
+                status: "redeemed",
+                granted_at: "2029-11-01T00:00:00Z",
+                expires_at: "2029-12-15T00:00:00Z",
+              },
+            ],
+          });
+        },
+      ),
     );
 
     const client = setupApp({
@@ -410,6 +448,7 @@ describe("POST /api/me/model-providers (upsert)", () => {
       type: "codex-oauth-token",
       accountEmail: "codex.user@example.com",
       subscriptionResetCredits: 3,
+      subscriptionResetCreditsNextExpiresAt: "2030-01-15T00:00:00.000Z",
       subscriptionUsage: {
         fiveHour: {
           usedPercent: 25,
@@ -425,6 +464,56 @@ describe("POST /api/me/model-providers (upsert)", () => {
         },
       },
     });
+  });
+
+  it("keeps reset credits when the expiry read fails", async () => {
+    const fixture = uniqueOrgUser("zmmp-codex-expiry-degraded");
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    server.use(
+      http.get("https://chatgpt.com/backend-api/wham/usage", () => {
+        return HttpResponse.json({
+          plan_type: "pro",
+          rate_limit_reset_credits: {
+            available_count: 2,
+          },
+        });
+      }),
+      http.get(
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits",
+        () => {
+          return new HttpResponse(null, { status: 500 });
+        },
+      ),
+    );
+
+    const client = setupApp({
+      context,
+      routes: personalModelProvidersMainTestRoutes,
+    })(personalModelProvidersMainContract);
+    await accept(
+      client.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: makeAuthJson() },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    const listed = await accept(
+      client.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    const [provider] = listed.body.modelProviders;
+    expect(provider).toMatchObject({
+      type: "codex-oauth-token",
+      subscriptionResetCredits: 2,
+    });
+    expect(provider?.subscriptionResetCreditsNextExpiresAt ?? null).toBeNull();
   });
 
   it("consumes a Codex subscription reset credit", async () => {

--- a/turbo/apps/api/src/signals/services/codex-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/codex-usage.service.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
+import { logger } from "../../lib/log";
 import { now } from "../../lib/time";
+import { tapError } from "../utils";
 import type {
   SubscriptionUsageMetadata,
   SubscriptionUsageWindowMetadata,
@@ -8,10 +10,18 @@ import type {
 import { extractCodexAccountEmailFromIdToken } from "./codex-auth-json-parser";
 
 const CHATGPT_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const CHATGPT_RESET_CREDITS_URL =
+  "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
 const CHATGPT_RESET_CREDITS_CONSUME_URL =
   "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume";
 const CODEX_ORIGINATOR = "codex_cli_rs";
 const CODEX_USER_AGENT = "codex_cli_rs/0.0.0";
+/**
+ * The usage response only carries the reset credit count, so the expiry needs a
+ * second upstream read. It is decorative next to the count that the reset flow
+ * actually depends on, so it gets its own short budget and degrades quietly.
+ */
+const RESET_CREDIT_DETAILS_TIMEOUT_MS = 5000;
 const WEEK_SECONDS = 7 * 24 * 60 * 60;
 const DAY_SECONDS = 24 * 60 * 60;
 const HOUR_SECONDS = 60 * 60;
@@ -37,6 +47,19 @@ const rateLimitDetailsSchema = z
 const rateLimitResetCreditsSchema = z
   .object({
     available_count: z.number().int().nonnegative().nullable().optional(),
+  })
+  .passthrough();
+
+const rateLimitResetCreditSchema = z
+  .object({
+    status: z.string().nullable().optional(),
+    expires_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const rateLimitResetCreditsDetailsSchema = z
+  .object({
+    credits: z.array(rateLimitResetCreditSchema).nullable().optional(),
   })
   .passthrough();
 
@@ -84,6 +107,8 @@ type RateLimitWindow = z.infer<typeof rateLimitWindowSchema>;
 type CodexNamedMetadata = z.infer<typeof namedMetadataSchema>;
 type CodexUsageResponse = z.infer<typeof codexUsageResponseSchema>;
 
+const L = logger("codex-usage.service");
+
 interface CodexUsageMetadata {
   readonly accountEmail: string | null;
   readonly planType: string | null;
@@ -92,6 +117,7 @@ interface CodexUsageMetadata {
   readonly subscriptionNextResetAt: Date | null;
   readonly subscriptionUsage: SubscriptionUsageMetadata | null;
   readonly subscriptionResetCredits: number | null;
+  readonly subscriptionResetCreditsNextExpiresAt: Date | null;
 }
 
 export type CodexRateLimitResetCreditOutcome =
@@ -298,15 +324,41 @@ function subscriptionUsageFromRateLimit(
   };
 }
 
-export async function fetchCodexUsageMetadata(
+/**
+ * Soonest expiry among the credits the account can still redeem. Credits that
+ * never expire and credits in a non-redeemable status carry no deadline worth
+ * showing, so they drop out here rather than in the view layer.
+ */
+function nextResetCreditExpiry(
+  credits: readonly z.infer<typeof rateLimitResetCreditSchema>[],
+): Date | null {
+  const expiries = credits
+    .filter((credit) => {
+      return credit.status === "available";
+    })
+    .map((credit) => {
+      return credit.expires_at ? new Date(credit.expires_at) : null;
+    })
+    .filter((expiry): expiry is Date => {
+      return expiry !== null && !Number.isNaN(expiry.getTime());
+    });
+
+  if (expiries.length === 0) {
+    return null;
+  }
+  return expiries.reduce((soonest, candidate) => {
+    return candidate < soonest ? candidate : soonest;
+  });
+}
+
+async function fetchCodexResetCreditExpiry(
   args: {
     readonly accessToken: string;
     readonly accountId: string;
-    readonly idToken?: string | null;
   },
   signal: AbortSignal,
-): Promise<CodexUsageMetadata | null> {
-  const response = await fetch(CHATGPT_USAGE_URL, {
+): Promise<Date | null> {
+  const response = await fetch(CHATGPT_RESET_CREDITS_URL, {
     method: "GET",
     headers: {
       authorization: `Bearer ${args.accessToken}`,
@@ -316,6 +368,61 @@ export async function fetchCodexUsageMetadata(
     },
     signal,
   });
+
+  if (!response.ok) {
+    throw new Error(
+      `Codex reset credit details request failed with status ${response.status}`,
+    );
+  }
+
+  const parsed = rateLimitResetCreditsDetailsSchema.safeParse(
+    await response.json(),
+  );
+  if (!parsed.success) {
+    throw new Error("Codex reset credit details response shape unrecognized");
+  }
+
+  return nextResetCreditExpiry(parsed.data.credits ?? []);
+}
+
+export async function fetchCodexUsageMetadata(
+  args: {
+    readonly accessToken: string;
+    readonly accountId: string;
+    readonly idToken?: string | null;
+  },
+  signal: AbortSignal,
+): Promise<CodexUsageMetadata | null> {
+  // The caller's abort still cancels both reads; only the extra detail budget
+  // is scoped here, so a slow expiry read cannot hold up the usage response.
+  const detailsSignal = AbortSignal.any([
+    signal,
+    AbortSignal.timeout(RESET_CREDIT_DETAILS_TIMEOUT_MS),
+  ]);
+  const [response, nextExpiresAt] = await Promise.all([
+    fetch(CHATGPT_USAGE_URL, {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${args.accessToken}`,
+        "chatgpt-account-id": args.accountId,
+        originator: CODEX_ORIGINATOR,
+        "user-agent": CODEX_USER_AGENT,
+      },
+      signal,
+    }),
+    tapError(
+      fetchCodexResetCreditExpiry(
+        {
+          accessToken: args.accessToken,
+          accountId: args.accountId,
+        },
+        detailsSignal,
+      ),
+      (error) => {
+        L.warn("failed to read codex reset credit expiry", { error });
+      },
+    ),
+  ]);
 
   if (!response.ok) {
     throw new Error(
@@ -338,6 +445,7 @@ export async function fetchCodexUsageMetadata(
     subscriptionUsage: subscriptionUsageFromRateLimit(parsed.data.rate_limit),
     subscriptionResetCredits:
       parsed.data.rate_limit_reset_credits?.available_count ?? null,
+    subscriptionResetCreditsNextExpiresAt: nextExpiresAt ?? null,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
@@ -161,9 +161,10 @@ function withSubscriptionMetadata(
     subscriptionUsage: serializeSubscriptionUsage(metadata.subscriptionUsage),
     subscriptionResetCredits:
       metadata.subscriptionResetCredits ?? provider.subscriptionResetCredits,
+    // No column backs this field, so there is no stored value to fall back to:
+    // an absent expiry is reported as such rather than deferred to the row.
     subscriptionResetCreditsNextExpiresAt:
-      metadata.subscriptionResetCreditsNextExpiresAt?.toISOString() ??
-      provider.subscriptionResetCreditsNextExpiresAt,
+      metadata.subscriptionResetCreditsNextExpiresAt?.toISOString() ?? null,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
@@ -43,6 +43,7 @@ interface SubscriptionMetadata {
   readonly subscriptionNextResetAt?: Date | null;
   readonly subscriptionUsage?: SubscriptionUsageMetadata | null;
   readonly subscriptionResetCredits?: number | null;
+  readonly subscriptionResetCreditsNextExpiresAt?: Date | null;
 }
 
 type SerializedSubscriptionUsage = NonNullable<
@@ -160,6 +161,9 @@ function withSubscriptionMetadata(
     subscriptionUsage: serializeSubscriptionUsage(metadata.subscriptionUsage),
     subscriptionResetCredits:
       metadata.subscriptionResetCredits ?? provider.subscriptionResetCredits,
+    subscriptionResetCreditsNextExpiresAt:
+      metadata.subscriptionResetCreditsNextExpiresAt?.toISOString() ??
+      provider.subscriptionResetCreditsNextExpiresAt,
   };
 }
 

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -5017,10 +5017,13 @@
       },
       "reset": {
         "confirmDescription": "Verwenden Sie einen Codex-Reset, um Ihre aktuellen Nutzungsfenster zurückzusetzen. Sie haben {{remaining}}.",
+        "expiresAt": "Nächster Reset läuft {{date}} ab",
         "progress": "Zurücksetzen...",
         "remaining_one": "{{value}} Reset übrig",
         "remaining_other": "{{value}} Resets übrig",
         "remainingUnavailable": "Verbleibende Resets nicht verfügbar",
+        "remainingWithExpiry_one": "{{value}} Reset übrig · läuft {{expiry}} ab",
+        "remainingWithExpiry_other": "{{value}} Resets übrig · laufen {{expiry}} ab",
         "title": "Codex-Nutzung zurücksetzen?"
       },
       "stale": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -5009,10 +5009,13 @@
       },
       "reset": {
         "confirmDescription": "Use one Codex reset to reset your current usage windows. You have {{remaining}}.",
+        "expiresAt": "Soonest reset expires {{date}}",
         "progress": "Resetting...",
         "remaining_one": "{{value}} reset left",
         "remaining_other": "{{value}} resets left",
         "remainingUnavailable": "Resets left unavailable",
+        "remainingWithExpiry_one": "{{value}} reset left · expires {{expiry}}",
+        "remainingWithExpiry_other": "{{value}} resets left · expires {{expiry}}",
         "title": "Reset Codex usage?"
       },
       "stale": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5072,11 +5072,15 @@
       },
       "reset": {
         "confirmDescription": "Usa un restablecimiento de Codex para reiniciar tus periodos de consumo actuales. Te quedan {{remaining}}.",
+        "expiresAt": "El restablecimiento más próximo vence {{date}}",
         "progress": "Restableciendo...",
         "remaining_one": "Queda {{value}} restablecimiento",
         "remaining_many": "Quedan {{value}} restablecimientos",
         "remaining_other": "Quedan {{value}} restablecimientos",
         "remainingUnavailable": "Reinicios no disponibles",
+        "remainingWithExpiry_one": "Queda {{value}} restablecimiento · vence {{expiry}}",
+        "remainingWithExpiry_many": "Quedan {{value}} restablecimientos · vencen {{expiry}}",
+        "remainingWithExpiry_other": "Quedan {{value}} restablecimientos · vencen {{expiry}}",
         "title": "¿Restablecer el uso de Codex?"
       },
       "stale": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5072,11 +5072,15 @@
       },
       "reset": {
         "confirmDescription": "Utilisez une réinitialisation de Codex pour remettre à zéro vos fenêtres d'utilisation actuelles. Il vous en reste {{remaining}}.",
+        "expiresAt": "La réinitialisation la plus proche expire {{date}}",
         "progress": "Réinitialisation en cours...",
         "remaining_one": "{{value}} réinitialisation restante",
         "remaining_many": "{{value}} réinitialisations restantes",
         "remaining_other": "{{value}} réinitialisations restantes",
         "remainingUnavailable": "Réinitialisations restantes non disponibles",
+        "remainingWithExpiry_one": "{{value}} réinitialisation restante · expire {{expiry}}",
+        "remainingWithExpiry_many": "{{value}} réinitialisations restantes · expirent {{expiry}}",
+        "remainingWithExpiry_other": "{{value}} réinitialisations restantes · expirent {{expiry}}",
         "title": "Réinitialiser l'utilisation de Codex ?"
       },
       "stale": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -5017,10 +5017,13 @@
       },
       "reset": {
         "confirmDescription": "अपनी वर्तमान उपयोग विंडो को रीसेट करने के लिए एक Codex रीसेट का उपयोग करें। आपके पास {{remaining}} है।",
+        "expiresAt": "निकटतम रीसेट {{date}} को समाप्त होगा",
         "progress": "रीसेट किया जा रहा है...",
         "remaining_one": "{{value}} रीसेट बचे हैं",
         "remaining_other": "{{value}} रीसेट बचे हैं",
         "remainingUnavailable": "रीसेट उपलब्ध नहीं हैं",
+        "remainingWithExpiry_one": "{{value}} रीसेट बचा है · {{expiry}} समाप्त",
+        "remainingWithExpiry_other": "{{value}} रीसेट बचे हैं · {{expiry}} समाप्त",
         "title": "Codex उपयोग रीसेट करें?"
       },
       "stale": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -5009,10 +5009,12 @@
       },
       "reset": {
         "confirmDescription": "Gunakan satu reset Codex untuk mereset jendela penggunaan saat ini. Anda memiliki {{remaining}}.",
+        "expiresAt": "Reset terdekat kedaluwarsa {{date}}",
         "progress": "Mereset...",
         "remaining_one": "{{value}} reset tersisa",
         "remaining_other": "{{value}} reset tersisa",
         "remainingUnavailable": "Sisa reset tidak tersedia",
+        "remainingWithExpiry_other": "{{value}} reset tersisa · kedaluwarsa {{expiry}}",
         "title": "Reset penggunaan Codex?"
       },
       "stale": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5072,11 +5072,15 @@
       },
       "reset": {
         "confirmDescription": "Usa un ripristino Codex per reimpostare le finestre di utilizzo correnti. Te ne restano {{remaining}}.",
+        "expiresAt": "Il ripristino più vicino scade {{date}}",
         "progress": "Reimpostazione...",
         "remaining_one": "{{value}} ripristino rimasto",
         "remaining_many": "{{value}} ripristini rimasti",
         "remaining_other": "{{value}} ripristini rimasti",
         "remainingUnavailable": "Ripristini rimasti non disponibili",
+        "remainingWithExpiry_one": "{{value}} ripristino rimasto · scade {{expiry}}",
+        "remainingWithExpiry_many": "{{value}} ripristini rimasti · scadono {{expiry}}",
+        "remainingWithExpiry_other": "{{value}} ripristini rimasti · scadono {{expiry}}",
         "title": "Reimpostare l'utilizzo di Codex?"
       },
       "stale": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -5009,10 +5009,12 @@
       },
       "reset": {
         "confirmDescription": "Codexリセットを1回使用して、現在の使用枠をリセットします。{{remaining}}。",
+        "expiresAt": "最も早いリセットの有効期限は{{date}}",
         "progress": "リセット中...",
         "remaining_one": "リセット残り{{value}}回",
         "remaining_other": "リセット残り{{value}}回",
         "remainingUnavailable": "残りのリセット回数を取得できません",
+        "remainingWithExpiry_other": "リセット残り{{value}}回 · 有効期限{{expiry}}",
         "title": "Codexの使用量をリセットしますか？"
       },
       "stale": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -5009,10 +5009,12 @@
       },
       "reset": {
         "confirmDescription": "현재 사용량 창을 재설정하려면 Codex 재설정 1회를 사용하세요. 남은 횟수: {{remaining}}.",
+        "expiresAt": "가장 빠른 재설정 만료: {{date}}",
         "progress": "재설정 중...",
         "remaining_one": "{{value}}회 재설정 가능",
         "remaining_other": "{{value}}회 재설정 가능",
         "remainingUnavailable": "재설정 가능 횟수 없음",
+        "remainingWithExpiry_other": "{{value}}회 재설정 가능 · {{expiry}} 만료",
         "title": "Codex 사용량을 재설정하시겠습니까?"
       },
       "stale": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5072,11 +5072,15 @@
       },
       "reset": {
         "confirmDescription": "Use uma redefinição do Codex para redefinir suas janelas de uso atuais. Você tem {{remaining}}.",
+        "expiresAt": "A redefinição mais próxima expira {{date}}",
         "progress": "Redefinindo...",
         "remaining_one": "{{value}} redefinição restante",
         "remaining_many": "{{value}} redefinições restantes",
         "remaining_other": "{{value}} redefinições restantes",
         "remainingUnavailable": "Redefinições restantes indisponíveis",
+        "remainingWithExpiry_one": "{{value}} redefinição restante · expira {{expiry}}",
+        "remainingWithExpiry_many": "{{value}} redefinições restantes · expiram {{expiry}}",
+        "remainingWithExpiry_other": "{{value}} redefinições restantes · expiram {{expiry}}",
         "title": "Redefinir o uso do Codex?"
       },
       "stale": {

--- a/turbo/apps/platform/src/signals/external/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/external/personal-model-providers.ts
@@ -8,12 +8,29 @@ import {
 import type { ModelProviderType } from "@okouai/api-contracts/contracts/model-providers";
 import { apiClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
+import { now } from "../../lib/time.ts";
 
 /**
  * Reload trigger for personal model provider signals.
  * Increment to force recomputation of personalModelProviders$.
  */
 const internalReloadPersonalModelProviders$ = state(0);
+
+/**
+ * Listing personal providers makes the API read every connected subscription's
+ * usage upstream, so opportunistic callers reuse a recent read instead of
+ * paying for it again. Mutations bypass this window entirely.
+ */
+const PERSONAL_MODEL_PROVIDERS_STALE_MS = 60_000;
+
+const internalPersonalModelProvidersRefreshedAt$ = state<number | null>(null);
+
+const forcePersonalModelProvidersReload$ = command(({ set }) => {
+  set(internalPersonalModelProvidersRefreshedAt$, now());
+  set(internalReloadPersonalModelProviders$, (x) => {
+    return x + 1;
+  });
+});
 
 /**
  * Personal (user-level) model providers for the requesting user.
@@ -41,9 +58,7 @@ export const deletePersonalModelProvider$ = command(
       [204],
     );
 
-    set(internalReloadPersonalModelProviders$, (x) => {
-      return x + 1;
-    });
+    set(forcePersonalModelProvidersReload$);
   },
 );
 
@@ -60,9 +75,7 @@ export const activatePersonalModelProviderAccount$ = command(
       [200],
     );
     signal.throwIfAborted();
-    set(internalReloadPersonalModelProviders$, (x) => {
-      return x + 1;
-    });
+    set(forcePersonalModelProvidersReload$);
     return result.body;
   },
 );
@@ -79,9 +92,7 @@ export const deletePersonalModelProviderAccount$ = command(
       [204],
     );
     signal.throwIfAborted();
-    set(internalReloadPersonalModelProviders$, (x) => {
-      return x + 1;
-    });
+    set(forcePersonalModelProvidersReload$);
   },
 );
 
@@ -102,9 +113,7 @@ export const resetPersonalCodexAccountSubscriptionUsage$ = command(
       [200],
     );
     signal.throwIfAborted();
-    set(internalReloadPersonalModelProviders$, (x) => {
-      return x + 1;
-    });
+    set(forcePersonalModelProvidersReload$);
     return result.body;
   },
 );
@@ -129,9 +138,7 @@ export const resetPersonalCodexSubscriptionUsage$ = command(
     );
     signal.throwIfAborted();
 
-    set(internalReloadPersonalModelProviders$, (x) => {
-      return x + 1;
-    });
+    set(forcePersonalModelProvidersReload$);
 
     return result.body;
   },
@@ -143,7 +150,21 @@ export const resetPersonalCodexSubscriptionUsage$ = command(
  * `reloadOrgModelProviders$` in `external/org-model-providers.ts`.
  */
 export const reloadPersonalModelProviders$ = command(({ set }) => {
-  set(internalReloadPersonalModelProviders$, (x) => {
-    return x + 1;
-  });
+  set(forcePersonalModelProvidersReload$);
+});
+
+/**
+ * Refresh only when the last read has aged out. For callers that refresh on a
+ * recurring UI event rather than after a change, such as opening the account
+ * menu, where a slightly stale usage reading costs nothing.
+ */
+export const refreshPersonalModelProvidersIfStale$ = command(({ get, set }) => {
+  const refreshedAt = get(internalPersonalModelProvidersRefreshedAt$);
+  if (
+    refreshedAt !== null &&
+    now() - refreshedAt < PERSONAL_MODEL_PROVIDERS_STALE_MS
+  ) {
+    return;
+  }
+  set(forcePersonalModelProvidersReload$);
 });

--- a/turbo/apps/platform/src/signals/okou-page/account-menu-subscriptions.ts
+++ b/turbo/apps/platform/src/signals/okou-page/account-menu-subscriptions.ts
@@ -3,7 +3,7 @@ import type {
   ModelProviderResponse,
   ModelProviderType,
 } from "@okouai/api-contracts/contracts/model-providers";
-import { reloadPersonalModelProviders$ } from "../external/personal-model-providers.ts";
+import { refreshPersonalModelProvidersIfStale$ } from "../external/personal-model-providers.ts";
 import { personalConfiguredProviders$ } from "./settings/personal-model-providers.ts";
 
 export type AccountMenuSubscriptionUsage = NonNullable<
@@ -17,6 +17,7 @@ export interface AccountMenuSubscriptionUsageRow {
   readonly type: ModelProviderType;
   readonly usage: AccountMenuSubscriptionUsage;
   readonly resetCredits?: number | null;
+  readonly resetCreditsNextExpiresAt?: string | null;
 }
 
 export type AccountMenuSubscriptionUsageRowsCacheKey = string | null;
@@ -64,7 +65,7 @@ export const reloadAccountMenuSubscriptionUsageRows$ = command(
     set(internalAccountMenuSubscriptionUsageRowsRequestId$, requestId);
 
     const promise = (async () => {
-      set(reloadPersonalModelProviders$);
+      set(refreshPersonalModelProvidersIfStale$);
       const providers = await get(personalConfiguredProviders$);
       signal.throwIfAborted();
       if (
@@ -103,6 +104,10 @@ function accountMenuSubscriptionUsageRows(
         resetCredits:
           provider.type === "codex-oauth-token"
             ? (provider.subscriptionResetCredits ?? null)
+            : undefined,
+        resetCreditsNextExpiresAt:
+          provider.type === "codex-oauth-token"
+            ? (provider.subscriptionResetCreditsNextExpiresAt ?? null)
             : undefined,
       },
     ];

--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-providers-tab.test.tsx
@@ -735,6 +735,29 @@ describe("personal model providers settings", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows when the soonest Codex reset expires in the row menu", async () => {
+    mockNow(context.signal, new Date("2030-01-01T00:00:00.000Z"));
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Test Org",
+      role: "member",
+    });
+    context.mocks.data.personalModelProviders([
+      {
+        ...connectedPersonalCodexProvider(),
+        subscriptionResetCreditsNextExpiresAt: "2030-01-01T06:30:00.000Z",
+      },
+    ]);
+
+    await openModelSettings();
+
+    const codexRow = await screen.findByTestId("oauth-card-codex-oauth-token");
+    click(within(codexRow).getByLabelText("More options"));
+    await expect(
+      screen.findByText("2 resets left · expires in 6h 30m"),
+    ).resolves.toBeInTheDocument();
+  });
+
   it("resets connected personal Codex usage from the row menu", async () => {
     context.mocks.data.org({
       id: "org_1",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -242,6 +242,13 @@ async function openAccountMenu(): Promise<HTMLElement> {
   return screen.findByRole("menu");
 }
 
+async function closeAccountMenu(): Promise<void> {
+  fireEvent.keyDown(document.body, { key: "Escape" });
+  await waitFor(() => {
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+}
+
 function setupAddAccountPage(): void {
   prepareDefaultAgent();
   detachedSetupPage({
@@ -999,6 +1006,60 @@ describe("zero sidebar account menu", () => {
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
+  it("shows when the soonest Codex reset expires", async () => {
+    mockAdminAccountSidebar();
+    mockNow(context.signal, new Date("2030-01-01T00:00:00.000Z"));
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider({
+        subscriptionResetCreditsNextExpiresAt: "2030-01-04T00:00:00.000Z",
+      }),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+      featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
+    });
+
+    const menu = await openAccountMenu();
+    const panel = await within(menu).findByTestId("account-menu-subscriptions");
+    expect(
+      within(panel).getByText("2 resets left · expires in 3d"),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the expiry when no Codex reset is left", async () => {
+    mockAdminAccountSidebar();
+    mockNow(context.signal, new Date("2030-01-01T00:00:00.000Z"));
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider({
+        subscriptionResetCredits: 0,
+        subscriptionResetCreditsNextExpiresAt: "2030-01-04T00:00:00.000Z",
+      }),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+      featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
+    });
+
+    const menu = await openAccountMenu();
+    const panel = await within(menu).findByTestId("account-menu-subscriptions");
+    expect(within(panel).getByText("0 resets left")).toBeInTheDocument();
+    expect(within(panel).queryByText(/expires/)).not.toBeInTheDocument();
+  });
+
   it("resets Codex usage from the account menu", async () => {
     mockAdminAccountSidebar();
     context.mocks.data.personalModelProviders([
@@ -1058,12 +1119,22 @@ describe("zero sidebar account menu", () => {
     expect(within(panel).getByText("1 reset left")).toBeInTheDocument();
   });
 
-  it("refreshes account menu subscriptions when the menu opens", async () => {
+  it("refreshes account menu subscriptions once the last read goes stale", async () => {
     mockAdminAccountSidebar();
-    context.mocks.data.personalModelProviders([
+    mockNow(context.signal, new Date("2030-01-01T00:00:00.000Z"));
+
+    let providers = [
       connectedPersonalCodexProvider(),
       connectedPersonalClaudeCodeProvider(),
-    ]);
+    ];
+    let listCalls = 0;
+    context.mocks.api(
+      personalModelProvidersMainContract.list,
+      ({ respond }) => {
+        listCalls += 1;
+        return respond(200, { modelProviders: providers });
+      },
+    );
 
     detachedSetupPage({
       context,
@@ -1079,8 +1150,9 @@ describe("zero sidebar account menu", () => {
     let menu = await openAccountMenu();
     let panel = await within(menu).findByTestId("account-menu-subscriptions");
     expect(within(panel).getByText("82%")).toBeInTheDocument();
+    const callsAfterFirstOpen = listCalls;
 
-    context.mocks.data.personalModelProviders([
+    providers = [
       connectedPersonalCodexProvider({
         subscriptionUsage: {
           fiveHour: {
@@ -1098,14 +1170,18 @@ describe("zero sidebar account menu", () => {
         },
       }),
       connectedPersonalClaudeCodeProvider(),
-    ]);
+    ];
 
+    await closeAccountMenu();
+    menu = await openAccountMenu();
+    panel = await within(menu).findByTestId("account-menu-subscriptions");
+
+    expect(within(panel).getByText("82%")).toBeInTheDocument();
     expect(within(panel).queryByText("64%")).not.toBeInTheDocument();
-    fireEvent.keyDown(document.body, { key: "Escape" });
-    await waitFor(() => {
-      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-    });
+    expect(listCalls).toBe(callsAfterFirstOpen);
 
+    mockNow(context.signal, new Date("2030-01-01T00:01:01.000Z"));
+    await closeAccountMenu();
     menu = await openAccountMenu();
     panel = await within(menu).findByTestId("account-menu-subscriptions");
 
@@ -1113,10 +1189,12 @@ describe("zero sidebar account menu", () => {
       expect(within(panel).getByText("64%")).toBeInTheDocument();
       expect(within(panel).getByText("30%")).toBeInTheDocument();
     });
+    expect(listCalls).toBeGreaterThan(callsAfterFirstOpen);
   });
 
   it("keeps loaded subscription usage visible while a menu refresh is pending", async () => {
     mockAdminAccountSidebar();
+    mockNow(context.signal, new Date("2030-01-01T00:00:00.000Z"));
     context.mocks.data.personalModelProviders([
       connectedPersonalCodexProvider(),
     ]);
@@ -1158,6 +1236,7 @@ describe("zero sidebar account menu", () => {
       },
     );
 
+    mockNow(context.signal, new Date("2030-01-01T00:01:01.000Z"));
     menu = await openAccountMenu();
     panel = await within(menu).findByTestId("account-menu-subscriptions");
 

--- a/turbo/apps/platform/src/views/okou-page/components/preferences/codex-reset-usage-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/preferences/codex-reset-usage-dialog.tsx
@@ -10,15 +10,35 @@ import {
 import { useTranslation } from "react-i18next";
 import { formatLocalizedNumber } from "../../../../i18n/format.ts";
 import { i18n } from "../../../../i18n/index.ts";
+import { formatCodexResetCreditExpiry } from "../../subscription-usage-format.ts";
 
 export function formatCodexResetCredits(
   value: number | null | undefined,
+  expiresAt?: string | null,
 ): string {
   if (value === null || value === undefined) {
     return i18n.t(($) => {
       return $.settings.models.reset.remainingUnavailable;
     });
   }
+
+  // Nothing is left to expire once the count reaches zero, so the deadline is
+  // suppressed there instead of contradicting the count.
+  const expiry =
+    value > 0 ? formatCodexResetCreditExpiry(expiresAt ?? null) : null;
+  if (expiry) {
+    return i18n.t(
+      ($) => {
+        return $.settings.models.reset.remainingWithExpiry;
+      },
+      {
+        count: value,
+        value: formatLocalizedNumber(value),
+        expiry: expiry.relativeText,
+      },
+    );
+  }
+
   return i18n.t(
     ($) => {
       return $.settings.models.reset.remaining;

--- a/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
@@ -437,7 +437,10 @@ function OAuthAccountMenu({
       ? [
           {
             kind: "status" as const,
-            label: formatCodexResetCredits(resetCredits),
+            label: formatCodexResetCredits(
+              resetCredits,
+              account.subscriptionResetCreditsNextExpiresAt,
+            ),
           },
           { kind: "separator" as const },
           {
@@ -750,7 +753,10 @@ function CodexOAuthCredentialRow({
   onOpenReset: () => void;
 }) {
   const { t } = useTranslation();
-  const resetCreditLabel = formatCodexResetCredits(resetCredits);
+  const resetCreditLabel = formatCodexResetCredits(
+    resetCredits,
+    provider?.subscriptionResetCreditsNextExpiresAt,
+  );
   return (
     <OAuthCredentialRow
       type="codex-oauth-token"

--- a/turbo/apps/platform/src/views/okou-page/sidebar-subscriptions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-subscriptions.tsx
@@ -19,7 +19,10 @@ import {
 } from "../../signals/okou-page/account-menu-subscriptions.ts";
 import { DropdownMenuModalItem } from "../components/dropdown-menu-modal-item.tsx";
 import { formatCodexResetCredits } from "./components/preferences/codex-reset-usage-dialog.tsx";
-import { formatSubscriptionUsageReset } from "./subscription-usage-format.ts";
+import {
+  formatCodexResetCreditExpiry,
+  formatSubscriptionUsageReset,
+} from "./subscription-usage-format.ts";
 import { formatLocalizedNumber } from "../../i18n/format.ts";
 
 type SubscriptionUsage = AccountMenuSubscriptionUsage;
@@ -81,6 +84,7 @@ export function AccountMenuSubscriptionsPanel({
                   label={label}
                   usage={row.usage}
                   resetCredits={row.resetCredits}
+                  resetCreditsNextExpiresAt={row.resetCreditsNextExpiresAt}
                   resetPending={resetPending}
                   onResetCodexUsage={onResetCodexUsage}
                 />
@@ -126,6 +130,7 @@ function AccountMenuSubscriptionProviderSection({
   label,
   usage,
   resetCredits,
+  resetCreditsNextExpiresAt,
   resetPending,
   onResetCodexUsage,
 }: {
@@ -134,11 +139,15 @@ function AccountMenuSubscriptionProviderSection({
   readonly label: string;
   readonly usage: SubscriptionUsage;
   readonly resetCredits?: number | null;
+  readonly resetCreditsNextExpiresAt?: string | null;
   readonly resetPending: boolean;
   readonly onResetCodexUsage?: (resetCredits: number | null) => void;
 }) {
   const { t } = useTranslation();
   const windows = accountMenuSubscriptionUsageWindows(usage);
+  const resetExpiry = formatCodexResetCreditExpiry(
+    (resetCredits ?? 0) > 0 ? resetCreditsNextExpiresAt : null,
+  );
   const canResetCodex =
     type === "codex-oauth-token" &&
     onResetCodexUsage !== undefined &&
@@ -188,9 +197,11 @@ function AccountMenuSubscriptionProviderSection({
           }}
           className="mt-1 flex h-7 items-center justify-between gap-2 rounded-md px-2 py-1 text-xs"
         >
-          <span className="min-w-0 flex-1 truncate text-muted-foreground">
-            {formatCodexResetCredits(resetCredits)}
-          </span>
+          <ResetCreditsLabel
+            resetCredits={resetCredits}
+            resetCreditsNextExpiresAt={resetCreditsNextExpiresAt}
+            expiryTooltip={resetExpiry?.absoluteText ?? null}
+          />
           <span className="shrink-0 font-medium text-foreground">
             {t(($) => {
               return $.settings.accountMenu.subscriptions.reset;
@@ -199,6 +210,43 @@ function AccountMenuSubscriptionProviderSection({
         </DropdownMenuModalItem>
       ) : null}
     </section>
+  );
+}
+
+function ResetCreditsLabel({
+  resetCredits,
+  resetCreditsNextExpiresAt,
+  expiryTooltip,
+}: {
+  readonly resetCredits?: number | null;
+  readonly resetCreditsNextExpiresAt?: string | null;
+  readonly expiryTooltip: string | null;
+}) {
+  const { t } = useTranslation();
+  // The menu is narrow enough that the inline deadline truncates, so the exact
+  // date stays reachable through the tooltip.
+  const label = (
+    <span className="min-w-0 flex-1 truncate text-muted-foreground">
+      {formatCodexResetCredits(resetCredits, resetCreditsNextExpiresAt)}
+    </span>
+  );
+
+  if (!expiryTooltip) {
+    return label;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{label}</TooltipTrigger>
+      <TooltipContent>
+        {t(
+          ($) => {
+            return $.settings.models.reset.expiresAt;
+          },
+          { date: expiryTooltip },
+        )}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/turbo/apps/platform/src/views/okou-page/subscription-usage-format.ts
+++ b/turbo/apps/platform/src/views/okou-page/subscription-usage-format.ts
@@ -58,6 +58,40 @@ export function formatSubscriptionUsageReset(
   };
 }
 
+interface ResetCreditExpiryDisplay {
+  readonly relativeText: string;
+  readonly absoluteText: string;
+}
+
+/**
+ * Reset credits are only worth a deadline while they are still redeemable, so
+ * an absent, unparseable, or already-passed expiry renders nothing at all
+ * rather than a stale "expired" label next to a positive credit count.
+ */
+export function formatCodexResetCreditExpiry(
+  expiresAt: string | null | undefined,
+): ResetCreditExpiryDisplay | null {
+  const text = expiresAt?.trim();
+  if (!text) {
+    return null;
+  }
+
+  const date = new Date(text);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const remainingMs = date.getTime() - now();
+  if (remainingMs <= 0) {
+    return null;
+  }
+
+  return {
+    relativeText: formatRelativeResetTime(remainingMs),
+    absoluteText: formatAbsoluteResetDate(date),
+  };
+}
+
 function formatAbsoluteResetDate(date: Date): string {
   const options: Intl.DateTimeFormatOptions = {
     month: "short",

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -1447,6 +1447,10 @@ export const modelProviderResponseSchema = z.object({
     .nonnegative()
     .nullable()
     .optional(),
+  // Soonest expiry among the reset credits the account can still redeem. Null
+  // when nothing expires, and also when the upstream detail read degraded to a
+  // bare count, so the UI must treat it as decoration on top of the count.
+  subscriptionResetCreditsNextExpiresAt: z.string().nullable().optional(),
   // OAuth refresh state. `needsReconnect` flips to true when the firewall's
   // refresh attempt fails (#11921 writes this on the model_providers row).
   // `lastRefreshErrorCode` carries the typed code from `ChatgptRefreshError`


### PR DESCRIPTION
Closes #31410

`N resets left` said nothing about how long those resets stay usable. Both Codex surfaces now read `N resets left · expires in 3d`.

## What changed

**API.** The expiry is not in `wham/usage` — that endpoint returns only `rate_limit_reset_credits.available_count`. It lives behind `wham/rate-limit-reset-credits`, which returns per-credit `expires_at` (ISO-8601, nullable). `fetchCodexUsageMetadata` now issues both reads in parallel, with the detail read scoped to its own 5s budget via `AbortSignal.any([signal, AbortSignal.timeout(...)])`. The caller's abort still cancels both.

Failure, timeout, or an unrecognized shape degrades to count-only through `tapError`, which re-throws real aborts (`AbortError`) but swallows the timeout (`TimeoutError`) — exactly the split this needs. That matters because this response also feeds the chat-side "Reset and try again" recovery; a decorative deadline must not be able to break or delay it.

**Contract.** `subscriptionResetCreditsNextExpiresAt` carries only the soonest expiry among credits whose `status` is `available`. The full credit array is deliberately not exposed — the UI renders one deadline, and `credit_id`-targeted redemption is not being built.

**UI.** Nothing renders when the count is zero, when the credit never expires, or when the detail read degraded. The account menu row is `w-[240px]` and the settings dropdown `w-44`, so the inline text truncates; the account menu adds a tooltip with the absolute date.

**Frontend cache.** `GET /api/me/model-providers` does a live upstream read per connected subscription and has no cache, while the account menu called `reloadPersonalModelProviders$` on *every* open. Adding a second upstream call per Codex account would have doubled that. The menu now calls `refreshPersonalModelProvidersIfStale$`, which reuses a read taken within 60s. All mutations route through one shared `forcePersonalModelProvidersReload$` sub-command that stamps the same clock, so a consumed reset still updates the count immediately.

## Decisions worth reviewing

**No API-layer cache.** `apps/api` is Vercel serverless with no Redis/KV dependency: an in-process map is per-instance and unreliable, and a durable cache needs a migration on `model_provider_accounts`. The waste is client-driven, so the cache belongs in the frontend.

**Both surfaces fetch it, not just settings.** They share one `personalModelProviders$` computed. Splitting them would mean a duplicate cache or a new endpoint, and would leave two surfaces showing different text for the same state.

**The detail call fires even at zero credits.** The count is not known until the usage response returns, so making it conditional would serialize the reads and add a round trip for users who do have credits. The 60s window is what keeps volume down.

**The cache is per tab and in memory.** A reload or a second tab starts cold, and it does not throttle other clients.

## Fallbacks

- `turbo/apps/api/src/signals/services/codex-usage.service.ts` `fetchCodexUsageMetadata` — when the `wham/rate-limit-reset-credits` read fails, exceeds its 5s budget, or returns an unrecognized shape, the response keeps `subscriptionResetCredits` and reports no expiry. Surface: none — third-party API, not a cross-version rollout. Removal condition: none; this is `docs/fallback.md` §6 category 2, genuinely optional external data. `expires_at` is documented nullable and upstream Codex applies the same count-only fallback under the same 5s budget. Without it a decorative deadline could fail or delay the usage response that the chat-side "Reset and try again" recovery depends on.

## Tests

- API: soonest-available expiry is selected across a later credit, a never-expiring credit, and a redeemed one; a 500 on the detail endpoint still returns the count with no expiry.
- Platform: expiry renders in both surfaces; suppressed at zero credits; the account menu reuses a read within 60s and refreshes past it.
- Two existing account-menu tests asserted a refetch on every reopen. They now advance mocked time past the window — that assumption is what this PR intentionally changes.
- A default MSW handler for the new endpoint was added so existing suites keep a defined boundary under `onUnhandledRequest: "error"`.

## Verification

`vitest` green on all touched suites (api model-provider + auth-device, platform account menu / providers tab / composer / run queue / run results), `prettier`, `eslint`, `knip`, `i18n:check` (10 locales at 100%), and `tsc` on platform and api-contracts. The `apps/api` type-check OOMs in this sandbox (3 GB) and is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

