### PR TITLE
test(api): type shared sdk mock boundaries

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -42,7 +42,7 @@ const NEWER_WEB_CLIENT_VERSION = MINIMUM_WEB_CLIENT_VERSION.replace(
 const { mockFlushLogs } = vi.hoisted(() => {
   return {
     // eslint-disable-next-line api/no-test-vi-mocks
-    mockFlushLogs: vi.fn(),
+    mockFlushLogs: vi.fn<typeof import("../lib/log").flushLogs>(),
   };
 });
 

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -19,6 +19,24 @@ type AbortSignalTimeoutMock = Mock<
 >;
 type SyncMock = Mock<(...args: unknown[]) => void>;
 type UnknownMock = Mock<(...args: unknown[]) => unknown>;
+type AxiomSdkConstructor = typeof import("@axiomhq/js").Axiom;
+type AxiomSdkClient = InstanceType<AxiomSdkConstructor>;
+type AxiomSdkConstructorArguments = ConstructorParameters<AxiomSdkConstructor>;
+type AxiomSdkQueryBridge = (
+  ...args: Parameters<AxiomSdkClient["query"]>
+) => Promise<unknown>;
+type ResendConstructorArguments = ConstructorParameters<
+  typeof import("resend").Resend
+>;
+type SlackWebClientConstructorArguments = ConstructorParameters<
+  typeof import("@slack/web-api").WebClient
+>;
+type AxiomLoggerConstructorArguments = ConstructorParameters<
+  typeof import("@axiomhq/logging").Logger
+>;
+type AxiomJSTransportConstructorArguments = ConstructorParameters<
+  typeof import("@axiomhq/logging").AxiomJSTransport
+>;
 
 function resolveDefaultStripePrice(priceId: unknown): Promise<unknown> {
   return Promise.resolve({
@@ -32,15 +50,11 @@ function resolveDefaultStripePrice(priceId: unknown): Promise<unknown> {
   });
 }
 
-interface AxiomClientOptions {
-  readonly onError?: (error: Error) => void;
-  readonly token?: string;
-}
 interface AxiomSdkClientMock {
-  readonly options: AxiomClientOptions;
-  readonly flush: AsyncMock;
-  readonly ingest: UnknownMock;
-  readonly query: AsyncMock;
+  readonly options: AxiomSdkConstructorArguments[0];
+  readonly flush: Mock<AxiomSdkClient["flush"]>;
+  readonly ingest: Mock<AxiomSdkClient["ingest"]>;
+  readonly query: Mock<AxiomSdkQueryBridge>;
 }
 interface BrowserUseCdpCommand {
   readonly id: number;
@@ -294,6 +308,15 @@ export interface ApiTestMocks {
     readonly nativeNodeFetchIntegration: Mock<(...args: unknown[]) => unknown>;
   };
 }
+
+interface ResendClientMock {
+  readonly emails: {
+    readonly send: ApiTestMocks["resend"]["send"];
+  };
+}
+type SlackWebClientMock = Omit<ApiTestMocks["slack"], "fetchFile">;
+type AxiomLoggerMock = ApiTestMocks["axiomLogging"];
+type AxiomJSTransportMock = Readonly<Record<string, never>>;
 
 const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
   const axiom = {
@@ -912,13 +935,16 @@ vi.mock("web-push", async (importActual) => {
 
 vi.mock("resend", () => {
   return {
-    Resend: vi.fn(function (): unknown {
-      return {
-        emails: {
-          send: apiTestMocks.resend.send,
-        },
-      };
-    }),
+    Resend: vi.fn<(...args: ResendConstructorArguments) => ResendClientMock>(
+      function () {
+        const client: ResendClientMock = {
+          emails: {
+            send: apiTestMocks.resend.send,
+          },
+        };
+        return client;
+      },
+    ),
   };
 });
 
@@ -1056,8 +1082,10 @@ vi.mock("stripe", async (importOriginal) => {
 
 vi.mock("@slack/web-api", () => {
   return {
-    WebClient: vi.fn(function (): unknown {
-      return {
+    WebClient: vi.fn<
+      (...args: SlackWebClientConstructorArguments) => SlackWebClientMock
+    >(function () {
+      const client: SlackWebClientMock = {
         assistant: {
           threads: {
             setStatus: apiTestMocks.slack.assistant.threads.setStatus,
@@ -1093,6 +1121,7 @@ vi.mock("@slack/web-api", () => {
           info: apiTestMocks.slack.users.info,
         },
       };
+      return client;
     }),
   };
 });
@@ -1155,44 +1184,50 @@ vi.mock("../signals/external/axiom", async () => {
 
 vi.mock("@axiomhq/js", () => {
   return {
-    Axiom: vi.fn<(options: AxiomClientOptions) => unknown>(function (
-      options: AxiomClientOptions,
-    ) {
-      apiTestMocks.axiom.clientError.mockImplementation((error: Error) => {
-        options.onError?.(error);
-      });
-      const client: AxiomSdkClientMock = {
-        options,
-        flush: vi.fn((...args: unknown[]) => {
-          return apiTestMocks.axiom.flush(...args);
-        }),
-        ingest: vi.fn((...args: unknown[]) => {
-          return apiTestMocks.axiom.sdkIngest(...args);
-        }),
-        query: vi.fn((...args: unknown[]) => {
-          return apiTestMocks.axiom.query(...args);
-        }),
-      };
-      apiTestMocks.axiom.clients.push(client);
-      return client;
-    }),
+    Axiom: vi.fn<(...args: AxiomSdkConstructorArguments) => AxiomSdkClientMock>(
+      function (options) {
+        apiTestMocks.axiom.clientError.mockImplementation((error: Error) => {
+          options.onError?.(error);
+        });
+        const client: AxiomSdkClientMock = {
+          options,
+          flush: vi.fn<AxiomSdkClient["flush"]>(async (...args) => {
+            await apiTestMocks.axiom.flush(...args);
+          }),
+          ingest: vi.fn<AxiomSdkClient["ingest"]>((...args) => {
+            apiTestMocks.axiom.sdkIngest(...args);
+          }),
+          query: vi.fn<AxiomSdkQueryBridge>((...args) => {
+            return apiTestMocks.axiom.query(...args);
+          }),
+        };
+        apiTestMocks.axiom.clients.push(client);
+        return client;
+      },
+    ),
   };
 });
 
 vi.mock("@axiomhq/logging", () => {
   return {
     EVENT: Symbol("EVENT"),
-    Logger: vi.fn(function () {
-      return {
+    Logger: vi.fn<
+      (...args: AxiomLoggerConstructorArguments) => AxiomLoggerMock
+    >(function () {
+      const logger: AxiomLoggerMock = {
         debug: apiTestMocks.axiomLogging.debug,
         info: apiTestMocks.axiomLogging.info,
         warn: apiTestMocks.axiomLogging.warn,
         error: apiTestMocks.axiomLogging.error,
         flush: apiTestMocks.axiomLogging.flush,
       };
+      return logger;
     }),
-    AxiomJSTransport: vi.fn(function () {
-      return {};
+    AxiomJSTransport: vi.fn<
+      (...args: AxiomJSTransportConstructorArguments) => AxiomJSTransportMock
+    >(function () {
+      const transport: AxiomJSTransportMock = {};
+      return transport;
     }),
   };
 });


### PR DESCRIPTION
## Summary

- derive the hoisted `flushLogs` mock from the real internal export
- derive Resend, Slack, Axiom, Logger, and Axiom transport constructor arguments from their installed SDK declarations
- expose explicit minimal mock facades while preserving spy history, reset behavior, and per-test configuration
- keep the shared Axiom query seam as an honest `Promise<unknown>` bridge while matching the SDK argument tuple; await or discard the wider flush and ingest seam results to match SDK returns

## Warning baseline

- rebased baseline: `origin/main` at `40a2a9d5a99d27eef49fcab8547af52bd43055e0`
- regular API Oxlint: 118 warnings before, 110 warnings after
- `vitest(require-mock-type-parameters)`: 8 warnings before, 0 warnings after (1 in `app-factory.test.ts`, 7 in the global `src/__tests__/mocks.ts`)
- no open pull request modified either target file when implementation started

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (14/14 tasks; API regular Oxlint reports 110 warnings and both type-aware passes report 0)
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter api exec vitest run src/__tests__/app-factory.test.ts` (55 tests)
- `pnpm --filter api exec vitest run src/signals/external/__tests__/axiom.test.ts` (3 tests)
- `pnpm --filter api exec vitest run src/lib/__tests__/log.test.ts` (50 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-drain-email-outbox-scoped.test.ts` (2 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/slack-oauth.test.ts` (54 tests)
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations-slack-message.test.ts` (12 tests)

Closes #31697
