### PR TITLE
fix(platform): remove new chat from chat list menu

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -656,11 +656,14 @@ describe("zero sidebar", () => {
       expect(
         within(sidebar()).getByText("Existing conversation"),
       ).toBeInTheDocument();
-      return within(sidebar()).getByLabelText("Open chat list menu");
+      const chatThreadsTitle = within(sidebar()).getByText("Chats with Zero");
+      if (!chatThreadsTitle.parentElement) {
+        throw new Error("Chat threads header not found");
+      }
+      return within(chatThreadsTitle.parentElement).getByLabelText("New chat");
     });
 
     click(newChatButton);
-    click(menuItemByText("New chat"));
 
     await waitFor(() => {
       const sidebar = screen.getByTestId("chat-list-column");
@@ -825,7 +828,7 @@ describe("zero sidebar", () => {
       ).toBeInTheDocument();
     });
     openChatListMenu();
-    expect(menuItemByText("New chat")).toBeInTheDocument();
+    expect(menuItemByText("All chats")).toBeInTheDocument();
   });
 
   it("preserves server thread order while creating an optimistic new chat", async () => {
@@ -887,11 +890,14 @@ describe("zero sidebar", () => {
           "C server third",
         ]),
       ).toStrictEqual(["A server first", "B server second", "C server third"]);
-      return within(sidebar()).getByLabelText("Open chat list menu");
+      const chatThreadsTitle = within(sidebar()).getByText("Chats with Zero");
+      if (!chatThreadsTitle.parentElement) {
+        throw new Error("Chat threads header not found");
+      }
+      return within(chatThreadsTitle.parentElement).getByLabelText("New chat");
     });
 
     click(newChatButton);
-    click(menuItemByText("New chat"));
 
     await waitFor(() => {
       expect(
@@ -4160,12 +4166,7 @@ describe("zero sidebar", () => {
         queryAllByRoleFast("menuitem").map((item) => {
           return item.textContent?.replace(/\s+/g, " ").trim();
         }),
-      ).toStrictEqual([
-        "New chat",
-        "Mark all read",
-        "All chats",
-        "Unread only",
-      ]);
+      ).toStrictEqual(["Mark all read", "All chats", "Unread only"]);
     });
     click(menuItemByText("Mark all read"));
 

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -722,7 +722,7 @@ function ChatThreadsListMenuTooltip() {
   );
 }
 
-function useNewChatMenuAction() {
+function useNewChatAction() {
   const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;
   const createNewChat = useSet(createNewChatThread$);
   const setExpanded = useSet(setSidebarExpanded$);
@@ -744,30 +744,6 @@ function useNewChatMenuAction() {
     disabled: !currentChatAgentId || newChatDisabled,
     onSelect,
   };
-}
-
-function NewChatMenuItem({
-  disabled,
-  onSelect,
-}: {
-  disabled: boolean;
-  onSelect: (pane: NewChatThreadPane) => void;
-}) {
-  const { t } = useTranslation();
-
-  return (
-    <DropdownMenuItem
-      onSelect={() => {
-        onSelect("main");
-      }}
-      disabled={disabled}
-    >
-      <Plus size={16} className="mr-2" />
-      {t(($) => {
-        return $.chat.newChat;
-      })}
-    </DropdownMenuItem>
-  );
 }
 
 function useMarkAllReadMenuAction(showMarkAllRead: boolean) {
@@ -861,7 +837,6 @@ function ChatThreadsListMenu({
   showMarkAllRead: boolean;
 }) {
   const { t } = useTranslation();
-  const newChatAction = useNewChatMenuAction();
   const markAllReadAction = useMarkAllReadMenuAction(showMarkAllRead);
 
   return (
@@ -891,11 +866,12 @@ function ChatThreadsListMenu({
             e.stopPropagation();
           }}
         >
-          <NewChatMenuItem {...newChatAction} />
           {markAllReadAction.visible ? (
-            <MarkAllReadMenuItem {...markAllReadAction} />
+            <>
+              <MarkAllReadMenuItem {...markAllReadAction} />
+              <DropdownMenuSeparator />
+            </>
           ) : null}
-          <DropdownMenuSeparator />
           <ChatThreadFilterMenuItems />
         </DropdownMenuContent>
       </DropdownMenu>
@@ -906,7 +882,7 @@ function ChatThreadsListMenu({
 function ChatThreadsTitle({ showMarkAllRead }: { showMarkAllRead: boolean }) {
   const { t } = useTranslation();
   const { titleLabel } = useChatThreadsTitleLabels();
-  const newChatAction = useNewChatMenuAction();
+  const newChatAction = useNewChatAction();
   const newChatLabel = t(($) => {
     return $.chat.newChat;
   });


### PR DESCRIPTION
## Summary

- remove the New chat action from the chat list overflow menu
- keep the adjacent New chat button as the creation entry point
- show the menu separator only when Mark all read is visible

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx` (83 tests passed)
