### PR TITLE
fix(cli): package image resize worker

### DIFF
--- a/.github/scripts/smoke-okou-cli-artifact.sh
+++ b/.github/scripts/smoke-okou-cli-artifact.sh
@@ -12,6 +12,7 @@ if [[ ! -f "$package_path" ]]; then
   exit 1
 fi
 package_path="$(cd "$(dirname "$package_path")" && pwd -P)/$(basename "$package_path")"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
@@ -24,6 +25,11 @@ clean_bin="${tmp_dir}/bin"
 mkdir -p "$clean_bin"
 ln -s "$node_path" "$clean_bin/node"
 clean_path="${clean_bin}:/usr/bin:/bin"
+
+tar -xzf "$package_path" -C "$tmp_dir"
+"$node_path" \
+  "$script_dir/smoke-okou-cli-image-resize.mjs" \
+  "$tmp_dir/package"
 
 if PATH="$clean_path" command -v zero >/dev/null 2>&1; then
   echo "Clean CLI smoke environment unexpectedly contains zero" >&2

--- a/.github/scripts/smoke-okou-cli-artifact.sh
+++ b/.github/scripts/smoke-okou-cli-artifact.sh
@@ -26,11 +26,6 @@ mkdir -p "$clean_bin"
 ln -s "$node_path" "$clean_bin/node"
 clean_path="${clean_bin}:/usr/bin:/bin"
 
-tar -xzf "$package_path" -C "$tmp_dir"
-"$node_path" \
-  "$script_dir/smoke-okou-cli-image-resize.mjs" \
-  "$tmp_dir/package"
-
 if PATH="$clean_path" command -v zero >/dev/null 2>&1; then
   echo "Clean CLI smoke environment unexpectedly contains zero" >&2
   exit 1
@@ -41,7 +36,10 @@ run_cli() {
   local stdout_file="$2"
   local stderr_file="$3"
   shift 3
-  PATH="$clean_path" npm_config_audit=false "$node_path" "$npx_path" \
+  PATH="$clean_path" \
+    npm_config_audit=false \
+    npm_config_cache="$tmp_dir/npm-cache" \
+    "$node_path" "$npx_path" \
     --yes --package="$package_path" "$entrypoint" "$@" \
     >"$stdout_file" 2>"$stderr_file"
 }
@@ -71,6 +69,15 @@ assert_clean_success() {
     exit 1
   fi
 }
