### PR TITLE
refactor(platform): classify and retire the residual zero-* platform names

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -39,4 +39,8 @@ surface; the index does not replace their detailed rules.
   verify host-local concurrency and I/O capacity overrides.
 - [Runner multi-architecture rollout](./runner-multi-architecture.md): build,
   deploy, and validate runner artifacts for supported host architectures.
+- [Residual platform brand names](./residual-platform-brand-names.md): which
+  `zero-*` names in the platform and UI packages are safe to rename, which are
+  published asset keys or client-persisted identities, and which are the English
+  word.
 - [Testing catalog](./testing/anti-patterns.md): detailed testing anti-patterns.

--- a/docs/residual-platform-brand-names.md
+++ b/docs/residual-platform-brand-names.md
@@ -1,0 +1,191 @@
+# Residual Platform Brand Names
+
+Classification of every `zero-*` name that remained in `turbo/apps/platform` and
+`turbo/packages/ui` after #31802 renamed the design-token prefix and #31815
+renamed the `data-vm0-*` DOM attributes. #31816 produced it.
+
+A hyphenated `zero-` name is not one kind of thing. Some are internal CSS
+identifiers nobody outside the repository can observe; some are the names of
+databases and keys held on a user's own device, where a rename silently destroys
+state; some are published asset paths; some are the English word "zero". This
+document records which is which, so the residual brand-name guard (#31813) can
+consume the classification instead of rediscovering it, and so a future prefix
+sweep does not treat the whole set as one rename list.
+
+Categories below are the ones the guard's manifest defines in
+`RESIDUAL_BRAND_BOUNDARY_CATEGORIES`. A boundary entry is a permanent rule with
+a reason. A baseline entry is a name still awaiting a decision, and it carries
+an owning issue.
+
+This document quotes every name it classifies, so the guard needs an
+`out-of-scope` file rule for it for the same reason its own manifest has one.
+
+## Method
+
+Measured on `main` at `82f7578`:
+
+```bash
+git grep -nE 'zero-[a-z0-9]' -- turbo/apps/platform turbo/packages/ui
+git grep -ohE 'zero-[a-z0-9-]+' -- turbo/apps/platform turbo/packages/ui | sort -u
+```
+
+52 distinct names over 122 occurrences, of which 29 names and 85 occurrences sit
+outside `CHANGELOG.md`. #31816's issue body quoted 51 names and 78 occurrences
+from an earlier inventory pass with a slightly different token regex; the
+classification below covers the full 52 either way.
+
+The narrower acceptance grep #31802 established stays empty, because it only
+matches names introduced by `.` or `--`:
+
+```bash
+git grep -nE '(--|\.)zero-[a-z0-9-]+' -- turbo/apps/platform turbo/packages/ui
+```
+
+## Renamed by #31816
+
+Fifteen names. Each is defined and consumed entirely inside this repository,
+persists nothing, and is not part of any published artifact, so `zero-` became
+`okou-` with the rest of the name unchanged — the same shape as #31802.
+
+| Name                          | Kind               | Site                                                 |
+| ----------------------------- | ------------------ | ---------------------------------------------------- |
+| `zero-shimmer`                | CSS `@keyframes`   | `apps/platform/src/views/css/index.css`              |
+| `zero-thinking-in`            | CSS `@keyframes`   | `apps/platform/src/views/css/index.css`              |
+| `zero-locator-landed`         | CSS `@keyframes`   | `apps/platform/src/views/css/index.css`              |
+| `zero-block-pop`              | CSS `@keyframes`   | `apps/platform/src/views/css/index.css`              |
+| `zero-realtime-status-reveal` | CSS `@keyframes`   | `apps/platform/src/views/css/index.css`              |
+| `zero-dialog-overlay-in`      | CSS `@keyframes`   | `packages/ui/src/styles/globals.css`                 |
+| `zero-dialog-overlay-out`     | CSS `@keyframes`   | `packages/ui/src/styles/globals.css`                 |
+| `zero-dialog-blur-in`         | CSS `@keyframes`   | `packages/ui/src/styles/globals.css`                 |
+| `zero-dialog-content-in`      | CSS `@keyframes`   | `packages/ui/src/styles/globals.css`                 |
+| `zero-dialog-content-out`     | CSS `@keyframes`   | `packages/ui/src/styles/globals.css`                 |
+| `zero-icon`                   | CSS class          | `.owf-diagram-zero-icon` -> `.owf-diagram-okou-icon` |
+| `zero-thinking-spinner-frame` | marker class       | `views/okou-page/chat-thread-page.tsx`               |
+| `zero-nav-recent-label`       | marker class       | `views/okou-page/sidebar-threads.tsx`                |
+| `zero-agent-name`             | DOM `id`           | `views/okou-page/settings-tab.tsx`                   |
+| `zero-attachment-url`         | client logger name | `views/okou-page/attachment-url.ts`                  |
+
+A `@keyframes` name and every `animation:` shorthand naming it must move
+together; a half-renamed animation silently stops playing rather than failing a
+build. #31816 renamed each pair in one edit and asserted afterwards that every
+renamed name has both a definition and a reference.
+
+`zero-thinking-spinner-frame` and `zero-nav-recent-label` are marker classes:
+they appear in a `className` and match no CSS rule and no test selector anywhere
+in the repository. They document what an element is, so they were renamed rather
+than deleted.
+
+Two stale references were corrected rather than renamed, because the files they
+named no longer exist: a `zero-chat.ts` provenance note in
+`signals/okou-page/chat-draft.ts` and a `zero-chat-composer.tsx` pointer in
+`views/okou-page/chat-feedback-selection.tsx`. Two dead lint overrides for
+`src/signals/zero-page/**`, a directory deleted before this cleanup began, were
+removed from `.oxlintrc.json` and `eslint.config.js`; both globs matched no
+file.
+
+## Boundaries
+
+### `immutable-history` — release changelogs
+
+Twenty-five names appear only in `turbo/apps/platform/CHANGELOG.md`:
+`zero-account-page`, `zero-app`, `zero-app-shell`, `zero-chat`,
+`zero-chat-composer`, `zero-chat-page`, `zero-job-detail`,
+`zero-job-detail-page`, `zero-jobs-page`, `zero-meet`, `zero-model-preference`,
+`zero-native`, `zero-onboarding`, `zero-prop`, `zero-run-service`,
+`zero-schedule-card`, `zero-schedule-detail-page`, `zero-schedule-page`,
+`zero-schedule-tab`, `zero-send-key`, `zero-session-chat-page`,
+`zero-settings-tab`, `zero-sidebar`, `zero-slack-connect-page`,
+`zero-works-page`.
+
+Release-please owns that file and each entry describes what shipped under the
+name in force at the time. They are covered by the guard's existing
+`immutable-history/package-changelog` file rule; no per-name entry is needed.
+
+### `immutable-static-asset-key` — published asset paths
+
+| Name                            | Site                                               | Reason                                                                                                                                                    |
+| ------------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `zero-page`                     | `views/zero-page/**` keys, 39 occurrences          | The key is the path of an object already published under `static.vm0.io`; the repository holds the reference, not the object. Renaming it 404s the asset. |
+| `zero-avatar-face-19a2ae88c11d` | `views/onboarding/onboarding-workflow-diagram.tsx` | Content-hashed published SVG filename. The hash is part of the identity, so the name cannot be edited without republishing under a new hash.              |
+| `zero-avatar-hair-c1d917488df8` | `views/onboarding/onboarding-workflow-diagram.tsx` | Same.                                                                                                                                                     |
+| `zero-avatar-head-840043d16b50` | `views/onboarding/onboarding-workflow-diagram.tsx` | Same.                                                                                                                                                     |
+
+### `wire-and-persisted-value` — client-persisted identities
+
+Both are decided in full below.
+
+| Name                            | Site                                          | Decision |
+| ------------------------------- | --------------------------------------------- | -------- |
+| `zero-intro-video-drafts`       | `signals/external/intro-video-draft-store.ts` | Kept     |
+| `zero-install-banner-dismissed` | `signals/pwa-install.ts`                      | Kept     |
+
+### `external-identity`
+
+| Name                | Site                                 | Reason                                                                                                                      |
+| ------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `zero-fractions`    | `apps/platform/.oxlintrc.json`       | `no-zero-fractions` is an oxlint rule id. The linter defines the name; renaming it disables the rule silently.              |
+| `zero-design-color` | `packages/ui/src/styles/globals.css` | `https://zero-design-color.sites.vm0.io` is a deployed site. A source edit does not move the host, it only breaks the link. |
+
+### `semantic-non-brand`
+
+| Name         | Site                                                      | Reason                                                                                                                     |
+| ------------ | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `zero-sized` | `views/okou-page/image-annotation-editor.tsx:58`          | English prose: "would leave a zero-sized mark".                                                                            |
+| `zero-usage` | `views/okou-page/__tests__/chat-run-history.test.tsx:890` | Fixture id for a usage event carrying `creditUsage(0, [])` — a run that consumed zero credits. The numeral, not the brand. |
+
+## Baseline — still undecided
+
+| Name        | Site                       | Owner  | Reason                                                                                                                                                                                  |
+| ----------- | -------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `zero-left` | `views/css/index.css:1542` | #31840 | `--workflow-zero-left`. #31816's brief labelled this semantic and excluded it from scope; it is not. It positions the Zero avatar node in the onboarding diagram, and nothing reads it. |
+| `zero-size` | `views/css/index.css:1543` | #31840 | `--workflow-zero-size`. Same declaration block, and `72px` is exactly the `.owf-diagram-avatar` box. Also unreferenced.                                                                 |
+
+Both are dead declarations, so #31840 can delete rather than rename them. They
+were left untouched here because #31816's scope explicitly excluded them, and
+changing a name the brief said not to change is worse than recording that the
+brief was wrong.
+
+## Persisted-Key Decisions
+
+Renaming a name the browser stores is not a rename. The old name keeps the data
+and the new name starts empty, so the user loses state without any error. Both
+of the platform's persisted `zero-*` names are therefore kept, with the decision
+recorded at the declaration site.
+
+### `zero-intro-video-drafts` — kept
+
+`signals/external/intro-video-draft-store.ts` passes it to `openDB()`, so it is
+an IndexedDB database name holding the user's saved intro-video draft, blob
+included.
+
+- **If renamed with no migration:** every draft saved before the deploy is
+  invisible. The old database still holds the blob and still consumes quota, and
+  the wizard shows an empty state, so the user reads it as data loss.
+- **Cost of migrating:** open both databases, copy the record, delete the old
+  one, and do this on every client that ever loads the page again — including
+  clients that reach it mid-write.
+- **Users who never return:** they keep an orphaned IndexedDB database on their
+  device forever, because only their own browser can delete it. No migration can
+  reach them.
+- **Removal gate:** rename only inside a slice that already has to restructure
+  this store and can carry the copy as part of its own work.
+
+### `zero-install-banner-dismissed` — kept
+
+`signals/pwa-install.ts` reads it through `localStorageSignals`, so it is a
+localStorage flag recording that the user dismissed the PWA install banner.
+
+- **If renamed with no migration:** the banner reappears once for every user who
+  had already dismissed it.
+- **Why not a dual read:** reading the legacy key alongside a new one would
+  prevent that, but the flag has no expiry and no writer that would retire it,
+  so the tolerant branch would have no verifiable removal gate.
+  `docs/fallback.md` §8 rejects exactly that — a tolerated old shape with no
+  removal condition is not a rollout fallback.
+- **Users who never return:** unaffected either way; the flag is only read on a
+  page load they never make.
+- **Removal gate:** rename when the install banner is next reworked and the flag
+  is being rewritten anyway.
+
+Neither decision introduces a fallback branch, so neither carries a
+`docs/fallback.md` §9 declaration.

--- a/docs/residual-platform-brand-names.md
+++ b/docs/residual-platform-brand-names.md
@@ -43,9 +43,9 @@ git grep -nE '(--|\.)zero-[a-z0-9-]+' -- turbo/apps/platform turbo/packages/ui
 
 ## Renamed by #31816
 
-Fifteen names. Each is defined and consumed entirely inside this repository,
-persists nothing, and is not part of any published artifact, so `zero-` became
-`okou-` with the rest of the name unchanged — the same shape as #31802.
+Fifteen names. Each is defined inside this repository, persists nothing, and is
+not part of any published artifact, so `zero-` became `okou-` with the rest of
+the name unchanged — the same shape as #31802.
 
 | Name                          | Kind               | Site                                                 |
 | ----------------------------- | ------------------ | ---------------------------------------------------- |
@@ -69,6 +69,15 @@ A `@keyframes` name and every `animation:` shorthand naming it must move
 together; a half-renamed animation silently stops playing rather than failing a
 build. #31816 renamed each pair in one edit and asserted afterwards that every
 renamed name has both a definition and a reference.
+
+One of the fifteen does leave the repository, and it is the only one that does.
+`logger(name)` in `signals/log.ts` is registered as a Sentry `logger` tag by
+`captureSentryLogError`, so renaming `zero-attachment-url` changes the tag value
+on that module's future error events. Past events keep the old value and a saved
+Sentry search or alert pinned to `logger:zero-attachment-url` stops matching.
+That is an observability discontinuity, not a data or contract boundary: nothing
+reads the tag back, and no in-repo alert definition names it. The rename stands;
+the discontinuity is recorded here so it is not rediscovered as a mystery.
 
 `zero-thinking-spinner-frame` and `zero-nav-recent-label` are marker classes:
 they appear in a `className` and match no CSS rule and no test selector anywhere

--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -127,7 +127,6 @@
     },
     {
       "files": [
-        "src/signals/zero-page/zero-chat.ts",
         "src/signals/okou-page/chat-draft.ts",
         "src/signals/voice-io/voice-io-tts.ts",
         "src/signals/voice-io/voice-io-stt.ts"

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -285,7 +285,6 @@ export default [
       "src/signals/__tests__/test-helpers.ts",
       "src/signals/__tests__/utils.test.ts",
       "src/signals/__tests__/realtime.test.ts",
-      "src/signals/zero-page/__tests__/poll-slack-connection.test.ts",
     ],
     rules: {
       "ccstate/no-new-abort-controller": "off",

--- a/turbo/apps/platform/src/signals/external/intro-video-draft-store.ts
+++ b/turbo/apps/platform/src/signals/external/intro-video-draft-store.ts
@@ -48,6 +48,18 @@ interface IntroVideoDraftDatabase extends DBSchema {
   };
 }
 
+/**
+ * Client-persisted identity, deliberately kept under the pre-rename name.
+ *
+ * The browser keys an IndexedDB database by this string. Renaming it does not
+ * move the stored drafts: the old database keeps the user's saved blob and this
+ * build opens an empty new one, so every draft saved before the rename is
+ * silently lost. Copying them across would mean opening both databases, moving
+ * blobs, and deleting the old one on every client that ever returns — and a
+ * client that never returns keeps an orphaned database forever. The name is
+ * invisible to users, so #31816 keeps it. Rename it only as part of a slice
+ * that already has to restructure this store and can carry the copy.
+ */
 const DATABASE_NAME = "zero-intro-video-drafts";
 const DATABASE_VERSION = 1;
 const TRANSACTION_TEMPLATES = {

--- a/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-draft.ts
@@ -34,7 +34,7 @@ import { publicAttachmentUrl } from "../../views/okou-page/attachment-url.ts";
 import { isAnnotationMeaningful } from "./image-annotation.ts";
 
 // ---------------------------------------------------------------------------
-// Attachment types (moved from zero-chat.ts)
+// Attachment types
 // ---------------------------------------------------------------------------
 
 interface FileInfo {

--- a/turbo/apps/platform/src/signals/pwa-install.ts
+++ b/turbo/apps/platform/src/signals/pwa-install.ts
@@ -26,8 +26,20 @@ function detectIOSSafari(): boolean {
 
 const iosModalOpen$ = state(false);
 
+/**
+ * Client-persisted identity, deliberately kept under the pre-rename name.
+ *
+ * This localStorage key records that a user dismissed the install banner.
+ * Renaming it makes the banner reappear once for everyone who already dismissed
+ * it. Reading the legacy key alongside a new one would fix that, but the flag
+ * never expires, so that branch would have no verifiable removal gate and
+ * `docs/fallback.md` §8 rejects a tolerated old shape with no removal
+ * condition. The key is invisible to users, so #31816 keeps it.
+ */
+const INSTALL_BANNER_DISMISSED_KEY = "zero-install-banner-dismissed";
+
 const { get$: dismissedRaw$, set$: setDismissed$ } = localStorageSignals(
-  "zero-install-banner-dismissed",
+  INSTALL_BANNER_DISMISSED_KEY,
 );
 
 export const installBannerVisible$ = computed((get) => {

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -215,7 +215,7 @@ body {
    box that holds glyphs, so the text cannot shift.
 
    `contain: paint` keeps the per-frame repaint inside the label. */
-@keyframes zero-shimmer {
+@keyframes okou-shimmer {
   from {
     background-position: 100% center;
   }
@@ -238,10 +238,10 @@ body {
   background-clip: text;
   -webkit-text-fill-color: transparent;
   contain: paint;
-  animation: zero-shimmer 3.5s linear infinite;
+  animation: okou-shimmer 3.5s linear infinite;
 }
 
-@keyframes zero-thinking-in {
+@keyframes okou-thinking-in {
   from {
     opacity: 0;
     transform: translateY(0.5rem);
@@ -252,7 +252,7 @@ body {
   }
 }
 .okou-thinking-enter {
-  animation: zero-thinking-in 0.3s ease-out;
+  animation: okou-thinking-in 0.3s ease-out;
 }
 
 .okou-thinking-spinner {
@@ -272,7 +272,7 @@ body {
 }
 
 /* Conversation locator: mark where a rail jump landed, then fade back out. */
-@keyframes zero-locator-landed {
+@keyframes okou-locator-landed {
   from {
     background-color: hsl(var(--primary) / 0.1);
     box-shadow: 0 0 0 0.75rem hsl(var(--primary) / 0.1);
@@ -284,7 +284,7 @@ body {
 }
 [data-locator-landed] {
   border-radius: 0.75rem;
-  animation: zero-locator-landed 1.15s cubic-bezier(0.2, 0.8, 0.2, 1);
+  animation: okou-locator-landed 1.15s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 @media (prefers-reduced-motion: reduce) {
   [data-locator-landed] {
@@ -306,21 +306,21 @@ body {
   background: var(--zb-c1);
   grid-column: 2;
   grid-row: 1;
-  animation: zero-block-pop 1.4s ease-in-out infinite;
+  animation: okou-block-pop 1.4s ease-in-out infinite;
 }
 .okou-blocks span:nth-child(2) {
   background: var(--zb-c2);
   grid-column: 1;
   grid-row: 2;
-  animation: zero-block-pop 1.4s ease-in-out 0.2s infinite;
+  animation: okou-block-pop 1.4s ease-in-out 0.2s infinite;
 }
 .okou-blocks span:nth-child(3) {
   background: var(--zb-c3);
   grid-column: 2;
   grid-row: 2;
-  animation: zero-block-pop 1.4s ease-in-out 0.4s infinite;
+  animation: okou-block-pop 1.4s ease-in-out 0.4s infinite;
 }
-@keyframes zero-block-pop {
+@keyframes okou-block-pop {
   0%,
   100% {
     transform: scale(0.8);
@@ -602,7 +602,7 @@ body {
 
 .okou-realtime-status-reconnecting {
   opacity: 0;
-  animation: zero-realtime-status-reveal 160ms cubic-bezier(0.16, 1, 0.3, 1)
+  animation: okou-realtime-status-reveal 160ms cubic-bezier(0.16, 1, 0.3, 1)
     300ms forwards;
 }
 
@@ -611,7 +611,7 @@ body {
   animation: okou-realtime-cloud-flow 1.05s linear infinite;
 }
 
-@keyframes zero-realtime-status-reveal {
+@keyframes okou-realtime-status-reveal {
   to {
     opacity: 0.8;
   }
@@ -1755,7 +1755,7 @@ details > summary {
   padding: 4px;
 }
 
-.owf-diagram-zero-icon {
+.owf-diagram-okou-icon {
   position: relative;
   display: inline-block;
   width: 64px;
@@ -1763,7 +1763,7 @@ details > summary {
   overflow: hidden;
 }
 
-.owf-diagram-zero-icon img {
+.owf-diagram-okou-icon img {
   position: absolute;
   top: -9.73px;
   left: -6.4px;

--- a/turbo/apps/platform/src/views/okou-page/attachment-url.ts
+++ b/turbo/apps/platform/src/views/okou-page/attachment-url.ts
@@ -9,7 +9,7 @@ import { logger } from "../../signals/log.ts";
 import { throwIfAbort } from "../../signals/utils.ts";
 import { writeToClipboard } from "../../signals/okou-page/clipboard.ts";
 
-const log = logger("zero-attachment-url");
+const log = logger("okou-attachment-url");
 
 const LEGACY_FILE_PATH_PATTERN = /^\/f\/([^/]+)\/([^/]+)\/([^/]+)$/;
 const ARTIFACT_FILE_PATH_PATTERN = /^\/artifacts\/([^/]+)\/([^/]+)\/([^/]+)$/;

--- a/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
@@ -372,8 +372,8 @@ function TranslationResult({
 
 // Mounts the selection listeners and the floating Copy / Quote / Forward
 // toolbar anchored to the selected passage. Picking "Quote"
-// drops the quoted passage straight into the composer (see ComposerFeedbackRows
-// in zero-chat-composer.tsx) — there is no separate feedback panel.
+// drops the quoted passage straight into the composer (see the feedback rows in
+// chat-composer.tsx) — there is no separate feedback panel.
 export function ChatFeedbackSelection({
   feedback,
   sourceAgentId,

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -4835,7 +4835,7 @@ function ThinkingLoader({
       <span
         aria-hidden
         data-thinking-loader="spinner"
-        className="zero-thinking-spinner-frame inline-flex size-[11.5px] shrink-0 items-center justify-center"
+        className="okou-thinking-spinner-frame inline-flex size-[11.5px] shrink-0 items-center justify-center"
       >
         <img
           src={thinkingSpinnerImg}

--- a/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/settings-tab.tsx
@@ -236,7 +236,7 @@ export function SettingsTab({
   visibility: initialVisibility = "public",
   canEditVisibility = true,
   updateSettings$,
-  inputId = "zero-agent-name",
+  inputId = "okou-agent-name",
   isDefaultAgent = false,
   onDelete,
   deleteWorkflows = [],

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -856,7 +856,7 @@ function ChatThreadsTitle({ showMarkAllRead }: { showMarkAllRead: boolean }) {
 
   return (
     <div
-      className="zero-nav-recent-label group flex h-8 shrink-0 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-state-hover transition-colors"
+      className="okou-nav-recent-label group flex h-8 shrink-0 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-state-hover transition-colors"
       onClick={() => {
         return setCollapsed(!collapsed);
       }}

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
@@ -368,7 +368,7 @@ export function WorkflowPreviewDiagram({
           className="owf-diagram-node-zero"
           iconClassName="owf-diagram-avatar"
         >
-          <span className="owf-diagram-zero-icon" aria-hidden="true">
+          <span className="owf-diagram-okou-icon" aria-hidden="true">
             <img src={ZERO_AVATAR_HEAD_IMG} alt="" aria-hidden />
             <img src={ZERO_AVATAR_HAIR_IMG} alt="" aria-hidden />
             <img src={ZERO_AVATAR_FACE_IMG} alt="" aria-hidden />

--- a/turbo/packages/ui/src/styles/__tests__/globals.test.ts
+++ b/turbo/packages/ui/src/styles/__tests__/globals.test.ts
@@ -241,7 +241,7 @@ describe("dialog transitions", () => {
         globalCss,
         ".okou-dialog-overlay[data-ending-style]:not([data-open])",
       ),
-    ).toMatch(/animation:\s*zero-dialog-overlay-out/);
+    ).toMatch(/animation:\s*okou-dialog-overlay-out/);
     expect(
       readRuleBody(
         globalCss,
@@ -253,7 +253,7 @@ describe("dialog transitions", () => {
         globalCss,
         ".okou-dialog-content[data-ending-style]:not([data-open])",
       ),
-    ).toMatch(/animation:\s*zero-dialog-content-out/);
+    ).toMatch(/animation:\s*okou-dialog-content-out/);
   });
 });
 

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -927,7 +927,7 @@
   }
 
   .okou-dialog-overlay[data-open] {
-    animation: zero-dialog-overlay-in 180ms ease;
+    animation: okou-dialog-overlay-in 180ms ease;
   }
 
   /* Base UI can briefly retain the previous ending style while a controlled
@@ -935,7 +935,7 @@
      is no longer open, otherwise the first frame flashes fully visible before
      the enter animation starts. */
   .okou-dialog-overlay[data-ending-style]:not([data-open]) {
-    animation: zero-dialog-overlay-out 180ms ease;
+    animation: okou-dialog-overlay-out 180ms ease;
   }
 
   /* The scrim carries its blur on a separate layer. A backdrop-filter costs
@@ -952,7 +952,7 @@
   }
 
   .okou-dialog-overlay[data-open]::after {
-    animation: zero-dialog-blur-in 180ms step-end;
+    animation: okou-dialog-blur-in 180ms step-end;
   }
 
   .okou-dialog-overlay[data-ending-style]:not([data-open])::after {
@@ -978,11 +978,11 @@
   }
 
   .okou-dialog-content[data-open] {
-    animation: zero-dialog-content-in 180ms ease;
+    animation: okou-dialog-content-in 180ms ease;
   }
 
   .okou-dialog-content[data-ending-style]:not([data-open]) {
-    animation: zero-dialog-content-out 180ms ease;
+    animation: okou-dialog-content-out 180ms ease;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -1042,7 +1042,7 @@
   }
 }
 
-@keyframes zero-dialog-overlay-in {
+@keyframes okou-dialog-overlay-in {
   from {
     opacity: 0;
   }
@@ -1051,7 +1051,7 @@
   }
 }
 
-@keyframes zero-dialog-overlay-out {
+@keyframes okou-dialog-overlay-out {
   from {
     opacity: 1;
   }
@@ -1060,7 +1060,7 @@
   }
 }
 
-@keyframes zero-dialog-blur-in {
+@keyframes okou-dialog-blur-in {
   from {
     visibility: hidden;
   }
@@ -1069,7 +1069,7 @@
   }
 }
 
-@keyframes zero-dialog-content-in {
+@keyframes okou-dialog-content-in {
   from {
     transform: translateY(8px);
   }
@@ -1078,7 +1078,7 @@
   }
 }
 
-@keyframes zero-dialog-content-out {
+@keyframes okou-dialog-content-out {
   from {
     transform: translateY(0);
   }


### PR DESCRIPTION
Closes #31816. Part of #31801 (workstream R1b), after #31802 and #31815.

## What this is

A classification pass, not a prefix sweep. Measured on `main` at `82f7578`,
`turbo/apps/platform` and `turbo/packages/ui` held **52 distinct `zero-*` names
over 122 occurrences** (29 names / 85 occurrences outside `CHANGELOG.md`). The
issue body quoted 51/78 from an earlier inventory with a slightly different
token regex; the classification covers the full 52 either way.

Three of them are client-persisted or published identities where a rename
destroys user state or 404s an asset, so every name was classified before
anything moved. `docs/residual-platform-brand-names.md` records the result in
the vocabulary #31813's manifest defines, so that guard can consume it rather
than rediscover it.

| Outcome | Names |
| --- | ---: |
| Renamed `zero-` -> `okou-` | 15 |
| Boundary — `immutable-history` (changelog only) | 25 |
| Boundary — `immutable-static-asset-key` | 4 |
| Boundary — `wire-and-persisted-value` (kept, decided) | 2 |
| Boundary — `external-identity` | 2 |
| Boundary — `semantic-non-brand` | 2 |
| Baseline — owned by #31840 | 2 |

## Renamed (15)

Each is defined and consumed entirely inside this repository, persists nothing,
and is in no published artifact.

- 10 `@keyframes`: `zero-shimmer`, `zero-thinking-in`, `zero-locator-landed`,
  `zero-block-pop`, `zero-realtime-status-reveal` in
  `apps/platform/src/views/css/index.css`, and `zero-dialog-{overlay,content}-
  {in,out}` plus `zero-dialog-blur-in` in `packages/ui/src/styles/globals.css`.
  Every definition moved with every `animation:` shorthand naming it — verified
  afterwards that each of the 10 new names has both a `@keyframes` and a
  reference, and that no keyframe name is now defined twice across the two
  stylesheets.
- `.owf-diagram-zero-icon` -> `.owf-diagram-okou-icon` (CSS + the one JSX
  `className`). This one was not in the issue's category lists.
- `zero-thinking-spinner-frame`, `zero-nav-recent-label` — marker classes in a
  `className` that match no CSS rule and no selector anywhere in the repo.
- `zero-agent-name` — the `SettingsTab` input `id` default.
- `zero-attachment-url` — a client logger name.

Repo-wide grep for all 15 old names is empty, including `e2e/` and `crates/`.

One of the fifteen is not purely repository-internal: `logger(name)` becomes a
Sentry `logger` tag through `captureSentryLogError`, so `zero-attachment-url`
-> `okou-attachment-url` changes that tag's value on future error events from
that module. Past events keep the old value, and a saved Sentry search pinned
to the old value stops matching. No in-repo alert names it. Recorded in the doc
rather than left to be rediscovered.

## Persisted keys — both kept, decided per key

The issue required an explicit decision, not a silent rename. Both decisions are
recorded at the declaration site and in the doc.

- **`zero-intro-video-drafts`** (`signals/external/intro-video-draft-store.ts`,
  IndexedDB database name) — **kept**. Renaming does not move the data: the old
  database keeps the user's saved blob and the app opens an empty new one, so
  every pre-rename draft reads as data loss. Migrating means opening both
  databases and copying blobs on every client that ever returns; a client that
  never returns keeps an orphaned database forever, and no migration can reach
  it. Rename only inside a slice that already has to restructure this store.
- **`zero-install-banner-dismissed`** (`signals/pwa-install.ts`, localStorage) —
  **kept**. Renaming re-shows the install banner once to everyone who dismissed
  it. A #31815-shaped dual read would prevent that, but this flag never expires
  and has no writer that retires it, so the legacy branch would have no
  verifiable removal gate — `docs/fallback.md` §8 rejects exactly that. Users
  who never return are unaffected either way. Rename when the banner is next
  reworked and the flag is rewritten anyway.

Neither introduces a tolerant branch, so there is no `Fallbacks` section.

## Untouched, with reasons recorded

- `immutable-static-asset-key`: `zero-avatar-{face,hair,head}-<hash>.svg` and
  the 39 `views/zero-page/**` keys — objects already published to
  `static.vm0.io`.
- `external-identity`: `no-zero-fractions` is an oxlint rule id; renaming
  disables the rule silently. `zero-design-color.sites.vm0.io` is a live host.
- `semantic-non-brand`: `zero-sized` in prose, and the `zero-usage` fixture id
  for a `creditUsage(0, [])` event — the numeral.
- `immutable-history`: 25 names that now exist only in
  `apps/platform/CHANGELOG.md`, covered by the guard's existing changelog file
  rule.

## One correction to the issue's classification

The issue listed `zero-size` and `zero-left` as "semantic, not brand — leave
alone". They are `--workflow-zero-left: 277px` and `--workflow-zero-size: 72px`
on `.owf-diagram`: the position and box of the **Zero avatar node** in the
onboarding diagram, sitting between `--workflow-source-icon-left` and
`--workflow-output-icon-left`, where `72px` is exactly the `.owf-diagram-avatar`
box. They are also dead — `git grep 'workflow-zero'` returns only the two
declarations.

They are left untouched here because the issue's scope excluded them, and are
recorded as the only two baseline entries with **#31840** as owner, which can
delete rather than rename them.

## Incidental cleanup

Two lint overrides globbing `src/signals/zero-page/**` — a directory deleted
before this cleanup — matched no file and were removed from `.oxlintrc.json`
and `eslint.config.js`. Two comments naming `zero-chat.ts` and
`zero-chat-composer.tsx`, neither of which exists, were corrected.

## Verification

- `git grep -nE '(--|\.)zero-[a-z0-9-]+' -- turbo/apps/platform turbo/packages/ui` — empty.
- `pnpm format`, `pnpm -F @okouai/app lint`, `pnpm -F @okouai/ui lint`,
  `pnpm -F @okouai/app check-types`, `pnpm knip` — clean.
- `pnpm -F @okouai/ui exec vitest run src/styles` — 44 passed, including the two
  assertions on the renamed dialog exit animations.
- `pnpm -F @okouai/app exec vitest run` on `settings-tab`, `chat-run-history`,
  `team-navigation`, `integrations-feishu`, `indexeddb-client` — 64 passed.

No behaviour change: no persisted key, published asset, wire value, or rendered
output moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)