### PR TITLE
perf(guest-agent): bound artifact traversal work

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -690,7 +690,6 @@ mod tests {
     use super::*;
     use std::ffi::{CString, OsStr};
     use std::io::Cursor;
-    use std::os::fd::AsRawFd;
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs as unix_fs;
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -1362,50 +1361,6 @@ mod tests {
         // .git and .vm0 contents must NOT be present
         assert!(!paths.iter().any(|p| p.starts_with(".git")));
         assert!(!paths.iter().any(|p| p.starts_with(".vm0")));
-    }
-
-    #[test]
-    fn collect_file_metadata_rejects_active_path_above_limit_at_max_depth() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path().join("root");
-        std::fs::create_dir(&root).unwrap();
-
-        let directory_name = "d".repeat(255);
-        let mut current = File::open(&root).unwrap();
-        for _ in 0..ARTIFACT_TRAVERSAL_MAX_DEPTH {
-            let child = PathBuf::from(format!("/proc/self/fd/{}", current.as_raw_fd()))
-                .join(&directory_name);
-            std::fs::create_dir(&child).unwrap();
-            current = File::open(child).unwrap();
-        }
-        let file_path = PathBuf::from(format!("/proc/self/fd/{}", current.as_raw_fd())).join("f");
-        std::fs::write(file_path, "data").unwrap();
-        drop(current);
-
-        let error = collect_file_metadata(root.to_str().unwrap()).unwrap_err();
-        let ArchiveError::TraversalLimitExceeded {
-            observed_entries,
-            max_entries,
-            observed_depth,
-            max_depth,
-            observed_path_bytes,
-            max_path_bytes,
-        } = error
-        else {
-            panic!("expected traversal limit error, got: {error}");
-        };
-        assert_eq!(
-            observed_entries,
-            ARTIFACT_TRAVERSAL_MAX_DEPTH.saturating_add(1)
-        );
-        assert_eq!(max_entries, ARTIFACT_TRAVERSAL_MAX_ENTRIES);
-        assert_eq!(observed_depth, ARTIFACT_TRAVERSAL_MAX_DEPTH);
-        assert_eq!(max_depth, ARTIFACT_TRAVERSAL_MAX_DEPTH);
-        assert_eq!(
-            observed_path_bytes,
-            ARTIFACT_TRAVERSAL_MAX_PATH_BYTES.saturating_add(1)
-        );
-        assert_eq!(max_path_bytes, ARTIFACT_TRAVERSAL_MAX_PATH_BYTES);
     }
 
     #[test]

--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -16,6 +16,19 @@ use thiserror::Error;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
+/// Maximum entries returned by `ReadDir` across one artifact walk.
+///
+/// This is deliberately independent from the retained-file limit. The larger
+/// value leaves room for directory structure while bounding skipped entries.
+#[cfg(target_os = "linux")]
+pub(crate) const ARTIFACT_TRAVERSAL_MAX_ENTRIES: u64 = 100_000;
+/// Maximum directory levels traversed below the configured artifact root.
+#[cfg(target_os = "linux")]
+pub(crate) const ARTIFACT_TRAVERSAL_MAX_DEPTH: u64 = 256;
+/// Maximum bytes in the active UTF-8 path relative to the artifact root.
+#[cfg(target_os = "linux")]
+pub(crate) const ARTIFACT_TRAVERSAL_MAX_PATH_BYTES: u64 = 64 * 1024;
+
 /// Collect a best-effort manifest of successfully observed regular files.
 ///
 /// On Linux, access to the configured artifact root is strict: the root must be
@@ -26,6 +39,10 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 /// A nested directory iteration, child open, metadata, or file read/hash
 /// failure can therefore omit an entry or subtree while the walk still
 /// succeeds. On non-Linux targets, root access is unsupported.
+/// Every successfully yielded directory entry consumes a separate traversal
+/// budget, including excluded and non-regular entries. Exceeding that budget,
+/// the directory-depth limit, or the active relative-path limit is a hard
+/// checkpoint failure rather than a best-effort omission.
 ///
 /// Entries named `.git` or `.vm0`, symlinks, FIFOs, and other non-regular
 /// entries are intentionally excluded. The root and descendant descriptors use
@@ -45,10 +62,19 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 pub(super) fn collect_file_metadata(dir_path: &str) -> Result<Vec<FileEntry>, ArchiveError> {
     let mut files = Vec::new();
     let mut path_bytes = 0;
+    let mut observed_entries = 0;
     let root_path = Path::new(dir_path);
     let root = open_artifact_root(root_path)?;
     let entries = read_artifact_root(&root, root_path)?;
-    walk_entries(&root, "", entries, &mut files, &mut path_bytes)?;
+    walk_entries(
+        &root,
+        "",
+        entries,
+        0,
+        &mut observed_entries,
+        &mut files,
+        &mut path_bytes,
+    )?;
     Ok(files)
 }
 
