### PR TITLE
refactor(api): switch custom oauth state discriminator

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/custom-connectors-oauth2.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/custom-connectors-oauth2.test.ts
@@ -125,7 +125,7 @@ describe("Custom connector OAuth public-brand callbacks", () => {
       ).resolves.toMatchObject({
         custom_oauth_state: {
           auth_mode: "oauth",
-          context_format: "legacy",
+          context_format: "canonical",
           context_valid: true,
         },
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts
@@ -550,7 +550,7 @@ describe("POST /api/mcp-connectors/:id/oauth2/reauthorize", () => {
       ).resolves.toMatchObject({
         custom_oauth_state: {
           auth_mode: "automatic",
-          context_format: "legacy",
+          context_format: "canonical",
           context_valid: true,
         },
       });
@@ -629,7 +629,7 @@ describe("POST /api/mcp-connectors/:id/oauth2/reauthorize", () => {
       ).resolves.toMatchObject({
         custom_oauth_state: {
           auth_mode: "automatic",
-          context_format: "legacy",
+          context_format: "canonical",
           context_valid: true,
         },
       });

--- a/turbo/apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts
@@ -922,6 +922,8 @@ async function resolveAutomaticOAuthClient(
 }
 
 export type CustomConnectorAutomaticOAuthStateContext = {
+  readonly version: 2;
+  readonly authMode: "automatic";
   readonly connectorId: string;
   readonly storageVersion: number;
   readonly issuer: string;
@@ -946,18 +948,12 @@ export type CustomConnectorAutomaticOAuthStateContext = {
     }
 );
 
-export type LegacyCustomConnectorAutomaticOAuthStateContext =
-  CustomConnectorAutomaticOAuthStateContext & {
-    readonly version: 1;
-    readonly oauthSetup: "automatic";
-  };
-
 interface CustomConnectorAutomaticOAuthAuthorization {
   readonly kind: "oauth";
   readonly authorizationUrl: string;
   readonly codeVerifier: string;
   readonly requestedScope: string | null;
-  readonly context: LegacyCustomConnectorAutomaticOAuthStateContext;
+  readonly context: CustomConnectorAutomaticOAuthStateContext;
 }
 
 async function discoverBoundAutomaticOAuthAuthority(
@@ -1056,8 +1052,8 @@ export async function prepareCustomConnectorAutomaticOAuthReauthorization(
     },
   );
   const contextBase = {
-    version: 1,
-    oauthSetup: "automatic",
+    version: 2,
+    authMode: "automatic",
     connectorId: args.binding.customConnectorId,
     storageVersion: args.storageVersion,
     issuer: args.binding.issuer,
@@ -1070,7 +1066,7 @@ export async function prepareCustomConnectorAutomaticOAuthReauthorization(
     clientId: args.binding.clientId,
     tokenEndpointAuthMethod: args.binding.tokenEndpointAuthMethod,
   } as const;
-  const context: LegacyCustomConnectorAutomaticOAuthStateContext =
+  const context: CustomConnectorAutomaticOAuthStateContext =
     args.binding.registrationMethod === "dcr"
       ? {
           ...contextBase,
@@ -1173,8 +1169,8 @@ export async function prepareCustomConnectorAutomaticOAuthAuthorization(
     },
   );
   const contextBase = {
-    version: 1,
-    oauthSetup: "automatic",
+    version: 2,
+    authMode: "automatic",
     connectorId: args.customConnectorId,
     storageVersion: args.storageVersion,
     issuer: authority.issuer,
@@ -1187,7 +1183,7 @@ export async function prepareCustomConnectorAutomaticOAuthAuthorization(
     clientId: client.clientId,
     tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
   } as const;
-  const context: LegacyCustomConnectorAutomaticOAuthStateContext =
+  const context: CustomConnectorAutomaticOAuthStateContext =
     client.registrationMethod === "dcr"
       ? {
           ...contextBase,

--- a/turbo/apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts
@@ -922,8 +922,6 @@ async function resolveAutomaticOAuthClient(
 }
 
 export type CustomConnectorAutomaticOAuthStateContext = {
-  readonly version: 2;
-  readonly authMode: "automatic";
   readonly connectorId: string;
   readonly storageVersion: number;
   readonly issuer: string;
@@ -948,12 +946,18 @@ export type CustomConnectorAutomaticOAuthStateContext = {
     }
 );
 
+export type CustomConnectorCanonicalAutomaticOAuthStateContext =
+  CustomConnectorAutomaticOAuthStateContext & {
+    readonly version: 2;
+    readonly authMode: "automatic";
+  };
+
 interface CustomConnectorAutomaticOAuthAuthorization {
   readonly kind: "oauth";
   readonly authorizationUrl: string;
   readonly codeVerifier: string;
   readonly requestedScope: string | null;
-  readonly context: CustomConnectorAutomaticOAuthStateContext;
+  readonly context: CustomConnectorCanonicalAutomaticOAuthStateContext;
 }
 
 async function discoverBoundAutomaticOAuthAuthority(
@@ -1066,7 +1070,7 @@ export async function prepareCustomConnectorAutomaticOAuthReauthorization(
     clientId: args.binding.clientId,
     tokenEndpointAuthMethod: args.binding.tokenEndpointAuthMethod,
   } as const;
-  const context: CustomConnectorAutomaticOAuthStateContext =
+  const context: CustomConnectorCanonicalAutomaticOAuthStateContext =
     args.binding.registrationMethod === "dcr"
       ? {
           ...contextBase,
@@ -1183,7 +1187,7 @@ export async function prepareCustomConnectorAutomaticOAuthAuthorization(
     clientId: client.clientId,
     tokenEndpointAuthMethod: client.tokenEndpointAuthMethod,
   } as const;
-  const context: CustomConnectorAutomaticOAuthStateContext =
+  const context: CustomConnectorCanonicalAutomaticOAuthStateContext =
     client.registrationMethod === "dcr"
       ? {
           ...contextBase,

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -93,7 +93,7 @@ import {
   refreshCustomConnectorAutomaticOAuthToken,
   retireCustomConnectorDcrRegistration,
   type CustomConnectorAutomaticOAuthBinding,
-  type LegacyCustomConnectorAutomaticOAuthStateContext,
+  type CustomConnectorAutomaticOAuthStateContext as PreparedCustomConnectorAutomaticOAuthStateContext,
 } from "./custom-connector-automatic-oauth.service";
 import { configuredOkouMcpOAuthClientMetadata } from "./mcp-oauth-client-metadata.service";
 
@@ -266,14 +266,6 @@ const customConnectorOAuthStateContextSchema = z.union([
 type CustomConnectorOAuthStateContext = z.infer<
   typeof customConnectorOAuthStateContextSchema
 >;
-
-type CustomConnectorLegacyCustomOAuthStateContext = z.infer<
-  typeof customConnectorLegacyCustomOAuthStateContextSchema
->;
-
-type CustomConnectorLegacyOAuthStateContext =
-  | CustomConnectorLegacyCustomOAuthStateContext
-  | LegacyCustomConnectorAutomaticOAuthStateContext;
 
 export type CustomConnectorCustomOAuthStateContext = z.infer<
   typeof customConnectorCustomOAuthStateContextSchema
@@ -672,16 +664,22 @@ interface StartCustomConnectorOAuth2Args {
   };
 }
 
-interface PreparedOAuthStart {
-  readonly oauthSetup: "custom" | "automatic";
+type PreparedOAuthStart = {
   readonly redirectUri: string;
   readonly state: string;
   readonly authorizationUrl: string;
   readonly codeVerifier: string | null;
   readonly oauthRequestedScopes: string | null;
-  // Keep emitting the legacy callback state until #31471 is deployed.
-  readonly context: CustomConnectorLegacyOAuthStateContext;
-}
+} & (
+  | {
+      readonly authMode: "oauth";
+      readonly context: CustomConnectorCanonicalCustomOAuthStateContext;
+    }
+  | {
+      readonly authMode: "automatic";
+      readonly context: PreparedCustomConnectorAutomaticOAuthStateContext;
+    }
+);
 
 function connectorConnectionMutationFailure(
   resolution: ConnectorConnectionMutationResolution,
@@ -709,7 +707,7 @@ function prepareCustomOAuthStart(
   const codeVerifier =
     connector.oauthConfig.pkceMethod === "S256" ? createPkceVerifier() : null;
   return {
-    oauthSetup: "custom",
+    authMode: "oauth",
     redirectUri: args.redirectUri,
     state,
     authorizationUrl: buildCustomConnectorOAuth2AuthorizationUrl({
@@ -721,7 +719,8 @@ function prepareCustomOAuthStart(
     codeVerifier,
     oauthRequestedScopes: null,
     context: {
-      oauthSetup: "custom",
+      version: 2,
+      authMode: "oauth",
       connectorId: connector.id,
       storageVersion: connector.storageVersion,
       ...(connector.oauthConfig.providerAdapter === "feishu" &&
@@ -824,14 +823,14 @@ async function prepareAutomaticOAuthStart(
     result: {
       kind: "oauth" as const,
       prepared: {
-        oauthSetup: "automatic",
+        authMode: "automatic",
         redirectUri: client.redirectUri,
         state,
         authorizationUrl: prepared.authorizationUrl,
         codeVerifier: prepared.codeVerifier,
         oauthRequestedScopes: prepared.requestedScope,
         context:
-          prepared.context satisfies LegacyCustomConnectorAutomaticOAuthStateContext,
+          prepared.context satisfies PreparedCustomConnectorAutomaticOAuthStateContext,
       } satisfies PreparedOAuthStart,
     },
   };
@@ -855,7 +854,7 @@ async function persistCustomConnectorOAuthStart(
       orgId: args.orgId,
       connectorId: connector.id,
       storageVersion: connector.storageVersion,
-      authMode: prepared.oauthSetup === "automatic" ? "automatic" : "oauth",
+      authMode: prepared.authMode,
     });
     const resolution = await resolveConnectorConnectionMutation(tx, {
       orgId: args.orgId,
@@ -1277,7 +1276,7 @@ export const startCustomConnectorAutomaticOAuthReauthorization$ = command(
         },
         featureContext,
         prepared: {
-          oauthSetup: "automatic",
+          authMode: "automatic",
           redirectUri,
           state,
           authorizationUrl: prepared.authorizationUrl,

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -93,7 +93,7 @@ import {
   refreshCustomConnectorAutomaticOAuthToken,
   retireCustomConnectorDcrRegistration,
   type CustomConnectorAutomaticOAuthBinding,
-  type CustomConnectorAutomaticOAuthStateContext as PreparedCustomConnectorAutomaticOAuthStateContext,
+  type CustomConnectorCanonicalAutomaticOAuthStateContext as PreparedCustomConnectorAutomaticOAuthStateContext,
 } from "./custom-connector-automatic-oauth.service";
 import { configuredOkouMcpOAuthClientMetadata } from "./mcp-oauth-client-metadata.service";
 


### PR DESCRIPTION
## Summary

- switch Custom OAuth callback-state writers to canonical `version: 2` / `authMode: "oauth"` contexts
- switch initial Automatic OAuth and scope-reauthorization writers to canonical `version: 2` / `authMode: "automatic"` contexts
- make the shared prepared-state model use authoritative `authMode` while retaining strict legacy and canonical callback readers
- update API integration assertions to prove canonical writes and continued callback completion

## Compatibility and rollout

- #30891 / PR #31498 is deployed and accepts the canonical contexts emitted here, preserving rolling API and supported rollback compatibility
- unexpired legacy callback states remain readable during and after this deployment
- #31472 must wait until this PR is deployed fleet-wide and the 15-minute callback-state TTL has elapsed after legacy writers drain

## Exclusions

- no UI or user-flow changes
- no public API, runner, token, account, or OAuth provider behavior changes
- no database migration or `org_custom_connectors.oauth_setup` column removal; #31476 owns that independent cleanup
- no legacy callback reader removal; #31472 owns that post-drain cleanup

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/custom-connector-automatic-oauth.service.ts apps/api/src/signals/services/custom-connector-oauth2.service.ts apps/api/src/signals/routes/__tests__/custom-connectors-oauth2.test.ts apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/custom-connectors-oauth2.test.ts src/signals/routes/__tests__/mcp-connectors.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts --maxWorkers=4 --silent=passed-only` — 105 tests passed
- `pnpm knip --workspace api`
- `git diff --check`
- pre-commit full-repository Knip and TypeScript checks

Closes #31471

Parent: #30466
