### PR TITLE
fix(platform): center avatar options and keep selections on the current step

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/settings/avatar-maker.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/avatar-maker.ts
@@ -270,12 +270,6 @@ export const selectAvatarOption$ = command(
     await delay(350, { signal });
     set(internalJustPicked$, null);
     set(internalShowSparkles$, false);
-
-    const steps = stepsForConfig(previous, get(avatarNeckSweaterEnabled$));
-    const idx = steps.indexOf(selection.field);
-    if (idx + 1 < steps.length) {
-      set(internalStep$, steps[idx + 1]!);
-    }
   },
 );
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -1,4 +1,9 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import {
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from "@testing-library/react";
 import { expect, test } from "vitest";
 
 import {
@@ -40,6 +45,11 @@ function isNeckOrSweaterLayer(src: string): boolean {
 
 function findCreateCustomAvatarButton(): Promise<HTMLElement> {
   return screen.findByLabelText("Create custom avatar");
+}
+
+async function waitForAvatarFeedback(dialog: HTMLElement): Promise<void> {
+  const sparkles = within(dialog).getByTestId("avatar-sparkles");
+  await waitForElementToBeRemoved(sparkles);
 }
 
 async function findAvatarRow(): Promise<HTMLElement> {
@@ -361,12 +371,15 @@ test("Create and save a composer avatar from the profile page", async () => {
   });
   expect(within(dialog).getByText("Face")).toBeVisible();
   click(within(dialog).getByLabelText("Randomize avatar"));
+  await waitForAvatarFeedback(dialog);
   click(within(dialog).getByLabelText("Round"));
+  await waitForAvatarFeedback(dialog);
   expect(within(dialog).getByLabelText("Round")).toHaveAttribute(
     "aria-pressed",
     "true",
   );
   click(within(dialog).getByLabelText("Oval"));
+  await waitForAvatarFeedback(dialog);
   expect(within(dialog).getByLabelText("Round")).toHaveAttribute(
     "aria-pressed",
     "false",
@@ -380,7 +393,9 @@ test("Create and save a composer avatar from the profile page", async () => {
     await expect(within(dialog).findByText(step)).resolves.toBeVisible();
   }
   click(within(dialog).getByLabelText("Green"));
+  await waitForAvatarFeedback(dialog);
   click(within(dialog).getByLabelText("Blue"));
+  await waitForAvatarFeedback(dialog);
   expect(within(dialog).getByText("Color")).toBeVisible();
   expect(within(dialog).getByLabelText("Blue")).toHaveAttribute(
     "aria-pressed",
@@ -389,6 +404,7 @@ test("Create and save a composer avatar from the profile page", async () => {
   click(within(dialog).getByLabelText("Next step"));
   await expect(within(dialog).findByText("Sweater")).resolves.toBeVisible();
   click(within(dialog).getByLabelText("Pink"));
+  await waitForAvatarFeedback(dialog);
   click(within(dialog).getByLabelText("Previous step"));
   expect(within(dialog).getByLabelText("Blue")).toHaveAttribute(
     "aria-pressed",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -361,13 +361,44 @@ test("Create and save a composer avatar from the profile page", async () => {
   });
   expect(within(dialog).getByText("Face")).toBeVisible();
   click(within(dialog).getByLabelText("Randomize avatar"));
+  click(within(dialog).getByLabelText("Round"));
+  expect(within(dialog).getByLabelText("Round")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  click(within(dialog).getByLabelText("Oval"));
+  expect(within(dialog).getByLabelText("Round")).toHaveAttribute(
+    "aria-pressed",
+    "false",
+  );
+  expect(within(dialog).getByLabelText("Oval")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
   for (const step of ["Hair", "Mood", "Skin", "Color"]) {
     click(within(dialog).getByLabelText("Next step"));
     await expect(within(dialog).findByText(step)).resolves.toBeVisible();
   }
+  click(within(dialog).getByLabelText("Green"));
   click(within(dialog).getByLabelText("Blue"));
+  expect(within(dialog).getByText("Color")).toBeVisible();
+  expect(within(dialog).getByLabelText("Blue")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  click(within(dialog).getByLabelText("Next step"));
   await expect(within(dialog).findByText("Sweater")).resolves.toBeVisible();
   click(within(dialog).getByLabelText("Pink"));
+  click(within(dialog).getByLabelText("Previous step"));
+  expect(within(dialog).getByLabelText("Blue")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  click(within(dialog).getByLabelText("Next step"));
+  expect(within(dialog).getByLabelText("Pink")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
   click(within(dialog).getByText("Use this avatar"));
 
   await waitFor(() => {
@@ -379,7 +410,7 @@ test("Create and save a composer avatar from the profile page", async () => {
   expect(savedLayerSrcs).toStrictEqual([
     expect.stringMatching(/\/avatar-svg-v2\/.*\/neck\//u),
     expect.stringMatching(/\/avatar-svg-v2\/.*\/hairs\/.*-blue-rear\.svg$/u),
-    expect.stringMatching(/\/avatar-svg-v2\/.*\/faces\//u),
+    expect.stringMatching(/\/avatar-svg-v2\/.*\/faces\/oval-/u),
     expect.stringMatching(/\/avatar-svg-v2\/.*\/hairs\/.*-blue-front\.svg$/u),
     expect.stringMatching(/\/avatar-svg-v2\/.*\/expressions\//u),
     expect.stringMatching(/\/avatar-svg-v2\/.*\/sweater\/pink\.svg$/u),

--- a/turbo/apps/platform/src/views/okou-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-maker.tsx
@@ -102,7 +102,10 @@ function Sparkles({ active }: { active: boolean }) {
 
   const particles = getSparkleParticles();
   return (
-    <div className="pointer-events-none absolute inset-0 z-10">
+    <div
+      className="pointer-events-none absolute inset-0 z-10"
+      data-testid="avatar-sparkles"
+    >
       {particles.map((p) => {
         const key = `${p.x.toFixed(2)}_${p.y.toFixed(2)}_${p.size.toFixed(2)}`;
         return (

--- a/turbo/apps/platform/src/views/okou-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-maker.tsx
@@ -179,16 +179,14 @@ function avatarOptionLabel(value: string): string {
 function ComposerStepOptions({
   step,
   config,
-  justPicked,
   selectOption,
 }: {
   step: ComposerStep;
   config: AvatarSvgConfig;
-  justPicked: string | null;
   selectOption: (selection: AvatarMakerSelection) => void;
 }) {
   return avatarMakerSelections(step).map((selection, index) => {
-    const isPicked = justPicked === `${selection.field}-${selection.value}`;
+    const isPicked = config[selection.field] === selection.value;
     const disabled =
       selection.field === "hair" &&
       !isAvatarComposerCombinationCompatible(
@@ -202,7 +200,7 @@ function ComposerStepOptions({
         type="button"
         disabled={disabled}
         className={cn(
-          "rounded-full transition-all hover:scale-110 disabled:opacity-30 disabled:hover:scale-100",
+          "flex size-14 shrink-0 items-center justify-center rounded-full transition-all hover:scale-110 disabled:opacity-30 disabled:hover:scale-100",
           isPicked && "scale-110 ring-2 ring-[#ed4e01] ring-offset-2",
         )}
         style={{
@@ -212,8 +210,9 @@ function ComposerStepOptions({
           return selectOption(selection);
         }}
         aria-label={avatarOptionLabel(selection.value)}
+        aria-pressed={isPicked}
       >
-        <AvatarSvgPreview config={preview} size={56} />
+        <AvatarSvgPreview config={preview} size={56} centerContent />
       </button>
     );
   });
@@ -373,7 +372,6 @@ function StepOptions({
     <ComposerStepOptions
       step={step}
       config={config}
-      justPicked={justPicked}
       selectOption={selectOption}
     />
   ) : null;

--- a/turbo/apps/platform/src/views/okou-page/avatar-svg-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/avatar-svg-preview.tsx
@@ -11,6 +11,7 @@ interface AvatarSvgPreviewProps {
   config: ResolvedAvatarSvgConfig;
   size?: number;
   className?: string;
+  centerContent?: boolean;
   alt?: string;
   "data-testid"?: string;
 }
@@ -22,13 +23,13 @@ export function AvatarSvgPreview({
   config,
   size,
   className,
+  centerContent = false,
   alt,
   "data-testid": testId,
 }: AvatarSvgPreviewProps) {
   const neckSweater = useGet(avatarNeckSweaterEnabled$);
-  const { behind, head, front, headScale } = avatarSvgComposition(config, {
-    neckSweater,
-  });
+  const { behind, head, front, headScale, contentOffsetY } =
+    avatarSvgComposition(config, { neckSweater });
   const layerClassName = "absolute inset-0 h-full w-full object-cover";
   const layer = (src: string) => {
     return <img key={src} alt="" src={src} className={layerClassName} />;
@@ -43,6 +44,11 @@ export function AvatarSvgPreview({
     >
       <div
         className={`absolute inset-0 ${isLegacyAvatarSvgConfig(config) ? "scale-[1.25]" : ""}`}
+        style={
+          centerContent
+            ? { transform: `translateY(${contentOffsetY}%)` }
+            : undefined
+        }
       >
         {behind.map(layer)}
         <div

--- a/turbo/apps/platform/src/views/okou-page/avatar-svg-utils.ts
+++ b/turbo/apps/platform/src/views/okou-page/avatar-svg-utils.ts
@@ -4,6 +4,7 @@ import {
   randomAvatarComposerConfig,
   type AvatarComposerConfig,
   type AvatarComposerFaceShape,
+  type AvatarComposerHairStyle,
 } from "@okouai/core/agent-avatar";
 import {
   avatarComposerAssetUrl,
@@ -101,6 +102,53 @@ const AVATAR_CHIN_BASELINE_Y = 327.6;
 /** The face pivot (190, 116) of the 380px canvas, as a CSS transform origin. */
 export const AVATAR_HEAD_TRANSFORM_ORIGIN = "50% 30.5263%";
 
+/**
+ * Visible hair tops, including strokes, on the 380px composer canvas. Square
+ * faces use separate hair geometry. Center the artwork rather than its
+ * transparent canvas when displaying it inside a picker option.
+ */
+const AVATAR_HAIR_TOP_Y: Readonly<
+  Record<AvatarComposerHairStyle, readonly [regular: number, square: number]>
+> = {
+  "high-bun": [22, 3],
+  "geometric-long": [116, 81],
+  "center-part": [114, 116],
+  "curly-cap": [74, 92],
+  "long-center-part": [116, 116],
+  sparse: [99, 96],
+  "triple-bun": [43, 68],
+  "rounded-crop": [116, 116],
+  halo: [85, 116],
+  "topknot-locks": [17, 56],
+  "low-pigtails": [116, 116],
+  "ribbon-updo": [45, 51],
+};
+
+function composerContentOffsetY(
+  config: AvatarSvgConfig,
+  headScale: number,
+  neckSweater: boolean,
+): number {
+  const hairTop =
+    AVATAR_HAIR_TOP_Y[config.hair][config.face === "square" ? 1 : 0];
+  const hairBottom =
+    config.hair === "low-pigtails"
+      ? config.face === "square"
+        ? 370
+        : 348
+      : config.hair === "geometric-long" || config.hair === "long-center-part"
+        ? 316
+        : AVATAR_FACE_CHIN_Y[config.face];
+  const top = Math.max(
+    0,
+    AVATAR_FACE_TOP_Y + (hairTop - AVATAR_FACE_TOP_Y) * headScale,
+  );
+  const bottom = neckSweater
+    ? 380
+    : Math.min(380, Math.max(AVATAR_FACE_CHIN_Y[config.face], hairBottom));
+  return ((380 - top - bottom) / 2 / 380) * 100;
+}
+
 interface AvatarSvgComposition {
   /** Drawn behind the head, and never scaled with it. */
   readonly behind: readonly string[];
@@ -109,6 +157,8 @@ interface AvatarSvgComposition {
   /** Drawn in front of the head, and never scaled with it. */
   readonly front: readonly string[];
   readonly headScale: number;
+  /** Percentage translation that centers the visible artwork vertically. */
+  readonly contentOffsetY: number;
 }
 
 /**
@@ -135,6 +185,7 @@ export function avatarSvgComposition(
       ],
       front: [],
       headScale: 1,
+      contentOffsetY: 0,
     };
   }
 
@@ -149,15 +200,23 @@ export function avatarSvgComposition(
     ),
   ];
   if (!neckSweater) {
-    return { behind: [], head, front: [], headScale: 1 };
+    return {
+      behind: [],
+      head,
+      front: [],
+      headScale: 1,
+      contentOffsetY: composerContentOffsetY(config, 1, false),
+    };
   }
+  const headScale =
+    (AVATAR_CHIN_BASELINE_Y - AVATAR_FACE_TOP_Y) /
+    (AVATAR_FACE_CHIN_Y[config.face] - AVATAR_FACE_TOP_Y);
   return {
     behind: [avatarComposerAssetUrl(`neck/${config.skin}.svg`)],
     head,
     front: [avatarComposerAssetUrl(`sweater/${config.sweater}.svg`)],
-    headScale:
-      (AVATAR_CHIN_BASELINE_Y - AVATAR_FACE_TOP_Y) /
-      (AVATAR_FACE_CHIN_Y[config.face] - AVATAR_FACE_TOP_Y),
+    headScale,
+    contentOffsetY: composerContentOffsetY(config, headScale, true),
   };
 }
 


### PR DESCRIPTION
Selecting an avatar option previously advanced to the next category after 350 ms, preventing users from comparing alternatives. Keep the current category open until the user clicks a navigation arrow, and retain the selected option's highlight while trying other choices.

Center the visible avatar artwork within circular composer options. Account for each hairstyle's transparent padding, square-face geometry, and the neck/sweater setting when positioning the layered preview.

## Verification

- Avatar profile integration tests: 16 passed, including repeated selections after feedback completes, manual category navigation, and saving/reopening the selected avatar
- Regression validation: temporarily restoring the old delayed auto-advance makes the updated page test fail after selecting Round; the fixed implementation passes
- Formatting, repository lint (14 workspaces), type checking (15 tasks), and Knip passed
- Browser rendering inspection: all 144 face/hairstyle/neck-setting combinations centered within 0.15 px at the 56 px option size
- PR preview: PASS on desktop (1440 × 900) and mobile (390 × 844), with no horizontal overflow
- Repeated face, hair, and color selections stay in their category after the selection animation finishes; arrows navigate explicitly, and saving/reopening restores the final face, hair, skin, expression, and sweater

## Preview evidence

- App: https://pr-31852-app-okou-app-preview.vm0.workers.dev
- API: https://pr-31852-api.vm6.ai
- Browser-verified implementation: `30c0e960ac7928a18876125d826b150f78220d17`; deployed merge artifact: `0a281afeedc8e43f0f0c5bce37aad53675aef53b`. Changes after that preview add only the feedback test selector and regression synchronization.
- Fixture: fresh preview admin account, normal Explore onboarding, and a disposable `Avatar QA 31852` agent; `avatarComposerV2` and `avatarNeckSweater` enabled; no agent runs needed
- [Desktop screenshot](https://a.okou.io/9ryy417cym.png) · [Mobile screenshot](https://a.okou.io/nuh5g03r37.png)
