### PR TITLE
perf(ci): disable implicit npm audits

### DIFF
--- a/.github/scripts/tests/implicit-npm-audit-test.sh
+++ b/.github/scripts/tests/implicit-npm-audit-test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+ruby -ryaml - "$repo_root" <<'RUBY'
+repo_root = ARGV.fetch(0)
+
+def load_yaml(path)
+  YAML.load_file(path, aliases: true)
+end
+
+def audit_setting(*environments)
+  environments.reverse_each do |environment|
+    next unless environment.is_a?(Hash)
+
+    key = environment.keys.find do |candidate|
+      candidate.to_s.downcase == "npm_config_audit"
+    end
+    return environment.fetch(key).to_s if key
+  end
+  nil
+end
+
+def command_lines(script, command)
+  script.lines.filter do |line|
+    stripped = line.strip
+    next false if stripped.empty? || stripped.start_with?("#")
+
+    stripped.match?(
+      /(?:\A|&&\s*|\|\|\s*|;\s*)(?:RUN\s+)?#{command}/,
+    )
+  end
+end
+
+def implicit_npm_install?(script)
+  install = /(?:npm_config_audit=false\s+)?npm\s+(?:ci|install|i)\b/
+  command_lines(script, install).any? do |line|
+    !line.match?(/(?:\A|\s)(?:-g|--global)(?:\s|\z)/) &&
+      !line.include?("--no-audit") &&
+      !line.include?("npm_config_audit=false")
+  end
+end
+
+violations = []
+explicit_audit_paths = []
+
+workflow_paths = Dir[File.join(repo_root, ".github/workflows/*.{yml,yaml}")]
+workflow_paths.each do |path|
+  document = load_yaml(path)
+  workflow_environment = document.fetch("env", {})
+
+  document.fetch("jobs", {}).each do |job_name, job|
+    next unless job.is_a?(Hash)
+
+    job_environment = job.fetch("env", {})
+    job.fetch("steps", []).each_with_index do |step, index|
+      next unless step.is_a?(Hash)
+
+      effective_audit = audit_setting(
+        workflow_environment,
+        job_environment,
+        step.fetch("env", {}),
+      )
+      location = "#{path.delete_prefix("#{repo_root}/")}:#{job_name}:step-#{index + 1}"
+
+      if step.fetch("uses", "").start_with?("pnpm/action-setup@") &&
+          effective_audit != "false"
+        violations << "#{location} runs pnpm/action-setup without npm_config_audit=false"
+      end
+
+      run = step.fetch("run", "")
+      if implicit_npm_install?(run) && effective_audit != "false"
+        violations << "#{location} runs an implicit npm audit"
+      end
+      unless command_lines(run, /(?:npm|pnpm)\s+audit\b/).empty?
+        explicit_audit_paths << path.delete_prefix("#{repo_root}/")
+      end
+    end
+  end
+end
+
+action_paths = Dir[File.join(repo_root, ".github/actions/**/action.{yml,yaml}")]
+action_paths.each do |path|
+  document = load_yaml(path)
+  document.dig("runs", "steps")&.each_with_index do |step, index|
+    next unless step.is_a?(Hash)
+
+    location = "#{path.delete_prefix("#{repo_root}/")}:step-#{index + 1}"
+    effective_audit = audit_setting(step.fetch("env", {}))
+    run = step.fetch("run", "")
+
+    if step.fetch("uses", "").start_with?("pnpm/action-setup@") &&
+        effective_audit != "false"
+      violations << "#{location} runs pnpm/action-setup without npm_config_audit=false"
+    end
+    if implicit_npm_install?(run) && effective_audit != "false"
+      violations << "#{location} runs an implicit npm audit"
+    end
+    unless command_lines(run, /(?:npm|pnpm)\s+audit\b/).empty?
+      explicit_audit_paths << path.delete_prefix("#{repo_root}/")
+    end
+  end
+end
+
+script_globs = [
+  ".github/scripts/**/*.sh",
+  ".devcontainer/**/*.sh",
+  "scripts/**/*.sh",
+  "crates/**/scripts/**/*.sh",
+  "e2e/**/*.sh",
+  "e2e/**/*.bash",
+  "e2e/**/*.bats",
+  "docker/**/Dockerfile*",
+]
+script_paths = script_globs.flat_map do |glob|
+  Dir[File.join(repo_root, glob)]
+end.uniq.reject do |path|
+  path.end_with?("/.github/scripts/tests/implicit-npm-audit-test.sh") ||
+    path.include?("/e2e/test/libs/")
+end
+
+script_paths.each do |path|
+  content = File.read(path)
+  relative_path = path.delete_prefix("#{repo_root}/")
+
+  if implicit_npm_install?(content) &&
+      !content.match?(/^\s*export\s+npm_config_audit=false\b/)
+    violations << "#{relative_path} runs an implicit npm audit"
+  end
+  unless command_lines(content, /(?:npm|pnpm)\s+audit\b/).empty?
+    explicit_audit_paths << relative_path
+  end
+end
+
+expected_audit_path = ".github/workflows/security.yml"
+unless explicit_audit_paths.uniq == [expected_audit_path]
+  violations << "explicit dependency audit must remain owned only by #{expected_audit_path}"
+end
+
+unless violations.empty?
+  warn violations.join("\n")
+  exit 1
+end
+RUBY

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -40,6 +40,10 @@ concurrency:
 permissions:
   contents: read
 
+# Dependency vulnerability scanning is owned by security.yml.
+env:
+  npm_config_audit: "false"
+
 jobs:
   detect-desktop-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,10 @@ permissions:
   packages: write
   checks: write
 
+# Dependency vulnerability scanning is owned by security.yml.
+env:
+  npm_config_audit: "false"
+
 jobs:
   # A push to main can carry several merge-queue entries at once, so look at every
   # commit subject in the push rather than only the head commit. Without this the

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'merge_group' && format('merge-queue-{0}', github.run_id) || 'staging') }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Dependency vulnerability scanning is owned by security.yml.
+env:
+  npm_config_audit: "false"
+
 jobs:
   # Detect release-please context across all event types (PR, push, merge queue).
   # github.head_ref is empty in merge_group events, so we extract the PR number


### PR DESCRIPTION
## Summary

- disable npm's automatic install-time audit in Turbo, Desktop, and release workflows
- keep the explicit `pnpm audit` job in `security.yml` as the sole dependency vulnerability scan
- add a CI contract test covering workflows, composite actions, first-party CI scripts, and Dockerfiles

## Performance evidence

- reproduced `pnpm/action-setup@v6` locally at 105.9 seconds with its default `npm ci`
- the same cold setup completed in 26.8 seconds with `npm_config_audit=false`
- an isolated npm bulk advisory request spent 146 seconds in the audit endpoint; a direct request waited 157.9 seconds for its first response byte

## Validation

- `bash -n .github/scripts/tests/implicit-npm-audit-test.sh`
- `shellcheck .github/scripts/tests/implicit-npm-audit-test.sh`
- `.github/scripts/tests/implicit-npm-audit-test.sh`
- `.github/scripts/tests/turbo-playwright-runner-workflow-test.sh`
- `.github/scripts/tests/deploy-desktop-workflow-test.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/turbo.yml .github/workflows/desktop.yml .github/workflows/release-please.yml`
- `git diff --check`

## Exclusions

- does not remove or weaken the dedicated security audit job
- does not change global npm installs, which do not perform project dependency audits
