### PR TITLE
perf(python): bound resolved auth base validation work

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_rewrite.py
+++ b/crates/runner/mitm-addon/src/auth_base_rewrite.py
@@ -29,6 +29,10 @@ _URL_PATH_SAFE_CHARS = "/%:@!$&'()*+,;="
 _URL_QUERY_SAFE_CHARS = "/?%:@!$&'()*+,;="
 _VALID_AUTH_BASE_SCHEME = "https"
 
+# Bound the complete resolved value before synchronous URL processing on the
+# mitmproxy event loop. This matches the connector-check URL ceiling while
+# retaining ample room for ordinary connector URLs.
+MAX_RESOLVED_AUTH_BASE_CHARACTERS = 8 * 1024
 # This matches the runner's existing managed-query work scale while retaining
 # ample room for ordinary connector URLs. Count every segment that auth.base
 # materializes, including empty segments separated by either ``&`` or ``;``.
@@ -186,6 +190,10 @@ def _raw_rewrite_base_host(netloc: str) -> str | None:
 
 
 def _validated_rewrite_base(resolved_base: str) -> tuple[urllib.parse.SplitResult, str]:
+    if len(resolved_base) > MAX_RESOLVED_AUTH_BASE_CHARACTERS:
+        raise ValueError(
+            f"Invalid auth.base URL: must not exceed {MAX_RESOLVED_AUTH_BASE_CHARACTERS} characters"
+        )
     if "\\" in resolved_base:
         raise ValueError("Invalid auth.base URL: must not contain backslash")
     if has_raw_whitespace(resolved_base):
@@ -250,14 +258,16 @@ def build_rewrite_url(
     incoming request (no leading ``?``). Query key precedence is
     ``resolved_query`` > resolved base query > original request query.
 
-    ``resolved_base`` must be an absolute HTTPS URL with a valid authority and
-    safe path; userinfo and fragments are not allowed. Backslashes, whitespace
-    or unsafe code points, invalid ports, unsafe path syntax, malformed Unicode,
-    and unsafe or invalid percent-encoded host syntax are rejected. Accepted
-    hosts are normalized for forwarding: Unicode and safely percent-encoded
-    Unicode names use canonical IDNA form, IPv4 literals must be canonical dotted
-    quads after safe percent-decoding, IPv6 literals are compressed and bracketed,
-    and explicit valid ports are preserved.
+    ``resolved_base`` must contain at most
+    ``MAX_RESOLVED_AUTH_BASE_CHARACTERS`` characters and be an absolute HTTPS
+    URL with a valid authority and safe path; userinfo and fragments are not
+    allowed. Backslashes, whitespace or unsafe code points, invalid ports,
+    unsafe path syntax, malformed Unicode, and unsafe or invalid percent-encoded
+    host syntax are rejected. Accepted hosts are normalized for forwarding:
+    Unicode and safely percent-encoded Unicode names use canonical IDNA form,
+    IPv4 literals must be canonical dotted quads after safe percent-decoding,
+    IPv6 literals are compressed and bracketed, and explicit valid ports are
+    preserved.
 
     Unsafe path syntax in ``rel_path`` is rejected as an invariant; firewall
     matching should already have blocked it before auth is applied.

--- a/crates/runner/mitm-addon/tests/test_auth_base_rewrite.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_rewrite.py
@@ -13,6 +13,11 @@ class _FailOnIterationQuery(str):
         raise AssertionError("original query must not be tokenized without trusted query sources")
 
 
+class _FailOnContentScanBase(str):
+    def __contains__(self, key: str) -> bool:
+        raise AssertionError("oversized resolved base must be rejected before content scanning")
+
+
 class TestBuildRewriteUrl:
     """Tests for build_rewrite_url pure URL construction."""
 
@@ -63,6 +68,23 @@ class TestBuildRewriteUrl:
             "",
         )
         assert url == "https://example.com/hook?token=secret"
