### PR TITLE
fix(app): match the chat list's right inset to the workspace card gutter

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1625,6 +1625,51 @@ test("Keep pinned agents and the chat heading visible while conversations scroll
   });
 });
 
+// The new shell parks the workspace card's eight-pixel gutter, painted in the
+// sidebar colour, immediately right of this column. Keeping the full inset here
+// as well stacks the two, so the rows sit twice as far from the card's border
+// as from the rail.
+test("Spend the workspace card's gutter out of the chat list's right inset", async () => {
+  prepareDefaultAgent();
+  mockSidebarThreadStory([createThread(EXISTING_THREAD_ID, "Release plan")]);
+
+  await setupSidebarPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: {
+      [FeatureSwitchKey.NewUi]: true,
+    },
+  });
+
+  await waitFor(() => {
+    return within(sidebar()).getByText("Chats with Zero");
+  });
+
+  const pinnedContent = within(sidebar()).getByTestId(
+    "pinned-agents-horizontal",
+  ).parentElement;
+  const threadContent =
+    within(sidebar()).getByText("Chats with Zero").parentElement?.parentElement;
+  const header = sidebar().firstElementChild;
+  const footer = sidebar().lastElementChild;
+  if (
+    !(pinnedContent instanceof HTMLElement) ||
+    !(threadContent instanceof HTMLElement) ||
+    !(header instanceof HTMLElement) ||
+    !(footer instanceof HTMLElement)
+  ) {
+    throw new Error("Chat list column frame not found");
+  }
+
+  // The rail on the other side supplies no such gutter, so the left inset is
+  // unchanged and the two edges only read alike once the right one hands its
+  // eight pixels to the card.
+  for (const element of [header, pinnedContent, threadContent, footer]) {
+    expect(element).toHaveClass("pl-3", "pr-1");
+    expect(element).not.toHaveClass("px-3");
+  }
+});
+
 test("Route New chat to the current agent and Chat to the default agent", async () => {
   prepareAgents();
   mockSidebarThreadStory([

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -696,6 +696,11 @@ test("Drag the sidebar scrollbar when enabled", async () => {
 
   const scrollbar = await screen.findByTestId("sidebar-scrollbar");
   const thumb = await screen.findByTestId("sidebar-scrollbar-thumb");
+  // The thumb sits against the viewport's edge rather than centred in the
+  // track. Beside the workspace card the chat list keeps only four pixels of
+  // right inset, and a centred thumb lands on the trailing menu button of the
+  // row it is scrolling past.
+  expect(scrollbar).toHaveClass("justify-end");
   scrollbar.style.paddingBlockStart = "0px";
   scrollbar.style.paddingBlockEnd = "0px";
   thumb.style.marginBlockStart = "0px";
@@ -799,6 +804,11 @@ test("Collapse and expand Manage navigation", async () => {
   }
 
   expect(scrollWrapper).toHaveClass("group/sidebar-scroll");
+  // The track hugs the viewport's edge for the same reason the Base UI thumb
+  // does: beside the workspace card the chat list keeps only four pixels of
+  // right inset, and anything further in overlaps the row's trailing menu
+  // button.
+  expect(scrollbarTrack).toHaveClass("right-px");
   expect(scrollbarTrack).toHaveClass(
     "opacity-0",
     "transition-opacity",

--- a/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
@@ -75,8 +75,12 @@ function LegacyOverlayScrollArea({
       >
         <div className={contentClassName}>{children}</div>
       </div>
+      {/* The thumb hugs the viewport's edge instead of floating in the middle
+          of the gutter. Beside the workspace card that gutter is only four
+          pixels wide, and anything further in overlaps the trailing menu
+          button on the row it is scrolling past. */}
       <div
-        className={`absolute right-1 top-0 bottom-0 w-[6px] pointer-events-none opacity-0 transition-opacity duration-150 ${
+        className={`absolute right-px top-0 bottom-0 w-[6px] pointer-events-none opacity-0 transition-opacity duration-150 ${
           thumbStyleValue.visible
             ? "group-hover/sidebar-scroll:opacity-100"
             : ""
@@ -129,8 +133,11 @@ function BaseUiOverlayScrollArea({
           {children}
         </ScrollArea.Content>
       </ScrollArea.Viewport>
+      {/* The track stays wide enough to grab; `justify-end` keeps the thumb
+          itself against the viewport's edge, clear of the trailing menu button
+          on the rows beside the workspace card. */}
       <ScrollArea.Scrollbar
-        className="m-px flex w-3 justify-center opacity-0 transition-opacity duration-150 data-hovering:opacity-100 data-scrolling:opacity-100 data-scrolling:duration-0"
+        className="m-px flex w-3 justify-end opacity-0 transition-opacity duration-150 data-hovering:opacity-100 data-scrolling:opacity-100 data-scrolling:duration-0"
         data-testid="sidebar-scrollbar"
       >
         <ScrollArea.Thumb

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -723,8 +723,22 @@ function ThreeColumnSearchDialogContainer() {
   );
 }
 
+/** Inset the chat list column keeps on its own, away from the workspace card. */
+const CHAT_LIST_INSET = "px-3";
+
+/* Under the new shell the workspace card's gutter runs down the right of this
+   column, painted in the sidebar colour, so it already reads as part of the
+   column. A full inset on this side stacks on top of it and the rows end up
+   twice as far from the card's border as from the rail, which is the gap that
+   reads as too wide. Spending the gutter's eight pixels here restores the
+   match. The overlay scrollbar hugs the column edge for the same reason: with
+   only four pixels left it would otherwise sit over the row's trailing menu
+   button rather than beside it. */
+const CHAT_LIST_INSET_BESIDE_CARD = "pl-3 pr-1";
+
 function ChatListColumn() {
   const newUiEnabled = useGet(featureSwitch$)[FeatureSwitchKey.NewUi] ?? false;
+  const inset = newUiEnabled ? CHAT_LIST_INSET_BESIDE_CARD : CHAT_LIST_INSET;
   const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;
   const navigate = useSet(detachedNavigateTo$);
   const openThreeColumnSearch = useSet(openThreeColumnSearchDialog$);
@@ -754,7 +768,7 @@ function ChatListColumn() {
         !newUiEnabled && "border-r-[0.7px] border-sidebar-border",
       )}
     >
-      <div className="flex shrink-0 items-center gap-1 px-3 pb-2 pt-3">
+      <div className={cn("flex shrink-0 items-center gap-1 pb-2 pt-3", inset)}>
         <span className="zero-nav-copy flex-1 pl-2 text-[15px] font-semibold text-sidebar-foreground">
           {t(($) => {
             return $.appShell.sidebar.chat;
@@ -803,19 +817,19 @@ function ChatListColumn() {
         </TooltipProvider>
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden pt-1">
-        <div className="px-3">
+        <div className={inset}>
           <PinnedAgentListSection layout="horizontal" />
         </div>
         <ChatThreadsSection
           scrollSignals={threeColumnSidebarChatThreadScrollSignals}
-          contentClassName="px-3"
+          contentClassName={inset}
           showMarkAllRead
         />
       </div>
       {/* Collapses to nothing when SidebarUpgradeCard renders null, so the
           thread list reaches the column bottom instead of clipping its last
           row above a reserved strip. */}
-      <div className="px-3 pb-3 empty:hidden">
+      <div className={cn("pb-3 empty:hidden", inset)}>
         <SidebarUpgradeCard />
       </div>
     </aside>


### PR DESCRIPTION
## Problem

Under the new UI the workspace card sits beside the chat list column with an eight-pixel gutter painted in `hsl(var(--sidebar))`. That gutter reads as part of the chat column, so the column's own `px-3` stacks on top of it: rows end up 20px from the card's border but only 12px from the rail. That is the wide right-hand gap in the report.

## Change

- The chat list column's right inset drops to `pr-1` under the new UI, so `4px + 8px` gutter matches the unchanged `pl-3` on the rail side. Applied to the header, the pinned row, the thread list content, and the upgrade footer so the whole column keeps one edge.
- The overlay scrollbar thumb now hugs the viewport edge instead of centring in its track. With only four pixels of inset left, a centred thumb would sit over each row's trailing menu button (`icon-2xs` at `left-1` inside the 32px slot) rather than beside it. Both the Base UI and legacy scroll areas move, since the two feature switches are independent.

The legacy (non-new-UI) column keeps `px-3`.

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx` — 83 passed, including a new case asserting the card-adjacent inset.
- `pnpm turbo run lint --filter=@okouai/app`, `tsc --noEmit`, `pnpm knip --workspace apps/platform`, `pnpm format` — clean.

Visual confirmation is left to the Cloudflare preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)