### PR TITLE
perf(python): bound request header field count

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -125,6 +125,8 @@ _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 # Release: auth marker is popped by terminal cleanup.
 # _REQUEST_HEADERS_TERMINATED is a flow-local sentinel for request() early exit.
 _HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE = 431
+# Match the existing 64 KiB HTTP/2/SigV4 minimum per-field accounting budget.
+_MAX_REQUEST_HEADER_FIELDS = 2048
 _MAX_REQUEST_HEADER_NAME_BYTES = 4096
 _REQUEST_HEADERS_TERMINATED = "_request_headers_terminated"
 _FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS = "_firewall_auth_applied_in_requestheaders"
@@ -748,6 +750,11 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     """Handle request-header-only decisions before mitmproxy buffers bodies."""
     request_end_stream = mitmproxy_compat.take_request_end_stream(flow)
     request_header_fields = flow.request.headers.fields
+    if len(request_header_fields) > _MAX_REQUEST_HEADER_FIELDS:
+        flow.request.headers.fields = ()
+        flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+        flow.kill()
+        return None
     if any(len(name) > _MAX_REQUEST_HEADER_NAME_BYTES for name, _value in request_header_fields):
         # Mitmproxy performs an Expect lookup after this hook, so rejected names
         # must be gone before control returns while ordinary protocol fields stay.

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -751,6 +751,8 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     request_end_stream = mitmproxy_compat.take_request_end_stream(flow)
     request_header_fields = flow.request.headers.fields
     if len(request_header_fields) > _MAX_REQUEST_HEADER_FIELDS:
+        # A local response waits for body completion. Kill before mitmproxy's
+        # Expect lookup instead of retaining or rescanning the rejected tuple.
         flow.request.headers.fields = ()
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
         flow.kill()