+
+assert_clean_success \
+  node \
+  image-resize \
+  "$script_dir/smoke-okou-cli-image-resize.mjs"
+grep -Fxq \
+  "Smoke-tested packaged Pi image resize worker and fallback" \
+  "$tmp_dir/image-resize.stdout"
+cat "$tmp_dir/image-resize.stdout"
 
 assert_unsupported_entrypoint() {
   local entrypoint="$1"

--- a/.github/scripts/smoke-okou-cli-image-resize.mjs
+++ b/.github/scripts/smoke-okou-cli-image-resize.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { appendFile, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
+
+const packageDirectory = process.argv[2];
+assert(packageDirectory, "CLI package directory is required");
+
+const timeout = setTimeout(() => {
+  throw new Error("Packaged image resize smoke test timed out");
+}, 10_000);
+
+function pngDimensions(bytes) {
+  assert.equal(bytes.subarray(1, 4).toString("ascii"), "PNG");
+  return {
+    width: bytes.readUInt32BE(16),
+    height: bytes.readUInt32BE(20),
+  };
+}
+
+const packageEntries = await readdir(packageDirectory);
+const agentLoopChunks = packageEntries.filter(
+  (entry) => entry.startsWith("__agent-loop-") && entry.endsWith(".js"),
+);
+assert.equal(
+  agentLoopChunks.length,
+  1,
+  "expected one packaged agent loop chunk",
+);
+
+const agentLoopPath = join(packageDirectory, agentLoopChunks[0]);
+const agentLoopSource = await readFile(agentLoopPath, "utf8");
+const readToolMarker =
+  "node_modules/@earendil-works/pi-coding-agent/dist/core/tools/read.js";
+const readToolStart = agentLoopSource.lastIndexOf(readToolMarker);
+assert.notEqual(
+  readToolStart,
+  -1,
+  "packaged agent loop is missing Pi read tool",
+);
+const nextModuleStart = agentLoopSource.indexOf("\n// ", readToolStart + 1);
+assert.notEqual(nextModuleStart, -1, "packaged Pi read tool has no boundary");
+const readToolSource = agentLoopSource.slice(readToolStart, nextModuleStart);
+const createReadToolMatch = readToolSource.match(
+  /function (createReadTool\d*)\(cwd, options\)/,
+);
+assert(createReadToolMatch, "packaged agent loop is missing createReadTool");
+await appendFile(
+  agentLoopPath,
+  `\nexport { ${createReadToolMatch[1]} as __smokeCreateReadTool };\n`,
+);
+
+const { __smokeCreateReadTool: createReadTool } = await import(
+  pathToFileURL(agentLoopPath).href
+);
+assert.equal(typeof createReadTool, "function");
+
+const tinyImagePath = join(packageDirectory, "tiny.png");
+const oversizedImagePath = join(packageDirectory, "oversized.png");
+await writeFile(
+  tinyImagePath,
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA8UlEQVR42r2UzQqCQBzEPfUheikI0lNEp67RQ4iXfM7qEmQFQa9gl4KO1i2MiA5GVCNssAy6llALv9OMs+7fWTXtT6sMXOABs0iADiywBk/BHnQ+DWiAhfQwcwMRGAlv5horQpiZKuhE5iuYggk4k/YAlbSQ5PyxZEzmY0t6DawozOIQUwzzbbiDdspmdXCRfAEoyQaPdgoUx/fJ68iiS+JGEbQk74CLF9AgeykhLZpjCAw22bTTAfQlvQu2kh5nFVQXb8J92YmjshapejT/opDDvCuS1P8orkNWiJ93RbigIVWiCapF/gKG+LwOF+9n6wW7L3pUFsFiAgAAAABJRU5ErkJggg==",
+    "base64",
+  ),
+);
+await writeFile(
+  oversizedImagePath,
+  Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAB9EAAAACCAYAAADvqyztAAAALklEQVR4nO3OsQ0AMAjAsPz/NJV4gg4evLtqAAAAAAAAAIB1HgAAAAAAAACALzxAcpNAdlqyuwAAAABJRU5ErkJggg==",
+    "base64",
+  ),
+);
+
+const workerInput = new Uint8Array(await readFile(tinyImagePath));
+const worker = new Worker(
+  pathToFileURL(join(packageDirectory, "image-resize-worker.js")),
+);
+const workerResponse = await new Promise((resolve, reject) => {
+  worker.once("message", resolve);
+  worker.once("error", reject);
+  worker.once("exit", (code) => {
+    if (code !== 0) {
+      reject(new Error(`Image resize worker exited with code ${code}`));
+    }
+  });
+  worker.postMessage(
+    {
+      inputBytes: workerInput,
+      mimeType: "image/png",
+      options: { maxWidth: 9, maxHeight: 9 },
+    },
+    [workerInput.buffer],
+  );
+});
+await worker.terminate();
+assert.equal(workerResponse.error, undefined);
+assert.deepEqual(
+  {
+    originalWidth: workerResponse.result?.originalWidth,
+    originalHeight: workerResponse.result?.originalHeight,
+    width: workerResponse.result?.width,
+    height: workerResponse.result?.height,
+    wasResized: workerResponse.result?.wasResized,
+  },
+  {
+    originalWidth: 18,
+    originalHeight: 18,
+    width: 9,
+    height: 9,
+    wasResized: true,
+  },
+);
+
+const readTool = createReadTool(packageDirectory);
+async function readImage(path) {
+  const result = await readTool.execute("image-resize-smoke", { path });
+  const image = result.content.find((item) => item.type === "image");
+  assert(image, `Pi read omitted ${basename(path)}`);
+  return Buffer.from(image.data, "base64");
+}
+
+assert.deepEqual(pngDimensions(await readImage(tinyImagePath)), {
+  width: 18,
+  height: 18,
+});
+assert.deepEqual(pngDimensions(await readImage(oversizedImagePath)), {
+  width: 2000,
+  height: 2,
+});
+
+await rm(join(packageDirectory, "image-resize-worker.js"));
+assert.deepEqual(pngDimensions(await readImage(tinyImagePath)), {
+  width: 18,
+  height: 18,
+});
+
+clearTimeout(timeout);
+console.log("Smoke-tested packaged Pi image resize worker and fallback");

--- a/.github/scripts/smoke-okou-cli-image-resize.mjs
+++ b/.github/scripts/smoke-okou-cli-image-resize.mjs
@@ -1,11 +1,24 @@
 import assert from "node:assert/strict";
