### PR TITLE
fix(voice): use supported reasoning for transcription

### DIFF
--- a/turbo/apps/api/src/signals/external/openrouter-voice.ts
+++ b/turbo/apps/api/src/signals/external/openrouter-voice.ts
@@ -6,8 +6,11 @@ import {
 import { z } from "zod";
 
 import { optionalEnv } from "../../lib/env";
+import { logger } from "../../lib/log";
 import { OpenRouterRequestError, type OpenRouterTextPart } from "./openrouter";
 import { readBoundedResponseText, safeJsonParse } from "../utils";
+
+const L = logger("OpenRouterVoice");
 
 const OPENROUTER_CHAT_COMPLETIONS_URL =
   "https://openrouter.ai/api/v1/chat/completions";
@@ -15,6 +18,8 @@ const OPENROUTER_VOICE_RESPONSE_MAX_BYTES = 1024 * 1024;
 const OPENROUTER_VOICE_MAX_TOKENS = 65_536;
 
 const OPENROUTER_VOICE_MODEL = "google/gemini-3.6-flash";
+// Gemini 3.6 Flash requires reasoning and rejects the "none" effort with HTTP 400.
+const OPENROUTER_VOICE_REASONING_EFFORT = "minimal";
 export const OPENROUTER_VOICE_NO_SPEECH = "[NO_SPEECH]";
 
 const TRANSCRIPTION_SYSTEM_PROMPT = [
@@ -298,7 +303,7 @@ async function generateStructuredVoiceResponse<T>(
         { role: "user", content: args.content },
       ],
       max_tokens: OPENROUTER_VOICE_MAX_TOKENS,
-      reasoning: { effort: "none" },
+      reasoning: { effort: OPENROUTER_VOICE_REASONING_EFFORT },
       temperature: 0,
       store: false,
       response_format: {
@@ -316,11 +321,19 @@ async function generateStructuredVoiceResponse<T>(
   const parsedBody =
     responseBody.kind === "text" ? safeJsonParse(responseBody.text) : undefined;
   if (!response.ok) {
-    throw requestError(
+    const error = requestError(
       "OpenRouter voice request failed",
       response.status,
       parsedBody,
     );
+    L.warn("OpenRouter voice request rejected", {
+      model: OPENROUTER_VOICE_MODEL,
+      reasoningEffort: OPENROUTER_VOICE_REASONING_EFFORT,
+      responseSchema: args.jsonSchema.name,
+      status: error.status,
+      errorType: error.errorType,
+    });
+    throw error;
   }
   if (parsedBody === undefined) {
     throw new Error("OpenRouter voice response was not valid JSON");

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
@@ -24,6 +24,10 @@ const mocks = createRouteMocks(context);
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 
 interface OpenRouterRequest {
+  readonly reasoning?: {
+    readonly effort?: string;
+    readonly enabled?: boolean;
+  };
   readonly messages: readonly {
     readonly role: string;
     readonly content:
@@ -144,6 +148,26 @@ function requestAudioParts(request: OpenRouterRequest) {
     throw new Error("Expected a multimodal user message");
   }
   return userMessage.content;
+}
+
+function rejectDisabledReasoning(request: OpenRouterRequest) {
+  if (
+    request.reasoning?.effort === "none" ||
+    request.reasoning?.enabled === false
+  ) {
+    return HttpResponse.json(
+      {
+        error: {
+          message:
+            "Reasoning is mandatory for this endpoint and cannot be disabled.",
+          code: 400,
+          metadata: { provider_name: null },
+        },
+      },
+      { status: 400 },
+    );
+  }
+  return undefined;
 }
 
 describe("POST /api/voice-io/transcribe", () => {
@@ -281,6 +305,10 @@ describe("POST /api/voice-io/transcribe", () => {
     server.use(
       http.post(OPENROUTER_URL, async ({ request }) => {
         providerRequest = (await request.json()) as OpenRouterRequest;
+        const reasoningError = rejectDisabledReasoning(providerRequest);
+        if (reasoningError) {
+          return reasoningError;
+        }
         return HttpResponse.json({
           choices: [
             {
@@ -314,7 +342,7 @@ describe("POST /api/voice-io/transcribe", () => {
     expect(providerRequest).toMatchObject({
       model: "google/gemini-3.6-flash",
       max_tokens: 65_536,
-      reasoning: { effort: "none" },
+      reasoning: { effort: "minimal" },
       temperature: 0,
       store: false,
       response_format: {
@@ -457,6 +485,10 @@ describe("POST /api/voice-io/transcribe", () => {
     server.use(
       http.post(OPENROUTER_URL, async ({ request }) => {
         const body = (await request.json()) as OpenRouterRequest;
+        const reasoningError = rejectDisabledReasoning(body);
+        if (reasoningError) {
+          return reasoningError;
+        }
         const schemaName = body.response_format.json_schema.name;
         schemaNames.push(schemaName);
         return HttpResponse.json({


### PR DESCRIPTION
Voice Draft sends `reasoning.effort: "none"` to `google/gemini-3.6-flash`, which requires reasoning. OpenRouter rejects the request with HTTP 400, and the transcription API returns 502 to the composer.

Use the lowest supported effort, `minimal`, for short recordings, long-recording chunks, and the final polish request. Make the existing short- and long-recording route tests reproduce OpenRouter's mandatory-reasoning rejection, and record bounded diagnostic metadata when a provider request is rejected.

## Validation

- The two relevant route tests return 502 with the old production code; all 9 transcription route tests pass with this fix against an isolated local PostgreSQL database.
- API type checks and Knip passed; Prettier, Oxlint (including type-aware rules), and ESLint passed for the changed files. Commit hooks also passed full Knip, all 15 type-check tasks, file-size checks, and commitlint. The local Knip deadline was extended from 60 to 180 seconds after a timeout.
- Confirmed the model's supported effort levels against the live OpenRouter model catalog and its [mandatory reasoning documentation](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#discovering-per-model-reasoning-options). Provider calls are mocked in the integration tests.
- Full local Vitest checks were not run; repository-wide validation runs in PR CI.
