### PR TITLE
chore(api): stop serving the frozen zero desktop update line

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -14,10 +14,10 @@ import { testDesktopUpdateManifestStateRoutes } from "../test-desktop-update-man
 const TEST_APP_ROUTES = Object.freeze([...desktopUpdateRoutes]);
 
 const context = testContext();
-const DESKTOP_UPDATE_MANIFEST_URL =
-  "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
 const OKOU_DESKTOP_UPDATE_MANIFEST_URL =
   "https://github.com/vm0-ai/vm0/releases/download/ai-okou-desktop-updates/ai-okou-desktop-update-manifest.json";
+const LEGACY_OKOU_DESKTOP_UPDATE_MANIFEST_URL =
+  "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-updates/okou-desktop-update-manifest.json";
 
 interface DesktopUpdateRelease {
   readonly version: string;
@@ -29,7 +29,7 @@ interface DesktopUpdateRelease {
 
 interface DesktopUpdateManifest {
   readonly schemaVersion: 1;
-  readonly product?: "zero" | "okou";
+  readonly product?: "okou";
   readonly channels: Record<
     string,
     { readonly latest: string; readonly blocked?: readonly string[] }
@@ -60,7 +60,7 @@ function appRequest(path: string): Promise<Response> {
 
 function mockDesktopUpdateManifest(
   manifest: DesktopUpdateManifest,
-  manifestUrl = DESKTOP_UPDATE_MANIFEST_URL,
+  manifestUrl = OKOU_DESKTOP_UPDATE_MANIFEST_URL,
 ): void {
   server.use(
     http.get(manifestUrl, () => {
@@ -76,6 +76,7 @@ function stableManifest(
 ): DesktopUpdateManifest {
   return {
     schemaVersion: 1,
+    product: "okou",
     channels: {
       stable: { latest, blocked: [...blocked] },
     },
@@ -83,17 +84,10 @@ function stableManifest(
   };
 }
 
-function darwinArm64Release(
-  version: string,
-  url: string,
-  productName = "Zero",
-) {
+function darwinArm64Release(version: string, url: string) {
   return {
     version,
-    name:
-      productName === "Okou"
-        ? `Okou ${version}`
-        : `Zero Computer Use ${version}`,
+    name: `Okou ${version}`,
     notes: `Release ${version}`,
     pubDate: "2026-06-08T00:00:00.000Z",
     platforms: {
@@ -107,7 +101,7 @@ function darwinArm64Release(
 function legacyDarwinX64Release(version: string, url: string) {
   return {
     version,
-    name: `Zero Computer Use ${version}`,
+    name: `Okou ${version}`,
     notes: `Release ${version}`,
     pubDate: "2026-06-08T00:00:00.000Z",
     platforms: {
@@ -116,6 +110,10 @@ function legacyDarwinX64Release(version: string, url: string) {
       },
     },
   };
+}
+
+function okouZipUrl(version: string): string {
+  return `https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v${version}/Okou-darwin-arm64-${version}.zip`;
 }
 
 describe("desktop update routes", () => {
@@ -142,36 +140,27 @@ describe("desktop update routes", () => {
   // is the only one either route serves.
   //
   // The update line is asserted alongside the path, because the move alone
-  // would have changed it: the neutral path has to serve the Okou line the
-  // `okou` form served rather than the Zero line. Both manifests are mocked, so
-  // reading the wrong one resolves to a Zero artifact and fails here rather
-  // than 404ing. Every expectation is written out rather than derived from the
-  // path under test, which would assert nothing.
+  // would have changed it: the neutral path has to serve the final
+  // `ai-okou-desktop` line rather than the pre-adoption `okou` line it
+  // succeeded. Both Okou manifests are mocked at different versions, so reading
+  // the wrong one resolves to the wrong release and fails here rather than
+  // 404ing. Every expectation is written out rather than derived from the path
+  // under test, which would assert nothing.
   //
-  // Two plainer redirect cases and an `/api/okou` cutover case used to sit
-  // beside this one. #31088 left them without a path of their own to drive, and
-  // what they asserted is covered here.
+  // The unqualified DMG route is what the Zero migration wall's `Download Okou`
+  // button opens and what the bridge compiled into installed Zero builds
+  // hard-codes, so this case guards a live migration dependency.
   it("serves the moved desktop routes on the neutral path", async () => {
     mockDesktopUpdateManifest(
       stableManifest("0.12.0", {
-        "0.12.0": darwinArm64Release(
-          "0.12.0",
-          "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.12.0/Zero-darwin-arm64-0.12.0.zip",
-        ),
+        "0.12.0": darwinArm64Release("0.12.0", okouZipUrl("0.12.0")),
       }),
+      LEGACY_OKOU_DESKTOP_UPDATE_MANIFEST_URL,
     );
     mockDesktopUpdateManifest(
-      {
-        ...stableManifest("1.2.3", {
-          "1.2.3": darwinArm64Release(
-            "1.2.3",
-            "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip",
-            "Okou",
-          ),
-        }),
-        product: "okou",
-      },
-      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
+      stableManifest("1.2.3", {
+        "1.2.3": darwinArm64Release("1.2.3", okouZipUrl("1.2.3")),
+      }),
     );
 
     const releaseResponse = await appRequest(
@@ -195,56 +184,24 @@ describe("desktop update routes", () => {
     expect(dmgResponse.headers.get("Cache-Control")).toBe("no-store");
   });
 
-  it("serves the current stable macOS arm64 update from the manifest", async () => {
-    const zipUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.1/Zero-darwin-arm64-0.2.1.zip";
-    mockDesktopUpdateManifest(
-      stableManifest("0.2.1", {
-        "0.2.1": darwinArm64Release("0.2.1", zipUrl),
-      }),
-    );
-
-    const response = await accept(
-      client().feed({
-        params: { channel: "stable", platform: "darwin", arch: "arm64" },
-      }),
-      [200],
-    );
-
-    expect(response.body).toStrictEqual({
-      currentRelease: "0.2.1",
-      releases: [
-        {
-          version: "0.2.1",
-          updateTo: {
-            name: "Zero Computer Use 0.2.1",
-            version: "0.2.1",
-            pub_date: "2026-06-08T00:00:00.000Z",
-            url: zipUrl,
-            notes: "Release 0.2.1",
-          },
-        },
-      ],
-    });
-  });
-
   it("caches the desktop manifest until the 60-second ttl expires", async () => {
     const initialNow = Date.parse("2026-06-08T00:00:00.000Z");
-    const firstZipUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.1/Zero-darwin-arm64-0.2.1.zip";
-    const refreshedZipUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.2/Zero-darwin-arm64-0.2.2.zip";
 
     await withMockNowForTest(initialNow, async () => {
       mockDesktopUpdateManifest(
         stableManifest("0.2.1", {
-          "0.2.1": darwinArm64Release("0.2.1", firstZipUrl),
+          "0.2.1": darwinArm64Release("0.2.1", okouZipUrl("0.2.1")),
         }),
       );
 
       const firstResponse = await accept(
-        client().feed({
-          params: { channel: "stable", platform: "darwin", arch: "arm64" },
+        client().productFeed({
+          params: {
+            product: "ai-okou-desktop",
+            channel: "stable",
+            platform: "darwin",
+            arch: "arm64",
+          },
         }),
         [200],
       );
@@ -252,14 +209,19 @@ describe("desktop update routes", () => {
 
       mockDesktopUpdateManifest(
         stableManifest("0.2.2", {
-          "0.2.2": darwinArm64Release("0.2.2", refreshedZipUrl),
+          "0.2.2": darwinArm64Release("0.2.2", okouZipUrl("0.2.2")),
         }),
       );
       mockNow(initialNow + 59_999);
 
       const cachedResponse = await accept(
-        client().feed({
-          params: { channel: "stable", platform: "darwin", arch: "arm64" },
+        client().productFeed({
+          params: {
+            product: "ai-okou-desktop",
+            channel: "stable",
+            platform: "darwin",
+            arch: "arm64",
+          },
         }),
         [200],
       );
@@ -268,8 +230,13 @@ describe("desktop update routes", () => {
       mockNow(initialNow + 60_000);
 
       const refreshedResponse = await accept(
-        client().feed({
-          params: { channel: "stable", platform: "darwin", arch: "arm64" },
+        client().productFeed({
+          params: {
+            product: "ai-okou-desktop",
+            channel: "stable",
+            platform: "darwin",
+            arch: "arm64",
+          },
         }),
         [200],
       );
@@ -278,16 +245,11 @@ describe("desktop update routes", () => {
   });
 
   it("serves an Okou release only from the isolated Okou manifest", async () => {
-    const zipUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip";
+    const zipUrl = okouZipUrl("1.2.3");
     mockDesktopUpdateManifest(
-      {
-        ...stableManifest("1.2.3", {
-          "1.2.3": darwinArm64Release("1.2.3", zipUrl, "Okou"),
-        }),
-        product: "okou",
-      },
-      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
+      stableManifest("1.2.3", {
+        "1.2.3": darwinArm64Release("1.2.3", zipUrl),
+      }),
     );
 
     const response = await accept(
@@ -320,16 +282,10 @@ describe("desktop update routes", () => {
   });
 
   it("redirects the final Okou line to final-identity release assets", async () => {
-    const zipUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip";
     mockDesktopUpdateManifest(
-      {
-        ...stableManifest("1.2.3", {
-          "1.2.3": darwinArm64Release("1.2.3", zipUrl, "Okou"),
-        }),
-        product: "okou",
-      },
-      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
+      stableManifest("1.2.3", {
+        "1.2.3": darwinArm64Release("1.2.3", okouZipUrl("1.2.3")),
+      }),
     );
 
     const releaseResponse = await appRequest(
@@ -349,30 +305,26 @@ describe("desktop update routes", () => {
     );
   });
 
-  it("returns not found for the retired pre-adoption Okou update line", async () => {
-    for (const path of [
-      "/api/desktop/updates/okou/stable/darwin/arm64/release",
-      "/api/desktop/updates/okou/stable/darwin/arm64/dmg",
-      "/api/desktop/updates/okou/stable/darwin/arm64/RELEASES.json",
-    ]) {
-      const response = await appRequest(`http://api.test${path}`);
+  it("returns not found for the retired desktop update lines", async () => {
+    for (const line of ["okou", "zero"]) {
+      for (const suffix of ["release", "dmg", "RELEASES.json"]) {
+        const response = await appRequest(
+          `http://api.test/api/desktop/updates/${line}/stable/darwin/arm64/${suffix}`,
+        );
 
-      expect(response.status).toBe(404);
+        expect(response.status).toBe(404);
+      }
     }
   });
 
   it("does not serve a Zero artifact from the final Okou feed", async () => {
     mockDesktopUpdateManifest(
-      {
-        ...stableManifest("1.2.3", {
-          "1.2.3": darwinArm64Release(
-            "1.2.3",
-            "https://github.com/vm0-ai/vm0/releases/download/desktop-v1.2.3/Zero-darwin-arm64-1.2.3.zip",
-          ),
-        }),
-        product: "okou",
-      },
-      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
+      stableManifest("1.2.3", {
+        "1.2.3": darwinArm64Release(
+          "1.2.3",
+          "https://github.com/vm0-ai/vm0/releases/download/desktop-v1.2.3/Zero-darwin-arm64-1.2.3.zip",
+        ),
+      }),
     );
 
     const response = await accept(
@@ -390,38 +342,18 @@ describe("desktop update routes", () => {
     expect(response.body.error.code).toBe("NOT_FOUND");
   });
 
-  it("does not serve an Okou artifact from the legacy Zero feed", async () => {
+  it("rejects the retired macOS x64 update feed", async () => {
     mockDesktopUpdateManifest(
-      stableManifest("1.2.3", {
-        "1.2.3": darwinArm64Release(
-          "1.2.3",
-          "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v1.2.3/Okou-darwin-arm64-1.2.3.zip",
-          "Okou",
+      stableManifest("0.2.1", {
+        "0.2.1": legacyDarwinX64Release(
+          "0.2.1",
+          "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v0.2.1/Okou-darwin-x64-0.2.1.zip",
         ),
       }),
     );
 
-    const response = await accept(
-      client().feed({
-        params: { channel: "stable", platform: "darwin", arch: "arm64" },
-      }),
-      [404],
-    );
-
-    expect(response.body.error.code).toBe("NOT_FOUND");
-  });
-
-  it("rejects the retired macOS x64 update feed", async () => {
-    const zipUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.1/Zero-darwin-x64-0.2.1.zip";
-    mockDesktopUpdateManifest(
-      stableManifest("0.2.1", {
-        "0.2.1": legacyDarwinX64Release("0.2.1", zipUrl),
-      }),
-    );
-
     const response = await appRequest(
-      "http://api.test/api/desktop/updates/stable/darwin/x64/RELEASES.json",
+      "http://api.test/api/desktop/updates/ai-okou-desktop/stable/darwin/x64/RELEASES.json",
     );
 
     expect(response.status).toBe(400);
@@ -429,11 +361,12 @@ describe("desktop update routes", () => {
   });
 
   it("rejects the retired macOS x64 dmg download", async () => {
-    const zipUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.12.0/Zero-darwin-x64-0.12.0.zip";
     mockDesktopUpdateManifest(
       stableManifest("0.12.0", {
-        "0.12.0": legacyDarwinX64Release("0.12.0", zipUrl),
+        "0.12.0": legacyDarwinX64Release(
+          "0.12.0",
+          "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v0.12.0/Okou-darwin-x64-0.12.0.zip",
+        ),
       }),
     );
 
@@ -446,29 +379,27 @@ describe("desktop update routes", () => {
   });
 
   it("does not return a blocked latest release", async () => {
-    const previousUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.1/Zero-darwin-arm64-0.2.1.zip";
+    const previousUrl = okouZipUrl("0.2.1");
     mockDesktopUpdateManifest(
       stableManifest(
         "0.2.2",
         {
           "0.2.1": darwinArm64Release("0.2.1", previousUrl),
-          "0.2.2": darwinArm64Release(
-            "0.2.2",
-            "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.2/Zero-darwin-arm64-0.2.2.zip",
-          ),
-          "0.3.0": darwinArm64Release(
-            "0.3.0",
-            "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.3.0/Zero-darwin-arm64-0.3.0.zip",
-          ),
+          "0.2.2": darwinArm64Release("0.2.2", okouZipUrl("0.2.2")),
+          "0.3.0": darwinArm64Release("0.3.0", okouZipUrl("0.3.0")),
         },
         ["0.2.2"],
       ),
     );
 
     const response = await accept(
-      client().feed({
-        params: { channel: "stable", platform: "darwin", arch: "arm64" },
+      client().productFeed({
+        params: {
+          product: "ai-okou-desktop",
+          channel: "stable",
+          platform: "darwin",
+          arch: "arm64",
+        },
       }),
       [200],
     );
@@ -491,8 +422,13 @@ describe("desktop update routes", () => {
     );
 
     const response = await accept(
-      client().feed({
-        params: { channel: "stable", platform: "darwin", arch: "arm64" },
+      client().productFeed({
+        params: {
+          product: "ai-okou-desktop",
+          channel: "stable",
+          platform: "darwin",
+          arch: "arm64",
+        },
       }),
       [404],
     );
@@ -501,16 +437,10 @@ describe("desktop update routes", () => {
   });
 
   it("returns not found when no dmg release is available", async () => {
-    const zipUrl =
-      "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-v0.11.2/Okou-darwin-arm64-0.11.2.zip";
     mockDesktopUpdateManifest(
-      {
-        ...stableManifest("0.11.2", {
-          "0.11.2": darwinArm64Release("0.11.2", zipUrl, "Okou"),
-        }),
-        product: "okou",
-      },
-      OKOU_DESKTOP_UPDATE_MANIFEST_URL,
+      stableManifest("0.11.2", {
+        "0.11.2": darwinArm64Release("0.11.2", okouZipUrl("0.11.2")),
+      }),
     );
 
     const response = await appRequest(

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -4,7 +4,6 @@ import {
   DESKTOP_UPDATE_LINE_ZERO,
   desktopUpdatesContract,
   type DesktopZeroMigrationPolicy,
-  type DesktopUpdateLine,
 } from "@okouai/api-contracts/contracts/desktop-updates";
 import { command } from "ccstate";
 
@@ -18,7 +17,6 @@ import {
   loadDesktopUpdateFeed,
 } from "../services/desktop-updates.service";
 
-const feedParams$ = pathParamsOf(desktopUpdatesContract.feed);
 const releasePageParams$ = pathParamsOf(desktopUpdatesContract.releasePage);
 const dmgDownloadParams$ = pathParamsOf(desktopUpdatesContract.dmgDownload);
 const productFeedParams$ = pathParamsOf(desktopUpdatesContract.productFeed);
@@ -63,18 +61,15 @@ const getDesktopMigrationPolicy$ = command(({ set }) => {
  * than a new one: the platform download button and the Zero migration bridge
  * both point at it and both expect an Okou artifact.
  *
- * These two routes used to read the line off the request namespace, so the
- * `/api/zero/**` compatibility alias kept resolving to the Zero line its
- * callers reached before the move. #31088 removed the branded compatibility
- * rows that registered that alias, #31090 removed the mechanism behind them,
- * and nothing else registers a branded path, so no request can arrive on one
- * and the Zero branch had no reachable input left. The Zero line is still
- * reachable through
- * `productFeed`, `productReleasePage` and `productDmgDownload`, which name it
- * in the path.
+ * `/api/desktop/updates/stable/darwin/arm64/dmg` is what the migration wall's
+ * `Download Okou` button opens and what the bridge compiled into installed Zero
+ * builds hard-codes, so this constant must keep resolving to the current Okou
+ * DMG. The unqualified RELEASES.json feed used to resolve to Zero instead;
+ * #31475 removed that route rather than aligning it, because a Zero client
+ * cannot cross to the Okou bundle through Squirrel and no other caller reached
+ * it.
  */
-const UNQUALIFIED_DESKTOP_UPDATE_LINE: DesktopUpdateLine =
-  DESKTOP_UPDATE_LINE_OKOU;
+const UNQUALIFIED_DESKTOP_UPDATE_LINE = DESKTOP_UPDATE_LINE_OKOU;
 
 const getDesktopReleasePage$ = command(async ({ get }, signal: AbortSignal) => {
   const url = await loadDesktopReleasePageUrl(
@@ -97,23 +92,6 @@ const getDesktopReleasePage$ = command(async ({ get }, signal: AbortSignal) => {
       "Cache-Control": "no-store",
     },
   });
-});
-
-const getDesktopUpdateFeed$ = command(async ({ get }, signal: AbortSignal) => {
-  const feed = await loadDesktopUpdateFeed(
-    { line: DESKTOP_UPDATE_LINE_ZERO, ...get(feedParams$) },
-    signal,
-  );
-  signal.throwIfAborted();
-
-  if (!feed) {
-    return notFound("No desktop update is available for this feed.");
-  }
-
-  return {
-    status: 200 as const,
-    body: feed,
-  };
 });
 
 const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
@@ -139,10 +117,23 @@ const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
   });
 });
 
+/**
+ * The update lines the `:product` routes still accept in the path but no longer
+ * serve.
+ *
+ * `okou` is the pre-adoption Okou line. `zero` joined it in #31475: its
+ * manifest had been frozen since the `hard` migration policy went live, and the
+ * only clients left polling it were Squirrel auto-updaters that cannot cross
+ * from the Zero bundle to the Okou one, so the feed could not upgrade anyone.
+ * Neither line is removed from the contract union — see the note there.
+ */
 const getProductDesktopReleasePage$ = command(
   async ({ get }, signal: AbortSignal) => {
     const { product, ...params } = get(productReleasePageParams$);
-    if (product === DESKTOP_UPDATE_LINE_LEGACY_OKOU) {
+    if (
+      product === DESKTOP_UPDATE_LINE_LEGACY_OKOU ||
+      product === DESKTOP_UPDATE_LINE_ZERO
+    ) {
       return notFound("This desktop update line is retired.");
     }
     const url = await loadDesktopReleasePageUrl(
@@ -168,7 +159,10 @@ const getProductDesktopReleasePage$ = command(
 const getProductDesktopUpdateFeed$ = command(
   async ({ get }, signal: AbortSignal) => {
     const { product, ...params } = get(productFeedParams$);
-    if (product === DESKTOP_UPDATE_LINE_LEGACY_OKOU) {
+    if (
+      product === DESKTOP_UPDATE_LINE_LEGACY_OKOU ||
+      product === DESKTOP_UPDATE_LINE_ZERO
+    ) {
       return notFound("This desktop update line is retired.");
     }
     const feed = await loadDesktopUpdateFeed(
@@ -191,7 +185,10 @@ const getProductDesktopUpdateFeed$ = command(
 const getProductDesktopDmgDownload$ = command(
   async ({ get }, signal: AbortSignal) => {
     const { product, ...params } = get(productDmgDownloadParams$);
-    if (product === DESKTOP_UPDATE_LINE_LEGACY_OKOU) {
+    if (
+      product === DESKTOP_UPDATE_LINE_LEGACY_OKOU ||
+      product === DESKTOP_UPDATE_LINE_ZERO
+    ) {
       return notFound("This desktop update line is retired.");
     }
     const url = await loadDesktopDmgDownloadUrl(
@@ -226,10 +223,6 @@ export const desktopUpdateRoutes: readonly RouteEntry[] = [
   {
     route: desktopUpdatesContract.dmgDownload,
     handler: getDesktopDmgDownload$,
-  },
-  {
-    route: desktopUpdatesContract.feed,
-    handler: getDesktopUpdateFeed$,
   },
   {
     route: desktopUpdatesContract.productReleasePage,

--- a/turbo/apps/api/src/signals/routes/desktop-updates.ts
+++ b/turbo/apps/api/src/signals/routes/desktop-updates.ts
@@ -117,16 +117,13 @@ const getDesktopDmgDownload$ = command(async ({ get }, signal: AbortSignal) => {
   });
 });
 
-/**
- * The update lines the `:product` routes still accept in the path but no longer
- * serve.
- *
- * `okou` is the pre-adoption Okou line. `zero` joined it in #31475: its
- * manifest had been frozen since the `hard` migration policy went live, and the
- * only clients left polling it were Squirrel auto-updaters that cannot cross
- * from the Zero bundle to the Okou one, so the feed could not upgrade anyone.
- * Neither line is removed from the contract union — see the note there.
- */
+// All three `:product` handlers below reject the same retired lines. `okou` is
+// the pre-adoption Okou line. `zero` joined it in #31475: its manifest had been
+// frozen since the `hard` migration policy went live, and the only clients left
+// polling it were Squirrel auto-updaters that cannot cross from the Zero bundle
+// to the Okou one, so the feed could not upgrade anyone. Neither line is
+// removed from the contract union — see the note there.
+
 const getProductDesktopReleasePage$ = command(
   async ({ get }, signal: AbortSignal) => {
     const { product, ...params } = get(productReleasePageParams$);

--- a/turbo/apps/api/src/signals/services/desktop-updates.service.ts
+++ b/turbo/apps/api/src/signals/services/desktop-updates.service.ts
@@ -11,8 +11,6 @@ import {
 import {
   DESKTOP_PRODUCTS,
   DESKTOP_PRODUCT_OKOU,
-  DESKTOP_PRODUCT_ZERO,
-  type DesktopProduct,
 } from "@okouai/api-contracts/contracts/client-headers";
 import { z } from "zod";
 
@@ -27,10 +25,27 @@ const MIN_DESKTOP_DMG_VERSION = "0.12.0";
 
 const DESKTOP_UPDATE_MANIFEST_CACHE_TTL_MS = 60_000;
 
-function desktopUpdateManifestUrl(line: DesktopUpdateLine): string {
-  if (line === DESKTOP_UPDATE_LINE_ZERO) {
-    return "https://github.com/vm0-ai/vm0/releases/download/desktop-updates/desktop-update-manifest.json";
-  }
+/**
+ * Every artifact this service can still name belongs to the Okou desktop
+ * product. #31475 removed the Zero line, so the artifact name and release tag
+ * prefix are no longer derived per line.
+ */
+const DESKTOP_ARTIFACT_NAME = "Okou";
+const DESKTOP_RELEASE_TAG_PREFIX = "okou-desktop-v";
+
+/**
+ * The update lines this service can resolve a manifest for.
+ *
+ * The Zero line is excluded rather than left unreachable, so that the compiler
+ * rejects any future caller that tries to resolve a Zero artifact. The route
+ * layer narrows `:product` past the retired lines before calling in.
+ */
+type ServedDesktopUpdateLine = Exclude<
+  DesktopUpdateLine,
+  typeof DESKTOP_UPDATE_LINE_ZERO
+>;
+
+function desktopUpdateManifestUrl(line: ServedDesktopUpdateLine): string {
   if (line === DESKTOP_UPDATE_LINE_LEGACY_OKOU) {
     return "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-updates/okou-desktop-update-manifest.json";
   }
@@ -38,20 +53,6 @@ function desktopUpdateManifestUrl(line: DesktopUpdateLine): string {
     return "https://github.com/vm0-ai/vm0/releases/download/ai-okou-desktop-updates/ai-okou-desktop-update-manifest.json";
   }
   return line satisfies never;
-}
-
-function desktopProductForUpdateLine(line: DesktopUpdateLine): DesktopProduct {
-  return line === DESKTOP_UPDATE_LINE_ZERO
-    ? DESKTOP_PRODUCT_ZERO
-    : DESKTOP_PRODUCT_OKOU;
-}
-
-function desktopProductArtifactName(product: DesktopProduct): string {
-  return product === DESKTOP_PRODUCT_OKOU ? "Okou" : "Zero";
-}
-
-function desktopProductReleaseTagPrefix(product: DesktopProduct): string {
-  return product === DESKTOP_PRODUCT_OKOU ? "okou-desktop-v" : "desktop-v";
 }
 
 const desktopUpdateAssetSchema = z.object({
@@ -84,7 +85,7 @@ const desktopUpdateManifestSchema = z.object({
 type DesktopUpdateManifest = z.infer<typeof desktopUpdateManifestSchema>;
 
 interface DesktopUpdateFeedRequest {
-  readonly line: DesktopUpdateLine;
+  readonly line: ServedDesktopUpdateLine;
   readonly channel: DesktopUpdateChannel;
   readonly platform: DesktopUpdatePlatform;
   readonly arch: DesktopUpdateArchitecture;
@@ -96,13 +97,13 @@ interface DesktopUpdateManifestCacheEntry {
 }
 
 const desktopUpdateManifestCache = testOverride<
-  Partial<Record<DesktopUpdateLine, DesktopUpdateManifestCacheEntry>>
+  Partial<Record<ServedDesktopUpdateLine, DesktopUpdateManifestCacheEntry>>
 >(() => {
   return {};
 });
 
 const desktopUpdateManifestOverride = testOverride<
-  Partial<Record<DesktopUpdateLine, DesktopUpdateManifest>>
+  Partial<Record<ServedDesktopUpdateLine, DesktopUpdateManifest>>
 >(() => {
   return {};
 });
@@ -139,8 +140,7 @@ function assetForRelease(
     return null;
   }
 
-  const product = desktopProductForUpdateLine(request.line);
-  const expectedAssetName = `${desktopProductArtifactName(product)}-${request.platform}-${request.arch}-${release.version}.zip`;
+  const expectedAssetName = `${DESKTOP_ARTIFACT_NAME}-${request.platform}-${request.arch}-${release.version}.zip`;
   const actualAssetName = decodeURIComponent(
     new URL(asset.url).pathname.split("/").at(-1) ?? "",
   );
@@ -150,14 +150,11 @@ function assetForRelease(
 function squirrelRelease(
   release: DesktopUpdateManifest["releases"][string],
   asset: { readonly url: string },
-  product: DesktopProduct,
 ) {
   return {
     version: release.version,
     updateTo: {
-      name:
-        release.name ??
-        `${desktopProductArtifactName(product)} ${release.version}`,
+      name: release.name ?? `${DESKTOP_ARTIFACT_NAME} ${release.version}`,
       version: release.version,
       pub_date: release.pubDate,
       url: asset.url,
@@ -168,9 +165,8 @@ function squirrelRelease(
 
 function desktopReleasePageUrl(
   release: DesktopUpdateManifest["releases"][string],
-  product: DesktopProduct,
 ): string {
-  const tagName = `${desktopProductReleaseTagPrefix(product)}${release.version}`;
+  const tagName = `${DESKTOP_RELEASE_TAG_PREFIX}${release.version}`;
   return `${DESKTOP_RELEASE_PAGE_URL_PREFIX}/${encodeURIComponent(tagName)}`;
 }
 
@@ -178,9 +174,8 @@ function desktopDmgDownloadUrl(
   release: DesktopUpdateManifest["releases"][string],
   request: DesktopUpdateFeedRequest,
 ): string {
-  const product = desktopProductForUpdateLine(request.line);
-  const tagName = `${desktopProductReleaseTagPrefix(product)}${release.version}`;
-  const assetName = `${desktopProductArtifactName(product)}-${request.platform}-${request.arch}-${release.version}.dmg`;
+  const tagName = `${DESKTOP_RELEASE_TAG_PREFIX}${release.version}`;
+  const assetName = `${DESKTOP_ARTIFACT_NAME}-${request.platform}-${request.arch}-${release.version}.dmg`;
   return `${DESKTOP_RELEASE_DOWNLOAD_URL_PREFIX}/${encodeURIComponent(
     tagName,
   )}/${encodeURIComponent(assetName)}`;
@@ -238,18 +233,12 @@ function buildDesktopUpdateFeed(
 
   return {
     currentRelease: selected.release.version,
-    releases: [
-      squirrelRelease(
-        selected.release,
-        selected.asset,
-        desktopProductForUpdateLine(request.line),
-      ),
-    ],
+    releases: [squirrelRelease(selected.release, selected.asset)],
   };
 }
 
 async function fetchDesktopUpdateManifest(
-  line: DesktopUpdateLine,
+  line: ServedDesktopUpdateLine,
   signal: AbortSignal,
 ): Promise<DesktopUpdateManifest> {
   const override = desktopUpdateManifestOverride.get()[line];
@@ -268,18 +257,18 @@ async function fetchDesktopUpdateManifest(
   }
 
   const manifest = desktopUpdateManifestSchema.parse(await response.json());
-  const manifestProduct = manifest.product ?? DESKTOP_PRODUCT_ZERO;
-  const expectedProduct = desktopProductForUpdateLine(line);
-  if (manifestProduct !== expectedProduct) {
+  // Fail closed: a manifest that does not declare the Okou product is not
+  // served, including one that omits the field entirely.
+  if (manifest.product !== DESKTOP_PRODUCT_OKOU) {
     throw new Error(
-      `Desktop update manifest product mismatch: expected ${expectedProduct}, received ${manifestProduct}`,
+      `Desktop update manifest product mismatch: expected ${DESKTOP_PRODUCT_OKOU}, received ${manifest.product ?? "none"}`,
     );
   }
   return manifest;
 }
 
 async function loadDesktopUpdateManifest(
-  line: DesktopUpdateLine,
+  line: ServedDesktopUpdateLine,
   signal: AbortSignal,
 ): Promise<DesktopUpdateManifest> {
   const cache = desktopUpdateManifestCache.get();
@@ -314,12 +303,7 @@ export async function loadDesktopReleasePageUrl(
 ): Promise<string | null> {
   const manifest = await loadDesktopUpdateManifest(request.line, signal);
   const selected = selectDesktopRelease(manifest, request);
-  return selected
-    ? desktopReleasePageUrl(
-        selected.release,
-        desktopProductForUpdateLine(request.line),
-      )
-    : null;
+  return selected ? desktopReleasePageUrl(selected.release) : null;
 }
 
 export async function loadDesktopDmgDownloadUrl(

--- a/turbo/apps/api/src/signals/services/desktop-updates.service.ts
+++ b/turbo/apps/api/src/signals/services/desktop-updates.service.ts
@@ -34,18 +34,20 @@ const DESKTOP_ARTIFACT_NAME = "Okou";
 const DESKTOP_RELEASE_TAG_PREFIX = "okou-desktop-v";
 
 /**
- * The update lines this service can resolve a manifest for.
+ * The update lines whose manifest this service can still name.
  *
- * The Zero line is excluded rather than left unreachable, so that the compiler
- * rejects any future caller that tries to resolve a Zero artifact. The route
- * layer narrows `:product` past the retired lines before calling in.
+ * Narrower than `DesktopUpdateLine` and wider than what actually reaches here:
+ * the Zero line is excluded so the compiler rejects any future caller that
+ * tries to resolve a Zero artifact, while `okou` remains nameable but is
+ * rejected by every `:product` route before it gets this far. Only
+ * `ai-okou-desktop` is served in practice.
  */
-type ServedDesktopUpdateLine = Exclude<
+type ResolvableDesktopUpdateLine = Exclude<
   DesktopUpdateLine,
   typeof DESKTOP_UPDATE_LINE_ZERO
 >;
 
-function desktopUpdateManifestUrl(line: ServedDesktopUpdateLine): string {
+function desktopUpdateManifestUrl(line: ResolvableDesktopUpdateLine): string {
   if (line === DESKTOP_UPDATE_LINE_LEGACY_OKOU) {
     return "https://github.com/vm0-ai/vm0/releases/download/okou-desktop-updates/okou-desktop-update-manifest.json";
   }
@@ -85,7 +87,7 @@ const desktopUpdateManifestSchema = z.object({
 type DesktopUpdateManifest = z.infer<typeof desktopUpdateManifestSchema>;
 
 interface DesktopUpdateFeedRequest {
-  readonly line: ServedDesktopUpdateLine;
+  readonly line: ResolvableDesktopUpdateLine;
   readonly channel: DesktopUpdateChannel;
   readonly platform: DesktopUpdatePlatform;
   readonly arch: DesktopUpdateArchitecture;
@@ -97,13 +99,13 @@ interface DesktopUpdateManifestCacheEntry {
 }
 
 const desktopUpdateManifestCache = testOverride<
-  Partial<Record<ServedDesktopUpdateLine, DesktopUpdateManifestCacheEntry>>
+  Partial<Record<ResolvableDesktopUpdateLine, DesktopUpdateManifestCacheEntry>>
 >(() => {
   return {};
 });
 
 const desktopUpdateManifestOverride = testOverride<
-  Partial<Record<ServedDesktopUpdateLine, DesktopUpdateManifest>>
+  Partial<Record<ResolvableDesktopUpdateLine, DesktopUpdateManifest>>
 >(() => {
   return {};
 });
@@ -238,7 +240,7 @@ function buildDesktopUpdateFeed(
 }
 
 async function fetchDesktopUpdateManifest(
-  line: ServedDesktopUpdateLine,
+  line: ResolvableDesktopUpdateLine,
   signal: AbortSignal,
 ): Promise<DesktopUpdateManifest> {
   const override = desktopUpdateManifestOverride.get()[line];
@@ -268,7 +270,7 @@ async function fetchDesktopUpdateManifest(
 }
 
 async function loadDesktopUpdateManifest(
-  line: ServedDesktopUpdateLine,
+  line: ResolvableDesktopUpdateLine,
   signal: AbortSignal,
 ): Promise<DesktopUpdateManifest> {
   const cache = desktopUpdateManifestCache.get();

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -147,22 +147,26 @@ replace it from the Okou update ZIP, and launch it again.
 
 ### Zero and Okou update compatibility
 
-Zero and Okou desktop releases are independent products during the rename
-rollout. Existing Zero installations keep using
-`/api/desktop/updates/stable/darwin/arm64` and the `desktop-updates` manifest.
 Final `ai.okou.desktop` installations use
-`/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64` and the separate
+`/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64` and the
 `ai-okou-desktop-updates` manifest. The stable Okou download route at
 `/api/desktop/updates/stable/darwin/arm64` also resolves through this
-final-identity manifest. The pre-adoption Okou manifest
-remains frozen without a final-identity artifact, and its explicit product
-routes return `404`. Each manifest identifies its product, and the API rejects
-ZIP assets whose product filename does not match the requested feed. A Zero
-feed must never publish an Okou artifact, and the pre-adoption Okou feed must
-never publish a final-identity archive.
+final-identity manifest. The manifest identifies its product, and the API
+rejects ZIP assets whose product filename does not match it, so an Okou feed
+never publishes a Zero archive.
 
-The release systems may deploy independently. The API therefore preserves the
-legacy Zero routes and accepts both Zero callback schemes
+`ai-okou-desktop` is the only line the API still resolves. The pre-adoption
+`okou` manifest remains frozen without a final-identity artifact, and #31475
+retired the `zero` line the same way: its manifest had been frozen since the
+`hard` migration policy went live, and the Squirrel clients still polling it
+could not have crossed to the Okou bundle anyway. Both retired lines answer
+`404` on their explicit `:product` routes, and the unqualified
+`RELEASES.json` route — the only route that ever resolved to Zero — is gone.
+Only the unqualified `release` and `dmg` routes remain unqualified, and both
+resolve to Okou.
+
+The release systems may deploy independently. The API therefore accepts both
+Zero callback schemes
 (`ai.vm0.zero.desktop` and `ai.vm0.zero.desktop.dev`) while also accepting the
 Okou schemes (`ai.okou.desktop` and `ai.okou.desktop.dev`). Desktop
 builds select exactly one product feed and one callback scheme from their

--- a/turbo/apps/desktop/src/bootstrap-degraded.test.ts
+++ b/turbo/apps/desktop/src/bootstrap-degraded.test.ts
@@ -128,7 +128,7 @@ describe("enterDegradedDesktopMode", () => {
       expect.objectContaining({
         updateSource: expect.objectContaining({
           baseUrl:
-            "https://api.vm0.ai/api/desktop/updates/stable/darwin/" +
+            "https://api.vm0.ai/api/desktop/updates/zero/stable/darwin/" +
             process.arch,
         }),
       }),

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -132,7 +132,8 @@ function installAndCaptureUpdateOptions(
       notifyUser: true,
       updateInterval: "30 minutes",
       updateSource: expect.objectContaining({
-        baseUrl: "https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64",
+        baseUrl:
+          "https://api.vm0.ai/api/desktop/updates/zero/stable/darwin/arm64",
       }),
     }),
   );

--- a/turbo/apps/desktop/src/desktop-update-feed.test.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.test.ts
@@ -60,7 +60,7 @@ describe("desktop update feed", () => {
 
   it("builds the static feed base URL used by update-electron-app", () => {
     expect(desktopUpdateFeedBaseUrl("https://api.vm0.ai", "zero")).toBe(
-      "https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64",
+      "https://api.vm0.ai/api/desktop/updates/zero/stable/darwin/arm64",
     );
     expect(
       desktopUpdateFeedBaseUrl("https://api.okou.ai", "ai-okou-desktop"),

--- a/turbo/apps/desktop/src/desktop-update-feed.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.ts
@@ -27,9 +27,10 @@ export function desktopUpdateFeedBaseUrl(
   updateLine: DesktopConfig["identity"]["updateLine"],
 ): string {
   const url = new URL(apiBaseUrl);
-  const updateLinePath =
-    updateLine === "zero" ? "" : `/${encodeURIComponent(updateLine)}`;
-  url.pathname = `/api/desktop/updates${updateLinePath}/${DESKTOP_UPDATE_CHANNEL}/${DESKTOP_UPDATE_PLATFORM}/${DESKTOP_UPDATE_ARCH}`;
+  // The `zero` line used to be spelled as the unqualified path, which predates
+  // the `:product` routes. #31475 removed that route, so every line now names
+  // itself in the path.
+  url.pathname = `/api/desktop/updates/${encodeURIComponent(updateLine)}/${DESKTOP_UPDATE_CHANNEL}/${DESKTOP_UPDATE_PLATFORM}/${DESKTOP_UPDATE_ARCH}`;
   url.search = "";
   url.hash = "";
   return url.toString().replace(/\/$/, "");

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -7,10 +7,10 @@ const c = initContract();
 /**
  * Every desktop update line the `:product` routes accept.
  *
- * `ai-okou-desktop` is the only line the API still resolves a manifest for.
- * `okou` and `zero` are retired: their `:product` routes answer 404, and the
- * API can no longer name their manifests. They stay in the union because it is
- * not API-private — `apps/desktop/src/config.ts` validates
+ * `ai-okou-desktop` is the only line the API still serves. `okou` and `zero`
+ * are retired and their `:product` routes answer 404; `zero` is retired harder,
+ * because the API can no longer name its manifest at all. They stay in the
+ * union because it is not API-private — `apps/desktop/src/config.ts` validates
  * `desktop-identities.json`'s `updateLine` against it, and the desktop `zero`
  * identity that #31372 deliberately kept still declares `updateLine: "zero"`.
  * Keeping them here also lets a retired line answer a truthful 404 rather than

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -4,6 +4,18 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
+/**
+ * Every desktop update line the `:product` routes accept.
+ *
+ * `ai-okou-desktop` is the only line the API still resolves a manifest for.
+ * `okou` and `zero` are retired: their `:product` routes answer 404, and the
+ * API can no longer name their manifests. They stay in the union because it is
+ * not API-private — `apps/desktop/src/config.ts` validates
+ * `desktop-identities.json`'s `updateLine` against it, and the desktop `zero`
+ * identity that #31372 deliberately kept still declares `updateLine: "zero"`.
+ * Keeping them here also lets a retired line answer a truthful 404 rather than
+ * a path-param validation error.
+ */
 const DESKTOP_UPDATE_LINES = ["zero", "okou", "ai-okou-desktop"] as const;
 export const DESKTOP_UPDATE_LINE_ZERO = DESKTOP_UPDATE_LINES[0];
 export const DESKTOP_UPDATE_LINE_LEGACY_OKOU = DESKTOP_UPDATE_LINES[1];
@@ -90,21 +102,6 @@ export const desktopUpdatesContract = c.router({
       404: apiErrorSchema,
     },
     summary: "Redirect to the current desktop DMG download",
-  },
-  feed: {
-    method: "GET",
-    path: "/api/desktop/updates/:channel/:platform/:arch/RELEASES.json",
-    pathParams: z.object({
-      channel: desktopUpdateChannelSchema,
-      platform: desktopUpdatePlatformSchema,
-      arch: desktopUpdateArchitectureSchema,
-    }),
-    responses: {
-      200: squirrelMacReleasesSchema,
-      400: apiErrorSchema,
-      404: apiErrorSchema,
-    },
-    summary: "Get the desktop auto-update feed",
   },
   productReleasePage: {
     method: "GET",


### PR DESCRIPTION
Closes #31475. Part of #26701.

Stops the API resolving the frozen `zero` desktop update line. The build side was already gone (#31372 flipped the default product to Okou and removed the Zero packaging pass); this removes the last thing still serving a Zero manifest.

## The premise, verified

The whole justification is that the Zero migration bridge — deleted from the tree in #30477, but compiled into every installed Zero build from 0.34.0 up — never reads the update feed. I re-read the deleted source at the parent commit `3d07b64b` rather than taking that on trust.

`turbo/apps/desktop/src/desktop-zero-migration-config.ts` names exactly two endpoints:

```ts
policyPath:  "/api/desktop/migration-policy",
downloadUrl: "https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64/dmg",
```

`desktop-zero-migration.ts` confirms these are the bridge's only network reach: the controller's sole HTTP dependency is the injected `fetchPolicy` (wired in `main.ts:685-689` to `new URL(ZERO_MIGRATION_BRIDGE_CONFIG.policyPath, desktopApiBaseUrl)`), and `openDownload(ZERO_MIGRATION_BRIDGE_CONFIG.downloadUrl)` at lines 202 and 221. I also grepped every `.ts`/`.tsx` under `turbo/apps/desktop/src` at that commit for `fetchPolicy`/`policyPath`/`fetch(`; nothing else in the bridge touches the network. **The update feed is not among the bridge's endpoints.** Removing it cannot strand a held client.

The premise holds, so the removal proceeds.

## Kept working — deliberately untouched

- **`/api/desktop/migration-policy` still returns `{"schemaVersion":1,"mode":"hard"}`.** Verified in the source why this matters, not just asserted: `desktop-zero-migration.ts:91` initialises `rolloutMode = "soft"` and `:277` re-initialises `mode = "soft"` before the fetch, keeping `soft` on any failure. `applyRolloutMode` then sees `previousMode === "hard"` with no `startedAt` and calls `startZero()`. Breaking this endpoint does not degrade the migration, it **rolls it back** — every held client restarts into a working Zero. Route and handler are unchanged.
- **`/api/desktop/updates/stable/darwin/arm64/dmg` still 302s to the current Okou DMG.** The asymmetry at `desktop-updates.ts` — unqualified `release`/`dmg` resolve to Okou while only the unqualified `RELEASES.json` used Zero — was deliberate, and is preserved rather than "unified": this PR deletes the Zero side instead of aligning the Okou side. `apps/platform/src/signals/okou-page/computer-use-hosts.ts:7` depends on this route too, as does the wall's `Download Okou` button. The `UNQUALIFIED_DESKTOP_UPDATE_LINE` comment now records why.
- `desktop-identities.json`'s `zero` entry and `mode: "hard"` are unchanged.

## Decision 1: the union member stays

`DESKTOP_UPDATE_LINES` is not API-private — `apps/desktop/src/config.ts:53` validates `desktop-identities.json`'s `updateLine` against it, and the `zero` identity still declares `updateLine: "zero"`. I took the first option in the issue: **remove the API's ability to resolve a Zero manifest, leave the union member for the desktop identity.**

- #31372 deliberately kept the `zero` desktop identity. Dropping the union member forces retiring it, and a build-side identity is a separate question with its own blast radius (bundle IDs, auth schemes, user-data directories, dev builds). Nothing in this issue makes that safe now.
- The repo already has this exact precedent: the pre-adoption `okou` line stays in the union while every `:product` handler returns a retired 404. Making `zero` behave identically keeps one rule for retired lines instead of two.
- Keeping it in the `:product` path schema means `/api/desktop/updates/zero/...` answers a truthful `404` rather than a zod path-param `400`. For pollers, "retired" is the more honest answer than "malformed".

Explicitly not chosen for grep cleanliness — removing the member would have looked tidier and been wrong.

The compile-time guarantee comes from the service instead, which is stronger than deleting a union member would have been: `ServedDesktopUpdateLine = Exclude<DesktopUpdateLine, typeof DESKTOP_UPDATE_LINE_ZERO>` makes a Zero manifest unnameable. Deleting the union member would only have closed `:product=zero`; the unqualified feed hard-coded the constant and needed handling either way. With Zero excluded, every artifact the service resolves is an Okou one, so the per-line product/artifact/tag derivation collapses into two constants.

## Decision 2: the unqualified `RELEASES.json` route is removed, not 404'd

- A registered route whose only behaviour is `notFound` advertises a `200 squirrelMacReleasesSchema` response that can never occur. Keeping it honest would mean a 404-only route — a stranger artifact than no route.
- It is observationally identical for the only remaining callers. The API already answers unregistered paths with a JSON 404; confirmed against production before the change: `GET /api/desktop/updates/stable/darwin/arm64/NOPE.json` → `404 {"error":"Not found"}`.
- YAGNI / "delete unused code aggressively" is an explicit project principle.
- No path collision: the unqualified form has four segments after `updates`, the `:product` form five.

The unqualified `dmg` and `release` routes are unaffected — only `feed` is removed.

One consequence worth naming: `/api/desktop/updates/stable/darwin/x64/RELEASES.json` previously returned `400` (zod rejecting the arch) and now returns `404`. Both are non-200 and no client distinguishes them.

`apps/desktop/src/desktop-update-feed.ts` carried a special case spelling the `zero` line as the *unqualified* path, predating the `:product` routes. Left alone it would point the desktop source at a route that no longer exists — and would silently re-latch Zero builds onto any future unqualified feed. Every line now names itself in the path. This has no shipped effect: no Zero builds are packaged any more (`release-please.yml` packages only `Okou-darwin-arm64`), and installed builds carry their own compiled copy.

## Production probes

Baseline, taken against `api.vm0.ai` **before** the change:

| Endpoint | Result |
| --- | --- |
| `/api/desktop/migration-policy` | `200` `{"schemaVersion":1,"mode":"hard"}` |
| `/api/desktop/updates/stable/darwin/arm64/dmg` | `302` → `.../okou-desktop-v0.45.0/Okou-darwin-arm64-0.45.0.dmg` |
| `/api/desktop/updates/stable/darwin/arm64/release` | `302` → `.../releases/tag/okou-desktop-v0.45.0` |
| `/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64/RELEASES.json` | `200`, `currentRelease` `0.45.0` |
| `/api/desktop/updates/stable/darwin/arm64/RELEASES.json` | `200`, Zero `0.38.126` — the line being removed |

The acceptance gate is that the first two are still alive after deploy, not that the removal is thorough. **Post-deploy probe results will be added to this PR as a comment once the change is released** — the merge itself does not deploy them.

## Verification

- `pnpm -F api check-types`, `pnpm -F @okouai/desktop check-types`, `pnpm -F @okouai/api-contracts check-types` — pass
- `pnpm -F api lint`, `pnpm -F @okouai/desktop lint`, `pnpm -F @okouai/api-contracts lint` — pass
- `pnpm knip` — clean
- `apps/api` `desktop-updates.test.ts` (12), `global-sweep-contracts.test.ts` + `app-factory.test.ts` (65), `api-contracts` full suite (691), `apps/desktop` full suite (499 of 501) — pass

The two `apps/desktop/src/bootstrap-degraded.test.ts` failures reproduce identically on unmodified `main` in this x64 Linux sandbox: `shouldInstallDesktopAutoUpdates` requires `darwin/arm64`, so `updateElectronApp` is never called there. Not introduced here; its feed-URL assertion is updated for consistency.

Test coverage moved rather than dropped: the manifest cache TTL, blocked-release, missing-asset and x64-rejection cases previously drove the unqualified feed and now drive the `ai-okou-desktop` product feed. The retired-line 404 case covers `zero` alongside `okou`. The neutral-path case now mocks both Okou manifests at different versions, so resolving the wrong line fails loudly instead of 404ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
