### PR TITLE
revert(platform): remove pinned agent preview cache

### DIFF
--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -11,9 +11,6 @@ import { setupBillingRealtime$ } from "./okou-page/billing.ts";
 import { subscribePresentationTemplatesChanged$ } from "./okou-page/presentation-template-library.ts";
 import { subscribeCustomConnectorListChanged$ } from "./okou-page/settings/custom-connectors.ts";
 import { bridgeConnected$ } from "./shared-database-bridge-state.ts";
-import { syncPinnedAgentPreviewCache$ } from "./okou-page/pinned-agents.ts";
-import { isOnboardingGuardedPath } from "./okou-page/onboard-guard.ts";
-import { pathname$ } from "./route.ts";
 
 const runAppRealtimeDaemons$ = command(
   async ({ set }, signal: AbortSignal): Promise<void> => {
@@ -66,16 +63,8 @@ export const setupAuthenticatedBootstrapData$ = command(
     if (!clerk.user || !clerk.organization) {
       return;
     }
-    // Pinned agents depend on onboarding status. Keep exempt bootstrap routes
-    // from expanding the onboarding guard's one-time request boundary.
-    const pinnedAgentPreviewCacheSync = isOnboardingGuardedPath(get(pathname$))
-      ? set(syncPinnedAgentPreviewCache$, signal)
-      : Promise.resolve();
     await get(bridgeConnected$);
     signal.throwIfAborted();
-    await Promise.all([
-      pinnedAgentPreviewCacheSync,
-      set(subscribeEventDrivenChatThreads$, signal),
-    ]);
+    await set(subscribeEventDrivenChatThreads$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/job-detail/delete.ts
+++ b/turbo/apps/platform/src/signals/okou-page/job-detail/delete.ts
@@ -6,7 +6,6 @@ import { accept } from "../../../lib/accept.ts";
 import { agentDetail$ } from "./detail.ts";
 import { reloadAgents$ } from "../../agent.ts";
 import { i18n } from "../../../i18n/index.ts";
-import { syncPinnedAgentPreviewCache$ } from "../pinned-agents.ts";
 
 // ---------------------------------------------------------------------------
 // Delete agent
@@ -37,6 +36,5 @@ export const deleteAgent$ = command(
     // caller navigates away, so reloading it would refetch a deleted agent and
     // surface an "Agent not found" error toast on top of the success toast.
     set(reloadAgents$);
-    await set(syncPinnedAgentPreviewCache$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/job-detail/settings.ts
+++ b/turbo/apps/platform/src/signals/okou-page/job-detail/settings.ts
@@ -4,7 +4,6 @@ import { apiClient$ } from "../../api-client.ts";
 import { accept } from "../../../lib/accept.ts";
 import { agentDetail$, reloadAgentDetail$ } from "./detail.ts";
 import { reloadAgentById$, reloadAgents$ } from "../../agent.ts";
-import { syncPinnedAgentPreviewCache$ } from "../pinned-agents.ts";
 
 // ---------------------------------------------------------------------------
 // Settings: update agent metadata (displayName, sound)
@@ -42,6 +41,5 @@ export const updateAgentSettings$ = command(
     set(reloadAgentDetail$);
     set(reloadAgents$);
     set(reloadAgentById$);
-    await set(syncPinnedAgentPreviewCache$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/okou-page/onboard-guard.ts
@@ -60,7 +60,7 @@ const onboardingGuardedPathMatchers = ONBOARDING_GUARDED_PATHS.map((path) => {
   return match(path, { decode: decodeURIComponent });
 });
 
-export function isOnboardingGuardedPath(pathname: string): boolean {
+function isOnboardingGuardedPath(pathname: string): boolean {
   return onboardingGuardedPathMatchers.some((matcher) => {
     return matcher(pathname);
   });

--- a/turbo/apps/platform/src/signals/okou-page/pinned-agents.ts
+++ b/turbo/apps/platform/src/signals/okou-page/pinned-agents.ts
@@ -1,66 +1,12 @@
-import { command, computed, state } from "ccstate";
-import { z } from "zod";
+import { command, computed } from "ccstate";
 import { onboardingStatus$ } from "./onboarding.ts";
 import { defaultAgentId$, sortedAgents$, subagents$ } from "../agent.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
 import { unreadAgentIds$ } from "../chat-page/chat-thread-indicators-from-worker.ts";
-import { clerk$, currentOrgInfo$, currentUserInfo$ } from "../auth.ts";
-import { localStorageSignals } from "../external/local-storage.ts";
-import { bestEffort, jsonParseOr } from "../utils.ts";
 import {
   updateUserPreference$,
   userPreferences$,
 } from "./settings/user-preferences.ts";
-
-const PINNED_AGENT_PREVIEW_CACHE_VERSION = 1;
-const MAX_CACHED_PINNED_AGENT_PREVIEWS = 100;
-const pinnedAgentPreviewCacheSchema = z
-  .object({
-    version: z.literal(PINNED_AGENT_PREVIEW_CACHE_VERSION),
-    userId: z.string().min(1),
-    orgId: z.string().min(1),
-    defaultAgentId: z.string().nullable(),
-    agents: z
-      .array(
-        z
-          .object({
-            agentId: z.string().min(1),
-            displayName: z.string().nullable(),
-            avatarUrl: z.string().nullable(),
-          })
-          .strict(),
-      )
-      .max(MAX_CACHED_PINNED_AGENT_PREVIEWS),
-  })
-  .strict();
-
-export interface PinnedAgentPreview {
-  readonly agentId: string;
-  readonly displayName: string | null;
-  readonly avatarUrl: string | null;
-}
-
-export interface PinnedAgentPreviewSnapshot {
-  readonly defaultAgentId: string | null;
-  readonly agents: readonly PinnedAgentPreview[];
-}
-
-const {
-  get$: pinnedAgentPreviewCacheRaw$,
-  set$: setPinnedAgentPreviewCacheRaw$,
-} = localStorageSignals("vm0:pinned-agent-preview-cache:v1");
-const pinnedAgentPreviewCacheSyncGeneration$ = state(0);
-
-const parsedPinnedAgentPreviewCache$ = computed((get) => {
-  const raw = get(pinnedAgentPreviewCacheRaw$);
-  if (raw === null) {
-    return null;
-  }
-  const parsed = pinnedAgentPreviewCacheSchema.safeParse(
-    jsonParseOr<unknown>(raw, null),
-  );
-  return parsed.success ? parsed.data : null;
-});
 
 /**
  * Pinned agent IDs fetched from user preferences API.
@@ -107,78 +53,6 @@ export const pinnedAgents$ = computed(async (get) => {
     });
 });
 
-/**
- * Last authoritative pinned-agent presentation for the active user and org.
- * This cache intentionally excludes unread state and unread-only agents.
- */
-export const cachedPinnedAgentPreviewSnapshot$ = computed(async (get) => {
-  const cached = get(parsedPinnedAgentPreviewCache$);
-  if (cached === null) {
-    return null;
-  }
-  const [user, organization] = await Promise.all([
-    get(currentUserInfo$),
-    get(currentOrgInfo$),
-  ]);
-  if (user?.id !== cached.userId || organization?.id !== cached.orgId) {
-    return null;
-  }
-  return {
-    defaultAgentId: cached.defaultAgentId,
-    agents: cached.agents,
-  } satisfies PinnedAgentPreviewSnapshot;
-});
-
-const persistPinnedAgentPreviewCache$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const generation = get(pinnedAgentPreviewCacheSyncGeneration$) + 1;
-    set(pinnedAgentPreviewCacheSyncGeneration$, generation);
-    const clerk = await get(clerk$);
-    signal.throwIfAborted();
-    const userId = clerk.user?.id;
-    const orgId = clerk.organization?.id;
-    if (!userId || !orgId) {
-      return;
-    }
-
-    const [agents, defaultAgentId] = await Promise.all([
-      get(pinnedAgents$),
-      get(defaultAgentId$),
-    ]);
-    signal.throwIfAborted();
-    if (
-      get(pinnedAgentPreviewCacheSyncGeneration$) !== generation ||
-      clerk.user?.id !== userId ||
-      clerk.organization?.id !== orgId
-    ) {
-      return;
-    }
-    const serialized = JSON.stringify({
-      version: PINNED_AGENT_PREVIEW_CACHE_VERSION,
-      userId,
-      orgId,
-      defaultAgentId,
-      agents: agents.slice(0, MAX_CACHED_PINNED_AGENT_PREVIEWS).map((agent) => {
-        return {
-          agentId: agent.agentId,
-          displayName: agent.displayName ?? null,
-          avatarUrl: agent.avatarUrl ?? null,
-        };
-      }),
-    });
-    if (get(pinnedAgentPreviewCacheRaw$) !== serialized) {
-      set(setPinnedAgentPreviewCacheRaw$, serialized);
-    }
-  },
-);
-
-/** Refresh the local preview cache without making cache failures user-facing. */
-export const syncPinnedAgentPreviewCache$ = command(
-  async ({ set }, signal: AbortSignal) => {
-    await bestEffort(set(persistPinnedAgentPreviewCache$, signal), signal);
-  },
-);
-
 export const displayedPinnedAgents$ = computed(async (get) => {
   const pinnedAgents = await get(pinnedAgents$);
   const unreadAgentIds = await get(unreadAgentIds$);
@@ -221,8 +95,6 @@ export const setAgentPinned$ = command(
     }
 
     await set(updateUserPreference$, { pinnedAgentIds: [...next] }, signal);
-    signal.throwIfAborted();
-    await set(syncPinnedAgentPreviewCache$, signal);
   },
 );
 
@@ -259,8 +131,6 @@ export const movePinnedAgent$ = command(
     next.splice(from, 1);
     next.splice(to, 0, agentId);
     await set(updateUserPreference$, { pinnedAgentIds: next }, signal);
-    signal.throwIfAborted();
-    await set(syncPinnedAgentPreviewCache$, signal);
   },
 );
 

--- a/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { localStorageSignals } from "../external/local-storage.ts";
+import { onDomEventFn, onRef } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Chat navigation search query
@@ -250,6 +251,49 @@ export const setAgentCardCollapsed$ = command(({ set }, collapsed: boolean) => {
     set(clearAgentCardCollapsed$);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Pinned agent grid rows (three-column sidebar) — persisted in localStorage
+// ---------------------------------------------------------------------------
+export const PINNED_AGENT_GRID_COLUMNS = 5;
+
+const { get$: pinnedAgentGridRowsRaw$, set$: setPinnedAgentGridRowsRaw$ } =
+  localStorageSignals("pinnedAgentGridRows");
+export const pinnedAgentGridRows$ = computed((get) => {
+  const rows = Number(get(pinnedAgentGridRowsRaw$));
+  return Number.isSafeInteger(rows) && rows > 0 ? rows : 1;
+});
+const cachePinnedAgentGridRowsFromElement$ = command(
+  ({ get, set }, element: HTMLDivElement) => {
+    const rows = Math.max(
+      1,
+      Math.ceil(element.childElementCount / PINNED_AGENT_GRID_COLUMNS),
+    );
+    const next = String(rows);
+    if (get(pinnedAgentGridRowsRaw$) === next) {
+      return;
+    }
+    set(setPinnedAgentGridRowsRaw$, next);
+  },
+);
+export const cachePinnedAgentGridRowsRef$ = onRef(
+  command(({ set }, element: HTMLDivElement, signal: AbortSignal) => {
+    set(cachePinnedAgentGridRowsFromElement$, element);
+    const observer = new MutationObserver(
+      onDomEventFn(() => {
+        set(cachePinnedAgentGridRowsFromElement$, element);
+      }),
+    );
+    observer.observe(element, { childList: true });
+    signal.addEventListener(
+      "abort",
+      () => {
+        observer.disconnect();
+      },
+      { once: true },
+    );
+  }),
+);
 
 // ---------------------------------------------------------------------------
 // Chat thread virtual list geometry (RecentChatSection)

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { agentsMainContract } from "@okouai/api-contracts/contracts/agents";
 import {
@@ -11,7 +11,6 @@ import {
   queryAllByRoleFast,
   setupPage,
 } from "../../../__tests__/page-helper.ts";
-import { localStorageSignals } from "../../../signals/external/local-storage.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   CHAT_LIST_AGENT_ID,
@@ -27,102 +26,6 @@ import {
 } from "./chat-list-test-helpers.ts";
 
 const context = testContext();
-const { set$: setPinnedAgentPreviewCache$ } = localStorageSignals(
-  "vm0:pinned-agent-preview-cache:v1",
-);
-
-test("Cached pinned agents remain visible while live details load", async () => {
-  const auth = chatListAuth(20);
-  const agents = context.mocks.deferred<void>();
-  const cachedAvatarUrl = "https://cdn.example.test/cached-agent.png";
-  context.store.set(
-    setPinnedAgentPreviewCache$,
-    JSON.stringify({
-      version: 1,
-      userId: "chat-list-user-20",
-      orgId: "chat-list-org-20",
-      defaultAgentId: CHAT_LIST_AGENT_ID,
-      agents: [
-        {
-          agentId: CHAT_LIST_AGENT_ID,
-          displayName: "Cached list agent",
-          avatarUrl: cachedAvatarUrl,
-        },
-      ],
-    }),
-  );
-  context.mocks.data.onboardingStatus({
-    defaultAgentId: CHAT_LIST_AGENT_ID,
-  });
-  installChatListStream(context, { caseId: 20, snapshot: [] });
-  installChatListAgent(context, agents.promise);
-
-  await setupPage({
-    context,
-    path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth,
-  });
-
-  const pinnedAgents = await screen.findByTestId("pinned-agents-grid");
-  await waitFor(() => {
-    expect(within(pinnedAgents).getByText("Cached list agent")).toBeVisible();
-  });
-  expect(
-    within(pinnedAgents).getByTestId("pinned-agent-avatar"),
-  ).toHaveAttribute("src", cachedAvatarUrl);
-  expect(agents.settled()).toBeFalsy();
-
-  agents.resolve(undefined);
-
-  await waitFor(() => {
-    expect(within(pinnedAgents).getByText("List agent")).toBeVisible();
-  });
-  expect(within(pinnedAgents).queryByText("Cached list agent")).toBeNull();
-  expect(
-    within(pinnedAgents).getByTestId("pinned-agent-avatar"),
-  ).not.toHaveAttribute("src");
-});
-
-test("Do not reveal cached pinned agents from another workspace", async () => {
-  const auth = chatListAuth(21);
-  const agents = context.mocks.deferred<void>();
-  context.store.set(
-    setPinnedAgentPreviewCache$,
-    JSON.stringify({
-      version: 1,
-      userId: "chat-list-user-21",
-      orgId: "another-chat-list-org",
-      defaultAgentId: CHAT_LIST_AGENT_ID,
-      agents: [
-        {
-          agentId: CHAT_LIST_AGENT_ID,
-          displayName: "Another workspace agent",
-          avatarUrl: null,
-        },
-      ],
-    }),
-  );
-  context.mocks.data.onboardingStatus({
-    defaultAgentId: CHAT_LIST_AGENT_ID,
-  });
-  installChatListStream(context, { caseId: 21, snapshot: [] });
-  installChatListAgent(context, agents.promise);
-
-  await setupPage({
-    context,
-    path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth,
-  });
-
-  const pinnedAgents = await screen.findByTestId("pinned-agents-grid");
-  expect(
-    within(pinnedAgents).queryByText("Another workspace agent"),
-  ).toBeNull();
-  expect(
-    within(pinnedAgents).getAllByTestId("pinned-agent-skeleton"),
-  ).toHaveLength(4);
-  expect(agents.settled()).toBeFalsy();
-});
 
 test("Cached conversations appear before remote synchronization", async () => {
   const auth = chatListAuth(1);

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -2,11 +2,9 @@
 // oxlint-disable max-lines-per-function
 import {
   useGet,
-  useLoadable,
   useSet,
   useLastResolved,
   useLastLoadable,
-  type Loadable,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Plus, ChevronRight, Pin, PinOff, CheckCheck } from "lucide-react";
@@ -29,6 +27,9 @@ import { pathParams$ } from "../../signals/route.ts";
 import {
   agentCardCollapsed$,
   setAgentCardCollapsed$,
+  pinnedAgentGridRows$,
+  cachePinnedAgentGridRowsRef$,
+  PINNED_AGENT_GRID_COLUMNS,
   openPinAgentDialog$,
   pinAgentDialogOpen$,
   setPinAgentDialogOpen$,
@@ -44,15 +45,13 @@ import {
   setAgentPinned$,
   movePinnedAgent$,
   pinnedAgents$,
-  cachedPinnedAgentPreviewSnapshot$,
-  type PinnedAgentPreviewSnapshot,
 } from "../../signals/okou-page/pinned-agents.ts";
 import { unreadAgentIds$ } from "../../signals/chat-page/chat-thread-indicators-from-worker.ts";
 import { markAgentThreadsRead$ } from "../../signals/chat-page/sidebar-unread-threads.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { equalSets } from "../../lib/equality.ts";
-import { AvatarFromUrl } from "./sidebar-shared.tsx";
+import { AgentAvatarImg } from "./sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
 import { PinAgentDialog } from "./sidebar-dialogs.tsx";
 import {
@@ -191,43 +190,6 @@ function PinnedAgentContextDecorator({
 interface PinnedGridAgent {
   readonly agentId: string;
   readonly displayName?: string | null;
-  readonly avatarUrl?: string | null;
-}
-
-function loadableData<T>(loadable: Loadable<T>): T | undefined {
-  return loadable.state === "hasData" ? loadable.data : undefined;
-}
-
-function resolvePinnedAgentPresentation({
-  pinnedAgentsLoadable,
-  displayedPinnedAgentsLoadable,
-  cachedPreviewLoadable,
-  defaultAgentId,
-}: {
-  readonly pinnedAgentsLoadable: Loadable<readonly PinnedGridAgent[]>;
-  readonly displayedPinnedAgentsLoadable: Loadable<readonly PinnedGridAgent[]>;
-  readonly cachedPreviewLoadable: Loadable<PinnedAgentPreviewSnapshot | null>;
-  readonly defaultAgentId: string | null | undefined;
-}) {
-  const livePinnedAgents = loadableData(pinnedAgentsLoadable);
-  const cachedPreview = loadableData(cachedPreviewLoadable);
-  const pinnedAgents = livePinnedAgents ?? cachedPreview?.agents ?? [];
-  const loadingWithoutCache =
-    livePinnedAgents === undefined &&
-    (cachedPreview === null || cachedPreview === undefined) &&
-    (pinnedAgentsLoadable.state === "loading" ||
-      cachedPreviewLoadable.state === "loading");
-  const basePinnedAgents = loadingWithoutCache ? null : pinnedAgents;
-  return {
-    displayedAgents:
-      loadableData(displayedPinnedAgentsLoadable) ?? basePinnedAgents,
-    pinnedAgentIds: new Set(
-      pinnedAgents.map((agent) => {
-        return agent.agentId;
-      }),
-    ),
-    defaultAgentId: defaultAgentId ?? cachedPreview?.defaultAgentId,
-  };
 }
 
 /** Which side of the hovered card the dragged agent lands on. */
@@ -382,11 +344,10 @@ function PinnedAgentGridCard({
         />
       )}
       <span className={`relative ${isDragging ? "opacity-0" : ""}`}>
-        <AvatarFromUrl
-          avatarUrl={agent.avatarUrl}
+        <AgentAvatarImg
+          name={agent.agentId}
           alt=""
           className="h-9 w-9 rounded-full object-cover object-top"
-          data-testid="pinned-agent-avatar"
         />
         {hasUnread && (
           <span className="absolute -right-0.5 -top-0.5 flex">
@@ -484,9 +445,6 @@ export function PinnedAgentListSection({
   const sidebarAgentId = useLastResolved(currentChatAgentId$) ?? null;
   const pinnedAgentsLoadable = useLastLoadable(pinnedAgents$);
   const displayedPinnedAgentsLoadable = useLastLoadable(displayedPinnedAgents$);
-  const cachedPinnedAgentPreviewLoadable = useLoadable(
-    cachedPinnedAgentPreviewSnapshot$,
-  );
   const unreadAgentIds = useLastResolved(unreadAgentIds$, {
     equalityFn: equalSets,
   });
@@ -495,34 +453,46 @@ export function PinnedAgentListSection({
   const setExpanded = useSet(setSidebarExpanded$);
   const collapsed = useGet(agentCardCollapsed$);
   const setCollapsed = useSet(setAgentCardCollapsed$);
+  const cachedPinnedAgentGridRows = useGet(pinnedAgentGridRows$);
+  const cachePinnedAgentGridRowsRef = useSet(cachePinnedAgentGridRowsRef$);
   const draggingAgentId = useGet(draggingPinnedAgentId$);
   const dropTargetAgentId = useGet(pinnedAgentDropTargetId$);
   const defaultAgentId = useLastResolved(defaultAgentId$);
-  const pinnedAgentPresentation = resolvePinnedAgentPresentation({
-    pinnedAgentsLoadable,
-    displayedPinnedAgentsLoadable,
-    cachedPreviewLoadable: cachedPinnedAgentPreviewLoadable,
-    defaultAgentId,
-  });
-  const displayedPinnedAgents = pinnedAgentPresentation.displayedAgents;
-  const pinnedAgentIds = pinnedAgentPresentation.pinnedAgentIds;
-  const resolvedDefaultAgentId = pinnedAgentPresentation.defaultAgentId;
+  const pinnedAgents =
+    pinnedAgentsLoadable.state === "hasData" ? pinnedAgentsLoadable.data : [];
+  const pinnedAgentIds = new Set(
+    pinnedAgents.map((agent) => {
+      return agent.agentId;
+    }),
+  );
+  const displayedPinnedAgents =
+    displayedPinnedAgentsLoadable.state === "hasData"
+      ? displayedPinnedAgentsLoadable.data
+      : pinnedAgents;
 
   const selectedAgentId = routeAgentId ?? sidebarAgentId;
 
   if (layout === "horizontal") {
-    const horizontalPinnedAgents = displayedPinnedAgents;
+    const horizontalPinnedAgents =
+      displayedPinnedAgentsLoadable.state === "loading"
+        ? null
+        : displayedPinnedAgents;
     const pinnedAgentCards =
       horizontalPinnedAgents === null
-        ? Array.from({ length: 4 }, (_, index) => {
-            return <PinnedAgentGridSkeletonCard key={index} />;
-          })
+        ? Array.from(
+            {
+              length: cachedPinnedAgentGridRows * PINNED_AGENT_GRID_COLUMNS - 1,
+            },
+            (_, index) => {
+              return <PinnedAgentGridSkeletonCard key={index} />;
+            },
+          )
         : horizontalPinnedAgents.map((agent) => {
             const isPrimarySelected =
               isChatRoute(activeRoute) && selectedAgentId === agent.agentId;
             const hasUnread = unreadAgentIds?.has(agent.agentId) ?? false;
             const isPinned = pinnedAgentIds.has(agent.agentId);
-            const isDefaultAgent = agent.agentId === resolvedDefaultAgentId;
+            const isDefaultAgent = agent.agentId === defaultAgentId;
             return (
               <PinnedAgentContextDecorator
                 key={agent.agentId}
@@ -555,6 +525,7 @@ export function PinnedAgentListSection({
           })}
         </span>
         <div
+          ref={cachePinnedAgentGridRowsRef}
           className="grid min-w-0 grid-cols-5 items-start gap-x-1 gap-y-2.5"
           data-testid="pinned-agents-grid"
         >
@@ -607,7 +578,7 @@ export function PinnedAgentListSection({
       </div>
       {!collapsed && (
         <div className="flex flex-col gap-0.5 mt-1">
-          {displayedPinnedAgents === null && (
+          {pinnedAgentsLoadable.state === "loading" && (
             <>
               <div className="flex h-8 items-center gap-2 px-2">
                 <div className="h-5 w-5 shrink-0 rounded-md bg-muted animate-pulse" />
@@ -619,14 +590,14 @@ export function PinnedAgentListSection({
               </div>
             </>
           )}
-          {displayedPinnedAgents !== null &&
+          {pinnedAgentsLoadable.state === "hasData" &&
             displayedPinnedAgents.map((agent) => {
               const isPrimarySelected =
                 isChatRoute(activeRoute) && selectedAgentId === agent.agentId;
               const isFromChat = sidebarAgentId === agent.agentId;
               const isPinned = pinnedAgentIds.has(agent.agentId);
               const hasUnread = unreadAgentIds?.has(agent.agentId) ?? false;
-              const isDefaultAgent = agent.agentId === resolvedDefaultAgentId;
+              const isDefaultAgent = agent.agentId === defaultAgentId;
               const hasSideActions = hasUnread || (!isDefaultAgent && isPinned);
               return (
                 <div
@@ -654,11 +625,10 @@ export function PinnedAgentListSection({
                           : "text-sidebar-foreground hover:bg-state-hover"
                     }`}
                   >
-                    <AvatarFromUrl
-                      avatarUrl={agent.avatarUrl}
+                    <AgentAvatarImg
+                      name={agent.agentId}
                       alt={agent.displayName ?? agent.agentId}
                       className="h-5 w-5 shrink-0 rounded-md object-cover object-top"
-                      data-testid="pinned-agent-avatar"
                     />
                     <span className="zero-nav-copy truncate">
                       {agent.displayName ?? agent.agentId}


### PR DESCRIPTION
## Summary

- revert the persisted pinned-agent preview cache introduced by #31506
- restore the previous row-count skeleton behavior while authoritative pinned-agent data loads
- remove the cache-specific tests moved by #31160 while preserving its remaining GWT coverage

## Verification

- `pnpm prettier --write --ignore-unknown` on all touched files
- `pnpm exec oxlint --deny-warnings src/views/okou-page/__tests__/chat-list-cache.test.tsx`
- `pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings src/views/okou-page/__tests__/chat-list-cache.test.tsx`
- `pnpm exec eslint src/views/okou-page/__tests__/chat-list-cache.test.tsx --max-warnings 0`
- `pnpm -F @okouai/app check-types`
- `pnpm knip`
- commitlint validation
- verified the seven original production files match the parent of the #31506 squash commit exactly

Vitest was not run locally per repository guidance; the PR pipeline will run it.