### PR TITLE
fix: use the standard inset focus ring on emoji picker emoji

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-emoji.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-emoji.test.tsx
@@ -191,6 +191,24 @@ test("The emoji picker names the emoji under the pointer", async () => {
   expect(screen.queryByText(":grinning_face:")).toBeNull();
 });
 
+test("A focused emoji draws the standard ring inside the feed", async () => {
+  const user = userEvent.setup();
+  const searchInput = await openEmojiPicker();
+  await user.type(searchInput, "entry");
+  await waitFor(() => {
+    expect(emojiButton("no entry")).toBeInTheDocument();
+  });
+
+  // Inset, because the feed is a scroll box: an offset ring on the outer
+  // columns or on the first and last rows would be clipped by its overflow.
+  expect(emojiButton("no entry")).toHaveClass(
+    "focus-visible:outline-none",
+    "focus-visible:ring-2",
+    "focus-visible:ring-inset",
+    "focus-visible:ring-ring",
+  );
+});
+
 test("Frequently used product emoji keep their translated labels", async () => {
   await openEmojiPicker();
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-emoji.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-emoji.test.tsx
@@ -191,24 +191,6 @@ test("The emoji picker names the emoji under the pointer", async () => {
   expect(screen.queryByText(":grinning_face:")).toBeNull();
 });
 
-test("A focused emoji draws the standard ring inside the feed", async () => {
-  const user = userEvent.setup();
-  const searchInput = await openEmojiPicker();
-  await user.type(searchInput, "entry");
-  await waitFor(() => {
-    expect(emojiButton("no entry")).toBeInTheDocument();
-  });
-
-  // Inset, because the feed is a scroll box: an offset ring on the outer
-  // columns or on the first and last rows would be clipped by its overflow.
-  expect(emojiButton("no entry")).toHaveClass(
-    "focus-visible:outline-none",
-    "focus-visible:ring-2",
-    "focus-visible:ring-inset",
-    "focus-visible:ring-ring",
-  );
-});
-
 test("Frequently used product emoji keep their translated labels", async () => {
   await openEmojiPicker();
 

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -1505,7 +1505,10 @@ function ChatThreadEmojiGrid({
               shortcodeNames,
             )}
             title={shortcutLabel}
-            className="relative flex aspect-square items-center justify-center rounded-md text-xl leading-none transition-colors hover:bg-state-hover"
+            // The focus ring is inset because the feed scrolls: an offset ring
+            // on the outer columns and on the first and last rows would be
+            // clipped by the feed's own overflow box.
+            className="relative flex aspect-square items-center justify-center rounded-md text-xl leading-none transition-colors hover:bg-state-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
             onClick={() => {
               onSelect(item.emoji);
             }}


### PR DESCRIPTION
Fixes #31624

## Problem

The emoji buttons in the chat thread emoji picker carried no `focus-visible` styling at all. Two things followed from that:

- **Wrong outline.** A focused emoji fell back to the user agent's default focus outline instead of the `ring-2 ring-ring` treatment every other control in the product uses.
- **Clipped outline.** The feed (`[data-chat-thread-emoji-feed]`) is `overflow-y-auto`, which also makes it clip horizontally. The UA outline is drawn outside the button box, so on the outer columns and on the first and last rows part of it was cut off by the feed. Searching `entry` puts `:no_entry:` (⛔) alone in the first column of the results grid, which is why that emoji shows the problem clearly.

## Fix

Give the grid buttons the project's standard focus ring, `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`, with `focus-visible:ring-inset`.

`ring-inset` is what the codebase already uses for focusable rows and tiles that live inside a scroll container (`sidebar-threads.tsx`, `chat-composer.tsx`, `artifact-catalog-page.tsx`). It matters here for two reasons: the ring is drawn inside the button box, so the feed's overflow can no longer clip it, and the grid's `gap-0.5` (2px) leaves no room for `ring-offset-2` without the ring bleeding over its neighbours.

`ChatThreadEmojiGrid` renders both the category sections and the search results, so one change covers both.

## Testing

This is a presentation-only change: a static class string with no logic, no branch, and no page-observable state. There is no assertion available at the external-behavior boundary, because jsdom does not compile Tailwind, evaluate `:focus-visible`, or compute layout and overflow clipping.

An earlier revision of this PR added a `toHaveClass(...)` assertion. It was removed in 08ab97c: asserting on CSS class names is an explicit platform testing anti-pattern (`docs/testing/anti-patterns.md` AP-7, `docs/testing/testing-external-behavior.md`, `docs/testing/app-testing.md`), and it protected nothing beyond pinning the literal utility strings.

Verification instead:

- **Visual, on the PR preview** — focus an emoji with the keyboard and confirm the ring renders fully inside the button on the first and last rows and on the leftmost and rightmost columns, in both light and dark themes.
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-emoji.test.tsx` — 6 passed (the picker's existing behavior tests are unaffected)
- `pnpm format`, `pnpm turbo run lint`, `pnpm check-types` — clean across the repository
