### PR TITLE
refactor(db): rename stale zero-run fixture identifiers in the migration consistency script

### DIFF
--- a/turbo/packages/db/scripts/test-migration-consistency-schema.ts
+++ b/turbo/packages/db/scripts/test-migration-consistency-schema.ts
@@ -7289,9 +7289,9 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
     goalAId: "00000000-0000-4000-8000-000000088604",
     goalBId: "00000000-0000-4000-8000-000000088605",
     sessionId: "00000000-0000-4000-8000-000000088606",
-    goalZeroRunId: "00000000-0000-4000-8000-000000088607",
-    danglingZeroRunId: "00000000-0000-4000-8000-000000088608",
-    conflictZeroRunId: "00000000-0000-4000-8000-000000088609",
+    goalRunId: "00000000-0000-4000-8000-000000088607",
+    danglingRunId: "00000000-0000-4000-8000-000000088608",
+    conflictRunId: "00000000-0000-4000-8000-000000088609",
     multiLeafEventId: "00000000-0000-4000-8000-000000088610",
     userMessageEventId: "00000000-0000-4000-8000-000000088611",
     thinkingEventId: "00000000-0000-4000-8000-000000088612",
@@ -7379,9 +7379,9 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
             ($3, 'canonical-backfill-user', $4, 'completed', 'conflicting goal run', 'canonical-backfill-org')
         `,
         [
-          fixture.goalZeroRunId,
-          fixture.danglingZeroRunId,
-          fixture.conflictZeroRunId,
+          fixture.goalRunId,
+          fixture.danglingRunId,
+          fixture.conflictRunId,
           fixture.sessionId,
         ],
       );
@@ -7503,8 +7503,8 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
             ($2, 'goal', $3, $5, NULL)
         `,
         [
-          fixture.goalZeroRunId,
-          fixture.danglingZeroRunId,
+          fixture.goalRunId,
+          fixture.danglingRunId,
           fixture.threadAId,
           fixture.goalAId,
           fixture.missingGoalId,
@@ -7575,7 +7575,7 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
           VALUES ($1, 'goal', $2, $3, $4)
         `,
         [
-          fixture.conflictZeroRunId,
+          fixture.conflictRunId,
           fixture.threadAId,
           fixture.goalAId,
           fixture.goalBId,
@@ -7589,7 +7589,7 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
         /zero_runs has .* rows whose goal_id conflicts with run_group_id/u,
       );
       await client.query(`DELETE FROM "zero_runs" WHERE "id" = $1`, [
-        fixture.conflictZeroRunId,
+        fixture.conflictRunId,
       ]);
 
       // Goal B disappears the way production goals do; its chat event keeps a
@@ -7785,16 +7785,16 @@ async function validateCanonicalChatEventStorageBackfill(): Promise<void> {
           WHERE "id" = ANY($1::uuid[])
           ORDER BY "id"
         `,
-        [[fixture.goalZeroRunId, fixture.danglingZeroRunId]],
+        [[fixture.goalRunId, fixture.danglingRunId]],
       );
       assert.deepEqual(zeroRunRows.rows, [
         {
-          id: fixture.goalZeroRunId,
+          id: fixture.goalRunId,
           runGroupId: fixture.goalAId,
           goalId: fixture.goalAId,
         },
         {
-          id: fixture.danglingZeroRunId,
+          id: fixture.danglingRunId,
           runGroupId: fixture.missingGoalId,
           goalId: null,
         },
@@ -8037,7 +8037,7 @@ async function validateChatEventPhysicalContraction(): Promise<void> {
     threadId: "00000000-0000-4000-8000-000000091002",
     goalId: "00000000-0000-4000-8000-000000091003",
     sessionId: "00000000-0000-4000-8000-000000091004",
-    zeroRunId: "00000000-0000-4000-8000-000000091005",
+    runId: "00000000-0000-4000-8000-000000091005",
     legacyEventId: "00000000-0000-4000-8000-000000091006",
     interruptEventId: "00000000-0000-4000-8000-000000091007",
     interruptRunId: "00000000-0000-4000-8000-000000091008",
@@ -8143,7 +8143,7 @@ async function validateChatEventPhysicalContraction(): Promise<void> {
             'physical contraction goal run', 'physical-contract-org'
           )
         `,
-        [fixture.zeroRunId, fixture.sessionId],
+        [fixture.runId, fixture.sessionId],
       );
       await client.query(
         `
@@ -8151,7 +8151,7 @@ async function validateChatEventPhysicalContraction(): Promise<void> {
             "id", "trigger_source", "chat_thread_id", "run_group_id", "goal_id"
           ) VALUES ($1, 'goal', $2, $3, $3)
         `,
-        [fixture.zeroRunId, fixture.threadId, fixture.goalId],
+        [fixture.runId, fixture.threadId, fixture.goalId],
       );
 
       await client.query(
@@ -8338,7 +8338,7 @@ async function validateChatEventPhysicalContraction(): Promise<void> {
               WHERE "id" = $1
             ) AS "zeroRunGoalId"
         `,
-        [fixture.zeroRunId],
+        [fixture.runId],
       );
       assert.deepEqual(catalog.rows, [
         {

--- a/turbo/packages/eslint-rules/scripts/residual-brand-name-manifest.ts
+++ b/turbo/packages/eslint-rules/scripts/residual-brand-name-manifest.ts
@@ -969,14 +969,10 @@ export const RESIDUAL_BRAND_NAME_BASELINE = [
   ...baselineNames(
     [
       "Zero-run",
-      "conflictZeroRunId",
-      "danglingZeroRunId",
-      "goalZeroRunId",
       "zero-run",
       "zero-run-fixture",
       "zeroRunGoalId",
       "zeroRunGroupId",
-      "zeroRunId",
       "zeroRunRows",
       "zeroRuns",
       "zero_runs-only",


### PR DESCRIPTION
Closes #31819. Part of #31801 (phase-3 continuation of #26873), follow-up to #26877 workstream **R4b**.

## What this fixes

#26877 was asked to rename these identifiers but was simultaneously told `packages/db/scripts` must have no diff. Its owner honoured the written boundary and escalated the contradiction — correct process. The *reason* recorded in that PR was wrong, though: it argued the names read correctly because they identify rows in the physical table `zero_runs`.

They do not. This PR applies the precise boundary: `packages/db/scripts` protects **SQL text and physical identifiers** — table, column, index and constraint names, and the migration replay logic — **not local TypeScript variable names inside those scripts**.

## Why `agent_runs` owns these identities

`zero_runs` is not an independent entity. It is a satellite table whose primary key *is* a foreign key to `agent_runs`:

```sql
-- turbo/packages/db/src/migrations/0808_baseline.sql:9234
ALTER TABLE ONLY public.zero_runs
    ADD CONSTRAINT zero_runs_id_agent_runs_id_fk FOREIGN KEY (id) REFERENCES public.agent_runs(id) ON DELETE CASCADE;
```

`0924_drop_zero_runs` later drops the table entirely; `agent_runs` is the only run table in the head schema. So a UUID seeded into both tables carries an `agent_runs.id` identity, and its `zero_runs` row is a dependent that borrows it. Naming such a UUID `…ZeroRunId` is stale, not boundary-accurate.

The file already agrees with this. `validateGoalOnlyRunGroupsCleanup` seeds runs into **both** tables and names them plainly, while keeping `zeroRun…` for a value read out of `zero_runs`:

```ts
// test-migration-consistency-schema.ts:5268 — seeded into agent_runs AND zero_runs
goalRunId: "00000000-0000-4000-8000-000000081007",
// test-migration-consistency-schema.ts:5547 — a column read from zero_runs, keeps the name
"run"."run_group_id" AS "zeroRunGroupId"
```

This PR makes the two remaining validators consistent with that existing convention.

## Renamed — 4 identifiers, each proven against a canonical table

| Identifier | New name | Statement it is bound into |
|---|---|---|
| `goalZeroRunId` (:7309) | `goalRunId` | `INSERT INTO "agent_runs"` (:7392), `$1` |
| `danglingZeroRunId` (:7310) | `danglingRunId` | `INSERT INTO "agent_runs"` (:7392), `$2` |
| `conflictZeroRunId` (:7311) | `conflictRunId` | `INSERT INTO "agent_runs"` (:7392), `$3` |
| `zeroRunId` (:8057) | `runId` | `INSERT INTO "agent_runs"` (:8156), `$1` |

The three in `validateCanonicalChatEventStorageBackfill` are the parameters of one statement:

```ts
// test-migration-consistency-schema.ts:7390-7402
`
  INSERT INTO "agent_runs" ("id", "user_id", "session_id", "status", "prompt", "org_id")
  VALUES
    ($1, 'canonical-backfill-user', $4, 'completed', 'goal continuation run', 'canonical-backfill-org'),
    ($2, 'canonical-backfill-user', $4, 'completed', 'dangling goal run', 'canonical-backfill-org'),
    ($3, 'canonical-backfill-user', $4, 'completed', 'conflicting goal run', 'canonical-backfill-org')
`,
[fixture.goalRunId, fixture.danglingRunId, fixture.conflictRunId, fixture.sessionId],
```

`zeroRunId` in `validateChatEventPhysicalContraction` is the same shape:

```ts
// test-migration-consistency-schema.ts:8155-8163
`
  INSERT INTO "agent_runs" (
    "id", "user_id", "session_id", "status", "prompt", "org_id"
  ) VALUES (
    $1, 'physical-contract-user', $2, 'completed',
    'physical contraction goal run', 'physical-contract-org'
  )
`,
[fixture.runId, fixture.sessionId],
```

Each of these rows is *also* given a satellite `zero_runs` row later in the same fixture. That does not make the identifier a `zero_runs` name — the satellite exists only because the `agent_runs` row does.

## Retained — 4 identifiers, each proven to target `zero_runs`

Renaming these would make the code read against the wrong table, so they keep their names.

| Identifier | SQL it names |
|---|---|
| `zeroRuns` (:7270, :7288) | `SELECT md5(...) AS "digest" FROM "zero_runs" AS "run"` — a digest **of the `zero_runs` table** |
| `zeroRunGroupId` (:5542, :5547, :5556) | `SELECT "run"."run_group_id" AS "zeroRunGroupId" FROM "zero_runs" AS "run"` |
| `zeroRunRows` (:7794, :7807) | `SELECT "id", "run_group_id" AS "runGroupId", "goal_id" AS "goalId" FROM "zero_runs"` |
| `zeroRunGoalId` (:8305, :8356, :8366) | `(SELECT "goal_id"::text FROM "zero_runs" WHERE "id" = $1) AS "zeroRunGoalId"` |

The split is consistent: **row identity** follows the canonical table (`agent_runs`), **table contents and column projections** follow the table actually being read (`zero_runs`).

## Untouched, by design

`git diff` changes no SQL string, physical name, migration identifier, or replay logic. Not one changed line contains SQL text — every changed line is a fixture object key or a parameter-array element. Verified by occurrence count against `main`:

| Physical / replayed identifier | `main` | this branch |
|---|---|---|
| `zero_runs` | 34 | 34 |
| `zero_agents` | 11 | 11 |
| `restricted_vm0_models` | 2 | 2 |
| `bridge_goal_only_zero_run_group_0810` | 6 | 6 |
| `sync_zero_run_metadata_to_agent_runs` | 2 | 2 |

(The issue quotes 28 `zero_runs`; the file actually contains 34 occurrences of the token, the extra ones being index names such as `idx_zero_runs_run_group` and error-matching regexes. Either way the count is unchanged.) Nothing under `packages/db/src/migrations/**` or `.github/workflows/**` is touched, and no unrelated zero/vm0 naming was swept in.

## Guard baseline

The four renamed names are removed from the R4 block of `residual-brand-name-manifest.ts`, which the guard requires in the same change. Verified that the edit is exactly necessary and exactly sufficient — reverting only the manifest makes the guard name precisely these four and no others:

```
Stale baseline entries (4):
- conflictZeroRunId (R4, #26877): no occurrence remains, delete the baseline entry
- danglingZeroRunId (R4, #26877): no occurrence remains, delete the baseline entry
- goalZeroRunId (R4, #26877): no occurrence remains, delete the baseline entry
- zeroRunId (R4, #26877): no occurrence remains, delete the baseline entry
```

## Verification

- **Migration consistency script against a real cluster** — PostgreSQL 18.6 + pgvector, `timezone=UTC`. Both affected validators pass: *"Canonical chat event storage backfill converges, aborts on conflicts, and reruns cleanly"*, and all four checks of *"Validate physical chat-event storage contraction"*.
- **Behaviourally inert** — the run log on this branch is byte-identical to the log on `main`, except one timing measurement that differs by 1 ms (`2068.4ms` vs `2069.4ms`). 95 passing checks on both.
- One pre-existing failure in `validateConnectorAccountExpansion` (`test-connector-account-expansion.ts`, untouched here) reproduces identically on unmodified `main` in this environment, so it is environmental and not from this change.
- Guard test `residual-brand-name-inventory.test.ts`: 10/10 pass.
- `tsc --noEmit` on `@okouai/db`: no errors in the changed file; total error count identical to `main` (53 before, 53 after — pre-existing).
- `oxlint` and `eslint --max-warnings 0` clean on both changed files; `prettier --check` clean.
- Rebased onto `main` after #31879 (`refactor(db): drop retired draft voice columns`) merged, since it edited the same file. All checks above were re-run post-rebase.

## Note for the follow-up

The four retained names still sit in the R4 baseline under `ownerIssue: "#26877"` with a reason that says they will be renamed. They will not be — they are correct as they stand. Reclassifying them from baseline candidates into an approved boundary rule is a manifest-design decision that belongs with #31813, so it is deliberately left out of this focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
