### PR TITLE
fix: open the sidebar chat menu from the row state indicator

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -2008,6 +2008,19 @@ test("Recognize and pin sidebar conversation states", async () => {
     within(threadRowByTitle("Draft brief")).getByLabelText("Draft"),
   ).toHaveAttribute("role", "img");
 
+  // Touch rows never hover, so the state indicator has to be the menu trigger
+  // itself; otherwise running, unread, and draft chats lose every row action.
+  for (const [title, label] of [
+    ["Incident notes", "Unread"],
+    ["Running analysis", "Running"],
+    ["Draft brief", "Draft"],
+  ] as const) {
+    const row = threadRowByTitle(title);
+    expect(
+      within(row).getByTestId("chat-thread-menu-trigger"),
+    ).toContainElement(within(row).getByLabelText(label));
+  }
+
   openThreadMenu("Release plan");
   click(menuItemByText("Pin chat"));
 
@@ -2033,6 +2046,10 @@ test("Recognize and pin sidebar conversation states", async () => {
       ),
     ).not.toBeInTheDocument();
   });
+
+  openThreadMenu("Running analysis");
+  expect(menuItemByText("Rename chat")).toBeInTheDocument();
+  expect(menuItemByText("Delete chat")).toBeInTheDocument();
 });
 
 test("Refresh agent and thread unread indicators", async () => {

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -94,7 +94,10 @@ import { Link } from "../router/link.tsx";
 import { OverlayScrollArea } from "./sidebar-scroll.tsx";
 import { equalArrays } from "../../lib/equality.ts";
 
-const CHAT_THREAD_ROW_ICON_CLASS = "[&_svg]:size-[17px] [&_svg]:opacity-70";
+// The row glyphs draw at 17px, which the shared button base (`[&_svg]:size-4`)
+// would otherwise clamp to 16px. Dimming stays on the individual glyphs so the
+// state indicators keep their own contrast.
+const CHAT_THREAD_ROW_ICON_CLASS = "[&_svg]:size-[17px]";
 
 function equalSidebarChatThreadWindows(
   previous: SidebarChatThreadWindow,
@@ -215,9 +218,9 @@ function ChatThreadMenu({
     detach(openRename(pageSignal), Reason.DomCallback);
   }
 
-  const hasOtherIndicator = indicatorState !== null || isPinned;
-  const usePinnedIndicatorTrigger = isPinned && indicatorState === null;
-  const showMobileTrigger = !hasOtherIndicator || usePinnedIndicatorTrigger;
+  const showStateIndicator = indicatorState !== null;
+  const showPinIndicator = isPinned && indicatorState === null;
+  const hasRestingIndicator = showStateIndicator || showPinIndicator;
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -228,9 +231,11 @@ function ChatThreadMenu({
             onClick={preventChatThreadMenuNavigation}
             variant="quiet"
             size="icon-2xs"
-            className={`peer pointer-events-auto absolute left-1 top-1 cursor-pointer rounded-md ${
-              showMobileTrigger ? "visible" : "invisible"
-            } transition-opacity duration-150 md:invisible md:group-hover:visible md:data-popup-open:visible ${CHAT_THREAD_ROW_ICON_CLASS}`}
+            className={`group/thread-menu pointer-events-auto absolute left-1 top-1 cursor-pointer rounded-md transition-opacity duration-150 ${
+              hasRestingIndicator
+                ? ""
+                : "md:invisible md:group-hover:visible md:data-popup-open:visible"
+            } ${CHAT_THREAD_ROW_ICON_CLASS}`}
             aria-label={t(($) => {
               return $.chat.sidebar.openChatMenu;
             })}
@@ -241,25 +246,35 @@ function ChatThreadMenu({
               <TooltipTrigger asChild>
                 <span
                   aria-label={
-                    usePinnedIndicatorTrigger
+                    showPinIndicator
                       ? t(($) => {
                           return $.chat.sidebar.pinned;
                         })
                       : undefined
                   }
                   data-testid={
-                    usePinnedIndicatorTrigger
+                    showPinIndicator
                       ? "chat-thread-pinned-indicator"
                       : undefined
                   }
+                  className="flex items-center justify-center"
                 >
-                  {usePinnedIndicatorTrigger ? (
+                  {hasRestingIndicator ? (
                     <>
-                      <Pin size={17} className="md:hidden" />
-                      <Ellipsis size={17} className="hidden md:block" />
+                      <span className="flex items-center justify-center md:group-hover:hidden md:group-data-[popup-open]/thread-menu:hidden">
+                        {showStateIndicator ? (
+                          <SessionStateIndicator signals={signals} />
+                        ) : (
+                          <Pin size={17} className="opacity-70" />
+                        )}
+                      </span>
+                      <Ellipsis
+                        size={17}
+                        className="hidden opacity-70 md:group-hover:block md:group-data-[popup-open]/thread-menu:block"
+                      />
                     </>
                   ) : (
-                    <Ellipsis size={17} />
+                    <Ellipsis size={17} className="opacity-70" />
                   )}
                 </span>
               </TooltipTrigger>
@@ -312,57 +327,6 @@ function ChatThreadMenu({
         </DropdownMenuContent>
       </DropdownMenu>
     </TooltipProvider>
-  );
-}
-
-function ChatThreadSideDecorator({
-  signals,
-}: {
-  signals: SidebarChatThreadItemSignals;
-}) {
-  const { t } = useTranslation();
-  const isPinned = useGet(signals.pinned$);
-  const indicatorState = useLastResolved(signals.indicatorState$) ?? null;
-  if (indicatorState === "draft") {
-    return (
-      <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
-        <span className="flex items-center justify-center">
-          <SessionStateIndicator signals={signals} />
-        </span>
-      </div>
-    );
-  }
-  return (
-    <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
-      <ChatThreadMenu signals={signals} />
-      {indicatorState !== null ? (
-        <span className="flex items-center justify-center group-hover:hidden peer-data-popup-open:hidden">
-          <SessionStateIndicator signals={signals} />
-        </span>
-      ) : isPinned ? (
-        <TooltipProvider delayDuration={200}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                aria-label={t(($) => {
-                  return $.chat.sidebar.pinned;
-                })}
-                className={`hidden items-center justify-center text-muted-foreground group-hover:hidden peer-data-popup-open:hidden md:flex ${CHAT_THREAD_ROW_ICON_CLASS}`}
-              >
-                <Pin size={17} />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p className="text-xs">
-                {t(($) => {
-                  return $.chat.sidebar.pinned;
-                })}
-              </p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      ) : null}
-    </div>
   );
 }
 
@@ -427,7 +391,9 @@ function ChatThreadItem({
   return (
     <div className="group relative">
       <ChatThreadItemLink signals={signals} />
-      <ChatThreadSideDecorator signals={signals} />
+      <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
+        <ChatThreadMenu signals={signals} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Problem

On touch viewports a chat row with a running / unread / draft indicator has **no reachable row menu**. Reported from the mobile PWA: tapping the indicator on a running thread was expected to open the menu, but it only opened the chat.

`sidebar-threads.tsx` hid the `...` trigger whenever the row carried an indicator (`showMobileTrigger = !hasOtherIndicator || usePinnedIndicatorTrigger`) and only revealed it again through `md:group-hover:visible` / `md:data-popup-open:visible`. Touch has no hover and never reaches the `md` breakpoint, so the trigger stayed `invisible` forever — pin, rename, mark unread, and delete were all unreachable. The decorator was `pointer-events-none`, so the tap fell through to the row link and navigated instead. Draft rows returned early and had no menu on **any** viewport.

## Change

Make the state indicator itself the menu trigger, extending the pattern already used for pinned rows (`Pin` glyph acted as the mobile trigger):

- The trigger stays visible whenever the row has a resting glyph (running / unread / draft / pinned) and swaps that glyph for the ellipsis on desktop hover or while the menu is open.
- Rows with no glyph keep today's behavior: always visible on mobile, hover-revealed on desktop.
- `ChatThreadSideDecorator` is deleted — the indicator is now rendered exactly once, inside the trigger, so no duplicate a11y nodes.
- Draft rows get the same menu as every other row.
- `[&_svg]:opacity-70` moved off the shared button class onto the individual `Ellipsis` / `Pin` glyphs so state indicators keep their own contrast.

Desktop appearance is unchanged: resting shows the indicator, hover shows `...`.

## Verification

- `pnpm -F @okouai/app check-types` — pass
- `pnpm -F @okouai/app lint` — pass
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/sidebar.test.tsx` — 36/36 pass
- `pnpm format` — clean

Regression coverage added to `Recognize and pin sidebar conversation states`: each indicator (unread / running / draft) must render inside `chat-thread-menu-trigger`, and the menu opens from a running row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)