### PR TITLE
fix(platform): align account usage rings and show reset counts

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4995,6 +4995,7 @@
         "remaining_one": "{{value}} Reset übrig",
         "remaining_other": "{{value}} Resets übrig",
         "remainingUnavailable": "Verbleibende Resets nicht verfügbar",
+        "remainingUnknown": "Resets —",
         "remainingWithExpiry_one": "{{value}} Reset übrig · läuft {{expiry}} ab",
         "remainingWithExpiry_other": "{{value}} Resets übrig · laufen {{expiry}} ab",
         "title": "Codex-Nutzung zurücksetzen?"

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4987,6 +4987,7 @@
         "remaining_one": "{{value}} reset left",
         "remaining_other": "{{value}} resets left",
         "remainingUnavailable": "Resets left unavailable",
+        "remainingUnknown": "Resets —",
         "remainingWithExpiry_one": "{{value}} reset left · expires {{expiry}}",
         "remainingWithExpiry_other": "{{value}} resets left · expires {{expiry}}",
         "title": "Reset Codex usage?"

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5050,6 +5050,7 @@
         "remaining_many": "Quedan {{value}} restablecimientos",
         "remaining_other": "Quedan {{value}} restablecimientos",
         "remainingUnavailable": "Reinicios no disponibles",
+        "remainingUnknown": "Restablecimientos —",
         "remainingWithExpiry_one": "Queda {{value}} restablecimiento · vence {{expiry}}",
         "remainingWithExpiry_many": "Quedan {{value}} restablecimientos · vencen {{expiry}}",
         "remainingWithExpiry_other": "Quedan {{value}} restablecimientos · vencen {{expiry}}",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5050,6 +5050,7 @@
         "remaining_many": "{{value}} réinitialisations restantes",
         "remaining_other": "{{value}} réinitialisations restantes",
         "remainingUnavailable": "Réinitialisations restantes non disponibles",
+        "remainingUnknown": "Réinitialisations —",
         "remainingWithExpiry_one": "{{value}} réinitialisation restante · expire {{expiry}}",
         "remainingWithExpiry_many": "{{value}} réinitialisations restantes · expirent {{expiry}}",
         "remainingWithExpiry_other": "{{value}} réinitialisations restantes · expirent {{expiry}}",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4995,6 +4995,7 @@
         "remaining_one": "{{value}} रीसेट बचे हैं",
         "remaining_other": "{{value}} रीसेट बचे हैं",
         "remainingUnavailable": "रीसेट उपलब्ध नहीं हैं",
+        "remainingUnknown": "रीसेट —",
         "remainingWithExpiry_one": "{{value}} रीसेट बचा है · {{expiry}} समाप्त",
         "remainingWithExpiry_other": "{{value}} रीसेट बचे हैं · {{expiry}} समाप्त",
         "title": "Codex उपयोग रीसेट करें?"

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4987,6 +4987,7 @@
         "remaining_one": "{{value}} reset tersisa",
         "remaining_other": "{{value}} reset tersisa",
         "remainingUnavailable": "Sisa reset tidak tersedia",
+        "remainingUnknown": "Reset —",
         "remainingWithExpiry_other": "{{value}} reset tersisa · kedaluwarsa {{expiry}}",
         "title": "Reset penggunaan Codex?"
       },

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5050,6 +5050,7 @@
         "remaining_many": "{{value}} ripristini rimasti",
         "remaining_other": "{{value}} ripristini rimasti",
         "remainingUnavailable": "Ripristini rimasti non disponibili",
+        "remainingUnknown": "Ripristini —",
         "remainingWithExpiry_one": "{{value}} ripristino rimasto · scade {{expiry}}",
         "remainingWithExpiry_many": "{{value}} ripristini rimasti · scadono {{expiry}}",
         "remainingWithExpiry_other": "{{value}} ripristini rimasti · scadono {{expiry}}",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4987,6 +4987,7 @@
         "remaining_one": "リセット残り{{value}}回",
         "remaining_other": "リセット残り{{value}}回",
         "remainingUnavailable": "残りのリセット回数を取得できません",
+        "remainingUnknown": "リセット —",
         "remainingWithExpiry_other": "リセット残り{{value}}回 · 有効期限{{expiry}}",
         "title": "Codexの使用量をリセットしますか？"
       },

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4987,6 +4987,7 @@
         "remaining_one": "{{value}}회 재설정 가능",
         "remaining_other": "{{value}}회 재설정 가능",
         "remainingUnavailable": "재설정 가능 횟수 없음",
