### PR TITLE
fix(ui): restore amber primary and align toggle tracks

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1996,9 +1996,9 @@ html:has(.zero-dialog-overlay)
    dark card does not: it lands on a bright grey that reads as a white outline
    rather than as focus, which is what `--ring` means on every other control.
    Saturation, not lightness, does the work, so the ring stays quieter than the
-   full Cobalt stop. */
+   full Amber stop. */
 :where([data-theme="dark"][data-new-ui]) .zero-app .zero-composer {
-  --zero-composer-ring: 222 38% 38%;
+  --zero-composer-ring: 38.8 38% 38%;
 }
 
 /* ===================================================================
@@ -2038,15 +2038,18 @@ html:has(.zero-dialog-overlay)
   --zero-composer-focus-veil: 0 10px 48px -8px hsl(30 8% 45% / 0.09);
 }
 
-/* Markdown links read the brand tokens now that those carry Cobalt themselves.
-   They used to hardcode it, because Amber could not be a link colour, and the
-   dark pair below them never applied: `:where()` zeroes its own specificity, so
-   the light rule outweighed it. One theme-aware token settles both. */
+/* Markdown links use the palette's Cobalt rather than the Amber action color. */
 [data-new-ui] .wmde-markdown a {
-  color: hsl(var(--brand-text));
+  color: hsl(222 64% 45%);
 }
 [data-new-ui] .wmde-markdown a:hover {
-  color: hsl(var(--brand-text-hover));
+  color: hsl(222 65% 39%);
+}
+[data-theme="dark"][data-new-ui] .wmde-markdown a {
+  color: hsl(222 72% 70%);
+}
+[data-theme="dark"][data-new-ui] .wmde-markdown a:hover {
+  color: hsl(222 80% 88%);
 }
 
 /* Colour themes realigned to the new ramp's lightness steps. */

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -569,8 +569,10 @@ body {
   filter: invert(1);
 }
 
