### PR TITLE
feat(platform): preview inline hex code colors

### DIFF
--- a/turbo/apps/platform/src/lib/markdown/pipeline.ts
+++ b/turbo/apps/platform/src/lib/markdown/pipeline.ts
@@ -1,4 +1,4 @@
-import type { Data, ElementContent, Root, RootContent } from "hast";
+import type { Data, Element, ElementContent, Root, RootContent } from "hast";
 import { marked, Renderer, type Token, type Tokens } from "marked";
 import { normalizeUri } from "micromark-util-sanitize-uri";
 import rehypeAttrs from "rehype-attr";
@@ -335,11 +335,31 @@ const rewriteUnknownTags = rehypeRewriteHandle((node, _index, parent) => {
   }
 });
 
-const COLOR_PREVIEW_EXCLUDED_TAGS: ReadonlySet<string> = new Set([
-  "a",
-  "code",
-  "pre",
-]);
+const COLOR_PREVIEW_EXCLUDED_TAGS: ReadonlySet<string> = new Set(["a", "pre"]);
+
+function colorPreviewNode(color: string): Element {
+  return {
+    type: "element",
+    tagName: "span",
+    properties: {},
+    data: { colorPreview: color },
+    children: [],
+  };
+}
+
+function inlineCodeColor(node: Element): string | undefined {
+  if (node.children.length !== 1) {
+    return undefined;
+  }
+  const child = node.children[0];
+  if (child.type !== "text") {
+    return undefined;
+  }
+  const [color] = findHexRgbColors(child.value);
+  return color?.start === 0 && color.end === child.value.length
+    ? color.color
+    : undefined;
+}
 
 function colorPreviewChildren(value: string): readonly ElementContent[] {
   const colors = findHexRgbColors(value);
@@ -353,16 +373,7 @@ function colorPreviewChildren(value: string): readonly ElementContent[] {
     if (start > offset) {
       children.push({ type: "text", value: value.slice(offset, start) });
     }
-    children.push(
-      { type: "text", value: color },
-      {
-        type: "element",
-        tagName: "span",
-        properties: {},
-        data: { colorPreview: color },
-        children: [],
-      },
-    );
+    children.push({ type: "text", value: color }, colorPreviewNode(color));
     offset = end;
   }
   if (offset < value.length) {
@@ -378,6 +389,19 @@ function rehypeColorPreviews() {
         node.type === "element" &&
         COLOR_PREVIEW_EXCLUDED_TAGS.has(node.tagName)
       ) {
+        return SKIP;
+      }
+      if (node.type === "element" && node.tagName === "code") {
+        const color = inlineCodeColor(node);
+        if (
+          color !== undefined &&
+          parent !== undefined &&
+          index !== undefined &&
+          (parent.type === "element" || parent.type === "root")
+        ) {
+          parent.children.splice(index + 1, 0, colorPreviewNode(color));
+          return [SKIP, index + 2];
+        }
         return SKIP;
       }
       if (node.type !== "text" || parent === undefined || index === undefined) {

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -270,14 +270,16 @@ describe("assistant markdown", () => {
     expect(preview).toHaveAttribute("aria-hidden", "true");
   });
 
-  it("only previews complete HEX colors in ordinary rich Markdown text", async () => {
+  it("previews complete HEX colors after ordinary text and inline code", async () => {
     mockThread(
       [
-        "**Brand** #A1b2C3 and `#112233`.",
+        "**Brand** #A1b2C3 and `#A8B5A2`.",
         "",
         "[#445566](https://example.com/#445566)",
         "",
         "Not #ABC, #12345678, or word#ABCDEF.",
+        "",
+        "```text\n#77736F\n```",
       ].join("\n"),
     );
 
@@ -290,15 +292,22 @@ describe("assistant markdown", () => {
     });
 
     await screen.findByText("Brand", { selector: "strong, b" });
+    const inlineCode = await screen.findByText("#A8B5A2", {
+      selector: "code",
+    });
     await waitFor(() => {
-      const previews = document.querySelectorAll(
+      const previews = document.querySelectorAll<HTMLElement>(
         "[data-markdown-color-preview]",
       );
-      expect(previews).toHaveLength(1);
-      expect(previews[0]).toHaveAttribute(
-        "data-markdown-color-preview",
-        "#A1b2C3",
-      );
+      expect(
+        [...previews].map((preview) => {
+          return preview.dataset.markdownColorPreview;
+        }),
+      ).toStrictEqual(["#A1b2C3", "#A8B5A2"]);
+      expect(
+        inlineCode.querySelector("[data-markdown-color-preview]"),
+      ).toBeNull();
+      expect(inlineCode.nextElementSibling).toBe(previews[1]);
     });
   });
 


### PR DESCRIPTION
## Summary

- append the existing HEX swatch after inline Markdown code containing exactly one six-digit RGB color
- keep the inline code element and styling unchanged while continuing to exclude links and fenced code blocks
- reuse the existing `markdownHexColorPreview` feature switch from #31511

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/components/__tests__/markdown.test.tsx --silent=passed-only` (28 passed)
- `pnpm knip --workspace @okouai/app`
- `git diff --check`

## Related

- follow-up to #31511
