### PR TITLE
refactor(platform): move telegram connect flows into commands

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/telegram-connect-page.ts
+++ b/turbo/apps/platform/src/signals/okou-page/telegram-connect-page.ts
@@ -8,6 +8,7 @@ import { updatePage$ } from "../react-router.ts";
 import { searchParams$ } from "../route.ts";
 import { TelegramConnectPage } from "../../views/okou-page/telegram-connect-page.tsx";
 import { parseTelegramConnectParams } from "./telegram-connect-params.ts";
+import { pollTelegramConnectDomainStatus$ } from "./telegram-connect-signals.ts";
 
 export const setupTelegramConnectPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -29,6 +30,9 @@ export const setupTelegramConnectPage$ = command(
         return $.connectors.providerConnect.telegram.connectTitle;
       }),
     );
-    await set(hideAppSkeleton$, signal);
+    await Promise.all([
+      set(hideAppSkeleton$, signal),
+      set(pollTelegramConnectDomainStatus$, signal),
+    ]);
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/telegram-connect-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/telegram-connect-signals.ts
@@ -8,7 +8,7 @@ import { capturePlausibleEvent } from "../../lib/plausible.ts";
 import { apiClient$ } from "../api-client.ts";
 import { oauthBaseForNavigation$ } from "../fetch.ts";
 import { searchParams$ } from "../route.ts";
-import { createDeferredPromise, onRef, setLoop } from "../utils.ts";
+import { createDeferredPromise, setLoop } from "../utils.ts";
 import {
   parseTelegramPostMessage,
   type TelegramAuthResult,
@@ -47,6 +47,36 @@ export const reloadTelegramConnectLinkStatus$ = command(({ set }) => {
     return prev + 1;
   });
 });
+
+export const pollTelegramConnectDomainStatus$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const parsed = parseTelegramConnectParams(get(searchParams$));
+    if (!parsed.ok || parsed.params.connectSignature) {
+      return;
+    }
+
+    let first = true;
+    await setLoop(
+      async (loopSignal) => {
+        if (first) {
+          first = false;
+        } else {
+          set(reloadTelegramConnectLinkStatus$);
+        }
+
+        const status = await get(telegramConnectLinkStatus$);
+        loopSignal.throwIfAborted();
+        return (
+          status === null ||
+          status.linked ||
+          status.installation?.domainConfigured !== false
+        );
+      },
+      3000,
+      signal,
+    );
+  },
+);
 
 function requestTelegramAuth(
   telegramBotId: string,
@@ -124,40 +154,10 @@ export const connectTelegramAccount$ = command(
       },
     });
 
+    window.location.assign(
+      `tg://resolve?domain=${result.body.botUsername.replace(/^@/, "")}`,
+    );
+
     return result.body;
   },
-);
-
-const openTelegramOnRef$ = command(
-  (_ctx, element: HTMLElement, _signal: AbortSignal) => {
-    const href = element.dataset.telegramHref;
-    if (!href) {
-      return;
-    }
-    window.location.assign(href);
-  },
-);
-
-export const telegramAutoOpenRef$ = onRef(openTelegramOnRef$);
-
-const pollTelegramDomainStatusOnRef$ = command(
-  async ({ set }, _element: HTMLElement, signal: AbortSignal) => {
-    let first = true;
-    await setLoop(
-      () => {
-        if (first) {
-          first = false;
-          return false;
-        }
-        set(reloadTelegramConnectLinkStatus$);
-        return false;
-      },
-      3000,
-      signal,
-    );
-  },
-);
-
-export const telegramDomainStatusPollerRef$ = onRef(
-  pollTelegramDomainStatusOnRef$,
 );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/telegram-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/telegram-connect-page.test.tsx
@@ -58,6 +58,10 @@ function telegramConnectPath(signature = "b".repeat(64)): string {
   return `/telegram/connect?${params.toString()}`;
 }
 
