### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
+checksum = "9c054752dd9e4dc73d0b75748c99ac2d0feafbf2f25c7b0516f03a3534161223"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
+checksum = "8f94d16e797ec62cd999fc9d5942b48fa7050c3093ddadff48e4d7528d16fcb9"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -3388,9 +3388,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]


### PR DESCRIPTION
## Summary

- Update `aws-smithy-runtime-api` from 1.15.0 to 1.16.0.
- Update `aws-smithy-types` from 1.6.2 to 1.6.3.
- Update `tinyvec` from 1.12.0 to 1.13.2.

## Dependencies not updated

- `generic-array` remains at 0.14.7 because `crypto-common` 0.1.7 requires exactly `generic-array = 0.14.7`.

## Manual version bumps

- None. This PR only updates `crates/Cargo.lock`.

## Test status

- `cargo test --workspace --exclude runner --no-fail-fast`: all executed targets and doctests passed except `sandbox-fc`'s `workspace_drive_image::tests::prepare_workspace_drive_image_without_seed_truncates_and_formats_fresh_image` (834 of 835 `sandbox-fc` tests passed). The test requires `mkfs.ext4`, which is unavailable in the current environment.
- `cargo check -p runner --tests`: passed. Runner test execution was not attempted in this constrained environment; all runner test targets compiled successfully.
