### PR TITLE
test(cli): avoid repeated generate command imports

### DIFF
--- a/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { Command, Help } from "commander";
 import { buildHelpText, registerCommands } from "../okou";
+import { generateCommand } from "../commands/generate";
 import { decodeSandboxTokenPayload } from "../lib/api/sandbox-token";
 
 function buildOkouToken(payload: Record<string, unknown>): string {
@@ -1233,39 +1234,11 @@ describe("registerCommands", () => {
 });
 
 describe("okou generate command visibility", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.resetModules();
-  });
-
-  async function importGenerateCommand(token: string) {
-    vi.resetModules();
-    vi.stubEnv("OKOU_TOKEN", token);
-    const { generateCommand } = await import("../commands/generate");
-    return generateCommand as Command;
-  }
-
-  it("should show website generation", async () => {
-    const token = buildOkouToken({
-      scope: "okou",
-      capabilities: [],
-    });
-
-    const generateCommand = await importGenerateCommand(token);
-
+  it("should show website generation", () => {
     expect(visibleCommandNames(generateCommand)).toContain("website");
   });
 
-  it("should show source-backed artifact generation", async () => {
-    const token = buildOkouToken({
-      userId: "user-non-staff",
-      orgId: "org-non-staff",
-      scope: "okou",
-      capabilities: ["host:write"],
-    });
-
-    const generateCommand = await importGenerateCommand(token);
-
+  it("should show source-backed artifact generation", () => {
     expect(visibleCommandNames(generateCommand)).toEqual(
       expect.arrayContaining([
         "report",


### PR DESCRIPTION
## Summary

- import the real generate command tree once during test-file collection
- remove obsolete token setup, module resets, and repeated dynamic imports left behind by retired feature switches
- preserve website and source-backed artifact visibility assertions without changing CLI runtime behavior

## Scope

This is a test-only change. It does not alter the top-level CLI lazy loader, command visibility, APIs, persistence, or deployment contracts.

## Validation

- `pnpm --filter @okouai/cli exec vitest run src/__tests__/command-capability-visibility.test.ts -t "okou generate command visibility" --reporter=verbose`
- `pnpm --filter @okouai/cli exec vitest run src/__tests__/command-capability-visibility.test.ts --reporter=dot`
- `pnpm --filter @okouai/cli exec vitest run src/commands/social/__tests__/index.test.ts --reporter=dot` followed by the visibility-file run
- `pnpm exec prettier --check apps/cli/src/__tests__/command-capability-visibility.test.ts`
- `pnpm --filter @okouai/cli lint`
- `pnpm --filter @okouai/cli check-types`
- `pnpm knip --workspace @okouai/cli`
- `pnpm --filter @okouai/cli exec vitest run src/lib/pi-agent-loop.test.ts --reporter=dot`
- `pnpm --filter @okouai/cli exec vitest run --maxWorkers=1 --silent=passed-only` (104 files passed, 1 skipped; 1,196 tests passed, 1 skipped)
- pre-commit hook: Prettier, repository Knip, repository type checks, and file-size validation

Default-worker and four-worker CLI suite diagnostics exposed pre-existing `pi-agent-loop` child-process RPC timeouts under suite contention; the affected file passed in isolation and the complete CLI suite passed with one worker. No timeout was increased and no test was skipped by this change.

Closes #31489
