### PR TITLE
fix(platform): stabilize pinned agent label transition

### DIFF
--- a/e2e/playwright/tests/agents.spec.ts
+++ b/e2e/playwright/tests/agents.spec.ts
@@ -10,3 +10,58 @@ test("navigate to agents page and verify heading", async ({ page }) => {
     timeout: 20_000,
   });
 });
+
+test.describe("pinned-agent loading transition", () => {
+  test.use({
+    deviceScaleFactor: 2,
+    viewport: { width: 1440, height: 900 },
+  });
+
+  test("keeps the label frame on the same device pixels", async ({ page }) => {
+    let releasePreferences = () => {};
+    const preferencesGate = new Promise<void>((resolve) => {
+      releasePreferences = resolve;
+    });
+
+    await page.route("**/api/user-preferences", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+      await preferencesGate;
+      await route.continue();
+    });
+
+    try {
+      await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+
+      const loadingLabel = page.getByTestId("pinned-agent-label-frame");
+      await expect(loadingLabel).toBeVisible({ timeout: 20_000 });
+      const loadingBox = await loadingLabel.boundingBox();
+      if (!loadingBox) {
+        throw new Error("Pinned-agent loading label has no rendered bounds");
+      }
+      const devicePixelRatio = await page.evaluate(() => {
+        return window.devicePixelRatio;
+      });
+      expect(loadingBox.height * devicePixelRatio).toBe(28);
+
+      releasePreferences();
+
+      const resolvedLabel = page
+        .getByTestId("pinned-agent-card")
+        .first()
+        .getByTestId("pinned-agent-label-frame");
+      await expect(resolvedLabel).toBeVisible({ timeout: 20_000 });
+      const resolvedBox = await resolvedLabel.boundingBox();
+      if (!resolvedBox) {
+        throw new Error("Pinned-agent resolved label has no rendered bounds");
+      }
+
+      expect(resolvedBox.y).toBe(loadingBox.y);
+      expect(resolvedBox.height * devicePixelRatio).toBe(28);
+    } finally {
+      releasePreferences();
+    }
+  });
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1578,11 +1578,7 @@ test("Keep pin management usable with many pinned agents", async () => {
   const pinnedSection = await screen.findByTestId("pinned-agents-horizontal");
   const grid = within(pinnedSection).getByTestId("pinned-agents-grid");
   expect(within(pinnedSection).getByText("Pinned agents")).toBeVisible();
-  const pinnedAgentSkeleton = within(grid).getByTestId("pinned-agent-skeleton");
-  expect(pinnedAgentSkeleton.lastElementChild).toHaveClass(
-    "h-3.5",
-    "leading-[14px]",
-  );
+  expect(within(grid).getByTestId("pinned-agent-skeleton")).toBeVisible();
   expect(within(grid).queryByTestId("pinned-agent-card")).toBeNull();
   expect(within(grid).queryByLabelText("Pin an agent")).toBeNull();
 
@@ -1593,14 +1589,6 @@ test("Keep pin management usable with many pinned agents", async () => {
     expect(within(grid).getAllByTestId("pinned-agent-card")).toHaveLength(6);
     expect(buttonByLabel("Pin an agent", grid)).toBeVisible();
   });
-  expect(pinnedAgentLink(grid, "Zero").lastElementChild).toHaveClass(
-    "h-3.5",
-    "leading-[14px]",
-  );
-  expect(buttonByLabel("Pin an agent", grid).lastElementChild).toHaveClass(
-    "h-3.5",
-    "leading-[14px]",
-  );
   expect(
     queryAllByRoleFast("link", grid).map((link) => {
       return link.textContent?.trim();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1578,7 +1578,11 @@ test("Keep pin management usable with many pinned agents", async () => {
   const pinnedSection = await screen.findByTestId("pinned-agents-horizontal");
   const grid = within(pinnedSection).getByTestId("pinned-agents-grid");
   expect(within(pinnedSection).getByText("Pinned agents")).toBeVisible();
-  expect(within(grid).getAllByTestId("pinned-agent-skeleton")).toHaveLength(1);
+  const pinnedAgentSkeleton = within(grid).getByTestId("pinned-agent-skeleton");
+  expect(pinnedAgentSkeleton.lastElementChild).toHaveClass(
+    "h-3.5",
+    "leading-[14px]",
+  );
   expect(within(grid).queryByTestId("pinned-agent-card")).toBeNull();
   expect(within(grid).queryByLabelText("Pin an agent")).toBeNull();
 
@@ -1589,6 +1593,14 @@ test("Keep pin management usable with many pinned agents", async () => {
     expect(within(grid).getAllByTestId("pinned-agent-card")).toHaveLength(6);
     expect(buttonByLabel("Pin an agent", grid)).toBeVisible();
   });
+  expect(pinnedAgentLink(grid, "Zero").lastElementChild).toHaveClass(
+    "h-3.5",
+    "leading-[14px]",
+  );
+  expect(buttonByLabel("Pin an agent", grid).lastElementChild).toHaveClass(
+    "h-3.5",
+    "leading-[14px]",
+  );
   expect(
     queryAllByRoleFast("link", grid).map((link) => {
       return link.textContent?.trim();

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -75,7 +75,10 @@ function PinnedAgentGridSkeletonCard() {
       <span className="flex h-9 w-9 shrink-0">
         <Skeleton className="h-full w-full rounded-full" />
       </span>
-      <Skeleton className={`${pinnedAgentGridLabelFrameClassName} w-10`} />
+      <Skeleton
+        data-testid="pinned-agent-label-frame"
+        className={`${pinnedAgentGridLabelFrameClassName} w-10`}
+      />
     </div>
   );
 }
@@ -366,6 +369,7 @@ function PinnedAgentGridCard({
         )}
       </span>
       <span
+        data-testid="pinned-agent-label-frame"
         className={`zero-nav-copy ${pinnedAgentGridLabelFrameClassName} w-full truncate text-center text-[11px] ${
           isPrimarySelected ? "font-medium" : ""
         } ${isDragging ? "opacity-0" : ""}`}
@@ -543,6 +547,7 @@ export function PinnedAgentListSection({
                 <Plus size={18} />
               </span>
               <span
+                data-testid="pinned-agent-label-frame"
                 className={`zero-nav-copy-muted ${pinnedAgentGridLabelFrameClassName} text-[11px]`}
               >
                 {t(($) => {

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -60,6 +60,10 @@ import {
 
 const pinnedAgentGridCardFrameClassName =
   "flex w-full min-w-0 flex-col items-center gap-1.5 rounded-lg p-1.5";
+// `leading-tight` at 11px is 13.75px. Keep both loading and resolved labels on
+// the same whole-pixel line box so swapping their DOM elements cannot round the
+// baseline onto different device pixels.
+const pinnedAgentGridLabelFrameClassName = "h-3.5 leading-[14px]";
 
 function PinnedAgentGridSkeletonCard() {
   return (
@@ -71,7 +75,7 @@ function PinnedAgentGridSkeletonCard() {
       <span className="flex h-9 w-9 shrink-0">
         <Skeleton className="h-full w-full rounded-full" />
       </span>
-      <Skeleton className="h-[13.75px] w-10" />
+      <Skeleton className={`${pinnedAgentGridLabelFrameClassName} w-10`} />
     </div>
   );
 }
@@ -362,7 +366,7 @@ function PinnedAgentGridCard({
         )}
       </span>
       <span
-        className={`zero-nav-copy w-full truncate text-center text-[11px] leading-tight ${
+        className={`zero-nav-copy ${pinnedAgentGridLabelFrameClassName} w-full truncate text-center text-[11px] ${
           isPrimarySelected ? "font-medium" : ""
         } ${isDragging ? "opacity-0" : ""}`}
       >
@@ -538,7 +542,9 @@ export function PinnedAgentListSection({
               <span className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-[hsl(var(--gray-300))]">
                 <Plus size={18} />
               </span>
-              <span className="zero-nav-copy-muted text-[11px] leading-tight">
+              <span
+                className={`zero-nav-copy-muted ${pinnedAgentGridLabelFrameClassName} text-[11px]`}
+              >
                 {t(($) => {
                   return $.sidebar.addPin;
                 })}


### PR DESCRIPTION
## Summary

- use one whole-pixel 14px label frame for the pinned-agent skeleton, resolved agent names, and Pin action
- prevent the previous 13.75px line box from rounding onto different device pixels during the DOM handoff
- cover the shared loading and resolved label geometry in the existing sidebar integration test

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx --silent=passed-only` (46 passed)
- isolated reruns of the changed cold-loading case and two virtual-list cases that timed out during a resource-contended repeat (all passed)

## Browser QA

- not run because the repository instructions prohibit starting a local dev server unless explicitly requested
- diagnosis was verified against the provided 60fps Retina screen recording
