### PR TITLE
perf(python): bound zstd frame validation work

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -476,7 +476,8 @@ def decode_response_body_for_network_log_capture(
     - ``br`` rejects invalid or incomplete input, except that reaching the
       decoded-output bound returns the bounded prefix.
     - ``zstd`` reads concatenated frames up to ``max_output`` bytes and rejects
-      malformed or incomplete frames unless the decoded-output bound is reached.
+      malformed, incomplete, or strict-frame-budget-exceeding input unless the
+      decoded-output bound is reached.
 
     This is stricter than the best-effort ``decompress_body()`` path used for
     retained streaming buffers, which can preserve original wire bytes or
@@ -796,7 +797,8 @@ def decompress_json_usage_body(
     empty body because body capture can still mark those responses truncated
     from stream metadata. JSON usage fallback only has the final buffer, so it
     needs to distinguish a valid compressed empty response from an incomplete
-    compressed frame that produced no JSON bytes.
+    compressed frame that produced no JSON bytes. Strict zstd validation also
+    rejects bodies that exceed its per-body frame budget.
 
     """
     encoding = headers.get("content-encoding", "").strip().lower()

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -36,9 +36,13 @@ _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
 # zstd's Python decompression object has no zlib-style max_length argument.
 # Keep validation input chunks small so the discarded decoded output is bounded.
 _ZSTD_VALIDATE_INPUT_CHUNK_SIZE = 32
+# Preserve ordinary concatenation with substantial headroom while capping
+# per-frame decoder construction independently of compressed and decoded bytes.
+_ZSTD_VALIDATE_MAX_FRAMES = 64
 INVALID_COMPRESSED_BODY = "invalid compressed body"
 INCOMPLETE_COMPRESSED_BODY = "incomplete compressed body"
 DECODED_BODY_LIMIT_EXCEEDED = "decoded body limit exceeded"
+COMPRESSED_FRAME_LIMIT_EXCEEDED = "compressed frame limit exceeded"
 _STREAM_ZLIB_WBITS_BY_ENCODING = {
     "gzip": 16 + zlib.MAX_WBITS,
     "deflate": zlib.MAX_WBITS,
@@ -675,7 +679,11 @@ def _validate_complete_zstd_frames(data: bytes, max_output: int) -> str | None:
     source_offset = 0
     pending_input = b""
     decoded_size = 0
+    validated_frames = 0
     while source_offset < len(source) or pending_input:
+        if validated_frames >= _ZSTD_VALIDATE_MAX_FRAMES:
+            return COMPRESSED_FRAME_LIMIT_EXCEEDED
+        validated_frames += 1
         obj = zstandard.ZstdDecompressor().decompressobj()
 
         while source_offset < len(source) or pending_input:

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -1056,6 +1056,10 @@ class TestDecompressJsonUsageBody:
         assert decoded == body
         assert error is None
 
+
+class TestStrictZstdFrameBudget:
+    """Structural coverage for strict zstd decoder construction bounds."""
+
     def test_zstd_validation_bounds_frame_transitions_for_strict_consumers(
         self, headers, monkeypatch
     ):

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -12,6 +12,7 @@ from body_decoding import (
     can_stream_decode_usage,
     create_stream_decode_session,
     decode_request_body_for_network_log_capture,
+    decode_response_body_for_network_log_capture,
     decompress_body,
     decompress_json_usage_body,
 )
@@ -1055,14 +1056,12 @@ class TestDecompressJsonUsageBody:
         assert decoded == body
         assert error is None
 
-    def test_zstd_validation_carries_bounded_unused_data_without_rebuilding_tail(
+    def test_zstd_validation_bounds_frame_transitions_for_strict_consumers(
         self, headers, monkeypatch
     ):
-        frame_count = 7000
         frame = zstandard.ZstdCompressor().compress(b"")
-        compressed = frame * frame_count
-        assert len(compressed) < STREAM_BUFFER_LIMIT
         hdrs = headers(("Content-Encoding", "zstd"))
+        validation_objects = 0
         validation_input_sizes: list[int] = []
         real_factory = zstandard.ZstdDecompressor
 
@@ -1098,6 +1097,8 @@ class TestDecompressJsonUsageBody:
                 return self._wrapped.stream_reader(*args, **kwargs)
 
             def decompressobj(self, *args, **kwargs):
+                nonlocal validation_objects
+                validation_objects += 1
                 return TrackingDecompressionObj(self._wrapped.decompressobj(*args, **kwargs))
 
         monkeypatch.setattr(
@@ -1105,13 +1106,32 @@ class TestDecompressJsonUsageBody:
             TrackingZstdDecompressor,
         )
 
+        accepted = frame * 64
         decoded, error = decompress_json_usage_body(
-            compressed,
+            accepted,
             hdrs,
             max_output=1,
         )
 
         assert decoded == b""
         assert error is None
+        assert validation_objects == 64
         assert validation_input_sizes
         assert max(validation_input_sizes) <= 32
+
+        over_budget = frame * (STREAM_BUFFER_LIMIT // len(frame))
+        assert len(over_budget) < STREAM_BUFFER_LIMIT
+
+        validation_objects = 0
+        decoded, error = decompress_json_usage_body(over_budget, hdrs, max_output=1)
+        assert decoded == b""
+        assert error == "compressed frame limit exceeded"
+        assert validation_objects == 64
+
+        validation_objects = 0
+        assert decode_request_body_for_network_log_capture(over_budget, hdrs, max_output=1) is None
+        assert validation_objects == 64
+
+        validation_objects = 0
+        assert decode_response_body_for_network_log_capture(over_budget, hdrs, max_output=1) is None
+        assert validation_objects == 64


### PR DESCRIPTION
## Summary

- cap strict zstd validation at 64 frames before constructing decoder object 65
- report a dedicated `compressed frame limit exceeded` diagnostic while keeping usage and capture callers fail closed
- structurally verify the accepted boundary and near-64-KiB rejection across JSON usage, request capture, and response capture

## Compatibility

- preserves existing malformed, incomplete, trailing-data, decoded-overflow, and ordinary concatenated-frame behavior within the budget
- changes no API, queue, schema, persisted state, dependency, or cross-version runner protocol
- valid strict bodies containing 65 or more zstd frames are intentionally omitted from fallback usage and network-log capture
- the C-backed initial reader still traverses the bounded body; this change specifically caps Python per-frame decoder construction

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_body_decoding.py` (118 passed)
- `uv run --no-sync python -m pytest tests/test_body_capture_decompression.py tests/test_model_provider_json_streaming.py` (51 passed)
- `uv run --no-sync python -m pytest tests/` (7,274 passed)
- `lefthook run pre-commit`

Closes #31859
