### PR TITLE
refactor(agent): centralize cli framework selector parsing

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -12,6 +12,7 @@ use api_contracts::generated::{
     constants::runners::paths::{CANONICAL_CLAUDE_CONFIG_DIR, CANONICAL_CODEX_HOME_DIR},
     types::runners::storage::ArtifactEntryMissingRootPolicy,
 };
+use guest_contracts::env::{CliAgentTypeSelection, CliFramework};
 
 use crate::constants;
 use guest_common::log_warn;
@@ -43,10 +44,26 @@ pub enum Framework {
 impl Framework {
     /// Stable CLI agent type string used in runner/web contracts and logs.
     pub fn agent_type(self) -> &'static str {
-        match self {
-            Framework::ClaudeCode => "claude-code",
-            Framework::Codex => "codex",
-            Framework::Pi => "pi",
+        CliFramework::from(self).as_cli_agent_type()
+    }
+}
+
+impl From<CliFramework> for Framework {
+    fn from(framework: CliFramework) -> Self {
+        match framework {
+            CliFramework::ClaudeCode => Self::ClaudeCode,
+            CliFramework::Codex => Self::Codex,
+            CliFramework::Pi => Self::Pi,
+        }
+    }
+}
+
+impl From<Framework> for CliFramework {
+    fn from(framework: Framework) -> Self {
+        match framework {
+            Framework::ClaudeCode => Self::ClaudeCode,
+            Framework::Codex => Self::Codex,
+            Framework::Pi => Self::Pi,
         }
     }
 }
@@ -607,18 +624,14 @@ impl GuestConfig {
 }
 
 fn framework_from_cli_agent_type(value: &str) -> Framework {
-    match value {
-        "codex" => Framework::Codex,
-        "pi" => Framework::Pi,
-        "" | "claude-code" => Framework::ClaudeCode,
-        other => {
-            log_warn!(
-                LOG_TAG,
-                "Unknown CLI_AGENT_TYPE={other:?}, defaulting to claude-code"
-            );
-            Framework::ClaudeCode
-        }
+    let selection = CliAgentTypeSelection::parse(value);
+    if selection.is_unknown() {
+        log_warn!(
+            LOG_TAG,
+            "Unknown CLI_AGENT_TYPE={value:?}, defaulting to claude-code"
+        );
     }
+    selection.framework().into()
 }
 
 fn non_empty(value: &str) -> Option<&str> {
@@ -1038,10 +1051,26 @@ mod tests {
             Framework::ClaudeCode
         );
         assert_eq!(framework_from_cli_agent_type("codex"), Framework::Codex);
+        assert_eq!(framework_from_cli_agent_type("pi"), Framework::Pi);
         assert_eq!(
             framework_from_cli_agent_type("unexpected"),
             Framework::ClaudeCode
         );
+    }
+
+    #[test]
+    fn guest_config_preserves_unknown_cli_agent_type_while_falling_back() {
+        let (_tmp, raw) =
+            raw_config_fixture_with_run_payload(&guest_contracts::env::RunPayload::default());
+        let raw = GuestConfigRaw {
+            cli_agent_type: "custom-agent".to_string(),
+            ..raw
+        };
+
+        let config = GuestConfig::from_raw(raw).unwrap();
+
+        assert_eq!(config.cli_agent_type, "custom-agent");
+        assert_eq!(config.framework, Framework::ClaudeCode);
     }
 
     #[test]

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -18,6 +18,7 @@ use guest_contracts::diagnostics::{
     EventDeliveryDiagnostic, FailureClass, FailureDetailSource, FailureDiagnostic, FailureReason,
     PromptMetadata, SessionHistoryStatus,
 };
+use guest_contracts::env::CliFramework;
 use serde_json::Value;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
@@ -44,11 +45,7 @@ pub fn base_failure_diagnostic_for_config(
     config: &env::GuestConfig,
     failure_class: FailureClass,
 ) -> FailureDiagnostic {
-    let framework = match config.framework {
-        env::Framework::ClaudeCode => AgentFramework::ClaudeCode,
-        env::Framework::Codex => AgentFramework::Codex,
-        env::Framework::Pi => AgentFramework::Pi,
-    };
+    let framework = AgentFramework::from(CliFramework::from(config.framework));
     FailureDiagnostic::new(
         failure_class,
         framework,

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -5,6 +5,7 @@ use crate::error::AgentError;
 use crate::session_history;
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
+use guest_contracts::env::CliFramework;
 use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
@@ -57,11 +58,7 @@ fn session_id_hash(framework: env::Framework, session_id: &str) -> Option<String
 }
 
 fn final_framework(framework: env::Framework) -> SessionHistoryFramework {
-    match framework {
-        env::Framework::ClaudeCode => SessionHistoryFramework::ClaudeCode,
-        env::Framework::Codex => SessionHistoryFramework::Codex,
-        env::Framework::Pi => SessionHistoryFramework::Pi,
-    }
+    SessionHistoryFramework::from(CliFramework::from(framework))
 }
 
 /// Verify the current guest session history matches final identity metadata.

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -841,6 +841,16 @@ pub enum AgentFramework {
     Pi,
 }
 
+impl From<crate::env::CliFramework> for AgentFramework {
+    fn from(framework: crate::env::CliFramework) -> Self {
+        match framework {
+            crate::env::CliFramework::ClaudeCode => Self::ClaudeCode,
+            crate::env::CliFramework::Codex => Self::Codex,
+            crate::env::CliFramework::Pi => Self::Pi,
+        }
+    }
+}
+
 impl AgentFramework {
     /// Return the stable snake_case string representation.
     #[must_use]
@@ -952,6 +962,28 @@ impl PromptMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cli_framework_projects_to_diagnostic_wire_values() {
+        for (framework, expected, wire_value) in [
+            (
+                crate::env::CliFramework::ClaudeCode,
+                AgentFramework::ClaudeCode,
+                "claude_code",
+            ),
+            (
+                crate::env::CliFramework::Codex,
+                AgentFramework::Codex,
+                "codex",
+            ),
+            (crate::env::CliFramework::Pi, AgentFramework::Pi, "pi"),
+        ] {
+            let projected = AgentFramework::from(framework);
+
+            assert_eq!(projected, expected);
+            assert_eq!(projected.as_str(), wire_value);
+        }
+    }
 
     #[test]
     fn prompt_metadata_classifies_safe_shapes_without_content() {

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -106,6 +106,96 @@ pub const SETTINGS_RUN_PAYLOAD_FIELD: &str = "OKOU_SETTINGS";
 /// this exact name.
 pub const CLI_AGENT_TYPE_ENV: &str = "CLI_AGENT_TYPE";
 
+/// Canonical CLI framework selected by [`CLI_AGENT_TYPE_ENV`].
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum CliFramework {
+    /// Anthropic Claude Code.
+    ClaudeCode,
+    /// OpenAI Codex CLI.
+    Codex,
+    /// Pi native agent loop.
+    Pi,
+}
+
+impl CliFramework {
+    /// Return the stable selector spelling used by [`CLI_AGENT_TYPE_ENV`].
+    #[must_use]
+    pub const fn as_cli_agent_type(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude-code",
+            Self::Codex => "codex",
+            Self::Pi => "pi",
+        }
+    }
+}
+
+/// Parsed [`CLI_AGENT_TYPE_ENV`] selection shared by runner and guest-agent.
+///
+/// Unknown non-empty values remain available through
+/// [`Self::normalized_cli_agent_type`] while selecting Claude Code effectively.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CliAgentTypeSelection<'a> {
+    framework: CliFramework,
+    normalized_cli_agent_type: &'a str,
+    unknown: bool,
+}
+
+impl<'a> CliAgentTypeSelection<'a> {
+    /// Parse a raw CLI framework selector.
+    ///
+    /// Empty input selects and normalizes to Claude Code without being marked
+    /// unknown. Unknown non-empty input remains unchanged for transport, is
+    /// marked unknown, and also selects Claude Code effectively.
+    #[must_use]
+    pub fn parse(value: &'a str) -> Self {
+        match value {
+            "" => Self {
+                framework: CliFramework::ClaudeCode,
+                normalized_cli_agent_type: CliFramework::ClaudeCode.as_cli_agent_type(),
+                unknown: false,
+            },
+            "claude-code" => Self {
+                framework: CliFramework::ClaudeCode,
+                normalized_cli_agent_type: value,
+                unknown: false,
+            },
+            "codex" => Self {
+                framework: CliFramework::Codex,
+                normalized_cli_agent_type: value,
+                unknown: false,
+            },
+            "pi" => Self {
+                framework: CliFramework::Pi,
+                normalized_cli_agent_type: value,
+                unknown: false,
+            },
+            _ => Self {
+                framework: CliFramework::ClaudeCode,
+                normalized_cli_agent_type: value,
+                unknown: true,
+            },
+        }
+    }
+
+    /// Return the effective framework after applying fallback semantics.
+    #[must_use]
+    pub const fn framework(self) -> CliFramework {
+        self.framework
+    }
+
+    /// Return the selector spelling transported to downstream consumers.
+    #[must_use]
+    pub const fn normalized_cli_agent_type(self) -> &'a str {
+        self.normalized_cli_agent_type
+    }
+
+    /// Return whether the raw non-empty selector was unknown.
+    #[must_use]
+    pub const fn is_unknown(self) -> bool {
+        self.unknown
+    }
+}
+
 /// Canonical private user-environment file pointer written by the runner.
 ///
 /// The guest-agent validates that the path points at its per-run private
@@ -503,6 +593,32 @@ pub fn sanitize_env_key_for_diagnostic(key: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cli_agent_type_selection_covers_known_empty_and_unknown_values() {
+        for (value, framework) in [
+            ("claude-code", CliFramework::ClaudeCode),
+            ("codex", CliFramework::Codex),
+            ("pi", CliFramework::Pi),
+        ] {
+            let selection = CliAgentTypeSelection::parse(value);
+
+            assert_eq!(selection.framework(), framework);
+            assert_eq!(selection.normalized_cli_agent_type(), value);
+            assert!(!selection.is_unknown());
+            assert_eq!(framework.as_cli_agent_type(), value);
+        }
+
+        let empty = CliAgentTypeSelection::parse("");
+        assert_eq!(empty.framework(), CliFramework::ClaudeCode);
+        assert_eq!(empty.normalized_cli_agent_type(), "claude-code");
+        assert!(!empty.is_unknown());
+
+        let unknown = CliAgentTypeSelection::parse("custom-agent");
+        assert_eq!(unknown.framework(), CliFramework::ClaudeCode);
+        assert_eq!(unknown.normalized_cli_agent_type(), "custom-agent");
+        assert!(unknown.is_unknown());
+    }
 
     #[test]
     fn run_artifacts_round_trip_with_and_without_missing_root_policy() {

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -53,6 +53,16 @@ pub enum SessionHistoryFramework {
     Pi,
 }
 
+impl From<crate::env::CliFramework> for SessionHistoryFramework {
+    fn from(framework: crate::env::CliFramework) -> Self {
+        match framework {
+            crate::env::CliFramework::ClaudeCode => Self::ClaudeCode,
+            crate::env::CliFramework::Codex => Self::Codex,
+            crate::env::CliFramework::Pi => Self::Pi,
+        }
+    }
+}
+
 /// Storage ref kind for session-history bytes.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -532,6 +542,32 @@ fn is_sha256_hex(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cli_framework_projects_to_session_history_wire_values() {
+        for (framework, expected, wire_value) in [
+            (
+                crate::env::CliFramework::ClaudeCode,
+                SessionHistoryFramework::ClaudeCode,
+                "claude-code",
+            ),
+            (
+                crate::env::CliFramework::Codex,
+                SessionHistoryFramework::Codex,
+                "codex",
+            ),
+            (
+                crate::env::CliFramework::Pi,
+                SessionHistoryFramework::Pi,
+                "pi",
+            ),
+        ] {
+            let projected = SessionHistoryFramework::from(framework);
+
+            assert_eq!(projected, expected);
+            assert_eq!(projected.as_str(), wire_value);
+        }
+    }
 
     fn valid_source() -> SessionHistorySourceRef {
         SessionHistorySourceRef::ClaudeCode {

--- a/crates/runner/src/executor/cli_framework.rs
+++ b/crates/runner/src/executor/cli_framework.rs
@@ -1,3 +1,5 @@
+use guest_contracts::env::{CliAgentTypeSelection, CliFramework};
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum EffectiveCliFramework {
     ClaudeCode,
@@ -5,22 +7,32 @@ pub(crate) enum EffectiveCliFramework {
     Pi,
 }
 
-pub(crate) fn effective_cli_framework(cli_agent_type: &str) -> EffectiveCliFramework {
-    match normalized_cli_agent_type(cli_agent_type) {
-        "codex" => EffectiveCliFramework::Codex,
-        "pi" => EffectiveCliFramework::Pi,
-        _ => {
-            // Guest-agent currently falls back unknown CLI_AGENT_TYPE values to
-            // Claude Code. Keep runner env gating aligned with that behavior.
-            EffectiveCliFramework::ClaudeCode
+impl From<CliFramework> for EffectiveCliFramework {
+    fn from(framework: CliFramework) -> Self {
+        match framework {
+            CliFramework::ClaudeCode => Self::ClaudeCode,
+            CliFramework::Codex => Self::Codex,
+            CliFramework::Pi => Self::Pi,
         }
     }
 }
 
-pub(super) fn normalized_cli_agent_type(cli_agent_type: &str) -> &str {
-    if cli_agent_type.is_empty() {
-        "claude-code"
-    } else {
-        cli_agent_type
+impl From<EffectiveCliFramework> for CliFramework {
+    fn from(framework: EffectiveCliFramework) -> Self {
+        match framework {
+            EffectiveCliFramework::ClaudeCode => Self::ClaudeCode,
+            EffectiveCliFramework::Codex => Self::Codex,
+            EffectiveCliFramework::Pi => Self::Pi,
+        }
     }
+}
+
+pub(crate) fn effective_cli_framework(cli_agent_type: &str) -> EffectiveCliFramework {
+    CliAgentTypeSelection::parse(cli_agent_type)
+        .framework()
+        .into()
+}
+
+pub(super) fn normalized_cli_agent_type(cli_agent_type: &str) -> &str {
+    CliAgentTypeSelection::parse(cli_agent_type).normalized_cli_agent_type()
 }

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
+use guest_contracts::env::CliFramework;
 use guest_contracts::session_history_identity::{SessionHistoryFramework, SessionHistoryRefKind};
 use sandbox::Sandbox;
 use tracing::{info, warn};
@@ -26,11 +27,7 @@ impl RestoredSessionIdentity {
         let resume_session = context.resume_session.as_ref()?;
         let history_ref = resume_session.history_ref()?;
         let effective_framework = effective_cli_framework(&context.cli_agent_type);
-        let framework = match effective_framework {
-            EffectiveCliFramework::ClaudeCode => SessionHistoryFramework::ClaudeCode,
-            EffectiveCliFramework::Codex => SessionHistoryFramework::Codex,
-            EffectiveCliFramework::Pi => SessionHistoryFramework::Pi,
-        };
+        let framework = SessionHistoryFramework::from(CliFramework::from(effective_framework));
         let history_ref_kind = match history_ref.kind {
             ResumeSessionHistoryRefKind::Blob => SessionHistoryRefKind::Blob,
         };

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -137,26 +137,26 @@ fn pi_context_for_test() -> ExecutionContext {
 
 #[test]
 fn effective_cli_framework_matches_guest_agent_fallback_semantics() {
-    assert_eq!(normalized_cli_agent_type(""), "claude-code");
-    assert_eq!(normalized_cli_agent_type("claude-code"), "claude-code");
-    assert_eq!(normalized_cli_agent_type("custom-agent"), "custom-agent");
+    for (value, framework) in [
+        ("claude-code", EffectiveCliFramework::ClaudeCode),
+        ("codex", EffectiveCliFramework::Codex),
+        ("pi", EffectiveCliFramework::Pi),
+    ] {
+        assert_eq!(normalized_cli_agent_type(value), value);
+        assert_eq!(effective_cli_framework(value), framework);
+    }
 
     assert_eq!(
         effective_cli_framework(""),
         EffectiveCliFramework::ClaudeCode
     );
-    assert_eq!(
-        effective_cli_framework("claude-code"),
-        EffectiveCliFramework::ClaudeCode
-    );
+    assert_eq!(normalized_cli_agent_type(""), "claude-code");
+
     assert_eq!(
         effective_cli_framework("custom-agent"),
         EffectiveCliFramework::ClaudeCode
     );
-    assert_eq!(
-        effective_cli_framework("codex"),
-        EffectiveCliFramework::Codex
-    );
+    assert_eq!(normalized_cli_agent_type("custom-agent"), "custom-agent");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add one canonical parser for the `CLI_AGENT_TYPE` selector in `guest-contracts`
- project the canonical framework into the runner, guest-agent, session-history, and diagnostic representations with exhaustive conversions
- cover known, empty, and unknown selectors while preserving the existing fallback and transport behavior

## Compatibility

- no selector spellings or persisted wire values change
- an empty selector still normalizes to `claude-code`
- an unknown non-empty selector is still transported unchanged, falls back effectively to Claude Code, and is warned about by the guest-agent
- this PR does not add a new framework or change framework-specific execution behavior

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p guest-contracts -p guest-agent -p runner --no-deps`
- `lefthook run pre-commit`

Closes #31633
