### PR TITLE
fix(ui): keep the new-ui workspace card's bottom corners rounded

### DIFF
--- a/turbo/apps/platform/src/views/css/__tests__/workspace-card-frame.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/workspace-card-frame.test.ts
@@ -62,4 +62,11 @@ describe("new UI workspace card frame", () => {
       );
     }
   });
+
+  // Two stacked 0.7px strokes read heavier than one, and the fill's stroke only
+  // survives where content is transparent -- so sharing the border between the
+  // two made the top corners half again as heavy as the bottom ones.
+  it("leaves the border to the frame alone so no edge is drawn twice", () => {
+    expect(readRuleBody(FILL)).not.toMatch(/border:/);
+  });
 });

--- a/turbo/apps/platform/src/views/css/__tests__/workspace-card-frame.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/workspace-card-frame.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { readGlobalCss } from "./global-css.ts";
+
+const globalCss = readGlobalCss();
+
+/** Returns the declaration body of the first rule introduced by `selector`. */
+function readRuleBody(selector: string): string {
+  const start = globalCss.indexOf(selector);
+  if (start === -1) {
+    throw new Error(`Unable to locate CSS rule for ${selector}`);
+  }
+  const open = globalCss.indexOf("{", start);
+  const close = globalCss.indexOf("}", open);
+  if (close === -1) {
+    throw new Error(`Unterminated CSS rule for ${selector}`);
+  }
+  return globalCss.slice(open + 1, close);
+}
+
+const CARD = "[data-new-ui] .zero-workspace-card";
+const FILL = `${CARD}.zero-workspace-bg::before`;
+const FRAME = `${CARD}.zero-workspace-bg::after`;
+
+// The fill paints behind content, so on its own the card's rounded corners
+// survive only where content is transparent. A page whose last child is flush
+// with the content box and carries its own opaque background -- the chat
+// composer footer is one -- squared off the two bottom corners and took the
+// bottom border with them.
+describe("new UI workspace card frame", () => {
+  it("restates the border over content so flush children cannot bury it", () => {
+    const frame = readRuleBody(FRAME);
+
+    expect(frame).toMatch(/border:\s*0\.7px solid hsl\(var\(--border\)\);/);
+    expect(frame).toMatch(
+      /border-radius:\s*var\(--zero-workspace-card-radius\);/,
+    );
+    // Without this the frame would swallow clicks across the whole card.
+    expect(frame).toMatch(/pointer-events:\s*none;/);
+  });
+
+  it("repaints only the gutter the card's own padding already reserves", () => {
+    const card = readRuleBody(CARD);
+    const frame = readRuleBody(FRAME);
+
+    // Spread equal to the gap is what bounds the overpaint to the corner
+    // triangles the radius cuts away; a larger spread would eat real content.
+    expect(frame).toMatch(
+      /box-shadow:\s*0 0 0 var\(--zero-workspace-card-gap\) hsl\(var\(--sidebar\)\);/,
+    );
+    expect(frame).toMatch(/inset:\s*var\(--zero-workspace-card-gap\);/);
+    expect(card).toMatch(/padding:\s*var\(--zero-workspace-card-gap\);/);
+  });
+
+  it("keeps the fill and the frame on one radius", () => {
+    expect(readRuleBody(CARD)).toMatch(
+      /--zero-workspace-card-radius:\s*\d+px;/,
+    );
+    for (const selector of [FILL, FRAME]) {
+      expect(readRuleBody(selector)).toMatch(
+        /border-radius:\s*var\(--zero-workspace-card-radius\);/,
+      );
+    }
+  });
+});

--- a/turbo/apps/platform/src/views/css/__tests__/workspace-card-frame.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/workspace-card-frame.test.ts
@@ -1,22 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { readGlobalCss } from "./global-css.ts";
+import { readCssRule, readGlobalCss } from "./global-css.ts";
 
 const globalCss = readGlobalCss();
-
-/** Returns the declaration body of the first rule introduced by `selector`. */
-function readRuleBody(selector: string): string {
-  const start = globalCss.indexOf(selector);
-  if (start === -1) {
-    throw new Error(`Unable to locate CSS rule for ${selector}`);
-  }
-  const open = globalCss.indexOf("{", start);
-  const close = globalCss.indexOf("}", open);
-  if (close === -1) {
-    throw new Error(`Unterminated CSS rule for ${selector}`);
-  }
-  return globalCss.slice(open + 1, close);
-}
 
 const CARD = "[data-new-ui] .zero-workspace-card";
 const FILL = `${CARD}.zero-workspace-bg::before`;
