### PR TITLE
fix(platform): show mark all read in mobile sidebar

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1340,6 +1340,35 @@ test("Mark all current-agent chats read from the chat-list menu", async () => {
   });
 });
 
+test("Show mark all read in the mobile chat-list menu", async () => {
+  mockMobileLayout();
+  prepareDefaultAgent();
+  mockSidebarThreadStory([
+    createThread(INCIDENT_THREAD_ID, "Unread conversation"),
+  ]);
+  mockUnreadAgents(() => {
+    return [AGENT_ID];
+  });
+
+  await setupSidebarPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+  });
+
+  const list = await waitFor(() => {
+    const current = mobileSidebar();
+    expect(
+      within(current).getByText("Unread conversation"),
+    ).toBeInTheDocument();
+    return current;
+  });
+  click(within(list).getByLabelText("Open chat list menu"));
+
+  await waitFor(() => {
+    expect(menuItemByText("Mark all read")).toBeInTheDocument();
+  });
+});
+
 test("Mark all of an agent’s chats read", async () => {
   mockMobileLayout();
   prepareAgents();

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -366,6 +366,7 @@ function ExpandedSidebarSections() {
       <ChatThreadsSection
         scrollSignals={responsiveSidebarChatThreadScrollSignals}
         contentClassName="px-2"
+        showMarkAllRead
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- show the existing **Mark all read** action in the responsive mobile chat-list menu when the current agent has unread chats
- add page-level regression coverage for the mobile sidebar menu

## Verification

- `pnpm exec prettier --write apps/platform/src/views/okou-page/sidebar.tsx apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx --silent=passed-only` (37 tests)
