### PR TITLE
refactor(api): remove legacy custom connector oauth readers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -3018,6 +3018,35 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       },
     });
 
+    const legacyCustomState = `legacy-custom-oauth-${randomUUID()}`;
+    await seedCustomConnectorOAuthStateContext(context, {
+      state: legacyCustomState,
+      orgId: requiredOrgId(owner),
+      userId: owner.userId,
+      customConnectorId: connector.id,
+      storageVersion: 1,
+      redirectUri: "https://app.vm0.test/api/custom-connectors/oauth2/callback",
+      oauthContext: {
+        oauthSetup: "custom",
+        connectorId: connector.id,
+        storageVersion: 1,
+      },
+    });
+    await expect(
+      readCustomConnectorOAuthStorageState(context, legacyCustomState),
+    ).resolves.toMatchObject({
+      custom_oauth_state: { context_valid: false },
+    });
+    const legacyCustomCallback =
+      await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
+        code: "legacy-custom-oauth-code",
+        state: legacyCustomState,
+      });
+    expect(legacyCustomCallback.body).toStrictEqual({
+      status: "error",
+      message: "Invalid OAuth state - please try again",
+    });
+
     const customAuthorizationUrl =
       await connectorsApi.startCustomConnectorOAuth2(owner, connector.id);
     const customState = stateFromAuthorizationUrl(customAuthorizationUrl);
@@ -4192,9 +4221,9 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       readAutomaticOAuthBindingState(context, connectorAccountId),
     ).resolves.toMatchObject({ exists: true, valid: true });
 
-    const validState = `automatic-oauth-${randomUUID()}`;
+    const legacyState = `legacy-automatic-oauth-${randomUUID()}`;
     await seedCustomConnectorOAuthStateContext(context, {
-      state: validState,
+      state: legacyState,
       orgId: requiredOrgId(admin),
       userId: admin.userId,
       customConnectorId,
@@ -4219,23 +4248,21 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       },
     });
     await expect(
-      readCustomConnectorOAuthStorageState(context, validState),
+      readCustomConnectorOAuthStorageState(context, legacyState),
     ).resolves.toMatchObject({
       custom_oauth_state: {
-        context_valid: true,
-        auth_mode: "automatic",
-        context_format: "legacy",
+        context_valid: false,
       },
     });
-    const callback =
+    const legacyCallback =
       await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
-        code: "automatic-oauth-code",
-        state: validState,
+        code: "legacy-automatic-oauth-code",
+        state: legacyState,
         iss: "https://issuer.example.test",
       });
-    expect(callback.body).toStrictEqual({
+    expect(legacyCallback.body).toStrictEqual({
       status: "error",
-      message: "OAuth token exchange failed - please try again",
+      message: "Invalid OAuth state - please try again",
     });
 
     const canonicalState = `canonical-automatic-oauth-${randomUUID()}`;
@@ -4270,7 +4297,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       custom_oauth_state: {
         context_valid: true,
         auth_mode: "automatic",
-        context_format: "canonical",
       },
     });
     const canonicalCallback =