+import { existsSync, realpathSync } from "node:fs";
 import { appendFile, readFile, readdir, rm, writeFile } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { basename, delimiter, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 
-const packageDirectory = process.argv[2];
-assert(packageDirectory, "CLI package directory is required");
+function resolvePackageDirectory() {
+  const explicitDirectory = process.argv[2];
+  if (explicitDirectory) {
+    return explicitDirectory;
+  }
+
+  const okouExecutable = process.env.PATH?.split(delimiter)
+    .map((directory) => join(directory, "okou"))
+    .find((path) => existsSync(path));
+  assert(okouExecutable, "npx environment is missing the okou executable");
+  return dirname(realpathSync(okouExecutable));
+}
+
+const packageDirectory = resolvePackageDirectory();
 
 const timeout = setTimeout(() => {
   throw new Error("Packaged image resize smoke test timed out");

--- a/.github/scripts/tests/deploy-cli-local-test.sh
+++ b/.github/scripts/tests/deploy-cli-local-test.sh
@@ -41,10 +41,13 @@ cat >"${test_root}/turbo/apps/cli/dist/package.json" <<'EOF'
   "version": "1.0.0",
   "private": true,
   "bin": { "okou": "okou.js" },
-  "files": ["*.js", "migrations/*.sql"]
+  "files": ["*.js", "*.wasm", "migrations/*.sql"]
 }
 EOF
 printf '#!/usr/bin/env node\n' >"${test_root}/turbo/apps/cli/dist/okou.js"
+printf 'worker\n' \
+  >"${test_root}/turbo/apps/cli/dist/image-resize-worker.js"
+printf 'wasm\n' >"${test_root}/turbo/apps/cli/dist/photon_rs_bg.wasm"
 printf 'CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY);\n' \
   >"${test_root}/turbo/apps/cli/dist/migrations/001_initial.sql"
 
@@ -122,6 +125,7 @@ jq -e '
   and .private == true
   and ((.bin | keys) == ["okou"])
   and .bin.okou == "okou.js"
+  and (.files | index("*.wasm") != null)
 ' <<<"$package_json" >/dev/null
 
 echo "deploy-cli-local tests passed"

--- a/.github/scripts/tests/smoke-okou-cli-artifact-test.sh
+++ b/.github/scripts/tests/smoke-okou-cli-artifact-test.sh
@@ -8,12 +8,20 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 fixture_bin="${tmp_dir}/bin"
 package_path="${tmp_dir}/package.tgz"
-mkdir -p "$fixture_bin"
-printf 'fixture\n' >"$package_path"
+fixture_package="${tmp_dir}/fixture/package"
+mkdir -p "$fixture_bin" "$fixture_package"
+printf 'fixture\n' >"${fixture_package}/okou.js"
+tar -czf "$package_path" -C "${tmp_dir}/fixture" package
 
 cat >"${fixture_bin}/node" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+
+if [[ "${1:-}" == */smoke-okou-cli-image-resize.mjs ]]; then
+  echo "Smoke-tested packaged Pi image resize worker and fallback"
+  exit 0
+fi
+
 exec "$@"
 EOF
 

--- a/.github/scripts/tests/smoke-okou-cli-artifact-test.sh
+++ b/.github/scripts/tests/smoke-okou-cli-artifact-test.sh
@@ -16,12 +16,6 @@ tar -czf "$package_path" -C "${tmp_dir}/fixture" package
 cat >"${fixture_bin}/node" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-
-if [[ "${1:-}" == */smoke-okou-cli-image-resize.mjs ]]; then
-  echo "Smoke-tested packaged Pi image resize worker and fallback"
-  exit 0
-fi
-
 exec "$@"
 EOF
 
@@ -48,6 +42,9 @@ if [[ "${EMIT_UNEXPECTED_STDERR:-false}" == "true" &&
 fi
 
 case "$entrypoint:$*" in
+  node:*smoke-okou-cli-image-resize.mjs)
+    echo "Smoke-tested packaged Pi image resize worker and fallback"
+    ;;
   "okou:--help")
     printf 'Usage: okou\nOkou CLI\n'
     ;;

--- a/.github/scripts/tests/verify-okou-cli-artifact-test.sh
+++ b/.github/scripts/tests/verify-okou-cli-artifact-test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+verify_script="${repo_root}/.github/scripts/verify-okou-cli-artifact.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+commit_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+create_artifact() {
+  local artifact_dir="$1"
+  local include_worker="$2"
+  local include_wasm="$3"
+  local package_root="${artifact_dir}/contents/package"
+
+  mkdir -p "$package_root"
+  printf '%s\n' \
+    '{"name":"@okouai/cli","private":true,"bin":{"okou":"okou.js"}}' \
+    >"${package_root}/package.json"
+  printf 'okou\n' >"${package_root}/okou.js"
+  if [[ "$include_worker" == "true" ]]; then
+    printf 'worker\n' >"${package_root}/image-resize-worker.js"
+  fi
+  if [[ "$include_wasm" == "true" ]]; then
+    printf 'wasm\n' >"${package_root}/photon_rs_bg.wasm"
+  fi
+
+  tar -czf "${artifact_dir}/package.tgz" \
+    -C "${artifact_dir}/contents" package
+  local package_sha256
+  package_sha256="$(sha256sum "${artifact_dir}/package.tgz" | cut -d ' ' -f 1)"
+  local package_size
+  package_size="$(wc -c <"${artifact_dir}/package.tgz" | tr -d '[:space:]')"
+  jq -n \
+    --arg commit_sha "$commit_sha" \
+    --arg package_sha256 "$package_sha256" \
+    --argjson package_size "$package_size" \
+    '{
+      version: 1,
+      commitSha: $commit_sha,
+      package: {
+        path: "package.tgz",
+        sha256: $package_sha256,
+        size: $package_size
+      }
+    }' >"${artifact_dir}/manifest.json"
+  local manifest_sha256
+  manifest_sha256="$(sha256sum "${artifact_dir}/manifest.json" | cut -d ' ' -f 1)"
+  jq -n \
+    --arg commit_sha "$commit_sha" \
+    --arg manifest_sha256 "$manifest_sha256" \
+    '{version: 1, commitSha: $commit_sha, manifestSha256: $manifest_sha256}' \
+    >"${artifact_dir}/ready.json"
+}
+
+complete_artifact="${tmp_dir}/complete"
+mkdir -p "$complete_artifact"
+create_artifact "$complete_artifact" true true
+bash "$verify_script" "$complete_artifact" "$commit_sha" >/dev/null
+
+missing_worker_artifact="${tmp_dir}/missing-worker"
+mkdir -p "$missing_worker_artifact"
+create_artifact "$missing_worker_artifact" false true
+missing_worker_output="${tmp_dir}/missing-worker.txt"
+if bash "$verify_script" "$missing_worker_artifact" "$commit_sha" \
+  >"$missing_worker_output" 2>&1; then
+  echo "Verifier accepted an artifact without the image resize worker" >&2
+  exit 1
+fi
+grep -Fq "CLI package is missing image-resize-worker.js" \
+  "$missing_worker_output"
+
+missing_wasm_artifact="${tmp_dir}/missing-wasm"
+mkdir -p "$missing_wasm_artifact"
+create_artifact "$missing_wasm_artifact" true false
+missing_wasm_output="${tmp_dir}/missing-wasm.txt"
+if bash "$verify_script" "$missing_wasm_artifact" "$commit_sha" \
+  >"$missing_wasm_output" 2>&1; then
+  echo "Verifier accepted an artifact without the Photon WASM" >&2
+  exit 1
+fi
+grep -Fq "CLI package is missing photon_rs_bg.wasm" "$missing_wasm_output"
+
+echo "verify-okou-cli-artifact tests passed"