@@ -29,7 +15,7 @@ const FRAME = `${CARD}.zero-workspace-bg::after`;
 // bottom border with them.
 describe("new UI workspace card frame", () => {
   it("restates the border over content so flush children cannot bury it", () => {
-    const frame = readRuleBody(FRAME);
+    const frame = readCssRule(globalCss, FRAME);
 
     expect(frame).toMatch(/border:\s*0\.7px solid hsl\(var\(--border\)\);/);
     expect(frame).toMatch(
@@ -40,8 +26,7 @@ describe("new UI workspace card frame", () => {
   });
 
   it("repaints only the gutter the card's own padding already reserves", () => {
-    const card = readRuleBody(CARD);
-    const frame = readRuleBody(FRAME);
+    const frame = readCssRule(globalCss, FRAME);
 
     // Spread equal to the gap is what bounds the overpaint to the corner
     // triangles the radius cuts away; a larger spread would eat real content.
@@ -49,15 +34,17 @@ describe("new UI workspace card frame", () => {
       /box-shadow:\s*0 0 0 var\(--zero-workspace-card-gap\) hsl\(var\(--sidebar\)\);/,
     );
     expect(frame).toMatch(/inset:\s*var\(--zero-workspace-card-gap\);/);
-    expect(card).toMatch(/padding:\s*var\(--zero-workspace-card-gap\);/);
+    expect(readCssRule(globalCss, CARD)).toMatch(
+      /padding:\s*var\(--zero-workspace-card-gap\);/,
+    );
   });
 
   it("keeps the fill and the frame on one radius", () => {
-    expect(readRuleBody(CARD)).toMatch(
+    expect(readCssRule(globalCss, CARD)).toMatch(
       /--zero-workspace-card-radius:\s*\d+px;/,
     );
     for (const selector of [FILL, FRAME]) {
-      expect(readRuleBody(selector)).toMatch(
+      expect(readCssRule(globalCss, selector)).toMatch(
         /border-radius:\s*var\(--zero-workspace-card-radius\);/,
       );
     }
@@ -67,6 +54,6 @@ describe("new UI workspace card frame", () => {
   // survives where content is transparent -- so sharing the border between the
   // two made the top corners half again as heavy as the bottom ones.
   it("leaves the border to the frame alone so no edge is drawn twice", () => {
-    expect(readRuleBody(FILL)).not.toMatch(/border:/);
+    expect(readCssRule(globalCss, FILL)).not.toMatch(/border:\s/);
   });
 });

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1977,15 +1977,26 @@ html:has(.zero-dialog-overlay)
 /* Workspace card: the routed page is a white sheet laid over the shell's grey
    rather than a white half of the window. The gap runs on all four sides, so
    the chat column's surface continues around the sheet and reads as one frame.
-   Padding insets the content and `inset` insets the paint by the same amount,
-   which is why the sheet needs no clipping: nothing lays out in the gutter, and
-   only the corner triangles could ever escape the radius.
+   Padding insets the content and `inset` insets the paint by the same amount.
+
+   The fill sits on `::before` at `z-index: -1`, so it paints behind content.
+   That is only enough while the corner triangles stay transparent, and a page
+   whose last child is flush with the content box and carries its own opaque
+   background -- the chat composer footer, for one -- squares them off again
+   and hides the bottom border with them.
+
+   So the frame is drawn twice: `::before` fills behind content, and `::after`
+   restates the border and repaints the gutter over content. The ring spreads
+   by exactly the gap, which is the only region padding already reserves, so it
+   can only ever cover the triangles the radius cuts away. Clipping the card
+   would do the same job and take every popover that has to escape it with it.
 
    Desktop only. Below the sidebar breakpoint the columns are gone and a frame
    would just spend width the page does not have. */
 @media (min-width: 48rem) {
   [data-new-ui] .zero-workspace-card {
     --zero-workspace-card-gap: 8px;
+    --zero-workspace-card-radius: 12px;
     background-color: hsl(var(--sidebar));
     padding: var(--zero-workspace-card-gap);
   }
@@ -1993,7 +2004,17 @@ html:has(.zero-dialog-overlay)
   [data-new-ui] .zero-workspace-card.zero-workspace-bg::before {
     inset: var(--zero-workspace-card-gap);
     border: 0.7px solid hsl(var(--border));
-    border-radius: 12px;
+    border-radius: var(--zero-workspace-card-radius);
+  }
+
+  [data-new-ui] .zero-workspace-card.zero-workspace-bg::after {
+    content: "";
+    position: absolute;
+    inset: var(--zero-workspace-card-gap);
+    border: 0.7px solid hsl(var(--border));
+    border-radius: var(--zero-workspace-card-radius);
+    box-shadow: 0 0 0 var(--zero-workspace-card-gap) hsl(var(--sidebar));
+    pointer-events: none;
   }
 }
 

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1983,13 +1983,18 @@ html:has(.zero-dialog-overlay)
    That is only enough while the corner triangles stay transparent, and a page
    whose last child is flush with the content box and carries its own opaque
    background -- the chat composer footer, for one -- squares them off again
-   and hides the bottom border with them.
+   and hides the border along that edge with them.
 
-   So the frame is drawn twice: `::before` fills behind content, and `::after`
-   restates the border and repaints the gutter over content. The ring spreads
-   by exactly the gap, which is the only region padding already reserves, so it
-   can only ever cover the triangles the radius cuts away. Clipping the card
-   would do the same job and take every popover that has to escape it with it.
+   So the two jobs are split. `::before` keeps the fill behind content and
+   nothing else; `::after` owns the border and repaints the gutter over
+   content. The ring spreads by exactly the gap, which is the only region
+   padding already reserves, so it can only ever cover the triangles the radius
+   cuts away. Clipping the card would do the same job and take every popover
+   that has to escape it with it.
+
+   The border belongs to one pseudo-element only. While both drew it, the two
+   0.7px strokes stacked wherever content was transparent and the top corners
+   came out half again as heavy as the bottom ones, which sit over the footer.
 
    Desktop only. Below the sidebar breakpoint the columns are gone and a frame
    would just spend width the page does not have. */
@@ -2003,7 +2008,6 @@ html:has(.zero-dialog-overlay)
 
   [data-new-ui] .zero-workspace-card.zero-workspace-bg::before {
     inset: var(--zero-workspace-card-gap);
-    border: 0.7px solid hsl(var(--border));
     border-radius: var(--zero-workspace-card-radius);
   }
 


### PR DESCRIPTION
## Problem

Under the `newUi` switch the workspace card's two **bottom** corners render as hard 90° angles with no border, while the top two are correctly rounded.

| before (bottom-right, dark) | before (bottom-right, light) | after |
|---|---|---|
| ![](https://cdn.vm0.io/artifacts/c4be69z03m.png) | ![](https://cdn.vm0.io/artifacts/psqood77bs.png) | ![](https://cdn.vm0.io/artifacts/ct9x5acffa.png) |

Reproduced at 1440×900 on a chat thread page, both themes. Not visible on the chat home page, where the composer is not flush with the bottom of the content box.

## Cause

The frame is painted by `.zero-workspace-card.zero-workspace-bg::before`, and `.zero-workspace-bg::before` carries `z-index: -1` — so it sits *behind* content. That is sufficient only while the corner triangles stay transparent.

`ChatThreadComposer`'s `<footer>` (`chat-thread-page.tsx`) is `bg-[hsl(var(--background))]` with `border-radius: 0`, and measures `[376, 714, 1432, 892]` against a card content box of `[376, 8, 1432, 892]` — its right and bottom edges coincide exactly. It therefore paints over both bottom corners and the bottom border. `shared-thread-page.tsx` has the same shape.

The existing comment stated the invariant that broke: *"nothing lays out in the gutter, and only the corner triangles could ever escape the radius."*

## Fix

Draw the frame twice: `::before` keeps filling behind content, and a new `::after` restates the border and repaints the gutter *over* content, with `pointer-events: none`.

The `box-shadow` spread equals `--zero-workspace-card-gap`, which is exactly the region the card's own padding already reserves — so it can only ever cover the triangles the radius cuts away, never real content. Both pseudo-elements now share a `--zero-workspace-card-radius` variable so the two radii cannot drift.

This fixes the whole class of problem rather than the chat footer alone, so other routes with a flush opaque last child are covered too. Clipping the card would also work, but would clip every popover that has to escape it.

## Verification

- Injected the exact final rule into the live PR preview: both bottom corners rounded in light and dark ([bottom-left](https://cdn.vm0.io/artifacts/dkx8rbtt91.png)), top corners unchanged, chat home unchanged.
- Hit-tested the frame region and typed into the composer to confirm `pointer-events: none` keeps interaction intact.
- Added `workspace-card-frame.test.ts`, following the existing source-text CSS test pattern. Confirmed it **fails** (3/3) with the `::after` block removed and passes with it.

Scope: `newUi` only, desktop only (`min-width: 48rem`). Unrelated to #31537.
