### PR TITLE
feat(pi): add dialect-aware fast carrier compatibility

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -130,6 +130,9 @@ pub mod runners {
     /// Current dialect-aware Pi model configuration generation.
     pub const PI_MODEL_CONFIG_CURRENT_GENERATION: u32 = 2;
 
+    /// Additive Pi generation with dialect-constrained request tiers.
+    pub const PI_MODEL_CONFIG_DIALECT_TIER_GENERATION: u32 = 3;
+
     /// Legacy unversioned Pi model configuration generation.
     pub const PI_MODEL_CONFIG_LEGACY_GENERATION: u32 = 1;
 

--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -370,6 +370,257 @@ pub mod runners {
             pub credential_bindings: Vec<PiModelConfigV2CredentialBinding>,
         }
 
+        /// Required Responses streaming transport.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum PiModelConfigV3OpenaiResponsesTransport {
+            /// Server-sent events only.
+            #[serde(rename = "sse")]
+            Sse,
+        }
+
+        /// Native Pi catalog providers for this dialect.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum PiModelConfigV3OpenaiResponsesProvider {
+            /// DeepSeek provider.
+            #[serde(rename = "deepseek")]
+            Deepseek,
+            /// OpenAI public API provider.
+            #[serde(rename = "openai")]
+            Openai,
+            /// OpenRouter provider.
+            #[serde(rename = "openrouter")]
+            Openrouter,
+        }
+
+        /// Thinking levels supported by Pi sessions.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum PiModelConfigV3OpenaiResponsesThinkingLevel {
+            /// Disable model thinking.
+            #[serde(rename = "off")]
+            Off,
+            /// Minimal thinking.
+            #[serde(rename = "minimal")]
+            Minimal,
+            /// Low thinking.
+            #[serde(rename = "low")]
+            Low,
+            /// Medium thinking.
+            #[serde(rename = "medium")]
+            Medium,
+            /// High thinking.
+            #[serde(rename = "high")]
+            High,
+            /// Extra-high thinking.
+            #[serde(rename = "xhigh")]
+            Xhigh,
+            /// Maximum thinking.
+            #[serde(rename = "max")]
+            Max,
+        }
+
+        /// Dialect-constrained request service tiers.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum PiModelConfigV3OpenaiResponsesServiceTier {
+            /// Public Responses priority service tier.
+            #[serde(rename = "priority")]
+            Priority,
+        }
+
+        /// Non-secret custom gateway credential header policy.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct PiModelConfigV3OpenaiResponsesCredentialBindingApiKeyCredentialHeader {
+            /// Request header name.
+            pub name: String,
+            /// Header value template containing the credential placeholder exactly once.
+            pub value_template: String,
+        }
+
+        /// One non-secret execution-edge credential binding.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(tag = "kind", rename_all_fields = "camelCase")]
+        pub enum PiModelConfigV3OpenaiResponsesCredentialBinding {
+            /// Public Responses API-key binding.
+            #[serde(rename = "api-key")]
+            ApiKey {
+                /// Sandbox environment entry containing the value.
+                environment: String,
+                /// API-owned encrypted secret containing the value.
+                secret_name: String,
+                /// Optional non-secret custom gateway header policy.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                credential_header:
+                    Option<PiModelConfigV3OpenaiResponsesCredentialBindingApiKeyCredentialHeader>,
+            },
+            /// ChatGPT access-token binding.
+            #[serde(rename = "access-token")]
+            AccessToken {
+                /// Sandbox environment entry containing the value.
+                environment: String,
+                /// API-owned encrypted secret containing the value.
+                secret_name: String,
+            },
+            /// ChatGPT account-ID binding.
+            #[serde(rename = "account-id")]
+            AccountId {
+                /// Sandbox environment entry containing the value.
+                environment: String,
+                /// API-owned encrypted secret containing the value.
+                secret_name: String,
+            },
+        }
+
+        /// Required Responses streaming transport.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum PiModelConfigV3OpenaiCodexResponsesTransport {
+            /// Server-sent events only.
+            #[serde(rename = "sse")]
+            Sse,
+        }
+
+        /// Native Pi catalog providers for this dialect.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum PiModelConfigV3OpenaiCodexResponsesProvider {
+            /// OpenAI Codex subscription provider.
+            #[serde(rename = "openai-codex")]
+            OpenaiCodex,
+        }
+
+        /// Thinking levels supported by Pi sessions.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum PiModelConfigV3OpenaiCodexResponsesThinkingLevel {
+            /// Disable model thinking.
+            #[serde(rename = "off")]
+            Off,
+            /// Minimal thinking.
+            #[serde(rename = "minimal")]
+            Minimal,
+            /// Low thinking.
+            #[serde(rename = "low")]
+            Low,
+            /// Medium thinking.
+            #[serde(rename = "medium")]
+            Medium,
+            /// High thinking.
+            #[serde(rename = "high")]
+            High,
+            /// Extra-high thinking.
+            #[serde(rename = "xhigh")]
+            Xhigh,
+            /// Maximum thinking.
+            #[serde(rename = "max")]
+            Max,
+        }
+
+        /// Dialect-constrained request service tiers.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        pub enum PiModelConfigV3OpenaiCodexResponsesServiceTier {
+            /// Native Codex Responses fast service tier.
+            #[serde(rename = "fast")]
+            Fast,
+        }
+
+        /// Non-secret custom gateway credential header policy.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct PiModelConfigV3OpenaiCodexResponsesCredentialBindingApiKeyCredentialHeader {
+            /// Request header name.
+            pub name: String,
+            /// Header value template containing the credential placeholder exactly once.
+            pub value_template: String,
+        }
+
+        /// One non-secret execution-edge credential binding.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(tag = "kind", rename_all_fields = "camelCase")]
+        pub enum PiModelConfigV3OpenaiCodexResponsesCredentialBinding {
+            /// Public Responses API-key binding.
+            #[serde(rename = "api-key")]
+            ApiKey {
+                /// Sandbox environment entry containing the value.
+                environment: String,
+                /// API-owned encrypted secret containing the value.
+                secret_name: String,
+                /// Optional non-secret custom gateway header policy.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                credential_header: Option<
+                    PiModelConfigV3OpenaiCodexResponsesCredentialBindingApiKeyCredentialHeader,
+                >,
+            },
+            /// ChatGPT access-token binding.
+            #[serde(rename = "access-token")]
+            AccessToken {
+                /// Sandbox environment entry containing the value.
+                environment: String,
+                /// API-owned encrypted secret containing the value.
+                secret_name: String,
+            },
+            /// ChatGPT account-ID binding.
+            #[serde(rename = "account-id")]
+            AccountId {
+                /// Sandbox environment entry containing the value.
+                environment: String,
+                /// API-owned encrypted secret containing the value.
+                secret_name: String,
+            },
+        }
+
+        /// API-owned dialect-aware non-secret Pi model configuration.
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        #[serde(tag = "dialect", rename_all_fields = "camelCase")]
+        pub enum PiModelConfigV3 {
+            /// Public Responses route with optional priority tier.
+            #[serde(rename = "openai-responses")]
+            OpenaiResponses {
+                /// Pi model configuration generation.
+                schema_version: i64,
+                /// Transport policy selected by the route.
+                transport: PiModelConfigV3OpenaiResponsesTransport,
+                /// Native Pi catalog provider selected by the route.
+                provider: PiModelConfigV3OpenaiResponsesProvider,
+                /// Exact base URL used for model requests.
+                base_url: String,
+                /// Exact provider model identifier sent with requests.
+                model: String,
+                /// Optional native Pi catalog model used for trusted public Responses metadata.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                catalog_model: Option<String>,
+                /// Explicit Pi thinking level.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                thinking_level: Option<PiModelConfigV3OpenaiResponsesThinkingLevel>,
+                /// Optional dialect-constrained request service tier.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                service_tier: Option<PiModelConfigV3OpenaiResponsesServiceTier>,
+                /// Bounded non-secret credential bindings materialized only at an execution edge.
+                credential_bindings: Vec<PiModelConfigV3OpenaiResponsesCredentialBinding>,
+            },
+            /// Native Codex Responses route with optional fast tier.
+            #[serde(rename = "openai-codex-responses")]
+            OpenaiCodexResponses {
+                /// Pi model configuration generation.
+                schema_version: i64,
+                /// Transport policy selected by the route.
+                transport: PiModelConfigV3OpenaiCodexResponsesTransport,
+                /// Native Pi catalog provider selected by the route.
+                provider: PiModelConfigV3OpenaiCodexResponsesProvider,
+                /// Exact base URL used for model requests.
+                base_url: String,
+                /// Exact provider model identifier sent with requests.
+                model: String,
+                /// Optional native Pi catalog model used for trusted public Responses metadata.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                catalog_model: Option<String>,
+                /// Explicit Pi thinking level.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                thinking_level: Option<PiModelConfigV3OpenaiCodexResponsesThinkingLevel>,
+                /// Optional dialect-constrained request service tier.
+                #[serde(default, skip_serializing_if = "Option::is_none")]
+                service_tier: Option<PiModelConfigV3OpenaiCodexResponsesServiceTier>,
+                /// Bounded non-secret credential bindings materialized only at an execution edge.
+                credential_bindings: Vec<PiModelConfigV3OpenaiCodexResponsesCredentialBinding>,
+            },
+        }
+
         /// DTOs for durable active-input delivery.
         pub mod active_inputs {
             /// DTOs for recording active-input acceptance receipts.

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -6,7 +6,7 @@ use api_contracts::generated::types::{
             CodexRuntimeConfig, PiLaunchConfig, PiLaunchConfigApiFirstTurn,
             PiLaunchConfigApiFirstTurnBaseSession, PiLaunchConfigMemoryRecall, PiModelConfig,
             PiModelConfigApiKeyEnv, PiModelConfigProvider, PiModelConfigServiceTier,
-            PiModelConfigV2, model_provider_failures,
+            PiModelConfigV2, PiModelConfigV3, model_provider_failures,
         },
         storage as runner_storage,
     },
@@ -872,4 +872,49 @@ fn generated_storage_mount_entry_preserves_canonical_shape() {
         mount.missing_root_policy,
         Some(runner_storage::ArtifactEntryMissingRootPolicy::PreserveParentVersion)
     );
+}
+
+#[test]
+fn generated_pi_model_config_v3_preserves_native_fast() {
+    let value = serde_json::json!({
+        "schemaVersion": 3,
+        "dialect": "openai-codex-responses",
+        "transport": "sse",
+        "provider": "openai-codex",
+        "baseUrl": "https://chatgpt.com/backend-api",
+        "model": "gpt-5.6-terra",
+        "serviceTier": "fast",
+        "credentialBindings": [
+            { "kind": "access-token", "environment": "CHATGPT_ACCESS_TOKEN", "secretName": "CHATGPT_ACCESS_TOKEN" },
+            { "kind": "account-id", "environment": "CHATGPT_ACCOUNT_ID", "secretName": "CHATGPT_ACCOUNT_ID" }
+        ]
+    });
+    let decoded: PiModelConfigV3 = serde_json::from_value(value.clone()).unwrap();
+    assert_eq!(serde_json::to_value(decoded).unwrap(), value);
+    assert!(serde_json::from_value::<PiModelConfigV2>(value.clone()).is_err());
+    for dialect in ["openai-responses", "openai-codex-responses"] {
+        for tier in [None, Some("priority"), Some("fast"), Some("unknown")] {
+            let mut candidate = value.clone();
+            candidate["dialect"] = serde_json::json!(dialect);
+            if dialect == "openai-responses" {
+                candidate["provider"] = serde_json::json!("openai");
+                candidate["credentialBindings"] = serde_json::json!([
+                    { "kind": "api-key", "environment": "OPENAI_API_KEY", "secretName": "OPENAI_API_KEY" }
+                ]);
+            }
+            if let Some(tier) = tier {
+                candidate["serviceTier"] = serde_json::json!(tier);
+            } else {
+                candidate.as_object_mut().unwrap().remove("serviceTier");
+            }
+            let supported = tier.is_none()
+                || (dialect == "openai-responses" && tier == Some("priority"))
+                || (dialect == "openai-codex-responses" && tier == Some("fast"));
+            let decoded = serde_json::from_value::<PiModelConfigV3>(candidate.clone());
+            assert_eq!(decoded.is_ok(), supported, "{candidate}");
+            if let Ok(decoded) = decoded {
+                assert_eq!(serde_json::to_value(decoded).unwrap(), candidate);
+            }
+        }
+    }
 }

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
-use api_contracts::generated::constants::runners::PI_MODEL_CONFIG_CURRENT_GENERATION;
+use api_contracts::generated::constants::runners::{
+    PI_MODEL_CONFIG_CURRENT_GENERATION, PI_MODEL_CONFIG_DIALECT_TIER_GENERATION,
+};
 use api_contracts::generated::types::runners::{
-    runs::{CodexRuntimeConfig, PiLaunchConfig, PiModelConfig, PiModelConfigV2},
+    runs::{CodexRuntimeConfig, PiLaunchConfig, PiModelConfig, PiModelConfigV2, PiModelConfigV3},
     storage::ArtifactEntryMissingRootPolicy,
 };
 use guest_contracts::cli_agent_session_id::is_valid_cli_agent_session_id;
