### PR TITLE
docs: present the product as okou across the repository

### DIFF
--- a/.claude/skills/feature-switch/SKILL.md
+++ b/.claude/skills/feature-switch/SKILL.md
@@ -45,7 +45,7 @@ Add an entry to the `FEATURE_SWITCHES` record:
 
 ```typescript
 [FeatureSwitchKey.MyFeature]: {
-  maintainer: "you@vm0.ai",
+  maintainer: "you@okou.ai",
   enabled: false,
   enabledOrgIdHashes: STAFF_ORG_ID_HASHES, // optional: staff-only access
 },

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,19 +1,19 @@
-# VM0 Code of Conduct
+# Okou Code of Conduct
 
-Like the technical community as a whole, the VM0 team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
+Like the technical community as a whole, the Okou team and community is made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
 
 Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to. This code applies equally to founders, mentors and those seeking help and guidance.
 
 This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
 
-This code of conduct applies to all spaces managed by the VM0 project or vm0-ai. This includes IRC, the mailing lists, the issue tracker, DSF events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+This code of conduct applies to all spaces managed by the Okou project or vm0-ai. This includes IRC, the mailing lists, the issue tracker, DSF events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing [contact@vm0.ai](mailto:contact@vm0.ai).
+If you believe someone is violating the code of conduct, we ask that you report it by emailing [contact@okou.ai](mailto:contact@okou.ai).
 
 - **Be friendly and patient.**
 - **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 - **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
-- **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the VM0 community should be respectful when dealing with other members as well as with people outside the VM0 community.
+- **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the Okou community should be respectful when dealing with other members as well as with people outside the Okou community.
 - **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to: 
  - Violent threats or language directed against another person.
  - Discriminatory jokes and language.
@@ -23,10 +23,10 @@ If you believe someone is violating the code of conduct, we ask that you report 
  - Unwelcome sexual attention.
  - Advocating for, or encouraging, any of the above behavior.
  - Repeated harassment of others. In general, if someone asks you to stop, then stop.
-- **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and VM0 is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of VM0 comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+- **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and Okou is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of Okou comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
 
 Original text courtesy of the [Speak Up! project](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html).
 
 ## Questions?
 
-If you have questions, please see . If that doesn't answer your questions, feel free to [contact us](mailto:contact@vm0.ai).
+If you have questions, please see . If that doesn't answer your questions, feel free to [contact us](mailto:contact@okou.ai).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,7 +100,7 @@ _Avoid_: Run finish, goal iteration finish
 
 # Billing Context
 
-The billing context decides whether a purchase can be reviewed and confirmed inside vm0 or must continue on a Stripe-hosted page.
+The billing context decides whether a purchase can be reviewed and confirmed inside Okou or must continue on a Stripe-hosted page.
 
 ## Language
 
@@ -118,20 +118,20 @@ _Avoid_: Checkout
 
 # Banking Context
 
-This context separates a user's provider-hosted bank connection consent from the narrower access delegated to a vm0 agent.
+This context separates a user's provider-hosted bank connection consent from the narrower access delegated to an Okou agent.
 
 ## Language
 
 **Mastercard Data Connect session**:
 The Mastercard-hosted flow where a user links a financial institution and consents to Mastercard Open Finance accessing selected bank data.
-_Avoid_: vm0 bank login, banking agent grant
+_Avoid_: Okou bank login, banking agent grant
 
 **Banking connection**:
-A reusable link between a vm0 user and bank accounts discovered through Mastercard Open Finance. It exists independently of any agent's access.
+A reusable link between an Okou user and bank accounts discovered through Mastercard Open Finance. It exists independently of any agent's access.
 _Avoid_: Banking agent grant, Data Connect session
 
 **Banking agent grant**:
-A vm0 authorization that lets one agent read selected connected accounts under explicit operations, duration, and automation rules.
+An Okou authorization that lets one agent read selected connected accounts under explicit operations, duration, and automation rules.
 _Avoid_: Bank consent, Mastercard connection
 
 **Banking access request**:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 <h2 align="center">
-  <a href="https://vm0.ai"><img src="https://static.vm0.io/web/assets/Logo_VM0_combo_black_bg.svg" alt="VM0 Logo" width="500"></a>
+  <a href="https://www.okou.ai">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://static.okou.io/web/assets/okou/brand/2026-09-04-f27a4cc3/logo-light.svg">
+      <img src="https://static.okou.io/web/assets/okou/brand/2026-09-04-f27a4cc3/logo-dark.svg" alt="Okou" width="420">
+    </picture>
+  </a>
   <br><br>
-  Zero, your trustworthy AI teammate for real work.
+  More done. Same team.
   <br><br>
   <p>
     <a href="https://deepwiki.com/vm0-ai/vm0"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
@@ -16,12 +21,15 @@
 </p>
 
 <p align="center">
-  <b>Zero connects to 100+ tools and does the work — reports, triage, outreach, research. In Slack or on the web.</b>
+  <b>Give it a job, not a prompt.</b><br>
+  Okou connects to the tools your team already uses and does the work — across marketing, sales, engineering, and operations, under your control.
 </p>
 
 <p align="center">
-  <a href="https://vm0.ai/en/use-cases"><b>Use cases</b></a> ·
-  <a href="https://vm0.ai/en/blog"><b>Blog</b></a> ·
+  <a href="https://app.okou.ai/sign-up"><b>Get started free</b></a> ·
+  <a href="https://www.okou.ai/api/slack/oauth/install?publicBrand=okou"><b>Add to Slack</b></a> ·
+  <a href="https://www.okou.ai/en/workflow-automation-examples"><b>Use cases</b></a> ·
+  <a href="https://www.okou.ai/en/blog"><b>Blog</b></a> ·
   <a href="https://discord.gg/WMpAmHFfp6"><b>Discord</b></a>
 </p>
 
@@ -29,64 +37,84 @@
 
 ---
 
-## What Zero owns for your team
+## Hire it into a role, not a task
 
-Zero isn't another chatbot or rigid automation. It's a teammate you @mention in Slack and hand real roles to.
+You @mention Okou the way you would ask a colleague — without spelling out the steps.
 
-### 🪄 For Founders & CEOs — the overflow only a founder carries
-- **Daily business brief** — Calendar, Linear, Slack, and X pulled into one morning digest, delivered before standup.
-- **Investor & board updates** — Monthly email drafted from live metrics and this month's shipping. You edit tone, not numbers.
-- **Inbox triage** — Ranks your mail, drafts replies in your voice, surfaces what only you can answer.
-- **Decision log** — Every "we decided X" buried in Slack becomes a searchable Notion record.
+> **Maya** 9:24 AM
+> @Okou build the Litoral one-pager — hero, the story, three room tiles. Brand kit is in Drive.
+>
+> **Okou** 9:24 AM
+> Read the brand brief. Publishing as soon as it reads right.
+> → *Litoral Coastal Hotel Site — published*
+>
+> **Dan** 9:31 AM
+> Reads well. Can you send the launch note to the list?
+>
+> **Okou** 9:31 AM
+> Drafted in Gmail — unsent, yours to send.
 
-### 📣 For Sales & Marketing — an SDR that researches, writes, and sends
-- **KOL & prospect research** — Crawls X and the open web into a Notion tracker with bios, follower counts, engagement signals.
-- **Personalized outreach** — Cold emails written from each prospect's own content. Reads like a thoughtful human, not a batch send.
-- **Lead follow-ups** — Scores Gmail leads, drafts tailored follow-ups. Reps only touch hot conversations.
-- **Marketing pulse** — Campaign results, content engagement, and site analytics rolled up to Slack every Monday.
-
-### ⚙️ For Engineering — a dev teammate that covers your backlog
-- **Sentry error triage** — Failures ranked by impact, stack traces expanded, root-cause read, not a log dump.
-- **Tech debt scanner** — Weekly repo scan surfaces risky files as Linear tickets with reproduction steps.
-- **Bug filing from Slack** — Bug reports in threads turn into scoped Linear/GitHub issues with owners.
-- **Release notes & standups** — Linear activity and merged PRs become changelog-ready notes.
-
-### 🛟 For Operations & Support — the ops hire you can bring on day one
-- **Weekly status report** — A week of calendar, email, and Linear stitched into a share-ready summary.
-- **Employee onboarding** — Day-one checklist: accounts, docs, Slack channels, calendar invites. Hands-free.
-- **Meeting digests** — Standups and all-hands become tracked action items with owners.
-- **Cross-team reminders** — Pending approvals, missing inputs, report deadlines chased on schedule.
-
-👉 **[Explore 30+ ready-to-use recipes →](https://vm0.ai/en/use-cases)**
+It works out the angle, picks its own tools, and does the job in the open where the team can see it.
 
 ---
 
-## Why Zero is different
+## Every workflow your team builds is an asset it keeps
+
+One person works out how a job should get done. That becomes something the whole team can run.
 
 | | |
 |---|---|
-| 🧠 **Remembers your context** | Past decisions, project context, preferences carry across sessions. No re-explaining. |
-| ⏰ **Scheduled intelligence** | Runs recurring tasks — daily error scans, morning briefs, tech debt reports — without being prompted. |
-| 🤝 **Specialized sub-agents** | Create agents for specific jobs — research, triage, outreach — and let them work in parallel. |
-| 🔧 **Tool orchestration** | Picks and chains the right tools from 100+ integrations. You describe the goal; Zero figures out the steps. |
-| 🆔 **Knows who you are** | "My PRs," "assign to me." Zero resolves your identity across GitHub, Slack, and Linear automatically. |
+| **1. Run** | Someone asks for a piece of work the way they would ask a colleague. Okou figures out the steps. |
+| **2. Save** | When it sees the job repeat, Okou offers to keep the run — the instructions it followed and the tools it reached for, saved together. |
+| **3. Hand over** | The workflow belongs to the workspace, not to one person. A teammate runs it from chat or Slack without rebuilding any setup. |
+| **4. Automate** | Put it on a schedule or a trigger, and the work starts arriving before anyone asks. |
+
+Each teammate runs it **with their own permissions** — a shared workflow never borrows someone else's access.
 
 ---
 
-## Works with 100+ tools you already use
+## A chat per task, all running at once
 
-Slack · GitHub · Gmail · Google Calendar · Google Sheets · Notion · Linear · Sentry · Axiom · HubSpot · Intercom · Figma · Vercel · Dropbox · DocuSign · Deel · Airtable · Ahrefs · Plausible · Resend · X · Reddit · v0 · Anthropic Managed Agents · …and [100+ more](https://github.com/vm0-ai/vm0-skills).
+Ask for five things and you get five chats, each doing its own work. Nothing waits in line, and nobody sits watching a queue.
+
+> **Theo:** Get everything ready for Thursday's launch.
+>
+> *Four chats opened · all running* — landing page published · 412 CRM records updated · newsletter drafted, not sent · eight-slide deck built from the numbers.
 
 ---
 
-## Your data stays yours
+## It drafts. You send.
 
-- **Granular permissions** — Set read/write permissions per tool, per agent. Zero only touches what you explicitly allow.
-- **Isolated execution** — Every task runs in its own Firecracker microVM. Credentials never leave the sandbox.
-- **Fully auditable** — Logs, metrics, and network visibility for every run.
-- **Open source** — This repo. Inspect, fork, or self-host.
+Anything that leaves your company or spends your money stops for a human.
 
-Read our [Security overview](https://vm0.ai/en/security).
+- **Drafts, not sends** — email lands in Gmail unsent; an ad budget shift waits in Meta for approval.
+- **Granular permissions** — read/write per tool, per agent. Okou only touches what you explicitly allow.
+- **Isolated execution** — every task runs in its own Firecracker microVM. Credentials never leave the sandbox.
+- **Fully auditable** — logs, metrics, and network visibility for every run.
+- **Open source** — this repository. Inspect, fork, or self-host.
+
+Read our [Security overview](https://www.okou.ai/en/security).
+
+---
+
+## What teams hand to it
+
+| | |
+|---|---|
+| 🪄 **Founders** | Morning brief across calendar, Linear, Slack and X. Investor updates drafted from live metrics. Inbox triaged down to what only you can answer. |
+| 📣 **Sales & Marketing** | Prospect and creator research into a tracker. Outreach written from each prospect's own content. Leads scored, follow-ups drafted, campaign results in Slack on Monday. |
+| ⚙️ **Engineering** | Sentry noise grouped by root cause and filed as issues. Weekly tech-debt scan. Slack bug reports turned into scoped tickets. Release notes from merged PRs. |
+| 🛟 **Operations & Support** | Weekly status reports. Day-one onboarding checklists. Meeting digests with owners. Approvals and deadlines chased on schedule. |
+
+👉 **[Explore 30+ ready-to-use recipes →](https://www.okou.ai/en/workflow-automation-examples)**
+
+---
+
+## Works with the tools you already use
+
+Slack · GitHub · Gmail · Google Calendar · Google Sheets · Notion · Linear · Sentry · Axiom · HubSpot · Intercom · Figma · Vercel · Dropbox · DocuSign · Deel · Airtable · Ahrefs · Meta Ads · X · Reddit · …and [3,000+ more connectors](https://github.com/vm0-ai/vm0-skills).
+
+Model providers are yours to pick — Anthropic, OpenAI, DeepSeek, Google and others, selected per run or per agent.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   <br><br>
   <p>
     <a href="https://deepwiki.com/vm0-ai/vm0"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
-    <a href="https://vm0.productlane.com"><img src="https://img.shields.io/badge/Productlane-Roadmap-blue" /></a>
     <a href="https://github.com/vm0-ai/vm0/actions/workflows/turbo.yml?query=event%3Apush+branch%3Amain"><img src="https://github.com/vm0-ai/vm0/actions/workflows/turbo.yml/badge.svg?event=push" alt="CI" /></a>
     <a href="https://codecov.io/gh/vm0-ai/vm0"><img src="https://codecov.io/gh/vm0-ai/vm0/branch/main/graph/badge.svg?token=UZSMUBBOUC"/></a>
   </p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ We only provide security updates for the latest release. We recommend always run
 
 If you discover a security vulnerability, please report it responsibly by emailing us at:
 
-**[contact@vm0.ai](mailto:contact@vm0.ai)**
+**[contact@okou.ai](mailto:contact@okou.ai)**
 
 ### What to Include
 
@@ -66,7 +66,7 @@ To qualify for safe harbor, you must:
 
 ### In Scope
 
-- The VM0 platform and its public-facing services
+- The Okou platform and its public-facing services
 - Code in this repository and related official repositories
 - Authentication, authorization, and access control mechanisms
 - Data handling and storage
@@ -74,14 +74,14 @@ To qualify for safe harbor, you must:
 ### Out of Scope
 
 - Third-party services and dependencies (report these to the respective maintainers)
-- Social engineering attacks against VM0 team members or users
+- Social engineering attacks against Okou team members or users
 - Physical attacks
 - Denial-of-service attacks
 - Issues already reported or known publicly
 
 ## Recognition
 
-We appreciate the security research community's efforts in helping keep VM0 and our users safe. With your permission, we will acknowledge your contribution in our security advisories.
+We appreciate the security research community's efforts in helping keep Okou and our users safe. With your permission, we will acknowledge your contribution in our security advisories.
 
 While we do not currently operate a formal bug bounty program, we evaluate significant, responsibly disclosed vulnerabilities on a case-by-case basis for recognition or rewards.
 

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -165,8 +165,8 @@ Use **sandbox** for provider-neutral runner lifecycle, ownership, status,
 network-policy, and operator concepts. Use **VM** only for concrete
 Firecracker/KVM implementation details such as the Firecracker `/vm` API, VM
 pause and resume, snapshots, vCPUs, VMGenID, KVM, and Firecracker processes.
-The VM0 brand, established environment-variable namespace, and fixed paths are
-not lifecycle terminology and remain unchanged.
+Product brand names, the established environment-variable namespace, and fixed
+paths are not lifecycle terminology and remain unchanged.
 
 Each runner version's `status.json` is a host-local persisted cross-version
 boundary. Current runner maintenance commands can inspect status files written

--- a/docs/react-commit.md
+++ b/docs/react-commit.md
@@ -1,7 +1,7 @@
 # React Commit Analysis
 
 This guide describes how to measure excessive React work, identify the state
-subscription that caused it, and reduce unnecessary work in the VM0 platform.
+subscription that caused it, and reduce unnecessary work in the Okou platform.
 The examples use `ccstate-react`, but the measurement method applies to any
 React external store.
 

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -12,7 +12,7 @@ metadata, native helper builds, and release verification all use the same
 minimum for Apple silicon artifacts. Intel Macs are not supported.
 
 When the user is signed in and the feature switch is enabled, the main process
-registers a Desktop Computer Use host through the Zero API command queue. It
+registers a Desktop Computer Use host through the platform API command queue. It
 uses the Electron session for auth, polls queued commands, executes them with a
 native macOS `computer-use-helper`, and completes commands back to the API.
 Electron only owns the app shell and command bridge; the helper owns macOS


### PR DESCRIPTION
Closes #31603. Part of #26701.

The repository front page still introduced the product as "Zero, your trustworthy AI teammate for real work" under a VM0 logo. This makes the documentation say Okou.

Depends on vm0-ai/static-files#187, **already merged**. The brand assets are live on `static.okou.io`; this PR only references them.

## `README.md` — the owner's approved rewrite

Implemented verbatim from the "Approved `README.md`" block in the issue, which the owner wrote after reviewing `www.okou.ai` against this file. I did not re-author the copy. The only edit applied to that block was substituting the two `{{STATIC}}` placeholders with the real published prefix.

The rewrite adds three things the site leads with and the old README never mentioned:

The connector count in "Works with the tools you already use" is **3,000+ connectors**, per the owner. (An earlier draft of the issue said to leave it as "many more" because the site's "1,000+ connectors" and the old README's "100+ tools" used different units; that has since been settled.)

- **Workflows become a team asset** — Run / Save / Hand over / Automate, with each teammate running a shared workflow under *their own* permissions.
- **A chat per task, all running at once** — five asks means five chats, not a queue.
- **Draft-not-send** — anything that leaves the company or spends money stops for a human.

The persona list survives but is compressed into a table and moved below those sections; as a four-block bullet list at the top it read like a feature inventory.

### Logo

```html
<source media="(prefers-color-scheme: dark)" srcset=".../logo-light.svg">
<img src=".../logo-dark.svg" alt="Okou" width="420">
```

The filenames describe the **ink, not the background**, which is the easy way to get this backwards. `logo-dark` is dark ink (`#252121`) for light backgrounds; `logo-light` is white ink (`#FFF`) and is invisible on white. A swapped pairing still returns HTTP 200 — it just renders an invisible logo in one theme, which no status check would catch.

