### PR TITLE
perf(api): overlap thread connector selection reads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -102,8 +102,10 @@ import { seededSystemSkillArchive } from "../../../test-fixtures/seeded-system-s
 import {
   API_TEST_CONNECTOR_CATALOG,
   apiTestConnectorCatalogValidationAuthority,
+  clearApiTestConnectorCatalogExternalReaderIdentityReplacements,
   installApiTestConnectorCatalog,
   replaceApiTestConnectorCatalogStoredBytes,
+  setApiTestConnectorCatalogExternalReaderIdentityReadHook,
 } from "../../../test-fixtures/connector-catalog";
 import {
   readRunChatThreadIdFixture,
@@ -170,6 +172,7 @@ import {
   readCustomConnectorCredentialStorageParent,
   setCustomConnectorCredentialStorageState,
 } from "./helpers/connector-credential-storage-state";
+import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
 import { verifyOkouToken } from "../../auth/tokens";
@@ -1338,7 +1341,223 @@ describe("CHAT-02: thread run admission invariant", () => {
   });
 });
 
+interface SelectedThreadConnectorFixture extends EntitledChatActor {
+  readonly connectionId: string;
+  readonly threadId: string;
+}
+
+async function selectedThreadConnectorFixture(
+  title: string,
+): Promise<SelectedThreadConnectorFixture> {
+  const entitled = await entitledChatActor();
+  const orgId = requireOrgId(entitled.actor);
+  await updateFeatureSwitchesForUser(
+    context,
+    { userId: entitled.actor.userId, orgId },
+    { [FeatureSwitchKey.ConnectorAccounts]: true },
+  );
+  await installApiTestConnectorCatalog({
+    catalogVersion: `api-test-thread-runtime-overlap-${randomUUID()}`,
+    runtimeProjection: true,
+  });
+  const connection = await connectors.connectManualGrant(
+    entitled.actor,
+    "openai",
+    "api-token",
+    { apiKey: `thread-runtime-overlap-${randomUUID()}` },
+    entitled.agentId,
+  );
+  const thread = await chat.createThread(entitled.actor, {
+    agentId: entitled.agentId,
+    title,
+  });
+  await accept(
+    chatThreadConnectorSelectionsClient().update({
+      headers: sessionHeaders(entitled.actor),
+      params: { id: thread.id },
+      body: {
+        connectionId: connection.id,
+        target: { kind: "builtin", connectorSlug: "openai" },
+      },
+    }),
+    [200],
+  );
+  return {
+    ...entitled,
+    connectionId: connection.id,
+    threadId: thread.id,
+  };
+}
+
+async function configureRuntimeContextGateway(
+  actor: ApiTestUser,
+): Promise<void> {
+  const gateway = await accept(
+    modelProviderConnectionsClient().create({
+      headers: sessionHeaders(actor),
+      body: {
+        displayName: "Runtime context priority gateway",
+        secret: "runtime-context-priority-secret",
+        surfaces: [
+          {
+            protocol: "anthropic-messages",
+            apiBaseUrl:
+              "https://runtime-context-priority.example.com/anthropic",
+            authHeaderName: "Authorization",
+            authHeaderTemplate: "Bearer {{secret}}",
+            modelMappings: {
+              "claude-sonnet-5": "anthropic/claude-sonnet-4.6",
+            },
+          },
+        ],
+      },
+    }),
+    [201],
+  );
+  const surfaceId = gateway.body.surfaces[0]?.id;
+  if (!surfaceId) {
+    throw new Error("Expected the runtime context gateway to have a surface");
+  }
+  await api.updateOrgModelPolicies(actor, [
+    {
+      model: "claude-sonnet-5",
+      isDefault: true,
+      defaultProviderType: "custom-anthropic-messages",
+      credentialScope: "org",
+      modelProviderId: null,
+      modelProviderSurfaceId: surfaceId,
+    },
+  ]);
+}
+
 describe("CHAT-02: thread connector account selection", () => {
+  it("overlaps stored thread selection with model-provider resolution", async () => {
+    const fixture = await selectedThreadConnectorFixture(
+      "Runtime context overlap thread",
+    );
+    await configureRuntimeContextGateway(fixture.actor);
+    onTestFinished(() => {
+      clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+    });
+    const threadCatalogReadStarted = createDeferredPromise<void>(
+      context.signal,
+    );
+    onTestFinished(() => {
+      if (!threadCatalogReadStarted.settled()) {
+        threadCatalogReadStarted.resolve(undefined);
+      }
+    });
+    setApiTestConnectorCatalogExternalReaderIdentityReadHook(() => {
+      if (!threadCatalogReadStarted.settled()) {
+        threadCatalogReadStarted.resolve(undefined);
+      }
+      return Promise.resolve();
+    });
+    const kms = useSecretKmsProbe(undefined, async () => {
+      await threadCatalogReadStarted.promise;
+      return Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
+    });
+
+    const run = await sendChatRun(fixture.actor, {
+      agentId: fixture.agentId,
+      threadId: fixture.threadId,
+      prompt: "Overlap stored thread selection with runtime context",
+    });
+    expect(threadCatalogReadStarted.settled()).toBeTruthy();
+    clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+    const claimed = await claimChatRun(fixture.runnerGroup, run.runId);
+    expect(kms.decryptCalls).toBeGreaterThan(0);
+    expect(claimed.claim.environment).toMatchObject({
+      ANTHROPIC_BASE_URL:
+        "https://runtime-context-priority.example.com/anthropic",
+      ANTHROPIC_MODEL: "anthropic/claude-sonnet-4.6",
+    });
+    expect(
+      claimed.claim.secretConnectorMetadataMap?.OPENAI_TOKEN,
+    ).toMatchObject({ sourceId: fixture.connectionId });
+    await cancelChatRun(fixture.actor, run.runId, claimed.sandboxHeaders);
+  });
+
+  it("keeps abort priority over a concurrent thread-selection failure", async () => {
+    const fixture = await selectedThreadConnectorFixture(
+      "Runtime context abort priority thread",
+    );
+    onTestFinished(() => {
+      clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+    });
+    const abortError = new Error("runtime context priority abort");
+    abortError.name = "AbortError";
+    const abortThreadError = new Error("thread selection below abort");
+    const abortController = new AbortController();
+    setApiTestConnectorCatalogExternalReaderIdentityReadHook(() => {
+      abortController.abort(abortError);
+      return Promise.reject(abortThreadError);
+    });
+    context.mocks.sentry.captureException.mockClear();
+    await expect(
+      chat.requestSendEvent(
+        fixture.actor,
+        {
+          agentId: fixture.agentId,
+          threadId: fixture.threadId,
+          prompt: "Prefer abort over a thread-selection failure",
+          clientEventId: randomUUID(),
+        },
+        [201],
+        {},
+        abortController.signal,
+      ),
+    ).rejects.toThrow("Unknown response status 500");
+    expect(abortController.signal.reason).toBe(abortError);
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("keeps thread-selection failure priority over a concurrent provider failure", async () => {
+    const fixture = await selectedThreadConnectorFixture(
+      "Runtime context thread priority thread",
+    );
+    await configureRuntimeContextGateway(fixture.actor);
+    onTestFinished(() => {
+      clearApiTestConnectorCatalogExternalReaderIdentityReplacements();
+    });
+    const providerFailureStarted = createDeferredPromise<void>(context.signal);
+    onTestFinished(() => {
+      if (!providerFailureStarted.settled()) {
+        providerFailureStarted.resolve(undefined);
+      }
+    });
+    const threadError = new Error("runtime thread selection priority failure");
+    const providerError = new Error("model provider below thread failure");
+    setApiTestConnectorCatalogExternalReaderIdentityReadHook(async () => {
+      await providerFailureStarted.promise;
+      throw threadError;
+    });
+    const kms = useSecretKmsProbe(undefined, () => {
+      if (!providerFailureStarted.settled()) {
+        providerFailureStarted.resolve(undefined);
+      }
+      return Promise.reject(providerError);
+    });
+    context.mocks.sentry.captureException.mockClear();
+    await expect(
+      chat.requestSendEvent(
+        fixture.actor,
+        {
+          agentId: fixture.agentId,
+          threadId: fixture.threadId,
+          prompt: "Prefer thread selection over provider failure",
+          clientEventId: randomUUID(),
+        },
+        [201],
+      ),
+    ).rejects.toThrow("Unknown response status 500");
+    expect(providerFailureStarted.settled()).toBeTruthy();
+    expect(kms.decryptCalls).toBeGreaterThan(0);
+    expect(context.mocks.sentry.captureException).toHaveBeenCalledWith(
+      threadError,
+    );
+  });
+
   it("uses the current default connector account without persisting an override", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     if (!actor.orgId) {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -666,6 +666,7 @@ async function expectBuiltInModelRunRuntimeRoute(
 }
 
 function useSecretKmsClientForTests(args: {
+  readonly decryptError?: Error;
   readonly failAfterGenerateDataKeys?: number;
   readonly onDecrypt?: () => void;
   readonly onGenerateDataKey?: (callNumber: number) => void;
@@ -696,6 +697,9 @@ function useSecretKmsClientForTests(args: {
     },
     decrypt(): Promise<Uint8Array> {
       args.onDecrypt?.();
+      if (args.decryptError) {
+        return Promise.reject(args.decryptError);
+      }
       return Promise.resolve(TEST_DATA_KEY);
     },
   };
@@ -2503,6 +2507,61 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         return candidate.prompt === cancelledPrompt;
       }),
     ).toHaveLength(0);
+  });
+
+  it("keeps a catalog rejection above concurrent abort and provider failure", async () => {
+    const api = createRunsApi(context);
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      `test-run-lifecycle-runtime-context-priority-${randomUUID()}`,
+    );
+    await installApiTestConnectorCatalog({
+      catalogVersion: `api-test-runtime-context-priority-${randomUUID()}`,
+      runtimeProjection: true,
+    });
+    const { actor, agentId } = await entitledRunActor();
+    await api.createOrgModelProvider(actor, {
+      type: "aws-bedrock",
+      authMethod: "access-keys",
+      secrets: {
+        AWS_ACCESS_KEY_ID: "runtime-context-priority-access-key",
+        AWS_SECRET_ACCESS_KEY: "runtime-context-priority-secret-key",
+        AWS_REGION: "us-east-1",
+      },
+    });
+    await invalidateApiTestConnectorCatalogCompatibility();
+
+    const requestController = new AbortController();
+    const abortError = new Error("runtime context priority abort");
+    abortError.name = "AbortError";
+    const providerError = new Error("model provider below catalog failure");
+    let providerDecryptCalls = 0;
+    useSecretKmsClientForTests({
+      decryptError: providerError,
+      onDecrypt: () => {
+        providerDecryptCalls += 1;
+        requestController.abort(abortError);
+      },
+    });
+    const cancellableApi = createRunsApi({
+      ...context,
+      signal: requestController.signal,
+    });
+    await expect(
+      cancellableApi.createDirectRun(actor, {
+        ...zeroBackedDirectRunBody({
+          agentId,
+          prompt: "prefer catalog failure during runtime preparation",
+        }),
+        modelProviderType: "aws-bedrock",
+        connectorScope: {
+          allowedConnectorSlugs: ["x"],
+          allowedCustomConnectorIds: [],
+        },
+      }),
+    ).rejects.toThrow("Accepted external connector catalog is unavailable");
+    expect(providerDecryptCalls).toBeGreaterThan(0);
+    expect(requestController.signal.reason).toBe(abortError);
   });
 
   it("memoizes scoped runtime entries by exact catalog identity", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -9326,21 +9326,16 @@ async function prepareRunRuntimeContext(
 ): Promise<PreparedRuntimeContext | CreateRunErrorResult> {
   const { body, resolved, requestedFramework, featureSwitchContext } =
     args.bodyContext;
-  const [connectorCatalogSelectionResult, modelProviderResult] =
-    await Promise.allSettled([
-      connectorCatalogSelectionForRun({
-        ...args,
-        orgId: args.createArgs.orgId,
-      }),
-      resolvePreparedRunModelProvider(args, signal),
-    ]);
-  if (connectorCatalogSelectionResult.status === "rejected") {
-    throw connectorCatalogSelectionResult.reason;
-  }
-  const connectorCatalogSelection = connectorCatalogSelectionResult.value;
-  signal.throwIfAborted();
-  const threadConnectorSelectionIds =
-    await resolvePreparedThreadConnectorSelections(
+  const [
+    connectorCatalogSelectionResult,
+    threadConnectorSelectionIdsResult,
+    modelProviderResult,
+  ] = await Promise.allSettled([
+    connectorCatalogSelectionForRun({
+      ...args,
+      orgId: args.createArgs.orgId,
+    }),
+    resolvePreparedThreadConnectorSelections(
       {
         db: args.db,
         createArgs: args.createArgs,
@@ -9348,7 +9343,18 @@ async function prepareRunRuntimeContext(
         featureSwitchContext,
       },
       signal,
-    );
+    ),
+    resolvePreparedRunModelProvider(args, signal),
+  ]);
+  if (connectorCatalogSelectionResult.status === "rejected") {
+    throw connectorCatalogSelectionResult.reason;
+  }
+  const connectorCatalogSelection = connectorCatalogSelectionResult.value;
+  signal.throwIfAborted();
+  if (threadConnectorSelectionIdsResult.status === "rejected") {
+    throw threadConnectorSelectionIdsResult.reason;
+  }
+  const threadConnectorSelectionIds = threadConnectorSelectionIdsResult.value;
   if (isRouteError(threadConnectorSelectionIds)) {
     return threadConnectorSelectionIds;
   }

--- a/turbo/apps/api/src/test-fixtures/connector-catalog.ts
+++ b/turbo/apps/api/src/test-fixtures/connector-catalog.ts
@@ -251,6 +251,12 @@ export function clearApiTestConnectorCatalogRuntimeProjectionIdentityReplacement
   clearConnectorCatalogRuntimeProjectionIdentityReadHookForTest();
 }
 
+export function setApiTestConnectorCatalogExternalReaderIdentityReadHook(
+  hook: () => Promise<void>,
+): void {
+  setConnectorCatalogExternalReaderIdentityReadHookForTest(hook);
+}
+
 export function setApiTestConnectorCatalogExternalReaderIdentityReplacements(
   catalogVersions: readonly [first: string, second: string],
 ): void {


### PR DESCRIPTION
## Summary

- start thread connector-selection resolution in the same settlement wave as connector-catalog and model-provider resolution
- preserve the existing observable result priority: catalog, abort, thread, then provider
- add API-entry integration coverage for the concurrency schedule, selected connector output, provider environment, and multi-failure priority

## Problem

The common runtime-context path serialized the thread connector-selection reads after catalog selection and model-provider resolution, even though all three inputs are independent. In 7,125 recent exact two-query prefixes, the measured lower-bound contribution was p50 5.1 ms, p90 11.2 ms, p95 16.3 ms, and p99 53.5 ms. The production sample contains mixed revisions and does not by itself prove causality, so this change is scoped as a tail-latency optimization with post-deploy cohort validation.

## Implementation

- extend the existing `Promise.allSettled()` wave from two independent operations to three
- inspect settled outcomes explicitly in the legacy catalog/abort/thread/provider order
- expose the existing catalog-reader test hook through the API fixture boundary
- use deterministic deferred handshakes and external KMS/catalog boundaries in route integration tests

There are no API, queue payload, Runner protocol, database schema, persisted-state, query-count, retry, cache, or feature-switch changes.

## Validation

- full `chat-events.bdd.test.ts`: 169 passed
- full `run-lifecycle.bdd.test.ts`: 196 passed
- focused new chat concurrency/priority coverage: 3 passed
- focused new catalog-priority coverage: 1 passed
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- repository pre-commit checks: Prettier, Knip, full `pnpm check-types`, and file-size validation
- `git diff --check`

## Risk and rollout

The unchanged thread-selection database reads can now execute speculatively on requests that later fail catalog selection, abort, or provider resolution. This can add limited database work and pool contention on failure-heavy traffic. All promises settle before the request returns, and integration tests lock the observable error priority. After deployment, compare a fixed API/Runner cohort for runtime-context tails, database acquisition tails, failure rate, `api_to_spawn` percentiles, and the fraction at or below one second.

Closes #31406

Parent: #24203
