### PR TITLE
fix(platform): remove shared worker timeouts and automatic reloads

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -44,8 +44,12 @@ a handled API request.
 The shared database Worker reports the same response to its connected tabs as
 a `worker-unavailable` event with reason `force-upgrade-required`. Tabs route
 that event through the same update dialog instead of reloading automatically.
-Other Worker-unavailable reasons continue to use the bounded automatic reload
-recovery and raise an error so the failure remains visible in Sentry.
+Worker load and transport failures reject pending requests with their original
+error and mark the connection disconnected. Queries and computed reads have no
+time limit and remain cancellable through their owning lifecycle. An IndexedDB
+version change closes the affected connection and reports it as unavailable.
+These failures propagate through the normal error handling without reloading
+the page.
 
 The platform app also registers a service worker. Service-worker code is a
 browser-resident deployable surface, so changes to its behavior must account for

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -3257,8 +3257,7 @@
   "global": {
     "errors": {
       "httpStatus": "HTTP {{status}}",
-      "requestFailed": "Die Anfrage ist fehlgeschlagen",
-      "sharedDatabaseUnavailable": "In der App ist ein Problem aufgetreten. Bitte warten Sie einen Moment und aktualisieren Sie dann die Seite, um es erneut zu versuchen."
+      "requestFailed": "Die Anfrage ist fehlgeschlagen"
     },
     "realtime": {
       "degraded": "Bei Live-Updates ist ein Problem aufgetreten. Bitte aktualisieren Sie die Seite.",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -3249,8 +3249,7 @@
   "global": {
     "errors": {
       "httpStatus": "HTTP {{status}}",
-      "requestFailed": "Request failed",
-      "sharedDatabaseUnavailable": "The app ran into a problem. Please wait a moment, then refresh the page to try again."
+      "requestFailed": "Request failed"
     },
     "realtime": {
       "degraded": "Live updates ran into a problem. Please refresh the page.",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -3307,8 +3307,7 @@
   "global": {
     "errors": {
       "httpStatus": "HTTP {{status}}",
-      "requestFailed": "Solicitud fallida",
-      "sharedDatabaseUnavailable": "Se produjo un problema en la aplicación. Espera un momento y, a continuación, actualiza la página para volver a intentarlo."
+      "requestFailed": "Solicitud fallida"
     },
     "realtime": {
       "degraded": "Se produjo un problema con las actualizaciones en directo. Actualiza la página.",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -3307,8 +3307,7 @@
   "global": {
     "errors": {
       "httpStatus": "HTTP {{status}}",
-      "requestFailed": "La requête a échoué",
-      "sharedDatabaseUnavailable": "L’application a rencontré un problème. Veuillez patienter un moment, puis actualiser la page pour réessayer."
+      "requestFailed": "La requête a échoué"
     },
     "realtime": {
       "degraded": "Les mises à jour en direct ont rencontré un problème. Veuillez actualiser la page.",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -3257,8 +3257,7 @@
   "global": {
     "errors": {
       "httpStatus": "HTTP {{status}}",
-      "requestFailed": "अनुरोध विफल रहा",
-      "sharedDatabaseUnavailable": "ऐप में कोई समस्या आ गई है। कृपया कुछ देर प्रतीक्षा करें, फिर दोबारा कोशिश करने के लिए पेज रीफ़्रेश करें।"
+      "requestFailed": "अनुरोध विफल रहा"
     },
     "realtime": {
       "degraded": "लाइव अपडेट में समस्या आई। कृपया पृष्ठ को ताज़ा करें.",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -3249,8 +3249,7 @@
   "global": {
     "errors": {
       "httpStatus": "HTTP {{status}}",
-      "requestFailed": "Permintaan gagal",
-      "sharedDatabaseUnavailable": "Aplikasi mengalami masalah. Tunggu sebentar, lalu segarkan halaman untuk mencoba lagi."
+      "requestFailed": "Permintaan gagal"
     },
     "realtime": {
       "degraded": "Pembaruan langsung mengalami masalah. Segarkan halaman.",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -3307,8 +3307,7 @@
   "global": {
     "errors": {
       "httpStatus": "HTTP {{status}}",
-      "requestFailed": "Richiesta non riuscita",
-      "sharedDatabaseUnavailable": "Si è verificato un problema nell'app. Attendi un momento, quindi aggiorna la pagina per riprovare."
+      "requestFailed": "Richiesta non riuscita"
     },
     "realtime": {
       "degraded": "Gli aggiornamenti in tempo reale hanno riscontrato un problema. Aggiorna la pagina.",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -3249,8 +3249,7 @@
   "global": {
     "errors": {
       "httpStatus": "HTTP {{status}}",
-      "requestFailed": "リクエストが失敗しました",
-      "sharedDatabaseUnavailable": "アプリで問題が発生しました。少し待ってから、ページを更新してもう一度お試しください。"
+      "requestFailed": "リクエストが失敗しました"
     },
     "realtime": {
       "degraded": "ライブアップデートで問題が発生しました。ページを更新してください。",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -3249,8 +3249,7 @@
   "global": {
     "errors": {
       "httpStatus": "HTTP {{status}}",
-      "requestFailed": "요청 실패",
-      "sharedDatabaseUnavailable": "앱에 문제가 발생했습니다. 잠시 기다린 후 페이지를 새로고침하여 다시 시도하세요."
+      "requestFailed": "요청 실패"
     },
     "realtime": {
       "degraded": "실시간 업데이트에 문제가 발생했습니다. 페이지를 새로고침하세요.",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -3307,8 +3307,7 @@
   "global": {
     "errors": {
       "httpStatus": "HTTP {{status}}",
-      "requestFailed": "Falha na solicitação",
-      "sharedDatabaseUnavailable": "O app encontrou um problema. Aguarde um momento e atualize a página para tentar novamente."
+      "requestFailed": "Falha na solicitação"
     },
     "realtime": {
       "degraded": "As atualizações em tempo real encontraram um problema. Atualize a página.",

--- a/turbo/apps/platform/src/shared-database/__tests__/single-connection-client.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/single-connection-client.test.ts
@@ -12,10 +12,7 @@ import type {
   SharedDatabaseQuery,
   SharedDatabaseQueryResult,
 } from "../data-key.ts";
-import {
-  SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME,
-  type SharedDatabaseConnectionStatus,
-} from "../protocol.ts";
+import type { SharedDatabaseConnectionStatus } from "../protocol.ts";
 import { SingleConnectionSharedDatabaseBridge } from "../single-connection-client.ts";
 
 const axiomTelemetry = vi.hoisted(() => {
@@ -42,7 +39,6 @@ vi.mock("@axiomhq/js", () => {
 
 class FakeBridge implements SharedDatabaseBridge {
   queryCalls = 0;
-  queryError: Error | null = null;
 
   registerTab(): Promise<void> {
     return Promise.resolve();
@@ -58,11 +54,6 @@ class FakeBridge implements SharedDatabaseBridge {
     _query: SharedDatabaseQuery<TKey>,
   ): Promise<SharedDatabaseQueryResult<TKey>> {
     this.queryCalls += 1;
-    if (this.queryError) {
-      const error = this.queryError;
-      this.queryError = null;
-      return Promise.reject(error);
-    }
     return Promise.resolve([] as SharedDatabaseQueryResult<TKey>);
   }
 }
@@ -74,12 +65,6 @@ function dataKey(): SharedDatabaseDataKey {
     kind: "chat-event",
     threadId: "single-connection-thread",
   };
-}
-
-function clientNotConnectedError(): Error {
-  const error = new Error("Shared database client is not connected");
-  error.name = SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME;
-  return error;
 }
 
 function createEvents(): SharedDatabaseBridgeEvents {
@@ -132,34 +117,6 @@ async function createRegisteredBridge(): Promise<{
   await bridge.registerTab(owner.signal);
   return { bridge, bridges, owner };
 }
-
-test("Reload a tab whose shared-data registration has expired", async () => {
-  const bridges: FakeBridge[] = [];
-  const events = createEvents();
-  const bridge = new SingleConnectionSharedDatabaseBridge({
-    createBridge: () => {
-      const created = new FakeBridge();
-      bridges.push(created);
-      return created;
-    },
-    events,
-  });
-  const owner = createChildAbortController(context.signal);
-  await bridge.registerTab(owner.signal);
-  bridges[0]!.queryError = clientNotConnectedError();
-
-  const pendingQuery = bridge.query(query(), owner.signal);
-  await vi.waitFor(() => {
-    expect(events.workerUnavailable).toHaveBeenCalledWith(
-      "worker-load-or-transport-failure",
-    );
-  });
-
-  expect(bridges).toHaveLength(1);
-  expect(bridges[0]!.queryCalls).toBe(1);
-  owner.abort(new DOMException("App unloaded", "AbortError"));
-  await expect(pendingQuery).rejects.toMatchObject({ name: "AbortError" });
-});
 
 test("Reports production shared worker queries without entity identifiers", async () => {
   configureClientTelemetry("https://app.okou.ai/", "xaat-test-ingest-token");

--- a/turbo/apps/platform/src/shared-database/__tests__/single-connection-client.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/single-connection-client.test.ts
@@ -1,10 +1,7 @@
 import { expect, test, vi } from "vitest";
 
 import { testContext } from "../../signals/__tests__/test-helpers.ts";
-import {
-  createChildAbortController,
-  createDeferredPromise,
-} from "../../signals/utils.ts";
+import { createChildAbortController } from "../../signals/utils.ts";
 import type {
   SharedDatabaseBridge,
   SharedDatabaseBridgeEvents,
@@ -44,14 +41,10 @@ vi.mock("@axiomhq/js", () => {
 });
 
 class FakeBridge implements SharedDatabaseBridge {
-  readonly registrationSignals: AbortSignal[] = [];
-  readonly querySignals: AbortSignal[] = [];
   queryCalls = 0;
   queryError: Error | null = null;
-  queryPending = false;
 
-  registerTab(signal: AbortSignal): Promise<void> {
-    this.registrationSignals.push(signal);
+  registerTab(): Promise<void> {
     return Promise.resolve();
   }
 
@@ -63,18 +56,12 @@ class FakeBridge implements SharedDatabaseBridge {
 
   query<TKey extends SharedDatabaseDataKey>(
     _query: SharedDatabaseQuery<TKey>,
-    signal: AbortSignal,
   ): Promise<SharedDatabaseQueryResult<TKey>> {
     this.queryCalls += 1;
-    this.querySignals.push(signal);
     if (this.queryError) {
       const error = this.queryError;
       this.queryError = null;
       return Promise.reject(error);
-    }
-    if (this.queryPending) {
-      return createDeferredPromise<SharedDatabaseQueryResult<TKey>>(signal)
-        .promise;
     }
     return Promise.resolve([] as SharedDatabaseQueryResult<TKey>);
   }
@@ -95,18 +82,14 @@ function clientNotConnectedError(): Error {
   return error;
 }
 
-function createEvents(
-  statuses: SharedDatabaseConnectionStatus[] = [],
-): SharedDatabaseBridgeEvents {
+function createEvents(): SharedDatabaseBridgeEvents {
   return {
     chatThreadReadCursorUpdated: vi.fn<(payload: unknown) => void>(),
     computedReloaded: vi.fn<(computedKey: ComputedKey) => void>(),
     databaseInvalidated: vi.fn<(dataKey: SharedDatabaseDataKey) => void>(),
     databaseReconnected: vi.fn<() => void>(),
     workerUnavailable: vi.fn<SharedDatabaseBridgeEvents["workerUnavailable"]>(),
-    statusChanged: (status) => {
-      statuses.push(status);
-    },
+    statusChanged: vi.fn<(status: SharedDatabaseConnectionStatus) => void>(),
   };
 }
 
@@ -149,42 +132,6 @@ async function createRegisteredBridge(): Promise<{
   await bridge.registerTab(owner.signal);
   return { bridge, bridges, owner };
 }
-
-test("Reload a page whose shared-data request stops responding", async () => {
-  vi.useFakeTimers();
-  context.signal.addEventListener("abort", () => {
-    vi.useRealTimers();
-  });
-  const bridges: FakeBridge[] = [];
-  const statuses: SharedDatabaseConnectionStatus[] = [];
-  const events = createEvents(statuses);
-  const bridge = new SingleConnectionSharedDatabaseBridge({
-    controlRequestTimeoutMs: 10,
-    createBridge: () => {
-      const created = new FakeBridge();
-      bridges.push(created);
-      return created;
-    },
-    events,
-  });
-  const owner = createChildAbortController(context.signal);
-  await bridge.registerTab(owner.signal);
-  const firstBridge = bridges[0]!;
-  firstBridge.queryPending = true;
-
-  const pendingQuery = bridge.query(query(), owner.signal);
-  await vi.advanceTimersByTimeAsync(10);
-
-  expect(events.workerUnavailable).toHaveBeenCalledWith(
-    "worker-load-or-transport-failure",
-  );
-  expect(bridges).toHaveLength(1);
-  expect(firstBridge.registrationSignals).toHaveLength(1);
-  expect(statuses).toStrictEqual(["connecting"]);
-
-  owner.abort(new DOMException("App unloaded", "AbortError"));
-  await expect(pendingQuery).rejects.toMatchObject({ name: "AbortError" });
-});
 
 test("Reload a tab whose shared-data registration has expired", async () => {
   const bridges: FakeBridge[] = [];

--- a/turbo/apps/platform/src/shared-database/message-port-client.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-client.ts
@@ -112,7 +112,7 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
   }
 
   fail(reason: unknown): void {
-    this.close(reason, false);
+    this.close(reason);
   }
 
   async getComputed<TKey extends ComputedKey>(

--- a/turbo/apps/platform/src/shared-database/message-port-server.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-server.ts
@@ -19,7 +19,6 @@ import {
   redactSharedDatabaseClientMessageForLog,
   serializeSharedDatabaseError,
   sharedDatabaseClientMessageSchema,
-  SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME,
   type SharedDatabaseClientMessage,
   type SharedDatabaseWorkerMessage,
 } from "./protocol.ts";
@@ -46,13 +45,6 @@ interface PendingTokenRequest {
 
 const L = logger("SharedDatabaseWorker");
 const BridgeL = logger("SharedWorkerBridge");
-
-class SharedDatabaseClientNotConnectedError extends Error {
-  constructor() {
-    super("Shared database tab registration is required before query");
-    this.name = SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME;
-  }
-}
 
 export class SharedDatabaseMessagePortServer {
   private readonly connectionId = crypto.randomUUID();
@@ -148,7 +140,9 @@ export class SharedDatabaseMessagePortServer {
     signal: AbortSignal,
   ): Promise<unknown> | unknown {
     if (this.registeredSignal !== signal) {
-      throw new SharedDatabaseClientNotConnectedError();
+      throw new Error(
+        "Shared database tab registration is required before query",
+      );
     }
     switch (message.type) {
       case "query": {
@@ -196,7 +190,9 @@ export class SharedDatabaseMessagePortServer {
   ) => {
     const registeredSignal = this.registeredSignal;
     if (!registeredSignal) {
-      throw new SharedDatabaseClientNotConnectedError();
+      throw new Error(
+        "Shared database tab registration is required before query",
+      );
     }
     const signal = AbortSignal.any([callerSignal, registeredSignal]);
     signal.throwIfAborted();
@@ -299,7 +295,9 @@ export class SharedDatabaseMessagePortServer {
       if (!registeredSignal) {
         if ("requestId" in message) {
           await this.startRequest(message, this.connectionSignal, () => {
-            throw new SharedDatabaseClientNotConnectedError();
+            throw new Error(
+              "Shared database tab registration is required before query",
+            );
           });
         }
         return;

--- a/turbo/apps/platform/src/shared-database/protocol.ts
+++ b/turbo/apps/platform/src/shared-database/protocol.ts
@@ -5,9 +5,6 @@ import {
   sharedDatabaseQuerySchema,
 } from "./data-key.ts";
 
-export const SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME =
-  "SharedDatabaseClientNotConnectedError";
-
 const requestIdSchema = z.string().min(1);
 
 const registerTabMessageSchema = z
@@ -145,7 +142,6 @@ const getTokenRequestSchema = z
 export const sharedDatabaseWorkerUnavailableReasonSchema = z.enum([
   "force-upgrade-required",
   "indexeddb-version-changed",
-  "worker-load-or-transport-failure",
 ]);
 
 export type SharedDatabaseWorkerUnavailableReason = z.infer<

--- a/turbo/apps/platform/src/shared-database/single-connection-client.ts
+++ b/turbo/apps/platform/src/shared-database/single-connection-client.ts
@@ -1,9 +1,4 @@
 import { observeClientOperation } from "../lib/client-telemetry.ts";
-import {
-  createChildAbortController,
-  createDeferredPromise,
-  settle,
-} from "../signals/utils.ts";
 import type {
   SharedDatabaseBridge,
   SharedDatabaseBridgeEvents,
@@ -14,10 +9,6 @@ import type {
   SharedDatabaseQueryResult,
 } from "./data-key.ts";
 import type { ComputedKey, ComputedValue } from "./computed-key.ts";
-import {
-  SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME,
-  type SharedDatabaseWorkerUnavailableReason,
-} from "./protocol.ts";
 
 interface SingleConnectionSharedDatabaseBridgeOptions {
   readonly createBridge: (
@@ -28,46 +19,26 @@ interface SingleConnectionSharedDatabaseBridgeOptions {
 }
 
 export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridge {
-  private readonly connectionEvents: SharedDatabaseBridgeEvents;
   private bridge: SharedDatabaseBridge | null = null;
-  private connectionController: AbortController | null = null;
   private ownerSignal: AbortSignal | null = null;
-  private preparation: Promise<void> | null = null;
-  private workerUnavailable = false;
 
   constructor(
     private readonly options: SingleConnectionSharedDatabaseBridgeOptions,
-  ) {
-    this.connectionEvents = {
-      ...options.events,
-      workerUnavailable: (reason) => {
-        this.reportWorkerUnavailable(reason);
-      },
-    };
-  }
+  ) {}
 
   prepare(signal: AbortSignal): Promise<void> {
     this.bindOwner(signal);
-    if (this.bridge) {
-      return Promise.resolve();
+    if (!this.bridge) {
+      this.options.events.statusChanged("connecting");
+      this.bridge = this.options.createBridge(this.options.events, signal);
     }
-    if (this.preparation) {
-      return this.preparation;
-    }
-    if (this.workerUnavailable) {
-      return this.waitForReload(signal);
-    }
-    const preparation = this.prepareTransport(signal);
-    this.preparation = preparation;
-    return preparation;
+    return Promise.resolve();
   }
 
   async registerTab(signal: AbortSignal): Promise<void> {
     await this.prepare(signal);
     const bridge = this.requireRegistered(this.bridge);
-    await bridge.registerTab(
-      this.requireRegistered(this.connectionController).signal,
-    );
+    await bridge.registerTab(this.requireRegistered(this.ownerSignal));
     signal.throwIfAborted();
   }
 
@@ -84,9 +55,7 @@ export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridg
         template: `${query.dataKey.kind}.${query.consistency}`,
       },
       async () => {
-        return await this.runWithReload(() => {
-          return bridge.query(query, signal);
-        }, signal);
+        return await bridge.query(query, signal);
       },
     );
   }
@@ -95,9 +64,7 @@ export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridg
     computedKey: TKey,
   ): Promise<ComputedValue<TKey>> {
     const bridge = this.requireRegistered(this.bridge);
-    return await this.runWithReload(() => {
-      return bridge.getComputed(computedKey);
-    }, this.requireRegistered(this.ownerSignal));
+    return await bridge.getComputed(computedKey);
   }
 
   private bindOwner(signal: AbortSignal): void {
@@ -109,75 +76,6 @@ export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridg
     }
     signal.throwIfAborted();
     this.ownerSignal = signal;
-  }
-
-  private async prepareTransport(signal: AbortSignal): Promise<void> {
-    signal.throwIfAborted();
-    const controller = createChildAbortController(
-      this.requireRegistered(this.ownerSignal),
-    );
-    this.options.events.statusChanged("connecting");
-    const created = await settle(
-      this.constructBridge(controller.signal),
-      signal,
-    );
-    if (!created.ok) {
-      controller.abort(created.error);
-      return await this.requestReload(signal);
-    }
-    this.connectionController = controller;
-    this.bridge = created.value;
-  }
-
-  private async constructBridge(
-    signal: AbortSignal,
-  ): Promise<SharedDatabaseBridge> {
-    return await this.options.createBridge(this.connectionEvents, signal);
-  }
-
-  private async runWithReload<T>(
-    operation: () => Promise<T>,
-    signal: AbortSignal,
-  ): Promise<T> {
-    signal.throwIfAborted();
-    if (this.workerUnavailable) {
-      return await this.waitForReload(signal);
-    }
-    const work = (async (): Promise<T> => {
-      return await operation();
-    })();
-    const result = await settle(work, signal);
-    if (this.workerUnavailable) {
-      return await this.waitForReload(signal);
-    }
-    if (result.ok) {
-      return result.value;
-    }
-    if (
-      result.error instanceof Error &&
-      result.error.name === SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME
-    ) {
-      return await this.requestReload(signal);
-    }
-    throw result.error;
-  }
-
-  private requestReload(signal: AbortSignal): Promise<never> {
-    this.reportWorkerUnavailable("worker-load-or-transport-failure");
-    return this.waitForReload(signal);
-  }
-
-  private reportWorkerUnavailable(
-    reason: SharedDatabaseWorkerUnavailableReason,
-  ): void {
-    if (!this.workerUnavailable) {
-      this.workerUnavailable = true;
-      this.options.events.workerUnavailable(reason);
-    }
-  }
-
-  private waitForReload(signal: AbortSignal): Promise<never> {
-    return createDeferredPromise<never>(signal).promise;
   }
 
   private requireRegistered<T>(value: T | null): T {

--- a/turbo/apps/platform/src/shared-database/single-connection-client.ts
+++ b/turbo/apps/platform/src/shared-database/single-connection-client.ts
@@ -1,11 +1,8 @@
-import { delay } from "signal-timers";
-
 import { observeClientOperation } from "../lib/client-telemetry.ts";
 import {
   createChildAbortController,
   createDeferredPromise,
   settle,
-  withCleanup,
 } from "../signals/utils.ts";
 import type {
   SharedDatabaseBridge,
@@ -22,51 +19,15 @@ import {
   type SharedDatabaseWorkerUnavailableReason,
 } from "./protocol.ts";
 
-const DEFAULT_CONTROL_REQUEST_TIMEOUT_MS = 10_000;
-
 interface SingleConnectionSharedDatabaseBridgeOptions {
   readonly createBridge: (
     events: SharedDatabaseBridgeEvents,
     signal: AbortSignal,
   ) => SharedDatabaseBridge;
   readonly events: SharedDatabaseBridgeEvents;
-  readonly controlRequestTimeoutMs?: number;
-}
-
-class SharedDatabaseTransportTimeoutError extends Error {
-  constructor() {
-    super("Shared database worker transport timed out");
-    this.name = "SharedDatabaseTransportTimeoutError";
-  }
-}
-
-function requiresReload(error: unknown): boolean {
-  return (
-    error instanceof SharedDatabaseTransportTimeoutError ||
-    (error instanceof Error &&
-      error.name === SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME)
-  );
-}
-
-async function withTransportTimeout<T>(
-  work: Promise<T>,
-  timeoutMs: number,
-  signal: AbortSignal,
-): Promise<T> {
-  const timeoutController = createChildAbortController(signal);
-  const timeout = (async (): Promise<never> => {
-    await delay(timeoutMs, { signal: timeoutController.signal });
-    throw new SharedDatabaseTransportTimeoutError();
-  })();
-  return await withCleanup(Promise.race([work, timeout]), () => {
-    timeoutController.abort(
-      new DOMException("Transport request completed", "AbortError"),
-    );
-  });
 }
 
 export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridge {
-  private readonly controlRequestTimeoutMs: number;
   private readonly connectionEvents: SharedDatabaseBridgeEvents;
   private bridge: SharedDatabaseBridge | null = null;
   private connectionController: AbortController | null = null;
@@ -77,8 +38,6 @@ export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridg
   constructor(
     private readonly options: SingleConnectionSharedDatabaseBridgeOptions,
   ) {
-    this.controlRequestTimeoutMs =
-      options.controlRequestTimeoutMs ?? DEFAULT_CONTROL_REQUEST_TIMEOUT_MS;
     this.connectionEvents = {
       ...options.events,
       workerUnavailable: (reason) => {
@@ -187,24 +146,20 @@ export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridg
     const work = (async (): Promise<T> => {
       return await operation();
     })();
-    const result = await settle(
-      withTransportTimeout(
-        work,
-        this.controlRequestTimeoutMs,
-        this.requireRegistered(this.connectionController).signal,
-      ),
-      signal,
-    );
+    const result = await settle(work, signal);
     if (this.workerUnavailable) {
       return await this.waitForReload(signal);
     }
     if (result.ok) {
       return result.value;
     }
-    if (!requiresReload(result.error)) {
-      throw result.error;
+    if (
+      result.error instanceof Error &&
+      result.error.name === SHARED_DATABASE_CLIENT_NOT_CONNECTED_ERROR_NAME
+    ) {
+      return await this.requestReload(signal);
     }
-    return await this.requestReload(signal);
+    throw result.error;
   }
 
   private requestReload(signal: AbortSignal): Promise<never> {

--- a/turbo/apps/platform/src/shared-database/worker-runtime.ts
+++ b/turbo/apps/platform/src/shared-database/worker-runtime.ts
@@ -1131,7 +1131,7 @@ export class SharedDatabaseWorkerRuntime {
     let entry = this.databaseEntry;
     if (!entry) {
       const opener = createChatIdbOpener({
-        reload: () => {
+        onVersionChange: () => {
           if (this.databaseEntry) {
             this.databaseEntry.invalidated = true;
           }

--- a/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/shared-database-browser.test.ts
@@ -1,19 +1,21 @@
 import { screen } from "@testing-library/react";
 import { CLIENT_FORCE_UPGRADE_STATUS } from "@okouai/api-contracts/contracts/client-headers";
-import { toast } from "@okouai/ui/components/ui/sonner";
 import { expect, vi } from "vitest";
 
 import { setupPage } from "../../__tests__/page-helper.ts";
 import { mockedClerk } from "../../__tests__/mock-auth.ts";
-import { mockNow } from "../../lib/time.ts";
 import type { SharedDatabasePortLike } from "../../shared-database/bridge.ts";
-import { logger } from "../log.ts";
+import { sharedDatabaseClientMessageSchema } from "../../shared-database/protocol.ts";
 import { setupSharedDatabaseBridge$ } from "../shared-database-browser.ts";
+import {
+  bridgeConnected$,
+  installedSharedDatabaseBridge$,
+} from "../shared-database-bridge-state.ts";
+import { sharedDatabaseConnectionStatus$ } from "../shared-database.ts";
 import { detach, Reason } from "../utils.ts";
 import { testContext } from "./test-helpers.ts";
 
 const context = testContext();
-const RELOAD_AT_MS = Date.parse("2030-01-01T00:00:00.000Z");
 
 class TestSharedWorkerPort implements SharedDatabasePortLike {
   readonly postedMessages: unknown[] = [];
@@ -195,169 +197,98 @@ test("Open the force-upgrade dialog when the worker requires an upgrade", async 
   });
   await setupPage({ context, path: "/" });
 
-  await screen.findByRole("dialog", {
+  const dialog = await screen.findByRole("dialog", {
     name: "Update required",
   });
-  expect(
-    new URL(window.location.href).searchParams.has(
-      "okou-shared-database-reload",
-    ),
-  ).toBeFalsy();
+  expect(dialog).toBeInTheDocument();
 });
 
-test("Reload after an IndexedDB version change makes the worker unavailable", async () => {
-  const replace = vi.fn<(url: string) => void>();
-  const debug = vi.spyOn(logger("SharedWorkerBridge"), "debug");
+// These failures originate at the browser's worker boundary and have no page
+// action. Exercise production bridge setup and its request contract directly.
+test("Expose worker construction failures to bridge consumers", async () => {
+  const error = new Error("SharedWorker construction failed");
+  vi.stubGlobal(
+    "SharedWorker",
+    class {
+      constructor() {
+        throw error;
+      }
+    },
+  );
+
+  setupBridge();
+
+  await expect(context.store.get(bridgeConnected$)).rejects.toBe(error);
+});
+
+test("Return a worker query error to its caller", async () => {
   const { workers } = installSharedWorkerMock();
   setupBridge();
-  await vi.waitFor(() => {
-    expect(workers).toHaveLength(1);
-  });
-  const currentUrl = new URL("/chat", window.location.href);
-  vi.stubGlobal("location", {
-    href: currentUrl.toString(),
-    hostname: currentUrl.hostname,
-    origin: currentUrl.origin,
-    replace,
-  });
+  await context.store.get(bridgeConnected$);
+  const bridge = context.store.get(installedSharedDatabaseBridge$);
+  const query = bridge.query(
+    {
+      dataKey: { kind: "chat-event", threadId: "thread-1" },
+      afterSeqId: null,
+      consistency: "cache-only",
+    },
+    context.signal,
+  );
+  const request = workers[0]!.port.postedMessages
+    .map((message) => {
+      return sharedDatabaseClientMessageSchema.parse(message);
+    })
+    .find((message) => {
+      return message.type === "query";
+    });
+  if (!request) {
+    throw new Error("Expected a worker query request");
+  }
 
   workers[0]!.port.receive({
-    type: "worker-unavailable",
-    reason: "indexeddb-version-changed",
+    type: "error",
+    requestId: request.requestId,
+    error: {
+      name: "Error",
+      message: "Shared database tab registration is required before query",
+    },
   });
 
-  await vi.waitFor(() => {
-    expect(replace).toHaveBeenCalledOnce();
-  });
-  expect(debug).toHaveBeenLastCalledWith("Reloading app", {
-    reason: "indexeddb-version-changed",
-  });
-  const debugCallOrder = debug.mock.invocationCallOrder.at(-1);
-  const replaceCallOrder = replace.mock.invocationCallOrder[0];
-  if (debugCallOrder === undefined || replaceCallOrder === undefined) {
-    throw new Error("Expected debug log before app reload");
-  }
-  expect(debugCallOrder).toBeLessThan(replaceCallOrder);
+  await expect(query).rejects.toThrow(
+    "Shared database tab registration is required before query",
+  );
 });
 
-test("Reload once after the shared-data service fails to load", async () => {
-  mockNow(RELOAD_AT_MS, context.signal);
-  const replace = vi.fn<(url: string) => void>();
-  const debug = vi.spyOn(logger("SharedWorkerBridge"), "debug");
+test("Reject pending requests and mark the connection disconnected when the worker fails", async () => {
   const { constructorCalls, workers } = installSharedWorkerMock();
   setupBridge();
-  await vi.waitFor(() => {
-    expect(workers).toHaveLength(1);
-  });
-  const currentUrl = new URL(
-    "/chat?threadId=thread-1#latest",
-    window.location.href,
+  await context.store.get(bridgeConnected$);
+  const bridge = context.store.get(installedSharedDatabaseBridge$);
+  workers[0]!.port.receive({ type: "status", status: "connected" });
+  expect(context.store.get(sharedDatabaseConnectionStatus$)).toBe("connected");
+  const query = bridge.query(
+    {
+      dataKey: { kind: "chat-event", threadId: "thread-1" },
+      afterSeqId: null,
+      consistency: "cache-only",
+    },
+    context.signal,
   );
-  vi.stubGlobal("location", {
-    href: currentUrl.toString(),
-    hostname: currentUrl.hostname,
-    origin: currentUrl.origin,
-    replace,
-  });
-  expect(() => {
-    workers[0]!.fail();
-  }).toThrow(
-    "Shared database worker failed to load or its transport became unrecoverable",
-  );
+  const computed = bridge.getComputed("chat-thread-indicators");
 
-  expect(replace).toHaveBeenCalledOnce();
-  expect(debug).toHaveBeenLastCalledWith("Reloading app", {
-    reason: "worker-load-or-transport-failure",
-  });
-  const debugCallOrder = debug.mock.invocationCallOrder.at(-1);
-  const replaceCallOrder = replace.mock.invocationCallOrder[0];
-  if (debugCallOrder === undefined || replaceCallOrder === undefined) {
-    throw new Error("Expected debug log before app reload");
-  }
-  expect(debugCallOrder).toBeLessThan(replaceCallOrder);
-  const recoveryUrl = new URL(replace.mock.calls[0]![0]);
-  expect(recoveryUrl.searchParams.get("okou-shared-database-reload")).toBe(
-    String(RELOAD_AT_MS),
-  );
-  expect(recoveryUrl.searchParams.get("threadId")).toBe("thread-1");
-  expect(recoveryUrl.hash).toBe("#latest");
-  expect(constructorCalls).toHaveLength(1);
-});
+  workers[0]!.fail();
 
-test("Stop reloading when the shared-data service repeatedly fails", async () => {
-  mockNow(RELOAD_AT_MS, context.signal);
-  const replace = vi.fn<(url: string) => void>();
-  const debug = vi.spyOn(logger("SharedWorkerBridge"), "debug");
-  const replaceState = vi
-    .spyOn(history, "replaceState")
-    .mockImplementation(() => {});
-  const toastError = vi.spyOn(toast, "error").mockReturnValue("toast-id");
-  const { constructorCalls, workers } = installSharedWorkerMock();
-  setupBridge();
-  await vi.waitFor(() => {
-    expect(workers).toHaveLength(1);
-  });
-  const currentUrl = new URL(
-    `/chat?threadId=thread-1&okou-shared-database-reload=${RELOAD_AT_MS - 59_999}#latest`,
-    window.location.href,
+  await expect(query).rejects.toThrow(
+    "SharedWorker module script failed to load",
   );
-  vi.stubGlobal("location", {
-    href: currentUrl.toString(),
-    hostname: currentUrl.hostname,
-    origin: currentUrl.origin,
-    replace,
-  });
-  expect(() => {
-    workers[0]!.fail();
-  }).toThrow(
-    "Shared database worker failed to load or its transport became unrecoverable",
+  await expect(computed).rejects.toThrow(
+    "SharedWorker module script failed to load",
   );
-
-  expect(toastError).toHaveBeenCalledOnce();
-  expect(debug).not.toHaveBeenCalledWith("Reloading app", {
-    reason: "worker-load-or-transport-failure",
-  });
-  expect(replace).not.toHaveBeenCalled();
-  expect(replaceState).toHaveBeenCalledOnce();
-  const retryUrl = new URL(String(replaceState.mock.calls[0]![2]));
-  expect(retryUrl.searchParams.has("okou-shared-database-reload")).toBeFalsy();
-  expect(retryUrl.searchParams.get("threadId")).toBe("thread-1");
-  expect(retryUrl.hash).toBe("#latest");
-  expect(constructorCalls).toHaveLength(1);
-});
-
-test("Reload again after the shared-data recovery window has elapsed", async () => {
-  mockNow(RELOAD_AT_MS, context.signal);
-  const replace = vi.fn<(url: string) => void>();
-  const toastError = vi.spyOn(toast, "error");
-  const { constructorCalls, workers } = installSharedWorkerMock();
-  setupBridge();
-  await vi.waitFor(() => {
-    expect(workers).toHaveLength(1);
-  });
-  const currentUrl = new URL(
-    `/chat?threadId=thread-1&okou-shared-database-reload=${RELOAD_AT_MS - 60_000}#latest`,
-    window.location.href,
+  await expect(bridge.getComputed("chat-thread-indicators")).rejects.toThrow(
+    "SharedWorker module script failed to load",
   );
-  vi.stubGlobal("location", {
-    href: currentUrl.toString(),
-    hostname: currentUrl.hostname,
-    origin: currentUrl.origin,
-    replace,
-  });
-  expect(() => {
-    workers[0]!.fail();
-  }).toThrow(
-    "Shared database worker failed to load or its transport became unrecoverable",
+  expect(context.store.get(sharedDatabaseConnectionStatus$)).toBe(
+    "disconnected",
   );
-
-  expect(replace).toHaveBeenCalledOnce();
-  const recoveryUrl = new URL(replace.mock.calls[0]![0]);
-  expect(recoveryUrl.searchParams.get("okou-shared-database-reload")).toBe(
-    String(RELOAD_AT_MS),
-  );
-  expect(recoveryUrl.searchParams.get("threadId")).toBe("thread-1");
-  expect(recoveryUrl.hash).toBe("#latest");
-  expect(toastError).not.toHaveBeenCalled();
   expect(constructorCalls).toHaveLength(1);
 });

--- a/turbo/apps/platform/src/signals/external/__tests__/chat-idb.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/chat-idb.test.ts
@@ -23,8 +23,8 @@ function closeOnAbort(database: IDBPDatabase): IDBPDatabase {
 }
 
 test("Local conversation data is isolated by user and workspace", async () => {
-  const reload = vi.fn<() => void>();
-  const opener = createChatIdbOpener({ reload });
+  const onVersionChange = vi.fn<() => void>();
+  const opener = createChatIdbOpener({ onVersionChange });
   const identitySuffix = context.resourceId;
   const primary = closeOnAbort(
     await opener.openChatIdb(
@@ -60,10 +60,10 @@ test("Local conversation data is isolated by user and workspace", async () => {
   await expect(
     otherUser.get(CHAT_THREAD_SNAPSHOT_STORE, privateSnapshot.id),
   ).resolves.toBeUndefined();
-  expect(reload).not.toHaveBeenCalled();
+  expect(onVersionChange).not.toHaveBeenCalled();
 });
 
-test("A local chat-cache upgrade refreshes open pages safely", async () => {
+test("A local chat-cache upgrade closes the old connection and notifies its owner", async () => {
   const identitySuffix = context.resourceId;
   const userId = `upgrade-user-${identitySuffix}`;
   const orgId = `upgrade-workspace-${identitySuffix}`;
@@ -75,9 +75,9 @@ test("A local chat-cache upgrade refreshes open pages safely", async () => {
     },
   });
   oldDatabase.close();
-  const reload = vi.fn<() => void>();
+  const onVersionChange = vi.fn<() => void>();
   const database = closeOnAbort(
-    await createChatIdbOpener({ reload }).openChatIdb(userId, orgId),
+    await createChatIdbOpener({ onVersionChange }).openChatIdb(userId, orgId),
   );
 
   expect(Array.from(database.objectStoreNames).sort()).toStrictEqual(
@@ -118,5 +118,5 @@ test("A local chat-cache upgrade refreshes open pages safely", async () => {
   );
 
   expect(newerDatabase.version).toBe(CHAT_IDB_VERSION + 1);
-  expect(reload).toHaveBeenCalledOnce();
+  expect(onVersionChange).toHaveBeenCalledOnce();
 });

--- a/turbo/apps/platform/src/signals/external/__tests__/indexeddb-client.test.ts
+++ b/turbo/apps/platform/src/signals/external/__tests__/indexeddb-client.test.ts
@@ -94,7 +94,7 @@ test("Reports a physical chat database open without credential identifiers", asy
   const sensitiveUserId = `private-user-${crypto.randomUUID()}`;
   const sensitiveOrgId = `private-org-${crypto.randomUUID()}`;
   const database = await createChatIdbOpener({
-    reload: vi.fn<() => void>(),
+    onVersionChange: vi.fn<() => void>(),
   }).openChatIdb(sensitiveUserId, sensitiveOrgId);
   database.close();
 
@@ -132,7 +132,7 @@ test("Reports a failed chat database open without hiding its error", async () =>
     openDatabase: () => {
       return Promise.reject(openError);
     },
-    reload: vi.fn<() => void>(),
+    onVersionChange: vi.fn<() => void>(),
   });
 
   await expect(opener.openChatIdb("private-user", "private-org")).rejects.toBe(

--- a/turbo/apps/platform/src/signals/external/chat-idb-opener.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-opener.ts
@@ -18,11 +18,8 @@ type OpenChatIdbDatabase = <DBTypes extends DBSchema | unknown = unknown>(
 
 interface ChatIdbOpenerOptions {
   readonly openDatabase?: OpenChatIdbDatabase;
-  // Required: the page reloads itself, while the shared database worker has no
-  // window to reload and instead tells its clients that it is unavailable.
-  // Keeping this explicit is what allows this module to stay free of DOM
-  // globals.
-  readonly reload: () => void;
+  // Notify the caller after closing a connection whose schema changed.
+  readonly onVersionChange: () => void;
 }
 
 interface ChatIdbOpener {
@@ -47,7 +44,7 @@ export function createChatIdbOpener(
   options: ChatIdbOpenerOptions,
 ): ChatIdbOpener {
   const openDatabase = options.openDatabase ?? openDB;
-  const reload = options.reload;
+  const onVersionChange = options.onVersionChange;
 
   return {
     async openChatIdb(userId, orgId) {
@@ -80,7 +77,7 @@ export function createChatIdbOpener(
             nextVersion: event.newVersion,
           });
           db.close();
-          reload();
+          onVersionChange();
         },
         { once: true },
       );

--- a/turbo/apps/platform/src/signals/shared-database-browser.ts
+++ b/turbo/apps/platform/src/signals/shared-database-browser.ts
@@ -1,11 +1,8 @@
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { derivePlatformServiceOrigin } from "@okouai/core/platform-service-origin";
-import { toast } from "@okouai/ui/components/ui/sonner";
 import { command, state } from "ccstate";
 import sharedDatabaseWorkerAssetUrl from "virtual:shared-database-worker";
 
-import { i18n } from "../i18n/index.ts";
-import { now } from "../lib/time.ts";
 import { CONNECTION_DIAGNOSTICS_PARAM } from "../lib/connection-diagnostics-param.ts";
 import { getCapturedPreviewBypassForTarget } from "../lib/preview-bypass-cookie.ts";
 import { VERCEL_PROTECTION_BYPASS_NAME } from "../lib/preview-bypass-name.ts";
@@ -31,7 +28,6 @@ import {
 } from "./chat-page/chat-event-signal-registry.ts";
 import { syncEventDrivenChatThreads$ } from "./chat-page/chat-thread-event-sourcing.ts";
 import { reportForceUpgradeRequired } from "./force-upgrade.ts";
-import { logger } from "./log.ts";
 import {
   installSharedDatabaseBridge$,
   setBridgeConnected$,
@@ -43,10 +39,6 @@ import {
 } from "./shared-database.ts";
 import { createDeferredPromise, onRejection } from "./utils.ts";
 
-const SHARED_DATABASE_RELOAD_MARKER = "okou-shared-database-reload";
-const SHARED_DATABASE_RELOAD_WINDOW_MS = 60_000;
-const L = logger("SharedWorkerBridge");
-
 export interface SharedDatabaseBridgeHost {
   createBridge(
     identity: SharedDatabaseIdentity,
@@ -57,33 +49,6 @@ export interface SharedDatabaseBridgeHost {
   ): SharedDatabaseBridge;
 }
 
-function handleSharedDatabaseReloadRequired(
-  reason: SharedDatabaseWorkerUnavailableReason,
-): void {
-  const url = new URL(location.href);
-  const reloadAtMs = now();
-  const reloadMarker = url.searchParams.get(SHARED_DATABASE_RELOAD_MARKER);
-  const previousReloadAtMs =
-    reloadMarker === null ? Number.NaN : Number(reloadMarker);
-  if (
-    Number.isFinite(previousReloadAtMs) &&
-    reloadAtMs - previousReloadAtMs < SHARED_DATABASE_RELOAD_WINDOW_MS
-  ) {
-    url.searchParams.delete(SHARED_DATABASE_RELOAD_MARKER);
-    history.replaceState(history.state, "", url);
-    toast.error(
-      i18n.t(($) => {
-        return $.global.errors.sharedDatabaseUnavailable;
-      }),
-    );
-    return;
-  }
-
-  url.searchParams.set(SHARED_DATABASE_RELOAD_MARKER, String(reloadAtMs));
-  L.debug("Reloading app", { reason });
-  location.replace(url.toString());
-}
-
 function handleSharedDatabaseWorkerUnavailable(
   reason: SharedDatabaseWorkerUnavailableReason,
 ): void {
@@ -92,14 +57,8 @@ function handleSharedDatabaseWorkerUnavailable(
     return;
   }
 
-  handleSharedDatabaseReloadRequired(reason);
-  if (reason === "indexeddb-version-changed") {
-    throw new Error(
-      "Shared database worker is unavailable after an IndexedDB version change",
-    );
-  }
   throw new Error(
-    "Shared database worker failed to load or its transport became unrecoverable",
+    "Shared database worker is unavailable after an IndexedDB version change",
   );
 }
 
@@ -138,21 +97,15 @@ function createBrowserSharedDatabaseBridge(
     signal,
     getToken,
   );
-  let failureHandled = false;
   worker.addEventListener(
     "error",
     (event) => {
-      if (failureHandled) {
-        return;
-      }
-      failureHandled = true;
       const workerError: unknown = event.error;
       portBridge.fail(
         workerError instanceof Error
           ? workerError
           : new Error("Shared database worker failed to load"),
       );
-      events.workerUnavailable("worker-load-or-transport-failure");
     },
     { signal },
   );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
@@ -115,7 +115,7 @@ export async function seedChatListCache(
   events: readonly ChatThreadEvent[] = [],
 ): Promise<void> {
   const identity = authIdentity(auth);
-  const opener = createChatIdbOpener({ reload: () => {} });
+  const opener = createChatIdbOpener({ onVersionChange: () => {} });
   const database: IDBPDatabase = await opener.openChatIdb(
     identity.userId,
     identity.orgId,


### PR DESCRIPTION
SharedWorker queries and computed reads can legitimately take longer than 10 seconds while waiting on API or IndexedDB work. Remove the App-side deadline so requests wait for completion, a real failure, or lifecycle cancellation.

Remove automatic page reload recovery, its URL marker and 60-second loop guard, reload-only error reporting and toast translations, and promises that waited indefinitely for a reload. Worker construction and request errors now reach callers directly; a failed Worker rejects pending requests and marks the connection disconnected. IndexedDB version changes still close the affected connection, and required upgrades still use the existing user-controlled update dialog.

## Verification

- 34 targeted tests passed across the browser bridge, single-connection client, MessagePort, Worker runtime, and IndexedDB suites, including construction failure, query error propagation, pending-request failure, and the force-upgrade dialog.
- Changed-file Prettier, ESLint, and Oxlint checks passed, including type-aware linting; platform and full-repository type checks, Knip, and translation checks passed.
- The timeout removal was browser-verified on parent commit `c3ec0da`: delayed query/computed responses, chat send/history/cancellation, multi-tab synchronization, and manual reload passed. [Browser verification report](https://a.okou.io/2msq75yod0.md). The additional reload-recovery cleanup is covered by the targeted tests above and this PR pipeline.
