### PR TITLE
fix(core): return morning brief to gated beta

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -2078,7 +2078,7 @@ describe.sequential("Morning Brief preference", () => {
 });
 
 describe.sequential("Morning Brief default onboarding", () => {
-  it("uses the production boundary with Morning Brief released and Official Workflows off", async () => {
+  it("emits scoped installed and not-eligible outcomes with Official Workflows off", async () => {
     installCatalogStorageFixture();
     await syncDeployedCatalog();
     const activationAt = new Date("2026-09-07T01:00:00.000Z");
@@ -2091,11 +2091,17 @@ describe.sequential("Morning Brief default onboarding", () => {
     });
 
     for (const actor of [preActivationActor, eligibleCreator]) {
+      await setMorningBriefEnabled(actor, true);
       await setOfficialWorkflowsEnabled(actor, false);
     }
 
-    await deliverClerkOrganizationCreated(preActivationActor, beforeActivation);
-    await deliverClerkOrganizationCreated(eligibleCreator, activationAt);
+    await withMorningBriefDefaultActivationFixture(activationAt, async () => {
+      await deliverClerkOrganizationCreated(
+        preActivationActor,
+        beforeActivation,
+      );
+      await deliverClerkOrganizationCreated(eligibleCreator, activationAt);
+    });
 
     await expect(
       readMorningBriefDefaultEligibilityFixture({

--- a/turbo/apps/api/src/signals/services/morning-brief-default-eligibility.service.ts
+++ b/turbo/apps/api/src/signals/services/morning-brief-default-eligibility.service.ts
@@ -2,10 +2,8 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 import { singleton } from "../../lib/singleton";
 
-// Monday 2026-09-07 09:00 Asia/Shanghai.
-const MORNING_BRIEF_DEFAULT_ACTIVATION_AT: Readonly<Date> = new Date(
-  "2026-09-07T01:00:00.000Z",
-);
+// Default enrollment remains inert until a separately reviewed rollout.
+const MORNING_BRIEF_DEFAULT_ACTIVATION_AT: Date | null = null;
 
 interface ScopedActivationInstant {
   readonly value: Date | null;

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -97,18 +97,30 @@ describe("isFeatureEnabled", () => {
     ).toBe(true);
   });
 
-  it("should release Morning Brief independently from Official Workflows and preserve false overrides", () => {
+  it("should keep Morning Brief default-off with an independent staff rollout and overrides", () => {
+    const staffOrgId = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
     const ordinaryOrgId = "org_nonexistent";
     expect(FeatureSwitchKey.MorningBrief).toBe("morningBrief");
-    expect(isFeatureEnabled(FeatureSwitchKey.MorningBrief, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.MorningBrief, {})).toBe(false);
     expect(
       isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
         orgId: ordinaryOrgId,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
         orgId: ordinaryOrgId,
+        overrides: { [FeatureSwitchKey.MorningBrief]: true },
+      }),
+    ).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
+        orgId: staffOrgId,
+      }),
+    ).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.MorningBrief, {
+        orgId: staffOrgId,
         overrides: { [FeatureSwitchKey.MorningBrief]: false },
       }),
     ).toBe(false);
@@ -121,7 +133,7 @@ describe("isFeatureEnabled", () => {
       maintainer: "lancy@vm0.ai",
       description:
         "Enable the first-class Morning Brief experience in Preferences.",
-      rolloutStage: "released",
+      rolloutStage: "beta",
     });
   });
 
@@ -216,7 +228,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(false);
   });
 
   it("should enable intro video and desktop recording for staff", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -233,7 +233,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "lancy@vm0.ai",
     description:
       "Enable the first-class Morning Brief experience in Preferences.",
-    enabled: true,
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.TestOauthConnector]: {
     maintainer: "liangyou@vm0.ai",


### PR DESCRIPTION
## Summary

- return `FeatureSwitchKey.MorningBrief` to default-off with the existing staff organization allowlist, so Lab metadata reports `beta` while explicit true/false overrides keep taking precedence
- reset `MORNING_BRIEF_DEFAULT_ACTIVATION_AT` to typed `null`, keeping the scoped test override so production creates no new automatic-enrollment eligibility
- adapt the focused onboarding boundary test to scoped activation and an explicit Morning Brief override while retaining installed and not-eligible `info` audit assertions, failure `warn`, and HTTP 200 coverage

## Safety

- `FeatureSwitchKey.OfficialWorkflows` remains unchanged and independently gated
- no migration, backfill, production-data mutation, or existing workflow/automation state change
- no installer, preference, locking, idempotency, schedule, result-email, Markdown, sender/footer, or Browse Official behavior change
- preserves the observability repair from #31396

## Verification

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/official-workflows.test.ts apps/api/src/signals/services/morning-brief-default-eligibility.service.ts packages/core/src/__tests__/feature-switch.test.ts packages/core/src/feature-switch.ts`
- `pnpm --filter @okouai/core run lint`
- `pnpm --filter api run lint` (passes with existing warnings)
- `pnpm --filter @okouai/core run check-types`
- `pnpm --filter api run check-types`
- `pnpm knip` (passes with existing configuration hints)
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (`31` passed)
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts -t 'Morning Brief'` (`9` passed, `41` skipped by the focused name filter)
- `git diff --check origin/main...HEAD`

## Exact head

- base: `cdee0f97fbd77c3c25401fd2a5984af478d804c7`
- candidate: `ce153cf3352cd53513a6ff5f5ba8a9b60b6703a5`

Refs #31156
Closes #31447
