### PR TITLE
test(platform): synchronize blocked chat send

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx
@@ -1252,16 +1252,20 @@ describe("chat scroll position", () => {
     expect(viewportOffsetTop("local-send-tail-4")).toBe(-20);
 
     const composer = await screen.findByRole("textbox", { name: "Message" });
-    await sendMessageInUI(user, composer, "Send from history");
-
-    await waitFor(() => {
-      expect(screen.getByText("Send from history")).toBeInTheDocument();
-      expect(container.scrollTop).toBe(
-        container.scrollHeight - container.clientHeight,
-      );
-    });
-
-    sendGate.resolve();
+    // Assert the optimistic row while the request is blocked, then release it
+    // without making the gate depend on the user interaction settling first.
+    await Promise.all([
+      sendMessageInUI(user, composer, "Send from history"),
+      (async () => {
+        await waitFor(() => {
+          expect(screen.getByText("Send from history")).toBeInTheDocument();
+          expect(container.scrollTop).toBe(
+            container.scrollHeight - container.clientHeight,
+          );
+        });
+        sendGate.resolve();
+      })(),
+    ]);
     await waitFor(() => {
       expect(sent).toBeTruthy();
     });


### PR DESCRIPTION
## Summary

- observe the optimistic chat row and tail scroll concurrently with the Enter interaction
- release the blocked send request as soon as the optimistic UI contract is satisfied
- keep the existing product-level scroll assertions unchanged

## Root cause

The test awaited `userEvent`'s Enter interaction before releasing `sendGate`. Under an unlucky scheduling interleaving, the interaction remained pending while the mocked request was waiting on that gate, so the test could only escape through Vitest's 5-second timeout. This occurred in merge-queue run [33732318080](https://github.com/vm0-ai/vm0/actions/runs/33732318080), where the test took 5.49 seconds, while the same test passed in 1.10 seconds on the PR branch and 1.35 seconds on an adjacent `main` run.

## Scope

- test synchronization only; no production behavior changes
- no timeout increase, sleep, retry, test skip, or manual detached cleanup

## Validation

- `corepack pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-scroll-position.test.tsx -t "follows the tail when the reader sends while away from the bottom" --maxWorkers=1 --reporter=verbose` (5/5 repeated runs passed)
- `corepack pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-scroll-position.test.tsx --maxWorkers=1 --reporter=verbose` (28/28 passed)
- `corepack pnpm exec prettier --check apps/platform/src/views/okou-page/__tests__/chat-scroll-position.test.tsx`
- `corepack pnpm -F @okouai/app exec eslint src/views/okou-page/__tests__/chat-scroll-position.test.tsx --max-warnings 0`
- `corepack pnpm -F @okouai/app exec tsc -p tsconfig.tests.json --noEmit`
