### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,8 +113,8 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.27.1"
-CLAUDE_CODE_VERSION="2.1.260"
-CODEX_CLI_VERSION="0.153.2"
+CLAUDE_CODE_VERSION="2.1.261"
+CODEX_CLI_VERSION="0.153.4"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
 AGENT_BROWSER_VERSION="0.33.0-vm0.1"


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.260` to `2.1.261`.
- Update Codex CLI from `0.153.2` to `0.153.4`.

Go, Google Workspace CLI, xurl, the vm0 agent-browser fork, pnpm, and Chromium Bookworm security remain current. Node.js 24 remains the current LTS major, and PostgreSQL 18 remains the current supported major.

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check origin/main...HEAD`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml --profile local -p runner --tests`
- Confirmed Claude Code 2.1.261 standalone binaries and manifest entries for linux-x64 and linux-arm64.
- Confirmed Codex CLI 0.153.4 and its linux-x64 and linux-arm64 packages; executed the published x64 artifact and confirmed `codex-cli 0.153.4`.
- Confirmed Chromium, Chromium Common, and Chromium Sandbox `152.0.7977.75-1~deb12u1` remain the latest Bookworm security packages.

The focused linked test command `CARGO_BUILD_JOBS=1 cargo test --manifest-path crates/Cargo.toml --profile local -p runner cmd::build::scripts::tests` was attempted, but this constrained runner was killed with exit 137 during test-binary generation before tests executed. The non-linking exact-head test-target check above passed; PR CI will run the linked test suite in its normal environment.