### PR TITLE
feat(app): add preview-only clerk edge session probe

### DIFF
--- a/.github/scripts/tests/app-preview-ingress-workflow-test.sh
+++ b/.github/scripts/tests/app-preview-ingress-workflow-test.sh
@@ -59,6 +59,10 @@ end
 unless deploy_step.dig("env", "CLOUDFLARE_API_TOKEN") == "${{ secrets.CF_API_WORKER_DEPLOY_API_TOKEN }}"
   raise "Worker preview deployment must use the isolated Worker deploy token"
 end
+unless deploy_step.dig("env", "CLERK_PUBLISHABLE_KEY") == "${{ github.event_name == 'pull_request' && vars.CLERK_PUBLISHABLE_KEY_PREVIEW || '' }}" &&
+    deploy_step.dig("env", "CLERK_SECRET_KEY") == "${{ github.event_name == 'pull_request' && secrets.CLERK_SECRET_KEY || '' }}"
+  raise "Only PR Worker previews may receive the Clerk test instance bindings"
+end
 deploy_source = deploy_step.fetch("run")
 unless deploy_source.include?("wrangler versions upload") &&
     deploy_source.include?('--preview-alias "$WORKER_PREVIEW_ALIAS"') &&
@@ -79,6 +83,26 @@ unless preview_enable_index && bootstrap_index && preview_upload_index &&
 end
 unless deploy_source.include?("Cloudflare-Workers-Script-Api-Date: 2025-08-01")
   raise "Worker preview configuration must use Cloudflare's current script API"
+end
+unless deploy_source.include?('case "$CLERK_PUBLISHABLE_KEY" in') &&
+    deploy_source.include?("pk_test_*") &&
+    deploy_source.include?('case "$CLERK_SECRET_KEY" in') &&
+    deploy_source.include?("sk_test_*")
+  raise "Worker preview deployment must reject non-test Clerk keys"
+end
+unless deploy_source.include?('worker_secrets="$(mktemp)"') &&
+    deploy_source.include?("umask 077") &&
+    deploy_source.include?('if [[ "$EVENT_NAME" == "pull_request" ]]') &&
+    deploy_source.include?('CLERK_EDGE_DEBUG_AUTHORIZED_PARTY: env.EXPECTED_PREVIEW_URL') &&
+    deploy_source.include?('unset CLERK_PUBLISHABLE_KEY CLERK_SECRET_KEY')
+  raise "Worker preview deployment must create an ephemeral exact-origin secrets file"
+end
+unless deploy_source.include?('worker_secret_args=(--secrets-file "$worker_secrets")') &&
+    deploy_source.scan('"${worker_secret_args[@]}"').length == 2
+  raise "Worker preview bootstrap and version upload must use encrypted Clerk bindings"
+end
+if deploy_source.include?("--var CLERK_SECRET_KEY")
+  raise "Worker preview deployment must not expose the Clerk secret on the command line"
 end
 
 readiness_step = find_step.call("Wait for standalone app Worker readiness")

--- a/.github/scripts/tests/app-preview-ingress-workflow-test.sh
+++ b/.github/scripts/tests/app-preview-ingress-workflow-test.sh
@@ -97,9 +97,15 @@ unless deploy_source.include?('worker_secrets="$(mktemp)"') &&
     deploy_source.include?('unset CLERK_PUBLISHABLE_KEY CLERK_SECRET_KEY')
   raise "Worker preview deployment must create an ephemeral exact-origin secrets file"
 end
+bootstrap_source = deploy_source[bootstrap_index...preview_upload_index]
+version_source = deploy_source[preview_upload_index..]
 unless deploy_source.include?('worker_secret_args=(--secrets-file "$worker_secrets")') &&
-    deploy_source.scan('"${worker_secret_args[@]}"').length == 2
-  raise "Worker preview bootstrap and version upload must use encrypted Clerk bindings"
+    version_source.include?('"${worker_secret_args[@]}"') &&
+    deploy_source.scan('"${worker_secret_args[@]}"').length == 1
+  raise "Only the PR version upload may use encrypted Clerk bindings"
+end
+if bootstrap_source.include?("worker_secret_args")
+  raise "The shared preview bootstrap must not receive PR Clerk bindings"
 end
 if deploy_source.include?("--var CLERK_SECRET_KEY")
   raise "Worker preview deployment must not expose the Clerk secret on the command line"

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -542,7 +542,9 @@ const edgeDebugEnvironment = {
   CLERK_SECRET_KEY: "sk_test_secret-must-not-render",
   PUBLIC_BRAND: "okou",
 };
