### PR TITLE
refactor(registry): trim presentation download response

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -72,12 +72,6 @@ describe("registry resource download", () => {
 
     expect(response.body).toStrictEqual({
       url: "https://r2.example.com/registry/schoolhouse-runbook-latest.tar.gz",
-      id,
-      type: "tar.gz",
-      expiresInSeconds: 900,
-      versionId: headVersionId,
-      fileCount: 13,
-      size: 5432,
     });
     const signedCommand = context.mocks.s3.getSignedUrl.mock.calls.at(-1)?.[1];
     expect(signedCommand).toMatchObject({

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -334,10 +334,7 @@ const downloadPresentationTemplateInner$ = computed(async (get) => {
 
   const [version] = await db
     .select({
-      versionId: storageVersions.id,
       s3Key: storageVersions.s3Key,
-      fileCount: storageVersions.fileCount,
-      size: storageVersions.size,
     })
     .from(storageVersions)
     .where(
@@ -371,12 +368,6 @@ const downloadPresentationTemplateInner$ = computed(async (get) => {
     status: 200 as const,
     body: {
       url,
-      id: entry.id,
-      type: entry.source.archive.type,
-      expiresInSeconds: DOWNLOAD_URL_TTL_SECONDS,
-      versionId: version.versionId,
-      fileCount: version.fileCount,
-      size: Number(version.size),
     },
   };
 });

--- a/turbo/apps/cli/src/commands/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/resource/__tests__/index.test.ts
@@ -201,12 +201,6 @@ describe("okou resource pull command", () => {
           );
           return HttpResponse.json({
             url: downloadUrl,
-            id,
-            type: "tar.gz",
-            expiresInSeconds: 900,
-            versionId,
-            fileCount: 1,
-            size: 6054,
           });
         },
       ),

--- a/turbo/apps/cli/src/lib/api/domains/registry-resources.ts
+++ b/turbo/apps/cli/src/lib/api/domains/registry-resources.ts
@@ -7,12 +7,6 @@ export async function getPresentationTemplateDownload(query: {
   id: string;
 }): Promise<{
   url: string;
-  id: string;
-  type: "tar.gz";
-  expiresInSeconds: number;
-  versionId: string;
-  fileCount: number;
-  size: number;
 }> {
   const config = await getClientConfig();
   const client = initClient(registryResourceDownloadContract, config);

--- a/turbo/packages/api-contracts/src/contracts/registry-resources.ts
+++ b/turbo/packages/api-contracts/src/contracts/registry-resources.ts
@@ -16,12 +16,6 @@ export const registryResourceDownloadContract = c.router({
     responses: {
       200: z.object({
         url: z.url(),
-        id: z.string(),
-        type: z.literal("tar.gz"),
-        expiresInSeconds: z.number().int().positive(),
-        versionId: z.string(),
-        fileCount: z.number().int().nonnegative(),
-        size: z.number().nonnegative(),
       }),
       400: apiErrorSchema,
       401: apiErrorSchema,

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -3384,8 +3384,9 @@ export interface PresentationRunbookPackage {
   readonly source: ResourceSourceRef;
 }
 
-// Archive digests for uploaded private R2 presentation runbook packages. Keep
-// these in sync with the private R2 version ids served by the API download route.
+// Immutable archive digests used to locate each canonical storage and serve
+// older digest-pinned CLIs. Current CLIs download the storage HEAD, so these
+// intentionally do not track later presentation template publishes.
 const PRESENTATION_RUNBOOK_ARCHIVE_SHA256: Record<string, string> = {
   bloom: "b9003d1545000987eac1868220b4ea1379ec1cdd79e884bc08d13539c1cc5f88",
   "blueprint-academy":


### PR DESCRIPTION
## Summary

- return only the signed URL from the new presentation-template download endpoint
- stop selecting and serializing response metadata that the CLI does not consume
- clarify that bundled presentation digests are immutable storage anchors retained for older digest-pinned CLIs

## Dependency

This PR is stacked on #31614 and targets its head branch so the diff contains only this cleanup. It should merge after #31614, or be retargeted to `main` once #31614 lands.

## Fallbacks

None. This PR leaves the compatibility behavior introduced by #31614 unchanged.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/registry-resources-download.test.ts` (10 passed)
- `pnpm --filter @okouai/cli exec vitest run src/commands/resource/__tests__/index.test.ts` (9 passed)
- `git diff --check`
