### PR TITLE
test(runtime): remove retired credential env tombstones

### DIFF
--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -107,11 +107,6 @@ ruby -e '
     "OKOU_DESKTOP_NOTARIZE_API_KEY_ID" => dollar + "{{ secrets.APP_STORE_CONNECT_API_KEY_ID }}",
     "OKOU_DESKTOP_NOTARIZE_API_ISSUER" => dollar + "{{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}",
   }
-  legacy_credentials = [
-    "VM0_DESKTOP_NOTARIZE_API_KEY_PATH",
-    "VM0_DESKTOP_NOTARIZE_API_KEY_ID",
-    "VM0_DESKTOP_NOTARIZE_API_ISSUER",
-  ]
   credential_steps = promote.fetch("steps").select do |step|
     environment = step.fetch("env", {})
     canonical_credentials.keys.any? { |name| environment.key?(name) }
@@ -124,7 +119,6 @@ ruby -e '
     release_text.scan(name).length == 2
   end
   raise "Desktop release workflow must use each canonical API credential alias exactly twice" unless canonical_occurrences_are_exact
-  raise "Desktop release workflow must not use legacy API credential aliases" if legacy_credentials.any? { |name| release_text.include?(name) }
 
   notarize_run = notarize_step.fetch("run")
   raise "Desktop app signing must consume the atomic API credential source" unless notarize_run.include?("sign-and-notarize-packaged-app.mjs")

--- a/.github/scripts/tests/runner-token-env-alias-test.sh
+++ b/.github/scripts/tests/runner-token-env-alias-test.sh
@@ -11,10 +11,4 @@ if [[ "$canonical_count" -ne 1 ]]; then
   exit 1
 fi
 
-legacy_count=$(jq '[.globalEnv[] | select(. == "VM0_RUNNER_TOKEN")] | length' "$TURBO_CONFIG")
-if [[ "$legacy_count" -ne 0 ]]; then
-  echo "expected turbo globalEnv not to contain VM0_RUNNER_TOKEN, found ${legacy_count}" >&2
-  exit 1
-fi
-
 echo "runner-token-env-alias-test: ok"

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -125,18 +125,16 @@ assert_api_backend_url_absent() {
   assert_env_key_absent "$env_file" OKOU_API_BACKEND_URL
 }
 
