### PR TITLE
fix(core): restrict intro video to bingjie

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -98,6 +98,7 @@ import {
   createBddApi,
   expectApiError,
   type ApiTestUser,
+  type ApiTestUserOptions,
 } from "./helpers/api-bdd";
 import { seedUserSecret, seedUserVariable } from "./helpers/user-config-state";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
@@ -1431,7 +1432,7 @@ function codexAuthJson(): string {
   });
 }
 
-async function entitledRunActor(): Promise<{
+async function entitledRunActor(userOptions: ApiTestUserOptions = {}): Promise<{
   readonly actor: ApiTestUser;
   readonly agentId: string;
   readonly runnerGroup: string;
@@ -1442,7 +1443,7 @@ async function entitledRunActor(): Promise<{
 }> {
   const bdd = createBddApi(context);
   const api = createRunsApi(context);
-  const actor = bdd.user();
+  const actor = bdd.user(userOptions);
   bdd.acceptAgentStorageWrites();
   api.acceptStorageDownloads();
   api.acceptTelemetryIngest();
@@ -1687,35 +1688,46 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
   });
 
   it("advertises intro-video camera tooling only while its rollout switch is on", async () => {
+    const bdd = createBddApi(context);
     const api = createRunsApi(context);
     const connectors = createConnectorBddApi(context);
-    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const { actor, agentId, runnerGroup } = await entitledRunActor({
+      email: "BINGJIE@VM0.AI",
+    });
     const toolHint = "Click-driven intro-video camera moves:";
+    await bdd.readMe(actor);
 
-    const gatedOff = await api.createRun(actor, {
+    const enabledByEmail = await api.createRun(actor, {
       agentId,
       prompt: "Create a polished video from the attached source.",
       modelProvider: "anthropic-api-key",
     });
     await api.heartbeatRunner(runnerGroup);
-    const gatedOffClaim = await api.claimRunnerJob(gatedOff.runId);
-    expect(gatedOffClaim.appendSystemPrompt ?? "").toContain("# Agent Tools");
-    expect(gatedOffClaim.appendSystemPrompt ?? "").not.toContain(toolHint);
+    const enabledByEmailClaim = await api.claimRunnerJob(enabledByEmail.runId);
+    expect(enabledByEmailClaim.appendSystemPrompt ?? "").toContain(toolHint);
+    expect(enabledByEmailClaim.appendSystemPrompt ?? "").toContain(
+      "okou video camera --help",
+    );
 
     await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.IntroVideo]: true,
+      [FeatureSwitchKey.IntroVideo]: false,
     });
 
-    const gatedOn = await api.createRun(actor, {
+    const disabledByOverride = await api.createRun(actor, {
       agentId,
       prompt: "Create a polished video from the attached source.",
       modelProvider: "anthropic-api-key",
     });
     await api.heartbeatRunner(runnerGroup);
-    const gatedOnClaim = await api.claimRunnerJob(gatedOn.runId);
-    const appendSystemPrompt = gatedOnClaim.appendSystemPrompt ?? "";
-    expect(appendSystemPrompt).toContain(toolHint);
-    expect(appendSystemPrompt).toContain("okou video camera --help");
+    const disabledByOverrideClaim = await api.claimRunnerJob(
+      disabledByOverride.runId,
+    );
+    expect(disabledByOverrideClaim.appendSystemPrompt ?? "").toContain(
+      "# Agent Tools",
+    );
+    expect(disabledByOverrideClaim.appendSystemPrompt ?? "").not.toContain(
+      toolHint,
+    );
   });
 
   it("advertises presentation screenshots only while their rollout switch is on", async () => {

--- a/turbo/apps/api/src/signals/services/run-bootstrap-context.service.ts
+++ b/turbo/apps/api/src/signals/services/run-bootstrap-context.service.ts
@@ -422,6 +422,7 @@ export function materializeRunBootstrapContext(
   const featureSwitchContext: FeatureSwitchContext = {
     orgId: args.orgId,
     userId: args.userId,
+    email: userInfo.email ?? undefined,
     overrides: userFeatureSwitchOverridesFromRows(
       featureSwitchRows,
       args.userId,

--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.tsx
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.tsx
@@ -17,6 +17,8 @@ import {
   mockOrgModelRoutes,
 } from "../../views/okou-page/__tests__/chat-composer-test-helpers.ts";
 
+const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+
 test("A signed-in workspace receives its enabled features", async () => {
   mockOrgModelRoutes("claude-sonnet-4-6");
   mockAgent();
@@ -36,6 +38,63 @@ test("A signed-in workspace receives its enabled features", async () => {
   await expect(
     screen.findByTestId("intro-video-start-card"),
   ).resolves.toBeVisible();
+});
+
+async function setupIntroVideoRolloutPage(args: {
+  readonly email: string;
+  readonly fullName: string;
+  readonly userId: string;
+}) {
+  mockOrgModelRoutes("claude-sonnet-4-6");
+  mockAgent();
+  context.mocks.api(featureSwitchesContract.get, ({ respond }) => {
+    return respond(200, {
+      switches: {},
+      effectiveSwitches: {
+        [FeatureSwitchKey.BaseUiSidebarScrollArea]: false,
+        [FeatureSwitchKey.IntroVideo]: false,
+      },
+    });
+  });
+
+  await setupPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    auth: {
+      user: { id: args.userId, fullName: args.fullName, email: args.email },
+      organization: {
+        activeOrg: { id: STAFF_ORG_ID, name: "Staff" },
+        memberships: [{ id: STAFF_ORG_ID }],
+      },
+    },
+    cachedFeatureSwitches: {
+      [FeatureSwitchKey.IntroVideo]: false,
+    },
+  });
+
+  await screen.findByRole("textbox", { name: "Message" });
+}
+
+test("Bingjie retains the intro video rollout after hydration", async () => {
+  await setupIntroVideoRolloutPage({
+    email: "BINGJIE@VM0.AI",
+    fullName: "Bingjie",
+    userId: "user_bingjie",
+  });
+
+  await expect(
+    screen.findByTestId("intro-video-start-card"),
+  ).resolves.toBeVisible();
+});
+
+test("another staff member does not receive the intro video rollout", async () => {
+  await setupIntroVideoRolloutPage({
+    email: "ethan@vm0.ai",
+    fullName: "Another staff member",
+    userId: "user_other_staff",
+  });
+
+  expect(screen.queryByTestId("intro-video-start-card")).toBeNull();
 });
 
 test("Image recognition remains available by default", async () => {

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -1,6 +1,9 @@
 import { command, computed } from "ccstate";
 import type { BrowserClerk as Clerk } from "@clerk/shared/types";
-import { getAllFeatureStates } from "@okouai/core/feature-switch";
+import {
+  getAllFeatureStates,
+  getEmailEnabledFeatureStates,
+} from "@okouai/core/feature-switch";
 import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { clerk$ } from "../auth";
@@ -90,13 +93,11 @@ const apiFeatureSwitchClient$ = computed((get) => {
 
 function applySwitches(
   result: Record<FeatureSwitchKey, boolean>,
-  overrides: Partial<Record<string, boolean>> | undefined,
-  effectiveSwitches: Partial<Record<string, boolean>> | undefined,
+  switches: Partial<Record<string, boolean>> | undefined,
 ) {
-  const resolvedSwitches = effectiveSwitches ?? overrides;
-  if (resolvedSwitches) {
+  if (switches) {
     for (const key of Object.values(FeatureSwitchKey)) {
-      const value = resolvedSwitches[key];
+      const value = switches[key];
       if (value !== undefined) {
         result[key] = Boolean(value);
       }
@@ -170,9 +171,10 @@ const hydrateFeatureSwitch$ = command(
     });
     applySwitches(
       combined,
-      result.body.switches,
-      result.body.effectiveSwitches,
+      result.body.effectiveSwitches ?? result.body.switches,
     );
+    applySwitches(combined, getEmailEnabledFeatureStates(identity.email));
+    applySwitches(combined, result.body.switches);
     set(setFeatureSwitchLocalStorage$, JSON.stringify(combined));
     set(syncShellDocumentAttributes$);
     set(writeConnectionDiagnostic$, {

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -88,7 +88,7 @@ test("Lab groups every feature by rollout stage with a switch", async () => {
     within(released).getByText(FeatureSwitchKey.NotionWorkflowAutomations),
   ).toBeVisible();
   expect(within(beta).getByText(FeatureSwitchKey.Banking)).toBeVisible();
-  expect(within(beta).getByText(FeatureSwitchKey.IntroVideo)).toBeVisible();
+  expect(within(alpha).getByText(FeatureSwitchKey.IntroVideo)).toBeVisible();
   expect(
     within(alpha).getByText(FeatureSwitchKey.AhrefsConnector),
   ).toBeVisible();

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -208,7 +208,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ComposerVoiceInputShortcut]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.BaseUiSidebarScrollArea]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
@@ -252,12 +252,18 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(false);
   });
 
-  it("should enable intro video for staff", () => {
-    const staffStates = getAllFeatureStates({
+  it("should enable intro video for Bingjie only", () => {
+    const bingjieStates = getAllFeatureStates({
+      email: "BINGJIE@VM0.AI",
+      orgId: "org_nonexistent",
+    });
+    expect(bingjieStates[FeatureSwitchKey.IntroVideo]).toBe(true);
+
+    const otherStaffStates = getAllFeatureStates({
       email: "ethan@vm0.ai",
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
-    expect(staffStates[FeatureSwitchKey.IntroVideo]).toBe(true);
+    expect(otherStaffStates[FeatureSwitchKey.IntroVideo]).toBe(false);
   });
 
   it("should enable gradient color themes for Ming only", () => {
@@ -390,7 +396,7 @@ describe("getFeatureSwitchMetadata", () => {
       metadata[FeatureSwitchKey.NotionWorkflowAutomations].rolloutStage,
     ).toBe("released");
     expect(metadata[FeatureSwitchKey.Banking].rolloutStage).toBe("beta");
-    expect(metadata[FeatureSwitchKey.IntroVideo].rolloutStage).toBe("beta");
+    expect(metadata[FeatureSwitchKey.IntroVideo].rolloutStage).toBe("alpha");
     expect(metadata[FeatureSwitchKey.AhrefsConnector].rolloutStage).toBe(
       "alpha",
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -316,7 +316,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show the guided intro video upload, screen recording, avatar, and voice workflow in new chat.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabledEmailHashes: ["9fd4ee92"], // fnv1a("bingjie@vm0.ai")
   },
   [FeatureSwitchKey.IosPwaStartupImages]: {
     maintainer: "ethan@vm0.ai",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -526,6 +526,30 @@ function evaluateSwitch(fs: FeatureSwitch, hashes: ResolvedHashes): boolean {
 }
 
 /**
+ * Return defaults enabled by the supplied email identity alone.
+ *
+ * The API feature-switch response cannot evaluate email allowlists because its
+ * auth context contains only user and organization IDs. Platform reapplies
+ * these defaults after the server's effective map, before stored overrides.
+ */
+export function getEmailEnabledFeatureStates(
+  email?: string,
+): Partial<Record<FeatureSwitchKey, true>> {
+  const result: Partial<Record<FeatureSwitchKey, true>> = {};
+  if (!email) {
+    return result;
+  }
+
+  const emailHash = fnv1a(email.toLowerCase());
+  for (const key of Object.values(FeatureSwitchKey)) {
+    if (FEATURE_SWITCHES[key].enabledEmailHashes?.includes(emailHash)) {
+      result[key] = true;
+    }
+  }
+  return result;
+}
+
+/**
  * Evaluate all feature switches at once for the given context.
  *
  * Computes identity hashes once and checks all switches synchronously.


### PR DESCRIPTION
## Summary

- Restrict the `introVideo` feature switch's default rollout from the staff organization to Bingjie's email allowlist.
- Update feature-switch and Lab coverage for the single-user Alpha rollout.

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm --filter @okouai/app exec vitest run src/views/lab-page/__tests__/lab-page.test.tsx`
