### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/.github/scripts/smoke-okou-cli-artifact.sh
+++ b/.github/scripts/smoke-okou-cli-artifact.sh
@@ -16,6 +16,8 @@ package_path="$(cd "$(dirname "$package_path")" && pwd -P)/$(basename "$package_
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
+readonly npm_advisory_retirement_notice="npm notice This endpoint is being retired. Use the bulk advisory endpoint instead."
+
 node_path="$(command -v node)"
 npx_path="$(command -v npx)"
 clean_bin="${tmp_dir}/bin"
@@ -41,18 +43,24 @@ run_cli() {
 assert_clean_success() {
   local entrypoint="$1"
   local output_name="$2"
+  local stdout_file="$tmp_dir/${output_name}.stdout"
+  local stderr_file="$tmp_dir/${output_name}.stderr"
+  local unexpected_stderr_file="$tmp_dir/${output_name}.unexpected-stderr"
   shift 2
   if ! run_cli \
     "$entrypoint" \
-    "$tmp_dir/${output_name}.stdout" \
-    "$tmp_dir/${output_name}.stderr" \
+    "$stdout_file" \
+    "$stderr_file" \
     "$@"; then
-    cat "$tmp_dir/${output_name}.stderr" >&2
+    cat "$stderr_file" >&2
     echo "CLI smoke failed: $entrypoint $*" >&2
     exit 1
   fi
-  if [[ -s "$tmp_dir/${output_name}.stderr" ]]; then
-    cat "$tmp_dir/${output_name}.stderr" >&2
+  awk -v ignored_notice="$npm_advisory_retirement_notice" \
+    '$0 != ignored_notice' \
+    "$stderr_file" >"$unexpected_stderr_file"
+  if [[ -s "$unexpected_stderr_file" ]]; then
+    cat "$unexpected_stderr_file" >&2
     echo "CLI smoke emitted unexpected stderr: $entrypoint $*" >&2
     exit 1
   fi

--- a/.github/scripts/smoke-okou-cli-artifact.sh
+++ b/.github/scripts/smoke-okou-cli-artifact.sh
@@ -35,7 +35,7 @@ run_cli() {
   local stdout_file="$2"
   local stderr_file="$3"
   shift 3
-  PATH="$clean_path" "$node_path" "$npx_path" \
+  PATH="$clean_path" npm_config_audit=false "$node_path" "$npx_path" \
     --yes --package="$package_path" "$entrypoint" "$@" \
     >"$stdout_file" 2>"$stderr_file"
 }

--- a/.github/scripts/smoke-okou-cli-artifact.sh
+++ b/.github/scripts/smoke-okou-cli-artifact.sh
@@ -16,7 +16,7 @@ package_path="$(cd "$(dirname "$package_path")" && pwd -P)/$(basename "$package_
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-readonly npm_advisory_retirement_notice="npm notice This endpoint is being retired. Use the bulk advisory endpoint instead."
+readonly npm_advisory_retirement_notice="npm notice This endpoint is being retired. Use the bulk advisory endpoint instead. See the following docs for more info: https://api-docs.npmjs.com/#tag/Audit"
 
 node_path="$(command -v node)"
 npx_path="$(command -v npx)"

--- a/.github/scripts/tests/smoke-okou-cli-artifact-test.sh
+++ b/.github/scripts/tests/smoke-okou-cli-artifact-test.sh
@@ -28,7 +28,7 @@ done
 entrypoint="$1"
 shift
 
-echo "npm notice This endpoint is being retired. Use the bulk advisory endpoint instead." >&2
+echo "npm notice This endpoint is being retired. Use the bulk advisory endpoint instead. See the following docs for more info: https://api-docs.npmjs.com/#tag/Audit" >&2
 if [[ "${EMIT_UNEXPECTED_STDERR:-false}" == "true" &&
   "$entrypoint" == "okou" && "${1:-}" == "--version" ]]; then
   echo "unexpected CLI stderr" >&2

--- a/.github/scripts/tests/smoke-okou-cli-artifact-test.sh
+++ b/.github/scripts/tests/smoke-okou-cli-artifact-test.sh
@@ -28,6 +28,11 @@ done
 entrypoint="$1"
 shift
 
+if [[ "${npm_config_audit:-}" != "false" ]]; then
+  echo "npm audit was not disabled" >&2
+  exit 1
+fi
+
 echo "npm notice This endpoint is being retired. Use the bulk advisory endpoint instead. See the following docs for more info: https://api-docs.npmjs.com/#tag/Audit" >&2
 if [[ "${EMIT_UNEXPECTED_STDERR:-false}" == "true" &&
   "$entrypoint" == "okou" && "${1:-}" == "--version" ]]; then

--- a/.github/scripts/tests/smoke-okou-cli-artifact-test.sh
+++ b/.github/scripts/tests/smoke-okou-cli-artifact-test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+smoke_script="${repo_root}/.github/scripts/smoke-okou-cli-artifact.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture_bin="${tmp_dir}/bin"
+package_path="${tmp_dir}/package.tgz"
+mkdir -p "$fixture_bin"
+printf 'fixture\n' >"$package_path"
+
+cat >"${fixture_bin}/node" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec "$@"
+EOF
+
+cat >"${fixture_bin}/npx" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+while [[ "${1:-}" == --* ]]; do
+  shift
+done
+
+entrypoint="$1"
+shift
+
+echo "npm notice This endpoint is being retired. Use the bulk advisory endpoint instead." >&2
+if [[ "${EMIT_UNEXPECTED_STDERR:-false}" == "true" &&
+  "$entrypoint" == "okou" && "${1:-}" == "--version" ]]; then
+  echo "unexpected CLI stderr" >&2
+fi
+
+case "$entrypoint:$*" in
+  "okou:--help")
+    printf 'Usage: okou\nOkou CLI\n'
+    ;;
+  "okou:--version")
+    echo "1.2.3"
+    ;;
+  "okou:__agent-loop --help")
+    echo "Internal sandbox Pi agent loop"
+    ;;
+  "okou:__unsupported-command")
+    exit 1
+    ;;
+  "zero:--help")
+    echo "unsupported entrypoint" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected invocation: $entrypoint $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+chmod +x "${fixture_bin}/node" "${fixture_bin}/npx"
+
+output="$({
+  PATH="${fixture_bin}:${PATH}" bash "$smoke_script" "$package_path"
+} 2>&1)"
+grep -Fq "Smoke-tested the canonical okou CLI and unsupported zero boundary" \
+  <<<"$output"
+
+failure_output="${tmp_dir}/failure-output.txt"
+if PATH="${fixture_bin}:${PATH}" \
+  EMIT_UNEXPECTED_STDERR=true \
+  bash "$smoke_script" "$package_path" >"$failure_output" 2>&1; then
+  echo "Smoke test unexpectedly ignored non-npm stderr" >&2
+  exit 1
+fi
+grep -Fxq "unexpected CLI stderr" "$failure_output"
+grep -Fq "CLI smoke emitted unexpected stderr: okou --version" "$failure_output"
+
+echo "smoke-okou-cli-artifact tests passed"

