### PR TITLE
fix(platform): fail closed to the okou clerk primary domain

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -233,10 +233,14 @@
         var publishableKey = production
           ? "%VITE_CLERK_PUBLISHABLE_KEY_PROD%"
           : "%VITE_CLERK_PUBLISHABLE_KEY_PREVIEW%";
+        // Keep this decision in sync with
+        // src/lib/clerk-production-topology.ts: only an explicit rollback
+        // value selects the pre-cutover topology, and everything else fails
+        // closed to the deployed one.
         var productionPrimaryAppDomain =
-          "__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__" === "app.okou.ai"
-            ? "app.okou.ai"
-            : "app.vm0.ai";
+          "__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__" === "app.vm0.ai"
+            ? "app.vm0.ai"
+            : "app.okou.ai";
         var okouPrimary = productionPrimaryAppDomain === "app.okou.ai";
         var satelliteDomain = null;
         if (

--- a/turbo/apps/platform/src/__tests__/clerk-primary-app-domain.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-primary-app-domain.test.ts
@@ -100,7 +100,7 @@ test("An explicitly requested app.vm0.ai keeps Okou a satellite", async () => {
   expect(clerk.loads).toContainEqual(VM0_PRIMARY_SATELLITE_LOAD_OPTIONS);
 });
 
-const BOOTSTRAP_SCRIPT_OPENING_TAG = '<script data-okou-clerk-bootstrap="">';
+const BOOTSTRAP_SCRIPT_SELECTOR = "[data-okou-clerk-bootstrap]";
 const PRIMARY_APP_DOMAIN_MARKER = "__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__";
 
 interface InlineBootstrapLoadOptions {
@@ -132,12 +132,12 @@ type InlineBootstrap = (
 ) => void;
 
 function inlineBootstrapSource(): string {
-  const start = indexHtml.indexOf(BOOTSTRAP_SCRIPT_OPENING_TAG);
-  const end = indexHtml.indexOf("</script>", start);
-  if (start === -1 || end === -1) {
+  const page = new DOMParser().parseFromString(indexHtml, "text/html");
+  const source = page.querySelector(BOOTSTRAP_SCRIPT_SELECTOR)?.textContent;
+  if (!source) {
     throw new Error("index.html no longer contains the Clerk bootstrap script");
   }
-  return indexHtml.slice(start + BOOTSTRAP_SCRIPT_OPENING_TAG.length, end);
+  return source;
 }
 
 // Runs the bootstrap the deployed page runs, with the deployment marker

--- a/turbo/apps/platform/src/__tests__/clerk-primary-app-domain.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-primary-app-domain.test.ts
@@ -1,0 +1,238 @@
+import { screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import indexHtml from "../../index.html?raw";
+import {
+  normalizeClerkProductionPrimaryAppDomain,
+  resolveClerkProductionSatelliteDomain,
+  resolveClerkProductionTopology,
+} from "../lib/clerk-production-topology.ts";
+import { setupPage } from "./page-helper.ts";
+import { testContext } from "../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+const OKOU_PRIMARY_SATELLITE_LOAD_OPTIONS = {
+  afterSignOutUrl: "https://app.okou.ai/sign-in",
+  isSatellite: true,
+  satelliteAutoSync: true,
+  signInUrl: "https://app.okou.ai/sign-in",
+  signUpUrl: "https://app.okou.ai/sign-up",
+} as const;
+
+const VM0_PRIMARY_LOAD_OPTIONS = {
+  afterSignOutUrl: "https://app.vm0.ai/sign-in",
+  signInUrl: "https://app.vm0.ai/sign-in",
+  signUpUrl: "https://app.vm0.ai/sign-up",
+} as const;
+
+const VM0_PRIMARY_SATELLITE_LOAD_OPTIONS = {
+  ...VM0_PRIMARY_LOAD_OPTIONS,
+  isSatellite: true,
+  satelliteAutoSync: true,
+} as const;
+
+test("A build that lost the injected primary app domain authenticates against Okou", async () => {
+  const clerk = context.mocks.clerk();
+
+  await setupPage({
+    context,
+    host: "app.vm0.ai",
+    path: "/agents",
+    primaryAppDomain: null,
+  });
+
+  expect(clerk.resourceRequests).toStrictEqual([
+    { domain: "vm0.ai", publishableKey: "test_production_key" },
+  ]);
+  expect(clerk.loads).toContainEqual(OKOU_PRIMARY_SATELLITE_LOAD_OPTIONS);
+});
+
+test("The deployed primary app domain keeps vm0.ai a satellite of Okou", async () => {
+  const clerk = context.mocks.clerk();
+
+  await setupPage({
+    context,
+    host: "app.vm0.ai",
+    path: "/agents",
+    primaryAppDomain: "app.okou.ai",
+  });
+
+  expect(clerk.resourceRequests).toStrictEqual([
+    { domain: "vm0.ai", publishableKey: "test_production_key" },
+  ]);
+  expect(clerk.loads).toContainEqual(OKOU_PRIMARY_SATELLITE_LOAD_OPTIONS);
+});
+
+// The rollback path: restoring the previous topology must stay a change to the
+// injected deployment value, never a code change.
+test("An explicitly requested app.vm0.ai still owns primary authentication", async () => {
+  const clerk = context.mocks.clerk();
+
+  await setupPage({
+    context,
+    host: "app.vm0.ai",
+    path: "/sign-in",
+    auth: null,
+    primaryAppDomain: "app.vm0.ai",
+  });
+
+  await expect(screen.findByLabelText("Email address")).resolves.toBeVisible();
+  expect(clerk.resourceRequests).toStrictEqual([
+    { domain: undefined, publishableKey: "test_production_key" },
+  ]);
+  expect(clerk.loads).toContainEqual(VM0_PRIMARY_LOAD_OPTIONS);
+});
+
+test("An explicitly requested app.vm0.ai keeps Okou a satellite", async () => {
+  const clerk = context.mocks.clerk();
+
+  await setupPage({
+    context,
+    host: "app.okou.ai",
+    path: "/agents",
+    primaryAppDomain: "app.vm0.ai",
+  });
+
+  expect(clerk.resourceRequests).toStrictEqual([
+    { domain: "app.okou.ai", publishableKey: "test_production_key" },
+  ]);
+  expect(clerk.loads).toContainEqual(VM0_PRIMARY_SATELLITE_LOAD_OPTIONS);
+});
+
+const BOOTSTRAP_SCRIPT_OPENING_TAG = '<script data-okou-clerk-bootstrap="">';
+const PRIMARY_APP_DOMAIN_MARKER = "__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__";
+
+interface InlineBootstrapLoadOptions {
+  readonly isSatellite?: true;
+  readonly signInUrl: string;
+}
+
+interface InlineBootstrapConfiguration {
+  readonly domain?: string;
+  readonly loadOptions: InlineBootstrapLoadOptions;
+  readonly productionPrimaryAppDomain: string;
+}
+
+interface InlineBootstrapWindow {
+  __vm0ClerkBootstrap?: InlineBootstrapConfiguration;
+}
+
+interface InlineBootstrapScript {
+  dataset: Record<string, string>;
+  onerror: (() => void) | null;
+  onload: (() => void) | null;
+  remove: () => void;
+}
+
+type InlineBootstrap = (
+  window: InlineBootstrapWindow,
+  document: { getElementById: (id: string) => InlineBootstrapScript },
+  location: { hostname: string; origin: string },
+) => void;
+
+function inlineBootstrapSource(): string {
+  const start = indexHtml.indexOf(BOOTSTRAP_SCRIPT_OPENING_TAG);
+  const end = indexHtml.indexOf("</script>", start);
+  if (start === -1 || end === -1) {
+    throw new Error("index.html no longer contains the Clerk bootstrap script");
+  }
+  return indexHtml.slice(start + BOOTSTRAP_SCRIPT_OPENING_TAG.length, end);
+}
+
+// Runs the bootstrap the deployed page runs, with the deployment marker
+// substituted the way the worker shell substitutes it.
+function runInlineBootstrap(
+  injectedPrimaryAppDomain: string,
+  hostname: string,
+): InlineBootstrapConfiguration {
+  const source = inlineBootstrapSource().replaceAll(
+    PRIMARY_APP_DOMAIN_MARKER,
+    injectedPrimaryAppDomain,
+  );
+  const runBootstrap = new Function(
+    "window",
+    "document",
+    "location",
+    source,
+  ) as InlineBootstrap;
+  const script: InlineBootstrapScript = {
+    dataset: {},
+    onerror: null,
+    onload: null,
+    remove: () => {
+      return;
+    },
+  };
+  const bootstrapWindow: InlineBootstrapWindow = {};
+  runBootstrap(
+    bootstrapWindow,
+    {
+      getElementById: () => {
+        return script;
+      },
+    },
+    { hostname, origin: `https://${hostname}` },
+  );
+  const bootstrap = bootstrapWindow.__vm0ClerkBootstrap;
+  if (!bootstrap) {
+    throw new Error("The inline Clerk bootstrap published no configuration");
+  }
+  return bootstrap;
+}
+
+const INJECTED_PRIMARY_APP_DOMAINS = [
+  "app.okou.ai",
+  "app.vm0.ai",
+  // A build that never substituted the marker, and a misspelled substitution.
+  PRIMARY_APP_DOMAIN_MARKER,
+  "app.okou.ia",
+  "",
+];
+
+const PAGE_HOSTNAMES = [
+  "app.vm0.ai",
+  "vm0.ai",
+  "www.vm0.ai",
+  "app.okou.ai",
+  "okou.ai",
+  "team.app.okou.ai",
+  "app.vm0.ai.evil.example",
+  "pr-30199-app.omby.ai",
+];
+
+// The page and the app decide the same thing in two languages. A change to one
+// without the other is a silent split-brain that type checking cannot catch.
+test("The inline Clerk bootstrap and the topology module agree", () => {
+  for (const injectedPrimaryAppDomain of INJECTED_PRIMARY_APP_DOMAINS) {
+    for (const hostname of PAGE_HOSTNAMES) {
+      const bootstrap = runInlineBootstrap(injectedPrimaryAppDomain, hostname);
+      const satelliteDomain = resolveClerkProductionSatelliteDomain(
+        hostname,
+        injectedPrimaryAppDomain,
+      );
+      const authOrigin = satelliteDomain
+        ? resolveClerkProductionTopology(injectedPrimaryAppDomain)
+            .primaryAppOrigin
+        : `https://${hostname}`;
+
+      expect({
+        hostname,
+        injectedPrimaryAppDomain,
+        pageDomain: bootstrap.domain ?? null,
+        pageIsSatellite: bootstrap.loadOptions.isSatellite ?? false,
+        pagePrimaryAppDomain: bootstrap.productionPrimaryAppDomain,
+        pageSignInUrl: bootstrap.loadOptions.signInUrl,
+      }).toStrictEqual({
+        hostname,
+        injectedPrimaryAppDomain,
+        pageDomain: satelliteDomain,
+        pageIsSatellite: satelliteDomain !== null,
+        pagePrimaryAppDomain: normalizeClerkProductionPrimaryAppDomain(
+          injectedPrimaryAppDomain,
+        ),
+        pageSignInUrl: `${authOrigin}/sign-in`,
+      });
+    }
+  }
+});

--- a/turbo/apps/platform/src/__tests__/clerk-primary-app-domain.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-primary-app-domain.test.ts
@@ -20,14 +20,14 @@ const OKOU_PRIMARY_SATELLITE_LOAD_OPTIONS = {
   signUpUrl: "https://app.okou.ai/sign-up",
 } as const;
 
-const VM0_PRIMARY_LOAD_OPTIONS = {
+const ROLLBACK_PRIMARY_LOAD_OPTIONS = {
   afterSignOutUrl: "https://app.vm0.ai/sign-in",
   signInUrl: "https://app.vm0.ai/sign-in",
   signUpUrl: "https://app.vm0.ai/sign-up",
 } as const;
 
-const VM0_PRIMARY_SATELLITE_LOAD_OPTIONS = {
-  ...VM0_PRIMARY_LOAD_OPTIONS,
+const ROLLBACK_SATELLITE_LOAD_OPTIONS = {
+  ...ROLLBACK_PRIMARY_LOAD_OPTIONS,
   isSatellite: true,
   satelliteAutoSync: true,
 } as const;
@@ -81,7 +81,7 @@ test("An explicitly requested app.vm0.ai still owns primary authentication", asy
   expect(clerk.resourceRequests).toStrictEqual([
     { domain: undefined, publishableKey: "test_production_key" },
   ]);
-  expect(clerk.loads).toContainEqual(VM0_PRIMARY_LOAD_OPTIONS);
+  expect(clerk.loads).toContainEqual(ROLLBACK_PRIMARY_LOAD_OPTIONS);
 });
 
 test("An explicitly requested app.vm0.ai keeps Okou a satellite", async () => {
@@ -97,7 +97,7 @@ test("An explicitly requested app.vm0.ai keeps Okou a satellite", async () => {
   expect(clerk.resourceRequests).toStrictEqual([
     { domain: "app.okou.ai", publishableKey: "test_production_key" },
   ]);
-  expect(clerk.loads).toContainEqual(VM0_PRIMARY_SATELLITE_LOAD_OPTIONS);
+  expect(clerk.loads).toContainEqual(ROLLBACK_SATELLITE_LOAD_OPTIONS);
 });
 
 const BOOTSTRAP_SCRIPT_SELECTOR = "[data-okou-clerk-bootstrap]";

--- a/turbo/apps/platform/src/__tests__/clerk-primary-app-domain.test.ts
+++ b/turbo/apps/platform/src/__tests__/clerk-primary-app-domain.test.ts
@@ -203,6 +203,11 @@ const PAGE_HOSTNAMES = [
 
 // The page and the app decide the same thing in two languages. A change to one
 // without the other is a silent split-brain that type checking cannot catch.
+//
+// This case cannot be built through the page: no page surface exposes the raw
+// bootstrap script, and `setupPage` accepts only the two valid primary app
+// domains, so a page test cannot present the unsubstituted marker or a
+// misspelled substitution this test exists to pin.
 test("The inline Clerk bootstrap and the topology module agree", () => {
   for (const injectedPrimaryAppDomain of INJECTED_PRIMARY_APP_DOMAINS) {
     for (const hostname of PAGE_HOSTNAMES) {

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -28,6 +28,11 @@ import {
   type SharedWorkerTestTransport,
 } from "../shared-database/test-bridge.ts";
 import {
+  resolveClerkProductionSatelliteDomain,
+  resolveClerkProductionTopology,
+  type ClerkProductionPrimaryAppDomain,
+} from "../lib/clerk-production-topology.ts";
+import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   type SupportedLocale,
@@ -104,6 +109,14 @@ interface SetupPageOptions {
   readonly context: TestContext;
   readonly path: string;
   readonly host?: string;
+  /**
+   * Clerk primary app domain, injected the way the deployed HTML injects it.
+   * Defaults to the primary app domain these page tests were written against,
+   * where `app.vm0.ai` owns primary authentication and `app.okou.ai` is the
+   * satellite. Pass `null` to omit the bootstrap object entirely, which is
+   * what a build that lost the injected value produces.
+   */
+  readonly primaryAppDomain?: ClerkProductionPrimaryAppDomain | null;
   readonly locale?: SupportedLocale;
   readonly auth?: SetupPageAuth;
   readonly debugLoggers?: string[];
@@ -172,6 +185,48 @@ function initialPageUrl(path: string, host: string): URL {
   return new URL(path, `${protocol}://${host}`);
 }
 
+// Mirrors the inline Clerk bootstrap in index.html, which publishes the
+// injected primary app domain and the load options derived from it before the
+// app module runs.
+function installClerkBootstrap(
+  pageUrl: URL,
+  requestedPrimaryAppDomain: ClerkProductionPrimaryAppDomain | null | undefined,
+  signal: AbortSignal,
+): void {
+  // A test that installs its own bootstrap owns the whole object.
+  if (requestedPrimaryAppDomain === null || window.__vm0ClerkBootstrap) {
+    return;
+  }
+  const primaryAppDomain = requestedPrimaryAppDomain ?? "app.vm0.ai";
+  const satelliteDomain = resolveClerkProductionSatelliteDomain(
+    pageUrl.hostname,
+    primaryAppDomain,
+  );
+  const authOrigin = satelliteDomain
+    ? resolveClerkProductionTopology(primaryAppDomain).primaryAppOrigin
+    : pageUrl.origin;
+  window.__vm0ClerkBootstrap = {
+    domain: satelliteDomain ?? undefined,
+    loadOptions: {
+      afterSignOutUrl: new URL("/sign-in", authOrigin).toString(),
+      ...(satelliteDomain
+        ? { isSatellite: true, satelliteAutoSync: true }
+        : {}),
+      signInUrl: new URL("/sign-in", authOrigin).toString(),
+      signUpUrl: new URL("/sign-up", authOrigin).toString(),
+    },
+    productionPrimaryAppDomain: primaryAppDomain,
+    publishableKey: "test_production_key",
+  };
+  signal.addEventListener(
+    "abort",
+    () => {
+      Reflect.deleteProperty(window, "__vm0ClerkBootstrap");
+    },
+    { once: true },
+  );
+}
+
 function resolveAuth(options: SetupPageOptions): {
   readonly organization: MockedOrganization;
   readonly session: MockedSession | null;
@@ -220,6 +275,11 @@ async function setupPageAsync(
   const initialUrl = initialPageUrl(options.path, options.host ?? "localhost");
   options.context.mocks.browser.url(initialUrl.toString());
   createPushStateMock(options.context.signal, initialUrl);
+  installClerkBootstrap(
+    initialUrl,
+    options.primaryAppDomain,
+    options.context.signal,
+  );
 
   if (options.debugLoggers) {
     options.context.store.set(

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -32,6 +32,7 @@ import {
   resolveClerkProductionTopology,
   type ClerkProductionPrimaryAppDomain,
 } from "../lib/clerk-production-topology.ts";
+import { resolvePlatformRuntimeConfig } from "../lib/platform-host.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
@@ -216,7 +217,9 @@ function installClerkBootstrap(
       signUpUrl: new URL("/sign-up", authOrigin).toString(),
     },
     productionPrimaryAppDomain: primaryAppDomain,
-    publishableKey: "test_production_key",
+    // The page selects the publishable key by hostname. Read the same source
+    // the app reads so the two never disagree for a preview host.
+    publishableKey: resolvePlatformRuntimeConfig().clerkPublishableKey,
   };
   signal.addEventListener(
     "abort",

--- a/turbo/apps/platform/src/lib/clerk-instance-config.ts
+++ b/turbo/apps/platform/src/lib/clerk-instance-config.ts
@@ -1,5 +1,5 @@
 import {
-  CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN,
+  normalizeClerkProductionPrimaryAppDomain,
   resolveClerkProductionSatelliteDomain,
   type ClerkProductionDomain,
   type ClerkProductionPrimaryAppDomain,
@@ -19,15 +19,15 @@ interface ClerkInstanceConfig {
 
 export function resolveConfiguredProductionPrimaryAppDomain(): ClerkProductionPrimaryAppDomain {
   const bootstrap = Reflect.get(globalThis, "__vm0ClerkBootstrap");
-  if (
+  const configured =
     typeof bootstrap === "object" &&
     bootstrap !== null &&
-    "productionPrimaryAppDomain" in bootstrap &&
-    bootstrap.productionPrimaryAppDomain === "app.okou.ai"
-  ) {
-    return bootstrap.productionPrimaryAppDomain;
-  }
-  return CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN;
+    "productionPrimaryAppDomain" in bootstrap
+      ? bootstrap.productionPrimaryAppDomain
+      : undefined;
+  // A missing bootstrap object is the same unknown input as a missing
+  // injected value, so both fail closed to the deployed topology.
+  return normalizeClerkProductionPrimaryAppDomain(configured);
 }
 
 export function resolveClerkSatelliteConfig(): ClerkSatelliteConfig | null {

--- a/turbo/apps/platform/src/lib/clerk-production-topology.ts
+++ b/turbo/apps/platform/src/lib/clerk-production-topology.ts
@@ -1,14 +1,18 @@
 const OKOU_CLERK_PRIMARY_APP_ORIGIN = "https://app.okou.ai";
 export const VM0_CLERK_PRIMARY_APP_ORIGIN = "https://app.vm0.ai";
 
-export const CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN = "app.vm0.ai";
-export const CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN = "app.okou.ai";
+// The deployed topology: Okou owns primary auth and the whole vm0.ai domain is
+// a satellite. Everything except an explicit rollback request resolves here.
+const DEFAULT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN = "app.okou.ai";
+// The pre-cutover topology, kept reachable so a rollback is a change to the
+// injected deployment value rather than a code change.
+const ROLLBACK_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN = "app.vm0.ai";
 const CLERK_PRIMARY_USER_PROFILE_URL = "https://accounts.vm0.ai/user";
 
 export type ClerkProductionDomain = "app.okou.ai" | "vm0.ai";
 export type ClerkProductionPrimaryAppDomain =
-  | typeof CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
-  | typeof CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN;
+  | typeof DEFAULT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
+  | typeof ROLLBACK_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN;
 
 interface ClerkProductionTopology {
   readonly primaryAppOrigin:
@@ -22,38 +26,43 @@ function isDomainOrSubdomain(hostname: string, domain: string): boolean {
   return hostname === domain || hostname.endsWith(`.${domain}`);
 }
 
-function normalizeClerkProductionPrimaryAppDomain(
+// Keep this decision in sync with the inline Clerk bootstrap in `index.html`,
+// which repeats it in the page itself so authentication starts before the app
+// module loads.
+export function normalizeClerkProductionPrimaryAppDomain(
   value: unknown,
 ): ClerkProductionPrimaryAppDomain {
-  // Web/app rollout fallback: production clients and retained rollback builds
-  // can straddle the Clerk primary/satellite cutover for about two days.
-  // Remove the VM0-primary branch only after #27750 records that replacement
-  // builds are live, auth verification passed, and the rollback gate closed.
-  return value === CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
-    ? CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
-    : CURRENT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN;
+  // Rollback path: an explicit rollback value must keep resolving to the
+  // pre-cutover topology. Remove that branch only after #27750 records that
+  // replacement builds are live, auth verification passed, and the rollback
+  // gate closed.
+  return value === ROLLBACK_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
+    ? ROLLBACK_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
+    : DEFAULT_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN;
 }
 
 // The Clerk instance and publishable key remain on clerk.vm0.ai. The explicit
 // primary-app deployment value is the source of truth for which app owns
-// primary auth. Unknown values fail closed to the currently deployed topology.
+// primary auth. Unknown values fail closed to the deployed topology, because a
+// build that lost the injected value must not send clients to an app that no
+// longer holds the session.
 export function resolveClerkProductionTopology(
   primaryAppDomain: unknown,
 ): ClerkProductionTopology {
   if (
     normalizeClerkProductionPrimaryAppDomain(primaryAppDomain) ===
-    CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
+    ROLLBACK_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
   ) {
     return {
-      primaryAppOrigin: OKOU_CLERK_PRIMARY_APP_ORIGIN,
-      primaryBrand: "okou",
+      primaryAppOrigin: VM0_CLERK_PRIMARY_APP_ORIGIN,
+      primaryBrand: "vm0",
       primaryUserProfileUrl: CLERK_PRIMARY_USER_PROFILE_URL,
     };
   }
 
   return {
-    primaryAppOrigin: VM0_CLERK_PRIMARY_APP_ORIGIN,
-    primaryBrand: "vm0",
+    primaryAppOrigin: OKOU_CLERK_PRIMARY_APP_ORIGIN,
+    primaryBrand: "okou",
     primaryUserProfileUrl: CLERK_PRIMARY_USER_PROFILE_URL,
   };
 }
@@ -65,13 +74,12 @@ export function resolveClerkProductionSatelliteDomain(
   const normalizedHostname = hostname.toLowerCase();
   if (
     normalizeClerkProductionPrimaryAppDomain(primaryAppDomain) ===
-    CUTOVER_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
+    ROLLBACK_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN
   ) {
-    return isDomainOrSubdomain(normalizedHostname, "vm0.ai") ? "vm0.ai" : null;
+    return isDomainOrSubdomain(normalizedHostname, "app.okou.ai")
+      ? "app.okou.ai"
+      : null;
   }
 
-  if (isDomainOrSubdomain(normalizedHostname, "app.okou.ai")) {
-    return "app.okou.ai";
-  }
-  return null;
+  return isDomainOrSubdomain(normalizedHostname, "vm0.ai") ? "vm0.ai" : null;
 }


### PR DESCRIPTION
Closes #31886.

## What changed

Production injects `app.okou.ai` as the Clerk primary app domain — both `app.vm0.ai` and `app.okou.ai` serve it — so Okou owns primary authentication and the whole `vm0.ai` domain is a satellite. Both copies of the decision still fell back to `app.vm0.ai`, so a build that lost or misspelled the injected value would decide VM0 is primary and try to sync sessions from an app that no longer holds them.

- `turbo/apps/platform/src/lib/clerk-production-topology.ts`: the unrecognised-value fallback is now `app.okou.ai`; `resolveClerkProductionTopology` and `resolveClerkProductionSatelliteDomain` follow it. The constants were named before the cutover and read backwards afterwards, so they are now `DEFAULT_…` (what everything fails closed to) and `ROLLBACK_…` (what a deployment must ask for explicitly); every reference is updated.
- `turbo/apps/platform/index.html`: the inline bootstrap's ternary matches, with a comment pointing at the module.
- `turbo/apps/platform/src/lib/clerk-instance-config.ts`: `resolveConfiguredProductionPrimaryAppDomain` now delegates to the module's `normalizeClerkProductionPrimaryAppDomain` instead of repeating the comparison a third time. A missing bootstrap object is the same unknown input as a missing injected value.

With the injected value `app.okou.ai`, behaviour is unchanged from today.

## The rollback path is kept, and tested

An explicit `app.vm0.ai` still resolves the VM0-primary topology, so rolling back stays a change to the injected deployment value rather than a code change. `An explicitly requested app.vm0.ai still owns primary authentication` and `An explicitly requested app.vm0.ai keeps Okou a satellite` cover both sides of it.

The VM0-primary branch, `VM0_CLERK_PRIMARY_APP_ORIGIN`, the dual-topology function, and the compatibility window at `signals/okou-page/agentphone-connect-params.ts:119` are all untouched. #27750 is closed as completed but records none of the three conditions its removal is gated on — its final comment is about database brand identity and states the VM0 public domains remain supported — so the documented precondition is not met.

## Split-brain guard

The page and the app decide the same thing in two languages, and type checking cannot catch a change to one without the other. `The inline Clerk bootstrap and the topology module agree` extracts the real bootstrap script from `index.html`, runs it across five injected values × eight hostnames — including an unsubstituted `__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__` marker and a misspelling — and asserts the published primary domain, satellite domain, satellite flag and auth origin match the module. Reverting either side alone fails it (verified by mutating `index.html` back).

## Test harness note

The platform's page tests were written against the VM0-primary topology and relied on the source fallback for it, so flipping the fallback silently turned ~160 tests into satellite pages. `setupPage`/`startPage` now inject the primary app domain the way the deployed HTML does, defaulting to `app.vm0.ai`; a test can pass `primaryAppDomain: "app.okou.ai"` for the deployed topology or `null` for a build that lost the value. Existing page tests keep exactly the configuration they were written for, and no test now depends on the source fallback except the ones that are about it. Migrating the page suite's default host to the deployed topology is a separate, mechanical change.

## Out of scope, worth a follow-up

The build layer still defaults to VM0 in two places: `.github/workflows/turbo.yml` and `.github/workflows/release-please.yml` use `${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.vm0.ai' }}`, and `.github/scripts/prepare-okou-app-worker-shell.sh` defaults to `app.vm0.ai`. Those inject `app.vm0.ai` *explicitly*, so this change does not fail them closed: losing the repository variable would still produce a VM0-primary build. The issue scoped itself to the two client-side places, so I left the deployment defaults alone rather than changing release behaviour in an auth PR.

## Verification

- `tsc -p tsconfig.production.json` and `tsc -p tsconfig.tests.json` clean
- `oxlint`, `oxlint --type-aware`, `eslint . --max-warnings 0`, `knip --workspace apps/platform` clean
- `prettier --write` on the changed files
- platform vitest: `src/__tests__`, `src/views/auth-v2`, `src/views/auth`, `src/views/onboarding`, `src/signals`, `src/views/router`, `src/views/notifications`, `src/views/pwa-install`, `src/views/redeem-campaign-page`, `src/views/browser-authorization`, `src/views/computer-use-authorization`, `src/views/agents-page`, `src/views/export-page` — 259 tests passed
- `packages/eslint-rules` vitest (residual brand-name inventory) — 762 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)