### PR TITLE
test(runner): tolerate balloon pressure variance

### DIFF
--- a/.github/scripts/runner-behavior-balloon-remote.sh
+++ b/.github/scripts/runner-behavior-balloon-remote.sh
@@ -1,5 +1,29 @@
 #!/usr/bin/env bash
 
+# Keep these expectations aligned with balloon.rs: the controller polls every
+# 5 seconds, deflates below 192 MiB available, and inflates above 384 MiB free.
+PRESSURE_AVAILABLE_BOUNDARY_MIB=192
+PRESSURE_TARGET_AVAILABLE_MIB=128
+MAX_PRESSURE_ALLOC_MIB=512
+
+pressure_allocation_mib() {
+  local available_mib=$1
+  local allocation_mib=$(( available_mib - PRESSURE_TARGET_AVAILABLE_MIB ))
+
+  if [ "$allocation_mib" -gt "$MAX_PRESSURE_ALLOC_MIB" ]; then
+    allocation_mib=$MAX_PRESSURE_ALLOC_MIB
+  fi
+  if [ $(( available_mib - allocation_mib )) -ge "$PRESSURE_AVAILABLE_BOUNDARY_MIB" ]; then
+    return 1
+  fi
+
+  printf '%s\n' "$allocation_mib"
+}
+
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  return 0
+fi
+
 BIN_DIR=$1; JOB_REF=$2
 RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-balloon"
 SVC="${JOB_REF}-balloon"
@@ -80,10 +104,6 @@ echo "Found sandbox: $SANDBOX_ID"
 
 API_SOCK="/run/vm0/sock/$SANDBOX_ID/api.sock"
 
-# Keep these expectations aligned with balloon.rs: the controller polls every
-# 5 seconds, deflates below 192 MiB available, and inflates above 384 MiB free.
-PRESSURE_TARGET_AVAILABLE_MIB=128
-MAX_PRESSURE_ALLOC_MIB=512
 # The retired controller physically relieved at most its 256 MiB free-memory
 # deficit. A larger physical drop distinguishes full relief without requiring
 # an external poll to observe the transient target-zero interval.
@@ -221,9 +241,9 @@ if [ "$PRE_PRESSURE_AVAIL_KB" -le "$PRESSURE_TARGET_AVAILABLE_KB" ]; then
   fail "guest MemAvailable too low before pressure allocation: ${PRE_PRESSURE_AVAIL_KB}kB (need > ${PRESSURE_TARGET_AVAILABLE_KB}kB)"
 fi
 PRE_PRESSURE_AVAIL_MIB=$(( PRE_PRESSURE_AVAIL_KB / 1024 ))
-PRESSURE_ALLOC_MIB=$(( PRE_PRESSURE_AVAIL_MIB - PRESSURE_TARGET_AVAILABLE_MIB ))
-if [ "$PRESSURE_ALLOC_MIB" -gt "$MAX_PRESSURE_ALLOC_MIB" ]; then
-  fail "required pressure allocation exceeds safety cap: required=${PRESSURE_ALLOC_MIB}MiB cap=${MAX_PRESSURE_ALLOC_MIB}MiB available=${PRE_PRESSURE_AVAIL_MIB}MiB target=${PRESSURE_TARGET_AVAILABLE_MIB}MiB"
+if ! PRESSURE_ALLOC_MIB=$(pressure_allocation_mib "$PRE_PRESSURE_AVAIL_MIB"); then
+  PROJECTED_AVAILABLE_MIB=$(( PRE_PRESSURE_AVAIL_MIB - MAX_PRESSURE_ALLOC_MIB ))
+  fail "maximum pressure allocation cannot cross controller boundary: available=${PRE_PRESSURE_AVAIL_MIB}MiB cap=${MAX_PRESSURE_ALLOC_MIB}MiB projected=${PROJECTED_AVAILABLE_MIB}MiB boundary=${PRESSURE_AVAILABLE_BOUNDARY_MIB}MiB"
 fi
 [ "$PRESSURE_ALLOC_MIB" -gt 0 ] || fail "pressure allocation would be zero: ${PRE_PRESSURE_AVAIL_KB}kB available"
 echo "Pre-pressure guest MemAvailable: ${PRE_PRESSURE_AVAIL_KB}kB; allocating ${PRESSURE_ALLOC_MIB}MiB"

--- a/.github/scripts/tests/runner-behavior-durable-test.sh
+++ b/.github/scripts/tests/runner-behavior-durable-test.sh
@@ -494,4 +494,22 @@ if [ -e "$replay_marker" ]; then
   exit 1
 fi
 
+for pressure_case in "636 508" "640 512" "641 512" "703 512"; do
+  read -r available_mib expected_allocation_mib <<< "$pressure_case"
+  actual_allocation_mib=$(bash -c \
+    'source "$1"; pressure_allocation_mib "$2"' \
+    runner-behavior-pressure-allocation "$BALLOON_REMOTE_WORKER" "$available_mib")
+  if [ "$actual_allocation_mib" -ne "$expected_allocation_mib" ]; then
+    echo "expected ${available_mib}MiB available to select ${expected_allocation_mib}MiB; got ${actual_allocation_mib}MiB" >&2
+    exit 1
+  fi
+done
+
+if bash -c \
+  'source "$1"; pressure_allocation_mib "$2"' \
+  runner-behavior-pressure-allocation "$BALLOON_REMOTE_WORKER" 704; then
+  echo "expected 704MiB available to exceed the bounded pressure allocation" >&2
+  exit 1
+fi
+
 echo "runner-behavior-durable-test: ok"


### PR DESCRIPTION
## Summary

- preserve the 512 MiB balloon pressure allocation ceiling while allowing capped allocations that still cross the controller's strict 192 MiB boundary
- keep genuinely insufficient pressure setups distinct from controller failures
- deterministically cover the observed 641 MiB case and the strict 191/192 MiB edge using the production worker's allocation selector

## Problem

The real-metal balloon fixture treated its preferred 128 MiB post-allocation target as mandatory. Normal Guest memory variation could produce 641 MiB available, requiring 513 MiB to reach that target, so the fixture failed before allocation even though the 512 MiB cap would leave approximately 129 MiB and still establish pressure.

## Solution

The worker now selects the preferred allocation up to 512 MiB, clamps larger requests to the existing cap, and rejects only when the capped projection is not strictly below the controller's 192 MiB pressure boundary. A source guard lets the consolidated shell fixture execute the exact selector without adding another staged runtime file. The real-metal allocator lifetime, VM survival, durable physical-relief, recovery, and cleanup assertions are unchanged.

## Explicit exclusions

- no production Runner or balloon-controller change
- no runner profile, image, API, protocol, migration, or persisted-state change
- no CI concurrency or timeout change
- no increase above the existing 512 MiB pressure allocation cap

## Validation

- `bash -n .github/scripts/runner-behavior-balloon-remote.sh .github/scripts/tests/runner-behavior-durable-test.sh`
- `bash .github/scripts/tests/runner-behavior-durable-test.sh`
- `./scripts/check-file-size.sh .github/scripts/runner-behavior-balloon-remote.sh .github/scripts/tests/runner-behavior-durable-test.sh`
- `git diff --check`
- pre-commit file-size hook and commitlint

The repository-wide shell fixture loop was also exercised. The changed durable fixture passed; unrelated fixtures requiring locally unavailable `ruby`, `yq`, or `shellcheck` could not complete in this container and remain covered by Security CI.

Closes #31689