+
+    def test_resolved_base_accepts_exact_character_limit(self):
+        prefix = "https://example.com/"
+        base = prefix + "x" * (auth_base_rewrite.MAX_RESOLVED_AUTH_BASE_CHARACTERS - len(prefix))
+
+        url = auth_base_rewrite.build_rewrite_url(base, "/", "")
+
+        assert len(base) == auth_base_rewrite.MAX_RESOLVED_AUTH_BASE_CHARACTERS
+        assert url == base
+
+    def test_oversized_resolved_base_rejected_before_content_scan(self):
+        base = _FailOnContentScanBase(
+            "x" * (auth_base_rewrite.MAX_RESOLVED_AUTH_BASE_CHARACTERS + 1)
+        )
+
+        with pytest.raises(ValueError, match="must not exceed 8192 characters"):
+            auth_base_rewrite.build_rewrite_url(base, "/", "")
 
     def test_resolved_base_does_not_enter_global_parse_cache(self):
         urllib.parse.urlsplit.cache_clear()

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
@@ -169,6 +169,63 @@ class TestAuthBaseUrlRewriteSafety:
         assert "super-secret-token" not in log_text
         assert "real-token" not in log_text
 
+    async def test_oversized_cached_resolved_base_fails_closed_before_forwarding(
+        self, headers, real_flow, mitm_ctx, tmp_path
+    ):
+        resolved_base_prefix = "https://real.example.com/webhook/super-secret-token-"
+        resolved_base = resolved_base_prefix + "x" * (
+            auth_base_rewrite.MAX_RESOLVED_AUTH_BASE_CHARACTERS + 1 - len(resolved_base_prefix)
+        )
+        flow, allow, sandbox_info, token_meta = make_safety_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            path="/hook?client=visible",
+            request_headers=headers(
+                ("Host", "firewall-placeholder.vm3.ai"),
+                ("Authorization", "Bearer agent"),
+            ),
+            resolved_base=resolved_base,
+            token_overrides={
+                "headers": {
+                    "Authorization": "Bearer real-token",
+                    "X-Custom": "injected-value",
+                },
+                "query": {"api_key": "resolved-key"},
+                "cache_hit": True,
+            },
+        )
+        get_headers = AsyncMock(return_value=token_meta)
+        mock_forward = AsyncMock()
+        mock_log = MagicMock()
+
+        with (
+            patch.object(auth, "get_firewall_headers", get_headers),
+            patch.object(auth, "forward_request", mock_forward),
+            patch.object(auth, "log_proxy_entry", mock_log),
+            mitm_ctx(),
+        ):
+            result = await handle_firewall_request_without_upstream_admission(
+                flow, allow, sandbox_info
+            )
+
+        assert len(resolved_base) == auth_base_rewrite.MAX_RESOLVED_AUTH_BASE_CHARACTERS + 1
+        assert token_meta["cache_hit"] is True
+        get_headers.assert_awaited_once()
+        mock_forward.assert_not_awaited()
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert json.loads(flow.response.content)["error"] == "url_rewrite_forward_failed"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
+        assert metadata_keys.AUTH_CACHE_HIT not in flow.metadata
+        assert flow.request.headers["Authorization"] == "Bearer agent"
+        assert "X-Custom" not in flow.request.headers
+        assert "api_key" not in flow.request.query
+        assert flow.request.query["client"] == "visible"
+        assert "super-secret-token" not in flow.response.text
+        assert "super-secret-token" not in json.dumps(mock_log.call_args_list)
+
     @pytest.mark.parametrize(
         ("extra_bytes", "accepted"),
         [


### PR DESCRIPTION
## Summary

- cap complete resolved `auth.base` values at 8,192 characters before URL scanning, parsing, percent decoding, or hostname normalization
- keep oversized values on the existing redacted `url_rewrite_forward_failed` path before forwarding or DNS resolution
- cover exact-limit acceptance, structural early rejection, and an oversized cached-result request through the real flow handler

## Scope

- runner Python addon only
- no backend/API contract, cache representation, persisted-state, or public error-code changes
- valid resolved bases above 8,192 characters now fail closed; existing in-bound URL behavior is unchanged

## Diagnostic benchmark

Inputs were constructed outside the timed region and the current implementation was compared with `main` in the same process:

| Input | `main` median | Current median |
| --- | ---: | ---: |
| ordinary 25-character URL | 0.150624 ms | 0.072114 ms |
| 249,008-character dense percent-encoded host | 483.629645 ms | 0.002066 ms |

Absolute timings are host-dependent; the diagnostic verifies bounded oversized rejection without adding a wall-clock test.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_auth_base_rewrite.py tests/test_firewall_rewrite_safety.py` (158 passed)
- `uv run --no-sync python -m pytest tests/` (7,336 passed)

Closes #31570
