### PR TITLE
fix(platform): align pinned loading with shared worker lifecycle

### DIFF
--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -157,6 +157,7 @@ function initializeWorker(): void {
 }
 
 function connectProtocolTransport(
+  bridgeSignal: AbortSignal,
   events: SharedDatabaseBridgeEvents = bridgeEvents(),
 ): {
   readonly bridge: MessagePortSharedDatabaseBridge;
@@ -170,7 +171,11 @@ function connectProtocolTransport(
     context.signal,
   );
   return {
-    bridge: new MessagePortSharedDatabaseBridge(platformPort, events),
+    bridge: new MessagePortSharedDatabaseBridge(
+      platformPort,
+      events,
+      bridgeSignal,
+    ),
     platformPort,
     workerPort,
   };
@@ -178,8 +183,8 @@ function connectProtocolTransport(
 
 test("Keep concurrent shared chat loads independent", async () => {
   initializeWorker();
-  const { bridge } = connectProtocolTransport();
   const owner = createChildAbortController(context.signal);
+  const { bridge } = connectProtocolTransport(owner.signal);
   await bridge.registerTab(owner.signal);
   const firstKey = dataKey(crypto.randomUUID());
   const secondKey = dataKey(crypto.randomUUID());
@@ -236,8 +241,8 @@ test("Keep concurrent shared chat loads independent", async () => {
 
 test("Cancel one shared chat load without cancelling worker progress", async () => {
   initializeWorker();
-  const { bridge, workerPort } = connectProtocolTransport();
   const owner = createChildAbortController(context.signal);
+  const { bridge, workerPort } = connectProtocolTransport(owner.signal);
   await bridge.registerTab(owner.signal);
   const key = dataKey(crypto.randomUUID());
   const canonicalRow = row(key.threadId, 1);
@@ -287,10 +292,10 @@ test("Cancel one shared chat load without cancelling worker progress", async () 
 
 test("Disconnect one tab without interrupting another tab", async () => {
   initializeWorker();
-  const first = connectProtocolTransport();
-  const second = connectProtocolTransport();
   const firstOwner = createChildAbortController(context.signal);
   const secondOwner = createChildAbortController(context.signal);
+  const first = connectProtocolTransport(firstOwner.signal);
+  const second = connectProtocolTransport(secondOwner.signal);
   await first.bridge.registerTab(firstOwner.signal);
   await second.bridge.registerTab(secondOwner.signal);
 
@@ -314,7 +319,7 @@ test("Disconnect one tab without interrupting another tab", async () => {
 
 test("Reject shared-data access before the tab is registered", async () => {
   initializeWorker();
-  const { bridge } = connectProtocolTransport();
+  const { bridge } = connectProtocolTransport(context.signal);
 
   await expect(
     bridge.query(
@@ -332,9 +337,11 @@ test("Reject shared-data access before the tab is registered", async () => {
 
 test("Validate shared chat results received from the worker", async () => {
   const [platformPort, workerPort] = messagePortPair();
+  const owner = createChildAbortController(context.signal);
   const bridge = new MessagePortSharedDatabaseBridge(
     platformPort,
     bridgeEvents(),
+    owner.signal,
   );
   workerPort.addEventListener("message", (event) => {
     const message = event.data;
@@ -354,7 +361,6 @@ test("Validate shared chat results received from the worker", async () => {
     }
   });
   workerPort.start();
-  const owner = createChildAbortController(context.signal);
   await bridge.registerTab(owner.signal);
 
   await expect(
@@ -367,4 +373,63 @@ test("Validate shared chat results received from the worker", async () => {
       owner.signal,
     ),
   ).rejects.toMatchObject({ name: "ZodError" });
+});
+
+test("Stop pending requests when the bridge lifecycle ends", async () => {
+  const [platformPort, workerPort] = messagePortPair();
+  const owner = createChildAbortController(context.signal);
+  const bridge = new MessagePortSharedDatabaseBridge(
+    platformPort,
+    bridgeEvents(),
+    owner.signal,
+  );
+  const requestsStarted = context.mocks.deferred<void>();
+  const requestIds = new Map<"get-computed" | "query", string>();
+  workerPort.addEventListener("message", (event) => {
+    const message = event.data;
+    if (
+      typeof message === "object" &&
+      message !== null &&
+      "type" in message &&
+      (message.type === "get-computed" || message.type === "query") &&
+      "requestId" in message &&
+      typeof message.requestId === "string"
+    ) {
+      requestIds.set(message.type, message.requestId);
+      if (requestIds.size === 2) {
+        requestsStarted.resolve(undefined);
+      }
+    }
+  });
+  workerPort.start();
+  await bridge.registerTab(owner.signal);
+
+  const caller = createChildAbortController(context.signal);
+  const pendingQuery = bridge.query(
+    {
+      dataKey: dataKey(crypto.randomUUID()),
+      afterSeqId: null,
+      consistency: "cache-only",
+    },
+    caller.signal,
+  );
+  const pendingComputed = bridge.getComputed("chat-thread-indicators");
+  await requestsStarted.promise;
+  const reason = new DOMException("Bridge closed", "AbortError");
+  owner.abort(reason);
+
+  await expect(pendingQuery).rejects.toBe(reason);
+  await expect(pendingComputed).rejects.toBe(reason);
+  expect(platformPort.closed).toBeTruthy();
+
+  for (const requestId of requestIds.values()) {
+    workerPort.postMessage({
+      type: "result",
+      requestId,
+      value: { agents: {}, threads: {} },
+    });
+  }
+  await expect(bridge.getComputed("chat-thread-indicators")).rejects.toBe(
+    reason,
+  );
 });

--- a/turbo/apps/platform/src/shared-database/message-port-client.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-client.ts
@@ -31,14 +31,20 @@ interface PendingRequest {
 export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
   private readonly pendingRequests = new Map<string, PendingRequest>();
   private readonly handleMessage: (event: MessageEvent<unknown>) => void;
-  private ownerSignal: AbortSignal | null = null;
+  private readonly handleBridgeAbort: () => void;
+  private registered = false;
   private closed = false;
   private closeReason: unknown = new Error("Shared database bridge is closed");
 
   constructor(
     private readonly port: SharedDatabasePortLike,
     private readonly events: SharedDatabaseBridgeEvents,
+    private readonly bridgeSignal: AbortSignal,
   ) {
+    bridgeSignal.throwIfAborted();
+    this.handleBridgeAbort = () => {
+      this.close(bridgeSignal.reason, false);
+    };
     this.handleMessage = onDomEventFn(async (event) => {
       const message = sharedDatabaseWorkerMessageSchema.parse(event.data);
       L.debug("got message from worker", message);
@@ -81,10 +87,14 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
     });
     this.port.addEventListener("message", this.handleMessage);
     this.port.start();
+    bridgeSignal.addEventListener("abort", this.handleBridgeAbort, {
+      once: true,
+    });
   }
 
   registerTab(signal: AbortSignal): Promise<void> {
-    this.bindOwner(signal);
+    AbortSignal.any([signal, this.bridgeSignal]).throwIfAborted();
+    this.registered = true;
     this.emit({ type: "register-tab" });
     return Promise.resolve();
   }
@@ -96,14 +106,12 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
   async getComputed<TKey extends ComputedKey>(
     computedKey: TKey,
   ): Promise<ComputedValue<TKey>> {
-    const value = await this.request(
-      {
-        type: "get-computed",
-        requestId: crypto.randomUUID(),
-        computedKey,
-      },
-      this.requireOwnerSignal(),
-    );
+    this.requireRegistration();
+    const value = await this.request({
+      type: "get-computed",
+      requestId: crypto.randomUUID(),
+      computedKey,
+    });
     return parseComputedValue(computedKey, value);
   }
 
@@ -122,24 +130,6 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
     return parseSharedDatabaseQueryResult(query.dataKey, value);
   }
 
-  private bindOwner(signal: AbortSignal): void {
-    if (this.ownerSignal === signal) {
-      return;
-    }
-    if (this.ownerSignal !== null) {
-      throw new Error("Shared database bridge already has a lifecycle owner");
-    }
-    signal.throwIfAborted();
-    this.ownerSignal = signal;
-    signal.addEventListener(
-      "abort",
-      () => {
-        this.close(signal.reason, false);
-      },
-      { once: true },
-    );
-  }
-
   private request(
     message: Extract<
       SharedDatabaseClientMessage,
@@ -147,8 +137,11 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
         readonly type: "query" | "get-computed";
       }
     >,
-    signal: AbortSignal,
+    callerSignal?: AbortSignal,
   ): Promise<unknown> {
+    const signal = callerSignal
+      ? AbortSignal.any([callerSignal, this.bridgeSignal])
+      : this.bridgeSignal;
     signal.throwIfAborted();
     if (this.closed) {
       throw this.closeReason;
@@ -175,11 +168,10 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
     return deferred.promise;
   }
 
-  private requireOwnerSignal(): AbortSignal {
-    if (!this.ownerSignal) {
+  private requireRegistration(): void {
+    if (!this.registered) {
       throw new Error("Shared database tab registration is required first");
     }
-    return this.ownerSignal;
   }
 
   private emit(message: SharedDatabaseClientMessage): void {
@@ -196,6 +188,7 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
     } satisfies SharedDatabaseClientMessage);
     this.closed = true;
     this.closeReason = reason;
+    this.bridgeSignal.removeEventListener("abort", this.handleBridgeAbort);
     this.port.removeEventListener("message", this.handleMessage);
     this.port.close();
     for (const pending of this.pendingRequests.values()) {

--- a/turbo/apps/platform/src/shared-database/test-bridge.ts
+++ b/turbo/apps/platform/src/shared-database/test-bridge.ts
@@ -292,7 +292,7 @@ export const setupSharedWorkerTestBootstrap$ = command(
     let directBridge: DirectSharedDatabaseBridge | null = null;
     let directRealtimeForwardingInstalled = false;
     const host: SharedDatabaseBridgeHost = {
-      createBridge: (_identity, events, _connectionSignal) => {
+      createBridge: (_identity, events, connectionSignal) => {
         let bridge: SharedDatabaseBridge;
         if (options.transport === "message-port") {
           const channel = new MessageChannel();
@@ -301,7 +301,11 @@ export const setupSharedWorkerTestBootstrap$ = command(
             channel.port1,
             signal,
           );
-          bridge = new MessagePortSharedDatabaseBridge(channel.port2, events);
+          bridge = new MessagePortSharedDatabaseBridge(
+            channel.port2,
+            events,
+            connectionSignal,
+          );
         } else {
           if (!directRealtimeForwardingInstalled) {
             subscribeChatDatabaseEvents((message) => {

--- a/turbo/apps/platform/src/signals/shared-database-browser.ts
+++ b/turbo/apps/platform/src/signals/shared-database-browser.ts
@@ -122,7 +122,11 @@ function createBrowserSharedDatabaseBridge(
     name: `okou_${identity.userId}_${identity.orgId}${diagnosticsEnabled ? "_diagnostics" : ""}`,
     type: "module",
   });
-  const portBridge = new MessagePortSharedDatabaseBridge(worker.port, events);
+  const portBridge = new MessagePortSharedDatabaseBridge(
+    worker.port,
+    events,
+    signal,
+  );
   let failureHandled = false;
   worker.addEventListener(
     "error",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -2396,6 +2396,45 @@ test("Pin and unpin agents without closing the pin manager", async () => {
   ).resolves.toBeInTheDocument();
 });
 
+test("Show pinned agents before unread indicators finish loading", async () => {
+  prepareAgents();
+  context.mocks.data.userPreferences({
+    pinnedAgentIds: [RESEARCH_AGENT_ID],
+  });
+  const indicatorRequestStarted = context.mocks.deferred<void>();
+  const releaseIndicators = context.mocks.deferred<void>();
+  context.mocks.api(chatThreadsContract.indicators, async ({ respond }) => {
+    if (!indicatorRequestStarted.settled()) {
+      indicatorRequestStarted.resolve(undefined);
+    }
+    await releaseIndicators.promise;
+    return respond(200, {
+      agents: { [SUPPORT_AGENT_ID]: "unread" },
+      threads: {},
+    });
+  });
+
+  await setupSidebarPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+  });
+  await indicatorRequestStarted.promise;
+
+  const grid = await screen.findByTestId("pinned-agents-grid");
+  await waitFor(() => {
+    expect(pinnedAgentNames(grid)).toStrictEqual(["Zero", "Research Agent"]);
+  });
+
+  releaseIndicators.resolve(undefined);
+  await waitFor(() => {
+    expect(pinnedAgentNames(grid)).toStrictEqual([
+      "Zero",
+      "Research Agent",
+      "Support Agent",
+    ]);
+  });
+});
+
 test("Preserve the user’s pinned-agent order", async () => {
   prepareAgents();
   context.mocks.data.userPreferences({

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -474,9 +474,7 @@ export function PinnedAgentListSection({
 
   if (layout === "horizontal") {
     const horizontalPinnedAgents =
-      displayedPinnedAgentsLoadable.state === "loading"
-        ? null
-        : displayedPinnedAgents;
+      pinnedAgentsLoadable.state === "loading" ? null : displayedPinnedAgents;
     const pinnedAgentCards =
       horizontalPinnedAgents === null
         ? Array.from(


### PR DESCRIPTION
## Summary

- bind message-port RPC deferreds to the bridge connection lifecycle while combining query caller cancellation locally
- stop pending and future bridge requests from returning data after teardown without adding a worker cancellation protocol
- render horizontal pinned agents once onboarding, preferences, and agents resolve, then append unread agents when indicators arrive

## Verification

- `pnpm -F @okouai/app exec vitest run src/shared-database/__tests__/message-port.test.ts --maxWorkers=1 --silent=passed-only` (6 tests)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx --maxWorkers=1 --silent=passed-only -t "Show pinned agents before unread indicators finish loading"` (1 test)
- `pnpm -F @okouai/app lint`
- focused Oxlint, type-aware Oxlint, and ESLint for the six changed files
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
