### PR TITLE
refactor: remove office preview response compatibility

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -1096,7 +1096,7 @@ describe("createApp", () => {
   });
 
   describe("web client compatibility", () => {
-    it("force-upgrades app clients below the failure-reason reader floor before route matching", async () => {
+    it("force-upgrades app clients below the Office preview reader floor before route matching", async () => {
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,
@@ -1105,11 +1105,11 @@ describe("createApp", () => {
         method: "DELETE",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.829.5",
+          [CLIENT_VERSION_HEADER]: "0.830.0",
         },
       });
 
-      expect(MINIMUM_WEB_CLIENT_VERSION).toBe("0.830.0");
+      expect(MINIMUM_WEB_CLIENT_VERSION).toBe("0.831.0");
       expect(response.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
       await expect(response.json()).resolves.toStrictEqual({
         error: "Client update required",

--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.830.0"
+  "minimumSupportedVersion": "0.831.0"
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feature-switches.test.ts
@@ -16,23 +16,6 @@ function client() {
 }
 
 describe("/api/feature-switches", () => {
-  it("keeps Office preview enabled for App clients during switch cleanup", async () => {
-    createRouteMocks(context).clerk.session(
-      "user_office_preview_compatibility_test",
-      "org_office_preview_compatibility_test",
-      "org:member",
-    );
-
-    const current = await accept(
-      client().get({
-        headers: { authorization: "Bearer clerk-session" },
-      }),
-      [200],
-    );
-
-    expect(current.body.effectiveSwitches.officeDocumentPreview).toBeTruthy();
-  });
-
   it("persists and activates a user override for a non-staff org", async () => {
     createRouteMocks(context).clerk.session(
       "user_nonstaff_feature_switch_test",

--- a/turbo/apps/api/src/signals/routes/feature-switches.ts
+++ b/turbo/apps/api/src/signals/routes/feature-switches.ts
@@ -20,8 +20,6 @@ const featureSwitchesAuthOptions = {
   missingOrganizationStatus: 401,
 } as const;
 
-const OFFICE_DOCUMENT_PREVIEW_COMPATIBILITY_KEY = "officeDocumentPreview";
-
 function featureSwitchResponseBody(params: {
   readonly orgId: string;
   readonly userId: string;
@@ -34,14 +32,7 @@ function featureSwitchResponseBody(params: {
   });
   return {
     switches: params.switches,
-    effectiveSwitches: {
-      ...registeredEffectiveSwitches,
-      // The API deploys before the App, whose old builds can remain active for
-      // about two days and treat a missing value as false. Remove this bridge
-      // after the client-version floor excludes every build that reads the
-      // switch; tracked by vm0-ai/vm0#31431.
-      [OFFICE_DOCUMENT_PREVIEW_COMPATIBILITY_KEY]: true,
-    },
+    effectiveSwitches: registeredEffectiveSwitches,
   };
 }
 


### PR DESCRIPTION
## Summary

- stop injecting the retired `officeDocumentPreview` key into API feature-switch responses
- restore `effectiveSwitches` to the registered feature-switch states only
- remove the integration test that existed solely for the expired response bridge

## Terminal state

- State: `fully-rolled-out`
- Basis: #31414 permanently enabled supported Office document previews and removed the typed feature switch. Ethan confirmed in the current request on 2026-09-04 that the #31431 compatibility removal gate is now satisfied.
- The temporary API bridge was introduced on `main` by commit [`e0dc666e4b`](https://github.com/vm0-ai/vm0/commit/e0dc666e4b7f3daefdf8204e96ec19f58f09fe08) in #31414.

## Behavior archaeology

- Before `e0dc666e4b`, `featureSwitchResponseBody` returned `getAllFeatureStates(...)` directly as `effectiveSwitches`.
- `e0dc666e4b` wrapped those states and appended raw `officeDocumentPreview: true` only to protect older App builds during the API-first rollout.
- This cleanup restores the pre-bridge response shape while preserving all later route/export changes on current `main`.
- Permanent Office preview behavior remains unconditional in the App. Registered feature switches and user overrides continue to work unchanged.

## Cleanup details

- removed `OFFICE_DOCUMENT_PREVIEW_COMPATIBILITY_KEY`
- removed the raw `officeDocumentPreview: true` response entry and rollout comment
- deleted the compatibility-only route integration test
- retained the existing integration coverage for persisted user overrides and effective registered states

## Keyword and Knip audit

- Zero remaining compatibility hits: `officeDocumentPreview`, `FeatureSwitchKey.OfficeDocumentPreview`, `officeDocumentPreviewEnabled`, `OFFICE_DOCUMENT_PREVIEW_COMPATIBILITY_KEY`, the compatibility fixture IDs, and the #31431 rollout comment.
- Expected permanent behavior reviewed and retained: `OfficeDocumentPreview`, `isOfficeFilePreview`, `officeFilePreviewKind`, `resolveOfficeDocumentViewerBaseUrl`, and `view.officeapps.live.com`.
- Knip baseline: exit 0 with 53 existing configuration hints and no unused-code or dependency findings.
- Knip after cleanup: exit 0 with the identical 53 configuration hints and no cleanup-caused orphan findings.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped` (14 tasks passed)
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'` (13 tasks passed)
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres pnpm --filter api exec vitest run src/signals/routes/__tests__/feature-switches.test.ts` (1 passed)
- `pnpm knip` before and after cleanup
- `git diff --check`
- commit subject validated with `pnpm exec commitlint`

After validation, the branch was rebased onto three newer `main` commits that did not touch the changed source or test. The targeted integration test passed again on the rebased head. The full local Vitest suite was not run per repository instructions; the PR pipeline owns the complete required suite.

Closes #31431
