### PR TITLE
fix(cli): show a standalone mail link reply example

### DIFF
--- a/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/mail/__tests__/index.test.ts
@@ -237,7 +237,7 @@ describe("okou mail", () => {
     );
   });
 
-  it("links an existing Gmail draft and prints only the review URL", async () => {
+  it("links an existing Gmail draft and shows a standalone review URL example", async () => {
     server.use(
       http.post(
         "http://localhost:3000/api/mail/drafts/link",
@@ -265,7 +265,9 @@ describe("okou mail", () => {
 
     expect(mockConsoleLog).toHaveBeenCalledOnce();
     expect(mockConsoleLog).toHaveBeenCalledWith(
-      `https://app.vm0.ai/mail/drafts/${MAIL_DRAFT_ID}`,
+      expect.stringContaining(
+        `Example reply:\n\nYour email draft is ready to review and send.\n\nhttps://app.vm0.ai/mail/drafts/${MAIL_DRAFT_ID}`,
+      ),
     );
   });
 
@@ -291,7 +293,8 @@ describe("okou mail", () => {
       "Confirm the email was sent",
     ]);
 
-    const reviewUrl = new URL(String(mockConsoleLog.mock.calls[0]?.[0]));
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    const reviewUrl = new URL(output.match(/^https:\/\/\S+$/m)?.[0] ?? "");
     expect(reviewUrl.pathname).toBe(`/mail/drafts/${MAIL_DRAFT_ID}`);
     expect(Array.from(reviewUrl.searchParams.entries())).toStrictEqual([
       ["source", "gmail"],
@@ -299,7 +302,6 @@ describe("okou mail", () => {
       ["threadId", THREAD_ID],
       ["callbackPrompt", "Confirm the email was sent"],
     ]);
-    const output = mockConsoleLog.mock.calls.flat().join("\n");
     expect(output).toContain("end the current turn");
     expect(output).toContain("exact callback URL above verbatim");
     expect(output).toContain("omitting any query parameters");

--- a/turbo/apps/cli/src/commands/mail/link.ts
+++ b/turbo/apps/cli/src/commands/mail/link.ts
@@ -72,12 +72,13 @@ ${callbackPromptNotes}  - The user reviews the draft and sends it from the linke
           agentId,
           gmailDraftId,
         });
+        const reviewUrl = mailDraftReviewUrl({
+          mailDraftUrl: result.mailDraftUrl,
+          agentId,
+          callbackPrompt: opts.callbackPrompt,
+        });
         console.log(
-          mailDraftReviewUrl({
-            mailDraftUrl: result.mailDraftUrl,
-            agentId,
-            callbackPrompt: opts.callbackPrompt,
-          }),
+          `Return the exact review URL on its own line, separated from other text by blank lines. Example reply:\n\nYour email draft is ready to review and send.\n\n${reviewUrl}`,
         );
         if (opts.callbackPrompt !== undefined) {
           printCallbackTurnInstruction();


### PR DESCRIPTION
`okou mail link` now prints a short example reply that places the exact review URL on its own line, separated from the message by a blank line. This guides agents to return links in a format that renders as an email card.

Validation: all 5 existing mail command tests pass, including callback URL parameter preservation. CLI lint and type checks, scoped Knip, Prettier, and commitlint pass.
