### PR TITLE
fix(chat): preserve structured runner timeout recovery

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -867,6 +867,9 @@ pub mod webhooks {
                 /// Session history exceeded its size limit.
                 #[serde(rename = "session_history_limit")]
                 SessionHistoryLimit,
+                /// The run reached its execution time limit.
+                #[serde(rename = "execution_timeout")]
+                ExecutionTimeout,
                 /// The provider account lacks credits.
                 #[serde(rename = "insufficient_credits")]
                 InsufficientCredits,

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -22,11 +22,13 @@ use serde_json::json;
 fn generated_completion_failure_reason_tokens_preserve_the_wire_contract() {
     let failure_reasons = [
         "session_history_limit",
+        "execution_timeout",
         "insufficient_credits",
         "invalid_api_key",
         "invalid_credentials",
         "terms_acceptance_required",
         "context_window_exceeded",
+        "input_too_large",
         "output_token_limit",
         "provider_rate_limited",
         "provider_overloaded",

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -14,9 +14,9 @@ use crate::session_history;
 use crate::session_metadata::CapturedSessionMetadata;
 use guest_common::{log_info, log_warn};
 use guest_contracts::diagnostics::{
-    AgentFramework, CliObservedExitDiagnostic, CliTerminationDiagnostic, EventDeliveryDiagnostic,
-    FailureClass, FailureDetailSource, FailureDiagnostic, FailureReason, PromptMetadata,
-    SessionHistoryStatus,
+    AgentFramework, CliObservedExitDiagnostic, CliTerminationDiagnostic, CliTerminationReason,
+    EventDeliveryDiagnostic, FailureClass, FailureDetailSource, FailureDiagnostic, FailureReason,
+    PromptMetadata, SessionHistoryStatus,
 };
 use serde_json::Value;
 
@@ -214,10 +214,13 @@ pub fn write_guest_failure_diagnostic(
 }
 
 fn with_cli_termination(
-    diagnostic: FailureDiagnostic,
+    mut diagnostic: FailureDiagnostic,
     cli_termination: Option<CliTerminationDiagnostic>,
 ) -> FailureDiagnostic {
     if let Some(cli_termination) = cli_termination {
+        if cli_termination.reason == CliTerminationReason::ExecutionTimeout {
+            diagnostic = diagnostic.with_failure_reason(FailureReason::ExecutionTimeout);
+        }
         diagnostic.with_cli_termination(cli_termination)
     } else {
         diagnostic

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -1677,6 +1677,30 @@ fn cli_termination_is_attached_without_changing_failure_reason() {
 }
 
 #[test]
+fn execution_timeout_termination_sets_authoritative_failure_reason() {
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliExecutionError,
+        AgentFramework::Codex,
+        PromptMetadata::from_prompt("plain prompt"),
+    )
+    .with_cli_exit_code(124)
+    .with_failure_reason(FailureReason::ProviderOverloaded);
+    let termination = CliTerminationDiagnostic::new(CliTerminationReason::ExecutionTimeout);
+
+    let with_termination = with_cli_termination(diagnostic, Some(termination));
+
+    assert_eq!(
+        with_termination.failure_class,
+        FailureClass::CliExecutionError
+    );
+    assert_eq!(
+        with_termination.failure_reason,
+        Some(FailureReason::ExecutionTimeout)
+    );
+    assert_eq!(with_termination.cli_termination, Some(termination));
+}
+
+#[test]
 fn cli_observed_exit_is_attached_without_changing_failure_reason() {
     let diagnostic = FailureDiagnostic::new(
         FailureClass::CliNonzero,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1552,7 +1552,13 @@ mod tests {
             .enable_all()
             .build()
             .unwrap()
-            .block_on(complete_execution_after_cli_failure_inner(200, 1));
+            .block_on(complete_execution_after_cli_failure_inner(
+                200,
+                1,
+                1,
+                "You've hit your usage limit.",
+                FailureReason::UsageLimit,
+            ));
     }
 
     #[test]
@@ -1562,7 +1568,29 @@ mod tests {
             .enable_all()
             .build()
             .unwrap()
-            .block_on(complete_execution_after_cli_failure_inner(500, 3));
+            .block_on(complete_execution_after_cli_failure_inner(
+                500,
+                3,
+                1,
+                "You've hit your usage limit.",
+                FailureReason::UsageLimit,
+            ));
+    }
+
+    #[test]
+    fn complete_execution_reports_timeout_reason_with_recovery_checkpoint() {
+        let _test_state_guard = lock_test_state();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(complete_execution_after_cli_failure_inner(
+                200,
+                1,
+                AGENT_EXECUTION_TIMEOUT_EXIT_CODE,
+                "execution: Agent execution timed out after 7200 seconds",
+                FailureReason::ExecutionTimeout,
+            ));
     }
 
     #[test]
@@ -1957,6 +1985,9 @@ mod tests {
     async fn complete_execution_after_cli_failure_inner(
         completion_status: u16,
         expected_completion_calls: usize,
+        failure_exit_code: i32,
+        failure_message: &str,
+        failure_reason: FailureReason,
     ) {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
@@ -2010,7 +2041,15 @@ mod tests {
             when.method(POST)
                 .path("/api/webhooks/agent/complete")
                 .json_body_includes(
-                    r#"{"exitCode":1,"failureReason":"usage_limit","error":"You've hit your usage limit.","checkpoint":{"cliAgentSessionId":"recovery-session-from-main"}}"#,
+                    serde_json::json!({
+                        "exitCode": failure_exit_code,
+                        "failureReason": failure_reason.as_str(),
+                        "error": failure_message,
+                        "checkpoint": {
+                            "cliAgentSessionId": "recovery-session-from-main"
+                        }
+                    })
+                    .to_string(),
                 );
             then.status(completion_status)
                 .header("Content-Type", "application/json")
@@ -2029,18 +2068,17 @@ mod tests {
         let telemetry =
             Telemetry::spawn_for_paths(config.run_id.clone(), &guest_paths, masker, http.clone());
         let runtime = test_guest_runtime(config, http.clone());
-        let failure_message = "You've hit your usage limit.";
         let failure_diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
             AgentFramework::ClaudeCode,
             PromptMetadata::from_prompt("plain prompt"),
         )
-        .with_cli_exit_code(1)
-        .with_failure_reason(FailureReason::UsageLimit)
+        .with_cli_exit_code(failure_exit_code)
+        .with_failure_reason(failure_reason)
         .with_session_history_status(SessionHistoryStatus::Present);
         let exit_code = complete_execution(
-            1,
-            1,
+            failure_exit_code,
+            failure_exit_code,
             Duration::ZERO,
             CompletionState {
                 last_event_sequence: None,
@@ -2055,7 +2093,7 @@ mod tests {
         .await;
         telemetry.shutdown().await;
 
-        assert_eq!(exit_code, 1);
+        assert_eq!(exit_code, failure_exit_code);
         assert_eq!(
             std::fs::read_to_string(guest_paths.checkpoint_error_file()).unwrap(),
             failure_message

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -709,6 +709,8 @@ impl FailureClass {
 pub enum FailureReason {
     /// The session history exceeded the checkpoint size limit.
     SessionHistoryLimit,
+    /// The run reached its execution time limit.
+    ExecutionTimeout,
     /// The provider account has insufficient credits.
     InsufficientCredits,
     /// The configured API key is invalid.
@@ -749,6 +751,7 @@ impl FailureReason {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::SessionHistoryLimit => "session_history_limit",
+            Self::ExecutionTimeout => "execution_timeout",
             Self::InsufficientCredits => "insufficient_credits",
             Self::InvalidApiKey => "invalid_api_key",
             Self::InvalidCredentials => "invalid_credentials",
@@ -775,6 +778,7 @@ impl From<FailureReason>
     fn from(reason: FailureReason) -> Self {
         match reason {
             FailureReason::SessionHistoryLimit => Self::SessionHistoryLimit,
+            FailureReason::ExecutionTimeout => Self::ExecutionTimeout,
             FailureReason::InsufficientCredits => Self::InsufficientCredits,
             FailureReason::InvalidApiKey => Self::InvalidApiKey,
             FailureReason::InvalidCredentials => Self::InvalidCredentials,
@@ -1460,6 +1464,7 @@ mod tests {
     fn failure_reason_maps_exhaustively_to_the_public_completion_contract() {
         for (reason, expected) in [
             (FailureReason::SessionHistoryLimit, "session_history_limit"),
+            (FailureReason::ExecutionTimeout, "execution_timeout"),
             (FailureReason::InsufficientCredits, "insufficient_credits"),
             (FailureReason::InvalidApiKey, "invalid_api_key"),
             (FailureReason::InvalidCredentials, "invalid_credentials"),

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -8,6 +8,7 @@ use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use api_contracts::generated::types::webhooks::agent::complete::RequestFailureReason;
 use futures_util::FutureExt;
 use sandbox::SandboxId;
 use tokio::sync::mpsc;
@@ -94,6 +95,27 @@ pub(super) struct SpawnContext {
     pub(super) outer_job_panic: Option<OuterJobPanicPoint>,
     #[cfg(test)]
     pub(super) test_observer: StartLoopTestObserver,
+}
+
+fn completion_failure_reason(
+    exit_code: i32,
+    cancelled: bool,
+    failure: Option<&executor::ExecutionFailure>,
+) -> Option<RequestFailureReason> {
+    if exit_code == 0 || cancelled {
+        return None;
+    }
+    let failure = failure?;
+    match failure.kind {
+        executor::ExecutionFailureKind::Generic => failure
+            .diagnostic
+            .as_ref()
+            .and_then(|diagnostic| diagnostic.failure_reason)
+            .map(Into::into),
+        executor::ExecutionFailureKind::RunnerJobTimeout { .. } => {
+            Some(RequestFailureReason::ExecutionTimeout)
+        }
+    }
 }
 
 pub(super) struct SpawnJobRequest {
@@ -745,17 +767,11 @@ pub(super) async fn run_job(
             cancelled_for_log,
             executor_result.outcome.failure.as_ref(),
         );
-        let failure_reason = if executor_result.exit_code == 0 || cancelled_for_log {
-            None
-        } else {
-            executor_result
-                .outcome
-                .failure
-                .as_ref()
-                .and_then(|failure| failure.diagnostic.as_ref())
-                .and_then(|diagnostic| diagnostic.failure_reason)
-                .map(Into::into)
-        };
+        let failure_reason = completion_failure_reason(
+            executor_result.exit_code,
+            cancelled_for_log,
+            executor_result.outcome.failure.as_ref(),
+        );
 
         let completion_payload = CompletionPayload::new(
             run_id,
@@ -881,6 +897,9 @@ pub(super) async fn handle_job_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use guest_contracts::diagnostics::{
+        AgentFramework, FailureClass, FailureDiagnostic, FailureReason, PromptMetadata,
+    };
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -1130,6 +1149,74 @@ mod tests {
                 panic!("expected runner job timeout failure kind")
             }
         }
+    }
+
+    #[test]
+    fn completion_reason_uses_diagnostic_for_generic_failure() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_failure_reason(FailureReason::UsageLimit);
+        let failure = executor::ExecutionFailure::new(1, "usage limit", Some(diagnostic));
+
+        assert_eq!(
+            completion_failure_reason(1, false, Some(&failure)),
+            Some(RequestFailureReason::UsageLimit)
+        );
+    }
+
+    #[test]
+    fn completion_reason_uses_runner_kind_for_timeout_and_overrides_diagnostic() {
+        let failure = executor::ExecutionFailure::runner_job_timeout(
+            124,
+            "execution timed out",
+            None,
+            Duration::from_secs(7200),
+            Duration::from_secs(7200),
+            None,
+        );
+
+        assert_eq!(
+            completion_failure_reason(124, false, Some(&failure)),
+            Some(RequestFailureReason::ExecutionTimeout)
+        );
+
+        let conflicting_diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_failure_reason(FailureReason::UsageLimit);
+        let failure_with_conflicting_diagnostic = executor::ExecutionFailure::runner_job_timeout(
+            124,
+            "execution timed out",
+            Some(conflicting_diagnostic),
+            Duration::from_secs(7200),
+            Duration::from_secs(7200),
+            None,
+        );
+
+        assert_eq!(
+            completion_failure_reason(124, false, Some(&failure_with_conflicting_diagnostic)),
+            Some(RequestFailureReason::ExecutionTimeout)
+        );
+    }
+
+    #[test]
+    fn completion_reason_omits_success_and_cancellation() {
+        let failure = executor::ExecutionFailure::runner_job_timeout(
+            124,
+            "execution timed out",
+            None,
+            Duration::from_secs(7200),
+            Duration::from_secs(7200),
+            None,
+        );
+
+        assert_eq!(completion_failure_reason(0, false, None), None);
+        assert_eq!(completion_failure_reason(124, true, Some(&failure)), None);
     }
 
     #[tokio::test]

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -4817,6 +4817,17 @@ describe("CHAT-02: failed chat callbacks", () => {
         failureReason: "provider_overloaded",
         selectedModel: "claude-sonnet-5",
       },
+      {
+        prompt: "round eleven",
+        error: "execution: Agent execution timed out after 7200 seconds",
+        expectedError: CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE,
+      },
+      {
+        prompt: "round twelve",
+        error: "Contradictory runner failure",
+        expectedError: CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE,
+        failureReason: "execution_timeout",
+      },
     ];
 
     let threadId: string | undefined;

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -18846,6 +18846,7 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       }),
       await completeFailure({}),
       await completeFailure({ failureReason: "session_history_limit" }),
+      await completeFailure({ failureReason: "execution_timeout" }),
       await completeFailure({ failureReason: "unsupported_model" }),
     ];
     for (const control of visibleControls) {

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -195,6 +195,7 @@ function shouldSuppressKnownFailureLog(
       );
     }
     case "session_history_limit":
+    case "execution_timeout":
     case "unsupported_model": {
       return false;
     }

--- a/turbo/apps/platform/src/signals/chat-page/assistant-error-recovery.ts
+++ b/turbo/apps/platform/src/signals/chat-page/assistant-error-recovery.ts
@@ -130,6 +130,22 @@ function isClaudeModelCapacity(error: string): boolean {
   );
 }
 
+function classifyExecutionTimeout(
+  event: EnrichedChatEvent,
+  error: string,
+): ClassifiedAssistantError {
+  return {
+    sourceEventId: event.id,
+    providerMessage: error,
+    kind: "execution-timeout",
+    framework: null,
+    scope: "framework",
+    limitWindow: null,
+    retryLabel: null,
+    failedModel: null,
+  };
+}
+
 function classifyAssistantErrorFromText(
   event: EnrichedChatEvent,
   error: string,
@@ -139,16 +155,7 @@ function classifyAssistantErrorFromText(
   const unsupportedModel = getCodexChatGptAccountUnsupportedModel(error);
 
   if (isAgentExecutionTimeoutRunError(normalized)) {
-    return {
-      sourceEventId: event.id,
-      providerMessage: error,
-      kind: "execution-timeout",
-      framework: null,
-      scope: "framework",
-      limitWindow: null,
-      retryLabel: null,
-      failedModel: null,
-    };
+    return classifyExecutionTimeout(event, error);
   }
 
   if (unsupportedModel !== undefined) {
@@ -223,8 +230,9 @@ function classifyAssistantErrorFromText(
   return null;
 }
 
-const STRUCTURED_PROVIDER_RECOVERY_KIND = Object.freeze({
+const STRUCTURED_RECOVERY_KIND = Object.freeze({
   session_history_limit: null,
+  execution_timeout: "execution-timeout",
   insufficient_credits: null,
   invalid_api_key: null,
   invalid_credentials: null,
@@ -241,14 +249,11 @@ const STRUCTURED_PROVIDER_RECOVERY_KIND = Object.freeze({
   reconnect_required: null,
   unsupported_model: "model-unavailable",
   usage_limit: "usage-limit",
-} satisfies Record<
-  KnownRunFailureReason,
-  ProviderAssistantErrorRecoveryKind | null
->);
+} satisfies Record<KnownRunFailureReason, AssistantErrorRecoveryKind | null>);
 
-function structuredProviderRecoveryKind(
+function structuredRecoveryKind(
   event: EnrichedChatEvent,
-): ProviderAssistantErrorRecoveryKind | null | undefined {
+): AssistantErrorRecoveryKind | null | undefined {
   if (event.eventType !== "run.failed" || event.failureReason === undefined) {
     return undefined;
   }
@@ -259,7 +264,7 @@ function structuredProviderRecoveryKind(
   if (!knownReason.success) {
     return null;
   }
-  return STRUCTURED_PROVIDER_RECOVERY_KIND[knownReason.data];
+  return STRUCTURED_RECOVERY_KIND[knownReason.data];
 }
 
 function structuredRecoveryFrameworkFromMessage(
@@ -488,7 +493,7 @@ function createClassifiedAssistantErrorComputed(
       return null;
     }
 
-    const structuredKind = structuredProviderRecoveryKind(candidate.event);
+    const structuredKind = structuredRecoveryKind(candidate.event);
     if (structuredKind === null) {
       return null;
     }
@@ -499,6 +504,8 @@ function createClassifiedAssistantErrorComputed(
         candidate.event,
         candidate.error,
       );
+    } else if (structuredKind === "execution-timeout") {
+      classified = classifyExecutionTimeout(candidate.event, candidate.error);
     } else {
       if (
         structuredKind !== "model-unavailable" &&

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-models.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-models.test.tsx
@@ -670,6 +670,33 @@ test("Continue a run that reached its execution time limit", async () => {
   });
 });
 
+test("Continue a run classified by a structured execution timeout reason", async () => {
+  configureModelPolicies(["gpt-5.6-sol"]);
+  installRunChat({
+    selectedModel: "gpt-5.6-sol",
+    chatEvents: failedRunEvents(
+      "Contradictory runner failure",
+      "gpt-5.6-sol",
+      "execution_timeout",
+    ),
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatErrorRecovery]: false },
+  });
+
+  await readyChat();
+  const recovery = await screen.findByRole("status");
+  expect(recovery).toHaveTextContent("Time limit reached");
+  expect(recovery).toHaveTextContent(
+    "This run reached its time limit. Continue to keep working.",
+  );
+  expect(within(recovery).queryByRole("combobox")).toBeNull();
+  expect(queryButton("Continue", recovery)).toBeVisible();
+});
+
 test("Preserve provider errors that have no guided recovery", async () => {
   const providerError =
     "Selected model capacity warning from a custom gateway; contact its operator.";

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -34,6 +34,7 @@ describe("formatRunErrorForExternalSurface", () => {
   it.each([
     "Agent execution timed out after 7200 seconds",
     "Agent execution timed out after 1 seconds",
+    "execution: Agent execution timed out after 7200 seconds",
   ])("shows controlled execution timeout errors safely: %s", (error) => {
     expect(
       formatRunErrorForExternalSurface({
@@ -44,6 +45,16 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isAgentExecutionTimeoutRunError(error)).toBe(true);
     expect(isActionableRunError(error)).toBe(true);
     expect(isGenericRunErrorForDisplay(error)).toBe(false);
+  });
+
+  it("uses the structured timeout reason instead of untrusted error text", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: "Contradictory runner failure",
+        failureReason: "execution_timeout",
+      }),
+    ).toBe(CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE);
   });
 
   it("keeps the canonical execution timeout message stable", () => {
@@ -64,6 +75,8 @@ describe("formatRunErrorForExternalSurface", () => {
     "Agent execution timed out after 7200 milliseconds",
     "Agent execution timed out after 7200 seconds while finalizing",
     "Sandbox execution timed out after 7200 seconds",
+    "Execution: Agent execution timed out after 7200 seconds",
+    "execution:  Agent execution timed out after 7200 seconds",
   ])("keeps unrelated execution timeout text generic: %s", (error) => {
     expect(
       formatRunErrorForExternalSurface({

--- a/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/webhooks.test.ts
@@ -281,6 +281,7 @@ describe("agent completion failure reasons", () => {
   it("accepts known reasons, future tokens, and omission", () => {
     expect(knownRunFailureReasonSchema.options).toStrictEqual([
       "session_history_limit",
+      "execution_timeout",
       "insufficient_credits",
       "invalid_api_key",
       "invalid_credentials",

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -204,6 +204,10 @@ export const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
 export const CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE =
   "This run reached its execution time limit.";
 
+// Existing runner/sandbox and commit-addressed CLI rollout fallback:
+// pre-execution_timeout senders may wrap the canonical text with `execution: `.
+// Remove after old instances drain, their queue, two-hour execution, and
+// finalization windows close, and the rollback floor is compatible; see #31713.
 const AGENT_EXECUTION_TIMEOUT_RUN_ERROR =
   /^(?:execution: )?Agent execution timed out after [1-9]\d* seconds$/u;
 

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -205,7 +205,7 @@ export const CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE =
   "This run reached its execution time limit.";
 
 const AGENT_EXECUTION_TIMEOUT_RUN_ERROR =
-  /^Agent execution timed out after [1-9]\d* seconds$/u;
+  /^(?:execution: )?Agent execution timed out after [1-9]\d* seconds$/u;
 
 const CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE =
   "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.";
@@ -647,6 +647,7 @@ export function isGenericRunErrorForDisplay(errorMessage: string): boolean {
 
 type StructuredRunErrorBehavior =
   | "credential"
+  | "execution-timeout"
   | "generic"
   | "insufficient-credits"
   | "overloaded"
@@ -659,6 +660,7 @@ const STRUCTURED_RUN_ERROR_BEHAVIOR: Record<
   StructuredRunErrorBehavior
 > = {
   session_history_limit: "generic",
+  execution_timeout: "execution-timeout",
   insufficient_credits: "insufficient-credits",
   invalid_api_key: "generic",
   invalid_credentials: "credential",
@@ -692,6 +694,9 @@ function formatStructuredRunError(params: {
   }
 
   switch (STRUCTURED_RUN_ERROR_BEHAVIOR[knownReason.data]) {
+    case "execution-timeout": {
+      return CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE;
+    }
     case "insufficient-credits": {
       return "insufficient_credits";
     }

--- a/turbo/packages/api-contracts/src/contracts/run-failure-reasons.ts
+++ b/turbo/packages/api-contracts/src/contracts/run-failure-reasons.ts
@@ -10,6 +10,7 @@ export type RunFailureReasonToken = z.infer<typeof runFailureReasonTokenSchema>;
 
 export const knownRunFailureReasonSchema = z.enum([
   "session_history_limit",
+  "execution_timeout",
   "insufficient_credits",
   "invalid_api_key",
   "invalid_credentials",

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -687,6 +687,7 @@ export const rustTypeBindings = [
         rustDoc: ["Known failure reason emitted by current Rust producers."],
         variants: {
           session_history_limit: ["Session history exceeded its size limit."],
+          execution_timeout: ["The run reached its execution time limit."],
           insufficient_credits: ["The provider account lacks credits."],
           invalid_api_key: ["The configured API key is invalid."],
           invalid_credentials: ["The configured credentials are invalid."],


### PR DESCRIPTION
## Summary

- add `execution_timeout` to the public runner completion failure-reason contract and generated Rust bindings
- make both guest completion and runner fallback completion emit the structured timeout reason, with timeout classification taking precedence over incidental provider diagnostics
- preserve recovery parity in API formatting and Web chat, including a strict compatibility match for legacy `execution: Agent execution timed out after <n> seconds` payloads
- keep every other known failure reason exhaustively classified, and restore the missing `input_too_large` token to the Rust wire-contract test inventory

## Compatibility and scope

- old runners remain supported through the narrowly scoped legacy text matcher
- new runners can deploy after API and Web consumers because future failure-reason tokens remain accepted and fail closed
- no database migration or historical-event backfill is required
- provider rate-limit, credential, and other non-recovery classifications keep their existing behavior; this PR does not broaden them into recovery cards

## Fallbacks

- `turbo/packages/api-contracts/src/contracts/errors.ts:AGENT_EXECUTION_TIMEOUT_RUN_ERROR` — accepts the exact `execution: ` wrapper emitted by pre-`execution_timeout` runner/sandbox and commit-addressed CLI senders. Surfaces: existing runner/sandbox -> new API and older CLI context -> new API. Remove after old runner instances drain, older CLI contexts exceed their maximum queue, two-hour execution, and finalization lifetime, and the rollback floor supports the structured reason; follow-up #31713.

## Validation

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- staged TypeScript checks for all non-API/non-Web packages, Web, and API
- targeted Vitest files for API contracts, Web chat recovery, failed chat callbacks, and completion-log visibility
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p api-contracts -p guest-contracts -p guest-agent -p runner --all-targets -- -D warnings`
- Rustdoc with warnings denied for the four affected crates
- targeted Rust contract, guest-contract, and guest-agent tests

The runner test target compiles under Clippy, but its monolithic test binary exceeded this 3.8 GiB local host's link memory. The three focused runner assertions are included for CI execution.

Closes #31684
