### PR TITLE
feat(api): route api-key terra fast through pi

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -51,7 +51,10 @@ import {
 } from "@okouai/api-contracts/contracts/model-providers";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import { modelProviderConnectionsMainContract } from "@okouai/api-contracts/contracts/model-provider-gateways";
-import { modelProvidersMainContract } from "@okouai/api-contracts/contracts/model-provider-routes";
+import {
+  modelProvidersByTypeContract,
+  modelProvidersMainContract,
+} from "@okouai/api-contracts/contracts/model-provider-routes";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { v5 as uuidv5 } from "uuid";
 import { z } from "zod";
@@ -277,6 +280,22 @@ const STANDARD_TERRA_API_KEY_BDD_ROUTES = [
     runtimeModel: "openai/gpt-5.6-terra",
   },
 ] as const;
+const USER_OWNED_TERRA_FAST_BDD_ROUTES = [
+  {
+    name: "subscription",
+    type: "codex-oauth-token",
+    endpoint: "https://chatgpt.com/backend-api/codex/responses",
+    runtimeModel: "gpt-5.6-terra",
+    wireTier: "fast",
+  },
+  ...STANDARD_TERRA_API_KEY_BDD_ROUTES.map((route) => {
+    return {
+      ...route,
+      wireTier: "priority" as const,
+    };
+  }),
+] as const;
+
 const TERRA_USAGE_PRICING = [
   "tokens.input",
   "tokens.output",
@@ -714,6 +733,48 @@ async function configureBuiltInPiModel(
       modelProviderId: null,
     },
   ]);
