### PR TITLE
refactor(runner): reuse shared gc lock removal

### DIFF
--- a/crates/runner/src/cmd/gc/lock_file.rs
+++ b/crates/runner/src/cmd/gc/lock_file.rs
@@ -76,6 +76,7 @@ fn lock_guard_matches_path(lock_path: &Path, lock: &Flock<std::fs::File>) -> boo
 async fn remove_lock_file(lock_path: &Path) -> bool {
     match tokio::fs::remove_file(lock_path).await {
         Ok(()) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
         Err(e) => {
             warn!("cannot remove {}: {e}", lock_path.display());
             false

--- a/crates/runner/src/cmd/gc/lock_file.rs
+++ b/crates/runner/src/cmd/gc/lock_file.rs
@@ -88,6 +88,9 @@ async fn remove_lock_file(lock_path: &Path) -> bool {
 mod tests {
     use super::*;
     use nix::fcntl::FlockArg;
+    use tracing::instrument::WithSubscriber;
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::CapturedEvents;
 
     #[test]
     fn probe_lock_free_when_no_holder() {
@@ -221,6 +224,25 @@ mod tests {
         assert!(
             path.exists(),
             "cleanup must not remove a lock path recreated after this lock was acquired"
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_lock_file_treats_missing_path_as_benign() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.lock");
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+
+        let removed = remove_lock_file(&path).with_subscriber(subscriber).await;
+
+        assert!(
+            !removed,
+            "a missing path must not count as this pass's removal"
+        );
+        assert!(
+            captured.entries().is_empty(),
+            "a concurrently removed lock path must not produce a warning"
         );
     }
 }

--- a/crates/runner/src/cmd/gc/storage.rs
+++ b/crates/runner/src/cmd/gc/storage.rs
@@ -2,7 +2,6 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-use nix::fcntl::Flock;
 use tracing::{info, warn};
 
 use crate::byte_size::human_bytes;
@@ -14,7 +13,7 @@ use super::filesystem::{
     GcDirStatus, collect_dir_stats, dir_stats, gc_entry_is_real_dir, gc_path_dir_status,
     next_entry_warn_or_stop, read_dir_or_missing,
 };
-use super::lock_file::{LockProbe, probe_lock};
+use super::lock_file::{LockProbe, probe_lock, remove_unused_lock_after_probe};
 use super::report::GcReport;
 
 /// Per-host storage archive cache byte target for best-effort eviction.
@@ -410,13 +409,8 @@ async fn evict_storage_candidate(
 
     match tokio::fs::remove_dir_all(&candidate.path).await {
         Ok(()) => {
-            remove_storage_lock_after_eviction(
-                &lock_path,
-                &lock,
-                &candidate.name,
-                &candidate.version,
-            )
-            .await;
+            let lock_name = lock_path.to_string_lossy();
+            remove_unused_lock_after_probe(&lock_path, &lock, &lock_name, false).await;
             remove_empty_storage_name_dir_after_eviction(&candidate.path, &candidate.name).await;
             StorageEvictionResult {
                 freed: size,
@@ -462,36 +456,6 @@ async fn remove_empty_storage_name_dir_after_eviction(version_path: &Path, name_
             warn!(
                 "storages/{name_hash}: failed to remove empty storage directory {}: {e}",
                 name_path.display()
-            );
-        }
-    }
-}
-
-async fn remove_storage_lock_after_eviction(
-    lock_path: &Path,
-    lock: &Flock<std::fs::File>,
-    name_hash: &str,
-    version_hash: &str,
-) {
-    let Ok(lock_meta) = lock.metadata() else {
-        return;
-    };
-
-    match tokio::fs::symlink_metadata(lock_path).await {
-        Ok(path_meta)
-            if path_meta.dev() == lock_meta.dev() && path_meta.ino() == lock_meta.ino() => {}
-        Ok(_) => return,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
-        Err(_) => return,
-    }
-
-    match tokio::fs::remove_file(lock_path).await {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => {
-            warn!(
-                "storages/{name_hash}/{version_hash}: failed to remove storage lock {}: {e}",
-                lock_path.display()
             );
         }
     }

--- a/crates/runner/src/cmd/gc/storage/tests.rs
+++ b/crates/runner/src/cmd/gc/storage/tests.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use nix::fcntl::FlockArg;
+use nix::fcntl::{Flock, FlockArg};
 
 use super::*;
 use crate::cmd::gc::test_support::{
@@ -519,64 +519,6 @@ async fn gc_storage_cache_removes_empty_name_dir_after_eviction() {
     assert!(
         !name_dir.exists(),
         "empty storage name dir should be removed with its last version"
-    );
-}
-
-#[tokio::test]
-async fn gc_storage_cache_lock_cleanup_keeps_replaced_lock_path() {
-    let dir = tempfile::tempdir().unwrap();
-    let home = test_home(dir.path());
-    std::fs::create_dir_all(home.locks_dir()).unwrap();
-
-    let lock_path = home.storage_lock("foo", "v1");
-    let held_lock = match probe_lock(&lock_path) {
-        LockProbe::Free(lock) => lock,
-        LockProbe::Held => panic!("new test lock must not be held"),
-        LockProbe::Error(e) => panic!("new test lock must be probeable: {e}"),
-    };
-
-    std::fs::remove_file(&lock_path).unwrap();
-    drop(lock::open_lock_file(&lock_path).unwrap());
-    assert!(
-        lock_path.exists(),
-        "test setup must recreate the lock path with a new inode"
-    );
-
-    remove_storage_lock_after_eviction(&lock_path, &held_lock, "foo", "v1").await;
-
-    assert!(
-        lock_path.exists(),
-        "cleanup must not remove a lock path recreated after this lock was acquired"
-    );
-}
-
-#[cfg(unix)]
-#[tokio::test]
-async fn gc_storage_cache_lock_cleanup_keeps_symlink_lock_path() {
-    let dir = tempfile::tempdir().unwrap();
-    let home = test_home(dir.path());
-    std::fs::create_dir_all(home.locks_dir()).unwrap();
-
-    let lock_path = home.storage_lock("foo", "v1");
-    let alias = home.locks_dir().join("storage-alias.lock");
-    let held_lock = match probe_lock(&lock_path) {
-        LockProbe::Free(lock) => lock,
-        LockProbe::Held => panic!("new test lock must not be held"),
-        LockProbe::Error(e) => panic!("new test lock must be probeable: {e}"),
-    };
-
-    std::fs::hard_link(&lock_path, &alias).unwrap();
-    std::fs::remove_file(&lock_path).unwrap();
-    std::os::unix::fs::symlink(&alias, &lock_path).unwrap();
-
-    remove_storage_lock_after_eviction(&lock_path, &held_lock, "foo", "v1").await;
-
-    assert!(
-        std::fs::symlink_metadata(&lock_path)
-            .unwrap()
-            .file_type()
-            .is_symlink(),
-        "cleanup must not remove a lock path replaced by a symlink"
     );
 }
 


### PR DESCRIPTION
## Summary

- delegate storage cache post-eviction lock cleanup to the shared GC lock helper
- treat a lock path that disappears between identity validation and unlink as a benign concurrent cleanup
- remove the storage-specific device/inode, symlink, and unlink implementation plus its duplicate low-level tests
- cover the shared helper's missing-path result and no-warning behavior

## Scope

- preserve storage candidate selection, deletion and lock ordering, acquired-guard lifetime, dry-run behavior, and eviction accounting
- retain fail-closed handling for replaced paths, symlinks, and identity-check failures through the canonical lock helper
- keep non-`NotFound` cleanup failures visible with the affected lock path
- no API, persisted data, protocol, configuration, migration, or deployment-order changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner cmd::gc::lock_file::tests` (8 passed)
- `cargo test -p runner cmd::gc::storage::tests` (31 passed, 1 ignored child helper)
- `cargo test -p runner` (3419 passed, 25 ignored; guest inventory passed)
- repository pre-commit Rust format, workspace Clippy, documentation, file-size, and commitlint hooks

Closes #31420
