### PR TITLE
feat(platform): merge goal continuations into triggering run work

### DIFF
--- a/.github/scripts/smoke-okou-cli-artifact.sh
+++ b/.github/scripts/smoke-okou-cli-artifact.sh
@@ -33,7 +33,7 @@ run_cli() {
   local stdout_file="$2"
   local stderr_file="$3"
   shift 3
-  PATH="$clean_path" "$node_path" "$npx_path" \
+  PATH="$clean_path" npm_config_audit=false "$node_path" "$npx_path" \
     --yes --package="$package_path" "$entrypoint" "$@" \
     >"$stdout_file" 2>"$stderr_file"
 }

--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -354,15 +354,16 @@ function createVisibleTurns(
   return computed((get): readonly LocatorTurn[] => {
     const activeGroups = activeGroupsForLocator(get(allChatGroups$));
     const targetEventId = get(threadScrollPosition$)?.targetEventId ?? null;
+    const runWorkFoldingEnabled =
+      get(featureSwitch$)[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
     const runGroupFolding = buildRunGroupFolding(
       activeGroups,
       get(runGroupExpansionOverrides$),
       targetEventId,
+      { preserveGoalRunsForWorkFolding: runWorkFoldingEnabled },
     );
     const runGroupVisibleGroups =
       runGroupFolding?.visibleGroups ?? activeGroups;
-    const runWorkFoldingEnabled =
-      get(featureSwitch$)[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
     if (!runWorkFoldingEnabled) {
       const completedWorkFolding = buildCompletedWorkFolding(
         runGroupVisibleGroups,

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-types.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-types.ts
@@ -22,3 +22,14 @@ export type ChatInputEvent = Extract<
       | "input.rejected";
   }
 >;
+
+export function isGoalContinuationInput(
+  event: ChatEvent,
+): event is ChatInputEvent {
+  return (
+    (event.eventType === "input.prompt" || event.eventType === "input.goal") &&
+    event.userMessage.parts.some((part) => {
+      return part.type === "goal";
+    })
+  );
+}

--- a/turbo/apps/platform/src/signals/chat-page/chat-event-usage.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-usage.ts
@@ -1,0 +1,63 @@
+import type { ChatEventUsagePayload } from "@okouai/api-contracts/contracts/chat-threads";
+
+interface UsageBreakdownAccumulator {
+  readonly kind: string;
+  credits: number;
+  readonly providers: Map<string, number>;
+}
+
+export function mergeChatEventUsagePayloads(
+  usages: readonly ChatEventUsagePayload[],
+): ChatEventUsagePayload | undefined {
+  if (usages.length === 0) {
+    return undefined;
+  }
+
+  let totalCredits = 0;
+  let settledAt = "";
+  const breakdownByKind = new Map<string, UsageBreakdownAccumulator>();
+
+  for (const usage of usages) {
+    totalCredits += usage.totalCredits;
+    settledAt = usage.settledAt;
+
+    for (const kindBreakdown of usage.breakdown) {
+      let accumulator = breakdownByKind.get(kindBreakdown.kind);
+      if (accumulator === undefined) {
+        accumulator = {
+          kind: kindBreakdown.kind,
+          credits: 0,
+          providers: new Map(),
+        };
+        breakdownByKind.set(kindBreakdown.kind, accumulator);
+      }
+
+      accumulator.credits += kindBreakdown.credits;
+
+      for (const providerBreakdown of kindBreakdown.providers) {
+        accumulator.providers.set(
+          providerBreakdown.provider,
+          (accumulator.providers.get(providerBreakdown.provider) ?? 0) +
+            providerBreakdown.credits,
+        );
+      }
+    }
+  }
+
+  return {
+    version: 1,
+    totalCredits,
+    settledAt,
+    breakdown: Array.from(breakdownByKind.values()).map((accumulator) => {
+      return {
+        kind: accumulator.kind,
+        credits: accumulator.credits,
+        providers: Array.from(accumulator.providers.entries()).map(
+          ([provider, credits]) => {
+            return { provider, credits };
+          },
+        ),
+      };
+    }),
+  };
+}

--- a/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
@@ -2,6 +2,8 @@ import { command, computed, state } from "ccstate";
 import type { EnrichedChatEvent, ChatEventGroup } from "./chat-event.ts";
 import type { ChatEventUsagePayload } from "@okouai/api-contracts/contracts/chat-threads";
 import { chatEventCompatibilityRole } from "@okouai/api-contracts/contracts/chat-events";
+import { mergeChatEventUsagePayloads } from "./chat-event-usage.ts";
+import { isGoalContinuationInput } from "./chat-event-types.ts";
 
 interface RunSegment {
   readonly runId: string;
@@ -35,6 +37,10 @@ export interface RunGroupFold {
 export interface RunGroupFolding {
   readonly visibleGroups: ChatEventGroup[];
   readonly foldsByNextGroupId: ReadonlyMap<string, readonly RunGroupFold[]>;
+}
+
+export interface RunGroupFoldingOptions {
+  readonly preserveGoalRunsForWorkFolding?: boolean;
 }
 
 const internalRunGroupExpansionOverrides$ = state<Map<string, boolean>>(
@@ -120,68 +126,6 @@ function setLatestUsageForRun(
   }
 }
 
-interface UsageBreakdownAccumulator {
-  readonly kind: string;
-  credits: number;
-  readonly providers: Map<string, number>;
-}
-
-function mergeUsagePayloads(
-  usages: readonly ChatEventUsagePayload[],
-): ChatEventUsagePayload | undefined {
-  if (usages.length === 0) {
-    return undefined;
-  }
-
-  let totalCredits = 0;
-  let settledAt = "";
-  const breakdownByKind = new Map<string, UsageBreakdownAccumulator>();
-
-  for (const usage of usages) {
-    totalCredits += usage.totalCredits;
-    settledAt = usage.settledAt;
-
-    for (const kindBreakdown of usage.breakdown) {
-      let accumulator = breakdownByKind.get(kindBreakdown.kind);
-      if (accumulator === undefined) {
-        accumulator = {
-          kind: kindBreakdown.kind,
-          credits: 0,
-          providers: new Map(),
-        };
-        breakdownByKind.set(kindBreakdown.kind, accumulator);
-      }
-
-      accumulator.credits += kindBreakdown.credits;
-
-      for (const providerBreakdown of kindBreakdown.providers) {
-        accumulator.providers.set(
-          providerBreakdown.provider,
-          (accumulator.providers.get(providerBreakdown.provider) ?? 0) +
-            providerBreakdown.credits,
-        );
-      }
-    }
-  }
-
-  return {
-    version: 1,
-    totalCredits,
-    settledAt,
-    breakdown: Array.from(breakdownByKind.values()).map((accumulator) => {
-      return {
-        kind: accumulator.kind,
-        credits: accumulator.credits,
-        providers: Array.from(accumulator.providers.entries()).map(
-          ([provider, credits]) => {
-            return { provider, credits };
-          },
-        ),
-      };
-    }),
-  };
-}
-
 function mergedUsageForRunSegments(
   runSegments: readonly GroupedRunSegment[],
   usageByRunId: ReadonlyMap<string, ChatEventUsagePayload>,
@@ -193,7 +137,7 @@ function mergedUsageForRunSegments(
       usages.push(usage);
     }
   }
-  return mergeUsagePayloads(usages);
+  return mergeChatEventUsagePayloads(usages);
 }
 
 function attachUsageToGroups(
@@ -546,6 +490,7 @@ export function buildRunGroupFolding(
   groups: readonly ChatEventGroup[],
   expansionOverrides?: ReadonlyMap<string, boolean>,
   protectedEventId: string | null = null,
+  options: RunGroupFoldingOptions = {},
 ): RunGroupFolding | null {
   const segments = eventSegmentsFromGroups(groups);
   const usageByRunId = usageByRunIdFromGroups(groups);
@@ -575,6 +520,20 @@ export function buildRunGroupFolding(
     const runSegments = segments
       .slice(index, endIndex)
       .filter(isGroupedRunSegment);
+    if (
+      options.preserveGoalRunsForWorkFolding &&
+      runSegments.some((item) => {
+        return item.events.some(isGoalContinuationInput);
+      })
+    ) {
+      visibleGroups.push(
+        ...runSegments.flatMap((item) => {
+          return segmentGroups(item, usageByRunId);
+        }),
+      );
+      index = endIndex;
+      continue;
+    }
     const foldSection = buildFoldSection(
       runSegments,
       usageByRunId,

--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -35,6 +35,7 @@ export interface RunWorkSection {
   readonly key: string;
   readonly anchorEventId: string;
   readonly hiddenGroups: ChatEventGroup[];
+  readonly hiddenGroupsAfterAnchor: ChatEventGroup[];
   readonly startTime: number;
   readonly endTime?: number;
 }
@@ -113,11 +114,13 @@ export function runWorkExpandedKeysForScrollTarget(
   const targetSection = Array.from(
     folding.sectionsByAnchorEventId.values(),
   ).find((section) => {
-    return section.hiddenGroups.some((group) => {
-      return group.events.some((event) => {
-        return event.id === targetEventId;
-      });
-    });
+    return [...section.hiddenGroups, ...section.hiddenGroupsAfterAnchor].some(
+      (group) => {
+        return group.events.some((event) => {
+          return event.id === targetEventId;
+        });
+      },
+    );
   });
   if (!targetSection || expandedKeys.has(targetSection.key)) {
     return expandedKeys;
@@ -160,8 +163,14 @@ function groupEventsForRunWorkDisplay(
       last?.events.some((candidate) => {
         return workAnchorEventIds.has(candidate.id);
       }) ?? false;
+    const joinsWorkAnchor = lastHasWorkAnchor && isCancelledRunEvent(event);
 
-    if (!forceStandalone && last && last.role === role && !lastHasWorkAnchor) {
+    if (
+      !forceStandalone &&
+      last &&
+      last.role === role &&
+      (!lastHasWorkAnchor || joinsWorkAnchor)
+    ) {
       last.events.push(event);
       continue;
     }
@@ -478,6 +487,7 @@ function foldRunWorkPhase(
   events: readonly EnrichedChatEvent[],
   endTime: number | undefined,
   hiddenUserEventIds: ReadonlySet<string>,
+  foldedEventIds: ReadonlySet<string>,
 ): RunWorkPhaseFolding {
   const latestAssistantOutput = lastEventMatching(
     events,
@@ -499,10 +509,24 @@ function foldRunWorkPhase(
 
   const anchorIndex = events.indexOf(anchorEvent);
   const hiddenEvents = events.slice(0, anchorIndex).filter((event) => {
-    return isRunWorkAssistantOutput(event);
+    return (
+      isRunWorkAssistantOutput(event) ||
+      (hiddenUserEventIds.has(event.id) && foldedEventIds.has(event.id))
+    );
   });
+  const hiddenEventsAfterAnchor = events
+    .slice(anchorIndex + 1)
+    .filter((event) => {
+      return hiddenUserEventIds.has(event.id) && foldedEventIds.has(event.id);
+    });
+  const hiddenEventIds = new Set(
+    [...hiddenEvents, ...hiddenEventsAfterAnchor].map((event) => {
+      return event.id;
+    }),
+  );
   const trailingStatusEvents = events.slice(anchorIndex + 1).filter((event) => {
     return (
+      !hiddenEventIds.has(event.id) &&
       !hiddenUserEventIds.has(event.id) &&
       isRenderableAssistantEvent(event) &&
       !isRunWorkAssistantOutput(event)
@@ -518,6 +542,7 @@ function foldRunWorkPhase(
       key: `${key}:${events[0]!.id}`,
       anchorEventId: anchorEvent.id,
       hiddenGroups: groupEventsByRole(hiddenEvents),
+      hiddenGroupsAfterAnchor: groupEventsByRole(hiddenEventsAfterAnchor),
       startTime,
       ...(endTime === undefined ? {} : { endTime }),
     },
@@ -578,6 +603,7 @@ function phaseEndTime(
 
 export function buildRunWorkFolding(
   groups: readonly ChatEventGroup[],
+  foldedEventIds: ReadonlySet<string> = new Set(),
 ): RunWorkFolding | null {
   const usageByRunId = usageByRunIdFromGroups(groups);
   const events = groups.flatMap((group) => {
@@ -609,6 +635,7 @@ export function buildRunWorkFolding(
         phase,
         phaseEndTime(phase, phaseIndex === phases.length - 1, terminalEvent),
         unit.hiddenUserEventIds,
+        foldedEventIds,
       );
       visibleEvents.push(...phaseFolding.visibleEvents);
       if (phaseFolding.section !== null) {
@@ -660,13 +687,22 @@ export function applyRunWorkExpansion(
     if (section === null || !expandedKeys.has(section.key)) {
       return group;
     }
+    const anchorIndex = group.events.findIndex((event) => {
+      return event.id === section.anchorEventId;
+    });
+    const anchorEndIndex =
+      anchorIndex === -1 ? group.events.length : anchorIndex + 1;
     return {
       ...group,
       events: [
         ...section.hiddenGroups.flatMap((hiddenGroup) => {
           return hiddenGroup.events;
         }),
-        ...group.events,
+        ...group.events.slice(0, anchorEndIndex),
+        ...section.hiddenGroupsAfterAnchor.flatMap((hiddenGroup) => {
+          return hiddenGroup.events;
+        }),
+        ...group.events.slice(anchorEndIndex),
       ],
     };
   });

--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -592,7 +592,7 @@ export function buildRunWorkFolding(
       continue;
     }
 
-    if (latestRunWasCancelled(unit.events)) {
+    if (!unit.isGoal && latestRunWasCancelled(unit.events)) {
       visibleEvents.push(
         ...unit.events.filter((event) => {
           return !unit.hiddenUserEventIds.has(event.id);

--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -4,6 +4,7 @@ import {
   chatEventCompatibilityRole,
   foldLatestChatUsageByRunId,
   isChatEventContentTextType,
+  isChatInputEventType,
   isChatRunTerminalEventType,
 } from "@okouai/api-contracts/contracts/chat-events";
 import { hasChatEventBodyContent } from "./chat-event-body-blocks.ts";
@@ -75,8 +76,12 @@ export function isRenderableAssistantEvent(event: EnrichedChatEvent): boolean {
   );
 }
 
-function isRunWorkAssistantEvent(event: EnrichedChatEvent): boolean {
-  return event.eventType !== "run.queued" && isRenderableAssistantEvent(event);
+function isRunWorkAssistantOutput(event: EnrichedChatEvent): boolean {
+  return (
+    event.eventType !== "run.queued" &&
+    !isCancelledRunEvent(event) &&
+    isRenderableAssistantEvent(event)
+  );
 }
 
 export function runWorkSectionForGroup(
@@ -267,7 +272,11 @@ function runWorkEventSegments(
 ): RunWorkEventSegment[] {
   const segments: RunWorkEventSegment[] = [];
   for (const event of events) {
-    const runId = event.runId;
+    const runId =
+      event.runId ??
+      (event.eventType === "control.interrupt"
+        ? event.interruptsRunId
+        : undefined);
     const last = segments[segments.length - 1];
     if (runId !== undefined && last?.runId === runId) {
       last.events.push(event);
@@ -392,8 +401,7 @@ function visibleRunWorkUserEvent(
   hiddenUserEventIds: ReadonlySet<string>,
 ): boolean {
   return (
-    chatEventCompatibilityRole(event.eventType) === "user" &&
-    !hiddenUserEventIds.has(event.id)
+    isChatInputEventType(event.eventType) && !hiddenUserEventIds.has(event.id)
   );
 }
 
@@ -471,14 +479,14 @@ function foldRunWorkPhase(
   endTime: number | undefined,
   hiddenUserEventIds: ReadonlySet<string>,
 ): RunWorkPhaseFolding {
-  const latestAssistantEvent = lastEventMatching(
+  const latestAssistantOutput = lastEventMatching(
     events,
-    isRunWorkAssistantEvent,
+    isRunWorkAssistantOutput,
   );
   const terminalEvent = lastEventMatching(events, (event) => {
     return isChatRunTerminalEventType(event.eventType);
   });
-  const anchorEvent = latestAssistantEvent ?? terminalEvent;
+  const anchorEvent = latestAssistantOutput ?? terminalEvent;
   const startTime = firstEventTime(events);
   if (anchorEvent === undefined || startTime === null) {
     return {
@@ -491,14 +499,21 @@ function foldRunWorkPhase(
 
   const anchorIndex = events.indexOf(anchorEvent);
   const hiddenEvents = events.slice(0, anchorIndex).filter((event) => {
-    return isRunWorkAssistantEvent(event);
+    return isRunWorkAssistantOutput(event);
+  });
+  const trailingStatusEvents = events.slice(anchorIndex + 1).filter((event) => {
+    return (
+      !hiddenUserEventIds.has(event.id) &&
+      isRenderableAssistantEvent(event) &&
+      !isRunWorkAssistantOutput(event)
+    );
   });
   const userEvents = events.filter((event) => {
     return visibleRunWorkUserEvent(event, hiddenUserEventIds);
   });
 
   return {
-    visibleEvents: [...userEvents, anchorEvent],
+    visibleEvents: [...userEvents, anchorEvent, ...trailingStatusEvents],
     section: {
       key: `${key}:${events[0]!.id}`,
       anchorEventId: anchorEvent.id,
@@ -533,16 +548,6 @@ function terminalEventForLatestRun(
       event.runId === latestRunId && isChatRunTerminalEventType(event.eventType)
     );
   });
-}
-
-function latestRunWasCancelled(events: readonly EnrichedChatEvent[]): boolean {
-  const latestRunId = latestRunIdForEvents(events);
-  return (
-    latestRunId !== undefined &&
-    events.some((event) => {
-      return event.runId === latestRunId && isCancelledRunEvent(event);
-    })
-  );
 }
 
 function mergedUsageForRunIds(
@@ -584,15 +589,6 @@ export function buildRunWorkFolding(
 
   for (const unit of runWorkUnits(events)) {
     if (unit.key === undefined) {
-      visibleEvents.push(
-        ...unit.events.filter((event) => {
-          return !unit.hiddenUserEventIds.has(event.id);
-        }),
-      );
-      continue;
-    }
-
-    if (!unit.isGoal && latestRunWasCancelled(unit.events)) {
       visibleEvents.push(
         ...unit.events.filter((event) => {
           return !unit.hiddenUserEventIds.has(event.id);

--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -8,7 +8,8 @@ import {
 } from "@okouai/api-contracts/contracts/chat-events";
 import { hasChatEventBodyContent } from "./chat-event-body-blocks.ts";
 import type { ChatEventGroup, EnrichedChatEvent } from "./chat-event.ts";
-import type { ChatEvent } from "./chat-event-types.ts";
+import { isGoalContinuationInput, type ChatEvent } from "./chat-event-types.ts";
+import { mergeChatEventUsagePayloads } from "./chat-event-usage.ts";
 import { isCancelledRunEvent } from "./chat-run-lifecycle.ts";
 
 const internalRunWorkExpandedKeys$ = state<Set<string>>(new Set());
@@ -201,6 +202,7 @@ function usageByRunIdFromGroups(
 function attachUsageToRunWorkGroups(
   groups: readonly ChatEventGroup[],
   usageByRunId: ReadonlyMap<string, ChatEventUsagePayload>,
+  usageByAnchorEventId: ReadonlyMap<string, ChatEventUsagePayload>,
   workAnchorEventIds: ReadonlySet<string>,
 ): ChatEventGroup[] {
   const lastAssistantGroupIndexByRunId = new Map<string, number>();
@@ -223,6 +225,16 @@ function attachUsageToRunWorkGroups(
     if (group.role !== "assistant") {
       return group;
     }
+    const anchorUsage = group.events
+      .map((event) => {
+        return usageByAnchorEventId.get(event.id);
+      })
+      .find((usage) => {
+        return usage !== undefined;
+      });
+    if (anchorUsage !== undefined) {
+      return { ...group, usage: anchorUsage };
+    }
     const runId = firstRunIdForEvents(group.events);
     if (
       runId === undefined ||
@@ -235,15 +247,166 @@ function attachUsageToRunWorkGroups(
   });
 }
 
+interface RunWorkEventSegment {
+  readonly runId: string | undefined;
+  runGroupId: string | undefined;
+  readonly events: EnrichedChatEvent[];
+}
+
+interface RunWorkUnit {
+  readonly key: string | undefined;
+  readonly runGroupId: string | undefined;
+  readonly events: readonly EnrichedChatEvent[];
+  readonly runIds: readonly string[];
+  readonly hiddenUserEventIds: ReadonlySet<string>;
+  readonly isGoal: boolean;
+}
+
+function runWorkEventSegments(
+  events: readonly EnrichedChatEvent[],
+): RunWorkEventSegment[] {
+  const segments: RunWorkEventSegment[] = [];
+  for (const event of events) {
+    const runId = event.runId;
+    const last = segments[segments.length - 1];
+    if (runId !== undefined && last?.runId === runId) {
+      last.events.push(event);
+      if (last.runGroupId === undefined) {
+        last.runGroupId = event.runGroupId;
+      }
+      continue;
+    }
+    segments.push({
+      runId,
+      runGroupId: event.runGroupId,
+      events: [event],
+    });
+  }
+  return segments;
+}
+
+function runGroupStreakEndIndex(
+  segments: readonly RunWorkEventSegment[],
+  startIndex: number,
+  runGroupId: string,
+): number {
+  let endIndex = startIndex + 1;
+  while (
+    endIndex < segments.length &&
+    segments[endIndex]?.runGroupId === runGroupId
+  ) {
+    endIndex++;
+  }
+  return endIndex;
+}
+
+function uniqueRunIds(segments: readonly RunWorkEventSegment[]): string[] {
+  return Array.from(
+    new Set(
+      segments.flatMap((segment) => {
+        return segment.runId === undefined ? [] : [segment.runId];
+      }),
+    ),
+  );
+}
+
+function standaloneRunWorkUnit(segment: RunWorkEventSegment): RunWorkUnit {
+  return {
+    key: segment.runId,
+    runGroupId: segment.runGroupId,
+    events: segment.events,
+    runIds: segment.runId === undefined ? [] : [segment.runId],
+    hiddenUserEventIds: new Set(),
+    isGoal: false,
+  };
+}
+
+function canAnchorGoalRun(unit: RunWorkUnit | undefined): boolean {
+  return unit !== undefined && !unit.isGoal && unit.runGroupId === undefined;
+}
+
+function runWorkUnits(events: readonly EnrichedChatEvent[]): RunWorkUnit[] {
+  const segments = runWorkEventSegments(events);
+  const units: RunWorkUnit[] = [];
+
+  for (let index = 0; index < segments.length; ) {
+    const segment = segments[index]!;
+    if (segment.runGroupId === undefined) {
+      units.push(standaloneRunWorkUnit(segment));
+      index++;
+      continue;
+    }
+
+    const endIndex = runGroupStreakEndIndex(
+      segments,
+      index,
+      segment.runGroupId,
+    );
+    const streak = segments.slice(index, endIndex);
+    const goalInputEvents = streak.flatMap((item) => {
+      return item.events.filter(isGoalContinuationInput);
+    });
+    if (goalInputEvents.length === 0) {
+      units.push(...streak.map(standaloneRunWorkUnit));
+      index = endIndex;
+      continue;
+    }
+
+    // Goal continuations are synthetic user turns. Attach their contiguous
+    // streak to the nearest preceding ungrouped run; an intervening run then
+    // naturally starts a new visual work section after an interruption.
+    const previousUnit = units[units.length - 1];
+    const anchorUnit = canAnchorGoalRun(previousUnit) ? units.pop() : undefined;
+    const hiddenUserEventIds = new Set(
+      goalInputEvents.map((event) => {
+        return event.id;
+      }),
+    );
+    // A render window can begin inside a goal streak. Keep one context row when
+    // its triggering run is outside the window instead of orphaning the work.
+    if (anchorUnit === undefined) {
+      hiddenUserEventIds.delete(goalInputEvents[0]!.id);
+    }
+    const goalRunIds = uniqueRunIds(streak);
+    units.push({
+      key: `goal:${segment.runGroupId}`,
+      runGroupId: segment.runGroupId,
+      events: [
+        ...(anchorUnit?.events ?? []),
+        ...streak.flatMap((item) => {
+          return item.events;
+        }),
+      ],
+      runIds: [...(anchorUnit?.runIds ?? []), ...goalRunIds],
+      hiddenUserEventIds,
+      isGoal: true,
+    });
+    index = endIndex;
+  }
+
+  return units;
+}
+
+function visibleRunWorkUserEvent(
+  event: EnrichedChatEvent,
+  hiddenUserEventIds: ReadonlySet<string>,
+): boolean {
+  return (
+    chatEventCompatibilityRole(event.eventType) === "user" &&
+    !hiddenUserEventIds.has(event.id)
+  );
+}
+
 function splitRunWorkEventsAtUsers(
   events: readonly EnrichedChatEvent[],
+  hiddenUserEventIds: ReadonlySet<string>,
 ): EnrichedChatEvent[][] {
   const phases: EnrichedChatEvent[][] = [];
   let phase: EnrichedChatEvent[] = [];
   for (const event of events) {
     if (
       phase.length > 0 &&
-      chatEventCompatibilityRole(event.eventType) === "user"
+      visibleRunWorkUserEvent(event, hiddenUserEventIds)
     ) {
       phases.push(phase);
       phase = [];
@@ -303,9 +466,10 @@ interface RunWorkPhaseFolding {
 }
 
 function foldRunWorkPhase(
-  runId: string,
+  key: string,
   events: readonly EnrichedChatEvent[],
   endTime: number | undefined,
+  hiddenUserEventIds: ReadonlySet<string>,
 ): RunWorkPhaseFolding {
   const latestAssistantEvent = lastEventMatching(
     events,
@@ -317,7 +481,12 @@ function foldRunWorkPhase(
   const anchorEvent = latestAssistantEvent ?? terminalEvent;
   const startTime = firstEventTime(events);
   if (anchorEvent === undefined || startTime === null) {
-    return { visibleEvents: events, section: null };
+    return {
+      visibleEvents: events.filter((event) => {
+        return !hiddenUserEventIds.has(event.id);
+      }),
+      section: null,
+    };
   }
 
   const anchorIndex = events.indexOf(anchorEvent);
@@ -325,13 +494,13 @@ function foldRunWorkPhase(
     return isRunWorkAssistantEvent(event);
   });
   const userEvents = events.filter((event) => {
-    return chatEventCompatibilityRole(event.eventType) === "user";
+    return visibleRunWorkUserEvent(event, hiddenUserEventIds);
   });
 
   return {
     visibleEvents: [...userEvents, anchorEvent],
     section: {
-      key: `${runId}:${events[0]!.id}`,
+      key: `${key}:${events[0]!.id}`,
       anchorEventId: anchorEvent.id,
       hiddenGroups: groupEventsByRole(hiddenEvents),
       startTime,
@@ -340,12 +509,52 @@ function foldRunWorkPhase(
   };
 }
 
-function terminalEventForRun(
+function latestRunIdForEvents(
+  events: readonly EnrichedChatEvent[],
+): string | undefined {
+  for (let index = events.length - 1; index >= 0; index--) {
+    const runId = events[index]?.runId;
+    if (runId !== undefined) {
+      return runId;
+    }
+  }
+  return undefined;
+}
+
+function terminalEventForLatestRun(
   events: readonly EnrichedChatEvent[],
 ): EnrichedChatEvent | undefined {
+  const latestRunId = latestRunIdForEvents(events);
+  if (latestRunId === undefined) {
+    return undefined;
+  }
   return lastEventMatching(events, (event) => {
-    return isChatRunTerminalEventType(event.eventType);
+    return (
+      event.runId === latestRunId && isChatRunTerminalEventType(event.eventType)
+    );
   });
+}
+
+function latestRunWasCancelled(events: readonly EnrichedChatEvent[]): boolean {
+  const latestRunId = latestRunIdForEvents(events);
+  return (
+    latestRunId !== undefined &&
+    events.some((event) => {
+      return event.runId === latestRunId && isCancelledRunEvent(event);
+    })
+  );
+}
+
+function mergedUsageForRunIds(
+  runIds: readonly string[],
+  usageByRunId: ReadonlyMap<string, ChatEventUsagePayload>,
+): ChatEventUsagePayload | undefined {
+  return mergeChatEventUsagePayloads(
+    runIds.flatMap((runId) => {
+      const usage = usageByRunId.get(runId);
+      return usage === undefined ? [] : [usage];
+    }),
+  );
 }
 
 function phaseEndTime(
@@ -371,42 +580,52 @@ export function buildRunWorkFolding(
   });
   const visibleEvents: EnrichedChatEvent[] = [];
   const sections: RunWorkSection[] = [];
+  const usageByAnchorEventId = new Map<string, ChatEventUsagePayload>();
 
-  for (let index = 0; index < events.length; ) {
-    const runId = events[index]!.runId;
-    if (runId === undefined) {
-      visibleEvents.push(events[index]!);
-      index++;
+  for (const unit of runWorkUnits(events)) {
+    if (unit.key === undefined) {
+      visibleEvents.push(
+        ...unit.events.filter((event) => {
+          return !unit.hiddenUserEventIds.has(event.id);
+        }),
+      );
       continue;
     }
 
-    let endIndex = index + 1;
-    while (endIndex < events.length && events[endIndex]!.runId === runId) {
-      endIndex++;
-    }
-
-    const runEvents = events.slice(index, endIndex);
-    if (runEvents.some(isCancelledRunEvent)) {
-      visibleEvents.push(...runEvents);
-      index = endIndex;
+    if (latestRunWasCancelled(unit.events)) {
+      visibleEvents.push(
+        ...unit.events.filter((event) => {
+          return !unit.hiddenUserEventIds.has(event.id);
+        }),
+      );
       continue;
     }
 
-    const terminalEvent = terminalEventForRun(runEvents);
-    const phases = splitRunWorkEventsAtUsers(runEvents);
+    const terminalEvent = terminalEventForLatestRun(unit.events);
+    const phases = splitRunWorkEventsAtUsers(
+      unit.events,
+      unit.hiddenUserEventIds,
+    );
+    const firstSectionIndex = sections.length;
     for (const [phaseIndex, phase] of phases.entries()) {
       const phaseFolding = foldRunWorkPhase(
-        runId,
+        unit.key,
         phase,
         phaseEndTime(phase, phaseIndex === phases.length - 1, terminalEvent),
+        unit.hiddenUserEventIds,
       );
       visibleEvents.push(...phaseFolding.visibleEvents);
       if (phaseFolding.section !== null) {
         sections.push(phaseFolding.section);
       }
     }
-
-    index = endIndex;
+    if (unit.isGoal && sections.length > firstSectionIndex) {
+      const mergedUsage = mergedUsageForRunIds(unit.runIds, usageByRunId);
+      const finalSection = sections[sections.length - 1];
+      if (mergedUsage !== undefined && finalSection !== undefined) {
+        usageByAnchorEventId.set(finalSection.anchorEventId, mergedUsage);
+      }
+    }
   }
 
   if (sections.length === 0) {
@@ -422,6 +641,7 @@ export function buildRunWorkFolding(
     visibleGroups: attachUsageToRunWorkGroups(
       groupEventsForRunWorkDisplay(visibleEvents, workAnchorEventIds),
       usageByRunId,
+      usageByAnchorEventId,
       workAnchorEventIds,
     ),
     sectionsByAnchorEventId: new Map(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
@@ -862,6 +862,42 @@ describe("chat conversation locator", () => {
     });
   });
 
+  it("indexes goal continuations inside their triggering run work", async () => {
+    const { rail, resize } = await renderMeasuredThread({
+      threadId: GOAL_THREAD_ID,
+      threadTitle: "Goal work locator turns",
+      chatEvents: goalConversation(),
+      renderedText: "Latest goal result in the locator",
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunWorkFolding]: true,
+      },
+    });
+
+    expect(screen.queryByText("First goal result in the locator")).toBeNull();
+    expect(ticksOf(rail)).toHaveLength(10);
+
+    fireEvent.click(screen.getByLabelText("Expand work history"));
+    await screen.findByText("First goal result in the locator");
+    resize.automationAll();
+    await waitFor(() => {
+      expect(ticksOf(rail)).toHaveLength(10);
+    });
+
+    pointerAt(rail, 0, "pointerenter");
+    const mergedAssistantTick = ticksOf(rail).find((tick) => {
+      return tick.dataset.turnIndex === "9";
+    });
+    expect(mergedAssistantTick).toBeDefined();
+    pointerAt(
+      rail,
+      Number.parseFloat(mergedAssistantTick!.style.top),
+      "pointermove",
+    );
+    await waitFor(() => {
+      expect(locatorPreview()).toHaveTextContent("Goal prefix answer 4");
+    });
+  });
+
   it.each([
     { name: "legacy folding", runWorkFoldingEnabled: false },
     { name: "run-work folding", runWorkFoldingEnabled: true },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-results.test.tsx
@@ -1649,7 +1649,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("keeps chat work visible when the run was cancelled", async () => {
+  it("folds a cancelled run around its last assistant output", async () => {
     mockChatLifecycle(context, {
       threadId: "e7000000-0000-4000-a000-000000000016",
       chatEvents: [
@@ -1664,6 +1664,18 @@ describe("chat lifecycle", () => {
           content: "Checking launch status.",
           runId: "run-work-folding-cancelled",
           createdAt: "2026-06-09T10:00:25Z",
+        },
+        {
+          role: "assistant",
+          content: "The latest launch status is ready.",
+          runId: "run-work-folding-cancelled",
+          createdAt: "2026-06-09T10:00:45Z",
+        },
+        {
+          role: "user",
+          content: null,
+          interruptsRunId: "run-work-folding-cancelled",
+          createdAt: "2026-06-09T10:00:50Z",
         },
         {
           role: "assistant",
@@ -1682,12 +1694,29 @@ describe("chat lifecycle", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Checking launch status.")).toBeInTheDocument();
+      expect(
+        screen.getByText("The latest launch status is ready."),
+      ).toBeInTheDocument();
       expect(
         screen.getByText("Paused mid-thought — pick it back up whenever."),
       ).toBeInTheDocument();
     });
-    expect(screen.queryByLabelText("Expand work history")).toBeNull();
+    expect(
+      screen.queryByText("Checking launch status."),
+    ).not.toBeInTheDocument();
+    const expandWork = screen.getByLabelText("Expand work history");
+    expect(expandWork).toHaveTextContent(/^Worked for /);
+    expectTextBefore(
+      document.body,
+      "The latest launch status is ready.",
+      "Paused mid-thought — pick it back up whenever.",
+    );
+
+    fireEvent.click(expandWork);
+
+    await expect(
+      screen.findByText("Checking launch status."),
+    ).resolves.toBeInTheDocument();
   });
 
   it("shows only Worked when a completed run has no assistant message", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-results.test.tsx
@@ -1711,6 +1711,17 @@ describe("chat lifecycle", () => {
       "The latest launch status is ready.",
       "Paused mid-thought — pick it back up whenever.",
     );
+    const finalOutputGroup = screen
+      .getByText("The latest launch status is ready.")
+      .closest<HTMLElement>('[data-role="assistant"]');
+    const cancellationGroup = screen
+      .getByText("Paused mid-thought — pick it back up whenever.")
+      .closest<HTMLElement>('[data-role="assistant"]');
+    expect(finalOutputGroup).not.toBeNull();
+    expect(cancellationGroup).toBe(finalOutputGroup);
+    expect(
+      within(finalOutputGroup!).getAllByLabelText("View agent profile"),
+    ).toHaveLength(1);
 
     fireEvent.click(expandWork);
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -1153,6 +1153,13 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           id: "msg-goal-work-trigger-user",
           role: "user",
           content: "Resume the release goal",
+          userMessage: {
+            version: 1,
+            parts: [
+              { type: "text", text: "Resume the release goal" },
+              { type: "model", selectedModel: "gpt-5.5" },
+            ],
+          },
           runId: "f0000001-0000-4000-a000-000000000b2c",
           createdAt: "2026-09-03T10:00:00Z",
         },
@@ -1170,7 +1177,10 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: goalPrompt,
           userMessage: {
             version: 1,
-            parts: [{ type: "goal", goalBrief }],
+            parts: [
+              { type: "goal", goalBrief },
+              { type: "model", selectedModel: "claude-sonnet-4-6" },
+            ],
           },
           runId: "f0000001-0000-4000-a000-000000000b2d",
           runGroupId,
@@ -1191,7 +1201,10 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: goalPrompt,
           userMessage: {
             version: 1,
-            parts: [{ type: "goal", goalBrief }],
+            parts: [
+              { type: "goal", goalBrief },
+              { type: "model", selectedModel: "claude-sonnet-4-6" },
+            ],
           },
           runId: "f0000001-0000-4000-a000-000000000b2e",
           runGroupId,
@@ -1232,6 +1245,9 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     expect(
       screen.queryByText("Checked the first release blocker."),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Model changed to Claude Sonnet 4.6"),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(expandWork);
 
@@ -1242,7 +1258,20 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       expect(
         screen.getByText("Checked the first release blocker."),
       ).toBeInTheDocument();
+      expect(
+        screen.getByText("Model changed to Claude Sonnet 4.6"),
+      ).toBeInTheDocument();
     });
+    expectTextBefore(
+      document.body,
+      "The goal is running again.",
+      "Model changed to Claude Sonnet 4.6",
+    );
+    expectTextBefore(
+      document.body,
+      "Model changed to Claude Sonnet 4.6",
+      "Checked the first release blocker.",
+    );
     expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();
     expect(
       screen.queryByLabelText("Expand grouped run history"),
@@ -1464,6 +1493,13 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           id: "msg-cancelled-goal-work-trigger-user",
           role: "user",
           content: "Start checking the release",
+          userMessage: {
+            version: 1,
+            parts: [
+              { type: "text", text: "Start checking the release" },
+              { type: "model", selectedModel: "gpt-5.5" },
+            ],
+          },
           runId: "f0000001-0000-4000-a000-000000000e2c",
           createdAt: "2026-09-03T10:00:00Z",
         },
@@ -1481,7 +1517,10 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: goalBrief,
           userMessage: {
             version: 1,
-            parts: [{ type: "goal", goalBrief }],
+            parts: [
+              { type: "goal", goalBrief },
+              { type: "model", selectedModel: "gpt-5.5" },
+            ],
           },
           runId: "f0000001-0000-4000-a000-000000000e2d",
           runGroupId,
@@ -1502,7 +1541,10 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
           content: goalBrief,
           userMessage: {
             version: 1,
-            parts: [{ type: "goal", goalBrief }],
+            parts: [
+              { type: "goal", goalBrief },
+              { type: "model", selectedModel: "claude-sonnet-4-6" },
+            ],
           },
           runId: "f0000001-0000-4000-a000-000000000e2e",
           runGroupId,
@@ -1544,6 +1586,19 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       "The first release check passed.",
       "Paused mid-thought — pick it back up whenever.",
     );
+    expect(
+      screen.queryByText("Model changed to Claude Sonnet 4.6"),
+    ).not.toBeInTheDocument();
+    const finalOutputGroup = screen
+      .getByText("The first release check passed.")
+      .closest<HTMLElement>('[data-role="assistant"]');
+    const cancellationGroup = screen
+      .getByText("Paused mid-thought — pick it back up whenever.")
+      .closest<HTMLElement>('[data-role="assistant"]');
+    expect(cancellationGroup).toBe(finalOutputGroup);
+    expect(
+      within(finalOutputGroup!).getAllByLabelText("View agent profile"),
+    ).toHaveLength(1);
     expect(screen.queryByLabelText("Goal")).not.toBeInTheDocument();
     expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();
     expect(
@@ -1556,7 +1611,20 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       expect(
         screen.getByText("The release check has started."),
       ).toBeInTheDocument();
+      expect(
+        screen.getByText("Model changed to Claude Sonnet 4.6"),
+      ).toBeInTheDocument();
     });
+    expectTextBefore(
+      document.body,
+      "The first release check passed.",
+      "Model changed to Claude Sonnet 4.6",
+    );
+    expectTextBefore(
+      document.body,
+      "Model changed to Claude Sonnet 4.6",
+      "Paused mid-thought — pick it back up whenever.",
+    );
     expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -1537,8 +1537,13 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       screen.queryByText("The release check has started."),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText("The first release check passed."),
-    ).not.toBeInTheDocument();
+      screen.getByText("The first release check passed."),
+    ).toBeInTheDocument();
+    expectTextBefore(
+      document.body,
+      "The first release check passed.",
+      "Paused mid-thought — pick it back up whenever.",
+    );
     expect(screen.queryByLabelText("Goal")).not.toBeInTheDocument();
     expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();
     expect(
@@ -1550,9 +1555,6 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     await waitFor(() => {
       expect(
         screen.getByText("The release check has started."),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("The first release check passed."),
       ).toBeInTheDocument();
     });
     expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { chatThreadArtifactsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import {
+  FeatureSwitchKey,
   ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_PICKER_ITEMS,
   VIDEO_TEMPLATE_ITEMS,
@@ -1136,6 +1137,318 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
       expect(screen.queryByText(goalPrompt)).not.toBeInTheDocument();
       expect(screen.getAllByText("Worked for 30s").length).toBeGreaterThan(0);
     });
+  });
+
+  it("folds goal continuations into their triggering run work", async () => {
+    const threadId = "e9000000-0000-4000-a000-000000000023";
+    const runGroupId = "f0000001-0000-4000-a000-000000000b2b";
+    const goalBrief = "Keep the release moving";
+    const goalPrompt = `${goalBrief}\n\nFull autonomous goal prompt`;
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Goal run work folding",
+      chatEvents: [
+        {
+          id: "msg-goal-work-trigger-user",
+          role: "user",
+          content: "Resume the release goal",
+          runId: "f0000001-0000-4000-a000-000000000b2c",
+          createdAt: "2026-09-03T10:00:00Z",
+        },
+        {
+          id: "msg-goal-work-trigger-assistant",
+          role: "assistant",
+          content: "The goal is running again.",
+          runId: "f0000001-0000-4000-a000-000000000b2c",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-09-03T10:00:10Z",
+        },
+        {
+          id: "msg-goal-work-user-1",
+          role: "user",
+          content: goalPrompt,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "goal", goalBrief }],
+          },
+          runId: "f0000001-0000-4000-a000-000000000b2d",
+          runGroupId,
+          createdAt: "2026-09-03T10:01:00Z",
+        },
+        {
+          id: "msg-goal-work-assistant-1",
+          role: "assistant",
+          content: "Checked the first release blocker.",
+          runId: "f0000001-0000-4000-a000-000000000b2d",
+          runGroupId,
+          runLifecycleEvent: "completed",
+          createdAt: "2026-09-03T10:01:30Z",
+        },
+        {
+          id: "msg-goal-work-user-2",
+          role: "user",
+          content: goalPrompt,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "goal", goalBrief }],
+          },
+          runId: "f0000001-0000-4000-a000-000000000b2e",
+          runGroupId,
+          createdAt: "2026-09-03T10:02:00Z",
+        },
+        {
+          id: "msg-goal-work-assistant-final",
+          role: "assistant",
+          content: "The release is ready.",
+          runId: "f0000001-0000-4000-a000-000000000b2e",
+          runGroupId,
+          runLifecycleEvent: "completed",
+          createdAt: "2026-09-03T10:03:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunWorkFolding]: true,
+      },
+    });
+
+    const expandWork = await screen.findByLabelText("Expand work history");
+    expect(expandWork).toHaveTextContent("Worked for 3m");
+    expect(screen.getByText("Resume the release goal")).toBeInTheDocument();
+    expect(screen.getByText("The release is ready.")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Goal")).not.toBeInTheDocument();
+    expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Expand grouped run history"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("The goal is running again."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Checked the first release blocker."),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(expandWork);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("The goal is running again."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Checked the first release blocker."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Expand grouped run history"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("starts a separate goal work fold after a new trigger", async () => {
+    const threadId = "e9000000-0000-4000-a000-000000000024";
+    const runGroupId = "f0000001-0000-4000-a000-000000000c2b";
+    const goalBrief = "Finish the release goal";
+    const goalPrompt = `${goalBrief}\n\nFull autonomous goal prompt`;
+
+    const segments = [
+      {
+        triggerId: "msg-goal-segment-start-user",
+        triggerText: "Start the release goal",
+        triggerResponse: "The release goal has started.",
+        triggerRunId: "f0000001-0000-4000-a000-000000000c2c",
+        goalInputId: "msg-goal-segment-start-input",
+        goalResponse: "The first goal segment finished.",
+        goalRunId: "f0000001-0000-4000-a000-000000000c2d",
+        startTime: "2026-09-03T10:00:00Z",
+        endTime: "2026-09-03T10:01:00Z",
+      },
+      {
+        triggerId: "msg-goal-segment-resume-user",
+        triggerText: "Resume the release goal",
+        triggerResponse: "The release goal has resumed.",
+        triggerRunId: "f0000001-0000-4000-a000-000000000c2e",
+        goalInputId: "msg-goal-segment-resume-input",
+        goalResponse: "The resumed goal segment finished.",
+        goalRunId: "f0000001-0000-4000-a000-000000000c2f",
+        startTime: "2026-09-03T10:10:00Z",
+        endTime: "2026-09-03T10:11:00Z",
+      },
+    ];
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Interrupted goal run work folding",
+      chatEvents: segments.flatMap((segment) => {
+        return [
+          {
+            id: segment.triggerId,
+            role: "user" as const,
+            content: segment.triggerText,
+            runId: segment.triggerRunId,
+            createdAt: segment.startTime,
+          },
+          {
+            id: `${segment.triggerId}-assistant`,
+            role: "assistant" as const,
+            content: segment.triggerResponse,
+            runId: segment.triggerRunId,
+            runLifecycleEvent: "completed" as const,
+            createdAt: segment.startTime,
+          },
+          {
+            id: segment.goalInputId,
+            role: "user" as const,
+            content: goalPrompt,
+            userMessage: {
+              version: 1 as const,
+              parts: [{ type: "goal" as const, goalBrief }],
+            },
+            runId: segment.goalRunId,
+            runGroupId,
+            createdAt: segment.endTime,
+          },
+          {
+            id: `${segment.goalInputId}-assistant`,
+            role: "assistant" as const,
+            content: segment.goalResponse,
+            runId: segment.goalRunId,
+            runGroupId,
+            runLifecycleEvent: "completed" as const,
+            createdAt: segment.endTime,
+          },
+        ];
+      }),
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunWorkFolding]: true,
+      },
+    });
+
+    await screen.findByText("The resumed goal segment finished.");
+    expect(screen.getByText("Start the release goal")).toBeInTheDocument();
+    expect(screen.getByText("Resume the release goal")).toBeInTheDocument();
+    expect(
+      screen.getByText("The first goal segment finished."),
+    ).toBeInTheDocument();
+    expect(screen.getAllByLabelText("Expand work history")).toHaveLength(2);
+    expect(
+      screen.queryByText("The release goal has started."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("The release goal has resumed."),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByLabelText("Expand work history")[1]!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("The release goal has resumed."),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("The release goal has started."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps merged goal work active while the latest continuation is running", async () => {
+    const threadId = "e9000000-0000-4000-a000-000000000025";
+    const runGroupId = "f0000001-0000-4000-a000-000000000d2b";
+    const goalBrief = "Keep checking the release";
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Active goal run work folding",
+      chatEvents: [
+        {
+          id: "msg-active-goal-work-trigger-user",
+          role: "user",
+          content: "Start checking the release",
+          runId: "f0000001-0000-4000-a000-000000000d2c",
+          createdAt: "2026-09-03T10:00:00Z",
+        },
+        {
+          id: "msg-active-goal-work-trigger-assistant",
+          role: "assistant",
+          content: "The release check has started.",
+          runId: "f0000001-0000-4000-a000-000000000d2c",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-09-03T10:00:10Z",
+        },
+        {
+          id: "msg-active-goal-work-user-1",
+          role: "user",
+          content: goalBrief,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "goal", goalBrief }],
+          },
+          runId: "f0000001-0000-4000-a000-000000000d2d",
+          runGroupId,
+          createdAt: "2026-09-03T10:01:00Z",
+        },
+        {
+          id: "msg-active-goal-work-assistant-1",
+          role: "assistant",
+          content: "The first release check passed.",
+          runId: "f0000001-0000-4000-a000-000000000d2d",
+          runGroupId,
+          runLifecycleEvent: "completed",
+          createdAt: "2026-09-03T10:01:30Z",
+        },
+        {
+          id: "msg-active-goal-work-user-2",
+          role: "user",
+          content: goalBrief,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "goal", goalBrief }],
+          },
+          runId: "f0000001-0000-4000-a000-000000000d2e",
+          runGroupId,
+          createdAt: "2026-09-03T10:02:00Z",
+        },
+        {
+          id: "msg-active-goal-work-thinking-2",
+          eventType: "output.thinking",
+          role: "assistant",
+          content: null,
+          thinking: "Checking the next release gate",
+          runId: "f0000001-0000-4000-a000-000000000d2e",
+          runGroupId,
+          createdAt: "2026-09-03T10:02:01Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunWorkFolding]: true,
+      },
+    });
+
+    const expandWork = await screen.findByLabelText("Expand work history");
+    expect(expandWork).toHaveTextContent(/^Working for /);
+    expect(screen.getByText("Start checking the release")).toBeInTheDocument();
+    expect(
+      screen.getByText("The first release check passed."),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Goal")).not.toBeInTheDocument();
+    expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Expand grouped run history"),
+    ).not.toBeInTheDocument();
+    expect(document.querySelector("[data-thinking-indicator]")).not.toBeNull();
   });
 
   it("expands archived goal history for an event hash", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-workflows-and-goals.test.tsx
@@ -1451,6 +1451,113 @@ Full autonomous goal prompt that should stay out of the compact chat UI`;
     expect(document.querySelector("[data-thinking-indicator]")).not.toBeNull();
   });
 
+  it("keeps cancelled goal continuations folded with their triggering run", async () => {
+    const threadId = "e9000000-0000-4000-a000-000000000026";
+    const runGroupId = "f0000001-0000-4000-a000-000000000e2b";
+    const goalBrief = "Keep checking the release";
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Cancelled goal run work folding",
+      chatEvents: [
+        {
+          id: "msg-cancelled-goal-work-trigger-user",
+          role: "user",
+          content: "Start checking the release",
+          runId: "f0000001-0000-4000-a000-000000000e2c",
+          createdAt: "2026-09-03T10:00:00Z",
+        },
+        {
+          id: "msg-cancelled-goal-work-trigger-assistant",
+          role: "assistant",
+          content: "The release check has started.",
+          runId: "f0000001-0000-4000-a000-000000000e2c",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-09-03T10:00:10Z",
+        },
+        {
+          id: "msg-cancelled-goal-work-user-1",
+          role: "user",
+          content: goalBrief,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "goal", goalBrief }],
+          },
+          runId: "f0000001-0000-4000-a000-000000000e2d",
+          runGroupId,
+          createdAt: "2026-09-03T10:01:00Z",
+        },
+        {
+          id: "msg-cancelled-goal-work-assistant-1",
+          role: "assistant",
+          content: "The first release check passed.",
+          runId: "f0000001-0000-4000-a000-000000000e2d",
+          runGroupId,
+          runLifecycleEvent: "completed",
+          createdAt: "2026-09-03T10:01:30Z",
+        },
+        {
+          id: "msg-cancelled-goal-work-user-2",
+          role: "user",
+          content: goalBrief,
+          userMessage: {
+            version: 1,
+            parts: [{ type: "goal", goalBrief }],
+          },
+          runId: "f0000001-0000-4000-a000-000000000e2e",
+          runGroupId,
+          createdAt: "2026-09-03T10:02:00Z",
+        },
+        {
+          id: "msg-cancelled-goal-work-assistant-2",
+          role: "assistant",
+          content: "Run cancelled",
+          error: "Run cancelled",
+          runId: "f0000001-0000-4000-a000-000000000e2e",
+          runGroupId,
+          runLifecycleEvent: "cancelled",
+          createdAt: "2026-09-03T10:02:30Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunWorkFolding]: true,
+      },
+    });
+
+    await screen.findByText("Paused mid-thought — pick it back up whenever.");
+    const expandWork = screen.getByLabelText("Expand work history");
+    expect(expandWork).toHaveTextContent(/^Worked for /);
+    expect(screen.getByText("Start checking the release")).toBeInTheDocument();
+    expect(
+      screen.queryByText("The release check has started."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("The first release check passed."),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Goal")).not.toBeInTheDocument();
+    expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Expand grouped run history"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(expandWork);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("The release check has started."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("The first release check passed."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText(goalBrief)).not.toBeInTheDocument();
+  });
+
   it("expands archived goal history for an event hash", async () => {
     const threadId = "e9000000-0000-4000-a000-000000000016";
     const runGroupId = "f0000001-0000-4000-a000-00000000092b";

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3094,7 +3094,7 @@ function ChatThreadRenderedEventGroups({
     );
   const toggleCompletedWorkExpanded = useSet(toggleCompletedWorkExpanded$);
   const runWorkFolding = runWorkFoldingEnabled
-    ? buildRunWorkFolding(runGroupVisibleGroups)
+    ? buildRunWorkFolding(runGroupVisibleGroups, new Set(modelChanges.keys()))
     : null;
   const runWorkExpandedKeys = useGet(runWorkExpandedKeys$);
   const effectiveRunWorkExpandedKeys = runWorkExpandedKeysForScrollTarget(
@@ -3409,9 +3409,12 @@ function ChatThreadEventGroups({
               runWorkSection={
                 runWorkSection !== null
                   ? {
+                      anchorEventId: runWorkSection.anchorEventId,
                       startTime: runWorkSection.startTime,
                       endTime: runWorkSection.endTime,
                       hiddenGroups: runWorkSection.hiddenGroups,
+                      hiddenGroupsAfterAnchor:
+                        runWorkSection.hiddenGroupsAfterAnchor,
                       expanded: runWorkExpanded,
                       onToggle: () => {
                         onToggleRunWork(runWorkSection.key);
@@ -3712,22 +3715,37 @@ function RunSectionDividerRow({
 
 function ModelChangeDividerRow({ change }: { change: RunModelChange }) {
   const { t } = useTranslation();
-  const label =
-    change.kind === "model"
-      ? t(
-          ($) => {
-            return $.chat.run.modelChangedTo;
-          },
-          { model: runModelDisplayName(t, change.selection) },
-        )
-      : change.enabled
-        ? t(($) => {
-            return $.chat.run.fastModeOn;
-          })
-        : t(($) => {
-            return $.chat.run.fastModeOff;
-          });
-  return <RunSectionDividerRow label={label} />;
+  return <RunSectionDividerRow label={modelChangeLabel(t, change)} />;
+}
+
+function modelChangeLabel(
+  t: TFunction<"common">,
+  change: RunModelChange,
+): string {
+  return change.kind === "model"
+    ? t(
+        ($) => {
+          return $.chat.run.modelChangedTo;
+        },
+        { model: runModelDisplayName(t, change.selection) },
+      )
+    : change.enabled
+      ? t(($) => {
+          return $.chat.run.fastModeOn;
+        })
+      : t(($) => {
+          return $.chat.run.fastModeOff;
+        });
+}
+
+function FoldedModelChangeDivider({ change }: { change: RunModelChange }) {
+  const { t } = useTranslation();
+  return (
+    <RunSectionDivider
+      label={modelChangeLabel(t, change)}
+      labelPosition="right"
+    />
+  );
 }
 
 function CompletedWorkFoldRow({
@@ -5853,19 +5871,8 @@ function PagedGroupRow({
   modelChanges: ReadonlyMap<string, RunModelChange>;
   stackFirstOnPrevious?: boolean;
   runGroupFolds?: readonly RunGroupFoldControl[];
-  completedWorkFold?: {
-    groups: readonly ChatEventGroup[];
-    hiddenGroups: readonly ChatEventGroup[];
-    expanded: boolean;
-    onToggle: () => void;
-  };
-  runWorkSection?: {
-    startTime: number;
-    endTime: number | undefined;
-    hiddenGroups: readonly ChatEventGroup[];
-    expanded: boolean;
-    onToggle: () => void;
-  };
+  completedWorkFold?: CompletedWorkFoldControl;
+  runWorkSection?: RunWorkSectionControl;
 }) {
   if (group.role === "user") {
     return (
@@ -5882,6 +5889,7 @@ function PagedGroupRow({
     <PagedAssistantGroup
       group={group}
       thread={thread}
+      modelChanges={modelChanges}
       runGroupFolds={runGroupFolds}
       completedWorkFold={completedWorkFold}
       runWorkSection={runWorkSection}
@@ -7376,36 +7384,188 @@ function PagedUserMessage({
   );
 }
 
+type CompletedWorkFoldControl = {
+  readonly groups: readonly ChatEventGroup[];
+  readonly hiddenGroups: readonly ChatEventGroup[];
+  readonly expanded: boolean;
+  readonly onToggle: () => void;
+};
+
+type RunWorkSectionControl = Omit<RunWorkSection, "key"> & {
+  readonly expanded: boolean;
+  readonly onToggle: () => void;
+};
+
+type PagedAssistantGroupProps = {
+  readonly group: ChatEventGroup;
+  readonly thread: ChatPanelSignals;
+  readonly modelChanges: ReadonlyMap<string, RunModelChange>;
+  readonly runGroupFolds?: readonly RunGroupFoldControl[];
+  readonly completedWorkFold?: CompletedWorkFoldControl;
+  readonly runWorkSection?: RunWorkSectionControl;
+};
+
+type PagedAssistantTimelineItem =
+  | {
+      readonly kind: "assistant";
+      readonly event: EnrichedChatEvent;
+    }
+  | {
+      readonly kind: "model-change";
+      readonly eventId: string;
+      readonly change: RunModelChange;
+    }
+  | {
+      readonly kind: "completed-work";
+      readonly control: CompletedWorkFoldControl;
+    }
+  | {
+      readonly kind: "run-work";
+      readonly control: RunWorkSectionControl;
+    };
+
+function assistantTimelineItems(
+  events: readonly EnrichedChatEvent[],
+): PagedAssistantTimelineItem[] {
+  return events.filter(isRenderableAssistantEvent).map((event) => {
+    return { kind: "assistant", event };
+  });
+}
+
+function foldedRunWorkTimelineItems(
+  groups: readonly ChatEventGroup[],
+  modelChanges: ReadonlyMap<string, RunModelChange>,
+): PagedAssistantTimelineItem[] {
+  return groups.flatMap((group) => {
+    return group.events.flatMap((event): PagedAssistantTimelineItem[] => {
+      const change = modelChanges.get(event.id);
+      if (change !== undefined) {
+        return [{ kind: "model-change", eventId: event.id, change }];
+      }
+      return isRenderableAssistantEvent(event)
+        ? [{ kind: "assistant", event }]
+        : [];
+    });
+  });
+}
+
+function buildPagedAssistantTimeline({
+  group,
+  modelChanges,
+  completedWorkFold,
+  runWorkSection,
+}: Pick<
+  PagedAssistantGroupProps,
+  "group" | "modelChanges" | "completedWorkFold" | "runWorkSection"
+>): PagedAssistantTimelineItem[] {
+  const items: PagedAssistantTimelineItem[] = [];
+  if (completedWorkFold !== undefined) {
+    items.push({ kind: "completed-work", control: completedWorkFold });
+    if (completedWorkFold.expanded) {
+      items.push(
+        ...completedWorkFold.hiddenGroups.flatMap((hiddenGroup) => {
+          return assistantTimelineItems(hiddenGroup.events);
+        }),
+      );
+    }
+  }
+  if (runWorkSection === undefined) {
+    items.push(...assistantTimelineItems(group.events));
+    return items;
+  }
+
+  items.push({ kind: "run-work", control: runWorkSection });
+  const anchorIndex = group.events.findIndex((event) => {
+    return event.id === runWorkSection.anchorEventId;
+  });
+  const anchorEndIndex =
+    anchorIndex === -1 ? group.events.length : anchorIndex + 1;
+  if (runWorkSection.expanded) {
+    items.push(
+      ...foldedRunWorkTimelineItems(runWorkSection.hiddenGroups, modelChanges),
+    );
+  }
+  items.push(...assistantTimelineItems(group.events.slice(0, anchorEndIndex)));
+  if (runWorkSection.expanded) {
+    items.push(
+      ...foldedRunWorkTimelineItems(
+        runWorkSection.hiddenGroupsAfterAnchor,
+        modelChanges,
+      ),
+    );
+  }
+  items.push(...assistantTimelineItems(group.events.slice(anchorEndIndex)));
+  return items;
+}
+
+function PagedAssistantTimeline({
+  items,
+  thread,
+}: {
+  items: readonly PagedAssistantTimelineItem[];
+  thread: ChatPanelSignals;
+}) {
+  let renderedAssistantItemCount = 0;
+  return items.map((item) => {
+    if (item.kind === "model-change") {
+      return (
+        <FoldedModelChangeDivider key={item.eventId} change={item.change} />
+      );
+    }
+    if (item.kind === "completed-work") {
+      return (
+        <CompletedWorkFoldRow
+          key="completed-work:control"
+          groups={item.control.groups}
+          expanded={item.control.expanded}
+          onToggle={item.control.onToggle}
+        />
+      );
+    }
+    if (item.kind === "run-work") {
+      const collapsible =
+        item.control.hiddenGroups.length > 0 ||
+        item.control.hiddenGroupsAfterAnchor.length > 0;
+      return (
+        <RunWorkSectionRow
+          key={`run-work:control:${item.control.anchorEventId}`}
+          startTime={item.control.startTime}
+          endTime={item.control.endTime}
+          collapsible={collapsible}
+          expanded={item.control.expanded}
+          onToggle={item.control.onToggle}
+        />
+      );
+    }
+    const compactTop = renderedAssistantItemCount > 0;
+    renderedAssistantItemCount += 1;
+    return (
+      <PagedAssistantEventItem
+        key={item.event.id}
+        event={item.event}
+        compactTop={compactTop}
+        thread={thread}
+      />
+    );
+  });
+}
+
 function PagedAssistantGroup({
   group,
   thread,
+  modelChanges,
   runGroupFolds,
   completedWorkFold,
   runWorkSection,
-}: {
-  group: ChatEventGroup;
-  thread: ChatPanelSignals;
-  runGroupFolds?: readonly RunGroupFoldControl[];
-  completedWorkFold?: {
-    groups: readonly ChatEventGroup[];
-    hiddenGroups: readonly ChatEventGroup[];
-    expanded: boolean;
-    onToggle: () => void;
-  };
-  runWorkSection?: {
-    startTime: number;
-    endTime: number | undefined;
-    hiddenGroups: readonly ChatEventGroup[];
-    expanded: boolean;
-    onToggle: () => void;
-  };
-}) {
+}: PagedAssistantGroupProps) {
   const hasRenderableEvent = group.events.some((event) => {
     return isRenderableAssistantEvent(event);
   });
   const hasRunGroupFolds = (runGroupFolds?.length ?? 0) > 0;
-  const showCompletedWorkFold = completedWorkFold && !hasRunGroupFolds;
-  const showRunWorkSection = runWorkSection && !hasRunGroupFolds;
+  const visibleCompletedWorkFold = hasRunGroupFolds
+    ? undefined
+    : completedWorkFold;
+  const visibleRunWorkSection = hasRunGroupFolds ? undefined : runWorkSection;
   if (
     !hasRenderableEvent &&
     !completedWorkFold &&
@@ -7423,21 +7583,12 @@ function PagedAssistantGroup({
     })
     .filter(Boolean)
     .join("\n\n");
-  let renderedAssistantItemCount = 0;
-  const renderAssistantTimeline = (events: readonly EnrichedChatEvent[]) => {
-    return events.filter(isRenderableAssistantEvent).map((event) => {
-      const compactTop = renderedAssistantItemCount > 0;
-      renderedAssistantItemCount += 1;
-      return (
-        <PagedAssistantEventItem
-          key={event.id}
-          event={event}
-          compactTop={compactTop}
-          thread={thread}
-        />
-      );
-    });
-  };
+  const timelineItems = buildPagedAssistantTimeline({
+    group,
+    modelChanges,
+    completedWorkFold: visibleCompletedWorkFold,
+    runWorkSection: visibleRunWorkSection,
+  });
 
   return (
     <div
@@ -7455,41 +7606,7 @@ function PagedAssistantGroup({
               <RunGroupFoldRow key={fold.fold.key} control={fold} embedded />
             );
           })}
-          {showCompletedWorkFold && (
-            <CompletedWorkFoldRow
-              groups={completedWorkFold.groups}
-              expanded={completedWorkFold.expanded}
-              onToggle={completedWorkFold.onToggle}
-            />
-          )}
-          {showCompletedWorkFold && completedWorkFold.expanded
-            ? completedWorkFold.hiddenGroups.map((hiddenGroup) => {
-                return (
-                  <div key={hiddenGroup.beginEventId} className="contents">
-                    {renderAssistantTimeline(hiddenGroup.events)}
-                  </div>
-                );
-              })
-            : null}
-          {showRunWorkSection && (
-            <RunWorkSectionRow
-              startTime={runWorkSection.startTime}
-              endTime={runWorkSection.endTime}
-              collapsible={runWorkSection.hiddenGroups.length > 0}
-              expanded={runWorkSection.expanded}
-              onToggle={runWorkSection.onToggle}
-            />
-          )}
-          {showRunWorkSection && runWorkSection.expanded
-            ? runWorkSection.hiddenGroups.map((hiddenGroup) => {
-                return (
-                  <div key={hiddenGroup.beginEventId} className="contents">
-                    {renderAssistantTimeline(hiddenGroup.events)}
-                  </div>
-                );
-              })
-            : null}
-          {renderAssistantTimeline(group.events)}
+          <PagedAssistantTimeline items={timelineItems} thread={thread} />
         </div>
       </div>
       <PagedGroupActions group={group} content={fullContent} thread={thread} />

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3070,17 +3070,18 @@ function ChatThreadRenderedEventGroups({
   const modelChanges = modelChangesByEventId(renderedActiveGroups);
   const scrollTargetEventId =
     useGet(thread.threadScrollPosition$)?.targetEventId ?? null;
+  const runWorkFoldingEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
   const runGroupExpansionOverrides = useGet(runGroupExpansionOverrides$);
   const toggleRunGroupExpanded = useSet(toggleRunGroupExpanded$);
   const runGroupFolding = buildRunGroupFolding(
     renderedActiveGroups,
     runGroupExpansionOverrides,
     scrollTargetEventId,
+    { preserveGoalRunsForWorkFolding: runWorkFoldingEnabled },
   );
   const runGroupVisibleGroups =
     runGroupFolding?.visibleGroups ?? renderedActiveGroups;
-  const runWorkFoldingEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
   const completedWorkFolding = runWorkFoldingEnabled
     ? null
     : buildCompletedWorkFolding(runGroupVisibleGroups);


### PR DESCRIPTION
## Summary

- Under ChatRunWorkFolding, merge each contiguous Goal continuation streak into its nearest preceding ungrouped trigger run. A new trigger after an interruption starts a separate work section.
- Hide synthetic Goal continuation inputs and intermediate model or Fast mode changes in the collapsed transcript. Expanding Work history restores model changes at their original chronological positions without exposing Goal prompts.
- Treat control.interrupt and run.cancelled as run status rather than assistant output. Keep the last assistant output visible, fold earlier output into Work history, and render cancellation after that output inside the same assistant group with one agent avatar.
- Preserve real run IDs, aggregated usage, conversation-locator behavior, and the existing switch-off Goal run-group UI.

## Testing

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped (14/14 tasks passed)
- pnpm knip
- staged workspace, App, and API type checks from commit-check
- chat-run-results.test.tsx (46/46 passed), including the real control.interrupt to run.cancelled sequence and a one-avatar group assertion
- chat-workflows-and-goals.test.tsx (37/37 passed), including model changes before and after the retained output in cancelled Goal continuations
- The avatar grouping and expanded model-change expectations failed before the implementation changes and passed afterward