### PR TITLE
perf(runner): skip futile finalizing workspace lock wait

### DIFF
--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -28,7 +28,9 @@
 //! when there is no executor to emit ordinary job telemetry.
 //!
 //! When no direct or published exact resource is available, fallback first retries matching idle
-//! exact reuse, then consumes retiring idle capacity, and finally uses fresh budget capacity.
+//! exact reuse, then consumes retiring idle capacity, and finally uses fresh budget capacity. A
+//! fresh fallback still attempts workspace-cache checkout, but skips its transient-contention
+//! retry when the predecessor state proves that a live or transferred sandbox retains the entry.
 //! Retiring leases are retained while the loop waits for capacity. The wait observes both budget
 //! availability and idle-pool changes: either can make the next exact or fresh-resource attempt
 //! viable, while cancellation exits through the same no-sandbox completion path. The admission
@@ -73,6 +75,7 @@ use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::run_cancellation::RunCancellationRegistration;
 use crate::telemetry::JobTelemetry;
 use crate::types::{CompleteRequest, SandboxReuseResult};
+use crate::workspace_image_cache::WorkspaceImagePrepareLockPolicy;
 
 pub(super) const FINALIZING_HANDOFF_ACCEPTANCE_GRACE: Duration = Duration::from_millis(1500);
 
@@ -243,6 +246,7 @@ async fn run_finalizing_claim(
         }
     };
 
+    let fresh_fallback = matches!(&resource, FinalizingResource::Fresh(_));
     let active_run_guard = ctx.active_runs.register(
         run_id,
         claimed.context().reuse_key().map(str::to_owned),
@@ -453,7 +457,7 @@ async fn run_finalizing_claim(
         },
         &ctx,
     );
-    let request = match AssertUnwindSafe(build_spawn_job_request(&mut activation, &ctx))
+    let mut request = match AssertUnwindSafe(build_spawn_job_request(&mut activation, &ctx))
         .catch_unwind()
         .await
     {
@@ -478,6 +482,23 @@ async fn run_finalizing_claim(
         }
     };
     drop(activation_transfer_guard);
+    let predecessor_state = admission.predecessor.state();
+    if fresh_fallback
+        && matches!(
+            predecessor_state,
+            ActiveRunReuseState::Pending
+                | ActiveRunReuseState::ExactSandboxPublished
+                | ActiveRunReuseState::ExactSandboxHandedOff
+        )
+    {
+        request.job_profile.workspace_image_prepare_lock_policy =
+            WorkspaceImagePrepareLockPolicy::ImmediateFallback;
+        info!(
+            run_id = %run_id,
+            ?predecessor_state,
+            "finalizing fallback will skip workspace cache lock retry"
+        );
+    }
     run_job(request, ctx).await
 }
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -912,6 +912,7 @@ pub(super) async fn build_spawn_job_request(
             budget_lease: active_lease,
             restore_guest_state,
             device_rate_limits,
+            workspace_image_prepare_lock_policy: Default::default(),
             factory,
             cancellation,
         },

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -58,6 +58,8 @@ pub(super) struct JobProfile {
     pub(super) budget_lease: BudgetLease,
     pub(super) restore_guest_state: bool,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
+    pub(super) workspace_image_prepare_lock_policy:
+        crate::workspace_image_cache::WorkspaceImagePrepareLockPolicy,
     pub(super) factory: SharedFactory,
     pub(super) cancellation: RunCancellationRegistration,
 }
