### PR TITLE
fix(pi-memory): promote terminal lifecycle telemetry

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -239,6 +239,23 @@ export default [
     },
   },
   {
+    files: [
+      "src/signals/services/pi-memory-stage1-worker.service.ts",
+      "src/signals/services/pi-memory-phase2-worker.service.ts",
+    ],
+    rules: {
+      "api/no-logger-info": [
+        "error",
+        {
+          allowedMessages: [
+            "Pi memory Stage 1 candidate processed",
+            "Pi memory Phase 2 work completed",
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ["src/**/*.ts"],
     ignores: [
       "src/**/__tests__/**",

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-memory-stage1-worker.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-memory-stage1-worker.test.ts
@@ -459,6 +459,16 @@ function stage1Client(storage: ReturnType<typeof createStorageFixture>) {
   })(cronExtractPiMemoryStage1Contract);
 }
 
+function stage1TerminalEvents(): readonly Record<string, unknown>[] {
+  return context.mocks.axiomLogging.info.mock.calls
+    .filter(([message]) => {
+      return message === "Pi memory Stage 1 candidate processed";
+    })
+    .map(([, fields]) => {
+      return fields as Record<string, unknown>;
+    });
+}
+
 beforeEach(async () => {
   mockEnv("R2_USER_STORAGES_BUCKET_NAME", BUCKET);
   mockEnv("CRON_SECRET", CRON_SECRET);
@@ -558,6 +568,25 @@ describe("Pi memory Stage 1 worker", () => {
     expect(provider.calls).toHaveLength(1);
     await expect(inspect(fixture)).resolves.toMatchObject({
       status: "succeeded",
+    });
+    const events = stage1TerminalEvents();
+    expect(events).toHaveLength(1);
+    expect(Object.keys(events[0] ?? {}).sort()).toStrictEqual([
+      "attemptCount",
+      "durationMs",
+      "inputTokens",
+      "memoryStorageId",
+      "orgId",
+      "outcome",
+      "outputTokens",
+      "piSessionId",
+      "sourceHistoryHash",
+      "userId",
+    ]);
+    expect(events[0]).toMatchObject({
+      outcome: "succeeded",
+      memoryStorageId: fixture.memory_storage_id,
+      piSessionId,
     });
   });
 
@@ -933,6 +962,10 @@ describe("Pi memory Stage 1 worker", () => {
       rollout_summary: null,
       rollout_slug: null,
     });
+    expect(stage1TerminalEvents()).toHaveLength(1);
+    expect(stage1TerminalEvents()[0]).toMatchObject({
+      outcome: "succeeded_no_output",
+    });
   });
 
   it("redacts an unsafe secret-bearing slug before retry and telemetry", async () => {
@@ -959,9 +992,13 @@ describe("Pi memory Stage 1 worker", () => {
       last_error_class: "provider_output_invalid",
       rollout_slug: null,
     });
-    expect(
-      JSON.stringify(context.mocks.axiomLogging.debug.mock.calls),
-    ).not.toContain(OUTPUT_SECRET);
+    const terminalEvents = stage1TerminalEvents();
+    expect(terminalEvents).toHaveLength(1);
+    expect(terminalEvents[0]).toMatchObject({
+      outcome: "retryable_failure",
+      errorClass: "provider_output_invalid",
+    });
+    expect(JSON.stringify(terminalEvents)).not.toContain(OUTPUT_SECRET);
   });
 
   it("retries exactly owned work when cancellation interrupts the provider", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-memory-stage1-worker.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-memory-stage1-worker.test.ts
@@ -573,6 +573,7 @@ describe("Pi memory Stage 1 worker", () => {
     expect(events).toHaveLength(1);
     expect(Object.keys(events[0] ?? {}).sort()).toStrictEqual([
       "attemptCount",
+      "context",
       "durationMs",
       "inputTokens",
       "memoryStorageId",

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
@@ -1306,6 +1306,7 @@ describe("Pi memory Phase 2 worker composition", () => {
     expect(Object.keys(terminalEvents[0] ?? {}).sort()).toStrictEqual([
       "claimedBaseVersionId",
       "claimedRevision",
+      "context",
       "durationMs",
       "errorClass",
       "leaseOwner",

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
@@ -1295,6 +1295,40 @@ describe("Pi memory Phase 2 worker composition", () => {
       failed: 1,
     });
     expect(provider.calls.value).toBe(1);
+    const terminalEvents = context.mocks.axiomLogging.info.mock.calls
+      .filter(([message]) => {
+        return message === "Pi memory Phase 2 work completed";
+      })
+      .map(([, fields]) => {
+        return fields as Record<string, unknown>;
+      });
+    expect(terminalEvents).toHaveLength(1);
+    expect(Object.keys(terminalEvents[0] ?? {}).sort()).toStrictEqual([
+      "claimedBaseVersionId",
+      "claimedRevision",
+      "durationMs",
+      "errorClass",
+      "leaseOwner",
+      "memoryStorageId",
+      "orgId",
+      "outcome",
+      "reconciliationLatencyMs",
+      "selectedCount",
+      "userId",
+      "versionId",
+    ]);
+    expect(terminalEvents[0]).toMatchObject({
+      outcome: "failed",
+      errorClass: "agent_output_invalid",
+      memoryStorageId: scope.memoryStorageId,
+    });
+    expect(JSON.stringify(terminalEvents)).not.toContain(MEMORY_SECRET);
+    expect(JSON.stringify(terminalEvents)).not.toContain(PATH_SECRET);
+    expect(JSON.stringify(terminalEvents)).not.toContain(PROVIDER_ID_SECRET);
+    expect(JSON.stringify(terminalEvents)).not.toContain(PROMPT_SECRET);
+    expect(JSON.stringify(terminalEvents)).not.toContain(
+      LAUNCH_SNAPSHOT_SECRET,
+    );
     const [storage] = await db()
       .select({ headVersionId: storages.headVersionId })
       .from(storages)

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-worker.service.ts
@@ -305,7 +305,8 @@ function logOutcome(args: {
   readonly errorClass?: string;
   readonly versionId?: string;
 }): void {
-  log.debug("Pi memory Phase 2 work completed", {
+  // eslint-disable-next-line api/no-logger-info -- terminal outcome is production diagnostic telemetry.
+  log.info("Pi memory Phase 2 work completed", {
     orgId: args.claim.orgId,
     userId: args.claim.userId,
     memoryStorageId: args.claim.memoryStorageId,

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-worker.service.ts
@@ -305,7 +305,6 @@ function logOutcome(args: {
   readonly errorClass?: string;
   readonly versionId?: string;
 }): void {
-  // eslint-disable-next-line api/no-logger-info -- terminal outcome is production diagnostic telemetry.
   log.info("Pi memory Phase 2 work completed", {
     orgId: args.claim.orgId,
     userId: args.claim.userId,

--- a/turbo/apps/api/src/signals/services/pi-memory-stage1-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-stage1-worker.service.ts
@@ -611,7 +611,8 @@ function logOutcome(args: {
   readonly outputTokens?: number;
   readonly errorClass?: string;
 }): void {
-  log.debug("Pi memory Stage 1 candidate processed", {
+  // eslint-disable-next-line api/no-logger-info -- terminal outcome is production diagnostic telemetry.
+  log.info("Pi memory Stage 1 candidate processed", {
     orgId: args.work.orgId,
     userId: args.work.userId,
     memoryStorageId: args.work.memoryStorageId,

--- a/turbo/apps/api/src/signals/services/pi-memory-stage1-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-stage1-worker.service.ts
@@ -611,7 +611,6 @@ function logOutcome(args: {
   readonly outputTokens?: number;
   readonly errorClass?: string;
 }): void {
-  // eslint-disable-next-line api/no-logger-info -- terminal outcome is production diagnostic telemetry.
   log.info("Pi memory Stage 1 candidate processed", {
     orgId: args.work.orgId,
     userId: args.work.userId,


### PR DESCRIPTION
## Summary
- promote the existing per-candidate Stage 1 terminal record and per-claimed-job Phase 2 terminal record from debug to info
- retain the existing terminal ownership and outcome paths; no lifecycle behavior changes
- assert info severity, exact terminal field inventories, and secret/content sentinel exclusions in existing worker coverage

## Usage-persistence decision
Successful Phase 2 usage persistence remains debug. usage_event and hourly rollups remain billing/reconciliation authority, while the one per-job terminal record gives production diagnosis without an additional info event.

## Validation
- pnpm --filter api run check-types
- pnpm --filter api run build
- pnpm --filter api run lint
- pnpm run knip
- focused Vitest command attempted but the local PostgreSQL test dependency was unavailable (ECONNREFUSED ::1:5432 / 127.0.0.1:5432); protected CI remains authoritative

Closes #31497