### PR TITLE
fix(billing): preserve managed allowance under shared debt

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -6,13 +6,15 @@ import {
   PutObjectCommand,
   type PutObjectCommandInput,
 } from "@aws-sdk/client-s3";
+import { billingStatusContract } from "@okouai/api-contracts/contracts/billing";
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
 import { onTestFinished } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { apiTestS3PresignedUrl } from "../../../__tests__/mocks";
-import { testContext } from "../../../__tests__/test-context";
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import {
   buildArtifactKeyV2,
@@ -1050,8 +1052,8 @@ describe("POST /api/image-io/generate", () => {
     await expect(orgCredits(fixture)).resolves.toBe(-50);
   });
 
-  it("keeps a legacy generation job on VM0 when allowance remains", async () => {
-    const fixture = await seedImageFixture({ credits: 0 });
+  it("uses allowance for a runless generation under shared debt", async () => {
+    const fixture = await seedImageFixture({ credits: -100 });
     const pricingFixture = await createScopedImagePricing({
       configured: GPT_IMAGE_1_PRICING,
     });
@@ -1060,7 +1062,7 @@ describe("POST /api/image-io/generate", () => {
       orgId: fixture.orgId,
       userId: fixture.userId,
       customerId: generatedStripeCustomerId(),
-      subscriptionId: `sub_image_allowance_${randomUUID()}`,
+      subscriptionId: `sub_image_debt_allowance_${randomUUID()}`,
       effectiveAt,
       expiresAt: new Date(effectiveAt.getTime() + 365 * 24 * 60 * 60 * 1000),
       shortWindowSeconds: 5 * 60 * 60,
@@ -1142,7 +1144,21 @@ describe("POST /api/image-io/generate", () => {
     expect(putObjectInput().Metadata).toMatchObject({
       "public-brand": "vm0",
     });
-    await expect(orgCredits(fixture)).resolves.toBe(0);
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const billingStatus = await accept(
+      setupApp({ context, routes: billingStatusRoutes })(
+        billingStatusContract,
+      ).get({ headers: authHeaders() }),
+      [200],
+    );
+    expect(billingStatus.body.credits).toBe(-100);
+    expect(
+      Object.fromEntries(
+        billingStatus.body.usageAllowance?.windows.map((window) => {
+          return [window.kind, window.consumedUnits];
+        }) ?? [],
+      ),
+    ).toStrictEqual({ short: 50, weekly: 50 });
   });
 
   it("returns 503 when image pricing is not configured", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -1052,7 +1052,7 @@ describe("POST /api/image-io/generate", () => {
     await expect(orgCredits(fixture)).resolves.toBe(-50);
   });
 
-  it("uses allowance for a runless generation under shared debt", async () => {
+  it("uses allowance for a legacy runless generation under shared debt", async () => {
     const fixture = await seedImageFixture({ credits: -100 });
     const pricingFixture = await createScopedImagePricing({
       configured: GPT_IMAGE_1_PRICING,

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -405,20 +405,20 @@ describe("Usage Allowance", () => {
     await expect(readVisibleUsageCredits(actor)).resolves.toBe(50);
   });
 
-  it("admits vm0 runs with zero org credits when allowance remains", async () => {
+  it("admits vm0 runs with shared debt when allowance remains", async () => {
     const { actor, agentId } = await vm0AllowanceActor({
-      credits: 0,
+      credits: -10,
       allowance: { shortWindowUnits: 10, weeklyWindowUnits: 10 },
     });
 
     const run = await createVm0Run(
       actor,
       agentId,
-      "vm0 run admitted by usage allowance",
+      "vm0 run admitted by allowance under shared debt",
     );
 
     expect(run.runId).toStrictEqual(expect.any(String));
-    // The activated windows fully cover usage despite the zero balance.
+    // The activated windows fully cover usage without repaying shared debt.
     const provider = usageProvider();
     await recordPendingUsage({
       actor,
@@ -427,6 +427,7 @@ describe("Usage Allowance", () => {
       quantity: 10,
     });
     await processOrgUsageEvents(actor);
+    await expect(readOrgCredits(actor)).resolves.toBe(-10);
     await expect(readVisibleUsageCredits(actor)).resolves.toBe(10);
   });
 
@@ -526,6 +527,43 @@ describe("Usage Allowance", () => {
     );
     expectApiError(rejected.body);
     expect(rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
+  });
+
+  it("uses run allowance for billable firewall fallback under shared debt", async () => {
+    const { actor, agentId } = await vm0AllowanceActor({
+      credits: -10,
+      allowance: { shortWindowUnits: 2, weeklyWindowUnits: 2 },
+    });
+    const api = createRunsApi(context);
+    await api.ensureOrgModelProvider(actor);
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "BYOK run uses allowance for billable firewall",
+      modelProvider: "anthropic-api-key",
+    });
+    const client = setupApp({
+      context,
+      routes: webhooksAgentFirewallAuthRoutes,
+    })(webhookFirewallAuthContract);
+
+    const before = Math.floor(now() / 1000);
+    const leased = await accept(
+      client.resolve({
+        headers: {
+          authorization: `Bearer ${api.sandboxTokenForRun(actor, run.runId)}`,
+        },
+        body: {
+          encryptedSecrets: encryptSecretForTests(JSON.stringify({})),
+          authHeaders: { Authorization: "Bearer static-token" },
+          firewallBillable: true,
+        },
+      }),
+      [200],
+    );
+
+    expect(leased.body.expiresAt).not.toBeNull();
+    expect(leased.body.expiresAt ?? 0).toBeGreaterThanOrEqual(before + 4);
+    expect(leased.body.expiresAt ?? 0).toBeLessThanOrEqual(before + 6);
   });
 
   it("does not let built-in credit admission bypass workspace suspension", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -560,10 +560,11 @@ describe("Usage Allowance", () => {
       }),
       [200],
     );
+    const after = Math.floor(now() / 1000);
 
     expect(leased.body.expiresAt).not.toBeNull();
     expect(leased.body.expiresAt ?? 0).toBeGreaterThanOrEqual(before + 4);
-    expect(leased.body.expiresAt ?? 0).toBeLessThanOrEqual(before + 6);
+    expect(leased.body.expiresAt ?? 0).toBeLessThanOrEqual(after + 6);
   });
 
   it("does not let built-in credit admission bypass workspace suspension", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/web-search.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-search.test.ts
@@ -413,15 +413,16 @@ describe("okou web-search route", () => {
     expect(providerRequests).toBe(0);
   });
 
-  it("uses allowance for runless searches when org credits are exhausted", async () => {
+  it("uses allowance for runless searches under shared debt", async () => {
     const actor = createBddApi(context).user();
     if (!actor.orgId) {
       throw new Error("Web Search test actor must belong to an organization");
     }
+    let providerRequests = 0;
     configureProvider();
     const pricing = await setupConfiguredWebSearchPricing();
     await bootstrapOnboarding(actor);
-    await setActorCredits(actor, 0);
+    await setActorCredits(actor, -10);
     const effectiveAt = nowDate();
     await postUsageAllowanceInvoicePaid(context.signal, {
       orgId: actor.orgId,
@@ -431,12 +432,13 @@ describe("okou web-search route", () => {
       effectiveAt,
       expiresAt: new Date(effectiveAt.getTime() + 365 * 24 * 60 * 60 * 1000),
       shortWindowSeconds: 5 * 60 * 60,
-      shortWindowUnits: 100,
+      shortWindowUnits: 10,
       weeklyWindowSeconds: 7 * 24 * 60 * 60,
-      weeklyWindowUnits: 200,
+      weeklyWindowUnits: 10,
     });
     server.use(
       http.post(PERPLEXITY_SEARCH_URL, () => {
+        providerRequests += 1;
         return HttpResponse.json(providerResponse());
       }),
     );
@@ -456,7 +458,8 @@ describe("okou web-search route", () => {
     );
 
     expect(response.body.creditsCharged).toBe(0);
-    expect(status.body.credits).toBe(0);
+    expect(providerRequests).toBe(1);
+    expect(status.body.credits).toBe(-10);
     expect(
       Object.fromEntries(
         status.body.usageAllowance?.windows.map((window) => {
@@ -464,6 +467,49 @@ describe("okou web-search route", () => {
         }) ?? [],
       ),
     ).toStrictEqual({ short: 5, weekly: 5 });
+  });
+
+  it("rejects runless searches when allowance cannot cover the exact price under shared debt", async () => {
+    const actor = createBddApi(context).user();
+    if (!actor.orgId) {
+      throw new Error("Web Search test actor must belong to an organization");
+    }
+    let providerRequests = 0;
+    configureProvider();
+    const pricing = await setupConfiguredWebSearchPricing();
+    await bootstrapOnboarding(actor);
+    await setActorCredits(actor, -10);
+    const effectiveAt = nowDate();
+    await postUsageAllowanceInvoicePaid(context.signal, {
+      orgId: actor.orgId,
+      userId: actor.userId,
+      customerId: generatedStripeCustomerId(),
+      subscriptionId: `sub_web_search_partial_allowance_${randomUUID()}`,
+      effectiveAt,
+      expiresAt: new Date(effectiveAt.getTime() + 365 * 24 * 60 * 60 * 1000),
+      shortWindowSeconds: 5 * 60 * 60,
+      shortWindowUnits: 4,
+      weeklyWindowSeconds: 7 * 24 * 60 * 60,
+      weeklyWindowUnits: 4,
+    });
+    server.use(
+      http.post(PERPLEXITY_SEARCH_URL, () => {
+        providerRequests += 1;
+        return HttpResponse.json(providerResponse());
+      }),
+    );
+
+    const response = await accept(
+      client(pricing.resolution)(webSearchContract).search({
+        headers: authenticate(actor),
+        body: defaultRequest(),
+      }),
+      [402],
+    );
+
+    expectApiError(response.body);
+    expect(response.body.error.code).toBe("INSUFFICIENT_CREDITS");
+    expect(providerRequests).toBe(0);
   });
 
   it("translates filtered searches and records successful usage", async () => {

--- a/turbo/apps/api/src/signals/services/managed-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/managed-usage.service.ts
@@ -198,13 +198,10 @@ export const checkManagedCredits$ = command(
       args.orgId,
     );
     signal.throwIfAborted();
-    const sharedSpendableUnits =
-      (spendableCredits > 0n ? spendableCredits : 0n) +
-      BigInt(allowance?.remainingUnits ?? 0) -
-      (spendableCredits < 0n ? -spendableCredits : 0n);
     const spendableUnits =
       usagePackCredits +
-      (sharedSpendableUnits > 0n ? sharedSpendableUnits : 0n);
+      (spendableCredits > 0n ? spendableCredits : 0n) +
+      BigInt(allowance?.remainingUnits ?? 0);
     return spendableUnits >= requiredCredits ? null : insufficientCredits();
   },
 );


### PR DESCRIPTION
## Summary

- Treat negative shared credits as unavailable instead of subtracting shared debt from managed usage allowance.
- Keep the existing settlement order unchanged: allowance, member usage-pack credits, then shared credits.
- Add integration coverage for run admission, billable firewall fallback, runless web search, and runless image generation under shared debt.

## Scope

- Changes only the managed-operation credit preflight calculation.
- Does not change run admission, firewall admission, or usage settlement production logic.
- Does not repay or mutate shared debt when allowance covers usage.

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/usage-allowance.test.ts src/signals/routes/__tests__/web-search.test.ts src/signals/routes/__tests__/image-io-generate.test.ts --maxWorkers=4 --silent=passed-only` (95 tests)
- `pnpm -F api exec vitest run --maxWorkers=4 --silent=passed-only` (4,163 tests)

Closes #31812
