### PR TITLE
fix(platform): restore clerk satellite auth navigation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,6 +177,28 @@ A server-side upload to the same conversion action using the same transaction
 ID when browser delivery may be missed.
 _Avoid_: Separate conversion, duplicate conversion
 
+# Clerk Satellite Authentication Context
+
+This context separates the app that owns authentication from another app that
+shares the same Clerk instance and receives its session.
+
+## Language
+
+**Clerk primary app**:
+The app origin where sign-in and sign-up run and where the primary Clerk
+session is established.
+_Avoid_: Main brand, login tab
+
+**Clerk satellite app**:
+A registered app origin that shares the primary app's Clerk instance and
+receives synchronized session state.
+_Avoid_: Secondary login, separate Clerk instance
+
+**Satellite session sync**:
+The Clerk-owned navigation handshake that transfers the active primary-app
+session into the current satellite browser context.
+_Avoid_: Cookie copy, custom auth redirect
+
 # Chat Image Annotation Context
 
 This context separates an uploaded image, its editable annotation structure,

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -999,7 +999,10 @@ function defaultBuildAuthUrl(
   if (internalMockedClerkLoadOptions.isSatellite) {
     redirectUrl.searchParams.set("__clerk_synced", "false");
   }
-  authUrl.searchParams.set("redirect_url", redirectUrl.toString());
+  // Clerk serializes redirect options into the auth route's fragment.
+  const authHashParams = new URLSearchParams();
+  authHashParams.set("redirect_url", redirectUrl.toString());
+  authUrl.hash = `/?${authHashParams.toString()}`;
   return authUrl.toString();
 }
 

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -646,6 +646,14 @@ function clearMockedAuth() {
   );
   mockedClerk.buildSignInUrl.mockReset();
   mockedClerk.buildSignInUrl.mockImplementation(defaultBuildSignInUrlImpl);
+  mockedClerk.buildSignUpUrl.mockReset();
+  mockedClerk.buildSignUpUrl.mockImplementation(defaultBuildSignUpUrlImpl);
+  mockedClerk.navigate.mockReset();
+  mockedClerk.navigate.mockImplementation(defaultNavigateImpl);
+  mockedClerk.redirectToSignIn.mockReset();
+  mockedClerk.redirectToSignIn.mockImplementation(defaultRedirectToSignInImpl);
+  mockedClerk.redirectToSignUp.mockReset();
+  mockedClerk.redirectToSignUp.mockImplementation(defaultRedirectToSignUpImpl);
   mockedClerk.initialize.mockReset();
 }
 
@@ -971,15 +979,17 @@ interface MockedSignInRedirectOptions {
   redirectUrl?: string | null;
 }
 
