### PR TITLE
docs(nbd-cow): describe cooldown claim reuse

### DIFF
--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -1,10 +1,15 @@
 //! Device pool for cooperatively claimed NBD devices.
 //!
-//! Allocation is demand-only: each acquire scans for a free `/dev/nbdN`,
+//! A successful acquire can come from either a demand scan or a cooled claim
+//! retained from a clean release. A demand scan looks for a free `/dev/nbdN`,
 //! acquires the per-index lock-file `flock`, and re-checks sysfs before returning a
-//! lease. Released devices keep their lock through a short cooldown period so
-//! kernel teardown cannot race another cooperating runner using the same lock
-//! directory.
+//! lease. A clean release keeps the existing claim and lock through a short
+//! cooldown period so kernel teardown cannot race another cooperating runner
+//! using the same lock directory. When the cooldown expires, a queued waiter
+//! can receive that still-locked claim after a sysfs free check, without a new
+//! scan or lock acquisition. If no waiter is queued or the free check fails,
+//! the expired claim is dropped and its lock is released; remaining waiters
+//! continue through the pool's normal progress path.
 
 mod actor;
 mod lease;

--- a/crates/nbd-cow/src/pool/actor.rs
+++ b/crates/nbd-cow/src/pool/actor.rs
@@ -22,6 +22,14 @@ use super::state::{DevicePool, DevicePoolConfig};
 /// The handle coordinates this process-local pool state, while cooperative
 /// cross-process safety still comes from shared per-index lock files and sysfs
 /// checks.
+///
+/// Successful acquisitions come either from a demand scan or from an expired
+/// clean-release claim. Demand scans acquire a per-index lock and re-check
+/// sysfs. Clean releases retain the claim and lock during cooldown; after
+/// cooldown, a queued waiter may receive that claim after a sysfs free check,
+/// without a new scan or lock acquisition. If no waiter is queued or the free
+/// check fails, the expired claim is dropped and its lock is released.
+///
 /// Dropping a handle is not normal device cleanup. Checked-out leases also carry
 /// return senders, so dropping every handle only stops the actor after
 /// outstanding leases release those senders. Successful pooled devices must

--- a/crates/nbd-cow/src/pool/state.rs
+++ b/crates/nbd-cow/src/pool/state.rs
@@ -80,10 +80,12 @@ pub(crate) struct DevicePoolSnapshot {
     pub(super) waiting_acquires: usize,
 }
 
-/// Demand-only NBD device claim pool.
+/// NBD device claim pool.
 ///
-/// Production callers should share it through [`crate::pool::DevicePoolHandle`] so pool
-/// release authority stays tied to owned device leases.
+/// Successful acquisitions use either a demand scan for a new claim or a
+/// cooled claim retained from a clean release. Production callers should share
+/// the pool through [`crate::pool::DevicePoolHandle`] so release authority stays
+/// tied to owned device leases.
 pub struct DevicePool {
     pub(super) active: bool,
     /// Recently released device claims waiting for cooldown to expire.


### PR DESCRIPTION
## Summary

- Explain that successful NBD pool acquisitions come from either a demand scan or a cooled claim handoff.
- Document that clean releases retain the existing claim lock through cooldown and can transfer it directly to a queued waiter after a sysfs free check.
- Align the `DevicePool` and `DevicePoolHandle` rustdoc with the existing cooldown state machine and tests.

## Scope

This is a documentation-only change. It does not modify the pool state machine, lock behavior, public API signatures, metrics, or tests.

Closes #31424

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc -p nbd-cow --all-features --no-deps`
- `cd crates && cargo test -p nbd-cow --lib pool::tests::cooldown` (7 passed)
- `git diff --check`
