### PR TITLE
test(api): remove dead scaffolding and pin gmail permission failure

### DIFF
--- a/turbo/apps/api/src/__tests__/test-app.ts
+++ b/turbo/apps/api/src/__tests__/test-app.ts
@@ -20,6 +20,7 @@ interface TestAppWithRoutesOptions {
 
 interface SetupAppWithRoutesOptions extends TestAppWithRoutesOptions {
   readonly baseUrl?: string;
+  readonly rethrowErrors?: boolean;
   readonly usagePricingResolution?: UsagePricingResolution;
 }
 
@@ -62,6 +63,7 @@ function createAppFetcher(
   context: TestContext,
   routes: readonly RouteEntry[],
   signal?: AbortSignal,
+  rethrowErrors?: boolean,
   usagePricingResolution?: UsagePricingResolution,
 ): ApiFetcher {
   const app = createAppWithRoutes({
@@ -69,6 +71,11 @@ function createAppFetcher(
     routes,
     usagePricingResolution,
   });
+  if (rethrowErrors) {
+    app.onError((error) => {
+      throw error;
+    });
+  }
 
   return (args) => {
     return requestApp(app, args);
@@ -104,9 +111,16 @@ export function setupAppWithRoutes({
   context,
   routes,
   signal,
+  rethrowErrors,
   usagePricingResolution,
 }: SetupAppWithRoutesOptions) {
-  const app = createAppFetcher(context, routes, signal, usagePricingResolution);
+  const app = createAppFetcher(
+    context,
+    routes,
+    signal,
+    rethrowErrors,
+    usagePricingResolution,
+  );
 
   return <TContract extends AppRouter>(
     contract: TContract,

--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -11,6 +11,7 @@ interface SetupRawAppOptions {
 
 interface SetupAppOptions extends SetupRawAppOptions {
   readonly baseUrl?: string;
+  readonly rethrowErrors?: boolean;
   readonly usagePricingResolution?: UsagePricingResolution;
 }
 
@@ -19,6 +20,7 @@ export function setupApp({
   context,
   routes,
   signal,
+  rethrowErrors,
   usagePricingResolution,
 }: SetupAppOptions) {
   return setupAppWithRoutes({
@@ -26,6 +28,7 @@ export function setupApp({
     context,
     routes,
     signal,
+    rethrowErrors,
     usagePricingResolution,
   });
 }

--- a/turbo/apps/api/src/signals/routes/__benches__/chat-threads.bench.ts
+++ b/turbo/apps/api/src/signals/routes/__benches__/chat-threads.bench.ts
@@ -15,7 +15,6 @@ import { connectors } from "@okouai/db/schema/connector";
 import { creditExpiresRecord } from "@okouai/db/schema/credit-expires-record";
 import { orgMembersMetadata } from "@okouai/db/schema/org-members-metadata";
 import { orgMetadataCanonicalWrites } from "@okouai/db/operations/org-metadata-canonical-write";
-import { orgMetadata } from "@okouai/db/schema/org-metadata";
 import { bench } from "vitest";
 import {
   chatThreadByIdContract,

--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -518,7 +518,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
 
   it("replies to failed linked iMessage runs", async () => {
     const ap = createAgentPhoneBddApi(context);
-    const { actor, phone, runnerGroup, sends } = await entitledLinkedActor();
+    const { phone, runnerGroup, sends } = await entitledLinkedActor();
     const conversationId = uniqueConversationId();
 
     await ap.postAgentPhoneInboundMessage({

--- a/turbo/apps/api/src/signals/routes/__tests__/built-in-generation.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/built-in-generation.test.ts
@@ -2,12 +2,10 @@ import { randomUUID } from "node:crypto";
 
 import { HttpResponse, http } from "msw";
 
-import { createAppWithRoutes } from "../../../app-factory-core";
 import { testContext } from "../../../__tests__/test-context";
 import { mockEnv } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
 import { server } from "../../../mocks/server";
-import { builtInGenerationRoutes } from "../built-in-generation";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-list.test.ts
@@ -9,7 +9,7 @@ import {
 import { afterEach } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
-import { setupApp, setupRawAppRequest } from "../../../__tests__/test-helpers";
+import { setupApp } from "../../../__tests__/test-helpers";
 import { mockOptionalEnv } from "../../../lib/env";
 import {
   invalidateApiTestConnectorCatalogCompatibility,

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -620,7 +620,7 @@ describe("POST /api/mail/drafts/link", () => {
           gmailDraftId: GMAIL_DRAFT_ID,
         },
       }),
-    ).rejects.toThrow();
+    ).rejects.toThrow("Failed to read Gmail draft (HTTP 403)");
 
     expect(gmail.draftReadCount).toBe(1);
     await expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -346,8 +346,8 @@ async function seedGmailMailCardFixture() {
   return { actor, agent, thread, gmail };
 }
 
-function client() {
-  return setupApp({ context, routes: mailRoutes })(mailContract);
+function client(options?: { readonly rethrowErrors?: boolean }) {
+  return setupApp({ context, routes: mailRoutes, ...options })(mailContract);
 }
 
 function connectorSelectionsClient() {
@@ -612,7 +612,7 @@ describe("POST /api/mail/drafts/link", () => {
     gmail.permissionDenied = true;
 
     await expect(
-      client().linkDraft({
+      client({ rethrowErrors: true }).linkDraft({
         headers: authHeaders(),
         body: {
           threadId: fixture.thread.id,

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-oauth.test.ts
@@ -32,8 +32,6 @@ const APP_ORIGIN = "https://app.vm0.test";
 const MICROSOFT_TOKEN_URL =
   "https://login.microsoftonline.com/common/oauth2/v2.0/token";
 const MICROSOFT_ME_URL = "https://graph.microsoft.com/v1.0/me";
-const TEAMS_APP_ID = "00000000-0000-0000-0000-000000000001";
-const TEAMS_APP_TENANT_ID = "11111111-1111-1111-1111-111111111111";
 
 async function appRequest(
   path: string,
@@ -70,14 +68,6 @@ function callbackPath(args: {
   }
   params.set("state", JSON.stringify(args.state));
   return `/api/integrations/teams/oauth/callback?${params.toString()}`;
-}
-
-function teamsInstallUrl(tenantId: string): string {
-  const url = new URL(`https://teams.microsoft.com/l/app/${TEAMS_APP_ID}`);
-  url.searchParams.set("installAppPackage", "true");
-  url.searchParams.set("appTenantId", TEAMS_APP_TENANT_ID);
-  url.searchParams.set("tenantId", tenantId);
-  return url.toString();
 }
 
 function mockMicrosoftOAuth(args: {
@@ -125,14 +115,6 @@ async function seedMembership(
   role: "admin" | "member" = "admin",
 ): Promise<void> {
   await store.set(seedOrgMembership$, { orgId, userId, role }, context.signal);
-}
-
-async function uninstalledTeamsFixture(
-  track: (
-    fixturePromise: Promise<TeamsConnectFixture>,
-  ) => Promise<TeamsConnectFixture>,
-): Promise<TeamsConnectFixture> {
-  return await track(Promise.resolve(teamsConnectFixture()));
 }
 
 async function seedTeamsInstallation(

--- a/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
@@ -15,7 +15,6 @@ import {
   type WorkflowUpdateRequest,
 } from "@okouai/api-contracts/contracts/workflows";
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
-import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   getCustomSkillStorageName,
@@ -53,13 +52,6 @@ import {
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createFixtureTracker, createRouteMocks } from "./helpers/route-test";
-import {
-  seedBuiltinThreadConnectorSelection,
-  seedConnectorStorageRow,
-  setBuiltinOAuthScopeFacts,
-  setConnectorAccountState,
-  setConnectorDefaultState,
-} from "./helpers/connector-credential-storage-state";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { chatThreadRoutes } from "../chat-threads";
 import { workflowAutomationsRoutes } from "../workflow-automations";
@@ -77,11 +69,6 @@ const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 
 type StaffFixture =
   | {
-      readonly kind: "connector";
-      readonly actor: ApiTestUser;
-      readonly connectorSlug: ConnectorSlug;
-    }
-  | {
       readonly kind: "workflow";
       readonly actor: ApiTestUser;
       readonly workflowId: string;
@@ -94,13 +81,6 @@ type StaffFixture =
 
 async function cleanupStaffFixture(fixture: StaffFixture): Promise<void> {
   switch (fixture.kind) {
-    case "connector": {
-      await connectorApi.disconnectSingleBuiltinConnectorAccount(
-        fixture.actor,
-        fixture.connectorSlug,
-      );
-      return;
-    }
     case "workflow": {
       await miscApi.deleteWorkflow(fixture.actor, fixture.workflowId, [204]);
       return;
@@ -333,71 +313,6 @@ async function enableWorkflowRuns(actor: ApiTestUser): Promise<void> {
   await api.grantProEntitlement(actor);
   await api.ensureOrgModelProvider(actor);
   api.configureRunnerGroup();
-}
-
-async function connectManualGrant(
-  actor: ApiTestUser,
-  connectorSlug: ConnectorSlug,
-  authMethod: Parameters<typeof connectorApi.connectManualGrant>[2],
-  values: Parameters<typeof connectorApi.connectManualGrant>[3],
-) {
-  const connector = await connectorApi.connectManualGrant(
-    actor,
-    connectorSlug,
-    authMethod,
-    values,
-  );
-  if (actor.orgId === STAFF_ORG_ID) {
-    await registerStaffFixture({
-      kind: "connector",
-      actor,
-      connectorSlug,
-    });
-  }
-  return connector;
-}
-
-async function connectGmailAccount(
-  actor: ApiTestUser,
-  agentId: string,
-  args: {
-    readonly accessToken: string;
-    readonly email: string;
-    readonly subject: string;
-    readonly account?: { readonly intent: "add"; readonly displayName: string };
-  },
-) {
-  mockGmailConnectorOAuth({
-    accessToken: args.accessToken,
-    email: args.email,
-    subject: args.subject,
-  });
-  const start = await connectorApi.startOauth(
-    actor,
-    "gmail",
-    "oauth",
-    agentId,
-    args.account,
-  );
-  const state = new URL(start.authorizationUrl).searchParams.get("state");
-  if (!state) {
-    throw new Error("Expected Gmail OAuth state");
-  }
-  await connectorApi.completeOauthCallback("gmail", {
-    code: `gmail-readiness-${randomUUID()}`,
-    state,
-  });
-  const accounts = await connectorApi.listBuiltinConnectorAccounts(
-    actor,
-    "gmail",
-  );
-  const account = accounts.find((candidate) => {
-    return candidate.externalEmail === args.email;
-  });
-  if (!account) {
-    throw new Error(`Expected Gmail account ${args.email}`);
-  }
-  return account;
 }
 
 async function connectGoogleCalendarAccount(


### PR DESCRIPTION
## Summary

- remove the 14 dead test and benchmark declarations identified in #31696, including the complete workflow connector-fixture and Teams install-URL cascades
- preserve the live workflow connector API/OAuth callers, installed Teams fixture cleanup, AgentPhone fixture setup, and every existing test and benchmark case
- pin the unrelated Gmail permission-denial rejection to Failed to read Gmail draft (HTTP 403) while retaining the draft-read and connector-status read-back assertions
- use an opt-in test-app rethrowErrors seam only for that Gmail assertion; its default is off, so normal test clients and production error handling are unchanged

## Rebased warning baseline

Rebased on origin/main at f503f4fed9d1ba6083ae8fbcfe766b74cdb03e30.

- clean-base regular API Oxlint: 76 warnings
- this branch regular API Oxlint: 61 warnings
- exact reduction: 15 warnings (14 eslint(no-unused-vars) and 1 vitest(require-to-throw-message))
- all seven warning-owning test/benchmark files now report zero regular Oxlint warnings; no unrelated warning category was changed

Open PR #31601 also touches workflows.test.ts in a different region. It remains rebase inventory only and is not a functional dependency.

## Validation

- Prettier on all changed files
- pnpm -F api lint
- pnpm -F api check-types
- pnpm knip (passes with the repository existing 53 configuration hints)
- git diff --check
- targeted Vitest was invoked once in one foreground process for the six affected test files, but local PostgreSQL was unavailable: /var/run/postgresql:5432 - no response, followed by connect ECONNREFUSED ::1:5432 and connect ECONNREFUSED 127.0.0.1:5432. All 86 selected tests were skipped during suite setup, so PR CI must provide the test execution evidence.
- the first PR CI run correctly exposed that the normal test client converts this unhandled provider error into a generic unknown 500; the repair adds the default-off test-only rethrow seam, and exact-head CI will verify the assertion

Closes #31696
