### PR TITLE
refactor(platform): centralize shell document attributes

### DIFF
--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -12,6 +12,7 @@ import { createAuthedContractClient } from "../api-client-base.ts";
 import { rootSignal$ } from "../root-signal.ts";
 import { readClerkToken } from "../clerk-token.ts";
 import { writeConnectionDiagnostic$ } from "../connection-diagnostics.ts";
+import { syncShellDocumentAttributes$ } from "../theme.ts";
 import {
   featureSwitchCacheState$,
   setFeatureSwitchLocalStorage$,
@@ -169,6 +170,7 @@ const hydrateFeatureSwitch$ = command(
       result.body.effectiveSwitches,
     );
     set(setFeatureSwitchLocalStorage$, JSON.stringify(combined));
+    set(syncShellDocumentAttributes$);
     set(writeConnectionDiagnostic$, {
       action: "set-enabled",
       enabled: combined[FeatureSwitchKey.OkouDebug],

--- a/turbo/apps/platform/src/signals/theme.ts
+++ b/turbo/apps/platform/src/signals/theme.ts
@@ -4,7 +4,9 @@ import {
   type ColorTheme,
   type ThemePreference,
 } from "@okouai/api-contracts/contracts/user-preferences";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { localStorageSignals } from "./external/local-storage.ts";
+import { featureSwitchCacheState$ } from "./external/feature-switch-state.ts";
 import { clerk$ } from "./auth.ts";
 import {
   updateUserPreference$,
@@ -15,6 +17,7 @@ import {
   readOkouThemePreferenceFromDocument,
   writeOkouThemePreferenceToDocument,
 } from "../lib/okou-theme-cookie.ts";
+import { onRef } from "./utils.ts";
 
 export { COLOR_THEMES };
 export type { ColorTheme, ThemePreference };
@@ -34,6 +37,7 @@ function isColorTheme(value: string | null): value is ColorTheme {
 const internalPreference$ = state<ThemePreference>("system");
 const internalResolved$ = state<"light" | "dark">("light");
 const internalColorTheme$ = state<ColorTheme>(DEFAULT_COLOR_THEME);
+const shellDocumentAttributesMounted$ = state(false);
 
 const { get$: themeStorageGet$, set$: themeStorageSet$ } =
   localStorageSignals("theme");
@@ -107,6 +111,7 @@ export const setTheme$ = command(({ set }, preference: ThemePreference) => {
  */
 export const setColorTheme$ = command(({ set }, colorTheme: ColorTheme) => {
   set(internalColorTheme$, colorTheme);
+  set(syncShellDocumentAttributes$);
   if (isOkouHostname(location.hostname)) {
     /* eslint-disable ccstate/no-catch-abort -- synchronous storage access cannot carry an application AbortSignal. */
     // eslint-disable-next-line no-restricted-syntax -- blocked localStorage must not prevent the authenticated theme preference from synchronizing.
@@ -184,7 +189,7 @@ export const syncThemePreferences$ = command(
  * mounted. Document scope lets portaled dialogs and popovers inherit the same
  * semantic tokens as the app shell.
  */
-export function applyColorThemeDocumentAttributes(
+function applyColorThemeDocumentAttributes(
   enabled: boolean,
   colorTheme: ColorTheme,
 ) {
@@ -204,7 +209,7 @@ export function applyColorThemeDocumentAttributes(
  * mounted. Document scope matches the color themes above: portaled dialogs,
  * popovers, and toasts read the same font tokens as the app shell.
  */
-export function applyTypefaceDocumentAttribute(enabled: boolean) {
+function applyTypefaceDocumentAttribute(enabled: boolean) {
   const root = document.documentElement;
 
   if (enabled) {
@@ -220,7 +225,7 @@ export function applyTypefaceDocumentAttribute(enabled: boolean) {
  * sidebars and the workspace card, and portaled dialogs inherit the same
  * sidebar token.
  */
-export function applyNewUiDocumentAttribute(enabled: boolean) {
+function applyNewUiDocumentAttribute(enabled: boolean) {
   const root = document.documentElement;
 
   if (enabled) {
@@ -229,6 +234,47 @@ export function applyNewUiDocumentAttribute(enabled: boolean) {
     delete root.dataset.newUi;
   }
 }
+
+/**
+ * Project the current shell appearance state onto the document. Mount state is
+ * owned by the shell ref; semantic setters call this command again when their
+ * source state changes without replacing the committed shell element.
+ */
+export const syncShellDocumentAttributes$ = command(
+  ({ get, set }, mounted?: boolean): void => {
+    if (mounted !== undefined) {
+      set(shellDocumentAttributesMounted$, mounted);
+    }
+
+    const shellMounted = get(shellDocumentAttributesMounted$);
+    const featureSwitches = get(featureSwitchCacheState$);
+    applyColorThemeDocumentAttributes(
+      shellMounted &&
+        (featureSwitches[FeatureSwitchKey.GradientColorThemes] ?? false),
+      get(colorTheme$),
+    );
+    applyTypefaceDocumentAttribute(
+      shellMounted &&
+        (featureSwitches[FeatureSwitchKey.GeistTypeface] ?? false),
+    );
+    applyNewUiDocumentAttribute(
+      shellMounted && (featureSwitches[FeatureSwitchKey.NewUi] ?? false),
+    );
+  },
+);
+
+export const shellDocumentAttributesRef$ = onRef(
+  command(({ set }, _element: HTMLDivElement, signal: AbortSignal): void => {
+    set(syncShellDocumentAttributes$, true);
+    signal.addEventListener(
+      "abort",
+      () => {
+        set(syncShellDocumentAttributes$, false);
+      },
+      { once: true },
+    );
+  }),
+);
 
 /**
  * Initialize theme from localStorage or system preference.

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -229,6 +229,43 @@ describe("lab page", () => {
     });
   });
 
+  it("updates shell document attributes when a switch changes", async () => {
+    let switches: Partial<Record<FeatureSwitchKey, boolean>> = {
+      [FeatureSwitchKey.Lab]: true,
+      [FeatureSwitchKey.NewUi]: false,
+    };
+    context.mocks.api(featureSwitchesContract.get, ({ respond }) => {
+      return respond(200, { switches, effectiveSwitches: switches });
+    });
+    context.mocks.api(featureSwitchesContract.update, ({ body, respond }) => {
+      switches = { ...switches, ...body.switches };
+      return respond(200, {
+        switches: body.switches,
+        effectiveSwitches: switches,
+      });
+    });
+
+    detachedSetupPage({ context, path: "/_/lab" });
+
+    await waitFor(() => {
+      expect(featureSwitchControl(FeatureSwitchKey.NewUi)).toHaveAttribute(
+        "aria-checked",
+        "false",
+      );
+      expect(document.documentElement.dataset.newUi).toBeUndefined();
+    });
+
+    click(featureSwitchControl(FeatureSwitchKey.NewUi));
+
+    await waitFor(() => {
+      expect(featureSwitchControl(FeatureSwitchKey.NewUi)).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+      expect(document.documentElement.dataset.newUi).toBe("");
+    });
+  });
+
   it("shows feature switches in name order within each rollout stage", async () => {
     context.mocks.api(featureSwitchesContract.get, ({ respond }) => {
       return respond(200, { switches: {}, effectiveSwitches: {} });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/preference-settings.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/preference-settings.test.tsx
@@ -105,6 +105,44 @@ describe("unified preference settings", () => {
     expect(new URLSearchParams(search()).get("settings")).toBe("debug");
   });
 
+  it("updates the shell document color theme", async () => {
+    context.mocks.data.userPreferences({ colorTheme: "blue-horizon" });
+
+    detachedSetupPage({
+      context,
+      path: "/agents?settings=preference",
+      featureSwitches: {
+        [FeatureSwitchKey.GradientColorThemes]: true,
+      },
+    });
+
+    const colorTheme = await screen.findByRole("group", {
+      name: "Color theme",
+    });
+    expect(document.documentElement).toHaveAttribute(
+      "data-color-theme",
+      "blue-horizon",
+    );
+
+    const goldenHourButton = queryAllByRoleFast("button", colorTheme).find(
+      (candidate) => {
+        return candidate.textContent?.trim() === "Golden hour";
+      },
+    );
+    if (!goldenHourButton) {
+      throw new Error("Golden hour button not found");
+    }
+    click(goldenHourButton);
+
+    await waitFor(() => {
+      expect(document.documentElement).toHaveAttribute(
+        "data-color-theme",
+        "golden-hour",
+      );
+      expect(goldenHourButton).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
   it.each([
     {
       morningBrief: false,

--- a/turbo/apps/platform/src/views/okou-page/directed-shared.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-shared.tsx
@@ -14,10 +14,8 @@ import { SettingsDialog } from "./components/settings/settings-dialog.tsx";
 import { AccountDropdown } from "./sidebar-account";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
-  applyColorThemeDocumentAttributes,
-  applyNewUiDocumentAttribute,
-  applyTypefaceDocumentAttribute,
   colorTheme$,
+  shellDocumentAttributesRef$,
 } from "../../signals/theme.ts";
 
 export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
@@ -28,22 +26,11 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
   const features = useGet(featureSwitch$);
   const gradientColorThemesEnabled =
     features[FeatureSwitchKey.GradientColorThemes] ?? false;
-  const geistTypefaceEnabled =
-    features[FeatureSwitchKey.GeistTypeface] ?? false;
-  const newUiEnabled = features[FeatureSwitchKey.NewUi] ?? false;
+  const shellDocumentAttributesRef = useSet(shellDocumentAttributesRef$);
 
   return (
     <div
-      ref={(element) => {
-        applyColorThemeDocumentAttributes(
-          element !== null && gradientColorThemesEnabled,
-          colorTheme,
-        );
-        applyTypefaceDocumentAttribute(
-          element !== null && geistTypefaceEnabled,
-        );
-        applyNewUiDocumentAttribute(element !== null && newUiEnabled);
-      }}
+      ref={shellDocumentAttributesRef}
       className="zero-app zero-viewport-shell flex w-full bg-background"
       data-gradient-color-themes={gradientColorThemesEnabled || undefined}
       data-color-theme={gradientColorThemesEnabled ? colorTheme : undefined}

--- a/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
@@ -50,10 +50,8 @@ import { SubscriptionPurchaseConfirmDialog } from "./components/org-manage/subsc
 import { lightboxUrl$ } from "../../signals/okou-page/attachment-chips.ts";
 import { AttachmentLightbox } from "./attachment-chips.tsx";
 import {
-  applyColorThemeDocumentAttributes,
-  applyNewUiDocumentAttribute,
-  applyTypefaceDocumentAttribute,
   colorTheme$,
+  shellDocumentAttributesRef$,
 } from "../../signals/theme.ts";
 import { SIDEBAR_DESKTOP_MEDIA_QUERY } from "./sidebar-breakpoint.ts";
 
@@ -373,23 +371,12 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
   const features = useGet(featureSwitch$);
   const gradientColorThemesEnabled =
     features[FeatureSwitchKey.GradientColorThemes] ?? false;
-  const geistTypefaceEnabled =
-    features[FeatureSwitchKey.GeistTypeface] ?? false;
-  const newUiEnabled = features[FeatureSwitchKey.NewUi] ?? false;
   const isDesktop = useMediaQuery(SIDEBAR_DESKTOP_MEDIA_QUERY);
+  const shellDocumentAttributesRef = useSet(shellDocumentAttributesRef$);
 
   return (
     <div
-      ref={(element) => {
-        applyColorThemeDocumentAttributes(
-          element !== null && gradientColorThemesEnabled,
-          colorTheme,
-        );
-        applyTypefaceDocumentAttribute(
-          element !== null && geistTypefaceEnabled,
-        );
-        applyNewUiDocumentAttribute(element !== null && newUiEnabled);
-      }}
+      ref={shellDocumentAttributesRef}
       className="zero-app zero-viewport-shell flex w-full bg-background"
       data-gradient-color-themes={gradientColorThemesEnabled || undefined}
       data-color-theme={gradientColorThemesEnabled ? colorTheme : undefined}


### PR DESCRIPTION
## Summary

- replace render-created document-attribute callback refs in both app shell layouts with one stable `onRef` lifecycle
- centralize shell document attribute synchronization in a command and resync it from feature-switch and color-theme setters
- add page-level coverage for live feature-switch and color-theme updates

## Test plan

- `pnpm exec vitest --run apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx apps/platform/src/views/okou-page/__tests__/preference-settings.test.tsx`
- `pnpm --filter @okouai/app exec oxlint --deny-warnings <touched files>`
- `pnpm --filter @okouai/app exec eslint <touched files> --max-warnings 0`
- `pnpm --filter @okouai/app exec tsc -p tsconfig.production.json --noEmit`
- `pnpm --filter @okouai/app exec tsc -p tsconfig.tests.json --noEmit`
- `pnpm --filter @okouai/app exec tsc -p tsconfig.build-config.json --noEmit`
