### PR TITLE
perf(mitm-addon): skip parsing canonical chat completion deltas

### DIFF
--- a/crates/runner/mitm-addon/scripts/README.md
+++ b/crates/runner/mitm-addon/scripts/README.md
@@ -54,7 +54,7 @@ before committing the related addon changes.
 
 # Chat Completions SSE fast-path benchmark
 
-The [Chat Completions extractor benchmark](benchmark_openai_chat_completions_usage.py)
+The [Chat Completions SSE fast-path benchmark](benchmark_openai_chat_completions_usage.py)
 compares fresh and reused selective JSON extraction with the bounded canonical-delta classifier
 and the complete SSE fast path. Run it from the repository root with the addon's locked uv
 environment:

--- a/crates/runner/mitm-addon/scripts/README.md
+++ b/crates/runner/mitm-addon/scripts/README.md
@@ -52,11 +52,11 @@ When adding or renaming a shared metadata key, update the registry and use its
 `metadata_keys` constants instead of literal shared keys, then run this check
 before committing the related addon changes.
 
-# Chat Completions extractor benchmark
+# Chat Completions SSE fast-path benchmark
 
 The [Chat Completions extractor benchmark](benchmark_openai_chat_completions_usage.py)
-compares the cost of constructing a selective JSON extractor for each event with the cost of
-resetting and reusing one extractor. Run it from the repository root with the addon's locked uv
+compares fresh and reused selective JSON extraction with the bounded canonical-delta classifier
+and the complete SSE fast path. Run it from the repository root with the addon's locked uv
 environment:
 
 ```bash
@@ -67,14 +67,23 @@ PYTHONPATH=src uv run --no-sync python scripts/benchmark_openai_chat_completions
 The benchmark uses this representative usage-free Chat Completions delta payload:
 
 ```json