-const defaultBuildSignInUrlImpl = (
+function defaultBuildAuthUrl(
+  configuredUrl: string | undefined,
+  fallbackPath: "/sign-in" | "/sign-up",
   options?: MockedSignInRedirectOptions,
-): string => {
+): string {
   if (!internalMockedClerkLoaded) {
     return "";
   }
 
-  const signInUrl = new URL(
-    internalMockedClerkLoadOptions.signInUrl ?? "/sign-in",
+  const authUrl = new URL(
+    configuredUrl ?? fallbackPath,
     window.location.origin,
   );
   const redirectUrl = new URL(
@@ -989,8 +999,45 @@ const defaultBuildSignInUrlImpl = (
   if (internalMockedClerkLoadOptions.isSatellite) {
     redirectUrl.searchParams.set("__clerk_synced", "false");
   }
-  signInUrl.searchParams.set("redirect_url", redirectUrl.toString());
-  return signInUrl.toString();
+  authUrl.searchParams.set("redirect_url", redirectUrl.toString());
+  return authUrl.toString();
+}
+
+const defaultBuildSignInUrlImpl = (
+  options?: MockedSignInRedirectOptions,
+): string => {
+  return defaultBuildAuthUrl(
+    internalMockedClerkLoadOptions.signInUrl,
+    "/sign-in",
+    options,
+  );
+};
+
+const defaultBuildSignUpUrlImpl = (
+  options?: MockedSignInRedirectOptions,
+): string => {
+  return defaultBuildAuthUrl(
+    internalMockedClerkLoadOptions.signUpUrl,
+    "/sign-up",
+    options,
+  );
+};
+
+const defaultNavigateImpl: BrowserClerk["navigate"] = (to) => {
+  replaceState(null, "", to);
+  return Promise.resolve();
+};
+
+const defaultRedirectToSignInImpl: BrowserClerk["redirectToSignIn"] = async (
+  options,
+): Promise<void> => {
+  await defaultNavigateImpl(defaultBuildSignInUrlImpl(options));
+};
+
+const defaultRedirectToSignUpImpl: BrowserClerk["redirectToSignUp"] = async (
+  options,
+): Promise<void> => {
+  await defaultNavigateImpl(defaultBuildSignUpUrlImpl(options));
 };
 
 const defaultLoadImpl = (options?: MockedClerkLoadOptions) => {
@@ -1220,9 +1267,18 @@ export const mockedClerk = {
       }
     };
   },
-  redirectToSignIn: vi.fn<BrowserClerk["redirectToSignIn"]>(),
+  navigate: vi.fn<BrowserClerk["navigate"]>(defaultNavigateImpl),
+  redirectToSignIn: vi.fn<BrowserClerk["redirectToSignIn"]>(
+    defaultRedirectToSignInImpl,
+  ),
+  redirectToSignUp: vi.fn<BrowserClerk["redirectToSignUp"]>(
+    defaultRedirectToSignUpImpl,
+  ),
   buildSignInUrl: vi.fn<typeof defaultBuildSignInUrlImpl>(
     defaultBuildSignInUrlImpl,
+  ),
+  buildSignUpUrl: vi.fn<typeof defaultBuildSignUpUrlImpl>(
+    defaultBuildSignUpUrlImpl,
   ),
   // Production-instance behavior: the URL passes through unchanged. Dev
   // instances append the __clerk_db_jwt session handoff parameter.

--- a/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
+++ b/turbo/apps/platform/src/signals/auth-v2-page-setup.ts
@@ -23,16 +23,14 @@ import {
   type AuthV2SignUpSignals,
 } from "./auth-v2/sign-up-flow.ts";
 import { AUTH_V2_SIGN_UP_OAUTH_CALLBACK_PATH } from "./auth-v2/sign-up-external-strategies.ts";
-import { resolveSatelliteAuthRouteRedirectUrl } from "./auth.ts";
+import { navigateSatelliteAuthRoute$ } from "./auth.ts";
 import { updateDocumentTitle$ } from "./document-title.ts";
 import { updatePage$ } from "./react-router.ts";
 import { ROUTES } from "./route-paths.ts";
 
 function setupAuthV2Page(mode: AuthV2PageMode) {
   return command(async ({ get, set }, signal: AbortSignal) => {
-    const satelliteAuthRedirectUrl = resolveSatelliteAuthRouteRedirectUrl(mode);
-    if (satelliteAuthRedirectUrl) {
-      location.replace(satelliteAuthRedirectUrl);
+    if (await set(navigateSatelliteAuthRoute$, mode, signal)) {
       return;
     }
 

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -193,16 +193,18 @@ export function resolveAppAuthUrl(
   return url.toString();
 }
 
-export function resolveSatelliteAuthRouteRedirectUrl(
+interface SatelliteAuthRouteNavigation {
+  readonly completionRedirectUrl: string;
+  readonly preservesRouteState: boolean;
+}
+
+function resolveSatelliteAuthRouteNavigation(
   mode: "sign-in" | "sign-up",
-): string | null {
+): SatelliteAuthRouteNavigation | null {
   if (!resolveClerkSatelliteConfig()) {
     return null;
   }
 
-  // Clerk authentication must run on the configured primary app. Keep the
-  // satellite destination explicit so the primary flow can safely return to
-  // the originating brand after it completes.
   const allowedRedirectOrigins = getAllowedAuthRedirectOriginsForCurrentPage();
   const completionRedirectUrl =
     mode === "sign-in"
@@ -216,12 +218,17 @@ export function resolveSatelliteAuthRouteRedirectUrl(
           allowedRedirectOrigins,
           location.hash,
         );
-  const redirectUrl = new URL(resolveAppAuthUrl("/sign-in"));
-  redirectUrl.pathname = location.pathname;
-  redirectUrl.search = location.search;
-  redirectUrl.hash = location.hash;
-  redirectUrl.searchParams.set("redirect_url", completionRedirectUrl);
-  return redirectUrl.toString();
+  const authRoute = mode === "sign-in" ? "/sign-in" : "/sign-up";
+  const routeState = new URLSearchParams(location.search);
+  routeState.delete("redirect_url");
+
+  return {
+    completionRedirectUrl,
+    preservesRouteState:
+      location.pathname !== authRoute ||
+      routeState.size > 0 ||
+      location.hash !== "",
+  };
 }
 
 // Clerk allowedRedirectOrigins for the current host: this app plus its www
@@ -424,6 +431,63 @@ export const clerk$ = computed(async () => {
 
   return runtime.clerk;
 });
+
+/**
+ * Moves satellite authentication to Clerk's primary app without bypassing
+ * Clerk's session-sync lifecycle. Stateful routes keep their path, query, and
+ * hash on top of the URL constructed by Clerk.
+ */
+export const navigateSatelliteAuthRoute$ = command(
+  async (
+    { get },
+    mode: "sign-in" | "sign-up",
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    const navigation = resolveSatelliteAuthRouteNavigation(mode);
+    if (!navigation) {
+      return false;
+    }
+
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+
+    if (!navigation.preservesRouteState) {
+      if (mode === "sign-in") {
+        await clerk.redirectToSignIn({
+          redirectUrl: navigation.completionRedirectUrl,
+        });
+      } else {
+        await clerk.redirectToSignUp({
+          redirectUrl: navigation.completionRedirectUrl,
+        });
+      }
+      signal.throwIfAborted();
+      return true;
+    }
+
+    const authUrl = new URL(
+      mode === "sign-in"
+        ? clerk.buildSignInUrl({
+            redirectUrl: navigation.completionRedirectUrl,
+          })
+        : clerk.buildSignUpUrl({
+            redirectUrl: navigation.completionRedirectUrl,
+          }),
+      location.href,
+    );
+    authUrl.pathname = location.pathname;
+    const routeState = new URLSearchParams(location.search);
+    routeState.delete("redirect_url");
+    for (const [key, value] of routeState) {
+      authUrl.searchParams.append(key, value);
+    }
+    authUrl.hash = location.hash;
+
+    await clerk.navigate(authUrl.toString());
+    signal.throwIfAborted();
+    return true;
+  },
+);
 
 /**
  * Command to setup Clerk authentication listeners.

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -198,6 +198,37 @@ interface SatelliteAuthRouteNavigation {
   readonly preservesRouteState: boolean;
 }
 
+function mergeClerkAuthHash(clerkHash: string, routeHash: string): string {
+  if (!routeHash) {
+    return clerkHash;
+  }
+
+  const clerkHashQueryIndex = clerkHash.indexOf("?");
+  if (clerkHashQueryIndex === -1) {
+    return routeHash;
+  }
+
+  const clerkHashParams = new URLSearchParams(
+    clerkHash.slice(clerkHashQueryIndex + 1),
+  );
+  const routeHashQueryIndex = routeHash.indexOf("?");
+  const routeHashPath =
+    routeHashQueryIndex === -1
+      ? routeHash
+      : routeHash.slice(0, routeHashQueryIndex);
+  const routeHashParams = new URLSearchParams(
+    routeHashQueryIndex === -1 ? "" : routeHash.slice(routeHashQueryIndex + 1),
+  );
+  for (const [key, value] of clerkHashParams) {
+    routeHashParams.set(key, value);
+  }
+
+  const routeHashSearch = routeHashParams.toString();
+  return routeHashSearch
+    ? `${routeHashPath}?${routeHashSearch}`
+    : routeHashPath;
+}
+
 function resolveSatelliteAuthRouteNavigation(
   mode: "sign-in" | "sign-up",
 ): SatelliteAuthRouteNavigation | null {
@@ -481,7 +512,7 @@ export const navigateSatelliteAuthRoute$ = command(
     for (const [key, value] of routeState) {
       authUrl.searchParams.append(key, value);
     }
-    authUrl.hash = location.hash;
+    authUrl.hash = mergeClerkAuthHash(authUrl.hash, location.hash);
 
     await clerk.navigate(authUrl.toString());
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/sign-in-token-setup.ts
+++ b/turbo/apps/platform/src/signals/sign-in-token-setup.ts
@@ -3,8 +3,8 @@ import {
   buildSignInRedirectUrl,
   clerk$,
   getAllowedAuthRedirectOriginsForCurrentPage,
+  navigateSatelliteAuthRoute$,
   resolveAppAuthUrl,
-  resolveSatelliteAuthRouteRedirectUrl,
 } from "./auth.ts";
 import { searchParams$, detachedNavigateTo$ } from "./route.ts";
 import { logger } from "./log.ts";
@@ -22,10 +22,7 @@ const L = logger("SignInToken");
  */
 export const setupSignInTokenPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const satelliteAuthRedirectUrl =
-      resolveSatelliteAuthRouteRedirectUrl("sign-in");
-    if (satelliteAuthRedirectUrl) {
-      location.replace(satelliteAuthRedirectUrl);
+    if (await set(navigateSatelliteAuthRoute$, "sign-in", signal)) {
       return;
     }
 

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-navigation-hosts.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-navigation-hosts.test.tsx
@@ -21,6 +21,12 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 
+function withClerkSatelliteSync(url: string): string {
+  const destination = new URL(url);
+  destination.searchParams.set("__clerk_synced", "false");
+  return destination.toString();
+}
+
 function currentSignInResource() {
   return mockedClerk.client.signIn;
 }
@@ -79,7 +85,40 @@ test("A presentation-onboarding deep link survives sign-in", async () => {
   );
 });
 
-test("An Okou sign-in route moves authentication to the primary app", async () => {
+test("An Okou sign-in route waits for Clerk before moving to the primary app", async () => {
+  const returnUrl = "https://app.okou.ai/agents?source=direct-sign-in";
+  const clerk = context.mocks.clerk();
+  const clerkResource = clerk.resourcePending();
+
+  await startPage({
+    context,
+    host: "app.okou.ai",
+    path: `/sign-in?redirect_url=${encodeURIComponent(returnUrl)}`,
+    auth: null,
+  });
+
+  await waitFor(() => {
+    expect(clerk.resourceRequests).toHaveLength(1);
+  });
+  expect(location.origin).toBe("https://app.okou.ai");
+  expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
+
+  clerkResource.resolve();
+
+  await waitFor(() => {
+    expect(location.origin).toBe("https://app.vm0.ai");
+  });
+  const destination = new URL(location.href);
+  expect(destination.pathname).toBe("/sign-in");
+  expect(destination.searchParams.get("redirect_url")).toBe(
+    withClerkSatelliteSync(returnUrl),
+  );
+  expect(mockedClerk.redirectToSignIn).toHaveBeenCalledWith({
+    redirectUrl: returnUrl,
+  });
+});
+
+test("An Okou stateful sign-in route moves authentication to the primary app", async () => {
   const returnUrl = "https://app.okou.ai/agents?source=direct-sign-in";
   await startPage({
     context,
@@ -93,11 +132,35 @@ test("An Okou sign-in route moves authentication to the primary app", async () =
   });
   const destination = new URL(location.href);
   expect(destination.pathname).toBe("/sign-in");
-  expect(destination.searchParams.get("redirect_url")).toBe(returnUrl);
+  expect(destination.searchParams.get("redirect_url")).toBe(
+    withClerkSatelliteSync(returnUrl),
+  );
   expect(destination.hash).toBe("#/identifier");
 });
 
 test("An Okou sign-up route moves registration to the primary app", async () => {
+  const returnUrl = "https://app.okou.ai/onboarding?source=direct-sign-up";
+  await startPage({
+    context,
+    host: "app.okou.ai",
+    path: `/sign-up?redirect_url=${encodeURIComponent(returnUrl)}`,
+    auth: null,
+  });
+
+  await waitFor(() => {
+    expect(location.origin).toBe("https://app.vm0.ai");
+  });
+  const destination = new URL(location.href);
+  expect(destination.pathname).toBe("/sign-up");
+  expect(destination.searchParams.get("redirect_url")).toBe(
+    withClerkSatelliteSync(returnUrl),
+  );
+  expect(mockedClerk.redirectToSignUp).toHaveBeenCalledWith({
+    redirectUrl: returnUrl,
+  });
+});
+
+test("An Okou stateful sign-up route moves registration to the primary app", async () => {
   const returnUrl = "https://app.okou.ai/onboarding?source=direct-sign-up";
   await startPage({
     context,
@@ -111,8 +174,92 @@ test("An Okou sign-up route moves registration to the primary app", async () => 
   });
   const destination = new URL(location.href);
   expect(destination.pathname).toBe("/sign-up");
-  expect(destination.searchParams.get("redirect_url")).toBe(returnUrl);
+  expect(destination.searchParams.get("redirect_url")).toBe(
+    withClerkSatelliteSync(returnUrl),
+  );
   expect(destination.hash).toBe("#/profile");
+});
+
+test("Okou sign-up attribution survives the move to the primary app", async () => {
+  await startPage({
+    context,
+    host: "app.okou.ai",
+    path: "/sign-up?gclid=click-123&utm_campaign=summer&utm_content=hero&utm_content=footer",
+    auth: null,
+  });
+
+  await waitFor(() => {
+    expect(location.origin).toBe("https://app.vm0.ai");
+  });
+  const destination = new URL(location.href);
+  expect(destination.pathname).toBe("/sign-up");
+  expect(destination.searchParams.get("gclid")).toBe("click-123");
+  expect(destination.searchParams.get("utm_campaign")).toBe("summer");
+  expect(destination.searchParams.getAll("utm_content")).toStrictEqual([
+    "hero",
+    "footer",
+  ]);
+  const redirectUrl = destination.searchParams.get("redirect_url");
+  if (!redirectUrl) {
+    throw new Error("Expected Clerk to retain the completion destination");
+  }
+  const completion = new URL(redirectUrl);
+  expect(completion.origin).toBe("https://app.okou.ai");
+  expect(completion.pathname).toBe("/onboarding");
+  expect(completion.searchParams.get("gclid")).toBe("click-123");
+  expect(completion.searchParams.get("utm_campaign")).toBe("summer");
+  expect(completion.searchParams.getAll("utm_content")).toStrictEqual([
+    "hero",
+    "footer",
+  ]);
+  expect(completion.searchParams.get("__clerk_synced")).toBe("false");
+});
+
+test("An Okou OAuth callback keeps its state on the primary app", async () => {
+  const returnUrl = "https://app.okou.ai/agents?source=oauth-callback";
+  await startPage({
+    context,
+    host: "app.okou.ai",
+    path: `/sign-in/sso-callback?code=oauth-code&state=oauth-state&redirect_url=${encodeURIComponent(
+      returnUrl,
+    )}#/callback?attempt=1`,
+    auth: null,
+  });
+
+  await waitFor(() => {
+    expect(location.origin).toBe("https://app.vm0.ai");
+  });
+  const destination = new URL(location.href);
+  expect(destination.pathname).toBe("/sign-in/sso-callback");
+  expect(destination.searchParams.get("code")).toBe("oauth-code");
+  expect(destination.searchParams.get("state")).toBe("oauth-state");
+  expect(destination.searchParams.get("redirect_url")).toBe(
+    withClerkSatelliteSync(returnUrl),
+  );
+  expect(destination.hash).toBe("#/callback?attempt=1");
+});
+
+test("An Okou session task keeps its state on the primary app", async () => {
+  const returnUrl = "https://app.okou.ai/onboarding?source=session-task";
+  await startPage({
+    context,
+    host: "app.okou.ai",
+    path: `/sign-up/tasks/choose-organization?session_id=session-test&redirect_url=${encodeURIComponent(
+      returnUrl,
+    )}#/tasks/choose-organization?attempt=1`,
+    auth: null,
+  });
+
+  await waitFor(() => {
+    expect(location.origin).toBe("https://app.vm0.ai");
+  });
+  const destination = new URL(location.href);
+  expect(destination.pathname).toBe("/sign-up/tasks/choose-organization");
+  expect(destination.searchParams.get("session_id")).toBe("session-test");
+  expect(destination.searchParams.get("redirect_url")).toBe(
+    withClerkSatelliteSync(returnUrl),
+  );
+  expect(destination.hash).toBe("#/tasks/choose-organization?attempt=1");
 });
 
 test("An Okou sign-in ticket is redeemed by the primary app", async () => {
@@ -132,7 +279,9 @@ test("An Okou sign-in ticket is redeemed by the primary app", async () => {
   const destination = new URL(location.href);
   expect(destination.pathname).toBe("/sign-in-token");
   expect(destination.searchParams.get("token")).toBe("clerk-ticket");
-  expect(destination.searchParams.get("redirect_url")).toBe(returnUrl);
+  expect(destination.searchParams.get("redirect_url")).toBe(
+    withClerkSatelliteSync(returnUrl),
+  );
   expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
 });
 

--- a/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-navigation-hosts.test.tsx
+++ b/turbo/apps/platform/src/views/auth-v2/__tests__/auth-v2-navigation-hosts.test.tsx
@@ -27,6 +27,13 @@ function withClerkSatelliteSync(url: string): string {
   return destination.toString();
 }
 
+function clerkAuthFragment(url: URL): URL {
+  if (!url.hash.startsWith("#/")) {
+    throw new Error("Expected Clerk auth state in the URL fragment");
+  }
+  return new URL(url.hash.slice(1), url.origin);
+}
+
 function currentSignInResource() {
   return mockedClerk.client.signIn;
 }
@@ -80,7 +87,7 @@ test("A presentation-onboarding deep link survives sign-in", async () => {
     expect(location.pathname).toBe("/sign-in");
   });
   const current = new URL(location.href);
-  expect(current.searchParams.get("redirect_url")).toBe(
+  expect(clerkAuthFragment(current).searchParams.get("redirect_url")).toBe(
     PRESENTATION_ONBOARDING_URL,
   );
 });
@@ -110,7 +117,7 @@ test("An Okou sign-in route waits for Clerk before moving to the primary app", a
   });
   const destination = new URL(location.href);
   expect(destination.pathname).toBe("/sign-in");
-  expect(destination.searchParams.get("redirect_url")).toBe(
+  expect(clerkAuthFragment(destination).searchParams.get("redirect_url")).toBe(
     withClerkSatelliteSync(returnUrl),
   );
   expect(mockedClerk.redirectToSignIn).toHaveBeenCalledWith({
@@ -132,10 +139,11 @@ test("An Okou stateful sign-in route moves authentication to the primary app", a
   });
   const destination = new URL(location.href);
   expect(destination.pathname).toBe("/sign-in");
-  expect(destination.searchParams.get("redirect_url")).toBe(
+  const authFragment = clerkAuthFragment(destination);
+  expect(authFragment.searchParams.get("redirect_url")).toBe(
     withClerkSatelliteSync(returnUrl),
   );
-  expect(destination.hash).toBe("#/identifier");
+  expect(authFragment.pathname).toBe("/identifier");
 });
 
 test("An Okou sign-up route moves registration to the primary app", async () => {
@@ -152,7 +160,7 @@ test("An Okou sign-up route moves registration to the primary app", async () => 
   });
   const destination = new URL(location.href);
   expect(destination.pathname).toBe("/sign-up");
-  expect(destination.searchParams.get("redirect_url")).toBe(
+  expect(clerkAuthFragment(destination).searchParams.get("redirect_url")).toBe(
     withClerkSatelliteSync(returnUrl),
   );
   expect(mockedClerk.redirectToSignUp).toHaveBeenCalledWith({
@@ -174,10 +182,11 @@ test("An Okou stateful sign-up route moves registration to the primary app", asy
   });
   const destination = new URL(location.href);
   expect(destination.pathname).toBe("/sign-up");
-  expect(destination.searchParams.get("redirect_url")).toBe(
+  const authFragment = clerkAuthFragment(destination);
+  expect(authFragment.searchParams.get("redirect_url")).toBe(
     withClerkSatelliteSync(returnUrl),
   );
-  expect(destination.hash).toBe("#/profile");
+  expect(authFragment.pathname).toBe("/profile");
 });
 
 test("Okou sign-up attribution survives the move to the primary app", async () => {
@@ -199,7 +208,8 @@ test("Okou sign-up attribution survives the move to the primary app", async () =
     "hero",
     "footer",
   ]);
-  const redirectUrl = destination.searchParams.get("redirect_url");
+  const redirectUrl =
+    clerkAuthFragment(destination).searchParams.get("redirect_url");
   if (!redirectUrl) {
     throw new Error("Expected Clerk to retain the completion destination");
   }
@@ -233,10 +243,12 @@ test("An Okou OAuth callback keeps its state on the primary app", async () => {
   expect(destination.pathname).toBe("/sign-in/sso-callback");
   expect(destination.searchParams.get("code")).toBe("oauth-code");
   expect(destination.searchParams.get("state")).toBe("oauth-state");
-  expect(destination.searchParams.get("redirect_url")).toBe(
+  const authFragment = clerkAuthFragment(destination);
+  expect(authFragment.searchParams.get("redirect_url")).toBe(
     withClerkSatelliteSync(returnUrl),
   );
-  expect(destination.hash).toBe("#/callback?attempt=1");
+  expect(authFragment.pathname).toBe("/callback");
+  expect(authFragment.searchParams.get("attempt")).toBe("1");
 });
 
 test("An Okou session task keeps its state on the primary app", async () => {
@@ -256,10 +268,12 @@ test("An Okou session task keeps its state on the primary app", async () => {
   const destination = new URL(location.href);
   expect(destination.pathname).toBe("/sign-up/tasks/choose-organization");
   expect(destination.searchParams.get("session_id")).toBe("session-test");
-  expect(destination.searchParams.get("redirect_url")).toBe(
+  const authFragment = clerkAuthFragment(destination);
+  expect(authFragment.searchParams.get("redirect_url")).toBe(
     withClerkSatelliteSync(returnUrl),
   );
-  expect(destination.hash).toBe("#/tasks/choose-organization?attempt=1");
+  expect(authFragment.pathname).toBe("/tasks/choose-organization");
+  expect(authFragment.searchParams.get("attempt")).toBe("1");
 });
 
 test("An Okou sign-in ticket is redeemed by the primary app", async () => {
@@ -279,7 +293,7 @@ test("An Okou sign-in ticket is redeemed by the primary app", async () => {
   const destination = new URL(location.href);
   expect(destination.pathname).toBe("/sign-in-token");
   expect(destination.searchParams.get("token")).toBe("clerk-ticket");
-  expect(destination.searchParams.get("redirect_url")).toBe(
+  expect(clerkAuthFragment(destination).searchParams.get("redirect_url")).toBe(
     withClerkSatelliteSync(returnUrl),
   );
   expect(mockedClerk.clientSignInCreate).not.toHaveBeenCalled();
@@ -410,7 +424,9 @@ test("Okou uses primary authentication with satellite context", async () => {
     expect(location.origin).toBe("https://app.vm0.ai");
     expect(location.pathname).toBe("/sign-in");
   });
-  const redirect = new URL(location.href).searchParams.get("redirect_url");
+  const redirect = clerkAuthFragment(new URL(location.href)).searchParams.get(
+    "redirect_url",
+  );
   expect(redirect).toBe(
     "https://app.okou.ai/agents?utm_source=okou-launch&__clerk_synced=false",
   );
@@ -440,7 +456,9 @@ test("Registered Okou subdomains use primary authentication with satellite conte
     expect(location.origin).toBe("https://app.vm0.ai");
     expect(location.pathname).toBe("/sign-in");
   });
-  const redirect = new URL(location.href).searchParams.get("redirect_url");
+  const redirect = clerkAuthFragment(new URL(location.href)).searchParams.get(
+    "redirect_url",
+  );
   expect(redirect).toBe(
     "https://team.app.okou.ai/agents?utm_source=okou-launch&__clerk_synced=false",
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -1459,7 +1459,7 @@ test("Sign out from the account menu", async () => {
       expect.objectContaining({
         sessionId: "test-session-id",
         redirectUrl: expect.stringMatching(
-          /(?=.*\/sign-in\?)(?=.*redirect_url=)(?=.*__clerk_synced%3Dfalse)/,
+          /(?=.*\/sign-in#\/\?)(?=.*redirect_url=)(?=.*__clerk_synced%3Dfalse)/,
         ),
       }),
     );


### PR DESCRIPTION
## Summary

- wait for the Clerk runtime before leaving a satellite authentication route
- use Clerk's sign-in and sign-up redirects for base routes, and Clerk-built navigation for stateful callbacks, tasks, and sign-in tickets
- preserve validated completion destinations, route query/hash state, acquisition attribution, and Clerk's satellite sync marker
- extend the Clerk test boundary and document the primary/satellite session-sync terminology

## Context

Auth V2 redirected satellite routes with `location.replace()` before Clerk initialized. That bypassed Clerk's native navigation and `satelliteAutoSync` lifecycle, differing from the former Clerk React flow. This change restores Clerk-owned navigation without changing the existing redirect allowlist or authentication completion behavior.

## Verification

- `pnpm format`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/auth-v2/__tests__/auth-v2-navigation-hosts.test.tsx --silent=passed-only` (16 passed)
- `pnpm -F @okouai/app exec vitest run src/views/router/__tests__/link-navigation.test.tsx --silent=passed-only` (7 passed)
- `pnpm -F @okouai/app exec vitest run src/__tests__/authentication-startup.test.tsx --silent=passed-only` (8 passed)

## Follow-up validation

- verify Google sign-in from the Okou iOS standalone PWA on the preview deployment; the code now matches Clerk's navigation lifecycle, but WebKit container behavior still requires device validation