@@ -591,6 +593,7 @@ pub(super) async fn run_job(
     let vcpu = job_profile.vcpu;
     let memory_mb = job_profile.memory_mb;
     let workspace_disk_mb = job_profile.workspace_disk_mb;
+    let workspace_image_prepare_lock_policy = job_profile.workspace_image_prepare_lock_policy;
     let active_lease = job_profile.budget_lease;
     let profile_name = job_profile.profile_name;
     let factory = job_profile.factory;
@@ -603,6 +606,7 @@ pub(super) async fn run_job(
         workspace_disk_mb,
         restore_guest_state: job_profile.restore_guest_state,
         device_rate_limits: job_profile.device_rate_limits.clone(),
+        workspace_image_prepare_lock_policy,
     };
     let job_device_rate_limits = params.device_rate_limits.clone();
 

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -17,7 +17,8 @@ use crate::provider::{
 };
 use crate::runner_process_identity::RunnerProcessIdentity;
 use crate::types::SandboxReuseResult;
-use crate::workspace_image_cache::WorkspaceImageCache;
+use crate::types::WorkspaceReuseResult;
+use crate::workspace_image_cache::{WorkspaceImageCache, WorkspaceImagePrepareLockTestGate};
 
 const NON_SELECTED_RUNNER_ID: u128 = 1;
 const FINALIZING_TEST_PREFERENCE_LIFETIME: Duration = Duration::from_secs(30);
@@ -1854,6 +1855,83 @@ async fn selected_ranked_finalizing_candidate_falls_back_at_deadline() {
         .expect("expired finalizing preference should enter ordinary admission");
     assert_ne!(completion.reuse_result, Some(SandboxReuseResult::Reused));
 
+    drop(predecessor_guard);
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn pending_finalizing_fallback_skips_workspace_cache_lock_retry() {
+    let reuse_key = "thread:pending-finalizing-workspace-lock";
+    let image_size_bytes = 1024 * 1024;
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 1;
+    let (mut config, env) = mock_run_config(profiles, 2, 4096, 1);
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let prepare_lock_gate = WorkspaceImagePrepareLockTestGate::default();
+    let workspace_cache =
+        WorkspaceImageCache::shared(runner_paths, &config.paths.home, &config.runner.group)
+            .with_prepare_lock_test_gate(prepare_lock_gate);
+    let cache_key = crate::paths::scoped_workspace_image_cache_key(
+        &config.runner.group,
+        "vm0/default",
+        reuse_key,
+        api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR,
+        image_size_bytes,
+    );
+    let held_lock = crate::lock::acquire(crate::paths::workspace_image_cache_lock_path(
+        &config.paths.home.locks_dir(),
+        &cache_key,
+    ))
+    .await
+    .unwrap();
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache);
+
+    let history_generation_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        history_generation_run_id,
+        Some(reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate_until(
+            run_id,
+            reuse_key,
+            history_generation_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+            std::time::Instant::now() + FINALIZING_TEST_PREFERENCE_LIFETIME,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle
+            .claim_candidates()
+            .iter()
+            .any(|candidate| candidate.run_id() == run_id),
+        "finalizing successor should be claimed before its deadline"
+    );
+
+    tokio::time::advance(FINALIZING_TEST_PREFERENCE_LIFETIME + Duration::from_millis(1)).await;
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("known long-lived workspace lock should not enter bounded retry");
+    assert_eq!(
+        completion.workspace_reuse_result,
+        Some(WorkspaceReuseResult::LockBusy),
+    );
+
+    drop(held_lock);
     drop(predecessor_guard);
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -159,7 +159,7 @@ use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, SandboxReuseResult, WorkspaceReuseResult};
 use crate::workspace_image_cache::{
     WorkspaceImageActiveLeaseRequest, WorkspaceImageCache, WorkspaceImageLease,
-    WorkspaceImageLeaseIdentity, WorkspaceImagePromotionContext,
+    WorkspaceImageLeaseIdentity, WorkspaceImagePrepareLockPolicy, WorkspaceImagePromotionContext,
     WorkspaceImagePromotionIdentityFailure, WorkspaceImagePromotionIdentityMismatch,
     WorkspaceImagePromotionIdentityRequest,
 };
@@ -212,6 +212,7 @@ pub struct JobParams {
     pub workspace_disk_mb: u32,
     pub restore_guest_state: bool,
     pub device_rate_limits: Option<sandbox::DeviceRateLimits>,
+    pub(crate) workspace_image_prepare_lock_policy: WorkspaceImagePrepareLockPolicy,
 }
 
 #[derive(Clone)]

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -50,7 +50,7 @@ use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, WorkspaceReuseResult};
 use crate::workspace_image_cache::{
     WorkspaceCacheCheckoutResult, WorkspaceImageLease, WorkspaceImageLeaseIdentity,
-    WorkspaceImagePrepareRequest,
+    WorkspaceImagePrepareLockPolicy, WorkspaceImagePrepareRequest,
 };
 use crate::workspace_mount::ensure_workspace_drive_mounted;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
@@ -501,6 +501,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         config,
         &params.profile_name,
         params.workspace_disk_mb,
+        params.workspace_image_prepare_lock_policy,
         telemetry,
     )
     .await;