+        "remainingUnknown": "재설정 —",
         "remainingWithExpiry_other": "{{value}}회 재설정 가능 · {{expiry}} 만료",
         "title": "Codex 사용량을 재설정하시겠습니까?"
       },

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5050,6 +5050,7 @@
         "remaining_many": "{{value}} redefinições restantes",
         "remaining_other": "{{value}} redefinições restantes",
         "remainingUnavailable": "Redefinições restantes indisponíveis",
+        "remainingUnknown": "Redefinições —",
         "remainingWithExpiry_one": "{{value}} redefinição restante · expira {{expiry}}",
         "remainingWithExpiry_many": "{{value}} redefinições restantes · expiram {{expiry}}",
         "remainingWithExpiry_other": "{{value}} redefinições restantes · expiram {{expiry}}",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/personal-providers-tab.test.tsx
@@ -265,14 +265,27 @@ test("Review and explicitly switch personal subscription accounts", async () => 
       createdAt: "2026-03-01T00:00:00Z",
     }),
     workspaceName: "Account A Organization",
+    subscriptionResetCreditsNextExpiresAt: "2030-01-04T00:48:00.000Z",
   };
-  const accountB = connectedPersonalCodexAccount({
-    id: "00000000-0000-4000-a000-000000000312",
-    email: "account-b@example.com",
-    isActive: false,
-    createdAt: "2026-03-02T00:00:00Z",
-  });
-  context.mocks.data.personalModelProviders([accountA, accountB]);
+  const accountB = {
+    ...connectedPersonalCodexAccount({
+      id: "00000000-0000-4000-a000-000000000312",
+      email: "account-b@example.com",
+      isActive: false,
+      createdAt: "2026-03-02T00:00:00Z",
+    }),
+    subscriptionResetCredits: 0,
+  };
+  const accountC = {
+    ...connectedPersonalCodexAccount({
+      id: "00000000-0000-4000-a000-000000000313",
+      email: "account-c@example.com",
+      isActive: false,
+      createdAt: "2026-03-03T00:00:00Z",
+    }),
+    subscriptionResetCredits: null,
+  };
+  context.mocks.data.personalModelProviders([accountA, accountB, accountC]);
 
   await openModelSettings("Models", {
     [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
@@ -280,8 +293,15 @@ test("Review and explicitly switch personal subscription accounts", async () => 
 
   const rowA = await screen.findByTestId(`oauth-account-${accountA.id}`);
   const rowB = await screen.findByTestId(`oauth-account-${accountB.id}`);
+  const rowC = await screen.findByTestId(`oauth-account-${accountC.id}`);
   expect(within(rowA).getByText("account-a@example.com")).toBeInTheDocument();
   expect(within(rowB).getByText("account-b@example.com")).toBeInTheDocument();
+  expect(within(rowA).getByText("2 resets left")).toBeVisible();
+  expect(within(rowB).getByText("0 resets left")).toBeVisible();
+  expect(within(rowC).getByText("Resets —")).toBeVisible();
+  expect(
+    within(rowC).getByLabelText("Resets left unavailable"),
+  ).toBeInTheDocument();
   expect(within(rowA).queryByText("Active")).not.toBeInTheDocument();
   expect(within(rowB).queryByText("Active")).not.toBeInTheDocument();
   expect(within(rowB).queryByText("Use")).not.toBeInTheDocument();
@@ -302,6 +322,11 @@ test("Review and explicitly switch personal subscription accounts", async () => 
   await user.hover(accountIdentity);
   await expect(
     screen.findAllByText("Account A Organization"),
+  ).resolves.not.toHaveLength(0);
+
+  await user.hover(within(rowA).getByLabelText("2 resets left"));
+  await expect(
+    screen.findAllByText("2 resets left · expires in 3d"),
   ).resolves.not.toHaveLength(0);
 
   usageRings[0].focus();

--- a/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/preferences/personal-providers-tab.tsx
@@ -1,6 +1,6 @@
 import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { useTranslation } from "react-i18next";
-import { EllipsisVertical, Plus } from "lucide-react";
+import { EllipsisVertical, Plus, RotateCcw } from "lucide-react";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   Button,
@@ -345,7 +345,7 @@ function OAuthAccountRow({
           className="absolute inset-y-3 left-0 w-[3px] rounded-r-full bg-foreground"
         />
       ) : null}
-      <div className="flex items-center gap-3">
+      <div className="grid grid-cols-[1.75rem_minmax(0,1fr)] items-center gap-x-3 gap-y-1 sm:flex sm:gap-3">
         <Button
           showTooltip
           type="button"
@@ -401,19 +401,70 @@ function OAuthAccountRow({
                 return $.settings.models.personal.status.stale;
               })}
             </span>
-          ) : (
-            <SubscriptionUsageRings identity={identity} usage={usage} />
-          )}
+          ) : null}
         </div>
