### PR TITLE
fix(ci): default clerk deployment inputs to okou

### DIFF
--- a/.github/scripts/prepare-okou-app-worker-shell.sh
+++ b/.github/scripts/prepare-okou-app-worker-shell.sh
@@ -8,7 +8,7 @@ fi
 
 canonical_dist="$1"
 worker_shell="$2"
-production_primary_app_domain="${CLERK_PRODUCTION_PRIMARY_APP_DOMAIN:-app.vm0.ai}"
+production_primary_app_domain="${CLERK_PRODUCTION_PRIMARY_APP_DOMAIN:-app.okou.ai}"
 
 case "$production_primary_app_domain" in
   app.vm0.ai | app.okou.ai) ;;

--- a/.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh
@@ -9,7 +9,8 @@ python3 - \
   "${repo_root}/.github/workflows/release-please.yml" \
   "${repo_root}/.github/workflows/rollback-production.yml" \
   "${repo_root}/.github/scripts/verify-okou-production-domains.sh" \
-  "${repo_root}/turbo/apps/app-worker/wrangler.jsonc" <<'PY'
+  "${repo_root}/turbo/apps/app-worker/wrangler.jsonc" \
+  "${repo_root}/.github/workflows/turbo.yml" << 'PY'
 from pathlib import Path
 import sys
 
@@ -47,6 +48,7 @@ release, _release_source = load_workflow(sys.argv[1])
 rollback, _rollback_source = load_workflow(sys.argv[2])
 production_verifier_source = Path(sys.argv[3]).read_text()
 worker_config_source = Path(sys.argv[4]).read_text()
+turbo, _turbo_source = load_workflow(sys.argv[5])
 
 release_jobs = release["jobs"]
 rollback_jobs = rollback["jobs"]
@@ -85,12 +87,22 @@ start_step = find_step(worker_release_job, "Start GitHub Deployment")
 finish_step = find_step(worker_release_job, "Finish GitHub Deployment")
 
 primary_app_domain_expression = (
-    "${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.vm0.ai' }}"
+    "${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.okou.ai' }}"
 )
