### PR TITLE
refactor(python): centralize runner state marker publication

### DIFF
--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -1,11 +1,9 @@
 """Runner-triggered usage flush and JSONL marker-watcher lifecycle owner."""
 
-import json
 import os
 import signal
 import threading
 import time
-from contextlib import suppress
 from pathlib import Path
 from typing import Literal
 
@@ -15,6 +13,7 @@ import claude_output_timing
 import codex_output_timing
 import logging_utils
 import runner_flush_request
+import state_file
 import usage
 
 _RunnerFlushPhase = Literal["running", "draining", "closed"]
@@ -43,11 +42,12 @@ _usage_flush_signal_lock = threading.Lock()
 # Running workers own requests under the lock. During shutdown, drain_and_close()
 # changes the phase before waiting for that lock and becomes the sole draining owner.
 _runner_flush_phase: _RunnerFlushPhase = "running"
-_jsonl_flush_state_write_lock = threading.Lock()
+_jsonl_flush_state_publisher = state_file.AtomicJsonPublisher()
 _jsonl_flush_worker_lock = threading.Lock()
 _jsonl_flush_stop = threading.Event()
 _jsonl_flush_worker: threading.Thread | None = None
 _last_jsonl_flush_request_id: str | None = None
+_last_jsonl_state_write_error_request_id: str | None = None
 _JSONL_FLUSH_REQUEST_FILE = "jsonl-flush-request"
 _JSONL_FLUSH_STATE_FILE = "jsonl-flush-state"
 RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS = 4.0
@@ -89,7 +89,8 @@ def wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout: float = 1.0) -
 
 
 def reset_runner_usage_flush_state_for_tests(timeout: float = 1.0) -> None:
-    global _last_jsonl_flush_request_id, _runner_flush_phase, _usage_flush_requested
+    global _last_jsonl_flush_request_id, _last_jsonl_state_write_error_request_id
+    global _runner_flush_phase, _usage_flush_requested
 
     _stop_runner_jsonl_flush_worker()
     acquired = _usage_flush_signal_lock.acquire(timeout=timeout)
@@ -99,6 +100,7 @@ def reset_runner_usage_flush_state_for_tests(timeout: float = 1.0) -> None:
         _runner_flush_phase = "running"
         _usage_flush_requested = False
         _last_jsonl_flush_request_id = None
+        _last_jsonl_state_write_error_request_id = None
     finally:
         _usage_flush_signal_lock.release()
 
@@ -317,7 +319,9 @@ def _write_jsonl_flush_state(
     *,
     pending: int = 0,
 ) -> bool:
