### PR TITLE
refactor(python): centralize platform api url parsing

### DIFF
--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -7,6 +7,7 @@ import uuid
 
 from mitmproxy import ctx, http
 
+import platform_api_url
 from authority_utils import authority_has_empty_port, format_url_host
 from host_normalization import normalize_hostname
 
@@ -54,23 +55,6 @@ def _split_url_without_value_diagnostics(
         return urllib.parse.urlsplit(value)
     except ValueError:
         raise ValueError(f"{subject} is invalid") from None
-
-
-def _canonical_platform_url(url: str) -> str:
-    parsed_url = _split_url_without_value_diagnostics(url, subject="Platform API URL")
-    scheme = parsed_url.scheme.lower()
-    if scheme not in {"http", "https"} or not parsed_url.netloc or parsed_url.hostname is None:
-        raise ValueError("Platform API URL must be an absolute http(s) URL")
-    if parsed_url.username is not None or parsed_url.password is not None:
-        raise ValueError("Platform API URL must not contain user information")
-
-    port = _parsed_port(parsed_url, subject="Platform API URL")
-    authority = format_url_host(normalize_hostname(parsed_url.hostname))
-    if port is not None:
-        authority = f"{authority}:{port}"
-    return urllib.parse.urlunsplit(
-        (scheme, authority, parsed_url.path, parsed_url.query, parsed_url.fragment)
-    )
 
 
 def normalize_proxy_url(proxy_url: str) -> str:
@@ -143,14 +127,14 @@ def make_api_request(url: str, data: bytes, bearer_credential: str) -> urllib.re
     redirects, using :func:`build_api_opener` or an equivalent transport policy,
     before contacting another URL.
     """
-    canonical_url = _canonical_platform_url(url)
+    parsed_url = platform_api_url.parse_platform_api_url(url)
     client_session_id, client_version = _CLIENT_HEADERS
 
     # S310 (suspicious-url-open-usage): callers build `url` from the
     # operator-configured platform API URL, and the scheme is validated above
     # before urllib can consume the request.
     req = urllib.request.Request(  # noqa: S310
-        canonical_url,
+        parsed_url.canonical_url,
         data=data,
         headers={
             "Content-Type": "application/json",

--- a/crates/runner/mitm-addon/src/platform_api_url.py
+++ b/crates/runner/mitm-addon/src/platform_api_url.py
@@ -1,0 +1,65 @@
+"""Platform API URL parsing and normalization contract."""
+
+import urllib.parse
+from dataclasses import dataclass
+from typing import Literal
+
+from authority_utils import authority_has_empty_port, format_url_host
+from host_normalization import normalize_hostname
+
+
+@dataclass(frozen=True)
+class PlatformApiUrl:
+    """Canonical request URL and normalized origin for the platform API."""
+
+    canonical_url: str
+    scheme: Literal["http", "https"]
+    host: str
+    port: int
+
+
+def _parsed_port(parsed_url: urllib.parse.SplitResult) -> int | None:
+    if authority_has_empty_port(parsed_url.netloc):
+        raise ValueError("Platform API URL has an invalid port")
+    try:
+        return parsed_url.port
+    except ValueError as exc:
+        raise ValueError("Platform API URL has an invalid port") from exc
+
+
+def _split_url_without_value_diagnostics(value: str) -> urllib.parse.SplitResult:
+    try:
+        return urllib.parse.urlsplit(value)
+    except ValueError:
+        raise ValueError("Platform API URL is invalid") from None
+
+
+def parse_platform_api_url(url: str) -> PlatformApiUrl:
+    """Parse one platform API URL into its canonical URL and effective origin."""
+    parsed_url = _split_url_without_value_diagnostics(url)
+    scheme = parsed_url.scheme.lower()
+    if scheme == "http":
+        default_port = 80
+    elif scheme == "https":
+        default_port = 443
+    else:
+        raise ValueError("Platform API URL must be an absolute http(s) URL")
+    if not parsed_url.netloc or parsed_url.hostname is None:
+        raise ValueError("Platform API URL must be an absolute http(s) URL")
+    if parsed_url.username is not None or parsed_url.password is not None:
+        raise ValueError("Platform API URL must not contain user information")
+
+    explicit_port = _parsed_port(parsed_url)
+    host = normalize_hostname(parsed_url.hostname)
+    authority = format_url_host(host)
+    if explicit_port is not None:
+        authority = f"{authority}:{explicit_port}"
+    canonical_url = urllib.parse.urlunsplit(
+        (scheme, authority, parsed_url.path, parsed_url.query, parsed_url.fragment)
+    )
+    return PlatformApiUrl(
+        canonical_url=canonical_url,
+        scheme=scheme,
+        host=host,
+        port=explicit_port if explicit_port is not None else default_port,
+    )

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -1,7 +1,6 @@
 """TLS and upstream destination admission lifecycle owner."""
 
 import os
-import urllib.parse
 from dataclasses import dataclass
 from typing import Final, Literal
 
@@ -11,6 +10,7 @@ import connection_endpoints
 import flow_metadata
 import matching
 import path_security
+import platform_api_url
 import registry
 import upstream_destination_binding
 from host_normalization import normalize_hostname
@@ -41,14 +41,7 @@ class TlsAdmission:
     sni: str | None = None
 
 
-@dataclass(frozen=True)
-class _ApiDestination:
-    scheme: Literal["http", "https"]
-    host: str
-    port: int
-
-
-_api_destination_cache: tuple[str, _ApiDestination | None] | None = None
+_api_destination_cache: tuple[str, platform_api_url.PlatformApiUrl | None] | None = None
 
 
 def _client_connection_id(client: object) -> str | None:
@@ -174,7 +167,7 @@ def _scheme_hostname_port_matches_api_destination(
     scheme: str,
     hostname: str,
     port: int,
-    api_destination: _ApiDestination,
+    api_destination: platform_api_url.PlatformApiUrl,
 ) -> bool:
     return (
         scheme.lower() == api_destination.scheme
@@ -185,50 +178,18 @@ def _scheme_hostname_port_matches_api_destination(
 
 def _api_destination(
     api_url: str,
-) -> _ApiDestination | None:
+) -> platform_api_url.PlatformApiUrl | None:
     global _api_destination_cache
     cached = _api_destination_cache
     if cached is not None and cached[0] == api_url:
         return cached[1]
 
-    api_destination = _derive_api_destination(api_url)
+    try:
+        api_destination = platform_api_url.parse_platform_api_url(api_url)
+    except (UnicodeError, ValueError):
+        api_destination = None
     _api_destination_cache = (api_url, api_destination)
     return api_destination
-
-
-def _derive_api_destination(
-    api_url: str,
-) -> _ApiDestination | None:
-    if not api_url:
-        return None
-    try:
-        parsed_api = urllib.parse.urlparse(api_url)
-        api_hostname_raw = parsed_api.hostname
-    except ValueError:
-        return None
-    if not api_hostname_raw:
-        return None
-    api_scheme = parsed_api.scheme.lower()
-    if api_scheme == "http":
-        default_port = 80
-    elif api_scheme == "https":
-        default_port = 443
-    else:
-        return None
-    try:
-        api_hostname = normalize_hostname(api_hostname_raw)
-    except (UnicodeError, ValueError):
-        return None
-    try:
-        explicit_port = parsed_api.port
-    except ValueError:
-        return None
-    api_port = explicit_port if explicit_port is not None else default_port
-    return _ApiDestination(
-        scheme=api_scheme,
-        host=api_hostname,
-        port=api_port,
-    )
 
 
 def _server_connect_binding_kinds(

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -550,6 +550,11 @@ def fresh_usage_executor():
         pytest.param("https://[::1", id="unmatched-ipv6-bracket"),
         pytest.param("https://api.vm0.ai:not-a-port", id="non-numeric-port"),
         pytest.param("https://api.vm0.ai:65536", id="out-of-range-port"),
+        pytest.param(
+            "https://user:secret@api.vm0.ai/base",
+            id="userinfo",
+        ),
+        pytest.param("https://api.vm0.ai:/base", id="empty-port"),
     ]
 )
 def malformed_platform_api_url(request: pytest.FixtureRequest) -> str:

--- a/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_api_admission.py
@@ -1,7 +1,6 @@
 """Platform API admission request hook integration tests."""
 
 import json
-import urllib.parse
 
 import pytest
 from mitmproxy import connection
@@ -9,9 +8,9 @@ from mitmproxy import connection
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import platform_api
+import platform_api_url
 import registry
 import request_classification
-import upstream_admission
 import upstream_destination_binding
 from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
 from tests.upstream_connection_helpers import (
@@ -373,21 +372,15 @@ async def test_malformed_vm0_api_url_is_cached_as_non_match(
     malformed_platform_api_url,
 ):
     parsed_api_urls: list[str] = []
-    parse_api_url = urllib.parse.urlparse
+    parse_api_url = platform_api_url.parse_platform_api_url
 
     def track_api_url_parse(
         api_url: str,
-        scheme: str = "",
-        allow_fragments: bool = True,
-    ) -> urllib.parse.ParseResult:
+    ) -> platform_api_url.PlatformApiUrl:
         parsed_api_urls.append(api_url)
-        return parse_api_url(
-            api_url,
-            scheme=scheme,
-            allow_fragments=allow_fragments,
-        )
+        return parse_api_url(api_url)
 
-    monkeypatch.setattr(upstream_admission.urllib.parse, "urlparse", track_api_url_parse)
+    monkeypatch.setattr(platform_api_url, "parse_platform_api_url", track_api_url_parse)
     flows = [
         real_flow(with_response=False, host="api.vm0.ai"),
         real_flow(with_response=False, host="api.vm0.ai"),

--- a/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_api_admission.py
@@ -1,6 +1,5 @@
 """Platform API requestheaders upstream-admission tests."""
 
-import urllib.parse
 from pathlib import Path
 
 from mitmproxy import connection, http
@@ -8,6 +7,7 @@ from mitmproxy import connection, http
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import platform_api
+import platform_api_url
 import request_classification
 import upstream_admission
 import upstream_destination_binding
@@ -38,32 +38,18 @@ async def test_api_destination_derivation_reuses_and_refreshes_effective_option(
 ):
     reg_path = _write_api_registry(tmp_path, capture_network_bodies=False)
     parsed_api_urls: list[str] = []
-    normalized_api_hosts: list[str] = []
-    parse_api_url = urllib.parse.urlparse
-    normalize_api_hostname = upstream_admission.normalize_hostname
+    parsed_api_hosts: list[str] = []
+    parse_api_url = platform_api_url.parse_platform_api_url
 
     def track_api_url_parse(
         api_url: str,
-        scheme: str = "",
-        allow_fragments: bool = True,
-    ) -> urllib.parse.ParseResult:
+    ) -> platform_api_url.PlatformApiUrl:
         parsed_api_urls.append(api_url)
-        return parse_api_url(
-            api_url,
-            scheme=scheme,
-            allow_fragments=allow_fragments,
-        )
+        parsed_url = parse_api_url(api_url)
+        parsed_api_hosts.append(parsed_url.host)
+        return parsed_url
 
-    def track_api_hostname_normalization(hostname: str) -> str:
-        normalized_api_hosts.append(hostname)
-        return normalize_api_hostname(hostname)
-
-    monkeypatch.setattr(upstream_admission.urllib.parse, "urlparse", track_api_url_parse)
-    monkeypatch.setattr(
-        upstream_admission,
-        "normalize_hostname",
-        track_api_hostname_normalization,
-    )
+    monkeypatch.setattr(platform_api_url, "parse_platform_api_url", track_api_url_parse)
 
     def api_flow(*, host: str, scheme: str = "https", port: int = 443) -> http.HTTPFlow:
         return real_flow(
@@ -91,7 +77,7 @@ async def test_api_destination_derivation_reuses_and_refreshes_effective_option(
             assert flow.response is None
 
         assert parsed_api_urls == [initial_api_url]
-        assert normalized_api_hosts == ["api.vm0.ai"]
+        assert parsed_api_hosts == ["api.vm0.ai"]
 
         updated_api_url = "http://API.PREVIEW.VM0.AI:8080"
         mitm_addon.ctx.options.vm0_api_url = updated_api_url
@@ -111,7 +97,7 @@ async def test_api_destination_derivation_reuses_and_refreshes_effective_option(
         assert updated_binding.port == 8080
         assert updated_binding.kinds == frozenset(("api_allow",))
         assert parsed_api_urls == [initial_api_url, updated_api_url]
-        assert normalized_api_hosts == ["api.vm0.ai", "api.preview.vm0.ai"]
+        assert parsed_api_hosts == ["api.vm0.ai", "api.preview.vm0.ai"]
 
         invalid_api_url = "ftp://api.invalid.vm0.ai"
         mitm_addon.ctx.options.vm0_api_url = invalid_api_url
@@ -127,7 +113,7 @@ async def test_api_destination_derivation_reuses_and_refreshes_effective_option(
     bindings = upstream_destination_binding.binding_snapshot_for_tests()
     assert all(flow.server_conn.id not in bindings for flow in invalid_flows)
     assert parsed_api_urls == [initial_api_url, updated_api_url, invalid_api_url]
-    assert normalized_api_hosts == ["api.vm0.ai", "api.preview.vm0.ai"]
+    assert parsed_api_hosts == ["api.vm0.ai", "api.preview.vm0.ai"]
 
 
 async def test_capture_enabled_api_allow_retargets_unconnected_upstream(


### PR DESCRIPTION
## Summary

- add one low-level `PlatformApiUrl` parser/value for canonical request URLs and normalized effective origins
- route credential-bearing request construction and privileged upstream admission through the shared contract while retaining admission's raw-option cache and fail-closed policy
- reject user information and explicitly empty ports across request, TLS ClientHello, and server-connect admission paths

## Exclusions

- no Rust runner configuration or command-line changes
- no addon option, protocol, network-policy, request-header, proxy URL, or persisted-state changes
- no migration or staged rollout

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest -q tests/test_platform_api.py tests/test_request_handler_api_admission.py tests/test_request_headers_api_admission.py tests/test_tls_clienthello_hook.py tests/test_server_connect_hook.py` (115 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` (0 errors, 0 warnings)
- `uv run --no-sync python -m pytest tests/` (7319 passed)

Closes #31427
