### PR TITLE
feat(ui): put the sand and amber palette behind the new-ui switch

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -170,7 +170,7 @@ function editorContentClass(singleLineOnMobile: boolean): string {
     : `${EDITOR_CONTENT_CLASS} min-h-[96px]`;
 }
 
-const WORKFLOW_HIGHLIGHT_CLASS = "text-primary";
+const WORKFLOW_HIGHLIGHT_CLASS = "text-brand-text";
 function composerPlaceholder(): string {
   return i18n.t(($) => {
     return $.chat.composer.placeholder;

--- a/turbo/apps/platform/src/signals/theme.ts
+++ b/turbo/apps/platform/src/signals/theme.ts
@@ -215,6 +215,22 @@ export function applyTypefaceDocumentAttribute(enabled: boolean) {
 }
 
 /**
+ * Keep the new shell attribute on the document while the app shell is mounted.
+ * Document scope matches the two above: the shell's surfaces are read by the
+ * sidebars and the workspace card, and portaled dialogs inherit the same
+ * sidebar token.
+ */
+export function applyNewUiDocumentAttribute(enabled: boolean) {
+  const root = document.documentElement;
+
+  if (enabled) {
+    root.dataset.newUi = "";
+  } else {
+    delete root.dataset.newUi;
+  }
+}
+
+/**
  * Initialize theme from localStorage or system preference.
  */
 export const initTheme$ = command(({ get, set }) => {

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -738,7 +738,7 @@ function AgentCard({ agent, creator, hasUnread, showCreator }: AgentProps) {
                       // Matches --zero-card-shadow; inlined because the tooltip
                       // portal renders outside .zero-app where the var is scoped.
                       boxShadow:
-                        "0 2px 12px hsl(220 12% 50% / 0.04), 0 0 0 0.5px hsl(220 12% 50% / 0.02)",
+                        "0 2px 12px hsl(30 6% 45% / 0.05), 0 0 0 0.5px hsl(30 6% 45% / 0.025)",
                       whiteSpace: "normal",
                     }}
                   >

--- a/turbo/apps/platform/src/views/components/avatar.tsx
+++ b/turbo/apps/platform/src/views/components/avatar.tsx
@@ -108,7 +108,7 @@ export function WorkspaceLogo({
     <div
       className={cn(
         base,
-        "flex items-center justify-center bg-[hsl(var(--gray-200))] font-bold text-[hsl(var(--primary-700))]",
+        "flex items-center justify-center bg-[hsl(var(--gray-200))] font-bold text-brand-text",
         THUMBNAIL_INITIAL_TEXT[size],
       )}
     >

--- a/turbo/apps/platform/src/views/components/instatus-status-notice.tsx
+++ b/turbo/apps/platform/src/views/components/instatus-status-notice.tsx
@@ -79,7 +79,7 @@ function InstatusIssueNotice({
       <CardContent className={compact ? "p-3" : "p-4"}>
         <div className="flex items-start gap-3">
           <span
-            className={`${compact ? "size-8" : "size-9"} flex shrink-0 items-center justify-center rounded-lg bg-gray-50 text-primary`}
+            className={`${compact ? "size-8" : "size-9"} flex shrink-0 items-center justify-center rounded-lg bg-gray-50 text-brand-text`}
           >
             <StatusIcon aria-hidden="true" size={18} />
           </span>
@@ -98,7 +98,7 @@ function InstatusIssueNotice({
               href={`${pageBaseUrl}/${encodeURIComponent(issue.id)}`}
               target="_blank"
               rel="noreferrer"
-              className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-primary-900 transition-colors hover:text-primary-950"
+              className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-brand-text transition-colors hover:text-brand-text-hover"
             >
               {t(($) => {
                 return $.serviceStatus.viewUpdates;

--- a/turbo/apps/platform/src/views/components/product-brand-mark.tsx
+++ b/turbo/apps/platform/src/views/components/product-brand-mark.tsx
@@ -1,4 +1,5 @@
 import { useGet } from "ccstate-react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import {
   platformOkouWordmarkDarkImg,
@@ -6,6 +7,7 @@ import {
 } from "../../lib/static-assets.ts";
 import { brandName$, type BrandName } from "../../signals/branding.ts";
 import { theme$ } from "../../signals/theme.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 
 type ProductBrandMarkSize = "default" | "compact" | "small";
 
@@ -18,6 +20,11 @@ function Vm0BrandMark({
   label: string;
   decorative: boolean;
 }) {
+  // The mark is an SVG fill, not a token, so it cannot follow the palette the
+  // way the stylesheet does. Read the switch directly instead.
+  const brandFill = useGet(featureSwitch$)[FeatureSwitchKey.NewUi]
+    ? "#FFA500"
+    : "#ED4E01";
   const dimensions =
     size === "default"
       ? { width: 80, height: 24 }
@@ -39,19 +46,19 @@ function Vm0BrandMark({
     >
       <path
         d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"
-        fill="#ED4E01"
+        fill={brandFill}
       />
       <path
         d="M0.710495 8.33374L12.6479 15.2595C12.7944 15.3445 12.8846 15.5015 12.8846 15.6715L12.8843 29.5237C12.8843 29.8899 12.4897 30.1187 12.1741 29.9356L0.236691 23.0096C0.0902206 22.9246 -3.46036e-06 22.7676 0 22.5977L0.00028208 8.74568C0.000289537 8.37949 0.394855 8.15064 0.710495 8.33374Z"
-        fill="#ED4E01"
+        fill={brandFill}
       />
       <path
         d="M24.947 21.6772C24.947 21.9507 24.8017 22.2036 24.5655 22.3415L16.2103 27.219C15.6975 27.5184 15.0533 27.1485 15.0533 26.5547L15.0531 16.7842C15.0531 16.5107 15.1983 16.2578 15.4345 16.1199L23.7897 11.2425C24.3025 10.9431 24.9468 11.313 24.9468 11.9068L24.947 21.6772ZM13.6541 16.3426V29.5279C13.6541 29.8852 14.0308 30.1106 14.3391 29.9444L14.3538 29.9362L25.5769 23.3654C26.25 22.9808 26.3462 22.6924 26.3459 22.1188L26.3459 8.93378C26.3459 8.57084 25.9572 8.344 25.6462 8.52548L14.4231 15.0001C14.0385 15.2885 13.6539 15.577 13.6541 16.3426Z"
-        fill="#ED4E01"
+        fill={brandFill}
       />
       <path
         d="M25.9616 10.58L15.2113 28.4616L14.2308 27.8817L24.981 10.0001L25.9616 10.58Z"
-        fill="#ED4E01"
+        fill={brandFill}
       />
       <path
         d="M42.1865 25L34.3459 5H37.4651L43.7887 21.4575L50.1264 5H53.2315L45.3908 25H42.1865Z"

--- a/turbo/apps/platform/src/views/css/__tests__/design-token-shadowing.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/design-token-shadowing.test.ts
@@ -18,6 +18,10 @@ function intentionalShadows(): string[] {
     // The Zero nav sits on its own surface: lighter than the design system's
     // sidebar in light mode, darker in dark mode.
     "--color-sidebar",
+    // Both nav surfaces are gated on the `newUi` switch. Off, they hold the
+    // flats the shell had before the workspace became a card; the design
+    // system's own two greys only take over under `[data-new-ui]`.
+    "--color-sidebar-rail",
   ];
 }
 

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -2135,3 +2135,34 @@ html:has(.zero-dialog-overlay)
       14%
   );
 }
+
+/* Brand washes and markdown accents. The Amber scale is not mirrored between
+   themes, so a raw stop that reads as a pale tint in light stays pale in dark
+   and blows out. These reach for the palette's own theme-aware brand tokens
+   instead; the ungated rules above keep the orange ramp's raw stops, which do
+   mirror. */
+[data-new-ui] ::selection {
+  background-color: hsl(var(--brand-subtle));
+}
+[data-new-ui] .wmde-markdown[data-color-mode*="light"],
+[data-new-ui] .wmde-markdown[data-color-mode*="dark"] {
+  --color-accent-fg: hsl(var(--brand-text));
+  --color-accent-emphasis: hsl(var(--brand-text));
+  --color-attention-subtle: hsl(var(--brand-subtle));
+  --color-attention-fg: hsl(var(--brand-text));
+  --color-attention-emphasis: hsl(var(--brand-text));
+  --color-prettylights-syntax-markup-heading: hsl(var(--brand-text));
+  --color-prettylights-syntax-markup-changed-bg: hsl(var(--brand-subtle));
+}
+[data-new-ui] .wmde-markdown mark {
+  background-color: hsl(var(--brand-subtle));
+}
+[data-new-ui] .wmde-markdown .markdown-alert.markdown-alert-note {
+  border-left-color: hsl(var(--brand-text));
+}
+[data-new-ui]
+  .wmde-markdown
+  .markdown-alert.markdown-alert-note
+  .markdown-alert-title {
+  color: hsl(var(--brand-text));
+}

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -21,7 +21,6 @@
     "Noto Color Emoji", sans-serif;
 
   /* Sidebar colors - using tokens for dark mode support */
-  --color-sidebar: hsl(var(--gray-0));
   --color-sidebar-border: hsl(var(--gray-200));
 
   /* Credit balance breakdown segment colors (usage bar chart) */
@@ -698,8 +697,19 @@ body {
 
 /* Zero left nav */
 .zero-nav {
-  --color-sidebar: hsl(var(--gray-0));
   --color-sidebar-border: hsl(var(--gray-200));
+}
+
+/* Shell surfaces, gated on the `newUi` switch. Off, both sidebars sit on the
+   flats they had before the workspace became a card. On, they take the site's
+   own two greys and the chat column doubles as the frame around that card. */
+.zero-app {
+  --color-sidebar: hsl(var(--gray-0));
+  --color-sidebar-rail: hsl(var(--gray-50));
+}
+:where([data-new-ui]) .zero-app {
+  --color-sidebar: hsl(var(--sidebar));
+  --color-sidebar-rail: hsl(var(--sidebar-rail));
 }
 .zero-app[data-gradient-color-themes] .zero-nav {
   --color-sidebar: hsl(var(--sidebar));
@@ -719,6 +729,9 @@ body {
 }
 :where([data-theme="dark"]) .zero-nav {
   --color-sidebar: hsl(240 5% 8%);
+}
+:where([data-new-ui][data-theme="dark"]) .zero-nav {
+  --color-sidebar: hsl(var(--sidebar));
 }
 
 /* Morandi outline buttons */
@@ -802,6 +815,7 @@ body {
 
 /* Composer / input card (white, light border — “Just ask” / chat input) */
 .zero-app .zero-composer {
+  --zero-composer-ring: var(--gray-500);
   background-color: hsl(var(--card));
   border: 0.7px solid hsl(var(--gray-400));
   border-radius: var(--zero-composer-radius);
@@ -814,7 +828,7 @@ body {
   content: "";
   position: absolute;
   inset: -0.7px;
-  border: 0.7px solid hsl(var(--gray-500));
+  border: 0.7px solid hsl(var(--zero-composer-ring));
   border-radius: inherit;
   box-shadow: var(--zero-composer-focus-veil);
   opacity: 0;
@@ -1952,4 +1966,172 @@ html:has(.zero-dialog-overlay)
     .owf-diagram-beam
   ):not(.zero-dialog-content *) {
   animation-play-state: paused;
+}
+
+/* Workspace card: the routed page is a white sheet laid over the shell's grey
+   rather than a white half of the window. The gap runs on all four sides, so
+   the chat column's surface continues around the sheet and reads as one frame.
+   Padding insets the content and `inset` insets the paint by the same amount,
+   which is why the sheet needs no clipping: nothing lays out in the gutter, and
+   only the corner triangles could ever escape the radius.
+
+   Desktop only. Below the sidebar breakpoint the columns are gone and a frame
+   would just spend width the page does not have. */
+@media (min-width: 48rem) {
+  [data-new-ui] .zero-workspace-card {
+    --zero-workspace-card-gap: 8px;
+    background-color: hsl(var(--sidebar));
+    padding: var(--zero-workspace-card-gap);
+  }
+
+  [data-new-ui] .zero-workspace-card.zero-workspace-bg::before {
+    inset: var(--zero-workspace-card-gap);
+    border: 0.7px solid hsl(var(--border));
+    border-radius: 12px;
+  }
+}
+
+/* Under the `newUi` switch dark carries the brand hue instead of a lighter
+   neutral. The light ring can stay neutral because there it darkens, and
+   darker-than-the-border already reads as emphasis. Lifting a neutral against a
+   dark card does not: it lands on a bright grey that reads as a white outline
+   rather than as focus, which is what `--ring` means on every other control.
+   Saturation, not lightness, does the work, so the ring stays quieter than the
+   full Amber stop. */
+:where([data-theme="dark"][data-new-ui]) .zero-app .zero-composer {
+  --zero-composer-ring: 38.8 38% 38%;
+}
+
+/* ===================================================================
+   Sand / Amber, behind the `newUi` switch.
+
+   `packages/ui`'s globals gate the whole base palette by scoping the token
+   blocks to `[data-new-ui]`, and every `@theme` alias follows because it is a
+   lazy `hsl(var(--x))` reference. What is left here is the handful of values
+   this sheet hardcodes instead of deriving, plus the two colour-theme ladders,
+   which carry their own selector and so need their own gated copy.
+
+   Delete this whole section when the palette graduates.
+   =================================================================== */
+
+:root[data-new-ui] {
+  /* Credit balance breakdown segments, drawn from the palette. */
+  --color-credit-free: #008d76;
+  --color-credit-promotional: #ff6030;
+  --color-credit-plan-pro: #ffa500;
+  --color-credit-plan-team: #3462d3;
+
+  /* Usage record kind segments, drawn from the palette's categorical set.
+     Model keeps a cool blue so the dominant LLM segment separates cleanly
+     from the image hue; image and video also sit far apart (blossom vs jade). */
+  --color-usage-kind-model: #3462d3;
+  --color-usage-kind-image: #ce9cb5;
+  --color-usage-kind-video: #008d76;
+  --color-usage-kind-connector: #779aad;
+  --color-usage-kind-other: #c8b800;
+}
+
+/* Shadows carry a hue of their own, so a cool one greys the warm surfaces. */
+:root[data-new-ui] {
+  --zero-card-shadow:
+    0 2px 12px hsl(30 6% 45% / 0.05), 0 0 0 0.5px hsl(30 6% 45% / 0.025);
+  --zero-chat-card-shadow: 0 1px 2px hsl(30 6% 45% / 0.05);
+  --zero-composer-focus-veil: 0 10px 48px -8px hsl(30 8% 45% / 0.09);
+}
+
+/* Markdown links move to the palette's Cobalt. */
+[data-new-ui] .wmde-markdown a {
+  color: hsl(222.6 64.4% 51.6%);
+}
+[data-new-ui] .wmde-markdown a:hover {
+  color: hsl(222.2 57.3% 40.4%);
+}
+:where([data-theme="dark"][data-new-ui]) .wmde-markdown a {
+  color: hsl(220.5 100% 84.3%);
+}
+:where([data-theme="dark"][data-new-ui]) .wmde-markdown a:hover {
+  color: hsl(220.4 100% 90.4%);
+}
+
+/* Colour themes realigned to the new ramp's lightness steps. */
+:root[data-new-ui][data-gradient-color-themes][data-color-theme] {
+  --gray-0: var(--zero-color-theme-hue) 24% 98.3%;
+  --gray-50: var(--zero-color-theme-hue) 22% 97.7%;
+  --gray-100: var(--zero-color-theme-hue) 20% 96.7%;
+  --gray-200: var(--zero-color-theme-hue) 18% 86.9%;
+  --gray-300: var(--zero-color-theme-hue) 17% 79.4%;
+  --gray-400: var(--zero-color-theme-hue) 16% 71.2%;
+  --gray-500: var(--zero-color-theme-hue) 16% 62.2%;
+
+  --divider: var(--gray-200);
+  --background: var(--zero-color-theme-hue) 24% 98.8%;
+  --card: var(--zero-color-theme-hue) 30% 99.4%;
+  --popover: var(--card);
+  --secondary: var(--zero-color-theme-hue) 22% 96.7%;
+  --muted: var(--gray-100);
+  --accent: var(--zero-color-theme-hue) 24% 96.7%;
+  --border: var(--gray-200);
+  --input: var(--card);
+  --ring: var(--zero-color-theme-ring);
+  /* Halved with the neutral sidebar: this surface now frames the workspace
+     card as well as backing the chat column, and a full-strength tint around a
+     white sheet overpowers it. The rail keeps its depth and stays the anchor. */
+  --sidebar: var(--zero-color-theme-hue) 30% 98.4%;
+  --zero-nav-rail: var(--zero-color-theme-hue) 36% 93.5%;
+  --zero-nav-foreground: var(--zero-color-theme-hue) 24% 18%;
+  --zero-nav-muted-foreground: var(--zero-color-theme-hue) 18% 38%;
+  --background-50: var(--gray-50);
+  --state-layer: var(--zero-color-theme-ring);
+  --segment-selected: var(--card);
+  --zero-color-theme-selected: color-mix(
+    in srgb,
+    #ffffff 84%,
+    color-mix(
+        in srgb,
+        var(--zero-color-theme-anchor) 82%,
+        var(--zero-color-theme-companion)
+      )
+      16%
+  );
+}
+
+:root[data-new-ui]:is(
+    .dark,
+    [data-theme="dark"]
+  )[data-gradient-color-themes][data-color-theme] {
+  --gray-0: var(--zero-color-theme-hue) 5% 10.5%;
+  --gray-50: var(--zero-color-theme-hue) 6% 13.5%;
+  --gray-100: var(--zero-color-theme-hue) 8% 18.5%;
+  --gray-200: var(--zero-color-theme-hue) 9% 22.5%;
+  --gray-300: var(--zero-color-theme-hue) 10% 26.5%;
+  --gray-400: var(--zero-color-theme-hue) 11% 30.5%;
+  --gray-500: var(--zero-color-theme-hue) 12% 36.5%;
+
+  --divider: var(--gray-200);
+  --background: var(--gray-50);
+  --card: var(--zero-color-theme-hue) 8% 16.5%;
+  --popover: var(--gray-100);
+  --secondary: var(--zero-color-theme-hue) 9% 20.5%;
+  --muted: var(--gray-200);
+  --accent: var(--zero-color-theme-hue) 12% 26.5%;
+  --border: var(--gray-200);
+  --input: var(--gray-200);
+  --ring: var(--zero-color-theme-hue) 45% 62%;
+  --sidebar: var(--zero-color-theme-hue) 14% 12%;
+  --zero-nav-rail: var(--zero-color-theme-hue) 18% 8%;
+  --zero-nav-foreground: var(--zero-color-theme-hue) 22% 90%;
+  --zero-nav-muted-foreground: var(--zero-color-theme-hue) 16% 64%;
+  --background-50: var(--gray-50);
+  --state-layer: var(--zero-color-theme-hue) 35% 82%;
+  --segment-selected: var(--gray-400);
+  --zero-color-theme-selected: color-mix(
+    in srgb,
+    hsl(var(--card)) 86%,
+    color-mix(
+        in srgb,
+        var(--zero-color-theme-anchor) 82%,
+        var(--zero-color-theme-companion)
+      )
+      14%
+  );
 }

--- a/turbo/apps/platform/src/views/not-found-page.tsx
+++ b/turbo/apps/platform/src/views/not-found-page.tsx
@@ -23,7 +23,7 @@ export function NotFoundPage() {
         </div>
 
         <div className="flex flex-col items-center px-6 pb-10 sm:px-10">
-          <p className="relative -mt-4 inline-flex h-8 items-center rounded-full border border-primary/20 bg-background px-3 text-xs font-semibold text-primary">
+          <p className="relative -mt-4 inline-flex h-8 items-center rounded-full border border-primary/20 bg-background px-3 text-xs font-semibold text-brand-text">
             404
           </p>
           <h1 className="mt-7 text-2xl font-semibold tracking-tight text-foreground">

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-editor-and-suggestions.test.tsx
@@ -302,7 +302,7 @@ describe("chat composer models", () => {
     const matchedSubstring = screen.getByText("research", {
       selector: "span",
     });
-    expect(matchedSubstring).toHaveClass("text-primary/60");
+    expect(matchedSubstring).toHaveClass("text-brand-text/60");
 
     await user.keyboard("{Enter}");
 
@@ -316,7 +316,7 @@ describe("chat composer models", () => {
       .find((element) => {
         return element.tagName.toLowerCase() === "span";
       });
-    expect(highlightedWorkflow).toHaveClass("text-primary");
+    expect(highlightedWorkflow).toHaveClass("text-brand-text");
   });
 
   it("matches slash skills by substring while prioritizing prefixes", async () => {
@@ -407,7 +407,9 @@ describe("chat composer models", () => {
     expect(mountedComposerText()).toContain(
       "https://www.vm0.ai/en/use-cases/pr-review",
     );
-    expect(editor.querySelector("span.text-primary")).not.toBeInTheDocument();
+    expect(
+      editor.querySelector("span.text-brand-text"),
+    ).not.toBeInTheDocument();
   });
 
   it("suggests threads from every agent with aligned agent avatars", async () => {
@@ -757,7 +759,7 @@ describe("chat composer models", () => {
     await waitFor(() => {
       expect(initialEditor).toHaveTextContent("/new-chat-workflow");
       expect(
-        initialEditor.querySelector("span.text-primary"),
+        initialEditor.querySelector("span.text-brand-text"),
       ).not.toBeInTheDocument();
     });
 
@@ -773,7 +775,7 @@ describe("chat composer models", () => {
 
     await waitFor(() => {
       expect(within(initialEditor).getByText("/new-chat-workflow")).toHaveClass(
-        "text-primary",
+        "text-brand-text",
       );
     });
     await expect(findComposerEditor()).resolves.toBe(initialEditor);
@@ -794,7 +796,7 @@ describe("chat composer models", () => {
       .find((element) => {
         return element.tagName.toLowerCase() === "span";
       });
-    expect(highlightedWorkflow).toHaveClass("text-primary");
+    expect(highlightedWorkflow).toHaveClass("text-brand-text");
   });
 
   it("keeps the latest workflow highlights when split-pane reloads resolve out of order", async () => {
@@ -942,7 +944,7 @@ describe("chat composer models", () => {
       .find((element) => {
         return element.tagName.toLowerCase() === "span";
       });
-    expect(highlightedWorkflow).toHaveClass("text-primary");
+    expect(highlightedWorkflow).toHaveClass("text-brand-text");
     releaseBarrierRequests.resolve();
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-picker.test.tsx
@@ -1311,7 +1311,7 @@ describe("chat composer templates", () => {
     });
     expect(voiceFiltersButton).not.toHaveClass(
       "border-primary/40",
-      "text-primary",
+      "text-brand-text",
     );
     await user.click(voiceFiltersButton);
     expect(screen.getByLabelText("Gender: Male")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/new-ui-feature-switch.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/new-ui-feature-switch.test.tsx
@@ -1,0 +1,101 @@
+import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { describe, expect, it } from "vitest";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function prepareDefaultAgent(): void {
+  context.mocks.data.agents([
+    {
+      agentId: AGENT_ID,
+      ownerId: "test-user-123",
+      displayName: "Zero",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      visibility: "public",
+    },
+  ]);
+}
+
+describe("new ui feature switch", () => {
+  it("leaves the app shell on the previous surfaces when the switch is off", async () => {
+    prepareDefaultAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    await screen.findByRole("textbox", { name: "Message" });
+
+    expect(document.documentElement.dataset.newUi).toBeUndefined();
+  });
+
+  it("moves the app shell onto the card layout when the switch is on", async () => {
+    prepareDefaultAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.NewUi]: true },
+    });
+
+    await screen.findByRole("textbox", { name: "Message" });
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.newUi).toBe("");
+    });
+  });
+
+  it("moves the minimal shell too so directed pages match the app", async () => {
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/permissions?connectorSlug=slack&permission=admin.analytics%3Aread&action=approve`,
+      featureSwitches: { [FeatureSwitchKey.NewUi]: true },
+    });
+
+    await screen.findByText("Unknown permission action: approve");
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.newUi).toBe("");
+    });
+  });
+
+  // The chat column and the gutter around the workspace card are one surface
+  // under the new shell, so the column's own right edge has to go: kept, it
+  // would run parallel to the card's border eight pixels away.
+  it("keeps the chat column's divider while the switch is off", async () => {
+    prepareDefaultAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    const column = await screen.findByTestId("chat-list-column");
+
+    expect(column.className).toContain("border-r-[0.7px]");
+  });
+
+  it("drops the chat column's divider once the switch is on", async () => {
+    prepareDefaultAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.NewUi]: true },
+    });
+
+    const column = await screen.findByTestId("chat-list-column");
+
+    await waitFor(() => {
+      expect(column.className).not.toContain("border-r-[0.7px]");
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/okou-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-maker.tsx
@@ -45,7 +45,7 @@ import {
 import { IconTooltipButton } from "../components/icon-tooltip.tsx";
 
 function getSparkleColors() {
-  return ["#ed4e01", "#E0B376", "#E26C9E", "#45A7A8", "#E0BB3C", "#FF990A"];
+  return ["#ffa500", "#E0B376", "#E26C9E", "#45A7A8", "#E0BB3C", "#FF990A"];
 }
 
 function generateParticles() {
@@ -63,7 +63,7 @@ function generateParticles() {
       x: xDir,
       y: yDir,
       size: 3 + rand() * 5,
-      color: colors[Math.floor(rand() * colors.length)] ?? "#ed4e01",
+      color: colors[Math.floor(rand() * colors.length)] ?? "#ffa500",
       delay: rand() * 0.15,
     };
   });
@@ -142,7 +142,7 @@ function StepOptions({
           type="button"
           className={cn(
             "flex flex-col items-center gap-1 rounded-full transition-all hover:scale-110",
-            isPicked && "scale-110 ring-2 ring-[#ed4e01] ring-offset-2",
+            isPicked && "scale-110 ring-2 ring-primary ring-offset-2",
           )}
           style={{
             animation: `avatar-option-appear 0.2s ease-out ${i * 0.05}s both`,
@@ -171,7 +171,7 @@ function StepOptions({
           type="button"
           className={cn(
             "rounded-full transition-all hover:scale-110",
-            isPicked && "scale-110 ring-2 ring-[#ed4e01] ring-offset-2",
+            isPicked && "scale-110 ring-2 ring-primary ring-offset-2",
           )}
           style={{
             animation: `avatar-option-appear 0.2s ease-out ${i * 0.05}s both`,
@@ -196,7 +196,7 @@ function StepOptions({
         type="button"
         className={cn(
           "rounded-full transition-all hover:scale-110",
-          isPicked && "scale-110 ring-2 ring-[#ed4e01] ring-offset-2",
+          isPicked && "scale-110 ring-2 ring-primary ring-offset-2",
         )}
         style={{
           animation: `avatar-option-appear 0.2s ease-out ${i * 0.05}s both`,

--- a/turbo/apps/platform/src/views/okou-page/avatar-template-picker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-template-picker.tsx
@@ -210,7 +210,7 @@ function CatalogFiltersPopover({
           {activeCount > 0 && (
             <button
               type="button"
-              className="text-xs font-medium text-primary hover:text-primary/80"
+              className="text-xs font-medium text-brand-text hover:text-brand-text/80"
               onClick={onClear}
             >
               {t(($) => {
@@ -807,7 +807,7 @@ function VoicePreviewControl({ voice }: { readonly voice: AvatarVideoVoice }) {
         disabled={!voice.sampleUrl}
         onClick={toggleVoicePreview}
         className={cn(
-          "flex size-11 shrink-0 items-center justify-center rounded-full border border-primary/15 bg-primary/10 text-primary transition-all hover:scale-105 hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-40",
+          "flex size-11 shrink-0 items-center justify-center rounded-full border border-primary/15 bg-primary/10 text-brand-text transition-all hover:scale-105 hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-40",
           "group-data-[playing=true]/voice:bg-primary group-data-[playing=true]/voice:text-primary-foreground",
         )}
       >
@@ -923,7 +923,7 @@ function AvatarVoiceCard({
             {recommended && (
               <span
                 id={recommendedDescriptionId}
-                className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary"
+                className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-brand-text"
               >
                 {t(($) => {
                   return $.artifacts.templates.recommended;

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -1564,7 +1564,7 @@ function WorkflowTemplateCard({
           className={cn(
             "ml-auto h-8 shrink-0 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             selected
-              ? "border-primary/40 bg-primary/10 text-primary"
+              ? "border-primary/40 bg-primary/10 text-brand-text"
               : "border-border bg-background text-foreground hover:bg-state-hover",
           )}
         >
@@ -4599,7 +4599,7 @@ function IllustrationTemplateCard({
           className={cn(
             "h-8 shrink-0 rounded-md border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             selected
-              ? "border-primary/40 bg-primary/10 text-primary"
+              ? "border-primary/40 bg-primary/10 text-brand-text"
               : "border-border bg-background text-foreground hover:bg-state-hover",
           )}
         >
@@ -7287,14 +7287,14 @@ function ConnectorTriggerIcons({
       })}
       {hasComputerUse && (
         <span className="relative shrink-0">
-          <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background text-primary zero-border sm:h-7 sm:w-7">
+          <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background text-brand-text zero-border sm:h-7 sm:w-7">
             <Monitor size={16} />
           </span>
         </span>
       )}
       {hasCloudBrowser && (
         <span className="relative shrink-0">
-          <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background text-primary zero-border sm:h-7 sm:w-7">
+          <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background text-brand-text zero-border sm:h-7 sm:w-7">
             <Globe size={16} />
           </span>
         </span>
@@ -8005,7 +8005,7 @@ function ComposerConnectorAccountChoices({
         className={choiceClassName}
         onClick={onUseDefault}
       >
-        <span className="flex h-4 w-4 shrink-0 items-center justify-center text-primary">
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center text-brand-text">
           {!selection ? <Check size={15} strokeWidth={2.5} /> : null}
         </span>
         <span className="min-w-0 flex-1">
@@ -8076,7 +8076,7 @@ function ComposerConnectorAccountChoices({
               onSelect(connection);
             }}
           >
-            <span className="flex h-4 w-4 shrink-0 items-center justify-center text-primary">
+            <span className="flex h-4 w-4 shrink-0 items-center justify-center text-brand-text">
               {checked ? <Check size={15} strokeWidth={2.5} /> : null}
             </span>
             <span className="min-w-0 flex-1">

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -524,7 +524,7 @@ function ArtifactsButtonInner({ thread }: { thread: ChatPanelSignals }) {
             iconSize="md"
             className={cn(
               "shrink-0 duration-150",
-              open && "bg-primary/10 text-primary hover:text-primary",
+              open && "bg-primary/10 text-brand-text hover:text-brand-text",
             )}
             aria-label={t(($) => {
               return $.chat.thread.openArtifacts;
@@ -582,7 +582,7 @@ export function AutomationMenuButton({
             iconSize="md"
             className={cn(
               "shrink-0 duration-150",
-              open && "bg-primary/10 text-primary hover:text-primary",
+              open && "bg-primary/10 text-brand-text hover:text-brand-text",
             )}
             aria-label={
               ariaLabel ??
@@ -626,7 +626,7 @@ function BrowserMenuButton({ thread }: { thread: ChatPanelSignals }) {
             iconSize="md"
             className={cn(
               "shrink-0 duration-150",
-              open && "bg-primary/10 text-primary hover:text-primary",
+              open && "bg-primary/10 text-brand-text hover:text-brand-text",
             )}
             aria-label={t(($) => {
               return $.chat.thread.openBrowser;
@@ -5642,9 +5642,9 @@ function AssistantErrorRecoveryCard({
       <div className="flex min-w-0 flex-[1_1_16rem] items-center gap-2.5">
         {recovery.kind === "usage-limit" ||
         recovery.kind === "execution-timeout" ? (
-          <Clock size={16} className="shrink-0 text-primary-950" />
+          <Clock size={16} className="shrink-0 text-brand-text" />
         ) : (
-          <Coffee size={16} className="shrink-0 text-primary-950" />
+          <Coffee size={16} className="shrink-0 text-brand-text" />
         )}
         <span className="shrink-0 text-[0.9375rem] font-medium leading-6">
           {title}

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
@@ -895,7 +895,7 @@ function ApiKeyProviderSection({
                   href={secretSignupUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="text-primary underline"
+                  className="text-brand-text underline"
                 >
                   {t(($) => {
                     return $.settings.models.policies.getKey;

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/usage-pack-pricing-page.tsx
@@ -1755,7 +1755,7 @@ function ManagedSubscriptionComparisonTooltip({
             backgroundColor: "hsl(var(--popover))",
             color: "hsl(var(--popover-foreground))",
             boxShadow:
-              "0 2px 12px hsl(220 12% 50% / 0.04), 0 0 0 0.5px hsl(220 12% 50% / 0.02)",
+              "0 2px 12px hsl(30 6% 45% / 0.05), 0 0 0 0.5px hsl(30 6% 45% / 0.025)",
           }}
         >
           <p className="text-sm font-medium text-foreground">

--- a/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
@@ -372,7 +372,7 @@ function OAuthAccountRow({
         </Button>
         <div className="flex min-w-0 flex-1 items-center gap-2">
           {plan ? (
-            <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary">
+            <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-brand-text">
               {plan}
             </span>
           ) : null}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-card.tsx
@@ -633,7 +633,7 @@ function OnboardingConnectorCard({
         </p>
       </div>
       {connected ? (
-        <span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-primary">
+        <span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-brand-text">
           <CircleCheck size={16} aria-hidden="true" />
           {t(($) => {
             return $.connectors.card.connected;

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-help-text.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-help-text.tsx
@@ -2,7 +2,7 @@ import { cn } from "@okouai/ui";
 import type { ReactNode } from "react";
 
 const DEFAULT_CONNECTOR_HELP_TEXT_CLASS =
-  "text-sm text-muted-foreground leading-relaxed whitespace-pre-line [&_a]:text-primary [&_a]:underline";
+  "text-sm text-muted-foreground leading-relaxed whitespace-pre-line [&_a]:text-brand-text [&_a]:underline";
 
 function renderBoldConnectorHelpMarkdown(
   text: string,
@@ -50,7 +50,7 @@ function renderInlineConnectorHelpMarkdown(
         href={match[2]}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-primary underline"
+        className="text-brand-text underline"
       >
         {renderBoldConnectorHelpMarkdown(
           match[1],

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
@@ -95,7 +95,7 @@ function AppearanceBlock() {
                 className={cn(
                   "flex items-center gap-2 rounded-lg border border-[0.7px] px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                   isActive
-                    ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
+                    ? "border-primary/40 bg-primary/10 text-brand-text dark:border-primary/50 dark:bg-primary/15"
                     : "zero-chip text-muted-foreground hover:text-foreground",
                 )}
               >
@@ -178,7 +178,7 @@ function EnterBlock() {
                 className={cn(
                   "flex items-center gap-2 rounded-lg border border-[0.7px] px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                   isActive
-                    ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
+                    ? "border-primary/40 bg-primary/10 text-brand-text dark:border-primary/50 dark:bg-primary/15"
                     : "zero-chip text-muted-foreground hover:text-foreground",
                   saving !== null && "opacity-60 cursor-not-allowed",
                 )}

--- a/turbo/apps/platform/src/views/okou-page/composer-video-options.tsx
+++ b/turbo/apps/platform/src/views/okou-page/composer-video-options.tsx
@@ -234,7 +234,7 @@ function VideoDurationField({
     <div className="flex flex-col gap-2">
       <div className="flex items-baseline justify-between gap-3">
         <span className="text-[13px] text-muted-foreground">{label}</span>
-        <span className="text-[13px] font-medium tabular-nums text-primary">
+        <span className="text-[13px] font-medium tabular-nums text-brand-text">
           {value}
         </span>
       </div>

--- a/turbo/apps/platform/src/views/okou-page/directed-shared.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-shared.tsx
@@ -15,6 +15,7 @@ import { AccountDropdown } from "./sidebar-account";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   applyColorThemeDocumentAttributes,
+  applyNewUiDocumentAttribute,
   applyTypefaceDocumentAttribute,
   colorTheme$,
 } from "../../signals/theme.ts";
@@ -29,6 +30,7 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
     features[FeatureSwitchKey.GradientColorThemes] ?? false;
   const geistTypefaceEnabled =
     features[FeatureSwitchKey.GeistTypeface] ?? false;
+  const newUiEnabled = features[FeatureSwitchKey.NewUi] ?? false;
 
   return (
     <div
@@ -40,6 +42,7 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
         applyTypefaceDocumentAttribute(
           element !== null && geistTypefaceEnabled,
         );
+        applyNewUiDocumentAttribute(element !== null && newUiEnabled);
       }}
       className="zero-app zero-viewport-shell flex w-full bg-background"
       data-gradient-color-themes={gradientColorThemesEnabled || undefined}
@@ -64,7 +67,7 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
           />
         </div>
       </aside>
-      <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">
+      <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg zero-workspace-card">
         {children}
       </div>
     </div>

--- a/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
+++ b/turbo/apps/platform/src/views/okou-page/growth-entry.tsx
@@ -165,7 +165,7 @@ function GrowthEntry({ slackInstalled }: { slackInstalled: boolean }) {
           {leadIsSlack ? (
             <SlackMark size={16} />
           ) : (
-            <PlusCircle className="text-primary" />
+            <PlusCircle className="text-brand-text" />
           )}
           <span className="text-[13px] font-medium">
             {leadIsSlack

--- a/turbo/apps/platform/src/views/okou-page/intro-video-wizard.tsx
+++ b/turbo/apps/platform/src/views/okou-page/intro-video-wizard.tsx
@@ -218,7 +218,7 @@ function WizardStepButton({
       className={cn(
         "flex shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         active
-          ? "bg-primary/10 text-primary"
+          ? "bg-primary/10 text-brand-text"
           : completed
             ? "text-foreground hover:bg-state-hover"
             : "text-muted-foreground hover:bg-state-hover disabled:pointer-events-none disabled:opacity-45",
@@ -230,7 +230,7 @@ function WizardStepButton({
           active
             ? "border-primary bg-primary text-primary-foreground"
             : completed
-              ? "border-primary/30 bg-primary/10 text-primary"
+              ? "border-primary/30 bg-primary/10 text-brand-text"
               : "border-border bg-background",
         )}
       >
@@ -260,7 +260,7 @@ function SourceChoice({
       onClick={onClick}
       className="group flex min-h-32 min-w-0 items-start gap-4 rounded-xl border border-border bg-card p-4 text-left transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
-      <span className="grid size-11 shrink-0 place-items-center rounded-xl bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+      <span className="grid size-11 shrink-0 place-items-center rounded-xl bg-primary/10 text-brand-text transition-colors group-hover:bg-primary/15">
         {icon}
       </span>
       <span className="min-w-0">
@@ -435,7 +435,7 @@ function DesktopStep({
 }) {
   return (
     <li className="flex items-start gap-3 py-3">
-      <span className="mt-0.5 grid size-6 shrink-0 place-items-center rounded-full bg-primary/10 text-xs font-medium text-primary">
+      <span className="mt-0.5 grid size-6 shrink-0 place-items-center rounded-full bg-primary/10 text-xs font-medium text-brand-text">
         {index}
       </span>
       <span className="min-w-0">
@@ -498,7 +498,7 @@ function DesktopRecordPage() {
           </div>
           <div className="grid min-h-48 place-items-center p-6 text-center">
             <div>
-              <MonitorUp className="mx-auto size-9 text-primary" />
+              <MonitorUp className="mx-auto size-9 text-brand-text" />
               <p className="mt-3 text-sm font-semibold text-foreground">
                 {t(
                   ($) => {
@@ -587,7 +587,7 @@ function SourceReviewPage({ source }: { readonly source: IntroVideoSource }) {
           />
         ) : (
           <div className="text-center">
-            <span className="mx-auto grid size-16 place-items-center rounded-2xl bg-primary/10 text-primary">
+            <span className="mx-auto grid size-16 place-items-center rounded-2xl bg-primary/10 text-brand-text">
               <FileText size={28} />
             </span>
             <div className="mx-auto mt-5 flex w-44 flex-col gap-2">
@@ -610,7 +610,7 @@ function SourceReviewPage({ source }: { readonly source: IntroVideoSource }) {
           })}
         </p>
         <div className="mt-5 flex items-center gap-3 rounded-xl border border-border bg-card p-3">
-          <span className="grid size-10 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary">
+          <span className="grid size-10 shrink-0 place-items-center rounded-lg bg-primary/10 text-brand-text">
             {source.kind === "video" ? (
               <Play size={18} fill="currentColor" />
             ) : (
@@ -903,7 +903,7 @@ function VoiceUtilityCard({
         selected ? "border-primary bg-primary/[0.04]" : "border-border",
       )}
     >
-      <span className="grid size-11 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
+      <span className="grid size-11 shrink-0 place-items-center rounded-full bg-primary/10 text-brand-text">
         {icon}
       </span>
       <span className="min-w-0 flex-1">
@@ -1004,7 +1004,7 @@ function ReviewItem({
 }) {
   return (
     <div className="flex items-center gap-3 rounded-xl border border-border bg-card p-3">
-      <span className="grid size-10 shrink-0 place-items-center rounded-lg bg-primary/10 text-primary">
+      <span className="grid size-10 shrink-0 place-items-center rounded-lg bg-primary/10 text-brand-text">
         {icon}
       </span>
       <span className="min-w-0">

--- a/turbo/apps/platform/src/views/okou-page/mail-draft-sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/mail-draft-sidebar.tsx
@@ -930,7 +930,7 @@ function MailDraftRichMessage({
       data-feedback-source-id={signals.mailDraftId}
       data-feedback-source-status={draft.status === "draft" ? "draft" : "sent"}
       data-feedback-source-sent-id={draft.sentGmailMessageId}
-      className="break-words text-sm leading-6 text-foreground [&_a]:text-primary [&_a]:underline [&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:font-semibold [&_hr]:my-3 [&_li]:ml-5 [&_ol]:list-decimal [&_p]:my-2 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:whitespace-pre-wrap [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_table]:my-2 [&_table]:block [&_table]:max-w-full [&_table]:overflow-x-auto [&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-border [&_th]:px-2 [&_th]:py-1 [&_ul]:list-disc"
+      className="break-words text-sm leading-6 text-foreground [&_a]:text-brand-text [&_a]:underline [&_blockquote]:my-2 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_h1]:text-xl [&_h1]:font-semibold [&_h2]:text-lg [&_h2]:font-semibold [&_h3]:font-semibold [&_hr]:my-3 [&_li]:ml-5 [&_ol]:list-decimal [&_p]:my-2 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:whitespace-pre-wrap [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_table]:my-2 [&_table]:block [&_table]:max-w-full [&_table]:overflow-x-auto [&_td]:border [&_td]:border-border [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-border [&_th]:px-2 [&_th]:py-1 [&_ul]:list-disc"
     >
       {Array.from(document.body.childNodes).map((node, index) => {
         return renderMailHtmlNode({

--- a/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
@@ -486,7 +486,7 @@ export function SettingsTab({
                         className={cn(
                           "w-full min-w-0 rounded-lg border border-[0.7px] px-3 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                           tone === opt
-                            ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
+                            ? "border-primary/40 bg-primary/10 text-brand-text dark:border-primary/50 dark:bg-primary/15"
                             : "zero-chip text-muted-foreground hover:text-foreground",
                         )}
                       >

--- a/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
@@ -51,6 +51,7 @@ import { lightboxUrl$ } from "../../signals/okou-page/attachment-chips.ts";
 import { AttachmentLightbox } from "./attachment-chips.tsx";
 import {
   applyColorThemeDocumentAttributes,
+  applyNewUiDocumentAttribute,
   applyTypefaceDocumentAttribute,
   colorTheme$,
 } from "../../signals/theme.ts";
@@ -119,7 +120,7 @@ function MobileArtifactsButtonInner({ thread }: { thread: ChatPanelSignals }) {
       size="icon-sm"
       className={cn(
         "shrink-0",
-        open && "bg-primary/10 text-primary hover:text-primary",
+        open && "bg-primary/10 text-brand-text hover:text-brand-text",
       )}
       aria-label={t(($) => {
         return $.appShell.sidebar.mobile.openArtifacts;
@@ -374,6 +375,7 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
     features[FeatureSwitchKey.GradientColorThemes] ?? false;
   const geistTypefaceEnabled =
     features[FeatureSwitchKey.GeistTypeface] ?? false;
+  const newUiEnabled = features[FeatureSwitchKey.NewUi] ?? false;
   const isDesktop = useMediaQuery(SIDEBAR_DESKTOP_MEDIA_QUERY);
 
   return (
@@ -386,6 +388,7 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
         applyTypefaceDocumentAttribute(
           element !== null && geistTypefaceEnabled,
         );
+        applyNewUiDocumentAttribute(element !== null && newUiEnabled);
       }}
       className="zero-app zero-viewport-shell flex w-full bg-background"
       data-gradient-color-themes={gradientColorThemesEnabled || undefined}
@@ -399,7 +402,7 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
       <AttachmentLightboxMount />
       <QueueDrawer />
       {isDesktop ? <Sidebar isDesktop /> : <MobileSidebarMount />}
-      <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">
+      <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg zero-workspace-card">
         <InstallBanner />
         <IosInstallModal />
         {!isDesktop && <MobileTopBar />}

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -395,7 +395,7 @@ function PinnedAgentGridCard({
         <span
           aria-hidden="true"
           data-testid="pinned-agent-drop-caret"
-          className={`pointer-events-none absolute inset-y-0 z-10 w-0.5 rounded-full bg-[hsl(var(--primary-700))] ${
+          className={`pointer-events-none absolute inset-y-0 z-10 w-0.5 rounded-full bg-primary ${
             dropSide === "before" ? "-left-[3px]" : "-right-[3px]"
           }`}
         />

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useLastResolved, useGet, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   LayoutGrid,
   Package,
@@ -61,6 +62,7 @@ import { SidebarUpgradeCard } from "./sidebar-upgrade.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { InstatusStatusNotice } from "../components/instatus-status-notice.tsx";
 import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 
@@ -642,7 +644,7 @@ function LabeledNavRail() {
   return (
     <aside
       data-testid="labeled-nav-rail"
-      className="zero-nav zero-nav-rail hidden md:flex h-full w-[68px] shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-gray-50 px-1.5 pb-2 pt-3"
+      className="zero-nav zero-nav-rail hidden md:flex h-full w-[68px] shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar-rail px-1.5 pb-2 pt-3"
     >
       <div className="zero-desktop-titlebar-drag-region" aria-hidden="true" />
       <div className="mb-3 shrink-0">
@@ -724,6 +726,7 @@ function ThreeColumnSearchDialogContainer() {
 }
 
 function ChatListColumn() {
+  const newUiEnabled = useGet(featureSwitch$)[FeatureSwitchKey.NewUi] ?? false;
   const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;
   const navigate = useSet(detachedNavigateTo$);
   const openThreeColumnSearch = useSet(openThreeColumnSearchDialog$);
@@ -746,7 +749,13 @@ function ChatListColumn() {
   return (
     <aside
       data-testid="chat-list-column"
-      className="zero-nav hidden md:flex h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar"
+      className={cn(
+        "zero-nav hidden md:flex h-full w-[300px] shrink-0 flex-col bg-sidebar",
+        // Under the new shell this column and the gutter around the workspace
+        // card are one surface, so a divider here would run parallel to the
+        // card's own border eight pixels away and read as a double rule.
+        !newUiEnabled && "border-r-[0.7px] border-sidebar-border",
+      )}
     >
       <div className="flex shrink-0 items-center gap-1 px-3 pb-2 pt-3">
         <span className="zero-nav-copy flex-1 pl-2 text-[15px] font-semibold text-sidebar-foreground">

--- a/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
@@ -119,10 +119,10 @@ export function SlashWorkflowMenu({
                 }}
               >
                 <span className="w-full truncate font-mono text-sm text-foreground">
-                  <span className="text-primary">/</span>
+                  <span className="text-brand-text">/</span>
                   {workflow.name.slice(0, matchStart)}
                   {query && matchStart !== -1 && (
-                    <span className="text-primary/60">
+                    <span className="text-brand-text/60">
                       {workflow.name.slice(matchStart, matchEnd)}
                     </span>
                   )}

--- a/turbo/apps/platform/src/views/okou-page/start-cards.tsx
+++ b/turbo/apps/platform/src/views/okou-page/start-cards.tsx
@@ -418,7 +418,7 @@ function IntroVideoStartCard({ onOpen }: { readonly onOpen: () => void }) {
       className="zero-card group relative flex min-h-28 items-center gap-3 overflow-hidden p-4 text-left transition-all hover:-translate-y-0.5 hover:border-primary/30 hover:bg-primary/[0.025] hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <span className="pointer-events-none absolute -right-8 -top-10 size-28 rounded-full bg-primary/[0.06] blur-2xl" />
-      <span className="grid size-[72px] shrink-0 place-items-center rounded-xl bg-primary/10 text-primary">
+      <span className="grid size-[72px] shrink-0 place-items-center rounded-xl bg-primary/10 text-brand-text">
         <span className="grid size-9 place-items-center rounded-lg bg-primary text-primary-foreground shadow-sm transition-transform group-hover:scale-105">
           <Clapperboard size={18} />
         </span>

--- a/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-shell.tsx
@@ -94,7 +94,7 @@ export function OnboardingFooter({
       {onBack ? (
         <button
           type="button"
-          className="h-10 border-0 bg-transparent px-0 text-sm font-medium text-primary hover:text-[hsl(var(--primary-800))]"
+          className="h-10 border-0 bg-transparent px-0 text-sm font-medium text-brand-text hover:text-brand-text-hover"
           onClick={onBack}
         >
           {t(($) => {
@@ -112,7 +112,7 @@ export function OnboardingFooter({
           aria-busy={busy}
           variant="default"
           size="lg"
-          className="min-w-[100px] gap-2 disabled:bg-[hsl(var(--primary-500))]"
+          className="min-w-[100px] gap-2 disabled:bg-[hsl(var(--primary-100))]"
         >
           {busy ? (
             <Loader2 size={16} className="animate-spin" aria-hidden="true" />

--- a/turbo/apps/platform/src/views/onboarding/onboarding-template-picker-pages.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-template-picker-pages.tsx
@@ -33,7 +33,7 @@ function SelectionCheck({ selected }: { readonly selected: boolean }) {
   return selected ? (
     <CircleCheckBig
       size={18}
-      className="shrink-0 text-primary"
+      className="shrink-0 text-brand-text"
       aria-hidden="true"
     />
   ) : null;

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-picker-page.tsx
@@ -224,7 +224,7 @@ function WorkflowCard({
         <WorkflowConnectorPills connectorSlugs={workflow.connectorSlugs} />
         <IconTooltipButton
           type="button"
-          className="ml-auto inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/30 text-muted-foreground hover:border-primary/35 hover:bg-gray-50 hover:text-primary dark:hover:bg-gray-50/10"
+          className="ml-auto inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/30 text-muted-foreground hover:border-primary/35 hover:bg-gray-50 hover:text-brand-text dark:hover:bg-gray-50/10"
           aria-label={t(($) => {
             return $.onboarding.common.previewWorkflowDetails;
           })}
@@ -236,7 +236,7 @@ function WorkflowCard({
       {selected ? (
         <CircleCheckBig
           size={18}
-          className="absolute right-3 top-3 text-primary"
+          className="absolute right-3 top-3 text-brand-text"
           aria-hidden="true"
         />
       ) : null}
@@ -286,7 +286,7 @@ function WorkflowOptions({
             "border-solid border-primary text-foreground",
         )}
       >
-        <span className="flex h-9 w-9 items-center justify-center rounded-[10px] bg-muted/40 text-primary">
+        <span className="flex h-9 w-9 items-center justify-center rounded-[10px] bg-muted/40 text-brand-text">
           <MessageSquarePlus size={19} aria-hidden="true" />
         </span>
         <span className="text-sm font-semibold text-foreground">

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-run-page.tsx
@@ -107,7 +107,7 @@ export function OnboardingWorkflowRunPage() {
               />
               <IconTooltipButton
                 type="button"
-                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/30 text-muted-foreground hover:border-primary/35 hover:text-primary"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/30 text-muted-foreground hover:border-primary/35 hover:text-brand-text"
                 aria-label={t(($) => {
                   return $.onboarding.common.previewWorkflowDetails;
                 })}

--- a/turbo/apps/platform/src/views/pwa-install/install-banner.tsx
+++ b/turbo/apps/platform/src/views/pwa-install/install-banner.tsx
@@ -33,7 +33,7 @@ export function InstallBanner() {
 
   return (
     <div className="shrink-0 flex items-center gap-2 bg-primary/5 border-b border-primary/20 px-3 py-2 text-sm">
-      <Download size={16} className="text-primary shrink-0" />
+      <Download size={16} className="text-brand-text shrink-0" />
       <span className="flex-1 min-w-0 truncate text-foreground">
         {t(($) => {
           return $.lifecycle.pwaInstall.banner;

--- a/turbo/apps/platform/src/views/unsupported-browser-page.tsx
+++ b/turbo/apps/platform/src/views/unsupported-browser-page.tsx
@@ -62,12 +62,12 @@ export function UnsupportedBrowserPage({
               stroke="currentColor"
               strokeLinecap="round"
               strokeWidth="2.5"
-              className="text-primary"
+              className="text-brand-text"
             />
             <path
               d="m24 11 1 4-4 1M16 29l-1-4 4-1"
               fill="currentColor"
-              className="text-primary"
+              className="text-brand-text"
             />
           </svg>
         </div>

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -75,4 +75,5 @@ export enum FeatureSwitchKey {
   IosPwaStartupImages = "iosPwaStartupImages",
   GeistTypeface = "geistTypeface",
   SocialDownloadDetectedMediaType = "socialDownloadDetectedMediaType",
+  NewUi = "newUi",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -476,6 +476,14 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.NewUi]: {
+    maintainer: "ming@vm0.ai",
+    description:
+      "Lay the workspace out as a card floating on the shell's grey, with the two sidebars on the site's own greys and a brand-hued composer focus ring in dark.",
+    enabled: false,
+    // Ming only while the shell settles; widen once the layout is signed off.
+    enabledEmailHashes: ["54757055"], // fnv1a("ming@vm0.ai")
+  },
 };
 
 interface ResolvedHashes {

--- a/turbo/packages/ui/src/components/ui/button.tsx
+++ b/turbo/packages/ui/src/components/ui/button.tsx
@@ -25,13 +25,13 @@ const buttonVariants = cva(
           "border-[0.7px] border-[hsl(var(--gray-400))] bg-background hover:bg-state-hover active:bg-state-pressed text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary-hover active:bg-secondary-pressed",
-        ghost: "text-primary hover:bg-state-hover active:bg-state-pressed",
+        ghost: "text-brand-text hover:bg-state-hover active:bg-state-pressed",
         // Neutral counterpart to `ghost`, for chrome that must not read as an
         // action: toolbar and composer icons, which inherit the muted ramp and
         // only gain weight on hover.
         quiet:
           "text-muted-foreground hover:bg-state-hover hover:text-foreground active:bg-state-pressed",
-        link: "text-primary underline-offset-4 hover:underline active:text-primary/80",
+        link: "text-brand-text underline-offset-4 hover:underline active:text-brand-text/80",
       },
       size: {
         xs: "h-7 px-2.5",

--- a/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
+++ b/turbo/packages/ui/src/components/ui/multi-select-combobox.tsx
@@ -193,7 +193,7 @@ export function MultiSelectCombobox({
                   )}
                   <span className="flex-1 text-left">{opt.label}</span>
                   {isSelected && (
-                    <Check size={16} className="shrink-0 text-primary" />
+                    <Check size={16} className="shrink-0 text-brand-text" />
                   )}
                 </button>
               );

--- a/turbo/packages/ui/src/styles/__tests__/globals.test.ts
+++ b/turbo/packages/ui/src/styles/__tests__/globals.test.ts
@@ -77,14 +77,25 @@ describe("global focus colors", () => {
     );
   });
 
-  it("resolves the focus color from each theme's primary scale", () => {
-    expect(globalCss).toMatch(
-      /:root\s*{[\s\S]*?--primary-600:\s*15 80% 66%;[\s\S]*?--ring:\s*var\(--primary-600\);/,
-    );
-    expect(globalCss).toMatch(
-      /\[data-theme="dark"\]\s*{[\s\S]*?--primary-600:\s*16 62% 41%;[\s\S]*?--ring:\s*var\(--primary-600\);/,
-    );
-  });
+  it.each(THEMES)(
+    "resolves $name's focus color from the primary scale",
+    ({ selector }) => {
+      const theme = readRuleBody(globalCss, selector);
+      const ring = /--ring:\s*var\(--(primary-\d+)\);/.exec(theme);
+
+      expect(ring).not.toBeNull();
+      // The stop each theme reaches for is a design choice and moves with the
+      // palette; what must hold is that it is a stop, not a loose literal.
+      const declaration = theme
+        .split("\n")
+        .find((line) => {
+          return line.trimStart().startsWith(`--${ring?.[1] ?? ""}:`);
+        })
+        ?.trim();
+
+      expect(declaration).toMatch(/^--primary-\d+:\s*[\d.]+ [\d.]+% [\d.]+%;/);
+    },
+  );
 });
 
 describe("global Lucide defaults", () => {

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -8,7 +8,41 @@
  * Based on Figma: https://www.figma.com/design/eTWIsjktpymTDYEb55OxXx/VM0-Cloud
  *
  * Typography: Noto Sans
- * Primary Color: #ed4e01 (Orange)
+ * Primary Color: #ffa500 (Amber)
+ *
+ * The two primitive scales below are the published palette:
+ * https://zero-design-color.sites.vm0.io
+ *
+ * `--gray-*` carries Sand, one neutral anchored at both ends (Linen and Ink) so
+ * the product has no cool grey. `--primary-*` carries Amber, whose brand stop is
+ * `--primary-300` (#ffa500) rather than the 700 the old orange used, because
+ * that scale is adopted stop-for-stop from the palette.
+ *
+ * Sand is the one deliberate deviation, and the reason is a ratio rather than a
+ * quantity. Take any warm neutral and ask where green sits relative to the
+ * midpoint of red and blue: above it the colour reads as cream, below it as
+ * magenta. Slack's warm chrome is rgb(253,242,217) -- a red-to-blue spread of
+ * 36, six times ours, and comfortable to look at because its green sits +7 above
+ * that midpoint, a ratio of +0.19. Sand as published is the opposite sign:
+ * Linen is #faf5f3, spread 7, green 1.5 *under*, a ratio of -0.21. Small, and
+ * unmissable once it fills a surface.
+ *
+ * Every stop is therefore rotated to hue 42.9, which reproduces Slack's ratio at
+ * our own chroma. Rotating hue at fixed S and L cannot change chroma
+ * (C = (1-|2L-1|)*S has no hue term), so each stop keeps its exact lightness and
+ * its exact red-to-blue spread; only the green channel moves, by one or two.
+ *
+ * Linen moves with them: the brand neutral is #faf8f3, and it is `--gray-100`.
+ * The published #faf5f3 is the same lightness and the same spread with green
+ * three lower, and is superseded rather than kept alongside -- a brand colour
+ * the ramp cannot contain is a brand colour the product cannot use.
+ *
+ * The other half of Slack's harmony is placement: it spends that saturated cream
+ * on 3.6% of the frame and leaves 57% pure white. Warmth belongs on chrome, not
+ * on fields -- which is why the canvas is white and `--muted` is nearly so.
+ *
+ * Amber is a light fill: it takes Ink text, never white (8.09:1 vs 1.97:1).
+ * That is why `--primary-foreground` is Ink in both themes.
  */
 
 /* Define theme colors and typography for Tailwind v4 */
@@ -89,12 +123,26 @@
   --color-card: hsl(var(--card));
   --color-card-foreground: hsl(var(--card-foreground));
   --color-sidebar: hsl(var(--sidebar));
+  --color-sidebar-rail: hsl(var(--sidebar-rail));
   --color-sidebar-foreground: hsl(var(--sidebar-foreground));
   --color-sidebar-primary: hsl(var(--sidebar-primary));
   --color-sidebar-primary-foreground: hsl(var(--sidebar-primary-foreground));
   --color-semantic-foreground: hsl(var(--semantic-foreground));
   --color-on-filled: hsl(var(--on-filled));
   --color-background-50: hsl(var(--background-50));
+
+  /* ===================================
+   * Brand Tint / Brand Text
+   *
+   * The Amber scale is no longer mirrored between themes, so a raw stop like
+   * `primary-100` is a pale tint in light and still a pale tint in dark, where
+   * it would blow out. These two are theme-aware: reach for them wherever the
+   * brand appears as a wash behind text or as text itself, and keep the raw
+   * stops for fills that already pair with `--primary-foreground`.
+   * =================================== */
+  --color-brand-subtle: hsl(var(--brand-subtle));
+  --color-brand-text: hsl(var(--brand-text));
+  --color-brand-text-hover: hsl(var(--brand-text-hover));
 
   /* Radius */
   --radius-xl: 14px;
@@ -337,6 +385,15 @@
       0 1px 2px hsl(220 12% 20% / 0.06), 0 1px 3px hsl(220 12% 20% / 0.08);
 
     --radius: 0.5rem;
+
+    /* The four tokens the Amber scale introduced, mapped onto this palette so
+       every call site that switched to them renders identically with the
+       switch off. `--brand-text` is simply the brand stop here, because the
+       orange ramp mirrors between themes and needs no theme-aware indirection. */
+    --brand-subtle: var(--primary-50);
+    --brand-text: var(--primary-700);
+    --brand-text-hover: var(--primary-800);
+    --sidebar-rail: var(--gray-50);
   }
 
   .dark,
@@ -444,6 +501,314 @@
        much quieter cool (hue 240 at 3% saturation), so the layer matches that
        hue and stays just saturated enough to hold it as the alpha climbs. */
     --state-layer: 240 100% 97%;
+
+    --state-hover-alpha: 7%;
+    --state-selected-alpha: 12%;
+    --state-selected-hover-alpha: 16%;
+    --state-pressed-alpha: 19%;
+    --state-on-filled-hover-alpha: 12%;
+    --state-on-filled-pressed-alpha: 20%;
+
+    /* Segment control (dark): the selection steps *up* the grey ramp from the
+       gray-200 track, and the veil turns black so it still reads as a lift. */
+    --segment-selected: var(--gray-400);
+    --segment-selected-shadow:
+      0 1px 3px hsl(0 0% 0% / 0.3), 0 2px 6px hsl(0 0% 0% / 0.2);
+
+    /* See the light block: same four bridge tokens on this palette's own stops. */
+    --brand-subtle: var(--primary-50);
+    --brand-text: var(--primary-700);
+    --brand-text-hover: var(--primary-800);
+    --sidebar-rail: var(--gray-50);
+  }
+
+  /* ===================================
+   * Sand / Amber, behind the `newUi` switch
+   *
+   * Both selectors match the same <html> the blocks above do, and win on
+   * specificity, so every `@theme` alias -- which is a lazy `hsl(var(--x))`
+   * reference resolved per element -- follows without being restated. The
+   * palette therefore switches per user with no duplication below this point.
+   *
+   * Three surfaces cannot follow: the boot skeleton in `index.html`, the
+   * automation-result email, and `apps/desktop`. They render before this
+   * stylesheet loads or outside the browser, so they stay on the current brand
+   * and will read as a mismatch while the switch is on. Delete this whole
+   * section, and the bridge tokens above, when the palette graduates.
+   * =================================== */
+  :root[data-new-ui] {
+    /* ===================================
+     * Base Color Palette (Tailwind Style)
+     * =================================== */
+
+    /* Primary Color Scale (Amber). Adopted stop-for-stop from the palette, so
+       the brand colour is 300 and the scale darkens monotonically from there.
+       Only `--primary-0` is generated, above the published 50. */
+    --primary-0: 31.4 100% 97.5%; /* #FFF9F2 */
+    --primary-50: 31.4 100% 91.4%; /* #FFEAD3 */
+    --primary-100: 31.6 100% 85.5%; /* #FFDCB5 */
+    --primary-200: 32.6 100% 75.1%; /* #FFC580 */
+    --primary-300: 38.8 100% 50%; /* #FFA500 - brand */
+    --primary-400: 38.7 100% 44.1%; /* #E19100 */
+    --primary-500: 38.5 100% 38.2%; /* #C37D00 */
+    --primary-600: 38.3 100% 32.5%; /* #A66A00 */
+    --primary-700: 37.9 100% 26.7%; /* #885600 */
+    --primary-800: 37.2 100% 21.2%; /* #6C4300 */
+    --primary-900: 35.5 81.6% 17.1%; /* #4F3208 */
+    --primary-950: 33.2 63.3% 11.8%; /* #31200B */
+
+    /* Background/Gray Color Scale (Sand — warm neutral, dual-anchored on
+       Linen and Ink, both rotated to hue 42.9 for harmony: #FAF8F3 and #242321.
+       Only `--gray-0` is generated, above the published 50. */
+    --gray-0: 42.9 41.2% 98.8%; /* #FDFCFB */
+    --gray-50: 42.9 17% 97.7%; /* #FAFAF8 - default neutral fill */
+    --gray-100: 42.9 41.2% 96.7%; /* #FAF8F3 */
+    --gray-200: 42.9 5.5% 92.9%; /* #EEEDEC */
+    --gray-300: 42.9 7.5% 86.9%; /* #E0DFDB */
+    --gray-400: 42.9 2.9% 84%; /* #D7D7D5 */
+    --gray-500: 42.9 1.6% 62.2%; /* #A09F9D */
+    --gray-600: 42.9 1.2% 52.7%; /* #888785 */
+    --gray-700: 42.9 1.4% 42.9%; /* #6F6E6C */
+    --gray-800: 42.9 1.8% 33.1%; /* #565553 */
+    --gray-900: 42.9 2.5% 23.3%; /* #3D3C3A */
+    --gray-950: 42.9 4.3% 13.5%; /* #242321 - Ink */
+
+    /* Divider Color */
+    --divider: 42.9 7.5% 94.8%; /* #F3F2F1 - between Sand 100 and 200 */
+
+    /* Theme-aware Colors */
+    --white: 0 0% 100%; /* #FFFFFF */
+    --black: 42.9 4.3% 13.5%; /* #242321 - Ink */
+
+    /* Dialog scrim. Deliberately NOT theme-aware: --black inverts to #FFFFFF
+       in dark, which would lighten the backdrop instead of dimming it. The
+       dark theme reuses this value and only raises the alpha. */
+    --overlay: 42.9 4.3% 13.5%; /* #242321 - Ink */
+
+    /* ===================================
+     * Semantic Colors (Light Theme)
+     * =================================== */
+    /* The page sits one step above the ramp, because `gray-50` is the app's
+       neutral *fill* (chips, icon containers, inset panels, mobile bars). If
+       the page took gray-50 as well, every one of those fills would vanish
+       against it. Linen sits one step below at gray-100, carrying the heavier
+       chrome -- sidebar, muted, accent, secondary.
+
+       The canvas is white and untinted. It is over half of a chat frame, and
+       everything else is read against it, so warmth there reads as dirt
+       rather than as character. Cards are white too and sit flush with it,
+       read from their border and shadow the way the design reference does.
+       `gray-50` and `gray-200` sit on the canvas and keep only a trace of
+       warmth; `gray-0` and Linen are chrome and keep theirs. */
+    --background: 0 0% 100%; /* #FFFFFF - the canvas carries no tint */
+    --foreground: var(--gray-950); /* gray-950 */
+
+    --card: var(--white); /* white */
+    --card-foreground: var(--gray-950); /* gray-950 */
+
+    --popover: var(--white); /* white */
+    --popover-foreground: var(--gray-950); /* gray-950 */
+
+    --primary: var(--primary-300); /* primary-300 - brand */
+    /* Amber is a light fill and cannot carry white text (1.97:1). Ink clears
+       8.09:1 and is the same in both themes, because the fill is too. */
+    --primary-foreground: 42.9 4.3% 13.5%; /* #242321 - Ink on brand */
+
+    --secondary: 42.9 41.2% 96.7%; /* gray-100 - direct value for opacity modifier support */
+    --secondary-foreground: var(--gray-950); /* gray-950 */
+
+    --muted: var(--gray-100); /* gray-100 */
+    --muted-foreground: var(--gray-800); /* gray-800 */
+
+    --accent: var(--gray-100); /* gray-100 - matches navigation hover */
+    --accent-foreground: var(--gray-950); /* gray-950 */
+
+    --destructive: 16.9 100% 36.9%; /* #BC3500 - Coral 700 */
+    --destructive-foreground: var(
+      --on-filled
+    ); /* on-filled - white text on destructive */
+
+    --border: var(--gray-200); /* gray-200 - primary border color (lighter) */
+    --input: var(--white); /* white - same as card */
+    --ring: var(--primary-400); /* primary-400 - readable ring against Amber */
+
+    /* Brand as a wash and as text (published brand-subtle / brand-text). */
+    --brand-subtle: var(--primary-50); /* #FFEAD3 */
+    --brand-text: var(--primary-700); /* #885600 */
+    --brand-text-hover: var(--primary-800); /* #6C4300 */
+
+    /* Text on filled/colored backgrounds (buttons, tooltips, badges) */
+    --on-filled: 0 0% 100%; /* Pure white for text on colored backgrounds */
+
+    /* Half the depth of the site's #FAF5F3 theme grey. This surface no longer
+       only backs the chat column: it also frames the workspace card, so it
+       reads as a border around white rather than as a panel beside it, and at
+       full strength that frame overpowered the sheet it holds. Lightness moves
+       to the midpoint with white while saturation holds, which halves the
+       channel spread by the same factor and keeps the hue intact. */
+    --sidebar: 17.1 41.2% 98.4%; /* #FDFAF9 - half of the theme grey */
+    --sidebar-rail: 17.1 17.9% 92.4%; /* #EFEAE8 - the site's nav grey */
+    --sidebar-foreground: var(--gray-950); /* gray-950 */
+    --sidebar-primary: var(--primary-800); /* primary-800 */
+    --sidebar-primary-foreground: var(--gray-50); /* gray-50 */
+    --semantic-foreground: var(--gray-0); /* gray-0 */
+
+    --background-50: var(
+      --gray-50
+    ); /* gray-50 - lighter background for code blocks */
+
+    /* Interaction state ladder (light).
+
+       The layer colour is chosen so that compositing it onto a surface lands
+       back on the neutral ramp rather than just darkening it. It is solved
+       from the step it has to produce: at `--state-hover-alpha` over a white
+       card this colour composites to gray-100's lightness, so every state
+       keeps Sand's warm cast instead of washing out to a flat grey. Sand
+       desaturates as it darkens while a fixed layer holds its chroma, so the
+       pressed step runs slightly warmer than gray-300 -- tune here if it ever
+       reads too peach. */
+    --state-layer: 42.9 21% 37.3%;
+
+    --state-hover-alpha: 5%;
+    --state-selected-alpha: 8.5%;
+    --state-selected-hover-alpha: 11.5%;
+    --state-pressed-alpha: 13%;
+    --state-on-filled-hover-alpha: 10%;
+    --state-on-filled-pressed-alpha: 16%;
+
+    /* Segment control (light): white lifts off the gray-100 track. */
+    --segment-selected: 0 0% 100%;
+    --segment-selected-shadow:
+      0 1px 2px hsl(30 4.3% 13.5% / 0.06), 0 1px 3px hsl(30 4.3% 13.5% / 0.08);
+
+    --radius: 0.5rem;
+  }
+
+  .dark[data-new-ui],
+  [data-theme="dark"][data-new-ui] {
+    /* ===================================
+     * Base Color Palette (Dark Theme)
+     * =================================== */
+
+    /* Primary Color Scale (Amber - Dark). The palette publishes one Amber, and
+       the brand fill is the same #FFA500 in both themes, so the scale is not
+       reversed here. Dark only reaches for different stops: the brand solid
+       stays 300, its hover steps *up* to 200, and 950 becomes the subtle fill. */
+    --primary-0: 31.4 100% 97.5%; /* #FFF9F2 */
+    --primary-50: 31.4 100% 91.4%; /* #FFEAD3 */
+    --primary-100: 31.6 100% 85.5%; /* #FFDCB5 */
+    --primary-200: 32.6 100% 75.1%; /* #FFC580 */
+    --primary-300: 38.8 100% 50%; /* #FFA500 - brand */
+    --primary-400: 38.7 100% 44.1%; /* #E19100 */
+    --primary-500: 38.5 100% 38.2%; /* #C37D00 */
+    --primary-600: 38.3 100% 32.5%; /* #A66A00 */
+    --primary-700: 37.9 100% 26.7%; /* #885600 */
+    --primary-800: 37.2 100% 21.2%; /* #6C4300 */
+    --primary-900: 35.5 81.6% 17.1%; /* #4F3208 */
+    --primary-950: 33.2 63.3% 11.8%; /* #31200B */
+
+    /* Background/Gray Color Scale (Sand - Dark).
+       The palette publishes four dark surfaces; this app needs eight distinct
+       elevations (page, nav, card, popover, input, border, hover, segment). So
+       the ramp keeps the step sizes that already separate them and shifts as a
+       whole until the page background lands on Ink, the published dark canvas.
+       Every stop is generated along Sand's own hue path, so nothing here is
+       off-palette -- 50 is Ink and 950 is Linen exactly, and 800 lands on
+       Sand 500, the published dark muted text. */
+    --gray-0: 42.9 4.3% 10.5%; /* #1C1B1A - deepest page bg */
+    --gray-50: 42.9 4.3% 13.5%; /* #242321 - Ink, page bg */
+    --gray-100: 42.9 3.4% 18.5%; /* #31302E - sidebar, popover */
+    --gray-200: 42.9 2.7% 22.5%; /* #3B3A38 - border, input */
+    --gray-300: 42.9 2.3% 26.5%; /* #454442 - accent hover */
+    --gray-400: 42.9 2% 30.5%; /* #4F4E4C - stronger border */
+    --gray-500: 42.9 1.6% 36.5%; /* #5F5E5C */
+    --gray-600: 42.9 1.3% 45.5%; /* #767573 */
+    --gray-700: 42.9 1.2% 52.5%; /* #878784 */
+    /* Raised from Sand 500 to clear 4.5:1 against `--muted`, which is the
+       segment-control track and the densest place secondary text lands.
+       On Sand 500 that pairing was 4.24:1 -- a failure this ramp inherited
+       rather than introduced; the old cool ramp was 4.14:1. */
+    --gray-800: 42.9 1.5% 64.5%; /* #A6A5A3 */
+    --gray-900: 42.9 4.1% 81.5%; /* #D2D1CE */
+    --gray-950: 42.9 41.2% 96.7%; /* #FAF8F3 */
+
+    /* Divider Color (Dark) */
+    --divider: 42.9 2.7% 22%; /* #3A3937 */
+
+    /* Theme-aware Colors (Dark - inverted) */
+    --white: 30 4.3% 13.5%; /* #242221 - Ink */
+    --black: 0 0% 100%; /* #FFFFFF */
+
+    /* ===================================
+     * Semantic Colors (Dark Theme)
+     * =================================== */
+    --background: var(--gray-50); /* gray-50 */
+    --foreground: var(--gray-950); /* gray-950 */
+
+    --card: 42.9 3.8% 16.5%; /* between gray-50 and gray-100 - card surface */
+    --card-foreground: var(--gray-950); /* gray-950 */
+
+    --popover: var(--gray-100); /* gray-100 - dark background */
+    --popover-foreground: var(--gray-950); /* gray-950 */
+
+    --primary: var(--primary-300); /* primary-300 - brand */
+    /* Same Amber fill as light, so the same Ink text (8.09:1). */
+    --primary-foreground: 42.9 4.3% 13.5%; /* #242321 - Ink on brand */
+
+    --secondary: 42.9 3.1% 20.5%; /* gray-200 (dark) - lighter than card for inner elements */
+    --secondary-foreground: var(--gray-950); /* gray-950 */
+
+    --muted: var(
+      --gray-200
+    ); /* gray-200 - lighter than card for visible inner surfaces */
+    --muted-foreground: var(--gray-800); /* gray-800 */
+
+    --accent: var(
+      --gray-300
+    ); /* gray-300 - visible hover against popover/card */
+    --accent-foreground: var(--gray-950); /* gray-950 */
+
+    /* Coral 400 rather than light's Coral 700: a dark page needs the lighter
+       stop to stay legible, and that stop flips the label to Ink (7.21:1). */
+    --destructive: 13.1 100% 72.2%; /* #FF9071 - Coral 400 */
+    --destructive-foreground: 42.9 4.3% 13.5%; /* #242321 - Ink on Coral 400 */
+
+    --border: var(--gray-200); /* gray-200 - primary border color */
+    --input: var(
+      --gray-200
+    ); /* gray-200 - lighter than card for visible input surfaces */
+    --ring: var(--primary-300); /* primary-300 - the brand stop reads on Ink */
+
+    /* Brand as a wash and as text. Dark takes the opposite end of the same
+       scale: the wash drops to 950 and the text rises to the brand stop. */
+    --brand-subtle: var(--primary-950); /* #31200B */
+    --brand-text: var(--primary-300); /* #FFA500 */
+    --brand-text-hover: var(--primary-200); /* #FFC580 */
+
+    /* Text on filled/colored backgrounds (buttons, tooltips, badges) */
+    --on-filled: 0 0% 100%; /* Pure white for text on colored backgrounds */
+
+    --sidebar: var(--gray-100); /* gray-100 - lighter than page bg */
+    --sidebar-rail: var(--gray-0); /* deepest chrome, under the chat column */
+    --sidebar-foreground: var(--gray-950); /* gray-950 */
+    --sidebar-primary: var(--primary-800); /* primary-800 */
+    --sidebar-primary-foreground: var(--gray-50); /* gray-50 */
+    --tooltip-bg: hsl(
+      var(--gray-300)
+    ); /* tooltip - visible against dark surfaces */
+
+    --semantic-foreground: var(--gray-0); /* gray-0 */
+
+    --background-50: var(
+      --gray-50
+    ); /* gray-50 - lighter background for code blocks */
+
+    /* Interaction state ladder (dark).
+       Dark surfaces need a wider ladder than light ones to read as the same
+       step, so the alphas are raised rather than mirrored. Sand's dark stops
+       are a very quiet warm neutral, so the layer takes Linen's hue and stays
+       just saturated enough to hold it as the alpha climbs. */
+    --state-layer: 42.9 100% 97%;
 
     --state-hover-alpha: 7%;
     --state-selected-alpha: 12%;


### PR DESCRIPTION
Re-lands #31081 (reverted in #31508) with the palette gated instead of GA.

The original PR shipped the Sand/Amber palette to everyone and put only the shell behind `newUi`. The reasoning was that three surfaces — the boot skeleton, the automation-result email, and `apps/desktop` — cannot read a per-user switch, so the palette had to go GA with them. That was wrong: those three are a small corner, and everything the stylesheet owns can be scoped.

## How it is gated

`packages/ui/src/styles/globals.css` keeps the orange palette on `:root` and `[data-theme="dark"]`, and adds `:root[data-new-ui]` / `[data-theme="dark"][data-new-ui]` twins carrying Sand and Amber. Both selectors match the same `<html>` and win on specificity, so every `@theme` alias follows without being restated — each is a lazy `hsl(var(--x))` reference resolved per element, not a snapshot.

That single mechanism covers the whole base palette. What is left in the platform sheet is the handful of values it hardcodes rather than derives — nine chart segment colours, three shadows, four markdown link colours — plus the two colour-theme ladders, which carry their own selector and so get their own gated copy. All of it sits in one clearly-marked block at the end of `index.css`, to be deleted in one pass when the palette graduates.

## Why this is not 40 files of conditionals

The Amber scale introduced four semantic tokens — `--brand-subtle`, `--brand-text`, `--brand-text-hover`, `--sidebar-rail` — and about forty component files moved onto them. Those files are untouched here. The tokens are bridged onto the orange palette as well (`--brand-text: var(--primary-700)`, `--sidebar-rail: var(--gray-50)`, and so on), so every call site that switched renders identically with the switch off. The indirection is an improvement on its own terms and stays either way.

## What still cannot follow

| Surface | Why | With the switch on |
| --- | --- | --- |
| boot skeleton in `index.html` | renders before the stylesheet loads | brief `#faf5f3` flash, then the new canvas |
| automation-result email | rendered server-side for an arbitrary recipient | badge stays `#ed4e01` on white |
| `apps/desktop` | self-contained stylesheet, no switch plumbing | stays on its current neutrals and brand |

The logo **can** follow — `product-brand-mark.tsx` is a component, so it reads `featureSwitch$` directly and picks its fill.


## The one place the off state is not identical

Sixty-eight call sites moved from `text-primary` / `bg-primary` onto the brand
tokens. Sixty-four are byte-identical with the switch off, because the orange
palette's `--primary` *is* `--primary-700`, which is exactly what the bridge
maps `--brand-text` to.

Five are not. Four icons and one link used `text-primary-900` / `text-primary-950`
directly rather than `text-primary`, and the single bridge token cannot reproduce
three different stops at once:

| | before (off) | after (off) |
| --- | --- | --- |
| light | `#D03200` / `#5C2918` | `#ED4E01` |
| dark | `#FF946E` / `#FED5C7` | `#ED4E01` |

`#ED4E01` is the colour their sixty-four siblings already render in both themes
today, so this normalises five stragglers onto the established brand text colour
rather than introducing a new one. It is a visible change for everyone, which is
why it is called out here rather than left to be discovered.

## Verification

Measured on the real built bundle (`vite build`, `index-B6873uiQ.css`), all four states, by toggling `data-theme` and `data-new-ui` on `<html>`:

| | page | brand text | brand fill | nav rail | chat column | card |
| --- | --- | --- | --- | --- | --- | --- |
| off, light | `rgb(250,251,252)` | `#ED4E01` | `#ED4E01` | `rgb(242,244,247)` | `rgb(249,250,251)` | none |
| on, light | `rgb(255,255,255)` | `rgb(136,86,0)` | `#FFA500` | `#EFEAE8` | `#FDFAF9` | 8px / 12px |
| off, dark | `rgb(25,25,26)` | `#ED4E01` | `#ED4E01` | `rgb(25,25,26)` | `rgb(19,19,21)` | none |
| on, dark | `rgb(36,35,33)` | `#FFA500` | `#FFA500` | `rgb(28,27,26)` | `rgb(49,48,46)` | 8px / 12px |

Every off-state value matches what `main` ships today.

- `pnpm -F @okouai/ui exec vitest run` — 95 passed
- `new-ui-feature-switch.test.tsx` + `design-token-shadowing.test.ts` — 7 passed
- `tsc --noEmit` clean on `@okouai/app` and `@okouai/ui`
- Confirmed the single bundle carries both scales: `--primary-300` and `--gray-0` each appear with four distinct values (orange light/dark, Amber light/dark)

## Fallbacks

None. The off branch is `main`'s live behaviour held behind a rollout gate, not a compatibility path; `docs/fallback.md` §2 covers the gated side. Removal condition: when the palette graduates, delete the `[data-new-ui]` blocks in both sheets, the four bridge tokens, and the switch together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

