### PR TITLE
perf(api): switch the fast-path llm to gemini-3.8-flash with pinned reasoning effort

### DIFF
--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -12,7 +12,7 @@ const OPENROUTER_ERROR_RESPONSE_MAX_BYTES = 64 * 1024;
  * short, latency-sensitive calls that are not user-selectable, so they share a
  * single model rather than one constant per service.
  */
-export const FAST_PATH_MODEL = "google/gemini-3.1-flash-lite";
+export const FAST_PATH_MODEL = "google/gemini-3.8-flash";
 
 export interface OpenRouterTextPart {
   readonly type: "text";

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -505,9 +505,9 @@ const openRouterBodySchema = z.object({
   model: z.string(),
   messages: z.array(z.object({ role: z.string(), content: z.string() })),
   max_tokens: z.number().optional(),
-  reasoning: z.object({
-    effort: z.enum(["none", "minimal", "low", "medium", "high"]),
-  }),
+  reasoning: z
+    .object({ effort: z.enum(["none", "minimal", "low", "medium", "high"]) })
+    .optional(),
 });
 
 async function entitledChatActor(
@@ -14271,6 +14271,8 @@ describe("CHAT-02: prior rounds and thread titles", () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "title-key");
     let upstreamAuthorization: string | null = null;
     let titleRequests = 0;
+    let titleRequestBody: z.infer<typeof openRouterBodySchema> | undefined;
+    let followupRequestBody: z.infer<typeof openRouterBodySchema> | undefined;
     server.use(
       http.post(
         "https://openrouter.ai/api/v1/chat/completions",
@@ -14279,6 +14281,7 @@ describe("CHAT-02: prior rounds and thread titles", () => {
           const payload = openRouterBodySchema.parse(await request.json());
           const systemContent = payload.messages[0]?.content ?? "";
           if (systemContent.includes("concise follow-up prompts")) {
+            followupRequestBody = payload;
             return HttpResponse.json({
               choices: [
                 {
@@ -14294,6 +14297,7 @@ describe("CHAT-02: prior rounds and thread titles", () => {
           }
           if (systemContent.includes("Generate a short, descriptive title")) {
             titleRequests += 1;
+            titleRequestBody = payload;
             return HttpResponse.json({
               choices: [
                 {
@@ -14320,6 +14324,10 @@ describe("CHAT-02: prior rounds and thread titles", () => {
     await waitForThreadTitle(actor, first.threadId, "Migration Plan");
     expect(titleRequests).toBe(1);
     expect(upstreamAuthorization).toBe("Bearer title-key");
+    expect(titleRequestBody).toMatchObject({
+      model: "google/gemini-3.8-flash",
+      reasoning: { effort: "low" },
+    });
 
     const firstClaim = await claimChatRun(runnerGroup, first.runId);
     chatCallbacks.mockChatOutputEvents([
@@ -14348,6 +14356,11 @@ describe("CHAT-02: prior rounds and thread titles", () => {
       throw new Error("Expected a recommended follow-ups message");
     }
     expect(recommender.eventType).toBe("output.followups");
+    expect(followupRequestBody).toMatchObject({
+      model: "google/gemini-3.8-flash",
+      max_tokens: 400,
+      reasoning: { effort: "low" },
+    });
     const futureFollowups = resolveChatEventRecommendedFollowups(recommender);
     expect(futureFollowups.length).toBeGreaterThan(0);
     const futureFollowupContent = recommender.content;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -505,7 +505,9 @@ const openRouterBodySchema = z.object({
   model: z.string(),
   messages: z.array(z.object({ role: z.string(), content: z.string() })),
   max_tokens: z.number().optional(),
-  reasoning: z.object({ effort: z.literal("none") }).optional(),
+  reasoning: z.object({
+    effort: z.enum(["none", "minimal", "low", "medium", "high"]),
+  }),
 });
 
 async function entitledChatActor(
@@ -14182,7 +14184,7 @@ describe("CHAT-02: initial thinking indicator", () => {
     });
     expect(thinkingAuthorization).toBe("Bearer thinking-key");
     expect(thinkingRequestBody).toMatchObject({
-      model: "google/gemini-3.1-flash-lite",
+      model: "google/gemini-3.8-flash",
       max_tokens: 160,
       reasoning: { effort: "none" },
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-polish.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-polish.test.ts
@@ -68,7 +68,7 @@ describe("POST /api/voice-io/polish", () => {
       text: "Ship the release on Monday.",
     });
     expect(requestBody).toMatchObject({
-      model: "google/gemini-3.1-flash-lite",
+      model: "google/gemini-3.8-flash",
       max_tokens: 65_536,
       temperature: 0,
       reasoning: { effort: "none" },

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -207,6 +207,7 @@ async function generateFastPathText(
   },
 ): Promise<string | null> {
   const content = await generateText(FAST_PATH_MODEL, messages, maxTokens, {
+    reasoning: { effort: "low" },
     temperature: 0.3,
   });
   if (content === null) {
@@ -508,7 +509,7 @@ async function generateRecommendedFollowups(
         content: `Recent conversation:\n${context}`,
       },
     ],
-    260,
+    400,
     { stripMarkdown: false },
   );
 

--- a/turbo/apps/api/src/signals/services/goal-objective-brief.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-objective-brief.service.ts
@@ -28,6 +28,7 @@ export async function generateGoalObjectiveBrief(
         },
       ],
       80,
+      { reasoning: { effort: "low" } },
     ),
     (error) => {
       log.warn("Failed to generate goal objective brief", {

--- a/turbo/apps/api/src/signals/services/run-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/run-summary.service.ts
@@ -57,7 +57,7 @@ async function generateRunSummary(
       },
     ],
     80,
-    { temperature: 0.3 },
+    { reasoning: { effort: "low" }, temperature: 0.3 },
   );
   return content === null ? null : stripMarkdown(content);
 }


### PR DESCRIPTION
Closes #31694. Slice 2 (final slice) of #31616.

## What changed

**1. `FAST_PATH_MODEL` → `google/gemini-3.8-flash`** (`signals/external/openrouter.ts`). Still the single fast-path model constant; no call site is routed anywhere else.

**2. Explicit `reasoning.effort` at all five call sites** — no site relies on a provider default any more:

| Call site | Before | After |
|---|---|---|
| `chat-title.service.ts` (chat title, shared title, notification summary, recommended follow-ups) | no reasoning | `"low"` |
| `run-summary.service.ts` | no reasoning | `"low"` |
| `goal-objective-brief.service.ts` | no options | `"low"` |
| `chat-initial-thinking.service.ts` | `"none"` | `"none"` (unchanged) |
| `voice-io-polish.service.ts` | `"none"`, `temperature: 0` | `"none"`, `temperature: 0` (unchanged) |

The two sites that already passed `"none"` keep it deliberately: they are the most latency-sensitive paths in the product, and changing model *and* effort together there would conflate two variables where a regression is hardest to attribute. `high` effort on this model has an 11.28s TTFT versus 0.70s at `low`, and TTFT dominates these short-output calls — hence "explicit everywhere" rather than "low everywhere".

**3. Recommended-follow-up `max_tokens` 260 → 400** (`chat-title.service.ts`). Reasoning tokens count against `max_tokens`, and #31611 lengthened that system prompt by ~200 tokens. Since #31653 a truncated response throws instead of silently yielding `[]`, so an under-budget setting costs the user their follow-ups and logs an error. The other four budgets are untouched: chat title 30, notification summary 35, run summary 80, goal objective brief 80.

**4. Tests.** The two existing assertions on the model id are updated (`voice-io-polish.test.ts`, `chat-events.bdd.test.ts`). The CHAT-02 thread-title scenario now also captures the chat-title and recommended-follow-up OpenRouter request bodies and asserts the new model id, the pinned `"low"` effort, and the 400-token follow-up budget. The shared mock request schema accepts the full effort range and stays permissive about `reasoning` so non-fast-path OpenRouter callers can still be exercised through the same handler.

## Not in scope

No prompt text, no other `max_tokens`, no `temperature`, no `finish_reason` bypass, no truncation tests (#31693), no `image-recognition.service.ts`, no historical Gemini billing mappings.

## Verification

- `rg 'gemini-3\.1-flash-lite'` returns no hits in the repo.
- All five call sites pass an explicit `reasoning.effort`; three `"low"`, two `"none"`.
- No prompt string constant differs from `main` (the only `chat-title.service.ts` changes are the options object and the `260` → `400` literal).
- Relying on the PR pipeline for lint / type-check / tests per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)