### PR TITLE
test(runner): cover version-service lock recreation during gc

### DIFF
--- a/crates/runner/src/cmd/gc/version_service_locks.rs
+++ b/crates/runner/src/cmd/gc/version_service_locks.rs
@@ -39,6 +39,14 @@ pub(super) async fn gc_orphaned_version_service_locks(
     home: &HomePaths,
     dry_run: bool,
 ) -> RunnerResult<GcReport> {
+    gc_orphaned_version_service_locks_with_observer(home, dry_run, || {}).await
+}
+
+async fn gc_orphaned_version_service_locks_with_observer(
+    home: &HomePaths,
+    dry_run: bool,
+    mut after_initial_missing_version_resource: impl FnMut(),
+) -> RunnerResult<GcReport> {
     let locks_dir = home.locks_dir();
     let Some(mut entries) = read_dir_or_missing(&locks_dir).await? else {
         return Ok(GcReport::default());
@@ -67,6 +75,8 @@ pub(super) async fn gc_orphaned_version_service_locks(
                 continue;
             }
         }
+
+        after_initial_missing_version_resource();
 
         let lock_path = entry.path();
         match probe_existing_lock(&lock_path) {
@@ -145,6 +155,31 @@ mod tests {
         assert!(
             !service_lock.exists(),
             "missing version bin dir should make its service lock stale"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_orphaned_version_service_locks_keeps_lock_for_recreated_version_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let version = "v1.0.0";
+        let service_lock = create_test_version_service_lock(&home, version);
+        let version_bin = home.bin_dir().join(version);
+
+        let removed = gc_orphaned_version_service_locks_with_observer(&home, false, || {
+            std::fs::create_dir_all(&version_bin).unwrap();
+        })
+        .await
+        .unwrap();
+
+        assert!(
+            version_bin.is_dir(),
+            "test observer should recreate the version directory"
+        );
+        assert_eq!(removed.version_service_locks_removed, 0);
+        assert!(
+            service_lock.exists(),
+            "version recreated before the lock probe should keep its service lock"
         );
     }
 


### PR DESCRIPTION
## Summary

- keep the existing orphaned version-service-lock GC entry point while adding a private deterministic observer seam after the initial missing-resource check and before the lock probe
- recreate a real version directory at that boundary and verify the post-acquisition recheck preserves the original lifecycle lock and reports zero removals
- retain the existing missing-version case as the no-recreation control, with no changes to no-follow directory checks or inode-safe lock removal

## Scope

- no public API, configuration, persistence, protocol, migration, compatibility, rollout, or fallback changes
- no changes outside `crates/runner/src/cmd/gc/version_service_locks.rs`

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo check --manifest-path crates/Cargo.toml -p runner --tests`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets`
- `git diff --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::gc::version_service_locks::tests` was attempted twice with a workspace-local target directory, one build job, disabled test debug info, and then incremental compilation disabled; both attempts were terminated by the host OOM killer while compiling the 3.8 GiB runner test binary on a 3.8 GiB no-swap machine. Pull-request CI remains responsible for executing the focused tests.

Closes #31423
