### PR TITLE
fix(e2e): recover stalled onboarding bootstrap

### DIFF
--- a/e2e/playwright/lib/clerk-readiness.test.ts
+++ b/e2e/playwright/lib/clerk-readiness.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./clerk-readiness";
 
 const BOOTSTRAPPING_APP: ClerkReadinessState = {
-  bootstrapSkeletonPresent: true,
+  bootstrapSkeleton: "active",
   client: "absent",
   organizationId: null,
   readyState: "complete",
@@ -21,7 +21,7 @@ const BOOTSTRAPPING_APP: ClerkReadinessState = {
 };
 
 const SIGNED_OUT_CLIENT: ClerkReadinessState = {
-  bootstrapSkeletonPresent: false,
+  bootstrapSkeleton: "removed",
   client: "loaded",
   organizationId: null,
   readyState: "complete",
@@ -48,7 +48,7 @@ test("a stalled Clerk bootstrap is described by its observed state", async (cont
       state: BOOTSTRAPPING_APP,
     });
     assert.match(stalled, /client=absent/u);
-    assert.match(stalled, /bootstrapSkeleton=present/u);
+    assert.match(stalled, /bootstrapSkeleton=active/u);
 
     const signedOut = describeClerkReadiness({
       kind: "observed",

--- a/e2e/playwright/lib/clerk-readiness.ts
+++ b/e2e/playwright/lib/clerk-readiness.ts
@@ -10,7 +10,7 @@ import { errors } from "@playwright/test";
  * Recording the observed state at the timeout keeps those causes separable.
  */
 export interface ClerkReadinessState {
-  readonly bootstrapSkeletonPresent: boolean;
+  readonly bootstrapSkeleton: "active" | "hidden" | "removed";
   readonly client: "absent" | "loaded" | "loading";
   readonly organizationId: string | null;
   readonly readyState: string;
@@ -38,7 +38,7 @@ export function describeClerkReadiness(report: ClerkReadinessReport): string {
     `client=${state.client}`,
     `session=${state.sessionPresent ? "present" : "absent"}`,
     `organization=${state.organizationId ?? "none"}`,
-    `bootstrapSkeleton=${state.bootstrapSkeletonPresent ? "present" : "removed"}`,
+    `bootstrapSkeleton=${state.bootstrapSkeleton}`,
     `readyState=${state.readyState}`,
     `route=${state.route}`,
   ].join(" ");
@@ -50,9 +50,15 @@ export async function captureClerkReadiness(
   try {
     const state = await page.evaluate((): ClerkReadinessState => {
       const clerk = window.Clerk;
+      const bootstrapSkeleton = document.getElementById(
+        "app-bootstrap-skeleton",
+      );
       return {
-        bootstrapSkeletonPresent:
-          document.getElementById("app-bootstrap-skeleton") !== null,
+        bootstrapSkeleton: bootstrapSkeleton
+          ? bootstrapSkeleton.getAttribute("aria-hidden") === "true"
+            ? "hidden"
+            : "active"
+          : "removed",
         client: clerk ? (clerk.loaded ? "loaded" : "loading") : "absent",
         organizationId: clerk?.organization?.id ?? null,
         readyState: document.readyState,

--- a/e2e/playwright/lib/onboarding.test.ts
+++ b/e2e/playwright/lib/onboarding.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import {
+  createServer,
+  type RequestListener,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { test } from "node:test";
+
+import { chromium } from "@playwright/test";
+
+import { startVideoOnboardingCheckout } from "./onboarding";
+
+interface TestServer {
+  readonly origin: string;
+  readonly server: Server;
+}
+
+test(
+  "video onboarding recovers a deep link stalled on the app bootstrap skeleton",
+  { timeout: 60_000 },
+  async () => {
+    let videoTemplateRequests = 0;
+    const browser = await chromium.launch();
+    try {
+      const fixture = await listen((request, response) => {
+        const url = new URL(request.url ?? "/", "http://fixture.invalid");
+        if (url.pathname === "/onboarding") {
+          sendHtml(response, "<h1>What do you want to make first</h1>");
+          return;
+        }
+        if (url.pathname === "/onboarding/video-template") {
+          videoTemplateRequests += 1;
+          if (videoTemplateRequests === 1) {
+            sendHtml(
+              response,
+              '<div id="app-bootstrap-skeleton" role="status">Loading</div>',
+            );
+            return;
+          }
+          sendHtml(
+            response,
+            [
+              "<h1>Pick a video template to start from</h1>",
+              "<button aria-pressed=\"false\" onclick=\"this.setAttribute('aria-pressed', 'true')\">Video template</button>",
+              "<button onclick=\"location.href='/onboarding/video-run'\">Continue</button>",
+            ].join(""),
+          );
+          return;
+        }
+        if (url.pathname === "/onboarding/video-run") {
+          sendHtml(
+            response,
+            [
+              "<h1>Customize your video</h1>",
+              "<button onclick=\"location.href='https://checkout.stripe.com/test-session'\">Upgrade Pro to run</button>",
+            ].join(""),
+          );
+          return;
+        }
+        response.writeHead(404).end();
+      });
+      try {
+        const page = await browser.newPage();
+        try {
+          await page.route("https://checkout.stripe.com/**", (route) =>
+            route.fulfill({ contentType: "text/html", body: "Checkout" }),
+          );
+
+          await startVideoOnboardingCheckout(page, { appUrl: fixture.origin });
+
+          assert.equal(videoTemplateRequests, 2);
+          assert.equal(
+            new URL(page.url()).origin,
+            "https://checkout.stripe.com",
+          );
+        } finally {
+          await page.close();
+        }
+      } finally {
+        await close(fixture.server);
+      }
+    } finally {
+      await browser.close();
+    }
+  },
+);
+
+async function listen(handler: RequestListener): Promise<TestServer> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    const handleError = (error: Error): void => reject(error);
+    server.once("error", handleError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", handleError);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await close(server);
+    throw new Error("Fixture server did not expose a TCP address");
+  }
+  return { origin: `http://127.0.0.1:${address.port}`, server };
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function sendHtml(response: ServerResponse, body: string): void {
+  response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+  response.end(`<!doctype html><html><body>${body}</body></html>`);
+}

--- a/e2e/playwright/lib/onboarding.test.ts
+++ b/e2e/playwright/lib/onboarding.test.ts
@@ -86,6 +86,46 @@ test(
   },
 );
 
+test(
+  "video onboarding does not retry a rendered route failure",
+  { timeout: 30_000 },
+  async () => {
+    let videoTemplateRequests = 0;
+    const browser = await chromium.launch();
+    try {
+      const fixture = await listen((request, response) => {
+        const url = new URL(request.url ?? "/", "http://fixture.invalid");
+        if (url.pathname === "/onboarding") {
+          sendHtml(response, "<h1>What do you want to make first</h1>");
+          return;
+        }
+        if (url.pathname === "/onboarding/video-template") {
+          videoTemplateRequests += 1;
+          sendHtml(response, "<main>Rendered unexpected page</main>");
+          return;
+        }
+        response.writeHead(404).end();
+      });
+      try {
+        const page = await browser.newPage();
+        try {
+          await assert.rejects(
+            startVideoOnboardingCheckout(page, { appUrl: fixture.origin }),
+            /bootstrapSkeleton=removed/u,
+          );
+          assert.equal(videoTemplateRequests, 1);
+        } finally {
+          await page.close();
+        }
+      } finally {
+        await close(fixture.server);
+      }
+    } finally {
+      await browser.close();
+    }
+  },
+);
+
 async function listen(handler: RequestListener): Promise<TestServer> {
   const server = createServer(handler);
   await new Promise<void>((resolve, reject) => {

--- a/e2e/playwright/lib/onboarding.ts
+++ b/e2e/playwright/lib/onboarding.ts
@@ -144,7 +144,7 @@ async function openVideoTemplatePicker(page: Page, url: URL): Promise<void> {
         currentUrl.origin === url.origin &&
         currentUrl.pathname === url.pathname &&
         report.kind === "observed" &&
-        report.state.bootstrapSkeletonPresent;
+        report.state.bootstrapSkeleton === "active";
       if (shouldRetry) {
         console.warn(
           `[e2e] Authenticated app bootstrap stalled; retrying video-template navigation. Observed Clerk state: ${describeClerkReadiness(report)}`,

--- a/e2e/playwright/lib/onboarding.ts
+++ b/e2e/playwright/lib/onboarding.ts
@@ -1,4 +1,11 @@
-import { expect, type Page } from "@playwright/test";
+import { errors, expect, type Page } from "@playwright/test";
+
+import {
+  captureClerkReadiness,
+  describeClerkReadiness,
+} from "./clerk-readiness";
+
+const VIDEO_TEMPLATE_BOOTSTRAP_TIMEOUTS_MS = [15_000, 30_000] as const;
 
 type AuthHeaders = Readonly<
   Record<"Authorization", string> &
@@ -90,14 +97,7 @@ export async function startVideoOnboardingCheckout(
     "/onboarding/video-template?choice=video",
     options.appUrl,
   );
-  await page.goto(videoTemplateUrl.toString(), {
-    waitUntil: "domcontentloaded",
-  });
-  await expect(
-    page.getByRole("heading", {
-      name: /pick a video template to start from/i,
-    }),
-  ).toBeVisible({ timeout: 30_000 });
+  await openVideoTemplatePicker(page, videoTemplateUrl);
   expect(new URL(page.url()).pathname).toBe("/onboarding/video-template");
 
   // The template pickers no longer pre-select a default, so a template must be
@@ -117,6 +117,47 @@ export async function startVideoOnboardingCheckout(
 
   await clickOnboardingButton(page, /^Upgrade Pro to run$/i);
   await expect(page).toHaveURL(/checkout\.stripe\.com/, { timeout: 60_000 });
+}
+
+async function openVideoTemplatePicker(page: Page, url: URL): Promise<void> {
+  const heading = page.getByRole("heading", {
+    name: /pick a video template to start from/i,
+  });
+
+  for (const [
+    attempt,
+    timeout,
+  ] of VIDEO_TEMPLATE_BOOTSTRAP_TIMEOUTS_MS.entries()) {
+    await page.goto(url.toString(), { waitUntil: "domcontentloaded" });
+    try {
+      await heading.waitFor({ state: "visible", timeout });
+      return;
+    } catch (error: unknown) {
+      if (!(error instanceof errors.TimeoutError)) {
+        throw error;
+      }
+
+      const report = await captureClerkReadiness(page);
+      const currentUrl = new URL(page.url());
+      const shouldRetry =
+        attempt < VIDEO_TEMPLATE_BOOTSTRAP_TIMEOUTS_MS.length - 1 &&
+        currentUrl.origin === url.origin &&
+        currentUrl.pathname === url.pathname &&
+        report.kind === "observed" &&
+        report.state.bootstrapSkeletonPresent;
+      if (shouldRetry) {
+        console.warn(
+          `[e2e] Authenticated app bootstrap stalled; retrying video-template navigation. Observed Clerk state: ${describeClerkReadiness(report)}`,
+        );
+        continue;
+      }
+
+      throw new Error(
+        `Timed out waiting for the video-template page to render. Observed Clerk state: ${describeClerkReadiness(report)}`,
+        { cause: error },
+      );
+    }
+  }
 }
 
 export async function waitForPaidOnboardingCompletion(

--- a/e2e/playwright/runner-token.ts
+++ b/e2e/playwright/runner-token.ts
@@ -8,6 +8,7 @@ import { refreshClerkSessionToken, signInWithClerkEmailCode } from "./lib/auth";
 import { issueCliToken } from "./lib/cli-token";
 import { runnerTestAccounts } from "./lib/clerk-api";
 import { formatErrorReport } from "./lib/error-report";
+import { captureClerkReadiness } from "./lib/clerk-readiness";
 import {
   ensureRunnerOrganizationReady,
   startVideoOnboardingCheckout,
@@ -194,14 +195,15 @@ async function completePaidOnboarding(
   appUrl: string,
   outputDirectory: string,
 ): Promise<void> {
-  await startVideoOnboardingCheckout(page, { appUrl });
   try {
+    await startVideoOnboardingCheckout(page, { appUrl });
     await fillStripeCheckout(page);
+    await waitForPaidOnboardingCompletion(page, { appUrl });
   } catch (error: unknown) {
     try {
-      await captureStripeCheckoutFailure(page, target, outputDirectory);
+      await capturePaidOnboardingFailure(page, target, outputDirectory);
     } catch (diagnosticError: unknown) {
-      console.error("Unable to capture Stripe Checkout diagnostics", {
+      console.error("Unable to capture paid onboarding diagnostics", {
         diagnosticErrorType:
           diagnosticError instanceof Error
             ? diagnosticError.name
@@ -211,10 +213,9 @@ async function completePaidOnboarding(
     }
     throw error;
   }
-  await waitForPaidOnboardingCompletion(page, { appUrl });
 }
 
-async function captureStripeCheckoutFailure(
+async function capturePaidOnboardingFailure(
   page: Page,
   target: RunnerCredentialTarget,
   outputDirectory: string,
@@ -227,7 +228,7 @@ async function captureStripeCheckoutFailure(
   await mkdir(diagnosticDirectory, { recursive: true });
 
   const results = await Promise.allSettled([
-    writeStripeCheckoutState(
+    writePaidOnboardingState(
       page,
       join(diagnosticDirectory, `${fileStem}.json`),
     ),
@@ -237,15 +238,25 @@ async function captureStripeCheckoutFailure(
     }),
   ]);
   if (!results.some((result) => result.status === "fulfilled")) {
-    throw new Error("Unable to capture any Stripe Checkout diagnostic");
+    throw new Error("Unable to capture any paid onboarding diagnostic");
   }
 }
 
-async function writeStripeCheckoutState(
+async function writePaidOnboardingState(
   page: Page,
   path: string,
 ): Promise<void> {
-  const state = await collectStripeCheckoutState(page);
+  const [stripeResult, clerk] = await Promise.all([
+    collectStripeCheckoutState(page).then(
+      (state) => ({ available: true as const, state }),
+      () => ({ available: false as const }),
+    ),
+    captureClerkReadiness(page),
+  ]);
+  const state = {
+    clerk,
+    stripe: stripeResult.available ? stripeResult.state : null,
+  };
   await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, {
     encoding: "utf8",
     mode: 0o600,


### PR DESCRIPTION
## Problem

Runner credential preparation can intermittently reach the authenticated video-template deep link but remain on the Platform bootstrap skeleton until the heading wait times out. The existing diagnostic boundary starts after that page has rendered, so this failure leaves no screenshot or app readiness state.

## Solution

- retry the idempotent video-template navigation once only when the expected destination still shows the active global bootstrap skeleton
- preserve the existing 30-second tolerance on the final attempt and attach credential-safe Clerk/app state to the final timeout
- distinguish active, hidden, and removed bootstrap skeleton states so rendered route failures are never retried
- capture paid-onboarding diagnostics around the complete phase, including failures before Stripe
- add real Chromium fixtures for both recovery and rendered-page failure behavior

Runner credential concurrency, production Platform behavior, workflow retries, and workflow timeouts are unchanged.

## Validation

- cd e2e && pnpm test
- cd e2e && pnpm check-types
- check-file-size pre-commit hook
- current-head CI: Turbo, Crates, and Security required gates passed
- cli-e2e-03-runner-prepare generated all four credentials; all 12 runner shards and all Playwright lanes passed

Closes #31411