### PR TITLE
fix(email): use workflow display name as result subject

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-automation-result-email.test.ts
@@ -371,6 +371,7 @@ describe.sequential("Official Automation result email callbacks", () => {
     if (!item) {
       throw new Error("Expected a Morning Brief result email");
     }
+    expect(item.subject).toBe("Morning Brief");
     const manageUrl =
       "https://app.okou.ai/agents?settings=preference&focus=morning-brief";
     const accountUnsubscribeUrl = `https://app.okou.ai/email/unsubscribe?token=${unsubscribeToken(
@@ -554,7 +555,7 @@ describe.sequential("Official Automation result email callbacks", () => {
     expect(send).toMatchObject({
       from: "Okou <okou@okou.io>",
       to: scenario.actor.email,
-      subject: 'Official <script> & " result completed',
+      subject: 'Official <script> & " result',
       headers: {
         "List-Unsubscribe": `<https://api.okou.ai/api/email/unsubscribe?token=${unsubscribeToken(scenario.actor.userId)}>`,
         "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -7734,6 +7734,7 @@ describe.sequential("Official Workflow Run admission", () => {
       expect(source.items).toStrictEqual([
         expect.objectContaining({
           public_brand: "okou",
+          subject: `Display ${definitionName}`,
           source_run_id: producer.runId,
           source_workflow_automation_id: producer.automationId,
           status: "pending",

--- a/turbo/apps/api/src/signals/services/internal-workflow-automation-result-email-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-workflow-automation-result-email-callback.service.ts
@@ -98,18 +98,28 @@ async function resultEmailWorkflowLabel(
   provenance: AgentRunOfficialWorkflowProvenance | null,
   signal: AbortSignal,
 ): Promise<string> {
-  const definition = provenance?.definitions.find((candidate) => {
+  if (!provenance) {
+    return workflowName;
+  }
+  const definition = provenance.definitions.find((candidate) => {
     return candidate.name === workflowName;
   });
   if (!definition) {
-    return workflowName;
+    throw new Error(
+      `Official Workflow provenance does not contain ${workflowName}`,
+    );
   }
   const revision = await readAcceptedOfficialWorkflowRevision(
     db,
     { name: definition.name, revision: definition.revision },
     signal,
   );
-  return revision?.definition.workflow.displayName ?? workflowName;
+  if (!revision) {
+    throw new Error(
+      `Official Workflow revision ${definition.name}@${definition.revision} is unavailable`,
+    );
+  }
+  return revision.definition.workflow.displayName;
 }
 
 function boundedResultText(output: string | undefined): string {

--- a/turbo/apps/api/src/signals/services/internal-workflow-automation-result-email-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-workflow-automation-result-email-callback.service.ts
@@ -4,6 +4,7 @@ import {
   MORNING_BRIEF_PREFERENCES_PATH,
 } from "@okouai/api-contracts/contracts/morning-brief-preference";
 import { appUrlForPublicBrand } from "@okouai/core/public-brand";
+import type { AgentRunOfficialWorkflowProvenance } from "@okouai/db/jsonb-contracts/agent-run-session-conversation";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { emailOutbox } from "@okouai/db/schema/email-outbox";
 import { officialAutomationResultEmailClaims } from "@okouai/db/schema/official-automation-result-email-claim";
@@ -32,6 +33,7 @@ import type {
   InternalRunCallbackDispatchResult,
   InternalRunCallbackEnvelope,
 } from "./internal-run-callback";
+import { readAcceptedOfficialWorkflowRevision } from "./official-workflow-catalog-read.service";
 import { getRunOutputText } from "./run-output.service";
 
 const log = logger("api:official-automation-result-email");
@@ -84,10 +86,30 @@ function resultEmailTitle(workflowName: string): string {
 
 function resultEmailSubject(workflowName: string): string {
   return truncateWithMarker(
-    `${workflowName} completed`,
+    workflowName,
     OFFICIAL_AUTOMATION_RESULT_EMAIL_SUBJECT_MAX_CHARACTERS,
     SHORT_TRUNCATION_MARKER,
   );
+}
+
+async function resultEmailWorkflowLabel(
+  db: Db,
+  workflowName: string,
+  provenance: AgentRunOfficialWorkflowProvenance | null,
+  signal: AbortSignal,
+): Promise<string> {
+  const definition = provenance?.definitions.find((candidate) => {
+    return candidate.name === workflowName;
+  });
+  if (!definition) {
+    return workflowName;
+  }
+  const revision = await readAcceptedOfficialWorkflowRevision(
+    db,
+    { name: definition.name, revision: definition.revision },
+    signal,
+  );
+  return revision?.definition.workflow.displayName ?? workflowName;
 }
 
 function boundedResultText(output: string | undefined): string {
@@ -159,6 +181,7 @@ export async function handleWorkflowAutomationResultEmailInternalCallback(
     .select({
       status: agentRuns.status,
       userId: agentRuns.userId,
+      officialWorkflowProvenance: agentRuns.officialWorkflowProvenance,
     })
     .from(agentRuns)
     .where(eq(agentRuns.id, envelope.runId))
@@ -181,6 +204,12 @@ export async function handleWorkflowAutomationResultEmailInternalCallback(
   }
 
   const output = await getRunOutputText(db, envelope.runId, signal);
+  const workflowLabel = await resultEmailWorkflowLabel(
+    db,
+    payload.data.workflowName,
+    run.officialWorkflowProvenance ?? null,
+    signal,
+  );
   const productUrl = appUrlForPublicBrand(env("APP_URL"), EMAIL_PUBLIC_BRAND);
   const manageUrl = await workflowAutomationManageUrl(
     db,
@@ -236,7 +265,7 @@ export async function handleWorkflowAutomationResultEmailInternalCallback(
       id: claim.emailOutboxId,
       fromAddress: buildFromAddress(),
       toAddresses: userEmail,
-      subject: resultEmailSubject(payload.data.workflowName),
+      subject: resultEmailSubject(workflowLabel),
       headers: buildUnsubscribeHeaders(buildOneClickUnsubscribeUrl(run.userId)),
       publicBrand: EMAIL_PUBLIC_BRAND,
       template: {


### PR DESCRIPTION
## Summary

- remove the system-oriented `completed` suffix from Official Workflow result email subjects
- resolve the user-facing display name from the immutable Official Workflow revision recorded on the Run
- fail fast when persisted Official Workflow provenance cannot resolve its callback workflow or exact revision

## Testing

- `pnpm exec prettier --write` on changed files
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/official-automation-result-email.test.ts -t "links Morning Brief management"` (1 passed)
- focused Official Workflow admission test attempted locally; the existing local runner-queue limitation returned `Job not found in queue` before reaching the new subject assertion; covered by PR CI

## Fallbacks

- `resultEmailWorkflowLabel` uses the callback's existing workflow name only when the persisted Run has no Official Workflow provenance. This preserves result-email presentation for legitimately nullable historical/non-Official Run metadata and has no identity, authorization, or delivery semantics. No rollout gate applies. Removal condition: none; the schema intentionally permits historical and non-Official Runs without provenance, so this remains a permanent presentational default rather than rollout compatibility.
