### PR TITLE
refactor(api): remove rollout oauth state fallbacks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -458,6 +458,7 @@ function legacyFeishuAppOAuthState(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly publicBrand: PublicBrand;
+  readonly redirectUri: string;
 }): string {
   const encodedPayload = Buffer.from(
     JSON.stringify({
@@ -2522,6 +2523,7 @@ describe("Feishu integration", () => {
           orgId: requireValue(member.orgId, "Expected an organization"),
           userId: member.userId,
           publicBrand: "vm0",
+          redirectUri: `${FEISHU_CALLBACK_ORIGIN}/api/integrations/feishu/oauth/callback`,
         }),
       })}`,
     );
@@ -2766,68 +2768,6 @@ describe("Feishu integration", () => {
       expect(oauthTokenRedirectUris).toStrictEqual([appCallbackUrl]);
     },
   );
-
-  it("keeps a legacy Okou signed state on its original VM0 redirect URI", async () => {
-    mockEnv("APP_URL", "https://app.vm0.ai");
-    mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
-    mockEnv("OKOU_WEB_URL", "https://www.vm0.ai");
-    mockEnv("FEISHU_CALLBACK_BASE_URL", "https://api.vm0.ai");
-
-    const fixture = await setupFeishuRunFixture({ publicBrand: "okou" });
-    const legacyConnectUrl = new URL(
-      feishuOauthContract.connect.path,
-      "https://api.vm0.ai",
-    );
-    legacyConnectUrl.searchParams.set(
-      "state",
-      legacyFeishuAppOAuthState({
-        installationId: fixture.installationId,
-        orgId: requireValue(fixture.actor.orgId, "Expected an organization"),
-        userId: fixture.actor.userId,
-        publicBrand: "okou",
-      }),
-    );
-    legacyConnectUrl.searchParams.set("callbackTarget", "app");
-
-    const oauthApp = createAppWithRoutes({
-      signal: context.signal,
-      routes: feishuOauthRoutes,
-    });
-    const response = await oauthApp.request(legacyConnectUrl);
-    expect(response.status).toBe(307);
-    const authorizationUrl = new URL(response.headers.get("location") ?? "");
-    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
-      "https://app.vm0.ai/connectors/feishu/callback",
-    );
-    const connectorState = requireValue(
-      authorizationUrl.searchParams.get("state"),
-      "Expected persisted legacy Okou connector state",
-    );
-    expect(connectorState).toMatch(/^okou\.[0-9a-f]{64}$/u);
-
-    const handoffResponse = await oauthApp.request(
-      `${feishuOauthContract.callback.path}?${new URLSearchParams({
-        code: "legacy-okou-feishu-code",
-        state: connectorState,
-      })}`,
-    );
-    expect(handoffResponse.status).toBe(307);
-    const handoffUrl = new URL(handoffResponse.headers.get("location") ?? "");
-    expect(handoffUrl.origin).toBe("https://app.okou.ai");
-    expect(handoffUrl.pathname).toBe("/connectors/feishu/callback");
-
-    const completionUrl = await completeFeishuAuthorization(
-      authorizationUrl,
-      "ou_oauth_user",
-      { intent: "add" },
-    );
-    expect(completionUrl.toString()).toBe(
-      `https://applink.feishu.cn/client/bot/open?appId=${fixture.appId}`,
-    );
-    expect(oauthTokenRedirectUris).toStrictEqual([
-      "https://app.vm0.ai/connectors/feishu/callback",
-    ]);
-  });
 
   it("uses the persisted installation brand for Feishu message-link OAuth", async () => {
     mockEnv("APP_URL", "https://app.vm0.ai");

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-oauth-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-oauth-state.test.ts
@@ -13,6 +13,7 @@ const context = testContext();
 const NOW = Date.parse("2026-08-25T00:00:00.000Z");
 const NOW_SECONDS = Math.floor(NOW / 1000);
 const SECRET = "a".repeat(64);
+const REDIRECT_URI = "https://app.vm0.ai/connectors/feishu/callback";
 
 function oauthClient() {
   return setupApp({ context, routes: feishuOauthRoutes })(feishuOauthContract);
@@ -24,6 +25,7 @@ function statePayload(): Readonly<Record<string, unknown>> {
     orgId: `org_${randomUUID()}`,
     userId: `user_${randomUUID()}`,
     callbackTarget: "app",
+    redirectUri: REDIRECT_URI,
     timestamp: NOW_SECONDS,
   };
 }
@@ -81,6 +83,14 @@ describe("Feishu OAuth state", () => {
   ])("rejects an $kind public brand", async ({ payload }) => {
     await expectConnectError(
       signedState(payload),
+      "Invalid or expired connect state",
+    );
+  });
+
+  it("rejects an omitted redirect URI", async () => {
+    const { redirectUri: _redirectUri, ...payload } = statePayload();
+    await expectConnectError(
+      signedState({ ...payload, publicBrand: "vm0" }),
       "Invalid or expired connect state",
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -6025,32 +6025,6 @@ describe("INT-03: GitHub and AgentPhone integrations", () => {
     if (!isRecord(vm0State)) {
       throw new Error("Expected VM0 GitHub OAuth state to be an object");
     }
-    const legacyState = JSON.stringify(
-      Object.fromEntries(
-        Object.entries(vm0State).filter(([key]) => {
-          return ![
-            "publicBrand",
-            "publicBrandSig",
-            "callbackRedirectUri",
-            "callbackRedirectUriSig",
-          ].includes(key);
-        }),
-      ),
-    );
-    const legacyError = await integrations.requestGithubAppSetupCallback(
-      {
-        error: "access_denied",
-        error_description: "Provider denied access",
-        state: legacyState,
-      },
-      [307],
-      "vm0",
-      "https://www.vm0.ai",
-    );
-    expect(new URL(legacyError.headers.get("location") ?? "").origin).toBe(
-      "https://app.vm0.ai",
-    );
-
     const tamperedState = JSON.stringify({
       ...vm0State,
       publicBrand: "okou",

--- a/turbo/apps/api/src/signals/routes/feishu-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/feishu-oauth.ts
@@ -165,18 +165,6 @@ function legacyOAuthRedirectUri(target: "app" | undefined): string {
     : feishuOAuthCallbackUrl();
 }
 
-function isFeishuAppCallbackRedirectUri(
-  redirectUri: string,
-  publicBrand: PublicBrand,
-): boolean {
-  return (
-    redirectUri === feishuOAuthAppCallbackUrl(publicBrand) ||
-    // A pre-#31030 API persisted the VM0 URI for Okou connector state. Remove
-    // under #31061 after its old-API rollback gate and 15-minute TTL close.
-    redirectUri === legacyFeishuOAuthAppCallbackUrl()
-  );
-}
-
 function callbackRedirectResponse(
   url: string,
   responseMode: "json" | undefined,
@@ -686,10 +674,7 @@ const connect$ = command(async ({ get, set }, signal: AbortSignal) => {
       orgId: state.orgId,
       userId: state.userId,
       connectorId,
-      // A pre-#31030 API signed this state without redirectUri. Remove under
-      // #31061 after its old-API rollback gate and 15-minute TTL close.
-      redirectUri:
-        state.redirectUri ?? legacyOAuthRedirectUri(query.callbackTarget),
+      redirectUri: state.redirectUri,
       publicBrand: state.publicBrand,
       account,
       feishuContext: {
@@ -981,10 +966,8 @@ const completeCustomFeishuOAuth$ = command(
       return jsonErrorResponse("Invalid or expired connect state");
     }
     if (
-      isFeishuAppCallbackRedirectUri(
-        preview.state.redirectUri,
-        preview.state.publicBrand,
-      ) &&
+      preview.state.redirectUri ===
+        feishuOAuthAppCallbackUrl(preview.state.publicBrand) &&
       query.responseMode !== "json"
     ) {
       return redirectResponse(appCallbackUrl(query, preview.state.publicBrand));

--- a/turbo/apps/api/src/signals/services/feishu-config.ts
+++ b/turbo/apps/api/src/signals/services/feishu-config.ts
@@ -114,13 +114,8 @@ export function feishuOAuthAppCallbackUrl(publicBrand: PublicBrand): string {
 }
 
 /**
- * Redirect URI emitted before Feishu OAuth became brand-aware. Keep this only
- * for the old-API-to-new-API rollout surface: in-flight signed state and
- * persisted connector state created by a pre-#31030 API must replay the
- * byte-for-byte URI that the provider received. Remove the compatibility
- * readers tracked by #31061 after that API is no longer serving or retained as
- * a rollback target and the longest state TTL (15 minutes) has elapsed. Keep
- * the current VM0 callback URI and its historical routes.
+ * Historical VM0 app callback URI used by the legacy signed-state completion
+ * path. Keep this URI and its historical routes while VM0 remains supported.
  */
 export function legacyFeishuOAuthAppCallbackUrl(): string {
   return new URL("/connectors/feishu/callback", env("APP_URL")).toString();

--- a/turbo/apps/api/src/signals/services/feishu-oauth-state.ts
+++ b/turbo/apps/api/src/signals/services/feishu-oauth-state.ts
@@ -22,7 +22,7 @@ const feishuOAuthStateSchema = z.object({
   userId: z.string().min(1),
   callbackTarget: z.literal("app").optional(),
   oauthRedirectTarget: z.literal("app").optional(),
-  redirectUri: z.url().optional(),
+  redirectUri: z.url(),
   publicBrand: publicBrandSchema,
   timestamp: z.number().int(),
 });
@@ -41,7 +41,7 @@ function createFeishuOAuthState(args: {
   readonly userId: string;
   readonly callbackTarget?: "app";
   readonly oauthRedirectTarget?: "app";
-  readonly redirectUri?: string;
+  readonly redirectUri: string;
   readonly publicBrand: PublicBrand;
   readonly timestamp?: number;
 }): string {

--- a/turbo/apps/api/src/signals/services/github-oauth.service.ts
+++ b/turbo/apps/api/src/signals/services/github-oauth.service.ts
@@ -86,8 +86,8 @@ type ParsedGithubOauthRequestedScopesState =
 type ParsedGithubOauthCallbackRedirectUriState =
   | {
       readonly ok: true;
-      readonly redirectUri: string | null;
-      readonly signature: string | null;
+      readonly redirectUri: string;
+      readonly signature: string;
     }
   | { readonly ok: false };
 
@@ -536,12 +536,6 @@ function parseGithubOauthCallbackRedirectUriState(args: {
   readonly redirectUri: unknown;
   readonly signature: unknown;
 }): ParsedGithubOauthCallbackRedirectUriState {
-  if (args.redirectUri === undefined && args.signature === undefined) {
-    // An old API can emit this state immediately before #31109 deploys, then
-    // its browser-held callback can reach the new API. Remove under #31123
-    // after the old API leaves rollback and the two-day client window closes.
-    return { ok: true, redirectUri: null, signature: null };
-  }
   if (
     typeof args.redirectUri !== "string" ||
     typeof args.signature !== "string"


### PR DESCRIPTION
## Summary

- require every current Feishu signed OAuth state to carry the exact persisted `redirectUri`, removing the pre-#31030 fallback
- accept only the app callback URI for the stored Feishu state's current `publicBrand`, while preserving the historical VM0 callback URI and routes
- require both signed callback-redirect fields on every present GitHub App installation state, while preserving the state-less `setup_action=update` flow

## Rollout decision

Both cleanup targets have a `fully-rolled-out` terminal state.

- #31061: the requester confirmed that every currently retained rollback version includes #31030, so its old state TTL has drained and cleanup is eligible now.
- #31123: the previously calculated conservative two-day client/in-flight-flow boundary was approximately **2026-09-05 19:07 CST (11:07 UTC)**.
- On **2026-09-04**, the requester explicitly directed this PR to proceed before the remainder of that conservative wait. This accepts the risk that an older in-flight pre-#31109 GitHub App installation state may be rejected. The PR still uses the normal protected merge queue; no direct or admin merge is permitted.

## Commit archaeology

- Feishu fallback introduction: `f6ce8bd0d6f8f4ab312a2340b716a035774d02ea` (#31030). Its parent used callback-target-derived VM0 redirect URIs; #31030 added exact brand-projected redirect persistence plus two temporary old-state readers. This change keeps the exact persisted path and removes only those readers.
- GitHub fallback introduction: `bf8cdec0c8016295208fae60bb63dd846c6f4f9d` (#31109). Its parent had no signed callback target; #31109 added signed exact-query replay and temporarily allowed a present pre-change state with both callback fields absent. This change keeps signed replay and rejects that expired shape.
- Later commits touching the surrounding files do not own or alter either fallback; the relevant lines still blame to the introduction commits.

## Kept and removed behavior

Kept:

- VM0 and Okou Feishu flows persist and replay their exact app callback URI.
- Feishu's historical VM0 callback URI, neutral API callback, and historical routes remain available.
- GitHub signed exact-query replay, VM0/Okou brand routing, historical callback routes, built-in connector callbacks, and state-less installation updates remain intact.
- `githubInstallations.setupPublicBrand` remains unchanged; it is the separate long-lived compatibility boundary documented in #31109/#27750.

Removed:

- Feishu signed states without `redirectUri`.
- the extra legacy-VM0 callback match for an Okou Feishu connector state.
- present GitHub installation states without both `callbackRedirectUri` and `callbackRedirectUriSig`.
- the Feishu and GitHub test cases that existed only for those temporary pre-change shapes.

The retained legacy Feishu signed-state route test now uses the current required `redirectUri` contract.

## Search and Knip

- second-pass search covered `#31061`, `#31123`, `pre-#31030`, `pre-#31109`, the removed fallback comments, `state.redirectUri ??`, and the deleted test names; no temporary fallback markers remain
- intentional remaining `legacyFeishuOAuthAppCallbackUrl`/`legacyOAuthRedirectUri` references serve the preserved historical VM0 signed-state completion path
- intentional nullable GitHub callback fields serve only the preserved no-state update flow
- `pnpm knip --workspace api --no-progress`: clean before and after the change

## Verification

- changed-file Prettier
- changed-file Oxlint
- changed-file type-aware Oxlint
- changed-file ESLint with zero warnings
- `pnpm --filter api run check-types`
- `git diff --check`
- targeted Feishu Vitest selection was attempted, but the suite could not initialize because this environment has no PostgreSQL listener (`ECONNREFUSED` on `localhost:5432`; all 41 file tests skipped). The PR pipeline remains authoritative for the affected DB-backed route tests.

Closes #31061
Closes #31123
