### PR TITLE
fix(pi): normalize native fast requests to priority

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -286,7 +286,7 @@ const USER_OWNED_TERRA_FAST_BDD_ROUTES = [
     type: "codex-oauth-token",
     endpoint: "https://chatgpt.com/backend-api/codex/responses",
     runtimeModel: "gpt-5.6-terra",
-    wireTier: "fast",
+    wireTier: "priority",
   },
   ...STANDARD_TERRA_API_KEY_BDD_ROUTES.map((route) => {
     return {
@@ -5301,7 +5301,7 @@ function expectNativeSubscriptionRequest(
   const { body } = z
     .object({ body: z.record(z.string(), z.unknown()) })
     .parse(request);
-  expect(body.service_tier).toBe(tier);
+  expect(body.service_tier).toBe(tier === undefined ? undefined : "priority");
   expect(body).not.toHaveProperty("previous_response_id");
 }
 
@@ -13760,7 +13760,7 @@ describe("CHAT-02: run-level model overrides", () => {
       accountId: "captured-subscription-account",
       body: {
         model: "gpt-5.6-terra",
-        service_tier: "fast",
+        service_tier: "priority",
         stream: true,
         store: false,
       },
@@ -13855,7 +13855,7 @@ describe("CHAT-02: run-level model overrides", () => {
       expect(
         requests.map(({ body }) => {
           return z
-            .object({ service_tier: z.enum(["fast", "priority"]).optional() })
+            .object({ service_tier: z.literal("priority").optional() })
             .parse(body).service_tier;
         }),
       ).toStrictEqual([undefined, route.wireTier, undefined]);

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -980,7 +980,7 @@ describe("sandbox Pi agent loop", () => {
         expect(continuationBody).toContain("rs_terra_okou_handoff");
         expect(occurrences(continuationBody, prompt)).toBe(1);
         expect(continuationRequest.body).toMatchObject({
-          service_tier: route === "codex-terra" ? "fast" : "priority",
+          service_tier: "priority",
         });
         continuationRequest.respond("Terra Okou handoff complete");
         await host.waitFor((record) => {
@@ -993,7 +993,7 @@ describe("sandbox Pi agent loop", () => {
         });
         const nextRequest = await provider.nextRequest();
         expect(nextRequest.body).toMatchObject({
-          service_tier: route === "codex-terra" ? "fast" : "priority",
+          service_tier: "priority",
         });
         nextRequest.respond("Terra followup complete");
         await host.waitFor((record) => {

--- a/turbo/packages/pi-agent-runtime/src/api.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/api.test.ts
@@ -356,6 +356,7 @@ describe("Pi API facade", () => {
         readonly url: string | undefined;
         readonly body: unknown;
         readonly accountId: string | string[] | undefined;
+        readonly authorization: string | undefined;
       }> = [];
       const server = createServer((request, response) => {
         void (async () => {
@@ -366,6 +367,7 @@ describe("Pi API facade", () => {
           providerRequests.push({
             url: request.url,
             accountId: request.headers["chatgpt-account-id"],
+            authorization: request.headers.authorization,
             body: JSON.parse(
               (request.headers["content-encoding"] === "zstd"
                 ? zstdDecompressSync(Buffer.concat(chunks))
@@ -393,21 +395,23 @@ describe("Pi API facade", () => {
       }
 
       try {
+        let sessionJsonl: string | undefined;
         const runTurn = async (
           serviceTier: "priority" | "fast" | undefined,
           api: "openai-completions" | "openai-codex-responses",
         ) => {
-          return runPiApiFirstTurn({
+          const result = await runPiApiFirstTurn({
             cwd: "/home/user/workspace",
             agentDir: "/home/user/.pi/agent",
             sessionId: SESSION_ID,
+            sessionJsonl,
             prompt: "answer through Terra",
             appendSystemPrompt: null,
             model:
               route === "native"
                 ? await materializePiAgentModelConfig({
                     config: piModelConfigSchema.parse({
-                      schemaVersion: 3,
+                      schemaVersion: serviceTier === undefined ? 2 : 3,
                       dialect: "openai-codex-responses",
                       transport: "sse",
                       provider: "openai-codex",
@@ -448,21 +452,32 @@ describe("Pi API facade", () => {
             resourceSnapshot: { schemaVersion: 1, agentsFiles: [], skills: [] },
             ownership: createPiApiFirstTurnOwnership(),
           });
+          sessionJsonl = result.sessionJsonl;
+          return result;
         };
         const standardResult = await runTurn(undefined, "openai-completions");
         const priorityResult = await runTurn(
           route === "native" ? "fast" : "priority",
           "openai-codex-responses",
         );
+        const standardReturnResult = await runTurn(
+          undefined,
+          "openai-completions",
+        );
 
-        expect(providerRequests).toHaveLength(2);
+        expect(providerRequests).toHaveLength(3);
         if (route === "native") {
           expect(
             providerRequests.map((request) => {
               return request.accountId;
             }),
-          ).toEqual(["exact-account-id", "exact-account-id"]);
+          ).toEqual([
+            "exact-account-id",
+            "exact-account-id",
+            "exact-account-id",
+          ]);
           for (const request of providerRequests) {
+            expect(request.authorization).toBe("Bearer opaque-access-token");
             expect(request.body).toMatchObject({ store: false, stream: true });
             expect(request.body).not.toHaveProperty("previous_response_id");
           }
@@ -480,8 +495,15 @@ describe("Pi API facade", () => {
           body: {
             model: "gpt-5.6-terra",
             reasoning: { effort: "low" },
-            service_tier: route === "native" ? "fast" : "priority",
+            service_tier: "priority",
           },
+        });
+        expect(providerRequests[2]?.body).not.toHaveProperty("service_tier");
+        expect(
+          inspectPiSessionJsonl(standardReturnResult.sessionJsonl),
+        ).toMatchObject({
+          sessionId: SESSION_ID,
+          messageCount: 6,
         });
         expect(standardResult.assistantMessage.content).toStrictEqual([
           { type: "text", text: "Terra API-first answer" },
@@ -491,8 +513,9 @@ describe("Pi API facade", () => {
         ]);
         expect(standardResult.observedServiceTier).toBeUndefined();
         expect(priorityResult.observedServiceTier).toBeUndefined();
-        expect(priorityResult.sessionJsonl).not.toContain("serviceTier");
-        expect(priorityResult.sessionJsonl).not.toContain("service_tier");
+        expect(standardReturnResult.sessionJsonl).not.toMatch(
+          /serviceTier|service_tier|exact-account-id|opaque-access-token|test-key/,
+        );
         expect(
           MemoryPiSession.fromJsonl(
             priorityResult.sessionJsonl,

--- a/turbo/packages/pi-agent-runtime/src/model.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.test.ts
@@ -279,7 +279,7 @@ describe("Pi agent model adapter", () => {
   );
 
   it.each([undefined, "fast"] as const)(
-    "passes an explicit account ID to native Codex Responses over SSE with tier %s",
+    "normalizes native config tier %s with exact credentials and no retry over SSE",
     async (serviceTier) => {
       const provider = await retryableCodexProvider();
       try {
@@ -313,9 +313,15 @@ describe("Pi agent model adapter", () => {
         if (serviceTier === undefined) {
           expect(request?.body).not.toHaveProperty("service_tier");
         } else {
-          expect(request?.body).toMatchObject({ service_tier: "fast" });
+          expect(config.serviceTier).toBe("fast");
+          expect(request?.body).toMatchObject({ service_tier: "priority" });
         }
-        expect(request?.body).toMatchObject({ store: false, stream: true });
+        expect(request?.body).toMatchObject({
+          model: "gpt-5.6-terra",
+          store: false,
+          stream: true,
+        });
+        expect(request?.body).not.toHaveProperty("previous_response_id");
         expect(request?.headers.authorization).toBe("Bearer opaque-not-a-jwt");
         expect(request?.headers["chatgpt-account-id"]).toBe(
           "account-id-from-binding",

--- a/turbo/packages/pi-agent-runtime/src/model.ts
+++ b/turbo/packages/pi-agent-runtime/src/model.ts
@@ -238,7 +238,8 @@ function piAgentCodexStream(
             options.onObservedServiceTier,
           ),
     reasoningEffort: clampedReasoning === "off" ? undefined : clampedReasoning,
-    serviceTier,
+    // Codex keeps fast in config but sends priority on Responses requests.
+    serviceTier: serviceTier === "fast" ? "priority" : undefined,
     accountId,
     maxRetries: 0,
     transport: "sse",

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
@@ -435,7 +435,17 @@ async function startResponsesProvider(
 describe("official Pi AgentSession runtime", () => {
   it.each([
     {
-      name: "subscription",
+      name: "standard subscription",
+      provider: "openai-codex",
+      dialect: "openai-codex-responses",
+      model: "gpt-5.6-terra",
+      basePath: "/backend-api",
+      endpoint: "/backend-api/codex/responses",
+      tier: undefined,
+      secretName: "CHATGPT_ACCESS_TOKEN",
+    },
+    {
+      name: "Fast subscription",
       provider: "openai-codex",
       dialect: "openai-codex-responses",
       model: "gpt-5.6-terra",
@@ -476,7 +486,7 @@ describe("official Pi AgentSession runtime", () => {
       secretName: "VERCEL_AI_GATEWAY_API_KEY",
     },
   ] as const)(
-    "keeps generation-3 $name Fast on every Sandbox turn after pending tools",
+    "preserves $name request policy on every Sandbox turn after pending tools",
     async (route) => {
       const cwd = await mkdtemp(join(tmpdir(), "pi-user-owned-fast-"));
       onTestFinished(async () => {
@@ -508,16 +518,17 @@ describe("official Pi AgentSession runtime", () => {
       const model = await materializePiAgentModelConfig({
         target: "sandbox-firewall",
         config: {
-          schemaVersion: 3,
           transport: "sse",
           baseUrl: provider.baseUrl.replace(/\/v1$/, route.basePath),
           thinkingLevel: "low",
           ...(route.dialect === "openai-codex-responses"
             ? {
+                ...(route.tier === undefined
+                  ? { schemaVersion: 2 as const }
+                  : { schemaVersion: 3 as const, serviceTier: route.tier }),
                 dialect: route.dialect,
                 provider: route.provider,
                 model: route.model,
-                serviceTier: route.tier,
                 credentialBindings: [
                   {
                     kind: "access-token",
@@ -532,13 +543,14 @@ describe("official Pi AgentSession runtime", () => {
                 ],
               }
             : {
+                schemaVersion: 3,
+                serviceTier: route.tier,
                 dialect: route.dialect,
                 provider: route.provider,
                 model: route.model,
                 ...(route.name === "Vercel API key"
                   ? { catalogModel: route.catalogModel }
                   : {}),
-                serviceTier: route.tier,
                 credentialBindings: [
                   {
                     kind: "api-key",
@@ -552,6 +564,7 @@ describe("official Pi AgentSession runtime", () => {
           return `opaque-${binding.secretName}`;
         },
       });
+      expect(model.serviceTier).toBe(route.tier);
       const created = await createPiAgentSessionForRuntime({
         cwd,
         agentDir: join(cwd, ".pi"),
@@ -576,10 +589,14 @@ describe("official Pi AgentSession runtime", () => {
               model: route.model,
               stream: true,
               store: false,
-              service_tier: route.tier,
               reasoning: { effort: "low" },
             },
           });
+          if (route.tier === undefined) {
+            expect(request.body).not.toHaveProperty("service_tier");
+          } else {
+            expect(request.body).toMatchObject({ service_tier: "priority" });
+          }
           expect(request.body).not.toHaveProperty("previous_response_id");
           expect(JSON.stringify(request.body)).toContain("Terra tool result");
         }
@@ -599,7 +616,7 @@ describe("official Pi AgentSession runtime", () => {
           content: [{ type: "text", text: "Sandbox answer" }],
         });
         expect(JSON.stringify(sessionManager.getEntries())).not.toMatch(
-          /serviceTier|service_tier/,
+          /serviceTier|service_tier|opaque-CHATGPT|opaque-OPENAI|opaque-OPENROUTER|opaque-VERCEL/,
         );
       } finally {
         created.session.dispose();

--- a/turbo/patches/@earendil-works__pi-ai@0.84.1.patch
+++ b/turbo/patches/@earendil-works__pi-ai@0.84.1.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/api/openai-codex-responses.d.ts b/dist/api/openai-codex-responses.d.ts
-index 704476da084be53d6aa194a5f774fa3ad47f5e9a..ffd6c5bde0ddd3b480af7bac0b49492abfa4b850 100644
+index 704476da084be53d6aa194a5f774fa3ad47f5e9a..8274468318617744f206f551fe5c0c22e935c7ef 100644
 --- a/dist/api/openai-codex-responses.d.ts
 +++ b/dist/api/openai-codex-responses.d.ts
 @@ -1,6 +1,7 @@
@@ -9,8 +9,7 @@ index 704476da084be53d6aa194a5f774fa3ad47f5e9a..ffd6c5bde0ddd3b480af7bac0b49492a
 +    accountId?: string;
      reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
      reasoningSummary?: "auto" | "concise" | "detailed" | "off" | "on" | null;
--    serviceTier?: ResponseCreateParamsStreaming["service_tier"];
-+    serviceTier?: ResponseCreateParamsStreaming["service_tier"] | "fast";
+     serviceTier?: ResponseCreateParamsStreaming["service_tier"];
 diff --git a/dist/api/openai-codex-responses.js b/dist/api/openai-codex-responses.js
 index 603ab2e3b082669045b7ecb849bd33f45918bce5..7ba136bcec10b3319108a6748fe1b0c5b3bb8a97 100644
 --- a/dist/api/openai-codex-responses.js

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -86,7 +86,7 @@ overrides:
 
 patchedDependencies:
   '@earendil-works/pi-ai@0.84.1':
-    hash: 727723aa6e61d3d9460e1bf669828c77a1ed0b2d49231a284d11cb6e3e931734
+    hash: e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55
     path: patches/@earendil-works__pi-ai@0.84.1.patch
   '@earendil-works/pi-coding-agent@0.84.1':
     hash: 370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289
@@ -1147,7 +1147,7 @@ importers:
     dependencies:
       '@earendil-works/pi-ai':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=727723aa6e61d3d9460e1bf669828c77a1ed0b2d49231a284d11cb6e3e931734)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
         version: 0.84.1(patch_hash=370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
@@ -11211,7 +11211,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
-      '@earendil-works/pi-ai': 0.84.1(patch_hash=727723aa6e61d3d9460e1bf669828c77a1ed0b2d49231a284d11cb6e3e931734)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-telemetry': 0.84.1
       diff: 8.0.4
       ignore: 7.0.5
@@ -11225,7 +11225,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.84.1(patch_hash=727723aa6e61d3d9460e1bf669828c77a1ed0b2d49231a284d11cb6e3e931734)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
+  '@earendil-works/pi-ai@0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -11254,7 +11254,7 @@ snapshots:
   '@earendil-works/pi-coding-agent@0.84.1(patch_hash=370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
-      '@earendil-works/pi-ai': 0.84.1(patch_hash=727723aa6e61d3d9460e1bf669828c77a1ed0b2d49231a284d11cb6e3e931734)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-client': 0.84.2
       '@earendil-works/pi-protocol': 0.84.2
       '@earendil-works/pi-tui': 0.84.2


### PR DESCRIPTION
## Summary

Subscription Terra Fast forwarded the generation-3 config value `fast` directly to native Codex Responses. Normalize it to wire `priority` in the shared API-first/Sandbox stream wrapper, matching [Codex CLI 0.153.4's official request contract](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/protocol/src/config_types.rs#L538-L550). Keep internal `fast`, native SSE, exact credentials, and single-request ownership unchanged.

Remove the upstream request-type widening for `fast` while retaining the explicit account-ID patch. Update HTTP and CLI subprocess coverage for native normalization, tierless standard turns, consecutive Sandbox turns, canonical session continuity, and the three public API-key routes. The lockfile changes only the Pi patch hash.

Refs #31885; parent #31803. Production release and canaries remain controller-owned.

## Validation

- Reproduced the old wire mismatch in three native API-first, Sandbox, and no-retry HTTP tests before applying the fix.
- Runtime: 63 tests across `api.test.ts`, `model.test.ts`, `session-runtime.test.ts`, and `credential.test.ts`.
- CLI Sandbox: 21 tests in `pi-agent-loop.test.ts`.
- TypeScript carriers: 105 tests in `runners.test.ts`; API admission/resolution: 565 tests in `pi-sandbox-config.test.ts`.
- Chat BDD: 48 focused subscription/API-key cases covering exact refresh, handoff, standard/Fast/standard continuity, rejection, cancellation, late results, queue promotion, and zero Built-in billing.
- Rust: 3 existing generated Pi model-config tests, including generation-3 native `fast` preservation and cross-dialect rejection (`cargo test --locked --profile local -p api-contracts --test types generated_pi_model_config`). Shared schemas and generated bindings are unchanged.
- Scoped formatting, lint, runtime/API/CLI type checks, Knip, runtime declarations, frozen-lockfile installation, and `git diff --check` pass.

The local BDD cluster initially used Asia/Shanghai; rerunning the same 48 cases with PostgreSQL on UTC passed without a code change. No full local Vitest suite, dev server, or production operation was used.
