### PR TITLE
feat(pi): activate chatgpt subscription terra route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { zstdDecompressSync } from "node:zlib";
 
 import { HeadObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
 import { createStore } from "ccstate";
@@ -44,6 +45,7 @@ import { mailContract } from "@okouai/api-contracts/contracts/mail";
 import { triggerSourceSchema } from "@okouai/api-contracts/contracts/logs";
 import {
   getModelProviderFirewall,
+  MODEL_PROVIDER_ENV_PLACEHOLDERS,
   type ModelProviderType,
   type SupportedRunModel,
 } from "@okouai/api-contracts/contracts/model-providers";
@@ -646,6 +648,13 @@ async function expectTerraApiFollowUpUsage(
     cacheRead: 0,
     cacheCreation: 0,
   });
+}
+
+async function expectNoVm0ModelUsage(runId: string): Promise<void> {
+  // Operational usage rows have no production run-scoped read API. This
+  // test-only observation is required to prove the subscription no-charge
+  // invariant rather than infer it from the public run status.
+  await expect(readRunUsageEventsFixture(runId)).resolves.toStrictEqual([]);
 }
 
 async function createTerraUsagePricingResolution(): Promise<
@@ -5075,6 +5084,15 @@ function piResponsesToolSse(args: {
       return `data: ${JSON.stringify(event)}\n\n`;
     })
     .join("");
+}
+
+async function readCodexRequestJson(request: Request): Promise<unknown> {
+  const bytes = Buffer.from(await request.arrayBuffer());
+  const body =
+    request.headers.get("content-encoding") === "zstd"
+      ? zstdDecompressSync(bytes)
+      : bytes;
+  return JSON.parse(body.toString("utf8")) as unknown;
 }
 
 interface PiCheckpointS3Command {
@@ -11964,7 +11982,509 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(actor, third.runId);
   }, 90_000);
 
