### PR TITLE
fix: stabilize pending goal run layout

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -1253,6 +1253,16 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           runGroupId,
           createdAt: "2026-06-09T10:02:00Z",
         },
+        {
+          id: "msg-goal-run-group-active-thinking-2",
+          eventType: "output.thinking",
+          role: "assistant",
+          content: null,
+          thinking: "Sketching the details",
+          runId: "f0000001-0000-4000-a000-00000000082d",
+          runGroupId,
+          createdAt: "2026-06-09T10:02:01Z",
+        },
       ],
     });
 
@@ -1279,13 +1289,25 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       "[data-thinking-indicator]",
     );
 
-    expect(thinkingIndicator).not.toBeNull();
+    if (!(thinkingIndicator instanceof HTMLElement)) {
+      throw new Error("Thinking indicator not found");
+    }
+    const waitingAssistantGroup = thinkingIndicator.closest(
+      '[data-role="assistant"]',
+    );
+    if (!(waitingAssistantGroup instanceof HTMLElement)) {
+      throw new Error("Waiting assistant group not found");
+    }
+    expect(waitingAssistantGroup).toContainElement(foldButton);
+    const thinkingLabel = within(waitingAssistantGroup).getByLabelText(
+      "Sketching the details",
+    );
     expect(
       goalText.compareDocumentPosition(foldButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      foldButton.compareDocumentPosition(thinkingIndicator!) &
+      foldButton.compareDocumentPosition(thinkingLabel) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3105,6 +3105,16 @@ function ChatThreadRenderedEventGroups({
   const visibleGroups = runWorkFoldingEnabled
     ? (runWorkFolding?.visibleGroups ?? runGroupVisibleGroups)
     : (completedWorkFolding?.visibleGroups ?? runGroupVisibleGroups);
+  const thinkingIndicatorMode =
+    useLastResolved(thread.thinkingIndicatorMode$) ?? null;
+  const runGroupFoldPlacements = resolveRunGroupFoldPlacements({
+    groups: visibleGroups,
+    runGroupFolding,
+    onToggleRunGroup: toggleRunGroupExpanded,
+    thinkingIndicatorCanHostFold:
+      thinkingIndicatorMode === "waiting" ||
+      thinkingIndicatorMode === "waiting-queued",
+  });
 
   return (
     <>
@@ -3112,8 +3122,7 @@ function ChatThreadRenderedEventGroups({
         thread={thread}
         groups={visibleGroups}
         modelChanges={modelChanges}
-        runGroupFolding={runGroupFolding}
-        onToggleRunGroup={toggleRunGroupExpanded}
+        runGroupFoldPlacements={runGroupFoldPlacements}
         runWorkFoldingEnabled={runWorkFoldingEnabled}
         completedWorkFolding={completedWorkFolding}
         completedWorkExpandedKeys={effectiveCompletedWorkExpandedKeys}
@@ -3125,6 +3134,11 @@ function ChatThreadRenderedEventGroups({
       <ChatThreadScrollCommitMarker
         thread={thread}
         renderedGroups={resolvedRenderedGroups}
+      />
+      <ChatThreadThinkingIndicator
+        thread={thread}
+        mode={thinkingIndicatorMode}
+        runGroupFolds={runGroupFoldPlacements.thinkingIndicatorRunGroupFolds}
       />
     </>
   );
@@ -3193,15 +3207,28 @@ function ChatThreadEventsMain({ thread }: { thread: ChatPanelSignals }) {
         <ChatThreadSessionError thread={thread} />
         <ChatThreadEmptyState thread={thread} />
         <ChatThreadRenderedEventGroups thread={thread} />
-        <ChatThreadThinkingIndicator thread={thread} />
         <ChatThreadNextRunModelNotice thread={thread} />
       </div>
     </main>
   );
 }
 
-function ChatThreadThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
-  return <ThinkingIndicator thread={thread} />;
+function ChatThreadThinkingIndicator({
+  thread,
+  mode,
+  runGroupFolds,
+}: {
+  thread: ChatPanelSignals;
+  mode: ThinkingIndicatorMode;
+  runGroupFolds: readonly RunGroupFoldControl[];
+}) {
+  return (
+    <ThinkingIndicator
+      thread={thread}
+      mode={mode}
+      runGroupFolds={runGroupFolds}
+    />
+  );
 }
 
 function ChatThreadNextRunModelNotice({
@@ -3287,8 +3314,7 @@ function ChatThreadEventGroups({
   thread,
   groups,
   modelChanges,
-  runGroupFolding,
-  onToggleRunGroup,
+  runGroupFoldPlacements,
   runWorkFoldingEnabled,
   completedWorkFolding,
   completedWorkExpandedKeys,
@@ -3300,8 +3326,7 @@ function ChatThreadEventGroups({
   thread: ChatPanelSignals;
   groups: readonly ChatEventGroup[];
   modelChanges: ReadonlyMap<string, RunModelChange>;
-  runGroupFolding: RunGroupFolding | null;
-  onToggleRunGroup: (key: string, expanded: boolean) => void;
+  runGroupFoldPlacements: RunGroupFoldPlacements;
   runWorkFoldingEnabled: boolean;
   completedWorkFolding: CompletedWorkFolding | null;
   completedWorkExpandedKeys: ReadonlySet<string>;
@@ -3311,11 +3336,7 @@ function ChatThreadEventGroups({
   onToggleRunWork: (key: string) => void;
 }) {
   const { embeddedRunGroupFolds, externalRunGroupFolds } =
-    resolveRunGroupFoldPlacements({
-      groups,
-      runGroupFolding,
-      onToggleRunGroup,
-    });
+    runGroupFoldPlacements;
   // A run that ends re-forms the groups around it, so the messages the user
   // sent back to back can land in separate groups with nothing rendered in
   // between. Tracking the last group that actually put something on screen
@@ -3411,23 +3432,33 @@ interface RunGroupFoldControl {
   onToggle: () => void;
 }
 
+interface RunGroupFoldPlacements {
+  embeddedRunGroupFolds: Map<string, RunGroupFoldControl[]>;
+  externalRunGroupFolds: Map<string, RunGroupFoldControl[]>;
+  thinkingIndicatorRunGroupFolds: RunGroupFoldControl[];
+}
+
 function resolveRunGroupFoldPlacements({
   groups,
   runGroupFolding,
   onToggleRunGroup,
+  thinkingIndicatorCanHostFold,
 }: {
   groups: readonly ChatEventGroup[];
   runGroupFolding: RunGroupFolding | null;
   onToggleRunGroup: (key: string, expanded: boolean) => void;
-}): {
-  embeddedRunGroupFolds: Map<string, RunGroupFoldControl[]>;
-  externalRunGroupFolds: Map<string, RunGroupFoldControl[]>;
-} {
+  thinkingIndicatorCanHostFold: boolean;
+}): RunGroupFoldPlacements {
   const embeddedRunGroupFolds = new Map<string, RunGroupFoldControl[]>();
   const externalRunGroupFolds = new Map<string, RunGroupFoldControl[]>();
+  const thinkingIndicatorRunGroupFolds: RunGroupFoldControl[] = [];
 
   if (runGroupFolding === null) {
-    return { embeddedRunGroupFolds, externalRunGroupFolds };
+    return {
+      embeddedRunGroupFolds,
+      externalRunGroupFolds,
+      thinkingIndicatorRunGroupFolds,
+    };
   }
 
   for (const [index, group] of groups.entries()) {
@@ -3444,6 +3475,15 @@ function resolveRunGroupFoldPlacements({
           onToggleRunGroup(fold.key, fold.expanded);
         },
       };
+      if (
+        !control.expanded &&
+        isGoalGroupFold(fold) &&
+        thinkingIndicatorCanHostFold &&
+        waitingIndicatorCanHostCollapsedRunGroupFold(groups, index)
+      ) {
+        thinkingIndicatorRunGroupFolds.push(control);
+        continue;
+      }
       const embeddedGroupId = control.expanded
         ? undefined
         : inlineGroupIdForCollapsedRunGroupFold(groups, index);
@@ -3460,7 +3500,39 @@ function resolveRunGroupFoldPlacements({
     }
   }
 
-  return { embeddedRunGroupFolds, externalRunGroupFolds };
+  return {
+    embeddedRunGroupFolds,
+    externalRunGroupFolds,
+    thinkingIndicatorRunGroupFolds,
+  };
+}
+
+function waitingIndicatorCanHostCollapsedRunGroupFold(
+  groups: readonly ChatEventGroup[],
+  index: number,
+): boolean {
+  const group = groups[index];
+  if (!group || group.role !== "user") {
+    return false;
+  }
+  const runId = firstRunIdForEvents(group.events);
+  if (runId === undefined) {
+    return false;
+  }
+  for (const candidate of groups.slice(index + 1)) {
+    const candidateRunId = firstRunIdForEvents(candidate.events);
+    if (candidateRunId !== undefined && candidateRunId !== runId) {
+      return false;
+    }
+    if (
+      candidateRunId === runId &&
+      candidate.role === "assistant" &&
+      candidate.events.some(isRenderableAssistantEvent)
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function inlineGroupIdForCollapsedRunGroupFold(
@@ -4807,12 +4879,14 @@ function WaitingForAssistantResponse({
   isQueued,
   thinkingLabel,
   serverThinkingLabel,
+  runGroupFolds,
 }: {
   thread: ChatPanelSignals;
   blockStyle: CSSProperties;
   isQueued: boolean;
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
+  runGroupFolds: readonly RunGroupFoldControl[];
 }) {
   const thinkingIndicatorProps = isQueued
     ? {}
@@ -4824,20 +4898,27 @@ function WaitingForAssistantResponse({
       data-role="assistant"
       className="zero-thinking-enter flex flex-col gap-1"
     >
-      <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
+      <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS}>
         <AssistantBubbleAvatar thread={thread} />
-        <div className="zero-chat-bubble-assistant rounded-xl py-4 text-[0.9375rem] leading-[1.7] min-w-0 overflow-hidden">
-          <div className="flex h-5 min-w-0 items-center gap-2">
-            <span className="zero-blocks shrink-0" style={blockStyle}>
-              <span />
-              <span />
-              <span />
-            </span>
-            <ThinkingLabel
-              isQueued={isQueued}
-              thinkingLabel={thinkingLabel}
-              serverThinkingLabel={serverThinkingLabel}
-            />
+        <div className="relative flex min-w-0 flex-col gap-2">
+          {runGroupFolds.map((fold) => {
+            return (
+              <RunGroupFoldRow key={fold.fold.key} control={fold} embedded />
+            );
+          })}
+          <div className="zero-chat-bubble-assistant min-w-0 overflow-hidden rounded-xl py-4 text-[0.9375rem] leading-[1.7]">
+            <div className="flex h-5 min-w-0 items-center gap-2">
+              <span className="zero-blocks shrink-0" style={blockStyle}>
+                <span />
+                <span />
+                <span />
+              </span>
+              <ThinkingLabel
+                isQueued={isQueued}
+                thinkingLabel={thinkingLabel}
+                serverThinkingLabel={serverThinkingLabel}
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -4920,7 +5001,15 @@ function equalRecommendedFollowupSources(
   );
 }
 
-function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
+function ThinkingIndicator({
+  thread,
+  mode,
+  runGroupFolds,
+}: {
+  thread: ChatPanelSignals;
+  mode: ThinkingIndicatorMode;
+  runGroupFolds: readonly RunGroupFoldControl[];
+}) {
   const runWorkFoldingEnabled =
     useGet(featureSwitch$)[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
   const [c1, c2, c3] = useGet(thread.blockColors$);
@@ -4929,7 +5018,6 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
     "--zb-c2": c2,
     "--zb-c3": c3,
   } as CSSProperties;
-  const mode = useLastResolved(thread.thinkingIndicatorMode$) ?? null;
   const thinkingText = useLastResolved(thread.thinkingText$);
   const recommendedFollowupSource =
     useLastResolved(thread.recommendedFollowupSource$, {
@@ -4989,6 +5077,7 @@ function ThinkingIndicator({ thread }: { thread: ChatPanelSignals }) {
       isQueued={isQueued}
       thinkingLabel={thinkingLabel}
       serverThinkingLabel={serverThinkingLabel}
+      runGroupFolds={runGroupFolds}
     />
   );
 }


### PR DESCRIPTION
## Summary

- keep collapsed goal-run history inside the waiting assistant group before the first assistant text arrives
- reuse the same avatar and content-column layout before and after that first assistant message
- cover the assistant-thinking-only state with an integration regression test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx` (33 passed)

## Browser verification

- Not run locally per repository guidance; rely on the PR preview and CI.