@@ -410,11 +412,41 @@ fn validate_pi_v2_credential_bindings(
 fn validate_pi_model_config_v2(value: &serde_json::Value) -> Result<(), String> {
     let model: PiModelConfigV2 = serde_json::from_value(value.clone())
         .map_err(|error| format!("Pi model config v2 is invalid: {error}"))?;
-    if model.schema_version != i64::from(PI_MODEL_CONFIG_CURRENT_GENERATION) {
-        return Err("Pi model config schemaVersion is unsupported".to_string());
-    }
-    validate_pi_model_config_common(&model.base_url, &model.model, value.get("catalogModel"))
-        .map_err(|error| match error {
+    validate_pi_versioned_model_config(
+        value,
+        &model.base_url,
+        &model.model,
+        PI_MODEL_CONFIG_CURRENT_GENERATION,
+    )
+}
+
+fn validate_pi_model_config_v3(value: &serde_json::Value) -> Result<(), String> {
+    let model: PiModelConfigV3 = serde_json::from_value(value.clone())
+        .map_err(|error| format!("Pi model config v3 is invalid: {error}"))?;
+    let (base_url, model_name) = match &model {
+        PiModelConfigV3::OpenaiResponses {
+            base_url, model, ..
+        }
+        | PiModelConfigV3::OpenaiCodexResponses {
+            base_url, model, ..
+        } => (base_url, model),
+    };
+    validate_pi_versioned_model_config(
+        value,
+        base_url,
+        model_name,
+        PI_MODEL_CONFIG_DIALECT_TIER_GENERATION,
+    )
+}
+
+fn validate_pi_versioned_model_config(
+    value: &serde_json::Value,
+    base_url: &str,
+    model: &str,
+    generation: u32,
+) -> Result<(), String> {
+    validate_pi_model_config_common(base_url, model, value.get("catalogModel")).map_err(
+        |error| match error {
             PiModelConfigCommonError::InvalidBaseUrl => {
                 "Pi model config baseUrl is invalid".to_string()
             }
@@ -422,12 +454,13 @@ fn validate_pi_model_config_v2(value: &serde_json::Value) -> Result<(), String> 
             PiModelConfigCommonError::InvalidCatalogModel => {
                 "Pi model config catalogModel is invalid".to_string()
             }
-        })?;
-    if model.model.encode_utf16().count() > 512 {
+        },
+    )?;
+    if model.encode_utf16().count() > 512 {
         return Err("Pi model config model is invalid".to_string());
     }
     let Some(object) = value.as_object() else {
-        return Err("Pi model config v2 is invalid".to_string());
+        return Err(format!("Pi model config v{generation} is invalid"));
     };
     if !has_exact_object_fields(
         object,
@@ -453,18 +486,25 @@ fn validate_pi_model_config_v2(value: &serde_json::Value) -> Result<(), String> 
             "credentialBindings",
         ],
     ) {
-        return Err("Pi model config v2 fields are invalid".to_string());
+        return Err(format!("Pi model config v{generation} fields are invalid"));
     }
     if object.get("transport").and_then(serde_json::Value::as_str) != Some("sse") {
         return Err("Pi model config transport must be sse".to_string());
     }
-    if model
-        .catalog_model
-        .as_deref()
+    if object
+        .get("catalogModel")
+        .and_then(serde_json::Value::as_str)
         .is_some_and(|catalog_model| catalog_model.encode_utf16().count() > 512)
     {
         return Err("Pi model config catalogModel is invalid".to_string());
     }
+    validate_pi_model_config_dialect(object, generation)
+}
+
+fn validate_pi_model_config_dialect(
+    object: &serde_json::Map<String, serde_json::Value>,
+    generation: u32,
+) -> Result<(), String> {
     let dialect = object
         .get("dialect")
         .and_then(serde_json::Value::as_str)
@@ -480,12 +520,21 @@ fn validate_pi_model_config_v2(value: &serde_json::Value) -> Result<(), String> 
         "openai-codex-responses"
             if provider != "openai-codex"
                 || object.contains_key("catalogModel")
-                || object.contains_key("serviceTier") =>
+                || (generation == PI_MODEL_CONFIG_CURRENT_GENERATION
+                    && object.contains_key("serviceTier")) =>
         {
             return Err("Pi Codex Responses route is invalid".to_string());
         }
         "openai-responses" | "openai-codex-responses" => {}
         _ => return Err("Pi model config dialect is unsupported".to_string()),
+    }
+    // Serde Option accepts null; the new wire contract permits omission only.
+    if generation == PI_MODEL_CONFIG_DIALECT_TIER_GENERATION {
+        for field in ["thinkingLevel", "serviceTier"] {
+            if object.get(field).is_some_and(serde_json::Value::is_null) {
+                return Err(format!("Pi model config {field} is invalid"));
+            }
+        }
     }
     validate_pi_v2_credential_bindings(
         object
@@ -502,6 +551,11 @@ fn validate_pi_model_config(value: &serde_json::Value) -> Result<(), String> {
             if generation.as_u64() == Some(u64::from(PI_MODEL_CONFIG_CURRENT_GENERATION)) =>
         {
             validate_pi_model_config_v2(value)
+        }
+        Some(serde_json::Value::Number(generation))
+            if generation.as_u64() == Some(u64::from(PI_MODEL_CONFIG_DIALECT_TIER_GENERATION)) =>
+        {
+            validate_pi_model_config_v3(value)
         }
         Some(_) => Err("Pi model config generation is unsupported".to_string()),
     }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -1507,16 +1507,47 @@ fn pi_execution_context_rejects_invalid_legacy_shared_model_fields_before_sandbo
 }
 
 #[test]
-fn pi_execution_context_accepts_and_preserves_both_v2_dialects() {
-    for dialect in ["openai-responses", "openai-codex-responses"] {
-        let mut context = pi_context_for_test();
-        let config = pi_model_config_v2_for_test(dialect);
-        context.pi_model_config = Some(config.clone());
+fn pi_execution_context_accepts_and_preserves_versioned_dialect_tiers() {
+    for generation in [2, 3] {
+        for dialect in ["openai-responses", "openai-codex-responses"] {
+            for tier in [None, Some("priority"), Some("fast"), Some("default")] {
+                let mut context = pi_context_for_test();
+                let mut config = pi_model_config_v2_for_test(dialect);
+                config["schemaVersion"] = json!(generation);
+                if let Some(tier) = tier {
+                    config["serviceTier"] = json!(tier);
+                }
+                context.pi_model_config = Some(config.clone());
+                let supported = tier.is_none()
+                    || (dialect == "openai-responses" && tier == Some("priority"))
+                    || (generation == 3
+                        && dialect == "openai-codex-responses"
+                        && tier == Some("fast"));
+                assert_eq!(
+                    validate_context_for_test(&context).is_ok(),
+                    supported,
+                    "{config}"
+                );
+                if supported {
+                    let payload = build_run_payload_for_run(&context).unwrap();
+                    let forwarded: serde_json::Value =
+                        serde_json::from_str(&payload.pi_model_config).unwrap();
+                    assert_eq!(forwarded, config);
+                }
+            }
+        }
+    }
+}
 
-        assert!(validate_context_for_test(&context).is_ok());
-        let payload = build_run_payload_for_run(&context).unwrap();
-        let forwarded: serde_json::Value = serde_json::from_str(&payload.pi_model_config).unwrap();
-        assert_eq!(forwarded, config);
+#[test]
+fn pi_execution_context_rejects_null_v3_optional_fields() {
+    for field in ["thinkingLevel", "serviceTier", "catalogModel"] {
+        let mut context = pi_context_for_test();
+        let mut config = pi_model_config_v2_for_test("openai-responses");
+        config["schemaVersion"] = json!(3);
+        config[field] = json!(null);
+        context.pi_model_config = Some(config);
+        assert!(validate_context_for_test(&context).is_err(), "{field}");
     }
 }
 
@@ -1622,21 +1653,36 @@ fn pi_execution_context_rejects_invalid_or_future_v2_routes() {
         (
             {
                 let mut config = pi_model_config_v2_for_test("openai-responses");
-                config["schemaVersion"] = json!(3);
+                config["schemaVersion"] = json!(4);
                 config
             },
             "Pi model config generation is unsupported",
         ),
     ];
 
-    for (config, expected) in invalid_configs {
-        let mut context = pi_context_for_test();
-        context.pi_model_config = Some(config);
-        let error = validate_context_for_test(&context).unwrap_err();
-        assert!(
-            error.contains(expected),
-            "expected {expected:?}, got unexpected error: {error}"
-        );
+    for generation in [2, 3] {
+        for (original, expected) in &invalid_configs {
+            let mut config = original.clone();
+            if config["schemaVersion"] == json!(2) {
+                config["schemaVersion"] = json!(generation);
+            }
+            let mut context = pi_context_for_test();
+            let expected = if generation == 3
+                && (config["transport"] == json!("auto")
+                    || (config["dialect"] == json!("openai-codex-responses")
+                        && config["provider"] == json!("openai")))
+            {
+                "Pi model config v3 is invalid".to_string()
+            } else {
+                expected.replace("v2", &format!("v{generation}"))
+            };
+            context.pi_model_config = Some(config);
+            let error = validate_context_for_test(&context).unwrap_err();
+            assert!(
+                error.contains(&expected),
+                "expected {expected:?}, got unexpected error: {error}"
+            );
+        }
     }
 }
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -11,8 +11,8 @@ use tracing::{error, info, warn};
 use api_contracts::generated::{
     constants::runners::{
         BUILTIN_FIREWALL_CATALOG_MAX_BYTES, CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
-        PI_MODEL_CONFIG_CURRENT_GENERATION, PI_MODEL_CONFIG_LEGACY_GENERATION,
-        RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
+        PI_MODEL_CONFIG_CURRENT_GENERATION, PI_MODEL_CONFIG_DIALECT_TIER_GENERATION,
+        PI_MODEL_CONFIG_LEGACY_GENERATION, RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
     },
     decode_paths, routes,
     types::runners::runs::active_inputs::{
@@ -71,7 +71,7 @@ struct ClaimRequestBody<'a> {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct RunnerClaimCapabilities {
-    pi_model_config_generations: [u32; 2],
+    pi_model_config_generations: [u32; 3],
 }
 
 #[derive(Serialize)]
@@ -1696,6 +1696,7 @@ fn claim_request_body<'a>(
             pi_model_config_generations: [
                 PI_MODEL_CONFIG_LEGACY_GENERATION,
                 PI_MODEL_CONFIG_CURRENT_GENERATION,
+                PI_MODEL_CONFIG_DIALECT_TIER_GENERATION,
             ],
         },
         telemetry: ClaimRequestTelemetry {
@@ -3156,7 +3157,7 @@ mod tests {
         assert!(!body.to_string().contains("path"));
         assert_eq!(
             body["capabilities"]["piModelConfigGenerations"],
-            serde_json::json!([1, 2])
+            serde_json::json!([1, 2, 3])
         );
 
         let runner_identity = test_runner_identity();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -1,10 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { RunFailureReasonToken } from "@okouai/api-contracts/contracts/run-failure-reasons";
-import type {
-  ConnectorRuntimeTargetRegistration,
-  PiModelConfigV2,
-} from "@okouai/api-contracts/contracts/runners";
+import type { ConnectorRuntimeTargetRegistration } from "@okouai/api-contracts/contracts/runners";
 import type {
   TestRuntimeStateActionBody,
   TestRuntimeStateActionResponse,
@@ -643,13 +640,13 @@ export async function mutateRunnerJobSecretValueEnvironmentKeys(
   });
 }
 
-export async function setRunnerJobPiContextAsV2Writer(
+export async function setRunnerJobPiContextAsVersionedWriter(
   context: TestContext,
   runId: string,
-  piModelConfig: PiModelConfigV2,
+  piModelConfig: Readonly<Record<string, unknown>>,
 ): Promise<void> {
   await postAction(context, {
-    action: "set-runner-job-pi-context-as-v2-writer",
+    action: "set-runner-job-pi-context-as-versioned-writer",
     run_id: runId,
     pi_model_config: piModelConfig,
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -18,7 +18,7 @@ import {
   type ConnectorRuntimeSyncResult,
   type ExecutionContext,
   type Job as RunnerJob,
-  type PiModelConfigV2,
+  type PiModelConfig,
 } from "@okouai/api-contracts/contracts/runners";
 import type { CreateCustomConnectorBody } from "@okouai/api-contracts/contracts/custom-connectors";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
@@ -159,7 +159,7 @@ import {
   setRunModelProviderStateFixture,
   setRunnerJobConnectorRuntimeTargets,
   setRunnerJobContextProfileAsPreviousApi,
-  setRunnerJobPiContextAsV2Writer,
+  setRunnerJobPiContextAsVersionedWriter,
 } from "./helpers/runtime-state";
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 import {
@@ -10434,50 +10434,150 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("leaves Pi V2 jobs queued until a capable Runner claims them", async () => {
-    const api = createRunsApi(context);
-    const { actor, agentId, runnerGroup } = await entitledRunActor();
-    const run = await api.createRun(actor, {
-      agentId,
-      prompt: "claim a dialect-aware Pi route",
-      modelProvider: "anthropic-api-key",
-    });
-    const piModelConfig: PiModelConfigV2 = {
-      schemaVersion: 2,
-      dialect: "openai-responses",
-      transport: "sse",
-      provider: "openai",
-      baseUrl: "https://api.openai.com/v1",
-      model: "gpt-5.4",
-      credentialBindings: [
-        {
-          kind: "api-key",
-          environment: "OPENAI_API_KEY",
-          secretName: "OPENAI_API_KEY",
-        },
-      ],
-    };
-    await setRunnerJobPiContextAsV2Writer(context, run.runId, piModelConfig);
-    await api.heartbeatRunner(runnerGroup);
+  // Current admission cannot produce generation 3 or future/invalid rows.
+  // The explicit stored-writer fixture exercises claim/read API behavior first.
+  it.each([1, 2, 3] as const)(
+    "claims stored Pi generation %s only with compatible capabilities",
+    async (generation) => {
+      const api = createRunsApi(context);
+      const { actor, agentId, runnerGroup } = await entitledRunActor();
+      const run = await api.createRun(actor, {
+        agentId,
+        prompt: "claim a dialect-aware Pi route",
+        modelProvider: "anthropic-api-key",
+      });
+      const piModelConfig: PiModelConfig =
+        generation === 1
+          ? {
+              provider: "openai",
+              baseUrl: "https://api.openai.com/v1",
+              model: "gpt-5.6-terra",
+              apiKeyEnv: "OPENAI_API_KEY",
+              credentialSecretName: "OPENAI_API_KEY",
+            }
+          : generation === 3
+            ? {
+                schemaVersion: 3,
+                dialect: "openai-codex-responses",
+                transport: "sse",
+                provider: "openai-codex",
+                baseUrl: "https://chatgpt.com/backend-api",
+                model: "gpt-5.6-terra",
+                serviceTier: "fast",
+                credentialBindings: [
+                  {
+                    kind: "access-token",
+                    environment: "CHATGPT_ACCESS_TOKEN",
+                    secretName: "CHATGPT_ACCESS_TOKEN",
+                  },
+                  {
+                    kind: "account-id",
+                    environment: "CHATGPT_ACCOUNT_ID",
+                    secretName: "CHATGPT_ACCOUNT_ID",
+                  },
+                ],
+              }
+            : {
+                schemaVersion: 2,
+                dialect: "openai-responses",
+                transport: "sse",
+                provider: "openai",
+                baseUrl: "https://api.openai.com/v1",
+                model: "gpt-5.4",
+                credentialBindings: [
+                  {
+                    kind: "api-key",
+                    environment: "OPENAI_API_KEY",
+                    secretName: "OPENAI_API_KEY",
+                  },
+                ],
+              };
+      await setRunnerJobPiContextAsVersionedWriter(
+        context,
+        run.runId,
+        piModelConfig,
+      );
+      await api.heartbeatRunner(runnerGroup);
 
-    const legacyClaim = await api.requestClaimRunnerJob(true, run.runId, [404]);
-    expectApiError(legacyClaim.body);
-    expect(legacyClaim.body.error.message).toBe("Job not found in queue");
-    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
-      status: "pending",
-    });
+      const incompatibleCapabilities =
+        generation === 3
+          ? [undefined, { piModelConfigGenerations: [1, 2] }]
+          : generation === 2
+            ? [undefined]
+            : [];
+      for (const capabilities of incompatibleCapabilities) {
+        const legacyClaim = await api.requestClaimRunnerJob(
+          true,
+          run.runId,
+          [404],
+          { capabilities },
+        );
+        expectApiError(legacyClaim.body);
+        expect(legacyClaim.body.error.message).toBe("Job not found in queue");
+        await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+          status: "pending",
+        });
+      }
 
-    const capableClaim = await api.claimRunnerJob(run.runId, {
-      capabilities: { piModelConfigGenerations: [1, 2] },
-    });
-    expect(capableClaim).toMatchObject({
-      cliAgentType: "pi",
-      piSessionId: run.runId,
-      piModelConfig,
-    });
+      const capableClaim = await api.claimRunnerJob(run.runId, {
+        capabilities: { piModelConfigGenerations: [1, 2, 3] },
+      });
+      expect(capableClaim).toMatchObject({
+        cliAgentType: "pi",
+        piSessionId: run.runId,
+        piModelConfig,
+      });
 
-    await api.requestCancelRun(actor, run.runId, [200]);
-  });
+      await api.requestCancelRun(actor, run.runId, [200]);
+    },
+  );
+
+  it.each([
+    {
+      schemaVersion: 4,
+      serviceTier: "priority",
+      status: 404,
+      runStatus: "pending",
+    },
+    { schemaVersion: 3, serviceTier: "fast", status: 400, runStatus: "failed" },
+  ] as const)(
+    "handles stored Pi generation $schemaVersion with $serviceTier without downgrading",
+    async (route) => {
+      const api = createRunsApi(context);
+      const { actor, agentId, runnerGroup } = await entitledRunActor();
+      const run = await api.createRun(actor, {
+        agentId,
+        prompt: "claim only a supported exact Pi route",
+        modelProvider: "anthropic-api-key",
+      });
+      await setRunnerJobPiContextAsVersionedWriter(context, run.runId, {
+        schemaVersion: route.schemaVersion,
+        serviceTier: route.serviceTier,
+        dialect: "openai-responses",
+        transport: "sse",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        model: "gpt-5.6-terra",
+        credentialBindings: [
+          {
+            kind: "api-key",
+            environment: "OPENAI_API_KEY",
+            secretName: "OPENAI_API_KEY",
+          },
+        ],
+      });
+      await api.heartbeatRunner(runnerGroup);
+      await api.requestClaimRunnerJob(true, run.runId, [route.status], {
+        capabilities: { piModelConfigGenerations: [1, 2, 3, 4] },
+      });
+      await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+        status: route.runStatus,
+      });
+      if (route.runStatus === "pending") {
+        await api.requestCancelRun(actor, run.runId, [200]);
+      }
+    },
+  );
 
   it("restores prepared masking values from direct run environments", async () => {
     const bdd = createBddApi(context);

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -1006,19 +1006,19 @@ async function mutateRunnerJobSecretValueEnvironmentKeys(
   signal.throwIfAborted();
 }
 
-type SetRunnerJobPiContextAsV2WriterAction = Extract<
+type SetRunnerJobPiContextAsVersionedWriterAction = Extract<
   TestRuntimeStateActionBody,
-  { action: "set-runner-job-pi-context-as-v2-writer" }
+  { action: "set-runner-job-pi-context-as-versioned-writer" }
 >;
 
-async function setRunnerJobPiContextAsV2Writer(
+async function setRunnerJobPiContextAsVersionedWriter(
   db: Db,
-  body: SetRunnerJobPiContextAsV2WriterAction,
+  body: SetRunnerJobPiContextAsVersionedWriterAction,
   signal: AbortSignal,
 ): Promise<void> {
-  // Current production writers stay legacy-only. This fixture models a queued
-  // row emitted by the later V2 activation slice so claim compatibility can be
-  // verified before that writer exists.
+  // Production writers still emit generations 1/2. This fixture models a
+  // stored route from each supported writer so claim compatibility is tested
+  // before generation 3 admission activates in #31803.
   const piContext = {
     cliAgentType: "pi",
     piSessionId: body.run_id,
@@ -1045,7 +1045,7 @@ async function setRunnerJobPiContextAsV2Writer(
     .returning({ runId: runnerJobQueue.runId });
   signal.throwIfAborted();
   if (!updated) {
-    throw new Error("Expected a queued runner job for Pi V2 context update");
+    throw new Error("Expected a queued runner job for Pi context update");
   }
 }
 
@@ -2634,8 +2634,8 @@ const postRuntimeStateAction$ = command(
         );
         return { status: 200 as const, body: { ok: true as const } };
       }
-      case "set-runner-job-pi-context-as-v2-writer": {
-        await setRunnerJobPiContextAsV2Writer(db, body, signal);
+      case "set-runner-job-pi-context-as-versioned-writer": {
+        await setRunnerJobPiContextAsVersionedWriter(db, body, signal);
         return { status: 200 as const, body: { ok: true as const } };
       }
       case "set-runner-job-connector-runtime-targets": {

--- a/turbo/apps/api/src/signals/services/__tests__/pi-sandbox-config.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-sandbox-config.test.ts
@@ -280,6 +280,44 @@ describe("Pi sandbox model configuration", () => {
     ).toBeNull();
   });
 
+  it.each(STANDARD_TERRA_API_KEY_ROUTES)(
+    "keeps $type Fast on Codex before Pi ownership",
+    (route) => {
+      expect(
+        resolvePiSandboxModelConfig(
+          {
+            type: route.type,
+            environment: {
+              OPENAI_API_KEY: "opaque-provider-placeholder",
+              OPENAI_BASE_URL: route.baseUrl,
+              OPENAI_MODEL: route.model,
+            },
+            selectedModel: "gpt-5.6-terra",
+          },
+          "fast",
+        ),
+      ).toBeNull();
+      expect(
+        shouldUsePiExecution({
+          modelProviderType: route.type,
+          selectedModel: "gpt-5.6-terra",
+          codexServiceTier: "fast",
+          triggerSource: "web",
+          chatThreadId: "thread-1",
+          builtInModelRuntimeRoute: undefined,
+          featureSwitchContext: {
+            userId: "user-1",
+            orgId: "org-1",
+            overrides: {
+              [FeatureSwitchKey.PiLoop]: true,
+              [FeatureSwitchKey.CodexFastMode]: true,
+            },
+          },
+        }),
+      ).toBeFalsy();
+    },
+  );
+
   it("rejects mismatched API-key provider identity and endpoint", () => {
     expect(
       resolvePiSandboxModelConfig({

--- a/turbo/apps/api/src/signals/services/pi-model-config-claim-capability.ts
+++ b/turbo/apps/api/src/signals/services/pi-model-config-claim-capability.ts
@@ -1,9 +1,11 @@
 import {
   PI_MODEL_CONFIG_CURRENT_GENERATION,
+  PI_MODEL_CONFIG_DIALECT_TIER_GENERATION,
   PI_MODEL_CONFIG_LEGACY_GENERATION,
   piModelConfigLegacySchema,
   piModelConfigSchema,
   piModelConfigV2Schema,
+  piModelConfigV3Schema,
   type PiModelConfig,
   type RunnerClaimCapabilities,
 } from "@okouai/api-contracts/contracts/runners";
@@ -79,6 +81,12 @@ export function resolvePiModelConfigForClaim(args: {
   }
   if (generation === PI_MODEL_CONFIG_CURRENT_GENERATION) {
     const parsed = piModelConfigV2Schema.safeParse(args.modelConfig);
+    return parsed.success
+      ? { status: "compatible", modelConfig: parsed.data }
+      : { status: "invalid", error: parsed.error };
+  }
+  if (generation === PI_MODEL_CONFIG_DIALECT_TIER_GENERATION) {
+    const parsed = piModelConfigV3Schema.safeParse(args.modelConfig);
     return parsed.success
       ? { status: "compatible", modelConfig: parsed.data }
       : { status: "invalid", error: parsed.error };

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -1,3 +1,4 @@
+import { zstdDecompressSync } from "node:zlib";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
@@ -190,7 +191,10 @@ class ProviderHarness {
           chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
         }
         const body = JSON.parse(
-          Buffer.concat(chunks).toString("utf8"),
+          (request.headers["content-encoding"] === "zstd"
+            ? zstdDecompressSync(Buffer.concat(chunks))
+            : Buffer.concat(chunks)
+          ).toString("utf8"),
         ) as unknown;
         const sequence = harness.requests.length + 1;
         const providerRequest: ProviderRequest = {
@@ -410,13 +414,16 @@ function prepareDeepSeekModel(session: MemoryPiSession, baseUrl: string): void {
 function prepareTerraModel(
   session: MemoryPiSession,
   baseUrl: string,
-  provider: "openai" | "openrouter" = "openai",
+  provider: "openai" | "openrouter" | "openai-codex" = "openai",
 ): void {
   session.prepareModelTurn(
     {
       id: provider === "openrouter" ? "openai/gpt-5.6-terra" : "gpt-5.6-terra",
       name: "GPT 5.6 Terra",
-      api: "openai-responses",
+      api:
+        provider === "openai-codex"
+          ? "openai-codex-responses"
+          : "openai-responses",
       provider,
       baseUrl,
       reasoning: true,
@@ -443,8 +450,8 @@ async function startOwnershipTransferHost(args: {
     | "settled-session-continuation";
   readonly baseSessionSha256: string | null;
   readonly providerBaseUrl: string;
-  readonly model?: "deepseek" | "openrouter-terra" | "terra";
-  readonly serviceTier?: "priority";
+  readonly model?: "deepseek" | "openrouter-terra" | "terra" | "codex-terra";
+  readonly serviceTier?: "priority" | "fast";
 }): Promise<{
   readonly host: RpcHost;
   readonly handoffServer: Server;
@@ -527,26 +534,56 @@ async function startOwnershipTransferHost(args: {
     OKOU_RUN_ID: RUN_ID,
     OKOU_PI_SESSION_ID: SESSION_ID,
     OKOU_PI_LAUNCH_PAYLOAD_FILE: payloadFile,
-    OKOU_PI_MODEL_CONFIG: JSON.stringify({
-      provider: openrouter ? "openrouter" : terra ? "openai" : "deepseek",
-      baseUrl: args.providerBaseUrl,
-      model: openrouter
-        ? "openai/gpt-5.6-terra"
-        : terra
-          ? "gpt-5.6-terra"
-          : "deepseek-v4-flash",
-      ...(terra
-        ? { api: "openai-responses" as const, thinkingLevel: "low" as const }
-        : {}),
-      ...(args.serviceTier ? { serviceTier: args.serviceTier } : {}),
-      apiKeyEnv: "OPENAI_API_KEY",
-      credentialSecretName: openrouter
-        ? "OPENROUTER_API_KEY"
-        : terra
-          ? "OPENAI_API_KEY"
-          : "DEEPSEEK_API_KEY",
-    }),
+    OKOU_PI_MODEL_CONFIG: JSON.stringify(
+      args.model === "codex-terra"
+        ? {
+            schemaVersion: 3,
+            dialect: "openai-codex-responses",
+            transport: "sse",
+            provider: "openai-codex",
+            baseUrl: args.providerBaseUrl,
+            model: "gpt-5.6-terra",
+            thinkingLevel: "low",
+            serviceTier: args.serviceTier,
+            credentialBindings: [
+              {
+                kind: "access-token",
+                environment: "CHATGPT_ACCESS_TOKEN",
+                secretName: "CHATGPT_ACCESS_TOKEN",
+              },
+              {
+                kind: "account-id",
+                environment: "CHATGPT_ACCOUNT_ID",
+                secretName: "CHATGPT_ACCOUNT_ID",
+              },
+            ],
+          }
+        : {
+            provider: openrouter ? "openrouter" : terra ? "openai" : "deepseek",
+            baseUrl: args.providerBaseUrl,
+            model: openrouter
+              ? "openai/gpt-5.6-terra"
+              : terra
+                ? "gpt-5.6-terra"
+                : "deepseek-v4-flash",
+            ...(terra
+              ? {
+                  api: "openai-responses" as const,
+                  thinkingLevel: "low" as const,
+                }
+              : {}),
+            ...(args.serviceTier ? { serviceTier: args.serviceTier } : {}),
+            apiKeyEnv: "OPENAI_API_KEY",
+            credentialSecretName: openrouter
+              ? "OPENROUTER_API_KEY"
+              : terra
+                ? "OPENAI_API_KEY"
+                : "DEEPSEEK_API_KEY",
+          },
+    ),
     OPENAI_API_KEY: "pi-ownership-transfer-test-key",
+    CHATGPT_ACCESS_TOKEN: "opaque-access-token-placeholder",
+    CHATGPT_ACCOUNT_ID: "opaque-account-id-placeholder",
   };
   return {
     host: new RpcHost({ cwd: args.root, agentDir, sessionDir, env }),
@@ -711,16 +748,69 @@ describe("sandbox Pi agent loop", () => {
     });
   });
 
-  it("materializes only the opaque subscription placeholders from V2", async () => {
-    const env = piEnv({ OKOU_RUN_ID: RUN_ID });
-    env.OKOU_PI_MODEL_CONFIG = JSON.stringify({
-      schemaVersion: 2,
+  it.each([2, 3] as const)(
+    "materializes exact subscription bindings from generation %s",
+    async (schemaVersion) => {
+      const env = piEnv({ OKOU_RUN_ID: RUN_ID });
+      env.OKOU_PI_MODEL_CONFIG = JSON.stringify({
+        schemaVersion,
+        ...(schemaVersion === 3 ? { serviceTier: "fast" } : {}),
+        dialect: "openai-codex-responses",
+        transport: "sse",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        model: "gpt-5.6-terra",
+        thinkingLevel: "low",
+        credentialBindings: [
+          {
+            kind: "access-token",
+            environment: "CHATGPT_ACCESS_TOKEN",
+            secretName: "CHATGPT_ACCESS_TOKEN",
+          },
+          {
+            kind: "account-id",
+            environment: "CHATGPT_ACCOUNT_ID",
+            secretName: "CHATGPT_ACCOUNT_ID",
+          },
+        ],
+      });
+      delete env.OPENAI_API_KEY;
+      env.CHATGPT_ACCESS_TOKEN = "opaque-access-token-placeholder";
+      env.CHATGPT_ACCOUNT_ID = "opaque-account-id-placeholder";
+
+      await expect(piSandboxAgentConfigFromEnv(env)).resolves.toMatchObject({
+        model: {
+          provider: "openai-codex",
+          baseUrl: "https://chatgpt.com/backend-api",
+          model: "gpt-5.6-terra",
+          api: "openai-codex-responses",
+          ...(schemaVersion === 3 ? { serviceTier: "fast" } : {}),
+          dialect: "openai-codex-responses",
+          transport: "sse",
+          apiKey: "opaque-access-token-placeholder",
+          accountId: "opaque-account-id-placeholder",
+        },
+      });
+    },
+  );
+
+  it.each([
+    {
+      dialect: "openai-responses",
+      provider: "openai",
+      serviceTier: "fast",
+      credentialBindings: [
+        {
+          kind: "api-key",
+          environment: "OPENAI_API_KEY",
+          secretName: "OPENAI_API_KEY",
+        },
+      ],
+    },
+    {
       dialect: "openai-codex-responses",
-      transport: "sse",
       provider: "openai-codex",
-      baseUrl: "https://chatgpt.com/backend-api",
-      model: "gpt-5.6-terra",
-      thinkingLevel: "low",
+      serviceTier: "priority",
       credentialBindings: [
         {
           kind: "access-token",
@@ -733,24 +823,21 @@ describe("sandbox Pi agent loop", () => {
           secretName: "CHATGPT_ACCOUNT_ID",
         },
       ],
-    });
-    delete env.OPENAI_API_KEY;
-    env.CHATGPT_ACCESS_TOKEN = "opaque-access-token-placeholder";
-    env.CHATGPT_ACCOUNT_ID = "opaque-account-id-placeholder";
-
-    await expect(piSandboxAgentConfigFromEnv(env)).resolves.toMatchObject({
-      model: {
-        provider: "openai-codex",
-        baseUrl: "https://chatgpt.com/backend-api",
-        model: "gpt-5.6-terra",
-        api: "openai-codex-responses",
-        dialect: "openai-codex-responses",
+    },
+  ])(
+    "rejects generation 3 $serviceTier on $dialect before credential materialization",
+    async (route) => {
+      const env = piEnv({ OKOU_RUN_ID: RUN_ID });
+      env.OKOU_PI_MODEL_CONFIG = JSON.stringify({
+        ...route,
+        schemaVersion: 3,
         transport: "sse",
-        apiKey: "opaque-access-token-placeholder",
-        accountId: "opaque-account-id-placeholder",
-      },
-    });
-  });
+        baseUrl: "https://example.test/v1",
+        model: "gpt-5.6-terra",
+      });
+      await expect(piSandboxAgentConfigFromEnv(env)).rejects.toThrow();
+    },
+  );
 
   it("requires the run id", async () => {
     await expect(piSandboxAgentConfigFromEnv(piEnv({}))).rejects.toThrowError(
@@ -796,124 +883,149 @@ describe("sandbox Pi agent loop", () => {
     }
   });
 
-  it("restores Terra H1, executes its pending tool, and checkpoints H2", async () => {
-    const root = await mkdtemp(join(tmpdir(), "vm0-pi-terra-handoff-rpc-"));
-    const sourceFile = join(root, "terra-handoff-source.txt");
-    const prompt = "read the Terra handoff source exactly once";
-    const provider = await ProviderHarness.start();
-    const memory = MemoryPiSession.create({ cwd: root, id: SESSION_ID });
-    prepareTerraModel(memory, provider.baseUrl, "openrouter");
-    memory.appendMessage({ role: "user", content: prompt, timestamp: 1 });
-    memory.appendMessage({
-      role: "assistant",
-      content: [
-        {
-          type: "thinking",
-          thinking: "Terra reasoning preserved for the Okou handoff",
-          thinkingSignature: JSON.stringify({
-            type: "reasoning",
-            id: "rs_terra_okou_handoff",
-            content: [
-              {
-                type: "reasoning_text",
-                text: "Terra reasoning preserved for the Okou handoff",
-              },
-            ],
-            summary: [],
-          }),
+  it.each(["openrouter-terra", "codex-terra"] as const)(
+    "restores %s H1, executes its pending tool, and checkpoints H2",
+    async (route) => {
+      const root = await mkdtemp(join(tmpdir(), "vm0-pi-terra-handoff-rpc-"));
+      const sourceFile = join(root, "terra-handoff-source.txt");
+      const prompt = "read the Terra handoff source exactly once";
+      const provider = await ProviderHarness.start();
+      const memory = MemoryPiSession.create({ cwd: root, id: SESSION_ID });
+      prepareTerraModel(
+        memory,
+        provider.baseUrl,
+        route === "codex-terra" ? "openai-codex" : "openrouter",
+      );
+      memory.appendMessage({ role: "user", content: prompt, timestamp: 1 });
+      memory.appendMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Terra reasoning preserved for the Okou handoff",
+            thinkingSignature: JSON.stringify({
+              type: "reasoning",
+              id: "rs_terra_okou_handoff",
+              content: [
+                {
+                  type: "reasoning_text",
+                  text: "Terra reasoning preserved for the Okou handoff",
+                },
+              ],
+              summary: [],
+            }),
+          },
+          {
+            type: "toolCall",
+            id: "api-terra-read-call",
+            name: "read",
+            arguments: { path: sourceFile },
+          },
+        ],
+        api:
+          route === "codex-terra"
+            ? "openai-codex-responses"
+            : "openai-responses",
+        provider: route === "codex-terra" ? "openai-codex" : "openrouter",
+        model:
+          route === "codex-terra" ? "gpt-5.6-terra" : "openai/gpt-5.6-terra",
+        usage: {
+          input: 5,
+          output: 3,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 8,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
         },
-        {
-          type: "toolCall",
-          id: "api-terra-read-call",
-          name: "read",
-          arguments: { path: sourceFile },
-        },
-      ],
-      api: "openai-responses",
-      provider: "openrouter",
-      model: "openai/gpt-5.6-terra",
-      usage: {
-        input: 5,
-        output: 3,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 8,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      stopReason: "toolUse",
-      timestamp: 2,
-    });
-    const h1 = memory.toJsonl();
-    let host: RpcHost | undefined;
-    let handoffServer: Server | undefined;
-
-    try {
-      await writeFile(
-        sourceFile,
-        "Terra tool output from the sandbox filesystem",
-      );
-      const started = await startOwnershipTransferHost({
-        root,
-        jsonl: h1,
-        mode: "pending-tool-continuation",
-        baseSessionSha256: null,
-        providerBaseUrl: provider.baseUrl,
-        model: "openrouter-terra",
-        serviceTier: "priority",
+        stopReason: "toolUse",
+        timestamp: 2,
       });
-      host = started.host;
-      handoffServer = started.handoffServer;
+      const h1 = memory.toJsonl();
+      let host: RpcHost | undefined;
+      let handoffServer: Server | undefined;
 
-      const state = await host.state("terra-handoff-state");
-      expect(host.records[0]).toStrictEqual({
-        type: "vm0_pi_api_first_turn_boundary",
-        schemaVersion: 2,
-        sandboxEventSequenceStart: 4,
-        ownershipTransferMode: "pending-tool-continuation",
-      });
-      expect(state).toMatchObject({ sessionId: SESSION_ID, messageCount: 2 });
-      expect(String(state.sessionFile)).toContain("api-first-turn-");
+      try {
+        await writeFile(
+          sourceFile,
+          "Terra tool output from the sandbox filesystem",
+        );
+        const started = await startOwnershipTransferHost({
+          root,
+          jsonl: h1,
+          mode: "pending-tool-continuation",
+          baseSessionSha256: null,
+          providerBaseUrl: provider.baseUrl,
+          model: route,
+          serviceTier: route === "codex-terra" ? "fast" : "priority",
+        });
+        host = started.host;
+        handoffServer = started.handoffServer;
 
-      host.send({ id: "terra-handoff", type: "prompt", message: prompt });
-      const continuationRequest = await provider.nextRequest();
-      const continuationBody = JSON.stringify(continuationRequest.body);
-      expect(continuationBody).toContain(
-        "Terra tool output from the sandbox filesystem",
-      );
-      expect(continuationBody).toContain("rs_terra_okou_handoff");
-      expect(occurrences(continuationBody, prompt)).toBe(1);
-      expect(continuationRequest.body).toMatchObject({
-        service_tier: "priority",
-      });
-      continuationRequest.respond("Terra Okou handoff complete");
-      await host.waitFor((record) => {
-        return record.type === "agent_settled";
-      });
-      await host.close();
-      host = undefined;
+        const state = await host.state("terra-handoff-state");
+        expect(host.records[0]).toStrictEqual({
+          type: "vm0_pi_api_first_turn_boundary",
+          schemaVersion: 2,
+          sandboxEventSequenceStart: 4,
+          ownershipTransferMode: "pending-tool-continuation",
+        });
+        expect(state).toMatchObject({ sessionId: SESSION_ID, messageCount: 2 });
+        expect(String(state.sessionFile)).toContain("api-first-turn-");
 
-      expect(provider.requests).toHaveLength(1);
-      const persisted = await readFile(String(state.sessionFile), "utf8");
-      expect(occurrences(persisted, prompt)).toBe(1);
-      expect(persisted).not.toContain("serviceTier");
-      expect(persisted).not.toContain("service_tier");
-      expect(persisted).toContain("api-terra-read-call");
-      expect(persisted).toContain(
-        "Terra tool output from the sandbox filesystem",
-      );
-      expect(persisted).toContain("Terra Okou handoff complete");
-      expect(MemoryPiSession.fromJsonl(persisted).isSettledCheckpoint()).toBe(
-        true,
-      );
-    } finally {
-      await host?.terminate();
-      if (handoffServer) {
-        await closeServer(handoffServer);
+        host.send({ id: "terra-handoff", type: "prompt", message: prompt });
+        const continuationRequest = await provider.nextRequest();
+        const continuationBody = JSON.stringify(continuationRequest.body);
+        expect(continuationBody).toContain(
+          "Terra tool output from the sandbox filesystem",
+        );
+        expect(continuationBody).toContain("rs_terra_okou_handoff");
+        expect(occurrences(continuationBody, prompt)).toBe(1);
+        expect(continuationRequest.body).toMatchObject({
+          service_tier: route === "codex-terra" ? "fast" : "priority",
+        });
+        continuationRequest.respond("Terra Okou handoff complete");
+        await host.waitFor((record) => {
+          return record.type === "agent_settled";
+        });
+        host.send({
+          id: "terra-followup",
+          type: "prompt",
+          message: "answer one more turn",
+        });
+        const nextRequest = await provider.nextRequest();
+        expect(nextRequest.body).toMatchObject({
+          service_tier: route === "codex-terra" ? "fast" : "priority",
+        });
+        nextRequest.respond("Terra followup complete");
+        await host.waitFor((record) => {
+          return record.type === "agent_settled";
+        });
+        await host.close();
+        host = undefined;
+
+        expect(provider.requests).toHaveLength(2);
+        const persisted = await readFile(String(state.sessionFile), "utf8");
+        expect(occurrences(persisted, prompt)).toBe(1);
+        expect(persisted).not.toContain("serviceTier");
+        expect(persisted).not.toContain("service_tier");
+        expect(persisted).toContain("api-terra-read-call");
+        expect(persisted).toContain(
+          "Terra tool output from the sandbox filesystem",
+        );
+        expect(persisted).toContain("Terra Okou handoff complete");
+        expect(MemoryPiSession.fromJsonl(persisted).isSettledCheckpoint()).toBe(
+          true,
+        );
+      } finally {
+        await host?.terminate();
+        if (handoffServer) {
+          await closeServer(handoffServer);
+        }
+        await provider.close();
+        await rm(root, { recursive: true, force: true });
       }
-      await provider.close();
-      await rm(root, { recursive: true, force: true });
-    }
-  }, 30_000);
+    },
+    30_000,
+  );
 
   it("keeps standard Terra tierless on the sandbox-first AgentSession call", async () => {
     const root = await mkdtemp(join(tmpdir(), "vm0-pi-sandbox-first-rpc-"));

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -21,6 +21,7 @@ import {
   piModelConfigLegacySchema,
   piModelConfigSchema,
   piModelConfigV2Schema,
+  piModelConfigV3Schema,
   RUNNER_CANCELLATION_RECOVERY_GRACE_MS,
   RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX,
   RUNNER_POLL_EXCLUDED_RUN_IDS_MAX,
@@ -420,109 +421,156 @@ describe("Pi sandbox execution contract", () => {
     }
   });
 
-  it("accepts only exact dialect-aware credential binding sets", () => {
-    const publicResponses = {
-      schemaVersion: 2,
-      dialect: "openai-responses",
-      transport: "sse",
-      provider: "openai",
-      baseUrl: "https://api.openai.com/v1",
-      model: "gpt-5.6-terra",
-      thinkingLevel: "low",
-      credentialBindings: [
-        {
-          kind: "api-key",
-          environment: "OPENAI_API_KEY",
-          secretName: "OPENAI_API_KEY",
-        },
-      ],
-    } as const;
-    const codexResponses = {
-      schemaVersion: 2,
-      dialect: "openai-codex-responses",
-      transport: "sse",
-      provider: "openai-codex",
-      baseUrl: "https://chatgpt.com/backend-api",
-      model: "gpt-5.6-terra",
-      thinkingLevel: "low",
-      credentialBindings: [
-        {
-          kind: "account-id",
-          environment: "CHATGPT_ACCOUNT_ID",
-          secretName: "CHATGPT_ACCOUNT_ID",
-        },
-        {
-          kind: "access-token",
-          environment: "CHATGPT_ACCESS_TOKEN",
-          secretName: "CHATGPT_ACCESS_TOKEN",
-        },
-      ],
-    } as const;
-
-    expect(piModelConfigV2Schema.parse(publicResponses)).toEqual(
-      publicResponses,
-    );
-    expect(piModelConfigV2Schema.parse(codexResponses)).toEqual(codexResponses);
-    expect(piModelConfigSchema.parse(publicResponses)).toEqual(publicResponses);
-    expect(piModelConfigSchema.parse(codexResponses)).toEqual(codexResponses);
-    expect(piModelConfigLegacySchema.safeParse(codexResponses).success).toBe(
-      false,
-    );
-
-    for (const invalid of [
-      { ...publicResponses, transport: "auto" },
-      { ...publicResponses, provider: "openai-codex" },
-      { ...publicResponses, credentialBindings: [] },
-      {
-        ...publicResponses,
-        credentialBindings: [
-          publicResponses.credentialBindings[0],
-          publicResponses.credentialBindings[0],
-        ],
-      },
-      {
-        ...publicResponses,
-        credentialBindings: [
-          {
-            kind: "api-key",
-            environment: "CHATGPT_ACCESS_TOKEN",
-            secretName: "OPENAI_API_KEY",
-          },
-        ],
-      },
-      {
-        ...publicResponses,
+  it.each([2, 3] as const)(
+    "accepts only exact generation %s dialect-aware credential binding sets",
+    (schemaVersion) => {
+      const schema =
+        schemaVersion === 2 ? piModelConfigV2Schema : piModelConfigV3Schema;
+      const publicResponses = {
+        schemaVersion,
+        dialect: "openai-responses",
+        transport: "sse",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        model: "gpt-5.6-terra",
+        thinkingLevel: "low",
         credentialBindings: [
           {
             kind: "api-key",
             environment: "OPENAI_API_KEY",
-            secretName: "CHATGPT_REFRESH_TOKEN",
+            secretName: "OPENAI_API_KEY",
           },
         ],
-      },
-      {
-        ...codexResponses,
-        credentialBindings: [codexResponses.credentialBindings[1]],
-      },
-      {
-        ...codexResponses,
-        serviceTier: "priority",
-      },
-      {
-        ...codexResponses,
+      } as const;
+      const codexResponses = {
+        schemaVersion,
+        dialect: "openai-codex-responses",
+        transport: "sse",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        model: "gpt-5.6-terra",
+        thinkingLevel: "low",
         credentialBindings: [
-          ...codexResponses.credentialBindings,
           {
-            kind: "id-token",
-            environment: "CHATGPT_ID_TOKEN",
-            secretName: "CHATGPT_ID_TOKEN",
+            kind: "account-id",
+            environment: "CHATGPT_ACCOUNT_ID",
+            secretName: "CHATGPT_ACCOUNT_ID",
+          },
+          {
+            kind: "access-token",
+            environment: "CHATGPT_ACCESS_TOKEN",
+            secretName: "CHATGPT_ACCESS_TOKEN",
           },
         ],
-      },
-    ]) {
-      expect(piModelConfigV2Schema.safeParse(invalid).success).toBe(false);
-    }
-  });
+      } as const;
+
+      expect(schema.parse(publicResponses)).toEqual(publicResponses);
+      expect(schema.parse(codexResponses)).toEqual(codexResponses);
+      expect(piModelConfigSchema.parse(publicResponses)).toEqual(
+        publicResponses,
+      );
+      expect(piModelConfigSchema.parse(codexResponses)).toEqual(codexResponses);
+      expect(piModelConfigLegacySchema.safeParse(codexResponses).success).toBe(
+        false,
+      );
+
+      for (const serviceTier of [
+        undefined,
+        "priority",
+        "fast",
+        "default",
+        "unknown",
+        null,
+      ]) {
+        for (const config of [publicResponses, codexResponses]) {
+          const candidate = {
+            ...config,
+            ...(serviceTier === undefined ? {} : { serviceTier }),
+          };
+          const expected =
+            serviceTier === undefined ||
+            (config.dialect === "openai-responses"
+              ? serviceTier === "priority"
+              : schemaVersion === 3 && serviceTier === "fast");
+          expect(piModelConfigSchema.safeParse(candidate).success).toBe(
+            expected,
+          );
+          expect(schema.safeParse(candidate).success).toBe(expected);
+          if (schemaVersion === 3) {
+            expect(piModelConfigV2Schema.safeParse(candidate).success).toBe(
+              false,
+            );
+          }
+        }
+      }
+
+      for (const invalid of [
+        { ...publicResponses, transport: "auto" },
+        { ...publicResponses, extra: true },
+        { ...publicResponses, thinkingLevel: "future" },
+        { ...publicResponses, catalogModel: "x".repeat(513) },
+        { ...codexResponses, catalogModel: "gpt-5.6-terra" },
+        { ...codexResponses, provider: "openai" },
+        {
+          ...codexResponses,
+          credentialBindings: [
+            codexResponses.credentialBindings[0],
+            codexResponses.credentialBindings[0],
+          ],
+        },
+        { ...publicResponses, provider: "openai-codex" },
+        { ...publicResponses, credentialBindings: [] },
+        {
+          ...publicResponses,
+          credentialBindings: [
+            publicResponses.credentialBindings[0],
+            publicResponses.credentialBindings[0],
+          ],
+        },
+        {
+          ...publicResponses,
+          credentialBindings: [
+            {
+              kind: "api-key",
+              environment: "CHATGPT_ACCESS_TOKEN",
+              secretName: "OPENAI_API_KEY",
+            },
+          ],
+        },
+        {
+          ...publicResponses,
+          credentialBindings: [
+            {
+              kind: "api-key",
+              environment: "OPENAI_API_KEY",
+              secretName: "CHATGPT_REFRESH_TOKEN",
+            },
+          ],
+        },
+        {
+          ...codexResponses,
+          credentialBindings: [codexResponses.credentialBindings[1]],
+        },
+        {
+          ...codexResponses,
+          serviceTier: "priority",
+        },
+        {
+          ...codexResponses,
+          credentialBindings: [
+            ...codexResponses.credentialBindings,
+            {
+              kind: "id-token",
+              environment: "CHATGPT_ID_TOKEN",
+              secretName: "CHATGPT_ID_TOKEN",
+            },
+          ],
+        },
+      ]) {
+        expect(schema.safeParse(invalid).success).toBe(false);
+      }
+    },
+  );
 
   it.each([
     {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -81,7 +81,9 @@ export const CANCELLATION_RECOVERY_STALE_AFTER_MS =
 export const BUILTIN_FIREWALL_CATALOG_CACHE_SCHEMA_VERSION = 1;
 export const RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX = 512;
 export const PI_MODEL_CONFIG_LEGACY_GENERATION = 1;
+// Existing versioned writers stay on generation 2 until their activation slice.
 export const PI_MODEL_CONFIG_CURRENT_GENERATION = 2;
+export const PI_MODEL_CONFIG_DIALECT_TIER_GENERATION = 3;
 export const RUNNER_CLAIM_PI_MODEL_CONFIG_GENERATIONS_MAX = 8;
 export const sessionHistoryEncodingSchema = z.enum([
   SESSION_HISTORY_ENCODING_IDENTITY,
@@ -1027,12 +1029,15 @@ const piModelCredentialBindingSchema = z.discriminatedUnion("kind", [
 ]);
 
 /**
- * Additive Pi route generation for dialect-aware readers. Current writers keep
- * emitting `piModelConfigLegacySchema` until a later activation slice.
+ * Shared strict route invariants. Generations are separate wire contracts;
+ * adding a reader must not move existing writers to a newer generation.
  */
-export const piModelConfigV2Schema = z
+const piModelConfigVersionedSchema = z
   .object({
-    schemaVersion: z.literal(PI_MODEL_CONFIG_CURRENT_GENERATION),
+    schemaVersion: z.union([
+      z.literal(PI_MODEL_CONFIG_CURRENT_GENERATION),
+      z.literal(PI_MODEL_CONFIG_DIALECT_TIER_GENERATION),
+    ]),
     dialect: z.enum(["openai-responses", "openai-codex-responses"]),
     transport: z.literal("sse"),
     provider: z.enum(["deepseek", "openai", "openrouter", "openai-codex"]),
@@ -1042,7 +1047,7 @@ export const piModelConfigV2Schema = z
     thinkingLevel: z
       .enum(["off", "minimal", "low", "medium", "high", "xhigh", "max"])
       .optional(),
-    serviceTier: z.enum(["priority"]).optional(),
+    serviceTier: z.enum(["priority", "fast"]).optional(),
     credentialBindings: z.array(piModelCredentialBindingSchema).min(1).max(2),
   })
   .strict()
@@ -1102,19 +1107,49 @@ export const piModelConfigV2Schema = z
         message: "Codex Responses uses its provider model as the catalog model",
       });
     }
-    if (config.serviceTier !== undefined) {
+    if (
+      config.schemaVersion === PI_MODEL_CONFIG_CURRENT_GENERATION &&
+      config.serviceTier !== undefined
+    ) {
       refinement.addIssue({
         code: "custom",
         path: ["serviceTier"],
         message: "Codex Responses does not accept a public API service tier",
       });
     }
+  });
+
+export const piModelConfigV2Schema = piModelConfigVersionedSchema
+  .safeExtend({
+    schemaVersion: z.literal(PI_MODEL_CONFIG_CURRENT_GENERATION),
+    serviceTier: z.enum(["priority"]).optional(),
   })
+  .readonly();
+
+/** Additive reader capability only; route writers activate separately in #31803. */
+export const piModelConfigV3Schema = z
+  .discriminatedUnion("dialect", [
+    piModelConfigVersionedSchema.safeExtend({
+      schemaVersion: z.literal(PI_MODEL_CONFIG_DIALECT_TIER_GENERATION),
+      dialect: z.literal("openai-responses"),
+      transport: z.enum(["sse"]),
+      provider: z.enum(["deepseek", "openai", "openrouter"]),
+      serviceTier: z.enum(["priority"]).optional(),
+    }),
+    piModelConfigVersionedSchema.safeExtend({
+      schemaVersion: z.literal(PI_MODEL_CONFIG_DIALECT_TIER_GENERATION),
+      dialect: z.literal("openai-codex-responses"),
+      transport: z.enum(["sse"]),
+      provider: z.enum(["openai-codex"]),
+      serviceTier: z.enum(["fast"]).optional(),
+    }),
+  ])
   .readonly();
 
 export const piModelConfigSchema = z.union([
   piModelConfigLegacySchema,
   piModelConfigV2Schema,
+  piModelConfigV3Schema,
 ]);
 
 /**
@@ -1687,6 +1722,7 @@ export type StoredExecutionContext = z.infer<
 export type PiModelConfig = z.infer<typeof piModelConfigSchema>;
 export type PiModelConfigLegacy = z.infer<typeof piModelConfigLegacySchema>;
 export type PiModelConfigV2 = z.infer<typeof piModelConfigV2Schema>;
+export type PiModelConfigV3 = z.infer<typeof piModelConfigV3Schema>;
 export type PiModelCredentialBinding = z.infer<
   typeof piModelCredentialBindingSchema
 >;

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -1,9 +1,6 @@
 import { z } from "zod";
 import { initContract } from "./base";
-import {
-  connectorRuntimeTargetsSchema,
-  piModelConfigV2Schema,
-} from "./runners";
+import { connectorRuntimeTargetsSchema } from "./runners";
 import { runFailureReasonTokenSchema } from "./run-failure-reasons";
 
 const c = initContract();
@@ -115,9 +112,11 @@ export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
     mode: z.enum(["remove", "invalid"]),
   }),
   z.object({
-    action: z.literal("set-runner-job-pi-context-as-v2-writer"),
+    action: z.literal("set-runner-job-pi-context-as-versioned-writer"),
     run_id: z.uuid(),
-    pi_model_config: piModelConfigV2Schema,
+    // Stored rows can come from a future or invalid writer. The claim boundary
+    // must validate them, not this test-only fixture endpoint.
+    pi_model_config: z.record(z.string(), z.unknown()),
   }),
   z.object({
     action: z.literal("enable-queued-pi-ownership-transfer"),

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -40,6 +40,7 @@ import {
   CONNECTOR_RUNTIME_SYNC_TARGETS_MAX,
   CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
   PI_MODEL_CONFIG_CURRENT_GENERATION,
+  PI_MODEL_CONFIG_DIALECT_TIER_GENERATION,
   PI_MODEL_CONFIG_LEGACY_GENERATION,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   RUNNER_CANCELLATION_RECOVERY_GRACE_MS,
@@ -301,6 +302,12 @@ const expectedBindings = [
     rustConstName: "PI_MODEL_CONFIG_CURRENT_GENERATION",
     value: rustU32(PI_MODEL_CONFIG_CURRENT_GENERATION),
     rustDoc: ["Current dialect-aware Pi model configuration generation."],
+  },
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "PI_MODEL_CONFIG_DIALECT_TIER_GENERATION",
+    value: rustU32(PI_MODEL_CONFIG_DIALECT_TIER_GENERATION),
+    rustDoc: ["Additive Pi generation with dialect-constrained request tiers."],
   },
   {
     rustModulePath: ["runners"],

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/types.test.ts
@@ -49,6 +49,11 @@ const expectedBindings = [
     direction: "response",
   },
   {
+    rustModulePath: ["runners", "runs"],
+    rustTypeName: "PiModelConfigV3",
+    direction: "response",
+  },
+  {
     rustModulePath: ["runners", "runs", "active_inputs", "reserve"],
     rustTypeName: "Response",
     direction: "response",
@@ -291,6 +296,10 @@ describe("Rust type bindings", () => {
     expect(firstRender).toContain("pub enum PiModelConfigServiceTier {");
     expect(firstRender).toContain("pub enum PiModelConfigApiKeyEnv {");
     expect(firstRender).toContain("pub struct PiModelConfigV2 {");
+    expect(firstRender).toContain("pub enum PiModelConfigV3 {");
+    expect(firstRender).toContain(
+      "pub enum PiModelConfigV3OpenaiCodexResponsesServiceTier {",
+    );
     expect(firstRender).toContain("pub enum PiModelConfigV2Dialect {");
     expect(firstRender).toContain("pub enum PiModelConfigV2Provider {");
     expect(firstRender).toContain(

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -29,6 +29,7 @@ import {
   CONNECTOR_RUNTIME_SYNC_TARGETS_MAX,
   CONNECTOR_RUNTIME_SYNC_RUN_TERMINAL_ERROR_CODE,
   PI_MODEL_CONFIG_CURRENT_GENERATION,
+  PI_MODEL_CONFIG_DIALECT_TIER_GENERATION,
   PI_MODEL_CONFIG_LEGACY_GENERATION,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   RUNNER_CANCELLATION_RECOVERY_GRACE_MS,
@@ -344,6 +345,12 @@ export const rustConstantBindings = [
     rustConstName: "PI_MODEL_CONFIG_CURRENT_GENERATION",
     value: rustU32(PI_MODEL_CONFIG_CURRENT_GENERATION),
     rustDoc: ["Current dialect-aware Pi model configuration generation."],
+  },
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "PI_MODEL_CONFIG_DIALECT_TIER_GENERATION",
+    value: rustU32(PI_MODEL_CONFIG_DIALECT_TIER_GENERATION),
+    rustDoc: ["Additive Pi generation with dialect-constrained request tiers."],
   },
   {
     rustModulePath: ["runners"],

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -9,6 +9,7 @@ import {
   piLaunchConfigSchema,
   piModelConfigLegacySchema,
   piModelConfigV2Schema,
+  piModelConfigV3Schema,
   runnersModelProviderFailuresContract,
   sessionHistoryEncodingSchema,
   storageMountEntrySchema,
@@ -411,6 +412,119 @@ export const rustTypeBindings = [
           ],
         },
       },
+    ],
+  },
+  {
+    schema: piModelConfigV3Schema,
+    rustModulePath: ["runners", "runs"],
+    rustTypeName: "PiModelConfigV3",
+    direction: "response",
+    fieldTypeOverrides: {
+      environment: "String",
+      secretName: "String",
+    },
+    declarations: [
+      {
+        rustTypeName: "PiModelConfigV3",
+        rustDoc: ["API-owned dialect-aware non-secret Pi model configuration."],
+        variants: {
+          "openai-responses": [
+            "Public Responses route with optional priority tier.",
+          ],
+          "openai-codex-responses": [
+            "Native Codex Responses route with optional fast tier.",
+          ],
+        },
+        fields: {
+          schemaVersion: ["Pi model configuration generation."],
+          transport: ["Transport policy selected by the route."],
+          provider: ["Native Pi catalog provider selected by the route."],
+          baseUrl: ["Exact base URL used for model requests."],
+          model: ["Exact provider model identifier sent with requests."],
+          catalogModel: [
+            "Optional native Pi catalog model used for trusted public Responses metadata.",
+          ],
+          thinkingLevel: ["Explicit Pi thinking level."],
+          serviceTier: ["Optional dialect-constrained request service tier."],
+          credentialBindings: [
+            "Bounded non-secret credential bindings materialized only at an execution edge.",
+          ],
+        },
+      },
+      ...(["OpenaiResponses", "OpenaiCodexResponses"] as const).flatMap(
+        (dialect): RustTypeDeclarationDoc[] => {
+          return [
+            {
+              rustTypeName: `PiModelConfigV3${dialect}Transport`,
+              rustDoc: ["Required Responses streaming transport."],
+              variants: { sse: ["Server-sent events only."] },
+            },
+            {
+              rustTypeName: `PiModelConfigV3${dialect}Provider`,
+              rustDoc: ["Native Pi catalog providers for this dialect."],
+              variants:
+                dialect === "OpenaiResponses"
+                  ? {
+                      deepseek: ["DeepSeek provider."],
+                      openai: ["OpenAI public API provider."],
+                      openrouter: ["OpenRouter provider."],
+                    }
+                  : { "openai-codex": ["OpenAI Codex subscription provider."] },
+            },
+            {
+              rustTypeName: `PiModelConfigV3${dialect}ThinkingLevel`,
+              rustDoc: ["Thinking levels supported by Pi sessions."],
+              variants: {
+                off: ["Disable model thinking."],
+                minimal: ["Minimal thinking."],
+                low: ["Low thinking."],
+                medium: ["Medium thinking."],
+                high: ["High thinking."],
+                xhigh: ["Extra-high thinking."],
+                max: ["Maximum thinking."],
+              },
+            },
+            {
+              rustTypeName: `PiModelConfigV3${dialect}ServiceTier`,
+              rustDoc: ["Dialect-constrained request service tiers."],
+              variants:
+                dialect === "OpenaiResponses"
+                  ? { priority: ["Public Responses priority service tier."] }
+                  : { fast: ["Native Codex Responses fast service tier."] },
+            },
+            {
+              rustTypeName: `PiModelConfigV3${dialect}CredentialBinding`,
+              rustDoc: ["One non-secret execution-edge credential binding."],
+              fields: {
+                environment: [
+                  "Sandbox environment entry containing the value.",
+                ],
+                secretName: [
+                  "API-owned encrypted secret containing the value.",
+                ],
+                credentialHeader: [
+                  "Optional non-secret custom gateway header policy.",
+                ],
+              },
+              variants: {
+                "api-key": ["Public Responses API-key binding."],
+                "access-token": ["ChatGPT access-token binding."],
+                "account-id": ["ChatGPT account-ID binding."],
+              },
+            },
+            {
+              rustTypeName: `PiModelConfigV3${dialect}CredentialBindingApiKeyCredentialHeader`,
+              rustDoc: ["Non-secret custom gateway credential header policy."],
+              fields: {
+                name: ["Request header name."],
+                valueTemplate: [
+                  "Header value template containing the credential placeholder exactly once.",
+                ],
+              },
+            },
+          ];
+        },
+      ),
     ],
   },
   {

--- a/turbo/packages/pi-agent-runtime/src/api.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.test.ts
@@ -1,5 +1,8 @@
+import { zstdDecompressSync } from "node:zlib";
 import { createServer, type ServerResponse } from "node:http";
 
+import { piModelConfigSchema } from "@okouai/api-contracts/contracts/runners";
+import { materializePiAgentModelConfig } from "./credential";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
@@ -309,115 +312,168 @@ describe("Pi API facade", () => {
     });
   });
 
-  it("normalizes legacy transport input and applies Terra request policy", async () => {
-    const providerRequests: Array<{
-      readonly url: string | undefined;
-      readonly body: unknown;
-    }> = [];
-    const server = createServer((request, response) => {
-      void (async () => {
-        const chunks: Buffer[] = [];
-        for await (const chunk of request) {
-          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-        }
-        providerRequests.push({
-          url: request.url,
-          body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown,
-        });
-        responsesTextSse(response, "Terra API-first answer");
-      })().catch((error: unknown) => {
-        response.destroy(
-          error instanceof Error ? error : new Error(String(error)),
-        );
-      });
-    });
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        server.off("error", reject);
-        resolve();
-      });
-    });
-    const address = server.address();
-    if (address === null || typeof address === "string") {
-      throw new Error("Terra API-first test server has no TCP address");
-    }
-
-    try {
-      const runTurn = async (
-        serviceTier: "priority" | undefined,
-        api: "openai-completions" | "openai-codex-responses",
-      ) => {
-        return runPiApiFirstTurn({
-          cwd: "/home/user/workspace",
-          agentDir: "/home/user/.pi/agent",
-          sessionId: SESSION_ID,
-          prompt: "answer through Terra",
-          appendSystemPrompt: null,
-          model: {
-            provider: "openai",
-            baseUrl: `http://127.0.0.1:${address.port}/v1`,
-            apiKey: "test-key",
-            model: "gpt-5.6-terra",
-            api,
-            dialect: "openai-responses",
-            thinkingLevel: "low",
-            ...(serviceTier ? { serviceTier } : {}),
-          },
-          resourceSnapshot: { schemaVersion: 1, agentsFiles: [], skills: [] },
-          ownership: createPiApiFirstTurnOwnership(),
-        });
-      };
-      const standardResult = await runTurn(undefined, "openai-completions");
-      const priorityResult = await runTurn(
-        "priority",
-        "openai-codex-responses",
-      );
-
-      expect(providerRequests).toHaveLength(2);
-      expect(providerRequests[0]).toMatchObject({
-        url: "/v1/responses",
-        body: {
-          model: "gpt-5.6-terra",
-          reasoning: { effort: "low" },
-        },
-      });
-      expect(providerRequests[0]?.body).not.toHaveProperty("service_tier");
-      expect(providerRequests[1]).toMatchObject({
-        url: "/v1/responses",
-        body: {
-          model: "gpt-5.6-terra",
-          reasoning: { effort: "low" },
-          service_tier: "priority",
-        },
-      });
-      expect(standardResult.assistantMessage.content).toStrictEqual([
-        { type: "text", text: "Terra API-first answer" },
-      ]);
-      expect(priorityResult.assistantMessage.content).toStrictEqual([
-        { type: "text", text: "Terra API-first answer" },
-      ]);
-      expect(standardResult.observedServiceTier).toBeUndefined();
-      expect(priorityResult.observedServiceTier).toBeUndefined();
-      expect(priorityResult.sessionJsonl).not.toContain("serviceTier");
-      expect(priorityResult.sessionJsonl).not.toContain("service_tier");
-      expect(
-        MemoryPiSession.fromJsonl(
-          priorityResult.sessionJsonl,
-        ).buildSessionContext().thinkingLevel,
-      ).toBe("low");
-    } finally {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve();
+  it.each(["public", "native"] as const)(
+    "applies %s Terra API-first request policy",
+    async (route) => {
+      const providerRequests: Array<{
+        readonly url: string | undefined;
+        readonly body: unknown;
+        readonly accountId: string | string[] | undefined;
+      }> = [];
+      const server = createServer((request, response) => {
+        void (async () => {
+          const chunks: Buffer[] = [];
+          for await (const chunk of request) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
           }
+          providerRequests.push({
+            url: request.url,
+            accountId: request.headers["chatgpt-account-id"],
+            body: JSON.parse(
+              (request.headers["content-encoding"] === "zstd"
+                ? zstdDecompressSync(Buffer.concat(chunks))
+                : Buffer.concat(chunks)
+              ).toString("utf8"),
+            ) as unknown,
+          });
+          responsesTextSse(response, "Terra API-first answer");
+        })().catch((error: unknown) => {
+          response.destroy(
+            error instanceof Error ? error : new Error(String(error)),
+          );
         });
       });
-    }
-  });
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+          server.off("error", reject);
+          resolve();
+        });
+      });
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        throw new Error("Terra API-first test server has no TCP address");
+      }
+
+      try {
+        const runTurn = async (
+          serviceTier: "priority" | "fast" | undefined,
+          api: "openai-completions" | "openai-codex-responses",
+        ) => {
+          return runPiApiFirstTurn({
+            cwd: "/home/user/workspace",
+            agentDir: "/home/user/.pi/agent",
+            sessionId: SESSION_ID,
+            prompt: "answer through Terra",
+            appendSystemPrompt: null,
+            model:
+              route === "native"
+                ? await materializePiAgentModelConfig({
+                    config: piModelConfigSchema.parse({
+                      schemaVersion: 3,
+                      dialect: "openai-codex-responses",
+                      transport: "sse",
+                      provider: "openai-codex",
+                      baseUrl: `http://127.0.0.1:${address.port}/v1`,
+                      model: "gpt-5.6-terra",
+                      thinkingLevel: "low",
+                      ...(serviceTier === undefined ? {} : { serviceTier }),
+                      credentialBindings: [
+                        {
+                          kind: "access-token",
+                          environment: "CHATGPT_ACCESS_TOKEN",
+                          secretName: "CHATGPT_ACCESS_TOKEN",
+                        },
+                        {
+                          kind: "account-id",
+                          environment: "CHATGPT_ACCOUNT_ID",
+                          secretName: "CHATGPT_ACCOUNT_ID",
+                        },
+                      ],
+                    }),
+                    target: "direct",
+                    resolveCredential(binding) {
+                      return binding.kind === "account-id"
+                        ? "exact-account-id"
+                        : "opaque-access-token";
+                    },
+                  })
+                : {
+                    provider: "openai",
+                    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+                    apiKey: "test-key",
+                    model: "gpt-5.6-terra",
+                    api,
+                    dialect: "openai-responses",
+                    thinkingLevel: "low",
+                    ...(serviceTier ? { serviceTier } : {}),
+                  },
+            resourceSnapshot: { schemaVersion: 1, agentsFiles: [], skills: [] },
+            ownership: createPiApiFirstTurnOwnership(),
+          });
+        };
+        const standardResult = await runTurn(undefined, "openai-completions");
+        const priorityResult = await runTurn(
+          route === "native" ? "fast" : "priority",
+          "openai-codex-responses",
+        );
+
+        expect(providerRequests).toHaveLength(2);
+        if (route === "native") {
+          expect(
+            providerRequests.map((request) => {
+              return request.accountId;
+            }),
+          ).toEqual(["exact-account-id", "exact-account-id"]);
+          for (const request of providerRequests) {
+            expect(request.body).toMatchObject({ store: false, stream: true });
+            expect(request.body).not.toHaveProperty("previous_response_id");
+          }
+        }
+        expect(providerRequests[0]).toMatchObject({
+          url: route === "native" ? "/v1/codex/responses" : "/v1/responses",
+          body: {
+            model: "gpt-5.6-terra",
+            reasoning: { effort: "low" },
+          },
+        });
+        expect(providerRequests[0]?.body).not.toHaveProperty("service_tier");
+        expect(providerRequests[1]).toMatchObject({
+          url: route === "native" ? "/v1/codex/responses" : "/v1/responses",
+          body: {
+            model: "gpt-5.6-terra",
+            reasoning: { effort: "low" },
+            service_tier: route === "native" ? "fast" : "priority",
+          },
+        });
+        expect(standardResult.assistantMessage.content).toStrictEqual([
+          { type: "text", text: "Terra API-first answer" },
+        ]);
+        expect(priorityResult.assistantMessage.content).toStrictEqual([
+          { type: "text", text: "Terra API-first answer" },
+        ]);
+        expect(standardResult.observedServiceTier).toBeUndefined();
+        expect(priorityResult.observedServiceTier).toBeUndefined();
+        expect(priorityResult.sessionJsonl).not.toContain("serviceTier");
+        expect(priorityResult.sessionJsonl).not.toContain("service_tier");
+        expect(
+          MemoryPiSession.fromJsonl(
+            priorityResult.sessionJsonl,
+          ).buildSessionContext().thinkingLevel,
+        ).toBe("low");
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        });
+      }
+    },
+  );
 
   it("sends direct DeepSeek through Responses with the stable Pi identity and no Chat fields", async () => {
     const providerRequests: Array<{

--- a/turbo/packages/pi-agent-runtime/src/credential.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/credential.test.ts
@@ -80,6 +80,51 @@ describe("Pi agent credential resolution", () => {
     },
   );
 
+  it.each(["direct", "sandbox-firewall"] as const)(
+    "materializes generation 3 public priority at the %s edge",
+    async (target) => {
+      const config = piModelConfigSchema.parse({
+        schemaVersion: 3,
+        dialect: "openai-responses",
+        transport: "sse",
+        provider: "openai",
+        baseUrl: "https://gateway.example.test/v1",
+        model: "gpt-5.6-terra",
+        serviceTier: "priority",
+        credentialBindings: [
+          {
+            kind: "api-key",
+            environment: "OPENAI_API_KEY",
+            secretName: "OPENAI_API_KEY",
+          },
+        ],
+      });
+      const materialized = await materializePiAgentModelConfig({
+        config,
+        target,
+        resolveCredential(binding) {
+          expect(binding.environment).toBe("OPENAI_API_KEY");
+          return target === "direct"
+            ? "selected-provider-key"
+            : "opaque-key-placeholder";
+        },
+      });
+      expect(materialized).toEqual({
+        provider: "openai",
+        baseUrl: "https://gateway.example.test/v1",
+        model: "gpt-5.6-terra",
+        serviceTier: "priority",
+        dialect: "openai-responses",
+        api: "openai-responses",
+        transport: "sse",
+        apiKey:
+          target === "direct"
+            ? "selected-provider-key"
+            : "opaque-key-placeholder",
+      });
+    },
+  );
+
   it("materializes legacy routes as public Responses", async () => {
     const config = piModelConfigSchema.parse({
       provider: "openai",
@@ -110,56 +155,61 @@ describe("Pi agent credential resolution", () => {
     });
   });
 
-  it("materializes both exact subscription values from the same binding set", async () => {
-    const config = piModelConfigSchema.parse({
-      schemaVersion: 2,
-      dialect: "openai-codex-responses",
-      transport: "sse",
-      provider: "openai-codex",
-      baseUrl: "https://chatgpt.com/backend-api",
-      model: "gpt-5.6-terra",
-      thinkingLevel: "low",
-      credentialBindings: [
-        {
-          kind: "account-id",
-          environment: "CHATGPT_ACCOUNT_ID",
-          secretName: "CHATGPT_ACCOUNT_ID",
-        },
-        {
-          kind: "access-token",
-          environment: "CHATGPT_ACCESS_TOKEN",
-          secretName: "CHATGPT_ACCESS_TOKEN",
-        },
-      ],
-    });
-    const resolutionOrder: string[] = [];
-    await expect(
-      materializePiAgentModelConfig({
-        config,
-        target: "direct",
-        resolveCredential(binding) {
-          resolutionOrder.push(binding.kind);
-          switch (binding.environment) {
-            case "CHATGPT_ACCESS_TOKEN":
-              return "opaque-access-token";
-            case "CHATGPT_ACCOUNT_ID":
-              return "account-id";
-            default:
-              throw new Error("Unexpected subscription binding");
-          }
-        },
-      }),
-    ).resolves.toStrictEqual({
-      provider: "openai-codex",
-      baseUrl: "https://chatgpt.com/backend-api",
-      model: "gpt-5.6-terra",
-      thinkingLevel: "low",
-      api: "openai-codex-responses",
-      dialect: "openai-codex-responses",
-      transport: "sse",
-      apiKey: "opaque-access-token",
-      accountId: "account-id",
-    });
-    expect(resolutionOrder).toStrictEqual(["access-token", "account-id"]);
-  });
+  it.each([2, 3] as const)(
+    "materializes exact subscription bindings from generation %s",
+    async (schemaVersion) => {
+      const config = piModelConfigSchema.parse({
+        schemaVersion,
+        ...(schemaVersion === 3 ? { serviceTier: "fast" } : {}),
+        dialect: "openai-codex-responses",
+        transport: "sse",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        model: "gpt-5.6-terra",
+        thinkingLevel: "low",
+        credentialBindings: [
+          {
+            kind: "account-id",
+            environment: "CHATGPT_ACCOUNT_ID",
+            secretName: "CHATGPT_ACCOUNT_ID",
+          },
+          {
+            kind: "access-token",
+            environment: "CHATGPT_ACCESS_TOKEN",
+            secretName: "CHATGPT_ACCESS_TOKEN",
+          },
+        ],
+      });
+      const resolutionOrder: string[] = [];
+      await expect(
+        materializePiAgentModelConfig({
+          config,
+          target: "direct",
+          resolveCredential(binding) {
+            resolutionOrder.push(binding.kind);
+            switch (binding.environment) {
+              case "CHATGPT_ACCESS_TOKEN":
+                return "opaque-access-token";
+              case "CHATGPT_ACCOUNT_ID":
+                return "account-id";
+              default:
+                throw new Error("Unexpected subscription binding");
+            }
+          },
+        }),
+      ).resolves.toStrictEqual({
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        model: "gpt-5.6-terra",
+        thinkingLevel: "low",
+        api: "openai-codex-responses",
+        ...(schemaVersion === 3 ? { serviceTier: "fast" } : {}),
+        dialect: "openai-codex-responses",
+        transport: "sse",
+        apiKey: "opaque-access-token",
+        accountId: "account-id",
+      });
+      expect(resolutionOrder).toStrictEqual(["access-token", "account-id"]);
+    },
+  );
 });

--- a/turbo/packages/pi-agent-runtime/src/model.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.test.ts
@@ -1,3 +1,6 @@
+import { zstdDecompressSync } from "node:zlib";
+import { once } from "node:events";
+import { createServer, type IncomingHttpHeaders } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 
 import { piAgentStreamForConfig, resolvePiAgentModel } from "./model";
@@ -9,6 +12,52 @@ const OPENAI_TERRA = {
   model: "gpt-5.6-terra",
   dialect: "openai-responses",
 } as const;
+
+async function retryableCodexProvider() {
+  const requests: Array<{ headers: IncomingHttpHeaders; body: unknown }> = [];
+  const server = createServer((request, response) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      const bytes = Buffer.concat(chunks);
+      requests.push({
+        headers: request.headers,
+        body: JSON.parse(
+          (request.headers["content-encoding"] === "zstd"
+            ? zstdDecompressSync(bytes)
+            : bytes
+          ).toString("utf8"),
+        ) as unknown,
+      });
+      response.writeHead(429, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "stop" } }));
+    })().catch((error: unknown) => {
+      response.destroy(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected a TCP provider address");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    close() {
+      return new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}
 
 describe("Pi agent model adapter", () => {
   it.each([
@@ -201,54 +250,81 @@ describe("Pi agent model adapter", () => {
     ).toBeNull();
   });
 
-  it("passes an explicit account ID to native Codex Responses over SSE", async () => {
-    const config = {
-      provider: "openai-codex",
-      baseUrl: "https://chatgpt.com/backend-api",
-      model: "gpt-5.6-terra",
-      apiKey: "opaque-not-a-jwt",
-      accountId: "account-id-from-binding",
-      dialect: "openai-codex-responses",
-      transport: "sse",
-    } as const;
-    const model = resolvePiAgentModel(config);
-    if (!model || model.api !== "openai-codex-responses") {
-      throw new Error("Expected a native Codex Responses model");
-    }
-    let requestHeaders: Headers | undefined;
-    const providerFetch = vi.fn(
-      async (
-        _input: Parameters<typeof globalThis.fetch>[0],
-        init?: Parameters<typeof globalThis.fetch>[1],
-      ) => {
-        requestHeaders = new Headers(init?.headers);
-        return new Response(JSON.stringify({ error: { message: "stop" } }), {
-          status: 401,
-          headers: { "content-type": "application/json" },
+  it.each([
+    { dialect: "openai-responses", serviceTier: "fast" },
+    { dialect: "openai-codex-responses", serviceTier: "priority" },
+  ] as const)(
+    "rejects $serviceTier on $dialect before a provider request",
+    (policy) => {
+      const config = {
+        ...OPENAI_TERRA,
+        ...policy,
+        provider:
+          policy.dialect === "openai-codex-responses"
+            ? "openai-codex"
+            : "openai",
+        accountId: "exact-account-id",
+        transport: "sse" as const,
+      };
+      expect(resolvePiAgentModel(config)).toBeNull();
+      const model = resolvePiAgentModel({ ...config, serviceTier: undefined });
+      if (!model) throw new Error("Expected a supported standard model");
+      expect(() => {
+        return piAgentStreamForConfig(config)(model, {
+          messages: [],
+          tools: [],
         });
-      },
-    );
+      }).toThrow("service tier");
+    },
+  );
 
-    const stream = piAgentStreamForConfig(config)(
-      model,
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 1 }],
-        tools: [],
-      },
-      { apiKey: config.apiKey, fetch: providerFetch },
-    );
-    for await (const _event of stream) {
-      // Drain the expected provider error so the adapter completes its task.
-    }
-
-    expect(providerFetch).toHaveBeenCalledOnce();
-    expect(requestHeaders?.get("authorization")).toBe(
-      "Bearer opaque-not-a-jwt",
-    );
-    expect(requestHeaders?.get("chatgpt-account-id")).toBe(
-      "account-id-from-binding",
-    );
-  });
+  it.each([undefined, "fast"] as const)(
+    "passes an explicit account ID to native Codex Responses over SSE with tier %s",
+    async (serviceTier) => {
+      const provider = await retryableCodexProvider();
+      try {
+        const config = {
+          provider: "openai-codex",
+          baseUrl: provider.baseUrl,
+          model: "gpt-5.6-terra",
+          apiKey: "opaque-not-a-jwt",
+          accountId: "account-id-from-binding",
+          dialect: "openai-codex-responses",
+          transport: "sse",
+          serviceTier,
+        } as const;
+        const model = resolvePiAgentModel(config);
+        if (!model || model.api !== "openai-codex-responses") {
+          throw new Error("Expected a native Codex Responses model");
+        }
+        const stream = piAgentStreamForConfig(config)(
+          model,
+          {
+            messages: [{ role: "user", content: "hello", timestamp: 1 }],
+            tools: [],
+          },
+          { apiKey: config.apiKey, serviceTier: "priority" },
+        );
+        for await (const _event of stream) {
+          // Drain the retryable provider error so the adapter completes its task.
+        }
+        expect(provider.requests).toHaveLength(1);
+        const request = provider.requests[0];
+        if (serviceTier === undefined) {
+          expect(request?.body).not.toHaveProperty("service_tier");
+        } else {
+          expect(request?.body).toMatchObject({ service_tier: "fast" });
+        }
+        expect(request?.body).toMatchObject({ store: false, stream: true });
+        expect(request?.headers.authorization).toBe("Bearer opaque-not-a-jwt");
+        expect(request?.headers["chatgpt-account-id"]).toBe(
+          "account-id-from-binding",
+        );
+      } finally {
+        await provider.close();
+      }
+    },
+  );
 
   it("preserves a native Codex Responses tool call over forced SSE", async () => {
     const config = {

--- a/turbo/packages/pi-agent-runtime/src/model.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.ts
@@ -64,6 +64,12 @@ function streamSimpleResponsesWithPolicy(
   context: Context,
   options?: PiAgentStreamOptions,
 ): AssistantMessageEventStream {
+  const serviceTier = options?.serviceTier;
+  if (serviceTier !== undefined && serviceTier !== "priority") {
+    throw new Error(
+      "Pi public Responses only accepts the priority service tier",
+    );
+  }
   const base = buildBaseOptions(model, context, options, options?.apiKey);
   const clampedReasoning =
     options?.reasoning === undefined
@@ -79,7 +85,7 @@ function streamSimpleResponsesWithPolicy(
             options.onObservedServiceTier,
           ),
     reasoningEffort: clampedReasoning === "off" ? undefined : clampedReasoning,
-    serviceTier: options?.serviceTier,
+    serviceTier,
   });
 }
 
@@ -213,6 +219,10 @@ function piAgentCodexStream(
   accountId: string,
   options?: PiAgentStreamOptions,
 ): AssistantMessageEventStream {
+  const serviceTier = options?.serviceTier;
+  if (serviceTier !== undefined && serviceTier !== "fast") {
+    throw new Error("Pi Codex Responses only accepts the fast service tier");
+  }
   const base = buildBaseOptions(model, context, options, options?.apiKey);
   const clampedReasoning =
     options?.reasoning === undefined
@@ -228,7 +238,7 @@ function piAgentCodexStream(
             options.onObservedServiceTier,
           ),
     reasoningEffort: clampedReasoning === "off" ? undefined : clampedReasoning,
-    serviceTier: options?.serviceTier,
+    serviceTier,
     accountId,
     maxRetries: 0,
     transport: "sse",
@@ -272,9 +282,8 @@ export function piAgentStreamForConfig(
         "User-Agent": PI_AGENT_USER_AGENT,
         ...config.requestHeaders,
       },
-      ...(config.serviceTier === undefined
-        ? {}
-        : { serviceTier: config.serviceTier }),
+      // The immutable route owns tier even when standard omits it.
+      serviceTier: config.serviceTier,
     };
     if (config.dialect === "openai-responses") {
       if (!isResponsesModel(model)) {
@@ -308,6 +317,13 @@ export function piAgentStreamForConfig(
 export function resolvePiAgentModel(
   config: PiAgentModelConfig,
 ): Model<"openai-responses"> | Model<"openai-codex-responses"> | null {
+  if (
+    config.serviceTier !== undefined &&
+    config.serviceTier !==
+      (config.dialect === "openai-codex-responses" ? "fast" : "priority")
+  ) {
+    return null;
+  }
   const source = sourceModel(
     config.provider,
     config.catalogModel ?? config.model,

--- a/turbo/packages/pi-agent-runtime/src/types.ts
+++ b/turbo/packages/pi-agent-runtime/src/types.ts
@@ -10,7 +10,7 @@ export const PI_AGENT_THINKING_LEVELS = [
 
 export type PiAgentThinkingLevel = (typeof PI_AGENT_THINKING_LEVELS)[number];
 
-export type PiAgentServiceTier = "priority";
+export type PiAgentServiceTier = "priority" | "fast";
 
 export type PiAgentDialect = "openai-responses" | "openai-codex-responses";
 

--- a/turbo/patches/@earendil-works__pi-ai@0.84.1.patch
+++ b/turbo/patches/@earendil-works__pi-ai@0.84.1.patch
@@ -9,7 +9,8 @@ index 704476da084be53d6aa194a5f774fa3ad47f5e9a..ffd6c5bde0ddd3b480af7bac0b49492a
 +    accountId?: string;
      reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
      reasoningSummary?: "auto" | "concise" | "detailed" | "off" | "on" | null;
-     serviceTier?: ResponseCreateParamsStreaming["service_tier"];
+-    serviceTier?: ResponseCreateParamsStreaming["service_tier"];
++    serviceTier?: ResponseCreateParamsStreaming["service_tier"] | "fast";
 diff --git a/dist/api/openai-codex-responses.js b/dist/api/openai-codex-responses.js
 index 603ab2e3b082669045b7ecb849bd33f45918bce5..7ba136bcec10b3319108a6748fe1b0c5b3bb8a97 100644
 --- a/dist/api/openai-codex-responses.js

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -86,7 +86,7 @@ overrides:
 
 patchedDependencies:
   '@earendil-works/pi-ai@0.84.1':
-    hash: e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e
+    hash: 727723aa6e61d3d9460e1bf669828c77a1ed0b2d49231a284d11cb6e3e931734
     path: patches/@earendil-works__pi-ai@0.84.1.patch
   '@earendil-works/pi-coding-agent@0.84.1':
     hash: 370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289
@@ -1147,7 +1147,7 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=727723aa6e61d3d9460e1bf669828c77a1ed0b2d49231a284d11cb6e3e931734)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
         version: 0.84.1(patch_hash=370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
@@ -11211,7 +11211,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
-      '@earendil-works/pi-ai': 0.84.1(patch_hash=e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.84.1(patch_hash=727723aa6e61d3d9460e1bf669828c77a1ed0b2d49231a284d11cb6e3e931734)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-telemetry': 0.84.1
       diff: 8.0.4
       ignore: 7.0.5
@@ -11225,7 +11225,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.84.1(patch_hash=e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
+  '@earendil-works/pi-ai@0.84.1(patch_hash=727723aa6e61d3d9460e1bf669828c77a1ed0b2d49231a284d11cb6e3e931734)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -11254,7 +11254,7 @@ snapshots:
   '@earendil-works/pi-coding-agent@0.84.1(patch_hash=370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
-      '@earendil-works/pi-ai': 0.84.1(patch_hash=e48c1a8d19be960cf1c6537b1321d466cfbf235897b6b7935c4b80c464e4496e)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.84.1(patch_hash=727723aa6e61d3d9460e1bf669828c77a1ed0b2d49231a284d11cb6e3e931734)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-client': 0.84.2
       '@earendil-works/pi-protocol': 0.84.2
       '@earendil-works/pi-tui': 0.84.2


### PR DESCRIPTION
Terra subscription Fast requires native Codex `service_tier: "fast"`, which generation-2 Runners reject. Add a separate generation-3 carrier and execution capability while existing standard writers continue emitting generation 2 and every user-owned Fast route remains on Codex.

The new TypeScript discriminated union and generated Rust enum constrain public Responses to absent/`priority` and native Codex Responses to absent/`fast`. API claim parsing and Runner validation support generations 1/2/3 without downgrading unknown generations. The Pi adapter forwards the immutable route tier on API-first and every Sandbox continuation request, with explicit account ID, SSE, and zero adapter retries; session identity and Pi JSONL remain tier-free.

Closes #31804. Parent: #31803.

## Deployment compatibility

- Generation 1 and the exact generation-2 reader remain supported; existing generated generation-2 Rust output is unchanged. `PI_MODEL_CONFIG_CURRENT_GENERATION` stays `2`; the new capability has its own constant.
- An old claimant with no capabilities or `[1,2]` leaves generation-3 work pending. A new `[1,2,3]` claimant reads stored generations 1/2/3; an unknown generation stays pending even if advertised, and malformed supported carriers fail closed.
- Existing API writers still produce only generations 1/2, so old API/Runner/commit-addressed CLI combinations retain their existing contract. Subscription and API-key admission changes are separate slices of #31803 after this foundation is accepted.
- Existing standard user-owned and Built-in Fast admission, endpoints, credentials, and accounting are unchanged. No session compatibility, pricing, model/default, UI, feature switch, migration, or production deployment changes are included.

## Validation

Focused checks cover strict route/binding matrices, Rust deserialization and Runner execution, real PostgreSQL claim behavior, exact execution-edge credentials, native/public HTTP request bodies, retry ownership, Sandbox tool handoff and later turns, and tier-free JSONL.

- Focused Vitest: contracts/binding generation **148**, Pi runtime **57**, CLI **21**, admission **70**, and PostgreSQL claim **5** selected cases passed. Contracts, admission and claim cases were rerun after rebasing onto `dd6fa9c`.
- Rust: `cargo test -p api-contracts` **39 passed**; Runner context matrix **11 passed** and claim capability serialization **1 passed**.
- API, CLI, api-contracts, and pi-agent-runtime package typechecks passed, including the runtime public-declaration boundary.
- Scoped Turbo lint (affected packages and dependencies), Knip, Prettier, `cargo fmt --all -- --check`, affected-crate Clippy and rustdoc passed.
- Canonical `generate:rust` rerun produced identical output; frozen lockfile installation and `git diff --check` passed.

Rust checks used one build job with debug information and incremental artifacts disabled for local memory limits. Full Vitest and development-server validation are left to the PR pipeline as requested.
