### PR TITLE
perf(runner): expose finalizing reuse miss reasons

### DIFF
--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -63,16 +63,16 @@ use super::idle_lifecycle::{
 use super::job_discovery::{
     ClaimedActivationGuard, ClaimedJobSetup, FinalizingAdmission, ReadyClaimedResource,
     ReservedActivation, ReservedActivationRequest, activate_reserved_idle, build_spawn_job_request,
-    reserve_reusable_idle_for_spawn, rollback_reserved_idle_for_spawn,
+    reserve_exact_idle_for_spawn, rollback_reserved_idle_for_spawn,
 };
 use super::job_spawn::{SpawnContext, run_job};
 #[cfg(test)]
 use super::{OuterJobPanicPoint, maybe_panic_outer_job};
 use crate::executor::{
-    ExecutionFailure, FinalizingHandoffOutcome, RunnerPreSpawnPhase, RunnerPreSpawnTiming,
-    validate_resume_session_id,
+    ExecutionFailure, FinalizingDiagnostics, FinalizingExactIdleLookup, FinalizingHandoffOutcome,
+    FinalizingHandoffReason, RunnerPreSpawnPhase, RunnerPreSpawnTiming, validate_resume_session_id,
 };
-use crate::idle_pool::FinalizingHandoffCandidate;
+use crate::idle_pool::{ExactIdleReservationMiss, FinalizingHandoffCandidate};
 use crate::ids::RunId;
 use crate::provider::ClaimedJob;
 use crate::resource_budget::{BudgetLease, ResourceBudget};
@@ -101,16 +101,18 @@ enum FinalizingWaitOutcome {
     Handoff(Box<FinalizingHandoffCandidate>),
     Exact(ReservedIdleActivation),
     Fallback {
-        reason: &'static str,
+        reason: FinalizingHandoffReason,
+        exact_lookup_miss: Option<ExactIdleReservationMiss>,
         handoff_outcome: FinalizingHandoffOutcome,
     },
     Cancelled(Option<Box<FinalizingHandoffCandidate>>),
 }
 
 impl FinalizingWaitOutcome {
-    fn no_exact(reason: &'static str) -> Self {
+    fn no_exact(reason: FinalizingHandoffReason) -> Self {
         Self::Fallback {
             reason,
+            exact_lookup_miss: None,
             handoff_outcome: FinalizingHandoffOutcome::NoExact,
         }
     }
@@ -124,6 +126,11 @@ enum FinalizingResource {
     Handoff(Box<FinalizingHandoffCandidate>),
     Exact(ReservedIdleActivation),
     Fresh(BudgetLease),
+}
+
+enum FallbackExactLookup {
+    Hit(ReservedIdleActivation),
+    Miss(ExactIdleReservationMiss),
 }
 
 struct FinalizingPreparation<'a> {
@@ -222,7 +229,7 @@ async fn run_finalizing_claim(
                 cancellation,
                 *failure,
                 None,
-                pre_spawn_timing.finalizing_handoff_outcome(),
+                pre_spawn_timing.finalizing_diagnostics(),
                 &ctx,
             )
             .await;
@@ -238,7 +245,7 @@ async fn run_finalizing_claim(
                     "runner panicked while preparing a claimed finalizing successor",
                 ),
                 None,
-                pre_spawn_timing.finalizing_handoff_outcome(),
+                pre_spawn_timing.finalizing_diagnostics(),
                 &ctx,
             )
             .await;
@@ -268,14 +275,16 @@ async fn run_finalizing_claim(
                 drop(transfer_guard);
                 drop(active_run_guard);
                 rollback_reserved_idle_for_spawn(reservation, &ctx).await;
-                pre_spawn_timing
-                    .record_finalizing_handoff_outcome(FinalizingHandoffOutcome::ActivationFailed);
+                pre_spawn_timing.record_finalizing_handoff(
+                    FinalizingHandoffOutcome::ActivationFailed,
+                    Some(FinalizingHandoffReason::ActivationCancelled),
+                );
                 return complete_claimed_without_sandbox(
                     claimed,
                     cancellation,
                     ExecutionFailure::cancelled(),
                     None,
-                    pre_spawn_timing.finalizing_handoff_outcome(),
+                    pre_spawn_timing.finalizing_diagnostics(),
                     &ctx,
                 )
                 .await;
@@ -302,8 +311,9 @@ async fn run_finalizing_claim(
                     idle_snapshot,
                 } => {
                     if reuse_entry.is_none() {
-                        pre_spawn_timing.record_finalizing_handoff_outcome(
+                        pre_spawn_timing.record_finalizing_handoff(
                             FinalizingHandoffOutcome::ActivationFailed,
+                            Some(FinalizingHandoffReason::ExactActivationFallback),
                         );
                     }
                     ReadyClaimedResource {
@@ -320,15 +330,16 @@ async fn run_finalizing_claim(
                 } => {
                     drop(activation_transfer_guard.take());
                     drop(active_run_guard);
-                    pre_spawn_timing.record_finalizing_handoff_outcome(
+                    pre_spawn_timing.record_finalizing_handoff(
                         FinalizingHandoffOutcome::ActivationFailed,
+                        Some(FinalizingHandoffReason::ExactActivationFailed),
                     );
                     let cancellation = complete_claimed_without_sandbox(
                         claimed,
                         cancellation,
                         ExecutionFailure::from_error(error),
                         Some(reuse_result),
-                        pre_spawn_timing.finalizing_handoff_outcome(),
+                        pre_spawn_timing.finalizing_diagnostics(),
                         &ctx,
                     )
                     .await;
@@ -348,8 +359,9 @@ async fn run_finalizing_claim(
                             .run_with_context("finalizing_handoff_identity_mismatch")
                             .await;
                         ctx.reuse_state_notify.notify_one();
-                        pre_spawn_timing.record_finalizing_handoff_outcome(
+                        pre_spawn_timing.record_finalizing_handoff(
                             FinalizingHandoffOutcome::ActivationFailed,
+                            Some(FinalizingHandoffReason::HandoffIdentityMismatch),
                         );
                         return complete_claimed_without_sandbox(
                             claimed,
@@ -358,7 +370,7 @@ async fn run_finalizing_claim(
                                 "finalizing handoff identity did not match claimed successor",
                             ),
                             None,
-                            pre_spawn_timing.finalizing_handoff_outcome(),
+                            pre_spawn_timing.finalizing_diagnostics(),
                             &ctx,
                         )
                         .await;
@@ -371,14 +383,16 @@ async fn run_finalizing_claim(
                 drop(transfer_guard);
                 drop(active_run_guard);
                 rollback_reserved_idle_for_spawn(reservation, &ctx).await;
-                pre_spawn_timing
-                    .record_finalizing_handoff_outcome(FinalizingHandoffOutcome::ActivationFailed);
+                pre_spawn_timing.record_finalizing_handoff(
+                    FinalizingHandoffOutcome::ActivationFailed,
+                    Some(FinalizingHandoffReason::ActivationCancelled),
+                );
                 return complete_claimed_without_sandbox(
                     claimed,
                     cancellation,
                     ExecutionFailure::cancelled(),
                     None,
-                    pre_spawn_timing.finalizing_handoff_outcome(),
+                    pre_spawn_timing.finalizing_diagnostics(),
                     &ctx,
                 )
                 .await;
@@ -404,11 +418,15 @@ async fn run_finalizing_claim(
                     reuse_result,
                     idle_snapshot,
                 } => {
-                    pre_spawn_timing.record_finalizing_handoff_outcome(if reuse_entry.is_some() {
-                        FinalizingHandoffOutcome::Accepted
+                    if reuse_entry.is_some() {
+                        pre_spawn_timing
+                            .record_finalizing_handoff_outcome(FinalizingHandoffOutcome::Accepted);
                     } else {
-                        FinalizingHandoffOutcome::ActivationFailed
-                    });
+                        pre_spawn_timing.record_finalizing_handoff(
+                            FinalizingHandoffOutcome::ActivationFailed,
+                            Some(FinalizingHandoffReason::ExactActivationFallback),
+                        );
+                    }
                     ReadyClaimedResource {
                         reuse_entry: reuse_entry.map(|entry| *entry),
                         active_lease,
@@ -423,15 +441,16 @@ async fn run_finalizing_claim(
                 } => {
                     drop(activation_transfer_guard.take());
                     drop(active_run_guard);
-                    pre_spawn_timing.record_finalizing_handoff_outcome(
+                    pre_spawn_timing.record_finalizing_handoff(
                         FinalizingHandoffOutcome::ActivationFailed,
+                        Some(FinalizingHandoffReason::ExactActivationFailed),
                     );
                     let cancellation = complete_claimed_without_sandbox(
                         claimed,
                         cancellation,
                         ExecutionFailure::from_error(error),
                         Some(reuse_result),
-                        pre_spawn_timing.finalizing_handoff_outcome(),
+                        pre_spawn_timing.finalizing_diagnostics(),
                         &ctx,
                     )
                     .await;
@@ -551,29 +570,38 @@ async fn prepare_finalizing_resource(
         FinalizingWaitOutcome::Exact(reservation) => {
             pre_spawn_timing
                 .record_finalizing_handoff_outcome(FinalizingHandoffOutcome::PublishedExact);
+            pre_spawn_timing.record_finalizing_exact_idle_lookup(FinalizingExactIdleLookup::Hit);
             Ok(FinalizingResource::Exact(reservation))
         }
         FinalizingWaitOutcome::Fallback {
             reason,
+            exact_lookup_miss,
             handoff_outcome,
         } => {
-            pre_spawn_timing.record_finalizing_handoff_outcome(handoff_outcome);
+            pre_spawn_timing.record_finalizing_handoff(handoff_outcome, Some(reason));
+            if let Some(miss) = exact_lookup_miss {
+                pre_spawn_timing
+                    .record_finalizing_exact_idle_lookup(FinalizingExactIdleLookup::Miss(miss));
+            }
             info!(
                 run_id = %run_id,
-                finalizing_fallback_reason = reason,
+                finalizing_fallback_reason = reason.as_str(),
                 "finalizing successor entering workspace or cold fallback"
             );
-            acquire_fallback_resource(FinalizingFallback {
-                run_id,
-                cancellation,
-                reuse_key: &admission.reuse_key,
-                history_generation_run_id: admission.history_generation_run_id,
-                profile_name,
-                vcpu,
-                memory_mb,
-                device_rate_limits,
-                ctx,
-            })
+            acquire_fallback_resource(
+                FinalizingFallback {
+                    run_id,
+                    cancellation,
+                    reuse_key: &admission.reuse_key,
+                    history_generation_run_id: admission.history_generation_run_id,
+                    profile_name,
+                    vcpu,
+                    memory_mb,
+                    device_rate_limits,
+                    ctx,
+                },
+                pre_spawn_timing,
+            )
             .await
         }
         FinalizingWaitOutcome::Cancelled(candidate) => {
@@ -584,7 +612,10 @@ async fn prepare_finalizing_resource(
                     .await;
                 ctx.reuse_state_notify.notify_one();
             }
-            pre_spawn_timing.record_finalizing_handoff_outcome(FinalizingHandoffOutcome::Cancelled);
+            pre_spawn_timing.record_finalizing_handoff(
+                FinalizingHandoffOutcome::Cancelled,
+                Some(FinalizingHandoffReason::SuccessorCancelled),
+            );
             Err(ExecutionFailure::cancelled().into())
         }
     }
@@ -633,25 +664,40 @@ async fn wait_for_finalizing_resource(
             handoff = None;
         }
         let missing_exact_reason = match state {
-            ActiveRunReuseState::ExactSandboxPublished => Some("published_exact_unavailable"),
-            ActiveRunReuseState::ExactSandboxHandedOff => {
-                return FinalizingWaitOutcome::no_exact("exact_handoff_unavailable");
+            ActiveRunReuseState::ExactSandboxPublished => {
+                Some(FinalizingHandoffReason::PublishedExactUnavailable)
             }
-            ActiveRunReuseState::Released => Some("predecessor_released_without_exact"),
+            ActiveRunReuseState::ExactSandboxHandedOff => {
+                return FinalizingWaitOutcome::no_exact(
+                    FinalizingHandoffReason::ExactHandoffUnavailable,
+                );
+            }
+            ActiveRunReuseState::Released => {
+                Some(FinalizingHandoffReason::PredecessorReleasedWithoutExact)
+            }
             ActiveRunReuseState::NoExactSandbox => {
-                return FinalizingWaitOutcome::no_exact("predecessor_no_exact");
+                return FinalizingWaitOutcome::no_exact(
+                    FinalizingHandoffReason::PredecessorNoExact,
+                );
             }
             ActiveRunReuseState::Pending | ActiveRunReuseState::Finalizing { .. } => None,
         };
         if let Some(missing_exact_reason) = missing_exact_reason {
-            *reserved_exact = reserve_reusable_idle_for_spawn(
+            let exact_lookup = reserve_exact_idle_for_spawn(
                 &admission.reuse_key,
                 profile_name,
                 device_rate_limits,
-                Some(admission.history_generation_run_id),
+                admission.history_generation_run_id,
                 ctx,
             )
             .await;
+            let exact_lookup_miss = match exact_lookup {
+                Ok(reservation) => {
+                    *reserved_exact = Some(reservation);
+                    None
+                }
+                Err(miss) => Some(miss),
+            };
             if cancel.is_cancelled() {
                 if let Some(reservation) = reserved_exact.take() {
                     rollback_reserved_idle_for_spawn(reservation, ctx).await;
@@ -667,7 +713,11 @@ async fn wait_for_finalizing_resource(
                 );
                 return FinalizingWaitOutcome::Exact(reservation);
             }
-            return FinalizingWaitOutcome::no_exact(missing_exact_reason);
+            return FinalizingWaitOutcome::Fallback {
+                reason: missing_exact_reason,
+                exact_lookup_miss,
+                handoff_outcome: FinalizingHandoffOutcome::NoExact,
+            };
         }
 
         let deadline = tokio::time::Instant::from_std(match state {
@@ -717,17 +767,16 @@ async fn wait_for_finalizing_resource(
                     }
                     return match state {
                         ActiveRunReuseState::Pending => FinalizingWaitOutcome::Fallback {
-                            reason: "pre_finalization_deadline",
+                            reason: FinalizingHandoffReason::PreFinalizationDeadline,
+                            exact_lookup_miss: None,
                             handoff_outcome:
                                 FinalizingHandoffOutcome::PreFinalizationDeadline,
                         },
-                        ActiveRunReuseState::Finalizing { .. } => {
-                            FinalizingWaitOutcome::Fallback {
-                                reason: "handoff_acceptance_deadline",
-                                handoff_outcome:
-                                    FinalizingHandoffOutcome::NotAcceptedBeforeDeadline,
-                            }
-                        }
+                        ActiveRunReuseState::Finalizing { .. } => FinalizingWaitOutcome::Fallback {
+                            reason: FinalizingHandoffReason::HandoffAcceptanceDeadline,
+                            exact_lookup_miss: None,
+                            handoff_outcome: FinalizingHandoffOutcome::NotAcceptedBeforeDeadline,
+                        },
                         ActiveRunReuseState::ExactSandboxPublished
                         | ActiveRunReuseState::ExactSandboxHandedOff
                         | ActiveRunReuseState::NoExactSandbox
@@ -748,12 +797,15 @@ async fn wait_for_finalizing_resource(
                     }
                     return match state {
                         ActiveRunReuseState::Pending => FinalizingWaitOutcome::Fallback {
-                            reason: "pre_finalization_deadline",
+                            reason: FinalizingHandoffReason::PreFinalizationDeadline,
+                            exact_lookup_miss: None,
                             handoff_outcome:
                                 FinalizingHandoffOutcome::PreFinalizationDeadline,
                         },
                         ActiveRunReuseState::Finalizing { .. } => {
-                            FinalizingWaitOutcome::no_exact("handoff_request_unavailable")
+                            FinalizingWaitOutcome::no_exact(
+                                FinalizingHandoffReason::HandoffRequestUnavailable,
+                            )
                         }
                         ActiveRunReuseState::ExactSandboxPublished
                         | ActiveRunReuseState::ExactSandboxHandedOff
@@ -786,7 +838,7 @@ async fn receive_finalizing_handoff(
         }
     };
     let Ok(candidate) = candidate else {
-        return FinalizingWaitOutcome::no_exact("exact_handoff_closed");
+        return FinalizingWaitOutcome::no_exact(FinalizingHandoffReason::ExactHandoffClosed);
     };
     if cancel.is_cancelled() {
         return FinalizingWaitOutcome::Cancelled(Some(candidate));
@@ -809,6 +861,7 @@ async fn receive_finalizing_handoff(
 /// without a resource so the outer claim path can complete the job and release retained leases.
 async fn acquire_fallback_resource(
     request: FinalizingFallback<'_>,
+    pre_spawn_timing: &mut RunnerPreSpawnTiming,
 ) -> Result<FinalizingResource, Box<ExecutionFailure>> {
     let FinalizingFallback {
         run_id,
@@ -846,10 +899,12 @@ async fn acquire_fallback_resource(
         {
             IdlePressureSelection::Reusable(reservation) => {
                 let reservation = accept_fallback_exact(cancellation, reservation, ctx).await?;
+                pre_spawn_timing
+                    .record_finalizing_exact_idle_lookup(FinalizingExactIdleLookup::Hit);
                 return Ok(FinalizingResource::Exact(reservation));
             }
             IdlePressureSelection::Fresh(lease) => {
-                if let Some(reservation) = reserve_fallback_exact(
+                match reserve_fallback_exact(
                     cancellation,
                     reuse_key,
                     profile_name,
@@ -859,8 +914,17 @@ async fn acquire_fallback_resource(
                 )
                 .await?
                 {
-                    drop(lease);
-                    return Ok(FinalizingResource::Exact(reservation));
+                    FallbackExactLookup::Hit(reservation) => {
+                        drop(lease);
+                        pre_spawn_timing
+                            .record_finalizing_exact_idle_lookup(FinalizingExactIdleLookup::Hit);
+                        return Ok(FinalizingResource::Exact(reservation));
+                    }
+                    FallbackExactLookup::Miss(miss) => {
+                        pre_spawn_timing.record_finalizing_exact_idle_lookup(
+                            FinalizingExactIdleLookup::Miss(miss),
+                        );
+                    }
                 }
                 return Ok(FinalizingResource::Fresh(lease));
             }
@@ -882,7 +946,7 @@ async fn acquire_fallback_resource(
                 vcpu,
                 memory_mb,
             ) => {
-                if let Some(reservation) = reserve_fallback_exact(
+                match reserve_fallback_exact(
                     cancellation,
                     reuse_key,
                     profile_name,
@@ -890,8 +954,17 @@ async fn acquire_fallback_resource(
                     history_generation_run_id,
                     ctx,
                 ).await? {
-                    drop(lease);
-                    return Ok(FinalizingResource::Exact(reservation));
+                    FallbackExactLookup::Hit(reservation) => {
+                        drop(lease);
+                        pre_spawn_timing
+                            .record_finalizing_exact_idle_lookup(FinalizingExactIdleLookup::Hit);
+                        return Ok(FinalizingResource::Exact(reservation));
+                    }
+                    FallbackExactLookup::Miss(miss) => {
+                        pre_spawn_timing.record_finalizing_exact_idle_lookup(
+                            FinalizingExactIdleLookup::Miss(miss),
+                        );
+                    }
                 }
                 return Ok(FinalizingResource::Fresh(lease));
             }
@@ -907,21 +980,22 @@ async fn reserve_fallback_exact(
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     history_generation_run_id: RunId,
     ctx: &SpawnContext,
-) -> Result<Option<ReservedIdleActivation>, Box<ExecutionFailure>> {
-    let Some(reservation) = reserve_reusable_idle_for_spawn(
+) -> Result<FallbackExactLookup, Box<ExecutionFailure>> {
+    let reservation = match reserve_exact_idle_for_spawn(
         reuse_key,
         profile_name,
         device_rate_limits,
-        Some(history_generation_run_id),
+        history_generation_run_id,
         ctx,
     )
     .await
-    else {
-        return Ok(None);
+    {
+        Ok(reservation) => reservation,
+        Err(miss) => return Ok(FallbackExactLookup::Miss(miss)),
     };
     accept_fallback_exact(cancellation, reservation, ctx)
         .await
-        .map(Some)
+        .map(FallbackExactLookup::Hit)
 }
 
 async fn accept_fallback_exact(
@@ -948,19 +1022,19 @@ async fn complete_claimed_without_sandbox(
     cancellation: RunCancellationRegistration,
     failure: ExecutionFailure,
     reuse_result: Option<SandboxReuseResult>,
-    handoff_outcome: Option<FinalizingHandoffOutcome>,
+    diagnostics: Option<FinalizingDiagnostics>,
     ctx: &SpawnContext,
 ) -> RunCancellationRegistration {
     let (context, completion_auth, active_input_source) = claimed.into_parts();
     drop(active_input_source);
-    let telemetry = handoff_outcome.map(|outcome| {
+    let telemetry = diagnostics.map(|diagnostics| {
         let mut telemetry = JobTelemetry::new(
             ctx.exec_config.http.clone(),
             context.run_id,
             context.sandbox_token.clone(),
             ctx.exec_config.runner_hostname.clone(),
         );
-        outcome.record(&mut telemetry);
+        diagnostics.record(&mut telemetry);
         telemetry
     });
     ctx.provider

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -127,8 +127,8 @@ use crate::executor::{
 };
 use crate::guest_timezone::{GuestTimezoneAssumption, GuestTimezoneIntent};
 use crate::idle_pool::{
-    DestroyOutcome, IdlePoolSnapshot, IdleUnparkResult, ReservedIdleSandbox,
-    RestoreReservedIdleResult, ReusableIdleSandbox, SpeculativeIdleSandbox,
+    DestroyOutcome, ExactIdleReservationMiss, IdlePoolSnapshot, IdleUnparkResult,
+    ReservedIdleSandbox, RestoreReservedIdleResult, ReusableIdleSandbox, SpeculativeIdleSandbox,
     SpeculativeIdleUnparkResult, SpeculativeReparkResult,
 };
 use crate::ids::RunId;
@@ -1603,6 +1603,27 @@ pub(super) async fn reserve_reusable_idle_for_spawn(
         (reservation, snapshot)
     };
     Some(ReservedIdleActivation::new(reservation, snapshot))
+}
+
+pub(super) async fn reserve_exact_idle_for_spawn(
+    reuse_key: &str,
+    profile_name: &str,
+    device_rate_limits: &Option<sandbox::DeviceRateLimits>,
+    history_generation_run_id: RunId,
+    ctx: &SpawnContext,
+) -> Result<ReservedIdleActivation, ExactIdleReservationMiss> {
+    let (reservation, snapshot) = {
+        let mut pool = ctx.idle_pool.lock().await;
+        let reservation = pool.reserve_reusable_generation_with_reason(
+            reuse_key,
+            profile_name,
+            device_rate_limits,
+            history_generation_run_id,
+        )?;
+        let snapshot = pool.status_snapshot();
+        (reservation, snapshot)
+    };
+    Ok(ReservedIdleActivation::new(reservation, snapshot))
 }
 
 pub(super) async fn rollback_reserved_idle_for_spawn(

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -494,6 +494,8 @@ async fn finalizing_handoff_deadline_reports_fallback_reason() {
         Some(reuse_key.to_owned()),
         "vm0/default".into(),
     );
+    let predecessor_reuse = predecessor_guard.reuse_publisher();
+    assert!(predecessor_reuse.mark_finalizing(std::time::Instant::now()));
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(2)).await;
 

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -342,7 +342,9 @@ async fn cancelled_finalizing_handoff_flushes_outcome_without_executor() {
             when.method(POST)
                 .path("/api/webhooks/agent/telemetry")
                 .body_includes("runner_claim_finalizing_handoff")
-                .body_includes(r#""outcome":"cancelled""#);
+                .body_includes(r#""outcome":"cancelled""#)
+                .body_includes(r#""reason":"successor_cancelled""#)
+                .body_includes(r#""error":"cancelled""#);
             then.status(200)
                 .header("content-type", "application/json")
                 .body(r#"{"success":true,"id":"ok"}"#);
@@ -397,6 +399,135 @@ async fn cancelled_finalizing_handoff_flushes_outcome_without_executor() {
 }
 
 #[tokio::test]
+async fn finalizing_no_exact_fallback_reports_atomic_idle_miss() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_includes("runner_claim_finalizing_handoff")
+                .body_includes(r#""outcome":"no_exact""#)
+                .body_includes(r#""reason":"predecessor_no_exact""#)
+                .body_includes("runner_claim_finalizing_exact_idle_lookup")
+                .body_includes(r#""outcome":"miss""#)
+                .body_includes(r#""reason":"absent""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+
+    let (config, env) =
+        mock_run_config_with_api_url(test_profiles(), 2, 4096, 1, &server.base_url());
+    let reuse_key = "thread:no-exact-fallback-telemetry";
+    let predecessor_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        predecessor_run_id,
+        Some(reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    let predecessor_reuse = predecessor_guard.reuse_publisher();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    let mut context = minimal_context(run_id);
+    context.reuse_key = Some(reuse_key.to_owned());
+    env.provider.set_claim_result(run_id, Some(context));
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+                .with_reuse_key(Some(reuse_key.to_owned()))
+                .with_history_generation_run_id(Some(predecessor_run_id))
+                .with_runner_preference_for_test(
+                    crate::provider::ActiveRunnerPreference::ranked_for_test(
+                        test_runner_identity(),
+                        crate::provider::RunnerPreferenceTier::FinalizingPredecessor,
+                        std::time::Instant::now() + Duration::from_secs(30),
+                    ),
+                ),
+        )
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    assert!(predecessor_reuse.publish_no_exact_sandbox());
+    env.handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("no-exact fallback should complete");
+
+    drop(predecessor_guard);
+    shutdown(&env, run_handle).await;
+    telemetry_mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn finalizing_handoff_deadline_reports_fallback_reason() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_includes("runner_claim_finalizing_handoff")
+                .body_includes(r#""outcome":"not_accepted_before_deadline""#)
+                .body_includes(r#""reason":"handoff_acceptance_deadline""#)
+                .body_includes("runner_claim_finalizing_exact_idle_lookup")
+                .body_includes(r#""outcome":"miss""#)
+                .body_includes(r#""reason":"absent""#);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+
+    let (config, env) =
+        mock_run_config_with_api_url(test_profiles(), 2, 4096, 1, &server.base_url());
+    let reuse_key = "thread:handoff-deadline-telemetry";
+    let predecessor_run_id = RunId::new_v4();
+    let predecessor_guard = env.active_runs.register(
+        predecessor_run_id,
+        Some(reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    let mut context = minimal_context(run_id);
+    context.reuse_key = Some(reuse_key.to_owned());
+    env.provider.set_claim_result(run_id, Some(context));
+    env.handle
+        .discover_tx
+        .send(
+            crate::provider::JobCandidate::new(run_id, "vm0/default".into())
+                .with_reuse_key(Some(reuse_key.to_owned()))
+                .with_history_generation_run_id(Some(predecessor_run_id))
+                .with_runner_preference_for_test(
+                    crate::provider::ActiveRunnerPreference::ranked_for_test(
+                        test_runner_identity(),
+                        crate::provider::RunnerPreferenceTier::FinalizingPredecessor,
+                        std::time::Instant::now() + Duration::from_secs(1),
+                    ),
+                ),
+        )
+        .unwrap();
+
+    env.handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("deadline fallback should complete");
+
+    drop(predecessor_guard);
+    shutdown(&env, run_handle).await;
+    telemetry_mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
 async fn finalizing_handoff_activation_failure_is_not_reported_as_accepted() {
     use httpmock::prelude::*;
 
@@ -407,7 +538,9 @@ async fn finalizing_handoff_activation_failure_is_not_reported_as_accepted() {
                 .path("/api/webhooks/agent/telemetry")
                 .body_includes("runner_claim_finalizing_wait")
                 .body_includes("runner_claim_finalizing_handoff")
-                .body_includes(r#""outcome":"activation_failed""#);
+                .body_includes(r#""outcome":"activation_failed""#)
+                .body_includes(r#""reason":"exact_activation_fallback""#)
+                .body_includes(r#""error":"activation_failed""#);
             then.status(200)
                 .header("content-type", "application/json")
                 .body(r#"{"success":true,"id":"ok"}"#);
@@ -500,7 +633,11 @@ async fn published_exact_activation_failure_is_reported_as_activation_failed() {
             when.method(POST)
                 .path("/api/webhooks/agent/telemetry")
                 .body_includes("runner_claim_finalizing_handoff")
-                .body_includes(r#""outcome":"activation_failed""#);
+                .body_includes(r#""outcome":"activation_failed""#)
+                .body_includes(r#""reason":"exact_activation_fallback""#)
+                .body_includes(r#""error":"activation_failed""#)
+                .body_includes("runner_claim_finalizing_exact_idle_lookup")
+                .body_includes(r#""outcome":"hit""#);
             then.status(200)
                 .header("content-type", "application/json")
                 .body(r#"{"success":true,"id":"ok"}"#);

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -65,7 +65,8 @@ use sandbox_run::{
     NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
 };
 pub(crate) use telemetry::{
-    ExactReuseSpeculationTiming, FinalizingHandoffOutcome, RunnerPreSpawnConcurrency,
+    ExactReuseSpeculationTiming, FinalizingDiagnostics, FinalizingExactIdleLookup,
+    FinalizingHandoffOutcome, FinalizingHandoffReason, RunnerPreSpawnConcurrency,
     RunnerPreSpawnOperationTiming, RunnerPreSpawnPhase, RunnerPreSpawnTiming,
 };
 use telemetry::{RunnerSpawnTiming, record_api_latency, record_reuse_result};

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -852,7 +852,7 @@ pub(super) async fn prepare_workspace_image(
         prepare_error.is_none(),
         prepare_error,
     );
-    record_workspace_cache_result(telemetry, lease.result());
+    record_workspace_cache_result(telemetry, &lease);
     Some(lease)
 }
 

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -12,6 +12,7 @@ use guest_contracts::epoch_milliseconds::{
 use tracing::warn;
 
 use crate::guest_timezone::GuestTimezoneAssumption;
+use crate::idle_pool::ExactIdleReservationMiss;
 use crate::provider::ApiClaimTiming;
 use crate::resource_budget::ResourceBudget;
 use crate::telemetry::{
@@ -19,7 +20,7 @@ use crate::telemetry::{
     RunnerResourceBudgetOccupancy, RunnerStartupPath,
 };
 use crate::types::{ExecutionContext, SandboxReuseResult, WorkspaceReuseResult};
-use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
+use crate::workspace_image_cache::{WorkspaceCacheCheckoutResult, WorkspaceImageLease};
 
 static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
 
@@ -104,6 +105,61 @@ pub(crate) enum FinalizingHandoffOutcome {
     Cancelled,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum FinalizingHandoffReason {
+    PreFinalizationDeadline,
+    HandoffAcceptanceDeadline,
+    PublishedExactUnavailable,
+    PredecessorReleasedWithoutExact,
+    PredecessorNoExact,
+    ExactHandoffUnavailable,
+    HandoffRequestUnavailable,
+    ExactHandoffClosed,
+    SuccessorCancelled,
+    ActivationCancelled,
+    HandoffIdentityMismatch,
+    ExactActivationFallback,
+    ExactActivationFailed,
+}
+
+impl FinalizingHandoffReason {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::PreFinalizationDeadline => "pre_finalization_deadline",
+            Self::HandoffAcceptanceDeadline => "handoff_acceptance_deadline",
+            Self::PublishedExactUnavailable => "published_exact_unavailable",
+            Self::PredecessorReleasedWithoutExact => "predecessor_released_without_exact",
+            Self::PredecessorNoExact => "predecessor_no_exact",
+            Self::ExactHandoffUnavailable => "exact_handoff_unavailable",
+            Self::HandoffRequestUnavailable => "handoff_request_unavailable",
+            Self::ExactHandoffClosed => "exact_handoff_closed",
+            Self::SuccessorCancelled => "successor_cancelled",
+            Self::ActivationCancelled => "activation_cancelled",
+            Self::HandoffIdentityMismatch => "handoff_identity_mismatch",
+            Self::ExactActivationFallback => "exact_activation_fallback",
+            Self::ExactActivationFailed => "exact_activation_failed",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FinalizingHandoffTelemetry {
+    outcome: FinalizingHandoffOutcome,
+    reason: Option<FinalizingHandoffReason>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum FinalizingExactIdleLookup {
+    Hit,
+    Miss(ExactIdleReservationMiss),
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FinalizingDiagnostics {
+    handoff: Option<FinalizingHandoffTelemetry>,
+    exact_idle_lookup: Option<FinalizingExactIdleLookup>,
+}
+
 impl FinalizingHandoffOutcome {
     const fn as_str(self) -> &'static str {
         match self {
@@ -120,15 +176,43 @@ impl FinalizingHandoffOutcome {
     const fn succeeded(self) -> bool {
         matches!(self, Self::Accepted | Self::PublishedExact)
     }
+}
 
+impl FinalizingHandoffTelemetry {
     pub(crate) fn record(self, telemetry: &mut JobTelemetry) {
-        telemetry.record_with_outcome(
+        telemetry.record_bounded_outcome_with_error(
             "runner_claim_finalizing_handoff",
-            Duration::ZERO,
-            self.succeeded(),
-            (!self.succeeded()).then_some(self.as_str()),
-            Some(self.as_str()),
+            self.outcome.succeeded(),
+            (!self.outcome.succeeded()).then_some(self.outcome.as_str()),
+            self.outcome.as_str(),
+            self.reason.map(FinalizingHandoffReason::as_str),
         );
+    }
+}
+
+impl FinalizingExactIdleLookup {
+    fn record(self, telemetry: &mut JobTelemetry) {
+        let (outcome, reason) = match self {
+            Self::Hit => ("hit", None),
+            Self::Miss(reason) => ("miss", Some(reason.as_str())),
+        };
+        telemetry.record_bounded_outcome(
+            "runner_claim_finalizing_exact_idle_lookup",
+            true,
+            outcome,
+            reason,
+        );
+    }
+}
+
+impl FinalizingDiagnostics {
+    pub(crate) fn record(self, telemetry: &mut JobTelemetry) {
+        if let Some(handoff) = self.handoff {
+            handoff.record(telemetry);
+        }
+        if let Some(exact_idle_lookup) = self.exact_idle_lookup {
+            exact_idle_lookup.record(telemetry);
+        }
     }
 }
 
@@ -227,7 +311,8 @@ pub(crate) struct RunnerPreSpawnTiming {
     phase_durations: RunnerPreSpawnPhaseDurations,
     task_enqueued_at: Option<Instant>,
     exact_reuse_speculation: Option<ExactReuseSpeculationTiming>,
-    finalizing_handoff_outcome: Option<FinalizingHandoffOutcome>,
+    finalizing_handoff: Option<FinalizingHandoffTelemetry>,
+    finalizing_exact_idle_lookup: Option<FinalizingExactIdleLookup>,
 }
 
 #[derive(Clone, Copy)]
@@ -269,7 +354,8 @@ impl RunnerPreSpawnTiming {
             phase_durations: RunnerPreSpawnPhaseDurations::default(),
             task_enqueued_at: None,
             exact_reuse_speculation: None,
-            finalizing_handoff_outcome: None,
+            finalizing_handoff: None,
+            finalizing_exact_idle_lookup: None,
         }
     }
 
@@ -278,11 +364,32 @@ impl RunnerPreSpawnTiming {
     }
 
     pub(crate) fn record_finalizing_handoff_outcome(&mut self, outcome: FinalizingHandoffOutcome) {
-        self.finalizing_handoff_outcome = Some(outcome);
+        self.record_finalizing_handoff(outcome, None);
     }
 
-    pub(crate) fn finalizing_handoff_outcome(&self) -> Option<FinalizingHandoffOutcome> {
-        self.finalizing_handoff_outcome
+    pub(crate) fn record_finalizing_handoff(
+        &mut self,
+        outcome: FinalizingHandoffOutcome,
+        reason: Option<FinalizingHandoffReason>,
+    ) {
+        self.finalizing_handoff = Some(FinalizingHandoffTelemetry { outcome, reason });
+    }
+
+    pub(crate) fn finalizing_diagnostics(&self) -> Option<FinalizingDiagnostics> {
+        (self.finalizing_handoff.is_some() || self.finalizing_exact_idle_lookup.is_some())
+            .then_some(FinalizingDiagnostics {
+                handoff: self.finalizing_handoff,
+                exact_idle_lookup: self.finalizing_exact_idle_lookup,
+            })
+    }
+
+    pub(crate) fn record_finalizing_exact_idle_lookup(
+        &mut self,
+        lookup: FinalizingExactIdleLookup,
+    ) {
+        // Capacity waits can probe more than once. Retaining only the latest atomic observation
+        // emits one terminal decision for the successor instead of one row per retry.
+        self.finalizing_exact_idle_lookup = Some(lookup);
     }
 
     pub(crate) fn record_phase(&mut self, phase: RunnerPreSpawnPhase, duration: Duration) {
@@ -353,8 +460,11 @@ impl RunnerPreSpawnTiming {
                 None,
             );
         }
-        if let Some(outcome) = self.finalizing_handoff_outcome {
-            outcome.record(telemetry);
+        if let Some(handoff) = self.finalizing_handoff {
+            handoff.record(telemetry);
+        }
+        if let Some(exact_lookup) = self.finalizing_exact_idle_lookup {
+            exact_lookup.record(telemetry);
         }
         if let Some(timing) = self.exact_reuse_speculation.as_ref() {
             telemetry.record(
@@ -485,8 +595,9 @@ pub(super) fn record_reuse_result(telemetry: &mut JobTelemetry, result: SandboxR
 
 pub(super) fn record_workspace_cache_result(
     telemetry: &mut JobTelemetry,
-    result: WorkspaceCacheCheckoutResult,
+    lease: &WorkspaceImageLease,
 ) {
+    let result = lease.result();
     let action_type = match result {
         WorkspaceCacheCheckoutResult::Hit => "workspace_image_cache_hit",
         WorkspaceCacheCheckoutResult::Miss => "workspace_image_cache_miss",
@@ -498,7 +609,15 @@ pub(super) fn record_workspace_cache_result(
         WorkspaceCacheCheckoutResult::InvalidMetadata => "workspace_image_cache_invalid_metadata",
         WorkspaceCacheCheckoutResult::DiskPressure => "workspace_image_cache_disk_pressure",
     };
-    telemetry.record(action_type, Duration::ZERO, true, None);
+    if result == WorkspaceCacheCheckoutResult::LockBusy {
+        if let Some((outcome, reason)) = lease.lock_outcome_and_reason() {
+            telemetry.record_bounded_outcome(action_type, true, outcome, reason);
+        } else {
+            telemetry.record(action_type, Duration::ZERO, true, None);
+        }
+    } else {
+        telemetry.record(action_type, Duration::ZERO, true, None);
+    }
 }
 
 pub(super) fn record_api_latency(

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -1136,6 +1136,12 @@ async fn execute_inner_records_workspace_cache_lock_busy_prepare_telemetry() {
         Some("workspace_image_prepare_lock_busy"),
     );
     assert_telemetry_action(&telemetry, "workspace_image_cache_lock_busy", true, None);
+    assert!(telemetry.pending_ops_with_outcome_snapshot().contains(&(
+        "workspace_image_cache_lock_busy".into(),
+        true,
+        Some("busy".into()),
+        Some("unknown".into()),
+    )));
 }
 
 #[tokio::test]
@@ -1209,6 +1215,12 @@ async fn execute_inner_logs_workspace_cache_lock_error_separately() {
         false,
         Some("workspace_image_prepare_lock_busy"),
     );
+    assert!(telemetry.pending_ops_with_outcome_snapshot().contains(&(
+        "workspace_image_cache_lock_busy".into(),
+        true,
+        Some("unavailable".into()),
+        None,
+    )));
     let errors = captured_events_named(
         &events,
         "workspace image cache lock unavailable; using fresh workspace image",

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -20,10 +20,10 @@ use super::super::telemetry::{
 };
 use super::super::{
     ExactReuseSpeculationTiming, ExecutionHooks, ExecutorConfig, FinalizingHandoffOutcome,
-    JobParams, NewSandboxDispatch, RunnerPreSpawnConcurrency, RunnerPreSpawnOperationTiming,
-    RunnerPreSpawnTiming, SandboxReuseDisposition, SandboxReuseRejection,
-    SessionHistoryRestorePlan, execute_job, execute_job_reuse, execute_job_reuse_with_hooks,
-    execute_job_with_prepared_notifier,
+    FinalizingHandoffReason, JobParams, NewSandboxDispatch, RunnerPreSpawnConcurrency,
+    RunnerPreSpawnOperationTiming, RunnerPreSpawnTiming, SandboxReuseDisposition,
+    SandboxReuseRejection, SessionHistoryRestorePlan, execute_job, execute_job_reuse,
+    execute_job_reuse_with_hooks, execute_job_with_prepared_notifier,
 };
 use super::support::{
     api_storage, context_with_env, default_params, make_reusable_idle_sandbox, minimal_context,
@@ -67,8 +67,16 @@ fn elapsed_since_api_start_ms_rejects_seconds_shaped_start() {
 #[test]
 fn pre_finalization_deadline_records_bounded_handoff_outcome() {
     let mut telemetry = new_telemetry();
+    let mut timing = RunnerPreSpawnTiming::start_after_claim();
 
-    FinalizingHandoffOutcome::PreFinalizationDeadline.record(&mut telemetry);
+    timing.record_finalizing_handoff(
+        FinalizingHandoffOutcome::PreFinalizationDeadline,
+        Some(FinalizingHandoffReason::PreFinalizationDeadline),
+    );
+    timing
+        .finalizing_diagnostics()
+        .expect("pre-finalization diagnostics")
+        .record(&mut telemetry);
 
     assert_action_outcome(
         &telemetry,
@@ -83,6 +91,7 @@ fn pre_finalization_deadline_records_bounded_handoff_outcome() {
             .any(|operation| {
                 operation.0 == "runner_claim_finalizing_handoff"
                     && operation.2.as_deref() == Some("pre_finalization_deadline")
+                    && operation.3.as_deref() == Some("pre_finalization_deadline")
             })
     );
 }

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 use std::time::Instant;
 
 use sandbox::{DeviceRateLimits, SandboxId};
@@ -63,6 +63,29 @@ pub struct IdlePool {
     /// Shared lifecycle gate. The signal/main-loop lifecycle controller updates
     /// this before publishing externally visible mode transitions.
     parking_gate: ParkingGate,
+}
+
+/// Why an exact idle reservation could not use the entry observed for its reuse key.
+///
+/// The classification is produced while the pool lock is held, so it describes the same
+/// observation that made the reservation decision without a racy follow-up lookup.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ExactIdleReservationMiss {
+    Absent,
+    ProfileMismatch,
+    DeviceLimitMismatch,
+    HistoryGenerationMismatch,
+}
+
+impl ExactIdleReservationMiss {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Absent => "absent",
+            Self::ProfileMismatch => "profile_mismatch",
+            Self::DeviceLimitMismatch => "device_limit_mismatch",
+            Self::HistoryGenerationMismatch => "history_generation_mismatch",
+        }
+    }
 }
 
 impl IdlePool {
@@ -164,18 +187,40 @@ impl IdlePool {
         device_rate_limits: &Option<DeviceRateLimits>,
         history_generation_run_id: RunId,
     ) -> Option<ReservedIdleSandbox> {
-        if !self.has_reusable(reuse_key, profile_name, device_rate_limits)
-            || self
-                .entries
-                .get(reuse_key)
-                .and_then(|entry| entry.metadata.history_generation_run_id)
-                != Some(history_generation_run_id)
-        {
-            return None;
-        }
-        let entry = self.entries.remove(reuse_key)?;
+        self.reserve_reusable_generation_with_reason(
+            reuse_key,
+            profile_name,
+            device_rate_limits,
+            history_generation_run_id,
+        )
+        .ok()
+    }
+
+    pub(crate) fn reserve_reusable_generation_with_reason(
+        &mut self,
+        reuse_key: &str,
+        profile_name: &str,
+        device_rate_limits: &Option<DeviceRateLimits>,
+        history_generation_run_id: RunId,
+    ) -> Result<ReservedIdleSandbox, ExactIdleReservationMiss> {
+        let entry = match self.entries.entry(reuse_key.to_owned()) {
+            Entry::Vacant(_) => return Err(ExactIdleReservationMiss::Absent),
+            Entry::Occupied(entry) => {
+                if entry.get().profile_name() != profile_name {
+                    return Err(ExactIdleReservationMiss::ProfileMismatch);
+                }
+                if entry.get().device_rate_limits() != device_rate_limits {
+                    return Err(ExactIdleReservationMiss::DeviceLimitMismatch);
+                }
+                if entry.get().metadata.history_generation_run_id != Some(history_generation_run_id)
+                {
+                    return Err(ExactIdleReservationMiss::HistoryGenerationMismatch);
+                }
+                entry.remove()
+            }
+        };
         self.bump_revision();
-        Some(ReservedIdleSandbox { entry })
+        Ok(ReservedIdleSandbox { entry })
     }
 
     /// Reserve a matching idle entry before pressure eviction begins.

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -92,28 +92,65 @@ fn reusable_reservation_is_exclusive_and_restorable() {
 }
 
 #[test]
-fn reusable_generation_reservation_requires_exact_generation() {
+fn reusable_generation_reservation_classifies_exact_misses() {
     let mut pool = IdlePool::new(pool_config(0));
     let held_generation_run_id = RunId::new_v4();
     let requested_generation_run_id = RunId::new_v4();
+    let device_rate_limits = sandbox::DeviceRateLimits {
+        block: sandbox::BlockRateLimits {
+            bandwidth_bytes_per_sec: 100 * 1024 * 1024,
+            ops_per_sec: 10_000,
+        },
+        network: sandbox::NetworkRateLimits {
+            rx_bytes_per_sec: 50 * 1024 * 1024,
+            tx_bytes_per_sec: 25 * 1024 * 1024,
+        },
+    };
     let candidate =
         ParkedIdleCandidateBuilder::new("session-generation", make_budget_lease(2, 2048))
+            .with_device_rate_limits(device_rate_limits.clone())
             .with_history_generation_run_id(held_generation_run_id)
             .with_last_completed_at("2026-07-15T00:00:00.000Z")
             .build();
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
     let parked_revision = pool.status_snapshot().revision;
 
-    assert!(
-        pool.reserve_reusable_generation(
+    assert!(matches!(
+        pool.reserve_reusable_generation_with_reason(
+            "missing-session",
+            "vm0/default",
+            &Some(device_rate_limits.clone()),
+            held_generation_run_id,
+        ),
+        Err(ExactIdleReservationMiss::Absent)
+    ));
+    assert!(matches!(
+        pool.reserve_reusable_generation_with_reason(
+            "session-generation",
+            "vm0/large",
+            &Some(device_rate_limits.clone()),
+            held_generation_run_id,
+        ),
+        Err(ExactIdleReservationMiss::ProfileMismatch)
+    ));
+    assert!(matches!(
+        pool.reserve_reusable_generation_with_reason(
             "session-generation",
             "vm0/default",
             &None,
+            held_generation_run_id,
+        ),
+        Err(ExactIdleReservationMiss::DeviceLimitMismatch)
+    ));
+    assert!(matches!(
+        pool.reserve_reusable_generation_with_reason(
+            "session-generation",
+            "vm0/default",
+            &Some(device_rate_limits.clone()),
             requested_generation_run_id,
-        )
-        .is_none(),
-        "a different generation must remain parked"
-    );
+        ),
+        Err(ExactIdleReservationMiss::HistoryGenerationMismatch)
+    ));
     assert_eq!(pool.len(), 1);
     assert_eq!(pool.status_snapshot().revision, parked_revision);
 
@@ -121,7 +158,7 @@ fn reusable_generation_reservation_requires_exact_generation() {
         .reserve_reusable_generation(
             "session-generation",
             "vm0/default",
-            &None,
+            &Some(device_rate_limits),
             held_generation_run_id,
         )
         .expect("the exact generation should reserve");

--- a/crates/runner/src/idle_pool/test_support.rs
+++ b/crates/runner/src/idle_pool/test_support.rs
@@ -82,6 +82,11 @@ impl ParkedIdleCandidateBuilder {
         self
     }
 
+    pub(crate) fn with_device_rate_limits(mut self, device_rate_limits: DeviceRateLimits) -> Self {
+        self.device_rate_limits = Some(device_rate_limits);
+        self
+    }
+
     pub(crate) fn with_source_ip(mut self, source_ip: impl Into<String>) -> Self {
         self.source_ip = source_ip.into();
         self

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -359,7 +359,18 @@ impl JobTelemetry {
         outcome: &'static str,
         reason: Option<&'static str>,
     ) {
-        let mut op = sandbox_op(action_type, Duration::ZERO, success, None, None, None);
+        self.record_bounded_outcome_with_error(action_type, success, None, outcome, reason);
+    }
+
+    pub(crate) fn record_bounded_outcome_with_error(
+        &mut self,
+        action_type: &'static str,
+        success: bool,
+        error: Option<&'static str>,
+        outcome: &'static str,
+        reason: Option<&'static str>,
+    ) {
+        let mut op = sandbox_op(action_type, Duration::ZERO, success, error, None, None);
         op.outcome = Some(outcome.to_string());
         op.reason = reason.map(str::to_string);
         self.push_operation(op);

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -41,7 +41,8 @@ use super::types::{
     WorkspaceSessionHistorySidecarPublication,
 };
 use super::{
-    CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache, WorkspaceImageCacheInner,
+    CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceCacheLockRegistration,
+    WorkspaceImageCache, WorkspaceImageCacheInner,
 };
 
 const WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT: Duration = Duration::from_millis(50);
@@ -157,6 +158,7 @@ struct WorkspaceImageLeaseState {
 struct WorkspaceEntryLock {
     inner: Arc<WorkspaceImageCacheInner>,
     cache_key: String,
+    identity: Arc<()>,
     lock: Option<Flock<std::fs::File>>,
 }
 
@@ -167,46 +169,66 @@ impl WorkspaceEntryLock {
         lock: Flock<std::fs::File>,
         owner: WorkspaceCacheLockOwner,
     ) -> Self {
-        let previous = cache
+        let identity = Arc::new(());
+        let mut owners = cache
             .inner
             .entry_lock_owners
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(cache_key.to_owned(), owner);
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let registration = owners.entry(cache_key.to_owned());
         assert!(
-            previous.is_none(),
+            matches!(&registration, std::collections::hash_map::Entry::Vacant(_)),
             "workspace entry lock acquired while a local owner remains registered"
         );
+        if let std::collections::hash_map::Entry::Vacant(registration) = registration {
+            registration.insert(WorkspaceCacheLockRegistration {
+                identity: Arc::clone(&identity),
+                owner,
+            });
+        }
+        drop(owners);
         Self {
             inner: Arc::clone(&cache.inner),
             cache_key: cache_key.to_owned(),
+            identity,
             lock: Some(lock),
         }
     }
 
     fn set_owner(&mut self, owner: WorkspaceCacheLockOwner) {
-        let registered = self
+        let mut owners = self
             .inner
             .entry_lock_owners
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(self.cache_key.clone(), owner);
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let registered = owners.get_mut(&self.cache_key);
         assert!(
-            registered.is_some(),
-            "workspace entry lock ownership transition requires a registered owner"
+            registered
+                .as_ref()
+                .is_some_and(|registered| Arc::ptr_eq(&registered.identity, &self.identity)),
+            "workspace entry lock ownership transition requires the original registration"
         );
+        if let Some(registered) = registered {
+            registered.owner = owner;
+        }
     }
 }
 
 impl Drop for WorkspaceEntryLock {
     fn drop(&mut self) {
-        let removed = self
+        let mut owners = self
             .inner
             .entry_lock_owners
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .remove(&self.cache_key);
-        debug_assert!(removed.is_some());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let owns_registration = owners
+            .get(&self.cache_key)
+            .is_some_and(|registered| Arc::ptr_eq(&registered.identity, &self.identity));
+        debug_assert!(owns_registration);
+        if owns_registration {
+            owners.remove(&self.cache_key);
+        }
+        drop(owners);
         drop(self.lock.take());
     }
 }
@@ -280,14 +302,30 @@ impl WorkspaceImageLease {
 }
 
 impl WorkspaceImageCache {
-    fn local_entry_lock_owner(&self, cache_key: &str) -> WorkspaceCacheLockOwner {
+    fn local_entry_lock_observation(
+        &self,
+        cache_key: &str,
+    ) -> Option<WorkspaceCacheLockRegistration> {
         self.inner
             .entry_lock_owners
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(cache_key)
-            .copied()
-            .unwrap_or(WorkspaceCacheLockOwner::Unknown)
+            .cloned()
+    }
+
+    fn stable_local_entry_lock_owner(
+        &self,
+        cache_key: &str,
+        before: Option<&WorkspaceCacheLockRegistration>,
+    ) -> WorkspaceCacheLockOwner {
+        let after = self.local_entry_lock_observation(cache_key);
+        match (before, after) {
+            (Some(before), Some(after)) if Arc::ptr_eq(&before.identity, &after.identity) => {
+                after.owner
+            }
+            _ => WorkspaceCacheLockOwner::Unknown,
+        }
     }
 
     async fn acquire_prepare_lock(
@@ -380,6 +418,7 @@ impl WorkspaceImageCache {
         };
 
         let cache_key = common.cache_key(self, reuse_key, working_dir);
+        let owner_before = self.local_entry_lock_observation(&cache_key);
         match crate::lock::try_acquire_or_busy(self.entry_lock_path(&cache_key)).await {
             Ok(crate::lock::TryLock::Acquired(lock)) => active_lease(
                 WorkspaceCacheCheckoutResult::Miss,
@@ -393,7 +432,7 @@ impl WorkspaceImageCache {
                 None,
             ),
             Ok(crate::lock::TryLock::Busy) => {
-                let owner = self.local_entry_lock_owner(&cache_key);
+                let owner = self.stable_local_entry_lock_owner(&cache_key, owner_before.as_ref());
                 info!(
                     run_id = %common.run_id,
                     cache_key,
@@ -549,10 +588,11 @@ impl WorkspaceImageCache {
 
         let cache_key = common.cache_key(self, reuse_key, working_dir);
         let lock_path = self.entry_lock_path(&cache_key);
+        let owner_before = self.local_entry_lock_observation(&cache_key);
         let lock = match self.acquire_prepare_lock(lock_path, lock_policy).await {
             Ok(crate::lock::TryLock::Acquired(lock)) => lock,
             Ok(crate::lock::TryLock::Busy) => {
-                let owner = self.local_entry_lock_owner(&cache_key);
+                let owner = self.stable_local_entry_lock_owner(&cache_key, owner_before.as_ref());
                 match lock_policy {
                     WorkspaceImagePrepareLockPolicy::WaitForTransientContention => info!(
                         run_id = %common.run_id,

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
@@ -31,15 +32,17 @@ use super::path_safety::{
     normalize_safe_guest_working_dir,
 };
 use super::types::{
-    CacheBudget, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
-    WorkspaceImageActiveLeaseRequest, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareLockPolicy,
-    WorkspaceImagePrepareRequest, WorkspaceImagePromotionIdentity,
+    CacheBudget, WorkspaceCacheCheckoutResult, WorkspaceCacheLockDecision, WorkspaceCacheLockOwner,
+    WorkspaceCacheTerminalStatus, WorkspaceImageActiveLeaseRequest, WorkspaceImageLeaseIdentity,
+    WorkspaceImagePrepareLockPolicy, WorkspaceImagePrepareRequest, WorkspaceImagePromotionIdentity,
     WorkspaceImagePromotionIdentityMismatch, WorkspaceImagePromotionIdentityRequest,
     WorkspaceImagePromotionRequest, WorkspaceSessionHistorySidecar,
     WorkspaceSessionHistorySidecarMiss, WorkspaceSessionHistorySidecarPromotionSource,
     WorkspaceSessionHistorySidecarPublication,
 };
-use super::{CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache};
+use super::{
+    CACHE_FORMAT_VERSION, WORKSPACE_DRIVE_LAYOUT, WorkspaceImageCache, WorkspaceImageCacheInner,
+};
 
 const WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT: Duration = Duration::from_millis(50);
 
@@ -56,13 +59,14 @@ pub(crate) struct WorkspaceImageLease {
     workspace_drive_enabled: bool,
     result: WorkspaceCacheCheckoutResult,
     previous_storage: Option<StorageFingerprints>,
-    entry_lock: Option<Flock<std::fs::File>>,
+    entry_lock: Option<WorkspaceEntryLock>,
+    lock_decision: Option<WorkspaceCacheLockDecision>,
 }
 
 pub(crate) struct WorkspaceImagePromotionContext {
     cache: WorkspaceImageCache,
     cache_key: String,
-    entry_lock: Option<Flock<std::fs::File>>,
+    entry_lock: Option<WorkspaceEntryLock>,
     run_id: RunId,
     sandbox_id: sandbox::SandboxId,
     profile_name: String,
@@ -82,7 +86,7 @@ pub(crate) struct WorkspaceSessionHistorySidecarEntryGuard {
     cache_key: String,
     run_id: RunId,
     restored_session_identity: crate::restored_session_identity::RestoredSessionIdentity,
-    _late_entry_lock: Option<Flock<std::fs::File>>,
+    _late_entry_lock: Option<WorkspaceEntryLock>,
 }
 
 pub(crate) struct WorkspaceImagePromotionIdentityFailure {
@@ -140,9 +144,71 @@ struct WorkspaceImageLeaseState {
     source_image: Option<PathBuf>,
     consumed_cache_hit: bool,
     previous_storage: Option<StorageFingerprints>,
-    entry_lock: Option<Flock<std::fs::File>>,
+    entry_lock: Option<WorkspaceEntryLock>,
     workspace_drive_enabled: bool,
     result: WorkspaceCacheCheckoutResult,
+    lock_decision: Option<WorkspaceCacheLockDecision>,
+}
+
+/// Couples a locally provable lifecycle phase to the flock that establishes ownership.
+///
+/// Separate cache instances and processes do not share the registry, so their busy locks remain
+/// explicitly `unknown` rather than being inferred from other runner state.
+struct WorkspaceEntryLock {
+    inner: Arc<WorkspaceImageCacheInner>,
+    cache_key: String,
+    lock: Option<Flock<std::fs::File>>,
+}
+
+impl WorkspaceEntryLock {
+    fn new(
+        cache: &WorkspaceImageCache,
+        cache_key: &str,
+        lock: Flock<std::fs::File>,
+        owner: WorkspaceCacheLockOwner,
+    ) -> Self {
+        let previous = cache
+            .inner
+            .entry_lock_owners
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(cache_key.to_owned(), owner);
+        assert!(
+            previous.is_none(),
+            "workspace entry lock acquired while a local owner remains registered"
+        );
+        Self {
+            inner: Arc::clone(&cache.inner),
+            cache_key: cache_key.to_owned(),
+            lock: Some(lock),
+        }
+    }
+
+    fn set_owner(&mut self, owner: WorkspaceCacheLockOwner) {
+        let registered = self
+            .inner
+            .entry_lock_owners
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(self.cache_key.clone(), owner);
+        assert!(
+            registered.is_some(),
+            "workspace entry lock ownership transition requires a registered owner"
+        );
+    }
+}
+
+impl Drop for WorkspaceEntryLock {
+    fn drop(&mut self) {
+        let removed = self
+            .inner
+            .entry_lock_owners
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&self.cache_key);
+        debug_assert!(removed.is_some());
+        drop(self.lock.take());
+    }
 }
 
 fn workspace_image_size_mb(image_size_bytes: u64) -> u32 {
@@ -208,11 +274,22 @@ impl WorkspaceImageLease {
             result: state.result,
             previous_storage: state.previous_storage,
             entry_lock: state.entry_lock,
+            lock_decision: state.lock_decision,
         }
     }
 }
 
 impl WorkspaceImageCache {
+    fn local_entry_lock_owner(&self, cache_key: &str) -> WorkspaceCacheLockOwner {
+        self.inner
+            .entry_lock_owners
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(cache_key)
+            .copied()
+            .unwrap_or(WorkspaceCacheLockOwner::Unknown)
+    }
+
     async fn acquire_prepare_lock(
         &self,
         lock_path: PathBuf,
@@ -269,7 +346,7 @@ impl WorkspaceImageCache {
         request: WorkspaceImageActiveLeaseRequest<'_>,
     ) -> WorkspaceImageLease {
         let common = WorkspaceImageLeaseCommon::new(self, request.identity);
-        let active_lease = |result, entry_lock, cache_key| {
+        let active_lease = |result, entry_lock, cache_key, lock_decision| {
             WorkspaceImageLease::from_parts(
                 common.lease_base(self),
                 WorkspaceImageLeaseState {
@@ -280,6 +357,7 @@ impl WorkspaceImageCache {
                     entry_lock,
                     workspace_drive_enabled: request.workspace_drive_available,
                     result,
+                    lock_decision,
                 },
             )
         };
@@ -290,27 +368,58 @@ impl WorkspaceImageCache {
                 working_dir = %common.raw_working_dir,
                 "workspace image cache active lease disabled for unsafe working directory"
             );
-            return active_lease(WorkspaceCacheCheckoutResult::InvalidWorkingDir, None, None);
+            return active_lease(
+                WorkspaceCacheCheckoutResult::InvalidWorkingDir,
+                None,
+                None,
+                None,
+            );
         };
         let Some(reuse_key) = common.reuse_key else {
-            return active_lease(WorkspaceCacheCheckoutResult::NoReuseKey, None, None);
+            return active_lease(WorkspaceCacheCheckoutResult::NoReuseKey, None, None, None);
         };
 
         let cache_key = common.cache_key(self, reuse_key, working_dir);
-        match crate::lock::try_acquire(self.entry_lock_path(&cache_key)).await {
-            Ok(lock) => active_lease(
+        match crate::lock::try_acquire_or_busy(self.entry_lock_path(&cache_key)).await {
+            Ok(crate::lock::TryLock::Acquired(lock)) => active_lease(
                 WorkspaceCacheCheckoutResult::Miss,
-                Some(lock),
+                Some(WorkspaceEntryLock::new(
+                    self,
+                    &cache_key,
+                    lock,
+                    WorkspaceCacheLockOwner::Active,
+                )),
                 Some(cache_key),
+                None,
             ),
+            Ok(crate::lock::TryLock::Busy) => {
+                let owner = self.local_entry_lock_owner(&cache_key);
+                info!(
+                    run_id = %common.run_id,
+                    cache_key,
+                    owner = owner.as_str(),
+                    "workspace image cache active lease lock busy; promotion disabled"
+                );
+                active_lease(
+                    WorkspaceCacheCheckoutResult::LockBusy,
+                    None,
+                    None,
+                    Some(WorkspaceCacheLockDecision::Busy(owner)),
+                )
+            }
             Err(e) => {
                 info!(
                     run_id = %common.run_id,
                     cache_key,
                     error = %e,
-                    "workspace image cache active lease lock busy or unavailable; promotion disabled"
+                    "workspace image cache active lease lock unavailable; promotion disabled"
                 );
-                active_lease(WorkspaceCacheCheckoutResult::LockBusy, None, None)
+                active_lease(
+                    WorkspaceCacheCheckoutResult::LockBusy,
+                    None,
+                    None,
+                    Some(WorkspaceCacheLockDecision::Unavailable),
+                )
             }
         }
     }
@@ -337,7 +446,8 @@ impl WorkspaceImageCache {
                                previous_storage: Option<StorageFingerprints>,
                                entry_lock,
                                cache_key,
-                               workspace_drive_enabled| {
+                               workspace_drive_enabled,
+                               lock_decision| {
             let consumed_cache_hit =
                 result == WorkspaceCacheCheckoutResult::Hit && source_image.is_some();
             WorkspaceImageLease::from_parts(
@@ -350,6 +460,7 @@ impl WorkspaceImageCache {
                     entry_lock,
                     workspace_drive_enabled,
                     result,
+                    lock_decision,
                 },
             )
         };
@@ -367,6 +478,7 @@ impl WorkspaceImageCache {
                 None,
                 None,
                 request.workspace_drive_required,
+                None,
             );
         };
         let Some(reuse_key) = common.reuse_key else {
@@ -377,6 +489,7 @@ impl WorkspaceImageCache {
                 None,
                 None,
                 true,
+                None,
             );
         };
         let Ok(mut stats) = self.fs_stats().await else {
@@ -391,6 +504,7 @@ impl WorkspaceImageCache {
                 None,
                 None,
                 true,
+                None,
             );
         };
         let mut budget = CacheBudget::from_fs_stats(stats);
@@ -429,6 +543,7 @@ impl WorkspaceImageCache {
                 None,
                 None,
                 true,
+                None,
             );
         }
 
@@ -437,16 +552,19 @@ impl WorkspaceImageCache {
         let lock = match self.acquire_prepare_lock(lock_path, lock_policy).await {
             Ok(crate::lock::TryLock::Acquired(lock)) => lock,
             Ok(crate::lock::TryLock::Busy) => {
+                let owner = self.local_entry_lock_owner(&cache_key);
                 match lock_policy {
                     WorkspaceImagePrepareLockPolicy::WaitForTransientContention => info!(
                         run_id = %common.run_id,
                         cache_key,
+                        owner = owner.as_str(),
                         wait_ms = duration_ms(WORKSPACE_IMAGE_PREPARE_LOCK_TIMEOUT),
                         "workspace image cache lock remained busy; using fresh workspace image"
                     ),
                     WorkspaceImagePrepareLockPolicy::ImmediateFallback => info!(
                         run_id = %common.run_id,
                         cache_key,
+                        owner = owner.as_str(),
                         wait_ms = 0,
                         "workspace image cache lock busy without retry; using fresh workspace image"
                     ),
@@ -458,6 +576,7 @@ impl WorkspaceImageCache {
                     None,
                     None,
                     true,
+                    Some(WorkspaceCacheLockDecision::Busy(owner)),
                 );
             }
             Err(e) => {
@@ -474,9 +593,11 @@ impl WorkspaceImageCache {
                     None,
                     None,
                     true,
+                    Some(WorkspaceCacheLockDecision::Unavailable),
                 );
             }
         };
+        let lock = WorkspaceEntryLock::new(self, &cache_key, lock, WorkspaceCacheLockOwner::Active);
 
         let entry_dir = self.workspace_image_cache_entry_dir(&cache_key);
         match remove_non_directory_workspace_cache_entry(&entry_dir).await {
@@ -494,6 +615,7 @@ impl WorkspaceImageCache {
                     Some(lock),
                     Some(cache_key),
                     true,
+                    None,
                 );
             }
             Ok(false) => {}
@@ -512,6 +634,7 @@ impl WorkspaceImageCache {
                     Some(lock),
                     Some(cache_key),
                     true,
+                    None,
                 );
             }
         }
@@ -552,6 +675,7 @@ impl WorkspaceImageCache {
                             Some(lock),
                             Some(cache_key),
                             true,
+                            None,
                         );
                     }
                 }
@@ -580,6 +704,7 @@ impl WorkspaceImageCache {
                             Some(lock),
                             Some(cache_key),
                             true,
+                            None,
                         );
                     }
                     Err(remove_error) if remove_error.kind() == std::io::ErrorKind::NotFound => {
@@ -590,6 +715,7 @@ impl WorkspaceImageCache {
                             Some(lock),
                             Some(cache_key),
                             true,
+                            None,
                         );
                     }
                     Err(remove_error) => {
@@ -608,6 +734,7 @@ impl WorkspaceImageCache {
                     Some(lock),
                     Some(cache_key),
                     true,
+                    None,
                 );
             }
         };
@@ -620,6 +747,7 @@ impl WorkspaceImageCache {
                 Some(lock),
                 Some(cache_key),
                 true,
+                None,
             ),
             None => workspace_drive(
                 WorkspaceCacheCheckoutResult::Miss,
@@ -628,6 +756,7 @@ impl WorkspaceImageCache {
                 Some(lock),
                 Some(cache_key),
                 true,
+                None,
             ),
         }
     }
@@ -1259,6 +1388,11 @@ impl WorkspaceImageLease {
         self.result
     }
 
+    pub(crate) fn lock_outcome_and_reason(&self) -> Option<(&'static str, Option<&'static str>)> {
+        self.lock_decision
+            .map(|decision| (decision.outcome(), decision.reason()))
+    }
+
     pub(crate) fn is_cache_hit(&self) -> bool {
         self.result == WorkspaceCacheCheckoutResult::Hit
     }
@@ -1375,10 +1509,15 @@ impl WorkspaceImageLease {
             }
         };
 
+        let mut entry_lock = self.entry_lock.take();
+        if let Some(entry_lock) = entry_lock.as_mut() {
+            entry_lock.set_owner(WorkspaceCacheLockOwner::Finalizing);
+        }
+
         Some(WorkspaceImagePromotionContext {
             cache: self.cache.clone(),
             cache_key: target.cache_key,
-            entry_lock: self.entry_lock.take(),
+            entry_lock,
             run_id,
             sandbox_id,
             profile_name: self.profile_name.clone(),
@@ -1483,7 +1622,12 @@ impl WorkspaceImagePromotionContext {
             Some(_) => None,
             None => {
                 match crate::lock::try_acquire(self.cache.entry_lock_path(&self.cache_key)).await {
-                    Ok(lock) => Some(lock),
+                    Ok(lock) => Some(WorkspaceEntryLock::new(
+                        &self.cache,
+                        &self.cache_key,
+                        lock,
+                        WorkspaceCacheLockOwner::Finalizing,
+                    )),
                     Err(e) => {
                         info!(
                             run_id = %self.run_id,
@@ -1525,7 +1669,12 @@ impl WorkspaceImagePromotionContext {
             Some(_) => None,
             None => {
                 match crate::lock::try_acquire(self.cache.entry_lock_path(&self.cache_key)).await {
-                    Ok(lock) => Some(lock),
+                    Ok(lock) => Some(WorkspaceEntryLock::new(
+                        &self.cache,
+                        &self.cache_key,
+                        lock,
+                        WorkspaceCacheLockOwner::Finalizing,
+                    )),
                     Err(e) => {
                         info!(
                             run_id = %self.run_id,
@@ -1616,7 +1765,12 @@ impl WorkspaceImagePromotionContext {
         let _late_entry_lock_guard = match entry_lock.as_ref() {
             Some(_) => None,
             None => match crate::lock::try_acquire(cache.entry_lock_path(&cache_key)).await {
-                Ok(lock) => Some(lock),
+                Ok(lock) => Some(WorkspaceEntryLock::new(
+                    &cache,
+                    &cache_key,
+                    lock,
+                    WorkspaceCacheLockOwner::Finalizing,
+                )),
                 Err(e) => {
                     warn!(
                         run_id = %run_id,
@@ -1670,7 +1824,7 @@ impl WorkspaceImagePromotionContext {
         let Self {
             cache,
             cache_key,
-            entry_lock,
+            mut entry_lock,
             run_id: _,
             sandbox_id: _,
             profile_name,
@@ -1684,6 +1838,9 @@ impl WorkspaceImagePromotionContext {
             storage_fingerprints,
             restored_session_identity: _,
         } = self;
+        if let Some(entry_lock) = entry_lock.as_mut() {
+            entry_lock.set_owner(WorkspaceCacheLockOwner::Active);
+        }
         let base = WorkspaceImageLeaseBase {
             cache,
             profile_name,
@@ -1702,6 +1859,7 @@ impl WorkspaceImagePromotionContext {
                 entry_lock,
                 workspace_drive_enabled: workspace_drive_available,
                 result: WorkspaceCacheCheckoutResult::Miss,
+                lock_decision: None,
             },
         )
     }

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -61,10 +61,11 @@
 //! - GC refreshes a candidate and compares the current image identity before
 //!   deleting, so concurrent replacement by another runner is preserved.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
@@ -93,8 +94,8 @@ pub(crate) use lifecycle::{
     cap_held_workspace_states,
 };
 pub(crate) use types::{
-    CacheBudget, FsStats, WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus,
-    WorkspaceImageActiveLeaseRequest, WorkspaceImageCacheInspection,
+    CacheBudget, FsStats, WorkspaceCacheCheckoutResult, WorkspaceCacheLockOwner,
+    WorkspaceCacheTerminalStatus, WorkspaceImageActiveLeaseRequest, WorkspaceImageCacheInspection,
     WorkspaceImageCacheInspectionEntry, WorkspaceImageCacheInspectionStatus,
     WorkspaceImageCacheInspectionSummary, WorkspaceImageLeaseIdentity,
     WorkspaceImagePrepareLockPolicy, WorkspaceImagePrepareRequest,
@@ -154,6 +155,7 @@ struct WorkspaceImageCacheInner {
     cache_dir: PathBuf,
     lock_dir: PathBuf,
     cache_scope: String,
+    entry_lock_owners: Mutex<HashMap<String, WorkspaceCacheLockOwner>>,
     #[cfg(test)]
     fs_stats_override: FsStats,
     #[cfg(test)]
@@ -224,6 +226,7 @@ impl WorkspaceImageCache {
                     cache_dir,
                     lock_dir,
                     cache_scope: cache_scope.to_owned(),
+                    entry_lock_owners: Mutex::new(HashMap::new()),
                 }),
                 session_history_sidecar_export_permits: Arc::new(Semaphore::new(
                     MAX_SESSION_HISTORY_SIDECAR_EXPORT_CONCURRENCY,
@@ -246,6 +249,7 @@ impl WorkspaceImageCache {
                 cache_dir,
                 lock_dir,
                 cache_scope: cache_scope.to_owned(),
+                entry_lock_owners: Mutex::new(HashMap::new()),
                 fs_stats_override: fs_stats,
                 gc_root_scan_count: AtomicUsize::new(0),
                 held_state_root_scan_count: AtomicUsize::new(0),

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -155,7 +155,7 @@ struct WorkspaceImageCacheInner {
     cache_dir: PathBuf,
     lock_dir: PathBuf,
     cache_scope: String,
-    entry_lock_owners: Mutex<HashMap<String, WorkspaceCacheLockOwner>>,
+    entry_lock_owners: Mutex<HashMap<String, WorkspaceCacheLockRegistration>>,
     #[cfg(test)]
     fs_stats_override: FsStats,
     #[cfg(test)]
@@ -166,6 +166,12 @@ struct WorkspaceImageCacheInner {
     held_state_root_scan_notify: tokio::sync::Notify,
     #[cfg(test)]
     fail_next_session_history_sidecar_metadata_commit: AtomicBool,
+}
+
+#[derive(Clone)]
+struct WorkspaceCacheLockRegistration {
+    identity: Arc<()>,
+    owner: WorkspaceCacheLockOwner,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
@@ -12,8 +12,8 @@ use super::super::metadata::{
 use super::super::{
     CACHE_FORMAT_VERSION, CacheBudget, FsStats, TEST_FS_TOTAL_BYTES, WORKSPACE_DRIVE_LAYOUT,
     WorkspaceCacheCheckoutResult, WorkspaceCacheTerminalStatus, WorkspaceImageActiveLeaseRequest,
-    WorkspaceImageCache, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
-    WorkspaceImagePromotionRequest,
+    WorkspaceImageCache, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareLockTestGate,
+    WorkspaceImagePrepareRequest, WorkspaceImagePromotionRequest,
 };
 use super::support::{TEST_PROFILE_NAME, local_cache, write_current_cache_entry};
 use crate::ids::RunId;
@@ -830,6 +830,59 @@ async fn lock_busy_checkout_reports_unknown_for_another_cache_instance() {
             workspace_drive_required: false,
         })
         .await;
+
+    assert_eq!(contender.result(), WorkspaceCacheCheckoutResult::LockBusy);
+    assert_eq!(
+        contender.lock_outcome_and_reason(),
+        Some(("busy", Some("unknown")))
+    );
+}
+
+#[tokio::test]
+async fn lock_busy_checkout_does_not_attribute_an_owner_acquired_after_the_first_attempt() {
+    let (_dir, _paths, cache) = local_cache().await;
+    let reuse_key = "thread:changed-lock-owner";
+    let cache_key = workspace_image_cache_key(reuse_key, "/workspace");
+    let external_lock = crate::lock::acquire(cache.entry_lock_path(&cache_key))
+        .await
+        .unwrap();
+    let prepare_lock_gate = WorkspaceImagePrepareLockTestGate::default();
+    let contender_cache = cache
+        .clone()
+        .with_prepare_lock_test_gate(prepare_lock_gate.clone());
+    let contender = tokio::spawn(async move {
+        contender_cache
+            .prepare(WorkspaceImagePrepareRequest {
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id: RunId::new_v4(),
+                    sandbox_id: sandbox::SandboxId::new_v4(),
+                    profile_name: TEST_PROFILE_NAME,
+                    reuse_key: Some(reuse_key),
+                    working_dir: "/workspace",
+                    image_size_bytes: 5,
+                },
+                workspace_drive_required: false,
+            })
+            .await
+    });
+    prepare_lock_gate.wait_entered(Duration::from_secs(1)).await;
+
+    drop(external_lock);
+    let _replacement_owner = cache
+        .lease_active(WorkspaceImageActiveLeaseRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
+            workspace_drive_available: true,
+        })
+        .await;
+    prepare_lock_gate.release();
+    let contender = contender.await.unwrap();
 
     assert_eq!(contender.result(), WorkspaceCacheCheckoutResult::LockBusy);
     assert_eq!(

--- a/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/tests/lifecycle.rs
@@ -716,3 +716,124 @@ async fn active_lease_hides_cached_reuse_key_until_dropped() {
     drop(lease);
     assert_eq!(cache.held_workspace_states().await.len(), 1);
 }
+
+#[tokio::test]
+async fn lock_busy_checkout_reports_local_active_and_finalizing_owners() {
+    let (_dir, _paths, cache) = local_cache().await;
+    let reuse_key = "thread:local-lock-owner";
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let active_lease = cache
+        .lease_active(WorkspaceImageActiveLeaseRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
+            workspace_drive_available: true,
+        })
+        .await;
+
+    let active_contender = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+    assert_eq!(
+        active_contender.result(),
+        WorkspaceCacheCheckoutResult::LockBusy
+    );
+    assert_eq!(
+        active_contender.lock_outcome_and_reason(),
+        Some(("busy", Some("active")))
+    );
+
+    let promotion = active_lease
+        .into_promotion_context(WorkspaceImagePromotionRequest {
+            run_id: RunId::new_v4(),
+            sandbox_id,
+            restored_session_identity: None,
+            terminal_status: WorkspaceCacheTerminalStatus::Success,
+            completed_at: "2026-09-03T00:00:00.000Z".into(),
+            storage_fingerprints: StorageFingerprints::default(),
+        })
+        .expect("active lease should retain a promotion target");
+    let finalizing_contender = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+    assert_eq!(
+        finalizing_contender.result(),
+        WorkspaceCacheCheckoutResult::LockBusy
+    );
+    assert_eq!(
+        finalizing_contender.lock_outcome_and_reason(),
+        Some(("busy", Some("finalizing")))
+    );
+    drop(promotion);
+}
+
+#[tokio::test]
+async fn lock_busy_checkout_reports_unknown_for_another_cache_instance() {
+    let (_dir, paths, owner_cache) = local_cache().await;
+    let contender_cache = WorkspaceImageCache::new_with_fs_stats(
+        paths,
+        FsStats {
+            total_bytes: TEST_FS_TOTAL_BYTES,
+            available_bytes: TEST_FS_TOTAL_BYTES,
+        },
+    );
+    let reuse_key = "thread:cross-instance-lock-owner";
+    let _active_lease = owner_cache
+        .lease_active(WorkspaceImageActiveLeaseRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
+            workspace_drive_available: true,
+        })
+        .await;
+
+    let contender = contender_cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id: RunId::new_v4(),
+                sandbox_id: sandbox::SandboxId::new_v4(),
+                profile_name: TEST_PROFILE_NAME,
+                reuse_key: Some(reuse_key),
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+
+    assert_eq!(contender.result(), WorkspaceCacheCheckoutResult::LockBusy);
+    assert_eq!(
+        contender.lock_outcome_and_reason(),
+        Some(("busy", Some("unknown")))
+    );
+}

--- a/crates/runner/src/workspace_image_cache/types.rs
+++ b/crates/runner/src/workspace_image_cache/types.rs
@@ -18,6 +18,45 @@ pub(crate) enum WorkspaceCacheCheckoutResult {
     DiskPressure,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkspaceCacheLockOwner {
+    Active,
+    Finalizing,
+    Unknown,
+}
+
+impl WorkspaceCacheLockOwner {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Finalizing => "finalizing",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkspaceCacheLockDecision {
+    Busy(WorkspaceCacheLockOwner),
+    Unavailable,
+}
+
+impl WorkspaceCacheLockDecision {
+    pub(crate) const fn outcome(self) -> &'static str {
+        match self {
+            Self::Busy(_) => "busy",
+            Self::Unavailable => "unavailable",
+        }
+    }
+
+    pub(crate) const fn reason(self) -> Option<&'static str> {
+        match self {
+            Self::Busy(owner) => Some(owner.as_str()),
+            Self::Unavailable => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) enum WorkspaceCacheTerminalStatus {


### PR DESCRIPTION
Closes #31456

## Summary

- classify phase-aware finalizing handoff fallback and exact-idle misses with bounded, authoritative telemetry values
- report one terminal exact-idle decision while preserving existing handoff actions and outcomes
- attribute workspace-cache lock contention only to stable, locally proven active/finalizing owners; otherwise report unknown or unavailable

## Compatibility

- reuses the existing optional operation `outcome` and `reason` fields
- preserves current action names, aggregate outcomes, fallback behavior, and timing
- keeps changed, cross-instance, and cross-process lock ownership intentionally unknown instead of inferring it

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- focused idle-pool, finalizing telemetry, workspace-cache lifecycle, and executor telemetry tests
- `cargo test -p runner --all-features` (3437 passed, 25 ignored; guest inventory passed)
- pre-commit Rust workspace formatting, Clippy, and documentation checks