@@ -63,6 +89,8 @@ pub(super) fn collect_file_metadata(dir_path: &str) -> Result<Vec<FileEntry>, Ar
 fn walk_dir(
     current: &Dir,
     relative: &str,
+    depth: u64,
+    observed_entries: &mut u64,
     out: &mut Vec<FileEntry>,
     path_bytes: &mut u64,
 ) -> Result<(), ArchiveError> {
@@ -70,7 +98,15 @@ fn walk_dir(
         Ok(e) => e,
         Err(_) => return Ok(()),
     };
-    walk_entries(current, relative, entries, out, path_bytes)
+    walk_entries(
+        current,
+        relative,
+        entries,
+        depth,
+        observed_entries,
+        out,
+        path_bytes,
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -78,10 +114,20 @@ fn walk_entries(
     current: &Dir,
     relative: &str,
     entries: fs::ReadDir,
+    depth: u64,
+    observed_entries: &mut u64,
     out: &mut Vec<FileEntry>,
     path_bytes: &mut u64,
 ) -> Result<(), ArchiveError> {
     for entry in entries.flatten() {
+        let candidate_entries = observed_entries.saturating_add(1);
+        enforce_traversal_limits(
+            candidate_entries,
+            depth,
+            u64::try_from(relative.len()).unwrap_or(u64::MAX),
+        )?;
+        *observed_entries = candidate_entries;
+
         let name = entry.file_name();
         if is_excluded_artifact_entry(&name) {
             continue;
@@ -94,7 +140,13 @@ fn walk_entries(
         if try_directory && let Ok(dir) = current.open_child_dir(&name) {
             let name_str = artifact_path_component(&name, relative)?;
             let rel = relative_artifact_path(relative, name_str);
-            walk_dir(&dir, &rel, out, path_bytes)?;
+            let child_depth = depth.saturating_add(1);
+            enforce_traversal_limits(
+                *observed_entries,
+                child_depth,
+                u64::try_from(rel.len()).unwrap_or(u64::MAX),
+            )?;
+            walk_dir(&dir, &rel, child_depth, observed_entries, out, path_bytes)?;
             continue;
         }
         if !try_file {
@@ -112,6 +164,11 @@ fn walk_entries(
         }
         let name_str = artifact_path_component(&name, relative)?;
         let rel = relative_artifact_path(relative, name_str);
+        enforce_traversal_limits(
+            *observed_entries,
+            depth,
+            u64::try_from(rel.len()).unwrap_or(u64::MAX),
+        )?;
         let observed_files = u64::try_from(out.len())
             .unwrap_or(u64::MAX)
             .saturating_add(1);
@@ -140,6 +197,28 @@ fn walk_entries(
                 log_warn!(LOG_TAG, "Could not process file {rel}: {e}");
             }
         }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn enforce_traversal_limits(
+    observed_entries: u64,
+    observed_depth: u64,
+    observed_path_bytes: u64,
+) -> Result<(), ArchiveError> {
+    if observed_entries > ARTIFACT_TRAVERSAL_MAX_ENTRIES
+        || observed_depth > ARTIFACT_TRAVERSAL_MAX_DEPTH
+        || observed_path_bytes > ARTIFACT_TRAVERSAL_MAX_PATH_BYTES
+    {
+        return Err(ArchiveError::TraversalLimitExceeded {
+            observed_entries,
+            max_entries: ARTIFACT_TRAVERSAL_MAX_ENTRIES,
+            observed_depth,
+            max_depth: ARTIFACT_TRAVERSAL_MAX_DEPTH,
+            observed_path_bytes,
+            max_path_bytes: ARTIFACT_TRAVERSAL_MAX_PATH_BYTES,
+        });
     }
     Ok(())
 }
@@ -212,6 +291,17 @@ pub(super) enum ArchiveError {
         "artifact path component is not valid UTF-8 under {parent:?}: {component}; artifact paths must be valid UTF-8"
     )]
     NonUtf8PathComponent { parent: String, component: String },
+    #[error(
+        "artifact checkpoint traversal limit exceeded: observed entries {observed_entries}/{max_entries}, directory depth {observed_depth}/{max_depth}, active UTF-8 path bytes {observed_path_bytes}/{max_path_bytes}"
+    )]
+    TraversalLimitExceeded {
+        observed_entries: u64,
+        max_entries: u64,
+        observed_depth: u64,
+        max_depth: u64,
+        observed_path_bytes: u64,
+        max_path_bytes: u64,
+    },
     #[error(
         "artifact checkpoint manifest limit exceeded: candidate files {observed_files}/{max_files}, candidate UTF-8 path bytes {observed_path_bytes}/{max_path_bytes}"
     )]

--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -690,6 +690,7 @@ mod tests {
     use super::*;
     use std::ffi::{CString, OsStr};
     use std::io::Cursor;
+    use std::os::fd::AsRawFd;
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs as unix_fs;
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -1361,6 +1362,50 @@ mod tests {
         // .git and .vm0 contents must NOT be present
         assert!(!paths.iter().any(|p| p.starts_with(".git")));
         assert!(!paths.iter().any(|p| p.starts_with(".vm0")));
+    }
+
+    #[test]
+    fn collect_file_metadata_rejects_active_path_above_limit_at_max_depth() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        std::fs::create_dir(&root).unwrap();
+
+        let directory_name = "d".repeat(255);
+        let mut current = File::open(&root).unwrap();
+        for _ in 0..ARTIFACT_TRAVERSAL_MAX_DEPTH {
+            let child = PathBuf::from(format!("/proc/self/fd/{}", current.as_raw_fd()))
+                .join(&directory_name);
+            std::fs::create_dir(&child).unwrap();
+            current = File::open(child).unwrap();
+        }
+        let file_path = PathBuf::from(format!("/proc/self/fd/{}", current.as_raw_fd())).join("f");
+        std::fs::write(file_path, "data").unwrap();
+        drop(current);
+
+        let error = collect_file_metadata(root.to_str().unwrap()).unwrap_err();
+        let ArchiveError::TraversalLimitExceeded {
+            observed_entries,
+            max_entries,
+            observed_depth,
+            max_depth,
+            observed_path_bytes,
+            max_path_bytes,
+        } = error
+        else {
+            panic!("expected traversal limit error, got: {error}");
+        };
+        assert_eq!(
+            observed_entries,
+            ARTIFACT_TRAVERSAL_MAX_DEPTH.saturating_add(1)
+        );
+        assert_eq!(max_entries, ARTIFACT_TRAVERSAL_MAX_ENTRIES);
+        assert_eq!(observed_depth, ARTIFACT_TRAVERSAL_MAX_DEPTH);
+        assert_eq!(max_depth, ARTIFACT_TRAVERSAL_MAX_DEPTH);
+        assert_eq!(
+            observed_path_bytes,
+            ARTIFACT_TRAVERSAL_MAX_PATH_BYTES.saturating_add(1)
+        );
+        assert_eq!(max_path_bytes, ARTIFACT_TRAVERSAL_MAX_PATH_BYTES);
     }
 
     #[test]

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -30,6 +30,10 @@ use api::{
     CommitSnapshotRequest, PrepareSnapshotRequest, PreparedSnapshot, PreparedUploads,
     commit_snapshot, prepare_snapshot,
 };
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) use archive::{
+    ARTIFACT_TRAVERSAL_MAX_DEPTH, ARTIFACT_TRAVERSAL_MAX_ENTRIES, ARTIFACT_TRAVERSAL_MAX_PATH_BYTES,
+};
 use archive::{collect_file_metadata, create_archive, validate_archive_inputs};
 use std::fs::File;
 use std::io::{BufWriter, Write};

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -289,6 +289,27 @@ mod tests {
         }
     }
 
