### PR TITLE
test(api): isolate runtime route cooldown fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -734,6 +734,23 @@ async function configureBuiltInPiModelOnOpenRouter(
   if (!primary || primary.provider_type === "openrouter-codex") {
     throw new Error(`Expected a primary managed route for ${selectedModel}`);
   }
+  const unavailableCandidate = {
+    selectedModel,
+    providerType: primary.provider_type,
+    upstreamModel: primary.upstream_model,
+  };
+  await withBuiltInModelRuntimeRouteCandidateUnavailableForTest(
+    unavailableCandidate,
+    async () => {
+      const fallback = await resolveVm0BuiltInModelRouteFixture(
+        context,
+        selectedModel,
+      );
+      if (!fallback || fallback.provider_type !== "openrouter-codex") {
+        throw new Error(`Expected an OpenRouter fallback for ${selectedModel}`);
+      }
+    },
+  );
   await api.updateOrgModelPolicies(actor, [
     {
       model: selectedModel,
@@ -745,23 +762,8 @@ async function configureBuiltInPiModelOnOpenRouter(
   ]);
   return async <T>(work: () => Promise<T>): Promise<T> => {
     return await withBuiltInModelRuntimeRouteCandidateUnavailableForTest(
-      {
-        selectedModel,
-        providerType: primary.provider_type,
-        upstreamModel: primary.upstream_model,
-      },
-      async () => {
-        const fallback = await resolveVm0BuiltInModelRouteFixture(
-          context,
-          selectedModel,
-        );
-        if (!fallback || fallback.provider_type !== "openrouter-codex") {
-          throw new Error(
-            `Expected an OpenRouter fallback for ${selectedModel}`,
-          );
-        }
-        return await work();
-      },
+      unavailableCandidate,
+      work,
     );
   };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -101,6 +101,7 @@ import {
   createUsagePricingFixture,
   type UsagePricingFixture,
 } from "../../../test-fixtures/usage-pricing";
+import { withBuiltInModelRuntimeRouteCandidateUnavailableForTest } from "../../../test-fixtures/built-in-model-runtime-route";
 import { setChatThreadVideoModelFixture } from "../../../test-fixtures/chat-thread-events";
 import { seededSystemSkillArchive } from "../../../test-fixtures/seeded-system-skill-archive";
 import {
@@ -160,7 +161,6 @@ import {
   resolveVm0BuiltInModelRouteFixture,
   seedVm0BuiltInModelCandidateKeys,
   seedVm0BuiltInModelKey as seedVm0BuiltInModelKeyState,
-  setVm0BuiltInCandidateCooldownFixture,
   setRunAutonomyBudgetFixture,
   steerRunTimeBudgetFixture,
 } from "./helpers/runtime-state";
@@ -725,7 +725,7 @@ async function configureBuiltInPiModel(
 async function configureBuiltInPiModelOnOpenRouter(
   actor: ApiTestUser,
   selectedModel: "deepseek-v4-flash" | "deepseek-v4-pro" | "gpt-5.6-terra",
-): Promise<void> {
+): Promise<<T>(work: () => Promise<T>) => Promise<T>> {
   await seedVm0BuiltInModelCandidateKeys(context, selectedModel);
   const primary = await resolveVm0BuiltInModelRouteFixture(
     context,
@@ -733,19 +733,6 @@ async function configureBuiltInPiModelOnOpenRouter(
   );
   if (!primary || primary.provider_type === "openrouter-codex") {
     throw new Error(`Expected a primary managed route for ${selectedModel}`);
-  }
-  await setVm0BuiltInCandidateCooldownFixture(
-    context,
-    selectedModel,
-    primary,
-    new Date(now() + 10 * 60_000),
-  );
-  const fallback = await resolveVm0BuiltInModelRouteFixture(
-    context,
-    selectedModel,
-  );
-  if (!fallback || fallback.provider_type !== "openrouter-codex") {
-    throw new Error(`Expected an OpenRouter fallback for ${selectedModel}`);
   }
   await api.updateOrgModelPolicies(actor, [
     {
@@ -756,6 +743,27 @@ async function configureBuiltInPiModelOnOpenRouter(
       modelProviderId: null,
     },
   ]);
+  return async <T>(work: () => Promise<T>): Promise<T> => {
+    return await withBuiltInModelRuntimeRouteCandidateUnavailableForTest(
+      {
+        selectedModel,
+        providerType: primary.provider_type,
+        upstreamModel: primary.upstream_model,
+      },
+      async () => {
+        const fallback = await resolveVm0BuiltInModelRouteFixture(
+          context,
+          selectedModel,
+        );
+        if (!fallback || fallback.provider_type !== "openrouter-codex") {
+          throw new Error(
+            `Expected an OpenRouter fallback for ${selectedModel}`,
+          );
+        }
+        return await work();
+      },
+    );
+  };
 }
 
 async function sendChatRun(
@@ -5309,8 +5317,14 @@ async function queueCapabilityProvenPiRun(args: {
     );
   }
   const anchorClaim = await claimChatRun(args.runnerGroup, anchor.runId);
+  let withModelRoute = async <T>(work: () => Promise<T>): Promise<T> => {
+    return await work();
+  };
   if (args.terraRoute === "openrouter") {
-    await configureBuiltInPiModelOnOpenRouter(args.actor, "gpt-5.6-terra");
+    withModelRoute = await configureBuiltInPiModelOnOpenRouter(
+      args.actor,
+      "gpt-5.6-terra",
+    );
   } else {
     await configureBuiltInPiModel(args.actor, "gpt-5.6-terra");
   }
@@ -5325,19 +5339,21 @@ async function queueCapabilityProvenPiRun(args: {
     },
   );
   const usagePricingResolution = await createTerraUsagePricingResolution();
-  const run = await sendChatRun(
-    args.actor,
-    {
-      agentId: args.agentId,
-      prompt: args.prompt,
-      model: "gpt-5.6-terra",
-      ...(args.codexServiceTier === undefined
-        ? {}
-        : { runOptions: { codexServiceTier: args.codexServiceTier } }),
-    },
-    "vm0",
-    usagePricingResolution,
-  );
+  const run = await withModelRoute(async () => {
+    return await sendChatRun(
+      args.actor,
+      {
+        agentId: args.agentId,
+        prompt: args.prompt,
+        model: "gpt-5.6-terra",
+        ...(args.codexServiceTier === undefined
+          ? {}
+          : { runOptions: { codexServiceTier: args.codexServiceTier } }),
+      },
+      "vm0",
+      usagePricingResolution,
+    );
+  });
   await waitForRunStatus(args.actor, run.runId, "queued");
   return { anchor, anchorClaim, run, usagePricingResolution };
 }
@@ -7334,7 +7350,10 @@ describe("CHAT-02: model-first provider policies", () => {
     async (selectedModel) => {
       const { actor, agentId } = await entitledChatActor();
       const orgId = requireOrgId(actor);
-      await configureBuiltInPiModelOnOpenRouter(actor, selectedModel);
+      const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
+        actor,
+        selectedModel,
+      );
       await updateFeatureSwitchesForUser(
         context,
         { ...actor, orgId },
@@ -7359,10 +7378,12 @@ describe("CHAT-02: model-first provider policies", () => {
         ),
       );
 
-      const run = await sendChatRun(actor, {
-        agentId,
-        prompt: `run ${selectedModel} on its managed fallback`,
-        model: selectedModel,
+      const run = await withOpenRouterRoute(async () => {
+        return await sendChatRun(actor, {
+          agentId,
+          prompt: `run ${selectedModel} on its managed fallback`,
+          model: selectedModel,
+        });
       });
       await waitForRunStatus(actor, run.runId, "completed", 10_000);
       await flushWaitUntilForTest();
@@ -7572,7 +7593,10 @@ describe("CHAT-02: model-first provider policies", () => {
     const { actor, agentId } = await entitledChatActor();
     const orgId = requireOrgId(actor);
     const usagePricingResolution = await createTerraUsagePricingResolution();
-    await configureBuiltInPiModelOnOpenRouter(actor, "gpt-5.6-terra");
+    const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
+      actor,
+      "gpt-5.6-terra",
+    );
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId },
@@ -7601,16 +7625,18 @@ describe("CHAT-02: model-first provider policies", () => {
         },
       ),
     );
-    const first = await sendChatRun(
-      actor,
-      {
-        agentId,
-        prompt: "seed the canonical Pi binding",
-        model: "gpt-5.6-terra",
-      },
-      "vm0",
-      usagePricingResolution,
-    );
+    const first = await withOpenRouterRoute(async () => {
+      return await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt: "seed the canonical Pi binding",
+          model: "gpt-5.6-terra",
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+    });
     await waitForRunStatus(actor, first.runId, "completed", 10_000);
     await flushWaitUntilForTest();
 
@@ -7685,17 +7711,19 @@ describe("CHAT-02: model-first provider policies", () => {
     );
 
     const prompt = "continue the migrated OpenRouter session";
-    const second = await sendChatRun(
-      actor,
-      {
-        agentId,
-        threadId: first.threadId,
-        prompt,
-        model: "gpt-5.6-terra",
-      },
-      "vm0",
-      usagePricingResolution,
-    );
+    const second = await withOpenRouterRoute(async () => {
+      return await sendChatRun(
+        actor,
+        {
+          agentId,
+          threadId: first.threadId,
+          prompt,
+          model: "gpt-5.6-terra",
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+    });
     await waitForRunStatus(actor, second.runId, "completed", 10_000);
     await flushWaitUntilForTest();
 
@@ -7738,7 +7766,10 @@ describe("CHAT-02: model-first provider policies", () => {
     const { actor, agentId } = await entitledChatActor();
     const orgId = requireOrgId(actor);
     const usagePricingResolution = await createTerraUsagePricingResolution();
-    await configureBuiltInPiModelOnOpenRouter(actor, "gpt-5.6-terra");
+    const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
+      actor,
+      "gpt-5.6-terra",
+    );
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId },
@@ -7795,16 +7826,18 @@ describe("CHAT-02: model-first provider policies", () => {
       ),
     );
 
-    const first = await sendChatRun(
-      actor,
-      {
-        agentId,
-        prompt: prompts[0],
-        model: "gpt-5.6-terra",
-      },
-      "vm0",
-      usagePricingResolution,
-    );
+    const first = await withOpenRouterRoute(async () => {
+      return await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt: prompts[0],
+          model: "gpt-5.6-terra",
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+    });
     await waitForRunStatus(actor, first.runId, "completed", 10_000);
     await flushWaitUntilForTest();
     const firstBinding = await readThreadSessionBinding(
@@ -7815,18 +7848,20 @@ describe("CHAT-02: model-first provider policies", () => {
       throw new Error("Expected standard Terra to bind a canonical Pi session");
     }
 
-    const fast = await sendChatRun(
-      actor,
-      {
-        agentId,
-        threadId: first.threadId,
-        prompt: prompts[1],
-        model: "gpt-5.6-terra",
-        runOptions: { codexServiceTier: "fast" },
-      },
-      "vm0",
-      usagePricingResolution,
-    );
+    const fast = await withOpenRouterRoute(async () => {
+      return await sendChatRun(
+        actor,
+        {
+          agentId,
+          threadId: first.threadId,
+          prompt: prompts[1],
+          model: "gpt-5.6-terra",
+          runOptions: { codexServiceTier: "fast" },
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+    });
     await waitForRunStatus(actor, fast.runId, "completed", 10_000);
     await flushWaitUntilForTest();
     const fastBinding = await readThreadSessionBinding(context, first.threadId);
@@ -7838,17 +7873,19 @@ describe("CHAT-02: model-first provider policies", () => {
       "gpt-5.6-terra",
       { codexServiceTier: null },
     );
-    const returned = await sendChatRun(
-      actor,
-      {
-        agentId,
-        threadId: first.threadId,
-        prompt: prompts[2],
-        model: "gpt-5.6-terra",
-      },
-      "vm0",
-      usagePricingResolution,
-    );
+    const returned = await withOpenRouterRoute(async () => {
+      return await sendChatRun(
+        actor,
+        {
+          agentId,
+          threadId: first.threadId,
+          prompt: prompts[2],
+          model: "gpt-5.6-terra",
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+    });
     await waitForRunStatus(actor, returned.runId, "completed", 10_000);
     await flushWaitUntilForTest();
     const returnedBinding = await readThreadSessionBinding(
@@ -7992,7 +8029,10 @@ describe("CHAT-02: model-first provider policies", () => {
     const { actor, agentId } = await entitledChatActor();
     const orgId = requireOrgId(actor);
     const usagePricingResolution = await createTerraUsagePricingResolution();
-    await configureBuiltInPiModelOnOpenRouter(actor, "gpt-5.6-terra");
+    const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
+      actor,
+      "gpt-5.6-terra",
+    );
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId },
@@ -8040,17 +8080,19 @@ describe("CHAT-02: model-first provider policies", () => {
     );
 
     for (const [index, testCase] of cases.entries()) {
-      const run = await sendChatRun(
-        actor,
-        {
-          agentId,
-          prompt: `observe OpenRouter tier case ${index.toString()}`,
-          model: "gpt-5.6-terra",
-          runOptions: { codexServiceTier: "fast" },
-        },
-        "vm0",
-        usagePricingResolution,
-      );
+      const run = await withOpenRouterRoute(async () => {
+        return await sendChatRun(
+          actor,
+          {
+            agentId,
+            prompt: `observe OpenRouter tier case ${index.toString()}`,
+            model: "gpt-5.6-terra",
+            runOptions: { codexServiceTier: "fast" },
+          },
+          "vm0",
+          usagePricingResolution,
+        );
+      });
       await waitForRunStatus(actor, run.runId, "completed", 10_000);
       await flushWaitUntilForTest();
       await expectTerraApiFollowUpUsage(run.runId, testCase.expectedSuffix);
@@ -9798,7 +9840,10 @@ describe("CHAT-02: model-first provider policies", () => {
     };
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "2");
 
-    await configureBuiltInPiModelOnOpenRouter(actor, "gpt-5.6-terra");
+    const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
+      actor,
+      "gpt-5.6-terra",
+    );
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId: actor.orgId },
@@ -9833,17 +9878,19 @@ describe("CHAT-02: model-first provider policies", () => {
       ),
     );
     const checkpointObjects = mockPiCheckpointObjectStore();
-    const first = await sendChatRun(
-      actor,
-      {
-        agentId,
-        prompt: "create a settled Pi checkpoint",
-        model: "gpt-5.6-terra",
-        runOptions: { codexServiceTier: "fast" },
-      },
-      "vm0",
-      usagePricingResolution,
-    );
+    const first = await withOpenRouterRoute(async () => {
+      return await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt: "create a settled Pi checkpoint",
+          model: "gpt-5.6-terra",
+          runOptions: { codexServiceTier: "fast" },
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+    });
     await waitForRunStatus(actor, first.runId, "completed");
     await flushWaitUntilForTest();
     expect(modelCalls).toBe(1);
@@ -9881,18 +9928,20 @@ describe("CHAT-02: model-first provider policies", () => {
 
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
     const prompt = "preserve this original prompt for official compaction";
-    const second = await sendChatRun(
-      actor,
-      {
-        agentId,
-        threadId: first.threadId,
-        prompt,
-        model: "gpt-5.6-terra",
-        runOptions: { codexServiceTier: "fast" },
-      },
-      "vm0",
-      usagePricingResolution,
-    );
+    const second = await withOpenRouterRoute(async () => {
+      return await sendChatRun(
+        actor,
+        {
+          agentId,
+          threadId: first.threadId,
+          prompt,
+          model: "gpt-5.6-terra",
+          runOptions: { codexServiceTier: "fast" },
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+    });
     await waitForRunStatus(actor, second.runId, "queued");
     context.mocks.axiomLogging.debug.mockClear();
     await completeChatRunOk(anchor.runId, anchorSandboxHeaders);
@@ -10044,7 +10093,10 @@ describe("CHAT-02: model-first provider policies", () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const orgId = requireOrgId(actor);
     const usagePricingResolution = await createTerraUsagePricingResolution();
-    await configureBuiltInPiModelOnOpenRouter(actor, "gpt-5.6-terra");
+    const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
+      actor,
+      "gpt-5.6-terra",
+    );
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId },
@@ -10107,17 +10159,19 @@ describe("CHAT-02: model-first provider policies", () => {
     );
     const checkpointObjects = mockPiCheckpointObjectStore();
     const prompt = "use the Okou CLI through the Sandbox handoff";
-    const run = await sendChatRun(
-      actor,
-      {
-        agentId,
-        prompt,
-        model: "gpt-5.6-terra",
-        runOptions: { codexServiceTier: "fast" },
-      },
-      "vm0",
-      usagePricingResolution,
-    );
+    const run = await withOpenRouterRoute(async () => {
+      return await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt,
+          model: "gpt-5.6-terra",
+          runOptions: { codexServiceTier: "fast" },
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+    });
     const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
     await expect
       .poll(() => {
@@ -10601,10 +10655,12 @@ describe("CHAT-02: model-first provider policies", () => {
     ).resolves.toStrictEqual(canonicalConversation);
     expect(modelCalls).toBe(1);
 
-    const failedHandoff = await sendChatRun(actor, {
-      agentId,
-      threadId: run.threadId,
-      prompt: "reject a non-native Sandbox H2",
+    const failedHandoff = await withOpenRouterRoute(async () => {
+      return await sendChatRun(actor, {
+        agentId,
+        threadId: run.threadId,
+        prompt: "reject a non-native Sandbox H2",
+      });
     });
     const failedManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${failedHandoff.runId}/manifest.json`;
     await expect
@@ -10707,10 +10763,12 @@ describe("CHAT-02: model-first provider policies", () => {
     await api.requestCancelRun(actor, explicitResume.runId, [200]);
     await waitForRunStatus(actor, explicitResume.runId, "cancelled");
 
-    const cancelledHandoff = await sendChatRun(actor, {
-      agentId,
-      threadId: run.threadId,
-      prompt: "reject H2 after an explicit Pi handoff is cancelled",
+    const cancelledHandoff = await withOpenRouterRoute(async () => {
+      return await sendChatRun(actor, {
+        agentId,
+        threadId: run.threadId,
+        prompt: "reject H2 after an explicit Pi handoff is cancelled",
+      });
     });
     const cancelledManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${cancelledHandoff.runId}/manifest.json`;
     await expect
@@ -10748,10 +10806,12 @@ describe("CHAT-02: model-first provider policies", () => {
     ).resolves.toStrictEqual(canonicalConversation);
     expect(modelCalls).toBe(3);
 
-    const racedHandoff = await sendChatRun(actor, {
-      agentId,
-      threadId: run.threadId,
-      prompt: "reject standalone H2 during an early successful completion",
+    const racedHandoff = await withOpenRouterRoute(async () => {
+      return await sendChatRun(actor, {
+        agentId,
+        threadId: run.threadId,
+        prompt: "reject standalone H2 during an early successful completion",
+      });
     });
     const racedManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${racedHandoff.runId}/manifest.json`;
     await expect
@@ -10807,10 +10867,12 @@ describe("CHAT-02: model-first provider policies", () => {
     ).resolves.toStrictEqual(canonicalConversation);
     expect(modelCalls).toBe(4);
 
-    const retry = await sendChatRun(actor, {
-      agentId,
-      threadId: run.threadId,
-      prompt: "resume only the last completed Pi checkpoint",
+    const retry = await withOpenRouterRoute(async () => {
+      return await sendChatRun(actor, {
+        agentId,
+        threadId: run.threadId,
+        prompt: "resume only the last completed Pi checkpoint",
+      });
     });
     const retryManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${retry.runId}/manifest.json`;
     await expect
@@ -10862,10 +10924,12 @@ describe("CHAT-02: model-first provider policies", () => {
     ).resolves.toStrictEqual(canonicalConversation);
     expect(modelCalls).toBe(5);
 
-    const reportedFailureHandoff = await sendChatRun(actor, {
-      agentId,
-      threadId: run.threadId,
-      prompt: "retry one atomically reported Pi failure",
+    const reportedFailureHandoff = await withOpenRouterRoute(async () => {
+      return await sendChatRun(actor, {
+        agentId,
+        threadId: run.threadId,
+        prompt: "retry one atomically reported Pi failure",
+      });
     });
     const reportedFailureManifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${reportedFailureHandoff.runId}/manifest.json`;
     await expect

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -117,6 +117,12 @@ describe("POST /api/test/runtime-state/action", () => {
           return route;
         },
       );
+    onTestFinished(async () => {
+      if (!releaseScopedRoute.settled()) {
+        releaseScopedRoute.resolve(undefined);
+      }
+      await scopedResolution;
+    });
 
     await scopedRouteResolved.promise;
     const unscopedRoute = await resolveVm0BuiltInModelRouteFixture(

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -6,12 +6,16 @@ import { describe, expect, it, onTestFinished } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
 import { mockNow, withMockNowForTest } from "../../../lib/time";
+import { createDeferredPromise } from "../../utils";
 import { createBddApi, expectApiError } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createRunReadsApi } from "./helpers/api-bdd-run-reads";
 import { setRunModelProviderFixture } from "../../../test-fixtures/agent-runs";
-import { holdBuiltInModelRouteLockFixture } from "../../../test-fixtures/built-in-model-runtime-route";
+import {
+  holdBuiltInModelRouteLockFixture,
+  withBuiltInModelRuntimeRouteCandidateUnavailableForTest,
+} from "../../../test-fixtures/built-in-model-runtime-route";
 import {
   deleteVm0BuiltInCandidateCooldownFixture,
   resolveVm0BuiltInModelRouteFixture,
@@ -81,6 +85,54 @@ describe("POST /api/test/runtime-state/action", () => {
 
     await expect(first.release()).resolves.toBeUndefined();
     await expect(second.release()).resolves.toBeUndefined();
+  });
+
+  it("scopes unavailable built-in model candidates to one async flow", async () => {
+    const selectedModel = "deepseek-v4-flash";
+    await seedVm0BuiltInModelCandidateKeys(context, selectedModel);
+    const primary = await resolveVm0BuiltInModelRouteFixture(
+      context,
+      selectedModel,
+    );
+    if (!primary || primary.provider_type === "openrouter-codex") {
+      throw new Error("Expected a primary DeepSeek route");
+    }
+
+    const scopedRouteResolved = createDeferredPromise<void>(context.signal);
+    const releaseScopedRoute = createDeferredPromise<void>(context.signal);
+    const scopedResolution =
+      withBuiltInModelRuntimeRouteCandidateUnavailableForTest(
+        {
+          selectedModel,
+          providerType: primary.provider_type,
+          upstreamModel: primary.upstream_model,
+        },
+        async () => {
+          const route = await resolveVm0BuiltInModelRouteFixture(
+            context,
+            selectedModel,
+          );
+          scopedRouteResolved.resolve(undefined);
+          await releaseScopedRoute.promise;
+          return route;
+        },
+      );
+
+    await scopedRouteResolved.promise;
+    const unscopedRoute = await resolveVm0BuiltInModelRouteFixture(
+      context,
+      selectedModel,
+    );
+    releaseScopedRoute.resolve(undefined);
+    const scopedRoute = await scopedResolution;
+
+    expect(unscopedRoute).toMatchObject({
+      provider_type: primary.provider_type,
+      upstream_model: primary.upstream_model,
+    });
+    expect(scopedRoute).toMatchObject({
+      provider_type: "openrouter-codex",
+    });
   });
 
   it.each(["deepseek-v4-flash", "deepseek-v4-pro"] as const)(

--- a/turbo/apps/api/src/signals/services/built-in-model-runtime-route.service.ts
+++ b/turbo/apps/api/src/signals/services/built-in-model-runtime-route.service.ts
@@ -27,8 +27,19 @@ export interface ModelRuntimeSessionRoute {
   readonly modelRuntimeModel: string | null;
 }
 
-const unavailableRuntimeRouteModelsForTest = singleton(() => {
-  return new AsyncLocalStorage<ReadonlySet<string>>();
+interface BuiltInModelRuntimeRouteIdentity {
+  readonly selectedModel: string;
+  readonly providerType: string;
+  readonly upstreamModel: string;
+}
+
+interface UnavailableRuntimeRoutesForTest {
+  readonly selectedModels: ReadonlySet<string>;
+  readonly candidates: readonly BuiltInModelRuntimeRouteIdentity[];
+}
+
+const unavailableRuntimeRoutesForTest = singleton(() => {
+  return new AsyncLocalStorage<UnavailableRuntimeRoutesForTest>();
 });
 
 /**
@@ -41,19 +52,48 @@ export async function withBuiltInModelRuntimeRouteUnavailableForTest<T>(
   selectedModel: string,
   work: () => Promise<T>,
 ): Promise<T> {
-  const inherited = unavailableRuntimeRouteModelsForTest.peek()?.getStore();
-  return await unavailableRuntimeRouteModelsForTest().run(
-    new Set([...(inherited ?? []), selectedModel]),
+  const inherited = unavailableRuntimeRoutesForTest.peek()?.getStore();
+  return await unavailableRuntimeRoutesForTest().run(
+    {
+      selectedModels: new Set([
+        ...(inherited?.selectedModels ?? []),
+        selectedModel,
+      ]),
+      candidates: inherited?.candidates ?? [],
+    },
     work,
   );
 }
 
-function runtimeRouteUnavailableForTest(selectedModel: string): boolean {
+export async function withBuiltInModelRuntimeRouteCandidateUnavailableForTest<
+  T,
+>(
+  candidate: BuiltInModelRuntimeRouteIdentity,
+  work: () => Promise<T>,
+): Promise<T> {
+  const inherited = unavailableRuntimeRoutesForTest.peek()?.getStore();
+  return await unavailableRuntimeRoutesForTest().run(
+    {
+      selectedModels: inherited?.selectedModels ?? new Set(),
+      candidates: [...(inherited?.candidates ?? []), candidate],
+    },
+    work,
+  );
+}
+
+function runtimeRouteUnavailableForTest(
+  target: BuiltInModelRouteTarget,
+): boolean {
+  const unavailable = unavailableRuntimeRoutesForTest.peek()?.getStore();
   return (
-    unavailableRuntimeRouteModelsForTest
-      .peek()
-      ?.getStore()
-      ?.has(selectedModel) === true
+    unavailable?.selectedModels.has(target.selectedModel) === true ||
+    unavailable?.candidates.some((candidate) => {
+      return (
+        candidate.selectedModel === target.selectedModel &&
+        candidate.providerType === target.providerType &&
+        candidate.upstreamModel === target.upstreamModel
+      );
+    }) === true
   );
 }
 
@@ -83,12 +123,11 @@ export async function resolveBuiltInModelRuntimeRoute(
   db: Db,
   selectedModel: string,
 ): Promise<BuiltInModelRuntimeRoute | null> {
-  if (runtimeRouteUnavailableForTest(selectedModel)) {
-    return null;
-  }
-
   const timestamp = nowDate();
   for (const target of getVm0BuiltInModelRouteCandidates(selectedModel)) {
+    if (runtimeRouteUnavailableForTest(target)) {
+      continue;
+    }
     const [key] = await db
       .select({ id: builtInModelKeys.id })
       .from(builtInModelKeys)

--- a/turbo/apps/api/src/test-fixtures/built-in-model-runtime-route.ts
+++ b/turbo/apps/api/src/test-fixtures/built-in-model-runtime-route.ts
@@ -5,7 +5,10 @@ import { z } from "zod";
 import { db } from "../lib/db";
 import { executeRawRows } from "../lib/db-raw-rows";
 import { createDeferredPromise } from "../signals/utils";
-import { withBuiltInModelRuntimeRouteUnavailableForTest as withRuntimeRouteUnavailable } from "../signals/services/built-in-model-runtime-route.service";
+import {
+  withBuiltInModelRuntimeRouteCandidateUnavailableForTest as withRuntimeRouteCandidateUnavailable,
+  withBuiltInModelRuntimeRouteUnavailableForTest as withRuntimeRouteUnavailable,
+} from "../signals/services/built-in-model-runtime-route.service";
 
 const databasePidRowSchema = z.object({ pid: z.int() });
 const waiterCountRowSchema = z.object({ waiterCount: z.int() });
@@ -32,6 +35,17 @@ export function withBuiltInModelRuntimeRouteUnavailableForTest<T>(
   work: () => Promise<T>,
 ): Promise<T> {
   return withRuntimeRouteUnavailable(selectedModel, work);
+}
+
+/**
+ * A candidate cooldown is global infrastructure state. Scope the unavailable
+ * candidate to one async test flow while preserving normal route selection.
+ */
+export function withBuiltInModelRuntimeRouteCandidateUnavailableForTest<T>(
+  candidate: BuiltInModelRuntimeRouteFixtureIdentity,
+  work: () => Promise<T>,
+): Promise<T> {
+  return withRuntimeRouteCandidateUnavailable(candidate, work);
 }
 
 function routeCondition(route: BuiltInModelRuntimeRouteFixtureIdentity) {


### PR DESCRIPTION
## Summary

- add an async-local test override for one exact built-in model route candidate
- replace the chat fallback fixture's shared database cooldown with the scoped override
- cover concurrent scoped and unscoped route resolution so parallel tests keep their primary route

## Scope

- production cooldown persistence and route ranking are unchanged
- the new override is test-only and matches the selected model, provider type, and upstream model

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/built-in-model-runtime-route.service.ts apps/api/src/test-fixtures/built-in-model-runtime-route.ts apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts src/signals/routes/__tests__/test-runtime-state.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=3 --silent=passed-only` (400 passed)
- rebase-head regression: `pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'scopes unavailable built-in model candidates|keeps VM0 DeepSeek admission after a Slack fixture releases its shared key' --maxWorkers=1 --silent=passed-only`
- pre-commit hook: repository Knip and TypeScript checks passed

## Full-suite note

Two local API full-suite attempts passed every changed and target test. Unrelated existing tests failed under load: chat search projection timing, a Teams callback timeout, and a repeated-run fixed fixture ID left in the local database. Each timing failure passed alone; the fixed fixture test passed after removing its prior local test row.

Closes #31630
