### PR TITLE
ci: disable npm audit in cli artifact smoke

### DIFF
--- a/.github/scripts/smoke-okou-cli-artifact.sh
+++ b/.github/scripts/smoke-okou-cli-artifact.sh
@@ -33,7 +33,7 @@ run_cli() {
   local stdout_file="$2"
   local stderr_file="$3"
   shift 3
-  PATH="$clean_path" "$node_path" "$npx_path" \
+  PATH="$clean_path" npm_config_audit=false "$node_path" "$npx_path" \
     --yes --package="$package_path" "$entrypoint" "$@" \
     >"$stdout_file" 2>"$stderr_file"
 }


### PR DESCRIPTION
## Summary

- disable npm automatic audit only for the temporary `npx --package=<artifact.tgz>` installation used by the canonical CLI artifact smoke test
- keep the smoke test's strict stderr validation intact for actual CLI output
- avoid false failures and stalls caused by npm's retiring advisory endpoint notice

## Scope

This is an independent CI-stability prerequisite extracted from #31542 while splitting the HeyGen Intro Video work. It does not change shipped CLI or HeyGen behavior. The repository's separate `pnpm audit (SCA)` check remains enabled.

## Verification

- canonical CLI artifact smoke passed locally with this exact change
- `deploy-cli` passed with this exact change on the previously combined PR #31542
- `git diff --check`