### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/signals/services/official-automation-result-email-renderer.ts
+++ b/turbo/apps/api/src/signals/services/official-automation-result-email-renderer.ts
@@ -225,27 +225,13 @@ function officialAutomationResultEmailHtml(
       ? `<td width="36" height="36" align="center" valign="middle" style="width:36px;height:36px;line-height:0;mso-line-height-rule:exactly"><img src="${OKOU_AUTOMATION_EMAIL_AVATAR_URL}" width="36" height="36" alt="" role="presentation" style="display:block;width:36px;height:36px;border:0;border-radius:50%;outline:none;text-decoration:none"></td>`
       : '<td width="32" height="32" align="center" valign="middle" bgcolor="#ed4e01" style="width:32px;height:32px;border-radius:9px;color:#ffffff;font-size:14px;font-weight:700;line-height:32px;mso-line-height-rule:exactly">0</td>';
   const automationArticle = publicBrand === "okou" ? "an" : "a";
-  // During the API rollout and rollback window, persisted outbox rows from
-  // the previous callback still carry the account-level confirmation URL in
-  // manageUrl. Remove after those API targets and rows drain; tracked by
-  // #30592. Until then, preserve their old footer instead of mislabelling a
-  // global unsubscribe as automation management.
-  const legacyManageUrl = new URL(props.manageUrl).pathname.endsWith(
-    "/email/unsubscribe",
-  );
-  const footer = legacyManageUrl
-    ? `Sent by ${automationArticle} ${escapeHtml(
-        presentation.assistantName,
-      )} automation &middot; <a href="${escapeHtml(
-        props.manageUrl,
-      )}" style="${FOOTER_LINK_STYLE}">Manage email preferences</a>`
-    : `Sent by ${automationArticle} ${escapeHtml(
-        presentation.assistantName,
-      )} automation &middot; <a href="${escapeHtml(
-        props.manageUrl,
-      )}" style="${FOOTER_LINK_STYLE}">Manage</a> &middot; <a href="${escapeHtml(
-        unsubscribeUrl,
-      )}" style="${FOOTER_LINK_STYLE}">Unsubscribe</a>`;
+  const footer = `Sent by ${automationArticle} ${escapeHtml(
+    presentation.assistantName,
+  )} automation &middot; <a href="${escapeHtml(
+    props.manageUrl,
+  )}" style="${FOOTER_LINK_STYLE}">Manage</a> &middot; <a href="${escapeHtml(
+    unsubscribeUrl,
+  )}" style="${FOOTER_LINK_STYLE}">Unsubscribe</a>`;
 
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="color-scheme" content="light"><meta name="supported-color-schemes" content="light"><title>${escapeHtml(
     props.title,


### PR DESCRIPTION
Removes the legacy footer branch in the Official Automation result email renderer. Closes the removal gate in #30592.

## Cohort — Official Automation result email legacy `manageUrl` footer

**Old boundary:** #30591 changed `manageUrl` from the account-level unsubscribe confirmation URL to an originating Workflow Automation deep link, without changing the persisted `official-automation-result` template shape. During the rollout the new outbox reader could still receive rows written by the previous callback producer, so the renderer sniffed `props.manageUrl` for a `/email/unsubscribe` path and, for those rows, emitted a single "Manage email preferences" link instead of mislabelling a global unsubscribe as automation management.

**New boundary:** the approved two-link footer — `Manage` plus `Unsubscribe` — is the only supported form.

Removed:
- the `legacyManageUrl` path sniff and the footer ternary, leaving the current footer as a single template literal

No test changes were needed. `Manage email preferences` appears nowhere else in the repository, so the legacy branch had no dedicated coverage to delete, and the existing footer, one-click unsubscribe, Markdown safety, and size-bound assertions are untouched.

**Window:** canonical window 1 for the old API writer, plus the issue's explicit persisted-row gate.

**Rollout evidence (observed):**
- #30591 merged `2026-09-01T03:20:56Z` (`0e556c4e817`).
- First `api/production` deployment containing it: `f41cf40bb8`, `2026-09-01T05:02:48Z`, confirmed with `git merge-base --is-ancestor` walking the deployment list forward from oldest.
- **50 further `api/production` deployments** have been promoted since.
- Elapsed: **~88 hours (3.7 days)**.

**MaskDB evidence (read-only, `vm0-prod-ro`, structured API only)** — this is the decisive proof for the persisted-row gate the issue named:
- `email_outbox` exposes `status`, `attempts`, `next_retry_at`, and `created_at` as unmasked and filterable; `template` (which carries `manageUrl`) is masked, so the URL itself cannot be filtered. That masking does not block the proof, because only a **non-terminal** row is ever re-rendered at send time.
- Grouped count over the whole table: **795 rows, all `status = "sent"`**. A structured read for any row whose status is not terminal returns **zero rows**.
- The newest row created **before** the cutover is `2026-08-31T23:07:18Z`, already `sent`.
- Freshness: the newest row overall is `2026-09-03T23:08:06Z`, so this is live production state rather than a stale snapshot. This is a low-volume daily-cadence table, which is consistent with the observed spacing.
- No row-level data is reproduced here; only aggregate counts, statuses, and timestamps.

**Render path:** `renderOfficialAutomationResultEmail` is called only from `email-common.service.ts` at send time, from the outbox drain. A row that has already reached `sent` is never re-rendered, so the zero non-terminal count is exactly the condition the gate requires.

**Axiom:** no route-level signal applies. The discriminator is the shape of a persisted template payload, not a request attribute. Recorded as a deliberate non-use rather than a zero-count claim; the deployment chain and the MaskDB census above carry this cohort.

## Explicitly deferred

- **`legacyDefaultAccountReady` in `artifact-actions.tsx`.** Its evidence is otherwise complete — #31316 reached `api/production` at `2026-09-03T06:23:13Z` and `app/production` at `2026-09-03T06:26:16Z`, 38.6 hours ago with 16 later API deployments — but **open PR #31780 (`chore(connectors): retire account rollout switch`) modifies that exact file**. Excluded under the open-PR overlap rule, not for lack of evidence.
- **AgentPhone brandless connect.** The path validates a request signature from sub-floor App builds, which the client census has repeatedly shown are still transmitting.
- **Queued-launch-context brand reads** for Telegram, AgentPhone, and Feishu — MaskDB's projection still does not expose `public_brand` on the context tables.
- **#29908**, **#28571**, **#26519**, **#27786**, **#28449 residue**, `browser-session` PK contraction, `model-provider-account` expansions, and the artifact-object fallbacks — unchanged product or evidence gates.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F api lint` (no new warnings), `pnpm -F api check-types`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F api exec vitest run` on `official-automation-result-email` + `email` (19) and `misc-routes.bdd` (6) — against a local Postgres with `timezone=UTC`

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.

Closes #30592.