--- a/.github/scripts/verify-okou-cli-artifact.sh
+++ b/.github/scripts/verify-okou-cli-artifact.sh
@@ -70,6 +70,14 @@ if ! grep -Fxq 'package/okou.js' <<<"$package_contents"; then
   echo "CLI package is missing the canonical okou.js implementation" >&2
   exit 1
 fi
+if ! grep -Fxq 'package/image-resize-worker.js' <<<"$package_contents"; then
+  echo "CLI package is missing image-resize-worker.js" >&2
+  exit 1
+fi
+if ! grep -Fxq 'package/photon_rs_bg.wasm' <<<"$package_contents"; then
+  echo "CLI package is missing photon_rs_bg.wasm" >&2
+  exit 1
+fi
 if grep -Fxq 'package/zero.js' <<<"$package_contents"; then
   echo "CLI package contains an unexpected duplicate zero.js implementation" >&2
   exit 1

--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@okouai/cli\"; delete this.scripts; delete this.devDependencies; this.bin={okou:\"okou.js\"}; this.files=[\"*.js\",\"*.js.map\",\"migrations/*.sql\"]'",
+    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@okouai/cli\"; delete this.scripts; delete this.devDependencies; this.bin={okou:\"okou.js\"}; this.files=[\"*.js\",\"*.js.map\",\"*.wasm\",\"migrations/*.sql\"]'",
     "dev": "tsup --watch",
     "bench:startup": "pnpm build && OKOU_STARTUP_BENCH=1 vitest run src/__tests__/okou-startup.bench.test.ts",
     "test": "vitest run",
