### PR TITLE
test(runtime): remove retired zero env tombstones

### DIFF
--- a/.github/scripts/audit-okou-cli-cutover.sh
+++ b/.github/scripts/audit-okou-cli-cutover.sh
@@ -155,12 +155,6 @@ if [[ -f "${repo_root}/${turbo_workflow_path}" ]] &&
   report_boundary_failure "${turbo_workflow_path}" "legacy symlink present or canonical loop smoke missing"
 fi
 
-e2e_setup_path="e2e/helpers/setup.bash"
-if [[ -f "${repo_root}/${e2e_setup_path}" ]] &&
-  rg -q -F 'ZERO_CLI' "${repo_root}/${e2e_setup_path}"; then
-  report_boundary_failure "${e2e_setup_path}" "legacy E2E command wrapper"
-fi
-
 e2e_trace_path="e2e/helpers/trace-cli.sh"
 if [[ -f "${repo_root}/${e2e_trace_path}" ]] &&
   (! rg -q -F 'CLI_ENTRYPOINT="okou"' "${repo_root}/${e2e_trace_path}" ||

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1100,7 +1100,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
             "https://app.runner-env.example.test/path".into(),
         ),
         (
-            "ZERO_APP_URL".into(),
+            "CUSTOM_APP_URL".into(),
             "https://app.runner-env.example.test/path".into(),
         ),
         (
@@ -1122,7 +1122,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
             "https://app.runner-env.example.test/path".into(),
         ),
         (
-            "ZERO_APP_URL".into(),
+            "CUSTOM_APP_URL".into(),
             "https://app.runner-env.example.test/path".into(),
         ),
     ]);
@@ -1190,7 +1190,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         "CUSTOM_USER_ENV",
         "LARGE_USER_ENV",
         "OKOU_APP_URL",
-        "ZERO_APP_URL",
+        "CUSTOM_APP_URL",
         "VM0_FUTURE_RUNNER_KEY",
         "CUSTOM_API_TOKEN",
         "BASH_ENV",
@@ -1236,7 +1236,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         "https://app.runner-env.example.test/path"
     );
     assert_eq!(
-        user_env.get("ZERO_APP_URL").unwrap(),
+        user_env.get("CUSTOM_APP_URL").unwrap(),
         "https://app.runner-env.example.test/path"
     );
     assert_eq!(user_env.get("BASH_ENV").unwrap(), "/tmp/user-bash-env");

--- a/e2e/tests/03-runner/run-t14-runner-context.bats
+++ b/e2e/tests/03-runner/run-t14-runner-context.bats
@@ -65,10 +65,6 @@ test -n "$OKOU_APP_URL"
 test -n "$OKOU_AGENT_ID"
 test -n "$OKOU_CHAT_THREAD_ID"
 test -n "$OKOU_TOKEN"
