### PR TITLE
perf: add low-resource local rust profile

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -105,6 +105,13 @@ uuid = "1"
 which = "8"
 zstd = { version = "0.13", default-features = false }
 
+# Keep routine local validation usable in constrained environments while
+# retaining source locations in backtraces.
+[profile.local]
+inherits = "dev"
+debug = "line-tables-only"
+incremental = false
+
 [profile.release]
 lto = true
 strip = true

--- a/crates/README.md
+++ b/crates/README.md
@@ -130,7 +130,10 @@ cargo build --target "$TARGET_TRIPLE" -p runner --profile ci
 
 ## Testing
 
+Use the `local` profile for routine local validation. Omit it when full debug information or
+incremental compilation is more useful.
+
 ```bash
-cargo test
-cargo clippy --all-targets
+cargo test --profile local
+cargo clippy --profile local --all-targets
 ```

--- a/docs/testing/rust-testing.md
+++ b/docs/testing/rust-testing.md
@@ -6,21 +6,26 @@ Rust crates live in `crates/` and use `cargo test` for testing. The same princip
 
 ## Running Tests
 
+Use the `local` profile for routine local validation. It retains source locations in backtraces
+while omitting full debug information and incremental artifacts to reduce resource and disk use.
+Omit `--profile local` when full debug information or incremental compilation is more useful.
+
 ```bash
 # All crates
-cargo test --manifest-path crates/Cargo.toml
+cargo test --manifest-path crates/Cargo.toml --profile local
 
 # Specific crate
-cargo test --manifest-path crates/Cargo.toml -p guest-agent
+cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent
 
 # Specific test by name
-cargo test --manifest-path crates/Cargo.toml -p runner config::tests::load_full_config
+cargo test --manifest-path crates/Cargo.toml --profile local -p runner config::tests::load_full_config
 
 # With output (for debugging)
-cargo test --manifest-path crates/Cargo.toml -- --nocapture
+cargo test --manifest-path crates/Cargo.toml --profile local -- --nocapture
 ```
 
-Pre-commit hooks run `cargo-clippy` and `cargo-fmt` on staged Rust files.
+Pre-commit hooks run `cargo fmt`, `cargo clippy --profile local`, and
+`cargo doc --profile local` on staged Rust files.
 
 ## Test Organization
 

--- a/docs/testing/rust-testing.md
+++ b/docs/testing/rust-testing.md
@@ -18,7 +18,8 @@ cargo test --manifest-path crates/Cargo.toml --profile local
 cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent
 
 # Specific test by name
-cargo test --manifest-path crates/Cargo.toml --profile local -p runner config::tests::load_full_config
+cargo test --manifest-path crates/Cargo.toml --profile local \
+  -p shell-quote --lib tests::quoted_words_round_trip_through_posix_shell -- --exact
 
 # With output (for debugging)
 cargo test --manifest-path crates/Cargo.toml --profile local -- --nocapture

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -49,11 +49,11 @@ pre-commit:
             glob: "crates/**/*.{rs,toml}"
             stage_fixed: true
           - name: cargo-clippy
-            run: cargo clippy --all-targets --all-features
+            run: cargo clippy --profile local --all-targets --all-features
             root: crates/
             glob: "crates/**/*.{rs,toml}"
           - name: cargo-doc
-            run: cargo doc --workspace --all-features --no-deps
+            run: cargo doc --profile local --workspace --all-features --no-deps
             root: crates/
             glob: "crates/**/*.{rs,toml}"
           - name: uv-lock


### PR DESCRIPTION
Routine Rust validation can exhaust memory and disk space in constrained development environments. Add an explicit `local` Cargo profile that retains source locations in backtraces while using line-table-only debug information and disabling incremental compilation; local test documentation and lefthook's clippy/rustdoc commands now select it.

Cargo defaults, CI commands and cache keys, and release profiles retain their existing settings. Omitting `--profile local` remains useful for full debugger information or incremental builds. The single-test example now selects an existing test with `--exact`.

## Validation

- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --format-version 1`
- `cargo clippy --profile local -p shell-quote --all-targets --all-features`
- `cargo doc --profile local -p shell-quote --all-features --no-deps`
- `CARGO_BUILD_JOBS=2 cargo test --profile local -p guest-agent --lib` — 632 passed
- `cargo test --manifest-path crates/Cargo.toml --profile local -p shell-quote --lib tests::quoted_words_round_trip_through_posix_shell -- --exact` — 1 passed
- `npx --yes lefthook@1.12.3 validate`
- Prettier, file-size, commitlint, and diff whitespace checks for the documentation correction

The documentation correction's applicable commit checks were run directly because this runtime cannot allocate the PTY required by lefthook 1.12.3.

Closes #31773
