### PR TITLE
test(vsock-host): remove redundant write-file test

### DIFF
--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -70,23 +70,6 @@ fn encode_test_write_file_frame(
 }
 
 #[tokio::test]
-async fn test_write_file() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let write_task = spawn_write_file(Arc::clone(&host), "/tmp/test.txt", b"hello".to_vec(), false);
-
-    let write = expect_write_file(&mut guest).await;
-    assert_eq!(write.path, "/tmp/test.txt");
-    assert_eq!(write.content, b"hello");
-    assert!(!write.sudo);
-    assert!(!write.append);
-
-    send_write_file_success(&mut guest, write.seq()).await;
-
-    write_task.await.unwrap().unwrap();
-}
-
-#[tokio::test]
 async fn write_files_sends_single_batch_and_tracks_until_result() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);


### PR DESCRIPTION
## Summary

- remove the redundant `test_write_file` success-path test
- retain `write_file_tracks_until_result` as the stronger coverage for request fields, successful completion, and tracker lifecycle

## Scope

- test-only deletion in `crates/vsock-host/src/tests/file/write.rs`
- no production behavior, protocol helpers, test renames, or replacement duplicate coverage

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml -p vsock-host --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host 'tests::file::write::' -- --test-threads=1` (43 passed)
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host` (395 passed)

Closes #31635
