### PR TITLE
refactor(platform): remove obsolete attachment gates and share automation logic

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1866,7 +1866,6 @@
       "threadSuggestions": "Chat-Threads",
       "useForFutureChats": "Dieses Modell für zukünftige Chats verwenden",
       "videoModelForThisChat": "Videomodell für diesen Chat",
-      "visualAttachmentsUnsupported": "{{modelName}} kann Bilder oder Videos nicht erkennen. Wechseln Sie vor dem Anhängen zu einem visionsfähigen Modell.",
       "workflows": {
         "empty": "Keine passenden Workflows",
         "loading": "Workflows werden geladen...",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1866,7 +1866,6 @@
       "threadSuggestions": "Chat threads",
       "useForFutureChats": "Use this for future chats",
       "videoModelForThisChat": "Video model for this chat",
-      "visualAttachmentsUnsupported": "{{modelName}} cannot recognize images or videos. Switch to a vision-capable model to attach them.",
       "workflows": {
         "empty": "No matching workflows",
         "loading": "Loading workflows...",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1896,7 +1896,6 @@
       "threadSuggestions": "Conversaciones",
       "useForFutureChats": "Usar este modelo en futuros chats",
       "videoModelForThisChat": "Modelo de vídeo para este chat",
-      "visualAttachmentsUnsupported": "{{modelName}} no reconoce imágenes ni vídeos. Cambia a un modelo con capacidad visual para adjuntarlos.",
       "workflows": {
         "empty": "No hay flujos de trabajo coincidentes",
         "loading": "Cargando flujos de trabajo...",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1896,7 +1896,6 @@
       "threadSuggestions": "Conversations",
       "useForFutureChats": "Utiliser ce modèle pour les prochaines discussions",
       "videoModelForThisChat": "Modèle vidéo pour cette discussion",
-      "visualAttachmentsUnsupported": "{{modelName}} ne peut pas reconnaître les images ou les vidéos. Passez à un modèle capable de vision pour les joindre.",
       "workflows": {
         "empty": "Aucun workflow correspondant",
         "loading": "Chargement des workflows...",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1866,7 +1866,6 @@
       "threadSuggestions": "चैट थ्रेड",
       "useForFutureChats": "भविष्य की चैट के लिए इस मॉडल का इस्तेमाल करें",
       "videoModelForThisChat": "इस चैट के लिए वीडियो मॉडल",
-      "visualAttachmentsUnsupported": "{{modelName}} छवियों या वीडियो को नहीं पहचान सकता। उन्हें संलग्न करने के लिए दृष्टि-सक्षम मॉडल पर स्विच करें।",
       "workflows": {
         "empty": "कोई मेल खाता वर्कफ़्लो नहीं",
         "loading": "वर्कफ़्लो लोड हो रहा है...",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1863,7 +1863,6 @@
       "threadSuggestions": "Thread chat",
       "useForFutureChats": "Gunakan ini untuk chat berikutnya",
       "videoModelForThisChat": "Model video untuk chat ini",
-      "visualAttachmentsUnsupported": "{{modelName}} tidak dapat mengenali gambar atau video. Ganti ke model yang mendukung visi untuk melampirkannya.",
       "workflows": {
         "empty": "Tidak ada alur kerja yang cocok",
         "loading": "Memuat alur kerja...",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1896,7 +1896,6 @@
       "threadSuggestions": "Thread di chat",
       "useForFutureChats": "Usa questo modello per le chat future",
       "videoModelForThisChat": "Modello video per questa chat",
-      "visualAttachmentsUnsupported": "{{modelName}} non supporta immagini o video. Passa a un modello con capacità visive per allegarli.",
       "workflows": {
         "empty": "Nessun flusso di lavoro corrispondente",
         "loading": "Caricamento flussi di lavoro...",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1863,7 +1863,6 @@
       "threadSuggestions": "チャットスレッド",
       "useForFutureChats": "今後のチャットでも使用",
       "videoModelForThisChat": "このチャットの動画モデル",
-      "visualAttachmentsUnsupported": "{{modelName}} は画像またはビデオを認識できません。ビジョン対応モデルに切り替えて取り付けてください。",
       "workflows": {
         "empty": "一致するワークフローがありません",
         "loading": "ワークフローを読み込んでいます...",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1863,7 +1863,6 @@
       "threadSuggestions": "채팅 스레드",
       "useForFutureChats": "향후 채팅에도 사용",
       "videoModelForThisChat": "이 채팅의 동영상 모델",
-      "visualAttachmentsUnsupported": "{{modelName}}은 이미지나 비디오를 인식할 수 없습니다. 첨부하려면 비전 기능이 있는 모델로 전환하세요.",
       "workflows": {
         "empty": "일치하는 워크플로가 없습니다",
         "loading": "워크플로 로딩 중...",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1896,7 +1896,6 @@
       "threadSuggestions": "Conversas",
       "useForFutureChats": "Usar este modelo em chats futuros",
       "videoModelForThisChat": "Modelo de vídeo para este chat",
-      "visualAttachmentsUnsupported": "{{modelName}} não reconhece imagens nem vídeos. Troque para um modelo com visão para anexá-los.",
       "workflows": {
         "empty": "Nenhum fluxo de trabalho correspondente",
         "loading": "Carregando fluxos de trabalho...",

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -47,7 +47,6 @@ import { buildDraftPersistencePayload } from "../okou-page/draft-persistence.ts"
 import {
   collectSuccessfulAttachmentInfos,
   prepareUserMessageFromDraft$,
-  shouldExcludeVisualAttachmentsForModel,
 } from "./resolve-draft-attachments.ts";
 import type {
   ChatEvent,
@@ -87,7 +86,6 @@ import { apiClient$ } from "../api-client.ts";
 import {
   codexFastModeEnabled$,
   featureSwitch$,
-  imageRecognitionAvailable$,
 } from "../external/feature-switch.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
@@ -3272,12 +3270,6 @@ function createPerformSendMessage(deps: SendMessageDeps) {
             prepareUserMessageFromDraft$,
             draft,
             submissionPrompt,
-            {
-              excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
-                request.modelSelection?.selectedModel,
-                get(imageRecognitionAvailable$),
-              ),
-            },
             signal,
           );
         },
@@ -3407,12 +3399,6 @@ function createQueueMessage(deps: QueueMessageDeps) {
         prepareUserMessageFromDraft$,
         draft,
         prompt,
-        {
-          excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
-            modelSelection?.selectedModel,
-            get(imageRecognitionAvailable$),
-          ),
-        },
         signal,
       );
       if (!result) {

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -23,10 +23,7 @@ import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { loadRightThread$ } from "./chat-thread-panes.ts";
 import { talkDraft$, type DraftSignals } from "../okou-page/chat-draft.ts";
 import { clearAgentDraftById$ } from "../okou-page/agent-draft.ts";
-import {
-  prepareUserMessageFromDraft$,
-  shouldExcludeVisualAttachmentsForModel,
-} from "./resolve-draft-attachments.ts";
+import { prepareUserMessageFromDraft$ } from "./resolve-draft-attachments.ts";
 import {
   appendOptimisticChatEvent$,
   createOptimisticChatEventEntry,
@@ -39,10 +36,7 @@ import {
 } from "../okou-page/model-default-selection.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
-import {
-  featureSwitch$,
-  imageRecognitionAvailable$,
-} from "../external/feature-switch.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import { logger } from "../log.ts";
 import {
   runOptionsFromModelProviderSelection,
@@ -558,12 +552,6 @@ const sendNewThreadMessage$ = command(
       prepareUserMessageFromDraft$,
       draft,
       prompt,
-      {
-        excludeVisualAttachments: shouldExcludeVisualAttachmentsForModel(
-          resolvedModelSelection.selectedModel,
-          get(imageRecognitionAvailable$),
-        ),
-      },
       signal,
     );
     if (!prepared) {

--- a/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
+++ b/turbo/apps/platform/src/signals/chat-page/resolve-draft-attachments.ts
@@ -1,6 +1,5 @@
 import { command } from "ccstate";
 import type { ResolvedAttachFile } from "@okouai/api-contracts/contracts/chat-threads";
-import { getModelImageInputSupport } from "@okouai/api-contracts/contracts/model-providers";
 import type { DraftSignals, ChatAttachment } from "../okou-page/chat-draft.ts";
 import { i18n } from "../../i18n/index.ts";
 import { isAnnotationMeaningful } from "../okou-page/image-annotation.ts";
@@ -36,42 +35,6 @@ interface AttachmentFileInfo {
 interface ResolvedDraftAttachment {
   attachment: ChatAttachment;
   info: AttachmentFileInfo;
-}
-
-interface VisualAttachmentDescriptor {
-  contentType?: string | null;
-  filename?: string | null;
-}
-
-interface PrepareUserMessageOptions {
-  excludeVisualAttachments?: boolean;
-}
-
-const VISUAL_ATTACHMENT_EXTENSION_RE =
-  /\.(?:png|jpe?g|gif|webp|avif|heic|heif|bmp|svg|mp4|m4v|mov|webm|avi|mkv)$/i;
-
-export function isVisualAttachment({
-  contentType,
-  filename,
-}: VisualAttachmentDescriptor): boolean {
-  const normalizedContentType = contentType?.toLowerCase() ?? "";
-  if (
-    normalizedContentType.startsWith("image/") ||
-    normalizedContentType.startsWith("video/")
-  ) {
-    return true;
-  }
-  return VISUAL_ATTACHMENT_EXTENSION_RE.test(filename ?? "");
-}
-
-export function shouldExcludeVisualAttachmentsForModel(
-  selectedModel: string | null | undefined,
-  imageRecognitionEnabled: boolean,
-): boolean {
-  return (
-    !imageRecognitionEnabled &&
-    getModelImageInputSupport(selectedModel) === "unsupported"
-  );
 }
 
 export function collectSuccessfulAttachmentInfos(
@@ -138,15 +101,9 @@ export const prepareUserMessageFromDraft$ = command(
     { get },
     draft: DraftSignals,
     prompt: string,
-    options: PrepareUserMessageOptions,
     signal: AbortSignal,
   ): Promise<PreparedUserMessage | null> => {
-    const draftAttachments = get(draft.attachments$);
-    const allAttachments = options.excludeVisualAttachments
-      ? draftAttachments.filter((attachment) => {
-          return !isVisualAttachment(attachment);
-        })
-      : draftAttachments;
+    const allAttachments = get(draft.attachments$);
     const allInfos = await Promise.allSettled(
       allAttachments.map((a) => {
         return get(a.fileInfo$);
@@ -172,8 +129,7 @@ export const prepareUserMessageFromDraft$ = command(
     // User prompt is clean text only — file description blocks are appended
     // server-side via buildFullPrompt so the agent gets the [Web file] [ID]
     // format it knows how to download with `okou web download-file`.
-    const finalPrompt =
-      trimmedPrompt || (ready.length > 0 ? ATTACH_ONLY_PLACEHOLDER : "");
+    const finalPrompt = trimmedPrompt || ATTACH_ONLY_PLACEHOLDER;
 
     const attachments: ResolvedAttachFile[] | undefined =
       ready.length > 0

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -109,10 +109,6 @@ export const featureSwitch$ = computed((get) => {
   return get(featureSwitchCacheState$);
 });
 
-export const imageRecognitionAvailable$ = computed((): boolean => {
-  return true;
-});
-
 export const composerImageAnnotationEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ComposerImageAnnotation] ?? false;
 });

--- a/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
@@ -11,12 +11,7 @@ import type { VideoModel } from "@okouai/core/video-model-catalog";
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { onDomEventFn, onRef, withCleanup } from "../utils.ts";
 import {
-  isVisualAttachment,
-  shouldExcludeVisualAttachmentsForModel,
-} from "../chat-page/resolve-draft-attachments.ts";
-import {
   featureSwitch$,
-  imageRecognitionAvailable$,
   voiceDraftEnabled$,
 } from "../external/feature-switch.ts";
 import {
@@ -391,24 +386,6 @@ function composerTemplateSignals(
     insertTemplate$: composer.insertTemplate$,
     openTemplatePicker$: composer.openTemplatePicker$,
   };
-}
-
-function hasVisibleAttachment(
-  selection: ModelProviderSelection | null,
-  attachments: readonly ChatAttachment[],
-  imageRecognitionEnabled: boolean,
-): boolean {
-  if (
-    !shouldExcludeVisualAttachmentsForModel(
-      selection?.selectedModel,
-      imageRecognitionEnabled,
-    )
-  ) {
-    return attachments.length > 0;
-  }
-  return attachments.some((attachment) => {
-    return !isVisualAttachment(attachment);
-  });
 }
 
 function createComputerUseUiSignals(): Pick<
@@ -877,16 +854,8 @@ function createComposerPrimaryActionSignal(args: {
 
     const uploadsReady = get(draft.attachmentUploadsReady$);
     const attachments = get(draft.attachments$);
-    let hasContent = get(workflowComposer.hasInput$);
-    if (!hasContent && attachments.length > 0) {
-      const modelSelection = await get(options.modelSelection$);
-      const imageRecognitionEnabled = get(imageRecognitionAvailable$);
-      hasContent = hasVisibleAttachment(
-        modelSelection,
-        attachments,
-        imageRecognitionEnabled,
-      );
-    }
+    const hasContent =
+      get(workflowComposer.hasInput$) || attachments.length > 0;
     const canSend = uploadsReady && hasContent;
     const sending = await get(eventSignals.sending$);
     if (sending && !canSend) {
@@ -955,23 +924,11 @@ function createComposerSubmissionSignals(
           );
           signal.throwIfAborted();
           const visiblePrompt = submission.prompt.trim();
-          if (visiblePrompt.length === 0) {
-            const attachments = get(draft.attachments$);
-            if (attachments.length === 0) {
-              return false;
-            }
-            const modelSelection = await get(options.modelSelection$);
-            signal.throwIfAborted();
-            const imageRecognitionEnabled = get(imageRecognitionAvailable$);
-            if (
-              !hasVisibleAttachment(
-                modelSelection,
-                attachments,
-                imageRecognitionEnabled,
-              )
-            ) {
-              return false;
-            }
+          if (
+            visiblePrompt.length === 0 &&
+            get(draft.attachments$).length === 0
+          ) {
+            return false;
           }
           if (!get(draft.attachmentUploadsReady$)) {
             return false;

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -72,7 +72,7 @@ export interface WorkflowCopyFormState {
   readonly removeOriginal: boolean;
 }
 
-export type GmailTextField = "from" | "subject" | "body" | "to" | "cc";
+type GmailTextField = "from" | "subject" | "body" | "to" | "cc";
 export type GmailTextOperator = "contains" | "containsAny" | "doesNotContain";
 export type GmailMatchField = GmailTextField | "threadId";
 export type GmailMatchOperator = GmailTextOperator | "is";

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -117,10 +117,6 @@ import {
 import { sendMode$ } from "../../signals/send-mode.ts";
 import type { ComposerTemplateAttachment } from "../../signals/okou-page/tiptap-workflow-composer.ts";
 import type { TemplatePreviewRuntime } from "../../signals/okou-page/template-preview-runtime.ts";
-import {
-  isVisualAttachment,
-  shouldExcludeVisualAttachmentsForModel,
-} from "../../signals/chat-page/resolve-draft-attachments.ts";
 import { agents$ } from "../../signals/agent.ts";
 import type {
   GenerationTemplateRequest,
@@ -226,7 +222,6 @@ import {
   composerVoiceInputShortcutEnabled$,
   customConnectorMcpEnabled$,
   featureSwitch$,
-  imageRecognitionAvailable$,
 } from "../../signals/external/feature-switch.ts";
 import {
   selectedComputerUseHostId,
@@ -349,12 +344,6 @@ interface ComposerComputerUseHost {
   status: "online" | "offline";
 }
 
-interface ComposerModelPicker {
-  readonly value: ModelProviderSelection | null;
-  readonly onChange: (value: ModelProviderSelection | null) => void;
-  readonly disabled?: boolean;
-}
-
 interface ComposerTemplatePicker {
   readonly value: GenerationTemplateRequest | undefined;
   readonly onChange: (value: GenerationTemplateRequest | undefined) => void;
@@ -424,83 +413,6 @@ type ComposerConnectorItem = PlatformConnectorCatalogStatusItem & {
 type ComposerCustomConnectorItem = CustomConnectorResponse & {
   readonly authorized: boolean;
 };
-
-function resolveComposerModelForSelection(
-  modelPicker: ComposerModelPicker | undefined,
-  selection: ModelProviderSelection | null,
-): ModelProviderSelection | null {
-  if (!modelPicker) {
-    return null;
-  }
-  if (selection) {
-    return selection;
-  }
-  return null;
-}
-
-interface VisualAttachmentUnsupportedState {
-  currentModelName: string;
-}
-
-interface VisualAttachmentCandidate {
-  contentType: string;
-  filename: string;
-}
-
-function getVisualAttachmentUnsupportedState(
-  modelPicker: ComposerModelPicker | undefined,
-  imageRecognitionEnabled: boolean,
-  selection: ModelProviderSelection | null = modelPicker?.value ?? null,
-): VisualAttachmentUnsupportedState | null {
-  const currentModel = resolveComposerModelForSelection(modelPicker, selection);
-  if (
-    !currentModel ||
-    !shouldExcludeVisualAttachmentsForModel(
-      currentModel.selectedModel,
-      imageRecognitionEnabled,
-    )
-  ) {
-    return null;
-  }
-  return {
-    currentModelName: getModelDisplayName(currentModel.selectedModel),
-  };
-}
-
-function isVisualAttachmentFile(file: File): boolean {
-  return isVisualAttachment({
-    contentType: file.type,
-    filename: file.name,
-  });
-}
-
-function showVisualAttachmentUnsupportedToast(
-  state: VisualAttachmentUnsupportedState,
-): void {
-  toast.error(
-    i18n.t(
-      ($) => {
-        return $.chat.composer.visualAttachmentsUnsupported;
-      },
-      {
-        modelName: state.currentModelName,
-      },
-    ),
-    { id: "visual-attachment-unsupported" },
-  );
-}
-
-function resolveVisibleAttachments<T extends VisualAttachmentCandidate>(
-  attachments: T[],
-  visualAttachmentUnsupported: VisualAttachmentUnsupportedState | null,
-): T[] {
-  if (!visualAttachmentUnsupported) {
-    return attachments;
-  }
-  return attachments.filter((attachment) => {
-    return !isVisualAttachment(attachment);
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Queued messages strip — separate card stacked behind the composer with a
@@ -9203,14 +9115,12 @@ function toRestorableAttachments(
 
 function restoreChatClipboardPayload({
   event,
-  visualAttachmentUnsupported,
   insertPromptMarkdown,
   insertUserMessage,
   restoreAttachments,
   onDraftChange,
 }: {
   event: ComposerPasteEvent;
-  visualAttachmentUnsupported: VisualAttachmentUnsupportedState | null;
   insertPromptMarkdown: (value: string) => void;
   insertUserMessage: (value: UserMessageDocument) => void;
   restoreAttachments: (attachments: RestorableAttachment[]) => void;
@@ -9233,17 +9143,6 @@ function restoreChatClipboardPayload({
   if (!userMessage && persistedAttachments.length === 0) {
     return false;
   }
-  const allowedAttachments = visualAttachmentUnsupported
-    ? persistedAttachments.filter((attachment) => {
-        return !isVisualAttachment(attachment);
-      })
-    : persistedAttachments;
-  if (
-    visualAttachmentUnsupported &&
-    allowedAttachments.length < persistedAttachments.length
-  ) {
-    showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported);
-  }
 
   event.preventDefault();
   const hasInsertableUserMessagePart = userMessage?.parts.some((part) => {
@@ -9260,8 +9159,8 @@ function restoreChatClipboardPayload({
   } else if (payload.text) {
     insertPromptMarkdown(payload.text);
   }
-  if (allowedAttachments.length > 0) {
-    restoreAttachments(allowedAttachments);
+  if (persistedAttachments.length > 0) {
+    restoreAttachments(persistedAttachments);
   }
   onDraftChange?.();
   return true;
@@ -9273,20 +9172,6 @@ function useComposerDraftChange(signals: ComposerSignals): () => void {
   return () => {
     detach(saveDraft(pageSignal), Reason.DomCallback);
   };
-}
-
-function useComposerVisualAttachmentUnsupported(
-  signals: ComposerSignals,
-): VisualAttachmentUnsupportedState | null {
-  const modelSelection = useLastResolved(signals.model.modelSelection$) ?? null;
-  const imageRecognitionEnabled = useGet(imageRecognitionAvailable$);
-  return getVisualAttachmentUnsupportedState(
-    {
-      value: modelSelection,
-      onChange: () => {},
-    },
-    imageRecognitionEnabled,
-  );
 }
 
 function useComposerTemplatePicker(
@@ -9349,16 +9234,10 @@ function startComposerSubmission(
 function useComposerFileUpload(
   signals: ComposerSignals,
 ): (file: File) => boolean {
-  const visualAttachmentUnsupported =
-    useComposerVisualAttachmentUnsupported(signals);
   const uploadAttachment = useSet(signals.draft.uploadAttachment$);
   const rootSignal = useGet(rootSignal$);
   const { t } = useTranslation();
   return (file) => {
-    if (visualAttachmentUnsupported && isVisualAttachmentFile(file)) {
-      showVisualAttachmentUnsupportedToast(visualAttachmentUnsupported);
-      return false;
-    }
     if (file.size > MAX_FILE_SIZE) {
       toast.error(
         t(
@@ -9378,8 +9257,6 @@ function useComposerFileUpload(
 function ComposerInputSlot({ signals }: { signals: ComposerSignals }) {
   const sending = useLastResolved(signals.submission.sending$) ?? false;
   const notifyDraftChanged = useComposerDraftChange(signals);
-  const visualAttachmentUnsupported =
-    useComposerVisualAttachmentUnsupported(signals);
   const restoreAttachments = useSet(signals.draft.restoreAttachments$);
   const pageSignal = useGet(pageSignal$);
   const insertPromptMarkdown = useSet(signals.editor.insertPromptMarkdown$);
@@ -9398,7 +9275,6 @@ function ComposerInputSlot({ signals }: { signals: ComposerSignals }) {
     if (
       restoreChatClipboardPayload({
         event,
-        visualAttachmentUnsupported,
         insertPromptMarkdown,
         insertUserMessage,
         restoreAttachments: (attachments) => {
@@ -9894,28 +9770,10 @@ function ComposerModelPickerSlotBase({
   const selectedModelOauthAvailable =
     useLastResolved(signals.model.selectedModelOauthAvailable$) ?? true;
   const setModelSelection = useSet(signals.model.setModelSelection$);
-  const attachments = useGet(signals.draft.attachments$);
-  const imageRecognitionEnabled = useGet(imageRecognitionAvailable$);
   const pageSignal = useGet(pageSignal$);
   const value = modelSelection.state === "hasData" ? modelSelection.data : null;
   const modelPickerLoading = modelSelection.state === "loading";
   const onModelPickerChange = (selection: ModelProviderSelection | null) => {
-    const nextUnsupported = getVisualAttachmentUnsupportedState(
-      {
-        value,
-        onChange: onModelPickerChange,
-      },
-      imageRecognitionEnabled,
-      selection,
-    );
-    if (
-      nextUnsupported &&
-      attachments.some((attachment) => {
-        return isVisualAttachment(attachment);
-      })
-    ) {
-      showVisualAttachmentUnsupportedToast(nextUnsupported);
-    }
     detach(setModelSelection(selection, pageSignal), Reason.DomCallback);
   };
   if (modelPickerLoading || value === null) {
@@ -10505,21 +10363,15 @@ function ComposerFileInput({ signals }: { signals: ComposerSignals }) {
 
 function ComposerAttachments({ signals }: { signals: ComposerSignals }) {
   const attachments = useGet(signals.draft.attachments$);
-  const visualAttachmentUnsupported =
-    useComposerVisualAttachmentUnsupported(signals);
-  const visibleAttachments = resolveVisibleAttachments(
-    attachments,
-    visualAttachmentUnsupported,
-  );
   const removeAttachment = useSet(signals.draft.removeAttachment$);
   const notifyDraftChanged = useComposerDraftChange(signals);
 
-  if (visibleAttachments.length === 0) {
+  if (attachments.length === 0) {
     return null;
   }
   return (
     <AttachmentChips
-      attachments={visibleAttachments}
+      attachments={attachments}
       annotationSignals={signals.imageAnnotation}
       onAnnotationChange={notifyDraftChanged}
       onRemove={(attachment) => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -8,7 +8,6 @@ import type { OfficialWorkflowInstallationDefinition } from "@okouai/api-contrac
 import type {
   ChatRunFinishedEventConfig,
   ChatRunFinishedRunStatus,
-  GmailLabelAppliedEventConfig,
   GmailNewMessageEventConfig,
   GithubDeploymentState,
   GithubDeploymentStatusCreatedEventConfig,
@@ -189,7 +188,6 @@ import {
   type GmailMatchField,
   type GmailMatchCondition,
   type GmailMatchOperator,
-  type GmailTextField,
   type GmailTextOperator,
   workflowMetadataPatch$,
   targetedWorkflowAutomationId$,
@@ -238,9 +236,14 @@ import {
 } from "@okouai/ui/components/ui/alert";
 import {
   agentLabel,
-  chatRunFinishedAutomationSummary,
+  buildGmailLabelAppliedEventConfig,
+  buildGmailNewMessageEventConfig,
   chatRunFinishedStatusLabel,
+  formTextValue,
   formatWorkflowIntervalSeconds,
+  GMAIL_TEXT_FIELDS,
+  gmailAutomationSummary as sharedAutomationSummary,
+  gmailAutomationTitle as sharedAutomationTitle,
   githubAutomationFilterValueLabel,
   getWorkflowIntervalSecondOptions,
   isMarkdownPath,
@@ -410,8 +413,6 @@ function workflowWebhookCopy() {
   };
 }
 
-type GmailMatchRules = NonNullable<GmailNewMessageEventConfig["match"]>;
-type GmailTextMatcher = NonNullable<GmailMatchRules["from"]>;
 type GmailWorkflowAutomationSummary = Extract<
   WorkflowAutomationSummary,
   {
@@ -447,52 +448,6 @@ type WebhookWorkflowAutomationSummary = Extract<
   WorkflowAutomationSummary,
   { readonly kind: "event"; readonly eventType: "webhook-received" }
 >;
-
-const GMAIL_TEXT_FIELDS: readonly {
-  readonly field: GmailTextField;
-  readonly label: string;
-}[] = [
-  {
-    field: "from",
-    get label() {
-      return i18n.t(($) => {
-        return $.workflows.automations.gmail.field.from;
-      });
-    },
-  },
-  {
-    field: "subject",
-    get label() {
-      return i18n.t(($) => {
-        return $.workflows.automations.gmail.field.subject;
-      });
-    },
-  },
-  {
-    field: "body",
-    get label() {
-      return i18n.t(($) => {
-        return $.workflows.automations.gmail.field.body;
-      });
-    },
-  },
-  {
-    field: "to",
-    get label() {
-      return i18n.t(($) => {
-        return $.workflows.automations.gmail.field.to;
-      });
-    },
-  },
-  {
-    field: "cc",
-    get label() {
-      return i18n.t(($) => {
-        return $.workflows.automations.gmail.field.cc;
-      });
-    },
-  },
-];
 
 const GMAIL_MATCH_FIELDS: readonly {
   readonly field: GmailMatchField;
@@ -3495,71 +3450,6 @@ function localDateTimeInputValue(value: string): string {
   return `${year}-${month}-${day}T${hour}:${minute}`;
 }
 
-function formTextValue(form: FormData, name: string): string | undefined {
-  const value = form.get(name);
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function formTextValues(
-  form: FormData,
-  name: string,
-): readonly string[] | undefined {
-  const value = formTextValue(form, name);
-  if (!value) {
-    return undefined;
-  }
-  const values = value
-    .split(",")
-    .map((entry) => {
-      return entry.trim();
-    })
-    .filter((entry) => {
-      return entry.length > 0;
-    });
-  return values.length > 0 ? values : undefined;
-}
-
-function buildGmailNewMessageEventConfig(
-  form: FormData,
-  baseConfig?: GmailNewMessageEventConfig,
-): GmailNewMessageEventConfig {
-  const baseMatch = baseConfig?.match;
-  const threadId = formTextValue(form, "threadId");
-  const match: GmailMatchRules = {};
-  for (const { field } of GMAIL_TEXT_FIELDS) {
-    const existing = baseMatch?.[field];
-    const contains = formTextValue(form, `${field}Contains`);
-    const containsAny = formTextValues(form, `${field}ContainsAny`);
-    const doesNotContain = formTextValue(form, `${field}DoesNotContain`);
-    const matcher: GmailTextMatcher = {};
-    if (existing?.doesNotContainAny) {
-      matcher.doesNotContainAny = existing.doesNotContainAny;
-    }
-    if (contains) {
-      matcher.contains = contains;
-    }
-    if (containsAny) {
-      matcher.containsAny = [...containsAny];
-    }
-    if (doesNotContain) {
-      matcher.doesNotContain = doesNotContain;
-    }
-    if (Object.keys(matcher).length > 0) {
-      match[field] = matcher;
-    }
-  }
-  return {
-    provider: "gmail",
-    event: "new_message",
-    ...(threadId ? { threadId } : {}),
-    ...(Object.keys(match).length > 0 ? { match } : {}),
-  };
-}
-
 function gmailMatchConditions(
   config?: GmailNewMessageEventConfig,
 ): GmailMatchCondition[] {
@@ -3657,20 +3547,6 @@ function gmailMatchOperatorForField(
     return "is";
   }
   return operator === "is" ? "contains" : operator;
-}
-
-function buildGmailLabelAppliedEventConfig(
-  form: FormData,
-): GmailLabelAppliedEventConfig | null {
-  const labelName = formTextValue(form, "labelName");
-  if (!labelName) {
-    return null;
-  }
-  return {
-    provider: "gmail",
-    event: "label_applied",
-    labelName,
-  };
 }
 
 type GoogleCalendarAutomationEventType =
@@ -3881,190 +3757,25 @@ function buildGithubWebhookEventConfig(
   };
 }
 
-function quote(value: string): string {
-  return `"${value}"`;
-}
-
-function quoteList(values: readonly string[]): string {
-  return values.map(quote).join(", ");
-}
-
-function textMatcherParts(
-  field: GmailTextField,
-  matcher: GmailTextMatcher,
-): string[] {
-  const parts: string[] = [];
-  const fieldOption = GMAIL_TEXT_FIELDS.find((option) => {
-    return option.field === field;
-  });
-  if (!fieldOption) {
-    throw new Error(`Unknown Gmail text field: ${field}`);
-  }
-  const fieldLabel = fieldOption.label.toLocaleLowerCase(currentLocale());
-  if (matcher.contains) {
-    parts.push(
-      i18n.t(
-        ($) => {
-          return $.workflows.automations.gmail.summary.contains;
-        },
-        { field: fieldLabel, value: quote(matcher.contains) },
-      ),
-    );
-  }
-  if (matcher.containsAny) {
-    parts.push(
-      i18n.t(
-        ($) => {
-          return $.workflows.automations.gmail.summary.containsAny;
-        },
-        { field: fieldLabel, value: quoteList(matcher.containsAny) },
-      ),
-    );
-  }
-  if (matcher.doesNotContain) {
-    parts.push(
-      i18n.t(
-        ($) => {
-          return $.workflows.automations.gmail.summary.doesNotContain;
-        },
-        { field: fieldLabel, value: quote(matcher.doesNotContain) },
-      ),
-    );
-  }
-  if (matcher.doesNotContainAny) {
-    parts.push(
-      i18n.t(
-        ($) => {
-          return $.workflows.automations.gmail.summary.doesNotContainAny;
-        },
-        { field: fieldLabel, value: quoteList(matcher.doesNotContainAny) },
-      ),
-    );
-  }
-  return parts;
-}
-
-function formatGmailMatchSummary(config: GmailNewMessageEventConfig): string {
-  const parts: string[] = config.threadId
-    ? [
-        i18n.t(
-          ($) => {
-            return $.workflows.automations.gmail.summary.threadId;
-          },
-          { value: quote(config.threadId) },
-        ),
-      ]
-    : [];
-  const match = config.match;
-  if (match) {
-    for (const { field } of GMAIL_TEXT_FIELDS) {
-      const matcher = match[field];
-      if (matcher) {
-        parts.push(...textMatcherParts(field, matcher));
-      }
-    }
-  }
-  return parts.length > 0
-    ? parts.join("; ")
-    : i18n.t(($) => {
-        return $.workflows.automations.gmail.allInboundMessages;
-      });
-}
-
 function workflowAutomationTitle(
   automation: WorkflowAutomationSummary,
 ): string {
-  if (automation.kind === "schedule") {
-    return automation.scheduleSummary;
+  if (automation.kind === "event") {
+    if (automation.eventType === "stripe-invoice-paid") {
+      return i18n.t(($) => {
+        return $.workflows.automations.stripe.invoicePaidTitle;
+      });
+    }
+    if (
+      automation.eventType === "google-forms-response-submitted" ||
+      automation.eventType === "webhook-received"
+    ) {
+      return i18n.t(($) => {
+        return $.workflows.automations.webhook.createTitle;
+      });
+    }
   }
-  if (automation.eventType === "gmail-new-message") {
-    return i18n.t(($) => {
-      return $.workflows.automations.gmail.newMessageTitle;
-    });
-  }
-  if (automation.eventType === "gmail-label-applied") {
-    return i18n.t(($) => {
-      return $.workflows.automations.gmail.labelAppliedTitle;
-    });
-  }
-  if (automation.eventType === "github-pull-request") {
-    return i18n.t(($) => {
-      return $.workflows.automations.github.pullRequestTitle;
-    });
-  }
-  if (automation.eventType === "github-workflow-job-completed") {
-    return i18n.t(($) => {
-      return $.workflows.automations.github.workflowJobTitle;
-    });
-  }
-  if (automation.eventType === "github-pull-request-review-submitted") {
-    return i18n.t(($) => {
-      return $.workflows.automations.github.reviewTitle;
-    });
-  }
-  if (automation.eventType === "github-deployment-status-created") {
-    return i18n.t(($) => {
-      return $.workflows.automations.github.deploymentStatusTitle;
-    });
-  }
-  if (automation.eventType === "github-issue-comment-created") {
-    return i18n.t(($) => {
-      return $.workflows.automations.github.issueCommentTitle;
-    });
-  }
-  if (automation.eventType === "github-workflow-run-completed") {
-    return i18n.t(($) => {
-      return $.workflows.automations.github.workflowRunTitle;
-    });
-  }
-  if (automation.eventType === "google-calendar-event-created") {
-    return i18n.t(($) => {
-      return $.workflows.automations.calendar.createdTitle;
-    });
-  }
-  if (automation.eventType === "google-calendar-event-updated") {
-    return i18n.t(($) => {
-      return $.workflows.automations.calendar.updatedTitle;
-    });
-  }
-  if (automation.eventType === "google-calendar-event-cancelled") {
-    return i18n.t(($) => {
-      return $.workflows.automations.calendar.cancelledTitle;
-    });
-  }
-  if (automation.eventType === "google-meet-transcript-generated") {
-    return i18n.t(($) => {
-      return $.workflows.automations.meet.transcriptReadyTitle;
-    });
-  }
-  if (automation.eventType === "chat-run-finished") {
-    return i18n.t(($) => {
-      return $.workflows.automations.chat.runFinishedTitle;
-    });
-  }
-  if (automation.eventType === "notion-child-page-created") {
-    return i18n.t(($) => {
-      return $.workflows.automations.notion.childPageTitle;
-    });
-  }
-  if (automation.eventType === "notion-database-item-created") {
-    return i18n.t(($) => {
-      return $.workflows.automations.notion.databaseItemTitle;
-    });
-  }
-  if (automation.eventType === "notion-page-content-updated") {
-    return i18n.t(($) => {
-      return $.workflows.automations.notion.contentUpdatedTitle;
-    });
-  }
-  if (automation.eventType === "stripe-invoice-paid") {
-    return i18n.t(($) => {
-      return $.workflows.automations.stripe.invoicePaidTitle;
-    });
-  }
-  return i18n.t(($) => {
-    return $.workflows.automations.webhook.createTitle;
-  });
+  return sharedAutomationTitle(automation);
 }
 
 function githubWorkflowRunAutomationSummary(
@@ -4275,33 +3986,6 @@ function githubWorkflowAutomationSummary(
   }
 }
 
-function eventWorkflowAutomationSummary(
-  automation: Extract<WorkflowAutomationSummary, { kind: "event" }>,
-): string | null {
-  if (automation.eventType === "google-meet-transcript-generated") {
-    return i18n.t(($) => {
-      return $.workflows.automations.meet.summary;
-    });
-  }
-  if (automation.eventType === "chat-run-finished") {
-    return chatRunFinishedAutomationSummary(automation.eventConfig);
-  }
-  if (automation.eventType === "stripe-invoice-paid") {
-    return i18n.t(
-      ($) => {
-        return $.workflows.automations.stripe.bindingSummary;
-      },
-      {
-        accountId: automation.eventConfig.stripeAccountId,
-        billingReasons: stripeBillingReasonsSummary(
-          automation.eventConfig.billingReasons,
-        ),
-      },
-    );
-  }
-  return null;
-}
-
 function stripeBillingReasonLabel(reason: StripeInvoiceBillingReason): string {
   switch (reason) {
     case "automatic_pending_invoice_item_invoice": {
@@ -4367,93 +4051,29 @@ function stripeBillingReasonsSummary(
 function workflowAutomationSummary(
   automation: WorkflowAutomationSummary,
 ): string | null {
-  if (automation.kind !== "event") {
+  if (
+    automation.kind !== "event" ||
+    automation.eventType === "google-forms-response-submitted"
+  ) {
     return null;
   }
-  if (automation.eventType === "gmail-new-message") {
-    return formatGmailMatchSummary(automation.eventConfig);
-  }
-  if (automation.eventType === "gmail-label-applied") {
+  if (automation.eventType === "stripe-invoice-paid") {
     return i18n.t(
       ($) => {
-        return $.workflows.automations.gmail.labelSummary;
+        return $.workflows.automations.stripe.bindingSummary;
       },
-      { label: quote(automation.eventConfig.labelName) },
+      {
+        accountId: automation.eventConfig.stripeAccountId,
+        billingReasons: stripeBillingReasonsSummary(
+          automation.eventConfig.billingReasons,
+        ),
+      },
     );
   }
-  const githubSummary = githubWorkflowAutomationSummary(automation);
-  if (githubSummary) {
-    return githubSummary;
-  }
-  if (
-    automation.eventType === "google-calendar-event-created" ||
-    automation.eventType === "google-calendar-event-updated" ||
-    automation.eventType === "google-calendar-event-cancelled"
-  ) {
-    return i18n.t(
-      ($) => {
-        return $.workflows.automations.calendar.summary;
-      },
-      { calendar: quote(automation.eventConfig.calendarId) },
-    );
-  }
-  const eventSummary = eventWorkflowAutomationSummary(automation);
-  if (eventSummary) {
-    return eventSummary;
-  }
-  if (automation.eventType === "notion-child-page-created") {
-    const title = automation.eventConfig.parentPage.title;
-    return title
-      ? i18n.t(
-          ($) => {
-            return $.workflows.automations.notion.parentPageSummary;
-          },
-          { title: quote(title) },
-        )
-      : i18n.t(($) => {
-          return $.workflows.automations.notion.configuredParentPage;
-        });
-  }
-  if (automation.eventType === "notion-database-item-created") {
-    const title = automation.eventConfig.dataSource.title;
-    return title
-      ? i18n.t(
-          ($) => {
-            return $.workflows.automations.notion.databaseSummary;
-          },
-          { title: quote(title) },
-        )
-      : i18n.t(($) => {
-          return $.workflows.automations.notion.configuredDatabase;
-        });
-  }
-  if (automation.eventType === "notion-page-content-updated") {
-    if (automation.eventConfig.scope.type === "page") {
-      const title = automation.eventConfig.scope.page.title;
-      return title
-        ? i18n.t(
-            ($) => {
-              return $.workflows.automations.notion.pageSummary;
-            },
-            { title: quote(title) },
-          )
-        : i18n.t(($) => {
-            return $.workflows.automations.notion.configuredPage;
-          });
-    }
-    const title = automation.eventConfig.scope.dataSource.title;
-    return title
-      ? i18n.t(
-          ($) => {
-            return $.workflows.automations.notion.databaseSummary;
-          },
-          { title: quote(title) },
-        )
-      : i18n.t(($) => {
-          return $.workflows.automations.notion.configuredDatabase;
-        });
-  }
-  return null;
+  return (
+    githubWorkflowAutomationSummary(automation) ??
+    sharedAutomationSummary(automation)
+  );
 }
 
 type AutomationCreateDialogKind =
@@ -5110,6 +4730,36 @@ function GoogleCalendarAutomationDialogs({
   );
 }
 
+function AutomationFormActions({
+  pending,
+  onCancel,
+  submitDisabled = pending,
+  children,
+}: {
+  readonly pending: boolean;
+  readonly onCancel: () => void;
+  readonly submitDisabled?: boolean;
+  readonly children: ReactNode;
+}) {
+  return (
+    <DialogFooter>
+      <Button
+        type="button"
+        variant="outline"
+        disabled={pending}
+        onClick={onCancel}
+      >
+        {i18n.t(($) => {
+          return $.workflows.automations.common.cancel;
+        })}
+      </Button>
+      <Button type="submit" disabled={submitDisabled}>
+        {children}
+      </Button>
+    </DialogFooter>
+  );
+}
+
 function CreateGoogleFormsResponseSubmittedAutomationDialog({
   workflowId,
   open,
@@ -5192,30 +4842,21 @@ function CreateGoogleFormsResponseSubmittedAutomationDialog({
               })}
             />
           </label>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <FileText size={14} />
-              )}
-              {i18n.t(($) => {
-                return $.workflows.automations.forms.addAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <FileText size={14} />
+            )}
+            {i18n.t(($) => {
+              return $.workflows.automations.forms.addAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -5303,30 +4944,21 @@ function CreateGoogleMeetTranscriptGeneratedAutomationDialog({
               return $.workflows.automations.meet.transcriptHint;
             })}
           </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <Video size={14} />
-              )}
-              {i18n.t(($) => {
-                return $.workflows.automations.meet.addAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Video size={14} />
+            )}
+            {i18n.t(($) => {
+              return $.workflows.automations.meet.addAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -5441,7 +5073,6 @@ function CreateChatRunFinishedAutomationDialog({
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
 }) {
-  const actionCopy = automationActionCopy();
   const pageSignal = useGet(pageSignal$);
   const [createLoadable, createAutomation] = useLoadableSet(
     createWorkflowChatRunFinishedAutomation$,
@@ -5486,26 +5117,17 @@ function CreateChatRunFinishedAutomationDialog({
           }}
         >
           <ChatRunFinishedAutomationFields creating={creating} />
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {actionCopy.cancel}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating && (
-                <Loader2 size={14} className="mr-1.5 animate-spin" />
-              )}
-              {i18n.t(($) => {
-                return $.workflows.automations.chat.addAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating && <Loader2 size={14} className="mr-1.5 animate-spin" />}
+            {i18n.t(($) => {
+              return $.workflows.automations.chat.addAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -5717,30 +5339,21 @@ function CreateStripeInvoicePaidAutomationDialog({
           {createError ? (
             <StripeAutomationCreateError message={createError} />
           ) : null}
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <BrandStripe size={14} />
-              )}
-              {i18n.t(($) => {
-                return $.workflows.automations.stripe.addAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <BrandStripe size={14} />
+            )}
+            {i18n.t(($) => {
+              return $.workflows.automations.stripe.addAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -6048,30 +5661,21 @@ function CreateNotionDatabaseItemAutomationDialog({
               })}
             />
           </label>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <BrandNotion size={14} />
-              )}
-              {i18n.t(($) => {
-                return $.workflows.automations.notion.addAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <BrandNotion size={14} />
+            )}
+            {i18n.t(($) => {
+              return $.workflows.automations.notion.addAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -6252,30 +5856,21 @@ function CreateNotionPageContentUpdatedAutomationDialog({
             creating={creating}
             setScope={setScope}
           />
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <BrandNotion size={14} />
-              )}
-              {i18n.t(($) => {
-                return $.workflows.automations.notion.addAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <BrandNotion size={14} />
+            )}
+            {i18n.t(($) => {
+              return $.workflows.automations.notion.addAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -6359,30 +5954,21 @@ function CreateNotionChildPageAutomationDialog({
               })}
             />
           </label>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <BrandNotion size={14} />
-              )}
-              {i18n.t(($) => {
-                return $.workflows.automations.notion.addAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <BrandNotion size={14} />
+            )}
+            {i18n.t(($) => {
+              return $.workflows.automations.notion.addAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -6453,26 +6039,17 @@ function CreateIntervalAutomationDialog({
         >
           <WorkflowIntervalField disabled={creating} />
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
-              {i18n.t(($) => {
-                return $.workflows.automations.schedule.addIntervalAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? <Loader2 size={14} className="animate-spin" /> : null}
+            {i18n.t(($) => {
+              return $.workflows.automations.schedule.addIntervalAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -6553,26 +6130,17 @@ function CreateScheduledAutomationDialog({
             disabled={creating}
           />
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
-              {i18n.t(($) => {
-                return $.workflows.automations.schedule.addScheduleAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? <Loader2 size={14} className="animate-spin" /> : null}
+            {i18n.t(($) => {
+              return $.workflows.automations.schedule.addScheduleAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -6652,26 +6220,17 @@ function CreateOnceAutomationDialog({
             disabled={creating}
           />
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
-              {i18n.t(($) => {
-                return $.workflows.automations.schedule.addOnceAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? <Loader2 size={14} className="animate-spin" /> : null}
+            {i18n.t(($) => {
+              return $.workflows.automations.schedule.addOnceAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -7399,26 +6958,17 @@ function CreateGmailNewMessageAutomationDialog({
             disabled={creating}
             onChange={setMatchConditions}
           />
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
-              {i18n.t(($) => {
-                return $.workflows.automations.gmail.addMessageAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? <Loader2 size={14} className="animate-spin" /> : null}
+            {i18n.t(($) => {
+              return $.workflows.automations.gmail.addMessageAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -7515,26 +7065,17 @@ function CreateGmailLabelAppliedAutomationDialog({
               })}
             />
           </label>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
-              {i18n.t(($) => {
-                return $.workflows.automations.gmail.addLabelAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? <Loader2 size={14} className="animate-spin" /> : null}
+            {i18n.t(($) => {
+              return $.workflows.automations.gmail.addLabelAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -8434,26 +7975,18 @@ function CreateGithubWorkflowRunCompletedAutomationDialog({
             <GithubNotInstalledNotice githubData={githubData} />
           ) : null}
           {githubLoadError ? <GithubLoadErrorNotice /> : null}
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {i18n.t(($) => {
-                return $.workflows.automations.common.cancel;
-              })}
-            </Button>
-            <Button type="submit" disabled={submitDisabled}>
-              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
-              {i18n.t(($) => {
-                return $.workflows.automations.github.addWorkflowAction;
-              })}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+            submitDisabled={submitDisabled}
+          >
+            {creating ? <Loader2 size={14} className="animate-spin" /> : null}
+            {i18n.t(($) => {
+              return $.workflows.automations.github.addWorkflowAction;
+            })}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -8612,26 +8145,20 @@ function CreateGithubWebhookAutomationDialog({
             <GithubNotInstalledNotice githubData={githubData} />
           ) : null}
           {githubLoadError ? <GithubLoadErrorNotice /> : null}
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {copy.cancel}
-            </Button>
-            <Button type="submit" disabled={submitDisabled}>
-              {creating ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <BrandGithub size={14} />
-              )}
-              {copy.action}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+            submitDisabled={submitDisabled}
+          >
+            {creating ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <BrandGithub size={14} />
+            )}
+            {copy.action}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -8763,22 +8290,15 @@ function CreateGoogleCalendarEventAutomationDialog({
               })}
             />
           </label>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={creating}
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              {copy.cancel}
-            </Button>
-            <Button type="submit" disabled={creating}>
-              {creating ? <Loader2 size={14} className="animate-spin" /> : null}
-              {copy.action}
-            </Button>
-          </DialogFooter>
+          <AutomationFormActions
+            pending={creating}
+            onCancel={() => {
+              onOpenChange(false);
+            }}
+          >
+            {creating ? <Loader2 size={14} className="animate-spin" /> : null}
+            {copy.action}
+          </AutomationFormActions>
         </form>
       </DialogContent>
     </Dialog>
@@ -10059,30 +9579,18 @@ function UpdateScheduleAutomationForm({
         }
         disabled={saving}
       />
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={saving}
-          onClick={onCancel}
-        >
+      <AutomationFormActions pending={saving} onCancel={onCancel}>
+        {saving ? (
+          <Loader2 size={13} className="animate-spin" />
+        ) : (
+          <Clock size={13} />
+        )}
+        <span>
           {i18n.t(($) => {
-            return $.workflows.automations.common.cancel;
+            return $.workflows.automations.schedule.saveSchedule;
           })}
-        </Button>
-        <Button type="submit" disabled={saving}>
-          {saving ? (
-            <Loader2 size={13} className="animate-spin" />
-          ) : (
-            <Clock size={13} />
-          )}
-          <span>
-            {i18n.t(($) => {
-              return $.workflows.automations.schedule.saveSchedule;
-            })}
-          </span>
-        </Button>
-      </DialogFooter>
+        </span>
+      </AutomationFormActions>
     </form>
   );
 }
@@ -10142,30 +9650,18 @@ function UpdateGmailNewMessageAutomationForm({
           setMatchConditions({ automationId: automation.id, conditions });
         }}
       />
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={saving}
-          onClick={onCancel}
-        >
+      <AutomationFormActions pending={saving} onCancel={onCancel}>
+        {saving ? (
+          <Loader2 size={13} className="animate-spin" />
+        ) : (
+          <Mail size={13} />
+        )}
+        <span>
           {i18n.t(($) => {
-            return $.workflows.automations.common.cancel;
+            return $.workflows.automations.gmail.saveMatch;
           })}
-        </Button>
-        <Button type="submit" disabled={saving}>
-          {saving ? (
-            <Loader2 size={13} className="animate-spin" />
-          ) : (
-            <Mail size={13} />
-          )}
-          <span>
-            {i18n.t(($) => {
-              return $.workflows.automations.gmail.saveMatch;
-            })}
-          </span>
-        </Button>
-      </DialogFooter>
+        </span>
+      </AutomationFormActions>
     </form>
   );
 }
@@ -10232,30 +9728,18 @@ function UpdateGmailLabelAppliedAutomationForm({
           className={AUTOMATION_FIELD_CLASS}
         />
       </label>
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={saving}
-          onClick={onCancel}
-        >
+      <AutomationFormActions pending={saving} onCancel={onCancel}>
+        {saving ? (
+          <Loader2 size={13} className="animate-spin" />
+        ) : (
+          <Mail size={13} />
+        )}
+        <span>
           {i18n.t(($) => {
-            return $.workflows.automations.common.cancel;
+            return $.workflows.automations.gmail.saveLabel;
           })}
-        </Button>
-        <Button type="submit" disabled={saving}>
-          {saving ? (
-            <Loader2 size={13} className="animate-spin" />
-          ) : (
-            <Mail size={13} />
-          )}
-          <span>
-            {i18n.t(($) => {
-              return $.workflows.automations.gmail.saveLabel;
-            })}
-          </span>
-        </Button>
-      </DialogFooter>
+        </span>
+      </AutomationFormActions>
     </form>
   );
 }
@@ -10305,30 +9789,18 @@ function UpdateGithubWorkflowRunCompletedAutomationForm({
         disabled={saving}
         defaultConfig={automation.eventConfig}
       />
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={saving}
-          onClick={onCancel}
-        >
+      <AutomationFormActions pending={saving} onCancel={onCancel}>
+        {saving ? (
+          <Loader2 size={13} className="animate-spin" />
+        ) : (
+          <BrandGithub size={13} />
+        )}
+        <span>
           {i18n.t(($) => {
-            return $.workflows.automations.common.cancel;
+            return $.workflows.automations.github.saveFilters;
           })}
-        </Button>
-        <Button type="submit" disabled={saving}>
-          {saving ? (
-            <Loader2 size={13} className="animate-spin" />
-          ) : (
-            <BrandGithub size={13} />
-          )}
-          <span>
-            {i18n.t(($) => {
-              return $.workflows.automations.github.saveFilters;
-            })}
-          </span>
-        </Button>
-      </DialogFooter>
+        </span>
+      </AutomationFormActions>
     </form>
   );
 }
@@ -10377,30 +9849,18 @@ function UpdateGithubWebhookAutomationForm({
         disabled={saving}
         defaultConfig={automation.eventConfig}
       />
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={saving}
-          onClick={onCancel}
-        >
+      <AutomationFormActions pending={saving} onCancel={onCancel}>
+        {saving ? (
+          <Loader2 size={13} className="animate-spin" />
+        ) : (
+          <BrandGithub size={13} />
+        )}
+        <span>
           {i18n.t(($) => {
-            return $.workflows.automations.common.cancel;
+            return $.workflows.automations.github.saveFilters;
           })}
-        </Button>
-        <Button type="submit" disabled={saving}>
-          {saving ? (
-            <Loader2 size={13} className="animate-spin" />
-          ) : (
-            <BrandGithub size={13} />
-          )}
-          <span>
-            {i18n.t(($) => {
-              return $.workflows.automations.github.saveFilters;
-            })}
-          </span>
-        </Button>
-      </DialogFooter>
+        </span>
+      </AutomationFormActions>
     </form>
   );
 }

--- a/turbo/apps/platform/src/views/workflows-page/workflow-shared.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-shared.tsx
@@ -261,7 +261,10 @@ export const GMAIL_TEXT_FIELDS: readonly {
   },
 ];
 
-function formTextValue(form: FormData, name: string): string | undefined {
+export function formTextValue(
+  form: FormData,
+  name: string,
+): string | undefined {
   const value = form.get(name);
   if (typeof value !== "string") {
     return undefined;
@@ -362,7 +365,7 @@ export function chatRunFinishedStatusLabel(
   }
 }
 
-export function chatRunFinishedAutomationSummary(
+function chatRunFinishedAutomationSummary(
   config: ChatRunFinishedEventConfig,
 ): string {
   const statusText = config.runStatuses


### PR DESCRIPTION
The image-recognition capability is always enabled, but the composer still carries upload, paste, display, model-change, and send branches that would reject or hide visual attachments only when it is disabled. Remove that unreachable path and its unused translations while preserving upload failures, annotations, attachment-only messages, and model authorization.

The workflow detail page also repeats existing Gmail form parsing and automation labels/summaries. Reuse the shared implementations, retain the detail page's specific GitHub, Stripe, and Forms presentation, and share the cancel/submit rendering used by 20 automation forms without changing their disabled states or submit contents.

## Size audit

Production TypeScript/TSX under `apps/platform/src` decreases from **230,597 to 229,795 lines**, a net reduction of **802 lines (0.35%)**. This excludes tests, mocks, benchmarks, declaration/generated files, and locale JSON. The requested 10% reduction is not established by this audit; this PR contains the behavior-preserving cleanup found so far.

## Validation

- Platform lint, type checking, and scoped Knip.
- Formatting and whitespace checks on the changed files.
- **103 tests passed in eight focused integration-test files** covering workflow forms, composer model selection, sending/queueing, attachment upload/paste, and annotations (`--maxWorkers=1`).
- One-off before/after comparisons of automation titles, summaries, and Gmail form parsing: **1,160 equal results across 10 locales**.

The initial two-worker test run passed 102 of 103 tests and hit the existing 5-second timeout in the Standard/Fast model picker test. Its entire eight-test file passed when run alone, and all 103 focused tests subsequently passed serially, without increasing timeouts.
