### PR TITLE
test(runner): cover managed kill refusal after control failure

### DIFF
--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -484,7 +484,7 @@ async fn confirm() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
     use std::path::Path;
 
     use sandbox::SandboxControlTarget;
@@ -581,6 +581,72 @@ mod tests {
             control.recorded_kill_targets(),
             vec![SandboxControlTarget::sandbox("sbox-123")]
         );
+    }
+
+    #[tokio::test]
+    async fn managed_target_refuses_orphan_fallback_after_owner_control_failure() {
+        let workspace_base = tempfile::tempdir().unwrap();
+        let socket_base = tempfile::tempdir().unwrap();
+        let control = MockSandboxControl::new(socket_base.path());
+        control.push_kill_remote_result(Err(SandboxControlError::Connection(
+            "owner unavailable".into(),
+        )));
+        let target = make_target_at_base(
+            u32::MAX - 2_000,
+            "sandbox-managed-full-id",
+            workspace_base.path(),
+        );
+        let workspace = workspace_base
+            .path()
+            .join("workspaces/sandbox-managed-full-id");
+        let socket_dir = control.runtime_dir("sandbox-managed-full-id");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::create_dir_all(&socket_dir).await.unwrap();
+        let runner_pids = vec![101, 202];
+        let refreshed = ResolvedKillTarget {
+            target: target.clone(),
+            runner_pids: runner_pids.clone(),
+        };
+        let classifier_input = RefCell::new(None);
+        let discovery_called = Cell::new(false);
+
+        let outcome = kill_current_target_with_orphan_fallback(
+            target.clone(),
+            false,
+            &control,
+            || std::future::ready(Ok(refreshed)),
+            |pid, runner_pids| {
+                classifier_input.replace(Some((pid, runner_pids)));
+                std::future::ready(false)
+            },
+            || {
+                discovery_called.set(true);
+                std::future::ready(empty_process_discovery(true))
+            },
+        )
+        .await;
+
+        match &outcome {
+            KillOutcome::RefusedManagedControlFailed(error) => {
+                assert_eq!(error, "connection failed: owner unavailable")
+            }
+            other => panic!("expected managed control refusal, got {other:?}"),
+        }
+        assert_eq!(
+            classifier_input.into_inner(),
+            Some((target.pid, runner_pids))
+        );
+        assert!(!discovery_called.get());
+        assert_eq!(
+            control.recorded_kill_targets(),
+            vec![SandboxControlTarget::sandbox("sandbox-managed-full-id")]
+        );
+
+        let exit_code = finish_kill_outcome(&target, &target, &outcome, &control).await;
+
+        assert_eq!(exit_code, ExitCode::FAILURE);
+        assert!(workspace.exists());
+        assert!(socket_dir.exists());
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -599,6 +599,8 @@ mod tests {
         );
     }
 
