### PR TITLE
fix(api): honor active run credit admission in okou gates

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -49,6 +49,9 @@ import { removeBuiltInGenerationPublicBrandFixture } from "../../../test-fixture
 import { upsertOrgPlanEntitlementFixture } from "../../../test-fixtures/org-plan-entitlement";
 import { hostedTextFile } from "./helpers/api-bdd-host-files";
 import { createHostMapsBddApi } from "./helpers/api-bdd-host-maps";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+import { seedVm0BuiltInDefaultModelKey } from "./helpers/runtime-state";
 
 const context = testContext();
 const store = createStore();
@@ -185,6 +188,11 @@ function readPublishedGenerationId(
 interface ImageFixture {
   readonly orgId: string;
   readonly userId: string;
+}
+
+interface AdmittedImageFixture extends ImageFixture {
+  readonly actor: ApiTestUser;
+  readonly runId: string;
 }
 
 function authHeaders() {
@@ -572,6 +580,36 @@ async function seedImageFixture(options: {
   return fixture;
 }
 
+async function seedAdmittedImageRun(): Promise<AdmittedImageFixture> {
+  await seedVm0BuiltInDefaultModelKey(context);
+  const bdd = createBddApi(context);
+  const runs = createRunsApi(context);
+  const actor = bdd.user();
+  if (!actor.orgId) {
+    throw new Error("Image tests require an organization");
+  }
+  bdd.acceptAgentStorageWrites();
+  runs.configureRunnerGroup();
+  const completed = await bdd.completeOnboarding(actor);
+  expect(completed.status).toBe(200);
+  await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 1 });
+  const agent = await bdd.createAgent(actor, {
+    displayName: "Admitted image agent",
+    visibility: "private",
+  });
+  const run = await runs.createRun(actor, {
+    agentId: agent.agentId,
+    prompt: "Generate after credit exhaustion",
+    modelProvider: "built-in",
+  });
+  return {
+    actor,
+    orgId: actor.orgId,
+    userId: actor.userId,
+    runId: run.runId,
+  };
+}
+
 async function seedImageRun(
   fixture: ImageFixture,
   options: {
@@ -944,6 +982,72 @@ describe("POST /api/image-io/generate", () => {
     });
     expect(falCalls).toBe(0);
     await expect(orgCredits(fixture)).resolves.toBe(0);
+  });
+
+  it("settles admitted provider work after the run becomes terminal", async () => {
+    const fixture = await seedAdmittedImageRun();
+    const pricingFixture = await createScopedImagePricing({
+      configured: GPT_IMAGE_1_PRICING,
+    });
+    await seedOrgMetadata({ orgId: fixture.orgId, tier: "pro", credits: 0 });
+    let observedRequestUrl: string | null = null;
+    server.use(
+      http.post(FAL_GPT_IMAGE_1_URL, ({ request }) => {
+        observedRequestUrl = request.url;
+        return HttpResponse.json(
+          falQueueHandle("admitted-terminal-image-request"),
+        );
+      }),
+      http.get(FAL_GPT_MEDIA_URL, () => {
+        return new HttpResponse(IMAGE_BYTES, {
+          headers: { "Content-Type": "image/png" },
+        });
+      }),
+    );
+    const token = okouToken(fixture);
+    const app = createImageIoTestApp(pricingFixture.resolution);
+
+    const response = await app.request("/api/image-io/generate", {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: JSON.stringify({ prompt: "an admitted terminal run image" }),
+    });
+    expect(response.status).toBe(202);
+    const generationId = readAcceptedGenerationId(
+      await response.json(),
+      "image",
+      fixture.userId,
+    );
+
+    const runs = createRunsApi(context);
+    await runs.requestCancelRun(fixture.actor, fixture.runId, [200]);
+    await expect(
+      runs.readRun(fixture.actor, fixture.runId),
+    ).resolves.toMatchObject({ status: "cancelled" });
+    await postFalWebhook(app, observedRequestUrl, {
+      images: [
+        {
+          url: FAL_GPT_MEDIA_URL,
+          width: 1024,
+          height: 1024,
+          content_type: "image/png",
+        },
+      ],
+      prompt: "An admitted terminal run image.",
+    });
+    await flushWaitUntilForTest();
+
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const statusResponse = await app.request(
+      `/api/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    expect(readGenerationResult(await statusResponse.json())).toMatchObject({
+      creditsCharged: 50,
+      billingCategory: "output_image.medium.standard",
+    });
+    await expect(orgCredits(fixture)).resolves.toBe(-50);
   });
 
   it("keeps a legacy generation job on VM0 when allowance remains", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
@@ -26,6 +26,7 @@ import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { readUsageStorageCounts$ } from "./helpers/usage-state";
 import { createRouteMocks } from "./helpers/route-test";
+import { seedVm0BuiltInDefaultModelKey } from "./helpers/runtime-state";
 import { imageRecognitionRoutes } from "../image-recognition";
 import { usageRecordRoutes } from "../usage-record";
 
@@ -106,6 +107,40 @@ async function seedActor(): Promise<RecognitionActor> {
   const run = await api.createDirectRun(actor, {
     agentId: compose.agentId,
     prompt: "Recognize an uploaded image",
+  });
+  context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+    data: [
+      {
+        role: actor.orgRole ?? "org:admin",
+        organization: { id: actor.orgId },
+        publicUserData: { userId: actor.userId },
+      },
+    ],
+  });
+  return { ...actor, orgId: actor.orgId, runId: run.runId };
+}
+
+async function seedAdmittedActor(): Promise<RecognitionActor> {
+  await seedVm0BuiltInDefaultModelKey(context);
+  const bdd = createBddApi(context);
+  const api = createRunsApi(context);
+  const actor = bdd.user();
+  if (!actor.orgId) {
+    throw new Error("Recognition tests require an organization");
+  }
+  bdd.acceptAgentStorageWrites();
+  api.configureRunnerGroup();
+  const completed = await bdd.completeOnboarding(actor);
+  expect(completed.status).toBe(200);
+  await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 1 });
+  const agent = await bdd.createAgent(actor, {
+    displayName: "Admitted recognition agent",
+    visibility: "private",
+  });
+  const run = await api.createRun(actor, {
+    agentId: agent.agentId,
+    prompt: "Recognize after credit exhaustion",
+    modelProvider: "built-in",
   });
   context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
     data: [
@@ -304,6 +339,54 @@ describe("POST /api/recognize", () => {
         runId: actor.runId,
         tokens: 8000,
         credits: EXPECTED_CHARGE * 2,
+      }),
+    ]);
+  });
+
+  it("continues an admitted run after credits are exhausted", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: "An admitted run image." },
+            },
+          ],
+          usage: {
+            prompt_tokens: 3000,
+            completion_tokens: 1000,
+            prompt_tokens_details: { cached_tokens: 1000 },
+          },
+        });
+      }),
+    );
+    const actor = await seedAdmittedActor();
+    const pricing = await createConfiguredRecognitionPricing();
+    await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 0 });
+    const fileId = randomUUID();
+    setStoredObjects([
+      { userId: actor.userId, id: fileId, filename: "screen.png", size: 1024 },
+    ]);
+
+    const response = await requestRecognition({
+      token: okouToken(actor),
+      fileId,
+      usagePricingResolution: pricing.resolution,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toStrictEqual({
+      text: "An admitted run image.",
+      metadata: { creditsCharged: EXPECTED_CHARGE },
+    });
+    await expect(
+      createRunsApi(context).readBillingStatus(actor),
+    ).resolves.toMatchObject({ credits: -EXPECTED_CHARGE });
+    await expect(readUsageRecord(actor)).resolves.toStrictEqual([
+      expect.objectContaining({
+        credits: EXPECTED_CHARGE,
       }),
     ]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/scrape.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/scrape.test.ts
@@ -30,7 +30,9 @@ import {
 } from "./helpers/api-bdd";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
+import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createRouteMocks } from "./helpers/route-test";
+import { seedVm0BuiltInDefaultModelKey } from "./helpers/runtime-state";
 
 const context = testContext();
 const FIRECRAWL_SCRAPE_URL = "https://api.firecrawl.dev/v2/scrape";
@@ -128,6 +130,26 @@ async function setActorCredits(
 async function fundActor(actor: ApiTestUser): Promise<void> {
   await bootstrapOnboarding(actor);
   await setActorCredits(actor, 1000);
+}
+
+async function createAdmittedScrapeRun(actor: ApiTestUser): Promise<string> {
+  await seedVm0BuiltInDefaultModelKey(context);
+  const bdd = createBddApi(context);
+  const runs = createRunsApi(context);
+  bdd.acceptAgentStorageWrites();
+  runs.configureRunnerGroup();
+  await bootstrapOnboarding(actor);
+  await setActorCredits(actor, 1);
+  const agent = await bdd.createAgent(actor, {
+    displayName: "Admitted scrape agent",
+    visibility: "private",
+  });
+  const run = await runs.createRun(actor, {
+    agentId: agent.agentId,
+    prompt: "Scrape after credit exhaustion",
+    modelProvider: "built-in",
+  });
+  return run.runId;
 }
 
 async function credits(actor: ApiTestUser): Promise<number> {
@@ -616,6 +638,93 @@ describe("okou scrape route", () => {
     const response = await accept(
       client(pricing.resolution)(scrapeContract).scrape({
         headers: authenticate(actor),
+        body: {
+          url: "https://example.com/page",
+          format: "markdown",
+          mode: "standard",
+        },
+      }),
+      [402],
+    );
+
+    expectApiError(response.body);
+    expect(response.body.error.code).toBe("INSUFFICIENT_CREDITS");
+    expect(firecrawlRequests).toBe(0);
+  });
+
+  it("continues an admitted run after credits are exhausted", async () => {
+    const actor = createBddApi(context).user();
+    allowExampleDotCom();
+    configureProvider();
+    const pricing = await createScrapePricingFixture();
+    const runId = await createAdmittedScrapeRun(actor);
+    await setActorCredits(actor, 0);
+    server.use(
+      http.post(FIRECRAWL_SCRAPE_URL, () => {
+        return HttpResponse.json({
+          success: true,
+          data: {
+            markdown: "# Admitted run",
+            metadata: { sourceURL: "https://example.com/page" },
+          },
+        });
+      }),
+    );
+    const token = createRunsApi(context).okouTokenForRunWithCapabilities(
+      actor,
+      runId,
+      ["scrape:read"],
+    );
+
+    const response = await accept(
+      client(pricing.resolution)(scrapeContract).scrape({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          url: "https://example.com/page",
+          format: "markdown",
+          mode: "standard",
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      creditsCharged: 4,
+      result: { markdown: "# Admitted run" },
+    });
+    await expect(credits(actor)).resolves.toBe(-4);
+  });
+
+  it("does not let admitted runs bypass plan suspension", async () => {
+    const actor = createBddApi(context).user();
+    allowExampleDotCom();
+    configureProvider();
+    const pricing = await createScrapePricingFixture();
+    const runId = await createAdmittedScrapeRun(actor);
+    if (!actor.orgId) {
+      throw new Error("Scrape test actor must belong to an organization");
+    }
+    await seedOrgMetadata({
+      orgId: actor.orgId,
+      tier: "pro-suspend",
+      credits: 0,
+    });
+    let firecrawlRequests = 0;
+    server.use(
+      http.post(FIRECRAWL_SCRAPE_URL, () => {
+        firecrawlRequests += 1;
+        return HttpResponse.json({ success: true, data: {} });
+      }),
+    );
+    const token = createRunsApi(context).okouTokenForRunWithCapabilities(
+      actor,
+      runId,
+      ["scrape:read"],
+    );
+
+    const response = await accept(
+      client(pricing.resolution)(scrapeContract).scrape({
+        headers: { authorization: `Bearer ${token}` },
         body: {
           url: "https://example.com/page",
           format: "markdown",

--- a/turbo/apps/api/src/signals/routes/avatar-video.ts
+++ b/turbo/apps/api/src/signals/routes/avatar-video.ts
@@ -165,9 +165,13 @@ const postGenerateInner$ = command(
       return options;
     }
 
+    const runId =
+      auth.tokenType === "agent" || auth.tokenType === "sandbox"
+        ? auth.runId
+        : undefined;
     const hasCredits = await set(
       checkAvatarVideoCredits$,
-      { orgId: auth.orgId, userId: auth.userId },
+      { orgId: auth.orgId, userId: auth.userId, runId },
       signal,
     );
     if (!hasCredits) {
@@ -193,10 +197,6 @@ const postGenerateInner$ = command(
       generationId,
     );
     signal.throwIfAborted();
-    const runId =
-      auth.tokenType === "agent" || auth.tokenType === "sandbox"
-        ? auth.runId
-        : undefined;
     const publicBrand =
       auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
     const admission = await set(

--- a/turbo/apps/api/src/signals/routes/image-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/image-io-generate.ts
@@ -409,7 +409,7 @@ const postImageInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const hasCredits = await set(
     checkImageCredits$,
-    { orgId: auth.orgId, userId: auth.userId },
+    { orgId: auth.orgId, userId: auth.userId, runId },
     signal,
   );
   if (!hasCredits) {

--- a/turbo/apps/api/src/signals/routes/video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/video-io-generate.ts
@@ -481,7 +481,7 @@ const postVideoInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const hasCredits = await set(
     checkVideoCredits$,
-    { orgId: auth.orgId, userId: auth.userId },
+    { orgId: auth.orgId, userId: auth.userId, runId },
     signal,
   );
   if (!hasCredits) {

--- a/turbo/apps/api/src/signals/routes/voice-io-speech.ts
+++ b/turbo/apps/api/src/signals/routes/voice-io-speech.ts
@@ -157,9 +157,13 @@ const postSpeechInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     );
   }
 
+  const runId =
+    auth.tokenType === "agent" || auth.tokenType === "sandbox"
+      ? auth.runId
+      : undefined;
   const hasCredits = await set(
     checkSpeechCredits$,
-    { orgId: auth.orgId, userId: auth.userId },
+    { orgId: auth.orgId, userId: auth.userId, runId },
     signal,
   );
   if (!hasCredits) {
@@ -175,10 +179,6 @@ const postSpeechInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     );
   }
 
-  const runId =
-    auth.tokenType === "agent" || auth.tokenType === "sandbox"
-      ? auth.runId
-      : undefined;
   const publicBrand =
     auth.tokenType === "agent" ? auth.publicBrand : get(publicBrand$);
   const admission = await set(

--- a/turbo/apps/api/src/signals/services/air-quality.service.ts
+++ b/turbo/apps/api/src/signals/services/air-quality.service.ts
@@ -112,6 +112,7 @@ export const airQualityCurrent$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         resource: {
           kind: USAGE_KIND,
           provider: PROVIDER,

--- a/turbo/apps/api/src/signals/services/avatar-video.service.ts
+++ b/turbo/apps/api/src/signals/services/avatar-video.service.ts
@@ -289,7 +289,11 @@ export const avatarVideoPricing$: Computed<
 export const checkAvatarVideoCredits$ = command(
   async (
     { set },
-    args: { readonly orgId: string; readonly userId: string },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly runId?: string;
+    },
     signal: AbortSignal,
   ): Promise<boolean> => {
     return await set(checkBillableOperationCredits$, args, signal);

--- a/turbo/apps/api/src/signals/services/billable-operation-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/billable-operation-admission.service.ts
@@ -2,12 +2,19 @@ import { command } from "ccstate";
 
 import { writeDb$ } from "../external/db";
 import { resolveUsageAllowanceAvailability } from "./usage-allowance.service";
-import { resolveOrgCreditAvailability } from "./run-admission.service";
+import {
+  resolveActiveRunCreditAdmission,
+  resolveOrgCreditAvailability,
+} from "./run-admission.service";
 
 export const checkBillableOperationCredits$ = command(
   async (
     { set },
-    args: { readonly orgId: string; readonly userId: string },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly runId?: string;
+    },
     signal: AbortSignal,
   ): Promise<boolean> => {
     const writeDb = set(writeDb$);
@@ -20,6 +27,16 @@ export const checkBillableOperationCredits$ = command(
 
     if (!availability || availability.status !== "active") {
       return false;
+    }
+    const activeRunAdmission = await resolveActiveRunCreditAdmission({
+      db: writeDb,
+      runId: args.runId,
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+    signal.throwIfAborted();
+    if (activeRunAdmission) {
+      return true;
     }
     if (
       availability.usagePackCredits > 0 ||

--- a/turbo/apps/api/src/signals/services/finance.service.ts
+++ b/turbo/apps/api/src/signals/services/finance.service.ts
@@ -235,6 +235,7 @@ export const finance$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         resource: {
           kind: USAGE_KIND,
           provider: PROVIDER,

--- a/turbo/apps/api/src/signals/services/image-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/image-generation.service.ts
@@ -1493,7 +1493,11 @@ export const imagePricing$: Computed<Promise<ImagePricing>> = computed(
 export const checkImageCredits$ = command(
   async (
     { set },
-    args: { readonly orgId: string; readonly userId: string },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly runId?: string;
+    },
     signal: AbortSignal,
   ): Promise<boolean> => {
     return await set(checkBillableOperationCredits$, args, signal);

--- a/turbo/apps/api/src/signals/services/image-recognition.service.ts
+++ b/turbo/apps/api/src/signals/services/image-recognition.service.ts
@@ -177,7 +177,11 @@ export const imageRecognition$ = command(
     }
     const hasCredits = await set(
       checkBillableOperationCredits$,
-      { orgId: args.auth.orgId, userId: args.auth.userId },
+      {
+        orgId: args.auth.orgId,
+        userId: args.auth.userId,
+        runId: args.auth.runId,
+      },
       requestSignal,
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/managed-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/managed-usage.service.ts
@@ -17,9 +17,11 @@ import {
   usagePricingResolution$,
 } from "../context/usage-pricing-resolution";
 import { writeDb$ } from "../external/db";
+import { processOrgUsageEvents$ } from "./credit-usage.service";
+import { loadOrgPlanCapabilities } from "./org-plan-entitlement-read.service";
+import { resolveActiveRunCreditAdmission } from "./run-admission.service";
 import { resolveUsageAllowanceAvailability } from "./usage-allowance.service";
 import { getSpendableUsagePackCredits } from "./usage-pack-credit.service";
-import { processOrgUsageEvents$ } from "./credit-usage.service";
 
 export interface ManagedUsageErrorResponse {
   readonly status: 402 | 503;
@@ -91,6 +93,7 @@ export const checkManagedCredits$ = command(
     args: {
       readonly orgId: string;
       readonly userId: string;
+      readonly runId?: string;
       readonly resource: ManagedUsageResource;
       readonly label: string;
     },
@@ -160,6 +163,21 @@ export const checkManagedCredits$ = command(
       row.unitSize,
       quantity,
     );
+    const capabilities = await loadOrgPlanCapabilities(writeDb, args.orgId);
+    signal.throwIfAborted();
+    if (!capabilities || capabilities.status !== "active") {
+      return insufficientCredits();
+    }
+    const activeRunAdmission = await resolveActiveRunCreditAdmission({
+      db: writeDb,
+      runId: args.runId,
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+    signal.throwIfAborted();
+    if (activeRunAdmission) {
+      return null;
+    }
     const spendableCredits = credits - row.unsettledExpired;
     const usagePackCredits = BigInt(
       await getSpendableUsagePackCredits(writeDb, {

--- a/turbo/apps/api/src/signals/services/maps.service.ts
+++ b/turbo/apps/api/src/signals/services/maps.service.ts
@@ -84,6 +84,7 @@ interface CompleteGoogleMapsResultArgs {
 interface MapsCreditCheckArgs {
   readonly orgId: string;
   readonly userId: string;
+  readonly runId?: string;
   readonly provider?: string;
   readonly category: string;
 }
@@ -304,6 +305,7 @@ export const checkMapsCredits$ = command(
       {
         orgId: args.orgId,
         userId: args.userId,
+        runId: args.runId,
         resource: {
           kind: USAGE_KIND,
           provider,
@@ -386,6 +388,7 @@ export const mapsGeocode$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         category: GEOCODING_CATEGORY,
       },
       signal,
@@ -438,6 +441,7 @@ export const mapsReverseGeocode$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         category: GEOCODING_CATEGORY,
       },
       signal,
@@ -493,6 +497,7 @@ export const mapsDirections$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         category: billingCategory,
       },
       signal,
@@ -561,6 +566,7 @@ export const mapsPlacesSearch$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         category: billingCategory,
       },
       signal,
@@ -628,6 +634,7 @@ export const mapsPlacesDetails$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         category: billingCategory,
       },
       signal,

--- a/turbo/apps/api/src/signals/services/people-search.service.ts
+++ b/turbo/apps/api/src/signals/services/people-search.service.ts
@@ -714,6 +714,7 @@ export const peopleSearch$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         resource: {
           kind: USAGE_KIND,
           provider: PROVIDER,

--- a/turbo/apps/api/src/signals/services/run-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/run-admission.service.ts
@@ -79,6 +79,22 @@ export async function loadRunCreditAdmissionState(params: {
   return run;
 }
 
+export async function resolveActiveRunCreditAdmission(params: {
+  readonly db: Db;
+  readonly runId: string | undefined;
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<boolean> {
+  if (!params.runId) {
+    return false;
+  }
+  const run = await loadRunCreditAdmissionState({
+    ...params,
+    runId: params.runId,
+  });
+  return run !== undefined && runHasActiveCreditAdmission(run);
+}
+
 export async function resolveOrgCreditAvailability(params: {
   readonly db: CreditDb;
   readonly orgId: string;

--- a/turbo/apps/api/src/signals/services/scrape.service.ts
+++ b/turbo/apps/api/src/signals/services/scrape.service.ts
@@ -639,6 +639,7 @@ export const scrape$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         resource: {
           kind: USAGE_KIND,
           provider: PROVIDER,

--- a/turbo/apps/api/src/signals/services/seo.service.ts
+++ b/turbo/apps/api/src/signals/services/seo.service.ts
@@ -605,6 +605,7 @@ const runDataForSeo$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         resource: {
           kind: USAGE_KIND,
           provider: DATAFORSEO_PROVIDER,

--- a/turbo/apps/api/src/signals/services/social.service.ts
+++ b/turbo/apps/api/src/signals/services/social.service.ts
@@ -801,6 +801,7 @@ export const socialKitRequest$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         resource: preflightResource,
         label: "Okou SocialKit",
       },

--- a/turbo/apps/api/src/signals/services/socialkit-download.service.ts
+++ b/turbo/apps/api/src/signals/services/socialkit-download.service.ts
@@ -943,6 +943,7 @@ export const createSocialKitDownload$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runId(args.auth),
         resource: {
           kind: "social",
           provider: "socialkit",

--- a/turbo/apps/api/src/signals/services/video-generation.service.ts
+++ b/turbo/apps/api/src/signals/services/video-generation.service.ts
@@ -1167,7 +1167,11 @@ export const videoPricing$: Computed<Promise<VideoPricing>> = computed(
 export const checkVideoCredits$ = command(
   async (
     { set },
-    args: { readonly orgId: string; readonly userId: string },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly runId?: string;
+    },
     signal: AbortSignal,
   ): Promise<boolean> => {
     return await set(checkBillableOperationCredits$, args, signal);

--- a/turbo/apps/api/src/signals/services/voice-io-post.service.ts
+++ b/turbo/apps/api/src/signals/services/voice-io-post.service.ts
@@ -907,7 +907,11 @@ export const speechPricing$: Computed<Promise<SpeechPricing | null>> = computed(
 export const checkSpeechCredits$ = command(
   async (
     { set },
-    args: { readonly orgId: string; readonly userId: string },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly runId?: string;
+    },
     signal: AbortSignal,
   ): Promise<boolean> => {
     return await set(checkBillableOperationCredits$, args, signal);

--- a/turbo/apps/api/src/signals/services/weather.service.ts
+++ b/turbo/apps/api/src/signals/services/weather.service.ts
@@ -193,6 +193,7 @@ const weatherRequest$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         resource: {
           kind: USAGE_KIND,
           provider: PROVIDER,

--- a/turbo/apps/api/src/signals/services/web-search.service.ts
+++ b/turbo/apps/api/src/signals/services/web-search.service.ts
@@ -423,6 +423,7 @@ export const webSearch$ = command(
       {
         orgId: args.auth.orgId,
         userId: args.auth.userId,
+        runId: runIdForUsage(args.auth),
         resource: {
           kind: USAGE_KIND,
           provider: PROVIDER,


### PR DESCRIPTION
## Summary

- make managed-usage and generic billable-operation credit gates honor the exact active run's durable credit admission
- propagate authenticated agent and sandbox run IDs through managed services and image, video, voice, avatar, and recognition preflights
- preserve pricing and active-plan checks while allowing already-submitted asynchronous work to settle after its parent run becomes terminal

## Scope

- no public API, token, runner, CLI, frontend, schema, or migration changes
- session, PAT, manual, BYOK, unadmitted, mismatched, queued, terminal, and suspended-plan requests retain current credit behavior

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/scrape.test.ts src/signals/routes/__tests__/image-recognition.test.ts src/signals/routes/__tests__/image-io-generate.test.ts src/signals/routes/__tests__/video-io-generate.test.ts src/signals/routes/__tests__/voice-io-post.test.ts src/signals/routes/__tests__/voice-io-polish.test.ts src/signals/routes/__tests__/avatar-video.test.ts src/signals/routes/__tests__/finance.test.ts src/signals/routes/__tests__/people-search.test.ts src/signals/routes/__tests__/seo.test.ts src/signals/routes/__tests__/social.test.ts src/signals/routes/__tests__/weather.test.ts src/signals/routes/__tests__/web-search.test.ts src/signals/routes/__tests__/host-maps.bdd.test.ts --maxWorkers=4 --silent=passed-only` (307 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/image-io-generate.test.ts --silent=passed-only` (48 tests after terminal-state assertion)
- staged pre-commit formatter, full Knip, full Turbo type checks, and file-size checks

Closes #31701

Parent: #31681
