### PR TITLE
ci: restore standalone pnpm audit check

### DIFF
--- a/.github/scripts/tests/implicit-npm-audit-test.sh
+++ b/.github/scripts/tests/implicit-npm-audit-test.sh
@@ -52,8 +52,7 @@ workflow_paths.each do |path|
   workflow_environment = document.fetch("env", {})
   relative_path = path.delete_prefix("#{repo_root}/")
 
-  if relative_path != expected_audit_path &&
-      audit_setting(workflow_environment) != "false"
+  if audit_setting(workflow_environment) != "false"
     violations << "#{relative_path} must set top-level npm_config_audit=false"
   end
 

--- a/.github/scripts/tests/implicit-npm-audit-test.sh
+++ b/.github/scripts/tests/implicit-npm-audit-test.sh
@@ -44,6 +44,7 @@ end
 
 violations = []
 explicit_audit_paths = []
+expected_audit_path = ".github/workflows/security.yml"
 
 workflow_paths = Dir[File.join(repo_root, ".github/workflows/*.{yml,yaml}")]
 workflow_paths.each do |path|
@@ -51,7 +52,8 @@ workflow_paths.each do |path|
   workflow_environment = document.fetch("env", {})
   relative_path = path.delete_prefix("#{repo_root}/")
 
-  if audit_setting(workflow_environment) != "false"
+  if relative_path != expected_audit_path &&
+      audit_setting(workflow_environment) != "false"
     violations << "#{relative_path} must set top-level npm_config_audit=false"
   end
 
@@ -138,8 +140,8 @@ script_paths.each do |path|
   end
 end
 
-unless explicit_audit_paths.empty?
-  violations << "explicit dependency audits are disabled: #{explicit_audit_paths.uniq.sort.join(", ")}"
+unless explicit_audit_paths.uniq == [expected_audit_path]
+  violations << "explicit dependency audit must remain owned only by #{expected_audit_path}"
 end
 
 unless violations.empty?

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -171,10 +171,10 @@ jobs:
       run:
         working-directory: turbo
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22.19.0
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -159,6 +159,42 @@ jobs:
         with:
           category: codeql
 
+  pnpm-audit:
+    needs: [detect-release]
+    name: pnpm audit (SCA)
+    # Skip for release-please PRs, commits, and merge queue entries
+    if: needs.detect-release.outputs.skip != 'true'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: turbo
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.19.0
+
+      - name: Install pnpm
+        run: corepack enable pnpm
+
+      - name: Run pnpm audit
+        run: |
+          set -o pipefail
+          echo "## pnpm audit results" >> "$GITHUB_STEP_SUMMARY"
+          # --ignore-registry-errors: temporary workaround for transient npm registry
+          # connectivity failures in CI that cause false audit failures unrelated to
+          # actual vulnerability findings.
+          pnpm audit --prod --ignore-registry-errors 2>&1 | tee audit-output.txt
+          {
+            echo '```'
+            cat audit-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   actionlint:
     needs: [detect-release]
     name: Workflow Lint
@@ -343,6 +379,7 @@ jobs:
       - pr-title
       - semgrep
       - codeql
+      - pnpm-audit
       - actionlint
       - release-workspace-coverage
       - gitleaks
@@ -384,6 +421,7 @@ jobs:
           else
             check_result "codeql" "${{ needs.codeql.result }}"
           fi
+          check_result "pnpm-audit" "${{ needs.pnpm-audit.result }}"
           check_result "actionlint" "${{ needs.actionlint.result }}"
           check_result "gitleaks" "${{ needs.gitleaks.result }}"
 


### PR DESCRIPTION
## Summary

- Restore the standalone `pnpm audit (SCA)` job in the security workflow.
- Include it in the security CI gate.
- Restore the workflow test that enforces a single explicit dependency-audit owner.
- Keep install-time `npm_config_audit=false` safeguards unchanged in all workflows.

## Validation

- `pnpm audit --prod --ignore-registry-errors` with `npm_config_audit=false`: no known vulnerabilities found.
- `.github/scripts/tests/implicit-npm-audit-test.sh`
- Security workflow YAML parse
- `git diff --check`