### PR TITLE
fix(social): classify mp4 downloads by media tracks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -2293,19 +2293,60 @@ describe("managed SocialKit route", () => {
     0x00, 0x00,
   ]);
 
-  // A minimal ISO base media header: a box length, `ftyp`, then the brand.
-  function isoBaseMediaPayload(brand: string): Uint8Array {
-    const payload = new Uint8Array([
-      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00,
-    ]);
-    payload.set(
-      [...brand].map((character) => {
-        return character.charCodeAt(0);
-      }),
-      8,
+  function concatBytes(parts: readonly Uint8Array[]): Uint8Array {
+    const result = new Uint8Array(
+      parts.reduce((size, part) => {
+        return size + part.byteLength;
+      }, 0),
     );
-    return payload;
+    let offset = 0;
+    for (const part of parts) {
+      result.set(part, offset);
+      offset += part.byteLength;
+    }
+    return result;
+  }
+
+  function ascii(value: string): Uint8Array {
+    return Uint8Array.from(value, (character) => {
+      return character.charCodeAt(0);
+    });
+  }
+
+  function isoBox(type: string, payload: Uint8Array): Uint8Array {
+    const result = new Uint8Array(8 + payload.byteLength);
+    const view = new DataView(result.buffer);
+    view.setUint32(0, result.byteLength);
+    result.set(ascii(type), 4);
+    result.set(payload, 8);
+    return result;
+  }
+
+  function isoTrack(handler: "soun" | "vide"): Uint8Array {
+    const handlerPayload = new Uint8Array(12);
+    handlerPayload.set(ascii(handler), 8);
+    return isoBox("trak", isoBox("mdia", isoBox("hdlr", handlerPayload)));
+  }
+
+  // A small but structurally valid ISO base media file. Generic brands such as
+  // `isom` and `mp42` need the `hdlr` boxes to distinguish audio from video.
+  function isoBaseMediaPayload(
+    brand: string,
+    tracks: readonly ("soun" | "vide")[] = [],
+  ): Uint8Array {
+    const fileType = isoBox(
+      "ftyp",
+      concatBytes([ascii(brand), new Uint8Array(4), ascii(brand)]),
+    );
+    const movie = isoBox(
+      "moov",
+      concatBytes(
+        tracks.map((handler) => {
+          return isoTrack(handler);
+        }),
+      ),
+    );
+    return concatBytes([fileType, movie]);
   }
 
   async function completeDownloadWithPayload(
@@ -2400,13 +2441,25 @@ describe("managed SocialKit route", () => {
       contentType: "audio/mp4",
     },
     {
-      caseName: "an mp42-branded ISO container",
-      payload: isoBaseMediaPayload("mp42"),
+      caseName: "an isom-branded ISO container with only an audio track",
+      payload: isoBaseMediaPayload("isom", ["soun"]),
+      filename: "Public clip.m4a",
+      contentType: "audio/mp4",
+    },
+    {
+      caseName: "an mp42-branded ISO container with a video track",
+      payload: isoBaseMediaPayload("mp42", ["vide"]),
+      filename: "Public clip.mp4",
+      contentType: "video/mp4",
+    },
+    {
+      caseName: "an ISO container with audio and video tracks",
+      payload: isoBaseMediaPayload("isom", ["soun", "vide"]),
       filename: "Public clip.mp4",
       contentType: "video/mp4",
     },
   ])(
-    "files $caseName by its detected container once the switch is on",
+    "files $caseName by its detected media once the switch is on",
     async ({ payload, filename, contentType }) => {
       const actor = createBddApi(context).user();
       if (!actor.orgId) {

--- a/turbo/apps/api/src/signals/services/socialkit-download.service.ts
+++ b/turbo/apps/api/src/signals/services/socialkit-download.service.ts
@@ -61,9 +61,10 @@ const MAX_PROVIDER_RESPONSE_BYTES = 1024 * 1024;
 const MULTIPART_PART_BYTES = 8 * 1024 * 1024;
 const MAX_DOWNLOAD_BYTES = 2 * 1024 * 1024 * 1024;
 const MAX_ARTIFACT_FILENAME_STEM_CHARS = 120;
-// Enough for the ISO base media `ftyp` brand, which sits at offset 8 and is the
-// longest signature this service inspects.
-const MEDIA_SNIFF_BYTES = 12;
+// ISO base media files can use a generic `ftyp` brand for either audio or
+// video. Buffer enough of a fast-start file to inspect the `moov` track
+// handlers before allocating the immutable artifact key.
+const MEDIA_SNIFF_BYTES = 64 * 1024;
 const MAX_PROVIDER_FAILURE_CODE_CHARS = 128;
 const MAX_PROVIDER_FAILURE_MESSAGE_CHARS = 500;
 const INVALID_ARTIFACT_FILENAME_CHARS = String.raw`<>:"/\|?*`;
@@ -406,6 +407,15 @@ interface SniffedMedia {
   readonly extension: string;
 }
 
+type IsoTrackKind = "audio" | "video";
+type IsoContainerKind = "root" | "moov" | "trak" | "mdia";
+
+interface IsoBox {
+  readonly type: string;
+  readonly payloadStart: number;
+  readonly end: number;
+}
+
 function leadingBytesAre(
   head: Uint8Array,
   offset: number,
@@ -422,22 +432,140 @@ function leadingBytesAre(
   return true;
 }
 
+function readUint32(bytes: Uint8Array, offset: number): number | null {
+  if (offset + 4 > bytes.byteLength) {
+    return null;
+  }
+  return (
+    (bytes[offset]! * 0x01_00_00_00 +
+      bytes[offset + 1]! * 0x01_00_00 +
+      bytes[offset + 2]! * 0x01_00 +
+      bytes[offset + 3]!) >>>
+    0
+  );
+}
+
+function readIsoBox(
+  bytes: Uint8Array,
+  offset: number,
+  parentEnd: number,
+): IsoBox | null {
+  const size = readUint32(bytes, offset);
+  if (size === null || offset + 8 > parentEnd) {
+    return null;
+  }
+  const type = String.fromCharCode(...bytes.subarray(offset + 4, offset + 8));
+  let headerSize = 8;
+  let boxSize = size;
+  if (size === 1) {
+    const high = readUint32(bytes, offset + 8);
+    const low = readUint32(bytes, offset + 12);
+    if (high === null || low === null) {
+      return null;
+    }
+    boxSize = high * 0x01_00_00_00_00 + low;
+    headerSize = 16;
+  } else if (size === 0) {
+    boxSize = parentEnd - offset;
+  }
+  if (
+    !Number.isSafeInteger(boxSize) ||
+    boxSize < headerSize ||
+    offset + boxSize > parentEnd
+  ) {
+    return null;
+  }
+  return {
+    type,
+    payloadStart: offset + headerSize,
+    end: offset + boxSize,
+  };
+}
+
+function isoHandlerTrackKind(
+  bytes: Uint8Array,
+  box: IsoBox,
+): IsoTrackKind | null {
+  const handlerOffset = box.payloadStart + 8;
+  if (handlerOffset + 4 > box.end) {
+    return null;
+  }
+  if (leadingBytesAre(bytes, handlerOffset, "vide")) {
+    return "video";
+  }
+  return leadingBytesAre(bytes, handlerOffset, "soun") ? "audio" : null;
+}
+
+function collectIsoTrackKinds(
+  bytes: Uint8Array,
+  start: number,
+  end: number,
+  container: IsoContainerKind,
+  tracks: Set<IsoTrackKind>,
+): void {
+  let offset = start;
+  while (offset + 8 <= end) {
+    const box = readIsoBox(bytes, offset, end);
+    if (!box) {
+      return;
+    }
+    if (container === "mdia" && box.type === "hdlr") {
+      const track = isoHandlerTrackKind(bytes, box);
+      if (track) {
+        tracks.add(track);
+      }
+    } else {
+      const childContainer =
+        container === "root" && box.type === "moov"
+          ? "moov"
+          : container === "moov" && box.type === "trak"
+            ? "trak"
+            : container === "trak" && box.type === "mdia"
+              ? "mdia"
+              : null;
+      if (childContainer) {
+        collectIsoTrackKinds(
+          bytes,
+          box.payloadStart,
+          box.end,
+          childContainer,
+          tracks,
+        );
+      }
+    }
+    offset = box.end;
+  }
+}
+
+function sniffIsoMedia(head: Uint8Array): SniffedMedia | null {
+  const tracks = new Set<IsoTrackKind>();
+  collectIsoTrackKinds(head, 0, head.byteLength, "root", tracks);
+  if (tracks.has("video")) {
+    return { contentType: "video/mp4", extension: "mp4" };
+  }
+  if (tracks.has("audio")) {
+    return { contentType: "audio/mp4", extension: "m4a" };
+  }
+  return leadingBytesAre(head, 8, "M4A") || leadingBytesAre(head, 8, "M4B")
+    ? { contentType: "audio/mp4", extension: "m4a" }
+    : null;
+}
+
 /**
  * SocialKit echoes back only the format that was requested, and the artifact CDN
- * carries no trustworthy media type, so the container is read from the leading
- * bytes instead. A `format=mp4` request can still resolve to an audio-only file
- * upstream, and filing those bytes as `video/mp4` leaves an artifact that no
- * video consumer can decode. Returns null when the container is unrecognized,
- * which keeps the requested format as the recorded media type.
+ * carries no trustworthy media type, so the container and available track
+ * handlers are read from the leading file structure instead. A `format=mp4`
+ * request can still resolve to an audio-only file upstream, and filing those
+ * bytes as `video/mp4` leaves an artifact that no video consumer can decode.
+ * Returns null when the media is unrecognized, which keeps the requested format
+ * as the recorded media type.
  */
 function sniffMedia(head: Uint8Array): SniffedMedia | null {
   if (leadingBytesAre(head, 0, "ID3")) {
     return { contentType: "audio/mpeg", extension: "mp3" };
   }
   if (leadingBytesAre(head, 4, "ftyp")) {
-    return leadingBytesAre(head, 8, "M4A") || leadingBytesAre(head, 8, "M4B")
-      ? { contentType: "audio/mp4", extension: "m4a" }
-      : { contentType: "video/mp4", extension: "mp4" };
+    return sniffIsoMedia(head);
   }
   // MPEG audio frame sync: eleven set bits followed by a non-reserved layer.
   const sync = head[1];
@@ -501,7 +629,7 @@ async function fetchSafeSocialKitArtifact(
 
 interface ArtifactDownload {
   readonly reader: ReadableStreamDefaultReader<Uint8Array>;
-  // The leading bytes already pulled off the stream to identify the container.
+  // The leading bytes already pulled off the stream to identify the media.
   // The upload consumes them before draining the rest of the reader.
   readonly head: Uint8Array;
   readonly media: SniffedMedia | null;
@@ -526,10 +654,10 @@ async function readMediaHead(
 }
 
 /**
- * Start the artifact download and read just enough of it to identify the
- * container. The filename and content type are decided from this before the
- * artifact object is allocated, and the same open stream then carries the whole
- * body into R2, so the artifact is fetched exactly once.
+ * Start the artifact download and read a bounded prefix to identify its media.
+ * The filename and content type are decided from this before the artifact object
+ * is allocated, and the same open stream then carries the whole body into R2,
+ * so the artifact is fetched exactly once.
  *
  * The caller owns the returned reader and must cancel it on every path that
  * does not hand it to `streamDownloadToArtifact$`.

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -340,7 +340,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.SocialDownloadDetectedMediaType]: {
     maintainer: "bingjie@vm0.ai",
     description:
-      "File a social download by the container detected from its leading bytes instead of the requested format, so an audio-only result stops being recorded as video/mp4.",
+      "File a social download by the media kind detected from its leading file structure instead of the requested format, so an audio-only result stops being recorded as video/mp4.",
     enabled: false,
     // Staff first: this decides the stored filename and content type, and the
     // extension is baked into the public artifact URL, so widen only after real


### PR DESCRIPTION
## Summary

- inspect ISO BMFF `hdlr` boxes instead of treating every generic `ftyp` brand as video
- file audio-only MP4 containers as `.m4a` / `audio/mp4`, while preserving video precedence for mixed-track files
- keep `SocialDownloadDetectedMediaType` staff-only and fall back to the requested format when the bounded prefix is inconclusive

This is the producer-side slice of #30961. It prevents SocialKit audio results from being persisted as `video/mp4` and subsequently sent to Cloudflare video transforms.

## Fallbacks

- `sniffIsoMedia` / `materializeSocialKitArtifact$` retain the provider-requested extension and content type when the bounded prefix cannot conclusively identify the ISO track kind. This handles genuinely inconclusive third-party SocialKit media while `SocialDownloadDetectedMediaType` remains staff-only and non-GA, so there is no cross-version rollout surface. The fallback is intentionally retained until SocialKit supplies a trustworthy media type or the artifact path can inspect the complete container before allocating its immutable key; follow-up: #30961.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/socialkit-download.service.ts apps/api/src/signals/routes/__tests__/social.test.ts packages/core/src/feature-switch.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres pnpm -F api exec vitest run src/signals/routes/__tests__/social.test.ts -t "detected media|same artifact while the switch is off|unrecognized container"` (8 passed)
