### PR TITLE
test(api): name failure-reason client floor accurately

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -1096,7 +1096,7 @@ describe("createApp", () => {
   });
 
   describe("web client compatibility", () => {
-    it("force-upgrades app clients below the user-org realtime floor before route matching", async () => {
+    it("force-upgrades app clients below the failure-reason reader floor before route matching", async () => {
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,


### PR DESCRIPTION
## Summary

- rename the web-client compatibility regression test to describe the V7 failure-reason reader floor it now asserts
- leave runtime behavior unchanged

Follow-up to #31419.

Relates to #31264.

## Validation

- `pnpm exec prettier --check apps/api/src/__tests__/app-factory.test.ts`
- `pnpm -F api exec vitest run src/__tests__/app-factory.test.ts --maxWorkers=4 --silent=passed-only`
