### PR TITLE
docs(rust): clarify optional storage id on writeback manifest entries

### DIFF
--- a/crates/guest-contracts/src/storage_manifest.rs
+++ b/crates/guest-contracts/src/storage_manifest.rs
@@ -25,6 +25,11 @@
 //! Serialization always includes `cleanupPaths` and omits `instructionCleanups` when it is empty.
 //! Unknown top-level and mount fields are ignored during deserialization so future fields can be
 //! added compatibly.
+//! `storageId` is optional in canonical `storageMounts` input. For a `writeback: true` mount,
+//! omitting `storageId` defaults the value to `None` and preserves it as
+//! [`ArtifactEntry::vas_storage_id`] == `None`; deserialization does not require the field. The
+//! normal runner producer supplies an identifier for writeback mounts, but that producer behavior
+//! is not an input requirement of this decoder.
 
 use std::collections::HashSet;
 
@@ -220,7 +225,10 @@ pub struct ArtifactEntry {
     /// VAS storage name used for diagnostics and cache identity.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vas_storage_name: Option<String>,
-    /// VAS storage identifier retained in the runner payload.
+    /// Optional VAS storage identifier retained from the runner payload or canonical input.
+    ///
+    /// A writeback mount accepted by canonical deserialization may omit `storageId`, in which case
+    /// this value is `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub vas_storage_id: Option<String>,
     /// VAS version identifier used for diagnostics and cache identity.
@@ -238,7 +246,11 @@ pub struct StorageMountEntry {
     /// Storage name retained for diagnostics.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    /// Immutable Storage identifier, present for writeback mounts.
+    /// Optional immutable Storage identifier.
+    ///
+    /// The normal runner producer supplies this for writeback mounts, but canonical deserialization
+    /// accepts a writeback mount without `storageId`. In that case, the value defaults to `None` and
+    /// is retained as [`ArtifactEntry::vas_storage_id`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_id: Option<String>,
     /// Resolved Storage version identifier.

--- a/crates/guest-contracts/src/storage_manifest.rs
+++ b/crates/guest-contracts/src/storage_manifest.rs
@@ -25,6 +25,7 @@
 //! Serialization always includes `cleanupPaths` and omits `instructionCleanups` when it is empty.
 //! Unknown top-level and mount fields are ignored during deserialization so future fields can be
 //! added compatibly.
+//!
 //! `storageId` is optional in canonical `storageMounts` input. For a `writeback: true` mount,
 //! omitting `storageId` defaults the value to `None` and preserves it as
 //! [`ArtifactEntry::vas_storage_id`] == `None`; deserialization does not require the field. The


### PR DESCRIPTION
## Summary

- Clarify that `storageId` is optional at the `guest-contracts` canonical deserialization boundary.
- Document that a writeback mount omitting `storageId` produces `ArtifactEntry::vas_storage_id == None`.
- Distinguish this accepted-input behavior from the current runner producer's required-ID invariant.

## Scope

Documentation only in `crates/guest-contracts/src/storage_manifest.rs`. This does not change Serde attributes, field types, validation or classification logic, wire shape, generated API DTOs, or tests.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo test -p guest-contracts`
- `cd crates && cargo doc --workspace --all-features --no-deps`

Closes #31568
