### PR TITLE
test(api): normalize workflow automation observations

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts
@@ -370,8 +370,7 @@ async function expectAutomationSourceAnnotation(
   fixture: ChatAutomationFixture,
   automationId: string,
   sourceRun: { readonly runId: string; readonly threadId: string },
-  expectedDisplayMessage?: string,
-): Promise<void> {
+): Promise<string | null> {
   const automation = await accept(
     automationsClient().get({
       headers: authHeaders(),
@@ -402,9 +401,6 @@ async function expectAutomationSourceAnnotation(
   if (!automationInput || automationInput.eventType !== "input.prompt") {
     throw new Error("Expected the triggered automation input");
   }
-  if (expectedDisplayMessage) {
-    expect(chatEventDisplayText(automationInput)).toBe(expectedDisplayMessage);
-  }
   expect(
     automationInput.userMessage.parts.filter((part) => {
       return (
@@ -424,6 +420,7 @@ async function expectAutomationSourceAnnotation(
       href: `/chats/${sourceRun.threadId}#run-${sourceRun.runId}`,
     },
   ]);
+  return chatEventDisplayText(automationInput);
 }
 
 describe("chat-run-finished workflow automations", () => {
@@ -581,10 +578,12 @@ describe("chat-run-finished workflow automations", () => {
         readLatestWorkflowAutomationRunFixture(context, patternMatch),
       ).resolves.toMatchObject({ autonomyBudget: 1 });
 
-      await expectAutomationSourceAnnotation(
+      const displayMessage = await expectAutomationSourceAnnotation(
         fixture,
         fireAlways,
         run,
+      );
+      expect(displayMessage).toBe(
         "A run in the watched chat thread completed.",
       );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-github-workflow.test.ts
@@ -292,6 +292,11 @@ type GithubWebhookAutomationCase = {
   readonly expectedDisplayMessage: string;
   readonly expectedPrompt: readonly string[];
   readonly excludedPrompt?: readonly string[];
+  readonly allowlistActorKey?: "review" | "comment";
+};
+
+type GithubActorAllowlistAutomationCase = GithubWebhookAutomationCase & {
+  readonly allowlistActorKey: "review" | "comment";
 };
 
 function githubPullRequestReviewAutomationBody(): WorkflowAutomationCreateRequest {
@@ -459,6 +464,7 @@ const githubWebhookAutomationCases: readonly GithubWebhookAutomationCase[] = [
       'GitHub user "trusted-user" submitted a pull request review with state "approved".',
     expectedPrompt: ['review with state "approved"', '"authorAssociation"'],
     excludedPrompt: ["Ignore previous instructions"],
+    allowlistActorKey: "review",
   },
   {
     name: "deployment status created",
@@ -563,10 +569,65 @@ const githubWebhookAutomationCases: readonly GithubWebhookAutomationCase[] = [
     expectedDisplayMessage: 'GitHub user "trusted-user" added a comment.',
     expectedPrompt: ["created a comment", '"bodyIncluded": false'],
     excludedPrompt: ["/verify Ignore previous instructions"],
+    allowlistActorKey: "comment",
   },
 ];
 
+const githubActorAllowlistCases = githubWebhookAutomationCases.filter(
+  (testCase): testCase is GithubActorAllowlistAutomationCase => {
+    return testCase.allowlistActorKey !== undefined;
+  },
+);
+
+function outsideAllowlistPayload(
+  testCase: GithubActorAllowlistAutomationCase,
+  installationId: string,
+): string {
+  const payload = JSON.parse(testCase.payload(installationId)) as Partial<
+    Record<"review" | "comment", { user: { login: string } }>
+  >;
+  const actor = payload[testCase.allowlistActorKey];
+  if (!actor) {
+    throw new Error(`Expected ${testCase.allowlistActorKey} webhook actor`);
+  }
+  actor.user.login = "outside-allowlist";
+  return JSON.stringify(payload);
+}
+
 describe("POST /api/webhooks/github for workflow automations", () => {
+  it.each(githubActorAllowlistCases)(
+    "ignores $name events from outside the trusted-author allowlist",
+    async (testCase) => {
+      const { fixture, actor, agentId, workflowId } = await setupFixture();
+      const installed = await gh.installGithubApp(actor, agentId);
+      mockOptionalEnv("GITHUB_APP_WEBHOOK_SECRET", GITHUB_WEBHOOK_SECRET);
+      mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+      await accept(
+        automationsClient().create({
+          headers: authHeaders(),
+          params: { workflowId },
+          body: testCase.body,
+        }),
+        [201],
+      );
+
+      const ignored = await postGithubWebhook({
+        event: testCase.event,
+        deliveryId: `delivery-${randomUUID()}`,
+        rawBody: outsideAllowlistPayload(
+          testCase,
+          installed.remoteInstallationId,
+        ),
+        publicBrand: "vm0",
+      });
+      expect(ignored).toStrictEqual({ status: 200, text: "OK" });
+      await flushWaitUntilForTest();
+
+      const listedRuns = await runsApi.listAgentRuns(actor, { limit: 20 });
+      expect(listedRuns.runs).toHaveLength(0);
+    },
+  );
+
   it.each(githubWebhookAutomationCases)(
     "dispatches $name automations without an API feature gate",
     async (testCase) => {
@@ -584,32 +645,6 @@ describe("POST /api/webhooks/github for workflow automations", () => {
       );
       if (!created.body.chatThreadId) {
         throw new Error("Expected the automation to have a chat thread");
-      }
-
-      if (
-        testCase.event === "pull_request_review" ||
-        testCase.event === "issue_comment"
-      ) {
-        const untrustedPayload = JSON.parse(
-          testCase.payload(installed.remoteInstallationId),
-        ) as {
-          review?: { user: { login: string } };
-          comment?: { user: { login: string } };
-        };
-        if (untrustedPayload.review) {
-          untrustedPayload.review.user.login = "outside-allowlist";
-        }
-        if (untrustedPayload.comment) {
-          untrustedPayload.comment.user.login = "outside-allowlist";
-        }
-        const ignored = await postGithubWebhook({
-          event: testCase.event,
-          deliveryId: `delivery-${randomUUID()}`,
-          rawBody: JSON.stringify(untrustedPayload),
-          publicBrand: "vm0",
-        });
-        expect(ignored).toStrictEqual({ status: 200, text: "OK" });
-        await flushWaitUntilForTest();
       }
 
       const deliveryId = `delivery-${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
@@ -766,44 +766,60 @@ describe("okou workflow automation scheduler", () => {
     const automation = await createDueLoopAutomation(scenario, 300);
     const base = now();
     const seenRunIds = new Set<string>();
-    const threadIds = new Set<string>();
 
     // Three fire + failed-completion cycles through scoped execution, runner,
     // and sandbox completion surfaces auto-disable the automation.
-    for (let failure = 1; failure <= 3; failure += 1) {
-      if (failure > 1) {
-        mockNow(base + (failure - 1) * 320_000);
-      }
+    const fireAndFailNextRun = async (): Promise<string> => {
       const currentThreadId = await executeDueWorkflowAutomations(
         automation.automationId,
       );
-      threadIds.add(currentThreadId);
       const messages = await workflowRunMessages(currentThreadId);
       const nextRun = messages.find((message) => {
         return !seenRunIds.has(message.runId);
       });
       if (!nextRun) {
-        throw new Error(`Expected fire #${failure} to post a run message`);
+        throw new Error("Expected the next fire to post a run message");
       }
       seenRunIds.add(nextRun.runId);
       await completeRunThroughSandbox(scenario, nextRun.runId, 1);
-      if (failure < 3) {
-        await expect
-          .poll(async () => {
-            return (await wf.readAutomation(automation.automationId)).nextRunAt;
-          })
-          .not.toBeNull();
-      }
-    }
-    expect(threadIds.size).toBe(1);
+      return currentThreadId;
+    };
+    const readFailureState = async () => {
+      const read = await wf.readAutomation(automation.automationId);
+      return {
+        enabled: read.enabled,
+        nextRunAt: read.nextRunAt,
+        nextRunAtIsFuture:
+          read.nextRunAt !== null && Date.parse(read.nextRunAt) > now(),
+      };
+    };
 
-    await expect
-      .poll(async () => {
-        return (await wf.readAutomation(automation.automationId)).enabled;
-      })
-      .toBeFalsy();
-    const read = await wf.readAutomation(automation.automationId);
-    expect(read.nextRunAt).toBeNull();
+    const firstThreadId = await fireAndFailNextRun();
+    await expect.poll(readFailureState).toStrictEqual({
+      enabled: true,
+      nextRunAt: expect.any(String),
+      nextRunAtIsFuture: true,
+    });
+
+    mockNow(base + 320_000);
+    const secondThreadId = await fireAndFailNextRun();
+    await expect.poll(readFailureState).toStrictEqual({
+      enabled: true,
+      nextRunAt: expect.any(String),
+      nextRunAtIsFuture: true,
+    });
+
+    mockNow(base + 640_000);
+    const thirdThreadId = await fireAndFailNextRun();
+
+    expect(new Set([firstThreadId, secondThreadId, thirdThreadId]).size).toBe(
+      1,
+    );
+    await expect.poll(readFailureState).toStrictEqual({
+      enabled: false,
+      nextRunAt: null,
+      nextRunAtIsFuture: false,
+    });
   });
 
   it("preserves run messages when workflow deletion removes automation provenance", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -357,6 +357,9 @@ interface CalendarWatchRecorder {
   baselineCalls: number;
   incrementalCalls: number;
   readonly channelIds: string[];
+  readonly eventListRequests: {
+    readonly syncToken: string | null;
+  }[];
 }
 
 interface CalendarWatchRegistration {
@@ -413,6 +416,7 @@ function configureGoogleCalendarWatchMock(args?: {
     baselineCalls: 0,
     incrementalCalls: 0,
     channelIds: [],
+    eventListRequests: [],
   };
   const calendarId = args?.calendarId ?? "primary";
   mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
@@ -467,9 +471,9 @@ function configureGoogleCalendarWatchMock(args?: {
         expect(url.searchParams.get("showDeleted")).toBe("true");
         expect(url.searchParams.get("maxResults")).toBe("2500");
         const syncToken = url.searchParams.get("syncToken");
+        recorder.eventListRequests.push({ syncToken });
         if (syncToken) {
           recorder.incrementalCalls += 1;
-          expect(syncToken).toBe("calendar-sync-baseline");
           return HttpResponse.json({
             items: args?.incrementalItems ?? [],
             nextSyncToken: "calendar-sync-incremental",
@@ -1177,14 +1181,36 @@ describe("okou workflow automations", () => {
       ),
     ]);
 
-    if (created.status === 201) {
-      await expect(wf.readAutomation(created.body.id)).resolves.toMatchObject({
+    const readBack =
+      created.status === 201
+        ? await wf.readAutomation(created.body.id)
+        : undefined;
+    if (
+      readBack !== undefined &&
+      (readBack.kind !== "event" || readBack.eventType !== "webhook-received")
+    ) {
+      throw new Error("Expected a webhook automation");
+    }
+    const outcome = {
+      status: created.status,
+      enabled: readBack?.enabled,
+      disabledReason: readBack?.disabledReason,
+      errorCode: created.status === 402 ? created.body.error.code : undefined,
+    };
+    expect([
+      {
+        status: 201,
         enabled: false,
         disabledReason: "paid_plan_required",
-      });
-    } else {
-      expect(created.body.error.code).toBe("TEAM_REQUIRED");
-    }
+        errorCode: undefined,
+      },
+      {
+        status: 402,
+        enabled: undefined,
+        disabledReason: undefined,
+        errorCode: "TEAM_REQUIRED",
+      },
+    ]).toContainEqual(outcome);
   });
 
   it("lists owned workflow automations across visible workflows", async () => {
@@ -1476,14 +1502,29 @@ describe("okou workflow automations", () => {
     ]);
 
     const after = await wf.readAutomation(created.body.id);
-    expect(after.enabled).toBeFalsy();
-    if (enabled.status === 200) {
-      expect(after).toMatchObject({
-        disabledReason: "paid_plan_required",
-      });
-    } else {
-      expect(enabled.body.error.code).toBe("TEAM_REQUIRED");
+    if (after.kind !== "event" || after.eventType !== "webhook-received") {
+      throw new Error("Expected a webhook automation");
     }
+    const outcome = {
+      status: enabled.status,
+      enabled: after.enabled,
+      disabledReason: enabled.status === 200 ? after.disabledReason : undefined,
+      errorCode: enabled.status === 402 ? enabled.body.error.code : undefined,
+    };
+    expect([
+      {
+        status: 200,
+        enabled: false,
+        disabledReason: "paid_plan_required",
+        errorCode: undefined,
+      },
+      {
+        status: 402,
+        enabled: false,
+        disabledReason: undefined,
+        errorCode: "TEAM_REQUIRED",
+      },
+    ]).toContainEqual(outcome);
   });
 
   it("clears the plan-disabled reason without rotating webhook credentials", async () => {
@@ -2792,11 +2833,15 @@ describe("okou workflow automations", () => {
     expect(created.body.chatThreadId).toBeTruthy();
 
     // The provider watch was registered once and the baseline event snapshot
-    // sync ran once (the mock asserts calendar id, token, and sync params).
+    // sync ran once. The mock asserts the calendar id and shared sync params;
+    // this test owns the recorded sync-token assertion below.
     // Baseline semantics — pre-existing events never dispatch runs — are
     // covered by webhooks-google-calendar.test.ts.
     expect(watchRecorder.watchCalls).toBe(1);
     expect(watchRecorder.baselineCalls).toBe(1);
+    expect(watchRecorder.eventListRequests).toStrictEqual([
+      { syncToken: null },
+    ]);
   });
 
   it("catches up Calendar changes from the channel startup sync", async () => {
@@ -2863,6 +2908,10 @@ describe("okou workflow automations", () => {
     ]);
     expect(watch.baselineCalls).toBe(1);
     expect(watch.incrementalCalls).toBe(1);
+    expect(watch.eventListRequests).toStrictEqual([
+      { syncToken: null },
+      { syncToken: "calendar-sync-baseline" },
+    ]);
     await runs.heartbeatRunner(runnerGroup);
     const job = await runs.pollRunner(runnerGroup);
     expect(job.body.job?.runId).toStrictEqual(expect.any(String));


### PR DESCRIPTION
## Summary

- record Calendar sync request observations in MSW handlers and assert them in test bodies
- normalize legal create/enable downgrade races and make each scheduler failure state explicit
- split GitHub allowlist negative preflights into their own scenarios and keep chat-run source/display assertions unconditional

## Verification

- `pnpm format`
- `pnpm -F api lint` (target warnings: 9 -> 0; 22 unrelated warnings remain)
- `pnpm -F api check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/workflow-automations.test.ts` (81 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/workflow-automation-scheduler.test.ts` (14 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-github-workflow.test.ts` (17 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-run-finished-automations.bdd.test.ts` (10 passed)

Closes #31747
