### PR TITLE
fix(platform): prevent unsolicited video openings and endings

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/intro-video.ts
+++ b/turbo/apps/platform/src/signals/okou-page/intro-video.ts
@@ -188,7 +188,8 @@ function buildIntroVideoPrompt(args: {
   };
   const instructions = args.instructions.trim();
   return [
-    "Create a polished intro video from the attached source.",
+    "Create a polished video from the attached source.",
+    "Do not add an opening or ending unless the user explicitly requests them.",
     "",
     "Configuration:",
     `- Source: ${args.source.name}`,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-start-cards.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-start-cards.test.tsx
@@ -292,7 +292,10 @@ describe("chat start cards", () => {
     await expect(screen.findByLabelText("Stop")).resolves.toBeInTheDocument();
     await waitFor(() => {
       expect(sentPrompt).toContain(
-        "Create a polished intro video from the attached source.",
+        "Create a polished video from the attached source.",
+      );
+      expect(sentPrompt).toContain(
+        "Do not add an opening or ending unless the user explicitly requests them.",
       );
       expect(sentPrompt).toContain("- Source: launch.pdf");
       expect(sentPrompt).toContain("- Avatar: Amara (1785)");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/prompt-param-injection.test.tsx
@@ -303,6 +303,12 @@ describe("prompt query parameter injection", () => {
     await user.click(buttonWithText("Create in chat", dialog));
 
     await waitFor(() => {
+      expect(sentPrompt).toContain(
+        "Create a polished video from the attached source.",
+      );
+      expect(sentPrompt).toContain(
+        "Do not add an opening or ending unless the user explicitly requests them.",
+      );
       expect(sentPrompt).toContain("- Source: demo.mp4");
       expect(sentPrompt).toContain("- Source type: video");
       // A take from the recorder is edited by the click-driven camera pass, not


### PR DESCRIPTION
## Summary

- rename the generated request from "polished intro video" to "polished video"
- prohibit adding an opening or ending unless the user explicitly requests them
- cover both slide-deck and screen-recording submission paths with integration assertions

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/okou-page/intro-video.ts apps/platform/src/views/okou-page/__tests__/chat-start-cards.test.tsx apps/platform/src/views/okou-page/__tests__/prompt-param-injection.test.tsx`
- `pnpm --filter @okouai/app run lint`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-start-cards.test.tsx`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/prompt-param-injection.test.tsx`