+    fn assert_artifact_hash_failure(telemetry_path: &std::path::Path, expected_error: &str) {
+        let expected_error = expected_error
+            .strip_prefix("checkpoint: ")
+            .unwrap_or(expected_error);
+        let telemetry_entries = std::fs::read_to_string(telemetry_path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        let matching_failure = telemetry_entries.iter().any(|entry| {
+            entry.get("action_type").and_then(serde_json::Value::as_str)
+                == Some("artifact_hash_compute")
+                && entry.get("success").and_then(serde_json::Value::as_bool) == Some(false)
+                && entry.get("error").and_then(serde_json::Value::as_str) == Some(expected_error)
+        });
+        assert!(
+            matching_failure,
+            "missing failed artifact_hash_compute telemetry for {expected_error:?}"
+        );
+    }
+
     async fn start_artifact_checkpoint_test_server(
         artifact_count: usize,
     ) -> (String, tokio::task::JoinHandle<Vec<String>>) {
@@ -563,27 +584,7 @@ mod tests {
         upload.assert_calls(0);
         commit.assert_calls(0);
 
-        let telemetry_entries = std::fs::read_to_string(&telemetry_path)
-            .unwrap()
-            .lines()
-            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
-            .collect::<Vec<_>>();
-        let failure = telemetry_entries
-            .iter()
-            .find(|entry| {
-                entry.get("action_type").and_then(serde_json::Value::as_str)
-                    == Some("artifact_hash_compute")
-                    && entry.get("success").and_then(serde_json::Value::as_bool) == Some(false)
-            })
-            .expect("failed artifact_hash_compute telemetry entry");
-        assert_eq!(
-            failure.get("error").and_then(serde_json::Value::as_str),
-            Some(
-                count_message
-                    .strip_prefix("checkpoint: ")
-                    .unwrap_or(&count_message)
-            )
-        );
+        assert_artifact_hash_failure(&telemetry_path, &count_message);
 
         std::fs::remove_file(over_limit_path).unwrap();
         let path_error = vas::walk_files_for_checkpoint(dir.path().to_str().unwrap())
@@ -606,6 +607,171 @@ mod tests {
             )),
             "path-byte limit must fail before the file-count limit: {path_message}"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn artifact_snapshot_enforces_traversal_entry_limit_before_storage_api_calls() {
+        const PARENT_COUNT: usize = 100;
+
+        let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        guest_common::log::clear_system_log_file();
+
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join("wide");
+        std::fs::create_dir(&mount).unwrap();
+        std::fs::create_dir(mount.join(".git")).unwrap();
+        let max_entries = usize::try_from(vas::ARTIFACT_TRAVERSAL_MAX_ENTRIES).unwrap();
+        let children_per_parent = (max_entries - PARENT_COUNT) / PARENT_COUNT;
+        assert_eq!(
+            PARENT_COUNT * (children_per_parent + 1),
+            max_entries,
+            "fixture must contain exactly the traversal limit before .git"
+        );
+        for parent_index in 0..PARENT_COUNT {
+            let parent = mount.join(format!("p{parent_index:03}"));
+            std::fs::create_dir(&parent).unwrap();
+            for child_index in 0..children_per_parent {
+                std::fs::create_dir(parent.join(format!("d{child_index:03}"))).unwrap();
+            }
+        }
+
+        let telemetry_dir = tempfile::tempdir().unwrap();
+        let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
+        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let upload = server.mock(|when, then| {
+            when.method(PUT);
+            then.status(200);
+        });
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
+        let entries = vec![env::ArtifactEnv {
+            name: "workspace".to_string(),
+            mount_path: mount.to_string_lossy().into_owned(),
+            storage_id: "storage-id".to_string(),
+            version_id: "parent-version".to_string(),
+            missing_root_policy: None,
+        }];
+
+        let error = snapshot_artifact_entries(&http, "test-run", &entries)
+            .await
+            .unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains(&format!(
+                "observed entries {}/{}",
+                vas::ARTIFACT_TRAVERSAL_MAX_ENTRIES + 1,
+                vas::ARTIFACT_TRAVERSAL_MAX_ENTRIES
+            )),
+            "got: {message}"
+        );
+        assert!(
+            message.contains(&format!("/{}", vas::ARTIFACT_TRAVERSAL_MAX_DEPTH)),
+            "got: {message}"
+        );
+        assert!(
+            message.contains(&format!("/{}", vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES)),
+            "got: {message}"
+        );
+        prepare.assert_calls(0);
+        upload.assert_calls(0);
+        commit.assert_calls(0);
+        assert_artifact_hash_failure(&telemetry_path, &message);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn artifact_snapshot_enforces_traversal_depth_before_storage_api_calls() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        guest_common::log::clear_system_log_file();
+
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join("deep");
+        std::fs::create_dir(&mount).unwrap();
+        let mut deepest = mount.clone();
+        for _ in 0..=vas::ARTIFACT_TRAVERSAL_MAX_DEPTH {
+            deepest.push("d");
+            std::fs::create_dir(&deepest).unwrap();
+        }
+        std::fs::File::create(deepest.join(std::ffi::OsString::from_vec(vec![0xff]))).unwrap();
+
+        let telemetry_dir = tempfile::tempdir().unwrap();
+        let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
+        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let upload = server.mock(|when, then| {
+            when.method(PUT);
+            then.status(200);
+        });
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
+        let entries = vec![env::ArtifactEnv {
+            name: "workspace".to_string(),
+            mount_path: mount.to_string_lossy().into_owned(),
+            storage_id: "storage-id".to_string(),
+            version_id: "parent-version".to_string(),
+            missing_root_policy: None,
+        }];
+
+        let error = snapshot_artifact_entries(&http, "test-run", &entries)
+            .await
+            .unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains(&format!(
+                "directory depth {}/{}",
+                vas::ARTIFACT_TRAVERSAL_MAX_DEPTH + 1,
+                vas::ARTIFACT_TRAVERSAL_MAX_DEPTH
+            )),
+            "got: {message}"
+        );
+        assert!(
+            message.contains(&format!(
+                "active UTF-8 path bytes {}/{}",
+                2 * vas::ARTIFACT_TRAVERSAL_MAX_DEPTH + 1,
+                vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES
+            )),
+            "got: {message}"
+        );
+        prepare.assert_calls(0);
+        upload.assert_calls(0);
+        commit.assert_calls(0);
+        assert_artifact_hash_failure(&telemetry_path, &message);
     }
 
     #[tokio::test]

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -374,6 +374,53 @@ mod tests {
         Ok(unsafe { File::from_raw_fd(fd) })
     }
 
