### PR TITLE
fix(ui): deduplicate slash workflow suggestions

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/workflow-composer-domain.ts
+++ b/turbo/apps/platform/src/signals/okou-page/workflow-composer-domain.ts
@@ -27,6 +27,7 @@ export interface SlashWorkflowRange {
 }
 
 export interface ComposerSlashWorkflow {
+  readonly id: string;
   readonly name: string;
   readonly displayName: string | null;
   readonly description: string | null;
@@ -79,11 +80,15 @@ export function buildComposerSlashWorkflows({
 
   return workflows
     .filter((workflow) => {
-      return workflow.agentId === agentId;
+      return (
+        workflow.agentId === agentId &&
+        (workflow.shadowedBy === null || workflow.shadowedBy === undefined)
+      );
     })
     .map((workflow) => {
       const name = workflow.name;
       return {
+        id: workflow.id,
         name,
         displayName: workflow.displayName,
         description: workflow.description,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
@@ -18,6 +18,7 @@ import type {
   ModelProviderResponse,
   OrgModelPolicy,
 } from "@okouai/api-contracts/contracts/model-providers";
+import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows";
 import {
   agentsByIdContract,
   agentInstructionsContract,
@@ -759,7 +760,7 @@ export function workflowSummary({
   readonly displayName: string | null;
   readonly description: string | null;
   readonly agentId?: string;
-}) {
+}): WorkflowSummary {
   return {
     id: crypto.randomUUID(),
     agentId,
@@ -774,5 +775,6 @@ export function workflowSummary({
     canManage: true,
     canPublish: false,
     official: null,
+    shadowedBy: null,
   };
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-workflows.test.tsx
@@ -53,14 +53,20 @@ function workflow(
     readonly agentId?: string;
     readonly displayName?: string | null;
     readonly description?: string | null;
+    readonly visibility?: WorkflowFixture["visibility"];
+    readonly shadowedBy?: WorkflowFixture["shadowedBy"];
   } = {},
 ): WorkflowFixture {
-  return workflowSummary({
-    name,
-    agentId: options.agentId ?? AGENT_ID,
-    displayName: options.displayName ?? null,
-    description: options.description ?? `${name} description`,
-  });
+  return {
+    ...workflowSummary({
+      name,
+      agentId: options.agentId ?? AGENT_ID,
+      displayName: options.displayName ?? null,
+      description: options.description ?? `${name} description`,
+    }),
+    visibility: options.visibility ?? "public",
+    shadowedBy: options.shadowedBy ?? null,
+  };
 }
 
 function slashMenu(): HTMLElement {
@@ -518,6 +524,57 @@ test("Insert an attached workflow with slash suggestions", async () => {
     expect(screen.queryByTestId("slash-workflow-menu")).toBeNull();
   });
   expect(window.visualViewport?.offsetTop).toBe(160);
+});
+
+test("Suggest only the effective workflow when a private workflow shadows a public workflow", async () => {
+  const privateWorkflow = workflow("pr-auto", {
+    displayName: "PR Auto",
+    description: "Review, repair, and merge one pull request",
+    visibility: "private",
+  });
+  const publicWorkflow = workflow("pr-auto", {
+    displayName: "PR Auto",
+    description: "Legacy goal-driven pull request automation",
+    shadowedBy: {
+      id: privateWorkflow.id,
+      name: privateWorkflow.name,
+      displayName: privateWorkflow.displayName,
+    },
+  });
+  mockAgent();
+  mockThread();
+  installWorkflows(() => {
+    return [
+      workflow("aardvark"),
+      publicWorkflow,
+      privateWorkflow,
+      workflow("pr-implement"),
+      workflow("topic"),
+    ];
+  });
+
+  await setupPage({ context, path: `/chats/${THREAD_ID}` });
+
+  const user = userEvent.setup();
+  const editor = await findComposerEditor();
+  await user.click(editor);
+  await user.keyboard("/pr");
+
+  await waitFor(() => {
+    const matchingButtons = slashMenuButtons().filter((button) => {
+      return button.textContent
+        ?.replace(/\s+/gu, " ")
+        .trim()
+        .startsWith("/pr-auto");
+    });
+    expect(matchingButtons).toHaveLength(1);
+  });
+  expect(slashButton("/pr-auto")).toHaveTextContent(
+    "Review, repair, and merge one pull request",
+  );
+  expect(
+    screen.queryByText("Legacy goal-driven pull request automation"),
+  ).toBeNull();
 });
 
 test("Send a template while the current run is active", async () => {

--- a/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
@@ -8,8 +8,8 @@ import { ROUTES } from "../../signals/route-paths.ts";
 import { Link } from "../router/link.tsx";
 import type { ComposerSlashWorkflow } from "../../signals/okou-page/workflow-composer-domain.ts";
 
-function slashWorkflowOptionId(workflowName: string): string {
-  return `slash-workflow-option-${workflowName}`;
+function slashWorkflowOptionId(workflowId: string): string {
+  return `slash-workflow-option-${workflowId}`;
 }
 
 const COMPOSER_SUGGESTION_COLLISION_GAP = 12;
@@ -45,9 +45,7 @@ export function scrollSlashWorkflowIntoView(
   }
 
   window.requestAnimationFrame(() => {
-    const option = document.getElementById(
-      slashWorkflowOptionId(workflow.name),
-    );
+    const option = document.getElementById(slashWorkflowOptionId(workflow.id));
     if (option && typeof option.scrollIntoView === "function") {
       option.scrollIntoView({ block: "nearest" });
     }
@@ -106,8 +104,8 @@ export function SlashWorkflowMenu({
             const matchEnd = matchStart + query.length;
             return (
               <button
-                id={slashWorkflowOptionId(workflow.name)}
-                key={workflow.name}
+                id={slashWorkflowOptionId(workflow.id)}
+                key={workflow.id}
                 type="button"
                 className={cn(
                   "flex w-full flex-col items-start gap-0.5 rounded px-2 py-1.5 text-left transition-colors",


### PR DESCRIPTION
## Summary

- exclude shadowed workflow rows from slash-command suggestions so the composer shows only the effective runtime winner
- use the workflow UUID for React keys and option DOM IDs instead of the non-unique workflow name
- cover the private-over-public `pr-auto` collision with a page-level regression test

## Root cause

The workflows API intentionally returns both an effective private workflow and the public workflow it shadows. The composer ignored `shadowedBy` and keyed both rows by `name`, so React received duplicate `pr-auto` keys while the query changed and could duplicate the rendered option.

## Verification

- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-workflows.test.tsx --maxWorkers=1 --reporter=dot` (12 passed)
- `pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-workflows.test.tsx -t "Suggest only the effective workflow" --maxWorkers=1 --reporter=dot` (1 passed)
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/app check-types`
- `pnpm knip --workspace @okouai/app --no-progress`

## Compatibility

Responses that omit the optional `shadowedBy` field remain eligible, so this stays compatible with older API payloads.
