### PR TITLE
fix(platform): keep goal waiting indicator in work group

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -33,6 +33,7 @@ export const toggleRunWorkExpanded$ = command(({ set }, key: string) => {
 
 export interface RunWorkSection {
   readonly key: string;
+  readonly goalRunGroupId: string | undefined;
   readonly anchorEventId: string;
   readonly hiddenGroups: ChatEventGroup[];
   readonly hiddenGroupsAfterAnchor: ChatEventGroup[];
@@ -482,8 +483,13 @@ interface RunWorkPhaseFolding {
   readonly section: RunWorkSection | null;
 }
 
+interface RunWorkPhaseIdentity {
+  readonly key: string;
+  readonly goalRunGroupId: string | undefined;
+}
+
 function foldRunWorkPhase(
-  key: string,
+  identity: RunWorkPhaseIdentity,
   events: readonly EnrichedChatEvent[],
   endTime: number | undefined,
   hiddenUserEventIds: ReadonlySet<string>,
@@ -539,7 +545,8 @@ function foldRunWorkPhase(
   return {
     visibleEvents: [...userEvents, anchorEvent, ...trailingStatusEvents],
     section: {
-      key: `${key}:${events[0]!.id}`,
+      key: `${identity.key}:${events[0]!.id}`,
+      goalRunGroupId: identity.goalRunGroupId,
       anchorEventId: anchorEvent.id,
       hiddenGroups: groupEventsByRole(hiddenEvents),
       hiddenGroupsAfterAnchor: groupEventsByRole(hiddenEventsAfterAnchor),
@@ -631,7 +638,10 @@ export function buildRunWorkFolding(
     const firstSectionIndex = sections.length;
     for (const [phaseIndex, phase] of phases.entries()) {
       const phaseFolding = foldRunWorkPhase(
-        unit.key,
+        {
+          key: unit.key,
+          goalRunGroupId: unit.isGoal ? unit.runGroupId : undefined,
+        },
         phase,
         phaseEndTime(phase, phaseIndex === phases.length - 1, terminalEvent),
         unit.hiddenUserEventIds,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-goal-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-goal-history.test.tsx
@@ -211,6 +211,121 @@ test("Review goal continuations as one work history", async () => {
   );
 });
 
+const WAITING_GOAL_GROUP_ID = "e0000000-0000-4000-a000-000000000214";
+
+async function renderWaitingGoalContinuation(currentRunGroupId: string) {
+  installRunChat({
+    chatEvents: [
+      promptEvent({
+        id: "waiting-goal-trigger",
+        runId: RUN_A,
+        seqId: 1,
+        text: "Keep checking the release",
+        model: "gpt-5.6-sol",
+        createdAt: createdAt(0),
+      }),
+      assistantEvent({
+        id: "waiting-goal-trigger-work",
+        runId: RUN_A,
+        seqId: 2,
+        text: "Started checking the release",
+        createdAt: createdAt(0, 20),
+      }),
+      completedEvent({
+        id: "waiting-goal-trigger-complete",
+        runId: RUN_A,
+        seqId: 3,
+        createdAt: createdAt(0, 21),
+      }),
+      goalContinuationEvent({
+        id: "waiting-goal-first-continuation",
+        runId: RUN_B,
+        runGroupId: WAITING_GOAL_GROUP_ID,
+        seqId: 4,
+        brief: "Continue checking the release",
+        model: "gpt-5.6-sol",
+        createdAt: createdAt(1),
+      }),
+      inRunGroup(
+        assistantEvent({
+          id: "waiting-goal-latest-answer",
+          runId: RUN_B,
+          seqId: 5,
+          text: "The latest release gate passed",
+          createdAt: createdAt(1, 20),
+        }),
+        WAITING_GOAL_GROUP_ID,
+      ),
+      inRunGroup(
+        completedEvent({
+          id: "waiting-goal-first-complete",
+          runId: RUN_B,
+          seqId: 6,
+          createdAt: createdAt(1, 21),
+        }),
+        WAITING_GOAL_GROUP_ID,
+      ),
+      goalContinuationEvent({
+        id: "waiting-goal-current-continuation",
+        runId: RUN_C,
+        runGroupId: currentRunGroupId,
+        seqId: 7,
+        brief: "Continue checking the release",
+        model: "gpt-5.6-sol",
+        createdAt: createdAt(2),
+      }),
+    ],
+    activeRunIds: [RUN_C],
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+
+  await readyChat();
+  const latestAnswer = await screen.findByText(
+    "The latest release gate passed",
+  );
+  const previousAssistantGroup = latestAnswer.closest<HTMLElement>(
+    '[data-role="assistant"]',
+  );
+  const thinkingIndicator = document.querySelector<HTMLElement>(
+    "[data-thinking-indicator]",
+  );
+  if (!previousAssistantGroup || !thinkingIndicator) {
+    throw new Error("Expected the active goal in an assistant response");
+  }
+
+  return { previousAssistantGroup, thinkingIndicator };
+}
+
+test("Keep a waiting goal continuation in its existing assistant group", async () => {
+  const { previousAssistantGroup, thinkingIndicator } =
+    await renderWaitingGoalContinuation(WAITING_GOAL_GROUP_ID);
+
+  expect(previousAssistantGroup).toContainElement(thinkingIndicator);
+  expect(
+    queryAllByRoleFast("link").filter((link) => {
+      return link.getAttribute("aria-label") === "View agent profile";
+    }),
+  ).toHaveLength(1);
+  expect(screen.getByText(/^Working for /u)).toBeVisible();
+});
+
+test("Keep a waiting different goal in a separate assistant group", async () => {
+  const { previousAssistantGroup, thinkingIndicator } =
+    await renderWaitingGoalContinuation("e0000000-0000-4000-a000-000000000215");
+
+  expect(previousAssistantGroup).not.toContainElement(thinkingIndicator);
+  expect(
+    queryAllByRoleFast("link").filter((link) => {
+      return link.getAttribute("aria-label") === "View agent profile";
+    }),
+  ).toHaveLength(2);
+});
+
 test("Keep a cancelled goal continuation beside its latest answer", async () => {
   const goalGroupId = "e0000000-0000-4000-a000-000000000212";
   installRunChat({

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3055,6 +3055,42 @@ function ChatThreadScrollCommitMarker({
   );
 }
 
+type WaitingThinkingIndicatorMode = "waiting" | "waiting-queued";
+
+function isWaitingThinkingIndicatorMode(
+  mode: ThinkingIndicatorMode,
+): mode is WaitingThinkingIndicatorMode {
+  return mode === "waiting" || mode === "waiting-queued";
+}
+
+function assistantGroupIdForWaitingRunWorkIndicator(
+  groups: readonly ChatEventGroup[],
+  runWorkFolding: RunWorkFolding | null,
+  mode: ThinkingIndicatorMode,
+  currentRunGroupId: string | undefined,
+): string | null {
+  if (
+    runWorkFolding === null ||
+    currentRunGroupId === undefined ||
+    !isWaitingThinkingIndicatorMode(mode)
+  ) {
+    return null;
+  }
+
+  for (let index = groups.length - 1; index >= 0; index--) {
+    const group = groups[index]!;
+    const section = runWorkSectionForGroup(runWorkFolding, group);
+    if (
+      group.role === "assistant" &&
+      section?.goalRunGroupId === currentRunGroupId &&
+      section.endTime === undefined
+    ) {
+      return group.beginEventId;
+    }
+  }
+  return null;
+}
+
 function ChatThreadRenderedEventGroups({
   thread,
 }: {
@@ -3108,13 +3144,21 @@ function ChatThreadRenderedEventGroups({
     : (completedWorkFolding?.visibleGroups ?? runGroupVisibleGroups);
   const thinkingIndicatorMode =
     useLastResolved(thread.thinkingIndicatorMode$) ?? null;
+  const currentRunGroupId = renderedGroups.at(-1)?.events.at(-1)?.runGroupId;
+  const waitingIndicatorAssistantGroupId =
+    assistantGroupIdForWaitingRunWorkIndicator(
+      visibleGroups,
+      runWorkFolding,
+      thinkingIndicatorMode,
+      currentRunGroupId,
+    );
   const runGroupFoldPlacements = resolveRunGroupFoldPlacements({
     groups: visibleGroups,
     runGroupFolding,
     onToggleRunGroup: toggleRunGroupExpanded,
-    thinkingIndicatorCanHostFold:
-      thinkingIndicatorMode === "waiting" ||
-      thinkingIndicatorMode === "waiting-queued",
+    thinkingIndicatorCanHostFold: isWaitingThinkingIndicatorMode(
+      thinkingIndicatorMode,
+    ),
   });
 
   return (
@@ -3131,6 +3175,8 @@ function ChatThreadRenderedEventGroups({
         runWorkFolding={runWorkFolding}
         runWorkExpandedKeys={effectiveRunWorkExpandedKeys}
         onToggleRunWork={toggleRunWorkExpanded}
+        thinkingIndicatorMode={thinkingIndicatorMode}
+        waitingIndicatorAssistantGroupId={waitingIndicatorAssistantGroupId}
       />
       <ChatThreadScrollCommitMarker
         thread={thread}
@@ -3138,7 +3184,11 @@ function ChatThreadRenderedEventGroups({
       />
       <ChatThreadThinkingIndicator
         thread={thread}
-        mode={thinkingIndicatorMode}
+        mode={
+          waitingIndicatorAssistantGroupId === null
+            ? thinkingIndicatorMode
+            : null
+        }
         runGroupFolds={runGroupFoldPlacements.thinkingIndicatorRunGroupFolds}
       />
     </>
@@ -3323,6 +3373,8 @@ function ChatThreadEventGroups({
   runWorkFolding,
   runWorkExpandedKeys,
   onToggleRunWork,
+  thinkingIndicatorMode,
+  waitingIndicatorAssistantGroupId,
 }: {
   thread: ChatPanelSignals;
   groups: readonly ChatEventGroup[];
@@ -3335,6 +3387,8 @@ function ChatThreadEventGroups({
   runWorkFolding: RunWorkFolding | null;
   runWorkExpandedKeys: ReadonlySet<string>;
   onToggleRunWork: (key: string) => void;
+  thinkingIndicatorMode: ThinkingIndicatorMode;
+  waitingIndicatorAssistantGroupId: string | null;
 }) {
   const { embeddedRunGroupFolds, externalRunGroupFolds } =
     runGroupFoldPlacements;
@@ -3378,6 +3432,11 @@ function ChatThreadEventGroups({
         const runWorkExpanded =
           runWorkSection !== null &&
           runWorkExpandedKeys.has(runWorkSection.key);
+        const waitingIndicatorMode =
+          group.beginEventId === waitingIndicatorAssistantGroupId &&
+          isWaitingThinkingIndicatorMode(thinkingIndicatorMode)
+            ? thinkingIndicatorMode
+            : undefined;
         return (
           <div key={group.beginEventId} className="contents">
             {runGroupFolds.map((runGroupFold) => {
@@ -3422,6 +3481,7 @@ function ChatThreadEventGroups({
                     }
                   : undefined
               }
+              waitingIndicatorMode={waitingIndicatorMode}
             />
           </div>
         );
@@ -4934,6 +4994,7 @@ function WaitingForAssistantResponse({
   thinkingLabel,
   serverThinkingLabel,
   runGroupFolds,
+  inAssistantGroup,
 }: {
   thread: ChatPanelSignals;
   blockStyle: CSSProperties;
@@ -4942,10 +5003,29 @@ function WaitingForAssistantResponse({
   thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
   runGroupFolds: readonly RunGroupFoldControl[];
+  inAssistantGroup: boolean;
 }) {
   const thinkingIndicatorProps = isQueued
     ? {}
     : { "data-thinking-indicator": true };
+
+  if (inAssistantGroup) {
+    return (
+      <div
+        {...thinkingIndicatorProps}
+        data-role="assistant-thinking"
+        className="zero-thinking-enter min-w-0"
+      >
+        <InlineThinkingRow
+          blockStyle={blockStyle}
+          isQueued={isQueued}
+          spinnerEnabled={spinnerEnabled}
+          thinkingLabel={thinkingLabel}
+          serverThinkingLabel={serverThinkingLabel}
+        />
+      </div>
+    );
+  }
 
   return (
     <div
@@ -5062,10 +5142,12 @@ function ThinkingIndicator({
   thread,
   mode,
   runGroupFolds,
+  inAssistantGroup = false,
 }: {
   thread: ChatPanelSignals;
   mode: ThinkingIndicatorMode;
   runGroupFolds: readonly RunGroupFoldControl[];
+  inAssistantGroup?: boolean;
 }) {
   const featureSwitches = useGet(featureSwitch$);
   const runWorkFoldingEnabled =
@@ -5140,6 +5222,7 @@ function ThinkingIndicator({
       thinkingLabel={thinkingLabel}
       serverThinkingLabel={serverThinkingLabel}
       runGroupFolds={runGroupFolds}
+      inAssistantGroup={inAssistantGroup}
     />
   );
 }
@@ -5908,6 +5991,7 @@ function PagedGroupRow({
   runGroupFolds,
   completedWorkFold,
   runWorkSection,
+  waitingIndicatorMode,
 }: {
   group: ChatEventGroup;
   thread: ChatPanelSignals;
@@ -5916,6 +6000,7 @@ function PagedGroupRow({
   runGroupFolds?: readonly RunGroupFoldControl[];
   completedWorkFold?: CompletedWorkFoldControl;
   runWorkSection?: RunWorkSectionControl;
+  waitingIndicatorMode?: WaitingThinkingIndicatorMode;
 }) {
   if (group.role === "user") {
     return (
@@ -5936,6 +6021,7 @@ function PagedGroupRow({
       runGroupFolds={runGroupFolds}
       completedWorkFold={completedWorkFold}
       runWorkSection={runWorkSection}
+      waitingIndicatorMode={waitingIndicatorMode}
     />
   );
 }
@@ -5989,6 +6075,7 @@ function SelectablePagedGroupRow({
   runGroupFolds,
   completedWorkFold,
   runWorkSection,
+  waitingIndicatorMode,
 }: Parameters<typeof PagedGroupRow>[0]) {
   const { t } = useTranslation();
   const phase = useGet(thread.sharing.phase$);
@@ -6014,6 +6101,7 @@ function SelectablePagedGroupRow({
         runGroupFolds={runGroupFolds}
         completedWorkFold={completedWorkFold}
         runWorkSection={runWorkSection}
+        waitingIndicatorMode={waitingIndicatorMode}
       />
     );
   }
@@ -6059,6 +6147,7 @@ function SelectablePagedGroupRow({
         runGroupFolds={runGroupFolds}
         completedWorkFold={completedWorkFold}
         runWorkSection={runWorkSection}
+        waitingIndicatorMode={waitingIndicatorMode}
       />
       <Checkbox
         checked={checked}
@@ -7434,7 +7523,7 @@ type CompletedWorkFoldControl = {
   readonly onToggle: () => void;
 };
 
-type RunWorkSectionControl = Omit<RunWorkSection, "key"> & {
+type RunWorkSectionControl = Omit<RunWorkSection, "key" | "goalRunGroupId"> & {
   readonly expanded: boolean;
   readonly onToggle: () => void;
 };
@@ -7446,6 +7535,7 @@ type PagedAssistantGroupProps = {
   readonly runGroupFolds?: readonly RunGroupFoldControl[];
   readonly completedWorkFold?: CompletedWorkFoldControl;
   readonly runWorkSection?: RunWorkSectionControl;
+  readonly waitingIndicatorMode?: WaitingThinkingIndicatorMode;
 };
 
 type PagedAssistantTimelineItem =
@@ -7600,6 +7690,7 @@ function PagedAssistantGroup({
   runGroupFolds,
   completedWorkFold,
   runWorkSection,
+  waitingIndicatorMode,
 }: PagedAssistantGroupProps) {
   const hasRenderableEvent = group.events.some((event) => {
     return isRenderableAssistantEvent(event);
@@ -7650,6 +7741,14 @@ function PagedAssistantGroup({
             );
           })}
           <PagedAssistantTimeline items={timelineItems} thread={thread} />
+          {waitingIndicatorMode === undefined ? null : (
+            <ThinkingIndicator
+              thread={thread}
+              mode={waitingIndicatorMode}
+              runGroupFolds={[]}
+              inAssistantGroup
+            />
+          )}
         </div>
       </div>
       <PagedGroupActions group={group} content={fullContent} thread={thread} />


### PR DESCRIPTION
## Summary

- keep the waiting state inside the existing assistant group when the next active continuation belongs to the same Goal run group
- keep different Goals and non-Goal runs in separate assistant groups
- preserve Goal run-group identity through run-work folding and cover both the matching and non-matching cases with regression tests

## Testing

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-run-goal-history.test.tsx --maxWorkers=1`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-capability-run-history.test.tsx --maxWorkers=1`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-capability-thinking.test.tsx --maxWorkers=1`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-run-history.test.tsx --maxWorkers=1`
