### PR TITLE
refactor: rename module-scoped brand identifiers left in the r5 baseline

### DIFF
--- a/.github/scripts/runner-behavior-host-cpu-fairness.sh
+++ b/.github/scripts/runner-behavior-host-cpu-fairness.sh
@@ -32,7 +32,7 @@ fi
 
 REMOTE="${METAL_USER}@${HOST}"
 EXECUTION_KEY="${JOB_REF}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-REMOTE_BIN="/tmp/vm0-host-cpu-fairness-${EXECUTION_KEY}"
+REMOTE_BIN="/tmp/runner-host-cpu-fairness-${EXECUTION_KEY}"
 
 cleanup_remote_binary() {
   ssh "$REMOTE" bash -s -- "$REMOTE_BIN" 2>/dev/null <<'REMOTE_CLEANUP' || true
@@ -52,8 +52,8 @@ TEST_BIN=$1
 ROOTFS_HASH=$2
 EXECUTION_KEY=$3
 BASE_DIR="/var/lib/vm0-runner/host-cpu-fairness/${EXECUTION_KEY}"
-UNIT="vm0-host-cpu-managed-${EXECUTION_KEY}"
-LOCK_DIR="/run/lock/vm0-host-cpu-fairness"
+UNIT="runner-host-cpu-managed-${EXECUTION_KEY}"
+LOCK_DIR="/run/lock/runner-host-cpu-fairness"
 LOCK_FD=""
 
 case "$EXECUTION_KEY" in

--- a/turbo/apps/api/src/lib/oauth-origin.ts
+++ b/turbo/apps/api/src/lib/oauth-origin.ts
@@ -5,7 +5,7 @@ const WEB_ORIGIN_HEADER = "x-vm0-web-origin";
 
 type HostRole = "api" | "www";
 
-function isVm0Host(hostname: string, role: HostRole): boolean {
+function isTrustedFirstPartyHost(hostname: string, role: HostRole): boolean {
   return (
     (role === "www" &&
       (hostname === "okou.ai" || hostname.endsWith(".okou.ai"))) ||
@@ -31,7 +31,9 @@ function isTrustedOrigin(origin: string, role: HostRole): boolean {
     return url.protocol === "http:" || url.protocol === "https:";
   }
 
-  return url.protocol === "https:" && isVm0Host(url.hostname, role);
+  return (
+    url.protocol === "https:" && isTrustedFirstPartyHost(url.hostname, role)
+  );
 }
 
 function isTrustedHostedOrigin(origin: string, role: HostRole): boolean {
@@ -45,7 +47,7 @@ function isTrustedHostedOrigin(origin: string, role: HostRole): boolean {
     url.pathname === "/" &&
     url.search === "" &&
     url.hash === "" &&
-    isVm0Host(url.hostname, role)
+    isTrustedFirstPartyHost(url.hostname, role)
   );
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -15515,20 +15515,20 @@ describe("CHAT-02: run-level model overrides", () => {
     });
 
     // Chat send only accepts supported run models.
-    const vm0ThreadId = randomUUID();
+    const invalidModelThreadId = randomUUID();
     const invalidModel = await chat.requestSendEvent(
       actor,
       {
         agentId: agent.agentId,
         prompt: "use an unsupported vm0 model",
-        clientThreadId: vm0ThreadId,
+        clientThreadId: invalidModelThreadId,
         model: "codex" as never,
       },
       [400],
     );
     expectApiError(invalidModel.body);
     expect(invalidModel.body.error.message).toBe("Invalid input");
-    await chat.requestReadThread(actor, vm0ThreadId, [404]);
+    await chat.requestReadThread(actor, invalidModelThreadId, [404]);
 
     const unavailableThreadId = randomUUID();
     const unavailable = await chat.requestSendEvent(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1826,13 +1826,13 @@ function timeCursorRows(
   }
 
   return rows.map((row, index) => {
-    if (!isAxiomRow(row) || typeof row._vm0Cursor === "string") {
+    if (!isAxiomRow(row) || typeof row._timeCursor === "string") {
       return row;
     }
 
     return {
       ...row,
-      _vm0Cursor: `cursor-${index.toString().padStart(4, "0")}`,
+      _timeCursor: `cursor-${index.toString().padStart(4, "0")}`,
     };
   });
 }
@@ -1864,8 +1864,8 @@ function expectTimeCursorAxiomResume(
   expect(apl).toContain(`| order by _time ${expected.order}`);
   expect(apl).not.toContain("| where _time > datetime(");
   expect(apl).not.toContain("| where _time < datetime(");
-  expect(apl).not.toContain("_vm0Cursor >");
-  expect(apl).not.toContain("_vm0Cursor <");
+  expect(apl).not.toContain("_timeCursor >");
+  expect(apl).not.toContain("_timeCursor <");
 }
 
 function networkHardeningRows(
@@ -2184,7 +2184,7 @@ describe("RUN-04: agent run telemetry families", () => {
     const networkRows = [
       {
         _time: timestamp,
-        _vm0Cursor: "network-a",
+        _timeCursor: "network-a",
         runId,
         userId: actor.userId,
         type: "http",
@@ -2193,7 +2193,7 @@ describe("RUN-04: agent run telemetry families", () => {
       },
       {
         _time: timestamp,
-        _vm0Cursor: "network-b",
+        _timeCursor: "network-b",
         runId,
         userId: actor.userId,
         type: "http",
@@ -2202,7 +2202,7 @@ describe("RUN-04: agent run telemetry families", () => {
       },
       {
         _time: laterTimestamp,
-        _vm0Cursor: "network-c",
+        _timeCursor: "network-c",
         runId,
         userId: actor.userId,
         type: "http",
@@ -2229,7 +2229,7 @@ describe("RUN-04: agent run telemetry families", () => {
           cursor === undefined
             ? -1
             : networkRows.findIndex((row) => {
-                return row._vm0Cursor === cursor;
+                return row._timeCursor === cursor;
               });
         const startIndex =
           cursor === undefined
@@ -2297,7 +2297,7 @@ describe("RUN-04: agent run telemetry families", () => {
     const descRows = [
       {
         _time: timestamp,
-        _vm0Cursor: "desc-a",
+        _timeCursor: "desc-a",
         runId,
         userId: actor.userId,
         type: "http",
@@ -2306,7 +2306,7 @@ describe("RUN-04: agent run telemetry families", () => {
       },
       {
         _time: timestamp,
-        _vm0Cursor: "desc-b",
+        _timeCursor: "desc-b",
         runId,
         userId: actor.userId,
         type: "http",
@@ -2315,7 +2315,7 @@ describe("RUN-04: agent run telemetry families", () => {
       },
       {
         _time: olderTimestamp,
-        _vm0Cursor: "desc-c",
+        _timeCursor: "desc-c",
         runId,
         userId: actor.userId,
         type: "http",
@@ -2339,7 +2339,7 @@ describe("RUN-04: agent run telemetry families", () => {
           cursor === undefined
             ? -1
             : descRows.findIndex((row) => {
-                return row._vm0Cursor === cursor;
+                return row._timeCursor === cursor;
               });
         const startIndex =
           cursor === undefined

--- a/turbo/apps/api/src/signals/routes/integrations-telegram-link.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-telegram-link.ts
@@ -123,7 +123,7 @@ function linkConflictResponse(
   const message =
     reason === "telegram-user-linked"
       ? `This Telegram account is already connected to another ${brandName} account for this bot. Disconnect it before connecting a different account.`
-      : reason === "vm0-user-linked"
+      : reason === "user-linked"
         ? `Your ${brandName} account is already connected to another Telegram account for this bot. Disconnect it before connecting a different Telegram account.`
         : "This Telegram account link already exists. Disconnect it first and try again.";
 

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -85,7 +85,7 @@ import {
 // Test-only support actions for generic infrastructure fixtures.
 
 const actionBody$ = bodyResultOf(testRuntimeStateContract.action);
-const BUILT_IN_MODEL_KEY_FIXTURE_PREFIX = "vm0-key-runtime-fixture-";
+const BUILT_IN_MODEL_KEY_FIXTURE_PREFIX = "built-in-key-runtime-fixture-";
 
 interface OrgAdmissionLockGate {
   holderPid: number | null;

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -224,17 +224,17 @@ function vm0BuiltInModelKeyRows(agentId: string) {
   return [
     {
       vendor: getBuiltInVendor(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL),
-      apiKey: `vm0-key-default-${agentId}`,
+      apiKey: `built-in-key-default-${agentId}`,
       label: agentId,
     },
     {
       vendor: "anthropic",
-      apiKey: `vm0-key-anthropic-${agentId}`,
+      apiKey: `built-in-key-anthropic-${agentId}`,
       label: agentId,
     },
     {
       vendor: "moonshot",
-      apiKey: `vm0-key-moonshot-${agentId}`,
+      apiKey: `built-in-key-moonshot-${agentId}`,
       label: agentId,
     },
   ];

--- a/turbo/apps/api/src/signals/routes/test-teams-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-state.ts
@@ -40,7 +40,7 @@ const DEFAULT_TEST_EMAIL = "dev+clerk_test+serial@vm0-e2e.ai";
 const DEFAULT_TENANT_NAME = "E2E Test Tenant";
 const DEFAULT_TEAM_NAME = "E2E Test Team";
 const DEFAULT_SERVICE_URL = "https://smba.trafficmanager.net/amer/";
-const DEFAULT_BOT_ID = "28:e2e-zero-bot";
+const DEFAULT_BOT_ID = "28:e2e-test-bot";
 const DEFAULT_BOT_NAME = "Zero";
 const DEFAULT_AGENT_NAME = "e2e-teams-agent";
 const STARTER_GRANT_AMOUNT = 10_000;
@@ -265,17 +265,17 @@ function vm0BuiltInModelKeyRows(agentId: string) {
   return [
     {
       vendor: getBuiltInVendor(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL),
-      apiKey: `vm0-key-default-${agentId}`,
+      apiKey: `built-in-key-default-${agentId}`,
       label: agentId,
     },
     {
       vendor: "anthropic",
-      apiKey: `vm0-key-anthropic-${agentId}`,
+      apiKey: `built-in-key-anthropic-${agentId}`,
       label: agentId,
     },
     {
       vendor: "moonshot",
-      apiKey: `vm0-key-moonshot-${agentId}`,
+      apiKey: `built-in-key-moonshot-${agentId}`,
       label: agentId,
     },
   ];

--- a/turbo/apps/api/src/signals/routes/test-telegram-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-state.ts
@@ -56,7 +56,7 @@ const DEFAULT_TEST_AGENT_NAME = "e2e-slack-agent";
 const STARTER_GRANT_AMOUNT = 10_000;
 const STARTER_GRANT_SOURCE = "starter_grant";
 const TELEGRAM_E2E_FIXTURES = {
-  botUsername: "vm0_e2e_bot",
+  botUsername: "e2e_test_bot",
   botToken: "123456:e2e-test-bot-token",
   webhookSecret: "e2e-telegram-webhook-secret",
 } as const;
@@ -784,17 +784,17 @@ async function seedTelegramPostModelKeys(
     .values([
       {
         vendor: getBuiltInVendor(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL),
-        apiKey: `vm0-key-default-${seed.composeId}`,
+        apiKey: `built-in-key-default-${seed.composeId}`,
         label: seed.composeId,
       },
       {
         vendor: "anthropic",
-        apiKey: `vm0-key-anthropic-${seed.composeId}`,
+        apiKey: `built-in-key-anthropic-${seed.composeId}`,
         label: seed.composeId,
       },
       {
         vendor: "moonshot",
-        apiKey: `vm0-key-moonshot-${seed.composeId}`,
+        apiKey: `built-in-key-moonshot-${seed.composeId}`,
         label: seed.composeId,
       },
     ])
@@ -1302,7 +1302,7 @@ async function seedModelPoliciesForAction(
     .insert(builtInModelKeys)
     .values({
       vendor: "anthropic",
-      apiKey: "vm0-key-anthropic",
+      apiKey: "built-in-key-anthropic",
       label: required.compose_id!,
     })
     .onConflictDoNothing({ target: builtInModelKeys.vendor });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -453,7 +453,7 @@ function withOkouTokenSecret(
   return {
     ...body,
     secrets: {
-      ...withoutLegacyZeroEntries(body.secrets),
+      ...withoutLegacyAgentRunEnvironmentEntries(body.secrets),
       OKOU_TOKEN: okouToken,
     },
   };
@@ -3101,7 +3101,7 @@ function mergeRecords<T>(
   return compactRecord(merged);
 }
 
-function withoutLegacyZeroEntries<T>(
+function withoutLegacyAgentRunEnvironmentEntries<T>(
   values: Readonly<Record<string, T>> | undefined,
 ): Record<string, T> | undefined {
   if (!values) {
@@ -6494,7 +6494,7 @@ function buildStoredPlatformEnvironment(args: {
     CLI_PKG_URL: cliPackageUrlForPublicBrand(args.okouTokenPublicBrand),
   };
   return args.canonicalOkouRuntime
-    ? (withoutLegacyZeroEntries(platformEnvironment) ?? {})
+    ? (withoutLegacyAgentRunEnvironmentEntries(platformEnvironment) ?? {})
     : platformEnvironment;
 }
 
@@ -6506,7 +6506,9 @@ function buildStoredUntrustedEnvironment(args: {
     return args.expandedEnvironment;
   }
   return (
-    withoutLegacyZeroEntries(args.expandedEnvironment ?? undefined) ?? null
+    withoutLegacyAgentRunEnvironmentEntries(
+      args.expandedEnvironment ?? undefined,
+    ) ?? null
   );
 }
 
@@ -8817,7 +8819,7 @@ async function buildResolvedRunBody(
     runVars,
   });
   const vars = args.canonicalOkouRuntime
-    ? withoutLegacyZeroEntries(mergedVars)
+    ? withoutLegacyAgentRunEnvironmentEntries(mergedVars)
     : mergedVars;
   signal.throwIfAborted();
 
@@ -8840,7 +8842,7 @@ async function buildResolvedRunBody(
   return {
     ...body,
     secrets: args.canonicalOkouRuntime
-      ? withoutLegacyZeroEntries(mergedSecrets)
+      ? withoutLegacyAgentRunEnvironmentEntries(mergedSecrets)
       : mergedSecrets,
   };
 }

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -633,7 +633,7 @@ async function inferAgentIdFromSession(
   return session?.agentId ?? null;
 }
 
-async function loadZeroAgent(
+async function loadAgent(
   db: Db,
   agentId: string,
 ): Promise<AgentRunRecord | null> {
@@ -821,7 +821,7 @@ function createRunBody(args: {
   };
 }
 
-function measureZeroPreCreate<T>(
+function measureAgentRunPreCreate<T>(
   timing: ApiDispatchTimingCollector | undefined,
   actionType: ApiDispatchTimingActionType,
   operation: () => T | Promise<T>,
@@ -879,7 +879,7 @@ async function loadAgentRunPostAuthorizationContext(
   signal: AbortSignal,
 ) {
   let measuredSnapshotRows: RunBootstrapSnapshotRows | undefined;
-  const snapshotRows = await measureZeroPreCreate(
+  const snapshotRows = await measureAgentRunPreCreate(
     args.timing,
     "api_dispatch_pre_create_agent_load_bootstrap_snapshot_rows",
     async () => {
@@ -899,7 +899,7 @@ async function loadAgentRunPostAuthorizationContext(
   signal.throwIfAborted();
 
   let measuredBootstrapContext: RunBootstrapContext | undefined;
-  const bootstrapContext = await measureZeroPreCreate(
+  const bootstrapContext = await measureAgentRunPreCreate(
     args.timing,
     "api_dispatch_pre_create_agent_materialize_bootstrap_context",
     () => {
@@ -932,7 +932,7 @@ async function loadAgentRunPostAuthorizationContext(
           }),
         };
   signal.throwIfAborted();
-  const runPermissionPolicies = await measureZeroPreCreate(
+  const runPermissionPolicies = await measureAgentRunPreCreate(
     args.timing,
     "api_dispatch_pre_create_agent_resolve_firewall_metadata",
     async () => {
@@ -958,7 +958,7 @@ async function loadAgentRunPostAuthorizationContext(
   };
 }
 
-function buildZeroCreateAgentRunArgs(args: {
+function buildCreateAgentRunArgs(args: {
   readonly command: AnyCreateAgentRunCommandArgs;
   readonly agent: AgentRunRecord;
   readonly userInfo: UserInfo;
@@ -1176,7 +1176,7 @@ async function resolveThreadSessionForAgentRun(
   if (!threadSessionRoute) {
     throw new Error("Thread-bound agent run is missing its model route");
   }
-  const resolution = await measureZeroPreCreate(
+  const resolution = await measureAgentRunPreCreate(
     input.timing,
     "api_dispatch_pre_create_agent_resolve_thread_session",
     () => {
@@ -1196,7 +1196,7 @@ async function resolveThreadSessionForAgentRun(
   });
   const webChatSessionPromptContext = input.command.webChatSessionPromptContext;
   const sessionPrompt = webChatSessionPromptContext
-    ? await measureZeroPreCreate(
+    ? await measureAgentRunPreCreate(
         input.timing,
         "api_dispatch_pre_create_agent_web_chat_resolve_session_prompt_context",
         () => {
@@ -1235,7 +1235,7 @@ async function resolveThreadSessionForAgentRun(
 
 const THREAD_SESSION_PREPARATION_ATTEMPTS = 3;
 
-const createAgentRunAfterZeroPreCreate$ = command(
+const createAgentRunAfterPreCreate$ = command(
   async ({ set }, input: AgentRunAfterPreCreate, signal: AbortSignal) => {
     const db = set(writeDb$);
     const capturedInput = await captureCodexSubscriptionAccount(db, input);
@@ -1250,11 +1250,11 @@ const createAgentRunAfterZeroPreCreate$ = command(
         capturedInput,
       );
       signal.throwIfAborted();
-      const baseCreateAgentRunArgs = await measureZeroPreCreate(
+      const baseCreateAgentRunArgs = await measureAgentRunPreCreate(
         capturedInput.timing,
         "api_dispatch_pre_create_agent_build_create_run_args",
         () => {
-          return buildZeroCreateAgentRunArgs(attemptInput);
+          return buildCreateAgentRunArgs(attemptInput);
         },
       );
       signal.throwIfAborted();
@@ -1324,7 +1324,7 @@ const createAgentRunInternal$ = command(
     });
     const db = set(writeDb$);
 
-    const agentId = await measureZeroPreCreate(
+    const agentId = await measureAgentRunPreCreate(
       timing,
       "api_dispatch_pre_create_agent_resolve_agent_id",
       async () => {
@@ -1339,11 +1339,11 @@ const createAgentRunInternal$ = command(
         : badRequestMessage("Missing agentId or sessionId");
     }
 
-    const agent = await measureZeroPreCreate(
+    const agent = await measureAgentRunPreCreate(
       timing,
       "api_dispatch_pre_create_agent_load_agent",
       async () => {
-        return await loadZeroAgent(db, agentId);
+        return await loadAgent(db, agentId);
       },
     );
     signal.throwIfAborted();
@@ -1399,7 +1399,7 @@ const createAgentRunInternal$ = command(
     );
 
     return await set(
-      createAgentRunAfterZeroPreCreate$,
+      createAgentRunAfterPreCreate$,
       {
         command: args,
         agent,

--- a/turbo/apps/api/src/signals/services/browser.service.ts
+++ b/turbo/apps/api/src/signals/services/browser.service.ts
@@ -3560,7 +3560,7 @@ const reconcileBrowserInstance$ = command(
   },
 );
 
-const reconcileZeroBrowsersWithScope$ = command(
+const reconcileBrowsersWithScope$ = command(
   async (
     { get, set },
     chatThreadIds: readonly string[] | null,
@@ -3685,7 +3685,7 @@ const reconcileZeroBrowsersWithScope$ = command(
 
 export const reconcileBrowsers$ = command(
   async ({ set }, signal: AbortSignal): Promise<BrowserReconcileResult> => {
-    return await set(reconcileZeroBrowsersWithScope$, null, signal);
+    return await set(reconcileBrowsersWithScope$, null, signal);
   },
 );
 
@@ -3696,6 +3696,6 @@ export const reconcileBrowserFixtures$ = command(
     chatThreadIds: readonly string[],
     signal: AbortSignal,
   ): Promise<BrowserReconcileResult> => {
-    return await set(reconcileZeroBrowsersWithScope$, chatThreadIds, signal);
+    return await set(reconcileBrowsersWithScope$, chatThreadIds, signal);
   },
 );

--- a/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
@@ -273,7 +273,7 @@ function buildSkillSyncContext(extracted: ExtractedSkill): SkillSyncContext {
 async function createSkillArchive(
   files: readonly ExtractedFile[],
 ): Promise<{ archiveBuffer: Buffer; manifestBuffer: Buffer }> {
-  const tmpDir = await mkdtemp(join(tmpdir(), "vm0-api-skill-"));
+  const tmpDir = await mkdtemp(join(tmpdir(), "api-skill-"));
   await Promise.all(
     files.map((file) => {
       const filePath = join(tmpDir, file.path);

--- a/turbo/apps/api/src/signals/services/log-pagination.ts
+++ b/turbo/apps/api/src/signals/services/log-pagination.ts
@@ -17,7 +17,7 @@ interface DecodedTimeCursor {
 
 interface TimedAxiomRecord {
   readonly _time: string;
-  readonly _vm0Cursor?: unknown;
+  readonly _timeCursor?: unknown;
 }
 
 interface TimePaginationParams {
@@ -30,7 +30,7 @@ interface TimePaginationParams {
 const ISO_UTC_TIMESTAMP_PATTERN =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?Z$/;
 const MAX_TIME_CURSOR_TIE_BREAKER_LENGTH = 2048;
-const TIME_CURSOR_APL_FIELD = "_vm0Cursor";
+const TIME_CURSOR_APL_FIELD = "_timeCursor";
 
 function safeInteger(value: number | undefined): number | undefined {
   return value !== undefined && Number.isSafeInteger(value) ? value : undefined;
@@ -337,7 +337,7 @@ export function nextTimeCursor<T extends TimedAxiomRecord>(
 
   const timestamp = exactUtcTimestamp(lastRecord._time);
   const tieBreaker =
-    typeof lastRecord._vm0Cursor === "string" ? lastRecord._vm0Cursor : null;
+    typeof lastRecord._timeCursor === "string" ? lastRecord._timeCursor : null;
   if (timestamp === null) {
     timeCursorInvariantFailure("boundary record has invalid _time");
   }

--- a/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-volume-publication.service.ts
@@ -105,7 +105,7 @@ function compareArchiveFiles(
 function materializeFiles(
   files: readonly VolumeFileInput[],
 ): readonly MaterializedVolumeFile[] {
-  const validationRoot = resolve(tmpdir(), "vm0-api-volume-validation");
+  const validationRoot = resolve(tmpdir(), "api-volume-validation");
   return files.map((file) => {
     resolveVolumeFilePath(validationRoot, file.path);
     const content = Buffer.isBuffer(file.content)
@@ -183,7 +183,7 @@ async function createVolumeArchive(
   signal: AbortSignal,
 ): Promise<Buffer> {
   const archiveFiles = [...files].sort(compareArchiveFiles);
-  const tmpDir = await mkdtemp(join(tmpdir(), "vm0-api-volume-"));
+  const tmpDir = await mkdtemp(join(tmpdir(), "api-volume-"));
   const archiveBuffer = await onRejection(
     buildVolumeArchive(tmpDir, archiveFiles, signal),
     () => {

--- a/turbo/apps/api/src/signals/services/telegram-link.service.ts
+++ b/turbo/apps/api/src/signals/services/telegram-link.service.ts
@@ -33,7 +33,7 @@ export type LinkTelegramUserResult =
   | { readonly ok: true; readonly userLink: TelegramUserLink }
   | {
       readonly ok: false;
-      readonly reason: "telegram-user-linked" | "vm0-user-linked" | "conflict";
+      readonly reason: "telegram-user-linked" | "user-linked" | "conflict";
       readonly userLink?: TelegramUserLink;
     };
 
@@ -325,7 +325,7 @@ export const linkTelegramUser$ = command(
 
       return {
         ok: false,
-        reason: "vm0-user-linked",
+        reason: "user-linked",
         userLink: existingUserLink,
       };
     }

--- a/turbo/apps/cli/src/lib/api/domains/chat.ts
+++ b/turbo/apps/cli/src/lib/api/domains/chat.ts
@@ -36,7 +36,7 @@ interface ChatThreadUnread {
 
 export type ChatThreadEvent = ApiChatThreadEvent;
 
-type ZeroChatEventSnapshotResult =
+type ChatEventSnapshotResult =
   | {
       readonly kind: "snapshot";
       readonly url: string;
@@ -45,7 +45,7 @@ type ZeroChatEventSnapshotResult =
     }
   | { readonly kind: "missing" };
 
-type ZeroChatEventRowsPage =
+type ChatEventRowsPage =
   | {
       readonly kind: "rows";
       readonly rows: readonly ChatEventRow[];
@@ -78,21 +78,21 @@ function requireSupportedModel(model: string) {
   return model;
 }
 
-interface ZeroChatThreadCreateResult {
+interface ChatThreadCreateResult {
   readonly threadId: string;
   readonly title: string | null;
   readonly selectedModel: string | null;
   readonly serviceTier: ChatThreadServiceTier | null;
 }
 
-interface ZeroChatEventSendResult {
+interface ChatEventSendResult {
   readonly runId: string | null;
   readonly threadId: string;
   readonly status?: string;
   readonly createdAt?: string;
 }
 
-type ZeroChatThreadEventsResult =
+type ChatThreadEventsResult =
   | {
       readonly kind: "page";
       readonly events: readonly ChatThreadEvent[];
@@ -136,7 +136,7 @@ export async function getChatThreadSnapshot(): Promise<ChatThreadSnapshot> {
 
 export async function listChatThreadEvents(options: {
   sinceSeqId?: number;
-}): Promise<ZeroChatThreadEventsResult> {
+}): Promise<ChatThreadEventsResult> {
   const config = await getClientConfig();
   const client = initClient(chatThreadsContract, config);
   const result = await client.events({
@@ -177,7 +177,7 @@ export async function createChatThread(options: {
   title: string;
   model?: string;
   serviceTier?: ChatThreadServiceTier | null;
-}): Promise<ZeroChatThreadCreateResult> {
+}): Promise<ChatThreadCreateResult> {
   const config = await getClientConfig();
   const client = initClient(chatThreadsContract, config);
   const result = await client.create({
@@ -242,7 +242,7 @@ export async function getChatThreadAgentId(options: {
 
 export async function sendChatEvent(
   body: ChatEventSendBody,
-): Promise<ZeroChatEventSendResult> {
+): Promise<ChatEventSendResult> {
   const config = await getClientConfig();
   const client = initClient(chatEventsContract, config);
   const result = await client.send({ body });
@@ -254,7 +254,7 @@ export async function sendChatEvent(
 
 export async function getChatEventSnapshot(options: {
   readonly threadId: string;
-}): Promise<ZeroChatEventSnapshotResult> {
+}): Promise<ChatEventSnapshotResult> {
   const config = await getClientConfig();
   const client = initClient(chatThreadEventsContract, config);
   const result = await client.snapshot({
@@ -287,7 +287,7 @@ export async function listChatEventRows(
         readonly sinceSeqId: number;
       }
   ),
-): Promise<ZeroChatEventRowsPage> {
+): Promise<ChatEventRowsPage> {
   const config = await getClientConfig();
   const client = initClient(chatThreadEventsContract, config);
   const result = await client.rows({

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -46,18 +46,18 @@ import {
   type McpConnector,
 } from "@okouai/api-contracts/contracts/mcp-connectors";
 import type {
-  ConnectorListResponse,
+  ConnectorListResponse as ApiConnectorListResponse,
   ConnectorResponse,
 } from "@okouai/api-contracts/contracts/connector-schemas";
 import { getClientConfig, handleError } from "../core/client-factory";
 
 export type Connector = ConnectorResponse;
-type ZeroConnectorListResponse = ConnectorListResponse;
+type ConnectorListResponse = ApiConnectorListResponse;
 export type ConnectorCatalogItem =
   PublicConnectorCatalogListResponse["connectors"][number];
 export type ConnectorCatalogStatus = PublicConnectorCatalogStatusItem;
-type ZeroConnectorCatalogListResponse = PublicConnectorCatalogListResponse;
-type ZeroConnectorCatalogStatusResponse = PublicConnectorCatalogStatusResponse;
+type ConnectorCatalogListResponse = PublicConnectorCatalogListResponse;
+type ConnectorCatalogStatusResponse = PublicConnectorCatalogStatusResponse;
 export type ConnectorCatalogPermissionDetail =
   PublicConnectorCatalogPermissionDetail;
 
@@ -141,7 +141,7 @@ export async function inspectConnectorAccounts(
 /**
  * List all connectors for the authenticated user (zero proxy)
  */
-export async function listConnectors(): Promise<ZeroConnectorListResponse> {
+export async function listConnectors(): Promise<ConnectorListResponse> {
   const config = await getClientConfig();
   const client = initClient(connectorsMainContract, config);
 
@@ -154,7 +154,7 @@ export async function listConnectors(): Promise<ZeroConnectorListResponse> {
   handleError(result, "Failed to list connectors");
 }
 
-export async function listConnectorCatalog(): Promise<ZeroConnectorCatalogListResponse> {
+export async function listConnectorCatalog(): Promise<ConnectorCatalogListResponse> {
   const config = await getClientConfig();
   const client = initClient(connectorCatalogContract, config);
 
@@ -167,7 +167,7 @@ export async function listConnectorCatalog(): Promise<ZeroConnectorCatalogListRe
   handleError(result, "Failed to list connector catalog");
 }
 
-export async function listConnectorCatalogStatus(): Promise<ZeroConnectorCatalogStatusResponse> {
+export async function listConnectorCatalogStatus(): Promise<ConnectorCatalogStatusResponse> {
   const config = await getClientConfig();
   const client = initClient(connectorCatalogContract, config);
 

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -34,7 +34,7 @@ const clerkVersion$ = state(0);
 
 const ATTRIBUTION_SOURCE_PARAM = "vm0_source";
 const HOMEPAGE_ATTRIBUTION_VALUE = "homepage";
-const VM0_ONBOARDING_PATH = "/onboarding";
+const ONBOARDING_PATH = "/onboarding";
 const CLERK_SATELLITE_REDIRECT_ORIGIN_PATTERN =
   /^https:\/\/(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*okou\.ai(?::\d+)?$/i;
 const PRODUCTION_VM0_AUTH_REDIRECT_ORIGINS = [
@@ -294,10 +294,10 @@ function setCurrentLandingContext(params: URLSearchParams): void {
   }
 }
 
-function buildVm0OnboardingEntryUrl(paramsInit?: URLSearchParams): string {
+function buildOnboardingEntryUrl(paramsInit?: URLSearchParams): string {
   const params = new URLSearchParams(paramsInit);
   setCurrentLandingContext(params);
-  const url = new URL(VM0_ONBOARDING_PATH, resolveAppOrigin());
+  const url = new URL(ONBOARDING_PATH, resolveAppOrigin());
   url.search = params.toString();
   appendCapturedPreviewBypassToUrl(url);
   return url.toString();
@@ -396,12 +396,12 @@ export function buildSignupRedirectUrl(
   }
 
   if (!hasAdTraffic(params)) {
-    return new URL(VM0_ONBOARDING_PATH, appUrl).toString();
+    return new URL(ONBOARDING_PATH, appUrl).toString();
   }
 
   const redirectParams = new URLSearchParams();
   appendHomepageAttributionParams(redirectParams, params.toString());
-  return buildVm0OnboardingEntryUrl(redirectParams);
+  return buildOnboardingEntryUrl(redirectParams);
 }
 
 export function buildSignInRedirectUrl(

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -64,7 +64,7 @@ type HappyDomLifecycleCallback = (this: HTMLIFrameElement) => void;
 
 type PatchedHTMLIFrameElementPrototype = HTMLIFrameElement &
   Record<symbol, unknown> & {
-    vm0HappyDomIframeLoadPatched?: true;
+    happyDomIframeLoadPatched?: true;
   };
 
 type StderrWriteArgs = [
@@ -77,8 +77,8 @@ type StderrWrite = (...args: StderrWriteArgs) => boolean;
 
 type PatchedStderr = {
   write: StderrWrite;
-  vm0OriginalWrite?: StderrWrite;
-  vm0HappyDomIframeNoisePatched?: true;
+  originalWrite?: StderrWrite;
+  happyDomIframeNoisePatched?: true;
 };
 
 const nodeProcess = (
@@ -99,7 +99,7 @@ function findPrototypeSymbol(
 function installHappyDomIframeLoadPatch(): void {
   const iframePrototype =
     HTMLIFrameElement.prototype as PatchedHTMLIFrameElementPrototype;
-  if (iframePrototype.vm0HappyDomIframeLoadPatched) {
+  if (iframePrototype.happyDomIframeLoadPatched) {
     return;
   }
 
@@ -125,7 +125,7 @@ function installHappyDomIframeLoadPatch(): void {
     !onRemoveAttributeSymbol ||
     !connectedToDocumentSymbol
   ) {
-    iframePrototype.vm0HappyDomIframeLoadPatched = true;
+    iframePrototype.happyDomIframeLoadPatched = true;
     return;
   }
 
@@ -187,13 +187,13 @@ function installHappyDomIframeLoadPatch(): void {
       originalConnectedToDocument.call(this);
     };
 
-  iframePrototype.vm0HappyDomIframeLoadPatched = true;
+  iframePrototype.happyDomIframeLoadPatched = true;
 }
 
 installHappyDomIframeLoadPatch();
 
 const originalStderrWrite =
-  nodeProcess.stderr.vm0OriginalWrite ??
+  nodeProcess.stderr.originalWrite ??
   nodeProcess.stderr.write.bind(nodeProcess.stderr);
 
 function isDisabledIframePageLoadingLog(chunk: string | Uint8Array): boolean {
@@ -215,10 +215,10 @@ function writeStderrWithoutHappyDomIframeNoise(
   return originalStderrWrite(...args);
 }
 
-if (!nodeProcess.stderr.vm0HappyDomIframeNoisePatched) {
-  nodeProcess.stderr.vm0OriginalWrite = originalStderrWrite;
+if (!nodeProcess.stderr.happyDomIframeNoisePatched) {
+  nodeProcess.stderr.originalWrite = originalStderrWrite;
   nodeProcess.stderr.write = writeStderrWithoutHappyDomIframeNoise;
-  nodeProcess.stderr.vm0HappyDomIframeNoisePatched = true;
+  nodeProcess.stderr.happyDomIframeNoisePatched = true;
 }
 
 function ensureTestLocalStorage(): void {

--- a/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
+++ b/turbo/apps/platform/src/views/onboarding/__tests__/onboarding-flow.test.tsx
@@ -169,7 +169,7 @@ function setupCustomWorkflowPage(
     context,
     host,
     locale: "en-US",
-    path: "/onboarding/workflow-run?choice=workflow&category=engineering&workflow=talk-to-zero",
+    path: "/onboarding/workflow-run?choice=workflow&category=engineering&workflow=custom-workflow",
   });
 }
 

--- a/turbo/apps/platform/src/views/onboarding/onboarding-data.ts
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-data.ts
@@ -194,7 +194,7 @@ export function onboardingWorkflowCategories(
   });
 }
 
-export const CUSTOM_WORKFLOW_ID = "talk-to-zero";
+export const CUSTOM_WORKFLOW_ID = "custom-workflow";
 
 function onboardingWorkflowIdentity(workflowIdValue: string | null): {
   readonly id: OnboardingWorkflowId;

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -1485,7 +1485,7 @@ function urlForHostPolicyValidation(
   const schemeEnd = base.indexOf("://");
   const scheme = schemeEnd === -1 ? "https" : base.slice(0, schemeEnd);
   const port = new URL(
-    `${scheme}://vm0-host.invalid${authorityParts.portSuffix}`,
+    `${scheme}://validation-host.invalid${authorityParts.portSuffix}`,
   ).port;
   return { hostname, port };
 }
@@ -2521,7 +2521,7 @@ function authorityForUrlSyntaxValidation(authority: string): string {
   if (rawHost.startsWith("[") && rawHost.endsWith("]")) {
     return authority;
   }
-  return `vm0-host.invalid${authority.slice(rawHost.length)}`;
+  return `validation-host.invalid${authority.slice(rawHost.length)}`;
 }
 
 function urlForCanonicalBaseSyntax(base: string): URL {

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -199,7 +199,7 @@ function imageStyleArchiveSha256(slug: string): string {
   return sha256;
 }
 
-function vm0ImageStyleSource(slug: string): ResourceSourceRef {
+function imageStyleSource(slug: string): ResourceSourceRef {
   return {
     repo: VM0_SKILLS_REPO,
     ref: VM0_SKILLS_REF,
@@ -3048,7 +3048,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Hand-drawn product spot illustration style with simple ink contours and soft backgrounds.",
     desc: 'Notion-editorial-style hand-drawn spot illustration. Black brush-pen ink on white, tapered confident strokes, solid-black curly hair, solid-black pants/shoes, 3/4 face turned toward viewer with closed-eye smile and soft nose hint, open breathing body outlines, and 1-3 supporting scene props + ambient marks that frame the moment. Trigger when user says /notion-illustration, asks for a "Notion-style illustration", "Notion spot illustration", or a new piece in this hand-drawn brush-pen Notion editorial style.',
-    source: vm0ImageStyleSource("notion-illustration"),
+    source: imageStyleSource("notion-illustration"),
   },
   {
     id: "image-style:vm0-illustration",
@@ -3057,7 +3057,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "vm0 in-app spot illustration style with bold hand-drawn ink line art, white-filled interiors, and a soft rounded color backdrop.",
     desc: "Generate vm0-style vm0 in-app spot illustrations: bold hand-drawn ink line art with white-filled interiors, a soft rounded color backdrop, transparent output, and simple iconic metaphors for product states.",
-    source: vm0ImageStyleSource("vm0-illustration"),
+    source: imageStyleSource("vm0-illustration"),
   },
   {
     id: "image-style:postcard-illustration",
@@ -3066,7 +3066,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Hand-drawn editorial postcard / travel-journal illustration with fine black ink linework, flat saturated gouache fills, sharp edges, dense small repeated ink patterns, paper-grain texture, sparse white speckles, and a tall portrait composition.",
     desc: 'Hand-drawn editorial postcard illustration style. Fine black marker/pen ink linework over flat saturated gouache color fills with sharp edges, dense small repeated ink patterns on surfaces (rows of windows, shingle curves, hatching, stippling), subtle paper-grain background texture, tiny scattered white speckles (snow / petals / sparkle), and a tall portrait composition with a layered foreground-midground-background. Travel-journal / urban-sketcher aesthetic. Trigger when the user says /postcard-illustration, asks for a "postcard illustration", "travel illustration", "urban sketcher style", or briefs a palette + scene archetype + complexity.',
-    source: vm0ImageStyleSource("postcard-illustration"),
+    source: imageStyleSource("postcard-illustration"),
   },
   {
     id: "image-style:folk-storybook",
@@ -3075,7 +3075,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Folk-art children's picture-book illustration — hand-painted gouache and watercolor scenes with anthropomorphic animal characters, closed-crescent-eye smiles, dusty muted folk palette, and decorative pattern surfaces.",
     desc: "Folk-art children's picture-book illustration style — hand-painted gouache/watercolor scene on aged paper, anthropomorphic animal characters with closed-crescent-eye smiles, dusty muted folk palette, decorative pattern surfaces (wallpaper, rugs, textiles), and a hushed lullaby mood. Trigger when users ask for a folk-art illustration, storybook scene, cozy animal illustration, or any new piece in this Eastern European picture-book style.",
-    source: vm0ImageStyleSource("folk-storybook"),
+    source: imageStyleSource("folk-storybook"),
   },
   {
     id: "image-style:papernook",
@@ -3084,7 +3084,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Hand-drawn editorial illustration set in a cozy cluttered personal-studio scene with warm cream paper, scratchy ink, painterly gouache fills, dot-eye character face, and dense edge-to-edge thematic props.",
     desc: 'Hand-drawn editorial illustration in the spirit of a cluttered personal-studio scene. Loose scratchy black ink outlines that wobble, textured gouache fills with visible brush marks, warm cream paper background, simplified dot-eye character face, and a DENSE edge-to-edge composition where a centered character is orbited by thematic props that visually act out the scene metaphor. Default palette: dusty cornflower blue, soft coral pink, fresh sage green, charcoal, warm cream — no mustard, no burnt-orange. Trigger when user says /papernook, asks for a "papernook illustration", a "cozy cluttered editorial scene", a "warm-cream desk scene", or a new piece in this hand-drawn studio-clutter editorial style.',
-    source: vm0ImageStyleSource("papernook"),
+    source: imageStyleSource("papernook"),
   },
   {
     id: "image-style:painterly-botanical",
@@ -3093,7 +3093,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Painterly watercolor + gouache portrait illustration with a single figure embraced by lush botanicals, closed-eye introspective expression, and a softly tinted paper-wash background.",
     desc: 'Painterly watercolor + gouache portrait illustration. Single figure (closed eyes, contemplative) embraced by botanicals — leaves, blossoms, grasses. Translucent washes with visible pigment bleeds, sparse crisp ink line accents on key edges, tiny handwritten cursive signature in an upper corner, and a tinted paper-wash background (never pure white). Eight user axes drive composition: subject, hair, pose, botanicals, palette, background wash, complexity (L1/L2/L3), and format. Trigger when a brief describes a contemplative figure with foliage, a "watercolor portrait", a "botanical embrace", or asks for a piece in this painterly editorial style.',
-    source: vm0ImageStyleSource("painterly-botanical"),
+    source: imageStyleSource("painterly-botanical"),
   },
   {
     id: "image-style:iso-scene",
@@ -3102,7 +3102,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Isometric editorial-magazine scene illustration with ultra-fine hairline outlines, flat fills, a saturated monochromatic background, and a scene-as-metaphor composition built from theme-native props.",
     desc: 'Isometric editorial-magazine scene illustration in a locked flat-vector style — ultra-fine hairline outlines, monochromatic saturated background filling the canvas, and a single composed scene whose props themselves embody the theme. Trigger when users say /iso-scene, ask for an "isometric editorial illustration", a "scene illustration in the editorial machine style", or brief with palette + scene archetype + complexity.',
-    source: vm0ImageStyleSource("iso-scene"),
+    source: imageStyleSource("iso-scene"),
   },
   {
     id: "image-style:inkdab",
@@ -3111,7 +3111,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Brush-pen editorial illustration where a free-floating color dab is painted first, then loose black ink linework is drawn freely on top — never as an outline around the color. Scribbled hatched hair, open-outline bodies, pure white background.",
     desc: 'Brush-pen editorial illustration style — a flat accent-color "dab" painted first, then loose black ink drawn freely on top. ONE flat accent-color shape per prop (painted-first, never outlined in black), black hand-wobbled ink on pure white background, scribbled hatched hair, open-outline bodies with zero fill, and one small solid-accent triangle floating freely as a recurring motif. Trigger when user says /inkdab, asks for an "inkdab illustration", a "brush-pen illustration with a single accent color", a "free-floating color block illustration", or briefs in the style of the included reference images.',
-    source: vm0ImageStyleSource("inkdab"),
+    source: imageStyleSource("inkdab"),
   },
   {
     id: "image-style:riso-relic",
@@ -3120,7 +3120,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       'Pop-art retro risograph poster of a single nostalgic everyday object on a saturated single-hue field — bold black ink outlines, halftone grain, hand-drawn doodle accents, tiny "SMALL OBJECTS IN TIME" banner up top, chunky retro headline with offset drop-shadow at the bottom.',
     desc: 'Pop-art retro risograph poster of a single nostalgic everyday object — saturated single-color background, bold black ink outlines, halftone/riso grain, hand-drawn doodle accents (sparkles, squiggles, dots, music notes, lightning), tiny white "SMALL OBJECTS IN TIME" banner at top, chunky retro display headline at bottom with offset black drop-shadow. Trigger when user says /riso-relic, asks for a "riso poster", a "small objects in time" illustration, or any new piece in this nostalgic pop-art relic-object style.',
-    source: vm0ImageStyleSource("riso-relic"),
+    source: imageStyleSource("riso-relic"),
   },
   {
     id: "image-style:inkstomp",
@@ -3129,7 +3129,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Loud indie-packaging poster style — full-bleed saturated flat color, a two-line hand-lettered headline, and one weird-cute black brush-ink character.",
     desc: 'Inkstomp — a loud, hand-screened indie-packaging poster style. Full-bleed saturated flat color filling the entire canvas, a two-line hand-lettered headline (thin arched caps over chunky drop-shadowed display), and one weird-cute character drawn in thick uniform black brush ink. Trigger when the user says /inkstomp, asks for an "inkstomp poster", a "Ray Fenwick / Hattie Stewart packaging poster", an "indie brush-ink flavor card", or briefs in a "palette + headline + character" shape.',
-    source: vm0ImageStyleSource("inkstomp"),
+    source: imageStyleSource("inkstomp"),
   },
   {
     id: "image-style:folk-muse",
@@ -3138,7 +3138,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Flat folk-art gouache portrait style — a single contemplative chest-up figure framed by an asymmetric botanical surround, with painted irises, smooth flat hair, a hand against the cheek, and a patterned robe.",
     desc: 'Flat folk-art gouache portrait illustration in the contemporary editorial style of Carson Ellis, Maja Tomljanovic, and Bodil Jane. A single chest-up figure with an elongated mannerist oval face, tiny almond half-lidded eyes, smooth flat hair, one hand pressed against the face, a patterned robe filling the lower frame, and an asymmetric botanical surround filling the background edge-to-edge. Hand-painted matte gouache texture, flat color blocks, no harsh outlines, no photorealism. Calm, slightly melancholic, contemplative mood. Trigger when the user says /folk-muse, asks for a "folk-art portrait", "gouache portrait", "Carson Ellis style portrait", or any new piece in this contemplative folk-portrait style.',
-    source: vm0ImageStyleSource("folk-muse"),
+    source: imageStyleSource("folk-muse"),
   },
   {
     id: "image-style:sunlit-gouache",
@@ -3147,7 +3147,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Bright pastel travel-painting illustration in opaque gouache on textured paper with chunky flat brushstrokes, vertical one-point perspective, and figures walking into warm sunlight.",
     desc: 'Sunlit Gouache travel-painting illustration. Opaque gouache on textured paper, visible chunky flat brushstrokes with dry-brush highlights, locked six-color palette (cream, butter-yellow, sky-blue, sage-green, terracotta, one small red accent), vertical 2:3 one-point-perspective composition drawing the eye into a bright sunlit focal point, figures seen from behind walking into the scene, an overhead band of hanging elements (awning, prayer flags, catenary, bunting, lanterns) creating depth, dappled painterly reflections on the ground, airy optimistic warm mood. Trigger when user says /sunlit-gouache, asks for a "sunlit gouache illustration", "painterly travel scene", "gouache café/market/temple/station scene", or a new piece in this bright pastel painted-light style.',
-    source: vm0ImageStyleSource("sunlit-gouache"),
+    source: imageStyleSource("sunlit-gouache"),
   },
   {
     id: "image-style:mosaic-still-life",
@@ -3156,7 +3156,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Editorial still-life illustration in a mosaic-tile + painterly hybrid style — tessellated ground/sky/wall surfaces with crisp painterly objects, an animal companion, and a patterned textile peeking through.",
     desc: 'Mosaic-tile + painterly hybrid editorial illustration. Tessellated/pointillist mosaic surfaces (grass, sky, sand, walls, floors) anchor the scene, with crisp painterly still-life objects rendered ON TOP. Always features a still-life centerpiece on a table, an animal companion at the heart of the scene, and at least one patterned textile peeking through. Cozy, nostalgic, bucolic mood. Trigger when user says /mosaic-still-life, asks for a "mosaic illustration", "mosaic-tile editorial illustration", "tessellated still life", or briefs with a palette + scene + animal in this style.',
-    source: vm0ImageStyleSource("mosaic-still-life"),
+    source: imageStyleSource("mosaic-still-life"),
   },
   {
     id: "image-style:ink-mascot",
@@ -3165,7 +3165,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Vintage editorial marketing card. Bold serif headline and short serif descriptor over a hand-drawn black-ink anthropomorphic mascot (stick limbs, chunky white sneakers) on a single solid saturated flat color background.",
     desc: 'Generate a 3:5 portrait editorial marketing card in a locked vintage-textbook style. Bold serif headline plus an optional short serif descriptor sit on a single solid saturated flat color background (no gradient, no divider, no ground line). A hand-drawn black-ink anthropomorphic hero object — paint bucket, magnifying glass, envelope, notebook, funnel, megaphone, rocket, seedling, gift box, compass, etc. — stands with two thin stick arms, two stick legs, and chunky white sneakers with black laces (the signature detail). Crosshatch and stipple shading on rounded surfaces; floating ink doodles (sparkles, arrows, hearts, percent or dollar signs, motion lines) at the requested density. Dialable along six axes: concept, palette, hero object, action, doodle density (L1 minimal, L2 balanced, L3 packed), and type layout (A title-top, B headline-bottom, C headline-only, D big-word + tiny-descriptor). Trigger when user says /ink-mascot, asks for a "marketing card illustration", a "retro editorial mascot poster", or briefs with a marketing concept plus palette plus character.',
-    source: vm0ImageStyleSource("ink-mascot"),
+    source: imageStyleSource("ink-mascot"),
   },
   {
     id: "image-style:sticker-sheet",
@@ -3174,7 +3174,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Hand-painted gouache sticker-sheet illustration with ~20 themed objects floating on white, punchy saturated palette, wobbly hand-drawn ink overlay, and tiny decorative marks on every item.",
     desc: 'Sticker Sheet — hand-painted gouache sticker-sheet illustration. ~20 small floating themed objects on pure white, punchy saturated palette (coral, mustard, sage, dusty pink, navy, cream, warm brown), flat brushy gouache fills with wobbly hand-drawn ink linework and tiny decorative marks (dots, hatches, squiggles) on every object. Each object slightly tilted, no drop shadows, cheerful cozy lifestyle journal mood. Trigger when user says /sticker-sheet, asks for a "sticker sheet illustration", "hand-painted gouache sticker pack", "themed object sheet", or briefs with a scene theme + object count in this house style.',
-    source: vm0ImageStyleSource("sticker-sheet"),
+    source: imageStyleSource("sticker-sheet"),
   },
   {
     id: "image-style:flat-poster",
@@ -3183,7 +3183,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Vertical flat-color editorial poster style — saturated solid background, one centered hand-drawn vector subject in bold deep-navy outlines with strict two-tone fill, headline pinned top-left, and an optional user-supplied wordmark pinned bottom-right.",
     desc: 'Flat Poster — a vertical flat-color editorial poster style for brand benefit cards, marketing posters, and in-app campaign visuals. Portrait 2:3 canvas filled edge-to-edge with one saturated hue; a single centered hand-drawn vector subject in deep-navy outlines with strict two-tone fill (pure white plus one darker bg-tint accent); a bold rounded sans-serif headline pinned top-left; an optional short wordmark supplied by the user pinned bottom-right and omitted when none is supplied; small floating accent marks around the subject; no body copy. Six creative dials: palette, subject archetype, composition preset, accent marks, headline voice, mood. Trigger when the user says /flat-poster, asks for a "flat-color editorial poster", a "brand benefit card", a "marketing card in the bold outline + flat color style", or briefs with a palette + subject + headline shape.',
-    source: vm0ImageStyleSource("flat-poster"),
+    source: imageStyleSource("flat-poster"),
   },
   {
     id: "image-style:mellow-pop",
@@ -3192,7 +3192,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Chill flat-vector editorial poster of a serene recurring character on a fully saturated solid color background, with a signature pop of bright leaf-green and a scene-as-metaphor composition.",
     desc: 'Mellow-pop flat-vector editorial illustration: a recurring chill character with closed-eye smile, tiny nose hint, and short dark bobbed hair, posed inside a scene-as-metaphor composition on a single fully saturated solid color background, with a signature pop of bright leaf-green woven into every piece (hero prop, plants, motifs, or sweater). Thin uniform black outlines, flat solid fills only, no gradients or texture. Five dials per brief: palette, scene metaphor, complexity (L1/L2/L3), pose, outfit accent. Trigger when user says /mellow-pop, asks for a "mellow-pop illustration", "chill flat-vector poster", or briefs with a scene metaphor + palette + complexity.',
-    source: vm0ImageStyleSource("mellow-pop"),
+    source: imageStyleSource("mellow-pop"),
   },
   {
     id: "image-style:grainy-duotone",
@@ -3201,7 +3201,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Editorial spot illustration on a warm cream background — grainy charcoal-stippled hands, outline-free flat two-tone color blocks with internal patterns, and scattered ambient marks.",
     desc: 'Grainy-duotone editorial spot illustration: warm cream off-white background, grainy charcoal-stippled hands (and occasional faces) drawn in textured black ink, paired with free-floating flat two-tone color blocks that carry NO outlines and are filled with internal patterns (grid, dots, spiral, hatching, squiggles, wavy lines), surrounded by scattered ambient marks (zigzags, triangles, x marks, circles, dashes). Square 1:1 scene-as-metaphor compositions. Five creative dials per brief: palette (two flat hues, e.g. teal+yellow / coral+sage / lavender+mustard / navy+peach / burgundy+dusty pink), elements (hand(s) + 1-3 props like flag, sprout, magnifier, balloons, ladder), scene archetype (Launch / Grow / Connect / Discover / Communicate / Reflect / Navigate / Care / Transform / Build), complexity (L1 minimal / L2 balanced / L3 rich), and mood (celebratory / calm / curious / reflective / determined / warm / quiet). Trigger when user says /grainy-duotone, asks for a "grainy two-tone editorial illustration", "charcoal-stippled hand illustration", "duotone editorial spot", or briefs with a scene metaphor + two-color palette + complexity.',
-    source: vm0ImageStyleSource("grainy-duotone"),
+    source: imageStyleSource("grainy-duotone"),
   },
   {
     id: "image-style:op-ed-cover",
@@ -3210,7 +3210,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Editorial magazine op-ed cover — flat-vector scene with paper grain, elongated ink-line characters, muted retro palette, and a serif headline block in the lower-right.",
     desc: 'Editorial magazine op-ed cover illustration. Flat-vector + paper-grain scene with expressive elongated ink-line characters, gentle painterly shading, 1950s-60s editorial mood, and a serif headline overlay block in the lower-right corner carrying a witty contrarian or declarative title with two short lines of italic body copy. 5-axis framework: palette (background + accent + ink), complexity (L1 single hero / L2 small ensemble / L3 busy crowd), scene metaphor (specific cultural microcosm), headline voice (declarative / pun / appreciative / contrarian), and headline block style (solid vs. translucent). Trigger when user says /op-ed-cover, asks for an "editorial magazine illustration", an "op-ed cover", a "magazine essay illustration", or a scene with a headline overlay in this style.',
-    source: vm0ImageStyleSource("op-ed-cover"),
+    source: imageStyleSource("op-ed-cover"),
   },
   {
     id: "image-style:grain-poster",
@@ -3219,7 +3219,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Flat-vector editorial poster of a serene full-body figure with one hero prop — riso grain on a single textile, closed-eye smile + red cheek blush, muted limited palette.",
     desc: 'Grain Poster — flat-vector editorial illustration of a serene full-body figure interacting with one hero prop (bicycle, bouquet, cat, book, skateboard, sun hat, guitar, dog leash). Closed-eye smile + single round red cheek blush + dark nose mark + solid black hair, silhouette-first (no inked outlines). Riso/halftone grain confined to exactly ONE textile element (skirt or trousers); every other surface is flat color. Muted single-hue background, generous negative space, no headlines or wordmarks. Six tunable dials: palette (cool-dawn · sunset-coral · twilight · forest-green · custom), mood, scene, cast, complexity (L1/L2/L3), framing. Strongest at L1 + side-profile + solo. Trigger when user says /grain-poster, asks for a "flat-vector editorial poster", "riso-grain figure poster", "grainy editorial illustration", or briefs with a scene + palette + cast in this house style.',
-    source: vm0ImageStyleSource("grain-poster"),
+    source: imageStyleSource("grain-poster"),
   },
   {
     id: "image-style:light-pop-portrait",
@@ -3228,7 +3228,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Light hand-drawn flat-vector single-character portrait on a fully saturated color block — chunky black hair, big shiny eyes, tiny red nose, pink five-point-star sparkle blush.",
     desc: 'Light Pop Portrait — a hand-drawn flat-vector single-character portrait style for playful avatars, mood pieces, and editorial character cards. Square 1:1 canvas filled with one fully saturated background hue; a single child–tween character with chunky glossy-black hair (with one or two flyaway strands), big round shiny eyes (single white glint each, thin lashes above), tiny round red nose, expressive small mouth, and pink FIVE-POINT STAR sparkle blush on the cheeks (never solid dots). Thin delicate slightly-wavy hand-drawn contour lines, flat solid fills only, no gradients or texture, ~5-color palette per piece. Eight creative dials: expression, hairstyle, gender register, pose, palette, headwear, prop, outfit. Trigger when user says /light-pop-portrait, asks for a "light pop portrait", "flat-vector character portrait", "saturated color-block character", or briefs with expression + hairstyle + palette + prop.',
-    source: vm0ImageStyleSource("light-pop-portrait"),
+    source: imageStyleSource("light-pop-portrait"),
   },
   {
     id: "image-style:endpaper",
@@ -3237,7 +3237,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Riso-grain flat-vector collection of chill characters or objects scattered across a saturated solid color field, with two-tone interior shading and closed-eye sleepy faces.",
     desc: 'Riso-grain flat-vector editorial collection illustration. Many small animals or objects scattered across a fully saturated solid color background — like the inside endpaper of a children\'s picture book. Subtle riso/screenprint grain inside every fill, two-tone interior shading on every character (darker top + lighter belly), closed crescent-eye sleepy smiles with tiny dot noses, NO outlines on character bodies, loose hand-drawn line details on props (yarn spirals, leaf veins, pot stripes), scattered curated composition where characters overlap and touch the canvas edges. Five dials: background hue, cast (cats/dogs/foxes/birds/sea-creatures/houseplants/kitchen-objects/etc.), character palette (3–5 curated fills), density (L1 sparse / L2 balanced / L3 packed), prop vocabulary matched to cast. Trigger when user says /endpaper, asks for an "endpaper illustration", a "scattered animal or object collection on saturated color", a "children\'s-book endpaper scene", or briefs with a cast + background hue + density + palette.',
-    source: vm0ImageStyleSource("endpaper"),
+    source: imageStyleSource("endpaper"),
   },
   {
     id: "image-style:editorial-flatfolk",
@@ -3246,7 +3246,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Editorial hand-drawn naive book-illustration style — flat saturated color blocks, loose ink line overlay, paper grain, and a strong sense of place.",
     desc: 'Editorial hand-drawn naive book-illustration style. Flat saturated color blocks with loose hand-drawn ink line work sitting ON TOP of the color, subtle paper grain across the canvas, simple ink hatching for sky / sun rays / rain / snow, and a strong sense of place built from tall narrow architecture and a one-point depth axis. Five dials per brief: palette (warm-primary, coastal-peach, jewel-night, winter-cool, autumn-rust, monsoon-twilight), scene metaphor (street, harbor, market, transit, park, square, interior, alpine-village), perspective (one-point street, frontal facade, low-angle hero, isometric, top-down), cast (solo wanderer, paired, small crowd, none), and light/weather (midday sun, golden hour, rain, snow, blue hour). Trigger when user says /editorial-flatfolk, asks for an "editorial flat-folk illustration", a "saturated naive book-illustration scene", a "tall narrow row-house illustration", or briefs a palette + scene metaphor + season.',
-    source: vm0ImageStyleSource("editorial-flatfolk"),
+    source: imageStyleSource("editorial-flatfolk"),
   },
   {
     id: "image-style:soft-vector",
@@ -3255,7 +3255,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Airy flat-vector spot illustration — square pale-blue canvas, thin ~1.5-2px dark-navy linework with intentionally open / unclosed outlines, flat fills, one muted accent hue, centered subject with breathing room.",
     desc: 'Soft Vector — an airy flat-vector spot illustration style for in-app onboarding art, empty states, billing cards, and friendly UI moments. Square 1:1 canvas on a single flat pale-blue field #EEF1F5; thin uniform dark-navy outlines (~1.5-2px, rounded caps, NOT chunky); the signature lift comes from several intentionally OPEN / unclosed outlines per piece (mug rim gap, handle that doesn\'t close, ground line ending in mid-air, cloud silhouette break, lamp arm fade, pot rim gap); strictly flat colour fills with no gradients or shading; one muted lead accent (mustard / lime-sage / warm-orange / violet) plus neutrals; subject centered at ~60-75% of canvas with generous breathing room; scattered thin-navy micro-marks (dots, plus signs, sparkles, or motion ticks). Six dials per brief: palette accent, scene metaphor, complexity (L1/L2/L3), cast, accent marks, action/mood. Trigger when user says /soft-vector, asks for a "soft-vector illustration", a "friendly UI onboarding illustration", a "thin-line flat spot illustration", or briefs a scene metaphor + palette + complexity in this house style.',
-    source: vm0ImageStyleSource("soft-vector"),
+    source: imageStyleSource("soft-vector"),
   },
   {
     id: "image-style:loose-contour",
@@ -3264,7 +3264,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Flat editorial spot illustration — open teal contour lines, offset color blobs (printing-misregistration look), one ribbon line on warm cream paper.",
     desc: 'Loose-contour flat editorial spot illustration: confident open-contour ink drawings in dark teal-green (#1e4d4a) over flat offset color blobs (printing-misregistration look) on warm cream paper (#f0ebdc), with exactly one continuous looping ribbon line of the same teal weaving through the scene. Tight 5-color palette: cream + teal + mustard + soft blue + coral. Lines are deliberately broken at joints and edges. Five dials per brief: scene metaphor, cast, complexity (L1/L2/L3), accent lead, ribbon path. Trigger when user says /loose-contour, asks for a "loose-contour illustration", "offset-blob editorial illustration", or "cream paper ribbon-line scene".',
-    source: vm0ImageStyleSource("loose-contour"),
+    source: imageStyleSource("loose-contour"),
   },
   {
     id: "image-style:jade-blockprint",
@@ -3273,7 +3273,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Two-tone hand-drawn block-print spot illustration — accent color painted as free-floating shapes on white, with chunky black ink layered on top. Eight palettes.",
     desc: 'Jade-blockprint two-pass hand-drawn block-print spot illustration: one accent color painted FIRST as free-floating shapes on pure white, then chunky black ink line art layered ON TOP. Color blobs have no perimeter outline — ink draws detail, hatching, and motion marks, never traces the colored shape. Wobbly variable-weight linework with occasional flooded black masses; tiny linocut speckle grain inside color fills. Eight named palettes (jade, coral, cobalt, plum, sage, rose, slate, terracotta) plus custom-hex override. Resolves vague briefs (growth, trust, freedom, fairness) into concrete scene metaphors via an internal synthesizer table before generating. Five dials per piece: palette, scene metaphor, complexity (L1 single object / L2 mini-scene / L3 vignette), motion marks, speckle density. Trigger when the user says /jade-blockprint, asks for a "block-print illustration", "linocut spot illustration", "two-tone screen-print", or briefs a metaphor for a blog cover or marketing card in this style.',
-    source: vm0ImageStyleSource("jade-blockprint"),
+    source: imageStyleSource("jade-blockprint"),
   },
   {
     id: "image-style:shadow-pop",
@@ -3282,7 +3282,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Bright flat-vector illustration with offset black shape shadows, white dashed stitching, palette confetti, and transparent PNG output.",
     desc: 'Bright flat-vector editorial illustration style — every colored shape sits in front of an offset black silhouette of itself (the signature depth trick, no outlines on the fills), with white hand-drawn dashed stitching, scattered palette-colored sparkle confetti, and a fully transparent PNG background so the piece drops cleanly onto any surface. Five dials per brief — palette (default / berry-pop / tropical / citrus-cobalt), scene metaphor, complexity (L1 / L2 / L3), confetti density, and subject domain. Trigger when user says /shadow-pop, asks for a "shadow-pop illustration", a "bright flat-vector illustration with offset shadow", an "in-app illustration with offset shadow trick", or briefs in the style of the included reference images.',
-    source: vm0ImageStyleSource("shadow-pop"),
+    source: imageStyleSource("shadow-pop"),
   },
   {
     id: "image-style:tiny-wanderer",
@@ -3291,7 +3291,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Contemplative bande-dessinée landscape illustration — tiny human dwarfed by vast nature, ink hatching + flat color, vertical portrait canvas.",
     desc: 'Contemplative bande-dessinée landscape illustration in a locked house style — a tiny human (or 2–3 figures) is dwarfed by a vast natural panorama, hand-drawn black ink contour + parallel/cross-hatching for clouds, rock walls, foliage, grass, and water texture, sitting on flat color blocks beneath the ink (no gradients, no airbrush). Restrained 3–5 color palette per piece including black ink, vertical portrait canvas (1024x1536, reads ~3:5). Always outdoor/wilderness. Moebius / Christophe Chabouté travel-sketchbook lineage, quiet wonder mood. Six dials per brief: palette family (sage-plains / sunset-warm / coastal-teal / cool-mist / autumn-rust / winter-pale / custom), landscape archetype (plains+clouds / mountain valley / river vista / rocky ridge / coastal cliffs / misty gorge / forest clearing / alpine pass / desert mesa / lakeshore), activity (walking / cycling / hiking / standing-and-gazing), solitude count (1 / 2 / 3), complexity (L1 single plane / L2 fore+mid / L3 full multi-plane vista), and weather/time (midday / golden hour / sunset / overcast / mist / blue hour). Trigger when user says /tiny-wanderer, asks for a "tiny wanderer illustration", "bande-dessinée landscape", "Moebius-style travel illustration", "ink-hatched vertical landscape", or briefs with a palette + landscape archetype + complexity in this house style.',
-    source: vm0ImageStyleSource("tiny-wanderer"),
+    source: imageStyleSource("tiny-wanderer"),
   },
   {
     id: "image-style:iberian-vignette",
@@ -3300,7 +3300,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Hand-drawn editorial vignette style — loose wobble ink, flat muted cream + burgundy + one accent (sage / mustard / dusty blue / terracotta), minimal abstract faces, observed Mediterranean composition with a serif Spanish wordmark at the bottom.",
     desc: 'Iberian-vignette hand-drawn editorial illustration: loose hand-drawn ink linework with visible wobble and varied weight, flat muted color fills (no gradients, no shading, no texture) on a warm cream off-white background, burgundy/wine always present as the anchor color somewhere in the scene, exactly one secondary accent per piece (sage green / mustard yellow / dusty muted blue / terracotta-rust), minimal abstract faces (tiny dot or short-mark eyes, soft nose hint, almost no mouth), hair as flat color masses, warm sand skin tones, casually-observed body language (leaning, holding, mid-action, never stiffly posed), and a short Spanish serif lowercase wordmark anchored at the bottom center of the canvas. Always grounded by an architectural / scenic prop (stone arched doorway, tall arched window, balcony, sunlit courtyard, wooden counter, archway, stoop, open terrace). Six dials per brief: scene metaphor (trade shop, domestic moment, leisure ritual), cast (solo L1 / pair L2 / 3-4 figures L3), architectural prop, secondary accent (one only), wordmark (Spanish noun), complexity (L1/L2/L3). Trained on nano-banana-2 image-to-image with one of three locked anchor references (mañana / ritmo / familia). Trigger when user says /iberian-vignette, asks for an "Iberian vignette illustration", a "Spanish editorial illustration", a "Mediterranean observed-moment scene", or briefs a scene metaphor + cast + complexity in this hand-drawn editorial style.',
-    source: vm0ImageStyleSource("iberian-vignette"),
+    source: imageStyleSource("iberian-vignette"),
   },
   {
     id: "image-style:cozy-parlor",
@@ -3309,7 +3309,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Hand-painted watercolor + ink-line scene — one anthropomorphic animal in a quiet domestic interior, clean cool-white paper, neutral palette with one hot accent pop.",
     desc: "Hand-painted watercolor + brushy black ink line on clean cool-white paper (no amber tint). ONE anthropomorphic animal mid-quiet-activity in a domestic interior. Closed-crescent-eye smile, minimal facial features, expression through posture. At least two patterned surfaces per piece. Cool/neutral palette lead (sage, slate-blue, cornflower, lavender, mint, dove-gray) with a single hot accent pop (cherry-red, mustard, magenta-pink) on one object. Six dials per brief — cast, activity, palette family, pattern motif stack, hot accent object, and complexity (L1/L2/L3). Trigger when user says /cozy-parlor, asks for a 'cozy parlor illustration', a 'watercolor animal scene', a 'picture-book interior', or a new piece in this neutral-palette watercolor style.",
-    source: vm0ImageStyleSource("cozy-parlor"),
+    source: imageStyleSource("cozy-parlor"),
   },
   {
     id: "image-style:crowd-ink",
@@ -3318,7 +3318,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Hand-drawn editorial crowd illustration — sketchy black ink contours over flat 3-color spot fills on pure white, scene-as-metaphor composition.",
     desc: 'Hand-drawn editorial crowd illustration style — confident sketchy black ink contour lines with slightly irregular weight, flat 3-color spot fills sitting under or beside the ink lines (edges allowed to misregister slightly), on a PURE WHITE background (never cream). Fine-line backdrop drawn lighter than the foreground figures, scattered atmospheric marks in negative space (birds / leaves / steam / confetti / dots), and a scene-as-metaphor composition with a cast that varies per piece. Six dials per brief — palette (tested families: urban editorial / cool transit / warm natural / cozy interior), scene metaphor, complexity (L2 small group of 3–5 / L3 full crowd of 8–10), cast, backdrop, atmospheric motif. Trigger when the user says /crowd-ink, asks for a "crowd-ink illustration", "editorial crowd scene", "hand-drawn ink-and-spot-color illustration", "New-Yorker-style crowd vignette", or briefs with palette + scene metaphor + complexity level.',
-    source: vm0ImageStyleSource("crowd-ink"),
+    source: imageStyleSource("crowd-ink"),
   },
   {
     id: "image-style:ink-storefront",
@@ -3327,7 +3327,7 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     description:
       "Single-color hand-drawn ink fineliner illustration of a small storefront on warm cream paper — hand-lettered shop sign, foliage, and street props.",
     desc: 'Boutique-poster illustration style — a single-color hand-drawn ink line drawing of a small storefront (café, boulangerie, florist, bookshop, ramen, wine bar, barber, record store, etc.) seen from street level on warm cream paper #f4ecd8. Locked frame: portrait 1024x1536, monochromatic ink with occasional double-stroke shadow under awnings and signs, a hand-lettered shop sign baked into the building, foliage and at least one small street prop (bike, A-frame chalkboard, planters, lanterns, café tables, dog/cat at the door), and a faint horizontal sidewalk line across the bottom. No solid color fills, no shading, no gradients. Seven dials per brief — ink color, shop name + subtitle, archetype, perspective (flat facade vs 3/4 corner), foreground props, foliage density, and complexity (L1 single facade / L2 small scene / L3 full vignette). Trigger when user says /ink-storefront, asks for a "shopfront illustration", "storefront poster", "boutique fineliner illustration", "café line drawing", or briefs with a shop name + ink color + archetype in this house style.',
-    source: vm0ImageStyleSource("ink-storefront"),
+    source: imageStyleSource("ink-storefront"),
   },
 ];
 

--- a/turbo/packages/eslint-rules/scripts/residual-brand-name-manifest.ts
+++ b/turbo/packages/eslint-rules/scripts/residual-brand-name-manifest.ts
@@ -277,6 +277,30 @@ export const RESIDUAL_BRAND_BOUNDARY_OCCURRENCE_RULES = [
   },
   {
     category: "external-identity",
+    id: "external-identity/mermaid-lite-published-version",
+    paths: /^turbo\/packages\/mermaid-lite\/package\.json$/u,
+    reason:
+      "11.16.1-vm0.3 identifies the already published Mermaid-derived build. A source-only rename would claim a package version that was never published and break consumers that select the exact version identity.",
+    tokens: ["1-vm0"],
+  },
+  {
+    category: "external-identity",
+    id: "external-identity/slack-channel-name",
+    paths: /^turbo\/apps\/platform\/src\/views\/okou-page\/ideation-data\.ts$/u,
+    reason:
+      "#all-vm0 is the existing Slack channel named in the workflow prompt. Slack owns that channel identity, so changing the prompt token without renaming the channel makes the generated workflow post to a destination that does not exist.",
+    tokens: ["all-vm0"],
+  },
+  {
+    category: "external-identity",
+    id: "external-identity/developer-container-hostname",
+    paths: /^turbo\/scripts\/test-rebuild-snapshot\.sh$/u,
+    reason:
+      "vm01 is the developer-container hostname and /workspaces/vm01 mount selected by this operator script, matching the same externally configured hostname used by the root dcvnc and dcpf helpers. Renaming only this reference makes the script change into a directory that is not mounted.",
+    tokens: ["vm01"],
+  },
+  {
+    category: "external-identity",
     id: "external-identity/clerk-production-topology",
     reason:
       "The Clerk production instance origin is registered with Clerk and served to browsers; #31813 records it as an external identity.",
@@ -366,6 +390,23 @@ export const RESIDUAL_BRAND_BOUNDARY_OCCURRENCE_RULES = [
   },
   {
     category: "wire-and-persisted-value",
+    id: "wire-and-persisted-value/google-drive-artifact-app-properties",
+    paths:
+      /^turbo\/apps\/api\/src\/signals\/(?:services\/google-drive-artifact-sync\.service\.ts|routes\/__tests__\/(?:chat-threads\.bdd|integrations-slack-upload-complete)\.test\.ts)$/u,
+    reason:
+      "vm0Artifact, vm0ThreadId, vm0RunId, and vm0FileId are appProperties keys written onto files in users' Google Drive accounts. Artifact status lookup queries the first two keys and reads the latter two to recover each run/file pair. Those files live outside every system this repository can migrate, so changing any key makes every previously synced artifact unfindable and causes the sync to upload duplicates; the route tests deliberately spell the persisted keys to prove compatibility with files written by earlier deploys.",
+    tokens: ["vm0Artifact", "vm0FileId", "vm0RunId", "vm0ThreadId"],
+  },
+  {
+    category: "wire-and-persisted-value",
+    id: "wire-and-persisted-value/design-system-resource-id",
+    paths: /^turbo\/packages\/core\/src\/resource-registry\.ts$/u,
+    reason:
+      "atelier-zero is both the persisted design-system:atelier-zero identifier and its published design-systems/atelier-zero source path. Existing resource selections and the published asset cannot be rewritten by changing this registry, so both identity segments must remain exact.",
+    tokens: ["atelier-zero"],
+  },
+  {
+    category: "wire-and-persisted-value",
     id: "wire-and-persisted-value/billing-status-key",
     paths: /^turbo\/packages\/api-contracts\/src\/contracts\/billing\.ts$/u,
     reason:
@@ -397,6 +438,23 @@ export const RESIDUAL_BRAND_BOUNDARY_OCCURRENCE_RULES = [
     tokens: ["VM0", "Vm0", "Zero", "vm0", "zero"],
   },
   {
+    category: "dual-brand-product-contract",
+    id: "dual-brand-product-contract/vm0-brand-mark-component",
+    paths:
+      /^turbo\/apps\/platform\/src\/views\/components\/product-brand-mark\.tsx$/u,
+    reason:
+      "Vm0BrandMark is the VM0 half of ProductBrandMark's live two-brand branch, paired with the Okou wordmark path selected when brandName is not VM0. Its brand discriminator is intentional while VM0 remains supported.",
+    tokens: ["Vm0BrandMark"],
+  },
+  {
+    category: "dual-brand-product-contract",
+    id: "dual-brand-product-contract/vm0-logo-assets",
+    paths: /^turbo\/apps\/platform\/src\//u,
+    reason:
+      "platformVm0LogoImg and platformVm0LogoDarkImg point specifically at the VM0 logo asset files and are selected only for VM0 presentation surfaces. Dropping the discriminator would obscure which live brand asset each constant carries rather than retire a stale prefix.",
+    tokens: ["platformVm0LogoDarkImg", "platformVm0LogoImg"],
+  },
+  {
     category: "protocol-compatibility",
     id: "protocol-compatibility/zero-host-domain",
     line: /ZERO_HOST_DOMAIN/u,
@@ -418,6 +476,22 @@ export const RESIDUAL_BRAND_BOUNDARY_OCCURRENCE_RULES = [
     reason:
       "ZERO_* variables are read from deployed environments and Zero-scope tokens; renaming one is a deployment change owned by #26701 and #28278.",
     tokenPattern: /^ZERO_[A-Z0-9_]+$/u,
+  },
+  {
+    category: "protocol-compatibility",
+    id: "protocol-compatibility/retired-zero-scope-payload",
+    paths: /^turbo\/apps\/api\/src\/signals\/auth\/tokens\.ts$/u,
+    reason:
+      "RetiredZeroScopePayload names the exact retired zero token-scope shape that the test signer keeps reachable so verification can reject legacy tokens. #26701 owns removing that protocol compatibility object; renaming it ahead of the scope would hide what compatibility path the type represents.",
+    tokens: ["RetiredZeroScopePayload"],
+  },
+  {
+    category: "protocol-compatibility",
+    id: "protocol-compatibility/zero-host-domain-property",
+    paths: /^turbo\/apps\/platform\/src\/lib\/platform-host\.ts$/u,
+    reason:
+      "zeroHostDomain carries the deployed sites.vm0.io or sites.vm7.io value corresponding to the ZERO_HOST_DOMAIN protocol contract. #26701 and #28278 own retiring that host contract, so the property keeps naming the compatibility value until the protocol is removed.",
+    tokens: ["zeroHostDomain"],
   },
   {
     category: "desktop-identity",
@@ -442,6 +516,20 @@ export const RESIDUAL_BRAND_BOUNDARY_OCCURRENCE_RULES = [
       "The name uses zero as the number, not as the brand, so a brand rename must leave it alone.",
     tokenPattern:
       /^(?:all-zero|leading-zero|near-zero|non-?zero|non_?zero(?:_[a-z0-9_]+)?|zero-(?:amount|based|budget|cost|credit|filled|height|incident|length|lint|padded|price|quantity|row|size|sized|tolerance|width)|zero-usage|zero(?:Count|OrMore|OrOne)|isNegativeZero|zero100)$/iu,
+  },
+  {
+    category: "semantic-non-brand",
+    id: "semantic-non-brand/numeric-zero-identifiers",
+    reason:
+      "zeroBlock tests that every byte in a tar block equals numeric 0, while checkpointZero records a scheduler checkpoint at the unchanged previous boundary so its measured duration is zero. In both identifiers Zero is the number, not the retired product name.",
+    tokens: ["checkpointZero", "zeroBlock"],
+  },
+  {
+    category: "semantic-non-brand",
+    id: "semantic-non-brand/english-zero-phrases",
+    reason:
+      "zero-copy is the established English term for transferring ownership without copying bytes, and brand-from-zero means building a brand from scratch in an image-style description. Neither phrase uses Zero as a product name.",
+    tokens: ["brand-from-zero", "zero-copy"],
   },
   {
     after:
@@ -823,6 +911,14 @@ export const RESIDUAL_BRAND_BOUNDARY_OCCURRENCE_RULES = [
   },
   {
     category: "immutable-history",
+    id: "immutable-history/retired-zero-page-test-path",
+    paths: /^turbo\/packages\/eslint-rules\/src\/ccstate\/__tests__\//u,
+    reason:
+      "The RuleTester filenames quote the retired signals/zero-page and views/zero-page source layout as historical test inputs. They preserve the path shape that existed when the rules were introduced; live views/zero-page asset keys are separately protected by immutable-static-asset-key/platform-static-asset.",
+    tokens: ["zero-page"],
+  },
+  {
+    category: "immutable-history",
     id: "immutable-history/retired-runner-claim-feature-flag",
     paths: TEST_AND_FIXTURE_PATHS,
     reason:
@@ -1188,63 +1284,6 @@ export const RESIDUAL_BRAND_NAME_BASELINE = [
   ),
   ...baselineNames(
     [
-      "1-vm0",
-      "RetiredZeroScopePayload",
-      "Vm0BrandMark",
-      "ZeroChatEventRowsPage",
-      "ZeroChatEventSendResult",
-      "ZeroChatEventSnapshotResult",
-      "ZeroChatThreadCreateResult",
-      "ZeroChatThreadEventsResult",
-      "ZeroConnectorCatalogListResponse",
-      "ZeroConnectorCatalogStatusResponse",
-      "ZeroConnectorListResponse",
-      "all-vm0",
-      "atelier-zero",
-      "brand-from-zero",
-      "buildVm0OnboardingEntryUrl",
-      "buildZeroCreateAgentRunArgs",
-      "checkpointZero",
-      "createAgentRunAfterZeroPreCreate",
-      "e2e-zero-bot",
-      "isVm0Host",
-      "loadZeroAgent",
-      "measureZeroPreCreate",
-      "platformVm0LogoDarkImg",
-      "platformVm0LogoImg",
-      "reconcileZeroBrowsersWithScope",
-      "talk-to-zero",
-      "vm0-key-anthropic",
-      "vm0-key-default",
-      "vm0-key-moonshot",
-      "vm0-key-runtime-fixture",
-      "vm01",
-      "vm0Artifact",
-      "vm0EditId",
-      "vm0FileId",
-      "vm0HappyDomIframeLoadPatched",
-      "vm0HappyDomIframeNoisePatched",
-      "vm0ImageStyleSource",
-      "vm0NodeId",
-      "vm0OriginalWrite",
-      "vm0RunId",
-      "vm0ThreadId",
-      "vm0_e2e_bot",
-      "withoutLegacyZeroEntries",
-      "zero-copy",
-      "zero-page",
-      "zeroBlock",
-      "zeroHostDomain",
-    ],
-    {
-      ownerIssue: "#31801",
-      reason:
-        "Production TypeScript identifier or platform browser global that no boundary rule approves; #31867 triaged the infrastructure, wire, and db-script names out of this list and #31880 moved the six that cannot be renamed at all into boundary rules, so the follow-up R5 rename slice renames what remains.",
-      workstream: "R5",
-    },
-  ),
-  ...baselineNames(
-    [
       "ClaimedVm0Run",
       "createClaimedVm0Run",
       "createVm0Run",
@@ -1279,12 +1318,21 @@ export const RESIDUAL_BRAND_NAME_BASELINE = [
       "Bare brand literals and stale prose in comments, documentation, and user-facing copy; #31856 classified all 32 names, so every remaining occurrence is either an approved boundary above or was rewritten because it described something that no longer exists.",
     workstream: "R9",
   }),
-  ...baselineNames(["data-vm0", "data-vm0-edit-id", "data-vm0-node-id"], {
-    ownerIssue: "#31824",
-    reason:
-      "Legacy data-vm0-* edit-protocol reader kept for deck HTML that was stored or externally generated before the okou rename; #31824 drops it once no such deck remains.",
-    workstream: "R7",
-  }),
+  ...baselineNames(
+    [
+      "data-vm0",
+      "data-vm0-edit-id",
+      "data-vm0-node-id",
+      "vm0EditId",
+      "vm0NodeId",
+    ],
+    {
+      ownerIssue: "#31824",
+      reason:
+        "Legacy data-vm0-* edit-protocol readers kept for deck HTML that was stored or externally generated before the okou rename; vm0EditId and vm0NodeId name the values read from those legacy attributes. #31824 drops the complete compatibility path once no such deck remains.",
+      workstream: "R7",
+    },
+  ),
   ...baselineNames(["vm0-deck-metadata"], {
     ownerIssue: "#31824",
     reason:
@@ -1296,38 +1344,5 @@ export const RESIDUAL_BRAND_NAME_BASELINE = [
     reason:
       "Fixture id for the row carrying the legacy vm0 built-in-provider discriminator in the provider discriminator migration script, beside vm0Policy and vm0Provider in the same object; R3 renames the Vm0 provider vocabulary in one pass.",
     workstream: "R3",
-  }),
-  ...baselineNames(
-    ["vm0-api-skill", "vm0-api-volume", "vm0-api-volume-validation"],
-    {
-      ownerIssue: "#31801",
-      reason:
-        "#31867 triaged this name and found no boundary: it prefixes a scratch directory the owning service creates under os.tmpdir(), which nothing else reads and which does not outlive the process, so the R5 rename slice renames it with its service.",
-      workstream: "R5",
-    },
-  ),
-  ...baselineNames(["VM0_ONBOARDING_PATH"], {
-    ownerIssue: "#31801",
-    reason:
-      "#31867 triaged this name and found no boundary: it is internal to the module declaring it — the onboarding path constant beside buildVm0OnboardingEntryUrl — so the R5 rename slice renames it with the identifier it sits next to.",
-    workstream: "R5",
-  }),
-  ...baselineNames(["vm0-host"], {
-    ownerIssue: "#31801",
-    reason:
-      "#31880 answered the question #31867 left open, and the answer is that the placeholder is never persisted: vm0-host.invalid is substituted into a throwaway URL only so the firewall base-URL parser in packages/connectors can check syntax and read a port off it. urlForCanonicalBaseSyntax builds that URL from the real base with the host replaced, and every caller reads only protocol, search, hash, and — when the base has no raw authority to substitute into — hostname; the canonical base validateAndCanonicalizeBaseUrl returns and a stored firewall policy freezes is built from canonicalizeAuthorityForExecution on the real authority instead. urlForHostPolicyValidation likewise returns a hostname assembled from the real host segments and only the port string parsed out of the placeholder URL. Nothing carries the literal out of the function, so no stored policy can contain it and the R5 rename slice can take it. The identically spelled /tmp, systemd unit, and lock-directory names in .github/scripts/runner-behavior-host-cpu-fairness.sh are created and torn down inside one script run and are a separate, already approved CI boundary.",
-    workstream: "R5",
-  }),
-  ...baselineNames(["_vm0Cursor"], {
-    ownerIssue: "#31801",
-    reason:
-      "#31880 confirmed that nothing outside this repository can select on it, so the R5 rename slice can take it. _vm0Cursor is not an Axiom dataset field: buildTimeCursorProjection appends `| extend _vm0Cursor = cursor_current()` to the APL the log pagination service itself sends, and the same request reads the alias back off the returned rows. The risk #31842 records for the persisted op-log action types — an external saved query silently mismatching a name this repository changed — does not reach it, because a saved query, dashboard, or monitor elsewhere would have to write that same extend itself to produce the field. The pagination cursor handed to clients encodes only order, timestamp, and tie-breaker value and never the field name, so cursors already issued keep working across the rename.",
-    workstream: "R5",
-  }),
-  ...baselineNames(["vm0-user-linked"], {
-    ownerIssue: "#31801",
-    reason:
-      "#31867 triaged this name and found no boundary: the conflict reason never leaves the API process, the Telegram link route turns it into a message before responding, and no contract, client, or stored row carries the literal; the R5 rename slice renames it with its union.",
-    workstream: "R5",
   }),
 ] as const satisfies readonly ResidualBrandNameBaselineEntry[];


### PR DESCRIPTION
## Summary

- Rename the 33 module-scoped R5 identifiers from #31898 to domain-neutral vocabulary, resolve the conditional `talk-to-zero` item as a safe page-local rename, and disambiguate one unrelated test local that shared the persisted Google Drive key spelling.
- Classify the persisted, external-identity, protocol, dual-brand, historical, and numeral boundaries without weakening any existing rule. The four Google Drive `appProperties` keys remain byte-for-byte unchanged.
- Move `vm0EditId` / `vm0NodeId` to R7 under #31824. `vm0Preference` / `vm0Theme` were assigned to the atomic browser/bootstrap slice under #31899; that slice landed as #31904 while this PR was open, so after rebasing onto it the R5 baseline is now empty.

Closes #31898. Part of #31801, workstream R5c.

## Complete old -> new map

### CLI API domain types

| Old | New |
| --- | --- |
| `ZeroChatEventSnapshotResult` | `ChatEventSnapshotResult` |
| `ZeroChatEventRowsPage` | `ChatEventRowsPage` |
| `ZeroChatThreadCreateResult` | `ChatThreadCreateResult` |
| `ZeroChatEventSendResult` | `ChatEventSendResult` |
| `ZeroChatThreadEventsResult` | `ChatThreadEventsResult` |
| `ZeroConnectorListResponse` | `ConnectorListResponse` |
| `ZeroConnectorCatalogListResponse` | `ConnectorCatalogListResponse` |
| `ZeroConnectorCatalogStatusResponse` | `ConnectorCatalogStatusResponse` |

The imported API-contract `ConnectorListResponse` is locally aliased to `ApiConnectorListResponse` so the newly neutral domain type remains unambiguous.

### API service vocabulary

| Old | New |
| --- | --- |
| `buildZeroCreateAgentRunArgs` | `buildCreateAgentRunArgs` |
| `createAgentRunAfterZeroPreCreate$` | `createAgentRunAfterPreCreate$` |
| `loadZeroAgent` | `loadAgent` |
| `measureZeroPreCreate` | `measureAgentRunPreCreate` |
| `withoutLegacyZeroEntries` | `withoutLegacyAgentRunEnvironmentEntries` |
| `reconcileZeroBrowsersWithScope$` | `reconcileBrowsersWithScope$` |

### Module-scoped neutral names

| Old | New |
| --- | --- |
| `isVm0Host` | `isTrustedFirstPartyHost` |
| `buildVm0OnboardingEntryUrl` | `buildOnboardingEntryUrl` |
| `VM0_ONBOARDING_PATH` | `ONBOARDING_PATH` |
| `vm0ImageStyleSource` | `imageStyleSource` |
| `_vm0Cursor` | `_timeCursor` |
| `vm0-user-linked` | `user-linked` |
| `vm0-api-skill-` | `api-skill-` |
| `vm0-api-volume-` | `api-volume-` |
| `vm0-api-volume-validation` | `api-volume-validation` |
| `vm0-host` | `validation-host` in connector URL placeholders; `runner-host` in the ephemeral CPU-fairness paths/unit |

`isTrustedFirstPartyHost` retains the exact existing `okou.ai`, `vm0.ai`, `vm6.ai`, and `vm7.ai` host checks.

### Test-support names

| Old | New |
| --- | --- |
| `vm0-key-default` | `built-in-key-default` |
| `vm0-key-anthropic` | `built-in-key-anthropic` |
| `vm0-key-moonshot` | `built-in-key-moonshot` |
| `vm0-key-runtime-fixture` | `built-in-key-runtime-fixture` |
| `e2e-zero-bot` | `e2e-test-bot` |
| `vm0_e2e_bot` | `e2e_test_bot` |
| `vm0HappyDomIframeLoadPatched` | `happyDomIframeLoadPatched` |
| `vm0HappyDomIframeNoisePatched` | `happyDomIframeNoisePatched` |
| `vm0OriginalWrite` | `originalWrite` |

### Resolved conditional and homonym

| Old | New | Evidence |
| --- | --- | --- |
| `talk-to-zero` | `custom-workflow` | `CUSTOM_WORKFLOW_ID` only selects onboarding page state and a query parameter; the custom branch completes onboarding and navigates home without creating or persisting a workflow |
| `vm0ThreadId` (the unsupported-model BDD local only) | `invalidModelThreadId` | Prevents the unrelated local from broadening the strict Google Drive persisted-key boundary; the Google Drive key itself is unchanged |

## Boundary classifications

| Rule / class | Names | Why they cannot be renamed here |
| --- | --- | --- |
| Google Drive artifact `appProperties` | `vm0Artifact`, `vm0ThreadId`, `vm0RunId`, `vm0FileId` | Written onto files in users' Google Drive accounts. Lookups require exact keys; changing them would orphan every previously synced artifact and re-upload duplicates. |
| Published package identity | `1-vm0` in `11.16.1-vm0.3` | The Mermaid-derived version is already published outside this repository. |
| Numeric zero | `zeroBlock`, `checkpointZero` | Both mean the number zero, not the retired product brand. |
| Established English | `zero-copy`, `brand-from-zero` | Technical/from-scratch phrases, not brand identifiers. |
| Persisted resource identity | `atelier-zero` | Part of both `design-system:atelier-zero` and its published asset path. |
| External Slack identity | `all-vm0` | Names the existing `#all-vm0` channel. |
| Historical/static asset identity | `zero-page` | Historical RuleTester paths and an immutable `views/zero-page/**` asset key. |
| Dual-brand product contract | `Vm0BrandMark`, `platformVm0LogoImg`, `platformVm0LogoDarkImg` | These intentionally select the VM0 half/assets of live dual-brand presentation. |
| Retired protocol compatibility | `RetiredZeroScopePayload`, `zeroHostDomain` | They name the retired token scope and the deployed `ZERO_HOST_DOMAIN` contract until their owning retirement work removes them. |
| Developer-container identity | `vm01` | The operator script targets the externally configured container hostname and `/workspaces/vm01` mount. |

`brand-from-zero` and `vm01` were also present in the 70-name R5 baseline but omitted from the issue's disposition tables; classifying their actual meanings is required for the acceptance target of only 16 names remaining in R5.

## Ownership moves

| Names | New owner |
| --- | --- |
| `vm0EditId`, `vm0NodeId` | R7 / #31824 with the legacy `data-vm0-*` deck dataset readers |
| `vm0Preference`, `vm0Theme` | Assigned to R5 / #31899 with the atomic `index.html` + worker + build-script bootstrap rename; #31904 has now completed that rename on `main` |

No browser/bootstrap source name is changed by this PR diff, and nothing under `.github/workflows/**` is touched. The concurrent #31904 browser/bootstrap work is present only through the updated `main` base.

## Purity proof

Applying the complete reverse map to the 24 changed product/test files against the rebased `main` restores 22 files byte-for-byte immediately. The remaining two differ only at one Prettier wrap each caused by the longer replacement:

- `apps/api/src/lib/oauth-origin.ts`: the `isTrustedFirstPartyHost` return expression wraps.
- `apps/api/src/signals/services/agent-run-create.service.ts`: one `withoutLegacyAgentRunEnvironmentEntries` call wraps.

Collapsing those two wraps restores all 24/24 files byte-for-byte. The manifest is excluded from this reverse-map comparison because its intended change is the boundary/ownership classification itself.

## Verification

- `pnpm --filter @okouai/eslint-rules exec vitest run scripts/residual-brand-name-inventory.test.ts` — 10/10 passed; the R5 baseline is empty after rebasing onto completed slice #31904.
- Platform auth/onboarding targeted suites — 5 files, 63 tests passed.
- CLI chat/connector domain targeted suites — 5 files, 57 tests passed (with inherited Okou run-context variables unset for test isolation).
- Connector firewall targeted suites — 3 files, 445 tests passed.
- `pnpm --filter api --filter @okouai/cli --filter @okouai/app --filter @okouai/connectors --filter @okouai/core --filter @okouai/eslint-rules run check-types` — passed.
- The same six-package scoped `run lint` — passed.
- `bash -n .github/scripts/runner-behavior-host-cpu-fairness.sh` and `git diff --check` — passed.

The targeted API OAuth-origin/auth and agent-run-create BDD process was attempted, but this environment has no local PostgreSQL listener on port 5432, so setup failed with `ECONNREFUSED` before executing tests (201 skipped). CI supplies the database. For local API BDD execution, the PostgreSQL cluster timezone must be **UTC**.