@@ -822,24 +823,29 @@ pub(super) async fn prepare_workspace_image(
     config: &ExecutorConfig,
     profile_name: &str,
     workspace_disk_mb: u32,
+    lock_policy: WorkspaceImagePrepareLockPolicy,
     telemetry: &mut JobTelemetry,
 ) -> Option<WorkspaceImageLease> {
     let cache = config.workspace_cache.as_ref()?;
     let prepare_started = Instant::now();
     let reuse_key = context.reuse_key();
-    let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
-            identity: WorkspaceImageLeaseIdentity {
-                run_id: context.run_id,
-                sandbox_id,
-                profile_name,
-                reuse_key,
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
-            },
-            workspace_drive_required: true,
-        })
-        .await;
+    let request = WorkspaceImagePrepareRequest {
+        identity: WorkspaceImageLeaseIdentity {
+            run_id: context.run_id,
+            sandbox_id,
+            profile_name,
+            reuse_key,
+            working_dir: CANONICAL_WORKING_DIR,
+            image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
+        },
+        workspace_drive_required: true,
+    };
+    let lease = match lock_policy {
+        WorkspaceImagePrepareLockPolicy::WaitForTransientContention => cache.prepare(request).await,
+        WorkspaceImagePrepareLockPolicy::ImmediateFallback => {
+            cache.prepare_with_lock_policy(request, lock_policy).await
+        }
+    };
     let prepare_error = workspace_image_prepare_error(lease.result());
     telemetry.record(
         RUNNER_FRESH_WORKSPACE_IMAGE_PREPARE,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -12,7 +12,8 @@ use crate::types::{
     ResumeSessionHistoryRefKind, WorkspaceReuseResult,
 };
 use crate::workspace_image_cache::{
-    WorkspaceImagePrepareLockTestGate, WorkspaceSessionHistorySidecarRepresentation,
+    WorkspaceImagePrepareLockPolicy, WorkspaceImagePrepareLockTestGate,
+    WorkspaceSessionHistorySidecarRepresentation,
 };
 
 fn enable_api_start_telemetry(context: &mut crate::types::ExecutionContext) {
@@ -1010,6 +1011,58 @@ async fn execute_inner_waits_for_transient_workspace_cache_lock() {
         None,
     );
     assert_telemetry_action(&telemetry, "runner_fresh_sandbox_start", true, None);
+}
+
+#[tokio::test]
+async fn execute_inner_immediate_lock_policy_still_consumes_available_cache() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache.clone());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let mut ctx = minimal_context();
+    let session_id = "sess-cache-immediate-lock-policy";
+    set_reuse_and_session_identity(&mut ctx, session_id, r#"{"type":"init"}"#);
+    let params = JobParams {
+        workspace_disk_mb: 16,
+        workspace_image_prepare_lock_policy: WorkspaceImagePrepareLockPolicy::ImmediateFallback,
+        ..default_params()
+    };
+    let seeded_cache = seed_workspace_image_cache(&cache, &runner_paths, session_id, 16).await;
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &params,
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.exit_code(), 0);
+    assert_eq!(
+        outcome.workspace_reuse_result,
+        Some(WorkspaceReuseResult::Reused),
+    );
+    let configs = overrides.create_configs();
+    assert_eq!(configs.len(), 1);
+    assert_eq!(
+        configs[0].workspace_drive,
+        Some(sandbox::WorkspaceDriveConfig {
+            size_mb: 16,
+            seed_image: Some(sandbox::WorkspaceDriveSeedImage::Move(seeded_cache)),
+        })
+    );
+    assert_telemetry_action(&telemetry, "workspace_image_cache_hit", true, None);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -58,6 +58,7 @@ pub(in crate::executor::tests) fn default_params() -> JobParams {
         workspace_disk_mb: 16_384,
         restore_guest_state: false,
         device_rate_limits: None,
+        workspace_image_prepare_lock_policy: Default::default(),
     }
 }
 

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -32,11 +32,12 @@ use super::path_safety::{
 };
 use super::types::{
     CacheBudget, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
-    WorkspaceImageActiveLeaseRequest, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
-    WorkspaceImagePromotionIdentity, WorkspaceImagePromotionIdentityMismatch,
-    WorkspaceImagePromotionIdentityRequest, WorkspaceImagePromotionRequest,
-    WorkspaceSessionHistorySidecar, WorkspaceSessionHistorySidecarMiss,
-    WorkspaceSessionHistorySidecarPromotionSource, WorkspaceSessionHistorySidecarPublication,
+    WorkspaceImageActiveLeaseRequest, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareLockPolicy,
+    WorkspaceImagePrepareRequest, WorkspaceImagePromotionIdentity,
+    WorkspaceImagePromotionIdentityMismatch, WorkspaceImagePromotionIdentityRequest,
+    WorkspaceImagePromotionRequest, WorkspaceSessionHistorySidecar,
+    WorkspaceSessionHistorySidecarMiss, WorkspaceSessionHistorySidecarPromotionSource,
+    WorkspaceSessionHistorySidecarPublication,
 };
 use super::{CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache};
 
