### PR TITLE
fix(cli): make action url handoffs loss-resistant

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -67,6 +67,20 @@ resource key, define the card's signals and registry, and add its render case.
 The generic URL parser must not treat every `/chats/*` link as a card before
 that card type exists.
 
+## Producing User-facing Action URLs
+
+CLI producers must complete the action path and every action-defining query
+parameter before calling the shared action URL finalizer. For callback-capable
+actions, the finalizer appends `threadId` and then terminal `callbackPrompt`
+and returns the serialized URL. Callers must not append fields after that
+boundary.
+
+The CLI handoff output and run-level Agent Tools prompt require agents to return
+user-facing action URLs exactly as printed. Agents must not rewrite, shorten,
+reconstruct, or omit query parameters. Consumers continue to treat URL fields
+as untrusted claims: an incomplete or context-mismatched mutating action fails
+closed, and the parser must not infer missing authorization or target data.
+
 ## Data Flow
 
 ### 1. Parse content into pure descriptors

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -15373,7 +15373,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
   it("advertises connector account switching only while the feature is enabled", async () => {
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
-    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const { actor, agentId } = await entitledRunActor();
 
     await connectors.updateFeatureSwitches(actor, {
       [FeatureSwitchKey.ConnectorAccounts]: false,
@@ -15383,10 +15383,14 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       prompt: "switch my connector account",
       modelProvider: "anthropic-api-key",
     });
-    await api.heartbeatRunner(runnerGroup);
-    const gatedOffClaim = await api.claimRunnerJob(gatedOff.runId);
-    expect(gatedOffClaim.appendSystemPrompt ?? "").not.toContain(
+    const gatedOffPrompt =
+      (await api.readRun(actor, gatedOff.runId)).appendSystemPrompt ?? "";
+    expect(gatedOffPrompt).not.toContain(
       "okou connector account switch-request",
+    );
+    expect(gatedOffPrompt).toContain("return that exact URL verbatim");
+    expect(gatedOffPrompt).toContain(
+      "Never rewrite, shorten, reconstruct, or omit any query parameters",
     );
     await api.requestCancelRun(actor, gatedOff.runId, [200]);
 
@@ -15398,9 +15402,8 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       prompt: "switch my connector account",
       modelProvider: "anthropic-api-key",
     });
-    await api.heartbeatRunner(runnerGroup);
-    const gatedOnClaim = await api.claimRunnerJob(gatedOn.runId);
-    const appendSystemPrompt = gatedOnClaim.appendSystemPrompt ?? "";
+    const appendSystemPrompt =
+      (await api.readRun(actor, gatedOn.runId)).appendSystemPrompt ?? "";
     expect(appendSystemPrompt).toContain(
       "okou connector account list <slug> --json",
     );

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -427,6 +427,7 @@ function buildAgentToolsPrompt(args: {
     "# Agent Tools",
     `You have access to the Okou CLI. Run commands with: \`${okouCliCommand} <command>\``,
     "- Discover available commands: `okou --help`.",
+    "- When an Okou CLI command prints a user-facing action URL, return that exact URL verbatim. Never rewrite, shorten, reconstruct, or omit any query parameters.",
     "- Capability questions: when the user asks what Okou can do, whether Okou can do a category of work, or compares Okou to another assistant, run `okou intro` first. Use its output to synthesize a concise answer in the user's language. Do not paste the intro verbatim.",
     "- Locate local agent-session files, search web chat messages, or inspect external services via connectors: `okou search --help`.",
     '- Workflow and automation requests use the `workflow-setup` skill first, then follow its guidance. This covers creating, editing, inspecting, running, scheduling, enabling, disabling, copying, or deleting a workflow or automation, and any recurring or event-driven request (for example "every morning", "when a new email arrives", "whenever X happens", "monitor", "remind me", "keep this in sync") even when the user does not say the word "workflow".',

--- a/turbo/apps/cli/src/commands/banking/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/banking/__tests__/index.test.ts
@@ -172,11 +172,13 @@ describe("okou banking command", () => {
     }
     const url = new URL(urlText);
     expect(url.pathname).toBe(`/agents/${AGENT_ID}/banking`);
-    expect(url.searchParams.get("reason")).toBe("Review recent expenses");
-    expect(url.searchParams.get("threadId")).toBe(THREAD_ID);
-    expect(url.searchParams.get("callbackPrompt")).toBe(
-      "Continue the expense review",
-    );
+    expect(Array.from(url.searchParams.entries())).toStrictEqual([
+      ["reason", "Review recent expenses"],
+      ["threadId", THREAD_ID],
+      ["callbackPrompt", "Continue the expense review"],
+    ]);
     expect(output).toContain("end the current turn");
+    expect(output).toContain("exact callback URL above verbatim");
+    expect(output).toContain("omitting any query parameters");
   });
 });

