### PR TITLE
refactor(chat): remove prefixed timeout fallback

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -5037,11 +5037,6 @@ describe("CHAT-02: failed chat callbacks", () => {
       },
       {
         prompt: "round eleven",
-        error: "execution: Agent execution timed out after 7200 seconds",
-        expectedError: CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE,
-      },
-      {
-        prompt: "round twelve",
         error: "Contradictory runner failure",
         expectedError: CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE,
         failureReason: "execution_timeout",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-models.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-models.test.tsx
@@ -675,7 +675,7 @@ test("Continue a run classified by a structured execution timeout reason", async
   installRunChat({
     selectedModel: "gpt-5.6-sol",
     chatEvents: failedRunEvents(
-      "Contradictory runner failure",
+      "execution: Agent execution timed out after 7200 seconds",
       "gpt-5.6-sol",
       "execution_timeout",
     ),

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -34,7 +34,6 @@ describe("formatRunErrorForExternalSurface", () => {
   it.each([
     "Agent execution timed out after 7200 seconds",
     "Agent execution timed out after 1 seconds",
-    "execution: Agent execution timed out after 7200 seconds",
   ])("shows controlled execution timeout errors safely: %s", (error) => {
     expect(
       formatRunErrorForExternalSurface({

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -238,12 +238,8 @@ export const CHAT_RUN_TRANSIENT_ERROR_MESSAGE =
 export const CHAT_RUN_EXECUTION_TIMEOUT_MESSAGE =
   "This run reached its execution time limit.";
 
-// Existing runner/sandbox and commit-addressed CLI rollout fallback:
-// pre-execution_timeout senders may wrap the canonical text with `execution: `.
-// Remove after old instances drain, their queue, two-hour execution, and
-// finalization windows close, and the rollback floor is compatible; see #31713.
 const AGENT_EXECUTION_TIMEOUT_RUN_ERROR =
-  /^(?:execution: )?Agent execution timed out after [1-9]\d* seconds$/u;
+  /^Agent execution timed out after [1-9]\d* seconds$/u;
 
 const CODEX_OAUTH_RECONNECT_REQUIRED_MESSAGE =
   "ChatGPT session needs reconnection. Reconnect ChatGPT (Codex) in Model Providers, then retry.";


### PR DESCRIPTION
## Summary

- remove the exact `execution: ` wrapper from the reasonless execution-timeout text matcher
- remove the compatibility-owned prefixed positive fixtures from API Contracts and API callback coverage
- preserve canonical unprefixed historical recovery and prove structured `execution_timeout` remains authoritative with the historical prefixed raw text

## Deployment readiness

- #31711 first shipped in API `v1.545.0`, App `v0.840.0`, and Runner `v0.185.0`
- API promotion completed at `2026-09-04T12:09:16Z`; Runner promotion completed at `2026-09-04T12:10:44Z`
- the maximum two-hour queue, two-hour execution, and bounded finalization window passed at approximately `2026-09-04T16:10:56Z`
- rollback targets are out of scope and do not gate this cleanup

## Scope

- no failure-reason contract, API schema, database, Chat Event version, runner, guest, or CLI changes
- no removal of the canonical unprefixed historical timeout fallback
- no change to timeout limits, retry policy, recovery copy, or Continue behavior
- no tombstone negative test for the retired wrapper, following `docs/fallback.md`

## Accepted risk

If an old API or Runner is restored through rollback, a reasonless historical prefixed timeout can render as a generic transient failure. This rollback-only behavior is explicitly accepted and does not block merge.

## Validation

- `pnpm exec prettier --check packages/api-contracts/src/contracts/errors.ts packages/api-contracts/src/contracts/__tests__/errors.test.ts apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts apps/platform/src/views/okou-page/__tests__/chat-run-models.test.tsx`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/errors.test.ts --maxWorkers=4 --silent=passed-only` — 51 passed
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t 'formats failed-run errors and notifies, without auto-sending' --maxWorkers=4 --silent=passed-only` — 1 passed
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-run-models.test.tsx -t 'Continue a run (that reached its execution time limit|classified by a structured execution timeout reason)' --maxWorkers=4 --silent=passed-only` — 2 passed
- `pnpm turbo run lint check-types --concurrency=1 --filter=@okouai/api-contracts --filter=api --filter=@okouai/app` — 19 tasks passed
- `pnpm knip` — passed with existing configuration hints only
- pre-commit hook: Prettier, Knip, full Turbo type checking, and file-size checks passed

Closes #31713