### PR TITLE
fix(platform): buffer selection toolbar scroll dismissal

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -6,7 +6,7 @@ import {
   type Computed,
   type State,
 } from "ccstate";
-import { delay } from "signal-timers";
+import { animationFrame, delay } from "signal-timers";
 import { isEditableTarget, matchShortcut } from "@okouai/ui";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import type { ChatTranslationLanguage } from "@okouai/api-contracts/contracts/user-preferences";
@@ -41,6 +41,7 @@ const THREAD_CONTAINER_SELECTOR = "[data-chat-thread-container-id]";
 const CHAT_COMPOSER_SELECTOR = "[data-chat-composer]";
 const RUN_GROUP_SELECTOR = "[data-chat-run-id]";
 const SELECTION_INTERACTION_SELECTOR = "[data-chat-selection-interaction]";
+const SELECTION_SCROLL_DISMISS_DISTANCE_PX = 8;
 
 export interface ChatThreadFeedbackSelection {
   readonly rect: {
@@ -65,6 +66,7 @@ export interface ChatThreadTranslationResult {
 interface CapturedFeedbackSelection {
   readonly text: string;
   readonly rect: ChatThreadFeedbackSelection["rect"];
+  readonly scrollReferenceRect: ChatThreadFeedbackSelection["rect"];
   readonly threadId: string | null;
   readonly runId: string | null;
   readonly eventId?: string;
@@ -302,9 +304,11 @@ function readFeedbackSelection(): CapturedFeedbackSelection | null {
   }
   const source = resolveFeedbackSource(sourceElement);
   const location = resolveFeedbackLocation(range);
+  const rect = rectFromRange(range);
   return {
     text,
-    rect: rectFromRange(range),
+    rect,
+    scrollReferenceRect: rect,
     threadId: resolveSelectionThreadId(sourceElement),
     runId: resolveSelectionRunId(sourceElement),
     ...location,
@@ -378,9 +382,41 @@ function createSelectionState(threadId: string) {
     set(internalTranslationResult$, null);
     set(internalSelection$, selection);
   });
-  const dismissOnScroll$ = command(({ get, set }) => {
-    if (get(internalSelection$) !== null) {
+  const reconcileAfterScroll$ = command(({ get, set }) => {
+    const currentSelection = get(internalSelection$);
+    if (!currentSelection) {
+      return;
+    }
+    const selection = readFeedbackSelection();
+    if (
+      !selection ||
+      selection.threadId !== threadId ||
+      !isSameFeedbackSelection(currentSelection, selection)
+    ) {
       set(close$);
+      return;
+    }
+    const horizontalDisplacement =
+      selection.rect.left - currentSelection.scrollReferenceRect.left;
+    const verticalDisplacement =
+      selection.rect.top - currentSelection.scrollReferenceRect.top;
+    if (
+      Math.hypot(horizontalDisplacement, verticalDisplacement) >
+      SELECTION_SCROLL_DISMISS_DISTANCE_PX
+    ) {
+      set(close$);
+      return;
+    }
+    if (
+      selection.rect.top !== currentSelection.rect.top ||
+      selection.rect.left !== currentSelection.rect.left ||
+      selection.rect.width !== currentSelection.rect.width ||
+      selection.rect.height !== currentSelection.rect.height
+    ) {
+      set(internalSelection$, {
+        ...currentSelection,
+        rect: selection.rect,
+      });
     }
   });
   const copy$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -409,7 +445,7 @@ function createSelectionState(threadId: string) {
     selection$,
     close$,
     capture$,
-    dismissOnScroll$,
+    reconcileAfterScroll$,
     copy$,
   };
 }
@@ -665,13 +701,13 @@ function createListenersRef({
   selection$,
   close$,
   capture$,
-  dismissOnScroll$,
+  reconcileAfterScroll$,
   isProgrammaticScrollEvent$,
 }: {
   selection$: State<CapturedFeedbackSelection | null>;
   close$: Command<void, []>;
   capture$: Command<void, []>;
-  dismissOnScroll$: Command<void, []>;
+  reconcileAfterScroll$: Command<void, []>;
   isProgrammaticScrollEvent$: Command<boolean, [EventTarget | null]>;
 }) {
   const deferredCaptureSignal$ = resetSignal();
@@ -680,6 +716,7 @@ function createListenersRef({
       const doc = el.ownerDocument;
       let mouseSelectionInProgress = false;
       let selectionInteractionInProgress = false;
+      let scrollReconciliationScheduled = false;
       const captureDeferred = async () => {
         await delay(0, { signal: set(deferredCaptureSignal$, signal) });
         set(capture$);
@@ -759,12 +796,25 @@ function createListenersRef({
         "scroll",
         (event) => {
           if (
+            get(selection$) === null ||
             isSelectionInteractionTarget(event.target) ||
             set(isProgrammaticScrollEvent$, event.target)
           ) {
             return;
           }
-          set(dismissOnScroll$);
+          if (scrollReconciliationScheduled) {
+            return;
+          }
+          scrollReconciliationScheduled = true;
+          // Browser scroll events can precede the ResizeObserver pass that
+          // restores the selected text's viewport position.
+          animationFrame(
+            () => {
+              scrollReconciliationScheduled = false;
+              set(reconcileAfterScroll$);
+            },
+            { signal },
+          );
         },
         { capture: true, passive: true, signal },
       );
@@ -806,7 +856,7 @@ export function createChatThreadFeedbackSignals(
     selection$: selection.internalSelection$,
     close$: selection.close$,
     capture$: selection.capture$,
-    dismissOnScroll$: selection.dismissOnScroll$,
+    reconcileAfterScroll$: selection.reconcileAfterScroll$,
     isProgrammaticScrollEvent$,
   });
   return {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll.test.tsx
@@ -1,7 +1,7 @@
 import { chatThreadEventsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 
 import { click, queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import { createChatEvent } from "../../../mocks/mock-helpers.ts";
@@ -53,6 +53,34 @@ interface MutableConversation {
   readonly publish: (events: readonly MockChatEventInput[]) => void;
 }
 
+interface AnimationFrameController {
+  readonly flush: () => void;
+}
+
+function installQueuedAnimationFrames(): AnimationFrameController {
+  let nextFrameId = 0;
+  let callbacks = new Map<number, FrameRequestCallback>();
+
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    nextFrameId += 1;
+    callbacks.set(nextFrameId, callback);
+    return nextFrameId;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation((frameId) => {
+    callbacks.delete(frameId);
+  });
+
+  return {
+    flush: () => {
+      const scheduledCallbacks = Array.from(callbacks.values());
+      callbacks = new Map<number, FrameRequestCallback>();
+      for (const callback of scheduledCallbacks) {
+        callback(performance.now());
+      }
+    },
+  };
+}
+
 function mockPointerDevice(pointer: "desktop" | "touch"): void {
   context.mocks.browser.maxTouchPoints(pointer === "touch" ? 5 : 0);
   context.mocks.browser.matchMedia((query) => {
@@ -60,18 +88,18 @@ function mockPointerDevice(pointer: "desktop" | "touch"): void {
   });
 }
 
-function rect(top: number, height: number, width = 800): DOMRect {
+function rect(top: number, height: number, width = 800, left = 0): DOMRect {
   return {
     bottom: top + height,
     height,
-    left: 0,
-    right: width,
+    left,
+    right: left + width,
     toJSON: () => {
       return {};
     },
     top,
     width,
-    x: 0,
+    x: left,
     y: top,
   } as DOMRect;
 }
@@ -355,7 +383,7 @@ test("Preserve the visible message when earlier content grows", async () => {
   });
 });
 
-test("Keep passage actions during automatic scroll until the reader scrolls", async () => {
+test("Keep passage actions until the selection moves beyond the scroll buffer", async () => {
   const resize = mockResizeObserver();
   mockMutableConversation(
     THREAD_IDS.selectedPassage,
@@ -372,10 +400,39 @@ test("Keep passage actions during automatic scroll until the reader scrolls", as
   const readingAnchorId = anchorId(readingAnchor);
   const readingTop = readingAnchor.getBoundingClientRect().top;
   await selectPassage("History answer 8");
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    throw new Error("Selected passage range not found");
+  }
+  const selectedRange = selection.getRangeAt(0);
+  const selectedAtScrollTop = container.scrollTop;
+  let heightBeforeSelection = 0;
+  const selectionRect = (): DOMRect => {
+    return rect(
+      24 + heightBeforeSelection - (container.scrollTop - selectedAtScrollTop),
+      24,
+      200,
+      24,
+    );
+  };
+  Object.defineProperty(selectedRange, "getClientRects", {
+    configurable: true,
+    value: () => {
+      return [selectionRect()];
+    },
+  });
+  Object.defineProperty(selectedRange, "getBoundingClientRect", {
+    configurable: true,
+    value: selectionRect,
+  });
 
   expect(queryPassageAction("Quote")).toBeVisible();
+  const animationFrames = installQueuedAnimationFrames();
 
   geometry.growBeforeMessages(75);
+  heightBeforeSelection += 75;
+  container.scrollTop += 75;
+  fireEvent.scroll(container);
   act(() => {
     resize.automationAll();
   });
@@ -384,11 +441,28 @@ test("Keep passage actions during automatic scroll until the reader scrolls", as
       anchorById(container, readingAnchorId).getBoundingClientRect().top,
     ).toBe(readingTop);
   });
-  fireEvent.scroll(container);
+  act(() => {
+    animationFrames.flush();
+  });
 
   expect(queryPassageAction("Quote")).toBeVisible();
 
-  scrollFromUser(container, container.scrollTop - 20);
+  scrollFromUser(container, container.scrollTop - 4);
+  act(() => {
+    animationFrames.flush();
+  });
+  expect(queryPassageAction("Quote")).toBeVisible();
+
+  scrollFromUser(container, container.scrollTop - 4);
+  act(() => {
+    animationFrames.flush();
+  });
+  expect(queryPassageAction("Quote")).toBeVisible();
+
+  scrollFromUser(container, container.scrollTop - 1);
+  act(() => {
+    animationFrames.flush();
+  });
 
   await waitFor(() => {
     expect(queryPassageAction("Quote")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- defer scroll-driven selection reconciliation by one animation frame so layout restoration can settle
- keep and reposition the selection toolbar within an 8px cumulative viewport-movement buffer
- dismiss the toolbar after more than 8px of movement or when the live selection is no longer valid

## Root cause

The document-level scroll listener dismissed the selection toolbar synchronously. Browser or otherwise-unclassified scroll events can arrive around chat anchor restoration, so a visually stable selection could lose its menu before the final selection geometry was available.

## Verification

- `pnpm exec vitest run src/views/okou-page/__tests__/chat-scroll.test.tsx -t "Keep passage actions until the selection moves beyond the scroll buffer" --silent=passed-only`
- Prettier check for both changed files
- standard and type-aware Oxlint for both changed files
- ESLint for both changed files
- `pnpm run check-types` in `turbo/apps/platform`