I verified the mapping three independent ways rather than trusting the names: the SVG `fill` values, decoding both PNGs (`logo-dark` renders the wordmark, `logo-light` renders blank), and rendering the actual `<picture>` pairing against GitHub's real theme backgrounds (`#ffffff` and `#0d1117`) with the images fetched live from the published URLs. Both themes render the wordmark legibly.

### Links

Every target checked live, following redirects, and confirmed to land on Okou-branded content:

| Link | Status | Lands on |
| --- | --- | --- |
| `www.okou.ai` | 200 | *More done. Same team. \| Okou* |
| `www.okou.ai/en/workflow-automation-examples` | 200 | *Workflow Automation Examples… \| Okou* |
| `www.okou.ai/en/blog` | 200 | *AI Agent Insights, Workflows & Automation \| Okou* |
| `www.okou.ai/en/security` | 200 | *Security — isolated execution… \| Okou* |
| `app.okou.ai/sign-up` | 200 | *AI Agents for Real Work \| Okou* |
| `www.okou.ai/api/slack/oauth/install?publicBrand=okou` | 200 | Slack OAuth, `redirect_uri` on `api.okou.ai` |

`/en/use-cases` 301s to `/en/workflow-automation-examples` on both hosts, so the destination is linked directly rather than the redirect.

