### PR TITLE
test(platform): scope feedback quote assertions

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
@@ -268,15 +268,22 @@ test("Manage multiple quoted passages in one feedback message", async () => {
     },
   ]);
   await waitFor(() => {
-    const launchMentions = screen.getAllByText(
-      /launch plan has three careful stages/u,
+    const feedbackGroups = document.querySelectorAll<HTMLElement>(
+      "[data-structured-feedback-group]",
     );
-    const decisionMentions = screen.getAllByText(
-      /unrelated answer covers a separate decision/u,
+    expect(feedbackGroups).toHaveLength(2);
+    const currentGroup = feedbackGroups.item(1);
+    expect(currentGroup).toBeVisible();
+
+    const quotes = currentGroup.querySelectorAll<HTMLElement>(
+      "[data-structured-feedback-quote]",
     );
-    expect(launchMentions).toHaveLength(3);
-    expect(decisionMentions).toHaveLength(3);
-    expect(launchMentions.at(-1)).toBeVisible();
-    expect(decisionMentions.at(-1)).toBeVisible();
+    expect(quotes).toHaveLength(2);
+    expect(quotes.item(0)).toHaveTextContent(
+      "launch plan has three careful stages",
+    );
+    expect(quotes.item(1)).toHaveTextContent(
+      "unrelated answer covers a separate decision",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- locate the second submitted feedback message through its structured feedback-group boundary
- assert the current group's visibility and its two quote elements without global text counts or last-match ordering
- preserve the existing feedback payload and note-clearing coverage

## Scope

Test-only. This PR does not change product rendering, API behavior, CI sharding, or timeout configuration.

## Validation

- `pnpm exec prettier --check apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-capability-feedback.test.tsx --silent=passed-only` (6 sequential executions, 4/4 tests each)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `git diff --check`
- pre-commit hooks, including repository-wide Knip and TypeScript checks

Closes #31788
