### PR TITLE
fix: retire claude fable 5 from model selection

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-model-selection.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-model-selection.test.ts
@@ -109,6 +109,32 @@ function metadataClient() {
 }
 
 describe("POST /api/chat-threads/:id/model-selection", () => {
+  it("preserves the thread selection when an old client requests a retired model", async () => {
+    const fixture = await seedChatThread("Model retirement");
+    const token = okouToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:read", "chat-thread:write"],
+    });
+    const headers = { authorization: `Bearer ${token}` };
+    const rejected = await accept(
+      modelSelectionClient().update({
+        headers,
+        params: { id: fixture.threadId },
+        body: { model: "claude-fable-5" },
+      }),
+      [400],
+    );
+    expect(rejected.body.error.message).toBe(
+      "Claude Fable 5 has been retired. Select Claude Fable 5.1.",
+    );
+    const thread = await accept(
+      metadataClient().get({ headers, params: { id: fixture.threadId } }),
+      [200],
+    );
+    expect(thread.body.selectedModel).toBe("claude-sonnet-5");
+  });
+
   it("updates thread model selection with ZERO_TOKEN chat-thread:write capability", async () => {
     const fixture = await seedChatThread("Launch plan");
     const token = okouToken({

--- a/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   DEFAULT_ORG_MODEL_POLICY_MODELS,
   LIMITED_FREE1_DEFAULT_RUN_MODEL,
-  SUPPORTED_RUN_MODELS,
+  ACTIVE_RUN_MODELS,
   isBuiltInModelProviderType,
   type OrgModelPoliciesResponse,
   type UpdateOrgModelPolicy,
@@ -150,6 +150,52 @@ async function makeLimitedFreeWorkspace(
 }
 
 describe("GET/PUT /api/model-policies", () => {
+  it("keeps the successor usable after rejecting retired policy and preference writes", async () => {
+    const fixture = seedFixture();
+    useSession(fixture);
+    const client = apiClient();
+    const existing = await accept(
+      client.list({ headers: authHeaders() }),
+      [200],
+    );
+    const retired = await accept(
+      client.update({
+        headers: authHeaders(),
+        body: {
+          policies: [
+            ...toUpdate(existing.body),
+            makeVm0Policy("claude-fable-5"),
+          ],
+        },
+      }),
+      [400],
+    );
+    expect(retired.body.error.message).toBe(
+      "Claude Fable 5 has been retired. Select Claude Fable 5.1.",
+    );
+
+    const preferences = setupApp({
+      context,
+      routes: userModelPreferenceRoutes,
+    })(userModelPreferenceContract);
+    const oldPreference = await accept(
+      preferences.update({
+        headers: authHeaders(),
+        body: { selectedModel: "claude-fable-5", serviceTier: null },
+      }),
+      [400],
+    );
+    expect(oldPreference.body.error.message).toBe(retired.body.error.message);
+    const successor = await accept(
+      preferences.update({
+        headers: authHeaders(),
+        body: { selectedModel: "claude-fable-5-1", serviceTier: null },
+      }),
+      [200],
+    );
+    expect(successor.body.selectedModel).toBe("claude-fable-5-1");
+  });
+
   it("returns 401 for unauthenticated reads and writes", async () => {
     const client = apiClient();
 
@@ -634,7 +680,7 @@ describe("GET/PUT /api/model-policies", () => {
         return policy.model;
       }),
     ).toStrictEqual(
-      SUPPORTED_RUN_MODELS.filter((model) => {
+      ACTIVE_RUN_MODELS.filter((model) => {
         return configuredModels.has(model);
       }),
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7355,6 +7355,48 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 });
 
 describe("RUN-01: admission boundaries beyond request validation", () => {
+  it.each(["claude-fable-5", "anthropic/claude-fable-5"])(
+    "fails a pre-deployment queued %s selection when capacity becomes available",
+    async (selectedModel) => {
+      const api = createRunsApi(context);
+      const { actor, agentId } = await entitledRunActor();
+      const first = await api.createRun(actor, {
+        agentId,
+        prompt: "hold first slot",
+        modelProvider: "anthropic-api-key",
+      });
+      const second = await api.createRun(actor, {
+        agentId,
+        prompt: "hold second slot",
+        modelProvider: "anthropic-api-key",
+      });
+      const queued = await api.createRun(actor, {
+        agentId,
+        prompt: "queued before model retirement",
+        modelProvider: "anthropic-api-key",
+      });
+      expect(queued.status).toBe("queued");
+      // The previous API could enqueue this snapshot. The current write APIs
+      // reject it, so simulate only the persisted pre-deployment selection.
+      await setRunModelRuntimeRouteFixture({
+        runId: queued.runId,
+        selectedModel,
+        modelRuntimeProvider: "anthropic-api-key",
+        modelRuntimeModel: selectedModel,
+      });
+      await api.requestCancelRun(actor, first.runId, [200]);
+      const failed = await waitForRunStatus(api, actor, queued.runId, "failed");
+      expect(failed.error).toBe(
+        "Claude Fable 5 has been retired. Select Claude Fable 5.1.",
+      );
+      expect(
+        (await waitForRunQueueLength(api, actor, 0)).body.queue,
+      ).toHaveLength(0);
+      expect((await api.readRun(actor, second.runId)).status).toBe("pending");
+      await api.requestCancelRun(actor, second.runId, [200]);
+    },
+  );
+
   it("rejects runs for onboarded organizations that never gained an entitlement", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -227,7 +227,7 @@ describe("POST /api/test/runtime-state/action", () => {
   );
 
   it("isolates expiry-based cooldowns to exact built-in model routes", async () => {
-    await seedVm0BuiltInModelCandidateKeys(context, "claude-fable-5");
+    await seedVm0BuiltInModelCandidateKeys(context, "claude-fable-5-1");
     await seedVm0BuiltInModelCandidateKeys(context, "gpt-5.6-sol");
     const startedAt = Date.UTC(2026, 7, 20, 0, 0, 0);
     const routeCooldownUntil = new Date(startedAt + 60 * 1000);
@@ -294,7 +294,7 @@ describe("POST /api/test/runtime-state/action", () => {
     const claudePrimary = await withMockNowForTest(startedAt, async () => {
       return await resolveVm0BuiltInModelRouteFixture(
         context,
-        "claude-fable-5",
+        "claude-fable-5-1",
       );
     });
     expect(claudePrimary?.provider_type).toBe("anthropic-api-key");
@@ -303,14 +303,14 @@ describe("POST /api/test/runtime-state/action", () => {
     }
     await setVm0BuiltInCandidateCooldownFixture(
       context,
-      "claude-fable-5",
+      "claude-fable-5-1",
       claudePrimary,
       routeCooldownUntil,
     );
     const claudeFallback = await withMockNowForTest(startedAt, async () => {
       return await resolveVm0BuiltInModelRouteFixture(
         context,
-        "claude-fable-5",
+        "claude-fable-5-1",
       );
     });
     expect(claudeFallback?.provider_type).toBe("openrouter-api-key");
@@ -319,7 +319,7 @@ describe("POST /api/test/runtime-state/action", () => {
     }
     await setVm0BuiltInCandidateCooldownFixture(
       context,
-      "claude-fable-5",
+      "claude-fable-5-1",
       claudeFallback,
       routeCooldownUntil,
     );
@@ -373,7 +373,7 @@ describe("POST /api/test/runtime-state/action", () => {
         resolveVm0BuiltInModelRouteFixture(context, "gpt-5.6-sol"),
       ).resolves.toMatchObject({ provider_type: "openai-api-key" });
       await expect(
-        resolveVm0BuiltInModelRouteFixture(context, "claude-fable-5"),
+        resolveVm0BuiltInModelRouteFixture(context, "claude-fable-5-1"),
       ).resolves.toMatchObject({ provider_type: "anthropic-api-key" });
     });
   });

--- a/turbo/apps/api/src/signals/routes/user-model-preference.ts
+++ b/turbo/apps/api/src/signals/routes/user-model-preference.ts
@@ -1,4 +1,8 @@
 import { command, computed } from "ccstate";
+import {
+  getRunModelAccess,
+  RETIRED_RUN_MODEL_MESSAGE,
+} from "@okouai/api-contracts/contracts/model-providers";
 import type { UserPreferenceChangedPayload } from "@okouai/api-contracts/contracts/realtime";
 import { userModelPreferenceContract } from "@okouai/api-contracts/contracts/user-model-preference";
 import { isFeatureEnabled } from "@okouai/core/feature-switch";
@@ -35,6 +39,10 @@ const updateUserModelPreferenceInner$ = command(
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
+    }
+
+    if (getRunModelAccess(body.data.selectedModel) === "retired") {
+      return badRequestMessage(RETIRED_RUN_MODEL_MESSAGE);
     }
 
     const policies =

--- a/turbo/apps/api/src/signals/services/model-policy.service.ts
+++ b/turbo/apps/api/src/signals/services/model-policy.service.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   LIMITED_FREE1_DEFAULT_RUN_MODEL,
   MODEL_PROVIDER_TYPES,
-  SUPPORTED_RUN_MODELS,
+  ACTIVE_RUN_MODELS,
   getCanonicalModelDisplayName,
   getDefaultOrgModelPolicySeed,
   getFrameworkForType,
@@ -12,6 +12,8 @@ import {
   isBuiltInModelProviderType,
   isModelSupportedByProvider,
   isLimitedFree1RestrictedRunModel,
+  getRunModelAccess,
+  RETIRED_RUN_MODEL_MESSAGE,
   type ModelProviderCredentialScope,
   type OrgModelPoliciesResponse,
   type OrgModelPolicy,
@@ -109,7 +111,7 @@ function parseProviderType(value: string): ModelProviderType | null {
 }
 
 function parseSupportedModel(value: string): SupportedRunModel | null {
-  return SUPPORTED_RUN_MODELS.includes(value as SupportedRunModel)
+  return ACTIVE_RUN_MODELS.includes(value as SupportedRunModel)
     ? (value as SupportedRunModel)
     : null;
 }
@@ -140,7 +142,7 @@ function loadRows(db: Db, orgId: string): Promise<OrgModelPolicyRow[]> {
     .where(
       and(
         eq(orgModelPolicies.orgId, orgId),
-        inArray(orgModelPolicies.model, [...SUPPORTED_RUN_MODELS]),
+        inArray(orgModelPolicies.model, [...ACTIVE_RUN_MODELS]),
       ),
     );
 }
@@ -195,8 +197,7 @@ function modelAllowedForOrgPlan(
   capabilities: Pick<OrgPlanCapabilities, "restrictedVm0Models">,
 ): boolean {
   return (
-    !capabilities.restrictedVm0Models ||
-    !isLimitedFree1RestrictedRunModel(model)
+    getRunModelAccess(model, capabilities.restrictedVm0Models) === "allowed"
   );
 }
 
@@ -208,8 +209,8 @@ function modelProviderAllowedForOrgPlan(
 }
 
 function getSupportedModelRank(model: string): number {
-  const catalogIndex = SUPPORTED_RUN_MODELS.indexOf(model as SupportedRunModel);
-  return catalogIndex === -1 ? SUPPORTED_RUN_MODELS.length : catalogIndex;
+  const catalogIndex = ACTIVE_RUN_MODELS.indexOf(model as SupportedRunModel);
+  return catalogIndex === -1 ? ACTIVE_RUN_MODELS.length : catalogIndex;
 }
 
 function sortRowsByCatalog(rows: OrgModelPolicyRow[]): OrgModelPolicyRow[] {
@@ -562,6 +563,9 @@ async function validateUpdatePolicies(
   let defaultCount = 0;
 
   for (const policy of policies) {
+    if (getRunModelAccess(policy.model) === "retired") {
+      return bad(RETIRED_RUN_MODEL_MESSAGE);
+    }
     if (!parseSupportedModel(policy.model)) {
       return bad(`Unknown model "${policy.model}"`);
     }
@@ -792,7 +796,7 @@ async function persistOrgModelPolicyUpdates(params: {
       .where(
         and(
           eq(orgModelPolicies.orgId, params.orgId),
-          inArray(orgModelPolicies.model, [...SUPPORTED_RUN_MODELS]),
+          inArray(orgModelPolicies.model, [...ACTIVE_RUN_MODELS]),
           notInArray(
             orgModelPolicies.model,
             params.policies.map((policy) => {

--- a/turbo/apps/api/src/signals/services/model-provider-gateway.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-gateway.service.ts
@@ -4,7 +4,7 @@ import { and, eq, notExists, notInArray } from "drizzle-orm";
 import {
   getFrameworkForType,
   getVm0ConcreteProviderType,
-  isSupportedRunModel,
+  isActiveRunModel,
 } from "@okouai/api-contracts/contracts/model-providers";
 import type {
   CreateModelProviderConnectionRequest,
@@ -160,7 +160,7 @@ function protocolSupportsModel(
   protocol: ModelProviderSurfaceProtocol,
   model: string,
 ): boolean {
-  if (!isSupportedRunModel(model)) {
+  if (!isActiveRunModel(model)) {
     return false;
   }
   const framework = getFrameworkForType(getVm0ConcreteProviderType(model));

--- a/turbo/apps/api/src/signals/services/model-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/model-selection.service.ts
@@ -3,7 +3,8 @@ import {
   getVm0ConcreteProviderType,
   isCodexFastModeModel,
   isBuiltInModelProviderType,
-  isLimitedFree1RestrictedRunModel,
+  getRunModelAccess,
+  RETIRED_RUN_MODEL_MESSAGE,
   isSupportedRunModel,
   isModelSupportedByProvider,
   modelProviderTypeSchema,
@@ -137,8 +138,10 @@ function modelAllowedForOrgPlan(args: {
   readonly selectedModel: string | null | undefined;
 }): boolean {
   return (
-    !args.capabilities.restrictedVm0Models ||
-    !isLimitedFree1RestrictedRunModel(args.selectedModel)
+    getRunModelAccess(
+      args.selectedModel,
+      args.capabilities.restrictedVm0Models,
+    ) === "allowed"
   );
 }
 
@@ -525,6 +528,9 @@ export async function resolveModelSelectionPin(params: {
   | ReturnType<typeof insufficientCredits>
 > {
   const { db, orgId, userId, modelSelection } = params;
+  if (getRunModelAccess(modelSelection.selectedModel) === "retired") {
+    return badRequestMessage(RETIRED_RUN_MODEL_MESSAGE);
+  }
   const capabilities = modelRouteCapabilities(
     await loadOrgPlanCapabilities(db, orgId),
   );

--- a/turbo/apps/api/src/signals/services/run-admission.service.ts
+++ b/turbo/apps/api/src/signals/services/run-admission.service.ts
@@ -1,6 +1,7 @@
 import {
   isBuiltInModelProviderType,
-  isLimitedFree1RestrictedRunModel,
+  getRunModelAccess,
+  RETIRED_RUN_MODEL_MESSAGE,
 } from "@okouai/api-contracts/contracts/model-providers";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { creditExpiresRecord } from "@okouai/db/schema/credit-expires-record";
@@ -11,7 +12,7 @@ import {
   nullableDriverValueDecoder,
   pgInt8ToSafeIntegerDecoder,
 } from "../../lib/db-structured-result";
-import { insufficientCredits } from "../../lib/error";
+import { badRequestMessage, insufficientCredits } from "../../lib/error";
 import { nowDate } from "../../lib/time";
 import type { Tx } from "../../lib/db-types";
 import type { Db } from "../external/db";
@@ -25,6 +26,10 @@ import {
   resolveUsageAllowanceAvailability,
   resolveUsageAllowanceAvailabilityForLockedOrg,
 } from "./usage-allowance.service";
+
+type RunAdmissionFailure =
+  | ReturnType<typeof insufficientCredits>
+  | ReturnType<typeof badRequestMessage>;
 
 type CreditDb = Pick<Db, "$with" | "select" | "with">;
 
@@ -143,7 +148,7 @@ export async function checkOrgCreditsForRunAdmission(params: {
   readonly userId: string;
   readonly modelProviderType: string | null | undefined;
   readonly selectedModel?: string | null;
-}): Promise<ReturnType<typeof insufficientCredits> | undefined> {
+}): Promise<RunAdmissionFailure | undefined> {
   const availability = await resolveOrgCreditAvailability(params);
   return await checkResolvedOrgCreditsForRunAdmission({
     ...params,
@@ -158,7 +163,7 @@ export async function checkResolvedOrgCreditsForRunAdmission(params: {
   readonly modelProviderType: string | null | undefined;
   readonly selectedModel?: string | null;
   readonly availability: OrgCreditAvailability | null;
-}): Promise<ReturnType<typeof insufficientCredits> | undefined> {
+}): Promise<RunAdmissionFailure | undefined> {
   return await checkResolvedOrgCreditsForRunAdmissionWithAllowance({
     ...params,
     resolveAllowance: async () => {
@@ -175,8 +180,11 @@ async function checkResolvedOrgCreditsForRunAdmissionWithAllowance(params: {
   readonly resolveAllowance: () => Promise<{
     readonly remainingUnits: number;
   } | null>;
-}): Promise<ReturnType<typeof insufficientCredits> | undefined> {
+}): Promise<RunAdmissionFailure | undefined> {
   const { availability } = params;
+  if (getRunModelAccess(params.selectedModel) === "retired") {
+    return badRequestMessage(RETIRED_RUN_MODEL_MESSAGE);
+  }
   if (!availability) {
     return insufficientCredits();
   }
@@ -209,7 +217,7 @@ export async function checkOrgCreditsForRunAdmissionInTransaction(params: {
   readonly userId: string;
   readonly modelProviderType: string | null | undefined;
   readonly selectedModel?: string | null;
-}): Promise<ReturnType<typeof insufficientCredits> | undefined> {
+}): Promise<RunAdmissionFailure | undefined> {
   await lockOrgCredits(params.db, params.orgId);
   const availability = await resolveOrgCreditAvailability(params);
   return await checkResolvedOrgCreditsForRunAdmissionWithAllowance({
@@ -228,15 +236,21 @@ export function checkOrgPlanRunAdmission(params: {
   readonly capabilities: OrgPlanRunAdmissionCapabilities | null;
   readonly modelProviderType: string | null | undefined;
   readonly selectedModel: string | null | undefined;
-}): ReturnType<typeof insufficientCredits> | undefined {
+}): RunAdmissionFailure | undefined {
   const { capabilities } = params;
+  const modelAccess = getRunModelAccess(
+    params.selectedModel,
+    capabilities?.restrictedVm0Models,
+  );
+  if (modelAccess === "retired") {
+    return badRequestMessage(RETIRED_RUN_MODEL_MESSAGE);
+  }
   if (!capabilities || capabilities.status !== "active") {
     return insufficientCredits();
   }
   return (!capabilities.supportByok &&
     !isBuiltInModelProviderType(params.modelProviderType)) ||
-    (capabilities.restrictedVm0Models &&
-      isLimitedFree1RestrictedRunModel(params.selectedModel))
+    modelAccess === "pro_required"
     ? insufficientCredits()
     : undefined;
 }

--- a/turbo/apps/api/src/signals/services/user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/user-data.service.ts
@@ -16,7 +16,7 @@ import type {
   UpdateUserModelPreferenceRequest,
   UserModelPreferenceResponse,
 } from "@okouai/api-contracts/contracts/user-model-preference";
-import { isSupportedRunModel } from "@okouai/api-contracts/contracts/model-providers";
+import { isActiveRunModel } from "@okouai/api-contracts/contracts/model-providers";
 import { isImageModelId } from "@okouai/api-contracts/contracts/image-models";
 import { isVideoModelId } from "@okouai/api-contracts/contracts/video-models";
 import type { ChatThreadServiceTier } from "@okouai/api-contracts/contracts/chat-threads";
@@ -193,7 +193,7 @@ export function userModelPreference({
       )
       .limit(1);
 
-    const selectedModel = isSupportedRunModel(row?.selectedModel)
+    const selectedModel = isActiveRunModel(row?.selectedModel)
       ? row.selectedModel
       : null;
     const serviceTier: ChatThreadServiceTier | null =

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -601,10 +601,14 @@ export async function setRunModelRuntimeRouteFixture(args: {
   readonly runId: string;
   readonly modelRuntimeProvider: string | null;
   readonly modelRuntimeModel: string | null;
+  readonly selectedModel?: string;
 }): Promise<void> {
   const updated = await db()
     .update(agentRuns)
     .set({
+      ...(args.selectedModel !== undefined && {
+        selectedModel: args.selectedModel,
+      }),
       modelRuntimeProvider: args.modelRuntimeProvider,
       modelRuntimeModel: args.modelRuntimeModel,
     })

--- a/turbo/apps/platform/src/signals/okou-page/settings/model-provider-connections.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/model-provider-connections.ts
@@ -1,6 +1,6 @@
 import { command, computed, state } from "ccstate";
 import {
-  SUPPORTED_RUN_MODELS,
+  ACTIVE_RUN_MODELS,
   getProviderRuntimeModel,
   isModelSupportedByProvider,
   type ModelProviderType,
@@ -49,7 +49,7 @@ type SurfaceField = Exclude<keyof SurfaceDraft, "enabled">;
 function mappingsFor(type: ModelProviderType): string {
   return JSON.stringify(
     Object.fromEntries(
-      SUPPORTED_RUN_MODELS.filter((model) => {
+      ACTIVE_RUN_MODELS.filter((model) => {
         return isModelSupportedByProvider(model, type);
       }).map((model) => {
         return [model, getProviderRuntimeModel(type, model)];

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
@@ -42,7 +42,7 @@ import {
 } from "./chat-composer-test-helpers.ts";
 
 const SPLIT_THREAD_ID = "b1000000-0000-4000-a000-000000000106";
-const DEFAULT_RUN_MODEL = "claude-fable-5";
+const DEFAULT_RUN_MODEL = "claude-fable-5-1";
 const DEFAULT_IMAGE_MODEL = "fal-ai/nano-banana-2";
 const DEFAULT_VIDEO_MODEL = "MiniMax-H3";
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-resolution.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-resolution.test.tsx
@@ -168,8 +168,11 @@ test("Edit only the model for an existing thread", async () => {
 });
 
 test("Resolve the model shown for a chat", async () => {
-  installRunChat({ selectedModel: "claude-fable-5" });
-  configurePolicies(["claude-fable-5", "claude-opus-4-8"], "claude-fable-5");
+  installRunChat({ selectedModel: "claude-fable-5-1" });
+  configurePolicies(
+    ["claude-fable-5-1", "claude-opus-4-8"],
+    "claude-fable-5-1",
+  );
   preference("claude-opus-4-8");
 
   await setupPage({ context, path: NEW_CHAT_PATH });
@@ -181,8 +184,8 @@ test("Resolve the model shown for a chat", async () => {
 test("Keep an existing thread's explicit model", async () => {
   installRunChat({ selectedModel: "claude-opus-5" });
   configurePolicies(
-    ["claude-fable-5", "claude-opus-4-8", "claude-opus-5"],
-    "claude-fable-5",
+    ["claude-fable-5-1", "claude-opus-4-8", "claude-opus-5"],
+    "claude-fable-5-1",
   );
   preference("claude-opus-4-8");
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
@@ -261,7 +261,7 @@ test("Make a temporary Codex speed the default", async () => {
 test("Make a new-chat model choice the default immediately", async () => {
   const user = userEvent.setup({ delay: null });
   let update: UpdateUserModelPreferenceRequest | undefined;
-  installNewChat(["claude-fable-5", "claude-sonnet-4-6"], "claude-fable-5");
+  installNewChat(["claude-fable-5-1", "claude-sonnet-4-6"], "claude-fable-5-1");
   context.mocks.api(userModelPreferenceContract.update, ({ body, respond }) => {
     update = body;
     const nextPreference = preference("claude-sonnet-4-6");
@@ -278,7 +278,7 @@ test("Make a new-chat model choice the default immediately", async () => {
   });
 
   await readyComposer();
-  await chooseModel(user, "Claude Fable 5", /^Claude Sonnet 4\.6/iu);
+  await chooseModel(user, "Claude Fable 5.1", /^Claude Sonnet 4\.6/iu);
   await waitFor(() => {
     expect(update).toStrictEqual({
       selectedModel: "claude-sonnet-4-6",
@@ -296,7 +296,7 @@ test("Temporarily choose a model for a new chat", async () => {
   const updateGate = createDeferredPromise<void>(context.signal);
   const responsePrepared = createDeferredPromise<void>(context.signal);
   let update: UpdateUserModelPreferenceRequest | undefined;
-  installNewChat(["claude-fable-5", "claude-sonnet-4-6"], "claude-fable-5");
+  installNewChat(["claude-fable-5-1", "claude-sonnet-4-6"], "claude-fable-5-1");
   context.mocks.api(
     userModelPreferenceContract.update,
     async ({ body, respond }) => {
@@ -318,7 +318,7 @@ test("Temporarily choose a model for a new chat", async () => {
   });
 
   await readyComposer();
-  await chooseModel(user, "Claude Fable 5", /^Claude Sonnet 4\.6/iu);
+  await chooseModel(user, "Claude Fable 5.1", /^Claude Sonnet 4\.6/iu);
   expect(update).toBeUndefined();
   const scopeCard = await screen.findByRole("group", {
     name: "Model for this chat",
@@ -352,19 +352,19 @@ test("Keep the model picker stable while settings refresh", async () => {
   const user = userEvent.setup({ delay: null });
   const refreshGate = createDeferredPromise<void>(context.signal);
   let preferenceRequestCount = 0;
-  installNewChat(["claude-fable-5", "claude-sonnet-4-6"], "claude-fable-5");
+  installNewChat(["claude-fable-5-1", "claude-sonnet-4-6"], "claude-fable-5-1");
   context.mocks.api(userModelPreferenceContract.get, async ({ respond }) => {
     preferenceRequestCount += 1;
     if (preferenceRequestCount > 1) {
       await refreshGate.promise;
     }
-    return respond(200, preference("claude-fable-5"));
+    return respond(200, preference("claude-fable-5-1"));
   });
 
   await setupPage({ context, path: NEW_CHAT_PATH });
 
   await readyComposer();
-  await user.click(await modelPicker("Claude Fable 5"));
+  await user.click(await modelPicker("Claude Fable 5.1"));
   await expect(
     screen.findByRole("option", { name: /^Claude Sonnet 4\.6/iu }),
   ).resolves.toBeVisible();
@@ -376,7 +376,7 @@ test("Keep the model picker stable while settings refresh", async () => {
   expect(
     screen.getByRole("option", { name: /^Claude Sonnet 4\.6/iu }),
   ).toBeVisible();
-  await expect(modelPicker("Claude Fable 5")).resolves.toHaveAttribute(
+  await expect(modelPicker("Claude Fable 5.1")).resolves.toHaveAttribute(
     "aria-expanded",
     "true",
   );
@@ -387,18 +387,18 @@ test("Keep the model picker stable while settings refresh", async () => {
       screen.getByRole("option", { name: /^Claude Sonnet 4\.6/iu }),
     ).toBeVisible();
     expect(
-      screen.getByRole("combobox", { name: "Claude Fable 5" }),
+      screen.getByRole("combobox", { name: "Claude Fable 5.1" }),
     ).toHaveAttribute("aria-expanded", "true");
   });
 });
 
 test("Follow model preference changes made in another session", async () => {
-  installNewChat(["claude-fable-5", "claude-opus-4-8"], "claude-fable-5");
+  installNewChat(["claude-fable-5-1", "claude-opus-4-8"], "claude-fable-5-1");
 
   await setupPage({ context, path: NEW_CHAT_PATH });
 
   await readyComposer();
-  await expect(modelPicker("Claude Fable 5")).resolves.toBeVisible();
+  await expect(modelPicker("Claude Fable 5.1")).resolves.toBeVisible();
 
   context.mocks.data.userModelPreference({
     ...preference("claude-opus-4-8"),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-test-helpers.ts
@@ -155,9 +155,9 @@ export function mockOrgModelRoutes(defaultSelectedModel: string): void {
   context.mocks.data.orgModelPolicies([
     buildModelPolicy({
       id: "00000000-0000-4000-a000-000000000201",
-      model: "claude-fable-5",
-      modelLabel: "Claude Fable 5",
-      isDefault: defaultSelectedModel === "claude-fable-5",
+      model: "claude-fable-5-1",
+      modelLabel: "Claude Fable 5.1",
+      isDefault: defaultSelectedModel === "claude-fable-5-1",
       defaultProviderType: "openrouter-api-key",
       credentialScope: "org",
       modelProviderId: OPENROUTER_PROVIDER_ID,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-video-options.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-video-options.test.tsx
@@ -33,7 +33,7 @@ interface SubmittedMessage {
 
 function installVideoEnvironment(): void {
   const preference: UserModelPreferenceResponse = {
-    selectedModel: "claude-fable-5",
+    selectedModel: "claude-fable-5-1",
     serviceTier: null,
     selectedImageModel: "fal-ai/nano-banana-2",
     selectedVideoModel: "dreamina-seedance-2-0-260128",
@@ -52,7 +52,7 @@ function installVideoEnvironment(): void {
   });
   context.mocks.data.userModelPreference(preference);
   mockAgent();
-  mockOrgModelRoutes("claude-fable-5");
+  mockOrgModelRoutes("claude-fable-5-1");
   mockBillingCapabilities({
     supportByok: true,
     restrictedVm0Models: false,
@@ -203,7 +203,7 @@ test("Submit a video template with its default generation options", async () => 
 
   const prompt = "Generate the first cinematic clip.";
   const editor = await enterText(prompt);
-  await enterVideoMode("Claude Fable 5");
+  await enterVideoMode("Claude Fable 5.1");
   const template = await selectVideoTemplate();
   await expect(
     openVideoOptions("16:9 · 8s · 720p"),
@@ -233,7 +233,7 @@ test("Submit the video ratio selected by the user", async () => {
 
   const prompt = "Generate the portrait cinematic clip.";
   const editor = await enterText(prompt);
-  await enterVideoMode("Claude Fable 5");
+  await enterVideoMode("Claude Fable 5.1");
   const template = await selectVideoTemplate();
   const options = await openVideoOptions("16:9 · 8s · 720p");
   const ratioGroup = screen.getByRole("radiogroup", { name: "Ratio" });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/localization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/localization.test.tsx
@@ -220,7 +220,7 @@ test("A failed language download falls back without blocking chat", async () => 
     return respond(200, storedPreferences);
   });
   chatContext.mocks.data.onboardingStatus({ defaultAgentId: AGENT_ID });
-  mockOrgModelRoutes("claude-fable-5");
+  mockOrgModelRoutes("claude-fable-5-1");
   mockAgent();
   mockChatLifecycle(chatContext);
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/org-providers-tab.test.tsx
@@ -915,8 +915,8 @@ test("Offer an upgrade for restricted Pro models", async () => {
   context.mocks.data.orgModelPolicies([
     builtInPolicy(
       "00000000-0000-4000-a000-000000000221",
-      "claude-fable-5",
-      "Claude Fable 5",
+      "claude-fable-5-1",
+      "Claude Fable 5.1",
       false,
     ),
     builtInPolicy(

--- a/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/org-manage/org-model-policies-section.tsx
@@ -43,7 +43,7 @@ import {
 } from "@okouai/ui";
 import {
   MODEL_PROVIDER_TYPES,
-  SUPPORTED_RUN_MODELS,
+  ACTIVE_RUN_MODELS,
   getCanonicalModelDisplayName,
   getProvidersForModel,
   isBuiltInModelProviderType,
@@ -1762,14 +1762,14 @@ export function OrgModelPoliciesSection() {
 
   const policies = data.policies;
   const visiblePolicies = policies.filter((policy) => {
-    return SUPPORTED_RUN_MODELS.includes(policy.model);
+    return ACTIVE_RUN_MODELS.includes(policy.model);
   });
   const configuredModels = new Set(
     policies.map((policy) => {
       return policy.model;
     }),
   );
-  const addableModels = SUPPORTED_RUN_MODELS.filter((model) => {
+  const addableModels = ACTIVE_RUN_MODELS.filter((model) => {
     return isAddableBuiltInModel(model) && !configuredModels.has(model);
   });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -49,6 +49,7 @@ import {
   CODEX_FAST_MODE_MODELS,
   MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS,
   SUPPORTED_RUN_MODELS,
+  ACTIVE_RUN_MODELS,
   VM0_MODEL_PRICE_TIER,
   DEFAULT_ORG_MODEL_POLICY_MODELS,
   MODEL_PROVIDER_FIREWALL_CONFIGS,
@@ -337,7 +338,7 @@ describe("model-first canonical catalog", () => {
     expect(isSupportedRunModel("claude-sonnet-4-6")).toBe(true);
   });
 
-  it("exposes only selectable models in the shared schema catalog", () => {
+  it("keeps historical models readable in the shared schema catalog", () => {
     expect(SUPPORTED_RUN_MODELS).toEqual([
       "claude-fable-5-1",
       "claude-fable-5",
@@ -366,20 +367,6 @@ describe("model-first canonical catalog", () => {
       "vercel-ai-gateway",
     ]);
     expect(getProvidersForModel("anthropic/claude-fable-5.1")).toEqual([
-      "built-in",
-      "claude-code-oauth-token",
-      "anthropic-api-key",
-      "openrouter-api-key",
-      "vercel-ai-gateway",
-    ]);
-    expect(getProvidersForModel("claude-fable-5")).toEqual([
-      "built-in",
-      "claude-code-oauth-token",
-      "anthropic-api-key",
-      "openrouter-api-key",
-      "vercel-ai-gateway",
-    ]);
-    expect(getProvidersForModel("anthropic/claude-fable-5")).toEqual([
       "built-in",
       "claude-code-oauth-token",
       "anthropic-api-key",
@@ -641,7 +628,7 @@ describe("model-first canonical catalog", () => {
     },
   );
 
-  it("defines two statically compilable built-in model routes for every model", () => {
+  it("defines two statically compilable built-in model routes for every active model", () => {
     expect(Object.keys(VM0_MODEL_TO_PROVIDER)).toEqual([
       "claude-fable-5-1",
       "claude-fable-5",
@@ -664,7 +651,7 @@ describe("model-first canonical catalog", () => {
       "openai",
     ]);
 
-    for (const model of SUPPORTED_RUN_MODELS) {
+    for (const model of ACTIVE_RUN_MODELS) {
       const candidates = getVm0BuiltInModelRouteCandidates(model);
       expect(candidates).toHaveLength(2);
       expect(candidates[0]?.providerType).toBe(
@@ -871,7 +858,6 @@ describe("model selection for Anthropic-native providers", () => {
     (type) => {
       const models = getModels(type);
       expect(models).toContain("claude-fable-5-1");
-      expect(models).toContain("claude-fable-5");
       expect(models).toContain("claude-opus-5");
       expect(models).toContain("claude-sonnet-5");
       expect(models).toContain("claude-sonnet-4-6");
@@ -910,7 +896,6 @@ describe("model selection for Claude-compatible gateway providers", () => {
   it("openrouter-api-key exposes current Claude models", () => {
     expect(getModels("openrouter-api-key")).toEqual([
       "anthropic/claude-fable-5.1",
-      "anthropic/claude-fable-5",
       "anthropic/claude-opus-5",
       "anthropic/claude-opus-4.8",
       "anthropic/claude-sonnet-5",
@@ -929,13 +914,6 @@ describe("model selection for Claude-compatible gateway providers", () => {
       ).toBe(true);
       expect(getProviderRuntimeModel(type, "claude-fable-5-1")).toBe(
         "anthropic/claude-fable-5.1",
-      );
-      expect(getModels(type)).toContain("anthropic/claude-fable-5");
-      expect(isModelSupportedByProvider("anthropic/claude-fable-5", type)).toBe(
-        true,
-      );
-      expect(getProviderRuntimeModel(type, "claude-fable-5")).toBe(
-        "anthropic/claude-fable-5",
       );
       expect(getModels(type)).toContain("anthropic/claude-opus-5");
       expect(isModelSupportedByProvider("anthropic/claude-opus-5", type)).toBe(
@@ -962,7 +940,7 @@ describe("model selection for Claude-compatible gateway providers", () => {
 describe("getVm0VisibleModels", () => {
   it("returns only active VM0 built-in models", () => {
     const models = getVm0VisibleModels();
-    expect(models).toEqual(SUPPORTED_RUN_MODELS);
+    expect(models).toEqual(ACTIVE_RUN_MODELS);
     expect(models).toContain("gpt-5.5");
     expect(models).toContain("claude-sonnet-4-6");
     expect(models).not.toContain("kimi-k3");

--- a/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
@@ -7,6 +7,7 @@
 // Ordered by model family (claude → gpt → deepseek), and within each family
 // from newest/highest capability to oldest/lowest. This order is load-bearing:
 // it drives the model dropdown and all model-related UI via sortRowsByCatalog.
+// Recognized wire and historical IDs. Use ACTIVE_RUN_MODELS for model selection.
 export const SUPPORTED_RUN_MODELS = [
   "claude-fable-5-1",
   "claude-fable-5",

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -178,6 +178,30 @@ const SUPPORTED_RUN_MODEL_SET: ReadonlySet<string> = new Set(
   SUPPORTED_RUN_MODELS,
 );
 
+// Historical IDs remain in the wire schemas and billing catalog. Availability
+// is a separate product decision, including for provider-prefixed aliases.
+export const RETIRED_RUN_MODEL_MESSAGE =
+  "Claude Fable 5 has been retired. Select Claude Fable 5.1.";
+
+export function getRunModelAccess(
+  model: string | null | undefined,
+  restrictedBuiltInModels = false,
+): "allowed" | "pro_required" | "retired" {
+  const canonical = normalizeVm0ModelId(model?.trim().toLowerCase() ?? "");
+  if (canonical === "claude-fable-5") {
+    return "retired";
+  }
+  return restrictedBuiltInModels && isLimitedFree1RestrictedRunModel(model)
+    ? "pro_required"
+    : "allowed";
+}
+
+export function isActiveRunModel(
+  model: string | null | undefined,
+): model is SupportedRunModel {
+  return isSupportedRunModel(model) && getRunModelAccess(model) === "allowed";
+}
+
 export function isSupportedRunModel(
   model: string | null | undefined,
 ): model is SupportedRunModel {
@@ -476,6 +500,11 @@ export function isLimitedFree1RestrictedRunModel(
   return !LIMITED_FREE1_ALLOWED_RUN_MODELS.has(unprefixedModel);
 }
 
+export const ACTIVE_RUN_MODELS: readonly SupportedRunModel[] =
+  SUPPORTED_RUN_MODELS.filter((model) => {
+    return getRunModelAccess(model) === "allowed";
+  });
+
 export type ModelImageInputSupport = "supported" | "unsupported" | "unknown";
 
 const IMAGE_INPUT_SUPPORTED_MODELS = new Set([
@@ -535,7 +564,7 @@ export function modelSupportsImageInput(
  * Return the VM0 built-in models visible to callers.
  */
 export function getVm0VisibleModels(): string[] {
-  return [...SUPPORTED_RUN_MODELS];
+  return [...ACTIVE_RUN_MODELS];
 }
 
 /**
@@ -555,7 +584,7 @@ export function getVm0VisibleModels(): string[] {
 const BUILT_IN_MODEL_PROVIDER_CONFIG = {
   framework: "claude-code" as const,
   label: "Built-in model",
-  models: Object.keys(VM0_MODEL_TO_PROVIDER) as string[],
+  models: [...ACTIVE_RUN_MODELS],
   defaultModel: DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
 };
 
@@ -573,7 +602,6 @@ export const MODEL_PROVIDER_TYPES = {
     } satisfies ModelProviderEnvBindings,
     models: [
       "claude-fable-5-1",
-      "claude-fable-5",
       "claude-opus-5",
       "claude-sonnet-5",
       "claude-sonnet-4-6",
@@ -594,7 +622,6 @@ export const MODEL_PROVIDER_TYPES = {
     } satisfies ModelProviderEnvBindings,
     models: [
       "claude-fable-5-1",
-      "claude-fable-5",
       "claude-opus-5",
       "claude-sonnet-5",
       "claude-sonnet-4-6",
@@ -620,7 +647,6 @@ export const MODEL_PROVIDER_TYPES = {
     } satisfies ModelProviderEnvBindings,
     models: [
       "anthropic/claude-fable-5.1",
-      "anthropic/claude-fable-5",
       "anthropic/claude-opus-5",
       "anthropic/claude-opus-4.8",
       "anthropic/claude-sonnet-5",
@@ -662,7 +688,6 @@ export const MODEL_PROVIDER_TYPES = {
     } satisfies ModelProviderEnvBindings,
     models: [
       "anthropic/claude-fable-5.1",
-      "anthropic/claude-fable-5",
       "anthropic/claude-opus-5",
       "anthropic/claude-opus-4.8",
       "anthropic/claude-sonnet-5",
@@ -1073,7 +1098,7 @@ export function normalizeRunModelId(model: string): string {
 
 export function getProvidersForModel(model: string): ModelProviderType[] {
   const canonical = normalizeRunModelId(model);
-  if (!isSupportedRunModel(canonical)) {
+  if (!isActiveRunModel(canonical)) {
     return [];
   }
   return [...MODEL_FIRST_PROVIDER_COMPATIBILITY[canonical]];
@@ -1511,7 +1536,15 @@ export const upsertModelProviderRequestSchema = z.object({
   secret: z.string().min(1).optional(), // Legacy single secret
   authMethod: z.string().optional(), // For multi-auth providers
   secrets: z.record(z.string(), z.string()).optional(), // For multi-auth providers
-  selectedModel: z.string().optional(),
+  selectedModel: z
+    .string()
+    .refine(
+      (model) => {
+        return getRunModelAccess(model) !== "retired";
+      },
+      { message: RETIRED_RUN_MODEL_MESSAGE },
+    )
+    .optional(),
 });
 
 export type UpsertModelProviderRequest = z.infer<


### PR DESCRIPTION
## Summary

Claude Fable 5 remained selectable after the Fable 5.1 launch. Remove it from active model catalogs and provider settings, and reject new policy, preference, thread-selection and run-admission requests with a clear retirement error. Recheck queued runs at dispatch, including provider-prefixed model IDs.

Keep historical model IDs, display names and runtime metadata readable so existing run records and already-running work remain compatible. Update the existing picker and runtime-route fixtures to use Fable 5.1.

## Data cutover

This PR contains no database migration. The separately supplied [operator SQL](https://a.okou.io/267dez6r71.sql) adds missing Fable 5.1 policies, preserves existing successor routes, transfers Fable 5 organization/member defaults, replaces current thread selections and appends ordered thread events, then removes the old policies in one transaction. Apply the SQL before rolling out retirement to preserve the requested default-model transfers. It has not been executed in production.

No new lazy replacement fallback is introduced. Historical recognition remains supported; existing invalid-selection/default reconciliation is unchanged. Current Free plan restrictions remain in force.

## Verification

- API contracts lint, API lint, platform lint, Knip and formatting passed.
- Repository type checks: all 15 tasks passed.
- Model-provider contracts: 178 tests passed.
- Policy and thread-selection API tests: 47 tests passed.
- Runtime route API tests: 26 tests passed.
- Queued retirement integration tests: 2 tests passed, covering canonical and provider-prefixed IDs.
- Affected platform tests: 54 tests passed; one cold-start timeout passed when rerun alone after the other checks finished.
- Standalone SQL tested against a local database with current repository migrations: missing/existing successor routes, default transfers, member/thread aliases, event ordering and sequence cursors, service-tier cleanup, historical record preservation, repeat execution and atomic rollback on an invalid route.
- Full local Vitest and local dev servers were not run; broader coverage is left to the PR pipeline.
