### PR TITLE
fix(ci): disable remaining npm audit paths

### DIFF
--- a/.github/scripts/tests/implicit-npm-audit-test.sh
+++ b/.github/scripts/tests/implicit-npm-audit-test.sh
@@ -44,7 +44,6 @@ end
 
 violations = []
 explicit_audit_paths = []
-expected_audit_path = ".github/workflows/security.yml"
 
 workflow_paths = Dir[File.join(repo_root, ".github/workflows/*.{yml,yaml}")]
 workflow_paths.each do |path|
@@ -52,8 +51,7 @@ workflow_paths.each do |path|
   workflow_environment = document.fetch("env", {})
   relative_path = path.delete_prefix("#{repo_root}/")
 
-  if relative_path != expected_audit_path &&
-      audit_setting(workflow_environment) != "false"
+  if audit_setting(workflow_environment) != "false"
     violations << "#{relative_path} must set top-level npm_config_audit=false"
   end
 
@@ -140,8 +138,8 @@ script_paths.each do |path|
   end
 end
 
-unless explicit_audit_paths.uniq == [expected_audit_path]
-  violations << "explicit dependency audit must remain owned only by #{expected_audit_path}"
+unless explicit_audit_paths.empty?
+  violations << "explicit dependency audits are disabled: #{explicit_audit_paths.uniq.sort.join(", ")}"
 end
 
 unless violations.empty?

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -40,7 +40,6 @@ concurrency:
 permissions:
   contents: read
 
-# Dependency vulnerability scanning is owned by security.yml.
 env:
   npm_config_audit: "false"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,6 @@ permissions:
   packages: write
   checks: write
 
-# Dependency vulnerability scanning is owned by security.yml.
 env:
   npm_config_audit: "false"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+env:
+  npm_config_audit: "false"
+
 permissions:
   contents: read
   pull-requests: read
@@ -155,42 +158,6 @@ jobs:
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: codeql
-
-  pnpm-audit:
-    needs: [detect-release]
-    name: pnpm audit (SCA)
-    # Skip for release-please PRs, commits, and merge queue entries
-    if: needs.detect-release.outputs.skip != 'true'
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: turbo
-    steps:
-      - uses: actions/checkout@v7.0.1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22.19.0
-
-      - name: Install pnpm
-        run: corepack enable pnpm
-
-      - name: Run pnpm audit
-        run: |
-          set -o pipefail
-          echo "## pnpm audit results" >> "$GITHUB_STEP_SUMMARY"
-          # --ignore-registry-errors: temporary workaround for transient npm registry
-          # connectivity failures in CI that cause false audit failures unrelated to
-          # actual vulnerability findings.
-          pnpm audit --prod --ignore-registry-errors 2>&1 | tee audit-output.txt
-          {
-            echo '```'
-            cat audit-output.txt
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
 
   actionlint:
     needs: [detect-release]
@@ -376,7 +343,6 @@ jobs:
       - pr-title
       - semgrep
       - codeql
-      - pnpm-audit
       - actionlint
       - release-workspace-coverage
       - gitleaks
@@ -418,7 +384,6 @@ jobs:
           else
             check_result "codeql" "${{ needs.codeql.result }}"
           fi
-          check_result "pnpm-audit" "${{ needs.pnpm-audit.result }}"
           check_result "actionlint" "${{ needs.actionlint.result }}"
           check_result "gitleaks" "${{ needs.gitleaks.result }}"
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -11,7 +11,6 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'merge_group' && format('merge-queue-{0}', github.run_id) || 'staging') }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Dependency vulnerability scanning is owned by security.yml.
 env:
   npm_config_audit: "false"
 

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -516,6 +516,7 @@ fn build_pi_command_for_runtime(runtime: &CliRuntimeConfig<'_>) -> Result<Vec<St
     Ok(vec![
         "npx".to_string(),
         "--yes".to_string(),
+        "--no-audit".to_string(),
         format!("--package={package_url}"),
         "okou".to_string(),
         "__agent-loop".to_string(),

--- a/crates/guest-agent/tests/pi_cli_run_id_env.rs
+++ b/crates/guest-agent/tests/pi_cli_run_id_env.rs
@@ -56,6 +56,7 @@ async fn guest_projects_pi_blocks_with_canonical_sequences_and_run_id()
         &npx,
         r#"#!/bin/sh
 set -eu
+test "$*" = "--yes --no-audit --package=https://example.invalid/current-okou-cli.tgz okou __agent-loop"
 test -n "${OKOU_RUN_ID:-}"
 test -z "${OKOU_PI_LAUNCH_CONFIG:-}"
 test -n "${OKOU_PI_LAUNCH_PAYLOAD_FILE:-}"


### PR DESCRIPTION
## Summary

- pass `--no-audit` only to the managed Pi `npx` bootstrap and cover its exact argv through the existing Guest Agent integration entry point
- temporarily remove the dedicated `pnpm-audit` Security workflow job and its gate references while the npm advisory endpoint is unreliable
- require every workflow to disable implicit npm audit and reject explicit npm/pnpm audit commands in the repository policy

## Security and compatibility

This temporarily removes npm/pnpm SCA from GitHub Actions. Semgrep, CodeQL, and Gitleaks remain unchanged. #31677 tracks restoring the dedicated audit after the advisory endpoint is demonstrably stable.

The Pi opt-out is invocation-scoped: no Guest-global environment variable or prompt is changed, and dependency versions and resolution inputs remain unchanged. This PR also removes stale comments that claimed dependency scanning was still owned by `security.yml`.

The separate timed-out-run teardown 409 is out of scope.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test pi_cli_run_id_env`
- `bash .github/scripts/tests/implicit-npm-audit-test.sh`
- `bash -n .github/scripts/tests/implicit-npm-audit-test.sh`
- `shellcheck .github/scripts/tests/implicit-npm-audit-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh`
- `bash .github/scripts/tests/check-workflow-shell-compatibility-test.sh`
- `bash .github/scripts/tests/pass-release-pr-ci-gates-test.sh`
- `actionlint` on all changed workflows
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- repository pre-commit hooks
- `git diff --check`

Closes #31676
