### PR TITLE
test(api): normalize database telemetry invariants

### DIFF
--- a/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
@@ -168,34 +168,79 @@ function expectConnectionAcquisition(span: ReadableSpan): void {
     span,
     CONNECTION_LOOKUP_DURATION_ATTRIBUTE,
   );
-  if (lookupDuration !== undefined) {
-    expect(lookupDuration).toBeGreaterThanOrEqual(0);
-    expect(lookupDuration).toBeLessThanOrEqual(socketConnectDuration);
-  }
-
   const attemptCount = numericAttribute(
     span,
     CONNECTION_ATTEMPT_COUNT_ATTRIBUTE,
   );
-  if (attemptCount !== undefined) {
-    expect(Number.isInteger(attemptCount)).toBeTruthy();
-    expect(attemptCount).toBeGreaterThan(0);
-  }
-
-  for (const name of [
+  const failedAttemptCount = numericAttribute(
+    span,
     CONNECTION_ATTEMPT_FAILED_COUNT_ATTRIBUTE,
+  );
+  const timedOutAttemptCount = numericAttribute(
+    span,
     CONNECTION_ATTEMPT_TIMEOUT_COUNT_ATTRIBUTE,
-  ]) {
-    const count = numericAttribute(span, name);
-    if (count !== undefined) {
-      expect(Number.isInteger(count)).toBeTruthy();
-      expect(count).toBeGreaterThan(0);
-      expect(attemptCount).toBeDefined();
-      if (attemptCount !== undefined) {
-        expect(count).toBeLessThanOrEqual(attemptCount);
-      }
-    }
-  }
+  );
+
+  const optionalTelemetryObservation = {
+    lookupDuration: {
+      nonNegativeWhenPresent:
+        lookupDuration === undefined || lookupDuration >= 0,
+      noGreaterThanSocketConnectWhenPresent:
+        lookupDuration === undefined || lookupDuration <= socketConnectDuration,
+    },
+    attemptCount: {
+      integerWhenPresent:
+        attemptCount === undefined || Number.isInteger(attemptCount),
+      positiveWhenPresent: attemptCount === undefined || attemptCount > 0,
+    },
+    failedAttemptCount: {
+      integerWhenPresent:
+        failedAttemptCount === undefined ||
+        Number.isInteger(failedAttemptCount),
+      positiveWhenPresent:
+        failedAttemptCount === undefined || failedAttemptCount > 0,
+      attemptCountPresentWhenPresent:
+        failedAttemptCount === undefined || attemptCount !== undefined,
+      noGreaterThanAttemptCountWhenPresent:
+        failedAttemptCount === undefined ||
+        (attemptCount !== undefined && failedAttemptCount <= attemptCount),
+    },
+    timedOutAttemptCount: {
+      integerWhenPresent:
+        timedOutAttemptCount === undefined ||
+        Number.isInteger(timedOutAttemptCount),
+      positiveWhenPresent:
+        timedOutAttemptCount === undefined || timedOutAttemptCount > 0,
+      attemptCountPresentWhenPresent:
+        timedOutAttemptCount === undefined || attemptCount !== undefined,
+      noGreaterThanAttemptCountWhenPresent:
+        timedOutAttemptCount === undefined ||
+        (attemptCount !== undefined && timedOutAttemptCount <= attemptCount),
+    },
+  };
+
+  expect(optionalTelemetryObservation).toStrictEqual({
+    lookupDuration: {
+      nonNegativeWhenPresent: true,
+      noGreaterThanSocketConnectWhenPresent: true,
+    },
+    attemptCount: {
+      integerWhenPresent: true,
+      positiveWhenPresent: true,
+    },
+    failedAttemptCount: {
+      integerWhenPresent: true,
+      positiveWhenPresent: true,
+      attemptCountPresentWhenPresent: true,
+      noGreaterThanAttemptCountWhenPresent: true,
+    },
+    timedOutAttemptCount: {
+      integerWhenPresent: true,
+      positiveWhenPresent: true,
+      attemptCountPresentWhenPresent: true,
+      noGreaterThanAttemptCountWhenPresent: true,
+    },
+  });
 }
 
 function expectNoConnectionAcquisition(span: ReadableSpan): void {
@@ -276,7 +321,11 @@ describe("instrumentPgPool", () => {
 
   beforeAll(() => {
     const contextManager = new AsyncLocalStorageContextManager().enable();
-    expect(context.setGlobalContextManager(contextManager)).toBeTruthy();
+    if (!context.setGlobalContextManager(contextManager)) {
+      throw new Error(
+        "Failed to install the global context manager for database instrumentation tests",
+      );
+    }
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

- normalize optional connection telemetry into one explicit invariant observation without requiring event-driven attributes
- validate every present lookup, attempt, failure, and timeout value across type, range, and cross-field relationships
- fail global OpenTelemetry context-manager setup explicitly while leaving production instrumentation unchanged

## Verification

- `pnpm format`
- `pnpm -F api lint` (40 to 31 warnings; target file 9 to 0)
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/lib/__tests__/db-instrumentation.test.ts` (12 passed)

Closes #31744