-        <OAuthAccountMenu
-          account={account}
-          actionPending={actionPending}
-          onReconnect={onReconnect}
-          onRemove={onRemove}
-          onReset={onReset}
-        />
+        <div className="col-start-2 flex min-w-0 items-center justify-end gap-3 sm:ml-auto sm:shrink-0">
+          {account.type === "codex-oauth-token" ? (
+            <OAuthAccountResetCredits account={account} />
+          ) : null}
+          {!account.needsReconnect ? (
+            <SubscriptionUsageRings identity={identity} usage={usage} />
+          ) : null}
+          <OAuthAccountMenu
+            account={account}
+            actionPending={actionPending}
+            onReconnect={onReconnect}
+            onRemove={onRemove}
+            onReset={onReset}
+          />
+        </div>
       </div>
     </div>
+  );
+}
+
+function OAuthAccountResetCredits({
+  account,
+}: {
+  readonly account: ModelProviderResponse;
+}) {
+  const { t } = useTranslation();
+  const resetCredits = account.subscriptionResetCredits ?? null;
+  const label = formatCodexResetCredits(resetCredits);
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          tabIndex={0}
+          aria-label={label}
+          className="mr-auto flex h-7 min-w-0 cursor-default items-center gap-1.5 rounded-md px-1 text-xs tabular-nums text-muted-foreground outline-none transition-colors hover:bg-state-hover focus-visible:bg-state-hover sm:mr-0"
+        >
+          <RotateCcw size={14} className="shrink-0" aria-hidden />
+          <span className="truncate">
+            {resetCredits === null
+              ? t(($) => {
+                  return $.settings.models.reset.remainingUnknown;
+                })
+              : label}
+          </span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="end"
+        sideOffset={8}
+        className="border shadow-md"
+        style={{
+          backgroundColor: "hsl(var(--popover))",
+          color: "hsl(var(--popover-foreground))",
+        }}
+      >
+        {formatCodexResetCredits(
+          resetCredits,
+          account.subscriptionResetCreditsNextExpiresAt,
+        )}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -964,7 +1015,7 @@ function SubscriptionUsageRings({
   }
 
   return (
-    <span className="flex shrink-0 items-center gap-1.5">
+    <span className="ml-auto flex min-w-16 shrink-0 items-center justify-end gap-1.5">
       {windows.map(({ kind, window }) => {
         return (
           <SubscriptionUsageRing


### PR DESCRIPTION
Personal subscription usage rings currently follow each email, and Codex reset counts require opening the account menu. This aligns the rings immediately before the menu and displays available resets directly in each Codex account row, following the [approved design](https://account-usage-controls-94b080fd.okou.app).

The controls move below the account identity on narrow screens. Reset counts distinguish zero from unavailable, and hover or keyboard focus shows the existing expiry details. The change stays within the existing personal account view and its multiple-subscription rollout (`_multipleSubscriptions`).

## Fallbacks

- `personal-providers-tab.tsx:OAuthAccountResetCredits` renders `Resets —` with the full unavailable label when optional upstream reset-credit data is missing or null. It preserves zero as `0 resets left`. This is a presentational default for the current nullable/optional provider contract, with no old/new-version interaction or deployment window. It remains needed while the provider can omit this data; there is no scheduled rollout cleanup.

## Verification

- Platform formatting, lint (including all 10 locales), type checks, and Knip passed.
- `personal-providers-tab.test.tsx`: all 8 tests passed, including account switching, visible reset counts, expiry tooltips, and the existing reset confirmation flow.
- PR pipeline passed on `f9774be7900f3f1fb806d9e06b177d103a941452`; no full local Vitest run or local dev server was started.
- Browser-checked the [deployed App preview](https://pr-31870-app-okou-app-preview.vm0.workers.dev/agents?settings=model) at 1440 × 1000 and 390 × 844: 12 px ring-to-menu spacing, visible positive/zero/unknown reset counts, expiry details on hover and keyboard focus, long-email truncation, and no mobile horizontal overflow. The existing reset confirmation opens and can be cancelled.
- Browser setup: Chromium 152, a dev Clerk test account, onboarding completed through the preview API, and `_multipleSubscriptions` enabled through Lab and confirmed effective. Provider-list and billing-status GET responses used browser-only sample fixtures (two Claude accounts and three Codex accounts); live OAuth connection and reset execution were outside this visual check.
