### PR TITLE
docs: point the connector link at okou.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Read our [Security overview](https://www.okou.ai/en/security).
 
 ## Works with the tools you already use
 
-Slack · GitHub · Gmail · Google Calendar · Google Sheets · Notion · Linear · Sentry · Axiom · HubSpot · Intercom · Figma · Vercel · Dropbox · DocuSign · Deel · Airtable · Ahrefs · Meta Ads · X · Reddit · …and [3,000+ more connectors](https://github.com/vm0-ai/vm0-skills).
+Slack · GitHub · Gmail · Google Calendar · Google Sheets · Notion · Linear · Sentry · Axiom · HubSpot · Intercom · Figma · Vercel · Dropbox · DocuSign · Deel · Airtable · Ahrefs · Meta Ads · X · Reddit · …and [3,000+ more connectors](https://www.okou.ai/en/integrations).
 
 Model providers are yours to pick — Anthropic, OpenAI, DeepSeek, Google and others, selected per run or per agent.
 


### PR DESCRIPTION
Closes #31662. Part of #26701.

`README.md:114` ended the connector list by linking to the `vm0-ai/vm0-skills` repository. A GitHub repository is the wrong destination for a reader who wants to know what Okou connects to, so the link now points at the connectors page on the marketing site:

    https://www.okou.ai/en/integrations

Nothing else on that line changed — the tool names, the ordering, and the "3,000+ more connectors" wording all stay as they were.

## Verification

- Fetched `https://www.okou.ai/en/integrations` directly: **HTTP 200**, no redirect. Title is *"AI Integration: Slack and 3,000+ Connectors | Okou"*, and the page body is Okou-branded and uses the same "3,000+ connectors" figure the README does, so the link text needs no change.
- `git grep -n 'vm0-skills' -- '*.md'` now returns only the two historical lines in `docs/okou-cli-cutover.md` (lines 40 and 47). Those describe a past audit — "the supported durable source audit was clean at vm0-skills commit …" — and are correct as written, so they are deliberately left alone.

The `vm0-ai/vm0-skills` repository itself is untouched: this PR only removes the README reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)