### PR TITLE
feat(cli): support legacy ppt template sources

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/presentation-template-publish.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/presentation-template-publish.test.ts
@@ -34,6 +34,7 @@ const ARTIFACTS_BUCKET = "test-user-artifacts";
 
 const SOURCE_CONTENT_TYPE =
   "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const LEGACY_SOURCE_CONTENT_TYPE = "application/vnd.ms-powerpoint";
 
 interface StoredObject {
   readonly body: Buffer;
@@ -269,6 +270,10 @@ async function uploadInputs(
   actor: ApiTestUser,
   fixture: Fixture,
   archive: Buffer,
+  source: { readonly filename: string; readonly contentType: string } = {
+    filename: "brand-system.pptx",
+    contentType: SOURCE_CONTENT_TYPE,
+  },
 ): Promise<{
   readonly sourceFileId: string;
   readonly pageFileIds: string[];
@@ -277,7 +282,7 @@ async function uploadInputs(
   const sourceFileId = await upload(
     actor,
     fixture,
-    { filename: "brand-system.pptx", contentType: SOURCE_CONTENT_TYPE },
+    source,
     Buffer.from("PK deck bytes", "utf8"),
   );
   const pageFileIds: string[] = [];
@@ -396,6 +401,30 @@ describe("presentation template publish", () => {
         return key.endsWith("/archive.tar.gz");
       }),
     ).toBeTruthy();
+  });
+
+  it("publishes a legacy PowerPoint source without conversion", async () => {
+    const actor = bdd.user();
+    await enablePresentationTemplates(actor);
+    const fixture = installS3Fixture();
+    const inputs = await uploadInputs(actor, fixture, tarGz(guidance()), {
+      filename: "legacy-deck.ppt",
+      contentType: LEGACY_SOURCE_CONTENT_TYPE,
+    });
+
+    mocks.clerk.session(actor.userId, actor.orgId);
+    const published = await accept(
+      templateClient().publish({
+        headers: webHeaders(),
+        body: { title: "Legacy brand system", ...inputs },
+      }),
+      [200],
+    );
+    expect(published.body).toMatchObject({
+      title: "Legacy brand system",
+      sourceFilename: "legacy-deck.ppt",
+      pageCount: 2,
+    });
   });
 
   it("shares a public template with workspace members while keeping management owner-only", async () => {

--- a/turbo/apps/cli/src/commands/presentation-template/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/presentation-template/__tests__/index.test.ts
@@ -125,8 +125,8 @@ describe("okou presentation-template publish", () => {
     mkdirSync(pagesDir, { recursive: true });
     mkdirSync(packageDir, { recursive: true });
 
-    sourcePath = join(tempDir, "brand-system.pptx");
-    writeFileSync(sourcePath, Buffer.from("PK deck bytes"));
+    sourcePath = join(tempDir, "brand-system.ppt");
+    writeFileSync(sourcePath, Buffer.from("legacy deck bytes"));
     writeFileSync(join(packageDir, "SKILL.md"), "# Use this template\n");
     writeFileSync(join(packageDir, "design-system.md"), "Ink on paper.\n");
   });
@@ -156,7 +156,7 @@ describe("okou presentation-template publish", () => {
         return HttpResponse.json({
           id: TEMPLATE_ID,
           title: published.title,
-          sourceFilename: "brand-system.pptx",
+          sourceFilename: "brand-system.ppt",
           coverUrl: "https://presigned.example.com/cover.png",
           pageCount: published.pageFileIds.length,
           createdAt: "2026-08-20T00:00:00.000Z",
@@ -183,8 +183,9 @@ describe("okou presentation-template publish", () => {
       throw new Error("Expected the publish route to receive a request");
     }
     expect(published.title).toBe("Brand system");
-    expect(uploads.filenameOf(published.sourceFileId)).toBe(
-      "brand-system.pptx",
+    expect(uploads.filenameOf(published.sourceFileId)).toBe("brand-system.ppt");
+    expect(uploads.contentTypeOf(published.sourceFileId)).toBe(
+      "application/vnd.ms-powerpoint",
     );
     expect(
       published.pageFileIds.map((id) => {

--- a/turbo/apps/cli/src/commands/presentation-template/index.ts
+++ b/turbo/apps/cli/src/commands/presentation-template/index.ts
@@ -16,7 +16,7 @@ const publishCommand = new Command()
     "Publish an analysed deck as a reusable presentation template. Uploads the source deck, the ordered page images, and the guidance package, then commits them together.",
   )
   .requiredOption("--title <title>", "Template name shown to the user")
-  .requiredOption("--source <path>", "The original .pptx or .pdf")
+  .requiredOption("--source <path>", "The original .ppt, .pptx, or .pdf")
   .requiredOption(
     "--pages <dir>",
     "Directory of rendered page PNGs, in filename order",

--- a/turbo/packages/api-contracts/src/contracts/presentation-templates.ts
+++ b/turbo/packages/api-contracts/src/contracts/presentation-templates.ts
@@ -22,8 +22,9 @@ export const MAX_PRESENTATION_TEMPLATE_PACKAGE_FILES = 200;
 export const MAX_PRESENTATION_TEMPLATE_PACKAGE_FILE_BYTES = 25 * 1024 * 1024;
 export const PRESENTATION_TEMPLATE_URL_TTL_SECONDS = 15 * 60;
 
-/** A deck the user uploaded. Both are rendered to page images the same way. */
+/** An original deck the user uploaded alongside its rendered page images. */
 export const PRESENTATION_TEMPLATE_SOURCE_CONTENT_TYPES = [
+  "application/vnd.ms-powerpoint",
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   "application/pdf",
 ] as const;


### PR DESCRIPTION
## Summary

- accept legacy PowerPoint (`application/vnd.ms-powerpoint`) as a presentation-template source alongside PPTX and PDF
- advertise `.ppt` in `okou presentation-template publish --source` help while preserving the original source file
- cover the CLI upload MIME and API publication paths with focused integration tests

## Compatibility

This is an additive backend contract change. Existing PPTX and PDF callers remain valid. The backend capability should be available before the updated reverse-template guide in vm0-ai/Template-artifact#62 is treated as live.

## Test plan

- `pnpm format`
- `pnpm turbo run lint --concurrency=1 --log-order grouped`
- `pnpm knip`
- `pnpm turbo run check-types --concurrency=1 --filter='!api' --filter='!@okouai/app'`
- `pnpm --filter @okouai/app run check-types`
- `pnpm --filter api run check-types`
- `pnpm --filter @okouai/cli exec vitest run src/commands/presentation-template/__tests__/index.test.ts`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm --filter api exec vitest run src/signals/routes/__tests__/presentation-template-publish.test.ts`

Related: vm0-ai/Template-artifact#62
