### PR TITLE
fix(platform): preserve selection menu during automatic scroll

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -666,11 +666,13 @@ function createListenersRef({
   close$,
   capture$,
   dismissOnScroll$,
+  isProgrammaticScrollEvent$,
 }: {
   selection$: State<CapturedFeedbackSelection | null>;
   close$: Command<void, []>;
   capture$: Command<void, []>;
   dismissOnScroll$: Command<void, []>;
+  isProgrammaticScrollEvent$: Command<boolean, [EventTarget | null]>;
 }) {
   const deferredCaptureSignal$ = resetSignal();
   return onRef(
@@ -756,7 +758,10 @@ function createListenersRef({
       doc.addEventListener(
         "scroll",
         (event) => {
-          if (isSelectionInteractionTarget(event.target)) {
+          if (
+            isSelectionInteractionTarget(event.target) ||
+            set(isProgrammaticScrollEvent$, event.target)
+          ) {
             return;
           }
           set(dismissOnScroll$);
@@ -770,6 +775,7 @@ function createListenersRef({
 export function createChatThreadFeedbackSignals(
   threadId: string,
   feedback: ComposerFeedbackSignals,
+  isProgrammaticScrollEvent$: Command<boolean, [EventTarget | null]>,
 ): ChatThreadFeedbackSignals {
   const selection = createSelectionState(threadId);
   const translation = createTranslationState({
@@ -801,6 +807,7 @@ export function createChatThreadFeedbackSignals(
     close$: selection.close$,
     capture$: selection.capture$,
     dismissOnScroll$: selection.dismissOnScroll$,
+    isProgrammaticScrollEvent$,
   });
   return {
     selection$: selection.selection$,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-scroll.ts
@@ -50,6 +50,7 @@ export interface ChatThreadScrollSignals {
   readonly scrollContainer$: Computed<HTMLElement | null>;
   readonly threadScrollPosition$: Computed<ThreadScrollPosition | null>;
   readonly awayFromBottom$: Computed<boolean>;
+  readonly isProgrammaticScrollEvent$: Command<boolean, [EventTarget | null]>;
   readonly readRenderedThreadScrollPosition$: Command<
     ThreadScrollPosition | null,
     []
@@ -245,6 +246,16 @@ interface ScrollRuntime {
   // those events do not rewrite the held event position, and so a resize
   // restore during the animation preserves the requested behavior.
   programmaticSmoothScrollTop: number | null;
+}
+
+function isProgrammaticScroll(
+  runtime: ScrollRuntime,
+  container: HTMLElement,
+): boolean {
+  return (
+    runtime.programmaticSmoothScrollTop !== null ||
+    runtime.programmaticScrollTop === container.scrollTop
+  );
 }
 
 function createInternalScrollSignals(
@@ -664,10 +675,7 @@ function createScrollContainerOnRef(
           // too. Where they sit says nothing about where the thread sits.
           return;
         }
-        const smoothScrollTarget = runtime.programmaticSmoothScrollTop;
-        const programmatic =
-          smoothScrollTarget !== null ||
-          runtime.programmaticScrollTop === container.scrollTop;
+        const programmatic = isProgrammaticScroll(runtime, container);
         if (!programmatic) {
           // The container has left the offset this module wrote, so the reader
           // moved it. Until that happens the offset is still ours no matter how
@@ -809,6 +817,16 @@ export function createChatThreadScrollSignals(
     runtime,
   );
   const scrollContentOnRef$ = createScrollContentOnRef(threadId, navigation);
+  const isProgrammaticScrollEvent$ = command(
+    ({ get }, target: EventTarget | null): boolean => {
+      const container = get(scroll.scrollContainer$);
+      return (
+        container !== null &&
+        target === container &&
+        isProgrammaticScroll(runtime, container)
+      );
+    },
+  );
   const scrollToEvent$ = command(
     async (
       { get, set },
@@ -863,6 +881,7 @@ export function createChatThreadScrollSignals(
     scrollContainer$: scroll.scrollContainer$,
     threadScrollPosition$: scroll.threadScrollPosition$,
     awayFromBottom$: scroll.awayFromBottom$,
+    isProgrammaticScrollEvent$,
     readRenderedThreadScrollPosition$: scroll.readRenderedThreadScrollPosition$,
     autoScroll$: render.autoScroll$,
     scrollToEvent$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -4356,7 +4356,6 @@ function createChatPanelSignalsWithDraft(
     },
     draft,
   );
-  const feedback = createChatThreadFeedbackSignals(threadId, composer.feedback);
   const messagePipeline = createChatThreadMessagePipeline(
     {
       chatActionContext: { threadId, agentId },
@@ -4372,6 +4371,11 @@ function createChatPanelSignalsWithDraft(
     ...messagePipeline,
     ...artifact,
   };
+  const feedback = createChatThreadFeedbackSignals(
+    threadId,
+    composer.feedback,
+    messages.scroll.isProgrammaticScrollEvent$,
+  );
   const sharing = createChatThreadSharingSignals(threadId, messages.scroll);
   const locator = createChatConversationLocatorSignals({
     threadId,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
@@ -393,6 +393,26 @@ function scrollTo(container: HTMLElement, scrollTop: number): void {
   fireEvent.scroll(container);
 }
 
+function selectAssistantText(element: HTMLElement): void {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  Object.defineProperty(range, "getBoundingClientRect", {
+    configurable: true,
+    value: () => {
+      return domRect(120, 20);
+    },
+  });
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error("Selection API is not available");
+  }
+  element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  selection.removeAllRanges();
+  selection.addRange(range);
+  document.dispatchEvent(new Event("selectionchange"));
+  element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+}
+
 function buttonByName(name: string): HTMLElement {
   const button = queryAllByRoleFast("button").find((candidate) => {
     return (
@@ -1159,6 +1179,83 @@ describe("chat scroll position", () => {
 
     expect(viewportOffsetTop("grow-above-4")).toBe(-20);
     expect(container.scrollTop).toBe(820);
+  });
+
+  it("keeps the selection toolbar through an automatic anchor restore", async () => {
+    const threadId = "b0000000-0000-4000-a000-000000000821";
+    const prefix = "selection-restore";
+    const runIds = Array.from({ length: 8 }, (_, index) => {
+      return `${prefix}-run-${index}`;
+    });
+    mockChatLifecycleWithoutBrowserSession({
+      threadId,
+      threadTitle: "Selection restore",
+      activeRunIds: runIds,
+      chatEvents: runIds.map((runId, index) => {
+        return {
+          id: `${prefix}-${index}`,
+          role: "assistant" as const,
+          content: `${prefix} message ${index}`,
+          runId,
+          createdAt: new Date(Date.UTC(2026, 6, 30, 10, index)).toISOString(),
+        };
+      }),
+    });
+    let contentGrowth = 0;
+    installChatLayout(
+      new Map([
+        [
+          threadId,
+          {
+            clientHeight: () => {
+              return 300;
+            },
+            scrollHeight: () => {
+              return 1000 + contentGrowth;
+            },
+            eventRect: (eventId) => {
+              const index = Number(eventId.split("-").at(-1));
+              return Number.isFinite(index)
+                ? { top: index * 100 + contentGrowth, height: 80 }
+                : undefined;
+            },
+          },
+        ],
+      ]),
+    );
+    const resizeObserver = installResizeObserver();
+
+    await setupVisibleChatPage({ context, path: `/chats/${threadId}` });
+
+    const container = await waitFor(() => {
+      expect(screen.getByText(`${prefix} message 7`)).toBeInTheDocument();
+      const current = chatScrollContainer();
+      expect(current.scrollTop).toBe(700);
+      return current;
+    });
+    const messageContainer = container.querySelector(
+      "[data-message-container]",
+    );
+    if (!messageContainer) {
+      throw new Error("Chat message container not found");
+    }
+    scrollTo(container, 420);
+    selectAssistantText(screen.getByText(`${prefix} message 4`));
+    await screen.findByText("Quote");
+
+    contentGrowth = 400;
+    resizeObserver.trigger(messageContainer);
+    fireEvent.scroll(container);
+
+    expect(container.scrollTop).toBe(820);
+    expect(screen.getByText("Quote")).toBeInTheDocument();
+    expect(window.getSelection()?.toString()).toBe(`${prefix} message 4`);
+
+    scrollTo(container, 830);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Quote")).not.toBeInTheDocument();
+    });
   });
 
   it("keeps following the tail when a nested scroller scrolls after late content growth", async () => {


### PR DESCRIPTION
## Summary

- reuse the chat scroll runtime's existing provenance to keep the text-selection toolbar open during automatic anchor restoration
- continue dismissing the toolbar when the reader moves the thread away from the module-owned scroll offset
- add a page-level regression test covering content growth, automatic restoration, and a subsequent reader scroll

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-scroll-position.test.tsx` (29 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-inline-feedback.test.tsx` (34 passed)
