### PR TITLE
revert(platform): remove pinned agent row cache

### DIFF
--- a/turbo/apps/platform/src/__tests__/platform-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-entrypoint.test.ts
@@ -12,6 +12,10 @@ const context = testContext();
 const INSTATUS_WIDGET_HOSTNAME = "api.dashboard.instatus.com";
 const GOOGLE_TAG_SCRIPT_URL =
   "https://www.googletagmanager.com/gtag/js?id=AW-18144854014";
+const RETIRED_PINNED_AGENT_STORAGE_KEYS = [
+  "pinnedAgentGridRows",
+  "vm0:pinned-agent-preview-cache:v1",
+] as const;
 
 let googleAdsRequestedAfterApplicationStart = false;
 
@@ -90,6 +94,9 @@ describe("platform entrypoint", () => {
     context.mocks.posthog();
     context.mocks.sentry();
     setupPlatformDocument();
+    for (const key of RETIRED_PINNED_AGENT_STORAGE_KEYS) {
+      localStorage.setItem(key, "retired");
+    }
 
     const addEventListener = vi.spyOn(window, "addEventListener");
     const appendChild = document.head.appendChild.bind(document.head);
@@ -120,6 +127,12 @@ describe("platform entrypoint", () => {
 
   it("starts the application before requesting Google Ads", () => {
     expect(googleAdsRequestedAfterApplicationStart).toBeTruthy();
+  });
+
+  it("removes retired pinned-agent storage", () => {
+    for (const key of RETIRED_PINNED_AGENT_STORAGE_KEYS) {
+      expect(localStorage.getItem(key)).toBeNull();
+    }
   });
 });
 

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -96,6 +96,7 @@ import {
   featureSwitch$,
   reloadFeatureSwitch$,
 } from "./external/feature-switch.ts";
+import { clearRetiredPinnedAgentStorage$ } from "./external/retired-pinned-agent-storage.ts";
 import {
   setupBrowserLifecycleDiagnostics$,
   setupConnectionDiagnostics$,
@@ -538,6 +539,7 @@ export const bootstrap$ = command(
     render: () => void,
     signal: AbortSignal,
   ): BootstrapRuntime => {
+    set(clearRetiredPinnedAgentStorage$);
     set(initializeAppVersion$, appVersion);
     set(initBootstrapPhaseTiming$, signal);
     set(captureInvitationRedirect$);

--- a/turbo/apps/platform/src/signals/external/retired-pinned-agent-storage.ts
+++ b/turbo/apps/platform/src/signals/external/retired-pinned-agent-storage.ts
@@ -1,0 +1,14 @@
+import { command } from "ccstate";
+import { localStorageSignals } from "./local-storage.ts";
+
+const { clear$: clearPinnedAgentGridRows$ } = localStorageSignals(
+  "pinnedAgentGridRows",
+);
+const { clear$: clearPinnedAgentPreviewCache$ } = localStorageSignals(
+  "vm0:pinned-agent-preview-cache:v1",
+);
+
+export const clearRetiredPinnedAgentStorage$ = command(({ set }) => {
+  set(clearPinnedAgentGridRows$);
+  set(clearPinnedAgentPreviewCache$);
+});

--- a/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
@@ -1,6 +1,5 @@
 import { command, computed, state } from "ccstate";
 import { localStorageSignals } from "../external/local-storage.ts";
-import { onDomEventFn, onRef } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Chat navigation search query
@@ -251,49 +250,6 @@ export const setAgentCardCollapsed$ = command(({ set }, collapsed: boolean) => {
     set(clearAgentCardCollapsed$);
   }
 });
-
-// ---------------------------------------------------------------------------
-// Pinned agent grid rows (three-column sidebar) — persisted in localStorage
-// ---------------------------------------------------------------------------
-export const PINNED_AGENT_GRID_COLUMNS = 5;
-
-const { get$: pinnedAgentGridRowsRaw$, set$: setPinnedAgentGridRowsRaw$ } =
-  localStorageSignals("pinnedAgentGridRows");
-export const pinnedAgentGridRows$ = computed((get) => {
-  const rows = Number(get(pinnedAgentGridRowsRaw$));
-  return Number.isSafeInteger(rows) && rows > 0 ? rows : 1;
-});
-const cachePinnedAgentGridRowsFromElement$ = command(
-  ({ get, set }, element: HTMLDivElement) => {
-    const rows = Math.max(
-      1,
-      Math.ceil(element.childElementCount / PINNED_AGENT_GRID_COLUMNS),
-    );
-    const next = String(rows);
-    if (get(pinnedAgentGridRowsRaw$) === next) {
-      return;
-    }
-    set(setPinnedAgentGridRowsRaw$, next);
-  },
-);
-export const cachePinnedAgentGridRowsRef$ = onRef(
-  command(({ set }, element: HTMLDivElement, signal: AbortSignal) => {
-    set(cachePinnedAgentGridRowsFromElement$, element);
-    const observer = new MutationObserver(
-      onDomEventFn(() => {
-        set(cachePinnedAgentGridRowsFromElement$, element);
-      }),
-    );
-    observer.observe(element, { childList: true });
-    signal.addEventListener(
-      "abort",
-      () => {
-        observer.disconnect();
-      },
-      { once: true },
-    );
-  }),
-);
 
 // ---------------------------------------------------------------------------
 // Chat thread virtual list geometry (RecentChatSection)

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { agentsMainContract } from "@okouai/api-contracts/contracts/agents";
 import {
@@ -26,28 +26,6 @@ import {
 } from "./chat-list-test-helpers.ts";
 
 const context = testContext();
-
-test("Pinned agents use one loading row", async () => {
-  const auth = chatListAuth(21);
-  const agents = context.mocks.deferred<void>();
-  context.mocks.data.onboardingStatus({
-    defaultAgentId: CHAT_LIST_AGENT_ID,
-  });
-  installChatListStream(context, { caseId: 21, snapshot: [] });
-  installChatListAgent(context, agents.promise);
-
-  await setupPage({
-    context,
-    path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth,
-  });
-
-  const pinnedAgents = await screen.findByTestId("pinned-agents-grid");
-  expect(
-    within(pinnedAgents).getAllByTestId("pinned-agent-skeleton"),
-  ).toHaveLength(4);
-  expect(agents.settled()).toBeFalsy();
-});
 
 test("Cached conversations appear before remote synchronization", async () => {
   const auth = chatListAuth(1);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { agentsMainContract } from "@okouai/api-contracts/contracts/agents";
 import {
@@ -26,6 +26,28 @@ import {
 } from "./chat-list-test-helpers.ts";
 
 const context = testContext();
+
+test("Pinned agents use one loading row", async () => {
+  const auth = chatListAuth(21);
+  const agents = context.mocks.deferred<void>();
+  context.mocks.data.onboardingStatus({
+    defaultAgentId: CHAT_LIST_AGENT_ID,
+  });
+  installChatListStream(context, { caseId: 21, snapshot: [] });
+  installChatListAgent(context, agents.promise);
+
+  await setupPage({
+    context,
+    path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
+    auth,
+  });
+
+  const pinnedAgents = await screen.findByTestId("pinned-agents-grid");
+  expect(
+    within(pinnedAgents).getAllByTestId("pinned-agent-skeleton"),
+  ).toHaveLength(4);
+  expect(agents.settled()).toBeFalsy();
+});
 
 test("Cached conversations appear before remote synchronization", async () => {
   const auth = chatListAuth(1);

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -27,9 +27,6 @@ import { pathParams$ } from "../../signals/route.ts";
 import {
   agentCardCollapsed$,
   setAgentCardCollapsed$,
-  pinnedAgentGridRows$,
-  cachePinnedAgentGridRowsRef$,
-  PINNED_AGENT_GRID_COLUMNS,
   openPinAgentDialog$,
   pinAgentDialogOpen$,
   setPinAgentDialogOpen$,
@@ -453,8 +450,6 @@ export function PinnedAgentListSection({
   const setExpanded = useSet(setSidebarExpanded$);
   const collapsed = useGet(agentCardCollapsed$);
   const setCollapsed = useSet(setAgentCardCollapsed$);
-  const cachedPinnedAgentGridRows = useGet(pinnedAgentGridRows$);
-  const cachePinnedAgentGridRowsRef = useSet(cachePinnedAgentGridRowsRef$);
   const draggingAgentId = useGet(draggingPinnedAgentId$);
   const dropTargetAgentId = useGet(pinnedAgentDropTargetId$);
   const defaultAgentId = useLastResolved(defaultAgentId$);
@@ -479,14 +474,9 @@ export function PinnedAgentListSection({
         : displayedPinnedAgents;
     const pinnedAgentCards =
       horizontalPinnedAgents === null
-        ? Array.from(
-            {
-              length: cachedPinnedAgentGridRows * PINNED_AGENT_GRID_COLUMNS - 1,
-            },
-            (_, index) => {
-              return <PinnedAgentGridSkeletonCard key={index} />;
-            },
-          )
+        ? Array.from({ length: 4 }, (_, index) => {
+            return <PinnedAgentGridSkeletonCard key={index} />;
+          })
         : horizontalPinnedAgents.map((agent) => {
             const isPrimarySelected =
               isChatRoute(activeRoute) && selectedAgentId === agent.agentId;
@@ -525,7 +515,6 @@ export function PinnedAgentListSection({
           })}
         </span>
         <div
-          ref={cachePinnedAgentGridRowsRef}
           className="grid min-w-0 grid-cols-5 items-start gap-x-1 gap-y-2.5"
           data-testid="pinned-agents-grid"
         >


### PR DESCRIPTION
## Summary

- remove the localStorage-backed pinned-agent grid row counter and its MutationObserver
- keep the five-column pinned grid while rendering one fixed loading row with four skeleton cards and the pin action
- remove the retired `pinnedAgentGridRows` and `vm0:pinned-agent-preview-cache:v1` entries during Platform startup

This removes the row-count cache introduced in #27790 after the pinned-agent preview cache was reverted in #31631.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for shared packages, Platform, and API
- `pnpm --filter @okouai/app exec vitest run src/__tests__/platform-entrypoint.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-list-cache.test.tsx`
