### PR TITLE
fix(platform): scroll voice draft level history

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -36,6 +36,28 @@ const L = logger("VoiceIO:STT");
 
 const resetRecord$ = resetSignal();
 const resetVoiceSilenceTimer$ = resetSignal();
+const VOICE_LEVEL_SAMPLE_COUNT = 32;
+const VOICE_LEVEL_SAMPLE_INTERVAL_MS = 100;
+
+export interface VoiceLevelSample {
+  readonly id: number;
+  readonly level: number;
+}
+
+interface VoiceLevelHistory {
+  readonly nextId: number;
+  readonly samples: readonly VoiceLevelSample[];
+}
+
+function initialVoiceLevelHistory(): VoiceLevelHistory {
+  return {
+    nextId: VOICE_LEVEL_SAMPLE_COUNT,
+    samples: Array.from({ length: VOICE_LEVEL_SAMPLE_COUNT }, (_, id) => {
+      return { id, level: 0 };
+    }),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Internal state
 // ---------------------------------------------------------------------------
@@ -45,6 +67,7 @@ const internalStarting$ = state(false);
 const internalTranscribing$ = state(false);
 const internalSpeechDetected$ = state(false);
 const internalVoiceLevel$ = state(0);
+const internalVoiceLevelHistory$ = state(initialVoiceLevelHistory());
 const internalVoiceDetectedDuringRecording$ = state(false);
 const internalVoiceActivityAvailable$ = state(false);
 const internalVoiceActivityCoversRecording$ = state(false);
@@ -58,6 +81,7 @@ const internalStartingPromise$ =
   state<Promise<VoiceRecordingStartup | null> | null>(null);
 const internalStopAndTranscribePromise$ = state<Promise<void> | null>(null);
 export interface VoiceRecordingLifecycle {
+  readonly started: () => void;
   readonly finish: () => Promise<void>;
   readonly fail: () => Promise<void>;
 }
@@ -88,6 +112,9 @@ export const sttTranscribing$ = computed((get) => {
 });
 export const sttVoiceLevel$ = computed((get) => {
   return get(internalVoiceLevel$);
+});
+export const sttVoiceLevelSamples$ = computed((get) => {
+  return get(internalVoiceLevelHistory$).samples;
 });
 export const sttRecordingStartedAt$ = computed((get) => {
   return get(internalRecordingStartedAtEpochMs$);
@@ -199,6 +226,7 @@ interface VoiceActivity {
 
 type VoiceActivityCallback = (activity: VoiceActivity) => void;
 type VoiceSegmentTranscribedCallback = (text: string) => void;
+type VoiceSilenceStop = ReturnType<typeof createDeferredPromise<void>>;
 
 interface VoiceRecordingSession {
   readonly cancel: () => void;
@@ -214,7 +242,7 @@ interface VoiceRecordingStartup {
 }
 
 interface AudioActivityTracker {
-  handle(samples: Float32Array<ArrayBufferLike>): void;
+  handle(samples: Float32Array<ArrayBufferLike>): number;
   reset(): void;
 }
 
@@ -353,7 +381,7 @@ function createAudioActivityTracker(
   let lastSpeechAt = 0;
 
   return {
-    handle(samples: Float32Array<ArrayBufferLike>): void {
+    handle(samples: Float32Array<ArrayBufferLike>): number {
       const now = audioActivityNow();
       const nextRms = rms(samples);
       if (nextRms >= VOICE_ACTIVITY_RMS_THRESHOLD) {
@@ -368,6 +396,7 @@ function createAudioActivityTracker(
         level = nextLevel;
         onActivity({ detected: nextActive, level: nextLevel });
       }
+      return nextLevel;
     },
     reset(): void {
       lastSpeechAt = 0;
@@ -389,6 +418,7 @@ async function closeAudioContextQuietly(
 async function startAudioActivityMonitor(
   stream: MediaStream,
   onActivity: VoiceActivityCallback,
+  onLevelSample: (level: number) => void,
   signal: AbortSignal,
 ): Promise<AudioActivityMonitor | null> {
   const AudioContextConstructor = audioContextConstructor();
@@ -428,12 +458,18 @@ async function startAudioActivityMonitor(
     stopped: false,
   };
 
+  let nextLevelSampleAt = audioActivityNow() + VOICE_LEVEL_SAMPLE_INTERVAL_MS;
   const update = () => {
     if (monitor.stopped) {
       return;
     }
     monitor.analyser.getFloatTimeDomainData(monitor.samples);
-    monitor.tracker.handle(monitor.samples);
+    const level = monitor.tracker.handle(monitor.samples);
+    const currentTime = audioActivityNow();
+    if (currentTime >= nextLevelSampleAt) {
+      onLevelSample(level);
+      nextLevelSampleAt = currentTime + VOICE_LEVEL_SAMPLE_INTERVAL_MS;
+    }
     monitor.frameId = requestFrame(update);
   };
 
@@ -494,6 +530,7 @@ const resetState$ = command(({ set }) => {
   set(internalTranscribing$, false);
   set(internalSpeechDetected$, false);
   set(internalVoiceLevel$, 0);
+  set(internalVoiceLevelHistory$, initialVoiceLevelHistory());
   set(internalVoiceDetectedDuringRecording$, false);
   set(internalVoiceActivityAvailable$, false);
   set(internalVoiceActivityCoversRecording$, false);
@@ -508,10 +545,20 @@ const resetState$ = command(({ set }) => {
   set(internalStream$, null);
 });
 
+const appendVoiceLevelSample$ = command(({ set }, level: number) => {
+  set(internalVoiceLevelHistory$, (history) => {
+    return {
+      nextId: history.nextId + 1,
+      samples: [...history.samples.slice(1), { id: history.nextId, level }],
+    };
+  });
+});
+
 const prepareRecordingStart$ = command(({ set }) => {
   set(internalStarting$, true);
   set(internalSpeechDetected$, false);
   set(internalVoiceLevel$, 0);
+  set(internalVoiceLevelHistory$, initialVoiceLevelHistory());
   set(internalVoiceDetectedDuringRecording$, false);
   set(internalVoiceActivityAvailable$, false);
   set(internalVoiceActivityCoversRecording$, false);
@@ -1102,8 +1149,7 @@ export const startRecording$ = command(
     const signal = set(prepareRecordingLifecycle$, parentSignal, lifecycle);
     let audioActivityMonitor: AudioActivityMonitor | null = null;
     let voiceActivityReliable = false;
-    let silenceStop: ReturnType<typeof createDeferredPromise<void>> | null =
-      null;
+    let silenceStop: VoiceSilenceStop | null = null;
     const starting = withCleanup(
       (async (): Promise<VoiceRecordingStartup | null> => {
         await waitForBrowserPaint(signal);
@@ -1158,6 +1204,7 @@ export const startRecording$ = command(
         set(internalStream$, stream);
         set(internalRecorder$, recorder);
         set(internalRecordingSession$, session);
+        lifecycle?.started();
         return { stream, session, recordingStartedAt };
       })(),
       () => {
@@ -1186,6 +1233,9 @@ export const startRecording$ = command(
             set(internalVoiceDetectedDuringRecording$, true);
           }
           recordingSession.handleActivity(activity);
+        },
+        (level) => {
+          set(appendVoiceLevelSample$, level);
         },
         signal,
       ),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -1756,6 +1756,132 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("keeps the composer footer visible until a voice draft microphone starts", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e2000000-0000-4000-a000-000000000026";
+    const microphoneReady = context.mocks.deferred<void>();
+    context.mocks.browser.voiceInput({
+      getUserMediaReady: microphoneReady.promise,
+      rms: 0.1,
+    });
+    mockChatLifecycle(context, { threadId });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.VoiceDraft]: true },
+    });
+
+    const composer = await screen.findByPlaceholderText(PLACEHOLDER);
+    const composerShell = composerElementFrom(composer);
+    await user.click(await screen.findByLabelText("Voice input"));
+
+    await waitFor(() => {
+      expect(
+        within(composerShell).getByLabelText("Starting voice input"),
+      ).toBeDisabled();
+    });
+    expect(within(composerShell).getByLabelText("Send")).toBeInTheDocument();
+    expect(document.querySelector("[data-voice-draft]")).toBeNull();
+    expect(within(composerShell).queryByLabelText("Stop recording")).toBeNull();
+
+    microphoneReady.resolve(undefined);
+
+    await waitFor(() => {
+      expect(
+        within(composerShell).getByLabelText("Stop recording"),
+      ).toBeEnabled();
+    });
+    expect(within(composerShell).queryByLabelText("Send")).toBeNull();
+    expect(document.querySelector("[data-voice-draft]")).not.toBeNull();
+  });
+
+  it("restores the composer footer when a voice draft microphone fails to open", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e2000000-0000-4000-a000-000000000027";
+    const microphoneReady = context.mocks.deferred<void>();
+    context.mocks.browser.voiceInput({
+      getUserMediaReady: microphoneReady.promise,
+      rms: 0.1,
+    });
+    mockChatLifecycle(context, { threadId });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.VoiceDraft]: true },
+    });
+
+    const composer = await screen.findByPlaceholderText(PLACEHOLDER);
+    const composerShell = composerElementFrom(composer);
+    await user.click(await screen.findByLabelText("Voice input"));
+    await waitFor(() => {
+      expect(
+        within(composerShell).getByLabelText("Starting voice input"),
+      ).toBeDisabled();
+    });
+
+    microphoneReady.reject(
+      new DOMException("Microphone permission denied", "NotAllowedError"),
+    );
+
+    await waitFor(() => {
+      expect(within(composerShell).getByLabelText("Voice input")).toBeEnabled();
+    });
+    expect(within(composerShell).getByLabelText("Send")).toBeInTheDocument();
+    expect(within(composerShell).queryByLabelText("Stop recording")).toBeNull();
+    expect(document.querySelector("[data-voice-draft]")).toBeNull();
+  });
+
+  it("scrolls sampled voice draft levels from right to left", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e2000000-0000-4000-a000-000000000028";
+    let currentRms = 0.1;
+    context.mocks.browser.voiceInput({
+      rms: () => {
+        return currentRms;
+      },
+    });
+    mockChatLifecycle(context, { threadId });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.VoiceDraft]: true },
+    });
+
+    await screen.findByPlaceholderText(PLACEHOLDER);
+    await user.click(await screen.findByLabelText("Voice input"));
+    await screen.findByLabelText("Stop recording");
+
+    const waveform = await waitFor(() => {
+      const element = document.querySelector("[data-voice-level-waveform]");
+      if (!(element instanceof HTMLElement)) {
+        throw new Error("Voice level waveform not found");
+      }
+      return element;
+    });
+    const waveformHeights = () => {
+      return Array.from(waveform.children, (bar) => {
+        if (!(bar instanceof HTMLElement)) {
+          throw new Error("Voice level bar not found");
+        }
+        return bar.style.height;
+      });
+    };
+
+    await waitFor(() => {
+      expect(waveformHeights().at(-1)).toBe("16px");
+    });
+    currentRms = 0;
+
+    await waitFor(() => {
+      const heights = waveformHeights();
+      expect(heights.at(-1)).toBe("4px");
+      expect(heights.slice(0, -1)).toContain("16px");
+    });
+  });
+
   it("starts recording before the voice activity monitor is ready", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "e2000000-0000-4000-a000-000000000012";

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -133,6 +133,7 @@ import type {
 import { AttachmentChips } from "./attachment-chips.tsx";
 import { ImageAnnotationEditor } from "./image-annotation-editor.tsx";
 import { TiptapWorkflowComposer } from "./tiptap-workflow-composer.tsx";
+import { VoiceLevelWaveform } from "./voice-level-waveform.tsx";
 import { computerUseIllustrationImg } from "./platform-assets.ts";
 import type { ComposerPasteEvent } from "./composer-input-types.ts";
 import {
@@ -254,6 +255,7 @@ import {
   sttStarting$,
   sttTranscribing$,
   sttVoiceLevel$,
+  sttVoiceLevelSamples$,
   startRecording$,
   stopAndTranscribe$,
 } from "../../signals/voice-io/voice-io-stt.ts";
@@ -8937,22 +8939,34 @@ function MicButton({ signals }: { signals: ComposerSignals }) {
       return;
     }
     if (voiceDraftEnabled) {
-      const id = startVoiceDraft();
+      let voiceDraftId: string | null = null;
       detach(
         startRec(
           (text) => {
-            appendVoiceDraftTranscript(id, text);
+            if (voiceDraftId === null) {
+              return;
+            }
+            appendVoiceDraftTranscript(voiceDraftId, text);
             detach(saveDraft(signal), Reason.DomCallback);
           },
           quota.limit === null,
           {
+            started: () => {
+              voiceDraftId = startVoiceDraft();
+            },
             finish: async () => {
-              await finishVoiceDraft(id, "automatic", signal);
+              if (voiceDraftId === null) {
+                return;
+              }
+              await finishVoiceDraft(voiceDraftId, "automatic", signal);
               signal.throwIfAborted();
               await saveDraft(signal);
             },
             fail: async () => {
-              markVoiceDraftFailed(id);
+              if (voiceDraftId === null) {
+                return;
+              }
+              markVoiceDraftFailed(voiceDraftId);
               await saveDraft(signal);
             },
           },
@@ -9014,31 +9028,6 @@ function MicButton({ signals }: { signals: ComposerSignals }) {
   );
 }
 
-const VOICE_WAVEFORM_WEIGHTS = [
-  0.35, 0.64, 0.43, 0.82, 0.54, 1, 0.68, 0.39, 0.77, 0.49, 0.93, 0.58, 0.33,
-  0.72, 0.47, 0.87, 0.56, 0.97, 0.41, 0.79, 0.52, 0.7, 0.37, 0.62,
-] as const;
-
-function VoiceLevelWaveform({ level }: { level: number }) {
-  return (
-    <div
-      className="flex h-6 min-w-0 flex-1 items-center justify-center gap-1 overflow-hidden"
-      aria-hidden="true"
-    >
-      {VOICE_WAVEFORM_WEIGHTS.map((weight) => {
-        const height = Math.round(4 + level * 4 * weight);
-        return (
-          <span
-            key={weight}
-            className="w-0.5 shrink-0 rounded-full bg-[#2E9E9F] transition-[height] duration-100"
-            style={{ height: `${height}px` }}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
 function formatVoiceRecordingDuration(elapsedTime: number): string {
   const totalSeconds = Math.floor(elapsedTime / 1000);
   const minutes = Math.floor(totalSeconds / 60)
@@ -9054,7 +9043,7 @@ function VoiceDraftFooter({ status }: { status: "recording" | "processing" }) {
   const starting = useGet(sttStarting$);
   const transcribing = useGet(sttTranscribing$);
   const recordingStartedAt = useGet(sttRecordingStartedAt$);
-  const voiceLevel = useGet(sttVoiceLevel$);
+  const voiceLevelSamples = useGet(sttVoiceLevelSamples$);
   const stopAndTranscribe = useSet(stopAndTranscribe$);
   const signal = useGet(pageSignal$);
   const processing = transcribing || status === "processing";
@@ -9096,7 +9085,7 @@ function VoiceDraftFooter({ status }: { status: "recording" | "processing" }) {
           {formatVoiceRecordingDuration}
         </ElapsedTime>
       )}
-      <VoiceLevelWaveform level={voiceLevel} />
+      <VoiceLevelWaveform samples={voiceLevelSamples} />
       <Button
         type="button"
         variant="outline"

--- a/turbo/apps/platform/src/views/okou-page/voice-level-waveform.tsx
+++ b/turbo/apps/platform/src/views/okou-page/voice-level-waveform.tsx
@@ -1,0 +1,26 @@
+import type { VoiceLevelSample } from "../../signals/voice-io/voice-io-stt.ts";
+
+export function VoiceLevelWaveform({
+  samples,
+}: {
+  samples: readonly VoiceLevelSample[];
+}) {
+  return (
+    <div
+      className="flex h-6 min-w-0 flex-1 items-center justify-end gap-1 overflow-hidden"
+      data-voice-level-waveform
+      aria-hidden="true"
+    >
+      {samples.map((sample) => {
+        const height = 4 + sample.level * 4;
+        return (
+          <span
+            key={sample.id}
+            className="w-0.5 shrink-0 rounded-full bg-[#2E9E9F] transition-[height] duration-100 ease-linear"
+            style={{ height: `${height}px` }}
+          />
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- keep the normal composer footer visible while microphone access is opening, with the mic button showing its starting state
- create the hidden voice draft only after `MediaRecorder` starts, so denied microphone access returns cleanly to the idle composer
- sample voice levels at 10 Hz and scroll 32 samples from right to left in the recording footer

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx --maxWorkers=1 --silent=passed-only` (42 tests passed)
- `pnpm -F @okouai/app check-types`
- targeted Oxlint, type-aware Oxlint, and ESLint for changed files
- `pnpm knip --workspace @okouai/app`

Local browser verification was not run, per the repository instruction to rely on the PR pipeline unless a local dev server is explicitly requested.
