### PR TITLE
fix(platform): hide account manager empty state for a single account

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1782,6 +1782,45 @@ describe("connectors page", () => {
     expect(within(dialog).queryByText("No accounts found")).toBeNull();
   });
 
+  it("keeps a default account that a search matches", async () => {
+    const accounts = mockGitHubConnectorAccounts(7);
+    const defaultAccount = accounts.find((account) => {
+      return account.isDefault;
+    });
+    if (!defaultAccount) {
+      throw new Error("Expected a default account fixture");
+    }
+    context.mocks.api(
+      connectorAccountsContract.connections,
+      ({ query, respond }) => {
+        return respond(200, {
+          connections: query.search ? [defaultAccount] : accounts,
+          nextCursor: null,
+        });
+      },
+    );
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Manage GitHub accounts",
+    });
+    fireEvent.input(within(dialog).getByPlaceholderText("Find accounts"), {
+      target: { value: "Unnamed" },
+    });
+    // The default is the only match here, so it stays a result row instead of
+    // being replaced by the empty state.
+    await waitFor(() => {
+      expect(within(dialog).queryByText("Work 1")).toBeNull();
+      expect(within(dialog).getByText("Unnamed account")).toBeInTheDocument();
+      expect(within(dialog).queryByText("No accounts found")).toBeNull();
+    });
+  });
+
   it("paginates a feature-on account manager", async () => {
     const accounts = mockGitHubConnectorAccounts(8);
     // The server projects rows away before slicing, so a page can hold fewer
@@ -1903,7 +1942,9 @@ describe("connectors page", () => {
         { search: "Work 2", cursor: null },
       ]);
       expect(within(dialog).getByText("Work 2")).toBeInTheDocument();
-      expect(within(dialog).getAllByText("Unnamed account")).toHaveLength(1);
+      // A search owns the whole list: the default account is unpinned unless it
+      // matches, so the results never mix with a row the query excluded.
+      expect(within(dialog).queryByText("Unnamed account")).toBeNull();
     });
 
     fireEvent.input(searchInput, {
@@ -1915,7 +1956,7 @@ describe("connectors page", () => {
         cursor: null,
       });
       expect(within(dialog).getByText("No accounts found")).toBeInTheDocument();
-      expect(within(dialog).getAllByText("Unnamed account")).toHaveLength(1);
+      expect(within(dialog).queryByText("Unnamed account")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1759,6 +1759,29 @@ describe("connectors page", () => {
     expect(within(dialog).getAllByText("Unnamed account")).toHaveLength(1);
   });
 
+  it("keeps the empty state out of a single-account manager", async () => {
+    const accounts = mockGitHubConnectorAccounts(1);
+    context.mocks.api(connectorAccountsContract.connections, ({ respond }) => {
+      return respond(200, { connections: accounts, nextCursor: null });
+    });
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
+    const dialog = await screen.findByRole("dialog", {
+      name: "Manage GitHub accounts",
+    });
+    // The sole account is also the pinned default, so it is the only row the
+    // dialog can draw. That is a full list, not an empty search result.
+    await waitFor(() => {
+      expect(within(dialog).getByText("Unnamed account")).toBeInTheDocument();
+    });
+    expect(within(dialog).queryByText("No accounts found")).toBeNull();
+  });
+
   it("paginates a feature-on account manager", async () => {
     const accounts = mockGitHubConnectorAccounts(8);
     // The server projects rows away before slicing, so a page can hold fewer

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -286,12 +286,14 @@ function AccountRow({
 function AccountsCard({
   loadable,
   defaultConnection,
+  search,
   target,
   connectionActionsEnabled,
   onReconnect,
 }: {
   readonly loadable: Loadable<ConnectorAccountList>;
   readonly defaultConnection: ConnectorAccountConnection | null;
+  readonly search: string;
   readonly target: ConnectorAccountTarget;
   readonly connectionActionsEnabled: boolean;
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
@@ -334,7 +336,10 @@ function AccountsCard({
           </div>
         );
       })}
-      {defaultConnection && others.length === 0 ? (
+      {/* The pinned default survives a search that matches nothing, so this
+          message speaks for the filtered list only. Without the search guard a
+          connector holding just its default account would read as empty. */}
+      {search.trim() && loadable.data.connections.length === 0 ? (
         <AccountsMessage messageKey="noAccountsFound" />
       ) : null}
     </RadioGroup>
@@ -607,6 +612,7 @@ export function ConnectorAccountManagerDialog({
           <AccountsCard
             loadable={accountsLoadable}
             defaultConnection={defaultConnection}
+            search={search}
             target={target}
             connectionActionsEnabled={connectionActionsEnabled}
             onReconnect={reconnect}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -307,15 +307,21 @@ function AccountsCard({
   if (!loadable.data.available) {
     return <AccountsMessage messageKey="accountsUnavailable" />;
   }
-  // The default account stays pinned at the top even while a search filters the
-  // rest, so the dialog always shows which account new runs will use.
+  // At rest the default account is pinned on top, so the dialog always shows
+  // which account new runs will use. An active search owns the whole list
+  // instead: keeping a non-matching row pinned would put a visible account
+  // directly above a message saying no account was found.
   const others = loadable.data.connections.filter((account) => {
     return account.id !== defaultConnection?.id;
   });
-  if (!defaultConnection && others.length === 0) {
+  const rows: readonly ConnectorAccountConnection[] = search.trim()
+    ? loadable.data.connections
+    : defaultConnection
+      ? [defaultConnection, ...others]
+      : others;
+  if (rows.length === 0) {
     return <AccountsMessage messageKey="noAccountsFound" />;
   }
-  const rows = defaultConnection ? [defaultConnection, ...others] : others;
   return (
     <RadioGroup
       value={defaultConnection?.id ?? null}
@@ -336,12 +342,6 @@ function AccountsCard({
           </div>
         );
       })}
-      {/* The pinned default survives a search that matches nothing, so this
-          message speaks for the filtered list only. Without the search guard a
-          connector holding just its default account would read as empty. */}
-      {search.trim() && loadable.data.connections.length === 0 ? (
-        <AccountsMessage messageKey="noAccountsFound" />
-      ) : null}
     </RadioGroup>
   );
 }


### PR DESCRIPTION
## Problem

Two related defects in the connector account manager, both caused by the default account being pinned above the list.

1. Opening **Manage <connector> accounts** for a connector with exactly one account showed `No accounts found` directly beneath that connected account. The trailing empty state was keyed off `defaultConnection && others.length === 0`, which is also true when the connector simply has one account — its only account is the default, so `others` is empty with no search involved.
2. Even with the guard corrected, a search that matched nothing still rendered the pinned default row directly above `No accounts found`. Logically the message described the filtered list, but on screen it denied the existence of an account the user could see.

## Fix

A search now owns the whole list. The default is pinned only at rest — when a query is active, the rows are exactly what the query returned, and the default appears only if it matches. One empty state then covers every case, so the second, in-card message is gone.

This keeps the reason the pin exists (at rest the dialog shows which account new runs will use) while removing the state where a visible row and "nothing found" appear together.

## Verification

Live walkthrough on this PR's preview (`pr-31453-app-okou-app-preview.vm0.workers.dev`), with PR #31451's preview as the pre-fix build for comparison:

- One account, no search: account row only, no empty state.
- Seven accounts, no search: full list, search box appears at the threshold.
- Search matching nothing: only `No accounts found`, no orphaned pinned row.
- Search matching only the default: that row is shown as a result, no empty state.

Tests in `connectors-page.test.tsx`:

- New: a one-account manager renders no empty state (fails on the pre-fix component).
- New: a default account that a search matches stays a result row.
- Updated: the debounce test now asserts the default is unpinned during a search; confirmed load-bearing by re-pinning the row and watching it fail.
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-page.test.tsx` — 131 passed.
- `pnpm format`, platform `lint`, `tsc --noEmit`, `knip --workspace apps/platform` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
