### PR TITLE
fix(platform): measure sidebar virtualization after styles and layout updates

### DIFF
--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -17,6 +17,10 @@ const APP_BOOTSTRAP_SKELETON_HIDDEN_CLASS = "app-bootstrap-skeleton--hidden";
 
 const internalBootstrapSkeletonActive$ = state(false);
 
+export const mainStylesheetLoaded$ = computed(async () => {
+  return (await window.__mainStylesheetLoaded) !== "failed";
+});
+
 export const bootstrapSkeletonActive$ = computed((get) => {
   return get(internalBootstrapSkeletonActive$);
 });

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
@@ -101,8 +101,7 @@ function createSidebarChatThreadDomSignals() {
     return getScrollThumbStyle(get(internalScrollMetrics$));
   });
 
-  const bindScrollViewport$ = command(({ set }, viewport: HTMLElement) => {
-    set(internalScrollViewport$, viewport);
+  const measureScrollViewport$ = command(({ set }, viewport: HTMLElement) => {
     set(internalScrollMetrics$, {
       scrollTop: viewport.scrollTop,
       scrollHeight: viewport.scrollHeight,
@@ -120,10 +119,17 @@ function createSidebarChatThreadDomSignals() {
   );
   const setScrollViewport$ = onRef(
     command(({ set }, viewport: HTMLElement, signal: AbortSignal) => {
-      set(bindScrollViewport$, viewport);
+      set(internalScrollViewport$, viewport);
+      set(measureScrollViewport$, viewport);
+      // Async stylesheet activation can change the viewport without scrolling.
+      const resizeObserver = new ResizeObserver(() => {
+        set(measureScrollViewport$, viewport);
+      });
+      resizeObserver.observe(viewport);
       signal.addEventListener(
         "abort",
         () => {
+          resizeObserver.disconnect();
           set(clearScrollViewport$, viewport);
         },
         { once: true },

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
@@ -46,6 +46,7 @@ export interface SidebarChatThreadScrollSignals {
   readonly thumbStyle$: Computed<SidebarChatThreadScrollThumbStyle>;
   readonly window$: Computed<Promise<SidebarChatThreadWindow>>;
   readonly setScrollMetrics$: Command<void, [SidebarChatThreadScrollMetrics]>;
+  readonly refreshScrollViewport$: Command<void, []>;
   readonly setScrollViewport$: Command<
     (() => void) | undefined,
     [HTMLElement | null]
@@ -84,12 +85,16 @@ function getScrollThumbStyle({
 }
 
 function createSidebarChatThreadDomSignals() {
-  const internalScrollViewport$ = state<HTMLElement | null>(null);
+  const internalViewportRuntime$ = state<{
+    readonly element: HTMLElement;
+    readonly signal: AbortSignal;
+    resizeScheduled: boolean;
+  } | null>(null);
   const internalScrollMetrics$ =
     state<SidebarChatThreadScrollMetrics>(emptyScrollMetrics());
 
   const scrollViewport$ = computed((get) => {
-    return get(internalScrollViewport$);
+    return get(internalViewportRuntime$)?.element ?? null;
   });
   const scrollMetrics$ = computed((get) => {
     return get(internalScrollMetrics$);
@@ -119,40 +124,49 @@ function createSidebarChatThreadDomSignals() {
       set(internalScrollMetrics$, metrics);
     },
   );
+  const refreshScrollViewport$ = command(({ get, set }) => {
+    const runtime = get(internalViewportRuntime$);
+    if (!runtime || runtime.resizeScheduled) {
+      return;
+    }
+    runtime.resizeScheduled = true;
+    // Layout refs and window resize events share one pending measurement.
+    // Read after the DOM commit, using the latest layout in this frame.
+    animationFrame(
+      () => {
+        runtime.resizeScheduled = false;
+        set(measureScrollViewport$, runtime.element);
+      },
+      { signal: runtime.signal },
+    );
+  });
   const clearScrollViewport$ = command(
     ({ get, set }, viewport: HTMLElement) => {
-      if (get(internalScrollViewport$) !== viewport) {
+      if (get(internalViewportRuntime$)?.element !== viewport) {
         return;
       }
-      set(internalScrollViewport$, null);
+      set(internalViewportRuntime$, null);
       set(internalScrollMetrics$, emptyScrollMetrics());
     },
   );
   const setScrollViewport$ = onRef(
     command(({ set }, viewport: HTMLElement, signal: AbortSignal) => {
-      set(internalScrollViewport$, viewport);
-      set(measureScrollViewport$, viewport);
-      // Async stylesheet activation can change the viewport without scrolling.
-      // Fold notifications into one frame and measure the latest layout.
-      let resizeScheduled = false;
-      const resizeObserver = new ResizeObserver(() => {
-        if (resizeScheduled) {
-          return;
-        }
-        resizeScheduled = true;
-        animationFrame(
-          () => {
-            resizeScheduled = false;
-            set(measureScrollViewport$, viewport);
-          },
-          { signal },
-        );
+      set(internalViewportRuntime$, {
+        element: viewport,
+        signal,
+        resizeScheduled: false,
       });
-      resizeObserver.observe(viewport);
+      set(measureScrollViewport$, viewport);
+      window.addEventListener(
+        "resize",
+        () => {
+          set(refreshScrollViewport$);
+        },
+        { signal },
+      );
       signal.addEventListener(
         "abort",
         () => {
-          resizeObserver.disconnect();
           set(clearScrollViewport$, viewport);
         },
         { once: true },
@@ -172,6 +186,7 @@ function createSidebarChatThreadDomSignals() {
     scrollMetrics$,
     setScrollViewport$,
     setScrollMetrics$,
+    refreshScrollViewport$,
   };
 }
 
@@ -368,6 +383,7 @@ function createSidebarChatThreadScrollSignals(): SidebarChatThreadScrollSignals 
     window$: createSidebarChatThreadWindowSignal(dom),
     setScrollMetrics$: dom.setScrollMetrics$,
     setScrollViewport$: dom.setScrollViewport$,
+    refreshScrollViewport$: dom.refreshScrollViewport$,
     scrollToThread$,
     scrollCurrentChatThreadOnRef$,
   };
@@ -377,6 +393,27 @@ export const responsiveSidebarChatThreadScrollSignals =
   createSidebarChatThreadScrollSignals();
 export const threeColumnSidebarChatThreadScrollSignals =
   createSidebarChatThreadScrollSignals();
+
+const refreshSidebarChatThreadLayout$ = command(({ set }) => {
+  set(responsiveSidebarChatThreadScrollSignals.refreshScrollViewport$);
+  set(threeColumnSidebarChatThreadScrollSignals.refreshScrollViewport$);
+});
+
+// Pinned entries and upgrade cards consume space beside the chat viewport.
+// Their committed insertion/removal, including async data updates, determines
+// when the remaining height needs to be measured again.
+export const refreshSidebarChatThreadLayoutOnRef$ = onRef(
+  command(({ set }, _element: HTMLElement, signal: AbortSignal) => {
+    set(refreshSidebarChatThreadLayout$);
+    signal.addEventListener(
+      "abort",
+      () => {
+        set(refreshSidebarChatThreadLayout$);
+      },
+      { once: true },
+    );
+  }),
+);
 
 export const scrollToThread$ = command(
   async (

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
@@ -101,13 +101,24 @@ function createSidebarChatThreadDomSignals() {
     return getScrollThumbStyle(get(internalScrollMetrics$));
   });
 
-  const measureScrollViewport$ = command(({ set }, viewport: HTMLElement) => {
-    set(internalScrollMetrics$, {
-      scrollTop: viewport.scrollTop,
-      scrollHeight: viewport.scrollHeight,
-      clientHeight: viewport.clientHeight,
-    });
-  });
+  const measureScrollViewport$ = command(
+    ({ get, set }, viewport: HTMLElement) => {
+      const metrics = {
+        scrollTop: viewport.scrollTop,
+        scrollHeight: viewport.scrollHeight,
+        clientHeight: viewport.clientHeight,
+      };
+      const previous = get(internalScrollMetrics$);
+      if (
+        previous.scrollTop === metrics.scrollTop &&
+        previous.scrollHeight === metrics.scrollHeight &&
+        previous.clientHeight === metrics.clientHeight
+      ) {
+        return;
+      }
+      set(internalScrollMetrics$, metrics);
+    },
+  );
   const clearScrollViewport$ = command(
     ({ get, set }, viewport: HTMLElement) => {
       if (get(internalScrollViewport$) !== viewport) {
@@ -122,8 +133,20 @@ function createSidebarChatThreadDomSignals() {
       set(internalScrollViewport$, viewport);
       set(measureScrollViewport$, viewport);
       // Async stylesheet activation can change the viewport without scrolling.
+      // Fold notifications into one frame and measure the latest layout.
+      let resizeScheduled = false;
       const resizeObserver = new ResizeObserver(() => {
-        set(measureScrollViewport$, viewport);
+        if (resizeScheduled) {
+          return;
+        }
+        resizeScheduled = true;
+        animationFrame(
+          () => {
+            resizeScheduled = false;
+            set(measureScrollViewport$, viewport);
+          },
+          { signal },
+        );
       });
       resizeObserver.observe(viewport);
       signal.addEventListener(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
@@ -3,14 +3,22 @@ import {
   chatThreadsContract,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { browserContract } from "@okouai/api-contracts/contracts/browser";
+import { billingStatusContract } from "@okouai/api-contracts/contracts/billing";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { act, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { expect, test, vi } from "vitest";
 
 import {
   click,
   queryAllByRoleFast,
   setupPage,
+  startPage,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
@@ -79,60 +87,23 @@ function mockThreads(count: number): void {
   });
 }
 
-function mockViewportResize(): (target: HTMLElement) => void {
-  const observers = new Set<TestResizeObserver>();
+function mockViewportHeight(height: () => number, threadCount = 120): void {
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
+    function (this: HTMLElement) {
+      return this.dataset.testid === "sidebar-scroll-area" ? height() : 0;
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(
+    function (this: HTMLElement) {
+      return this.dataset.testid === "sidebar-scroll-area"
+        ? threadCount * ROW_HEIGHT
+        : 0;
+    },
+  );
+}
 
-  class TestResizeObserver implements ResizeObserver {
-    private targets = new Set<Element>();
-
-    constructor(private readonly callback: ResizeObserverCallback) {}
-
-    observe(target: Element): void {
-      this.targets.add(target);
-      observers.add(this);
-    }
-
-    unobserve(target: Element): void {
-      this.targets.delete(target);
-    }
-
-    disconnect(): void {
-      this.targets = new Set();
-      observers.delete(this);
-    }
-
-    resize(target: HTMLElement): void {
-      if (!this.targets.has(target)) {
-        return;
-      }
-      const contentRect = target.getBoundingClientRect();
-      const size = {
-        inlineSize: contentRect.width,
-        blockSize: contentRect.height,
-      };
-      this.callback(
-        [
-          {
-            target,
-            contentRect,
-            borderBoxSize: [size],
-            contentBoxSize: [size],
-            devicePixelContentBoxSize: [size],
-          },
-        ],
-        this,
-      );
-    }
-  }
-
-  vi.stubGlobal("ResizeObserver", TestResizeObserver);
-  return (target) => {
-    act(() => {
-      for (const observer of observers) {
-        observer.resize(target);
-      }
-    });
-  };
+function resizeWindow(): void {
+  fireEvent(window, new Event("resize"));
 }
 
 function queueAnimationFrames(): () => void {
@@ -158,55 +129,42 @@ function queueAnimationFrames(): () => void {
   };
 }
 
-test.each([
-  { baseUi: false, threadCount: 120, initialHeight: 120 * ROW_HEIGHT },
-  { baseUi: true, threadCount: 120, initialHeight: 120 * ROW_HEIGHT },
-  { baseUi: false, threadCount: 6406, initialHeight: 0 },
-  { baseUi: true, threadCount: 6406, initialHeight: 0 },
-])(
-  "Keep $threadCount sidebar threads virtualized after layout settles (baseUi=$baseUi)",
-  async ({ baseUi, threadCount, initialHeight }) => {
+test.each([false, true])(
+  "Wait for styles before mounting the virtual viewport (baseUi=%s)",
+  async (baseUi) => {
+    const threadCount = 6406;
     mockThreads(threadCount);
     context.mocks.browser.noAnimations();
-    const resize = mockViewportResize();
-    let viewportHeight = initialHeight;
-    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
-      function (this: HTMLElement) {
-        return this.dataset.testid === "sidebar-scroll-area"
-          ? viewportHeight
-          : 0;
-      },
-    );
-    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(
-      function (this: HTMLElement) {
-        return this.dataset.testid === "sidebar-scroll-area"
-          ? threadCount * ROW_HEIGHT
-          : 0;
-      },
-    );
+    const stylesheet = context.mocks.deferred<"loaded" | "failed">();
+    vi.stubGlobal("__mainStylesheetLoaded", stylesheet.promise);
+    let viewportHeight = threadCount * ROW_HEIGHT;
+    mockViewportHeight(() => {
+      return viewportHeight;
+    }, threadCount);
 
-    await setupPage({
+    const page = await startPage({
       context,
       path: `/chats/${threadId(0)}`,
       featureSwitches: {
         [FeatureSwitchKey.BaseUiSidebarScrollArea]: baseUi,
       },
     });
+    const sidebar = await screen.findByTestId("chat-list-column");
+    await within(sidebar).findByTestId("pinned-agent-card");
+    expect(
+      within(sidebar).queryByTestId("sidebar-scroll-area"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(sidebar).queryAllByTestId("sidebar-chat-thread-virtual-row"),
+    ).toHaveLength(0);
 
-    const sidebar = screen.getByTestId("chat-list-column");
+    // CSS is active before its existing readiness promise resolves.
+    viewportHeight = 612;
+    stylesheet.resolve("loaded");
+    await page.ready;
     const rows = () => {
       return within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row");
     };
-    await waitFor(() => {
-      expect(rows()).toHaveLength(initialHeight ? threadCount : 100);
-    });
-
-    // Model stylesheet activation without a scroll event. The smaller
-    // unbounded fixture exercises the same transition without mounting 6,406
-    // rows in happy-dom; the large fixture also verifies the 100-row fallback.
-    const viewport = within(sidebar).getByTestId("sidebar-scroll-area");
-    viewportHeight = 612;
-    resize(viewport);
     await waitFor(() => {
       expect(rows()).toHaveLength(25);
     });
@@ -214,14 +172,12 @@ test.each([
     expect(within(sidebar).queryByText("History 26")).not.toBeInTheDocument();
 
     viewportHeight = 900;
-    resize(viewport);
+    resizeWindow();
     await waitFor(() => {
-      expect(within(sidebar).getByText("History 33")).toBeInTheDocument();
+      expect(rows()).toHaveLength(33);
     });
-    expect(rows()).toHaveLength(33);
-
     viewportHeight = 360;
-    resize(viewport);
+    resizeWindow();
     await waitFor(() => {
       expect(rows()).toHaveLength(18);
     });
@@ -240,9 +196,23 @@ test.each([
   },
 );
 
+test("Keep the virtual viewport unmounted when the main stylesheet fails", async () => {
+  mockThreads(120);
+  vi.stubGlobal("__mainStylesheetLoaded", Promise.resolve("failed"));
+  await startPage({ context, path: `/chats/${threadId(0)}` });
+  const sidebar = await screen.findByTestId("chat-list-column");
+  await within(sidebar).findByTestId("pinned-agent-card");
+  expect(
+    within(sidebar).queryByTestId("sidebar-scroll-area"),
+  ).not.toBeInTheDocument();
+  expect(screen.getByTestId("app-skeleton")).not.toHaveAttribute(
+    "aria-hidden",
+    "true",
+  );
+});
+
 test("Coalesce sidebar resize bursts and cancel pending measurements when hidden", async () => {
   mockThreads(120);
-  const resize = mockViewportResize();
   await setupPage({
     context,
     path: `/chats/${threadId(0)}`,
@@ -269,11 +239,11 @@ test("Coalesce sidebar resize bursts and cancel pending measurements when hidden
   vi.spyOn(viewport, "scrollHeight", "get").mockReturnValue(120 * ROW_HEIGHT);
   const flushFrame = queueAnimationFrames();
 
-  resize(viewport);
+  resizeWindow();
   viewportHeight = 900;
-  resize(viewport);
+  resizeWindow();
   viewportHeight = 360;
-  resize(viewport);
+  resizeWindow();
 
   // Intermediate layouts must not force repeated geometry reads. The single
   // frame measurement must use the latest height and update the visible rows.
@@ -286,12 +256,191 @@ test("Coalesce sidebar resize bursts and cancel pending measurements when hidden
 
   heightReads = 0;
   viewportHeight = 900;
-  resize(viewport);
+  resizeWindow();
   click(within(sidebar).getByLabelText("Hide chat list"));
   await waitFor(() => {
     expect(screen.queryByTestId("chat-list-column")).not.toBeInTheDocument();
   });
-  resize(viewport);
+  resizeWindow();
   flushFrame();
   expect(heightReads).toBe(0);
+});
+
+function mockPinnedGrid(): string {
+  const agents = Array.from({ length: 5 }, (_, index) => {
+    return {
+      agentId: `c0000000-0000-4000-a000-${String(index + 1).padStart(12, "0")}`,
+      ownerId: "test-user-123",
+      displayName: index === 0 ? "Zero" : `Agent ${index + 1}`,
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      visibility: "public" as const,
+    };
+  });
+  context.mocks.data.agents(agents);
+  context.mocks.data.userPreferences({
+    pinnedAgentIds: agents.slice(1, 4).map((agent) => {
+      return agent.agentId;
+    }),
+  });
+  return "c0000000-0000-4000-a000-000000000005";
+}
+
+function pinToggle(container: HTMLElement, name: "Pin" | "Unpin"): HTMLElement {
+  const row = within(container).getByText("Agent 5").closest('[role="option"]');
+  if (!(row instanceof HTMLElement)) {
+    throw new Error("Fifth agent is missing from the pin manager");
+  }
+  const button = queryAllByRoleFast("button", row).find((candidate) => {
+    return candidate.textContent?.trim() === name;
+  });
+  if (!button) {
+    throw new Error(`${name} button is missing from the pin manager`);
+  }
+  return button;
+}
+
+test("Refresh virtualization after pinning adds a grid row and unpinning removes it", async () => {
+  mockThreads(120);
+  mockPinnedGrid();
+  mockViewportHeight(() => {
+    const cards = document.querySelectorAll(
+      '[data-testid="pinned-agent-card"]',
+    );
+    return cards.length > 4 ? 360 : 612;
+  });
+  await setupPage({ context, path: `/chats/${threadId(0)}` });
+  const sidebar = screen.getByTestId("chat-list-column");
+  const rows = () => {
+    return within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row");
+  };
+  await waitFor(() => {
+    return expect(rows()).toHaveLength(25);
+  });
+
+  click(screen.getByLabelText("Pin an agent"));
+  const dialog = await screen.findByTestId("pin-agent-dialog-list");
+  click(pinToggle(dialog, "Pin"));
+  await waitFor(() => {
+    expect(within(sidebar).getAllByTestId("pinned-agent-card")).toHaveLength(5);
+    expect(rows()).toHaveLength(18);
+  });
+  await waitFor(() => {
+    return expect(pinToggle(dialog, "Unpin")).toBeEnabled();
+  });
+  click(pinToggle(dialog, "Unpin"));
+  await waitFor(() => {
+    expect(within(sidebar).getAllByTestId("pinned-agent-card")).toHaveLength(4);
+    expect(rows()).toHaveLength(25);
+  });
+});
+
+test("Refresh virtualization when unread indicators add an agent to the grid", async () => {
+  mockThreads(120);
+  const unreadAgentId = mockPinnedGrid();
+  const indicators = context.mocks.deferred<void>();
+  context.mocks.api(chatThreadsContract.indicators, async ({ respond }) => {
+    await indicators.promise;
+    return respond(200, { agents: { [unreadAgentId]: "unread" }, threads: {} });
+  });
+  mockViewportHeight(() => {
+    return document.querySelectorAll('[data-testid="pinned-agent-card"]')
+      .length > 4
+      ? 360
+      : 612;
+  });
+  await setupPage({ context, path: `/chats/${threadId(0)}` });
+  const sidebar = screen.getByTestId("chat-list-column");
+  const rows = () => {
+    return within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row");
+  };
+  await waitFor(() => {
+    return expect(rows()).toHaveLength(25);
+  });
+  indicators.resolve(undefined);
+  await waitFor(() => {
+    expect(within(sidebar).getAllByTestId("pinned-agent-card")).toHaveLength(5);
+    expect(rows()).toHaveLength(18);
+  });
+});
+
+test("Refresh virtualization after collapsing and expanding the pinned section", async () => {
+  mockThreads(120);
+  context.mocks.browser.matchMedia(false);
+  mockViewportHeight(() => {
+    const header = document.querySelector(
+      '[data-testid="pinned-section-header"]',
+    );
+    return header?.nextElementSibling ? 360 : 612;
+  });
+  await setupPage({ context, path: `/chats/${threadId(0)}` });
+  const header = screen.getByTestId("pinned-section-header");
+  const rows = () => {
+    return screen.getAllByTestId("sidebar-chat-thread-virtual-row");
+  };
+  await waitFor(() => {
+    return expect(rows()).toHaveLength(18);
+  });
+  click(header);
+  await waitFor(() => {
+    return expect(rows()).toHaveLength(25);
+  });
+  click(header);
+  await waitFor(() => {
+    return expect(rows()).toHaveLength(18);
+  });
+});
+
+test("Refresh virtualization when the upgrade card appears and disappears", async () => {
+  mockThreads(120);
+  let tier = "team";
+  context.mocks.api(billingStatusContract.get, ({ respond }) => {
+    return respond(200, {
+      tier,
+      credits: 10_000,
+      onboardingPaymentPending: false,
+      subscriptionStatus: "active",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+      scheduledChange: null,
+      hasSubscription: true,
+      autoRecharge: { enabled: false, threshold: null, amount: null },
+      creditExpiry: { expiringNextCycle: 0, nextExpiryDate: null },
+      creditBreakdown: [],
+      creditGrants: [],
+      concurrencyLimit: 1,
+      concurrencySubscriptions: [],
+    });
+  });
+  mockViewportHeight(() => {
+    return screen.queryByText("Get Pro") ? 360 : 612;
+  });
+  await setupPage({ context, path: `/chats/${threadId(0)}` });
+  const sidebar = screen.getByTestId("chat-list-column");
+  const rows = () => {
+    return within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row");
+  };
+  await waitFor(() => {
+    return expect(rows()).toHaveLength(25);
+  });
+  await waitFor(() => {
+    return expect(
+      context.mocks.ably.hasSubscription("billing:changed"),
+    ).toBeTruthy();
+  });
+
+  tier = "pro-suspend";
+  context.mocks.ably.trigger("billing:changed");
+  await within(sidebar).findByText("Get Pro");
+  await waitFor(() => {
+    return expect(rows()).toHaveLength(18);
+  });
+
+  tier = "team";
+  context.mocks.ably.trigger("billing:changed");
+  await waitFor(() => {
+    expect(within(sidebar).queryByText("Get Pro")).not.toBeInTheDocument();
+    expect(rows()).toHaveLength(25);
+  });
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
@@ -105,15 +105,16 @@ function mockViewportResize(): (target: HTMLElement) => void {
       if (!this.targets.has(target)) {
         return;
       }
+      const contentRect = target.getBoundingClientRect();
       const size = {
-        inlineSize: target.clientWidth,
-        blockSize: target.clientHeight,
+        inlineSize: contentRect.width,
+        blockSize: contentRect.height,
       };
       this.callback(
         [
           {
             target,
-            contentRect: target.getBoundingClientRect(),
+            contentRect,
             borderBoxSize: [size],
             contentBoxSize: [size],
             devicePixelContentBoxSize: [size],
@@ -129,6 +130,29 @@ function mockViewportResize(): (target: HTMLElement) => void {
     act(() => {
       for (const observer of observers) {
         observer.resize(target);
+      }
+    });
+  };
+}
+
+function queueAnimationFrames(): () => void {
+  let nextFrameId = 0;
+  let callbacks = new Map<number, FrameRequestCallback>();
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    nextFrameId += 1;
+    callbacks.set(nextFrameId, callback);
+    return nextFrameId;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation((frameId) => {
+    callbacks.delete(frameId);
+  });
+
+  return () => {
+    act(() => {
+      const scheduled = Array.from(callbacks.values());
+      callbacks = new Map();
+      for (const callback of scheduled) {
+        callback(performance.now());
       }
     });
   };
@@ -215,3 +239,59 @@ test.each([
     expect(rows()).toHaveLength(18);
   },
 );
+
+test("Coalesce sidebar resize bursts and cancel pending measurements when hidden", async () => {
+  mockThreads(120);
+  const resize = mockViewportResize();
+  await setupPage({
+    context,
+    path: `/chats/${threadId(0)}`,
+    featureSwitches: {
+      [FeatureSwitchKey.BaseUiSidebarScrollArea]: false,
+    },
+  });
+
+  const sidebar = screen.getByTestId("chat-list-column");
+  const rows = () => {
+    return within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row");
+  };
+  await waitFor(() => {
+    expect(rows()).toHaveLength(100);
+  });
+
+  const viewport = within(sidebar).getByTestId("sidebar-scroll-area");
+  let viewportHeight = 120 * ROW_HEIGHT;
+  let heightReads = 0;
+  vi.spyOn(viewport, "clientHeight", "get").mockImplementation(() => {
+    heightReads += 1;
+    return viewportHeight;
+  });
+  vi.spyOn(viewport, "scrollHeight", "get").mockReturnValue(120 * ROW_HEIGHT);
+  const flushFrame = queueAnimationFrames();
+
+  resize(viewport);
+  viewportHeight = 900;
+  resize(viewport);
+  viewportHeight = 360;
+  resize(viewport);
+
+  // Intermediate layouts must not force repeated geometry reads. The single
+  // frame measurement must use the latest height and update the visible rows.
+  expect(heightReads).toBe(0);
+  flushFrame();
+  expect(heightReads).toBe(1);
+  await waitFor(() => {
+    expect(rows()).toHaveLength(18);
+  });
+
+  heightReads = 0;
+  viewportHeight = 900;
+  resize(viewport);
+  click(within(sidebar).getByLabelText("Hide chat list"));
+  await waitFor(() => {
+    expect(screen.queryByTestId("chat-list-column")).not.toBeInTheDocument();
+  });
+  resize(viewport);
+  flushFrame();
+  expect(heightReads).toBe(0);
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
@@ -1,0 +1,217 @@
+import {
+  chatThreadByIdContract,
+  chatThreadsContract,
+} from "@okouai/api-contracts/contracts/chat-threads";
+import { browserContract } from "@okouai/api-contracts/contracts/browser";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { act, screen, waitFor, within } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
+
+import {
+  click,
+  queryAllByRoleFast,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const ROW_HEIGHT = 36;
+
+function threadId(index: number): string {
+  return `b3200000-0000-4000-a000-${String(index).padStart(12, "0")}`;
+}
+
+function mockThreads(count: number): void {
+  context.mocks.data.agents([
+    {
+      agentId: AGENT_ID,
+      ownerId: "test-user-123",
+      displayName: "Zero",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      visibility: "public",
+    },
+  ]);
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: Array.from({ length: count }, (_, index) => {
+        return {
+          id: threadId(index),
+          agentId: AGENT_ID,
+          title: `History ${index + 1}`,
+          sortAt: new Date(
+            Date.parse("2026-03-10T00:00:00Z") + (count - index) * 1000,
+          ).toISOString(),
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+          pinnedAt: null,
+          renamedAt: null,
+          selectedModel: null,
+          serviceTier: null,
+          computerUseHostId: null,
+        };
+      }),
+      latestEventId: null,
+      latestSeqId: null,
+    });
+  });
+  context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+    return respond(200, { events: [], hasMore: false });
+  });
+  context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+    return respond(200, { agents: {}, threads: {} });
+  });
+  context.mocks.api(chatThreadByIdContract.get, ({ respond }) => {
+    return respond(200, {
+      lastReadAt: null,
+      cancellationRecoveryPending: false,
+    });
+  });
+  context.mocks.api(browserContract.get, ({ respond }) => {
+    return respond(404, {
+      error: {
+        code: "BROWSER_NOT_FOUND",
+        message: "Managed browser not found",
+      },
+    });
+  });
+}
+
+function mockViewportResize(): (target: HTMLElement) => void {
+  const observers = new Set<TestResizeObserver>();
+
+  class TestResizeObserver implements ResizeObserver {
+    private targets = new Set<Element>();
+
+    constructor(private readonly callback: ResizeObserverCallback) {}
+
+    observe(target: Element): void {
+      this.targets.add(target);
+      observers.add(this);
+    }
+
+    unobserve(target: Element): void {
+      this.targets.delete(target);
+    }
+
+    disconnect(): void {
+      this.targets = new Set();
+      observers.delete(this);
+    }
+
+    resize(target: HTMLElement): void {
+      if (!this.targets.has(target)) {
+        return;
+      }
+      const size = {
+        inlineSize: target.clientWidth,
+        blockSize: target.clientHeight,
+      };
+      this.callback(
+        [
+          {
+            target,
+            contentRect: target.getBoundingClientRect(),
+            borderBoxSize: [size],
+            contentBoxSize: [size],
+            devicePixelContentBoxSize: [size],
+          },
+        ],
+        this,
+      );
+    }
+  }
+
+  vi.stubGlobal("ResizeObserver", TestResizeObserver);
+  return (target) => {
+    act(() => {
+      for (const observer of observers) {
+        observer.resize(target);
+      }
+    });
+  };
+}
+
+test.each([
+  { baseUi: false, threadCount: 120, initialHeight: 120 * ROW_HEIGHT },
+  { baseUi: true, threadCount: 120, initialHeight: 120 * ROW_HEIGHT },
+  { baseUi: false, threadCount: 6406, initialHeight: 0 },
+  { baseUi: true, threadCount: 6406, initialHeight: 0 },
+])(
+  "Keep $threadCount sidebar threads virtualized after layout settles (baseUi=$baseUi)",
+  async ({ baseUi, threadCount, initialHeight }) => {
+    mockThreads(threadCount);
+    context.mocks.browser.noAnimations();
+    const resize = mockViewportResize();
+    let viewportHeight = initialHeight;
+    vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
+      function (this: HTMLElement) {
+        return this.dataset.testid === "sidebar-scroll-area"
+          ? viewportHeight
+          : 0;
+      },
+    );
+    vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(
+      function (this: HTMLElement) {
+        return this.dataset.testid === "sidebar-scroll-area"
+          ? threadCount * ROW_HEIGHT
+          : 0;
+      },
+    );
+
+    await setupPage({
+      context,
+      path: `/chats/${threadId(0)}`,
+      featureSwitches: {
+        [FeatureSwitchKey.BaseUiSidebarScrollArea]: baseUi,
+      },
+    });
+
+    const sidebar = screen.getByTestId("chat-list-column");
+    const rows = () => {
+      return within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row");
+    };
+    await waitFor(() => {
+      expect(rows()).toHaveLength(initialHeight ? threadCount : 100);
+    });
+
+    // Model stylesheet activation without a scroll event. The smaller
+    // unbounded fixture exercises the same transition without mounting 6,406
+    // rows in happy-dom; the large fixture also verifies the 100-row fallback.
+    const viewport = within(sidebar).getByTestId("sidebar-scroll-area");
+    viewportHeight = 612;
+    resize(viewport);
+    await waitFor(() => {
+      expect(rows()).toHaveLength(25);
+    });
+    expect(within(sidebar).getByText("History 25")).toBeInTheDocument();
+    expect(within(sidebar).queryByText("History 26")).not.toBeInTheDocument();
+
+    viewportHeight = 900;
+    resize(viewport);
+    await waitFor(() => {
+      expect(within(sidebar).getByText("History 33")).toBeInTheDocument();
+    });
+    expect(rows()).toHaveLength(33);
+
+    viewportHeight = 360;
+    resize(viewport);
+    await waitFor(() => {
+      expect(rows()).toHaveLength(18);
+    });
+
+    const nextThread = queryAllByRoleFast("link", sidebar).find((link) => {
+      return link.getAttribute("href") === `/chats/${threadId(1)}`;
+    });
+    if (!nextThread) {
+      throw new Error("Second sidebar thread is not mounted");
+    }
+    click(nextThread);
+    await waitFor(() => {
+      expect(nextThread).toHaveAttribute("aria-current", "page");
+    });
+    expect(rows()).toHaveLength(18);
+  },
+);

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -45,6 +45,7 @@ import {
 } from "../../signals/okou-page/pinned-agents.ts";
 import { unreadAgentIds$ } from "../../signals/chat-page/chat-thread-indicators-from-worker.ts";
 import { markAgentThreadsRead$ } from "../../signals/chat-page/sidebar-unread-threads.ts";
+import { refreshSidebarChatThreadLayoutOnRef$ } from "../../signals/chat-page/sidebar-chat-thread-scroll.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { equalSets } from "../../lib/equality.ts";
@@ -66,8 +67,10 @@ const pinnedAgentGridCardFrameClassName =
 const pinnedAgentGridLabelFrameClassName = "h-3.5 leading-[14px]";
 
 function PinnedAgentGridSkeletonCard() {
+  const refreshLayoutRef = useSet(refreshSidebarChatThreadLayoutOnRef$);
   return (
     <div
+      ref={refreshLayoutRef}
       aria-hidden="true"
       data-testid="pinned-agent-skeleton"
       className={pinnedAgentGridCardFrameClassName}
@@ -267,6 +270,7 @@ function PinnedAgentGridCard({
   const setDropTarget = useSet(setPinnedAgentDropTarget$);
   const endDrag = useSet(endPinnedAgentDrag$);
   const [, moveAgent] = useLoadableSet(movePinnedAgent$);
+  const refreshLayoutRef = useSet(refreshSidebarChatThreadLayoutOnRef$);
   const displayName = agent.displayName ?? agent.agentId;
 
   const isDragging = draggingAgentId === agent.agentId;
@@ -278,6 +282,7 @@ function PinnedAgentGridCard({
 
   const card = (
     <Link
+      ref={refreshLayoutRef}
       pathname="/agents/:agentId/chat"
       options={{ pathParams: { agentId: agent.agentId } }}
       data-testid="pinned-agent-card"
@@ -451,6 +456,7 @@ export function PinnedAgentListSection({
 }: {
   layout?: "vertical" | "horizontal";
 }) {
+  const refreshLayoutRef = useSet(refreshSidebarChatThreadLayoutOnRef$);
   const { t } = useTranslation("agents");
   const activeRoute = useGet(activeRoute$);
   const pathParams = useGet(pathParams$);
@@ -584,10 +590,13 @@ export function PinnedAgentListSection({
         </span>
       </div>
       {!collapsed && (
-        <div className="flex flex-col gap-0.5 mt-1">
+        <div ref={refreshLayoutRef} className="flex flex-col gap-0.5 mt-1">
           {pinnedAgentsLoadable.state === "loading" && (
             <>
-              <div className="flex h-8 items-center gap-2 px-2">
+              <div
+                ref={refreshLayoutRef}
+                className="flex h-8 items-center gap-2 px-2"
+              >
                 <div className="h-5 w-5 shrink-0 rounded-md bg-muted animate-pulse" />
                 <div className="h-3 w-20 rounded bg-muted animate-pulse" />
               </div>
@@ -609,6 +618,7 @@ export function PinnedAgentListSection({
               return (
                 <div
                   key={agent.agentId}
+                  ref={refreshLayoutRef}
                   className="group relative"
                   data-testid="pinned-agent-card"
                 >

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -46,6 +46,7 @@ import {
 import { Skeleton } from "@okouai/ui/components/ui/skeleton";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
+import { mainStylesheetLoaded$ } from "../../signals/app-skeleton.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   deleteChatThread$,
@@ -1153,6 +1154,7 @@ export function ChatThreadsSection({
   showMarkAllRead?: boolean;
 }) {
   const agentScope = useGet(currentChatAgentScope$);
+  const mainStylesheetLoaded = useLastResolved(mainStylesheetLoaded$);
 
   return (
     <div className="mt-4 flex flex-col min-h-0 flex-1">
@@ -1162,10 +1164,12 @@ export function ChatThreadsSection({
           showMarkAllRead={showMarkAllRead}
         />
       </div>
-      <ChatThreadsContent
-        scrollSignals={scrollSignals}
-        contentClassName={contentClassName}
-      />
+      {mainStylesheetLoaded && (
+        <ChatThreadsContent
+          scrollSignals={scrollSignals}
+          contentClassName={contentClassName}
+        />
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/sidebar-upgrade.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-upgrade.tsx
@@ -9,6 +9,7 @@ import {
   setSettingsDialogOpen$,
 } from "../../signals/okou-page/settings/settings-dialog.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
+import { refreshSidebarChatThreadLayoutOnRef$ } from "../../signals/chat-page/sidebar-chat-thread-scroll.ts";
 
 function nextTierInfo(
   tier: string,
@@ -23,6 +24,7 @@ function nextTierInfo(
 }
 
 export function SidebarUpgradeCard() {
+  const refreshLayoutRef = useSet(refreshSidebarChatThreadLayoutOnRef$);
   const { t } = useTranslation();
   const pageSignal = useGet(pageSignal$);
   const billingLoadable = useLastLoadable(billingStatusAsync$);
@@ -61,6 +63,7 @@ export function SidebarUpgradeCard() {
 
   return (
     <button
+      ref={refreshLayoutRef}
       type="button"
       onClick={handleClick}
       className="flex w-full items-center gap-3 p-2.5 text-left transition-colors hover:bg-state-hover zero-card shadow-[0_1px_2px_hsl(220_12%_20%/0.04),0_4px_12px_hsl(220_12%_20%/0.03)]"


### PR DESCRIPTION
Sidebar virtualization caches its viewport height. Expanding or collapsing pinned agents, adding another agent grid row, or showing and hiding the upgrade card can leave the visible range based on the previous layout until the user scrolls. Startup can also measure an unstyled viewport because only bootstrap-skeleton dismissal currently waits for the main stylesheet.

Mount the chat viewport only after `window.__mainStylesheetLoaded` succeeds. Refresh its metrics through a shared command when pinned entries, the collapsible pinned section, or the upgrade card are committed to or removed from the DOM. These commit callbacks also cover asynchronously loaded preferences and unread agents joining the pinned grid.

Window resize events use the same command. Coalesce requests into one animation-frame measurement of the latest layout, skip unchanged metrics, and cancel pending measurements and remove the window listener when the viewport unmounts.

## Verification

- Prettier, ESLint, and Oxlint, including type-aware analysis, on all changed files
- `pnpm exec knip --workspace apps/platform`
- `pnpm -F @okouai/app check-types`
- 49 tests passed across four targeted page test files: `sidebar-virtualization.test.tsx`, `sidebar.test.tsx`, `sidebar-mac-shortcut.test.tsx`, and `billing-plans-entry.test.tsx`
- Regression tests cover delayed and failed stylesheet loading, 6,406 threads with both scrollbar implementations, the bounded unmeasured fallback, window resize coalescing and cleanup, pin/unpin grid changes, unread-agent arrival, pinned-section collapse/expansion, upgrade-card visibility, and chat navigation
- Against main at `c7b2ab7`, the stylesheet-failure, pin/unpin, pinned-collapse, and upgrade-card regression tests all fail on the expected stale or prematurely mounted viewport behavior

Fixes #31439
