### PR TITLE
fix(api): require account-explicit app bundles

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -72,6 +72,30 @@ after a backend deployment. When changing an API used by the frontend, keep the
 old request shape working until old browser clients can no longer reasonably be
 active, or introduce a versioned/new endpoint and migrate the frontend first.
 
+#### Connector App retirement
+
+The first singleton-free connector App release is `0.843.1`, built from
+`3795939e97660ef4228122a57e3f6425b1e413c2` and promoted on
+2026-09-05 at 04:24:28 UTC after #29773 / #31780. Issue #29775 raises the API
+App floor to that version in a later release. Verify the deployed artifact,
+not only the GitHub deployment's moving-main SHA: the preceding `0.843.0`
+release deployed `30aadb42008af91a999faac6170262dd1de881cb`, which predates
+the connector producer cleanup.
+
+Older identified App bundles receive `426` before route handling and use the
+existing update dialog to refresh into the supported App. This applies to
+all handled App API requests, not only connector actions; idle pages are not
+automatically refreshed. No passive browser-expiry window or rollback gate
+is required for #29775.
+
+The floor does not retire CLI, unidentified, or missing/unparseable-version
+requests. Keep singleton request and persisted authorization-state decoding
+until their independent gates pass. #29776 must verify the deployed App cutoff
+and inventory the three authorization-state tables before #29777 removes the
+remaining singleton contract. The pre-cutoff production request evidence on
+#29775 is not proof that account mutations were exercised or stored callbacks
+have drained.
+
 ### Backend
 
 The backend is the compatibility boundary for both frontend and runner traffic.

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -1096,25 +1096,47 @@ describe("createApp", () => {
   });
 
   describe("web client compatibility", () => {
-    it("force-upgrades app clients below the Office preview reader floor before route matching", async () => {
+    it.each([
+      { method: "POST", path: "/api/connectors/github/oauth/start" },
+      { method: "PUT", path: "/api/custom-connectors/example/values" },
+      { method: "DELETE", path: "/api/connectors/github" },
+    ])(
+      "force-upgrades singleton-producing App bundles before $method $path route matching",
+      async ({ method, path }) => {
+        const app = createApp({
+          signal: context.signal,
+          routes: TEST_APP_ROUTES,
+        });
+        const response = await app.request(path, {
+          method,
+          headers: {
+            [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
+            [CLIENT_VERSION_HEADER]: "0.843.0",
+          },
+        });
+
+        expect(MINIMUM_WEB_CLIENT_VERSION).toBe("0.843.1");
+        expect(response.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
+        await expect(response.json()).resolves.toStrictEqual({
+          error: "Client update required",
+        });
+        expect(response.headers.get("cache-control")).toBe("no-store");
+      },
+    );
+
+    it("force-upgrades prereleases below the supported App release", async () => {
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,
       });
-      const response = await app.request("/api/connectors/github", {
-        method: "DELETE",
+      const response = await app.request("/health", {
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.830.0",
+          [CLIENT_VERSION_HEADER]: `${MINIMUM_WEB_CLIENT_VERSION}-rc.1`,
         },
       });
 
-      expect(MINIMUM_WEB_CLIENT_VERSION).toBe("0.831.0");
       expect(response.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
-      await expect(response.json()).resolves.toStrictEqual({
-        error: "Client update required",
-      });
-      expect(response.headers.get("cache-control")).toBe("no-store");
     });
 
     it("rejects pre-MCP-reader app clients before custom connector route matching", async () => {
@@ -1157,7 +1179,10 @@ describe("createApp", () => {
       expect(response.headers.get("cache-control")).toBe("no-store");
     });
 
-    it("allows the canonical web client floor", async () => {
+    it.each([
+      MINIMUM_WEB_CLIENT_VERSION,
+      `${MINIMUM_WEB_CLIENT_VERSION}+build.1`,
+    ])("allows the canonical web client floor %s", async (version) => {
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,
@@ -1166,7 +1191,7 @@ describe("createApp", () => {
         method: "GET",
         headers: {
           [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: MINIMUM_WEB_CLIENT_VERSION,
+          [CLIENT_VERSION_HEADER]: version,
         },
       });
 
@@ -1189,7 +1214,42 @@ describe("createApp", () => {
       expect(response.status).toBe(200);
     });
 
-    it("does not force upgrade other client types", async () => {
+    it.each([CLIENT_TYPE_CLI, CLIENT_TYPE_DESKTOP])(
+      "does not force upgrade %s clients",
+      async (clientType) => {
+        const app = createApp({
+          signal: context.signal,
+          routes: TEST_APP_ROUTES,
+        });
+        const response = await app.request("/health", {
+          headers: {
+            [CLIENT_TYPE_HEADER]: clientType,
+            [CLIENT_VERSION_HEADER]: "0.599.18",
+          },
+        });
+
+        expect(response.status).toBe(200);
+      },
+    );
+
+    it.each([undefined, "", "development"])(
+      "preserves App requests without a parseable version (%s)",
+      async (version) => {
+        const app = createApp({
+          signal: context.signal,
+          routes: TEST_APP_ROUTES,
+        });
+        const headers = new Headers({ [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP });
+        if (version !== undefined) {
+          headers.set(CLIENT_VERSION_HEADER, version);
+        }
+        const response = await app.request("/health", { headers });
+
+        expect(response.status).toBe(200);
+      },
+    );
+
+    it("preserves requests without a client type", async () => {
       const app = createApp({
         signal: context.signal,
         routes: TEST_APP_ROUTES,
@@ -1197,8 +1257,7 @@ describe("createApp", () => {
       const response = await app.request("/health", {
         method: "GET",
         headers: {
-          [CLIENT_TYPE_HEADER]: CLIENT_TYPE_CLI,
-          [CLIENT_VERSION_HEADER]: "0.599.18",
+          [CLIENT_VERSION_HEADER]: "0.843.0",
         },
       });
 

--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.831.0"
+  "minimumSupportedVersion": "0.843.1"
 }


### PR DESCRIPTION
## Summary

Closes #29775. Part of #28571 (does not close the delivery parent).

- Raise the existing minimum supported App version from `0.831.0` to `0.843.1`, the first verified deployed release containing the account-explicit Platform cleanup from #29773 / #31780.
- Verify old built-in/custom mutation and target-disconnect requests receive the existing `426` response before route matching. Cover release/prerelease/build-metadata boundaries and unchanged non-App/missing-version behavior.
- Document the deployed artifact and the separate client and persisted-state retirement boundaries.

## User-visible behavior

Already-loaded older App bundles receive the existing non-dismissible update dialog on their next handled API request, including non-connector requests. The user refreshes into an already-live supported App. Idle pages do not automatically reload. No connector UI, account selection, permission, or post-refresh operation flow is changed.

## Deployment and request evidence

- Replacement App: `app-v0.843.1`, artifact `3795939e97660ef4228122a57e3f6425b1e413c2`, promoted **2026-09-05 04:24:28 UTC** in [release run 33944179663](https://github.com/vm0-ai/vm0/actions/runs/33944179663). The live App HTML independently advertises `0.843.1`.
- This is a later API-floor change, not part of the replacement App release. `0.843.0` actually deployed a pre-cleanup artifact; the moving-main SHA on its GitHub deployment record was not the built artifact.
- Read-only request evidence for 04:24:28–04:40:00 UTC: **148 connector-related requests / 25 complete groups**, independently reconciled. New App: 11 successful reads; old App: 2 successful reads. No connector 5xx; one CLI diagnostics 400. [Evidence and limitations](https://github.com/vm0-ai/vm0/issues/29775#issuecomment-5549414227).
- No App account-lifecycle write appeared in that window. Logs do not prove every add/reconnect flow or persisted-state drain; those boundaries remain covered by existing behavior/tests and downstream issues.

## Scope and risks

- Rollback considerations are explicitly excluded by the user; no rollback guard or waiting period is added.
- The global floor intentionally interrupts any old App page on its next handled API request, not only connector pages.
- CLI, unidentified clients, and missing/unparseable App versions keep their existing behavior. The App floor is not an authentication boundary.
- No API contract, singleton writer/decoder, callback, schema, runner, or Platform source is removed or changed. #29776 must verify the deployed cutoff and inventory persisted authorization state before #29777 contracts the remaining singleton compatibility.
- Post-deployment cutoff behavior has not yet been observed because this PR is not deployed.

## Validation

- Scoped Prettier and `git diff --check`: passed.
- `pnpm -F api lint`: passed.
- `pnpm -F api check-types`: passed.
- `pnpm knip --workspace apps/api`: passed.
- API integration suites: `app-factory`, `connector-accounts`, `connectors-manual-grant-connect` — **109 tests passed**.
- Platform integration suites: `fetch`, `shared-database-browser`, `connectors-catalog` — **23 tests passed**.
- The first Platform attempt could not load missing VAD/ONNX dependencies and ran no tests. The repository-prescribed `scripts/prepare.sh` succeeded, then the same suites passed. No tests were suppressed or skipped and no dependency manifest changed.