+}
+
+async function configureApiKeyTerraPiModel(
+  actor: ApiTestUser,
+  route: (typeof STANDARD_TERRA_API_KEY_BDD_ROUTES)[number],
+  secret: string,
+): Promise<string> {
+  await authDeviceSupport.updateFeatureSwitches(actor, {
+    [FeatureSwitchKey.PiLoop]: true,
+    [FeatureSwitchKey.CodexFastMode]: true,
+  });
+  const { providerId } = await upsertOrgModelProvider(actor, {
+    type: route.type,
+    secret,
+  });
+  await api.updateOrgModelPolicies(actor, [
+    {
+      model: "gpt-5.6-terra",
+      isDefault: true,
+      defaultProviderType: route.type,
+      credentialScope: "org",
+      modelProviderId: providerId,
+    },
+  ]);
+  return providerId;
+}
+
+async function configureUserOwnedTerraPiModel(
+  actor: ApiTestUser,
+  route: (typeof USER_OWNED_TERRA_FAST_BDD_ROUTES)[number],
+): Promise<{ readonly secret: string; readonly accountId: string | null }> {
+  if (route.type === "codex-oauth-token") {
+    const accountId = "subscription-continuity-account";
+    const { oauth } = await configureSubscriptionPiModel(actor, { accountId });
+    return {
+      secret: z.string().parse(oauth.oauthTokenResponses[0]?.access_token),
+      accountId,
+    };
+  }
+  const secret = `${route.type}-pi-fixture-key`;
+  await configureApiKeyTerraPiModel(actor, route, secret);
+  return { secret, accountId: null };
 }
 
 async function configureSubscriptionPiModel(
@@ -5131,6 +5192,95 @@ function piResponsesToolSse(args: {
       return `data: ${JSON.stringify(event)}\n\n`;
     })
     .join("");
+}
+
+function expectApiKeyTerraRequest(
+  request: unknown,
+  route: (typeof STANDARD_TERRA_API_KEY_BDD_ROUTES)[number],
+  secret: string,
+  tier: "fast" | undefined,
+): void {
+  expect(request).toMatchObject({
+    authorization: `Bearer ${secret}`,
+    body: {
+      model: route.runtimeModel,
+      stream: true,
+      store: false,
+      reasoning: { effort: "low" },
+    },
+  });
+  const { body } = z
+    .object({ body: z.record(z.string(), z.unknown()) })
+    .parse(request);
+  expect(body.service_tier).toBe(tier === "fast" ? "priority" : undefined);
+  expect(body).not.toHaveProperty("previous_response_id");
+}
+
+async function claimTerraPiSandbox(
+  actor: ApiTestUser,
+  runId: string,
+  tier: "fast" | undefined,
+) {
+  for (const generations of tier === "fast"
+    ? [undefined, [1, 2]]
+    : [undefined]) {
+    const oldClaim = await api.requestClaimRunnerJob(true, runId, [404], {
+      capabilities:
+        generations === undefined
+          ? undefined
+          : { piModelConfigGenerations: generations },
+    });
+    expectApiError(oldClaim.body);
+    await expect(api.readRun(actor, runId)).resolves.toMatchObject({
+      status: "pending",
+    });
+  }
+  return await api.claimRunnerJob(runId, {
+    capabilities: {
+      piModelConfigGenerations: tier === "fast" ? [1, 2, 3] : [1, 2],
+    },
+  });
+}
+
+function expectApiKeyTerraSandboxCarrier(
+  claim: Awaited<ReturnType<typeof api.claimRunnerJob>>,
+  route: (typeof STANDARD_TERRA_API_KEY_BDD_ROUTES)[number],
+  tier: "fast" | undefined,
+): void {
+  expect(claim.piModelConfig).toStrictEqual({
+    schemaVersion: tier === undefined ? 2 : 3,
+    ...(tier === undefined ? {} : { serviceTier: "priority" }),
+    dialect: "openai-responses",
+    transport: "sse",
+    provider: route.piProvider,
+    baseUrl: route.baseUrl,
+    model: route.runtimeModel,
+    ...(route.type === "vercel-ai-gateway-codex"
+      ? { catalogModel: route.catalogModel }
+      : {}),
+    thinkingLevel: "low",
+    credentialBindings: [
+      {
+        kind: "api-key",
+        environment: "OPENAI_API_KEY",
+        secretName: route.secretName,
+      },
+    ],
+  });
+  expect(claimEnvironment(claim)).toMatchObject({
+    OPENAI_API_KEY: modelProviderSecretPlaceholder(
+      route.type,
+      route.secretName,
+    ),
+    OPENAI_MODEL: route.runtimeModel,
+  });
+  expect(claim.billableFirewalls).toStrictEqual([]);
+  expect(claim.secretConnectorMap?.[route.secretName]).toBe(route.type);
+  expect(claim.secretConnectorMetadataMap?.[route.secretName]).toStrictEqual({
+    sourceType: "model-provider",
+    sourceUserId: "__org__",
+    metadataKey: route.type,
+  });
 }
 
 function expectNativeSubscriptionRequest(
@@ -11251,32 +11401,27 @@ describe("CHAT-02: model-first provider policies", () => {
     30_000,
   );
 
-  it.each(STANDARD_TERRA_API_KEY_BDD_ROUTES)(
-    "runs $name API-key Terra through API-first and generation-2 Sandbox across credential rotation",
+  it.each(
+    STANDARD_TERRA_API_KEY_BDD_ROUTES.flatMap((route) => {
+      return [
+        { ...route, tier: undefined, generation: 2, outcome: "completed" },
+        { ...route, tier: "fast", generation: 3, outcome: "completed" },
+        { ...route, tier: "fast", generation: 3, outcome: "failed" },
+        { ...route, tier: "fast", generation: 3, outcome: "cancelled" },
+      ] as const;
+    }),
+  )(
+    "runs $name API-key Terra $tier through API-first and generation-$generation Sandbox with $outcome and credential rotation",
     async (route) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       const firewall = createFirewallApi(context);
-      const orgId = requireOrgId(actor);
       chatCallbacks.failIfChatCallbackRouteIsFetched();
-      await updateFeatureSwitchesForUser(
-        context,
-        { ...actor, orgId },
-        { [FeatureSwitchKey.PiLoop]: true },
-      );
       const initialSecret = `${route.type}-initial-secret`;
-      const { providerId } = await upsertOrgModelProvider(actor, {
-        type: route.type,
-        secret: initialSecret,
-      });
-      await api.updateOrgModelPolicies(actor, [
-        {
-          model: "gpt-5.6-terra",
-          isDefault: true,
-          defaultProviderType: route.type,
-          credentialScope: "org",
-          modelProviderId: providerId,
-        },
-      ]);
+      const providerId = await configureApiKeyTerraPiModel(
+        actor,
+        route,
+        initialSecret,
+      );
       mockPiResourceArchiveDownloads();
       const checkpointObjects = mockPiCheckpointObjectStore();
       const providerRequests: {
@@ -11320,6 +11465,7 @@ describe("CHAT-02: model-first provider policies", () => {
         agentId,
         prompt: firstPrompt,
         model: "gpt-5.6-terra",
+        runOptions: { codexServiceTier: route.tier },
       });
       const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${first.runId}/manifest.json`;
       const sessionKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${first.runId}/session.jsonl`;
@@ -11345,49 +11491,13 @@ describe("CHAT-02: model-first provider policies", () => {
       await expectNoBuiltInModelUsage(first.runId);
 
       await api.heartbeatRunner(runnerGroup);
-      const legacyClaim = await api.requestClaimRunnerJob(
-        true,
-        first.runId,
-        [404],
-      );
-      expectApiError(legacyClaim.body);
-      await expect(api.readRun(actor, first.runId)).resolves.toMatchObject({
-        status: "pending",
-      });
-      const claim = await api.claimRunnerJob(first.runId, {
-        capabilities: { piModelConfigGenerations: [1, 2] },
-      });
+      const claim = await claimTerraPiSandbox(actor, first.runId, route.tier);
       const sandboxHeaders = {
         authorization: `Bearer ${claim.sandboxToken}`,
       };
       expect(claim.cliAgentType).toBe("pi");
       expect(claim.piSessionId).toBe(first.threadId);
-      expect(claim.piModelConfig).toStrictEqual({
-        schemaVersion: 2,
-        dialect: "openai-responses",
-        transport: "sse",
-        provider: route.piProvider,
-        baseUrl: route.baseUrl,
-        model: route.runtimeModel,
-        ...(route.type === "vercel-ai-gateway-codex"
-          ? { catalogModel: route.catalogModel }
-          : {}),
-        thinkingLevel: "low",
-        credentialBindings: [
-          {
-            kind: "api-key",
-            environment: "OPENAI_API_KEY",
-            secretName: route.secretName,
-          },
-        ],
-      });
-      expect(claimEnvironment(claim)).toMatchObject({
-        OPENAI_API_KEY: modelProviderSecretPlaceholder(
-          route.type,
-          route.secretName,
-        ),
-        OPENAI_MODEL: route.runtimeModel,
-      });
+      expectApiKeyTerraSandboxCarrier(claim, route, route.tier);
       expect(JSON.stringify(claim)).not.toContain(initialSecret);
       if (!claim.encryptedSecrets) {
         throw new Error("Expected API-key Terra claim credentials");
@@ -11472,7 +11582,10 @@ describe("CHAT-02: model-first provider policies", () => {
         stopReason: "stop",
         timestamp: 3,
       });
+      expect(h1Bytes.toString("utf8")).not.toMatch(/serviceTier|service_tier/);
+      expect(h1Bytes.toString("utf8")).not.toContain(initialSecret);
       const h2 = h2Session.toJsonl();
+      expect(h2).not.toMatch(/serviceTier|service_tier/);
       const h2Hash = createHash("sha256").update(h2).digest("hex");
       await webhooks.requestAgentCheckpointPrepareHistory(
         {
@@ -11511,10 +11624,16 @@ describe("CHAT-02: model-first provider policies", () => {
         sandboxHeaders,
         [200],
       );
+      if (route.outcome === "cancelled") {
+        await cancelChatRun(actor, first.runId);
+      }
       await webhooks.requestAgentComplete(
         {
           runId: first.runId,
-          exitCode: 0,
+          exitCode: route.outcome === "failed" ? 1 : 0,
+          ...(route.outcome === "failed"
+            ? { error: "API-key Sandbox failed" }
+            : {}),
           lastEventSequence: sandboxEventSequenceStart + 1,
           checkpoint: {
             cliAgentType: "pi",
@@ -11523,11 +11642,40 @@ describe("CHAT-02: model-first provider policies", () => {
           },
         },
         sandboxHeaders,
+        route.outcome === "cancelled" ? [400] : [200],
+      );
+      await waitForRunStatus(actor, first.runId, route.outcome);
+      await flushWaitUntilForTest();
+      await webhooks.requestAgentComplete(
+        { runId: first.runId, exitCode: 0 },
+        sandboxHeaders,
         [200],
       );
-      await waitForRunStatus(actor, first.runId, "completed");
       await flushWaitUntilForTest();
+      expect(providerRequests).toHaveLength(1);
+      expectApiKeyTerraRequest(
+        providerRequests[0],
+        route,
+        initialSecret,
+        route.tier,
+      );
       await expectNoBuiltInModelUsage(first.runId);
+      const terminal = await api.readRun(actor, first.runId);
+      expect(terminal).toMatchObject({ status: route.outcome });
+      expect(
+        JSON.stringify({
+          terminal,
+          events: (await chat.listThreadEvents(actor, first.threadId)).events,
+          h2,
+          telemetry: [
+            ...context.mocks.axiomLogging.debug.mock.calls,
+            ...context.mocks.axiomLogging.warn.mock.calls,
+          ],
+        }),
+      ).not.toContain(initialSecret);
+      if (route.outcome !== "completed") {
+        return;
+      }
       const firstSession = await readThreadSessionConversation(
         context,
         first.threadId,
@@ -11539,10 +11687,17 @@ describe("CHAT-02: model-first provider policies", () => {
         threadId: first.threadId,
         prompt: followUpPrompt,
         model: "gpt-5.6-terra",
+        runOptions: { codexServiceTier: route.tier },
       });
       await waitForRunStatus(actor, followUp.runId, "completed");
       await flushWaitUntilForTest();
       expect(providerRequests).toHaveLength(2);
+      expectApiKeyTerraRequest(
+        providerRequests[1],
+        route,
+        initialSecret,
+        route.tier,
+      );
       expect(providerRequests[1]).toMatchObject({
         authorization: `Bearer ${initialSecret}`,
         body: {
@@ -11574,11 +11729,18 @@ describe("CHAT-02: model-first provider policies", () => {
           threadId: first.threadId,
           prompt: `continue after rotating the ${route.name} credential`,
           model: "gpt-5.6-terra",
+          runOptions: { codexServiceTier: route.tier },
         });
       });
       await waitForRunStatus(actor, rotated.runId, "completed");
       await flushWaitUntilForTest();
       expect(providerRequests).toHaveLength(3);
+      expectApiKeyTerraRequest(
+        providerRequests[2],
+        route,
+        rotatedSecret,
+        route.tier,
+      );
       expect(providerRequests[2]).toMatchObject({
         authorization: `Bearer ${rotatedSecret}`,
         body: {
@@ -11623,6 +11785,194 @@ describe("CHAT-02: model-first provider policies", () => {
       ]);
       expect(piLogCalls).not.toContain(initialSecret);
       expect(piLogCalls).not.toContain(rotatedSecret);
+      const publicState = JSON.stringify({
+        run: await api.readRun(actor, rotated.runId),
+        events: (await chat.listThreadEvents(actor, first.threadId)).events,
+      });
+      expect(publicState).not.toContain(initialSecret);
+      expect(publicState).not.toContain(rotatedSecret);
+      const histories = [...checkpointObjects].filter(([key]) => {
+        return key.endsWith(".blob") || key.endsWith(".jsonl");
+      });
+      expect(histories).not.toHaveLength(0);
+      for (const [, value] of histories) {
+        const jsonl = value.toString("utf8");
+        expect(jsonl).not.toMatch(/serviceTier|service_tier/);
+        expect(jsonl).not.toContain(initialSecret);
+        expect(jsonl).not.toContain(rotatedSecret);
+      }
+    },
+    90_000,
+  );
+
+  it.each(STANDARD_TERRA_API_KEY_BDD_ROUTES)(
+    "fails closed when the admitted $name Fast credential disappears before provider ownership",
+    async (route) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const secret = `${route.type}-deleted-secret`;
+      await configureApiKeyTerraPiModel(actor, route, secret);
+      const entered = createDeferredPromise<void>(context.signal);
+      const release = createDeferredPromise<void>(context.signal);
+      const objects = mockPiCheckpointObjectStore();
+      const providerRequests: string[] = [];
+      server.use(
+        http.get(PI_RESOURCE_ARCHIVE_DOWNLOAD_URL, async ({ request }) => {
+          if (!entered.settled()) {
+            entered.resolve(undefined);
+          }
+          await release.promise;
+          const objectKey = new URL(request.url).searchParams.get("object");
+          if (!objectKey) {
+            throw new Error("Expected Pi resource archive identity");
+          }
+          return new HttpResponse(piS3Object(objectKey), {
+            headers: { "content-type": "application/gzip" },
+          });
+        }),
+        ...USER_OWNED_TERRA_FAST_BDD_ROUTES.map((candidate) => {
+          return http.post(candidate.endpoint, ({ request }) => {
+            providerRequests.push(request.url);
+            return new HttpResponse(
+              piResponsesTextSse(
+                "unexpected provider owner",
+                providerRequests.length,
+              ),
+              { headers: { "content-type": "text/event-stream" } },
+            );
+          });
+        }),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        model: "gpt-5.6-terra",
+        prompt: "keep captured Fast credentials authoritative",
+        runOptions: { codexServiceTier: "fast" },
+      });
+      await entered.promise;
+      await accept(
+        setupApp({ context, routes: modelProvidersRoutes })(
+          modelProvidersByTypeContract,
+        ).delete({
+          headers: sessionHeaders(actor),
+          params: { type: route.type },
+        }),
+        [204],
+      );
+      release.resolve(undefined);
+      await waitForRunStatus(actor, run.runId, "failed");
+      await flushWaitUntilForTest();
+      const failed = await api.readRun(actor, run.runId);
+      expect(failed).toMatchObject({
+        status: "failed",
+        error: expect.stringContaining("[PI_API_MODEL_CREDENTIAL_INVALID]"),
+      });
+      expect(providerRequests).toStrictEqual([]);
+      await expectNoBuiltInModelUsage(run.runId);
+      await api.heartbeatRunner(runnerGroup);
+      const claim = await api.requestClaimRunnerJob(true, run.runId, [404], {
+        capabilities: { piModelConfigGenerations: [1, 2, 3] },
+      });
+      expectApiError(claim.body);
+      const publicState = JSON.stringify({
+        failed,
+        events: (await chat.listThreadEvents(actor, run.threadId)).events,
+        histories: [...objects.values()].map((value) => {
+          return value.toString("utf8");
+        }),
+      });
+      expect(publicState).not.toContain(secret);
+      expect(
+        objects.has(
+          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
+        ),
+      ).toBeFalsy();
+    },
+    90_000,
+  );
+
+  it.each(STANDARD_TERRA_API_KEY_BDD_ROUTES)(
+    "keeps rejected $name API-key Fast single-owner, redacted, and unbilled",
+    async (route) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const secret = `${route.type}-rejected-secret`;
+      const privateDiagnostic = "private-provider-rejection-details";
+      await configureApiKeyTerraPiModel(actor, route, secret);
+      mockPiResourceArchiveDownloads();
+      const objects = mockPiCheckpointObjectStore();
+      const requests: {
+        url: string;
+        authorization: string | null;
+        body: unknown;
+      }[] = [];
+      server.use(
+        ...USER_OWNED_TERRA_FAST_BDD_ROUTES.map((candidate) => {
+          return http.post(candidate.endpoint, async ({ request }) => {
+            requests.push({
+              url: request.url,
+              authorization: request.headers.get("authorization"),
+              body: await readCodexRequestJson(request),
+            });
+            return HttpResponse.json(
+              {
+                error: {
+                  code: "invalid_api_key",
+                  message: `${privateDiagnostic} ${secret}`,
+                },
+              },
+              { status: 401 },
+            );
+          });
+        }),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        model: "gpt-5.6-terra",
+        prompt: "fail the captured API-key Fast request once",
+        runOptions: { codexServiceTier: "fast" },
+      });
+      await waitForRunStatus(actor, run.runId, "failed");
+      await flushWaitUntilForTest();
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url).toBe(route.endpoint);
+      expectApiKeyTerraRequest(requests[0], route, secret, "fast");
+      const failed = await api.readRun(actor, run.runId);
+      expect(failed).toMatchObject({
+        status: "failed",
+        error: expect.stringContaining("[PI_API_MODEL_FAILED]"),
+      });
+      const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+      const publicState = JSON.stringify({
+        failed,
+        events,
+        histories: [...objects.values()].map((value) => {
+          return value.toString("utf8");
+        }),
+      });
+      expect(publicState).not.toContain(secret);
+      expect(publicState).not.toContain(privateDiagnostic);
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        "Pi API first-turn outcome",
+        expect.objectContaining({
+          runId: run.runId,
+          productProvider: route.type,
+          dialect: "openai-responses",
+          executionOwner: "api-first",
+          outcome: "terminal_failure",
+        }),
+      );
+      const telemetry = JSON.stringify([
+        ...context.mocks.axiomLogging.debug.mock.calls,
+        ...context.mocks.axiomLogging.warn.mock.calls,
+      ]);
+      expect(telemetry).not.toContain(secret);
+      expect(telemetry).not.toContain(privateDiagnostic);
+      await expectNoBuiltInModelUsage(run.runId);
+      await api.heartbeatRunner(runnerGroup);
+      const claim = await api.requestClaimRunnerJob(true, run.runId, [404], {
+        capabilities: { piModelConfigGenerations: [1, 2, 3] },
+      });
+      expectApiError(claim.body);
+      expect(requests).toHaveLength(1);
     },
     90_000,
   );
@@ -13382,21 +13732,23 @@ describe("CHAT-02: run-level model overrides", () => {
     await expectNoBuiltInModelUsage(run.runId);
   }, 90_000);
 
-  it("reuses one subscription Pi session across standard, Fast, and standard requests", async () => {
-    const { actor, agentId } = await entitledChatActor();
-    const accountId = "subscription-continuity-account";
-    const { oauth } = await configureSubscriptionPiModel(actor, { accountId });
-    mockPiResourceArchiveDownloads();
-    const objects = mockPiCheckpointObjectStore();
-    const requests: {
-      body: unknown;
-      authorization: string | null;
-      accountId: string | null;
-    }[] = [];
-    server.use(
-      http.post(
-        "https://chatgpt.com/backend-api/codex/responses",
-        async ({ request }) => {
+  it.each(USER_OWNED_TERRA_FAST_BDD_ROUTES)(
+    "reuses one $name Pi session across standard, Fast, and standard requests",
+    async (route) => {
+      const { actor, agentId } = await entitledChatActor();
+      const { secret, accountId } = await configureUserOwnedTerraPiModel(
+        actor,
+        route,
+      );
+      mockPiResourceArchiveDownloads();
+      const objects = mockPiCheckpointObjectStore();
+      const requests: {
+        body: unknown;
+        authorization: string | null;
+        accountId: string | null;
+      }[] = [];
+      server.use(
+        http.post(route.endpoint, async ({ request }) => {
           requests.push({
             body: await readCodexRequestJson(request),
             authorization: request.headers.get("authorization"),
@@ -13404,113 +13756,121 @@ describe("CHAT-02: run-level model overrides", () => {
           });
           return nativeCodexSseResponse(
             piResponsesTextSse(
-              `subscription answer ${requests.length}`,
+              `Terra answer ${requests.length}`,
               requests.length,
             ),
           );
-        },
-      ),
-    );
+        }),
+      );
 
-    const first = await sendChatRun(actor, {
-      agentId,
-      model: "gpt-5.6-terra",
-      prompt: "subscription standard start",
-    });
-    await waitForRunStatus(actor, first.runId, "completed");
-    await flushWaitUntilForTest();
-    const firstSession = await readThreadSessionConversation(
-      context,
-      first.threadId,
-    );
-    const fast = await sendChatRun(actor, {
-      agentId,
-      threadId: first.threadId,
-      model: "gpt-5.6-terra",
-      prompt: "subscription Fast continuation",
-      runOptions: { codexServiceTier: "fast" },
-    });
-    await waitForRunStatus(actor, fast.runId, "completed");
-    await flushWaitUntilForTest();
-    await expect(
-      readThreadSessionConversation(context, first.threadId),
-    ).resolves.toMatchObject({
-      agent_session_id: firstSession.agent_session_id,
-    });
-    await chat.updateThreadModelSelection(
-      actor,
-      first.threadId,
-      "gpt-5.6-terra",
-      { codexServiceTier: null },
-    );
-    const standard = await sendChatRun(actor, {
-      agentId,
-      threadId: first.threadId,
-      model: "gpt-5.6-terra",
-      prompt: "subscription standard return",
-    });
-    await waitForRunStatus(actor, standard.runId, "completed");
-    await flushWaitUntilForTest();
-    await expect(
-      readThreadSessionConversation(context, first.threadId),
-    ).resolves.toMatchObject({
-      agent_session_id: firstSession.agent_session_id,
-      conversation_run_id: standard.runId,
-    });
-
-    expect(requests).toHaveLength(3);
-    expect(
-      requests.map(({ body }) => {
-        return z
-          .object({ service_tier: z.literal("fast").optional() })
-          .parse(body).service_tier;
-      }),
-    ).toStrictEqual([undefined, "fast", undefined]);
-    for (const request of requests) {
-      expect(request).toMatchObject({
-        authorization: `Bearer ${oauth.oauthTokenResponses[0]?.access_token}`,
-        accountId,
-        body: {
-          model: "gpt-5.6-terra",
-          stream: true,
-          store: false,
-          reasoning: { effort: "low" },
-        },
+      const first = await sendChatRun(actor, {
+        agentId,
+        model: "gpt-5.6-terra",
+        prompt: "Terra standard start",
       });
-      expect(request.body).not.toHaveProperty("previous_response_id");
-    }
-    expect(JSON.stringify(requests[1]?.body)).toContain(
-      "subscription answer 1",
-    );
-    expect(JSON.stringify(requests[2]?.body)).toContain(
-      "subscription answer 2",
-    );
-    const histories = [...objects.entries()].filter(([key]) => {
-      return key.endsWith(".blob");
-    });
-    expect(histories).toHaveLength(3);
-    for (const [, value] of histories) {
-      expect(
-        MemoryPiSession.fromJsonl(value.toString("utf8")).getSessionId(),
-      ).toBe(first.threadId);
-      expect(value.toString("utf8")).not.toMatch(/serviceTier|service_tier/);
-    }
-    for (const run of [first, fast, standard]) {
-      await expectNoBuiltInModelUsage(run.runId);
-    }
-  }, 90_000);
+      await waitForRunStatus(actor, first.runId, "completed");
+      await flushWaitUntilForTest();
+      const firstSession = await readThreadSessionConversation(
+        context,
+        first.threadId,
+      );
+      const fast = await sendChatRun(actor, {
+        agentId,
+        threadId: first.threadId,
+        model: "gpt-5.6-terra",
+        prompt: "Terra Fast continuation",
+        runOptions: { codexServiceTier: "fast" },
+      });
+      await waitForRunStatus(actor, fast.runId, "completed");
+      await flushWaitUntilForTest();
+      await expect(
+        readThreadSessionConversation(context, first.threadId),
+      ).resolves.toMatchObject({
+        agent_session_id: firstSession.agent_session_id,
+      });
+      await chat.updateThreadModelSelection(
+        actor,
+        first.threadId,
+        "gpt-5.6-terra",
+        { codexServiceTier: null },
+      );
+      const standard = await sendChatRun(actor, {
+        agentId,
+        threadId: first.threadId,
+        model: "gpt-5.6-terra",
+        prompt: "Terra standard return",
+      });
+      await waitForRunStatus(actor, standard.runId, "completed");
+      await flushWaitUntilForTest();
+      await expect(
+        readThreadSessionConversation(context, first.threadId),
+      ).resolves.toMatchObject({
+        agent_session_id: firstSession.agent_session_id,
+        conversation_run_id: standard.runId,
+      });
 
-  it.each(["web", "agent"] as const)(
-    "promotes queued subscription Fast from %s through native API-first",
-    async (origin) => {
+      expect(requests).toHaveLength(3);
+      expect(
+        requests.map(({ body }) => {
+          return z
+            .object({ service_tier: z.enum(["fast", "priority"]).optional() })
+            .parse(body).service_tier;
+        }),
+      ).toStrictEqual([undefined, route.wireTier, undefined]);
+      for (const request of requests) {
+        expect(request).toMatchObject({
+          authorization: `Bearer ${secret}`,
+          accountId,
+          body: {
+            model: route.runtimeModel,
+            stream: true,
+            store: false,
+            reasoning: { effort: "low" },
+          },
+        });
+        expect(request.body).not.toHaveProperty("previous_response_id");
+      }
+      expect(JSON.stringify(requests[1]?.body)).toContain("Terra answer 1");
+      expect(JSON.stringify(requests[2]?.body)).toContain("Terra answer 2");
+      const histories = [...objects.entries()].filter(([key]) => {
+        return key.endsWith(".blob");
+      });
+      expect(histories).toHaveLength(3);
+      for (const [, value] of histories) {
+        expect(
+          MemoryPiSession.fromJsonl(value.toString("utf8")).getSessionId(),
+        ).toBe(first.threadId);
+        expect(value.toString("utf8")).not.toMatch(/serviceTier|service_tier/);
+        expect(value.toString("utf8")).not.toContain(secret);
+      }
+      for (const run of [first, fast, standard]) {
+        await expectNoBuiltInModelUsage(run.runId);
+      }
+    },
+    90_000,
+  );
+
+  it.each(
+    USER_OWNED_TERRA_FAST_BDD_ROUTES.flatMap((route) => {
+      return (["web", "agent"] as const).map((origin) => {
+        return {
+          route,
+          name: route.name,
+          origin,
+        };
+      });
+    }),
+  )(
+    "promotes queued and immediate $name Fast from $origin through API-first",
+    async ({ route, origin }) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       const source = await sendChatRun(actor, {
         agentId,
-        prompt: "source run for subscription handoff",
+        prompt: "source run for Terra handoff",
       });
       const anchor = await sendChatRun(actor, {
         agentId,
-        prompt: "hold the subscription target thread",
+        prompt: "hold the Terra target thread",
       });
       const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
       const token = api.okouTokenForRunWithCapabilities(actor, source.runId, [
@@ -13519,34 +13879,29 @@ describe("CHAT-02: run-level model overrides", () => {
         "chat-event:read",
         "chat-event:write",
       ]);
-      const accountId = "queued-subscription-account";
-      const { oauth } = await configureSubscriptionPiModel(actor, {
-        accountId,
-      });
+      const { secret, accountId } = await configureUserOwnedTerraPiModel(
+        actor,
+        route,
+      );
       mockPiResourceArchiveDownloads();
       mockPiCheckpointObjectStore();
       const requests: unknown[] = [];
       server.use(
-        http.post(
-          "https://chatgpt.com/backend-api/codex/responses",
-          async ({ request }) => {
-            expect(request.headers.get("authorization")).toBe(
-              `Bearer ${oauth.oauthTokenResponses[0]?.access_token}`,
-            );
-            expect(request.headers.get("chatgpt-account-id")).toBe(accountId);
-            requests.push(await readCodexRequestJson(request));
-            return nativeCodexSseResponse(
-              piResponsesTextSse("queued subscription answer", requests.length),
-            );
-          },
-        ),
+        http.post(route.endpoint, async ({ request }) => {
+          expect(request.headers.get("authorization")).toBe(`Bearer ${secret}`);
+          expect(request.headers.get("chatgpt-account-id")).toBe(accountId);
+          requests.push(await readCodexRequestJson(request));
+          return nativeCodexSseResponse(
+            piResponsesTextSse("queued Terra answer", requests.length),
+          );
+        }),
       );
       const queuedId = randomUUID();
       const body = {
         agentId,
         threadId: anchor.threadId,
         clientEventId: queuedId,
-        prompt: "queued native subscription Fast",
+        prompt: "queued Terra Fast",
         model: "gpt-5.6-terra" as const,
         runOptions: { codexServiceTier: "fast" as const },
       };
@@ -13582,8 +13937,8 @@ describe("CHAT-02: run-level model overrides", () => {
       await flushWaitUntilForTest();
       expect(requests).toHaveLength(1);
       expect(requests[0]).toMatchObject({
-        model: "gpt-5.6-terra",
-        service_tier: "fast",
+        model: route.runtimeModel,
+        service_tier: route.wireTier,
         stream: true,
         store: false,
       });
@@ -13600,7 +13955,7 @@ describe("CHAT-02: run-level model overrides", () => {
 
       const immediateBody = {
         agentId,
-        prompt: "immediate native subscription Fast",
+        prompt: "immediate Terra Fast",
         model: "gpt-5.6-terra" as const,
         runOptions: { codexServiceTier: "fast" as const },
       };
@@ -13614,47 +13969,54 @@ describe("CHAT-02: run-level model overrides", () => {
       await waitForRunStatus(actor, immediate.body.runId, "completed");
       await flushWaitUntilForTest();
       expect(requests).toHaveLength(2);
-      expect(requests[1]).toMatchObject({ service_tier: "fast" });
+      expect(requests[1]).toMatchObject({ service_tier: route.wireTier });
       await expectNoBuiltInModelUsage(immediate.body.runId);
       await cancelChatRun(actor, source.runId);
     },
     90_000,
   );
 
-  it.each(["in-flight", "late-result"] as const)(
-    "keeps cancelled subscription Fast %s results unbilled and unreplayed",
-    async (phase) => {
-      const { actor, agentId, runnerGroup } = await entitledChatActor();
-      await configureSubscriptionPiModel(actor, {
-        accountId: "cancelled-subscription-account",
+  it.each(
+    USER_OWNED_TERRA_FAST_BDD_ROUTES.flatMap((route) => {
+      return (["in-flight", "late-result"] as const).map((phase) => {
+        return {
+          route,
+          name: route.name,
+          phase,
+        };
       });
+    }),
+  )(
+    "keeps cancelled $name Fast $phase results unbilled and unreplayed",
+    async ({ route, phase }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const { secret, accountId } = await configureUserOwnedTerraPiModel(
+        actor,
+        route,
+      );
       mockPiResourceArchiveDownloads();
       const objects = mockPiCheckpointObjectStore();
       const entered = createDeferredPromise<void>(context.signal);
       const release = createDeferredPromise<void>(context.signal);
       const requests: unknown[] = [];
       server.use(
-        http.post(
-          "https://chatgpt.com/backend-api/codex/responses",
-          async ({ request }) => {
-            requests.push(await readCodexRequestJson(request));
-            if (!entered.settled()) {
-              entered.resolve(undefined);
-            }
-            await release.promise;
-            return nativeCodexSseResponse(
-              piResponsesTextSse(
-                "discarded subscription answer",
-                requests.length,
-              ),
-            );
-          },
-        ),
+        http.post(route.endpoint, async ({ request }) => {
+          expect(request.headers.get("authorization")).toBe(`Bearer ${secret}`);
+          expect(request.headers.get("chatgpt-account-id")).toBe(accountId);
+          requests.push(await readCodexRequestJson(request));
+          if (!entered.settled()) {
+            entered.resolve(undefined);
+          }
+          await release.promise;
+          return nativeCodexSseResponse(
+            piResponsesTextSse("discarded Terra answer", requests.length),
+          );
+        }),
       );
       const run = await sendChatRun(actor, {
         agentId,
         model: "gpt-5.6-terra",
-        prompt: "cancel subscription Fast ownership",
+        prompt: "cancel Terra Fast ownership",
         runOptions: { codexServiceTier: "fast" },
       });
       await entered.promise;
@@ -13672,7 +14034,7 @@ describe("CHAT-02: run-level model overrides", () => {
       });
       expect(requests).toHaveLength(1);
       expect(requests[0]).toMatchObject({
-        service_tier: "fast",
+        service_tier: route.wireTier,
         stream: true,
         store: false,
       });

--- a/turbo/apps/api/src/signals/services/__tests__/pi-sandbox-config.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-sandbox-config.test.ts
@@ -203,163 +203,124 @@ describe("Pi sandbox model configuration", () => {
     });
   });
 
-  it.each(STANDARD_TERRA_API_KEY_ROUTES)(
-    "emits the strict public Responses carrier for $type",
+  describe.each(STANDARD_TERRA_API_KEY_ROUTES)(
+    "$type Terra carrier",
     (route) => {
-      expect(
-        resolvePiSandboxModelConfig({
-          type: route.type,
+      it.each([
+        {
+          name: "standard",
+          tier: undefined,
+          generation: 2,
+          wireTier: undefined,
+        },
+        { name: "Fast", tier: "fast", generation: 3, wireTier: "priority" },
+      ] as const)(
+        "emits exact $name public Responses policy",
+        ({ tier, generation, wireTier }) => {
+          expect(
+            resolvePiSandboxModelConfig(
+              {
+                type: route.type,
+                environment: {
+                  OPENAI_API_KEY: "opaque-provider-placeholder",
+                  ...(route.type === "openai-api-key"
+                    ? {}
+                    : { OPENAI_BASE_URL: route.baseUrl }),
+                  OPENAI_MODEL: route.model,
+                },
+                selectedModel: "gpt-5.6-terra",
+              },
+              tier,
+            ),
+          ).toStrictEqual({
+            schemaVersion: generation,
+            ...(wireTier === undefined ? {} : { serviceTier: wireTier }),
+            dialect: "openai-responses",
+            transport: "sse",
+            provider: route.provider,
+            baseUrl: route.baseUrl,
+            model: route.model,
+            ...(route.type === "vercel-ai-gateway-codex"
+              ? { catalogModel: route.catalogModel }
+              : {}),
+            thinkingLevel: "low",
+            credentialBindings: [
+              {
+                kind: "api-key",
+                environment: "OPENAI_API_KEY",
+                secretName: route.credentialSecretName,
+              },
+            ],
+          });
+        },
+      );
+
+      it.each<{
+        name: string;
+        override?: Partial<
+          NonNullable<Parameters<typeof resolvePiSandboxModelConfig>[0]>
+        >;
+        environment?: Record<string, string>;
+      }>([
+        {
+          name: "different concrete provider",
+          override: { concreteType: "codex-oauth-token" },
+        },
+        { name: "inline firewall", override: { inlineFirewall: true } },
+        {
+          name: "custom header",
+          override: {
+            credentialHeader: {
+              name: "Authorization",
+              valueTemplate: "Bearer {{secret}}",
+            },
+          },
+        },
+        {
+          name: "different logical model",
+          override: { selectedModel: "gpt-5.6-sol" },
+        },
+        {
+          name: "different endpoint",
+          environment: { OPENAI_BASE_URL: "https://mismatched.example.com/v1" },
+        },
+        {
+          name: "different runtime model",
+          environment: { OPENAI_MODEL: "gpt-5.6-sol" },
+        },
+        { name: "missing runtime model", environment: { OPENAI_MODEL: "" } },
+        { name: "missing key", environment: { OPENAI_API_KEY: "" } },
+        { name: "blank key", environment: { OPENAI_API_KEY: "  " } },
+        {
+          name: "alternate key only",
           environment: {
-            OPENAI_API_KEY: "opaque-provider-placeholder",
-            ...(route.type === "openai-api-key"
-              ? {}
-              : { OPENAI_BASE_URL: route.baseUrl }),
-            OPENAI_MODEL: route.model,
+            OPENAI_API_KEY: "",
+            CHATGPT_ACCESS_TOKEN: "subscription-token",
+            DEEPSEEK_API_KEY: "other-key",
           },
-          selectedModel: "gpt-5.6-terra",
-        }),
-      ).toStrictEqual({
-        schemaVersion: 2,
-        dialect: "openai-responses",
-        transport: "sse",
-        provider: route.provider,
-        baseUrl: route.baseUrl,
-        model: route.model,
-        ...(route.type === "vercel-ai-gateway-codex"
-          ? { catalogModel: route.catalogModel }
-          : {}),
-        thinkingLevel: "low",
-        credentialBindings: [
-          {
-            kind: "api-key",
-            environment: "OPENAI_API_KEY",
-            secretName: route.credentialSecretName,
-          },
-        ],
+        },
+      ])("fails closed for $name in standard and Fast", (scenario) => {
+        for (const tier of [undefined, "fast"] as const) {
+          expect(
+            resolvePiSandboxModelConfig(
+              {
+                type: route.type,
+                selectedModel: "gpt-5.6-terra",
+                ...scenario.override,
+                environment: {
+                  OPENAI_API_KEY: "opaque-provider-placeholder",
+                  OPENAI_BASE_URL: route.baseUrl,
+                  OPENAI_MODEL: route.model,
+                  ...scenario.environment,
+                },
+              },
+              tier,
+            ),
+          ).toBeNull();
+        }
       });
     },
   );
-
-  it.each([
-    {
-      name: "fast tier",
-      type: "openai-api-key",
-      selectedModel: "gpt-5.6-terra",
-      model: "gpt-5.6-terra",
-      tier: "fast" as const,
-    },
-    {
-      name: "other logical model",
-      type: "openai-api-key",
-      selectedModel: "gpt-5.6-sol",
-      model: "gpt-5.6-sol",
-      tier: undefined,
-    },
-    {
-      name: "aliased runtime model",
-      type: "openrouter-codex",
-      selectedModel: "gpt-5.6-terra",
-      model: "gpt-5.6-terra",
-      tier: undefined,
-    },
-  ] as const)("rejects API-key Terra with $name", (testCase) => {
-    expect(
-      resolvePiSandboxModelConfig(
-        {
-          type: testCase.type,
-          environment: {
-            OPENAI_API_KEY: "opaque-provider-placeholder",
-            ...(testCase.type === "openrouter-codex"
-              ? { OPENAI_BASE_URL: "https://openrouter.ai/api/v1" }
-              : {}),
-            OPENAI_MODEL: testCase.model,
-          },
-          selectedModel: testCase.selectedModel,
-        },
-        testCase.tier,
-      ),
-    ).toBeNull();
-  });
-
-  it.each(STANDARD_TERRA_API_KEY_ROUTES)(
-    "keeps $type Fast on Codex before Pi ownership",
-    (route) => {
-      expect(
-        resolvePiSandboxModelConfig(
-          {
-            type: route.type,
-            environment: {
-              OPENAI_API_KEY: "opaque-provider-placeholder",
-              OPENAI_BASE_URL: route.baseUrl,
-              OPENAI_MODEL: route.model,
-            },
-            selectedModel: "gpt-5.6-terra",
-          },
-          "fast",
-        ),
-      ).toBeNull();
-      expect(
-        shouldUsePiExecution({
-          modelProviderType: route.type,
-          selectedModel: "gpt-5.6-terra",
-          codexServiceTier: "fast",
-          triggerSource: "web",
-          chatThreadId: "thread-1",
-          builtInModelRuntimeRoute: undefined,
-          featureSwitchContext: {
-            userId: "user-1",
-            orgId: "org-1",
-            overrides: {
-              [FeatureSwitchKey.PiLoop]: true,
-              [FeatureSwitchKey.CodexFastMode]: true,
-            },
-          },
-        }),
-      ).toBeFalsy();
-    },
-  );
-
-  it("rejects mismatched API-key provider identity and endpoint", () => {
-    expect(
-      resolvePiSandboxModelConfig({
-        type: "vercel-ai-gateway-codex",
-        concreteType: "openrouter-codex",
-        environment: {
-          OPENAI_API_KEY: "opaque-provider-placeholder",
-          OPENAI_BASE_URL: "https://openrouter.ai/api/v1",
-          OPENAI_MODEL: "openai/gpt-5.6-terra",
-        },
-        selectedModel: "gpt-5.6-terra",
-      }),
-    ).toBeNull();
-  });
-
-  it.each(STANDARD_TERRA_API_KEY_ROUTES)(
-    "rejects a base URL mismatch for $type",
-    (route) => {
-      expect(
-        resolvePiSandboxModelConfig({
-          type: route.type,
-          environment: {
-            OPENAI_API_KEY: "opaque-provider-placeholder",
-            OPENAI_BASE_URL: "https://mismatched.example.com/v1",
-            OPENAI_MODEL: route.model,
-          },
-          selectedModel: "gpt-5.6-terra",
-        }),
-      ).toBeNull();
-    },
-  );
-
-  it("rejects a direct route without its captured API-key binding", () => {
-    expect(
-      resolvePiSandboxModelConfig({
-        type: "openai-api-key",
-        environment: { OPENAI_MODEL: "gpt-5.6-terra" },
-        selectedModel: "gpt-5.6-terra",
-      }),
-    ).toBeNull();
-  });
 
   it.each([
     { name: "standard", tier: undefined, generation: 2 },
@@ -468,66 +429,72 @@ describe("Pi sandbox model configuration", () => {
     ).toBeNull();
   });
 
-  it.each(
-    triggerSourceSchema.options.flatMap((triggerSource) => {
-      return [true, false].flatMap((bound) => {
-        return [true, false].flatMap((piLoop) => {
-          return [true, false].map((fastMode) => {
-            return { triggerSource, bound, piLoop, fastMode };
+  describe.each([
+    "codex-oauth-token",
+    ...STANDARD_TERRA_API_KEY_ROUTES.map((route) => {
+      return route.type;
+    }),
+  ])("%s Fast admission", (modelProviderType) => {
+    it.each(
+      triggerSourceSchema.options.flatMap((triggerSource) => {
+        return [true, false].flatMap((bound) => {
+          return [true, false].flatMap((piLoop) => {
+            return [true, false].map((fastMode) => {
+              return { triggerSource, bound, piLoop, fastMode };
+            });
           });
         });
-      });
-    }),
-  )(
-    "routes subscription Fast for $triggerSource bound=$bound Pi=$piLoop Fast=$fastMode",
-    ({ triggerSource, bound, piLoop, fastMode }) => {
+      }),
+    )(
+      "routes $triggerSource bound=$bound Pi=$piLoop Fast=$fastMode",
+      ({ triggerSource, bound, piLoop, fastMode }) => {
+        expect(
+          shouldUsePiExecution({
+            chatThreadId: bound ? "thread-id" : undefined,
+            modelProviderType,
+            selectedModel: "gpt-5.6-terra",
+            codexServiceTier: "fast",
+            builtInModelRuntimeRoute: undefined,
+            triggerSource,
+            featureSwitchContext: {
+              overrides: {
+                [FeatureSwitchKey.PiLoop]: piLoop,
+                [FeatureSwitchKey.CodexFastMode]: fastMode,
+              },
+            },
+          }),
+        ).toBe(
+          bound &&
+            piLoop &&
+            fastMode &&
+            (triggerSource === "web" || triggerSource === "agent"),
+        );
+      },
+    );
+    it.each([
+      "gpt-5.6-sol",
+      "gpt-5.6-luna",
+      "gpt-5.5",
+      "deepseek-v4-flash",
+      "gpt-5.6-terra-fast",
+    ])("keeps %s outside Pi", (selectedModel) => {
       expect(
         shouldUsePiExecution({
-          chatThreadId: bound ? "thread-id" : undefined,
-          modelProviderType: "codex-oauth-token",
-          selectedModel: "gpt-5.6-terra",
+          chatThreadId: "thread-id",
+          modelProviderType,
+          selectedModel,
           codexServiceTier: "fast",
           builtInModelRuntimeRoute: undefined,
-          triggerSource,
+          triggerSource: "web",
           featureSwitchContext: {
             overrides: {
-              [FeatureSwitchKey.PiLoop]: piLoop,
-              [FeatureSwitchKey.CodexFastMode]: fastMode,
+              [FeatureSwitchKey.PiLoop]: true,
+              [FeatureSwitchKey.CodexFastMode]: true,
             },
           },
         }),
-      ).toBe(
-        bound &&
-          piLoop &&
-          fastMode &&
-          (triggerSource === "web" || triggerSource === "agent"),
-      );
-    },
-  );
-
-  it.each([
-    "gpt-5.6-sol",
-    "gpt-5.6-luna",
-    "gpt-5.5",
-    "deepseek-v4-flash",
-    "gpt-5.6-terra-fast",
-  ])("keeps subscription Fast %s outside Pi", (selectedModel) => {
-    expect(
-      shouldUsePiExecution({
-        chatThreadId: "thread-id",
-        modelProviderType: "codex-oauth-token",
-        selectedModel,
-        codexServiceTier: "fast",
-        builtInModelRuntimeRoute: undefined,
-        triggerSource: "web",
-        featureSwitchContext: {
-          overrides: {
-            [FeatureSwitchKey.PiLoop]: true,
-            [FeatureSwitchKey.CodexFastMode]: true,
-          },
-        },
-      }),
-    ).toBeFalsy();
+      ).toBeFalsy();
+    });
   });
 
   it("translates built-in OpenRouter Terra fast mode to priority Responses", () => {
@@ -834,17 +801,6 @@ describe("Pi sandbox model configuration", () => {
       triggerSource: "web" as const,
       chatThreadId: "thread-id",
       piLoopEnabled: false,
-      codexFastModeEnabled: true,
-    },
-    {
-      name: "fast Terra BYOK",
-      modelProviderType: "openai-api-key",
-      selectedModel: "gpt-5.6-terra",
-      codexServiceTier: "fast" as const,
-      builtInModelRuntimeRoute: undefined,
-      triggerSource: "web" as const,
-      chatThreadId: "thread-id",
-      piLoopEnabled: true,
       codexFastModeEnabled: true,
     },
     {

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -155,6 +155,7 @@ function isFastTerraPiProvider(
 ): boolean {
   return (
     modelProviderType === "codex-oauth-token" ||
+    isStandardTerraApiKeyPiProviderType(modelProviderType) ||
     (isBuiltInModelProviderType(modelProviderType) &&
       (builtInModelRuntimeRoute?.providerType === "openai-api-key" ||
         builtInModelRuntimeRoute?.providerType === "openrouter-codex"))
@@ -188,7 +189,7 @@ export function shouldUsePiExecution(args: {
     (args.modelProviderType === "codex-oauth-token" &&
       (isStandardTerra || isFastTerra)) ||
     (standardTerraApiKeyPiRoute(args.modelProviderType) !== null &&
-      isStandardTerra);
+      (isStandardTerra || isFastTerra));
   return (
     args.chatThreadId !== undefined &&
     isWebChatTriggerSource(args.triggerSource) &&
@@ -333,7 +334,6 @@ function resolveStandardTerraApiKeyPiModelConfig(
   if (
     !route ||
     provider.selectedModel !== "gpt-5.6-terra" ||
-    codexServiceTier !== undefined ||
     provider.inlineFirewall === true ||
     provider.credentialHeader !== undefined ||
     (provider.concreteType !== undefined &&
@@ -354,8 +354,14 @@ function resolveStandardTerraApiKeyPiModelConfig(
   ) {
     return null;
   }
+  const serviceTier = codexServiceTier === "fast" ? "priority" : undefined;
   const config = {
-    schemaVersion: PI_MODEL_CONFIG_CURRENT_GENERATION,
+    ...(serviceTier === undefined
+      ? { schemaVersion: PI_MODEL_CONFIG_CURRENT_GENERATION }
+      : {
+          schemaVersion: PI_MODEL_CONFIG_DIALECT_TIER_GENERATION,
+          serviceTier,
+        }),
     dialect: "openai-responses",
     transport: "sse",
     provider: route.provider,
@@ -382,6 +388,7 @@ function resolveStandardTerraApiKeyPiModelConfig(
     dialect: config.dialect,
     transport: config.transport,
     thinkingLevel: config.thinkingLevel,
+    serviceTier,
   })
     ? config
     : null;

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
@@ -326,116 +326,179 @@ async function startResponsesProvider(): Promise<{
 }
 
 describe("official Pi AgentSession runtime", () => {
-  it("keeps generation-3 native Fast on every Sandbox turn after pending tools", async () => {
-    const cwd = await mkdtemp(join(tmpdir(), "pi-subscription-fast-"));
-    onTestFinished(async () => {
-      await rm(cwd, { recursive: true, force: true });
-    });
-    const toolFile = join(cwd, "subscription.txt");
-    await writeFile(toolFile, "subscription tool result", "utf8");
-    const provider = await startResponsesProvider();
-    onTestFinished(async () => {
-      await provider.close();
-    });
-    const sessionManager = SessionManager.inMemory(cwd, {
-      id: randomUUID(),
-    });
-    sessionManager.appendMessage({
-      role: "user",
-      content: "run the pending subscription tool",
-      timestamp: 1,
-    });
-    sessionManager.appendMessage({
-      ...fauxAssistantMessage(fauxToolCall("read", { path: toolFile }), {
-        stopReason: "toolUse",
-        timestamp: 2,
-      }),
-      api: "openai-codex-responses",
+  it.each([
+    {
+      name: "subscription",
       provider: "openai-codex",
+      dialect: "openai-codex-responses",
       model: "gpt-5.6-terra",
-    });
-    const model = await materializePiAgentModelConfig({
-      target: "sandbox-firewall",
-      config: {
-        schemaVersion: 3,
-        dialect: "openai-codex-responses",
-        transport: "sse",
-        provider: "openai-codex",
-        baseUrl: provider.baseUrl.replace(/\/v1$/, "/backend-api"),
-        model: "gpt-5.6-terra",
-        thinkingLevel: "low",
-        serviceTier: "fast",
-        credentialBindings: [
-          {
-            kind: "access-token",
-            environment: "CHATGPT_ACCESS_TOKEN",
-            secretName: "CHATGPT_ACCESS_TOKEN",
-          },
-          {
-            kind: "account-id",
-            environment: "CHATGPT_ACCOUNT_ID",
-            secretName: "CHATGPT_ACCOUNT_ID",
-          },
-        ],
-      },
-      resolveCredential(binding) {
-        return binding.kind === "access-token"
-          ? "opaque-subscription-token"
-          : "opaque-subscription-account";
-      },
-    });
-    const created = await createPiAgentSessionForRuntime({
-      cwd,
-      agentDir: join(cwd, ".pi"),
-      sessionManager,
-      model,
-      appendSystemPrompt: null,
-      resourceSnapshot: EMPTY_RESOURCE_SNAPSHOT,
-    });
-    try {
-      await resumePiApiFirstTurn(created.session);
-      await created.session.prompt("continue the same Sandbox session");
-      expect(provider.requests).toHaveLength(2);
-      for (const request of provider.requests) {
-        expect(request).toMatchObject({
-          url: "/backend-api/codex/responses",
-          authorization: "Bearer opaque-subscription-token",
-          accountId: "opaque-subscription-account",
-          body: {
-            model: "gpt-5.6-terra",
-            stream: true,
-            store: false,
-            service_tier: "fast",
-            reasoning: { effort: "low" },
-          },
-        });
-        expect(request.body).not.toHaveProperty("previous_response_id");
-        expect(JSON.stringify(request.body)).toContain(
-          "subscription tool result",
-        );
-      }
-      expect(
-        created.session.messages.filter((message) => {
-          return message.role === "toolResult";
-        }),
-      ).toMatchObject([
-        {
-          toolName: "read",
-          isError: false,
-          content: [{ type: "text", text: "subscription tool result" }],
-        },
-      ]);
-      expect(created.session.messages.at(-1)).toMatchObject({
-        role: "assistant",
-        content: [{ type: "text", text: "Sandbox answer" }],
+      basePath: "/backend-api",
+      endpoint: "/backend-api/codex/responses",
+      tier: "fast",
+      secretName: "CHATGPT_ACCESS_TOKEN",
+    },
+    {
+      name: "OpenAI API key",
+      provider: "openai",
+      dialect: "openai-responses",
+      model: "gpt-5.6-terra",
+      basePath: "/v1",
+      endpoint: "/v1/responses",
+      tier: "priority",
+      secretName: "OPENAI_API_KEY",
+    },
+    {
+      name: "OpenRouter API key",
+      provider: "openrouter",
+      dialect: "openai-responses",
+      model: "openai/gpt-5.6-terra",
+      basePath: "/api/v1",
+      endpoint: "/api/v1/responses",
+      tier: "priority",
+      secretName: "OPENROUTER_API_KEY",
+    },
+    {
+      name: "Vercel API key",
+      provider: "openai",
+      dialect: "openai-responses",
+      model: "openai/gpt-5.6-terra",
+      catalogModel: "gpt-5.6-terra",
+      basePath: "/v1",
+      endpoint: "/v1/responses",
+      tier: "priority",
+      secretName: "VERCEL_AI_GATEWAY_API_KEY",
+    },
+  ] as const)(
+    "keeps generation-3 $name Fast on every Sandbox turn after pending tools",
+    async (route) => {
+      const cwd = await mkdtemp(join(tmpdir(), "pi-user-owned-fast-"));
+      onTestFinished(async () => {
+        await rm(cwd, { recursive: true, force: true });
       });
-      expect(JSON.stringify(sessionManager.getEntries())).not.toMatch(
-        /serviceTier|service_tier/,
-      );
-    } finally {
-      created.session.dispose();
-    }
-  });
+      const toolFile = join(cwd, "terra.txt");
+      await writeFile(toolFile, "Terra tool result", "utf8");
+      const provider = await startResponsesProvider();
+      onTestFinished(async () => {
+        await provider.close();
+      });
+      const sessionManager = SessionManager.inMemory(cwd, {
+        id: randomUUID(),
+      });
+      sessionManager.appendMessage({
+        role: "user",
+        content: "run the pending Terra tool",
+        timestamp: 1,
+      });
+      sessionManager.appendMessage({
+        ...fauxAssistantMessage(fauxToolCall("read", { path: toolFile }), {
+          stopReason: "toolUse",
+          timestamp: 2,
+        }),
+        api: route.dialect,
+        provider: route.provider,
+        model: route.model,
+      });
+      const model = await materializePiAgentModelConfig({
+        target: "sandbox-firewall",
+        config: {
+          schemaVersion: 3,
+          transport: "sse",
+          baseUrl: provider.baseUrl.replace(/\/v1$/, route.basePath),
+          thinkingLevel: "low",
+          ...(route.dialect === "openai-codex-responses"
+            ? {
+                dialect: route.dialect,
+                provider: route.provider,
+                model: route.model,
+                serviceTier: route.tier,
+                credentialBindings: [
+                  {
+                    kind: "access-token",
+                    environment: "CHATGPT_ACCESS_TOKEN",
+                    secretName: "CHATGPT_ACCESS_TOKEN",
+                  },
+                  {
+                    kind: "account-id",
+                    environment: "CHATGPT_ACCOUNT_ID",
+                    secretName: "CHATGPT_ACCOUNT_ID",
+                  },
+                ],
+              }
+            : {
+                dialect: route.dialect,
+                provider: route.provider,
+                model: route.model,
+                ...(route.name === "Vercel API key"
+                  ? { catalogModel: route.catalogModel }
+                  : {}),
+                serviceTier: route.tier,
+                credentialBindings: [
+                  {
+                    kind: "api-key",
+                    environment: "OPENAI_API_KEY",
+                    secretName: route.secretName,
+                  },
+                ],
+              }),
+        },
+        resolveCredential(binding) {
+          return `opaque-${binding.secretName}`;
+        },
+      });
+      const created = await createPiAgentSessionForRuntime({
+        cwd,
+        agentDir: join(cwd, ".pi"),
+        sessionManager,
+        model,
+        appendSystemPrompt: null,
+        resourceSnapshot: EMPTY_RESOURCE_SNAPSHOT,
+      });
+      try {
+        await resumePiApiFirstTurn(created.session);
+        await created.session.prompt("continue the same Sandbox session");
+        expect(provider.requests).toHaveLength(2);
+        for (const request of provider.requests) {
+          expect(request).toMatchObject({
+            url: route.endpoint,
+            authorization: `Bearer opaque-${route.secretName}`,
+            accountId:
+              route.dialect === "openai-codex-responses"
+                ? "opaque-CHATGPT_ACCOUNT_ID"
+                : undefined,
+            body: {
+              model: route.model,
+              stream: true,
+              store: false,
+              service_tier: route.tier,
+              reasoning: { effort: "low" },
+            },
+          });
+          expect(request.body).not.toHaveProperty("previous_response_id");
+          expect(JSON.stringify(request.body)).toContain("Terra tool result");
+        }
+        expect(
+          created.session.messages.filter((message) => {
+            return message.role === "toolResult";
+          }),
+        ).toMatchObject([
+          {
+            toolName: "read",
+            isError: false,
+            content: [{ type: "text", text: "Terra tool result" }],
+          },
+        ]);
+        expect(created.session.messages.at(-1)).toMatchObject({
+          role: "assistant",
+          content: [{ type: "text", text: "Sandbox answer" }],
+        });
+        expect(JSON.stringify(sessionManager.getEntries())).not.toMatch(
+          /serviceTier|service_tier/,
+        );
+      } finally {
+        created.session.dispose();
+      }
+    },
+  );
 
   it("registers one stable memory schema fixture only for valid V2 epochs", async () => {
     const content = "# Frozen memory\n\nExact API epoch.";


### PR DESCRIPTION
## Summary

Enable PiLoop for `gpt-5.6-terra` Fast on the existing `openai-api-key`, `openrouter-codex`, and `vercel-ai-gateway-codex` routes. Both `PiLoop` and `CodexFastMode` must be enabled for a bound Web or agent-originated Web run. The shared route table now emits generation 3 public Responses/SSE with low reasoning and `serviceTier: "priority"`; standard API-key Terra retains its tierless generation-2 carrier.

The implementation extends only shared admission and carrier selection. It preserves API-first ownership, exact provider credentials and endpoints, opaque Sandbox placeholders, generation-aware claims, and the runtime/model-family session policy from #31796. Subscription Fast continues to use native `fast`. No new fallback, billing path, schema, runtime implementation, or release changes are introduced.

Closes #31864. Final implementation slice of #31803, on top of #31839 and #31857.

## Coverage

- Expand the existing admission and carrier matrix across subscription plus all three API-key routes, including both switches, every trigger, bound/unbound chats, standard/Fast carriers, and invalid route identities, endpoints, models, and keys.
- Extend the existing API-key BDD table through API-first, tool handoff, absent/`[1,2]` versus `[1,2,3]` claimants, exact firewall credentials, Sandbox completion/failure/cancellation, credential rotation, redaction, and zero Built-in usage.
- Exercise four-route standard → Fast → standard session continuity, immediate/queued Web and agent sends, cancellation, and discarded results. Reject vanished captured credentials and provider failures without alternate ownership or replay.
- Extend the real Pi Sandbox runtime test through a pending filesystem tool and a second provider request, asserting native `fast` for subscription and public `priority` for each API-key route. Retain Built-in, DeepSeek, custom standard, and custom Fast regressions.

## Validation

- API admission/carrier suite: 565 passing tests.
- Focused chat BDD selection: 72 passing tests, with handoff scenarios rechecked after test-helper extraction and stronger redaction assertions.
- Pi runtime `session-runtime`, `model`, and `credential` suites: 48 passing tests.
- Affected API and Pi runtime package lint (including ESLint), typecheck, formatting, and Knip.
- Full local Vitest and a development server were not run. Full-suite validation is delegated to PR CI. No Rust or shared-contract source changed.

`main` and the shared immediate/queued callers were inventoried before implementation. Canonical release PR #31862 remains separate and untouched; this PR performs no production release or production verification.
