### PR TITLE
fix(api): set limited-free onboarding credits to 1,000

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/acquisition-attribution.test.ts
@@ -464,7 +464,7 @@ describe("GET /api/attribution/google-ads-milestones", () => {
         kind: "model",
         provider: usageProvider,
         category: "tokens.input",
-        unitPrice: 3000,
+        unitPrice: 1000,
         unitSize: 1_000_000,
       },
     ]);

--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -651,7 +651,7 @@ describe("ORG-03 onboarding status mapping", () => {
 
     const bootstrappedBilling = await runsApi.readBillingStatus(admin);
     expect(bootstrappedBilling).toMatchObject({
-      credits: 3000,
+      credits: 1000,
       tier: "limited-free-1",
       onboardingPaymentPending: false,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8119,7 +8119,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     const agentId = onboarding.defaultAgentId;
     await expect(api.readBillingStatus(actor)).resolves.toMatchObject({
       tier: "limited-free-1",
-      credits: 3000,
+      credits: 1000,
       onboardingPaymentPending: false,
     });
     const modelPolicies = await misc.listModelPolicies(actor);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -692,7 +692,7 @@ describe("WHCB-01: third-party webhook verification boundaries", () => {
 
     const billing = await runs.readBillingStatus(admin);
     expect(billing).toMatchObject({
-      credits: 3000,
+      credits: 1000,
       tier: "limited-free-1",
       onboardingPaymentPending: false,
     });
@@ -723,8 +723,8 @@ describe("WHCB-01: third-party webhook verification boundaries", () => {
       return grant.source === "onboarding";
     });
     expect(onboardingCreditGrant).toMatchObject({
-      amount: 3000,
-      remaining: 3000,
+      amount: 1000,
+      remaining: 1000,
     });
     expectExpiresAboutThirtyDaysFromNow(onboardingCreditGrant?.expiresAt);
     const limitedFreeProviders = await runs.listOrgModelProviders(admin);
@@ -749,7 +749,7 @@ describe("WHCB-01: third-party webhook verification boundaries", () => {
 
     const repeatedBilling = await runs.readBillingStatus(admin);
     expect(repeatedBilling).toMatchObject({
-      credits: 3000,
+      credits: 1000,
       tier: "limited-free-1",
       onboardingPaymentPending: false,
     });

--- a/turbo/apps/api/src/signals/services/onboarding-credit-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding-credit-grants.service.ts
@@ -8,7 +8,7 @@ import type { Tx } from "../../lib/db-types";
 
 const L = logger("onboarding-credit-grants.service");
 
-export const LIMITED_FREE_ONBOARDING_CREDITS = 3000;
+export const LIMITED_FREE_ONBOARDING_CREDITS = 1000;
 
 const ONBOARDING_CREDIT_SOURCE = "onboarding";
 const ONBOARDING_CREDIT_IDEMPOTENCY_KEY = "limited-free-onboarding";


### PR DESCRIPTION
## Summary

- Set the limited-free onboarding grant to 1,000 credits for newly bootstrapped workspaces.
- Preserve the existing 30-day expiry and idempotent grant behavior, so previously issued grants and balances are unchanged.
- Update route integration expectations for the new grant amount.

## Release order

Merge and deploy vm0-ai/vm0-marketing#592 first so public pricing copy changes before the API grant.

Depends on https://github.com/vm0-ai/vm0-marketing/pull/592

## Verification

- pnpm format
- pnpm turbo run lint --concurrency=1 --log-order grouped
- pnpm knip
- staged workspace, app, and API type checks
- auth-org-agents.bdd.test.ts: 11 passed
- focused Clerk bootstrap scenario in webhooks-callbacks.bdd.test.ts: passed

## Local baseline note

The focused run-lifecycle scenario reaches and passes the 1,000-credit billing assertion, then hits Job not found in queue at claimRunnerJob. The same test and same line reproduce on an unmodified origin/main worktree with the 3,000-credit grant, so this is not introduced by this change. PR CI remains authoritative.