### PR TITLE
perf(ci): disable npm audits across non-security workflows

### DIFF
--- a/.github/scripts/tests/implicit-npm-audit-test.sh
+++ b/.github/scripts/tests/implicit-npm-audit-test.sh
@@ -44,11 +44,18 @@ end
 
 violations = []
 explicit_audit_paths = []
+expected_audit_path = ".github/workflows/security.yml"
 
 workflow_paths = Dir[File.join(repo_root, ".github/workflows/*.{yml,yaml}")]
 workflow_paths.each do |path|
   document = load_yaml(path)
   workflow_environment = document.fetch("env", {})
+  relative_path = path.delete_prefix("#{repo_root}/")
+
+  if relative_path != expected_audit_path &&
+      audit_setting(workflow_environment) != "false"
+    violations << "#{relative_path} must set top-level npm_config_audit=false"
+  end
 
   document.fetch("jobs", {}).each do |job_name, job|
     next unless job.is_a?(Hash)
@@ -133,7 +140,6 @@ script_paths.each do |path|
   end
 end
 
-expected_audit_path = ".github/workflows/security.yml"
 unless explicit_audit_paths.uniq == [expected_audit_path]
   violations << "explicit dependency audit must remain owned only by #{expected_audit_path}"
 end

--- a/.github/workflows/cleanup-clerk-test-resources.yml
+++ b/.github/workflows/cleanup-clerk-test-resources.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  npm_config_audit: "false"
   DRY_RUN: ${{ inputs.dry-run || false }}
 
 jobs:

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -11,6 +11,7 @@ on:
         default: false
 
 env:
+  npm_config_audit: "false"
   DRY_RUN: ${{ inputs.dry-run || false }}
 
 jobs:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,5 +1,8 @@
 name: Cleanup Resources
 
+env:
+  npm_config_audit: "false"
+
 on:
   pull_request_target:
     types: [closed, reopened]

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,5 +1,8 @@
 name: Crates
 
+env:
+  npm_config_audit: "false"
+
 on:
   pull_request:
   push:

--- a/.github/workflows/docker-toolchain-publish.yml
+++ b/.github/workflows/docker-toolchain-publish.yml
@@ -17,6 +17,7 @@ permissions:
   packages: write
 
 env:
+  npm_config_audit: "false"
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/docker-toolchain.yml
+++ b/.github/workflows/docker-toolchain.yml
@@ -1,5 +1,8 @@
 name: Docker Toolchain Build
 
+env:
+  npm_config_audit: "false"
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/release-please-refresh.yml
+++ b/.github/workflows/release-please-refresh.yml
@@ -1,5 +1,8 @@
 name: release-please-refresh
 
+env:
+  npm_config_audit: "false"
+
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -4,6 +4,9 @@
 
 name: Rollback Production
 
+env:
+  npm_config_audit: "false"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -1,5 +1,8 @@
 name: Runner Image
 
+env:
+  npm_config_audit: "false"
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
## Summary

- disable implicit npm audits at workflow scope for every workflow except `security.yml`
- keep Security Scanning as the sole owner of explicit dependency auditing
- enforce the workflow-wide setting in the existing implicit-audit contract test

## Motivation

Runner Image consumer detection invokes `npx` on a fresh GitHub-hosted runner. Its temporary npm install can spend several minutes in npm network work that is unrelated to CI correctness. Disabling implicit audits removes the advisory request from non-security workflows while preserving the dedicated security scan.

## Exclusions

- no dependency versions or install behavior are changed
- `.github/workflows/security.yml` and its explicit `pnpm audit` remain unchanged

## Validation

- `bash -n .github/scripts/tests/implicit-npm-audit-test.sh`
- `shellcheck .github/scripts/tests/implicit-npm-audit-test.sh`
- `.github/scripts/tests/implicit-npm-audit-test.sh`
- `actionlint` v1.7.12
- `.github/scripts/check-workflow-shell-compatibility.sh`
- all `.github/scripts/tests/*.sh`
- `git diff --check`
