### PR TITLE
feat(platform): add draggable sidebar scrollbar behind switch

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -21,6 +21,7 @@
     "check-types": "tsc -p tsconfig.production.json --noEmit && tsc -p tsconfig.tests.json --noEmit && tsc -p tsconfig.build-config.json --noEmit"
   },
   "dependencies": {
+    "@base-ui/react": "^1.7.0",
     "@clerk/clerk-js": "6.25.8",
     "@clerk/localizations": "^4.13.8",
     "@clerk/react": "^6.12.8",

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -127,6 +127,10 @@ export const voiceDraftEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.VoiceDraft] ?? false;
 });
 
+export const baseUiSidebarScrollAreaEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.BaseUiSidebarScrollArea] ?? false;
+});
+
 const hydrateFeatureSwitch$ = command(
   async (
     { get, set },

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -66,15 +66,6 @@ globalThis.IDBRequest = IDBRequest;
 globalThis.IDBTransaction = IDBTransaction;
 globalThis.IDBVersionChangeEvent = IDBVersionChangeEvent;
 
-if (typeof Element.prototype.getAnimations !== "function") {
-  Object.defineProperty(Element.prototype, "getAnimations", {
-    configurable: true,
-    value: () => {
-      return [];
-    },
-  });
-}
-
 type HappyDomAttributeCallback = (
   this: HTMLIFrameElement,
   attribute: Attr,

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -66,6 +66,15 @@ globalThis.IDBRequest = IDBRequest;
 globalThis.IDBTransaction = IDBTransaction;
 globalThis.IDBVersionChangeEvent = IDBVersionChangeEvent;
 
+if (typeof Element.prototype.getAnimations !== "function") {
+  Object.defineProperty(Element.prototype, "getAnimations", {
+    configurable: true,
+    value: () => {
+      return [];
+    },
+  });
+}
+
 type HappyDomAttributeCallback = (
   this: HTMLIFrameElement,
   attribute: Attr,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -70,6 +70,18 @@ import {
   changeChatThreadReadCursor,
 } from "../../../mocks/mock-helpers.ts";
 
+// Base UI Scroll Area reads Web Animations during layout; happy-dom does not
+// implement that browser API. Keep the shim local so other Base UI components
+// retain their synchronous no-animation test behavior.
+if (typeof Element.prototype.getAnimations !== "function") {
+  Object.defineProperty(Element.prototype, "getAnimations", {
+    configurable: true,
+    value: () => {
+      return [];
+    },
+  });
+}
+
 // The composer editor is mounted on first paint and mounted again once page
 // bootstrap settles, so an element captured too early is detached before a test
 // can drive it. Keyboard events on a detached editor are silently dropped.

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -9,6 +9,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   chatSearchContract,
   chatThreadByIdContract,
@@ -1497,6 +1498,9 @@ describe("zero sidebar", () => {
     setupSidebarPage({
       context,
       path: `/chats/${EXISTING_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.BaseUiSidebarScrollArea]: true,
+      },
     });
 
     await waitFor(() => {
@@ -3321,6 +3325,75 @@ describe("zero sidebar", () => {
       expect(within(nav).getByText("Agents")).toBeInTheDocument();
       expect(within(nav).getByText("Connectors")).toBeInTheDocument();
     });
+  });
+
+  it("drags the Base UI three-column scrollbar when its feature switch is enabled", async () => {
+    prepareDefaultAgent();
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.BaseUiSidebarScrollArea]: true,
+      },
+    });
+
+    const nav = await screen.findByTestId("chat-list-column");
+    const scrollArea = within(nav).getByTestId("sidebar-scroll-area");
+    Object.defineProperties(scrollArea, {
+      clientHeight: { configurable: true, value: 200 },
+      clientWidth: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1000 },
+      scrollTop: { configurable: true, value: 0, writable: true },
+      scrollWidth: { configurable: true, value: 200 },
+    });
+    fireEvent.scroll(scrollArea);
+
+    const scrollbar = await within(nav).findByTestId("sidebar-scrollbar");
+    const thumb = within(scrollbar).getByTestId("sidebar-scrollbar-thumb");
+    let capturedPointerId: number | null = null;
+    Object.defineProperties(scrollbar, {
+      offsetHeight: { configurable: true, value: 200 },
+    });
+    Object.defineProperties(thumb, {
+      offsetHeight: { configurable: true, value: 40 },
+      setPointerCapture: {
+        configurable: true,
+        value: (pointerId: number) => {
+          capturedPointerId = pointerId;
+        },
+      },
+      hasPointerCapture: {
+        configurable: true,
+        value: (pointerId: number) => {
+          return capturedPointerId === pointerId;
+        },
+      },
+      releasePointerCapture: {
+        configurable: true,
+        value: (pointerId: number) => {
+          if (capturedPointerId === pointerId) {
+            capturedPointerId = null;
+          }
+        },
+      },
+    });
+
+    fireEvent.pointerDown(thumb, {
+      button: 0,
+      clientY: 0,
+      pointerId: 1,
+    });
+    fireEvent.pointerMove(thumb, {
+      buttons: 1,
+      clientY: 80,
+      pointerId: 1,
+    });
+
+    expect(scrollArea.scrollTop).toBe(400);
+
+    fireEvent.pointerUp(thumb, { pointerId: 1 });
+    expect(capturedPointerId).toBeNull();
   });
 
   it("orders artifacts after connectors in the manage navigation", async () => {

--- a/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
@@ -5,11 +5,40 @@ import type {
   ReactNode,
   UIEvent,
 } from "react";
+import { ScrollArea } from "@base-ui/react/scroll-area";
 import { useGet, useSet } from "ccstate-react";
-import type { SidebarChatThreadScrollSignals } from "../../signals/chat-page/sidebar-chat-thread-scroll.ts";
+import type {
+  SidebarChatThreadScrollMetrics,
+  SidebarChatThreadScrollSignals,
+} from "../../signals/chat-page/sidebar-chat-thread-scroll.ts";
+import { baseUiSidebarScrollAreaEnabled$ } from "../../signals/external/feature-switch.ts";
 
-/** Overlay scroll area: hides native scrollbar, renders a custom thin indicator. */
-export function OverlayScrollArea({
+interface OverlayScrollAreaProps {
+  readonly "aria-label"?: string;
+  readonly className?: string;
+  readonly children: ReactNode;
+  readonly onFocus?: FocusEventHandler<HTMLDivElement>;
+  readonly onPointerDownCapture?: PointerEventHandler<HTMLDivElement>;
+  readonly scrollSignals: SidebarChatThreadScrollSignals;
+  readonly style?: CSSProperties;
+  readonly "data-testid"?: string;
+  readonly tabIndex?: number;
+}
+
+function updateScrollMetrics(
+  event: UIEvent<HTMLDivElement>,
+  setScrollMetrics: (metrics: SidebarChatThreadScrollMetrics) => void,
+): void {
+  const element = event.currentTarget;
+  setScrollMetrics({
+    scrollTop: element.scrollTop,
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+  });
+}
+
+/** Existing scroll area retained unchanged behind the disabled switch. */
+function LegacyOverlayScrollArea({
   "aria-label": ariaLabel,
   className,
   children,
@@ -19,25 +48,13 @@ export function OverlayScrollArea({
   style,
   "data-testid": dataTestId,
   tabIndex,
-}: {
-  "aria-label"?: string;
-  className?: string;
-  children: ReactNode;
-  onFocus?: FocusEventHandler<HTMLDivElement>;
-  onPointerDownCapture?: PointerEventHandler<HTMLDivElement>;
-  scrollSignals: SidebarChatThreadScrollSignals;
-  style?: CSSProperties;
-  "data-testid"?: string;
-  tabIndex?: number;
-}) {
+}: OverlayScrollAreaProps) {
   const thumbStyleValue = useGet(scrollSignals.thumbStyle$);
   const setScrollMetrics = useSet(scrollSignals.setScrollMetrics$);
   const setViewportRef = useSet(scrollSignals.setScrollViewport$);
 
-  const handleScroll = (e: UIEvent<HTMLDivElement>) => {
-    const el = e.currentTarget;
-    const { scrollTop, scrollHeight, clientHeight } = el;
-    setScrollMetrics({ scrollTop, scrollHeight, clientHeight });
+  const handleScroll = (event: UIEvent<HTMLDivElement>) => {
+    updateScrollMetrics(event, setScrollMetrics);
   };
 
   return (
@@ -71,4 +88,70 @@ export function OverlayScrollArea({
       </div>
     </div>
   );
+}
+
+function BaseUiOverlayScrollArea({
+  "aria-label": ariaLabel,
+  className,
+  children,
+  onFocus,
+  onPointerDownCapture,
+  scrollSignals,
+  style,
+  "data-testid": dataTestId,
+  tabIndex,
+}: OverlayScrollAreaProps) {
+  const setScrollMetrics = useSet(scrollSignals.setScrollMetrics$);
+  const setViewportRef = useSet(scrollSignals.setScrollViewport$);
+
+  const handleScroll = (event: UIEvent<HTMLDivElement>) => {
+    updateScrollMetrics(event, setScrollMetrics);
+  };
+
+  return (
+    <ScrollArea.Root
+      className={`group/sidebar-scroll relative ${className ?? ""}`}
+    >
+      <ScrollArea.Viewport
+        ref={setViewportRef}
+        className="h-full overflow-x-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        style={{ ...style, overflowX: "hidden", overflowY: "auto" }}
+        onFocus={onFocus}
+        onPointerDownCapture={onPointerDownCapture}
+        onScroll={handleScroll}
+        tabIndex={tabIndex ?? -1}
+        role={ariaLabel ? "region" : undefined}
+        aria-label={ariaLabel}
+        data-testid={dataTestId}
+      >
+        <ScrollArea.Content style={{ minWidth: "100%" }}>
+          {children}
+        </ScrollArea.Content>
+      </ScrollArea.Viewport>
+      <ScrollArea.Scrollbar
+        className="w-3 px-[3.5px] opacity-0 transition-opacity duration-150 data-hovering:opacity-100 data-scrolling:opacity-100"
+        style={{
+          insetInlineEnd: "-0.5rem",
+          paddingBlockEnd: 0,
+          paddingBlockStart: 0,
+        }}
+        data-testid="sidebar-scrollbar"
+      >
+        <ScrollArea.Thumb
+          className="w-[5px] rounded-full bg-foreground/15"
+          style={{ marginBlockEnd: 0, marginBlockStart: 0 }}
+          data-testid="sidebar-scrollbar-thumb"
+        />
+      </ScrollArea.Scrollbar>
+    </ScrollArea.Root>
+  );
+}
+
+/** Overlay scroll area with a feature-gated draggable Base UI scrollbar. */
+export function OverlayScrollArea(props: OverlayScrollAreaProps) {
+  const baseUiEnabled = useGet(baseUiSidebarScrollAreaEnabled$);
+  if (baseUiEnabled) {
+    return <BaseUiOverlayScrollArea {...props} />;
+  }
+  return <LegacyOverlayScrollArea {...props} />;
 }

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -202,6 +202,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.BaseUiSidebarScrollArea]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.MorningBrief]).toBe(true);
 
@@ -232,6 +233,9 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.BaseUiSidebarScrollArea]).toBe(
+      false,
+    );
     expect(otherOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(false);
   });

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -58,6 +58,7 @@ export enum FeatureSwitchKey {
   MarkdownHexColorPreview = "markdownHexColorPreview",
   FollowUpOptimize = "followUpOptimize",
   ResponsiveFollowupCards = "responsiveFollowupCards",
+  BaseUiSidebarScrollArea = "baseUiSidebarScrollArea",
   SidebarSubscriptionUsage = "_sidebarSubscriptionUsage",
   PersonalModelProviderAccounts = "_multipleSubscriptions",
   ConnectorAccounts = "connectorAccounts",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -426,6 +426,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.BaseUiSidebarScrollArea]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Use the Base UI Scroll Area for draggable chat sidebar scrollbars.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.GradientColorThemes]: {
     maintainer: "ming@vm0.ai",
     description:

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -567,6 +567,9 @@ importers:
 
   apps/platform:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.7.0
+        version: 1.7.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/clerk-js':
         specifier: 6.25.8
         version: 6.25.8(@types/react@19.2.14)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)(use-sync-external-store@1.6.0(react@19.2.6))(zod@4.3.6)


### PR DESCRIPTION
## Summary

- add a staff-org `baseUiSidebarScrollArea` feature switch while retaining the current scroll area when disabled
- use Base UI Scroll Area for draggable sidebar scrollbars in both responsive and three-column layouts
- keep the existing ccstate virtual window, focus behavior, and scroll callbacks unchanged
- cover existing virtualization through the Base UI viewport and real scrollbar-thumb dragging

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --silent=passed-only` (31 passed)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx --silent=passed-only` (85 passed)
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/core lint`
- targeted platform Oxlint, type-aware Oxlint, and ESLint
- Prettier check for all changed files
