### PR TITLE
fix(runner): centralize gc serialization

### DIFF
--- a/.github/scripts/prepare-runner-image.sh
+++ b/.github/scripts/prepare-runner-image.sh
@@ -210,9 +210,7 @@ REMOTE_SCRIPT
   local gc_attempt gc_status
   gc_status=0
   for gc_attempt in 1 2; do
-    if ssh "$remote" sudo flock --exclusive \
-      /var/lib/vm0-runner/locks/deployment-gc.lock \
-      "${BIN_DIR}/runner" gc --keep-latest 6; then
+    if ssh "$remote" sudo "${BIN_DIR}/runner" gc --keep-latest 6; then
       gc_status=0
       break
     else

--- a/.github/scripts/tests/prepare-runner-image-test.sh
+++ b/.github/scripts/tests/prepare-runner-image-test.sh
@@ -230,31 +230,13 @@ if [ "${1:-}" = "sudo" ] && [ "${2:-}" = "install" ]; then
   exit 0
 fi
 
-if [ "${1:-}" = "sudo" ] && [ "${2:-}" = "flock" ]; then
+if [ "${1:-}" = "sudo" ] && [ "${3:-}" = "gc" ]; then
   gc_attempt=$(( $(< "$SSH_GC_COUNT_FILE") + 1 ))
   printf '%s\n' "$gc_attempt" > "$SSH_GC_COUNT_FILE"
   IFS=',' read -r -a gc_statuses <<< "$SSH_GC_STATUSES"
   if [ "$gc_attempt" -gt "${#gc_statuses[@]}" ]; then
     echo "unexpected GC attempt ${gc_attempt}" >&2
     exit 1
-  fi
-  if [ -n "${SSH_GC_SERIALIZATION_DIR:-}" ]; then
-    case "$gc_attempt" in
-      1)
-        read -r < "${SSH_GC_SERIALIZATION_DIR}/holder-ready"
-        ;;
-      2)
-        if flock --exclusive --nonblock \
-          "${SSH_GC_SERIALIZATION_DIR}/deployment-gc.lock" true; then
-          echo "GC retry acquired the surviving invocation's lock" >&2
-          exit 1
-        fi
-        printf 'retry arrived\n' > "${SSH_GC_SERIALIZATION_DIR}/retry-arrived"
-        flock --exclusive \
-          "${SSH_GC_SERIALIZATION_DIR}/deployment-gc.lock" true
-        printf 'serialized\n' > "${SSH_GC_SERIALIZATION_DIR}/serialized"
-        ;;
-    esac
   fi
   exit "${gc_statuses[$((gc_attempt - 1))]}"
 fi