@@ -29,6 +29,7 @@
     "check-types": "pnpm --filter @okouai/pi-agent-runtime run build && tsc --noEmit"
   },
   "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.84.1",
     "@modelcontextprotocol/client": "^2.0.0",
     "@sentry/node": "^10.50.0",
     "@types/node": "^24.3.0",

--- a/turbo/apps/cli/tsup.config.ts
+++ b/turbo/apps/cli/tsup.config.ts
@@ -1,13 +1,60 @@
-import { defineConfig } from "tsup";
-import { readFileSync } from "fs";
-import { execSync } from "child_process";
-import { resolve } from "path";
+import { execSync } from "node:child_process";
+import { copyFileSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { build, defineConfig } from "tsup";
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8")) as {
   version: string;
 };
 
 const isWatchMode = process.argv.includes("--watch");
+const banner = [
+  "#!/usr/bin/env node",
+  // Provide CJS require() for bundled CommonJS packages that call
+  // require("events"), require("fs"), etc. at runtime.
+  'import { createRequire as __createRequire } from "node:module";',
+  "const require = __createRequire(import.meta.url);",
+].join("\n");
+
+async function buildImageResizeWorker(): Promise<void> {
+  const piEntry = fileURLToPath(
+    import.meta.resolve("@earendil-works/pi-coding-agent"),
+  );
+  const photonEntry = createRequire(piEntry).resolve(
+    "@silvia-odwyer/photon-node",
+  );
+
+  await build({
+    config: false,
+    entry: {
+      "image-resize-worker": resolve(
+        dirname(piEntry),
+        "utils/image-resize-worker.js",
+      ),
+    },
+    outDir: "dist",
+    format: ["esm"],
+    platform: "node",
+    splitting: false,
+    dts: false,
+    sourcemap: true,
+    clean: false,
+    shims: true,
+    removeNodeProtocol: false,
+    banner: { js: banner },
+    esbuildOptions(options) {
+      options.nodePaths = [resolve("node_modules")];
+    },
+  });
+
+  copyFileSync(
+    resolve(dirname(photonEntry), "photon_rs_bg.wasm"),
+    resolve("dist/photon_rs_bg.wasm"),
+  );
+}
 
 export default defineConfig({
   entry: ["src/okou.ts"],
@@ -19,15 +66,7 @@ export default defineConfig({
   clean: true,
   shims: true,
   removeNodeProtocol: false,
-  banner: {
-    js: [
-      "#!/usr/bin/env node",
-      // Provide CJS require() for bundled CommonJS packages that call
-      // require("events"), require("fs"), etc. at runtime.
-      'import { createRequire as __createRequire } from "node:module";',
-      "const require = __createRequire(import.meta.url);",
-    ].join("\n"),
-  },
+  banner: { js: banner },
   // Resolve packages from the CLI's node_modules when bundling workspace deps
   // (e.g. @okouai/core imports zod, which lives in apps/cli/node_modules)
   esbuildOptions(options) {
@@ -41,6 +80,8 @@ export default defineConfig({
     ),
   },
   onSuccess: async () => {
+    await buildImageResizeWorker();
+
     if (!isWatchMode) {
       return;
     }

--- a/turbo/patches/@earendil-works__pi-coding-agent@0.84.1.patch
+++ b/turbo/patches/@earendil-works__pi-coding-agent@0.84.1.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/utils/photon.js b/dist/utils/photon.js
+index 3078895bedba898ce26c439b6123425834ca2586..2ad6a42c60d6277dd0ab49c3e972eaa42a2e3ff3 100644
+--- a/dist/utils/photon.js
++++ b/dist/utils/photon.js
+@@ -105,7 +105,8 @@ export async function loadPhoton() {
+     loadPromise = (async () => {
+         const restoreReadFileSync = patchPhotonWasmRead();
+         try {
+-            photonModule = await import("@silvia-odwyer/photon-node");
++            const imported = await import("@silvia-odwyer/photon-node");
++            photonModule = imported.default ?? imported;
+             return photonModule;
+         }
+         catch {

--- a/turbo/patches/@earendil-works__pi-coding-agent@0.84.1.patch
+++ b/turbo/patches/@earendil-works__pi-coding-agent@0.84.1.patch
@@ -8,7 +8,7 @@ index 3078895bedba898ce26c439b6123425834ca2586..2ad6a42c60d6277dd0ab49c3e972eaa4
          try {
 -            photonModule = await import("@silvia-odwyer/photon-node");
 +            const imported = await import("@silvia-odwyer/photon-node");
-+            photonModule = imported.default ?? imported;
++            photonModule = imported.default;
              return photonModule;
          }
          catch {

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -89,7 +89,7 @@ patchedDependencies:
     hash: e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e
     path: patches/@earendil-works__pi-ai@0.84.1.patch
   '@earendil-works/pi-coding-agent@0.84.1':
-    hash: 37333711dbb9f38820e5058ff678ea276a7999ff398ae08bb7ef1a180bb522fa
+    hash: 370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289
     path: patches/@earendil-works__pi-coding-agent@0.84.1.patch
 
 importers:
@@ -358,7 +358,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=37333711dbb9f38820e5058ff678ea276a7999ff398ae08bb7ef1a180bb522fa)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1105,7 +1105,7 @@ importers:
         version: 0.84.1(patch_hash=e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=37333711dbb9f38820e5058ff678ea276a7999ff398ae08bb7ef1a180bb522fa)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@okouai/api-contracts':
         specifier: workspace:*
         version: link:../api-contracts
@@ -11053,7 +11053,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-protocol': 0.84.2
 
-  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=37333711dbb9f38820e5058ff678ea276a7999ff398ae08bb7ef1a180bb522fa)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-ai': 0.84.1(patch_hash=e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -88,6 +88,9 @@ patchedDependencies:
   '@earendil-works/pi-ai@0.84.1':
     hash: e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e
     path: patches/@earendil-works__pi-ai@0.84.1.patch
+  '@earendil-works/pi-coding-agent@0.84.1':
+    hash: 37333711dbb9f38820e5058ff678ea276a7999ff398ae08bb7ef1a180bb522fa
+    path: patches/@earendil-works__pi-coding-agent@0.84.1.patch
 
 importers:
 
@@ -353,6 +356,9 @@ importers:
 
   apps/cli:
     devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.84.1
+        version: 0.84.1(patch_hash=37333711dbb9f38820e5058ff678ea276a7999ff398ae08bb7ef1a180bb522fa)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1099,7 +1105,7 @@ importers:
         version: 0.84.1(patch_hash=e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=37333711dbb9f38820e5058ff678ea276a7999ff398ae08bb7ef1a180bb522fa)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@okouai/api-contracts':
         specifier: workspace:*
         version: link:../api-contracts
@@ -11047,7 +11053,7 @@ snapshots:
     dependencies:
       '@earendil-works/pi-protocol': 0.84.2
 
-  '@earendil-works/pi-coding-agent@0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=37333711dbb9f38820e5058ff678ea276a7999ff398ae08bb7ef1a180bb522fa)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-ai': 0.84.1(patch_hash=e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)

--- a/turbo/pnpm-workspace.yaml
+++ b/turbo/pnpm-workspace.yaml
@@ -107,6 +107,7 @@ overrides:
 
 patchedDependencies:
   "@earendil-works/pi-ai@0.84.1": patches/@earendil-works__pi-ai@0.84.1.patch
+  "@earendil-works/pi-coding-agent@0.84.1": patches/@earendil-works__pi-coding-agent@0.84.1.patch
 
 ignoredBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Summary

- emit Pi's image resize worker as a standalone ESM bundle and package the adjacent Photon WASM
- normalize Photon CommonJS loading so the in-process fallback remains functional
- enforce the worker/WASM artifact contract and smoke-test real packed tiny, oversized, and fallback image reads

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `bash .github/scripts/tests/verify-okou-cli-artifact-test.sh`
- `bash .github/scripts/tests/smoke-okou-cli-artifact-test.sh`
- `pnpm --filter @okouai/cli build`
- canonical CLI artifact build and packaged smoke test on Node 24.20.0

Fixes #29435