### PR TITLE
feat(pi): activate terra api-key routes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -253,6 +253,36 @@ const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "okou web upload-file -f <path>";
 const RUN_TIME_BUDGET_STEER_AT_MS = 115 * 60 * 1000;
 const PI_API_FIRST_TURN_USAGE_NAMESPACE =
   "26e1c547-485d-4438-bf6d-4b77959da0cb";
+const STANDARD_TERRA_API_KEY_BDD_ROUTES = [
+  {
+    name: "OpenAI",
+    type: "openai-api-key",
+    endpoint: "https://api.openai.com/v1/responses",
+    baseUrl: "https://api.openai.com/v1",
+    secretName: "OPENAI_API_KEY",
+    piProvider: "openai",
+    runtimeModel: "gpt-5.6-terra",
+  },
+  {
+    name: "OpenRouter",
+    type: "openrouter-codex",
+    endpoint: "https://openrouter.ai/api/v1/responses",
+    baseUrl: "https://openrouter.ai/api/v1",
+    secretName: "OPENROUTER_API_KEY",
+    piProvider: "openrouter",
+    runtimeModel: "openai/gpt-5.6-terra",
+  },
+  {
+    name: "Vercel AI Gateway",
+    type: "vercel-ai-gateway-codex",
+    endpoint: "https://ai-gateway.vercel.sh/v1/responses",
+    baseUrl: "https://ai-gateway.vercel.sh/v1",
+    secretName: "VERCEL_AI_GATEWAY_API_KEY",
+    piProvider: "openai",
+    catalogModel: "gpt-5.6-terra",
+    runtimeModel: "openai/gpt-5.6-terra",
+  },
+] as const;
 const TERRA_USAGE_PRICING = [
   "tokens.input",
   "tokens.output",
@@ -2181,7 +2211,9 @@ async function upsertOrgModelProvider(
       | "deepseek"
       | "openai-api-key"
       | "openrouter-api-key"
+      | "openrouter-codex"
       | "vercel-ai-gateway"
+      | "vercel-ai-gateway-codex"
       | "built-in";
     readonly secret?: string;
   },
@@ -10954,11 +10986,6 @@ describe("CHAT-02: model-first provider policies", () => {
       model: "deepseek-v4-flash",
       providerType: "deepseek",
     },
-    {
-      name: "Terra",
-      model: "gpt-5.6-terra",
-      providerType: "openai-api-key",
-    },
   ] as const)(
     "keeps direct $name BYOK out of Pi execution",
     async ({ model, providerType }) => {
@@ -11007,6 +11034,382 @@ describe("CHAT-02: model-first provider policies", () => {
       await cancelChatRun(actor, run.runId, claimed.sandboxHeaders);
     },
     30_000,
+  );
+
+  it.each(STANDARD_TERRA_API_KEY_BDD_ROUTES)(
+    "runs $name API-key Terra through API-first and generation-2 Sandbox with exact credential continuity",
+    async (route) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const firewall = createFirewallApi(context);
+      const orgId = requireOrgId(actor);
+      chatCallbacks.failIfChatCallbackRouteIsFetched();
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: true },
+      );
+      const initialSecret = `${route.type}-initial-secret`;
+      const { providerId } = await upsertOrgModelProvider(actor, {
+        type: route.type,
+        secret: initialSecret,
+      });
+      await api.updateOrgModelPolicies(actor, [
+        {
+          model: "gpt-5.6-terra",
+          isDefault: true,
+          defaultProviderType: route.type,
+          credentialScope: "org",
+          modelProviderId: providerId,
+        },
+      ]);
+      mockPiResourceArchiveDownloads();
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      const providerRequests: {
+        readonly authorization: string | null;
+        readonly body: unknown;
+      }[] = [];
+      server.use(
+        http.post(route.endpoint, async ({ request }) => {
+          const sequence = providerRequests.length;
+          providerRequests.push({
+            authorization: request.headers.get("authorization"),
+            body: await request.json(),
+          });
+          const responseBody = piResponsesContentSse({
+            blocks:
+              sequence === 0
+                ? [
+                    {
+                      type: "toolCall",
+                      callId: `call_${route.type.replaceAll("-", "_")}`,
+                      name: "bash",
+                      arguments: { command: "okou --help" },
+                    },
+                  ]
+                : [
+                    {
+                      type: "text",
+                      text: `${route.name} API answer ${sequence}`,
+                    },
+                  ],
+            sequence,
+          });
+          return new HttpResponse(responseBody, {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }),
+      );
+
+      const firstPrompt = `use ${route.name} Terra and hand off one tool`;
+      const first = await sendChatRun(actor, {
+        agentId,
+        prompt: firstPrompt,
+        model: "gpt-5.6-terra",
+      });
+      const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${first.runId}/manifest.json`;
+      const sessionKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${first.runId}/session.jsonl`;
+      await expect
+        .poll(() => {
+          return checkpointObjects.has(manifestKey);
+        })
+        .toBe(true);
+      await flushWaitUntilForTest();
+      expect(providerRequests).toStrictEqual([
+        {
+          authorization: `Bearer ${initialSecret}`,
+          body: expect.objectContaining({
+            model: route.runtimeModel,
+            store: false,
+            stream: true,
+          }),
+        },
+      ]);
+      expect(providerRequests[0]?.body).not.toHaveProperty(
+        "previous_response_id",
+      );
+      await expectNoVm0ModelUsage(first.runId);
+
+      await api.heartbeatRunner(runnerGroup);
+      const legacyClaim = await api.requestClaimRunnerJob(
+        true,
+        first.runId,
+        [404],
+      );
+      expectApiError(legacyClaim.body);
+      await expect(api.readRun(actor, first.runId)).resolves.toMatchObject({
+        status: "pending",
+      });
+      const claim = await api.claimRunnerJob(first.runId, {
+        capabilities: { piModelConfigGenerations: [1, 2] },
+      });
+      const sandboxHeaders = {
+        authorization: `Bearer ${claim.sandboxToken}`,
+      };
+      expect(claim.cliAgentType).toBe("pi");
+      expect(claim.piSessionId).toBe(first.threadId);
+      expect(claim.piModelConfig).toStrictEqual({
+        schemaVersion: 2,
+        dialect: "openai-responses",
+        transport: "sse",
+        provider: route.piProvider,
+        baseUrl: route.baseUrl,
+        model: route.runtimeModel,
+        ...(route.type === "vercel-ai-gateway-codex"
+          ? { catalogModel: route.catalogModel }
+          : {}),
+        thinkingLevel: "low",
+        credentialBindings: [
+          {
+            kind: "api-key",
+            environment: "OPENAI_API_KEY",
+            secretName: route.secretName,
+          },
+        ],
+      });
+      expect(claimEnvironment(claim)).toMatchObject({
+        OPENAI_API_KEY: modelProviderSecretPlaceholder(
+          route.type,
+          route.secretName,
+        ),
+        OPENAI_MODEL: route.runtimeModel,
+      });
+      expect(JSON.stringify(claim)).not.toContain(initialSecret);
+      if (!claim.encryptedSecrets) {
+        throw new Error("Expected API-key Terra claim credentials");
+      }
+      const sandboxCredential = await firewall.requestFirewallAuth(
+        sandboxHeaders,
+        {
+          encryptedSecrets: claim.encryptedSecrets,
+          authHeaders: {
+            Authorization: `Bearer ${secretTemplate(route.secretName)}`,
+          },
+          secretConnectorMap: claim.secretConnectorMap ?? undefined,
+          secretConnectorMetadataMap:
+            claim.secretConnectorMetadataMap ?? undefined,
+        },
+        [200],
+      );
+      if (sandboxCredential.status !== 200) {
+        throw new Error("Expected exact API-key Terra firewall credential");
+      }
+      expect(sandboxCredential.body.headers.Authorization).toBe(
+        `Bearer ${initialSecret}`,
+      );
+      expect(sandboxCredential.body.resolvedSecrets).toStrictEqual([
+        route.secretName,
+      ]);
+
+      const manifestBytes = checkpointObjects.get(manifestKey);
+      const h1Bytes = checkpointObjects.get(sessionKey);
+      if (!manifestBytes || !h1Bytes) {
+        throw new Error("Expected API-key Terra ownership-transfer artifacts");
+      }
+      const manifest = piApiFirstTurnManifestSchema.parse(
+        JSON.parse(manifestBytes.toString("utf8")),
+      );
+      const h2Session = MemoryPiSession.fromJsonl(h1Bytes.toString("utf8"));
+      const pendingAssistant = [...h2Session.buildSessionContext().messages]
+        .reverse()
+        .find((message) => {
+          return message.role === "assistant";
+        });
+      const pendingTool =
+        pendingAssistant?.role === "assistant"
+          ? pendingAssistant.content.find((content) => {
+              return content.type === "toolCall";
+            })
+          : undefined;
+      if (!pendingTool || pendingTool.type !== "toolCall") {
+        throw new Error("Expected API-key Terra tool call in H1");
+      }
+      const sandboxToolResult = `${route.name} sandbox tool output`;
+      const sandboxAnswer = `${route.name} Sandbox completion`;
+      h2Session.appendMessage({
+        role: "toolResult",
+        toolCallId: pendingTool.id,
+        toolName: pendingTool.name,
+        content: [{ type: "text", text: sandboxToolResult }],
+        details: {},
+        isError: false,
+        timestamp: 2,
+      });
+      h2Session.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: sandboxAnswer }],
+        api: "openai-responses",
+        provider: route.piProvider,
+        model: route.runtimeModel,
+        usage: {
+          input: 5,
+          output: 3,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 8,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0,
+          },
+        },
+        stopReason: "stop",
+        timestamp: 3,
+      });
+      const h2 = h2Session.toJsonl();
+      const h2Hash = createHash("sha256").update(h2).digest("hex");
+      await webhooks.requestAgentCheckpointPrepareHistory(
+        {
+          runId: first.runId,
+          hash: h2Hash,
+          rawSize: Buffer.byteLength(h2),
+          encodedSize: Buffer.byteLength(h2),
+          encoding: "identity",
+        },
+        sandboxHeaders,
+        [200],
+      );
+      checkpointObjects.set(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${h2Hash}.blob`,
+        Buffer.from(h2, "utf8"),
+      );
+      const sandboxEventSequenceStart = manifest.sandboxEventSequenceStart;
+      await webhooks.requestAgentEvents(
+        {
+          runId: first.runId,
+          events: [
+            {
+              type: "assistant",
+              sequenceNumber: sandboxEventSequenceStart,
+              message: {
+                content: [{ type: "text", text: sandboxAnswer }],
+              },
+            },
+            {
+              type: "result",
+              sequenceNumber: sandboxEventSequenceStart + 1,
+              result: sandboxAnswer,
+            },
+          ],
+        },
+        sandboxHeaders,
+        [200],
+      );
+      await webhooks.requestAgentComplete(
+        {
+          runId: first.runId,
+          exitCode: 0,
+          lastEventSequence: sandboxEventSequenceStart + 1,
+          checkpoint: {
+            cliAgentType: "pi",
+            cliAgentSessionId: first.threadId,
+            cliAgentSessionHistoryHash: h2Hash,
+          },
+        },
+        sandboxHeaders,
+        [200],
+      );
+      await waitForRunStatus(actor, first.runId, "completed");
+      await flushWaitUntilForTest();
+      await expectNoVm0ModelUsage(first.runId);
+      const firstSession = await readThreadSessionConversation(
+        context,
+        first.threadId,
+      );
+
+      const followUpPrompt = `continue the same ${route.name} credential`;
+      const followUp = await sendChatRun(actor, {
+        agentId,
+        threadId: first.threadId,
+        prompt: followUpPrompt,
+        model: "gpt-5.6-terra",
+      });
+      await waitForRunStatus(actor, followUp.runId, "completed");
+      await flushWaitUntilForTest();
+      expect(providerRequests).toHaveLength(2);
+      expect(providerRequests[1]).toMatchObject({
+        authorization: `Bearer ${initialSecret}`,
+        body: {
+          model: route.runtimeModel,
+          store: false,
+          stream: true,
+        },
+      });
+      expect(JSON.stringify(providerRequests[1]?.body)).toContain(
+        sandboxToolResult,
+      );
+      await expect(
+        readThreadSessionConversation(context, first.threadId),
+      ).resolves.toMatchObject({
+        agent_session_id: firstSession.agent_session_id,
+      });
+      await expectNoVm0ModelUsage(followUp.runId);
+
+      const rotatedSecret = `${route.type}-rotated-secret`;
+      const rotatedAt = now() + 1000;
+      const rotated = await withMockNowForTest(rotatedAt, async () => {
+        const updated = await upsertOrgModelProvider(actor, {
+          type: route.type,
+          secret: rotatedSecret,
+        });
+        expect(updated.providerId).toBe(providerId);
+        return await sendChatRun(actor, {
+          agentId,
+          threadId: first.threadId,
+          prompt: `continue after rotating the ${route.name} credential`,
+          model: "gpt-5.6-terra",
+        });
+      });
+      await waitForRunStatus(actor, rotated.runId, "completed");
+      await flushWaitUntilForTest();
+      expect(providerRequests).toHaveLength(3);
+      expect(providerRequests[2]).toMatchObject({
+        authorization: `Bearer ${rotatedSecret}`,
+        body: {
+          model: route.runtimeModel,
+          store: false,
+          stream: true,
+        },
+      });
+      const rotatedBody = JSON.stringify(providerRequests[2]?.body);
+      expect(occurrences(rotatedBody, firstPrompt)).toBe(1);
+      expect(occurrences(rotatedBody, sandboxAnswer)).toBe(1);
+      expect(occurrences(rotatedBody, followUpPrompt)).toBe(1);
+      expect(rotatedBody).not.toContain(sandboxToolResult);
+      await expect(
+        readThreadSessionConversation(context, first.threadId),
+      ).resolves.not.toMatchObject({
+        agent_session_id: firstSession.agent_session_id,
+      });
+      await expectNoVm0ModelUsage(rotated.runId);
+      expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+        "Pi API first-turn outcome",
+        expect.objectContaining({
+          productProvider: route.type,
+          dialect: "openai-responses",
+          executionOwner: "api-first",
+          handoffOwner: "sandbox",
+          outcome: "ownership_transfer",
+        }),
+      );
+      expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+        "Pi API first-turn outcome",
+        expect.objectContaining({
+          productProvider: route.type,
+          dialect: "openai-responses",
+          executionOwner: "sandbox",
+          outcome: "sandbox_completion",
+        }),
+      );
+      const piLogCalls = JSON.stringify([
+        ...context.mocks.axiomLogging.debug.mock.calls,
+        ...context.mocks.axiomLogging.warn.mock.calls,
+      ]);
+      expect(piLogCalls).not.toContain(initialSecret);
+      expect(piLogCalls).not.toContain(rotatedSecret);
+    },
+    90_000,
   );
 
   it("reuses a Codex session across DeepSeek V4 model switches", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/pi-sandbox-config.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-sandbox-config.test.ts
@@ -20,6 +20,31 @@ const OPENROUTER_TERRA_ROUTE = {
   modelKeyId: "openrouter-terra-key",
 } as const;
 
+const STANDARD_TERRA_API_KEY_ROUTES = [
+  {
+    type: "openai-api-key",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    model: "gpt-5.6-terra",
+    credentialSecretName: "OPENAI_API_KEY",
+  },
+  {
+    type: "openrouter-codex",
+    provider: "openrouter",
+    baseUrl: "https://openrouter.ai/api/v1",
+    model: "openai/gpt-5.6-terra",
+    credentialSecretName: "OPENROUTER_API_KEY",
+  },
+  {
+    type: "vercel-ai-gateway-codex",
+    provider: "openai",
+    baseUrl: "https://ai-gateway.vercel.sh/v1",
+    model: "openai/gpt-5.6-terra",
+    catalogModel: "gpt-5.6-terra",
+    credentialSecretName: "VERCEL_AI_GATEWAY_API_KEY",
+  },
+] as const;
+
 describe("Pi sandbox model configuration", () => {
   it.each(["deepseek-v4-flash", "deepseek-v4-pro"] as const)(
     "resolves direct %s through Responses",
@@ -175,6 +200,126 @@ describe("Pi sandbox model configuration", () => {
       apiKeyEnv: "OPENAI_API_KEY",
       credentialSecretName: "OPENROUTER_API_KEY",
     });
+  });
+
+  it.each(STANDARD_TERRA_API_KEY_ROUTES)(
+    "emits the strict public Responses carrier for $type",
+    (route) => {
+      expect(
+        resolvePiSandboxModelConfig({
+          type: route.type,
+          environment: {
+            OPENAI_API_KEY: "opaque-provider-placeholder",
+            ...(route.type === "openai-api-key"
+              ? {}
+              : { OPENAI_BASE_URL: route.baseUrl }),
+            OPENAI_MODEL: route.model,
+          },
+          selectedModel: "gpt-5.6-terra",
+        }),
+      ).toStrictEqual({
+        schemaVersion: 2,
+        dialect: "openai-responses",
+        transport: "sse",
+        provider: route.provider,
+        baseUrl: route.baseUrl,
+        model: route.model,
+        ...(route.type === "vercel-ai-gateway-codex"
+          ? { catalogModel: route.catalogModel }
+          : {}),
+        thinkingLevel: "low",
+        credentialBindings: [
+          {
+            kind: "api-key",
+            environment: "OPENAI_API_KEY",
+            secretName: route.credentialSecretName,
+          },
+        ],
+      });
+    },
+  );
+
+  it.each([
+    {
+      name: "fast tier",
+      type: "openai-api-key",
+      selectedModel: "gpt-5.6-terra",
+      model: "gpt-5.6-terra",
+      tier: "fast" as const,
+    },
+    {
+      name: "other logical model",
+      type: "openai-api-key",
+      selectedModel: "gpt-5.6-sol",
+      model: "gpt-5.6-sol",
+      tier: undefined,
+    },
+    {
+      name: "aliased runtime model",
+      type: "openrouter-codex",
+      selectedModel: "gpt-5.6-terra",
+      model: "gpt-5.6-terra",
+      tier: undefined,
+    },
+  ] as const)("rejects API-key Terra with $name", (testCase) => {
+    expect(
+      resolvePiSandboxModelConfig(
+        {
+          type: testCase.type,
+          environment: {
+            OPENAI_API_KEY: "opaque-provider-placeholder",
+            ...(testCase.type === "openrouter-codex"
+              ? { OPENAI_BASE_URL: "https://openrouter.ai/api/v1" }
+              : {}),
+            OPENAI_MODEL: testCase.model,
+          },
+          selectedModel: testCase.selectedModel,
+        },
+        testCase.tier,
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects mismatched API-key provider identity and endpoint", () => {
+    expect(
+      resolvePiSandboxModelConfig({
+        type: "vercel-ai-gateway-codex",
+        concreteType: "openrouter-codex",
+        environment: {
+          OPENAI_API_KEY: "opaque-provider-placeholder",
+          OPENAI_BASE_URL: "https://openrouter.ai/api/v1",
+          OPENAI_MODEL: "openai/gpt-5.6-terra",
+        },
+        selectedModel: "gpt-5.6-terra",
+      }),
+    ).toBeNull();
+  });
+
+  it.each(STANDARD_TERRA_API_KEY_ROUTES)(
+    "rejects a base URL mismatch for $type",
+    (route) => {
+      expect(
+        resolvePiSandboxModelConfig({
+          type: route.type,
+          environment: {
+            OPENAI_API_KEY: "opaque-provider-placeholder",
+            OPENAI_BASE_URL: "https://mismatched.example.com/v1",
+            OPENAI_MODEL: route.model,
+          },
+          selectedModel: "gpt-5.6-terra",
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it("rejects a direct route without its captured API-key binding", () => {
+    expect(
+      resolvePiSandboxModelConfig({
+        type: "openai-api-key",
+        environment: { OPENAI_MODEL: "gpt-5.6-terra" },
+        selectedModel: "gpt-5.6-terra",
+      }),
+    ).toBeNull();
   });
 
   it("emits the strict native Codex carrier for standard subscription Terra", () => {
@@ -362,6 +507,31 @@ describe("Pi sandbox model configuration", () => {
     },
   );
 
+  it.each(
+    STANDARD_TERRA_API_KEY_ROUTES.flatMap((route) => {
+      return (["web", "agent"] as const).map((triggerSource) => {
+        return { type: route.type, triggerSource };
+      });
+    }),
+  )(
+    "makes standard $type Terra eligible for $triggerSource chat",
+    ({ type, triggerSource }) => {
+      expect(
+        shouldUsePiExecution({
+          chatThreadId: "thread-id",
+          modelProviderType: type,
+          selectedModel: "gpt-5.6-terra",
+          codexServiceTier: undefined,
+          builtInModelRuntimeRoute: undefined,
+          triggerSource,
+          featureSwitchContext: {
+            overrides: { [FeatureSwitchKey.PiLoop]: true },
+          },
+        }),
+      ).toBeTruthy();
+    },
+  );
+
   it.each(["web", "agent"] as const)(
     "makes standard subscription Terra eligible for %s chat",
     (triggerSource) => {
@@ -508,14 +678,14 @@ describe("Pi sandbox model configuration", () => {
       codexFastModeEnabled: true,
     },
     {
-      name: "Terra BYOK",
+      name: "API-key Terra with Pi feature switch off",
       modelProviderType: "openai-api-key",
       selectedModel: "gpt-5.6-terra",
       codexServiceTier: undefined,
-      builtInModelRuntimeRoute: OPENAI_TERRA_ROUTE,
+      builtInModelRuntimeRoute: undefined,
       triggerSource: "web" as const,
       chatThreadId: "thread-id",
-      piLoopEnabled: true,
+      piLoopEnabled: false,
       codexFastModeEnabled: true,
     },
     {

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -59,6 +59,7 @@ import {
   admitPiMemoryStage1Candidate,
   type PiMemoryStage1Admission,
 } from "./pi-memory-stage1-candidate.service";
+import { isStandardTerraApiKeyPiProviderType } from "./pi-sandbox-config";
 
 type WebhookCompleteBody = z.infer<
   typeof webhookCompleteContract.complete.body
@@ -69,6 +70,7 @@ interface CompleteAgentRunInput {
   readonly auth: SandboxAuth;
   readonly body: WebhookCompleteBody;
   readonly allowCheckpointlessSuccess?: boolean;
+  readonly executionOwner?: "api-first";
 }
 
 export interface TerminalSideEffectsInput {
@@ -166,6 +168,40 @@ type CompletionTransactionResult =
   | { readonly kind: "committed"; readonly commit: CompletionCommit };
 
 const L = logger("webhook:complete");
+
+function logStandardTerraApiKeyPiSandboxOutcome(
+  input: CompleteAgentRunInput,
+  commit: CompletionCommit,
+): void {
+  if (
+    input.executionOwner === "api-first" ||
+    commit.run.launchSnapshot?.framework !== "pi" ||
+    !isStandardTerraApiKeyPiProviderType(commit.run.modelProvider)
+  ) {
+    return;
+  }
+  const details = {
+    runId: input.body.runId,
+    productProvider: commit.run.modelProvider,
+    dialect: "openai-responses",
+    executionOwner: "sandbox",
+    outcome:
+      commit.responseStatus === "completed"
+        ? "sandbox_completion"
+        : "terminal_failure",
+    reason:
+      commit.transitionFailureReason ??
+      (commit.responseStatus === "completed"
+        ? "settled_session"
+        : "sandbox_failure"),
+    ownershipStage: "sandbox",
+  } as const;
+  if (commit.responseStatus === "completed") {
+    L.debug("Pi API first-turn outcome", details);
+    return;
+  }
+  L.warn("Pi API first-turn outcome", details);
+}
 
 function shouldSuppressKnownFailureLog(
   run: RunRecord,
@@ -945,6 +981,7 @@ export const completeAgentRun$ = command(
             : {}),
         },
       });
+      logStandardTerraApiKeyPiSandboxOutcome(input, commit);
       if (commit.responseStatus === "completed") {
         L.debug("Run completed successfully", { runId: input.body.runId });
       } else if (commit.transitionFailureKind === "missing-checkpoint") {

--- a/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-session-continuity.service.ts
@@ -9,6 +9,7 @@ import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentSessions } from "@okouai/db/schema/agent-session";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { conversations } from "@okouai/db/schema/conversation";
+import { modelProviders } from "@okouai/db/schema/model-provider";
 import {
   modelProviderConnections,
   modelProviderSurfaces,
@@ -21,6 +22,7 @@ import {
 } from "../../lib/db-structured-result";
 import type { Db, ReadonlyDb } from "../external/db";
 import { hasIncompatibleBuiltInModelRuntimeRoute } from "./built-in-model-runtime-route.service";
+import { isStandardTerraApiKeyPiProviderType } from "./pi-sandbox-config";
 
 export interface ChatThreadSessionRoute {
   readonly selectedModel: string | null;
@@ -289,6 +291,68 @@ function customSurfaceRouteMayBeInUse(args: {
   );
 }
 
+function isStandardTerraApiKeyPiRoute(route: ChatThreadSessionRoute): boolean {
+  return (
+    route.cliAgentType === "pi" &&
+    route.selectedModel === "gpt-5.6-terra" &&
+    isStandardTerraApiKeyPiProviderType(route.modelProvider)
+  );
+}
+
+function standardTerraApiKeyPiRouteIdentityChanged(args: {
+  readonly previousRoute: ChatThreadSessionRoute;
+  readonly nextRoute: ChatThreadSessionRoute;
+}): boolean {
+  if (
+    !isStandardTerraApiKeyPiRoute(args.previousRoute) &&
+    !isStandardTerraApiKeyPiRoute(args.nextRoute)
+  ) {
+    return false;
+  }
+  return (
+    args.previousRoute.modelProvider !== args.nextRoute.modelProvider ||
+    args.previousRoute.modelProviderId !== args.nextRoute.modelProviderId ||
+    args.previousRoute.modelRuntimeProvider !==
+      args.nextRoute.modelRuntimeProvider ||
+    args.previousRoute.modelRuntimeModel !== args.nextRoute.modelRuntimeModel
+  );
+}
+
+async function standardTerraApiKeyPiRouteRevisionChanged(args: {
+  readonly db: Db | ReadonlyDb;
+  readonly orgId: string;
+  readonly previousRoute: ChatThreadSessionRoute;
+  readonly nextRoute: ChatThreadSessionRoute;
+  readonly previousRunCreatedAt: Date | null;
+}): Promise<boolean> {
+  const productProvider = args.nextRoute.modelProvider;
+  if (
+    !isStandardTerraApiKeyPiRoute(args.previousRoute) ||
+    !isStandardTerraApiKeyPiRoute(args.nextRoute) ||
+    !isStandardTerraApiKeyPiProviderType(productProvider) ||
+    args.previousRoute.modelProvider !== args.nextRoute.modelProvider ||
+    args.previousRoute.modelProviderId === null ||
+    args.previousRoute.modelProviderId !== args.nextRoute.modelProviderId ||
+    args.previousRunCreatedAt === null
+  ) {
+    return false;
+  }
+  const [provider] = await args.db
+    .select({ updatedAt: modelProviders.updatedAt })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.id, args.previousRoute.modelProviderId),
+        eq(modelProviders.orgId, args.orgId),
+        eq(modelProviders.type, productProvider),
+      ),
+    )
+    .limit(1);
+  return (
+    provider !== undefined && provider.updatedAt > args.previousRunCreatedAt
+  );
+}
+
 function shouldRotateCanonicalSession(args: {
   readonly previousRoute: ChatThreadSessionRoute;
   readonly nextRoute: ChatThreadSessionRoute;
@@ -299,6 +363,12 @@ function shouldRotateCanonicalSession(args: {
       next: args.nextRoute,
     })
   ) {
+    return true;
+  }
+  if (standardTerraApiKeyPiRouteIdentityChanged(args)) {
+    // Public Responses state belongs to the exact product route and captured
+    // provider credential. Never cross that boundary with provider-private
+    // response, cache, or pending-tool state.
     return true;
   }
   const providerIdChanged =
@@ -346,7 +416,15 @@ async function shouldRotateResolvedSession(args: {
     nextModelProviderId: args.nextRoute.modelProviderId,
     previousRunCreatedAt: args.previousRunCreatedAt,
   });
-  return routeConfigurationChanged
+  const apiKeyRouteRevisionChanged =
+    await standardTerraApiKeyPiRouteRevisionChanged({
+      db: args.db,
+      orgId: args.orgId,
+      previousRoute: args.previousRoute,
+      nextRoute: args.nextRoute,
+      previousRunCreatedAt: args.previousRunCreatedAt,
+    });
+  return routeConfigurationChanged || apiKeyRouteRevisionChanged
     ? true
     : shouldRotateCanonicalSession({
         previousRoute: args.previousRoute,

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -11,6 +11,7 @@ import {
   type StoredExecutionContext,
 } from "@okouai/api-contracts/contracts/runners";
 import type { RunFailureReasonToken } from "@okouai/api-contracts/contracts/run-failure-reasons";
+import { modelProviderTypeSchema } from "@okouai/api-contracts/contracts/model-providers";
 import { activeInputDeliveries } from "@okouai/db/schema/active-input-delivery";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { blobs } from "@okouai/db/schema/blob";
@@ -637,6 +638,40 @@ type ApiFirstTurnExecutionContext =
 type ApiFirstTurnLaunchConfig =
   ApiFirstTurnExecutionContext["piLaunchConfig"]["apiFirstTurn"];
 
+function piApiFirstTurnOutcomeTelemetry(
+  executionContext: ApiFirstTurnExecutionContext,
+) {
+  const config = executionContext.piModelConfig;
+  const dialect =
+    "schemaVersion" in config
+      ? config.dialect
+      : (config.api ?? "openai-responses");
+  const providerTypes = new Set(
+    ("schemaVersion" in config ? config.credentialBindings : [])
+      .map((binding) => {
+        const providerType =
+          executionContext.secretConnectorMap?.[binding.secretName];
+        const metadata =
+          executionContext.secretConnectorMetadataMap?.[binding.secretName];
+        const parsed = modelProviderTypeSchema.safeParse(providerType);
+        return parsed.success &&
+          metadata?.sourceType === "model-provider" &&
+          metadata.metadataKey === parsed.data
+          ? parsed.data
+          : null;
+      })
+      .filter((providerType) => {
+        return providerType !== null;
+      }),
+  );
+  const [productProvider] = providerTypes;
+  return {
+    dialect,
+    executionOwner: "api-first" as const,
+    ...(providerTypes.size === 1 && productProvider ? { productProvider } : {}),
+  };
+}
+
 interface ApiFirstTurnCommitIdentity {
   readonly baseSessionId: string;
   readonly baseSessionSha256: string | null;
@@ -1084,6 +1119,7 @@ async function observeDiscardedProviderResult(
     await recordApiFirstTurnUsage(args, late.value);
     L.warn("Pi API first-turn outcome", {
       runId: args.activation.runId,
+      ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
       outcome: "discarded_late_provider_result",
       reason: "aborted_execution",
       ownershipStage: ownership.stage,
@@ -1573,6 +1609,7 @@ const finalizeCompleteTurn$ = command(async function finalizeCompleteTurn(
     completeAgentRun$,
     {
       auth: prepared.auth,
+      executionOwner: "api-first",
       body: {
         runId: args.activation.runId,
         exitCode: 0,
@@ -1685,6 +1722,8 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
       );
       L.debug("Pi API first-turn outcome", {
         runId: args.activation.runId,
+        ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
+        handoffOwner: "sandbox",
         outcome: "ownership_transfer",
         reason: hasActiveInput
           ? transferMode === "settled-session-continuation"
@@ -1707,6 +1746,7 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
     stopPreparedSandbox(args.activation, "completed");
     L.debug("Pi API first-turn outcome", {
       runId: args.activation.runId,
+      ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
       outcome: "api_completion",
       reason: "settled_session",
       ownershipStage: "provider-may-have-started",
@@ -1805,11 +1845,12 @@ async function canonicalApiFirstTurnCancellationWon(
 }
 
 function logCanonicalApiFirstTurnCancellation(
-  runId: string,
+  args: ApiFirstTurnContext,
   ownership: PiApiFirstTurnOwnership,
 ): void {
   L.debug("Pi API first-turn outcome", {
-    runId,
+    runId: args.activation.runId,
+    ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
     outcome: "canonical_cancellation",
     reason:
       ownership.stage === "pre-provider"
@@ -1832,7 +1873,7 @@ const failApiFirstTurn$ = command(async function failApiFirstTurn(
       args.activation.runId,
     );
     if (state?.status === "cancelled") {
-      logCanonicalApiFirstTurnCancellation(args.activation.runId, ownership);
+      logCanonicalApiFirstTurnCancellation(args, ownership);
       return undefined;
     }
     if (!state || (state.status !== "pending" && state.status !== "running")) {
@@ -1846,6 +1887,7 @@ const failApiFirstTurn$ = command(async function failApiFirstTurn(
           orgId: args.activation.orgId,
           runId: args.activation.runId,
         },
+        executionOwner: "api-first",
         body: {
           runId: args.activation.runId,
           exitCode: 1,
@@ -1913,6 +1955,8 @@ export const runPiApiFirstTurn$ = command(
       if (fallback.ok) {
         L.debug("Pi API first-turn outcome", {
           runId: activation.runId,
+          ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
+          handoffOwner: "sandbox",
           outcome:
             sandboxFirstReason === "active_input"
               ? "ownership_transfer"
@@ -1938,16 +1982,18 @@ export const runPiApiFirstTurn$ = command(
       ) {
         L.warn("Pi API first-turn outcome", {
           runId: activation.runId,
+          ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
           outcome: "discarded_late_provider_result",
           reason: "canonical_cancellation",
           ownershipStage: ownership.stage,
         });
       }
-      logCanonicalApiFirstTurnCancellation(activation.runId, ownership);
+      logCanonicalApiFirstTurnCancellation(context, ownership);
       return undefined;
     }
     L.warn("Pi API first-turn outcome", {
       runId: activation.runId,
+      ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
       outcome: "terminal_failure",
       reason: failure.code,
       ownershipStage: ownership.stage,

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -40,6 +40,60 @@ interface PiRuntimeContract {
 
 type PiCatalogProvider = "deepseek" | "openai";
 
+const STANDARD_TERRA_API_KEY_PI_ROUTES = {
+  "openai-api-key": {
+    productProviderType: "openai-api-key",
+    provider: "openai",
+    model: "gpt-5.6-terra",
+    endpoint: getModelProviderPiEndpoint("openai-api-key", "openai-responses"),
+    credentialSecretName: "OPENAI_API_KEY",
+  },
+  "openrouter-codex": {
+    productProviderType: "openrouter-codex",
+    provider: "openrouter",
+    model: "openai/gpt-5.6-terra",
+    endpoint: getModelProviderPiEndpoint(
+      "openrouter-codex",
+      "openai-responses",
+    ),
+    credentialSecretName: "OPENROUTER_API_KEY",
+  },
+  "vercel-ai-gateway-codex": {
+    productProviderType: "vercel-ai-gateway-codex",
+    provider: "openai",
+    catalogModel: "gpt-5.6-terra",
+    model: "openai/gpt-5.6-terra",
+    endpoint: getModelProviderPiEndpoint(
+      "vercel-ai-gateway-codex",
+      "openai-responses",
+    ),
+    credentialSecretName: "VERCEL_AI_GATEWAY_API_KEY",
+  },
+} as const;
+
+type StandardTerraApiKeyPiProviderType =
+  keyof typeof STANDARD_TERRA_API_KEY_PI_ROUTES;
+
+export function isStandardTerraApiKeyPiProviderType(
+  value: string | null | undefined,
+): value is StandardTerraApiKeyPiProviderType {
+  return (
+    value !== null &&
+    value !== undefined &&
+    Object.hasOwn(STANDARD_TERRA_API_KEY_PI_ROUTES, value)
+  );
+}
+
+function standardTerraApiKeyPiRoute(
+  value: string | null | undefined,
+):
+  | (typeof STANDARD_TERRA_API_KEY_PI_ROUTES)[StandardTerraApiKeyPiProviderType]
+  | null {
+  return isStandardTerraApiKeyPiProviderType(value)
+    ? STANDARD_TERRA_API_KEY_PI_ROUTES[value]
+    : null;
+}
+
 function piCatalogProvider(
   selectedModel: string | null | undefined,
 ): PiCatalogProvider | null {
@@ -117,7 +171,9 @@ export function shouldUsePiExecution(args: {
   const isPiModelProvider =
     isBuiltInModelProviderType(args.modelProviderType) ||
     args.modelProviderType === "custom-openai-responses" ||
-    (args.modelProviderType === "codex-oauth-token" && isStandardTerra);
+    (args.modelProviderType === "codex-oauth-token" && isStandardTerra) ||
+    (standardTerraApiKeyPiRoute(args.modelProviderType) !== null &&
+      isStandardTerra);
   return (
     args.chatThreadId !== undefined &&
     isWebChatTriggerSource(args.triggerSource) &&
@@ -236,6 +292,68 @@ function resolveCustomGatewayPiModelConfig(
     : null;
 }
 
+function resolveStandardTerraApiKeyPiModelConfig(
+  provider: PiModelProviderConfigInput,
+  codexServiceTier: "fast" | undefined,
+): PiModelConfig | null {
+  const route = standardTerraApiKeyPiRoute(provider.type);
+  if (
+    !route ||
+    provider.selectedModel !== "gpt-5.6-terra" ||
+    codexServiceTier !== undefined ||
+    provider.inlineFirewall === true ||
+    provider.credentialHeader !== undefined ||
+    (provider.concreteType !== undefined &&
+      provider.concreteType !== route.productProviderType) ||
+    !route.endpoint ||
+    getSecretNameForType(route.productProviderType) !==
+      route.credentialSecretName ||
+    provider.environment.OPENAI_MODEL !== route.model ||
+    !provider.environment.OPENAI_API_KEY?.trim()
+  ) {
+    return null;
+  }
+  const configuredBaseUrl = provider.environment.OPENAI_BASE_URL;
+  if (
+    configuredBaseUrl &&
+    normalizedBaseUrl(configuredBaseUrl) !==
+      normalizedBaseUrl(route.endpoint.baseUrl)
+  ) {
+    return null;
+  }
+  const config = {
+    schemaVersion: PI_MODEL_CONFIG_CURRENT_GENERATION,
+    dialect: "openai-responses",
+    transport: "sse",
+    provider: route.provider,
+    baseUrl: route.endpoint.baseUrl,
+    model: route.model,
+    ...(route.productProviderType === "vercel-ai-gateway-codex"
+      ? { catalogModel: route.catalogModel }
+      : {}),
+    thinkingLevel: "low",
+    credentialBindings: [
+      {
+        kind: "api-key",
+        environment: "OPENAI_API_KEY",
+        secretName: route.credentialSecretName,
+      },
+    ],
+  } satisfies PiModelConfig;
+  return isPiAgentModelSupported({
+    provider: config.provider,
+    baseUrl: config.baseUrl,
+    model: config.model,
+    ...(config.catalogModel ? { catalogModel: config.catalogModel } : {}),
+    apiKey: "sandbox-secret",
+    dialect: config.dialect,
+    transport: config.transport,
+    thinkingLevel: config.thinkingLevel,
+  })
+    ? config
+    : null;
+}
+
 export function resolvePiSandboxModelConfig(
   provider: PiModelProviderConfigInput | null,
   codexServiceTier: "fast" | undefined = undefined,
@@ -248,6 +366,9 @@ export function resolvePiSandboxModelConfig(
   }
   if (provider.type === "custom-openai-responses") {
     return resolveCustomGatewayPiModelConfig(provider, codexServiceTier);
+  }
+  if (isStandardTerraApiKeyPiProviderType(provider.type)) {
+    return resolveStandardTerraApiKeyPiModelConfig(provider, codexServiceTier);
   }
   if (provider.inlineFirewall) {
     return null;


### PR DESCRIPTION
## Summary

- activate standard Terra PiLoop routing for OpenAI API key, OpenRouter Codex, and Vercel AI Gateway Codex with strict generation-2 Responses/SSE contracts
- preserve API-first to Sandbox ownership and exact credential continuity, including canonical Pi session rotation when the product route or provider credential revision changes
- add credential-free outcome telemetry and end-to-end coverage for exact endpoints, runner-generation gating, H1 to H2 handoff, zero VM0 billing, and secret isolation

## Testing

- `pnpm --filter api check-types`
- `pnpm knip`
- targeted ESLint and Oxlint for all changed files
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm exec vitest run src/signals/services/__tests__/pi-sandbox-config.test.ts src/signals/routes/__tests__/chat-events.bdd.test.ts -t "Pi sandbox model configuration|API-key Terra through API-first"` (70 passed)

Closes #31705
Parent: #31373