### PR TITLE
fix: improve voice draft input feedback

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -2213,7 +2213,7 @@ function createInsertTextCommands(editor: Editor) {
     const { from, to } = editor.state.selection;
     const transaction = editor.state.tr.insertText(value, from, to);
     transaction.setSelection(
-      TextSelection.create(transaction.doc, from, from + value.length),
+      TextSelection.create(transaction.doc, from + value.length),
     );
     editor.view.dispatch(transaction.scrollIntoView());
     editor.view.focus();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-input.test.tsx
@@ -99,7 +99,7 @@ async function activeVoiceDraftStopButton(): Promise<HTMLElement> {
   expect(
     screen.getByText(/^\d{2}:\d{2}$/u, { selector: "time" }),
   ).toBeVisible();
-  expect(screen.queryByLabelText("Attach files")).not.toBeInTheDocument();
+  expect(queryButton("Attach")).toBeNull();
   return stop;
 }
 
@@ -227,6 +227,7 @@ test("Toggle voice input from the focused composer shortcut", async () => {
 });
 
 test("Transcribe a voice draft using the latest assistant reference", async () => {
+  const user = userEvent.setup({ delay: null });
   const transcriptionStarted = context.mocks.deferred<void>();
   const transcriptionReady = context.mocks.deferred<void>();
   context.mocks.browser.voiceInput({ rms: 0.12 });
@@ -292,42 +293,63 @@ test("Transcribe a voice draft using the latest assistant reference", async () =
       "Opening Send the launch update tomorrow. closing",
     );
   });
-  expect(window.getSelection()?.toString()).toBe(
-    "Send the launch update tomorrow.",
+  expect(window.getSelection()?.isCollapsed).toBeTruthy();
+  expect(currentComposer()).toHaveFocus();
+  await user.keyboard(" Additional note.");
+  expect(normalizedComposerText()).toBe(
+    "Opening Send the launch update tomorrow. Additional note. closing",
   );
   expectNoVoiceDraftNode();
   await expect(findButton("Send")).resolves.toBeEnabled();
   expect(queryButton("Finish")).toBeNull();
 });
 