-/* Switch track: ensure visibility against card background in dark mode */
-:where([data-theme="dark"]) .zero-app [role="switch"][data-unchecked] {
+/* Keep the legacy dark track visible without overriding the new UI's own step. */
+:where([data-theme="dark"]:not([data-new-ui]))
+  .zero-app
+  [role="switch"][data-unchecked] {
   background-color: hsl(var(--gray-400));
 }
 

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -569,10 +569,8 @@ body {
   filter: invert(1);
 }
 
-/* Keep the legacy dark track visible without overriding the new UI's own step. */
-:where([data-theme="dark"]:not([data-new-ui]))
-  .zero-app
-  [role="switch"][data-unchecked] {
+/* Switch track: ensure visibility against card background in dark mode */
+:where([data-theme="dark"]) .zero-app [role="switch"][data-unchecked] {
   background-color: hsl(var(--gray-400));
 }
 

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -569,8 +569,10 @@ body {
   filter: invert(1);
 }
 
-/* Switch track: ensure visibility against card background in dark mode */
-:where([data-theme="dark"]) .zero-app [role="switch"][data-unchecked] {
+/* Keep the legacy dark track visible without overriding the new UI token. */
+:where([data-theme="dark"]:not([data-new-ui]))
+  .zero-app
+  [role="switch"][data-unchecked] {
   background-color: hsl(var(--gray-400));
 }
 

--- a/turbo/apps/platform/src/views/okou-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/workflow-automations-page.tsx
@@ -738,7 +738,6 @@ export function WorkflowAutomationEnabledSwitch({
               { title },
             )
       }
-      className="data-checked:bg-primary data-unchecked:bg-muted"
       onCheckedChange={(enabled) => {
         detach(
           setEnabled(

--- a/turbo/apps/platform/src/views/okou-page/workflow-automations-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/workflow-automations-page.tsx
@@ -738,6 +738,7 @@ export function WorkflowAutomationEnabledSwitch({
               { title },
             )
       }
+      className="data-checked:bg-primary data-unchecked:bg-muted"
       onCheckedChange={(enabled) => {
         detach(
           setEnabled(

--- a/turbo/packages/ui/src/components/ui/__tests__/switch.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/switch.test.tsx
@@ -4,11 +4,12 @@ import { describe, expect, it } from "vitest";
 import { Switch } from "../switch";
 
 describe("Switch", () => {
-  it("uses the segmented-control track when unchecked", () => {
+  it("deepens only the new UI unchecked track by one neutral step", () => {
     render(<Switch aria-label="Notifications" />);
 
     expect(screen.getByRole("switch", { name: "Notifications" })).toHaveClass(
-      "data-unchecked:bg-segment-track",
+      "data-unchecked:bg-muted",
+      "new-ui:data-unchecked:bg-gray-300",
     );
   });
 });

--- a/turbo/packages/ui/src/components/ui/__tests__/switch.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/switch.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Switch } from "../switch";
+
+describe("Switch", () => {
+  it("uses the segmented-control track when unchecked", () => {
+    render(<Switch aria-label="Notifications" />);
+
+    expect(screen.getByRole("switch", { name: "Notifications" })).toHaveClass(
+      "data-unchecked:bg-segment-track",
+    );
+  });
+});

--- a/turbo/packages/ui/src/components/ui/__tests__/switch.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/switch.test.tsx
@@ -4,12 +4,13 @@ import { describe, expect, it } from "vitest";
 import { Switch } from "../switch";
 
 describe("Switch", () => {
-  it("deepens only the new UI unchecked track by one neutral step", () => {
+  it("deepens only the new UI checked track by one Amber step", () => {
     render(<Switch aria-label="Notifications" />);
 
     expect(screen.getByRole("switch", { name: "Notifications" })).toHaveClass(
+      "data-checked:bg-primary",
+      "new-ui:data-checked:bg-primary-400",
       "data-unchecked:bg-muted",
-      "new-ui:data-unchecked:bg-gray-300",
     );
   });
 });

--- a/turbo/packages/ui/src/components/ui/__tests__/switch.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/switch.test.tsx
@@ -1,17 +1,118 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import tailwindcss from "@tailwindcss/postcss";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import postcss from "postcss";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { Switch } from "../switch";
 
-describe("Switch", () => {
-  it("uses the new UI Amber and segment track tokens", () => {
-    render(<Switch aria-label="Notifications" />);
+let compiledSwitchCss = "";
 
-    expect(screen.getByRole("switch", { name: "Notifications" })).toHaveClass(
-      "data-checked:bg-primary",
-      "new-ui:data-checked:bg-primary-400",
-      "data-unchecked:bg-muted",
-      "new-ui:data-unchecked:bg-segment-track",
-    );
+function globalCssPath(): string {
+  const candidates = [
+    join(process.cwd(), "src/styles/globals.css"),
+    join(process.cwd(), "packages/ui/src/styles/globals.css"),
+  ];
+  const path = candidates.find((candidate) => {
+    return existsSync(candidate);
+  });
+  if (path === undefined) {
+    throw new Error("Unable to locate UI global CSS");
+  }
+  return path;
+}
+
+async function compileSwitchCss(): Promise<string> {
+  const path = globalCssPath();
+  const source = `${readFileSync(path, "utf8")}\n@source "../components/ui/switch.tsx";`;
+  const result = await postcss([tailwindcss()]).process(source, { from: path });
+  const rules: string[] = [];
+
+  postcss.parse(result.css).walkRules((rule) => {
+    const isSwitchState =
+      rule.selector.includes("[data-checked]") ||
+      rule.selector.includes("[data-unchecked]");
+    const setsBackground = rule.nodes.some((node) => {
+      return node.type === "decl" && node.prop === "background-color";
+    });
+    if (isSwitchState && setsBackground) {
+      rules.push(rule.toString());
+    }
+  });
+
+  if (rules.length === 0) {
+    throw new Error("Tailwind did not compile switch state backgrounds");
+  }
+  return rules.join("\n");
+}
+
+function installSwitchStyles(segmentTrack: string): () => void {
+  const style = document.createElement("style");
+  style.textContent = `${compiledSwitchCss}
+    :root {
+      --color-primary: rgb(237, 78, 1);
+      --color-primary-400: rgb(225, 145, 0);
+      --color-muted: rgb(231, 235, 240);
+      --color-segment-track: ${segmentTrack};
+    }
+  `;
+  document.head.append(style);
+  return () => {
+    style.remove();
+  };
+}
+
+beforeAll(async () => {
+  compiledSwitchCss = await compileSwitchCss();
+});
+
+describe("Switch", () => {
+  it.each([
+    { name: "light", segmentTrack: "rgb(240, 236, 234)" },
+    { name: "dark", segmentTrack: "rgb(62, 61, 60)" },
+  ])(
+    "renders the new UI $name track and checked Amber",
+    async ({ segmentTrack }) => {
+      const removeStyles = installSwitchStyles(segmentTrack);
+      try {
+        const user = userEvent.setup();
+        render(<Switch data-new-ui aria-label="Notifications" />);
+        const toggle = screen.getByRole("switch", { name: "Notifications" });
+
+        expect(toggle).not.toBeChecked();
+        expect(getComputedStyle(toggle).backgroundColor).toBe(segmentTrack);
+
+        await user.click(toggle);
+
+        expect(toggle).toBeChecked();
+        expect(getComputedStyle(toggle).backgroundColor).toBe(
+          "rgb(225, 145, 0)",
+        );
+      } finally {
+        removeStyles();
+      }
+    },
+  );
+
+  it("preserves the legacy switch colors", async () => {
+    const removeStyles = installSwitchStyles("rgb(240, 236, 234)");
+    try {
+      const user = userEvent.setup();
+      render(<Switch aria-label="Notifications" />);
+      const toggle = screen.getByRole("switch", { name: "Notifications" });
+
+      expect(getComputedStyle(toggle).backgroundColor).toBe(
+        "rgb(231, 235, 240)",
+      );
+
+      await user.click(toggle);
+
+      expect(getComputedStyle(toggle).backgroundColor).toBe("rgb(237, 78, 1)");
+    } finally {
+      removeStyles();
+    }
   });
 });

--- a/turbo/packages/ui/src/components/ui/__tests__/switch.test.tsx
+++ b/turbo/packages/ui/src/components/ui/__tests__/switch.test.tsx
@@ -4,13 +4,14 @@ import { describe, expect, it } from "vitest";
 import { Switch } from "../switch";
 
 describe("Switch", () => {
-  it("deepens only the new UI checked track by one Amber step", () => {
+  it("uses the new UI Amber and segment track tokens", () => {
     render(<Switch aria-label="Notifications" />);
 
     expect(screen.getByRole("switch", { name: "Notifications" })).toHaveClass(
       "data-checked:bg-primary",
       "new-ui:data-checked:bg-primary-400",
       "data-unchecked:bg-muted",
+      "new-ui:data-unchecked:bg-segment-track",
     );
   });
 });

--- a/turbo/packages/ui/src/components/ui/switch.tsx
+++ b/turbo/packages/ui/src/components/ui/switch.tsx
@@ -34,7 +34,7 @@ const Switch = React.forwardRef<HTMLElement, SwitchProps>(
       <SwitchPrimitive.Root
         data-slot="switch"
         className={cn(
-          "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none data-checked:bg-primary data-unchecked:bg-muted new-ui:data-unchecked:bg-gray-300 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-disabled:cursor-not-allowed data-disabled:opacity-50",
+          "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none data-checked:bg-primary new-ui:data-checked:bg-primary-400 data-unchecked:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-disabled:cursor-not-allowed data-disabled:opacity-50",
           s.root,
           className,
         )}

--- a/turbo/packages/ui/src/components/ui/switch.tsx
+++ b/turbo/packages/ui/src/components/ui/switch.tsx
@@ -34,7 +34,7 @@ const Switch = React.forwardRef<HTMLElement, SwitchProps>(
       <SwitchPrimitive.Root
         data-slot="switch"
         className={cn(
-          "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none data-checked:bg-primary new-ui:data-checked:bg-primary-400 data-unchecked:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-disabled:cursor-not-allowed data-disabled:opacity-50",
+          "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none data-checked:bg-primary new-ui:data-checked:bg-primary-400 data-unchecked:bg-muted new-ui:data-unchecked:bg-segment-track focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-disabled:cursor-not-allowed data-disabled:opacity-50",
           s.root,
           className,
         )}

--- a/turbo/packages/ui/src/components/ui/switch.tsx
+++ b/turbo/packages/ui/src/components/ui/switch.tsx
@@ -34,7 +34,7 @@ const Switch = React.forwardRef<HTMLElement, SwitchProps>(
       <SwitchPrimitive.Root
         data-slot="switch"
         className={cn(
-          "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none data-checked:bg-primary data-unchecked:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-disabled:cursor-not-allowed data-disabled:opacity-50",
+          "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none data-checked:bg-primary data-unchecked:bg-segment-track focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-disabled:cursor-not-allowed data-disabled:opacity-50",
           s.root,
           className,
         )}

--- a/turbo/packages/ui/src/components/ui/switch.tsx
+++ b/turbo/packages/ui/src/components/ui/switch.tsx
@@ -34,7 +34,7 @@ const Switch = React.forwardRef<HTMLElement, SwitchProps>(
       <SwitchPrimitive.Root
         data-slot="switch"
         className={cn(
-          "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none data-checked:bg-primary data-unchecked:bg-segment-track focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-disabled:cursor-not-allowed data-disabled:opacity-50",
+          "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none data-checked:bg-primary data-unchecked:bg-muted new-ui:data-unchecked:bg-gray-300 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-disabled:cursor-not-allowed data-disabled:opacity-50",
           s.root,
           className,
         )}

--- a/turbo/packages/ui/src/styles/__tests__/globals.test.ts
+++ b/turbo/packages/ui/src/styles/__tests__/globals.test.ts
@@ -318,53 +318,35 @@ describe("interaction state ladder", () => {
     "primary",
     "destructive",
     "interrupt",
-  ])("derives %s's hover from a state-alpha ladder", (surface) => {
+  ])("derives %s's hover from the shared state alphas", (surface) => {
     expect(globalCss).toContain(`--color-${surface}-hover: color-mix(`);
   });
 
-  // Primary is the one filled surface that does not ride the shared pair, so
-  // the case above cannot say which ladder it reads. Name it here, and keep a
-  // neighbour on the shared pair so the split stays visible rather than
-  // becoming the new default by drift.
-  it("reads primary's states from the primary alphas and the rest from the shared pair", () => {
+  it("uses the shared filled-state ladder for the Amber primary", () => {
     expect(readDeclarationValue(globalCss, "color-primary-hover")).toContain(
-      "var(--state-primary-hover-alpha)",
+      "var(--state-on-filled-hover-alpha)",
     );
     expect(readDeclarationValue(globalCss, "color-primary-pressed")).toContain(
-      "var(--state-primary-pressed-alpha)",
+      "var(--state-on-filled-pressed-alpha)",
     );
-    expect(
-      readDeclarationValue(globalCss, "color-destructive-hover"),
-    ).toContain("var(--state-on-filled-hover-alpha)");
   });
+});
 
-  // The default is declared once, on the same <html> every theme block targets,
-  // so a palette that does not override it inherits whichever shared pair won.
-  // Nothing else in this file records that, because a `var()` default carries
-  // no percentage for `readAlphas` to find.
-  it("defaults the primary alphas to the shared on-filled pair", () => {
+describe("new UI primary palette", () => {
+  it.each([
+    { name: "light", selector: ":root[data-new-ui]" },
+    { name: "dark", selector: ".dark[data-new-ui]," },
+  ])("pairs Amber with Ink in $name", ({ selector }) => {
+    const properties = readCustomProperties(readRuleBody(globalCss, selector));
+
+    expect(rgbToHex(color(properties, "--primary"))).toBe("#FFA500");
+    expect(rgbToHex(color(properties, "--primary-foreground"))).toBe("#242321");
     expect(
-      readDeclarationValue(globalCss, "state-primary-hover-alpha"),
-    ).toContain("var(--state-on-filled-hover-alpha)");
-    expect(
-      readDeclarationValue(globalCss, "state-primary-pressed-alpha"),
-    ).toContain("var(--state-on-filled-pressed-alpha)");
-  });
-
-  // Dark inverts `--black` to white, so a filled surface lightens on hover.
-  // That suits a fill carrying Ink and starves one carrying white: on Cobalt
-  // the shared 12% / 20% drop the label to 4.30:1 and 3.70:1, under the 4.5:1
-  // it needs. The override exists only to shorten that lift, so pin both the
-  // ordering and the fact that it stays shorter than the pair it replaces.
-  it("shortens the primary step where the new UI's dark fill carries white", () => {
-    const theme = readRuleBody(globalCss, ".dark[data-new-ui]");
-
-    const hover = readAlpha(theme, "primary-hover");
-    const pressed = readAlpha(theme, "primary-pressed");
-
-    expect(hover).toBeLessThan(pressed);
-    expect(hover).toBeLessThan(readAlpha(theme, "on-filled-hover"));
-    expect(pressed).toBeLessThan(readAlpha(theme, "on-filled-pressed"));
+      contrastRatio(
+        color(properties, "--primary-foreground"),
+        color(properties, "--primary"),
+      ),
+    ).toBeGreaterThanOrEqual(7.9);
   });
 });
 

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -14,7 +14,7 @@
  * Based on Figma: https://www.figma.com/design/eTWIsjktpymTDYEb55OxXx/VM0-Cloud
  *
  * Typography: Noto Sans
- * Primary Color: #3363d3 (Cobalt); Amber #ffa500 stays the identity mark
+ * Primary Color: #ffa500 (Amber)
  *
  * The two primitive scales below are derived from the published palette:
  * https://zero-design-color.sites.vm0.io
@@ -32,16 +32,12 @@
  * Surface steps are intentionally quieter: WCAG does not require decorative
  * surface fills to contrast with one another.
  *
- * `--primary-*` carries Cobalt, whose brand stop is `--primary-300` (#3363d3)
- * rather than the 700 the old orange used. Amber's scale held the same
- * position, and Cobalt inherits it so the semantic tokens did not have to move.
+ * `--primary-*` carries Amber, whose brand stop is `--primary-300` (#ffa500)
+ * rather than the 700 the old orange used, because that scale is adopted
+ * stop-for-stop from the palette.
  *
- * Amber is a light fill and cannot carry a label: white on it is 1.97:1 and Ink
- * is 7.95:1, so a filled control had to choose between a brand colour and a
- * readable one. Cobalt resolves it -- the palette already spends it on markdown
- * links and the usage charts, and it takes white at 5.43:1. So Amber keeps
- * identity (the mark, the app icon) and Cobalt takes action: `--primary` and
- * everything derived from it. `--primary-foreground` is white in both themes.
+ * Amber is a light fill: it takes Ink text, never white (7.95:1 vs 1.97:1).
+ * That is why `--primary-foreground` is Ink in both themes.
  */
 
 /* Define theme colors and typography for Tailwind v4 */
@@ -135,7 +131,7 @@
   /* ===================================
    * Brand Tint / Brand Text
    *
-   * The brand scale is no longer mirrored between themes, so a raw stop like
+   * The Amber scale is no longer mirrored between themes, so a raw stop like
    * `primary-100` is a pale tint in light and still a pale tint in dark, where
    * it would blow out. These two are theme-aware: reach for them wherever the
    * brand appears as a wash behind text or as text itself, and keep the raw
@@ -235,20 +231,15 @@
     hsl(var(--secondary)),
     hsl(var(--state-layer)) var(--state-pressed-alpha)
   );
-  /* Primary reads its own alphas rather than the shared on-filled pair. In dark
-     `--black` inverts to white, so a filled control *lightens* on hover -- which
-     is right for a fill that carries Ink text and wrong for one that carries
-     white. The aliases below default to the shared ladder; only the scope that
-     needs a shorter step overrides them. */
   --color-primary-hover: color-mix(
     in srgb,
     hsl(var(--primary)),
-    hsl(var(--black)) var(--state-primary-hover-alpha)
+    hsl(var(--black)) var(--state-on-filled-hover-alpha)
   );
   --color-primary-pressed: color-mix(
     in srgb,
     hsl(var(--primary)),
-    hsl(var(--black)) var(--state-primary-pressed-alpha)
+    hsl(var(--black)) var(--state-on-filled-pressed-alpha)
   );
   --color-destructive-hover: color-mix(
     in srgb,
@@ -405,11 +396,6 @@
     --state-on-filled-hover-alpha: 10%;
     --state-on-filled-pressed-alpha: 16%;
 
-    /* Declared once here, on the same <html> every theme block targets, so the
-       reference resolves against whichever on-filled pair is in effect. */
-    --state-primary-hover-alpha: var(--state-on-filled-hover-alpha);
-    --state-primary-pressed-alpha: var(--state-on-filled-pressed-alpha);
-
     /* Segment control (light): white lifts off the track. */
     --segment-selected: 0 0% 100%;
     --segment-track: var(--muted);
@@ -561,7 +547,7 @@
   }
 
   /* ===================================
-   * Neutral / Cobalt, behind the `newUi` switch
+   * Neutral / Amber, behind the `newUi` switch
    *
    * Both selectors match the same <html> the blocks above do, and win on
    * specificity, so every `@theme` alias -- which is a lazy `hsl(var(--x))`
@@ -579,24 +565,21 @@
      * Base Color Palette (Tailwind Style)
      * =================================== */
 
-    /* Primary Color Scale (Cobalt). The brand stop is 300, the position Amber
-       held, and the scale darkens monotonically from there. The stop itself is
-       the palette's existing Cobalt -- already spent on markdown links and the
-       usage-chart series -- so this promotes a colour the product ships rather
-       than introducing one. Every stop sits at hue 222; only 300 is published,
-       and the rest are generated along it. */
-    --primary-0: 222 100% 98.5%; /* #F7FAFF */
-    --primary-50: 222 85% 94.5%; /* #E5ECFD */
-    --primary-100: 222 80% 88%; /* #C8D7F9 */
-    --primary-200: 222 72% 70%; /* #7B9CEA */
-    --primary-300: 222 64.5% 51.4%; /* #3363D3 - brand */
-    --primary-400: 222 64% 45%; /* #2955BC */
-    --primary-500: 222 65% 39%; /* #234AA4 */
-    --primary-600: 222 66% 33%; /* #1D3E8C */
-    --primary-700: 222 67% 28%; /* #183477 */
-    --primary-800: 222 68% 23%; /* #132B63 */
-    --primary-900: 222 60% 18%; /* #122349 */
-    --primary-950: 222 55% 12%; /* #0E182F */
+    /* Primary Color Scale (Amber). Adopted stop-for-stop from the palette, so
+       the brand colour is 300 and the scale darkens monotonically from there.
+       Only `--primary-0` is generated, above the published 50. */
+    --primary-0: 31.4 100% 97.5%; /* #FFF9F2 */
+    --primary-50: 31.4 100% 91.4%; /* #FFEAD3 */
+    --primary-100: 31.6 100% 85.5%; /* #FFDCB5 */
+    --primary-200: 32.6 100% 75.1%; /* #FFC580 */
+    --primary-300: 38.8 100% 50%; /* #FFA500 - brand */
+    --primary-400: 38.7 100% 44.1%; /* #E19100 */
+    --primary-500: 38.5 100% 38.2%; /* #C37D00 */
+    --primary-600: 38.3 100% 32.5%; /* #A66A00 */
+    --primary-700: 37.9 100% 26.7%; /* #885600 */
+    --primary-800: 37.2 100% 21.2%; /* #6C4300 */
+    --primary-900: 35.5 81.6% 17.1%; /* #4F3208 */
+    --primary-950: 33.2 63.3% 11.8%; /* #31200B */
 
     /* Neutral Gray Color Scale (Light). Linen is exact at 100, Ink at 950;
        intermediate chroma tapers toward zero in OKLab. */
@@ -654,9 +637,9 @@
     --popover-foreground: var(--foreground); /* tracks body copy */
 
     --primary: var(--primary-300); /* primary-300 - brand */
-    /* Cobalt is a mid fill and takes white at 5.43:1, the same in both themes
-       because the fill is too. */
-    --primary-foreground: var(--on-filled); /* on-filled - white on brand */
+    /* Amber is a light fill and cannot carry white text (1.97:1). Ink clears
+       7.95:1 and is the same in both themes, because the fill is too. */
+    --primary-foreground: 40 4.3% 13.5%; /* #242321 - Ink */
 
     --secondary: 17.1 41.2% 96.7%; /* #FAF5F3 - Linen, tracking gray-100 */
     --secondary-foreground: var(--foreground); /* tracks body copy */
@@ -684,12 +667,10 @@
     --input: var(--white); /* white - same as card */
     --ring: var(--primary-400); /* primary-400 - 6.73:1 on the canvas */
 
-    /* Brand as a wash and as text. Amber only became legible at 700; Cobalt
-       clears 4.5:1 by 400, so text stops there and keeps the hue readable as
-       blue rather than as near-black. */
-    --brand-subtle: var(--primary-50); /* #E5ECFD */
-    --brand-text: var(--primary-400); /* #2955BC - 6.73:1 on white */
-    --brand-text-hover: var(--primary-500); /* #234AA4 - 8.12:1 */
+    /* Brand as a wash and as text (published brand-subtle / brand-text). */
+    --brand-subtle: var(--primary-50); /* #FFEAD3 */
+    --brand-text: var(--primary-700); /* #885600 */
+    --brand-text-hover: var(--primary-800); /* #6C4300 */
 
     /* Text on filled/colored backgrounds (buttons, tooltips, badges) */
     --on-filled: 0 0% 100%; /* Pure white for text on colored backgrounds */
@@ -748,23 +729,22 @@
      * Base Color Palette (Dark Theme)
      * =================================== */
 
-    /* Primary Color Scale (Cobalt - Dark). The brand fill is the same #3363D3 in
-       both themes, so the scale is not reversed here. Dark only reaches for
-       different stops: the brand solid stays 300, text and the ring rise to 200
-       because 300 is only 2.89:1 against the Ink page, and 950 is the subtle
-       fill. */
-    --primary-0: 222 100% 98.5%; /* #F7FAFF */
-    --primary-50: 222 85% 94.5%; /* #E5ECFD */
-    --primary-100: 222 80% 88%; /* #C8D7F9 */
-    --primary-200: 222 72% 70%; /* #7B9CEA */
-    --primary-300: 222 64.5% 51.4%; /* #3363D3 - brand */
-    --primary-400: 222 64% 45%; /* #2955BC */
-    --primary-500: 222 65% 39%; /* #234AA4 */
-    --primary-600: 222 66% 33%; /* #1D3E8C */
-    --primary-700: 222 67% 28%; /* #183477 */
-    --primary-800: 222 68% 23%; /* #132B63 */
-    --primary-900: 222 60% 18%; /* #122349 */
-    --primary-950: 222 55% 12%; /* #0E182F */
+    /* Primary Color Scale (Amber - Dark). The palette publishes one Amber, and
+       the brand fill is the same #FFA500 in both themes, so the scale is not
+       reversed here. Dark only reaches for different stops: the brand solid
+       stays 300, its hover steps *up* to 200, and 950 becomes the subtle fill. */
+    --primary-0: 31.4 100% 97.5%; /* #FFF9F2 */
+    --primary-50: 31.4 100% 91.4%; /* #FFEAD3 */
+    --primary-100: 31.6 100% 85.5%; /* #FFDCB5 */
+    --primary-200: 32.6 100% 75.1%; /* #FFC580 */
+    --primary-300: 38.8 100% 50%; /* #FFA500 - brand */
+    --primary-400: 38.7 100% 44.1%; /* #E19100 */
+    --primary-500: 38.5 100% 38.2%; /* #C37D00 */
+    --primary-600: 38.3 100% 32.5%; /* #A66A00 */
+    --primary-700: 37.9 100% 26.7%; /* #885600 */
+    --primary-800: 37.2 100% 21.2%; /* #6C4300 */
+    --primary-900: 35.5 81.6% 17.1%; /* #4F3208 */
+    --primary-950: 33.2 63.3% 11.8%; /* #31200B */
 
     /* Neutral Gray Color Scale (Dark). The existing shell and Ink canvas stay
        fixed at 0 and 50; Linen is exact at 950. Text stops are measured against
@@ -802,8 +782,8 @@
     --popover-foreground: var(--gray-950); /* gray-950 */
 
     --primary: var(--primary-300); /* primary-300 - brand */
-    /* Same Cobalt fill as light, so the same white text (5.43:1). */
-    --primary-foreground: var(--on-filled); /* on-filled - white on brand */
+    /* Same Amber fill as light, so the same Ink text (7.95:1). */
+    --primary-foreground: 40 4.3% 13.5%; /* #242321 - Ink */
 
     --secondary: 30 1.9% 20.8%; /* #363534 */
     --secondary-foreground: var(--gray-950); /* gray-950 */
@@ -834,13 +814,13 @@
     --input: var(
       --gray-200
     ); /* gray-200 - lighter than card for visible input surfaces */
-    --ring: var(--primary-200); /* primary-200 - 5.82:1 against the Ink page */
+    --ring: var(--primary-300); /* primary-300 - the brand stop reads on Ink */
 
     /* Brand as a wash and as text. Dark takes the opposite end of the same
        scale: the wash drops to 950 and the text rises to the brand stop. */
-    --brand-subtle: var(--primary-950); /* #0E182F */
-    --brand-text: var(--primary-200); /* #7B9CEA - 5.82:1 on the Ink page */
-    --brand-text-hover: var(--primary-100); /* #C8D7F9 - 10.87:1 */
+    --brand-subtle: var(--primary-950); /* #31200B */
+    --brand-text: var(--primary-300); /* #FFA500 */
+    --brand-text-hover: var(--primary-200); /* #FFC580 */
 
     /* Text on filled/colored backgrounds (buttons, tooltips, badges) */
     --on-filled: 0 0% 100%; /* Pure white for text on colored backgrounds */
@@ -872,16 +852,6 @@
     --state-pressed-alpha: 19%;
     --state-on-filled-hover-alpha: 12%;
     --state-on-filled-pressed-alpha: 20%;
-
-    /* Primary keeps the direction -- dark lifts a fill rather than deepening it
-       -- but not the distance. `--black` is white here, so the shared 12% / 20%
-       would carry Cobalt to 4.30:1 and 3.70:1 under its white label, under the
-       4.5:1 that label needs. 5% and 9% are the widest steps that hold it at
-       4.93:1 and 4.57:1, and they lift the button's own separation from the Ink
-       page past 3:1 on the way. Amber never needed this: it carried Ink, which
-       only gets easier as the fill brightens. */
-    --state-primary-hover-alpha: 5%;
-    --state-primary-pressed-alpha: 9%;
 
     /* Segment control (dark): the selection steps *up* the grey ramp from the
        gray-200 track, and the veil turns black so it still reads as a lift. */


### PR DESCRIPTION
## Summary

- deepen new UI checked toggles by one Amber step, from `primary-300` (`#FFA500`) to `primary-400` (`#E19100`)
- align new UI unchecked toggles with the shared `segment-track` token (`#F0ECEA` light, `#3E3D3C` dark)
- preserve legacy toggle colors while restoring the `newUi` primary palette to Amber (`#FFA500`) with Ink (`#242321`) foreground text
- keep Markdown links on their existing Cobalt colors while aligning primary focus and interaction states with Amber

## Verification

- `pnpm vitest run --project=@okouai/ui packages/ui/src/components/ui/__tests__/switch.test.tsx packages/ui/src/styles/__tests__/globals.test.ts` (45 tests passed)
- `pnpm vitest run --project=@okouai/app apps/platform/src/views/okou-page/__tests__/chat-list-event-order.test.tsx` (2 tests passed)
- `pnpm --filter @okouai/ui lint`
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/ui check-types`
- `pnpm --filter @okouai/app check-types`
- `pnpm knip --workspace @okouai/ui --workspace @okouai/app`
- focused Prettier check for all changed files
- PR preview browser QA on `4a989a7`:
  - light new UI unchecked toggle and Segment track both compute to `rgb(240, 236, 234)` (`#F0ECEA`)
  - dark new UI unchecked toggle and Segment track both compute to `rgb(62, 61, 60)` (`#3E3D3C`)
  - checked toggle remains `rgb(225, 145, 0)` (`#E19100`) in both themes
  - legacy dark toggles remain `rgb(239, 80, 1)` checked and `rgb(66, 67, 72)` unchecked

## Preview evidence

- [Light theme](https://cdn.vm0.io/artifacts/2ihdlhptqj.png)
- [Dark theme](https://cdn.vm0.io/artifacts/dfgl4xok6t.png)

## Notes

- Browser QA used the disposable Clerk organization-admin test account created for this PR and bypassed onboarding because onboarding is outside this PR's scope.
- The `newUi` feature switch was enabled; `_realAgentInPreview` remained disabled and no mock content was used.
