### PR TITLE
fix(agentphone): recognize @okou mentions in group messages

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -1230,6 +1230,64 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     expect(coldCutoverIdle.body.job).toBeNull();
   });
 
+  it("wakes iMessage groups on the canonical @okou handle and strips it from the prompt", async () => {
+    const runs = createRunsApi(context);
+    const ap = createAgentPhoneBddApi(context);
+    // The VM0 brand still presents the assistant as "Zero", so serving this
+    // conversation from that brand proves the canonical handle is recognized
+    // regardless of which brand the deployment presents.
+    const { phone, runnerGroup, sends } = await entitledLinkedActor("vm0");
+    const conversationId = uniqueConversationId();
+
+    // Body text addressing the canonical handle wakes the agent, and only the
+    // addressing handle is removed — a bare "okou" stays in the task.
+    const beforeMention = sends.messages.length;
+    await ap.postAgentPhoneInboundMessage({
+      channel: "imessage",
+      from: phone,
+      body: "@okou draft the okou launch note",
+      conversationId,
+      isGroup: true,
+    });
+    const mentionRun = await claimDispatchedRun(runnerGroup);
+    expect(mentionRun.prompt).toBe("draft the okou launch note");
+    expect(mentionRun.prompt).not.toContain("@okou");
+    await completeSandboxRun(mentionRun.sandboxToken, mentionRun.runId, 0);
+    await waitForSendCount(sends, beforeMention + 1);
+
+    // A provider mention object naming the canonical handle wakes the agent
+    // even when the body carries no handle text.
+    const beforeMentionObject = sends.messages.length;
+    await ap.postAgentPhoneInboundMessage({
+      channel: "imessage",
+      from: phone,
+      body: "and schedule it for Monday",
+      conversationId,
+      isGroup: true,
+      mentions: [{ username: "okou" }],
+    });
+    const mentionObjectRun = await claimDispatchedRun(runnerGroup);
+    expect(mentionObjectRun.prompt).toBe("and schedule it for Monday");
+    await completeSandboxRun(
+      mentionObjectRun.sandboxToken,
+      mentionObjectRun.runId,
+      0,
+    );
+    await waitForSendCount(sends, beforeMentionObject + 1);
+
+    // Group chatter that names no handle is still ignored.
+    await ap.postAgentPhoneInboundMessage({
+      channel: "imessage",
+      from: phone,
+      body: "okou would probably know",
+      conversationId,
+      isGroup: true,
+    });
+    await runs.heartbeatRunner(runnerGroup);
+    const idle = await runs.pollRunner(runnerGroup);
+    expect(idle.body.job).toBeNull();
+  });
+
   it("skips completion delivery for runs whose phone link was disconnected mid-flight", async () => {
     const integrations = createBddIntegrationApi(context);
     const ap = createAgentPhoneBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
@@ -73,6 +73,7 @@ interface AgentPhoneInboundMessage {
   readonly conversationId?: string;
   readonly isGroup?: boolean;
   readonly mediaUrl?: string;
+  readonly mentions?: readonly Readonly<Record<string, unknown>>[];
   readonly recentHistory?: readonly Readonly<Record<string, unknown>>[];
   readonly publicBrand?: PublicBrand;
 }
@@ -220,6 +221,7 @@ export function createAgentPhoneBddApi(context: TestContext) {
           : {}),
         ...(message.isGroup === undefined ? {} : { isGroup: message.isGroup }),
         ...(message.mediaUrl ? { mediaUrl: message.mediaUrl } : {}),
+        ...(message.mentions ? { mentions: message.mentions } : {}),
       },
     });
     await integrations.requestAgentPhoneWebhook(

--- a/turbo/apps/api/src/signals/routes/integrations-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-agentphone.ts
@@ -36,6 +36,7 @@ import {
   type AgentPhoneChannel,
   type AgentPhoneMessageEvent,
 } from "../services/agentphone.service";
+import { isAgentPhoneMentionText } from "../services/agentphone-shared.service";
 import { safeJsonParse, tapError } from "../utils";
 
 interface AgentPhoneConfig {
@@ -642,13 +643,9 @@ function parseDate(value: unknown): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
-function isZeroMentionText(value: string): boolean {
-  return /(^|\s)@(zero|vm0)\b/iu.test(value);
-}
-
-function mentionMatchesZero(value: unknown): boolean {
+function mentionMatchesAgentPhoneHandle(value: unknown): boolean {
   if (typeof value === "string") {
-    return isZeroMentionText(value.startsWith("@") ? value : `@${value}`);
+    return isAgentPhoneMentionText(value.startsWith("@") ? value : `@${value}`);
   }
   if (typeof value !== "object" || value === null) {
     return false;
@@ -657,7 +654,7 @@ function mentionMatchesZero(value: unknown): boolean {
   const mention = value as Record<string, unknown>;
   return ["text", "name", "username", "handle", "value"].some((key) => {
     const field = mention[key];
-    return typeof field === "string" && mentionMatchesZero(field);
+    return typeof field === "string" && mentionMatchesAgentPhoneHandle(field);
   });
 }
 
@@ -715,12 +712,12 @@ function extractAgentPhoneMentioned(
 
   return (
     arrayValue(data, ["mentions", "mentionedUsers", "mentioned_users"]).some(
-      mentionMatchesZero,
+      mentionMatchesAgentPhoneHandle,
     ) ||
     arrayValue(body, ["mentions", "mentionedUsers", "mentioned_users"]).some(
-      mentionMatchesZero,
+      mentionMatchesAgentPhoneHandle,
     ) ||
-    isZeroMentionText(messageBody)
+    isAgentPhoneMentionText(messageBody)
   );
 }
 

--- a/turbo/apps/api/src/signals/services/agentphone-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/agentphone-shared.service.ts
@@ -18,6 +18,30 @@ export type AgentPhoneUserLink = typeof agentphoneUserLinks.$inferSelect;
 const AGENTPHONE_EMAIL_HANDLE_PATTERN = /^[^@\s]+@[^@\s]+\.[^@\s]+$/u;
 const AGENTPHONE_PHONE_HANDLE_PATTERN = /^\+[1-9]\d{7,14}$/u;
 
+/**
+ * Handles that address the assistant in a group conversation. Every public
+ * brand answers to all of them, because group members do not know which brand
+ * the deployment presents and the VM0 brand still calls the assistant "Zero".
+ *
+ * Detection and stripping must stay in agreement, so both derive from this one
+ * pattern. If they drift, a message either wakes the agent with the mention
+ * still in the prompt, or is stripped without waking it.
+ */
+const AGENTPHONE_MENTION_PATTERN = /(^|\s)@(zero|vm0|okou)\b/iu;
+
+/** Whether free-form message text addresses the assistant by handle. */
+export function isAgentPhoneMentionText(value: string): boolean {
+  return AGENTPHONE_MENTION_PATTERN.test(value);
+}
+
+/** Removes the addressing handle so it never reaches the run prompt. */
+export function stripAgentPhoneMention(text: string): string {
+  return text
+    .replace(new RegExp(AGENTPHONE_MENTION_PATTERN.source, "giu"), " ")
+    .replace(/[ \t]{2,}/gu, " ")
+    .trim();
+}
+
 export function isAgentPhoneChannel(value: string): value is AgentPhoneChannel {
   return value === "imessage" || value === "sms" || value === "mms";
 }

--- a/turbo/apps/api/src/signals/services/agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/agentphone.service.ts
@@ -44,6 +44,7 @@ import {
   resolveAgentPhoneUserLink,
   resolveOrgDefaultComposeId,
   storeOutboundAgentPhoneMessage,
+  stripAgentPhoneMention,
   touchAgentPhoneUserLink,
   type AgentPhoneChannel,
   type AgentPhoneUserLink,
@@ -184,13 +185,6 @@ function isAgentPhoneGroupAccountCommand(
       commandName === "new_session" ||
       commandName === "model")
   );
-}
-
-function stripZeroMention(text: string): string {
-  return text
-    .replace(/(^|\s)@(zero|vm0)\b/giu, " ")
-    .replace(/[ \t]{2,}/gu, " ")
-    .trim();
 }
 
 function normalizeHandleForConnect(handle: string): string {
@@ -973,7 +967,7 @@ function enrichAgentPhonePrompt(opts: {
   readonly isGroup: boolean;
 }): string {
   const promptText = opts.isGroup
-    ? stripZeroMention(opts.prompt)
+    ? stripAgentPhoneMention(opts.prompt)
     : opts.prompt.trim();
   const parts = [promptText];
   if (opts.mediaUrl) {


### PR DESCRIPTION
Closes #31800

## Problem

AgentPhone group-message handling only recognized the retired brand handles, so two symmetric defects showed up on the Okou brand:

- **Detection** — `isZeroMentionText` / `mentionMatchesZero` tested `/(^|\s)@(zero|vm0)\b/iu`, so a group message addressing `@okou` was rejected at `integrations-agentphone.ts:886` and ignored again by `shouldIgnoreAgentPhoneGroupMessage` (`agentphone.service.ts:173`). Mentioning the assistant by name in a group chat did not wake it.
- **Stripping** — `stripZeroMention` used the same alternation, so an `@okou` message that did get through by an explicit provider `mentioned` flag leaked the mention text into the run prompt.

The two regexes lived in separate files, one copy each.

## Change

- Add one shared mention pattern in `agentphone-shared.service.ts` accepting `@okou` alongside `@zero` and `@vm0`, exported as `isAgentPhoneMentionText` (detection) and `stripAgentPhoneMention` (stripping). Both derive from that single pattern, so they cannot drift.
- Matching semantics are otherwise unchanged: start-or-whitespace anchor, word boundary, case-insensitive, Unicode.
- The legacy handles keep working. The VM0 brand is live and `PublicBrand` still presents `assistantName: "Zero"`, and group members do not know which brand the deployment serves — so matching is deliberately **not** brand-conditional.
- The brand-named helpers become brand-neutral: `isZeroMentionText` → `isAgentPhoneMentionText`, `mentionMatchesZero` → `mentionMatchesAgentPhoneHandle`, `stripZeroMention` → `stripAgentPhoneMention`.

Explicit provider `mentioned` / `isMentioned` / `mentionsAgent` reading and precedence, group detection, the non-group path, and every other channel are untouched. No other `zero` / `vm0` naming in the repository is changed.

## Tests

New BDD case in `agentphone.bdd.test.ts` alongside the existing group cases, served from the **vm0** brand to prove the canonical handle works regardless of the brand presented:

- `@okou draft the okou launch note` in a group dispatches a run whose prompt is `draft the okou launch note` — mention stripped, the bare `okou` inside the task preserved.
- A provider mention object `{ username: "okou" }` with no handle text in the body wakes the agent, matching current behavior for the legacy handles.
- Group chatter naming no handle is still ignored.

The new case fails on `main` (no run dispatched) and passes with this change. The 16 existing `@Zero` / `@vm0` group cases pass unmodified.

`api` lint, `check-types`, `knip`, and the AgentPhone-related suites (`agentphone.bdd`, `integrations.bdd`, `cron-monitor-chat-event-queue`) were run locally; everything else is left to the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)