### PR TITLE
fix(platform): stop the thinking shimmer shifting the status text

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -204,89 +204,41 @@ body {
   }
 }
 
-/* Shimmer text effect for active/thinking states */
-@keyframes zero-shimmer-window {
+/* Shimmer text effect for active/thinking states.
+
+   The bright band lives in the label's own background gradient, so the only
+   thing that moves is the gradient's paint origin. Sweeping it instead with a
+   translated overlay needs the overlay and the text copy inside it to cancel
+   each other out on every frame, and the compositor rasterises each animated
+   layer against its own whole-device-pixel origin, so that cancellation drifts
+   by up to a pixel and the status text jitters sideways. Nothing here moves a
+   box that holds glyphs, so the text cannot shift.
+
+   `contain: paint` keeps the per-frame repaint inside the label. */
+@keyframes zero-shimmer {
   from {
-    transform: translate3d(-50%, 0, 0);
+    background-position: 100% center;
   }
   to {
-    transform: translate3d(283.333333%, 0, 0);
+    background-position: -100% center;
   }
-}
-@keyframes zero-shimmer-highlight {
-  from {
-    transform: translate3d(30%, 0, 0);
-  }
-  to {
-    transform: translate3d(-170%, 0, 0);
-  }
-}
-@keyframes zero-shimmer-highlight-secondary {
-  from {
-    transform: translate3d(230%, 0, 0);
-  }
-  to {
-    transform: translate3d(30%, 0, 0);
-  }
-}
-.zero-shimmer-text-shell {
-  position: relative;
-  contain: paint;
 }
 .zero-shimmer-text {
-  background-color: hsl(var(--muted-foreground) / 0.8);
+  background: linear-gradient(
+    90deg,
+    hsl(var(--muted-foreground) / 0.8) 0%,
+    hsl(var(--muted-foreground) / 0.8) 35%,
+    hsl(var(--foreground)) 48%,
+    hsl(var(--foreground)) 52%,
+    hsl(var(--muted-foreground) / 0.8) 65%,
+    hsl(var(--muted-foreground) / 0.8) 100%
+  );
+  background-size: 200% 100%;
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-}
-.zero-shimmer-window {
-  position: absolute;
-  inset-block: 0;
-  left: 0;
-  width: 60%;
-  overflow: hidden;
-  background-color: hsl(var(--background));
-  pointer-events: none;
-  user-select: none;
-  /* Map the old 35%-65% band from its 200%-wide gradient into one window. */
-  -webkit-mask-image: linear-gradient(
-    90deg,
-    transparent 0%,
-    black 43.333333%,
-    black 56.666667%,
-    transparent 100%
-  );
-  mask-image: linear-gradient(
-    90deg,
-    transparent 0%,
-    black 43.333333%,
-    black 56.666667%,
-    transparent 100%
-  );
-  animation: zero-shimmer-window 3.5s linear infinite;
-  will-change: transform;
-}
-.zero-shimmer-highlight {
-  position: absolute;
-  inset-block: 0;
-  left: 0;
-  display: block;
-  width: 166.666667%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  background-color: hsl(var(--foreground));
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: zero-shimmer-highlight 3.5s linear infinite;
-  will-change: transform;
-}
-.zero-shimmer-window-secondary {
-  left: -200%;
-}
-.zero-shimmer-window-secondary .zero-shimmer-highlight {
-  animation-name: zero-shimmer-highlight-secondary;
+  contain: paint;
+  animation: zero-shimmer 3.5s linear infinite;
 }
 
 @keyframes zero-thinking-in {
@@ -1964,8 +1916,7 @@ details > summary {
    rendered inside the dialog keeps running. */
 html:has(.zero-dialog-overlay)
   :is(
-    .zero-shimmer-window,
-    .zero-shimmer-highlight,
+    .zero-shimmer-text,
     .zero-blocks span,
     .zero-thinking-spinner,
     .mic-starting-spinner,

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -4722,38 +4722,23 @@ function ShimmerText({
   children,
   className,
   setRef,
-  visualChildren = children,
 }: {
   readonly ariaLabel?: string;
   readonly children: ReactNode;
   readonly className?: string;
   readonly setRef?: ServerThinkingLabel["setRef"];
-  readonly visualChildren?: ReactNode;
 }) {
   return (
-    <div
+    <p
+      ref={setRef}
       className={cn(
-        "zero-shimmer-text-shell h-5 min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[0.8125rem] leading-5",
+        "zero-shimmer-text h-5 min-w-0 flex-1 truncate text-[0.8125rem] leading-5",
         className,
       )}
+      aria-label={ariaLabel}
     >
-      <p
-        ref={setRef}
-        className="zero-shimmer-text h-5 w-full truncate"
-        aria-label={ariaLabel}
-      >
-        {children}
-      </p>
-      <span className="zero-shimmer-window" aria-hidden>
-        <span className="zero-shimmer-highlight">{visualChildren}</span>
-      </span>
-      <span
-        className="zero-shimmer-window zero-shimmer-window-secondary"
-        aria-hidden
-      >
-        <span className="zero-shimmer-highlight">{visualChildren}</span>
-      </span>
-    </div>
+      {children}
+    </p>
   );
 }
 
@@ -4777,16 +4762,7 @@ function ThinkingLabel({
       return $.chat.run.queueEllipsis;
     });
     return (
-      <ShimmerText
-        visualChildren={
-          <>
-            {waitingIn}{" "}
-            <span className="underline underline-offset-2">
-              {queueEllipsis}
-            </span>
-          </>
-        }
-      >
+      <ShimmerText>
         {waitingIn}{" "}
         <button
           type="button"


### PR DESCRIPTION
## Problem

The thinking indicator's status text jitters ~1 CSS px horizontally while the shimmer animates (#31625).

The shimmer is built as a translated overlay (`.zero-shimmer-window`) that sweeps across the label, with a **counter-translated copy of the same text** inside it (`.zero-shimmer-highlight`). The two transforms are exact negatives of each other, so the bright copy is only stationary as long as they cancel *at paint time*.

Both elements carry a compositor-driven `transform` animation and `will-change: transform`, so each becomes its own composited layer, and an animated layer's glyphs are rasterised once against a whole-device-pixel origin rather than re-rastered every frame. The residual sub-pixel offsets no longer cancel, and the bright copy lands beside the muted base copy underneath.

Frame analysis of the recording attached to the issue (120 fps, DPR 2) confirms it — measuring the sub-pixel position of the first glyphs against the first frame:

```
frame   shift(device px)   ink
 87       +0.035           40932   base text only
 93       +0.159           42875   highlight fading in, 2px left of the base
100       +1.000           51442
110       +1.851           61902
119       +2.012           68407   highlight fully covering, 2 device px off
120       +0.023           63912   re-raster snaps it back into place
150       +0.042           41883   highlight fading out, aligned
```

The ramp is the highlight fading in over a base copy that is 2 device px (≈1 CSS px) away; the discontinuity at frame 120 is the layer being re-rastered at a corrected origin. That is the visible blink.

## Fix

Paint the band into the label's own background gradient — which is what the shimmer did before #26123 moved it onto transform layers — instead of sweeping a second copy of the text across it. Nothing that holds glyphs moves, so the text cannot shift, whatever the compositor does with the layer.

The label also drops from three copies of the same string to one, which removes the `visualChildren` prop that existed only to keep a duplicate `<button>` out of the visual copies, and removes four permanently promoted `will-change: transform` layers (two of them masked, i.e. render surfaces) per shimmering label.

The tradeoff is the one #26123 removed: the gradient's paint origin animates, so the label repaints each frame while a run is active. It is one ~250×20 CSS px line of cached glyphs; `contain: paint` keeps the invalidation inside it.

## Verification

The band is geometrically identical, not just similar. Both designs put the band centre at `2W·t` and ramp muted→foreground over the same `0.26W`. Rendering old and new side by side in Chromium at DPR 2, stepping both animations through one 3.5 s cycle:

```
 step   old centroid   new centroid    Δ      old ink    new ink
   0        134.95        134.84     -0.11    299609     299440
   1        150.43        150.49     +0.07    336316     336479
   2        158.32        158.44     +0.12    284595     284684
   3        146.96        146.88     -0.08    216582     216508
  ...
  13        128.40        128.46     +0.06    225907     225670
```

Centroids agree within 0.12 device px and total ink within 0.1% at every phase.

Sampling the fixed label at 70 phases across the cycle and correlating the glyph profile against the first frame gives **max |shift| = 0.004 device px** (the current implementation is what produced the 2.012 above).

## Notes

- `.zero-shimmer-text` is now the animated element, so the dialog-scrim "park always-on animations" rule points at it instead of the two removed overlay classes.
- The queued label's `queue…` button goes back to living directly inside the shimmering `<p>`, as it did before #26123; `background-clip: text` masks descendant glyphs too, so it still shimmers.
- `chat-capability-thinking.test.tsx` measures the element carrying `.zero-shimmer-text`, which is still the ref'd `<p>`.

Fixes #31625
