### PR TITLE
fix(platform): align sidebar scrollbar with base-ui layout

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1834,17 +1834,24 @@ describe("zero sidebar", () => {
       return within(sidebar()).getByText("Chats with Zero");
     });
 
-    const content = within(sidebar()).getByTestId(
+    const pinnedContent = within(sidebar()).getByTestId(
       "pinned-agents-horizontal",
     ).parentElement;
-    if (!(content instanceof HTMLElement)) {
+    const content = pinnedContent?.parentElement;
+    if (
+      !(pinnedContent instanceof HTMLElement) ||
+      !(content instanceof HTMLElement)
+    ) {
       throw new Error("Chat list content wrapper not found");
     }
 
+    // Horizontal spacing belongs to the content inside the full-width scroll
+    // area, while this outer column only owns the spacing above the list.
+    expect(pinnedContent).toHaveClass("px-3");
     // The footer below supplies the bottom boundary out of its own padding.
     // A bottom padding here stacks a second one on top of it, which reads as
     // a void under the last thread row.
-    expect(content).toHaveClass("px-3", "pt-1");
+    expect(content).toHaveClass("pt-1");
     expect(content).not.toHaveClass("p-3");
     expect(content).not.toHaveClass("pb-3");
   });
@@ -2881,6 +2888,12 @@ describe("zero sidebar", () => {
 
     const scrollbar = await within(nav).findByTestId("sidebar-scrollbar");
     const thumb = within(scrollbar).getByTestId("sidebar-scrollbar-thumb");
+    // Browsers expose unspecified logical spacing as 0px. happy-dom returns
+    // an empty string, which Base UI's drag geometry parses as NaN.
+    scrollbar.style.paddingBlockStart = "0px";
+    scrollbar.style.paddingBlockEnd = "0px";
+    thumb.style.marginBlockStart = "0px";
+    thumb.style.marginBlockEnd = "0px";
     let capturedPointerId: number | null = null;
     Object.defineProperties(scrollbar, {
       offsetHeight: { configurable: true, value: 200 },

--- a/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
@@ -16,6 +16,7 @@ import { baseUiSidebarScrollAreaEnabled$ } from "../../signals/external/feature-
 interface OverlayScrollAreaProps {
   readonly "aria-label"?: string;
   readonly className?: string;
+  readonly contentClassName?: string;
   readonly children: ReactNode;
   readonly onFocus?: FocusEventHandler<HTMLDivElement>;
   readonly onPointerDownCapture?: PointerEventHandler<HTMLDivElement>;
@@ -37,10 +38,11 @@ function updateScrollMetrics(
   });
 }
 
-/** Existing scroll area retained unchanged behind the disabled switch. */
+/** Existing custom scroll behavior retained behind the disabled switch. */
 function LegacyOverlayScrollArea({
   "aria-label": ariaLabel,
   className,
+  contentClassName,
   children,
   onFocus,
   onPointerDownCapture,
@@ -71,10 +73,10 @@ function LegacyOverlayScrollArea({
         aria-label={ariaLabel}
         data-testid={dataTestId}
       >
-        {children}
+        <div className={contentClassName}>{children}</div>
       </div>
       <div
-        className={`absolute -right-2 top-0 bottom-0 w-[6px] pointer-events-none opacity-0 transition-opacity duration-150 ${
+        className={`absolute right-1 top-0 bottom-0 w-[6px] pointer-events-none opacity-0 transition-opacity duration-150 ${
           thumbStyleValue.visible
             ? "group-hover/sidebar-scroll:opacity-100"
             : ""
@@ -93,6 +95,7 @@ function LegacyOverlayScrollArea({
 function BaseUiOverlayScrollArea({
   "aria-label": ariaLabel,
   className,
+  contentClassName,
   children,
   onFocus,
   onPointerDownCapture,
@@ -109,13 +112,11 @@ function BaseUiOverlayScrollArea({
   };
 
   return (
-    <ScrollArea.Root
-      className={`group/sidebar-scroll relative ${className ?? ""}`}
-    >
+    <ScrollArea.Root className={className}>
       <ScrollArea.Viewport
         ref={setViewportRef}
-        className="h-full overflow-x-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-        style={{ ...style, overflowX: "hidden", overflowY: "auto" }}
+        className="h-full focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        style={style}
         onFocus={onFocus}
         onPointerDownCapture={onPointerDownCapture}
         onScroll={handleScroll}
@@ -124,22 +125,16 @@ function BaseUiOverlayScrollArea({
         aria-label={ariaLabel}
         data-testid={dataTestId}
       >
-        <ScrollArea.Content style={{ minWidth: "100%" }}>
+        <ScrollArea.Content className={contentClassName}>
           {children}
         </ScrollArea.Content>
       </ScrollArea.Viewport>
       <ScrollArea.Scrollbar
-        className="w-3 px-[3.5px] opacity-0 transition-opacity duration-150 data-hovering:opacity-100 data-scrolling:opacity-100"
-        style={{
-          insetInlineEnd: "-0.5rem",
-          paddingBlockEnd: 0,
-          paddingBlockStart: 0,
-        }}
+        className="m-px flex w-3 justify-center opacity-0 transition-opacity duration-150 data-hovering:opacity-100 data-scrolling:opacity-100 data-scrolling:duration-0"
         data-testid="sidebar-scrollbar"
       >
         <ScrollArea.Thumb
           className="w-[5px] rounded-full bg-foreground/15"
-          style={{ marginBlockEnd: 0, marginBlockStart: 0 }}
           data-testid="sidebar-scrollbar-thumb"
         />
       </ScrollArea.Scrollbar>

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -990,8 +990,10 @@ function consumePointerFocus(viewport: HTMLElement) {
 
 function ChatThreadsContent({
   scrollSignals,
+  contentClassName,
 }: {
   scrollSignals: SidebarChatThreadScrollSignals;
+  contentClassName: string;
 }) {
   const collapsed = useGet(sessionListCollapsed$);
 
@@ -999,7 +1001,12 @@ function ChatThreadsContent({
     return null;
   }
 
-  return <ExpandedChatThreadsContent scrollSignals={scrollSignals} />;
+  return (
+    <ExpandedChatThreadsContent
+      scrollSignals={scrollSignals}
+      contentClassName={contentClassName}
+    />
+  );
 }
 
 function AgentChatThreadsContent({
@@ -1042,8 +1049,10 @@ function AgentChatThreadsContent({
 
 function ExpandedChatThreadsContent({
   scrollSignals,
+  contentClassName,
 }: {
   scrollSignals: SidebarChatThreadScrollSignals;
+  contentClassName: string;
 }) {
   const { t } = useTranslation();
   const agentScope = useGet(currentChatAgentScope$);
@@ -1106,6 +1115,7 @@ function ExpandedChatThreadsContent({
     <OverlayScrollArea
       scrollSignals={scrollSignals}
       className="mt-1 min-h-0 flex-1"
+      contentClassName={contentClassName}
       aria-label={t(($) => {
         return $.chat.sidebar.chatThreads;
       })}
@@ -1137,20 +1147,27 @@ function ExpandedChatThreadsContent({
 }
 export function ChatThreadsSection({
   scrollSignals,
+  contentClassName,
   showMarkAllRead = false,
 }: {
   scrollSignals: SidebarChatThreadScrollSignals;
+  contentClassName: string;
   showMarkAllRead?: boolean;
 }) {
   const agentScope = useGet(currentChatAgentScope$);
 
   return (
     <div className="mt-4 flex flex-col min-h-0 flex-1">
-      <ChatThreadsTitle
-        key={agentScope ?? "no-agent"}
-        showMarkAllRead={showMarkAllRead}
+      <div className={contentClassName}>
+        <ChatThreadsTitle
+          key={agentScope ?? "no-agent"}
+          showMarkAllRead={showMarkAllRead}
+        />
+      </div>
+      <ChatThreadsContent
+        scrollSignals={scrollSignals}
+        contentClassName={contentClassName}
       />
-      <ChatThreadsContent scrollSignals={scrollSignals} />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -359,10 +359,13 @@ function ExpandedManageSection() {
 
 function ExpandedSidebarSections() {
   return (
-    <div className="flex-1 min-h-0 -mx-2 px-2 mt-2 pt-2 flex flex-col overflow-hidden">
-      <PinnedAgentListSection />
+    <div className="flex-1 min-h-0 -mx-2 mt-2 pt-2 flex flex-col overflow-hidden">
+      <div className="px-2">
+        <PinnedAgentListSection />
+      </div>
       <ChatThreadsSection
         scrollSignals={responsiveSidebarChatThreadScrollSignals}
+        contentClassName="px-2"
       />
     </div>
   );
@@ -799,10 +802,13 @@ function ChatListColumn() {
           <ThreeColumnChatListToggle hidden={false} tooltipSide="bottom" />
         </TooltipProvider>
       </div>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pt-1">
-        <PinnedAgentListSection layout="horizontal" />
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden pt-1">
+        <div className="px-3">
+          <PinnedAgentListSection layout="horizontal" />
+        </div>
         <ChatThreadsSection
           scrollSignals={threeColumnSidebarChatThreadScrollSignals}
+          contentClassName="px-3"
           showMarkAllRead
         />
       </div>


### PR DESCRIPTION
## Summary

- follow up on #31532 by letting Base UI own viewport overflow and scrollbar positioning
- make the scroll root span the sidebar width, then move horizontal spacing into `ScrollArea.Content` and the non-scrolling section wrappers
- keep only product-level visual styling on the Base UI scrollbar and thumb, removing negative inset and logical spacing overrides
- preserve the feature-gated legacy scroll behavior with the same content alignment

## Verification

- `pnpm format`
- `pnpm --filter @okouai/app run lint`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx --silent=passed-only` (79 passed)
