### PR TITLE
feat(platform): report indexeddb setup telemetry

### DIFF
--- a/turbo/apps/platform/src/lib/client-telemetry.ts
+++ b/turbo/apps/platform/src/lib/client-telemetry.ts
@@ -25,9 +25,23 @@ interface ClientTelemetryMeasurement {
   readonly startedAtMonotonic: number;
 }
 
+type IndexedDbDatabase = "chat" | "intro_video_drafts";
+
+interface IndexedDbOpenTelemetry {
+  readonly event_name: "indexeddb.open";
+  readonly database: IndexedDbDatabase;
+}
+
+interface IndexedDbTransactionCreateTelemetry {
+  readonly event_name: "indexeddb.transaction.create";
+  readonly database: IndexedDbDatabase;
+  readonly template: string;
+  readonly transaction_mode: IDBTransactionMode;
+}
+
 interface IndexedDbTransactionTelemetry {
   readonly event_name: "indexeddb.transaction";
-  readonly database: "chat" | "intro_video_drafts";
+  readonly database: IndexedDbDatabase;
   readonly template: string;
   readonly transaction_mode: IDBTransactionMode;
   readonly request_count: number;
@@ -46,6 +60,8 @@ interface HttpRequestTelemetry {
 }
 
 export type ClientTelemetryOperation =
+  | IndexedDbOpenTelemetry
+  | IndexedDbTransactionCreateTelemetry
   | IndexedDbTransactionTelemetry
   | SharedDatabaseQueryTelemetry
   | HttpRequestTelemetry;
@@ -55,7 +71,11 @@ function runtimeName(): "shared_worker" | "window" {
 }
 
 function scopeName(operation: ClientTelemetryOperation): string {
-  if (operation.event_name === "indexeddb.transaction") {
+  if (
+    operation.event_name === "indexeddb.open" ||
+    operation.event_name === "indexeddb.transaction.create" ||
+    operation.event_name === "indexeddb.transaction"
+  ) {
     return "okou-app/indexeddb";
   }
   return operation.event_name === "shared_database.query"
@@ -80,14 +100,34 @@ function statusCode(
 }
 
 function operationName(operation: ClientTelemetryOperation): string {
-  return operation.event_name === "http.request"
-    ? `${operation.method} ${operation.route}`
-    : operation.template;
+  if (operation.event_name === "http.request") {
+    return `${operation.method} ${operation.route}`;
+  }
+  if (operation.event_name === "indexeddb.open") {
+    return `${operation.database}.open`;
+  }
+  if (operation.event_name === "indexeddb.transaction.create") {
+    return `${operation.template}.transaction.create`;
+  }
+  return operation.template;
 }
 
 function operationAttributes(
   operation: ClientTelemetryOperation,
 ): ClientTelemetryAttributes {
+  if (operation.event_name === "indexeddb.open") {
+    return {
+      "db.namespace": operation.database,
+      "db.system": "indexeddb",
+    };
+  }
+  if (operation.event_name === "indexeddb.transaction.create") {
+    return {
+      "db.namespace": operation.database,
+      "db.system": "indexeddb",
+      "okou.db.transaction.mode": operation.transaction_mode,
+    };
+  }
   if (operation.event_name !== "indexeddb.transaction") {
     return {};
   }
@@ -210,7 +250,7 @@ export async function observeClientOperation<TResult>(
   execute: () => Promise<TResult>,
 ): Promise<TResult> {
   const measurement = startClientTelemetryMeasurement();
-  const result = await onRejection(execute(), (error) => {
+  const result = await onRejection(execute, (error) => {
     recordClientTelemetry(measurement, operation, outcomeForError(error));
   });
   recordClientTelemetry(measurement, operation, "success");

--- a/turbo/apps/platform/src/signals/external/__tests__/indexeddb-client.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/indexeddb-client.test.ts
@@ -11,6 +11,7 @@ import {
   testContext,
 } from "../../__tests__/test-helpers.ts";
 import { createAuthedContractClient } from "../../api-client-base.ts";
+import { createChatIdbOpener } from "../chat-idb-opener.ts";
 import {
   deleteIntroVideoDraft,
   readIntroVideoDraft,
@@ -47,6 +48,8 @@ interface TelemetryTestDatabase extends DBSchema {
   };
 }
 
+// Client telemetry has no page-visible surface, so these integration tests use
+// real IndexedDB behavior and observe the external Axiom payload boundary.
 const context = testContext();
 
 beforeEach(() => {
@@ -69,17 +72,91 @@ async function openTelemetryTestDatabase() {
   });
 }
 
-async function capturedEvent(): Promise<Record<string, unknown>> {
+async function capturedEvents(
+  expectedCount: number,
+): Promise<readonly Record<string, unknown>[]> {
   await vi.waitFor(() => {
-    expect(axiomTelemetry.ingest).toHaveBeenCalledOnce();
+    expect(axiomTelemetry.ingest).toHaveBeenCalledTimes(expectedCount);
   });
-  const [dataset, events] = axiomTelemetry.ingest.mock.calls[0]!;
-  expect(dataset).toBe("vm0-client-telemetry-prod");
-  expect(events).toHaveLength(1);
+  return axiomTelemetry.ingest.mock.calls.map(([dataset, events]) => {
+    expect(dataset).toBe("vm0-client-telemetry-prod");
+    expect(events).toHaveLength(1);
+    return events[0]!;
+  });
+}
+
+async function capturedEvent(): Promise<Record<string, unknown>> {
+  const events = await capturedEvents(1);
   return events[0]!;
 }
 
-test("Reports one parameter-free event for a physical IndexedDB transaction", async () => {
+test("Reports a physical chat database open without credential identifiers", async () => {
+  const sensitiveUserId = `private-user-${crypto.randomUUID()}`;
+  const sensitiveOrgId = `private-org-${crypto.randomUUID()}`;
+  const database = await createChatIdbOpener({
+    reload: vi.fn<() => void>(),
+  }).openChatIdb(sensitiveUserId, sensitiveOrgId);
+  database.close();
+
+  const event = await capturedEvent();
+  expect(event).toMatchObject({
+    "attributes.custom": {
+      "db.namespace": "chat",
+      "db.system": "indexeddb",
+      "okou.client.outcome": "success",
+      "okou.client.runtime": "window",
+    },
+    kind: "client",
+    name: "chat.open",
+    "resource.deployment.environment.name": "production",
+    "scope.name": "okou-app/indexeddb",
+    "service.name": "Okou-app",
+    "service.version": "0.540.0",
+    "status.code": "OK",
+  });
+  expect(event.duration).toStrictEqual(expect.any(Number));
+  expect(event).not.toHaveProperty("attributes.custom.okou.db.request.count");
+  expect(event).not.toHaveProperty(
+    "attributes.custom.okou.db.transaction.mode",
+  );
+  expect(JSON.stringify(event)).not.toContain(sensitiveUserId);
+  expect(JSON.stringify(event)).not.toContain(sensitiveOrgId);
+});
+
+test("Reports a failed chat database open without hiding its error", async () => {
+  const openError = new DOMException(
+    "private open failure",
+    "InvalidStateError",
+  );
+  const opener = createChatIdbOpener({
+    openDatabase: () => {
+      return Promise.reject(openError);
+    },
+    reload: vi.fn<() => void>(),
+  });
+
+  await expect(opener.openChatIdb("private-user", "private-org")).rejects.toBe(
+    openError,
+  );
+
+  const event = await capturedEvent();
+  expect(event).toMatchObject({
+    "attributes.custom": {
+      "db.namespace": "chat",
+      "db.system": "indexeddb",
+      "okou.client.outcome": "error",
+    },
+    name: "chat.open",
+    "scope.name": "okou-app/indexeddb",
+    "status.code": "ERROR",
+  });
+  expect(event.duration).toStrictEqual(expect.any(Number));
+  expect(JSON.stringify(event)).not.toContain(openError.message);
+  expect(JSON.stringify(event)).not.toContain("private-user");
+  expect(JSON.stringify(event)).not.toContain("private-org");
+});
+
+test("Reports separate creation and execution events for an IndexedDB transaction", async () => {
   const database = await openTelemetryTestDatabase();
   const sensitiveKey = `private-key-${crypto.randomUUID()}`;
   const sensitiveValue = `private-value-${crypto.randomUUID()}`;
@@ -91,6 +168,7 @@ test("Reports one parameter-free event for a physical IndexedDB transaction", as
         {
           database: "chat",
           template: "records.put+get",
+          transaction_mode: "readwrite",
         },
         () => {
           return database.transaction("records", "readwrite");
@@ -107,7 +185,29 @@ test("Reports one parameter-free event for a physical IndexedDB transaction", as
     database.close();
   }
 
-  const event = await capturedEvent();
+  const events = await capturedEvents(2);
+  const creationEvent = events[0]!;
+  const event = events[1]!;
+  expect(creationEvent).toMatchObject({
+    "attributes.custom": {
+      "db.namespace": "chat",
+      "db.system": "indexeddb",
+      "okou.client.outcome": "success",
+      "okou.client.runtime": "shared_worker",
+      "okou.db.transaction.mode": "readwrite",
+    },
+    kind: "client",
+    name: "records.put+get.transaction.create",
+    "resource.deployment.environment.name": "production",
+    "scope.name": "okou-app/indexeddb",
+    "service.name": "Okou-app",
+    "service.version": "0.540.0",
+    "status.code": "OK",
+  });
+  expect(creationEvent.duration).toStrictEqual(expect.any(Number));
+  expect(creationEvent).not.toHaveProperty(
+    "attributes.custom.okou.db.request.count",
+  );
   expect(event).toMatchObject({
     "attributes.custom": {
       "db.namespace": "chat",
@@ -143,6 +243,7 @@ test("Reports an aborted IndexedDB transaction without hiding its error", async 
         {
           database: "intro_video_drafts",
           template: "records.put",
+          transaction_mode: "readwrite",
         },
         () => {
           return database.transaction("records", "readwrite");
@@ -160,7 +261,18 @@ test("Reports an aborted IndexedDB transaction without hiding its error", async 
     database.close();
   }
 
-  const event = await capturedEvent();
+  const events = await capturedEvents(2);
+  const creationEvent = events[0]!;
+  const event = events[1]!;
+  expect(creationEvent).toMatchObject({
+    "attributes.custom": {
+      "db.namespace": "intro_video_drafts",
+      "okou.client.outcome": "success",
+      "okou.db.transaction.mode": "readwrite",
+    },
+    name: "records.put.transaction.create",
+    "status.code": "OK",
+  });
   expect(event).toMatchObject({
     "attributes.custom": {
       "db.namespace": "intro_video_drafts",
@@ -173,7 +285,48 @@ test("Reports an aborted IndexedDB transaction without hiding its error", async 
   expect(event).not.toHaveProperty("status.code");
 });
 
-test("Routes every intro video draft operation through one transaction event", async () => {
+test("Reports a synchronous IndexedDB transaction creation failure", async () => {
+  const creationError = new DOMException(
+    "private creation failure",
+    "InvalidStateError",
+  );
+
+  await expect(
+    runIndexedDbTransaction(
+      {
+        database: "chat",
+        template: "records.get",
+        transaction_mode: "readonly",
+      },
+      () => {
+        throw creationError;
+      },
+      () => {
+        return Promise.reject(
+          new Error("Transaction execution must not start"),
+        );
+      },
+    ),
+  ).rejects.toBe(creationError);
+
+  const event = await capturedEvent();
+  expect(event).toMatchObject({
+    "attributes.custom": {
+      "db.namespace": "chat",
+      "db.system": "indexeddb",
+      "okou.client.outcome": "error",
+      "okou.db.transaction.mode": "readonly",
+    },
+    name: "records.get.transaction.create",
+    "scope.name": "okou-app/indexeddb",
+    "status.code": "ERROR",
+  });
+  expect(event.duration).toStrictEqual(expect.any(Number));
+  expect(event).not.toHaveProperty("attributes.custom.okou.db.request.count");
+  expect(JSON.stringify(event)).not.toContain(creationError.message);
+});
+
+test("Reports all intro video draft IndexedDB lifecycle events", async () => {
   const draft = {
     blob: new Blob(["private draft"]),
     contentType: "video/mp4",
@@ -196,43 +349,64 @@ test("Routes every intro video draft operation through one transaction event", a
   await deleteIntroVideoDraft();
   await expect(readIntroVideoDraft()).resolves.toBeNull();
 
-  await vi.waitFor(() => {
-    expect(axiomTelemetry.ingest).toHaveBeenCalledTimes(4);
-  });
+  const events = await capturedEvents(12);
+  const operations = [
+    { mode: "readwrite", template: "intro_video_drafts.put" },
+    { mode: "readonly", template: "intro_video_drafts.get" },
+    { mode: "readwrite", template: "intro_video_drafts.delete" },
+    { mode: "readonly", template: "intro_video_drafts.get" },
+  ] as const;
   expect(
-    axiomTelemetry.ingest.mock.calls.map(([, events]) => {
-      return events[0];
+    events.map((event) => {
+      return event.name;
     }),
-  ).toMatchObject([
-    {
+  ).toStrictEqual(
+    operations.flatMap(({ template }) => {
+      return [
+        "intro_video_drafts.open",
+        `${template}.transaction.create`,
+        template,
+      ];
+    }),
+  );
+  for (const [index, operation] of operations.entries()) {
+    const openEvent = events[index * 3]!;
+    const creationEvent = events[index * 3 + 1]!;
+    const transactionEvent = events[index * 3 + 2]!;
+    expect(openEvent).toMatchObject({
       "attributes.custom": {
         "db.namespace": "intro_video_drafts",
-        "okou.db.request.count": 1,
+        "okou.client.outcome": "success",
       },
-      name: "intro_video_drafts.put",
-    },
-    {
+      "status.code": "OK",
+    });
+    expect(openEvent).not.toHaveProperty(
+      "attributes.custom.okou.db.request.count",
+    );
+    expect(openEvent).not.toHaveProperty(
+      "attributes.custom.okou.db.transaction.mode",
+    );
+    expect(creationEvent).toMatchObject({
       "attributes.custom": {
         "db.namespace": "intro_video_drafts",
-        "okou.db.request.count": 1,
+        "okou.client.outcome": "success",
+        "okou.db.transaction.mode": operation.mode,
       },
-      name: "intro_video_drafts.get",
-    },
-    {
+      "status.code": "OK",
+    });
+    expect(creationEvent).not.toHaveProperty(
+      "attributes.custom.okou.db.request.count",
+    );
+    expect(transactionEvent).toMatchObject({
       "attributes.custom": {
         "db.namespace": "intro_video_drafts",
+        "okou.client.outcome": "success",
         "okou.db.request.count": 1,
+        "okou.db.transaction.mode": operation.mode,
       },
-      name: "intro_video_drafts.delete",
-    },
-    {
-      "attributes.custom": {
-        "db.namespace": "intro_video_drafts",
-        "okou.db.request.count": 1,
-      },
-      name: "intro_video_drafts.get",
-    },
-  ]);
+      "status.code": "OK",
+    });
+  }
 });
 
 test("Reports typed API requests with route templates and no parameters", async () => {

--- a/turbo/apps/platform/src/signals/external/chat-idb-opener.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-opener.ts
@@ -4,6 +4,7 @@ import {
   type IDBPDatabase,
   type OpenDBCallbacks,
 } from "idb";
+import { observeClientOperation } from "../../lib/client-telemetry.ts";
 import { logger } from "../log.ts";
 import { CHAT_IDB_VERSION, upgradeChatIdb } from "./chat-idb-schema.ts";
 
@@ -52,15 +53,24 @@ export function createChatIdbOpener(
     async openChatIdb(userId, orgId) {
       const dbName = chatIdbName(userId, orgId);
       L.debug("openDB", { dbName });
-      const db = await openDatabase(dbName, CHAT_IDB_VERSION, {
-        upgrade(db, oldVersion) {
-          L.debug("openDB:upgrade", { dbName });
-          upgradeChatIdb(db, oldVersion);
+      const db = await observeClientOperation(
+        { event_name: "indexeddb.open", database: "chat" },
+        () => {
+          return openDatabase(dbName, CHAT_IDB_VERSION, {
+            upgrade(db, oldVersion) {
+              L.debug("openDB:upgrade", { dbName });
+              upgradeChatIdb(db, oldVersion);
+            },
+            blocked(currentVersion, blockedVersion) {
+              L.warn("openDB:blocked", {
+                dbName,
+                currentVersion,
+                blockedVersion,
+              });
+            },
+          });
         },
-        blocked(currentVersion, blockedVersion) {
-          L.warn("openDB:blocked", { dbName, currentVersion, blockedVersion });
-        },
-      });
+      );
       db.addEventListener(
         "versionchange",
         (event) => {

--- a/turbo/apps/platform/src/signals/external/idb-chat-thread-event-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-chat-thread-event-store.ts
@@ -104,6 +104,7 @@ async function readEventBoundary(
     {
       database: "chat",
       template: TRANSACTION_TEMPLATES.readEventBoundary,
+      transaction_mode: "readonly",
     },
     () => {
       return db.transaction(CHAT_THREAD_EVENTS_STORE, "readonly");
@@ -138,6 +139,7 @@ async function readEventPage(
     {
       database: "chat",
       template: TRANSACTION_TEMPLATES.readEventPage,
+      transaction_mode: "readonly",
     },
     () => {
       return db.transaction(CHAT_THREAD_EVENTS_STORE, "readonly");
@@ -165,6 +167,7 @@ function createStrictReadStore(getDb: GetDb) {
         {
           database: "chat",
           template: TRANSACTION_TEMPLATES.readSnapshot,
+          transaction_mode: "readonly",
         },
         () => {
           return db.transaction(CHAT_THREAD_SNAPSHOT_STORE, "readonly");
@@ -224,6 +227,7 @@ function createStrictWriteStore(getDb: GetDb) {
         {
           database: "chat",
           template: TRANSACTION_TEMPLATES.replaceFromSnapshot,
+          transaction_mode: "readwrite",
         },
         () => {
           return db.transaction(
@@ -266,6 +270,7 @@ function createStrictWriteStore(getDb: GetDb) {
         {
           database: "chat",
           template: TRANSACTION_TEMPLATES.upsertEvents,
+          transaction_mode: "readwrite",
         },
         () => {
           return db.transaction(CHAT_THREAD_EVENTS_STORE, "readwrite");
@@ -288,6 +293,7 @@ function createStrictWriteStore(getDb: GetDb) {
         {
           database: "chat",
           template: TRANSACTION_TEMPLATES.clear,
+          transaction_mode: "readwrite",
         },
         () => {
           return db.transaction(

--- a/turbo/apps/platform/src/signals/external/idb-event-row-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-event-row-store.ts
@@ -131,6 +131,7 @@ function createRowReadStore(
         {
           database: "chat",
           template: TRANSACTION_TEMPLATES.readCursors,
+          transaction_mode: "readonly",
         },
         () => {
           return db.transaction(cursorStoreName, "readonly");
@@ -163,6 +164,7 @@ function createRowReadStore(
         {
           database: "chat",
           template: TRANSACTION_TEMPLATES.readCursor,
+          transaction_mode: "readonly",
         },
         () => {
           return db.transaction(cursorStoreName, "readonly");
@@ -182,6 +184,7 @@ function createRowReadStore(
         {
           database: "chat",
           template: TRANSACTION_TEMPLATES.readRowsAfter,
+          transaction_mode: "readonly",
         },
         () => {
           return db.transaction([storeName, cursorStoreName], "readonly");
@@ -229,6 +232,7 @@ function createUpsertRowsAndCursors(
       {
         database: "chat",
         template: TRANSACTION_TEMPLATES.upsertRowsAndCursors,
+        transaction_mode: "readwrite",
       },
       () => {
         return db.transaction([storeName, cursorStoreName], "readwrite");
@@ -283,6 +287,7 @@ function createRowWriteStore(
         {
           database: "chat",
           template: TRANSACTION_TEMPLATES.upsertRowsAndCursor,
+          transaction_mode: "readwrite",
         },
         () => {
           return db.transaction([storeName, cursorStoreName], "readwrite");
@@ -316,6 +321,7 @@ function createRowWriteStore(
         {
           database: "chat",
           template: TRANSACTION_TEMPLATES.replaceRowsAndCursor,
+          transaction_mode: "readwrite",
         },
         () => {
           return db.transaction([storeName, cursorStoreName], "readwrite");
@@ -363,6 +369,7 @@ function createRowWriteStore(
         {
           database: "chat",
           template: TRANSACTION_TEMPLATES.clearThread,
+          transaction_mode: "readwrite",
         },
         () => {
           return db.transaction([storeName, cursorStoreName], "readwrite");

--- a/turbo/apps/platform/src/signals/external/indexeddb-client.ts
+++ b/turbo/apps/platform/src/signals/external/indexeddb-client.ts
@@ -2,6 +2,7 @@ import {
   clientTelemetryOutcomeForError,
   recordClientTelemetry,
   startClientTelemetryMeasurement,
+  type ClientTelemetryOperation,
 } from "../../lib/client-telemetry.ts";
 import { onRejection } from "../utils.ts";
 
@@ -14,6 +15,7 @@ interface IndexedDbTransactionDetails {
   readonly database: "chat" | "intro_video_drafts";
   /** Stable operation shape only. Never include keys, ranges, or values. */
   readonly template: string;
+  readonly transaction_mode: IDBTransactionMode;
 }
 
 export type TrackIndexedDbRequest = <TResult>(
@@ -37,8 +39,22 @@ export async function runIndexedDbTransaction<
     trackRequest: TrackIndexedDbRequest,
   ) => Promise<TResult>,
 ): Promise<TResult> {
+  const creationMeasurement = startClientTelemetryMeasurement();
+  const creationOperation = {
+    event_name: "indexeddb.transaction.create",
+    database: details.database,
+    template: details.template,
+    transaction_mode: details.transaction_mode,
+  } satisfies ClientTelemetryOperation;
+  const transaction = await onRejection(createTransaction, (error) => {
+    recordClientTelemetry(
+      creationMeasurement,
+      creationOperation,
+      clientTelemetryOutcomeForError(error),
+    );
+  });
   const measurement = startClientTelemetryMeasurement();
-  const transaction = createTransaction();
+  recordClientTelemetry(creationMeasurement, creationOperation, "success");
   let requestCount = 0;
   const trackRequest: TrackIndexedDbRequest = (request) => {
     requestCount += 1;

--- a/turbo/apps/platform/src/signals/external/intro-video-draft-store.ts
+++ b/turbo/apps/platform/src/signals/external/intro-video-draft-store.ts
@@ -1,5 +1,6 @@
 import { openDB, type DBSchema } from "idb";
 
+import { observeClientOperation } from "../../lib/client-telemetry.ts";
 import { withCleanup } from "../utils.ts";
 import { runIndexedDbTransaction } from "./indexeddb-client.ts";
 
@@ -56,13 +57,14 @@ const TRANSACTION_TEMPLATES = {
 } as const;
 
 async function openIntroVideoDraftDatabase() {
-  return await openDB<IntroVideoDraftDatabase>(
-    DATABASE_NAME,
-    DATABASE_VERSION,
-    {
-      upgrade(database) {
-        database.createObjectStore("drafts");
-      },
+  return await observeClientOperation(
+    { event_name: "indexeddb.open", database: "intro_video_drafts" },
+    () => {
+      return openDB<IntroVideoDraftDatabase>(DATABASE_NAME, DATABASE_VERSION, {
+        upgrade(database) {
+          database.createObjectStore("drafts");
+        },
+      });
     },
   );
 }
@@ -74,6 +76,7 @@ export async function readIntroVideoDraft(): Promise<IntroVideoDraftRecord | nul
       {
         database: "intro_video_drafts",
         template: TRANSACTION_TEMPLATES.read,
+        transaction_mode: "readonly",
       },
       () => {
         return database.transaction("drafts", "readonly");
@@ -101,6 +104,7 @@ export async function saveIntroVideoDraft(
       {
         database: "intro_video_drafts",
         template: TRANSACTION_TEMPLATES.save,
+        transaction_mode: "readwrite",
       },
       () => {
         return database.transaction("drafts", "readwrite");
@@ -122,6 +126,7 @@ export async function deleteIntroVideoDraft(): Promise<void> {
       {
         database: "intro_video_drafts",
         template: TRANSACTION_TEMPLATES.delete,
+        transaction_mode: "readwrite",
       },
       () => {
         return database.transaction("drafts", "readwrite");

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -228,20 +228,21 @@ export async function tapError<T>(
 }
 
 /**
- * Await `p` and invoke `fn` on any rejection (including abort), then re-throw.
- * Use as a `.catch(handler)` replacement when the caller needs to run a
- * cleanup side effect before the rejection propagates. `fn` runs on abort by
- * design so cleanup still happens when the page is cancelled, which is why
- * `ccstate/no-catch-abort` cannot apply to this file.
+ * Await a promise or invoke a factory and call `fn` on any rejection (including
+ * synchronous throws and abort), then re-throw. Use as a `.catch(handler)`
+ * replacement when the caller needs to run a side effect before the rejection
+ * propagates. `fn` runs on abort by design so cleanup still happens when the
+ * page is cancelled, which is why `ccstate/no-catch-abort` cannot apply to this
+ * file.
  */
 export async function onRejection<T>(
-  p: Promise<T>,
+  operation: Promise<T> | (() => Promise<T> | T),
   fn: (error: unknown) => unknown,
 ): Promise<T> {
   // confirmed by ethan@vm0.ai
   // eslint-disable-next-line no-restricted-syntax
   try {
-    return await p;
+    return await (typeof operation === "function" ? operation() : operation);
   } catch (error) {
     await fn(error);
     throw error;


### PR DESCRIPTION
## Summary

- report terminal client telemetry for physical IndexedDB open attempts
- report synchronous transaction creation separately from transaction execution
- start transaction duration after successful creation while keeping request counts on execution events only

## Telemetry contract

- Open names: `chat.open`, `intro_video_drafts.open`
- Creation names: `<transaction-template>.transaction.create`
- Existing transaction names remain unchanged
- All events reuse the existing duration, outcome, status, database, runtime, and transaction-mode fields; no new fields or user/database identifiers are emitted

## Verification

- `pnpm exec prettier --check <changed platform files>`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/signals/external/__tests__/indexeddb-client.test.ts --silent=passed-only`
- `pnpm knip --workspace @okouai/app`
