### PR TITLE
test(api): use native clock-scoped lifecycle hooks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -11,7 +11,7 @@ import {
   chatThreadsContract,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { HttpResponse, http } from "msw";
-import { describe, expect, test as vitestTest } from "vitest";
+import { aroundEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { createApp } from "../../../app-factory";
@@ -69,15 +69,9 @@ function commandInput(command: unknown): Record<string, unknown> {
   return command.input as Record<string, unknown>;
 }
 
-function it(name: string, test: () => Promise<void>, timeout?: number): void {
-  vitestTest(
-    name,
-    async () => {
-      await withMockNowForTest(STARTED_AT_MS, test);
-    },
-    timeout,
-  );
-}
+aroundEach(async (runTest) => {
+  await withMockNowForTest(STARTED_AT_MS, runTest);
+});
 
 function isoAt(offsetMs: number): string {
   return new Date(STARTED_AT_MS + offsetMs).toISOString();

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-queue.test.ts
@@ -5,7 +5,7 @@ import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/con
 import { testWorkflowAutomationExecutionContract } from "@okouai/api-contracts/contracts/test-workflow-automation-execution";
 import { modelProvidersByTypeContract } from "@okouai/api-contracts/contracts/model-provider-routes";
 import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
-import { onTestFinished, test as vitestTest } from "vitest";
+import { aroundEach, it, onTestFinished } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -76,15 +76,9 @@ const WORKFLOW_NAME = "workflow-queue-workflow";
 const BUILT_IN_MODEL_ROUTES_UNAVAILABLE_MESSAGE =
   "Every built-in model route for this model is temporarily unavailable";
 
-function it(name: string, test: () => Promise<void>, timeout?: number): void {
-  vitestTest(
-    name,
-    async () => {
-      await withNowScopeForTest(test);
-    },
-    timeout,
-  );
-}
+aroundEach(async (runTest) => {
+  await withNowScopeForTest(runTest);
+});
 
 function authHeaders() {
   return { authorization: "Bearer clerk-session" };


### PR DESCRIPTION
## Summary

- replace the two custom clock-scoped `it()` wrappers with Vitest's native file-scoped `aroundEach`
- keep `browser.test.ts` initialized at `STARTED_AT_MS` while leaving the initial workflow-queue clock value unset
- preserve all 49 native tests and their existing third-argument timeouts

Fixes #31575
Part of #31516

## Lint inventory

Measured from implementation baseline `0ba342178d4c5119fbfd54e14c806c94e903fa45`; the later rebase target `5eae6943caf38bfec71dd7ce163add224074d6a8` only adds unrelated Platform changes.

| Scope | Before | After | Change |
| --- | ---: | ---: | ---: |
| `browser.test.ts` regular Oxlint | 172 | 0 | -172 |
| `workflow-queue.test.ts` regular Oxlint | 171 | 0 | -171 |
| API regular Oxlint | 456 | 113 | -343 |

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (14/14 tasks; API regular Oxlint: 113 warnings, 0 errors)
- focused regular Oxlint for both changed files (0 warnings, 0 errors)
- `pnpm knip`
- staged workspace type-checks, including `pnpm --filter api run check-types`
- `pnpm -F api exec vitest run src/lib/__tests__/time.test.ts` (6/6 passed)
- `browser.test.ts` and `workflow-queue.test.ts` were each run as separate foreground Vitest processes. In this fresh local checkout/database they encounter the existing `404 Job not found in queue` baseline. A controlled per-file A/B run with each original wrapper produced the exact same pass/fail sets as the native hook (browser: 3 passed, 12 failed; workflow queue: 17 passed, 17 failed), with no hook or timeout failures. The PR pipeline remains the authoritative environment for their complete route-test run.

The time-helper tests cover scoped cleanup and concurrent async isolation. The native hook deliberately extends the clock scope across inherited `beforeEach`, the test callback, inherited `afterEach`, and `onTestFinished`, while retaining Vitest's native per-test timeout arguments.
