### PR TITLE
fix(platform): track batch indicator catch-up scheduling in the store

### DIFF
--- a/docs/testing/app-testing.md
+++ b/docs/testing/app-testing.md
@@ -234,6 +234,12 @@ or `nowDate()` rather than `Date.now()`; only `lib/time.ts` may call
 `Date.now()`. Do not use fake timers, `vi.setSystemTime`, or a `Date.now()`
 spy. Continue using real timers with Testing Library queries and `waitFor`.
 
+For a race that crosses a clock boundary between synchronous reads, `mockNow`
+also accepts a `() => number` reader. Install it at the relevant external
+response boundary and pass `context.signal` so the shared lifecycle removes
+the override. Control only the returned time; keep timers and application
+commands real.
+
 ## Test Context and Cleanup
 
 Create one `testContext()` at file scope. It provides a fresh store and worker

--- a/turbo/apps/platform/src/lib/time.ts
+++ b/turbo/apps/platform/src/lib/time.ts
@@ -1,16 +1,19 @@
+type NowValue = number | (() => number);
+
 interface NowOverride {
-  readonly value: number;
+  readonly value: NowValue;
 }
 
 function createNowOverride(): {
   readonly get: () => number | undefined;
-  readonly set: (value: number, signal: AbortSignal) => void;
+  readonly set: (value: NowValue, signal: AbortSignal) => void;
 } {
   let current: NowOverride | undefined;
 
   return {
     get: () => {
-      return current?.value;
+      const value = current?.value;
+      return typeof value === "function" ? value() : value;
     },
     set: (value, signal) => {
       signal.throwIfAborted();
@@ -39,6 +42,6 @@ export function nowDate(): Date {
   return new Date(now());
 }
 
-export function mockNow(value: Date | number, signal: AbortSignal): void {
+export function mockNow(value: Date | NowValue, signal: AbortSignal): void {
   setMockedNow(value instanceof Date ? value.getTime() : value, signal);
 }

--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -502,6 +502,92 @@ function mockBatchIndicators(threadId: string): void {
   });
 }
 
+test.each([false, undefined])(
+  "Keep legacy indicator catch-up when the batch switch is %s",
+  async (enabled) => {
+    mockNow(40_000, context.signal);
+    const threadId = crypto.randomUUID();
+    const rows = [row(threadId, 1), row(threadId, 2)];
+    let availableRows = rows.slice(0, 1);
+    context.mocks.api(featureSwitchesContract.get, ({ respond }) => {
+      return respond(200, {
+        switches: {},
+        effectiveSwitches:
+          enabled === undefined
+            ? {}
+            : { [FeatureSwitchKey.BatchChatEventCatchUp]: enabled },
+      });
+    });
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      return respond(200, { agents: {}, threads: { [threadId]: "unread" } });
+    });
+    context.mocks.api(chatThreadEventsContract.catchUp, ({ respond }) => {
+      return respond(500, {
+        error: {
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Batch catch-up must remain disabled",
+        },
+      });
+    });
+    context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+      return respond(404, {
+        error: {
+          code: "CHAT_EVENT_SNAPSHOT_NOT_FOUND",
+          message: "Chat event snapshot not found",
+        },
+      });
+    });
+    context.mocks.api(
+      chatThreadEventsContract.rows,
+      ({ params, query, respond }) => {
+        return respond(
+          200,
+          chatEventRowsResponse(
+            availableRows.filter((event) => {
+              return (
+                event.chatThreadId === params.threadId &&
+                event.seqId > query.sinceSeqId
+              );
+            }),
+            query,
+          ),
+        );
+      },
+    );
+    initializeWorker();
+    const { bridge } = connectProtocolTransport(context.signal);
+    await bridge.registerTab(context.signal);
+    await bridge.getComputed("chat-thread-indicators");
+    const initial = await bridge.query(
+      {
+        dataKey: dataKey(threadId),
+        afterSeqId: null,
+        consistency: "cache-only",
+      },
+      context.signal,
+    );
+    expect(initial).toStrictEqual(rows.slice(0, 1));
+
+    availableRows = rows;
+    context.workerStore.set(refreshWorkerComputed$, "chat-thread-indicators");
+    await expect(
+      bridge.getComputed("chat-thread-indicators"),
+    ).resolves.toStrictEqual({
+      agents: {},
+      threads: { [threadId]: "unread" },
+    });
+    const refreshed = await bridge.query(
+      {
+        dataKey: dataKey(threadId),
+        afterSeqId: null,
+        consistency: "cache-only",
+      },
+      context.signal,
+    );
+    expect(refreshed).toStrictEqual(rows);
+  },
+);
+
 test("Continue warming unread chats after a trailing indicator catch-up completes", async () => {
   const startedAt = 10_000;
   mockNow(startedAt, context.signal);

--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -588,60 +588,106 @@ test.each([false, undefined])(
   },
 );
 
-test("Continue warming unread chats after a trailing indicator catch-up completes", async () => {
-  const startedAt = 10_000;
-  mockNow(startedAt, context.signal);
-  const threadId = crypto.randomUUID();
-  const rows = [row(threadId, 1), row(threadId, 2), row(threadId, 3)];
-  let availableRows = rows.slice(0, 1);
-  mockBatchIndicators(threadId);
-  context.mocks.api(chatThreadEventsContract.catchUp, ({ body, respond }) => {
-    return respond(200, {
-      events: Object.fromEntries(
-        body.map(([id, sinceSeqId]) => {
-          return [
-            id,
-            availableRows.filter((event) => {
-              return event.chatThreadId === id && event.seqId > sinceSeqId;
-            }),
-          ];
-        }),
-      ),
-      notFoundThreads: [],
+test.each([
+  { boundary: "before", firstRead: 999, nextRead: 999 },
+  { boundary: "across", firstRead: 999, nextRead: 1000 },
+  { boundary: "at", firstRead: 1000, nextRead: 1000 },
+])(
+  "Continue warming unread chats when indicator catch-up reads time $boundary the throttle boundary",
+  async ({ firstRead, nextRead }) => {
+    const startedAt = 10_000;
+    mockNow(startedAt, context.signal);
+    const threadId = crypto.randomUUID();
+    const rows = [row(threadId, 1), row(threadId, 2), row(threadId, 3)];
+    let availableRows = rows.slice(0, 1);
+    let refreshing = false;
+    mockBatchIndicators(threadId);
+    context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+      if (refreshing) {
+        // Arm the clock after the HTTP request so telemetry cannot consume the
+        // boundary read. The scheduler may cross the threshold without yielding.
+        let time = startedAt + firstRead;
+        mockNow(() => {
+          const sampledAt = time;
+          time = startedAt + nextRead;
+          return sampledAt;
+        }, context.signal);
+      }
+      return respond(200, { agents: {}, threads: { [threadId]: "unread" } });
     });
-  });
-  initializeWorker();
-  const { bridge } = connectProtocolTransport(context.signal);
-  await bridge.registerTab(context.signal);
-  await bridge.getComputed("chat-thread-indicators");
+    context.mocks.api(chatThreadEventsContract.catchUp, ({ body, respond }) => {
+      return respond(200, {
+        events: Object.fromEntries(
+          body.map(([id, sinceSeqId]) => {
+            return [
+              id,
+              availableRows.filter((event) => {
+                return event.chatThreadId === id && event.seqId > sinceSeqId;
+              }),
+            ];
+          }),
+        ),
+        notFoundThreads: [],
+      });
+    });
+    initializeWorker();
+    const subscriptionCatchUpFinished = context.mocks.deferred<void>();
+    const { bridge } = connectProtocolTransport(context.signal, undefined, {
+      ...bridgeEvents(),
+      computedReloaded: (computedKey) => {
+        if (
+          computedKey === "chat-thread-indicators" &&
+          !subscriptionCatchUpFinished.settled()
+        ) {
+          subscriptionCatchUpFinished.resolve();
+        }
+      },
+    });
+    await bridge.registerTab(context.signal);
+    // The initial realtime subscription also refreshes indicators. Observe its
+    // completion before scheduling a new refresh with the boundary clock.
+    await Promise.all([
+      bridge.getComputed("chat-thread-indicators"),
+      subscriptionCatchUpFinished.promise,
+    ]);
 
-  availableRows = rows.slice(0, 2);
-  mockNow(startedAt + 999, context.signal);
-  context.workerStore.set(refreshWorkerComputed$, "chat-thread-indicators");
-  const indicators = await Promise.all([
-    bridge.getComputed("chat-thread-indicators"),
-    bridge.getComputed("chat-thread-indicators"),
-  ]);
-  expect(indicators).toStrictEqual([
-    { agents: {}, threads: { [threadId]: "unread" } },
-    { agents: {}, threads: { [threadId]: "unread" } },
-  ]);
-  const second = await bridge.query(
-    { dataKey: dataKey(threadId), afterSeqId: null, consistency: "cache-only" },
-    context.signal,
-  );
-  expect(second).toStrictEqual(rows.slice(0, 2));
+    availableRows = rows.slice(0, 2);
+    refreshing = true;
+    context.workerStore.set(refreshWorkerComputed$, "chat-thread-indicators");
+    const indicators = await Promise.all([
+      bridge.getComputed("chat-thread-indicators"),
+      bridge.getComputed("chat-thread-indicators"),
+    ]);
+    expect(indicators).toStrictEqual([
+      { agents: {}, threads: { [threadId]: "unread" } },
+      { agents: {}, threads: { [threadId]: "unread" } },
+    ]);
+    const second = await bridge.query(
+      {
+        dataKey: dataKey(threadId),
+        afterSeqId: null,
+        consistency: "cache-only",
+      },
+      context.signal,
+    );
+    expect(second).toStrictEqual(rows.slice(0, 2));
 
-  availableRows = rows;
-  mockNow(startedAt + 2000, context.signal);
-  context.workerStore.set(refreshWorkerComputed$, "chat-thread-indicators");
-  await bridge.getComputed("chat-thread-indicators");
-  const third = await bridge.query(
-    { dataKey: dataKey(threadId), afterSeqId: null, consistency: "cache-only" },
-    context.signal,
-  );
-  expect(third).toStrictEqual(rows);
-});
+    availableRows = rows;
+    refreshing = false;
+    mockNow(startedAt + 2000, context.signal);
+    context.workerStore.set(refreshWorkerComputed$, "chat-thread-indicators");
+    await bridge.getComputed("chat-thread-indicators");
+    const third = await bridge.query(
+      {
+        dataKey: dataKey(threadId),
+        afterSeqId: null,
+        consistency: "cache-only",
+      },
+      context.signal,
+    );
+    expect(third).toStrictEqual(rows);
+  },
+);
 
 test("Recover indicator catch-up after a shared trailing request fails", async () => {
   const startedAt = 20_000;

--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -1,5 +1,10 @@
 import type { ChatEventRow } from "@okouai/api-contracts/contracts/chat-event-rows";
-import { chatThreadEventsContract } from "@okouai/api-contracts/contracts/chat-threads";
+import {
+  chatThreadEventsContract,
+  chatThreadsContract,
+} from "@okouai/api-contracts/contracts/chat-threads";
+import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { expect, test, vi } from "vitest";
 
 import {
@@ -7,6 +12,7 @@ import {
   testContext,
 } from "../../signals/__tests__/test-helpers.ts";
 import { createChildAbortController } from "../../signals/utils.ts";
+import { mockNow } from "../../lib/time.ts";
 import type {
   SharedDatabaseBridgeEvents,
   SharedDatabasePortLike,
@@ -21,8 +27,15 @@ import type {
 import { MessagePortSharedDatabaseBridge } from "../message-port-client.ts";
 import { SharedDatabaseMessagePortServer } from "../message-port-server.ts";
 import type { SharedDatabaseConnectionStatus } from "../protocol.ts";
-import { requestTokenFromFirstConnection$ } from "../worker-context.ts";
-import { initializeSharedDatabaseWorker$ } from "../worker-signals.ts";
+import {
+  registerConnection$,
+  requestTokenFromFirstConnection$,
+} from "../worker-context.ts";
+import {
+  getComputedStoreMessage$,
+  initializeSharedDatabaseWorker$,
+  refreshWorkerComputed$,
+} from "../worker-signals.ts";
 
 const context = testContext();
 const CREATED_AT = "2026-08-14T09:00:00.000Z";
@@ -128,7 +141,7 @@ function bridgeEvents(): SharedDatabaseBridgeEvents {
   };
 }
 
-function initializeWorker(): void {
+function initializeWorker(signal: AbortSignal = context.signal): void {
   const workerIdentity = identity();
   context.workerStore.set(
     initializeSharedDatabaseWorker$,
@@ -145,7 +158,7 @@ function initializeWorker(): void {
       oauthApiBaseUrl: location.origin,
       onForceUpgrade: vi.fn<() => void>(),
     },
-    context.signal,
+    signal,
   );
 }
 
@@ -475,4 +488,202 @@ test("Stop pending requests when the bridge lifecycle ends", async () => {
   await expect(bridge.getComputed("chat-thread-indicators")).rejects.toBe(
     reason,
   );
+});
+
+function mockBatchIndicators(threadId: string): void {
+  context.mocks.api(featureSwitchesContract.get, ({ respond }) => {
+    return respond(200, {
+      switches: {},
+      effectiveSwitches: { [FeatureSwitchKey.BatchChatEventCatchUp]: true },
+    });
+  });
+  context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+    return respond(200, { agents: {}, threads: { [threadId]: "unread" } });
+  });
+}
+
+test("Continue warming unread chats after a trailing indicator catch-up completes", async () => {
+  const startedAt = 10_000;
+  mockNow(startedAt, context.signal);
+  const threadId = crypto.randomUUID();
+  const rows = [row(threadId, 1), row(threadId, 2), row(threadId, 3)];
+  let availableRows = rows.slice(0, 1);
+  mockBatchIndicators(threadId);
+  context.mocks.api(chatThreadEventsContract.catchUp, ({ body, respond }) => {
+    return respond(200, {
+      events: Object.fromEntries(
+        body.map(([id, sinceSeqId]) => {
+          return [
+            id,
+            availableRows.filter((event) => {
+              return event.chatThreadId === id && event.seqId > sinceSeqId;
+            }),
+          ];
+        }),
+      ),
+      notFoundThreads: [],
+    });
+  });
+  initializeWorker();
+  const { bridge } = connectProtocolTransport(context.signal);
+  await bridge.registerTab(context.signal);
+  await bridge.getComputed("chat-thread-indicators");
+
+  availableRows = rows.slice(0, 2);
+  mockNow(startedAt + 999, context.signal);
+  context.workerStore.set(refreshWorkerComputed$, "chat-thread-indicators");
+  const indicators = await Promise.all([
+    bridge.getComputed("chat-thread-indicators"),
+    bridge.getComputed("chat-thread-indicators"),
+  ]);
+  expect(indicators).toStrictEqual([
+    { agents: {}, threads: { [threadId]: "unread" } },
+    { agents: {}, threads: { [threadId]: "unread" } },
+  ]);
+  const second = await bridge.query(
+    { dataKey: dataKey(threadId), afterSeqId: null, consistency: "cache-only" },
+    context.signal,
+  );
+  expect(second).toStrictEqual(rows.slice(0, 2));
+
+  availableRows = rows;
+  mockNow(startedAt + 2000, context.signal);
+  context.workerStore.set(refreshWorkerComputed$, "chat-thread-indicators");
+  await bridge.getComputed("chat-thread-indicators");
+  const third = await bridge.query(
+    { dataKey: dataKey(threadId), afterSeqId: null, consistency: "cache-only" },
+    context.signal,
+  );
+  expect(third).toStrictEqual(rows);
+});
+
+test("Recover indicator catch-up after a shared trailing request fails", async () => {
+  const startedAt = 20_000;
+  mockNow(startedAt, context.signal);
+  const threadId = crypto.randomUUID();
+  const recoveredRows = [row(threadId, 1), row(threadId, 2)];
+  let availableRows = recoveredRows.slice(0, 1);
+  let failCatchUp = false;
+  mockBatchIndicators(threadId);
+  context.mocks.api(chatThreadEventsContract.catchUp, ({ body, respond }) => {
+    if (failCatchUp) {
+      return respond(500, {
+        error: { message: "Catch-up failed", code: "INTERNAL_SERVER_ERROR" },
+      });
+    }
+    return respond(200, {
+      events: Object.fromEntries(
+        body.map(([id, sinceSeqId]) => {
+          return [
+            id,
+            availableRows.filter((event) => {
+              return event.chatThreadId === id && event.seqId > sinceSeqId;
+            }),
+          ];
+        }),
+      ),
+      notFoundThreads: [],
+    });
+  });
+  initializeWorker();
+  const { bridge } = connectProtocolTransport(context.signal);
+  await bridge.registerTab(context.signal);
+  await bridge.getComputed("chat-thread-indicators");
+
+  failCatchUp = true;
+  mockNow(startedAt + 999, context.signal);
+  context.workerStore.set(refreshWorkerComputed$, "chat-thread-indicators");
+  await Promise.all([
+    expect(bridge.getComputed("chat-thread-indicators")).rejects.toThrow(
+      "Shared database request failed with status 500",
+    ),
+    expect(bridge.getComputed("chat-thread-indicators")).rejects.toThrow(
+      "Shared database request failed with status 500",
+    ),
+  ]);
+
+  failCatchUp = false;
+  availableRows = recoveredRows;
+  mockNow(startedAt + 2000, context.signal);
+  context.workerStore.set(refreshWorkerComputed$, "chat-thread-indicators");
+  await expect(
+    bridge.getComputed("chat-thread-indicators"),
+  ).resolves.toStrictEqual({
+    agents: {},
+    threads: { [threadId]: "unread" },
+  });
+  const cached = await bridge.query(
+    { dataKey: dataKey(threadId), afterSeqId: null, consistency: "cache-only" },
+    context.signal,
+  );
+  expect(cached).toStrictEqual(recoveredRows);
+});
+
+test("Cancel waiting indicator reads when their Worker lifecycle ends", async () => {
+  mockNow(30_000, context.signal);
+  const threadId = crypto.randomUUID();
+  const worker = createChildAbortController(context.signal);
+  const refreshLoaded = context.mocks.deferred<void>();
+  let refreshing = false;
+  mockBatchIndicators(threadId);
+  context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
+    if (refreshing && !refreshLoaded.settled()) {
+      refreshLoaded.resolve();
+    }
+    return respond(200, { agents: {}, threads: { [threadId]: "unread" } });
+  });
+  context.mocks.api(chatThreadEventsContract.catchUp, ({ body, respond }) => {
+    return respond(200, {
+      events: Object.fromEntries(
+        body.map(([id]) => {
+          return [id, []];
+        }),
+      ),
+      notFoundThreads: [],
+    });
+  });
+  initializeWorker(worker.signal);
+  const connectionId = crypto.randomUUID();
+  context.workerStore.set(
+    registerConnection$,
+    connectionId,
+    worker,
+    {
+      getToken: () => {
+        return Promise.resolve("message-port-token");
+      },
+      port: new InMemoryMessagePort(),
+    },
+    worker.signal,
+  );
+  // Observe the Worker request directly: abort closes its message port before
+  // the server can send a response to the client.
+  const readIndicators = () => {
+    return context.workerStore.set(
+      getComputedStoreMessage$,
+      connectionId,
+      {
+        type: "get-computed",
+        requestId: crypto.randomUUID(),
+        computedKey: "chat-thread-indicators",
+      },
+      worker.signal,
+    );
+  };
+  await readIndicators();
+
+  refreshing = true;
+  context.workerStore.set(refreshWorkerComputed$, "chat-thread-indicators");
+  await Promise.all([
+    expect(readIndicators()).rejects.toMatchObject({
+      name: "AbortError",
+    }),
+    expect(readIndicators()).rejects.toMatchObject({
+      name: "AbortError",
+    }),
+    (async () => {
+      await refreshLoaded.promise;
+      worker.abort(new DOMException("Worker stopped", "AbortError"));
+    })(),
+  ]);
 });

--- a/turbo/apps/platform/src/shared-database/worker-signals.ts
+++ b/turbo/apps/platform/src/shared-database/worker-signals.ts
@@ -1,5 +1,5 @@
 import type { InboundMessage } from "ably";
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Command } from "ccstate";
 import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import { replayChatThreadEvents } from "@okouai/core/chat-thread-event-replay";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -36,7 +36,12 @@ import {
   type RealtimeConnectionState,
 } from "../signals/realtime.ts";
 import { rootSignal$, setRootSignal$ } from "../signals/root-signal.ts";
-import { settle, withCleanup } from "../signals/utils.ts";
+import {
+  createDeferredPromise,
+  onRejection,
+  settle,
+  withCleanup,
+} from "../signals/utils.ts";
 import {
   chatThreadIndicators$,
   reloadChatThreadIndicators$,
@@ -126,20 +131,6 @@ const catchUpLegacyChatEvents$ = command(
   },
 );
 
-interface CatchUpChatEventThrottle {
-  lastStartedAt: number | null;
-  active: Promise<void> | null;
-  trailing: {
-    readonly owner: object;
-    readonly promise: Promise<void>;
-  } | null;
-}
-
-const catchUpChatEventThrottle$ = computed((get): CatchUpChatEventThrottle => {
-  get(rootSignal$).throwIfAborted();
-  return { lastStartedAt: null, active: null, trailing: null };
-});
-
 const executeCatchUpChatEvent$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
     signal.throwIfAborted();
@@ -182,90 +173,127 @@ const executeCatchUpChatEvent$ = command(
   },
 );
 
