### PR TITLE
feat(platform): announce the vm0 to okou rename with a top banner

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -3316,6 +3316,10 @@
       "stepTwo": "Wählen Sie „Zum Startbildschirm hinzufügen“.",
       "title": "Installieren Sie {{assistantName}}"
     },
+    "rebrandBanner": {
+      "dismiss": "Banner zur Namensänderung schließen",
+      "message": "VM0 heißt jetzt Okou. Gleiches Team, gleiches Produkt, neuer Name."
+    },
     "redeemCampaign": {
       "actions": {
         "back": "Zurück zu {{brandName}}",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -3308,6 +3308,10 @@
       "stepTwo": "Choose Add to Home Screen.",
       "title": "Install {{assistantName}}"
     },
+    "rebrandBanner": {
+      "dismiss": "Dismiss rename banner",
+      "message": "VM0 is now Okou. Same team, same product, new name."
+    },
     "redeemCampaign": {
       "actions": {
         "back": "Back to {{brandName}}",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -3367,6 +3367,10 @@
       "stepTwo": "Elige Añadir a la pantalla de inicio.",
       "title": "Instalar {{assistantName}}"
     },
+    "rebrandBanner": {
+      "dismiss": "Cerrar banner de cambio de nombre",
+      "message": "VM0 ahora es Okou. El mismo equipo, el mismo producto, un nombre nuevo."
+    },
     "redeemCampaign": {
       "actions": {
         "back": "Volver a {{brandName}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -3367,6 +3367,10 @@
       "stepTwo": "Choisissez Ajouter à l’écran d’accueil.",
       "title": "Installer {{assistantName}}"
     },
+    "rebrandBanner": {
+      "dismiss": "Fermer la bannière de changement de nom",
+      "message": "VM0 devient Okou. La même équipe, le même produit, un nouveau nom."
+    },
     "redeemCampaign": {
       "actions": {
         "back": "Retour à {{brandName}}",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -3316,6 +3316,10 @@
       "stepTwo": "होम स्क्रीन में जोड़ें चुनें.",
       "title": "{{assistantName}} स्थापित करें"
     },
+    "rebrandBanner": {
+      "dismiss": "नाम बदलने का बैनर बंद करें",
+      "message": "VM0 अब Okou है। वही टीम, वही प्रोडक्ट, नया नाम।"
+    },
     "redeemCampaign": {
       "actions": {
         "back": "{{brandName}} पर वापस जाएँ",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -3308,6 +3308,10 @@
       "stepTwo": "Pilih Tambahkan ke Layar Utama.",
       "title": "Instal {{assistantName}}"
     },
+    "rebrandBanner": {
+      "dismiss": "Tutup banner perubahan nama",
+      "message": "VM0 kini menjadi Okou. Tim yang sama, produk yang sama, nama baru."
+    },
     "redeemCampaign": {
       "actions": {
         "back": "Kembali ke {{brandName}}",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -3367,6 +3367,10 @@
       "stepTwo": "Scegli Aggiungi alla schermata principale.",
       "title": "Installa {{assistantName}}"
     },
+    "rebrandBanner": {
+      "dismiss": "Chiudi il banner di cambio nome",
+      "message": "VM0 ora è Okou. Stesso team, stesso prodotto, nuovo nome."
+    },
     "redeemCampaign": {
       "actions": {
         "back": "Torna a {{brandName}}",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -3308,6 +3308,10 @@
       "stepTwo": "「ホーム画面に追加」を選択します。",
       "title": "{{assistantName}} をインストールする"
     },
+    "rebrandBanner": {
+      "dismiss": "名称変更バナーを閉じる",
+      "message": "VM0 は Okou になりました。同じチーム、同じプロダクト、新しい名前です。"
+    },
     "redeemCampaign": {
       "actions": {
         "back": "{{brandName}} に戻る",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -3308,6 +3308,10 @@
       "stepTwo": "홈 화면에 추가를 선택하세요.",
       "title": "{{assistantName}} 설치"
     },
+    "rebrandBanner": {
+      "dismiss": "이름 변경 배너 닫기",
+      "message": "VM0가 이제 Okou입니다. 같은 팀, 같은 제품, 새로운 이름입니다."
+    },
     "redeemCampaign": {
       "actions": {
         "back": "{{brandName}}로 돌아가기",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -3367,6 +3367,10 @@
       "stepTwo": "Escolha Adicionar à Tela Inicial.",
       "title": "Instalar {{assistantName}}"
     },
+    "rebrandBanner": {
+      "dismiss": "Fechar banner de mudança de nome",
+      "message": "A VM0 agora é Okou. Mesma equipe, mesmo produto, novo nome."
+    },
     "redeemCampaign": {
       "actions": {
         "back": "Voltar para {{brandName}}",

--- a/turbo/apps/platform/src/signals/rebrand-banner.ts
+++ b/turbo/apps/platform/src/signals/rebrand-banner.ts
@@ -1,0 +1,24 @@
+import { command, computed } from "ccstate";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { brandName$ } from "./branding.ts";
+import { featureSwitch$ } from "./external/feature-switch.ts";
+import { localStorageSignals } from "./external/local-storage.ts";
+
+const { get$: dismissedRaw$, set$: setDismissed$ } = localStorageSignals(
+  "okou-rebrand-banner-dismissed",
+);
+
+export const rebrandBannerVisible$ = computed((get) => {
+  // The announcement only makes sense where the product already reads as Okou.
+  if (get(brandName$) !== "Okou") {
+    return false;
+  }
+  if (get(dismissedRaw$) !== null) {
+    return false;
+  }
+  return get(featureSwitch$)[FeatureSwitchKey.RebrandBanner] ?? false;
+});
+
+export const dismissRebrandBanner$ = command(({ set }) => {
+  set(setDismissed$, "1");
+});

--- a/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
@@ -41,6 +41,7 @@ import {
   InstallBanner,
   IosInstallModal,
 } from "../pwa-install/install-banner.tsx";
+import { RebrandBanner } from "../rebrand-banner/rebrand-banner.tsx";
 import { useOpenThreadArtifacts } from "./thread-sidebar.tsx";
 import { ChatShortcutHelpDialog } from "./chat-shortcut-help-dialog.tsx";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
@@ -403,6 +404,7 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
       <QueueDrawer />
       {isDesktop ? <Sidebar isDesktop /> : <MobileSidebarMount />}
       <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg zero-workspace-card">
+        <RebrandBanner />
         <InstallBanner />
         <IosInstallModal />
         {!isDesktop && <MobileTopBar />}

--- a/turbo/apps/platform/src/views/rebrand-banner/__tests__/rebrand-banner.test.tsx
+++ b/turbo/apps/platform/src/views/rebrand-banner/__tests__/rebrand-banner.test.tsx
@@ -1,0 +1,59 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+
+import { click, detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+const REBRAND_MESSAGE = "VM0 is now Okou. Same team, same product, new name.";
+
+describe("rebrand banner", () => {
+  it("announces the new name on an Okou host until it is dismissed", async () => {
+    context.mocks.browser.url("https://app.okou.ai/");
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.RebrandBanner]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(REBRAND_MESSAGE)).toBeVisible();
+    });
+
+    click(screen.getByLabelText("Dismiss rename banner"));
+
+    await waitFor(() => {
+      expect(screen.queryByText(REBRAND_MESSAGE)).not.toBeInTheDocument();
+    });
+  });
+
+  it("stays hidden on a VM0 host", async () => {
+    context.mocks.browser.url("https://app.vm0.ai/");
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.RebrandBanner]: true },
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector(".zero-workspace-card")).not.toBeNull();
+    });
+    expect(screen.queryByText(REBRAND_MESSAGE)).not.toBeInTheDocument();
+  });
+
+  it("stays hidden while the feature switch is off", async () => {
+    context.mocks.browser.url("https://app.okou.ai/");
+    detachedSetupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.RebrandBanner]: false },
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector(".zero-workspace-card")).not.toBeNull();
+    });
+    expect(screen.queryByText(REBRAND_MESSAGE)).not.toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/rebrand-banner/rebrand-banner.tsx
+++ b/turbo/apps/platform/src/views/rebrand-banner/rebrand-banner.tsx
@@ -1,0 +1,44 @@
+import { useGet, useSet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
+import { Sparkles, X } from "lucide-react";
+import { Button } from "@okouai/ui";
+import {
+  dismissRebrandBanner$,
+  rebrandBannerVisible$,
+} from "../../signals/rebrand-banner.ts";
+
+export function RebrandBanner() {
+  const { t } = useTranslation();
+  const visible = useGet(rebrandBannerVisible$);
+  const dismiss = useSet(dismissRebrandBanner$);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="shrink-0 flex items-center gap-2 bg-primary/5 border-b border-primary/20 px-3 py-2 text-sm">
+      <Sparkles size={16} className="text-brand-text shrink-0" />
+      <span className="flex-1 min-w-0 truncate text-foreground">
+        {t(($) => {
+          return $.lifecycle.rebrandBanner.message;
+        })}
+      </span>
+      <Button
+        showTooltip
+        type="button"
+        onClick={() => {
+          dismiss();
+        }}
+        variant="quiet"
+        size="icon-xs"
+        className="shrink-0"
+        aria-label={t(($) => {
+          return $.lifecycle.rebrandBanner.dismiss;
+        })}
+      >
+        <X size={14} />
+      </Button>
+    </div>
+  );
+}

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -79,4 +79,5 @@ export enum FeatureSwitchKey {
   GeistTypeface = "geistTypeface",
   SocialDownloadDetectedMediaType = "socialDownloadDetectedMediaType",
   NewUi = "newUi",
+  RebrandBanner = "rebrandBanner",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -504,6 +504,14 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     // Ming only while the shell settles; widen once the layout is signed off.
     enabledEmailHashes: ["54757055"], // fnv1a("ming@vm0.ai")
   },
+  [FeatureSwitchKey.RebrandBanner]: {
+    maintainer: "ming@vm0.ai",
+    description:
+      "Show a dismissible top banner on Okou-branded hosts announcing that VM0 is now Okou.",
+    enabled: false,
+    // Staff review the copy first; flip to `enabled: true` at rebrand launch.
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## What

Adds a dismissible banner at the top of the workspace announcing the rename:

> VM0 is now Okou. Same team, same product, new name.

- Renders only on Okou-branded hosts (`brandName$ === "Okou"`), so nothing changes on `app.vm0.ai`.
- Sits directly above the PWA install banner in `SidebarLayout`, reusing that banner's visual treatment.
- Dismissal persists in local storage (`okou-rebrand-banner-dismissed`).
- Gated behind the new `rebrandBanner` feature switch (`enabled: false`, staff orgs only) so the team can review the copy on a preview first. Flip `enabled: true` in `turbo/packages/core/src/feature-switch.ts` at launch.
- Copy translated into all 10 supported locales.

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/rebrand-banner` — 3 passed (shows and dismisses on an Okou host, hidden on a VM0 host, hidden with the switch off)
- `pnpm -F @okouai/app exec vitest run src/views/lab-page src/views/pwa-install` — 9 passed
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` — 31 passed
- `pnpm -F @okouai/app lint`, `pnpm -F @okouai/core lint`, `pnpm -F @okouai/app check-types`, `pnpm -F @okouai/core check-types`, `pnpm knip`, `pnpm format` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)