+let unexpectedClerkClientFactoryCalls = 0;
 const unexpectedClerkClientFactory = () => {
+  unexpectedClerkClientFactoryCalls += 1;
   throw new Error("Clerk must not run for this request");
 };
 const guardedEdgeWorker = workerModule.createWorker(
@@ -566,7 +568,9 @@ assert.deepEqual(duplicateFlag, edgeDebugBaseline);
 
 for (const ineligibleOrigin of [
   "https://app.okou.ai",
+  "https://app.vm0.ai",
   "https://app-worker.okou.ai",
+  "https://app-worker.vm0.ai",
   "https://pr-25304-app.omby.ai",
   "https://staging-app-okou-app-preview.vm0.workers.dev",
 ]) {
@@ -598,6 +602,7 @@ const missingConfig = await responseSnapshot(
   },
 );
 assert.deepEqual(missingConfig, edgeDebugBaseline);
+assert.equal(unexpectedClerkClientFactoryCalls, 0);
 
 function clerkClientReturning(requestState) {
   return () => ({
@@ -756,6 +761,30 @@ assert.deepEqual(Object.keys(clerkEdgeSessionJson(authenticated.body)).sort(), [
   "userId",
 ]);
 assertNoClerkSecrets(authenticated);
+
+const authenticatedWithoutOrganization = await responseSnapshot(
+  workerModule.createWorker(
+    embeddedShell,
+    clerkClientReturning({
+      headers: new Headers(),
+      isAuthenticated: true,
+      toAuth() {
+        return { userId: "user_without_organization", orgId: null };
+      },
+    }),
+  ),
+  `${edgeDebugUrl}?__clerk_edge_debug=1`,
+  edgeDebugEnvironment,
+);
+assert.deepEqual(clerkEdgeSessionJson(authenticatedWithoutOrganization.body), {
+  userId: "user_without_organization",
+  orgId: null,
+});
+assert.equal(
+  new Headers(authenticatedWithoutOrganization.headers).get("Cache-Control"),
+  "private, no-store",
+);
+assertNoClerkSecrets(authenticatedWithoutOrganization);
 
 const embeddedServiceWorker = await embeddedWorker.fetch(
   new Request("https://pr-25304-app-okou-app-preview.vm0.workers.dev/sw.js"),

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -79,7 +79,9 @@ function rewritePairedTag(html, tagName, handler) {
       ? /<html([^>]*)>([\s\S]*?)<\/html>/iu
       : tagName === "head"
         ? /<head([^>]*)>([\s\S]*?)<\/head>/iu
-        : /<title([^>]*)>([\s\S]*?)<\/title>/iu;
+        : tagName === "body"
+          ? /<body([^>]*)>([\s\S]*?)<\/body>/iu
+          : /<title([^>]*)>([\s\S]*?)<\/title>/iu;
   return html.replace(pattern, (_tag, attributeSource, innerContent) => {
     const state = applyHandler({
       attributes: parseAttributes(attributeSource),
@@ -114,7 +116,12 @@ function rewriteVoidTag(html, tagName, selector, handler) {
 }
 
 function rewriteHtml(html, selector, handler) {
-  if (selector === "html" || selector === "head" || selector === "title") {
+  if (
+    selector === "html" ||
+    selector === "head" ||
+    selector === "body" ||
+    selector === "title"
+  ) {
     return rewritePairedTag(html, selector, handler);
   }
   if (selector.startsWith("meta[")) {
@@ -197,7 +204,7 @@ const embeddedIndexTemplate = builtIndexTemplate
     "</body>",
     '<script type="module" src="https://static.okou.io/okou-app/assets/index-Test1234.js"></script>\n</body>',
   );
-const embeddedWorker = workerModule.createWorker({
+const embeddedShell = {
   icon192: new TextEncoder().encode("icon-192").buffer,
   icon512: new TextEncoder().encode("icon-512").buffer,
   icon512Maskable: new TextEncoder().encode("icon-maskable").buffer,
@@ -205,7 +212,8 @@ const embeddedWorker = workerModule.createWorker({
   manifest: manifestTemplate,
   robots: "User-agent: *\nAllow: /\n",
   serviceWorker: 'self.addEventListener("install", () => {});',
-});
+};
+const embeddedWorker = workerModule.createWorker(embeddedShell);
 const worker = embeddedWorker;
 const expectedClerkCoreScript = clerkCoreScript(builtIndexTemplate);
 const expectedClerkBootstrap = clerkBootstrap(builtIndexTemplate);
@@ -290,6 +298,50 @@ function documentTitle(html) {
 function htmlAttribute(html, attributeName) {
   const tag = /<html\b[^>]*>/iu.exec(html)?.[0];
   return tag ? (parseAttributes(tag).get(attributeName) ?? null) : null;
+}
+
+function clerkEdgeSessionJson(html) {
+  const matches = [
+    ...html.matchAll(
+      /<script type="application\/json" id="vm0-clerk-edge-session">([\s\S]*?)<\/script>/giu,
+    ),
+  ];
+  assert.equal(matches.length, 1);
+  return JSON.parse(matches[0][1]);
+}
+
+async function responseSnapshot(targetWorker, url, env) {
+  const response = await targetWorker.fetch(
+    new Request(url, {
+      headers: {
+        Cookie:
+          "__session=jwt-cookie-must-not-render; __clerk_db_jwt=dev-browser-jwt-must-not-render",
+      },
+    }),
+    env,
+  );
+  return {
+    body: await response.text(),
+    headers: [...response.headers.entries()],
+    status: response.status,
+    statusText: response.statusText,
+  };
+}
+
+function assertNoClerkSecrets(snapshot) {
+  for (const sensitiveValue of [
+    "jwt-cookie-must-not-render",
+    "dev-browser-jwt-must-not-render",
+    "sk_test_secret-must-not-render",
+    "session-token-must-not-render",
+    "sess_must-not-render",
+    "claim-must-not-render",
+    "handshake-cookie-must-not-render",
+    "refreshed-cookie-must-not-render",
+    "token=must-not-render",
+  ]) {
+    assert.doesNotMatch(snapshot.body, new RegExp(sensitiveValue, "u"));
+  }
 }
 
 function clerkBootstrap(html) {
@@ -481,6 +533,229 @@ assert.doesNotMatch(
   embeddedProductionHtml,
   /https:\/\/app\.okou\.ai\/okou-app\/assets\/index-Test1234\.js/u,
 );
+
+const edgeDebugOrigin = "https://pr-25304-app-okou-app-preview.vm0.workers.dev";
+const edgeDebugUrl = `${edgeDebugOrigin}/settings/profile`;
+const edgeDebugEnvironment = {
+  CLERK_EDGE_DEBUG_AUTHORIZED_PARTY: edgeDebugOrigin,
+  CLERK_PUBLISHABLE_KEY: previewClerkPublishableKey,
+  CLERK_SECRET_KEY: "sk_test_secret-must-not-render",
+  PUBLIC_BRAND: "okou",
+};
+const unexpectedClerkClientFactory = () => {
+  throw new Error("Clerk must not run for this request");
+};
+const guardedEdgeWorker = workerModule.createWorker(
+  embeddedShell,
+  unexpectedClerkClientFactory,
+);
+const edgeDebugBaseline = await responseSnapshot(
+  guardedEdgeWorker,
+  edgeDebugUrl,
+  edgeDebugEnvironment,
+);
+assert.doesNotMatch(edgeDebugBaseline.body, /vm0-clerk-edge-session/u);
+assertNoClerkSecrets(edgeDebugBaseline);
+
+const duplicateFlag = await responseSnapshot(
+  guardedEdgeWorker,
+  `${edgeDebugUrl}?__clerk_edge_debug=1&__clerk_edge_debug=1`,
+  edgeDebugEnvironment,
+);
+assert.deepEqual(duplicateFlag, edgeDebugBaseline);
+
+for (const ineligibleOrigin of [
+  "https://app.okou.ai",
+  "https://app-worker.okou.ai",
+  "https://pr-25304-app.omby.ai",
+  "https://staging-app-okou-app-preview.vm0.workers.dev",
+]) {
+  const ineligibleUrl = `${ineligibleOrigin}/settings/profile`;
+  const ineligibleEnvironment = {
+    ...edgeDebugEnvironment,
+    CLERK_EDGE_DEBUG_AUTHORIZED_PARTY: ineligibleOrigin,
+  };
+  const baseline = await responseSnapshot(
+    guardedEdgeWorker,
+    ineligibleUrl,
+    ineligibleEnvironment,
+  );
+  const flagged = await responseSnapshot(
+    guardedEdgeWorker,
+    `${ineligibleUrl}?__clerk_edge_debug=1`,
+    ineligibleEnvironment,
+  );
+  assert.deepEqual(flagged, baseline);
+  assertNoClerkSecrets(flagged);
+}
+
+const missingConfig = await responseSnapshot(
+  guardedEdgeWorker,
+  `${edgeDebugUrl}?__clerk_edge_debug=1`,
+  {
+    CLERK_EDGE_DEBUG_AUTHORIZED_PARTY: edgeDebugOrigin,
+    PUBLIC_BRAND: "okou",
+  },
+);
+assert.deepEqual(missingConfig, edgeDebugBaseline);
+
+function clerkClientReturning(requestState) {
+  return () => ({
+    authenticateRequest() {
+      return Promise.resolve(requestState);
+    },
+  });
+}
+
+const anonymous = await responseSnapshot(
+  workerModule.createWorker(
+    embeddedShell,
+    clerkClientReturning({
+      headers: new Headers(),
+      isAuthenticated: false,
+    }),
+  ),
+  `${edgeDebugUrl}?__clerk_edge_debug=1`,
+  edgeDebugEnvironment,
+);
+
+const handshake = await responseSnapshot(
+  workerModule.createWorker(
+    embeddedShell,
+    clerkClientReturning({
+      headers: new Headers({
+        Location: "https://clerk.example/handshake?token=must-not-render",
+        "Set-Cookie": "__session=handshake-cookie-must-not-render",
+      }),
+      isAuthenticated: false,
+    }),
+  ),
+  `${edgeDebugUrl}?__clerk_edge_debug=1`,
+  edgeDebugEnvironment,
+);
+
+const refresh = await responseSnapshot(
+  workerModule.createWorker(
+    embeddedShell,
+    clerkClientReturning({
+      headers: new Headers({
+        "Set-Cookie": "__session=refreshed-cookie-must-not-render",
+      }),
+      isAuthenticated: true,
+      toAuth() {
+        throw new Error("Refresh state must not be consumed");
+      },
+    }),
+  ),
+  `${edgeDebugUrl}?__clerk_edge_debug=1`,
+  edgeDebugEnvironment,
+);
+
+const thrown = await responseSnapshot(
+  workerModule.createWorker(embeddedShell, () => ({
+    authenticateRequest() {
+      return Promise.reject(new Error("Clerk network failure"));
+    },
+  })),
+  `${edgeDebugUrl}?__clerk_edge_debug=1`,
+  edgeDebugEnvironment,
+);
+
+const constructorThrown = await responseSnapshot(
+  workerModule.createWorker(embeddedShell, () => {
+    throw new Error("Clerk SDK failure");
+  }),
+  `${edgeDebugUrl}?__clerk_edge_debug=1`,
+  edgeDebugEnvironment,
+);
+
+const timedOut = await responseSnapshot(
+  workerModule.createWorker(embeddedShell, () => ({
+    authenticateRequest() {
+      return new Promise(() => {});
+    },
+  })),
+  `${edgeDebugUrl}?__clerk_edge_debug=1`,
+  edgeDebugEnvironment,
+);
+
+for (const unchanged of [
+  anonymous,
+  handshake,
+  refresh,
+  thrown,
+  constructorThrown,
+  timedOut,
+]) {
+  assert.deepEqual(unchanged, edgeDebugBaseline);
+  assertNoClerkSecrets(unchanged);
+  assert.equal(new Headers(unchanged.headers).get("Location"), null);
+  assert.equal(new Headers(unchanged.headers).get("Set-Cookie"), null);
+}
+
+const currentUserId = "user_current</script><script>alert(1)</script>";
+const currentOrgId = "org_current";
+const authenticatedWorker = workerModule.createWorker(
+  embeddedShell,
+  ({ publishableKey, secretKey, telemetry }) => {
+    if (
+      publishableKey !== previewClerkPublishableKey ||
+      secretKey !== "sk_test_secret-must-not-render" ||
+      telemetry?.disabled !== true
+    ) {
+      throw new Error("Unexpected Clerk client configuration");
+    }
+    return {
+      authenticateRequest(request, options) {
+        if (
+          request.url !== `${edgeDebugUrl}?__clerk_edge_debug=1` ||
+          options.acceptsToken !== "session_token" ||
+          options.authorizedParties.length !== 1 ||
+          options.authorizedParties[0] !== edgeDebugOrigin
+        ) {
+          return Promise.reject(new Error("Unexpected Clerk request options"));
+        }
+        return Promise.resolve({
+          headers: new Headers(),
+          isAuthenticated: true,
+          token: "session-token-must-not-render",
+          toAuth() {
+            return {
+              orgId: currentOrgId,
+              sessionClaims: { private: "claim-must-not-render" },
+              sessionId: "sess_must-not-render",
+              userId: currentUserId,
+            };
+          },
+        });
+      },
+    };
+  },
+);
+const authenticated = await responseSnapshot(
+  authenticatedWorker,
+  `${edgeDebugUrl}?__clerk_edge_debug=1`,
+  edgeDebugEnvironment,
+);
+assert.equal(authenticated.status, 200);
+assert.equal(
+  new Headers(authenticated.headers).get("Cache-Control"),
+  "private, no-store",
+);
+assert.equal(new Headers(authenticated.headers).get("Location"), null);
+assert.equal(new Headers(authenticated.headers).get("Set-Cookie"), null);
+assert.match(authenticated.body, /id="app-bootstrap-skeleton"/u);
+assert.match(authenticated.body, /\\u003c\/script>/u);
+assert.doesNotMatch(authenticated.body, /<script>alert\(1\)<\/script>/u);
+assert.deepEqual(clerkEdgeSessionJson(authenticated.body), {
+  userId: currentUserId,
+  orgId: currentOrgId,
+});
+assert.deepEqual(Object.keys(clerkEdgeSessionJson(authenticated.body)).sort(), [
+  "orgId",
+  "userId",
+]);
+assertNoClerkSecrets(authenticated);
 
 const embeddedServiceWorker = await embeddedWorker.fetch(
   new Request("https://pr-25304-app-okou-app-preview.vm0.workers.dev/sw.js"),

--- a/.github/scripts/tests/okou-app-worker-test.sh
+++ b/.github/scripts/tests/okou-app-worker-test.sh
@@ -2,9 +2,6 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT
-
 worker_config="${repo_root}/turbo/apps/app-worker/wrangler.jsonc"
 if ! grep -Fq '"global_fetch_strictly_public"' "$worker_config"; then
   echo "app Worker must allow public same-zone fetches" >&2
@@ -30,8 +27,7 @@ for module_path in \
   fi
 done
 
-cp "${repo_root}/turbo/apps/app-worker/src/worker.js" "${tmp_dir}/worker.mjs"
 node "${repo_root}/.github/scripts/tests/okou-app-worker-test.mjs" \
-  "${tmp_dir}/worker.mjs" \
+  "${repo_root}/turbo/apps/app-worker/src/worker.js" \
   "${repo_root}/turbo/apps/platform/index.html" \
   "${repo_root}/turbo/apps/platform/public/manifest.webmanifest"

--- a/.github/scripts/tests/okou-app-worker-test.sh
+++ b/.github/scripts/tests/okou-app-worker-test.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
 worker_config="${repo_root}/turbo/apps/app-worker/wrangler.jsonc"
 if ! grep -Fq '"global_fetch_strictly_public"' "$worker_config"; then
   echo "app Worker must allow public same-zone fetches" >&2
@@ -27,7 +30,19 @@ for module_path in \
   fi
 done
 
+clerk_stub_dir="${tmp_dir}/node_modules/@clerk/backend"
+mkdir -p "$clerk_stub_dir"
+printf '%s\n' \
+  '{"name":"@clerk/backend","type":"module","exports":"./index.js"}' \
+  > "${clerk_stub_dir}/package.json"
+printf '%s\n' \
+  'export function createClerkClient() {' \
+  '  throw new Error("Unexpected default Clerk client invocation");' \
+  '}' \
+  > "${clerk_stub_dir}/index.js"
+cp "${repo_root}/turbo/apps/app-worker/src/worker.js" "${tmp_dir}/worker.mjs"
+
 node "${repo_root}/.github/scripts/tests/okou-app-worker-test.mjs" \
-  "${repo_root}/turbo/apps/app-worker/src/worker.js" \
+  "${tmp_dir}/worker.mjs" \
   "${repo_root}/turbo/apps/platform/index.html" \
   "${repo_root}/turbo/apps/platform/public/manifest.webmanifest"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1568,7 +1568,6 @@ jobs:
             <<< "$deployments_response" >/dev/null; then
             pnpm --filter @okouai/app-worker exec wrangler deploy \
               --env preview \
-              "${worker_secret_args[@]}" \
               --message "bootstrap app preview Worker (${ARTIFACT_SHA})"
           fi
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1491,7 +1491,10 @@ jobs:
         id: worker-deploy
         env:
           ARTIFACT_SHA: ${{ steps.artifact.outputs.sha }}
+          CLERK_PUBLISHABLE_KEY: ${{ github.event_name == 'pull_request' && vars.CLERK_PUBLISHABLE_KEY_PREVIEW || '' }}
+          CLERK_SECRET_KEY: ${{ github.event_name == 'pull_request' && secrets.CLERK_SECRET_KEY || '' }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_WORKER_DEPLOY_API_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
           EXPECTED_PREVIEW_URL: ${{ steps.app-preview.outputs.url }}
           WORKER_PREVIEW_ALIAS: ${{ steps.worker-alias.outputs.alias }}
         run: |
@@ -1499,6 +1502,34 @@ jobs:
           : "${CLOUDFLARE_API_TOKEN:?CF_API_WORKER_DEPLOY_API_TOKEN secret is required}"
           : "${CLOUDFLARE_ACCOUNT_ID:?CF_ACCOUNT_ID variable is required}"
           : "${EXPECTED_PREVIEW_URL:?app Worker preview URL is required}"
+
+          worker_secret_args=()
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            : "${CLERK_PUBLISHABLE_KEY:?CLERK_PUBLISHABLE_KEY_PREVIEW variable is required}"
+            : "${CLERK_SECRET_KEY:?CLERK_SECRET_KEY secret is required}"
+            case "$CLERK_PUBLISHABLE_KEY" in
+              pk_test_*) ;;
+              *) echo "App Worker preview requires a Clerk test publishable key" >&2; exit 1 ;;
+            esac
+            case "$CLERK_SECRET_KEY" in
+              sk_test_*) ;;
+              *) echo "App Worker preview requires a Clerk test secret key" >&2; exit 1 ;;
+            esac
+
+            # Keep Clerk bindings encrypted and version-scoped. The exact alias
+            # origin is included so the Worker never trusts an arbitrary Host.
+            umask 077
+            worker_secrets="$(mktemp)"
+            trap 'rm -f "$worker_secrets"' EXIT
+            jq -n \
+              '{
+                CLERK_EDGE_DEBUG_AUTHORIZED_PARTY: env.EXPECTED_PREVIEW_URL,
+                CLERK_PUBLISHABLE_KEY: env.CLERK_PUBLISHABLE_KEY,
+                CLERK_SECRET_KEY: env.CLERK_SECRET_KEY
+              }' > "$worker_secrets"
+            worker_secret_args=(--secrets-file "$worker_secrets")
+          fi
+          unset CLERK_PUBLISHABLE_KEY CLERK_SECRET_KEY
 
           # Preview URLs must already be enabled when Wrangler uploads the
           # version, otherwise Cloudflare does not register --preview-alias.
@@ -1537,12 +1568,14 @@ jobs:
             <<< "$deployments_response" >/dev/null; then
             pnpm --filter @okouai/app-worker exec wrangler deploy \
               --env preview \
+              "${worker_secret_args[@]}" \
               --message "bootstrap app preview Worker (${ARTIFACT_SHA})"
           fi
 
           pnpm --filter @okouai/app-worker exec wrangler versions upload \
             --env preview \
             --preview-alias "$WORKER_PREVIEW_ALIAS" \
+            "${worker_secret_args[@]}" \
             --message "app artifact ${ARTIFACT_SHA}"
 
           echo "url=$EXPECTED_PREVIEW_URL" >> "$GITHUB_OUTPUT"

--- a/turbo/apps/app-worker/package.json
+++ b/turbo/apps/app-worker/package.json
@@ -8,6 +8,9 @@
     "lint": "oxlint && eslint . --max-warnings 0",
     "test": "node ../../../.github/scripts/tests/okou-app-worker-test.mjs src/worker.js ../platform/index.html ../platform/public/manifest.webmanifest"
   },
+  "dependencies": {
+    "@clerk/backend": "^3.13.1"
+  },
   "devDependencies": {
     "@okouai/eslint-config": "workspace:*",
     "@okouai/typescript-config": "workspace:*",

--- a/turbo/apps/app-worker/src/worker.js
+++ b/turbo/apps/app-worker/src/worker.js
@@ -1,3 +1,5 @@
+import { createClerkClient } from "@clerk/backend";
+
 const SHARED_THREAD_PATH =
   /^\/share\/threads\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/iu;
 const PREVIEW_API_ORIGIN_PATTERN =
@@ -21,6 +23,10 @@ const PRODUCTION_API_ORIGINS = new Map([
   ["app-worker.vm0.ai", "https://api.vm0.ai"],
 ]);
 const VERCEL_PROTECTION_BYPASS = "x-vercel-protection-bypass";
+const CLERK_EDGE_DEBUG_QUERY_PARAMETER = "__clerk_edge_debug";
+const CLERK_EDGE_DEBUG_TIMEOUT_MS = 1000;
+const CLERK_EDGE_DEBUG_PREVIEW_HOSTNAME_PATTERN =
+  /^pr-[1-9][0-9]*-app-okou-app-preview\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.workers\.dev$/u;
 const SECURITY_HEADERS = {
   "Permissions-Policy":
     "camera=(), geolocation=(), payment=(), usb=(), serial=(), display-capture=(self), clipboard-read=(), microphone=(self), bluetooth=(self), clipboard-write=(self), fullscreen=(self)",
@@ -186,12 +192,12 @@ function htmlResponse(indexHtml, assetResponse, status, cacheControl) {
   return new Response(indexHtml, { status, headers });
 }
 
-function noIndexResponse(response) {
+function noIndexResponse(response, cacheControl) {
   const headers = new Headers(response.headers);
   headers.delete("Content-Encoding");
   headers.delete("Content-Length");
   headers.delete("ETag");
-  headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+  headers.set("Cache-Control", cacheControl);
   headers.set("X-Robots-Tag", "noindex, nofollow");
   return new Response(response.body, {
     status: response.status,
@@ -200,7 +206,87 @@ function noIndexResponse(response) {
   });
 }
 
-function rewriteAppPage(response, metadata) {
+function serializeClerkEdgeSession(session) {
+  return JSON.stringify(session)
+    .replaceAll("<", "\\u003c")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}
+
+function isClerkEdgeDebugRequest(requestUrl, env) {
+  const debugFlags = requestUrl.searchParams.getAll(
+    CLERK_EDGE_DEBUG_QUERY_PARAMETER,
+  );
+  return (
+    requestUrl.protocol === "https:" &&
+    debugFlags.length === 1 &&
+    debugFlags[0] === "1" &&
+    CLERK_EDGE_DEBUG_PREVIEW_HOSTNAME_PATTERN.test(requestUrl.hostname) &&
+    env.CLERK_EDGE_DEBUG_AUTHORIZED_PARTY === requestUrl.origin
+  );
+}
+
+async function clerkEdgeSession(request, env, requestUrl, clerkClientFactory) {
+  let timeoutId;
+  try {
+    const publishableKey = env.CLERK_PUBLISHABLE_KEY;
+    const secretKey = env.CLERK_SECRET_KEY;
+    if (
+      typeof publishableKey !== "string" ||
+      publishableKey.length === 0 ||
+      typeof secretKey !== "string" ||
+      secretKey.length === 0
+    ) {
+      return null;
+    }
+
+    const timeout = new Promise((resolve) => {
+      timeoutId = globalThis.setTimeout(() => {
+        resolve(null);
+      }, CLERK_EDGE_DEBUG_TIMEOUT_MS);
+    });
+    const authentication = Promise.resolve().then(() => {
+      const clerk = clerkClientFactory({
+        publishableKey,
+        secretKey,
+        telemetry: { disabled: true },
+      });
+      return clerk.authenticateRequest(request, {
+        acceptsToken: "session_token",
+        authorizedParties: [env.CLERK_EDGE_DEBUG_AUTHORIZED_PARTY],
+      });
+    });
+    const requestState = await Promise.race([authentication, timeout]);
+    // Browser mutations are outside this observation-only diagnostic branch.
+    if (
+      requestState === null ||
+      !requestState.isAuthenticated ||
+      requestState.headers.has("Location") ||
+      requestState.headers.has("Set-Cookie")
+    ) {
+      return null;
+    }
+
+    const { userId, orgId } = requestState.toAuth();
+    if (
+      typeof userId !== "string" ||
+      userId.length === 0 ||
+      (orgId !== null && typeof orgId !== "string")
+    ) {
+      return null;
+    }
+    return { userId, orgId };
+  } catch {
+    // Clerk must never affect availability of the existing app shell.
+    return null;
+  } finally {
+    if (timeoutId !== undefined) {
+      globalThis.clearTimeout(timeoutId);
+    }
+  }
+}
+
+function rewriteAppPage(response, metadata, edgeSession) {
   const rewriter = new HTMLRewriter()
     .on("html", setBrandContext(metadata.brandName))
     .on("title", {
@@ -254,8 +340,23 @@ function rewriteAppPage(response, metadata) {
       },
     });
   addStaticAssetHandlers(rewriter, metadata);
+  if (edgeSession !== null) {
+    rewriter.on("body", {
+      element(element) {
+        element.append(
+          `<script type="application/json" id="vm0-clerk-edge-session">${serializeClerkEdgeSession(edgeSession)}</script>`,
+          { html: true },
+        );
+      },
+    });
+  }
   const rewrittenResponse = rewriter.transform(response);
-  return noIndexResponse(rewrittenResponse);
+  return noIndexResponse(
+    rewrittenResponse,
+    edgeSession === null
+      ? "public, max-age=0, must-revalidate"
+      : "private, no-store",
+  );
 }
 
 async function rewriteManifest(response, metadata) {
@@ -518,7 +619,13 @@ function withAppHeaders(response, requestUrl) {
   });
 }
 
-async function handleRequest(request, env, requestUrl, embeddedShell) {
+async function handleRequest(
+  request,
+  env,
+  requestUrl,
+  embeddedShell,
+  clerkClientFactory,
+) {
   if (
     (request.method === "GET" || request.method === "HEAD") &&
     requestUrl.pathname.startsWith(APP_ASSET_PATH_PREFIX)
@@ -619,10 +726,16 @@ async function handleRequest(request, env, requestUrl, embeddedShell) {
   ) {
     return assetResponse;
   }
-  return rewriteAppPage(assetResponse, metadata);
+  const edgeSession = isClerkEdgeDebugRequest(requestUrl, env)
+    ? await clerkEdgeSession(request, env, requestUrl, clerkClientFactory)
+    : null;
+  return rewriteAppPage(assetResponse, metadata, edgeSession);
 }
 
-export function createWorker(embeddedShell) {
+export function createWorker(
+  embeddedShell,
+  clerkClientFactory = createClerkClient,
+) {
   return {
     async fetch(request, env) {
       const requestUrl = new URL(request.url);
@@ -631,6 +744,7 @@ export function createWorker(embeddedShell) {
         env,
         requestUrl,
         embeddedShell,
+        clerkClientFactory,
       );
       return withAppHeaders(response, requestUrl);
     },

--- a/turbo/apps/app-worker/src/worker.js
+++ b/turbo/apps/app-worker/src/worker.js
@@ -1,3 +1,5 @@
+import { createClerkClient } from "@clerk/backend";
+
 const SHARED_THREAD_PATH =
   /^\/share\/threads\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/iu;
 const PREVIEW_API_ORIGIN_PATTERN =
@@ -224,11 +226,6 @@ function isClerkEdgeDebugRequest(requestUrl, env) {
   );
 }
 
-async function createClerkBackendClient(options) {
-  const { createClerkClient } = await import("@clerk/backend");
-  return createClerkClient(options);
-}
-
 async function clerkEdgeSession(request, env, requestUrl, clerkClientFactory) {
   let timeoutId;
   try {
@@ -248,8 +245,8 @@ async function clerkEdgeSession(request, env, requestUrl, clerkClientFactory) {
         resolve(null);
       }, CLERK_EDGE_DEBUG_TIMEOUT_MS);
     });
-    const authentication = Promise.resolve().then(async () => {
-      const clerk = await clerkClientFactory({
+    const authentication = Promise.resolve().then(() => {
+      const clerk = clerkClientFactory({
         publishableKey,
         secretKey,
         telemetry: { disabled: true },
@@ -737,7 +734,7 @@ async function handleRequest(
 
 export function createWorker(
   embeddedShell,
-  clerkClientFactory = createClerkBackendClient,
+  clerkClientFactory = createClerkClient,
 ) {
   return {
     async fetch(request, env) {

--- a/turbo/apps/app-worker/src/worker.js
+++ b/turbo/apps/app-worker/src/worker.js
@@ -1,5 +1,3 @@
-import { createClerkClient } from "@clerk/backend";
-
 const SHARED_THREAD_PATH =
   /^\/share\/threads\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/iu;
 const PREVIEW_API_ORIGIN_PATTERN =
@@ -226,6 +224,11 @@ function isClerkEdgeDebugRequest(requestUrl, env) {
   );
 }
 
+async function createClerkBackendClient(options) {
+  const { createClerkClient } = await import("@clerk/backend");
+  return createClerkClient(options);
+}
+
 async function clerkEdgeSession(request, env, requestUrl, clerkClientFactory) {
   let timeoutId;
   try {
@@ -245,8 +248,8 @@ async function clerkEdgeSession(request, env, requestUrl, clerkClientFactory) {
         resolve(null);
       }, CLERK_EDGE_DEBUG_TIMEOUT_MS);
     });
-    const authentication = Promise.resolve().then(() => {
-      const clerk = clerkClientFactory({
+    const authentication = Promise.resolve().then(async () => {
+      const clerk = await clerkClientFactory({
         publishableKey,
         secretKey,
         telemetry: { disabled: true },
@@ -734,7 +737,7 @@ async function handleRequest(
 
 export function createWorker(
   embeddedShell,
-  clerkClientFactory = createClerkClient,
+  clerkClientFactory = createClerkBackendClient,
 ) {
   return {
     async fetch(request, env) {

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -322,6 +322,10 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.6)(msw@2.13.2(@types/node@24.3.0)(typescript@6.0.3))(vite@8.0.16(@types/node@24.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/app-worker:
+    dependencies:
+      '@clerk/backend':
+        specifier: ^3.13.1
+        version: 3.13.1(react-dom@19.2.6(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@okouai/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- add an experimental Clerk authentication probe to the standalone App Worker that is enabled only when both the exact PR Worker preview origin and `?__clerk_edge_debug=1` are present
- authenticate with the official `@clerk/backend` SDK, an exact `authorizedParties` origin, a one-second fail-open timeout, and no vm0 API/bootstrap request
- inject only `{ userId, orgId }` as inert `application/json` when authentication succeeds; anonymous, handshake, refresh, timeout, missing-config, and exception paths preserve the existing shell response
- pass the existing Clerk development-instance keys to PR Worker version uploads through an ephemeral, permission-restricted Wrangler `--secrets-file`; reject non-test key prefixes

## Security boundaries

- production, canary, staging, custom-domain preview, and ordinary PR preview requests stay on the existing path without invoking Clerk
- the diagnostic response never forwards `Location` or `Set-Cookie`, never emits tokens, cookies, secrets, session IDs, claims, or profiles, and is `private, no-store` only after successful injection
- production Worker configuration, routes, DNS, Clerk production configuration, and vm0 APIs are untouched
- Ethan explicitly approved pr-auto merge after preview verification on 2026-09-03

## Validation

- `pnpm --filter @okouai/app-worker lint`
- `pnpm --filter @okouai/app-worker check-types`
- `pnpm knip --workspace @okouai/app-worker`
- `.github/scripts/tests/okou-app-worker-test.sh`
- `.github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh`
- `.github/scripts/tests/resolve-app-preview-alias-test.sh`
- targeted Prettier, ShellCheck, and actionlint checks
- Wrangler preview `--dry-run` with disposable dummy test credentials, followed by a bundle scan confirming they were absent

Browser verification: https://github.com/vm0-ai/vm0/pull/31510#issuecomment-5525679469
