### PR TITLE
fix(platform): close voice audio contexts on abort

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -835,6 +835,7 @@ function mockAudioContext(signal: AbortSignal): void {
 interface VoiceInputMockOptions {
   readonly audioContextReady?: Promise<void>;
   readonly getUserMediaReady?: Promise<void>;
+  readonly onAudioContextClose?: () => void;
   readonly onRecorderStart?: () => void;
   readonly onRecorderStop?: () => void;
   readonly rms?: number | readonly number[] | (() => number);
@@ -906,6 +907,7 @@ function mockVoiceInput(
     }
 
     close(): Promise<void> {
+      options.onAudioContextClose?.();
       return Promise.resolve();
     }
 

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -260,6 +260,7 @@ interface AudioActivityMonitor {
   readonly cancelFrame: (handle: number) => void;
   frameId: number | null;
   stopped: boolean;
+  closePromise: Promise<void> | null;
 }
 
 type SttSegmentResult =
@@ -432,54 +433,82 @@ async function startAudioActivityMonitor(
   }
 
   const audioContext = new AudioContextConstructor();
-  if (
-    typeof audioContext.createMediaStreamSource !== "function" ||
-    typeof audioContext.createAnalyser !== "function"
-  ) {
-    await closeAudioContextQuietly(audioContext);
-    return null;
-  }
-
-  await audioContext.resume();
-  if (signal.aborted) {
-    await closeAudioContextQuietly(audioContext);
-    signal.throwIfAborted();
-  }
-
-  const source = audioContext.createMediaStreamSource(stream);
-  const analyser = audioContext.createAnalyser();
-  const requestFrame = window.requestAnimationFrame.bind(window);
-  analyser.fftSize = 1024;
-  source.connect(analyser);
-
-  const monitor: AudioActivityMonitor = {
-    audioContext,
-    source,
-    analyser,
-    samples: new Float32Array(analyser.fftSize),
-    tracker: createAudioActivityTracker(onActivity),
-    cancelFrame: window.cancelAnimationFrame.bind(window),
-    frameId: null,
-    stopped: false,
-  };
-
-  let nextLevelSampleAt = audioActivityNow() + VOICE_LEVEL_SAMPLE_INTERVAL_MS;
-  const update = () => {
-    if (monitor.stopped) {
+  let audioContextClosePromise: Promise<void> | null = null;
+  let monitor: AudioActivityMonitor | null = null;
+  let retainedByMonitor = false;
+  const stopOnAbort = () => {
+    if (monitor) {
+      stopAudioActivityMonitor(monitor);
       return;
     }
-    monitor.analyser.getFloatTimeDomainData(monitor.samples);
-    const level = monitor.tracker.handle(monitor.samples);
-    const currentTime = audioActivityNow();
-    if (currentTime >= nextLevelSampleAt) {
-      onLevelSample(level);
-      nextLevelSampleAt = currentTime + VOICE_LEVEL_SAMPLE_INTERVAL_MS;
-    }
-    monitor.frameId = requestFrame(update);
+    audioContextClosePromise ??= closeAudioContextQuietly(audioContext);
   };
+  signal.addEventListener("abort", stopOnAbort, { once: true });
+  return await withCleanup(
+    (async () => {
+      signal.throwIfAborted();
+      if (
+        typeof audioContext.createMediaStreamSource !== "function" ||
+        typeof audioContext.createAnalyser !== "function"
+      ) {
+        return null;
+      }
 
-  update();
-  return monitor;
+      await audioContext.resume();
+      signal.throwIfAborted();
+
+      const source = audioContext.createMediaStreamSource(stream);
+      const analyser = audioContext.createAnalyser();
+      const requestFrame = window.requestAnimationFrame.bind(window);
+      analyser.fftSize = 1024;
+      source.connect(analyser);
+
+      const startedMonitor: AudioActivityMonitor = {
+        audioContext,
+        source,
+        analyser,
+        samples: new Float32Array(analyser.fftSize),
+        tracker: createAudioActivityTracker(onActivity),
+        cancelFrame: window.cancelAnimationFrame.bind(window),
+        frameId: null,
+        stopped: false,
+        closePromise: null,
+      };
+      monitor = startedMonitor;
+
+      let nextLevelSampleAt =
+        audioActivityNow() + VOICE_LEVEL_SAMPLE_INTERVAL_MS;
+      const update = () => {
+        if (startedMonitor.stopped) {
+          return;
+        }
+        startedMonitor.analyser.getFloatTimeDomainData(startedMonitor.samples);
+        const level = startedMonitor.tracker.handle(startedMonitor.samples);
+        const currentTime = audioActivityNow();
+        if (currentTime >= nextLevelSampleAt) {
+          onLevelSample(level);
+          nextLevelSampleAt = currentTime + VOICE_LEVEL_SAMPLE_INTERVAL_MS;
+        }
+        startedMonitor.frameId = requestFrame(update);
+      };
+
+      update();
+      retainedByMonitor = true;
+      return startedMonitor;
+    })(),
+    async () => {
+      if (retainedByMonitor) {
+        return;
+      }
+      signal.removeEventListener("abort", stopOnAbort);
+      if (monitor) {
+        await stopAudioActivityMonitorAndWait(monitor);
+        return;
+      }
+      audioContextClosePromise ??= closeAudioContextQuietly(audioContext);
+      await audioContextClosePromise;
+    },
+  );
 }
 
 function stopAudioActivityMonitor(monitor: AudioActivityMonitor): void {
@@ -495,6 +524,16 @@ function stopAudioActivityMonitor(monitor: AudioActivityMonitor): void {
   monitor.tracker.reset();
   monitor.source.disconnect();
   monitor.analyser.disconnect();
+  monitor.closePromise = closeAudioContextQuietly(monitor.audioContext);
+}
+
+async function stopAudioActivityMonitorAndWait(
+  monitor: AudioActivityMonitor,
+): Promise<void> {
+  stopAudioActivityMonitor(monitor);
+  if (monitor.closePromise) {
+    await monitor.closePromise;
+  }
 }
 
 function isAudioInputQuotaExceeded(failure: SttApiFailure): boolean {
@@ -1203,9 +1242,6 @@ export const startRecording$ = command(
 
         signal.addEventListener("abort", () => {
           session.cancel();
-          if (audioActivityMonitor) {
-            stopAudioActivityMonitor(audioActivityMonitor);
-          }
           stopAllTracks(stream);
           set(resetState$);
         });
@@ -1301,8 +1337,7 @@ export const stopAndTranscribe$ = command(
           const session = get(internalRecordingSession$);
           const audioActivityMonitor = get(internalAudioActivityMonitor$);
           if (audioActivityMonitor) {
-            stopAudioActivityMonitor(audioActivityMonitor);
-            await closeAudioContextQuietly(audioActivityMonitor.audioContext);
+            await stopAudioActivityMonitorAndWait(audioActivityMonitor);
             signal.throwIfAborted();
             set(internalAudioActivityMonitor$, null);
             set(internalSpeechDetected$, false);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx
@@ -2207,8 +2207,12 @@ describe("chat lifecycle", () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "e2000000-0000-4000-a000-000000000012";
     const audioReady = context.mocks.deferred<void>();
+    let audioContextCloseCount = 0;
     context.mocks.browser.voiceInput({
       audioContextReady: audioReady.promise,
+      onAudioContextClose: () => {
+        audioContextCloseCount += 1;
+      },
       rms: 0.1,
     });
     mockChatLifecycle(context, { threadId });
@@ -2236,18 +2240,105 @@ describe("chat lifecycle", () => {
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByLabelText("Stop recording"));
+    await waitFor(() => {
+      expect(audioContextCloseCount).toBe(1);
+    });
     audioReady.resolve(undefined);
 
     await waitFor(() => {
       expect(transcriptionCalled).toBeTruthy();
       expect(textarea).toHaveTextContent("first words");
+      expect(audioContextCloseCount).toBe(1);
+    });
+  });
+
+  it("closes the voice audio context when its activity monitor fails", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e2000000-0000-4000-a000-000000000031";
+    const audioReady = context.mocks.deferred<void>();
+    let audioContextCloseCount = 0;
+    context.mocks.browser.voiceInput({
+      audioContextReady: audioReady.promise,
+      onAudioContextClose: () => {
+        audioContextCloseCount += 1;
+      },
+      rms: 0.1,
+    });
+    mockChatLifecycle(context, { threadId });
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    await user.click(await enabledVoiceInputButton());
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
+    });
+
+    audioReady.reject(new Error("Audio activity monitor failed to start"));
+
+    await waitFor(() => {
+      expect(audioContextCloseCount).toBe(1);
+    });
+    expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
+  });
+
+  it("closes the voice audio context when page navigation aborts recording", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "e2000000-0000-4000-a000-000000000032";
+    const nextThreadId = "e2000000-0000-4000-a000-000000000033";
+    let audioContextCloseCount = 0;
+    context.mocks.browser.voiceInput({
+      rms: 0.1,
+      onAudioContextClose: () => {
+        audioContextCloseCount += 1;
+      },
+    });
+    const lifecycle = mockChatLifecycle(context, { threadId });
+    lifecycle.setThreadList([
+      {
+        id: threadId,
+        title: "Recording voice thread",
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      },
+      {
+        id: nextThreadId,
+        title: "Other voice thread",
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      },
+    ]);
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    await user.click(await enabledVoiceInputButton());
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
+    });
+
+    await user.click(
+      await waitFor(() => {
+        return linkByText("Other voice thread");
+      }),
+    );
+
+    await waitFor(() => {
+      expect(document.title).toBe("Other voice thread | VM0");
+      expect(audioContextCloseCount).toBe(1);
     });
   });
 
   it("cancels silent voice input without calling transcription", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "e2000000-0000-4000-a000-000000000013";
-    context.mocks.browser.voiceInput({ rms: 0 });
+    let audioContextCloseCount = 0;
+    context.mocks.browser.voiceInput({
+      rms: 0,
+      onAudioContextClose: () => {
+        audioContextCloseCount += 1;
+      },
+    });
     mockChatLifecycle(context, { threadId });
     let transcriptionCalled = false;
     context.mocks.http.post("*/api/voice-io/stt", () => {
@@ -2273,6 +2364,7 @@ describe("chat lifecycle", () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
+      expect(audioContextCloseCount).toBe(1);
     });
     expect(transcriptionCalled).toBeFalsy();
     expect(textarea.textContent ?? "").toBe("");


### PR DESCRIPTION
## Summary

- close each recording-owned `AudioContext` on normal stop and page lifecycle abort
- release contexts when audio activity monitor startup fails
- keep cleanup idempotent and cover all lifecycle paths with page-level tests

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx --silent=passed-only` (48 passed)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app --no-progress`
- `pnpm exec prettier --check apps/platform/src/signals/voice-io/voice-io-stt.ts apps/platform/src/signals/__tests__/test-mocks.ts apps/platform/src/views/okou-page/__tests__/chat-computer-use-and-voice.test.tsx`