--- a/turbo/apps/platform/src/signals/attachment-resource-url.ts
+++ b/turbo/apps/platform/src/signals/attachment-resource-url.ts
@@ -25,11 +25,11 @@ export interface AttachmentUrls {
    */
   readonly resourceUrl: string;
   /**
-   * URL that still works for whoever receives it, or null when the attachment
-   * has no such address. Never the canonical API URL: that one answers only to
-   * the owner's credentials, so a recipient gets a 401 instead of the file.
+   * URL that still works for whoever receives it. Never the canonical API URL:
+   * that one answers only to the owner's credentials, so a recipient gets a 401
+   * instead of the file.
    */
-  readonly shareUrl: string | null;
+  readonly shareUrl: string;
 }
 
 /**
@@ -64,12 +64,7 @@ function createAttachmentResourceUrl$(
     );
     return {
       resourceUrl: response.body.url,
-      // Rollout fallback, surface new web/app -> old API: a newly promoted app
-      // can reach an API deployed before `publicUrl` existed. Report no share
-      // URL rather than a presigned one that expires under the recipient.
-      // Remove once that API is no longer serving and is no longer retained as
-      // a rollback target; follow-up #30847.
-      shareUrl: response.body.publicUrl ?? null,
+      shareUrl: response.body.publicUrl,
     };
   });
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/attachment-chips.test.tsx
@@ -1190,7 +1190,10 @@ describe("zero attachment chips", () => {
       expect(new URL(request.url).searchParams.get("file_id")).toBe(
         "attachment-photo",
       );
-      return HttpResponse.json({ url: presignedFileUrl("attachment-photo") });
+      return HttpResponse.json({
+        url: presignedFileUrl("attachment-photo"),
+        publicUrl: publicFileUrl("attachment-photo"),
+      });
     });
     mockChatLifecycle(context, {
       threadId: THREAD_ID,
@@ -1250,7 +1253,7 @@ describe("zero attachment chips", () => {
       expect(new URL(request.url).searchParams.get("file_id")).toBe(fileId);
       const url = ownerUrls[Math.min(nextOwnerUrl, ownerUrls.length - 1)]!;
       nextOwnerUrl += 1;
-      return HttpResponse.json({ url });
+      return HttpResponse.json({ url, publicUrl: publicFileUrl(fileId) });
     });
     const lifecycle = mockChatLifecycle(context, {
       threadId: leftThreadId,
@@ -1357,7 +1360,10 @@ describe("zero attachment chips", () => {
     let pageOwner: keyof typeof pageUrls = "first";
     context.mocks.http.get("/api/web/file-url", ({ request }) => {
       expect(new URL(request.url).searchParams.get("file_id")).toBe(fileId);
-      return HttpResponse.json({ url: pageUrls[pageOwner] });
+      return HttpResponse.json({
+        url: pageUrls[pageOwner],
+        publicUrl: publicFileUrl(fileId),
+      });
     });
     context.mocks.api(logsListContract.list, ({ respond }) => {
       return respond(200, {
@@ -3503,52 +3509,6 @@ describe("zero attachment chips", () => {
       screen.findByText(`![1280x720](${imageUrl})`),
     ).resolves.toBeInTheDocument();
     expect(screen.queryByAltText("1280x720")).toBeNull();
-  });
-
-  it("hides the share action when the api reports no public attachment url", async () => {
-    context.mocks.http.get("/api/web/file-url", ({ request }) => {
-      const fileId = new URL(request.url).searchParams.get("file_id") ?? "";
-      return HttpResponse.json({ url: presignedFileUrl(fileId) });
-    });
-    context.mocks.http.get(PRESIGNED_FILE_PATTERN, () => {
-      return new Response("# Release notes\n\nThe rollout is ready.", {
-        headers: { "Content-Type": "text/markdown" },
-      });
-    });
-    mockChatLifecycle(context, {
-      threadId: THREAD_ID,
-      chatEvents: [
-        {
-          id: "msg-no-public-url",
-          role: "user",
-          content: "Review this attachment",
-          fileParts: [
-            {
-              type: "file",
-              fileId: "attachment-markdown",
-              filenameSnapshot: "release-notes.md",
-              contentType: "text/markdown",
-            },
-          ],
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-      ],
-    });
-
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
-
-    click(
-      await screen.findByLabelText(
-        "Open markdown preview for release-notes.md",
-      ),
-    );
-
-    // The body renders from the same resolution that would have carried a
-    // share URL, so its arrival means "no share URL" is settled, not pending.
-    await waitFor(() => {
-      expect(screen.getByText("The rollout is ready.")).toBeInTheDocument();
-    });
-    expect(screen.queryByLabelText("Share")).toBeNull();
   });
 
   it("shares a public artifact by its cdn url", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-draft.test.tsx
@@ -699,6 +699,7 @@ describe("chat drafts", () => {
       validationRequests += 1;
       return respond(200, {
         url: "https://cdn.vm7.io/artifacts/test/drafts/brief.md",
+        publicUrl: "https://cdn.vm7.io/artifacts/test/drafts/brief.md",
       });
     });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/image-annotation.test.tsx
@@ -91,7 +91,7 @@ function mockDraftWithImage(
 ): void {
   // A restored attachment revalidates its file before a send can use it.
   context.mocks.api(webFilesContract.fileUrl, ({ respond }) => {
-    return respond(200, { url: FILE_URL });
+    return respond(200, { url: FILE_URL, publicUrl: FILE_URL });
   });
   context.mocks.api(agentDraftContract.patch, ({ body, respond }) => {
     savedDrafts.push({

--- a/turbo/apps/platform/src/views/okou-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/prompt-param-injection.test.tsx
@@ -119,6 +119,7 @@ describe("prompt query parameter injection", () => {
       const id = new URL(request.url).searchParams.get("file_id");
       return HttpResponse.json({
         url: `https://resolved.example/${id ?? "missing"}`,
+        publicUrl: `https://resolved.example/${id ?? "missing"}`,
       });
     });
     const params = new URLSearchParams(DESKTOP_HANDOFF_PARAMS);
@@ -207,6 +208,7 @@ describe("prompt query parameter injection", () => {
       const id = new URL(request.url).searchParams.get("file_id");
       return HttpResponse.json({
         url: `https://resolved.example/${id ?? "missing"}`,
+        publicUrl: `https://resolved.example/${id ?? "missing"}`,
       });
     });
     mockChatLifecycle(context);
@@ -257,6 +259,7 @@ describe("prompt query parameter injection", () => {
       const id = new URL(request.url).searchParams.get("file_id");
       return HttpResponse.json({
         url: `https://resolved.example/${id ?? "missing"}`,
+        publicUrl: `https://resolved.example/${id ?? "missing"}`,
       });
     });
     mockChatLifecycle(context, {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-sidebar.test.tsx
@@ -709,35 +709,6 @@ describe("thread-owned utility sidebar", () => {
     );
   });
 
-  it("does not send a presigned office attachment url to the viewer when the api omits its public url", async () => {
-    const filename = "legacy-api-document.docx";
-    const fileId = "office-without-public-url";
-    const resourceUrl = `https://r2.example.com/artifacts/${filename}?sig=test`;
-    context.mocks.api(webFilesContract.fileUrl, ({ query, respond }) => {
-      expect(query.file_id).toBe(fileId);
-      return respond(200, { url: resourceUrl });
-    });
-    setupChatThread({
-      messages: officeUserFileMessages(fileId, filename),
-    });
-
-    click(await screen.findByLabelText(`Preview ${filename}`));
-
-    const dialog = await screen.findByTestId("attachment-lightbox");
-    await expect(
-      within(dialog).findByText("Preview unavailable."),
-    ).resolves.toBeInTheDocument();
-    expect(within(dialog).queryByTitle(`${filename} preview`)).toBeNull();
-
-    click(within(dialog).getByLabelText("Open in split view"));
-
-    const sidebar = await screen.findByTestId("artifact-sidebar");
-    await expect(
-      within(sidebar).findByText("Preview unavailable."),
-    ).resolves.toBeInTheDocument();
-    expect(within(sidebar).queryByTitle(`${filename} preview`)).toBeNull();
-  });
-
   it("previews a public catalog document through the resolved resource url", async () => {
     const htmlUrl = "https://catalog-document.sites.vm7.io";
     const summary = catalogArtifact({ title: "launch-site.html" });

--- a/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
@@ -172,8 +172,8 @@ export function ArtifactShareButton({
       return $.artifacts.actions.share;
     });
   if (shareUrl === null) {
-    // No address a recipient could open. Offering the action anyway would hand
-    // out a link that only works for the person who copied it.
+    // The share address is still being resolved. Offering the action now would
+    // hand out nothing, so wait until the resolution settles.
     return null;
   }
   return (

--- a/turbo/apps/platform/src/views/okou-page/office-document-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/office-document-preview.tsx
@@ -34,16 +34,6 @@ export function OfficeDocumentPreview({
     );
   }
 
-  if (attachmentUrls.shareUrl === null) {
-    return (
-      <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
-        {t(($) => {
-          return $.artifacts.preview.genericUnavailable;
-        })}
-      </div>
-    );
-  }
-
   // The Office viewer fetches the document server-side, so it needs the
   // durable public URL rather than the browser-scoped presigned resource URL.
   return (

--- a/turbo/packages/api-contracts/src/contracts/web-files.ts
+++ b/turbo/packages/api-contracts/src/contracts/web-files.ts
@@ -34,16 +34,8 @@ export const webFilesContract = c.router({
         /**
          * Stable public artifacts URL for the same object, suitable for a link
          * handed to someone else.
-         *
-         * Rollout fallback, surface new web/app -> old API: this route also
-         * resolves the URL attachments render from, and the contract client
-         * rejects a response missing a required field. Keeping `publicUrl`
-         * optional means a newly promoted app reaching an API deployed before
-         * this field loses only the share action instead of all attachment
-         * rendering. Make it required once that API is no longer serving and is
-         * no longer retained as a rollback target; follow-up #30847.
          */
