### PR TITLE
fix(api): waive upgrade debt only for first-time paying orgs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -5185,6 +5185,44 @@ describe("legacy subscription usage pack migration", () => {
     expect(persisted.subscriptionCount).toBe(0);
   });
 
+  it("preserves negative legacy credits when the first usage pack migration invoice is paid", async () => {
+    const fixture = await seedLegacyMigrationFixture({
+      tier: "pro",
+      orgId: `org_migration_debt_${randomUUID()}`,
+    });
+    const stripe = mockMigrationStripe({
+      fixture,
+      packageQuantity: 1,
+      currentRecurringAmountCents: 2000,
+      amountDueCents: 4000,
+      amountPaidCents: 4000,
+    });
+    const preview = await previewMigration(fixture);
+    await accept(
+      migrationClient().confirm({
+        params: { migrationId: preview.migrationId },
+        body: {},
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    await seedOrgMetadata({
+      orgId: fixture.orgId,
+      tier: "pro",
+      credits: -5000,
+    });
+
+    stripe.startScheduledPhase();
+    await postMigrationInvoice(stripe.invoice());
+
+    const state = await readUsagePackState(fixture.orgId, preview.migrationId);
+    expect(state.org).toMatchObject({ tier: "pro", credits: -5000 });
+    expect(state.migrations).toContainEqual(
+      expect.objectContaining({ id: preview.migrationId, status: "completed" }),
+    );
+    expect(state.grants).toHaveLength(2);
+  });
+
   it("schedules a legacy Pro-to-Team conversion at the billing boundary", async () => {
     const fixture = await seedLegacyMigrationFixture({ tier: "pro" });
     const stripe = mockMigrationStripe({

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
@@ -304,6 +304,7 @@ async function readBillingStatus(fixture: UsagePackLifecycleFixture) {
 async function seedUsagePackLifecycle(
   selections: readonly UsagePackSelection[],
   tier: "pro" | "team" = "pro",
+  credits = 0,
 ): Promise<UsagePackLifecycleFixture> {
   const orgId = `org_usage_pack_${randomUUID()}`;
   const customerId = `cus_${randomUUID()}`;
@@ -318,7 +319,7 @@ async function seedUsagePackLifecycle(
       return selection.invitationId !== undefined;
     })?.invitationId ?? null;
 
-  await seedOrgMetadata({ orgId, tier: "limited-free-1", credits: 0 });
+  await seedOrgMetadata({ orgId, tier: "limited-free-1", credits });
   const seeded = await usagePackStateAction({
     action: "seed",
     orgId,
@@ -1312,15 +1313,17 @@ describe("usage pack subscription Stripe lifecycle", () => {
     );
   });
 
-  it("reconciles an expired payment failure through the existing billing fallback", async () => {
+  it("clears negative credits on the first paid upgrade but not after a payment-failure downgrade", async () => {
     mockNow(new Date("2999-02-01T00:00:00.000Z"));
     onTestFinished(() => {
       clearMockNow();
     });
     const userId = `user_${randomUUID()}`;
-    const fixture = await seedUsagePackLifecycle([
-      { userId, usagePackUsd: 20 },
-    ]);
+    const fixture = await seedUsagePackLifecycle(
+      [{ userId, usagePackUsd: 20 }],
+      "pro",
+      -5000,
+    );
     const quantities = new Map([[TEST_PRICE_PACK_20, 1]]);
     const paidPeriod = period(-32);
     let currentSubscription = stripeSubscription(
@@ -1341,6 +1344,10 @@ describe("usage pack subscription Stripe lifecycle", () => {
         }),
       ),
       200,
+    );
+    const firstUpgradeOrg = (await readUsagePackState(fixture)).org;
+    expect(firstUpgradeOrg).toStrictEqual(
+      expect.objectContaining({ tier: "pro", credits: 0 }),
     );
 
     currentSubscription = stripeSubscription(fixture, paidPeriod, quantities, {
@@ -1363,6 +1370,40 @@ describe("usage pack subscription Stripe lifecycle", () => {
       expect.objectContaining({
         tier: "limited-free-1",
         subscriptionStatus: "past_due",
+      }),
+    );
+
+    await seedOrgMetadata({
+      orgId: fixture.orgId,
+      tier: "limited-free-1",
+      credits: -3000,
+    });
+    const recoveredPeriod = period(0);
+    currentSubscription = stripeSubscription(
+      fixture,
+      recoveredPeriod,
+      quantities,
+    );
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      currentSubscription,
+    );
+    await postStripeEvent(
+      stripeEvent(
+        "invoice.paid",
+        paidInvoice(fixture, {
+          invoiceId: `in_${randomUUID()}`,
+          paidPeriod: recoveredPeriod,
+          quantities,
+        }),
+      ),
+      200,
+    );
+    const recoveredOrg = (await readUsagePackState(fixture)).org;
+    expect(recoveredOrg).toStrictEqual(
+      expect.objectContaining({
+        tier: "pro",
+        subscriptionStatus: "active",
+        credits: -3000,
       }),
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
@@ -11,6 +11,7 @@ import { createApp } from "../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
+import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { createRouteMocks } from "./helpers/route-test";
 import { mockStripeClient } from "../../external/stripe-client";
 import { testBillingReconciliationStateRoutes } from "../test-billing-reconciliation-state";
@@ -389,6 +390,28 @@ function mockUsagePackPriceCatalog(
 
 async function grantRows(fixture: UsagePackLifecycleFixture) {
   return (await readUsagePackState(fixture)).grants;
+}
+
+async function fulfillFirstUsagePackInvoice(
+  fixture: UsagePackLifecycleFixture,
+) {
+  const paidPeriod = period(0);
+  const quantities = new Map([[TEST_PRICE_PACK_20, 1]]);
+  context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+    stripeSubscription(fixture, paidPeriod, quantities),
+  );
+  await postStripeEvent(
+    stripeEvent(
+      "invoice.paid",
+      paidInvoice(fixture, {
+        invoiceId: `in_${randomUUID()}`,
+        paidPeriod,
+        quantities,
+      }),
+    ),
+    200,
+  );
+  return await readUsagePackState(fixture);
 }
 
 describe("usage pack subscription Stripe lifecycle", () => {
@@ -1311,6 +1334,179 @@ describe("usage pack subscription Stripe lifecycle", () => {
         stripeSubscriptionId: null,
       }),
     );
+  });
+
+  it("clears debt for a new organization that only received free onboarding credits", async () => {
+    const fixture = await seedUsagePackLifecycle([
+      { userId: `user_${randomUUID()}`, usagePackUsd: 20 },
+    ]);
+    const authOrgApi = createAuthOrgAgentsBddApi(context);
+    const actor = authOrgApi.user({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+    });
+    authOrgApi.acceptAgentStorageWrites();
+    authOrgApi.mockClerkOrg(actor);
+    await authOrgApi.bootstrapLimitedFreeOnboarding(actor, {
+      displayName: "First purchase agent",
+      sound: "calm",
+    });
+    expect((await readUsagePackState(fixture)).legacyCredits).toContainEqual(
+      expect.objectContaining({
+        stripeInvoiceId: "limited-free-onboarding",
+        amount: 1000,
+      }),
+    );
+    await seedOrgMetadata({
+      orgId: fixture.orgId,
+      tier: "limited-free-1",
+      credits: -5000,
+    });
+
+    const state = await fulfillFirstUsagePackInvoice(fixture);
+
+    expect(state.org).toMatchObject({ tier: "pro", credits: 0 });
+    expect(state.grants).toHaveLength(2);
+  });
+
+  it.each(["credit_purchase", "auto_recharge"])(
+    "preserves debt after a previous %s even when the organization is free again",
+    async (source) => {
+      const fixture = await seedUsagePackLifecycle([
+        { userId: `user_${randomUUID()}`, usagePackUsd: 20 },
+      ]);
+      await postStripeEvent(
+        stripeEvent("invoice.paid", {
+          id: `in_${randomUUID()}`,
+          customer: fixture.customerId,
+          status: "paid",
+          paid: true,
+          subtotal: 1000,
+          metadata: {
+            type: source,
+            orgId: fixture.orgId,
+            creditsAmount: "10000",
+          },
+          parent: null,
+          lines: { has_more: false, data: [] },
+        }),
+        200,
+      );
+      expect((await readUsagePackState(fixture)).org?.credits).toBe(10_000);
+      await seedOrgMetadata({
+        orgId: fixture.orgId,
+        tier: "limited-free-1",
+        credits: -5000,
+      });
+
+      const state = await fulfillFirstUsagePackInvoice(fixture);
+
+      expect(state.org).toMatchObject({ tier: "pro", credits: -5000 });
+      expect(state.grants).toHaveLength(2);
+    },
+  );
+
+  it.each(["pro", "custom"])(
+    "preserves debt for a returning legacy %s subscriber after its old billing period",
+    async (tier) => {
+      const fixture = await seedUsagePackLifecycle([
+        { userId: `user_${randomUUID()}`, usagePackUsd: 20 },
+      ]);
+      const legacyPriceId =
+        tier === "pro" ? TEST_PRICE_PRO : `price_custom_${randomUUID()}`;
+      mockEnv("OKOU_PRICE_CUSTOM", legacyPriceId);
+      const legacySubscriptionId = `sub_legacy_${randomUUID()}`;
+      const legacyPeriod = period(-60);
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue({
+        id: legacySubscriptionId,
+        customer: fixture.customerId,
+        status: "active",
+        cancel_at: null,
+        cancel_at_period_end: false,
+        schedule: null,
+        trial_end: null,
+        metadata: { orgId: fixture.orgId, tier },
+        items: {
+          data: [{ price: { id: legacyPriceId }, quantity: 1 }],
+        },
+      });
+      await postStripeEvent(
+        stripeEvent("invoice.paid", {
+          id: `in_legacy_${randomUUID()}`,
+          customer: fixture.customerId,
+          status: "paid",
+          paid: true,
+          metadata: { orgId: fixture.orgId },
+          parent: {
+            subscription_details: { subscription: legacySubscriptionId },
+          },
+          lines: {
+            has_more: false,
+            data: [
+              {
+                price: { id: legacyPriceId },
+                quantity: 1,
+                period: legacyPeriod,
+                parent: { type: "subscription_item_details" },
+              },
+            ],
+          },
+        }),
+        200,
+      );
+      const legacyState = await readUsagePackState(fixture);
+      expect(legacyState.org?.tier).toBe(tier);
+      expect(legacyState.legacyCredits).toHaveLength(tier === "pro" ? 1 : 0);
+      expect(legacyState.fulfillmentInvoiceIds).toStrictEqual([]);
+      await seedOrgMetadata({
+        orgId: fixture.orgId,
+        tier: "limited-free-1",
+        credits: -5000,
+      });
+
+      const state = await fulfillFirstUsagePackInvoice(fixture);
+
+      expect(state.org).toMatchObject({ tier: "pro", credits: -5000 });
+      expect(state.grants).toHaveLength(2);
+    },
+  );
+
+  it("preserves debt after a one-time credit purchase has expired", async () => {
+    const fixture = await seedUsagePackLifecycle([
+      { userId: `user_${randomUUID()}`, usagePackUsd: 20 },
+    ]);
+    const purchasedAt = now();
+    mockEnv(
+      "OKOU_ONE_TIME_CAMPAIGN",
+      JSON.stringify({
+        ZERO100: { priceId: "price_one_time", couponId: "coupon_one_time" },
+      }),
+    );
+    await postStripeEvent(
+      stripeEvent("checkout.session.completed", {
+        id: `cs_one_time_${randomUUID()}`,
+        customer: fixture.customerId,
+        payment_status: "paid",
+        metadata: {
+          purpose: "one_time_purchase",
+          campaignKey: "ZERO100",
+          orgId: fixture.orgId,
+        },
+      }),
+      200,
+    );
+    expect((await readUsagePackState(fixture)).org?.credits).toBe(100_000);
+    mockNow(purchasedAt + 31 * 86_400_000);
+    await seedOrgMetadata({
+      orgId: fixture.orgId,
+      tier: "limited-free-1",
+      credits: -5000,
+    });
+
+    const state = await fulfillFirstUsagePackInvoice(fixture);
+
+    expect(state.org).toMatchObject({ tier: "pro", credits: -5000 });
+    expect(state.grants).toHaveLength(2);
   });
 
   it("clears negative credits on the first paid upgrade but not after a payment-failure downgrade", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-pack-subscription-lifecycle.test.ts
@@ -14,6 +14,7 @@ import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { createRouteMocks } from "./helpers/route-test";
 import { mockStripeClient } from "../../external/stripe-client";
+import { createDeferredPromise } from "../../utils";
 import { testBillingReconciliationStateRoutes } from "../test-billing-reconciliation-state";
 import {
   testUsagePackSubscriptionStateContract,
@@ -1367,6 +1368,135 @@ describe("usage pack subscription Stripe lifecycle", () => {
 
     expect(state.org).toMatchObject({ tier: "pro", credits: 0 });
     expect(state.grants).toHaveLength(2);
+  });
+
+  it.each([0, 5000])(
+    "preserves a first-upgrade balance of %i and does not waive later renewal debt",
+    async (credits) => {
+      const fixture = await seedUsagePackLifecycle(
+        [{ userId: `user_${randomUUID()}`, usagePackUsd: 20 }],
+        "pro",
+        credits,
+      );
+      const firstUpgrade = await fulfillFirstUsagePackInvoice(fixture);
+
+      expect(firstUpgrade.org).toMatchObject({ tier: "pro", credits });
+      expect(firstUpgrade.grants).toHaveLength(2);
+      expect(firstUpgrade.fulfillmentInvoiceIds).toHaveLength(1);
+
+      await seedOrgMetadata({
+        orgId: fixture.orgId,
+        tier: "pro",
+        credits: -3000,
+      });
+      const paidPeriod = period(30);
+      const quantities = new Map([[TEST_PRICE_PACK_20, 1]]);
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+        stripeSubscription(fixture, paidPeriod, quantities),
+      );
+      await postStripeEvent(
+        stripeEvent(
+          "invoice.paid",
+          paidInvoice(fixture, {
+            invoiceId: `in_${randomUUID()}`,
+            paidPeriod,
+            quantities,
+          }),
+        ),
+        200,
+      );
+
+      const renewed = await readUsagePackState(fixture);
+      expect(renewed.org).toMatchObject({ tier: "pro", credits: -3000 });
+      expect(renewed.grants).toHaveLength(4);
+      expect(renewed.fulfillmentInvoiceIds).toHaveLength(2);
+    },
+  );
+
+  it("fulfills concurrent first invoices once and preserves new debt when the invoice is replayed", async () => {
+    const fixture = await seedUsagePackLifecycle(
+      [{ userId: `user_${randomUUID()}`, usagePackUsd: 20 }],
+      "pro",
+      -5000,
+    );
+    const paidPeriod = period(0);
+    const quantities = new Map([[TEST_PRICE_PACK_20, 1]]);
+    const invoice = paidInvoice(fixture, {
+      invoiceId: `in_${randomUUID()}`,
+      paidPeriod,
+      quantities,
+    });
+    const bothRequestsStarted = createDeferredPromise<void>(context.signal);
+    let startedRequests = 0;
+    context.mocks.stripe.subscriptions.retrieve.mockImplementation(async () => {
+      startedRequests += 1;
+      if (startedRequests === 2) {
+        bothRequestsStarted.resolve(undefined);
+      }
+      await bothRequestsStarted.promise;
+      return stripeSubscription(fixture, paidPeriod, quantities);
+    });
+
+    await Promise.all([
+      postStripeEvent(stripeEvent("invoice.paid", invoice), 200),
+      postStripeEvent(stripeEvent("invoice.paid", invoice), 200),
+    ]);
+
+    const fulfilled = await readUsagePackState(fixture);
+    expect(fulfilled.org).toMatchObject({ tier: "pro", credits: 0 });
+    expect(fulfilled.grants).toHaveLength(2);
+    expect(fulfilled.fulfillmentInvoiceIds).toStrictEqual([invoice.id]);
+
+    await seedOrgMetadata({
+      orgId: fixture.orgId,
+      tier: "pro",
+      credits: -3000,
+    });
+    await postStripeEvent(stripeEvent("invoice.paid", invoice), 200);
+
+    const replayed = await readUsagePackState(fixture);
+    expect(replayed.org).toMatchObject({ tier: "pro", credits: -3000 });
+    expect(replayed.grants).toStrictEqual(fulfilled.grants);
+    expect(replayed.fulfillmentInvoiceIds).toStrictEqual([invoice.id]);
+  });
+
+  it("rolls back debt forgiveness and grants when the subscription cannot be persisted", async () => {
+    const fixture = await seedUsagePackLifecycle(
+      [{ userId: `user_${randomUUID()}`, usagePackUsd: 20 }],
+      "pro",
+      -5000,
+    );
+    const paidPeriod = period(0);
+    const quantities = new Map([[TEST_PRICE_PACK_20, 1]]);
+    const invoice = paidInvoice(fixture, {
+      invoiceId: `in_${randomUUID()}`,
+      paidPeriod,
+      quantities,
+    });
+    // An oversized provider status fails during plan persistence, after the
+    // debt waiver and member grant writes have executed in the transaction.
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      stripeSubscription(fixture, paidPeriod, quantities, {
+        status: "invalid_subscription_status_from_stripe",
+      }),
+    );
+    const beforePayment = await readUsagePackState(fixture);
+
+    await postStripeEvent(stripeEvent("invoice.paid", invoice), 500);
+
+    await expect(readUsagePackState(fixture)).resolves.toStrictEqual(
+      beforePayment,
+    );
+
+    context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+      stripeSubscription(fixture, paidPeriod, quantities),
+    );
+    await postStripeEvent(stripeEvent("invoice.paid", invoice), 200);
+
+    const retried = await readUsagePackState(fixture);
+    expect(retried.org).toMatchObject({ tier: "pro", credits: 0 });
+    expect(retried.grants).toHaveLength(2);
+    expect(retried.fulfillmentInvoiceIds).toStrictEqual([invoice.id]);
   });
 
   it.each(["credit_purchase", "auto_recharge"])(

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -21,7 +21,9 @@ import {
   inArray,
   isNotNull,
   isNull,
+  lt,
   lte,
+  notExists,
   notInArray,
   or,
   sql,
@@ -47,6 +49,7 @@ import { upsertOrgPlanEntitlement } from "./org-plan-entitlements.service";
 import { stripePreviewMetadata } from "./stripe-preview-metadata.service";
 import {
   handleUsagePackAllocationChangeInvoicePaid,
+  lockUsagePackBillingOrg,
   reconcileUsagePackAllocationChanges,
   reconcileUsagePackAllocationChangeSubscription,
   reconcileUsagePackAllocationChangeSubscriptionDeleted,
@@ -2991,6 +2994,45 @@ async function createUsagePackMemberGrants(
   }
 }
 
+async function clearNegativeOrgCreditsForFirstUsagePackUpgrade(
+  tx: WriteTx,
+  subscription: UsagePackSubscriptionRow,
+  invoiceId: string,
+): Promise<void> {
+  const priorFulfillment = tx
+    .select({
+      stripeInvoiceId: usagePackInvoiceFulfillments.stripeInvoiceId,
+    })
+    .from(usagePackInvoiceFulfillments)
+    .innerJoin(
+      usagePackSubscriptions,
+      eq(
+        usagePackSubscriptions.id,
+        usagePackInvoiceFulfillments.usagePackSubscriptionId,
+      ),
+    )
+    .where(eq(usagePackSubscriptions.orgId, subscription.orgId));
+  const cleared = await tx
+    .update(orgMetadata)
+    .set({ credits: 0, updatedAt: nowDate() })
+    .where(
+      and(
+        eq(orgMetadata.orgId, subscription.orgId),
+        lt(orgMetadata.credits, 0),
+        notExists(priorFulfillment),
+      ),
+    )
+    .returning({ orgId: orgMetadata.orgId });
+  if (cleared.length === 0) {
+    return;
+  }
+  L.debug("negative organization credits cleared on first usage pack upgrade", {
+    invoiceId,
+    orgId: subscription.orgId,
+    usagePackSubscriptionId: subscription.id,
+  });
+}
+
 async function persistUsagePackPlanState(
   tx: WriteTx,
   subscription: UsagePackSubscriptionRow,
@@ -3158,6 +3200,7 @@ async function commitUsagePackFulfillmentTransaction(
   tx: WriteTx,
   args: CommitUsagePackFulfillmentArgs,
 ): Promise<void> {
+  await lockUsagePackBillingOrg(tx, args.context.subscription.orgId);
   const [lockedSubscription] = await tx
     .select()
     .from(usagePackSubscriptions)
@@ -3188,6 +3231,11 @@ async function commitUsagePackFulfillmentTransaction(
   }
 
   await requireCurrentFulfillmentAllocations(tx, lockedSubscription, args);
+  await clearNegativeOrgCreditsForFirstUsagePackUpgrade(
+    tx,
+    lockedSubscription,
+    args.invoice.id,
+  );
   await createUsagePackMemberGrants(tx, lockedSubscription, args);
   await advanceUsagePackProjection(tx, lockedSubscription, args);
   await tx.insert(usagePackInvoiceFulfillments).values({

--- a/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-subscription.service.ts
@@ -5,6 +5,7 @@ import {
   type UsagePackPurchasePreviewResponse,
   type UsagePackUsd,
 } from "@okouai/api-contracts/contracts/billing";
+import { creditExpiresRecord } from "@okouai/db/schema/credit-expires-record";
 import { orgMetadata } from "@okouai/db/schema/org-metadata";
 import {
   USAGE_PACK_ALLOCATION_STATUSES,
@@ -2994,11 +2995,27 @@ async function createUsagePackMemberGrants(
   }
 }
 
-async function clearNegativeOrgCreditsForFirstUsagePackUpgrade(
+async function clearNegativeOrgCreditsForFirstPaidUpgrade(
   tx: WriteTx,
   subscription: UsagePackSubscriptionRow,
   invoiceId: string,
 ): Promise<void> {
+  // Free onboarding grants also store an idempotency key in stripeInvoiceId.
+  const priorPaidCreditGrant = tx
+    .select({ id: creditExpiresRecord.id })
+    .from(creditExpiresRecord)
+    .where(
+      and(
+        eq(creditExpiresRecord.orgId, subscription.orgId),
+        isNotNull(creditExpiresRecord.stripeInvoiceId),
+        inArray(creditExpiresRecord.source, [
+          "subscription_renewal",
+          "credit_purchase",
+          "auto_recharge",
+          "one_time_purchase",
+        ]),
+      ),
+    );
   const priorFulfillment = tx
     .select({
       stripeInvoiceId: usagePackInvoiceFulfillments.stripeInvoiceId,
@@ -3019,6 +3036,8 @@ async function clearNegativeOrgCreditsForFirstUsagePackUpgrade(
       and(
         eq(orgMetadata.orgId, subscription.orgId),
         lt(orgMetadata.credits, 0),
+        isNull(orgMetadata.lastProcessedInvoiceId),
+        notExists(priorPaidCreditGrant),
         notExists(priorFulfillment),
       ),
     )
@@ -3026,7 +3045,7 @@ async function clearNegativeOrgCreditsForFirstUsagePackUpgrade(
   if (cleared.length === 0) {
     return;
   }
-  L.debug("negative organization credits cleared on first usage pack upgrade", {
+  L.debug("negative organization credits cleared on first paid upgrade", {
     invoiceId,
     orgId: subscription.orgId,
     usagePackSubscriptionId: subscription.id,
@@ -3231,7 +3250,7 @@ async function commitUsagePackFulfillmentTransaction(
   }
 
   await requireCurrentFulfillmentAllocations(tx, lockedSubscription, args);
-  await clearNegativeOrgCreditsForFirstUsagePackUpgrade(
+  await clearNegativeOrgCreditsForFirstPaidUpgrade(
     tx,
     lockedSubscription,
     args.invoice.id,


### PR DESCRIPTION
## Summary

Clear negative organization credits on the first Usage Pack invoice only for an organization with no previous billing history. Legacy subscribers migrating to Usage Pack, returning subscribers, and organizations that previously bought credits retain their debt.

- Check the existing legacy invoice marker, paid credit-grant history (subscription, credit purchase, auto-recharge, and one-time purchase), and Usage Pack fulfillment history under the organization billing lock.
- Keep free onboarding grants eligible, including grants that use the invoice-ID column for their idempotency key. Expired paid grants still disqualify an organization.
- Keep the waiver, member credit grants, and fulfillment marker in the same transaction, so retries and payment-failure recovery cannot repeat the waiver. No schema changes.

## Verification

- API integration tests for Usage Pack lifecycle and billing checkout, including legacy migration, returning Pro/Custom subscribers, credit purchases, auto-recharge, expired one-time purchases, and free onboarding.
- Additional lifecycle coverage for zero/positive starting balances, later renewal debt, concurrent invoice delivery, replay after new debt accrues, and transaction rollback followed by a successful retry.
- API lint and type checks.
- API-scoped Knip and formatting for changed files.