--- a/turbo/apps/api/src/signals/routes/__tests__/custom-connectors-oauth2.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/custom-connectors-oauth2.test.ts
@@ -125,7 +125,6 @@ describe("Custom connector OAuth public-brand callbacks", () => {
       ).resolves.toMatchObject({
         custom_oauth_state: {
           auth_mode: "oauth",
-          context_format: "canonical",
           context_valid: true,
         },
       });
@@ -212,7 +211,7 @@ describe("Custom connector OAuth public-brand callbacks", () => {
     await connectors.deleteCustomConnector(actor, connector.id);
   });
 
-  it("replays a legacy Okou state callback and uses Okou on reconnect", async () => {
+  it("replays a pre-brand-fix Okou callback and uses Okou on reconnect", async () => {
     mockEnv("APP_URL", "https://app.vm0.ai");
     const provider = mockCustomConnectorOAuth2Provider(context, {
       initialScope: "read",
@@ -234,6 +233,8 @@ describe("Custom connector OAuth public-brand callbacks", () => {
       storageVersion: connector.storageVersion,
       redirectUri: legacyRedirectUri,
       oauthContext: {
+        version: 2,
+        authMode: "oauth",
         connectorId: connector.id,
         storageVersion: connector.storageVersion,
       },

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -69,8 +69,8 @@ import {
   readCustomConnectorCredentialStorageParent,
   readFeishuMemberConnectorState,
   seedConnectorStorageRow,
+  seedCustomConnectorOAuthStateContext,
   seedCustomThreadConnectorSelection,
-  seedLegacyCustomFeishuOAuthState,
   setConnectorExternalIdState,
   setFeishuMemberConnectorLink,
 } from "./helpers/connector-credential-storage-state";
@@ -2197,28 +2197,37 @@ describe("Feishu integration", () => {
       "This connector is managed by its integration",
     );
 
-    const legacyGenericState = `legacy-generic-feishu-${randomUUID()}`;
-    await seedLegacyCustomFeishuOAuthState(context, {
-      state: legacyGenericState,
+    const genericState = `generic-feishu-${randomUUID()}`;
+    await seedCustomConnectorOAuthStateContext(context, {
+      state: genericState,
       orgId: requireValue(admin.orgId, "Expected an organization"),
       userId: admin.userId,
       customConnectorId: managedConnector.id,
       storageVersion: managedConnector.storageVersion,
       redirectUri: `${APP_ORIGIN}/connectors/feishu/callback`,
-      providerContext: { completionTarget: "custom" },
+      oauthContext: {
+        version: 2,
+        authMode: "oauth",
+        connectorId: managedConnector.id,
+        storageVersion: managedConnector.storageVersion,
+        providerContext: {
+          provider: "feishu",
+          completionTarget: "custom",
+        },
+      },
     });
-    const legacyGenericCallbackResponse = await createAppWithRoutes({
+    const genericCallbackResponse = await createAppWithRoutes({
       signal: context.signal,
       routes: feishuOauthRoutes,
     }).request(
       `${feishuOauthContract.callback.path}?${new URLSearchParams({
-        code: "legacy-generic-feishu-code",
+        code: "generic-feishu-code",
         responseMode: "json",
-        state: legacyGenericState,
+        state: genericState,
       })}`,
     );
-    expect(legacyGenericCallbackResponse.status).toBe(400);
-    await expect(legacyGenericCallbackResponse.json()).resolves.toStrictEqual({
+    expect(genericCallbackResponse.status).toBe(400);
+    await expect(genericCallbackResponse.json()).resolves.toStrictEqual({
       error: "Invalid or expired connect state",
     });
     expect(oauthTokenRedirectUris).toStrictEqual([]);
@@ -2473,18 +2482,25 @@ describe("Feishu integration", () => {
       },
     });
 
-    const persistedSingletonState = `legacy-managed-feishu-${randomUUID()}`;
-    await seedLegacyCustomFeishuOAuthState(context, {
+    const persistedSingletonState = `managed-feishu-${randomUUID()}`;
+    await seedCustomConnectorOAuthStateContext(context, {
       state: persistedSingletonState,
       orgId: requireValue(member.orgId, "Expected an organization"),
       userId: member.userId,
       customConnectorId: managedConnector.id,
       storageVersion: managedConnector.storageVersion,
       redirectUri: `${APP_ORIGIN}/connectors/feishu/callback`,
-      providerContext: {
-        completionTarget: "feishu",
-        installationId,
-        expectedOpenId: "ou_oauth_user",
+      oauthContext: {
+        version: 2,
+        authMode: "oauth",
+        connectorId: managedConnector.id,
+        storageVersion: managedConnector.storageVersion,
+        providerContext: {
+          provider: "feishu",
+          completionTarget: "feishu",
+          installationId,
+          expectedOpenId: "ou_oauth_user",
+        },
       },
     });
     await expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-credential-storage-state.ts
@@ -255,45 +255,6 @@ export async function setFeishuMemberConnectorLink(
   });
 }
 
-export async function seedLegacyCustomFeishuOAuthState(
-  context: TestContext,
-  args: {
-    readonly state: string;
-    readonly orgId: string;
-    readonly userId: string;
-    readonly customConnectorId: string;
-    readonly storageVersion: number;
-    readonly redirectUri: string;
-    readonly providerContext:
-      | { readonly completionTarget: "custom" }
-      | {
-          readonly completionTarget: "feishu";
-          readonly installationId: string;
-          readonly expectedOpenId?: string;
-        };
-  },
-): Promise<void> {
-  await postAction(context, {
-    action: "seed-legacy-custom-feishu-oauth-state",
-    state: args.state,
-    org_id: args.orgId,
-    user_id: args.userId,
-    custom_connector_id: args.customConnectorId,
-    storage_version: args.storageVersion,
-    redirect_uri: args.redirectUri,
-    provider_context:
-      args.providerContext.completionTarget === "custom"
-        ? { completion_target: "custom" }
-        : {
-            completion_target: "feishu",
-            installation_id: args.providerContext.installationId,
-            ...(args.providerContext.expectedOpenId
-              ? { expected_open_id: args.providerContext.expectedOpenId }
-              : {}),
-          },
-  });
-}
-
 export async function seedOwnedConnectorSecret(
   context: TestContext,
   args: {

--- a/turbo/apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts
@@ -553,7 +553,6 @@ describe("POST /api/mcp-connectors/:id/oauth2/reauthorize", () => {
       ).resolves.toMatchObject({
         custom_oauth_state: {
           auth_mode: "automatic",
-          context_format: "canonical",
           context_valid: true,
         },
       });
@@ -632,7 +631,6 @@ describe("POST /api/mcp-connectors/:id/oauth2/reauthorize", () => {
       ).resolves.toMatchObject({
         custom_oauth_state: {
           auth_mode: "automatic",
-          context_format: "canonical",
           context_valid: true,
         },
       });

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -19,7 +19,6 @@ import { and, asc, eq, inArray } from "drizzle-orm";
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
-import { safeJsonParse } from "../utils";
 import { connectorOAuthStateExpiresAt } from "../../lib/connector-oauth-state";
 import type { RouteEntry } from "../route-entry";
 import { parseCustomConnectorOAuthStateContext } from "../services/custom-connector-oauth2.service";
@@ -241,22 +240,12 @@ async function readCustomOAuthState(
     return actionOk({ custom_oauth_state: null });
   }
   const context = parseCustomConnectorOAuthStateContext(state.oauthContext);
-  const rawContext = safeJsonParse(state.oauthContext ?? "null");
-  const contextFormat =
-    typeof rawContext === "object" &&
-    rawContext !== null &&
-    "version" in rawContext &&
-    rawContext.version === 2
-      ? "canonical"
-      : "legacy";
   return actionOk({
     custom_oauth_state: {
       storage_version: state.storageVersion,
       context_storage_version: context?.storageVersion ?? null,
       context_valid: context !== null,
-      ...(context
-        ? { auth_mode: context.authMode, context_format: contextFormat }
-        : {}),
+      ...(context ? { auth_mode: context.authMode } : {}),
     },
   });
 }
@@ -510,42 +499,6 @@ async function setFeishuMemberConnectorLink(
         status: 400 as const,
         body: { error: "Feishu member connection test fixture was not found" },
       };
-}
-
-async function seedLegacyCustomFeishuOAuthState(
-  db: Db,
-  body: ConnectorCredentialStorageAction<"seed-legacy-custom-feishu-oauth-state">,
-  signal: AbortSignal,
-) {
-  await db.insert(connectorOauthStates).values({
-    state: body.state,
-    customConnectorId: body.custom_connector_id,
-    storageVersion: body.storage_version,
-    authMethod: "oauth",
-    userId: body.user_id,
-    orgId: body.org_id,
-    redirectUri: body.redirect_uri,
-    oauthContext: JSON.stringify({
-      connectorId: body.custom_connector_id,
-      storageVersion: body.storage_version,
-      providerContext: {
-        provider: "feishu",
-        ...(body.provider_context.completion_target === "custom"
-          ? { completionTarget: "custom" }
-          : {
-              completionTarget: "feishu",
-              installationId: body.provider_context.installation_id,
-              ...(body.provider_context.expected_open_id
-                ? { expectedOpenId: body.provider_context.expected_open_id }
-                : {}),
-            }),
-      },
-    }),
-    accountMutation: { intent: "single-account" },
-    expiresAt: connectorOAuthStateExpiresAt(),
-  });
-  signal.throwIfAborted();
-  return actionOk();
 }
 
 async function seedCustomOAuthStateContext(
@@ -1075,9 +1028,6 @@ const mutateConnectorCredentialStorageState$ = command(
       }
       case "clear-feishu-connector-ownership": {
         return await clearFeishuConnectorOwnership(db, body, signal);
-      }
-      case "seed-legacy-custom-feishu-oauth-state": {
-        return await seedLegacyCustomFeishuOAuthState(db, body, signal);
       }
       case "seed-owned-secret": {
         return await seedOwnedSecret(db, body, signal);

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -111,48 +111,19 @@ const customConnectorCustomOAuthProviderContextSchema = z
   })
   .strict();
 
-const customConnectorLegacyCustomOAuthStateContextSchema = z
-  .object({
-    version: z.never().optional(),
-    authMode: z.never().optional(),
-    oauthSetup: z.literal("custom").optional(),
-    connectorId: z.string().uuid(),
-    storageVersion: z.number().int().positive(),
-    providerContext: customConnectorCustomOAuthProviderContextSchema.optional(),
-  })
-  .strict();
-
-const customConnectorCanonicalCustomOAuthStateContextSchema = z
+const customConnectorCustomOAuthStateContextSchema = z
   .object({
     version: z.literal(2),
     authMode: z.literal("oauth"),
-    oauthSetup: z.never().optional(),
     connectorId: z.string().uuid(),
     storageVersion: z.number().int().positive(),
     providerContext: customConnectorCustomOAuthProviderContextSchema.optional(),
   })
   .strict();
 
-type CustomConnectorCanonicalCustomOAuthStateContext = z.infer<
-  typeof customConnectorCanonicalCustomOAuthStateContextSchema
+export type CustomConnectorCustomOAuthStateContext = z.infer<
+  typeof customConnectorCustomOAuthStateContextSchema
 >;
-
-const customConnectorCustomOAuthStateContextSchema = z.union([
-  customConnectorCanonicalCustomOAuthStateContextSchema,
-  customConnectorLegacyCustomOAuthStateContextSchema.transform(
-    (value): CustomConnectorCanonicalCustomOAuthStateContext => {
-      return {
-        version: 2,
-        authMode: "oauth",
-        connectorId: value.connectorId,
-        storageVersion: value.storageVersion,
-        ...(value.providerContext
-          ? { providerContext: value.providerContext }
-          : {}),
-      };
-    },
-  ),
-]);
 
 const customConnectorAutomaticOAuthStateContextCoreSchema = z.object({
   connectorId: z.string().uuid(),
@@ -172,86 +143,25 @@ const customConnectorAutomaticOAuthStateContextCoreSchema = z.object({
   providerContext: z.never().optional(),
 });
 
-const customConnectorLegacyAutomaticOAuthStateContextBaseSchema =
-  customConnectorAutomaticOAuthStateContextCoreSchema.extend({
-    version: z.literal(1),
-    authMode: z.never().optional(),
-    oauthSetup: z.literal("automatic"),
-  });
-
-const customConnectorLegacyAutomaticOAuthStateContextSchema = z.union([
-  customConnectorLegacyAutomaticOAuthStateContextBaseSchema
-    .extend({
-      registrationMethod: z.literal("cimd"),
-      dcrRegistrationId: z.never().optional(),
-    })
-    .strict(),
-  customConnectorLegacyAutomaticOAuthStateContextBaseSchema
-    .extend({
-      registrationMethod: z.literal("dcr"),
-      dcrRegistrationId: z.string().uuid(),
-    })
-    .strict(),
-]);
-
-const customConnectorCanonicalAutomaticOAuthStateContextBaseSchema =
+const customConnectorAutomaticOAuthStateContextBaseSchema =
   customConnectorAutomaticOAuthStateContextCoreSchema.extend({
     version: z.literal(2),
     authMode: z.literal("automatic"),
-    oauthSetup: z.never().optional(),
   });
 
-const customConnectorCanonicalAutomaticOAuthStateContextSchema = z.union([
-  customConnectorCanonicalAutomaticOAuthStateContextBaseSchema
+const customConnectorAutomaticOAuthStateContextSchema = z.union([
+  customConnectorAutomaticOAuthStateContextBaseSchema
     .extend({
       registrationMethod: z.literal("cimd"),
       dcrRegistrationId: z.never().optional(),
     })
     .strict(),
-  customConnectorCanonicalAutomaticOAuthStateContextBaseSchema
+  customConnectorAutomaticOAuthStateContextBaseSchema
     .extend({
       registrationMethod: z.literal("dcr"),
       dcrRegistrationId: z.string().uuid(),
     })
     .strict(),
-]);
-
-type CustomConnectorCanonicalAutomaticOAuthStateContext = z.infer<
-  typeof customConnectorCanonicalAutomaticOAuthStateContextSchema
->;
-
-function normalizeLegacyAutomaticOAuthStateContext(
-  value: z.infer<typeof customConnectorLegacyAutomaticOAuthStateContextSchema>,
-): CustomConnectorCanonicalAutomaticOAuthStateContext {
-  const common = {
-    version: 2 as const,
-    authMode: "automatic" as const,
-    connectorId: value.connectorId,
-    storageVersion: value.storageVersion,
-    issuer: value.issuer,
-    resource: value.resource,
-    resourceMetadataUrl: value.resourceMetadataUrl,
-    authorizationEndpoint: value.authorizationEndpoint,
-    tokenEndpoint: value.tokenEndpoint,
-    authorizationResponseIssParameterSupported:
-      value.authorizationResponseIssParameterSupported,
-    clientId: value.clientId,
-    tokenEndpointAuthMethod: value.tokenEndpointAuthMethod,
-  };
-  return value.registrationMethod === "cimd"
-    ? { ...common, registrationMethod: "cimd" }
-    : {
-        ...common,
-        registrationMethod: "dcr",
-        dcrRegistrationId: value.dcrRegistrationId,
-      };
-}
-
-const customConnectorAutomaticOAuthStateContextSchema = z.union([
-  customConnectorCanonicalAutomaticOAuthStateContextSchema,
-  customConnectorLegacyAutomaticOAuthStateContextSchema.transform(
-    normalizeLegacyAutomaticOAuthStateContext,
-  ),
 ]);
 
 const customConnectorOAuthStateContextSchema = z.union([
@@ -261,10 +171,6 @@ const customConnectorOAuthStateContextSchema = z.union([
 
 type CustomConnectorOAuthStateContext = z.infer<
   typeof customConnectorOAuthStateContextSchema
->;
-
-export type CustomConnectorCustomOAuthStateContext = z.infer<
-  typeof customConnectorCustomOAuthStateContextSchema
 >;
 
 type CustomConnectorAutomaticOAuthStateContext = z.infer<
@@ -669,7 +575,7 @@ type PreparedOAuthStart = {
 } & (
   | {
       readonly authMode: "oauth";
-      readonly context: CustomConnectorCanonicalCustomOAuthStateContext;
+      readonly context: CustomConnectorCustomOAuthStateContext;
     }
   | {
       readonly authMode: "automatic";

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors-test-helpers.ts
@@ -724,7 +724,6 @@ export function httpConnector(
     authMode,
     ...(authMode === "oauth"
       ? {
-          oauthSetup: "custom",
           oauthConfig: {
             providerAdapter: args.providerAdapter ?? "standard",
             clientId: "client-id",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
@@ -362,8 +362,8 @@ export function mockCustomConnectorStory(context: TestContext): void {
           authMode,
           storageVersion: body.storageVersion ?? connector.storageVersion,
           ...(authMode === "oauth"
-            ? { oauthSetup: "custom", oauthConfig }
-            : { oauthSetup: undefined, oauthConfig: undefined }),
+            ? { oauthConfig }
+            : { oauthConfig: undefined }),
         });
         updated = next;
         return next;

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
@@ -261,12 +261,12 @@ describe("custom connector response contracts", () => {
 
     expect(customConnectorResponseSchema.parse(payload)).toStrictEqual(payload);
 
-    expect(
+    expect(() => {
       customConnectorResponseSchema.parse({
         ...payload,
         oauthSetup: "custom",
-      }),
-    ).toStrictEqual(payload);
+      });
+    }).toThrow();
   });
 
   it("parses top-level Automatic MCP authentication", () => {
@@ -442,13 +442,6 @@ describe("connector client request contracts", () => {
         prefixTemplates: ["https://api.example.test"],
       });
     }).toThrow();
-    expect(
-      createCustomConnectorBodySchema.parse({
-        ...manualDefinition,
-        authMode: "manual",
-        oauthSetup: "custom",
-      }),
-    ).toStrictEqual({ ...manualDefinition, authMode: "manual" });
   });
 
   it("accepts canonical connector check requests", () => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/custom-connectors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/custom-connectors.test.ts
@@ -45,15 +45,6 @@ describe("Custom connector no-auth contracts", () => {
     );
   });
 
-  it("strips the obsolete OAuth setup request field", () => {
-    expect(
-      customConnectorHttpCreateBodySchema.parse({
-        ...httpNone,
-        oauthSetup: "custom",
-      }),
-    ).toStrictEqual(httpNone);
-  });
-
   it.each([
     {
       name: "a secret field",

--- a/turbo/packages/api-contracts/src/contracts/custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/custom-connectors.ts
@@ -213,7 +213,7 @@ const customConnectorNoAuthResponseSchema = z
 const customConnectorCustomOAuthResponseSchema = z
   .object({
     authMode: z.literal("oauth"),
-    oauthSetup: z.literal("custom").optional(),
+    oauthSetup: z.never().optional(),
     oauthConfig: customConnectorOAuthConfigSchema,
   })
   .transform((value) => {

--- a/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-connector-credential-storage-state.ts
@@ -41,7 +41,6 @@ const customOauthStateSchema = z.object({
   context_storage_version: z.number().int().positive().nullable(),
   context_valid: z.boolean().optional(),
   auth_mode: z.enum(["oauth", "automatic"]).optional(),
-  context_format: z.enum(["legacy", "canonical"]).optional(),
 });
 
 const automaticOauthBindingStateSchema = z.object({
@@ -139,23 +138,6 @@ export const testConnectorCredentialStorageStateActionBodySchema =
       user_id: z.string(),
       installation_id: z.uuid(),
       connector_id: z.uuid().nullable(),
-    }),
-    z.object({
-      action: z.literal("seed-legacy-custom-feishu-oauth-state"),
-      state: z.string().min(1),
-      org_id: z.string(),
-      user_id: z.string(),
-      custom_connector_id: z.uuid(),
-      storage_version: z.number().int().positive(),
-      redirect_uri: z.url(),
-      provider_context: z.discriminatedUnion("completion_target", [
-        z.object({ completion_target: z.literal("custom") }),
-        z.object({
-          completion_target: z.literal("feishu"),
-          installation_id: z.uuid(),
-          expected_open_id: z.string().min(1).optional(),
-        }),
-      ]),
     }),
     z.object({
       action: z.literal("seed-owned-secret"),


### PR DESCRIPTION
## Summary

- accept only canonical version 2 `authMode` callback state for Custom and Automatic OAuth
- reject the retired `oauthSetup` response discriminator while preserving tolerance for unrelated additive response fields
- remove rollout-only state-format diagnostics and legacy fixtures, and migrate Feishu and Platform scenarios to canonical state

## Compatibility

- the canonical writer is present in the current and rollback API deployments, and multiple 15-minute state TTL windows have elapsed
- no database migration, canonical API output, UI, user flow, OAuth provider, account, reconnect, refresh, or multi-account behavior changes
- historical migration and snapshot records remain unchanged

## Validation

- `pnpm format`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/app lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @okouai/api-contracts test` (38 files, 702 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/custom-connectors-oauth2.test.ts src/signals/routes/__tests__/connectors.bdd.test.ts src/signals/routes/__tests__/mcp-connectors.test.ts src/signals/routes/__tests__/feishu-integration.test.ts --maxWorkers=2 --silent=passed-only` (4 files, 153 tests)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx src/views/okou-page/__tests__/chat-composer-connectors.test.tsx src/views/okou-page/__tests__/connectors-accounts.test.tsx src/views/okou-page/__tests__/connectors-auth-methods.test.tsx src/views/okou-page/__tests__/connectors-catalog.test.tsx src/views/okou-page/__tests__/connectors-custom.test.tsx --maxWorkers=2 --silent=passed-only` (6 files, 98 tests)

Closes #31472

Parent: #30466
