### PR TITLE
refactor(platform): route instatus status polling through the shared loop helper

### DIFF
--- a/turbo/apps/platform/src/signals/instatus-status.ts
+++ b/turbo/apps/platform/src/signals/instatus-status.ts
@@ -3,7 +3,7 @@ import { delay } from "signal-timers";
 
 import { localStorageSignals } from "./external/local-storage.ts";
 import { rootSignal$ } from "./root-signal.ts";
-import { jsonParseOr } from "./utils.ts";
+import { jsonParseOr, setLoop } from "./utils.ts";
 import { resolvePlatformServiceStatusConfig } from "../lib/platform-host.ts";
 
 const STATUS_REFRESH_INTERVAL_MS = 3 * 60 * 1000;
@@ -138,11 +138,17 @@ export const pollInstatusIssues$ = command(
       return;
     }
 
-    while (!signal.aborted) {
-      await delay(STATUS_REFRESH_INTERVAL_MS, { signal });
-      set(refreshVersion$, (version) => {
-        return version + 1;
-      });
-    }
+    await setLoop(
+      async (loopSignal) => {
+        await delay(STATUS_REFRESH_INTERVAL_MS, { signal: loopSignal });
+        set(refreshVersion$, (version) => {
+          return version + 1;
+        });
+        return false;
+      },
+      0,
+      signal,
+      { retryTransientErrors: false },
+    );
   },
 );


### PR DESCRIPTION
## Violation found

The daily platform loop audit found one new violation on `main`:

- `turbo/apps/platform/src/signals/instatus-status.ts` — `pollInstatusIssues$` drove its own `while (!signal.aborted)` loop with a raw `delay` to refresh the Instatus service-status data every 3 minutes. Recurring async work in the platform must go through the shared `setLoop` helper rather than a hand-rolled polling loop.

Introduced by #30857 (`fix(platform): replace instatus widget with branded status notice`).

## Fix

Routed the recurring refresh through `setLoop`, keeping the delay inside the loop body:

```ts
await setLoop(
  async (loopSignal) => {
    await delay(STATUS_REFRESH_INTERVAL_MS, { signal: loopSignal });
    set(refreshVersion$, (version) => version + 1);
    return false;
  },
  0,
  signal,
  { retryTransientErrors: false },
);
```

## Signal ownership

- Owner is the unchanged app-root `AbortSignal` that `views/main.tsx` already passes when it detaches the daemon (`store.get(rootSignal$)`).
- The inner `delay` is bound to `loopSignal`, so both a parent abort and the loop's own teardown cancel the pending timer.
- No placeholder or never-aborting signal was introduced.

## Preserved behavior

- **Timing is unchanged.** The delay stays at the top of the loop body with `setLoop`'s own interval set to `0`, so the first refresh still lands one full `STATUS_REFRESH_INTERVAL_MS` after startup, and each subsequent refresh one interval after the previous one. Moving the delay to `setLoop`'s interval argument would have fired an extra refresh at t=0.
- **Test timing is unchanged.** `setLoop` collapses its own interval to a macrotask under Vitest; keeping the real delay in the body means this app-root daemon still ticks on the real 3-minute interval in tests instead of spinning and tripping `MAX_LOOP_COUNT_IN_TEST`.
- **Stopping conditions are unchanged.** The body always returns `false`, so the loop still terminates only on abort.
- `retryTransientErrors: false` preserves the original semantics, where any non-abort rejection propagated instead of being retried with backoff.

This matches the existing precedent in `signals/shared-database-browser.ts` (heartbeat loop) and `signals/okou-page/presentation-template-library.ts`.

## Also audited, no change needed

Every other `signal-timers` call added since the previous audit already carries a real owner signal:

- `shared-database/worker-signals.ts:225` — one-shot throttle `delay` with the caller's signal, using `now()`.
- `signals/chat-page/run-work-folding.ts` — finite array traversal, not a control-flow loop.

## Local checks

- Both audit scans re-run: the native timer scan is empty, and the loop scan now matches only the two known exemptions (`signals/utils.ts` `setLoop` itself, and the artifact cursor pagination in `create-artifact-catalog-signals.ts`).
- Prettier on the changed file: clean.
- `oxlint --deny-warnings` on the changed file: clean.
- `tsc -p tsconfig.production.json --noEmit`: no new errors (the two pre-existing module-resolution errors reproduce identically on unmodified `main` in this container).
- `vitest run src/views/router/__tests__/instatus-status-notice.test.tsx` — 5 passed.
- `vitest run src/__tests__/platform-entrypoint.test.ts` — 6 passed.

Full validation is delegated to the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