-  it("pins switched Codex accounts without rotating the thread session", async () => {
+  it("hands native subscription Terra tools to a generation-2 Sandbox without VM0 billing", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const firewall = createFirewallApi(context);
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    await authDeviceSupport.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
+      [FeatureSwitchKey.PiLoop]: true,
+    });
+
+    const externalAccountId = "chat-codex-pi-subscription-account";
+    const refreshToken = "rt_pi_subscription_fixture_high_entropy";
+    const oauth = mockCodexDeviceAuthProvider({
+      tokenScope: "personal",
+      accountId: externalAccountId,
+      refreshToken,
+      accessTokenExpiresAt: Math.floor(now() / 1000) - 60,
+      refreshedAccessTokenExpiresAt: Math.floor(now() / 1000) + 7200,
+      workspaceName: "Pi Subscription Account",
+    });
+    const started = await authDevice.requestCodexStart(
+      actor,
+      "personal",
+      [200],
+      { mode: "add" },
+    );
+    if (started.status !== 200) {
+      throw new Error("Expected subscription auth to start");
+    }
+    const completed = await authDevice.requestCodexComplete(
+      actor,
+      started.body.sessionToken,
+      [200],
+    );
+    if (!("status" in completed.body) || completed.body.status !== "complete") {
+      throw new Error("Expected subscription auth to complete");
+    }
+    const accountSourceId = completed.body.provider.id;
+    await authDeviceSupport.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.PersonalModelProviderAccounts]: false,
+      [FeatureSwitchKey.PiLoop]: true,
+    });
+
+    await chatCallbacks.updateOrgModelPolicies(actor, [
+      {
+        model: "gpt-5.6-terra",
+        isDefault: true,
+        defaultProviderType: "codex-oauth-token",
+        credentialScope: "member",
+        modelProviderId: null,
+      },
+    ]);
+    mockPiResourceArchiveDownloads();
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const providerRequests: {
+      readonly accountMatches: boolean;
+      readonly authorizationIsReal: boolean;
+      readonly body: unknown;
+    }[] = [];
+    server.use(
+      http.post(
+        "https://chatgpt.com/backend-api/codex/responses",
+        async ({ request }) => {
+          const authorization = request.headers.get("authorization");
+          const body = await readCodexRequestJson(request);
+          providerRequests.push({
+            accountMatches:
+              request.headers.get("chatgpt-account-id") === externalAccountId,
+            authorizationIsReal:
+              authorization?.startsWith("Bearer ") === true &&
+              authorization !==
+                `Bearer ${MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN}`,
+            body,
+          });
+          const responseBody = piResponsesContentSse({
+            blocks:
+              providerRequests.length === 1
+                ? [
+                    {
+                      type: "toolCall",
+                      callId: "call_subscription_tool",
+                      name: "bash",
+                      arguments: {
+                        command: `npx --yes --package="\${CLI_PKG_URL}" okou --help`,
+                      },
+                    },
+                  ]
+                : [
+                    {
+                      type: "text",
+                      text: "Subscription API-first continuation complete",
+                    },
+                  ],
+            sequence: providerRequests.length,
+          });
+          return new HttpResponse(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode(responseBody));
+                controller.close();
+              },
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          );
+        },
+      ),
+    );
+
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt: "use the Okou CLI through native subscription Terra",
+      model: "gpt-5.6-terra",
+    });
+    await expect
+      .poll(() => {
+        return providerRequests.length;
+      })
+      .toBe(1);
+    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+    const sessionKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.has(manifestKey);
+      })
+      .toBe(true);
+    await flushWaitUntilForTest();
+
+    expect(providerRequests).toHaveLength(1);
+    expect(providerRequests[0]).toMatchObject({
+      accountMatches: true,
+      authorizationIsReal: true,
+      body: {
+        model: "gpt-5.6-terra",
+        stream: true,
+      },
+    });
+    expect(providerRequests[0]?.body).not.toHaveProperty("service_tier");
+    expect(oauth.oauthToken).toHaveLength(2);
+    expect(oauth.oauthToken[1]?.get("grant_type")).toBe("refresh_token");
+    await expectNoVm0ModelUsage(run.runId);
+
+    await api.heartbeatRunner(runnerGroup);
+    const legacyClaim = await api.requestClaimRunnerJob(true, run.runId, [404]);
+    expectApiError(legacyClaim.body);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "pending",
+    });
+
+    const claim = await api.claimRunnerJob(run.runId, {
+      capabilities: { piModelConfigGenerations: [1, 2] },
+    });
+    const sandboxHeaders = {
+      authorization: `Bearer ${claim.sandboxToken}`,
+    };
+    expect(claim).toMatchObject({
+      cliAgentType: "pi",
+      piSessionId: run.threadId,
+      piModelConfig: {
+        schemaVersion: 2,
+        dialect: "openai-codex-responses",
+        transport: "sse",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        model: "gpt-5.6-terra",
+        thinkingLevel: "low",
+        credentialBindings: [
+          {
+            kind: "access-token",
+            environment: "CHATGPT_ACCESS_TOKEN",
+            secretName: "CHATGPT_ACCESS_TOKEN",
+          },
+          {
+            kind: "account-id",
+            environment: "CHATGPT_ACCOUNT_ID",
+            secretName: "CHATGPT_ACCOUNT_ID",
+          },
+        ],
+      },
+    });
+    expect(claimEnvironment(claim)).toMatchObject({
+      CHATGPT_ACCESS_TOKEN:
+        MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN,
+      CHATGPT_ACCOUNT_ID: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCOUNT_ID,
+    });
+    expect(
+      claim.secretConnectorMetadataMap?.CHATGPT_ACCESS_TOKEN,
+    ).toMatchObject({ sourceId: accountSourceId });
+    expect(claim.secretConnectorMetadataMap?.CHATGPT_ACCOUNT_ID).toMatchObject({
+      sourceId: accountSourceId,
+    });
+    expect(JSON.stringify(claim)).not.toContain(externalAccountId);
+    expect(JSON.stringify(claim)).not.toContain(refreshToken);
+
+    if (!claim.encryptedSecrets) {
+      throw new Error("Expected subscription claim credentials");
+    }
+    const sandboxCredential = await firewall.requestFirewallAuth(
+      sandboxHeaders,
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          Authorization: `Bearer \${{ secrets.CHATGPT_ACCESS_TOKEN }}`,
+          "ChatGPT-Account-ID": `\${{ secrets.CHATGPT_ACCOUNT_ID }}`,
+        },
+        secretConnectorMap: claim.secretConnectorMap ?? undefined,
+        secretConnectorMetadataMap:
+          claim.secretConnectorMetadataMap ?? undefined,
+      },
+      [200],
+    );
+    if (sandboxCredential.status !== 200) {
+      throw new Error("Expected exact subscription firewall credentials");
+    }
+    expect(sandboxCredential.body.headers["ChatGPT-Account-ID"]).toBe(
+      externalAccountId,
+    );
+    expect(oauth.oauthToken).toHaveLength(2);
+
+    const h1Bytes = checkpointObjects.get(sessionKey);
+    if (!h1Bytes) {
+      throw new Error("Expected native Codex pending-tool session");
+    }
+    const h1 = h1Bytes.toString("utf8");
+    expect(h1).not.toContain(externalAccountId);
+    expect(h1).not.toContain(refreshToken);
+    expect(h1).not.toContain(
+      MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN,
+    );
+    const h2Session = MemoryPiSession.fromJsonl(h1);
+    const pendingAssistant = [...h2Session.buildSessionContext().messages]
+      .reverse()
+      .find((message) => {
+        return message.role === "assistant";
+      });
+    const pendingTool =
+      pendingAssistant?.role === "assistant"
+        ? pendingAssistant.content.find((content) => {
+            return content.type === "toolCall";
+          })
+        : undefined;
+    if (!pendingTool || pendingTool.type !== "toolCall") {
+      throw new Error("Expected native Codex tool call in H1");
+    }
+    h2Session.appendMessage({
+      role: "toolResult",
+      toolCallId: pendingTool.id,
+      toolName: pendingTool.name,
+      content: [{ type: "text", text: "Okou CLI help output" }],
+      details: {},
+      isError: false,
+      timestamp: 2,
+    });
+    h2Session.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Subscription Sandbox complete" }],
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      model: "gpt-5.6-terra",
+      usage: {
+        input: 5,
+        output: 3,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 8,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "stop",
+      timestamp: 3,
+    });
+    const h2 = h2Session.toJsonl();
+    const h2Hash = createHash("sha256").update(h2).digest("hex");
+    await webhooks.requestAgentCheckpointPrepareHistory(
+      {
+        runId: run.runId,
+        hash: h2Hash,
+        rawSize: Buffer.byteLength(h2),
+        encodedSize: Buffer.byteLength(h2),
+        encoding: "identity",
+      },
+      sandboxHeaders,
+      [200],
+    );
+    checkpointObjects.set(
+      `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${h2Hash}.blob`,
+      Buffer.from(h2, "utf8"),
+    );
+    await webhooks.requestAgentComplete(
+      {
+        runId: run.runId,
+        exitCode: 0,
+        checkpoint: {
+          cliAgentType: "pi",
+          cliAgentSessionId: run.threadId,
+          cliAgentSessionHistoryHash: h2Hash,
+        },
+      },
+      sandboxHeaders,
+      [200],
+    );
+    await waitForRunStatus(actor, run.runId, "completed");
+    await flushWaitUntilForTest();
+    expect(providerRequests).toHaveLength(1);
+    await expectNoVm0ModelUsage(run.runId);
+
+    const firstSession = await readThreadSessionConversation(
+      context,
+      run.threadId,
+    );
+    const continued = await sendChatRun(actor, {
+      agentId,
+      threadId: run.threadId,
+      prompt: "continue on the same subscription account",
+      model: "gpt-5.6-terra",
+    });
+    await waitForRunStatus(actor, continued.runId, "completed");
+    await flushWaitUntilForTest();
+    expect(providerRequests).toHaveLength(2);
+    expect(providerRequests[1]).toMatchObject({
+      accountMatches: true,
+      authorizationIsReal: true,
+      body: {
+        model: "gpt-5.6-terra",
+        stream: true,
+      },
+    });
+    expect(JSON.stringify(providerRequests[1]?.body)).toContain(
+      "Okou CLI help output",
+    );
+    expect(
+      eventBackedContents(
+        (await chat.listThreadEvents(actor, run.threadId)).events,
+        continued.runId,
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        content: "Subscription API-first continuation complete",
+      }),
+    );
+    await expect(
+      readThreadSessionConversation(context, run.threadId),
+    ).resolves.toMatchObject({
+      agent_session_id: firstSession.agent_session_id,
+    });
+    await expectNoVm0ModelUsage(continued.runId);
+  }, 90_000);
+
+  it.each([
+    {
+      name: "reconnect-required refresh",
+      failureReason: "reconnect_required" as const,
+      errorCode: "PI_API_MODEL_CREDENTIAL_INVALID",
+      expired: true,
+      providerCalls: 0,
+    },
+    {
+      name: "subscription usage limit",
+      failureReason: "usage_limit" as const,
+      errorCode: "PI_API_MODEL_FAILED",
+      expired: false,
+      providerCalls: 1,
+    },
+  ])(
+    "classifies a $name without replay, billing, or private diagnostics",
+    async (scenario) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const privateMarker = `private-${scenario.failureReason}-diagnostic`;
+      const externalAccountId = `chat-${scenario.failureReason}-account`;
+      const refreshToken = `rt_${scenario.failureReason}_high_entropy`;
+      await authDeviceSupport.updateFeatureSwitches(actor, {
+        [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
+        [FeatureSwitchKey.PiLoop]: true,
+      });
+      const oauth = mockCodexDeviceAuthProvider({
+        tokenScope: "personal",
+        accountId: externalAccountId,
+        refreshToken,
+        accessTokenExpiresAt: scenario.expired
+          ? Math.floor(now() / 1000) - 60
+          : Math.floor(now() / 1000) + 7200,
+        workspaceName: "Pi Failure Account",
+      });
+      const started = await authDevice.requestCodexStart(
+        actor,
+        "personal",
+        [200],
+        { mode: "add" },
+      );
+      if (started.status !== 200) {
+        throw new Error("Expected subscription auth to start");
+      }
+      const completed = await authDevice.requestCodexComplete(
+        actor,
+        started.body.sessionToken,
+        [200],
+      );
+      if (
+        !("status" in completed.body) ||
+        completed.body.status !== "complete"
+      ) {
+        throw new Error("Expected subscription auth to complete");
+      }
+      let refreshAttempts = 0;
+      if (scenario.failureReason === "reconnect_required") {
+        server.use(
+          http.post("https://auth.openai.com/oauth/token", () => {
+            refreshAttempts += 1;
+            return HttpResponse.json(
+              {
+                error: {
+                  code: "refresh_token_invalidated",
+                  message: privateMarker,
+                },
+              },
+              { status: 401 },
+            );
+          }),
+        );
+      }
+
+      await chatCallbacks.updateOrgModelPolicies(actor, [
+        {
+          model: "gpt-5.6-terra",
+          isDefault: true,
+          defaultProviderType: "codex-oauth-token",
+          credentialScope: "member",
+          modelProviderId: null,
+        },
+      ]);
+      mockPiResourceArchiveDownloads();
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      let modelCalls = 0;
+      server.use(
+        http.post("https://chatgpt.com/backend-api/codex/responses", () => {
+          modelCalls += 1;
+          return HttpResponse.json(
+            {
+              error: {
+                code: "usage_limit_reached",
+                message: privateMarker,
+              },
+            },
+            { status: 429 },
+          );
+        }),
+      );
+
+      const run = await sendChatRun(actor, {
+        agentId,
+        prompt: `classify ${scenario.failureReason}`,
+        model: "gpt-5.6-terra",
+      });
+      await waitForRunStatus(actor, run.runId, "failed", 10_000);
+      await flushWaitUntilForTest();
+
+      const failed = await api.readRun(actor, run.runId);
+      expect(failed).toMatchObject({
+        status: "failed",
+        error: expect.stringContaining(`[${scenario.errorCode}]`),
+      });
+      expect(modelCalls).toBe(scenario.providerCalls);
+      expect(refreshAttempts).toBe(scenario.expired ? 1 : 0);
+      expect(oauth.oauthToken).toHaveLength(1);
+      const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          eventType: "run.failed",
+          runId: run.runId,
+          failureReason: scenario.failureReason,
+        }),
+      );
+      const publicState = JSON.stringify({
+        failed,
+        events,
+        checkpointObjects: [...checkpointObjects.entries()].map(
+          ([key, value]) => {
+            return [key, value.toString("utf8")];
+          },
+        ),
+      });
+      expect(publicState).not.toContain(privateMarker);
+      expect(publicState).not.toContain(externalAccountId);
+      expect(publicState).not.toContain(refreshToken);
+      expect(
+        checkpointObjects.has(
+          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
+        ),
+      ).toBeFalsy();
+      await expectNoVm0ModelUsage(run.runId);
+      await api.heartbeatRunner(runnerGroup);
+      const claim = await api.requestClaimRunnerJob(true, run.runId, [404], {
+        capabilities: { piModelConfigGenerations: [1, 2] },
+      });
+      expectApiError(claim.body);
+    },
+    90_000,
+  );
+
+  it("rotates switched Codex accounts and resumes the captured account", async () => {
     const { actor, agentId, runnerGroup, providerId } =
       await entitledChatActor();
     const firewall = createFirewallApi(context);
@@ -12093,9 +12613,7 @@ describe("CHAT-02: run-level model overrides", () => {
       prompt: "continue with account B",
     });
     const secondClaim = await claimChatRun(runnerGroup, second.runId);
-    expect(secondClaim.claim.resumeSession?.sessionId).toBe(
-      `bdd-cli-${first.runId}`,
-    );
+    expect(secondClaim.claim.resumeSession).toBeNull();
     expect(
       secondClaim.claim.secretConnectorMetadataMap?.CHATGPT_ACCESS_TOKEN,
     ).toMatchObject({ sourceId: accountBId });
@@ -12126,7 +12644,26 @@ describe("CHAT-02: run-level model overrides", () => {
       firstResolved.body.headers.Authorization,
     );
 
-    await cancelChatRun(actor, second.runId);
+    chatCallbacks.mockChatOutputEvents([]);
+    await completeChatRunOk(second.runId, secondClaim.sandboxHeaders, {
+      cliAgentType: "codex",
+    });
+    await flushWaitUntilForTest();
+
+    const third = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue again with account B",
+    });
+    const thirdClaim = await claimChatRun(runnerGroup, third.runId);
+    expect(thirdClaim.claim.resumeSession?.sessionId).toBe(
+      `bdd-cli-${second.runId}`,
+    );
+    expect(
+      thirdClaim.claim.secretConnectorMetadataMap?.CHATGPT_ACCESS_TOKEN,
+    ).toMatchObject({ sourceId: accountBId });
+
+    await cancelChatRun(actor, third.runId);
     await authDeviceSupport.deletePersonalModelProvider(
       actor,
       "codex-oauth-token",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-device.ts
@@ -297,6 +297,7 @@ interface CodexDeviceAuthProviderRecorder {
 export function mockCodexDeviceAuthProvider(
   options: {
     readonly accessTokenExpiresAt?: number;
+    readonly refreshedAccessTokenExpiresAt?: number;
     readonly tokenScope?: "org" | "personal";
     readonly accountId?: string;
     readonly refreshToken?: string;
@@ -333,9 +334,23 @@ export function mockCodexDeviceAuthProvider(
       },
     ),
     http.post("https://auth.openai.com/oauth/token", async ({ request }) => {
-      recorded.oauthToken.push(new URLSearchParams(await request.text()));
+      const rawBody = await request.text();
+      const body = request.headers
+        .get("content-type")
+        ?.includes("application/json")
+        ? new URLSearchParams(JSON.parse(rawBody) as Record<string, string>)
+        : new URLSearchParams(rawBody);
+      recorded.oauthToken.push(body);
       return HttpResponse.json(
-        makeCodexTokenResponse(options.tokenScope ?? "org", options),
+        makeCodexTokenResponse(options.tokenScope ?? "org", {
+          ...options,
+          ...(body.get("grant_type") === "refresh_token" &&
+          options.refreshedAccessTokenExpiresAt !== undefined
+            ? {
+                accessTokenExpiresAt: options.refreshedAccessTokenExpiresAt,
+              }
+            : {}),
+        }),
       );
     }),
   );

--- a/turbo/apps/api/src/signals/services/__tests__/pi-sandbox-config.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-sandbox-config.test.ts
@@ -177,6 +177,66 @@ describe("Pi sandbox model configuration", () => {
     });
   });
 
+  it("emits the strict native Codex carrier for standard subscription Terra", () => {
+    expect(
+      resolvePiSandboxModelConfig({
+        type: "codex-oauth-token",
+        environment: {
+          CHATGPT_ACCESS_TOKEN: "opaque-access-placeholder",
+          CHATGPT_ACCOUNT_ID: "opaque-account-placeholder",
+          OPENAI_MODEL: "gpt-5.6-terra",
+        },
+        selectedModel: "gpt-5.6-terra",
+      }),
+    ).toStrictEqual({
+      schemaVersion: 2,
+      dialect: "openai-codex-responses",
+      transport: "sse",
+      provider: "openai-codex",
+      baseUrl: "https://chatgpt.com/backend-api",
+      model: "gpt-5.6-terra",
+      thinkingLevel: "low",
+      credentialBindings: [
+        {
+          kind: "access-token",
+          environment: "CHATGPT_ACCESS_TOKEN",
+          secretName: "CHATGPT_ACCESS_TOKEN",
+        },
+        {
+          kind: "account-id",
+          environment: "CHATGPT_ACCOUNT_ID",
+          secretName: "CHATGPT_ACCOUNT_ID",
+        },
+      ],
+    });
+  });
+
+  it.each(["gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.5"] as const)(
+    "keeps subscription %s outside the Pi config",
+    (selectedModel) => {
+      expect(
+        resolvePiSandboxModelConfig({
+          type: "codex-oauth-token",
+          environment: { OPENAI_MODEL: selectedModel },
+          selectedModel,
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it("keeps fast subscription Terra outside the Pi config", () => {
+    expect(
+      resolvePiSandboxModelConfig(
+        {
+          type: "codex-oauth-token",
+          environment: { OPENAI_MODEL: "gpt-5.6-terra" },
+          selectedModel: "gpt-5.6-terra",
+        },
+        "fast",
+      ),
+    ).toBeNull();
+  });
+
   it("translates built-in OpenRouter Terra fast mode to priority Responses", () => {
     expect(
       resolvePiSandboxModelConfig(
@@ -293,6 +353,25 @@ describe("Pi sandbox model configuration", () => {
           selectedModel: "gpt-5.6-terra",
           codexServiceTier: undefined,
           builtInModelRuntimeRoute: OPENROUTER_TERRA_ROUTE,
+          triggerSource,
+          featureSwitchContext: {
+            overrides: { [FeatureSwitchKey.PiLoop]: true },
+          },
+        }),
+      ).toBeTruthy();
+    },
+  );
+
+  it.each(["web", "agent"] as const)(
+    "makes standard subscription Terra eligible for %s chat",
+    (triggerSource) => {
+      expect(
+        shouldUsePiExecution({
+          chatThreadId: "thread-id",
+          modelProviderType: "codex-oauth-token",
+          selectedModel: "gpt-5.6-terra",
+          codexServiceTier: undefined,
+          builtInModelRuntimeRoute: undefined,
           triggerSource,
           featureSwitchContext: {
             overrides: { [FeatureSwitchKey.PiLoop]: true },
@@ -448,6 +527,28 @@ describe("Pi sandbox model configuration", () => {
       triggerSource: "web" as const,
       chatThreadId: "thread-id",
       piLoopEnabled: true,
+      codexFastModeEnabled: true,
+    },
+    {
+      name: "fast subscription Terra",
+      modelProviderType: "codex-oauth-token",
+      selectedModel: "gpt-5.6-terra",
+      codexServiceTier: "fast" as const,
+      builtInModelRuntimeRoute: undefined,
+      triggerSource: "web" as const,
+      chatThreadId: "thread-id",
+      piLoopEnabled: true,
+      codexFastModeEnabled: true,
+    },
+    {
+      name: "subscription Terra with Pi feature switch off",
+      modelProviderType: "codex-oauth-token",
+      selectedModel: "gpt-5.6-terra",
+      codexServiceTier: undefined,
+      builtInModelRuntimeRoute: undefined,
+      triggerSource: "web" as const,
+      chatThreadId: "thread-id",
+      piLoopEnabled: false,
       codexFastModeEnabled: true,
     },
     {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -9,7 +9,8 @@ import {
   type PiMemoryRecallSelection,
   type PiLaunchConfig,
   type PiApiFirstTurnConfig,
-  type PiModelConfigLegacy as PiModelConfig,
+  type PiModelConfig,
+  type PiModelConfigLegacy,
   type ConnectorRuntimeTargetRegistration,
   PI_MEMORY_ROOT,
   piMemoryRecallSelectionSchema,
@@ -876,7 +877,9 @@ interface ResolvedModelProviderEnvironment {
   readonly secretConnectorMetadataMap?: Record<string, SecretConnectorMetadata>;
   readonly codexRuntimeConfig?: ModelProviderCodexRuntimeConfig;
   readonly builtInModelRuntimeRoute?: BuiltInModelRuntimeRoute;
-  readonly credentialHeader?: NonNullable<PiModelConfig["credentialHeader"]>;
+  readonly credentialHeader?: NonNullable<
+    PiModelConfigLegacy["credentialHeader"]
+  >;
 }
 
 type BuiltinRuntimeTargetRegistration = Extract<
@@ -2498,6 +2501,7 @@ interface ResolveModelProviderEnvironmentArgs {
   readonly modelProviderType?: string;
   readonly selectedModelOverride?: string;
   readonly builtInModelRuntimeRoute?: BuiltInModelRuntimeRoute;
+  readonly piExecution: boolean;
   readonly featureSwitchContext: FeatureSwitchContext;
 }
 
@@ -2706,10 +2710,11 @@ async function resolveExactPersonalModelProviderAccount(
   if (
     !args.modelProviderId ||
     args.modelProviderCredentialScope === "org" ||
-    !isFeatureEnabled(
-      FeatureSwitchKey.PersonalModelProviderAccounts,
-      args.featureSwitchContext,
-    )
+    (!args.piExecution &&
+      !isFeatureEnabled(
+        FeatureSwitchKey.PersonalModelProviderAccounts,
+        args.featureSwitchContext,
+      ))
   ) {
     return null;
   }
@@ -8620,6 +8625,7 @@ async function resolveRunModelProvider(
         modelProviderType: args.modelProviderType,
         selectedModelOverride: args.selectedModelOverride,
         builtInModelRuntimeRoute: args.builtInModelRuntimeRoute,
+        piExecution: args.piExecution,
         featureSwitchContext: options.featureSwitchContext,
       })
     : null;

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -82,6 +82,7 @@ import {
   resolveWebChatSessionPrompt,
   type WebChatSessionPromptContext,
 } from "./web-chat-session-prompt.service";
+import { captureActiveCodexModelProviderAccount } from "./model-provider-account.service";
 
 type AgentRunCreateBody = z.infer<typeof runCreateBodySchema>;
 // Emitted as the agent_run_origin observability dimension. The values name what
@@ -1057,6 +1058,49 @@ interface AgentRunAfterPreCreate {
   readonly threadSessionResolution?: ChatThreadSessionResolution;
 }
 
+async function captureCodexSubscriptionAccount(
+  db: Db,
+  input: AgentRunAfterPreCreate,
+): Promise<AgentRunAfterPreCreate> {
+  const { command } = input;
+  if (
+    (!command.piExecution &&
+      !isFeatureEnabled(
+        FeatureSwitchKey.PersonalModelProviderAccounts,
+        input.featureSwitchContext,
+      )) ||
+    command.agentRunModelPin?.modelProvider !== "codex-oauth-token" ||
+    command.threadSessionRoute?.modelProvider !== "codex-oauth-token"
+  ) {
+    return input;
+  }
+  const account = await captureActiveCodexModelProviderAccount({
+    db,
+    orgId: command.auth.orgId,
+    userId: command.auth.userId,
+    modelProviderId: command.agentRunModelPin.modelProviderId,
+    featureSwitchContext: input.featureSwitchContext,
+  });
+  if (!account) {
+    return input;
+  }
+  return {
+    ...input,
+    command: {
+      ...command,
+      modelProviderId: account.id,
+      agentRunModelPin: {
+        ...command.agentRunModelPin,
+        modelProviderId: account.id,
+      },
+      threadSessionRoute: {
+        ...command.threadSessionRoute,
+        modelProviderId: account.id,
+      },
+    },
+  };
+}
+
 async function resolvePausedThreadGoalPrompt(
   db: Db,
   args: { readonly orgId: string; readonly threadId: string },
@@ -1165,15 +1209,20 @@ const THREAD_SESSION_PREPARATION_ATTEMPTS = 3;
 const createAgentRunAfterZeroPreCreate$ = command(
   async ({ set }, input: AgentRunAfterPreCreate, signal: AbortSignal) => {
     const db = set(writeDb$);
+    const capturedInput = await captureCodexSubscriptionAccount(db, input);
+    signal.throwIfAborted();
     for (
       let attempt = 0;
       attempt < THREAD_SESSION_PREPARATION_ATTEMPTS;
       attempt += 1
     ) {
-      const attemptInput = await resolveThreadSessionForAgentRun(db, input);
+      const attemptInput = await resolveThreadSessionForAgentRun(
+        db,
+        capturedInput,
+      );
       signal.throwIfAborted();
       const baseCreateAgentRunArgs = await measureZeroPreCreate(
-        input.timing,
+        capturedInput.timing,
         "api_dispatch_pre_create_zero_build_create_run_args",
         () => {
           return buildZeroCreateAgentRunArgs(attemptInput);
@@ -1188,27 +1237,27 @@ const createAgentRunAfterZeroPreCreate$ = command(
         },
       };
       const phaseTiming = new ApiDispatchPhaseCollector(
-        input.command.apiStartTime,
+        capturedInput.command.apiStartTime,
       );
-      input.timing.recordElapsed(
+      capturedInput.timing.recordElapsed(
         "api_dispatch_pre_create_agent_run",
         "top_level",
-        input.command.apiStartTime,
+        capturedInput.command.apiStartTime,
       );
       phaseTiming.checkpoint("api_dispatch_phase_pre_create", now());
       const preparedAgentRun = await set(
         prepareAgentRun$,
         {
           args: createAgentRunArgs,
-          timing: input.timing,
+          timing: capturedInput.timing,
           phaseTiming,
           checkOrgPlanStatusBeforeContext: false,
-          preloadedFeatureSwitchContext: input.featureSwitchContext,
-          preloadedUserTimezone: input.userInfo.timezone,
-          ...(input.connectorCatalogSelection.kind === "scoped"
+          preloadedFeatureSwitchContext: capturedInput.featureSwitchContext,
+          preloadedUserTimezone: capturedInput.userInfo.timezone,
+          ...(capturedInput.connectorCatalogSelection.kind === "scoped"
             ? {
                 preloadedConnectorCatalogSnapshot:
-                  input.connectorCatalogSelection.selection,
+                  capturedInput.connectorCatalogSelection.selection,
               }
             : {}),
         },

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -2476,7 +2476,11 @@ async function markAndReturnRefreshFailure(
   const message = error instanceof Error ? error.message : "Unknown error";
   const { errorCode, failureReason } = classifyRefreshFailure(error, signal);
   if (shouldLogWarning) {
-    L.warn(`${args.accessSourceKey} token refresh failed: ${message}`, {
+    const logMessage =
+      args.accessSourceKey === "codex-oauth-token"
+        ? `${args.accessSourceKey} token refresh failed`
+        : `${args.accessSourceKey} token refresh failed: ${message}`;
+    L.warn(logMessage, {
       accessSourceKey: args.accessSourceKey,
       orgId: args.orgId,
       userId: args.userId,

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -303,6 +303,15 @@ function shouldRotateCanonicalSession(args: {
   }
   const providerIdChanged =
     args.previousRoute.modelProviderId !== args.nextRoute.modelProviderId;
+  if (
+    providerIdChanged &&
+    args.previousRoute.modelProvider === "codex-oauth-token" &&
+    args.nextRoute.modelProvider === "codex-oauth-token"
+  ) {
+    // A ChatGPT account owns provider-private response/cache/tool state. Keep
+    // that state inside the exact account captured for each run admission.
+    return true;
+  }
   if (providerIdChanged && customSurfaceRouteMayBeInUse(args)) {
     // Once a custom gateway connection is deleted, the surface row can no
     // longer prove that the previous route was custom, so the provider

--- a/turbo/apps/api/src/signals/services/model-provider-account.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-account.service.ts
@@ -1002,6 +1002,63 @@ export async function activePersonalModelProviderAccount(args: {
   return account ?? null;
 }
 
+/**
+ * Capture the concrete ChatGPT account selected for one run admission.
+ *
+ * A non-null candidate can name either the logical provider row or an already
+ * captured account row. Unknown/stale explicit IDs fail closed instead of
+ * falling back to whichever sibling account is active.
+ */
+export async function captureActiveCodexModelProviderAccount(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly modelProviderId: string | null;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): Promise<AccountRow | null> {
+  if (args.modelProviderId !== null) {
+    const exactAccount = await personalModelProviderAccountById({
+      db: args.db,
+      id: args.modelProviderId,
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+    if (exactAccount) {
+      return exactAccount.type === CODEX_TYPE ? exactAccount : null;
+    }
+  }
+
+  const [provider] = await args.db
+    .select()
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, args.orgId),
+        eq(modelProviders.userId, args.userId),
+        eq(modelProviders.type, CODEX_TYPE),
+        ...(args.modelProviderId === null
+          ? []
+          : [eq(modelProviders.id, args.modelProviderId)]),
+      ),
+    )
+    .limit(1);
+  if (!provider) {
+    return null;
+  }
+  await ensurePersonalModelProviderAccount({
+    db: args.db,
+    provider,
+    featureSwitchContext: args.featureSwitchContext,
+  });
+  const account = await activePersonalModelProviderAccount({
+    db: args.db,
+    modelProviderId: provider.id,
+    orgId: args.orgId,
+    userId: args.userId,
+  });
+  return account?.type === CODEX_TYPE ? account : null;
+}
+
 export async function personalModelProviderAccountById(args: {
   readonly db: Db;
   readonly id: string;

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -7,8 +7,10 @@ import {
   type PiApiFirstTurnManifest,
   type PiApiFirstTurnOwnershipTransferMode,
   type PiResourceSnapshot,
+  type SecretConnectorMetadata,
   type StoredExecutionContext,
 } from "@okouai/api-contracts/contracts/runners";
+import type { RunFailureReasonToken } from "@okouai/api-contracts/contracts/run-failure-reasons";
 import { activeInputDeliveries } from "@okouai/db/schema/active-input-delivery";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { blobs } from "@okouai/db/schema/blob";
@@ -20,6 +22,7 @@ import {
 import {
   createPiApiFirstTurnOwnership,
   createPiSessionJsonl,
+  classifyPiApiProviderFailure,
   inspectPiSessionJsonl,
   PiApiFirstTurnCompactionRequiredError,
   runPiApiFirstTurn,
@@ -51,7 +54,10 @@ import {
   type DispatchCompleteSideEffectsInput,
 } from "./agent-webhook-complete.service";
 import { createPiApiFirstTurnCheckpoint$ } from "./agent-webhook-checkpoints.service";
-import { resolveModelProviderRuntimeSecretForApi } from "./agent-webhook-firewall-auth.service";
+import {
+  resolveCurrentModelProviderRuntimeSecretForApi,
+  resolveModelProviderRuntimeSecretForApi,
+} from "./agent-webhook-firewall-auth.service";
 import {
   dispatchOptionalAgentEventConsumers$,
   receiveAgentEvents$,
@@ -120,15 +126,23 @@ type PiApiFirstTurnErrorCode =
 
 class PiApiFirstTurnError extends Error {
   readonly code: PiApiFirstTurnErrorCode;
+  readonly failureReason: RunFailureReasonToken | undefined;
 
   constructor(
     code: PiApiFirstTurnErrorCode,
     message: string,
-    options?: ErrorOptions,
+    options?: {
+      readonly cause?: unknown;
+      readonly failureReason?: RunFailureReasonToken;
+    },
   ) {
-    super(`[${code}] ${message}`, options);
+    super(
+      `[${code}] ${message}`,
+      options && "cause" in options ? { cause: options.cause } : undefined,
+    );
     this.name = "PiApiFirstTurnError";
     this.code = code;
+    this.failureReason = options?.failureReason;
   }
 }
 
@@ -150,11 +164,14 @@ function piApiFirstTurnError(
   code: PiApiFirstTurnErrorCode,
   message: string,
   cause?: unknown,
+  failureReason?: RunFailureReasonToken,
 ): PiApiFirstTurnError {
   return new PiApiFirstTurnError(
     code,
     message,
-    cause === undefined ? undefined : { cause },
+    cause === undefined && failureReason === undefined
+      ? undefined
+      : { cause, failureReason },
   );
 }
 
@@ -786,17 +803,201 @@ const loadApiFirstTurnResource$ = command(
   },
 );
 
+interface CodexSubscriptionCredentialReference {
+  readonly binding: PiAgentCredentialReference;
+  readonly providerKey: "codex-oauth-token";
+  readonly metadata: SecretConnectorMetadata & {
+    readonly sourceType: "model-provider";
+    readonly sourceUserId: string;
+    readonly sourceId: string;
+    readonly metadataKey: "codex-oauth-token";
+  };
+}
+
+function sameCredentialSource(
+  left: SecretConnectorMetadata,
+  right: SecretConnectorMetadata,
+): boolean {
+  return (
+    left.sourceType === right.sourceType &&
+    left.sourceUserId === right.sourceUserId &&
+    left.sourceId === right.sourceId &&
+    left.metadataKey === right.metadataKey
+  );
+}
+
+function codexSubscriptionCredentialReferences(args: {
+  readonly activation: PiApiFirstTurnActivation;
+  readonly executionContext: ApiFirstTurnExecutionContext;
+}): {
+  readonly accessToken: CodexSubscriptionCredentialReference;
+  readonly accountId: CodexSubscriptionCredentialReference;
+} | null {
+  const config = args.executionContext.piModelConfig;
+  if (
+    !("schemaVersion" in config) ||
+    config.dialect !== "openai-codex-responses"
+  ) {
+    return null;
+  }
+  const reference = (
+    kind: PiAgentCredentialReference["kind"],
+  ): CodexSubscriptionCredentialReference => {
+    const binding = config.credentialBindings.find((candidate) => {
+      return candidate.kind === kind;
+    });
+    if (!binding) {
+      throw piApiFirstTurnError(
+        "PI_API_MODEL_CREDENTIAL_INVALID",
+        "Pi API first-turn subscription binding is missing",
+      );
+    }
+    const providerKey =
+      args.executionContext.secretConnectorMap?.[binding.secretName];
+    const metadata =
+      args.executionContext.secretConnectorMetadataMap?.[binding.secretName];
+    if (
+      providerKey !== "codex-oauth-token" ||
+      metadata?.sourceType !== "model-provider" ||
+      metadata.sourceUserId !== args.activation.userId ||
+      !metadata.sourceId ||
+      metadata.metadataKey !== "codex-oauth-token"
+    ) {
+      throw piApiFirstTurnError(
+        "PI_API_MODEL_CREDENTIAL_INVALID",
+        "Pi API first-turn subscription binding is not exact-account scoped",
+      );
+    }
+    return {
+      binding,
+      providerKey,
+      metadata: {
+        ...metadata,
+        sourceType: "model-provider",
+        sourceUserId: metadata.sourceUserId,
+        sourceId: metadata.sourceId,
+        metadataKey: "codex-oauth-token",
+      },
+    };
+  };
+  const accessToken = reference("access-token");
+  const accountId = reference("account-id");
+  if (!sameCredentialSource(accessToken.metadata, accountId.metadata)) {
+    throw piApiFirstTurnError(
+      "PI_API_MODEL_CREDENTIAL_INVALID",
+      "Pi API first-turn subscription bindings do not share one account",
+    );
+  }
+  return { accessToken, accountId };
+}
+
+function runtimeCredentialLookupArgs(
+  args: ApiFirstTurnContext,
+  reference: CodexSubscriptionCredentialReference,
+) {
+  return {
+    db: args.db,
+    orgId: args.activation.orgId,
+    userId: args.activation.userId,
+    key: reference.binding.secretName,
+    providerKey: reference.providerKey,
+    metadata: reference.metadata,
+    featureSwitchContext: {
+      userId: args.activation.userId,
+      orgId: args.activation.orgId,
+    },
+  };
+}
+
+async function resolveCodexSubscriptionCredentials(
+  args: ApiFirstTurnContext,
+  references: NonNullable<
+    ReturnType<typeof codexSubscriptionCredentialReferences>
+  >,
+  signal: AbortSignal,
+): Promise<ReadonlyMap<string, string>> {
+  const accessTokenResolution = await settle(
+    resolveCurrentModelProviderRuntimeSecretForApi(
+      runtimeCredentialLookupArgs(args, references.accessToken),
+      signal,
+    ),
+  );
+  signal.throwIfAborted();
+  if (!accessTokenResolution.ok) {
+    throw piApiFirstTurnError(
+      "PI_API_MODEL_CREDENTIAL_INVALID",
+      "Pi API first-turn subscription access token refresh failed",
+      accessTokenResolution.error,
+    );
+  }
+  const accessToken = accessTokenResolution.value;
+  if (accessToken.status === "unavailable") {
+    const reconnectRequired =
+      accessToken.reconnectState === null ||
+      accessToken.reconnectState.needsReconnect;
+    throw piApiFirstTurnError(
+      "PI_API_MODEL_CREDENTIAL_INVALID",
+      "Pi API first-turn subscription access token is unavailable",
+      undefined,
+      reconnectRequired ? "reconnect_required" : undefined,
+    );
+  }
+
+  // Deliberately read only after access-token refresh, using the already
+  // validated immutable sourceId rather than resolving the active account.
+  const accountIdResolution = await settle(
+    resolveModelProviderRuntimeSecretForApi(
+      runtimeCredentialLookupArgs(args, references.accountId),
+    ),
+  );
+  signal.throwIfAborted();
+  if (!accountIdResolution.ok) {
+    throw piApiFirstTurnError(
+      "PI_API_MODEL_CREDENTIAL_INVALID",
+      "Pi API first-turn subscription account lookup failed",
+      accountIdResolution.error,
+    );
+  }
+  const accountId = accountIdResolution.value;
+  if (!accessToken.value.trim() || !accountId?.trim()) {
+    throw piApiFirstTurnError(
+      "PI_API_MODEL_CREDENTIAL_INVALID",
+      "Pi API first-turn subscription credential is unavailable",
+      undefined,
+      "reconnect_required",
+    );
+  }
+  return new Map([
+    [references.accessToken.binding.secretName, accessToken.value],
+    [references.accountId.binding.secretName, accountId],
+  ]);
+}
+
 async function apiFirstTurnModelConfig(
   args: ApiFirstTurnContext,
   executionContext: ApiFirstTurnExecutionContext,
+  signal: AbortSignal,
 ): Promise<PiAgentModelConfig> {
   const modelConfig = executionContext.piModelConfig;
-  const decrypted = await settle(
-    decryptPersistentSecretsMap(executionContext.encryptedSecrets, {
-      userId: args.activation.userId,
-      orgId: args.activation.orgId,
-    }),
-  );
+  const subscriptionReferences = codexSubscriptionCredentialReferences({
+    activation: args.activation,
+    executionContext,
+  });
+  const subscriptionCredentials = subscriptionReferences
+    ? await resolveCodexSubscriptionCredentials(
+        args,
+        subscriptionReferences,
+        signal,
+      )
+    : null;
+  const decrypted = subscriptionReferences
+    ? { ok: true as const, value: null }
+    : await settle(
+        decryptPersistentSecretsMap(executionContext.encryptedSecrets, {
+          userId: args.activation.userId,
+          orgId: args.activation.orgId,
+        }),
+      );
   if (!decrypted.ok) {
     throw piApiFirstTurnError(
       "PI_API_MODEL_CREDENTIAL_INVALID",
@@ -809,7 +1010,14 @@ async function apiFirstTurnModelConfig(
     config: modelConfig,
     target: "direct",
     async resolveCredential(binding: PiAgentCredentialReference) {
-      let value = secrets?.[binding.secretName];
+      let value = subscriptionCredentials?.get(binding.secretName);
+      if (subscriptionCredentials && !value) {
+        throw piApiFirstTurnError(
+          "PI_API_MODEL_CREDENTIAL_INVALID",
+          "Pi API first-turn subscription credential binding is invalid",
+        );
+      }
+      value ??= secrets?.[binding.secretName];
       const providerKey =
         executionContext.secretConnectorMap?.[binding.secretName];
       const metadata =
@@ -986,6 +1194,9 @@ async function executeApiModelTurn(
         ? "Pi API first-turn model deadline elapsed"
         : "Pi API first-turn model request failed",
       executed.error,
+      modelSignal.aborted || args.model.provider !== "openai-codex"
+        ? undefined
+        : classifyPiApiProviderFailure(executed.error),
     );
   }
   const turn = executed.value;
@@ -997,6 +1208,8 @@ async function executeApiModelTurn(
     throw piApiFirstTurnError(
       "PI_API_MODEL_FAILED",
       `Pi API first-turn model stopped with ${turn.assistantMessage.stopReason}`,
+      undefined,
+      turn.assistantMessage.failureReason,
     );
   }
   return { startedAt, turn };
@@ -1259,7 +1472,7 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
     signal,
   );
   signal.throwIfAborted();
-  const model = await apiFirstTurnModelConfig(args, executionContext);
+  const model = await apiFirstTurnModelConfig(args, executionContext, signal);
   signal.throwIfAborted();
   const loadedSession = await set(
     loadResumeSessionJsonl$,
@@ -1637,6 +1850,9 @@ const failApiFirstTurn$ = command(async function failApiFirstTurn(
           runId: args.activation.runId,
           exitCode: 1,
           error: failure.message,
+          ...(failure.failureReason
+            ? { failureReason: failure.failureReason }
+            : {}),
         },
       },
       failureSignal,

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -1,4 +1,8 @@
-import type { PiModelConfigLegacy as PiModelConfig } from "@okouai/api-contracts/contracts/runners";
+import {
+  PI_MODEL_CONFIG_CURRENT_GENERATION,
+  type PiModelConfig,
+  type PiModelConfigLegacy,
+} from "@okouai/api-contracts/contracts/runners";
 import type { TriggerSource } from "@okouai/api-contracts/contracts/logs";
 import {
   getModelProviderPiEndpoint,
@@ -30,8 +34,8 @@ function normalizedBaseUrl(url: string): string {
 
 interface PiRuntimeContract {
   readonly api: "openai-responses";
-  readonly thinkingLevel?: PiModelConfig["thinkingLevel"];
-  readonly serviceTier?: PiModelConfig["serviceTier"];
+  readonly thinkingLevel?: PiModelConfigLegacy["thinkingLevel"];
+  readonly serviceTier?: PiModelConfigLegacy["serviceTier"];
 }
 
 type PiCatalogProvider = "deepseek" | "openai";
@@ -112,7 +116,8 @@ export function shouldUsePiExecution(args: {
     isFeatureEnabled(FeatureSwitchKey.CodexFastMode, args.featureSwitchContext);
   const isPiModelProvider =
     isBuiltInModelProviderType(args.modelProviderType) ||
-    args.modelProviderType === "custom-openai-responses";
+    args.modelProviderType === "custom-openai-responses" ||
+    (args.modelProviderType === "codex-oauth-token" && isStandardTerra);
   return (
     args.chatThreadId !== undefined &&
     isWebChatTriggerSource(args.triggerSource) &&
@@ -128,7 +133,61 @@ interface PiModelProviderConfigInput {
   readonly environment: Record<string, string>;
   readonly selectedModel: string | null;
   readonly inlineFirewall?: boolean;
-  readonly credentialHeader?: PiModelConfig["credentialHeader"];
+  readonly credentialHeader?: PiModelConfigLegacy["credentialHeader"];
+}
+
+function resolveCodexSubscriptionPiModelConfig(
+  provider: PiModelProviderConfigInput,
+  codexServiceTier: "fast" | undefined,
+): PiModelConfig | null {
+  if (
+    provider.type !== "codex-oauth-token" ||
+    provider.selectedModel !== "gpt-5.6-terra" ||
+    codexServiceTier !== undefined ||
+    provider.inlineFirewall === true
+  ) {
+    return null;
+  }
+  const endpoint = getModelProviderPiEndpoint(
+    "codex-oauth-token",
+    "openai-codex-responses",
+  );
+  if (!endpoint) {
+    return null;
+  }
+  const config = {
+    schemaVersion: PI_MODEL_CONFIG_CURRENT_GENERATION,
+    dialect: "openai-codex-responses",
+    transport: "sse",
+    provider: "openai-codex",
+    baseUrl: endpoint.baseUrl,
+    model: "gpt-5.6-terra",
+    thinkingLevel: "low",
+    credentialBindings: [
+      {
+        kind: "access-token",
+        environment: "CHATGPT_ACCESS_TOKEN",
+        secretName: "CHATGPT_ACCESS_TOKEN",
+      },
+      {
+        kind: "account-id",
+        environment: "CHATGPT_ACCOUNT_ID",
+        secretName: "CHATGPT_ACCOUNT_ID",
+      },
+    ],
+  } satisfies PiModelConfig;
+  return isPiAgentModelSupported({
+    provider: config.provider,
+    baseUrl: config.baseUrl,
+    model: config.model,
+    apiKey: "sandbox-access-token-placeholder",
+    accountId: "sandbox-account-id-placeholder",
+    dialect: config.dialect,
+    transport: config.transport,
+    thinkingLevel: config.thinkingLevel,
+  })
+    ? config
+    : null;
 }
 
 function resolveCustomGatewayPiModelConfig(
@@ -183,6 +242,9 @@ export function resolvePiSandboxModelConfig(
 ): PiModelConfig | null {
   if (!provider || !provider.selectedModel) {
     return null;
+  }
+  if (provider.type === "codex-oauth-token") {
+    return resolveCodexSubscriptionPiModelConfig(provider, codexServiceTier);
   }
   if (provider.type === "custom-openai-responses") {
     return resolveCustomGatewayPiModelConfig(provider, codexServiceTier);

--- a/turbo/packages/pi-agent-runtime/src/api-failure.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-failure.ts
@@ -1,0 +1,34 @@
+const CODEX_USAGE_LIMIT_SNIPPETS = [
+  "usage limit",
+  "usage_limit",
+  "usage-limit",
+  "usagelimit",
+] as const;
+
+/** Reduce native provider diagnostics to the only subscription product states. */
+export function classifyPiApiProviderFailure(
+  error: unknown,
+): "reconnect_required" | "usage_limit" | undefined {
+  const message =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+        ? error.message
+        : undefined;
+  if (!message) {
+    return undefined;
+  }
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("token_refresh_failed") &&
+    normalized.includes("codex-oauth-token") &&
+    normalized.includes("reconnect_required")
+  ) {
+    return "reconnect_required";
+  }
+  return CODEX_USAGE_LIMIT_SNIPPETS.some((snippet) => {
+    return normalized.includes(snippet);
+  })
+    ? "usage_limit"
+    : undefined;
+}

--- a/turbo/packages/pi-agent-runtime/src/api-turn.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-turn.ts
@@ -13,6 +13,7 @@ import type {
   PiObservedServiceTier,
 } from "./api-types";
 import { UnsupportedPiResourceSnapshotError } from "./errors";
+import { classifyPiApiProviderFailure } from "./api-failure";
 
 function projectAssistantContent(
   message: AssistantMessage,
@@ -46,11 +47,18 @@ function projectAssistantContent(
 export function projectPiApiAssistantMessage(
   message: AssistantMessage,
 ): PiApiAssistantMessage {
+  const failureReason =
+    message.stopReason === "error" &&
+    message.api === "openai-codex-responses" &&
+    message.provider === "openai-codex"
+      ? classifyPiApiProviderFailure(message.errorMessage)
+      : undefined;
   return {
     content: projectAssistantContent(message),
     model: message.model,
     responseId: message.responseId,
     stopReason: message.stopReason,
+    ...(failureReason ? { failureReason } : {}),
     timestamp: message.timestamp,
     usage: {
       input: message.usage.input,

--- a/turbo/packages/pi-agent-runtime/src/api-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/api-types.ts
@@ -148,6 +148,8 @@ export interface PiApiAssistantMessage {
   readonly model: string;
   readonly responseId?: string;
   readonly stopReason: PiApiAssistantStopReason;
+  /** Content-free product classification; native provider diagnostics stay private. */
+  readonly failureReason?: "reconnect_required" | "usage_limit";
   readonly timestamp: number;
   readonly usage: {
     readonly input: number;

--- a/turbo/packages/pi-agent-runtime/src/api.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.test.ts
@@ -964,6 +964,50 @@ describe("Pi API facade", () => {
     });
   });
 
+  it("projects only a content-free usage-limit classification", () => {
+    const nativeMessage: AssistantMessage = {
+      role: "assistant",
+      content: [],
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      model: "gpt-5.6-terra",
+      errorMessage:
+        "You've hit your usage limit; private upstream response omitted",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "error",
+      timestamp: 456,
+    };
+
+    expect(projectPiApiAssistantMessage(nativeMessage)).toMatchObject({
+      stopReason: "error",
+      failureReason: "usage_limit",
+    });
+    expect(projectPiApiAssistantMessage(nativeMessage)).not.toHaveProperty(
+      "errorMessage",
+    );
+    expect(
+      projectPiApiAssistantMessage({
+        ...nativeMessage,
+        api: "openai-responses",
+        provider: "deepseek",
+      }),
+    ).not.toHaveProperty("failureReason");
+  });
+
   it("projects native session state into a narrow inspection result", () => {
     const session = MemoryPiSession.create({
       cwd: "/home/user/workspace",

--- a/turbo/packages/pi-agent-runtime/src/api.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.ts
@@ -1,3 +1,4 @@
+import { classifyPiApiProviderFailure } from "./api-failure";
 import { runPiApiFirstTurn as runPiApiFirstTurnImpl } from "./api-turn";
 import { MemoryPiSession } from "./session-memory";
 import type {
@@ -70,6 +71,7 @@ import type {
   PiMemoryStage1ProviderUsage,
 } from "./stage1-memory";
 export {
+  classifyPiApiProviderFailure,
   PI_MEMORY_STAGE1_RESPONSE_SCHEMA,
   PiMemoryStage1ProviderError,
   projectPiMemoryStage1History,

--- a/turbo/packages/pi-agent-runtime/src/credential.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/credential.test.ts
@@ -132,11 +132,13 @@ describe("Pi agent credential resolution", () => {
         },
       ],
     });
+    const resolutionOrder: string[] = [];
     await expect(
       materializePiAgentModelConfig({
         config,
         target: "direct",
         resolveCredential(binding) {
+          resolutionOrder.push(binding.kind);
           switch (binding.environment) {
             case "CHATGPT_ACCESS_TOKEN":
               return "opaque-access-token";
@@ -158,5 +160,6 @@ describe("Pi agent credential resolution", () => {
       apiKey: "opaque-access-token",
       accountId: "account-id",
     });
+    expect(resolutionOrder).toStrictEqual(["access-token", "account-id"]);
   });
 });

--- a/turbo/packages/pi-agent-runtime/src/credential.ts
+++ b/turbo/packages/pi-agent-runtime/src/credential.ts
@@ -175,16 +175,17 @@ export async function materializePiAgentModelConfig(args: {
 
   const accessTokenBinding = requiredBinding(args.config, "access-token");
   const accountIdBinding = requiredBinding(args.config, "account-id");
-  const [apiKey, accountId] = await Promise.all([
-    resolvedCredentialValue({
-      binding: accessTokenBinding,
-      resolveCredential: args.resolveCredential,
-    }),
-    resolvedCredentialValue({
-      binding: accountIdBinding,
-      resolveCredential: args.resolveCredential,
-    }),
-  ]);
+  // Subscription credentials are one ordered bundle. The access token may be
+  // refreshed at this boundary, so the matching account ID must only be read
+  // after that refresh has settled.
+  const apiKey = await resolvedCredentialValue({
+    binding: accessTokenBinding,
+    resolveCredential: args.resolveCredential,
+  });
+  const accountId = await resolvedCredentialValue({
+    binding: accountIdBinding,
+    resolveCredential: args.resolveCredential,
+  });
   return {
     ...route,
     api: dialect,

--- a/turbo/packages/pi-agent-runtime/src/model.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.test.ts
@@ -249,4 +249,104 @@ describe("Pi agent model adapter", () => {
       "account-id-from-binding",
     );
   });
+
+  it("preserves a native Codex Responses tool call over forced SSE", async () => {
+    const config = {
+      provider: "openai-codex",
+      baseUrl: "https://chatgpt.com/backend-api",
+      model: "gpt-5.6-terra",
+      apiKey: "opaque-not-a-jwt",
+      accountId: "account-id-from-binding",
+      dialect: "openai-codex-responses",
+      transport: "sse",
+    } as const;
+    const model = resolvePiAgentModel(config);
+    if (!model || model.api !== "openai-codex-responses") {
+      throw new Error("Expected a native Codex Responses model");
+    }
+    const call = {
+      type: "function_call",
+      id: "fc_native_tool",
+      call_id: "call_native_tool",
+      name: "bash",
+      arguments: '{"command":"okou --help"}',
+      status: "completed",
+    };
+    const response = {
+      id: "resp_native_tool",
+      object: "response",
+      status: "completed",
+      output: [call],
+      usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+    };
+    const providerEvents = [
+      {
+        type: "response.created",
+        response: {
+          ...response,
+          status: "in_progress",
+          output: [],
+          usage: null,
+        },
+      },
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { ...call, arguments: "", status: "in_progress" },
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: call.id,
+        delta: call.arguments,
+      },
+      {
+        type: "response.function_call_arguments.done",
+        output_index: 0,
+        item_id: call.id,
+        arguments: call.arguments,
+      },
+      { type: "response.output_item.done", output_index: 0, item: call },
+      { type: "response.completed", response },
+    ]
+      .map((event) => {
+        return `data: ${JSON.stringify(event)}\n\n`;
+      })
+      .join("");
+    const providerFetch = vi.fn(async () => {
+      return new Response(providerEvents, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    });
+
+    const stream = piAgentStreamForConfig(config)(
+      model,
+      {
+        messages: [{ role: "user", content: "use a tool", timestamp: 1 }],
+        tools: [],
+      },
+      {
+        apiKey: config.apiKey,
+        fetch: providerFetch,
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+    for await (const _event of stream) {
+      // Drain the native event stream before inspecting its canonical result.
+    }
+
+    expect(providerFetch).toHaveBeenCalledOnce();
+    await expect(stream.result()).resolves.toMatchObject({
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_native_tool|fc_native_tool",
+          name: "bash",
+          arguments: { command: "okou --help" },
+        },
+      ],
+    });
+  });
 });

--- a/turbo/packages/pi-agent-runtime/src/model.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.ts
@@ -230,6 +230,7 @@ function piAgentCodexStream(
     reasoningEffort: clampedReasoning === "off" ? undefined : clampedReasoning,
     serviceTier: options?.serviceTier,
     accountId,
+    maxRetries: 0,
     transport: "sse",
   });
 }


### PR DESCRIPTION
## Summary

- route only standard GPT-5.6 Terra Web and agent-originated Web chat on the existing `codex-oauth-token` Personal Model connection through `PiLoop`
- emit the strict generation-2 native Codex Responses/SSE carrier and bind API-first plus Sandbox firewall resolution to one captured account `sourceId`
- refresh the captured access token before resolving its matching account ID, rotate provider-private sessions on account changes, and preserve reconnect/usage-limit classification without fallback, duplicate requests, or VM0 model billing

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged workspace, app, and API TypeScript checks
- focused Pi runtime credential/API/model tests (39 assertions)
- focused API carrier tests (50 assertions)
- focused Web chat native tool handoff, terminal classification, account rotation, session reuse, and zero-billing BDD (4 scenarios)
- focused account connection/refresh BDD (2 scenarios)
- focused generation-2 CLI placeholder materialization and H1 tool-to-H2 handoff tests

Closes #31528
Parent: #31373