### PR TITLE
fix(platform): hide composer placeholder after a newline

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-keyboard.test.tsx
@@ -330,6 +330,36 @@ test("Treat whitespace as an empty message", async () => {
   expect(sentPrompts).toHaveLength(0);
 });
 
+test("Hide the placeholder after adding an empty line", async () => {
+  const user = userEvent.setup({ delay: null });
+  const sentPrompts: string[] = [];
+  installComposerChat(sentPrompts, "enter");
+
+  await setupPage({
+    context,
+    path: `/agents/${MESSAGE_EXPERIENCE_AGENT_ID}/chat`,
+  });
+
+  const editor = await loadNewChatComposer();
+  const composer = editor.closest(".zero-composer");
+  if (!(composer instanceof HTMLElement)) {
+    throw new Error("Composer surface not found");
+  }
+  const send = await findFastControl("button", "Send", composer);
+  expect(within(composer).getByText(COMPOSER_PLACEHOLDER)).toBeVisible();
+  expect(send).toBeDisabled();
+
+  await user.click(editor);
+  await user.keyboard("{Shift>}{Enter}{/Shift}");
+
+  expect(draftLines(editor)).toStrictEqual(["", ""]);
+  await waitFor(() => {
+    expect(within(composer).queryByText(COMPOSER_PLACEHOLDER)).toBeNull();
+  });
+  expect(send).toBeDisabled();
+  expect(sentPrompts).toHaveLength(0);
+});
+
 test("Edit individual lines in a multiline draft", async () => {
   const user = userEvent.setup({ delay: null });
   const sentPrompts: string[] = [];

--- a/turbo/apps/platform/src/views/okou-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/tiptap-workflow-composer.tsx
@@ -139,6 +139,21 @@ function workflowComposerPlaceholder(sending: boolean | undefined): string {
       });
 }
 
+function workflowComposerHasContent(editor: Editor): boolean {
+  let textblockCount = 0;
+  for (let index = 0; index < editor.state.doc.childCount; index++) {
+    const node = editor.state.doc.child(index);
+    if (!node.isTextblock) {
+      continue;
+    }
+    textblockCount += 1;
+    if (node.content.size > 0 || textblockCount > 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function WorkflowComposerPlaceholder({
   composer,
   sending,
@@ -148,16 +163,16 @@ function WorkflowComposerPlaceholder({
 }) {
   useTranslation();
   const hasInput = useGet(composer.editor.hasInput$);
-  const hasEditorText = useEditorState({
+  const hasEditorContent = useEditorState({
     editor: composer.editor.editor,
     selector: ({ editor }) => {
-      return editor.state.doc.textContent.length > 0;
+      return workflowComposerHasContent(editor);
     },
   });
   const hasTemplateAttachment = useGet(
     composer.template.hasTemplateAttachment$,
   );
-  if (hasInput || hasEditorText) {
+  if (hasInput || hasEditorContent) {
     return null;
   }
   return (


### PR DESCRIPTION
## Summary

- hide the composer placeholder when the editor contains a newline-only draft
- keep whitespace-only and newline-only drafts ineligible for sending
- add page-level keyboard regression coverage for the empty-line case

## Verification

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-keyboard.test.tsx` (7 tests passed)