-        publicUrl: z.string().optional(),
+        publicUrl: z.string(),
       }),
       400: apiErrorSchema,
       401: apiErrorSchema,


### PR DESCRIPTION
Removes the new-App-to-old-API `publicUrl` fallback on the web file-url route. Closes the removal gate in #30847.

## Cohort — attachment share URL `publicUrl`

**Old boundary:** #30835 added `publicUrl` to `GET /api/web/file-url` so an attachment can be shared by a stable public artifacts address instead of an expiring presigned URL. That route also resolves the URL attachments *render* from, and the contract client rejects a response missing a required field, so keeping `publicUrl` optional meant a newly promoted App reaching a pre-#30835 API lost only the share action instead of all attachment rendering.

**New boundary:** `publicUrl` is required. `createAttachmentResourceUrl$` reads it directly and `AttachmentUrls.shareUrl` is a plain `string`.

Removed:
- `.optional()` and the rollout comment on `publicUrl` in `webFilesContract.fileUrl`
- `shareUrl: response.body.publicUrl ?? null` and its rollout comment
- `| null` on `AttachmentUrls.shareUrl`, and the "or null when the attachment has no such address" clause in its doc comment — the early-return branch for an already-public URL returns the URL itself, so no path yields null
- `hides the share action when the api reports no public attachment url` (attachment-chips) and `does not send a presigned office attachment url to the viewer when the api omits its public url` (thread-sidebar), both of which built their fixture by omitting the field