All 9 URLs introduced on added lines resolve 2xx. Pre-existing links on untouched lines were left as they are.

## Other files

- **`SECURITY.md`** — `contact@vm0.ai` → `contact@okou.ai` (owner-confirmed live), plus "the Okou platform", "Okou team members", "keep Okou and our users safe".
- **`CODE_OF_CONDUCT.md`** — title, the team/community and project-spaces sentences, and both reporting addresses.
- **`CONTEXT.md`** — five product references in the billing and banking glossaries.
- **`docs/react-commit.md`** — "the VM0 platform" → "the Okou platform".
- **`docs/deployment-compatibility.md`** — see the judgement note below.
- **`turbo/apps/desktop/README.md`** — one line only: the app registers its host "through the **platform** API command queue", previously "the Zero API command queue". Everything else in that file is retired-bridge history, build identifiers, or real hostnames, and is untouched.
- **`.claude/skills/feature-switch/SKILL.md`** — the example `maintainer: "you@vm0.ai"`.

## The Productlane badge is removed, not repointed

The owner confirmed the board is no longer in use, so the badge is gone rather than pointed somewhere else. One line was deleted from the README header:

```html
<a href="https://vm0.productlane.com"><img src="https://img.shields.io/badge/Productlane-Roadmap-blue" /></a>
```

