### PR TITLE
feat(app): enable production clerk edge sessions

### DIFF
--- a/.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh
@@ -11,6 +11,8 @@ python3 - \
   "${repo_root}/.github/scripts/verify-okou-production-domains.sh" \
   "${repo_root}/turbo/apps/app-worker/wrangler.jsonc" <<'PY'
 from pathlib import Path
+import os
+import subprocess
 import sys
 
 import yaml
@@ -162,6 +164,56 @@ if retire_domains_step.get("env", {}).get("CLOUDFLARE_API_TOKEN") != (
     raise RuntimeError("domain retirement must use the Worker token")
 if retire_domains_source.count("--request DELETE") != 1:
     raise RuntimeError("domain retirement must use one guarded deletion path")
+
+idempotency_probe_source = r'''
+curl() {
+  local args=" $* "
+  case "$args" in
+    *" --request DELETE "*)
+      if [[ "$args" != *"/workers/domains/0123456789abcdef0123456789abcdef"* ]]; then
+        echo "unexpected Worker domain deletion: $args" >&2
+        return 99
+      fi
+      printf '%s\n' '{"success":true}'
+      ;;
+    *" hostname=app-worker.okou.ai "*)
+      printf '%s\n' '{"success":true,"result":[]}'
+      ;;
+    *" hostname=app-worker.vm0.ai "*)
+      printf '%s\n' '{"success":true,"result":[{"hostname":"app-worker.vm0.ai","service":"okou-app-production","id":"0123456789abcdef0123456789abcdef"}]}'
+      ;;
+    *)
+      echo "unexpected Cloudflare request: $args" >&2
+      return 99
+      ;;
+  esac
+}
+''' + retire_domains_source
+idempotency_probe = subprocess.run(
+    ["bash", "-c", idempotency_probe_source],
+    check=False,
+    capture_output=True,
+    text=True,
+    env={
+        **os.environ,
+        "CLOUDFLARE_ACCOUNT_ID": "test-account",
+        "CLOUDFLARE_API_TOKEN": "test-token",
+    },
+)
+if idempotency_probe.returncode != 0:
+    raise RuntimeError(
+        "domain retirement must tolerate a partially completed retry:\n"
+        f"{idempotency_probe.stderr}"
+    )
+expected_idempotency_output = (
+    "Worker custom domain is already retired: app-worker.okou.ai\n"
+    "Retired Worker custom domain: app-worker.vm0.ai\n"
+)
+if idempotency_probe.stdout != expected_idempotency_output:
+    raise RuntimeError(
+        "domain retirement produced unexpected retry output:\n"
+        f"{idempotency_probe.stdout}"
+    )
 if start_step.get("with", {}).get("env") != "app/production":
     raise RuntimeError("production Worker must own the canonical App deployment")
 if finish_step.get("with", {}).get("status") != "${{ job.status }}":

--- a/.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh
@@ -81,6 +81,9 @@ verify_assets_step = find_step(
 )
 sentry_step = find_step(worker_release_job, "Upload App source maps to Sentry")
 deploy_step = find_step(worker_release_job, "Deploy App Worker production")
+retire_domains_step = find_step(
+    worker_release_job, "Retire App Worker diagnostic domains"
+)
 start_step = find_step(worker_release_job, "Start GitHub Deployment")
 finish_step = find_step(worker_release_job, "Finish GitHub Deployment")
 
@@ -128,8 +131,6 @@ deploy_source = require_fragments(
         '--message "app artifact ${ARTIFACT_SHA}"',
         '"https://app.vm0.ai|https://api.vm0.ai"',
         '"https://app.okou.ai|https://api.okou.ai"',
-        '"https://app-worker.vm0.ai|https://api.vm0.ai"',
-        '"https://app-worker.okou.ai|https://api.okou.ai"',
         "Access-Control-Request-Method: GET",
         "%header{access-control-allow-origin}",
         "%header{access-control-allow-credentials}",
@@ -141,6 +142,26 @@ if deploy_step.get("env", {}).get("CLOUDFLARE_API_TOKEN") != (
     "${{ secrets.CF_API_WORKER_DEPLOY_API_TOKEN }}"
 ):
     raise RuntimeError("production Worker deployment must use the Worker token")
+retire_domains_source = require_fragments(
+    retire_domains_step,
+    [
+        'retire_custom_domain "app-worker.okou.ai"',
+        'retire_custom_domain "app-worker.vm0.ai"',
+        "/workers/domains",
+        '--data-urlencode "hostname=${hostname}"',
+        ".service",
+        '"okou-app-production"',
+        '^[0-9a-f]{32}$',
+        "--request DELETE",
+        ".success == true",
+    ],
+)
+if retire_domains_step.get("env", {}).get("CLOUDFLARE_API_TOKEN") != (
+    "${{ secrets.CF_API_WORKER_DEPLOY_API_TOKEN }}"
+):
+    raise RuntimeError("domain retirement must use the Worker token")
+if retire_domains_source.count("--request DELETE") != 1:
+    raise RuntimeError("domain retirement must use one guarded deletion path")
 if start_step.get("with", {}).get("env") != "app/production":
     raise RuntimeError("production Worker must own the canonical App deployment")
 if finish_step.get("with", {}).get("status") != "${{ job.status }}":
@@ -152,6 +173,7 @@ if not (
     < steps.index(verify_assets_step)
     < steps.index(sentry_step)
     < steps.index(deploy_step)
+    < steps.index(retire_domains_step)
     < steps.index(finish_step)
 ):
     raise RuntimeError("Worker artifact verification must precede deployment reporting")
@@ -184,9 +206,6 @@ for fragment in (
     '"zone_name": "okou.ai"',
     '"pattern": "app.vm0.ai/*"',
     '"zone_name": "vm0.ai"',
-    '"pattern": "app-worker.okou.ai"',
-    '"pattern": "app-worker.vm0.ai"',
-    '"custom_domain": true',
 ):
     if fragment not in worker_config_source:
         raise RuntimeError(f"production Worker config is missing: {fragment}")

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -333,6 +333,7 @@ function assertNoClerkSecrets(snapshot) {
     "jwt-cookie-must-not-render",
     "dev-browser-jwt-must-not-render",
     "sk_test_secret-must-not-render",
+    "sk_live_secret-must-not-render",
     "session-token-must-not-render",
     "sess_must-not-render",
     "claim-must-not-render",
@@ -457,19 +458,6 @@ assertBootstrapAvatar(okouPage.html);
 assert.equal(clerkCoreScript(okouPage.html), expectedClerkCoreScript);
 assert.equal(clerkBootstrap(okouPage.html), expectedClerkBootstrap);
 
-for (const [origin, brandName] of [
-  ["https://app-worker.vm0.ai", "VM0"],
-  ["https://app-worker.okou.ai", "Okou"],
-]) {
-  const canaryPage = await requestAppPage(origin);
-  assert.equal(canaryPage.response.status, 200);
-  assert.equal(
-    htmlAttribute(canaryPage.html, "data-app-brand-name"),
-    brandName,
-  );
-  assert.equal(clerkBootstrap(canaryPage.html), expectedClerkBootstrap);
-}
-
 const okouPreview = await requestAppPage(
   "https://pr-25304-app-okou-app-preview.vm0.workers.dev",
   "okou",
@@ -567,10 +555,8 @@ const duplicateFlag = await responseSnapshot(
 assert.deepEqual(duplicateFlag, edgeDebugBaseline);
 
 for (const ineligibleOrigin of [
-  "https://app.okou.ai",
-  "https://app.vm0.ai",
-  "https://app-worker.okou.ai",
-  "https://app-worker.vm0.ai",
+  "http://app.okou.ai",
+  "https://app.okou.ai.evil.example",
   "https://pr-25304-app.omby.ai",
   "https://staging-app-okou-app-preview.vm0.workers.dev",
 ]) {
@@ -761,6 +747,71 @@ assert.deepEqual(Object.keys(clerkEdgeSessionJson(authenticated.body)).sort(), [
   "userId",
 ]);
 assertNoClerkSecrets(authenticated);
+
+for (const [productionOrigin, publicBrand] of [
+  ["https://app.okou.ai", "okou"],
+  ["https://app.vm0.ai", "vm0"],
+]) {
+  const productionEdgeUrl = `${productionOrigin}/settings/profile`;
+  const productionEdgeEnvironment = {
+    CLERK_PUBLISHABLE_KEY: productionClerkPublishableKey,
+    CLERK_SECRET_KEY: "sk_live_secret-must-not-render",
+    PUBLIC_BRAND: publicBrand,
+  };
+  let clerkClientFactoryCalls = 0;
+  const productionEdgeWorker = workerModule.createWorker(
+    embeddedShell,
+    ({ publishableKey, secretKey, telemetry }) => {
+      clerkClientFactoryCalls += 1;
+      assert.equal(publishableKey, productionClerkPublishableKey);
+      assert.equal(secretKey, "sk_live_secret-must-not-render");
+      assert.equal(telemetry?.disabled, true);
+      return {
+        authenticateRequest(request, options) {
+          assert.equal(
+            request.url,
+            `${productionEdgeUrl}?__clerk_edge_debug=1`,
+          );
+          assert.equal(options.acceptsToken, "session_token");
+          assert.deepEqual(options.authorizedParties, [productionOrigin]);
+          return Promise.resolve({
+            headers: new Headers(),
+            isAuthenticated: true,
+            toAuth() {
+              return {
+                orgId: "org_production",
+                userId: "user_production",
+              };
+            },
+          });
+        },
+      };
+    },
+  );
+  const productionBaseline = await responseSnapshot(
+    productionEdgeWorker,
+    productionEdgeUrl,
+    productionEdgeEnvironment,
+  );
+  assert.equal(clerkClientFactoryCalls, 0);
+  assert.doesNotMatch(productionBaseline.body, /vm0-clerk-edge-session/u);
+
+  const productionAuthenticated = await responseSnapshot(
+    productionEdgeWorker,
+    `${productionEdgeUrl}?__clerk_edge_debug=1`,
+    productionEdgeEnvironment,
+  );
+  assert.equal(clerkClientFactoryCalls, 1);
+  assert.deepEqual(clerkEdgeSessionJson(productionAuthenticated.body), {
+    userId: "user_production",
+    orgId: "org_production",
+  });
+  assert.equal(
+    new Headers(productionAuthenticated.headers).get("Cache-Control"),
+    "private, no-store",
+  );
+  assertNoClerkSecrets(productionAuthenticated);
+}
 
 const authenticatedWithoutOrganization = await responseSnapshot(
   workerModule.createWorker(
@@ -969,21 +1020,6 @@ assert.equal(
   null,
 );
 const productionHtml = await production.response.text();
-
-const canaryProduction = await requestSharedPage({
-  appOrigin: "https://app-worker.okou.ai",
-  metaResponse() {
-    return Response.json({
-      title: "Canary production conversation",
-      publicBrand: "okou",
-    });
-  },
-});
-assert.equal(canaryProduction.response.status, 200);
-assert.equal(
-  canaryProduction.observedUrl,
-  `https://api.okou.ai/api/shared-threads/${sharedThreadId}/meta`,
-);
 
 const vm0SharedOnOkouHost = await requestSharedPage({
   appOrigin: "https://app.okou.ai",

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1712,7 +1712,7 @@ jobs:
                 "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/domains"
             )"
             domain_record="$(
-              jq -cer --arg hostname "$hostname" '
+              jq -cr --arg hostname "$hostname" '
                 if .success != true then
                   error("Cloudflare domain lookup failed")
                 else

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1478,8 +1478,8 @@ jobs:
 
           echo "Published runtime API schema for $RELEASE_SHA"
 
-  # The Worker owns the live App routes and direct canary domains. App releases
-  # must wait for the canonical build artifact and API production lifecycle.
+  # The Worker owns the live App routes. App releases must wait for the
+  # canonical build artifact and API production lifecycle.
   promote-app-worker-production:
     needs: [release-please, builds-complete, promote-api-production]
     if: >-
@@ -1664,9 +1664,7 @@ jobs:
 
           for mapping in \
             "https://app.vm0.ai|https://api.vm0.ai" \
-            "https://app.okou.ai|https://api.okou.ai" \
-            "https://app-worker.vm0.ai|https://api.vm0.ai" \
-            "https://app-worker.okou.ai|https://api.okou.ai"; do
+            "https://app.okou.ai|https://api.okou.ai"; do
             IFS='|' read -r app_origin api_origin <<< "$mapping"
             cors_result="$(
               curl -fsS \
@@ -1691,6 +1689,66 @@ jobs:
             fi
           done
 
+      - name: Retire App Worker diagnostic domains
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CF_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_WORKER_DEPLOY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          : "${CLOUDFLARE_ACCOUNT_ID:?CF_ACCOUNT_ID variable is required}"
+          : "${CLOUDFLARE_API_TOKEN:?CF_API_WORKER_DEPLOY_API_TOKEN secret is required}"
+
+          retire_custom_domain() {
+            local hostname="$1"
+            local domain_id
+            local domain_record
+            local domain_response
+
+            domain_response="$(
+              curl -fsS --get \
+                --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+                --data-urlencode "hostname=${hostname}" \
+                "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/domains"
+            )"
+            domain_record="$(
+              jq -cer --arg hostname "$hostname" '
+                if .success != true then
+                  error("Cloudflare domain lookup failed")
+                else
+                  [.result[] | select(.hostname == $hostname)]
+                  | if length == 0 then null
+                    elif length == 1 then .[0]
+                    else error("Cloudflare returned duplicate Worker domains")
+                    end
+                end
+              ' <<<"$domain_response"
+            )"
+            if [[ "$domain_record" == "null" ]]; then
+              echo "Worker custom domain is already retired: ${hostname}"
+              return
+            fi
+            if [[ "$(jq -r '.service' <<<"$domain_record")" != "okou-app-production" ]]; then
+              echo "Refusing to detach ${hostname} from another Worker" >&2
+              exit 1
+            fi
+            domain_id="$(jq -er '.id | select(type == "string")' <<<"$domain_record")"
+            if [[ ! "$domain_id" =~ ^[0-9a-f]{32}$ ]]; then
+              echo "Invalid Worker custom domain ID for ${hostname}" >&2
+              exit 1
+            fi
+
+            curl -fsS \
+              --request DELETE \
+              --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/domains/${domain_id}" \
+              | jq -e '.success == true' >/dev/null
+            echo "Retired Worker custom domain: ${hostname}"
+          }
+
+          retire_custom_domain "app-worker.okou.ai"
+          retire_custom_domain "app-worker.vm0.ai"
+
       - name: Finish GitHub Deployment
         if: always()
         uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
@@ -1711,10 +1769,6 @@ jobs:
             echo "### Live"
             echo "- https://app.okou.ai"
             echo "- https://app.vm0.ai"
-            echo
-            echo "### Direct canaries"
-            echo "- https://app-worker.okou.ai"
-            echo "- https://app-worker.vm0.ai"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Calculate duration

--- a/turbo/apps/api/src/__tests__/release-please-config.test.ts
+++ b/turbo/apps/api/src/__tests__/release-please-config.test.ts
@@ -174,8 +174,9 @@ describe("release-please API deployment graph", () => {
     );
     expect(promoteAppWorkerProductionJob).toContain("app.okou.ai");
     expect(promoteAppWorkerProductionJob).toContain("app.vm0.ai");
-    expect(promoteAppWorkerProductionJob).toContain("app-worker.okou.ai");
-    expect(promoteAppWorkerProductionJob).toContain("app-worker.vm0.ai");
+    expect(promoteAppWorkerProductionJob).toContain(
+      "Retire App Worker diagnostic domains",
+    );
     expect(updateRollbackDashboardJob).toContain(
       "needs.release-please.outputs.app_deploy_required != 'true'",
     );

--- a/turbo/apps/app-worker/src/worker.js
+++ b/turbo/apps/app-worker/src/worker.js
@@ -18,14 +18,12 @@ const APP_ASSET_REQUEST_HEADER_NAMES = [
 const OKOU_ROOT_DOMAINS = ["okou.ai", "omby.ai"];
 const PRODUCTION_API_ORIGINS = new Map([
   ["app.okou.ai", "https://api.okou.ai"],
-  ["app-worker.okou.ai", "https://api.okou.ai"],
   ["app.vm0.ai", "https://api.vm0.ai"],
-  ["app-worker.vm0.ai", "https://api.vm0.ai"],
 ]);
 const VERCEL_PROTECTION_BYPASS = "x-vercel-protection-bypass";
-const CLERK_EDGE_DEBUG_QUERY_PARAMETER = "__clerk_edge_debug";
-const CLERK_EDGE_DEBUG_TIMEOUT_MS = 1000;
-const CLERK_EDGE_DEBUG_PREVIEW_HOSTNAME_PATTERN =
+const CLERK_EDGE_SESSION_QUERY_PARAMETER = "__clerk_edge_debug";
+const CLERK_EDGE_SESSION_TIMEOUT_MS = 1000;
+const CLERK_EDGE_SESSION_PREVIEW_HOSTNAME_PATTERN =
   /^pr-[1-9][0-9]*-app-okou-app-preview\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.workers\.dev$/u;
 const SECURITY_HEADERS = {
   "Permissions-Policy":
@@ -213,20 +211,33 @@ function serializeClerkEdgeSession(session) {
     .replaceAll("\u2029", "\\u2029");
 }
 
-function isClerkEdgeDebugRequest(requestUrl, env) {
+function clerkEdgeSessionAuthorizedParty(requestUrl, env) {
   const debugFlags = requestUrl.searchParams.getAll(
-    CLERK_EDGE_DEBUG_QUERY_PARAMETER,
+    CLERK_EDGE_SESSION_QUERY_PARAMETER,
   );
-  return (
-    requestUrl.protocol === "https:" &&
-    debugFlags.length === 1 &&
-    debugFlags[0] === "1" &&
-    CLERK_EDGE_DEBUG_PREVIEW_HOSTNAME_PATTERN.test(requestUrl.hostname) &&
-    env.CLERK_EDGE_DEBUG_AUTHORIZED_PARTY === requestUrl.origin
-  );
+  if (
+    requestUrl.protocol !== "https:" ||
+    debugFlags.length !== 1 ||
+    debugFlags[0] !== "1"
+  ) {
+    return null;
+  }
+  if (PRODUCTION_API_ORIGINS.has(requestUrl.hostname)) {
+    return requestUrl.origin;
+  }
+  return CLERK_EDGE_SESSION_PREVIEW_HOSTNAME_PATTERN.test(
+    requestUrl.hostname,
+  ) && env.CLERK_EDGE_DEBUG_AUTHORIZED_PARTY === requestUrl.origin
+    ? requestUrl.origin
+    : null;
 }
 
-async function clerkEdgeSession(request, env, requestUrl, clerkClientFactory) {
+async function clerkEdgeSession(
+  request,
+  env,
+  authorizedParty,
+  clerkClientFactory,
+) {
   let timeoutId;
   try {
     const publishableKey = env.CLERK_PUBLISHABLE_KEY;
@@ -243,7 +254,7 @@ async function clerkEdgeSession(request, env, requestUrl, clerkClientFactory) {
     const timeout = new Promise((resolve) => {
       timeoutId = globalThis.setTimeout(() => {
         resolve(null);
-      }, CLERK_EDGE_DEBUG_TIMEOUT_MS);
+      }, CLERK_EDGE_SESSION_TIMEOUT_MS);
     });
     const authentication = Promise.resolve().then(() => {
       const clerk = clerkClientFactory({
@@ -253,11 +264,11 @@ async function clerkEdgeSession(request, env, requestUrl, clerkClientFactory) {
       });
       return clerk.authenticateRequest(request, {
         acceptsToken: "session_token",
-        authorizedParties: [env.CLERK_EDGE_DEBUG_AUTHORIZED_PARTY],
+        authorizedParties: [authorizedParty],
       });
     });
     const requestState = await Promise.race([authentication, timeout]);
-    // Browser mutations are outside this observation-only diagnostic branch.
+    // App shell session bootstrap must not forward Clerk browser mutations.
     if (
       requestState === null ||
       !requestState.isAuthenticated ||
@@ -726,8 +737,9 @@ async function handleRequest(
   ) {
     return assetResponse;
   }
-  const edgeSession = isClerkEdgeDebugRequest(requestUrl, env)
-    ? await clerkEdgeSession(request, env, requestUrl, clerkClientFactory)
+  const authorizedParty = clerkEdgeSessionAuthorizedParty(requestUrl, env);
+  const edgeSession = authorizedParty
+    ? await clerkEdgeSession(request, env, authorizedParty, clerkClientFactory)
     : null;
   return rewriteAppPage(assetResponse, metadata, edgeSession);
 }

--- a/turbo/apps/app-worker/wrangler.jsonc
+++ b/turbo/apps/app-worker/wrangler.jsonc
@@ -31,14 +31,6 @@
           "pattern": "app.vm0.ai/*",
           "zone_name": "vm0.ai",
         },
-        {
-          "pattern": "app-worker.okou.ai",
-          "custom_domain": true,
-        },
-        {
-          "pattern": "app-worker.vm0.ai",
-          "custom_domain": true,
-        },
       ],
     },
   },

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -256,12 +256,6 @@
           isDomainOrSubdomain(hostname, "app.okou.ai")
         ) {
           satelliteDomain = "app.okou.ai";
-        } else if (
-          production &&
-          !okouPrimary &&
-          isDomainOrSubdomain(hostname, "app-worker.okou.ai")
-        ) {
-          satelliteDomain = "app-worker.okou.ai";
         }
         var satellite = satelliteDomain !== null;
         var authOrigin = satellite

--- a/turbo/apps/platform/src/lib/clerk-production-topology.ts
+++ b/turbo/apps/platform/src/lib/clerk-production-topology.ts
@@ -3,13 +3,9 @@ export const VM0_CLERK_PRIMARY_APP_ORIGIN = "https://app.vm0.ai";
 
 export const CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN = "app.vm0.ai";
 export const CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN = "app.okou.ai";
-const OKOU_WORKER_CANARY_APP_DOMAIN = "app-worker.okou.ai";
 const CLERK_PRIMARY_USER_PROFILE_URL = "https://accounts.vm0.ai/user";
 
-export type ClerkProductionDomain =
-  | "app.okou.ai"
-  | typeof OKOU_WORKER_CANARY_APP_DOMAIN
-  | "vm0.ai";
+export type ClerkProductionDomain = "app.okou.ai" | "vm0.ai";
 export type ClerkProductionPrimaryAppDomain =
   | typeof CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
   | typeof CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN;
@@ -77,7 +73,5 @@ export function resolveClerkProductionSatelliteDomain(
   if (isDomainOrSubdomain(normalizedHostname, "app.okou.ai")) {
     return "app.okou.ai";
   }
-  return isDomainOrSubdomain(normalizedHostname, OKOU_WORKER_CANARY_APP_DOMAIN)
-    ? OKOU_WORKER_CANARY_APP_DOMAIN
-    : null;
+  return null;
 }


### PR DESCRIPTION
## Summary

- enable the query-gated Clerk edge session bootstrap on `app.okou.ai` and `app.vm0.ai`, while retaining the exact PR Worker preview path
- use each eligible request origin as Clerk's single `authorizedParties` value and consume the existing `production` Worker bindings; no new GitHub or Wrangler secret plumbing is added
- retire `app-worker.okou.ai` and `app-worker.vm0.ai` from Worker routes, App/Clerk topology, CORS verification, and release reporting
- explicitly detach those two custom domains after the next production deployment, guarded by exact hostname, owning Worker, and domain ID validation

## Security boundaries

- only HTTPS requests with one `__clerk_edge_debug=1` value can enter the session path
- production eligibility comes from the fixed canonical production-origin map; preview eligibility still requires both the exact PR Worker hostname shape and its deployment-provided authorized party
- authenticated responses inject only `{ userId, orgId }`, remain `private, no-store`, and never forward Clerk redirects, cookies, tokens, claims, session IDs, or credentials
- custom-domain cleanup refuses to detach a hostname owned by any Worker other than `okou-app-production`

## Fallbacks

- surface: the query-gated production App shell session enrichment retains the existing fail-open behavior for missing bindings, anonymous/handshake/refresh states, Clerk errors, and the one-second timeout
- window: this remains in place through the production rollout of the explicit parameter
- removal condition: reassess and make the permanent failure policy explicit when App Shell first-response cache prefetch takes ownership of this session data

## Verification

- `pnpm --filter @okouai/app-worker lint`
- `pnpm --filter @okouai/app-worker check-types`
- `pnpm knip --workspace @okouai/app-worker`
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm --filter @okouai/app exec vitest run src/lib/__tests__/clerk-worker-runtime.test.ts`
- `pnpm --filter api exec vitest run src/__tests__/release-please-config.test.ts`
- `pnpm --filter api check-types`
- targeted API Oxlint and ESLint checks
- `.github/scripts/tests/okou-app-worker-test.sh`
- `.github/scripts/tests/app-preview-ingress-workflow-test.sh`
- `.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh`
- targeted Prettier, ShellCheck, and actionlint checks
