### PR TITLE
feat: add gpt-6 astra to new workspace model defaults

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -718,13 +718,13 @@ describe("model-first canonical catalog", () => {
   it("builds the default org policy seed from the workspace defaults", () => {
     expect(DEFAULT_ORG_MODEL_POLICY_MODELS).toEqual([
       "claude-fable-5-1",
+      "gpt-6-astra",
       "gpt-5.6-sol",
       "gpt-5.6-luna",
       "deepseek-v4-flash",
     ]);
     expect(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL).toBe("deepseek-v4-flash");
     expect(LIMITED_FREE1_DEFAULT_RUN_MODEL).toBe("deepseek-v4-flash");
-    expect(DEFAULT_ORG_MODEL_POLICY_MODELS).not.toContain("gpt-6-astra");
     expect(DEFAULT_ORG_MODEL_POLICY_MODELS).not.toContain("deepseek-v4-pro");
     expect(getDefaultModel("built-in")).toBe(
       DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -131,6 +131,7 @@ const MODEL_PROVIDER_CODEX_RUNTIME_CONFIGS: Partial<
 
 export const DEFAULT_ORG_MODEL_POLICY_MODELS = [
   "claude-fable-5-1",
+  "gpt-6-astra",
   "gpt-5.6-sol",
   "gpt-5.6-luna",
   "deepseek-v4-flash",


### PR DESCRIPTION
## Summary

Add GPT-6 Astra to the initial model list for new workspaces, in this order: Claude Fable 5.1, GPT-6 Astra, GPT-5.6 Sol, GPT-5.6 Luna, and DeepSeek V4 Flash (default). Astra follows the existing Pro model restriction.

Update the existing policy-seed test to cover the five-model order.

## Verification

- Formatting check passed for both changed files.
- API contracts lint, Knip, and type checks passed.
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts` — 178 tests passed.
- Full test suites are left to the PR pipeline, per repository instructions.
