### PR TITLE
test(api): validate social download media detection in preview

### DIFF
--- a/turbo/apps/api/src/signals/services/socialkit-download.service.ts
+++ b/turbo/apps/api/src/signals/services/socialkit-download.service.ts
@@ -50,6 +50,12 @@ import { recordWebUploadedFile$ } from "./run-uploaded-files.service";
 import { validateScrapeTargetUrl } from "./scrape-target-policy";
 
 const SOCIALKIT_API_BASE = "https://api.socialkit.dev";
+// Temporary preview-only provider fixture for staging E2E validation. This
+// branch is intentionally not mergeable and must be deleted after validation.
+const PREVIEW_MOCK_REQUEST_URL = "https://www.youtube.com/watch?v=okoumock001";
+const PREVIEW_MOCK_PROVIDER_JOB_ID = "fixture-audio-only-mp3";
+const PREVIEW_MOCK_START_URL = "https://cdn.vm0.io/artifacts/d857xuk07q.json";
+const PREVIEW_MOCK_STATUS_URL = "https://cdn.vm0.io/artifacts/vn9zxvn7yk.json";
 const SOCIALKIT_PROVIDER_TIMEOUT_MS = 240_000;
 const SOCIALKIT_DOWNLOAD_TIMEOUT_MS = 270_000;
 export const SOCIALKIT_RECONCILIATION_TIMEOUT_MS = 280_000;
@@ -321,21 +327,27 @@ async function startProviderJob(
   request: SocialKitDownloadRequest,
   signal: AbortSignal,
 ): Promise<string> {
+  const usePreviewMock =
+    env("ENV") === "preview" && request.url === PREVIEW_MOCK_REQUEST_URL;
   const result = await providerJson(
-    `${SOCIALKIT_API_BASE}/v2/${request.platform}/download`,
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-access-key": accessKey,
-      },
-      body: JSON.stringify({
-        url: request.url,
-        max_duration: request.maxDuration,
-        quality: request.quality,
-        format: request.format,
-      }),
-    },
+    usePreviewMock
+      ? PREVIEW_MOCK_START_URL
+      : `${SOCIALKIT_API_BASE}/v2/${request.platform}/download`,
+    usePreviewMock
+      ? { method: "GET" }
+      : {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-access-key": accessKey,
+          },
+          body: JSON.stringify({
+            url: request.url,
+            max_duration: request.maxDuration,
+            quality: request.quality,
+            format: request.format,
+          }),
+        },
     signal,
   );
   if (!result.response.ok) {
@@ -363,9 +375,16 @@ async function pollProviderJob(
   providerJobId: string,
   signal: AbortSignal,
 ): Promise<ProviderPollResult> {
+  const usePreviewMock =
+    env("ENV") === "preview" && providerJobId === PREVIEW_MOCK_PROVIDER_JOB_ID;
   const result = await providerJson(
-    `${SOCIALKIT_API_BASE}/v2/downloads/${encodeURIComponent(providerJobId)}`,
-    { method: "GET", headers: { "x-access-key": accessKey } },
+    usePreviewMock
+      ? PREVIEW_MOCK_STATUS_URL
+      : `${SOCIALKIT_API_BASE}/v2/downloads/${encodeURIComponent(providerJobId)}`,
+    {
+      method: "GET",
+      ...(usePreviewMock ? {} : { headers: { "x-access-key": accessKey } }),
+    },
     signal,
   );
   if (!result.response.ok) {

--- a/turbo/apps/api/src/signals/services/socialkit-download.service.ts
+++ b/turbo/apps/api/src/signals/services/socialkit-download.service.ts
@@ -1,4 +1,4 @@
-import { v5 as uuidv5 } from "uuid";
+import { v4 as uuidv4, v5 as uuidv5 } from "uuid";
 
 import {
   MANAGED_SOCIALKIT_BILLING_CATEGORY,
@@ -355,7 +355,8 @@ async function startProviderJob(
       `SocialKit download start failed (${result.response.status})`,
     );
   }
-  return providerStartSchema.parse(result.body).jobId;
+  const providerJobId = providerStartSchema.parse(result.body).jobId;
+  return usePreviewMock ? `${providerJobId}-${uuidv4()}` : providerJobId;
 }
 
 type ProviderPollResult =
@@ -376,7 +377,8 @@ async function pollProviderJob(
   signal: AbortSignal,
 ): Promise<ProviderPollResult> {
   const usePreviewMock =
-    env("ENV") === "preview" && providerJobId === PREVIEW_MOCK_PROVIDER_JOB_ID;
+    env("ENV") === "preview" &&
+    providerJobId.startsWith(`${PREVIEW_MOCK_PROVIDER_JOB_ID}-`);
   const result = await providerJson(
     usePreviewMock
       ? PREVIEW_MOCK_STATUS_URL
@@ -415,7 +417,14 @@ async function pollProviderJob(
   if (result.body.status !== "ready") {
     return { status: "invalid" };
   }
-  const ready = providerReadySchema.safeParse(result.body);
+  const ready = providerReadySchema.safeParse(
+    usePreviewMock &&
+      typeof result.body === "object" &&
+      result.body !== null &&
+      !Array.isArray(result.body)
+      ? { ...result.body, jobId: providerJobId }
+      : result.body,
+  );
   return ready.success
     ? { status: "ready", ready: ready.data }
     : { status: "invalid" };


### PR DESCRIPTION
## Summary

- **DO NOT MERGE:** this draft PR exists only to deploy a disposable API preview for staging E2E validation
- route one unique YouTube-shaped request through deterministic provider start and poll fixtures when `ENV=preview`
- return MP3 bytes from an `.mp4` URL so the real staging artifact pipeline can validate `socialDownloadDetectedMediaType`

## Guardrail

Production and every request other than `https://www.youtube.com/watch?v=okoumock001` continue to use the real SocialKit API. The PR will remain draft and will not enter the merge queue.

## Fixture boundaries

- provider start: `https://cdn.vm0.io/artifacts/d857xuk07q.json`
- provider status: `https://cdn.vm0.io/artifacts/vn9zxvn7yk.json`
- provider artifact: `https://cdn.vm0.io/artifacts/2aykmtgpcb.mp4` (MP3 bytes, misleading MP4 path and HTTP content type)

## Local checks

- `pnpm exec prettier --check apps/api/src/signals/services/socialkit-download.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types:gateways`
- `pnpm -F api check-types:core`

## Staging acceptance matrix

- switch OFF: completed artifact is `*.mp4` with `video/mp4`
- switch ON: completed artifact is `*.mp3` with `audio/mpeg`
- both paths use the real preview API, database, billing settlement, safe artifact fetch, multipart R2 upload, uploaded-file record, and final GET response
