### PR TITLE
refactor: remove social download media type feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -21,7 +21,6 @@ import {
   type SocialKitRequest,
 } from "@okouai/api-contracts/contracts/social";
 import { billingStatusContract } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { usageRecordContract } from "@okouai/api-contracts/contracts/usage-record";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
@@ -51,7 +50,6 @@ import {
   type ApiTestUser,
 } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
-import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { createRouteMocks } from "./helpers/route-test";
 import { reconcileSocialKitDownloadsForTest } from "./helpers/runtime-state";
 
@@ -2459,20 +2457,12 @@ describe("managed SocialKit route", () => {
       contentType: "video/mp4",
     },
   ])(
-    "files $caseName by its detected media once the switch is on",
+    "files $caseName by its detected media",
     async ({ payload, filename, contentType }) => {
       const actor = createBddApi(context).user();
-      if (!actor.orgId) {
-        throw new Error("Expected the download actor to have an organization");
-      }
       configureProvider();
       const pricing = await setupConfiguredPricing();
       await fundActor(actor);
-      await updateFeatureSwitchesForUser(
-        context,
-        { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
-        { [FeatureSwitchKey.SocialDownloadDetectedMediaType]: true },
-      );
 
       const body = await completeDownloadWithPayload(actor, pricing, payload);
 
@@ -2489,17 +2479,9 @@ describe("managed SocialKit route", () => {
 
   it("keeps the requested format for an unrecognized container", async () => {
     const actor = createBddApi(context).user();
-    if (!actor.orgId) {
-      throw new Error("Expected the download actor to have an organization");
-    }
     configureProvider();
     const pricing = await setupConfiguredPricing();
     await fundActor(actor);
-    await updateFeatureSwitchesForUser(
-      context,
-      { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
-      { [FeatureSwitchKey.SocialDownloadDetectedMediaType]: true },
-    );
     const payload = new Uint8Array([
       0x1a, 0x45, 0xdf, 0xa3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
       0x00, 0x00,
@@ -2513,28 +2495,6 @@ describe("managed SocialKit route", () => {
         filename: "Public clip.mp4",
         contentType: "video/mp4",
         sizeBytes: payload.byteLength,
-      },
-    });
-  });
-
-  it("keeps the requested format for the same artifact while the switch is off", async () => {
-    const actor = createBddApi(context).user();
-    configureProvider();
-    const pricing = await setupConfiguredPricing();
-    await fundActor(actor);
-
-    const body = await completeDownloadWithPayload(
-      actor,
-      pricing,
-      AUDIO_ONLY_PAYLOAD,
-    );
-
-    expect(body).toMatchObject({
-      status: "completed",
-      artifact: {
-        filename: "Public clip.mp4",
-        contentType: "video/mp4",
-        sizeBytes: AUDIO_ONLY_PAYLOAD.byteLength,
       },
     });
   });

--- a/turbo/apps/api/src/signals/services/socialkit-download.service.ts
+++ b/turbo/apps/api/src/signals/services/socialkit-download.service.ts
@@ -9,8 +9,6 @@ import {
   type SocialKitDownloadRequest,
   type SocialKitDownloadResponse,
 } from "@okouai/api-contracts/contracts/social";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
 import { socialKitDownloadJobs } from "@okouai/db/schema/socialkit-download-job";
 import { command } from "ccstate";
 import { and, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
@@ -40,7 +38,6 @@ import {
   allocateArtifactObject$,
   resolveArtifactObject$,
 } from "./artifact-storage.service";
-import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import {
   checkManagedCredits$,
   recordManagedUsage$,
@@ -1211,22 +1208,8 @@ const materializeSocialKitArtifact$ = command(
     },
     signal: AbortSignal,
   ): Promise<NonNullable<DownloadJob["artifact"]>> => {
-    const featureContext = await loadUserFeatureSwitchContext(
-      set(writeDb$),
-      args.job.orgId,
-      args.job.userId,
-    );
-    signal.throwIfAborted();
     const download = await openArtifactDownload(args.ready.downloadUrl, signal);
-    // The switch gates the outcome, not the transfer: the container is always
-    // read off the stream, but until it graduates the artifact keeps being
-    // filed under the requested format.
-    const media = isFeatureEnabled(
-      FeatureSwitchKey.SocialDownloadDetectedMediaType,
-      featureContext,
-    )
-      ? download.media
-      : null;
+    const media = download.media;
     const filename = artifactFilename(
       args.providerResult.title,
       args.job.id,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -78,7 +78,6 @@ export enum FeatureSwitchKey {
   GradientColorThemes = "gradientColorThemes",
   IosPwaStartupImages = "iosPwaStartupImages",
   GeistTypeface = "geistTypeface",
-  SocialDownloadDetectedMediaType = "socialDownloadDetectedMediaType",
   AvatarComposerV2 = "avatarComposerV2",
   NewUi = "newUi",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -325,16 +325,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.SocialDownloadDetectedMediaType]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "File a social download by the media kind detected from its leading file structure instead of the requested format, so an audio-only result stops being recorded as video/mp4.",
-    enabled: false,
-    // Staff first: this decides the stored filename and content type, and the
-    // extension is baked into the public artifact URL, so widen only after real
-    // downloads confirm the detection agrees with the requested format.
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.AvatarComposerV2]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- permanently use the media type detected from the downloaded file structure when materializing SocialKit artifacts
- remove the `socialDownloadDetectedMediaType` registry entry, enum member, feature-context lookup, and conditional fallback branch
- convert the retained media-classification coverage to direct product-behavior tests and delete the switch-off-only test

## Terminal state

**`fully-rolled-out`** — Bingjie explicitly confirmed that the detected-media behavior should become permanent after the staging mock E2E verified both switch states.

Staging evidence: [draft validation PR #31733](https://github.com/vm0-ai/vm0/pull/31733) and its [result comment](https://github.com/vm0-ai/vm0/pull/31733#issuecomment-5540883284). With identical MP3 bytes returned for an MP4 request, switch-off recorded `.mp4` / `video/mp4`, while switch-on recorded `.mp3` / `audio/mpeg`.

## Commit archaeology and behavior decision

- Introduction: `3752d3fea2e6f5dbd535693ad4346f58e943485a` / #30998.
- Its parent stored filename and content type only from `job.request.format`; the introduction added single-fetch stream sniffing, detected-media metadata, the feature gate, and paired on/off coverage.
- Follow-up: `23dd5951c24da38ea4c8e3cbfaa839a1de974e42` / #31418 added bounded ISO BMFF track inspection so generic MP4 brands are classified by `hdlr` tracks.
- This cleanup preserves the complete switch-on path, including the follow-up's audio/video track precedence, stream ownership and cancellation safeguards, and the requested-format fallback for genuinely unrecognized media. It removes only the switch-off branch and switch-only plumbing.

## Search and orphan cleanup

- Exact searches covered `socialDownloadDetectedMediaType`, `SocialDownloadDetectedMediaType`, kebab/snake/case variants, and retired rollout phrases (`switch is on/off`, `until it graduates`, `staff first`). No feature-specific remnants remain.
- Second-pass searches covered the introduced detection and stream symbols (`SniffedMedia`, `ArtifactDownload`, `readMediaHead`, `sniffMedia`, `sniffIsoMedia`, `collectIsoTrackKinds`, `isoHandlerTrackKind`, `openArtifactDownload`) and test fixtures. Every retained match has a direct production or test consumer.
- Knip baseline: `pnpm knip --workspace apps/api --workspace packages/core --no-progress` — clean.
- Knip after: same command — clean; no new unused files, exports, types, or dependencies.

## Test changes

- Kept six detected-media cases: ID3 MPEG, bare MPEG frame sync, M4A brand, audio-only generic ISO, video ISO, and mixed audio/video ISO.
- Kept the unknown-container case that verifies the permanent path's intentional requested-format fallback.
- Removed feature-switch overrides and the obsolete switch-off test that expected audio bytes to be filed as `.mp4` / `video/mp4`.

## Validation

- `pnpm exec prettier --write apps/api/src/signals/services/socialkit-download.service.ts apps/api/src/signals/routes/__tests__/social.test.ts packages/core/src/feature-switch.ts packages/core/src/feature-switch-key.ts`
- `git diff --check`
- `pnpm -F api lint`
- `pnpm -F @okouai/core lint`
- `pnpm -F api check-types`
- `pnpm -F @okouai/core check-types`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres pnpm -F api exec vitest run src/signals/routes/__tests__/social.test.ts -t 'detected media|unrecognized container'` — 7 passed
- Knip baseline/after command above

The full local Vitest suite was not run per repository guidance; the PR pipeline owns full-suite validation.
