### PR TITLE
fix(platform): keep account switch cards at a fixed height

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
@@ -3,7 +3,7 @@ import {
   connectorAccountExternalIdentity,
   type ConnectorAccountConnection,
 } from "@okouai/api-contracts/contracts/connector-accounts";
-import { Button } from "@okouai/ui";
+import { Button, cn } from "@okouai/ui";
 import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { AlertCircle, Check, Loader2 } from "lucide-react";
@@ -17,6 +17,8 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { CustomConnectorIcon } from "./components/settings/custom-connector-icon.tsx";
+
+const ACCOUNT_ACTION_CARD_HEIGHT_CLASS = "h-[136px] sm:h-[88px]";
 
 export function ConnectorAccountActionCard({
   signals,
@@ -46,7 +48,10 @@ function ConnectorAccountActionCardLoading() {
   return (
     <div
       data-testid="connector-account-action-card-loading"
-      className="okou-chat-card flex min-h-[104px] w-full items-center justify-center p-3"
+      className={cn(
+        "okou-chat-card flex w-full items-center justify-center p-3",
+        ACCOUNT_ACTION_CARD_HEIGHT_CLASS,
+      )}
     >
       <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
     </div>
@@ -63,15 +68,23 @@ function ConnectorAccountActionCardError({
   return (
     <div
       data-testid="connector-account-action-card-error"
-      className="okou-chat-card flex min-h-[104px] w-full items-center gap-3 p-3"
+      className={cn(
+        "okou-chat-card flex w-full items-center gap-3 p-3",
+        ACCOUNT_ACTION_CARD_HEIGHT_CLASS,
+      )}
     >
       <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
-      <div className="min-w-0 flex-1 text-sm text-muted-foreground">
+      <div className="min-w-0 flex-1 line-clamp-3 text-sm leading-5 text-muted-foreground">
         {t(($) => {
           return $.chat.connectorAccountSwitch.loadFailed;
         })}
       </div>
-      <Button size="sm" variant="outline" onClick={refresh}>
+      <Button
+        size="sm"
+        variant="outline"
+        className="shrink-0"
+        onClick={refresh}
+      >
         {t(($) => {
           return $.chat.connectorAccountSwitch.retry;
         })}
@@ -98,18 +111,21 @@ function UnavailableConnectorAccountActionCard() {
   return (
     <div
       data-testid="connector-account-action-card-unavailable"
-      className="okou-chat-card flex min-h-[104px] w-full items-center gap-3 p-3"
+      className={cn(
+        "okou-chat-card flex w-full items-center gap-3 p-3",
+        ACCOUNT_ACTION_CARD_HEIGHT_CLASS,
+      )}
     >
       <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">
         <AlertCircle size={22} />
       </div>
       <div className="min-w-0">
-        <div className="text-[0.9375rem] font-medium text-foreground">
+        <div className="truncate text-[0.9375rem] font-medium leading-5 text-foreground">
           {t(($) => {
             return $.chat.connectorAccountSwitch.unavailableTitle;
           })}
         </div>
-        <div className="mt-0.5 text-sm leading-5 text-muted-foreground">
+        <div className="mt-0.5 line-clamp-2 text-sm leading-5 text-muted-foreground">
           {t(($) => {
             return $.chat.connectorAccountSwitch.unavailableDescription;
           })}
@@ -126,6 +142,41 @@ function accountTargetLabel(
   return account.target.kind === "builtin"
     ? account.target.connectorSlug
     : `${customConnectorLabel} · ${account.target.customConnectorId.slice(0, 8)}`;
+}
+
+function ConnectorAccountActionNotice({
+  reconnectRequired,
+  switchFailed,
+}: {
+  readonly reconnectRequired: boolean;
+  readonly switchFailed: boolean;
+}) {
+  const { t } = useTranslation();
+  const accountStatus = [
+    switchFailed
+      ? t(($) => {
+          return $.chat.connectorAccountSwitch.actionFailed;
+        })
+      : null,
+    reconnectRequired
+      ? t(($) => {
+          return $.chat.connectorAccountSwitch.reconnectRequired;
+        })
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return accountStatus ? (
+    <div
+      className={cn(
+        "mt-1 truncate text-xs leading-4",
+        switchFailed ? "text-destructive" : "text-muted-foreground",
+      )}
+      title={accountStatus}
+    >
+      {accountStatus}
+    </div>
+  ) : null;
 }
 
 function ReadyConnectorAccountActionCard({
@@ -173,79 +224,75 @@ function ReadyConnectorAccountActionCard({
   return (
     <div
       data-testid="connector-account-action-card"
-      className="okou-chat-card w-full p-3 text-left"
+      className={cn(
+        "okou-chat-card flex w-full flex-col justify-between gap-3 p-3 text-left sm:flex-row sm:items-center",
+        ACCOUNT_ACTION_CARD_HEIGHT_CLASS,
+      )}
     >
-      <div className="flex items-start gap-3">
+      <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">
           {connectorIcon}
         </div>
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5 truncate text-[0.9375rem] font-medium text-foreground">
+          <div className="flex items-center gap-1.5 text-[0.9375rem] font-medium leading-5 text-foreground">
             {selected ? (
               <Check
                 size={15}
                 className="shrink-0 text-emerald-600 dark:text-emerald-400"
               />
             ) : null}
-            {selected
-              ? t(
-                  ($) => {
-                    return $.chat.connectorAccountSwitch.selected;
-                  },
-                  { account: accountLabel },
-                )
-              : t(
-                  ($) => {
-                    return $.chat.connectorAccountSwitch.title;
-                  },
-                  { account: accountLabel },
-                )}
+            <span className="truncate">
+              {selected
+                ? t(
+                    ($) => {
+                      return $.chat.connectorAccountSwitch.selected;
+                    },
+                    { account: accountLabel },
+                  )
+                : t(
+                    ($) => {
+                      return $.chat.connectorAccountSwitch.title;
+                    },
+                    { account: accountLabel },
+                  )}
+            </span>
           </div>
-          <div className="mt-0.5 truncate text-sm text-muted-foreground">
+          <div className="mt-0.5 truncate text-sm leading-5 text-muted-foreground">
             {[target, identity && identity !== accountLabel ? identity : null]
               .filter(Boolean)
               .join(" · ")}
           </div>
-          {status.account.connectionStatus === "reconnect-required" ? (
-            <div className="mt-1 text-xs text-muted-foreground">
-              {t(($) => {
-                return $.chat.connectorAccountSwitch.reconnectRequired;
-              })}
-            </div>
-          ) : null}
-          {switchFailed ? (
-            <div className="mt-1 text-xs text-destructive">
-              {t(($) => {
-                return $.chat.connectorAccountSwitch.actionFailed;
-              })}
-            </div>
-          ) : null}
+          <ConnectorAccountActionNotice
+            reconnectRequired={
+              status.account.connectionStatus === "reconnect-required"
+            }
+            switchFailed={switchFailed}
+          />
         </div>
-        {selected ? null : (
-          <Button
-            size="sm"
-            disabled={switching}
-            onClick={() => {
-              detach(confirm(pageSignal), Reason.DomCallback);
-            }}
-          >
-            {switching ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : null}
-            {switching
-              ? t(($) => {
-                  return $.chat.connectorAccountSwitch.switching;
-                })
-              : switchFailed
-                ? t(($) => {
-                    return $.chat.connectorAccountSwitch.retry;
-                  })
-                : t(($) => {
-                    return $.chat.connectorAccountSwitch.switch;
-                  })}
-          </Button>
-        )}
       </div>
+      {selected ? null : (
+        <Button
+          size="sm"
+          className="w-full shrink-0 sm:w-auto"
+          disabled={switching}
+          onClick={() => {
+            detach(confirm(pageSignal), Reason.DomCallback);
+          }}
+        >
+          {switching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          {switching
+            ? t(($) => {
+                return $.chat.connectorAccountSwitch.switching;
+              })
+            : switchFailed
+              ? t(($) => {
+                  return $.chat.connectorAccountSwitch.retry;
+                })
+              : t(($) => {
+                  return $.chat.connectorAccountSwitch.switch;
+                })}
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Account switch cards previously reserved 104px while loading and resized to their content when ready, moving the following chat messages. All states now share fixed heights of 136px on mobile and 88px from the `sm` breakpoint, matching the connector action card dimensions.

The action button uses the connector card's mobile layout. Explicit line heights, truncated account details, and one bounded notice line keep long names and simultaneous switch/reconnect errors inside the card; the notice retains its full text in a title attribute.

## Verification

- Chromium fixture built from the actual React component and application Tailwind stylesheet: 540 cases across 320/640/1280px viewports, all 10 locales, normal/long account names, and loading/ready/switching/failed/reconnect/reconnect-failed/selected/unavailable/load-error states. Card heights matched exactly, the following message did not move, and no content extended outside the card. This was isolated component verification with fixture data.
- Prettier, platform static asset/localization/build configuration checks, Oxlint, type-aware Oxlint, ESLint, platform TypeScript checks, scoped Knip, and `git diff --check` passed.
- Full Vitest execution is left to the PR pipeline; no local development server was started.