--- a/turbo/apps/cli/src/commands/banking/index.ts
+++ b/turbo/apps/cli/src/commands/banking/index.ts
@@ -8,7 +8,7 @@ import {
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { getOkouAgentId } from "../../lib/okou-env";
 import {
-  addRequestedCallbackSearchParams,
+  finalizeActionUrl,
   printCallbackTurnInstruction,
 } from "../connector/action-url";
 import { getPlatformOrigin } from "../doctor/platform-url";
@@ -101,17 +101,16 @@ const accessRequestCommand = new Command()
         throw new Error("--reason cannot exceed 500 characters");
       }
 
-      const params = new URLSearchParams({ reason });
-      addRequestedCallbackSearchParams(params, options.callbackPrompt, agentId);
       const origin = await getPlatformOrigin();
-      const url = new URL(
+      const actionUrl = new URL(
         `/agents/${encodeURIComponent(agentId)}/banking`,
         origin,
       );
-      url.search = params.toString();
+      actionUrl.searchParams.set("reason", reason);
+      const url = finalizeActionUrl(actionUrl, options.callbackPrompt, agentId);
 
       console.log("Banking access requires user approval:");
-      console.log(url.toString());
+      console.log(url);
       printCallbackTurnInstruction();
     }),
   );

--- a/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
@@ -870,6 +870,38 @@ describe("okou connector check command", () => {
       },
     );
 
