### PR TITLE
refactor(platform): roll out markdown hex color previews

### DIFF
--- a/turbo/apps/platform/src/views/components/markdown-color-preview.tsx
+++ b/turbo/apps/platform/src/views/components/markdown-color-preview.tsx
@@ -1,11 +1,8 @@
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { useGet } from "ccstate-react";
 import type { ReactNode } from "react";
 
 import { findHexRgbColors } from "../../lib/markdown/hex-rgb-color.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 
-function ColorPreview({ color }: { readonly color: string }) {
+export function MarkdownColorPreview({ color }: { readonly color: string }) {
   return (
     <span
       aria-hidden="true"
@@ -16,27 +13,11 @@ function ColorPreview({ color }: { readonly color: string }) {
   );
 }
 
-function useMarkdownColorPreviewEnabled(): boolean {
-  return (
-    useGet(featureSwitch$)[FeatureSwitchKey.MarkdownHexColorPreview] ?? false
-  );
-}
-
-export function MarkdownColorPreview({ color }: { readonly color: string }) {
-  return useMarkdownColorPreviewEnabled() ? (
-    <ColorPreview color={color} />
-  ) : null;
-}
-
 export function MarkdownTextWithColorPreviews({
   text,
 }: {
   readonly text: string;
 }) {
-  const enabled = useMarkdownColorPreviewEnabled();
-  if (!enabled) {
-    return text;
-  }
   const colors = findHexRgbColors(text);
   if (colors.length === 0) {
     return text;
@@ -48,7 +29,7 @@ export function MarkdownTextWithColorPreviews({
     if (start > offset) {
       content.push(text.slice(offset, start));
     }
-    content.push(color, <ColorPreview key={start} color={color} />);
+    content.push(color, <MarkdownColorPreview key={start} color={color} />);
     offset = end;
   }
   if (offset < text.length) {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-content.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-content.test.tsx
@@ -1,4 +1,3 @@
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { expect, test } from "vitest";
 
@@ -123,7 +122,6 @@ test("A complete HEX color has a preview in a plain assistant response", async (
     context,
     path: chat.path,
     host: "app.vm0.ai",
-    featureSwitches: { [FeatureSwitchKey.MarkdownHexColorPreview]: true },
   });
 
   await waitFor(() => {
@@ -162,7 +160,6 @@ test("Preview exact inline HEX code without decorating linked or partial code", 
     context,
     path: chat.path,
     host: "app.vm0.ai",
-    featureSwitches: { [FeatureSwitchKey.MarkdownHexColorPreview]: true },
   });
 
   const brand = await screen.findByText("Brand #112233");
@@ -181,28 +178,6 @@ test("Preview exact inline HEX code without decorating linked or partial code", 
   expect(frame).toHaveTextContent("#AABB");
   expect(frame).toHaveTextContent("shade#DDEEFFtail");
   expect(frame).toHaveTextContent("#123456");
-});
-
-test("HEX colors remain undecorated when previews are unavailable", async () => {
-  const chat = createMarkdownChatFixture(context);
-  const source = "Accent #ABCDEF remains readable.";
-  const rows = completedMessageRows(chat, source);
-  chat.install({
-    rows: () => {
-      return rows;
-    },
-  });
-
-  await setupPage({
-    context,
-    path: chat.path,
-    host: "app.vm0.ai",
-    featureSwitches: { [FeatureSwitchKey.MarkdownHexColorPreview]: false },
-  });
-
-  const response = await screen.findByText(source);
-  expect(response).toBeVisible();
-  expect(colorPreviews(markdownFrameFor(response))).toHaveLength(0);
 });
 
 test("Fenced code stays readable for known and unknown languages", async () => {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -27,9 +27,6 @@ describe("FeatureSwitchKey", () => {
     expect(FeatureSwitchKey.ProgressiveArtifactPreview).toBe(
       "progressiveArtifactPreview",
     );
-    expect(FeatureSwitchKey.MarkdownHexColorPreview).toBe(
-      "markdownHexColorPreview",
-    );
   });
 });
 
@@ -191,7 +188,6 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.ChatThinkingSpinner]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.MarkdownHexColorPreview]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       true,
@@ -224,9 +220,6 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatThinkingSpinner]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.MarkdownHexColorPreview]).toBe(
-      false,
-    );
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.NewChatDefaultModelAction]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -56,7 +56,6 @@ export enum FeatureSwitchKey {
   ChatRunWorkFolding = "chatRunWorkFolding",
   ProgressiveArtifactPreview = "progressiveArtifactPreview",
   ChatThinkingSpinner = "chatThinkingSpinner",
-  MarkdownHexColorPreview = "markdownHexColorPreview",
   FollowUpOptimize = "followUpOptimize",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   BaseUiSidebarScrollArea = "baseUiSidebarScrollArea",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -400,13 +400,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.MarkdownHexColorPreview]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show a color swatch after six-digit HEX RGB colors in rendered Markdown.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ComposerImageAnnotation]: {
     maintainer: "tongx@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

Show six-digit HEX RGB color swatches in rendered Markdown for every workspace by retaining the enabled behavior and removing `markdownHexColorPreview`. Preserve previews in ordinary text and exact standalone inline HEX code, along with the existing exclusions for links, fenced code, partial colors, and embedded tokens.

Terminal state: **fully-rolled-out**, explicitly requested by Ethan in this cleanup task ("全量并删除下面的开关"). This PR implements that rollout decision; it does not claim the change is already deployed.

## Cleanup and history

- Introduced by `cfa67403943362e9a5b46fef7f8a9cc64aaab0d3` (#31511). Its parent rendered undecorated plain text and ordinary spans; the commit added parser markers and feature-gated swatch rendering. Retain the inline-code enhancement from `205e10797e` (#31540) and the current page-level integration coverage migrated in `f6b1eca5c7` (#31160).
- Remove the registry entry, enum member, switch subscription hook, disabled branches, and redundant component wrapper. Both plain-text and parsed Markdown use the unconditional `MarkdownColorPreview` component.
- Remove the disabled-preview test, explicit switch-on fixtures, and registry assertions for the retired key. Existing product tests now verify default swatches directly.
- Second repository sweep covers `markdownHexColorPreview`, `MarkdownHexColorPreview`, kebab/snake variants, `useMarkdownColorPreviewEnabled`, `markdown-color-preview`, `MarkdownTextWithColorPreviews`, `findHexRgbColors`, `rehypeColorPreviews`, `colorPreviewNode`, and `COLOR_PREVIEW_EXCLUDED_TAGS`. Retained parser helpers, color markers, renderers, and tests are required for the permanent behavior and have no switch dependency.

## Validation

- Passed: `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=2 --silent=passed-only`, **32 tests**.
- Passed: `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/markdown-content.test.tsx --maxWorkers=2 --silent=passed-only`, **9 tests**.
- Passed: Prettier on all changed files; core lint; platform Oxlint, type-aware Oxlint, and ESLint; scoped core/platform Knip; core and platform type checking; commitlint; `git diff --check`; and the repository keyword sweep.
- Full Vitest, deployment, and end-to-end checks are delegated to the PR pipeline; no local dev server was used.
