### PR TITLE
refactor(platform): rename data-vm0-* dom attributes to data-okou-*

### DIFF
--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -392,7 +392,7 @@ function clerkEdgeSessionJson(html) {
 
 function appBootstrapJson(html, path) {
   for (const match of html.matchAll(
-    /<script\b[^>]*data-vm0-api-bootstrap=""[^>]*>([\s\S]*?)<\/script>/giu,
+    /<script\b[^>]*data-okou-api-bootstrap=""[^>]*>([\s\S]*?)<\/script>/giu,
   )) {
     const attributes = parseAttributes(match[0]);
     if (attributes.get("data-path") === encodeURIComponent(path)) {
@@ -439,7 +439,7 @@ function assertNoClerkSecrets(snapshot) {
 
 function clerkBootstrap(html) {
   const bootstrap =
-    /<script\b[^>]*data-vm0-clerk-bootstrap=""[^>]*>[\s\S]*?<\/script>/iu.exec(
+    /<script\b[^>]*data-okou-clerk-bootstrap=""[^>]*>[\s\S]*?<\/script>/iu.exec(
       html,
     )?.[0];
   if (!bootstrap) {
@@ -1029,7 +1029,7 @@ assert.deepEqual(appBootstrapJson(bootstrapped.body, "/api/feature-switches"), {
 });
 assert.doesNotMatch(bootstrapped.body, /<script>alert\(1\)<\/script>/u);
 assert.ok(
-  bootstrapped.body.indexOf("data-vm0-api-bootstrap") <
+  bootstrapped.body.indexOf("data-okou-api-bootstrap") <
     bootstrapped.body.indexOf('id="root"'),
 );
 

--- a/e2e/playwright/lib/stripe-checkout.ts
+++ b/e2e/playwright/lib/stripe-checkout.ts
@@ -179,7 +179,7 @@ async function createStripeFrameBaseline(
 ): Promise<StripeFrameBaseline> {
   stripeFrameBaselineSequence += 1;
   const attributeName =
-    `data-vm0-stripe-frame-baseline-${Date.now()}-` +
+    `data-okou-stripe-frame-baseline-${Date.now()}-` +
     stripeFrameBaselineSequence;
   await frame.locator("iframe").evaluateAll((elements, attribute) => {
     for (const element of elements) {

--- a/turbo/apps/app-worker/src/worker.js
+++ b/turbo/apps/app-worker/src/worker.js
@@ -273,7 +273,7 @@ async function fetchAppBootstrap(request, requestUrl, fetcher) {
 
 function appBootstrapScript(entry) {
   const path = encodeURIComponent(entry.path);
-  return `<script type="application/json" data-vm0-api-bootstrap="" data-method="GET" data-path="${path}" data-content-type="application/json">${serializeClerkEdgeSession(entry.body)}</script>`;
+  return `<script type="application/json" data-okou-api-bootstrap="" data-method="GET" data-path="${path}" data-content-type="application/json">${serializeClerkEdgeSession(entry.body)}</script>`;
 }
 
 function clerkEdgeSessionAuthorizedParty(requestUrl, env) {

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -222,7 +222,7 @@
       defer
       type="text/javascript"
     ></script>
-    <script data-vm0-clerk-bootstrap="">
+    <script data-okou-clerk-bootstrap="">
       (function () {
         var hostname = location.hostname.toLowerCase();
         var production =

--- a/turbo/apps/platform/scripts/check-build-config.node.ts
+++ b/turbo/apps/platform/scripts/check-build-config.node.ts
@@ -368,7 +368,7 @@ function clerkDiscoveryFixture(): string {
     "<!doctype html><html><head>",
     '<style id="app-bootstrap-critical-styles">body { color: black; }</style>',
     '<script id="vm0-clerk-core-script" src="https://cdn.example.test/clerk.js" defer></script>',
-    '<script data-vm0-clerk-bootstrap="">window.__clerkConfigured = true;</script>',
+    '<script data-okou-clerk-bootstrap="">window.__clerkConfigured = true;</script>',
     '<script type="module" src="/src/main.js"></script>',
     "</head><body>",
     '<div id="app-bootstrap-skeleton"></div>',
@@ -378,7 +378,7 @@ function clerkDiscoveryFixture(): string {
 
 function assertClerkDiscoveryOrder(htmlSource: string): void {
   const clerkCoreIndex = htmlSource.indexOf('id="vm0-clerk-core-script"');
-  const clerkBootstrapIndex = htmlSource.indexOf('data-vm0-clerk-bootstrap=""');
+  const clerkBootstrapIndex = htmlSource.indexOf('data-okou-clerk-bootstrap=""');
   const appModuleIndex = htmlSource.indexOf('<script type="module"');
   assert.notEqual(clerkCoreIndex, -1);
   assert.ok(clerkBootstrapIndex > clerkCoreIndex);
@@ -394,7 +394,7 @@ function assertApplicationStylesheetPreload(htmlSource: string): void {
     'id="vm0-main-stylesheet-loader"',
   );
   const clerkCoreIndex = htmlSource.indexOf('id="vm0-clerk-core-script"');
-  const clerkBootstrapIndex = htmlSource.indexOf('data-vm0-clerk-bootstrap=""');
+  const clerkBootstrapIndex = htmlSource.indexOf('data-okou-clerk-bootstrap=""');
   const headEndIndex = htmlSource.indexOf("</head>");
   const skeletonIndex = htmlSource.indexOf('id="app-bootstrap-skeleton"');
   const appModuleIndex = htmlSource.indexOf('<script type="module"');

--- a/turbo/apps/platform/scripts/check-build-config.node.ts
+++ b/turbo/apps/platform/scripts/check-build-config.node.ts
@@ -378,7 +378,9 @@ function clerkDiscoveryFixture(): string {
 
 function assertClerkDiscoveryOrder(htmlSource: string): void {
   const clerkCoreIndex = htmlSource.indexOf('id="vm0-clerk-core-script"');
-  const clerkBootstrapIndex = htmlSource.indexOf('data-okou-clerk-bootstrap=""');
+  const clerkBootstrapIndex = htmlSource.indexOf(
+    'data-okou-clerk-bootstrap=""',
+  );
   const appModuleIndex = htmlSource.indexOf('<script type="module"');
   assert.notEqual(clerkCoreIndex, -1);
   assert.ok(clerkBootstrapIndex > clerkCoreIndex);
@@ -394,7 +396,9 @@ function assertApplicationStylesheetPreload(htmlSource: string): void {
     'id="vm0-main-stylesheet-loader"',
   );
   const clerkCoreIndex = htmlSource.indexOf('id="vm0-clerk-core-script"');
-  const clerkBootstrapIndex = htmlSource.indexOf('data-okou-clerk-bootstrap=""');
+  const clerkBootstrapIndex = htmlSource.indexOf(
+    'data-okou-clerk-bootstrap=""',
+  );
   const headEndIndex = htmlSource.indexOf("</head>");
   const skeletonIndex = htmlSource.indexOf('id="app-bootstrap-skeleton"');
   const appModuleIndex = htmlSource.indexOf('<script type="module"');

--- a/turbo/apps/platform/src/lib/rehype-mermaid.ts
+++ b/turbo/apps/platform/src/lib/rehype-mermaid.ts
@@ -20,9 +20,9 @@ interface HastNode {
 }
 
 export const MARKDOWN_MERMAID_FENCE_ATTRIBUTE =
-  "data-vm0-markdown-mermaid-fence";
+  "data-okou-markdown-mermaid-fence";
 
-const MARKDOWN_MERMAID_FENCE_PROPERTY = "dataVm0MarkdownMermaidFence";
+const MARKDOWN_MERMAID_FENCE_PROPERTY = "dataOkouMarkdownMermaidFence";
 
 interface TextTreeNode {
   readonly type: string;

--- a/turbo/apps/platform/src/signals/__tests__/api-client-bootstrap.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client-bootstrap.test.ts
@@ -17,7 +17,7 @@ test("uses a matching bootstrap response once before falling back to the network
   };
   const script = document.createElement("script");
   script.type = "application/json";
-  script.dataset.vm0ApiBootstrap = "";
+  script.dataset.okouApiBootstrap = "";
   script.dataset.method = "GET";
   script.dataset.path = encodeURIComponent(featureSwitchesContract.get.path);
   script.dataset.contentType = "application/json";

--- a/turbo/apps/platform/src/signals/api-client-base.ts
+++ b/turbo/apps/platform/src/signals/api-client-base.ts
@@ -33,14 +33,8 @@ interface AuthedClientOptions {
   ) => Promise<string> | string;
 }
 
-// Surface: new app bundle -> old serving artifact. The app Worker that injects
-// this script deploys independently from the bundle that reads it, because
-// `app-worker/wrangler.jsonc` reads hashed assets from the R2 origin, so the
-// selector also accepts the pre-rename spelling. Drop the legacy half once the
-// Worker release carrying this change is live and outside its rollback window;
-// follow-up #31824.
 const API_BOOTSTRAP_SELECTOR =
-  'script[type="application/json"][data-okou-api-bootstrap],script[type="application/json"][data-vm0-api-bootstrap]';
+  'script[type="application/json"][data-okou-api-bootstrap]';
 
 function takeBootstrapResponse(
   method: string,

--- a/turbo/apps/platform/src/signals/api-client-base.ts
+++ b/turbo/apps/platform/src/signals/api-client-base.ts
@@ -33,10 +33,12 @@ interface AuthedClientOptions {
   ) => Promise<string> | string;
 }
 
-// The app Worker that injects this script deploys independently from the app
-// bundle that reads it, so the selector also accepts the pre-rename spelling.
-// Drop the legacy half once every deployed Worker emits `data-okou-api-bootstrap`,
-// which the Worker release carrying this change establishes.
+// Surface: new app bundle -> old serving artifact. The app Worker that injects
+// this script deploys independently from the bundle that reads it, because
+// `app-worker/wrangler.jsonc` reads hashed assets from the R2 origin, so the
+// selector also accepts the pre-rename spelling. Drop the legacy half once the
+// Worker release carrying this change is live and outside its rollback window;
+// follow-up #31824.
 const API_BOOTSTRAP_SELECTOR =
   'script[type="application/json"][data-okou-api-bootstrap],script[type="application/json"][data-vm0-api-bootstrap]';
 

--- a/turbo/apps/platform/src/signals/api-client-base.ts
+++ b/turbo/apps/platform/src/signals/api-client-base.ts
@@ -33,8 +33,12 @@ interface AuthedClientOptions {
   ) => Promise<string> | string;
 }
 
+// The app Worker that injects this script deploys independently from the app
+// bundle that reads it, so the selector also accepts the pre-rename spelling.
+// Drop the legacy half once every deployed Worker emits `data-okou-api-bootstrap`,
+// which the Worker release carrying this change establishes.
 const API_BOOTSTRAP_SELECTOR =
-  'script[type="application/json"][data-vm0-api-bootstrap]';
+  'script[type="application/json"][data-okou-api-bootstrap],script[type="application/json"][data-vm0-api-bootstrap]';
 
 function takeBootstrapResponse(
   method: string,

--- a/turbo/apps/platform/src/signals/okou-page/clipboard.ts
+++ b/turbo/apps/platform/src/signals/okou-page/clipboard.ts
@@ -13,10 +13,10 @@ import {
 } from "../utils.ts";
 
 const CHAT_MESSAGE_CLIPBOARD_ATTR = "data-okou-chat-message";
-// Clipboard content outlives the session that produced it, so a paste can still
-// carry the pre-rename attribute. Drop this once no clipboard written before the
-// okou rename can realistically be pasted back, which is at most a few days of
-// system clipboard lifetime after the rename ships.
+// Surface: content copied by a pre-rename app client and held in the system
+// clipboard, which outlives the session that produced it. The window is
+// clipboard lifetime rather than an API contract, so it closes about a week
+// after the rename reaches production; follow-up #31824.
 const LEGACY_CHAT_MESSAGE_CLIPBOARD_ATTR = "data-vm0-chat-message";
 
 export interface ChatClipboardAttachment {

--- a/turbo/apps/platform/src/signals/okou-page/clipboard.ts
+++ b/turbo/apps/platform/src/signals/okou-page/clipboard.ts
@@ -12,7 +12,12 @@ import {
   withCleanup,
 } from "../utils.ts";
 
-const CHAT_MESSAGE_CLIPBOARD_ATTR = "data-vm0-chat-message";
+const CHAT_MESSAGE_CLIPBOARD_ATTR = "data-okou-chat-message";
+// Clipboard content outlives the session that produced it, so a paste can still
+// carry the pre-rename attribute. Drop this once no clipboard written before the
+// okou rename can realistically be pasted back, which is at most a few days of
+// system clipboard lifetime after the rename ships.
+const LEGACY_CHAT_MESSAGE_CLIPBOARD_ATTR = "data-vm0-chat-message";
 
 export interface ChatClipboardAttachment {
   id: string | null;
@@ -137,7 +142,7 @@ function formatMessageHtml(payload: ChatClipboardPayload): string {
     .map((attachment) => {
       const name = escapeHtml(attachment.filename);
       const url = escapeHtml(attachment.url);
-      return `<div><a href="${url}" data-vm0-attachment-id="${escapeHtml(attachment.id ?? "")}">${name}</a></div>`;
+      return `<div><a href="${url}" data-okou-attachment-id="${escapeHtml(attachment.id ?? "")}">${name}</a></div>`;
     })
     .join("");
   const attachmentsHtml = attachmentLinksHtml
@@ -298,6 +303,21 @@ export async function writeChatMessageToClipboard(
   }
 }
 
+function encodedChatMessageFromDocument(doc: Document): string | null {
+  for (const attribute of [
+    CHAT_MESSAGE_CLIPBOARD_ATTR,
+    LEGACY_CHAT_MESSAGE_CLIPBOARD_ATTR,
+  ]) {
+    const encoded = doc
+      .querySelector(`[${attribute}]`)
+      ?.getAttribute(attribute);
+    if (encoded) {
+      return encoded;
+    }
+  }
+  return null;
+}
+
 export function readChatMessageFromClipboard(
   clipboardData: DataTransfer,
 ): ChatClipboardPayload | null {
@@ -306,8 +326,7 @@ export function readChatMessageFromClipboard(
     return null;
   }
   const doc = new DOMParser().parseFromString(html, "text/html");
-  const node = doc.querySelector(`[${CHAT_MESSAGE_CLIPBOARD_ATTR}]`);
-  const encoded = node?.getAttribute(CHAT_MESSAGE_CLIPBOARD_ATTR);
+  const encoded = encodedChatMessageFromDocument(doc);
   if (!encoded) {
     return null;
   }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-gallery-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-template-gallery-test-helpers.ts
@@ -130,7 +130,7 @@ export function mockTemplateObjectUrls(): void {
 function presentationHtml(slideTitles: readonly string[]): string {
   return `<!doctype html><html><body>${slideTitles
     .map((title, index) => {
-      return `<section data-vm0-slide data-slide-id="slide-${index + 1}"><h1 data-vm0-editable="text">${title}</h1></section>`;
+      return `<section data-okou-slide data-slide-id="slide-${index + 1}"><h1 data-okou-editable="text">${title}</h1></section>`;
     })
     .join("")}</body></html>`;
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-clipboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-clipboard.test.tsx
@@ -40,12 +40,13 @@ interface RichClipboardPayload {
 function richClipboard(
   payload: RichClipboardPayload,
   plainText = payload.text,
+  attribute = "data-okou-chat-message",
 ): DataTransfer {
   const data = new DataTransfer();
   const encoded = encodeURIComponent(JSON.stringify(payload));
   data.setData(
     "text/html",
-    `<div data-vm0-chat-message="${encoded}">${payload.text}</div>`,
+    `<div ${attribute}="${encoded}">${payload.text}</div>`,
   );
   data.setData("text/plain", plainText);
   return data;
@@ -177,6 +178,46 @@ test("Paste copied chat text and attachments safely", async () => {
     expect(composer).toHaveTextContent("Resumo copiado em duas linhas");
     expect(composer).toHaveTextContent("Continuação preservada");
     expect(fastButton("Remove locale-copy.txt")).toBeVisible();
+  });
+});
+
+test("Paste chat content copied before the okou attribute rename", async () => {
+  const thread = continuityThread(17, 1, "Legacy clipboard restoration");
+  const available = continuityAttachment(17, 1, "legacy-copy.txt");
+  const workspace = await installContinuityWorkspace(context, {
+    caseId: 17,
+    threads: [thread],
+    resolveAttachment() {
+      return "available";
+    },
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${thread.id}`,
+    auth: workspace.auth,
+  });
+
+  const composer = await screen.findByRole("textbox", { name: "Message" });
+  placeCaretAtEnd(composer);
+  fireEvent.paste(composer, {
+    clipboardData: richClipboard(
+      {
+        text: "Copied before the rename",
+        attachments: [available],
+        userMessage: {
+          version: 1,
+          parts: [{ type: "text", text: "Copied before the rename" }],
+        },
+      },
+      "Copied before the rename",
+      "data-vm0-chat-message",
+    ),
+  });
+
+  await waitFor(() => {
+    expect(composer).toHaveTextContent("Copied before the rename");
+    expect(fastButton("Remove legacy-copy.txt")).toBeVisible();
   });
 });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-lifecycle-test-helpers.ts
@@ -108,8 +108,8 @@ export function parseChatClipboardPayload(html: string): {
   userMessage?: UserMessageDocument;
 } {
   const doc = new DOMParser().parseFromString(html, "text/html");
-  const encoded = doc.querySelector<HTMLElement>("[data-vm0-chat-message]")
-    ?.dataset.vm0ChatMessage;
+  const encoded = doc.querySelector<HTMLElement>("[data-okou-chat-message]")
+    ?.dataset.okouChatMessage;
   if (!encoded) {
     throw new Error("chat clipboard payload not found");
   }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/presentation-preview.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/presentation-preview.test.tsx
@@ -182,12 +182,12 @@ test("Selecting a slide preserves its authored layout", async () => {
       </head>
       <body>
         <div class="slide slide-shell active" aria-hidden="false">
-          <section class="authored-slide active" data-vm0-slide data-slide-id="slide-one">
+          <section class="authored-slide active" data-okou-slide data-slide-id="slide-one">
             <h1>First slide</h1>
           </section>
         </div>
         <div class="slide slide-shell" hidden inert aria-hidden="true" style="display: none">
-          <section class="authored-slide" data-vm0-slide data-slide-id="slide-two" hidden inert aria-hidden="true" style="display: none">
+          <section class="authored-slide" data-okou-slide data-slide-id="slide-two" hidden inert aria-hidden="true" style="display: none">
             <h1>Selected slide</h1>
           </section>
         </div>
@@ -210,7 +210,7 @@ test("Selecting a slide preserves its authored layout", async () => {
   const frameDocument = await hydratePreviewFrame(secondFrame, objectUrls);
 
   expect(frameDocument.querySelector('[data-slide-id="slide-one"]')).toBeNull();
-  expect(frameDocument.querySelectorAll("[data-vm0-slide]")).toHaveLength(1);
+  expect(frameDocument.querySelectorAll("[data-okou-slide]")).toHaveLength(1);
   const wrapper = elementBySelector(frameDocument, ".slide-shell");
   const selectedSlide = elementBySelector(
     frameDocument,
@@ -230,11 +230,56 @@ test("Selecting a slide preserves its authored layout", async () => {
   );
 });
 
+test("A deck authored with the legacy vm0 attributes still previews", async () => {
+  // `div` matches no other slide selector and `strong` matches no fallback
+  // editable selector, so the deck only splits into slides and annotates an
+  // editable block when the legacy `data-vm0-*` readers still apply.
+  const objectUrls = arrangePresentation(`<!doctype html>
+    <html>
+      <body>
+        <script type="application/json" id="vm0-deck-metadata">{"editProtocolVersion":1,"kind":"deck","slides":{"slide-two":{"speakerNotes":"Legacy notes"}}}</script>
+        <div data-vm0-slide data-slide-id="slide-one">
+          <strong data-vm0-editable="text">Legacy first</strong>
+        </div>
+        <div data-vm0-slide data-slide-id="slide-two">
+          <strong data-vm0-editable="text">Legacy second</strong>
+        </div>
+      </body>
+    </html>`);
+  await setupPage({
+    context,
+    host: "app.vm0.ai",
+    path: `/agents/${AGENT_ID}/chat`,
+  });
+
+  const firstFrame = await openPresentationDetail();
+  await hydratePreviewFrame(firstFrame, objectUrls);
+  const firstFrameUrl = firstFrame.getAttribute("src");
+  click(await waitForNamedButton("Preview slide 2"));
+  await waitFor(() => {
+    expect(activePreviewFrame().getAttribute("src")).not.toBe(firstFrameUrl);
+  });
+  const frameDocument = await hydratePreviewFrame(
+    activePreviewFrame(),
+    objectUrls,
+  );
+
+  expect(frameDocument.querySelectorAll("[data-vm0-slide]")).toHaveLength(1);
+  expect(frameDocument.querySelector('[data-slide-id="slide-one"]')).toBeNull();
+  const editable = elementBySelector(
+    frameDocument,
+    '[data-vm0-editable="text"]',
+  );
+  expect(editable).toHaveTextContent("Legacy second");
+  expect(editable).toHaveAttribute("data-okou-editor-slide-id", "slide-two");
+  expect(editable).toHaveAttribute("data-okou-editor-edit-id");
+});
+
 test("A presentation slide fills its preview frame cleanly", async () => {
   const objectUrls = arrangePresentation(`<!doctype html>
     <html>
       <body>
-        <section data-vm0-slide data-slide-id="slide-one" style="width: 100vw; height: 100vh; border-radius: 32px; box-shadow: 0 20px 60px #0008">
+        <section data-okou-slide data-slide-id="slide-one" style="width: 100vw; height: 100vh; border-radius: 32px; box-shadow: 0 20px 60px #0008">
           <div class="stage" style="width: 100vw; height: 100vh; max-width: 1440px; max-height: 810px; border-radius: 24px; box-shadow: 0 12px 40px #0006">
             <h1>Nested stage</h1>
           </div>
@@ -248,7 +293,7 @@ test("A presentation slide fills its preview frame cleanly", async () => {
   });
 
   const { document: frameDocument } = await openReadyPresentation(objectUrls);
-  const slide = elementBySelector(frameDocument, "[data-vm0-slide]");
+  const slide = elementBySelector(frameDocument, "[data-okou-slide]");
   const stage = elementBySelector(frameDocument, ".stage");
   const slideStyle = computedStyle(slide);
   const stageStyle = computedStyle(stage);
@@ -269,7 +314,7 @@ test("An unusable generated theme does not break the presentation preview", asyn
   const objectUrls = arrangePresentation(`<!doctype html>
     <html>
       <body>
-        <section data-vm0-slide data-slide-id="slide-one" style="background-color: #fef3c7; color: #1f2937">
+        <section data-okou-slide data-slide-id="slide-one" style="background-color: #fef3c7; color: #1f2937">
           <h1>Authored fallback remains</h1>
         </section>
         <script>
@@ -293,7 +338,7 @@ test("An unusable generated theme does not break the presentation preview", asyn
 
   const { document: frameDocument, frame } =
     await openReadyPresentation(objectUrls);
-  const slide = elementBySelector(frameDocument, "[data-vm0-slide]");
+  const slide = elementBySelector(frameDocument, "[data-okou-slide]");
   const slideStyle = computedStyle(slide);
 
   expect(frame).toHaveAttribute("data-loaded", "true");
@@ -302,7 +347,7 @@ test("An unusable generated theme does not break the presentation preview", asyn
   expectCssColor(slideStyle.color, ["#1f2937", "rgb(31,41,55)"]);
   expect(frameDocument.querySelector("script")).toBeNull();
   expect(
-    frameDocument.querySelector('[data-vm0-materialized-theme="true"]'),
+    frameDocument.querySelector('[data-okou-materialized-theme="true"]'),
   ).toBeNull();
 });
 
@@ -315,7 +360,7 @@ test("Presentation previews preserve the selected theme", async () => {
         </style>
       </head>
       <body>
-        <section class="themed-slide" data-vm0-slide data-slide-id="slide-one">
+        <section class="themed-slide" data-okou-slide data-slide-id="slide-one">
           <h1>Selected generated theme</h1>
         </section>
         <script>
@@ -345,7 +390,7 @@ test("Presentation previews preserve the selected theme", async () => {
   expect(rootStyle.getPropertyValue("--fd")).toContain("Fraunces");
   expect(rootStyle.getPropertyValue("--fb")).toContain("Inter");
   expect(
-    frameDocument.querySelector('[data-vm0-materialized-theme="true"]'),
+    frameDocument.querySelector('[data-okou-materialized-theme="true"]'),
   ).not.toBeNull();
   expect(frameDocument.querySelector("script")).toBeNull();
   expect(elementBySelector(frameDocument, ".themed-slide")).toHaveTextContent(

--- a/turbo/apps/platform/src/views/okou-page/presentation-html-preview.ts
+++ b/turbo/apps/platform/src/views/okou-page/presentation-html-preview.ts
@@ -1,8 +1,11 @@
 import { i18n } from "../../i18n/index.ts";
 
-// Deck HTML is authored outside this repository, so the reader keeps accepting
-// the pre-rename `data-vm0-*` edit protocol alongside `data-okou-*`. Drop the
-// legacy halves once no stored or user-supplied deck still carries them.
+// Surface: stored and externally authored deck HTML, not a deploy skew, so it
+// has no rollout window. The deck generator lives outside this repository and
+// decks are persisted, so the reader keeps accepting the pre-rename
+// `data-vm0-*` edit protocol alongside `data-okou-*`. Drop the legacy halves
+// once stored decks are migrated or regenerated and the generator emits only
+// `data-okou-*`; follow-up #31824.
 const EDITABLE_SELECTOR =
   '[data-okou-editable="text"],[data-vm0-editable="text"]';
 const METADATA_SCRIPT_IDS = [
@@ -770,8 +773,8 @@ function materializePresentationThemeSwitcherDefaults(doc: Document): void {
 }
 
 // The stage layout rules keep matching the legacy `[data-vm0-slide]` spelling so
-// decks authored before the okou rename still fill the stage. Drop those halves
-// together with the legacy deck-protocol readers above.
+// decks authored before the okou rename still fill the stage. Same surface and
+// removal condition as the deck-protocol readers above; follow-up #31824.
 function appendPresentationPreviewStyle(previewDoc: Document): void {
   const style = previewDoc.createElement("style");
   style.textContent = `

--- a/turbo/apps/platform/src/views/okou-page/presentation-html-preview.ts
+++ b/turbo/apps/platform/src/views/okou-page/presentation-html-preview.ts
@@ -1,9 +1,16 @@
 import { i18n } from "../../i18n/index.ts";
 
-const EDITABLE_SELECTOR = '[data-vm0-editable="text"]';
-const METADATA_SCRIPT_ID = "vm0-deck-metadata";
+// Deck HTML is authored outside this repository, so the reader keeps accepting
+// the pre-rename `data-vm0-*` edit protocol alongside `data-okou-*`. Drop the
+// legacy halves once no stored or user-supplied deck still carries them.
+const EDITABLE_SELECTOR =
+  '[data-okou-editable="text"],[data-vm0-editable="text"]';
+const METADATA_SCRIPT_IDS = [
+  "okou-deck-metadata",
+  "vm0-deck-metadata",
+] as const;
 const SLIDE_SELECTORS = [
-  "[data-vm0-slide]",
+  "[data-okou-slide],[data-vm0-slide]",
   "[data-slide]",
   "[data-slide-index]",
   "[data-page]",
@@ -77,11 +84,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function deckMetadataScript(doc: Document): HTMLScriptElement | null {
-  const script = doc.getElementById(METADATA_SCRIPT_ID);
-  if (!(script instanceof HTMLScriptElement) || !script.textContent) {
-    return null;
+  for (const id of METADATA_SCRIPT_IDS) {
+    const script = doc.getElementById(id);
+    if (script instanceof HTMLScriptElement && script.textContent) {
+      return script;
+    }
   }
-  return script;
+  return null;
 }
 
 function parseDeckMetadata(doc: Document): DeckMetadata {
@@ -130,8 +139,12 @@ function editIdForElement(editable: Element, index: number): string | null {
     return `text-${index + 1}`;
   }
   return (
+    editable.dataset.okouEditId ??
+    // Legacy `data-vm0-edit-id` / `data-vm0-node-id`: drop once no stored deck
+    // HTML written before the okou rename remains.
     editable.dataset.vm0EditId ??
     editable.dataset.editId ??
+    editable.dataset.okouNodeId ??
     editable.dataset.vm0NodeId ??
     editable.dataset.nodeId ??
     `text-${index + 1}`
@@ -140,8 +153,14 @@ function editIdForElement(editable: Element, index: number): string | null {
 
 function ensureEditIdForElement(editable: Element, index: number): string {
   const editId = editIdForElement(editable, index) ?? `text-${index + 1}`;
-  if (editable instanceof HTMLElement && !editable.dataset.vm0EditId) {
-    editable.dataset.vm0EditId = editId;
+  if (
+    editable instanceof HTMLElement &&
+    !editable.dataset.okouEditId &&
+    // A legacy id already anchors this block; rewriting it would change the
+    // stored deck rather than annotate it.
+    !editable.dataset.vm0EditId
+  ) {
+    editable.dataset.okouEditId = editId;
   }
   return editId;
 }
@@ -317,9 +336,9 @@ export function parsePresentationPreviewDraft(
 
 function isTransientPresentationEditorAttribute(name: string): boolean {
   switch (name) {
-    case "data-vm0-editor-edit-id":
-    case "data-vm0-editor-slide-id":
-    case "data-vm0-editor-stage": {
+    case "data-okou-editor-edit-id":
+    case "data-okou-editor-slide-id":
+    case "data-okou-editor-stage": {
       return true;
     }
     default: {
@@ -742,7 +761,7 @@ function materializePresentationThemeSwitcherDefaults(doc: Document): void {
     return;
   }
   const style = doc.createElement("style");
-  style.dataset.vm0MaterializedTheme = "true";
+  style.dataset.okouMaterializedTheme = "true";
   style.textContent = materializedThemeCss({
     fontPair: selectedFontPairFromScript(scriptText),
     palette,
@@ -750,6 +769,9 @@ function materializePresentationThemeSwitcherDefaults(doc: Document): void {
   doc.head.append(style);
 }
 
+// The stage layout rules keep matching the legacy `[data-vm0-slide]` spelling so
+// decks authored before the okou rename still fill the stage. Drop those halves
+// together with the legacy deck-protocol readers above.
 function appendPresentationPreviewStyle(previewDoc: Document): void {
   const style = previewDoc.createElement("style");
   style.textContent = `
@@ -762,7 +784,7 @@ function appendPresentationPreviewStyle(previewDoc: Document): void {
     body {
       display: block !important;
     }
-    [data-vm0-editor-stage] {
+    [data-okou-editor-stage] {
       width: 100%;
       height: 100%;
       display: flex !important;
@@ -770,7 +792,7 @@ function appendPresentationPreviewStyle(previewDoc: Document): void {
       justify-content: center !important;
       overflow: hidden !important;
     }
-    [data-vm0-editor-stage] > * {
+    [data-okou-editor-stage] > * {
       visibility: visible !important;
       opacity: 1 !important;
       max-width: 100% !important;
@@ -778,16 +800,17 @@ function appendPresentationPreviewStyle(previewDoc: Document): void {
       margin: 0 !important;
       box-sizing: border-box !important;
     }
-    [data-vm0-editor-stage] > .slide,
-    [data-vm0-editor-stage] > .ppt-slide,
-    [data-vm0-editor-stage] > .presentation-slide,
-    [data-vm0-editor-stage] > .deck-slide,
-    [data-vm0-editor-stage] > .slide-page,
-    [data-vm0-editor-stage] > section,
-    [data-vm0-editor-stage] > [data-vm0-slide],
-    [data-vm0-editor-stage] > [data-slide],
-    [data-vm0-editor-stage] > [data-slide-index],
-    [data-vm0-editor-stage] > [data-page] {
+    [data-okou-editor-stage] > .slide,
+    [data-okou-editor-stage] > .ppt-slide,
+    [data-okou-editor-stage] > .presentation-slide,
+    [data-okou-editor-stage] > .deck-slide,
+    [data-okou-editor-stage] > .slide-page,
+    [data-okou-editor-stage] > section,
+    [data-okou-editor-stage] > [data-okou-slide],
+    [data-okou-editor-stage] > [data-vm0-slide],
+    [data-okou-editor-stage] > [data-slide],
+    [data-okou-editor-stage] > [data-slide-index],
+    [data-okou-editor-stage] > [data-page] {
       width: 100% !important;
       height: 100% !important;
       min-width: 0 !important;
@@ -800,16 +823,17 @@ function appendPresentationPreviewStyle(previewDoc: Document): void {
       overflow: hidden !important;
       box-sizing: border-box !important;
     }
-    [data-vm0-editor-stage] > .slide > .stage,
-    [data-vm0-editor-stage] > .ppt-slide > .stage,
-    [data-vm0-editor-stage] > .presentation-slide > .stage,
-    [data-vm0-editor-stage] > .deck-slide > .stage,
-    [data-vm0-editor-stage] > .slide-page > .stage,
-    [data-vm0-editor-stage] > section > .stage,
-    [data-vm0-editor-stage] > [data-vm0-slide] > .stage,
-    [data-vm0-editor-stage] > [data-slide] > .stage,
-    [data-vm0-editor-stage] > [data-slide-index] > .stage,
-    [data-vm0-editor-stage] > [data-page] > .stage {
+    [data-okou-editor-stage] > .slide > .stage,
+    [data-okou-editor-stage] > .ppt-slide > .stage,
+    [data-okou-editor-stage] > .presentation-slide > .stage,
+    [data-okou-editor-stage] > .deck-slide > .stage,
+    [data-okou-editor-stage] > .slide-page > .stage,
+    [data-okou-editor-stage] > section > .stage,
+    [data-okou-editor-stage] > [data-okou-slide] > .stage,
+    [data-okou-editor-stage] > [data-vm0-slide] > .stage,
+    [data-okou-editor-stage] > [data-slide] > .stage,
+    [data-okou-editor-stage] > [data-slide-index] > .stage,
+    [data-okou-editor-stage] > [data-page] > .stage {
       width: 100% !important;
       height: 100% !important;
       max-width: none !important;
@@ -821,7 +845,7 @@ function appendPresentationPreviewStyle(previewDoc: Document): void {
       border-radius: 0 !important;
       box-sizing: border-box !important;
     }
-    [data-vm0-editor-edit-id] {
+    [data-okou-editor-edit-id] {
       cursor: text !important;
       outline: 4px solid transparent !important;
       outline-offset: 4px !important;
@@ -832,11 +856,11 @@ function appendPresentationPreviewStyle(previewDoc: Document): void {
       -webkit-user-modify: read-write-plaintext-only !important;
       caret-color: auto !important;
     }
-    [data-vm0-editor-edit-id]:hover {
+    [data-okou-editor-edit-id]:hover {
       outline-color: #0f82ff !important;
       filter: none !important;
     }
-    [data-vm0-editor-edit-id]:focus {
+    [data-okou-editor-edit-id]:focus {
       outline-color: hsl(var(--ring, 15 80% 66%)) !important;
       filter: none !important;
     }
@@ -864,8 +888,8 @@ function annotatePresentationEditableElements(
     slide,
   ).entries()) {
     if (editable instanceof HTMLElement) {
-      editable.dataset.vm0EditorSlideId = slideId;
-      editable.dataset.vm0EditorEditId =
+      editable.dataset.okouEditorSlideId = slideId;
+      editable.dataset.okouEditorEditId =
         editIdForElement(editable, editableIndex) ?? "";
     }
   }
@@ -909,7 +933,7 @@ export function previewPresentationHtml(params: {
     }
   }
   sanitizePreviewDocument(previewDoc);
-  stage.dataset.vm0EditorStage = "true";
+  stage.dataset.okouEditorStage = "true";
   if (activeSlideClone) {
     annotatePresentationEditableElements(activeSlideClone, activeSlideId);
   }


### PR DESCRIPTION
Closes #31815. Part of #31801 (phase-3 continuation of #26873), workstream R7. Follows #31802 / #31808, which shared five platform files with this change.

## What changed

Every writer of a branded DOM attribute now emits `data-okou-*`. Readers that consume HTML this repository does not author keep accepting the legacy `data-vm0-*` spelling.

### Writer-side rename plus dual read

| Attribute | Why the legacy read stays |
|---|---|
| `data-okou-slide`, `data-okou-editable` | Deck HTML is generated or authored outside this repository and stored; already-generated decks must keep rendering. Added as a combined first entry to `SLIDE_SELECTORS` and to `EDITABLE_SELECTOR` rather than replacing the `vm0` form. |
| `okou-deck-metadata` (element id) | Same reason. `deckMetadataScript` now looks up both ids in order. |
| `data-okou-edit-id`, `data-okou-node-id` | Stored deck HTML round-trips through `parsePresentationPreviewDraft`. `editIdForElement` reads both; `ensureEditIdForElement` writes the okou form only when neither spelling is already present, so a legacy deck keeps its stable ids instead of being rewritten. |
| `data-okou-chat-message` | Clipboard content outlives the session that wrote it — a paste days after this ships can still carry the old attribute. |

The preview stage CSS also keeps matching `[data-vm0-slide]` so legacy decks still stretch to fill the frame.

Each retained legacy acceptance carries a comment naming the condition that would allow dropping it. No legacy acceptance is removed in this PR.

### Renamed outright (written and read in this repository)

`data-okou-editor-stage`, `data-okou-editor-edit-id`, `data-okou-editor-slide-id`, `data-okou-materialized-theme`, `data-okou-clerk-bootstrap`, `data-okou-markdown-mermaid-fence`, `data-okou-attachment-id` (write-only annotation, no reader), and the `data-okou-stripe-frame-baseline-` prefix in the Playwright helper.

`e2e/playwright/lib/stripe-checkout.ts` runs against the per-PR preview deployment, so its locator is updated in the same PR.

## Tests

Two new tests prove the dual read, and both were confirmed to fail when the legacy halves are removed:

- `presentation-preview.test.tsx` — "A deck authored with the legacy vm0 attributes still previews". The fixture uses `div` for slides and `strong` for the editable, neither of which matches any other selector in the fallback lists, so the deck only splits into slides and annotates an editable block when the legacy readers apply.
- `chat-continuity-clipboard.test.tsx` — "Paste chat content copied before the okou attribute rename". Pastes a `data-vm0-chat-message` payload and asserts the text and attachment are restored.

Existing preview and template-gallery fixtures were moved to the `data-okou-*` spelling, so both forms stay covered.

Verified locally: `@okouai/app check-types`, eslint and oxlint on the changed files, `lint:build-config`, `.github/scripts/tests/okou-app-worker-test.sh`, and the presentation preview, clipboard, template gallery, markdown/mermaid, and API bootstrap vitest files (11 files, 46 tests).

## Non-goals honored

- No legacy attribute acceptance removed.
- No CSS class or custom property touched — `git grep -nE '(--|\.)zero-[a-z0-9-]+' -- turbo/apps/platform turbo/packages/ui` is still empty.
- The residual platform `zero-*` names tracked in #31816 (keyframes, storage keys, page identifiers) are untouched.
- No change to rendering, editor, or clipboard payload structure beyond attribute names.

## Fallbacks

Per `docs/fallback.md` §9. Follow-up removal issue for all three: #31824.

- `turbo/apps/platform/src/views/okou-page/presentation-html-preview.ts` — `SLIDE_SELECTORS`, `EDITABLE_SELECTOR`, `METADATA_SCRIPT_IDS`, `editIdForElement`, `ensureEditIdForElement`, `appendPresentationPreviewStyle` keep accepting `data-vm0-slide`, `data-vm0-editable`, `vm0-deck-metadata`, `data-vm0-edit-id` and `data-vm0-node-id`. Protects: stored and externally authored deck HTML written before the rename against the renamed reader. Surface: persisted, externally produced content — not a deploy skew, so §7 has no matching time-boxed gate. Removal condition: stored decks are migrated or regenerated and the out-of-repo deck generator emits only `data-okou-*`; tracked in #31824.
- `turbo/apps/platform/src/signals/okou-page/clipboard.ts` — `LEGACY_CHAT_MESSAGE_CLIPBOARD_ATTR` keeps `readChatMessageFromClipboard` accepting `data-vm0-chat-message`. Protects: content copied by the pre-rename app and pasted into the post-rename app. Surface: old web/app client output held in the system clipboard, bounded by clipboard lifetime rather than by an API contract. Removal condition: roughly one week after this PR reaches production; tracked in #31824.

`data-okou-api-bootstrap` deliberately gets **no** compatibility path. The `okou-app` Worker serves `index.html` from its own embedded shell (`worker.js:fetchShellAsset` -> `embeddedShellAsset`), so the injector, the HTML and the hashed bundle that reads it ship as one Worker artifact. A new bundle can never read HTML injected by an old Worker, and a tolerant selector there would be `docs/fallback.md` §3 slop.

No fallback is removed by this PR.

