### PR TITLE
perf(sandbox-fc): preserve supported guest capacity

### DIFF
--- a/crates/sandbox-fc/src/api/client.rs
+++ b/crates/sandbox-fc/src/api/client.rs
@@ -424,11 +424,13 @@ impl ApiClient {
         &self,
         amount_mib: u32,
         deflate_on_oom: bool,
+        free_page_reporting: bool,
         stats_polling_interval_s: u32,
     ) -> Result<(), ApiError> {
         self.configure_balloon_payload(&BalloonConfig {
             amount_mib,
             deflate_on_oom,
+            free_page_reporting,
             stats_polling_interval_s,
         })
         .await

--- a/crates/sandbox-fc/src/api/tests.rs
+++ b/crates/sandbox-fc/src/api/tests.rs
@@ -770,7 +770,7 @@ async fn configure_balloon_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
     let client = ApiClient::new(&sock_path).unwrap();
-    let result = client.configure_balloon(0, true, 0).await;
+    let result = client.configure_balloon(0, true, true, 0).await;
     assert!(result.is_ok());
 
     let request = api.next_request().await;
@@ -778,6 +778,8 @@ async fn configure_balloon_succeeds_on_204() {
     let body = request_body_json(&request);
     assert_eq!(body["amount_mib"], 0);
     assert_eq!(body["deflate_on_oom"], true);
+    assert_eq!(body["free_page_reporting"], true);
+    assert!(body.get("free_page_hinting").is_none());
     assert_eq!(body["stats_polling_interval_s"], 0);
 }
 

--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -28,11 +28,12 @@ pub(crate) const PRESSURE_AVAILABLE_MIB: i64 = TARGET_FREE_MIB - DEFLATE_HYSTERE
 /// Caps the per-tick increase to prevent sudden memory pressure spikes in the
 /// guest when a large amount of free memory is detected on the first tick.
 const MAX_INFLATE_PER_TICK_MIB: u32 = 256;
-/// Minimum guaranteed guest memory — never inflate beyond `memory_mb - MIN_GUEST_MIB`.
+/// Minimum supported guest memory — never inflate beyond
+/// `memory_mb - MIN_GUEST_MIB`.
 ///
 /// Exposed to the rest of the crate so that idle-park logic in `sandbox.rs`
 /// can use the same lower bound when one-shot inflating on idle transitions.
-pub(crate) const MIN_GUEST_MIB: u32 = 512;
+pub(crate) const MIN_GUEST_MIB: u32 = guest_contracts::process_containment::MIN_PROFILE_MEMORY_MB;
 /// Poll interval for balloon stats.
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// Fast-start polling while a post-unpark controller protects the lifecycle's
@@ -665,12 +666,12 @@ mod tests {
 
     #[tokio::test]
     async fn tick_releases_high_retention_near_pressure_boundary() {
-        // A 4-GiB Guest can retain 3584 MiB. Just below the 192-MiB pressure
+        // A 4-GiB Guest can retain 3072 MiB. Just below the 192-MiB pressure
         // boundary, the retired policy requested only partial relief. When
         // physical actual stalled behind that pending target, its
         // actual-relative candidate could not continue toward zero.
-        let stats = r#"{"target_mib":3584,"actual_mib":3584,"target_pages":917504,"actual_pages":917504,"free_memory":52428800,"available_memory":200278016}"#;
-        let patch = run_tick_with_mock(stats, 3584)
+        let stats = r#"{"target_mib":3072,"actual_mib":3072,"target_pages":786432,"actual_pages":786432,"free_memory":52428800,"available_memory":200278016}"#;
+        let patch = run_tick_with_mock(stats, 3072)
             .await
             .expect("expected PATCH releasing high balloon retention");
         assert_eq!(patch_amount_mib(&patch), 0);
@@ -738,7 +739,7 @@ mod tests {
 
     #[tokio::test]
     async fn tick_respects_max_inflate() {
-        // free_memory = 2 GiB, max_inflate is 512 (memory_mb=1024, MIN_GUEST=512).
+        // free_memory = 2 GiB and the supplied maximum inflation is 512 MiB.
         // Per-tick cap (256) < max_inflate (512), so cap wins.
         let stats = r#"{"target_mib":0,"actual_mib":0,"target_pages":0,"actual_pages":0,"free_memory":2147483648,"available_memory":2147483648}"#;
         let patch = run_tick_with_mock(stats, 512).await;

--- a/crates/sandbox-fc/src/boot_config.rs
+++ b/crates/sandbox-fc/src/boot_config.rs
@@ -55,6 +55,7 @@ pub(crate) struct VsockConfig {
 pub(crate) struct BalloonConfig {
     pub(crate) amount_mib: u32,
     pub(crate) deflate_on_oom: bool,
+    pub(crate) free_page_reporting: bool,
     pub(crate) stats_polling_interval_s: u32,
 }
 

--- a/crates/sandbox-fc/src/factory/invariant.rs
+++ b/crates/sandbox-fc/src/factory/invariant.rs
@@ -80,6 +80,7 @@ impl InvariantConfig {
             balloon: BalloonConfig {
                 amount_mib: 0,
                 deflate_on_oom: true,
+                free_page_reporting: true,
                 stats_polling_interval_s: 5,
             },
             prewarm_script: PREWARM_SCRIPT,
@@ -188,6 +189,26 @@ mod tests {
             expected_fields.len(),
             "unexpected Firecracker boot config section"
         );
+        assert_eq!(obj["balloon"]["free_page_reporting"], true);
+        assert!(obj["balloon"].get("free_page_hinting").is_none());
+    }
+
+    #[test]
+    fn balloon_reporting_change_changes_config_hash() {
+        let invariant = InvariantConfig::new();
+        let config = canonical_snapshot_boot_config(&invariant);
+        let original =
+            config_hash_for(&config, invariant.tap_mac, invariant.prewarm_script).unwrap();
+        let mut reporting_disabled = config.clone();
+        reporting_disabled.balloon.free_page_reporting = false;
+        let changed = config_hash_for(
+            &reporting_disabled,
+            invariant.tap_mac,
+            invariant.prewarm_script,
+        )
+        .unwrap();
+
+        assert_ne!(original, changed);
     }
 
     #[test]

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -5063,8 +5063,8 @@ async fn wait_for_balloon_extends_deadline_for_recent_safe_progress() {
     );
     assert_eq!(event.level, Level::INFO);
     assert_event_field(event, "actual", "Some(2314)");
-    assert_event_field(event, "target", "3584");
-    assert_event_field(event, "deficit_mib", "Some(1270)");
+    assert_event_field(event, "target", "3072");
+    assert_event_field(event, "deficit_mib", "Some(758)");
     assert_event_field(event, "previous_actual_mib", "Some(256)");
     assert_event_field(event, "reported_free_mib", "Some(2136)");
     assert_event_field(event, "reported_available_mib", "Some(2265)");
@@ -5136,7 +5136,7 @@ async fn wait_for_balloon_progress_grace_remains_bounded() {
     );
     assert_eq!(event.level, Level::WARN);
     assert_event_field(event, "actual", "Some(2314)");
-    assert_event_field(event, "deficit_mib", "Some(1270)");
+    assert_event_field(event, "deficit_mib", "Some(758)");
     assert_event_field(event, "reason", "severe_deficit");
     assert_event_field(event, "admission_action", "reject_and_destroy");
 }
@@ -5174,15 +5174,15 @@ async fn wait_for_balloon_near_target_logs_summary_without_timeout() {
         "balloon inflated within tolerance, proceeding to pause",
     );
     assert_eq!(event.level, Level::INFO);
-    assert_event_field(event, "actual", "3545");
-    assert_event_field(event, "target", "3584");
+    assert_event_field(event, "actual", "3033");
+    assert_event_field(event, "target", "3072");
     assert_event_field(event, "deficit_mib", "39");
     assert_event_field(event, "sample_count", "1");
-    assert_event_field(event, "requested_target_mib", "3584");
+    assert_event_field(event, "requested_target_mib", "3072");
     assert_event_field(event, "target_observed", "true");
-    assert_event_field(event, "observed_target_mib", "Some(3584)");
-    assert_event_field(event, "first_actual_mib", "Some(3545)");
-    assert_event_field(event, "max_actual_mib", "Some(3545)");
+    assert_event_field(event, "observed_target_mib", "Some(3072)");
+    assert_event_field(event, "first_actual_mib", "Some(3033)");
+    assert_event_field(event, "max_actual_mib", "Some(3033)");
     assert_event_field(event, "actual_delta_mib", "Some(0)");
 }
 
@@ -5192,7 +5192,7 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
     let api = MockLifecycleApi::with_stats(
         std::collections::VecDeque::new(),
         std::collections::VecDeque::from([MockBalloonStatsReply::Ok(MockBalloonStats::new(
-            target_mib, 1250,
+            target_mib, 800,
         ))]),
     );
     let client = ApiClient::new(api.socket_path()).unwrap();
@@ -5212,14 +5212,14 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
         "balloon inflate incomplete after 5s, pausing anyway",
     );
     assert_eq!(event.level, Level::WARN);
-    assert_event_field(event, "actual", "Some(1250)");
-    assert_event_field(event, "target", "1536");
-    assert_event_field(event, "deficit_mib", "Some(286)");
-    assert_event_field(event, "requested_target_mib", "1536");
+    assert_event_field(event, "actual", "Some(800)");
+    assert_event_field(event, "target", "1024");
+    assert_event_field(event, "deficit_mib", "Some(224)");
+    assert_event_field(event, "requested_target_mib", "1024");
     assert_event_field(event, "target_observed", "true");
-    assert_event_field(event, "observed_target_mib", "Some(1536)");
-    assert_event_field(event, "first_actual_mib", "Some(1250)");
-    assert_event_field(event, "max_actual_mib", "Some(1250)");
+    assert_event_field(event, "observed_target_mib", "Some(1024)");
+    assert_event_field(event, "first_actual_mib", "Some(800)");
+    assert_event_field(event, "max_actual_mib", "Some(800)");
     assert_event_field(event, "actual_delta_mib", "Some(0)");
     assert_event_field(event, "reason", "actual_stalled");
     assert_event_field(event, "admission_action", "reuse");
@@ -5228,7 +5228,7 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
 #[tokio::test]
 async fn wait_for_balloon_accepts_pressure_limited_partial_reclaim() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
-    let stats = MockBalloonStats::new(target_mib, 1250).with_memory(mib(64), mib(128), mib(2048));
+    let stats = MockBalloonStats::new(target_mib, 800).with_memory(mib(64), mib(128), mib(2048));
     let api = MockLifecycleApi::with_stats(
         std::collections::VecDeque::new(),
         std::collections::VecDeque::from([MockBalloonStatsReply::Ok(stats)]),
@@ -5256,10 +5256,10 @@ async fn wait_for_balloon_accepts_pressure_limited_partial_reclaim() {
         "balloon pressure-limited partial reclaim, proceeding to pause",
     );
     assert_eq!(event.level, Level::INFO);
-    assert_event_field(event, "actual", "1250");
-    assert_event_field(event, "target", "1536");
-    assert_event_field(event, "deficit_mib", "286");
-    assert_event_field(event, "tolerance_mib", "192");
+    assert_event_field(event, "actual", "800");
+    assert_event_field(event, "target", "1024");
+    assert_event_field(event, "deficit_mib", "224");
+    assert_event_field(event, "tolerance_mib", "128");
     assert_event_field(event, "sample_count", "1");
     assert_event_field(event, "target_observed", "true");
     assert_event_field(event, "reported_free_mib", "Some(64)");
@@ -5275,11 +5275,11 @@ fn balloon_settle_tolerance_is_capped_and_scales_for_small_targets() {
     );
     assert_eq!(
         balloon_settle_tolerance_mib(2048 - balloon::MIN_GUEST_MIB),
-        192
+        128
     );
     assert_eq!(
         balloon_settle_tolerance_mib(1024 - balloon::MIN_GUEST_MIB),
-        64
+        0
     );
     assert_eq!(balloon_settle_tolerance_mib(1), 0);
 }
@@ -5289,15 +5289,15 @@ fn balloon_settle_summary_classifies_progressing_timeout() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
     let mut summary = BalloonSettleSummary::new(target_mib);
 
-    summary.observe(&balloon_statistics(target_mib, 1200));
-    summary.observe(&balloon_statistics(target_mib, 1300));
+    summary.observe(&balloon_statistics(target_mib, 700));
+    summary.observe(&balloon_statistics(target_mib, 800));
 
     assert_eq!(summary.reason(), "actual_progressing_timeout");
     assert_eq!(summary.park_outcome(), SandboxParkOutcome::Reusable);
-    assert_eq!(summary.last_actual_mib, Some(1300));
-    assert_eq!(summary.last_deficit_mib, Some(236));
-    assert_eq!(summary.first_actual_mib, Some(1200));
-    assert_eq!(summary.max_actual_mib, Some(1300));
+    assert_eq!(summary.last_actual_mib, Some(800));
+    assert_eq!(summary.last_deficit_mib, Some(224));
+    assert_eq!(summary.first_actual_mib, Some(700));
+    assert_eq!(summary.max_actual_mib, Some(800));
     assert_eq!(summary.actual_delta_mib(), Some(100));
 }
 
@@ -5306,7 +5306,7 @@ fn pressure_limited_reclaim_ignores_free_memory_when_available_memory_is_missing
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
     let tolerance_mib = balloon_settle_tolerance_mib(target_mib);
     let mut available_summary = BalloonSettleSummary::new(target_mib);
-    let mut available_stats = balloon_statistics(target_mib, 1250);
+    let mut available_stats = balloon_statistics(target_mib, 800);
     available_stats.free_memory = Some(mib(2048));
     available_stats.available_memory = Some(mib(128));
     available_stats.total_memory = Some(mib(2048));
@@ -5317,7 +5317,7 @@ fn pressure_limited_reclaim_ignores_free_memory_when_available_memory_is_missing
     );
 
     let mut missing_available_summary = BalloonSettleSummary::new(target_mib);
-    let mut missing_available_stats = balloon_statistics(target_mib, 1250);
+    let mut missing_available_stats = balloon_statistics(target_mib, 800);
     missing_available_stats.free_memory = Some(mib(32));
     missing_available_stats.total_memory = Some(mib(2048));
     let missing_available_deficit_mib = missing_available_summary.observe(&missing_available_stats);
@@ -5334,7 +5334,7 @@ async fn wait_for_balloon_timeout_logs_target_not_observed_reason() {
     let api = MockLifecycleApi::with_stats(
         std::collections::VecDeque::new(),
         std::collections::VecDeque::from([MockBalloonStatsReply::Ok(MockBalloonStats::new(
-            1024, 1200,
+            512, 800,
         ))]),
     );
     let client = ApiClient::new(api.socket_path()).unwrap();
@@ -5355,7 +5355,7 @@ async fn wait_for_balloon_timeout_logs_target_not_observed_reason() {
     );
     assert_eq!(event.level, Level::WARN);
     assert_event_field(event, "target_observed", "false");
-    assert_event_field(event, "observed_target_mib", "Some(1024)");
+    assert_event_field(event, "observed_target_mib", "Some(512)");
     assert_event_field(event, "reason", "target_not_observed");
 }
 
@@ -5412,7 +5412,7 @@ async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
 #[tokio::test]
 async fn wait_for_balloon_timeout_logs_severe_deficit_and_memory_stats() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
-    let stats = MockBalloonStats::new(target_mib, 900)
+    let stats = MockBalloonStats::new(target_mib, 600)
         .with_memory(mib(32), mib(0), mib(2048))
         .with_extended_counters(11, 12, 13, 14, 15);
     let api = MockLifecycleApi::with_stats(
@@ -5435,10 +5435,10 @@ async fn wait_for_balloon_timeout_logs_severe_deficit_and_memory_stats() {
     assert_eq!(diagnostics.first_observed_target_mib, Some(target_mib));
     assert_eq!(diagnostics.observed_target_mib, Some(target_mib));
     assert!(diagnostics.target_observed);
-    assert_eq!(diagnostics.first_actual_mib, Some(900));
-    assert_eq!(diagnostics.actual_mib, Some(900));
-    assert_eq!(diagnostics.max_actual_mib, Some(900));
-    assert_eq!(diagnostics.deficit_mib, Some(636));
+    assert_eq!(diagnostics.first_actual_mib, Some(600));
+    assert_eq!(diagnostics.actual_mib, Some(600));
+    assert_eq!(diagnostics.max_actual_mib, Some(600));
+    assert_eq!(diagnostics.deficit_mib, Some(424));
     assert_eq!(diagnostics.actual_delta_mib, Some(0));
     assert_eq!(diagnostics.sample_count, 1);
     assert_eq!(diagnostics.reported_free_memory_bytes, Some(mib(32)));
@@ -5455,8 +5455,8 @@ async fn wait_for_balloon_timeout_logs_severe_deficit_and_memory_stats() {
         "balloon inflate incomplete after 5s, pausing anyway",
     );
     assert_eq!(event.level, Level::WARN);
-    assert_event_field(event, "actual", "Some(900)");
-    assert_event_field(event, "deficit_mib", "Some(636)");
+    assert_event_field(event, "actual", "Some(600)");
+    assert_event_field(event, "deficit_mib", "Some(424)");
     assert_event_field(event, "reported_free_mib", "Some(32)");
     assert_event_field(event, "reported_available_mib", "Some(0)");
     assert_event_field(event, "reported_total_mib", "Some(2048)");
@@ -5833,7 +5833,7 @@ async fn park_inflates_and_pauses() {
     );
     assert_eq!(ps[0].path, "/balloon");
     let parsed: serde_json::Value = serde_json::from_str(&ps[0].body).unwrap();
-    assert_eq!(parsed["amount_mib"].as_u64().unwrap(), 1536); // 2048 - 512
+    assert_eq!(parsed["amount_mib"].as_u64().unwrap(), 1024);
     assert_eq!(ps[1].path, "/vm");
     assert!(ps[1].body.contains("Paused"));
 }
@@ -5847,7 +5847,7 @@ async fn park_inflates_by_one_at_min_plus_one() {
 
     park_inner(
         &mut is_parked,
-        513,
+        balloon::MIN_GUEST_MIB + 1,
         &mut controller,
         api.socket_path(),
         "test-min-plus-1",
@@ -5880,7 +5880,7 @@ async fn park_small_vm_skips_balloon_but_pauses_vcpus() {
     let result = {
         let (_events, result) = park_inner_with_guest(
             &mut is_parked,
-            512,
+            balloon::MIN_GUEST_MIB,
             &mut controller,
             api.socket_path(),
             "test-park-small",
@@ -6093,7 +6093,7 @@ async fn unpark_small_vm_skips_balloon_but_resumes_vcpus() {
 
     unpark_inner(
         &mut is_parked,
-        512,
+        balloon::MIN_GUEST_MIB,
         &mut controller,
         api.socket_path(),
         state_rx.clone(),
@@ -6297,11 +6297,11 @@ async fn park_unpark_park_cycle() {
     assert_eq!(
         ops,
         vec![
-            ("/balloon", Some(1536)), // park 1: inflate
+            ("/balloon", Some(1024)), // park 1: inflate
             ("/vm", None),            // park 1: pause
             ("/vm", None),            // unpark: resume
             ("/balloon", Some(0)),    // unpark: deflate
-            ("/balloon", Some(1536)), // park 2: inflate
+            ("/balloon", Some(1024)), // park 2: inflate
             ("/vm", None),            // park 2: pause
         ],
         "unexpected PATCH sequence: {ops:?}"
@@ -6673,7 +6673,7 @@ async fn park_pauses_when_balloon_is_within_settle_tolerance() {
     // low-hundreds MiB residual while the guest reports little available
     // memory. That is close enough to park without waiting for the full
     // timeout and emitting a WARN.
-    let balloon_actual = Arc::new(AtomicU32::new(3545));
+    let balloon_actual = Arc::new(AtomicU32::new(4096 - balloon::MIN_GUEST_MIB - 39));
     let mut api = MockLifecycleApi::new(
         std::collections::VecDeque::new(),
         Some(Arc::clone(&balloon_actual)),
@@ -6755,7 +6755,7 @@ async fn park_pauses_when_balloon_deficit_equals_settle_tolerance() {
 #[tokio::test]
 async fn park_pauses_when_balloon_reclaim_is_pressure_limited() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
-    let stats = MockBalloonStats::new(target_mib, 1250).with_memory(mib(64), mib(128), mib(2048));
+    let stats = MockBalloonStats::new(target_mib, 800).with_memory(mib(64), mib(128), mib(2048));
     let mut api = MockLifecycleApi::with_stats(
         std::collections::VecDeque::new(),
         std::collections::VecDeque::from([MockBalloonStatsReply::Ok(stats)]),
@@ -6977,7 +6977,7 @@ async fn reusable_park_does_not_request_terminal_guest_memory() {
 
 #[tokio::test]
 async fn park_small_vm_pause_failure_preserves_controller() {
-    // Small VM (≤512 MiB): no balloon work, just pause. If pause
+    // A minimum-size VM does no balloon work and only pauses. If pause
     // fails, the controller must be preserved (not aborted) — unlike
     // large VMs where the controller is already gone.
     let api = MockLifecycleApi::new(std::collections::VecDeque::from(vec![500]), None);
@@ -6991,7 +6991,7 @@ async fn park_small_vm_pause_failure_preserves_controller() {
     let result = {
         let (_events, result) = park_inner_with_guest(
             &mut is_parked,
-            512,
+            balloon::MIN_GUEST_MIB,
             &mut controller,
             api.socket_path(),
             "small-fail",


### PR DESCRIPTION
## Summary

- preserve the supported 1 GiB guest capacity floor when reclaiming memory from active and idle sandboxes
- enable stable free-page reporting in the Firecracker balloon device without adding a startup barrier
- include the reporting mode in API serialization and snapshot configuration identity
- update integration coverage for the new invariant and reclaim targets

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p sandbox-fc --all-targets --all-features`
- `cargo clippy -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sandbox-fc --no-deps --all-features`
- `cargo test -p sandbox-fc`
- repository pre-commit Rust checks
- local-11 ordinary exact-reuse cohort: 12/12 successful runs, private writes preserved, candidate reused agent-ready p50 22 ms / p95 34 ms, runner RSS 120148 KiB

The exact natural `during_balloon` handoff window was not hit deterministically on metal. A controlled pause exercised severe-retention protection and fresh fallback instead, so that specific handoff gate remains open for CI or rollout validation.

Closes #31545
Parent: #31534
