### PR TITLE
fix(platform): derive run work folding from output events

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-conversation-locator.ts
@@ -360,7 +360,7 @@ function createVisibleTurns(
       activeGroups,
       get(runGroupExpansionOverrides$),
       targetEventId,
-      { preserveGoalRunsForWorkFolding: runWorkFoldingEnabled },
+      { preserveRunGroupsForWorkFolding: runWorkFoldingEnabled },
     );
     const runGroupVisibleGroups =
       runGroupFolding?.visibleGroups ?? activeGroups;

--- a/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
@@ -3,7 +3,6 @@ import type { EnrichedChatEvent, ChatEventGroup } from "./chat-event.ts";
 import type { ChatEventUsagePayload } from "@okouai/api-contracts/contracts/chat-threads";
 import { chatEventCompatibilityRole } from "@okouai/api-contracts/contracts/chat-events";
 import { mergeChatEventUsagePayloads } from "./chat-event-usage.ts";
-import { isGoalContinuationInput } from "./chat-event-types.ts";
 
 interface RunSegment {
   readonly runId: string;
@@ -40,7 +39,7 @@ export interface RunGroupFolding {
 }
 
 interface RunGroupFoldingOptions {
-  readonly preserveGoalRunsForWorkFolding?: boolean;
+  readonly preserveRunGroupsForWorkFolding?: boolean;
 }
 
 const internalRunGroupExpansionOverrides$ = state<Map<string, boolean>>(
@@ -520,12 +519,7 @@ export function buildRunGroupFolding(
     const runSegments = segments
       .slice(index, endIndex)
       .filter(isGroupedRunSegment);
-    if (
-      options.preserveGoalRunsForWorkFolding &&
-      runSegments.some((item) => {
-        return item.events.some(isGoalContinuationInput);
-      })
-    ) {
+    if (options.preserveRunGroupsForWorkFolding) {
       visibleGroups.push(
         ...runSegments.flatMap((item) => {
           return segmentGroups(item, usageByRunId);

--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -13,8 +13,7 @@ import type { ChatEventGroup, EnrichedChatEvent } from "./chat-event.ts";
 import { isGoalContinuationInput, type ChatEvent } from "./chat-event-types.ts";
 import { mergeChatEventUsagePayloads } from "./chat-event-usage.ts";
 import { isCancelledRunEvent } from "./chat-run-lifecycle.ts";
-import { isImageUrl, isSafeMediaUrl, isVideoUrl } from "../../lib/media-url.ts";
-import { eventBodyPlan } from "./parse-body-blocks.ts";
+import type { MarkdownCardRef } from "./markdown-card-ref.ts";
 
 const internalRunWorkExpandedKeys$ = state<Set<string>>(new Set());
 
@@ -36,16 +35,21 @@ export const toggleRunWorkExpanded$ = command(({ set }, key: string) => {
 
 export interface RunWorkSection {
   readonly key: string;
-  readonly goalRunGroupId: string | undefined;
+  readonly runGroupId: string | undefined;
+  readonly runIds: readonly string[];
   readonly anchorEventId: string;
-  readonly collapsedGroups: ChatEventGroup[];
-  readonly previewEventIds: ReadonlySet<string>;
   readonly collapsible: boolean;
   readonly hiddenGroups: ChatEventGroup[];
   readonly hiddenGroupsAfterAnchor: ChatEventGroup[];
+  readonly remainingArtifactCards: readonly RunWorkArtifactCard[];
   readonly startTime: number;
   readonly endTime?: number;
 }
+
+type RunWorkArtifactCard = Extract<
+  MarkdownCardRef,
+  { readonly kind: "artifact" }
+>;
 
 export interface RunWorkFolding {
   readonly visibleGroups: ChatEventGroup[];
@@ -92,66 +96,54 @@ function isRunWorkAssistantOutput(event: EnrichedChatEvent): boolean {
   );
 }
 
-const NON_TEXT_TREE_TAGS: ReadonlySet<string> = new Set([
-  "audio",
-  "canvas",
-  "iframe",
-  "img",
-  "svg",
-  "video",
-]);
-
-function elementHasNonTextContent(node: Element): boolean {
-  const href = node.tagName === "a" ? node.properties.href : undefined;
-  return (
-    node.data?.card !== undefined ||
-    node.data?.imageLoadSignals !== undefined ||
-    node.data?.mermaid !== undefined ||
-    node.data?.mermaidSignals !== undefined ||
-    NON_TEXT_TREE_TAGS.has(node.tagName) ||
-    (typeof href === "string" &&
-      isSafeMediaUrl(href) &&
-      (isImageUrl(href) || isVideoUrl(href)))
-  );
+function isRunWorkMessage(event: EnrichedChatEvent): boolean {
+  return event.eventType === "output.message";
 }
 
-function treeHasNonTextContent(node: Root | Element): boolean {
-  if (node.type === "element" && elementHasNonTextContent(node)) {
-    return true;
+function artifactCardsInTree(
+  tree: Root | undefined,
+): readonly RunWorkArtifactCard[] {
+  if (tree === undefined) {
+    return [];
   }
-  return node.children.some((child) => {
-    return child.type === "element" && treeHasNonTextContent(child);
-  });
+  const cards: RunWorkArtifactCard[] = [];
+  const visit = (node: Root | Element): void => {
+    if (node.type === "element" && node.data?.card?.kind === "artifact") {
+      cards.push(node.data.card);
+    }
+    for (const child of node.children) {
+      if (child.type === "element") {
+        visit(child);
+      }
+    }
+  };
+  visit(tree);
+  return cards;
 }
 
-const MARKDOWN_IMAGE_PATTERN = /!\[[^\]\n]*\](?:\([^\n)]*\)|\[[^\]\n]*\])/u;
-const MEDIA_URL_PATTERN =
-  /https?:\/\/[^\s<>"'()[\]]+\.(?:png|jpe?g|gif|webp|svg|bmp|avif|mp4|webm|mov|ogv)(?:[?#][^\s<>"'()[\]]*)?/iu;
-const MEDIA_HTML_TAG_PATTERN = /<(?:audio|canvas|iframe|img|svg|video)\b/iu;
-const MERMAID_FENCE_PATTERN =
-  /^ {0,3}(?:`{3,}|~{3,})[ \t]*mermaid(?:[ \t]|$)/imu;
-const BROWSER_SESSION_URL_PATTERN =
-  /\/browsers\/[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?:[/?#\s)]|$)/iu;
-
-function messageSourceHasNonTextContent(content: string): boolean {
-  const plan = eventBodyPlan(content, { previews: true });
-  return (
-    plan.descriptors.length > 0 ||
-    MARKDOWN_IMAGE_PATTERN.test(plan.treeSource) ||
-    MEDIA_URL_PATTERN.test(plan.treeSource) ||
-    MEDIA_HTML_TAG_PATTERN.test(plan.treeSource) ||
-    MERMAID_FENCE_PATTERN.test(plan.treeSource) ||
-    BROWSER_SESSION_URL_PATTERN.test(plan.treeSource)
+function remainingArtifactCards(
+  outputMessages: readonly EnrichedChatEvent[],
+): readonly RunWorkArtifactCard[] {
+  const finalUrls = new Set(
+    artifactCardsInTree(outputMessages.at(-1)?.tree).map((card) => {
+      return card.signals.url;
+    }),
   );
-}
-
-function isRunWorkTextMessage(event: EnrichedChatEvent): boolean {
-  if (event.eventType !== "output.message" || !event.content) {
-    return false;
+  const seenUrls = new Set<string>();
+  const remaining: RunWorkArtifactCard[] = [];
+  for (const message of outputMessages) {
+    for (const card of artifactCardsInTree(message.tree)) {
+      const { url } = card.signals;
+      if (seenUrls.has(url)) {
+        continue;
+      }
+      seenUrls.add(url);
+      if (!finalUrls.has(url)) {
+        remaining.push(card);
+      }
+    }
   }
-  return event.tree === undefined
-    ? !messageSourceHasNonTextContent(event.content)
-    : !treeHasNonTextContent(event.tree);
+  return remaining;
 }
 
 export function runWorkSectionForGroup(
@@ -228,18 +220,8 @@ function groupEventsForRunWorkDisplay(
     const role = chatEventCompatibilityRole(event.eventType);
     const forceStandalone = workAnchorEventIds.has(event.id);
     const last = groups[groups.length - 1];
-    const lastHasWorkAnchor =
-      last?.events.some((candidate) => {
-        return workAnchorEventIds.has(candidate.id);
-      }) ?? false;
-    const joinsWorkAnchor = lastHasWorkAnchor && isCancelledRunEvent(event);
 
-    if (
-      !forceStandalone &&
-      last &&
-      last.role === role &&
-      (!lastHasWorkAnchor || joinsWorkAnchor)
-    ) {
+    if (!forceStandalone && last && last.role === role) {
       last.events.push(event);
       continue;
     }
@@ -408,6 +390,12 @@ function standaloneRunWorkUnit(segment: RunWorkEventSegment): RunWorkUnit {
   };
 }
 
+function isRunGroupInternalInput(event: EnrichedChatEvent): boolean {
+  return (
+    event.eventType === "input.automation" || isGoalContinuationInput(event)
+  );
+}
+
 function canAnchorGoalRun(unit: RunWorkUnit | undefined): boolean {
   return unit !== undefined && !unit.isGoal && unit.runGroupId === undefined;
 }
@@ -434,7 +422,21 @@ function runWorkUnits(events: readonly EnrichedChatEvent[]): RunWorkUnit[] {
       return item.events.filter(isGoalContinuationInput);
     });
     if (goalInputEvents.length === 0) {
-      units.push(...streak.map(standaloneRunWorkUnit));
+      const events = streak.flatMap((item) => {
+        return item.events;
+      });
+      units.push({
+        key: `group:${segment.runGroupId}`,
+        runGroupId: segment.runGroupId,
+        events,
+        runIds: uniqueRunIds(streak),
+        hiddenUserEventIds: new Set(
+          events.filter(isRunGroupInternalInput).map((event) => {
+            return event.id;
+          }),
+        ),
+        isGoal: false,
+      });
       index = endIndex;
       continue;
     }
@@ -444,8 +446,11 @@ function runWorkUnits(events: readonly EnrichedChatEvent[]): RunWorkUnit[] {
     // naturally starts a new visual work section after an interruption.
     const previousUnit = units[units.length - 1];
     const anchorUnit = canAnchorGoalRun(previousUnit) ? units.pop() : undefined;
+    const groupedEvents = streak.flatMap((item) => {
+      return item.events;
+    });
     const hiddenUserEventIds = new Set(
-      goalInputEvents.map((event) => {
+      groupedEvents.filter(isRunGroupInternalInput).map((event) => {
         return event.id;
       }),
     );
@@ -458,12 +463,7 @@ function runWorkUnits(events: readonly EnrichedChatEvent[]): RunWorkUnit[] {
     units.push({
       key: `goal:${segment.runGroupId}`,
       runGroupId: segment.runGroupId,
-      events: [
-        ...(anchorUnit?.events ?? []),
-        ...streak.flatMap((item) => {
-          return item.events;
-        }),
-      ],
+      events: [...(anchorUnit?.events ?? []), ...groupedEvents],
       runIds: [...(anchorUnit?.runIds ?? []), ...goalRunIds],
       hiddenUserEventIds,
       isGoal: true,
@@ -553,7 +553,8 @@ interface RunWorkPhaseFolding {
 
 interface RunWorkPhaseIdentity {
   readonly key: string;
-  readonly goalRunGroupId: string | undefined;
+  readonly runGroupId: string | undefined;
+  readonly runIds: readonly string[];
 }
 
 function foldRunWorkPhase(
@@ -563,12 +564,8 @@ function foldRunWorkPhase(
   hiddenUserEventIds: ReadonlySet<string>,
   foldedEventIds: ReadonlySet<string>,
 ): RunWorkPhaseFolding {
-  const textMessages = events.filter(isRunWorkTextMessage);
-  const latestTextMessage = textMessages.at(-1);
-  const terminalEvent = lastEventMatching(events, (event) => {
-    return isChatRunTerminalEventType(event.eventType);
-  });
-  const anchorEvent = latestTextMessage ?? terminalEvent;
+  const outputMessages = events.filter(isRunWorkMessage);
+  const anchorEvent = outputMessages.at(-1);
   const startTime = firstEventTime(events);
   if (anchorEvent === undefined || startTime === null) {
     return {
@@ -586,19 +583,6 @@ function foldRunWorkPhase(
       (hiddenUserEventIds.has(event.id) && foldedEventIds.has(event.id))
     );
   });
-  const previewTextMessages =
-    endTime === undefined ? textMessages.slice(-4, -1) : [];
-  const previewEventIds = new Set(
-    previewTextMessages.map((event) => {
-      return event.id;
-    }),
-  );
-  const collapsedEvents = hiddenEvents.filter((event) => {
-    return (
-      previewEventIds.has(event.id) ||
-      (isRenderableAssistantEvent(event) && !isRunWorkTextMessage(event))
-    );
-  });
   const hiddenEventsAfterAnchor = events
     .slice(anchorIndex + 1)
     .filter((event) => {
@@ -614,7 +598,7 @@ function foldRunWorkPhase(
       !hiddenEventIds.has(event.id) &&
       !hiddenUserEventIds.has(event.id) &&
       isRenderableAssistantEvent(event) &&
-      !isRunWorkTextMessage(event)
+      !isRunWorkMessage(event)
     );
   });
   const userEvents = events.filter((event) => {
@@ -625,13 +609,13 @@ function foldRunWorkPhase(
     visibleEvents: [...userEvents, anchorEvent, ...trailingStatusEvents],
     section: {
       key: `${identity.key}:${events[0]!.id}`,
-      goalRunGroupId: identity.goalRunGroupId,
+      runGroupId: identity.runGroupId,
+      runIds: identity.runIds,
       anchorEventId: anchorEvent.id,
-      collapsedGroups: groupEventsByRole(collapsedEvents),
-      previewEventIds,
-      collapsible: textMessages.length > 1,
+      collapsible: outputMessages.length > 1,
       hiddenGroups: groupEventsByRole(hiddenEvents),
       hiddenGroupsAfterAnchor: groupEventsByRole(hiddenEventsAfterAnchor),
+      remainingArtifactCards: remainingArtifactCards(outputMessages),
       startTime,
       ...(endTime === undefined ? {} : { endTime }),
     },
@@ -722,7 +706,8 @@ export function buildRunWorkFolding(
       const phaseFolding = foldRunWorkPhase(
         {
           key: unit.key,
-          goalRunGroupId: unit.isGoal ? unit.runGroupId : undefined,
+          runGroupId: unit.runGroupId,
+          runIds: unit.runIds,
         },
         phase,
         phaseEndTime(phase, phaseIndex === phases.length - 1, terminalEvent),
@@ -734,7 +719,7 @@ export function buildRunWorkFolding(
         sections.push(phaseFolding.section);
       }
     }
-    if (unit.isGoal && sections.length > firstSectionIndex) {
+    if (unit.runGroupId !== undefined && sections.length > firstSectionIndex) {
       const mergedUsage = mergedUsageForRunIds(unit.runIds, usageByRunId);
       const finalSection = sections[sections.length - 1];
       if (mergedUsage !== undefined && finalSection !== undefined) {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-run-history.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { expect, test } from "vitest";
 
 import {
@@ -13,7 +14,11 @@ import {
   RUN_PATH,
 } from "./chat-capability-test-helpers.ts";
 import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
-import { installRunChat, publishRunUpdate } from "./chat-run-test-fixtures.ts";
+import {
+  installRunChat,
+  publishRunUpdate,
+  queryButton,
+} from "./chat-run-test-fixtures.ts";
 
 const WORKFLOW_GROUP_ID = "e0000000-0000-4000-a000-000000000871";
 const WORKFLOW_RUN_IDS = [
@@ -140,7 +145,7 @@ function completedWorkflowRun(args: {
   ];
 }
 
-test("Browse earlier runs in a grouped goal or workflow history", async () => {
+test("Project all workflow run outputs through one run-group history", async () => {
   const events = [
     ...completedWorkflowRun({
       number: 1,
@@ -173,67 +178,152 @@ test("Browse earlier runs in a grouped goal or workflow history", async () => {
       createdAt: timestamp(4, 10),
     },
   ] satisfies MockChatEventInput[];
-  installRunChat({ chatEvents: events });
+  installRunChat({ chatEvents: events, activeRunIds: [WORKFLOW_RUN_IDS[2]] });
 
-  await setupPage({ context, path: RUN_PATH });
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
 
   await readyChat();
-  const fold = await findButton("Expand grouped run history");
-  expect(fold).toHaveTextContent("2 runs for Nightly launch review");
-  expect(fold).not.toHaveTextContent(/goal/iu);
+  expect(screen.queryByText("Earlier workflow evidence 1")).toBeNull();
+  expect(screen.queryByText("Earlier workflow result 1")).toBeNull();
+  expect(screen.queryByText("Earlier workflow evidence 2")).toBeNull();
+  const main = screen.getByText("Earlier workflow result 2");
+  expect(main).toBeVisible();
+  expect(queryButton("Expand grouped run history")).toBeNull();
+  const fold = await findButton("Expand work history");
   const currentProgress = await screen.findByLabelText(
     "Checking the latest workflow run",
   );
   expect(currentProgress).toBeVisible();
+  const assistantGroup = main.closest<HTMLElement>('[data-role="assistant"]');
+  if (!assistantGroup) {
+    throw new Error(
+      "Expected the workflow result inside an assistant response",
+    );
+  }
+  expect(assistantGroup).toContainElement(currentProgress);
   expect(
-    screen.queryByText("Earlier workflow result 1"),
-  ).not.toBeInTheDocument();
-  expect(
-    screen.queryByText("Earlier workflow result 2"),
-  ).not.toBeInTheDocument();
+    queryAllByRoleFast("link").filter((link) => {
+      return link.getAttribute("aria-label") === "View agent profile";
+    }),
+  ).toHaveLength(1);
 
   click(fold);
 
-  const firstEarlierResult = await screen.findByText(
-    "Earlier workflow result 1",
+  const firstEarlierEvidence = await screen.findByText(
+    "Earlier workflow evidence 1",
   );
-  expect(firstEarlierResult).toBeVisible();
+  expect(firstEarlierEvidence).toBeVisible();
+  expect(screen.getByText("Earlier workflow result 1")).toBeVisible();
+  expect(screen.getByText("Earlier workflow evidence 2")).toBeVisible();
   expect(screen.getByText("Earlier workflow result 2")).toBeVisible();
-  const workHistory = await findButton("Expand work history");
-  expect(workHistory).toHaveTextContent(/Worked for \d+s/u);
+  expect(firstEarlierEvidence.closest('[data-role="assistant"]')).toBe(
+    assistantGroup,
+  );
+  expect(screen.queryByText("Nightly launch review")).toBeNull();
 
-  click(await findButton("Collapse grouped run history"));
+  click(await findButton("Collapse work history"));
   await waitFor(() => {
-    expect(
-      screen.queryByText("Earlier workflow result 1"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Earlier workflow result 1")).toBeNull();
   });
-  events.push({
-    id: "workflow-history-current-paused",
-    role: "assistant",
-    eventType: "run.cancelled",
-    content: null,
-    error: "Run cancelled",
-    runId: WORKFLOW_RUN_IDS[2],
-    runGroupId: WORKFLOW_GROUP_ID,
-    runLifecycleEvent: "cancelled",
-    seqId: 11,
-    createdAt: timestamp(4, 20),
-  });
+  events.push(
+    assistantOutput({
+      id: "workflow-history-current-result",
+      runId: WORKFLOW_RUN_IDS[2],
+      runGroupId: WORKFLOW_GROUP_ID,
+      seqId: 11,
+      minute: 4,
+      second: 20,
+      text: "Current workflow result",
+    }),
+  );
   publishRunUpdate();
 
-  const paused = await screen.findByText(
-    "Paused mid-thought — pick it back up whenever.",
-  );
-  expect(paused).toBeVisible();
-  expect(
-    screen.queryByText("Earlier workflow result 1"),
-  ).not.toBeInTheDocument();
-  const collapsedFold = await findButton("Expand grouped run history");
-  expect(collapsedFold).toBeVisible();
+  const currentMain = await screen.findByText("Current workflow result");
+  expect(currentMain).toBeVisible();
+  expect(screen.queryByText("Earlier workflow result 2")).toBeNull();
+  expect(currentMain.closest('[data-role="assistant"]')).toBe(assistantGroup);
+  expect(queryButton("Expand grouped run history")).toBeNull();
+  await expect(findButton("Expand work history")).resolves.toBeVisible();
 });
 
-test("Keep pending grouped goal history with the assistant response", async () => {
+test("Keep different run groups as separate assistant responses", async () => {
+  const secondGroupId = "e0000000-0000-4000-a000-000000000879";
+  installRunChat({
+    chatEvents: [
+      workflowInput({
+        id: "first-group-input",
+        runId: WORKFLOW_RUN_IDS[0],
+        runGroupId: WORKFLOW_GROUP_ID,
+        seqId: 1,
+        minute: 0,
+      }),
+      assistantOutput({
+        id: "first-group-output",
+        runId: WORKFLOW_RUN_IDS[0],
+        runGroupId: WORKFLOW_GROUP_ID,
+        seqId: 2,
+        minute: 0,
+        second: 20,
+        text: "First group result",
+      }),
+      completedMarker({
+        id: "first-group-completed",
+        runId: WORKFLOW_RUN_IDS[0],
+        runGroupId: WORKFLOW_GROUP_ID,
+        seqId: 3,
+        minute: 0,
+      }),
+      workflowInput({
+        id: "second-group-input",
+        runId: WORKFLOW_RUN_IDS[1],
+        runGroupId: secondGroupId,
+        seqId: 4,
+        minute: 2,
+      }),
+      assistantOutput({
+        id: "second-group-output",
+        runId: WORKFLOW_RUN_IDS[1],
+        runGroupId: secondGroupId,
+        seqId: 5,
+        minute: 2,
+        second: 20,
+        text: "Second group result",
+      }),
+      completedMarker({
+        id: "second-group-completed",
+        runId: WORKFLOW_RUN_IDS[1],
+        runGroupId: secondGroupId,
+        seqId: 6,
+        minute: 2,
+      }),
+    ],
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+
+  const first = screen.getByText("First group result");
+  const second = screen.getByText("Second group result");
+  expect(first.closest('[data-role="assistant"]')).not.toBe(
+    second.closest('[data-role="assistant"]'),
+  );
+  expect(
+    queryAllByRoleFast("link").filter((link) => {
+      return link.getAttribute("aria-label") === "View agent profile";
+    }),
+  ).toHaveLength(2);
+  expect(queryButton("Expand work history")).toBeNull();
+});
+
+test("Keep the prior goal result as main while the next run has no output", async () => {
   const goalGroupId = "e0000000-0000-4000-a000-000000000874";
   const completedRunId = "d0000000-0000-4000-a000-000000000874";
   const activeRunId = "d0000000-0000-4000-a000-000000000875";
@@ -295,10 +385,19 @@ test("Keep pending grouped goal history with the assistant response", async () =
   ] satisfies MockChatEventInput[];
   installRunChat({ chatEvents: events, activeRunIds: [activeRunId] });
 
-  await setupPage({ context, path: RUN_PATH });
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
 
   await readyChat();
-  const fold = await findButton("Expand grouped run history");
+  const priorMain = screen.getByText(
+    "The earlier launch evidence is complete.",
+  );
+  expect(priorMain).toBeVisible();
+  expect(queryButton("Expand grouped run history")).toBeNull();
+  expect(queryButton("Expand work history")).toBeNull();
   const thinking = await waitFor(() => {
     const indicator = document.querySelector<HTMLElement>(
       "[data-thinking-indicator]",
@@ -309,11 +408,13 @@ test("Keep pending grouped goal history with the assistant response", async () =
     expect(indicator).toBeVisible();
     return indicator;
   });
-  const pendingAssistant = fold.closest<HTMLElement>('[data-role="assistant"]');
+  const pendingAssistant = priorMain.closest<HTMLElement>(
+    '[data-role="assistant"]',
+  );
   if (!pendingAssistant) {
-    throw new Error("Expected grouped goal history in an assistant response");
+    throw new Error("Expected the prior goal result in an assistant response");
   }
-  expect(pendingAssistant).toBe(thinking);
+  expect(pendingAssistant).toContainElement(thinking);
   expect(
     queryAllByRoleFast("link", pendingAssistant).filter((link) => {
       return link.getAttribute("aria-label") === "View agent profile";
@@ -336,7 +437,10 @@ test("Keep pending grouped goal history with the assistant response", async () =
   const answer = await screen.findByText(
     "The current launch evidence is ready.",
   );
-  const currentFold = await findButton("Expand grouped run history");
+  expect(
+    screen.queryByText("The earlier launch evidence is complete."),
+  ).toBeNull();
+  const currentFold = await findButton("Expand work history");
   const answeringAssistant = answer.closest<HTMLElement>(
     '[data-role="assistant"]',
   );
@@ -346,6 +450,8 @@ test("Keep pending grouped goal history with the assistant response", async () =
   expect(currentFold.closest('[data-role="assistant"]')).toBe(
     answeringAssistant,
   );
+  expect(answeringAssistant).toBe(pendingAssistant);
+  expect(queryButton("Expand grouped run history")).toBeNull();
   expect(
     queryAllByRoleFast("link", answeringAssistant).filter((link) => {
       return link.getAttribute("aria-label") === "View agent profile";
@@ -426,12 +532,14 @@ test("Open an archived goal run from a linked event", async () => {
   await setupPage({
     context,
     path: `${RUN_PATH}#event-${LINKED_ARCHIVED_EVENT_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
   });
 
   await readyChat();
   const linkedResult = await screen.findByText("Linked archived launch result");
   expect(linkedResult).toBeVisible();
   expect(screen.getByText("Latest launch result")).toBeVisible();
-  const expandedFold = await findButton("Collapse grouped run history");
+  const expandedFold = await findButton("Collapse work history");
   expect(expandedFold).toBeVisible();
+  expect(queryButton("Collapse grouped run history")).toBeNull();
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
@@ -439,6 +439,7 @@ test("The conversation locator follows the work currently shown in the thread", 
     context,
     path: `/chats/${THREAD_IDS.folded}`,
     host: "app.vm0.ai",
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: false },
   });
 
   await screen.findByText("Grouped result 3");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-engagement-telemetry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-engagement-telemetry.test.tsx
@@ -98,20 +98,12 @@ describe("chat engagement telemetry", () => {
       return buttonByLabel("Expand work history");
     });
     expect(expandWork).toHaveTextContent(/^Working for /);
-    expect(
-      screen
-        .getByText("Checking the launch brief.")
-        .closest("[data-chat-run-work-preview]"),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Checking the launch brief.")).toBeNull();
 
     click(expandWork);
 
     await waitFor(() => {
-      expect(
-        screen
-          .getByText("Checking the launch brief.")
-          .closest("[data-chat-run-work-preview]"),
-      ).toBeNull();
+      expect(screen.getByText("Checking the launch brief.")).toBeVisible();
     });
     expect(capturedEvents("chat_work_history_expanded")).toStrictEqual([
       ["chat_work_history_expanded", { work_status: "active" }],
@@ -120,11 +112,7 @@ describe("chat engagement telemetry", () => {
     click(buttonByLabel("Collapse work history"));
 
     await waitFor(() => {
-      expect(
-        screen
-          .getByText("Checking the launch brief.")
-          .closest("[data-chat-run-work-preview]"),
-      ).toBeInTheDocument();
+      expect(screen.queryByText("Checking the launch brief.")).toBeNull();
     });
     expect(capturedEvents("chat_work_history_expanded")).toHaveLength(1);
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-history.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { expect, test } from "vitest";
 
 import {
@@ -27,6 +28,7 @@ function setupHistory(events: readonly MockChatEventInput[]): Promise<void> {
     context,
     path: `/chats/${THREAD_ID}`,
     host: "app.vm0.ai",
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: false },
   });
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -1,0 +1,371 @@
+import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { expect, test } from "vitest";
+
+import { queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
+import { setupPage } from "./chat-lifecycle-test-helpers.ts";
+import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
+import {
+  assistantEvent,
+  completedEvent,
+  context,
+  findButton,
+  installRunChat,
+  promptEvent,
+  queryButton,
+  readyChat,
+  RUN_PATH,
+} from "./chat-run-test-fixtures.ts";
+
+const RUN_ID = "a0000000-0000-4000-a000-000000000281";
+
+function artifactUrl(id: string, filename: string): string {
+  return `https://cdn.vm7.io/artifacts/run-folding/${id}/${filename}`;
+}
+
+function assistantGroupFor(element: Element): HTMLElement {
+  const group = element.closest<HTMLElement>('[data-role="assistant"]');
+  if (!group) {
+    throw new Error("Expected content inside one assistant response");
+  }
+  return group;
+}
+
+function expectDocumentOrder(...elements: readonly Element[]): void {
+  for (let index = 1; index < elements.length; index += 1) {
+    expect(
+      elements[index - 1]!.compareDocumentPosition(elements[index]!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  }
+}
+
+function viewAgentProfileLinks(): HTMLElement[] {
+  return queryAllByRoleFast("link").filter((link) => {
+    return link.getAttribute("aria-label") === "View agent profile";
+  });
+}
+
+function namedLinks(name: string): HTMLElement[] {
+  return queryAllByRoleFast("link").filter((link) => {
+    return link.getAttribute("aria-label") === name;
+  });
+}
+
+function queryNamedLink(name: string): HTMLElement | null {
+  return namedLinks(name)[0] ?? null;
+}
+
+function findNamedLink(name: string): Promise<HTMLElement> {
+  return waitFor(() => {
+    const link = queryNamedLink(name);
+    if (!link) {
+      throw new Error(`Link ${name} was not visible`);
+    }
+    return link;
+  });
+}
+
+async function setupArtifactRun(
+  outputEvents: ReturnType<typeof assistantEvent>[],
+): Promise<void> {
+  installRunChat({
+    chatEvents: [
+      promptEvent({
+        id: "artifact-projection-user",
+        runId: RUN_ID,
+        seqId: 1,
+        text: "Prepare the artifact summary",
+      }),
+      ...outputEvents,
+      completedEvent({
+        id: "artifact-projection-complete",
+        runId: RUN_ID,
+        seqId: outputEvents.length + 2,
+      }),
+    ],
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+}
+
+test("Carry an artifact referenced only by history below the main result", async () => {
+  const reportUrl = artifactUrl("supporting-report", "supporting-report.pdf");
+  await setupArtifactRun([
+    assistantEvent({
+      id: "history-only-artifact",
+      runId: RUN_ID,
+      seqId: 2,
+      text: `Generated supporting evidence.\n\n${reportUrl}`,
+    }),
+    assistantEvent({
+      id: "history-only-main",
+      runId: RUN_ID,
+      seqId: 3,
+      text: "Final release summary",
+    }),
+  ]);
+
+  const main = screen.getByText("Final release summary");
+  const artifact = await findNamedLink(
+    "Open pdf preview for supporting-report.pdf",
+  );
+  const assistantGroup = assistantGroupFor(main);
+  const actions = assistantGroup.querySelector<HTMLElement>(
+    '[data-testid="chat-event-actions"]',
+  );
+  if (!actions) {
+    throw new Error("Expected the main result action bar");
+  }
+  expect(actions).toBeVisible();
+  expectDocumentOrder(main, artifact, actions);
+  expect(screen.queryByText("Generated supporting evidence.")).toBeNull();
+  expect(assistantGroupFor(artifact)).toBe(assistantGroup);
+  const mainMessage = main.closest<HTMLElement>("[data-chat-run-work-main]");
+  if (!mainMessage) {
+    throw new Error("Expected the artifact inside the main message region");
+  }
+  expect(mainMessage).toContainElement(actions);
+  await expect(findButton("Expand work history")).resolves.toBeVisible();
+  expect(viewAgentProfileLinks()).toHaveLength(1);
+});
+
+test("Subtract final artifacts after ordered URL deduplication", async () => {
+  const appendixUrl = artifactUrl("appendix", "appendix.pdf");
+  const repeatedUrl = artifactUrl("repeated", "repeated.pdf");
+  const sourceUrl = artifactUrl("source", "source.pdf");
+  await setupArtifactRun([
+    assistantEvent({
+      id: "artifact-difference-first-history",
+      runId: RUN_ID,
+      seqId: 2,
+      text: ["First historical output", appendixUrl, repeatedUrl].join("\n\n"),
+    }),
+    assistantEvent({
+      id: "artifact-difference-second-history",
+      runId: RUN_ID,
+      seqId: 3,
+      text: ["Second historical output", repeatedUrl, sourceUrl].join("\n\n"),
+    }),
+    assistantEvent({
+      id: "artifact-difference-main",
+      runId: RUN_ID,
+      seqId: 4,
+      text: ["Final artifact summary", repeatedUrl].join("\n\n"),
+    }),
+  ]);
+
+  const main = screen.getByText("Final artifact summary");
+  await findNamedLink("Open pdf preview for repeated.pdf");
+  const repeatedArtifacts = namedLinks("Open pdf preview for repeated.pdf");
+  expect(repeatedArtifacts).toHaveLength(1);
+  const repeated = repeatedArtifacts[0]!;
+  const appendix = await findNamedLink("Open pdf preview for appendix.pdf");
+  const source = await findNamedLink("Open pdf preview for source.pdf");
+  expect(screen.queryByText("First historical output")).toBeNull();
+  expect(screen.queryByText("Second historical output")).toBeNull();
+  expectDocumentOrder(main, repeated, appendix, source);
+  expect(assistantGroupFor(appendix)).toBe(assistantGroupFor(main));
+  expect(assistantGroupFor(source)).toBe(assistantGroupFor(main));
+});
+
+test("Keep artifacts with the same filename distinct when their URLs differ", async () => {
+  const firstUrl = artifactUrl("first-report", "report.pdf");
+  const secondUrl = artifactUrl("second-report", "report.pdf");
+  await setupArtifactRun([
+    assistantEvent({
+      id: "same-name-first-history",
+      runId: RUN_ID,
+      seqId: 2,
+      text: `First report version\n\n${firstUrl}`,
+    }),
+    assistantEvent({
+      id: "same-name-second-history",
+      runId: RUN_ID,
+      seqId: 3,
+      text: `Second report version\n\n${secondUrl}`,
+    }),
+    assistantEvent({
+      id: "same-name-main",
+      runId: RUN_ID,
+      seqId: 4,
+      text: "Final same-name report summary",
+    }),
+  ]);
+
+  await findNamedLink("Open pdf preview for report.pdf");
+  await waitFor(() => {
+    expect(namedLinks("Open pdf preview for report.pdf")).toHaveLength(2);
+  });
+  const main = screen.getByText("Final same-name report summary");
+  const artifacts = namedLinks("Open pdf preview for report.pdf");
+  expectDocumentOrder(main, ...artifacts);
+  expect(artifacts[0]).toHaveAttribute("href", firstUrl);
+  expect(artifacts[1]).toHaveAttribute("href", secondUrl);
+  expect(screen.queryByText("First report version")).toBeNull();
+  expect(screen.queryByText("Second report version")).toBeNull();
+});
+
+test("Do not carry inline media or action cards out of historical messages", async () => {
+  await setupArtifactRun([
+    assistantEvent({
+      id: "non-artifact-history",
+      runId: RUN_ID,
+      seqId: 2,
+      text: [
+        "Historical rich output",
+        "![Inline chart](https://example.com/inline-chart.png)",
+        "[Compare plans](/?settings=billing&billingView=plans)",
+      ].join("\n\n"),
+    }),
+    assistantEvent({
+      id: "non-artifact-main",
+      runId: RUN_ID,
+      seqId: 3,
+      text: "Final result without artifacts",
+    }),
+  ]);
+
+  expect(screen.getByText("Final result without artifacts")).toBeVisible();
+  expect(screen.queryByText("Historical rich output")).toBeNull();
+  expect(screen.queryByAltText("Inline chart")).toBeNull();
+  expect(screen.queryByTestId("plan-upgrade-card")).toBeNull();
+  await expect(findButton("Expand work history")).resolves.toBeVisible();
+});
+
+test("Carry artifacts across every run in the same run group", async () => {
+  const runGroupId = "e0000000-0000-4000-a000-000000000282";
+  const nextRunId = "a0000000-0000-4000-a000-000000000282";
+  const earlierUrl = artifactUrl("earlier-run", "earlier-run.pdf");
+  const automationInput = (
+    id: string,
+    runId: string,
+    seqId: number,
+  ): MockChatEventInput => {
+    return {
+      id,
+      role: "user",
+      eventType: "input.automation",
+      content: null,
+      runId,
+      runGroupId,
+      seqId,
+      createdAt: `2026-08-01T10:00:0${String(seqId)}.000Z`,
+      userMessage: {
+        version: 1,
+        parts: [
+          {
+            type: "automation",
+            workflowName: "artifact-review",
+            automationBrief: "Review generated artifacts",
+          },
+        ],
+      },
+    };
+  };
+  const inRunGroup = (event: MockChatEventInput): MockChatEventInput => {
+    return { ...event, runGroupId };
+  };
+  installRunChat({
+    chatEvents: [
+      automationInput("earlier-run-input", RUN_ID, 1),
+      inRunGroup(
+        assistantEvent({
+          id: "earlier-run-artifact",
+          runId: RUN_ID,
+          seqId: 2,
+          text: `Earlier run output\n\n${earlierUrl}`,
+        }),
+      ),
+      inRunGroup(
+        completedEvent({
+          id: "earlier-run-complete",
+          runId: RUN_ID,
+          seqId: 3,
+        }),
+      ),
+      automationInput("next-run-input", nextRunId, 4),
+      inRunGroup(
+        assistantEvent({
+          id: "next-run-main",
+          runId: nextRunId,
+          seqId: 5,
+          text: "Latest run result",
+        }),
+      ),
+      inRunGroup(
+        completedEvent({
+          id: "next-run-complete",
+          runId: nextRunId,
+          seqId: 6,
+        }),
+      ),
+    ],
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+
+  const main = screen.getByText("Latest run result");
+  const artifact = await findNamedLink("Open pdf preview for earlier-run.pdf");
+  expect(screen.queryByText("Earlier run output")).toBeNull();
+  expectDocumentOrder(main, artifact);
+  expect(assistantGroupFor(artifact)).toBe(assistantGroupFor(main));
+  expect(queryButton("Expand grouped run history")).toBeNull();
+  await expect(findButton("Expand work history")).resolves.toBeVisible();
+});
+
+test("Ignore artifacts from revoked output messages", async () => {
+  const obsoleteUrl = artifactUrl("obsolete", "obsolete.pdf");
+  installRunChat({
+    chatEvents: [
+      promptEvent({
+        id: "revoked-artifact-user",
+        runId: RUN_ID,
+        seqId: 1,
+        text: "Replace the obsolete artifact",
+      }),
+      assistantEvent({
+        id: "revoked-artifact-output",
+        runId: RUN_ID,
+        seqId: 2,
+        text: obsoleteUrl,
+      }),
+      {
+        id: "revoked-artifact-replacement",
+        eventType: "output.message",
+        role: "assistant",
+        content: "The obsolete artifact was withdrawn",
+        runId: RUN_ID,
+        revokesEventId: "revoked-artifact-output",
+        seqId: 3,
+        createdAt: "2026-08-01T10:00:03.000Z",
+      },
+      completedEvent({
+        id: "revoked-artifact-complete",
+        runId: RUN_ID,
+        seqId: 4,
+      }),
+    ],
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+
+  expect(screen.getByText("The obsolete artifact was withdrawn")).toBeVisible();
+  expect(queryNamedLink("Open pdf preview for obsolete.pdf")).toBeNull();
+  expect(queryButton("Expand work history")).toBeNull();
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -135,6 +135,76 @@ test("Carry an artifact referenced only by history below the main result", async
   expect(viewAgentProfileLinks()).toHaveLength(1);
 });
 
+test("Keep completed result actions before recommended followups", async () => {
+  const reportUrl = artifactUrl("followup-report", "followup-report.pdf");
+  installRunChat({
+    chatEvents: [
+      promptEvent({
+        id: "followup-actions-user",
+        runId: RUN_ID,
+        seqId: 1,
+        text: "Prepare the followup report",
+      }),
+      assistantEvent({
+        id: "followup-actions-history",
+        runId: RUN_ID,
+        seqId: 2,
+        text: `Generated the supporting report.\n\n${reportUrl}`,
+      }),
+      assistantEvent({
+        id: "followup-actions-main",
+        runId: RUN_ID,
+        seqId: 3,
+        text: "The followup report is ready",
+      }),
+      completedEvent({
+        id: "followup-actions-complete",
+        runId: RUN_ID,
+        seqId: 4,
+      }),
+      {
+        id: "followup-actions-recommendations",
+        eventType: "output.followups",
+        role: "assistant",
+        content: null,
+        runId: RUN_ID,
+        seqId: 5,
+        createdAt: "2026-08-01T10:00:05.000Z",
+        followups: [{ prompt: "Summarize the report", kind: "talk" }],
+      },
+    ],
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+
+  const main = screen.getByText("The followup report is ready");
+  const artifact = await findNamedLink(
+    "Open pdf preview for followup-report.pdf",
+  );
+  const mainMessage = main.closest<HTMLElement>("[data-chat-run-work-main]");
+  if (!mainMessage) {
+    throw new Error("Expected the result inside the main message region");
+  }
+  const actions = mainMessage.querySelector<HTMLElement>(
+    '[data-testid="chat-event-actions"]',
+  );
+  if (!actions) {
+    throw new Error("Expected the completed result action bar");
+  }
+  const keepGoing = await screen.findByRole("group", { name: "Keep going" });
+
+  expect(actions).toBeVisible();
+  expect(mainMessage).toContainElement(actions);
+  expect(mainMessage).not.toContainElement(keepGoing);
+  expect(assistantGroupFor(main)).toContainElement(keepGoing);
+  expectDocumentOrder(main, artifact, actions, keepGoing);
+});
+
 test("Subtract final artifacts after ordered URL deduplication", async () => {
   const appendixUrl = artifactUrl("appendix", "appendix.pdf");
   const repeatedUrl = artifactUrl("repeated", "repeated.pdf");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
@@ -580,6 +580,32 @@ test("Render progress or result actions, never both", async () => {
   ).toBeNull();
 });
 
+test("Do not render result actions while waiting for assistant output", async () => {
+  installRunChat({
+    activeRunIds: [RUN_A],
+    chatEvents: [
+      promptEvent({
+        id: "waiting-actions-user",
+        runId: RUN_A,
+        seqId: 1,
+        text: "Prepare a result",
+      }),
+    ],
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+
+  await readyChat();
+  expect(document.querySelector("[data-thinking-indicator]")).toBeVisible();
+  expect(
+    document.querySelector('[data-testid="chat-event-actions"]'),
+  ).toBeNull();
+});
+
 test("Render result actions after a run completes", async () => {
   installRunChat({
     chatEvents: [

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
@@ -13,11 +13,13 @@ import {
   creditUsage,
   expectTextOrder,
   findButton,
+  findLink,
   installRunChat,
   promptEvent,
   queryButton,
   readyChat,
   RUN_PATH,
+  thinkingEvent,
   usageEvent,
 } from "./chat-run-test-fixtures.ts";
 
@@ -36,10 +38,14 @@ function buttonsNamed(name: string): HTMLElement[] {
   });
 }
 
-function runWorkPreviews(): HTMLElement[] {
-  return Array.from(
-    document.querySelectorAll<HTMLElement>("[data-chat-run-work-preview]"),
-  );
+function buttonNamedIn(name: string, container: HTMLElement): HTMLElement {
+  const button = buttonsNamed(name).find((candidate) => {
+    return container.contains(candidate);
+  });
+  if (!button) {
+    throw new Error(`Expected button named "${name}" in container`);
+  }
+  return button;
 }
 
 function workMessage(index: number): string {
@@ -71,23 +77,17 @@ function activeWorkChatEvents(messageCount: number): MockChatEventInput[] {
   ];
 }
 
-function visibleWorkMessages(messageCount: number): string[] {
-  return Array.from({ length: messageCount }, (_, index) => {
-    return workMessage(index);
-  }).filter((message) => {
-    return screen.queryByText(message) !== null;
-  });
+function assistantGroupFor(element: Element): HTMLElement {
+  const group = element.closest<HTMLElement>('[data-role="assistant"]');
+  if (!group) {
+    throw new Error("Expected content inside one assistant response");
+  }
+  return group;
 }
 
-function fullWorkMessages(messageCount: number): string[] {
-  return Array.from({ length: messageCount }, (_, index) => {
-    return workMessage(index);
-  }).filter((message) => {
-    const element = screen.queryByText(message);
-    return (
-      element !== null &&
-      element.closest("[data-chat-run-work-preview]") === null
-    );
+function viewAgentProfileLinks(): HTMLElement[] {
+  return queryAllByRoleFast("link").filter((link) => {
+    return link.getAttribute("aria-label") === "View agent profile";
   });
 }
 
@@ -263,10 +263,28 @@ test("Browse completed work by conversation phase", async () => {
   expect(screen.getByText("Phase one final plan")).toBeVisible();
 });
 
-test.each([0, 1, 2, 5])(
-  "Summarize an active run with %i text messages",
-  async (messageCount) => {
-    const messages = workMessageEvents(messageCount);
+test.each([
+  {
+    label: "no output messages",
+    messageCount: 0,
+    showsHistoryStatus: false,
+    canExpandHistory: false,
+  },
+  {
+    label: "one output message",
+    messageCount: 1,
+    showsHistoryStatus: true,
+    canExpandHistory: false,
+  },
+  {
+    label: "multiple output messages",
+    messageCount: 3,
+    showsHistoryStatus: true,
+    canExpandHistory: true,
+  },
+])(
+  "Project an active run with $label",
+  async ({ messageCount, showsHistoryStatus, canExpandHistory }) => {
     installRunChat({
       activeRunIds: [RUN_A],
       chatEvents: activeWorkChatEvents(messageCount),
@@ -279,88 +297,62 @@ test.each([0, 1, 2, 5])(
     });
 
     await readyChat();
-    expect(document.querySelector("[data-thinking-indicator]")).toBeVisible();
-    const expectedPreviews = messages
-      .slice(Math.max(0, messageCount - 4), -1)
-      .map((_, index) => {
-        return workMessage(Math.max(0, messageCount - 4) + index);
-      });
-    const expectedLatestMessage =
-      messageCount === 0 ? [] : [workMessage(messageCount - 1)];
-    expect(screen.queryAllByText(/^Working for /)).toHaveLength(
-      messageCount === 0 ? 0 : 1,
+    const thinking = document.querySelector<HTMLElement>(
+      "[data-thinking-indicator]",
     );
-    expect(
-      runWorkPreviews().map((preview) => {
-        return preview.textContent?.replace(/\s+/gu, " ").trim();
-      }),
-    ).toStrictEqual(
-      expectedPreviews.map((message) => {
-        return `•${message}`;
-      }),
+    expect(thinking).toBeVisible();
+    expect(screen.queryAllByText(/^Working(?: for)? /u)).toHaveLength(
+      showsHistoryStatus ? 1 : 0,
     );
-    expect(visibleWorkMessages(messageCount)).toStrictEqual([
-      ...expectedPreviews,
-      ...expectedLatestMessage,
-    ]);
-    expect(fullWorkMessages(messageCount)).toStrictEqual(expectedLatestMessage);
     expect(buttonsNamed("Expand work history")).toHaveLength(
-      messageCount > 1 ? 1 : 0,
+      canExpandHistory ? 1 : 0,
     );
-  },
-);
 
-test.each([2, 8])(
-  "Expand an active run with %i text messages",
-  async (messageCount) => {
-    installRunChat({
-      activeRunIds: [RUN_A],
-      chatEvents: activeWorkChatEvents(messageCount),
-    });
+    if (messageCount === 0) {
+      return;
+    }
 
-    await setupPage({
-      context,
-      path: RUN_PATH,
-      featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
-    });
+    const main = screen.getByText(workMessage(messageCount - 1));
+    expect(main).toBeVisible();
+
+    for (let index = 0; index < messageCount - 1; index += 1) {
+      expect(screen.queryByText(workMessage(index))).toBeNull();
+    }
+    expect(assistantGroupFor(main)).toContainElement(thinking);
+
+    if (!canExpandHistory) {
+      return;
+    }
 
     click(await findButton("Expand work history"));
-    await waitFor(() => {
-      expect(runWorkPreviews()).toHaveLength(0);
-    });
-    expect(fullWorkMessages(messageCount)).toStrictEqual(
-      Array.from({ length: messageCount }, (_, index) => {
-        return workMessage(index);
-      }),
+    const firstHistoryMessage = await screen.findByText(workMessage(0));
+    const secondHistoryMessage = screen.getByText(workMessage(1));
+    expect(assistantGroupFor(firstHistoryMessage)).toBe(
+      assistantGroupFor(main),
     );
+    expect(assistantGroupFor(secondHistoryMessage)).toBe(
+      assistantGroupFor(main),
+    );
+    expectTextOrder(workMessage(0), workMessage(1), workMessage(2));
   },
 );
 
-test("Treat media-looking literals inside code as text work messages", async () => {
-  const mediaUrl = "https://example.com/example.png";
+test("Do not create history before the first output.message", async () => {
   installRunChat({
     activeRunIds: [RUN_A],
     chatEvents: [
       promptEvent({
-        id: "code-literal-user",
+        id: "status-only-user",
         runId: RUN_A,
         seqId: 1,
-        text: "Review this media URL",
-        createdAt: createdAt(10),
+        text: "Inspect the release",
+        createdAt: createdAt(0),
       }),
-      assistantEvent({
-        id: "code-literal-work",
+      thinkingEvent({
+        id: "status-only-thinking",
         runId: RUN_A,
         seqId: 2,
-        text: ["```text", mediaUrl, "```"].join("\n"),
-        createdAt: createdAt(10, 20),
-      }),
-      assistantEvent({
-        id: "code-literal-latest",
-        runId: RUN_A,
-        seqId: 3,
-        text: "The URL remains plain text",
-        createdAt: createdAt(10, 40),
+        text: "Reading release evidence",
       }),
     ],
   });
@@ -372,31 +364,72 @@ test("Treat media-looking literals inside code as text work messages", async () 
   });
 
   await readyChat();
-  expect(runWorkPreviews()).toHaveLength(1);
-  expect(runWorkPreviews()[0]).toHaveTextContent(mediaUrl);
-  expect(screen.getByText("The URL remains plain text")).toBeVisible();
-
-  click(await findButton("Expand work history"));
-  await waitFor(() => {
-    expect(runWorkPreviews()).toHaveLength(0);
-  });
-  expect(screen.getByText(mediaUrl).closest("pre")).toBeInTheDocument();
+  expect(screen.queryByText(/^Working(?: for)? /u)).toBeNull();
+  expect(buttonsNamed("Expand work history")).toHaveLength(0);
+  expect(document.querySelector("[data-thinking-indicator]")).toBeVisible();
 });
 
-test.each([0, 1, 2])(
-  "Summarize a finished run with %i text messages",
-  async (messageCount) => {
-    const messages = workMessageEvents(messageCount);
+test("Count one output.message once when Markdown renders multiple child blocks", async () => {
+  const artifactUrl =
+    "https://cdn.vm7.io/artifacts/run-folding/multi-block/package.pdf";
+  installRunChat({
+    activeRunIds: [RUN_A],
+    chatEvents: [
+      promptEvent({
+        id: "multi-block-user",
+        runId: RUN_A,
+        seqId: 1,
+        text: "Prepare the package",
+      }),
+      assistantEvent({
+        id: "multi-block-output",
+        runId: RUN_A,
+        seqId: 2,
+        text: [
+          "Final package",
+          "![Package chart](https://example.com/package-chart.png)",
+          artifactUrl,
+          "[Compare plans](/?settings=billing&billingView=plans)",
+        ].join("\n\n"),
+      }),
+    ],
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+
+  await readyChat();
+  expect(screen.getByText("Final package")).toBeVisible();
+  await expect(screen.findByAltText("Package chart")).resolves.toBeVisible();
+  await expect(
+    findLink("Open pdf preview for package.pdf"),
+  ).resolves.toBeVisible();
+  await expect(screen.findByTestId("plan-upgrade-card")).resolves.toBeVisible();
+  expect(buttonsNamed("Expand work history")).toHaveLength(0);
+  expect(screen.queryAllByText(/^Working(?: for)? /u)).toHaveLength(1);
+  expect(viewAgentProfileLinks()).toHaveLength(1);
+});
+
+test.each([
+  {
+    label: "one output message",
+    messageCount: 1,
+    canExpandHistory: false,
+  },
+  {
+    label: "multiple output messages",
+    messageCount: 3,
+    canExpandHistory: true,
+  },
+])(
+  "Project a completed run with $label",
+  async ({ messageCount, canExpandHistory }) => {
     installRunChat({
       chatEvents: [
-        promptEvent({
-          id: "finished-work-user",
-          runId: RUN_A,
-          seqId: 1,
-          text: "Prepare the deployment review",
-          createdAt: createdAt(10),
-        }),
-        ...messages,
+        ...activeWorkChatEvents(messageCount),
         completedEvent({
           id: "finished-work-complete",
           runId: RUN_A,
@@ -413,62 +446,123 @@ test.each([0, 1, 2])(
     });
 
     await readyChat();
-    expect(screen.getByText(/^Worked for /)).toBeVisible();
-    expect(runWorkPreviews()).toHaveLength(0);
-    const expectedLatestMessage =
-      messageCount === 0 ? [] : [workMessage(messageCount - 1)];
-    expect(visibleWorkMessages(messageCount)).toStrictEqual(
-      expectedLatestMessage,
-    );
-    expect(fullWorkMessages(messageCount)).toStrictEqual(expectedLatestMessage);
+    expect(screen.getByText(workMessage(messageCount - 1))).toBeVisible();
+    expect(document.querySelector("[data-thinking-indicator]")).toBeNull();
+    expect(screen.queryAllByText(/^Worked(?: for)? /u)).toHaveLength(1);
     expect(buttonsNamed("Expand work history")).toHaveLength(
-      messageCount > 1 ? 1 : 0,
+      canExpandHistory ? 1 : 0,
     );
+    for (let index = 0; index < messageCount - 1; index += 1) {
+      expect(screen.queryByText(workMessage(index))).toBeNull();
+    }
   },
 );
 
-test("Keep non-text run output fully visible and outside the message count", async () => {
+const finalOutputDocuments = [
+  {
+    label: "plain Markdown",
+    content: "Final plain answer",
+    find: () => {
+      return screen.findByText("Final plain answer");
+    },
+  },
+  {
+    label: "a fenced media-looking literal",
+    content: ["```text", "https://example.com/final-literal.png", "```"].join(
+      "\n",
+    ),
+    find: () => {
+      return screen.findByText("https://example.com/final-literal.png");
+    },
+  },
+  {
+    label: "an inline image",
+    content: "![Final chart](https://example.com/final-chart.png)",
+    find: () => {
+      return screen.findByAltText("Final chart");
+    },
+  },
+  {
+    label: "an artifact card",
+    content: "https://cdn.vm7.io/artifacts/tests/run-folding/final-report.pdf",
+    find: () => {
+      return findLink("Open pdf preview for final-report.pdf");
+    },
+  },
+  {
+    label: "an action card",
+    content: "[Compare plans](/?settings=billing&billingView=plans)",
+    find: () => {
+      return screen.findByTestId("plan-upgrade-card");
+    },
+  },
+] as const;
+
+test.each(finalOutputDocuments)(
+  "Use the last output.message as the main result when it renders $label",
+  async ({ content, find }) => {
+    installRunChat({
+      activeRunIds: [RUN_A],
+      chatEvents: [
+        promptEvent({
+          id: "document-shape-user",
+          runId: RUN_A,
+          seqId: 1,
+          text: "Prepare the final result",
+          createdAt: createdAt(10),
+        }),
+        assistantEvent({
+          id: "document-shape-history",
+          runId: RUN_A,
+          seqId: 2,
+          text: "Earlier output belongs in history",
+          createdAt: createdAt(10, 20),
+        }),
+        assistantEvent({
+          id: "document-shape-main",
+          runId: RUN_A,
+          seqId: 3,
+          text: content,
+          createdAt: createdAt(10, 40),
+        }),
+      ],
+    });
+
+    await setupPage({
+      context,
+      path: RUN_PATH,
+      featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+    });
+
+    await readyChat();
+    const main = await find();
+    expect(main).toBeVisible();
+    expect(viewAgentProfileLinks()).toHaveLength(1);
+    expect(screen.queryByText("Earlier output belongs in history")).toBeNull();
+    expect(buttonsNamed("Expand work history")).toHaveLength(1);
+    const thinking = document.querySelector<HTMLElement>(
+      "[data-thinking-indicator]",
+    );
+    expect(assistantGroupFor(main)).toContainElement(thinking);
+  },
+);
+
+test("Render progress or result actions, never both", async () => {
   installRunChat({
     activeRunIds: [RUN_A],
     chatEvents: [
       promptEvent({
-        id: "active-work-user",
+        id: "exclusive-tail-user",
         runId: RUN_A,
         seqId: 1,
-        text: "Prepare the deployment review",
-        createdAt: createdAt(10),
+        text: "Prepare a result",
       }),
       assistantEvent({
-        id: "active-work-text",
+        id: "exclusive-tail-result",
         runId: RUN_A,
         seqId: 2,
-        text: "Checked the deployment logs",
-        createdAt: createdAt(10, 20),
+        text: "The result is still being checked",
       }),
-      assistantEvent({
-        id: "active-work-image",
-        runId: RUN_A,
-        seqId: 3,
-        text: "![Generated chart](https://example.com/generated-chart.png)",
-        createdAt: createdAt(10, 40),
-      }),
-      assistantEvent({
-        id: "active-work-action",
-        runId: RUN_A,
-        seqId: 4,
-        text: "[Compare plans](/?settings=billing&billingView=plans)",
-        createdAt: createdAt(10, 45),
-      }),
-      {
-        id: "active-work-error",
-        eventType: "output.error",
-        role: "assistant",
-        content: null,
-        error: "Health check failed visibly",
-        runId: RUN_A,
-        seqId: 5,
-        createdAt: createdAt(10, 50),
-      },
     ],
   });
 
@@ -479,13 +573,61 @@ test("Keep non-text run output fully visible and outside the message count", asy
   });
 
   await readyChat();
-  expect(screen.getByText("Checked the deployment logs")).toBeVisible();
-  await expect(screen.findByAltText("Generated chart")).resolves.toBeVisible();
-  await expect(screen.findByTestId("plan-upgrade-card")).resolves.toBeVisible();
-  expect(screen.getByText("Health check failed visibly")).toBeVisible();
-  expect(screen.getByText(/^Working for /)).toBeVisible();
-  expect(runWorkPreviews()).toHaveLength(0);
-  expect(buttonsNamed("Expand work history")).toHaveLength(0);
+  expect(screen.getByText("The result is still being checked")).toBeVisible();
+  expect(document.querySelector("[data-thinking-indicator]")).toBeVisible();
+  expect(
+    document.querySelector('[data-testid="chat-event-actions"]'),
+  ).toBeNull();
+});
+
+test("Render result actions after a run completes", async () => {
+  installRunChat({
+    chatEvents: [
+      promptEvent({
+        id: "completed-actions-user",
+        runId: RUN_A,
+        seqId: 1,
+        text: "Prepare a completed result",
+      }),
+      assistantEvent({
+        id: "completed-actions-result",
+        runId: RUN_A,
+        seqId: 2,
+        text: "The completed result is ready",
+      }),
+      completedEvent({
+        id: "completed-actions-terminal",
+        runId: RUN_A,
+        seqId: 3,
+      }),
+    ],
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+
+  await readyChat();
+  const result = screen.getByText("The completed result is ready");
+  const assistantGroup = assistantGroupFor(result);
+  const mainMessage = result.closest<HTMLElement>("[data-chat-run-work-main]");
+  if (!mainMessage) {
+    throw new Error("Expected the result inside the main message region");
+  }
+  expect(assistantGroup.querySelector("[data-thinking-indicator]")).toBeNull();
+  const actions = assistantGroup.querySelector<HTMLElement>(
+    '[data-testid="chat-event-actions"]',
+  );
+  if (!actions) {
+    throw new Error("Expected the completed result action bar");
+  }
+  expect(actions).toBeVisible();
+  expect(mainMessage).toContainElement(actions);
+  expect(
+    result.compareDocumentPosition(actions) & Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
 });
 
 test("Fold intermediate work only after a run completes", async () => {
@@ -571,8 +713,20 @@ test("Fold intermediate work only after a run completes", async () => {
     screen.queryByText("Intermediate research one"),
   ).not.toBeInTheDocument();
   expect(screen.getByText("Completed research answer")).toBeVisible();
-  expect(screen.getByText("Direct answer")).toBeVisible();
+  const directAnswer = screen.getByText("Direct answer");
+  expect(directAnswer).toBeVisible();
   expect(buttonsNamed("Expand work history")).toHaveLength(1);
+
+  const directGroup = assistantGroupFor(directAnswer);
+  const directCopy = buttonNamedIn("Copy message", directGroup);
+  expect(directGroup.firstElementChild).toContainElement(directAnswer);
+  expect(directGroup.firstElementChild).not.toContainElement(directCopy);
+  expect(directGroup.lastElementChild).toContainElement(directCopy);
+  expect(
+    directGroup.querySelector(
+      "[data-chat-run-work], [data-chat-run-work-main], [data-chat-run-work-remaining-artifacts]",
+    ),
+  ).toBeNull();
 
   click(await findButton("Expand work history"));
 
@@ -581,6 +735,36 @@ test("Fold intermediate work only after a run completes", async () => {
   ).resolves.toBeVisible();
   expect(screen.getByText("Intermediate research two")).toBeVisible();
   expect(buttonsNamed("Collapse work history")).toHaveLength(1);
+});
+
+test("Keep the legacy running tail outside the response when work folding is disabled", async () => {
+  installRunChat({
+    activeRunIds: [RUN_A],
+    chatEvents: activeWorkChatEvents(2),
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: false },
+  });
+
+  await readyChat();
+  const latestMessage = screen.getByText(workMessage(1));
+  const assistantGroup = assistantGroupFor(latestMessage);
+  const thinking = document.querySelector<HTMLElement>(
+    "[data-thinking-indicator]",
+  );
+  const copy = buttonNamedIn("Copy message", assistantGroup);
+
+  expect(screen.getByText(workMessage(0))).toBeVisible();
+  expect(thinking).toBeVisible();
+  expect(assistantGroup).not.toContainElement(thinking);
+  expect(assistantGroup.firstElementChild).toContainElement(latestMessage);
+  expect(assistantGroup.firstElementChild).not.toContainElement(copy);
+  expect(assistantGroup.lastElementChild).toContainElement(copy);
+  expect(assistantGroup.querySelector("[data-chat-run-work]")).toBeNull();
+  expect(buttonsNamed("Expand work history")).toHaveLength(0);
 });
 
 test("Keep interleaved run updates with their own turns", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-sharing.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-sharing.test.tsx
@@ -198,12 +198,8 @@ test("A folded multi-message answer counts as one shared selection", async () =>
   });
 
   await screen.findByText("Launch answer 3");
-  expect(
-    screen.getByText("Launch answer 1").closest("[data-chat-run-work-preview]"),
-  ).toBeInTheDocument();
-  expect(
-    screen.getByText("Launch answer 2").closest("[data-chat-run-work-preview]"),
-  ).toBeInTheDocument();
+  expect(screen.queryByText("Launch answer 1")).toBeNull();
+  expect(screen.queryByText("Launch answer 2")).toBeNull();
   await waitFor(() => {
     expect(buttonsNamed("Share messages").length).toBeGreaterThan(0);
   });

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -6,7 +6,6 @@ import type {
   ReactNode,
   UIEvent as ReactUIEvent,
 } from "react";
-import type { Element, Root } from "hast";
 import {
   useGet,
   useLoadable,
@@ -122,6 +121,7 @@ import {
   CHAT_INLINE_VIDEO_ATTACHMENT_PREVIEW_CLASS,
   ChatImagePreviewLink,
   ChatVideoPreviewButton,
+  MarkdownCardView,
 } from "./chat-body-cards.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 import { ChatConversationLocator } from "./chat-conversation-locator.tsx";
@@ -3067,17 +3067,14 @@ function isWaitingThinkingIndicatorMode(
   return mode === "waiting" || mode === "waiting-queued";
 }
 
-function assistantGroupIdForWaitingRunWorkIndicator(
+function assistantGroupIdForRunWorkIndicator(
   groups: readonly ChatEventGroup[],
   runWorkFolding: RunWorkFolding | null,
   mode: ThinkingIndicatorMode,
+  currentRunId: string | undefined,
   currentRunGroupId: string | undefined,
 ): string | null {
-  if (
-    runWorkFolding === null ||
-    currentRunGroupId === undefined ||
-    !isWaitingThinkingIndicatorMode(mode)
-  ) {
+  if (runWorkFolding === null || mode === null || currentRunId === undefined) {
     return null;
   }
 
@@ -3086,8 +3083,10 @@ function assistantGroupIdForWaitingRunWorkIndicator(
     const section = runWorkSectionForGroup(runWorkFolding, group);
     if (
       group.role === "assistant" &&
-      section?.goalRunGroupId === currentRunGroupId &&
-      section.endTime === undefined
+      section !== null &&
+      (section.runIds.includes(currentRunId) ||
+        (currentRunGroupId !== undefined &&
+          section.runGroupId === currentRunGroupId))
     ) {
       return group.beginEventId;
     }
@@ -3118,7 +3117,7 @@ function ChatThreadRenderedEventGroups({
     renderedActiveGroups,
     runGroupExpansionOverrides,
     scrollTargetEventId,
-    { preserveGoalRunsForWorkFolding: runWorkFoldingEnabled },
+    { preserveRunGroupsForWorkFolding: runWorkFoldingEnabled },
   );
   const runGroupVisibleGroups =
     runGroupFolding?.visibleGroups ?? renderedActiveGroups;
@@ -3148,16 +3147,14 @@ function ChatThreadRenderedEventGroups({
     : (completedWorkFolding?.visibleGroups ?? runGroupVisibleGroups);
   const thinkingIndicatorMode =
     useLastResolved(thread.thinkingIndicatorMode$) ?? null;
-  const currentRunGroupId = renderedActiveGroups
-    .at(-1)
-    ?.events.at(-1)?.runGroupId;
-  const waitingIndicatorAssistantGroupId =
-    assistantGroupIdForWaitingRunWorkIndicator(
-      visibleGroups,
-      runWorkFolding,
-      thinkingIndicatorMode,
-      currentRunGroupId,
-    );
+  const currentEvent = renderedActiveGroups.at(-1)?.events.at(-1);
+  const runIndicatorAssistantGroupId = assistantGroupIdForRunWorkIndicator(
+    visibleGroups,
+    runWorkFolding,
+    thinkingIndicatorMode,
+    currentEvent?.runId,
+    currentEvent?.runGroupId,
+  );
   const runGroupFoldPlacements = resolveRunGroupFoldPlacements({
     groups: visibleGroups,
     runGroupFolding,
@@ -3182,7 +3179,7 @@ function ChatThreadRenderedEventGroups({
         runWorkExpandedKeys={effectiveRunWorkExpandedKeys}
         onToggleRunWork={toggleRunWorkExpanded}
         thinkingIndicatorMode={thinkingIndicatorMode}
-        waitingIndicatorAssistantGroupId={waitingIndicatorAssistantGroupId}
+        runIndicatorAssistantGroupId={runIndicatorAssistantGroupId}
       />
       <ChatThreadScrollCommitMarker
         thread={thread}
@@ -3191,9 +3188,7 @@ function ChatThreadRenderedEventGroups({
       <ChatThreadThinkingIndicator
         thread={thread}
         mode={
-          waitingIndicatorAssistantGroupId === null
-            ? thinkingIndicatorMode
-            : null
+          runIndicatorAssistantGroupId === null ? thinkingIndicatorMode : null
         }
         runGroupFolds={runGroupFoldPlacements.thinkingIndicatorRunGroupFolds}
       />
@@ -3404,7 +3399,7 @@ function ChatThreadEventGroups({
   runWorkExpandedKeys,
   onToggleRunWork,
   thinkingIndicatorMode,
-  waitingIndicatorAssistantGroupId,
+  runIndicatorAssistantGroupId,
 }: {
   thread: ChatPanelSignals;
   groups: readonly ChatEventGroup[];
@@ -3418,7 +3413,7 @@ function ChatThreadEventGroups({
   runWorkExpandedKeys: ReadonlySet<string>;
   onToggleRunWork: (key: string) => void;
   thinkingIndicatorMode: ThinkingIndicatorMode;
-  waitingIndicatorAssistantGroupId: string | null;
+  runIndicatorAssistantGroupId: string | null;
 }) {
   const { embeddedRunGroupFolds, externalRunGroupFolds } =
     runGroupFoldPlacements;
@@ -3459,13 +3454,16 @@ function ChatThreadEventGroups({
         const completedWorkExpanded =
           completedWorkFold !== null &&
           completedWorkExpandedKeys.has(completedWorkFold.key);
-        const waitingIndicatorMode =
-          group.beginEventId === waitingIndicatorAssistantGroupId &&
-          isWaitingThinkingIndicatorMode(thinkingIndicatorMode)
+        const runIndicatorMode =
+          group.beginEventId === runIndicatorAssistantGroupId &&
+          thinkingIndicatorMode !== null
             ? thinkingIndicatorMode
             : undefined;
         return (
-          <div key={group.beginEventId} className="contents">
+          <div
+            key={runWorkSection?.key ?? group.beginEventId}
+            className="contents"
+          >
             {runGroupFolds.map((runGroupFold) => {
               return (
                 <RunGroupFoldRow
@@ -3502,7 +3500,7 @@ function ChatThreadEventGroups({
                 runWorkExpandedKeys,
                 onToggleRunWork,
               )}
-              waitingIndicatorMode={waitingIndicatorMode}
+              runIndicatorMode={runIndicatorMode}
             />
           </div>
         );
@@ -3928,7 +3926,7 @@ function RunWorkSectionRow({
   const className =
     "mt-1.5 inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground";
   return (
-    <div data-chat-run-work className="-mx-2 @[900px]:-mb-[15px]">
+    <div data-chat-run-work className="-mx-2">
       {collapsible ? (
         <button
           type="button"
@@ -5073,6 +5071,7 @@ function AssistantThinkingStatusRow({
   serverThinkingLabel,
   thread,
   recommendedFollowupSource,
+  inAssistantGroup,
 }: {
   active: boolean;
   blockStyle: CSSProperties;
@@ -5082,10 +5081,33 @@ function AssistantThinkingStatusRow({
   serverThinkingLabel?: ServerThinkingLabel;
   thread: ChatPanelSignals;
   recommendedFollowupSource: RecommendedFollowupSource | null;
+  inAssistantGroup: boolean;
 }) {
   const thinkingIndicatorProps =
     active && !isQueued ? { "data-thinking-indicator": true } : {};
 
+  const content = active ? (
+    <InlineThinkingRow
+      blockStyle={blockStyle}
+      isQueued={isQueued}
+      spinnerEnabled={spinnerEnabled}
+      thinkingLabel={thinkingLabel}
+      serverThinkingLabel={serverThinkingLabel}
+    />
+  ) : (
+    <FinishedRunRow thread={thread} source={recommendedFollowupSource} />
+  );
+  if (inAssistantGroup) {
+    return (
+      <div
+        {...thinkingIndicatorProps}
+        data-role="assistant-thinking"
+        className="zero-thinking-enter min-w-0"
+      >
+        {content}
+      </div>
+    );
+  }
   return (
     <div
       {...thinkingIndicatorProps}
@@ -5093,19 +5115,7 @@ function AssistantThinkingStatusRow({
       className={RUN_SECTION_ROW_CLASS}
     >
       <div className="hidden @[900px]:block" />
-      <div className="min-w-0">
-        {active ? (
-          <InlineThinkingRow
-            blockStyle={blockStyle}
-            isQueued={isQueued}
-            spinnerEnabled={spinnerEnabled}
-            thinkingLabel={thinkingLabel}
-            serverThinkingLabel={serverThinkingLabel}
-          />
-        ) : (
-          <FinishedRunRow thread={thread} source={recommendedFollowupSource} />
-        )}
-      </div>
+      <div className="min-w-0">{content}</div>
     </div>
   );
 }
@@ -5205,6 +5215,7 @@ function ThinkingIndicator({
         serverThinkingLabel={serverThinkingLabel}
         thread={thread}
         recommendedFollowupSource={recommendedFollowupSource}
+        inAssistantGroup={inAssistantGroup}
       />
     );
   }
@@ -5988,7 +5999,7 @@ function PagedGroupRow({
   runGroupFolds,
   completedWorkFold,
   runWorkSection,
-  waitingIndicatorMode,
+  runIndicatorMode,
 }: {
   group: ChatEventGroup;
   thread: ChatPanelSignals;
@@ -5997,7 +6008,7 @@ function PagedGroupRow({
   runGroupFolds?: readonly RunGroupFoldControl[];
   completedWorkFold?: CompletedWorkFoldControl;
   runWorkSection?: RunWorkSectionControl;
-  waitingIndicatorMode?: WaitingThinkingIndicatorMode;
+  runIndicatorMode?: Exclude<ThinkingIndicatorMode, null>;
 }) {
   if (group.role === "user") {
     return (
@@ -6018,7 +6029,7 @@ function PagedGroupRow({
       runGroupFolds={runGroupFolds}
       completedWorkFold={completedWorkFold}
       runWorkSection={runWorkSection}
-      waitingIndicatorMode={waitingIndicatorMode}
+      runIndicatorMode={runIndicatorMode}
     />
   );
 }
@@ -6072,7 +6083,7 @@ function SelectablePagedGroupRow({
   runGroupFolds,
   completedWorkFold,
   runWorkSection,
-  waitingIndicatorMode,
+  runIndicatorMode,
 }: Parameters<typeof PagedGroupRow>[0]) {
   const { t } = useTranslation();
   const phase = useGet(thread.sharing.phase$);
@@ -6098,7 +6109,7 @@ function SelectablePagedGroupRow({
         runGroupFolds={runGroupFolds}
         completedWorkFold={completedWorkFold}
         runWorkSection={runWorkSection}
-        waitingIndicatorMode={waitingIndicatorMode}
+        runIndicatorMode={runIndicatorMode}
       />
     );
   }
@@ -6144,7 +6155,7 @@ function SelectablePagedGroupRow({
         runGroupFolds={runGroupFolds}
         completedWorkFold={completedWorkFold}
         runWorkSection={runWorkSection}
-        waitingIndicatorMode={waitingIndicatorMode}
+        runIndicatorMode={runIndicatorMode}
       />
       <Checkbox
         checked={checked}
@@ -7491,7 +7502,7 @@ type CompletedWorkFoldControl = {
   readonly onToggle: () => void;
 };
 
-type RunWorkSectionControl = Omit<RunWorkSection, "key" | "goalRunGroupId"> & {
+type RunWorkSectionControl = Omit<RunWorkSection, "key"> & {
   readonly expanded: boolean;
   readonly onToggle: () => void;
 };
@@ -7503,8 +7514,21 @@ type PagedAssistantGroupProps = {
   readonly runGroupFolds?: readonly RunGroupFoldControl[];
   readonly completedWorkFold?: CompletedWorkFoldControl;
   readonly runWorkSection?: RunWorkSectionControl;
-  readonly waitingIndicatorMode?: WaitingThinkingIndicatorMode;
+  readonly runIndicatorMode?: Exclude<ThinkingIndicatorMode, null>;
 };
+
+function visibleRunIndicatorMode(
+  mode: Exclude<ThinkingIndicatorMode, null> | undefined,
+  recommendedFollowupSource: RecommendedFollowupSource | null,
+): Exclude<ThinkingIndicatorMode, null> | undefined {
+  if (mode === undefined) {
+    return undefined;
+  }
+  if (mode === "finished" && recommendedFollowupSource === null) {
+    return undefined;
+  }
+  return mode;
+}
 
 type PagedAssistantTimelineItem =
   | {
@@ -7525,8 +7549,9 @@ type PagedAssistantTimelineItem =
       readonly control: RunWorkSectionControl;
     }
   | {
-      readonly kind: "run-work-preview";
+      readonly kind: "run-work-main";
       readonly event: EnrichedChatEvent;
+      readonly artifactCards: RunWorkSectionControl["remainingArtifactCards"];
     };
 
 function assistantTimelineItems(
@@ -7540,7 +7565,6 @@ function assistantTimelineItems(
 function foldedRunWorkTimelineItems(
   groups: readonly ChatEventGroup[],
   modelChanges: ReadonlyMap<string, RunModelChange>,
-  previewEventIds?: ReadonlySet<string>,
 ): PagedAssistantTimelineItem[] {
   return groups.flatMap((group) => {
     return group.events.flatMap((event): PagedAssistantTimelineItem[] => {
@@ -7549,76 +7573,10 @@ function foldedRunWorkTimelineItems(
         return [{ kind: "model-change", eventId: event.id, change }];
       }
       return isRenderableAssistantEvent(event)
-        ? [
-            previewEventIds?.has(event.id) === true
-              ? { kind: "run-work-preview", event }
-              : { kind: "assistant", event },
-          ]
+        ? [{ kind: "assistant", event }]
         : [];
     });
   });
-}
-
-const RUN_WORK_PREVIEW_BLOCK_TAGS: ReadonlySet<string> = new Set([
-  "address",
-  "blockquote",
-  "div",
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "li",
-  "ol",
-  "p",
-  "pre",
-  "table",
-  "tr",
-  "ul",
-]);
-
-function runWorkPreviewText(event: EnrichedChatEvent): string {
-  const tree = event.tree;
-  if (tree === undefined) {
-    return normalizedInlineLabel(event.content ?? "");
-  }
-  const parts: string[] = [];
-  const visit = (node: Root | Element): void => {
-    const block =
-      node.type === "element" && RUN_WORK_PREVIEW_BLOCK_TAGS.has(node.tagName);
-    if (block) {
-      parts.push(" ");
-    }
-    for (const child of node.children) {
-      if (child.type === "text" || child.type === "raw") {
-        parts.push(child.value);
-      } else if (child.type === "element") {
-        visit(child);
-      }
-    }
-    if (block) {
-      parts.push(" ");
-    }
-  };
-  visit(tree);
-  return normalizedInlineLabel(parts.join(""));
-}
-
-function RunWorkMessagePreview({ event }: { event: EnrichedChatEvent }) {
-  return (
-    <div
-      data-chat-run-work-preview
-      className="flex h-5 min-w-0 max-w-full items-center gap-2 text-[13px] leading-5 text-muted-foreground/60"
-    >
-      <span aria-hidden className="shrink-0">
-        •
-      </span>
-      <span className="min-w-0 flex-1 truncate whitespace-nowrap">
-        {runWorkPreviewText(event)}
-      </span>
-    </div>
-  );
 }
 
 function buildPagedAssistantTimeline({
@@ -7646,26 +7604,30 @@ function buildPagedAssistantTimeline({
     return items;
   }
 
-  items.push({ kind: "run-work", control: runWorkSection });
   const anchorIndex = group.events.findIndex((event) => {
     return event.id === runWorkSection.anchorEventId;
   });
-  const anchorEndIndex =
-    anchorIndex === -1 ? group.events.length : anchorIndex + 1;
+  if (anchorIndex === -1) {
+    items.push(...assistantTimelineItems(group.events));
+    return items;
+  }
+
+  items.push({ kind: "run-work", control: runWorkSection });
+  const anchorEndIndex = anchorIndex + 1;
   if (runWorkSection.expanded) {
     items.push(
       ...foldedRunWorkTimelineItems(runWorkSection.hiddenGroups, modelChanges),
     );
-  } else {
-    items.push(
-      ...foldedRunWorkTimelineItems(
-        runWorkSection.collapsedGroups,
-        modelChanges,
-        runWorkSection.previewEventIds,
-      ),
-    );
   }
-  items.push(...assistantTimelineItems(group.events.slice(0, anchorEndIndex)));
+  items.push(...assistantTimelineItems(group.events.slice(0, anchorIndex)));
+  const anchorEvent = group.events[anchorIndex];
+  if (anchorEvent !== undefined) {
+    items.push({
+      kind: "run-work-main",
+      event: anchorEvent,
+      artifactCards: runWorkSection.remainingArtifactCards,
+    });
+  }
   if (runWorkSection.expanded) {
     items.push(
       ...foldedRunWorkTimelineItems(
@@ -7681,9 +7643,11 @@ function buildPagedAssistantTimeline({
 function PagedAssistantTimeline({
   items,
   thread,
+  mainActions,
 }: {
   items: readonly PagedAssistantTimelineItem[];
   thread: ChatPanelSignals;
+  mainActions?: ReactNode;
 }) {
   let renderedAssistantItemCount = 0;
   return items.map((item) => {
@@ -7714,11 +7678,38 @@ function PagedAssistantTimeline({
         />
       );
     }
-    if (item.kind === "run-work-preview") {
-      return <RunWorkMessagePreview key={item.event.id} event={item.event} />;
-    }
     const compactTop = renderedAssistantItemCount > 0;
     renderedAssistantItemCount += 1;
+    if (item.kind === "run-work-main") {
+      return (
+        <div
+          key={item.event.id}
+          data-chat-run-work-main
+          className="flex min-w-0 flex-col gap-2"
+        >
+          <PagedAssistantEventItem
+            event={item.event}
+            compactTop={compactTop}
+            thread={thread}
+          />
+          {item.artifactCards.length === 0 ? null : (
+            <div
+              data-chat-run-work-remaining-artifacts
+              className="flex min-w-0 flex-col gap-2"
+            >
+              {item.artifactCards.map((card) => {
+                return (
+                  <div key={card.signals.url} className="zero-markdown-card">
+                    <MarkdownCardView card={card} />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          {mainActions}
+        </div>
+      );
+    }
     return (
       <PagedAssistantEventItem
         key={item.event.id}
@@ -7730,6 +7721,70 @@ function PagedAssistantTimeline({
   });
 }
 
+function PagedRunWorkAssistantContent({
+  group,
+  thread,
+  modelChanges,
+  completedWorkFold,
+  runWorkSection,
+  runIndicatorMode,
+}: Pick<
+  PagedAssistantGroupProps,
+  | "group"
+  | "thread"
+  | "modelChanges"
+  | "completedWorkFold"
+  | "runWorkSection"
+  | "runIndicatorMode"
+>) {
+  const recommendedFollowupSource =
+    useLastResolved(thread.recommendedFollowupSource$, {
+      equalityFn: equalRecommendedFollowupSources,
+    }) ?? null;
+  const timelineItems = buildPagedAssistantTimeline({
+    group,
+    modelChanges,
+    completedWorkFold,
+    runWorkSection,
+  });
+  const mainEvent = runWorkSection
+    ? group.events.find((event) => {
+        return event.id === runWorkSection.anchorEventId;
+      })
+    : undefined;
+  const visibleIndicatorMode = visibleRunIndicatorMode(
+    runIndicatorMode,
+    recommendedFollowupSource,
+  );
+  const mainActions =
+    runWorkSection !== undefined && visibleIndicatorMode === undefined ? (
+      <PagedGroupActions
+        group={group}
+        content={mainEvent?.content ?? ""}
+        thread={thread}
+        embedded
+      />
+    ) : undefined;
+
+  return (
+    <>
+      <PagedAssistantTimeline
+        items={timelineItems}
+        thread={thread}
+        mainActions={mainActions}
+      />
+      {visibleIndicatorMode === undefined ? null : (
+        <ThinkingIndicator
+          thread={thread}
+          mode={visibleIndicatorMode}
+          runGroupFolds={[]}
+          inAssistantGroup
+        />
+      )}
+    </>
+  );
+}
+
 function PagedAssistantGroup({
   group,
   thread,
@@ -7737,7 +7792,7 @@ function PagedAssistantGroup({
   runGroupFolds,
   completedWorkFold,
   runWorkSection,
-  waitingIndicatorMode,
+  runIndicatorMode,
 }: PagedAssistantGroupProps) {
   const hasRenderableEvent = group.events.some((event) => {
     return isRenderableAssistantEvent(event);
@@ -7764,12 +7819,8 @@ function PagedAssistantGroup({
     })
     .filter(Boolean)
     .join("\n\n");
-  const timelineItems = buildPagedAssistantTimeline({
-    group,
-    modelChanges,
-    completedWorkFold: visibleCompletedWorkFold,
-    runWorkSection: visibleRunWorkSection,
-  });
+  const usesRunWorkPresentation =
+    visibleRunWorkSection !== undefined || runIndicatorMode !== undefined;
 
   return (
     <div
@@ -7787,18 +7838,35 @@ function PagedAssistantGroup({
               <RunGroupFoldRow key={fold.fold.key} control={fold} embedded />
             );
           })}
-          <PagedAssistantTimeline items={timelineItems} thread={thread} />
-          {waitingIndicatorMode === undefined ? null : (
-            <ThinkingIndicator
+          {usesRunWorkPresentation ? (
+            <PagedRunWorkAssistantContent
+              group={group}
               thread={thread}
-              mode={waitingIndicatorMode}
-              runGroupFolds={[]}
-              inAssistantGroup
+              modelChanges={modelChanges}
+              completedWorkFold={visibleCompletedWorkFold}
+              runWorkSection={visibleRunWorkSection}
+              runIndicatorMode={runIndicatorMode}
+            />
+          ) : (
+            <PagedAssistantTimeline
+              items={buildPagedAssistantTimeline({
+                group,
+                modelChanges,
+                completedWorkFold: visibleCompletedWorkFold,
+                runWorkSection: undefined,
+              })}
+              thread={thread}
             />
           )}
         </div>
       </div>
-      <PagedGroupActions group={group} content={fullContent} thread={thread} />
+      {visibleRunWorkSection === undefined ? (
+        <PagedGroupActions
+          group={group}
+          content={fullContent}
+          thread={thread}
+        />
+      ) : null}
     </div>
   );
 }
@@ -8088,10 +8156,12 @@ function PagedGroupActions({
   group,
   content,
   thread,
+  embedded = false,
 }: {
   group: ChatEventGroup;
   content: string;
   thread: ChatPanelSignals;
+  embedded?: boolean;
 }) {
   const pageSignal = useGet(pageSignal$);
   const copiedId = useGet(thread.copiedEventId$);
@@ -8122,18 +8192,24 @@ function PagedGroupActions({
     );
   };
 
+  const actions = (
+    <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS}>
+      <PagedGroupPrimaryActions
+        firstRunId={firstRunId}
+        hasContent={hasContent}
+        usage={usage}
+        copied={copied}
+        onCopy={handleCopy}
+      />
+    </div>
+  );
+  if (embedded) {
+    return actions;
+  }
   return (
     <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS}>
       <div className="hidden @[900px]:block" />
-      <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS}>
-        <PagedGroupPrimaryActions
-          firstRunId={firstRunId}
-          hasContent={hasContent}
-          usage={usage}
-          copied={copied}
-          onCopy={handleCopy}
-        />
-      </div>
+      {actions}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -7757,7 +7757,9 @@ function PagedRunWorkAssistantContent({
     recommendedFollowupSource,
   );
   const mainActions =
-    runWorkSection !== undefined && visibleIndicatorMode === undefined ? (
+    runWorkSection !== undefined &&
+    (visibleIndicatorMode === undefined ||
+      visibleIndicatorMode === "finished") ? (
       <PagedGroupActions
         group={group}
         content={mainEvent?.content ?? ""}


### PR DESCRIPTION
## Summary

- derive `ChatRunWorkFolding` entirely from `output.message` events, including run groups with multiple runs
- keep the last output message as the main result and carry forward ordered, unique historical artifact cards that are absent from the final output
- render completed output in the stable `message -> remaining artifacts -> action bar` order while keeping running and follow-up tails in the run section
- preserve the legacy run-group folding, completed-work folding, global thinking tail, external action row, and spacing when the feature switch is disabled

## Behavior covered

- zero, one, and multiple output-message runs
- Markdown messages that render text, images, artifact cards, and action cards without affecting fold boundaries
- artifact URL deduplication and final-output subtraction across a grouped run
- active, waiting, completed, cancelled, model-change, sharing, locator, scroll, and usage behavior
- explicit `ChatRunWorkFolding=false` coverage for legacy run-group projection and action/thinking DOM placement

## Verification

- `corepack pnpm exec prettier --check <11 changed files>`
- `corepack pnpm --filter @okouai/app exec oxlint --deny-warnings <11 changed files>`
- `corepack pnpm --filter @okouai/app exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings <11 changed files>`
- `corepack pnpm --filter @okouai/app exec eslint <11 changed files> --max-warnings 0 --cache --cache-strategy content --cache-location .eslintcache`
- `corepack pnpm exec knip --workspace @okouai/app --no-progress --include files,exports,types,unresolved`
- `corepack pnpm --filter @okouai/app exec vitest run src/views/okou-page/__tests__/chat-run-history.test.tsx src/views/okou-page/__tests__/chat-capability-run-history.test.tsx src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx src/views/okou-page/__tests__/chat-run-goal-history.test.tsx src/views/okou-page/__tests__/chat-sharing.test.tsx src/views/okou-page/__tests__/chat-engagement-telemetry.test.tsx src/views/okou-page/__tests__/chat-conversation-locator.test.tsx src/views/okou-page/__tests__/chat-scroll.test.tsx src/views/okou-page/__tests__/chat-capability-goals.test.tsx src/views/okou-page/__tests__/chat-history.test.tsx src/views/okou-page/__tests__/chat-capability-message-actions.test.tsx src/views/okou-page/__tests__/chat-run-usage-localization.test.tsx --maxWorkers=1` (12 files, 77 tests)

Full app Knip also reports the pre-existing `@typescript/native` dev dependency from `origin/main`; this PR does not modify package dependencies.
