### PR TITLE
feat(core): enable follow-up optimization for staff

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -182,6 +182,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ConnectorAccounts]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.FollowUpOptimize]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.VoiceDraft]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(true);
@@ -209,6 +210,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ConnectorAccounts]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.FollowUpOptimize]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.VoiceDraft]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -408,6 +408,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Use a concise, language-matched prompt for recommended chat follow-ups.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ResponsiveFollowupCards]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

- enable `followUpOptimize` by default for staff organizations
- keep the switch disabled by default for non-staff organizations
- cover both rollout states in the feature-switch matrix test

## Testing

- `pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm --filter @okouai/core run lint`
- `pnpm --filter @okouai/core run check-types`
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm knip --workspace @okouai/core`