@@ -212,7 +213,15 @@ impl WorkspaceImageLease {
 }
 
 impl WorkspaceImageCache {
-    async fn acquire_prepare_lock(&self, lock_path: PathBuf) -> RunnerResult<crate::lock::TryLock> {
+    async fn acquire_prepare_lock(
+        &self,
+        lock_path: PathBuf,
+        lock_policy: WorkspaceImagePrepareLockPolicy,
+    ) -> RunnerResult<crate::lock::TryLock> {
+        if lock_policy == WorkspaceImagePrepareLockPolicy::ImmediateFallback {
+            return crate::lock::try_acquire_or_busy(lock_path).await;
+        }
+
         #[cfg(test)]
         if let Some(gate) = &self.prepare_lock_test_gate {
             return crate::lock::acquire_with_contention_timeout_after_busy_for_test(
@@ -309,6 +318,18 @@ impl WorkspaceImageCache {
     pub(crate) async fn prepare(
         &self,
         request: WorkspaceImagePrepareRequest<'_>,
+    ) -> WorkspaceImageLease {
+        self.prepare_with_lock_policy(
+            request,
+            WorkspaceImagePrepareLockPolicy::WaitForTransientContention,
+        )
+        .await
+    }
+
+    pub(crate) async fn prepare_with_lock_policy(
+        &self,
+        request: WorkspaceImagePrepareRequest<'_>,
+        lock_policy: WorkspaceImagePrepareLockPolicy,
     ) -> WorkspaceImageLease {
         let common = WorkspaceImageLeaseCommon::new(self, request.identity);
         let workspace_drive = |result,
@@ -413,15 +434,23 @@ impl WorkspaceImageCache {
 
         let cache_key = common.cache_key(self, reuse_key, working_dir);
         let lock_path = self.entry_lock_path(&cache_key);
-        let lock = match self.acquire_prepare_lock(lock_path).await {
+        let lock = match self.acquire_prepare_lock(lock_path, lock_policy).await {
             Ok(crate::lock::TryLock::Acquired(lock)) => lock,
             Ok(crate::lock::TryLock::Busy) => {
-                info!(
-                    run_id = %common.run_id,
-                    cache_key,
-                    wait_ms = duration_ms(WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT),
-                    "workspace image cache lock remained busy; using fresh workspace image"
-                );
+                match lock_policy {
+                    WorkspaceImagePrepareLockPolicy::WaitForTransientContention => info!(
+                        run_id = %common.run_id,
+                        cache_key,
+                        wait_ms = duration_ms(WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT),
+                        "workspace image cache lock remained busy; using fresh workspace image"
+                    ),
+                    WorkspaceImagePrepareLockPolicy::ImmediateFallback => info!(
+                        run_id = %common.run_id,
+                        cache_key,
+                        wait_ms = 0,
+                        "workspace image cache lock busy without retry; using fresh workspace image"
+                    ),
+                }
                 return workspace_drive(
                     WorkspaceCacheCheckoutResult::LockBusy,
                     None,

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -97,10 +97,10 @@ pub(crate) use types::{
     WorkspaceImageActiveLeaseRequest, WorkspaceImageCacheInspection,
     WorkspaceImageCacheInspectionEntry, WorkspaceImageCacheInspectionStatus,
     WorkspaceImageCacheInspectionSummary, WorkspaceImageLeaseIdentity,
-    WorkspaceImagePrepareRequest, WorkspaceImagePromotionIdentityMismatch,
-    WorkspaceImagePromotionIdentityRequest, WorkspaceImagePromotionRequest,
-    WorkspaceSessionHistorySidecar, WorkspaceSessionHistorySidecarPromotionSource,
-    WorkspaceSessionHistorySidecarRepresentation,
+    WorkspaceImagePrepareLockPolicy, WorkspaceImagePrepareRequest,
+    WorkspaceImagePromotionIdentityMismatch, WorkspaceImagePromotionIdentityRequest,
+    WorkspaceImagePromotionRequest, WorkspaceSessionHistorySidecar,
+    WorkspaceSessionHistorySidecarPromotionSource, WorkspaceSessionHistorySidecarRepresentation,
 };
 pub(crate) use watcher::{WorkspaceCacheChange, WorkspaceCacheWatcher};
 

--- a/crates/runner/src/workspace_image_cache/types.rs
+++ b/crates/runner/src/workspace_image_cache/types.rs
@@ -42,6 +42,13 @@ pub(crate) struct WorkspaceImagePrepareRequest<'a> {
     pub(crate) workspace_drive_required: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum WorkspaceImagePrepareLockPolicy {
+    #[default]
+    WaitForTransientContention,
+    ImmediateFallback,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct WorkspaceImageActiveLeaseRequest<'a> {
     pub(crate) identity: WorkspaceImageLeaseIdentity<'a>,


### PR DESCRIPTION
## Summary

- let finalizing fresh fallbacks make one immediate workspace-cache lock attempt when the predecessor still owns or transferred the exact sandbox
- preserve the existing bounded retry for ordinary fresh starts and finalizing paths where transient contention can still clear
- cover the finalizing admission path and confirm immediate mode still consumes an available cache entry

## Scope

This changes only the runner's internal workspace-image prepare lock policy. It does not change runner/API protocols, persisted state, cache formats, or the finalizing handoff deadline.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p runner --all-targets --all-features`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --no-deps`
- `cargo test -p runner pending_finalizing_fallback_skips_workspace_cache_lock_retry -- --nocapture`
- `cargo test -p runner execute_inner_immediate_lock_policy_still_consumes_available_cache -- --nocapture`
- `cargo test -p runner execute_inner_waits_for_transient_workspace_cache_lock -- --nocapture`
- `cargo test -p runner execute_inner_records_workspace_cache_lock_busy_prepare_telemetry -- --nocapture`
- `cargo test -p runner workspace_image_cache::tests`
- `cargo test -p runner`

Closes #31458
