### PR TITLE
feat: add progressive artifact preview switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1716,6 +1716,40 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(gatedOnClaim.appendSystemPrompt ?? "").toContain(toolHint);
   });
 
+  it("asks chat runs for a generic progressive artifact preview only while its switch is on", async () => {
+    const api = createRunsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const promptHeading = "# Progressive Artifact Preview";
+
+    const gatedOff = await api.createRun(actor, {
+      agentId,
+      prompt: "make a launch deck",
+      modelProvider: "anthropic-api-key",
+    });
+    const gatedOffRun = await api.readRun(actor, gatedOff.runId);
+    expect(gatedOffRun.appendSystemPrompt ?? "").not.toContain(promptHeading);
+
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.ProgressiveArtifactPreview]: true,
+    });
+
+    const gatedOn = await api.createRun(actor, {
+      agentId,
+      prompt: "make a launch deck",
+      modelProvider: "anthropic-api-key",
+    });
+    const gatedOnRun = await api.readRun(actor, gatedOn.runId);
+    const appendSystemPrompt = gatedOnRun.appendSystemPrompt ?? "";
+    expect(appendSystemPrompt).toContain(promptHeading);
+    expect(appendSystemPrompt).toContain("returned Alias URL");
+    expect(appendSystemPrompt).toContain("still working on it");
+    expect(appendSystemPrompt).toContain("same `--site` slug");
+    expect(appendSystemPrompt).toContain(
+      "Do not report named stages, draft/final labels, or completion percentages",
+    );
+  });
+
   it("emits api dispatch timing for exact-empty direct dispatch runs", async () => {
     const api = createRunsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -52,6 +52,7 @@ import {
   type AgentRunModelPin,
 } from "./agent-run-create.service";
 import { buildAgentExecutionConfig } from "./agent-execution-config";
+import { isWebChatTriggerSource } from "./chat-trigger-source.service";
 import {
   resolveChatThreadSession,
   type ChatThreadSessionResolution,
@@ -335,6 +336,26 @@ function buildExecutionTimeLimitPrompt(): string {
   ].join("\n");
 }
 
+function buildProgressiveArtifactPreviewPrompt(args: {
+  readonly triggerSource: TriggerSource;
+  readonly enabled: boolean;
+}): string | null {
+  if (!args.enabled || !isWebChatTriggerSource(args.triggerSource)) {
+    return null;
+  }
+
+  return [
+    "# Progressive Artifact Preview",
+    "",
+    "When generating a static website or HTML presentation:",
+    "- As soon as a coherent, navigable first draft exists, publish it with `okou host`. For an HTML presentation, include `--artifact-kind presentation-html` on every publish.",
+    "- Share the returned Alias URL in a brief commentary update and say that you are still working on it.",
+    "- Continue improving the artifact, and republish the same directory with the same `--site` slug at meaningful checkpoints so the Alias keeps showing the newest version.",
+    "- Keep the in-progress status generic. Do not report named stages, draft/final labels, or completion percentages.",
+    "- Complete the normal verification and publish the final version before your final response.",
+  ].join("\n");
+}
+
 function buildIntegrationToolsPrompt(
   triggerSource: TriggerSource,
 ): readonly string[] {
@@ -561,6 +582,7 @@ function buildAppendSystemPrompt(args: {
   readonly connectorAccountsEnabled: boolean;
   readonly presentationScreenshotEnabled: boolean;
   readonly presentationTemplatesEnabled: boolean;
+  readonly progressiveArtifactPreviewEnabled: boolean;
 }): string {
   const identity = buildAgentIdentityPrompt(args.agent, args.publicBrand);
   return [
@@ -573,6 +595,10 @@ function buildAppendSystemPrompt(args: {
       connectorAccountsEnabled: args.connectorAccountsEnabled,
       presentationScreenshotEnabled: args.presentationScreenshotEnabled,
       presentationTemplatesEnabled: args.presentationTemplatesEnabled,
+    }),
+    buildProgressiveArtifactPreviewPrompt({
+      triggerSource: args.triggerSource,
+      enabled: args.progressiveArtifactPreviewEnabled,
     }),
     buildCurrentUserPrompt(args.userInfo),
   ]
@@ -754,6 +780,7 @@ function createRunBody(args: {
   readonly connectorAccountsEnabled: boolean;
   readonly presentationScreenshotEnabled: boolean;
   readonly presentationTemplatesEnabled: boolean;
+  readonly progressiveArtifactPreviewEnabled: boolean;
 }) {
   const triggerSource = args.triggerSource ?? "web";
   const baseAppendSystemPrompt = buildAppendSystemPrompt({
@@ -766,6 +793,7 @@ function createRunBody(args: {
     connectorAccountsEnabled: args.connectorAccountsEnabled,
     presentationScreenshotEnabled: args.presentationScreenshotEnabled,
     presentationTemplatesEnabled: args.presentationTemplatesEnabled,
+    progressiveArtifactPreviewEnabled: args.progressiveArtifactPreviewEnabled,
   });
   return {
     prompt: args.body.prompt,
@@ -974,6 +1002,10 @@ function buildZeroCreateAgentRunArgs(args: {
       ),
       presentationTemplatesEnabled: isFeatureEnabled(
         FeatureSwitchKey.PresentationTemplates,
+        args.featureSwitchContext,
+      ),
+      progressiveArtifactPreviewEnabled: isFeatureEnabled(
+        FeatureSwitchKey.ProgressiveArtifactPreview,
         args.featureSwitchContext,
       ),
     }),

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -24,6 +24,9 @@ describe("FeatureSwitchKey", () => {
     expect(FeatureSwitchKey.RealAgentInPreview).toBe("_realAgentInPreview");
     expect(FeatureSwitchKey.TestOauthConnector).toBe("_testOauthConnector");
     expect(FeatureSwitchKey.ChatRunWorkFolding).toBe("chatRunWorkFolding");
+    expect(FeatureSwitchKey.ProgressiveArtifactPreview).toBe(
+      "progressiveArtifactPreview",
+    );
     expect(FeatureSwitchKey.MarkdownHexColorPreview).toBe(
       "markdownHexColorPreview",
     );
@@ -184,6 +187,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.BatchChatEventCatchUp]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatRunWorkFolding]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.ProgressiveArtifactPreview]).toBe(
+      true,
+    );
     expect(staffOrgStates[FeatureSwitchKey.ChatThinkingSpinner]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.MarkdownHexColorPreview]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
@@ -216,6 +222,9 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ChatErrorRecovery]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.BatchChatEventCatchUp]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatRunWorkFolding]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ProgressiveArtifactPreview]).toBe(
+      false,
+    );
     expect(otherOrgStates[FeatureSwitchKey.ChatThinkingSpinner]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.MarkdownHexColorPreview]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -54,6 +54,7 @@ export enum FeatureSwitchKey {
   ChatErrorRecovery = "chatErrorRecovery",
   BatchChatEventCatchUp = "batchChatEventCatchUp",
   ChatRunWorkFolding = "chatRunWorkFolding",
+  ProgressiveArtifactPreview = "progressiveArtifactPreview",
   ChatThinkingSpinner = "chatThinkingSpinner",
   MarkdownHexColorPreview = "markdownHexColorPreview",
   FollowUpOptimize = "followUpOptimize",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -395,6 +395,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ProgressiveArtifactPreview]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Publish coherent website and HTML presentation previews while the agent continues improving them.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatThinkingSpinner]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add a staff-first `progressiveArtifactPreview` feature switch that remains globally disabled
- when enabled for Web Chat runs, ask the agent to publish a coherent static website or HTML presentation early, share the stable Alias with a generic working update, and refresh the same Alias at meaningful checkpoints
- leave the disabled path unchanged and avoid named stages, completion percentages, draft/final metadata, or schema changes

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (12/12 tasks passed)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (11/11 tasks passed)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (31/31 tests passed)
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "asks chat runs for a generic progressive artifact preview only while its switch is on"` (1/1 selected test passed)