+    it("prints a finalized callback action URL for the current web chat", async () => {
+      vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-abc-123");
+      stubDiagnostic(resolvedEnvironment());
+      stubResolvedDependencies("github", {
+        connector: null,
+        enabledConnectorSlugs: [],
+      });
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      const callbackUrlText = getOutput()
+        .split("\n")
+        .find((line) => {
+          return line.includes("callbackPrompt=");
+        });
+      if (!callbackUrlText) {
+        throw new Error("Expected callback action URL");
+      }
+      const callbackUrl = new URL(callbackUrlText);
+      expect(callbackUrl.pathname).toBe("/connectors/github/authorize");
+      expect(Array.from(callbackUrl.searchParams.entries())).toStrictEqual([
+        ["agentId", AGENT_ID],
+        ["threadId", "thread-abc-123"],
+        ["callbackPrompt", "SOMETHING_AGENT_WANT_TO_BE_CALLBACK"],
+      ]);
+    });
+
     it.each([
       {
         name: "unavailable environment metadata",

--- a/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
@@ -31,6 +31,14 @@ interface NonRequestablePolicyCase {
   readonly expected: string;
 }
 
+function permissionActionUrl(output: string): URL {
+  const href = output.match(/\[Manage [^\]]+ permissions\]\(([^)]+)\)/)?.[1];
+  if (!href) {
+    throw new Error("Expected permission action URL");
+  }
+  return new URL(href);
+}
+
 function resolvedUrlDiagnostic(
   args: {
     readonly connectorSlug?: string;
@@ -205,13 +213,18 @@ describe("okou connector permission-request command", () => {
     ]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("connectorSlug=slack");
-    expect(logCalls).toContain("action=allow");
-    expect(logCalls).toContain("threadId=thread-abc-123");
-    expect(logCalls).toContain(
-      "callbackPrompt=Re-check+permission+%26+continue",
-    );
+    expect(
+      Array.from(permissionActionUrl(logCalls).searchParams.entries()),
+    ).toStrictEqual([
+      ["connectorSlug", "slack"],
+      ["permission", SLACK_READ_PERMISSION],
+      ["action", "allow"],
+      ["threadId", "thread-abc-123"],
+      ["callbackPrompt", "Re-check permission & continue"],
+    ]);
     expect(logCalls).toContain("end the current turn");
+    expect(logCalls).toContain("exact callback URL above verbatim");
+    expect(logCalls).toContain("omitting any query parameters");
     expect(logCalls).not.toContain("expiresIn=");
   });
 

--- a/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/account/__tests__/switch-request.test.ts
@@ -171,17 +171,19 @@ describe("okou connector account switch-request command", () => {
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("use Work for GitHub in future runs");
     expect(output).toContain("end the current turn");
+    expect(output).toContain("exact callback URL above verbatim");
+    expect(output).toContain("omitting any query parameters");
     const url = actionUrlFromOutput(output);
     expect(url.origin).toBe("http://localhost:3000");
     expect(url.pathname).toBe(
       `/agents/${AGENT_ID}/connector-accounts/${CONNECTION_ID}/select`,
     );
-    expect(Object.fromEntries(url.searchParams)).toStrictEqual({
-      callbackPrompt: "Continue with the selected account & finish",
-      connectorSlug: "github",
-      kind: "builtin",
-      threadId: THREAD_ID,
-    });
+    expect(Array.from(url.searchParams.entries())).toStrictEqual([
+      ["kind", "builtin"],
+      ["connectorSlug", "github"],
+      ["threadId", THREAD_ID],
+      ["callbackPrompt", "Continue with the selected account & finish"],
+    ]);
   });
 
   it("resolves and validates a custom connector target", async () => {
@@ -216,13 +218,14 @@ describe("okou connector account switch-request command", () => {
     const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("use Work for Acme Search");
     expect(
-      Object.fromEntries(actionUrlFromOutput(output).searchParams),
-    ).toStrictEqual({
-      callbackPrompt: "Continue the search",
-      customConnectorId: CUSTOM_CONNECTOR_ID,
-      kind: "custom",
-      threadId: THREAD_ID,
-    });
+      Array.from(actionUrlFromOutput(output).searchParams.entries()),
+    ).toStrictEqual([
+      ["kind", "custom"],
+      ["customConnectorId", CUSTOM_CONNECTOR_ID],
+      ["threadId", THREAD_ID],
+      ["callbackPrompt", "Continue the search"],
+    ]);
+    expect(output).toContain("exact callback URL above verbatim");
   });
 
   it("rejects malformed connection IDs before account discovery", async () => {

--- a/turbo/apps/cli/src/commands/connector/account/switch-request.ts
+++ b/turbo/apps/cli/src/commands/connector/account/switch-request.ts
@@ -14,10 +14,7 @@ import { getOkouAgentId } from "../../../lib/okou-env";
 import { isUuid } from "../../../lib/utils/uuid";
 import { getPlatformOrigin } from "../../doctor/platform-url";
 import { connectorAccountCliLabel } from "../account-label";
-import {
-  addRequestedCallbackSearchParams,
-  printCallbackTurnInstruction,
-} from "../action-url";
+import { finalizeActionUrl, printCallbackTurnInstruction } from "../action-url";
 import {
   connectorDiscoveryItems,
   isConnectorDiscoveryAuthorized,
@@ -119,13 +116,6 @@ Notes:
             "Connector account switches require the current web chat agent",
           );
         }
-        const params = new URLSearchParams();
-        addRequestedCallbackSearchParams(
-          params,
-          options.callbackPrompt,
-          agentId,
-        );
-
         const [{ connectors }, customConnectors, agentContext] =
           await Promise.all([
             listConnectorCatalogStatus(),
@@ -168,10 +158,15 @@ Notes:
           connector.slug,
           connectionId,
         );
-        addTargetSearchParams(params, target);
         const origin = await getPlatformOrigin();
         const path = `/agents/${encodeURIComponent(agentId)}/connector-accounts/${encodeURIComponent(connectionId)}/select`;
-        const url = `${origin}${path}?${params.toString()}`;
+        const actionUrl = new URL(path, origin);
+        addTargetSearchParams(actionUrl.searchParams, target);
+        const url = finalizeActionUrl(
+          actionUrl,
+          options.callbackPrompt,
+          agentId,
+        );
         const label = connectorAccountCliLabel({
           ...inspection,
           connectionId: inspection.connectionId,

--- a/turbo/apps/cli/src/commands/connector/action-url.ts
+++ b/turbo/apps/cli/src/commands/connector/action-url.ts
@@ -22,22 +22,26 @@ export function currentChatSupportsActionCallback(
   return currentChatThreadId(agentId) !== null;
 }
 
-function addCallbackSearchParams(
-  params: URLSearchParams,
+function serializeCallbackActionUrl(
+  actionUrl: URL,
   threadId: string,
   callbackPrompt: string,
-): void {
-  params.set("threadId", threadId);
-  params.set("callbackPrompt", callbackPrompt);
+): string {
+  const finalizedUrl = new URL(actionUrl.toString());
+  finalizedUrl.searchParams.delete("threadId");
+  finalizedUrl.searchParams.delete("callbackPrompt");
+  finalizedUrl.searchParams.append("threadId", threadId);
+  finalizedUrl.searchParams.append("callbackPrompt", callbackPrompt);
+  return finalizedUrl.toString();
 }
 
-export function addRequestedCallbackSearchParams(
-  params: URLSearchParams,
+export function finalizeActionUrl(
+  actionUrl: URL,
   callbackPrompt: string | undefined,
   agentId: string | undefined,
-): void {
+): string {
   if (callbackPrompt === undefined) {
-    return;
+    return actionUrl.toString();
   }
 
   const normalizedPrompt = callbackPrompt.trim();
@@ -51,7 +55,7 @@ export function addRequestedCallbackSearchParams(
       "--callback-prompt can only target the current web chat thread and agent",
     );
   }
-  addCallbackSearchParams(params, threadId, normalizedPrompt);
+  return serializeCallbackActionUrl(actionUrl, threadId, normalizedPrompt);
 }
 
 export function connectorActionUrl(args: {
@@ -75,13 +79,11 @@ function callbackActionUrlExample(
     return null;
   }
 
-  const url = new URL(actionUrl);
-  addCallbackSearchParams(
-    url.searchParams,
+  return serializeCallbackActionUrl(
+    new URL(actionUrl),
     threadId,
     CALLBACK_PROMPT_PLACEHOLDER,
   );
-  return url.toString();
 }
 
 export function printCallbackActionUrlExample(
@@ -103,6 +105,6 @@ export function printCallbackActionUrlExample(
 export function printCallbackTurnInstruction(): void {
   console.log("");
   console.log(
-    "After sharing this callback URL, end the current turn. When the user completes the action, Okou will automatically start the next round with the callback prompt.",
+    "Return the exact callback URL above verbatim, without rewriting, shortening, reconstructing, or omitting any query parameters. Then end the current turn. When the user completes the action, Okou will automatically start the next round with the callback prompt.",
   );
 }

--- a/turbo/apps/cli/src/commands/connector/permission-request.ts
+++ b/turbo/apps/cli/src/commands/connector/permission-request.ts
@@ -17,8 +17,8 @@ import { createComputerUseAuthorizationRequest } from "../../lib/api/domains/com
 import { diagnoseConnectorCheck } from "../../lib/api/domains/connectors";
 import { getOkouAgentId, getOkouToken } from "../../lib/okou-env";
 import {
-  addRequestedCallbackSearchParams,
   connectorActionCallbackAvailable,
+  finalizeActionUrl,
   printCallbackTurnInstruction,
 } from "./action-url";
 import {
@@ -259,15 +259,12 @@ async function outputPermissionRequestMessage(
 ): Promise<void> {
   const platformOrigin = await getPlatformOrigin();
 
-  const urlParams = new URLSearchParams({
-    connectorSlug,
-    permission,
-    action: "allow",
-  });
-  addRequestedCallbackSearchParams(urlParams, callbackPrompt, agentId);
-
   const pagePath = agentId ? `/agents/${agentId}/permissions` : "/agents";
-  const url = `${platformOrigin}${pagePath}?${urlParams.toString()}`;
+  const actionUrl = new URL(pagePath, platformOrigin);
+  actionUrl.searchParams.set("connectorSlug", connectorSlug);
+  actionUrl.searchParams.set("permission", permission);
+  actionUrl.searchParams.set("action", "allow");
+  const url = finalizeActionUrl(actionUrl, callbackPrompt, agentId);
 
   printSensitivePermissionGuidance(connectorSlug, permission);
   printPermissionRequestMessage({

--- a/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
@@ -275,7 +275,7 @@ describe("okou mail", () => {
         return HttpResponse.json(
           {
             mailDraftId: MAIL_DRAFT_ID,
-            mailDraftUrl: `https://app.vm0.ai/mail/drafts/${MAIL_DRAFT_ID}`,
+            mailDraftUrl: `https://app.vm0.ai/mail/drafts/${MAIL_DRAFT_ID}?source=gmail`,
           },
           { status: 200 },
         );
@@ -293,13 +293,15 @@ describe("okou mail", () => {
 
     const reviewUrl = new URL(String(mockConsoleLog.mock.calls[0]?.[0]));
     expect(reviewUrl.pathname).toBe(`/mail/drafts/${MAIL_DRAFT_ID}`);
-    expect(reviewUrl.searchParams.get("agentId")).toBe(AGENT_ID);
-    expect(reviewUrl.searchParams.get("threadId")).toBe(THREAD_ID);
-    expect(reviewUrl.searchParams.get("callbackPrompt")).toBe(
-      "Confirm the email was sent",
-    );
-    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain(
-      "end the current turn",
-    );
+    expect(Array.from(reviewUrl.searchParams.entries())).toStrictEqual([
+      ["source", "gmail"],
+      ["agentId", AGENT_ID],
+      ["threadId", THREAD_ID],
+      ["callbackPrompt", "Confirm the email was sent"],
+    ]);
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("end the current turn");
+    expect(output).toContain("exact callback URL above verbatim");
+    expect(output).toContain("omitting any query parameters");
   });
 });

--- a/turbo/apps/cli/src/commands/mail/link.ts
+++ b/turbo/apps/cli/src/commands/mail/link.ts
@@ -4,8 +4,8 @@ import { linkMailDraft } from "../../lib/api/domains/mail";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { getOkouChatThreadId } from "../../lib/okou-env";
 import {
-  addRequestedCallbackSearchParams,
   connectorActionCallbackAvailable,
+  finalizeActionUrl,
   printCallbackTurnInstruction,
 } from "../connector/action-url";
 import { currentAgentId } from "./shared";
@@ -20,28 +20,16 @@ function currentChatThreadId(): string {
   return threadId;
 }
 
-function reviewUrlSearchParams(args: {
+function mailDraftReviewUrl(args: {
+  readonly mailDraftUrl: string;
   readonly agentId: string;
   readonly callbackPrompt: string | undefined;
-}): URLSearchParams {
-  const params = new URLSearchParams();
-  if (args.callbackPrompt === undefined) {
-    return params;
+}): string {
+  const actionUrl = new URL(args.mailDraftUrl);
+  if (args.callbackPrompt !== undefined) {
+    actionUrl.searchParams.set("agentId", args.agentId);
   }
-  params.set("agentId", args.agentId);
-  addRequestedCallbackSearchParams(params, args.callbackPrompt, args.agentId);
-  return params;
-}
-
-function mailDraftReviewUrl(
-  mailDraftUrl: string,
-  params: URLSearchParams,
-): string {
-  const url = new URL(mailDraftUrl);
-  for (const [name, value] of params) {
-    url.searchParams.set(name, value);
-  }
-  return url.toString();
+  return finalizeActionUrl(actionUrl, args.callbackPrompt, args.agentId);
 }
 
 const callbackPromptOption = new Option(
@@ -79,16 +67,18 @@ ${callbackPromptNotes}  - The user reviews the draft and sends it from the linke
       async (gmailDraftId: string, opts: { callbackPrompt?: string }) => {
         const agentId = currentAgentId();
         const threadId = currentChatThreadId();
-        const params = reviewUrlSearchParams({
-          agentId,
-          callbackPrompt: opts.callbackPrompt,
-        });
         const result = await linkMailDraft({
           threadId,
           agentId,
           gmailDraftId,
         });
-        console.log(mailDraftReviewUrl(result.mailDraftUrl, params));
+        console.log(
+          mailDraftReviewUrl({
+            mailDraftUrl: result.mailDraftUrl,
+            agentId,
+            callbackPrompt: opts.callbackPrompt,
+          }),
+        );
         if (opts.callbackPrompt !== undefined) {
           printCallbackTurnInstruction();
         }


### PR DESCRIPTION
## Summary

- finalize connector account, permission, banking, and mail callback URLs only after all action-defining parameters are present
- require agents to return CLI action URLs verbatim in both callback handoff output and the run-level Agent Tools prompt
- document the fail-closed producer/consumer contract and cover ordered query parameters across all callback producers

## Scope

- preserves the current API, persistence, and frontend card parsing contracts
- adds no compatibility or fallback path; agents use the latest CLI
- keeps incomplete or context-mismatched mutating actions fail-closed

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped --output-logs=errors-only`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app' --output-logs=errors-only`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/cli exec vitest run src/commands/connector/__tests__/check.test.ts`
- `pnpm --filter @okouai/cli exec vitest run src/commands/connector/account/__tests__/switch-request.test.ts`
- `pnpm --filter @okouai/cli exec vitest run src/commands/connector/__tests__/permission-request.test.ts`
- `pnpm --filter @okouai/cli exec vitest run src/commands/banking/__tests__/index.test.ts`
- `pnpm --filter @okouai/cli exec vitest run src/commands/mail/__tests__/index.test.ts`
- targeted V8 coverage for `action-url.ts`: 100% statements, branches, functions, and lines
- `DATABASE_URL=<temporary-postgres> pnpm --filter api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "advertises connector account switching only while the feature is enabled"`

Closes #31405
