### PR TITLE
refactor(api): consolidate openrouter fast-path callers onto the shared helper

### DIFF
--- a/turbo/apps/api/src/lib/strip-markdown.ts
+++ b/turbo/apps/api/src/lib/strip-markdown.ts
@@ -1,0 +1,15 @@
+/**
+ * Remove the Markdown syntax a model tends to emit even when asked for plain
+ * text. Shared by every surface that renders generated text unstyled: chat
+ * titles, run summaries, and goal objective briefs.
+ */
+export function stripMarkdown(text: string): string {
+  return text
+    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^[-*_]{3,}\s*$/gm, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^["'](.+)["']$/, "$1")
+    .trim();
+}

--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -5,6 +5,15 @@ const OPENROUTER_CHAT_COMPLETIONS_URL =
   "https://openrouter.ai/api/v1/chat/completions";
 const OPENROUTER_ERROR_RESPONSE_MAX_BYTES = 64 * 1024;
 
+/**
+ * The model behind every internal fast-path generation: chat and shared-thread
+ * titles, recommended follow-ups, notification summaries, initial thinking
+ * copy, run summaries, goal objective briefs, and voice I/O polish. These are
+ * short, latency-sensitive calls that are not user-selectable, so they share a
+ * single model rather than one constant per service.
+ */
+export const FAST_PATH_MODEL = "google/gemini-3.1-flash-lite";
+
 export interface OpenRouterTextPart {
   readonly type: "text";
   readonly text: string;
@@ -55,8 +64,10 @@ interface OpenRouterResponse {
   readonly choices?: readonly OpenRouterChoice[];
 }
 
+type OpenRouterReasoningEffort = "none" | "minimal" | "low" | "medium" | "high";
+
 interface OpenRouterGenerateTextOptions {
-  readonly reasoning?: { readonly effort: "none" };
+  readonly reasoning?: { readonly effort: OpenRouterReasoningEffort };
   readonly temperature?: number;
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -13960,7 +13960,7 @@ describe("CHAT-02: initial thinking indicator", () => {
     });
     expect(thinkingAuthorization).toBe("Bearer thinking-key");
     expect(thinkingRequestBody).toMatchObject({
-      model: "google/gemini-3.1-flash-lite-preview",
+      model: "google/gemini-3.1-flash-lite",
       max_tokens: 160,
       reasoning: { effort: "none" },
     });
@@ -14058,6 +14058,7 @@ describe("CHAT-02: prior rounds and thread titles", () => {
             return HttpResponse.json({
               choices: [
                 {
+                  finish_reason: "stop",
                   message: {
                     content: JSON.stringify([
                       { prompt: "Summarize the migration steps", kind: "talk" },
@@ -14070,11 +14071,21 @@ describe("CHAT-02: prior rounds and thread titles", () => {
           if (systemContent.includes("Generate a short, descriptive title")) {
             titleRequests += 1;
             return HttpResponse.json({
-              choices: [{ message: { content: "**Migration Plan**" } }],
+              choices: [
+                {
+                  finish_reason: "stop",
+                  message: { content: "**Migration Plan**" },
+                },
+              ],
             });
           }
           return HttpResponse.json({
-            choices: [{ message: { content: "Generated summary" } }],
+            choices: [
+              {
+                finish_reason: "stop",
+                message: { content: "Generated summary" },
+              },
+            ],
           });
         },
       ),
@@ -14228,6 +14239,7 @@ describe("CHAT-02: prior rounds and thread titles", () => {
           return HttpResponse.json({
             choices: [
               {
+                finish_reason: "stop",
                 message: {
                   content: systemContent.includes("concise follow-up prompts")
                     ? JSON.stringify([

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -3048,6 +3048,7 @@ describe("CHAT-01 chat search index", () => {
           return HttpResponse.json({
             choices: [
               {
+                finish_reason: "stop",
                 message: {
                   content: body.includes("concise follow-up prompts")
                     ? JSON.stringify([

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
@@ -309,7 +309,12 @@ export function createChatCallbacksApi(context: TestContext) {
             await request.json(),
           );
           return HttpResponse.json({
-            choices: [{ message: { content: await handler(body) } }],
+            choices: [
+              {
+                finish_reason: "stop",
+                message: { content: await handler(body) },
+              },
+            ],
           });
         }),
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -305,7 +305,7 @@ function mockOpenRouterSummary(summary: string): unknown[] {
       async ({ request }) => {
         requests.push(await request.json());
         return HttpResponse.json({
-          choices: [{ message: { content: summary } }],
+          choices: [{ finish_reason: "stop", message: { content: summary } }],
         });
       },
     ),

--- a/turbo/apps/api/src/signals/services/chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-initial-thinking.service.ts
@@ -16,7 +16,7 @@ import {
 
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
-import { generateText } from "../external/openrouter";
+import { FAST_PATH_MODEL, generateText } from "../external/openrouter";
 import { publishChatThreadMessageCreatedSafely } from "../external/realtime";
 import { tapError } from "../utils";
 import { assistantEventIdForRunEvent } from "./assistant-event-id";
@@ -39,7 +39,6 @@ import {
 
 const log = logger("api:chat-initial-thinking");
 
-const FAST_CHAT_MODEL = "google/gemini-3.1-flash-lite-preview";
 const INITIAL_THINKING_RUN_EVENT_ID = "thinking:initial";
 const THINKING_CONTEXT_MESSAGE_CAP = 8;
 const THINKING_CONTEXT_CHAR_CAP = 700;
@@ -201,7 +200,7 @@ async function generateInitialThinkingText(args: {
     .join("\n\n");
 
   const text = await generateText(
-    FAST_CHAT_MODEL,
+    FAST_PATH_MODEL,
     [
       {
         role: "system",

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -21,9 +21,14 @@ import {
   not,
   type SQL,
 } from "drizzle-orm";
-import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
+import { stripMarkdown } from "../../lib/strip-markdown";
 import { waitUntil } from "../context/wait-until";
+import {
+  FAST_PATH_MODEL,
+  generateText,
+  isLlmConfigured,
+} from "../external/openrouter";
 import { publishThreadListChanged } from "../external/realtime";
 import type { Db } from "../external/db";
 import { nowDate } from "../../lib/time";
@@ -46,9 +51,6 @@ import {
 } from "./canonical-chat-event-read.service";
 
 const log = logger("api:zero:chat-title");
-const OPENROUTER_CHAT_COMPLETIONS_URL =
-  "https://openrouter.ai/api/v1/chat/completions";
-const FAST_CHAT_MODEL = "google/gemini-3.1-flash-lite-preview";
 const TITLE_CONTEXT_CHAR_CAP = 150;
 const TITLE_PRIOR_MESSAGE_CAP = 10;
 const FOLLOWUP_CONTEXT_CHAR_CAP = 700;
@@ -133,14 +135,6 @@ interface ChatTitleInput {
   readonly priorRounds?: readonly ChatCompletionContextMessage[];
 }
 
-interface OpenRouterResponse {
-  readonly choices: readonly {
-    readonly message: {
-      readonly content: string;
-    };
-  }[];
-}
-
 interface ChatMessageForGeneration {
   readonly role: "system" | "user" | "assistant";
   readonly content: string;
@@ -153,10 +147,6 @@ interface ChatCompletionContextRow {
 }
 
 type SelectDb = Pick<Db, "select">;
-
-function isChatTitleGenerationConfigured(): boolean {
-  return Boolean(optionalEnv("OPENROUTER_API_KEY"));
-}
 
 function completedConversationContextMessageCondition(db: SelectDb) {
   return and(
@@ -199,58 +189,19 @@ function chatCompletionContextMessage(
   return row.content === null ? [] : [{ role, content: row.content }];
 }
 
-function stripMarkdown(text: string): string {
-  return text
-    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
-    .replace(/^#{1,6}\s+/gm, "")
-    .replace(/^[-*_]{3,}\s*$/gm, "")
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/^["'](.+)["']$/, "$1")
-    .trim();
-}
-
-async function generateText(
+async function generateFastPathText(
   messages: readonly ChatMessageForGeneration[],
   maxTokens = 30,
   options?: {
     readonly stripMarkdown?: boolean;
   },
 ): Promise<string | null> {
-  const apiKey = optionalEnv("OPENROUTER_API_KEY");
-  if (!apiKey) {
+  const content = await generateText(FAST_PATH_MODEL, messages, maxTokens, {
+    temperature: 0.3,
+  });
+  if (content === null) {
     return null;
   }
-
-  const response = await fetch(OPENROUTER_CHAT_COMPLETIONS_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: FAST_CHAT_MODEL,
-      messages,
-      max_tokens: maxTokens,
-      temperature: 0.3,
-    }),
-  });
-
-  if (!response.ok) {
-    const text = (await tapError(response.text())) ?? "unknown error";
-    throw new Error(`OpenRouter request failed: ${response.status} ${text}`);
-  }
-
-  const data = (await response.json()) as OpenRouterResponse;
-  const rawContent = data.choices[0]?.message.content;
-  if (rawContent === undefined) {
-    throw new Error("OpenRouter returned empty content");
-  }
-  const content = rawContent.trim();
-  if (!content) {
-    throw new Error("OpenRouter returned empty content");
-  }
-
   return options?.stripMarkdown === false ? content : stripMarkdown(content);
 }
 
@@ -273,7 +224,7 @@ function generateChatTitle(input: ChatTitleInput): Promise<string | null> {
     `Most recent user message:\n${input.currentUserMessage.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
   );
 
-  return generateText([
+  return generateFastPathText([
     {
       role: "system",
       content:
@@ -296,7 +247,7 @@ export async function generateSharedThreadTitle(
       return `${message.role}: ${message.content.slice(0, TITLE_CONTEXT_CHAR_CAP)}`;
     })
     .join("\n");
-  const title = await generateText([
+  const title = await generateFastPathText([
     {
       role: "system",
       content:
@@ -454,7 +405,7 @@ export function scheduleChatThreadTitleGeneration(args: {
   readonly prompt: string;
   readonly includePriorRounds: boolean;
 }): void {
-  if (!isChatTitleGenerationConfigured() || args.prompt.trim().length === 0) {
+  if (!isLlmConfigured() || args.prompt.trim().length === 0) {
     return;
   }
   waitUntil(generateAndPersistChatThreadTitle(args));
@@ -464,7 +415,7 @@ export function generateChatNotificationSummary(
   prompt: string,
   resultText: string,
 ): Promise<string | null> {
-  return generateText(
+  return generateFastPathText(
     [
       {
         role: "system",
@@ -534,7 +485,7 @@ async function generateRecommendedFollowups(
     })
     .join("\n\n");
 
-  const text = await generateText(
+  const text = await generateFastPathText(
     [
       {
         role: "system",

--- a/turbo/apps/api/src/signals/services/goal-objective-brief-normalization.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-objective-brief-normalization.service.ts
@@ -1,16 +1,7 @@
+import { stripMarkdown } from "../../lib/strip-markdown";
+
 const OBJECTIVE_BRIEF_MAX_CHARS = 140;
 const DEFAULT_GOAL_OBJECTIVE_BRIEF = "Untitled goal";
-
-function stripMarkdown(text: string): string {
-  return text
-    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
-    .replace(/^#{1,6}\s+/gm, "")
-    .replace(/^[-*_]{3,}\s*$/gm, "")
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/^["'](.+)["']$/, "$1")
-    .trim();
-}
 
 export function compactGoalObjectiveBriefText(text: string): string {
   return stripMarkdown(text).replace(/\s+/g, " ").trim();

--- a/turbo/apps/api/src/signals/services/goal-objective-brief.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-objective-brief.service.ts
@@ -1,5 +1,5 @@
 import { logger } from "../../lib/log";
-import { generateText } from "../external/openrouter";
+import { FAST_PATH_MODEL, generateText } from "../external/openrouter";
 import { tapError } from "../utils";
 import {
   capGoalObjectiveBriefText,
@@ -8,7 +8,6 @@ import {
 } from "./goal-objective-brief-normalization.service";
 
 const log = logger("api:goal-objective-brief");
-const OBJECTIVE_BRIEF_MODEL = "google/gemini-3.1-flash-lite-preview";
 const OBJECTIVE_CONTEXT_CHAR_CAP = 4000;
 export async function generateGoalObjectiveBrief(
   objective: string,
@@ -16,7 +15,7 @@ export async function generateGoalObjectiveBrief(
   const fallback = fallbackGoalObjectiveBrief(objective);
   const generated = await tapError(
     generateText(
-      OBJECTIVE_BRIEF_MODEL,
+      FAST_PATH_MODEL,
       [
         {
           role: "system",

--- a/turbo/apps/api/src/signals/services/run-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/run-summary.service.ts
@@ -3,75 +3,17 @@ import { eq } from "drizzle-orm";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 
 import { logger } from "../../lib/log";
-import { optionalEnv } from "../../lib/env";
+import { stripMarkdown } from "../../lib/strip-markdown";
 import { writeDb$, type Db } from "../external/db";
+import {
+  FAST_PATH_MODEL,
+  generateText,
+  isLlmConfigured,
+} from "../external/openrouter";
 import { tapError } from "../utils";
 import { writeRunMetadata } from "./agent-run-metadata-write.service";
 
 const log = logger("run-summary");
-const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
-const OPENROUTER_MODEL = "google/gemini-3.1-flash-lite-preview";
-
-interface ChatMessage {
-  readonly role: "system" | "user" | "assistant";
-  readonly content: string;
-}
-
-interface OpenRouterResponse {
-  readonly choices: readonly {
-    readonly message: {
-      readonly content: string;
-    };
-  }[];
-}
-
-async function generateText(
-  messages: readonly ChatMessage[],
-  maxTokens: number,
-): Promise<string | null> {
-  const apiKey = optionalEnv("OPENROUTER_API_KEY");
-  if (!apiKey) {
-    log.warn("OPENROUTER_API_KEY not configured, skipping text generation");
-    return null;
-  }
-
-  const response = await fetch(OPENROUTER_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: OPENROUTER_MODEL,
-      messages,
-      max_tokens: maxTokens,
-      temperature: 0.3,
-    }),
-  });
-
-  if (!response.ok) {
-    const text = (await tapError(response.text())) ?? "unknown error";
-    throw new Error(`OpenRouter request failed: ${response.status} ${text}`);
-  }
-
-  const data = (await response.json()) as OpenRouterResponse;
-  const content = data.choices[0]?.message.content.trim();
-  if (!content) {
-    throw new Error("OpenRouter returned empty content");
-  }
-  return stripMarkdown(content);
-}
-
-function stripMarkdown(text: string): string {
-  return text
-    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
-    .replace(/^#{1,6}\s+/gm, "")
-    .replace(/^[-*_]{3,}\s*$/gm, "")
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/^["'](.+)["']$/, "$1")
-    .trim();
-}
 
 function truncateSnippet(
   text: string,
@@ -89,15 +31,21 @@ function truncateSnippet(
     .join("\n");
 }
 
-function generateRunSummary(
+async function generateRunSummary(
   triggerSource: string,
   prompt: string,
   resultText: string,
 ): Promise<string | null> {
+  if (!isLlmConfigured()) {
+    log.warn("OPENROUTER_API_KEY not configured, skipping text generation");
+    return null;
+  }
+
   const promptSnippet = truncateSnippet(prompt);
   const resultSnippet = truncateSnippet(resultText);
 
-  return generateText(
+  const content = await generateText(
+    FAST_PATH_MODEL,
     [
       {
         role: "system",
@@ -109,7 +57,9 @@ function generateRunSummary(
       },
     ],
     80,
+    { temperature: 0.3 },
   );
+  return content === null ? null : stripMarkdown(content);
 }
 
 export async function saveRunSummary(

--- a/turbo/apps/api/src/signals/services/voice-io-polish.service.ts
+++ b/turbo/apps/api/src/signals/services/voice-io-polish.service.ts
@@ -8,13 +8,13 @@ import { command } from "ccstate";
 import { notConfigured } from "../../lib/error";
 import { requestSignal$ } from "../context/hono";
 import {
+  FAST_PATH_MODEL,
   generateText,
   isLlmConfigured,
   OpenRouterRequestError,
 } from "../external/openrouter";
 import { settle } from "../utils";
 
-const VOICE_IO_POLISH_MODEL = "google/gemini-3.1-flash-lite";
 const VOICE_IO_POLISH_MAX_TOKENS = 65_536;
 const VOICE_IO_POLISH_SYSTEM_PROMPT = [
   "The task is careful editing of raw voice dictation into send-ready writing, rather than summarization or assistance.",
@@ -65,7 +65,7 @@ export const polishVoiceTranscript$ = command(
 
     const generated = await settle(
       generateText(
-        VOICE_IO_POLISH_MODEL,
+        FAST_PATH_MODEL,
         [
           { role: "system", content: VOICE_IO_POLISH_SYSTEM_PROMPT },
           { role: "user", content: JSON.stringify(body) },


### PR DESCRIPTION
Slice 1 of #31616. Closes #31619.

Collapses the three parallel OpenRouter client implementations in `apps/api` into one. Pure refactor apart from the two deliberate differences called out below.

## What changed

- **Deleted both private inline `fetch` implementations** (`chat-title.service.ts`, `run-summary.service.ts`) and routed both through `signals/external/openrouter.ts`.
- **Moved `stripMarkdown` into `lib/strip-markdown.ts`.** There were **three** byte-identical copies, not two — `goal-objective-brief-normalization.service.ts` had one as well. Verified identical against `origin/main` before collapsing; the shared body is character-for-character the original.
- **One shared model constant** `FAST_PATH_MODEL` in `signals/external/openrouter.ts`. Deleted `FAST_CHAT_MODEL` (×2), `OPENROUTER_MODEL`, `OBJECTIVE_BRIEF_MODEL`, `VOICE_IO_POLISH_MODEL`.
- **Widened the reasoning option** to `"none" | "minimal" | "low" | "medium" | "high"`, unblocking slice 2's `effort: "low"`. No call site's reasoning behavior changed; call sites that pass nothing today still pass nothing.
- `chat-title.service.ts`'s private `isChatTitleGenerationConfigured()` is now the shared `isLlmConfigured()` — identical implementation, and the private `optionalEnv` import had to go with the private `fetch`.

## Deliberate difference 1: preview → GA model id

`voice-io-polish.service.ts` named the GA id `google/gemini-3.1-flash-lite`; the other four named the preview alias `google/gemini-3.1-flash-lite-preview`. One constant forces a choice, and **this PR picks the GA id**. Pricing, context window, and supported parameters are identical, and leaving a preview alias in production is the riskier option.

**This changes the model string for four call sites**: chat titles / follow-ups / notification summaries, initial thinking, run summaries, and goal objective briefs. It is the only model-string change in this slice — the actual model migration is slice 2.

Forced fixture update: `chat-events.bdd.test.ts` asserted `-preview` and now asserts the GA id. `voice-io-polish.test.ts` already asserted the GA id and is unchanged.

## Deliberate difference 2: truncated responses now fail loudly

The shared helper is **stricter** than the private implementations: `parseOpenRouterGeneration` throws when `finish_reason !== "stop"`, and neither private implementation inspected `finish_reason` at all.

Today a truncated response (`finish_reason: "length"`) is silently accepted on the private paths. After this PR it throws and is caught by each call site's existing `tapError`/`settle` wrapper. Per call site:

| Path | `max_tokens` | Before | After |
|---|---|---|---|
| Recommended follow-ups | 260 | partial JSON → `safeJsonParse` → usually `[]`, silently | `Recommended follow-up generation failed` warn, `[]` returned |
| Chat / shared-thread title | 30 | truncated title persisted | `Chat title generation failed` warn, thread stays untitled and retries next round |
| Notification summary | 35 | truncated sentence used | `null`, caller falls back |
| Run summary | 80 | truncated summary persisted | `Failed to generate run summary` warn, no summary written |

This is a **strict improvement** — a currently-silent failure class becomes observable — but it is a real behavior change on the error path, so it is stated here rather than buried. Per #31619 no `finish_reason` bypass was added to preserve the old silence.

Forced fixture update: MSW mocks that feed these paths returned `choices: [{ message: { content } }]` with no `finish_reason`, which the shared helper now rejects. Added `finish_reason: "stop"` in `helpers/api-bdd-chat-callbacks.ts`, `chat-events.bdd.test.ts`, `chat-threads.bdd.test.ts`, and `internal-callbacks-teams.test.ts`. No assertion was changed to accommodate the refactor.

## Preserved exactly

- `temperature: 0.3` on every call the private implementations made. Note the shared helper already defaults to `0.3` when the option is absent, so the wire body is byte-identical either way — it is passed explicitly anyway so the preserved value is visible at the call site.
- `maxTokens` per call site: chat title `30`, notification summary `35`, follow-ups `260`, run summary `80`, thinking `160`, objective brief `80`, voice polish `65536`. None changed.
- The `stripMarkdown` opt-out: follow-ups still pass `{ stripMarkdown: false }` because the payload is JSON; every other caller still strips.
- `run-summary.service.ts`'s `log.warn("OPENROUTER_API_KEY not configured, skipping text generation")`, which the shared helper does not emit — kept at the call site behind `isLlmConfigured()`.
- The reasoning arguments already passed by `chat-initial-thinking.service.ts` (`{ effort: "none" }`) and `voice-io-polish.service.ts` (`{ effort: "none" }`, `temperature: 0`).
- **No prompt text touched.** `git diff` shows zero changes to any prompt string constant, including `OPTIMIZED_RECOMMENDED_FOLLOWUP_SYSTEM_PROMPT` which #31611 is editing concurrently.

## Non-goals respected

No model migration (slice 2), no new reasoning effort on any call site, no `max_tokens` change, no prompt change, no `image-recognition.service.ts` change, no public API or contract change. #31573 was closed, so there is no `openrouter-voice.ts` to fold in.

## Verification

Rebased onto `920d77b`. `pnpm -F api check-types`, `pnpm -F api lint`, `pnpm knip --workspace apps/api`, and Prettier all pass.

Targeted tests run locally: `voice-io-polish.test.ts` (3/3), plus the `chat-events.bdd.test.ts` initial-thinking cases that assert the model string and the truncated-response path. The remaining BDD cases cannot complete in this container — `claimChatRun` returns `Job not found in queue` because the runner job queue is unavailable locally, and the same cases fail identically on unmodified `origin/main`. Those are left to the PR pipeline. The title path is covered regardless: that test reaches `waitForThreadTitle("Migration Plan")` and `titleRequests === 1` before the infrastructure-blocked claim step.
