### PR TITLE
refactor(platform): roll out base ui sidebar scroll area

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.tsx
+++ b/turbo/apps/platform/src/signals/__tests__/bootstrap-feature-switch.test.tsx
@@ -51,7 +51,6 @@ async function setupIntroVideoRolloutPage(args: {
     return respond(200, {
       switches: {},
       effectiveSwitches: {
-        [FeatureSwitchKey.BaseUiSidebarScrollArea]: false,
         [FeatureSwitchKey.IntroVideo]: false,
       },
     });

--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -581,22 +581,6 @@ export function createTestMocks(getSignal: () => AbortSignal) {
       canvasRendering: (): CanvasRenderingMock => {
         return mockCanvasRendering(getSignal());
       },
-      noAnimations: (): void => {
-        const descriptor = defineWindowProperty(
-          HTMLElement.prototype,
-          "getAnimations",
-          () => {
-            return [];
-          },
-        );
-        restoreOnAbort(getSignal(), () => {
-          restoreWindowProperty(
-            HTMLElement.prototype,
-            "getAnimations",
-            descriptor,
-          );
-        });
-      },
       indexedDbUnavailable: (): void => {
         const open = vi
           .spyOn(globalThis.indexedDB, "open")

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
@@ -24,16 +24,9 @@ export interface SidebarChatThreadWindow {
   readonly items: readonly SidebarChatThreadItemSignals[];
 }
 
-export interface SidebarChatThreadScrollMetrics {
+interface SidebarChatThreadScrollMetrics {
   readonly scrollTop: number;
-  readonly scrollHeight: number;
   readonly clientHeight: number;
-}
-
-export interface SidebarChatThreadScrollThumbStyle {
-  readonly top: number;
-  readonly height: number;
-  readonly visible: boolean;
 }
 
 export interface ScrollToThreadRequest {
@@ -43,7 +36,6 @@ export interface ScrollToThreadRequest {
 
 export interface SidebarChatThreadScrollSignals {
   readonly isScrolled$: Computed<boolean>;
-  readonly thumbStyle$: Computed<SidebarChatThreadScrollThumbStyle>;
   readonly window$: Computed<Promise<SidebarChatThreadWindow>>;
   readonly setScrollMetrics$: Command<void, [SidebarChatThreadScrollMetrics]>;
   readonly refreshScrollViewport$: Command<void, []>;
@@ -64,24 +56,8 @@ export interface SidebarChatThreadScrollSignals {
 function emptyScrollMetrics(): SidebarChatThreadScrollMetrics {
   return {
     scrollTop: 0,
-    scrollHeight: 0,
     clientHeight: 0,
   };
-}
-
-function getScrollThumbStyle({
-  scrollTop,
-  scrollHeight,
-  clientHeight,
-}: SidebarChatThreadScrollMetrics): SidebarChatThreadScrollThumbStyle {
-  if (scrollHeight <= clientHeight) {
-    return { top: 0, height: 0, visible: false };
-  }
-  const ratio = clientHeight / scrollHeight;
-  const height = Math.max(ratio * clientHeight, 24);
-  const maxTop = clientHeight - height;
-  const top = (scrollTop / (scrollHeight - clientHeight)) * maxTop;
-  return { top, height, visible: true };
 }
 
 function createSidebarChatThreadDomSignals() {
@@ -102,21 +78,16 @@ function createSidebarChatThreadDomSignals() {
   const isScrolled$ = computed((get) => {
     return get(internalScrollMetrics$).scrollTop > 0;
   });
-  const thumbStyle$ = computed((get) => {
-    return getScrollThumbStyle(get(internalScrollMetrics$));
-  });
 
   const measureScrollViewport$ = command(
     ({ get, set }, viewport: HTMLElement) => {
       const metrics = {
         scrollTop: viewport.scrollTop,
-        scrollHeight: viewport.scrollHeight,
         clientHeight: viewport.clientHeight,
       };
       const previous = get(internalScrollMetrics$);
       if (
         previous.scrollTop === metrics.scrollTop &&
-        previous.scrollHeight === metrics.scrollHeight &&
         previous.clientHeight === metrics.clientHeight
       ) {
         return;
@@ -181,7 +152,6 @@ function createSidebarChatThreadDomSignals() {
 
   return {
     isScrolled$,
-    thumbStyle$,
     scrollViewport$,
     scrollMetrics$,
     setScrollViewport$,
@@ -321,7 +291,6 @@ function createScrollVirtualListToIndexCommand(
       scrollViewport.scrollTop = nextScrollTop;
       set(dom.setScrollMetrics$, {
         scrollTop: nextScrollTop,
-        scrollHeight: scrollViewport.scrollHeight,
         clientHeight: scrollViewport.clientHeight,
       });
       return true;
@@ -379,7 +348,6 @@ function createSidebarChatThreadScrollSignals(): SidebarChatThreadScrollSignals 
 
   return {
     isScrolled$: dom.isScrolled$,
-    thumbStyle$: dom.thumbStyle$,
     window$: createSidebarChatThreadWindowSignal(dom),
     setScrollMetrics$: dom.setScrollMetrics$,
     setScrollViewport$: dom.setScrollViewport$,

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -139,10 +139,6 @@ export const composerVoiceInputShortcutEnabled$ = computed((get): boolean => {
   );
 });
 
-export const baseUiSidebarScrollAreaEnabled$ = computed((get): boolean => {
-  return get(featureSwitch$)[FeatureSwitchKey.BaseUiSidebarScrollArea] ?? false;
-});
-
 const hydrateFeatureSwitch$ = command(
   async (
     { get, set },

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -39,6 +39,21 @@ globalThis.IDBRequest = IDBRequest;
 globalThis.IDBTransaction = IDBTransaction;
 globalThis.IDBVersionChangeEvent = IDBVersionChangeEvent;
 
+// Base UI Scroll Area requires Web Animations, which happy-dom does not
+// implement. Scope the shim to sidebar viewports so dialogs and menus retain
+// their synchronous no-animation behavior unless a test supplies animations.
+Object.defineProperty(HTMLElement.prototype, "getAnimations", {
+  configurable: true,
+  get(this: HTMLElement): (() => Animation[]) | undefined {
+    if (this.dataset.testid !== "sidebar-scroll-area") {
+      return undefined;
+    }
+    return () => {
+      return [];
+    };
+  },
+});
+
 type HappyDomAttributeCallback = (
   this: HTMLIFrameElement,
   attribute: Attr,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
@@ -4,7 +4,6 @@ import {
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { browserContract } from "@okouai/api-contracts/contracts/browser";
 import { billingStatusContract } from "@okouai/api-contracts/contracts/billing";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   act,
   fireEvent,
@@ -129,72 +128,65 @@ function queueAnimationFrames(): () => void {
   };
 }
 
-test.each([false, true])(
-  "Wait for styles before mounting the virtual viewport (baseUi=%s)",
-  async (baseUi) => {
-    const threadCount = 6406;
-    mockThreads(threadCount);
-    context.mocks.browser.noAnimations();
-    const stylesheet = context.mocks.deferred<"loaded" | "failed">();
-    vi.stubGlobal("__mainStylesheetLoaded", stylesheet.promise);
-    let viewportHeight = threadCount * ROW_HEIGHT;
-    mockViewportHeight(() => {
-      return viewportHeight;
-    }, threadCount);
+test("Wait for styles before mounting the virtual viewport", async () => {
+  const threadCount = 6406;
+  mockThreads(threadCount);
+  const stylesheet = context.mocks.deferred<"loaded" | "failed">();
+  vi.stubGlobal("__mainStylesheetLoaded", stylesheet.promise);
+  let viewportHeight = threadCount * ROW_HEIGHT;
+  mockViewportHeight(() => {
+    return viewportHeight;
+  }, threadCount);
 
-    const page = await startPage({
-      context,
-      path: `/chats/${threadId(0)}`,
-      featureSwitches: {
-        [FeatureSwitchKey.BaseUiSidebarScrollArea]: baseUi,
-      },
-    });
-    const sidebar = await screen.findByTestId("chat-list-column");
-    await within(sidebar).findByTestId("pinned-agent-card");
-    expect(
-      within(sidebar).queryByTestId("sidebar-scroll-area"),
-    ).not.toBeInTheDocument();
-    expect(
-      within(sidebar).queryAllByTestId("sidebar-chat-thread-virtual-row"),
-    ).toHaveLength(0);
+  const page = await startPage({
+    context,
+    path: `/chats/${threadId(0)}`,
+  });
+  const sidebar = await screen.findByTestId("chat-list-column");
+  await within(sidebar).findByTestId("pinned-agent-card");
+  expect(
+    within(sidebar).queryByTestId("sidebar-scroll-area"),
+  ).not.toBeInTheDocument();
+  expect(
+    within(sidebar).queryAllByTestId("sidebar-chat-thread-virtual-row"),
+  ).toHaveLength(0);
 
-    // CSS is active before its existing readiness promise resolves.
-    viewportHeight = 612;
-    stylesheet.resolve("loaded");
-    await page.ready;
-    const rows = () => {
-      return within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row");
-    };
-    await waitFor(() => {
-      expect(rows()).toHaveLength(25);
-    });
-    expect(within(sidebar).getByText("History 25")).toBeInTheDocument();
-    expect(within(sidebar).queryByText("History 26")).not.toBeInTheDocument();
+  // CSS is active before its existing readiness promise resolves.
+  viewportHeight = 612;
+  stylesheet.resolve("loaded");
+  await page.ready;
+  const rows = () => {
+    return within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row");
+  };
+  await waitFor(() => {
+    expect(rows()).toHaveLength(25);
+  });
+  expect(within(sidebar).getByText("History 25")).toBeInTheDocument();
+  expect(within(sidebar).queryByText("History 26")).not.toBeInTheDocument();
 
-    viewportHeight = 900;
-    resizeWindow();
-    await waitFor(() => {
-      expect(rows()).toHaveLength(33);
-    });
-    viewportHeight = 360;
-    resizeWindow();
-    await waitFor(() => {
-      expect(rows()).toHaveLength(18);
-    });
-
-    const nextThread = queryAllByRoleFast("link", sidebar).find((link) => {
-      return link.getAttribute("href") === `/chats/${threadId(1)}`;
-    });
-    if (!nextThread) {
-      throw new Error("Second sidebar thread is not mounted");
-    }
-    click(nextThread);
-    await waitFor(() => {
-      expect(nextThread).toHaveAttribute("aria-current", "page");
-    });
+  viewportHeight = 900;
+  resizeWindow();
+  await waitFor(() => {
+    expect(rows()).toHaveLength(33);
+  });
+  viewportHeight = 360;
+  resizeWindow();
+  await waitFor(() => {
     expect(rows()).toHaveLength(18);
-  },
-);
+  });
+
+  const nextThread = queryAllByRoleFast("link", sidebar).find((link) => {
+    return link.getAttribute("href") === `/chats/${threadId(1)}`;
+  });
+  if (!nextThread) {
+    throw new Error("Second sidebar thread is not mounted");
+  }
+  click(nextThread);
+  await waitFor(() => {
+    expect(nextThread).toHaveAttribute("aria-current", "page");
+  });
+  expect(rows()).toHaveLength(18);
+});
 
 test("Keep the virtual viewport unmounted when the main stylesheet fails", async () => {
   mockThreads(120);
@@ -216,9 +208,6 @@ test("Coalesce sidebar resize bursts and cancel pending measurements when hidden
   await setupPage({
     context,
     path: `/chats/${threadId(0)}`,
-    featureSwitches: {
-      [FeatureSwitchKey.BaseUiSidebarScrollArea]: false,
-    },
   });
 
   const sidebar = screen.getByTestId("chat-list-column");

--- a/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
@@ -6,12 +6,8 @@ import type {
   UIEvent,
 } from "react";
 import { ScrollArea } from "@base-ui/react/scroll-area";
-import { useGet, useSet } from "ccstate-react";
-import type {
-  SidebarChatThreadScrollMetrics,
-  SidebarChatThreadScrollSignals,
-} from "../../signals/chat-page/sidebar-chat-thread-scroll.ts";
-import { baseUiSidebarScrollAreaEnabled$ } from "../../signals/external/feature-switch.ts";
+import { useSet } from "ccstate-react";
+import type { SidebarChatThreadScrollSignals } from "../../signals/chat-page/sidebar-chat-thread-scroll.ts";
 
 interface OverlayScrollAreaProps {
   readonly "aria-label"?: string;
@@ -26,77 +22,8 @@ interface OverlayScrollAreaProps {
   readonly tabIndex?: number;
 }
 
-function updateScrollMetrics(
-  event: UIEvent<HTMLDivElement>,
-  setScrollMetrics: (metrics: SidebarChatThreadScrollMetrics) => void,
-): void {
-  const element = event.currentTarget;
-  setScrollMetrics({
-    scrollTop: element.scrollTop,
-    scrollHeight: element.scrollHeight,
-    clientHeight: element.clientHeight,
-  });
-}
-
-/** Existing custom scroll behavior retained behind the disabled switch. */
-function LegacyOverlayScrollArea({
-  "aria-label": ariaLabel,
-  className,
-  contentClassName,
-  children,
-  onFocus,
-  onPointerDownCapture,
-  scrollSignals,
-  style,
-  "data-testid": dataTestId,
-  tabIndex,
-}: OverlayScrollAreaProps) {
-  const thumbStyleValue = useGet(scrollSignals.thumbStyle$);
-  const setScrollMetrics = useSet(scrollSignals.setScrollMetrics$);
-  const setViewportRef = useSet(scrollSignals.setScrollViewport$);
-
-  const handleScroll = (event: UIEvent<HTMLDivElement>) => {
-    updateScrollMetrics(event, setScrollMetrics);
-  };
-
-  return (
-    <div className={`group/sidebar-scroll relative ${className ?? ""}`}>
-      <div
-        ref={setViewportRef}
-        className="h-full overflow-y-auto overflow-x-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-        style={style}
-        onFocus={onFocus}
-        onPointerDownCapture={onPointerDownCapture}
-        onScroll={handleScroll}
-        tabIndex={tabIndex}
-        role={ariaLabel ? "region" : undefined}
-        aria-label={ariaLabel}
-        data-testid={dataTestId}
-      >
-        <div className={contentClassName}>{children}</div>
-      </div>
-      {/* The thumb hugs the viewport's edge instead of floating in the middle
-          of the gutter. Beside the workspace card that gutter is only four
-          pixels wide, and anything further in overlaps the trailing menu
-          button on the row it is scrolling past. */}
-      <div
-        className={`absolute right-px top-0 bottom-0 w-[6px] pointer-events-none opacity-0 transition-opacity duration-150 ${
-          thumbStyleValue.visible
-            ? "group-hover/sidebar-scroll:opacity-100"
-            : ""
-        }`}
-        aria-hidden="true"
-      >
-        <div
-          className="absolute right-0 w-[5px] rounded-full bg-foreground/15"
-          style={{ top: thumbStyleValue.top, height: thumbStyleValue.height }}
-        />
-      </div>
-    </div>
-  );
-}
-
-function BaseUiOverlayScrollArea({
+/** Overlay scroll area with a draggable Base UI scrollbar. */
+export function OverlayScrollArea({
   "aria-label": ariaLabel,
   className,
   contentClassName,
@@ -112,7 +39,11 @@ function BaseUiOverlayScrollArea({
   const setViewportRef = useSet(scrollSignals.setScrollViewport$);
 
   const handleScroll = (event: UIEvent<HTMLDivElement>) => {
-    updateScrollMetrics(event, setScrollMetrics);
+    const element = event.currentTarget;
+    setScrollMetrics({
+      scrollTop: element.scrollTop,
+      clientHeight: element.clientHeight,
+    });
   };
 
   return (
@@ -147,13 +78,4 @@ function BaseUiOverlayScrollArea({
       </ScrollArea.Scrollbar>
     </ScrollArea.Root>
   );
-}
-
-/** Overlay scroll area with a feature-gated draggable Base UI scrollbar. */
-export function OverlayScrollArea(props: OverlayScrollAreaProps) {
-  const baseUiEnabled = useGet(baseUiSidebarScrollAreaEnabled$);
-  if (baseUiEnabled) {
-    return <BaseUiOverlayScrollArea {...props} />;
-  }
-  return <LegacyOverlayScrollArea {...props} />;
 }

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -209,7 +209,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.BaseUiSidebarScrollArea]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.MorningBrief]).toBe(true);
 
@@ -244,9 +243,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.BaseUiSidebarScrollArea]).toBe(
-      false,
-    );
     expect(otherOrgStates[FeatureSwitchKey.OfficialWorkflows]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.MorningBrief]).toBe(false);
   });

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -59,7 +59,6 @@ export enum FeatureSwitchKey {
   MarkdownHexColorPreview = "markdownHexColorPreview",
   FollowUpOptimize = "followUpOptimize",
   ResponsiveFollowupCards = "responsiveFollowupCards",
-  BaseUiSidebarScrollArea = "baseUiSidebarScrollArea",
   SidebarSubscriptionUsage = "_sidebarSubscriptionUsage",
   PersonalModelProviderAccounts = "_multipleSubscriptions",
   ComposerConnectorPopoverPlacement = "composerConnectorPopoverPlacement",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -430,13 +430,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.BaseUiSidebarScrollArea]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Use the Base UI Scroll Area for draggable chat sidebar scrollbars.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.GradientColorThemes]: {
     maintainer: "ming@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

Make the draggable Base UI sidebar scrollbar available to every workspace by permanently retaining the enabled behavior and removing `baseUiSidebarScrollArea`. Preserve the current viewport layout, thumb placement, focus handling, virtualized chat history, and current-thread positioning.

Terminal state: **fully-rolled-out**, explicitly requested by Ethan in this cleanup task ("全量并删除下面的开关"). This PR implements that rollout decision; it does not claim the change is already deployed.

## Cleanup and history

- Introduced by `72e1f7e12c865bffa3679a6374eccbdba4ad324e` (#31532). Its parent used the custom, non-draggable indicator; the enabled branch added Base UI. Retain the later layout and gutter fixes from `5eae6943ca` (#31564) and `7b59b543c3` (#31623), and the virtual-list lifecycle changes from `8a58754c07` (#31585). Also preserve `75a7f8b950` (#31789)'s stylesheet readiness gate, frame-coalesced resizing, and pinned/upgrade layout refreshes.
- Export the Base UI implementation directly as `OverlayScrollArea`. Remove the legacy component, branch-selection wrapper, switch signal, enum member, and registry entry.
- Remove the legacy-only thumb type, calculation, derived signal, and unused `scrollHeight` metrics. The remaining metrics and viewport lifecycle still serve chat virtualization. The Base UI dependency remains required.
- Remove the retired staff/non-staff registry assertions and bootstrap override. Collapse the viewport switch matrix into its permanent product behavior and remove the explicit disabled override. Add a happy-dom `getAnimations` shim scoped to sidebar viewports because the now-unconditional Scroll Area requires that browser API; remove the redundant `noAnimations` test mock. Other dialogs and menus keep their existing animation behavior.
- Second repository sweep covered `baseUiSidebarScrollArea`, `BaseUiSidebarScrollArea`, kebab/snake variants, `LegacyOverlayScrollArea`, `BaseUiOverlayScrollArea`, `SidebarChatThreadScrollThumbStyle`, `getScrollThumbStyle`, `thumbStyle$`, `updateScrollMetrics`, and `group/sidebar-scroll`. These retired symbols have no remaining references. `OverlayScrollArea`, Base UI parts, and viewport/virtual-list signals remain as unconditional product behavior.

## Validation

- Passed: core feature-switch tests, **32 tests**.
- Passed on the rebased source: **61 platform tests** across `sidebar.test.tsx` (37), `sidebar-virtualization.test.tsx` (7), `bootstrap-feature-switch.test.tsx` (7), and `markdown-content.test.tsx` (10). The two-worker run had six timeout/readiness failures in sidebar/bootstrap tests; both affected files then passed all 44 tests with `--maxWorkers=1`, without changing assertions or timeout limits. The virtualization and Markdown files passed in the first run.
- Passed: Prettier on changed files; core lint; platform Oxlint and type-aware Oxlint; ESLint on changed platform files. Platform static-asset, emoji, localized-UI, build-config, and i18n checks also passed during the initial verification.
- Passed: `pnpm exec knip --workspace packages/core --workspace apps/platform`; core and platform `check-types`; `git diff --check`; commitlint and the repository keyword sweep.
- Full Vitest, deployment, and end-to-end checks are delegated to the PR pipeline; no local dev server was used.
