### PR TITLE
feat(core): roll out connector accounts to all users

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -584,6 +584,9 @@ describe("POST /api/zero/chat-threads", () => {
 
   it("rejects connector selections while connector accounts are disabled", async () => {
     const fixture = await seedAgent();
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.ConnectorAccounts]: false,
+    });
     const connection = await connectorApi.connectManualGrant(
       fixture.actor,
       "openai",

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -208,7 +208,8 @@ describe("connector account lifecycle routes", () => {
   }
 
   it("hides canonical account resources while the feature is disabled", async () => {
-    await seedFixture();
+    const fixture = await seedFixture();
+    await setConnectorAccountsEnabled(fixture, false);
     const response = await accept(
       accountClient().summaries({ headers: authHeaders() }),
       [404],

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
@@ -410,6 +410,9 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
 
   it("accepts CLI add and reconnect while preserving account errors", async () => {
     const fixture = await seedFixture();
+    await updateFeatureSwitches(fixture, {
+      [FeatureSwitchKey.ConnectorAccounts]: false,
+    });
     const client = setupApp({ context, routes: connectorsRoutes })(
       connectorManualGrantContract,
     );
@@ -510,7 +513,10 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
   });
 
   it("serializes concurrent first-account adds", async () => {
-    await seedFixture();
+    const fixture = await seedFixture();
+    await updateFeatureSwitches(fixture, {
+      [FeatureSwitchKey.ConnectorAccounts]: false,
+    });
     const client = setupApp({ context, routes: connectorsRoutes })(
       connectorManualGrantContract,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -590,6 +590,9 @@ describe("CONN-02: OAuth start and callback", () => {
 
     const bdd = createBddApi(context);
     const actor = bdd.user();
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ConnectorAccounts]: false,
+    });
     const initialStart = await connectorsApi.startOauth(
       actor,
       "github",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
@@ -33,6 +33,10 @@ import {
 
 const context = testContext();
 
+function legacyConnectorFeatureSwitches() {
+  return { [FeatureSwitchKey.ConnectorAccounts]: false };
+}
+
 function createAuthWindow(): Window {
   const authWindow = context.mocks.browser.authWindow();
   Object.defineProperty(authWindow, "location", {
@@ -341,7 +345,11 @@ test("Keep a connector connected when an account must be chosen", async () => {
       });
     },
   );
-  await setupPage({ context, path: "/connectors" });
+  await setupPage({
+    context,
+    path: "/connectors",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
   const card = await waitFor(() => {
     return getConnectorCard("GitHub");
   });
@@ -735,7 +743,11 @@ test("Reconnect an expired connection", async () => {
       });
     },
   );
-  await setupPage({ context, path: "/connectors" });
+  await setupPage({
+    context,
+    path: "/connectors",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
   const card = await waitFor(() => {
     return getConnectorCard("Meta Ads");
   });
@@ -1050,7 +1062,11 @@ test("Review newly requested connector permissions", async () => {
       storedScopes,
     });
   });
-  await setupPage({ context, path: "/connectors" });
+  await setupPage({
+    context,
+    path: "/connectors",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
   const card = await waitFor(() => {
     return getConnectorCard("Google Ads");
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -35,6 +35,10 @@ import {
 
 const context = testContext();
 
+function legacyConnectorFeatureSwitches() {
+  return { [FeatureSwitchKey.ConnectorAccounts]: false };
+}
+
 function createAuthWindow(): Window {
   const authWindow = context.mocks.browser.authWindow();
   Object.defineProperty(authWindow, "location", {
@@ -339,7 +343,11 @@ test("Choose a credential-free method among multiple connection methods", async 
       return respond(200, connectedConnector("stripe", body.authMethod));
     },
   );
-  await setupPage({ context, path: "/connectors?keywords=public+stripe" });
+  await setupPage({
+    context,
+    path: "/connectors?keywords=public+stripe",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Connect Public Stripe");
@@ -391,7 +399,11 @@ test("Authorize eligible agents after a manual connection", async () => {
     },
   );
   mockAgentConnectorAccess("axiom");
-  await setupPage({ context, path: "/connectors?keywords=axiom" });
+  await setupPage({
+    context,
+    path: "/connectors?keywords=axiom",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Connect Public Axiom");
@@ -439,7 +451,11 @@ test("Connect through device authorization", async () => {
     }),
   ]);
   const browserOpen = context.mocks.browser.open(createAuthWindow());
-  await setupPage({ context, path: "/connectors" });
+  await setupPage({
+    context,
+    path: "/connectors",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Connect Base44");
@@ -492,7 +508,11 @@ test("Connect with a manual credential", async () => {
       return respond(200, connectedConnector("axiom", body.authMethod));
     },
   );
-  await setupPage({ context, path: "/connectors" });
+  await setupPage({
+    context,
+    path: "/connectors",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Connect Public Axiom");
@@ -538,7 +558,11 @@ test("Enable a connector that needs no credentials", async () => {
     },
   );
   mockAgentConnectorAccess("stripe");
-  await setupPage({ context, path: "/connectors" });
+  await setupPage({
+    context,
+    path: "/connectors",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
 
   click(
     await waitFor(() => {
@@ -651,7 +675,11 @@ test("Complete OAuth only after the selected connector changes", async () => {
   context.mocks.api(connectorsMainContract.list, ({ respond }) => {
     return respond(200, { connectors: listed, connectorProvidedBindings: [] });
   });
-  await setupPage({ context, path: "/connectors?keywords=public+stripe" });
+  await setupPage({
+    context,
+    path: "/connectors?keywords=public+stripe",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Connect Public Stripe");
@@ -1087,7 +1115,11 @@ test("Submit credentials only for the chosen manual method", async () => {
       return respond(200, connectedConnector("axiom", body.authMethod));
     },
   );
-  await setupPage({ context, path: "/connectors" });
+  await setupPage({
+    context,
+    path: "/connectors",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Connect Public Axiom");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -31,6 +31,10 @@ import {
 
 const context = testContext();
 
+function legacyConnectorFeatureSwitches() {
+  return { [FeatureSwitchKey.ConnectorAccounts]: false };
+}
+
 function oauthMethod() {
   return {
     id: "oauth",
@@ -503,7 +507,11 @@ test("Use the connectors experience in Portuguese", async () => {
   context.mocks.api(userPermissionGrantsContract.list, ({ respond }) => {
     return respond(200, []);
   });
-  await setupPage({ context, path: "/connectors" });
+  await setupPage({
+    context,
+    path: "/connectors",
+    featureSwitches: legacyConnectorFeatureSwitches(),
+  });
 
   await expect(
     screen.findByRole("heading", { name: "Conectores" }),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
@@ -572,7 +572,13 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
     listAgent(RESEARCH_ID, "Research"),
     listAgent(SUPPORT_ID, "Support"),
   ]);
-  await setupPage({ context, path: "/connectors" });
+  await setupPage({
+    context,
+    path: "/connectors",
+    featureSwitches: {
+      [FeatureSwitchKey.ConnectorAccounts]: false,
+    },
+  });
   click(
     await waitFor(() => {
       return getConnectorAction("tab", "Custom");

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -39,6 +39,7 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.GoogleFormsWorkflowAutomations, {}),
     ).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.ConnectorAccounts, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -194,7 +195,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.PersonalModelProviderAccounts]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.ConnectorAccounts]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.FollowUpOptimize]).toBe(true);
@@ -228,7 +228,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.PersonalModelProviderAccounts]).toBe(
       false,
     );
-    expect(otherOrgStates[FeatureSwitchKey.ConnectorAccounts]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.FollowUpOptimize]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -479,8 +479,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "liangyou@vm0.ai",
     description:
       "Enable multiple credential accounts per built-in or custom connector.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.FeishuIntegration]: {
     maintainer: "linghan@vm0.ai",


### PR DESCRIPTION
## Summary

- enable `ConnectorAccounts` for every user in the core feature-switch registry
- keep the feature-switch key, all existing gates, and database overrides intact
- explicitly pin legacy single-account compatibility tests to the disabled state while preserving default and explicit-enabled coverage for the rollout path

## Scope

This changes the default rollout audience from the staff organization to all users. It does not remove the switch, change connector account behavior, alter API or database contracts, or remove mixed-version compatibility paths. An explicit database override can still disable the switch for a user.

## Validation

- `pnpm exec prettier --write apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts apps/api/src/signals/routes/__tests__/connector-accounts.test.ts apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts apps/platform/src/views/okou-page/__tests__/connectors-page.test.tsx packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=4 --silent=passed-only` (31 tests)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads-create.test.ts src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts --maxWorkers=1 --silent=passed-only` (41 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-accounts.test.ts --maxWorkers=1 --silent=passed-only` (16 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connectors.bdd.test.ts --maxWorkers=1 --silent=passed-only` (91 tests)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/connectors-page.test.tsx --maxWorkers=1 --silent=passed-only` (133 tests)
- `pnpm knip`
- pre-commit hooks, including repository-wide Prettier, Knip, type checks (15 workspaces), file-size validation, and commitlint

Relates to #28571
Umbrella context: #22832
