### PR TITLE
fix(auth): prevent decorative overflow from scrolling

### DIFF
--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -125,6 +125,36 @@ describe("auth v2 presentation", () => {
     expect(announcer).toHaveAttribute("aria-live", "polite");
   });
 
+  it.each(["/sign-in", "/sign-up"])(
+    "clips decorative overflow without disabling content scrolling on %s",
+    async (path) => {
+      setBrowserUrl(`https://app.vm0.ai${path}`);
+
+      detachedSetupPage({ context, path });
+
+      await screen.findByTestId("app-auth-v2");
+      const layout = screen.getByTestId("app-auth-layout");
+      const background = screen.getByTestId("app-auth-background");
+      const styleElement = document.createElement("style");
+      const tailwindCompiler = await compile("@tailwind utilities;");
+      styleElement.textContent = tailwindCompiler.build([
+        ...layout.classList,
+        ...background.classList,
+      ]);
+      document.head.append(styleElement);
+      context.signal.addEventListener(
+        "abort",
+        () => {
+          styleElement.remove();
+        },
+        { once: true },
+      );
+
+      expect(getComputedStyle(layout).overflowY).toBe("auto");
+      expect(getComputedStyle(background).overflow).toBe("hidden");
+    },
+  );
+
   it("keeps password controls in their accessible region", async () => {
     setBrowserUrl("https://app.vm0.ai/sign-up");
 

--- a/turbo/apps/platform/src/views/auth/auth-shell.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-shell.tsx
@@ -26,11 +26,17 @@ export function AuthShell({ authBrand, children }: AuthShellProps) {
       className="zero-app relative flex h-full min-h-0 overflow-x-hidden overflow-y-auto bg-background p-6"
       data-testid="app-auth-layout"
     >
-      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--primary)/0.06)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--primary)/0.06)_1px,transparent_1px)] bg-[size:3rem_3rem]" />
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-[#FFC8B0]/20 via-[#A6DEFF]/15 to-[#FFE7A2]/20 blur-3xl" />
-      <div className="pointer-events-none absolute -top-40 -left-40 h-96 w-96 rounded-full bg-[#FFC8B0]/15 blur-3xl" />
-      <div className="pointer-events-none absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#A6DEFF]/10 blur-3xl" />
-      <div className="pointer-events-none absolute -right-40 -bottom-40 h-96 w-96 rounded-full bg-[#FFE7A2]/15 blur-3xl" />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 overflow-hidden"
+        data-testid="app-auth-background"
+      >
+        <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--primary)/0.06)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--primary)/0.06)_1px,transparent_1px)] bg-[size:3rem_3rem]" />
+        <div className="absolute inset-0 bg-gradient-to-r from-[#FFC8B0]/20 via-[#A6DEFF]/15 to-[#FFE7A2]/20 blur-3xl" />
+        <div className="absolute -top-40 -left-40 h-96 w-96 rounded-full bg-[#FFC8B0]/15 blur-3xl" />
+        <div className="absolute top-1/2 left-1/2 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#A6DEFF]/10 blur-3xl" />
+        <div className="absolute -right-40 -bottom-40 h-96 w-96 rounded-full bg-[#FFE7A2]/15 blur-3xl" />
+      </div>
 
       <Button
         showTooltip


### PR DESCRIPTION
## Summary

- clip the shared authentication background in its own visual layer
- preserve vertical scrolling for authentication content on genuinely constrained viewports
- cover both sign-in and sign-up presentation behavior

## Root cause

The decorative orb positioned with `-bottom-40` participated in the shared layout's scrollable overflow. That added a 160 px blank scroll range even when the authentication card fit inside the viewport.

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx --silent=passed-only`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `git diff --check`
- PR Preview at 1440 x 900: sign-in and sign-up both have 0 px horizontal and vertical scroll range
- PR Preview at 390 x 600: overflowing sign-up content remains scrollable through its full 271 px range