-    state = {
+    global _last_jsonl_state_write_error_request_id
+
+    state: dict[str, object] = {
         "pid": os.getpid(),
         "usageStateId": usage.current_usage_state_id(),
         "updatedAtMs": int(time.time() * 1000),
@@ -325,21 +329,21 @@ def _write_jsonl_flush_state(
         "path": log_path,
         "pending": pending,
     }
-    tmp_path = state_path.with_name(f"{state_path.name}.{flush_request_id}.tmp")
-    with _jsonl_flush_state_write_lock:
-        try:
-            with tmp_path.open("w") as f:
-                json.dump(state, f, separators=(",", ":"))
-            tmp_path.replace(state_path)
-            return True
-        except OSError as exc:
-            with suppress(OSError):
-                tmp_path.unlink()
+    try:
+        _jsonl_flush_state_publisher.publish(state_path, state)
+        return True
+    except OSError as exc:
+        if _last_jsonl_state_write_error_request_id != flush_request_id:
+            _last_jsonl_state_write_error_request_id = flush_request_id
             addon_process_logging.emit_addon_process_event(
                 "warn",
-                f"Failed to write JSONL flush state: {type(exc).__name__}: {exc}",
+                (
+                    f"Failed to write JSONL flush state for request {flush_request_id!r} at "
+                    f"{state_path}: {type(exc).__name__}: {exc}. Subsequent failures for this "
+                    "request will be silent."
+                ),
             )
-            return False
+        return False
 
 
 def drain_and_close() -> None:

--- a/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
+++ b/crates/runner/mitm-addon/src/runner_flush_lifecycle.py
@@ -338,9 +338,9 @@ def _write_jsonl_flush_state(
             addon_process_logging.emit_addon_process_event(
                 "warn",
                 (
-                    f"Failed to write JSONL flush state for request {flush_request_id!r} at "
-                    f"{state_path}: {type(exc).__name__}: {exc}. Subsequent failures for this "
-                    "request will be silent."
+                    f"Failed to write JSONL flush state for request {flush_request_id!r} "
+                    f"({type(exc).__name__}). Subsequent failures for this request will be "
+                    f"silent. State path: {state_path}. Error: {exc}"
                 ),
             )
         return False

--- a/crates/runner/mitm-addon/src/state_file.py
+++ b/crates/runner/mitm-addon/src/state_file.py
@@ -1,8 +1,12 @@
-"""Safe bounded reads for runner-owned state files."""
+"""Shared state-file reads and atomic JSON publication."""
 
+import json
 import os
 import stat
+import threading
+import uuid
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple, Self
@@ -10,6 +14,35 @@ from typing import NamedTuple, Self
 _READ_CHUNK_BYTES = 1024 * 1024
 
 type StatValidator = Callable[[Path, os.stat_result], None]
+
+
+class AtomicJsonPublisher:
+    """Publish compact JSON with atomic visibility for one state-file owner.
+
+    Each instance serializes its own writes so independent state protocols do
+    not block one another. Publication is not crash durable: callers own any
+    durability, retry, and diagnostic policy beyond same-directory replacement.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def publish(self, path: Path, state: dict[str, object]) -> None:
+        """Replace ``path`` with compact JSON, cleaning failed attempts.
+
+        Filesystem failures are re-raised after best-effort temporary-file
+        cleanup so the protocol owner can apply its own failure policy.
+        """
+        tmp_path = path.with_name(f"{path.name}.{uuid.uuid4()}.tmp")
+        with self._lock:
+            try:
+                with tmp_path.open("w") as output:
+                    json.dump(state, output, separators=(",", ":"))
+                tmp_path.replace(path)
+            except OSError:
+                with suppress(OSError):
+                    tmp_path.unlink()
+                raise
 
 
 class StateFileIdentity(NamedTuple):

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -8,22 +8,20 @@ only; runner-requested snapshots are JSON written atomically (tmp +
 process or old flush request.
 """
 
-import json
 import os
 import threading
 import time
 import uuid
-from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import runner_flush_request
+import state_file
 
 from .underbilling import log_usage_underbilling
 
 _counter_lock = threading.Lock()
-_pending_write_lock = threading.Lock()
+_pending_state_publisher = state_file.AtomicJsonPublisher()
 _buffered_usage_events = 0
 _pending_path = ""
 _usage_state_id = str(uuid.uuid4())
@@ -83,8 +81,8 @@ def current_usage_state_id() -> str:
         return _usage_state_id
 
 
-def _pending_snapshot_locked(flush_request_id: str | None = None) -> tuple[str, dict[str, Any]]:
-    state: dict[str, Any] = {
+def _pending_snapshot_locked(flush_request_id: str | None = None) -> tuple[str, dict[str, object]]:
+    state: dict[str, object] = {
         "pid": os.getpid(),
         "usageStateId": _usage_state_id,
         "updatedAtMs": int(time.time() * 1000),
@@ -122,38 +120,32 @@ def read_usage_flush_request_id() -> str | None:
     return request.flush_request_id
 
 
-def _write_pending_state(pending_path: str, state: dict[str, Any]) -> None:
+def _write_pending_state(pending_path: str, state: dict[str, object]) -> None:
     """Atomically write a pending-count snapshot to file."""
     global _pending_write_error_logged
     if not pending_path:
         return
-    tmp = Path(f"{pending_path}.{uuid.uuid4()}.tmp")
-    with _pending_write_lock:
-        try:
-            with tmp.open("w") as f:
-                json.dump(state, f, separators=(",", ":"))
-            tmp.replace(pending_path)
-        except OSError as exc:
-            with suppress(OSError):
-                tmp.unlink()
-            # Best-effort: the runner polls this file to wait for in-flight
-            # flows, buffered work, and pending reports to drain before
-            # SIGTERM. Transient write failures are upper-bounded by the
-            # runner's drain timeout and mitmdump stop timeout.
-            if not _pending_write_error_logged:
-                _pending_write_error_logged = True
-                log_usage_underbilling(
-                    "",
-                    (
-                        "Failed to write pending count. Subsequent failures in this process will "
-                        "be silent; runner shutdown may hit the bounded proxy stop timeout."
-                    ),
-                    "pending_snapshot_write_failed",
-                    "risk",
-                    error=str(exc),
-                    error_type=type(exc).__name__,
-                    pending_path=pending_path,
-                )
+    try:
+        _pending_state_publisher.publish(Path(pending_path), state)
+    except OSError as exc:
+        # Best-effort: the runner polls this file to wait for in-flight
+        # flows, buffered work, and pending reports to drain before
+        # SIGTERM. Transient write failures are upper-bounded by the
+        # runner's drain timeout and mitmdump stop timeout.
+        if not _pending_write_error_logged:
+            _pending_write_error_logged = True
+            log_usage_underbilling(
+                "",
+                (
+                    "Failed to write pending count. Subsequent failures in this process will "
+                    "be silent; runner shutdown may hit the bounded proxy stop timeout."
+                ),
+                "pending_snapshot_write_failed",
+                "risk",
+                error=str(exc),
+                error_type=type(exc).__name__,
+                pending_path=pending_path,
+            )
 
 
 def increment_in_flight_flows() -> None:

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 import flow_metadata_keys as metadata_keys
+import state_file
 import usage
 from tests.pending_helpers import assert_current_pending, assert_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event
@@ -59,7 +60,7 @@ class TestUsagePendingCounter:
     def test_reset_for_tests_reenables_pending_write_failure_signal(self, tmp_path, mitm_ctx):
         with (
             mitm_ctx() as mock_log,
-            patch.object(usage.counters.Path, "open", side_effect=OSError("disk full")),
+            patch.object(state_file.Path, "open", side_effect=OSError("disk full")),
         ):
             usage.set_pending_path(str(tmp_path / "usage-pending-before-reset"))
             usage.write_pending_snapshot(flush_request_id="before-reset")
@@ -353,7 +354,7 @@ class TestUsagePendingCounter:
         with (
             mitm_ctx() as mock_log,
             patch.object(
-                usage.counters.Path,
+                state_file.Path,
                 "replace",
                 side_effect=OSError("replace failed\nretry"),
             ),
@@ -391,7 +392,7 @@ class TestUsagePendingCounter:
 
         with (
             mitm_ctx() as mock_log,
-            patch.object(usage.counters.Path, "open", side_effect=write_error),
+            patch.object(state_file.Path, "open", side_effect=write_error),
         ):
             usage.set_pending_path(pending_path)
             for _ in range(2):
@@ -424,6 +425,6 @@ class TestUsagePendingCounter:
 
         with (
             mitm_ctx(),
-            patch.object(usage.counters.Path, "open", side_effect=OSError("disk full")),
+            patch.object(state_file.Path, "open", side_effect=OSError("disk full")),
         ):
             usage.write_pending_snapshot(flush_request_id="request-1")  # should not raise

--- a/crates/runner/mitm-addon/tests/test_runner_jsonl_flush.py
+++ b/crates/runner/mitm-addon/tests/test_runner_jsonl_flush.py
@@ -327,7 +327,8 @@ class TestRunnerJsonlFlush:
         log.warn.assert_called_once()
         warning = log.warn.call_args.args[0]
         assert _DEFAULT_JSONL_FLUSH_REQUEST_ID in warning
-        assert "OSError: state replace failed" in warning
+        assert "(OSError)" in warning
+        assert "Error: state replace failed" in warning
         assert "Subsequent failures for this request will be silent" in warning
 
     def test_persistent_jsonl_acknowledgement_write_failure_logs_once_per_request(
@@ -375,6 +376,7 @@ class TestRunnerJsonlFlush:
 
         assert flush_log_path.call_count == 4
         assert len(failed_tmp_paths) == 4
+        assert len(set(failed_tmp_paths)) == 4
         assert state_path.read_text() == baseline_state
         assert all(not tmp_path.exists() for tmp_path in failed_tmp_paths)
         assert list(runner_jsonl_flush_files.tmp_path.glob(f"{state_path.name}.*.tmp")) == []

--- a/crates/runner/mitm-addon/tests/test_runner_jsonl_flush.py
+++ b/crates/runner/mitm-addon/tests/test_runner_jsonl_flush.py
@@ -15,6 +15,7 @@ import pytest
 import jsonl_writer
 import logging_utils
 import runner_flush_lifecycle
+import state_file
 import usage
 from tests.process_log_helpers import capture_addon_process_events
 
@@ -287,20 +288,15 @@ class TestRunnerJsonlFlush:
     ):
         log_path = runner_jsonl_flush_files.write_jsonl_flush_request()
         state_path = runner_jsonl_flush_files.jsonl_flush_state_path
-        tmp_state_path = state_path.with_name(
-            f"{state_path.name}.{_DEFAULT_JSONL_FLUSH_REQUEST_ID}.tmp"
-        )
         original_replace = Path.replace
-        failure_injected = False
+        failed_tmp_paths: list[Path] = []
 
         def fail_first_state_replace(
             source: Path,
             target: str | os.PathLike[str],
         ) -> Path:
-            nonlocal failure_injected
-
-            if source == tmp_state_path and Path(target) == state_path and not failure_injected:
-                failure_injected = True
+            if Path(target) == state_path and not failed_tmp_paths:
+                failed_tmp_paths.append(source)
                 raise OSError("state replace failed")
             return original_replace(source, target)
 
@@ -310,13 +306,13 @@ class TestRunnerJsonlFlush:
                 "flush_log_path",
                 wraps=logging_utils.flush_log_path,
             ) as flush_log_path,
-            capture_addon_process_events(),
-            patch.object(Path, "replace", new=fail_first_state_replace),
+            capture_addon_process_events() as log,
+            patch.object(state_file.Path, "replace", new=fail_first_state_replace),
             running_jsonl_flush_worker(runner_jsonl_flush_files),
         ):
             state = wait_for_jsonl_flush_state(runner_jsonl_flush_files)
 
-        assert failure_injected
+        assert len(failed_tmp_paths) == 1
         assert flush_log_path.call_count == 2
         assert state == {
             "pid": state["pid"],
@@ -326,7 +322,80 @@ class TestRunnerJsonlFlush:
             "path": str(log_path),
             "pending": 0,
         }
-        assert not tmp_state_path.exists()
+        assert not failed_tmp_paths[0].exists()
+        assert list(runner_jsonl_flush_files.tmp_path.glob(f"{state_path.name}.*.tmp")) == []
+        log.warn.assert_called_once()
+        warning = log.warn.call_args.args[0]
+        assert _DEFAULT_JSONL_FLUSH_REQUEST_ID in warning
+        assert "OSError: state replace failed" in warning
+        assert "Subsequent failures for this request will be silent" in warning
+
+    def test_persistent_jsonl_acknowledgement_write_failure_logs_once_per_request(
+        self, runner_jsonl_flush_files: RunnerJsonlFlushFiles
+    ):
+        state_path = runner_jsonl_flush_files.jsonl_flush_state_path
+        log_path = runner_jsonl_flush_files.write_jsonl_flush_request(
+            flush_request_id="baseline-request"
+        )
+        runner_flush_lifecycle._flush_jsonl_for_runner_request(
+            runner_jsonl_flush_files.jsonl_flush_request_path,
+            state_path,
+        )
+        baseline_state = state_path.read_text()
+        original_replace = Path.replace
+        failed_tmp_paths: list[Path] = []
+
+        def fail_state_replace(
+            source: Path,
+            target: str | os.PathLike[str],
+        ) -> Path:
+            if Path(target) == state_path:
+                failed_tmp_paths.append(source)
+                raise OSError("persistent state replace failure")
+            return original_replace(source, target)
+
+        runner_jsonl_flush_files.write_jsonl_flush_request(flush_request_id="failed-request-1")
+        with (
+            patch.object(logging_utils, "flush_log_path", return_value=True) as flush_log_path,
+            capture_addon_process_events() as log,
+            patch.object(state_file.Path, "replace", new=fail_state_replace),
+        ):
+            for _ in range(2):
+                runner_flush_lifecycle._flush_jsonl_for_runner_request(
+                    runner_jsonl_flush_files.jsonl_flush_request_path,
+                    state_path,
+                )
+
+            runner_jsonl_flush_files.write_jsonl_flush_request(flush_request_id="failed-request-2")
+            for _ in range(2):
+                runner_flush_lifecycle._flush_jsonl_for_runner_request(
+                    runner_jsonl_flush_files.jsonl_flush_request_path,
+                    state_path,
+                )
+
+        assert flush_log_path.call_count == 4
+        assert len(failed_tmp_paths) == 4
+        assert state_path.read_text() == baseline_state
+        assert all(not tmp_path.exists() for tmp_path in failed_tmp_paths)
+        assert list(runner_jsonl_flush_files.tmp_path.glob(f"{state_path.name}.*.tmp")) == []
+        assert log.warn.call_count == 2
+        warnings = [call.args[0] for call in log.warn.call_args_list]
+        assert "failed-request-1" in warnings[0]
+        assert "failed-request-2" in warnings[1]
+        assert all("persistent state replace failure" in warning for warning in warnings)
+        assert all(
+            "Subsequent failures for this request will be silent" in warning for warning in warnings
+        )
+
+        runner_jsonl_flush_files.write_jsonl_flush_request(flush_request_id="recovered-request")
+        runner_flush_lifecycle._flush_jsonl_for_runner_request(
+            runner_jsonl_flush_files.jsonl_flush_request_path,
+            state_path,
+        )
+        recovered_state = json.loads(state_path.read_text())
+        assert recovered_state["flushRequestId"] == "recovered-request"
+        assert recovered_state["path"] == str(log_path)
+        assert recovered_state["pending"] == 0
 
     def test_jsonl_watcher_acknowledges_rapid_sequential_paths(
         self, runner_jsonl_flush_files: RunnerJsonlFlushFiles


### PR DESCRIPTION
## Summary

- centralize addon-owned atomic JSON state publication in a per-owner `AtomicJsonPublisher`
- preserve the existing usage-pending underbilling policy while sharing UUID temporary files, compact serialization, atomic replacement, and failed-file cleanup
- bound JSONL acknowledgement write warnings to once per request ID without suppressing retries or acknowledging failed writes
- cover persistent and transient publication failures, prior-state preservation, temporary cleanup, distinct requests, and recovery

## Exclusions

- no changes to `usage-pending` or `jsonl-flush-state` schemas
- no Rust-side protocol or timeout changes
- no crash-durability, retry-interval, migration, or rollout fallback changes

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_state_file.py tests/test_counters.py tests/test_runner_jsonl_flush.py` (`41 passed`)
- `uv run --no-sync python -m pytest tests/` (`7334 passed`)

Closes #31551
