### PR TITLE
ci: retain clerk test resources for two hours

### DIFF
--- a/.github/scripts/tests/clerk-test-resource-workflow-test.sh
+++ b/.github/scripts/tests/clerk-test-resource-workflow-test.sh
@@ -388,10 +388,10 @@ end
 stale_step = stale_steps.fetch(0)
 expected_roles = "browser,playwright,paid-onboarding,runner,runner-real-codex,runner-real-claude,runner-mock-claude"
 unless stale_step.fetch("run").include?(
-    "cleanup-stale #{expected_roles} --ci-older-than-hours 0.5 --staging-browser-older-than-hours 8",
+    "cleanup-stale #{expected_roles} --ci-older-than-hours 2 --staging-browser-older-than-hours 8",
   ) && stale_step.dig("env", "CLERK_SECRET_KEY") == "${{ secrets.CLERK_SECRET_KEY }}" &&
     stale_step.dig("env", "DRY_RUN") == "${{ env.DRY_RUN }}"
-  raise "stale Clerk cleanup must use every marked role, a 30-minute CI cutoff, and an 8-hour staging browser cutoff"
+  raise "stale Clerk cleanup must use every marked role, a 2-hour CI cutoff, and an 8-hour staging browser cutoff"
 end
 
 cleanup_sources = [

--- a/.github/workflows/cleanup-clerk-test-resources.yml
+++ b/.github/workflows/cleanup-clerk-test-resources.yml
@@ -39,7 +39,7 @@ jobs:
           cd e2e && pnpm exec tsx playwright/clerk-test-resources.ts
           cleanup-stale
           browser,playwright,paid-onboarding,runner,runner-real-codex,runner-real-claude,runner-mock-claude
-          --ci-older-than-hours 0.5
+          --ci-older-than-hours 2
           --staging-browser-older-than-hours 8
         env:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}


### PR DESCRIPTION
## Summary

- retain marked Clerk CI test users and organizations for two hours before stale cleanup
- update the workflow contract test to enforce the two-hour cutoff

## Exclusions

- keep the staging browser cleanup cutoff at eight hours
- keep generation, workflow-run, and closed-PR cleanup behavior unchanged

## Validation

- `pnpm exec prettier --check ../.github/workflows/cleanup-clerk-test-resources.yml`
- `bash -n .github/scripts/tests/clerk-test-resource-workflow-test.sh`
- `git diff --check`

The full workflow contract script was not run locally because Ruby is unavailable in the development container; CI runs it on an Ubuntu runner with Ruby.