+    #[cfg(target_os = "linux")]
+    async fn artifact_snapshot_preflight_error(mount: &std::path::Path) -> String {
+        let telemetry_dir = tempfile::tempdir().unwrap();
+        let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
+        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let upload = server.mock(|when, then| {
+            when.method(PUT);
+            then.status(200);
+        });
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
+        let entries = vec![env::ArtifactEnv {
+            name: "workspace".to_string(),
+            mount_path: mount.to_string_lossy().into_owned(),
+            storage_id: "storage-id".to_string(),
+            version_id: "parent-version".to_string(),
+            missing_root_policy: None,
+        }];
+
+        let error = snapshot_artifact_entries(&http, "test-run", &entries)
+            .await
+            .unwrap_err();
+        let message = error.to_string();
+        prepare.assert_calls(0);
+        upload.assert_calls(0);
+        commit.assert_calls(0);
+        assert_artifact_hash_failure(&telemetry_path, &message);
+        message
+    }
+
     async fn start_artifact_checkpoint_test_server(
         artifact_count: usize,
     ) -> (String, tokio::task::JoinHandle<Vec<String>>) {
@@ -702,44 +749,7 @@ mod tests {
             }
         }
 
-        let telemetry_dir = tempfile::tempdir().unwrap();
-        let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
-        let server = MockServer::start();
-        let prepare = server.mock(|when, then| {
-            when.method(POST)
-                .path("/api/webhooks/agent/storages/prepare");
-            then.status(200).json_body(json!({"unreachable": true}));
-        });
-        let commit = server.mock(|when, then| {
-            when.method(POST)
-                .path("/api/webhooks/agent/storages/commit");
-            then.status(200).json_body(json!({"unreachable": true}));
-        });
-        let upload = server.mock(|when, then| {
-            when.method(PUT);
-            then.status(200);
-        });
-        let http = HttpClient::with_api_config(
-            server.base_url(),
-            "test-token",
-            "",
-            "test-run-001",
-            Duration::ZERO,
-        )
-        .unwrap();
-        let entries = vec![env::ArtifactEnv {
-            name: "workspace".to_string(),
-            mount_path: mount.to_string_lossy().into_owned(),
-            storage_id: "storage-id".to_string(),
-            version_id: "parent-version".to_string(),
-            missing_root_policy: None,
-        }];
-
-        let error = snapshot_artifact_entries(&http, "test-run", &entries)
-            .await
-            .unwrap_err();
-        let message = error.to_string();
+        let message = artifact_snapshot_preflight_error(&mount).await;
         assert!(
             message.contains(&format!(
                 "observed entries {}/{}",
@@ -756,10 +766,6 @@ mod tests {
             message.contains(&format!("/{}", vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES)),
             "got: {message}"
         );
-        prepare.assert_calls(0);
-        upload.assert_calls(0);
-        commit.assert_calls(0);
-        assert_artifact_hash_failure(&telemetry_path, &message);
     }
 
     #[cfg(target_os = "linux")]
@@ -780,44 +786,7 @@ mod tests {
         drop(file);
         drop(current);
 
-        let telemetry_dir = tempfile::tempdir().unwrap();
-        let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
-        let server = MockServer::start();
-        let prepare = server.mock(|when, then| {
-            when.method(POST)
-                .path("/api/webhooks/agent/storages/prepare");
-            then.status(200).json_body(json!({"unreachable": true}));
-        });
-        let commit = server.mock(|when, then| {
-            when.method(POST)
-                .path("/api/webhooks/agent/storages/commit");
-            then.status(200).json_body(json!({"unreachable": true}));
-        });
-        let upload = server.mock(|when, then| {
-            when.method(PUT);
-            then.status(200);
-        });
-        let http = HttpClient::with_api_config(
-            server.base_url(),
-            "test-token",
-            "",
-            "test-run-001",
-            Duration::ZERO,
-        )
-        .unwrap();
-        let entries = vec![env::ArtifactEnv {
-            name: "workspace".to_string(),
-            mount_path: mount.to_string_lossy().into_owned(),
-            storage_id: "storage-id".to_string(),
-            version_id: "parent-version".to_string(),
-            missing_root_policy: None,
-        }];
-
-        let error = snapshot_artifact_entries(&http, "test-run", &entries)
-            .await
-            .unwrap_err();
-        let message = error.to_string();
+        let message = artifact_snapshot_preflight_error(&mount).await;
         assert!(
             message.contains(&format!(
                 "observed entries {}/{}",
@@ -841,10 +810,6 @@ mod tests {
             )),
             "got: {message}"
         );
-        prepare.assert_calls(0);
-        upload.assert_calls(0);
-        commit.assert_calls(0);
-        assert_artifact_hash_failure(&telemetry_path, &message);
     }
 
     #[cfg(target_os = "linux")]
@@ -865,44 +830,7 @@ mod tests {
         }
         std::fs::File::create(deepest.join(std::ffi::OsString::from_vec(vec![0xff]))).unwrap();
 
-        let telemetry_dir = tempfile::tempdir().unwrap();
-        let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
-        let server = MockServer::start();
-        let prepare = server.mock(|when, then| {
-            when.method(POST)
-                .path("/api/webhooks/agent/storages/prepare");
-            then.status(200).json_body(json!({"unreachable": true}));
-        });
-        let commit = server.mock(|when, then| {
-            when.method(POST)
-                .path("/api/webhooks/agent/storages/commit");
-            then.status(200).json_body(json!({"unreachable": true}));
-        });
-        let upload = server.mock(|when, then| {
-            when.method(PUT);
-            then.status(200);
-        });
-        let http = HttpClient::with_api_config(
-            server.base_url(),
-            "test-token",
-            "",
-            "test-run-001",
-            Duration::ZERO,
-        )
-        .unwrap();
-        let entries = vec![env::ArtifactEnv {
-            name: "workspace".to_string(),
-            mount_path: mount.to_string_lossy().into_owned(),
-            storage_id: "storage-id".to_string(),
-            version_id: "parent-version".to_string(),
-            missing_root_policy: None,
-        }];
-
-        let error = snapshot_artifact_entries(&http, "test-run", &entries)
-            .await
-            .unwrap_err();
-        let message = error.to_string();
+        let message = artifact_snapshot_preflight_error(&mount).await;
         assert!(
             message.contains(&format!(
                 "directory depth {}/{}",
@@ -919,10 +847,6 @@ mod tests {
             )),
             "got: {message}"
         );
-        prepare.assert_calls(0);
-        upload.assert_calls(0);
-        commit.assert_calls(0);
-        assert_artifact_hash_failure(&telemetry_path, &message);
     }
 
     #[tokio::test]

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -774,7 +774,9 @@ mod tests {
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
         guest_common::log::clear_system_log_file();
 
-        let dir = tempfile::tempdir().unwrap();
+        // Use tmpfs so the descriptor-relative fixture is not constrained by
+        // an overlay filesystem's internal backing-path length.
+        let dir = tempfile::tempdir_in("/dev/shm").unwrap();
         let mount = dir.path().join("long-path");
         std::fs::create_dir(&mount).unwrap();
         let mut current = File::open(&mount).unwrap();

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -268,6 +268,14 @@ mod tests {
     use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
     use httpmock::prelude::*;
     use serde_json::json;
+    #[cfg(target_os = "linux")]
+    use std::ffi::CString;
+    #[cfg(target_os = "linux")]
+    use std::fs::File;
+    #[cfg(target_os = "linux")]
+    use std::os::fd::{AsRawFd, FromRawFd};
+    #[cfg(target_os = "linux")]
+    use std::os::unix::ffi::OsStrExt;
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, TcpStream};
@@ -308,6 +316,62 @@ mod tests {
             matching_failure,
             "missing failed artifact_hash_compute telemetry for {expected_error:?}"
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn make_fifo(path: &std::path::Path) -> std::io::Result<()> {
+        let path = CString::new(path.as_os_str().as_bytes())
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
+        // SAFETY: `path` is a NUL-terminated filesystem path owned for the call.
+        let result = unsafe { libc::mkfifo(path.as_ptr(), 0o600) };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn create_and_open_child_dir(parent: &File, name: &CString) -> std::io::Result<File> {
+        // SAFETY: `parent` is a live directory descriptor and `name` is a
+        // NUL-terminated basename owned for the duration of both calls.
+        let created = unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o755) };
+        if created != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: the arguments satisfy `openat`, and a successful result is a
+        // newly owned descriptor transferred to `File` below.
+        let fd = unsafe {
+            libc::openat(
+                parent.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: `fd` is the newly owned descriptor returned by `openat`.
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+
+    #[cfg(target_os = "linux")]
+    fn create_child_file(parent: &File, name: &CString) -> std::io::Result<File> {
+        // SAFETY: `parent` is a live directory descriptor, `name` is a
+        // NUL-terminated basename, and `O_CREAT` supplies the explicit mode.
+        let fd = unsafe {
+            libc::openat(
+                parent.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                0o600,
+            )
+        };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: `fd` is the newly owned descriptor returned by `openat`.
+        Ok(unsafe { File::from_raw_fd(fd) })
     }
 
     async fn start_artifact_checkpoint_test_server(
@@ -612,7 +676,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn artifact_snapshot_enforces_traversal_entry_limit_before_storage_api_calls() {
-        const PARENT_COUNT: usize = 100;
+        const PARENT_COUNT: usize = 2;
 
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
         guest_common::log::clear_system_log_file();
@@ -622,17 +686,19 @@ mod tests {
         std::fs::create_dir(&mount).unwrap();
         std::fs::create_dir(mount.join(".git")).unwrap();
         let max_entries = usize::try_from(vas::ARTIFACT_TRAVERSAL_MAX_ENTRIES).unwrap();
-        let children_per_parent = (max_entries - PARENT_COUNT) / PARENT_COUNT;
+        let links_per_parent = (max_entries - PARENT_COUNT) / PARENT_COUNT - 1;
         assert_eq!(
-            PARENT_COUNT * (children_per_parent + 1),
+            PARENT_COUNT * (links_per_parent + 2),
             max_entries,
             "fixture must contain exactly the traversal limit before .git"
         );
         for parent_index in 0..PARENT_COUNT {
             let parent = mount.join(format!("p{parent_index:03}"));
             std::fs::create_dir(&parent).unwrap();
-            for child_index in 0..children_per_parent {
-                std::fs::create_dir(parent.join(format!("d{child_index:03}"))).unwrap();
+            let source = parent.join("source");
+            make_fifo(&source).unwrap();
+            for link_index in 0..links_per_parent {
+                std::fs::hard_link(&source, parent.join(format!("l{link_index:05}"))).unwrap();
             }
         }
 
@@ -688,6 +754,91 @@ mod tests {
         );
         assert!(
             message.contains(&format!("/{}", vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES)),
+            "got: {message}"
+        );
+        prepare.assert_calls(0);
+        upload.assert_calls(0);
+        commit.assert_calls(0);
+        assert_artifact_hash_failure(&telemetry_path, &message);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn artifact_snapshot_enforces_traversal_active_path_limit_before_storage_api_calls() {
+        let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        guest_common::log::clear_system_log_file();
+
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join("long-path");
+        std::fs::create_dir(&mount).unwrap();
+        let directory_name = CString::new("d".repeat(255)).unwrap();
+        let mut current = File::open(&mount).unwrap();
+        for _ in 0..vas::ARTIFACT_TRAVERSAL_MAX_DEPTH {
+            current = create_and_open_child_dir(&current, &directory_name).unwrap();
+        }
+        let file = create_child_file(&current, &CString::new("f").unwrap()).unwrap();
+        drop(file);
+        drop(current);
+
+        let telemetry_dir = tempfile::tempdir().unwrap();
+        let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
+        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let upload = server.mock(|when, then| {
+            when.method(PUT);
+            then.status(200);
+        });
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
+        let entries = vec![env::ArtifactEnv {
+            name: "workspace".to_string(),
+            mount_path: mount.to_string_lossy().into_owned(),
+            storage_id: "storage-id".to_string(),
+            version_id: "parent-version".to_string(),
+            missing_root_policy: None,
+        }];
+
+        let error = snapshot_artifact_entries(&http, "test-run", &entries)
+            .await
+            .unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains(&format!(
+                "observed entries {}/{}",
+                vas::ARTIFACT_TRAVERSAL_MAX_DEPTH + 1,
+                vas::ARTIFACT_TRAVERSAL_MAX_ENTRIES
+            )),
+            "got: {message}"
+        );
+        assert!(
+            message.contains(&format!(
+                "directory depth {0}/{0}",
+                vas::ARTIFACT_TRAVERSAL_MAX_DEPTH
+            )),
+            "got: {message}"
+        );
+        assert!(
+            message.contains(&format!(
+                "active UTF-8 path bytes {}/{}",
+                vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES + 1,
+                vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES
+            )),
             "got: {message}"
         );
         prepare.assert_calls(0);

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -777,24 +777,33 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mount = dir.path().join("long-path");
         std::fs::create_dir(&mount).unwrap();
-        let directory_name = CString::new("d".repeat(255)).unwrap();
         let mut current = File::open(&mount).unwrap();
-        for _ in 0..vas::ARTIFACT_TRAVERSAL_MAX_DEPTH {
+        for depth in 0..vas::ARTIFACT_TRAVERSAL_MAX_DEPTH {
+            let component_bytes = if depth + 1 == vas::ARTIFACT_TRAVERSAL_MAX_DEPTH {
+                254
+            } else {
+                255
+            };
+            let directory_name = CString::new("d".repeat(component_bytes)).unwrap();
             current = create_and_open_child_dir(&current, &directory_name).unwrap();
         }
         let file = create_child_file(&current, &CString::new("f").unwrap()).unwrap();
         drop(file);
+
+        let exact_files = vas::walk_files_for_checkpoint(mount.to_str().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(exact_files.len(), 1);
+        assert_eq!(
+            exact_files.first().unwrap().path.len(),
+            usize::try_from(vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES).unwrap()
+        );
+
+        let file = create_child_file(&current, &CString::new("gg").unwrap()).unwrap();
+        drop(file);
         drop(current);
 
         let message = artifact_snapshot_preflight_error(&mount).await;
-        assert!(
-            message.contains(&format!(
-                "observed entries {}/{}",
-                vas::ARTIFACT_TRAVERSAL_MAX_DEPTH + 1,
-                vas::ARTIFACT_TRAVERSAL_MAX_ENTRIES
-            )),
-            "got: {message}"
-        );
         assert!(
             message.contains(&format!(
                 "directory depth {0}/{0}",

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -271,10 +271,6 @@ mod tests {
     #[cfg(target_os = "linux")]
     use std::ffi::CString;
     #[cfg(target_os = "linux")]
-    use std::fs::File;
-    #[cfg(target_os = "linux")]
-    use std::os::fd::{AsRawFd, FromRawFd};
-    #[cfg(target_os = "linux")]
     use std::os::unix::ffi::OsStrExt;
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -329,49 +325,6 @@ mod tests {
         } else {
             Err(std::io::Error::last_os_error())
         }
-    }
-
-    #[cfg(target_os = "linux")]
-    fn create_and_open_child_dir(parent: &File, name: &CString) -> std::io::Result<File> {
-        // SAFETY: `parent` is a live directory descriptor and `name` is a
-        // NUL-terminated basename owned for the duration of both calls.
-        let created = unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o755) };
-        if created != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        // SAFETY: the arguments satisfy `openat`, and a successful result is a
-        // newly owned descriptor transferred to `File` below.
-        let fd = unsafe {
-            libc::openat(
-                parent.as_raw_fd(),
-                name.as_ptr(),
-                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-            )
-        };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        // SAFETY: `fd` is the newly owned descriptor returned by `openat`.
-        Ok(unsafe { File::from_raw_fd(fd) })
-    }
-
-    #[cfg(target_os = "linux")]
-    fn create_child_file(parent: &File, name: &CString) -> std::io::Result<File> {
-        // SAFETY: `parent` is a live directory descriptor, `name` is a
-        // NUL-terminated basename, and `O_CREAT` supplies the explicit mode.
-        let fd = unsafe {
-            libc::openat(
-                parent.as_raw_fd(),
-                name.as_ptr(),
-                libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-                0o600,
-            )
-        };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        // SAFETY: `fd` is the newly owned descriptor returned by `openat`.
-        Ok(unsafe { File::from_raw_fd(fd) })
     }
 
     #[cfg(target_os = "linux")]
@@ -764,61 +717,6 @@ mod tests {
         );
         assert!(
             message.contains(&format!("/{}", vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES)),
-            "got: {message}"
-        );
-    }
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn artifact_snapshot_enforces_traversal_active_path_limit_before_storage_api_calls() {
-        let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
-        guest_common::log::clear_system_log_file();
-
-        // Use tmpfs so the descriptor-relative fixture is not constrained by
-        // an overlay filesystem's internal backing-path length.
-        let dir = tempfile::tempdir_in("/dev/shm").unwrap();
-        let mount = dir.path().join("long-path");
-        std::fs::create_dir(&mount).unwrap();
-        let mut current = File::open(&mount).unwrap();
-        for depth in 0..vas::ARTIFACT_TRAVERSAL_MAX_DEPTH {
-            let component_bytes = if depth + 1 == vas::ARTIFACT_TRAVERSAL_MAX_DEPTH {
-                254
-            } else {
-                255
-            };
-            let directory_name = CString::new("d".repeat(component_bytes)).unwrap();
-            current = create_and_open_child_dir(&current, &directory_name).unwrap();
-        }
-        let file = create_child_file(&current, &CString::new("f").unwrap()).unwrap();
-        drop(file);
-
-        let exact_files = vas::walk_files_for_checkpoint(mount.to_str().unwrap())
-            .await
-            .unwrap();
-        assert_eq!(exact_files.len(), 1);
-        assert_eq!(
-            exact_files.first().unwrap().path.len(),
-            usize::try_from(vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES).unwrap()
-        );
-
-        let file = create_child_file(&current, &CString::new("gg").unwrap()).unwrap();
-        drop(file);
-        drop(current);
-
-        let message = artifact_snapshot_preflight_error(&mount).await;
-        assert!(
-            message.contains(&format!(
-                "directory depth {0}/{0}",
-                vas::ARTIFACT_TRAVERSAL_MAX_DEPTH
-            )),
-            "got: {message}"
-        );
-        assert!(
-            message.contains(&format!(
-                "active UTF-8 path bytes {}/{}",
-                vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES + 1,
-                vas::ARTIFACT_TRAVERSAL_MAX_PATH_BYTES
-            )),
             "got: {message}"
         );
     }


### PR DESCRIPTION
## Summary

- bound artifact directory traversal to 100,000 yielded entries, 256 directory levels, and a 64 KiB active UTF-8 relative path
- return a typed diagnostic containing observed and configured traversal limits before any snapshot storage API call
- cover excluded-entry accounting and deep-tree rejection with real filesystem checkpoint tests and failure telemetry assertions

## Scope

- preserves the existing 50,000-file and aggregate manifest-path limits
- preserves strict root access, best-effort nested access, descriptor-relative traversal, and no-symlink-following behavior
- does not change snapshot storage protocols or archive encoding

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p guest-agent`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p guest-agent --all-features --no-deps`

Closes #31425
