### PR TITLE
fix(platform): scope avatar operations to dialog sessions

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/job-detail/settings.ts
+++ b/turbo/apps/platform/src/signals/okou-page/job-detail/settings.ts
@@ -33,8 +33,10 @@ export const updateAgentSettings$ = command(
       client.updateMetadata({
         params: { id: detail.agentId },
         body: update,
+        fetchOptions: { signal },
       }),
       [200],
+      signal,
     );
     signal.throwIfAborted();
 

--- a/turbo/apps/platform/src/signals/okou-page/jobs-page.ts
+++ b/turbo/apps/platform/src/signals/okou-page/jobs-page.ts
@@ -6,6 +6,7 @@ import {
 } from "../../views/okou-page/avatar-svg-utils.ts";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { featureSwitch$ } from "../external/feature-switch.ts";
+import { closeAvatarMaker$ } from "./settings/avatar-maker.ts";
 
 function randomSvgAvatarUrl(composerEnabled = true): string {
   return serializeAvatarSvgConfig(
@@ -22,6 +23,9 @@ export const jobsDialogOpen$ = computed((get) => {
   return get(internalDialogOpen$);
 });
 export const setJobsDialogOpen$ = command(({ set }, open: boolean) => {
+  if (!open) {
+    set(closeAvatarMaker$);
+  }
   set(internalDialogOpen$, open);
 });
 
@@ -70,6 +74,7 @@ export const setJobsAvatarUrl$ = command(({ set }, url: string) => {
 // -- Create a fresh dialog draft --------------------------------------------
 
 export const resetJobsDialog$ = command(({ get, set }) => {
+  set(closeAvatarMaker$);
   set(internalNewName$, "");
   set(internalVisibility$, "private");
   set(

--- a/turbo/apps/platform/src/signals/okou-page/settings/avatar-maker.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/avatar-maker.ts
@@ -18,6 +18,7 @@ import {
   avatarNeckSweaterEnabled$,
   featureSwitch$,
 } from "../../external/feature-switch.ts";
+import { resetSignal } from "../../utils.ts";
 
 export type ComposerStep =
   | "face"
@@ -121,6 +122,11 @@ function updateLegacyConfig(
 }
 
 const internalOpen$ = state(false);
+const internalDialogSignal$ = state<AbortSignal | null>(null);
+const resetAvatarMakerDialogSignal$ = resetSignal();
+
+export { internalDialogSignal$ as avatarMakerDialogSignal$ };
+
 export const avatarMakerOpen$ = computed((get) => {
   return get(internalOpen$);
 });
@@ -172,8 +178,18 @@ export const setAvatarMakerSaving$ = command(({ set }, value: boolean) => {
   set(internalSaving$, value);
 });
 
+const releaseAvatarMakerSession$ = command(({ set }) => {
+  set(internalDialogSignal$, null);
+  set(internalOpen$, false);
+  set(internalJustPicked$, null);
+  set(internalShowSparkles$, false);
+  set(internalShuffling$, false);
+  set(internalSaving$, false);
+});
+
 export const shuffleAvatar$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    signal.throwIfAborted();
     const config = get(internalConfig$);
     set(
       internalConfig$,
@@ -196,7 +212,17 @@ export const shuffleAvatar$ = command(
  * avatar keeps being edited in the legacy steps even once the composer ships.
  */
 export const openAvatarMaker$ = command(
-  ({ get, set }, avatarUrl: string | null) => {
+  ({ get, set }, avatarUrl: string | null, parentSignal: AbortSignal) => {
+    parentSignal.throwIfAborted();
+    const dialogSignal = set(resetAvatarMakerDialogSignal$, parentSignal);
+    dialogSignal.addEventListener(
+      "abort",
+      () => {
+        set(releaseAvatarMakerSession$);
+      },
+      { once: true },
+    );
+    set(internalDialogSignal$, dialogSignal);
     const composerEnabled =
       get(featureSwitch$)[FeatureSwitchKey.AvatarComposerV2];
     const current = resolveAvatarSvgConfig(avatarUrl);
@@ -214,6 +240,7 @@ export const openAvatarMaker$ = command(
     set(internalJustPicked$, null);
     set(internalShowSparkles$, false);
     set(internalShuffling$, false);
+    set(internalSaving$, false);
     set(internalOpen$, true);
   },
 );
@@ -224,6 +251,7 @@ export const selectAvatarOption$ = command(
     selection: AvatarMakerSelection,
     signal: AbortSignal,
   ) => {
+    signal.throwIfAborted();
     const previous = get(internalConfig$);
     if (isLegacyAvatarSvgConfig(previous)) {
       if (selection.mode !== "legacy") {
@@ -268,7 +296,6 @@ export const goForwardStep$ = command(({ get, set }) => {
 });
 
 export const closeAvatarMaker$ = command(({ set }) => {
-  set(internalOpen$, false);
-  set(internalShowSparkles$, false);
-  set(internalJustPicked$, null);
+  set(resetAvatarMakerDialogSignal$);
+  set(releaseAvatarMakerSession$);
 });

--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-management.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-management.test.tsx
@@ -127,6 +127,7 @@ function configureCatalog(
   options: {
     readonly defaultAgentId?: string;
     readonly instructions?: Readonly<Record<string, string>>;
+    readonly createResponse?: Promise<void>;
   } = {},
 ): { readonly lastCreatedAgent: () => AgentResponse | null } {
   let agents = [...initialAgents];
@@ -138,17 +139,23 @@ function configureCatalog(
   context.mocks.api(agentsMainContract.list, ({ respond }) => {
     return respond(200, agents);
   });
-  context.mocks.api(agentsMainContract.create, ({ body, respond }) => {
-    const created = agent(CREATED_AGENT_ID, {
-      avatarUrl: body.avatarUrl ?? null,
-      description: body.description ?? null,
-      displayName: body.displayName ?? null,
-      visibility: body.visibility ?? "private",
-    });
-    lastCreatedAgent = created;
-    agents = [...agents, created];
-    return respond(201, created);
-  });
+  context.mocks.api(
+    agentsMainContract.create,
+    async ({ body, respond, withSignal }) => {
+      if (options.createResponse) {
+        await withSignal(options.createResponse);
+      }
+      const created = agent(CREATED_AGENT_ID, {
+        avatarUrl: body.avatarUrl ?? null,
+        description: body.description ?? null,
+        displayName: body.displayName ?? null,
+        visibility: body.visibility ?? "private",
+      });
+      lastCreatedAgent = created;
+      agents = [...agents, created];
+      return respond(201, created);
+    },
+  );
   context.mocks.api(agentsByIdContract.get, ({ params, respond }) => {
     const selected = agents.find((candidate) => {
       return candidate.agentId === params.id;
@@ -350,6 +357,37 @@ test("Create a public agent with a customized avatar", async () => {
   expect(
     within(createdCard).getByRole("img", { name: "Marketing Bot" }),
   ).toBeVisible();
+});
+
+test("Release avatar editing when the parent agent creation finishes", async () => {
+  const createResponse = context.mocks.deferred<void>();
+  configureCatalog(
+    [agent(CORE_AGENT_ID, { displayName: "Core Agent", visibility: "public" })],
+    { createResponse: createResponse.promise },
+  );
+  await setupPage({ context, path: "/agents" });
+  const creationDialog = await openCreateDialog("Private");
+  await fill(within(creationDialog).getByLabelText("Name"), "Private Analyst");
+  click(buttonByText("Create", creationDialog));
+  click(buttonByLabel("Customize avatar", creationDialog));
+  const avatarDialog = await screen.findByRole("dialog", {
+    name: "Give your agent a face",
+  });
+  click(buttonByLabel("Randomize avatar", avatarDialog));
+
+  createResponse.resolve(undefined);
+
+  await waitForAgentCard(CREATED_AGENT_ID);
+  const nextCreationDialog = await openCreateDialog("Private");
+  expect(within(nextCreationDialog).getByLabelText("Name")).toHaveValue("");
+  expect(
+    screen.queryByRole("dialog", { name: "Give your agent a face" }),
+  ).not.toBeInTheDocument();
+  click(buttonByLabel("Customize avatar", nextCreationDialog));
+  const nextAvatarDialog = await screen.findByRole("dialog", {
+    name: "Give your agent a face",
+  });
+  expect(buttonByLabel("Randomize avatar", nextAvatarDialog)).toBeEnabled();
 });
 
 test("Open an agent's management page from its card", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -182,6 +182,39 @@ test("Load the existing avatar into the maker instead of randomizing it", async 
   ]);
 });
 
+test("Cancel a pending avatar save and reopen an editable dialog", async () => {
+  prepareAgentProfile();
+  const saveStarted = context.mocks.deferred<void>();
+  let saveCancelled = false;
+  context.mocks.api(agentsByIdContract.updateMetadata, ({ request, never }) => {
+    request.signal.addEventListener(
+      "abort",
+      () => {
+        saveCancelled = true;
+      },
+      { once: true },
+    );
+    saveStarted.resolve(undefined);
+    return never();
+  });
+  await setupPage({ context, path: `/agents/${AGENT_ID}?tab=profile` });
+  click(await findCustomizeAvatarButton());
+  const dialog = await screen.findByRole("dialog", { name: "Edit avatar" });
+  click(within(dialog).getByLabelText("Angle 2"));
+  click(within(dialog).getByText("Use this avatar"));
+  await saveStarted.promise;
+
+  click(within(dialog).getByLabelText("Close"));
+
+  await waitFor(() => {
+    expect(saveCancelled).toBeTruthy();
+  });
+  click(await findCustomizeAvatarButton());
+  const reopened = await screen.findByRole("dialog", { name: "Edit avatar" });
+  expect(within(reopened).getByText("Use this avatar")).toBeEnabled();
+  expect(within(reopened).getByLabelText("Angle 2")).toBeEnabled();
+});
+
 test("Offer avatar creation instead of editing when the agent has no avatar", async () => {
   prepareAgentProfile(null);
   await setupPage({

--- a/turbo/apps/platform/src/views/okou-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-maker.tsx
@@ -35,10 +35,10 @@ import {
 } from "./avatar-svg-utils.ts";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
 import {
-  bestEffort,
   detach,
   onDomEventFn,
   Reason,
+  withCleanup,
 } from "../../signals/utils.ts";
 import {
   type AvatarMakerSelection,
@@ -46,6 +46,7 @@ import {
   type LegacyStep,
   type Step,
   avatarMakerOpen$,
+  avatarMakerDialogSignal$,
   avatarMakerConfig$,
   avatarMakerEditing$,
   avatarMakerStep$,
@@ -385,7 +386,7 @@ function AvatarPreviewWithShuffle() {
   const showSparkles = useGet(avatarMakerShowSparkles$);
   const shuffling = useGet(avatarMakerShuffling$);
   const shuffle = useSet(shuffleAvatar$);
-  const pageSignal = useGet(pageSignal$);
+  const dialogSignal = useGet(avatarMakerDialogSignal$);
 
   return (
     <div
@@ -402,9 +403,12 @@ function AvatarPreviewWithShuffle() {
             <button
               type="button"
               tabIndex={-1}
+              disabled={!dialogSignal}
               className="absolute -right-1 -bottom-1 flex h-7 w-7 items-center justify-center rounded-full bg-background text-muted-foreground shadow-sm border border-border hover:text-foreground transition-colors"
               onClick={() => {
-                detach(shuffle(pageSignal), Reason.DomCallback);
+                if (dialogSignal) {
+                  detach(shuffle(dialogSignal), Reason.DomCallback);
+                }
               }}
               aria-label={t(($) => {
                 return $.avatar.randomize;
@@ -534,7 +538,10 @@ function StepNavigator() {
 function AvatarMakerDialogBody({
   onConfirm,
 }: {
-  onConfirm: (config: ResolvedAvatarSvgConfig) => Promise<void>;
+  onConfirm: (
+    config: ResolvedAvatarSvgConfig,
+    signal: AbortSignal,
+  ) => Promise<void>;
 }) {
   const { t } = useTranslation("agents");
   const config = useGet(avatarMakerConfig$);
@@ -544,7 +551,7 @@ function AvatarMakerDialogBody({
   const saving = useGet(avatarMakerSaving$);
 
   const selectOption = useSet(selectAvatarOption$);
-  const pageSignal = useGet(pageSignal$);
+  const dialogSignal = useGet(avatarMakerDialogSignal$);
   const closeMaker = useSet(closeAvatarMaker$);
   const setSaving = useSet(setAvatarMakerSaving$);
 
@@ -564,14 +571,23 @@ function AvatarMakerDialogBody({
       });
 
   const handleConfirm = onDomEventFn(async () => {
+    if (!dialogSignal) {
+      return;
+    }
+    dialogSignal.throwIfAborted();
     setSaving(true);
-    await bestEffort(
+    await withCleanup(
       (async () => {
-        await onConfirm(config);
+        await onConfirm(config, dialogSignal);
+        dialogSignal.throwIfAborted();
         closeMaker();
       })(),
+      () => {
+        if (!dialogSignal.aborted) {
+          setSaving(false);
+        }
+      },
     );
-    setSaving(false);
   });
 
   return (
@@ -609,7 +625,12 @@ function AvatarMakerDialogBody({
               config={config}
               justPicked={justPicked}
               selectOption={(selection) => {
-                detach(selectOption(selection, pageSignal), Reason.DomCallback);
+                if (dialogSignal) {
+                  detach(
+                    selectOption(selection, dialogSignal),
+                    Reason.DomCallback,
+                  );
+                }
               }}
             />
           </div>
@@ -623,7 +644,7 @@ function AvatarMakerDialogBody({
             return $.actions.cancel;
           })}
         </Button>
-        <Button onClick={handleConfirm} disabled={saving}>
+        <Button onClick={handleConfirm} disabled={saving || !dialogSignal}>
           {saving
             ? t(($) => {
                 return $.actions.saving;
@@ -638,7 +659,10 @@ function AvatarMakerDialogBody({
 }
 
 interface AvatarMakerProps {
-  onConfirm: (config: ResolvedAvatarSvgConfig) => Promise<void>;
+  onConfirm: (
+    config: ResolvedAvatarSvgConfig,
+    signal: AbortSignal,
+  ) => Promise<void>;
   /** Avatar to load for editing. Omit to start from a random avatar. */
   avatarUrl?: string | null;
   /** Custom trigger element. Receives `openMaker` as `onClick`. When omitted, the default wand button is rendered. */
@@ -654,8 +678,9 @@ export function AvatarMaker({
   const open = useGet(avatarMakerOpen$);
   const setOpenMaker = useSet(openAvatarMaker$);
   const closeMaker = useSet(closeAvatarMaker$);
+  const pageSignal = useGet(pageSignal$);
   const openMaker = () => {
-    setOpenMaker(avatarUrl);
+    setOpenMaker(avatarUrl, pageSignal);
   };
 
   return (

--- a/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
@@ -103,7 +103,10 @@ function AvatarSettingsControl({
   isDefaultAgent: boolean;
   avatarUrl: string | null;
   alt: string;
-  onConfirm: (config: ResolvedAvatarSvgConfig) => Promise<void>;
+  onConfirm: (
+    config: ResolvedAvatarSvgConfig,
+    signal: AbortSignal,
+  ) => Promise<void>;
 }) {
   if (isDefaultAgent) {
     return (
@@ -403,7 +406,7 @@ export function SettingsTab({
                     isDefaultAgent={isDefaultAgent}
                     avatarUrl={avatarUrl}
                     alt={resolvedAgentName}
-                    onConfirm={async (cfg) => {
+                    onConfirm={async (cfg, signal) => {
                       const newAvatarUrl = serializeAvatarSvgConfig(cfg);
                       patchForm({
                         agentId,
@@ -417,8 +420,9 @@ export function SettingsTab({
                           avatarUrl: newAvatarUrl,
                           ...(canEditVisibility ? { visibility } : {}),
                         },
-                        pageSignal,
+                        signal,
                       );
+                      signal.throwIfAborted();
                       toast.success(
                         t(($) => {
                           return $.profile.saved;

--- a/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-detail-page.tsx
@@ -857,6 +857,7 @@ function AgentHeader({
   const { t } = useTranslation("agents");
   const nav = useSet(detachedNavigateTo$);
   const openMaker = useSet(openAvatarMaker$);
+  const pageSignal = useGet(pageSignal$);
 
   return (
     <DetailPageHeader>
@@ -876,7 +877,7 @@ function AgentHeader({
                       type="button"
                       onClick={() => {
                         onTabChange("profile");
-                        openMaker(avatarUrl);
+                        openMaker(avatarUrl, pageSignal);
                       }}
                       className="absolute -right-0.5 -bottom-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-background text-muted-foreground shadow-sm border border-border opacity-0 group-hover:opacity-100 hover:text-foreground transition-all"
                       aria-label={t(($) => {


### PR DESCRIPTION
## Summary

Closing and reopening Avatar Maker during its selection or shuffle delay could let an old operation advance the new dialog's step or stop its animation. Give each opening a page-bound dialog signal through `resetSignal`, cancel it on close or replacement, and release transient state when the session ends. Closing or resetting the parent agent-creation dialog also releases Avatar Maker.

Pass the same dialog signal through avatar saving to the metadata HTTP request, and guard save completion and cleanup so an expired session cannot close or reset a later dialog.

## Verification

- Focused Platform page tests: `settings-tab.test.tsx` and `agents-management.test.tsx` — 24 passed, including regressions for cancelling an in-flight avatar save and completing parent agent creation while Avatar Maker is open.
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm exec knip --workspace apps/platform`
- Real-timer command reproduction: composer and legacy selection cancellation, shuffle isolation across reopening, and page-abort cleanup.
