### PR TITLE
fix(app): keep voice drafts recording through silence

### DIFF
--- a/.github/scripts/smoke-okou-cli-artifact.sh
+++ b/.github/scripts/smoke-okou-cli-artifact.sh
@@ -33,7 +33,7 @@ run_cli() {
   local stdout_file="$2"
   local stderr_file="$3"
   shift 3
-  PATH="$clean_path" "$node_path" "$npx_path" \
+  NPM_CONFIG_AUDIT=false PATH="$clean_path" "$node_path" "$npx_path" \
     --yes --package="$package_path" "$entrypoint" "$@" \
     >"$stdout_file" 2>"$stderr_file"
 }

--- a/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
@@ -541,7 +541,10 @@ function createComposerVoiceInputSignals(
             );
             await set(draft.save$, signal);
           }),
-          quota.limit === null,
+          {
+            autoSegment: quota.limit === null,
+            autoStopOnSilence: false,
+          },
           {
             started: () => {
               voiceDraftId = set(workflowComposer.voiceDraft.start$);
@@ -578,7 +581,10 @@ function createComposerVoiceInputSignals(
           set(workflowComposer.appendText$, text);
           await set(draft.save$, signal);
         }),
-        quota.limit === null,
+        {
+          autoSegment: quota.limit === null,
+          autoStopOnSilence: true,
+        },
         undefined,
         signal,
       );

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -86,6 +86,11 @@ export interface VoiceRecordingLifecycle {
   readonly fail: () => Promise<void>;
 }
 
+interface VoiceRecordingOptions {
+  readonly autoSegment: boolean;
+  readonly autoStopOnSilence: boolean;
+}
+
 interface VoiceRecordingCompletion {
   readonly finish: () => Promise<void>;
   readonly fail: () => Promise<void>;
@@ -842,6 +847,7 @@ interface VoiceSegmentSessionOptions {
   readonly initialRecorder: MediaRecorder;
   readonly stream: MediaStream;
   readonly autoSegment: boolean;
+  readonly autoStopOnSilence: boolean;
   readonly onSegmentTranscribed: VoiceSegmentTranscribedCallback;
   readonly transcribeBlob: (
     input: TranscribeAudioBlobInput,
@@ -1112,11 +1118,13 @@ function createVoiceSegmentSession(
         if (options.autoSegment && currentSegmentHasVoice) {
           transcriber.enqueueBackgroundSegment("silence", true, true);
         }
-        silenceTimer.start();
+        if (options.autoStopOnSilence) {
+          silenceTimer.start();
+        }
       }
     },
     startSilenceTimeout(): void {
-      if (!currentSegmentHasVoice) {
+      if (options.autoStopOnSilence && !currentSegmentHasVoice) {
         silenceTimer.start();
       }
     },
@@ -1134,7 +1142,7 @@ export const startRecording$ = command(
   async (
     { get, set },
     onSegmentTranscribed: VoiceSegmentTranscribedCallback,
-    autoSegment: boolean,
+    options: VoiceRecordingOptions,
     lifecycle: VoiceRecordingLifecycle | undefined,
     parentSignal: AbortSignal,
   ) => {
@@ -1146,6 +1154,7 @@ export const startRecording$ = command(
       return;
     }
 
+    const { autoSegment, autoStopOnSilence } = options;
     const signal = set(prepareRecordingLifecycle$, parentSignal, lifecycle);
     let audioActivityMonitor: AudioActivityMonitor | null = null;
     let voiceActivityReliable = false;
@@ -1165,6 +1174,7 @@ export const startRecording$ = command(
           initialRecorder: recorder,
           stream,
           autoSegment,
+          autoStopOnSilence,
           onSegmentTranscribed,
           transcribeBlob: (input, uploadSignal) => {
             return set(transcribeAudioBlob$, input, uploadSignal);
@@ -1254,16 +1264,13 @@ export const startRecording$ = command(
     set(internalAudioActivityMonitor$, audioActivityMonitor);
     set(internalVoiceActivityAvailable$, audioActivityMonitor !== null);
     set(internalVoiceActivityCoversRecording$, voiceActivityReliable);
-    if (voiceActivityReliable) {
+    if (voiceActivityReliable && autoStopOnSilence) {
       silenceStop = createDeferredPromise<void>(signal);
       recordingSession.startSilenceTimeout();
-    } else {
-      return;
+      await silenceStop.promise;
+      signal.throwIfAborted();
+      await set(stopAndTranscribe$, signal);
     }
-
-    await silenceStop.promise;
-    signal.throwIfAborted();
-    await set(stopAndTranscribe$, signal);
   },
 );
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -1942,6 +1942,73 @@ describe("chat lifecycle", () => {
     expect(transcriptionCalls).toBe(1);
   });
 
+  it("keeps a voice draft recording after extended silence", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e2000000-0000-4000-a000-000000000030";
+    const silenceSegmentRequested = context.mocks.deferred<void>();
+    const continuedSilenceObserved = context.mocks.deferred<void>();
+    let sampleCount = 0;
+    let continuedSilenceStartedAt: number | null = null;
+    let transcriptionCalls = 0;
+    let polishCalls = 0;
+    context.mocks.browser.voiceInput({
+      rms: () => {
+        sampleCount += 1;
+        if (sampleCount <= 2) {
+          return 0.1;
+        }
+        if (silenceSegmentRequested.settled()) {
+          continuedSilenceStartedAt ??= performance.now();
+          if (performance.now() - continuedSilenceStartedAt >= 100) {
+            continuedSilenceObserved.resolve(undefined);
+          }
+        }
+        return 0;
+      },
+    });
+    mockChatLifecycle(context, { threadId });
+    context.mocks.api(voiceIoQuotaContract.get, ({ respond }) => {
+      return respond(200, { allowed: true, count: 0, limit: null });
+    });
+    context.mocks.http.post("*/api/voice-io/stt", () => {
+      transcriptionCalls += 1;
+      silenceSegmentRequested.resolve(undefined);
+      return new Response(JSON.stringify({ text: "Extended voice draft" }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    context.mocks.api(voiceIoPolishContract.post, ({ respond }) => {
+      polishCalls += 1;
+      return respond(200, { text: "Extended voice draft." });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.VoiceDraft]: true },
+    });
+
+    const composer = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER);
+    });
+    await user.click(await screen.findByLabelText("Voice input"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
+    });
+
+    await continuedSilenceObserved.promise;
+    expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
+    expect(transcriptionCalls).toBe(1);
+    expect(polishCalls).toBe(0);
+
+    await user.click(screen.getByLabelText("Stop recording"));
+    await waitFor(() => {
+      expect(composer).toHaveTextContent("Extended voice draft.");
+      expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
+    });
+    expect(polishCalls).toBe(1);
+  });
+
   it("appends a delayed voice input segment to the current composer text", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "e2000000-0000-4000-a000-000000000010";


### PR DESCRIPTION
## Summary

- keep Voice Draft recording active through extended silence while preserving silence-driven segment transcription
- preserve the existing long-silence auto-stop behavior for standard voice input
- add page-level coverage for both feature-switch branches

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx -t "automatically stops voice input after extended silence|keeps a voice draft recording after extended silence"`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app lint`
- `pnpm knip --workspace @okouai/app`