-test -z "${ZERO_APP_URL:-}"
-test -z "${ZERO_AGENT_ID:-}"
-test -z "${ZERO_CHAT_THREAD_ID:-}"
-test -z "${ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED:-}"
 node -e '
 const token = process.env.OKOU_TOKEN;
 if (!token?.startsWith("vm0_sandbox_")) throw new Error("OKOU_TOKEN is not a sandbox token");

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -4540,7 +4540,6 @@ describe("Feishu integration", () => {
     const claim = await runsApi.claimRunnerJob(run.id);
     expect(claim.prompt).toBe("do the Feishu task");
     expect(claim.platformEnvironment.OKOU_AGENT_ID).toBe(alternateAgentId);
-    expect(claim.environment ?? {}).not.toHaveProperty("ZERO_AGENT_ID");
     expect(claim.appendSystemPrompt).toContain(
       "You are currently running inside: Feishu",
     );
@@ -4799,9 +4798,6 @@ describe("Feishu integration", () => {
     );
     expect(switchedAgentClaim.platformEnvironment.OKOU_AGENT_ID).toBe(
       alternateAgentId,
-    );
-    expect(switchedAgentClaim.environment ?? {}).not.toHaveProperty(
-      "ZERO_AGENT_ID",
     );
     expect(switchedAgentClaim.resumeSession).toBeNull();
     await runsApi.requestCancelRun(actor, switchedAgentRun.id, [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -14952,7 +14952,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     }
 
     const directEnvironment = {
-      ZERO_AGENT_ID: `\${{ vars.ZERO_AGENT_ID }}`,
+      CUSTOM_AGENT_ID: `\${{ vars.CUSTOM_AGENT_ID }}`,
       CUSTOM_API_TOKEN: `\${{ secrets.CUSTOM_API_TOKEN }}`,
     };
     const directAgent = await api.createDirectAgent(actor, {
@@ -14974,13 +14974,13 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       agentId: directAgent.agentId,
       prompt: "consume an application-owned Zero context",
       modelProviderType: "anthropic-api-key",
-      vars: { ZERO_AGENT_ID: directAgent.agentId },
+      vars: { CUSTOM_AGENT_ID: directAgent.agentId },
       secrets: { CUSTOM_API_TOKEN: directOkouToken },
     });
     await api.heartbeatRunner(runnerGroup);
     const directClaim = await api.claimRunnerJob(direct.runId);
     expect(directClaim.environment).toMatchObject({
-      ZERO_AGENT_ID: directAgent.agentId,
+      CUSTOM_AGENT_ID: directAgent.agentId,
       CUSTOM_API_TOKEN: directOkouToken,
     });
     expect(directClaim.environment ?? {}).not.toHaveProperty("OKOU_TOKEN");
@@ -15292,9 +15292,6 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       value: "***",
     });
     expect(claim.environment?.APP_URL).toBeUndefined();
-    expect(claim.environment ?? {}).not.toHaveProperty(
-      "ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED",
-    );
     expect(findFirewallEntry(claim.firewalls, "slack")).toStrictEqual({
       kind: "builtin",
       name: "slack",

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
@@ -394,20 +394,6 @@ describe("okou workflow automation scheduler", () => {
     await disableAutomation(automation.automationId);
   });
 
-  it("does not expose workflow permission deep-link ids to the run environment", async () => {
-    const scenario = await setup();
-    const automation = await createDueLoopAutomation(scenario, 60);
-
-    await executeDueWorkflowAutomations(automation.automationId);
-
-    const run = await onlyWorkflowRunMessage(automation.threadId);
-    await runsApi.heartbeatRunner(scenario.runnerGroup);
-    const claim = await runsApi.claimRunnerJob(run.runId);
-    const environment = claim.environment ?? {};
-    expect(environment.ZERO_WORKFLOW_ID).toBeUndefined();
-    await disableAutomation(automation.automationId);
-  });
-
   it("fires a due cron automation: creates a run, posts to the thread, sets last run state", async () => {
     const scenario = await setup({ timezone: "Asia/Shanghai" });
     const created = await accept(

--- a/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
@@ -168,33 +168,6 @@ describe("okou connector permission-request command", () => {
     expect(logCalls).not.toContain("secret");
   });
 
-  it("uses the agent permission page inside an automated run", async () => {
-    vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
-    vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");
-    vi.stubEnv("ZERO_WORKFLOW_ID", "wf-789");
-
-    await permissionRequestCommand.parseAsync([
-      "node",
-      "cli",
-      "slack",
-      "--permission",
-      SLACK_READ_PERMISSION,
-      "--url",
-      SLACK_READ_URL,
-    ]);
-
-    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("/agents/agent-abc-123/permissions?");
-    expect(logCalls).not.toContain("/workflows/wf-789/permissions?");
-    expect(logCalls).toContain("connectorSlug=slack");
-    expect(logCalls).toContain(
-      `permission=${encodeURIComponent(SLACK_READ_PERMISSION)}`,
-    );
-    expect(logCalls).toContain("action=allow");
-    expect(logCalls).not.toContain("expiresIn=");
-    expect(logCalls).not.toContain("Requested duration:");
-  });
-
   it("includes the current thread and callback prompt in the grant URL", async () => {
     vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");

--- a/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/status.test.ts
@@ -304,28 +304,11 @@ describe("okou connector status command", () => {
 
     it("fails closed for canonical run context without a projection", async () => {
       vi.stubEnv("OKOU_AGENT_ID", AGENT_UUID);
-      vi.stubEnv("ZERO_AGENT_ID", ALT_AGENT_UUID);
-      vi.stubEnv("ZERO_CHAT_THREAD_ID", "zero-thread-456");
 
       await statusCommand.parseAsync(["node", "cli", "github"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Account used by this run is unavailable");
-      expect(logCalls).not.toContain(ALT_AGENT_UUID);
-      expect(logCalls).not.toContain("zero-thread-456");
-    });
-
-    it("ignores legacy Zero runtime context without canonical values", async () => {
-      vi.stubEnv("ZERO_AGENT_ID", ALT_AGENT_UUID);
-      vi.stubEnv("ZERO_CHAT_THREAD_ID", "zero-thread-456");
-      server.use(stubConnector(connectedGithub));
-
-      await statusCommand.parseAsync(["node", "cli", "github"]);
-
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).not.toContain("Authorized:");
-      expect(logCalls).not.toContain(ALT_AGENT_UUID);
-      expect(logCalls).not.toContain("zero-thread-456");
     });
 
     it("uses the production app origin in authorization links", async () => {

--- a/turbo/apps/cli/src/commands/goal/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/goal/__tests__/index.test.ts
@@ -25,7 +25,6 @@ describe("okou goal command", () => {
     vi.stubEnv("OKOU_APP_URL", undefined);
     vi.stubEnv("OKOU_AGENT_ID", undefined);
     vi.stubEnv("OKOU_CHAT_THREAD_ID", undefined);
-    vi.stubEnv("ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED", undefined);
   });
 
   afterEach(() => {

--- a/turbo/apps/cli/src/test/setup.ts
+++ b/turbo/apps/cli/src/test/setup.ts
@@ -12,9 +12,7 @@ beforeEach(() => {
   vi.stubEnv("OKOU_APP_URL", undefined);
   vi.stubEnv("OKOU_TOKEN", "");
   vi.stubEnv("OKOU_AGENT_ID", "");
-  vi.stubEnv("ZERO_AGENT_ID", "");
   vi.stubEnv("OKOU_CHAT_THREAD_ID", "");
-  vi.stubEnv("ZERO_CHAT_THREAD_ID", "");
   vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", undefined);
 
   vi.stubEnv("SENTRY_DSN", "");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/telegram-settings.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/telegram-settings.test.tsx
@@ -8,7 +8,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { getAction } from "./connector-integrations-test-helpers.ts";
 
 const context = testContext();
-const ZERO_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const PRIMARY_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 
 function agent(agentId: string, displayName: string | null): AgentResponse {
   return {
@@ -29,7 +29,7 @@ test("An admin can set up a new Telegram bot", async () => {
   const clipboard = context.mocks.browser.clipboardWriteText();
   const creationReady = context.mocks.deferred<void>();
   context.mocks.data.agents([
-    agent(ZERO_AGENT_ID, null),
+    agent(PRIMARY_AGENT_ID, null),
     agent("c0000000-0000-4000-a000-000000000002", "Support"),
   ]);
   context.mocks.data.telegramIntegration({
@@ -46,14 +46,14 @@ test("An admin can set up a new Telegram bot", async () => {
     async ({ body, respond }) => {
       expect(body).toStrictEqual({
         botToken: "123:token",
-        defaultAgentId: ZERO_AGENT_ID,
+        defaultAgentId: PRIMARY_AGENT_ID,
       });
       await creationReady.promise;
       return respond(201, {
         id: "bot_registered",
         username: "registered_bot",
         avatarUrl: null,
-        agent: { id: ZERO_AGENT_ID, name: "Zero" },
+        agent: { id: PRIMARY_AGENT_ID, name: "Zero" },
         isOwner: true,
         isConnected: false,
         connectedUser: null,


### PR DESCRIPTION
Closes #31579.

## Summary

- remove pure negative tombstones for the six retired `ZERO_*` test names scoped by the issue
- preserve general environment propagation, isolation, and selection coverage by renaming useful fixtures to `CUSTOM_APP_URL`, `CUSTOM_AGENT_ID`, and `PRIMARY_AGENT_ID`
- retain the sole historical record in `docs/okou-protocol-migration.md` unchanged; production readers/writers and protocol fields are untouched

## Exact inventory

Audited against `main@cdd82126201d921d9ae9e4203b7f243b515d50d8` with fixed-string searches that include hidden paths.

| Name | Active before | Active after | Historical after |
| --- | ---: | ---: | ---: |
| `ZERO_AGENT_ID` | 14 | 0 | 0 |
| `ZERO_APP_URL` | 5 | 0 | 0 |
| `ZERO_CHAT_THREAD_ID` | 4 | 0 | 0 |
| `ZERO_WORKFLOW_ID` | 2 | 0 | 0 |
| `ZERO_CONNECTOR_ACTION_CALLBACK_ENABLED` | 3 | 0 | 1 |
| `ZERO_CLI` | 1 | 0 | 0 |
| **Total** | **29** | **0** | **1** |

The remaining historical occurrence is `docs/okou-protocol-migration.md:37`.

## Open PR inventory

- fully paginated 49 open PRs immediately before push
- GitHub-declared changed files: 376; fetched changed-file entries: 376; mismatches: 0
- ordinary file-level overlaps: #31622 (`run-lifecycle.bdd.test.ts`), #31609 (`feishu-integration.test.ts`), #31607 (`fresh_sandbox.rs`), and #31601 (`workflow-automation-scheduler.test.ts`)
- none is a functional dependency; this PR follows first-merged precedence

## Verification

- Bash syntax, ShellCheck 0.11.0, and the cutover audit contract test
- Prettier 3.8.1 on all changed TypeScript/TSX files
- CLI lint and type-check; focused CLI tests: 55/55 passed
- App lint and type-check; focused Telegram test: 1/1 passed
- API lint and type-check
- `cargo fmt --check`
- `cargo check --locked -p runner --all-targets --all-features`
- `cargo clippy --locked -p runner --all-targets --all-features -- -D warnings`
- `git diff --check`

Local environment limits recorded for CI follow-up:

- API runner-claim test paths reached the local queue fixture as `404 Job not found in queue` before any changed assertion; the standard PR fixture will validate those paths
- the exact Runner test binary cold link was killed at the documented local 3.8 GiB memory ceiling (exit 137); affected check and strict Clippy both pass on the exact rebased head
