### PR TITLE
feat(platform): gate chat thinking spinner for staff

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -304,6 +304,11 @@ body {
   animation: zero-thinking-in 0.3s ease-out;
 }
 
+.zero-thinking-spinner {
+  animation-duration: 1.4s;
+  will-change: transform;
+}
+
 @keyframes zero-chat-skeleton-reveal {
   to {
     opacity: 1;
@@ -1948,6 +1953,7 @@ html:has(.zero-dialog-overlay)
     .zero-shimmer-window,
     .zero-shimmer-highlight,
     .zero-blocks span,
+    .zero-thinking-spinner,
     .mic-starting-spinner,
     .owf-diagram-beam
   ):not(.zero-dialog-content *) {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thinking-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thinking-indicator.test.tsx
@@ -168,37 +168,34 @@ describe("chat thinking indicator", () => {
     await setupThinkingRun();
 
     expect(
-      document.querySelector("[data-thinking-indicator] .zero-blocks"),
+      document.querySelector(
+        '[data-thinking-indicator] [data-thinking-loader="blocks"]',
+      ),
     ).toBeInTheDocument();
     expect(
       document.querySelector(
-        "[data-thinking-indicator] .zero-thinking-spinner",
+        '[data-thinking-indicator] [data-thinking-loader="spinner"]',
       ),
     ).not.toBeInTheDocument();
   });
 
-  it("uses the rotating Okou mark for the active-run loader", async () => {
+  it("uses the Okou mark for the active-run loader", async () => {
     await setupThinkingRun({
       [FeatureSwitchKey.ChatThinkingSpinner]: true,
     });
 
-    const spinnerFrame = document.querySelector<HTMLElement>(
-      "[data-thinking-indicator] .zero-thinking-spinner-frame",
+    const spinner = document.querySelector<HTMLImageElement>(
+      '[data-thinking-indicator] [data-thinking-loader="spinner"] img',
     );
-    const spinner = spinnerFrame?.querySelector<HTMLImageElement>(
-      "img.zero-thinking-spinner",
-    );
-    expect(spinnerFrame).toHaveClass("size-[11.5px]");
     expect(spinner).toHaveAttribute(
       "src",
       "https://static.vm0.io/public/okou-transparent.svg",
     );
-    expect(spinner).toHaveClass(
-      "size-3.5",
-      "max-w-none",
-      "animate-spin",
-      "motion-reduce:animate-none",
-    );
+    expect(
+      document.querySelector(
+        '[data-thinking-indicator] [data-thinking-loader="blocks"]',
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("discards an overflowing line remainder before showing the next explicit line", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-thinking-indicator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-thinking-indicator.test.tsx
@@ -1,4 +1,5 @@
 import { waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it, vi } from "vitest";
 import { setupPageAndWaitForContent } from "../../../__tests__/page-helper.ts";
 import { context } from "./chat-lifecycle-test-helpers.ts";
@@ -106,7 +107,9 @@ function recordRenderedLabelText(): string[] {
   return rendered;
 }
 
-async function setupThinkingRun(): Promise<string[]> {
+async function setupThinkingRun(
+  featureSwitches: Partial<Record<FeatureSwitchKey, boolean>> = {},
+): Promise<string[]> {
   stubLabelTextMeasurement();
   mockChatLifecycle(context, {
     threadId: THREAD_ID,
@@ -143,6 +146,7 @@ async function setupThinkingRun(): Promise<string[]> {
   await setupPageAndWaitForContent({
     context,
     path: `/chats/${THREAD_ID}`,
+    featureSwitches,
   });
   return rendered;
 }
@@ -160,6 +164,43 @@ async function waitForTypedLines(rendered: readonly string[]): Promise<void> {
 }
 
 describe("chat thinking indicator", () => {
+  it("keeps the three-block loader when the spinner switch is off", async () => {
+    await setupThinkingRun();
+
+    expect(
+      document.querySelector("[data-thinking-indicator] .zero-blocks"),
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector(
+        "[data-thinking-indicator] .zero-thinking-spinner",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the rotating Okou mark for the active-run loader", async () => {
+    await setupThinkingRun({
+      [FeatureSwitchKey.ChatThinkingSpinner]: true,
+    });
+
+    const spinnerFrame = document.querySelector<HTMLElement>(
+      "[data-thinking-indicator] .zero-thinking-spinner-frame",
+    );
+    const spinner = spinnerFrame?.querySelector<HTMLImageElement>(
+      "img.zero-thinking-spinner",
+    );
+    expect(spinnerFrame).toHaveClass("size-[11.5px]");
+    expect(spinner).toHaveAttribute(
+      "src",
+      "https://static.vm0.io/public/okou-transparent.svg",
+    );
+    expect(spinner).toHaveClass(
+      "size-3.5",
+      "max-w-none",
+      "animate-spin",
+      "motion-reduce:animate-none",
+    );
+  });
+
   it("discards an overflowing line remainder before showing the next explicit line", async () => {
     const rendered = await setupThinkingRun();
     await waitForTypedLines(rendered);

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -4812,6 +4812,7 @@ function ThinkingLoader({
     return (
       <span
         aria-hidden
+        data-thinking-loader="spinner"
         className="zero-thinking-spinner-frame inline-flex size-[11.5px] shrink-0 items-center justify-center"
       >
         <img
@@ -4824,7 +4825,11 @@ function ThinkingLoader({
   }
 
   return (
-    <span className="zero-blocks shrink-0" style={blockStyle}>
+    <span
+      data-thinking-loader="blocks"
+      className="zero-blocks shrink-0"
+      style={blockStyle}
+    >
       <span />
       <span />
       <span />

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -109,7 +109,7 @@ import type {
   WorkflowSchedule,
 } from "@okouai/api-contracts/contracts/workflows";
 import { getModelDisplayName } from "@okouai/core/model-display-name";
-import { emptyChatImg } from "./platform-assets.ts";
+import { emptyChatImg, thinkingSpinnerImg } from "./platform-assets.ts";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { isMobileTextInputDevice } from "../../lib/visual-viewport-keyboard.ts";
 import { Markdown, MarkdownEventBody } from "../components/markdown.tsx";
@@ -4801,24 +4801,53 @@ function ThinkingLabel({
   return <ShimmerText>{thinkingLabel}</ShimmerText>;
 }
 
+function ThinkingLoader({
+  blockStyle,
+  spinnerEnabled,
+}: {
+  blockStyle: CSSProperties;
+  spinnerEnabled: boolean;
+}) {
+  if (spinnerEnabled) {
+    return (
+      <span
+        aria-hidden
+        className="zero-thinking-spinner-frame inline-flex size-[11.5px] shrink-0 items-center justify-center"
+      >
+        <img
+          src={thinkingSpinnerImg}
+          alt=""
+          className="zero-thinking-spinner size-3.5 max-w-none shrink-0 animate-spin motion-reduce:animate-none"
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span className="zero-blocks shrink-0" style={blockStyle}>
+      <span />
+      <span />
+      <span />
+    </span>
+  );
+}
+
 function InlineThinkingRow({
   blockStyle,
   isQueued,
+  spinnerEnabled,
   thinkingLabel,
   serverThinkingLabel,
 }: {
   blockStyle: CSSProperties;
   isQueued: boolean;
+  spinnerEnabled: boolean;
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
 }) {
   return (
     <div className="flex items-center gap-2 h-5">
-      <span className="zero-blocks shrink-0" style={blockStyle}>
-        <span />
-        <span />
-        <span />
-      </span>
+      <ThinkingLoader blockStyle={blockStyle} spinnerEnabled={spinnerEnabled} />
       <ThinkingLabel
         isQueued={isQueued}
         thinkingLabel={thinkingLabel}
@@ -4877,6 +4906,7 @@ function WaitingForAssistantResponse({
   thread,
   blockStyle,
   isQueued,
+  spinnerEnabled,
   thinkingLabel,
   serverThinkingLabel,
   runGroupFolds,
@@ -4884,6 +4914,7 @@ function WaitingForAssistantResponse({
   thread: ChatPanelSignals;
   blockStyle: CSSProperties;
   isQueued: boolean;
+  spinnerEnabled: boolean;
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
   runGroupFolds: readonly RunGroupFoldControl[];
@@ -4908,11 +4939,10 @@ function WaitingForAssistantResponse({
           })}
           <div className="zero-chat-bubble-assistant min-w-0 overflow-hidden rounded-xl py-4 text-[0.9375rem] leading-[1.7]">
             <div className="flex h-5 min-w-0 items-center gap-2">
-              <span className="zero-blocks shrink-0" style={blockStyle}>
-                <span />
-                <span />
-                <span />
-              </span>
+              <ThinkingLoader
+                blockStyle={blockStyle}
+                spinnerEnabled={spinnerEnabled}
+              />
               <ThinkingLabel
                 isQueued={isQueued}
                 thinkingLabel={thinkingLabel}
@@ -4937,6 +4967,7 @@ function AssistantThinkingStatusRow({
   active,
   blockStyle,
   isQueued,
+  spinnerEnabled,
   thinkingLabel,
   serverThinkingLabel,
   thread,
@@ -4945,6 +4976,7 @@ function AssistantThinkingStatusRow({
   active: boolean;
   blockStyle: CSSProperties;
   isQueued: boolean;
+  spinnerEnabled: boolean;
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
   thread: ChatPanelSignals;
@@ -4965,6 +4997,7 @@ function AssistantThinkingStatusRow({
           <InlineThinkingRow
             blockStyle={blockStyle}
             isQueued={isQueued}
+            spinnerEnabled={spinnerEnabled}
             thinkingLabel={thinkingLabel}
             serverThinkingLabel={serverThinkingLabel}
           />
@@ -5010,8 +5043,11 @@ function ThinkingIndicator({
   mode: ThinkingIndicatorMode;
   runGroupFolds: readonly RunGroupFoldControl[];
 }) {
+  const featureSwitches = useGet(featureSwitch$);
   const runWorkFoldingEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
+    featureSwitches[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
+  const spinnerEnabled =
+    featureSwitches[FeatureSwitchKey.ChatThinkingSpinner] ?? false;
   const [c1, c2, c3] = useGet(thread.blockColors$);
   const blockStyle = {
     "--zb-c1": c1,
@@ -5061,6 +5097,7 @@ function ThinkingIndicator({
         active={active}
         blockStyle={blockStyle}
         isQueued={isQueued}
+        spinnerEnabled={spinnerEnabled}
         thinkingLabel={thinkingLabel}
         serverThinkingLabel={serverThinkingLabel}
         thread={thread}
@@ -5075,6 +5112,7 @@ function ThinkingIndicator({
       thread={thread}
       blockStyle={blockStyle}
       isQueued={isQueued}
+      spinnerEnabled={spinnerEnabled}
       thinkingLabel={thinkingLabel}
       serverThinkingLabel={serverThinkingLabel}
       runGroupFolds={runGroupFolds}

--- a/turbo/apps/platform/src/views/okou-page/platform-assets.ts
+++ b/turbo/apps/platform/src/views/okou-page/platform-assets.ts
@@ -1,4 +1,7 @@
-import { platformStaticAssetUrl } from "../../lib/static-assets.ts";
+import {
+  platformPublicStaticUrl,
+  platformStaticAssetUrl,
+} from "../../lib/static-assets.ts";
 
 function pageAssetUrl(path: string): string {
   return platformStaticAssetUrl(`views/zero-page/${path.replace(/^\/+/u, "")}`);
@@ -21,6 +24,9 @@ export const emptyUsageImg = pageAssetUrl(
 );
 export const emptySearchImg = pageAssetUrl(
   "assets/empty-search-b4e60a8e07b8.webp",
+);
+export const thinkingSpinnerImg = platformPublicStaticUrl(
+  "https://static.vm0.io/public/okou-transparent.svg",
 );
 export const computerUseIllustrationImg = pageAssetUrl(
   "assets/computer-use-illustration-eecea534a3ac.png?v=568fa471",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -181,6 +181,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.BatchChatEventCatchUp]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatRunWorkFolding]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ChatThinkingSpinner]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiMemoryRecall]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiMemoryGeneration]).toBe(true);
@@ -209,6 +210,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.BatchChatEventCatchUp]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatRunWorkFolding]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ChatThinkingSpinner]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiMemoryRecall]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiMemoryGeneration]).toBe(false);

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -53,6 +53,7 @@ export enum FeatureSwitchKey {
   ChatErrorRecovery = "chatErrorRecovery",
   BatchChatEventCatchUp = "batchChatEventCatchUp",
   ChatRunWorkFolding = "chatRunWorkFolding",
+  ChatThinkingSpinner = "chatThinkingSpinner",
   FollowUpOptimize = "followUpOptimize",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   SidebarSubscriptionUsage = "_sidebarSubscriptionUsage",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -396,6 +396,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ChatThinkingSpinner]: {
+    maintainer: "yuma@vm0.ai",
+    description:
+      "Replace the three-block chat thinking loader with a rotating Okou mark.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ComposerImageAnnotation]: {
     maintainer: "tongx@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add the `chatThinkingSpinner` feature switch, disabled globally and enabled for staff organizations
- replace the three-block chat thinking loader with the rotating Okou mark while preserving the original 11.5px layout footprint
- keep the legacy loader when the switch is off and cover both rollout branches in page-level tests

## Verification

- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (31 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-thinking-indicator.test.tsx` (4 passed)
- `pnpm format`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm turbo run lint --concurrency=1 --log-order grouped` (14 tasks successful)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (13 tasks successful)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
