### PR TITLE
fix(api): retry transient clerk read failures

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -313,6 +313,63 @@ describe("Axiom log source field", () => {
     );
   });
 
+  it("lifts sanitized provider-unavailable fields into the Axiom event root", () => {
+    const log = logger("provider-unavailable-test");
+    log.error("Clerk read unavailable during scrape authentication", {
+      type: "provider_unavailable",
+      provider: "clerk",
+      provider_status: 521,
+      failure_class: "transient_read_exhausted",
+      method: "POST",
+      route: "/api/scrape",
+    });
+
+    expect(axiomLogging.error).toHaveBeenCalledWith(
+      "Clerk read unavailable during scrape authentication",
+      {
+        type: "provider_unavailable",
+        provider: "clerk",
+        provider_status: 521,
+        failure_class: "transient_read_exhausted",
+        method: "POST",
+        route: "/api/scrape",
+        context: "provider-unavailable-test",
+        [EVENT]: {
+          source: "api",
+          type: "provider_unavailable",
+          provider: "clerk",
+          provider_status: 521,
+          failure_class: "transient_read_exhausted",
+          method: "POST",
+          route: "/api/scrape",
+        },
+      },
+    );
+  });
+
+  it("does not lift malformed provider-unavailable fields", () => {
+    const log = logger("malformed-provider-unavailable-test");
+    log.error("provider error", {
+      type: "provider_unavailable",
+      provider: "clerk",
+      provider_status: "521",
+      failure_class: "transient_read_exhausted",
+      method: "POST",
+      route: "/api/scrape",
+    });
+
+    expect(axiomLogging.error).toHaveBeenCalledWith("provider error", {
+      type: "provider_unavailable",
+      provider: "clerk",
+      provider_status: "521",
+      failure_class: "transient_read_exhausted",
+      method: "POST",
+      route: "/api/scrape",
+      context: "malformed-provider-unavailable-test",
+      [EVENT]: { source: "api" },
+    });
+  });
+
   it("does not lift unknown type fields into the Axiom event root", () => {
     const log = logger("unknown-type-test");
     log.error("custom event", {

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -181,6 +181,15 @@ interface UnhandledRequestErrorRootFields {
   readonly errorCode?: string;
 }
 
+interface ProviderUnavailableRootFields {
+  readonly type: "provider_unavailable";
+  readonly provider: "clerk";
+  readonly provider_status: number;
+  readonly failure_class: "transient_read_exhausted";
+  readonly method: string;
+  readonly route: string;
+}
+
 function usageUnderbillingRootFields(
   fields: Record<string, unknown>,
 ): UsageUnderbillingRootFields | null {
@@ -234,12 +243,51 @@ function unhandledRequestErrorRootFields(
   };
 }
 
+function providerUnavailableRootFields(
+  fields: Record<string, unknown>,
+): ProviderUnavailableRootFields | null {
+  const type = fields.type;
+  const provider = fields.provider;
+  const providerStatus = fields.provider_status;
+  const failureClass = fields.failure_class;
+  const method = fields.method;
+  const route = fields.route;
+
+  if (
+    type !== "provider_unavailable" ||
+    provider !== "clerk" ||
+    typeof providerStatus !== "number" ||
+    !Number.isInteger(providerStatus) ||
+    providerStatus < 500 ||
+    providerStatus > 599 ||
+    failureClass !== "transient_read_exhausted" ||
+    typeof method !== "string" ||
+    typeof route !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    type,
+    provider,
+    provider_status: providerStatus,
+    failure_class: failureClass,
+    method,
+    route,
+  };
+}
+
 function rootEventFields(
   fields: Record<string, unknown>,
-): UsageUnderbillingRootFields | UnhandledRequestErrorRootFields | null {
+):
+  | UsageUnderbillingRootFields
+  | UnhandledRequestErrorRootFields
+  | ProviderUnavailableRootFields
+  | null {
   return (
     usageUnderbillingRootFields(fields) ??
-    unhandledRequestErrorRootFields(fields)
+    unhandledRequestErrorRootFields(fields) ??
+    providerUnavailableRootFields(fields)
   );
 }
 

--- a/turbo/apps/api/src/signals/external/clerk.ts
+++ b/turbo/apps/api/src/signals/external/clerk.ts
@@ -206,6 +206,21 @@ export class ClerkRateLimitError extends Error implements ClerkRateLimit {
 const CLERK_READ_MAX_ATTEMPTS = 3;
 const CLERK_READ_MAX_TOTAL_DELAY_MS = 15_000;
 const CLERK_READ_MAX_JITTER_MS = 250;
+const CLERK_READ_PROVIDER_UNAVAILABLE_DELAY_MS = 1000;
+
+export interface ClerkReadUnavailable {
+  readonly providerStatus: number;
+}
+
+class ClerkReadUnavailableError extends Error implements ClerkReadUnavailable {
+  constructor(
+    readonly providerStatus: number,
+    cause: unknown,
+  ) {
+    super("Clerk read is temporarily unavailable", { cause });
+    this.name = "ClerkReadUnavailableError";
+  }
+}
 
 export interface ClerkReadContext {
   readonly remainingDelayMs: () => number;
@@ -240,7 +255,58 @@ export function clerkRateLimit(error: unknown): ClerkRateLimit | null {
   };
 }
 
-/** Apply the shared 429 policy inside a Clerk external read adapter. */
+export function clerkReadUnavailable(
+  error: unknown,
+): ClerkReadUnavailable | null {
+  return error instanceof ClerkReadUnavailableError ? error : null;
+}
+
+interface ClerkRateLimitRetry {
+  readonly kind: "rate_limit";
+  readonly delayMs: number;
+}
+
+interface ClerkProviderUnavailableRetry {
+  readonly kind: "provider_unavailable";
+  readonly delayMs: number;
+  readonly providerStatus: number;
+}
+
+type ClerkReadRetry = ClerkRateLimitRetry | ClerkProviderUnavailableRetry;
+
+function clerkReadRetry(error: unknown): ClerkReadRetry | null {
+  const rateLimit = clerkRateLimit(error);
+  if (rateLimit) {
+    return {
+      kind: "rate_limit",
+      delayMs: rateLimit.retryAfterSeconds * 1000,
+    };
+  }
+
+  if (
+    !isClerkAPIResponseError(error) ||
+    !Number.isInteger(error.status) ||
+    error.status < 500 ||
+    error.status > 599
+  ) {
+    return null;
+  }
+
+  return {
+    kind: "provider_unavailable",
+    delayMs: CLERK_READ_PROVIDER_UNAVAILABLE_DELAY_MS,
+    providerStatus: error.status,
+  };
+}
+
+function throwTerminalClerkRead(error: unknown, retry: ClerkReadRetry): never {
+  if (retry.kind === "provider_unavailable") {
+    throw new ClerkReadUnavailableError(retry.providerStatus, error);
+  }
+  throw error;
+}
+
+/** Apply the shared transient-failure policy inside a Clerk read adapter. */
 export async function retryClerkRead<T>(
   read: () => Promise<T>,
   context: ClerkReadContext = createClerkReadContext(),
@@ -254,25 +320,27 @@ export async function retryClerkRead<T>(
       return result.value;
     }
 
-    const rateLimit = clerkRateLimit(result.error);
-    if (!rateLimit || attempt >= CLERK_READ_MAX_ATTEMPTS) {
+    const retry = clerkReadRetry(result.error);
+    if (!retry) {
       throw result.error;
     }
+    if (attempt >= CLERK_READ_MAX_ATTEMPTS) {
+      throwTerminalClerkRead(result.error, retry);
+    }
 
-    const retryAfterMs = rateLimit.retryAfterSeconds * 1000;
     const remainingDelayMs = Math.min(
       CLERK_READ_MAX_TOTAL_DELAY_MS - totalDelayMs,
       context.remainingDelayMs(),
     );
-    if (retryAfterMs > remainingDelayMs) {
-      throw result.error;
+    if (retry.delayMs > remainingDelayMs) {
+      throwTerminalClerkRead(result.error, retry);
     }
     const jitterBudgetMs = Math.min(
       CLERK_READ_MAX_JITTER_MS,
-      remainingDelayMs - retryAfterMs,
+      remainingDelayMs - retry.delayMs,
     );
     const jitterMs = Math.floor(Math.random() * (jitterBudgetMs + 1));
-    const waitMs = retryAfterMs + jitterMs;
+    const waitMs = retry.delayMs + jitterMs;
     await delay(waitMs, { signal });
     totalDelayMs += waitMs;
   }
@@ -402,21 +470,6 @@ const clerkClient = singleton((): ClerkClient => {
 export const clerk$: Computed<ClerkClient> = computed((): ClerkClient => {
   return clerkClient();
 });
-
-export type OrganizationMembershipList =
-  ClerkPaginated<ClerkOrganizationMembership>;
-
-export function membershipsByUserId(
-  userId: string,
-  limit = 100,
-): Computed<Promise<OrganizationMembershipList>> {
-  return computed((get) => {
-    return get(clerk$).users.getOrganizationMembershipList({
-      userId,
-      limit,
-    });
-  });
-}
 
 /**
  * Clerk's `RequestState` is a wide union whose members disagree about what

--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -862,7 +862,7 @@ describe("FILE-03 desktop computer-use runtime", () => {
       "Multiple active computer-use hosts are online",
     );
 
-    // Zero-token auth resolves the org role through membershipsByUserId.
+    // Zero-token auth resolves the organization role through Clerk membership lookup.
     mockClerkMembership(context, actor, "org:admin");
 
     const missingCapability = await api.requestCreateComputerUseReadCommand(

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -40,10 +40,12 @@ const DEFAULT_AGENT_AVATAR_URL =
 
 class ClerkApiResponseTestError extends Error {
   static readonly kind = "ClerkAPIResponseError";
-  readonly status = 429;
 
-  constructor(readonly retryAfter: number) {
-    super("Clerk Backend API rate limit exceeded");
+  constructor(
+    readonly retryAfter: number,
+    readonly status = 429,
+  ) {
+    super(`Clerk Backend API request failed with status ${status}`);
   }
 }
 
@@ -427,6 +429,29 @@ describe("ORG-01: org update and delete error matrix", () => {
       error: { message: "Resource not found", code: "NOT_FOUND" },
     });
   });
+
+  it("does not retry Clerk mutation failures", async () => {
+    const admin = api.user();
+    const baseSlug = slug("bdd-r5-org-mutation");
+    api.acceptAgentStorageWrites();
+    await onboardAdmin(admin, { slug: baseSlug, name: "BDD R5 Org" });
+    context.mocks.clerk.organizations.updateOrganization.mockClear();
+    context.mocks.clerk.organizations.updateOrganization.mockRejectedValue(
+      new ClerkApiResponseTestError(1, 521),
+    );
+
+    const response = await api.requestUpdateOrg(
+      admin,
+      { name: "Unavailable Rename" },
+      [500],
+    );
+
+    expect(response.status).toBe(500);
+    expect(
+      context.mocks.clerk.organizations.updateOrganization,
+    ).toHaveBeenCalledOnce();
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+  });
 });
 
 describe("ORG-02: membership admin matrix", () => {
@@ -455,6 +480,47 @@ describe("ORG-02: membership admin matrix", () => {
     ).toHaveBeenCalledTimes(2);
     expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(1);
 
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockClear();
+    context.mocks.signalTimers.delay.mockClear();
+    context.mocks.clerk.organizations.getOrganizationMembershipList
+      .mockRejectedValueOnce(new ClerkApiResponseTestError(1, 521))
+      .mockResolvedValue({
+        data: [
+          {
+            role: "org:admin",
+            publicUserData: { userId: admin.userId },
+            createdAt: now(),
+          },
+        ],
+      });
+
+    const recoveredUnavailable = await api.requestListMembers(admin, [200]);
+    expect(recoveredUnavailable.body.members).toHaveLength(1);
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(2);
+    expect(context.mocks.signalTimers.delay).toHaveBeenCalledOnce();
+
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockReset();
+    context.mocks.signalTimers.delay.mockClear();
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
+      new ClerkApiResponseTestError(1, 521),
+    );
+
+    const unavailable = await api.requestListMembers(admin, [500]);
+    expect(unavailable.status).toBe(500);
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(3);
+    expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(2);
+    expect(context.mocks.sentry.captureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "ClerkReadUnavailableError",
+        message: "Clerk read is temporarily unavailable",
+        providerStatus: 521,
+      }),
+    );
+
     api.mockClerkOrg(admin);
     context.mocks.signalTimers.delay.mockClear();
     const requests = api.mockClerkMembershipRequestHandlers(orgId, {
@@ -473,6 +539,22 @@ describe("ORG-02: membership admin matrix", () => {
     expect(exhausted.headers.get("Cache-Control")).toBe("no-store");
     expect(requests.listCalls()).toBe(3);
     expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry Clerk 4xx reads", async () => {
+    const admin = api.user();
+    api.mockClerkOrg(admin);
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
+      new ClerkApiResponseTestError(1, 404),
+    );
+
+    const response = await api.requestListMembers(admin, [500]);
+
+    expect(response.status).toBe(500);
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledOnce();
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
   });
 
   it("stops sibling Clerk work when a directory read is exhausted", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -500,6 +500,13 @@ describe("ORG-02: membership admin matrix", () => {
       context.mocks.clerk.organizations.getOrganizationMembershipList,
     ).toHaveBeenCalledTimes(2);
     expect(context.mocks.signalTimers.delay).toHaveBeenCalledOnce();
+    const [providerWaitMs, providerDelayOptions] =
+      context.mocks.signalTimers.delay.mock.calls[0] ?? [];
+    expect(providerWaitMs).toBeGreaterThanOrEqual(1000);
+    expect(providerWaitMs).toBeLessThanOrEqual(1250);
+    expect(providerDelayOptions).toMatchObject({
+      signal: expect.any(AbortSignal),
+    });
 
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockReset();
     context.mocks.signalTimers.delay.mockClear();
@@ -541,7 +548,7 @@ describe("ORG-02: membership admin matrix", () => {
     expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(2);
   });
 
-  it("does not retry Clerk 4xx reads", async () => {
+  it("does not retry Clerk 4xx or malformed read failures", async () => {
     const admin = api.user();
     api.mockClerkOrg(admin);
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
@@ -551,6 +558,20 @@ describe("ORG-02: membership admin matrix", () => {
     const response = await api.requestListMembers(admin, [500]);
 
     expect(response.status).toBe(500);
+    expect(
+      context.mocks.clerk.organizations.getOrganizationMembershipList,
+    ).toHaveBeenCalledOnce();
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+
+    api.mockClerkOrg(admin);
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockClear();
+    context.mocks.clerk.organizations.getOrganizationMembershipList.mockRejectedValue(
+      { status: 521 },
+    );
+
+    const malformed = await api.requestListMembers(admin, [500]);
+
+    expect(malformed.status).toBe(500);
     expect(
       context.mocks.clerk.organizations.getOrganizationMembershipList,
     ).toHaveBeenCalledOnce();

--- a/turbo/apps/api/src/signals/routes/__tests__/scrape.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/scrape.test.ts
@@ -28,6 +28,8 @@ import {
   expectApiError,
   type ApiTestUser,
 } from "./helpers/api-bdd";
+import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
+import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createRouteMocks } from "./helpers/route-test";
 
 const context = testContext();
@@ -43,9 +45,19 @@ interface AuthHeaders {
 }
 
 interface RawScrapeRequestOptions {
+  readonly authHeaders?: AuthHeaders;
   readonly instanceSignal?: AbortSignal;
   readonly requestSignal?: AbortSignal;
   readonly usagePricingResolution?: UsagePricingFixture["resolution"];
+}
+
+class ClerkApiResponseTestError extends Error {
+  static readonly kind = "ClerkAPIResponseError";
+  readonly code = "api_response_error";
+
+  constructor(readonly status: number) {
+    super("Clerk request failed for user_sensitive and org_sensitive");
+  }
 }
 
 function authHeaders(actor: ApiTestUser | null): AuthHeaders {
@@ -89,7 +101,7 @@ async function rawScrapeRequest(
   const request = new Request("http://api.test/api/scrape", {
     method: "POST",
     headers: {
-      ...authenticate(actor),
+      ...(options.authHeaders ?? authenticate(actor)),
       "content-type": "application/json",
     },
     body: JSON.stringify(body),
@@ -212,6 +224,213 @@ describe("okou scrape route", () => {
     expect(response.body.error.message).toBe(
       "Missing required capability: scrape:read",
     );
+  });
+
+  it("retries a transient Clerk membership failure before scraping with a CLI PAT", async () => {
+    const actor = createBddApi(context).user();
+    const { token } =
+      await createAuthOrgAgentsBddApi(context).createCliToken(actor);
+    let firecrawlRequests = 0;
+    allowExampleDotCom();
+    configureProvider();
+    const pricing = await createScrapePricingFixture();
+    await fundActor(actor);
+    mockClerkMembership(context, actor, "org:admin");
+    context.mocks.clerk.users.getOrganizationMembershipList.mockRejectedValueOnce(
+      new ClerkApiResponseTestError(521),
+    );
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+    server.use(
+      http.post(FIRECRAWL_SCRAPE_URL, () => {
+        firecrawlRequests += 1;
+        return HttpResponse.json({
+          success: true,
+          data: {
+            markdown: "# Example page",
+            metadata: { sourceURL: "https://example.com/page" },
+          },
+        });
+      }),
+    );
+
+    const response = await rawScrapeRequest(
+      null,
+      {
+        url: "https://example.com/page",
+        format: "markdown",
+        mode: "standard",
+      },
+      {
+        authHeaders: { authorization: `Bearer ${token}` },
+        usagePricingResolution: pricing.resolution,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      context.mocks.clerk.users.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(2);
+    expect(context.mocks.signalTimers.delay).toHaveBeenCalledOnce();
+    expect(firecrawlRequests).toBe(1);
+  });
+
+  it("returns a sanitized 503 when Clerk membership reads remain unavailable", async () => {
+    const actor = createBddApi(context).user();
+    const { token } =
+      await createAuthOrgAgentsBddApi(context).createCliToken(actor);
+    let firecrawlRequests = 0;
+    allowExampleDotCom();
+    configureProvider();
+    const pricing = await createScrapePricingFixture();
+    await fundActor(actor);
+    const beforeCredits = await credits(actor);
+    context.mocks.clerk.users.getOrganizationMembershipList.mockRejectedValue(
+      new ClerkApiResponseTestError(521),
+    );
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+    server.use(
+      http.post(FIRECRAWL_SCRAPE_URL, () => {
+        firecrawlRequests += 1;
+        return HttpResponse.json({ success: true, data: {} });
+      }),
+    );
+
+    const response = await rawScrapeRequest(
+      null,
+      {
+        url: "https://example.com/page",
+        format: "markdown",
+        mode: "standard",
+      },
+      {
+        authHeaders: { authorization: `Bearer ${token}` },
+        usagePricingResolution: pricing.resolution,
+      },
+    );
+    const afterCredits = await credits(actor);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "Authentication provider is temporarily unavailable",
+        code: "PROVIDER_UNAVAILABLE",
+      },
+    });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(
+      context.mocks.clerk.users.getOrganizationMembershipList,
+    ).toHaveBeenCalledTimes(3);
+    expect(context.mocks.signalTimers.delay).toHaveBeenCalledTimes(2);
+    expect(firecrawlRequests).toBe(0);
+    expect(afterCredits).toBe(beforeCredits);
+    expect(context.mocks.axiomLogging.error).toHaveBeenCalledOnce();
+    expect(context.mocks.axiomLogging.error).toHaveBeenCalledWith(
+      "Clerk read unavailable during scrape authentication",
+      expect.objectContaining({
+        type: "provider_unavailable",
+        provider: "clerk",
+        provider_status: 521,
+        failure_class: "transient_read_exhausted",
+        method: "POST",
+        route: "/api/scrape",
+      }),
+    );
+    expect(
+      JSON.stringify(context.mocks.axiomLogging.error.mock.calls),
+    ).not.toContain("sensitive");
+    expect(context.mocks.sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("stops Clerk membership retries when the API instance is aborted", async () => {
+    const actor = createBddApi(context).user();
+    const { token } =
+      await createAuthOrgAgentsBddApi(context).createCliToken(actor);
+    const controller = new AbortController();
+    const retryStarted = createDeferredPromise<void>(context.signal);
+    const abortError = new Error("client disconnected during Clerk retry");
+    abortError.name = "AbortError";
+    await fundActor(actor);
+    context.mocks.clerk.users.getOrganizationMembershipList.mockRejectedValue(
+      new ClerkApiResponseTestError(521),
+    );
+    context.mocks.signalTimers.delay.mockImplementation((_ms, options) => {
+      retryStarted.resolve(undefined);
+      const signal = options?.signal;
+      if (!signal) {
+        throw new Error("Expected Clerk retry delay to receive a signal");
+      }
+      return createDeferredPromise<void>(signal).promise;
+    });
+
+    const responsePromise = rawScrapeRequest(
+      null,
+      {
+        url: "https://example.com/page",
+        format: "markdown",
+        mode: "standard",
+      },
+      {
+        authHeaders: { authorization: `Bearer ${token}` },
+        instanceSignal: controller.signal,
+      },
+    );
+    await retryStarted.promise;
+    controller.abort(abortError);
+    const response = await responsePromise;
+
+    expect(response.status).toBe(500);
+    expect(
+      context.mocks.clerk.users.getOrganizationMembershipList,
+    ).toHaveBeenCalledOnce();
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps successful Clerk membership misses on the unauthorized path", async () => {
+    const actor = createBddApi(context).user();
+    const { token } =
+      await createAuthOrgAgentsBddApi(context).createCliToken(actor);
+    context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+      data: [],
+    });
+
+    const response = await rawScrapeRequest(
+      null,
+      {
+        url: "https://example.com/page",
+        format: "markdown",
+        mode: "standard",
+      },
+      { authHeaders: { authorization: `Bearer ${token}` } },
+    );
+
+    expect(response.status).toBe(401);
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalled();
+  });
+
+  it("does not classify direct Clerk session failures as exhausted reads", async () => {
+    context.mocks.clerk.authenticateRequest.mockRejectedValue(
+      new ClerkApiResponseTestError(521),
+    );
+
+    const response = await rawScrapeRequest(
+      null,
+      {
+        url: "https://example.com/page",
+        format: "markdown",
+        mode: "standard",
+      },
+      { authHeaders: { authorization: "Bearer clerk-session" } },
+    );
+
+    expect(response.status).toBe(500);
+    expect(context.mocks.signalTimers.delay).not.toHaveBeenCalled();
+    expect(context.mocks.axiomLogging.error).toHaveBeenCalledOnce();
+    expect(context.mocks.axiomLogging.error).not.toHaveBeenCalledWith(
+      "Clerk read unavailable during scrape authentication",
+      expect.anything(),
+    );
+    expect(context.mocks.sentry.captureException).toHaveBeenCalledOnce();
   });
 
   it("rejects scrape requests when the provider is not configured", async () => {

--- a/turbo/apps/api/src/signals/routes/scrape.ts
+++ b/turbo/apps/api/src/signals/routes/scrape.ts
@@ -1,11 +1,18 @@
 import { scrapeContract } from "@okouai/api-contracts/contracts/scrape";
 import { command } from "ccstate";
 
+import { providerUnavailable } from "../../lib/error";
+import { logger } from "../../lib/log";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { setResHeader$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
+import { clerkReadUnavailable } from "../external/clerk";
 import type { RouteEntry } from "../route-entry";
 import { scrape$ } from "../services/scrape.service";
+import { settle } from "../utils";
+
+const L = logger("Scrape");
 
 const scrapeBody$ = bodyResultOf(scrapeContract.scrape);
 
@@ -19,16 +26,43 @@ const scrapeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return await set(scrape$, { auth, body: bodyResult.data }, signal);
 });
 
+const authenticatedScrape$ = authRoute(
+  {
+    requireOrganization: true,
+    missingOrganizationStatus: 401,
+    requiredCapability: "scrape:read",
+  },
+  scrapeInner$,
+);
+
+const scrapeRoute$ = command(async ({ set }, signal: AbortSignal) => {
+  const result = await settle(set(authenticatedScrape$, signal), signal);
+  if (result.ok) {
+    return result.value;
+  }
+
+  const unavailable = clerkReadUnavailable(result.error);
+  if (!unavailable) {
+    throw result.error;
+  }
+
+  L.error("Clerk read unavailable during scrape authentication", {
+    type: "provider_unavailable",
+    provider: "clerk",
+    provider_status: unavailable.providerStatus,
+    failure_class: "transient_read_exhausted",
+    method: "POST",
+    route: "/api/scrape",
+  });
+  set(setResHeader$, "Cache-Control", "no-store");
+  return providerUnavailable(
+    "Authentication provider is temporarily unavailable",
+  );
+});
+
 export const scrapeRoutes: readonly RouteEntry[] = [
   {
     route: scrapeContract.scrape,
-    handler: authRoute(
-      {
-        requireOrganization: true,
-        missingOrganizationStatus: 401,
-        requiredCapability: "scrape:read",
-      },
-      scrapeInner$,
-    ),
+    handler: scrapeRoute$,
   },
 ];

--- a/turbo/apps/api/src/signals/services/auth.service.ts
+++ b/turbo/apps/api/src/signals/services/auth.service.ts
@@ -3,7 +3,7 @@ import { cliTokens } from "@okouai/db/schema/cli-tokens";
 import { orgMembersCache } from "@okouai/db/schema/org-members-cache";
 import { and, eq, gt } from "drizzle-orm";
 
-import { membershipsByUserId } from "../external/clerk";
+import { clerk$ } from "../external/clerk";
 import { db$, writeDb$ } from "../external/db";
 import { now, nowDate } from "../../lib/time";
 import type { ApiOrgRole, CliAuth, CliTokenRecord } from "../../types/auth";
@@ -94,7 +94,11 @@ export const getMemberRoleAndUpdateCache$ = command(
       return { role };
     }
 
-    const memberships = await get(membershipsByUserId(userId));
+    const memberships = await get(clerk$).users.getOrganizationMembershipList(
+      { userId, limit: 100 },
+      undefined,
+      signal,
+    );
     signal.throwIfAborted();
     const membership = memberships.data.find((candidate) => {
       return candidate.organization.id === orgId;


### PR DESCRIPTION
## Summary

- retry Clerk Backend API 500-599 failures only inside the existing idempotent-read gateway, using the current three-attempt/shared-delay budget and a stable terminal error
- propagate the active API signal into CLI PAT membership reads, then map exhausted reads on `POST /api/scrape` to the existing non-cacheable 503 contract
- emit one sanitized, queryable Clerk provider-unavailable event and cover recovery, exhaustion, cancellation, authorization misses, 4xx behavior, and mutation non-retry through API entry points

## Scope and compatibility

- Clerk 429 `Retry-After` behavior is unchanged
- Clerk mutations remain single-attempt
- expired membership roles are never used as an availability fallback
- direct Clerk session failures and unrelated exceptions remain on their existing unhandled paths
- no schema, contract, frontend, CLI, runner, queue, or persisted-state change is required

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm check-types --filter=api`
- `pnpm -F api check-types:tests`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/lib/__tests__/log.test.ts src/signals/routes/__tests__/scrape.test.ts src/signals/routes/__tests__/org-team.bdd.test.ts --maxWorkers=1` (89 passed)
- pre-commit hook: full-repository Knip, full-repository type checking (15 tasks), staged formatting, and file-size checks

Closes #31576