-const runCatchUpChatEventNow$ = command(
-  async (
-    { set },
-    throttle: CatchUpChatEventThrottle,
-    signal: AbortSignal,
-  ): Promise<void> => {
-    throttle.lastStartedAt = now();
-    const execution = set(executeCatchUpChatEvent$, signal);
-    throttle.active = execution;
-    await withCleanup(execution, () => {
-      if (throttle.active === execution) {
-        throttle.active = null;
-      }
-    });
-  },
-);
+type CatchUpChatEventCompletion = ReturnType<
+  typeof createDeferredPromise<void>
+>;
 
-const runTrailingCatchUpChatEvent$ = command(
-  async (
-    { set },
-    throttle: CatchUpChatEventThrottle,
-    owner: object,
-    active: Promise<void> | null,
-    signal: AbortSignal,
-  ): Promise<void> => {
-    if (active) {
-      await settle(active, signal);
+/** Keep catch-up scheduling state private to one Worker lifecycle. */
+function createCatchUpChatEventThrottle(): Command<
+  Promise<void>,
+  [AbortSignal]
+> {
+  const lastStartedAt$ = state<number | null>(null);
+  const active$ = state<CatchUpChatEventCompletion | null>(null);
+  const trailing$ = state<CatchUpChatEventCompletion | null>(null);
+
+  const executeScheduledCatchUp$ = command(
+    async (
+      { get, set },
+      completion: CatchUpChatEventCompletion,
+      previous: Promise<void> | null,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      signal.throwIfAborted();
+      if (previous) {
+        await settle(previous, signal);
+      }
+      const lastStartedAt = get(lastStartedAt$);
+      const remaining =
+        lastStartedAt === null
+          ? 0
+          : Math.max(
+              0,
+              lastStartedAt + CHAT_EVENT_CATCH_UP_THROTTLE_MS - now(),
+            );
+      if (remaining > 0) {
+        await delay(remaining, { signal });
+      }
+      signal.throwIfAborted();
+
+      if (get(trailing$) === completion) {
+        set(trailing$, null);
+      }
+      set(active$, completion);
+      set(lastStartedAt$, now());
+      await set(executeCatchUpChatEvent$, signal);
+    },
+  );
+
+  const runScheduledCatchUp$ = command(
+    async (
+      { get, set },
+      completion: CatchUpChatEventCompletion,
+      previous: Promise<void> | null,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      await onRejection(
+        withCleanup(
+          set(executeScheduledCatchUp$, completion, previous, signal),
+          () => {
+            if (get(active$) === completion) {
+              set(active$, null);
+            }
+            if (get(trailing$) === completion) {
+              set(trailing$, null);
+            }
+          },
+        ),
+        (error) => {
+          if (!completion.settled()) {
+            completion.reject(error);
+          }
+        },
+      );
+      signal.throwIfAborted();
+      completion.resolve(undefined);
+    },
+  );
+
+  return command(({ get, set }, signal: AbortSignal): Promise<void> => {
+    signal.throwIfAborted();
+    const trailing = get(trailing$);
+    if (trailing) {
+      return trailing.promise;
     }
-    const lastStartedAt = throttle.lastStartedAt;
-    if (lastStartedAt === null) {
-      throw new Error("Trailing ChatEvent catch-up has no prior start time");
-    }
-    const remaining = Math.max(
-      0,
-      lastStartedAt + CHAT_EVENT_CATCH_UP_THROTTLE_MS - now(),
+
+    const active = get(active$);
+    const lastStartedAt = get(lastStartedAt$);
+    const leading =
+      active === null &&
+      (lastStartedAt === null ||
+        now() - lastStartedAt >= CHAT_EVENT_CATCH_UP_THROTTLE_MS);
+    const completion = createDeferredPromise<void>(signal);
+    // Publish ownership before starting work: a trailing call may have no
+    // remaining delay by the time it starts executing.
+    set(leading ? active$ : trailing$, completion);
+    return set(
+      runScheduledCatchUp$,
+      completion,
+      active?.promise ?? null,
+      signal,
     );
-    if (remaining > 0) {
-      await delay(remaining, { signal });
-    }
-    if (throttle.trailing?.owner === owner) {
-      throttle.trailing = null;
-    }
-    await set(runCatchUpChatEventNow$, throttle, signal);
-  },
-);
+  });
+}
+
+const catchUpChatEventThrottle$ = computed((get) => {
+  get(rootSignal$).throwIfAborted();
+  return createCatchUpChatEventThrottle();
+});
 
 /** Globally serialize ChatEvent catch-up with leading and trailing throttle. */
 const catchUpChatEvent$ = command(({ get, set }): Promise<void> => {
-  const signal = get(rootSignal$);
-  signal.throwIfAborted();
-  const throttle = get(catchUpChatEventThrottle$);
-  if (throttle.trailing) {
-    return throttle.trailing.promise;
-  }
-  if (
-    throttle.active === null &&
-    (throttle.lastStartedAt === null ||
-      now() - throttle.lastStartedAt >= CHAT_EVENT_CATCH_UP_THROTTLE_MS)
-  ) {
-    return set(runCatchUpChatEventNow$, throttle, signal);
-  }
-  const owner = {};
-  const promise = set(
-    runTrailingCatchUpChatEvent$,
-    throttle,
-    owner,
-    throttle.active,
-    signal,
-  );
-  throttle.trailing = { owner, promise };
-  return promise;
+  return set(get(catchUpChatEventThrottle$), get(rootSignal$));
 });
 
 interface WorkerChatThreadIndicatorsCache {
-  source: Promise<ChatThreadIndicators> | null;
-  result: Promise<ChatThreadIndicators> | null;
+  readonly source: Promise<ChatThreadIndicators>;
+  readonly result: Promise<ChatThreadIndicators>;
 }
 
-const workerChatThreadIndicatorsCache$ = computed(
-  (get): WorkerChatThreadIndicatorsCache => {
-    get(rootSignal$).throwIfAborted();
-    return { source: null, result: null };
-  },
-);
+const workerChatThreadIndicatorsCache$ = computed((get) => {
+  get(rootSignal$).throwIfAborted();
+  return state<WorkerChatThreadIndicatorsCache | null>(null);
+});
 
 const loadWorkerChatThreadIndicators$ = command(
   async (
@@ -291,8 +319,9 @@ const loadWorkerChatThreadIndicators$ = command(
 const readWorkerChatThreadIndicators$ = command(
   ({ get, set }): Promise<ChatThreadIndicators> => {
     const source = get(chatThreadIndicators$);
-    const cache = get(workerChatThreadIndicatorsCache$);
-    if (cache.source === source && cache.result) {
+    const cache$ = get(workerChatThreadIndicatorsCache$);
+    const cache = get(cache$);
+    if (cache?.source === source) {
       return cache.result;
     }
     const result = set(
@@ -300,8 +329,7 @@ const readWorkerChatThreadIndicators$ = command(
       source,
       get(rootSignal$),
     );
-    cache.source = source;
-    cache.result = result;
+    set(cache$, { source, result });
     return result;
   },
 );

--- a/turbo/apps/platform/src/shared-database/worker-signals.ts
+++ b/turbo/apps/platform/src/shared-database/worker-signals.ts
@@ -286,14 +286,16 @@ const catchUpChatEvent$ = command(({ get, set }): Promise<void> => {
 });
 
 interface WorkerChatThreadIndicatorsCache {
-  readonly source: Promise<ChatThreadIndicators>;
-  readonly result: Promise<ChatThreadIndicators>;
+  source: Promise<ChatThreadIndicators> | null;
+  result: Promise<ChatThreadIndicators> | null;
 }
 
-const workerChatThreadIndicatorsCache$ = computed((get) => {
-  get(rootSignal$).throwIfAborted();
-  return state<WorkerChatThreadIndicatorsCache | null>(null);
-});
+const workerChatThreadIndicatorsCache$ = computed(
+  (get): WorkerChatThreadIndicatorsCache => {
+    get(rootSignal$).throwIfAborted();
+    return { source: null, result: null };
+  },
+);
 
 const loadWorkerChatThreadIndicators$ = command(
   async (
@@ -319,9 +321,8 @@ const loadWorkerChatThreadIndicators$ = command(
 const readWorkerChatThreadIndicators$ = command(
   ({ get, set }): Promise<ChatThreadIndicators> => {
     const source = get(chatThreadIndicators$);
-    const cache$ = get(workerChatThreadIndicatorsCache$);
-    const cache = get(cache$);
-    if (cache?.source === source) {
+    const cache = get(workerChatThreadIndicatorsCache$);
+    if (cache.source === source && cache.result) {
       return cache.result;
     }
     const result = set(
@@ -329,7 +330,8 @@ const readWorkerChatThreadIndicators$ = command(
       source,
       get(rootSignal$),
     );
-    set(cache$, { source, result });
+    cache.source = source;
+    cache.result = result;
     return result;
   },
 );


### PR DESCRIPTION
With batch ChatEvent catch-up enabled, crossing the 1,000 ms throttle boundary between the eligibility and delay calculations can leave a completed trailing Promise cached permanently. Later indicator refreshes then skip cache catch-up.

Keep scheduling state in ccstate atoms scoped to the Worker lifecycle. Register each shared completion before starting its command, await cleanup and error propagation, and bind signal-timers waits to the Worker root signal. Preserve immediate leading execution, serialized requests, at most one trailing execution, and the existing 1-second start interval.

The new scheduler runs only when `batchChatEventCatchUp` is enabled. False and absent switch values retain the original per-thread catch-up path. The shared indicator result cache, feature gate, and legacy catch-up implementation are unchanged from the PR base.

Committed regressions drive the real MessagePort/Worker path before, across, and at the throttle boundary, asserting that a later refresh warms newly available chat rows. They wait for initial subscription catch-up to finish, then sample the lifecycle-owned application clock at the indicator HTTP response boundary. Numeric/Date clock overrides retain their behavior; timers and application commands remain real.

Validation:

- 29 targeted tests passed: MessagePort (14), Worker runtime (8), and platform shared-database recovery (7), including false/absent switch behavior, failure recovery, and cancellation.
- With the committed tests and the pre-fix production scheduler, the cross-boundary case failed at the missing third chat row in 5/5 runs; both boundary controls passed. All three cases passed with the new scheduler in 5/5 runs.
- Full formatting, lint (14 tasks), type checks (15 tasks), and Knip passed. Normal pre-commit and commit-message hooks passed.
