### PR TITLE
refactor: consolidate desktop recording under intro video switch

### DIFF
--- a/turbo/apps/desktop/src/desktop-developer-tools-controller.test.ts
+++ b/turbo/apps/desktop/src/desktop-developer-tools-controller.test.ts
@@ -66,14 +66,13 @@ describe("DeveloperToolsController", () => {
     expect(setFilesystemPluginFeatureEnabled).toHaveBeenCalledWith(true);
   });
 
-  it("enables native screen recording when both required switches are on", async () => {
+  it("enables native screen recording when intro video is on", async () => {
     const { controller, setScreenRecordingFeatureEnabled } = createController(
       async () =>
         jsonResponse({
           effectiveSwitches: {
             _debug: false,
             introVideo: true,
-            desktopScreenRecording: true,
           },
         }),
     );
@@ -86,22 +85,16 @@ describe("DeveloperToolsController", () => {
     expect(controller.getState().available).toBeFalsy();
   });
 
-  it.each([
-    { introVideo: false, desktopScreenRecording: true },
-    { introVideo: true, desktopScreenRecording: false },
-  ])(
-    "keeps native screen recording off when a required switch is off",
-    async (effectiveSwitches) => {
-      const { controller, setScreenRecordingFeatureEnabled } = createController(
-        async () => jsonResponse({ effectiveSwitches }),
-      );
+  it("keeps native screen recording off when intro video is off", async () => {
+    const { controller, setScreenRecordingFeatureEnabled } = createController(
+      async () => jsonResponse({ effectiveSwitches: { introVideo: false } }),
+    );
 
-      controller.requestRefresh();
-      await vi.waitFor(() => {
-        expect(setScreenRecordingFeatureEnabled).toHaveBeenCalledWith(false);
-      });
-    },
-  );
+    controller.requestRefresh();
+    await vi.waitFor(() => {
+      expect(setScreenRecordingFeatureEnabled).toHaveBeenCalledWith(false);
+    });
+  });
 
   it("releases screen recording when the session is unauthorized", async () => {
     const responses = [
@@ -109,7 +102,6 @@ describe("DeveloperToolsController", () => {
         effectiveSwitches: {
           _debug: true,
           introVideo: true,
-          desktopScreenRecording: true,
         },
       }),
       new Response(null, { status: 401 }),
@@ -175,7 +167,6 @@ describe("DeveloperToolsController", () => {
           _debug: true,
           computerUseDesktopPlugins: true,
           introVideo: true,
-          desktopScreenRecording: true,
         },
       }),
       new Response(null, { status: 500 }),

--- a/turbo/apps/desktop/src/desktop-developer-tools-controller.ts
+++ b/turbo/apps/desktop/src/desktop-developer-tools-controller.ts
@@ -5,7 +5,6 @@ const OKOU_DEBUG_FEATURE_SWITCH_KEY = "_debug";
 const COMPUTER_USE_DESKTOP_PLUGINS_FEATURE_SWITCH_KEY =
   "computerUseDesktopPlugins";
 const INTRO_VIDEO_FEATURE_SWITCH_KEY = "introVideo";
-const DESKTOP_SCREEN_RECORDING_FEATURE_SWITCH_KEY = "desktopScreenRecording";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -33,9 +32,8 @@ interface DeveloperToolsControllerOptions {
   /** Propagates the `computerUseDesktopPlugins` switch to the plugin manager. */
   readonly setFilesystemPluginFeatureEnabled: (enabled: boolean) => void;
   /**
-   * Propagates the effective intro-video recording availability to the
-   * recorder. Turning either required switch off must release the native
-   * helper, not just hide the entry point.
+   * Propagates the `introVideo` switch to the recorder. Turning it off must
+   * release the native helper, not just hide the entry point.
    */
   readonly setScreenRecordingFeatureEnabled: (enabled: boolean) => void;
   /** Zero-arg "something changed" signal; defaults to a no-op. */
@@ -142,11 +140,7 @@ export class DeveloperToolsController {
       ),
     );
     this.setScreenRecordingFeatureEnabled(
-      featureSwitchEnabledFromBody(body, INTRO_VIDEO_FEATURE_SWITCH_KEY) &&
-        featureSwitchEnabledFromBody(
-          body,
-          DESKTOP_SCREEN_RECORDING_FEATURE_SWITCH_KEY,
-        ),
+      featureSwitchEnabledFromBody(body, INTRO_VIDEO_FEATURE_SWITCH_KEY),
     );
   }
 }

--- a/turbo/apps/desktop/src/desktop-recorder-controller.ts
+++ b/turbo/apps/desktop/src/desktop-recorder-controller.ts
@@ -90,7 +90,7 @@ export class DesktopRecorderController {
 
   /**
    * Applies the effective native recording availability resolved from the
-   * `introVideo` and `desktopScreenRecording` feature switches.
+   * `introVideo` feature switch.
    *
    * Turning it off releases the native helper rather than only hiding the
    * entry point. An in-flight recording is stopped first so the file on disk is

--- a/turbo/apps/platform/src/signals/okou-page/desktop-recording-handoff.ts
+++ b/turbo/apps/platform/src/signals/okou-page/desktop-recording-handoff.ts
@@ -88,10 +88,7 @@ export function hasDesktopRecordingHandoff(params: URLSearchParams): boolean {
 export function desktopRecordingHandoffFeatureEnabled(
   switches: Partial<Record<FeatureSwitchKey, boolean>>,
 ): boolean {
-  return (
-    (switches[FeatureSwitchKey.IntroVideo] ?? false) &&
-    (switches[FeatureSwitchKey.DesktopScreenRecording] ?? false)
-  );
+  return switches[FeatureSwitchKey.IntroVideo] ?? false;
 }
 
 function withoutHandoffParams(params: URLSearchParams): URLSearchParams {

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -90,9 +90,6 @@ test("Lab groups every feature by rollout stage with a switch", async () => {
   expect(within(beta).getByText(FeatureSwitchKey.Banking)).toBeVisible();
   expect(within(beta).getByText(FeatureSwitchKey.IntroVideo)).toBeVisible();
   expect(
-    within(beta).getByText(FeatureSwitchKey.DesktopScreenRecording),
-  ).toBeVisible();
-  expect(
     within(alpha).getByText(FeatureSwitchKey.AhrefsConnector),
   ).toBeVisible();
   expect(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-message-intro-video.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-message-intro-video.test.tsx
@@ -28,8 +28,7 @@ const DESKTOP_HANDOFF_PARAMS = {
   "intro-video-user": "test-user-123",
 } as const;
 
-const DESKTOP_HANDOFF_SWITCHES = {
-  [FeatureSwitchKey.DesktopScreenRecording]: true,
+const INTRO_VIDEO_SWITCHES = {
   [FeatureSwitchKey.IntroVideo]: true,
 } as const;
 
@@ -326,7 +325,7 @@ test("Screen recording hands the user off to the desktop app", async () => {
   await setupPage({
     context,
     path: `/agents/${MESSAGE_EXPERIENCE_AGENT_ID}/chat`,
-    featureSwitches: DESKTOP_HANDOFF_SWITCHES,
+    featureSwitches: INTRO_VIDEO_SWITCHES,
   });
 
   const dialog = await openIntroVideoDialog();
@@ -362,7 +361,7 @@ test("A desktop recording video request does not invent an opening or ending", a
   await setupPage({
     context,
     path: `/agents/${MESSAGE_EXPERIENCE_AGENT_ID}/chat?${new URLSearchParams(DESKTOP_HANDOFF_PARAMS).toString()}`,
-    featureSwitches: DESKTOP_HANDOFF_SWITCHES,
+    featureSwitches: INTRO_VIDEO_SWITCHES,
   });
 
   const dialog = await screen.findByRole("dialog", {
@@ -407,7 +406,7 @@ test("A desktop recording survives leaving the presenter step", async () => {
   await setupPage({
     context,
     path: `/agents/${MESSAGE_EXPERIENCE_AGENT_ID}/chat?${new URLSearchParams(DESKTOP_HANDOFF_PARAMS).toString()}`,
-    featureSwitches: DESKTOP_HANDOFF_SWITCHES,
+    featureSwitches: INTRO_VIDEO_SWITCHES,
   });
 
   const dialog = await screen.findByRole("dialog", {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -209,7 +209,6 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.BaseUiSidebarScrollArea]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
@@ -245,7 +244,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.BaseUiSidebarScrollArea]).toBe(
       false,
@@ -254,13 +252,12 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(false);
   });
 
-  it("should enable intro video and desktop recording for staff", () => {
+  it("should enable intro video for staff", () => {
     const staffStates = getAllFeatureStates({
       email: "ethan@vm0.ai",
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
     expect(staffStates[FeatureSwitchKey.IntroVideo]).toBe(true);
-    expect(staffStates[FeatureSwitchKey.DesktopScreenRecording]).toBe(true);
   });
 
   it("should enable gradient color themes for Ming only", () => {
@@ -394,9 +391,6 @@ describe("getFeatureSwitchMetadata", () => {
     ).toBe("released");
     expect(metadata[FeatureSwitchKey.Banking].rolloutStage).toBe("beta");
     expect(metadata[FeatureSwitchKey.IntroVideo].rolloutStage).toBe("beta");
-    expect(metadata[FeatureSwitchKey.DesktopScreenRecording].rolloutStage).toBe(
-      "beta",
-    );
     expect(metadata[FeatureSwitchKey.AhrefsConnector].rolloutStage).toBe(
       "alpha",
     );

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -76,7 +76,6 @@ export enum FeatureSwitchKey {
   ComposerVoiceInputShortcut = "composerVoiceInputShortcut",
   ComposerImageAnnotation = "composerImageAnnotation",
   GradientColorThemes = "gradientColorThemes",
-  DesktopScreenRecording = "desktopScreenRecording",
   IosPwaStartupImages = "iosPwaStartupImages",
   GeistTypeface = "geistTypeface",
   SocialDownloadDetectedMediaType = "socialDownloadDetectedMediaType",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -318,13 +318,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.DesktopScreenRecording]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Enable Okou Desktop screen recording: native capture, click track, and delivery back into the intro video workflow.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.IosPwaStartupImages]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- gate native desktop screen recording and browser handoff with the existing `introVideo` feature switch
- remove the redundant `DesktopScreenRecording` enum, registry entry, and Lab row
- update desktop, core, and platform coverage for the consolidated switch

## Verification

- `pnpm --filter @okouai/desktop lint`
- `pnpm --filter @okouai/core lint`
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/desktop check-types`
- `pnpm --filter @okouai/core check-types`
- `pnpm --filter @okouai/app check-types`
- `pnpm knip --workspace @okouai/desktop --workspace @okouai/core --workspace @okouai/app`
- `pnpm --filter @okouai/desktop exec vitest run src/desktop-developer-tools-controller.test.ts`
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/views/lab-page/__tests__/lab-page.test.tsx src/views/okou-page/__tests__/chat-message-intro-video.test.tsx`
