### PR TITLE
test(api): make observation contracts unconditional

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -885,7 +885,7 @@ async function expectGoalDrainPreCreateTiming(args: {
   readonly runId: string;
   readonly schedulerOrigin: "chat_callback" | "terminal_callback_fallback";
   readonly builtInModelContext: boolean;
-  readonly skippedHigherPriorityDrains?: boolean;
+  readonly skippedHigherPriorityDrains: boolean;
   readonly forbiddenValues: readonly string[];
 }): Promise<void> {
   const expectedActionTypes = [
@@ -963,10 +963,15 @@ async function expectGoalDrainPreCreateTiming(args: {
   ].map((actionType) => {
     return timingEventsForAction(goalDrainEvents, actionType)[0]?.duration_ms;
   });
+  const numericHigherPriorityDrainDurations = [
+    expect.any(Number),
+    expect.any(Number),
+  ];
+  const expectedHigherPriorityDrainDurations = args.skippedHigherPriorityDrains
+    ? [0, 0]
+    : numericHigherPriorityDrainDurations;
   expect(higherPriorityDrainDurations).toStrictEqual(
-    args.skippedHigherPriorityDrains
-      ? [0, 0]
-      : [expect.any(Number), expect.any(Number)],
+    expectedHigherPriorityDrainDurations,
   );
 
   const entrypointGapEvents = timingEventsForAction(
@@ -2198,6 +2203,7 @@ Goal CLI:
       runId: continuation.runId,
       schedulerOrigin: "terminal_callback_fallback",
       builtInModelContext: false,
+      skippedHigherPriorityDrains: false,
       forbiddenValues: [
         goalBrief,
         actor.userId,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-snapshot-chat-events.test.ts
@@ -279,7 +279,7 @@ function expectArchiveInvariants(
   expect(lines.length).toBeGreaterThan(0);
   const lastLine = lines[lines.length - 1];
   expect(lastLine?.seqId).toBe(lastPhysicalSeqId ?? Number(match?.[2]));
-  for (const [index, line] of lines.entries()) {
+  for (const line of lines) {
     const expectedKeys = [
       ...CANONICAL_ARCHIVE_KEYS,
       ...(line.failureReason === undefined ? [] : ["failureReason"]),
@@ -295,11 +295,14 @@ function expectArchiveInvariants(
     expect(line.chatThreadId).toBe(threadId);
     expect(Number.isInteger(line.seqId)).toBeTruthy();
     expect(Number.isNaN(Date.parse(line.createdAt))).toBeFalsy();
-    const previous = lines[index - 1];
-    if (previous !== undefined) {
-      expect(line.seqId).toBeGreaterThan(previous.seqId);
-    }
   }
+  const seqIds = lines.map((line) => {
+    return line.seqId;
+  });
+  const strictlyIncreasingSeqIds = [...new Set(seqIds)].sort((left, right) => {
+    return left - right;
+  });
+  expect(seqIds).toStrictEqual(strictlyIncreasingSeqIds);
   return lines;
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
@@ -86,12 +86,13 @@ function newTelegramBotId(): string {
   return String(Math.floor(Math.random() * 9_000_000_000) + 1_000_000_000);
 }
 
-function telegramOauthHead(contentLength: string, expectedOrigin?: string) {
+function telegramOauthHead(
+  contentLength: string,
+  observedOrigins: (string | null)[] = [],
+) {
   return http.head("https://oauth.telegram.org/auth", ({ request }) => {
     const url = new URL(request.url);
-    if (expectedOrigin) {
-      expect(url.searchParams.get("origin")).toBe(expectedOrigin);
-    }
+    observedOrigins.push(url.searchParams.get("origin"));
     return new HttpResponse(null, {
       headers: { "content-length": contentLength },
     });
@@ -785,7 +786,8 @@ describe("POST /api/telegram/setup-status", () => {
       privacyDisabled: true,
     });
     mockEnv("APP_URL", "https://app.vm0.ai");
-    server.use(telegramOauthHead("2048", "https://app.okou.ai"));
+    const observedOrigins: (string | null)[] = [];
+    server.use(telegramOauthHead("2048", observedOrigins));
 
     const response = await createApp({
       signal: context.signal,
@@ -809,6 +811,7 @@ describe("POST /api/telegram/setup-status", () => {
       domainConfigured: true,
       privacyDisabled: true,
     });
+    expect(observedOrigins).toStrictEqual(["https://app.okou.ai"]);
   });
 
   it("rejects an already installed bot", async () => {
@@ -882,7 +885,8 @@ describe("POST /api/telegram/register", () => {
     mockTelegramGetMe({ botId: telegramBotId, username: "registered_bot" });
     context.mocks.telegram.setWebhook.mockResolvedValue(undefined);
     context.mocks.telegram.setMyCommands.mockResolvedValue(undefined);
-    server.use(telegramOauthHead("1001", "https://app.example.test"));
+    const observedOrigins: (string | null)[] = [];
+    server.use(telegramOauthHead("1001", observedOrigins));
 
     const response = await accept(
       telegramClient().register({
@@ -904,6 +908,7 @@ describe("POST /api/telegram/register", () => {
       isOwner: true,
       isConnected: false,
     });
+    expect(observedOrigins).toStrictEqual(["https://app.example.test"]);
     expect(context.mocks.telegram.setWebhook).toHaveBeenCalledWith(
       TEST_BOT_TOKEN,
       `https://www.example.test/api/telegram/webhook/${telegramBotId}`,
@@ -931,7 +936,8 @@ describe("POST /api/telegram/register", () => {
     mockTelegramGetMe({ botId: telegramBotId, username: "owner_named_bot" });
     context.mocks.telegram.setWebhook.mockResolvedValue(undefined);
     context.mocks.telegram.setMyCommands.mockResolvedValue(undefined);
-    server.use(telegramOauthHead(telegramBotId, "https://app.okou.ai"));
+    const observedOrigins: (string | null)[] = [];
+    server.use(telegramOauthHead(telegramBotId, observedOrigins));
 
     const response = await postRegisterRaw(
       {
@@ -947,6 +953,7 @@ describe("POST /api/telegram/register", () => {
       username: "owner_named_bot",
       domainConfigured: true,
     });
+    expect(observedOrigins).toStrictEqual(["https://app.okou.ai"]);
     expect(context.mocks.telegram.setWebhook).toHaveBeenCalledWith(
       TEST_BOT_TOKEN,
       `https://api.okou.ai/api/telegram/webhook/${telegramBotId}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram.test.ts
@@ -81,12 +81,13 @@ function mintOkouToken(args: {
   });
 }
 
-function telegramOauthHead(contentLength: string, expectedOrigin?: string) {
+function telegramOauthHead(
+  contentLength: string,
+  observedOrigins: (string | null)[] = [],
+) {
   return http.head("https://oauth.telegram.org/auth", ({ request }) => {
     const url = new URL(request.url);
-    if (expectedOrigin) {
-      expect(url.searchParams.get("origin")).toBe(expectedOrigin);
-    }
+    observedOrigins.push(url.searchParams.get("origin"));
     return new HttpResponse(null, {
       headers: { "content-length": contentLength },
     });
@@ -936,7 +937,8 @@ describe("GET /api/integrations/telegram/link", () => {
     builder.telegramBotIds.push(installation.telegramBotId);
     fixtures.push(freezeTelegramFixture(builder));
     mockEnv("APP_URL", "https://app.example.com");
-    server.use(telegramOauthHead("2048", "https://app.example.com"));
+    const observedOrigins: (string | null)[] = [];
+    server.use(telegramOauthHead("2048", observedOrigins));
     const client = setupApp({
       context,
       routes: integrationsTelegramRoutes,
@@ -962,6 +964,7 @@ describe("GET /api/integrations/telegram/link", () => {
         domainConfigured: true,
       },
     });
+    expect(observedOrigins).toStrictEqual(["https://app.example.com"]);
   });
 
   it("returns official bot link status with the login bot id", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -879,15 +879,9 @@ function expectCanonicalOkouRunEnvironment(args: {
   readonly orgId: string;
   readonly runId: string;
   readonly publicBrand?: PublicBrand;
-  readonly chatThreadId?: string;
 }): void {
   expect(args.platformEnvironment.OKOU_APP_URL).toBe(args.appUrl);
   expect(args.platformEnvironment.OKOU_AGENT_ID).toBe(args.agentId);
-  if (args.chatThreadId) {
-    expect(args.platformEnvironment.OKOU_CHAT_THREAD_ID).toBe(
-      args.chatThreadId,
-    );
-  }
   expect(
     Object.keys(args.environment ?? {}).filter((key) => {
       return key.startsWith("ZERO_");
@@ -1101,17 +1095,33 @@ function expectClaimRouteResponseTimingActions(args: {
 }): void {
   const events = claimRouteTimingEventsForRun(args.runId);
   const expectedActionTypes = new Set(args.expectedActionTypes);
-  for (const actionType of CLAIM_ROUTE_RESPONSE_TIMING_ACTION_TYPES) {
-    const matchingEvents = events.filter((event) => {
-      return event.op_type === actionType;
-    });
-    if (!expectedActionTypes.has(actionType)) {
-      expect(matchingEvents).toHaveLength(0);
-      continue;
-    }
+  const actionCounts = CLAIM_ROUTE_RESPONSE_TIMING_ACTION_TYPES.map(
+    (actionType) => {
+      return {
+        actionType,
+        count: events.filter((event) => {
+          return event.op_type === actionType;
+        }).length,
+      };
+    },
+  );
+  const expectedActionCounts = CLAIM_ROUTE_RESPONSE_TIMING_ACTION_TYPES.map(
+    (actionType) => {
+      return {
+        actionType,
+        count: expectedActionTypes.has(actionType) ? 1 : 0,
+      };
+    },
+  );
+  expect(actionCounts).toStrictEqual(expectedActionCounts);
 
-    expect(matchingEvents).toHaveLength(1);
-    const event = matchingEvents[0];
+  for (const actionType of args.expectedActionTypes) {
+    const event = events.find((candidate) => {
+      return candidate.op_type === actionType;
+    });
+    if (!event) {
+      throw new Error(`Expected claim response timing for ${actionType}`);
+    }
     expect(event).toStrictEqual(
       expect.objectContaining({
         source: "api",
@@ -6988,24 +6998,29 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         throw new Error("Expected ordered-heartbeat poll to return 200");
       }
       expect(poll.body.job?.runId).toBe(followUp.runId);
-      if (expectedResource) {
-        expect(runnerPreference(poll.body.job)).toMatchObject({
-          kind: "preference",
-          runnerIdentity: {
-            runnerId,
-            heartbeatGeneration: 1,
-          },
-          tier:
-            expectedResource === "reusableSandbox"
-              ? "reusableSandbox"
-              : "workspaceCache",
-          expiresAt: expect.any(String),
-        });
-      } else {
-        expect(runnerPreference(poll.body.job)).toMatchObject({
-          kind: "noPreference",
-        });
-      }
+      const preference = runnerPreference(poll.body.job);
+      const preferenceProjection =
+        preference?.kind === "preference"
+          ? {
+              kind: preference.kind,
+              runnerIdentity: preference.runnerIdentity,
+              tier: preference.tier,
+              expiresAtType: typeof preference.expiresAt,
+            }
+          : { kind: preference?.kind };
+      const expectedPreferenceProjection =
+        expectedResource === undefined
+          ? { kind: "noPreference" }
+          : {
+              kind: "preference",
+              runnerIdentity: {
+                runnerId,
+                heartbeatGeneration: 1,
+              },
+              tier: expectedResource,
+              expiresAtType: "string",
+            };
+      expect(preferenceProjection).toStrictEqual(expectedPreferenceProjection);
       await api.requestCancelRun(actor, followUp.runId, [200]);
       await flushWaitUntilForTest();
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1849,7 +1849,6 @@ function expectTimeCursorAxiomResume(
   expected: {
     readonly cursor: string;
     readonly order: "asc" | "desc";
-    readonly hasCreatedAtBound?: boolean;
   },
 ): void {
   const apl = call[0];
@@ -1858,9 +1857,6 @@ function expectTimeCursorAxiomResume(
     noCache: true,
   });
   expect(apl).toContain(`| order by _time ${expected.order}`);
-  if (expected.hasCreatedAtBound) {
-    expect(apl).toContain("| where _time >= datetime(");
-  }
   expect(apl).not.toContain("| where _time > datetime(");
   expect(apl).not.toContain("| where _time < datetime(");
   expect(apl).not.toContain("_vm0Cursor >");

--- a/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/social.test.ts
@@ -1824,9 +1824,10 @@ describe("managed SocialKit route", () => {
           message: testCase.expectedMessage,
         },
       });
-      if (testCase.message !== undefined) {
-        expect(JSON.stringify(body)).not.toContain(testCase.message.trim());
-      }
+      const includesProviderMessage =
+        testCase.message !== undefined &&
+        JSON.stringify(body).includes(testCase.message.trim());
+      expect(includesProviderMessage).toBeFalsy();
     }
 
     let nonTranscriptRequests = 0;


### PR DESCRIPTION
Closes #31746.

## Summary

- replace 12 helper-backed conditional expectations with unconditional, complete observation projections across the seven scoped API test files
- remove the unreachable run-read created-at branch and unused run-lifecycle chat-thread branch after rechecking every caller
- preserve provider-message redaction, cursor semantics, canonical run environment and claim timing coverage, goal drain durations, caller-specific Telegram origins, and archive ordering invariants
- keep the change test-only with no production behavior, suppression, skipped test, unsafe cast, or timeout change

## Verification

- `pnpm exec prettier --check <7 changed test files>`
- `pnpm -F api lint` (passes; repository warnings decrease from 40 to 28 and all 12 scoped warnings are removed)
- `pnpm -F api check-types`
- `pnpm knip` (passes with 53 existing configuration hints)
- focused Vitest: SocialKit redaction 1 passed; run-read cursor 1 passed; Telegram origin GET 1 passed; Telegram origin POST 3 passed
- archive file: 12 passed; the database-backed failure-reason case is blocked before the archive helper by the local queue returning `404 Job not found in queue`
- run-lifecycle 8 scoped callers and chat-callback 2 scoped callers are likewise blocked before the modified helpers by the local queue claim/poll returning 404 or no job; PR CI remains the authoritative integration result

## Scope review

- latest `origin/main` rebased before commit
- repository-wide helper caller inventory repeated after rebase
- open-PR overlap checked: #31753 also adds tests in `chat-callbacks.bdd.test.ts`, without a functional dependency on this goal-drain observation change
