### PR TITLE
refactor(vsock-guest): centralize lazy worker lifecycle

### DIFF
--- a/crates/vsock-guest/src/guest_dns_readiness.rs
+++ b/crates/vsock-guest/src/guest_dns_readiness.rs
@@ -2,9 +2,9 @@ use std::io;
 use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, SyncSender, TrySendError};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -15,16 +15,14 @@ use vsock_proto::{
 
 use crate::drain::{BoundedDrainResult, DrainCancellation, drain_bounded_cancellable};
 use crate::error::to_io_error;
-use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
 use crate::quiesce::OperationGuard;
 use crate::user::apply_command_identity;
 use crate::wait::{
     WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
 };
-use crate::worker_ownership::{
-    ShutdownConnectionOnDrop, SingleActiveAdmission, SingleActivePermit,
-};
+pub(crate) use crate::worker_ownership::LazyConnectionWorkerSubmitError as GuestDnsReadinessSubmitError;
+use crate::worker_ownership::{LazyConnectionWorker, SingleActivePermit};
 use crate::writer::GuestWriter;
 
 const PRODUCTION_PROGRAM: &str = "/usr/bin/getent";
@@ -58,12 +56,6 @@ impl GuestDnsReadinessProgram {
     }
 }
 
-pub(crate) enum GuestDnsReadinessSubmitError {
-    Busy,
-    Disconnected,
-    Start(io::Error),
-}
-
 struct GuestDnsReadinessRequest {
     seq: u32,
     timeout_ms: u32,
@@ -73,16 +65,7 @@ struct GuestDnsReadinessRequest {
 }
 
 pub(crate) struct GuestDnsReadinessWorker {
-    state: Mutex<GuestDnsReadinessWorkerState>,
-    writer: GuestWriter,
-    program: GuestDnsReadinessProgram,
-    admission: SingleActiveAdmission,
-    connection_cancel: Arc<AtomicBool>,
-}
-
-struct GuestDnsReadinessWorkerState {
-    sender: Option<SyncSender<GuestDnsReadinessRequest>>,
-    handle: Option<JoinHandle<()>>,
+    inner: LazyConnectionWorker<GuestDnsReadinessRequest, GuestDnsReadinessProgram>,
 }
 
 impl GuestDnsReadinessWorker {
@@ -92,19 +75,19 @@ impl GuestDnsReadinessWorker {
         program: GuestDnsReadinessProgram,
     ) -> Self {
         Self {
-            state: Mutex::new(GuestDnsReadinessWorkerState {
-                sender: None,
-                handle: None,
-            }),
-            writer,
-            program,
-            admission: SingleActiveAdmission::new(),
-            connection_cancel,
+            inner: LazyConnectionWorker::new(
+                writer,
+                connection_cancel,
+                program,
+                handle_request,
+                THREAD_WORKER,
+                "guest DNS readiness worker",
+            ),
         }
     }
 
     pub(crate) fn try_admit(&self) -> Option<SingleActivePermit> {
-        self.admission.try_acquire()
+        self.inner.try_admit()
     }
 
     pub(crate) fn submit(
@@ -115,65 +98,14 @@ impl GuestDnsReadinessWorker {
         operation_guard: OperationGuard,
         admission: SingleActivePermit,
     ) -> Result<(), GuestDnsReadinessSubmitError> {
-        let sender = self.sender()?;
-        let request = GuestDnsReadinessRequest {
-            seq,
-            timeout_ms,
-            hostname: hostname.to_owned(),
-            operation_guard,
-            admission,
-        };
-        match sender.try_send(request) {
-            Ok(()) => Ok(()),
-            Err(TrySendError::Full(_)) => Err(GuestDnsReadinessSubmitError::Busy),
-            Err(TrySendError::Disconnected(_)) => Err(GuestDnsReadinessSubmitError::Disconnected),
-        }
-    }
-
-    fn sender(&self) -> Result<SyncSender<GuestDnsReadinessRequest>, GuestDnsReadinessSubmitError> {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        if let Some(sender) = &state.sender {
-            return Ok(sender.clone());
-        }
-
-        let (sender, receiver) = mpsc::sync_channel(1);
-        let writer = self.writer.clone();
-        let worker_cancel = Arc::clone(&self.connection_cancel);
-        let program = self.program.clone();
-        let handle = thread::Builder::new()
-            .name(THREAD_WORKER.to_string())
-            .spawn(move || {
-                let _shutdown_on_exit = ShutdownConnectionOnDrop::new(writer.clone());
-                while let Ok(request) = receiver.recv() {
-                    if let Err(error) = handle_request(request, &writer, &worker_cancel, &program) {
-                        log(
-                            "ERROR",
-                            &format!("guest DNS readiness worker failed: {error}"),
-                        );
-                        break;
-                    }
-                }
+        self.inner
+            .try_submit_with(move || GuestDnsReadinessRequest {
+                seq,
+                timeout_ms,
+                hostname: hostname.to_owned(),
+                operation_guard,
+                admission,
             })
-            .map_err(GuestDnsReadinessSubmitError::Start)?;
-        state.sender = Some(sender.clone());
-        state.handle = Some(handle);
-        Ok(sender)
-    }
-}
-
-impl Drop for GuestDnsReadinessWorker {
-    fn drop(&mut self) {
-        self.connection_cancel.store(true, Ordering::Release);
-        let state = self
-            .state
-            .get_mut()
-            .unwrap_or_else(|error| error.into_inner());
-        drop(state.sender.take());
-        if let Some(handle) = state.handle.take()
-            && handle.join().is_err()
-        {
-            log("ERROR", "guest DNS readiness worker panicked");
-        }
     }
 }
 

--- a/crates/vsock-guest/src/guest_state_restore.rs
+++ b/crates/vsock-guest/src/guest_state_restore.rs
@@ -1,9 +1,9 @@
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, SyncSender, TrySendError};
-use std::sync::{Arc, Mutex};
+use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -20,9 +20,8 @@ use crate::quiesce::OperationGuard;
 use crate::wait::{
     WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
 };
-use crate::worker_ownership::{
-    ShutdownConnectionOnDrop, SingleActiveAdmission, SingleActivePermit,
-};
+pub(crate) use crate::worker_ownership::LazyConnectionWorkerSubmitError as GuestStateRestoreSubmitError;
+use crate::worker_ownership::{LazyConnectionWorker, SingleActivePermit};
 use crate::writer::GuestWriter;
 
 const THREAD_WORKER: &str = "vsock-guest-state-restore";
@@ -51,12 +50,6 @@ impl GuestStateRestoreProgram {
             Self::Test(path) => path,
         }
     }
-}
-
-pub(crate) enum GuestStateRestoreSubmitError {
-    Busy,
-    Disconnected,
-    Start(io::Error),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -101,18 +94,14 @@ struct GuestStateRestoreRequest {
     admission: SingleActivePermit,
 }
 
-pub(crate) struct GuestStateRestoreWorker {
-    state: Mutex<GuestStateRestoreWorkerState>,
-    writer: GuestWriter,
+#[derive(Clone)]
+struct GuestStateRestoreWorkerContext {
     program: GuestStateRestoreProgram,
-    admission: SingleActiveAdmission,
-    connection_cancel: Arc<AtomicBool>,
     drain_deadline: Duration,
 }
 
-struct GuestStateRestoreWorkerState {
-    sender: Option<SyncSender<GuestStateRestoreRequest>>,
-    handle: Option<JoinHandle<()>>,
+pub(crate) struct GuestStateRestoreWorker {
+    inner: LazyConnectionWorker<GuestStateRestoreRequest, GuestStateRestoreWorkerContext>,
 }
 
 impl GuestStateRestoreWorker {
@@ -123,20 +112,22 @@ impl GuestStateRestoreWorker {
         drain_deadline: Duration,
     ) -> Self {
         Self {
-            state: Mutex::new(GuestStateRestoreWorkerState {
-                sender: None,
-                handle: None,
-            }),
-            writer,
-            program,
-            admission: SingleActiveAdmission::new(),
-            connection_cancel,
-            drain_deadline,
+            inner: LazyConnectionWorker::new(
+                writer,
+                connection_cancel,
+                GuestStateRestoreWorkerContext {
+                    program,
+                    drain_deadline,
+                },
+                handle_worker_request,
+                THREAD_WORKER,
+                "guest state restore worker",
+            ),
         }
     }
 
     pub(crate) fn try_admit(&self) -> Option<SingleActivePermit> {
-        self.admission.try_acquire()
+        self.inner.try_admit()
     }
 
     pub(crate) fn submit(
@@ -145,55 +136,17 @@ impl GuestStateRestoreWorker {
         operation_guard: OperationGuard,
         admission: SingleActivePermit,
     ) -> Result<(), GuestStateRestoreSubmitError> {
-        let sender = self.sender()?;
-        let request = GuestStateRestoreRequest {
-            seq: submission.seq,
-            timeout_ms: submission.timeout_ms,
-            unix_seconds: submission.unix_seconds,
-            unix_nanoseconds: submission.unix_nanoseconds,
-            entropy: submission.entropy.to_vec(),
-            timezone: OwnedTimezone::from_borrowed(submission.timezone),
-            operation_guard,
-            admission,
-        };
-        match sender.try_send(request) {
-            Ok(()) => Ok(()),
-            Err(TrySendError::Full(_)) => Err(GuestStateRestoreSubmitError::Busy),
-            Err(TrySendError::Disconnected(_)) => Err(GuestStateRestoreSubmitError::Disconnected),
-        }
-    }
-
-    fn sender(&self) -> Result<SyncSender<GuestStateRestoreRequest>, GuestStateRestoreSubmitError> {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        if let Some(sender) = &state.sender {
-            return Ok(sender.clone());
-        }
-
-        let (sender, receiver) = mpsc::sync_channel(1);
-        let writer = self.writer.clone();
-        let worker_cancel = Arc::clone(&self.connection_cancel);
-        let program = self.program.clone();
-        let drain_deadline = self.drain_deadline;
-        let handle = thread::Builder::new()
-            .name(THREAD_WORKER.to_string())
-            .spawn(move || {
-                let _shutdown_on_exit = ShutdownConnectionOnDrop::new(writer.clone());
-                while let Ok(request) = receiver.recv() {
-                    if let Err(error) =
-                        handle_request(request, &writer, &worker_cancel, &program, drain_deadline)
-                    {
-                        log(
-                            "ERROR",
-                            &format!("guest state restore worker failed: {error}"),
-                        );
-                        break;
-                    }
-                }
+        self.inner
+            .try_submit_with(move || GuestStateRestoreRequest {
+                seq: submission.seq,
+                timeout_ms: submission.timeout_ms,
+                unix_seconds: submission.unix_seconds,
+                unix_nanoseconds: submission.unix_nanoseconds,
+                entropy: submission.entropy.to_vec(),
+                timezone: OwnedTimezone::from_borrowed(submission.timezone),
+                operation_guard,
+                admission,
             })
-            .map_err(GuestStateRestoreSubmitError::Start)?;
-        state.sender = Some(sender.clone());
-        state.handle = Some(handle);
-        Ok(sender)
     }
 }
 
@@ -206,27 +159,26 @@ pub(crate) struct GuestStateRestoreSubmission<'a> {
     pub(crate) timezone: GuestStateRestoreTimezone<'a>,
 }
 
-impl Drop for GuestStateRestoreWorker {
-    fn drop(&mut self) {
-        self.connection_cancel.store(true, Ordering::Release);
-        let state = self
-            .state
-            .get_mut()
-            .unwrap_or_else(|error| error.into_inner());
-        drop(state.sender.take());
-        if let Some(handle) = state.handle.take()
-            && handle.join().is_err()
-        {
-            log("ERROR", "guest state restore worker panicked");
-        }
-    }
-}
-
 struct GuestStateRestoreOutput {
     termination: ExecTermination,
     duration_ms: u32,
     stderr: BoundedDrainResult,
     diagnostic: String,
+}
+
+fn handle_worker_request(
+    request: GuestStateRestoreRequest,
+    writer: &GuestWriter,
+    connection_cancel: &AtomicBool,
+    context: &GuestStateRestoreWorkerContext,
+) -> io::Result<()> {
+    handle_request(
+        request,
+        writer,
+        connection_cancel,
+        &context.program,
+        context.drain_deadline,
+    )
 }
 
 fn handle_request(

--- a/crates/vsock-guest/src/guest_storage_manifest.rs
+++ b/crates/vsock-guest/src/guest_storage_manifest.rs
@@ -1,9 +1,9 @@
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, SyncSender, TrySendError};
-use std::sync::{Arc, Mutex};
+use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -21,9 +21,8 @@ use crate::quiesce::OperationGuard;
 use crate::wait::{
     WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
 };
-use crate::worker_ownership::{
-    ShutdownConnectionOnDrop, SingleActiveAdmission, SingleActivePermit,
-};
+pub(crate) use crate::worker_ownership::LazyConnectionWorkerSubmitError as GuestStorageManifestSubmitError;
+use crate::worker_ownership::{LazyConnectionWorker, SingleActivePermit};
 use crate::writer::GuestWriter;
 
 const THREAD_WORKER: &str = "vsock-guest-storage-manifest";
@@ -55,12 +54,6 @@ impl GuestStorageManifestProgram {
     }
 }
 
-pub(crate) enum GuestStorageManifestSubmitError {
-    Busy,
-    Disconnected,
-    Start(io::Error),
-}
-
 struct GuestStorageManifestRequest {
     seq: u32,
     timeout_ms: u32,
@@ -71,19 +64,15 @@ struct GuestStorageManifestRequest {
     admission: SingleActivePermit,
 }
 
-pub(crate) struct GuestStorageManifestWorker {
-    state: Mutex<GuestStorageManifestWorkerState>,
-    writer: GuestWriter,
+#[derive(Clone)]
+struct GuestStorageManifestWorkerContext {
     program: GuestStorageManifestProgram,
-    admission: SingleActiveAdmission,
-    connection_cancel: Arc<AtomicBool>,
     process_containment_mode: ProcessContainmentMode,
     drain_deadline: Duration,
 }
 
-struct GuestStorageManifestWorkerState {
-    sender: Option<SyncSender<GuestStorageManifestRequest>>,
-    handle: Option<JoinHandle<()>>,
+pub(crate) struct GuestStorageManifestWorker {
+    inner: LazyConnectionWorker<GuestStorageManifestRequest, GuestStorageManifestWorkerContext>,
 }
 
 impl GuestStorageManifestWorker {
@@ -95,21 +84,23 @@ impl GuestStorageManifestWorker {
         drain_deadline: Duration,
     ) -> Self {
         Self {
-            state: Mutex::new(GuestStorageManifestWorkerState {
-                sender: None,
-                handle: None,
-            }),
-            writer,
-            program,
-            admission: SingleActiveAdmission::new(),
-            connection_cancel,
-            process_containment_mode,
-            drain_deadline,
+            inner: LazyConnectionWorker::new(
+                writer,
+                connection_cancel,
+                GuestStorageManifestWorkerContext {
+                    program,
+                    process_containment_mode,
+                    drain_deadline,
+                },
+                handle_worker_request,
+                THREAD_WORKER,
+                "guest storage manifest worker",
+            ),
         }
     }
 
     pub(crate) fn try_admit(&self) -> Option<SingleActivePermit> {
-        self.admission.try_acquire()
+        self.inner.try_admit()
     }
 
     pub(crate) fn submit(
@@ -118,64 +109,16 @@ impl GuestStorageManifestWorker {
         operation_guard: OperationGuard,
         admission: SingleActivePermit,
     ) -> Result<(), GuestStorageManifestSubmitError> {
-        let sender = self.sender()?;
-        let request = GuestStorageManifestRequest {
-            seq: submission.seq,
-            timeout_ms: submission.timeout_ms,
-            run_id: submission.run_id.to_owned(),
-            runtime_dir: submission.runtime_dir.to_owned(),
-            manifest_json: submission.manifest_json.to_vec(),
-            operation_guard,
-            admission,
-        };
-        match sender.try_send(request) {
-            Ok(()) => Ok(()),
-            Err(TrySendError::Full(_)) => Err(GuestStorageManifestSubmitError::Busy),
-            Err(TrySendError::Disconnected(_)) => {
-                Err(GuestStorageManifestSubmitError::Disconnected)
-            }
-        }
-    }
-
-    fn sender(
-        &self,
-    ) -> Result<SyncSender<GuestStorageManifestRequest>, GuestStorageManifestSubmitError> {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        if let Some(sender) = &state.sender {
-            return Ok(sender.clone());
-        }
-
-        let (sender, receiver) = mpsc::sync_channel(1);
-        let writer = self.writer.clone();
-        let worker_cancel = Arc::clone(&self.connection_cancel);
-        let program = self.program.clone();
-        let process_containment_mode = self.process_containment_mode;
-        let drain_deadline = self.drain_deadline;
-        let handle = thread::Builder::new()
-            .name(THREAD_WORKER.to_string())
-            .spawn(move || {
-                let _shutdown_on_exit = ShutdownConnectionOnDrop::new(writer.clone());
-                while let Ok(request) = receiver.recv() {
-                    if let Err(error) = handle_request(
-                        request,
-                        &writer,
-                        &worker_cancel,
-                        &program,
-                        process_containment_mode,
-                        drain_deadline,
-                    ) {
-                        log(
-                            "ERROR",
-                            &format!("guest storage manifest worker failed: {error}"),
-                        );
-                        break;
-                    }
-                }
+        self.inner
+            .try_submit_with(move || GuestStorageManifestRequest {
+                seq: submission.seq,
+                timeout_ms: submission.timeout_ms,
+                run_id: submission.run_id.to_owned(),
+                runtime_dir: submission.runtime_dir.to_owned(),
+                manifest_json: submission.manifest_json.to_vec(),
+                operation_guard,
+                admission,
             })
-            .map_err(GuestStorageManifestSubmitError::Start)?;
-        state.sender = Some(sender.clone());
-        state.handle = Some(handle);
-        Ok(sender)
     }
 }
 
@@ -187,28 +130,28 @@ pub(crate) struct GuestStorageManifestSubmission<'a> {
     pub(crate) manifest_json: &'a [u8],
 }
 
-impl Drop for GuestStorageManifestWorker {
-    fn drop(&mut self) {
-        self.connection_cancel.store(true, Ordering::Release);
-        let state = self
-            .state
-            .get_mut()
-            .unwrap_or_else(|error| error.into_inner());
-        drop(state.sender.take());
-        if let Some(handle) = state.handle.take()
-            && handle.join().is_err()
-        {
-            log("ERROR", "guest storage manifest worker panicked");
-        }
-    }
-}
-
 struct GuestStorageManifestOutput {
     termination: ExecTermination,
     duration_ms: u32,
     stdout: BoundedDrainResult,
     stderr: BoundedDrainResult,
     diagnostic: String,
+}
+
+fn handle_worker_request(
+    request: GuestStorageManifestRequest,
+    writer: &GuestWriter,
+    connection_cancel: &AtomicBool,
+    context: &GuestStorageManifestWorkerContext,
+) -> io::Result<()> {
+    handle_request(
+        request,
+        writer,
+        connection_cancel,
+        &context.program,
+        context.process_containment_mode,
+        context.drain_deadline,
+    )
 }
 
 fn handle_request(

--- a/crates/vsock-guest/src/worker_ownership.rs
+++ b/crates/vsock-guest/src/worker_ownership.rs
@@ -1,7 +1,142 @@
-use std::sync::Arc;
+use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
 
+use crate::log::log;
 use crate::writer::GuestWriter;
+
+pub(crate) enum LazyConnectionWorkerSubmitError {
+    Busy,
+    Disconnected,
+    Start(io::Error),
+}
+
+struct LazyConnectionWorkerState<Request> {
+    sender: Option<SyncSender<Request>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+type LazyConnectionWorkerHandler<Request, Context> =
+    fn(Request, &GuestWriter, &AtomicBool, &Context) -> io::Result<()>;
+
+pub(crate) struct LazyConnectionWorker<Request, Context>
+where
+    Request: Send + 'static,
+    Context: Clone + Send + 'static,
+{
+    state: Mutex<LazyConnectionWorkerState<Request>>,
+    writer: GuestWriter,
+    context: Context,
+    handler: LazyConnectionWorkerHandler<Request, Context>,
+    thread_name: &'static str,
+    worker_label: &'static str,
+    admission: SingleActiveAdmission,
+    connection_cancel: Arc<AtomicBool>,
+}
+
+impl<Request, Context> LazyConnectionWorker<Request, Context>
+where
+    Request: Send + 'static,
+    Context: Clone + Send + 'static,
+{
+    pub(crate) fn new(
+        writer: GuestWriter,
+        connection_cancel: Arc<AtomicBool>,
+        context: Context,
+        handler: LazyConnectionWorkerHandler<Request, Context>,
+        thread_name: &'static str,
+        worker_label: &'static str,
+    ) -> Self {
+        Self {
+            state: Mutex::new(LazyConnectionWorkerState {
+                sender: None,
+                handle: None,
+            }),
+            writer,
+            context,
+            handler,
+            thread_name,
+            worker_label,
+            admission: SingleActiveAdmission::new(),
+            connection_cancel,
+        }
+    }
+
+    pub(crate) fn try_admit(&self) -> Option<SingleActivePermit> {
+        self.admission.try_acquire()
+    }
+
+    pub(crate) fn try_submit_with(
+        &self,
+        build_request: impl FnOnce() -> Request,
+    ) -> Result<(), LazyConnectionWorkerSubmitError> {
+        let sender = self.sender()?;
+        match sender.try_send(build_request()) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => Err(LazyConnectionWorkerSubmitError::Busy),
+            Err(TrySendError::Disconnected(_)) => {
+                Err(LazyConnectionWorkerSubmitError::Disconnected)
+            }
+        }
+    }
+
+    fn sender(&self) -> Result<SyncSender<Request>, LazyConnectionWorkerSubmitError> {
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        if let Some(sender) = &state.sender {
+            return Ok(sender.clone());
+        }
+
+        // Admission bounds active plus queued work to one. The channel keeps
+        // submission nonblocking even before the worker reaches `recv`.
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let writer = self.writer.clone();
+        let worker_cancel = Arc::clone(&self.connection_cancel);
+        let context = self.context.clone();
+        let handler = self.handler;
+        let worker_label = self.worker_label;
+        let handle = thread::Builder::new()
+            .name(self.thread_name.to_string())
+            .spawn(move || {
+                // Each lazy worker belongs to one connection. Any thread exit
+                // closes it so no host request can lose its response producer.
+                let _shutdown_on_exit = ShutdownConnectionOnDrop::new(writer.clone());
+                while let Ok(request) = receiver.recv() {
+                    if let Err(error) = handler(request, &writer, &worker_cancel, &context) {
+                        log("ERROR", &format!("{worker_label} failed: {error}"));
+                        break;
+                    }
+                }
+            })
+            .map_err(LazyConnectionWorkerSubmitError::Start)?;
+        state.sender = Some(sender.clone());
+        state.handle = Some(handle);
+        Ok(sender)
+    }
+}
+
+impl<Request, Context> Drop for LazyConnectionWorker<Request, Context>
+where
+    Request: Send + 'static,
+    Context: Clone + Send + 'static,
+{
+    fn drop(&mut self) {
+        // Signal first so active domain work can stop before sender closure and
+        // the connection-owned thread join.
+        self.connection_cancel.store(true, Ordering::Release);
+        let state = self
+            .state
+            .get_mut()
+            .unwrap_or_else(|error| error.into_inner());
+        drop(state.sender.take());
+        if let Some(handle) = state.handle.take()
+            && handle.join().is_err()
+        {
+            log("ERROR", &format!("{} panicked", self.worker_label));
+        }
+    }
+}
 
 pub(crate) struct SingleActiveAdmission {
     active: Arc<AtomicBool>,

--- a/crates/vsock-guest/src/workspace_drive_mount.rs
+++ b/crates/vsock-guest/src/workspace_drive_mount.rs
@@ -1,9 +1,9 @@
 use std::io;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, SyncSender, TrySendError};
-use std::sync::{Arc, Mutex};
+use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -12,16 +12,14 @@ use vsock_proto::{ExecCapturedOutput, ExecTermination, WORKSPACE_DRIVE_MOUNT_OUT
 
 use crate::drain::{BoundedDrainResult, DrainCancellation, drain_bounded_cancellable};
 use crate::error::to_io_error;
-use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
 use crate::quiesce::OperationGuard;
 use crate::shell_command::{EnvScriptGuard, PreparedShellCommand, build_shell_command_with_env};
 use crate::wait::{
     WaitOutcome, await_drain_deadline, wait_with_kill_timeout_or_connection_cancelled,
 };
-use crate::worker_ownership::{
-    ShutdownConnectionOnDrop, SingleActiveAdmission, SingleActivePermit,
-};
+pub(crate) use crate::worker_ownership::LazyConnectionWorkerSubmitError as WorkspaceDriveMountSubmitError;
+use crate::worker_ownership::{LazyConnectionWorker, SingleActivePermit};
 use crate::writer::GuestWriter;
 
 const WORKSPACE_DIR: &str = "/home/user/workspace";
@@ -88,30 +86,20 @@ struct SpawnedWorkspaceMountCommand {
     env_script: Option<EnvScriptGuard>,
 }
 
-pub(crate) enum WorkspaceDriveMountSubmitError {
-    Busy,
-    Disconnected,
-    Start(io::Error),
-}
-
 struct WorkspaceDriveMountRequest {
     seq: u32,
     operation_guard: OperationGuard,
     admission: SingleActivePermit,
 }
 
-pub(crate) struct WorkspaceDriveMountWorker {
-    state: Mutex<WorkspaceDriveMountWorkerState>,
-    writer: GuestWriter,
+#[derive(Clone)]
+struct WorkspaceDriveMountWorkerContext {
     program: WorkspaceDriveMountProgram,
-    admission: SingleActiveAdmission,
-    connection_cancel: Arc<AtomicBool>,
     drain_deadline: Duration,
 }
 
-struct WorkspaceDriveMountWorkerState {
-    sender: Option<SyncSender<WorkspaceDriveMountRequest>>,
-    handle: Option<JoinHandle<()>>,
+pub(crate) struct WorkspaceDriveMountWorker {
+    inner: LazyConnectionWorker<WorkspaceDriveMountRequest, WorkspaceDriveMountWorkerContext>,
 }
 
 impl WorkspaceDriveMountWorker {
@@ -122,20 +110,22 @@ impl WorkspaceDriveMountWorker {
         drain_deadline: Duration,
     ) -> Self {
         Self {
-            state: Mutex::new(WorkspaceDriveMountWorkerState {
-                sender: None,
-                handle: None,
-            }),
-            writer,
-            program,
-            admission: SingleActiveAdmission::new(),
-            connection_cancel,
-            drain_deadline,
+            inner: LazyConnectionWorker::new(
+                writer,
+                connection_cancel,
+                WorkspaceDriveMountWorkerContext {
+                    program,
+                    drain_deadline,
+                },
+                handle_worker_request,
+                THREAD_WORKER,
+                "workspace drive mount worker",
+            ),
         }
     }
 
     pub(crate) fn try_admit(&self) -> Option<SingleActivePermit> {
-        self.admission.try_acquire()
+        self.inner.try_admit()
     }
 
     pub(crate) fn submit(
@@ -144,68 +134,12 @@ impl WorkspaceDriveMountWorker {
         operation_guard: OperationGuard,
         admission: SingleActivePermit,
     ) -> Result<(), WorkspaceDriveMountSubmitError> {
-        let sender = self.sender()?;
-        let request = WorkspaceDriveMountRequest {
-            seq,
-            operation_guard,
-            admission,
-        };
-        match sender.try_send(request) {
-            Ok(()) => Ok(()),
-            Err(TrySendError::Full(_)) => Err(WorkspaceDriveMountSubmitError::Busy),
-            Err(TrySendError::Disconnected(_)) => Err(WorkspaceDriveMountSubmitError::Disconnected),
-        }
-    }
-
-    fn sender(
-        &self,
-    ) -> Result<SyncSender<WorkspaceDriveMountRequest>, WorkspaceDriveMountSubmitError> {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        if let Some(sender) = &state.sender {
-            return Ok(sender.clone());
-        }
-
-        let (sender, receiver) = mpsc::sync_channel(1);
-        let writer = self.writer.clone();
-        let worker_cancel = Arc::clone(&self.connection_cancel);
-        let program = self.program.clone();
-        let drain_deadline = self.drain_deadline;
-        let handle = thread::Builder::new()
-            .name(THREAD_WORKER.to_string())
-            .spawn(move || {
-                let _shutdown_on_exit = ShutdownConnectionOnDrop::new(writer.clone());
-                while let Ok(request) = receiver.recv() {
-                    if let Err(error) =
-                        handle_request(request, &writer, &worker_cancel, &program, drain_deadline)
-                    {
-                        log(
-                            "ERROR",
-                            &format!("workspace drive mount worker failed: {error}"),
-                        );
-                        break;
-                    }
-                }
+        self.inner
+            .try_submit_with(move || WorkspaceDriveMountRequest {
+                seq,
+                operation_guard,
+                admission,
             })
-            .map_err(WorkspaceDriveMountSubmitError::Start)?;
-        state.sender = Some(sender.clone());
-        state.handle = Some(handle);
-        Ok(sender)
-    }
-}
-
-impl Drop for WorkspaceDriveMountWorker {
-    fn drop(&mut self) {
-        self.connection_cancel.store(true, Ordering::Release);
-        let state = self
-            .state
-            .get_mut()
-            .unwrap_or_else(|error| error.into_inner());
-        drop(state.sender.take());
-        if let Some(handle) = state.handle.take()
-            && handle.join().is_err()
-        {
-            log("ERROR", "workspace drive mount worker panicked");
-        }
     }
 }
 
@@ -215,6 +149,21 @@ struct WorkspaceDriveMountOutput {
     stdout: BoundedDrainResult,
     stderr: BoundedDrainResult,
     diagnostic: String,
+}
+
+fn handle_worker_request(
+    request: WorkspaceDriveMountRequest,
+    writer: &GuestWriter,
+    connection_cancel: &AtomicBool,
+    context: &WorkspaceDriveMountWorkerContext,
+) -> io::Result<()> {
+    handle_request(
+        request,
+        writer,
+        connection_cancel,
+        &context.program,
+        context.drain_deadline,
+    )
 }
 
 fn handle_request(

--- a/crates/vsock-guest/tests/connection/guest_dns_readiness.rs
+++ b/crates/vsock-guest/tests/connection/guest_dns_readiness.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::net::Shutdown;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
@@ -70,6 +71,21 @@ printf '192.0.2.1 STREAM success.invalid\n'
     assert!(!result.output_truncated);
     assert!(result.diagnostic.is_empty());
     finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn guest_dns_readiness_worker_failure_closes_connection() {
+    let (_directory, program) = create_program(
+        r#"
+printf '192.0.2.1 STREAM success.invalid\n'
+"#,
+    );
+    let (handle, mut host_stream) = start_guest_connection_with_dns_readiness_program(program);
+
+    host_stream.shutdown(Shutdown::Read).unwrap();
+    send_request(&mut host_stream, 312, 1_100, "success.invalid");
+
+    join_guest_connection(handle);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add one private, typed lazy connection-worker owner for admission, channel/thread startup, shutdown-on-exit, submission mapping, cancellation, and joining
- migrate DNS readiness, storage manifest, state restore, and workspace drive mount to that owner while retaining their domain request and execution boundaries
- cover worker response-write failure through the real connection boundary and verify it closes the owning connection

## Behavior and compatibility

- preserve capacity-one nonblocking submission, first-use startup under synchronization, retry after thread-start failure, and disconnected behavior after a running worker exits
- preserve cancellation-before-sender-close-and-join teardown, affine admission lifetime, thread names, worker diagnostics, and protocol-visible errors
- keep the eager file-write worker separate
- no wire protocol, public API, persistence, migration, configuration, dependency, feature-switch, or deployment change

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo check --manifest-path crates/Cargo.toml -p vsock-guest --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest` (183 library tests, 120 connection tests, and 2 production-identity harness tests passed; 3 existing root-only production cases ignored)
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection guest_dns_readiness_worker_failure_closes_connection`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p vsock-guest --all-features --no-deps`
- `cargo check --manifest-path crates/Cargo.toml --release -p vsock-guest --no-default-features`
- `git diff --check`

Closes #31550
