### PR TITLE
perf(runner): overlap reused archive delivery

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1107,7 +1107,7 @@ pub(super) struct RunControls {
     pub(super) active_input_source: Option<ActiveInputSource>,
     pub(super) spawn_timing: Option<RunnerSpawnTiming>,
     pub(super) session_history_restore_plan: SessionHistoryRestorePlan,
-    pub(super) prepared_storage: Option<crate::storage_cache::PreparedFreshStorage>,
+    pub(super) prepared_storage: Option<crate::storage_cache::PreparedStorage>,
     pub(super) prepared_guest_runtime: Option<PreparedGuestRuntime>,
     pub(super) pre_spawn_admission_lease:
         Option<crate::pre_spawn_admission::PreSpawnAdmissionLease>,
@@ -1385,7 +1385,7 @@ async fn prepare_guest_storage(
     config: &ExecutorConfig,
     start: &RunStart<'_>,
     telemetry: &mut JobTelemetry,
-    prepared_storage: &mut Option<crate::storage_cache::PreparedFreshStorage>,
+    prepared_storage: &mut Option<crate::storage_cache::PreparedStorage>,
 ) -> RunnerResult<Option<crate::storage_cache::DeferredBackgroundFill>> {
     let Some(manifest) = &context.storage_manifest else {
         return Ok(None);

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1408,7 +1408,8 @@ pub(super) async fn destroy_sandbox_panic_safe(
 
 /// Run a job inside a reused (kept-alive) sandbox.
 ///
-/// Skips create + start. Re-registers proxy, fixes clock/entropy, then runs.
+/// Skips create + start. Starts bounded archive delivery, re-registers the
+/// proxy, fixes clock/entropy, then runs.
 pub(super) async fn execute_reused_sandbox(
     sandbox: Box<dyn Sandbox>,
     source_ip: &str,

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -44,7 +44,8 @@ use crate::network_log_manager::NetworkLogSession;
 use crate::provider::ConnectorRuntimeSyncRegistration;
 use crate::proxy;
 use crate::restored_session_identity::RestoredSessionIdentity;
-use crate::storage_cache::PreparedFreshStorage;
+use crate::storage_cache::PreparedStorage;
+use crate::storage_fingerprints::StorageFingerprints;
 use crate::storage_plan::build_storage_plan;
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, WorkspaceReuseResult};
@@ -394,24 +395,20 @@ pub(super) async fn execute_new_sandbox(
     .await
 }
 
-async fn prepare_fresh_storage(
+async fn prepare_storage(
     context: &ExecutionContext,
-    workspace_image: Option<&WorkspaceImageLease>,
+    previous_storage: Option<&StorageFingerprints>,
     config: &ExecutorConfig,
     cancel: &CancellationToken,
     telemetry: &mut JobTelemetry,
-) -> RunnerResult<Option<PreparedFreshStorage>> {
+) -> RunnerResult<Option<PreparedStorage>> {
     let Some(manifest) = &context.storage_manifest else {
         return Ok(None);
     };
     let apply_started = Instant::now();
-    let result: RunnerResult<Option<PreparedFreshStorage>> = async {
+    let result: RunnerResult<Option<PreparedStorage>> = async {
         let runtime_dir = super::guest_runtime_dir(context.run_id)?;
-        let plan = build_storage_plan(
-            manifest,
-            runtime_dir.as_str(),
-            workspace_image.and_then(WorkspaceImageLease::previous_storage),
-        )?;
+        let plan = build_storage_plan(manifest, runtime_dir.as_str(), previous_storage)?;
         let delivery = crate::storage_cache::prepare_fresh_archive_delivery(
             &plan,
             &config.home,
@@ -420,7 +417,7 @@ async fn prepare_fresh_storage(
             telemetry,
         )
         .await?;
-        Ok(Some(PreparedFreshStorage { plan, delivery }))
+        Ok(Some(PreparedStorage { plan, delivery }))
     }
     .await;
     if let Err(error) = &result {
@@ -504,9 +501,11 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         telemetry,
     )
     .await;
-    let prepared_storage = prepare_fresh_storage(
+    let prepared_storage = prepare_storage(
         context,
-        workspace_image.as_ref(),
+        workspace_image
+            .as_ref()
+            .and_then(WorkspaceImageLease::previous_storage),
         config,
         &controls.cancel,
         telemetry,
@@ -681,7 +680,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 None,
             );
             workspace_image = None;
-            match prepare_fresh_storage(context, None, config, &controls.cancel, telemetry).await {
+            match prepare_storage(context, None, config, &controls.cancel, telemetry).await {
                 Ok(prepared_storage) => controls.prepared_storage = prepared_storage,
                 Err(error) => {
                     if let Some(replacement) = dns_replacement.take() {
@@ -1417,7 +1416,7 @@ pub(super) async fn execute_reused_sandbox(
     config: &ExecutorConfig,
     prev_storage: &crate::storage_fingerprints::StorageFingerprints,
     telemetry: &mut JobTelemetry,
-    inputs: PreparedRunInputs,
+    mut inputs: PreparedRunInputs,
 ) -> ExecuteOutcome {
     info!(
         run_id = %context.run_id,
@@ -1427,30 +1426,49 @@ pub(super) async fn execute_reused_sandbox(
 
     let source_ip = source_ip.to_string();
     let prepare_started = Instant::now();
-    let network_log_session = match register_proxy(config, context, &source_ip).await {
-        Ok(session) => session,
-        Err(e) => {
+    let prepared_storage = prepare_storage(
+        context,
+        Some(prev_storage),
+        config,
+        &inputs.controls.cancel,
+        telemetry,
+    )
+    .await;
+    match prepared_storage {
+        Ok(prepared_storage) => inputs.controls.prepared_storage = prepared_storage,
+        Err(error) => {
             telemetry.record(
                 "runner_reused_sandbox_prepare",
                 prepare_started.elapsed(),
                 false,
-                Some(&e.to_string()),
+                Some(&error.to_string()),
             );
-            return ExecuteOutcome {
-                failure: Some(ExecutionFailure::from_error(e.to_string())),
-                active_input_delivery_ids: Vec::new(),
-                sandbox_reuse_disposition: SandboxReuseDisposition::default(),
-                sandbox: Some(sandbox),
+            return ExecuteOutcome::reused_sandbox_failure(
+                ExecutionFailure::from_error(error.to_string()),
+                sandbox,
                 source_ip,
-                network_log_session: None,
-                workspace_image: None,
-                workspace_reuse_result: None,
-                discovered_cli_agent_session_id: None,
-                restored_session_identity: None,
-            };
+                None,
+            );
+        }
+    }
+    let network_log_session = match register_proxy(config, context, &source_ip).await {
+        Ok(session) => session,
+        Err(error) => {
+            cancel_prepared_storage(&mut inputs.controls, telemetry).await;
+            telemetry.record(
+                "runner_reused_sandbox_prepare",
+                prepare_started.elapsed(),
+                false,
+                Some(&error.to_string()),
+            );
+            return ExecuteOutcome::reused_sandbox_failure(
+                ExecutionFailure::from_error(error.to_string()),
+                sandbox,
+                source_ip,
+                None,
+            );
         }
     };
-
     telemetry.record(
         "runner_reused_sandbox_prepare",
         prepare_started.elapsed(),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::executor::tests::support::RUN_IN_SANDBOX_TEST_TIMEOUT;
 use crate::executor::{SandboxReuseDisposition, SandboxReuseRejection};
+use httpmock::Method::GET;
+use httpmock::MockServer;
 
 fn capture_proxy_register_events(action: impl FnOnce()) -> Vec<CapturedEvent> {
     let captured = CapturedEvents::default();
@@ -186,29 +188,71 @@ async fn execute_job_proxy_register_failure_destroys_fresh_sandbox_before_agent_
 async fn execute_reused_sandbox_proxy_register_failure_returns_sandbox_before_agent_start() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
+    let registry_guard = crate::lock::acquire(dir.path().join("proxy-registry.json.lock"))
+        .await
+        .unwrap();
     tokio::fs::remove_file(dir.path().join("proxy-registry.json"))
         .await
         .unwrap();
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let source_ip = sandbox.source_ip().to_string();
-    let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
+    let server = MockServer::start_async().await;
+    let body = b"reused proxy failure".to_vec();
+    let full_get = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/reused-proxy-failure.tar.gz")
+                .header_missing("range");
+            then.status(200).body(body.clone());
+        })
+        .await;
+    let archive_url = server.url("/reused-proxy-failure.tar.gz");
+    let mut ctx = minimal_context();
+    let mut storage = api_storage("reused-proxy-failure", "/data", "v1", &archive_url);
+    storage.archive_size = Some(body.len() as u64);
+    ctx.storage_manifest = Some(StorageManifest {
+        storages: vec![storage],
+        artifacts: Vec::new(),
+    });
+    let storage_lock_path = config.home.storage_lock("reused-proxy-failure", "v1");
     let prev_storage = crate::storage_fingerprints::StorageFingerprints::default();
 
-    let outcome = execute_reused_sandbox(
-        sandbox,
-        &source_ip,
-        &ctx,
-        &config,
-        &prev_storage,
-        &mut telemetry,
-        PreparedRunInputs::new(
-            RunControls::new(tokio_util::sync::CancellationToken::new(), None),
-            prepare_run_payload_for_run(&ctx).unwrap(),
-        ),
-    )
-    .await;
+    let task = tokio::spawn(async move {
+        let mut telemetry = test_telemetry(&config, &ctx);
+        let outcome = execute_reused_sandbox(
+            sandbox,
+            &source_ip,
+            &ctx,
+            &config,
+            &prev_storage,
+            &mut telemetry,
+            PreparedRunInputs::new(
+                RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+                prepare_run_payload_for_run(&ctx).unwrap(),
+            ),
+        )
+        .await;
+        (outcome, telemetry)
+    });
+
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
+        while full_get.calls_async().await == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("archive request should start while proxy registration is blocked");
+    assert!(
+        !task.is_finished(),
+        "proxy lock should keep registration from completing"
+    );
+    drop(registry_guard);
+
+    let (outcome, telemetry) = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, task)
+        .await
+        .expect("proxy failure should drain prepared storage")
+        .expect("reused execution task should not panic");
 
     assert_eq!(outcome.exit_code(), 1);
     let error = outcome.error().unwrap();
@@ -218,10 +262,29 @@ async fn execute_reused_sandbox_proxy_register_failure_returns_sandbox_before_ag
     );
     assert!(outcome.sandbox.is_some());
     assert!(outcome.network_log_session.is_none());
+    full_get.assert_calls_async(1).await;
     assert!(
         overrides.start_agent_process_calls().is_empty(),
         "reused sandbox must not start an agent when proxy registration fails"
     );
+    assert_telemetry_action(
+        &telemetry,
+        "storage_cache_fresh_delivery_cancelled",
+        true,
+        None,
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "storage_cache_fresh_delivery_drained",
+        true,
+        None,
+    );
+    assert!(matches!(
+        crate::lock::try_acquire_or_busy(storage_lock_path)
+            .await
+            .unwrap(),
+        crate::lock::TryLock::Acquired(_)
+    ));
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -1,11 +1,27 @@
 use std::time::Duration;
 
 use super::*;
+use httpmock::Method::GET;
+use httpmock::MockServer;
 use tokio_util::sync::CancellationToken;
+
+use crate::executor::tests::support::RUN_IN_SANDBOX_TEST_TIMEOUT;
+use crate::types::ExecutionContext;
 
 // -----------------------------------------------------------------------
 // Keep-alive sandbox reuse integration tests
 // -----------------------------------------------------------------------
+
+fn context_with_remote_storage(archive_url: &str, archive_size: usize) -> ExecutionContext {
+    let mut context = minimal_context();
+    let mut storage = api_storage("reused-archive", "/data", "v1", archive_url);
+    storage.archive_size = Some(archive_size as u64);
+    context.storage_manifest = Some(StorageManifest {
+        storages: vec![storage],
+        artifacts: Vec::new(),
+    });
+    context
+}
 
 #[tokio::test]
 async fn execute_job_reuse_succeeds() {
@@ -99,6 +115,304 @@ async fn execute_job_reuse_bypasses_fresh_pre_spawn_admission() {
     assert_eq!(outcome.exit_code(), 0);
     assert_no_telemetry_action(&telemetry, "runner_fresh_pre_spawn_admission_wait");
     drop(holder);
+}
+
+#[tokio::test]
+async fn execute_job_reuse_stages_runner_owned_archive_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let registry_guard = crate::lock::acquire(dir.path().join("proxy-registry.json.lock"))
+        .await
+        .unwrap();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let source_ip = sandbox.source_ip().to_string();
+    let (idle_sandbox, _budget_lease) =
+        make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
+    let server = MockServer::start_async().await;
+    let body = b"reused archive".to_vec();
+    let full_get = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/reused-archive.tar.gz")
+                .header_missing("range");
+            then.status(200).body(body.clone());
+        })
+        .await;
+    let archive_url = server.url("/reused-archive.tar.gz");
+    let context = context_with_remote_storage(&archive_url, body.len());
+
+    let task = tokio::spawn(async move {
+        execute_job_reuse(
+            idle_sandbox,
+            context,
+            &config,
+            &default_params(),
+            CancellationToken::new(),
+        )
+        .await
+    });
+
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
+        while full_get.calls_async().await == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("archive request should start while reused proxy registration is blocked");
+    assert!(
+        !task.is_finished(),
+        "proxy lock should keep the reused run from reaching guest storage"
+    );
+    drop(registry_guard);
+
+    let (outcome, telemetry) = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, task)
+        .await
+        .expect("reused run should finish after proxy registration is released")
+        .expect("reused execution task should not panic");
+
+    assert_eq!(outcome.exit_code(), 0, "error={:?}", outcome.error());
+    full_get.assert_calls_async(1).await;
+    let writes = overrides.write_files_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].files.len(), 1);
+    assert_eq!(writes[0].files[0].content, body);
+    let manifests = overrides.storage_manifest_calls();
+    assert_eq!(manifests.len(), 1);
+    let manifest: guest_contracts::storage_manifest::Manifest =
+        serde_json::from_slice(&manifests[0].manifest_json).unwrap();
+    let staged_url = manifest.storages[0].archive_url.as_deref().unwrap();
+    assert!(staged_url.starts_with("file://"), "got: {staged_url}");
+    assert_ne!(staged_url, archive_url);
+    assert_telemetry_action(
+        &telemetry,
+        "storage_cache_fresh_delivery_single_request",
+        true,
+        None,
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "storage_cache_fresh_delivery_staged",
+        true,
+        None,
+    );
+}
+
+#[tokio::test]
+async fn execute_job_reuse_preserves_guest_fallback_after_runner_http_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let source_ip = sandbox.source_ip().to_string();
+    let (idle_sandbox, _budget_lease) =
+        make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
+    let server = MockServer::start_async().await;
+    let body = b"reused fallback".to_vec();
+    let full_get = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/reused-fallback.tar.gz")
+                .header_missing("range");
+            then.status(503);
+        })
+        .await;
+    let archive_url = server.url("/reused-fallback.tar.gz");
+    let context = context_with_remote_storage(&archive_url, body.len());
+
+    let (outcome, telemetry) = execute_job_reuse(
+        idle_sandbox,
+        context,
+        &config,
+        &default_params(),
+        CancellationToken::new(),
+    )
+    .await;
+
+    assert_eq!(outcome.exit_code(), 0, "error={:?}", outcome.error());
+    full_get.assert_calls_async(1).await;
+    assert!(overrides.write_files_calls().is_empty());
+    let manifests = overrides.storage_manifest_calls();
+    assert_eq!(manifests.len(), 1);
+    let manifest: guest_contracts::storage_manifest::Manifest =
+        serde_json::from_slice(&manifests[0].manifest_json).unwrap();
+    assert_eq!(
+        manifest.storages[0].archive_url.as_deref(),
+        Some(archive_url.as_str())
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "storage_cache_fresh_delivery_failed",
+        false,
+        Some("http-status"),
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "storage_cache_fresh_delivery_guest_fallback",
+        true,
+        Some("http-status"),
+    );
+    let operations = telemetry.pending_ops_snapshot();
+    let failed_index = operations
+        .iter()
+        .position(|(action, _, _)| action == "storage_cache_fresh_delivery_failed")
+        .unwrap();
+    let fallback_index = operations
+        .iter()
+        .position(|(action, _, _)| action == "storage_cache_fresh_delivery_guest_fallback")
+        .unwrap();
+    assert!(failed_index < fallback_index);
+}
+
+#[tokio::test]
+async fn execute_reused_sandbox_drains_archive_when_guest_state_restore_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let registry_guard = crate::lock::acquire(dir.path().join("proxy-registry.json.lock"))
+        .await
+        .unwrap();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_guest_state_restore_result(Err(sandbox_exec_error("restore failed")));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let source_ip = sandbox.source_ip().to_string();
+    let server = MockServer::start_async().await;
+    let body = b"reused restore failure".to_vec();
+    let full_get = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/reused-restore-failure.tar.gz")
+                .header_missing("range");
+            then.status(200).body(body.clone());
+        })
+        .await;
+    let archive_url = server.url("/reused-restore-failure.tar.gz");
+    let context = context_with_remote_storage(&archive_url, body.len());
+    let storage_lock_path = config.home.storage_lock("reused-archive", "v1");
+    let previous_storage = crate::storage_fingerprints::StorageFingerprints::default();
+
+    let task = tokio::spawn(async move {
+        let mut telemetry = test_telemetry(&config, &context);
+        let outcome = execute_reused_sandbox(
+            sandbox,
+            &source_ip,
+            &context,
+            &config,
+            &previous_storage,
+            &mut telemetry,
+            PreparedRunInputs::new(
+                RunControls::new(CancellationToken::new(), None),
+                prepare_run_payload_for_run(&context).unwrap(),
+            ),
+        )
+        .await;
+        (outcome, telemetry)
+    });
+
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
+        while full_get.calls_async().await == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("archive request should start before proxy registration completes");
+    assert!(
+        !task.is_finished(),
+        "proxy lock should keep reused preparation from reaching guest state restore"
+    );
+    drop(registry_guard);
+
+    let (outcome, telemetry) = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, task)
+        .await
+        .expect("guest state failure should drain prepared storage")
+        .expect("reused execution task should not panic");
+
+    assert_eq!(outcome.exit_code(), 1);
+    assert!(outcome.error().unwrap().contains("restore failed"));
+    full_get.assert_calls_async(1).await;
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert_telemetry_action(
+        &telemetry,
+        "storage_cache_fresh_delivery_cancelled",
+        true,
+        None,
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "storage_cache_fresh_delivery_drained",
+        true,
+        None,
+    );
+    assert!(matches!(
+        crate::lock::try_acquire_or_busy(storage_lock_path)
+            .await
+            .unwrap(),
+        crate::lock::TryLock::Acquired(_)
+    ));
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
+async fn execute_job_reuse_rejects_invalid_storage_plan_before_proxy_registration() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let source_ip = sandbox.source_ip().to_string();
+    let (idle_sandbox, _budget_lease) =
+        make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
+    let mut context = minimal_context();
+    let mut artifact = api_artifact(
+        "memory",
+        "/home/user/.claude/projects/project",
+        "storage-id-1",
+        "version-2",
+        "https://storage.example/artifact.tar.gz",
+    );
+    artifact.archive_url = None;
+    context.storage_manifest = Some(StorageManifest {
+        storages: Vec::new(),
+        artifacts: vec![artifact],
+    });
+
+    let (outcome, telemetry) = execute_job_reuse(
+        idle_sandbox,
+        context,
+        &config,
+        &default_params(),
+        CancellationToken::new(),
+    )
+    .await;
+
+    assert_eq!(outcome.exit_code(), 1);
+    let error = outcome.error().unwrap();
+    assert!(error.contains("missing archiveUrl"), "got: {error}");
+    assert!(outcome.network_log_session.is_none());
+    assert!(overrides.start_agent_process_calls().is_empty());
+    let registry: serde_json::Value = serde_json::from_str(
+        &tokio::fs::read_to_string(dir.path().join("proxy-registry.json"))
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(registry["updatedAt"], 0);
+    assert_eq!(
+        registry["sandboxes"]
+            .as_object()
+            .map(|entries| entries.len()),
+        Some(0)
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_storage_manifest_apply",
+        false,
+        Some(error),
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_reused_sandbox_prepare",
+        false,
+        Some(error),
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -12,13 +12,12 @@
 //! so `guest-download` reads the guest-local staged archive instead of
 //! re-fetching.
 //!
-//! Eligible fresh sandbox attempts can assign bounded cold identities
-//! to a runner owner before sandbox creation. That owner performs one full
-//! request, keeps the cache writer through atomic publication and the
-//! runner-wide permit through guest application, and stages only complete
-//! content. A terminal owner is drained before the unchanged remote URL is
-//! allowed to fall back to guest download.
-//! Reused live sandboxes continue through the ordinary guest-owned path.
+//! Eligible fresh and reused sandbox attempts can assign bounded cold
+//! identities to a runner owner before independent pre-spawn preparation.
+//! That owner performs one full request, keeps the cache writer through atomic
+//! publication and the runner-wide permit through guest application, and
+//! stages only complete content. A terminal owner is drained before the
+//! unchanged remote URL is allowed to fall back to guest download.
 //! Keying on both name and version gives same-version entries with different
 //! storage names separate collision-resistant staged filenames in normal
 //! operation, so they do not clobber each other on the guest tmpfs.
@@ -263,7 +262,7 @@ impl FreshDeliveryScanSummary {
     }
 }
 
-/// Runner-wide admission control for fresh archive delivery.
+/// Runner-wide admission control for bounded archive delivery.
 ///
 /// Clones share one semaphore, so concurrent executor attempts draw from the
 /// same `FRESH_DELIVERY_RUNNER_LIMIT`. For an admitted archive, the owned

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -874,14 +874,14 @@ impl FreshArchiveDelivery {
             if let Err(error) = result
                 && !error.is_cancelled()
             {
-                warn!(%error, "fresh archive fetch task failed while draining");
+                warn!(%error, "runner-owned archive fetch task failed while draining");
             }
         }
         // Once a complete response enters publication, wait for the atomic
         // cache transaction even when the run itself has been cancelled.
         while let Some(result) = self.publications.join_next().await {
             if let Err(error) = result {
-                warn!(%error, "fresh archive publication task failed while draining");
+                warn!(%error, "runner-owned archive publication task failed while draining");
             }
         }
         if had_owned_work {
@@ -906,7 +906,7 @@ impl FreshArchiveDelivery {
         let mut resolved = Vec::new();
         while let Some(task) = self.fetches.join_next().await {
             match task.map_err(|error| {
-                RunnerError::Internal(format!("fresh archive fetch task: {error}"))
+                RunnerError::Internal(format!("runner-owned archive fetch task: {error}"))
             })? {
                 FreshArchiveFetchTaskResult::Downloaded(downloaded) => {
                     telemetry.record(
@@ -936,7 +936,7 @@ impl FreshArchiveDelivery {
                         None,
                     );
                     let target = group.targets.first().ok_or_else(|| {
-                        RunnerError::Internal("empty fresh archive target group".to_string())
+                        RunnerError::Internal("empty runner-owned archive target group".to_string())
                     })?;
                     let cache_dir = home.storage_cache_dir(&target.name, &target.version);
                     self.publications.spawn(async move {
@@ -961,7 +961,7 @@ impl FreshArchiveDelivery {
 
         while let Some(task) = self.publications.join_next().await {
             let task = task.map_err(|error| {
-                RunnerError::Internal(format!("fresh archive publication task: {error}"))
+                RunnerError::Internal(format!("runner-owned archive publication task: {error}"))
             })?;
             match task.result {
                 Ok(archive) => {
@@ -1495,7 +1495,7 @@ async fn stage_fresh_archives(
             FreshArchiveResolved::Ready { group, archive } => {
                 let FreshArchivePublished { bytes, permit } = archive;
                 let target = group.targets.first().ok_or_else(|| {
-                    RunnerError::Internal("empty fresh archive target group".to_string())
+                    RunnerError::Internal("empty runner-owned archive target group".to_string())
                 })?;
                 let write = GuestStageWrite {
                     guest_path: guest_archive_path(&target.name, &target.version),
@@ -1938,7 +1938,7 @@ pub(crate) async fn prepare_fresh_archive_delivery(
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(|error| {
-                RunnerError::Internal(format!("build fresh archive client: {error}"))
+                RunnerError::Internal(format!("build runner-owned archive client: {error}"))
             })?;
 
         let mut scanned = 0;
@@ -1978,7 +1978,7 @@ pub(crate) async fn prepare_fresh_archive_delivery(
                 }
             };
             let target = group.targets.first().ok_or_else(|| {
-                RunnerError::Internal("empty fresh archive target group".to_string())
+                RunnerError::Internal("empty runner-owned archive target group".to_string())
             })?;
             let lock_path = home.storage_lock(&target.name, &target.version);
             let cache_dir = home.storage_cache_dir(&target.name, &target.version);
@@ -2102,8 +2102,8 @@ pub(crate) async fn prepare_fresh_archive_delivery(
     Ok(delivery)
 }
 
-/// Fresh storage delivery uses the shared bounded timeout and falls back to
-/// guest-download when its best-effort request cannot complete successfully.
+/// Runner-owned archive delivery uses the shared bounded timeout and falls
+/// back to guest-download when its best-effort request cannot complete.
 async fn fetch_fresh_archive(
     http: &Client,
     archive_url: &str,

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -801,11 +801,12 @@ enum FreshArchiveResolved {
     },
 }
 
-/// In-flight runner ownership for archives selected from one fresh storage plan.
+/// In-flight runner ownership for archives selected from one storage plan.
 ///
-/// Fetch tasks start before sandbox creation, but a completed fetch waits on
-/// its apply gate until guest storage application resolves this delivery. The
-/// delivery then owns any atomic cache publication tasks until they finish.
+/// Fetch tasks start during fresh or reused pre-spawn preparation, but a
+/// completed fetch waits on its apply gate until guest storage application
+/// resolves this delivery. The delivery then owns any atomic cache publication
+/// tasks until they finish.
 ///
 /// Callers must either pass this value with its original plan to
 /// `populate_cache_with_fresh_delivery` or call
@@ -820,13 +821,13 @@ pub(crate) struct FreshArchiveDelivery {
     publications: JoinSet<FreshArchivePublicationTaskResult>,
 }
 
-/// A fresh storage plan paired with the delivery prepared for its plan inputs.
+/// A storage plan paired with the delivery prepared for its plan inputs.
 ///
 /// The plan and delivery must remain together. A retry that changes the
 /// workspace-image selection must drain the previous delivery and rebuild both
 /// values; a retry such as DNS-only sandbox replacement may retain the pair
 /// when the plan inputs are unchanged.
-pub(crate) struct PreparedFreshStorage {
+pub(crate) struct PreparedStorage {
     pub(crate) plan: StoragePlan,
     pub(crate) delivery: FreshArchiveDelivery,
 }
@@ -1890,13 +1891,14 @@ fn collect_targets(plan: &StoragePlan) -> Vec<CacheTarget> {
         .collect()
 }
 
-/// Starts bounded runner-owned archive delivery for one fresh storage plan.
+/// Starts bounded runner-owned archive delivery for one storage plan.
 ///
-/// The executor calls this after workspace-image selection fixes the plan and
-/// before sandbox creation, allowing eligible full-archive fetches to overlap
-/// sandbox startup. Preparation examines at most `FRESH_DELIVERY_SCAN_LIMIT` target
-/// groups, admits at most `FRESH_DELIVERY_PER_RUN_LIMIT`, and draws each
-/// admission from the shared `FRESH_DELIVERY_RUNNER_LIMIT`.
+/// The executor calls this after previous-storage selection fixes the plan and
+/// before fresh or reused sandbox preparation, allowing eligible full-archive
+/// fetches to overlap pre-spawn work. Preparation examines at most
+/// `FRESH_DELIVERY_SCAN_LIMIT` target groups, admits at most
+/// `FRESH_DELIVERY_PER_RUN_LIMIT`, and draws each admission from the shared
+/// `FRESH_DELIVERY_RUNNER_LIMIT`.
 ///
 /// Each admitted group acquires its cache-writer flock before fetching. After
 /// validating a complete response, the fetch waits on a one-shot apply gate;


### PR DESCRIPTION
## Summary

- build the existing bounded archive-delivery owner from authoritative reused-sandbox storage
  fingerprints before proxy registration
- carry the paired storage plan and owner through the existing guest-storage consumer, preserving
  one-request ownership and direct HTTPS fallback
- cancel and drain prepared archive work when reused proxy or guest-runtime preparation fails
- add reused entry-point integration coverage for overlap, local rewrite, fallback ordering,
  invalid plans, and cleanup

## Scope

This changes only the Runner-internal reused pre-spawn lifecycle. It does not change archive limits,
admission bounds, cache identity or format, API/queue payloads, storage manifests, guest protocols,
persisted state, or the established `storage_cache_fresh_delivery_*` telemetry names.

## Controlled gate

The same-host optimized gate passed on `local-11.gcp.vm3.ai` with 100 post-warm-up samples per arm:
eligible remote p90 improved from 300.383 ms to 167.058 ms, remote p99 improved from 309.341 ms to
178.742 ms, warm/no-remote p95 and p99 did not regress, 210 eligible executions produced exactly
210 full GETs, and open file descriptors remained 15 before and after. Full method, resource, and
control results are recorded in the
[issue gate comment](https://github.com/vm0-ai/vm0/issues/31407#issuecomment-5523902731).

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p runner --all-targets --all-features`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p runner --no-deps --all-features`
- `cargo test -p runner` (3425 passed, 25 ignored, 0 failed; guest inventory 1 passed)
- `cargo build -p runner --all-features`
- pre-commit cargo format, workspace rustdoc, workspace Clippy, file-size, and commitlint hooks
- same-host optimized controlled gate plus fresh-delivery, reuse, and proxy-failure control tests

Closes #31407

Parent context: #24203
