### PR TITLE
fix(platform): show standalone upgrade as one dialog

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/settings-dialog.ts
@@ -8,10 +8,13 @@ import { resetSignal } from "../../utils.ts";
 import { reloadConnectorCatalogDiagnostics$ } from "./connector-catalog-diagnostics.ts";
 import { reloadBuiltInModelCooldownDiagnostics$ } from "./built-in-model-cooldown-diagnostics.ts";
 import {
+  billingPlansStandalone$,
+  billingSubPage$,
   clearBillingScrollTarget$,
   clearPendingLogo$,
   initProfileName$,
   requestBuyCreditsScroll$,
+  setBillingPlansStandalone$,
   setBillingSubPage$,
 } from "./workspace-settings-state.ts";
 import {
@@ -188,6 +191,9 @@ const releaseSettingsDialogSession$ = command(({ set }) => {
   set(internalSettingsDialogSessionActive$, false);
   set(clearPendingLogo$);
   set(resetUsagePackPricing$);
+  // The billing sub-page belongs to the session, not to the tab: a closed
+  // dialog must not reopen on the plans page the next time it is opened.
+  set(setBillingSubPage$, false);
   set(internalSettingsDialogOpen$, false);
 });
 
@@ -202,6 +208,20 @@ export const closeSettingsModal$ = command(({ get, set }) => {
     params.delete("billingView");
     set(updateSearchParams$, params);
   }
+});
+
+/**
+ * Dismiss the billing plans surface. A standalone upgrade flow was launched
+ * from outside Settings, so dismissing it closes the whole dialog and returns
+ * to the launching screen; a flow reached from inside Settings goes back to the
+ * billing tab.
+ */
+export const dismissBillingPlans$ = command(({ get, set }) => {
+  if (get(billingPlansStandalone$)) {
+    set(closeSettingsModal$);
+    return;
+  }
+  set(setBillingSubPage$, false);
 });
 
 export const setSettingsDialogOpen$ = command(
@@ -226,6 +246,9 @@ export const setSettingsDialogOpen$ = command(
     );
     set(internalSettingsDialogSignal$, modalSignal);
     set(internalSettingsDialogSessionActive$, true);
+    // A plans sub-page that is already open when the session starts was opened
+    // by an entry point outside Settings, so that flow owns the whole dialog.
+    set(setBillingPlansStandalone$, get(billingSubPage$));
     set(reloadBillingStatus$);
     if (get(internalActiveSection$) === "debug") {
       set(reloadConnectorCatalogDiagnostics$);

--- a/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/workspace-settings-state.ts
@@ -200,8 +200,29 @@ export const billingMigrationTargetTier$ = computed((get) => {
       : null;
 });
 
+/**
+ * True while the plans sub-page is a standalone upgrade flow launched from
+ * outside Settings: the sidebar upgrade card, a chat upgrade action, or a
+ * `?billingView=plans` deep link. Such a flow owns the whole Settings surface,
+ * so dismissing it returns to the screen that launched it instead of leaving
+ * the billing tab open underneath.
+ */
+const internalBillingPlansStandalone$ = state(false);
+
+export const billingPlansStandalone$ = computed((get) => {
+  return get(internalBillingPlansStandalone$);
+});
+
+export const setBillingPlansStandalone$ = command(({ set }, value: boolean) => {
+  set(internalBillingPlansStandalone$, value);
+});
+
 export const setBillingSubPage$ = command(({ set }, value: boolean) => {
   set(internalBillingSubPage$, value ? "plans" : null);
+  if (!value) {
+    // Leaving the plans sub-page ends the standalone upgrade flow it belonged to.
+    set(internalBillingPlansStandalone$, false);
+  }
 });
 
 export const openBillingMigrationSubPage$ = command(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/billing-plans-entry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/billing-plans-entry.test.tsx
@@ -73,6 +73,14 @@ test("Dismissing the sidebar upgrade flow returns to the chat screen", async () 
   await setupPage({ context, path: `/agents/${AGENT_ID}/chat` });
 
   await clickSidebarUpgradeCard();
+  await screen.findByText("Start with Pro");
+  await screen.findByRole("dialog", {
+    name: "Choose a plan",
+  });
+  expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+  expect(
+    screen.queryByRole("dialog", { name: "Settings" }),
+  ).not.toBeInTheDocument();
   await dismissPlansDialog();
 
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/billing-plans-entry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/billing-plans-entry.test.tsx
@@ -1,0 +1,110 @@
+import {
+  billingUsagePackCatalogContract,
+  billingUsagePackManagementContract,
+} from "@okouai/api-contracts/contracts/billing";
+import { screen, waitFor, within } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import { click, setupPage } from "../../../__tests__/page-helper.ts";
+import { search } from "../../../signals/location.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+/** A new workspace with no active plan, so the sidebar offers the Pro upgrade. */
+function prepareUpgradeFlow(): void {
+  context.mocks.browser.matchMedia((query) => {
+    return query === "(min-width: 48rem)";
+  });
+  context.mocks.data.agents([
+    {
+      agentId: AGENT_ID,
+      ownerId: "test-user-123",
+      displayName: "Zero",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      visibility: "public",
+    },
+  ]);
+  context.mocks.api(billingUsagePackCatalogContract.get, ({ respond }) => {
+    return respond(200, {
+      usagePacks: [
+        {
+          usagePackUsd: 20,
+          priceUsd: 20,
+          purchasedCredits: 20_000,
+          bonusCredits: 2000,
+          totalCredits: 22_000,
+        },
+      ],
+    });
+  });
+  context.mocks.api(billingUsagePackManagementContract.get, ({ respond }) => {
+    return respond(404, {
+      error: {
+        code: "NOT_FOUND",
+        message: "No usage-pack subscription",
+      },
+    });
+  });
+}
+
+async function clickSidebarUpgradeCard(): Promise<void> {
+  const upgradeCard = (await screen.findByText("Get Pro")).closest("button");
+  if (!upgradeCard) {
+    throw new Error("Sidebar upgrade card is not mounted");
+  }
+  click(upgradeCard);
+}
+
+async function dismissPlansDialog(): Promise<void> {
+  const plansDialog = await screen.findByRole("dialog", {
+    name: "Choose a plan",
+  });
+  click(within(plansDialog).getByLabelText("Close"));
+}
+
+test("Dismissing the sidebar upgrade flow returns to the chat screen", async () => {
+  prepareUpgradeFlow();
+
+  await setupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+  await clickSidebarUpgradeCard();
+  await dismissPlansDialog();
+
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("dialog", { name: "Choose a plan" }),
+    ).not.toBeInTheDocument();
+  });
+  expect(
+    screen.queryByRole("dialog", { name: "Settings" }),
+  ).not.toBeInTheDocument();
+  expect(search()).not.toContain("settings=billing");
+});
+
+test("Relaunching the upgrade flow after dismissing a plans deep link", async () => {
+  prepareUpgradeFlow();
+
+  await setupPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat?settings=billing&billingView=plans`,
+  });
+
+  await dismissPlansDialog();
+
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("dialog", { name: "Settings" }),
+    ).not.toBeInTheDocument();
+  });
+
+  await clickSidebarUpgradeCard();
+
+  await expect(
+    screen.findByRole("dialog", { name: "Choose a plan" }),
+  ).resolves.toBeInTheDocument();
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
@@ -453,19 +453,17 @@ test("Explain model availability by plan and provider", async () => {
     name: "Choose a plan",
   });
   expect(planDialog).toBeVisible();
+  // The composer opened the upgrade flow, so dismissing it returns to the
+  // composer instead of leaving the Settings billing tab open underneath.
   click(buttonNamed("Close", planDialog));
   await waitFor(() => {
     expect(
       screen.queryByRole("dialog", { name: "Choose a plan" }),
     ).not.toBeInTheDocument();
   });
-  const settingsDialog = screen.getByRole("dialog", { name: "Settings" });
-  click(buttonNamed("Close", settingsDialog));
-  await waitFor(() => {
-    expect(
-      screen.queryByRole("dialog", { name: "Settings" }),
-    ).not.toBeInTheDocument();
-  });
+  expect(
+    screen.queryByRole("dialog", { name: "Settings" }),
+  ).not.toBeInTheDocument();
   expect(
     screen.getByRole("combobox", { name: "DeepSeek V4 Flash" }),
   ).toBeVisible();

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
@@ -2664,7 +2664,7 @@ function StandaloneBillingPricingDialog({
       >
         <DialogTitle className="sr-only">
           {i18n.t(($) => {
-            return $.billing.plans.usagePacks.choosePlan;
+            return $.settings.dialog.sections.billing.title;
           })}
         </DialogTitle>
         <div className="dialog-scrollable flex min-h-0 flex-1 flex-col overflow-y-auto p-5">

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
@@ -99,7 +99,10 @@ import {
 } from "../../../../signals/okou-page/settings/workspace-settings-state.ts";
 import { currentLocale, i18n } from "../../../../i18n/index.ts";
 import { formatLocalizedNumber, formatUsd } from "../../../../i18n/format.ts";
-import { openSettingsUsagePackUpgrade$ } from "../../../../signals/okou-page/settings/settings-dialog.ts";
+import {
+  dismissBillingPlans$,
+  openSettingsUsagePackUpgrade$,
+} from "../../../../signals/okou-page/settings/settings-dialog.ts";
 import {
   UsagePackMigrationPage,
   UsagePackMigrationDialogs,
@@ -2805,6 +2808,7 @@ export function OrgBillingTab() {
   const setBillingSubPage = useSet(setBillingSubPage$);
   const openMigrationPage = useSet(openBillingMigrationSubPage$);
   const buyCreditsScrollRef = useSet(buyCreditsScrollRef$);
+  const dismissPlans = useSet(dismissBillingPlans$);
   const closeBillingSubPage = () => {
     return setBillingSubPage(false);
   };
@@ -2922,7 +2926,7 @@ export function OrgBillingTab() {
         onSelectMigration={openMigrationPage}
         scheduledChange={scheduledChange}
         periodEnd={periodEnd}
-        onBack={closeBillingSubPage}
+        onBack={dismissPlans}
         onRestore={handleRestore}
         paidConcurrency={paidConcurrency}
       />
@@ -3100,7 +3104,7 @@ export function OrgBillingTab() {
           migrationOpen={migrationOpen}
           migrationTargetTier={migrationTargetTier}
           onMigrationBack={closeMigrationSubPage}
-          onClose={closeBillingSubPage}
+          onClose={dismissPlans}
           onReplaceCancellationWithPro={replaceCancellationWithPro}
           onSelectMigration={openMigrationPage}
         />

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-billing-tab.tsx
@@ -2642,6 +2642,72 @@ function BillingPricingPage({
   );
 }
 
+function StandaloneBillingPricingDialog({
+  children,
+  onClose,
+}: {
+  readonly children: React.ReactNode;
+  readonly onClose: () => void;
+}) {
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent
+        aria-describedby={undefined}
+        className="zero-app flex h-[min(43rem,calc(100dvh-4rem))] w-[calc(100vw-2rem)] max-w-[860px] flex-col gap-0 overflow-hidden p-0"
+      >
+        <DialogTitle className="sr-only">
+          {i18n.t(($) => {
+            return $.billing.plans.usagePacks.choosePlan;
+          })}
+        </DialogTitle>
+        <div className="dialog-scrollable flex min-h-0 flex-1 flex-col overflow-y-auto p-5">
+          {children}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function billingPricingReplacement({
+  onStandaloneClose,
+  pricingFlow,
+  pricingOpen,
+  pricingPage,
+  standalonePlans,
+  usagePackPlanDialogs,
+}: {
+  readonly onStandaloneClose: () => void;
+  readonly pricingFlow: React.ReactNode;
+  readonly pricingOpen: boolean;
+  readonly pricingPage: React.ReactNode;
+  readonly standalonePlans: boolean;
+  readonly usagePackPlanDialogs: boolean;
+}): React.ReactNode | null {
+  if (!pricingOpen) {
+    return null;
+  }
+  if (!usagePackPlanDialogs) {
+    return standalonePlans ? (
+      <StandaloneBillingPricingDialog onClose={onStandaloneClose}>
+        {pricingPage}
+      </StandaloneBillingPricingDialog>
+    ) : (
+      pricingPage
+    );
+  }
+  if (standalonePlans) {
+    return pricingFlow;
+  }
+  return null;
+}
+
 function shouldWaitForUsagePackMigration(loading: boolean): boolean {
   return loading;
 }
@@ -2800,7 +2866,11 @@ function UsagePackPricingFlowDialogs({
   );
 }
 
-export function OrgBillingTab() {
+export function OrgBillingTab({
+  standalonePlans = false,
+}: {
+  readonly standalonePlans?: boolean;
+}) {
   const { t } = useTranslation();
   const pricingOpen = useGet(billingSubPage$);
   const migrationOpen = useGet(billingMigrationSubPage$);
@@ -2913,24 +2983,48 @@ export function OrgBillingTab() {
     migration,
   );
 
-  if (pricingOpen && !usagePackPlanDialogs) {
-    return (
-      <BillingPricingPage
-        currentTier={currentTier}
-        canRestorePlan={canRestorePlan}
-        migration={migration}
-        migrationLoading={migrationLoading}
-        migrationOpen={migrationOpen}
-        migrationTargetTier={migrationTargetTier}
-        onMigrationBack={closeMigrationSubPage}
-        onSelectMigration={openMigrationPage}
-        scheduledChange={scheduledChange}
-        periodEnd={periodEnd}
-        onBack={dismissPlans}
-        onRestore={handleRestore}
-        paidConcurrency={paidConcurrency}
-      />
-    );
+  const pricingFlow = (
+    <UsagePackPricingFlowDialogs
+      checkoutAllowed={canStartUsagePackCheckout(status)}
+      currentTier={currentTier}
+      grantedPlanCheckoutAllowed={canConfigureGrantedUsagePackPlan(status)}
+      migration={migration}
+      migrationOpen={migrationOpen}
+      migrationTargetTier={migrationTargetTier}
+      onMigrationBack={closeMigrationSubPage}
+      onClose={dismissPlans}
+      onReplaceCancellationWithPro={replaceCancellationWithPro}
+      onSelectMigration={openMigrationPage}
+    />
+  );
+  const pricingPage = (
+    <BillingPricingPage
+      currentTier={currentTier}
+      canRestorePlan={canRestorePlan}
+      migration={migration}
+      migrationLoading={migrationLoading}
+      migrationOpen={migrationOpen}
+      migrationTargetTier={migrationTargetTier}
+      onMigrationBack={closeMigrationSubPage}
+      onSelectMigration={openMigrationPage}
+      scheduledChange={scheduledChange}
+      periodEnd={periodEnd}
+      onBack={dismissPlans}
+      onRestore={handleRestore}
+      paidConcurrency={paidConcurrency}
+    />
+  );
+  const pricingReplacement = billingPricingReplacement({
+    onStandaloneClose: dismissPlans,
+    pricingFlow,
+    pricingOpen,
+    pricingPage,
+    standalonePlans,
+    usagePackPlanDialogs,
+  });
+
+  if (pricingReplacement) {
+    return pricingReplacement;
   }
 
   return (
@@ -3092,23 +3186,7 @@ export function OrgBillingTab() {
 
       {showConcurrency && <ConcurrencyBillingSection status={status} />}
 
-      {/* Past the early return above, an open billing sub-page is an actionable
-          usage pack pricing flow. Mount it only while it is open so its catalog
-          and subscription load with the flow, not with every tab visit. */}
-      {pricingOpen && (
-        <UsagePackPricingFlowDialogs
-          checkoutAllowed={canStartUsagePackCheckout(status)}
-          currentTier={currentTier}
-          grantedPlanCheckoutAllowed={canConfigureGrantedUsagePackPlan(status)}
-          migration={migration}
-          migrationOpen={migrationOpen}
-          migrationTargetTier={migrationTargetTier}
-          onMigrationBack={closeMigrationSubPage}
-          onClose={dismissPlans}
-          onReplaceCancellationWithPro={replaceCancellationWithPro}
-          onSelectMigration={openMigrationPage}
-        />
-      )}
+      {pricingOpen && pricingFlow}
 
       <DowngradeConfirmDialog
         currentTier={currentTier}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/billing-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/billing-section.tsx
@@ -1,5 +1,9 @@
 import { OrgBillingTab } from "../../org-manage/org-billing-tab.tsx";
 
-export function BillingSection() {
-  return <OrgBillingTab />;
+export function BillingSection({
+  standalonePlans = false,
+}: {
+  readonly standalonePlans?: boolean;
+}) {
+  return <OrgBillingTab standalonePlans={standalonePlans} />;
 }

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -29,6 +29,7 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
 import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
+import { billingPlansStandalone$ } from "../../../../signals/okou-page/settings/workspace-settings-state.ts";
 import {
   isAdminOnlySettingsSection,
   settingsActiveSection$,
@@ -98,7 +99,15 @@ function SectionContent({ section }: { section: SettingsSection }) {
   return <Component />;
 }
 
-export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
+export function SettingsDialog(props: SettingsDialogProps) {
+  const standalonePlans = useGet(billingPlansStandalone$);
+  if (props.open && standalonePlans) {
+    return <BillingSection standalonePlans />;
+  }
+  return <SettingsDialogSurface {...props} />;
+}
+
+function SettingsDialogSurface({ open, onOpenChange }: SettingsDialogProps) {
   const { t } = useTranslation();
   const activeSection = useGet(settingsActiveSection$);
   const setActiveSection = useSet(setSettingsActiveSection$);


### PR DESCRIPTION
## Problem

Fixes #31725.

For a newly created user with no active plan, clicking **Get Pro** outside Settings opened two stacked surfaces: **Choose a plan** on top of **Settings > Billing**. Closing the plan picker then exposed Billing, forcing the user to dismiss a second surface.

The same standalone plan flow can be launched from the sidebar, chat actions and model selection, insufficient-credit and voice-quota prompts, and the billing plans deep link.

## Change

- Track whether the plans sub-page was already open when a Settings session starts, which identifies plan flows launched outside Settings.
- For a standalone plan flow, mount Billing without the Settings shell and render the existing pricing dialog as the only modal surface.
- Keep loading or migration-progress content in one billing-labelled dialog until an actionable plan dialog is ready, avoiding a duplicate accessible name during the transition.
- Closing a standalone plan flow releases the Settings session and clears its billing sub-page; opening plans from inside Settings still returns to **Settings > Billing**.

## Verification

### Automated

- Five focused app test files: 72 tests passed, covering standalone plan entry, chat plan actions, model selection, Billing, and Settings.
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace apps/platform`
- Prettier and `git diff --check`
- Exact-head CI for `4289db7`: all Turbo app test shards, lint/type checks, security checks, and final gates passed.

### PR preview walkthrough

Preview app: https://pr-31737-app-okou-app-preview.vm0.workers.dev  
Preview API: https://pr-31737-api.vm6.ai

- Desktop sidebar **Get Pro**: exactly one visible `Choose a plan` dialog; the background is Chat, not Settings. Closing leaves zero dialogs and returns to Chat. [Screenshot](https://cdn.vm0.io/artifacts/0cyomaeoqi.png)
- Mobile (393 x 852): exactly one visible `Choose a plan` dialog with body scroll locked; closing leaves zero dialogs and no Settings surface. [Screenshot](https://cdn.vm0.io/artifacts/x4qsdk4c0k.png)
- Desktop **Settings > Billing > Upgrade**: retains the intentional Settings-owned flow; closing the plan picker returns to Billing with the Settings dialog still open. [Screenshot](https://cdn.vm0.io/artifacts/rg8g13rv8a.png)
- No browser page errors were reported; console output was limited to the expected Clerk development-key warning.

## Acceptance criteria

- [x] A single standalone **Get Pro** action produces one visible modal.
- [x] Closing the standalone plan picker returns to the launching screen without a Billing modal underneath.
- [x] Plans opened from inside Settings still return to the Billing section.
- [x] Desktop and mobile preview behavior is verified.
- [x] Regression coverage includes a new user with no active plan and chat action entry points.
