### PR TITLE
fix(api): recover artifact preview navigation timeouts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -52,6 +52,12 @@ interface SnapshotRequest {
 
 interface SnapshotFixture {
   readonly content?: string;
+  readonly error?: {
+    readonly code: number;
+    readonly detail: string;
+    readonly message: string;
+    readonly status: number;
+  };
   readonly screenshot?: string;
   readonly status?: number;
   readonly title?: string;
@@ -62,7 +68,7 @@ interface MediaFrameRequest {
 }
 
 function mockCloudflareSnapshot(
-  fixture: SnapshotFixture = {},
+  fixtures: readonly SnapshotFixture[] = [{}],
 ): SnapshotRequest[] {
   const requests: SnapshotRequest[] = [];
   server.use(
@@ -72,6 +78,27 @@ function mockCloudflareSnapshot(
         url: request.url,
         body: await request.json(),
       });
+      const fixture = fixtures[requests.length - 1];
+      if (!fixture) {
+        throw new Error("Missing Cloudflare snapshot fixture");
+      }
+      if (fixture.error) {
+        return HttpResponse.json(
+          {
+            success: false,
+            errors: [
+              {
+                code: fixture.error.code,
+                message: fixture.error.message,
+                detail: fixture.error.detail,
+              },
+            ],
+            messages: [],
+            result: null,
+          },
+          { status: fixture.error.status },
+        );
+      }
       return HttpResponse.json({
         meta: {
           status: fixture.status ?? 200,
@@ -615,6 +642,8 @@ describe("hosted Artifact previews", () => {
           height: 800,
           deviceScaleFactor: 0.5,
         },
+        gotoOptions: { waitUntil: "networkidle2", timeout: 20_000 },
+        actionTimeout: 30_000,
         screenshotOptions: { type: "webp", quality: 80 },
       },
     });
@@ -640,15 +669,98 @@ describe("hosted Artifact previews", () => {
     expect(snapshotRequests).toHaveLength(1);
   }, 120_000);
 
+  it("retries navigation timeouts once with explicit DOM readiness", async () => {
+    const owner = await artifactActor("Artifacts API navigation retry agent");
+    mockEnv("CLOUDFLARE_BROWSER_RENDERING_API_TOKEN", "preview-token");
+    mockEnv("ARTIFACT_PREVIEW_WAF_SECRET", ARTIFACT_PREVIEW_WAF_SECRET);
+    const snapshotRequests = mockCloudflareSnapshot([
+      {
+        error: {
+          code: 6002,
+          message:
+            "A timeout was reached. Check gotoOptions/waitForSelector/waitForTimeout/actionTimeout options.",
+          detail: "Navigation timeout of 20000 ms exceeded",
+          status: 422,
+        },
+      },
+      {},
+    ]);
+    const site = `navigation-retry-${randomUUID().slice(0, 8)}`;
+
+    await createHostedArtifact({
+      actor: owner.actor,
+      agentId: owner.agentId,
+      runnerGroup: owner.runnerGroup,
+      site,
+    });
+    await flushWaitUntilForTest();
+
+    expect(snapshotRequests).toHaveLength(2);
+    expect(snapshotRequests[0]?.body).toMatchObject({
+      gotoOptions: { waitUntil: "networkidle2", timeout: 20_000 },
+      actionTimeout: 30_000,
+    });
+    expect(snapshotRequests[1]?.body).toMatchObject({
+      gotoOptions: { waitUntil: "domcontentloaded", timeout: 15_000 },
+      waitForSelector: {
+        selector: "body > *",
+        visible: true,
+        timeout: 10_000,
+      },
+      actionTimeout: 30_000,
+    });
+    const previewedArtifact = await findCatalogArtifact(owner.actor, site);
+    expect(previewedArtifact?.thumbnail?.url).toMatch(
+      /\/artifacts\/[0-9a-z]{10}\.webp$/u,
+    );
+  }, 120_000);
+
+  it("does not retry non-navigation browser rendering timeouts", async () => {
+    const owner = await artifactActor("Artifacts API screenshot timeout agent");
+    mockEnv("CLOUDFLARE_BROWSER_RENDERING_API_TOKEN", "preview-token");
+    mockEnv("ARTIFACT_PREVIEW_WAF_SECRET", ARTIFACT_PREVIEW_WAF_SECRET);
+    const snapshotRequests = mockCloudflareSnapshot([
+      {
+        error: {
+          code: 6002,
+          message:
+            "A timeout was reached. Check gotoOptions/waitForSelector/waitForTimeout/actionTimeout options.",
+          detail: "Screenshot timed out after 30000 ms",
+          status: 422,
+        },
+      },
+    ]);
+    const site = `screenshot-timeout-${randomUUID().slice(0, 8)}`;
+
+    const artifact = await createHostedArtifact({
+      actor: owner.actor,
+      agentId: owner.agentId,
+      runnerGroup: owner.runnerGroup,
+      site,
+    });
+    await flushWaitUntilForTest();
+
+    expect(snapshotRequests).toHaveLength(1);
+    const unpreviewedArtifact = await findCatalogArtifact(owner.actor, site);
+    expect(unpreviewedArtifact?.thumbnail).toBeNull();
+    expect(
+      owner.objectStore.puts.some((put) => {
+        return put.key.endsWith(`/preview-v3-${artifact.deploymentId}.webp`);
+      }),
+    ).toBeFalsy();
+  }, 120_000);
+
   it("rejects page errors and Cloudflare challenges instead of saving them as previews", async () => {
     const owner = await artifactActor("Artifacts API challenge preview agent");
     mockEnv("CLOUDFLARE_BROWSER_RENDERING_API_TOKEN", "preview-token");
     mockEnv("ARTIFACT_PREVIEW_WAF_SECRET", ARTIFACT_PREVIEW_WAF_SECRET);
-    const pageErrorRequests = mockCloudflareSnapshot({
-      status: 403,
-      title: "Forbidden",
-      content: "<!doctype html><html><body>forbidden</body></html>",
-    });
+    const pageErrorRequests = mockCloudflareSnapshot([
+      {
+        status: 403,
+        title: "Forbidden",
+        content: "<!doctype html><html><body>forbidden</body></html>",
+      },
+    ]);
     const pageErrorSite = `error-preview-${randomUUID().slice(0, 8)}`;
 
     const pageErrorArtifact = await createHostedArtifact({
@@ -659,11 +771,13 @@ describe("hosted Artifact previews", () => {
     });
     await flushWaitUntilForTest();
 
-    const challengeRequests = mockCloudflareSnapshot({
-      title: "Just a moment...",
-      content:
-        "<!doctype html><html><body><h1>Performing security verification</h1><p>Incompatible browser extension or network configuration</p><script>window.__cf_chl_opt={}</script></body></html>",
-    });
+    const challengeRequests = mockCloudflareSnapshot([
+      {
+        title: "Just a moment...",
+        content:
+          "<!doctype html><html><body><h1>Performing security verification</h1><p>Incompatible browser extension or network configuration</p><script>window.__cf_chl_opt={}</script></body></html>",
+      },
+    ]);
     const challengeSite = `challenge-preview-${randomUUID().slice(0, 8)}`;
 
     const challengeArtifact = await createHostedArtifact({

--- a/turbo/apps/api/src/signals/services/artifact-preview.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-preview.service.ts
@@ -11,7 +11,7 @@ import { nowDate } from "../../lib/time";
 import { waitUntil } from "../context/wait-until";
 import { writeDb$ } from "../external/db";
 import { putImmutableS3Object } from "../external/s3";
-import { tapError } from "../utils";
+import { safeJsonParse, tapError } from "../utils";
 import { allocateArtifactObject$ } from "./artifact-storage.service";
 import { syncArtifactCatalogForFile$ } from "./artifact-catalog.service";
 import { publishArtifactsChangedForRun } from "./artifact-realtime.service";
@@ -30,6 +30,18 @@ const PREVIEW_IMAGE_CONTENT_TYPE = "image/webp";
 const PREVIEW_IMAGE_EXTENSION = "webp";
 const PREVIEW_IMAGE_BASENAME = "preview-v3";
 const PREVIEW_WAF_COOKIE_NAME = "vm0_artifact_preview";
+const SNAPSHOT_ACTION_TIMEOUT_MS = 30_000;
+const PRIMARY_NAVIGATION_OPTIONS = {
+  gotoOptions: { waitUntil: "networkidle2", timeout: 20_000 },
+} as const;
+const NAVIGATION_TIMEOUT_RETRY_OPTIONS = {
+  gotoOptions: { waitUntil: "domcontentloaded", timeout: 15_000 },
+  waitForSelector: {
+    selector: "body > *",
+    visible: true,
+    timeout: 10_000,
+  },
+} as const;
 
 const browserSnapshotSchema = z.object({
   meta: z.object({
@@ -41,6 +53,15 @@ const browserSnapshotSchema = z.object({
     content: z.string().min(1),
     screenshot: z.string().min(1),
   }),
+});
+
+const browserSnapshotErrorSchema = z.object({
+  errors: z.array(
+    z.object({
+      code: z.number(),
+      detail: z.string().optional(),
+    }),
+  ),
 });
 
 // Poster versions are write-once. Renderer changes must use a new filename
@@ -127,25 +148,51 @@ function isCloudflareChallenge(content: string, title?: string): boolean {
   return hasChallengeCopy && hasChallengeImplementation;
 }
 
-async function renderArtifactSnapshot(
-  token: string,
-  wafSecret: string,
-  url: string,
-  signal: AbortSignal,
-): Promise<Buffer> {
-  const previewUrl = new URL(url);
-  const hostDomains = [env("ZERO_HOST_DOMAIN"), env("OKOU_PUBLIC_HOST_DOMAIN")];
-  if (
-    previewUrl.protocol !== "https:" ||
-    !hostDomains.some((hostDomain) => {
-      return previewUrl.hostname.endsWith(`.${hostDomain}`);
-    })
-  ) {
-    throw new Error("artifact preview URL must use a hosted-site domain");
+function isNavigationTimeoutResponse(
+  status: number,
+  responseBody: string,
+): boolean {
+  if (status !== 422) {
+    return false;
   }
+  const parsed = browserSnapshotErrorSchema.safeParse(
+    safeJsonParse(responseBody),
+  );
+  return (
+    parsed.success &&
+    parsed.data.errors.some((error) => {
+      return (
+        error.code === 6002 &&
+        error.detail?.startsWith("Navigation timeout") === true
+      );
+    })
+  );
+}
 
+type SnapshotNavigationOptions =
+  | typeof PRIMARY_NAVIGATION_OPTIONS
+  | typeof NAVIGATION_TIMEOUT_RETRY_OPTIONS;
+
+interface FetchArtifactSnapshotArgs {
+  readonly token: string;
+  readonly wafSecret: string;
+  readonly url: string;
+  readonly previewUrl: URL;
+  readonly navigationOptions: SnapshotNavigationOptions;
+}
+
+function fetchArtifactSnapshot(
+  {
+    token,
+    wafSecret,
+    url,
+    previewUrl,
+    navigationOptions,
+  }: FetchArtifactSnapshotArgs,
+  signal: AbortSignal,
+): Promise<Response> {
   const accountId = env("R2_ACCOUNT_ID");
-  const response = await fetch(
+  return fetch(
     `https://api.cloudflare.com/client/v4/accounts/${accountId}/browser-rendering/snapshot?cacheTTL=0`,
     {
       method: "POST",
@@ -167,12 +214,62 @@ async function renderArtifactSnapshot(
         ],
         formats: ["content", "screenshot"],
         viewport: PREVIEW_VIEWPORT,
-        gotoOptions: { waitUntil: "networkidle0" },
+        ...navigationOptions,
+        actionTimeout: SNAPSHOT_ACTION_TIMEOUT_MS,
         screenshotOptions: { type: "webp", quality: 80 },
       }),
       signal,
     },
   );
+}
+
+async function renderArtifactSnapshot(
+  token: string,
+  wafSecret: string,
+  url: string,
+  signal: AbortSignal,
+): Promise<Buffer> {
+  const previewUrl = new URL(url);
+  const hostDomains = [env("ZERO_HOST_DOMAIN"), env("OKOU_PUBLIC_HOST_DOMAIN")];
+  if (
+    previewUrl.protocol !== "https:" ||
+    !hostDomains.some((hostDomain) => {
+      return previewUrl.hostname.endsWith(`.${hostDomain}`);
+    })
+  ) {
+    throw new Error("artifact preview URL must use a hosted-site domain");
+  }
+
+  let response = await fetchArtifactSnapshot(
+    {
+      token,
+      wafSecret,
+      url,
+      previewUrl,
+      navigationOptions: PRIMARY_NAVIGATION_OPTIONS,
+    },
+    signal,
+  );
+  if (!response.ok) {
+    const responseBody = await response.text();
+    // Keep the extra Browser Rendering request exclusive to navigation: action
+    // and request-stage timeouts need different fixes and should not double cost.
+    if (!isNavigationTimeoutResponse(response.status, responseBody)) {
+      throw new Error(
+        `browser-rendering snapshot failed (${response.status}): ${responseBody}`,
+      );
+    }
+    response = await fetchArtifactSnapshot(
+      {
+        token,
+        wafSecret,
+        url,
+        previewUrl,
+        navigationOptions: NAVIGATION_TIMEOUT_RETRY_OPTIONS,
+      },
+      signal,
+    );
+  }
   if (!response.ok) {
     throw new Error(
       `browser-rendering snapshot failed (${response.status}): ${await response.text()}`,


### PR DESCRIPTION
## Summary

- replace the artifact snapshot's normal `networkidle0` wait with a bounded `networkidle2` wait
- retry exactly once with `domcontentloaded` plus visible body content only for Cloudflare HTTP 422 / code 6002 navigation timeouts
- preserve the existing page-status and Cloudflare Challenge rejection checks, while leaving request and screenshot failures single-attempt

## Cost and safety

- successful previews still use one Browser Rendering request
- navigation timeouts use at most two requests
- request-stage and screenshot-stage failures still use one request
- the retry completes before any R2 upload or database write, so it cannot duplicate preview persistence

## Test plan

- [x] `pnpm -F api exec vitest run src/signals/routes/__tests__/artifacts.bdd.test.ts -t "hosted Artifact previews"` (5 passed)
- [x] `pnpm -F api lint`
- [x] `pnpm -F api check-types`
- [x] `pnpm exec prettier --check apps/api/src/signals/services/artifact-preview.service.ts apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts`

Refs #30962
