### PR TITLE
fix(runner): reject non-http pi model base urls

### DIFF
--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -220,7 +220,10 @@ fn validate_pi_model_config_common(
     model: &str,
     catalog_model: Option<&serde_json::Value>,
 ) -> Result<(), PiModelConfigCommonError> {
-    url::Url::parse(base_url).map_err(|_| PiModelConfigCommonError::InvalidBaseUrl)?;
+    let parsed = url::Url::parse(base_url).map_err(|_| PiModelConfigCommonError::InvalidBaseUrl)?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(PiModelConfigCommonError::InvalidBaseUrl);
+    }
     if model.is_empty() {
         return Err(PiModelConfigCommonError::EmptyModel);
     }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -1507,6 +1507,49 @@ fn pi_execution_context_rejects_invalid_legacy_shared_model_fields_before_sandbo
 }
 
 #[test]
+fn pi_execution_context_restricts_model_base_url_schemes_before_sandbox() {
+    let v2_public = pi_model_config_v2_for_test("openai-responses");
+    let v2_codex = pi_model_config_v2_for_test("openai-codex-responses");
+    let mut v3_public = v2_public.clone();
+    v3_public["schemaVersion"] = json!(3);
+    let mut v3_codex = v2_codex.clone();
+    v3_codex["schemaVersion"] = json!(3);
+    let configs = [
+        pi_model_config_for_test(),
+        v2_public,
+        v2_codex,
+        v3_public,
+        v3_codex,
+    ];
+
+    for (base_url, supported) in [
+        ("http://provider.example/v1", true),
+        ("https://provider.example/v1", true),
+        ("ftp://provider.example/v1", false),
+        ("file:///tmp/model", false),
+    ] {
+        for original in &configs {
+            let mut context = pi_context_for_test();
+            let mut config = original.clone();
+            config["baseUrl"] = json!(base_url);
+            context.pi_model_config = Some(config.clone());
+
+            let result = validate_context_for_test(&context);
+
+            if supported {
+                assert!(result.is_ok(), "{config}");
+            } else {
+                assert_eq!(
+                    result.unwrap_err(),
+                    "Pi model config baseUrl is invalid",
+                    "{config}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn pi_execution_context_accepts_and_preserves_versioned_dialect_tiers() {
     for generation in [2, 3] {
         for dialect in ["openai-responses", "openai-codex-responses"] {


### PR DESCRIPTION
## Summary

- reject parseable Pi model base URLs whose schemes are not HTTP or HTTPS at the runner's shared pre-sandbox validator
- cover legacy generation 1 plus both dialects in generations 2 and 3 with HTTP, HTTPS, FTP, and file URL cases
- preserve the existing invalid-base-URL diagnostic and raw model payload behavior

## Exclusions

- no TypeScript schema or API route-building changes
- no HTTPS-only restriction for custom gateways
- no wire generation, persisted state, or migration changes

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo xtask check-rust-path-attributes`
- `cd crates && cargo clippy -p runner --all-targets --all-features`
- `cd crates && cargo doc -p runner --all-features --no-deps`
- `cd crates && cargo test -p runner pi_execution_context_restricts_model_base_url_schemes_before_sandbox`
- `cd crates && cargo test -p runner`
- `git diff --check`

Closes #31865