Fixture updates: six untyped `HttpResponse.json` mocks that had written a minimal body now carry `publicUrl` — three in `attachment-chips`, three in `prompt-param-injection` — plus one typed fixture each in `chat-draft` and `image-annotation`. These were not exercising the old API; they simply predate the field, and only the typed ones were caught by `check-types`.

**Windows:** both applicable windows are satisfied.
- Canonical window 1 (old API drained): the pre-#30835 API left service when the replacement became healthy.
- Canonical window 2 (App/web client, 24 hours after the replacement App version is available in production): **43.9 hours** elapsed.

**Rollout evidence (observed):**
- #30835 merged `2026-09-02T00:30:07Z` (`7aa3ac38432`).
- First `api/production` deployment containing it: `adbc835912`, `2026-09-02T01:10:06Z`; first `app/production` deployment: the same SHA at `2026-09-02T01:11:57Z`. Both confirmed with `git merge-base --is-ancestor` walking each deployment list forward from oldest.
- **28 further `api/production`** and **22 further `app/production`** deployments have been promoted since, so the pre-#30835 build is far behind the current rollback target on both surfaces.

**Source evidence that the current API always sets the field:** `web-file-url.ts` returns `{ status: 200, body: { url, publicUrl: object.url } }` on its only success path; the sole other exit is `notFound("File not found")`. No branch omits the key.

