### PR TITLE
fix(api): give reasoning-enabled fast-path calls enough token budget

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -14863,6 +14863,7 @@ describe("CHAT-02: prior rounds and thread titles", () => {
     expect(upstreamAuthorization).toBe("Bearer title-key");
     expect(titleRequestBody).toMatchObject({
       model: "google/gemini-3.8-flash",
+      max_tokens: 512,
       reasoning: { effort: "low" },
     });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -14895,7 +14895,7 @@ describe("CHAT-02: prior rounds and thread titles", () => {
     expect(recommender.eventType).toBe("output.followups");
     expect(followupRequestBody).toMatchObject({
       model: "google/gemini-3.8-flash",
-      max_tokens: 400,
+      max_tokens: 1024,
       reasoning: { effort: "low" },
     });
     const futureFollowups = resolveChatEventRecommendedFollowups(recommender);

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -201,7 +201,7 @@ function chatCompletionContextMessage(
 
 async function generateFastPathText(
   messages: readonly ChatMessageForGeneration[],
-  maxTokens = 30,
+  maxTokens = 512,
   options?: {
     readonly stripMarkdown?: boolean;
   },
@@ -438,7 +438,7 @@ export function generateChatNotificationSummary(
         content: `User request:\n${prompt.slice(0, TITLE_CONTEXT_CHAR_CAP)}\n\nAssistant reply:\n${resultText.slice(0, TITLE_CONTEXT_CHAR_CAP)}`,
       },
     ],
-    35,
+    512,
   );
 }
 
@@ -509,7 +509,7 @@ async function generateRecommendedFollowups(
         content: `Recent conversation:\n${context}`,
       },
     ],
-    400,
+    1024,
     { stripMarkdown: false },
   );
 

--- a/turbo/apps/api/src/signals/services/goal-objective-brief.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-objective-brief.service.ts
@@ -27,7 +27,7 @@ export async function generateGoalObjectiveBrief(
           content: `Objective:\n${objective.slice(0, OBJECTIVE_CONTEXT_CHAR_CAP)}`,
         },
       ],
-      80,
+      768,
       { reasoning: { effort: "low" } },
     ),
     (error) => {

--- a/turbo/apps/api/src/signals/services/run-summary.service.ts
+++ b/turbo/apps/api/src/signals/services/run-summary.service.ts
@@ -56,7 +56,7 @@ async function generateRunSummary(
         content: `Context (user request):\n${promptSnippet}\n\nResult:\n${resultSnippet}`,
       },
     ],
-    80,
+    768,
     { reasoning: { effort: "low" }, temperature: 0.3 },
   );
   return content === null ? null : stripMarkdown(content);


### PR DESCRIPTION
Fixes #31714. Repair for a defect introduced by #31698 (slice 2 of #31616), merged to `main` at `a849749` and not yet released.

## Problem

#31698 moved the fast path to `google/gemini-3.8-flash` and pinned `reasoning: { effort: "low" }` on three call sites without resizing their `max_tokens`. Those budgets were sized for a non-reasoning model's answer alone.

On Gemini 3 models `max_output_tokens` is a **combined** budget for thinking tokens plus output tokens, contrary to Google's own documentation — measured in [googleapis/python-genai#2062](https://github.com/googleapis/python-genai/issues/2062), where thinking consumed ~906 of a 1024 budget and the answer was truncated with `finishReason: MAX_TOKENS`. OpenRouter maps `max_tokens` onto `maxOutputTokens`, and `turbo/apps/api/src/signals/external/openrouter.ts:238` sends it.

Since #31653, truncation is no longer silently accepted: `openrouter.ts:159` throws when `finish_reason !== "stop"`. So the chain on `main` is `max_tokens: 30` + low-effort reasoning → thinking eats the budget → `finish_reason: "length"` → helper throws → caller logs and returns null → **the title is never persisted**.

## Change

Reserve headroom for the reasoning channel at every site that emits reasoning tokens:

| Call site | From | To |
|---|---|---|
| chat title / shared-thread title (`chat-title.service.ts`) | 30 | 512 |
| notification summary (`chat-title.service.ts`) | 35 | 512 |
| run summary (`run-summary.service.ts`) | 80 | 768 |
| goal objective brief (`goal-objective-brief.service.ts`) | 80 | 768 |
| recommended follow-ups (`chat-title.service.ts`) | 400 | 1024 |

Raising a ceiling is free at the billing level — generated tokens are billed, not the ceiling — and output length stays governed by the prompts, which already state their own limits ("max 60 chars" for titles, "max 90 chars" for the notification summary, "at most 50 words" for the run summary, "max 140 characters" for the objective brief). This removes a truncation failure; it does not make outputs longer.

`chat-events.bdd.test.ts` asserted the recommended-follow-up budget of 400 as of #31698 and is updated to 1024. It is the only test that asserted any of the five values; the `max_tokens: 160` assertion in the same file belongs to the `effort: "none"` initial-thinking site and is unchanged.

## Explicitly not changed

- `FAST_PATH_MODEL` is still `google/gemini-3.8-flash` and still the only fast-path model constant.
- Every `reasoning.effort` is unchanged — three `"low"`, two `"none"`. The problem is the budget, not the effort; reverting to `"none"` would undo what #31616 is for.
- No `finish_reason` bypass is reintroduced. Truncation stays a hard failure; the missing tests for that are #31693, out of scope here.
- `THINKING_MAX_TOKENS` and `VOICE_IO_POLISH_MAX_TOKENS` are untouched — those sites emit no reasoning tokens and were never affected.
- No `temperature` value and no prompt string differs from `main`.
- `image-recognition.service.ts` and the historical Gemini billing mappings from #31616 are untouched.

## Verification

`git diff main` is six numeric literals in three service files, plus two assertion lines in `chat-events.bdd.test.ts` that pin the chat-title budget at 512 and the recommended-follow-up budget at 1024. Nothing else changes.

The title assertion is the regression guard for the defect's primary symptom: `titleRequestBody` was already captured and already asserted for `model` and `reasoning.effort`, so it now also asserts `max_tokens`, and reverting the title default to `30` fails the suite. The notification-summary, run-summary, and objective-brief budgets stay unpinned because no existing test discriminates those three OpenRouter requests; that gap belongs with the truncation-behavior coverage tracked in #31693.
