### PR TITLE
chore: delete dead workflow-zero diagram custom properties

### DIFF
--- a/docs/residual-platform-brand-names.md
+++ b/docs/residual-platform-brand-names.md
@@ -142,17 +142,17 @@ Both are decided in full below.
 | `zero-sized` | `views/okou-page/image-annotation-editor.tsx:58`          | English prose: "would leave a zero-sized mark".                                                                            |
 | `zero-usage` | `views/okou-page/__tests__/chat-run-history.test.tsx:890` | Fixture id for a usage event carrying `creditUsage(0, [])` — a run that consumed zero credits. The numeral, not the brand. |
 
-## Baseline — still undecided
+## Baseline — resolved
 
-| Name        | Site                       | Owner  | Reason                                                                                                                                                                                  |
-| ----------- | -------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `zero-left` | `views/css/index.css:1542` | #31840 | `--workflow-zero-left`. #31816's brief labelled this semantic and excluded it from scope; it is not. It positions the Zero avatar node in the onboarding diagram, and nothing reads it. |
-| `zero-size` | `views/css/index.css:1543` | #31840 | `--workflow-zero-size`. Same declaration block, and `72px` is exactly the `.owf-diagram-avatar` box. Also unreferenced.                                                                 |
-
-Both are dead declarations, so #31840 can delete rather than rename them. They
-were left untouched here because #31816's scope explicitly excluded them, and
-changing a name the brief said not to change is worse than recording that the
-brief was wrong.
+`zero-left` and `zero-size` were the only names this document left undecided.
+They were the `--workflow-zero-left: 277px` and `--workflow-zero-size: 72px`
+declarations in the `.owf-diagram` block of `views/css/index.css`: the geometry
+of the Zero avatar node in the onboarding diagram, with no `var()` reader
+anywhere in the repository. #31816's brief labelled them semantic and excluded
+them from scope, which was wrong, so #31816 recorded them here instead of
+changing a name its brief said not to change. #31840 deleted both declarations
+and their R1 baseline entries; deletion, not a rename, because nothing read
+them.
 
 ## Persisted-Key Decisions
 

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1571,8 +1571,6 @@ details > summary {
   --workflow-top-line-y: 81px;
   --workflow-source-icon-left: 107px;
   --workflow-node-icon-size: 56px;
-  --workflow-zero-left: 277px;
-  --workflow-zero-size: 72px;
   --workflow-output-icon-left: 457.5px;
   --workflow-output-icon-top: 53px;
   --workflow-source-dot-x: calc(

--- a/turbo/packages/eslint-rules/scripts/residual-brand-name-manifest.ts
+++ b/turbo/packages/eslint-rules/scripts/residual-brand-name-manifest.ts
@@ -1247,12 +1247,6 @@ export const RESIDUAL_BRAND_NAME_BASELINE = [
       "Legacy data-vm0-* edit-protocol reader kept for deck HTML that was stored or externally generated before the okou rename; #31824 drops it once no such deck remains.",
     workstream: "R7",
   }),
-  ...baselineNames(["workflow-zero-left", "workflow-zero-size"], {
-    ownerIssue: "#31840",
-    reason:
-      "Dead custom property in the onboarding diagram declaration block that nothing reads; docs/residual-platform-brand-names.md records it as undecided and #31840 can delete rather than rename it.",
-    workstream: "R1",
-  }),
   ...baselineNames(["vm0-deck-metadata"], {
     ownerIssue: "#31824",
     reason:


### PR DESCRIPTION
Closes #31840. Phase 3 of #26873, under EPIC #31801.

## What

`--workflow-zero-left: 277px` and `--workflow-zero-size: 72px` sat in the `.owf-diagram` declaration block in `turbo/apps/platform/src/views/css/index.css`, between `--workflow-source-icon-left` and `--workflow-output-icon-left`. They were the geometry of the Zero avatar node in the onboarding diagram, and `72px` is exactly the `.owf-diagram-avatar` box.

Nothing reads them. `var(--workflow-zero...)` has zero consumers in the repository — the two declarations were the only occurrences of either name outside the guard baseline and the classification document. The avatar node is sized and positioned by `.owf-diagram-node-zero` and `.owf-diagram-avatar` in `onboarding-workflow-diagram.tsx`, not by these properties.

So this deletes them rather than renaming them. #31816 kept them because its brief labelled them semantic and excluded them from scope, and opened #31840 to carry the decision.

## Changes

- `views/css/index.css` — delete the two declarations. No other `--workflow-*` property in the block is touched; the rest have real consumers.
- `residual-brand-name-manifest.ts` — drop the two R1 baseline entries (`workflow-zero-left`, `workflow-zero-size`). This must be the same PR: the ratchet fails on a baseline entry whose occurrences are gone. R1 is now the 5 remaining names in its other block. No other workstream's names are touched.
- `docs/residual-platform-brand-names.md` — the "still undecided" section listed exactly these two names, at line numbers that no longer exist. Rewritten to record the resolution.

## Verification

- `pnpm -F @okouai/eslint-rules exec vitest run scripts/residual-brand-name-inventory.test.ts` — 10 passed. Confirmed the two halves are genuinely coupled: with the CSS deletion applied but the baseline entries restored, the ratchet fails.
- `pnpm -F @okouai/app exec vitest run src/views/onboarding/__tests__/onboarding-flow.test.tsx` — 31 passed.
- `pnpm check-types` (15 tasks), `pnpm turbo run lint --filter=@okouai/app --filter=@okouai/eslint-rules`, `pnpm knip`, `pnpm format` — all clean.

No visual change is expected or possible: a custom property with no `var()` reader has no rendered effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)