@@ -378,7 +360,6 @@ run_remote_case() {
   if PATH="${TMPDIR}/bin:${PATH}" \
     SSH_LOG="${case_dir}/ssh.log" \
     SSH_GC_COUNT_FILE="${case_dir}/gc-count" \
-    SSH_GC_SERIALIZATION_DIR="${REMOTE_GC_SERIALIZATION_DIR:-}" \
     SSH_GC_STATUSES="${REMOTE_GC_STATUSES:-}" \
     SSH_REACH_GC="${REMOTE_REACH_GC:-}" \
     SYSTEMCTL_LOG="${case_dir}/systemctl.log" \
@@ -480,39 +461,24 @@ if grep -q '^mutate ' "${verification_failure_case}/systemctl.log"; then
 fi
 grep -q 'runner service vm0-runner-pr-123-2.service is active after stop' "${verification_failure_case}/out" || fail "expected verification failure output"
 
-gc_command='ci@dev-arm-1 sudo flock --exclusive /var/lib/vm0-runner/locks/deployment-gc.lock /var/lib/vm0-runner/bin/pr-123/runner gc --keep-latest 6'
+gc_command='ci@dev-arm-1 sudo /var/lib/vm0-runner/bin/pr-123/runner gc --keep-latest 6'
 setup_command='ci@dev-arm-1 sudo /var/lib/vm0-runner/bin/pr-123/runner setup'
 
 gc_success_case="${TMPDIR}/gc-success"
 prepare_remote_case "$gc_success_case"
 REMOTE_REACH_GC=1 REMOTE_GC_STATUSES=0 run_remote_case "$gc_success_case"
 [ "$(< "${gc_success_case}/gc-count")" -eq 1 ] || fail "successful GC must run once"
-[ "$(grep -Fxc -- "$gc_command" "${gc_success_case}/ssh.log")" -eq 1 ] || fail "successful GC must use the deployment lock once"
+[ "$(grep -Fxc -- "$gc_command" "${gc_success_case}/ssh.log")" -eq 1 ] || fail "successful GC must invoke the runner directly once"
 grep -Fqx -- "$setup_command" "${gc_success_case}/ssh.log" || fail "successful GC must continue to runner setup"
 
 gc_retry_case="${TMPDIR}/gc-retry"
 prepare_remote_case "$gc_retry_case"
-mkfifo "${gc_retry_case}/holder-ready" "${gc_retry_case}/retry-arrived"
-(
-  exec 9> "${gc_retry_case}/deployment-gc.lock"
-  flock --exclusive 9
-  printf 'lock held\n' > "${gc_retry_case}/holder-ready"
-  read -r < "${gc_retry_case}/retry-arrived"
-) &
-gc_holder_pid=$!
 REMOTE_REACH_GC=1 \
 REMOTE_GC_STATUSES=255,0 \
-REMOTE_GC_SERIALIZATION_DIR="$gc_retry_case" \
   run_remote_case "$gc_retry_case"
 gc_retry_count=$(< "${gc_retry_case}/gc-count")
-if [ "$gc_retry_count" -ne 2 ]; then
-  kill "$gc_holder_pid" 2>/dev/null || true
-  wait "$gc_holder_pid" 2>/dev/null || true
-  fail "SSH status 255 must retry GC once"
-fi
-wait "$gc_holder_pid"
-[ -f "${gc_retry_case}/serialized" ] || fail "GC retry must wait for a surviving invocation's lock"
-[ "$(grep -Fxc -- "$gc_command" "${gc_retry_case}/ssh.log")" -eq 2 ] || fail "each GC retry must use the deployment lock"
+[ "$gc_retry_count" -eq 2 ] || fail "SSH status 255 must retry GC once"
+[ "$(grep -Fxc -- "$gc_command" "${gc_retry_case}/ssh.log")" -eq 2 ] || fail "each GC retry must invoke the runner directly"
 grep -Fq 'runner GC SSH transport failed on dev-arm-1 with status 255; retrying once' "${gc_retry_case}/out" || fail "expected transient GC retry diagnostic"
 grep -Fqx -- "$setup_command" "${gc_retry_case}/ssh.log" || fail "recovered GC must continue to runner setup"
 
@@ -530,7 +496,7 @@ prepare_remote_case "$gc_transport_failure_case"
 REMOTE_REACH_GC=1 REMOTE_GC_STATUSES=255,255 \
   run_remote_case "$gc_transport_failure_case"
 [ "$(< "${gc_transport_failure_case}/gc-count")" -eq 2 ] || fail "persistent SSH failure must stop after one GC retry"
-[ "$(grep -Fxc -- "$gc_command" "${gc_transport_failure_case}/ssh.log")" -eq 2 ] || fail "persistent SSH attempts must use the deployment lock"
+[ "$(grep -Fxc -- "$gc_command" "${gc_transport_failure_case}/ssh.log")" -eq 2 ] || fail "persistent SSH attempts must invoke the runner directly"
 grep -Fq 'runner GC failed on dev-arm-1 with status 255' "${gc_transport_failure_case}/out" || fail "expected final SSH failure status"
 if grep -Fqx -- "$setup_command" "${gc_transport_failure_case}/ssh.log"; then
   fail "persistent SSH failure must not continue to runner setup"

--- a/.github/scripts/tests/runner-promotion-ansible-test.sh
+++ b/.github/scripts/tests/runner-promotion-ansible-test.sh
@@ -58,34 +58,16 @@ trap cleanup EXIT
 
 test_home="$tmp/home"
 data_dir="$tmp/vm0-runner"
-test_bin="$tmp/bin"
 runner_release=v999.0.0
 runner_bin_dir="$data_dir/bin/$runner_release"
 invocation_log="$data_dir/runner-invocations"
 gc_arrivals="$data_dir/gc-arrivals"
 mkdir -p \
   "$test_home" \
-  "$test_bin" \
   "$data_dir/locks" \
   "$data_dir/runners/$runner_release" \
   "$gc_arrivals" \
   "$runner_bin_dir"
-
-ln -s "$(command -v flock)" "$test_bin/real-flock"
-cat > "$test_bin/flock" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-
-if [ "${1:-}" != "--exclusive" ] || [ -z "${2:-}" ]; then
-  echo "unexpected flock invocation: $*" >&2
-  exit 1
-fi
-
-data_dir="$(cd "$(dirname "$2")/.." && pwd)"
-touch "$data_dir/gc-arrivals/$BASHPID"
-exec "$(dirname "$0")/real-flock" "$@"
-EOF
-chmod +x "$test_bin/flock"
 
 fake_runner="$runner_bin_dir/runner"
 cat > "$fake_runner" <<'EOF'
@@ -112,6 +94,10 @@ case "${1:-}" in
       echo "unexpected gc arguments: $*" >&2
       exit 1
     fi
+
+    touch "$data_dir/gc-arrivals/$BASHPID"
+    exec 9> "$data_dir/locks/deployment-gc.lock"
+    flock --exclusive 9
 
     active_dir="$data_dir/gc-active"
     if ! mkdir "$active_dir"; then
@@ -154,10 +140,14 @@ done
 
 assert_contains "$promote_playbook" "include_tasks: ../tasks/garbage-collect-runner.yml"
 assert_contains "$rollback_playbook" "include_tasks: ../tasks/garbage-collect-runner.yml"
-assert_contains "$gc_task" "{{ data_dir }}/locks/deployment-gc.lock"
+assert_contains "$gc_task" '      - "{{ bin_dir }}/runner"'
+if grep -Fq -- "flock" "$gc_task"; then
+  echo "shared GC task must rely on runner-owned serialization" >&2
+  cat "$gc_task" >&2
+  exit 1
+fi
 
-if ! PATH="$test_bin:$PATH" \
-  HOME="$test_home" \
+if ! HOME="$test_home" \
   ANSIBLE_CONFIG="$ansible_config" \
   ANSIBLE_NOCOLOR=1 \
   ansible-playbook \

--- a/ansible/tasks/garbage-collect-runner.yml
+++ b/ansible/tasks/garbage-collect-runner.yml
@@ -1,9 +1,6 @@
-- name: Run serialized runner garbage collection
+- name: Run runner garbage collection
   ansible.builtin.command:
     argv:
-      - flock
-      - --exclusive
-      - "{{ data_dir }}/locks/deployment-gc.lock"
       - "{{ bin_dir }}/runner"
       - gc
       - --keep-latest

--- a/crates/runner/src/cmd/gc/mod.rs
+++ b/crates/runner/src/cmd/gc/mod.rs
@@ -220,6 +220,8 @@ async fn run_gc_with_operations(
     home: &HomePaths,
     operations: &mut impl GcOperations,
 ) -> RunnerResult<()> {
+    let _gc_lock = crate::lock::acquire(home.gc_lock()).await?;
+
     // Retained version and service configs protect their image pairs before
     // version cleanup consumes the same retention analysis.
     let version_analysis = operations
@@ -294,8 +296,12 @@ fn record_gc_phase(total: &mut GcReport, domain: &str, phase: GcReport, dry_run:
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
+    use std::time::Duration;
+
     use super::*;
     use clap::{CommandFactory, Parser};
+    use tokio::sync::oneshot;
     use tracing_subscriber::prelude::*;
     use tracing_test_support::CapturedEvents;
 
@@ -320,6 +326,7 @@ mod tests {
     struct FakeGcOperations {
         events: Vec<SafetyGcPhase>,
         expected_analysis: VersionGcAnalysis,
+        first_phase_gate: Option<(oneshot::Sender<()>, oneshot::Receiver<()>)>,
     }
 
     impl FakeGcOperations {
@@ -327,6 +334,17 @@ mod tests {
             Self {
                 events: Vec::new(),
                 expected_analysis: versions::empty_complete_version_gc_analysis(),
+                first_phase_gate: None,
+            }
+        }
+
+        fn with_first_phase_gate(
+            entered: oneshot::Sender<()>,
+            resume: oneshot::Receiver<()>,
+        ) -> Self {
+            Self {
+                first_phase_gate: Some((entered, resume)),
+                ..Self::new()
             }
         }
     }
@@ -339,6 +357,10 @@ mod tests {
             _keep_latest: Option<usize>,
         ) -> RunnerResult<VersionGcAnalysis> {
             self.events.push(SafetyGcPhase::AnalyzeVersions);
+            if let Some((entered, resume)) = self.first_phase_gate.take() {
+                entered.send(()).unwrap();
+                resume.await.unwrap();
+            }
             Ok(self.expected_analysis.clone())
         }
 
@@ -489,6 +511,68 @@ mod tests {
                 SafetyGcPhase::OrphanedVersionServiceLocks,
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn gc_coordinator_serializes_complete_runs_and_initializes_lock_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let first_home = home.clone();
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (resume_tx, resume_rx) = oneshot::channel();
+
+        let first_gc = tokio::spawn(async move {
+            let args = GcArgs {
+                dry_run: true,
+                keep_latest: None,
+                protect_version: None,
+            };
+            let mut operations = FakeGcOperations::with_first_phase_gate(entered_tx, resume_rx);
+            run_gc_with_operations(&args, &first_home, &mut operations).await
+        });
+
+        entered_rx.await.unwrap();
+        assert_eq!(
+            std::fs::metadata(home.locks_dir())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(home.gc_lock())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+
+        let second_args = GcArgs {
+            dry_run: true,
+            keep_latest: None,
+            protect_version: None,
+        };
+        let mut second_operations = FakeGcOperations::new();
+        let mut second_gc = Box::pin(run_gc_with_operations(
+            &second_args,
+            &home,
+            &mut second_operations,
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut second_gc)
+                .await
+                .is_err(),
+            "a second GC must wait while the first GC is inside a phase"
+        );
+
+        resume_tx.send(()).unwrap();
+        first_gc.await.unwrap().unwrap();
+        tokio::time::timeout(Duration::from_secs(5), &mut second_gc)
+            .await
+            .expect("second GC should acquire the released global lock")
+            .unwrap();
     }
 
     #[test]

--- a/crates/runner/src/cmd/gc/orphaned_locks.rs
+++ b/crates/runner/src/cmd/gc/orphaned_locks.rs
@@ -15,8 +15,9 @@ use super::workspaces::is_base_dir_lock_name;
 /// because this GC pass runs before version GC, which relies on those lock paths
 /// to coordinate with concurrent service install/uninstall commands. The
 /// systemd reload lock is also retained because non-runner lifecycle owners use
-/// the same stable path with plain `flock`. Stale version service locks are
-/// cleaned by a post-version-GC pass.
+/// the same stable path with plain `flock`. The global GC lock remains stable so
+/// old external holders and runner-owned locking coordinate on the same inode.
+/// Stale version service locks are cleaned by a post-version-GC pass.
 pub(super) async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<GcReport> {
     let locks_dir = home.locks_dir();
     let Some(mut entries) = read_dir_or_missing(&locks_dir).await? else {
@@ -39,6 +40,7 @@ pub(super) async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> Runner
         // the base_dir metadata needed to rediscover dead-runner workspaces.
         if RunnerServiceUnit::from_lock_file_name(name).is_some()
             || entry.path() == home.systemd_daemon_reload_lock()
+            || entry.path() == home.gc_lock()
             || is_base_dir_lock_name(name)
         {
             continue;
@@ -126,14 +128,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gc_orphaned_locks_preserves_systemd_reload_lock() {
+    async fn gc_orphaned_locks_preserves_host_global_locks() {
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());
         let locks_dir = home.locks_dir();
         std::fs::create_dir_all(&locks_dir).unwrap();
         let reload_lock = home.systemd_daemon_reload_lock();
+        let gc_lock = home.gc_lock();
         let stale_lock = locks_dir.join("workspace-image-cache-test.lock");
         std::fs::write(&reload_lock, "").unwrap();
+        std::fs::write(&gc_lock, "").unwrap();
         std::fs::write(&stale_lock, "").unwrap();
 
         let report = gc_orphaned_locks(&home, false).await.unwrap();
@@ -143,6 +147,10 @@ mod tests {
         assert!(
             reload_lock.exists(),
             "the shared systemd reload lock must keep a stable inode"
+        );
+        assert!(
+            gc_lock.exists(),
+            "the global GC lock must keep a stable inode"
         );
         assert!(
             !stale_lock.exists(),

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -267,6 +267,13 @@ impl HomePaths {
         self.locks_dir().join("systemd-daemon-reload.lock")
     }
 
+    /// Host-global lock serializing complete garbage collection runs.
+    pub fn gc_lock(&self) -> PathBuf {
+        // Keep the historical filename so runner-owned locking coordinates
+        // with deployment processes that acquired the external lock.
+        self.locks_dir().join("deployment-gc.lock")
+    }
+
     pub fn base_dir_lock(&self, base_dir: &Path) -> PathBuf {
         self.locks_dir().join(base_dir_lock_name(base_dir))
     }


### PR DESCRIPTION
## Summary

- make `runner gc` acquire and hold a host-global lock across every GC phase
- create and validate the lock path through the runner's existing secure filesystem abstraction
- remove caller-owned GNU `flock` wrappers from runner image preparation and promotion/rollback orchestration
- preserve runner-image SSH status 255 retry behavior

## Compatibility

The runner keeps the historical `deployment-gc.lock` filename so in-flight external holders coordinate with the new runner-owned lock. Compatibility with rollback targets whose runner binary predates internal GC serialization is intentionally excluded from this change.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --bin runner`
- `.github/scripts/tests/prepare-runner-image-test.sh`
- `.github/scripts/tests/runner-promotion-ansible-test.sh`

Closes #31660
