### PR TITLE
fix(agent): align avatar edits with visibility permissions

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agents-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-update.test.ts
@@ -12,6 +12,7 @@ import {
   cliAuthDeviceContract,
   cliAuthTokenContract,
 } from "@okouai/api-contracts/contracts/cli-auth";
+import { onboardingStatusContract } from "@okouai/api-contracts/contracts/onboarding";
 import { createStore } from "ccstate";
 
 import { accept, testContext } from "../../../__tests__/test-context";
@@ -23,6 +24,7 @@ import { seedOrgMembership$ } from "./helpers/org-membership";
 import { cliAuthRoutes } from "../cli-auth";
 import { agentInstructionsRoutes } from "../agent-instructions";
 import { agentsRoutes } from "../agents";
+import { onboardingStatusRoutes } from "../onboarding-status";
 import { workflowsRoutes } from "../workflows";
 
 const context = testContext();
@@ -94,6 +96,12 @@ function agentsClient() {
 
 function agentsCollectionClient() {
   return setupApp({ context, routes: agentsRoutes })(agentsMainContract);
+}
+
+function onboardingStatusClient() {
+  return setupApp({ context, routes: onboardingStatusRoutes })(
+    onboardingStatusContract,
+  );
 }
 
 function instructionsClient() {
@@ -493,6 +501,40 @@ describe("PATCH /api/agents/:id", () => {
     expect(response.body).toStrictEqual({
       error: {
         message: "Only the agent owner or org admin can update agent avatar",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
+  it("returns a profile-specific error for a forbidden default agent update", async () => {
+    const owner = newOrgUser();
+    mocks.clerk.session(owner.userId, owner.orgId, "org:admin");
+    context.mocks.s3.send.mockResolvedValue({ ContentLength: 1024 });
+    context.mocks.s3.getSignedUrl.mockResolvedValue(
+      "https://r2.example.test/default-agent.tar.gz?signature=test",
+    );
+    const onboarding = await accept(
+      onboardingStatusClient().getStatus({ headers: authHeaders() }),
+      [200],
+    );
+    const agentId = onboarding.body.defaultAgentId;
+    if (!agentId) {
+      throw new Error("Expected onboarding to create a default agent");
+    }
+
+    mocks.clerk.session(`user_${randomUUID()}`, owner.orgId, "org:member");
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agentId },
+        headers: authHeaders(),
+        body: { description: "Nope" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only the agent owner or org admin can update agent profile",
         code: "FORBIDDEN",
       },
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/agents-update.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agents-update.test.ts
@@ -476,6 +476,28 @@ describe("PATCH /api/agents/:id", () => {
     });
   });
 
+  it("returns an avatar-specific error for a forbidden avatar update", async () => {
+    const user = newOrgUser();
+    const agent = await createAgentAs(user);
+    mocks.clerk.session(`user_${randomUUID()}`, user.orgId, "org:member");
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { avatarUrl: "preset:4" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Only the agent owner or org admin can update agent avatar",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+
   it("allows an org admin to update another user's public agent", async () => {
     const user = newOrgUser();
     const adminUserId = `user_${randomUUID()}`;
@@ -497,6 +519,32 @@ describe("PATCH /api/agents/:id", () => {
       agentId: agent.agentId,
       ownerId: user.userId,
       displayName: "Admin Updated",
+    });
+  });
+
+  it("accepts an old avatar update that repeats unchanged visibility", async () => {
+    const user = newOrgUser();
+    const adminUserId = `user_${randomUUID()}`;
+    const agent = await createAgentAs(user, {
+      avatarUrl: "preset:0",
+      visibility: "public",
+    });
+    mocks.clerk.session(adminUserId, user.orgId, "org:admin");
+
+    const response = await accept(
+      agentsClient().updateMetadata({
+        params: { id: agent.agentId },
+        headers: authHeaders(),
+        body: { avatarUrl: "preset:4", visibility: "public" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      agentId: agent.agentId,
+      ownerId: user.userId,
+      avatarUrl: "preset:4",
+      visibility: "public",
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/agents.ts
+++ b/turbo/apps/api/src/signals/routes/agents.ts
@@ -211,11 +211,14 @@ function visibilityOwnerError(
   member: AgentMember,
   requestedVisibility: AgentVisibility | undefined,
 ) {
-  if (
-    requestedVisibility === undefined ||
-    requestedVisibility === existing.visibility ||
-    existing.owner === member.userId
-  ) {
+  if (requestedVisibility === undefined || existing.owner === member.userId) {
+    return null;
+  }
+
+  // Old web/app -> new API: already-open clients can keep sending unchanged
+  // visibility for about two days. Remove after the client-version floor
+  // excludes builds before #31731; tracked by #31732.
+  if (requestedVisibility === existing.visibility) {
     return null;
   }
 
@@ -656,7 +659,7 @@ const updateAgentMetadataInner$ = command(
       const permissionError = requireAgentPermission(
         existing.owner,
         member,
-        updateBody.avatarUrl === undefined
+        body.data.avatarUrl === undefined
           ? "update agent profile"
           : "update agent avatar",
         { visibility: existing.visibility },

--- a/turbo/apps/api/src/signals/routes/agents.ts
+++ b/turbo/apps/api/src/signals/routes/agents.ts
@@ -211,7 +211,11 @@ function visibilityOwnerError(
   member: AgentMember,
   requestedVisibility: AgentVisibility | undefined,
 ) {
-  if (requestedVisibility === undefined || existing.owner === member.userId) {
+  if (
+    requestedVisibility === undefined ||
+    requestedVisibility === existing.visibility ||
+    existing.owner === member.userId
+  ) {
     return null;
   }
 
@@ -652,7 +656,9 @@ const updateAgentMetadataInner$ = command(
       const permissionError = requireAgentPermission(
         existing.owner,
         member,
-        "update agent profile",
+        updateBody.avatarUrl === undefined
+          ? "update agent profile"
+          : "update agent avatar",
         { visibility: existing.visibility },
       );
       if (permissionError) {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -4,6 +4,7 @@ import { expect, test } from "vitest";
 import {
   agentInstructionsContract,
   agentsByIdContract,
+  type AgentMetadataRequest,
   type AgentResponse,
 } from "@okouai/api-contracts/contracts/agents";
 import {
@@ -51,13 +52,18 @@ function tabByText(text: string): HTMLElement {
   return tab;
 }
 
-function prepareAgentProfile(avatarUrl = "preset:0"): {
+function prepareAgentProfile(
+  avatarUrl = "preset:0",
+  ownerId = "test-user-123",
+): {
+  readonly lastUpdate: () => AgentMetadataRequest | null;
   readonly lastSavedProfile: () => AgentResponse | null;
 } {
+  let lastUpdate: AgentMetadataRequest | null = null;
   let lastSavedProfile: AgentResponse | null = null;
   let detail: AgentResponse = {
     agentId: AGENT_ID,
-    ownerId: "test-user-123",
+    ownerId,
     description: "A helpful agent",
     displayName: "Research Agent",
     sound: "professional",
@@ -80,7 +86,7 @@ function prepareAgentProfile(avatarUrl = "preset:0"): {
     },
     {
       agentId: AGENT_ID,
-      ownerId: "test-user-123",
+      ownerId,
       displayName: detail.displayName,
       description: detail.description,
       sound: detail.sound,
@@ -92,6 +98,7 @@ function prepareAgentProfile(avatarUrl = "preset:0"): {
     return respond(200, detail);
   });
   context.mocks.api(agentsByIdContract.updateMetadata, ({ body, respond }) => {
+    lastUpdate = body;
     detail = { ...detail, ...body };
     lastSavedProfile = detail;
     return respond(200, detail);
@@ -100,6 +107,9 @@ function prepareAgentProfile(avatarUrl = "preset:0"): {
     return respond(200, { content: null, filename: null });
   });
   return {
+    lastUpdate: () => {
+      return lastUpdate;
+    },
     lastSavedProfile: () => {
       return lastSavedProfile;
     },
@@ -262,6 +272,43 @@ test("Create and save a composer avatar from the profile page", async () => {
     expect.stringMatching(/\/avatar-svg-v2\/.*\/hairs\/.*-blue-front\.svg$/u),
     expect.stringMatching(/\/avatar-svg-v2\/.*\/expressions\//u),
   ]);
+});
+
+test("Allow an org admin to update another user's public agent avatar", async () => {
+  const profile = prepareAgentProfile("preset:0", "agent-owner");
+  context.mocks.data.org({
+    id: "org_default",
+    name: "Default Org",
+    role: "admin",
+  });
+  await setupPage({
+    context,
+    path: `/agents/${AGENT_ID}?tab=profile`,
+    featureSwitches: { [FeatureSwitchKey.AvatarComposerV2]: true },
+  });
+
+  click(await findCreateCustomAvatarButton());
+
+  const dialog = await screen.findByRole("dialog", {
+    name: "Give your agent a face",
+  });
+  click(within(dialog).getByLabelText("Randomize avatar"));
+  click(within(dialog).getByText("Use this avatar"));
+
+  await waitFor(() => {
+    expect(profile.lastSavedProfile()).not.toBeNull();
+  });
+  const savedProfile = profile.lastSavedProfile();
+  if (!savedProfile) {
+    throw new Error("Expected the avatar update to finish");
+  }
+  const update = profile.lastUpdate();
+  if (!update) {
+    throw new Error("Expected an avatar update request");
+  }
+  expect(savedProfile.avatarUrl).not.toBe("preset:0");
+  expect(savedProfile.visibility).toBe("public");
+  expect(update).not.toHaveProperty("visibility");
 });
 
 test("Keep the default agent’s canonical identity read-only", async () => {

--- a/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
@@ -312,7 +312,7 @@ export function SettingsTab({
             description: desc,
             sound: tone,
             avatarUrl,
-            visibility,
+            ...(canEditVisibility ? { visibility } : {}),
           },
           pageSignal,
         );
@@ -370,7 +370,7 @@ export function SettingsTab({
                           description: desc,
                           sound: tone,
                           avatarUrl: newAvatarUrl,
-                          visibility,
+                          ...(canEditVisibility ? { visibility } : {}),
                         },
                         pageSignal,
                       );

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -177,6 +177,53 @@ test("A user opens avatar customization from an agent", async () => {
   expect(within(dialog).getByText("Face")).toBeVisible();
 });
 
+test("A member cannot customize another user's public agent avatar", async () => {
+  context.mocks.data.org({
+    id: "org_default",
+    name: "Default Org",
+    role: "member",
+  });
+  await setupTeamPage({
+    context,
+    path: `/agents/${RESEARCH_AGENT_ID}?tab=profile`,
+    agents: [
+      agentFixture(RESEARCH_AGENT_ID, "Research Agent", {
+        ownerId: "agent-owner",
+      }),
+    ],
+  });
+
+  await screen.findByRole("heading", { name: "Research Agent" });
+  expect(screen.queryByLabelText("Customize avatar")).not.toBeInTheDocument();
+  expect(
+    screen.queryByLabelText("Create custom avatar"),
+  ).not.toBeInTheDocument();
+});
+
+test("An org admin cannot customize another user's private agent avatar", async () => {
+  context.mocks.data.org({
+    id: "org_default",
+    name: "Default Org",
+    role: "admin",
+  });
+  await setupTeamPage({
+    context,
+    path: `/agents/${RESEARCH_AGENT_ID}?tab=profile`,
+    agents: [
+      agentFixture(RESEARCH_AGENT_ID, "Private Agent", {
+        ownerId: "agent-owner",
+        visibility: "private",
+      }),
+    ],
+  });
+
+  await screen.findByRole("heading", { name: "Private Agent" });
+  expect(screen.queryByLabelText("Customize avatar")).not.toBeInTheDocument();
+  expect(
+    screen.queryByLabelText("Create custom avatar"),
+  ).not.toBeInTheDocument();
+});
+
 test("A user starts a chat from an agent's detail page", async () => {
   await setupTeamPage({
     context,

--- a/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
@@ -1117,7 +1117,11 @@ function useAgentFields() {
   };
 }
 
-function useTabVisibility(agentId: string, ownerId: string) {
+function useTabVisibility(
+  agentId: string,
+  ownerId: string,
+  visibility: "public" | "private",
+) {
   const statusLoadable = useLastLoadable(onboardingStatus$);
   const isDefaultAgent =
     statusLoadable.state === "hasData" &&
@@ -1130,10 +1134,11 @@ function useTabVisibility(agentId: string, ownerId: string) {
   const currentUserId =
     userLoadable.state === "hasData" ? userLoadable.data?.id : undefined;
   const isOwner = currentUserId === ownerId;
+  const canEditProfile = isOwner || (isAdmin && visibility === "public");
 
   const rawTab = useGet(agentActiveTab$);
   const setActiveTab = useSet(setAgentActiveTab$);
-  const hideProfileAndInstructions = !isAdmin && !isOwner;
+  const hideProfileAndInstructions = !canEditProfile;
   const activeTab = resolveVisibleTab(rawTab, hideProfileAndInstructions);
 
   return {
@@ -1163,7 +1168,7 @@ export function JobDetailPage() {
     isOwner,
     activeTab,
     setActiveTab,
-  } = useTabVisibility(fields.agentId, fields.ownerId);
+  } = useTabVisibility(fields.agentId, fields.ownerId, fields.visibility);
 
   if (!fields.detail && !error) {
     return <DetailSkeleton />;


### PR DESCRIPTION
## Summary

- align agent profile/avatar visibility with the backend permission rule: owner access for private agents, owner or org-admin access for public agents
- omit the owner-only `visibility` field from non-owner profile and avatar updates
- accept legacy clients that repeat the existing visibility without allowing an actual visibility change, and return an avatar-specific permission error

## Fallbacks

- `turbo/apps/api/src/signals/routes/agents.ts:visibilityOwnerError` — accepts the previous frontend profile/avatar request shape when it repeats unchanged `visibility`. Surface: old web/app → new API, with already-open clients exposed for about two days. Remove after the replacement app is live and the enforced client-version floor excludes builds before #31731; tracked by #31732.

## Testing

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/settings-tab.test.tsx`
- `pnpm -F @okouai/app exec vitest run src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agents-update.test.ts`
- `pnpm -F @okouai/app lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F api check-types`
- `pnpm exec knip --workspace api --workspace @okouai/app`

Fixes #31720
