### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,16 +113,16 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.27.1"
-CLAUDE_CODE_VERSION="2.1.259"
-CODEX_CLI_VERSION="0.153.0"
+CLAUDE_CODE_VERSION="2.1.260"
+CODEX_CLI_VERSION="0.153.2"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
 AGENT_BROWSER_VERSION="0.33.0-vm0.1"
 AGENT_BROWSER_LINUX_X64_SHA256="a9e3fbe24c537960b9ac0d1f358224a10eb70d87a619aec7bcb1175222a46a18"
 AGENT_BROWSER_LINUX_ARM64_SHA256="6a74dba04c299a69d564eae5aff67adc2ffc6fda5ddf672994ff75b73d64a9fe"
 PNPM_VERSION="11.25.0"
-CHROMIUM_VERSION="151.0.7922.173-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260824T110509Z"
+CHROMIUM_VERSION="152.0.7977.75-1~deb12u1"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260903T220410Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.259` to `2.1.260`.
- Update Codex CLI from `0.153.0` to `0.153.2`.
- Update Chromium from `151.0.7922.173-1~deb12u1` to `152.0.7977.75-1~deb12u1`.
- Advance the Debian security snapshot from `20260824T110509Z` to `20260903T220410Z`.

Go, Google Workspace CLI, xurl, agent-browser, and pnpm remain current. Node.js 24 remains the current LTS major, and PostgreSQL 18 remains the current supported major.

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 CARGO_PROFILE_TEST_DEBUG=0 cargo check --manifest-path crates/Cargo.toml -p runner --tests`
- Confirmed Claude Code 2.1.260 standalone binaries and manifest entries for linux-x64 and linux-arm64.
- Confirmed Codex CLI 0.153.2 and its linux-x64 and linux-arm64 packages; executed the published x64 artifact and confirmed `codex-cli 0.153.2`.
- Confirmed Chromium, Chromium Common, and Chromium Sandbox `152.0.7977.75-1~deb12u1` for amd64 and arm64 in the pinned Debian security snapshot.

The focused linked test command was attempted twice, but this 4 GiB runner was killed during test-binary code generation with exit 137 before tests executed. The non-linking test-target check above passed; PR CI will run the linked test suite in its normal environment.