+function telegramLoginConnectPath(): string {
+  return `/telegram/connect?${new URLSearchParams({ bot: botId }).toString()}`;
+}
+
 describe("zero Telegram connect page", () => {
   it("shows invalid signed links through the rendered page", async () => {
     detachedSetupPage({ context, path: telegramConnectPath("invalid") });
@@ -68,6 +72,35 @@ describe("zero Telegram connect page", () => {
     expect(
       screen.getByText("The signature on this link is not valid."),
     ).toBeInTheDocument();
+  });
+
+  it("continues after the Telegram login domain is configured", async () => {
+    let domainConfigured = false;
+    context.mocks.api(
+      integrationsTelegramContract.getLinkStatus,
+      ({ respond }) => {
+        return respond(200, {
+          linked: false,
+          installation: {
+            id: botId,
+            botUsername: "agent_bot",
+            domainConfigured,
+          },
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: telegramLoginConnectPath() });
+
+    await expect(
+      screen.findByRole("heading", { name: "Set Telegram login domain" }),
+    ).resolves.toBeInTheDocument();
+
+    domainConfigured = true;
+
+    await expect(
+      screen.findByRole("heading", { name: "Connect to Telegram" }),
+    ).resolves.toBeInTheDocument();
   });
 
   it("links the Telegram user and shows the connected state", async () => {
@@ -85,7 +118,7 @@ describe("zero Telegram connect page", () => {
         });
       },
     );
-    context.mocks.browser.locationAssign();
+    const locationAssign = context.mocks.browser.locationAssign();
 
     detachedSetupPage({ context, path: telegramConnectPath() });
 
@@ -110,6 +143,9 @@ describe("zero Telegram connect page", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Open Telegram")).toBeInTheDocument();
     expect(screen.getByText("Back to Telegram settings")).toBeInTheDocument();
+    expect(locationAssign.calls).toStrictEqual([
+      "tg://resolve?domain=agent_bot",
+    ]);
     // Product brand is carried by the app/API Host. Keeping this request body
     // byte-for-byte compatible lets old and new app/API versions interoperate.
     expect(capturedLinkBody).toStrictEqual({

--- a/turbo/apps/platform/src/views/okou-page/telegram-connect-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/telegram-connect-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type { JSX, ReactNode } from "react";
 import { AlertCircle, ArrowLeft, CircleCheck, Loader2 } from "lucide-react";
@@ -11,9 +11,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { searchParams$ } from "../../signals/route.ts";
 import {
   connectTelegramAccount$,
-  telegramAutoOpenRef$,
   telegramConnectLinkStatus$,
-  telegramDomainStatusPollerRef$,
 } from "../../signals/okou-page/telegram-connect-signals.ts";
 import {
   parseTelegramConnectParams,
@@ -103,19 +101,6 @@ function InvalidState({ title, message }: { title: string; message: string }) {
   );
 }
 
-function TelegramAutoOpen({ href }: { href: string }) {
-  const telegramAutoOpenRef = useSet(telegramAutoOpenRef$);
-
-  return (
-    <span
-      key={href}
-      ref={telegramAutoOpenRef}
-      data-telegram-href={href}
-      hidden
-    />
-  );
-}
-
 function SuccessState({ botUsername }: { botUsername: string }) {
   const { t } = useTranslation();
   const telegramHref = `tg://resolve?domain=${botUsername.replace(/^@/, "")}`;
@@ -123,7 +108,6 @@ function SuccessState({ botUsername }: { botUsername: string }) {
 
   return (
     <PageShell>
-      <TelegramAutoOpen href={telegramHref} />
       <TelegramMark state="success" />
       <CenterText
         title={t(($) => {
@@ -224,18 +208,14 @@ function getTelegramConnectErrorMessage(error: unknown): string {
 
 function DomainStatusPolling() {
   const { t } = useTranslation();
-  const domainStatusPollerRef = useSet(telegramDomainStatusPollerRef$);
 
   return (
-    <>
-      <span ref={domainStatusPollerRef} hidden />
-      <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
-        <Loader2 size={13} className="animate-spin" />
-        {t(($) => {
-          return $.connectors.providerConnect.telegram.checkingDomain;
-        })}
-      </div>
-    </>
+    <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+      <Loader2 size={13} className="animate-spin" />
+      {t(($) => {
+        return $.connectors.providerConnect.telegram.checkingDomain;
+      })}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- move the automatic Telegram redirect into the successful account-link command
- start domain-status polling from the Telegram connect page setup command and bind it to the route lifecycle
- remove the hidden DOM refs that previously triggered both flows during render

## Testing

- `pnpm vitest --run apps/platform/src/views/okou-page/__tests__/telegram-connect-page.test.tsx`
- `pnpm --filter @okouai/app check-types`
- changed-file Prettier, Oxlint, type-aware Oxlint, and ESLint checks
- `pnpm knip --workspace @okouai/app --no-progress`
