### PR TITLE
test(platform): synchronize chat list lifecycle assertions

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-event-order.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-event-order.test.tsx
@@ -24,7 +24,7 @@ test("Conversation lifecycle events produce the current list", async () => {
   const newThreadId = chatListThreadId(32);
   await seedChatListCache(5, auth, [oldThread]);
   installChatListAgent(context);
-  installChatListStream(context, {
+  const stream = installChatListStream(context, {
     caseId: 5,
     snapshot: [oldThread],
     events: [
@@ -46,6 +46,8 @@ test("Conversation lifecycle events produce the current list", async () => {
     auth,
   });
 
+  // Page readiness can precede the first conversation event response.
+  await stream.eventsServed;
   await waitFor(() => {
     expect(sidebarThreadTitles()).toStrictEqual(["Current conversation"]);
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
@@ -146,10 +146,10 @@ export function installChatListStream(
   options: ChatListStreamOptions,
 ): {
   readonly setEvents: (events: readonly ChatThreadEvent[]) => void;
-  readonly wasEventServed: (eventId: string) => boolean;
+  readonly eventsServed: Promise<void>;
 } {
   let currentEvents = [...(options.events ?? [])];
-  const servedEventIds = new Set<string>();
+  const eventsServed = context.mocks.deferred<void>();
   context.mocks.api(chatThreadsContract.snapshot, async ({ respond }) => {
     await options.remoteGate;
     return respond(200, {
@@ -164,8 +164,8 @@ export function installChatListStream(
     const events = currentEvents.filter((event) => {
       return event.seqId > sinceSeqId;
     });
-    for (const event of events) {
-      servedEventIds.add(event.id);
+    if (!eventsServed.settled()) {
+      eventsServed.resolve();
     }
     return respond(200, {
       events,
@@ -182,9 +182,7 @@ export function installChatListStream(
     setEvents(events) {
       currentEvents = [...events];
     },
-    wasEventServed(eventId) {
-      return servedEventIds.has(eventId);
-    },
+    eventsServed: eventsServed.promise,
   };
 }
 


### PR DESCRIPTION
The conversation lifecycle page test intermittently failed with an empty list or `Old conversation` instead of `Current conversation`. `setupPage()` resolves when the first page content appears, while conversation cache hydration and event catch-up can still be pending. Starting the DOM assertion's one-second wait at that point made it depend on bootstrap scheduling under sharded test load.

Replace the chat-list fixture's unused per-event tracking hook with a test-signal-owned promise for its first event response, and await that boundary before checking the rendered list. The test continues to exercise the complete rename, sort, create and delete event batch and assert the resulting conversation ID and navigation link.

Validation:

- Reproduced the original empty-list failure in a temporary 12-iteration diagnostic run alongside the cache tests with two workers. The projection was still empty throughout the failed DOM wait. The same harness passed all 18 tests with this change; instrumentation has been removed.
- The final event-order file passed five separate runs, two tests per run.
- All four chat-list test files passed, 14 tests total.
- Platform lint, production/test/build-config type checks, scoped Knip, focused Prettier, commitlint and diff whitespace checks passed.
- [PR CI passed on attempt 2](https://github.com/vm0-ai/vm0/actions/runs/33942629158/attempts/2), including all eight app test shards. Attempt 1 already passed this file and all 130 tests in its shard; a separate touch-keyboard visibility failure caused matrix cancellation before the shard finished uploading coverage.

Reported failures: [run 33905408378](https://github.com/vm0-ai/vm0/actions/runs/33905408378/job/101129126322), [run 33897196808](https://github.com/vm0-ai/vm0/actions/runs/33897196808/job/101102604143).
