### PR TITLE
fix(api): refresh api release marker comment

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createProductionApp } from "./production-bootstrap";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed for the GitHub App slug cutover on 2026-09-02)
+// (no-op API release marker refreshed to deploy the public artifact base URL on 2026-09-03)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary

- refresh the existing no-op API release marker comment
- trigger a release-please API release so production picks up `OKOU_PUBLIC_ARTIFACTS_BASE_URL=https://a.okou.io`
- intentionally make no runtime behavior change

## Verification

- `git diff --check`
- API package type check: `pnpm --dir turbo --filter api check-types`
- repository Prettier, Knip, and file-size checks passed; the full pre-commit type-check task exceeded its 5-minute local hook timeout before the targeted API check passed

This PR is intentionally comment-only and exists to trigger a release-please API release.