### PR TITLE
fix(ui): give the pause button its own coral fill

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -9439,7 +9439,7 @@ function ComposerSendButton({
       <Button
         showTooltip
         size="icon-sm"
-        variant="destructive"
+        variant="interrupt"
         className="shrink-0"
         onClick={onActivate}
         aria-label={t(($) => {

--- a/turbo/packages/ui/src/components/ui/button.tsx
+++ b/turbo/packages/ui/src/components/ui/button.tsx
@@ -21,6 +21,11 @@ const buttonVariants = cva(
           "bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-pressed",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive-hover active:bg-destructive-pressed",
+        // Halts something in flight without discarding it -- pausing a run.
+        // `destructive` is reserved for deletes, so this takes the lighter
+        // Coral stop and reads as an interruption rather than a warning.
+        interrupt:
+          "bg-interrupt text-interrupt-foreground hover:bg-interrupt-hover active:bg-interrupt-pressed",
         outline:
           "border-[0.7px] border-[hsl(var(--gray-400))] bg-background hover:bg-state-hover active:bg-state-pressed text-foreground",
         secondary:

--- a/turbo/packages/ui/src/styles/__tests__/globals.test.ts
+++ b/turbo/packages/ui/src/styles/__tests__/globals.test.ts
@@ -193,10 +193,14 @@ describe("interaction state ladder", () => {
   // A translucent layer replaces an opaque fill instead of sitting on it, so
   // every surface that carries one needs a pre-mixed pair derived from the
   // same alphas.
-  it.each(["card", "input", "secondary", "primary", "destructive"])(
-    "derives %s's hover from the shared state alphas",
-    (surface) => {
-      expect(globalCss).toContain(`--color-${surface}-hover: color-mix(`);
-    },
-  );
+  it.each([
+    "card",
+    "input",
+    "secondary",
+    "primary",
+    "destructive",
+    "interrupt",
+  ])("derives %s's hover from the shared state alphas", (surface) => {
+    expect(globalCss).toContain(`--color-${surface}-hover: color-mix(`);
+  });
 });

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -114,6 +114,8 @@
   --color-secondary-foreground: hsl(var(--secondary-foreground));
   --color-destructive: hsl(var(--destructive));
   --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-interrupt: hsl(var(--interrupt));
+  --color-interrupt-foreground: hsl(var(--interrupt-foreground));
   --color-muted: hsl(var(--muted));
   --color-muted-foreground: hsl(var(--muted-foreground));
   --color-accent: hsl(var(--accent));
@@ -254,6 +256,16 @@
     hsl(var(--destructive)),
     hsl(var(--black)) var(--state-on-filled-pressed-alpha)
   );
+  --color-interrupt-hover: color-mix(
+    in srgb,
+    hsl(var(--interrupt)),
+    hsl(var(--black)) var(--state-on-filled-hover-alpha)
+  );
+  --color-interrupt-pressed: color-mix(
+    in srgb,
+    hsl(var(--interrupt)),
+    hsl(var(--black)) var(--state-on-filled-pressed-alpha)
+  );
 
   /* ===================================
    * Segment Control
@@ -344,6 +356,15 @@
     --destructive-foreground: var(
       --on-filled
     ); /* on-filled - white text on destructive */
+
+    /* Interrupting a run is not destruction -- nothing is lost and the work is
+       resumable -- so it takes Coral rather than the delete red, one stop
+       lighter than `--destructive` so the two never read as the same control.
+       The glyph stays white: Amber's 1.97:1 forced Ink on `--primary`, but
+       Coral 500 carries white at 3.01:1, over the 3:1 bar an icon has to
+       clear, and the filled white square is what reads as a stop. */
+    --interrupt: 13.9 100% 59.4%; /* #FF6030 - Coral 500 */
+    --interrupt-foreground: var(--on-filled); /* white on Coral 500 */
 
     --border: var(--gray-200); /* gray-200 - primary border color (lighter) */
     --input: var(--white); /* white - same as card */
@@ -471,6 +492,12 @@
     --destructive-foreground: var(
       --on-filled
     ); /* on-filled - white text on destructive */
+
+    /* Coral 500 holds across both themes: it is bright enough to read on the
+       dark page (5.23:1) without needing the lighter stop `--destructive`
+       falls back to, so the pause control keeps one colour everywhere. */
+    --interrupt: 13.9 100% 59.4%; /* #FF6030 - Coral 500 */
+    --interrupt-foreground: var(--on-filled); /* white on Coral 500 */
 
     --border: var(--gray-200); /* gray-200 - primary border color */
     --input: var(
@@ -628,6 +655,14 @@
       --on-filled
     ); /* on-filled - white text on destructive */
 
+    /* Interrupting a run is not destruction -- nothing is lost and the work is
+       resumable -- so it steps two stops up the same Coral ramp: still clearly
+       an interruption, but without the delete button's weight. Unlike Amber,
+       Coral 500 does carry white (3.01:1, over the 3:1 an icon has to clear),
+       and the white square is the stop glyph everyone already reads. */
+    --interrupt: 13.9 100% 59.4%; /* #FF6030 - Coral 500 */
+    --interrupt-foreground: var(--on-filled); /* white on Coral 500 */
+
     --border: var(--gray-200); /* gray-200 - primary border color (lighter) */
     --input: var(--white); /* white - same as card */
     --ring: var(--primary-400); /* primary-400 - readable ring against Amber */
@@ -772,6 +807,13 @@
        stop to stay legible, and that stop flips the label to Ink (7.21:1). */
     --destructive: 13.1 100% 72.2%; /* #FF9071 - Coral 400 */
     --destructive-foreground: 42.9 4.3% 13.5%; /* #242321 - Ink on Coral 400 */
+
+    /* Coral 500 does not flip the way `--destructive` does: it already clears
+       5.23:1 against the dark page, so the pause control keeps one fill and one
+       white glyph in both themes and stays a stop darker than the destructive
+       fill beside it. */
+    --interrupt: 13.9 100% 59.4%; /* #FF6030 - Coral 500 */
+    --interrupt-foreground: var(--on-filled); /* white on Coral 500 */
 
     --border: var(--gray-200); /* gray-200 - primary border color */
     --input: var(


### PR DESCRIPTION
## Problem

The composer's stop control reused `variant="destructive"`, so pausing a run was painted in the delete colour — `red/600` `#EF4444` on the legacy theme, Coral 700 `#BC3500` on the new UI. It was the only non-delete use of `destructive` in the app, and it read heavier than the action deserves: interrupting a run destroys nothing and the work is resumable.

## Change

Adds a semantic `--interrupt` / `--interrupt-foreground` pair set to **Coral 500 `#FF6030`** with a white glyph, plus the matching `interrupt` Button variant, and points the composer's stop button at it.

- Coral 500 is two stops lighter than the destructive fill, so the two controls never read as the same button.
- It holds in both themes — `--destructive` has to flip to Coral 400 in dark to stay legible; Coral 500 already clears 5.23:1 against the dark page, so the pause button keeps one fill and one glyph colour everywhere.
- The glyph is white. Amber's 1.97:1 is what forces Ink on `--primary`, but Coral 500 carries white at 3.01:1, above the 3:1 an icon has to clear, and the filled white square is the stop glyph people already read.
- `destructive` is untouched, so every delete confirmation in the app keeps its current colour.

Colour comes from the published Coral ramp in the design tokens (`zero-design-color`), stop 500.

## Preview

Before/after and the ramp position: https://pause-button-coral.sites.vm0.io

## Checks

`pnpm format`, `pnpm turbo run lint --filter=@okouai/ui --filter=@okouai/app`, `pnpm check-types`, `pnpm knip --workspace packages/ui`, `@okouai/ui` suite (95 tests), and the composer/run-state platform tests all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