-test("Keep voice-draft recording outside TipTap while the microphone starts", async () => {
-  const microphoneReady = context.mocks.deferred<void>();
-  context.mocks.browser.voiceInput({
-    getUserMediaReady: microphoneReady.promise,
-    rms: 0,
-  });
-  installAvailableVoiceQuota();
-  installRunChat();
+test.each(["button", "keyboard"])(
+  "Show microphone startup before the voice-draft waveform via %s",
+  async (trigger) => {
+    const user = userEvent.setup({ delay: null });
+    const microphoneReady = context.mocks.deferred<void>();
+    context.mocks.browser.voiceInput({
+      getUserMediaReady: microphoneReady.promise,
+      rms: 0,
+    });
+    installAvailableVoiceQuota();
+    installRunChat();
 
-  await setupPage({
-    context,
-    path: RUN_PATH,
-    featureSwitches: { [FeatureSwitchKey.VoiceDraft]: true },
-  });
+    await setupPage({
+      context,
+      path: RUN_PATH,
+      featureSwitches: {
+        [FeatureSwitchKey.VoiceDraft]: true,
+        [FeatureSwitchKey.ComposerVoiceInputShortcut]: true,
+      },
+    });
 
-  click(await readyVoiceInput());
+    const voiceInput = await readyVoiceInput();
+    if (trigger === "button") {
+      click(voiceInput);
+    } else {
+      currentComposer().focus();
+      await user.keyboard("{Control>}{Shift>}e{/Shift}{/Control}");
+    }
 
-  await expect(findButton("Stop recording")).resolves.toBeDisabled();
-  expectNoVoiceDraftNode();
+    const starting = await findButton("Starting voice input");
+    expect(starting).toBeDisabled();
+    expect(starting).toHaveAttribute("aria-busy", "true");
+    expect(queryButton("Stop recording")).toBeNull();
+    expect(queryButton("Attach")).toBeVisible();
+    expect(document.querySelector("[data-voice-level-waveform]")).toBeNull();
+    expectNoVoiceDraftNode();
 
-  microphoneReady.resolve(undefined);
+    microphoneReady.resolve(undefined);
 
-  await activeVoiceDraftStopButton();
-  expectNoVoiceDraftNode();
-  expect(
-    document.querySelector("[data-voice-level-waveform]"),
-  ).toBeInTheDocument();
-});
+    await activeVoiceDraftStopButton();
+    expectNoVoiceDraftNode();
+    expect(
+      document.querySelector("[data-voice-level-waveform]"),
+    ).toBeInTheDocument();
+  },
+);
 
 test("Keep a silent voice draft recording until the user stops it", async () => {
   const voiceActivityObserved = context.mocks.deferred<void>();
@@ -528,7 +550,7 @@ test("Release a late microphone stream after navigating away during voice startu
   });
 
   click(await readyVoiceInput());
-  await expect(findButton("Stop recording")).resolves.toBeDisabled();
+  await expect(findButton("Starting voice input")).resolves.toBeDisabled();
   await waitFor(() => {
     expect(microphoneRequest).toHaveBeenCalledOnce();
   });
@@ -584,7 +606,8 @@ test("Release the microphone and allow retry when PCM startup fails", async () =
   const voiceInput = await readyVoiceInput();
   await fill(currentComposer(), "Keep these typed notes. ");
   click(voiceInput);
-  await expect(findButton("Stop recording")).resolves.toBeDisabled();
+  await expect(findButton("Starting voice input")).resolves.toBeDisabled();
+  expect(document.querySelector("[data-voice-level-waveform]")).toBeNull();
   await waitFor(() => {
     expect(pcmWorkletReady).toHaveBeenCalledOnce();
   });
@@ -593,7 +616,11 @@ test("Release the microphone and allow retry when PCM startup fails", async () =
   await expect(
     screen.findByText("Voice transcription failed. Try again."),
   ).resolves.toBeVisible();
-  await expect(findButton("Voice input")).resolves.toBeEnabled();
+  const restoredVoiceInput = await findButton("Voice input");
+  expect(restoredVoiceInput).toBeEnabled();
+  expect(restoredVoiceInput).toHaveAttribute("aria-busy", "false");
+  expect(queryButton("Attach")).toBeVisible();
+  expect(document.querySelector("[data-voice-level-waveform]")).toBeNull();
   expect(normalizedComposerText()).toBe("Keep these typed notes.");
   expect(microphoneStops).toBe(1);
   expect(audioContextCloses).toBe(1);

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8560,7 +8560,7 @@ function MicButton({ signals }: { signals: ComposerSignals }) {
   const starting = useGet(sttStarting$);
   const sttTranscribing = useGet(sttTranscribing$);
   const recording = voiceDraftEnabled
-    ? voiceDraftStatus === "recording"
+    ? voiceDraftStatus === "recording" && sttRecording
     : sttRecording;
   const transcribing = voiceDraftEnabled
     ? voiceDraftStatus === "transcribing"
@@ -8603,6 +8603,7 @@ function MicButton({ signals }: { signals: ComposerSignals }) {
             onClick={handleClick}
             disabled={disabled}
             aria-label={micButtonAriaLabel(status)}
+            aria-busy={starting || transcribing}
             aria-keyshortcuts={
               voiceInputShortcutEnabled
                 ? COMPOSER_VOICE_INPUT_ARIA_KEY_SHORTCUTS
@@ -10554,9 +10555,12 @@ function ComposerConnectorsSlot({ signals }: { signals: ComposerSignals }) {
 function ComposerFooter({ signals }: { signals: ComposerSignals }) {
   const voiceDraftEnabled = useGet(voiceDraftEnabled$);
   const voiceDraftStatus = useGet(signals.voice.status$);
+  const recording = useGet(sttRecording$);
   return (
     <div className="flex items-center justify-between gap-1 px-4 pb-4 pt-1 sm:gap-2">
-      {voiceDraftEnabled && voiceDraftStatus !== "idle" ? (
+      {voiceDraftEnabled &&
+      (voiceDraftStatus === "transcribing" ||
+        (voiceDraftStatus === "recording" && recording)) ? (
         <VoiceDraftFooter signals={signals} status={voiceDraftStatus} />
       ) : (
         <>


### PR DESCRIPTION
Voice Draft now leaves the caret after the inserted transcript so continued typing preserves the new text. Starting voice input keeps the regular composer controls visible and shows the existing loading indicator in the mic button until audio capture is ready; only then does the waveform appear. Startup failure restores the idle mic button and preserves the typed draft.

Validation:

- All 23 targeted voice-input and voice-quota integration tests passed, covering caret placement and continued typing, button and keyboard startup, failed startup and retry, navigation cancellation, and ordinary dictation.
- Scoped formatting, Oxlint, type-aware Oxlint, ESLint, App type checks, Knip, file-size checks, and commitlint passed.
- Browser verification passed in Chrome 151 at 1440 x 900 and 390 x 844 on https://pr-31866-app-okou-app-preview.vm0.workers.dev, with `voiceDraft` and `composerVoiceInputShortcut` enabled for a fresh test account. Build `6af7011a9fbfc1a0a1d7fa0dc597a19762b8ca3a` includes PR head `5f38d90c934eef463f7c0f58a4bed948a33c4fa6`; the API preview is https://pr-31866-api.vm6.ai.
- Browser checks used a native audio stream with controlled microphone permission and a controlled transcription response. Verified loading before the waveform, successful PCM capture, collapsed selection with continued typing, keyboard startup, permission-denial recovery, retry, hover feedback, and no horizontal overflow. Test audio and response overrides were removed afterward.
- All 61 non-skipped PR checks passed.
