### PR TITLE
chore(api): enforce zero-warning lint gate

### DIFF
--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -11,7 +11,7 @@
     "db:dev-bench-seed": "dotenv -e .env.local -- tsx src/scripts/dev-bench-seed.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "oxlint && GOMAXPROCS=1 oxlint src --type-aware -c ../../.oxlintrc.typeaware.json --ignore-pattern '**/__tests__/**' && GOMAXPROCS=1 oxlint $(find src -type d -name __tests__) --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
+    "lint": "oxlint --deny-warnings && GOMAXPROCS=1 oxlint src --type-aware -c ../../.oxlintrc.typeaware.json --ignore-pattern '**/__tests__/**' --deny-warnings && GOMAXPROCS=1 oxlint $(find src -type d -name __tests__) --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings && eslint . --max-warnings 0",
     "check-types": "pnpm run check-types:deps && pnpm run check-types:boundaries && pnpm run check-types:gateways && pnpm run check-types:core && pnpm run check-types:bootstrap && pnpm run check-types:tests && pnpm run check-types:bootstrap-wiring",
     "check-types:deps": "pnpm --filter @okouai/pi-agent-runtime run build",
     "check-types:boundaries": "node scripts/check-typecheck-boundaries.mjs",


### PR DESCRIPTION
## Summary

- make all three API Oxlint passes reject warnings
- preserve the regular, production type-aware, and test type-aware scopes and the existing ESLint gate

## Verification

- `pnpm exec prettier --check apps/api/package.json`
- `pnpm --filter api lint` (0 warnings, 0 errors)

Closes #31764
