### PR TITLE
test(api): make delegated assertion contracts explicit

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
@@ -690,6 +690,7 @@ describe("chat-run-finished workflow automations", () => {
     "fires a %s-run automation when the terminal run pauses the goal",
     { timeout: 30_000 },
     async (terminalStatus) => {
+      expect.hasAssertions();
       const fixture = await setupChatAutomationFixture();
       const run = await startWatchedChatRun(
         fixture,
@@ -726,6 +727,7 @@ describe("chat-run-finished workflow automations", () => {
     "fires the completed-run automation when continuation launch failure pauses the goal",
     { timeout: 60_000 },
     async () => {
+      expect.hasAssertions();
       const fixture = await setupChatAutomationFixture();
       const firstRun = await startWatchedChatRun(
         fixture,

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
@@ -1008,6 +1008,7 @@ describe("CLI-TEST: test-codex-oauth", () => {
   });
 
   it("maps invalid pasted auth.json inputs to endpoint errors", async () => {
+    expect.hasAssertions();
     const actor = bdd.user();
     await authDevice.provisionTestOrg(actor);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -6118,6 +6118,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
   });
 
   it("invalidates every organization member for definitions and only the owner for credentials", async () => {
+    expect.hasAssertions();
     const bdd = createBddApi(context);
     const admin = bdd.user({ orgRole: "org:admin" });
     const member = bdd.user({ orgId: admin.orgId, orgRole: "org:member" });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -6211,6 +6211,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
   });
 
   it("classifies unavailable and oversized objects before acceptance", async () => {
+    expect.hasAssertions();
     configureSource();
     context.mocks.s3.send.mockRejectedValue(
       new Error("private source credentials and URL must stay private"),
@@ -6893,6 +6894,7 @@ describe("connector catalog rejection and latest-valid retention", () => {
       },
     },
   ])("rejects $name", async ({ expected, release }) => {
+    expect.hasAssertions();
     configureSource();
     const fixture = release();
     serveObjects(catalogObjects([fixture], fixture));

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-oauth-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-oauth-state.test.ts
@@ -60,6 +60,7 @@ describe("Feishu OAuth state", () => {
   it.each(["vm0", "okou"] as const)(
     "passes an explicit %s public brand to installation validation",
     async (publicBrand) => {
+      expect.hasAssertions();
       await expectConnectError(
         signedState({ ...statePayload(), publicBrand }),
         "Feishu bot not found",
@@ -81,6 +82,7 @@ describe("Feishu OAuth state", () => {
       payload: { ...statePayload(), publicBrand: "zero" },
     },
   ])("rejects an $kind public brand", async ({ payload }) => {
+    expect.hasAssertions();
     await expectConnectError(
       signedState(payload),
       "Invalid or expired connect state",
@@ -88,6 +90,7 @@ describe("Feishu OAuth state", () => {
   });
 
   it("rejects an omitted redirect URI", async () => {
+    expect.hasAssertions();
     const { redirectUri: _redirectUri, ...payload } = statePayload();
     await expectConnectError(
       signedState({ ...payload, publicBrand: "vm0" }),
@@ -96,6 +99,7 @@ describe("Feishu OAuth state", () => {
   });
 
   it("preserves the 10-minute expiration boundary", async () => {
+    expect.hasAssertions();
     await expectConnectError(
       signedState({
         ...statePayload(),
@@ -115,6 +119,7 @@ describe("Feishu OAuth state", () => {
   });
 
   it("rejects a state signed with a different secret", async () => {
+    expect.hasAssertions();
     await expectConnectError(
       signedState({ ...statePayload(), publicBrand: "vm0" }, "b".repeat(64)),
       "Invalid or expired connect state",

--- a/turbo/apps/api/src/signals/routes/__tests__/global-sweep-contracts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/global-sweep-contracts.test.ts
@@ -24,6 +24,7 @@ describe("production-global sweep route contracts", () => {
   });
 
   it("rejects cleanup-sandboxes requests with an invalid cron secret", async () => {
+    expect.hasAssertions();
     await expectGlobalSweepWrongAuth(
       context,
       cronCleanupSandboxesRoutes,
@@ -32,6 +33,7 @@ describe("production-global sweep route contracts", () => {
   });
 
   it("rejects cleanup-sandboxes requests without authorization", async () => {
+    expect.hasAssertions();
     await expectGlobalSweepMissingAuth(
       context,
       cronCleanupSandboxesRoutes,
@@ -40,6 +42,7 @@ describe("production-global sweep route contracts", () => {
   });
 
   it("rejects connector OAuth cleanup requests without authorization", async () => {
+    expect.hasAssertions();
     await expectGlobalSweepMissingAuth(
       context,
       cronConnectorOauthStateCleanupRoutes,
@@ -48,6 +51,7 @@ describe("production-global sweep route contracts", () => {
   });
 
   it("rejects billing reconciliation requests without authorization", async () => {
+    expect.hasAssertions();
     await expectGlobalSweepMissingAuth(
       context,
       cronReconcileBillingEntitlementsRoutes,
@@ -65,6 +69,7 @@ describe("production-global sweep route contracts", () => {
   });
 
   it("rejects email-outbox drain requests without authorization", async () => {
+    expect.hasAssertions();
     await expectGlobalSweepMissingAuth(
       context,
       cronDrainEmailOutboxRoutes,
@@ -73,6 +78,7 @@ describe("production-global sweep route contracts", () => {
   });
 
   it("rejects sync-skills requests with an invalid cron secret", async () => {
+    expect.hasAssertions();
     await expectGlobalSweepWrongAuth(
       context,
       cronSyncSkillsRoutes,
@@ -81,6 +87,7 @@ describe("production-global sweep route contracts", () => {
   });
 
   it("rejects sync-skills requests without authorization", async () => {
+    expect.hasAssertions();
     await expectGlobalSweepMissingAuth(
       context,
       cronSyncSkillsRoutes,
@@ -89,6 +96,7 @@ describe("production-global sweep route contracts", () => {
   });
 
   it("rejects workflow automation sweeps without authorization", async () => {
+    expect.hasAssertions();
     await expectGlobalSweepMissingAuth(
       context,
       cronExecuteWorkflowAutomationsRoutes,
@@ -97,6 +105,7 @@ describe("production-global sweep route contracts", () => {
   });
 
   it("rejects Gmail watch renewal without authorization", async () => {
+    expect.hasAssertions();
     await expectGlobalSweepMissingAuth(
       context,
       cronRenewGmailWatchesRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-slack.test.ts
@@ -802,12 +802,14 @@ describe("GET /api/integrations/slack/download-file", () => {
   }
 
   it("returns 401 when the request is unauthenticated", async () => {
+    expect.hasAssertions();
     const response = await requestDownloadFile("?file_id=F1");
 
     await expectErrorResponse(response, 401, "UNAUTHORIZED");
   });
 
   it("rejects an agent token without slack:write capability", async () => {
+    expect.hasAssertions();
     const token = okouToken({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,
@@ -823,6 +825,7 @@ describe("GET /api/integrations/slack/download-file", () => {
   });
 
   it("returns 400 when file_id query param is missing", async () => {
+    expect.hasAssertions();
     const { token } = await seedDownloadContext();
 
     const response = await requestDownloadFile("", `Bearer ${token}`);
@@ -831,6 +834,7 @@ describe("GET /api/integrations/slack/download-file", () => {
   });
 
   it("returns 404 when no Slack installation exists for org", async () => {
+    expect.hasAssertions();
     const { token } = await seedDownloadContext({ withInstallation: false });
 
     const response = await requestDownloadFile(
@@ -842,6 +846,7 @@ describe("GET /api/integrations/slack/download-file", () => {
   });
 
   it("returns 404 when Slack reports file not found", async () => {
+    expect.hasAssertions();
     const { token } = await seedDownloadContext();
     mockSlackFilesInfo({ ok: false, error: "file_not_found" });
 
@@ -854,6 +859,7 @@ describe("GET /api/integrations/slack/download-file", () => {
   });
 
   it("returns 404 when the Slack file has no downloadable URL", async () => {
+    expect.hasAssertions();
     const { token } = await seedDownloadContext();
     const file = defaultSlackFile();
     mockSlackFilesInfo({
@@ -875,6 +881,7 @@ describe("GET /api/integrations/slack/download-file", () => {
   });
 
   it("returns 400 for disallowed download hostnames", async () => {
+    expect.hasAssertions();
     const { token } = await seedDownloadContext();
     mockSlackFilesInfo({
       ok: true,
@@ -895,6 +902,7 @@ describe("GET /api/integrations/slack/download-file", () => {
   });
 
   it("returns 413 when file metadata exceeds the 100MB limit", async () => {
+    expect.hasAssertions();
     const { token } = await seedDownloadContext();
     mockSlackFilesInfo({
       ok: true,
@@ -910,6 +918,7 @@ describe("GET /api/integrations/slack/download-file", () => {
   });
 
   it("returns 502 when Slack file download fails", async () => {
+    expect.hasAssertions();
     const { token } = await seedDownloadContext();
     mockSlackFilesInfo({ ok: true, file: defaultSlackFile() });
     context.mocks.slack.fetchFile.mockRejectedValue(
@@ -929,6 +938,7 @@ describe("GET /api/integrations/slack/download-file", () => {
   });
 
   it("returns 502 when Slack returns an HTML response", async () => {
+    expect.hasAssertions();
     const { token } = await seedDownloadContext();
     mockSlackFilesInfo({ ok: true, file: defaultSlackFile() });
     context.mocks.slack.fetchFile.mockResolvedValue(
@@ -947,6 +957,7 @@ describe("GET /api/integrations/slack/download-file", () => {
   });
 
   it("returns 400 when Slack files.info returns a platform error", async () => {
+    expect.hasAssertions();
     const { token } = await seedDownloadContext();
     mockSlackFilesInfo({ ok: false, error: "invalid_auth" });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram.test.ts
@@ -227,6 +227,7 @@ describe("GET /api/integrations/telegram/bots", () => {
   });
 
   it("returns 401 when the token has no active organization membership", async () => {
+    expect.hasAssertions();
     context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
       data: [],
     });
@@ -252,6 +253,7 @@ describe("GET /api/integrations/telegram/bots", () => {
   });
 
   it("returns 401 when the authenticated session has no organization", async () => {
+    expect.hasAssertions();
     mocks.clerk.session(`user_${randomUUID()}`, null);
     const client = setupApp({
       context,
@@ -436,6 +438,7 @@ describe("GET /api/integrations/telegram", () => {
   });
 
   it("returns 401 when no auth token is provided", async () => {
+    expect.hasAssertions();
     const client = setupApp({
       context,
       routes: integrationsTelegramRoutes,
@@ -783,6 +786,7 @@ describe("GET /api/integrations/telegram/link", () => {
   }
 
   it("returns 401 when no auth token is provided", async () => {
+    expect.hasAssertions();
     const client = setupApp({
       context,
       routes: integrationsTelegramRoutes,
@@ -1090,6 +1094,7 @@ describe("POST /api/integrations/telegram/link", () => {
   }
 
   it("returns 401 when not authenticated", async () => {
+    expect.hasAssertions();
     const client = setupApp({
       context,
       routes: integrationsTelegramRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -6830,6 +6830,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
   });
 
   it("keeps runner heartbeat snapshots ordered", async () => {
+    expect.hasAssertions();
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/web-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-download.test.ts
@@ -156,12 +156,14 @@ async function expectErrorResponse(
 
 describe("GET /api/web/download-file", () => {
   it("returns 401 when no auth token is provided", async () => {
+    expect.hasAssertions();
     const response = await requestDownload({ fileId: "abc" });
 
     await expectErrorResponse(response, 401, "UNAUTHORIZED");
   });
 
   it("returns 403 for an agent token without file:read capability", async () => {
+    expect.hasAssertions();
     const token = mintOkouToken({
       userId: `user_${randomUUID()}`,
       orgId: `org_${randomUUID()}`,
@@ -174,6 +176,7 @@ describe("GET /api/web/download-file", () => {
   });
 
   it("returns 400 when file_id query param is missing", async () => {
+    expect.hasAssertions();
     const { token } = await mintFileReadToken();
 
     const response = await requestDownload({ token });
@@ -182,6 +185,7 @@ describe("GET /api/web/download-file", () => {
   });
 
   it("returns 400 when file_id query param is empty", async () => {
+    expect.hasAssertions();
     const { token } = await mintFileReadToken();
 
     const response = await requestDownload({ fileId: "", token });
@@ -190,6 +194,7 @@ describe("GET /api/web/download-file", () => {
   });
 
   it("returns 404 when the file is not found in S3", async () => {
+    expect.hasAssertions();
     const { token } = await mintFileReadToken();
     mockS3Objects([]);
 


### PR DESCRIPTION
## Summary

- add explicit `expect.hasAssertions()` contracts to all 42 verified helper-only API test callbacks across 10 files
- keep every delegated helper invocation unconditional and preserve the helpers' real runtime assertions
- absorb the additional Feishu caller merged by #31609 while leaving the 13 direct assertion-gap warnings and existing heartbeat conditional assertions for later EPIC slices

Parent EPIC: #31516

## Warning delta

Measured against `origin/main` at `df9f44c98af3fa1e063f81bb4902642446b986df`:

| Inventory | Main | This PR | Delta |
| --- | ---: | ---: | ---: |
| Regular API Oxlint warnings | 118 | 76 | -42 |
| `vitest(expect-expect)` warnings | 55 | 13 | -42 |

All other warning classes are unchanged by this diff. The 13 remaining `expect-expect` warnings are the direct outcome/read-back/cardinality cases excluded from this slice.

## Validation

- `pnpm exec prettier --check <10 affected files>`
- focused and full regular API Oxlint inventory (`76` warnings total; `13` `vitest(expect-expect)`)
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- staged workspace and API type checks, including `pnpm --filter api run check-types`
- `pnpm knip` (passes with existing configuration hints)
- targeted Vitest runs, one foreground process at a time:
  - fully passing: CLI auth (21), connectors (91), Feishu OAuth state (8), global sweep contracts (10), Slack integration (25), Telegram integration (58), and web download (12)
  - cron connector catalog: 108 passed; 4 unrelated valid-lifecycle queue-claim cases failed locally before the edited rejection helpers
  - chat-run-finished automations: 2 passed; 8 queue-claim cases failed locally at the untouched `claimChatRun` 404 polling assertion, including the edited callbacks before their delegated helpers
  - run lifecycle: 48 passed; 149 queue-dependent cases failed locally with `Job not found in queue`; the edited heartbeat case was isolated and fails at `claimRunnerJob` before `expectReusePreference`
- `git diff --check`

The local queue-claim limitation does not overlap this assertion-contract-only diff; the PR pipeline remains authoritative for the full required checks.

Closes #31664
