### PR TITLE
test(api): assert direct observable outcomes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-auto-recharge.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-auto-recharge.test.ts
@@ -356,37 +356,70 @@ describe("PUT /api/billing/auto-recharge", () => {
   it("returns 400 when enabling without threshold and amount", async () => {
     const { admin } = await createProActor();
 
-    await billingApi.updateAutoRecharge(admin, { enabled: true }, [400]);
+    const response = await billingApi.updateAutoRecharge(
+      admin,
+      { enabled: true },
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message:
+          "threshold and amount are required when enabling auto-recharge",
+        code: "BAD_REQUEST",
+      },
+    });
   });
 
   it("returns 400 when amount is below minimum", async () => {
     const { admin } = await createProActor();
 
-    await billingApi.updateAutoRecharge(
+    const response = await billingApi.updateAutoRecharge(
       admin,
       { enabled: true, threshold: 1000, amount: 500 },
       [400],
     );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "amount: Too small: expected number to be >=1000",
+        code: "BAD_REQUEST",
+      },
+    });
   });
 
   it("returns 400 when amount exceeds the maximum", async () => {
     const { admin } = await createProActor();
 
-    await billingApi.updateAutoRecharge(
+    const response = await billingApi.updateAutoRecharge(
       admin,
       { enabled: true, threshold: 1000, amount: 10_000_001 },
       [400],
     );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "amount: Too big: expected number to be <=10000000",
+        code: "BAD_REQUEST",
+      },
+    });
   });
 
   it("returns 400 when threshold exceeds the maximum", async () => {
     const { admin } = await createProActor();
 
-    await billingApi.updateAutoRecharge(
+    const response = await billingApi.updateAutoRecharge(
       admin,
-      { enabled: true, threshold: 10_000_001, amount: 20_000_000 },
+      { enabled: true, threshold: 10_000_001, amount: 10_000_000 },
       [400],
     );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "threshold: Too big: expected number to be <=10000000",
+        code: "BAD_REQUEST",
+      },
+    });
   });
 
   it("returns 400 when threshold equals amount", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-catalog.test.ts
@@ -916,6 +916,7 @@ describe("GET /api/connector-catalog", () => {
       [200],
     );
 
+    expect(listResponse.body.connectors.length).toBeGreaterThan(0);
     for (const connector of listResponse.body.connectors) {
       const detailResponse = await accept(
         client.get({

--- a/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
@@ -1211,7 +1211,7 @@ describe("GET/PUT /api/model-policies", () => {
     const outsideCatalog =
       DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL as unknown as VideoModelId;
 
-    await accept(
+    const response = await accept(
       preferenceClient.update({
         headers: authHeaders(),
         body: {
@@ -1222,6 +1222,13 @@ describe("GET/PUT /api/model-policies", () => {
       }),
       [400],
     );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: expect.stringMatching(/^selectedVideoModel: Invalid option:/),
+        code: "BAD_REQUEST",
+      },
+    });
   });
 
   it("stores, preserves, and clears a member image default", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/presentation-templates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/presentation-templates.test.ts
@@ -64,11 +64,11 @@ describe("presentation template owner routes", () => {
     const client = templateClient();
     const templateId = randomUUID();
 
-    await accept(
+    const readResponse = await accept(
       client.get({ headers: webHeaders(), params: { templateId } }),
       [404],
     );
-    await accept(
+    const updateResponse = await accept(
       client.update({
         headers: webHeaders(),
         params: { templateId },
@@ -76,9 +76,21 @@ describe("presentation template owner routes", () => {
       }),
       [404],
     );
-    await accept(
+    const deleteResponse = await accept(
       client.delete({ headers: webHeaders(), params: { templateId } }),
       [404],
     );
+
+    const notFoundBody = {
+      error: {
+        message: `Presentation template not found: ${templateId}`,
+        code: "NOT_FOUND",
+      },
+    };
+    expect([
+      readResponse.body,
+      updateResponse.body,
+      deleteResponse.body,
+    ]).toStrictEqual([notFoundBody, notFoundBody, notFoundBody]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -14049,7 +14049,12 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       },
       [400],
     );
-    expectApiError(rejected.body);
+    expect(rejected.body).toStrictEqual({
+      error: {
+        message: `Invalid base URL "https://\${{ vars.JIRA_DOMAIN }}" in firewall "jira": host policy does not allow resolved host "attacker.example"`,
+        code: "BAD_REQUEST",
+      },
+    });
   });
 
   it("refreshes queued connector grants from the stored permission baseline", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/test-usage-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-usage-state.test.ts
@@ -1,8 +1,11 @@
 import { createStore } from "ccstate";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
-import { seedOwnedConnectorSecret } from "./helpers/connector-credential-storage-state";
+import {
+  readConnectorCredentialStorageState,
+  seedOwnedConnectorSecret,
+} from "./helpers/connector-credential-storage-state";
 import {
   deleteUsageStateFixture$,
   insertUsageEvent$,
@@ -32,6 +35,17 @@ describe("usage state test state", () => {
     });
 
     await store.set(deleteUsageStateFixture$, fixture, context.signal);
+
+    const storageState = await readConnectorCredentialStorageState(context, {
+      ...fixture,
+      connectorSlug: "fixture-connector",
+      secretNames: ["FIXTURE_CONNECTOR_TOKEN"],
+    });
+    expect(storageState).toMatchObject({
+      connector: null,
+      secrets: [],
+      variables: [],
+    });
   });
 
   it("moves processed fixture usage to hourly storage", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -1001,7 +1001,7 @@ describe("okou workflow automations", () => {
       visibility: "private",
     });
 
-    await accept(
+    const response = await accept(
       automationsClient().create({
         headers: authHeaders(),
         params: { workflowId: hidden.workflowId },
@@ -1011,12 +1011,19 @@ describe("okou workflow automations", () => {
       }),
       [404],
     );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Workflow not found: ${hidden.workflowId}`,
+        code: "NOT_FOUND",
+      },
+    });
   });
 
   it("rejects an invalid cron expression and a past one-time schedule", async () => {
     const { workflowId } = await setupFixture();
 
-    await accept(
+    const invalidCron = await accept(
       automationsClient().create({
         headers: authHeaders(),
         params: { workflowId },
@@ -1031,7 +1038,7 @@ describe("okou workflow automations", () => {
       [400],
     );
 
-    await accept(
+    const pastOnce = await accept(
       automationsClient().create({
         headers: authHeaders(),
         params: { workflowId },
@@ -1045,6 +1052,19 @@ describe("okou workflow automations", () => {
       }),
       [400],
     );
+
+    expect(invalidCron.body).toStrictEqual({
+      error: {
+        message: "Invalid cron expression: not a cron",
+        code: "BAD_REQUEST",
+      },
+    });
+    expect(pastOnce.body).toStrictEqual({
+      error: {
+        message: "Schedule atTime must be in the future",
+        code: "BAD_REQUEST",
+      },
+    });
   });
 
   it("makes a loop automation due immediately when enabled", async () => {
@@ -4618,13 +4638,20 @@ describe("okou workflow automations", () => {
       [204],
     );
 
-    await accept(
+    const response = await accept(
       automationsClient().enable({
         headers: authHeaders(),
         params: { id: created.body.id },
       }),
       [404],
     );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Workflow automation not found",
+        code: "NOT_FOUND",
+      },
+    });
   });
 
   it("allows another org member to manage only their own automations", async () => {
@@ -4645,7 +4672,7 @@ describe("okou workflow automations", () => {
     const otherUserId = `user_${randomUUID()}`;
     mocks.clerk.session(otherUserId, fixture.orgId, "org:member");
 
-    await accept(
+    const memberAutomation = await accept(
       automationsClient().create({
         headers: authHeaders(),
         params: { workflowId },
@@ -4656,13 +4683,21 @@ describe("okou workflow automations", () => {
       [201],
     );
 
-    await accept(
+    const denied = await accept(
       automationsClient().delete({
         headers: authHeaders(),
         params: { id: ownerAutomation.body.id },
       }),
       [403],
     );
+
+    expect(memberAutomation.body.ownerUserId).toBe(otherUserId);
+    expect(denied.body).toStrictEqual({
+      error: {
+        message: "Only the automation owner can manage this automation",
+        code: "FORBIDDEN",
+      },
+    });
   });
 
   it("keeps the bound chat thread when an automation is deleted", async () => {


### PR DESCRIPTION
## Summary

- add direct observable assertions for all 13 `vitest(expect-expect)` cases owned by #31675
- verify stable API error bodies, persisted credential cleanup, cross-member ownership, and non-empty connector catalog traversal
- isolate the billing threshold boundary by keeping the recharge amount valid

## Moving-main inventory

The implementation started from exact `origin/main` HEAD `64eddf256934747393a2d98636560ca2fad45a6c`, where regular API Oxlint reported 113 total warnings and 54 `vitest(expect-expect)` warnings. Before opening this PR, it was rebased onto `b2ff1a1fba3f264e6c6ad1c48f1c1e491a97633d`.

On that latest base, unrelated main changes moved the inventory to 118 total warnings and 55 `vitest(expect-expect)` warnings. This branch reports 105 and 42 respectively: an exact reduction of 13 in both inventories, with none of the 13 assigned locations remaining.

The live Jira response retains the unresolved stored-domain template in the rejected URL while reporting the resolved disallowed host. The assertion therefore follows the live contract: `https://${{ vars.JIRA_DOMAIN }}` plus resolved host `attacker.example`.

Open PR overlap was inspected for #31601, #31674, #31622, #31666, and #31673; their edits are in other regions. #31664 remains the separate helper-backed slice. These are rebase inventory only.

## Validation

- Prettier check: passed for all 7 changed files
- focused Oxlint: passed; only 10 existing `no-conditional-expect` warnings and the separate #31664 helper-backed warning remain in these files
- regular API Oxlint inventory: 118 -> 105 total warnings; 55 -> 42 `vitest(expect-expect)` warnings
- `pnpm -F api check-types`: passed
- `pnpm knip`: passed (existing configuration hints only)
- full-file Vitest passed: billing auto-recharge (19), model policies (43), presentation templates (2), usage state (2), connector catalog (33)
- changed workflow automation scenarios: 4 passed, 77 skipped
- changed run lifecycle scenario: 1 passed, 196 skipped

The local full-file workflow automation run reached 79/81; its two failures are unchanged runner-queue scenarios. A fresh-DB `run-lifecycle` run fails from its first unchanged test because the local runner-queue harness returns `Job not found in queue`; `--bail=1` confirms this precedes the changed scenario. The PR pipeline remains the authoritative complete-file gate.

Closes #31675
