### PR TITLE
fix(platform): remove shortcut hints from sidebar tooltips

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -3404,6 +3404,53 @@ describe("zero sidebar", () => {
     ).toBeInTheDocument();
   });
 
+  it("omits shortcut hints from three-column action tooltips", async () => {
+    const user = userEvent.setup();
+    prepareDefaultAgent();
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await screen.findByPlaceholderText(PLACEHOLDER);
+    const list = screen.getByTestId("chat-list-column");
+    const searchButton = within(list).getByLabelText("Search workspace");
+    const hideButton = within(list).getByLabelText("Hide chat list");
+
+    await user.hover(searchButton);
+    const searchTooltip = await waitFor(() => {
+      const popup = document.querySelector('[data-slot="tooltip-content"]');
+      if (!(popup instanceof HTMLElement)) {
+        throw new Error("Search workspace tooltip is not open");
+      }
+      return popup;
+    });
+    expect(searchTooltip).toHaveTextContent(/^Search workspace$/);
+    await user.unhover(searchButton);
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="tooltip-content"]'),
+      ).not.toBeInTheDocument();
+    });
+
+    await user.hover(hideButton);
+    const hideTooltip = await waitFor(() => {
+      const popup = document.querySelector('[data-slot="tooltip-content"]');
+      if (!(popup instanceof HTMLElement)) {
+        throw new Error("Hide chat list tooltip is not open");
+      }
+      return popup;
+    });
+    expect(hideTooltip).toHaveTextContent(/^Hide chat list$/);
+
+    expect(searchButton).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Meta+K Control+K",
+    );
+    expect(hideButton).toHaveAttribute("aria-keyshortcuts", "Meta+B Control+B");
+  });
+
   it("collapses the upgrade slot when the chat list has no upgrade card", async () => {
     prepareDefaultAgent();
     mockChatThreadSnapshot(() => {

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -20,7 +20,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
   cn,
-  getShortcutLabel,
 } from "@okouai/ui";
 import { settingsIconAssetUrl } from "./components/settings/settings-icon-assets.ts";
 import {
@@ -561,7 +560,6 @@ function ThreeColumnChatListToggle({
     : t(($) => {
         return $.appShell.sidebar.hideChatList;
       });
-  const shortcutLabel = getShortcutLabel("mod+b");
 
   return (
     <Tooltip>
@@ -585,10 +583,7 @@ function ThreeColumnChatListToggle({
         </Button>
       </TooltipTrigger>
       <TooltipContent side={tooltipSide}>
-        <p className="text-xs">
-          {label}
-          <span aria-hidden="true">{` · ${shortcutLabel}`}</span>
-        </p>
+        <p className="text-xs">{label}</p>
       </TooltipContent>
     </Tooltip>
   );
@@ -731,7 +726,6 @@ function ChatListColumn() {
   const searchLabel = t(($) => {
     return $.appShell.sidebar.searchWorkspace;
   });
-  const searchShortcutLabel = getShortcutLabel("mod+k");
   const newChatLabel = t(($) => {
     return $.chat.newChat;
   });
@@ -772,10 +766,7 @@ function ChatListColumn() {
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
-              <p className="text-xs">
-                {searchLabel}
-                <span aria-hidden="true">{` · ${searchShortcutLabel}`}</span>
-              </p>
+              <p className="text-xs">{searchLabel}</p>
             </TooltipContent>
           </Tooltip>
           <Tooltip>


### PR DESCRIPTION
## Summary

- remove the visible shortcut suffix from the Search workspace tooltip
- remove the visible shortcut suffix from the Show/Hide chat list tooltip
- preserve the existing keyboard handlers and `aria-keyshortcuts` metadata

## Verification

- `npx --yes prettier@3.8.1 --check apps/platform/src/views/okou-page/sidebar.tsx`
- file-scoped Oxlint, type-aware Oxlint, and ESLint
- `pnpm --filter @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar-mac-shortcut.test.tsx -t 'toggles the chat list with cmd\\+b while the chat composer is focused'`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx -t 'renders the three-column chat navigation and actions|hides only the three-column chat list and keeps search available'`

## Visual verification

- not run locally per repository guidance; rely on the PR preview pipeline