-if prepare_step.get("env", {}).get("CLERK_PRODUCTION_PRIMARY_APP_DOMAIN") != (
-    primary_app_domain_expression
-):
-    raise RuntimeError("Worker shell preparation must inject the Clerk primary domain")
+preview_prepare_step = find_step(
+    turbo["jobs"]["deploy-app"], "Prepare standalone app Worker preview"
+)
+for shell_prepare_step in (prepare_step, preview_prepare_step):
+    if shell_prepare_step.get("env", {}).get("CLERK_PRODUCTION_PRIMARY_APP_DOMAIN") != (
+        primary_app_domain_expression
+    ):
+        raise RuntimeError(
+            f"{shell_prepare_step['name']} must retain the configured Clerk primary "
+            "domain with an app.okou.ai default"
+        )
+    require_fragments(
+        shell_prepare_step, ["bash .github/scripts/prepare-okou-app-worker-shell.sh"]
+    )
 require_fragments(
     prepare_step,
     [

--- a/.github/scripts/tests/prepare-okou-app-worker-shell-test.sh
+++ b/.github/scripts/tests/prepare-okou-app-worker-shell-test.sh
@@ -23,7 +23,8 @@ printf '512\n' > "${canonical_dist}/icons/icon-512.png"
 printf 'maskable\n' > "${canonical_dist}/icons/icon-512-maskable.png"
 printf 'source map\n' > "${canonical_dist}/app.js.map"
 
-bash "$script" "$canonical_dist" "$worker_shell"
+env -u CLERK_PRODUCTION_PRIMARY_APP_DOMAIN \
+  bash "$script" "$canonical_dist" "$worker_shell"
 
 expected_files="$(find "$worker_shell" -type f -printf '%P\n' | sort)"
 test "$expected_files" = "$(printf '%s\n' \
@@ -39,21 +40,52 @@ test "$expected_files" = "$(printf '%s\n' \
   'robots.txt' \
   'sw.js' \
   'sw.txt')"
-grep -Fq 'window.testPrimary="app.vm0.ai"' "${worker_shell}/index.html"
+grep -Fq 'window.testPrimary="app.okou.ai"' "${worker_shell}/index.html"
 grep -Fq 'https://static.okou.io/okou-app/assets/app-123.js' \
   "${worker_shell}/index.html"
 test ! -e "${worker_shell}/app.js.map"
 
-cutover_shell="${tmp_dir}/cutover-shell"
-mkdir "$cutover_shell"
-CLERK_PRODUCTION_PRIMARY_APP_DOMAIN=app.okou.ai \
-  bash "$script" "$canonical_dist" "$cutover_shell"
-grep -Fq 'window.testPrimary="app.okou.ai"' "${cutover_shell}/index.html"
+empty_shell="${tmp_dir}/empty-shell"
+mkdir "$empty_shell"
+CLERK_PRODUCTION_PRIMARY_APP_DOMAIN='' \
+  bash "$script" "$canonical_dist" "$empty_shell"
+grep -Fq 'window.testPrimary="app.okou.ai"' "${empty_shell}/index.html"
+
+for primary_app_domain in app.okou.ai app.vm0.ai; do
+  explicit_shell="${tmp_dir}/${primary_app_domain}-shell"
+  mkdir "$explicit_shell"
+  CLERK_PRODUCTION_PRIMARY_APP_DOMAIN="$primary_app_domain" \
+    bash "$script" "$canonical_dist" "$explicit_shell"
+  grep -Fq "window.testPrimary=\"${primary_app_domain}\"" \
+    "${explicit_shell}/index.html"
+done
+
+for prepared_shell in "$worker_shell" "$empty_shell" \
+  "${tmp_dir}/app.okou.ai-shell" "${tmp_dir}/app.vm0.ai-shell"; do
+  if grep -Fq '__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__' \
+    "${prepared_shell}/index.html"; then
+    echo "expected the primary app domain marker to be replaced: $prepared_shell" >&2
+    exit 1
+  fi
+done
+
+invalid_shell="${tmp_dir}/invalid-shell"
+mkdir "$invalid_shell"
+if CLERK_PRODUCTION_PRIMARY_APP_DOMAIN=app.okou.ia \
+  bash "$script" "$canonical_dist" "$invalid_shell" \
+  > "${tmp_dir}/invalid.log" 2>&1; then
+  echo "expected an invalid primary app domain to be rejected" >&2
+  exit 1
+fi
+grep -Fq 'invalid Clerk production primary app domain: app.okou.ia' \
+  "${tmp_dir}/invalid.log"
+test -z "$(find "$invalid_shell" -mindepth 1 -print -quit)"
 
 nonempty_shell="${tmp_dir}/nonempty-shell"
 mkdir "$nonempty_shell"
 touch "${nonempty_shell}/existing"
-if bash "$script" "$canonical_dist" "$nonempty_shell" >/dev/null 2>&1; then
+if env -u CLERK_PRODUCTION_PRIMARY_APP_DOMAIN \
+  bash "$script" "$canonical_dist" "$nonempty_shell" > /dev/null 2>&1; then
   echo "expected a non-empty Worker shell directory to be rejected" >&2
   exit 1
 fi
@@ -61,7 +93,8 @@ fi
 missing_shell="${tmp_dir}/missing-shell"
 missing_dist="${tmp_dir}/missing-dist"
 mkdir "$missing_shell" "$missing_dist"
-if bash "$script" "$missing_dist" "$missing_shell" >/dev/null 2>&1; then
+if env -u CLERK_PRODUCTION_PRIMARY_APP_DOMAIN \
+  bash "$script" "$missing_dist" "$missing_shell" > /dev/null 2>&1; then
   echo "expected a canonical artifact with missing shell files to be rejected" >&2
   exit 1
 fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1563,7 +1563,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATIC_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATIC_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
-          CLERK_PRODUCTION_PRIMARY_APP_DOMAIN: ${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.vm0.ai' }}
+          CLERK_PRODUCTION_PRIMARY_APP_DOMAIN: ${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.okou.ai' }}
           R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
           R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
         run: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1493,7 +1493,7 @@ jobs:
       - name: Prepare standalone app Worker preview
         id: worker-preview
         env:
-          CLERK_PRODUCTION_PRIMARY_APP_DOMAIN: ${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.vm0.ai' }}
+          CLERK_PRODUCTION_PRIMARY_APP_DOMAIN: ${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.okou.ai' }}
           ARTIFACT_EXISTS: ${{ steps.existing.outputs.exists }}
           ARTIFACT_PREFIX: ${{ steps.artifact.outputs.prefix }}
           WORKER_PREVIEW_ALIAS: ${{ steps.worker-alias.outputs.alias }}


### PR DESCRIPTION
Closes #31900.

When the Clerk primary-domain configuration is absent or empty, both deployment workflows and standalone Worker shell preparation now select `app.okou.ai`. Previously, these inputs injected an explicit `app.vm0.ai`, unintentionally selecting the rollback topology even after the client default changed in #31894.

The configured override retains precedence: explicit `app.vm0.ai` still produces a VM0-primary shell, explicit `app.okou.ai` is unchanged, and unsupported nonempty values fail before writing shell files. Regression tests run the real shell with isolated unset, empty, explicit Okou, explicit VM0, and invalid inputs; inspect the substituted HTML; verify marker removal; and retain the asset-copy and artifact-validation checks. Both workflow expressions are covered.

The existing dual topology, VM0 rollback origin, #27750 removal conditions, AgentPhone compatibility window, marker names, release controls, deployment ordering, and immutable artifact behavior are preserved. No live configuration changes or production release operations are included. Merging this PR does not establish deployment.

## Validation

Passed locally:

- `bash .github/scripts/tests/prepare-okou-app-worker-shell-test.sh`, also with inherited `CLERK_PRODUCTION_PRIMARY_APP_DOMAIN=inherited.invalid`.
- `bash .github/scripts/tests/deploy-okou-app-worker-workflow-test.sh`.
- `bash .github/scripts/tests/okou-app-worker-test.sh` (retains the intentional explicit VM0 fixture).
- `bash .github/scripts/tests/app-preview-ingress-workflow-test.sh`.
- `bash .github/scripts/tests/clerk-test-resource-workflow-test.sh`.
- `bash -n` and ShellCheck 0.9.0 on the three changed shell files.
- `shfmt -d -i 2 -ci -sr` on the two changed test scripts; Prettier 3.6.2 on both changed workflows; `git diff --check`.
- `.github/scripts/check-workflow-shell-compatibility.sh` and actionlint 1.7.12 on both changed workflows.
- Temporary-copy mutation checks: tests fail if any of the three defaults reverts to VM0, empty-input fallback is lost, or explicit VM0 rollback is ignored.

Full caller/assertion search included hidden `.github` paths. No local Vitest suite or development server was run. Required PR and merge-group checks will be verified in CI before protected merge-queue completion.
