### PR TITLE
test(api): cover the goal objective brief token budget and truncation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
@@ -1,4 +1,5 @@
 import { HttpResponse, http } from "msw";
+import { z } from "zod";
 import type { Capability } from "@okouai/api-contracts/contracts/capabilities";
 import { chatThreadsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { goalsContract } from "@okouai/api-contracts/contracts/goals";
@@ -120,24 +121,27 @@ async function seedGoalApiFixture(): Promise<GoalApiFixture> {
   };
 }
 
+const openRouterBodySchema = z.object({
+  model: z.string(),
+  messages: z.array(z.object({ role: z.string(), content: z.string() })),
+  max_tokens: z.number().optional(),
+  reasoning: z
+    .object({ effort: z.enum(["none", "minimal", "low", "medium", "high"]) })
+    .optional(),
+});
+
 /**
  * Goal creation is the only fast-path caller on this route, but the OpenRouter
  * endpoint is shared, so match the objective-brief system prompt rather than
  * counting every completion request.
  */
-function isObjectiveBriefRequest(body: Record<string, unknown>): boolean {
-  const messages = body.messages;
-  if (!Array.isArray(messages)) {
-    return false;
-  }
-  const system: unknown = messages[0];
-  const content =
-    typeof system === "object" && system !== null && "content" in system
-      ? system.content
-      : undefined;
+function isObjectiveBriefRequest(
+  body: z.infer<typeof openRouterBodySchema>,
+): boolean {
   return (
-    typeof content === "string" &&
-    content.includes("Rewrite the goal objective into a short objective brief")
+    body.messages[0]?.content.includes(
+      "Rewrite the goal objective into a short objective brief",
+    ) ?? false
   );
 }
 
@@ -695,12 +699,12 @@ describe("agent goals", () => {
     const fixture = await seedGoalApiFixture();
     mockOptionalEnv("OPENROUTER_API_KEY", "goal-brief-key");
 
-    let briefRequestBody: Record<string, unknown> | undefined;
+    let briefRequestBody: z.infer<typeof openRouterBodySchema> | undefined;
     server.use(
       http.post(
         "https://openrouter.ai/api/v1/chat/completions",
         async ({ request }) => {
-          const body = (await request.json()) as Record<string, unknown>;
+          const body = openRouterBodySchema.parse(await request.json());
           if (isObjectiveBriefRequest(body)) {
             briefRequestBody = body;
           }
@@ -745,7 +749,7 @@ describe("agent goals", () => {
       http.post(
         "https://openrouter.ai/api/v1/chat/completions",
         async ({ request }) => {
-          const body = (await request.json()) as Record<string, unknown>;
+          const body = openRouterBodySchema.parse(await request.json());
           if (isObjectiveBriefRequest(body)) {
             briefRequests += 1;
           }

--- a/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/goals.test.ts
@@ -1,8 +1,10 @@
+import { HttpResponse, http } from "msw";
 import type { Capability } from "@okouai/api-contracts/contracts/capabilities";
 import { chatThreadsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { goalsContract } from "@okouai/api-contracts/contracts/goals";
 
 import { mockOptionalEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import {
@@ -116,6 +118,27 @@ async function seedGoalApiFixture(): Promise<GoalApiFixture> {
     threadId: sent.body.threadId,
     agentId: agent.agentId,
   };
+}
+
+/**
+ * Goal creation is the only fast-path caller on this route, but the OpenRouter
+ * endpoint is shared, so match the objective-brief system prompt rather than
+ * counting every completion request.
+ */
+function isObjectiveBriefRequest(body: Record<string, unknown>): boolean {
+  const messages = body.messages;
+  if (!Array.isArray(messages)) {
+    return false;
+  }
+  const system: unknown = messages[0];
+  const content =
+    typeof system === "object" && system !== null && "content" in system
+      ? system.content
+      : undefined;
+  return (
+    typeof content === "string" &&
+    content.includes("Rewrite the goal objective into a short objective brief")
+  );
 }
 
 async function createGoal(fixture: GoalApiFixture, objective = "ship goals") {
@@ -664,6 +687,87 @@ describe("agent goals", () => {
     expect(created.body).toStrictEqual({
       objective,
       objectiveBrief: objective,
+      status: "active",
+    });
+  });
+
+  it("pins the model, reasoning effort, and token budget of the objective brief completion", async () => {
+    const fixture = await seedGoalApiFixture();
+    mockOptionalEnv("OPENROUTER_API_KEY", "goal-brief-key");
+
+    let briefRequestBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>;
+          if (isObjectiveBriefRequest(body)) {
+            briefRequestBody = body;
+          }
+          return HttpResponse.json({
+            choices: [
+              {
+                finish_reason: "stop",
+                message: { content: "Ship the token budget repair" },
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const created = await createGoal(
+      fixture,
+      "Make sure the reasoning token budgets are large enough everywhere",
+    );
+
+    expect(created.body).toStrictEqual({
+      objective:
+        "Make sure the reasoning token budgets are large enough everywhere",
+      objectiveBrief: "Ship the token budget repair",
+      status: "active",
+    });
+    // Reasoning tokens are drawn from the same budget as the answer, so a
+    // budget sized for a non-reasoning model starves the answer entirely.
+    expect(briefRequestBody).toMatchObject({
+      model: "google/gemini-3.8-flash",
+      max_tokens: 768,
+      reasoning: { effort: "low" },
+    });
+  });
+
+  it("falls back to the objective when the brief completion is token-limited", async () => {
+    const fixture = await seedGoalApiFixture();
+    mockOptionalEnv("OPENROUTER_API_KEY", "goal-brief-key");
+
+    let briefRequests = 0;
+    server.use(
+      http.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>;
+          if (isObjectiveBriefRequest(body)) {
+            briefRequests += 1;
+          }
+          return HttpResponse.json({
+            choices: [
+              {
+                finish_reason: "length",
+                native_finish_reason: "MAX_TOKENS",
+                message: { content: "A truncated brief that must not" },
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const created = await createGoal(fixture, "ship thread goals");
+
+    expect(briefRequests).toBe(1);
+    expect(created.body).toStrictEqual({
+      objective: "ship thread goals",
+      objectiveBrief: "ship thread goals",
       status: "active",
     });
   });


### PR DESCRIPTION
Follow-up to #31753, closing the one coverage gap that PR named in its own review.

## Problem

#31753 pinned the model, reasoning effort, and token budget for four of the five fast-path OpenRouter callers, and covered their truncation behaviour. It deliberately left out `goal-objective-brief.service.ts`, because that site is reached through goal creation rather than the chat callback path and therefore needs a different test surface.

That site has identical exposure. It runs at `reasoning: { effort: "low" }` with a 768-token budget, Gemini 3 draws thinking tokens from the same `max_output_tokens` budget as the answer, and since #31653 a truncated completion throws at `signals/external/openrouter.ts:159`. Reverting its budget from 768 to the pre-#31715 value of 80 left the whole suite green.

## Change

Two tests in `goals.test.ts`, both asserting through the goals API rather than internals:

| Test | Asserts |
|---|---|
| pins the model, reasoning effort, and token budget of the objective brief completion | the outbound request carries `google/gemini-3.8-flash`, `max_tokens: 768`, `effort: "low"`, and the created goal's `objectiveBrief` is the generated text |
| falls back to the objective when the brief completion is token-limited | a `finish_reason: "length"` completion yields the objective-derived brief, not the truncated text |

Both drive the real `POST /api/goals` route and assert on its response body, so the user-visible outcome is the assertion rather than an internal call.

The file's `beforeEach` clears `OPENROUTER_API_KEY`, so existing tests continue to exercise the no-LLM fallback path; these two opt in explicitly.

A small `isObjectiveBriefRequest` helper matches the objective-brief system prompt instead of counting every completion request, so the tests stay correct if another fast-path caller is ever reached from this route.

No production code changed.

## Verification

`prettier`, `oxlint`, `oxlint --type-aware`, and `eslint` all pass on the changed file. The API workspace type-check needs more memory than this container has, and the suite needs a Postgres instance that is not initialised here, so both are left to the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
