### PR TITLE
chore(connectors): retire account rollout switch

### DIFF
--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -72,7 +72,7 @@ if grep -R -Fq '/api/test/' "$RUNNER_TESTS" "${RUNNER_HELPERS[@]}"; then
 fi
 grep -Fq 'REAL_CLAUDE_MODEL="claude-sonnet-5"' "$REAL_CLAUDE_TEST" ||
   fail "real Claude E2E must select Sonnet 5"
-if [[ "$(grep -Fc '"$REAL_CLAUDE_MODEL"' "$REAL_CLAUDE_TEST")" -ne 3 ]]; then
+if [[ "$(grep -Fc "\"\$REAL_CLAUDE_MODEL\"" "$REAL_CLAUDE_TEST")" -ne 3 ]]; then
   fail "real Claude E2E must use its model pin for policy, smoke, and steer coverage"
 fi
 if grep -Fq 'claude-sonnet-4-6' "$REAL_CLAUDE_TEST"; then
@@ -457,9 +457,6 @@ unless bootstrap_steps.any? do |step|
       step.dig("with", "name") == "e2e-tokens"
   end
   raise "runner bootstrap must download the token artifact"
-end
-if bootstrap_steps.any? { |step| step["run"]&.include?("connectorAccounts") }
-  raise "runner bootstrap must not configure the retired connector account switch"
 end
 model_defaults_step = bootstrap_steps.find do |step|
   step["name"] == "Reset runner model defaults"

--- a/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
+++ b/.github/scripts/tests/turbo-playwright-runner-workflow-test.sh
@@ -458,26 +458,8 @@ unless bootstrap_steps.any? do |step|
   end
   raise "runner bootstrap must download the token artifact"
 end
-connector_accounts_step = bootstrap_steps.find do |step|
-  step["name"] == "Enable runner connector account coverage"
-end
-raise "missing runner connector account bootstrap" unless connector_accounts_step
-connector_accounts_script = connector_accounts_step.fetch("run")
-unless connector_accounts_step.fetch("shell") == "bash" &&
-    connector_accounts_script.include?('/api/feature-switches') &&
-    connector_accounts_script.include?(
-      '{"switches":{"connectorAccounts":true}}',
-    ) &&
-    connector_accounts_script.include?(
-      '.effectiveSwitches.connectorAccounts == true',
-    )
-  raise "runner connector account bootstrap must enable and verify the public feature switch"
-end
-unless connector_accounts_step.dig(
-    "env",
-    "VERCEL_AUTOMATION_BYPASS_SECRET",
-  ) == "${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}"
-  raise "runner connector account bootstrap must receive the preview bypass secret"
+if bootstrap_steps.any? { |step| step["run"]&.include?("connectorAccounts") }
+  raise "runner bootstrap must not configure the retired connector account switch"
 end
 model_defaults_step = bootstrap_steps.find do |step|
   step["name"] == "Reset runner model defaults"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2589,23 +2589,6 @@ jobs:
           echo "::add-mask::$token"
           echo "E2E_API_TOKEN=$token" >> "$GITHUB_ENV"
           echo "E2E_API_URL=$api_url" >> "$GITHUB_ENV"
-      - name: Enable runner connector account coverage
-        shell: bash
-        run: |
-          set -euo pipefail
-          headers=(-H "Authorization: Bearer ${E2E_API_TOKEN}" -H "Content-Type: application/json")
-          if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
-            headers+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
-          fi
-
-          curl -fsS "${headers[@]}" \
-            -X POST \
-            -d '{"switches":{"connectorAccounts":true}}' \
-            "${E2E_API_URL}/api/feature-switches" \
-            | jq -e '.effectiveSwitches.connectorAccounts == true' \
-            >/dev/null
-        env:
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       - name: Reset runner model defaults
         shell: bash
         run: |

--- a/e2e/tests/03-runner/run-t23-custom-connector.bats
+++ b/e2e/tests/03-runner/run-t23-custom-connector.bats
@@ -8,12 +8,6 @@ setup() {
     runner_e2e_require_environment
     runner_e2e_setup_test
     CUSTOM_CONNECTOR_ID=""
-
-    local feature_switches
-    feature_switches="$(runner_api_curl "/api/feature-switches")"
-    jq -e '.effectiveSwitches.connectorAccounts == true' \
-        <<<"$feature_switches" \
-        >/dev/null
 }
 
 teardown() {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1457,12 +1457,6 @@ async function selectedThreadConnectorFixture(
   title: string,
 ): Promise<SelectedThreadConnectorFixture> {
   const entitled = await entitledChatActor();
-  const orgId = requireOrgId(entitled.actor);
-  await updateFeatureSwitchesForUser(
-    context,
-    { userId: entitled.actor.userId, orgId },
-    { [FeatureSwitchKey.ConnectorAccounts]: true },
-  );
   await installApiTestConnectorCatalog({
     catalogVersion: `api-test-thread-runtime-overlap-${randomUUID()}`,
     runtimeProjection: true,
@@ -1670,11 +1664,6 @@ describe("CHAT-02: thread connector account selection", () => {
     if (!actor.orgId) {
       throw new Error("Expected an organization-scoped chat actor");
     }
-    await updateFeatureSwitchesForUser(
-      context,
-      { userId: actor.userId, orgId: actor.orgId },
-      { [FeatureSwitchKey.ConnectorAccounts]: true },
-    );
     const connection = await connectors.connectManualGrant(
       actor,
       "openai",
@@ -1766,11 +1755,6 @@ describe("CHAT-02: thread connector account selection", () => {
     if (!orgId) {
       throw new Error("Expected an organization-scoped chat actor");
     }
-    await updateFeatureSwitchesForUser(
-      context,
-      { userId: actor.userId, orgId },
-      { [FeatureSwitchKey.ConnectorAccounts]: true },
-    );
     const connection = await connectors.connectManualGrant(
       actor,
       "openai",
@@ -1874,7 +1858,6 @@ describe("CHAT-02: thread connector account selection", () => {
       context,
       { userId: actor.userId, orgId },
       {
-        [FeatureSwitchKey.ConnectorAccounts]: true,
         [FeatureSwitchKey.CustomConnectorMcp]: true,
       },
     );
@@ -1979,11 +1962,6 @@ describe("CHAT-02: thread connector account selection", () => {
     if (!orgId) {
       throw new Error("Expected an organization-scoped chat actor");
     }
-    await updateFeatureSwitchesForUser(
-      context,
-      { userId: actor.userId, orgId },
-      { [FeatureSwitchKey.ConnectorAccounts]: true },
-    );
     const customConnector = await connectors.createCustomConnector(
       actor,
       manualHttpCustomConnectorCreateBody({
@@ -2071,11 +2049,6 @@ describe("CHAT-02: thread connector account selection", () => {
     if (!orgId) {
       throw new Error("Expected an organization-scoped chat actor");
     }
-    await updateFeatureSwitchesForUser(
-      context,
-      { userId: actor.userId, orgId },
-      { [FeatureSwitchKey.ConnectorAccounts]: true },
-    );
     const connection = await connectors.connectManualGrant(
       actor,
       "openai",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -193,9 +193,7 @@ async function readCreatedThreadEvent(threadId: string, token: string) {
 describe("POST /api/zero/chat-threads", () => {
   it("resolves only sparse connector selections during account deletion", async () => {
     const fixture = await seedAgent();
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await updateFeatureSwitchesForUser(context, fixture, {});
     const firstResponse = await connectorApi.requestManualGrant(
       fixture.actor,
       "openai",
@@ -350,9 +348,7 @@ describe("POST /api/zero/chat-threads", () => {
 
   it("creates and reads an exact built-in connector account selection", async () => {
     const fixture = await seedAgent();
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await updateFeatureSwitchesForUser(context, fixture, {});
     const connection = await connectorApi.connectManualGrant(
       fixture.actor,
       "openai",
@@ -426,11 +422,6 @@ describe("POST /api/zero/chat-threads", () => {
     );
 
     const foreignActor = bdd.user({ orgId: fixture.orgId });
-    await updateFeatureSwitchesForUser(
-      context,
-      { userId: foreignActor.userId, orgId: fixture.orgId },
-      { [FeatureSwitchKey.ConnectorAccounts]: true },
-    );
     await store.set(
       seedOrgMembership$,
       { orgId: fixture.orgId, userId: foreignActor.userId },
@@ -582,84 +573,9 @@ describe("POST /api/zero/chat-threads", () => {
     expect(afterDisconnect.body.selections).toStrictEqual([]);
   });
 
-  it("rejects connector selections while connector accounts are disabled", async () => {
-    const fixture = await seedAgent();
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.ConnectorAccounts]: false,
-    });
-    const connection = await connectorApi.connectManualGrant(
-      fixture.actor,
-      "openai",
-      "api-token",
-      { apiKey: "disabled-openai-key" },
-      fixture.agentId,
-    );
-    const token = okouToken({
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-      capabilities: ["chat-thread:read", "chat-thread:write"],
-    });
-
-    const response = await accept(
-      threadsClient().create({
-        headers: { authorization: `Bearer ${token}` },
-        body: {
-          agentId: fixture.agentId,
-          model: WORKSPACE_DEFAULT_MODEL,
-          connectorSelections: [
-            {
-              connectionId: connection.id,
-              target: { kind: "builtin", connectorSlug: "openai" },
-            },
-          ],
-        },
-      }),
-      [404],
-    );
-    expect(response.body.error.code).toBe("NOT_FOUND");
-
-    const legacyCreated = await accept(
-      threadsClient().create({
-        headers: { authorization: `Bearer ${token}` },
-        body: {
-          agentId: fixture.agentId,
-          model: WORKSPACE_DEFAULT_MODEL,
-        },
-      }),
-      [201],
-    );
-    await accept(
-      connectorSelectionsClient().get({
-        headers: { authorization: `Bearer ${token}` },
-        params: { id: legacyCreated.body.id },
-      }),
-      [404],
-    );
-    await accept(
-      connectorSelectionsClient().update({
-        headers: { authorization: `Bearer ${token}` },
-        params: { id: legacyCreated.body.id },
-        body: {
-          connectionId: connection.id,
-          target: { kind: "builtin", connectorSlug: "openai" },
-        },
-      }),
-      [404],
-    );
-    await accept(
-      connectorSelectionsClient().clear({
-        headers: { authorization: `Bearer ${token}` },
-        params: { id: legacyCreated.body.id },
-        body: { kind: "builtin", connectorSlug: "openai" },
-      }),
-      [404],
-    );
-  });
-
   it("creates exact custom HTTP and MCP connector selections", async () => {
     const fixture = await seedAgent();
     await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
       [FeatureSwitchKey.CustomConnectorMcp]: true,
     });
     const httpConnector = await connectorApi.createCustomConnector(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -20,7 +20,6 @@ import {
   type SupportedRunModel,
 } from "@okouai/api-contracts/contracts/model-providers";
 import { goalsContract } from "@okouai/api-contracts/contracts/goals";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { createApp } from "../../../app-factory";
 import { stubTestTimezone } from "../../../__tests__/env-stub";
@@ -71,7 +70,6 @@ import {
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { chatEventDisplayText } from "./helpers/chat-event";
-import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { createRouteMocks } from "./helpers/route-test";
 import { seedVm0BuiltInDefaultModelKey } from "./helpers/runtime-state";
 import {
@@ -3643,10 +3641,6 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     if (!actor.orgId) {
       throw new Error("Expected an entitled chat actor with an organization");
     }
-    const actorWithOrg = { ...actor, orgId: actor.orgId };
-    await updateFeatureSwitchesForUser(context, actorWithOrg, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const objectStore = chatCallbacks.acceptChatObjectStorage();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -100,22 +100,6 @@ function customConnectorValuesClient() {
   return setupApp({ context, routes })(customConnectorValuesContract);
 }
 
-async function setConnectorAccountsEnabled(
-  fixture: Fixture,
-  enabled: boolean,
-): Promise<void> {
-  mocks.clerk.session(fixture.userId, fixture.orgId);
-  await accept(
-    featureClient().update({
-      headers: authHeaders(),
-      body: {
-        switches: { [FeatureSwitchKey.ConnectorAccounts]: enabled },
-      },
-    }),
-    [200],
-  );
-}
-
 async function cleanupFixture(fixture: Fixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
   for (const connectorSlug of ["openai", "github"] as const) {
@@ -207,15 +191,14 @@ describe("connector account lifecycle routes", () => {
     return fixture;
   }
 
-  it("hides canonical account resources while the feature is disabled", async () => {
-    const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, false);
+  it("exposes canonical account resources without feature setup", async () => {
+    await seedFixture();
     const response = await accept(
       accountClient().summaries({ headers: authHeaders() }),
-      [404],
+      [200],
     );
 
-    expect(response.body.error.message).toBe("Resource not found");
+    expect(response.body.summaries).toStrictEqual([]);
     const exact = await accept(
       accountClient().connection({
         headers: authHeaders(),
@@ -224,15 +207,15 @@ describe("connector account lifecycle routes", () => {
       }),
       [404],
     );
-    expect(exact.body.error.message).toBe("Resource not found");
+    expect(exact.body.error.message).toBe("Connector account not found");
     const inspection = await accept(
       accountClient().inspect({
         headers: authHeaders(),
         body: { selections: [] },
       }),
-      [404],
+      [200],
     );
-    expect(inspection.body.error.message).toBe("Resource not found");
+    expect(inspection.body.results).toStrictEqual([]);
     const scopeDiff = await accept(
       accountClient().scopeDiff({
         headers: authHeaders(),
@@ -241,12 +224,11 @@ describe("connector account lifecycle routes", () => {
       }),
       [404],
     );
-    expect(scopeDiff.body.error.message).toBe("Resource not found");
+    expect(scopeDiff.body.error.message).toBe("Connector account not found");
   });
 
   it("reviews requested scopes for one exact account across default changes", async () => {
     const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, true);
     const currentScopes = ["repo", "project", "workflow"] as const;
     const staleId = await seedConnectorStorageRow(context, {
       orgId: fixture.orgId,
@@ -401,8 +383,7 @@ describe("connector account lifecycle routes", () => {
       }),
       [404],
     );
-    const foreign = await seedFixture();
-    await setConnectorAccountsEnabled(foreign, true);
+    await seedFixture();
     await accept(
       accountClient().scopeDiff({
         headers: authHeaders(),
@@ -432,8 +413,7 @@ describe("connector account lifecycle routes", () => {
   });
 
   it("inspects only exact owned accounts without leaking credentials", async () => {
-    const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, true);
+    await seedFixture();
     const connected = await accept(
       connectorClient().connect({
         headers: authHeaders(),
@@ -499,7 +479,6 @@ describe("connector account lifecycle routes", () => {
 
   it("requires connector read capability for account inspection", async () => {
     const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, true);
     mockClerkMembership(
       context,
       {
@@ -537,8 +516,7 @@ describe("connector account lifecycle routes", () => {
   });
 
   it("accepts one bounded inspection batch and rejects a larger one", async () => {
-    const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, true);
+    await seedFixture();
     const selection = {
       connectionId: randomUUID(),
       target: { kind: "builtin" as const, connectorSlug: "openai" },
@@ -583,8 +561,7 @@ describe("connector account lifecycle routes", () => {
   });
 
   it("adds siblings and manages exact default and deletion lifecycle", async () => {
-    const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, true);
+    await seedFixture();
 
     const first = await accept(
       connectorClient().connect({
@@ -777,8 +754,7 @@ describe("connector account lifecycle routes", () => {
   });
 
   it("keeps concurrent sibling creation to exactly one default", async () => {
-    const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, true);
+    await seedFixture();
 
     const responses = await Promise.all(
       ["Concurrent A", "Concurrent B"].map((displayName) => {
@@ -834,8 +810,7 @@ describe("connector account lifecycle routes", () => {
   });
 
   it("reuses an explicit single account and rejects an ambiguous target", async () => {
-    const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, true);
+    await seedFixture();
 
     const first = await accept(
       connectorClient().connect({
@@ -919,8 +894,7 @@ describe("connector account lifecycle routes", () => {
   });
 
   it("serializes concurrent single-account writes and disconnects", async () => {
-    const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, true);
+    await seedFixture();
 
     const responses = await Promise.all(
       ["first", "second"].map((suffix) => {
@@ -990,8 +964,7 @@ describe("connector account lifecycle routes", () => {
   });
 
   it("paginates and searches more than one hundred accounts", async () => {
-    const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, true);
+    await seedFixture();
 
     const createdAccountIds: string[] = [];
     for (let index = 0; index < 101; index += 1) {
@@ -1132,7 +1105,6 @@ describe("connector account lifecycle routes", () => {
 
   it("does not enumerate or mutate another member account", async () => {
     const owner = await seedFixture();
-    await setConnectorAccountsEnabled(owner, true);
     const account = await accept(
       connectorClient().connect({
         headers: authHeaders(),
@@ -1146,7 +1118,6 @@ describe("connector account lifecycle routes", () => {
       [200],
     );
     const other = await seedFixture({ orgId: owner.orgId });
-    await setConnectorAccountsEnabled(other, true);
     mocks.clerk.session(other.userId, other.orgId);
 
     const listed = await accept(
@@ -1203,8 +1174,7 @@ describe("connector account lifecycle routes", () => {
       [404],
     );
 
-    const outsider = await seedFixture();
-    await setConnectorAccountsEnabled(outsider, true);
+    await seedFixture();
     const crossOrganization = await accept(
       accountClient().inspect({
         headers: authHeaders(),
@@ -1224,7 +1194,6 @@ describe("connector account lifecycle routes", () => {
 
   it("treats a removed built-in catalog target as absent", async () => {
     const fixture = await seedFixture();
-    await setConnectorAccountsEnabled(fixture, true);
     const accountId = await seedConnectorStorageRow(context, {
       orgId: fixture.orgId,
       userId: fixture.userId,
@@ -1312,7 +1281,6 @@ describe("connector account lifecycle routes", () => {
           headers: authHeaders(),
           body: {
             switches: {
-              [FeatureSwitchKey.ConnectorAccounts]: true,
               [FeatureSwitchKey.CustomConnectorMcp]: true,
             },
           },
@@ -1448,7 +1416,6 @@ describe("connector account lifecycle routes", () => {
           headers: authHeaders(),
           body: {
             switches: {
-              [FeatureSwitchKey.ConnectorAccounts]: true,
               [FeatureSwitchKey.CustomConnectorMcp]: true,
             },
           },

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -7,7 +7,6 @@
 import { Buffer } from "node:buffer";
 
 import { HttpResponse, http } from "msw";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
@@ -495,9 +494,7 @@ describe("CONN-02: external-code session lifecycle", () => {
   it("replays the exact non-default account added by an external-code session", async () => {
     const provider = mockAwsExternalCodeProvider();
     const actor = awsActor();
-    await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectorsApi.updateFeatureSwitches(actor, {});
 
     const defaultSession = await connectorsApi.startExternalCode(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
@@ -117,15 +117,31 @@ async function deleteConnector(
   connectorSlug: (typeof CONNECTOR_SLUGS_TO_CLEAN_UP)[number],
 ): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
-  await accept(
-    setupApp({ context, routes: connectorAccountRoutes })(
-      connectorAccountsContract,
-    ).disconnectSingleAccount({
-      headers: authHeaders(),
-      body: { target: { kind: "builtin", connectorSlug } },
-    }),
-    [204, 404],
+  const client = setupApp({ context, routes: connectorAccountRoutes })(
+    connectorAccountsContract,
   );
+  while (true) {
+    const listed = await accept(
+      client.connections({
+        headers: authHeaders(),
+        query: { kind: "builtin", connectorSlug, limit: 50 },
+      }),
+      [200],
+    );
+    if (listed.body.connections.length === 0) {
+      return;
+    }
+    for (const connection of listed.body.connections) {
+      await accept(
+        client.delete({
+          headers: authHeaders(),
+          params: { connectionId: connection.id },
+          body: { target: { kind: "builtin", connectorSlug } },
+        }),
+        [200, 404],
+      );
+    }
+  }
 }
 
 async function cleanupFixture(fixture: AuthenticatedFixture): Promise<void> {
@@ -408,11 +424,8 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     });
   });
 
-  it("accepts CLI add and reconnect while preserving account errors", async () => {
+  it("accepts CLI add and reconnect while preserving sibling accounts", async () => {
     const fixture = await seedFixture();
-    await updateFeatureSwitches(fixture, {
-      [FeatureSwitchKey.ConnectorAccounts]: false,
-    });
     const client = setupApp({ context, routes: connectorsRoutes })(
       connectorManualGrantContract,
     );
@@ -454,11 +467,24 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         },
         headers: cliAuthHeaders(),
       }),
-      [409],
+      [200],
     );
-    expect(sibling.body.error.message).toBe(
-      "Additional connector accounts are not enabled yet",
+    expect(sibling.body.id).not.toBe(added.body.id);
+    const accounts = await accept(
+      setupApp({ context, routes: connectorAccountRoutes })(
+        connectorAccountsContract,
+      ).connections({
+        headers: authHeaders(),
+        query: { kind: "builtin", connectorSlug: "openai" },
+      }),
+      [200],
     );
+    expect(
+      accounts.body.connections.map(({ id }) => {
+        return id;
+      }),
+    ).toStrictEqual(expect.arrayContaining([added.body.id, sibling.body.id]));
+    expect(accounts.body.connections).toHaveLength(2);
 
     const missing = await accept(
       client.connect({
@@ -512,11 +538,8 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     expect(stored.body.id).toBe(added.body.id);
   });
 
-  it("serializes concurrent first-account adds", async () => {
-    const fixture = await seedFixture();
-    await updateFeatureSwitches(fixture, {
-      [FeatureSwitchKey.ConnectorAccounts]: false,
-    });
+  it("allows concurrent first-account adds", async () => {
+    await seedFixture();
     const client = setupApp({ context, routes: connectorsRoutes })(
       connectorManualGrantContract,
     );
@@ -539,7 +562,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
           return response.status;
         })
         .sort(),
-    ).toStrictEqual([200, 409]);
+    ).toStrictEqual([200, 200]);
   });
 
   it("connects Zendesk manual grant fields through the API", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -586,14 +586,11 @@ describe("CONN-02: OAuth start and callback", () => {
     expect(failedConnector.body.error.code).toBe("NOT_FOUND");
   });
 
-  it("restores explicit single-account and reconnect intents across OAuth callbacks", async () => {
+  it("preserves legacy intents and allows explicit sibling adds across OAuth callbacks", async () => {
     mockGitHubConnectorOAuth();
 
     const bdd = createBddApi(context);
     const actor = bdd.user();
-    await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: false,
-    });
     const initialStart = await connectorsApi.startOauth(
       actor,
       "github",
@@ -675,18 +672,25 @@ describe("CONN-02: OAuth start and callback", () => {
       externalId: initialConnection.externalId,
     });
 
-    const siblingAdd = await connectorsApi.requestOauthStart(
+    const siblingAdd = await connectorsApi.startOauth(
       actor,
       "github",
       "oauth",
-      {
-        statuses: [409],
-        authorizeAgent: true,
-        account: { intent: "add", displayName: "Personal" },
-      },
+      undefined,
+      { intent: "add", displayName: "Personal" },
     );
-    expectApiError(siblingAdd.body);
-    expect(siblingAdd.body.error.code).toBe("CONFLICT");
+    await connectorsApi.completeOauthCallback("github", {
+      code: "github-sibling-account-code",
+      state: stateFromAuthorizationUrl(siblingAdd.authorizationUrl),
+    });
+    const accounts = await connectorsApi.listBuiltinConnectorAccounts(
+      actor,
+      "github",
+    );
+    expect(accounts).toHaveLength(2);
+    expect(accounts).toContainEqual(
+      expect.objectContaining({ displayName: "Personal", isDefault: false }),
+    );
   });
 
   it("persists the callback-selected Datadog site through the public OAuth flow", async () => {
@@ -1003,7 +1007,6 @@ describe("CONN-02: OAuth device authorization", () => {
     const provider = mockTestOAuthDeviceConnectorProvider();
     const actor = createBddApi(context).user();
     await connectorsApi.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
       [FeatureSwitchKey.TestOauthConnector]: true,
     });
 
@@ -2392,7 +2395,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
   it("uses explicit single-account semantics for HTTP and MCP custom connectors", async () => {
     const admin = createBddApi(context).user({ orgRole: "org:admin" });
     await connectorsApi.updateFeatureSwitches(admin, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
       [FeatureSwitchKey.CustomConnectorMcp]: true,
     });
     const definitions = [
@@ -2828,9 +2830,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
               initialScope: tokenScope,
             });
       const admin = createBddApi(context).user({ orgRole: "org:admin" });
-      await connectorsApi.updateFeatureSwitches(admin, {
-        [FeatureSwitchKey.ConnectorAccounts]: true,
-      });
+      await connectorsApi.updateFeatureSwitches(admin, {});
       const connector = await connectorsApi.createCustomConnector(admin, {
         displayName: `BDD OAuth Scope ${randomUUID()}`,
         prefixTemplates: [
@@ -3352,7 +3352,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     });
     await connectorsApi.updateFeatureSwitches(admin, {
       [FeatureSwitchKey.CustomConnectorMcp]: true,
-      [FeatureSwitchKey.ConnectorAccounts]: true,
     });
     const connector = await connectorsApi.createCustomConnector(admin, {
       kind: "mcp",
@@ -3437,7 +3436,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     });
     await connectorsApi.updateFeatureSwitches(admin, {
       [FeatureSwitchKey.CustomConnectorMcp]: true,
-      [FeatureSwitchKey.ConnectorAccounts]: true,
     });
     const connector = await connectorsApi.createCustomConnector(admin, {
       kind: "mcp",
@@ -3643,7 +3641,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     const admin = createBddApi(context).user({ orgRole: "org:admin" });
     await connectorsApi.updateFeatureSwitches(admin, {
       [FeatureSwitchKey.CustomConnectorMcp]: true,
-      [FeatureSwitchKey.ConnectorAccounts]: true,
     });
     const connector = await connectorsApi.createCustomConnector(admin, {
       kind: "mcp",
@@ -3820,7 +3817,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     const admin = createBddApi(context).user({ orgRole: "org:admin" });
     await connectorsApi.updateFeatureSwitches(admin, {
       [FeatureSwitchKey.CustomConnectorMcp]: true,
-      [FeatureSwitchKey.ConnectorAccounts]: true,
     });
     const connector = await connectorsApi.createCustomConnector(admin, {
       kind: "mcp",
@@ -4038,7 +4034,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     const admin = createBddApi(context).user({ orgRole: "org:admin" });
     await connectorsApi.updateFeatureSwitches(admin, {
       [FeatureSwitchKey.CustomConnectorMcp]: true,
-      [FeatureSwitchKey.ConnectorAccounts]: true,
     });
     const connector = await connectorsApi.createCustomConnector(admin, {
       kind: "mcp",
@@ -4084,7 +4079,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     const admin = bdd.user({ orgRole: "org:admin" });
     await connectorsApi.updateFeatureSwitches(admin, {
       [FeatureSwitchKey.CustomConnectorMcp]: true,
-      [FeatureSwitchKey.ConnectorAccounts]: true,
     });
     const definition = {
       kind: "mcp" as const,

--- a/turbo/apps/api/src/signals/routes/__tests__/custom-connectors-oauth2.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/custom-connectors-oauth2.test.ts
@@ -1,7 +1,6 @@
 import { randomBytes, randomUUID } from "node:crypto";
 
 import type { CreateCustomConnectorBody } from "@okouai/api-contracts/contracts/custom-connectors";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
@@ -217,9 +216,7 @@ describe("Custom connector OAuth public-brand callbacks", () => {
       initialScope: "read",
     });
     const actor = createBddApi(context).user({ orgRole: "org:admin" });
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(actor, {});
     const connector = await createCustomOAuthConnector(actor, provider);
     const legacyRedirectUri = "https://app.vm0.ai/connectors/custom/callback";
     const state = `okou.${randomBytes(32).toString("hex")}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -4226,7 +4226,6 @@ describe("Feishu integration", () => {
     const fixture = await setupFeishuRunFixture();
     const { actor, runnerGroup, appId, callbackUrl } = fixture;
     await enableFeishuIntegration(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
       [FeatureSwitchKey.OkouDebug]: true,
     });
     await connectFixtureUser(fixture);

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -371,7 +371,7 @@ async function expectExactFeishuMemberConnector(args: {
   const unlinkedStart = await oauthApp.request(appConnectUrl);
   expect(unlinkedStart.status).toBe(400);
   await expect(unlinkedStart.json()).resolves.toStrictEqual({
-    error: "Additional connector accounts are not enabled yet",
+    error: "This connector does not support additional accounts",
   });
   const unlinked = await accept(
     args.client.getStatus({

--- a/turbo/apps/api/src/signals/routes/__tests__/github-oauth-account-mutations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/github-oauth-account-mutations.test.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
@@ -118,9 +117,7 @@ describe("GitHub OAuth account mutation selection", () => {
   it("adds a new identity and refreshes the exact existing sibling", async () => {
     await installApiTestConnectorCatalog();
     const actor = bdd.user();
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(actor, {});
 
     await connectGithubAdd(actor, {
       code: "github-first-add",
@@ -188,9 +185,7 @@ describe("GitHub OAuth account mutation selection", () => {
   it("serializes concurrent callbacks for the same new identity", async () => {
     await installApiTestConnectorCatalog();
     const actor = bdd.user();
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(actor, {});
     mockGitHubConnectorOAuth({ userId: 303, login: "github-concurrent" });
 
     const [first, second] = await Promise.all([
@@ -229,12 +224,8 @@ describe("GitHub OAuth account mutation selection", () => {
     await installApiTestConnectorCatalog();
     const firstActor = bdd.user();
     const secondActor = bdd.user();
-    await connectors.updateFeatureSwitches(firstActor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
-    await connectors.updateFeatureSwitches(secondActor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(firstActor, {});
+    await connectors.updateFeatureSwitches(secondActor, {});
 
     await connectGithubAdd(firstActor, {
       code: "github-first-owner",
@@ -269,9 +260,7 @@ describe("GitHub OAuth account mutation selection", () => {
   it("fails closed when historical rows duplicate an owned identity", async () => {
     await installApiTestConnectorCatalog();
     const actor = bdd.user();
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(actor, {});
     await connectGithubAdd(actor, {
       code: "github-duplicate-first",
       displayName: "Duplicate first",
@@ -342,9 +331,7 @@ describe("GitHub OAuth account mutation selection", () => {
   it("uses the same exact-identity selection for GitHub App setup", async () => {
     await installApiTestConnectorCatalog();
     const actor = bdd.user();
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(actor, {});
     await connectGithubAdd(actor, {
       code: "github-before-setup-first",
       displayName: "Before setup first",
@@ -397,9 +384,7 @@ describe("GitHub OAuth account mutation selection", () => {
     });
 
     const siblingActor = bdd.user();
-    await connectors.updateFeatureSwitches(siblingActor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(siblingActor, {});
     await connectGithubAdd(siblingActor, {
       code: "github-before-setup-sibling",
       displayName: "Existing before setup",

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -4,7 +4,6 @@ import { randomUUID } from "node:crypto";
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { testMailDraftStateContract } from "@okouai/api-contracts/contracts/test-mail-draft-state";
 import { mailContract } from "@okouai/api-contracts/contracts/mail";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -405,9 +404,7 @@ async function addGmailAccount(
     readonly subject: string;
   },
 ): Promise<string> {
-  await connectors.updateFeatureSwitches(fixture.actor, {
-    [FeatureSwitchKey.ConnectorAccounts]: true,
-  });
+  await connectors.updateFeatureSwitches(fixture.actor, {});
   mockGmailConnectorOAuth(args);
   const start = await connectors.startOauth(
     fixture.actor,
@@ -534,9 +531,7 @@ describe("POST /api/mail/drafts/link", () => {
   it("uses a healthy Gmail connection with unknown historical grants", async () => {
     const fixture = await seedGmailMailCardFixture();
     await setGmailOAuthScopeFacts(fixture, null);
-    await connectors.updateFeatureSwitches(fixture.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(fixture.actor, {});
     const gmail = mockGmailDraftApi();
 
     await expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mcp-connectors.test.ts
@@ -147,7 +147,6 @@ describe("GET /api/mcp-connectors", () => {
     });
     await connectors.updateFeatureSwitches(actor, {
       [FeatureSwitchKey.CustomConnectorMcp]: true,
-      [FeatureSwitchKey.ConnectorAccounts]: true,
     });
     const selected = await connectors.createCustomConnector(
       actor,
@@ -329,7 +328,6 @@ describe("GET /api/mcp-connectors", () => {
     await runs.ensureOrgModelProvider(actor);
     await connectors.updateFeatureSwitches(actor, {
       [FeatureSwitchKey.CustomConnectorMcp]: true,
-      [FeatureSwitchKey.ConnectorAccounts]: true,
     });
     const agent = await bdd.createAgent(actor, {
       displayName: "MCP exact identity Agent",
@@ -529,7 +527,6 @@ describe("POST /api/mcp-connectors/:id/oauth2/reauthorize", () => {
       });
       await connectors.updateFeatureSwitches(actor, {
         [FeatureSwitchKey.CustomConnectorMcp]: true,
-        [FeatureSwitchKey.ConnectorAccounts]: true,
       });
       const connector = await connectors.createCustomConnector(actor, {
         kind: "mcp",

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -4586,7 +4586,6 @@ describe.sequential("Official Workflow installations", () => {
       context,
       { orgId: actor.orgId, userId: actor.userId },
       {
-        [FeatureSwitchKey.ConnectorAccounts]: true,
         [FeatureSwitchKey.OfficialWorkflows]: true,
       },
     );
@@ -5782,9 +5781,7 @@ describe.sequential("Official Workflow installations", () => {
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId: actor.orgId },
-      {
-        [FeatureSwitchKey.ConnectorAccounts]: true,
-      },
+      {},
     );
     const firstAccessToken = `calendar-transition-first-${suffix}`;
     const secondAccessToken = `calendar-transition-second-${suffix}`;
@@ -6778,11 +6775,6 @@ describe.sequential("Official Workflow installations", () => {
       await cleanupCatalog();
     });
     await setOfficialWorkflowsEnabled(actor, true);
-    await updateFeatureSwitchesForUser(
-      context,
-      { orgId: actor.orgId, userId: actor.userId },
-      { [FeatureSwitchKey.ConnectorAccounts]: true },
-    );
 
     const firstAccountSpec = {
       code: `meet-race-first-${suffix}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -9826,9 +9826,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(actor, {});
 
     const connected = await connectors.connectManualGrant(
       actor,
@@ -9946,9 +9944,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await installApiTestConnectorCatalog();
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(actor, {});
     const connected = await connectors.connectManualGrant(
       actor,
       "lark",
@@ -12469,9 +12465,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     const connectors = createConnectorBddApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(actor, {});
 
     const custom = await connectors.createCustomConnector(actor, {
       displayName: "BDD OAuth 2.0 Runtime API",
@@ -15578,40 +15572,17 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     await api.requestCancelRun(actor, gatedOn.runId, [200]);
   });
 
-  it("advertises connector account switching only while the feature is enabled", async () => {
+  it("advertises connector account switching", async () => {
     const api = createRunsApi(context);
-    const connectors = createConnectorBddApi(context);
     const { actor, agentId } = await entitledRunActor();
 
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: false,
-    });
-    const gatedOff = await api.createRun(actor, {
-      agentId,
-      prompt: "switch my connector account",
-      modelProvider: "anthropic-api-key",
-    });
-    const gatedOffPrompt =
-      (await api.readRun(actor, gatedOff.runId)).appendSystemPrompt ?? "";
-    expect(gatedOffPrompt).not.toContain(
-      "okou connector account switch-request",
-    );
-    expect(gatedOffPrompt).toContain("return that exact URL verbatim");
-    expect(gatedOffPrompt).toContain(
-      "Never rewrite, shorten, reconstruct, or omit any query parameters",
-    );
-    await api.requestCancelRun(actor, gatedOff.runId, [200]);
-
-    await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
-    const gatedOn = await api.createRun(actor, {
+    const run = await api.createRun(actor, {
       agentId,
       prompt: "switch my connector account",
       modelProvider: "anthropic-api-key",
     });
     const appendSystemPrompt =
-      (await api.readRun(actor, gatedOn.runId)).appendSystemPrompt ?? "";
+      (await api.readRun(actor, run.runId)).appendSystemPrompt ?? "";
     expect(appendSystemPrompt).toContain(
       "okou connector account list <slug> --json",
     );
@@ -15631,7 +15602,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
       "only after the user confirms and the selection succeeds",
     );
 
-    await api.requestCancelRun(actor, gatedOn.runId, [200]);
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("advertises managed SEO tools by default", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -679,9 +679,7 @@ describe("Stripe automation event webhook", () => {
 
   it("uses the exact Stripe source without persisting a thread override", async () => {
     const scenario = await setupScenario();
-    await connectors.updateFeatureSwitches(scenario.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(scenario.actor, {});
     await runs.enableAgentConnectors(scenario.actor, scenario.agentId, [
       "stripe",
     ]);
@@ -720,9 +718,7 @@ describe("Stripe automation event webhook", () => {
     if (!orgId) {
       throw new Error("Expected an organization-scoped workflow owner");
     }
-    await connectors.updateFeatureSwitches(scenario.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(scenario.actor, {});
     await runs.enableAgentConnectors(scenario.actor, scenario.agentId, [
       "stripe",
     ]);
@@ -860,9 +856,7 @@ describe("Stripe automation event webhook", () => {
     if (!orgId) {
       throw new Error("Expected an organization-scoped workflow owner");
     }
-    await connectors.updateFeatureSwitches(scenario.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(scenario.actor, {});
     await runs.enableAgentConnectors(scenario.actor, scenario.agentId, [
       "stripe",
     ]);
@@ -936,9 +930,7 @@ describe("Stripe automation event webhook", () => {
     if (!orgId) {
       throw new Error("Expected an organization-scoped workflow owner");
     }
-    await connectors.updateFeatureSwitches(scenario.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(scenario.actor, {});
     await runs.enableAgentConnectors(scenario.actor, scenario.agentId, [
       "stripe",
     ]);
@@ -1102,9 +1094,7 @@ describe("Stripe automation event webhook", () => {
 
   it("falls back when a queued event's Stripe source is deleted", async () => {
     const scenario = await setupScenario();
-    await connectors.updateFeatureSwitches(scenario.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await connectors.updateFeatureSwitches(scenario.actor, {});
     await runs.enableAgentConnectors(scenario.actor, scenario.agentId, [
       "stripe",
     ]);
@@ -1614,9 +1604,7 @@ describe("Stripe automation event webhook", () => {
       if (!orgId) {
         throw new Error("Expected an organization-scoped workflow owner");
       }
-      await connectors.updateFeatureSwitches(scenario.actor, {
-        [FeatureSwitchKey.ConnectorAccounts]: true,
-      });
+      await connectors.updateFeatureSwitches(scenario.actor, {});
       await runs.enableAgentConnectors(scenario.actor, scenario.agentId, [
         "stripe",
       ]);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -943,7 +943,6 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       const { actor, headers } = await firewallRun();
       await connectors.updateFeatureSwitches(actor, {
         [FeatureSwitchKey.CustomConnectorMcp]: true,
-        [FeatureSwitchKey.ConnectorAccounts]: true,
       });
       const mcp = await connectors.createCustomConnector(actor, {
         kind: "mcp",

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -15,7 +15,6 @@ import {
   workflowAutomationsContract,
   type WorkflowAutomationSummary,
 } from "@okouai/api-contracts/contracts/workflows";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
@@ -656,9 +655,7 @@ interface MultiAccountGmailTestFixture extends GmailTestFixture {
 
 async function setupMultiAccountGmailFixture(): Promise<MultiAccountGmailTestFixture> {
   const fixture = await setupFixture();
-  await updateFeatureSwitchesForUser(context, fixture.actor, {
-    [FeatureSwitchKey.ConnectorAccounts]: true,
-  });
+  await updateFeatureSwitchesForUser(context, fixture.actor, {});
   const firstEmail = uniqueGmailEmail();
   const secondEmail = uniqueGmailEmail();
   const firstConnectorId = await connectGmail(
@@ -1759,9 +1756,7 @@ describe("POST /api/webhooks/gmail", () => {
     configureGmailEnv();
     const recorder = configureGmailWatchLifecycleMock();
     const { actor, agentId, workflowId } = await setupFixture();
-    await updateFeatureSwitchesForUser(context, actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await updateFeatureSwitchesForUser(context, actor, {});
     const firstConnectorId = await connectGmail(
       actor,
       uniqueGmailEmail(),

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -3,7 +3,6 @@ import { createHash } from "node:crypto";
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { expect, onTestFinished } from "vitest";
 
@@ -607,9 +606,7 @@ describe("POST /api/webhooks/google-calendar", () => {
 
     const scenario = await setupFixture();
     const { runnerGroup, workflowId } = scenario;
-    await updateFeatureSwitchesForUser(context, scenario.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await updateFeatureSwitchesForUser(context, scenario.actor, {});
     await connectGoogleCalendar(scenario);
     const created = await accept(
       automationsClient().create({
@@ -736,9 +733,7 @@ describe("POST /api/webhooks/google-calendar", () => {
     });
 
     const scenario = await setupFixture();
-    await updateFeatureSwitchesForUser(context, scenario.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await updateFeatureSwitchesForUser(context, scenario.actor, {});
     mockGoogleCalendarConnectorOAuth({
       accessToken: firstAccessToken,
       email: "calendar-first@example.com",
@@ -852,9 +847,7 @@ describe("POST /api/webhooks/google-calendar", () => {
     });
 
     const scenario = await setupFixture();
-    await updateFeatureSwitchesForUser(context, scenario.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await updateFeatureSwitchesForUser(context, scenario.actor, {});
     mockGoogleCalendarConnectorOAuth({
       accessToken: firstAccessToken,
       email: "calendar-admission-first@example.com",
@@ -939,9 +932,7 @@ describe("POST /api/webhooks/google-calendar", () => {
     });
 
     const scenario = await setupFixture();
-    await updateFeatureSwitchesForUser(context, scenario.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await updateFeatureSwitchesForUser(context, scenario.actor, {});
     mockGoogleCalendarConnectorOAuth({
       accessToken: firstAccessToken,
       email: "calendar-lifecycle-first@example.com",
@@ -1126,9 +1117,7 @@ describe("POST /api/webhooks/google-calendar", () => {
       resourcePrefix: "calendar-cleanup-abort",
     });
     const scenario = await setupFixture();
-    await updateFeatureSwitchesForUser(context, scenario.actor, {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
-    });
+    await updateFeatureSwitchesForUser(context, scenario.actor, {});
 
     mockGoogleCalendarConnectorOAuth({
       accessToken,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
@@ -338,7 +338,6 @@ async function setupGoogleFormsAutomation() {
     { orgId: actor.orgId, userId: actor.userId },
     {
       [FeatureSwitchKey.GoogleFormsWorkflowAutomations]: true,
-      [FeatureSwitchKey.ConnectorAccounts]: true,
     },
   );
   mockGoogleFormsConnectorOAuth();
@@ -695,7 +694,6 @@ describe("Google Forms Pub/Sub webhook", () => {
       { orgId: actor.orgId, userId: actor.userId },
       {
         [FeatureSwitchKey.GoogleFormsWorkflowAutomations]: true,
-        [FeatureSwitchKey.ConnectorAccounts]: true,
       },
     );
     mockGoogleFormsConnectorOAuth();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-workspace-events.test.ts
@@ -11,7 +11,6 @@ import {
   workflowAutomationsContract,
   workflowsDetailContract,
 } from "@okouai/api-contracts/contracts/workflows";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
 
@@ -27,7 +26,6 @@ import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
 import { chatEventDisplayText } from "./helpers/chat-event";
-import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import {
   clearWorkflowAutomationEventConnectorAsPreviousApi,
   holdOrgAdmissionLock,
@@ -465,11 +463,6 @@ async function setupFixture(
     agentId: agent.agentId,
     name: `google-meet-transcript-${randomUUID()}`,
   });
-  await updateFeatureSwitchesForUser(
-    context,
-    { orgId: orgActor.orgId, userId: orgActor.userId },
-    { [FeatureSwitchKey.ConnectorAccounts]: true },
-  );
   const connectorId = await connectGoogleMeet(orgActor, provider);
   context.mocks.s3.send.mockResolvedValue({});
   return {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
@@ -122,7 +122,6 @@ async function enableNotionWorkflowAutomations(
 ): Promise<void> {
   await updateFeatureSwitchesForUser(context, fixture, {
     [FeatureSwitchKey.NotionWorkflowAutomations]: true,
-    [FeatureSwitchKey.ConnectorAccounts]: true,
   });
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflows.test.ts
@@ -1375,9 +1375,7 @@ describe("workflows", () => {
     await updateFeatureSwitchesForUser(
       context,
       { ...actor, orgId: actor.orgId },
-      {
-        [FeatureSwitchKey.ConnectorAccounts]: true,
-      },
+      {},
     );
     const sourceAgent = await createAgent(actor, {
       displayName: "Gmail Copy Source Agent",
@@ -1529,11 +1527,6 @@ describe("workflows", () => {
       );
     }
     await api.grantProEntitlement(actor, { tier: "team" });
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.ConnectorAccounts]: true },
-    );
     const sourceAgent = await createAgent(actor, {
       displayName: "Calendar Copy Source Agent",
       visibility: "private",
@@ -1657,7 +1650,6 @@ describe("workflows", () => {
       context,
       { ...actor, orgId: actor.orgId },
       {
-        [FeatureSwitchKey.ConnectorAccounts]: true,
         [FeatureSwitchKey.NotionWorkflowAutomations]: true,
       },
     );
@@ -1878,7 +1870,6 @@ describe("workflows", () => {
       context,
       { ...actor, orgId: actor.orgId },
       {
-        [FeatureSwitchKey.ConnectorAccounts]: true,
         [FeatureSwitchKey.StripeInvoicePaidWorkflowAutomations]: true,
       },
     );
@@ -2019,7 +2010,6 @@ describe("workflows", () => {
       context,
       { ...actor, orgId: actor.orgId },
       {
-        [FeatureSwitchKey.ConnectorAccounts]: true,
         [FeatureSwitchKey.GoogleFormsWorkflowAutomations]: true,
       },
     );

--- a/turbo/apps/api/src/signals/routes/chat-threads-connector-selections.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-connector-selections.ts
@@ -1,7 +1,5 @@
 import { command, computed } from "ccstate";
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { badRequestMessage, notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -15,24 +13,14 @@ import {
   listChatThreadConnectorSelections,
   updateChatThreadConnectorSelection,
 } from "../services/chat-thread-connector-selection.service";
-import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event.service";
 import { reconcileGoogleCalendarWatchesForUser } from "../services/google-calendar-automation-event.service";
 import { reconcileGoogleFormsWatchesForUser } from "../services/google-forms-automation-event.service";
 import { reconcileGoogleMeetSubscriptionsForUser } from "../services/google-meet-automation-event.service";
 import type { RouteEntry } from "../route-entry";
 
-const connectorAccountsEnabled$ = computed(async (get) => {
-  const auth = get(organizationAuthContext$);
-  const context = await get(userFeatureSwitchContext(auth.orgId, auth.userId));
-  return isFeatureEnabled(FeatureSwitchKey.ConnectorAccounts, context);
-});
-
 const getSelectionsInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
-  if (!(await get(connectorAccountsEnabled$))) {
-    return notFound("Resource not found");
-  }
   const params = get(pathParamsOf(chatThreadConnectorSelectionContract.get));
   const result = await listChatThreadConnectorSelections(get(db$), {
     orgId: auth.orgId,
@@ -54,9 +42,6 @@ const getSelectionsInner$ = computed(async (get): Promise<unknown> => {
 const updateSelectionInner$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
     const auth = get(organizationAuthContext$);
-    if (!(await get(connectorAccountsEnabled$))) {
-      return notFound("Resource not found");
-    }
     const params = get(
       pathParamsOf(chatThreadConnectorSelectionContract.update),
     );
@@ -124,9 +109,6 @@ const updateSelectionInner$ = command(
 const clearSelectionInner$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
     const auth = get(organizationAuthContext$);
-    if (!(await get(connectorAccountsEnabled$))) {
-      return notFound("Resource not found");
-    }
     const params = get(
       pathParamsOf(chatThreadConnectorSelectionContract.clear),
     );

--- a/turbo/apps/api/src/signals/routes/chat-threads-create.ts
+++ b/turbo/apps/api/src/signals/routes/chat-threads-create.ts
@@ -9,8 +9,6 @@ import {
   isImageModelId,
   type ImageModelId,
 } from "@okouai/api-contracts/contracts/image-models";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 
@@ -29,7 +27,6 @@ import {
 } from "../services/model-selection.service";
 import { chatThreadModelPinColumns } from "../services/chat-thread-model.service";
 import { chatThreadServiceTierFromCodex } from "../services/chat-thread-event.service";
-import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import type { RouteEntry } from "../route-entry";
 
 const createBody$ = bodyResultOf(chatThreadsContract.create);
@@ -106,20 +103,6 @@ const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const writeDb = set(writeDb$);
   const connectorSelections = body.data.connectorSelections ?? [];
-  if (connectorSelections.length > 0) {
-    const featureSwitchContext = await get(
-      userFeatureSwitchContext(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !isFeatureEnabled(
-        FeatureSwitchKey.ConnectorAccounts,
-        featureSwitchContext,
-      )
-    ) {
-      return notFound("Resource not found");
-    }
-  }
   const callerRunId =
     auth.tokenType === "sandbox" || auth.tokenType === "agent"
       ? auth.runId

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -4,8 +4,6 @@ import {
   connectorAccountsContract,
   type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
@@ -34,19 +32,12 @@ import {
   disconnectCustomConnector$,
   integrationManagedCustomConnectorMutationForbidden,
 } from "../services/custom-connector.service";
-import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event.service";
 import { reconcileGoogleCalendarWatchesForUser } from "../services/google-calendar-automation-event.service";
 import { reconcileGoogleFormsWatchesForUser } from "../services/google-forms-automation-event.service";
 import { reconcileGoogleMeetSubscriptionsForUser } from "../services/google-meet-automation-event.service";
 
 const log = logger("api:connector-account-mutation");
-
-const connectorAccountsEnabled$ = computed(async (get) => {
-  const auth = get(organizationAuthContext$);
-  const context = await get(userFeatureSwitchContext(auth.orgId, auth.userId));
-  return isFeatureEnabled(FeatureSwitchKey.ConnectorAccounts, context);
-});
 
 function targetFromQuery(
   query: ConnectorAccountTarget,
@@ -58,9 +49,6 @@ function targetFromQuery(
 
 const inspectInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  if (!(await get(connectorAccountsEnabled$))) {
-    return notFound("Resource not found");
-  }
   const body = await get(bodyResultOf(connectorAccountsContract.inspect));
   if (!body.ok) {
     return body.response;
@@ -108,18 +96,12 @@ const inspectInner$ = computed(async (get) => {
 
 const summariesInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  if (!(await get(connectorAccountsEnabled$))) {
-    return notFound("Resource not found");
-  }
   const summaries = await listConnectorAccountSummaries(get(db$), auth);
   return { status: 200 as const, body: { summaries: [...summaries] } };
 });
 
 const connectionsInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  if (!(await get(connectorAccountsEnabled$))) {
-    return notFound("Resource not found");
-  }
   const query = get(queryOf(connectorAccountsContract.connections));
   const result = await listConnectorAccountsForTarget(get(db$), {
     orgId: auth.orgId,
@@ -152,9 +134,6 @@ const connectionsInner$ = computed(async (get) => {
 
 const connectionInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  if (!(await get(connectorAccountsEnabled$))) {
-    return notFound("Resource not found");
-  }
   const params = get(pathParamsOf(connectorAccountsContract.connection));
   const query = get(queryOf(connectorAccountsContract.connection));
   const account = await getConnectorAccount(get(db$), {
@@ -170,9 +149,6 @@ const connectionInner$ = computed(async (get) => {
 
 const scopeDiffInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  if (!(await get(connectorAccountsEnabled$))) {
-    return notFound("Resource not found");
-  }
   const params = get(pathParamsOf(connectorAccountsContract.scopeDiff));
   const query = get(queryOf(connectorAccountsContract.scopeDiff));
   const diff = await get(
@@ -191,9 +167,6 @@ const scopeDiffInner$ = computed(async (get) => {
 const renameInner$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
     const auth = get(organizationAuthContext$);
-    if (!(await get(connectorAccountsEnabled$))) {
-      return notFound("Resource not found");
-    }
     const params = get(pathParamsOf(connectorAccountsContract.rename));
     const body = await get(bodyResultOf(connectorAccountsContract.rename));
     signal.throwIfAborted();
@@ -234,9 +207,6 @@ const renameInner$ = command(
 const setDefaultInner$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
     const auth = get(organizationAuthContext$);
-    if (!(await get(connectorAccountsEnabled$))) {
-      return notFound("Resource not found");
-    }
     const params = get(pathParamsOf(connectorAccountsContract.setDefault));
     const body = await get(bodyResultOf(connectorAccountsContract.setDefault));
     signal.throwIfAborted();
@@ -314,9 +284,6 @@ const setDefaultInner$ = command(
 
 const deletionImpactInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
-  if (!(await get(connectorAccountsEnabled$))) {
-    return notFound("Resource not found");
-  }
   const params = get(pathParamsOf(connectorAccountsContract.deletionImpact));
   const query = get(queryOf(connectorAccountsContract.deletionImpact));
   const request = {
@@ -462,9 +429,6 @@ const disconnectSingleAccountInner$ = command(
 const deleteInner$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
     const auth = get(organizationAuthContext$);
-    if (!(await get(connectorAccountsEnabled$))) {
-      return notFound("Resource not found");
-    }
     const params = get(pathParamsOf(connectorAccountsContract.delete));
     const body = await get(bodyResultOf(connectorAccountsContract.delete));
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -121,7 +121,7 @@ function connectorAccountMutationFailureResponse(
   if (kind === "ambiguous" || kind === "accountAmbiguous") {
     return conflict("Multiple connector accounts require an exact choice");
   }
-  return conflict("Additional connector accounts are not enabled yet");
+  return conflict("This connector does not support additional accounts");
 }
 
 type ActionGrantKind =

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -62,9 +62,7 @@ import {
   buildConnectorOpenIdAuthUrlWithMethod,
   prepareConnectorOpenIdAuthStartWithMethod,
 } from "./connector-openid-auth-start";
-import { connectorAccountSiblingWritesEnabled } from "../services/connector-account-mutation.service";
 import { resolveConnectorConnectionMutation } from "../services/connector-connection-write.service";
-import { userFeatureSwitchContext } from "../services/feature-switches.service";
 import { insertConnectorOAuthState } from "../services/connector-oauth-state.service";
 
 const connectorReadAuth = {
@@ -510,10 +508,6 @@ const startConnectorOauthInner$ = command(
     });
     signal.throwIfAborted();
 
-    const featureSwitchContext = await get(
-      userFeatureSwitchContext(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
     const writeDb = set(writeDb$);
     const mutationStart = await writeDb.transaction(async (tx) => {
       const resolution = await resolveConnectorConnectionMutation(tx, {
@@ -521,8 +515,7 @@ const startConnectorOauthInner$ = command(
         userId: auth.userId,
         target: { kind: "builtin", connectorSlug: resolved.connectorSlug },
         mutation: bodyResult.data.account,
-        allowSiblings:
-          connectorAccountSiblingWritesEnabled(featureSwitchContext),
+        allowSiblings: true,
       });
       if (resolution.kind !== "ready") {
         return { resolution, connectionId: null };
@@ -641,10 +634,6 @@ const startConnectorOpenIdInner$ = command(
     });
     signal.throwIfAborted();
 
-    const featureSwitchContext = await get(
-      userFeatureSwitchContext(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
     const writeDb = set(writeDb$);
     const mutationStart = await writeDb.transaction(async (tx) => {
       const resolution = await resolveConnectorConnectionMutation(tx, {
@@ -652,8 +641,7 @@ const startConnectorOpenIdInner$ = command(
         userId: auth.userId,
         target: { kind: "builtin", connectorSlug: resolved.connectorSlug },
         mutation: bodyResult.data.account,
-        allowSiblings:
-          connectorAccountSiblingWritesEnabled(featureSwitchContext),
+        allowSiblings: true,
       });
       if (resolution.kind !== "ready") {
         return { resolution, connectionId: null };

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -9288,7 +9288,6 @@ async function resolvePreparedThreadConnectorSelections(
     readonly db: Db;
     readonly createArgs: CreateAgentRunArgs;
     readonly connectorScope: EffectiveConnectorScope;
-    readonly featureSwitchContext: FeatureSwitchContext;
   },
   signal: AbortSignal,
 ): Promise<ThreadConnectorSelectionIds | CreateRunErrorResult | undefined> {
@@ -9345,7 +9344,6 @@ async function prepareRunRuntimeContext(
         db: args.db,
         createArgs: args.createArgs,
         connectorScope: args.connectorScope,
-        featureSwitchContext,
       },
       signal,
     ),

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -9293,13 +9293,7 @@ async function resolvePreparedThreadConnectorSelections(
   signal: AbortSignal,
 ): Promise<ThreadConnectorSelectionIds | CreateRunErrorResult | undefined> {
   const chatThreadId = args.createArgs.chatThreadId;
-  if (
-    chatThreadId === undefined ||
-    !isFeatureEnabled(
-      FeatureSwitchKey.ConnectorAccounts,
-      args.featureSwitchContext,
-    )
-  ) {
+  if (chatThreadId === undefined) {
     return undefined;
   }
   const resolved = await resolveChatThreadConnectorSelections(args.db, {

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -440,7 +440,6 @@ function buildAgentToolsPrompt(args: {
   readonly triggerSource: TriggerSource;
   readonly cloudBrowserEnabled: boolean | undefined;
   readonly bankingEnabled: boolean;
-  readonly connectorAccountsEnabled: boolean;
   readonly introVideoEnabled: boolean;
   readonly presentationScreenshotEnabled: boolean;
   readonly presentationTemplatesEnabled: boolean;
@@ -503,12 +502,8 @@ function buildAgentToolsPrompt(args: {
       : []),
     "- Static web artifacts can be published with `okou host <dir> --site <slug> [--spa]`; for HTML presentations, include `--artifact-kind presentation-html`; run `okou host --help` for details.",
     "- Third-party services (GitHub, Slack, Notion, 100+ more) are accessed via connectors that expose environment names like `GH_TOKEN`. Find: `okou connector search <keyword>`. List connected: `okou connector list`. Inspect: `okou connector status <slug>`.",
-    ...(args.connectorAccountsEnabled
-      ? [
-          "- Connector accounts: inspect the current account with `okou connector status <slug> --json` and list alternatives with `okou connector account list <slug> --json`. Use only an exact `connectionId` returned by these commands; never invent an ID or reuse one from another connector.",
-          "- Request one account switch in the current web chat with `okou connector account switch-request <slug> --connection-id <uuid> --callback-prompt <prompt>`. This changes only the current thread's override for future runs, not the current run or global default. Keep the callback prompt concise and do not include secrets because it is included in the URL. Share the returned link and end the turn; Okou starts the callback round only after the user confirms and the selection succeeds.",
-        ]
-      : []),
+    "- Connector accounts: inspect the current account with `okou connector status <slug> --json` and list alternatives with `okou connector account list <slug> --json`. Use only an exact `connectionId` returned by these commands; never invent an ID or reuse one from another connector.",
+    "- Request one account switch in the current web chat with `okou connector account switch-request <slug> --connection-id <uuid> --callback-prompt <prompt>`. This changes only the current thread's override for future runs, not the current run or global default. Keep the callback prompt concise and do not include secrets because it is included in the URL. Share the returned link and end the turn; Okou starts the callback round only after the user confirms and the selection succeeds.",
     "- Custom connectors: when the user wants to add their own custom connector, run `okou connector custom -h` first and follow its guidance.",
     "- Model availability and provider routing are workspace model settings, separate from connectors. Use `okou model ls` to list allowed models, `okou model switch` for model-switching guidance, and `okou model-provider ls` to inspect built-in/BYOK routing.",
     "- Credit diagnostics: use `okou doctor credit` when a run or generation fails with insufficient credits, when the user asks how to recharge, or before buying credits. It reports the org balance, tier, purchase eligibility, current user admin status, and org admins. If it says credit purchases are unavailable, do not run `okou credit`.",
@@ -586,7 +581,6 @@ function buildAppendSystemPrompt(args: {
   readonly triggerSource: TriggerSource;
   readonly cloudBrowserEnabled: boolean | undefined;
   readonly bankingEnabled: boolean;
-  readonly connectorAccountsEnabled: boolean;
   readonly introVideoEnabled: boolean;
   readonly presentationScreenshotEnabled: boolean;
   readonly presentationTemplatesEnabled: boolean;
@@ -600,7 +594,6 @@ function buildAppendSystemPrompt(args: {
       triggerSource: args.triggerSource,
       cloudBrowserEnabled: args.cloudBrowserEnabled,
       bankingEnabled: args.bankingEnabled,
-      connectorAccountsEnabled: args.connectorAccountsEnabled,
       introVideoEnabled: args.introVideoEnabled,
       presentationScreenshotEnabled: args.presentationScreenshotEnabled,
       presentationTemplatesEnabled: args.presentationTemplatesEnabled,
@@ -786,7 +779,6 @@ function createRunBody(args: {
   readonly appendSystemPrompt: string | undefined;
   readonly cloudBrowserEnabled: boolean | undefined;
   readonly bankingEnabled: boolean;
-  readonly connectorAccountsEnabled: boolean;
   readonly introVideoEnabled: boolean;
   readonly presentationScreenshotEnabled: boolean;
   readonly presentationTemplatesEnabled: boolean;
@@ -800,7 +792,6 @@ function createRunBody(args: {
     triggerSource,
     cloudBrowserEnabled: args.cloudBrowserEnabled,
     bankingEnabled: args.bankingEnabled,
-    connectorAccountsEnabled: args.connectorAccountsEnabled,
     introVideoEnabled: args.introVideoEnabled,
     presentationScreenshotEnabled: args.presentationScreenshotEnabled,
     presentationTemplatesEnabled: args.presentationTemplatesEnabled,
@@ -1001,10 +992,6 @@ function buildZeroCreateAgentRunArgs(args: {
       cloudBrowserEnabled: args.cloudBrowserEnabled,
       bankingEnabled: isFeatureEnabled(
         FeatureSwitchKey.Banking,
-        args.featureSwitchContext,
-      ),
-      connectorAccountsEnabled: isFeatureEnabled(
-        FeatureSwitchKey.ConnectorAccounts,
         args.featureSwitchContext,
       ),
       introVideoEnabled: isFeatureEnabled(

--- a/turbo/apps/api/src/signals/services/connector-account-mutation.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-mutation.service.ts
@@ -2,11 +2,6 @@ import {
   connectorAccountMutationIntentSchema,
   type ConnectorAccountMutationIntent,
 } from "@okouai/api-contracts/contracts/connector-accounts";
-import {
-  isFeatureEnabled,
-  type FeatureSwitchContext,
-} from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { sql, type SQLWrapper } from "drizzle-orm";
 
 import { zodDriverValueDecoder } from "../../lib/db-structured-result";
@@ -18,12 +13,6 @@ const storedConnectorAccountMutationDecoder = zodDriverValueDecoder(
 export type ConnectorAccountMutation =
   | { readonly intent: "target-only-client-singleton" }
   | ConnectorAccountMutationIntent;
-
-export function connectorAccountSiblingWritesEnabled(
-  context: FeatureSwitchContext,
-): boolean {
-  return isFeatureEnabled(FeatureSwitchKey.ConnectorAccounts, context);
-}
 
 export function normalizeConnectorAccountMutation(
   intent: ConnectorAccountMutationIntent | undefined,

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -110,10 +110,7 @@ import {
   type ConnectorConnectionMutationResolution,
   type StoredConnectorConnectionRow as StoredConnectorRow,
 } from "./connector-connection-write.service";
-import {
-  connectorAccountSiblingWritesEnabled,
-  normalizeConnectorAccountMutation,
-} from "./connector-account-mutation.service";
+import { normalizeConnectorAccountMutation } from "./connector-account-mutation.service";
 import { reprojectWorkflowAutomationsForOwner } from "./workflow-automation-account-projection.service";
 
 const log = logger("api:connector-data");
@@ -1506,9 +1503,7 @@ async function commitManualGrantConnector(
       connectorSlug: args.runtimeMethod.connectorSlug,
     },
     mutation: normalizeConnectorAccountMutation(args.account),
-    allowSiblings: connectorAccountSiblingWritesEnabled(
-      args.featureSwitchContext,
-    ),
+    allowSiblings: true,
   });
   signal.throwIfAborted();
   if (resolution.kind !== "ready") {
@@ -1699,8 +1694,7 @@ export const connectNoAuthConnector$ = command(
           connectorSlug: args.runtimeMethod.connectorSlug,
         },
         mutation: normalizeConnectorAccountMutation(args.account),
-        allowSiblings:
-          connectorAccountSiblingWritesEnabled(featureSwitchContext),
+        allowSiblings: true,
       });
       signal.throwIfAborted();
       if (resolution.kind !== "ready") {
@@ -2360,9 +2354,7 @@ async function commitConnectorTokenConnection(
       connectorSlug: args.runtimeMethod.connectorSlug,
     },
     mutation,
-    allowSiblings: connectorAccountSiblingWritesEnabled(
-      args.featureSwitchContext,
-    ),
+    allowSiblings: true,
     matchExternalId: authorizedExternalIdForMutation({
       mutation,
       matchExistingExternalIdentity: args.matchExistingExternalIdentity,

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -184,7 +184,7 @@ export function connectorConnectionWriteFailureMessage(
       return "Multiple connector accounts require an exact choice";
     }
     case "siblingDisabled": {
-      return "Additional connector accounts are not enabled yet";
+      return "This connector does not support additional accounts";
     }
   }
 }

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -1008,7 +1008,7 @@ export const startConnectorExternalCodeSession$ = command(
         : conflict(
             sessionResult.kind === "ambiguous"
               ? "Multiple connector accounts require an exact choice"
-              : "Additional connector accounts are not enabled yet",
+              : "This connector does not support additional accounts",
           );
     }
 

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -58,12 +58,8 @@ import {
   connectorAgentAuthorizationRequested,
   validateConnectorAuthorizationTarget$,
 } from "./connected-connector-authorization.service";
-import {
-  connectorAccountSiblingWritesEnabled,
-  storedConnectorAccountMutationSelection,
-} from "./connector-account-mutation.service";
+import { storedConnectorAccountMutationSelection } from "./connector-account-mutation.service";
 import { resolveConnectorConnectionMutation } from "./connector-connection-write.service";
-import { userFeatureSwitchContext } from "./feature-switches.service";
 
 const SUPERSEDABLE_EXTERNAL_CODE_SESSION_STATUSES = ["pending"] as const;
 const SUPERSEDED_SESSION_ERROR_CODE = "session_superseded";
@@ -854,7 +850,6 @@ async function createExternalCodeSession(
     readonly connectorSlug: ConnectorSlug;
     readonly authMethod: ConnectorAuthMethodId;
     readonly account: ConnectorAccountMutationIntent;
-    readonly allowSiblings: boolean;
     readonly sessionToken: string;
     readonly encryptedProviderState: string;
     readonly authorizationUrl: string;
@@ -877,7 +872,7 @@ async function createExternalCodeSession(
       userId: args.userId,
       target: { kind: "builtin", connectorSlug: args.connectorSlug },
       mutation: args.account,
-      allowSiblings: args.allowSiblings,
+      allowSiblings: true,
     });
     signal.throwIfAborted();
     if (mutationResolution.kind !== "ready") {
@@ -986,10 +981,6 @@ export const startConnectorExternalCodeSession$ = command(
     );
     signal.throwIfAborted();
 
-    const featureSwitchContext = await get(
-      userFeatureSwitchContext(args.orgId, args.userId),
-    );
-    signal.throwIfAborted();
     const sessionResult = await createExternalCodeSession(
       set(writeDb$),
       {
@@ -1000,8 +991,6 @@ export const startConnectorExternalCodeSession$ = command(
         agentId: args.agentId,
         authorizeAgent: args.authorizeAgent,
         account: args.account,
-        allowSiblings:
-          connectorAccountSiblingWritesEnabled(featureSwitchContext),
         sessionToken,
         encryptedProviderState,
         authorizationUrl: startResult.authorizationUrl,

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -1213,7 +1213,7 @@ export const startConnectorOauthDeviceAuthSession$ = command(
         : conflict(
             sessionResult.kind === "ambiguous"
               ? "Multiple connector accounts require an exact choice"
-              : "Additional connector accounts are not enabled yet",
+              : "This connector does not support additional accounts",
           );
     }
 

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -61,12 +61,8 @@ import {
   connectorAgentAuthorizationRequested,
   validateConnectorAuthorizationTarget$,
 } from "./connected-connector-authorization.service";
-import {
-  connectorAccountSiblingWritesEnabled,
-  storedConnectorAccountMutationSelection,
-} from "./connector-account-mutation.service";
+import { storedConnectorAccountMutationSelection } from "./connector-account-mutation.service";
 import { resolveConnectorConnectionMutation } from "./connector-connection-write.service";
-import { userFeatureSwitchContext } from "./feature-switches.service";
 
 const DEFAULT_POLL_INTERVAL_SECONDS = 5;
 const SLOW_DOWN_INCREMENT_SECONDS = 5;
@@ -1039,7 +1035,6 @@ async function createDeviceAuthSession(
     readonly connectorSlug: ConnectorSlug;
     readonly authMethod: ConnectorAuthMethodId;
     readonly account: ConnectorAccountMutationIntent;
-    readonly allowSiblings: boolean;
     readonly sessionToken: string;
     readonly encryptedProviderState: string;
     readonly oauthRequestedScopes: readonly string[];
@@ -1065,7 +1060,7 @@ async function createDeviceAuthSession(
       userId: args.userId,
       target: { kind: "builtin", connectorSlug: args.connectorSlug },
       mutation: args.account,
-      allowSiblings: args.allowSiblings,
+      allowSiblings: true,
     });
     signal.throwIfAborted();
     if (mutationResolution.kind !== "ready") {
@@ -1188,10 +1183,6 @@ export const startConnectorOauthDeviceAuthSession$ = command(
     );
     signal.throwIfAborted();
 
-    const featureSwitchContext = await get(
-      userFeatureSwitchContext(args.orgId, args.userId),
-    );
-    signal.throwIfAborted();
     const sessionResult = await createDeviceAuthSession(
       set(writeDb$),
       {
@@ -1202,8 +1193,6 @@ export const startConnectorOauthDeviceAuthSession$ = command(
         agentId: args.agentId,
         authorizeAgent: args.authorizeAgent,
         account: args.account,
-        allowSiblings:
-          connectorAccountSiblingWritesEnabled(featureSwitchContext),
         sessionToken,
         encryptedProviderState,
         oauthRequestedScopes: connectorGrantScopes(resolvedMethod.method.grant),

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -593,7 +593,7 @@ function connectorConnectionMutationFailure(
     : conflict(
         resolution.kind === "ambiguous"
           ? "Multiple connector accounts require an exact choice"
-          : "Additional connector accounts are not enabled yet",
+          : "This connector does not support additional accounts",
       );
 }
 

--- a/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-oauth2.service.ts
@@ -69,7 +69,6 @@ import {
   replaceConnectorConnection,
   resolveConnectorConnectionMutation,
 } from "./connector-connection-write.service";
-import { connectorAccountSiblingWritesEnabled } from "./connector-account-mutation.service";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 import { addUserCustomConnector } from "./user-connectors.service";
 import { commitConnectorRuntimeMutation } from "./connector-runtime-wakeup.service";
@@ -672,7 +671,7 @@ async function prepareAutomaticOAuthStart(
       userId: args.userId,
       target: { kind: "custom", customConnectorId: connector.id },
       mutation: args.account,
-      allowSiblings: connectorAccountSiblingWritesEnabled(featureContext),
+      allowSiblings: true,
     });
   });
   signal.throwIfAborted();
@@ -756,12 +755,11 @@ async function persistCustomConnectorOAuthStart(
     readonly db: Db;
     readonly connector: CustomConnectorRow;
     readonly args: StartCustomConnectorOAuth2Args;
-    readonly featureContext: FeatureSwitchContext;
     readonly prepared: PreparedOAuthStart;
   },
   signal: AbortSignal,
 ) {
-  const { db, connector, args, featureContext, prepared } = context;
+  const { db, connector, args, prepared } = context;
   const expiresAt = connectorOAuthStateExpiresAt();
   const result = await db.transaction(async (tx) => {
     await lockCustomConnectorOAuth2CredentialContract({
@@ -776,9 +774,7 @@ async function persistCustomConnectorOAuthStart(
       userId: args.userId,
       target: { kind: "custom", customConnectorId: connector.id },
       mutation: args.account,
-      allowSiblings:
-        !isIntegrationManagedCustomConnector(connector) &&
-        connectorAccountSiblingWritesEnabled(featureContext),
+      allowSiblings: !isIntegrationManagedCustomConnector(connector),
     });
     if (resolution.kind !== "ready") {
       return { resolution, connectionId: null, expiresAt };
@@ -854,11 +850,10 @@ async function persistAutomaticNoAuthConnection(
       readonly oauthConfig: null;
     };
     readonly args: StartCustomConnectorOAuth2Args;
-    readonly featureContext: FeatureSwitchContext;
   },
   signal: AbortSignal,
 ) {
-  const { db, connector, args, featureContext } = context;
+  const { db, connector, args } = context;
   const transaction = db.transaction(async (tx) => {
     await lockCustomConnectorOAuth2CredentialContract({
       db: tx,
@@ -872,7 +867,7 @@ async function persistAutomaticNoAuthConnection(
       userId: args.userId,
       target: { kind: "custom", customConnectorId: connector.id },
       mutation: args.account,
-      allowSiblings: connectorAccountSiblingWritesEnabled(featureContext),
+      allowSiblings: true,
     });
     if (resolution.kind !== "ready") {
       return { resolution, connection: null };
@@ -1019,7 +1014,6 @@ export const startCustomConnectorOAuth2$ = command(
             db: set(writeDb$),
             connector,
             args,
-            featureContext,
           },
           signal,
         );
@@ -1033,7 +1027,6 @@ export const startCustomConnectorOAuth2$ = command(
         db: set(writeDb$),
         connector,
         args,
-        featureContext,
         prepared,
       },
       signal,
@@ -1206,7 +1199,6 @@ export const startCustomConnectorAutomaticOAuthReauthorization$ = command(
             connectionId: args.connectionId,
           },
         },
-        featureContext,
         prepared: {
           authMode: "automatic",
           redirectUri,
@@ -1483,10 +1475,9 @@ export async function storeCustomConnectorOAuth2Connection(
       userId: args.userId,
       target: { kind: "custom", customConnectorId: args.connectorId },
       mutation: args.account,
-      allowSiblings:
-        !isIntegrationManagedCustomConnectorProviderAdapter(
-          contract.providerAdapter,
-        ) && connectorAccountSiblingWritesEnabled(args.featureContext),
+      allowSiblings: !isIntegrationManagedCustomConnectorProviderAdapter(
+        contract.providerAdapter,
+      ),
     });
     signal.throwIfAborted();
     if (resolution.kind !== "ready") {

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -93,10 +93,7 @@ import {
   type ReadyConnectorConnectionMutation,
   writeConnectorConnectionMetadata,
 } from "./connector-connection-write.service";
-import {
-  connectorAccountSiblingWritesEnabled,
-  normalizeConnectorAccountMutation,
-} from "./connector-account-mutation.service";
+import { normalizeConnectorAccountMutation } from "./connector-account-mutation.service";
 import type { Tx } from "../../lib/db-types";
 
 const L = logger("CustomConnectorService");
@@ -2895,9 +2892,7 @@ async function prepareCustomConnectorValueWrite(args: {
       customConnectorId: args.request.connectorId,
     },
     mutation: normalizeConnectorAccountMutation(args.request.account),
-    allowSiblings: connectorAccountSiblingWritesEnabled(
-      args.featureSwitchContext,
-    ),
+    allowSiblings: true,
   });
   if (resolution.kind !== "ready") {
     return resolution.kind === "missing"

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -2841,7 +2841,6 @@ async function prepareCustomConnectorValueWrite(args: {
   readonly request: SetCustomConnectorValuesArgs;
   readonly expectedConnector: CustomConnectorRow;
   readonly expectedValues: readonly CustomConnectorValueInput[];
-  readonly featureSwitchContext: NonNullable<FeatureSwitchContextArg>;
 }): Promise<
   | CustomConnectorValueWriteState
   | BadRequestResponse
@@ -2946,7 +2945,6 @@ async function persistCustomConnectorValues(
     readonly expectedConnector: CustomConnectorRow;
     readonly expectedValues: readonly CustomConnectorValueInput[];
     readonly preparedValues: readonly PreparedCustomConnectorValue[];
-    readonly featureSwitchContext: NonNullable<FeatureSwitchContextArg>;
   },
   signal: AbortSignal,
 ): Promise<
@@ -3088,7 +3086,6 @@ export const setCustomConnectorValues$ = command(
           expectedConnector: connector,
           expectedValues: values,
           preparedValues,
-          featureSwitchContext,
         },
         signal,
       );

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -2900,7 +2900,7 @@ async function prepareCustomConnectorValueWrite(args: {
       : conflict(
           resolution.kind === "ambiguous"
             ? "Multiple connector accounts require an exact choice"
-            : "Additional connector accounts are not enabled yet",
+            : "This connector does not support additional accounts",
         );
   }
   const storedConnector =

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2768,12 +2768,10 @@
       "mcpStreamableHttp": "MCP · Streamable HTTP",
       "mcpType": "MCP",
       "moreOptions": "Weitere Optionen",
-      "statusConnected": "Verbunden",
       "toasts": {
         "connected": "Verbunden",
         "created": "Erstellt „{{connector}}“",
         "deleted": "Benutzerdefinierte Integration gelöscht",
-        "disconnected": "Getrennt",
         "updated": "Aktualisiert „{{connector}}“"
       },
       "updateConfirm": {
@@ -3278,8 +3276,7 @@
       "redirectTitle": "Weiterleitung zu {{connector}}…"
     },
     "toasts": {
-      "connected": "{{connector}} verbunden",
-      "disconnected": "{{connector}} getrennt"
+      "connected": "{{connector}} verbunden"
     }
   },
   "global": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2760,12 +2760,10 @@
       "mcpStreamableHttp": "MCP · Streamable HTTP",
       "mcpType": "MCP",
       "moreOptions": "More options",
-      "statusConnected": "Connected",
       "toasts": {
         "connected": "Connected",
         "created": "Created \"{{connector}}\"",
         "deleted": "Custom connector deleted",
-        "disconnected": "Disconnected",
         "updated": "Updated \"{{connector}}\""
       },
       "updateConfirm": {
@@ -3270,8 +3268,7 @@
       "redirectTitle": "Redirecting to {{connector}}…"
     },
     "toasts": {
-      "connected": "{{connector}} connected",
-      "disconnected": "{{connector}} disconnected"
+      "connected": "{{connector}} connected"
     }
   },
   "global": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2816,12 +2816,10 @@
       "mcpStreamableHttp": "MCP · Streamable HTTP",
       "mcpType": "MCP",
       "moreOptions": "Más opciones",
-      "statusConnected": "Conectado",
       "toasts": {
         "connected": "Conectado",
         "created": "Se ha creado \"{{connector}}\"",
         "deleted": "Conector personalizado eliminado",
-        "disconnected": "Desconectado",
         "updated": "Se ha actualizado \"{{connector}}\""
       },
       "updateConfirm": {
@@ -3329,8 +3327,7 @@
       "redirectTitle": "Redirigiendo a {{connector}}..."
     },
     "toasts": {
-      "connected": "{{connector}} conectado",
-      "disconnected": "{{connector}} desconectado"
+      "connected": "{{connector}} conectado"
     }
   },
   "global": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2816,12 +2816,10 @@
       "mcpStreamableHttp": "MCP · Streamable HTTP",
       "mcpType": "MCP",
       "moreOptions": "Plus d'options",
-      "statusConnected": "Connecté",
       "toasts": {
         "connected": "Connecté",
         "created": "Créé \"{{connector}}\"",
         "deleted": "Connecteur personnalisé supprimé",
-        "disconnected": "Déconnecté",
         "updated": "Mis à jour \"{{connector}}\""
       },
       "updateConfirm": {
@@ -3329,8 +3327,7 @@
       "redirectTitle": "Redirection vers {{connector}}…"
     },
     "toasts": {
-      "connected": "{{connector}} connecté",
-      "disconnected": "{{connector}} déconnecté"
+      "connected": "{{connector}} connecté"
     }
   },
   "global": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2768,12 +2768,10 @@
       "mcpStreamableHttp": "MCP · Streamable HTTP",
       "mcpType": "MCP",
       "moreOptions": "अधिक विकल्प",
-      "statusConnected": "जुड़े हुए",
       "toasts": {
         "connected": "जुड़े हुए",
         "created": "\"{{connector}}\" बनाया गया",
         "deleted": "कस्टम कनेक्टर हटा दिया गया",
-        "disconnected": "डिस्कनेक्ट किया गया",
         "updated": "अपडेट किया गया \"{{connector}}\""
       },
       "updateConfirm": {
@@ -3278,8 +3276,7 @@
       "redirectTitle": "{{connector}} पर पुनर्निर्देशित किया जा रहा है..."
     },
     "toasts": {
-      "connected": "{{connector}} कनेक्ट हुआ",
-      "disconnected": "{{connector}} डिस्कनेक्ट हो गया"
+      "connected": "{{connector}} कनेक्ट हुआ"
     }
   },
   "global": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2760,12 +2760,10 @@
       "mcpStreamableHttp": "MCP · Streamable HTTP",
       "mcpType": "MCP",
       "moreOptions": "Opsi lainnya",
-      "statusConnected": "Terhubung",
       "toasts": {
         "connected": "Terhubung",
         "created": "Membuat \"{{connector}}\"",
         "deleted": "Konektor kustom dihapus",
-        "disconnected": "Terputus",
         "updated": "Diperbarui \"{{connector}}\""
       },
       "updateConfirm": {
@@ -3270,8 +3268,7 @@
       "redirectTitle": "Mengarahkan ke {{connector}}…"
     },
     "toasts": {
-      "connected": "{{connector}} terhubung",
-      "disconnected": "{{connector}} terputus"
+      "connected": "{{connector}} terhubung"
     }
   },
   "global": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2816,12 +2816,10 @@
       "mcpStreamableHttp": "MCP · Streamable HTTP",
       "mcpType": "MCP",
       "moreOptions": "Più opzioni",
-      "statusConnected": "Connesso",
       "toasts": {
         "connected": "Connesso",
         "created": "Creato \"{{connector}}\"",
         "deleted": "Connettore personalizzato eliminato",
-        "disconnected": "Disconnesso",
         "updated": "Aggiornato \"{{connector}}\""
       },
       "updateConfirm": {
@@ -3329,8 +3327,7 @@
       "redirectTitle": "Reindirizzamento a {{connector}}…"
     },
     "toasts": {
-      "connected": "{{connector}} connesso",
-      "disconnected": "{{connector}} disconnesso"
+      "connected": "{{connector}} connesso"
     }
   },
   "global": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2760,12 +2760,10 @@
       "mcpStreamableHttp": "MCP · Streamable HTTP",
       "mcpType": "MCP",
       "moreOptions": "その他のオプション",
-      "statusConnected": "接続済み",
       "toasts": {
         "connected": "接続済み",
         "created": "「{{connector}}」を作成しました",
         "deleted": "カスタムコネクタが削除されました",
-        "disconnected": "切断されました",
         "updated": "「{{connector}}」を更新しました"
       },
       "updateConfirm": {
@@ -3270,8 +3268,7 @@
       "redirectTitle": "{{connector}} にリダイレクトしています…"
     },
     "toasts": {
-      "connected": "{{connector}} が接続されました",
-      "disconnected": "{{connector}} が切断されました"
+      "connected": "{{connector}} が接続されました"
     }
   },
   "global": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2760,12 +2760,10 @@
       "mcpStreamableHttp": "MCP · Streamable HTTP",
       "mcpType": "MCP",
       "moreOptions": "추가 옵션",
-      "statusConnected": "연결됨",
       "toasts": {
         "connected": "연결됨",
         "created": "\"{{connector}}\" 생성됨",
         "deleted": "커스텀 커넥터가 삭제되었습니다",
-        "disconnected": "연결 해제됨",
         "updated": "\"{{connector}}\" 업데이트됨"
       },
       "updateConfirm": {
@@ -3270,8 +3268,7 @@
       "redirectTitle": "{{connector}}로 리디렉션 중…"
     },
     "toasts": {
-      "connected": "{{connector}} 연결됨",
-      "disconnected": "{{connector}} 연결 해제됨"
+      "connected": "{{connector}} 연결됨"
     }
   },
   "global": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2816,12 +2816,10 @@
       "mcpStreamableHttp": "MCP · Streamable HTTP",
       "mcpType": "MCP",
       "moreOptions": "Mais opções",
-      "statusConnected": "Conectado",
       "toasts": {
         "connected": "Conectado",
         "created": "\"{{connector}}\" criado",
         "deleted": "Conector personalizado excluído",
-        "disconnected": "Desconectado",
         "updated": "\"{{connector}}\" atualizado"
       },
       "updateConfirm": {
@@ -3329,8 +3327,7 @@
       "redirectTitle": "Redirecionando para {{connector}}…"
     },
     "toasts": {
-      "connected": "{{connector}} conectado",
-      "disconnected": "{{connector}} desconectado"
+      "connected": "{{connector}} conectado"
     }
   },
   "global": {

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -688,34 +688,6 @@ export const apiConnectorsHandlers = [
     });
   }),
 
-  mockApi(
-    connectorAccountsContract.disconnectSingleAccount,
-    ({ body, respond }) => {
-      if (body.target.kind === "custom") {
-        return respond(404, {
-          error: { message: "Connector not found", code: "NOT_FOUND" },
-        });
-      }
-
-      const connectorSlug = body.target.connectorSlug;
-      const existing = mockConnectors.find((c) => {
-        return c.slug === connectorSlug;
-      });
-
-      if (!existing) {
-        return respond(404, {
-          error: { message: "Connector not found", code: "NOT_FOUND" },
-        });
-      }
-
-      mockConnectors = mockConnectors.filter((c) => {
-        return c.slug !== connectorSlug;
-      });
-      mockConnectorRequestedScopes.delete(existing.id);
-      return respond(204);
-    },
-  ),
-
   mockApi(connectorManualGrantContract.connect, ({ body, params, respond }) => {
     const connector = createMockLocalGrantConnector(
       params.connectorSlug,

--- a/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts
@@ -227,9 +227,6 @@ function createConnectorAccountActionSignals(
   const status$ = computed(
     async (get): Promise<ConnectorAccountActionStatus> => {
       get(reload$);
-      if (!get(connector.accounts.enabled$)) {
-        return { kind: "unavailable" };
-      }
       const authorization = await get(connector.connectorAuthorization$);
       if (!targetIsAuthorized(authorization, descriptor.selection.target)) {
         return { kind: "unavailable" };

--- a/turbo/apps/platform/src/signals/connector-domain.ts
+++ b/turbo/apps/platform/src/signals/connector-domain.ts
@@ -12,6 +12,7 @@ export type PlatformConnectorCatalogStatusItem =
 export type PlatformConnectorPermissionMetadata =
   PublicConnectorCatalogPermissionDetail;
 export type PlatformUserPermissionGrant = UserPermissionGrantResponse;
-export const singleAccountConnectorMutation = {
-  intent: "single-account",
-} satisfies ConnectorAccountMutationIntent;
+export type PlatformConnectorAccountMutationIntent = Extract<
+  ConnectorAccountMutationIntent,
+  { readonly intent: "add" | "reconnect" }
+>;

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -1,6 +1,5 @@
 import { command, computed, state, type Computed } from "ccstate";
 import { connectorsMainContract } from "@okouai/api-contracts/contracts/connectors";
-import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   connectorCatalogContract,
   type PublicConnectorCatalogDiscoveryResponse,
@@ -97,27 +96,3 @@ export const reloadConnectors$ = command(({ set }) => {
     return x + 1;
   });
 });
-
-/**
- * Delete a connector by slug.
- */
-export const deleteConnector$ = command(
-  async ({ get, set }, connectorSlug: ConnectorSlug, signal: AbortSignal) => {
-    const createClient = get(apiClient$);
-    const client = createClient(connectorAccountsContract);
-    await accept(
-      client.disconnectSingleAccount({
-        body: {
-          target: { kind: "builtin", connectorSlug },
-        },
-        fetchOptions: { signal },
-      }),
-      [204],
-    );
-    signal.throwIfAborted();
-
-    set(internalReloadConnectors$, (x) => {
-      return x + 1;
-    });
-  },
-);

--- a/turbo/apps/platform/src/signals/okou-page/composer-connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-connector-accounts.ts
@@ -13,11 +13,9 @@ import type {
   ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
 import { chatThreadConnectorSelectionContract } from "@okouai/api-contracts/contracts/chat-threads";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { accept } from "../../lib/accept.ts";
 import { apiClient$ } from "../api-client.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import { withCleanup } from "../utils.ts";
 import {
   connectorAccountSummaryByTarget$,
@@ -32,7 +30,6 @@ export interface ComposerConnectorAccountPreferenceState {
 }
 
 export interface ComposerConnectorAccountSignals {
-  readonly enabled$: Computed<boolean>;
   readonly preferenceState$: Computed<
     Promise<ComposerConnectorAccountPreferenceState>
   >;
@@ -189,14 +186,8 @@ export function createComposerConnectorAccountSignals(
     emptyPreferenceState(),
   );
   const savingTargetKey$ = state<string | null>(null);
-  const enabled$ = computed((get): boolean => {
-    return get(featureSwitch$)[FeatureSwitchKey.ConnectorAccounts] ?? false;
-  });
   const preferenceState$ = computed(
     async (get): Promise<ComposerConnectorAccountPreferenceState> => {
-      if (!get(enabled$)) {
-        return emptyPreferenceState();
-      }
       if (!threadId) {
         return get(pendingState$);
       }
@@ -264,7 +255,6 @@ export function createComposerConnectorAccountSignals(
   });
 
   return {
-    enabled$,
     preferenceState$,
     summaryByTarget$: connectorAccountSummaryByTarget$,
     menuTarget$: computed((get) => {

--- a/turbo/apps/platform/src/signals/okou-page/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/connector-accounts.ts
@@ -7,11 +7,9 @@ import {
   type ConnectorAccountSummary,
   type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { accept } from "../../lib/accept.ts";
 import { apiClient$, type ApiClientFactory } from "../api-client.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import { onRejection, resetSignal } from "../utils.ts";
 
 const CONNECTOR_ACCOUNT_PAGE_SIZE = 50;
@@ -26,11 +24,6 @@ const internalSummariesReload$ = state(0);
 const connectorAccountSummaries$ = computed(
   async (get): Promise<readonly ConnectorAccountSummary[]> => {
     get(internalSummariesReload$);
-    const enabled =
-      get(featureSwitch$)[FeatureSwitchKey.ConnectorAccounts] ?? false;
-    if (!enabled) {
-      return [];
-    }
     const result = await accept(
       get(apiClient$)(connectorAccountsContract).summaries(),
       [200],

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-account-dialogs.ts
@@ -3,11 +3,13 @@ import type { CustomConnectorResponse } from "@okouai/api-contracts/contracts/cu
 import type { ConnectorAuthMethodId } from "@okouai/api-contracts/contracts/connector-identity";
 import type {
   ConnectorAccountConnection,
-  ConnectorAccountMutationIntent,
   ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
 
-import type { PlatformConnectorCatalogStatusItem } from "../../connector-domain.ts";
+import type {
+  PlatformConnectorAccountMutationIntent,
+  PlatformConnectorCatalogStatusItem,
+} from "../../connector-domain.ts";
 import { reloadConnectorAccountSummaries$ } from "../connector-accounts.ts";
 import {
   connectorAccountDeletionImpact$,
@@ -25,35 +27,13 @@ export type ConnectorAccountConnectMode =
     };
 
 export interface ConnectorAccountMutationOptions {
-  readonly account?: ConnectorAccountMutationIntent;
+  readonly account: PlatformConnectorAccountMutationIntent;
   readonly useDefaultConnectorProjection?: true;
 }
 
 export interface DefaultConnectorAccountMutationOptions {
-  readonly account: ConnectorAccountMutationIntent;
+  readonly account: PlatformConnectorAccountMutationIntent;
   readonly useDefaultConnectorProjection: true;
-}
-
-function connectorAccountMutationFor(
-  mode: ConnectorAccountConnectMode | undefined,
-): ConnectorAccountMutationIntent | undefined {
-  if (!mode) {
-    return undefined;
-  }
-  if (mode.kind === "reconnect") {
-    return { intent: "reconnect", connectionId: mode.connectionId };
-  }
-  return { intent: "add" };
-}
-
-export function connectorAccountOptionsFor(
-  mode: ConnectorAccountConnectMode | undefined,
-): ConnectorAccountMutationOptions {
-  const account = connectorAccountMutationFor(mode);
-  if (!account) {
-    return {};
-  }
-  return { account };
 }
 
 export function defaultBuiltinConnectorAccountOptions(

--- a/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connector-accounts.ts
@@ -2,12 +2,12 @@ import { command } from "ccstate";
 import {
   connectorAccountsContract,
   type ConnectorAccountConnection,
-  type ConnectorAccountMutationIntent,
   type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
 
 import { accept } from "../../../lib/accept.ts";
 import { apiClient$, type ApiClientFactory } from "../../api-client.ts";
+import type { PlatformConnectorAccountMutationIntent } from "../../connector-domain.ts";
 import {
   connectorAccountTargetKey,
   createConnectorAccountListSignals,
@@ -19,7 +19,7 @@ export type ConnectorAccountMutationVersion = number | string | null;
 export async function readConnectorAccountMutationVersion(
   createClient: ApiClientFactory,
   target: ConnectorAccountTarget,
-  account: ConnectorAccountMutationIntent,
+  account: PlatformConnectorAccountMutationIntent,
   signal: AbortSignal,
 ): Promise<ConnectorAccountMutationVersion> {
   if (account.intent === "add") {
@@ -38,18 +38,15 @@ export async function readConnectorAccountMutationVersion(
       })?.accountCount ?? 0
     );
   }
-  if (account.intent === "reconnect") {
-    const result = await accept(
-      createClient(connectorAccountsContract).connection({
-        params: { connectionId: account.connectionId },
-        query: target,
-        fetchOptions: { signal },
-      }),
-      [200, 404],
-    );
-    return result.status === 404 ? null : result.body.updatedAt;
-  }
-  return null;
+  const result = await accept(
+    createClient(connectorAccountsContract).connection({
+      params: { connectionId: account.connectionId },
+      query: target,
+      fetchOptions: { signal },
+    }),
+    [200, 404],
+  );
+  return result.status === 404 ? null : result.body.updatedAt;
 }
 
 export async function connectorAccountConnectionExists(
@@ -70,7 +67,7 @@ export async function connectorAccountConnectionExists(
 }
 
 export function connectorAccountMutationCompleted(
-  account: ConnectorAccountMutationIntent,
+  account: PlatformConnectorAccountMutationIntent,
   initialVersion: ConnectorAccountMutationVersion,
   currentVersion: ConnectorAccountMutationVersion,
 ): boolean {
@@ -81,9 +78,9 @@ export function connectorAccountMutationCompleted(
       currentVersion > initialVersion
     );
   }
-  return account.intent === "reconnect"
-    ? typeof currentVersion === "string" && currentVersion !== initialVersion
-    : true;
+  return (
+    typeof currentVersion === "string" && currentVersion !== initialVersion
+  );
 }
 
 export const settingsConnectorAccounts = createConnectorAccountListSignals({

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -14,12 +14,8 @@ import {
   type ConnectorAuthMethodId,
   type ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
+import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
-  connectorAccountsContract,
-  type ConnectorAccountMutationIntent,
-} from "@okouai/api-contracts/contracts/connector-accounts";
-import {
-  connectorScopeDiffContract,
   connectorExternalCodeSessionContract,
   connectorOauthDeviceAuthSessionContract,
   connectorOpenIdStartContract,
@@ -41,7 +37,6 @@ import type {
 } from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   connectors$,
-  deleteConnector$,
   relatedConnectorCatalog,
   reloadConnectors$,
 } from "../../external/connectors.ts";
@@ -63,15 +58,16 @@ import { setAblyPayloadLoop$ } from "../../realtime.ts";
 import { localStorageSignals } from "../../external/local-storage.ts";
 import { subagents$ } from "../../agent.ts";
 import { reloadAgentConnectorAuthorizations$ } from "../agent-connector-authorizations.ts";
+import { reloadConnectorAccountSummaries$ } from "../connector-accounts.ts";
 import { sanitizeTokenInputRecord } from "./token-input.ts";
 import { IN_VITEST } from "../../../env.ts";
 import { connectorRedirectingPath } from "../../connectors-page/connector-redirecting.ts";
 import { isConnectorChangedPayloadFor } from "../../connector-change.ts";
 import { i18n } from "../../../i18n/index.ts";
-import {
-  singleAccountConnectorMutation,
-  type PlatformConnector,
-  type PlatformConnectorCatalogStatusItem,
+import type {
+  PlatformConnector,
+  PlatformConnectorAccountMutationIntent,
+  PlatformConnectorCatalogStatusItem,
 } from "../../connector-domain.ts";
 import {
   connectorAccountConnectionExists,
@@ -88,7 +84,7 @@ type PostConnectOptions = {
   readonly authorizeVisibleAgents?: boolean;
   readonly connectorLabel?: string;
   readonly agentId?: string;
-  readonly account?: ConnectorAccountMutationIntent;
+  readonly account: PlatformConnectorAccountMutationIntent;
   readonly useDefaultConnectorProjection?: boolean;
 };
 type BrowserAuthPostConnectOptions = PostConnectOptions & {
@@ -100,11 +96,13 @@ export interface ConnectorConnectionResult {
 }
 
 function shouldAuthorizeAgent(options: PostConnectOptions): boolean {
-  return (
-    options.account === undefined ||
-    Boolean(options.authorizeVisibleAgents || options.agentId)
-  );
+  return Boolean(options.authorizeVisibleAgents || options.agentId);
 }
+
+const reloadConnectorConnectionState$ = command(({ set }) => {
+  set(reloadConnectors$);
+  set(reloadConnectorAccountSummaries$);
+});
 // ---------------------------------------------------------------------------
 // Derived state
 // ---------------------------------------------------------------------------
@@ -746,17 +744,11 @@ export const setConnectorOAuthDeviceAuthStartOptionValue$ = command(
 // Scope review modal state
 // ---------------------------------------------------------------------------
 
-export type ConnectorScopeReviewSelection =
-  | {
-      readonly kind: "default";
-      readonly connectorSlug: ConnectorSlug;
-    }
-  | {
-      readonly kind: "account";
-      readonly connectorSlug: ConnectorSlug;
-      readonly connectionId: string;
-      readonly authMethod: ConnectorAuthMethodId;
-    };
+export interface ConnectorScopeReviewSelection {
+  readonly connectorSlug: ConnectorSlug;
+  readonly connectionId: string;
+  readonly authMethod: ConnectorAuthMethodId;
+}
 
 const internalScopeReviewSelection$ =
   state<ConnectorScopeReviewSelection | null>(null);
@@ -770,21 +762,11 @@ export const scopeDiff$ = computed(async (get) => {
     return null;
   }
   const createClient = get(apiClient$);
-  if (selection.kind === "account") {
-    const client = createClient(connectorAccountsContract);
-    const result = await accept(
-      client.scopeDiff({
-        params: { connectionId: selection.connectionId },
-        query: { connectorSlug: selection.connectorSlug },
-      }),
-      [200],
-    );
-    return result.body;
-  }
-  const client = createClient(connectorScopeDiffContract);
+  const client = createClient(connectorAccountsContract);
   const result = await accept(
-    client.getScopeDiff({
-      params: { connectorSlug: selection.connectorSlug },
+    client.scopeDiff({
+      params: { connectionId: selection.connectionId },
+      query: { connectorSlug: selection.connectorSlug },
     }),
     [200],
   );
@@ -966,7 +948,7 @@ export const submitManualGrant$ = command(
           connectorClient.connect({
             params: { connectorSlug },
             body: {
-              account: options.account ?? singleAccountConnectorMutation,
+              account: options.account,
               authMethod,
               ...(shouldAuthorizeAgent(options)
                 ? { authorizeAgent: true as const }
@@ -997,7 +979,7 @@ export const submitManualGrant$ = command(
           return current?.id === flow.id ? null : current;
         });
         if (connectorStateChanged) {
-          set(reloadConnectors$);
+          set(reloadConnectorConnectionState$);
         }
       },
     );
@@ -1042,7 +1024,7 @@ export const connectConnectorNoAuth$ = command(
           connectorClient.connect({
             params: { connectorSlug },
             body: {
-              account: options.account ?? singleAccountConnectorMutation,
+              account: options.account,
               authMethod,
               ...(shouldAuthorizeAgent(options)
                 ? { authorizeAgent: true as const }
@@ -1072,7 +1054,7 @@ export const connectConnectorNoAuth$ = command(
           return current?.id === flow.id ? null : current;
         });
         if (connectorStateChanged) {
-          set(reloadConnectors$);
+          set(reloadConnectorConnectionState$);
         }
       },
     );
@@ -1156,45 +1138,6 @@ export const justConnectedSlugs$ = computed((get) => {
   return get(internalJustConnectedSlugs$);
 });
 
-/**
- * Disconnect a connector and clear its optimistic "just connected" flag.
- *
- * Without this cleanup, a connector that was connected earlier in the session
- * stays in the Connected section of /connectors after disconnect because the
- * optimistic override in relatedCatalogItems$ wins over the fresh
- * `connected = false` from the API (regression #10272).
- */
-export const disconnectConnector$ = command(
-  async (
-    { set },
-    connectorSlug: ConnectorSlug,
-    connectorLabel: string,
-    signal: AbortSignal,
-  ): Promise<void> => {
-    await set(deleteConnector$, connectorSlug, signal);
-    signal.throwIfAborted();
-    set(internalJustConnectedSlugs$, (prev) => {
-      if (!prev.has(connectorSlug)) {
-        return prev;
-      }
-      const next = new Set(prev);
-      next.delete(connectorSlug);
-      return next;
-    });
-    toast.success(
-      i18n.t(
-        ($) => {
-          return $.connectors.toasts.disconnected;
-        },
-        { connector: connectorLabel },
-      ),
-      {
-        id: `connector-disconnected-${connectorSlug}`,
-      },
-    );
-  },
-);
-
 function createConnectorConnectFlowState(
   connectorSlug: ConnectorSlug,
 ): ConnectorConnectFlowState {
@@ -1234,7 +1177,7 @@ function connectorOAuthDeviceAuthStartBody(
 ) {
   const optionEntries = Object.entries(args.startOptions ?? {});
   return {
-    account: args.options.account ?? singleAccountConnectorMutation,
+    account: args.options.account,
     authMethod: args.authMethod,
     ...(shouldAuthorizeAgent(args.options)
       ? { authorizeAgent: true as const }
@@ -1487,7 +1430,7 @@ const pollConnectorOAuthDeviceAuthOnce$ = command(
       })(),
       () => {
         if (connectorStateChanged) {
-          set(reloadConnectors$);
+          set(reloadConnectorConnectionState$);
         }
       },
     );
@@ -1723,7 +1666,7 @@ type ConnectConnectorExternalCodeParams = {
   readonly connectorSlug: ConnectorSlug;
   readonly authMethod: ConnectorAuthMethodId;
   readonly agentId?: string;
-  readonly account?: ConnectorAccountMutationIntent;
+  readonly account: PlatformConnectorAccountMutationIntent;
   readonly authorizeVisibleAgents?: boolean;
 };
 
@@ -1862,7 +1805,7 @@ export const connectConnectorExternalCode$ = command(
             client.create({
               params: { connectorSlug },
               body: {
-                account: args.account ?? singleAccountConnectorMutation,
+                account: args.account,
                 authMethod,
                 ...(shouldAuthorizeAgent(args)
                   ? { authorizeAgent: true as const }
@@ -2039,7 +1982,7 @@ const completeConnectorExternalCode$ = command(
       })(),
       () => {
         if (connectorStateChanged) {
-          set(reloadConnectors$);
+          set(reloadConnectorConnectionState$);
         }
       },
     );
@@ -2130,7 +2073,7 @@ function createConnectorOAuthAuthCodeChangedCommand(
   connectorSlug: ConnectorSlug,
   authMethod: ConnectorAuthMethodId,
   agentId: string | undefined,
-  account: ConnectorAccountMutationIntent,
+  account: PlatformConnectorAccountMutationIntent,
   useDefaultConnectorProjection: boolean,
 ) {
   // Snapshot taken on the first body invocation: `null` marks "no connector
@@ -2141,7 +2084,7 @@ function createConnectorOAuthAuthCodeChangedCommand(
   let initialAccountVersion: ConnectorAccountMutationVersion | undefined;
 
   return command(async ({ get }, sig: AbortSignal): Promise<boolean> => {
-    if (!useDefaultConnectorProjection && account.intent !== "single-account") {
+    if (!useDefaultConnectorProjection) {
       const currentVersion = await readConnectorAccountMutationVersion(
         get(apiClient$),
         { kind: "builtin", connectorSlug },
@@ -2222,7 +2165,7 @@ const defaultConnectorProjectionMatchesAuthMethod$ = command(
 );
 
 function getDefaultConnectorProjectionConnectionId(
-  account: ConnectorAccountMutationIntent,
+  account: PlatformConnectorAccountMutationIntent,
   expectedConnectionId: string | null,
   useDefaultConnectorProjection: boolean,
 ): string | null {
@@ -2268,7 +2211,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
       readonly connectorLabel: string;
       readonly connectorIcon: PublicConnectorCatalogIcon;
       readonly agentId: string | undefined;
-      readonly account: ConnectorAccountMutationIntent;
+      readonly account: PlatformConnectorAccountMutationIntent;
       readonly authorizeAgent: boolean;
       readonly beforeStart: (signal: AbortSignal) => Promise<void>;
     },
@@ -2399,7 +2342,7 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
       readonly connectorSlug: ConnectorSlug;
       readonly method: PublicConnectorCatalogAuthMethodDetail;
       readonly options: BrowserAuthPostConnectOptions;
-      readonly account: ConnectorAccountMutationIntent;
+      readonly account: PlatformConnectorAccountMutationIntent;
       readonly onConnectorChanged$: ReturnType<
         typeof createConnectorOAuthAuthCodeChangedCommand
       >;
@@ -2487,10 +2430,9 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
         account.intent === "reconnect" ? account.connectionId : null;
     }
 
-    set(reloadConnectors$);
+    set(reloadConnectorConnectionState$);
     const isConnected =
-      (!options.useDefaultConnectorProjection &&
-        account.intent !== "single-account") ||
+      !options.useDefaultConnectorProjection ||
       (await set(
         defaultConnectorProjectionMatchesAuthMethod$,
         connectorSlug,
@@ -2540,7 +2482,7 @@ export const connectConnectorOAuthAuthCode$ = command(
     }
 
     const flow = createConnectorConnectFlowState(connectorSlug);
-    const account = options.account ?? singleAccountConnectorMutation;
+    const account = options.account;
     set(internalConnectFlowState$, flow);
     set(internalPollingOAuthAuthCodeConnectorSlug$, connectorSlug);
 

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -180,7 +180,7 @@ function isNoAuthGrantKind(grantKind: ConnectorStatusGrantKind): boolean {
   return grantKind === "none";
 }
 
-export function getConnectorStatusAuthMethod(
+function getConnectorStatusAuthMethod(
   connector: PlatformConnectorCatalogStatusItem,
   authMethod: ConnectorAuthMethodId,
 ): PublicConnectorCatalogAuthMethodDetail | null {
@@ -234,7 +234,7 @@ export function getConnectorStatusConnectLaunchMode(
   return getConnectorStatusDirectConnectMethod(connector)?.kind ?? "modal";
 }
 
-export function getAvailableStatusAuthCodeAuthMethod(
+function getAvailableStatusAuthCodeAuthMethod(
   connector: PlatformConnectorCatalogStatusItem,
   authMethod: string,
 ): ConnectorAuthMethodId | null {

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -13,10 +13,6 @@ import {
   type UpdateCustomConnectorBody,
 } from "@okouai/api-contracts/contracts/custom-connectors";
 import {
-  connectorAccountsContract,
-  type ConnectorAccountMutationIntent,
-} from "@okouai/api-contracts/contracts/connector-accounts";
-import {
   agentCustomConnectorsContract,
   type AgentCustomConnectorGrants,
 } from "@okouai/api-contracts/contracts/agent-custom-connectors";
@@ -29,7 +25,7 @@ import { agents$ } from "../../agent.ts";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
 import { setAblyLoop$ } from "../../realtime.ts";
 import { setLoop, withCleanup } from "../../utils.ts";
-import { singleAccountConnectorMutation } from "../../connector-domain.ts";
+import type { PlatformConnectorAccountMutationIntent } from "../../connector-domain.ts";
 import {
   connectorAccountConnectionExists,
   connectorAccountMutationCompleted,
@@ -386,7 +382,7 @@ const setCustomConnectorValuesForTarget$ = command(
       readonly id: string;
       readonly values: readonly CustomConnectorValueInput[];
       readonly authorizationTarget: CustomConnectorAuthorizationTarget;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: PlatformConnectorAccountMutationIntent;
       readonly authorizeTarget?: boolean;
     },
     signal: AbortSignal,
@@ -397,7 +393,7 @@ const setCustomConnectorValuesForTarget$ = command(
       client.set({
         params: { id: args.id },
         body: {
-          account: args.account ?? singleAccountConnectorMutation,
+          account: args.account,
           values: [...args.values],
         },
         fetchOptions: { signal },
@@ -459,7 +455,7 @@ export const setCustomConnectorValues$ = command(
     args: {
       readonly id: string;
       readonly values: readonly CustomConnectorValueInput[];
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: PlatformConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
@@ -481,7 +477,7 @@ export const setCustomConnectorValuesForAgent$ = command(
       readonly id: string;
       readonly values: readonly CustomConnectorValueInput[];
       readonly agentId: string;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: PlatformConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
@@ -490,7 +486,7 @@ export const setCustomConnectorValuesForAgent$ = command(
       {
         id: args.id,
         values: args.values,
-        ...(args.account ? { account: args.account } : {}),
+        account: args.account,
         authorizationTarget: { kind: "agent", agentId: args.agentId },
       },
       signal,
@@ -504,7 +500,7 @@ export const setCustomConnectorAccountValues$ = command(
     args: {
       readonly id: string;
       readonly values: readonly CustomConnectorValueInput[];
-      readonly account: ConnectorAccountMutationIntent;
+      readonly account: PlatformConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
@@ -520,39 +516,13 @@ export const setCustomConnectorAccountValues$ = command(
   },
 );
 
-export const disconnectCustomConnector$ = command(
-  async ({ get, set }, id: string, signal: AbortSignal): Promise<void> => {
-    const createClient = get(apiClient$);
-    const client = createClient(connectorAccountsContract);
-    await accept(
-      client.disconnectSingleAccount({
-        body: {
-          target: { kind: "custom", customConnectorId: id },
-        },
-        fetchOptions: { signal },
-      }),
-      [204],
-    );
-    signal.throwIfAborted();
-    set(bumpReload$);
-    toast.success(
-      i18n.t(($) => {
-        return $.connectors.custom.toasts.disconnected;
-      }),
-    );
-  },
-);
-
 async function customConnectorAccountMutationCompleted(
   createClient: ApiClientFactory,
   connectorId: string,
-  account: ConnectorAccountMutationIntent | undefined,
+  account: PlatformConnectorAccountMutationIntent,
   initialVersion: ConnectorAccountMutationVersion | undefined,
   signal: AbortSignal,
 ): Promise<boolean> {
-  if (!account || account.intent === "single-account") {
-    return true;
-  }
   const currentVersion = await readConnectorAccountMutationVersion(
     createClient,
     { kind: "custom", customConnectorId: connectorId },
@@ -568,7 +538,7 @@ async function customConnectorAccountMutationCompleted(
 interface CustomConnectorAuthorizationTargetArgs {
   readonly id: string;
   readonly authorizationTarget: CustomConnectorAuthorizationTarget;
-  readonly account?: ConnectorAccountMutationIntent;
+  readonly account: PlatformConnectorAccountMutationIntent;
   readonly authorizeTarget?: boolean;
   readonly useDefaultConnectorProjection?: boolean;
 }
@@ -580,23 +550,23 @@ interface CustomConnectorOAuthCompletion {
 
 function defaultCustomConnectorOAuthCompletion(args: {
   readonly connector: CustomConnectorResponse | undefined;
-  readonly account: ConnectorAccountMutationIntent | undefined;
+  readonly account: PlatformConnectorAccountMutationIntent;
   readonly expectedConnectionId: string | null;
   readonly initialUpdatedAt: string | null | undefined;
 }): CustomConnectorOAuthCompletion {
   const connectionId =
-    args.account?.intent === "reconnect"
+    args.account.intent === "reconnect"
       ? args.account.connectionId
       : args.expectedConnectionId;
   const projectedAccountMatches =
     args.connector?.connectedAccountId === connectionId ||
-    (args.account?.intent === "add" &&
+    (args.account.intent === "add" &&
       args.connector?.connectedAccountId === undefined);
   const completed =
     connectionId !== null &&
     args.connector?.connected === true &&
     projectedAccountMatches &&
-    (args.account?.intent === "add"
+    (args.account.intent === "add"
       ? args.initialUpdatedAt === null
       : args.initialUpdatedAt !== undefined &&
         args.connector.connectedAccountUpdatedAt !== undefined &&
@@ -649,7 +619,7 @@ async function customConnectorOAuthCompletion(
   return {
     completed,
     connectionId:
-      completed && args.target.account?.intent === "reconnect"
+      completed && args.target.account.intent === "reconnect"
         ? args.target.account.connectionId
         : null,
   };
@@ -716,22 +686,21 @@ const connectCustomConnectorAuthorizationForTarget$ = command(
               return connector.id === args.id;
             })?.connectedAccountUpdatedAt ?? null;
         }
-        initialAccountVersion =
-          args.account && !args.useDefaultConnectorProjection
-            ? await readConnectorAccountMutationVersion(
-                createClient,
-                { kind: "custom", customConnectorId: args.id },
-                args.account,
-                signal,
-              )
-            : undefined;
+        initialAccountVersion = !args.useDefaultConnectorProjection
+          ? await readConnectorAccountMutationVersion(
+              createClient,
+              { kind: "custom", customConnectorId: args.id },
+              args.account,
+              signal,
+            )
+          : undefined;
         const client = createClient(customConnectorOAuth2Contract, {
           apiBase: "api",
         });
         const result = await accept(
           client.start({
             params: { id: args.id },
-            body: { account: args.account ?? singleAccountConnectorMutation },
+            body: { account: args.account },
             fetchOptions: { signal },
           }),
           [200],
@@ -823,7 +792,7 @@ export const connectCustomConnectorAuthorization$ = command(
     { set },
     args: {
       readonly id: string;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: PlatformConnectorAccountMutationIntent;
       readonly useDefaultConnectorProjection?: boolean;
     },
     signal: AbortSignal,
@@ -845,7 +814,7 @@ export const connectCustomConnectorAuthorizationForAgent$ = command(
     args: {
       readonly id: string;
       readonly agentId: string;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: PlatformConnectorAccountMutationIntent;
       readonly useDefaultConnectorProjection?: boolean;
     },
     signal: AbortSignal,
@@ -854,7 +823,7 @@ export const connectCustomConnectorAuthorizationForAgent$ = command(
       connectCustomConnectorAuthorizationForTarget$,
       {
         id: args.id,
-        ...(args.account ? { account: args.account } : {}),
+        account: args.account,
         ...(args.useDefaultConnectorProjection
           ? { useDefaultConnectorProjection: true as const }
           : {}),
@@ -870,7 +839,7 @@ export const connectCustomConnectorAccountAuthorization$ = command(
     { set },
     args: {
       readonly id: string;
-      readonly account: ConnectorAccountMutationIntent;
+      readonly account: PlatformConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
@@ -894,7 +863,6 @@ type DialogState =
   | { kind: "none" }
   | { kind: "create" }
   | { kind: "edit"; connector: CustomConnectorResponse }
-  | { kind: "connect"; connector: CustomConnectorResponse }
   | { kind: "access"; connector: CustomConnectorResponse }
   | { kind: "delete"; connector: CustomConnectorResponse };
 
@@ -936,12 +904,6 @@ export const openCustomConnectorEditConfirmationDialog$ = command(
 export const closeCustomConnectorEditConfirmationDialog$ = command(
   ({ set }) => {
     set(internalEditConfirmation$, null);
-  },
-);
-export const openCustomConnectorConnectDialog$ = command(
-  ({ set }, connector: CustomConnectorResponse) => {
-    set(internalConnectForm$, CONNECT_FORM_DEFAULTS);
-    set(internalDialog$, { kind: "connect", connector });
   },
 );
 export const openCustomConnectorAccessDialog$ = command(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx
@@ -163,7 +163,6 @@ test("Carry a connector account choice into a new chat", async () => {
   await setupPage({
     context,
     path: `/agents/${SCOUT_AGENT_ID}/chat`,
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
 
   await loadComposer();
@@ -271,7 +270,6 @@ test("Choose an account for a custom MCP connector", async () => {
     context,
     path: `/chats/${SCOUT_THREAD_ID}`,
     featureSwitches: {
-      [FeatureSwitchKey.ConnectorAccounts]: true,
       [FeatureSwitchKey.CustomConnectorMcp]: true,
     },
   });
@@ -319,7 +317,6 @@ test("Keep the selected connector account visible during search", async () => {
   await setupPage({
     context,
     path: `/chats/${SCOUT_THREAD_ID}`,
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
 
   await loadComposer();
@@ -357,7 +354,6 @@ test("Choose which connector account a chat uses", async () => {
   await setupPage({
     context,
     path: `/chats/${SCOUT_THREAD_ID}`,
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
 
   await loadComposer();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connectors.test.tsx
@@ -427,7 +427,6 @@ test("Show only the connector actions that are useful in chat", async () => {
   await setupPage({
     context,
     path: `/agents/${SCOUT_AGENT_ID}/chat`,
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
 
   await loadComposer();
@@ -538,7 +537,6 @@ test("Respect integration-managed connector availability in chat", async () => {
   await setupPage({
     context,
     path: `/agents/${SCOUT_AGENT_ID}/chat`,
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
 
   await loadComposer();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connector-page-test-helpers.ts
@@ -275,9 +275,35 @@ function publicOAuthConfig(
 export function mockCustomConnectorStory(context: TestContext): void {
   context.mocks.data.org({ id: "org_1", name: "Test Org", role: "admin" });
   let connectors: CustomConnectorHttpResponse[] = [];
+  const accounts = new Map<string, ConnectorAccountConnection>();
   context.mocks.api(customConnectorsContract.list, ({ respond }) => {
     return respond(200, { connectors });
   });
+  context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+    return respond(200, {
+      summaries: [...accounts.values()].map((account) => {
+        return {
+          target: account.target,
+          accountCount: 1,
+          attentionCount: 0,
+          defaultConnection: account,
+        };
+      }),
+    });
+  });
+  context.mocks.api(
+    connectorAccountsContract.connection,
+    ({ params, respond }) => {
+      const account = [...accounts.values()].find((candidate) => {
+        return candidate.id === params.connectionId;
+      });
+      return account
+        ? respond(200, account)
+        : respond(404, {
+            error: { message: "Account not found", code: "NOT_FOUND" },
+          });
+    },
+  );
   context.mocks.api(customConnectorsContract.create, ({ body, respond }) => {
     if (body.kind === "mcp" || body.authMode === "automatic") {
       throw new Error("Expected an HTTP custom connector");
@@ -314,27 +340,31 @@ export function mockCustomConnectorStory(context: TestContext): void {
       if (!updated) {
         throw new Error(`Expected custom connector ${params.id}`);
       }
-      return respond(200, updated);
-    },
-  );
-  context.mocks.api(
-    connectorAccountsContract.disconnectSingleAccount,
-    ({ body, respond }) => {
-      if (body.target.kind !== "custom") {
-        throw new Error("Expected custom connector disconnect target");
-      }
-      const customConnectorId = body.target.customConnectorId;
-      connectors = connectors.map((connector) => {
-        return connector.id === customConnectorId
-          ? {
-              ...connector,
-              connected: false,
-              missingRequiredFields: ["secret"],
-              configuredFieldKeys: [],
-            }
-          : connector;
+      const connectionId = crypto.randomUUID();
+      accounts.set(params.id, {
+        id: connectionId,
+        target: { kind: "custom", customConnectorId: params.id },
+        authMethod: "manual",
+        displayName: null,
+        isDefault: true,
+        externalId: null,
+        externalUsername: null,
+        externalEmail: null,
+        oauthScopes: null,
+        connectionStatus: "connected",
+        reconnectReason: null,
+        tokenExpiresAt: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
       });
-      return respond(204);
+      const connected = customConnectorHttpResponseSchema.parse({
+        ...updated,
+        connectedAccountId: connectionId,
+      });
+      connectors = connectors.map((connector) => {
+        return connector.id === params.id ? connected : connector;
+      });
+      return respond(200, connected);
     },
   );
   context.mocks.api(
@@ -377,6 +407,7 @@ export function mockCustomConnectorStory(context: TestContext): void {
   context.mocks.api(
     customConnectorByIdContract.delete,
     ({ params, respond }) => {
+      accounts.delete(params.id);
       connectors = connectors.filter((connector) => {
         return connector.id !== params.id;
       });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
@@ -2,14 +2,10 @@ import {
   type ConnectorAccountConnection,
   connectorAccountsContract,
 } from "@okouai/api-contracts/contracts/connector-accounts";
-import {
-  connectorOauthStartContract,
-  connectorScopeDiffContract,
-} from "@okouai/api-contracts/contracts/connectors";
+import { connectorOauthStartContract } from "@okouai/api-contracts/contracts/connectors";
 import { customConnectorsContract } from "@okouai/api-contracts/contracts/custom-connectors";
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
 import { userPermissionGrantsContract } from "@okouai/api-contracts/contracts/user-permission-grants";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { expect, test } from "vitest";
 
@@ -32,10 +28,6 @@ import {
 } from "./connector-page-test-helpers.ts";
 
 const context = testContext();
-
-function legacyConnectorFeatureSwitches() {
-  return { [FeatureSwitchKey.ConnectorAccounts]: false };
-}
 
 function createAuthWindow(): Window {
   const authWindow = context.mocks.browser.authWindow();
@@ -91,7 +83,6 @@ function setupAccountsPage(): Promise<void> {
   return setupPage({
     context,
     path: "/connectors",
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
 }
 
@@ -330,41 +321,6 @@ test("Summarize connector access on its card", async () => {
   ).toBeEnabled();
 });
 
-test("Keep a connector connected when an account must be chosen", async () => {
-  mockConnectors(context, [
-    { connectorSlug: "github", externalUsername: "octocat" },
-  ]);
-  context.mocks.api(
-    connectorAccountsContract.disconnectSingleAccount,
-    ({ respond }) => {
-      return respond(409, {
-        error: {
-          code: "CONFLICT",
-          message: "Choose an account before disconnecting",
-        },
-      });
-    },
-  );
-  await setupPage({
-    context,
-    path: "/connectors",
-    featureSwitches: legacyConnectorFeatureSwitches(),
-  });
-  const card = await waitFor(() => {
-    return getConnectorCard("GitHub");
-  });
-
-  click(getConnectorAction("button", "More options", card));
-  click(getConnectorAction("menuitem", "Disconnect"));
-
-  await expect(
-    screen.findByText("Choose an account before disconnecting"),
-  ).resolves.toBeInTheDocument();
-  expect(within(card).getByText("@octocat")).toBeInTheDocument();
-  click(getConnectorAction("button", "More options", card));
-  expect(getConnectorAction("menuitem", "Disconnect")).toBeInTheDocument();
-});
-
 test("Make another connector account the default", async () => {
   const [connector] = mockConnectors(context, [
     { connectorSlug: "github", externalUsername: "work" },
@@ -532,34 +488,6 @@ test("Discard a pending account deletion when its manager closes", async () => {
   });
 });
 
-test("Disconnect a connected connector", async () => {
-  mockConnectors(context, [
-    { connectorSlug: "github", externalUsername: "octocat" },
-  ]);
-  context.mocks.api(
-    connectorAccountsContract.disconnectSingleAccount,
-    ({ respond }) => {
-      context.mocks.data.connectors([]);
-      return respond(204);
-    },
-  );
-  await setupPage({
-    context,
-    path: "/connectors",
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: false },
-  });
-  const card = await waitFor(() => {
-    return getConnectorCard("GitHub");
-  });
-
-  click(getConnectorAction("button", "More options", card));
-  click(getConnectorAction("menuitem", "Disconnect"));
-
-  await waitFor(() => {
-    expect(getConnectorAction("button", "Connect GitHub")).toBeInTheDocument();
-  });
-});
-
 test("Exclude deleted agents from connector access", async () => {
   const activeId = "c0000000-0000-4000-a000-000000000001";
   const deletedId = "c0000000-0000-4000-a000-000000000002";
@@ -719,55 +647,6 @@ test("Load connector accounts progressively", async () => {
   expect(queryConnectorAction("button", "Load more", dialog)).toBeNull();
   expect(within(dialog).getAllByText("Unnamed account")).toHaveLength(1);
   expect(accountActions(dialog)).toHaveLength(8);
-});
-
-test("Reconnect an expired connection", async () => {
-  mockConnectors(context, [
-    {
-      connectorSlug: "meta-ads",
-      connectionStatus: "reconnect-required",
-      reconnectReason: "authorization_expired_or_revoked",
-    },
-  ]);
-  const authWindow = createAuthWindow();
-  context.mocks.browser.open(authWindow);
-  context.mocks.browser.standaloneDisplayMode(true);
-  context.mocks.api(
-    connectorOauthStartContract.start,
-    ({ body, params, respond }) => {
-      expect(params.connectorSlug).toBe("meta-ads");
-      expect(body.account).toStrictEqual({ intent: "single-account" });
-      expect(body.callbackTarget).toBe("app");
-      return respond(200, {
-        authorizationUrl: "https://oauth.test/meta-ads/authorize",
-      });
-    },
-  );
-  await setupPage({
-    context,
-    path: "/connectors",
-    featureSwitches: legacyConnectorFeatureSwitches(),
-  });
-  const card = await waitFor(() => {
-    return getConnectorCard("Meta Ads");
-  });
-  expect(within(card).getByText("Connection expired")).toBeInTheDocument();
-  expect(
-    queryConnectorAction("button", "Why this connection expired", card),
-  ).toBeNull();
-
-  click(getConnectorAction("button", "More options", card));
-  click(getConnectorAction("menuitem", "Reconnect"));
-
-  await waitFor(() => {
-    expect(authWindow.location.href).toBe(
-      "https://oauth.test/meta-ads/authorize",
-    );
-  });
-  expect(within(card).getByText("Connecting…")).toBeInTheDocument();
-  expect(
-    within(card).queryByText("Switch back here after completing sign-in."),
-  ).not.toBeInTheDocument();
 });
 
 test("Reconnect the selected non-default account", async () => {
@@ -1043,44 +922,6 @@ test("Rename and delete a specific connector account", async () => {
     expect(within(manager).getByText("No accounts found")).toBeInTheDocument();
     expect(getConnectorAction("button", "Add account", manager)).toBeEnabled();
   });
-});
-
-test("Review newly requested connector permissions", async () => {
-  const storedScopes = ["https://www.googleapis.com/auth/adwords"];
-  const addedScopes = [
-    "https://www.googleapis.com/auth/datamanager",
-    "https://www.googleapis.com/auth/userinfo.email",
-  ];
-  mockConnectors(context, [
-    { connectorSlug: "google-ads", oauthScopes: storedScopes },
-  ]);
-  context.mocks.api(connectorScopeDiffContract.getScopeDiff, ({ respond }) => {
-    return respond(200, {
-      addedScopes,
-      removedScopes: [],
-      currentScopes: [...storedScopes, ...addedScopes],
-      storedScopes,
-    });
-  });
-  await setupPage({
-    context,
-    path: "/connectors",
-    featureSwitches: legacyConnectorFeatureSwitches(),
-  });
-  const card = await waitFor(() => {
-    return getConnectorCard("Google Ads");
-  });
-  expect(within(card).getByText("Update permissions")).toBeInTheDocument();
-
-  click(getConnectorAction("button", "More options", card));
-  click(getConnectorAction("menuitem", "Review permissions"));
-
-  const dialog = await screen.findByRole("dialog", {
-    name: "Google Ads permissions update",
-  });
-  expect(within(dialog).getByText("New permissions")).toBeInTheDocument();
-  expect(within(dialog).getByText(addedScopes[0] ?? "")).toBeInTheDocument();
-  expect(within(dialog).getByText(addedScopes[1] ?? "")).toBeInTheDocument();
 });
 
 test("Review and reconnect the connector account the user selected", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -11,7 +11,6 @@ import {
 } from "@okouai/api-contracts/contracts/connectors";
 import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import { userConnectorsContract } from "@okouai/api-contracts/contracts/user-connectors";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import { HttpResponse } from "msw";
 import { expect, test } from "vitest";
@@ -34,10 +33,6 @@ import {
 } from "./connector-page-test-helpers.ts";
 
 const context = testContext();
-
-function legacyConnectorFeatureSwitches() {
-  return { [FeatureSwitchKey.ConnectorAccounts]: false };
-}
 
 function createAuthWindow(): Window {
   const authWindow = context.mocks.browser.authWindow();
@@ -74,12 +69,12 @@ function createReusableAuthWindow(): {
   };
 }
 
-function connectedConnector(
+function storeConnectedConnector(
   slug: ConnectorSlug,
   authMethod: string,
   externalUsername: string | null = null,
 ): ConnectorResponse {
-  return {
+  const connector = {
     id: crypto.randomUUID(),
     slug,
     authMethod,
@@ -92,7 +87,9 @@ function connectedConnector(
     tokenExpiresAt: null,
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
-  };
+  } satisfies ConnectorResponse;
+  context.mocks.data.connectors([connector]);
+  return connector;
 }
 
 function mockAgentConnectorAccess(connectorSlug: ConnectorSlug): void {
@@ -223,7 +220,6 @@ test("Add an AWS account with an external code", async () => {
   await setupPage({
     context,
     path: "/connectors",
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
   await fill(await screen.findByPlaceholderText("Find connectors"), "aws");
   click(
@@ -309,7 +305,6 @@ test("Add an account through OpenID", async () => {
   await setupPage({
     context,
     path: "/connectors?keywords=partner+steam",
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
 
   await expect(screen.findByText("Partner Steam")).resolves.toBeInTheDocument();
@@ -340,13 +335,12 @@ test("Choose a credential-free method among multiple connection methods", async 
     connectorNoAuthGrantContract.connect,
     ({ body, respond }) => {
       selectedMethod = body.authMethod;
-      return respond(200, connectedConnector("stripe", body.authMethod));
+      return respond(200, storeConnectedConnector("stripe", body.authMethod));
     },
   );
   await setupPage({
     context,
     path: "/connectors?keywords=public+stripe",
-    featureSwitches: legacyConnectorFeatureSwitches(),
   });
   click(
     await waitFor(() => {
@@ -365,12 +359,12 @@ test("Choose a credential-free method among multiple connection methods", async 
   await waitFor(() => {
     expect(selectedMethod).toBe("api");
     expect(
-      within(getConnectorCard("Public Stripe")).getByText("Connected"),
+      within(getConnectorCard("Public Stripe")).getByText("API key"),
     ).toBeInTheDocument();
   });
 });
 
-test("Authorize eligible agents after a manual connection", async () => {
+test("Keep agent access independent after a manual connection", async () => {
   const researchId = "c0000000-0000-4000-a000-000000000002";
   mockConnectors(context, []);
   context.mocks.data.agents([
@@ -395,14 +389,13 @@ test("Authorize eligible agents after a manual connection", async () => {
   context.mocks.api(
     connectorManualGrantContract.connect,
     ({ body, respond }) => {
-      return respond(200, connectedConnector("axiom", body.authMethod));
+      return respond(200, storeConnectedConnector("axiom", body.authMethod));
     },
   );
   mockAgentConnectorAccess("axiom");
   await setupPage({
     context,
     path: "/connectors?keywords=axiom",
-    featureSwitches: legacyConnectorFeatureSwitches(),
   });
   click(
     await waitFor(() => {
@@ -417,9 +410,13 @@ test("Authorize eligible agents after a manual connection", async () => {
   await expect(
     screen.findByText("Public Axiom connected successfully"),
   ).resolves.toBeInTheDocument();
+  const naming = await screen.findByRole("dialog", {
+    name: "Name your Public Axiom account",
+  });
+  click(getConnectorAction("button", "Skip", naming));
   await waitFor(() => {
     expect(
-      within(getConnectorCard("Public Axiom")).getByText("Connected"),
+      within(getConnectorCard("Public Axiom")).getByText("API token"),
     ).toBeInTheDocument();
     expect(
       getConnectorAction(
@@ -427,7 +424,7 @@ test("Authorize eligible agents after a manual connection", async () => {
         "Manage Public Axiom access",
         getConnectorCard("Public Axiom"),
       ),
-    ).toHaveTextContent("Used by Research Agent");
+    ).toHaveTextContent("Add access");
   });
   expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 });
@@ -454,7 +451,6 @@ test("Connect through device authorization", async () => {
   await setupPage({
     context,
     path: "/connectors",
-    featureSwitches: legacyConnectorFeatureSwitches(),
   });
   click(
     await waitFor(() => {
@@ -474,9 +470,13 @@ test("Connect through device authorization", async () => {
       return call.url?.includes("oauth.test/base44/device") ?? false;
     }),
   ).toBeTruthy();
+  const naming = await screen.findByRole("dialog", {
+    name: "Name your Base44 account",
+  });
+  click(getConnectorAction("button", "Skip", naming));
   await waitFor(() => {
     expect(
-      within(getConnectorCard("Base44")).getByText("Connected"),
+      within(getConnectorCard("Base44")).getByText("mock-base44"),
     ).toBeInTheDocument();
   });
 });
@@ -505,13 +505,12 @@ test("Connect with a manual credential", async () => {
     ({ body, respond }) => {
       submits += 1;
       submitted = body.values;
-      return respond(200, connectedConnector("axiom", body.authMethod));
+      return respond(200, storeConnectedConnector("axiom", body.authMethod));
     },
   );
   await setupPage({
     context,
     path: "/connectors",
-    featureSwitches: legacyConnectorFeatureSwitches(),
   });
   click(
     await waitFor(() => {
@@ -530,7 +529,7 @@ test("Connect with a manual credential", async () => {
     expect(submitted).toStrictEqual({ apiToken: "xaat-test" });
     expect(submits).toBe(1);
     expect(
-      within(getConnectorCard("Public Axiom")).getByText("Connected"),
+      within(getConnectorCard("Public Axiom")).getByText("API token"),
     ).toBeInTheDocument();
   });
 });
@@ -553,15 +552,14 @@ test("Enable a connector that needs no credentials", async () => {
   context.mocks.api(
     connectorNoAuthGrantContract.connect,
     ({ body, respond }) => {
-      expect(body.authorizeAgent).toBeTruthy();
-      return respond(200, connectedConnector("stripe", body.authMethod));
+      expect(body.authorizeAgent).toBeFalsy();
+      return respond(200, storeConnectedConnector("stripe", body.authMethod));
     },
   );
   mockAgentConnectorAccess("stripe");
   await setupPage({
     context,
     path: "/connectors",
-    featureSwitches: legacyConnectorFeatureSwitches(),
   });
 
   click(
@@ -573,9 +571,13 @@ test("Enable a connector that needs no credentials", async () => {
   await expect(
     screen.findByText("Public Stripe enabled successfully"),
   ).resolves.toBeInTheDocument();
+  const naming = await screen.findByRole("dialog", {
+    name: "Name your Public Stripe account",
+  });
+  click(getConnectorAction("button", "Skip", naming));
   await waitFor(() => {
     expect(
-      within(getConnectorCard("Public Stripe")).getByText("Connected"),
+      within(getConnectorCard("Public Stripe")).getByText("API key"),
     ).toBeInTheDocument();
     expect(
       getConnectorAction(
@@ -583,7 +585,7 @@ test("Enable a connector that needs no credentials", async () => {
         "Manage Public Stripe access",
         getConnectorCard("Public Stripe"),
       ),
-    ).toHaveTextContent("Used by Research Agent");
+    ).toHaveTextContent("Add access");
   });
   expect(browserOpen.calls).toHaveLength(0);
   expect(screen.queryByText(/You've successfully connected with/u)).toBeNull();
@@ -678,7 +680,6 @@ test("Complete OAuth only after the selected connector changes", async () => {
   await setupPage({
     context,
     path: "/connectors?keywords=public+stripe",
-    featureSwitches: legacyConnectorFeatureSwitches(),
   });
   click(
     await waitFor(() => {
@@ -704,7 +705,9 @@ test("Complete OAuth only after the selected connector changes", async () => {
   });
   await waitFor(() => {
     const stripeCard = getConnectorCard("Public Stripe");
-    expect(stripeCard).toHaveAttribute("aria-label", "Connect Public Stripe");
+    expect(
+      within(stripeCard).getByLabelText("Connect Public Stripe"),
+    ).toBeInTheDocument();
     expect(within(stripeCard).queryByText("Connected")).toBeNull();
     expect(within(stripeCard).queryByText("Research Agent")).toBeNull();
   });
@@ -728,7 +731,7 @@ test("Complete OAuth only after the selected connector changes", async () => {
   await waitFor(() => {
     expect(screen.queryByRole("dialog", { name: "Public Stripe" })).toBeNull();
     expect(
-      within(getConnectorCard("Public Stripe")).getByText("Connected"),
+      within(getConnectorCard("Public Stripe")).getByText("Unnamed account"),
     ).toBeInTheDocument();
   });
   await waitFor(() => {
@@ -738,7 +741,7 @@ test("Complete OAuth only after the selected connector changes", async () => {
         "Manage Public Stripe access",
         getConnectorCard("Public Stripe"),
       ),
-    ).toHaveTextContent("Used by Research Agent");
+    ).toHaveTextContent("Add access");
   });
 });
 
@@ -751,7 +754,7 @@ test("Name a newly added manual account", async () => {
     connectorManualGrantContract.connect,
     ({ body, respond }) => {
       const connector = {
-        ...connectedConnector("ahrefs", body.authMethod),
+        ...storeConnectedConnector("ahrefs", body.authMethod),
         id: connectionId,
         externalEmail: "owner@example.com",
       };
@@ -784,7 +787,6 @@ test("Name a newly added manual account", async () => {
   await setupPage({
     context,
     path: "/connectors",
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
   click(
     await waitFor(() => {
@@ -830,7 +832,7 @@ test("Optionally name a newly added credential-free account", async () => {
       submittedAccount = body.account;
       submittedAuthorizeAgent = body.authorizeAgent;
       const connector = {
-        ...connectedConnector("stripe", body.authMethod),
+        ...storeConnectedConnector("stripe", body.authMethod),
         id: connectionId,
       };
       context.mocks.data.connectors([connector]);
@@ -840,7 +842,6 @@ test("Optionally name a newly added credential-free account", async () => {
   await setupPage({
     context,
     path: "/connectors",
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
 
   click(
@@ -936,7 +937,6 @@ test("Retry device authorization after a provider error", async () => {
   await setupPage({
     context,
     path: "/connectors",
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
   click(
     await waitFor(() => {
@@ -1112,13 +1112,12 @@ test("Submit credentials only for the chosen manual method", async () => {
     ({ body, respond }) => {
       submittedMethod = body.authMethod;
       submittedValues = body.values;
-      return respond(200, connectedConnector("axiom", body.authMethod));
+      return respond(200, storeConnectedConnector("axiom", body.authMethod));
     },
   );
   await setupPage({
     context,
     path: "/connectors",
-    featureSwitches: legacyConnectorFeatureSwitches(),
   });
   click(
     await waitFor(() => {
@@ -1145,7 +1144,7 @@ test("Submit credentials only for the chosen manual method", async () => {
     expect(submittedMethod).toBe("api");
     expect(submittedValues).toStrictEqual({ apiKey: "api-key-test" });
     expect(
-      within(getConnectorCard("Public Axiom")).getByText("Connected"),
+      within(getConnectorCard("Public Axiom")).getByText("API key"),
     ).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-catalog.test.tsx
@@ -411,7 +411,6 @@ test("Present a connector with no accounts", async () => {
   await setupPage({
     context,
     path: "/connectors",
-    featureSwitches: { [FeatureSwitchKey.ConnectorAccounts]: true },
   });
   const card = await waitFor(() => {
     return getConnectorCard("GitHub");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
@@ -49,7 +49,6 @@ const SUPPORT_ID = "c0000000-0000-4000-a000-000000000052";
 
 function setupCustomPage(
   options: {
-    readonly accounts?: boolean;
     readonly mcp?: boolean;
   } = {},
 ): Promise<void> {
@@ -58,7 +57,6 @@ function setupCustomPage(
     context,
     path: "/connectors?tab=custom",
     featureSwitches: {
-      [FeatureSwitchKey.ConnectorAccounts]: options.accounts ?? false,
       [FeatureSwitchKey.CustomConnectorMcp]: options.mcp ?? false,
     },
   });
@@ -102,6 +100,32 @@ function customAccount(
     updatedAt: "2026-01-01T00:00:00.000Z",
     ...overrides,
   };
+}
+
+function mockCustomAccountSummary(
+  readConnector: () => CustomConnectorResponse | null,
+): void {
+  context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+    const connector = readConnector();
+    if (!connector?.connected) {
+      return respond(200, { summaries: [] });
+    }
+    const account = customAccount(
+      connector.id,
+      "66666666-6666-4666-8666-666666666666",
+      { authMethod: connector.authMode === "manual" ? "manual" : "oauth" },
+    );
+    return respond(200, {
+      summaries: [
+        {
+          target: account.target,
+          accountCount: 1,
+          attentionCount: 0,
+          defaultConnection: account,
+        },
+      ],
+    });
+  });
 }
 
 function accountAction(container: ParentNode): HTMLElement {
@@ -221,7 +245,7 @@ test("Add and optionally name a custom connector account", async () => {
     grantMutations += 1;
     return respond(200, { grants: [] });
   });
-  await setupCustomPage({ accounts: true, mcp: true });
+  await setupCustomPage({ mcp: true });
 
   for (const name of ["Acme Search", "Acme MCP"]) {
     click(
@@ -296,7 +320,7 @@ test("Enable custom connector access when an account becomes available", async (
       });
     },
   );
-  await setupCustomPage({ accounts: true });
+  await setupCustomPage();
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Manage Acme Search access");
@@ -389,6 +413,9 @@ test("Manage agent access and permissions for a custom connector", async () => {
       return respond(200, grants);
     },
   );
+  mockCustomAccountSummary(() => {
+    return connector;
+  });
   await setupCustomPage();
   click(
     await waitFor(() => {
@@ -547,7 +574,7 @@ test("Complete a custom connector’s declared fields", async () => {
   expect(within(dialog).getByLabelText("Backup token")).toHaveValue("");
   expect(
     within(dialog).getByLabelText("Backup token"),
-  ).toHaveAccessibleDescription("Optional · Configured");
+  ).toHaveAccessibleDescription("Optional");
   const save = getConnectorAction("button", "Save", dialog);
   expect(save).toBeDisabled();
 
@@ -575,9 +602,6 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
   await setupPage({
     context,
     path: "/connectors",
-    featureSwitches: {
-      [FeatureSwitchKey.ConnectorAccounts]: false,
-    },
   });
   click(
     await waitFor(() => {
@@ -614,7 +638,7 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
   });
   expect(card).toHaveTextContent("HTTP API");
   expect(card).toHaveTextContent("https://api.acme.test/v1/");
-  expect(card).toHaveTextContent("Not connected");
+  expect(card).toHaveTextContent("No accounts");
 
   click(getConnectorAction("button", "Connect Acme API", card));
   const connect = await screen.findByRole("dialog", {
@@ -622,15 +646,19 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
   });
   await fill(within(connect).getByLabelText("Secret"), "acme-secret");
   click(getConnectorAction("button", "Save", connect));
+  const naming = await screen.findByRole("dialog", {
+    name: "Name your Acme API account",
+  });
+  click(getConnectorAction("button", "Skip", naming));
   await waitFor(() => {
-    expect(getConnectorCard("Acme API")).toHaveTextContent("Connected");
+    expect(getConnectorCard("Acme API")).toHaveTextContent("Unnamed account");
     expect(
       getConnectorAction(
         "button",
         "Manage Acme API access",
         getConnectorCard("Acme API"),
       ),
-    ).toHaveTextContent("Used by 2 agents");
+    ).toHaveTextContent("Add access");
   });
 
   click(
@@ -651,33 +679,12 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
   await expect(
     screen.findByText("Acme Billing API"),
   ).resolves.toBeInTheDocument();
-  expect(getConnectorCard("Acme Billing API")).toHaveTextContent("Connected");
+  expect(getConnectorCard("Acme Billing API")).toHaveTextContent(
+    "Unnamed account",
+  );
   expect(getConnectorCard("Acme Billing API")).toHaveTextContent(
     "https://api.acme.test/v1/",
   );
-
-  click(
-    await waitFor(() => {
-      return getConnectorAction("button", "More options");
-    }),
-  );
-  click(
-    await waitFor(() => {
-      return getConnectorAction("menuitem", "Disconnect");
-    }),
-  );
-  await waitFor(() => {
-    expect(
-      getConnectorAction("button", "Connect Acme Billing API"),
-    ).toBeInTheDocument();
-  });
-  expect(
-    queryConnectorAction(
-      "button",
-      "Manage Acme Billing API access",
-      getConnectorCard("Acme Billing API"),
-    ),
-  ).toBeNull();
 
   click(
     await waitFor(() => {
@@ -751,7 +758,7 @@ test("Configure and maintain OAuth for a custom HTTP connector", async () => {
   context.mocks.api(
     customConnectorOAuth2Contract.start,
     ({ body, respond }) => {
-      expect(body.account).toStrictEqual({ intent: "single-account" });
+      expect(body.account).toStrictEqual({ intent: "add" });
       if (!connector) {
         throw new Error("Expected OAuth connector");
       }
@@ -763,6 +770,9 @@ test("Configure and maintain OAuth for a custom HTTP connector", async () => {
       });
     },
   );
+  mockCustomAccountSummary(() => {
+    return connector;
+  });
   await setupCustomPage();
   click(
     await waitFor(() => {
@@ -832,7 +842,7 @@ test("Configure and maintain OAuth for a custom HTTP connector", async () => {
   const card = await waitFor(() => {
     return getConnectorCard("Acme API");
   });
-  expect(card).toHaveTextContent("Not connected");
+  expect(card).toHaveTextContent("No accounts");
   expect(created[0]).toMatchObject({
     authMode: "oauth",
     prefixTemplates: ["https://api.acme.test/v1/"],
@@ -896,14 +906,14 @@ test("Configure and maintain OAuth for a custom HTTP connector", async () => {
     expect(authWindow.location.href).toBe(
       "https://oauth.acme.test/authorize?state=ui-test",
     );
-    expect(getConnectorCard("Acme API")).toHaveTextContent("Connected");
+    expect(getConnectorCard("Acme API")).toHaveTextContent("Unnamed account");
     expect(
       getConnectorAction(
         "button",
         "Manage Acme API access",
         getConnectorCard("Acme API"),
       ),
-    ).toHaveTextContent("Used by Research");
+    ).toHaveTextContent("Add access");
   });
 });
 
@@ -985,16 +995,9 @@ test("Manage a manual MCP connector through its lifecycle", async () => {
     };
     return respond(200, connector);
   });
-  context.mocks.api(
-    connectorAccountsContract.disconnectSingleAccount,
-    ({ respond }) => {
-      if (!connector) {
-        throw new Error("Expected MCP connector");
-      }
-      connector = { ...connector, connected: false };
-      return respond(204);
-    },
-  );
+  mockCustomAccountSummary(() => {
+    return connector;
+  });
   await setupCustomPage({ mcp: true });
   click(
     await waitFor(() => {
@@ -1025,7 +1028,7 @@ test("Manage a manual MCP connector through its lifecycle", async () => {
   });
   expect(card).toHaveTextContent("MCP");
   expect(card).toHaveTextContent("https://mcp.acme.test/server");
-  expect(card).toHaveTextContent("Not connected");
+  expect(card).toHaveTextContent("No accounts");
 
   click(getConnectorAction("button", "Connect Acme MCP", card));
   const connect = await screen.findByRole("dialog", {
@@ -1034,7 +1037,7 @@ test("Manage a manual MCP connector through its lifecycle", async () => {
   await fill(within(connect).getByLabelText("Secret"), "mcp-secret");
   click(getConnectorAction("button", "Save", connect));
   await waitFor(() => {
-    expect(getConnectorCard("Acme MCP")).toHaveTextContent("Connected");
+    expect(getConnectorCard("Acme MCP")).toHaveTextContent("Unnamed account");
     expect(
       getConnectorAction(
         "button",
@@ -1103,22 +1106,6 @@ test("Manage a manual MCP connector through its lifecycle", async () => {
     ],
     queryInjections: [],
   });
-
-  click(
-    await waitFor(() => {
-      return getConnectorAction("button", "More options");
-    }),
-  );
-  click(
-    await waitFor(() => {
-      return getConnectorAction("menuitem", "Disconnect");
-    }),
-  );
-  await waitFor(() => {
-    return expect(
-      getConnectorAction("button", "Connect Acme MCP v2"),
-    ).toBeInTheDocument();
-  });
 });
 
 test("Create and connect an MCP server with automatic authentication", async () => {
@@ -1152,7 +1139,7 @@ test("Create and connect an MCP server with automatic authentication", async () 
   context.mocks.api(
     customConnectorOAuth2Contract.start,
     ({ body, respond }) => {
-      expect(body.account).toStrictEqual({ intent: "single-account" });
+      expect(body.account).toStrictEqual({ intent: "add" });
       if (!connector) {
         throw new Error("Expected automatic MCP connector");
       }
@@ -1169,6 +1156,9 @@ test("Create and connect an MCP server with automatic authentication", async () 
     },
   );
 
+  mockCustomAccountSummary(() => {
+    return connector;
+  });
   await setupCustomPage({ mcp: true });
   click(
     await waitFor(() => {
@@ -1205,12 +1195,14 @@ test("Create and connect an MCP server with automatic authentication", async () 
     headerInjections: [],
     queryInjections: [],
   });
-  expect(card).toHaveTextContent("Not connected");
+  expect(card).toHaveTextContent("No accounts");
 
   click(getConnectorAction("button", "Connect Discovery MCP", card));
 
   await waitFor(() => {
-    expect(getConnectorCard("Discovery MCP")).toHaveTextContent("Connected");
+    expect(getConnectorCard("Discovery MCP")).toHaveTextContent(
+      "Unnamed account",
+    );
     expect(authWindow.closed).toBeTruthy();
   });
 });
@@ -1308,7 +1300,7 @@ test("Create, edit, and connect an OAuth MCP connector", async () => {
     return getConnectorCard("OAuth MCP");
   });
   expect(createdCard).toHaveTextContent("MCP");
-  expect(createdCard).toHaveTextContent("Not connected");
+  expect(createdCard).toHaveTextContent("No accounts");
   expect(created[0]).toMatchObject({
     kind: "mcp",
     endpoint: "https://mcp.acme.test/oauth",
@@ -1428,7 +1420,7 @@ test("Add and optionally name a custom OAuth account", async () => {
     grantMutations += 1;
     return respond(200, { grants: [] });
   });
-  await setupCustomPage({ accounts: true });
+  await setupCustomPage();
 
   click(
     await waitFor(() => {
@@ -1635,11 +1627,14 @@ test("Manage a custom connector before it is connected", async () => {
     return getConnectorCard("Acme Search");
   });
   expect(card).toHaveTextContent("HTTP API");
-  expect(card).toHaveTextContent("Not connected");
+  expect(card).toHaveTextContent("No accounts");
   expect(card).toHaveTextContent("https://api.acme.test/v1/");
   expect(
     queryConnectorAction("button", "Manage Acme Search access", card),
   ).toBeNull();
+  expect(
+    getConnectorAction("button", "Connect Acme Search", card),
+  ).toBeInTheDocument();
 
   click(
     await waitFor(() => {
@@ -1647,11 +1642,7 @@ test("Manage a custom connector before it is connected", async () => {
     }),
   );
 
-  await expect(
-    waitFor(() => {
-      return getConnectorAction("menuitem", "Connect");
-    }),
-  ).resolves.toBeInTheDocument();
+  expect(queryConnectorAction("menuitem", "Connect")).toBeNull();
   expect(getConnectorAction("menuitem", "Edit")).toBeInTheDocument();
   expect(getConnectorAction("menuitem", "Delete")).toBeInTheDocument();
 });
@@ -1679,7 +1670,7 @@ test("Restrict MCP account actions when MCP is unavailable", async () => {
   context.mocks.api(connectorAccountsContract.connections, ({ respond }) => {
     return respond(200, { connections: [account], nextCursor: null });
   });
-  await setupCustomPage({ accounts: true, mcp: false });
+  await setupCustomPage();
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Manage Acme MCP accounts");
@@ -1699,7 +1690,7 @@ test("Restrict MCP account actions when MCP is unavailable", async () => {
 });
 
 test("Allow safe MCP reductions when new MCP actions are unavailable", async () => {
-  let connector = mcpCustomConnector();
+  const connector = mcpCustomConnector();
   const grants = new Map<string, AgentCustomConnectorGrant[]>([
     [RESEARCH_ID, [{ customConnectorId: connector.id, permissionNames: [] }]],
     [SUPPORT_ID, []],
@@ -1735,17 +1726,9 @@ test("Allow safe MCP reductions when new MCP actions are unavailable", async () 
       return respond(200, { grants: next });
     },
   );
-  context.mocks.api(
-    connectorAccountsContract.disconnectSingleAccount,
-    ({ body, respond }) => {
-      expect(body.target).toStrictEqual({
-        kind: "custom",
-        customConnectorId: connector.id,
-      });
-      connector = { ...connector, connected: false };
-      return respond(204);
-    },
-  );
+  mockCustomAccountSummary(() => {
+    return connector;
+  });
   await setupCustomPage({ mcp: false });
   click(
     await waitFor(() => {
@@ -1764,7 +1747,7 @@ test("Allow safe MCP reductions when new MCP actions are unavailable", async () 
   });
   expect(card).toHaveTextContent("MCP");
   expect(card).toHaveTextContent("https://mcp.acme.test/server");
-  expect(card).toHaveTextContent("Connected");
+  expect(card).toHaveTextContent("Unnamed account");
   expect(
     getConnectorAction("button", "Manage Acme MCP access", card),
   ).toHaveTextContent("Used by Research");
@@ -1792,20 +1775,6 @@ test("Allow safe MCP reductions when new MCP actions are unavailable", async () 
     return expect(access).not.toBeInTheDocument();
   });
 
-  click(
-    await waitFor(() => {
-      return getConnectorAction("button", "More options");
-    }),
-  );
-  click(
-    await waitFor(() => {
-      return getConnectorAction("menuitem", "Disconnect");
-    }),
-  );
-  await waitFor(() => {
-    expect(getConnectorCard("Acme MCP")).toHaveTextContent("Not connected");
-  });
-  expect(queryConnectorAction("button", "Connect Acme MCP")).toBeNull();
   click(
     await waitFor(() => {
       return getConnectorAction("button", "More options");
@@ -1861,7 +1830,7 @@ test("Validate new and reconnecting custom accounts appropriately", async () => 
     submitted = body.account;
     return respond(200, { ...connector, connectedAccountId: existing.id });
   });
-  await setupCustomPage({ accounts: true });
+  await setupCustomPage();
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Manage Acme Search accounts");
@@ -1974,6 +1943,9 @@ test("Preserve custom connector grants when credentials are added", async () => 
       missingRequiredFields: [],
     });
   });
+  mockCustomAccountSummary(() => {
+    return connected ? { ...connector, connected: true } : null;
+  });
   await setupCustomPage();
   click(
     await waitFor(() => {
@@ -1988,7 +1960,9 @@ test("Preserve custom connector grants when credentials are added", async () => 
   click(getConnectorAction("button", "Save", dialog));
 
   await waitFor(() => {
-    expect(getConnectorCard("Acme Search")).toHaveTextContent("Connected");
+    expect(getConnectorCard("Acme Search")).toHaveTextContent(
+      "Unnamed account",
+    );
     expect(
       getConnectorAction(
         "button",

--- a/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
@@ -13,7 +13,6 @@ import {
   BrandGoogleDrive,
 } from "@okouai/ui";
 import { toast } from "@okouai/ui/components/ui/sonner";
-import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import type {
   ChatThreadArtifactFile,
   ChatThreadArtifactGoogleDriveRecovery,
@@ -21,6 +20,7 @@ import type {
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
 import { i18n } from "../../i18n/index.ts";
+import type { PlatformConnectorAccountMutationIntent } from "../../signals/connector-domain.ts";
 import { downloadAttachment$ } from "../../signals/attachment-download.ts";
 import { apiClient$ } from "../../signals/api-client.ts";
 import {
@@ -282,7 +282,7 @@ type GoogleDrivePendingAction =
   | { readonly kind: "authorize" }
   | {
       readonly kind: "connect";
-      readonly account: ConnectorAccountMutationIntent;
+      readonly account: PlatformConnectorAccountMutationIntent;
       readonly useDefaultConnectorProjection: boolean;
     }
   | { readonly kind: "unavailable" };

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8409,7 +8409,6 @@ function ConnectorsPopoverButton({
   const { t } = useTranslation();
   const connectorUi = useGet(signals.connector.connectorUiState$);
   const updateConnectorUi = useSet(signals.connector.updateConnectorUiState$);
-  const connectorAccountsEnabled = useGet(signals.connector.accounts.enabled$);
   const stablePopoverPlacementEnabled =
     useGet(featureSwitch$)[
       FeatureSwitchKey.ComposerConnectorPopoverPlacement
@@ -8472,7 +8471,6 @@ function ConnectorsPopoverButton({
     });
   const accountSummaryForItem = (item: ComposerPopoverConnectorItem) => {
     if (
-      !connectorAccountsEnabled ||
       !item.connector.authorized ||
       (item.kind === "custom" &&
         isIntegrationManagedCustomConnector(item.connector))

--- a/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/add-connection-dialog.tsx
@@ -27,8 +27,10 @@ import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogStartOption,
 } from "@okouai/api-contracts/contracts/connector-catalog";
-import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
-import type { PlatformConnectorCatalogStatusItem } from "../../../../signals/connector-domain.ts";
+import type {
+  PlatformConnectorAccountMutationIntent,
+  PlatformConnectorCatalogStatusItem,
+} from "../../../../signals/connector-domain.ts";
 import {
   connectFlowConnectorSlug$,
   pollingOAuthAuthCodeConnectorSlug$,
@@ -64,10 +66,9 @@ import { ConnectorIcon } from "./connector-icons.tsx";
 import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
 import { ConnectorHelpText } from "./connector-help-text.tsx";
 import { i18n } from "../../../../i18n/index.ts";
-import {
-  connectorAccountOptionsFor,
-  type ConnectorAccountConnectMode,
-  type ConnectorAccountMutationOptions,
+import type {
+  ConnectorAccountConnectMode,
+  ConnectorAccountMutationOptions,
 } from "../../../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 // ---------------------------------------------------------------------------
@@ -115,7 +116,7 @@ type PostConnectOptions = {
   readonly authorizeVisibleAgents?: boolean;
   readonly connectorLabel?: string;
   readonly agentId?: string;
-  readonly account?: ConnectorAccountMutationIntent;
+  readonly account: PlatformConnectorAccountMutationIntent;
   readonly useDefaultConnectorProjection?: boolean;
 };
 type BrowserAuthPostConnectOptions = PostConnectOptions & {
@@ -154,7 +155,7 @@ type ConnectExternalCodeFn = (
     readonly connectorSlug: ConnectorSlug;
     readonly authMethod: ConnectorAuthMethodId;
     readonly agentId?: string;
-    readonly account?: ConnectorAccountMutationIntent;
+    readonly account: PlatformConnectorAccountMutationIntent;
     readonly authorizeVisibleAgents?: boolean;
   },
   signal: AbortSignal,
@@ -1511,7 +1512,7 @@ export function ConnectModal({
   onSuccess?: (connectionId: string | null) => void | Promise<void>;
   authorizeVisibleAgentsOnConnect?: boolean;
   agentId?: string;
-  accountOptions?: ConnectorAccountMutationOptions;
+  accountOptions: ConnectorAccountMutationOptions;
   accountMode?: ConnectorAccountConnectMode;
   reconnectAuthMethod?: ConnectorAuthMethodId;
 }) {
@@ -1575,9 +1576,7 @@ export function ConnectModal({
           item={item}
           agentId={agentId}
           authorizeVisibleAgentsOnConnect={authorizeVisibleAgentsOnConnect}
-          accountOptions={
-            accountOptions ?? connectorAccountOptionsFor(accountMode)
-          }
+          accountOptions={accountOptions}
           accountMode={accountMode}
           reconnectAuthMethod={reconnectAuthMethod}
           onSuccess={async (connectionId) => {

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
@@ -33,10 +33,9 @@ import {
 import { sanitizeTokenInputRecord } from "../../../../signals/okou-page/settings/token-input.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { CustomConnectorIcon } from "./custom-connector-icon.tsx";
-import {
-  connectorAccountOptionsFor,
-  type ConnectorAccountConnectMode,
-  type ConnectorAccountMutationOptions,
+import type {
+  ConnectorAccountConnectMode,
+  ConnectorAccountMutationOptions,
 } from "../../../../signals/okou-page/settings/connector-account-dialogs.ts";
 
 interface CustomConnectorConnectionSubmission {
@@ -172,7 +171,7 @@ function useCustomConnectorConnectionSubmitters(
   const account = accountOptions.account;
   const usesDefaultProjection =
     accountOptions.useDefaultConnectorProjection === true;
-  const managesAccount = account !== undefined && !usesDefaultProjection;
+  const managesAccount = !usesDefaultProjection;
 
   const submitDeclaredValues = async (
     args: {
@@ -181,25 +180,19 @@ function useCustomConnectorConnectionSubmitters(
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionSubmission> => {
-    if (managesAccount && account) {
+    if (managesAccount) {
       return await submitAccountValues({ ...args, account }, signal);
     }
     if (agentId) {
-      return await submitAgentValues(
-        { ...args, agentId, ...(account ? { account } : {}) },
-        signal,
-      );
+      return await submitAgentValues({ ...args, agentId, account }, signal);
     }
-    return await submitValues(
-      { ...args, ...(account ? { account } : {}) },
-      signal,
-    );
+    return await submitValues({ ...args, account }, signal);
   };
   const submitAuthorizationMode = async (
     connectorId: string,
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionSubmission> => {
-    if (managesAccount && account) {
+    if (managesAccount) {
       return await submitAccountAuthorization(
         { id: connectorId, account },
         signal,
@@ -210,7 +203,7 @@ function useCustomConnectorConnectionSubmitters(
         {
           id: connectorId,
           agentId,
-          ...(account ? { account } : {}),
+          account,
           ...(usesDefaultProjection
             ? { useDefaultConnectorProjection: true as const }
             : {}),
@@ -221,7 +214,7 @@ function useCustomConnectorConnectionSubmitters(
     return await submitAuthorization(
       {
         id: connectorId,
-        ...(account ? { account } : {}),
+        account,
         ...(usesDefaultProjection
           ? { useDefaultConnectorProjection: true as const }
           : {}),
@@ -300,7 +293,7 @@ interface CustomConnectorConnectDialogProps {
   readonly agentId?: string;
   readonly onClose?: () => void;
   readonly onSuccess?: (connectionId: string | null) => void | Promise<void>;
-  readonly accountOptions?: ConnectorAccountMutationOptions;
+  readonly accountOptions: ConnectorAccountMutationOptions;
   readonly accountMode?: ConnectorAccountConnectMode;
 }
 
@@ -372,10 +365,8 @@ export function CustomConnectorConnectDialog({
   const setField = useSet(setCustomConnectorConnectField$);
   const resetForm = useSet(resetCustomConnectorConnectInput$);
   const closeDialog = useSet(closeCustomConnectorDialog$);
-  const resolvedAccountOptions =
-    accountOptions ?? connectorAccountOptionsFor(accountMode);
   const { submitting, submitDeclaredValues, submitAuthorizationMode } =
-    useCustomConnectorConnectionSubmitters(agentId, resolvedAccountOptions);
+    useCustomConnectorConnectionSubmitters(agentId, accountOptions);
   const signal = useGet(pageSignal$);
   const authorization =
     connector.authMode === "oauth" || connector.authMode === "automatic";

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
@@ -13,7 +13,6 @@ import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@okouai/ui";
 import {
@@ -21,25 +20,18 @@ import {
   type CustomConnectorResponse,
 } from "@okouai/api-contracts/contracts/custom-connectors";
 import type { ConnectorAccountSummary } from "@okouai/api-contracts/contracts/connector-accounts";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
-  disconnectCustomConnector$,
   closeCustomConnectorDialog$,
   connectCustomConnectorAccountAuthorization$,
-  connectCustomConnectorAuthorization$,
   customConnectorAuthorizedAgentsById$,
   customConnectorDialog$,
   customConnectors$,
   openCustomConnectorAccessDialog$,
-  openCustomConnectorConnectDialog$,
   openCustomConnectorDeleteDialog$,
   openCustomConnectorEditDialog$,
 } from "../../../../signals/okou-page/settings/custom-connectors.ts";
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
-import {
-  customConnectorMcpEnabled$,
-  featureSwitch$,
-} from "../../../../signals/external/feature-switch.ts";
+import { customConnectorMcpEnabled$ } from "../../../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { CustomConnectorIcon } from "./custom-connector-icon.tsx";
@@ -82,13 +74,11 @@ interface CustomConnectorRowProps {
   readonly isAdmin: boolean;
   readonly mcpEnabled: boolean;
   readonly onConnect: () => void;
-  readonly onDisconnect: () => void;
   readonly onEdit: () => void;
   readonly onManageAccess: () => void;
   readonly onDelete: () => void;
   readonly accountSummary?: ConnectorAccountSummary;
   readonly accountSummaryStatus: ConnectorAccountSummaryStatus;
-  readonly accountManagement: boolean;
   readonly onManageAccounts: () => void;
 }
 
@@ -127,7 +117,6 @@ interface CustomConnectorCardContentProps {
   readonly onManageAccess: () => void;
   readonly accountSummary?: ConnectorAccountSummary;
   readonly accountSummaryStatus: ConnectorAccountSummaryStatus;
-  readonly accountManagement: boolean;
 }
 
 function CustomConnectorHeaderContent({
@@ -184,30 +173,6 @@ function CustomConnectorCardHeader({
   );
 }
 
-function CustomConnectorConnectionStatus({
-  connected,
-}: {
-  readonly connected: boolean;
-}) {
-  const { t } = useTranslation();
-  return (
-    <span className="flex shrink-0 items-center gap-2 truncate text-xs text-muted-foreground">
-      <span
-        className={`h-1.5 w-1.5 shrink-0 rounded-full ${
-          connected ? "bg-emerald-500" : "bg-muted-foreground/50"
-        }`}
-      />
-      {connected
-        ? t(($) => {
-            return $.connectors.custom.statusConnected;
-          })
-        : t(($) => {
-            return $.connectors.catalog.filters.notConnected;
-          })}
-    </span>
-  );
-}
-
 function CustomConnectorCardFooter({
   connector,
   hasActions,
@@ -215,32 +180,25 @@ function CustomConnectorCardFooter({
   onManageAccess,
   accountSummary,
   accountSummaryStatus,
-  accountManagement,
-}: Omit<CustomConnectorCardContentProps, "canConnect">) {
+}: CustomConnectorCardContentProps) {
   return (
     <div
       className={`flex h-11 items-center justify-between gap-2 border-t border-border/50 pl-5 ${
         hasActions ? "pr-12" : "pr-2"
       }`}
     >
-      {accountManagement ? (
-        <ConnectorAccountSummaryText
-          summary={accountSummary}
-          status={accountSummaryStatus}
-          className="min-w-0 flex-1 text-xs text-muted-foreground"
+      <ConnectorAccountSummaryText
+        summary={accountSummary}
+        status={accountSummaryStatus}
+        className="min-w-0 flex-1 text-xs text-muted-foreground"
+      />
+      <div className="relative z-20 min-w-0 max-w-full">
+        <CustomConnectorAgentAccess
+          connector={connector}
+          allowAccessIncrease={allowAccessIncrease}
+          onManageAccess={onManageAccess}
         />
-      ) : (
-        <CustomConnectorConnectionStatus connected={connector.connected} />
-      )}
-      {connector.connected || accountManagement ? (
-        <div className="relative z-20 min-w-0 max-w-full">
-          <CustomConnectorAgentAccess
-            connector={connector}
-            allowAccessIncrease={allowAccessIncrease}
-            onManageAccess={onManageAccess}
-          />
-        </div>
-      ) : null}
+      </div>
     </div>
   );
 }
@@ -293,25 +251,15 @@ function CustomConnectorActivationCard({
 }
 
 function CustomConnectorActions({
-  connector,
   hasActions,
-  canActivate,
-  accountManagement,
   adminCanEdit,
   adminCanDelete,
-  onConnect,
-  onDisconnect,
   onEdit,
   onDelete,
 }: {
-  readonly connector: CustomConnectorResponse;
   readonly hasActions: boolean;
-  readonly canActivate: boolean;
-  readonly accountManagement: boolean;
   readonly adminCanEdit: boolean;
   readonly adminCanDelete: boolean;
-  readonly onConnect: () => void;
-  readonly onDisconnect: () => void;
   readonly onEdit: () => void;
   readonly onDelete: () => void;
 }) {
@@ -319,7 +267,6 @@ function CustomConnectorActions({
   if (!hasActions) {
     return null;
   }
-  const directAuthorization = connectsDirectlyWithAuthorization(connector);
   return (
     <div className="absolute bottom-2 right-2 z-20">
       <DropdownMenu>
@@ -337,27 +284,6 @@ function CustomConnectorActions({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
-          {canActivate && !accountManagement && directAuthorization ? (
-            <DropdownMenuItem onClick={onConnect}>
-              {t(($) => {
-                return $.connectors.actions.connect;
-              })}
-            </DropdownMenuItem>
-          ) : null}
-          {canActivate && !accountManagement && !directAuthorization ? (
-            <DropdownMenuModalItem onModalSelect={onConnect}>
-              {t(($) => {
-                return $.connectors.actions.connect;
-              })}
-            </DropdownMenuModalItem>
-          ) : null}
-          {connector.connected && !accountManagement ? (
-            <DropdownMenuItem onClick={onDisconnect}>
-              {t(($) => {
-                return $.connectors.actions.disconnect;
-              })}
-            </DropdownMenuItem>
-          ) : null}
           {adminCanEdit ? (
             <DropdownMenuModalItem onModalSelect={onEdit}>
               {t(($) => {
@@ -386,13 +312,11 @@ function CustomConnectorRow({
   isAdmin,
   mcpEnabled,
   onConnect,
-  onDisconnect,
   onEdit,
   onManageAccess,
   onDelete,
   accountSummary,
   accountSummaryStatus,
-  accountManagement,
   onManageAccounts,
 }: CustomConnectorRowProps) {
   const adminCanDelete = isAdmin;
@@ -400,25 +324,20 @@ function CustomConnectorRow({
   const connectionActionsEnabled = mcpActionsEnabled;
   const adminCanEdit = adminCanDelete && mcpActionsEnabled;
   const accountCount = accountSummary?.accountCount ?? 0;
-  const canActivate = accountManagement
-    ? accountSummaryStatus === "ready" &&
-      (accountCount > 0 || connectionActionsEnabled)
-    : connectionActionsEnabled && !connector.connected;
-  const activate =
-    accountManagement && accountCount > 0 ? onManageAccounts : onConnect;
-  const managesAccounts = accountManagement && accountCount > 0;
-  const hasActions = connector.connected || adminCanDelete;
+  const canActivate =
+    accountSummaryStatus === "ready" &&
+    (accountCount > 0 || connectionActionsEnabled);
+  const activate = accountCount > 0 ? onManageAccounts : onConnect;
+  const managesAccounts = accountCount > 0;
+  const hasActions = adminCanDelete;
   const cardContent = (
     <CustomConnectorCardContent
       connector={connector}
       hasActions={hasActions}
-      allowAccessIncrease={
-        connectionActionsEnabled && (!accountManagement || accountCount > 0)
-      }
+      allowAccessIncrease={connectionActionsEnabled && accountCount > 0}
       onManageAccess={onManageAccess}
       accountSummary={accountSummary}
       accountSummaryStatus={accountSummaryStatus}
-      accountManagement={accountManagement}
     />
   );
 
@@ -433,14 +352,9 @@ function CustomConnectorRow({
         {cardContent}
       </CustomConnectorActivationCard>
       <CustomConnectorActions
-        connector={connector}
         hasActions={hasActions}
-        canActivate={canActivate}
-        accountManagement={accountManagement}
         adminCanEdit={adminCanEdit}
         adminCanDelete={adminCanDelete}
-        onConnect={onConnect}
-        onDisconnect={onDisconnect}
         onEdit={onEdit}
         onDelete={onDelete}
       />
@@ -455,8 +369,6 @@ function CustomConnectorDialogs({
 }) {
   const dialog = useGet(customConnectorDialog$);
   const closeDialog = useSet(closeCustomConnectorDialog$);
-  const accountManagement =
-    useGet(featureSwitch$)[FeatureSwitchKey.ConnectorAccounts] ?? false;
   const accountSummariesLoadable = useLoadable(
     connectorAccountSummaryByTarget$,
   );
@@ -467,17 +379,13 @@ function CustomConnectorDialogs({
   const allowAccessIncrease =
     dialog.kind === "access" &&
     (dialog.connector.kind === "http" || mcpEnabled) &&
-    (!accountManagement ||
-      (accountSummariesLoadable.state === "hasData" &&
-        (accessAccountSummary?.accountCount ?? 0) > 0));
+    accountSummariesLoadable.state === "hasData" &&
+    (accessAccountSummary?.accountCount ?? 0) > 0;
   return (
     <>
       {dialog.kind === "create" && <CustomConnectorCreateDialog />}
       {dialog.kind === "edit" && (
         <CustomConnectorCreateDialog connector={dialog.connector} />
-      )}
-      {dialog.kind === "connect" && (
-        <CustomConnectorConnectDialog connector={dialog.connector} />
       )}
       {dialog.kind === "access" && (
         <CustomConnectorAccessManagementDialog
@@ -529,8 +437,6 @@ function CustomConnectorGrid({
   readonly isAdmin: boolean;
   readonly mcpEnabled: boolean;
 }) {
-  const connectorAccountsEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ConnectorAccounts] ?? false;
   const accountSummariesLoadable = useLoadable(
     connectorAccountSummaryByTarget$,
   );
@@ -539,21 +445,14 @@ function CustomConnectorGrid({
   );
   const openEdit = useSet(openCustomConnectorEditDialog$);
   const openAccess = useSet(openCustomConnectorAccessDialog$);
-  const openConnect = useSet(openCustomConnectorConnectDialog$);
   const openDelete = useSet(openCustomConnectorDeleteDialog$);
-  const connectAuthorization = useSet(connectCustomConnectorAuthorization$);
   const connectAccountAuthorization = useSet(
     connectCustomConnectorAccountAuthorization$,
   );
-  const disconnect = useSet(disconnectCustomConnector$);
   const signal = useGet(pageSignal$);
   const openAccountManager = useSet(openCustomAccountManager$);
   const openAccountConnect = useSet(openCustomAccountConnectDialog$);
   const finishAccountConnection = useSet(finishConnectorAccountConnection$);
-  const handleDisconnect = (connector: CustomConnectorResponse) => {
-    detach(disconnect(connector.id, signal), Reason.DomCallback);
-  };
-
   const finishExplicitAccountAdd = async (
     connector: CustomConnectorResponse,
     connectionId: string | null,
@@ -569,33 +468,22 @@ function CustomConnectorGrid({
     );
   };
   const handleConnect = (connector: CustomConnectorResponse) => {
-    if (connectorAccountsEnabled) {
-      if (connectsDirectlyWithAuthorization(connector)) {
-        detach(
-          (async () => {
-            const result = await connectAccountAuthorization(
-              { id: connector.id, account: { intent: "add" } },
-              signal,
-            );
-            if (result.connected) {
-              await finishExplicitAccountAdd(connector, result.connectionId);
-            }
-          })(),
-          Reason.DomCallback,
-        );
-        return;
-      }
-      openAccountConnect(connector, { kind: "add" });
-      return;
-    }
     if (connectsDirectlyWithAuthorization(connector)) {
       detach(
-        connectAuthorization({ id: connector.id }, signal),
+        (async () => {
+          const result = await connectAccountAuthorization(
+            { id: connector.id, account: { intent: "add" } },
+            signal,
+          );
+          if (result.connected) {
+            await finishExplicitAccountAdd(connector, result.connectionId);
+          }
+        })(),
         Reason.DomCallback,
       );
       return;
     }
-    openConnect(connector);
+    openAccountConnect(connector, { kind: "add" });
   };
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -613,9 +501,6 @@ function CustomConnectorGrid({
             onConnect={() => {
               return handleConnect(connector);
             }}
-            onDisconnect={() => {
-              return handleDisconnect(connector);
-            }}
             onEdit={() => {
               return openEdit(connector);
             }}
@@ -627,7 +512,6 @@ function CustomConnectorGrid({
             }}
             accountSummary={accountSummary}
             accountSummaryStatus={accountSummaryStatus}
-            accountManagement={connectorAccountsEnabled}
             onManageAccounts={() => {
               return openAccountManager(connector, signal);
             }}
@@ -659,6 +543,15 @@ function CustomAccountDialogs({
         <CustomConnectorConnectDialog
           connector={accountConnect.connector}
           accountMode={accountConnect.mode}
+          accountOptions={{
+            account:
+              accountConnect.mode.kind === "add"
+                ? { intent: "add" }
+                : {
+                    intent: "reconnect",
+                    connectionId: accountConnect.mode.connectionId,
+                  },
+          }}
           onClose={closeAccountConnect}
           onSuccess={async (connectionId) => {
             await finishAccountConnection(

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -9,7 +9,6 @@ import {
   useLastResolved,
   type Loadable,
 } from "ccstate-react";
-import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { Search, Plus, Filter, ChevronDown, Check } from "lucide-react";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
@@ -20,7 +19,6 @@ import type {
 } from "@okouai/api-contracts/contracts/connector-catalog";
 import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
 import type { AgentResponse } from "@okouai/api-contracts/contracts/agents";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { Tabs, TabsList, TabsTrigger } from "@okouai/ui/components/ui/tabs";
 import { formatLocalizedNumber } from "../../i18n/format.ts";
 import {
@@ -28,7 +26,6 @@ import {
   setConnectorsPageTab$,
   openCustomConnectorCreateDialog$,
 } from "../../signals/okou-page/settings/custom-connectors.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { agents$ } from "../../signals/agent.ts";
 import { CustomConnectorsPanel } from "./components/settings/custom-connectors-panel.tsx";
@@ -39,20 +36,14 @@ import {
   connectFlowConnectorSlug$,
   connectorsSearch$,
   connectorsConnectionFilter$,
-  disconnectConnector$,
   filteredConnectorCatalogItems$,
   setConnectorsConnectionFilter$,
   setConnectorsSearch$,
-  selectedConnectorSlug$,
-  setSelectedConnectorSlug$,
   pollingOAuthAuthCodeConnectorSlug$,
   pollingOAuthDeviceAuthConnectorSlug$,
-  justConnectedSlugs$,
   relatedCatalogItems$,
   scopeReviewSelection$,
   setScopeReviewSelection$,
-  getAvailableStatusAuthCodeAuthMethod,
-  getConnectorStatusAuthMethod,
   type ConnectorsConnectionFilter,
 } from "../../signals/okou-page/settings/connectors.ts";
 import {
@@ -87,10 +78,8 @@ import {
   managedConnectorAccessSlug$,
   setManagedConnectorAccessSlug$,
 } from "../../signals/okou-page/settings/connector-access-management.ts";
-import { toast } from "@okouai/ui/components/ui/sonner";
 import { noConnectorImg } from "./platform-assets.ts";
 import { AvatarFromUrl } from "./sidebar-shared.tsx";
-import { detach, Reason } from "../../signals/utils.ts";
 import {
   Button,
   DropdownMenu,
@@ -889,17 +878,12 @@ function effectiveConnectorCatalogCount(
 
 interface SettingsConnectorCardProps {
   readonly connector: PlatformConnectorCatalogStatusItem;
-  readonly accountManagement: boolean;
   readonly accountSummary: ConnectorAccountSummary | undefined;
   readonly accountSummaryStatus: ConnectorAccountSummaryStatus;
-  readonly connected: boolean;
   readonly busy: boolean;
-  readonly disconnecting: boolean;
   readonly connect: ConnectorConnectHandlers;
   readonly onManageAccounts: () => void;
   readonly onManageAccess: () => void;
-  readonly onDisconnect: () => void;
-  readonly onReviewScopes: () => void;
 }
 
 interface ConnectorCatalogHeaderProps {
@@ -941,48 +925,22 @@ function SettingsConnectorCard(props: SettingsConnectorCardProps) {
       connectorSlug={props.connector.slug}
       connectorLabel={props.connector.label}
       allowAccessIncrease={
-        !props.accountManagement ||
-        (props.accountSummaryStatus === "ready" &&
-          (props.accountSummary?.accountCount ?? 0) > 0)
+        props.accountSummaryStatus === "ready" &&
+        (props.accountSummary?.accountCount ?? 0) > 0
       }
       onClick={props.onManageAccess}
     />
   );
-  if (props.accountManagement) {
-    return (
-      <ConnectorCard
-        variant="accounts"
-        connector={props.connector}
-        summary={props.accountSummary}
-        summaryStatus={props.accountSummaryStatus}
-        busy={props.busy}
-        connect={props.connect}
-        onManage={props.onManageAccounts}
-        manageAccess={manageAccess}
-      />
-    );
-  }
-  if (!props.connected) {
-    return (
-      <ConnectorCard
-        variant="catalog"
-        connector={props.connector}
-        busy={props.busy}
-        connect={props.connect}
-      />
-    );
-  }
   return (
     <ConnectorCard
-      variant="connection"
+      variant="accounts"
       connector={props.connector}
-      connected
+      summary={props.accountSummary}
+      summaryStatus={props.accountSummaryStatus}
       busy={props.busy}
-      disconnecting={props.disconnecting}
       connect={props.connect}
-      onDisconnect={props.onDisconnect}
+      onManage={props.onManageAccounts}
       manageAccess={manageAccess}
-      onReviewScopes={props.onReviewScopes}
     />
   );
 }
@@ -994,8 +952,6 @@ function ManagedConnectorAccessDialog() {
   const accountSummariesLoadable = useLoadable(
     connectorAccountSummaryByTarget$,
   );
-  const accountManagement =
-    useGet(featureSwitch$)[FeatureSwitchKey.ConnectorAccounts] ?? false;
   if (!connectorSlug || catalogItemsLoadable.state !== "hasData") {
     return null;
   }
@@ -1014,9 +970,7 @@ function ManagedConnectorAccessDialog() {
     <ConnectorAccessManagementDialog
       connectorSlug={connectorSlug}
       connectorLabel={connectorLabel}
-      allowAccessIncrease={
-        !accountManagement || (accountSummary?.accountCount ?? 0) > 0
-      }
+      allowAccessIncrease={(accountSummary?.accountCount ?? 0) > 0}
       onClose={close}
     />
   );
@@ -1029,8 +983,6 @@ export function ConnectorsPage() {
     filteredConnectorCatalogItems$,
   );
   const catalogStatusLoadable = useLastLoadable(connectorCatalogDiscovery$);
-  const connectorAccountsEnabled =
-    useGet(featureSwitch$)[FeatureSwitchKey.ConnectorAccounts] ?? false;
   const accountSummariesLoadable = useLoadable(
     connectorAccountSummaryByTarget$,
   );
@@ -1049,14 +1001,10 @@ export function ConnectorsPage() {
   const connectFlowSlug = useGet(connectFlowConnectorSlug$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const connectNoAuth = useSet(connectConnectorNoAuth$);
-  const [disconnectLoadable, disconnect] = useLoadableSet(disconnectConnector$);
   const signal = useGet(pageSignal$);
-  const selectedConnectorSlug = useGet(selectedConnectorSlug$);
-  const setSelected = useSet(setSelectedConnectorSlug$);
   const scopeReviewSelection = useGet(scopeReviewSelection$);
   const setScopeReviewSelection = useSet(setScopeReviewSelection$);
   const setManagedConnectorSlug = useSet(setManagedConnectorAccessSlug$);
-  const optimisticConnected = useGet(justConnectedSlugs$);
   const activeTab = useGet(connectorsPageTab$);
   const setActiveTab = useSet(setConnectorsPageTab$);
   const isAdmin = useLastResolved(isOrgAdmin$) ?? false;
@@ -1095,48 +1043,6 @@ export function ConnectorsPage() {
     relatedCatalogItemsLoadable.state === "hasData"
       ? relatedCatalogItemsLoadable.data
       : [];
-  const selectedConnector = selectedConnectorSlug
-    ? allConnectors.find((connector) => {
-        return connector.slug === selectedConnectorSlug;
-      })
-    : undefined;
-  const disconnecting = disconnectLoadable.state === "loading";
-
-  const connectHandlers = (
-    connector: PlatformConnectorCatalogStatusItem,
-  ): ConnectorConnectHandlers => {
-    return {
-      openModal: () => {
-        setSelected(connector.slug);
-      },
-      connectBrowserAuth: (authMethod) => {
-        return connect(
-          connector.slug,
-          authMethod,
-          {
-            authorizeVisibleAgents: true,
-            connectorLabel: connector.label,
-            connectorIcon: connector.icon,
-          },
-          signal,
-        );
-      },
-      connectNoAuth: (authMethod) => {
-        return connectNoAuth(
-          {
-            connectorSlug: connector.slug,
-            authMethod,
-            options: {
-              authorizeVisibleAgents: true,
-              connectorLabel: connector.label,
-            },
-          },
-          signal,
-        );
-      },
-    };
-  };
-
   const finishExplicitAccountAdd = async (
     connector: PlatformConnectorCatalogStatusItem,
     connectionId: string | null,
@@ -1195,18 +1101,7 @@ export function ConnectorsPage() {
     };
   };
 
-  const disconnectHandler = async (
-    connectorSlug: ConnectorSlug,
-    connectorLabel: string,
-  ) => {
-    if (disconnecting) {
-      return;
-    }
-    await disconnect(connectorSlug, connectorLabel, signal);
-  };
-
   const renderCard = (c: PlatformConnectorCatalogStatusItem) => {
-    const isConnected = c.connected || optimisticConnected.has(c.slug);
     const isPolling =
       pollingAuthCodeSlug === c.slug ||
       pollingDeviceAuthSlug === c.slug ||
@@ -1219,31 +1114,15 @@ export function ConnectorsPage() {
       <SettingsConnectorCard
         key={c.slug}
         connector={c}
-        accountManagement={connectorAccountsEnabled}
         accountSummary={summary}
         accountSummaryStatus={accountSummaryStatus}
-        connected={isConnected}
         busy={isPolling}
-        disconnecting={disconnecting}
-        connect={
-          connectorAccountsEnabled
-            ? accountConnectHandlers(c)
-            : connectHandlers(c)
-        }
-        onDisconnect={() => {
-          detach(disconnectHandler(c.slug, c.label), Reason.DomCallback);
-        }}
+        connect={accountConnectHandlers(c)}
         onManageAccounts={() => {
           return openAccountManager(c, signal);
         }}
         onManageAccess={() => {
           return setManagedConnectorSlug(c.slug);
-        }}
-        onReviewScopes={() => {
-          return setScopeReviewSelection({
-            kind: "default",
-            connectorSlug: c.slug,
-          });
         }}
       />
     );
@@ -1323,34 +1202,19 @@ export function ConnectorsPage() {
         </div>
       </main>
 
-      {selectedConnector && (
-        <ConnectModal
-          item={selectedConnector}
-          authorizeVisibleAgentsOnConnect
-          onClose={() => {
-            return setSelected(null);
-          }}
-          onSuccess={() => {
-            const label =
-              allConnectors.find((c) => {
-                return c.slug === selectedConnectorSlug;
-              })?.label ?? selectedConnectorSlug;
-            toast.success(
-              t(
-                ($) => {
-                  return $.connectors.callback.connected;
-                },
-                { connector: label },
-              ),
-            );
-          }}
-        />
-      )}
-
       {accountConnect && (
         <ConnectModal
           item={accountConnect.connector}
           accountMode={accountConnect.mode}
+          accountOptions={{
+            account:
+              accountConnect.mode.kind === "add"
+                ? { intent: "add" }
+                : {
+                    intent: "reconnect",
+                    connectionId: accountConnect.mode.connectionId,
+                  },
+          }}
           onClose={() => {
             closeAccountConnect();
           }}
@@ -1400,7 +1264,6 @@ export function ConnectorsPage() {
           onReviewScopes={(account) => {
             closeAccountManager();
             setScopeReviewSelection({
-              kind: "account",
               connectorSlug: managedAccountConnector.slug,
               connectionId: account.id,
               authMethod: account.authMethod,
@@ -1420,45 +1283,13 @@ export function ConnectorsPage() {
             const connector = allConnectors.find((connector) => {
               return connector.slug === selection.connectorSlug;
             });
-            if (selection.kind === "account") {
-              if (connector) {
-                openAccountConnect(connector, {
-                  kind: "reconnect",
-                  connectionId: selection.connectionId,
-                  authMethod: selection.authMethod,
-                });
-              }
-              return;
+            if (connector) {
+              openAccountConnect(connector, {
+                kind: "reconnect",
+                connectionId: selection.connectionId,
+                authMethod: selection.authMethod,
+              });
             }
-            const connection = connector?.connection ?? null;
-            if (!connector || !connection) {
-              setSelected(selection.connectorSlug);
-              return;
-            }
-            const authMethodId = getAvailableStatusAuthCodeAuthMethod(
-              connector,
-              connection.authMethod,
-            );
-            const authMethod = authMethodId
-              ? getConnectorStatusAuthMethod(connector, authMethodId)
-              : null;
-            if (!authMethod) {
-              setSelected(selection.connectorSlug);
-              return;
-            }
-            detach(
-              connect(
-                selection.connectorSlug,
-                authMethod,
-                {
-                  authorizeVisibleAgents: true,
-                  connectorLabel: connector.label,
-                  connectorIcon: connector.icon,
-                },
-                signal,
-              ),
-              Reason.DomCallback,
-            );
           }}
         />
       )}

--- a/turbo/apps/platform/src/views/okou-page/directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-authorize-page.tsx
@@ -6,8 +6,10 @@ import {
   type ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/connector-catalog";
-import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
-import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
+import type {
+  PlatformConnectorAccountMutationIntent,
+  PlatformConnectorCatalogStatusItem,
+} from "../../signals/connector-domain.ts";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   connectConnectorOAuthAuthCode$,
@@ -298,7 +300,7 @@ function runDirectedAuthorize(
         readonly connectorLabel?: string;
         readonly connectorIcon: PlatformConnectorCatalogStatusItem["icon"];
         readonly agentId?: string;
-        readonly account?: ConnectorAccountMutationIntent;
+        readonly account: PlatformConnectorAccountMutationIntent;
         readonly useDefaultConnectorProjection?: boolean;
       },
       signal: AbortSignal,
@@ -310,7 +312,7 @@ function runDirectedAuthorize(
         readonly options: {
           readonly connectorLabel?: string;
           readonly agentId?: string;
-          readonly account?: ConnectorAccountMutationIntent;
+          readonly account: PlatformConnectorAccountMutationIntent;
           readonly useDefaultConnectorProjection?: boolean;
         };
       },

--- a/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-connect-page.tsx
@@ -6,15 +6,15 @@ import {
   type ConnectorSlug,
 } from "@okouai/api-contracts/contracts/connector-identity";
 import type { PublicConnectorCatalogAuthMethodDetail } from "@okouai/api-contracts/contracts/connector-catalog";
-import type {
-  ConnectorAccountConnection,
-  ConnectorAccountMutationIntent,
-} from "@okouai/api-contracts/contracts/connector-accounts";
+import type { ConnectorAccountConnection } from "@okouai/api-contracts/contracts/connector-accounts";
 import type {
   CustomConnectorResponse,
   CustomConnectorSlug,
 } from "@okouai/api-contracts/contracts/custom-connectors";
-import type { PlatformConnectorCatalogStatusItem } from "../../signals/connector-domain.ts";
+import type {
+  PlatformConnectorAccountMutationIntent,
+  PlatformConnectorCatalogStatusItem,
+} from "../../signals/connector-domain.ts";
 import { Input } from "@okouai/ui/components/ui/input";
 import {
   Dialog,
@@ -106,7 +106,7 @@ function runDirectedConnect(
         readonly connectorLabel?: string;
         readonly connectorIcon: PlatformConnectorCatalogStatusItem["icon"];
         readonly agentId?: string;
-        readonly account?: ConnectorAccountMutationIntent;
+        readonly account: PlatformConnectorAccountMutationIntent;
         readonly useDefaultConnectorProjection?: boolean;
         readonly authorizeVisibleAgents?: boolean;
       },
@@ -119,7 +119,7 @@ function runDirectedConnect(
         readonly options: {
           readonly connectorLabel?: string;
           readonly agentId?: string;
-          readonly account?: ConnectorAccountMutationIntent;
+          readonly account: PlatformConnectorAccountMutationIntent;
           readonly useDefaultConnectorProjection?: boolean;
           readonly authorizeVisibleAgents?: boolean;
         };

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -42,7 +42,6 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.GoogleFormsWorkflowAutomations, {}),
     ).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.ConnectorAccounts, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -62,7 +62,6 @@ export enum FeatureSwitchKey {
   BaseUiSidebarScrollArea = "baseUiSidebarScrollArea",
   SidebarSubscriptionUsage = "_sidebarSubscriptionUsage",
   PersonalModelProviderAccounts = "_multipleSubscriptions",
-  ConnectorAccounts = "connectorAccounts",
   ComposerConnectorPopoverPlacement = "composerConnectorPopoverPlacement",
   FeishuIntegration = "_feishuIntegration",
   CustomConnectorMcp = "customConnectorMcp",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -464,12 +464,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ConnectorAccounts]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Enable multiple credential accounts per built-in or custom connector.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ComposerConnectorPopoverPlacement]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

Connector accounts are already enabled globally, but the rollout switch still lets stored false overrides restore compact Settings and target-level mutations. Retire that switch across Core, API, Platform, and runner bootstrap so account-aware behavior is the only current path.

- Make account lifecycle, thread selection, run resolution, and account-aware Settings unconditional.
- Require current Platform mutations and OAuth completion helpers to use explicit `add` or exact `reconnect`; remove compact target-only disconnect callers, singleton fallbacks, unused exports, and rollout-only arguments.
- Allow sibling accounts for generic connectors while preserving the independent Integration-managed restriction and its accurate error message.

## Compatibility

Retain the public and persisted `single-account` intent, omitted-intent normalization, target-only disconnect API, persisted callback decoding, and the existing identified-CLI cutoff. Older App bundles remain supported until #29775–#29777 complete their retirement gates. This PR changes neither the database schema nor the App minimum version.

## Validation

- API and Platform lint and type checks passed; repository Knip passed after fixing two exports left unused by the rebase.
- Changed-file formatting and staged-path checks passed.
- Previous application-code review: 56 Platform connector tests and 297 API connector/run-lifecycle tests passed.
- Latest current-head review: API lifecycle/thread-create/manual-grant/Feishu tests passed (4 files, 97 tests); Platform composer-account/direct-connect/direct-authorize tests passed (3 files, 24 tests).
- The full workflow regression script now passes locally: `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh` (`turbo-playwright-runner-workflow-test: ok`), plus `bash -n` and ShellCheck on the same script.
- Self-review removed the retired-switch tombstone assertion, as required by `docs/fallback.md`. Runtime/bootstrap behavior is unchanged by that cleanup.
- Earlier broad pre-rebase run: 795 files and 10,428 tests passed; one additional test failed on fixed-ID local database residue and passed after exact cleanup in a separate rerun. This was not a single green full-suite invocation.
- Static inventory confirms no retired switch reference or current Platform singleton/target-only disconnect caller remains; required server compatibility is retained.

## CI readiness

Current head `e90457008771af0ed1e06c731b8a9cdb9409c0eb` has passed all three required gates: [Turbo](https://github.com/vm0-ai/vm0/actions/runs/33942283553/job/101242704307), Crates, and Security. Final inspection reports 91 passed checks, 6 conditionally skipped jobs, and no pending, failed, or cancelled checks. GitHub reports `MERGEABLE` / `CLEAN`. The earlier workflow approval blocker is resolved. The PR has not been merged.

Closes #29773
Relates to #28571
