### PR TITLE
fix(chat): skip empty event tails in batch catch-up

### DIFF
--- a/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
@@ -505,6 +505,47 @@ test("Rebuild chat data after its saved cursor expires", async () => {
   }
 });
 
+test("Report only non-empty tails from a batched chat catch-up", async () => {
+  const { runtime } = startRuntime();
+  const unchangedThreadId = crypto.randomUUID();
+  const updatedThreadId = crypto.randomUUID();
+  const updatedRow = chatEventRow(updatedThreadId, 1);
+  context.mocks.api(chatThreadEventsContract.catchUp, ({ body, respond }) => {
+    expect(body).toStrictEqual([
+      [unchangedThreadId, 0],
+      [updatedThreadId, 0],
+    ]);
+    return respond(200, {
+      events: {
+        [unchangedThreadId]: [],
+        [updatedThreadId]: [updatedRow],
+      },
+      notFoundThreads: [],
+    });
+  });
+
+  await expect(
+    runtime.catchUpChatEvents(
+      [unchangedThreadId, updatedThreadId],
+      context.signal,
+    ),
+  ).resolves.toStrictEqual([updatedThreadId]);
+  await expect(
+    queryRuntime(runtime, {
+      dataKey: chatEventKey(unchangedThreadId),
+      afterSeqId: null,
+      consistency: "cache-only",
+    }),
+  ).resolves.toStrictEqual([]);
+  await expect(
+    queryRuntime(runtime, {
+      dataKey: chatEventKey(updatedThreadId),
+      afterSeqId: null,
+      consistency: "cache-only",
+    }),
+  ).resolves.toStrictEqual([updatedRow]);
+});
+
 test("Rebuild a cached chat when batched catch-up cannot continue its cursor", async () => {
   const { runtime } = startRuntime();
   const dataKey = chatEventKey(crypto.randomUUID());

--- a/turbo/apps/platform/src/shared-database/worker-runtime.ts
+++ b/turbo/apps/platform/src/shared-database/worker-runtime.ts
@@ -359,19 +359,20 @@ export class SharedDatabaseWorkerRuntime {
 
     const writes: ChatEventBatchWrite[] = Object.entries(
       response.body.events,
-    ).map(([threadId, rows]) => {
+    ).flatMap(([threadId, rows]) => {
       const last = rows.at(-1);
-      return {
-        dataKey: scopeSharedDatabaseDataKey(
-          { kind: "chat-event", threadId },
-          this.identity,
-        ),
-        rows,
-        cursor:
-          last === undefined
-            ? requireChatEventCursor(cursors, threadId)
-            : { lastEventId: last.id, lastSeqId: last.seqId },
-      };
+      return last === undefined
+        ? []
+        : [
+            {
+              dataKey: scopeSharedDatabaseDataKey(
+                { kind: "chat-event", threadId },
+                this.identity,
+              ),
+              rows,
+              cursor: { lastEventId: last.id, lastSeqId: last.seqId },
+            },
+          ];
     });
     const batchWritten = await this.persistChatEventBatch(writes, signal);
     const rebuiltThreadIds = await Promise.all(


### PR DESCRIPTION
## Summary

- skip empty per-thread tails before batched ChatEvent IndexedDB writes
- report only thread IDs that actually persisted new events, preventing no-op invalidation broadcasts
- keep expired-cursor snapshot rebuild behavior unchanged

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/shared-database/__tests__/worker-runtime.test.ts` (8 tests)

## Fallbacks

- None.
