### PR TITLE
fix(platform): make connector scope review account-exact

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -298,6 +298,7 @@ describe("connector account lifecycle routes", () => {
         return !("scopeMismatch" in account);
       }),
     ).toBeTruthy();
+    expect("defaultConnection" in legacyList.body).toBeFalsy();
 
     const enrichedList = await accept(
       accountClient().connections({
@@ -322,6 +323,30 @@ describe("connector account lifecycle routes", () => {
         [currentId, false],
       ]),
     );
+    expect(enrichedList.body.defaultConnection).toMatchObject({
+      id: currentId,
+      scopeMismatch: false,
+    });
+
+    const filteredList = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: {
+          kind: "builtin",
+          connectorSlug: "github",
+          includeScopeMismatch: "true",
+          limit: 100,
+          search: staleId,
+        },
+      }),
+      [200],
+    );
+    expect(filteredList.body.connections).toHaveLength(1);
+    expect(filteredList.body.connections[0]?.id).toBe(staleId);
+    expect(filteredList.body.defaultConnection).toMatchObject({
+      id: currentId,
+      scopeMismatch: false,
+    });
 
     const staleDiff = await accept(
       accountClient().scopeDiff({

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -406,22 +406,6 @@ describe("connector account lifecycle routes", () => {
       }),
       [404],
     );
-
-    const unavailableMethodId = await seedConnectorStorageRow(context, {
-      orgId: fixture.orgId,
-      userId: fixture.userId,
-      connectorSlug: "openai",
-      authMethod: "unavailable-method",
-      storageVersion: 1,
-    });
-    await accept(
-      accountClient().scopeDiff({
-        headers: authHeaders(),
-        params: { connectionId: unavailableMethodId },
-        query: { connectorSlug: "openai" },
-      }),
-      [404],
-    );
   });
 
   it("inspects only exact owned accounts without leaking credentials", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -28,7 +28,11 @@ import { customConnectorsRoutes } from "../custom-connectors";
 import { customConnectorsDeleteRoutes } from "../custom-connectors-delete";
 import { customConnectorsValuesSetRoutes } from "../custom-connectors-values-set";
 import { featureSwitchesRoutes } from "../feature-switches";
-import { seedConnectorStorageRow } from "./helpers/connector-credential-storage-state";
+import {
+  seedConnectorStorageRow,
+  setBuiltinOAuthScopeFacts,
+  setConnectorDefaultState,
+} from "./helpers/connector-credential-storage-state";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createFixtureTracker, createRouteMocks } from "./helpers/route-test";
 
