### PR TITLE
perf(app): remove redundant sidebar list measurement

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
@@ -4,7 +4,6 @@ import { createDeferredPromise, onRef } from "../utils.ts";
 import {
   CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT,
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
-  getChatThreadVirtualListScrollMargin,
   type ChatThreadVirtualListScrollAlign,
 } from "../okou-page/sidebar-state.ts";
 import {
@@ -51,10 +50,6 @@ export interface SidebarChatThreadScrollSignals {
     (() => void) | undefined,
     [HTMLElement | null]
   >;
-  readonly setVirtualListElement$: Command<
-    (() => void) | undefined,
-    [HTMLElement | null]
-  >;
   readonly scrollToThread$: Command<
     Promise<boolean>,
     [string | ScrollToThreadRequest, AbortSignal]
@@ -92,16 +87,12 @@ function createSidebarChatThreadDomSignals() {
   const internalScrollViewport$ = state<HTMLElement | null>(null);
   const internalScrollMetrics$ =
     state<SidebarChatThreadScrollMetrics>(emptyScrollMetrics());
-  const internalVirtualListElement$ = state<HTMLElement | null>(null);
 
   const scrollViewport$ = computed((get) => {
     return get(internalScrollViewport$);
   });
   const scrollMetrics$ = computed((get) => {
     return get(internalScrollMetrics$);
-  });
-  const virtualListElement$ = computed((get) => {
-    return get(internalVirtualListElement$);
   });
   const isScrolled$ = computed((get) => {
     return get(internalScrollMetrics$).scrollTop > 0;
@@ -145,39 +136,13 @@ function createSidebarChatThreadDomSignals() {
     },
   );
 
-  const bindVirtualListElement$ = command(({ set }, element: HTMLElement) => {
-    set(internalVirtualListElement$, element);
-  });
-  const clearVirtualListElement$ = command(
-    ({ get, set }, element: HTMLElement) => {
-      if (get(internalVirtualListElement$) !== element) {
-        return;
-      }
-      set(internalVirtualListElement$, null);
-    },
-  );
-  const setVirtualListElement$ = onRef(
-    command(({ set }, element: HTMLElement, signal: AbortSignal) => {
-      set(bindVirtualListElement$, element);
-      signal.addEventListener(
-        "abort",
-        () => {
-          set(clearVirtualListElement$, element);
-        },
-        { once: true },
-      );
-    }),
-  );
-
   return {
     isScrolled$,
     thumbStyle$,
     scrollViewport$,
     scrollMetrics$,
-    virtualListElement$,
     setScrollViewport$,
     setScrollMetrics$,
-    setVirtualListElement$,
   };
 }
 
@@ -187,18 +152,15 @@ type SidebarChatThreadDomSignals = ReturnType<
 
 function getFixedVirtualRange({
   itemCount,
-  scrollMargin,
   scrollTop,
   viewportHeight,
 }: {
   itemCount: number;
-  scrollMargin: number;
   scrollTop: number;
   viewportHeight: number;
 }) {
-  const localScrollTop = Math.max(0, scrollTop - scrollMargin);
   const requestedFirstVisibleIndex = Math.floor(
-    localScrollTop / CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
+    Math.max(0, scrollTop) / CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
   );
   const visibleCount = Math.max(
     1,
@@ -243,11 +205,6 @@ function createSidebarChatThreadWindowSignal(
     const chatThreads = await get(chatThreads$);
     const scrollViewport = get(dom.scrollViewport$);
     const scrollMetrics = get(dom.scrollMetrics$);
-    const virtualListElement = get(dom.virtualListElement$);
-    const scrollMargin = getChatThreadVirtualListScrollMargin(
-      scrollViewport,
-      virtualListElement,
-    );
     const measuredViewportHeight =
       scrollMetrics.clientHeight || scrollViewport?.clientHeight;
     const viewportHeight =
@@ -255,7 +212,6 @@ function createSidebarChatThreadWindowSignal(
     const scrollTop = scrollViewport?.scrollTop ?? scrollMetrics.scrollTop;
     const { startIndex, endIndex } = getFixedVirtualRange({
       itemCount: chatThreads.length,
-      scrollMargin,
       scrollTop,
       viewportHeight,
     });
@@ -295,21 +251,16 @@ function createScrollVirtualListToIndexCommand(
       }
 
       const scrollViewport = get(dom.scrollViewport$);
-      const virtualListElement = get(dom.virtualListElement$);
-      if (!scrollViewport || !virtualListElement) {
+      if (!scrollViewport) {
         return false;
       }
 
       const currentMetrics = get(dom.scrollMetrics$);
-      const scrollMargin = getChatThreadVirtualListScrollMargin(
-        scrollViewport,
-        virtualListElement,
-      );
       const viewportHeight =
         currentMetrics.clientHeight ||
         scrollViewport.clientHeight ||
         CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT;
-      const rowTop = scrollMargin + index * CHAT_THREAD_VIRTUAL_ROW_HEIGHT;
+      const rowTop = index * CHAT_THREAD_VIRTUAL_ROW_HEIGHT;
       const rowBottom = rowTop + CHAT_THREAD_VIRTUAL_ROW_HEIGHT;
       const viewportTop = scrollViewport.scrollTop;
       const viewportBottom = viewportTop + viewportHeight;
@@ -388,7 +339,6 @@ function createSidebarChatThreadScrollSignals(): SidebarChatThreadScrollSignals 
     window$: createSidebarChatThreadWindowSignal(dom),
     setScrollMetrics$: dom.setScrollMetrics$,
     setScrollViewport$: dom.setScrollViewport$,
-    setVirtualListElement$: dom.setVirtualListElement$,
     scrollToThread$,
     scrollCurrentChatThreadOnRef$,
   };

--- a/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
@@ -296,36 +296,9 @@ export const cachePinnedAgentGridRowsRef$ = onRef(
 );
 
 // ---------------------------------------------------------------------------
-// Chat thread virtual list geometry (RecentChatSection)
+// Chat thread virtual list layout (RecentChatSection)
 // ---------------------------------------------------------------------------
 export const CHAT_THREAD_VIRTUAL_ROW_HEIGHT = 36;
 export const CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT =
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT * 12;
 export type ChatThreadVirtualListScrollAlign = "top" | "bottom";
-
-function hasUsableLayoutPosition(rect: DOMRectReadOnly): boolean {
-  return rect.top !== 0 || rect.left !== 0;
-}
-
-export function getChatThreadVirtualListScrollMargin(
-  scrollViewport: HTMLElement | null,
-  virtualListElement: HTMLElement | null,
-): number {
-  if (!scrollViewport || !virtualListElement) {
-    return 0;
-  }
-
-  const viewportRect = scrollViewport.getBoundingClientRect();
-  const virtualListRect = virtualListElement.getBoundingClientRect();
-  if (
-    hasUsableLayoutPosition(viewportRect) ||
-    hasUsableLayoutPosition(virtualListRect)
-  ) {
-    return Math.max(
-      0,
-      scrollViewport.scrollTop + virtualListRect.top - viewportRect.top,
-    );
-  }
-
-  return Math.max(0, virtualListElement.offsetTop - scrollViewport.offsetTop);
-}

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -58,10 +58,7 @@ import {
 import { pathname, search } from "../../../signals/location.ts";
 import { eventDrivenChatThread } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
 import { setChatPageImageModelSelection$ } from "../../../signals/okou-page/chat-page.ts";
-import {
-  CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
-  getChatThreadVirtualListScrollMargin,
-} from "../../../signals/okou-page/sidebar-state.ts";
+import { CHAT_THREAD_VIRTUAL_ROW_HEIGHT } from "../../../signals/okou-page/sidebar-state.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
 import { mockChatEventRows } from "./chat-event-test-helpers.ts";
 import {
@@ -1956,9 +1953,6 @@ describe("zero sidebar", () => {
     });
 
     const scrollArea = within(sidebar()).getByTestId("sidebar-scroll-area");
-    const virtualList = within(sidebar()).getByTestId(
-      "sidebar-chat-threads-virtual-list",
-    );
     const currentRow = threadLinkByTitle("Release plan").closest(
       '[data-testid="sidebar-chat-thread-virtual-row"]',
     );
@@ -1966,31 +1960,10 @@ describe("zero sidebar", () => {
       throw new Error("Release plan virtual row not found");
     }
     const currentIndex = Number(currentRow.dataset.index);
-    const scrollMargin = getChatThreadVirtualListScrollMargin(
-      scrollArea,
-      virtualList,
-    );
 
     expect(scrollArea.scrollTop).toBe(
-      scrollMargin + currentIndex * CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
+      currentIndex * CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
     );
-  });
-
-  it("computes the virtual chat list margin relative to the scroll viewport", () => {
-    const scrollViewport = document.createElement("div");
-    const virtualList = document.createElement("div");
-    Object.defineProperty(scrollViewport, "offsetTop", {
-      configurable: true,
-      value: 8,
-    });
-    Object.defineProperty(virtualList, "offsetTop", {
-      configurable: true,
-      value: 88,
-    });
-
-    expect(
-      getChatThreadVirtualListScrollMargin(scrollViewport, virtualList),
-    ).toBe(80);
   });
 
   it("cancels and confirms deleting a regular chat from the sidebar", async () => {

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -638,13 +638,11 @@ function VirtualizedChatThreads({
   const window = useLastResolved(scrollSignals.window$, {
     equalityFn: equalSidebarChatThreadWindows,
   });
-  const setVirtualListElement = useSet(scrollSignals.setVirtualListElement$);
   const startIndex = window?.startIndex ?? 0;
   const visibleItems = window?.items ?? [];
 
   return (
     <div
-      ref={setVirtualListElement}
       className="relative w-full"
       data-testid="sidebar-chat-threads-virtual-list"
       style={{ height: threadCount * CHAT_THREAD_VIRTUAL_ROW_HEIGHT }}


### PR DESCRIPTION
## Summary

- Remove synchronous DOM geometry reads from sidebar thread virtualization now that the list starts at the scroll viewport origin.
- Calculate virtual windows and scroll-to-thread targets directly from `scrollTop` and the fixed row height.
- Remove the obsolete virtual-list DOM ref and signal lifecycle while retaining page-level row-alignment coverage.

## Context

The scroll margin was introduced when spacing lived inside the scroll viewport. The current layout puts that spacing on the scroll-area root, so the virtual list is the viewport's only laid-out child and its content origin is always zero. Reading both bounding rectangles is therefore redundant and can force layout during a thread switch.

## Verification

- `corepack pnpm exec prettier --check apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts apps/platform/src/signals/okou-page/sidebar-state.ts apps/platform/src/views/okou-page/sidebar-threads.tsx apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx`
- Targeted Oxlint, type-aware Oxlint, and ESLint checks for the four changed files
- `NODE_OPTIONS=--max-old-space-size=4096 corepack pnpm -F @okouai/app check-types`
- `corepack pnpm knip --workspace @okouai/app`
- Targeted sidebar virtualization and scroll-to-thread tests: every selected scenario passed in at least one run. Repeated grouped runs intermittently hit the existing 5-second page-test timeout during mocked page initialization with a realtime HTTP 500 warning; there were no assertion failures.
