### PR TITLE
fix(billing): stop telling free plans to add credits or bring their own key

### DIFF
--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -337,6 +337,16 @@ fn cli_failure_reason_classifies_insufficient_credits() {
 }
 
 #[test]
+fn cli_failure_reason_classifies_insufficient_credits_billing_copy() {
+    let reason = classify_cli_failure_reason(
+        AgentFramework::ClaudeCode,
+        "API Error: 402 Insufficient credits. Check your workspace billing to continue.",
+    );
+
+    assert_eq!(reason, Some(FailureReason::InsufficientCredits));
+}
+
+#[test]
 fn cli_failure_reason_classifies_provider_credit_affordability_error() {
     let reason = classify_cli_failure_reason(
         AgentFramework::ClaudeCode,

--- a/turbo/apps/api/src/lib/error.ts
+++ b/turbo/apps/api/src/lib/error.ts
@@ -61,7 +61,7 @@ export function insufficientCredits() {
   return httpError(
     402,
     "INSUFFICIENT_CREDITS",
-    "Insufficient credits. Add credits or configure your own API key to continue.",
+    "Insufficient credits. Check your workspace billing to continue.",
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1324,7 +1324,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       expectApiError(restrictedSelection.body);
       expect(restrictedSelection.body.error).toStrictEqual({
         message:
-          "Insufficient credits. Add credits or configure your own API key to continue.",
+          "Insufficient credits. Check your workspace billing to continue.",
         code: "INSUFFICIENT_CREDITS",
       });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
@@ -665,7 +665,7 @@ describe("GET/PUT /api/model-policies", () => {
     expect(response.body).toStrictEqual({
       error: {
         message:
-          "Insufficient credits. Add credits or configure your own API key to continue.",
+          "Insufficient credits. Check your workspace billing to continue.",
         code: "INSUFFICIENT_CREDITS",
       },
     });
@@ -712,7 +712,7 @@ describe("GET/PUT /api/model-policies", () => {
     expect(response.body).toStrictEqual({
       error: {
         message:
-          "Insufficient credits. Add credits or configure your own API key to continue.",
+          "Insufficient credits. Check your workspace billing to continue.",
         code: "INSUFFICIENT_CREDITS",
       },
     });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -5,7 +5,9 @@ import {
   CHAT_RUN_TRANSIENT_ERROR_MESSAGE,
   formatRunErrorForExternalSurface,
   getCodexChatGptAccountUnsupportedModel,
+  INSUFFICIENT_CREDITS_ADD_CREDITS_MESSAGE,
   INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE,
+  INSUFFICIENT_CREDITS_UPGRADE_MESSAGE,
   isActionableRunError,
   isAgentExecutionTimeoutRunError,
   isCodexChatGptAccountUnsupportedModelRunError,
@@ -88,7 +90,7 @@ describe("formatRunErrorForExternalSurface", () => {
         },
       }),
     ).toBe(
-      "Insufficient credits. Please add credits to continue.\n\nAdd credits: https://app.example.test/?settings=billing&billingView=credits",
+      `${INSUFFICIENT_CREDITS_ADD_CREDITS_MESSAGE}\n\nAdd credits: https://app.example.test/?settings=billing&billingView=credits`,
     );
   });
 
@@ -118,8 +120,25 @@ describe("formatRunErrorForExternalSurface", () => {
         },
       }),
     ).toBe(
-      "Insufficient credits. Please add credits to continue.\n\nCompare plans: https://app.example.test/?settings=billing&billingView=plans",
+      `${INSUFFICIENT_CREDITS_UPGRADE_MESSAGE}\n\nCompare plans: https://app.example.test/?settings=billing&billingView=plans`,
     );
+  });
+
+  it("never tells a plan that cannot buy credits to add credits or bring its own API key", () => {
+    const formatted = formatRunErrorForExternalSurface({
+      code: "INSUFFICIENT_CREDITS",
+      message:
+        "Insufficient credits. Add credits or configure your own API key to continue.",
+      insufficientCredits: {
+        canManageBilling: true,
+        comparePlansUrl:
+          "https://app.example.test/?settings=billing&billingView=plans",
+      },
+    });
+
+    expect(formatted).not.toContain("Add credits");
+    expect(formatted).not.toContain("your own API key");
+    expect(formatted).toContain("Compare plans:");
   });
 
   it("shows Codex usage limit errors verbatim", () => {

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -271,6 +271,12 @@ const CODEX_CHATGPT_ACCOUNT_UNSUPPORTED_MODEL_MESSAGE =
 export const INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE =
   "Ask a workspace admin to add credits or upgrade the workspace plan.";
 
+export const INSUFFICIENT_CREDITS_ADD_CREDITS_MESSAGE =
+  "Insufficient credits. Add credits to continue.";
+
+export const INSUFFICIENT_CREDITS_UPGRADE_MESSAGE =
+  "Insufficient credits. Your current plan cannot buy credits. Upgrade to continue.";
+
 export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   ...Object.values(RUN_ERROR_GUIDANCE).flatMap((guidance) => {
     return [guidance.title, guidance.guidance];
@@ -826,10 +832,14 @@ export function formatRunErrorForExternalSurface(params: {
     if (!params.insufficientCredits.canManageBilling) {
       return INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE;
     }
+    // The upstream 402 body cannot know the caller's plan, so it is replaced
+    // here rather than appended to: a plan without `canBuyCredits` must not be
+    // told to add credits, and a plan without BYOK must not be told to bring
+    // its own API key.
     if (params.insufficientCredits.addCreditsUrl !== undefined) {
-      return `${errorMessage}\n\nAdd credits: ${params.insufficientCredits.addCreditsUrl}`;
+      return `${INSUFFICIENT_CREDITS_ADD_CREDITS_MESSAGE}\n\nAdd credits: ${params.insufficientCredits.addCreditsUrl}`;
     }
-    return `${errorMessage}\n\nCompare plans: ${params.insufficientCredits.comparePlansUrl}`;
+    return `${INSUFFICIENT_CREDITS_UPGRADE_MESSAGE}\n\nCompare plans: ${params.insufficientCredits.comparePlansUrl}`;
   }
 
   if (isCodexOAuthReconnectRequiredRunError(errorMessage)) {

--- a/turbo/packages/api-services/src/errors.ts
+++ b/turbo/packages/api-services/src/errors.ts
@@ -97,7 +97,7 @@ export const insufficientCredits = makeApiError(
   "InsufficientCreditsError",
   "INSUFFICIENT_CREDITS",
   402,
-  "Insufficient credits. Add credits or configure your own API key to continue.",
+  "Insufficient credits. Check your workspace billing to continue.",
 );
 
 export const providerIncompatible = makeApiError(


### PR DESCRIPTION
## Problem

The 402 body for `INSUFFICIENT_CREDITS` was a fixed string prescribing two remedies:

> Insufficient credits. **Add credits or configure your own API key** to continue.

`limited-free-1` is configured with `canBuyCredits: false` and `supportByok: false` (`org-plan-entitlement-tier-values.ts`), so both suggested actions are blocked for exactly the users who see this error most.

It also contradicted the link rendered next to it. `integration-run-errors.service.ts` already branches on `canBuyCredits` and gives a free org a **Compare plans** link — placed directly under a sentence telling them to add credits:

```
Insufficient credits. Add credits or configure your own API key to continue.

Compare plans: https://app.vm0.ai/?settings=billing&billingView=plans
```

## Why this matters

This screen sits at the highest-intent moment in the conversion funnel. From the masked production DB, for orgs that signed up on/after 2026-08-25 and exhausted their 3,000 free credits (n=62): 38.7% ended on a failed task (vs 0.0% across their 892 earlier tasks), 76% were active on only one day, and **0 converted to paid**. Across the wider 2026-07-13+ cohort (n=317), users whose last task failed opened the pricing page about twice as often (31.1% vs 16.8%) and still converted 0 out of 122.

## Change

- The gateway cannot know the caller's plan, so the base 402 body now states the condition without prescribing a remedy: `"Insufficient credits. Check your workspace billing to continue."` (`turbo/apps/api/src/lib/error.ts`, `turbo/packages/api-services/src/errors.ts`).
- `formatRunErrorForExternalSurface` — the layer that *does* know the capability — now supplies the sentence and the link together, so they can never disagree. Two exported constants back this: `INSUFFICIENT_CREDITS_ADD_CREDITS_MESSAGE` and `INSUFFICIENT_CREDITS_UPGRADE_MESSAGE`.
- The `canManageBilling: false` branch (`INSUFFICIENT_CREDITS_ASK_ADMIN_MESSAGE`) is unchanged — it was already plan-neutral.

Web chat's `InsufficientCreditsCard` was already plan-aware via `insufficientCreditsCopy({ canBuyCredits, ... })` and is untouched.

The two base strings stay duplicated across `apps/api` and `packages/api-services` as they were before; `api-services` is deliberately dependency-free (see its file header), and adding a cross-package dependency for one string is not worth it.

## Tests

- New contract test asserts a plan that cannot buy credits is never told to add credits or bring its own API key, even when the stale upstream text arrives.
- Two existing contract tests now assert against the exported constants.
- New Rust test pins that the new copy is still classified as `FailureReason::InsufficientCredits` (`is_insufficient_credits_error` matches on `402 insufficient credits`, which the new string preserves). The existing fixtures with the old copy are kept — in-flight runs and older agents can still emit it.
- Three API route tests updated for the new 402 body.

## Verification

Formatted with the lockfile-pinned prettier 3.8.1. Per repo practice, the local vitest suite and dev server were not run — relying on the PR pipeline.

## Scope

Copy/CTA correctness only. Not included, tracked separately:

- #31670 — give free orgs a small credit top-up so there is a CTA that actually resolves the block
- #31669 — stop killing in-flight runs when credits hit zero
- #23167 — suppress the raw `API Error: 402 ...` line above the recovery card in web chat

Refs #23167

🤖 Generated with [Claude Code](https://claude.com/claude-code)