+    // A CLI test cannot safely construct this post-control race without a real
+    // Firecracker process and owning runner, so inject only those OS boundaries.
     #[tokio::test]
     async fn managed_target_refuses_orphan_fallback_after_owner_control_failure() {
         let workspace_base = tempfile::tempdir().unwrap();

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -185,6 +185,7 @@ async fn kill_current_target(
         control,
         move || async move { rediscover_same_sandbox_process(&rediscovery_target).await },
         |pid, runner_pids| async move { process::is_orphan(pid, &runner_pids).await },
+        |target| async move { orphan::terminate(&target).await },
         process::discover_all_with_status,
     )
     .await
@@ -195,6 +196,8 @@ async fn kill_current_target_with_orphan_fallback<
     RediscoverFuture,
     IsOrphan,
     IsOrphanFuture,
+    Terminate,
+    TerminateFuture,
     Discover,
     DiscoverFuture,
 >(
@@ -203,6 +206,7 @@ async fn kill_current_target_with_orphan_fallback<
     control: &dyn SandboxControl,
     rediscover: Rediscover,
     classify_orphan: IsOrphan,
+    terminate: Terminate,
     discover: Discover,
 ) -> KillOutcome
 where
@@ -211,6 +215,8 @@ where
         std::future::Future<Output = Result<ResolvedKillTarget, RediscoverTargetError>>,
     IsOrphan: FnOnce(u32, Vec<u32>) -> IsOrphanFuture,
     IsOrphanFuture: std::future::Future<Output = bool>,
+    Terminate: FnOnce(KillTarget) -> TerminateFuture,
+    TerminateFuture: std::future::Future<Output = OrphanOutcome>,
     Discover: FnOnce() -> DiscoverFuture,
     DiscoverFuture: std::future::Future<Output = process::ProcessDiscovery>,
 {
@@ -224,6 +230,7 @@ where
                 is_orphan,
                 rediscover,
                 classify_orphan,
+                terminate,
                 discover,
             )
             .await
@@ -236,6 +243,8 @@ async fn retry_as_orphan_if_owner_disappeared<
     RediscoverFuture,
     IsOrphan,
     IsOrphanFuture,
+    Terminate,
+    TerminateFuture,
     Discover,
     DiscoverFuture,
 >(
@@ -244,6 +253,7 @@ async fn retry_as_orphan_if_owner_disappeared<
     was_orphan: bool,
     rediscover: Rediscover,
     classify_orphan: IsOrphan,
+    terminate: Terminate,
     discover: Discover,
 ) -> KillOutcome
 where
@@ -252,6 +262,8 @@ where
         std::future::Future<Output = Result<ResolvedKillTarget, RediscoverTargetError>>,
     IsOrphan: FnOnce(u32, Vec<u32>) -> IsOrphanFuture,
     IsOrphanFuture: std::future::Future<Output = bool>,
+    Terminate: FnOnce(KillTarget) -> TerminateFuture,
+    TerminateFuture: std::future::Future<Output = OrphanOutcome>,
     Discover: FnOnce() -> DiscoverFuture,
     DiscoverFuture: std::future::Future<Output = process::ProcessDiscovery>,
 {
@@ -283,7 +295,7 @@ where
         return KillOutcome::RefusedTargetChanged(RUN_ORPHAN_FALLBACK_REFUSAL.into());
     }
 
-    KillOutcome::from(orphan::terminate(&refreshed).await)
+    KillOutcome::from(terminate(refreshed).await)
 }
 
 async fn finish_kill_outcome(
@@ -506,6 +518,10 @@ mod tests {
         target
     }
 
+    fn orphan_already_exited(target: KillTarget) -> std::future::Ready<OrphanOutcome> {
+        std::future::ready(OrphanOutcome::AlreadyExited(target))
+    }
+
     #[test]
     fn run_scoped_target_refuses_orphan_fallback() {
         assert!(should_refuse_orphan_fallback(Some("run-full-id")));
@@ -608,6 +624,7 @@ mod tests {
             runner_pids: runner_pids.clone(),
         };
         let classifier_input = RefCell::new(None);
+        let termination_called = Cell::new(false);
         let discovery_called = Cell::new(false);
 
         let outcome = kill_current_target_with_orphan_fallback(
@@ -618,6 +635,10 @@ mod tests {
             |pid, runner_pids| {
                 classifier_input.replace(Some((pid, runner_pids)));
                 std::future::ready(false)
+            },
+            |target| {
+                termination_called.set(true);
+                orphan_already_exited(target)
             },
             || {
                 discovery_called.set(true);
@@ -636,6 +657,7 @@ mod tests {
             classifier_input.into_inner(),
             Some((target.pid, runner_pids))
         );
+        assert!(!termination_called.get());
         assert!(!discovery_called.get());
         assert_eq!(
             control.recorded_kill_targets(),
@@ -671,6 +693,7 @@ mod tests {
                 classification_called.set(true);
                 std::future::ready(true)
             },
+            orphan_already_exited,
             || {
                 discovery_called.set(true);
                 std::future::ready(empty_process_discovery(true))
@@ -709,6 +732,7 @@ mod tests {
             &control,
             || std::future::ready(Ok(refreshed)),
             |_, _| std::future::ready(true),
+            orphan_already_exited,
             || std::future::ready(empty_process_discovery(true)),
         )
         .await;
@@ -741,6 +765,7 @@ mod tests {
                 )))
             },
             |_, _| std::future::ready(true),
+            orphan_already_exited,
             || std::future::ready(empty_process_discovery(true)),
         )
         .await;
@@ -767,6 +792,7 @@ mod tests {
                 )))
             },
             |_, _| std::future::ready(true),
+            orphan_already_exited,
             || std::future::ready(empty_process_discovery(false)),
         )
         .await;


### PR DESCRIPTION
## Summary

- add a private termination callback to the existing kill fallback test seam while preserving the production delegate to `orphan::terminate`
- cover the owner-control failure path that rediscovers a still-managed Firecracker target
- verify refreshed ancestry inputs, the exact sandbox control target, and the preserved control diagnostic
- prove managed refusal returns failure before orphan termination or discovery and without cleaning workspace/runtime state

## Scope

This adds a private testability seam and one regression test. It does not change runner runtime behavior, process classification, control protocols, cleanup logic, public APIs, or deployment compatibility.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::kill::tests::managed_target_refuses_orphan_fallback_after_owner_control_failure -- --exact`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (3425 passed, 25 ignored; guest inventory passed)
- `lefthook run pre-commit`

Closes #31421
