### PR TITLE
fix(guest-agent): preserve success when history upload fails

### DIFF
--- a/crates/guest-agent/src/checkpoint/session_history.rs
+++ b/crates/guest-agent/src/checkpoint/session_history.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use guest_common::telemetry::{
     SandboxOpDimensions, record_sandbox_op, record_sandbox_op_with_dimensions,
 };
-use guest_common::{log_info, log_warn};
+use guest_common::{log_error, log_info, log_warn};
 use guest_contracts::session_history_identity::SessionHistorySourceRef;
 use guest_session_prune::{
     ClaudeHistoryCandidate, ClaudeHistoryIneligibleReason, ClaudeHistorySelection,
@@ -431,17 +431,23 @@ where
         })
 }
 
+enum SessionHistoryUploadOutcome {
+    Uploaded,
+    Unavailable,
+}
+
 /// Prepare + upload one session history to S3 via a presigned URL. If
 /// the prepare endpoint reports `existing=true`, skip the upload
 /// (content-addressed dedup). Telemetry is recorded under
 /// `session_history_prepare` and `session_history_s3_upload` to match the
-/// pre-parallelization op names.
+/// pre-parallelization op names. A failed presigned upload is observable but
+/// leaves history unavailable so the remaining checkpoint can still persist.
 async fn upload_session_history(
     http: &HttpClient,
     run_id: &str,
     history_hash: &str,
     history_upload: SessionHistoryUpload,
-) -> Result<(), AgentError> {
+) -> Result<SessionHistoryUploadOutcome, AgentError> {
     let prep_start = std::time::Instant::now();
     let url = http.checkpoint_prepare_history_url()?;
     let requested_encoding = history_upload.requested_encoding();
@@ -515,7 +521,7 @@ async fn upload_session_history(
             LOG_TAG,
             "Session history already exists in S3 (deduplicated, encoding={accepted_encoding})"
         );
-        return Ok(());
+        return Ok(SessionHistoryUploadOutcome::Uploaded);
     }
 
     let presigned_url = prep_resp.presigned_url.ok_or_else(|| {
@@ -533,15 +539,18 @@ async fn upload_session_history(
         .put_presigned(&presigned_url, upload_bytes, "application/octet-stream")
         .await
     {
+        let error = e.to_string();
         record_sandbox_op(
             "session_history_s3_upload",
             upload_start.elapsed(),
             false,
-            None,
+            Some(&error),
         );
-        return Err(AgentError::Checkpoint(format!(
-            "session history upload failed: {e}"
-        )));
+        log_error!(
+            LOG_TAG,
+            "Session history upload failed; continuing checkpoint without history: {error}"
+        );
+        return Ok(SessionHistoryUploadOutcome::Unavailable);
     }
     record_sandbox_op(
         "session_history_s3_upload",
@@ -550,7 +559,7 @@ async fn upload_session_history(
         None,
     );
     log_info!(LOG_TAG, "Session history uploaded to S3");
-    Ok(())
+    Ok(SessionHistoryUploadOutcome::Uploaded)
 }
 
 fn prepare_session_history(
@@ -1043,8 +1052,16 @@ pub(super) async fn prepare_and_upload_session_history(
         };
     match prepared {
         PreparedCheckpointSessionHistory::Upload { checkpoint, upload } => {
-            upload_session_history(http, run_id, &checkpoint.history_hash, upload).await?;
-            Ok(CheckpointSessionHistory::Uploaded(*checkpoint))
+            match upload_session_history(http, run_id, &checkpoint.history_hash, upload).await? {
+                SessionHistoryUploadOutcome::Uploaded => {
+                    Ok(CheckpointSessionHistory::Uploaded(*checkpoint))
+                }
+                SessionHistoryUploadOutcome::Unavailable => {
+                    Ok(CheckpointSessionHistory::Unavailable {
+                        cli_agent_session_id,
+                    })
+                }
+            }
         }
         PreparedCheckpointSessionHistory::DiscardedOversized {
             cli_agent_session_id,

--- a/crates/guest-agent/tests/integration_cases/checkpoint/success.rs
+++ b/crates/guest-agent/tests/integration_cases/checkpoint/success.rs
@@ -269,13 +269,25 @@ async fn checkpoint_rejects_prepare_response_without_upload_url() {
 }
 
 #[tokio::test]
-async fn checkpoint_reports_session_history_upload_stage_and_final_status() {
+async fn checkpoint_reports_failed_session_history_upload_as_unavailable() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
     let mut runtime = runtime_from_process_env().unwrap();
     runtime.config.framework = guest_agent::env::Framework::Codex;
+    let _system_log_guard = SystemLogOverrideGuard::set(runtime.paths.system_log_file());
     let _files_guard = SessionCheckpointFilesGuard::new();
+    let artifact_dir = tempfile::tempdir().unwrap();
+    let missing_artifact_mount = artifact_dir.path().join("missing-memory");
+    runtime.config.artifacts = vec![guest_agent::env::ArtifactEnv {
+        name: "memory".to_string(),
+        mount_path: missing_artifact_mount.to_string_lossy().into_owned(),
+        storage_id: "memory-storage-id".to_string(),
+        version_id: "preserved-memory-version".to_string(),
+        missing_root_policy: Some(
+            api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy::PreserveParentVersion,
+        ),
+    }];
     let session_id = "aeaeaeae-aeae-4eae-8eae-aeaeaeaeaeae";
     let (history_dir, history_path, history) = write_prunable_codex_history(session_id).unwrap();
     std::fs::write(&history_path, &history).unwrap();
@@ -297,27 +309,57 @@ async fn checkpoint_reports_session_history_upload_stage_and_final_status() {
         when.method(PUT).path(upload_path);
         then.status(502);
     });
+    let artifact_snapshot = json!({
+        "checkpoint": {
+            "artifactSnapshots": [{
+                "name": "memory",
+                "version": "preserved-memory-version",
+                "mountPath": missing_artifact_mount,
+                "missingRootPolicy": "preserveParentVersion",
+            }],
+        },
+    })
+    .to_string();
     let complete_mock = server.mock(|when, then| {
-        when.method(POST).path("/api/webhooks/agent/complete");
+        when.method(POST)
+            .path("/api/webhooks/agent/complete")
+            .json_body_includes(r#"{"exitCode":0}"#)
+            .json_body_includes(
+                r#"{"checkpoint":{"cliAgentSessionHistoryDisposition":"unavailable"}}"#,
+            )
+            .json_body_includes(artifact_snapshot);
         then.status(200)
             .json_body(json!({"success": true, "status": "completed"}));
     });
 
-    let error = guest_agent::checkpoint::prepare_checkpoint_for_runtime(
-        &runtime,
-        &checkpoint_session_metadata(&runtime),
-    )
-    .await
-    .err()
-    .expect("failed history upload should fail checkpoint preparation");
+    create_bounded_checkpoint(&runtime).await.unwrap();
 
-    assert_eq!(
-        error.to_string(),
-        "checkpoint: session history upload failed: http: PUT presigned failed after 3 attempts; last failure: HTTP 502"
-    );
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(3).await;
-    complete_mock.assert_calls_async(0).await;
+    complete_mock.assert_calls_async(1).await;
+
+    let operations = std::fs::read_to_string(runtime.paths.sandbox_ops_file()).unwrap();
+    let upload_operation = operations
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+        .into_iter()
+        .find(|operation| operation["action_type"] == "session_history_s3_upload")
+        .expect("session history upload operation");
+    assert_eq!(upload_operation["success"], false);
+    assert_eq!(
+        upload_operation["error"],
+        "http: PUT presigned failed after 3 attempts; last failure: HTTP 502"
+    );
+
+    let system_log = std::fs::read_to_string(runtime.paths.system_log_file()).unwrap();
+    assert!(system_log.contains(
+        "[ERROR] [sandbox:guest-agent] Session history upload failed; continuing checkpoint \
+         without history: http: PUT presigned failed after 3 attempts; last failure: HTTP 502"
+    ));
+    assert!(!system_log.contains(upload_path));
+    assert!(!std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- keep a semantically successful run successful when its session-history presigned upload exhausts retries
- report the history disposition as `unavailable` while still committing artifact snapshots and the terminal checkpoint
- retain error-level local observability and failed sandbox-operation telemetry without exposing the presigned URL

## Behavior

Only a failure from the session-history object PUT is degraded. Prepare-response errors, malformed protocol responses, artifact/storage failures, and the final combined completion request remain fatal checkpoint failures.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p guest-agent --all-features --no-deps`
- `cargo test -p guest-agent`
- repository pre-commit hooks (workspace Rust formatting, documentation, Clippy, file-size check, commitlint)

Closes #31574