@@ -114,31 +118,33 @@ async function setConnectorAccountsEnabled(
 
 async function cleanupFixture(fixture: Fixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
-  let hasBuiltinAccounts = true;
-  while (hasBuiltinAccounts) {
-    const accounts = await accept(
-      accountClient().connections({
-        headers: authHeaders(),
-        query: { kind: "builtin", connectorSlug: "openai", limit: 100 },
-      }),
-      [200, 404],
-    );
-    hasBuiltinAccounts =
-      accounts.status === 200 && accounts.body.connections.length > 0;
-    if (accounts.status !== 200) {
-      break;
-    }
-    for (const account of accounts.body.connections) {
-      await accept(
-        accountClient().delete({
+  for (const connectorSlug of ["openai", "github"] as const) {
+    let hasBuiltinAccounts = true;
+    while (hasBuiltinAccounts) {
+      const accounts = await accept(
+        accountClient().connections({
           headers: authHeaders(),
-          params: { connectionId: account.id },
-          body: {
-            target: { kind: "builtin", connectorSlug: "openai" },
-          },
+          query: { kind: "builtin", connectorSlug, limit: 100 },
         }),
         [200, 404],
       );
+      hasBuiltinAccounts =
+        accounts.status === 200 && accounts.body.connections.length > 0;
+      if (accounts.status !== 200) {
+        break;
+      }
+      for (const account of accounts.body.connections) {
+        await accept(
+          accountClient().delete({
+            headers: authHeaders(),
+            params: { connectionId: account.id },
+            body: {
+              target: { kind: "builtin", connectorSlug },
+            },
+          }),
+          [200, 404],
+        );
+      }
     }
   }
   const customConnectors = await accept(
@@ -226,6 +232,196 @@ describe("connector account lifecycle routes", () => {
       [404],
     );
     expect(inspection.body.error.message).toBe("Resource not found");
+    const scopeDiff = await accept(
+      accountClient().scopeDiff({
+        headers: authHeaders(),
+        params: { connectionId: randomUUID() },
+        query: { connectorSlug: "github" },
+      }),
+      [404],
+    );
+    expect(scopeDiff.body.error.message).toBe("Resource not found");
+  });
+
+  it("reviews requested scopes for one exact account across default changes", async () => {
+    const fixture = await seedFixture();
+    await setConnectorAccountsEnabled(fixture, true);
+    const currentScopes = ["repo", "project", "workflow"] as const;
+    const staleId = await seedConnectorStorageRow(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "github",
+      authMethod: "oauth",
+      storageVersion: 1,
+    });
+    await setConnectorDefaultState(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorId: staleId,
+      isDefault: false,
+    });
+    const currentId = await seedConnectorStorageRow(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "github",
+      authMethod: "oauth",
+      storageVersion: 1,
+    });
+    await setBuiltinOAuthScopeFacts(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "github",
+      connectorId: staleId,
+      oauthScopes: ["repo"],
+      oauthGrantedScopes: ["repo"],
+    });
+    await setBuiltinOAuthScopeFacts(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "github",
+      connectorId: currentId,
+      oauthScopes: currentScopes,
+      // A provider may return fewer granted scopes than the app requested.
+      // Scope review must compare against the requested snapshot instead.
+      oauthGrantedScopes: ["repo"],
+    });
+
+    const legacyList = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: { kind: "builtin", connectorSlug: "github", limit: 100 },
+      }),
+      [200],
+    );
+    expect(
+      legacyList.body.connections.every((account) => {
+        return !("scopeMismatch" in account);
+      }),
+    ).toBeTruthy();
+
+    const enrichedList = await accept(
+      accountClient().connections({
+        headers: authHeaders(),
+        query: {
+          kind: "builtin",
+          connectorSlug: "github",
+          includeScopeMismatch: "true",
+          limit: 100,
+        },
+      }),
+      [200],
+    );
+    const mismatchById = new Map(
+      enrichedList.body.connections.map((account) => {
+        return [account.id, account.scopeMismatch] as const;
+      }),
+    );
+    expect(mismatchById).toStrictEqual(
+      new Map([
+        [staleId, true],
+        [currentId, false],
+      ]),
+    );
+
+    const staleDiff = await accept(
+      accountClient().scopeDiff({
+        headers: authHeaders(),
+        params: { connectionId: staleId },
+        query: { connectorSlug: "github" },
+      }),
+      [200],
+    );
+    expect(staleDiff.body).toStrictEqual({
+      addedScopes: ["project", "workflow"],
+      removedScopes: [],
+      currentScopes,
+      storedScopes: ["repo"],
+    });
+    const currentDiff = await accept(
+      accountClient().scopeDiff({
+        headers: authHeaders(),
+        params: { connectionId: currentId },
+        query: { connectorSlug: "github" },
+      }),
+      [200],
+    );
+    expect(currentDiff.body).toStrictEqual({
+      addedScopes: [],
+      removedScopes: [],
+      currentScopes,
+      storedScopes: currentScopes,
+    });
+
+    await accept(
+      accountClient().setDefault({
+        headers: authHeaders(),
+        params: { connectionId: staleId },
+        body: { target: { kind: "builtin", connectorSlug: "github" } },
+      }),
+      [200],
+    );
+    const currentDiffAfterDefaultChange = await accept(
+      accountClient().scopeDiff({
+        headers: authHeaders(),
+        params: { connectionId: currentId },
+        query: { connectorSlug: "github" },
+      }),
+      [200],
+    );
+    expect(currentDiffAfterDefaultChange.body).toStrictEqual(currentDiff.body);
+
+    await accept(
+      accountClient().scopeDiff({
+        headers: authHeaders(),
+        params: { connectionId: currentId },
+        query: { connectorSlug: "openai" },
+      }),
+      [404],
+    );
+    const foreign = await seedFixture();
+    await setConnectorAccountsEnabled(foreign, true);
+    await accept(
+      accountClient().scopeDiff({
+        headers: authHeaders(),
+        params: { connectionId: currentId },
+        query: { connectorSlug: "github" },
+      }),
+      [404],
+    );
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    await accept(
+      accountClient().delete({
+        headers: authHeaders(),
+        params: { connectionId: currentId },
+        body: { target: { kind: "builtin", connectorSlug: "github" } },
+      }),
+      [200],
+    );
+    await accept(
+      accountClient().scopeDiff({
+        headers: authHeaders(),
+        params: { connectionId: currentId },
+        query: { connectorSlug: "github" },
+      }),
+      [404],
+    );
+
+    const unavailableMethodId = await seedConnectorStorageRow(context, {
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      connectorSlug: "openai",
+      authMethod: "unavailable-method",
+      storageVersion: 1,
+    });
+    await accept(
+      accountClient().scopeDiff({
+        headers: authHeaders(),
+        params: { connectionId: unavailableMethodId },
+        query: { connectorSlug: "openai" },
+      }),
+      [404],
+    );
   });
 
   it("inspects only exact owned accounts without leaking credentials", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -343,10 +343,7 @@ describe("connector account lifecycle routes", () => {
     );
     expect(filteredList.body.connections).toHaveLength(1);
     expect(filteredList.body.connections[0]?.id).toBe(staleId);
-    expect(filteredList.body.defaultConnection).toMatchObject({
-      id: currentId,
-      scopeMismatch: false,
-    });
+    expect("defaultConnection" in filteredList.body).toBeFalsy();
 
     const staleDiff = await accept(
       accountClient().scopeDiff({

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -143,6 +143,9 @@ const connectionsInner$ = computed(async (get) => {
     body: {
       connections: [...result.connections],
       nextCursor: result.nextCursor,
+      ...(result.defaultConnection !== undefined
+        ? { defaultConnection: result.defaultConnection }
+        : {}),
     },
   };
 });

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -25,7 +25,10 @@ import {
   setDefaultConnectorAccount,
 } from "../services/connector-account-lifecycle.service";
 import { commitConnectorRuntimeMutation } from "../services/connector-runtime-wakeup.service";
-import { deleteConnectorLocalState$ } from "../services/connector-data.service";
+import {
+  connectorScopeDiff,
+  deleteConnectorLocalState$,
+} from "../services/connector-data.service";
 import {
   deleteCustomConnectorAccount$,
   disconnectCustomConnector$,
@@ -125,6 +128,9 @@ const connectionsInner$ = computed(async (get) => {
     limit: query.limit,
     ...(query.cursor ? { cursor: query.cursor } : {}),
     ...(query.search ? { search: query.search } : {}),
+    ...(query.kind === "builtin" && query.includeScopeMismatch === "true"
+      ? { includeScopeMismatch: true }
+      : {}),
   });
   if (result.kind === "invalid-cursor") {
     return badRequestMessage("Invalid connector account cursor");
@@ -156,6 +162,26 @@ const connectionInner$ = computed(async (get) => {
   });
   return account
     ? { status: 200 as const, body: account }
+    : notFound("Connector account not found");
+});
+
+const scopeDiffInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  if (!(await get(connectorAccountsEnabled$))) {
+    return notFound("Resource not found");
+  }
+  const params = get(pathParamsOf(connectorAccountsContract.scopeDiff));
+  const query = get(queryOf(connectorAccountsContract.scopeDiff));
+  const diff = await get(
+    connectorScopeDiff({
+      orgId: auth.orgId,
+      userId: auth.userId,
+      connectorSlug: query.connectorSlug,
+      connectorId: params.connectionId,
+    }),
+  );
+  return diff
+    ? { status: 200 as const, body: diff }
     : notFound("Connector account not found");
 });
 
@@ -521,6 +547,10 @@ export const connectorAccountRoutes: readonly RouteEntry[] = [
   {
     route: connectorAccountsContract.connections,
     handler: authRoute(readAuth, connectionsInner$),
+  },
+  {
+    route: connectorAccountsContract.scopeDiff,
+    handler: authRoute(readAuth, scopeDiffInner$),
   },
   {
     route: connectorAccountsContract.connection,

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -177,7 +177,7 @@ const scopeDiffInner$ = computed(async (get) => {
       orgId: auth.orgId,
       userId: auth.userId,
       connectorSlug: query.connectorSlug,
-      connectorId: params.connectionId,
+      selection: { kind: "exact", connectorId: params.connectionId },
     }),
   );
   return diff

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -218,6 +218,7 @@ const getScopeDiffInner$ = computed(async (get) => {
       orgId: auth.orgId,
       userId: auth.userId,
       connectorSlug: params.connectorSlug,
+      selection: { kind: "default" },
     }),
   );
   if (!diff) {

--- a/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
@@ -12,6 +12,7 @@ import {
   type ConnectorReconnectReason,
 } from "@okouai/api-contracts/contracts/connector-schemas";
 import { isIntegrationManagedCustomConnectorProviderAdapter } from "@okouai/api-contracts/contracts/custom-connectors";
+import { connectorAuthMethodHasRequiredScopes } from "@okouai/connectors/connector-auth-method";
 import { connectors } from "@okouai/db/schema/connector";
 import { customConnectorAccountOauthBindings } from "@okouai/db/schema/custom-connector-account-oauth-binding";
 import { chatThreadConnectorSelections } from "@okouai/db/schema/chat-thread-connector-selection";
@@ -424,6 +425,7 @@ function builtinConnection(
   row: ConnectorAccountRow,
   snapshot: ConnectorRuntimeSnapshot,
   now: Date,
+  includeScopeMismatch = false,
 ): ConnectorAccountConnection | null {
   const parsedSlug = connectorSlugSchema.safeParse(row.connectorSlug);
   if (!parsedSlug.success || !snapshot.connectors.has(parsedSlug.data)) {
@@ -469,6 +471,14 @@ function builtinConnection(
     externalUsername: row.externalUsername,
     externalEmail: row.externalEmail,
     oauthScopes: parseOauthScopes(row.oauthGrantedScopes),
+    ...(includeScopeMismatch && runtimeMethod
+      ? {
+          scopeMismatch: !connectorAuthMethodHasRequiredScopes(
+            runtimeMethod.method,
+            parseOauthScopes(row.oauthScopes),
+          ),
+        }
+      : {}),
     connectionStatus,
     reconnectReason:
       !runtimeMethod || !storageCompatible
@@ -560,9 +570,12 @@ function projectConnection(
   row: ConnectorAccountRow,
   snapshot: ConnectorRuntimeSnapshot | null,
   now: Date,
+  includeBuiltinScopeMismatch = false,
 ): ConnectorAccountConnection | null {
   if (row.connectorSlug !== null) {
-    return snapshot ? builtinConnection(row, snapshot, now) : null;
+    return snapshot
+      ? builtinConnection(row, snapshot, now, includeBuiltinScopeMismatch)
+      : null;
   }
   return customConnection(row, now);
 }
@@ -707,6 +720,7 @@ export async function listConnectorAccountsForTarget(
     readonly cursor?: string;
     readonly limit: number;
     readonly search?: string;
+    readonly includeScopeMismatch?: true;
   },
 ): Promise<
   | {
@@ -744,7 +758,12 @@ export async function listConnectorAccountsForTarget(
   });
   const now = nowDate();
   const projected = rows.flatMap((row) => {
-    const connection = projectConnection(row, snapshot, now);
+    const connection = projectConnection(
+      row,
+      snapshot,
+      now,
+      args.includeScopeMismatch === true,
+    );
     return connection ? [connection] : [];
   });
   if (

--- a/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
@@ -727,6 +727,7 @@ export async function listConnectorAccountsForTarget(
       readonly kind: "ok";
       readonly connections: readonly ConnectorAccountConnection[];
       readonly nextCursor: string | null;
+      readonly defaultConnection?: ConnectorAccountConnection | null;
     }
   | { readonly kind: "invalid-cursor" }
   | { readonly kind: "missing" }
@@ -766,6 +767,23 @@ export async function listConnectorAccountsForTarget(
     );
     return connection ? [connection] : [];
   });
+  const defaultRow = args.includeScopeMismatch
+    ? (rows.find((row) => {
+        return row.isDefault;
+      }) ??
+      (
+        await loadConnectorAccountRows(db, {
+          ...args,
+          cursor: undefined,
+          limit: 1,
+          search: undefined,
+          defaultOnly: true,
+        })
+      )[0])
+    : undefined;
+  const defaultConnection = defaultRow
+    ? projectConnection(defaultRow, snapshot, now, true)
+    : null;
   if (
     args.target.kind === "custom" &&
     rows.length > 0 &&
@@ -778,6 +796,7 @@ export async function listConnectorAccountsForTarget(
     kind: "ok",
     connections: projected.slice(0, args.limit),
     nextCursor: hasMore ? encodeCursor(rows[args.limit - 1]!) : null,
+    ...(args.includeScopeMismatch ? { defaultConnection } : {}),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-lifecycle.service.ts
@@ -767,7 +767,11 @@ export async function listConnectorAccountsForTarget(
     );
     return connection ? [connection] : [];
   });
-  const defaultRow = args.includeScopeMismatch
+  const includeDefaultConnection =
+    args.includeScopeMismatch === true &&
+    args.cursor === undefined &&
+    args.search === undefined;
+  const defaultRow = includeDefaultConnection
     ? (rows.find((row) => {
         return row.isDefault;
       }) ??
@@ -796,7 +800,7 @@ export async function listConnectorAccountsForTarget(
     kind: "ok",
     connections: projected.slice(0, args.limit),
     nextCursor: hasMore ? encodeCursor(rows[args.limit - 1]!) : null,
-    ...(args.includeScopeMismatch ? { defaultConnection } : {}),
+    ...(includeDefaultConnection ? { defaultConnection } : {}),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -2595,7 +2595,7 @@ export function connectorScopeDiff(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly connectorSlug: string;
-  readonly connectorId?: string;
+  readonly selection: StoredConnectorSelection;
   readonly snapshot?: ConnectorRuntimeSnapshot;
 }): Computed<Promise<ScopeDiffResponse | null>> {
   return computed(async (get): Promise<ScopeDiffResponse | null> => {
@@ -2610,10 +2610,7 @@ export function connectorScopeDiff(args: {
         userId: args.userId,
         connectorSlug: args.connectorSlug,
         snapshot,
-        selection:
-          args.connectorId === undefined
-            ? { kind: "default" }
-            : { kind: "exact", connectorId: args.connectorId },
+        selection: args.selection,
       }),
     );
     return connector === null

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -2595,6 +2595,7 @@ export function connectorScopeDiff(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly connectorSlug: string;
+  readonly connectorId?: string;
   readonly snapshot?: ConnectorRuntimeSnapshot;
 }): Computed<Promise<ScopeDiffResponse | null>> {
   return computed(async (get): Promise<ScopeDiffResponse | null> => {
@@ -2605,9 +2606,13 @@ export function connectorScopeDiff(args: {
     }
     const connector = await get(
       storedConnector({
-        ...args,
+        orgId: args.orgId,
+        userId: args.userId,
+        connectorSlug: args.connectorSlug,
         snapshot,
-        selection: { kind: "default" },
+        selection: args.connectorId
+          ? { kind: "exact", connectorId: args.connectorId }
+          : { kind: "default" },
       }),
     );
     return connector === null

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -2610,9 +2610,10 @@ export function connectorScopeDiff(args: {
         userId: args.userId,
         connectorSlug: args.connectorSlug,
         snapshot,
-        selection: args.connectorId
-          ? { kind: "exact", connectorId: args.connectorId }
-          : { kind: "default" },
+        selection:
+          args.connectorId === undefined
+            ? { kind: "default" }
+            : { kind: "exact", connectorId: args.connectorId },
       }),
     );
     return connector === null

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -549,24 +549,24 @@ export const apiConnectorsHandlers = [
   }),
 
   mockApi(connectorAccountsContract.connections, ({ query, respond }) => {
-    const accounts = mockConnectors
-      .map((connector) => {
-        const account = mockAccountForConnector(connector);
-        const definition = testConnectorCatalogDefinitions.find((candidate) => {
-          return candidate.connectorSlug === connector.slug;
-        });
-        return query.kind === "builtin" &&
-          query.includeScopeMismatch === "true" &&
-          definition
-          ? {
-              ...account,
-              scopeMismatch: !mockConnectorHasRequestedScopes(
-                definition,
-                connector,
-              ),
-            }
-          : account;
-      })
+    const allAccounts = mockConnectors.map((connector) => {
+      const account = mockAccountForConnector(connector);
+      const definition = testConnectorCatalogDefinitions.find((candidate) => {
+        return candidate.connectorSlug === connector.slug;
+      });
+      return query.kind === "builtin" &&
+        query.includeScopeMismatch === "true" &&
+        definition
+        ? {
+            ...account,
+            scopeMismatch: !mockConnectorHasRequestedScopes(
+              definition,
+              connector,
+            ),
+          }
+        : account;
+    });
+    const accounts = allAccounts
       .filter((account) => {
         return mockAccountMatchesTarget(account, query);
       })
@@ -586,9 +586,15 @@ export const apiConnectorsHandlers = [
     const start = query.cursor ? Number(query.cursor) : 0;
     const page = accounts.slice(start, start + query.limit);
     const next = start + page.length;
+    const defaultConnection = allAccounts.find((account) => {
+      return account.isDefault && mockAccountMatchesTarget(account, query);
+    });
     return respond(200, {
       connections: page,
       nextCursor: next < accounts.length ? String(next) : null,
+      ...(query.kind === "builtin" && query.includeScopeMismatch === "true"
+        ? { defaultConnection: defaultConnection ?? null }
+        : {}),
     });
   }),
 

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -7,6 +7,7 @@ import type {
   ConnectorOauthDeviceAuthSessionPollResponse,
   ConnectorOauthDeviceAuthSessionStartResponse,
   ConnectorResponse,
+  ScopeDiffResponse,
 } from "@okouai/api-contracts/contracts/connector-schemas";
 import {
   connectorCatalogContract,
@@ -327,6 +328,36 @@ function mockConnectorHasRequestedScopes(
   });
 }
 
+function mockConnectorScopeDiff(
+  connector: ConnectorResponse,
+): ScopeDiffResponse | null {
+  const definition = testConnectorCatalogDefinitions.find((candidate) => {
+    return candidate.connectorSlug === connector.slug;
+  });
+  const method = definition?.authMethods.find((candidate) => {
+    return candidate.detail.id === connector.authMethod;
+  });
+  if (!method) {
+    return null;
+  }
+  const currentScopes = [...method.requestedScopes];
+  const storedScopes = [
+    ...(mockConnectorRequestedScopes.get(connector.id) ?? []),
+  ];
+  const current = new Set(currentScopes);
+  const stored = new Set(storedScopes);
+  return {
+    addedScopes: currentScopes.filter((scope) => {
+      return !stored.has(scope);
+    }),
+    removedScopes: storedScopes.filter((scope) => {
+      return !current.has(scope);
+    }),
+    currentScopes,
+    storedScopes,
+  };
+}
+
 function mockConnectorCatalogStatusItem(
   definition: TestConnectorCatalogDefinition,
   authMethods: readonly PublicConnectorCatalogAuthMethodDetail[],
@@ -519,7 +550,23 @@ export const apiConnectorsHandlers = [
 
   mockApi(connectorAccountsContract.connections, ({ query, respond }) => {
     const accounts = mockConnectors
-      .map(mockAccountForConnector)
+      .map((connector) => {
+        const account = mockAccountForConnector(connector);
+        const definition = testConnectorCatalogDefinitions.find((candidate) => {
+          return candidate.connectorSlug === connector.slug;
+        });
+        return query.kind === "builtin" &&
+          query.includeScopeMismatch === "true" &&
+          definition
+          ? {
+              ...account,
+              scopeMismatch: !mockConnectorHasRequestedScopes(
+                definition,
+                connector,
+              ),
+            }
+          : account;
+      })
       .filter((account) => {
         return mockAccountMatchesTarget(account, query);
       })
@@ -559,6 +606,24 @@ export const apiConnectorsHandlers = [
           });
     },
   ),
+
+  mockApi(connectorAccountsContract.scopeDiff, ({ params, query, respond }) => {
+    const connector = mockConnectors.find((candidate) => {
+      return (
+        candidate.id === params.connectionId &&
+        candidate.slug === query.connectorSlug
+      );
+    });
+    const diff = connector ? mockConnectorScopeDiff(connector) : null;
+    return diff
+      ? respond(200, diff)
+      : respond(404, {
+          error: {
+            message: "Connector account not found",
+            code: "NOT_FOUND",
+          },
+        });
+  }),
 
   mockApi(connectorAccountsContract.rename, ({ params, body, respond }) => {
     const account = findMockAccount(params.connectionId, body.target);
@@ -675,13 +740,16 @@ export const apiConnectorsHandlers = [
     return respond(200, connector);
   }),
 
-  mockApi(connectorScopeDiffContract.getScopeDiff, ({ respond }) => {
-    return respond(200, {
-      addedScopes: [],
-      removedScopes: [],
-      currentScopes: [],
-      storedScopes: [],
+  mockApi(connectorScopeDiffContract.getScopeDiff, ({ params, respond }) => {
+    const connector = mockConnectors.find((candidate) => {
+      return candidate.slug === params.connectorSlug;
     });
+    const diff = connector ? mockConnectorScopeDiff(connector) : null;
+    return diff
+      ? respond(200, diff)
+      : respond(404, {
+          error: { message: "Connector not found", code: "NOT_FOUND" },
+        });
   }),
 
   mockApi(

--- a/turbo/apps/platform/src/signals/okou-page/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connector-accounts.ts
@@ -128,32 +128,17 @@ async function fetchConnectorAccountPage(
   },
   signal: AbortSignal,
 ): Promise<ConnectorAccountPage> {
-  const client = args.createClient(connectorAccountsContract);
   const enriched =
     args.includeBuiltinScopeMismatch && args.target.kind === "builtin";
   const result = await accept(
-    client.connections({
+    args.createClient(connectorAccountsContract).connections({
       query: targetListQuery(args.target, args.search, args.cursor, enriched),
       fetchOptions: { signal },
     }),
-    enriched ? [200, 400, 404] : [200, 404],
+    [200, 404],
     signal,
   );
   signal.throwIfAborted();
-  if (result.status === 400) {
-    const fallback = await accept(
-      client.connections({
-        query: targetListQuery(args.target, args.search, args.cursor),
-        fetchOptions: { signal },
-      }),
-      [200, 404],
-      signal,
-    );
-    signal.throwIfAborted();
-    return fallback.status === 404
-      ? emptyConnectorAccountPage()
-      : { ...fallback.body, available: true };
-  }
   return result.status === 404
     ? emptyConnectorAccountPage()
     : { ...result.body, available: true };

--- a/turbo/apps/platform/src/signals/okou-page/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connector-accounts.ts
@@ -60,6 +60,7 @@ interface ConnectorAccountPage {
   readonly connections: readonly ConnectorAccountConnection[];
   readonly nextCursor: string | null;
   readonly available: boolean;
+  readonly defaultConnection?: ConnectorAccountConnection | null;
 }
 
 function emptyConnectorAccountPage(): ConnectorAccountPage {
@@ -70,6 +71,7 @@ export interface ConnectorAccountList {
   readonly connections: readonly ConnectorAccountConnection[];
   readonly nextCursor: string | null;
   readonly available: boolean;
+  readonly defaultConnection?: ConnectorAccountConnection | null;
 }
 
 function mergeConnectorAccountPages(
@@ -88,6 +90,9 @@ function mergeConnectorAccountPages(
     // keep "Load more" alive and re-request the page after the first one.
     nextCursor: (pages.at(-1) ?? firstPage).nextCursor,
     available: firstPage.available,
+    ...(firstPage.defaultConnection !== undefined
+      ? { defaultConnection: firstPage.defaultConnection }
+      : {}),
   };
 }
 

--- a/turbo/apps/platform/src/signals/okou-page/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connector-accounts.ts
@@ -95,6 +95,7 @@ function targetListQuery(
   target: ConnectorAccountTarget,
   search: string,
   cursor?: string,
+  includeBuiltinScopeMismatch = false,
 ) {
   const page = {
     limit: CONNECTOR_ACCOUNT_PAGE_SIZE,
@@ -102,7 +103,14 @@ function targetListQuery(
     ...(cursor ? { cursor } : {}),
   };
   return target.kind === "builtin"
-    ? { ...page, kind: target.kind, connectorSlug: target.connectorSlug }
+    ? {
+        ...page,
+        kind: target.kind,
+        connectorSlug: target.connectorSlug,
+        ...(includeBuiltinScopeMismatch
+          ? { includeScopeMismatch: "true" as const }
+          : {}),
+      }
     : {
         ...page,
         kind: target.kind,
@@ -110,21 +118,42 @@ function targetListQuery(
       };
 }
 
-async function fetchConnectorAccountFirstPage(
-  createClient: ApiClientFactory,
-  target: ConnectorAccountTarget,
-  search: string,
+async function fetchConnectorAccountPage(
+  args: {
+    readonly createClient: ApiClientFactory;
+    readonly target: ConnectorAccountTarget;
+    readonly search: string;
+    readonly cursor?: string;
+    readonly includeBuiltinScopeMismatch: boolean;
+  },
   signal: AbortSignal,
 ): Promise<ConnectorAccountPage> {
+  const client = args.createClient(connectorAccountsContract);
+  const enriched =
+    args.includeBuiltinScopeMismatch && args.target.kind === "builtin";
   const result = await accept(
-    createClient(connectorAccountsContract).connections({
-      query: targetListQuery(target, search),
+    client.connections({
+      query: targetListQuery(args.target, args.search, args.cursor, enriched),
       fetchOptions: { signal },
     }),
-    [200, 404],
+    enriched ? [200, 400, 404] : [200, 404],
     signal,
   );
   signal.throwIfAborted();
+  if (result.status === 400) {
+    const fallback = await accept(
+      client.connections({
+        query: targetListQuery(args.target, args.search, args.cursor),
+        fetchOptions: { signal },
+      }),
+      [200, 404],
+      signal,
+    );
+    signal.throwIfAborted();
+    return fallback.status === 404
+      ? emptyConnectorAccountPage()
+      : { ...fallback.body, available: true };
+  }
   return result.status === 404
     ? emptyConnectorAccountPage()
     : { ...result.body, available: true };
@@ -133,6 +162,7 @@ async function fetchConnectorAccountFirstPage(
 function createConnectorAccountFirstPageQuery(
   effectiveSearch$: State<string>,
   resetPages$: Command<void, []>,
+  includeBuiltinScopeMismatch: boolean,
 ) {
   return command(
     async (
@@ -148,17 +178,22 @@ function createConnectorAccountFirstPageQuery(
       signal.throwIfAborted();
       set(effectiveSearch$, search);
       set(resetPages$);
-      return fetchConnectorAccountFirstPage(
-        get(apiClient$),
-        target,
-        search,
+      return fetchConnectorAccountPage(
+        {
+          createClient: get(apiClient$),
+          target,
+          search,
+          includeBuiltinScopeMismatch,
+        },
         signal,
       );
     },
   );
 }
 
-function createConnectorAccountFirstPageSignals() {
+function createConnectorAccountFirstPageSignals(
+  includeBuiltinScopeMismatch: boolean,
+) {
   const target$ = state<ConnectorAccountTarget | null>(null);
   const search$ = state("");
   const effectiveSearch$ = state("");
@@ -181,6 +216,7 @@ function createConnectorAccountFirstPageSignals() {
   const queryFirstPage$ = createConnectorAccountFirstPageQuery(
     effectiveSearch$,
     resetPages$,
+    includeBuiltinScopeMismatch,
   );
 
   const startFirstPageQuery$ = command(
@@ -283,8 +319,14 @@ function createConnectorAccountFirstPageSignals() {
   };
 }
 
-export function createConnectorAccountListSignals() {
-  const firstPageSignals = createConnectorAccountFirstPageSignals();
+export function createConnectorAccountListSignals(
+  options: { readonly includeBuiltinScopeMismatch?: true } = {},
+) {
+  const includeBuiltinScopeMismatch =
+    options.includeBuiltinScopeMismatch === true;
+  const firstPageSignals = createConnectorAccountFirstPageSignals(
+    includeBuiltinScopeMismatch,
+  );
   const loadMore$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
       const generation = get(firstPageSignals.generation$);
@@ -303,16 +345,14 @@ export function createConnectorAccountListSignals() {
       }
       set(firstPageSignals.loadingCursor$, cursor);
       const result = await onRejection(
-        accept(
-          get(apiClient$)(connectorAccountsContract).connections({
-            query: targetListQuery(
-              target,
-              get(firstPageSignals.effectiveSearch$),
-              cursor,
-            ),
-            fetchOptions: { signal },
-          }),
-          [200, 404],
+        fetchConnectorAccountPage(
+          {
+            createClient: get(apiClient$),
+            target,
+            search: get(firstPageSignals.effectiveSearch$),
+            cursor,
+            includeBuiltinScopeMismatch,
+          },
           signal,
         ),
         () => {
@@ -326,12 +366,12 @@ export function createConnectorAccountListSignals() {
       if (get(firstPageSignals.generation$) !== generation) {
         return;
       }
-      if (result.status === 404) {
+      if (!result.available) {
         set(firstPageSignals.reload$, signal);
         return;
       }
       set(firstPageSignals.pages$, (pages) => {
-        return [...pages, { ...result.body, available: true }];
+        return [...pages, result];
       });
       set(firstPageSignals.loadingCursor$, null);
     },

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
@@ -86,7 +86,9 @@ export function connectorAccountMutationCompleted(
     : true;
 }
 
-export const settingsConnectorAccounts = createConnectorAccountListSignals();
+export const settingsConnectorAccounts = createConnectorAccountListSignals({
+  includeBuiltinScopeMismatch: true,
+});
 
 const invalidateConnectorAccounts$ = command(({ set }, signal: AbortSignal) => {
   set(reloadConnectorAccountSummaries$);

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -14,7 +14,10 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
-import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
+import {
+  connectorAccountsContract,
+  type ConnectorAccountMutationIntent,
+} from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   connectorScopeDiffContract,
   connectorExternalCodeSessionContract,
@@ -743,28 +746,54 @@ export const setConnectorOAuthDeviceAuthStartOptionValue$ = command(
 // Scope review modal state
 // ---------------------------------------------------------------------------
 
-const internalScopeReviewConnectorSlug$ = state<ConnectorSlug | null>(null);
-export const scopeReviewConnectorSlug$ = computed((get) => {
-  return get(internalScopeReviewConnectorSlug$);
+export type ConnectorScopeReviewSelection =
+  | {
+      readonly kind: "default";
+      readonly connectorSlug: ConnectorSlug;
+    }
+  | {
+      readonly kind: "account";
+      readonly connectorSlug: ConnectorSlug;
+      readonly connectionId: string;
+      readonly authMethod: ConnectorAuthMethodId;
+    };
+
+const internalScopeReviewSelection$ =
+  state<ConnectorScopeReviewSelection | null>(null);
+export const scopeReviewSelection$ = computed((get) => {
+  return get(internalScopeReviewSelection$);
 });
 
 export const scopeDiff$ = computed(async (get) => {
-  const connectorSlug = get(internalScopeReviewConnectorSlug$);
-  if (!connectorSlug) {
+  const selection = get(internalScopeReviewSelection$);
+  if (!selection) {
     return null;
   }
   const createClient = get(apiClient$);
+  if (selection.kind === "account") {
+    const client = createClient(connectorAccountsContract);
+    const result = await accept(
+      client.scopeDiff({
+        params: { connectionId: selection.connectionId },
+        query: { connectorSlug: selection.connectorSlug },
+      }),
+      [200],
+    );
+    return result.body;
+  }
   const client = createClient(connectorScopeDiffContract);
   const result = await accept(
-    client.getScopeDiff({ params: { connectorSlug } }),
+    client.getScopeDiff({
+      params: { connectorSlug: selection.connectorSlug },
+    }),
     [200],
   );
   return result.body;
 });
 
-export const setScopeReviewConnectorSlug$ = command(
-  ({ set }, connectorSlug: ConnectorSlug | null) => {
-    set(internalScopeReviewConnectorSlug$, connectorSlug);
+export const setScopeReviewSelection$ = command(
+  ({ set }, selection: ConnectorScopeReviewSelection | null) => {
+    set(internalScopeReviewSelection$, selection);
   },
 );
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -1831,13 +1831,18 @@ describe("connectors page", () => {
     const accountQueries: {
       readonly limit: number;
       readonly cursor: string | null;
+      readonly includeScopeMismatch: "true" | null;
     }[] = [];
     context.mocks.api(
       connectorAccountsContract.connections,
       ({ query, respond }) => {
+        if (query.kind !== "builtin") {
+          throw new Error("Expected a built-in connector account query");
+        }
         accountQueries.push({
           limit: query.limit,
           cursor: query.cursor ?? null,
+          includeScopeMismatch: query.includeScopeMismatch ?? null,
         });
         const start = query.cursor ? Number(query.cursor) : 0;
         const page = accounts.slice(
@@ -1890,6 +1895,11 @@ describe("connectors page", () => {
         return query.cursor;
       }),
     ).toStrictEqual([null, "3", "6"]);
+    expect(
+      accountQueries.map((query) => {
+        return query.includeScopeMismatch;
+      }),
+    ).toStrictEqual(["true", "true", "true"]);
     // One bounded limit per request, wider than the whole fixture: every extra
     // page came from following the server cursor, not from a client-side slice.
     expect([...requestedLimits]).toHaveLength(1);
@@ -1901,13 +1911,18 @@ describe("connectors page", () => {
     const accountQueries: {
       readonly search: string | null;
       readonly cursor: string | null;
+      readonly includeScopeMismatch: "true" | null;
     }[] = [];
     context.mocks.api(
       connectorAccountsContract.connections,
       ({ query, respond }) => {
+        if (query.kind !== "builtin") {
+          throw new Error("Expected a built-in connector account query");
+        }
         accountQueries.push({
           search: query.search ?? null,
           cursor: query.cursor ?? null,
+          includeScopeMismatch: query.includeScopeMismatch ?? null,
         });
         const search = query.search;
         const filtered = search
@@ -1939,7 +1954,11 @@ describe("connectors page", () => {
     expect(accountQueries).toHaveLength(queryCountBeforeSearch);
     await waitFor(() => {
       expect(accountQueries.slice(queryCountBeforeSearch)).toStrictEqual([
-        { search: "Work 2", cursor: null },
+        {
+          search: "Work 2",
+          cursor: null,
+          includeScopeMismatch: "true",
+        },
       ]);
       expect(within(dialog).getByText("Work 2")).toBeInTheDocument();
       // A search owns the whole list: the default account is unpinned unless it
@@ -1954,6 +1973,7 @@ describe("connectors page", () => {
       expect(accountQueries.at(-1)).toStrictEqual({
         search: "No matching account",
         cursor: null,
+        includeScopeMismatch: "true",
       });
       expect(within(dialog).getByText("No accounts found")).toBeInTheDocument();
       expect(within(dialog).queryByText("Unnamed account")).toBeNull();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -2698,7 +2698,7 @@ describe("connectors page", () => {
   });
 
   it("reviews and reconnects one exact non-default account", async () => {
-    const accounts = mockGitHubConnectorAccounts(2).map((account) => {
+    const accounts = mockGitHubConnectorAccounts(7).map((account) => {
       return {
         ...account,
         connectionStatus: "connected" as const,
@@ -2710,7 +2710,7 @@ describe("connectors page", () => {
       return account.isDefault;
     });
     const personalAccount = accounts.find((account) => {
-      return !account.isDefault;
+      return account.displayName === "Work 1";
     });
     if (!defaultAccount || !personalAccount) {
       throw new Error("Expected default and non-default GitHub accounts");
@@ -2728,7 +2728,7 @@ describe("connectors page", () => {
         summaries: [
           {
             target: defaultAccount.target,
-            accountCount: 2,
+            accountCount: accounts.length,
             attentionCount: 0,
             defaultConnection,
           },
@@ -2753,9 +2753,15 @@ describe("connectors page", () => {
           throw new Error("Expected a built-in connector account query");
         }
         listEnrichmentValues.push(query.includeScopeMismatch ?? null);
+        const search = query.search?.toLowerCase();
         return respond(200, {
-          connections: [defaultAccount, personalAccount],
+          connections: search
+            ? accounts.filter((account) => {
+                return account.displayName?.toLowerCase().includes(search);
+              })
+            : accounts,
           nextCursor: null,
+          defaultConnection: defaultAccount,
         });
       },
     );
@@ -2813,7 +2819,21 @@ describe("connectors page", () => {
       expect(listEnrichmentValues).toContain("true");
       expect(within(personalRow).getByText("Update permissions")).toBeVisible();
     });
-    click(within(personalRow).getByLabelText("Account actions"));
+    fireEvent.input(within(manager).getByPlaceholderText("Find accounts"), {
+      target: { value: personalAccount.displayName },
+    });
+    await waitFor(() => {
+      expect(
+        within(accountRow(manager, "Unnamed account")).getByText(
+          "Update permissions",
+        ),
+      ).toBeVisible();
+    });
+    const filteredPersonalRow = accountRow(
+      manager,
+      personalAccount.displayName ?? "",
+    );
+    click(within(filteredPersonalRow).getByLabelText("Account actions"));
     click(menuItemByText("Review permissions"));
 
     const reviewDialog = await screen.findByRole("dialog", {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -2745,14 +2745,20 @@ describe("connectors page", () => {
             });
       },
     );
-    const listEnrichmentValues: ("true" | null)[] = [];
+    const listQueries: {
+      readonly search: string | null;
+      readonly includeScopeMismatch: "true" | null;
+    }[] = [];
     context.mocks.api(
       connectorAccountsContract.connections,
       ({ query, respond }) => {
         if (query.kind !== "builtin") {
           throw new Error("Expected a built-in connector account query");
         }
-        listEnrichmentValues.push(query.includeScopeMismatch ?? null);
+        listQueries.push({
+          search: query.search ?? null,
+          includeScopeMismatch: query.includeScopeMismatch ?? null,
+        });
         const search = query.search?.toLowerCase();
         return respond(200, {
           connections: search
@@ -2808,26 +2814,34 @@ describe("connectors page", () => {
       name: "Manage GitHub accounts",
     });
     await waitFor(() => {
-      expect(listEnrichmentValues).toStrictEqual(["true"]);
+      expect(listQueries).toStrictEqual([
+        { search: null, includeScopeMismatch: "true" },
+      ]);
     });
-    const defaultRow = accountRow(manager, "Unnamed account");
+    const defaultRow = await waitFor(() => {
+      return accountRow(manager, "Unnamed account");
+    });
     expect(within(defaultRow).getByText("Update permissions")).toBeVisible();
     const personalRow = await waitFor(() => {
       return accountRow(manager, personalAccount.displayName ?? "");
     });
     await waitFor(() => {
-      expect(listEnrichmentValues).toContain("true");
       expect(within(personalRow).getByText("Update permissions")).toBeVisible();
     });
     fireEvent.input(within(manager).getByPlaceholderText("Find accounts"), {
       target: { value: personalAccount.displayName },
     });
     await waitFor(() => {
+      expect(listQueries.at(-1)).toStrictEqual({
+        search: personalAccount.displayName,
+        includeScopeMismatch: "true",
+      });
       expect(
-        within(accountRow(manager, "Unnamed account")).getByText(
-          "Update permissions",
-        ),
+        accountRow(manager, personalAccount.displayName ?? ""),
       ).toBeVisible();
+      expect(
+        within(manager).queryByRole("group", { name: "Unnamed account" }),
+      ).toBeNull();
     });
     const filteredPersonalRow = accountRow(
       manager,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -2703,7 +2703,7 @@ describe("connectors page", () => {
         ...account,
         connectionStatus: "connected" as const,
         reconnectReason: null,
-        scopeMismatch: !account.isDefault,
+        scopeMismatch: true,
       };
     });
     const defaultAccount = accounts.find((account) => {
@@ -2715,12 +2715,15 @@ describe("connectors page", () => {
     if (!defaultAccount || !personalAccount) {
       throw new Error("Expected default and non-default GitHub accounts");
     }
+    const { scopeMismatch: defaultScopeMismatch, ...summaryDefaultAccount } =
+      defaultAccount;
+    expect(defaultScopeMismatch).toBeTruthy();
     let projectedDefaultId = defaultAccount.id;
     context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
       const defaultConnection =
         projectedDefaultId === personalAccount.id
           ? { ...personalAccount, isDefault: true }
-          : defaultAccount;
+          : summaryDefaultAccount;
       return respond(200, {
         summaries: [
           {
@@ -2801,6 +2804,8 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(listEnrichmentValues).toStrictEqual(["true"]);
     });
+    const defaultRow = accountRow(manager, "Unnamed account");
+    expect(within(defaultRow).getByText("Update permissions")).toBeVisible();
     const personalRow = await waitFor(() => {
       return accountRow(manager, personalAccount.displayName ?? "");
     });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -2868,43 +2868,6 @@ describe("connectors page", () => {
     expect(queryButtonByText("Reconnect", reviewDialog)).toBeNull();
   });
 
-  it("retries account listing without enrichment against an older API", async () => {
-    const accounts = mockGitHubConnectorAccounts(2).map((account) => {
-      const { scopeMismatch: _scopeMismatch, ...legacyAccount } = account;
-      return legacyAccount;
-    });
-    const enrichmentValues: ("true" | null)[] = [];
-    context.mocks.api(
-      connectorAccountsContract.connections,
-      ({ query, respond }) => {
-        if (query.kind !== "builtin") {
-          throw new Error("Expected a built-in connector account query");
-        }
-        enrichmentValues.push(query.includeScopeMismatch ?? null);
-        return query.includeScopeMismatch === "true"
-          ? respond(400, {
-              error: { message: "Invalid query", code: "BAD_REQUEST" },
-            })
-          : respond(200, { connections: accounts, nextCursor: null });
-      },
-    );
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
-    });
-
-    click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
-    const manager = await screen.findByRole("dialog", {
-      name: "Manage GitHub accounts",
-    });
-    await waitFor(() => {
-      expect(enrichmentValues).toStrictEqual(["true", null]);
-      expect(within(manager).getByText("Work 1")).toBeInTheDocument();
-    });
-    expect(within(manager).queryByText("Update permissions")).toBeNull();
-  });
-
   it("navigates connector categories and opens a connector from the keyboard", async () => {
     mockConnectors([]);
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx
@@ -2618,6 +2618,26 @@ describe("connectors page", () => {
         });
       },
     );
+    let exactScopeDiffRequests = 0;
+    context.mocks.api(connectorAccountsContract.scopeDiff, ({ respond }) => {
+      exactScopeDiffRequests += 1;
+      return respond(404, {
+        error: { message: "Account not found", code: "NOT_FOUND" },
+      });
+    });
+    let submittedAccount: unknown;
+    context.mocks.api(
+      connectorOauthStartContract.start,
+      ({ body, params, respond }) => {
+        expect(params.connectorSlug).toBe("google-ads");
+        submittedAccount = body.account;
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/google-ads/authorize",
+        });
+      },
+    );
+    const authWindow = createMockAuthWindow();
+    context.mocks.browser.open(authWindow);
 
     detachedSetupPage({
       context,
@@ -2647,6 +2667,242 @@ describe("connectors page", () => {
     });
     expect(within(dialog).getByText("New permissions")).toBeInTheDocument();
     expect(within(dialog).getByText(addedScopes[0])).toBeInTheDocument();
+    click(buttonByText("Reconnect", dialog));
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/google-ads/authorize",
+      );
+    });
+    expect(submittedAccount).toStrictEqual({ intent: "single-account" });
+    expect(exactScopeDiffRequests).toBe(0);
+  });
+
+  it("reviews and reconnects one exact non-default account", async () => {
+    const accounts = mockGitHubConnectorAccounts(2).map((account) => {
+      return {
+        ...account,
+        connectionStatus: "connected" as const,
+        reconnectReason: null,
+        scopeMismatch: !account.isDefault,
+      };
+    });
+    const defaultAccount = accounts.find((account) => {
+      return account.isDefault;
+    });
+    const personalAccount = accounts.find((account) => {
+      return !account.isDefault;
+    });
+    if (!defaultAccount || !personalAccount) {
+      throw new Error("Expected default and non-default GitHub accounts");
+    }
+    let projectedDefaultId = defaultAccount.id;
+    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+      const defaultConnection =
+        projectedDefaultId === personalAccount.id
+          ? { ...personalAccount, isDefault: true }
+          : defaultAccount;
+      return respond(200, {
+        summaries: [
+          {
+            target: defaultAccount.target,
+            accountCount: 2,
+            attentionCount: 0,
+            defaultConnection,
+          },
+        ],
+      });
+    });
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, respond }) => {
+        return params.connectionId === personalAccount.id
+          ? respond(200, personalAccount)
+          : respond(404, {
+              error: { message: "Account not found", code: "NOT_FOUND" },
+            });
+      },
+    );
+    const listEnrichmentValues: ("true" | null)[] = [];
+    context.mocks.api(
+      connectorAccountsContract.connections,
+      ({ query, respond }) => {
+        if (query.kind !== "builtin") {
+          throw new Error("Expected a built-in connector account query");
+        }
+        listEnrichmentValues.push(query.includeScopeMismatch ?? null);
+        return respond(200, {
+          connections: [defaultAccount, personalAccount],
+          nextCursor: null,
+        });
+      },
+    );
+    const exactScopeDiffIds: string[] = [];
+    context.mocks.api(
+      connectorAccountsContract.scopeDiff,
+      ({ params, query, respond }) => {
+        exactScopeDiffIds.push(params.connectionId);
+        expect(query.connectorSlug).toBe("github");
+        if (params.connectionId !== personalAccount.id) {
+          return respond(404, {
+            error: { message: "Account not found", code: "NOT_FOUND" },
+          });
+        }
+        return respond(200, {
+          addedScopes: ["scope-new"],
+          removedScopes: [],
+          currentScopes: ["scope-old", "scope-new"],
+          storedScopes: ["scope-old"],
+        });
+      },
+    );
+    let submittedAccount: unknown;
+    context.mocks.api(
+      connectorOauthStartContract.start,
+      ({ body, params, respond }) => {
+        expect(params.connectorSlug).toBe("github");
+        submittedAccount = body.account;
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/github/authorize",
+        });
+      },
+    );
+    const authWindow = createMockAuthWindow();
+    context.mocks.browser.open(authWindow);
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
+    const manager = await screen.findByRole("dialog", {
+      name: "Manage GitHub accounts",
+    });
+    await waitFor(() => {
+      expect(listEnrichmentValues).toStrictEqual(["true"]);
+    });
+    const personalRow = await waitFor(() => {
+      return accountRow(manager, personalAccount.displayName ?? "");
+    });
+    await waitFor(() => {
+      expect(listEnrichmentValues).toContain("true");
+      expect(within(personalRow).getByText("Update permissions")).toBeVisible();
+    });
+    click(within(personalRow).getByLabelText("Account actions"));
+    click(menuItemByText("Review permissions"));
+
+    const reviewDialog = await screen.findByRole("dialog", {
+      name: "GitHub permissions update",
+    });
+    await expect(
+      within(reviewDialog).findByText("scope-new"),
+    ).resolves.toBeInTheDocument();
+    expect(exactScopeDiffIds).toStrictEqual([personalAccount.id]);
+
+    // Changing the projected default while review is open must not retarget
+    // the reconnect selected from the account manager.
+    projectedDefaultId = personalAccount.id;
+    click(buttonByText("Reconnect", reviewDialog));
+    const connectDialog = await screen.findByRole("dialog", {
+      name: "GitHub",
+    });
+    click(buttonByText("Reconnect", connectDialog));
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/github/authorize",
+      );
+    });
+    expect(submittedAccount).toStrictEqual({
+      intent: "reconnect",
+      connectionId: personalAccount.id,
+    });
+  });
+
+  it("fails closed when an exact scope-review account becomes unavailable", async () => {
+    const accounts = mockGitHubConnectorAccounts(2).map((account) => {
+      return account.isDefault ? account : { ...account, scopeMismatch: true };
+    });
+    context.mocks.api(
+      connectorAccountsContract.connections,
+      ({ query, respond }) => {
+        if (query.kind !== "builtin") {
+          throw new Error("Expected a built-in connector account query");
+        }
+        expect(query.includeScopeMismatch).toBe("true");
+        return respond(200, { connections: accounts, nextCursor: null });
+      },
+    );
+    context.mocks.api(connectorAccountsContract.scopeDiff, ({ respond }) => {
+      return respond(404, {
+        error: { message: "Account not found", code: "NOT_FOUND" },
+      });
+    });
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
+    const manager = await screen.findByRole("dialog", {
+      name: "Manage GitHub accounts",
+    });
+    const nonDefaultAccount = accounts.find((account) => {
+      return !account.isDefault;
+    });
+    if (!nonDefaultAccount) {
+      throw new Error("Expected a non-default GitHub account");
+    }
+    const row = await waitFor(() => {
+      return accountRow(manager, nonDefaultAccount.displayName ?? "");
+    });
+    click(within(row).getByLabelText("Account actions"));
+    click(menuItemByText("Review permissions"));
+
+    const reviewDialog = await screen.findByRole("dialog", {
+      name: "GitHub permissions update",
+    });
+    await expect(
+      within(reviewDialog).findByText("Failed to load scope changes."),
+    ).resolves.toBeInTheDocument();
+    expect(queryButtonByText("Reconnect", reviewDialog)).toBeNull();
+  });
+
+  it("retries account listing without enrichment against an older API", async () => {
+    const accounts = mockGitHubConnectorAccounts(2).map((account) => {
+      const { scopeMismatch: _scopeMismatch, ...legacyAccount } = account;
+      return legacyAccount;
+    });
+    const enrichmentValues: ("true" | null)[] = [];
+    context.mocks.api(
+      connectorAccountsContract.connections,
+      ({ query, respond }) => {
+        if (query.kind !== "builtin") {
+          throw new Error("Expected a built-in connector account query");
+        }
+        enrichmentValues.push(query.includeScopeMismatch ?? null);
+        return query.includeScopeMismatch === "true"
+          ? respond(400, {
+              error: { message: "Invalid query", code: "BAD_REQUEST" },
+            })
+          : respond(200, { connections: accounts, nextCursor: null });
+      },
+    );
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
+    });
+
+    click(await waitForButtonByAriaLabel("Manage GitHub accounts"));
+    const manager = await screen.findByRole("dialog", {
+      name: "Manage GitHub accounts",
+    });
+    await waitFor(() => {
+      expect(enrichmentValues).toStrictEqual(["true", null]);
+      expect(within(manager).getByText("Work 1")).toBeInTheDocument();
+    });
+    expect(within(manager).queryByText("Update permissions")).toBeNull();
   });
 
   it("navigates connector categories and opens a connector from the keyboard", async () => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -571,6 +571,12 @@ function connectorAccountSearchIsVisible(
   );
 }
 
+function connectorAccountNextCursor(
+  accounts: Loadable<ConnectorAccountList>,
+): string | null {
+  return accounts.state === "hasData" ? accounts.data.nextCursor : null;
+}
+
 function enrichedDefaultConnection(
   accounts: ConnectorAccountList,
   summarizedDefault: ConnectorAccountConnection | null,
@@ -606,10 +612,7 @@ export function ConnectorAccountManagerDialog({
   );
   const resetDrafts = useSet(resetConnectorAccountManagerDrafts$);
   const signal = useGet(pageSignal$);
-  const nextCursor =
-    accountsLoadable.state === "hasData"
-      ? accountsLoadable.data.nextCursor
-      : null;
+  const nextCursor = connectorAccountNextCursor(accountsLoadable);
   const defaultConnection =
     summariesLoadable.state === "hasData" &&
     accountsLoadable.state === "hasData" &&

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -571,6 +571,22 @@ function connectorAccountSearchIsVisible(
   );
 }
 
+function enrichedDefaultConnection(
+  accounts: ConnectorAccountList,
+  summarizedDefault: ConnectorAccountConnection | null,
+): ConnectorAccountConnection | null {
+  if (!summarizedDefault) {
+    return null;
+  }
+  // Summaries intentionally omit opt-in list enrichment. Prefer the matching
+  // list row so the pinned default account retains its scope review state.
+  return (
+    accounts.connections.find((account) => {
+      return account.id === summarizedDefault.id;
+    }) ?? summarizedDefault
+  );
+}
+
 export function ConnectorAccountManagerDialog({
   target,
   connectorLabel,
@@ -598,8 +614,11 @@ export function ConnectorAccountManagerDialog({
     summariesLoadable.state === "hasData" &&
     accountsLoadable.state === "hasData" &&
     accountsLoadable.data.available
-      ? (summariesLoadable.data.get(connectorAccountTargetKey(target))
-          ?.defaultConnection ?? null)
+      ? enrichedDefaultConnection(
+          accountsLoadable.data,
+          summariesLoadable.data.get(connectorAccountTargetKey(target))
+            ?.defaultConnection ?? null,
+        )
       : null;
   const showSearch = connectorAccountSearchIsVisible(search, accountsLoadable);
   const leave = (next: () => void) => {
@@ -607,9 +626,8 @@ export function ConnectorAccountManagerDialog({
     next();
   };
   const reconnect = accountActionAfterLeave(leave, onReconnect);
-  const reviewScopes = onReviewScopes
-    ? accountActionAfterLeave(leave, onReviewScopes)
-    : undefined;
+  const reviewScopes =
+    onReviewScopes && accountActionAfterLeave(leave, onReviewScopes);
   return (
     <Dialog
       open

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -60,6 +60,18 @@ interface ConnectorAccountManagerDialogProps {
   readonly onClose: () => void;
   readonly onAdd: () => void;
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
+  readonly onReviewScopes?: (account: ConnectorAccountConnection) => void;
+}
+
+function accountActionAfterLeave(
+  leave: (next: () => void) => void,
+  action: (account: ConnectorAccountConnection) => void,
+): (account: ConnectorAccountConnection) => void {
+  return (account) => {
+    leave(() => {
+      action(account);
+    });
+  };
 }
 
 // Mirrors the status dot used by ConnectorAccountSummaryText on the connector
@@ -67,18 +79,20 @@ interface ConnectorAccountManagerDialogProps {
 function AccountStatus({ account }: { account: ConnectorAccountConnection }) {
   const { t } = useTranslation();
   const needsReconnect = account.connectionStatus === "reconnect-required";
+  const needsScopeReview = account.scopeMismatch === true;
+  const needsAttention = needsReconnect || needsScopeReview;
   return (
     <span className="flex min-w-0 items-center gap-2">
       <span
         className={cn(
           "h-1.5 w-1.5 shrink-0 rounded-full",
-          needsReconnect ? "bg-amber-500" : "bg-emerald-500",
+          needsAttention ? "bg-amber-500" : "bg-emerald-500",
         )}
       />
       <span
         className={cn(
           "truncate",
-          needsReconnect
+          needsAttention
             ? "text-amber-600 dark:text-amber-400"
             : "text-muted-foreground",
         )}
@@ -87,9 +101,13 @@ function AccountStatus({ account }: { account: ConnectorAccountConnection }) {
           ? t(($) => {
               return $.connectors.accounts.reconnectRequired;
             })
-          : t(($) => {
-              return $.connectors.accounts.connected;
-            })}
+          : needsScopeReview
+            ? t(($) => {
+                return $.connectors.card.updatePermissions;
+              })
+            : t(($) => {
+                return $.connectors.accounts.connected;
+              })}
       </span>
     </span>
   );
@@ -150,11 +168,13 @@ function AccountActions({
   account,
   connectionActionsEnabled,
   onReconnect,
+  onReviewScopes,
 }: {
   readonly target: ConnectorAccountTarget;
   readonly account: ConnectorAccountConnection;
   readonly connectionActionsEnabled: boolean;
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
+  readonly onReviewScopes?: (account: ConnectorAccountConnection) => void;
 }) {
   const { t } = useTranslation();
   const startRename = useSet(startConnectorAccountRename$);
@@ -176,6 +196,17 @@ function AccountActions({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {account.scopeMismatch === true && onReviewScopes ? (
+          <DropdownMenuItem
+            onClick={() => {
+              return onReviewScopes(account);
+            }}
+          >
+            {t(($) => {
+              return $.connectors.card.reviewPermissions;
+            })}
+          </DropdownMenuItem>
+        ) : null}
         {connectionActionsEnabled &&
         account.connectionStatus !== "reconnect-required" ? (
           <DropdownMenuItem
@@ -220,11 +251,13 @@ function AccountRow({
   account,
   connectionActionsEnabled,
   onReconnect,
+  onReviewScopes,
 }: {
   readonly target: ConnectorAccountTarget;
   readonly account: ConnectorAccountConnection;
   readonly connectionActionsEnabled: boolean;
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
+  readonly onReviewScopes?: (account: ConnectorAccountConnection) => void;
 }) {
   const { t } = useTranslation();
   const renameDraft = useGet(connectorAccountRenameDraft$);
@@ -277,6 +310,7 @@ function AccountRow({
           account={account}
           connectionActionsEnabled={connectionActionsEnabled}
           onReconnect={onReconnect}
+          onReviewScopes={onReviewScopes}
         />
       </div>
     </div>
@@ -290,6 +324,7 @@ function AccountsCard({
   target,
   connectionActionsEnabled,
   onReconnect,
+  onReviewScopes,
 }: {
   readonly loadable: Loadable<ConnectorAccountList>;
   readonly defaultConnection: ConnectorAccountConnection | null;
@@ -297,6 +332,7 @@ function AccountsCard({
   readonly target: ConnectorAccountTarget;
   readonly connectionActionsEnabled: boolean;
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
+  readonly onReviewScopes?: (account: ConnectorAccountConnection) => void;
 }) {
   if (loadable.state === "hasError") {
     return <AccountsMessage messageKey="accountsUnavailable" />;
@@ -338,6 +374,7 @@ function AccountsCard({
               account={account}
               connectionActionsEnabled={connectionActionsEnabled}
               onReconnect={onReconnect}
+              onReviewScopes={onReviewScopes}
             />
           </div>
         );
@@ -542,6 +579,7 @@ export function ConnectorAccountManagerDialog({
   onClose,
   onAdd,
   onReconnect,
+  onReviewScopes,
 }: ConnectorAccountManagerDialogProps) {
   const { t } = useTranslation();
   const accountsLoadable = useLoadable(settingsConnectorAccounts.accounts$);
@@ -568,11 +606,10 @@ export function ConnectorAccountManagerDialog({
     resetDrafts();
     next();
   };
-  const reconnect = (account: ConnectorAccountConnection) => {
-    leave(() => {
-      return onReconnect(account);
-    });
-  };
+  const reconnect = accountActionAfterLeave(leave, onReconnect);
+  const reviewScopes = onReviewScopes
+    ? accountActionAfterLeave(leave, onReviewScopes)
+    : undefined;
   return (
     <Dialog
       open
@@ -616,6 +653,7 @@ export function ConnectorAccountManagerDialog({
             target={target}
             connectionActionsEnabled={connectionActionsEnabled}
             onReconnect={reconnect}
+            onReviewScopes={reviewScopes}
           />
           {nextCursor ? (
             <Button

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -581,6 +581,9 @@ function enrichedDefaultConnection(
   accounts: ConnectorAccountList,
   summarizedDefault: ConnectorAccountConnection | null,
 ): ConnectorAccountConnection | null {
+  if (accounts.defaultConnection !== undefined) {
+    return accounts.defaultConnection;
+  }
   if (!summarizedDefault) {
     return null;
   }

--- a/turbo/apps/platform/src/views/okou-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/scope-review-modal.tsx
@@ -6,30 +6,32 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@okouai/ui/components/ui/dialog";
-import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import { useTranslation } from "react-i18next";
 import { ConnectorIcon } from "./connector-icons.tsx";
-import { scopeDiff$ } from "../../../../signals/okou-page/settings/connectors.ts";
+import {
+  scopeDiff$,
+  type ConnectorScopeReviewSelection,
+} from "../../../../signals/okou-page/settings/connectors.ts";
 import { connectorCatalogStatus$ } from "../../../../signals/external/connectors.ts";
 
 interface ScopeReviewModalProps {
-  connectorSlug: ConnectorSlug | null;
+  selection: ConnectorScopeReviewSelection;
   onClose: () => void;
-  onReconnect: (connectorSlug: ConnectorSlug) => void;
+  onReconnect: (selection: ConnectorScopeReviewSelection) => void;
 }
 
 function ScopeDiffContent({
-  connectorSlug,
+  selection,
   addedScopes,
   removedScopes,
   onClose,
   onReconnect,
 }: {
-  connectorSlug: ConnectorSlug;
+  selection: ConnectorScopeReviewSelection;
   addedScopes: readonly string[];
   removedScopes: readonly string[];
   onClose: () => void;
-  onReconnect: (connectorSlug: ConnectorSlug) => void;
+  onReconnect: (selection: ConnectorScopeReviewSelection) => void;
 }) {
   const { t } = useTranslation();
   return (
@@ -94,7 +96,7 @@ function ScopeDiffContent({
         <Button
           type="button"
           onClick={() => {
-            return onReconnect(connectorSlug);
+            return onReconnect(selection);
           }}
           className="flex-1"
         >
@@ -113,7 +115,7 @@ function ScopeDiffContent({
 }
 
 export function ScopeReviewModal({
-  connectorSlug,
+  selection,
   onClose,
   onReconnect,
 }: ScopeReviewModalProps) {
@@ -124,14 +126,10 @@ export function ScopeReviewModal({
   const scopeDiff =
     scopeDiffLoadable.state === "hasData" ? scopeDiffLoadable.data : null;
 
-  if (!connectorSlug) {
-    return null;
-  }
-
   const connector = connectorCatalog?.connectors.find((candidate) => {
-    return candidate.slug === connectorSlug;
+    return candidate.slug === selection.connectorSlug;
   });
-  const connectorLabel = connector?.label ?? connectorSlug;
+  const connectorLabel = connector?.label ?? selection.connectorSlug;
 
   return (
     <Dialog
@@ -165,7 +163,7 @@ export function ScopeReviewModal({
           </p>
         ) : scopeDiff ? (
           <ScopeDiffContent
-            connectorSlug={connectorSlug}
+            selection={selection}
             addedScopes={scopeDiff.addedScopes}
             removedScopes={scopeDiff.removedScopes}
             onClose={onClose}

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -49,8 +49,8 @@ import {
   pollingOAuthDeviceAuthConnectorSlug$,
   justConnectedSlugs$,
   relatedCatalogItems$,
-  scopeReviewConnectorSlug$,
-  setScopeReviewConnectorSlug$,
+  scopeReviewSelection$,
+  setScopeReviewSelection$,
   getAvailableStatusAuthCodeAuthMethod,
   getConnectorStatusAuthMethod,
   type ConnectorsConnectionFilter,
@@ -1053,8 +1053,8 @@ export function ConnectorsPage() {
   const signal = useGet(pageSignal$);
   const selectedConnectorSlug = useGet(selectedConnectorSlug$);
   const setSelected = useSet(setSelectedConnectorSlug$);
-  const scopeReviewConnectorSlug = useGet(scopeReviewConnectorSlug$);
-  const setScopeReviewConnectorSlug = useSet(setScopeReviewConnectorSlug$);
+  const scopeReviewSelection = useGet(scopeReviewSelection$);
+  const setScopeReviewSelection = useSet(setScopeReviewSelection$);
   const setManagedConnectorSlug = useSet(setManagedConnectorAccessSlug$);
   const optimisticConnected = useGet(justConnectedSlugs$);
   const activeTab = useGet(connectorsPageTab$);
@@ -1240,7 +1240,10 @@ export function ConnectorsPage() {
           return setManagedConnectorSlug(c.slug);
         }}
         onReviewScopes={() => {
-          return setScopeReviewConnectorSlug(c.slug);
+          return setScopeReviewSelection({
+            kind: "default",
+            connectorSlug: c.slug,
+          });
         }}
       />
     );
@@ -1394,23 +1397,42 @@ export function ConnectorsPage() {
               authMethod: account.authMethod,
             });
           }}
+          onReviewScopes={(account) => {
+            closeAccountManager();
+            setScopeReviewSelection({
+              kind: "account",
+              connectorSlug: managedAccountConnector.slug,
+              connectionId: account.id,
+              authMethod: account.authMethod,
+            });
+          }}
         />
       )}
 
-      {scopeReviewConnectorSlug && (
+      {scopeReviewSelection && (
         <ScopeReviewModal
-          connectorSlug={scopeReviewConnectorSlug}
+          selection={scopeReviewSelection}
           onClose={() => {
-            return setScopeReviewConnectorSlug(null);
+            return setScopeReviewSelection(null);
           }}
-          onReconnect={(connectorSlug) => {
-            setScopeReviewConnectorSlug(null);
+          onReconnect={(selection) => {
+            setScopeReviewSelection(null);
             const connector = allConnectors.find((connector) => {
-              return connector.slug === connectorSlug;
+              return connector.slug === selection.connectorSlug;
             });
+            if (selection.kind === "account") {
+              if (connector) {
+                openAccountConnect(connector, {
+                  kind: "reconnect",
+                  connectionId: selection.connectionId,
+                  authMethod: selection.authMethod,
+                });
+              }
+              return;
+            }
             const connection = connector?.connection ?? null;
             if (!connector || !connection) {
-              setSelected(connectorSlug);
+              setSelected(selection.connectorSlug);
               return;
             }
             const authMethodId = getAvailableStatusAuthCodeAuthMethod(
@@ -1421,12 +1443,12 @@ export function ConnectorsPage() {
               ? getConnectorStatusAuthMethod(connector, authMethodId)
               : null;
             if (!authMethod) {
-              setSelected(connectorSlug);
+              setSelected(selection.connectorSlug);
               return;
             }
             detach(
               connect(
-                connectorSlug,
+                selection.connectorSlug,
                 authMethod,
                 {
                   authorizeVisibleAgents: true,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
@@ -216,12 +216,14 @@ describe("connector account contracts", () => {
       connectorAccountListQuerySchema.parse({
         kind: "builtin",
         connectorSlug: "github",
+        includeScopeMismatch: "true",
         limit: "100",
         search: "  work  ",
       }),
     ).toStrictEqual({
       kind: "builtin",
       connectorSlug: "github",
+      includeScopeMismatch: "true",
       limit: 100,
       search: "work",
     });
@@ -234,11 +236,51 @@ describe("connector account contracts", () => {
     ).toBe(false);
     expect(
       connectorAccountListQuerySchema.safeParse({
+        kind: "custom",
+        customConnectorId,
+        includeScopeMismatch: "true",
+      }).success,
+    ).toBe(false);
+    expect(
+      connectorAccountListQuerySchema.safeParse({
         kind: "builtin",
         connectorSlug: "github",
         limit: 101,
       }).success,
     ).toBe(false);
+  });
+
+  it("keeps scope mismatch enrichment optional for legacy account lists", () => {
+    const connection = {
+      id: connectionId,
+      target: { kind: "builtin" as const, connectorSlug: "github" },
+      authMethod: "oauth",
+      displayName: null,
+      isDefault: true,
+      externalId: null,
+      externalUsername: "octocat",
+      externalEmail: null,
+      oauthScopes: ["repo"],
+      connectionStatus: "connected" as const,
+      reconnectReason: null,
+      tokenExpiresAt: null,
+      createdAt: "2026-09-03T00:00:00.000Z",
+      updatedAt: "2026-09-03T00:00:00.000Z",
+    };
+    const response = connectorAccountsContract.connections.responses[200];
+
+    expect(
+      response.parse({ connections: [connection], nextCursor: null }),
+    ).toStrictEqual({ connections: [connection], nextCursor: null });
+    expect(
+      response.parse({
+        connections: [{ ...connection, scopeMismatch: true }],
+        nextCursor: null,
+      }),
+    ).toStrictEqual({
+      connections: [{ ...connection, scopeMismatch: true }],
+      nextCursor: null,
+    });
   });
 
   it("requires an exact target for one account read", () => {
@@ -251,6 +293,23 @@ describe("connector account contracts", () => {
     expect(
       connectorAccountsContract.connection.query.safeParse({
         kind: "builtin",
+        connectorSlug: "github",
+        customConnectorId,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("binds scope diff to an exact built-in account and slug", () => {
+    expect(
+      connectorAccountsContract.scopeDiff.pathParams.parse({ connectionId }),
+    ).toStrictEqual({ connectionId });
+    expect(
+      connectorAccountsContract.scopeDiff.query.parse({
+        connectorSlug: "github",
+      }),
+    ).toStrictEqual({ connectorSlug: "github" });
+    expect(
+      connectorAccountsContract.scopeDiff.query.safeParse({
         connectorSlug: "github",
         customConnectorId,
       }).success,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
@@ -276,10 +276,12 @@ describe("connector account contracts", () => {
       response.parse({
         connections: [{ ...connection, scopeMismatch: true }],
         nextCursor: null,
+        defaultConnection: { ...connection, scopeMismatch: true },
       }),
     ).toStrictEqual({
       connections: [{ ...connection, scopeMismatch: true }],
       nextCursor: null,
+      defaultConnection: { ...connection, scopeMismatch: true },
     });
   });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
@@ -516,6 +516,11 @@ describe("connector path parameter contracts", () => {
         body: { target: { kind: "builtin", connectorSlug: "github" } },
       },
     );
+    await initClient(connectorAccountsContract, config).scopeDiff({
+      params: { connectionId: connector.id },
+      query: { connectorSlug: "github" },
+      headers: {},
+    });
     await initClient(connectorCatalogContract, config).permissions({
       params: { connectorSlug: "github" },
       headers: {},
@@ -528,6 +533,7 @@ describe("connector path parameter contracts", () => {
 
     expect(paths).toStrictEqual([
       "https://api.example.test/api/connector-accounts/single-account",
+      `https://api.example.test/api/connector-accounts/${connector.id}/scope-diff?connectorSlug=github`,
       "https://api.example.test/api/connector-catalog/github/permissions",
       "https://api.example.test/api/connectors/github/callback?responseMode=json",
     ]);

--- a/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
@@ -226,6 +226,9 @@ export const connectorAccountsContract = c.router({
       200: z.object({
         connections: z.array(connectorAccountConnectionSchema),
         nextCursor: z.string().nullable(),
+        defaultConnection: connectorAccountConnectionSchema
+          .nullable()
+          .optional(),
       }),
       400: apiErrorSchema,
       401: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
@@ -8,6 +8,7 @@ import {
 import {
   connectorReconnectReasonSchema,
   connectorResponseConnectionStatusSchema,
+  scopeDiffResponseSchema,
 } from "./connector-schemas";
 import { apiErrorSchema } from "./errors";
 
@@ -45,6 +46,7 @@ export const connectorAccountConnectionSchema = z
     externalUsername: z.string().nullable(),
     externalEmail: z.string().nullable(),
     oauthScopes: z.array(z.string()).nullable(),
+    scopeMismatch: z.boolean().optional(),
     connectionStatus: connectorResponseConnectionStatusSchema,
     reconnectReason: connectorReconnectReasonSchema.nullable(),
     tokenExpiresAt: z.string().nullable(),
@@ -148,6 +150,7 @@ export const connectorAccountListQuerySchema = z.discriminatedUnion("kind", [
     .object({
       kind: z.literal("builtin"),
       connectorSlug: connectorSlugSchema,
+      includeScopeMismatch: z.literal("true").optional(),
       ...connectorAccountListQueryFields,
     })
     .strict(),
@@ -245,6 +248,21 @@ export const connectorAccountsContract = c.router({
       404: apiErrorSchema,
     },
     summary: "Get one exact connector account",
+  },
+  scopeDiff: {
+    method: "GET",
+    path: "/api/connector-accounts/:connectionId/scope-diff",
+    headers: authHeadersSchema,
+    pathParams: connectorAccountPathParamsSchema,
+    query: z.object({ connectorSlug: connectorSlugSchema }).strict(),
+    responses: {
+      200: scopeDiffResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get requested scope diff for one exact connector account",
   },
   rename: {
     method: "PATCH",


### PR DESCRIPTION
## Summary

- add opt-in, server-computed requested-scope drift metadata to built-in connector account lists, including an enriched default projection on the unfiltered first page
- add an account-exact scope-diff endpoint and preserve the selected connection ID through review and reconnect
- expose scope review for affected default and non-default accounts while keeping compact feature-off behavior unchanged
- fail closed for missing, foreign, wrong-target, or deleted accounts without retargeting a sibling

## Compatibility

- unopted account-list responses omit the new optional fields for older Platform bundles
- the legacy slug/default scope-diff endpoint and `single-account` reconnect path remain unchanged
- because Connector Accounts is still staff-only, a new Platform fails fast against an API version that predates the enrichment query instead of carrying a reverse-rollout fallback

## Out of scope

- changing provider partial-grant policy or runtime credential selection
- removing the connector-accounts feature switch or singleton compatibility
- changing account summary semantics or graduating the multi-account rollout

## Validation

- `pnpm --filter @okouai/api-contracts exec vitest run src/contracts/__tests__/connector-accounts.test.ts src/contracts/__tests__/connector-client-contract.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/connector-accounts.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/connectors-scope-diff.test.ts --maxWorkers=1 --silent=passed-only`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-page.test.tsx --maxWorkers=1 --silent=passed-only`
- `pnpm --filter @okouai/api-contracts check-types`
- `pnpm --filter api check-types`
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/api-contracts lint`
- `pnpm --filter api lint`
- `pnpm --filter @okouai/app lint`
- `pnpm knip`
- `git diff --check`

Closes #31433

Parent context: #30585
Rollout context: #28571