**Axiom:** no route-level signal applies. The discriminator is the presence of one response-body key, and `vm0-request-log-prod` records `path_template`, `method`, `status`, and client headers but not response bodies. Recorded as a deliberate non-use rather than a zero-count claim.

**MaskDB:** not applicable. No schema, column, or persisted payload changes.

## Client-floor observation, recorded for other candidates

`minimumSupportedVersion` was raised to `0.830.0`, but the floor does not immediately drain sub-floor App builds. On `vm0-request-log-prod` over `2026-09-03T09:00:00Z` → `2026-09-03T21:00:00Z`, grouping `x_client_type == "App"` by `x_client_version` still shows `0.782.1` (604 requests, last `16:11:45Z`) and `0.810.0` (1627 requests, last `20:59:49Z`). This PR does not depend on the floor — tightening a shared **response** schema only affects clients that ship the new bundle, since an older bundle carries its own older, permissive parser. It does, however, keep the AgentPhone brandless-connect candidate blocked, because that path validates a **request** signature from exactly those clients.

## Explicitly deferred

- **AgentPhone brandless connect** — see the census above; App `0.782.1` is below the pre-rollout `0.788.0` and was still transmitting hours before this run.
- **`chatThreadSnapshotProjection.selectedVideoModel` / `selectedImageModel`** — gate includes cached IndexedDB rows resyncing, which is persisted browser data.
- **`official-workflows.ts` `definition`** — the install routes still build the body with a conditional spread and can legitimately omit it.
- **#31085 pi transport values and `runners.ts` stored-context fields** — gates require the previous API rollback, runner/Sandbox drain, and pre-cutover context checks; all landed within days.
- **Queued-launch-context brand reads** for Telegram, AgentPhone, and Feishu — MaskDB's projection still does not expose `public_brand` on the context tables and `feishu_chat_ingress` is still absent. Ninth consecutive run blocked on this.
- **#29908**, **#28571**, **#26519**, **#27786** — unchanged product or evidence gates.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F @okouai/app lint`, `pnpm -F @okouai/api-contracts lint` (no new warnings)
- `pnpm -F @okouai/api-contracts check-types`, `pnpm -F @okouai/app check-types`, `pnpm -F api check-types` — re-run after refreshing against `main`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F @okouai/api-contracts exec vitest run` — 695 passing across 38 files
- `pnpm -F @okouai/app exec vitest run` on `attachment-chips` (53) and `prompt-param-injection` + `thread-sidebar` + `chat-draft` + `image-annotation` (123)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/web-file-url.test.ts` — 9 passing against a local Postgres with `timezone=UTC`

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.

Closes #30847.
