### PR TITLE
refactor(api): retire the legacy zero run vocabulary

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1429,7 +1429,7 @@ describe("CHAT-02: thread run admission invariant", () => {
     await expect(
       createUnassociatedThreadBoundAgentRunsServiceFixture(),
     ).rejects.toThrow(
-      "Thread-bound Zero run requires a queue-first association",
+      "Thread-bound agent run requires a queue-first association",
     );
 
     await expect(
@@ -1439,7 +1439,7 @@ describe("CHAT-02: thread run admission invariant", () => {
     await expect(
       createUnassociatedThreadBoundAgentRunsServiceFixture(""),
     ).rejects.toThrow(
-      "Thread-bound Zero run requires a queue-first association",
+      "Thread-bound agent run requires a queue-first association",
     );
 
     await expect(
@@ -18237,7 +18237,7 @@ describe("CHAT-02: run-scoped agent-token chat launches", () => {
       },
       context.signal,
     );
-    expect(immediateState.zero_run).toMatchObject({
+    expect(immediateState.agent_run).toMatchObject({
       triggerSource: "agent",
     });
     expect(
@@ -18303,7 +18303,7 @@ describe("CHAT-02: run-scoped agent-token chat launches", () => {
       },
       context.signal,
     );
-    expect(promotedState.zero_run).toMatchObject({
+    expect(promotedState.agent_run).toMatchObject({
       triggerSource: "agent",
     });
     expect(
@@ -18797,7 +18797,7 @@ describe("CHAT-02: shared user message queue", () => {
       },
       context.signal,
     );
-    expect(forwardedState.zero_run).toMatchObject({ triggerSource: "web" });
+    expect(forwardedState.agent_run).toMatchObject({ triggerSource: "web" });
     const forwardedSystemPrompt = forwardedRun.appendSystemPrompt ?? "";
     expect(forwardedSystemPrompt).toContain("# This Run's Trigger");
     expect(forwardedSystemPrompt).toContain(
@@ -19204,7 +19204,7 @@ describe("CHAT-02: shared user message queue", () => {
       },
       context.signal,
     );
-    expect(rotatedState.zero_run).toMatchObject({ triggerSource: "agent" });
+    expect(rotatedState.agent_run).toMatchObject({ triggerSource: "agent" });
     expect(rotatedSystemPrompt).toContain("# Web Chat Run Context");
     expect(rotatedSystemPrompt).toContain("# This Run's Trigger");
     expect(rotatedSystemPrompt).toContain(`SOURCE_RUN_ID: ${source.runId}`);
@@ -19289,7 +19289,7 @@ describe("CHAT-02: shared user message queue", () => {
       },
       context.signal,
     );
-    expect(incompleteState.zero_run).toMatchObject({ triggerSource: "agent" });
+    expect(incompleteState.agent_run).toMatchObject({ triggerSource: "agent" });
     expect(incompleteSystemPrompt).toContain("# Incomplete Rounds Context");
     expect(incompleteSystemPrompt).toContain(incompletePrompt);
     expect(incompleteSystemPrompt).not.toContain("# Web Chat Run Context");

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/agent-run-callback.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/agent-run-callback.ts
@@ -27,7 +27,7 @@ const agentRunCallbackSnapshotSchema = z.object({
 });
 
 const agentRunStateResponseSchema = z.object({
-  zero_run: z
+  agent_run: z
     .object({
       triggerSource: z.string().nullable(),
     })

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -50,7 +50,7 @@ interface RequiredAuthHeaders {
 
 /**
  * Computer-use routes accept either a Clerk session actor or a bearer token
- * (zero run tokens for command routes). `null` issues an unauthenticated
+ * (agent run tokens for command routes). `null` issues an unauthenticated
  * request.
  */
 type ComputerUseAuth = ApiTestUser | { readonly bearer: string } | null;
@@ -311,7 +311,7 @@ function bodyStream(buffer: Buffer): AsyncIterable<Uint8Array> {
 }
 
 /**
- * Mint a zero run token directly, the same auth boundary production crosses
+ * Mint an agent run token directly, the same auth boundary production crosses
  * when agent-runs-create issues a token whose chat thread granted a
  * computer-use host (`generateOkouToken`). Precedent: `zeroCapabilityToken`
  * in api-bdd-github.ts. Returns the runId so audit events created by the

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs.ts
@@ -811,7 +811,7 @@ export function createRunsApi(context: TestContext) {
       publicBrand?: PublicBrand,
     ): string {
       if (!actor.orgId) {
-        throw new Error("Zero run tokens require an org-scoped actor");
+        throw new Error("Agent run tokens require an org-scoped actor");
       }
       const seconds = Math.floor(now() / 1000);
       return signSandboxJwtForTests({

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
@@ -468,7 +468,7 @@ async function telegramPostRunState(
 
   return {
     run: runSnapshot(response.run),
-    agentRun: agentRunSnapshot(response.zero_run),
+    agentRun: agentRunSnapshot(response.agent_run),
     callbacks: stateRecords(response.callbacks).map(callbackSnapshot),
     jobExists: response.job_exists === true,
   };

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -248,7 +248,7 @@ function mcpConnectorPromptSection(prompt: string): string | undefined {
     nextSectionStart === -1 ? undefined : nextSectionStart,
   );
 }
-const EXPECTED_ZERO_RUN_DISALLOWED_TOOLS = [
+const EXPECTED_AGENT_RUN_DISALLOWED_TOOLS = [
   "CronCreate",
   "CronList",
   "CronDelete",
@@ -1468,7 +1468,7 @@ async function entitledRunActor(userOptions: ApiTestUserOptions = {}): Promise<{
   return { actor, agentId: agent.agentId, runnerGroup, granted };
 }
 
-function zeroBackedDirectRunBody(args: {
+function agentBackedDirectRunBody(args: {
   readonly agentId: string;
   readonly prompt: string;
 }) {
@@ -2081,7 +2081,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const missingAuthorityRun = await api.createDirectRun(
       missingAuthorityActor.actor,
       {
-        ...zeroBackedDirectRunBody({
+        ...agentBackedDirectRunBody({
           agentId: missingAuthorityActor.agentId,
           prompt: missingAuthorityPrompt,
         }),
@@ -2146,7 +2146,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const missingCompatibilityRun = await api.createDirectRun(
       missingCompatibilityActor.actor,
       {
-        ...zeroBackedDirectRunBody({
+        ...agentBackedDirectRunBody({
           agentId: missingCompatibilityActor.agentId,
           prompt: missingCompatibilityPrompt,
         }),
@@ -2201,7 +2201,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     const differentAuthorityActor = await entitledRunActor();
     const warmRun = await api.createDirectRun(differentAuthorityActor.actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId: differentAuthorityActor.agentId,
         prompt: "warm catalog before changing validation authority",
       }),
@@ -2251,7 +2251,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const differentAuthorityRun = await api.createDirectRun(
       differentAuthorityActor.actor,
       {
-        ...zeroBackedDirectRunBody({
+        ...agentBackedDirectRunBody({
           agentId: differentAuthorityActor.agentId,
           prompt: differentAuthorityPrompt,
         }),
@@ -2303,7 +2303,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const cachedActor = await entitledRunActor();
     const cachedPrompt = "cached connector catalog fallback";
     const cachedRun = await api.createDirectRun(cachedActor.actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId: cachedActor.agentId,
         prompt: cachedPrompt,
       }),
@@ -2361,7 +2361,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const secondConcurrentPrompt = "second concurrent attested catalog load";
     const [firstConcurrentRun, secondConcurrentRun] = await Promise.all([
       api.createDirectRun(concurrentActor.actor, {
-        ...zeroBackedDirectRunBody({
+        ...agentBackedDirectRunBody({
           agentId: concurrentActor.agentId,
           prompt: firstConcurrentPrompt,
         }),
@@ -2371,7 +2371,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         },
       }),
       api.createDirectRun(concurrentActor.actor, {
-        ...zeroBackedDirectRunBody({
+        ...agentBackedDirectRunBody({
           agentId: concurrentActor.agentId,
           prompt: secondConcurrentPrompt,
         }),
@@ -2516,7 +2516,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
 
     const run = await api.createDirectRun(actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId,
         prompt: "overlap runtime catalog and provider reads",
       }),
@@ -2579,7 +2579,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const cancelledPrompt = `cancel overlapped runtime context ${randomUUID()}`;
     await expect(
       cancellableApi.createDirectRun(actor, {
-        ...zeroBackedDirectRunBody({ agentId, prompt: cancelledPrompt }),
+        ...agentBackedDirectRunBody({ agentId, prompt: cancelledPrompt }),
         modelProviderType: "aws-bedrock",
         connectorScope: {
           allowedConnectorSlugs: ["x"],
@@ -2639,7 +2639,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     await expect(
       cancellableApi.createDirectRun(actor, {
-        ...zeroBackedDirectRunBody({
+        ...agentBackedDirectRunBody({
           agentId,
           prompt: "prefer catalog failure during runtime preparation",
         }),
@@ -2672,7 +2672,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       allowedConnectorSlugs: readonly string[],
     ) => {
       return await api.createDirectRun(actor, {
-        ...zeroBackedDirectRunBody({ agentId, prompt }),
+        ...agentBackedDirectRunBody({ agentId, prompt }),
         connectorScope: {
           allowedConnectorSlugs,
           allowedCustomConnectorIds: [],
@@ -2870,7 +2870,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     const createProjectedRun = async (prompt: string) => {
       return await api.createDirectRun(actor, {
-        ...zeroBackedDirectRunBody({ agentId, prompt }),
+        ...agentBackedDirectRunBody({ agentId, prompt }),
         connectorScope: {
           allowedConnectorSlugs: ["x", "runtime-projection-unknown", "x"],
           allowedCustomConnectorIds: [],
@@ -3029,7 +3029,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
 
     const run = await api.createDirectRun(actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId,
         prompt: "reuse unchanged catalog validation authority",
       }),
@@ -3083,7 +3083,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const { actor, agentId } = await entitledRunActor();
 
     const run = await api.createDirectRun(actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId,
         prompt: "missing projection compatibility fallback",
       }),
@@ -3130,7 +3130,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     await expect(
       api.createDirectRun(actor, {
-        ...zeroBackedDirectRunBody({
+        ...agentBackedDirectRunBody({
           agentId,
           prompt: rejectedPrompt,
         }),
@@ -3166,7 +3166,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const { actor, agentId } = await entitledRunActor();
     const createProjectedRun = async (prompt: string) => {
       return await api.createDirectRun(actor, {
-        ...zeroBackedDirectRunBody({ agentId, prompt }),
+        ...agentBackedDirectRunBody({ agentId, prompt }),
         connectorScope: {
           allowedConnectorSlugs: ["x"],
           allowedCustomConnectorIds: [],
@@ -3237,7 +3237,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const { actor, agentId } = await entitledRunActor();
 
     const run = await api.createDirectRun(actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId,
         prompt: "bound repeated runtime projection identity replacement",
       }),
@@ -3278,7 +3278,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await corruptApiTestConnectorCatalogRuntimeProjectionDigest("x");
     const { actor, agentId } = await entitledRunActor();
     const run = await api.createDirectRun(actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId,
         prompt: "digest-mismatched runtime projection",
       }),
@@ -3339,7 +3339,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       );
       const { actor, agentId } = await entitledRunActor();
       const run = await api.createDirectRun(actor, {
-        ...zeroBackedDirectRunBody({
+        ...agentBackedDirectRunBody({
           agentId,
           prompt: `${payloadState} attested runtime projection`,
         }),
@@ -3380,7 +3380,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await expireApiTestConnectorCatalogRuntimeProjectionAuthority();
     const { actor, agentId } = await entitledRunActor();
     const run = await api.createDirectRun(actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId,
         prompt: "stale runtime projection authority",
       }),
@@ -3428,7 +3428,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       allowedCustomConnectorIds: [],
     } as const;
     const warmed = await api.createDirectRun(actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId,
         prompt: "warm the exact catalog identity before corruption",
       }),
@@ -3463,7 +3463,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "reject catalog-backed creation while the catalog is unavailable";
     await expect(
       api.createDirectRun(actor, {
-        ...zeroBackedDirectRunBody({ agentId, prompt: rejectedPrompt }),
+        ...agentBackedDirectRunBody({ agentId, prompt: rejectedPrompt }),
         connectorScope: catalogBackedScope,
       }),
     ).rejects.toThrow("Accepted external connector catalog is unavailable");
@@ -3695,7 +3695,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.heartbeatRunner(runnerGroup);
 
     const initialRun = await api.createDirectRun(actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId,
         prompt: "establish canonical storage for overlap",
       }),
@@ -7992,7 +7992,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
 });
 
 describe("RUN-01: agent run authorization and session boundaries", () => {
-  it("does not expose the removed Zero run creation route", async () => {
+  it("does not expose the removed agent run creation route", async () => {
     const actor = createBddApi(context).user();
     await expect(
       createRunsApi(context).requestRemovedAgentRunCreation(actor),
@@ -10345,7 +10345,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.enableAgentConnectors(actor, agentId, ["google-ads"]);
 
     const run = await api.createDirectRun(actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId,
         prompt: "use google ads with explicit developer token",
       }),
@@ -11934,7 +11934,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     const genericDirectRun = await api.createDirectRun(
       actor,
-      zeroBackedDirectRunBody({
+      agentBackedDirectRunBody({
         agentId,
         prompt: "do not advertise Zero MCP without a server-issued token",
       }),
@@ -12253,7 +12253,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, restoredRun.runId, [200]);
 
     const directRun = await api.createDirectRun(actor, {
-      ...zeroBackedDirectRunBody({
+      ...agentBackedDirectRunBody({
         agentId,
         prompt: "use the direct scoped custom connector",
       }),
@@ -15166,7 +15166,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     const misc = createMiscRoutesApi(context);
     const actor = bdd.user();
     if (!actor.orgId) {
-      throw new Error("Zero runner context requires an organization");
+      throw new Error("Agent runner context requires an organization");
     }
     bdd.acceptAgentStorageWrites();
     api.acceptStorageDownloads();
@@ -15404,7 +15404,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
 
     expect(claim.featureFlags).not.toHaveProperty("zeroWebSearch");
     expect(claim.disallowedTools).toStrictEqual(
-      EXPECTED_ZERO_RUN_DISALLOWED_TOOLS,
+      EXPECTED_AGENT_RUN_DISALLOWED_TOOLS,
     );
     expect(claim.disallowedTools).not.toContain("WebFetch");
     expectCanonicalOkouRunEnvironment({
@@ -15505,7 +15505,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
 
     expect(claim.featureFlags).not.toHaveProperty("zeroWebSearch");
     expect(claim.disallowedTools).toStrictEqual(
-      EXPECTED_ZERO_RUN_DISALLOWED_TOOLS,
+      EXPECTED_AGENT_RUN_DISALLOWED_TOOLS,
     );
     expect(claim.appendSystemPrompt ?? "").toContain("okou web-search --help");
     expect(claim.appendSystemPrompt ?? "").toContain("okou finance --help");
@@ -15781,7 +15781,7 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
 
     expect(claim.featureFlags).not.toHaveProperty("zeroWebSearch");
     expect(claim.disallowedTools).toStrictEqual(
-      EXPECTED_ZERO_RUN_DISALLOWED_TOOLS,
+      EXPECTED_AGENT_RUN_DISALLOWED_TOOLS,
     );
     expect(claim.disallowedTools).not.toContain("WebFetch");
     expect(claim.disallowedTools).not.toContain("goal");
@@ -19984,7 +19984,7 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     await api.grantProEntitlement(actor);
 
     // Direct compose runs created without vars leave the stored vars null,
-    // and their zero-run rows carry no model provider or pinned model.
+    // and their agent-run rows carry no model provider or pinned model.
     const composeName = `bdd-null-vars-${randomUUID().slice(0, 8)}`;
     const compose = await api.createDirectAgent(actor, {
       version: "1",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -37,7 +37,7 @@ import {
 
 /*
  * RUN-03/RUN-04 read surfaces for agent runs (list/read/queue/cancel,
- * zero run detail reads, queue position, event logs, and log reads) plus the RUN-01/02
+ * agent run detail reads, queue position, event logs, and log reads) plus the RUN-01/02
  * direct-run create arms that
  * end in those reads (session continuation, memory root policies, volume
  * pinning, concurrency caps, and the production capture gate).
@@ -445,7 +445,7 @@ describe("RUN-03/RUN-04: direct run list, detail, and queue reads", () => {
       visibility: "private",
     });
 
-    // Seed a terminal zero-run session so a later queued run can carry a
+    // Seed a terminal agent-run session so a later queued run can carry a
     // continuation session link.
     const seedRun = await api.createRun(actor, {
       agentId: agent.agentId,
@@ -575,7 +575,7 @@ describe("RUN-03/RUN-04: direct run list, detail, and queue reads", () => {
       status: "completed",
       prompt: "other run b",
     });
-    mustOk(detail, "Zero run detail");
+    mustOk(detail, "Agent run detail");
     expect(detail.body.startedAt).toBeDefined();
     expect(detail.body.completedAt).toBeDefined();
 
@@ -769,7 +769,7 @@ describe("RUN-03: cancel through the run cancel route", () => {
     expectApiError(crossOrg.body);
     expect(crossOrg.body.error.code).toBe("NOT_FOUND");
 
-    // A queued Zero run cancelled through the Zero route disappears from
+    // A queued agent run cancelled through the Zero route disappears from
     // the visible queue.
     await api.ensureOrgModelProvider(actor);
     const agent = await bdd.createAgent(actor, {
@@ -2637,13 +2637,13 @@ describe("RUN-04: agent run telemetry families", () => {
     await api.ensureOrgModelProvider(actor);
     const agent = await bdd.createAgent(actor, {
       displayName: "BDD zero detail agent",
-      description: "Zero run detail reads.",
+      description: "Agent run detail reads.",
       visibility: "private",
     });
 
     const agentRun = await api.createRun(actor, {
       agentId: agent.agentId,
-      prompt: "zero run detail",
+      prompt: "agent run detail",
       modelProvider: "anthropic-api-key",
     });
     const claim = await api.claimRunnerJob(agentRun.runId);
@@ -2668,7 +2668,7 @@ describe("RUN-04: agent run telemetry families", () => {
 
     const bareRun = await api.createRun(actor, {
       agentId: agent.agentId,
-      prompt: "zero run without snapshots",
+      prompt: "agent run without snapshots",
       modelProvider: "anthropic-api-key",
     });
 
@@ -2883,7 +2883,7 @@ describe("RUN-04: agent run telemetry families", () => {
     }
     expect(contextRead.body).toMatchObject({
       runId,
-      prompt: "zero run detail",
+      prompt: "agent run detail",
       cliAgentType: "claude-code",
       sessionId: "bdd-session-1",
       environment: { NODE_ENV: "production" },

--- a/turbo/apps/api/src/signals/routes/banking.ts
+++ b/turbo/apps/api/src/signals/routes/banking.ts
@@ -37,7 +37,7 @@ function okouTokenRequired() {
     status: 403 as const,
     body: {
       error: {
-        message: "Banking gateway access requires a zero run token",
+        message: "Banking gateway access requires an agent run token",
         code: "FORBIDDEN",
       },
     },

--- a/turbo/apps/api/src/signals/routes/test-run-fixture.ts
+++ b/turbo/apps/api/src/signals/routes/test-run-fixture.ts
@@ -75,7 +75,7 @@ const createAgentRunFixture$ = command(
 );
 
 /**
- * Test-only Zero run creation adapter. This route is intentionally omitted
+ * Test-only agent run creation adapter. This route is intentionally omitted
  * from every production and E2E route registry.
  */
 export const runFixtureRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -714,7 +714,7 @@ async function clearRunApiStart(
   });
   signal.throwIfAborted();
   if (!cleared) {
-    throw new Error("Expected a Zero run timing row");
+    throw new Error("Expected an agent run timing row");
   }
 }
 
@@ -730,7 +730,7 @@ async function readRunApiStart(
     .limit(1);
   signal.throwIfAborted();
   if (!run) {
-    throw new Error("Expected a Zero run timing row");
+    throw new Error("Expected an agent run timing row");
   }
   return run.apiStartedAt?.toISOString() ?? null;
 }

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -1046,7 +1046,7 @@ async function getTelegramPostRunStateForAction(
   if (!run) {
     return actionOk({
       run: null,
-      zero_run: null,
+      agent_run: null,
       callbacks: [],
       job_exists: false,
     });
@@ -1087,7 +1087,7 @@ async function getTelegramPostRunStateForAction(
 
   return actionOk({
     run,
-    zero_run: agentRun ?? null,
+    agent_run: agentRun ?? null,
     callbacks: callbacks.map((callback) => {
       return {
         id: callback.id,

--- a/turbo/apps/api/src/signals/routes/video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/video-io-generate.ts
@@ -78,7 +78,7 @@ async function loadRunVideoModel(
     .where(and(eq(agentRuns.id, runId), isNotNull(agentRuns.triggerSource)))
     .limit(1);
   if (!run) {
-    throw new Error("Expected a Zero run row for the default video model");
+    throw new Error("Expected an agent run row for the default video model");
   }
   if (run.selectedVideoModel === null) {
     return null;

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -270,7 +270,7 @@ function assertThreadBoundAgentRunHasQueueAssociation(
   if (!("queueFirstAssociation" in args)) {
     if (args.chatThreadId !== undefined) {
       throw new Error(
-        "Thread-bound Zero run requires a queue-first association",
+        "Thread-bound agent run requires a queue-first association",
       );
     }
     return;
@@ -1191,7 +1191,7 @@ async function resolveThreadSessionForAgentRun(
   }
   const threadSessionRoute = input.command.threadSessionRoute;
   if (!threadSessionRoute) {
-    throw new Error("Thread-bound Zero run is missing its model route");
+    throw new Error("Thread-bound agent run is missing its model route");
   }
   const resolution = await measureZeroPreCreate(
     input.timing,
@@ -1444,7 +1444,7 @@ export const createTestFixtureAgentRun$ = command(
   async ({ set }, args: CreateAgentRunCommandArgs, signal: AbortSignal) => {
     const result = await set(createAgentRunInternal$, args, signal);
     if (isQueueFirstRunClaimLost(result)) {
-      throw new Error("Zero run without a queue association lost a claim");
+      throw new Error("Agent run without a queue association lost a claim");
     }
     return result;
   },

--- a/turbo/apps/api/src/test-fixtures/thread-bound-run-admission.ts
+++ b/turbo/apps/api/src/test-fixtures/thread-bound-run-admission.ts
@@ -64,7 +64,7 @@ export async function createUnassociatedThreadBoundAgentRunsServiceFixture(
       },
       body: {
         agentId: "thread-run-invariant-agent",
-        prompt: "must be rejected before Zero run preparation",
+        prompt: "must be rejected before agent run preparation",
       },
       apiStartTime: now(),
       piExecution: false,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runs.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runs.test.ts
@@ -87,7 +87,7 @@ describe("unified run request contract", () => {
     },
   );
 
-  it("accepts only the canonical provider on internal Zero run requests", () => {
+  it("accepts only the canonical provider on internal agent run requests", () => {
     expect(
       runCreateBodySchema.safeParse({
         prompt: "run through Zero",

--- a/turbo/packages/api-contracts/src/contracts/run-routes.ts
+++ b/turbo/packages/api-contracts/src/contracts/run-routes.ts
@@ -25,7 +25,7 @@ import {
 } from "./runner-primitives";
 
 /**
- * Zero run request schema — subset of unified schema.
+ * Agent run request schema — subset of unified schema.
  * Server-side defaults are injected by agent-runs-create.service.ts:
  * artifacts, disallowedTools.
  * Fields not used by unattended workflow runs are omitted:
@@ -61,7 +61,7 @@ const networkLogPaginationQuerySchema = createLogPaginationQuerySchema({
 });
 
 /**
- * Zero runs by ID contract (GET /api/runs/:id)
+ * Agent runs by ID contract (GET /api/runs/:id)
  */
 export const runsByIdContract = c.router({
   getById: {
@@ -83,7 +83,7 @@ export const runsByIdContract = c.router({
 });
 
 /**
- * Zero runs cancel contract (POST /api/runs/:id/cancel)
+ * Agent runs cancel contract (POST /api/runs/:id/cancel)
  */
 export const runsCancelContract = c.router({
   cancel: {
@@ -106,7 +106,7 @@ export const runsCancelContract = c.router({
 });
 
 /**
- * Zero runs queue contract (GET /api/runs/queue)
+ * Agent runs queue contract (GET /api/runs/queue)
  */
 export const runsQueueContract = c.router({
   getQueue: {
@@ -123,7 +123,7 @@ export const runsQueueContract = c.router({
 });
 
 /**
- * Zero run agent events contract (GET /api/runs/:id/telemetry/agent)
+ * Agent run telemetry events contract (GET /api/runs/:id/telemetry/agent)
  */
 export const runAgentEventsContract = c.router({
   getAgentEvents: {
@@ -216,7 +216,7 @@ export const runContextResponseSchema = z.object({
 });
 
 /**
- * Zero run context contract (GET /api/runs/:id/context)
+ * Agent run context contract (GET /api/runs/:id/context)
  * Returns a launch-time execution context snapshot for debugging
  */
 export const runContextContract = c.router({
@@ -239,7 +239,7 @@ export const runContextContract = c.router({
 });
 
 /**
- * Zero run network logs contract (GET /api/runs/:id/network)
+ * Agent run network logs contract (GET /api/runs/:id/network)
  * Returns mitmproxy network logs for a run
  */
 export const runNetworkLogsContract = c.router({
@@ -263,7 +263,7 @@ export const runNetworkLogsContract = c.router({
 });
 
 /**
- * Zero run runner contract (GET /api/runs/:id/runner)
+ * Agent run runner contract (GET /api/runs/:id/runner)
  * Returns runner-level metadata about how the run was provisioned
  * (sandbox reuse decision, etc.). Kept separate from logDetailSchema
  * so runner-tab fields can grow without polluting the generic log

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -17,7 +17,7 @@ const directRunModelProviderTypeSchema = modelProviderWriteTypeSchema.refine(
   (type) => {
     return type !== "built-in";
   },
-  { message: "built-in model provider is only supported by zero runs" },
+  { message: "built-in model provider is only supported by agent runs" },
 );
 
 export const claudeToolEntrySchema = z


### PR DESCRIPTION
Closes #26877 (workstream R4 of #31801, phase-3 continuation of #26873).

## What

Replaces the residual `zero run` vocabulary in the run contract layer and the API run tests with the canonical `agent run` vocabulary already used everywhere else in the run subsystem (`agent_runs` is the physical table, `agent-run-create.service.ts` is the writer, `api_dispatch_pre_create_agent_run` is the canonical telemetry sibling).

Pure rename and wording: **75 insertions / 75 deletions**, no behavior change, no file renames.

### Contract layer
- `contracts/runs.ts:20` — refinement message now reads `built-in model provider is only supported by agent runs`.
- `contracts/run-routes.ts` — all eight JSDoc summaries (`Zero run request schema`, `Zero runs by ID/cancel/queue contract`, `Zero run agent events/context/network logs/runner contract`) rewritten to `Agent run …`. The agent-events one reads `Agent run telemetry events contract` to avoid the doubled word.
- `contracts/__tests__/runs.test.ts:90` — test title.

### API source
- `banking.ts`, `video-io-generate.ts`, `test-runtime-state.ts`, `agent-runs-create.service.ts`, `test-run-fixture.ts` JSDoc, `test-fixtures/thread-bound-run-admission.ts` — error and prompt strings. The `agent-runs-create.service.ts` messages and their `chat-events.bdd.test.ts` assertions move together.

### API tests
- `EXPECTED_ZERO_RUN_DISALLOWED_TOOLS` → `EXPECTED_AGENT_RUN_DISALLOWED_TOOLS`.
- `zeroBackedDirectRunBody` → `agentBackedDirectRunBody` (27 call sites).
- Prose in `run-reads.bdd.test.ts`, `helpers/api-bdd-computer-use.ts`, `helpers/api-bdd-runs.ts`, `run-lifecycle.bdd.test.ts`.

### Internal test-state key
`zero_run` → `agent_run`, renamed at **all four sites in this one commit**, as the issue requires:
1. `signals/routes/test-telegram-state.ts:1049,1090` (producer)
2. `__tests__/helpers/agent-run-callback.ts:30` (schema)
3. `__tests__/integrations-telegram-post.test.ts:471` (consumer)
4. `__tests__/chat-events.bdd.test.ts` — five state assertions (consumer)

The `test-telegram-state` contract in `api-contracts` is `.passthrough()` and does not declare the key, so no contract change was needed. The key is confined to the test-state route; `git grep zero_run` finds no other reader in the repo.

## Deliberately untouched

- **Physical database identity** — `git diff --name-only -- turbo/packages/db` is empty. No migration, no `packages/db/scripts` file, no `zero_runs` / `zero_agents` identifier. The `*ZeroRunId` fixture consts named in the issue's acceptance list live in `turbo/packages/db/scripts/test-migration-consistency-schema.ts` and directly name rows inserted into the physical `zero_runs` table, so they are covered by the "no change under `turbo/packages/db/scripts`" boundary and by the physical-identity boundary; see the note below.
- **Op-log action types** — `enqueue_zero_run` (`agent-run-create.service.ts:6723`), `dequeue_zero_run` (`run-queue.service.ts:224`), and the three test assertions on them. Owned by workstream R2, which needs a saved-query decision first. `git diff -U0 | grep -E '^[+-].*(en|de)queue_zero_run'` returns nothing.
- **`/api/zero/**` route literals, `ZERO_*` env readers, Zero scope tokens** — owned by #26701. This also covers `path: "/api/test/zero-run-fixture"` in `test-run-fixture.ts`, which is an HTTP path literal and therefore excluded by the issue's non-goals; only its JSDoc was reworded.
- No other `zero` / `vm0` naming was swept, to stay clear of the parallel #31799 / #31800 / #31802 threads and the R3 `Vm0*` model-vocabulary work that shares `run-lifecycle.bdd.test.ts` and `chat-events.bdd.test.ts`.

### Note on one acceptance-criteria conflict

The issue lists the `*ZeroRunId` fixture identifiers under "API tests and fixtures" and asks for them to be renamed, but they are actually in `turbo/packages/db/scripts/test-migration-consistency-schema.ts` — which another acceptance criterion and the hard boundaries say must show no change. I resolved it in favour of the boundary and left them alone; they read correctly as-is, because they name rows in the physical `zero_runs` table. Happy to split them into a follow-up if R2 wants them.

## Acceptance grep

```
git grep -niE 'zero[ _-]?runs?' -- turbo/packages/api-contracts turbo/apps/api/src ':!*__tests__/helpers/legacy*'
```

returns exactly six lines, all boundary-protected:

```
__tests__/chat-events.bdd.test.ts:4275:        op_type: "enqueue_zero_run",
__tests__/run-lifecycle.bdd.test.ts:7898:  ... event.op_type === "enqueue_zero_run";
__tests__/run-lifecycle.bdd.test.ts:7919:        op_type: "enqueue_zero_run",
routes/test-run-fixture.ts:23:    path: "/api/test/zero-run-fixture",
services/agent-run-create.service.ts:6723:      actionType: "enqueue_zero_run",
services/run-queue.service.ts:224:    actionType: "dequeue_zero_run",
```

## Verification

Run locally against a Postgres 18 + pgvector instance with the repo migrations applied. Full vitest and the dev server were deliberately not run; the rest is left to the PR pipeline.

| Check | Result |
| --- | --- |
| `pnpm -F @okouai/api-contracts run check-types` | pass |
| `pnpm -F api run check-types` (all 7 stages) | pass |
| `pnpm -F @okouai/api-contracts run lint` | pass |
| `pnpm -F api run lint` (oxlint + type-aware + eslint) | pass |
| `prettier --check` on changed files | pass |
| `api-contracts` `contracts/__tests__/runs.test.ts` | 13 passed |
| `run-lifecycle.bdd.test.ts` + `integrations-telegram-post.test.ts` | 247 passed |
| `chat-events.bdd.test.ts` | 175 passed |
| `run-reads.bdd.test.ts` | 27 passed |
| `banking` + `computer-use.bdd` + `test-runtime-state` + `video-io-generate` | 99 passed |

API request and response shapes are unchanged; no contract test needed modification beyond the one renamed test title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)