### PR TITLE
fix(runner): validate shared pi model constraints

### DIFF
--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -210,20 +210,20 @@ fn is_pi_credential_secret_name(value: &str) -> bool {
 enum PiModelConfigCommonError {
     InvalidBaseUrl,
     EmptyModel,
-    EmptyCatalogModel,
+    InvalidCatalogModel,
 }
 
 fn validate_pi_model_config_common(
     base_url: &str,
     model: &str,
-    catalog_model: Option<&str>,
+    catalog_model: Option<&serde_json::Value>,
 ) -> Result<(), PiModelConfigCommonError> {
     url::Url::parse(base_url).map_err(|_| PiModelConfigCommonError::InvalidBaseUrl)?;
     if model.is_empty() {
         return Err(PiModelConfigCommonError::EmptyModel);
     }
-    if catalog_model.is_some_and(str::is_empty) {
-        return Err(PiModelConfigCommonError::EmptyCatalogModel);
+    if catalog_model.is_some_and(|value| value.as_str().is_none_or(str::is_empty)) {
+        return Err(PiModelConfigCommonError::InvalidCatalogModel);
     }
     Ok(())
 }
@@ -231,22 +231,18 @@ fn validate_pi_model_config_common(
 fn validate_legacy_pi_model_config(value: &serde_json::Value) -> Result<(), String> {
     let model: PiModelConfig = serde_json::from_value(value.clone())
         .map_err(|error| format!("Pi legacy model config is invalid: {error}"))?;
-    validate_pi_model_config_common(
-        &model.base_url,
-        &model.model,
-        model.catalog_model.as_deref(),
-    )
-    .map_err(|error| match error {
-        PiModelConfigCommonError::InvalidBaseUrl => {
-            "Pi model config baseUrl is invalid".to_string()
-        }
-        PiModelConfigCommonError::EmptyModel => {
-            "Pi model config model must not be empty".to_string()
-        }
-        PiModelConfigCommonError::EmptyCatalogModel => {
-            "Pi model config catalogModel must not be empty".to_string()
-        }
-    })?;
+    validate_pi_model_config_common(&model.base_url, &model.model, value.get("catalogModel"))
+        .map_err(|error| match error {
+            PiModelConfigCommonError::InvalidBaseUrl => {
+                "Pi model config baseUrl is invalid".to_string()
+            }
+            PiModelConfigCommonError::EmptyModel => {
+                "Pi model config model must not be empty".to_string()
+            }
+            PiModelConfigCommonError::InvalidCatalogModel => {
+                "Pi model config catalogModel is invalid".to_string()
+            }
+        })?;
     if !is_pi_credential_secret_name(&model.credential_secret_name) {
         return Err("Pi model config credentialSecretName is invalid".to_string());
     }
@@ -417,20 +413,16 @@ fn validate_pi_model_config_v2(value: &serde_json::Value) -> Result<(), String> 
     if model.schema_version != i64::from(PI_MODEL_CONFIG_CURRENT_GENERATION) {
         return Err("Pi model config schemaVersion is unsupported".to_string());
     }
-    validate_pi_model_config_common(
-        &model.base_url,
-        &model.model,
-        model.catalog_model.as_deref(),
-    )
-    .map_err(|error| match error {
-        PiModelConfigCommonError::InvalidBaseUrl => {
-            "Pi model config baseUrl is invalid".to_string()
-        }
-        PiModelConfigCommonError::EmptyModel => "Pi model config model is invalid".to_string(),
-        PiModelConfigCommonError::EmptyCatalogModel => {
-            "Pi model config catalogModel is invalid".to_string()
-        }
-    })?;
+    validate_pi_model_config_common(&model.base_url, &model.model, value.get("catalogModel"))
+        .map_err(|error| match error {
+            PiModelConfigCommonError::InvalidBaseUrl => {
+                "Pi model config baseUrl is invalid".to_string()
+            }
+            PiModelConfigCommonError::EmptyModel => "Pi model config model is invalid".to_string(),
+            PiModelConfigCommonError::InvalidCatalogModel => {
+                "Pi model config catalogModel is invalid".to_string()
+            }
+        })?;
     if model.model.encode_utf16().count() > 512 {
         return Err("Pi model config model is invalid".to_string());
     }

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -207,16 +207,54 @@ fn is_pi_credential_secret_name(value: &str) -> bool {
         && bytes.all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
 }
 
+enum PiModelConfigCommonError {
+    InvalidBaseUrl,
+    EmptyModel,
+    EmptyCatalogModel,
+}
+
+fn validate_pi_model_config_common(
+    base_url: &str,
+    model: &str,
+    catalog_model: Option<&str>,
+) -> Result<(), PiModelConfigCommonError> {
+    url::Url::parse(base_url).map_err(|_| PiModelConfigCommonError::InvalidBaseUrl)?;
+    if model.is_empty() {
+        return Err(PiModelConfigCommonError::EmptyModel);
+    }
+    if catalog_model.is_some_and(str::is_empty) {
+        return Err(PiModelConfigCommonError::EmptyCatalogModel);
+    }
+    Ok(())
+}
+
 fn validate_legacy_pi_model_config(value: &serde_json::Value) -> Result<(), String> {
     let model: PiModelConfig = serde_json::from_value(value.clone())
         .map_err(|error| format!("Pi legacy model config is invalid: {error}"))?;
-    url::Url::parse(&model.base_url)
-        .map_err(|_| "Pi model config baseUrl is invalid".to_string())?;
-    if model.model.is_empty() {
-        return Err("Pi model config model must not be empty".to_string());
-    }
+    validate_pi_model_config_common(
+        &model.base_url,
+        &model.model,
+        model.catalog_model.as_deref(),
+    )
+    .map_err(|error| match error {
+        PiModelConfigCommonError::InvalidBaseUrl => {
+            "Pi model config baseUrl is invalid".to_string()
+        }
+        PiModelConfigCommonError::EmptyModel => {
+            "Pi model config model must not be empty".to_string()
+        }
+        PiModelConfigCommonError::EmptyCatalogModel => {
+            "Pi model config catalogModel must not be empty".to_string()
+        }
+    })?;
     if !is_pi_credential_secret_name(&model.credential_secret_name) {
         return Err("Pi model config credentialSecretName is invalid".to_string());
+    }
+    if value
+        .get("credentialHeader")
+        .is_some_and(|header| !is_valid_pi_credential_header(header))
+    {
+        return Err("Pi model config credentialHeader is invalid".to_string());
     }
     Ok(())
 }
@@ -379,9 +417,21 @@ fn validate_pi_model_config_v2(value: &serde_json::Value) -> Result<(), String> 
     if model.schema_version != i64::from(PI_MODEL_CONFIG_CURRENT_GENERATION) {
         return Err("Pi model config schemaVersion is unsupported".to_string());
     }
-    url::Url::parse(&model.base_url)
-        .map_err(|_| "Pi model config baseUrl is invalid".to_string())?;
-    if model.model.is_empty() || model.model.encode_utf16().count() > 512 {
+    validate_pi_model_config_common(
+        &model.base_url,
+        &model.model,
+        model.catalog_model.as_deref(),
+    )
+    .map_err(|error| match error {
+        PiModelConfigCommonError::InvalidBaseUrl => {
+            "Pi model config baseUrl is invalid".to_string()
+        }
+        PiModelConfigCommonError::EmptyModel => "Pi model config model is invalid".to_string(),
+        PiModelConfigCommonError::EmptyCatalogModel => {
+            "Pi model config catalogModel is invalid".to_string()
+        }
+    })?;
+    if model.model.encode_utf16().count() > 512 {
         return Err("Pi model config model is invalid".to_string());
     }
     let Some(object) = value.as_object() else {
@@ -416,12 +466,10 @@ fn validate_pi_model_config_v2(value: &serde_json::Value) -> Result<(), String> 
     if object.get("transport").and_then(serde_json::Value::as_str) != Some("sse") {
         return Err("Pi model config transport must be sse".to_string());
     }
-    if object
-        .get("catalogModel")
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|catalog_model| {
-            catalog_model.is_empty() || catalog_model.encode_utf16().count() > 512
-        })
+    if model
+        .catalog_model
+        .as_deref()
+        .is_some_and(|catalog_model| catalog_model.encode_utf16().count() > 512)
     {
         return Err("Pi model config catalogModel is invalid".to_string());
     }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -1536,15 +1536,17 @@ fn pi_execution_context_rejects_invalid_legacy_shared_model_fields_before_sandbo
         );
     }
 
-    let mut context = pi_context_for_test();
-    context.pi_model_config.as_mut().unwrap()["catalogModel"] = json!("");
+    for (case, catalog_model) in [("empty", json!("")), ("null", json!(null))] {
+        let mut context = pi_context_for_test();
+        context.pi_model_config.as_mut().unwrap()["catalogModel"] = catalog_model;
 
-    let error = validate_context_for_test(&context).unwrap_err();
+        let error = validate_context_for_test(&context).unwrap_err();
 
-    assert!(
-        error.contains("Pi model config catalogModel must not be empty"),
-        "empty catalogModel produced unexpected error: {error}"
-    );
+        assert!(
+            error.contains("Pi model config catalogModel is invalid"),
+            "{case} catalogModel produced unexpected error: {error}"
+        );
+    }
 }
 
 #[test]
@@ -1584,6 +1586,14 @@ fn pi_execution_context_rejects_invalid_or_future_v2_routes() {
             {
                 let mut config = pi_model_config_v2_for_test("openai-responses");
                 config["catalogModel"] = json!("");
+                config
+            },
+            "Pi model config catalogModel is invalid",
+        ),
+        (
+            {
+                let mut config = pi_model_config_v2_for_test("openai-responses");
+                config["catalogModel"] = json!(null);
                 config
             },
             "Pi model config catalogModel is invalid",

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -1569,6 +1569,14 @@ fn pi_execution_context_rejects_invalid_or_future_v2_routes() {
         (
             {
                 let mut config = pi_model_config_v2_for_test("openai-responses");
+                config["baseUrl"] = json!("not a URL");
+                config
+            },
+            "Pi model config baseUrl is invalid",
+        ),
+        (
+            {
+                let mut config = pi_model_config_v2_for_test("openai-responses");
                 config["model"] = json!("");
                 config
             },

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -1240,6 +1240,11 @@ fn pi_execution_context_preserves_additive_fields_in_run_payload() {
     ctx.pi_launch_config.as_mut().unwrap()["apiFirstTurn"]["futureFirstTurnField"] =
         json!("first-turn");
     ctx.pi_launch_config.as_mut().unwrap()["apiFirstTurn"]["sandboxEventSequenceStart"] = json!(4);
+    ctx.pi_model_config.as_mut().unwrap()["catalogModel"] = json!("deepseek-v4-flash");
+    ctx.pi_model_config.as_mut().unwrap()["credentialHeader"] = json!({
+        "name": "X-Api-Key",
+        "valueTemplate": "Bearer {{secret}}"
+    });
     ctx.pi_model_config.as_mut().unwrap()["futureModelField"] = json!("model-root");
     let sandbox_id = SandboxId::new_v4().to_string();
     let payload = validate_execution_context_before_sandbox(
@@ -1265,6 +1270,12 @@ fn pi_execution_context_preserves_additive_fields_in_run_payload() {
     assert_eq!(model["provider"], "deepseek");
     assert_eq!(model["apiKeyEnv"], "OPENAI_API_KEY");
     assert_eq!(model["credentialSecretName"], "DEEPSEEK_API_KEY");
+    assert_eq!(model["catalogModel"], "deepseek-v4-flash");
+    assert_eq!(model["credentialHeader"]["name"], "X-Api-Key");
+    assert_eq!(
+        model["credentialHeader"]["valueTemplate"],
+        "Bearer {{secret}}"
+    );
     assert_eq!(model["futureModelField"], "model-root");
 }
 
@@ -1424,6 +1435,119 @@ fn pi_execution_context_rejects_invalid_model_fields_before_sandbox() {
 }
 
 #[test]
+fn pi_execution_context_rejects_invalid_legacy_shared_model_fields_before_sandbox() {
+    let invalid_headers = [
+        (
+            "non-object",
+            json!(null),
+            "Pi model config credentialHeader",
+        ),
+        (
+            "missing name",
+            json!({ "valueTemplate": "Bearer {{secret}}" }),
+            "Pi legacy model config is invalid",
+        ),
+        (
+            "missing value template",
+            json!({ "name": "X-Api-Key" }),
+            "Pi legacy model config is invalid",
+        ),
+        (
+            "invalid name",
+            json!({
+                "name": "1-Api-Key",
+                "valueTemplate": "Bearer {{secret}}"
+            }),
+            "Pi model config credentialHeader",
+        ),
+        (
+            "oversized name",
+            json!({
+                "name": "A".repeat(129),
+                "valueTemplate": "Bearer {{secret}}"
+            }),
+            "Pi model config credentialHeader",
+        ),
+        (
+            "missing placeholder",
+            json!({ "name": "X-Api-Key", "valueTemplate": "Bearer token" }),
+            "Pi model config credentialHeader",
+        ),
+        (
+            "repeated placeholder",
+            json!({
+                "name": "X-Api-Key",
+                "valueTemplate": "{{secret}} {{secret}}"
+            }),
+            "Pi model config credentialHeader",
+        ),
+        (
+            "other template reference",
+            json!({
+                "name": "X-Api-Key",
+                "valueTemplate": "{{secret}} {{future}}"
+            }),
+            "Pi model config credentialHeader",
+        ),
+        (
+            "carriage return",
+            json!({
+                "name": "X-Api-Key",
+                "valueTemplate": "Bearer {{secret}}\rSuffix"
+            }),
+            "Pi model config credentialHeader",
+        ),
+        (
+            "line feed",
+            json!({
+                "name": "X-Api-Key",
+                "valueTemplate": "Bearer {{secret}}\nSuffix"
+            }),
+            "Pi model config credentialHeader",
+        ),
+        (
+            "oversized template",
+            json!({
+                "name": "X-Api-Key",
+                "valueTemplate": format!("{}{{{{secret}}}}", "😀".repeat(508))
+            }),
+            "Pi model config credentialHeader",
+        ),
+        (
+            "unknown nested field",
+            json!({
+                "name": "X-Api-Key",
+                "valueTemplate": "Bearer {{secret}}",
+                "futureField": true
+            }),
+            "Pi model config credentialHeader",
+        ),
+    ];
+
+    for (case, header, expected) in invalid_headers {
+        let mut context = pi_context_for_test();
+        context.pi_model_config.as_mut().unwrap()["credentialHeader"] = header;
+
+        let error = validate_context_for_test(&context).unwrap_err();
+
+        assert!(
+            error.contains(expected),
+            "{case} produced unexpected error: {error}"
+        );
+    }
+
+    let mut context = pi_context_for_test();
+    context.pi_model_config.as_mut().unwrap()["catalogModel"] = json!("");
+
+    let error = validate_context_for_test(&context).unwrap_err();
+
+    assert!(
+        error.contains("Pi model config catalogModel must not be empty"),
+        "empty catalogModel produced unexpected error: {error}"
+    );
+}
+
+#[test]
 fn pi_execution_context_accepts_and_preserves_both_v2_dialects() {
     for dialect in ["openai-responses", "openai-codex-responses"] {
         let mut context = pi_context_for_test();
@@ -1440,6 +1564,38 @@ fn pi_execution_context_accepts_and_preserves_both_v2_dialects() {
 #[test]
 fn pi_execution_context_rejects_invalid_or_future_v2_routes() {
     let invalid_configs = [
+        (
+            {
+                let mut config = pi_model_config_v2_for_test("openai-responses");
+                config["model"] = json!("");
+                config
+            },
+            "Pi model config model is invalid",
+        ),
+        (
+            {
+                let mut config = pi_model_config_v2_for_test("openai-responses");
+                config["model"] = json!("😀".repeat(257));
+                config
+            },
+            "Pi model config model is invalid",
+        ),
+        (
+            {
+                let mut config = pi_model_config_v2_for_test("openai-responses");
+                config["catalogModel"] = json!("");
+                config
+            },
+            "Pi model config catalogModel is invalid",
+        ),
+        (
+            {
+                let mut config = pi_model_config_v2_for_test("openai-responses");
+                config["catalogModel"] = json!("😀".repeat(257));
+                config
+            },
+            "Pi model config catalogModel is invalid",
+        ),
         (
             {
                 let mut config = pi_model_config_v2_for_test("openai-codex-responses");


### PR DESCRIPTION
## Summary

- centralize Pi model `baseUrl`, non-empty `model`, and present non-empty `catalogModel` validation across legacy and V2 Runner readers
- reject malformed legacy credential headers at the Runner pre-sandbox boundary with the same strict policy already used by V2
- preserve V2-only UTF-16 limits, generation-specific route and binding rules, additive legacy root fields, and the original forwarded JSON
- add entry-point coverage for valid forwarding, malformed legacy header categories, invalid and null `catalogModel` values, and V2 shared scalar constraints

## Exclusions

- no API-contract, generated binding, wire-format, writer, credential-materialization, provider, database, configuration, or rollout changes
- no strict-field enforcement at the legacy model-config root

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet` (3439 passed, 25 ignored; integration target 1 passed)
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --all-features --no-deps`
- `cargo check --manifest-path crates/Cargo.toml --release -p runner --no-default-features`
- `cargo check --manifest-path crates/Cargo.toml -p runner --all-features`
- `git diff --check`
- repository pre-commit and commit-message hooks

Closes #31569
