### PR TITLE
refactor(chat): consume structured run failure reasons

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -4699,7 +4699,25 @@ describe("CHAT-02: drain-time admission failure", () => {
 
 describe("CHAT-02: failed chat callbacks", () => {
   it("formats failed-run errors and notifies, without auto-sending", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const { actor, agentId, runnerGroup, providerId } =
+      await entitledChatActor();
+    await seedVm0BuiltInModelKey(context, "gpt-5.6-sol");
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "claude-sonnet-5",
+        isDefault: true,
+        defaultProviderType: "anthropic-api-key",
+        credentialScope: "org",
+        modelProviderId: providerId,
+      },
+      {
+        model: "gpt-5.6-sol",
+        isDefault: false,
+        defaultProviderType: "built-in",
+        credentialScope: "org",
+        modelProviderId: null,
+      },
+    ]);
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     await chatCallbacks.registerPushSubscription(actor);
     chatCallbacks.enableVapid();
@@ -4713,17 +4731,63 @@ describe("CHAT-02: failed chat callbacks", () => {
     const rounds: readonly {
       readonly prompt: string;
       readonly error: string;
+      readonly expectedError?: string;
       readonly failureReason?: RunFailureReasonToken;
+      readonly selectedModel?: SupportedRunModel;
     }[] = [
       { prompt: "round one", error: actionableError },
       {
         prompt: "round two",
-        error: "First runner failure",
+        error: executionTimeoutError,
+        expectedError: "Oops, something went wrong. Please try again later.",
         failureReason: "future_reason",
       },
-      { prompt: "round three", error: "Second runner failure" },
+      {
+        prompt: "round three",
+        error: "Second runner failure",
+        expectedError: "Oops, something went wrong. Please try again later.",
+      },
       { prompt: "round four", error: usageLimitError },
-      { prompt: "round five", error: executionTimeoutError },
+      {
+        prompt: "round five",
+        error: executionTimeoutError,
+        expectedError: CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE,
+      },
+      {
+        prompt: "round six",
+        error: usageLimitError,
+        expectedError: "Oops, something went wrong. Please try again later.",
+        failureReason: "provider_rate_limited",
+      },
+      {
+        prompt: "round seven",
+        error: usageLimitError,
+        expectedError:
+          "Selected model is at capacity. Please try a different model.",
+        failureReason: "provider_overloaded",
+        selectedModel: "gpt-5.6-sol",
+      },
+      {
+        prompt: "round eight",
+        error:
+          "Claude Sonnet 5 is overloaded. Please wait a few minutes and try again, or switch to another model.",
+        failureReason: "usage_limit",
+        selectedModel: "claude-sonnet-5",
+      },
+      {
+        prompt: "round nine",
+        error: "Unrelated runner failure",
+        expectedError: "insufficient_credits",
+        failureReason: "insufficient_credits",
+      },
+      {
+        prompt: "round ten",
+        error: "Contradictory runner failure",
+        expectedError:
+          "Claude Sonnet 5 is overloaded. Please wait a few minutes and try again, or switch to another model.",
+        failureReason: "provider_overloaded",
+        selectedModel: "claude-sonnet-5",
+      },
     ];
 
     let threadId: string | undefined;
@@ -4733,6 +4797,9 @@ describe("CHAT-02: failed chat callbacks", () => {
         agentId,
         prompt: round.prompt,
         ...(threadId === undefined ? {} : { threadId }),
+        ...(round.selectedModel === undefined
+          ? {}
+          : { selectedModel: round.selectedModel }),
       });
       threadId = run.threadId;
       runIds.push(run.runId);
@@ -4769,7 +4836,7 @@ describe("CHAT-02: failed chat callbacks", () => {
       }
     }
     if (!threadId) {
-      throw new Error("Expected five failed chat rounds");
+      throw new Error("Expected failed chat rounds");
     }
 
     const messages = await waitForThreadMessages(actor, threadId, (items) => {
@@ -4789,8 +4856,8 @@ describe("CHAT-02: failed chat callbacks", () => {
     const replacements = users.filter((message) => {
       return message.runId !== undefined;
     });
-    expect(originals).toHaveLength(5);
-    expect(replacements).toHaveLength(5);
+    expect(originals).toHaveLength(rounds.length);
+    expect(replacements).toHaveLength(rounds.length);
     expect(
       replacements.every((replacement) => {
         return originals.some((original) => {
@@ -4807,13 +4874,11 @@ describe("CHAT-02: failed chat callbacks", () => {
           return message.runId === runId;
         })?.error;
       }),
-    ).toStrictEqual([
-      actionableError,
-      "Oops, something went wrong. Please try again later.",
-      "Oops, something went wrong. Please try again later.",
-      usageLimitError,
-      CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE,
-    ]);
+    ).toStrictEqual(
+      rounds.map((round) => {
+        return round.expectedError ?? round.error;
+      }),
+    );
     expect(
       failed.find((message) => {
         return message.runId === runIds[0];
@@ -4835,13 +4900,11 @@ describe("CHAT-02: failed chat callbacks", () => {
           return message.runId === runId;
         })?.failureReason;
       }),
-    ).toStrictEqual([
-      undefined,
-      "future_reason",
-      undefined,
-      undefined,
-      undefined,
-    ]);
+    ).toStrictEqual(
+      rounds.map((round) => {
+        return round.failureReason;
+      }),
+    );
 
     const rawRows = await chat.listThreadEventRows(actor, threadId);
     const rawFailures = rawRows.filter((row) => {
@@ -4853,13 +4916,11 @@ describe("CHAT-02: failed chat callbacks", () => {
           return row.runId === runId;
         })?.failureReason;
       }),
-    ).toStrictEqual([
-      undefined,
-      "future_reason",
-      undefined,
-      undefined,
-      undefined,
-    ]);
+    ).toStrictEqual(
+      rounds.map((round) => {
+        return round.failureReason;
+      }),
+    );
     expect(
       rawFailures.find((row) => {
         return row.runId === runIds[1];
@@ -4869,7 +4930,9 @@ describe("CHAT-02: failed chat callbacks", () => {
       error: "Oops, something went wrong. Please try again later.",
     });
 
-    expect(context.mocks.webpush.sendNotification).toHaveBeenCalledTimes(5);
+    expect(context.mocks.webpush.sendNotification).toHaveBeenCalledTimes(
+      rounds.length,
+    );
     expect(
       pushPayload(context.mocks.webpush.sendNotification.mock.calls[1]),
     ).toMatchObject({
@@ -4964,6 +5027,7 @@ describe("CHAT-02: failed chat callbacks", () => {
     async function failAndReadError(params: {
       readonly prompt: string;
       readonly errorMessage?: string;
+      readonly failureReason?: RunFailureReasonToken;
       readonly selectedModel?: SupportedRunModel;
       readonly orgRole?: TestOrgRole;
       readonly publicBrand?: PublicBrand;
@@ -5003,6 +5067,7 @@ describe("CHAT-02: failed chat callbacks", () => {
         run.runId,
         sandboxHeaders,
         params.errorMessage ?? upstreamAuthError,
+        params.failureReason,
       );
 
       const page = await waitForThreadMessages(
@@ -5034,6 +5099,17 @@ describe("CHAT-02: failed chat callbacks", () => {
       }),
     ).resolves.toBe(
       "Claude Code subscription authentication failed. Reconnect Claude Code in Model Providers, then retry.\n\nReconnect Claude Code: https://app.okou.ai/?settings=model",
+    );
+    await expect(
+      failAndReadError({
+        prompt: "structured subscription credential failed",
+        errorMessage: "Provider authentication copy changed",
+        failureReason: "invalid_credentials",
+        selectedModel: "claude-opus-4-8",
+        configureProvider: configureClaudeCodeSubscriptionProvider,
+      }),
+    ).resolves.toBe(
+      "Claude Code subscription authentication failed. Reconnect Claude Code in Model Providers, then retry.\n\nReconnect Claude Code: https://app.vm0.ai/?settings=model",
     );
     await expect(
       failAndReadError({

--- a/turbo/apps/api/src/signals/services/run-error-format.service.ts
+++ b/turbo/apps/api/src/signals/services/run-error-format.service.ts
@@ -4,12 +4,15 @@ import {
   isClaudeCodeAuthenticationCredentialsError,
 } from "@okouai/api-contracts/contracts/errors";
 import {
+  getFrameworkForType,
   modelProviderCredentialScopeSchema,
   modelProviderTypeSchema,
   type ModelProviderCredentialScope,
   type ModelProviderType,
 } from "@okouai/api-contracts/contracts/model-providers";
+import type { ModelProviderFramework } from "@okouai/api-contracts/contracts/model-provider-types";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import type { RunFailureReasonToken } from "@okouai/api-contracts/contracts/run-failure-reasons";
 import { appUrlForPublicBrand } from "@okouai/core/public-brand";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { eq } from "drizzle-orm";
@@ -26,6 +29,8 @@ interface RunErrorProviderContext {
   readonly orgId: string;
   readonly modelProviderType: ModelProviderType | null;
   readonly modelProviderCredentialScope: ModelProviderCredentialScope | null;
+  readonly failureReason: RunFailureReasonToken | null;
+  readonly framework: ModelProviderFramework | null;
   readonly selectedModel: string | null;
 }
 
@@ -34,6 +39,8 @@ interface FormatRunErrorLikeWebMessageParams {
   readonly runId: string;
   readonly errorMessage: string;
   readonly publicBrand: PublicBrand;
+  readonly failureReason?: RunFailureReasonToken;
+  readonly framework?: ModelProviderFramework | null;
   readonly modelProviderType?: ModelProviderType | null;
   readonly modelProviderCredentialScope?: ModelProviderCredentialScope | null;
   readonly selectedModel?: string | null;
@@ -108,7 +115,9 @@ function runErrorProviderContext(
         userId: agentRuns.userId,
         orgId: agentRuns.orgId,
         modelProviderType: agentRuns.modelProvider,
+        modelRuntimeProviderType: agentRuns.modelRuntimeProvider,
         modelProviderCredentialScope: agentRuns.modelProviderCredentialScope,
+        failureReason: agentRuns.failureReason,
         selectedModel: agentRuns.selectedModel,
       })
       .from(agentRuns)
@@ -119,13 +128,28 @@ function runErrorProviderContext(
       return undefined;
     }
 
+    const modelProviderType = formatLatestSessionProviderType(
+      run.modelProviderType,
+    );
+    const modelRuntimeProviderType = formatLatestSessionProviderType(
+      run.modelRuntimeProviderType,
+    );
+    const frameworkProviderType =
+      modelRuntimeProviderType ??
+      (modelProviderType === "built-in" ? null : modelProviderType);
+
     return {
       userId: run.userId,
       orgId: run.orgId,
-      modelProviderType: formatLatestSessionProviderType(run.modelProviderType),
+      modelProviderType,
       modelProviderCredentialScope: formatRunModelProviderCredentialScope(
         run.modelProviderCredentialScope,
       ),
+      failureReason: run.failureReason,
+      framework:
+        frameworkProviderType === null
+          ? null
+          : getFrameworkForType(frameworkProviderType),
       selectedModel: run.selectedModel,
     };
   });
@@ -136,11 +160,13 @@ function formatRunErrorLikeWebMessage(
 ): Computed<Promise<string>> {
   return computed(async (get): Promise<string> => {
     const errorMessage = params.errorMessage.trim() || "Run failed";
-    if (isProRequiredRunError(errorMessage)) {
-      return PRO_REQUIRED_MARKER;
-    }
-    if (isInsufficientCreditsRunError(errorMessage)) {
-      return INSUFFICIENT_CREDITS_MARKER;
+    if (params.failureReason === undefined) {
+      if (isProRequiredRunError(errorMessage)) {
+        return PRO_REQUIRED_MARKER;
+      }
+      if (isInsufficientCreditsRunError(errorMessage)) {
+        return INSUFFICIENT_CREDITS_MARKER;
+      }
     }
 
     const providerContext =
@@ -164,6 +190,8 @@ function formatRunErrorLikeWebMessage(
     return formatRunErrorForExternalSurface({
       code: "INTERNAL_SERVER_ERROR",
       message: errorMessage,
+      failureReason: params.failureReason,
+      framework: params.framework,
       selectedModel,
       claudeCodeCredentialRecovery: {
         modelProviderType,
@@ -184,7 +212,10 @@ export const formatRunErrorForRunOwner$ = command(
     { get, set },
     params: Omit<
       FormatRunErrorLikeWebMessageParams,
-      "modelProviderType" | "modelProviderCredentialScope"
+      | "failureReason"
+      | "framework"
+      | "modelProviderType"
+      | "modelProviderCredentialScope"
     >,
     signal: AbortSignal,
   ): Promise<string> => {
@@ -196,7 +227,9 @@ export const formatRunErrorForRunOwner$ = command(
       params.canManageOrgModelProviders === undefined &&
       providerContext?.modelProviderType === "anthropic-api-key" &&
       providerContext.modelProviderCredentialScope === "org" &&
-      isClaudeCodeAuthenticationCredentialsError(params.errorMessage)
+      (providerContext.failureReason === "invalid_credentials" ||
+        (providerContext.failureReason === null &&
+          isClaudeCodeAuthenticationCredentialsError(params.errorMessage)))
     ) {
       const membership = await set(
         getMemberRoleAndUpdateCache$,
@@ -211,6 +244,8 @@ export const formatRunErrorForRunOwner$ = command(
     return await get(
       formatRunErrorLikeWebMessage({
         ...params,
+        failureReason: providerContext?.failureReason ?? undefined,
+        framework: providerContext?.framework ?? null,
         modelProviderType: providerContext?.modelProviderType ?? null,
         modelProviderCredentialScope:
           providerContext?.modelProviderCredentialScope ?? null,

--- a/turbo/apps/platform/src/signals/chat-page/assistant-error-recovery.ts
+++ b/turbo/apps/platform/src/signals/chat-page/assistant-error-recovery.ts
@@ -8,11 +8,18 @@ import {
 } from "@okouai/api-contracts/contracts/errors";
 import type { ModelProviderFramework } from "@okouai/api-contracts/contracts/model-provider-types";
 import {
+  getFrameworkForType,
+  getVm0ConcreteProviderType,
   isSupportedRunModel,
+  type OrgModelPolicy,
   type ModelProviderResponse,
   type OrgModelPoliciesResponse,
   type SupportedRunModel,
 } from "@okouai/api-contracts/contracts/model-providers";
+import {
+  knownRunFailureReasonSchema,
+  type KnownRunFailureReason,
+} from "@okouai/api-contracts/contracts/run-failure-reasons";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { personalModelProviders$ } from "../external/personal-model-providers.ts";
@@ -109,7 +116,21 @@ function isClaudeUsageLimit(error: string): boolean {
   );
 }
 
-function classifyAssistantError(
+function isCodexModelCapacity(error: string): boolean {
+  return /selected model is at capacity\.? please try a different model/iu.test(
+    error,
+  );
+}
+
+function isClaudeModelCapacity(error: string): boolean {
+  return (
+    /\bclaude\b.*\b(?:is overloaded|overloaded|at capacity)\b/iu.test(error) ||
+    /\b529\b.*\boverload/iu.test(error) ||
+    /\boverloaded_error\b/iu.test(error)
+  );
+}
+
+function classifyAssistantErrorFromText(
   event: EnrichedChatEvent,
   error: string,
 ): ClassifiedAssistantError | null {
@@ -145,11 +166,7 @@ function classifyAssistantError(
     };
   }
 
-  if (
-    /selected model is at capacity\.? please try a different model/iu.test(
-      normalized,
-    )
-  ) {
+  if (isCodexModelCapacity(normalized)) {
     return {
       sourceEventId: event.id,
       providerMessage: error,
@@ -162,13 +179,7 @@ function classifyAssistantError(
     };
   }
 
-  if (
-    /\bclaude\b.*\b(?:is overloaded|overloaded|at capacity)\b/iu.test(
-      normalized,
-    ) ||
-    /\b529\b.*\boverload/iu.test(normalized) ||
-    /\boverloaded_error\b/iu.test(normalized)
-  ) {
+  if (isClaudeModelCapacity(normalized)) {
     return {
       sourceEventId: event.id,
       providerMessage: error,
@@ -212,6 +223,129 @@ function classifyAssistantError(
   return null;
 }
 
+const STRUCTURED_PROVIDER_RECOVERY_KIND = Object.freeze({
+  session_history_limit: null,
+  insufficient_credits: null,
+  invalid_api_key: null,
+  invalid_credentials: null,
+  terms_acceptance_required: null,
+  context_window_exceeded: null,
+  input_too_large: null,
+  output_token_limit: null,
+  provider_rate_limited: null,
+  provider_overloaded: "model-capacity",
+  provider_stream_timeout: null,
+  provider_server_error: null,
+  response_connection_lost: null,
+  safety_policy_refusal: null,
+  reconnect_required: null,
+  unsupported_model: "model-unavailable",
+  usage_limit: "usage-limit",
+} satisfies Record<
+  KnownRunFailureReason,
+  ProviderAssistantErrorRecoveryKind | null
+>);
+
+function structuredProviderRecoveryKind(
+  event: EnrichedChatEvent,
+): ProviderAssistantErrorRecoveryKind | null | undefined {
+  if (event.eventType !== "run.failed" || event.failureReason === undefined) {
+    return undefined;
+  }
+
+  const knownReason = knownRunFailureReasonSchema.safeParse(
+    event.failureReason,
+  );
+  if (!knownReason.success) {
+    return null;
+  }
+  return STRUCTURED_PROVIDER_RECOVERY_KIND[knownReason.data];
+}
+
+function structuredRecoveryFrameworkFromMessage(
+  kind: ProviderAssistantErrorRecoveryKind,
+  error: string,
+): ModelProviderFramework | null {
+  const normalized = normalizedProviderMessage(error);
+  switch (kind) {
+    case "model-capacity": {
+      if (isCodexModelCapacity(normalized)) {
+        return getFrameworkForType("openai-api-key");
+      }
+      if (isClaudeModelCapacity(normalized)) {
+        return getFrameworkForType("anthropic-api-key");
+      }
+      return null;
+    }
+    case "model-unavailable": {
+      return getCodexChatGptAccountUnsupportedModel(error) === undefined
+        ? null
+        : getFrameworkForType("openai-api-key");
+    }
+    case "usage-limit": {
+      if (/you(?:'|’)ve hit your usage limit\b/iu.test(normalized)) {
+        return getFrameworkForType("openai-api-key");
+      }
+      if (isClaudeUsageLimit(normalized)) {
+        return getFrameworkForType("anthropic-api-key");
+      }
+      return null;
+    }
+  }
+}
+
+function classifyStructuredAssistantError(
+  event: EnrichedChatEvent,
+  error: string,
+  kind: ProviderAssistantErrorRecoveryKind,
+  framework: ModelProviderFramework,
+): ClassifiedAssistantError {
+  const normalized = normalizedProviderMessage(error);
+  const unsupportedModel = getCodexChatGptAccountUnsupportedModel(error);
+  const hasCodexUsageDetails =
+    kind === "usage-limit" &&
+    /you(?:'|’)ve hit your usage limit\b/iu.test(normalized);
+  const hasClaudeUsageDetails =
+    kind === "usage-limit" && isClaudeUsageLimit(normalized);
+  const codexModelScoped =
+    framework === "codex" &&
+    hasCodexUsageDetails &&
+    /\busage limit for\b/iu.test(normalized);
+  const limitWindow =
+    kind === "usage-limit"
+      ? framework === "claude-code" && hasClaudeUsageDetails
+        ? (claudeLimitWindow(normalized) ?? "unknown")
+        : codexModelScoped
+          ? "model"
+          : "unknown"
+      : null;
+
+  return {
+    sourceEventId: event.id,
+    providerMessage: error,
+    kind,
+    framework,
+    scope:
+      kind === "model-unavailable" ||
+      kind === "model-capacity" ||
+      codexModelScoped ||
+      limitWindow === "model"
+        ? "model"
+        : "framework",
+    limitWindow,
+    retryLabel:
+      hasCodexUsageDetails || hasClaudeUsageDetails
+        ? resetLabelFromProviderMessage(normalized)
+        : null,
+    failedModel:
+      kind === "model-unavailable" &&
+      unsupportedModel !== undefined &&
+      isSupportedRunModel(unsupportedModel)
+        ? unsupportedModel
+        : null,
+  };
+}
+
 function isRenderableAssistantEvent(event: EnrichedChatEvent): boolean {
   return (
     (isChatEventContentTextType(event.eventType) && Boolean(event.content)) ||
@@ -223,9 +357,10 @@ function isRenderableAssistantEvent(event: EnrichedChatEvent): boolean {
   );
 }
 
-function latestAssistantRecoveryCandidate(
-  groups: readonly ChatEventGroup[],
-): ClassifiedAssistantError | null {
+function latestAssistantErrorCandidate(groups: readonly ChatEventGroup[]): {
+  readonly event: EnrichedChatEvent;
+  readonly error: string;
+} | null {
   const group = groups.at(-1);
   if (group?.role !== "assistant") {
     return null;
@@ -246,7 +381,7 @@ function latestAssistantRecoveryCandidate(
   ) {
     return null;
   }
-  return classifyAssistantError(event, event.error);
+  return { event, error: event.error };
 }
 
 function exhaustedUsageWindow(provider: ModelProviderResponse): {
@@ -304,7 +439,7 @@ function providerSubscriptionReset(
 function selectedModelPolicy(
   policies: OrgModelPoliciesResponse,
   selectedModel: string | null,
-) {
+): OrgModelPolicy | undefined {
   const model =
     selectedModel ??
     policies.policies.find((policy) => {
@@ -314,6 +449,19 @@ function selectedModelPolicy(
   return policies.policies.find((policy) => {
     return policy.model === model;
   });
+}
+
+function modelPolicyFramework(
+  policy: OrgModelPolicy | undefined,
+): ModelProviderFramework | null {
+  if (policy === undefined) {
+    return null;
+  }
+  const providerType =
+    policy.defaultProviderType === "built-in"
+      ? getVm0ConcreteProviderType(policy.model)
+      : policy.defaultProviderType;
+  return getFrameworkForType(providerType);
 }
 
 function usesPersonalSubscription(
@@ -328,15 +476,76 @@ function usesPersonalSubscription(
   );
 }
 
+function createClassifiedAssistantErrorComputed(
+  visibleRenderedChatGroups$: Computed<Promise<ChatEventGroup[]>>,
+  selectedModel$: Computed<string | null>,
+): Computed<Promise<ClassifiedAssistantError | null>> {
+  return computed(async (get): Promise<ClassifiedAssistantError | null> => {
+    const candidate = latestAssistantErrorCandidate(
+      await get(visibleRenderedChatGroups$),
+    );
+    if (candidate === null) {
+      return null;
+    }
+
+    const structuredKind = structuredProviderRecoveryKind(candidate.event);
+    if (structuredKind === null) {
+      return null;
+    }
+
+    let classified: ClassifiedAssistantError | null;
+    if (structuredKind === undefined) {
+      classified = classifyAssistantErrorFromText(
+        candidate.event,
+        candidate.error,
+      );
+    } else {
+      if (
+        structuredKind !== "model-unavailable" &&
+        !get(featureSwitch$)[FeatureSwitchKey.ChatErrorRecovery]
+      ) {
+        return null;
+      }
+      const frameworkFromMessage = structuredRecoveryFrameworkFromMessage(
+        structuredKind,
+        candidate.error,
+      );
+      const framework =
+        frameworkFromMessage ??
+        modelPolicyFramework(
+          selectedModelPolicy(
+            await get(orgModelPolicies$),
+            get(selectedModel$),
+          ),
+        );
+      if (framework === null) {
+        return null;
+      }
+      classified = classifyStructuredAssistantError(
+        candidate.event,
+        candidate.error,
+        structuredKind,
+        framework,
+      );
+    }
+    if (classified === null) {
+      return null;
+    }
+    return classified;
+  });
+}
+
 function createAssistantErrorRecoveryComputed(
   visibleRenderedChatGroups$: Computed<Promise<ChatEventGroup[]>>,
   selectedModel$: Computed<string | null>,
 ) {
+  const classifiedAssistantError$ = createClassifiedAssistantErrorComputed(
+    visibleRenderedChatGroups$,
+    selectedModel$,
+  );
   return computed(async (get): Promise<AssistantErrorRecovery | null> => {
-    const classified = latestAssistantRecoveryCandidate(
-      await get(visibleRenderedChatGroups$),
-    );
-    if (!classified) {
+    const classified = await get(classifiedAssistantError$);
+    if (classified === null) {
       return null;
     }
     if (

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-test-helpers.ts
@@ -211,6 +211,7 @@ const mockChatEventOverrides = {
     return {
       runId: message.runId ?? `mock-run-${id}`,
       error: message.error,
+      failureReason: message.failureReason,
       runLifecycleEvent: "failed",
     };
   },
@@ -421,6 +422,9 @@ export function mockChatEventRows(
       contextId: goalContextId,
       runEventSequenceNumber: event.sequenceNumber ?? null,
       runEventId: event.runEventId ?? null,
+      ...(event.eventType === "run.failed" && event.failureReason !== undefined
+        ? { failureReason: event.failureReason }
+        : {}),
       seqId: event.seqId,
       createdAt: event.createdAt,
     });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-results.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-results.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { billingStatusContract } from "@okouai/api-contracts/contracts/billing";
 import { CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE } from "@okouai/api-contracts/contracts/errors";
+import type { SupportedRunModel } from "@okouai/api-contracts/contracts/model-providers";
+import type { RunFailureReasonToken } from "@okouai/api-contracts/contracts/run-failure-reasons";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   click,
@@ -1954,6 +1956,13 @@ describe("chat lifecycle", () => {
         "Claude Sonnet 4.6 is overloaded. Please wait a few minutes and try again, or switch to another model.",
       title: "This model is busy right now",
     },
+    {
+      name: "unsupported model",
+      threadId: "e7000000-0000-4000-a000-000000000039",
+      error:
+        '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'gpt-5.6-sol\' model is not supported when using Codex with a ChatGPT account."}}',
+      title: "Selected model isn't available",
+    },
   ])(
     "recognizes the latest $name error",
     async ({ threadId, error, title }) => {
@@ -1990,6 +1999,151 @@ describe("chat lifecycle", () => {
       expect(
         screen.getByTestId("assistant-error-recovery"),
       ).toBeInTheDocument();
+    },
+  );
+
+  it.each([
+    {
+      name: "usage limit",
+      threadId: "e7000000-0000-4000-a000-000000000033",
+      selectedModel: "claude-sonnet-4-6",
+      failureReason: "usage_limit",
+      error: "You've hit your weekly limit · resets Friday at 5:00 PM",
+      title: "Claude Code limit reached",
+    },
+    {
+      name: "model capacity with contradictory usage text",
+      threadId: "e7000000-0000-4000-a000-000000000034",
+      selectedModel: "claude-sonnet-4-6",
+      failureReason: "provider_overloaded",
+      error: "You've hit your usage limit. Try again at 5:00 PM.",
+      title: "This model is busy right now",
+    },
+    {
+      name: "unsupported model",
+      threadId: "e7000000-0000-4000-a000-000000000035",
+      selectedModel: "gpt-5.6-sol",
+      failureReason: "unsupported_model",
+      error:
+        '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'gpt-5.6-sol\' model is not supported when using Codex with a ChatGPT account."}}',
+      title: "Selected model isn't available",
+    },
+  ] satisfies readonly {
+    readonly name: string;
+    readonly threadId: string;
+    readonly selectedModel: SupportedRunModel;
+    readonly failureReason: RunFailureReasonToken;
+    readonly error: string;
+    readonly title: string;
+  }[])(
+    "uses the structured $name reason",
+    async ({ threadId, selectedModel, failureReason, error, title }) => {
+      context.mocks.data.orgModelPolicies([
+        buildModelPolicy({
+          id: threadId,
+          model: selectedModel,
+          modelLabel: selectedModel,
+          isDefault: true,
+          defaultProviderType: "built-in",
+          credentialScope: "org",
+        }),
+      ]);
+      mockChatLifecycle(context, {
+        threadId,
+        selectedModel,
+        chatEvents: [
+          {
+            id: `${threadId}-user`,
+            role: "user",
+            content: "Continue",
+            runId: `${threadId}-run`,
+            createdAt: "2026-07-30T09:00:00Z",
+          },
+          {
+            id: `${threadId}-failure`,
+            role: "assistant",
+            content: null,
+            error,
+            failureReason,
+            runId: `${threadId}-run`,
+            runLifecycleEvent: "failed",
+            createdAt: "2026-07-30T09:00:01Z",
+          },
+        ],
+      });
+
+      detachedSetupPage({
+        context,
+        featureSwitches: { [FeatureSwitchKey.ChatErrorRecovery]: true },
+        path: `/chats/${threadId}`,
+      });
+
+      const card = await screen.findByTestId("assistant-error-recovery");
+      expect(within(card).getByText(title)).toBeInTheDocument();
+    },
+  );
+
+  it.each([
+    {
+      name: "provider rate limiting",
+      threadId: "e7000000-0000-4000-a000-000000000036",
+      failureReason: "provider_rate_limited",
+      error: "You've hit your usage limit. Try again at 5:00 PM.",
+    },
+    {
+      name: "known non-recovery failure",
+      threadId: "e7000000-0000-4000-a000-000000000037",
+      failureReason: "invalid_credentials",
+      error: "Selected model is at capacity. Please try a different model.",
+    },
+    {
+      name: "future failure",
+      threadId: "e7000000-0000-4000-a000-000000000038",
+      failureReason: "future_reason",
+      error: CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE,
+    },
+  ] satisfies readonly {
+    readonly name: string;
+    readonly threadId: string;
+    readonly failureReason: RunFailureReasonToken;
+    readonly error: string;
+  }[])(
+    "does not text-classify a present $name reason",
+    async ({ threadId, failureReason, error }) => {
+      mockChatLifecycle(context, {
+        threadId,
+        selectedModel: "gpt-5.6-sol",
+        chatEvents: [
+          {
+            id: `${threadId}-user`,
+            role: "user",
+            content: "Continue",
+            runId: `${threadId}-run`,
+            createdAt: "2026-07-30T09:00:00Z",
+          },
+          {
+            id: `${threadId}-failure`,
+            role: "assistant",
+            content: null,
+            error,
+            failureReason,
+            runId: `${threadId}-run`,
+            runLifecycleEvent: "failed",
+            createdAt: "2026-07-30T09:00:01Z",
+          },
+        ],
+      });
+
+      detachedSetupPage({
+        context,
+        featureSwitches: { [FeatureSwitchKey.ChatErrorRecovery]: true },
+        path: `/chats/${threadId}`,
+      });
+
+      await expect(screen.findByText(error)).resolves.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("assistant-error-recovery"),
+      ).not.toBeInTheDocument();
     },
   );
 
@@ -2195,6 +2349,7 @@ describe("chat lifecycle", () => {
             role: "assistant",
             content: null,
             error,
+            failureReason: "usage_limit",
             runId: "codex-limit-run",
             runLifecycleEvent: "failed",
             createdAt: "2026-07-30T09:00:01Z",
@@ -2263,6 +2418,7 @@ describe("chat lifecycle", () => {
           role: "assistant",
           content: null,
           error: "You've hit your usage limit. Try again at 5:00 PM.",
+          failureReason: "usage_limit",
           runId: "codex-reset-run",
           runLifecycleEvent: "failed",
           createdAt: "2026-07-30T09:00:01Z",
@@ -2329,6 +2485,7 @@ describe("chat lifecycle", () => {
           content: null,
           error:
             "Claude Sonnet 4.6 is overloaded. Please wait a few minutes and try again, or switch to another model.",
+          failureReason: "provider_overloaded",
           runId: "claude-capacity-run",
           runLifecycleEvent: "failed",
           createdAt: "2026-07-30T09:00:01Z",
@@ -2421,6 +2578,7 @@ describe("chat lifecycle", () => {
           role: "assistant",
           content: null,
           error,
+          failureReason: "unsupported_model",
           runId: "unsupported-model-run",
           runLifecycleEvent: "failed",
           createdAt: "2026-07-30T09:00:01Z",

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -5,6 +5,12 @@ import {
   type ModelProviderCredentialScope,
   type ModelProviderType,
 } from "./model-providers";
+import type { ModelProviderFramework } from "./model-provider-types";
+import {
+  knownRunFailureReasonSchema,
+  type KnownRunFailureReason,
+  type RunFailureReasonToken,
+} from "./run-failure-reasons";
 
 /**
  * API error definitions with associated HTTP status codes
@@ -219,6 +225,8 @@ const CLAUDE_CODE_TERMS_ACCEPTANCE_REQUIRED_MESSAGE =
 const CLAUDE_PROVIDER_OVERLOADED_FALLBACK_MODEL = "Claude Model";
 const CLAUDE_PROVIDER_OVERLOADED_GUIDANCE =
   "is overloaded. Please wait a few minutes and try again, or switch to another model.";
+const CODEX_PROVIDER_OVERLOADED_MESSAGE =
+  "Selected model is at capacity. Please try a different model.";
 
 const CLAUDE_CODE_LIMIT_SNIPPETS = [
   "usage limit",
@@ -270,7 +278,7 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   "Cannot continue session",
   "Invalid signature in thinking block",
   "Run cancelled",
-  "Selected model is at capacity. Please try a different model.",
+  CODEX_PROVIDER_OVERLOADED_MESSAGE,
   // Upstream model usage/quota limits are shown verbatim (the CLI already
   // emits clean, user-friendly copy with reset time and upgrade links).
   // Codex: "You've hit your usage limit …"
@@ -637,6 +645,109 @@ export function isGenericRunErrorForDisplay(errorMessage: string): boolean {
   return !isActionableRunError(normalizedErrorMessage);
 }
 
+type StructuredRunErrorBehavior =
+  | "credential"
+  | "generic"
+  | "insufficient-credits"
+  | "overloaded"
+  | "passthrough"
+  | "reconnect"
+  | "terms";
+
+const STRUCTURED_RUN_ERROR_BEHAVIOR: Record<
+  KnownRunFailureReason,
+  StructuredRunErrorBehavior
+> = {
+  session_history_limit: "generic",
+  insufficient_credits: "insufficient-credits",
+  invalid_api_key: "generic",
+  invalid_credentials: "credential",
+  terms_acceptance_required: "terms",
+  context_window_exceeded: "generic",
+  input_too_large: "generic",
+  output_token_limit: "generic",
+  provider_rate_limited: "generic",
+  provider_overloaded: "overloaded",
+  provider_stream_timeout: "generic",
+  provider_server_error: "generic",
+  response_connection_lost: "generic",
+  safety_policy_refusal: "generic",
+  reconnect_required: "reconnect",
+  unsupported_model: "passthrough",
+  usage_limit: "passthrough",
+};
+
+function formatStructuredRunError(params: {
+  readonly failureReason: RunFailureReasonToken;
+  readonly errorMessage: string;
+  readonly framework?: ModelProviderFramework | null;
+  readonly selectedModel?: string | null;
+  readonly claudeCodeCredentialRecovery?: ClaudeCodeCredentialRecovery;
+}): string {
+  const knownReason = knownRunFailureReasonSchema.safeParse(
+    params.failureReason,
+  );
+  if (!knownReason.success) {
+    return CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+  }
+
+  switch (STRUCTURED_RUN_ERROR_BEHAVIOR[knownReason.data]) {
+    case "insufficient-credits": {
+      return "insufficient_credits";
+    }
+    case "credential": {
+      const recoveryMessage =
+        params.claudeCodeCredentialRecovery === undefined
+          ? undefined
+          : formatClaudeCodeCredentialRecoveryMessage(
+              params.claudeCodeCredentialRecovery,
+            );
+      return recoveryMessage ?? CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+    }
+    case "reconnect": {
+      if (
+        params.claudeCodeCredentialRecovery?.modelProviderType ===
+        "codex-oauth-token"
+      ) {
+        return CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE;
+      }
+      if (
+        params.claudeCodeCredentialRecovery?.modelProviderType ===
+        "claude-code-oauth-token"
+      ) {
+        return (
+          formatClaudeCodeCredentialRecoveryMessage(
+            params.claudeCodeCredentialRecovery,
+          ) ?? CHAT_RUN_TRANSIENT_ERROR_MESSAGE
+        );
+      }
+      return CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+    }
+    case "terms": {
+      return withOptionalActionUrl(
+        CLAUDE_CODE_TERMS_ACCEPTANCE_REQUIRED_MESSAGE,
+        "Open Model Providers",
+        params.claudeCodeCredentialRecovery?.modelProvidersUrl,
+      );
+    }
+    case "overloaded": {
+      if (params.framework === "claude-code") {
+        return formatClaudeProviderOverloadedMessage(params.selectedModel);
+      }
+      if (params.framework === "codex") {
+        return CODEX_PROVIDER_OVERLOADED_MESSAGE;
+      }
+      return CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+    }
+    case "passthrough": {
+      return params.errorMessage;
+    }
+    case "generic": {
+      return CHAT_RUN_TRANSIENT_ERROR_MESSAGE;
+    }
+  }
+}
+
 /**
  * Plain-text run error copy shared by Web chat and external integrations.
  * Web may wrap generic failures with its report-link affordance after this
@@ -645,6 +756,8 @@ export function isGenericRunErrorForDisplay(errorMessage: string): boolean {
 export function formatRunErrorForExternalSurface(params: {
   readonly code: string;
   readonly message: string;
+  readonly failureReason?: RunFailureReasonToken;
+  readonly framework?: ModelProviderFramework | null;
   readonly selectedModel?: string | null;
   readonly claudeCodeCredentialRecovery?: ClaudeCodeCredentialRecovery;
   readonly insufficientCredits?:
@@ -660,6 +773,16 @@ export function formatRunErrorForExternalSurface(params: {
       };
 }): string {
   const errorMessage = params.message.trim() || "Run failed";
+
+  if (params.failureReason !== undefined) {
+    return formatStructuredRunError({
+      failureReason: params.failureReason,
+      errorMessage,
+      framework: params.framework,
+      selectedModel: params.selectedModel,
+      claudeCodeCredentialRecovery: params.claudeCodeCredentialRecovery,
+    });
+  }
 
   if (isAgentExecutionTimeoutRunError(errorMessage)) {
     return CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE;


### PR DESCRIPTION
## Summary

- make persisted `failureReason` authoritative for terminal API error formatting
- select Platform recovery kinds from structured reasons while retaining text-only compatibility for historical events
- keep text parsing for compatible secondary details and preserve live provider, entitlement, feature-switch, and retry policy checks
- cover contradictory text, unknown and non-recovery reasons, configured and built-in providers, and reasonless fallback behavior

## Compatibility and exclusions

- events and callers without `failureReason` keep the complete legacy text-classification path
- present unknown or non-recovery reasons fail closed and do not fall through to text cause classification
- this does not change failure classification, Chat Event V7, storage, runner payloads, retry policy, or raw run errors

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/errors.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --maxWorkers=4 --silent=passed-only`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-run-results.test.tsx --maxWorkers=4 --silent=passed-only`
- `pnpm knip`
- `git diff --check`
- pre-commit hook (`prettier`, repository `check-types`)

Closes #31080

Parent objective: #31048