-{"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"delta":{"content":"x"}}]}
+{"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"x"}}]}
 ```
 
 Each fresh cycle constructs an extractor, feeds the payload, and finishes the document. Each reused
-cycle resets the existing extractor before feeding and finishing the same payload. The script runs
-10,000 cycles per repeat for five repeats, reports the median duration for each path, and reports a
-speedup ratio calculated as fresh duration divided by reused duration.
+cycle resets the existing extractor before feeding and finishing the same payload. The bounded
+classification cycle validates and classifies the complete payload without selective extraction.
+The complete fast-path cycle sends the corresponding `data:` event through a reused
+`SseUsageScanner`, including SSE framing and provider-handler work, and verifies before timing that
+the payload is eligible for the fast path.
+
+The script runs 10,000 cycles per repeat for five repeats, reports the median duration for each
+path, and reports construction-reuse, full-parse-to-classification, and
+full-parse-to-complete-fast-path ratios. The bounded classifier retains at most 1,024 event bytes;
+unknown, ambiguous, candidate-bearing, malformed, or larger events use the authoritative selective
+extractor and are outside the optimized benchmark path.
 
 The timings are informational and machine-dependent microbenchmark results, not an end-to-end
-parser benchmark or a fixed CI pass/fail threshold. For before-and-after comparisons, use the same
-Python and dependency environment, hardware, and similar system conditions where possible.
+response latency measurement or a fixed CI pass/fail threshold. For before-and-after comparisons,
+use the same Python and dependency environment, hardware, and similar system conditions where
+possible.

--- a/crates/runner/mitm-addon/scripts/benchmark_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/scripts/benchmark_openai_chat_completions_usage.py
@@ -1,18 +1,25 @@
-"""Benchmark fresh and reused Chat Completions selective JSON extraction."""
+"""Benchmark Chat Completions full extraction and bounded SSE fast paths."""
 
 import sys
 from collections.abc import Callable
 from statistics import median
 from time import perf_counter
 
-from usage.openai_chat_completions import _new_extractor
+from usage.openai_chat_completions import (
+    _is_canonical_usage_free_delta,
+    _new_extractor,
+    create_openai_chat_completions_sse_usage_extractor,
+)
 
 _CYCLES = 10_000
 _REPEATS = 5
 _PAYLOAD = (
-    b'{"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"delta":{"content":"x"}}]}'
+    b'{"id":"chatcmpl_1","object":"chat.completion.chunk",'
+    b'"choices":[{"index":0,"delta":{"content":"x"}}]}'
 )
+_SSE_EVENT = b"data: " + _PAYLOAD + b"\n\n"
 _REUSED_EXTRACTOR = _new_extractor()
+_FAST_PATH_SCANNER, _ = create_openai_chat_completions_sse_usage_extractor()
 
 
 def _fresh_cycle() -> None:
@@ -27,6 +34,14 @@ def _reused_cycle() -> None:
     _REUSED_EXTRACTOR.finish()
 
 
+def _bounded_classification_cycle() -> None:
+    _is_canonical_usage_free_delta(_PAYLOAD)
+
+
+def _fast_path_sse_cycle() -> None:
+    _FAST_PATH_SCANNER(_SSE_EVENT)
+
+
 def _median_duration(cycle: Callable[[], None]) -> float:
     durations: list[float] = []
     for _ in range(_REPEATS):
@@ -38,12 +53,22 @@ def _median_duration(cycle: Callable[[], None]) -> float:
 
 
 def main() -> None:
+    if not _is_canonical_usage_free_delta(_PAYLOAD):
+        raise RuntimeError("benchmark payload did not enter the bounded fast path")
     fresh_duration = _median_duration(_fresh_cycle)
     reused_duration = _median_duration(_reused_cycle)
+    classification_duration = _median_duration(_bounded_classification_cycle)
+    sse_fast_path_duration = _median_duration(_fast_path_sse_cycle)
     sys.stdout.write(
         f"{_CYCLES:,} fresh construction/feed/finish cycles: {fresh_duration:.6f} s\n"
         f"{_CYCLES:,} reused reset/feed/finish cycles: {reused_duration:.6f} s\n"
-        f"speedup: {fresh_duration / reused_duration:.2f}x\n"
+        f"{_CYCLES:,} bounded decode/classify cycles: {classification_duration:.6f} s\n"
+        f"{_CYCLES:,} complete SSE fast-path cycles: {sse_fast_path_duration:.6f} s\n"
+        f"construction reuse speedup: {fresh_duration / reused_duration:.2f}x\n"
+        f"reused full parse to bounded classification speedup: "
+        f"{reused_duration / classification_duration:.2f}x\n"
+        f"reused full parse to complete SSE fast-path speedup: "
+        f"{reused_duration / sse_fast_path_duration:.2f}x\n"
     )
 
 

--- a/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
+++ b/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
@@ -235,6 +235,7 @@ def _new_extractor(
             include_usage=include_usage,
             include_failure=include_failure,
         ),
+        max_number_bytes=_JSON_MAX_NUMBER_BYTES,
         max_work_units=_CHAT_COMPLETIONS_MAX_WORK_UNITS,
     )
 

--- a/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
+++ b/crates/runner/mitm-addon/src/usage/openai_chat_completions.py
@@ -1,5 +1,7 @@
 """OpenAI-compatible Chat Completions usage parsing primitives."""
 
+import json
+import math
 from collections.abc import Callable
 
 from mitmproxy import http
@@ -13,6 +15,7 @@ from .json_selective import (
     JsonSelectiveExtractor,
     Path,
     ScalarField,
+    json_nesting_within_limit,
 )
 from .model_http import (
     ModelHttpFailureEvidence,
@@ -33,9 +36,33 @@ from .quantities import MAX_USAGE_QUANTITY
 from .sse import SseUsageScanner
 
 _CHAT_COMPLETIONS_MAX_WORK_UNITS = 65_536
+_CHAT_COMPLETIONS_SSE_FAST_PATH_MAX_BYTES = 1024
+_JSON_MAX_NUMBER_BYTES = 128
 _DONE_SENTINEL = b"[DONE]"
 _DONE_PREFIX_MAX_BYTES = 16
 _SseUsageParseErrorCallback = Callable[[str, str], None]
+
+_CHAT_COMPLETIONS_CHUNK_KEYS = frozenset(
+    (
+        "id",
+        "object",
+        "created",
+        "model",
+        "service_tier",
+        "system_fingerprint",
+        "choices",
+    )
+)
+_CHAT_COMPLETIONS_CHOICE_KEYS = frozenset(
+    (
+        "index",
+        "delta",
+        "logprobs",
+        "finish_reason",
+    )
+)
+_UTF8_SURROGATE_MIN = 0xD800
+_UTF8_SURROGATE_MAX = 0xDFFF
 
 _TOP_LEVEL_USAGE_PATH = ("usage",)
 _FIRST_CHOICE_USAGE_PATH = ("choices", FIRST_ARRAY_ELEMENT, "usage")
@@ -73,6 +100,122 @@ _USAGE_VALUE_PRESENCE_PATHS = {
     *_USAGE_PATHS,
     *{(*prefix, *_CACHED_TOKENS_SUFFIX) for prefix in _USAGE_PATHS},
 }
+
+
+class _JsonObjectPairs(list[tuple[str, object]]):
+    """Decoded JSON object that preserves member order and duplicates."""
+
+
+class _FastPathRejectedError(ValueError):
+    """Internal signal that bounded JSON must use the authoritative extractor."""
+
+
+def _parse_bounded_json_int(value: str) -> int:
+    if len(value) > _JSON_MAX_NUMBER_BYTES:
+        raise _FastPathRejectedError
+    return int(value)
+
+
+def _parse_bounded_json_float(value: str) -> float:
+    if len(value) > _JSON_MAX_NUMBER_BYTES:
+        raise _FastPathRejectedError
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise _FastPathRejectedError
+    return parsed
+
+
+def _reject_json_constant(value: str) -> object:
+    raise _FastPathRejectedError(value)
+
+
+def _contains_surrogate(value: str) -> bool:
+    return any(_UTF8_SURROGATE_MIN <= ord(char) <= _UTF8_SURROGATE_MAX for char in value)
+
+
+def _json_value_is_unambiguous(value: object) -> bool:
+    if isinstance(value, str):
+        return not _contains_surrogate(value)
+    if isinstance(value, _JsonObjectPairs):
+        keys: set[str] = set()
+        for key, child in value:
+            if key in keys or _contains_surrogate(key) or not _json_value_is_unambiguous(child):
+                return False
+            keys.add(key)
+        return True
+    if isinstance(value, list):
+        return all(_json_value_is_unambiguous(child) for child in value)
+    return value is None or type(value) in (bool, int, float)
+
+
+def _object_values(value: object) -> dict[str, object] | None:
+    if not isinstance(value, _JsonObjectPairs):
+        return None
+    return dict(value)
+
+
+def _optional_string_has_type(values: dict[str, object], key: str, *, nullable: bool) -> bool:
+    if key not in values:
+        return True
+    value = values[key]
+    return isinstance(value, str) or (nullable and value is None)
+
+
+def _is_canonical_usage_free_delta(body: bytes) -> bool:
+    """Return whether bounded JSON is a strict ordinary Chat Completions chunk."""
+
+    if not body or len(body) > _CHAT_COMPLETIONS_SSE_FAST_PATH_MAX_BYTES:
+        return False
+    if not json_nesting_within_limit(body):
+        return False
+    try:
+        decoded = json.loads(
+            body.decode("utf-8"),
+            object_pairs_hook=_JsonObjectPairs,
+            parse_int=_parse_bounded_json_int,
+            parse_float=_parse_bounded_json_float,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, _FastPathRejectedError, RecursionError):
+        return False
+    if not _json_value_is_unambiguous(decoded):
+        return False
+
+    values = _object_values(decoded)
+    if values is None or not set(values).issubset(_CHAT_COMPLETIONS_CHUNK_KEYS):
+        return False
+    if values.get("object") != "chat.completion.chunk":
+        return False
+    if not _optional_string_has_type(values, "id", nullable=False):
+        return False
+    if not _optional_string_has_type(values, "model", nullable=False):
+        return False
+    if not _optional_string_has_type(values, "service_tier", nullable=True):
+        return False
+    if not _optional_string_has_type(values, "system_fingerprint", nullable=True):
+        return False
+    if "created" in values and type(values["created"]) is not int:
+        return False
+
+    choices = values.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return False
+    for choice in choices:
+        choice_values = _object_values(choice)
+        if choice_values is None or not set(choice_values).issubset(_CHAT_COMPLETIONS_CHOICE_KEYS):
+            return False
+        if type(choice_values.get("index")) is not int:
+            return False
+        if not isinstance(choice_values.get("delta"), _JsonObjectPairs):
+            return False
+        if not _optional_string_has_type(choice_values, "finish_reason", nullable=True):
+            return False
+        if "logprobs" in choice_values and not (
+            choice_values["logprobs"] is None
+            or isinstance(choice_values["logprobs"], _JsonObjectPairs)
+        ):
+            return False
+    return True
 
 
 def _new_extractor(
@@ -174,38 +317,41 @@ class _OpenAIChatCompletionsSseUsageHandler:
             include_usage=include_usage,
             include_failure=failure_observer is not None,
         )
-        self._data_prefix = bytearray()
-        self._data_prefix_complete = True
+        self._event_data = bytearray()
+        self._using_extractor = False
 
     def should_capture_event(self, event_name: str | None) -> bool:
         """Capture named and eventless compatible frames."""
         return True
 
     def on_event_start(self, event_name: str | None) -> None:
-        self._data_prefix.clear()
-        self._data_prefix_complete = True
+        self._event_data.clear()
+        self._using_extractor = False
 
     def on_data(self, chunk: bytes) -> None:
-        self._extractor.feed(chunk)
+        if self._using_extractor:
+            self._extractor.feed(chunk)
+            return
 
-        remaining = max(_DONE_PREFIX_MAX_BYTES - len(self._data_prefix), 0)
-        self._data_prefix.extend(chunk[:remaining])
+        remaining = max(
+            _CHAT_COMPLETIONS_SSE_FAST_PATH_MAX_BYTES - len(self._event_data),
+            0,
+        )
+        self._event_data.extend(chunk[:remaining])
         if len(chunk) > remaining:
-            self._data_prefix_complete = False
+            self._extractor.feed(bytes(self._event_data))
+            self._event_data.clear()
+            self._using_extractor = True
+            self._extractor.feed(chunk[remaining:])
 
     def on_data_separator(self) -> None:
         self.on_data(b"\n")
 
     def on_event_end(self, event_name: str | None) -> None:
-        data_prefix = bytes(self._data_prefix)
-        data_prefix_complete = self._data_prefix_complete
-        self._data_prefix.clear()
-        self._data_prefix_complete = True
-
-        result = self._extractor.finish()
-        self._extractor.reset()
-        if not result.complete:
-            if data_prefix_complete and data_prefix.strip() == _DONE_SENTINEL:
+        if not self._using_extractor:
+            event_data = bytes(self._event_data)
+            self._event_data.clear()
+            if len(event_data) <= _DONE_PREFIX_MAX_BYTES and event_data.strip() == _DONE_SENTINEL:
                 if self._failure_observer is not None:
                     self._failure_observer.observe(
                         ModelHttpFailureEvidence(
@@ -215,6 +361,22 @@ class _OpenAIChatCompletionsSseUsageHandler:
                         )
                     )
                 return
+            if _is_canonical_usage_free_delta(event_data):
+                if self._failure_observer is not None:
+                    self._failure_observer.observe(
+                        ModelHttpFailureEvidence(
+                            event_name=event_name,
+                            has_choices=True,
+                            is_valid=True,
+                        )
+                    )
+                return
+            self._extractor.feed(event_data)
+        self._using_extractor = False
+
+        result = self._extractor.finish()
+        self._extractor.reset()
+        if not result.complete:
             if self._failure_observer is not None:
                 self._failure_observer.observe(
                     failure_evidence_from_result(result, event_name=event_name)
@@ -244,8 +406,8 @@ class _OpenAIChatCompletionsSseUsageHandler:
 
     def on_event_discard(self, event_name: str | None) -> None:
         self._extractor.reset()
-        self._data_prefix.clear()
-        self._data_prefix_complete = True
+        self._event_data.clear()
+        self._using_extractor = False
         if self._failure_observer is not None:
             self._failure_observer.observe(ModelHttpFailureEvidence(event_name=event_name))
 

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -156,9 +156,7 @@ def test_sse_fast_path_bound_is_inclusive_and_overflow_replays_once():
     exact = _canonical_delta_with_size(
         openai_chat_completions._CHAT_COMPLETIONS_SSE_FAST_PATH_MAX_BYTES
     )
-    over = _canonical_delta_with_size(
-        openai_chat_completions._CHAT_COMPLETIONS_SSE_FAST_PATH_MAX_BYTES + 1
-    )
+    over = exact[:-1] + b',"usage":{"prompt_tokens":9,"completion_tokens":2}}'
 
     with patch.object(
         openai_chat_completions.JsonSelectiveExtractor,
@@ -172,7 +170,11 @@ def test_sse_fast_path_bound_is_inclusive_and_overflow_replays_once():
         scanner.finish()
 
     assert len(finish_calls) == 1
-    assert parsed_usage == {}
+    assert parsed_usage == {
+        "tokens.input": 9,
+        "tokens.output": 2,
+        "message_id": "chatcmpl_bound",
+    }
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -3,6 +3,7 @@
 import json
 from collections.abc import Callable
 from pathlib import Path
+from unittest.mock import patch
 
 import brotli
 import pytest
@@ -12,10 +13,12 @@ from mitmproxy.test import tutils
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
+import usage.openai_chat_completions as openai_chat_completions
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.model_provider_flow_helpers import make_model_provider_flow
 from tests.stream_buffer_helpers import set_response_stream_buffer
+from usage.model_http import ModelHttpFailureEvidence
 from usage.quantities import MAX_USAGE_QUANTITY
 
 
@@ -63,6 +66,301 @@ def _run_response(flow: http.HTTPFlow, usage_webhook_api):
         mitm_addon.response(flow)
         usage.flush_usage_events(trigger="test")
     return webhook
+
+
+class _RecordingFailureObserver:
+    def __init__(self) -> None:
+        self.observed: list[ModelHttpFailureEvidence] = []
+
+    def needs_sse_event(self, event_name: str | None) -> bool:
+        return True
+
+    def observe(self, evidence: ModelHttpFailureEvidence) -> None:
+        self.observed.append(evidence)
+
+    def observe_json(self, evidence: ModelHttpFailureEvidence) -> None:
+        raise AssertionError("unexpected JSON evidence")
+
+    def finish(self) -> None:
+        return None
+
+
+def _track_chat_extractor_finishes() -> tuple[list[object], Callable[..., object]]:
+    calls: list[object] = []
+    original_finish = openai_chat_completions.JsonSelectiveExtractor.finish
+
+    def finish(extractor):
+        calls.append(extractor)
+        return original_finish(extractor)
+
+    return calls, finish
+
+
+def _canonical_delta_with_size(size: int) -> bytes:
+    prefix = (
+        b'{"id":"chatcmpl_bound","object":"chat.completion.chunk",'
+        b'"choices":[{"index":0,"delta":{"content":"'
+    )
+    suffix = b'"}}]}'
+    assert size >= len(prefix) + len(suffix)
+    return prefix + b"x" * (size - len(prefix) - len(suffix)) + suffix
+
+
+def test_canonical_sse_deltas_skip_selective_extraction_across_framing_variants():
+    observer = _RecordingFailureObserver()
+    finish_calls, tracked_finish = _track_chat_extractor_finishes()
+    stream = (
+        b'data: {"id":"chatcmpl_text","object":"chat.completion.chunk",'
+        b'"created":1,"model":"gpt-5.5","service_tier":null,'
+        b'"choices":[{"index":0,"delta":{"content":"hello"},'
+        b'"logprobs":null,"finish_reason":null}]}\n\n'
+        b"event: chunk\n"
+        b'data: {"object":"chat.completion.chunk",'
+        b'"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+        b'data: {"object":"chat.completion.chunk","choices":\n'
+        b'data: [{"index":0,"delta":{"tool_calls":[]}},'
+        b'{"index":1,"delta":{}}]}\n\n'
+    )
+
+    with patch.object(
+        openai_chat_completions.JsonSelectiveExtractor,
+        "finish",
+        tracked_finish,
+    ):
+        scanner, parsed_usage = (
+            openai_chat_completions.create_openai_chat_completions_sse_usage_extractor(
+                failure_observer=observer
+            )
+        )
+        chunk_sizes = (1, 2, 5, 13, 3, 8)
+        offset = 0
+        chunk_index = 0
+        while offset < len(stream):
+            chunk_size = chunk_sizes[chunk_index % len(chunk_sizes)]
+            scanner(stream[offset : offset + chunk_size])
+            offset += chunk_size
+            chunk_index += 1
+        scanner.finish()
+
+    assert finish_calls == []
+    assert parsed_usage == {}
+    assert observer.observed == [
+        ModelHttpFailureEvidence(has_choices=True, is_valid=True),
+        ModelHttpFailureEvidence(event_name="chunk", has_choices=True, is_valid=True),
+        ModelHttpFailureEvidence(has_choices=True, is_valid=True),
+    ]
+
+
+def test_sse_fast_path_bound_is_inclusive_and_overflow_replays_once():
+    finish_calls, tracked_finish = _track_chat_extractor_finishes()
+    exact = _canonical_delta_with_size(
+        openai_chat_completions._CHAT_COMPLETIONS_SSE_FAST_PATH_MAX_BYTES
+    )
+    over = _canonical_delta_with_size(
+        openai_chat_completions._CHAT_COMPLETIONS_SSE_FAST_PATH_MAX_BYTES + 1
+    )
+
+    with patch.object(
+        openai_chat_completions.JsonSelectiveExtractor,
+        "finish",
+        tracked_finish,
+    ):
+        scanner, parsed_usage = (
+            openai_chat_completions.create_openai_chat_completions_sse_usage_extractor()
+        )
+        scanner(b"data: " + exact + b"\n\ndata: " + over + b"\n\n")
+        scanner.finish()
+
+    assert len(finish_calls) == 1
+    assert parsed_usage == {}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        (
+            b'{"object":"chat.completion.chunk","provider":"compatible",'
+            b'"choices":[{"index":0,"delta":{}}]}',
+            None,
+        ),
+        (
+            b'{"object":"chat.completion.chunk","object":"chat.completion.chunk",'
+            b'"choices":[{"index":0,"delta":{}}]}',
+            None,
+        ),
+        (
+            b'{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"value":NaN}}]}',
+            "expected json value",
+        ),
+        (
+            b'{"object":"chat.completion.chunk",'
+            + rb'"choices":[{"index":0,"delta":{"content":"\ud800"}}]}',
+            None,
+        ),
+        (
+            b'{"object":"chat.completion.chunk",'
+            b'"choices":[{"index":0,"delta":{"value":' + b"9" * 129 + b"}}]}",
+            "number limit exceeded",
+        ),
+        (
+            b'{"object":"chat.completion.chunk",'
+            b'"choices":[{"index":0,"delta":{"value":' + b"[" * 260 + b"0" + b"]" * 260 + b"}}]}",
+            "max depth exceeded",
+        ),
+        (
+            b'{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}]}x',
+            "trailing data after root value",
+        ),
+        (
+            b'{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}]',
+            "incomplete json",
+        ),
+    ],
+    ids=(
+        "unknown-envelope-key",
+        "duplicate-key",
+        "non-standard-constant",
+        "lone-surrogate",
+        "oversized-number",
+        "excessive-depth",
+        "trailing-data",
+        "malformed",
+    ),
+)
+def test_ambiguous_sse_delta_falls_back_once(payload: bytes, expected_error: str | None):
+    errors: list[tuple[str, str]] = []
+    finish_calls, tracked_finish = _track_chat_extractor_finishes()
+
+    with patch.object(
+        openai_chat_completions.JsonSelectiveExtractor,
+        "finish",
+        tracked_finish,
+    ):
+        scanner, parsed_usage = (
+            openai_chat_completions.create_openai_chat_completions_sse_usage_extractor(
+                lambda event, error: errors.append((event, error))
+            )
+        )
+        scanner(b"data: " + payload + b"\n\n")
+        scanner.finish()
+
+    assert len(finish_calls) == 1
+    assert parsed_usage == {}
+    assert errors == ([] if expected_error is None else [("eventless", expected_error)])
+
+
+def test_escaped_usage_candidate_falls_back_and_reports_usage():
+    payload = (
+        b'{"id":"chatcmpl_escaped","object":"chat.completion.chunk","model":"gpt-5.5",'
+        b'"choices":[{"index":0,"delta":{}}],'
+        + rb'"\u0075sage":{"prompt_tokens":9,"completion_tokens":2}}'
+    )
+    finish_calls, tracked_finish = _track_chat_extractor_finishes()
+
+    with patch.object(
+        openai_chat_completions.JsonSelectiveExtractor,
+        "finish",
+        tracked_finish,
+    ):
+        scanner, parsed_usage = (
+            openai_chat_completions.create_openai_chat_completions_sse_usage_extractor()
+        )
+        scanner(b"data: " + payload + b"\n\n")
+        scanner.finish()
+
+    assert len(finish_calls) == 1
+    assert parsed_usage == {
+        "tokens.input": 9,
+        "tokens.output": 2,
+        "model": "gpt-5.5",
+        "message_id": "chatcmpl_escaped",
+    }
+
+
+@pytest.mark.parametrize(
+    ("usage_members", "expected_usage"),
+    [
+        (
+            b'"usage":{"prompt_tokens":9,"completion_tokens":2},"usage":null',
+            {},
+        ),
+        (
+            rb'"\u0075sage":null,"usage":{"prompt_tokens":9,"completion_tokens":2}',
+            {
+                "tokens.input": 9,
+                "tokens.output": 2,
+                "model": "gpt-5.5",
+                "message_id": "chatcmpl_duplicate",
+            },
+        ),
+    ],
+    ids=("last-null-clears", "escaped-first-last-usage-wins"),
+)
+def test_duplicate_usage_candidates_keep_authoritative_last_member_semantics(
+    usage_members: bytes,
+    expected_usage: dict[str, object],
+):
+    payload = (
+        b'{"id":"chatcmpl_duplicate","object":"chat.completion.chunk",'
+        b'"model":"gpt-5.5","choices":[{"index":0,"delta":{}}],' + usage_members + b"}"
+    )
+    finish_calls, tracked_finish = _track_chat_extractor_finishes()
+
+    with patch.object(
+        openai_chat_completions.JsonSelectiveExtractor,
+        "finish",
+        tracked_finish,
+    ):
+        scanner, parsed_usage = (
+            openai_chat_completions.create_openai_chat_completions_sse_usage_extractor()
+        )
+        scanner(b"data: " + payload + b"\n\n")
+        scanner.finish()
+
+    assert len(finish_calls) == 1
+    assert parsed_usage == expected_usage
+
+
+def test_fast_path_preserves_canonical_error_and_done_failure_evidence():
+    observer = _RecordingFailureObserver()
+    finish_calls, tracked_finish = _track_chat_extractor_finishes()
+    canonical_delta = (
+        b'{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"x"}}]}'
+    )
+    escaped_error = (
+        b'{"choices":[{'
+        + rb'"\u0065rror":{"metadata":{"error_type":"provider_overloaded"}}'
+        + b"}]}"
+    )
+
+    with patch.object(
+        openai_chat_completions.JsonSelectiveExtractor,
+        "finish",
+        tracked_finish,
+    ):
+        scanner, parsed_usage = (
+            openai_chat_completions.create_openai_chat_completions_sse_usage_extractor(
+                include_usage=False,
+                failure_observer=observer,
+            )
+        )
+        scanner(
+            b"data: " + canonical_delta + b"\n\ndata: " + escaped_error + b"\n\ndata: [DONE]\n\n"
+        )
+        scanner.finish()
+
+    assert len(finish_calls) == 1
+    assert parsed_usage == {}
+    assert observer.observed == [
+        ModelHttpFailureEvidence(has_choices=True, is_valid=True),
+        ModelHttpFailureEvidence(
+            failure_codes=("provider_overloaded",),
+            has_error=True,
+            has_choices=True,
+            is_valid=True,
+        ),
+        ModelHttpFailureEvidence(is_done=True, is_valid=True),
+    ]
 
 
 class TestOpenAIChatCompletionsUsage:
@@ -239,42 +537,49 @@ class TestOpenAIChatCompletionsUsage:
             content_type="text/event-stream",
         )
         delta = (
-            b'data: {"id":"chatcmpl_delta","model":"gpt-5.5",'
-            b'"choices":[{"delta":{"content":"x"}}]}\n\n'
+            b'data: {"id":"chatcmpl_delta","object":"chat.completion.chunk",'
+            b'"model":"gpt-5.5","choices":[{"index":0,"delta":{"content":"x"}}]}\n\n'
         )
 
-        mitm_addon.responseheaders(flow)
-        callback = response_stream(flow)
-        callback(
-            b"data: "
-            + _chat_payload(usage_payload={"prompt_tokens": 90, "completion_tokens": 40})
-            + b"\n\n"
-            + delta * 2_560
-            + b'data: {"id":"chatcmpl_discarded"\n'
-            + b"x" * 4_097
-            + b"\n\n"
-            + b'data: {"id":"chatcmpl_bad","usage":{"prompt_tokens":30}\n\n'
-        )
-        final_payload = {
-            "id": "chatcmpl_final",
-            "model": "gpt-5.5",
-            "choices": [
-                {
-                    "usage": {
-                        "prompt_tokens": 30,
-                        "completion_tokens": 5,
+        finish_calls, tracked_finish = _track_chat_extractor_finishes()
+        with patch.object(
+            openai_chat_completions.JsonSelectiveExtractor,
+            "finish",
+            tracked_finish,
+        ):
+            mitm_addon.responseheaders(flow)
+            callback = response_stream(flow)
+            callback(
+                b"data: "
+                + _chat_payload(usage_payload={"prompt_tokens": 90, "completion_tokens": 40})
+                + b"\n\n"
+                + delta * 2_560
+                + b'data: {"id":"chatcmpl_discarded"\n'
+                + b"x" * 4_097
+                + b"\n\n"
+                + b'data: {"id":"chatcmpl_bad","usage":{"prompt_tokens":30}\n\n'
+            )
+            final_payload = {
+                "id": "chatcmpl_final",
+                "model": "gpt-5.5",
+                "choices": [
+                    {
+                        "usage": {
+                            "prompt_tokens": 30,
+                            "completion_tokens": 5,
+                        }
                     }
-                }
-            ],
-        }
-        callback(
-            b"data: "
-            + json.dumps(final_payload, separators=(",", ":")).encode()
-            + b"\n\ndata: [DONE]\n\n"
-        )
+                ],
+            }
+            callback(
+                b"data: "
+                + json.dumps(final_payload, separators=(",", ":")).encode()
+                + b"\n\ndata: [DONE]\n\n"
+            )
 
-        webhook = _run_response(flow, self._usage_webhook_api)
+            webhook = _run_response(flow, self._usage_webhook_api)
 
+        assert len(finish_calls) == 3
         expected_quantities = {
             "tokens.input": 30,
             "tokens.output": 5,

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -321,12 +321,13 @@ def test_duplicate_usage_candidates_keep_authoritative_last_member_semantics(
     assert parsed_usage == expected_usage
 
 
-def test_fast_path_preserves_canonical_error_and_done_failure_evidence():
+def test_fast_path_preserves_error_and_done_failure_evidence():
     observer = _RecordingFailureObserver()
     finish_calls, tracked_finish = _track_chat_extractor_finishes()
     canonical_delta = (
         b'{"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"x"}}]}'
     )
+    top_level_error = b'{"error":{"metadata":{"error_type":"provider_unavailable"}}}'
     escaped_error = (
         b'{"choices":[{'
         + rb'"\u0065rror":{"metadata":{"error_type":"provider_overloaded"}}'
@@ -345,14 +346,25 @@ def test_fast_path_preserves_canonical_error_and_done_failure_evidence():
             )
         )
         scanner(
-            b"data: " + canonical_delta + b"\n\ndata: " + escaped_error + b"\n\ndata: [DONE]\n\n"
+            b"data: "
+            + canonical_delta
+            + b"\n\ndata: "
+            + top_level_error
+            + b"\n\ndata: "
+            + escaped_error
+            + b"\n\ndata: [DONE]\n\n"
         )
         scanner.finish()
 
-    assert len(finish_calls) == 1
+    assert len(finish_calls) == 2
     assert parsed_usage == {}
     assert observer.observed == [
         ModelHttpFailureEvidence(has_choices=True, is_valid=True),
+        ModelHttpFailureEvidence(
+            failure_codes=("provider_unavailable",),
+            has_error=True,
+            is_valid=True,
+        ),
         ModelHttpFailureEvidence(
             failure_codes=("provider_overloaded",),
             has_error=True,


### PR DESCRIPTION
## Summary

- add a 1,024-byte bounded classifier for canonical usage-free Chat Completions SSE deltas
- skip the reusable selective extractor only for strict, unambiguous delta envelopes while preserving equivalent failure evidence
- replay candidate-bearing, unknown, malformed, ambiguous, and over-bound events through the existing authoritative extractor exactly once
- extend deterministic coverage and the committed microbenchmark for the complete SSE fast path

## Behavior and safety

The fast path requires strict UTF-8, complete JSON, unique keys, bounded nesting and number tokens, the canonical `chat.completion.chunk` envelope, and canonical choice shapes. Usage or error candidates, escaped candidate keys, duplicates, unknown shapes, malformed JSON, and larger events retain the existing extraction, accounting, diagnostics, and failure-classification behavior.

This change is limited to streaming Chat Completions event inspection. It does not change non-streaming JSON handling, provider wire formats, APIs, storage, migrations, or rollout configuration.

## Benchmark

Locked CPython 3.14.0 environment, 10,000 cycles per repeat, median of five repeats:

```text
fresh construction/feed/finish:             1.035419 s
reused reset/feed/finish:                    0.621923 s
bounded decode/classify:                     0.128644 s
complete SSE fast path:                      0.151129 s
reused full parse -> bounded classification: 4.83x
reused full parse -> complete SSE fast path:  4.12x
```

The benchmark is informational and has no wall-clock CI threshold.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `ruff format --check src/usage/openai_chat_completions.py tests/test_openai_chat_completions_usage.py scripts/benchmark_openai_chat_completions_usage.py`
- `ruff check src/usage/openai_chat_completions.py tests/test_openai_chat_completions_usage.py scripts/benchmark_openai_chat_completions_usage.py`
- `basedpyright -p .`
- `python -m pytest tests/test_openai_chat_completions_usage.py -q` (31 passed)
- `python -m pytest tests/test_model_provider_failure_reporting.py -q` (100 passed)
- `python -m pytest -q` (7,327 passed)
- `PYTHONPATH=src python scripts/benchmark_openai_chat_completions_usage.py`

Closes #31430
