### PR TITLE
fix(platform): follow the newUi palette on the authentication page

### DIFF
--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-presentation.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import {
   click,
@@ -122,18 +123,59 @@ test("Authentication link actions remain readable in light and dark themes", asy
     return linkByText("Sign up");
   });
   const surface = screen.getByTestId("app-auth-v2");
-  await expect(
-    renderedAuthV2LinkContrast(signUp, surface, "light", context.signal),
-  ).resolves.toBeGreaterThanOrEqual(4.5);
+  for (const palette of ["current-ui", "new-ui"] as const) {
+    await expect(
+      renderedAuthV2LinkContrast(
+        signUp,
+        surface,
+        "light",
+        palette,
+        context.signal,
+      ),
+    ).resolves.toBeGreaterThanOrEqual(4.5);
+  }
 
   click(buttonByLabel("Toggle theme"));
 
   await waitFor(() => {
     expect(document.documentElement).toHaveAttribute("data-theme", "dark");
   });
-  await expect(
-    renderedAuthV2LinkContrast(signUp, surface, "dark", context.signal),
-  ).resolves.toBeGreaterThanOrEqual(4.5);
+  for (const palette of ["current-ui", "new-ui"] as const) {
+    await expect(
+      renderedAuthV2LinkContrast(
+        signUp,
+        surface,
+        "dark",
+        palette,
+        context.signal,
+      ),
+    ).resolves.toBeGreaterThanOrEqual(4.5);
+  }
+});
+
+test("Authentication stays on the current palette without the switch", async () => {
+  await setupPage({
+    auth: null,
+    context,
+    host: "app.vm0.ai",
+    path: "/sign-in",
+  });
+
+  await expect(screen.findByLabelText("Email address")).resolves.toBeVisible();
+  expect(document.documentElement).not.toHaveAttribute("data-new-ui");
+});
+
+test("Authentication signs the user in on the palette their switch selects", async () => {
+  await setupPage({
+    auth: null,
+    cachedFeatureSwitches: { [FeatureSwitchKey.NewUi]: true },
+    context,
+    host: "app.vm0.ai",
+    path: "/sign-in",
+  });
+
+  await expect(screen.findByLabelText("Email address")).resolves.toBeVisible();
+  expect(document.documentElement).toHaveAttribute("data-new-ui");
 });
 
 test("Okou authentication localizes app copy while keeping English startup metadata", async () => {

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-style-assertions.ts
@@ -38,11 +38,25 @@ const authV2ActionTheme = `
   @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
   @theme {
     --color-card: rgb(255 255 255);
-    --color-primary-900: rgb(208 50 0);
-    --color-primary-950: rgb(92 41 24);
+    --color-auth-link: rgb(208 50 0);
   }
   @tailwind utilities;
 `;
+
+/* The resolved value of `--auth-link` and the card it sits on, per palette and
+   per theme, taken from `packages/ui`'s design system and the platform sheet.
+   The compiler above only ever sees the light branch, so the dark and gated
+   branches are restated as a plain override below. */
+const AUTH_LINK_SURFACES = {
+  "current-ui": {
+    light: { card: "rgb(255 255 255)", link: "rgb(208 50 0)" }, // primary-900
+    dark: { card: "rgb(37 37 39)", link: "rgb(255 148 110)" }, // primary-900
+  },
+  "new-ui": {
+    light: { card: "rgb(255 255 255)", link: "rgb(136 86 0)" }, // brand-text
+    dark: { card: "rgb(43 42 40)", link: "rgb(255 165 0)" }, // brand-text
+  },
+} as const;
 
 function colorChannels(color: string): readonly [number, number, number] {
   const channels = color
@@ -85,8 +99,10 @@ export async function renderedAuthV2LinkContrast(
   linkAction: HTMLElement,
   surface: HTMLElement,
   theme: "dark" | "light",
+  palette: keyof typeof AUTH_LINK_SURFACES,
   signal: AbortSignal,
 ): Promise<number> {
+  const resolved = AUTH_LINK_SURFACES[palette][theme];
   const compiler = await compile(authV2ActionTheme);
   const styleElement = document.createElement("style");
   const effectiveRestingColorClasses = (element: HTMLElement): string[] => {
@@ -126,10 +142,9 @@ export async function renderedAuthV2LinkContrast(
   ];
   styleElement.textContent = [
     compiler.build(restingColorClasses),
-    `[data-theme="dark"] {
-      --color-card: rgb(37 37 39);
-      --color-primary-900: rgb(255 148 110);
-      --color-primary-950: rgb(254 213 199);
+    `:root {
+      --color-card: ${resolved.card};
+      --color-auth-link: ${resolved.link};
     }`,
   ].join("\n");
   document.head.append(styleElement);

--- a/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
+++ b/turbo/apps/platform/src/views/auth-v2/auth-v2-action-styles.ts
@@ -2,4 +2,4 @@ export const AUTH_V2_PRIMARY_ACTION_CLASS =
   "bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-pressed";
 
 export const AUTH_V2_LINK_ACTION_CLASS =
-  "text-primary-900 hover:text-primary-950 active:text-primary-950";
+  "text-auth-link hover:text-auth-link-hover active:text-auth-link-hover";

--- a/turbo/apps/platform/src/views/auth/auth-shell.tsx
+++ b/turbo/apps/platform/src/views/auth/auth-shell.tsx
@@ -3,12 +3,18 @@ import { Moon, Sun } from "lucide-react";
 import { useGet, useSet } from "ccstate-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   platformVm0LogoDarkImg,
   platformVm0LogoImg,
 } from "../../lib/static-assets.ts";
 import type { AuthBrandContext } from "../../signals/auth.ts";
-import { setTheme$, theme$ } from "../../signals/theme.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import {
+  applyNewUiDocumentAttribute,
+  setTheme$,
+  theme$,
+} from "../../signals/theme.ts";
 import { ProductBrandMark } from "../components/product-brand-mark.tsx";
 
 interface AuthShellProps {
@@ -20,9 +26,18 @@ export function AuthShell({ authBrand, children }: AuthShellProps) {
   const { t } = useTranslation();
   const theme = useGet(theme$);
   const setTheme = useSet(setTheme$);
+  const newUiEnabled = useGet(featureSwitch$)[FeatureSwitchKey.NewUi] ?? false;
 
   return (
     <div
+      ref={(element) => {
+        // The palette is a per-user switch and this page runs before there is a
+        // session to read it from, so it comes off the cache the last signed-in
+        // session left behind. A returning user therefore signs in on the same
+        // brand they left, and a first-ever visitor gets the current one --
+        // which is the same answer the switch itself gives them.
+        applyNewUiDocumentAttribute(element !== null && newUiEnabled);
+      }}
       className="zero-app relative flex h-full min-h-0 overflow-x-hidden overflow-y-auto bg-background p-6"
       data-testid="app-auth-layout"
     >

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -37,6 +37,13 @@
   --color-usage-kind-video: #358a8e;
   --color-usage-kind-connector: #98928b;
   --color-usage-kind-other: #e1c43c;
+
+  /* Brand as text on the authentication card. Its own token because the two
+     palettes disagree about which stop that is, and the card is the one place
+     the brand carries 13px body copy, so the answer has to clear 4.5:1 in both
+     themes. See the pair it resolves from below. */
+  --color-auth-link: hsl(var(--auth-link));
+  --color-auth-link-hover: hsl(var(--auth-link-hover));
 }
 
 /* Safe area insets as CSS custom properties — more reliable than direct env() in inline
@@ -49,6 +56,15 @@
   --sal: env(safe-area-inset-left, 0px);
   --zero-viewport-height: 100dvh;
   --zero-desktop-titlebar-height: 48px;
+}
+
+/* The orange ramp mirrors between themes, so its 900 is a brand red in light
+   and a light salmon in dark, and both clear 4.5:1 on the card. `--brand-text`
+   cannot stand in for it here: on this ramp that token is the brand stop
+   itself, which reads at 3.69:1 on white. */
+:root {
+  --auth-link: var(--primary-900);
+  --auth-link-hover: var(--primary-950);
 }
 
 @supports (height: 100lvh) {
@@ -2060,6 +2076,15 @@ html:has(.zero-dialog-overlay)
   --color-usage-kind-video: #008d76;
   --color-usage-kind-connector: #779aad;
   --color-usage-kind-other: #c8b800;
+}
+
+/* Amber does not mirror, so the 900 the orange ramp used for the card's
+   secondary actions is a near-black brown in both themes: body copy in light,
+   and 1.2:1 against the dark canvas. Here `--brand-text` is the readable one --
+   a stop below the brand in light (6.2:1), the brand itself in dark (7.3:1). */
+:root[data-new-ui] {
+  --auth-link: var(--brand-text);
+  --auth-link-hover: var(--brand-text-hover);
 }
 
 /* Shadows carry a hue of their own, so a cool one greys the warm surfaces. */


### PR DESCRIPTION
The sign-in card's primary button reads the brand from `--primary`, and the design system already switches that token per user under `newUi`. What sets the switching attribute is the app shell — and authentication runs before that shell mounts. So the page kept the current brand's orange primary while the app behind it drew Amber. The VM0 mark on that same card already reads the switch directly and drew Amber, so the mismatch was visible side by side.

`AuthShell` now applies the same attribute the app shell does. The switch is per-user and there is no session here to resolve it against, so it comes off the cache the last signed-in session left behind: a returning user signs in on the brand they left, and a first-ever visitor gets the current one — which is the answer the switch would give them anyway.

### The card's secondary actions could not follow as they were

They reached for `primary-900` directly. That works on the orange ramp, which mirrors between themes: a brand red in light, a light salmon in dark, both clearing 4.5:1 on the card. Amber does not mirror, and its 900 is a near-black brown in both — body copy in light, and **1.2:1 against the dark canvas**. `--brand-text` cannot simply replace it either, because on the orange ramp that token is the brand stop itself at 3.69:1 on white.

So the links take an `--auth-link` pair that resolves per palette: `primary-900` / `primary-950` as today, and `--brand-text` / `--brand-text-hover` under the switch (6.2:1 light, 7.3:1 dark).

### Verification

- The existing contrast assertion now runs over both palettes in both themes; it was confirmed to fail at 1.22 when pointed at Amber's 900, which is the case this change exists to prevent.
- Two new tests cover the attribute: absent without the switch, present with it cached.
- Rendered the card off the real compiled stylesheet in both palettes and both themes:

| | current | `newUi` |
|---|---|---|
| light | orange primary, white label | Amber primary, Ink label |
| dark | unchanged | Amber primary, readable brand link |

`pnpm format`, `eslint`, `pnpm check-types`, `pnpm knip --workspace apps/platform`, and `vitest run src/views/auth src/views/auth-v2 src/views/css` (111 tests) all pass locally.

Nothing changes for anyone without the switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)