### PR TITLE
fix(ci): disable sandbox npm audits in runner e2e

### DIFF
--- a/.github/scripts/tests/implicit-npm-audit-test.sh
+++ b/.github/scripts/tests/implicit-npm-audit-test.sh
@@ -143,3 +143,15 @@ unless violations.empty?
   exit 1
 end
 RUBY
+
+test_script='npx --yes --package=https://example.invalid/package.tgz okou --help'
+expected_prompt=$'@shell@\nexport npm_config_audit=false\nnpx --yes --package=https://example.invalid/package.tgz okou --help\n@end-shell@'
+actual_prompt=$(bash -c '
+source "$1"
+runner_e2e_shell_prompt "$2"
+' _ "$repo_root/e2e/helpers/runner-api.bash" "$test_script")
+
+if [[ "$actual_prompt" != "$expected_prompt" ]]; then
+  echo "runner E2E shell prompts must disable npm audit before caller code" >&2
+  exit 1
+fi

--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -186,7 +186,7 @@ runner_e2e_wait_for_run_status() {
 
 runner_e2e_shell_prompt() {
     local script="$1"
-    printf '@shell@\n%s\n@end-shell@' "$script"
+    printf '@shell@\nexport npm_config_audit=false\n%s\n@end-shell@' "$script"
 }
 
 runner_e2e_start_chat_run() {


### PR DESCRIPTION
## Summary

- inject `npm_config_audit=false` into ordinary runner E2E shell prompts before caller code
- protect both initial and continuation sandbox `npx --package` executions from implicit advisory requests
- extend the existing npm-audit policy test with an exact prompt-rendering contract

## Scope

- runner E2E test prompts only
- no production sandbox defaults or dependency-resolution changes
- dedicated `pnpm audit` security scanning remains enabled and unchanged

## Validation

- `bash -n e2e/helpers/runner-api.bash .github/scripts/tests/implicit-npm-audit-test.sh`
- `shellcheck .github/scripts/tests/implicit-npm-audit-test.sh`
- `shellcheck -e SC2034 e2e/helpers/runner-api.bash .github/scripts/tests/implicit-npm-audit-test.sh`
- `.github/scripts/tests/implicit-npm-audit-test.sh`
- `git diff --check`

Closes #31637
