### PR TITLE
fix(app): unify chat response layout and status lifecycle

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-event-state.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event-state.ts
@@ -3,6 +3,7 @@ import {
   foldChatRunStates,
   isBrowserLifecycleEventType,
   isChatGoalMarkerEventType,
+  isChatInputEventType,
   isChatRunTerminalEventType,
   revokedChatEventIds,
   terminatedChatRunIds,
@@ -91,6 +92,7 @@ export function isInterruptedAssistantCancellation(
 export interface SemanticChatEventState {
   readonly event: ChatEvent;
   readonly isQueued: boolean;
+  readonly inputCreatedAt?: string;
 }
 
 type QueuedChatEvent = Extract<
@@ -173,6 +175,18 @@ export function semanticChatEventsFromChatEvents(
     }),
   );
 
+  // Resolve submission times before hiding replaced inputs. Delivery appends a
+  // new event, but does not start another user-facing work interval.
+  const inputCreatedAtById = new Map<string, string>();
+  for (const event of events) {
+    if (isChatInputEventType(event.eventType)) {
+      const previousCreatedAt = event.revokesEventId
+        ? inputCreatedAtById.get(event.revokesEventId)
+        : undefined;
+      inputCreatedAtById.set(event.id, previousCreatedAt ?? event.createdAt);
+    }
+  }
+
   return events.flatMap((event): SemanticChatEventState[] => {
     if (
       isHiddenSemanticChatEvent(event, {
@@ -204,7 +218,9 @@ export function semanticChatEventsFromChatEvents(
       isUnassociatedUser &&
       optimisticAssociation !== "run" &&
       event.eventType === "input.automation";
-    return [{ event, isQueued }];
+    return [
+      { event, isQueued, inputCreatedAt: inputCreatedAtById.get(event.id) },
+    ];
   });
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-event.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-event.ts
@@ -122,6 +122,8 @@ export type EnrichedChatEvent = ChatEvent & {
   /** The current rich body failed to load and can be retried locally. */
   richContentError: boolean;
   isQueued: boolean;
+  /** The user's submission time, preserved across delivery replacement events. */
+  inputCreatedAt?: string;
   userMessageRenderDocument: UserMessageRenderDocument | undefined;
 };
 

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1331,12 +1331,14 @@ function enrichedChatEventsFromSemantic(
   entries: readonly SemanticChatEvent[],
 ): EnrichedChatEvent[] {
   return entries.map((entry) => {
-    const { event, isQueued, userMessageRenderDocument } = entry;
+    const { event, isQueued, inputCreatedAt, userMessageRenderDocument } =
+      entry;
     return {
       ...event,
       tree: entry.tree,
       richContentError: entry.richContentError,
       isQueued,
+      inputCreatedAt,
       userMessageRenderDocument,
     };
   });

--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -41,6 +41,7 @@ export interface RunWorkSection {
   readonly collapsible: boolean;
   readonly hiddenGroups: ChatEventGroup[];
   readonly hiddenGroupsAfterAnchor: ChatEventGroup[];
+  readonly previewMessages: readonly EnrichedChatEvent[];
   readonly remainingArtifactCards: readonly RunWorkArtifactCard[];
   readonly startTime: number;
   readonly endTime?: number;
@@ -54,6 +55,12 @@ type RunWorkArtifactCard = Extract<
 export interface RunWorkFolding {
   readonly visibleGroups: ChatEventGroup[];
   readonly sectionsByAnchorEventId: Map<string, RunWorkSection>;
+  readonly statusTail: RunWorkStatusTail | null;
+}
+
+interface RunWorkStatusTail {
+  readonly anchorEventId: string | undefined;
+  readonly events: readonly EnrichedChatEvent[];
 }
 
 function chatEventDisplayError(event: ChatEvent): string | undefined {
@@ -549,6 +556,7 @@ function lastEventMatching(
 interface RunWorkPhaseFolding {
   readonly visibleEvents: readonly EnrichedChatEvent[];
   readonly section: RunWorkSection | null;
+  readonly statusTail: RunWorkStatusTail;
 }
 
 interface RunWorkPhaseIdentity {
@@ -566,17 +574,34 @@ function foldRunWorkPhase(
 ): RunWorkPhaseFolding {
   const outputMessages = events.filter(isRunWorkMessage);
   const anchorEvent = outputMessages.at(-1);
+  const anchorIndex =
+    anchorEvent === undefined ? -1 : events.indexOf(anchorEvent);
+  const latestRunId = latestRunIdForEvents(events);
+  const trailingStatusEvents = events.slice(anchorIndex + 1).filter((event) => {
+    return (
+      isRenderableAssistantEvent(event) && Boolean(chatEventDisplayError(event))
+    );
+  });
+  const statusTail = {
+    anchorEventId: anchorEvent?.id,
+    events: trailingStatusEvents.filter((event) => {
+      return event.runId === latestRunId;
+    }),
+  };
   const startTime = firstEventTime(events);
   if (anchorEvent === undefined || startTime === null) {
     return {
       visibleEvents: events.filter((event) => {
-        return !hiddenUserEventIds.has(event.id);
+        return (
+          !hiddenUserEventIds.has(event.id) &&
+          !trailingStatusEvents.includes(event)
+        );
       }),
       section: null,
+      statusTail,
     };
   }
 
-  const anchorIndex = events.indexOf(anchorEvent);
   const hiddenEvents = events.slice(0, anchorIndex).filter((event) => {
     return (
       isRunWorkAssistantOutput(event) ||
@@ -588,25 +613,13 @@ function foldRunWorkPhase(
     .filter((event) => {
       return hiddenUserEventIds.has(event.id) && foldedEventIds.has(event.id);
     });
-  const hiddenEventIds = new Set(
-    [...hiddenEvents, ...hiddenEventsAfterAnchor].map((event) => {
-      return event.id;
-    }),
-  );
-  const trailingStatusEvents = events.slice(anchorIndex + 1).filter((event) => {
-    return (
-      !hiddenEventIds.has(event.id) &&
-      !hiddenUserEventIds.has(event.id) &&
-      isRenderableAssistantEvent(event) &&
-      !isRunWorkMessage(event)
-    );
-  });
   const userEvents = events.filter((event) => {
     return visibleRunWorkUserEvent(event, hiddenUserEventIds);
   });
 
   return {
-    visibleEvents: [...userEvents, anchorEvent, ...trailingStatusEvents],
+    visibleEvents: [...userEvents, anchorEvent],
+    statusTail,
     section: {
       key: `${identity.key}:${events[0]!.id}`,
       runGroupId: identity.runGroupId,
@@ -615,6 +628,7 @@ function foldRunWorkPhase(
       collapsible: outputMessages.length > 1,
       hiddenGroups: groupEventsByRole(hiddenEvents),
       hiddenGroupsAfterAnchor: groupEventsByRole(hiddenEventsAfterAnchor),
+      previewMessages: outputMessages.slice(-4, -1),
       remainingArtifactCards: remainingArtifactCards(outputMessages),
       startTime,
       ...(endTime === undefined ? {} : { endTime }),
@@ -677,25 +691,17 @@ function phaseEndTime(
 export function buildRunWorkFolding(
   groups: readonly ChatEventGroup[],
   foldedEventIds: ReadonlySet<string> = new Set(),
-): RunWorkFolding | null {
+): RunWorkFolding {
   const usageByRunId = usageByRunIdFromGroups(groups);
   const events = groups.flatMap((group) => {
     return group.events;
   });
   const visibleEvents: EnrichedChatEvent[] = [];
   const sections: RunWorkSection[] = [];
+  let statusTail: RunWorkStatusTail | null = null;
   const usageByAnchorEventId = new Map<string, ChatEventUsagePayload>();
 
   for (const unit of runWorkUnits(events)) {
-    if (unit.key === undefined) {
-      visibleEvents.push(
-        ...unit.events.filter((event) => {
-          return !unit.hiddenUserEventIds.has(event.id);
-        }),
-      );
-      continue;
-    }
-
     const terminalEvent = terminalEventForLatestRun(unit.events);
     const phases = splitRunWorkEventsAtUsers(
       unit.events,
@@ -705,7 +711,7 @@ export function buildRunWorkFolding(
     for (const [phaseIndex, phase] of phases.entries()) {
       const phaseFolding = foldRunWorkPhase(
         {
-          key: unit.key,
+          key: unit.key ?? phase[0]!.id,
           runGroupId: unit.runGroupId,
           runIds: unit.runIds,
         },
@@ -715,6 +721,20 @@ export function buildRunWorkFolding(
         foldedEventIds,
       );
       visibleEvents.push(...phaseFolding.visibleEvents);
+      // Phases include pending user inputs without a run or output. The latest
+      // response therefore owns the tail before its first main result exists.
+      // An isolated bookkeeping marker does not start another response.
+      if (
+        phase.some((event) => {
+          return (
+            isChatInputEventType(event.eventType) ||
+            isRenderableAssistantEvent(event) ||
+            event.eventType === "output.thinking"
+          );
+        })
+      ) {
+        statusTail = phaseFolding.statusTail;
+      }
       if (phaseFolding.section !== null) {
         sections.push(phaseFolding.section);
       }
@@ -728,9 +748,8 @@ export function buildRunWorkFolding(
     }
   }
 
-  if (sections.length === 0) {
-    return null;
-  }
+  // Historical errors stay in the source events; only the latest tail is rendered.
+  visibleEvents.push(...(statusTail?.events ?? []));
 
   const workAnchorEventIds = new Set(
     sections.map((section) => {
@@ -738,6 +757,7 @@ export function buildRunWorkFolding(
     }),
   );
   return {
+    statusTail,
     visibleGroups: attachUsageToRunWorkGroups(
       groupEventsForRunWorkDisplay(visibleEvents, workAnchorEventIds),
       usageByRunId,

--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -516,23 +516,13 @@ function eventTime(event: EnrichedChatEvent | undefined): number | null {
   if (event === undefined) {
     return null;
   }
-  const timestamp = Date.parse(event.createdAt);
+  const timestamp = Date.parse(event.inputCreatedAt ?? event.createdAt);
   return Number.isNaN(timestamp) ? null : timestamp;
 }
 
 function firstEventTime(events: readonly EnrichedChatEvent[]): number | null {
   for (const event of events) {
     const timestamp = eventTime(event);
-    if (timestamp !== null) {
-      return timestamp;
-    }
-  }
-  return null;
-}
-
-function lastEventTime(events: readonly EnrichedChatEvent[]): number | null {
-  for (let index = events.length - 1; index >= 0; index--) {
-    const timestamp = eventTime(events[index]);
     if (timestamp !== null) {
       return timestamp;
     }
@@ -553,25 +543,26 @@ function lastEventMatching(
   return undefined;
 }
 
-interface RunWorkPhaseFolding {
+interface RunWorkGroupFolding {
   readonly visibleEvents: readonly EnrichedChatEvent[];
   readonly section: RunWorkSection | null;
   readonly statusTail: RunWorkStatusTail;
 }
 
-interface RunWorkPhaseIdentity {
-  readonly key: string;
-  readonly runGroupId: string | undefined;
-  readonly runIds: readonly string[];
+// A work group is bounded by visible user inputs, independently of execution:
+// one run can span several groups, and goal continuations can span several runs.
+interface RunWorkGroup {
+  readonly unit: RunWorkUnit;
+  readonly events: readonly EnrichedChatEvent[];
+  readonly endTime: number | undefined;
 }
 
-function foldRunWorkPhase(
-  identity: RunWorkPhaseIdentity,
-  events: readonly EnrichedChatEvent[],
-  endTime: number | undefined,
-  hiddenUserEventIds: ReadonlySet<string>,
+function foldRunWorkGroup(
+  group: RunWorkGroup,
   foldedEventIds: ReadonlySet<string>,
-): RunWorkPhaseFolding {
+): RunWorkGroupFolding {
+  const { unit, events, endTime } = group;
+  const { hiddenUserEventIds } = unit;
   const outputMessages = events.filter(isRunWorkMessage);
   const anchorEvent = outputMessages.at(-1);
   const anchorIndex =
@@ -621,9 +612,9 @@ function foldRunWorkPhase(
     visibleEvents: [...userEvents, anchorEvent],
     statusTail,
     section: {
-      key: `${identity.key}:${events[0]!.id}`,
-      runGroupId: identity.runGroupId,
-      runIds: identity.runIds,
+      key: `${unit.key ?? events[0]!.id}:${events[0]!.id}`,
+      runGroupId: unit.runGroupId,
+      runIds: unit.runIds,
       anchorEventId: anchorEvent.id,
       collapsible: outputMessages.length > 1,
       hiddenGroups: groupEventsByRole(hiddenEvents),
@@ -674,18 +665,36 @@ function mergedUsageForRunIds(
   );
 }
 
-function phaseEndTime(
-  phase: readonly EnrichedChatEvent[],
-  isFinalPhase: boolean,
-  terminalEvent: EnrichedChatEvent | undefined,
-): number | undefined {
-  if (!isFinalPhase) {
-    return lastEventTime(phase) ?? undefined;
+function runWorkGroups(events: readonly EnrichedChatEvent[]): RunWorkGroup[] {
+  const groups = runWorkUnits(events).flatMap((unit) => {
+    return splitRunWorkEventsAtUsers(unit.events, unit.hiddenUserEventIds).map(
+      (events) => {
+        return { unit, events };
+      },
+    );
+  });
+  const workGroups: RunWorkGroup[] = [];
+  let nextInputTime: number | undefined;
+  for (let index = groups.length - 1; index >= 0; index--) {
+    const group = groups[index]!;
+    const terminalTime =
+      eventTime(terminalEventForLatestRun(group.events)) ?? undefined;
+    const endTime =
+      terminalTime === undefined
+        ? nextInputTime
+        : nextInputTime === undefined
+          ? terminalTime
+          : Math.min(terminalTime, nextInputTime);
+    workGroups.push({ ...group, endTime });
+
+    const input = group.events.find((event) => {
+      return visibleRunWorkUserEvent(event, group.unit.hiddenUserEventIds);
+    });
+    if (input !== undefined) {
+      nextInputTime = eventTime(input) ?? undefined;
+    }
   }
-  if (terminalEvent === undefined) {
-    return undefined;
-  }
-  return eventTime(terminalEvent) ?? lastEventTime(phase) ?? undefined;
+  return workGroups.reverse();
 }
 
 export function buildRunWorkFolding(
@@ -700,49 +709,33 @@ export function buildRunWorkFolding(
   const sections: RunWorkSection[] = [];
   let statusTail: RunWorkStatusTail | null = null;
   const usageByAnchorEventId = new Map<string, ChatEventUsagePayload>();
+  const finalSectionByUnit = new Map<RunWorkUnit, RunWorkSection>();
 
-  for (const unit of runWorkUnits(events)) {
-    const terminalEvent = terminalEventForLatestRun(unit.events);
-    const phases = splitRunWorkEventsAtUsers(
-      unit.events,
-      unit.hiddenUserEventIds,
-    );
-    const firstSectionIndex = sections.length;
-    for (const [phaseIndex, phase] of phases.entries()) {
-      const phaseFolding = foldRunWorkPhase(
-        {
-          key: unit.key ?? phase[0]!.id,
-          runGroupId: unit.runGroupId,
-          runIds: unit.runIds,
-        },
-        phase,
-        phaseEndTime(phase, phaseIndex === phases.length - 1, terminalEvent),
-        unit.hiddenUserEventIds,
-        foldedEventIds,
-      );
-      visibleEvents.push(...phaseFolding.visibleEvents);
-      // Phases include pending user inputs without a run or output. The latest
-      // response therefore owns the tail before its first main result exists.
-      // An isolated bookkeeping marker does not start another response.
-      if (
-        phase.some((event) => {
-          return (
-            isChatInputEventType(event.eventType) ||
-            isRenderableAssistantEvent(event) ||
-            event.eventType === "output.thinking"
-          );
-        })
-      ) {
-        statusTail = phaseFolding.statusTail;
-      }
-      if (phaseFolding.section !== null) {
-        sections.push(phaseFolding.section);
-      }
+  for (const group of runWorkGroups(events)) {
+    const folding = foldRunWorkGroup(group, foldedEventIds);
+    visibleEvents.push(...folding.visibleEvents);
+    // Work groups exist before their first output, so a pending input retires
+    // the previous tail immediately. Bookkeeping alone does not start a group.
+    if (
+      group.events.some((event) => {
+        return (
+          isChatInputEventType(event.eventType) ||
+          isRenderableAssistantEvent(event) ||
+          event.eventType === "output.thinking"
+        );
+      })
+    ) {
+      statusTail = folding.statusTail;
     }
-    if (unit.runGroupId !== undefined && sections.length > firstSectionIndex) {
+    if (folding.section !== null) {
+      sections.push(folding.section);
+      finalSectionByUnit.set(group.unit, folding.section);
+    }
+  }
+  for (const [unit, finalSection] of finalSectionByUnit) {
+    if (unit.runGroupId !== undefined) {
       const mergedUsage = mergedUsageForRunIds(unit.runIds, usageByRunId);
-      const finalSection = sections[sections.length - 1];
-      if (mergedUsage !== undefined && finalSection !== undefined) {
+      if (mergedUsage !== undefined) {
         usageByAnchorEventId.set(finalSection.anchorEventId, mergedUsage);
       }
     }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-run-history.test.tsx
@@ -13,7 +13,10 @@ import {
   readyChat,
   RUN_PATH,
 } from "./chat-capability-test-helpers.ts";
-import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
+import {
+  queryMessageBody,
+  type MockChatEventInput,
+} from "./chat-event-test-helpers.ts";
 import {
   installRunChat,
   publishRunUpdate,
@@ -187,9 +190,9 @@ test("Project all workflow run outputs through one run-group history", async () 
   });
 
   await readyChat();
-  expect(screen.queryByText("Earlier workflow evidence 1")).toBeNull();
-  expect(screen.queryByText("Earlier workflow result 1")).toBeNull();
-  expect(screen.queryByText("Earlier workflow evidence 2")).toBeNull();
+  expect(queryMessageBody("Earlier workflow evidence 1")).toBeNull();
+  expect(queryMessageBody("Earlier workflow result 1")).toBeNull();
+  expect(queryMessageBody("Earlier workflow evidence 2")).toBeNull();
   const main = screen.getByText("Earlier workflow result 2");
   expect(main).toBeVisible();
   expect(queryButton("Expand grouped run history")).toBeNull();
@@ -227,7 +230,7 @@ test("Project all workflow run outputs through one run-group history", async () 
 
   click(await findButton("Collapse work history"));
   await waitFor(() => {
-    expect(screen.queryByText("Earlier workflow result 1")).toBeNull();
+    expect(queryMessageBody("Earlier workflow result 1")).toBeNull();
   });
   events.push(
     assistantOutput({
@@ -244,7 +247,7 @@ test("Project all workflow run outputs through one run-group history", async () 
 
   const currentMain = await screen.findByText("Current workflow result");
   expect(currentMain).toBeVisible();
-  expect(screen.queryByText("Earlier workflow result 2")).toBeNull();
+  expect(queryMessageBody("Earlier workflow result 2")).toBeNull();
   expect(currentMain.closest('[data-role="assistant"]')).toBe(assistantGroup);
   expect(queryButton("Expand grouped run history")).toBeNull();
   await expect(findButton("Expand work history")).resolves.toBeVisible();
@@ -438,7 +441,7 @@ test("Keep the prior goal result as main while the next run has no output", asyn
     "The current launch evidence is ready.",
   );
   expect(
-    screen.queryByText("The earlier launch evidence is complete."),
+    queryMessageBody("The earlier launch evidence is complete."),
   ).toBeNull();
   const currentFold = await findButton("Expand work history");
   const answeringAssistant = answer.closest<HTMLElement>(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
@@ -4,7 +4,10 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { expect, test } from "vitest";
 
 import { queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
-import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
+import {
+  queryMessageBody,
+  type MockChatEventInput,
+} from "./chat-event-test-helpers.ts";
 import {
   context,
   mockChatLifecycleWithoutBrowserSession,
@@ -494,7 +497,7 @@ test("The conversation locator follows folded goal continuation work", async () 
 
   await screen.findByText("All deployment regions are healthy");
   expect(
-    screen.queryByText("Checked the first deployment region"),
+    queryMessageBody("Checked the first deployment region"),
   ).not.toBeInTheDocument();
   expect(
     screen.queryByText("Keep checking the deployment regions"),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-engagement-telemetry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-engagement-telemetry.test.tsx
@@ -1,3 +1,4 @@
+import { queryMessageBody } from "./chat-event-test-helpers.ts";
 import { screen, waitFor } from "@testing-library/react";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -98,7 +99,7 @@ describe("chat engagement telemetry", () => {
       return buttonByLabel("Expand work history");
     });
     expect(expandWork).toHaveTextContent(/^Working for /);
-    expect(screen.queryByText("Checking the launch brief.")).toBeNull();
+    expect(queryMessageBody("Checking the launch brief.")).toBeNull();
 
     click(expandWork);
 
@@ -112,7 +113,7 @@ describe("chat engagement telemetry", () => {
     click(buttonByLabel("Collapse work history"));
 
     await waitFor(() => {
-      expect(screen.queryByText("Checking the launch brief.")).toBeNull();
+      expect(queryMessageBody("Checking the launch brief.")).toBeNull();
     });
     expect(capturedEvents("chat_work_history_expanded")).toHaveLength(1);
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-event-test-helpers.ts
@@ -1,3 +1,4 @@
+import { screen } from "@testing-library/react";
 import {
   chatEventSchema,
   serializeChatFollowupsContent,
@@ -437,4 +438,13 @@ export function mockChatEventRows(
       createdAt: event.createdAt,
     });
   });
+}
+
+/** A collapsed preview is visible text, but does not mount the message body. */
+export function queryMessageBody(text: string | RegExp): HTMLElement | null {
+  return (
+    screen.queryAllByText(text).find((element) => {
+      return element.closest("[data-chat-run-work-preview]") === null;
+    }) ?? null
+  );
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
@@ -36,7 +36,7 @@ test("Cached conversations appear before remote synchronization", async () => {
   await seedChatListCache(1, auth, [cached], [rename]);
   const remote = context.mocks.deferred<void>();
   const agents = context.mocks.deferred<void>();
-  installChatListStream(context, {
+  const { eventsRequested } = installChatListStream(context, {
     caseId: 1,
     snapshot: [cached],
     events: [rename],
@@ -49,6 +49,8 @@ test("Cached conversations appear before remote synchronization", async () => {
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
   });
+  // Catch-up starts after cache hydration; its response remains blocked.
+  await eventsRequested;
 
   await waitFor(() => {
     expect(sidebarThreadTitles()).toStrictEqual(["Latest cached title"]);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
@@ -146,9 +146,11 @@ export function installChatListStream(
   options: ChatListStreamOptions,
 ): {
   readonly setEvents: (events: readonly ChatThreadEvent[]) => void;
+  readonly eventsRequested: Promise<void>;
   readonly eventsServed: Promise<void>;
 } {
   let currentEvents = [...(options.events ?? [])];
+  const eventsRequested = context.mocks.deferred<void>();
   const eventsServed = context.mocks.deferred<void>();
   context.mocks.api(chatThreadsContract.snapshot, async ({ respond }) => {
     await options.remoteGate;
@@ -159,6 +161,9 @@ export function installChatListStream(
     });
   });
   context.mocks.api(chatThreadsContract.events, async ({ query, respond }) => {
+    if (!eventsRequested.settled()) {
+      eventsRequested.resolve();
+    }
     await options.remoteGate;
     const sinceSeqId = query.sinceSeqId ?? 0;
     const events = currentEvents.filter((event) => {
@@ -182,6 +187,7 @@ export function installChatListStream(
     setEvents(events) {
       currentEvents = [...events];
     },
+    eventsRequested: eventsRequested.promise,
     eventsServed: eventsServed.promise,
   };
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-goal-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-goal-history.test.tsx
@@ -4,7 +4,10 @@ import { expect, test } from "vitest";
 
 import { click, queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import { setupPage } from "./chat-lifecycle-test-helpers.ts";
-import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
+import {
+  queryMessageBody,
+  type MockChatEventInput,
+} from "./chat-event-test-helpers.ts";
 import {
   assistantEvent,
   cancelledEvent,
@@ -189,9 +192,9 @@ test("Review goal continuations as one work history", async () => {
   expect(screen.getByText("The launch is ready in every region")).toBeVisible();
   expect(screen.getByLabelText("Credit usage 10")).toBeVisible();
   expect(
-    screen.queryByText("Checked the initial launch evidence"),
+    queryMessageBody("Checked the initial launch evidence"),
   ).not.toBeInTheDocument();
-  expect(screen.queryByText("Validated the regional rollout")).toBeNull();
+  expect(queryMessageBody("Validated the regional rollout")).toBeNull();
   expect(screen.queryByText("Keep checking launch readiness")).toBeNull();
   expect(screen.queryByText("Finish checking launch readiness")).toBeNull();
 
@@ -566,13 +569,13 @@ test("Start a fresh work history after interrupting a goal continuation", async 
   await readyChat();
   const workHistories = buttonsNamed("Expand work history");
   expect(workHistories).toHaveLength(2);
-  expect(screen.queryByText("Checked the first rollout logs")).toBeNull();
-  expect(screen.queryByText("Checked the replacement rollout logs")).toBeNull();
+  expect(queryMessageBody("Checked the first rollout logs")).toBeNull();
+  expect(queryMessageBody("Checked the replacement rollout logs")).toBeNull();
 
   click(workHistories[0]!);
 
   await expect(
     screen.findByText("Checked the first rollout logs"),
   ).resolves.toBeVisible();
-  expect(screen.queryByText("Checked the replacement rollout logs")).toBeNull();
+  expect(queryMessageBody("Checked the replacement rollout logs")).toBeNull();
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
@@ -1,0 +1,206 @@
+import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { expect, test } from "vitest";
+import { click } from "../../../__tests__/page-helper.ts";
+import { setupPage } from "./chat-lifecycle-test-helpers.ts";
+import {
+  assistantEvent,
+  cancelledEvent,
+  completedEvent,
+  context,
+  findButton,
+  installRunChat,
+  promptEvent,
+  queryButton,
+  readyChat,
+  RUN_PATH,
+} from "./chat-run-test-fixtures.ts";
+
+const RUN_ID = "a0000000-0000-4000-a000-000000000294";
+
+test.each([
+  { count: 0, expected: [] },
+  { count: 1, expected: [] },
+  { count: 2, expected: ["•Step 1"] },
+  { count: 3, expected: ["•Step 1", "•Step 2"] },
+  { count: 4, expected: ["•Step 1", "•Step 2", "•Step 3"] },
+  { count: 6, expected: ["•Step 3", "•Step 4", "•Step 5"] },
+])(
+  "Preview up to three messages immediately before the main result with $count outputs",
+  async ({ count, expected }) => {
+    installRunChat({
+      activeRunIds: [RUN_ID],
+      chatEvents: [
+        promptEvent({
+          id: "preview-input",
+          runId: RUN_ID,
+          seqId: 1,
+          text: "Check every step",
+        }),
+        ...Array.from({ length: count }, (_, index) => {
+          return assistantEvent({
+            id: `preview-${index}`,
+            runId: RUN_ID,
+            seqId: index + 2,
+            text: `Step ${index + 1}`,
+          });
+        }),
+      ],
+    });
+    await setupPage({
+      context,
+      path: RUN_PATH,
+      featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+    });
+    await readyChat();
+
+    const previews = Array.from(
+      document.querySelectorAll("[data-chat-run-work-preview]"),
+    );
+    expect(
+      previews.map((element) => {
+        return element.textContent;
+      }),
+    ).toStrictEqual(expected);
+    if (count === 0) {
+      return;
+    }
+    const main = screen
+      .getByText(`Step ${count}`)
+      .closest("[data-chat-run-work-main]");
+    if (!main) {
+      throw new Error("Expected the main result container");
+    }
+    expect(queryButton("Copy message", main)).toBeVisible();
+    if (count < 2) {
+      return;
+    }
+    click(await findButton("Expand work history"));
+    await findButton("Collapse work history");
+    expect(document.querySelector("[data-chat-run-work-preview]")).toBeNull();
+    expect(screen.getByText("Step 1")).toBeVisible();
+
+    click(await findButton("Collapse work history"));
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll("[data-chat-run-work-preview]"),
+      ).toHaveLength(expected.length);
+    });
+  },
+);
+
+test("Keep a card-only output in the collapsed history preview", async () => {
+  installRunChat({
+    chatEvents: [
+      promptEvent({
+        id: "action-preview-input",
+        runId: RUN_ID,
+        seqId: 1,
+        text: "Review the available plans",
+      }),
+      assistantEvent({
+        id: "action-preview-card",
+        runId: RUN_ID,
+        seqId: 2,
+        text: "[Compare plans](/?settings=billing&billingView=plans)",
+      }),
+      assistantEvent({
+        id: "action-preview-result",
+        runId: RUN_ID,
+        seqId: 3,
+        text: "The comparison is ready",
+      }),
+      completedEvent({
+        id: "action-preview-complete",
+        runId: RUN_ID,
+        seqId: 4,
+      }),
+    ],
+  });
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+
+  expect(
+    document.querySelector("[data-chat-run-work-preview]"),
+  ).toHaveTextContent("Message");
+  expect(screen.queryByTestId("plan-upgrade-card")).toBeNull();
+
+  click(await findButton("Expand work history"));
+
+  await expect(screen.findByTestId("plan-upgrade-card")).resolves.toBeVisible();
+});
+
+test.each(["completed", "failed", "cancelled"] as const)(
+  "Keep Markdown and media previews after a run is %s",
+  async (status) => {
+    const terminal =
+      status === "completed"
+        ? completedEvent({ id: "preview-terminal", runId: RUN_ID, seqId: 6 })
+        : status === "cancelled"
+          ? cancelledEvent({ id: "preview-terminal", runId: RUN_ID, seqId: 6 })
+          : {
+              id: "preview-terminal",
+              eventType: "run.failed" as const,
+              runId: RUN_ID,
+              seqId: 6,
+              content: null,
+              error: "The request failed",
+              createdAt: "2026-08-01T10:00:06.000Z",
+            };
+    installRunChat({
+      chatEvents: [
+        promptEvent({
+          id: "rich-preview-input",
+          runId: RUN_ID,
+          seqId: 1,
+          text: "Prepare the report",
+        }),
+        ...[
+          "## Review\n\nChecked **dependencies** and `tests`.",
+          "![Dependency chart](https://example.com/dependencies.png)",
+          "https://cdn.vm7.io/artifacts/history-preview/report/report.pdf",
+          "The review is ready",
+        ].map((text, index) => {
+          return assistantEvent({
+            id: `rich-preview-${index}`,
+            runId: RUN_ID,
+            seqId: index + 2,
+            text,
+          });
+        }),
+        terminal,
+      ],
+    });
+    await setupPage({
+      context,
+      path: RUN_PATH,
+      featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+    });
+    await readyChat();
+
+    expect(
+      Array.from(document.querySelectorAll("[data-chat-run-work-preview]")).map(
+        (element) => {
+          return element.textContent;
+        },
+      ),
+    ).toStrictEqual([
+      "•Review Checked dependencies and tests.",
+      "•Dependency chart",
+      "•report.pdf",
+    ]);
+    expect(screen.queryByAltText("Dependency chart")).toBeNull();
+    expect(screen.getByText("The review is ready")).toBeVisible();
+
+    click(await findButton("Expand work history"));
+
+    await expect(
+      screen.findByAltText("Dependency chart"),
+    ).resolves.toBeVisible();
+    expect(document.querySelector("[data-chat-run-work-preview]")).toBeNull();
+  },
+);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
@@ -194,8 +194,12 @@ test("Browse completed work by conversation phase", async () => {
   });
 
   await readyChat();
-  expect(screen.getByText("Worked for 40s")).toBeVisible();
-  expect(screen.getByText("Worked for 1m")).toBeVisible();
+  expect(
+    assistantGroupFor(screen.getByText("Phase one outline")),
+  ).toHaveTextContent("Worked for 1m");
+  expect(
+    assistantGroupFor(screen.getByText("Phase one final plan")),
+  ).toHaveTextContent("Worked for 1m");
   expect(screen.getByText("Worked for 2m")).toBeVisible();
   expect(screen.getByText("Phase one outline")).toBeVisible();
   expect(screen.getByText("Phase one final plan")).toBeVisible();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
@@ -4,7 +4,10 @@ import { expect, test } from "vitest";
 
 import { click, queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import { setupPage } from "./chat-lifecycle-test-helpers.ts";
-import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
+import {
+  queryMessageBody,
+  type MockChatEventInput,
+} from "./chat-event-test-helpers.ts";
 import {
   assistantEvent,
   cancelledEvent,
@@ -197,12 +200,10 @@ test("Browse completed work by conversation phase", async () => {
   expect(screen.getByText("Phase one outline")).toBeVisible();
   expect(screen.getByText("Phase one final plan")).toBeVisible();
   expect(screen.getByText("Phase two final plan")).toBeVisible();
-  expect(screen.queryByText("Collected requirements")).not.toBeInTheDocument();
+  expect(queryMessageBody("Collected requirements")).not.toBeInTheDocument();
+  expect(queryMessageBody("Compared rollback options")).not.toBeInTheDocument();
   expect(
-    screen.queryByText("Compared rollback options"),
-  ).not.toBeInTheDocument();
-  expect(
-    screen.queryByText("Checked launch dependencies"),
+    queryMessageBody("Checked launch dependencies"),
   ).not.toBeInTheDocument();
   const firstExpand = buttonsNamed("Expand work history")[0];
   if (!firstExpand) {
@@ -214,9 +215,7 @@ test("Browse completed work by conversation phase", async () => {
   await expect(
     screen.findByText("Collected requirements"),
   ).resolves.toBeVisible();
-  expect(
-    screen.queryByText("Compared rollback options"),
-  ).not.toBeInTheDocument();
+  expect(queryMessageBody("Compared rollback options")).not.toBeInTheDocument();
   expectTextOrder(
     "Plan phase one",
     "Collected requirements",
@@ -225,14 +224,12 @@ test("Browse completed work by conversation phase", async () => {
     "Phase one final plan",
   );
   expect(
-    screen.queryByText("Checked launch dependencies"),
+    queryMessageBody("Checked launch dependencies"),
   ).not.toBeInTheDocument();
 
   click(await findButton("Collapse work history"));
   await waitFor(() => {
-    expect(
-      screen.queryByText("Collected requirements"),
-    ).not.toBeInTheDocument();
+    expect(queryMessageBody("Collected requirements")).not.toBeInTheDocument();
   });
 
   const secondRunExpand = buttonsNamed("Expand work history").at(-1);
@@ -245,16 +242,14 @@ test("Browse completed work by conversation phase", async () => {
     screen.findByText("Checked launch dependencies"),
   ).resolves.toBeVisible();
   expect(screen.getByLabelText("Credit usage 7")).toBeVisible();
-  expect(screen.queryByText("Collected requirements")).not.toBeInTheDocument();
-  expect(
-    screen.queryByText("Compared rollback options"),
-  ).not.toBeInTheDocument();
+  expect(queryMessageBody("Collected requirements")).not.toBeInTheDocument();
+  expect(queryMessageBody("Compared rollback options")).not.toBeInTheDocument();
 
   click(await findButton("Collapse work history"));
 
   await waitFor(() => {
     expect(
-      screen.queryByText("Checked launch dependencies"),
+      queryMessageBody("Checked launch dependencies"),
     ).not.toBeInTheDocument();
   });
   expect(screen.getByText("Plan phase two")).toBeVisible();
@@ -316,7 +311,7 @@ test.each([
     expect(main).toBeVisible();
 
     for (let index = 0; index < messageCount - 1; index += 1) {
-      expect(screen.queryByText(workMessage(index))).toBeNull();
+      expect(queryMessageBody(workMessage(index))).toBeNull();
     }
     expect(assistantGroupFor(main)).toContainElement(thinking);
 
@@ -453,7 +448,7 @@ test.each([
       canExpandHistory ? 1 : 0,
     );
     for (let index = 0; index < messageCount - 1; index += 1) {
-      expect(screen.queryByText(workMessage(index))).toBeNull();
+      expect(queryMessageBody(workMessage(index))).toBeNull();
     }
   },
 );
@@ -538,7 +533,7 @@ test.each(finalOutputDocuments)(
     const main = await find();
     expect(main).toBeVisible();
     expect(viewAgentProfileLinks()).toHaveLength(1);
-    expect(screen.queryByText("Earlier output belongs in history")).toBeNull();
+    expect(queryMessageBody("Earlier output belongs in history")).toBeNull();
     expect(buttonsNamed("Expand work history")).toHaveLength(1);
     const thinking = document.querySelector<HTMLElement>(
       "[data-thinking-indicator]",
@@ -547,7 +542,7 @@ test.each(finalOutputDocuments)(
   },
 );
 
-test("Render progress or result actions, never both", async () => {
+test("Keep result actions visible alongside running progress", async () => {
   installRunChat({
     activeRunIds: [RUN_A],
     chatEvents: [
@@ -577,7 +572,7 @@ test("Render progress or result actions, never both", async () => {
   expect(document.querySelector("[data-thinking-indicator]")).toBeVisible();
   expect(
     document.querySelector('[data-testid="chat-event-actions"]'),
-  ).toBeNull();
+  ).toBeVisible();
 });
 
 test("Do not render result actions while waiting for assistant output", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-status-tail.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-status-tail.test.tsx
@@ -1,0 +1,306 @@
+import { screen, waitFor } from "@testing-library/react";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { expect, test } from "vitest";
+import { setupPage } from "./chat-lifecycle-test-helpers.ts";
+import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
+import {
+  assistantEvent,
+  cancelledEvent,
+  completedEvent,
+  context,
+  findLink,
+  installRunChat,
+  promptEvent,
+  publishRunUpdate,
+  queryButton,
+  readyChat,
+  RUN_PATH,
+  sendText,
+} from "./chat-run-test-fixtures.ts";
+
+const RUN_A = "a0000000-0000-4000-a000-000000000291";
+const RUN_B = "a0000000-0000-4000-a000-000000000292";
+const GROUP_ID = "a0000000-0000-4000-a000-000000000293";
+const RESULT = "The API is checking dependencies. No errors so far.";
+const OLD_ERROR = "You've hit your usage limit. Please try again later.";
+const NEW_ERROR = "The provider could not complete the next request.";
+
+function failedEvent(
+  runId = RUN_A,
+  error = OLD_ERROR,
+  seqId = 4,
+): MockChatEventInput {
+  return {
+    id: `${runId}-failure`,
+    eventType: "run.failed",
+    content: null,
+    error,
+    runId,
+    seqId,
+    createdAt: "2026-08-01T10:00:04.000Z",
+  };
+}
+
+function resultEvents(): MockChatEventInput[] {
+  return [
+    promptEvent({
+      id: "first-input",
+      runId: RUN_A,
+      seqId: 1,
+      text: "Check the API",
+    }),
+    assistantEvent({
+      id: "supporting-artifact",
+      runId: RUN_A,
+      seqId: 2,
+      text: "https://cdn.vm7.io/artifacts/status-tail/evidence/report.pdf",
+    }),
+    assistantEvent({
+      id: "first-result",
+      runId: RUN_A,
+      seqId: 3,
+      text: RESULT,
+    }),
+  ];
+}
+
+async function openChat(): Promise<void> {
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+}
+
+async function expectRetainedResult(): Promise<HTMLElement> {
+  const result = screen.getByText(RESULT);
+  const main = result.closest<HTMLElement>("[data-chat-run-work-main]");
+  if (!main) {
+    throw new Error("Expected the previous main result");
+  }
+  expect(main).toContainElement(
+    await findLink("Open pdf preview for report.pdf"),
+  );
+  expect(queryButton("Copy message", main)).toBeVisible();
+  return main;
+}
+
+test("Retire the previous error as soon as a new message is sent, before acknowledgement or output", async () => {
+  const sendGate = context.mocks.deferred<void>();
+  const runCreated = context.mocks.deferred<void>();
+  const chat = installRunChat({
+    chatEvents: [...resultEvents(), failedEvent()],
+    sendGate: sendGate.promise,
+    onRunCreate: () => {
+      runCreated.resolve();
+    },
+  });
+  await openChat();
+  const error = await screen.findByText(OLD_ERROR);
+  const main = await expectRetainedResult();
+  expect(error.closest("[data-chat-run-status-tail]")).toBeVisible();
+  expect(main).not.toContainElement(error);
+
+  await sendText("Continue checking");
+
+  await expect(screen.findByText("Continue checking")).resolves.toBeVisible();
+  await waitFor(() => {
+    expect(document.querySelector("[data-thinking-indicator]")).toBeVisible();
+    expect(screen.queryByText(OLD_ERROR)).toBeNull();
+  });
+  await expectRetainedResult();
+
+  sendGate.resolve();
+  await runCreated.promise;
+  chat.failRun(NEW_ERROR);
+
+  const nextError = await screen.findByText(NEW_ERROR);
+  expect(nextError.closest("[data-chat-run-status-tail]")).toBeVisible();
+  expect(screen.queryByText(OLD_ERROR)).toBeNull();
+  expect(document.querySelector("[data-thinking-indicator]")).toBeNull();
+  expect(screen.getAllByTestId("chat-event-actions")).toHaveLength(1);
+  await expectRetainedResult();
+
+  await sendText("Try the next check");
+
+  await expect(screen.findByText("Try the next check")).resolves.toBeVisible();
+  await waitFor(() => {
+    expect(document.querySelector("[data-thinking-indicator]")).toBeVisible();
+    expect(screen.queryByText(NEW_ERROR)).toBeNull();
+  });
+  await expectRetainedResult();
+});
+
+test.each([
+  { label: "unassociated input", runId: undefined, sameGroup: false },
+  { label: "input in the same run", runId: RUN_A, sameGroup: false },
+  { label: "input in the same run group", runId: RUN_B, sameGroup: true },
+])(
+  "Derive the latest response from recorded $label when opening a chat",
+  async ({ runId, sameGroup }) => {
+    const events = [
+      ...resultEvents(),
+      failedEvent(),
+      promptEvent({
+        id: "recorded-next-input",
+        runId,
+        seqId: 5,
+        text: "Continue from the recorded input",
+      }),
+    ].map((event) => {
+      return sameGroup ? { ...event, runGroupId: GROUP_ID } : event;
+    });
+    installRunChat({ chatEvents: events, activeRunIds: runId ? [runId] : [] });
+
+    await openChat();
+
+    expect(screen.getByText("Continue from the recorded input")).toBeVisible();
+    expect(screen.queryByText(OLD_ERROR)).toBeNull();
+    await expectRetainedResult();
+  },
+);
+
+test("Show only the latest failure when neither response produced output", async () => {
+  installRunChat({
+    chatEvents: [
+      promptEvent({
+        id: "empty-a",
+        runId: RUN_A,
+        seqId: 1,
+        text: "First attempt",
+      }),
+      failedEvent(RUN_A, OLD_ERROR, 2),
+      promptEvent({
+        id: "empty-b",
+        runId: RUN_B,
+        seqId: 3,
+        text: "Second attempt",
+      }),
+      failedEvent(RUN_B, NEW_ERROR),
+    ],
+  });
+
+  await openChat();
+
+  expect(
+    screen.getByText(NEW_ERROR).closest("[data-chat-run-status-tail]"),
+  ).toBeVisible();
+  expect(screen.queryByText(OLD_ERROR)).toBeNull();
+  expect(screen.queryByTestId("chat-event-actions")).toBeNull();
+});
+
+test.each(["failed", "cancelled"] as const)(
+  "Keep a %s tail mutually exclusive with late followups",
+  async (status) => {
+    const terminal =
+      status === "failed"
+        ? failedEvent()
+        : cancelledEvent({ id: "cancelled", runId: RUN_A, seqId: 4 });
+    installRunChat({
+      chatEvents: [
+        ...resultEvents(),
+        terminal,
+        {
+          id: "late-followups",
+          content: null,
+          runId: RUN_A,
+          seqId: 5,
+          createdAt: "2026-08-01T10:00:05.000Z",
+          followups: [{ prompt: "Summarize the check", kind: "talk" }],
+        },
+      ],
+    });
+
+    await openChat();
+
+    expect(
+      screen.getByText(
+        status === "failed"
+          ? OLD_ERROR
+          : "Paused mid-thought — pick it back up whenever.",
+      ),
+    ).toBeVisible();
+    expect(screen.queryByRole("group", { name: "Keep going" })).toBeNull();
+    expect(screen.queryByText("Summarize the check")).toBeNull();
+    expect(document.querySelector("[data-thinking-indicator]")).toBeNull();
+    await expectRetainedResult();
+  },
+);
+
+test("Retire completion and followups while retaining the result actions", async () => {
+  const sendGate = context.mocks.deferred<void>();
+  installRunChat({
+    sendGate: sendGate.promise,
+    chatEvents: [
+      ...resultEvents(),
+      completedEvent({ id: "completed", runId: RUN_A, seqId: 4 }),
+      {
+        id: "followups",
+        content: null,
+        runId: RUN_A,
+        seqId: 5,
+        createdAt: "2026-08-01T10:00:05.000Z",
+        followups: [{ prompt: "Summarize the check", kind: "talk" }],
+      },
+    ],
+  });
+  await openChat();
+  await expect(
+    screen.findByRole("group", { name: "Keep going" }),
+  ).resolves.toBeVisible();
+
+  await sendText("Start another check");
+
+  await expect(screen.findByText("Start another check")).resolves.toBeVisible();
+  await waitFor(() => {
+    expect(document.querySelector("[data-thinking-indicator]")).toBeVisible();
+    expect(screen.queryByRole("group", { name: "Keep going" })).toBeNull();
+  });
+  await expectRetainedResult();
+  sendGate.resolve();
+});
+
+test.each([true, false])(
+  "Handle a late previous-run failure with work folding enabled=%s",
+  async (enabled) => {
+    const events = [
+      ...resultEvents(),
+      completedEvent({ id: "old-completion", runId: RUN_A, seqId: 4 }),
+      promptEvent({
+        id: "pending-next-input",
+        runId: RUN_B,
+        seqId: 5,
+        text: "Continue with the next response",
+      }),
+    ];
+    installRunChat({ chatEvents: events, activeRunIds: [RUN_B] });
+    await setupPage({
+      context,
+      path: RUN_PATH,
+      featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: enabled },
+    });
+    await readyChat();
+    expect(screen.getByText("Continue with the next response")).toBeVisible();
+
+    events.push(
+      failedEvent(RUN_A, OLD_ERROR, 6),
+      assistantEvent({
+        id: "next-response-result",
+        runId: RUN_B,
+        seqId: 7,
+        text: "The next response is progressing",
+      }),
+    );
+    publishRunUpdate();
+
+    await expect(
+      screen.findByText("The next response is progressing"),
+    ).resolves.toBeVisible();
+    expect(screen.queryByText(OLD_ERROR) !== null).toBe(!enabled);
+    if (!enabled) {
+      return;
+    }
+    await expectRetainedResult();
+  },
+);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-steer.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-steer.test.tsx
@@ -1,0 +1,425 @@
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { screen, waitFor } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import { mockNow } from "../../../__tests__/time.ts";
+import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
+import { setupPage } from "./chat-lifecycle-test-helpers.ts";
+import {
+  assistantEvent,
+  completedEvent,
+  context,
+  expectTextOrder,
+  findLink,
+  installRunChat,
+  promptEvent,
+  publishRunUpdate,
+  queryButton,
+  readyChat,
+  RUN_PATH,
+  sendText,
+} from "./chat-run-test-fixtures.ts";
+
+const RUN_A = "a0000000-0000-4000-a000-000000000301";
+const RUN_B = "a0000000-0000-4000-a000-000000000302";
+const RESULT = "The API review is in progress.";
+const STEER = "Focus on the authentication boundary first";
+const NEXT_RESULT = "The authentication boundary review is ready.";
+
+function createdAt(second: number): string {
+  return `2026-08-01T10:00:${String(second).padStart(2, "0")}.000Z`;
+}
+
+function resultEvents(): MockChatEventInput[] {
+  return [
+    promptEvent({
+      id: "initial-request",
+      runId: RUN_A,
+      seqId: 1,
+      text: "Review the API",
+      createdAt: createdAt(0),
+    }),
+    assistantEvent({
+      id: "review-artifact",
+      runId: RUN_A,
+      seqId: 2,
+      text: "https://cdn.vm7.io/artifacts/steer/review/report.pdf",
+      createdAt: createdAt(1),
+    }),
+    assistantEvent({
+      id: "initial-result",
+      runId: RUN_A,
+      seqId: 3,
+      text: RESULT,
+      createdAt: createdAt(2),
+    }),
+  ];
+}
+
+function pendingSteer(): MockChatEventInput {
+  return promptEvent({
+    id: "pending-steer",
+    seqId: 4,
+    text: STEER,
+    createdAt: createdAt(12),
+  });
+}
+
+function deliveredSteer(): MockChatEventInput {
+  return {
+    ...promptEvent({
+      id: "delivered-steer",
+      runId: RUN_A,
+      seqId: 5,
+      text: STEER,
+      createdAt: createdAt(15),
+    }),
+    revokesEventId: "pending-steer",
+  };
+}
+
+async function openChat(second: number): Promise<void> {
+  mockNow(new Date(createdAt(second)), context.signal);
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+}
+
+function mainResult(text: string): HTMLElement {
+  const main = screen
+    .getByText(text)
+    .closest<HTMLElement>("[data-chat-run-work-main]");
+  if (!main) {
+    throw new Error(`Expected a main result for ${text}`);
+  }
+  return main;
+}
+
+function assistantGroup(text: string): HTMLElement {
+  const group = mainResult(text).closest<HTMLElement>(
+    '[data-role="assistant"]',
+  );
+  if (!group) {
+    throw new Error(`Expected an assistant response for ${text}`);
+  }
+  return group;
+}
+
+function workSummary(text = RESULT): Element | null {
+  return assistantGroup(text).querySelector("[data-chat-run-work]");
+}
+
+async function expectRetainedResult(): Promise<void> {
+  const main = mainResult(RESULT);
+  expect(main).toBeVisible();
+  expect(main).toContainElement(
+    await findLink("Open pdf preview for report.pdf"),
+  );
+  expect(queryButton("Copy message", main)).toBeVisible();
+}
+
+function expectWaitingAfter(text: string): void {
+  const waiting = document.querySelector("[data-thinking-indicator]");
+  expect(waiting).toBeVisible();
+  expect(document.querySelectorAll("[data-thinking-indicator]")).toHaveLength(
+    1,
+  );
+  expect(
+    screen.getByText(text).compareDocumentPosition(waiting!) &
+      Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+}
+
+test("Freeze the previous work when a steer is sent, before the send request returns", async () => {
+  const appendGate = context.mocks.deferred<void>();
+  const appendStarted = context.mocks.deferred<void>();
+  installRunChat({
+    chatEvents: resultEvents(),
+    activeRunIds: [RUN_A],
+    appendGate: appendGate.promise,
+    onQueuedEventAppend: () => {
+      appendStarted.resolve();
+    },
+  });
+  await openChat(12);
+  expect(workSummary()).toHaveTextContent("Working for");
+
+  await sendText(STEER);
+  await appendStarted.promise;
+
+  await expect(screen.findByText(STEER)).resolves.toBeVisible();
+  expectWaitingAfter(STEER);
+  await expectRetainedResult();
+  expect(workSummary()).toHaveTextContent("Worked for 12s");
+
+  appendGate.resolve();
+});
+
+test.each([
+  { state: "pending", deliveryEvents: [] },
+  { state: "delivered", deliveryEvents: [deliveredSteer()] },
+])(
+  "Restore the original steer boundary from recorded $state input when opening a chat",
+  async ({ deliveryEvents }) => {
+    installRunChat({
+      chatEvents: [...resultEvents(), pendingSteer(), ...deliveryEvents],
+      activeRunIds: [RUN_A],
+    });
+
+    await openChat(20);
+
+    expect(screen.getAllByText(STEER)).toHaveLength(1);
+    expectWaitingAfter(STEER);
+    await expectRetainedResult();
+    expect(workSummary()).toHaveTextContent("Worked for 12s");
+  },
+);
+
+test("Keep the work boundary and elapsed time stable through steer delivery and completion", async () => {
+  const events = [...resultEvents(), pendingSteer()];
+  const chat = installRunChat({ chatEvents: events, activeRunIds: [RUN_A] });
+  await openChat(12);
+  expect(screen.getByText(STEER)).toBeVisible();
+  expectWaitingAfter(STEER);
+  expect.soft(workSummary()).toHaveTextContent("Worked for 12s");
+
+  mockNow(new Date(createdAt(20)), context.signal);
+  events.push(
+    deliveredSteer(),
+    assistantEvent({
+      id: "result-after-steer",
+      runId: RUN_A,
+      seqId: 6,
+      text: NEXT_RESULT,
+      createdAt: createdAt(18),
+    }),
+  );
+  publishRunUpdate();
+
+  await expect(screen.findByText(NEXT_RESULT)).resolves.toBeVisible();
+  expect(screen.getAllByText(STEER)).toHaveLength(1);
+  await expectRetainedResult();
+  expect(queryButton("Copy message", mainResult(NEXT_RESULT))).toBeVisible();
+  expectTextOrder(RESULT, STEER, NEXT_RESULT);
+  expect.soft(workSummary()).toHaveTextContent("Worked for 12s");
+  expect(workSummary(NEXT_RESULT)).toHaveTextContent("Working for");
+
+  chat.completeRun();
+
+  await waitFor(() => {
+    expect(workSummary(NEXT_RESULT)).toHaveTextContent("Worked for");
+  });
+  expect.soft(workSummary()).toHaveTextContent("Worked for 12s");
+  expect.soft(workSummary(NEXT_RESULT)).toHaveTextContent("Worked for 8s");
+});
+
+test("Keep separate history previews, artifacts and actions on both sides of a steer in the same run", async () => {
+  const oldHistory = [
+    "Started the API review",
+    "Checked the dependency graph",
+    "Checked the service boundaries",
+    "Checked the request gateways",
+  ];
+  installRunChat({
+    chatEvents: [
+      promptEvent({
+        id: "history-request",
+        runId: RUN_A,
+        seqId: 1,
+        text: "Review the API",
+        createdAt: createdAt(0),
+      }),
+      assistantEvent({
+        id: "history-artifact",
+        runId: RUN_A,
+        seqId: 2,
+        text: "https://cdn.vm7.io/artifacts/steer/review/report.pdf",
+        createdAt: createdAt(1),
+      }),
+      ...oldHistory.map((text, index) => {
+        return assistantEvent({
+          id: `history-${String(index)}`,
+          runId: RUN_A,
+          seqId: index + 3,
+          text,
+          createdAt: createdAt(index + 2),
+        });
+      }),
+      assistantEvent({
+        id: "history-result",
+        runId: RUN_A,
+        seqId: 7,
+        text: RESULT,
+        createdAt: createdAt(6),
+      }),
+      promptEvent({
+        id: "history-steer",
+        runId: RUN_A,
+        seqId: 8,
+        text: STEER,
+        createdAt: createdAt(12),
+      }),
+      assistantEvent({
+        id: "next-history",
+        runId: RUN_A,
+        seqId: 9,
+        text: "Checked the token validation path",
+        createdAt: createdAt(16),
+      }),
+      assistantEvent({
+        id: "next-result",
+        runId: RUN_A,
+        seqId: 10,
+        text: NEXT_RESULT,
+        createdAt: createdAt(18),
+      }),
+    ],
+    activeRunIds: [RUN_A],
+  });
+
+  await openChat(20);
+
+  await expectRetainedResult();
+  const previousGroup = assistantGroup(RESULT);
+  const nextGroup = assistantGroup(NEXT_RESULT);
+  expect(previousGroup).not.toBe(nextGroup);
+  const oldPreviews = previousGroup.querySelectorAll(
+    "[data-chat-run-work-preview]",
+  );
+  expect(oldPreviews).toHaveLength(3);
+  for (const [index, text] of oldHistory.slice(-3).entries()) {
+    expect(oldPreviews[index]).toHaveTextContent(text);
+  }
+  const newPreviews = nextGroup.querySelectorAll(
+    "[data-chat-run-work-preview]",
+  );
+  expect(newPreviews).toHaveLength(1);
+  expect(newPreviews[0]).toHaveTextContent("Checked the token validation path");
+  expect(screen.queryByText("Started the API review")).toBeNull();
+  expect(queryButton("Copy message", mainResult(NEXT_RESULT))).toBeVisible();
+  expect(screen.getAllByTestId("chat-event-actions")).toHaveLength(2);
+  expect(nextGroup).not.toContainElement(
+    await findLink("Open pdf preview for report.pdf"),
+  );
+  expect(workSummary()).toHaveTextContent("Worked for");
+  expect(workSummary(NEXT_RESULT)).toHaveTextContent("Working for");
+  expectWaitingAfter(NEXT_RESULT);
+  expectTextOrder(RESULT, STEER, NEXT_RESULT);
+});
+
+test.each([
+  { state: "pending", runId: undefined },
+  { state: "delivered", runId: RUN_A },
+])(
+  "Keep consecutive $state steers visible without empty work sections between them",
+  async ({ runId }) => {
+    const secondSteer = "Include the token refresh path as well";
+    installRunChat({
+      chatEvents: [
+        ...resultEvents(),
+        { ...pendingSteer(), runId },
+        promptEvent({
+          id: "second-steer",
+          runId,
+          seqId: 5,
+          text: secondSteer,
+          createdAt: createdAt(16),
+        }),
+      ],
+      activeRunIds: [RUN_A],
+    });
+
+    await openChat(20);
+
+    expect(screen.getAllByText(STEER)).toHaveLength(1);
+    expect(screen.getAllByText(secondSteer)).toHaveLength(1);
+    expectTextOrder(RESULT, STEER, secondSteer);
+    await expectRetainedResult();
+    expect(document.querySelectorAll("[data-chat-run-work-main]")).toHaveLength(
+      1,
+    );
+    expect(document.querySelectorAll("[data-chat-run-work]")).toHaveLength(1);
+    expect(screen.getAllByTestId("chat-event-actions")).toHaveLength(1);
+    expectWaitingAfter(secondSteer);
+  },
+);
+
+test("Wait after a steer before the first output without creating an empty previous result", async () => {
+  const events = [
+    promptEvent({
+      id: "empty-request",
+      runId: RUN_A,
+      seqId: 1,
+      text: "Review the API",
+      createdAt: createdAt(0),
+    }),
+    pendingSteer(),
+  ];
+  installRunChat({ chatEvents: events, activeRunIds: [RUN_A] });
+  await openChat(12);
+
+  expect(screen.getByText(STEER)).toBeVisible();
+  expectWaitingAfter(STEER);
+  expect(document.querySelector("[data-chat-run-work-main]")).toBeNull();
+  expect(document.querySelector("[data-chat-run-work]")).toBeNull();
+  expect(screen.queryByTestId("chat-event-actions")).toBeNull();
+
+  events.push(
+    deliveredSteer(),
+    assistantEvent({
+      id: "first-result-after-steer",
+      runId: RUN_A,
+      seqId: 6,
+      text: NEXT_RESULT,
+      createdAt: createdAt(20),
+    }),
+  );
+  mockNow(new Date(createdAt(20)), context.signal);
+  publishRunUpdate();
+
+  await expect(screen.findByText(NEXT_RESULT)).resolves.toBeVisible();
+  expectTextOrder("Review the API", STEER, NEXT_RESULT);
+  expect(screen.getAllByText(STEER)).toHaveLength(1);
+  expect(document.querySelectorAll("[data-chat-run-work-main]")).toHaveLength(
+    1,
+  );
+  expect(document.querySelectorAll("[data-chat-run-work]")).toHaveLength(1);
+  expect(queryButton("Copy message", mainResult(NEXT_RESULT))).toBeVisible();
+});
+
+test("Keep an already completed response's original duration when the next user message arrives", async () => {
+  const events = [
+    ...resultEvents(),
+    completedEvent({
+      id: "initial-completion",
+      runId: RUN_A,
+      seqId: 4,
+      createdAt: createdAt(5),
+    }),
+  ];
+  installRunChat({ chatEvents: events, activeRunIds: [RUN_B] });
+  await openChat(12);
+  expect(workSummary()).toHaveTextContent("Worked for 5s");
+
+  events.push(
+    promptEvent({
+      id: "next-request",
+      runId: RUN_B,
+      seqId: 5,
+      text: STEER,
+      createdAt: createdAt(12),
+    }),
+  );
+  mockNow(new Date(createdAt(20)), context.signal);
+  publishRunUpdate();
+
+  await expect(screen.findByText(STEER)).resolves.toBeVisible();
+  await waitFor(() => {
+    expectWaitingAfter(STEER);
+  });
+  expect(workSummary()).toHaveTextContent("Worked for 5s");
+  await expectRetainedResult();
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-sharing.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-sharing.test.tsx
@@ -1,3 +1,4 @@
+import { queryMessageBody } from "./chat-event-test-helpers.ts";
 import { screen, waitFor, within } from "@testing-library/react";
 import { sharedThreadsContract } from "@okouai/api-contracts/contracts/shared-threads";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -198,8 +199,8 @@ test("A folded multi-message answer counts as one shared selection", async () =>
   });
 
   await screen.findByText("Launch answer 3");
-  expect(screen.queryByText("Launch answer 1")).toBeNull();
-  expect(screen.queryByText("Launch answer 2")).toBeNull();
+  expect(queryMessageBody("Launch answer 1")).toBeNull();
+  expect(queryMessageBody("Launch answer 2")).toBeNull();
   await waitFor(() => {
     expect(buttonsNamed("Share messages").length).toBeGreaterThan(0);
   });

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -7,11 +7,14 @@ export const CHAT_THREAD_CONTENT_MAIN_CLASS =
 export const CHAT_THREAD_MESSAGE_LIST_CLASS =
   "w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4 overflow-visible";
 
+// The message list owns spacing between rows; nested assistant stacks use an
+// 8px gap between blocks. Bodies and action rows add no vertical padding.
+
 export const CHAT_THREAD_USER_MESSAGE_ROW_CLASS =
   "flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
 export const CHAT_THREAD_ASSISTANT_MESSAGE_GROUP_CLASS =
-  "flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300";
+  "flex flex-col gap-2 animate-in fade-in slide-in-from-bottom-2 duration-300";
 
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS =
   "flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
@@ -29,7 +32,7 @@ export const CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS =
   "@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]";
 
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS =
-  "flex items-center justify-between pt-2 pb-1 gap-2 -ml-1";
+  "flex items-center justify-between gap-2 -ml-1";
 
 // Consecutive user messages read as one burst. The copy button already sits
 // `mt-1` below its message, so this pull keeps the gap below it equally tight.
@@ -52,14 +55,12 @@ export function ChatUserMessageBubble({
 
 export function ChatAssistantMessageBody({
   className,
-  compactTop = false,
   ...props
-}: HTMLAttributes<HTMLDivElement> & { readonly compactTop?: boolean }) {
+}: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn(
-        "okou-chat-bubble-assistant px-0 text-[0.9375rem] leading-[1.7] min-w-0 [overflow-wrap:anywhere]",
-        compactTop ? "@[900px]:pt-0" : "@[900px]:pt-2.5",
+        "okou-chat-bubble-assistant p-0 text-[0.9375rem] leading-[1.7] min-w-0 [overflow-wrap:anywhere]",
         className,
       )}
       {...props}

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3685,7 +3685,7 @@ function completedWorkLabel(groups: readonly ChatEventGroup[]): string {
 const RUN_SECTION_LABEL_CLASS =
   "min-w-0 max-w-full shrink-0 break-words font-serif text-[13px] italic text-muted-foreground/50";
 const RUN_SECTION_ROW_CLASS =
-  "-mt-5 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
+  "@[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
 function RunSectionDivider({
   label,
@@ -3782,7 +3782,7 @@ function CompletedWorkFoldRow({
   const { t } = useTranslation();
   const label = completedWorkLabel(groups);
   return (
-    <div data-chat-completed-work-fold className="-mx-2 @[900px]:-mb-[15px]">
+    <div data-chat-completed-work-fold className="-mx-2">
       <button
         type="button"
         aria-expanded={expanded}
@@ -3796,7 +3796,7 @@ function CompletedWorkFoldRow({
               })
         }
         onClick={onToggle}
-        className="mt-1.5 inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-state-hover"
+        className="inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-state-hover"
       >
         <Hourglass aria-hidden size={14} className="shrink-0" />
         <span className="text-[13px]">{label}</span>
@@ -3867,7 +3867,7 @@ function RunWorkSectionRow({
     </>
   );
   const className =
-    "mt-1.5 inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground";
+    "inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground";
   return (
     <div data-chat-run-work className="-mx-2">
       {collapsible ? (
@@ -4054,23 +4054,14 @@ function runGroupFoldLabel(fold: RunGroupFold): string {
   );
 }
 
-function RunGroupFoldRow({
-  control,
-  embedded = false,
-}: {
-  control: RunGroupFoldControl;
-  embedded?: boolean;
-}) {
+function RunGroupFoldRow({ control }: { control: RunGroupFoldControl }) {
   const { t } = useTranslation();
   const { fold, expanded, onToggle } = control;
   const label = runGroupFoldLabel(fold);
   const isGoal = isGoalGroupFold(fold);
   const Icon = isGoal ? Target : Package;
   return (
-    <div
-      data-chat-run-group-fold
-      className={cn("-mx-2", embedded && "@[900px]:-mb-[15px]")}
-    >
+    <div data-chat-run-group-fold className="-mx-2">
       <button
         type="button"
         aria-expanded={expanded}
@@ -4084,10 +4075,7 @@ function RunGroupFoldRow({
               })
         }
         onClick={onToggle}
-        className={cn(
-          "inline-flex min-h-9 max-w-full items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-state-hover",
-          embedded && "mt-1.5",
-        )}
+        className="inline-flex min-h-9 max-w-full items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-state-hover"
       >
         <Icon aria-hidden size={14} className="shrink-0" />
         <span className="min-w-0 truncate whitespace-nowrap text-[13px]">
@@ -4969,37 +4957,24 @@ function WaitingForAssistantResponse({
     <div
       {...thinkingIndicatorProps}
       data-role="assistant"
-      className="okou-thinking-enter flex flex-col gap-1"
+      className="okou-thinking-enter flex flex-col gap-2"
     >
       <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS}>
         <AssistantBubbleAvatar thread={thread} />
         <div className="relative flex min-w-0 flex-col gap-2">
           {runGroupFolds.map((fold) => {
-            return (
-              <RunGroupFoldRow key={fold.fold.key} control={fold} embedded />
-            );
+            return <RunGroupFoldRow key={fold.fold.key} control={fold} />;
           })}
-          <div className="okou-chat-bubble-assistant min-w-0 overflow-hidden rounded-xl py-4 text-[0.9375rem] leading-[1.7]">
-            <div className="flex h-5 min-w-0 items-center gap-2">
-              <ThinkingLoader
-                blockStyle={blockStyle}
-                spinnerEnabled={spinnerEnabled}
-              />
-              <ThinkingLabel
-                isQueued={isQueued}
-                thinkingLabel={thinkingLabel}
-                serverThinkingLabel={serverThinkingLabel}
-              />
-            </div>
-          </div>
+          <ChatAssistantMessageBody>
+            <InlineThinkingRow
+              blockStyle={blockStyle}
+              isQueued={isQueued}
+              spinnerEnabled={spinnerEnabled}
+              thinkingLabel={thinkingLabel}
+              serverThinkingLabel={serverThinkingLabel}
+            />
+          </ChatAssistantMessageBody>
         </div>
-      </div>
-      <div
-        aria-hidden
-        className="@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]"
-      >
-        <div className="hidden @[900px]:block" />
-        <div className="flex items-center py-2 gap-1 -ml-1" />
       </div>
     </div>
   );
@@ -7608,7 +7583,6 @@ function PagedAssistantTimeline({
   thread: ChatPanelSignals;
   mainActions?: ReactNode;
 }) {
-  let renderedAssistantItemCount = 0;
   return items.map((item) => {
     if (item.kind === "model-change") {
       return (
@@ -7637,8 +7611,6 @@ function PagedAssistantTimeline({
         />
       );
     }
-    const compactTop = renderedAssistantItemCount > 0;
-    renderedAssistantItemCount += 1;
     if (item.kind === "run-work-preview") {
       return <RunWorkMessagePreview key={item.event.id} event={item.event} />;
     }
@@ -7649,11 +7621,7 @@ function PagedAssistantTimeline({
           data-chat-run-work-main
           className="flex min-w-0 flex-col gap-2"
         >
-          <PagedAssistantEventItem
-            event={item.event}
-            compactTop={compactTop}
-            thread={thread}
-          />
+          <PagedAssistantEventItem event={item.event} thread={thread} />
           {item.artifactCards.length === 0 ? null : (
             <div
               data-chat-run-work-remaining-artifacts
@@ -7676,7 +7644,6 @@ function PagedAssistantTimeline({
       <PagedAssistantEventItem
         key={item.event.id}
         event={item.event}
-        compactTop={compactTop}
         thread={thread}
       />
     );
@@ -7751,7 +7718,6 @@ function PagedRunWorkAssistantContent({
                 <PagedAssistantEventItem
                   key={event.id}
                   event={event}
-                  compactTop
                   thread={thread}
                 />
               );
@@ -7822,9 +7788,7 @@ function PagedAssistantGroup({
         <AssistantBubbleAvatar thread={thread} />
         <div className="relative flex flex-col gap-2">
           {runGroupFolds?.map((fold) => {
-            return (
-              <RunGroupFoldRow key={fold.fold.key} control={fold} embedded />
-            );
+            return <RunGroupFoldRow key={fold.fold.key} control={fold} />;
           })}
           {usesRunWorkPresentation ? (
             <PagedRunWorkAssistantContent
@@ -7862,11 +7826,9 @@ function PagedAssistantGroup({
 
 function PagedAssistantEventItem({
   event,
-  compactTop = false,
   thread,
 }: {
   event: EnrichedChatEvent;
-  compactTop?: boolean;
   thread: ChatPanelSignals;
 }) {
   const retryRichEventTree = useSet(thread.retryRichEventTree$);
@@ -7877,7 +7839,6 @@ function PagedAssistantEventItem({
       <ChatAssistantMessageBody
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
-        compactTop={compactTop}
       >
         <AssistantErrorContent
           error={error}
@@ -7896,7 +7857,6 @@ function PagedAssistantEventItem({
       <ChatAssistantMessageBody
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
-        compactTop={compactTop}
       >
         <MarkdownEventBody
           tree={event.tree}

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -1,3 +1,4 @@
+import { RunWorkMessagePreview } from "./run-work-message-preview.tsx";
 import type {
   CSSProperties,
   FormEvent,
@@ -3018,28 +3019,18 @@ function isWaitingThinkingIndicatorMode(
 function assistantGroupIdForRunWorkIndicator(
   groups: readonly ChatEventGroup[],
   runWorkFolding: RunWorkFolding | null,
-  mode: ThinkingIndicatorMode,
-  currentRunId: string | undefined,
-  currentRunGroupId: string | undefined,
 ): string | null {
-  if (runWorkFolding === null || mode === null || currentRunId === undefined) {
+  const anchorEventId = runWorkFolding?.statusTail?.anchorEventId;
+  if (anchorEventId === undefined) {
     return null;
   }
-
-  for (let index = groups.length - 1; index >= 0; index--) {
-    const group = groups[index]!;
-    const section = runWorkSectionForGroup(runWorkFolding, group);
-    if (
-      group.role === "assistant" &&
-      section !== null &&
-      (section.runIds.includes(currentRunId) ||
-        (currentRunGroupId !== undefined &&
-          section.runGroupId === currentRunGroupId))
-    ) {
-      return group.beginEventId;
-    }
-  }
-  return null;
+  return (
+    groups.find((group) => {
+      return group.events.some((event) => {
+        return event.id === anchorEventId;
+      });
+    })?.beginEventId ?? null
+  );
 }
 
 function ChatThreadRenderedEventGroups({
@@ -3093,15 +3084,14 @@ function ChatThreadRenderedEventGroups({
   const visibleGroups = runWorkFoldingEnabled
     ? (runWorkFolding?.visibleGroups ?? runGroupVisibleGroups)
     : (completedWorkFolding?.visibleGroups ?? runGroupVisibleGroups);
-  const thinkingIndicatorMode =
+  const resolvedThinkingIndicatorMode =
     useLastResolved(thread.thinkingIndicatorMode$) ?? null;
-  const currentEvent = renderedActiveGroups.at(-1)?.events.at(-1);
+  const thinkingIndicatorMode = runWorkFolding?.statusTail?.events.length
+    ? null
+    : resolvedThinkingIndicatorMode;
   const runIndicatorAssistantGroupId = assistantGroupIdForRunWorkIndicator(
     visibleGroups,
     runWorkFolding,
-    thinkingIndicatorMode,
-    currentEvent?.runId,
-    currentEvent?.runGroupId,
   );
   const runGroupFoldPlacements = resolveRunGroupFoldPlacements({
     groups: visibleGroups,
@@ -3449,6 +3439,11 @@ function ChatThreadEventGroups({
                 onToggleRunWork,
               )}
               runIndicatorMode={runIndicatorMode}
+              statusTailEvents={runWorkFolding?.statusTail?.events.filter(
+                (event) => {
+                  return group.events.includes(event);
+                },
+              )}
             />
           </div>
         );
@@ -5947,6 +5942,7 @@ function PagedGroupRow({
   completedWorkFold,
   runWorkSection,
   runIndicatorMode,
+  statusTailEvents,
 }: {
   group: ChatEventGroup;
   thread: ChatPanelSignals;
@@ -5956,6 +5952,7 @@ function PagedGroupRow({
   completedWorkFold?: CompletedWorkFoldControl;
   runWorkSection?: RunWorkSectionControl;
   runIndicatorMode?: Exclude<ThinkingIndicatorMode, null>;
+  statusTailEvents?: readonly EnrichedChatEvent[];
 }) {
   if (group.role === "user") {
     return (
@@ -5977,6 +5974,7 @@ function PagedGroupRow({
       completedWorkFold={completedWorkFold}
       runWorkSection={runWorkSection}
       runIndicatorMode={runIndicatorMode}
+      statusTailEvents={statusTailEvents}
     />
   );
 }
@@ -6031,6 +6029,7 @@ function SelectablePagedGroupRow({
   completedWorkFold,
   runWorkSection,
   runIndicatorMode,
+  statusTailEvents,
 }: Parameters<typeof PagedGroupRow>[0]) {
   const { t } = useTranslation();
   const phase = useGet(thread.sharing.phase$);
@@ -6057,6 +6056,7 @@ function SelectablePagedGroupRow({
         completedWorkFold={completedWorkFold}
         runWorkSection={runWorkSection}
         runIndicatorMode={runIndicatorMode}
+        statusTailEvents={statusTailEvents}
       />
     );
   }
@@ -6103,6 +6103,7 @@ function SelectablePagedGroupRow({
         completedWorkFold={completedWorkFold}
         runWorkSection={runWorkSection}
         runIndicatorMode={runIndicatorMode}
+        statusTailEvents={statusTailEvents}
       />
       <Checkbox
         checked={checked}
@@ -7462,6 +7463,7 @@ type PagedAssistantGroupProps = {
   readonly completedWorkFold?: CompletedWorkFoldControl;
   readonly runWorkSection?: RunWorkSectionControl;
   readonly runIndicatorMode?: Exclude<ThinkingIndicatorMode, null>;
+  readonly statusTailEvents?: readonly EnrichedChatEvent[];
 };
 
 function visibleRunIndicatorMode(
@@ -7494,6 +7496,10 @@ type PagedAssistantTimelineItem =
   | {
       readonly kind: "run-work";
       readonly control: RunWorkSectionControl;
+    }
+  | {
+      readonly kind: "run-work-preview";
+      readonly event: EnrichedChatEvent;
     }
   | {
       readonly kind: "run-work-main";
@@ -7560,10 +7566,17 @@ function buildPagedAssistantTimeline({
   }
 
   items.push({ kind: "run-work", control: runWorkSection });
-  const anchorEndIndex = anchorIndex + 1;
   if (runWorkSection.expanded) {
     items.push(
       ...foldedRunWorkTimelineItems(runWorkSection.hiddenGroups, modelChanges),
+    );
+  } else {
+    items.push(
+      ...runWorkSection.previewMessages.map(
+        (event): PagedAssistantTimelineItem => {
+          return { kind: "run-work-preview", event };
+        },
+      ),
     );
   }
   items.push(...assistantTimelineItems(group.events.slice(0, anchorIndex)));
@@ -7583,7 +7596,6 @@ function buildPagedAssistantTimeline({
       ),
     );
   }
-  items.push(...assistantTimelineItems(group.events.slice(anchorEndIndex)));
   return items;
 }
 
@@ -7627,6 +7639,9 @@ function PagedAssistantTimeline({
     }
     const compactTop = renderedAssistantItemCount > 0;
     renderedAssistantItemCount += 1;
+    if (item.kind === "run-work-preview") {
+      return <RunWorkMessagePreview key={item.event.id} event={item.event} />;
+    }
     if (item.kind === "run-work-main") {
       return (
         <div
@@ -7675,6 +7690,7 @@ function PagedRunWorkAssistantContent({
   completedWorkFold,
   runWorkSection,
   runIndicatorMode,
+  statusTailEvents,
 }: Pick<
   PagedAssistantGroupProps,
   | "group"
@@ -7683,13 +7699,19 @@ function PagedRunWorkAssistantContent({
   | "completedWorkFold"
   | "runWorkSection"
   | "runIndicatorMode"
+  | "statusTailEvents"
 >) {
   const recommendedFollowupSource =
     useLastResolved(thread.recommendedFollowupSource$, {
       equalityFn: equalRecommendedFollowupSources,
     }) ?? null;
   const timelineItems = buildPagedAssistantTimeline({
-    group,
+    group: {
+      ...group,
+      events: group.events.filter((event) => {
+        return !statusTailEvents?.includes(event);
+      }),
+    },
     modelChanges,
     completedWorkFold,
     runWorkSection,
@@ -7704,12 +7726,10 @@ function PagedRunWorkAssistantContent({
     recommendedFollowupSource,
   );
   const mainActions =
-    runWorkSection !== undefined &&
-    (visibleIndicatorMode === undefined ||
-      visibleIndicatorMode === "finished") ? (
+    mainEvent !== undefined ? (
       <PagedGroupActions
         group={group}
-        content={mainEvent?.content ?? ""}
+        content={mainEvent.content ?? ""}
         thread={thread}
         embedded
       />
@@ -7722,14 +7742,30 @@ function PagedRunWorkAssistantContent({
         thread={thread}
         mainActions={mainActions}
       />
-      {visibleIndicatorMode === undefined ? null : (
-        <ThinkingIndicator
-          thread={thread}
-          mode={visibleIndicatorMode}
-          runGroupFolds={[]}
-          inAssistantGroup
-        />
-      )}
+      {(statusTailEvents?.length ?? 0) > 0 ||
+      visibleIndicatorMode !== undefined ? (
+        <div data-chat-run-status-tail className="flex min-w-0 flex-col gap-2">
+          {statusTailEvents?.length ? (
+            statusTailEvents.map((event) => {
+              return (
+                <PagedAssistantEventItem
+                  key={event.id}
+                  event={event}
+                  compactTop
+                  thread={thread}
+                />
+              );
+            })
+          ) : visibleIndicatorMode !== undefined ? (
+            <ThinkingIndicator
+              thread={thread}
+              mode={visibleIndicatorMode}
+              runGroupFolds={[]}
+              inAssistantGroup
+            />
+          ) : null}
+        </div>
+      ) : null}
     </>
   );
 }
@@ -7742,6 +7778,7 @@ function PagedAssistantGroup({
   completedWorkFold,
   runWorkSection,
   runIndicatorMode,
+  statusTailEvents,
 }: PagedAssistantGroupProps) {
   const hasRenderableEvent = group.events.some((event) => {
     return isRenderableAssistantEvent(event);
@@ -7769,7 +7806,9 @@ function PagedAssistantGroup({
     .filter(Boolean)
     .join("\n\n");
   const usesRunWorkPresentation =
-    visibleRunWorkSection !== undefined || runIndicatorMode !== undefined;
+    visibleRunWorkSection !== undefined ||
+    runIndicatorMode !== undefined ||
+    (statusTailEvents?.length ?? 0) > 0;
 
   return (
     <div
@@ -7795,6 +7834,7 @@ function PagedAssistantGroup({
               completedWorkFold={visibleCompletedWorkFold}
               runWorkSection={visibleRunWorkSection}
               runIndicatorMode={runIndicatorMode}
+              statusTailEvents={statusTailEvents}
             />
           ) : (
             <PagedAssistantTimeline
@@ -7809,7 +7849,7 @@ function PagedAssistantGroup({
           )}
         </div>
       </div>
-      {visibleRunWorkSection === undefined ? (
+      {!usesRunWorkPresentation ? (
         <PagedGroupActions
           group={group}
           content={fullContent}

--- a/turbo/apps/platform/src/views/okou-page/run-work-message-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/run-work-message-preview.tsx
@@ -1,0 +1,79 @@
+import type { Element, Root } from "hast";
+import { useTranslation } from "react-i18next";
+import type { EnrichedChatEvent } from "../../signals/chat-page/chat-event.ts";
+
+const blockTags: ReadonlySet<string> = new Set([
+  "address",
+  "blockquote",
+  "div",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "li",
+  "ol",
+  "p",
+  "pre",
+  "table",
+  "tr",
+  "ul",
+  "br",
+]);
+
+function previewText(event: EnrichedChatEvent, fallback: string): string {
+  if (event.tree === undefined) {
+    return event.content?.trim().replace(/\s+/g, " ") || fallback;
+  }
+  const parts: string[] = [];
+  const visit = (node: Root | Element): void => {
+    if (node.type === "element") {
+      const card = node.data?.card;
+      if (card !== undefined) {
+        parts.push(card.kind === "artifact" ? card.signals.filename : fallback);
+        return;
+      }
+      if (node.tagName === "img") {
+        const alt = node.properties.alt;
+        parts.push(typeof alt === "string" && alt.trim() ? alt : fallback);
+      }
+      if (blockTags.has(node.tagName)) {
+        parts.push(" ");
+      }
+    }
+    for (const child of node.children) {
+      if (child.type === "text" || child.type === "raw") {
+        parts.push(child.value);
+      } else if (child.type === "element") {
+        visit(child);
+      }
+    }
+    if (node.type === "element" && blockTags.has(node.tagName)) {
+      parts.push(" ");
+    }
+  };
+  visit(event.tree);
+  return parts.join("").trim().replace(/\s+/g, " ") || fallback;
+}
+
+export function RunWorkMessagePreview({ event }: { event: EnrichedChatEvent }) {
+  const { t } = useTranslation();
+  const text = previewText(
+    event,
+    t(($) => {
+      return $.chat.composer.message;
+    }),
+  );
+  return (
+    <div
+      data-chat-run-work-preview
+      className="flex h-5 min-w-0 max-w-full items-center gap-2 text-[13px] leading-5 text-muted-foreground/60"
+    >
+      <span aria-hidden className="shrink-0">
+        •
+      </span>
+      <span className="min-w-0 flex-1 truncate whitespace-nowrap">{text}</span>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -213,12 +213,9 @@ function SharedAssistantGroup({
       <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS}>
         <SharedAssistantAvatar assistantName={assistantName} />
         <div className="relative flex min-w-0 flex-col gap-2">
-          {group.messages.map((message, index) => {
+          {group.messages.map((message) => {
             return (
-              <ChatAssistantMessageBody
-                key={message.messageIndex}
-                compactTop={index > 0}
-              >
+              <ChatAssistantMessageBody key={message.messageIndex}>
                 {message.tree === undefined && richContent !== undefined ? (
                   <SharedRichMessageBody
                     messageIndex={message.messageIndex}


### PR DESCRIPTION
Chat responses keep history previews, the main result, and the latest status tail distinct. Sending another message immediately retires the previous tail while preserving its message, artifacts, and actions. Steering an active run also ends the previous work group immediately, before acknowledgement or another output.

- Restore chronological previews of the three output messages immediately before the main result. Expanding reveals the complete history, including rich content.
- Keep the main result ordered as message → remaining artifacts → action bar. Actions remain visible during progress and after subsequent user messages.
- Give only the latest response a status tail. Errors/interruption take precedence over progress, completion, and follow-ups. Pending inputs retire old tails before acknowledgement or output; stored events remain intact and reloading derives the same presentation.
- Separate UI work groups from execution runs. Visible user input ends the preceding group, including unassociated optimistic/pending steer messages. Delivery replacements retain the original submission time, and an earlier terminal event retains its original end time. One run can span several work groups; automatic goal continuations can span several runs within a group. Consecutive inputs without output do not create empty result sections.
- Let containers own spacing: 24px between message-list rows and 8px between nested assistant blocks. Message bodies and action rows add no vertical padding. Remove message-order and embedded-fold spacing conditions, negative vertical margin compensation, and the waiting response's empty action placeholder. Normal and shared chat views use the same message surfaces; controls retain their hit-target padding.

For example, steering at 12s now freezes the old group at `Worked for 12s`. If delivery occurs at 15s and the run finishes at 20s, the new group reports 8s. Previously, pending steer left the old group Working, delivery shortened it to the last output time, and the new group counted only the 5s after delivery.

The existing `ChatRunWorkFolding` switch controls work grouping, history folding, and status-tail ownership. Shared spacing rules apply to both normal and shared chat views. Submission times are derived from existing input replacement events; no stored event or API shape changes.

Validation: 121 unique focused page integration tests passed across 21 files, including nine new steer cases and the corrected history-duration expectation. Coverage includes optimistic send before acknowledgement, recorded pending/delivered input on page entry, stable timing through delivery/completion, previews/artifacts/actions, consecutive input, goal continuation, cancellation, long-history synchronization, conversation navigation, capability history, sharing, and engagement telemetry. Platform lint (including localization, Oxlint/type-aware checks, and ESLint), production/test/build-config type checks, formatting, and workspace Knip passed. The cached-list file also passed five consecutive runs. Its assertion now waits for the first catch-up request, after cache hydration, while remote and agent responses remain blocked; this keeps bootstrap latency outside the DOM assertion window and preserves the cache-before-network requirement. The complete test suite runs in the PR pipeline.

Layout screenshots: [full response on desktop and mobile](https://a.okou.io/ls8hqszojd.png) · [short response on desktop and mobile](https://a.okou.io/rzxpz299af.png).

Browser QA: PASS on head `dd10f4c4b2b915caf4cc303edcddf090a44c2f4c`, deployed as GitHub preview merge `6013db8feea3f0939c8e296ea84e7fb780609147` on both [App](https://pr-31791-app-okou-app-preview.vm0.workers.dev) and [API](https://pr-31791-api.vm6.ai). Chromium 151, 1440×1100 and 390×844; disposable test Pro account, onboarding bypassed, `chatRunWorkFolding=true`, `_realAgentInPreview=false`, Claude Fable 5.1 mock runner (Sonnet is absent from the current picker).

The live DOM trace changed Working to `Worked for 37s` on steer submission and retained 37s through delivery, completion, and reload. Persisted input timestamps span 36.898s, matching the rounded display. The prior main message and its copy action remained visible; waiting moved below the steer. Both widths had no horizontal overflow. Computed container spacing is 24px between message rows and 8px inside the main result, with zero vertical main padding. The mock fixture completed without a second output; the new output group's duration is covered by the page integration tests.

Current steer screenshots: [desktop](https://a.okou.io/af3aod71ar.png) · [mobile](https://a.okou.io/vl37ktv1fb.png).

Latest-head CI: 63 successful checks, 23 configured skips, no failures or pending checks.