--- a/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_aws_sigv4_body.py
@@ -536,7 +536,7 @@ async def test_sigv4_request_header_list_inspection_boundary(
     assert aws_sigv4_body_admission.state_for_tests() == (0, 0)
 
 
-async def test_sigv4_request_header_field_count_fails_closed(
+async def test_sigv4_request_hook_header_field_count_fails_closed(
     tmp_path,
     real_flow,
     headers,
@@ -562,7 +562,6 @@ async def test_sigv4_request_header_field_count_fails_closed(
         mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
         patch.object(auth, "get_firewall_headers", get_headers),
     ):
-        assert mitm_addon.requestheaders(flow) is None
         await mitm_addon.request(flow)
 
         assert flow.response is not None

--- a/crates/runner/mitm-addon/tests/test_request_header_names.py
+++ b/crates/runner/mitm-addon/tests/test_request_header_names.py
@@ -1,5 +1,6 @@
 """Request-header field-count and field-name admission integration tests."""
 
+import pytest
 from mitmproxy import connection
 from mitmproxy.addons.proxyserver import Proxyserver
 from mitmproxy.flow import Error
@@ -94,10 +95,18 @@ async def test_requestheaders_rejects_over_budget_names_before_header_processing
     assert metadata_keys.SANDBOX_RUN_ID not in flow.metadata
 
 
+@pytest.mark.parametrize(
+    "body_field",
+    [
+        (b"cOnTeNt-LeNgTh", b"0"),
+        (b"TrAnSfEr-EnCoDiNg", b"chunked"),
+    ],
+)
 async def test_requestheaders_accepts_name_budget_and_preserves_existing_header_behavior(
     registry_file,
     real_flow,
     mitm_ctx,
+    body_field,
 ):
     boundary_name = b"X" * _MAX_REQUEST_HEADER_NAME_BYTES
     repeated_fields = (
@@ -106,7 +115,7 @@ async def test_requestheaders_accepts_name_budget_and_preserves_existing_header_
     )
     fixed_fields = (
         (b"hOsT", b"example.com"),
-        (b"cOnTeNt-LeNgTh", b"0"),
+        body_field,
         (b"uSeR-aGeNt", _BROWSER_USER_AGENT),
         *repeated_fields,
         (boundary_name, b"accepted"),
@@ -128,6 +137,7 @@ async def test_requestheaders_accepts_name_budget_and_preserves_existing_header_
     assert (boundary_name, b"accepted") in flow.request.headers.fields
     assert all(field in flow.request.headers.fields for field in repeated_fields)
     assert (b"hOsT", b"example.com") in flow.request.headers.fields
+    assert body_field in flow.request.headers.fields
     assert (b"uSeR-aGeNt", _BROWSER_USER_AGENT) in flow.request.headers.fields
     assert all(
         name

--- a/crates/runner/mitm-addon/tests/test_request_header_names.py
+++ b/crates/runner/mitm-addon/tests/test_request_header_names.py
@@ -1,10 +1,23 @@
-"""Request-header field-name admission integration tests."""
+"""Request-header field-count and field-name admission integration tests."""
+
+from mitmproxy import connection
+from mitmproxy.addons.proxyserver import Proxyserver
+from mitmproxy.flow import Error
+from mitmproxy.proxy import commands, events
+from mitmproxy.proxy.layers.http._hooks import (
+    HttpErrorHook,
+    HttpRequestHeadersHook,
+    HttpRequestHook,
+)
+from mitmproxy.test import taddons
 
 import connector_intent
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+from tests.mitmproxy_http_framing_helpers import PLACEHOLDER_HOST, start_http_layer
 from tests.requestheaders_helpers import _assert_no_request_stream
 
+_MAX_REQUEST_HEADER_FIELDS = 2048
 _MAX_REQUEST_HEADER_NAME_BYTES = 4096
 _BROWSER_USER_AGENT = (
     b"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
@@ -15,6 +28,31 @@ _BROWSER_USER_AGENT = (
 class _LowerGuardHeaderName(bytes):
     def lower(self) -> bytes:
         raise AssertionError("over-budget request header name must not be lowercased")
+
+
+async def test_requestheaders_rejects_over_budget_field_count_before_header_processing(real_flow):
+    guarded_name = _LowerGuardHeaderName(b"X")
+    flow = real_flow(
+        with_response=False,
+        request_headers=mitm_addon.http.Headers(
+            [(guarded_name, b"y")] * (_MAX_REQUEST_HEADER_FIELDS + 1)
+        ),
+    )
+
+    assert mitm_addon.requestheaders(flow) is None
+
+    assert flow.error is not None
+    assert flow.error.msg == Error.KILLED_MESSAGE
+    assert flow.response is None
+    assert flow.request.headers.fields == ()
+    assert metadata_keys.SANDBOX_RUN_ID not in flow.metadata
+    _assert_no_request_stream(flow)
+
+    await mitm_addon.request(flow)
+
+    assert flow.request.headers.fields == ()
+    assert connector_intent.from_flow(flow) == connector_intent.ABSENT
+    assert metadata_keys.SANDBOX_RUN_ID not in flow.metadata
 
 
 async def test_requestheaders_rejects_over_budget_names_before_header_processing(real_flow):
@@ -66,19 +104,21 @@ async def test_requestheaders_accepts_name_budget_and_preserves_existing_header_
         (b"X-Trace", b"first"),
         (b"x-trace", b"second"),
     )
+    fixed_fields = (
+        (b"hOsT", b"example.com"),
+        (b"cOnTeNt-LeNgTh", b"0"),
+        (b"uSeR-aGeNt", _BROWSER_USER_AGENT),
+        *repeated_fields,
+        (boundary_name, b"accepted"),
+        (b"x-VM0-Connector-Intent", b"primary"),
+        (b"x-VM0-Codex-Model-Catalog-Prefetch", b"1"),
+    )
+    padding_fields = ((b"X-Padding", b""),) * (_MAX_REQUEST_HEADER_FIELDS - len(fixed_fields))
     flow = real_flow(
         with_response=False,
-        request_headers=mitm_addon.http.Headers(
-            [
-                (b"hOsT", b"example.com"),
-                (b"uSeR-aGeNt", _BROWSER_USER_AGENT),
-                *repeated_fields,
-                (boundary_name, b"accepted"),
-                (b"x-VM0-Connector-Intent", b"primary"),
-                (b"x-VM0-Codex-Model-Catalog-Prefetch", b"1"),
-            ]
-        ),
+        request_headers=mitm_addon.http.Headers((*fixed_fields, *padding_fields)),
     )
+    assert len(flow.request.headers.fields) == _MAX_REQUEST_HEADER_FIELDS
 
     with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
         assert mitm_addon.requestheaders(flow) is None
@@ -103,3 +143,54 @@ async def test_requestheaders_accepts_name_budget_and_preserves_existing_header_
     assert flow.metadata[metadata_keys.BROWSER_USER_AGENT] is True
     assert flow.metadata["_codex_model_catalog_prefetch_request"] is True
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+
+
+async def test_http1_over_budget_field_count_kills_before_expect_and_body_processing() -> None:
+    request_head = (
+        (
+            f"POST / HTTP/1.1\r\nHost: {PLACEHOLDER_HOST}\r\n"
+            "Expect: 100-continue\r\nContent-Length: 1\r\n"
+        ).encode()
+        + b"X: y\r\n" * (_MAX_REQUEST_HEADER_FIELDS - 2)
+        + b"\r\n"
+    )
+
+    with taddons.context(Proxyserver(), mitm_addon) as addon_context:
+        client, http_layer = start_http_layer(addon_context, alpn=b"http/1.1")
+        initial_commands = list(http_layer.handle_event(events.DataReceived(client, request_head)))
+        request_headers_hook = next(
+            command for command in initial_commands if isinstance(command, HttpRequestHeadersHook)
+        )
+        assert len(request_headers_hook.flow.request.headers.fields) == (
+            _MAX_REQUEST_HEADER_FIELDS + 1
+        )
+
+        await addon_context.master.addons.invoke_addon(mitm_addon, request_headers_hook)
+        flow = request_headers_hook.flow
+        header_commands = list(
+            http_layer.handle_event(events.HookCompleted(request_headers_hook, None))
+        )
+        error_hook = next(
+            command for command in header_commands if isinstance(command, HttpErrorHook)
+        )
+        await addon_context.master.addons.invoke_addon(mitm_addon, error_hook)
+        terminal_commands = list(http_layer.handle_event(events.HookCompleted(error_hook, None)))
+
+    assert flow.error is not None
+    assert flow.error.msg == Error.KILLED_MESSAGE
+    assert flow.request.headers.fields == ()
+    assert flow.request.raw_content is None
+    assert not any(isinstance(command, HttpRequestHook) for command in header_commands)
+    assert any(
+        isinstance(command, commands.CloseConnection) and command.connection is flow.client_conn
+        for command in terminal_commands
+    )
+    assert not any(
+        isinstance(command, commands.SendData) and command.connection is flow.client_conn
+        for command in terminal_commands
+    )
+    assert not any(
+        isinstance(command, (commands.OpenConnection, commands.SendData))
+        and isinstance(command.connection, connection.Server)
+        for command in (*header_commands, *terminal_commands)
+    )


### PR DESCRIPTION
## Summary

- cap generic raw request headers at an inclusive 2,048 fields before per-name checks or repeated header scans
- release the complete over-limit tuple and immediately kill the flow before mitmproxy's `Expect` lookup or request-body processing
- preserve exact-limit behavior for both `Content-Length` and `Transfer-Encoding`, and keep the later SigV4-specific field-count contract covered at its independent request-hook entry
- cover guarded no-normalization rejection and real HTTP/1 `Expect: 100-continue` termination through pinned mitmproxy hooks

## Rejection behavior

Over-limit requests terminate the client connection or protocol stream instead of receiving HTTP 431. Pinned mitmproxy delays a local response created in `requestheaders()` until the request body completes. Retaining or locating `Expect` would rescan the attacker-sized tuple, while clearing it without terminating can leave the client waiting for `100 Continue`.

## Explicit exclusions

- does not bound mitmproxy's pre-hook HTTP/1 buffering, parsing, validation, or initial header allocation
- does not add a generic aggregate request-head byte limit
- does not add configuration, logging, or a new externally visible error contract
- does not change APIs, queue payloads, persisted data, environment variables, or cross-deployment protocols

## Diagnostic

Genuine mitmproxy flows were constructed outside timing under the locked CPython 3.14 environment. Each row is the median of seven fresh-flow calls. The previous column executes the exact accepted common prefix through framing checks; the new column includes tuple release and flow termination.

| Repeated tiny fields | Approximate HTTP/1 head | Previous prefix | New rejection |
| ---: | ---: | ---: | ---: |
| 10,000 | 60,056 bytes | 3.447 ms | 0.024 ms |
| 50,000 | 300,056 bytes | 17.941 ms | 0.076 ms |
| 100,000 | 600,056 bytes | 39.051 ms | 0.127 ms |
| 250,000 | 1,500,056 bytes | 103.817 ms | 0.328 ms |
| 500,000 | 3,000,056 bytes | 206.823 ms | 0.594 ms |

Separate `tracemalloc` runs after constructing the 500,000-field input observed 7.790 MiB of additional peak allocation in the previous prefix and 0.0003 MiB in the new rejection path.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_request_header_names.py tests/test_request_handler_aws_sigv4_body.py` (42 passed)
- `uv run --no-sync python -m pytest tests/` (7,272 passed)

Closes #31645