**That was the only Productlane link in any documentation.** I grepped the whole repository: `SECURITY.md`, `CONTRIBUTING.md` and every other markdown file are clean. The badge row now holds three badges — DeepWiki, CI, codecov — all still at the same four-space indent, so the header stays aligned.

Two non-documentation matches are deliberately kept, because they are the Productlane **connector** we offer to users, not our own roadmap board:

| File | Why it stays |
| --- | --- |
| `turbo/apps/api/src/scripts/dev-seed-skill-volumes.json` | Seed data for the Productlane connector skill |
| `turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx` | Connector display name in the onboarding diagram |

(For the record, had repointing been on the table: `okou.productlane.com` resolves to *"Productlane | Customer Support for modern companies"*, Productlane's own generic marketing page — not ours.)

## Deliberately unchanged

- **`github.com/vm0-ai/vm0` paths.** `git grep -o 'vm0-ai/vm0' | wc -l` is **46054 before and after**. Renaming the repository is a separate decision.
- **Every `CHANGELOG.md`.** None appears in the diff — release history records what shipped under the name it had.
- **Historical statements.** `docs/okou-protocol-migration.md` is untouched. No `ZERO_TOKEN` or `/api/zero/**` reference is added or removed. The retired-bridge sections of the desktop README, the frozen Zero manifest notes, the `OKOU_DESKTOP_PRODUCT=zero` build path, and the `app.vm0.ai` / `api.vm0.ai` / `www.vm0.ai` hostnames all still describe reality and would become wrong if rewritten.

## Three judgement calls worth a reviewer's eye

**1. The issue's internal-doc counts were mostly false positives.** It listed `REVIEW.md` (37 occurrences), `turbo/packages/db/MIGRATIONS.md` (17) and five `.claude/skills/**` files as needing a brand pass. Inspecting them:

- `REVIEW.md`'s 73 lowercase `vm0` hits are **all** `vm0-ai/vm0` repository paths — explicitly out of scope.
- `MIGRATIONS.md`'s are all `vm0-transition-validator:` and `vm0:non-transactional` annotation tokens — code identifiers, out of scope.
- Five of the six skills files matched only on the English idiom **"Zero tolerance"** (for lint violations, for `any` types), not the brand. `CLAUDE.md`, `docs/bad-smell.md` and `turbo/docs/react.md` matched the same way.

So those files are correctly left alone. Only the one real brand word in the skills tree was changed.

**2. `docs/deployment-compatibility.md` is brand-neutral rather than rebranded.** The sentence read *"The VM0 brand, established environment-variable namespace, and fixed paths are not lifecycle terminology and remain unchanged."* Writing "The Okou brand" there would be actively misleading, because the environment-variable namespace it is talking about really is still `VM0_`. It now reads *"Product brand names, the established environment-variable namespace, and fixed paths…"*, which states the rule without pinning it to a brand that can drift again.

**3. Files with brand words that this PR does not touch,** because the issue did not scope them and I would rather flag than silently widen a documentation PR:

| File | Brand reference |
| --- | --- |
| `turbo/packages/ui/README.md` | 7 — "VM0's shared UI component library", "Maintainer: VM0 Team", Figma file named *VM0-Cloud* |
| `docs/effect.md` | 1 — "the VM0 platform" (identical phrasing to the `react-commit.md` line this PR does fix) |
| `docs/chat-cards.md` | 2 — "allowed VM0 platform origin" |
| `turbo/packages/proxy/README.md` | 1 — "Part of VM0 monorepo" |

`e2e/playwright/AUTH_V2.md` also names both brands, but deliberately: it contrasts VM0 branding on the production host against Okou branding on preview hosts, and is accurate as written. Happy to fold the four rows above into this PR or file a follow-up — say which.

## Verification

- `git grep -o 'vm0-ai/vm0' | wc -l` — 46054 before, 46054 after.
- No `CHANGELOG.md` in `git diff --name-only`.
- All 9 URLs on added lines return 2xx and land on Okou-branded pages.
- `<picture>` rendered against both GitHub theme backgrounds with live assets; legible in each.
- `git diff --check` clean. Prettier covers `turbo/**` only and defaults to `proseWrap: preserve`, so no markdown reflow; the one rewrapped paragraph keeps its file's 80-column style.
- Per repository convention, no full local test suite and no dev server were run; CI owns those.
