### PR TITLE
test(platform): stabilize touch keyboard send assertion

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-keyboard.test.tsx
@@ -292,9 +292,7 @@ test("Use the appropriate Enter behavior on touch devices", async () => {
       "Send with the hardware shortcut",
     ]);
   });
-  await expect(
-    screen.findByText("Send with the hardware shortcut"),
-  ).resolves.toBeVisible();
+  await expectSentPrompt("Send with the hardware shortcut");
 });
 
 test("Treat whitespace as an empty message", async () => {


### PR DESCRIPTION
The touch-device keyboard test can fail after Control+Enter because `findByText` returns a message span that is detached before `.resolves.toBeVisible()` runs. Reuse the existing `expectSentPrompt` helper to query the current sent user message and check its visibility synchronously inside `waitFor`. The exact sent-prompt assertions remain intact.

Failure evidence: [test-app (5)](https://github.com/vm0-ai/vm0/actions/runs/33938778551/job/101231920694), at `chat-composer-keyboard.test.tsx:297`, reports an element no longer in the document. The [same SHA passed in the merge queue](https://github.com/vm0-ai/vm0/actions/runs/33938462633/job/101230979859), and [the adjacent main run passed](https://github.com/vm0-ai/vm0/actions/runs/33938896609/job/101232582761). The unrelated HTTP 500 and coverage-upload warnings are not the failing assertion; no teardown AbortError or unhandled rejection was reported for this test.

Validation:

- Target file: 5 consecutive runs, all 7 tests passed each time (35/35).
- Formatting and commit-message validation passed.
- Scoped ESLint, Oxlint (including type-aware lint), all three Platform TypeScript configurations, and Platform Knip passed.
- [PR Turbo CI](https://github.com/vm0-ai/vm0/actions/runs/33941574278) passed, including all 8 App test shards. [Shard 5](https://github.com/vm0-ai/vm0/actions/runs/33941574278/job/101239959089) passed all 143 tests, including the touch-device keyboard case.
- The original intermittent detached-node timing was not reproduced locally; diagnosis uses the failing CI log and the query/assertion scheduling boundary. The full test suite runs in the PR pipeline.
