### PR TITLE
fix(runner): apply late fast tier to split websocket usage

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -579,8 +579,9 @@ def _source_model_usage_pricing(
     if remembered_decision is not None:
         tier = remembered_decision.tier
         fast = remembered_decision.fast
-        if not remembered_decision.committed and billing_tier is not None:
-            tier = billing_tier
+        if not remembered_decision.committed:
+            if billing_tier is not None:
+                tier = billing_tier
             if observed_fast is not None:
                 fast = observed_fast
         tiers[message_id] = _ModelUsageTierDecision(

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage_aggregation.py
@@ -406,6 +406,66 @@ class TestModelProviderWebSocketUsageAggregation:
             [("gpt-5.5", "tokens.output", 12)],
         )
 
+    def test_model_websocket_late_priority_output_commits_fast_tier(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        flow = make_openai_responses_websocket_flow(real_flow, tmp_path)
+        mitm_addon.responseheaders(flow)
+
+        webhook = self._run_websocket_messages_and_end(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_late_priority",
+                        "model": "gpt-5.5",
+                        "usage": {"input_tokens": 0},
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_late_priority",
+                        "model": "gpt-5.5",
+                        "service_tier": "priority",
+                        "usage": {"output_tokens": 12},
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_late_priority",
+                        "model": "gpt-5.5",
+                        "service_tier": "default",
+                        "usage": {"output_tokens": 7},
+                    },
+                }
+            ).encode(),
+        )
+
+        assert_usage_event_rows(
+            webhook.usage_events(),
+            "provider",
+            [("gpt-5.5", "tokens.output.fast", 12)],
+        )
+        output_entries = [
+            entry
+            for entry in model_usage_source_entries(flow)
+            if entry["usage"].get("tokens.output") in (12, 7)
+        ]
+        assert len(output_entries) == 2
+        for entry in output_entries:
+            [event] = entry["usage_events"]
+            assert event["category"] == "tokens.output.fast"
+            assert event["buffer_accepted"] is (entry["usage"]["tokens.output"] == 12)
+
     def test_model_websocket_output_without_input_uses_conservative_billing_fallback(
         self,
         tmp_path,


### PR DESCRIPTION
## Summary

- refresh uncommitted input-tier and service-tier pricing evidence independently for split WebSocket usage frames
- preserve the remembered base/long-context tier when a late frame contains only output and an explicit priority tier
- cover late priority output plus a contradictory post-commit duplicate through the real WebSocket usage pipeline

## Scope

This change is limited to runner mitm-addon WebSocket pricing reconciliation. It does not change OpenAI response parsing, HTTP/SSE billing, generated model contracts, APIs, database state, or deployment configuration.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_model_provider_websocket_usage_aggregation.py` (25 passed)
- `uv run --no-sync python -m pytest tests/` (7,334 passed)

Closes #31641