-assert_machine_secret_canonical_only() {
+assert_machine_secret_canonical() {
   local env_file="$1"
   local expected="$2"
   assert_env_key_count "$env_file" OKOU_MACHINE_SECRET_KEY 1
   assert_env_value "$env_file" OKOU_MACHINE_SECRET_KEY "$expected"
-  assert_env_key_count "$env_file" VM0_MACHINE_SECRET_KEY 0
 }
 
-assert_machine_secret_aliases_absent() {
+assert_machine_secret_absent() {
   local env_file="$1"
   assert_env_key_absent "$env_file" OKOU_MACHINE_SECRET_KEY
-  assert_env_key_absent "$env_file" VM0_MACHINE_SECRET_KEY
 }
 
 assert_machine_secret_values_absent_from_output() {
@@ -393,7 +391,7 @@ assert_machine_secret_canonical_case() {
   env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${test_dir}/github-output")"
   assert_contains "$output" "Rendered"
   assert_machine_secret_values_absent_from_output "$output" "$expected"
-  assert_machine_secret_canonical_only "$env_file" "$expected"
+  assert_machine_secret_canonical "$env_file" "$expected"
 }
 
 if grep -En 'add_(var|secret) [A-Z0-9_]+_OAUTH_CLIENT_(ID|SECRET)' "$ACTION"; then
@@ -444,7 +442,7 @@ TEMP_DIRS+=("$machine_secret_absent_dir")
 machine_secret_absent_output="$(run_machine_secret_action "$machine_secret_absent_dir" api preview '{}' 2>&1)"
 machine_secret_absent_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${machine_secret_absent_dir}/github-output")"
 assert_contains "$machine_secret_absent_output" "Rendered"
-assert_machine_secret_aliases_absent "$machine_secret_absent_env_file"
+assert_machine_secret_absent "$machine_secret_absent_env_file"
 
 machine_secret_web_dir="$(mktemp -d)"
 TEMP_DIRS+=("$machine_secret_web_dir")
@@ -459,7 +457,7 @@ machine_secret_web_output="$(
 machine_secret_web_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' "${machine_secret_web_dir}/github-output")"
 assert_contains "$machine_secret_web_output" "Rendered"
 assert_machine_secret_values_absent_from_output "$machine_secret_web_output" " web-isolated-machine-secret "
-assert_machine_secret_aliases_absent "$machine_secret_web_env_file"
+assert_machine_secret_absent "$machine_secret_web_env_file"
 
 api_backend_url_explicit_dir="$(mktemp -d)"
 TEMP_DIRS+=("$api_backend_url_explicit_dir")
@@ -544,7 +542,7 @@ assert_env_value "$success_env_file" FINICITY_APP_KEY "github-finicity-app-key"
 assert_env_value "$success_env_file" FINICITY_APP_SECRET "github-finicity-app-secret"
 assert_env_value "$success_env_file" FINICITY_PARTNER_ID "github-finicity-partner-id"
 assert_env_value "$success_env_file" ATOM_URL "https://tunnel-yuma-atom-api.vm7.ai"
-assert_machine_secret_canonical_only "$success_env_file" "github-atom-machine-secret"
+assert_machine_secret_canonical "$success_env_file" "github-atom-machine-secret"
 assert_env_value "$success_env_file" VERCEL_AUTOMATION_BYPASS_SECRET "github-vercel-bypass-secret"
 assert_env_key_count "$success_env_file" OKOU_PREVIEW_JOB_REF 1
 assert_env_value "$success_env_file" OKOU_PREVIEW_JOB_REF "pr-123"
@@ -599,7 +597,6 @@ assert_preview_job_ref_absent "$preview_web_env_file"
 assert_debug_canonical "$preview_web_env_file"
 assert_api_backend_url_canonical "$preview_web_env_file" "https://pr-123-api-backend.vm0.test"
 assert_env_key_absent "$preview_web_env_file" OKOU_MACHINE_SECRET_KEY
-assert_env_key_absent "$preview_web_env_file" VM0_MACHINE_SECRET_KEY
 assert_web_url_absent "$preview_web_env_file"
 
 empty_job_ref_dir="$(mktemp -d)"
@@ -610,7 +607,7 @@ assert_contains "$empty_job_ref_output" "Rendered"
 assert_preview_job_ref_absent "$empty_job_ref_env_file"
 assert_debug_canonical "$empty_job_ref_env_file"
 assert_api_backend_url_canonical "$empty_job_ref_env_file" "https://pr-123-api-backend.vm0.test"
-assert_machine_secret_canonical_only "$empty_job_ref_env_file" "github-atom-machine-secret"
+assert_machine_secret_canonical "$empty_job_ref_env_file" "github-atom-machine-secret"
 
 empty_dir="$(mktemp -d)"
 TEMP_DIRS+=("$empty_dir")
@@ -621,7 +618,7 @@ assert_no_fixture_secret_values "$empty_output"
 assert_zero_keys_with_live_readers_absent "$empty_env_file"
 assert_debug_canonical "$empty_env_file"
 assert_api_backend_url_canonical "$empty_env_file" "https://pr-123-api-backend.vm0.test"
-assert_machine_secret_aliases_absent "$empty_env_file"
+assert_machine_secret_absent "$empty_env_file"
 assert_env_value "$empty_env_file" OKOU_PUBLIC_ARTIFACTS_BASE_URL ""
 assert_env_value "$empty_env_file" OKOU_PUBLIC_HOST_DOMAIN ""
 assert_env_value "$empty_env_file" OKOU_MAPS_GOOGLE_MAPS_TOKEN ""
@@ -646,7 +643,6 @@ assert_env_value "$production_web_env_file" POSTHOG_HOST "https://posthog.github
 assert_env_value "$production_web_env_file" GIT_COMMIT_SHA "$EXPECTED_BUILD_COMMIT_SHA"
 assert_env_absent_value "$production_web_env_file" "ATOM_URL="
 assert_env_key_absent "$production_web_env_file" OKOU_MACHINE_SECRET_KEY
-assert_env_key_absent "$production_web_env_file" VM0_MACHINE_SECRET_KEY
 assert_env_absent_value "$production_web_env_file" "CLI_PKG_URL="
 assert_env_absent_value "$production_web_env_file" "JOGGAI_WEBHOOK_SECRET="
 assert_env_value "$production_web_env_file" OKOU_WEATHER_GOOGLE_WEATHER_TOKEN "github-google-weather-token"
@@ -675,7 +671,7 @@ assert_env_value "$production_api_env_file" FEISHU_CALLBACK_BASE_URL "https://pr
 assert_env_value "$production_api_env_file" FINICITY_WEBHOOK_BASE_URL "https://pr-123-api-backend.vm0.test"
 assert_env_value "$production_api_env_file" CLI_PKG_URL "https://static.vm0.io/okou-cli/test-sha/package.tgz"
 assert_env_value "$production_api_env_file" ATOM_URL "https://atom.github.test"
-assert_machine_secret_canonical_only "$production_api_env_file" "github-atom-machine-secret"
+assert_machine_secret_canonical "$production_api_env_file" "github-atom-machine-secret"
 assert_env_value "$production_api_env_file" JOGGAI_WEBHOOK_SECRET "github-joggai-webhook-secret"
 assert_env_value "$production_api_env_file" MICROSOFT_TEAMS_BOT_APP_ID "github-teams-bot-app-id"
 assert_env_value "$production_api_env_file" MICROSOFT_TEAMS_BOT_APP_PASSWORD "github-teams-bot-app-password"

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1227,7 +1227,6 @@ mod tests {
     unsafe fn clear_test_env() {
         for key in [
             guest_contracts::env::RUN_ID_ENV,
-            "VM0_API_TOKEN",
             guest_contracts::env::CANONICAL_API_TOKEN_ENV,
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,

--- a/crates/guest-agent/tests/api_token_env_aliases.rs
+++ b/crates/guest-agent/tests/api_token_env_aliases.rs
@@ -12,8 +12,6 @@ use guest_agent::http::HttpClient;
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 const CANONICAL_TOKEN: &str = "canonical-token-must-not-leak";
-const RETIRED_TOKEN: &str = "retired-token-must-not-leak";
-const TOKEN_VALUES: [&str; 2] = [CANONICAL_TOKEN, RETIRED_TOKEN];
 
 #[derive(Clone, Copy)]
 enum EnvInput {
@@ -26,81 +24,28 @@ enum EnvInput {
 struct CaptureCase {
     name: &'static str,
     canonical: EnvInput,
-    retired: EnvInput,
     expected_value: &'static str,
 }
 
-const CAPTURE_CASES: [CaptureCase; 12] = [
+const CAPTURE_CASES: [CaptureCase; 4] = [
     CaptureCase {
-        name: "both-absent",
+        name: "absent",
         canonical: EnvInput::Absent,
-        retired: EnvInput::Absent,
-        expected_value: "",
-    },
-    CaptureCase {
-        name: "retired-only-readable",
-        canonical: EnvInput::Absent,
-        retired: EnvInput::Readable(RETIRED_TOKEN),
-        expected_value: "",
-    },
-    CaptureCase {
-        name: "retired-only-empty",
-        canonical: EnvInput::Absent,
-        retired: EnvInput::Readable(""),
-        expected_value: "",
-    },
-    CaptureCase {
-        name: "retired-only-non-unicode",
-        canonical: EnvInput::Absent,
-        retired: EnvInput::NonUnicode,
         expected_value: "",
     },
     CaptureCase {
         name: "canonical-readable",
         canonical: EnvInput::Readable(CANONICAL_TOKEN),
-        retired: EnvInput::Absent,
-        expected_value: CANONICAL_TOKEN,
-    },
-    CaptureCase {
-        name: "canonical-readable-with-retired-readable",
-        canonical: EnvInput::Readable(CANONICAL_TOKEN),
-        retired: EnvInput::Readable(RETIRED_TOKEN),
-        expected_value: CANONICAL_TOKEN,
-    },
-    CaptureCase {
-        name: "canonical-readable-with-retired-empty",
-        canonical: EnvInput::Readable(CANONICAL_TOKEN),
-        retired: EnvInput::Readable(""),
-        expected_value: CANONICAL_TOKEN,
-    },
-    CaptureCase {
-        name: "canonical-readable-with-retired-non-unicode",
-        canonical: EnvInput::Readable(CANONICAL_TOKEN),
-        retired: EnvInput::NonUnicode,
         expected_value: CANONICAL_TOKEN,
     },
     CaptureCase {
         name: "canonical-empty",
         canonical: EnvInput::Readable(""),
-        retired: EnvInput::Absent,
-        expected_value: "",
-    },
-    CaptureCase {
-        name: "canonical-empty-with-retired-readable",
-        canonical: EnvInput::Readable(""),
-        retired: EnvInput::Readable(RETIRED_TOKEN),
         expected_value: "",
     },
     CaptureCase {
         name: "canonical-non-unicode",
         canonical: EnvInput::NonUnicode,
-        retired: EnvInput::Absent,
-        expected_value: "",
-    },
-    CaptureCase {
-        name: "canonical-non-unicode-with-retired-readable",
-        canonical: EnvInput::NonUnicode,
-        retired: EnvInput::Readable(RETIRED_TOKEN),
         expected_value: "",
     },
 ];
@@ -132,7 +77,6 @@ fn apply_input(key: &str, input: EnvInput) {
 
 fn clear_api_token_env() {
     remove_test_env(guest_contracts::env::CANONICAL_API_TOKEN_ENV);
-    remove_test_env("VM0_API_TOKEN");
 }
 
 fn capture_raw(log_path: &Path) -> Result<GuestConfigRaw, String> {
@@ -146,12 +90,10 @@ fn capture_raw(log_path: &Path) -> Result<GuestConfigRaw, String> {
 }
 
 fn assert_value_free(text: &str, context: &str) {
-    for token in TOKEN_VALUES {
-        assert!(
-            !text.contains(token),
-            "{context} exposed API token material"
-        );
-    }
+    assert!(
+        !text.contains(CANONICAL_TOKEN),
+        "{context} exposed API token material"
+    );
 }
 
 fn assert_http_mode(tmp: &Path, case: CaptureCase, raw: GuestConfigRaw) -> TestResult {
@@ -211,7 +153,6 @@ fn process_env_reads_only_canonical_api_token_without_value_leaks() -> TestResul
             guest_contracts::env::CANONICAL_API_TOKEN_ENV,
             case.canonical,
         );
-        apply_input("VM0_API_TOKEN", case.retired);
         let raw = capture_raw(&tmp.path().join(format!("{}.log", case.name)));
         let raw = match raw {
             Ok(raw) => raw,

--- a/crates/guest-agent/tests/api_token_process_isolation.rs
+++ b/crates/guest-agent/tests/api_token_process_isolation.rs
@@ -19,23 +19,17 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 #[tokio::test]
-async fn guest_agent_hides_canonical_and_retired_api_tokens_from_its_cli_child() -> TestResult {
+async fn guest_agent_hides_canonical_api_token_from_its_cli_child() -> TestResult {
     assert!(
         Path::new("/proc/self/environ").is_file(),
         "the process-isolation test requires procfs"
     );
     common::ensure_canonical_workspace_for_test()?;
 
-    for (case, token_env) in [
-        ("retired", "VM0_API_TOKEN"),
-        ("canonical", guest_contracts::env::CANONICAL_API_TOKEN_ENV),
-    ] {
-        assert_api_token_process_isolation(case, token_env).await?;
-    }
-    Ok(())
+    assert_api_token_process_isolation().await
 }
 
-async fn assert_api_token_process_isolation(case: &str, token_env: &str) -> TestResult {
+async fn assert_api_token_process_isolation() -> TestResult {
     let tmp = tempfile::tempdir()?;
     let home = tmp.path().join("home");
     let runtime_dir = tmp.path().join("runtime");
@@ -69,8 +63,8 @@ async fn assert_api_token_process_isolation(case: &str, token_env: &str) -> Test
             guest_contracts::env::CANONICAL_API_URL_ENV,
             "http://127.0.0.1:1",
         )
-        .env(token_env, API_TOKEN)
-        .env(guest_contracts::env::RUN_ID_ENV, format!("{RUN_ID}-{case}"))
+        .env(guest_contracts::env::CANONICAL_API_TOKEN_ENV, API_TOKEN)
+        .env(guest_contracts::env::RUN_ID_ENV, RUN_ID)
         .env(
             guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
             "00000000-0000-4000-8000-000000000abc",
@@ -110,24 +104,24 @@ async fn assert_api_token_process_isolation(case: &str, token_env: &str) -> Test
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !stderr.contains(API_TOKEN),
-        "{case} guest-agent stderr exposed API token material"
+        "guest-agent stderr exposed API token material"
     );
     assert!(
         !stdout.contains(API_TOKEN),
-        "{case} guest-agent stdout exposed API token material"
+        "guest-agent stdout exposed API token material"
     );
     let system_log_path = guest_contracts::runtime_paths::system_log_file(&runtime_dir);
     if let Ok(system_log) = std::fs::read_to_string(system_log_path) {
         assert!(
             !system_log.contains(API_TOKEN),
-            "{case} guest-agent system log exposed API token material"
+            "guest-agent system log exposed API token material"
         );
     }
     let observed = std::fs::read_to_string(&marker_path).map_err(|error| {
         std::io::Error::new(
             error.kind(),
             format!(
-                "read {case} process-inspection marker after guest-agent exited with {}: {error}",
+                "read process-inspection marker after guest-agent exited with {}: {error}",
                 output.status
             ),
         )
@@ -135,13 +129,12 @@ async fn assert_api_token_process_isolation(case: &str, token_env: &str) -> Test
 
     assert_eq!(
         observed, "parent-access-denied",
-        "{case} CLI process inspection result was {observed}"
+        "CLI process inspection result was {observed}"
     );
     Ok(())
 }
 
 fn write_process_inspection_probe(path: &Path, marker_path: &Path) -> TestResult {
-    let expected_retired = format!("VM0_API_TOKEN={API_TOKEN}");
     let expected_canonical = format!(
         "{}={API_TOKEN}",
         guest_contracts::env::CANONICAL_API_TOKEN_ENV
@@ -150,13 +143,10 @@ fn write_process_inspection_probe(path: &Path, marker_path: &Path) -> TestResult
         "#!/bin/sh\n\
          set -eu\n\
          marker={}\n\
-         expected_legacy={}\n\
          expected_canonical={}\n\
-         if env | grep -Fqx -- \"$expected_legacy\" \
-             || env | grep -Fqx -- \"$expected_canonical\"; then\n\
+         if env | grep -Fqx -- \"$expected_canonical\"; then\n\
            result=child-env-visible\n\
-         elif grep -aFq -- \"$expected_legacy\" \"/proc/$PPID/environ\" 2>/dev/null \
-             || grep -aFq -- \"$expected_canonical\" \"/proc/$PPID/environ\" 2>/dev/null; then\n\
+         elif grep -aFq -- \"$expected_canonical\" \"/proc/$PPID/environ\" 2>/dev/null; then\n\
            result=parent-token-visible\n\
          elif cat \"/proc/$PPID/environ\" >/dev/null 2>&1; then\n\
            result=parent-readable-token-absent\n\
@@ -166,7 +156,6 @@ fn write_process_inspection_probe(path: &Path, marker_path: &Path) -> TestResult
          printf '%s' \"$result\" > \"$marker\"\n\
          exit 1\n",
         quote_shell_arg(&marker_path.to_string_lossy()),
-        quote_shell_arg(&expected_retired),
         quote_shell_arg(&expected_canonical),
     );
     std::fs::write(path, script)?;

--- a/crates/guest-agent/tests/api_url_env.rs
+++ b/crates/guest-agent/tests/api_url_env.rs
@@ -84,7 +84,6 @@ fn clear_api_url_env() {
 
 fn clear_api_token_env() {
     remove_test_env(guest_contracts::env::CANONICAL_API_TOKEN_ENV);
-    remove_test_env("VM0_API_TOKEN");
 }
 
 fn capture_raw(log_path: &Path) -> Result<GuestConfigRaw, String> {

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -69,7 +69,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
             "CUSTOM_USER_ENV": "visible-to-cli",
             "VM0_FUTURE_RUNNER_KEY": "ordinary-vm0-value",
             "VM0_PROMPT": "ordinary-user-prompt",
-            "VM0_API_TOKEN": "ordinary-user-token",
+            "CUSTOM_API_TOKEN": "ordinary-user-token",
             "BASH_ENV": "/tmp/user-bash-env",
             "OKOU_API_BACKEND_URL": "https://canonical-user-env.example.invalid",
             "OPENAI_API_KEY": "sk-user",
@@ -122,7 +122,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     );
 
     unsafe {
-        std::env::set_var("VM0_API_TOKEN", "stale token after runtime construction");
+        std::env::set_var("CUSTOM_API_TOKEN", "stale token after runtime construction");
         std::env::set_var(
             guest_contracts::env::CANONICAL_API_URL_ENV,
             "https://stale-canonical-api.example.invalid",
@@ -169,7 +169,7 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
     for (key, expected_value) in [
         ("VM0_FUTURE_RUNNER_KEY", "ordinary-vm0-value"),
         ("VM0_PROMPT", "ordinary-user-prompt"),
-        ("VM0_API_TOKEN", "ordinary-user-token"),
+        ("CUSTOM_API_TOKEN", "ordinary-user-token"),
     ] {
         assert_eq!(cli_env.get(key).map(String::as_str), Some(expected_value));
     }

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -1043,7 +1043,6 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
     for key in [
         guest_contracts::env::CANONICAL_API_URL_ENV,
         guest_contracts::env::RUN_ID_ENV,
-        "VM0_API_TOKEN",
         guest_contracts::env::CANONICAL_API_TOKEN_ENV,
         guest_contracts::env::CANONICAL_SANDBOX_ID_ENV,
         guest_contracts::env::CANONICAL_SANDBOX_REUSE_RESULT_ENV,

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -453,7 +453,6 @@ fn build_env_json_required_keys() {
             .unwrap(),
         "tok"
     );
-    assert!(!env.contains_key("VM0_API_TOKEN"));
     assert_eq!(
         env.get(guest_contracts::env::CANONICAL_AGENT_EXECUTION_TIMEOUT_SECS_ENV)
             .unwrap(),
@@ -1441,11 +1440,11 @@ fn build_env_json_user_timezone_not_override_environment() {
 }
 
 #[test]
-fn arbitrary_vm0_user_env_cannot_override_canonical_or_private_payload() {
+fn user_env_cannot_override_canonical_or_private_payload() {
     let mut ctx = minimal_context();
     ctx.environment = Some(HashMap::from([
         ("VM0_PROMPT".into(), "hacked".into()),
-        ("VM0_API_TOKEN".into(), "stolen".into()),
+        ("CUSTOM_API_TOKEN".into(), "user-token".into()),
         ("CUSTOM_ENV".into(), "kept".into()),
     ]));
 
@@ -1461,11 +1460,11 @@ fn arbitrary_vm0_user_env_cannot_override_canonical_or_private_payload() {
             .unwrap(),
         "tok"
     );
-    assert!(!env.contains_key("VM0_API_TOKEN"));
+    assert!(!env.contains_key("CUSTOM_API_TOKEN"));
     assert!(!env.contains_key("CUSTOM_ENV"));
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
     assert_eq!(user_env.get("VM0_PROMPT").unwrap(), "hacked");
-    assert_eq!(user_env.get("VM0_API_TOKEN").unwrap(), "stolen");
+    assert_eq!(user_env.get("CUSTOM_API_TOKEN").unwrap(), "user-token");
     assert!(!user_env.contains_key(guest_contracts::env::CANONICAL_API_TOKEN_ENV));
 }
 
@@ -1544,13 +1543,6 @@ fn build_env_json_mock_codex_suppressed_by_real_agent_preview_flag() {
         },
     );
     assert!(!env.contains_key("USE_MOCK_CODEX"));
-}
-
-#[test]
-fn build_env_json_does_not_inject_vm0_token() {
-    let ctx = minimal_context();
-    let env = build_env_for_test(&ctx, "http://localhost");
-    assert!(!env.contains_key("VM0_TOKEN"));
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1110,7 +1110,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         ("BASH_ENV".into(), "/tmp/user-bash-env".into()),
         ("NODE_OPTIONS".into(), "--require /tmp/user-node.js".into()),
         ("VM0_PROMPT".into(), "hostile-user-prompt".into()),
-        ("VM0_API_TOKEN".into(), "stolen-token".into()),
+        ("CUSTOM_API_TOKEN".into(), "user-token".into()),
         (
             guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV.into(),
             "/tmp/evil-connector-account-context.json".into(),
@@ -1159,7 +1159,6 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
             .unwrap(),
         "tok"
     );
-    assert!(!start_env.contains_key("VM0_API_TOKEN"));
     assert_eq!(
         start_env
             .get(guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV)
@@ -1193,6 +1192,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         "OKOU_APP_URL",
         "ZERO_APP_URL",
         "VM0_FUTURE_RUNNER_KEY",
+        "CUSTOM_API_TOKEN",
         "BASH_ENV",
         "NODE_OPTIONS",
         "TZ",
@@ -1254,8 +1254,8 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         Some("hostile-user-prompt")
     );
     assert_eq!(
-        user_env.get("VM0_API_TOKEN").map(String::as_str),
-        Some("stolen-token")
+        user_env.get("CUSTOM_API_TOKEN").map(String::as_str),
+        Some("user-token")
     );
     assert!(!user_env.contains_key(guest_contracts::env::CANONICAL_API_TOKEN_ENV));
     assert_eq!(

--- a/docs/testing/cli-testing.md
+++ b/docs/testing/cli-testing.md
@@ -31,12 +31,10 @@ src/commands/
 
 Product CLI requests read `OKOU_TOKEN` and nothing else. `getToken()` in
 `src/lib/api/config.ts` delegates to `getOkouToken()` in `src/lib/okou-env.ts`,
-which reads only `OKOU_TOKEN`. The retired `ZERO_TOKEN` and `VM0_TOKEN` names
-are not honored, and there is no fallback to them when `OKOU_TOKEN` is unset or
-empty. Routing reads only `OKOU_API_BACKEND_URL`; when it is unset or empty,
-the CLI defaults to `https://api.okou.ai`. A configured host without a protocol
-receives `https://`, while an explicit protocol and trailing slash are
-preserved.
+which reads only `OKOU_TOKEN`. Routing reads only `OKOU_API_BACKEND_URL`; when
+it is unset or empty, the CLI defaults to `https://api.okou.ai`. A configured
+host without a protocol receives `https://`, while an explicit protocol and
+trailing slash are preserved.
 
 Set the canonical token explicitly together with the API URL:
 
@@ -51,44 +49,9 @@ afterEach(() => {
 });
 ```
 
-Do not create `~/.vm0/config.json`, set `VM0_TOKEN`, or mock the config module.
-Tests for missing authentication should leave every token name unset and assert
-the resulting guidance.
-
-Do not write a test that asserts a legacy token name still reaches the Okou
-path. No such fallback exists, so the test fails.
-
-Token acceptance is a fail-closed credential boundary, so rejecting a legacy
-token name is the product behavior and negative assertions belong here. This is
-the narrow exception in [Fallbacks to Avoid](../fallback.md) §1; do not
-generalize it. Everywhere else, a test that only asserts removed behavior stays
-removed is a tombstone and should not be written.
-`src/lib/api/__tests__/config.test.ts` holds the pattern for this boundary:
-
-```typescript
-it("ignores ZERO_TOKEN when OKOU_TOKEN is present", async () => {
-  vi.stubEnv("OKOU_TOKEN", "okou-token-value");
-  vi.stubEnv("ZERO_TOKEN", "zero-token-value");
-
-  await expect(getToken()).resolves.toBe("okou-token-value");
-  await expect(getActiveToken()).resolves.toBe("okou-token-value");
-});
-
-it("does not fall back to ZERO_TOKEN when OKOU_TOKEN is empty", async () => {
-  vi.stubEnv("OKOU_TOKEN", "");
-  vi.stubEnv("ZERO_TOKEN", "zero-token-value");
-
-  await expect(getToken()).resolves.toBeUndefined();
-  await expect(getActiveToken()).resolves.toBeUndefined();
-});
-
-it("does not fall back to VM0_TOKEN", async () => {
-  vi.stubEnv("VM0_TOKEN", "legacy-token-value");
-
-  await expect(getToken()).resolves.toBeUndefined();
-  await expect(getActiveToken()).resolves.toBeUndefined();
-});
-```
+Do not create a local authentication config file or mock the config module.
+Tests for missing authentication should leave `OKOU_TOKEN` unset and assert the
+resulting guidance.
 
 ## Command integration pattern
 

--- a/e2e/tests/03-runner/run-t14-runner-context.bats
+++ b/e2e/tests/03-runner/run-t14-runner-context.bats
@@ -68,7 +68,6 @@ test -n "$OKOU_TOKEN"
 test -z "${ZERO_APP_URL:-}"
 test -z "${ZERO_AGENT_ID:-}"
 test -z "${ZERO_CHAT_THREAD_ID:-}"
-test -z "${ZERO_TOKEN:-}"
 test -z "${ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED:-}"
 node -e '
 const token = process.env.OKOU_TOKEN;

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7578,7 +7578,6 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
       throw new Error("Expected the promoted claim to expose the Okou token");
     }
     expect(thirdClaim.secretValues).toContain(okouToken);
-    expect(thirdClaim.environment ?? {}).not.toHaveProperty("ZERO_TOKEN");
     expect(thirdClaim).not.toHaveProperty("secretValueEnvironmentKeys");
     expect(thirdClaim).not.toHaveProperty("runContextStorage");
     expectClaimNetworkPolicyRefreshPath(third.runId, "no_builtin_targets");
@@ -14910,7 +14909,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
 
     const directEnvironment = {
       ZERO_AGENT_ID: `\${{ vars.ZERO_AGENT_ID }}`,
-      ZERO_TOKEN: `\${{ secrets.ZERO_TOKEN }}`,
+      CUSTOM_API_TOKEN: `\${{ secrets.CUSTOM_API_TOKEN }}`,
     };
     const directAgent = await api.createDirectAgent(actor, {
       version: "1",
@@ -14932,13 +14931,13 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       prompt: "consume an application-owned Zero context",
       modelProviderType: "anthropic-api-key",
       vars: { ZERO_AGENT_ID: directAgent.agentId },
-      secrets: { ZERO_TOKEN: directOkouToken },
+      secrets: { CUSTOM_API_TOKEN: directOkouToken },
     });
     await api.heartbeatRunner(runnerGroup);
     const directClaim = await api.claimRunnerJob(direct.runId);
     expect(directClaim.environment).toMatchObject({
       ZERO_AGENT_ID: directAgent.agentId,
-      ZERO_TOKEN: directOkouToken,
+      CUSTOM_API_TOKEN: directOkouToken,
     });
     expect(directClaim.environment ?? {}).not.toHaveProperty("OKOU_TOKEN");
     expect(sandboxTokenPayload(directOkouToken)).toMatchObject({
@@ -15244,7 +15243,6 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     }
     const runContextSnapshot = runContextSnapshotForRun(run.runId);
     expect(runContextSnapshot.secretNames).toContain("OKOU_TOKEN");
-    expect(runContextSnapshot.secretNames).not.toContain("ZERO_TOKEN");
     expect(runContextSnapshot.environmentEntries).toContainEqual({
       name: "OKOU_TOKEN",
       value: "***",

--- a/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
@@ -254,22 +254,6 @@ describe("registerCommands", () => {
     ]);
   });
 
-  it("prefers OKOU_TOKEN when both token names are present", () => {
-    vi.stubEnv(
-      "OKOU_TOKEN",
-      buildOkouToken({ scope: "okou", capabilities: ["agent:read"] }),
-    );
-    vi.stubEnv(
-      "ZERO_TOKEN",
-      buildOkouToken({ scope: "okou", capabilities: ["connector:read"] }),
-    );
-
-    const prog = buildProgram();
-
-    expect(visibleCommandNames(prog)).toContain("agent");
-    expect(visibleCommandNames(prog)).not.toContain("connector");
-  });
-
   it("should hide run-only commands and keep global commands visible with malformed token", () => {
     vi.stubEnv("OKOU_TOKEN", "not-a-valid-token");
 

--- a/turbo/apps/cli/src/commands/goal/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/goal/__tests__/index.test.ts
@@ -22,7 +22,6 @@ describe("okou goal command", () => {
   beforeEach(() => {
     vi.stubEnv("OKOU_API_BACKEND_URL", "http://localhost:3000");
     vi.stubEnv("OKOU_TOKEN", "test-okou-token");
-    vi.stubEnv("ZERO_TOKEN", undefined);
     vi.stubEnv("OKOU_APP_URL", undefined);
     vi.stubEnv("OKOU_AGENT_ID", undefined);
     vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);

--- a/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
@@ -23,33 +23,9 @@ describe("Okou configuration", () => {
 
   it("uses OKOU_TOKEN as the run authentication source", async () => {
     vi.stubEnv("OKOU_TOKEN", "okou-token-value");
-    vi.stubEnv("VM0_TOKEN", "legacy-token-value");
 
     await expect(getToken()).resolves.toBe("okou-token-value");
     await expect(getActiveToken()).resolves.toBe("okou-token-value");
-  });
-
-  it("ignores ZERO_TOKEN when OKOU_TOKEN is present", async () => {
-    vi.stubEnv("OKOU_TOKEN", "okou-token-value");
-    vi.stubEnv("ZERO_TOKEN", "zero-token-value");
-
-    await expect(getToken()).resolves.toBe("okou-token-value");
-    await expect(getActiveToken()).resolves.toBe("okou-token-value");
-  });
-
-  it("does not fall back to ZERO_TOKEN when OKOU_TOKEN is empty", async () => {
-    vi.stubEnv("OKOU_TOKEN", "");
-    vi.stubEnv("ZERO_TOKEN", "zero-token-value");
-
-    await expect(getToken()).resolves.toBeUndefined();
-    await expect(getActiveToken()).resolves.toBeUndefined();
-  });
-
-  it("does not fall back to VM0_TOKEN", async () => {
-    vi.stubEnv("VM0_TOKEN", "legacy-token-value");
-
-    await expect(getToken()).resolves.toBeUndefined();
-    await expect(getActiveToken()).resolves.toBeUndefined();
   });
 
   it("rejects a zero-scoped OKOU_TOKEN", async () => {

--- a/turbo/apps/cli/src/test/setup.ts
+++ b/turbo/apps/cli/src/test/setup.ts
@@ -11,7 +11,6 @@ beforeEach(() => {
   vi.stubEnv("OKOU_API_BACKEND_URL", undefined);
   vi.stubEnv("OKOU_APP_URL", undefined);
   vi.stubEnv("OKOU_TOKEN", "");
-  vi.stubEnv("ZERO_TOKEN", "");
   vi.stubEnv("OKOU_AGENT_ID", "");
   vi.stubEnv("ZERO_AGENT_ID", "");
   vi.stubEnv("OKOU_CHAT_THREAD_ID", "");

--- a/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
@@ -28,15 +28,7 @@ const canonicalAliases = {
   keyId: "OKOU_DESKTOP_NOTARIZE_API_KEY_ID",
   issuer: "OKOU_DESKTOP_NOTARIZE_API_ISSUER",
 } as const;
-const retiredAliases = {
-  keyPath: "VM0_DESKTOP_NOTARIZE_API_KEY_PATH",
-  keyId: "VM0_DESKTOP_NOTARIZE_API_KEY_ID",
-  issuer: "VM0_DESKTOP_NOTARIZE_API_ISSUER",
-} as const;
-const credentialAliases = [
-  ...Object.values(canonicalAliases),
-  ...Object.values(retiredAliases),
-];
+const credentialAliases = Object.values(canonicalAliases);
 const canonicalKeychainAliases = {
   profile: "OKOU_DESKTOP_NOTARIZE_KEYCHAIN_PROFILE",
   path: "OKOU_DESKTOP_NOTARIZE_KEYCHAIN",
@@ -144,8 +136,6 @@ type CredentialCase =
   | "absent"
   | "empty"
   | "canonical-only"
-  | "canonical-and-retired"
-  | "retired-only"
   | IncompleteCredentialCase;
 
 const incompleteCredentialCases = [
@@ -226,7 +216,7 @@ function credentialValues(directory: string): CredentialValues {
 
 function assignCredentialValues(
   environment: NodeJS.ProcessEnv,
-  aliases: typeof canonicalAliases | typeof retiredAliases,
+  aliases: typeof canonicalAliases,
   values: CredentialValues,
 ): void {
   environment[aliases.keyPath] = values.keyPath;
@@ -250,14 +240,8 @@ function applyCredentialCase(
   }
 
   const canonical = credentialValues(directory);
-  const retired = credentialValues(directory);
   if (credentialCase === "canonical-only") {
     assignCredentialValues(environment, canonicalAliases, canonical);
-  } else if (credentialCase === "canonical-and-retired") {
-    assignCredentialValues(environment, canonicalAliases, canonical);
-    assignCredentialValues(environment, retiredAliases, retired);
-  } else if (credentialCase === "retired-only") {
-    assignCredentialValues(environment, retiredAliases, retired);
   } else {
     for (const field of incompleteCredentialFields[credentialCase]) {
       environment[canonicalAliases[field]] = canonical[field];
@@ -376,10 +360,7 @@ function runForge(
     expectedSigningIdentity === "-" ? "false" : "true";
   environment.TEST_EXPECTED_SIGNING_TIMESTAMP =
     expectedSigningIdentity === "-" ? "none" : "absent";
-  if (
-    credentialCase === "canonical-only" ||
-    credentialCase === "canonical-and-retired"
-  ) {
+  if (credentialCase === "canonical-only") {
     environment.TEST_NOTARIZE_MODE = "api";
   }
   if (options.keychainMode) {
@@ -521,10 +502,6 @@ describe("Desktop Forge notarization entry point", () => {
     expectSuccessfulApiEntryPoint(runForge("canonical-only"));
   });
 
-  it("keeps canonical credentials authoritative over hostile retired values", () => {
-    expectSuccessfulApiEntryPoint(runForge("canonical-and-retired"));
-  });
-
   it.each(incompleteCredentialCases)(
     "rejects the incomplete canonical %s shape before signing",
     (credentialCase) => {
@@ -535,7 +512,7 @@ describe("Desktop Forge notarization entry point", () => {
     },
   );
 
-  it.each(["absent", "empty", "retired-only"] as const)(
+  it.each(["absent", "empty"] as const)(
     "keeps the default Keychain profile when API credentials are %s",
     (credentialCase) => {
       const result = runForge(credentialCase, {
@@ -548,8 +525,7 @@ describe("Desktop Forge notarization entry point", () => {
   );
 
   it.each([
-    ["canonical and retired API credentials", "canonical-and-retired"],
-    ["retired-only API credentials", "retired-only"],
+    ["complete canonical API credentials", "canonical-only"],
     ["incomplete canonical API credentials", "key-path-only"],
   ] as const)(
     "keeps a custom Keychain profile ahead of %s",
@@ -721,12 +697,6 @@ describe("packaged Desktop signing and notarization entry point", () => {
     expectSuccessfulApiEntryPoint(runPackagedAppHelper("canonical-only"));
   });
 
-  it("keeps canonical credentials authoritative over hostile retired values", () => {
-    expectSuccessfulApiEntryPoint(
-      runPackagedAppHelper("canonical-and-retired"),
-    );
-  });
-
   it.each(incompleteCredentialCases)(
     "rejects the incomplete canonical %s shape before signing",
     (credentialCase) => {
@@ -737,7 +707,7 @@ describe("packaged Desktop signing and notarization entry point", () => {
     },
   );
 
-  it.each(["absent", "empty", "retired-only"] as const)(
+  it.each(["absent", "empty"] as const)(
     "rejects %s API credentials before signing",
     (credentialCase) => {
       expectFailedBeforeExternalSideEffects(


### PR DESCRIPTION
Closes #31478

## Summary

- Remove test-only tombstones for retired credential environment names across Guest Agent, Runner, CLI, Desktop, and generated-environment contracts.
- Keep canonical `OKOU_*` credential capture, value non-disclosure, canonical parent/child and bootstrap isolation, Desktop atomic credential validation, and generic user-environment separation.
- Replace credential-shaped arbitrary user fixtures with `CUSTOM_API_TOKEN` where the live generic isolation invariant still needs a positive fixture.
- Leave production readers/writers, Zero protocol and token-scope behavior, historical records, Actions/workflows, and release/deployment surfaces unchanged.

## Exact inventory

Inventory excludes the intentionally untouched historical `docs/okou-protocol-migration.md` and `turbo/apps/api/CHANGELOG.md` records.

| Spelling | `origin/main@709e1a2670` | This PR |
| --- | ---: | ---: |
| `VM0_API_TOKEN` | 17 | 0 |
| `VM0_MACHINE_SECRET_KEY` | 4 | 0 |
| `VM0_RUNNER_TOKEN` | 2 | 0 |
| `VM0_TOKEN` | 8 | 0 |
| `VM0_DESKTOP_NOTARIZE_API_KEY_PATH` | 2 | 0 |
| `VM0_DESKTOP_NOTARIZE_API_KEY_ID` | 2 | 0 |
| `VM0_DESKTOP_NOTARIZE_API_ISSUER` | 2 | 0 |
| `ZERO_TOKEN` (non-historical) | 36 | 17 |

All 17 retained non-historical `ZERO_TOKEN` occurrences are API test descriptions for the separate capability-token contract. The two historical occurrences remain untouched.

## Open-PR overlap audit

Immediately before push, the paginated audit covered all 31 open PRs and fetched 863/863 declared changed files with zero count mismatches. The only overlaps were #31493 (Pi v2 runtime contract), #29948 (connector settings cleanup), and #25722 (Cloudflare worker cutover); their current patches are unrelated hunks and are inventory rather than ordering blockers.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo check --locked -p guest-agent -p runner --all-targets --all-features`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 cargo clippy --locked -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- Guest Agent focused integration targets: `api_token_env_aliases`, `api_token_process_isolation`, `api_url_env`, and `cli_child_env` (4/4 passed)
- `bash -n` and ShellCheck 0.11.0 for all four changed shell/Bats files
- Focused shell contracts: Desktop deployment, Runner token propagation, and Web/API environment rendering (3/3 passed)
- Prettier for all affected TypeScript/Markdown files
- CLI, Desktop, and API lint; Knip
- CLI, Desktop, and API type-check
- Focused Vitest: CLI 108 tests and Desktop 39 tests passed; the post-rebase overlapping CLI file passed again (86 tests)
- `git diff --check`

Local constraints retained for protected CI: the single-job Runner test binary link was terminated with exit 137 after reaching about 3.71 GiB RSS (about 92% of the host), and API BDD setup cannot connect because no PostgreSQL listens on localhost:5432. The Runner preview E2E Bats case also requires CI preview/runner credentials. Coverage was not reduced to work around those limits.
