### PR TITLE
fix(platform): preserve focus during agent connector updates

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/job-detail-page.ts
+++ b/turbo/apps/platform/src/signals/okou-page/job-detail-page.ts
@@ -1,6 +1,7 @@
 import { command, computed, state } from "ccstate";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import { firewallPermissionMetadataByConnector } from "../firewall-permission-metadata.ts";
+import { onRef } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
 // JobPermissionsTab UI state
@@ -31,6 +32,13 @@ export const permSearch$ = computed((get) => {
 export const setPermSearch$ = command(({ set }, value: string) => {
   set(internalPermSearch$, value);
 });
+
+export const focusPermSearchRef$ = onRef(
+  command((_context, input: HTMLInputElement, signal: AbortSignal) => {
+    signal.throwIfAborted();
+    input.focus();
+  }),
+);
 
 const internalPermSearchActive$ = state(false);
 export const permSearchActive$ = computed((get) => {

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-connectors.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-connectors.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   connectorCatalogContract,
@@ -48,7 +49,7 @@ interface ConnectorSurfaceOptions {
     readonly agentId: string;
     readonly connectorSlugs: readonly string[];
     readonly operation: "add" | "remove" | "replace" | undefined;
-  }) => void;
+  }) => void | Promise<void>;
   readonly onCustomSave?: (args: {
     readonly agentId: string;
     readonly grants: readonly AgentCustomConnectorGrant[];
@@ -151,8 +152,8 @@ function mockConnectorSurface(
   );
   testContextValue.mocks.api(
     userConnectorsContract.update,
-    ({ body, params, respond }) => {
-      options.onBuiltInSave?.({
+    async ({ body, params, respond }) => {
+      await options.onBuiltInSave?.({
         agentId: params.id,
         connectorSlugs: body.enabledConnectorSlugs,
         operation: body.operation,
@@ -295,6 +296,60 @@ test("Connector changes for one agent never appear on another agent", async () =
   expect(
     screen.queryByLabelText("Revoke GitHub access"),
   ).not.toBeInTheDocument();
+});
+
+test("Connector search preserves keyboard focus while access is saved", async () => {
+  const user = userEvent.setup({ delay: null });
+  const save = context.mocks.deferred<void>();
+  mockConnectorSurface(context, {
+    catalog: [
+      catalogConnectorFixture("github", "GitHub", { hasPermissions: false }),
+      catalogConnectorFixture("axiom", "Axiom", { hasPermissions: false }),
+    ],
+    onBuiltInSave: () => {
+      return save.promise;
+    },
+  });
+  await setupTeamPage({
+    context,
+    path: `/agents/${RESEARCH_AGENT_ID}`,
+  });
+
+  await screen.findByText("GitHub");
+  click(screen.getByLabelText("Find connectors"));
+  const search = screen.getByPlaceholderText("Find connectors...");
+  expect(search).toHaveFocus();
+
+  await user.keyboard("{Tab}{Tab}");
+  expect(connectorAccessSwitch("Grant GitHub access")).toHaveFocus();
+  await user.keyboard(" ");
+  await waitFor(() => {
+    expect(connectorAccessSwitch("Revoke GitHub access")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+  expect(search).not.toHaveFocus();
+
+  const nextConnector = connectorAccessSwitch("Grant Axiom access");
+  nextConnector.focus();
+  expect(nextConnector).toHaveFocus();
+  save.resolve();
+  await screen.findByText("Connectors saved");
+  await waitFor(() => {
+    expect(connectorAccessSwitch("Revoke GitHub access")).not.toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+  expect(nextConnector).toHaveFocus();
+
+  click(screen.getByLabelText("Close search"));
+  expect(
+    screen.queryByPlaceholderText("Find connectors..."),
+  ).not.toBeInTheDocument();
+  click(screen.getByLabelText("Find connectors"));
+  expect(screen.getByPlaceholderText("Find connectors...")).toHaveFocus();
 });
 
 test("An agent with no connected services guides the user to Connectors", async () => {

--- a/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
@@ -105,6 +105,7 @@ import {
   setPermConnectorSlug$,
   permSearch$,
   setPermSearch$,
+  focusPermSearchRef$,
   permSearchActive$,
   setPermSearchActive$,
   permSavingConnectorSlug$,
@@ -442,6 +443,7 @@ function ConnectedConnectorPermissions({
   onManage: (connectorSlug: ConnectorSlug) => void;
 }) {
   const { t } = useTranslation("agents");
+  const focusSearch = useSet(focusPermSearchRef$);
   return (
     <>
       <div className="zero-card">
@@ -461,9 +463,7 @@ function ConnectedConnectorPermissions({
             <div className="absolute inset-0 flex items-center gap-2 px-5">
               <Search size={14} className="shrink-0 text-muted-foreground" />
               <input
-                ref={(el) => {
-                  return el?.focus();
-                }}
+                ref={focusSearch}
                 type="text"
                 placeholder={t(($) => {
                   return $.authorization.searchPlaceholder;


### PR DESCRIPTION
## Summary

When connector search is open on an agent's permissions page, saving connector access pulls keyboard focus back into the search field. Bind focus to the input's mount lifecycle with `onRef` and pass the stable `useSet` callback directly, preserving focus during permission updates while still focusing the field whenever search opens.

This follows the existing focus-ref pattern in `auth-v2-presentation.ts` and `settings/usage-pack-pricing-state.ts`.

## Verification

- Added a page integration regression covering initial focus, keyboard activation of an access toggle, focus during and after a deferred save, and focus when reopening search. Confirmed it fails against the original inline ref.
- Connector page suite: all 8 tests pass.
- Passed Platform type checks, scoped Knip, ESLint, Oxlint (including type-aware checks), Prettier, and diff/file-size checks.
