### PR TITLE
test(runner): cover benchmark exit code mapping

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -639,6 +639,40 @@ mod tests {
     }
 
     #[test]
+    fn benchmark_exit_codes_match_terminal_states() {
+        for (case, termination, expected_exit_code) in [
+            ("exited zero", ExecTermination::Exited { exit_code: 0 }, 0),
+            (
+                "exited u8 maximum",
+                ExecTermination::Exited { exit_code: 255 },
+                255,
+            ),
+            (
+                "exited below u8 range",
+                ExecTermination::Exited { exit_code: -1 },
+                1,
+            ),
+            (
+                "exited above u8 range",
+                ExecTermination::Exited { exit_code: 256 },
+                1,
+            ),
+            ("timed out", ExecTermination::TimedOut, 124),
+            ("cancelled", ExecTermination::Cancelled, 1),
+            ("start failed", ExecTermination::StartFailed, 1),
+            ("wait failed", ExecTermination::WaitFailed, 1),
+        ] {
+            let result = exec_result(termination, b"", b"", "");
+
+            assert_eq!(
+                benchmark_exit_code(&result),
+                expected_exit_code,
+                "case={case}"
+            );
+        }
+    }
+
+    #[test]
     fn benchmark_output_preserves_timeout_stderr_fallback() {
         let result = exec_result(ExecTermination::TimedOut, b"partial stdout\n", b"", "");
         let mut stdout = Vec::new();


### PR DESCRIPTION
## Summary

- add a table-driven Runner test for the benchmark terminal exit-code policy
- cover valid boundary codes, invalid structured guest codes, timeout, cancellation, start failure, and wait failure
- keep production behavior and command flow unchanged

## Scope

This is a test-only change in `crates/runner/src/cmd/benchmark.rs`. It does not change APIs, protocols, configuration, persisted data, runtime behavior, or deployment compatibility.

## Validation

- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner --bin runner cmd::benchmark::tests::benchmark_exit_codes_match_terminal_states -- --exact`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --all-features --no-deps`
- `lefthook run pre-commit --files crates/runner/src/cmd/benchmark.rs`

Closes #31850
