### PR TITLE
refactor(eslint): rename the internal lint plugin namespace to okou

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -269,7 +269,7 @@ export default [
       "src/signals/routes/test-*.ts",
     ],
     rules: {
-      "vm0/no-abort-signal-in-object-params": [
+      "okou/no-abort-signal-in-object-params": [
         "error",
         {
           allowedFunctions: [

--- a/turbo/apps/cli/eslint.config.mjs
+++ b/turbo/apps/cli/eslint.config.mjs
@@ -14,7 +14,7 @@ export default [
       "src/**/*.spec.ts",
     ],
     rules: {
-      "vm0/no-abort-signal-in-object-params": "error",
+      "okou/no-abort-signal-in-object-params": "error",
     },
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -49,7 +49,7 @@ export default [
     ...pluginReact.configs.flat.recommended,
     settings: {
       react: { version: "detect" },
-      "vm0/eslint-cache-fingerprint": eslintCacheFingerprint,
+      "okou/eslint-cache-fingerprint": eslintCacheFingerprint,
     },
   },
   {
@@ -134,7 +134,7 @@ export default [
       "src/signals/fetch.ts",
     ],
     rules: {
-      "vm0/no-abort-signal-in-object-params": "error",
+      "okou/no-abort-signal-in-object-params": "error",
     },
   },
   {

--- a/turbo/packages/api-contracts/eslint.config.mjs
+++ b/turbo/packages/api-contracts/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
   {
     files: ["src/contracts/*.ts"],
     rules: {
-      "vm0/no-re-export": "off",
+      "okou/no-re-export": "off",
     },
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),

--- a/turbo/packages/api-services/eslint.config.mjs
+++ b/turbo/packages/api-services/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
   {
     files: ["src/index.ts"],
     rules: {
-      "vm0/no-re-export": "off",
+      "okou/no-re-export": "off",
     },
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),

--- a/turbo/packages/connectors/eslint.config.mjs
+++ b/turbo/packages/connectors/eslint.config.mjs
@@ -18,14 +18,14 @@ export default [
       "src/auth-providers/connectors/test-oauth/**",
     ],
     rules: {
-      "vm0/no-abort-signal-in-object-params": "error",
+      "okou/no-abort-signal-in-object-params": "error",
     },
   },
   // Public package entry points may aggregate implementation modules.
   {
     files: ["src/firewall-types.ts", "src/firewall-metadata/policy.ts"],
     rules: {
-      "vm0/no-re-export": "off",
+      "okou/no-re-export": "off",
     },
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),

--- a/turbo/packages/core/eslint.config.mjs
+++ b/turbo/packages/core/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
   {
     files: ["src/*.ts", "src/contracts/index.ts"],
     rules: {
-      "vm0/no-re-export": "off",
+      "okou/no-re-export": "off",
     },
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),

--- a/turbo/packages/db/eslint.config.mjs
+++ b/turbo/packages/db/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
   {
     files: ["src/schema/*.ts"],
     rules: {
-      "vm0/no-re-export": "off",
+      "okou/no-re-export": "off",
     },
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),

--- a/turbo/packages/eslint-config/base.js
+++ b/turbo/packages/eslint-config/base.js
@@ -8,7 +8,7 @@ import { noAbortSignalInObjectParams } from "./no-abort-signal-in-object-params.
 
 export { oxlint };
 
-const vm0Plugin = {
+const okouPlugin = {
   rules: {
     "no-abort-signal-in-object-params": noAbortSignalInObjectParams,
     "no-msw-bypass": {
@@ -148,14 +148,14 @@ export const config = [
   {
     plugins: {
       turbo: turboPlugin,
-      vm0: vm0Plugin,
+      okou: okouPlugin,
     },
     rules: {
       "turbo/no-undeclared-env-vars": "warn",
       "arrow-body-style": ["error", "always"],
       complexity: ["error", { max: 20 }],
-      "vm0/no-msw-bypass": "error",
-      "vm0/no-re-export": "error",
+      "okou/no-msw-bypass": "error",
+      "okou/no-re-export": "error",
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
@@ -165,7 +165,7 @@ export const config = [
   {
     files: ["**/*.ts", "**/*.tsx"],
     rules: {
-      "vm0/no-legacy-automation-identifiers": "error",
+      "okou/no-legacy-automation-identifiers": "error",
       "@typescript-eslint/naming-convention": [
         "error",
         // Variables and parameters: camelCase, UPPER_CASE, or PascalCase
@@ -206,7 +206,7 @@ export const config = [
   {
     files: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
     rules: {
-      "vm0/no-fetch-spy": "error",
+      "okou/no-fetch-spy": "error",
     },
   },
   {

--- a/turbo/packages/eslint-config/no-abort-signal-in-object-params.node.js
+++ b/turbo/packages/eslint-config/no-abort-signal-in-object-params.node.js
@@ -21,9 +21,9 @@ function lint(code, options) {
         sourceType: "module",
         parser: tseslint.parser,
       },
-      plugins: { vm0: plugin },
+      plugins: { okou: plugin },
       rules: {
-        "vm0/no-abort-signal-in-object-params": ["error", options ?? {}],
+        "okou/no-abort-signal-in-object-params": ["error", options ?? {}],
       },
     },
   ]);

--- a/turbo/packages/eslint-rules/eslint.config.mjs
+++ b/turbo/packages/eslint-rules/eslint.config.mjs
@@ -16,7 +16,7 @@ export default [
   {
     files: ["src/index.ts"],
     rules: {
-      "vm0/no-re-export": "off",
+      "okou/no-re-export": "off",
     },
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),

--- a/turbo/packages/pi-agent-runtime/eslint.config.mjs
+++ b/turbo/packages/pi-agent-runtime/eslint.config.mjs
@@ -17,13 +17,13 @@ export default [
       "src/**/*.spec.ts",
     ],
     rules: {
-      "vm0/no-abort-signal-in-object-params": "error",
+      "okou/no-abort-signal-in-object-params": "error",
     },
   },
   {
     files: ["src/index.ts", "src/node.ts"],
     rules: {
-      "vm0/no-re-export": "off",
+      "okou/no-re-export": "off",
     },
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),

--- a/turbo/packages/ui/eslint.config.mjs
+++ b/turbo/packages/ui/eslint.config.mjs
@@ -7,7 +7,7 @@ export default [
   {
     files: ["src/index.ts"],
     rules: {
-      "vm0/no-re-export": "off",
+      "okou/no-re-export": "off",
     },
   },
   ...oxlint.buildFromOxlintConfigFile("./.oxlintrc.json"),


### PR DESCRIPTION
Closes #31799 — #26873 workstream R8 (tier P0).

## What

Renames the repository's internal ESLint plugin namespace from the retired brand `vm0` to `okou`:

- `turbo/packages/eslint-config/base.js` — `const vm0Plugin` → `const okouPlugin`, and the registration `vm0: vm0Plugin` → `okou: okouPlugin`.
- All 20 `vm0/<rule>` references across 13 config files → `okou/<rule>`.
- The `vm0/eslint-cache-fingerprint` settings key in `turbo/apps/platform/eslint.config.js` → `okou/eslint-cache-fingerprint`.

Rule names, rule implementations, severities, and the set of enabled rules are unchanged. No file is added, renamed, or deleted.

## Why now

#26873 R0 adds a repository guard rejecting new unclassified branded identifiers, and the natural implementation is a new rule in this plugin (precedent: `no-legacy-automation-identifiers`). Landing that guard first would name it `vm0/no-legacy-brand-identifiers` — after the brand it exists to retire — and force an immediate second rename.

## Evidence that no rule went silently inactive

Dumped `eslint --print-config` for 18 representative files covering every affected package (including files that hit each per-package override and a `*.test.ts` for `no-fetch-spy`), on `main` and on this branch. After normalizing `vm0/` → `okou/` in the baseline, the resolved configs match exactly: identical rule ids, severities, options, and key order in all 18.

The only intended differences are the `plugins` array entry (`vm0` → `okou`) and the platform ESLint cache fingerprint, which hashes the config files and therefore changes by design.

Also run locally:

- `node --test no-abort-signal-in-object-params.node.js` — 8/8 pass.
- `pnpm lint` in `apps/api`, `apps/cli`, `apps/platform`, `packages/{core,db,ui,api-services,api-contracts,eslint-rules,connectors,pi-agent-runtime}` — all exit 0.
- `git grep -nE 'vm0/(no-|eslint-cache-fingerprint)' -- turbo ':!*CHANGELOG.md'` — no output.
- `npx prettier --check` on all changed files — clean.

## The trap, avoided

Three `vm0/`-prefixed string families in this repo are **not** rule ids and are untouched:

- `group: "vm0/bdd-auth"` in `run-lifecycle.bdd.test.ts` — runner group label.
- `RUNNER_GROUP = "vm0/google-forms-webhook-test"` in `webhooks-google-forms.test.ts` — runner group label.
- `vm0/default`, `vm0/large`, `vm0/test` — built-in model ids, wire values.

`git diff` on both test files is empty; the diff touches only the 13 ESLint config files.

## Non-goals respected

No rules added, removed, or re-severitied. No other plugin namespace touched (`react-hooks`, `turbo`, `@typescript-eslint`, `apiLintPlugin`, `ccstatePlugin`). No package, directory, or file renamed. No unrelated lint violations fixed. No other `zero`/`vm0` naming touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)