### PR TITLE
ci: run stale cleanup every two hours

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -2,7 +2,7 @@ name: Cleanup Stale Resources
 
 on:
   schedule:
-    - cron: "0 3 * * *" # Daily at 3:00 AM UTC
+    - cron: "0 */2 * * *" # Every two hours
   workflow_dispatch:
     inputs:
       dry-run:


### PR DESCRIPTION
## Summary

- run stale resource reconciliation every two hours instead of once per day
- keep the existing manual dispatch behavior unchanged

## Exclusions

- does not change cleanup discovery, authorization, or deletion behavior
- does not trigger an immediate cleanup run

## Validation

- parsed `.github/workflows/cleanup-stale.yml` with PyYAML and asserted the cron value
- `bash .github/scripts/check-workflow-shell-compatibility.sh`
- `actionlint 1.7.12 .github/workflows/cleanup-stale.yml`
- `git diff --check`
- repository pre-commit hooks
