### PR TITLE
fix(pi): validate native session parent graphs before traversal

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -212,6 +212,8 @@ import { mailRoutes } from "../mail";
 import { modelProviderGatewayRoutes } from "../model-provider-gateways";
 import { modelProvidersRoutes } from "../model-providers";
 
+import { runInIsolatedProcess } from "../../../../../../scripts/run-isolated-test.mjs";
+
 const TEST_APP_ROUTES = Object.freeze([
   ...chatEventsRoutes,
   ...chatThreadRoutes,
@@ -10353,7 +10355,106 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(claim.status).toBe(404);
   }, 90_000);
 
+  it("rejects cyclic Pi H0 before provider or fallback and resumes valid history later", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) {
+      return;
+    }
+    const { actor, agentId } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected entitled chat actor to have an org");
+    }
+    await configureBuiltInPiModel(actor, "deepseek-v4-flash");
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    mockPiResourceArchiveDownloads();
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.deepseek.com/responses", () => {
+        modelCalls += 1;
+        return new HttpResponse(
+          piResponsesTextSse("canonical H0 answer", modelCalls),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const first = await sendChatRun(actor, {
+      agentId,
+      prompt: "create canonical Pi H0",
+      model: "deepseek-v4-flash",
+    });
+    await waitForRunStatus(actor, first.runId, "completed");
+    await flushWaitUntilForTest();
+    expect(modelCalls).toBe(1);
+    const bindingBeforeFailure = await readThreadSessionBinding(
+      context,
+      first.threadId,
+    );
+    const firstSessionBytes = checkpointObjects.get(
+      [...checkpointObjects.keys()].find((key) => {
+        return key.includes("/blobs/");
+      }) ?? "missing-canonical-pi-blob",
+    );
+    if (!firstSessionBytes) {
+      throw new Error("Expected the first Pi run to persist native H1");
+    }
+    const cyclicH0 = `${firstSessionBytes.toString("utf8")}${JSON.stringify({ type: "model_change", id: "cycle", parentId: "cycle", timestamp: "2026-09-05T00:00:00.000Z", provider: "openai", modelId: "gpt-5.6-terra" })}\n`;
+    // A cyclic canonical H0 cannot be written through today's validated
+    // checkpoint API; seed this historical corruption at the existing fixture.
+    const h0Hash = await replacePiSessionHistoryJsonlFixture({
+      runId: first.runId,
+      jsonl: cyclicH0,
+    });
+    checkpointObjects.set(
+      `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${h0Hash}.blob`,
+      Buffer.from(cyclicH0, "utf8"),
+    );
+
+    const second = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "must not reach the model",
+    });
+    await waitForRunStatus(actor, second.runId, "failed");
+    await flushWaitUntilForTest();
+    expect((await api.readRun(actor, second.runId)).error).toContain(
+      "[PI_H0_JSONL_INVALID]",
+    );
+    expect(modelCalls).toBe(1);
+    await expect(
+      readThreadSessionBinding(context, first.threadId),
+    ).resolves.toStrictEqual({
+      ...bindingBeforeFailure,
+      agent_session_run_id: second.runId,
+    });
+    expect(
+      checkpointObjects.has(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${second.runId}/manifest.json`,
+      ),
+    ).toBeFalsy();
+    const claim = await api.requestClaimRunnerJob(true, second.runId, [404]);
+    expect(claim.status).toBe(404);
+    await replacePiSessionHistoryJsonlFixture({
+      runId: first.runId,
+      jsonl: firstSessionBytes.toString("utf8"),
+    });
+    const third = await sendChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "resume valid history",
+    });
+    await waitForRunStatus(actor, third.runId, "completed");
+    await flushWaitUntilForTest();
+    expect(modelCalls).toBe(2);
+  }, 150_000);
+
   it("publishes OpenRouter Responses blocks, hands tools to H2, and checkpoints Pi memory notes", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) {
+      return;
+    }
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const orgId = requireOrgId(actor);
     const usagePricingResolution = await createTerraUsagePricingResolution();
@@ -10974,6 +11075,47 @@ describe("CHAT-02: model-first provider policies", () => {
       })
       .toBe(true);
     const failedClaim = await claimChatRun(runnerGroup, failedHandoff.runId);
+    const cyclicH2 = Buffer.from(
+      `${h2}${JSON.stringify({ type: "model_change", id: "cycle", parentId: "cycle", timestamp: "2026-09-05T00:00:00.000Z", provider: "openai", modelId: "gpt-5.6-terra" })}\n`,
+      "utf8",
+    );
+    const cyclicH2Hash = createHash("sha256").update(cyclicH2).digest("hex");
+    await webhooks.requestAgentCheckpointPrepareHistory(
+      {
+        runId: failedHandoff.runId,
+        hash: cyclicH2Hash,
+        rawSize: cyclicH2.length,
+        encodedSize: cyclicH2.length,
+        encoding: "identity",
+      },
+      failedClaim.sandboxHeaders,
+      [200],
+    );
+    checkpointObjects.set(
+      `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${cyclicH2Hash}.blob`,
+      cyclicH2,
+    );
+    const cyclicCheckpoint = await webhooks.requestAgentComplete(
+      {
+        runId: failedHandoff.runId,
+        exitCode: 1,
+        error: "reject cyclic native checkpoint",
+        checkpoint: {
+          cliAgentType: "pi",
+          cliAgentSessionId: run.threadId,
+          cliAgentSessionHistoryHash: cyclicH2Hash,
+        },
+      },
+      failedClaim.sandboxHeaders,
+      [400],
+    );
+    expect(JSON.stringify(cyclicCheckpoint.body)).toContain(
+      "[PI_H2_JSONL_INVALID]",
+    );
+    await expect(
+      readThreadSessionConversation(context, run.threadId),
+    ).resolves.toStrictEqual(canonicalConversation);
+    expect(modelCalls).toBe(2);
     const invalidH2 = Buffer.from(`${h2}{malformed\n`, "utf8");
     const invalidH2Hash = createHash("sha256").update(invalidH2).digest("hex");
     await webhooks.requestAgentCheckpointPrepareHistory(
@@ -11299,7 +11441,7 @@ describe("CHAT-02: model-first provider policies", () => {
       [200],
     );
     expect(repeatedCombinedH2.body).toStrictEqual(combinedH2.body);
-  }, 90_000);
+  }, 150_000);
 
   it("routes DeepSeek V4 Flash through the native Responses adapter", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-memory-stage1-worker.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-memory-stage1-worker.test.ts
@@ -31,6 +31,8 @@ import {
   testPiMemoryStage1StateRoutes,
 } from "../test-pi-memory-stage1-state";
 
+import { runInIsolatedProcess } from "../../../../../../scripts/run-isolated-test.mjs";
+
 const context = testContext();
 const BUCKET = "pi-memory-stage1-worker-test";
 const CRON_SECRET = "test-pi-memory-stage1-secret";
@@ -673,7 +675,10 @@ describe("Pi memory Stage 1 worker", () => {
     expect(serializedLogs).not.toContain(OUTPUT_SECRET);
   });
 
-  it("isolates malformed, future, wrong-session, and unsettled sources before the provider", async () => {
+  it("isolates malformed and cyclic sources permanently before the provider", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) {
+      return;
+    }
     const storage = createStorageFixture();
     const futureId = randomUUID();
     const wrongExpectedId = randomUUID();
@@ -711,6 +716,29 @@ describe("Pi memory Stage 1 worker", () => {
         raw: Buffer.from(unsettled.toJsonl(), "utf8"),
       }),
     ];
+    for (const duplicate of [false, true]) {
+      const id = randomUUID();
+      const history = settledHistory(id, "invalid graph candidate").toString(
+        "utf8",
+      );
+      const record = JSON.stringify({
+        type: "model_change",
+        id: "graph-entry",
+        parentId: duplicate ? null : "graph-entry",
+        timestamp: "2026-09-05T00:00:00.000Z",
+        provider: "openai",
+        modelId: "gpt-5.6-terra",
+      });
+      invalid.push(
+        await storage.seed({
+          piSessionId: id,
+          raw: Buffer.from(
+            `${history}${record}\n${duplicate ? `${record}\n` : ""}`,
+            "utf8",
+          ),
+        }),
+      );
+    }
     const validId = randomUUID();
     const valid = await storage.seed({
       piSessionId: validId,
@@ -719,9 +747,9 @@ describe("Pi memory Stage 1 worker", () => {
     const provider = installProvider();
 
     await expect(runScoped(storage)).resolves.toMatchObject({
-      claimed: 5,
+      claimed: 7,
       succeeded: 1,
-      terminalFailure: 4,
+      terminalFailure: 6,
     });
     expect(provider.calls).toHaveLength(1);
     for (const fixture of invalid) {
@@ -733,7 +761,7 @@ describe("Pi memory Stage 1 worker", () => {
     await expect(inspect(valid)).resolves.toMatchObject({
       status: "succeeded",
     });
-  });
+  }, 150_000);
 
   it("fences concurrent claims and stale workers while recording both provider usages", async () => {
     const storage = createStorageFixture();

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.test.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,11 +12,15 @@ import {
 import { MAX_EVENT_SEQUENCE_NUMBER } from "@okouai/api-contracts/contracts/runs";
 import { MemoryPiSession } from "@okouai/pi-agent-runtime/node";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/server";
 
 import {
   resolvePiApiFirstTurnHandoff,
   type HandoffRuntime,
 } from "./pi-api-first-turn-handoff";
+
+import { runInIsolatedProcess } from "../../../../scripts/run-isolated-test.mjs";
 
 const SESSION_ID = "11111111-1111-4111-8111-111111111111";
 const H0_HASH = "b".repeat(64);
@@ -639,3 +643,64 @@ describe("Pi API first-turn handoff loader", () => {
     expect(cancel).toHaveBeenCalledOnce();
   });
 });
+
+it("rejects cyclic and duplicate downloaded histories without replacing installed bytes", async () => {
+  if (await runInIsolatedProcess(import.meta.url)) {
+    return;
+  }
+  const directory = await mkdtemp(join(tmpdir(), "pi-handoff-invalid-"));
+  temporaryDirectories.push(directory);
+  const sessionFile = join(directory, `api-first-turn-${SESSION_ID}.jsonl`);
+  await writeFile(sessionFile, HANDOFF_SESSION_JSONL);
+  for (const mode of [
+    "sandbox-first",
+    "pending-tool-continuation",
+    "settled-session-continuation",
+  ] as const) {
+    for (const duplicate of [false, true]) {
+      const record = JSON.stringify({
+        type: "model_change",
+        id: "graph-entry",
+        parentId: duplicate ? null : "graph-entry",
+        timestamp: "2026-09-05T00:00:00.000Z",
+        provider: "openai",
+        modelId: "gpt-5.6-terra",
+      });
+      const history = `${HANDOFF_SESSION_JSONL}${record}\n${duplicate ? `${record}\n` : ""}`;
+      server.use(
+        http.get("https://handoff.example/manifest.json", () => {
+          return HttpResponse.json(manifestV3(history, mode, 4));
+        }),
+        http.get("https://handoff.example/session.jsonl", () => {
+          return new HttpResponse(history);
+        }),
+      );
+      await expect(
+        resolvePiApiFirstTurnHandoff({
+          config: config(5_000),
+          sessionDir: directory,
+          sessionId: SESSION_ID,
+          runtime: fixedRuntime(fetch),
+        }),
+      ).rejects.toMatchObject({ code: "PI_HANDOFF_H1_INVALID" });
+      expect(await readFile(sessionFile, "utf8")).toBe(HANDOFF_SESSION_JSONL);
+    }
+  }
+  server.use(
+    http.get("https://handoff.example/manifest.json", () => {
+      return HttpResponse.json(manifest(HANDOFF_SESSION_JSONL));
+    }),
+    http.get("https://handoff.example/session.jsonl", () => {
+      return new HttpResponse(HANDOFF_SESSION_JSONL);
+    }),
+  );
+  await expect(
+    resolvePiApiFirstTurnHandoff({
+      config: config(5_000),
+      sessionDir: directory,
+      sessionId: SESSION_ID,
+      runtime: fixedRuntime(fetch),
+    }),
+  ).resolves.toMatchObject({ sessionFile });
+  expect(await readFile(sessionFile, "utf8")).toBe(HANDOFF_SESSION_JSONL);
+}, 150_000);

--- a/turbo/packages/pi-agent-runtime/src/rpc.ts
+++ b/turbo/packages/pi-agent-runtime/src/rpc.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import type {
   AssistantMessage,
   Message,
@@ -13,6 +15,10 @@ import {
   type CreateAgentSessionRuntimeFactory,
 } from "@earendil-works/pi-coding-agent";
 
+import {
+  parseValidatedPiSessionJsonl,
+  validatePiSessionEntries,
+} from "./session-validation";
 import { createPiAgentSessionForRuntime } from "./session-runtime";
 import type {
   PiMemoryRecallOutcome,
@@ -26,12 +32,22 @@ export type PiSandboxOwnershipTransferMode =
   | "pending-tool-continuation"
   | "settled-session-continuation";
 
-async function resolveSessionManager(args: {
+function resolveSessionManager(args: {
   readonly cwd: string;
   readonly sessionDir: string;
   readonly sessionId: string;
   readonly sessionFile: string;
-}): Promise<SessionManager> {
+}): SessionManager {
+  // Keep the read, validation and SDK open synchronous: opening can migrate
+  // and rewrite a legacy file. Reject invalid bytes and identity before that.
+  const { header } = parseValidatedPiSessionJsonl(
+    new TextDecoder("utf-8", { fatal: true }).decode(
+      readFileSync(args.sessionFile),
+    ),
+  );
+  if (header.id !== args.sessionId) {
+    throw new Error("Pi handoff session id does not match the launch session");
+  }
   const sessionManager = SessionManager.open(
     args.sessionFile,
     args.sessionDir,
@@ -40,6 +56,8 @@ async function resolveSessionManager(args: {
   if (sessionManager.getSessionId() !== args.sessionId) {
     throw new Error("Pi handoff session id does not match the launch session");
   }
+  // Validate the actual SDK-loaded entries before any context traversal, too.
+  validatePiSessionEntries(sessionManager.getEntries());
   return sessionManager;
 }
 
@@ -241,7 +259,7 @@ export async function runPiOfficialRpcMode(args: {
   readonly ownershipTransferMode: PiSandboxOwnershipTransferMode;
 }): Promise<never> {
   const createRuntime = createRuntimeFactory(args);
-  const sessionManager = await resolveSessionManager(args);
+  const sessionManager = resolveSessionManager(args);
   const runtime = await createAgentSessionRuntime(createRuntime, {
     cwd: args.cwd,
     agentDir: args.agentDir,

--- a/turbo/packages/pi-agent-runtime/src/session-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-memory.ts
@@ -16,15 +16,13 @@ import {
   buildSessionContext,
   convertToLlm,
   CURRENT_SESSION_VERSION,
-  migrateSessionEntries,
-  parseSessionEntries,
   type FileEntry,
   type SessionContext,
   type SessionEntry,
   type SessionHeader,
 } from "@earendil-works/pi-coding-agent";
 
-import { UnsupportedPiSessionVersionError } from "./errors";
+import { parseValidatedPiSessionJsonl } from "./session-validation";
 import type { PiApiFirstTurnOwnership } from "./provider-ownership";
 import type { PiAgentStreamOptions } from "./stream-options";
 
@@ -73,27 +71,12 @@ type NewMemorySessionEntry =
 // that has messages but no explicit thinking_level_change entry.
 const PI_DEFAULT_THINKING_LEVEL: ModelThinkingLevel = "medium";
 
-function assertSessionHeader(entry: FileEntry | undefined): SessionHeader {
-  if (entry?.type !== "session" || typeof entry.id !== "string") {
-    throw new Error("Pi session JSONL must start with a session header");
-  }
-  return entry;
-}
-
 function serializeFileEntries(entries: readonly FileEntry[]): string {
   return `${entries
     .map((entry) => {
       return JSON.stringify(entry);
     })
     .join("\n")}\n`;
-}
-
-function assertStrictJsonl(jsonl: string): void {
-  for (const line of jsonl.split("\n")) {
-    if (line.trim()) {
-      JSON.parse(line);
-    }
-  }
 }
 
 function generateEntryId(existingIds: ReadonlySet<string>): string {
@@ -137,27 +120,8 @@ export class MemoryPiSession {
   }
 
   static fromJsonl(jsonl: string): MemoryPiSession {
-    // Pi's exported parser intentionally skips malformed lines so an
-    // interactive local session can recover. Checkpoint boundaries cannot do
-    // that: silently dropping one line would change the canonical history.
-    assertStrictJsonl(jsonl);
-    const entries = parseSessionEntries(jsonl);
-    const header = assertSessionHeader(entries[0]);
-    if (
-      header.version !== undefined &&
-      header.version > CURRENT_SESSION_VERSION
-    ) {
-      throw new UnsupportedPiSessionVersionError(
-        `Pi session version ${header.version} is newer than supported version ${CURRENT_SESSION_VERSION}`,
-      );
-    }
-    migrateSessionEntries(entries);
-    if (header.version !== CURRENT_SESSION_VERSION) {
-      throw new UnsupportedPiSessionVersionError(
-        "Pi session could not be migrated to the current version",
-      );
-    }
-    return new MemoryPiSession(header, entries.slice(1) as SessionEntry[]);
+    const { header, entries } = parseValidatedPiSessionJsonl(jsonl);
+    return new MemoryPiSession(header, entries);
   }
 
   appendMessage(message: Message): string {

--- a/turbo/packages/pi-agent-runtime/src/session-validation.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-validation.test.ts
@@ -1,0 +1,336 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import { runInIsolatedProcess } from "../../../scripts/run-isolated-test.mjs";
+import { inspectPiSessionJsonl, projectPiMemoryStage1History } from "./api";
+import { runPiOfficialRpcMode } from "./rpc";
+import { MemoryPiSession } from "./session-memory";
+import { UnsupportedPiSessionVersionError } from "./errors";
+
+const SESSION_ID = "synthetic-session";
+const header = {
+  type: "session",
+  version: 3,
+  id: SESSION_ID,
+  timestamp: "2026-09-05T00:00:00.000Z",
+  cwd: "/workspace",
+};
+function jsonl(
+  entries: readonly unknown[],
+  version: number | null = 3,
+): string {
+  return (
+    [{ ...header, version: version ?? undefined }, ...entries]
+      .map((record) => {
+        return JSON.stringify(record);
+      })
+      .join("\n") + "\n"
+  );
+}
+function entry(id: string, parentId: string | null) {
+  return {
+    type: "model_change",
+    id,
+    parentId,
+    timestamp: header.timestamp,
+    provider: "openai",
+    modelId: "gpt-5.6-terra",
+  };
+}
+const cycles = [
+  [entry("self", "self")],
+  [entry("a", "b"), entry("b", "a")],
+  [entry("a", "b"), entry("b", "c"), entry("c", "a")],
+  [entry("a", "b"), entry("b", "a"), entry("active", null)],
+];
+
+describe("native Pi history structural boundaries", () => {
+  it("rejects cycles in every component before API inspection and Stage 1 projection", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) {
+      return;
+    }
+    for (const entries of cycles) {
+      const history = jsonl(entries);
+      expect(() => {
+        return inspectPiSessionJsonl(history);
+      }).toThrow("Pi session parent graph contains a cycle");
+      expect(() => {
+        return projectPiMemoryStage1History({
+          jsonl: history,
+          expectedSessionId: SESSION_ID,
+        });
+      }).toThrow("Pi session parent graph contains a cycle");
+    }
+  }, 150_000);
+  it.each([
+    {
+      entries: [entry("a", null), entry("a", null)],
+      error: "duplicate entry ids",
+    },
+    { entries: [entry("", null)], error: "nonempty string" },
+    { entries: [{ ...entry("a", null), id: 42 }], error: "nonempty string" },
+    {
+      entries: [{ type: "extension", parentId: null }],
+      error: "nonempty string",
+    },
+    {
+      entries: [{ type: "extension", id: "a" }],
+      error: "parentId must be null or a string",
+    },
+    {
+      entries: [{ ...entry("a", null), parentId: {} }],
+      error: "parentId must be null or a string",
+    },
+    { entries: [header], error: "exactly one session header" },
+    ...[null, [], 0, false, "private source"].map((record) => {
+      return {
+        entries: [record],
+        error: "records must be objects",
+      };
+    }),
+  ])("rejects malformed structure ($error)", ({ entries, error }) => {
+    expect(() => {
+      return inspectPiSessionJsonl(jsonl(entries));
+    }).toThrow(error);
+  });
+  it("sanitizes malformed JSON errors and retains future-version classification", () => {
+    expect(() => {
+      return inspectPiSessionJsonl(`${jsonl([])}private source`);
+    }).toThrow(
+      new SyntaxError("Pi session JSONL contains an invalid JSON record"),
+    );
+    expect(() => {
+      return inspectPiSessionJsonl(jsonl([], 999));
+    }).toThrow(UnsupportedPiSessionVersionError);
+    expect(() => {
+      return inspectPiSessionJsonl(JSON.stringify(entry("a", null)));
+    }).toThrow("must start with a session header");
+  });
+  it("validates deep chains and wide branching iteratively", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) {
+      return;
+    }
+    const entries = Array.from({ length: 30_000 }, (_, index) => {
+      return entry(`deep-${index}`, index === 0 ? null : `deep-${index - 1}`);
+    });
+    entries.reverse();
+    entries.push(
+      ...Array.from({ length: 30_000 }, (_, index) => {
+        return entry(`wide-${index}`, "deep-29999");
+      }),
+    );
+    expect(inspectPiSessionJsonl(jsonl(entries))).toStrictEqual({
+      sessionId: SESSION_ID,
+      messageCount: 0,
+      hasPendingToolCalls: false,
+      isSettledCheckpoint: false,
+    });
+  }, 150_000);
+  it.each([null, 1, 2])(
+    "preserves official legacy migration for version %s",
+    (version) => {
+      const history = jsonl(
+        [
+          {
+            type: "message",
+            ...(version === 2 ? { id: "legacy", parentId: null } : {}),
+            timestamp: header.timestamp,
+            message: {
+              role: "hookMessage",
+              customType: "legacy-extension",
+              content: "legacy custom",
+              display: true,
+              timestamp: 1,
+              extra: { preserved: true },
+            },
+          },
+          {
+            type: "message",
+            ...(version === 2 ? { id: "answer", parentId: "legacy" } : {}),
+            timestamp: header.timestamp,
+            message: {
+              ...fauxAssistantMessage("legacy answer"),
+              legacyField: "preserved",
+            },
+          },
+        ],
+        version,
+      );
+      const migrated = MemoryPiSession.fromJsonl(history);
+      expect(migrated.getHeader()).toMatchObject({
+        id: SESSION_ID,
+        version: 3,
+      });
+      expect(migrated.buildSessionContext().messages).toMatchObject([
+        { role: "custom", extra: { preserved: true } },
+        { role: "assistant", legacyField: "preserved" },
+      ]);
+      expect(migrated.isSettledCheckpoint()).toBe(true);
+    },
+  );
+  it("preserves SDK multiple roots, branches, labels, compaction and custom records", () => {
+    const native = SessionManager.inMemory("/workspace", { id: SESSION_ID });
+    const root = native.appendMessage({
+      role: "user",
+      content: "first root",
+      timestamp: 1,
+    });
+    native.appendMessage(fauxAssistantMessage("abandoned branch"));
+    native.branch(root);
+    native.appendCustomEntry("extension", { preserved: [1, 2] });
+    native.appendLabelChange(root, "branch label");
+    native.resetLeaf();
+    const kept = native.appendMessage({
+      role: "user",
+      content: "new root",
+      timestamp: 2,
+    });
+    native.appendCompaction("summary", kept, 100, { preserved: true });
+    native.appendMessage(fauxAssistantMessage("compacted answer"));
+    native.branchWithSummary(null, "root summary", { preserved: true });
+    native.appendSessionInfo("session title");
+    native.appendMessage(
+      fauxAssistantMessage("active answer", { stopReason: "length" }),
+    );
+    const history =
+      [native.getHeader(), ...native.getEntries()]
+        .map((record) => {
+          return JSON.stringify(record);
+        })
+        .join("\n") + "\n";
+    const memory = MemoryPiSession.fromJsonl(history);
+    expect(memory.toJsonl()).toBe(history);
+    expect(memory.buildSessionContext()).toEqual(
+      JSON.parse(JSON.stringify(native.buildSessionContext())),
+    );
+    expect(memory.isSettledCheckpoint()).toBe(true);
+  });
+  it("preserves legacy null message content through the official projection", () => {
+    const history = jsonl([
+      {
+        ...entry("answer", null),
+        type: "message",
+        message: { ...fauxAssistantMessage("legacy"), content: null },
+      },
+    ]);
+    const memory = MemoryPiSession.fromJsonl(history);
+    expect(memory.toJsonl()).toBe(history);
+    expect(memory.buildSessionContext().messages).toMatchObject([
+      { role: "assistant", content: [] },
+    ]);
+    expect(inspectPiSessionJsonl(history)).toMatchObject({
+      messageCount: 1,
+      isSettledCheckpoint: true,
+    });
+  });
+
+  it("preserves orphans, forward references and non-parent reference namespaces", () => {
+    const history = jsonl([
+      {
+        ...entry("child", "parent"),
+        type: "extension",
+        targetId: "child",
+        fromId: "child",
+      },
+      entry("parent", "missing"),
+      entry(SESSION_ID, null),
+      {
+        ...entry("answer", "child"),
+        type: "message",
+        message: fauxAssistantMessage("forward branch"),
+      },
+    ]);
+    const memory = MemoryPiSession.fromJsonl(history);
+    expect(memory.toJsonl()).toBe(history);
+    expect(
+      memory.getBranchEntries().map((record) => {
+        return record.id;
+      }),
+    ).toEqual(["parent", "child", "answer"]);
+    expect(memory.buildSessionContext().messages).toMatchObject([
+      { role: "assistant" },
+    ]);
+    expect(inspectPiSessionJsonl(jsonl([]))).toMatchObject({
+      messageCount: 0,
+      isSettledCheckpoint: false,
+    });
+  });
+  it("rejects direct persisted RPC startup before rewriting files or executing runtime work", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) {
+      return;
+    }
+    const directory = await mkdtemp(join(tmpdir(), "pi-invalid-rpc-"));
+    const sessionFile = join(directory, "session.jsonl");
+    const args = {
+      sessionId: SESSION_ID,
+      sessionFile,
+      sessionDir: directory,
+      cwd: directory,
+      agentDir: join(directory, "agent"),
+      appendSystemPrompt: null,
+      ownershipTransferMode: "sandbox-first" as const,
+      model: {
+        provider: "openai",
+        model: "gpt-5.6-terra",
+        dialect: "openai-responses" as const,
+        apiKey: "synthetic-key",
+        baseUrl: "http://127.0.0.1:1",
+      },
+    };
+    try {
+      for (const version of [2, 3]) {
+        for (const entries of cycles) {
+          const history = jsonl(entries, version);
+          await writeFile(sessionFile, history);
+          await expect(runPiOfficialRpcMode(args)).rejects.toThrow(
+            "Pi session parent graph contains a cycle",
+          );
+          expect(await readFile(sessionFile, "utf8")).toBe(history);
+        }
+      }
+      for (const { history, error } of [
+        {
+          history: jsonl([entry("a", null), entry("a", null)], 2),
+          error: "duplicate entry ids",
+        },
+        { history: jsonl([null], 1), error: "records must be objects" },
+        { history: jsonl([], 999), error: "newer than supported" },
+        {
+          history: jsonl([], 1).replace(SESSION_ID, "wrong-session"),
+          error: "session id does not match",
+        },
+      ]) {
+        await writeFile(sessionFile, history);
+        await expect(runPiOfficialRpcMode(args)).rejects.toThrow(error);
+        expect(await readFile(sessionFile, "utf8")).toBe(history);
+      }
+      const valid = jsonl([entry("a", null)]);
+      await writeFile(sessionFile, valid);
+      // Fault-inject the third-party load result to prove runtime validates
+      // the entries it receives, independently of the earlier byte check.
+      const open = SessionManager.open.bind(SessionManager);
+      const spy = vi
+        .spyOn(SessionManager, "open")
+        .mockImplementation((...openArgs) => {
+          const manager = open(...openArgs);
+          const loaded = manager.getEntries()[0];
+          if (!loaded) throw new Error("Expected a loaded entry");
+          loaded.parentId = loaded.id;
+          return manager;
+        });
+      try {
+        await expect(runPiOfficialRpcMode(args)).rejects.toThrow(
+          "Pi session parent graph contains a cycle",
+        );
+        expect(await readFile(sessionFile, "utf8")).toBe(valid);
+      } finally {
+        spy.mockRestore();
+      }
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }, 150_000);
+});

--- a/turbo/packages/pi-agent-runtime/src/session-validation.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-validation.ts
@@ -1,0 +1,110 @@
+import {
+  CURRENT_SESSION_VERSION,
+  migrateSessionEntries,
+  parseSessionEntries,
+  type SessionEntry,
+  type SessionHeader,
+} from "@earendil-works/pi-coding-agent";
+
+import { UnsupportedPiSessionVersionError } from "./errors";
+
+function assertStrictJsonl(jsonl: string): void {
+  for (const line of jsonl.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    let entry: unknown;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      // JSON.parse errors can include source text. History errors must not.
+      throw new SyntaxError("Pi session JSONL contains an invalid JSON record");
+    }
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new Error("Pi session JSONL records must be objects");
+    }
+  }
+}
+
+/** Validate every parent component without restricting Pi's extension payloads. */
+export function validatePiSessionEntries(
+  entries: readonly SessionEntry[],
+): void {
+  const parents = new Map<string, string | null>();
+  for (const entry of entries) {
+    if (typeof entry.id !== "string" || entry.id.length === 0) {
+      throw new Error("Pi session entry id must be a nonempty string");
+    }
+    if (parents.has(entry.id)) {
+      throw new Error("Pi session contains duplicate entry ids");
+    }
+    if (entry.parentId !== null && typeof entry.parentId !== "string") {
+      throw new Error("Pi session entry parentId must be null or a string");
+    }
+    parents.set(entry.id, entry.parentId);
+  }
+
+  const visited = new Set<string>();
+  const complete = new Set<string>();
+  for (const id of parents.keys()) {
+    const path: string[] = [];
+    let current: string | null | undefined = id;
+    // Multiple roots, forward references and missing-parent termination are
+    // official Pi semantics. Only parentId is an edge, not other references.
+    while (current !== null && current !== undefined && parents.has(current)) {
+      if (complete.has(current)) {
+        break;
+      }
+      if (visited.has(current)) {
+        throw new Error("Pi session parent graph contains a cycle");
+      }
+      visited.add(current);
+      path.push(current);
+      current = parents.get(current);
+    }
+    for (const entryId of path) {
+      complete.add(entryId);
+    }
+  }
+}
+
+/** Keep strict checkpoint parsing around the pinned SDK's official migrations. */
+export function parseValidatedPiSessionJsonl(jsonl: string): {
+  readonly header: SessionHeader;
+  readonly entries: SessionEntry[];
+} {
+  // The SDK parser skips malformed lines for interactive recovery. Canonical
+  // checkpoint boundaries cannot silently drop records.
+  assertStrictJsonl(jsonl);
+  const fileEntries = parseSessionEntries(jsonl);
+  const header = fileEntries[0];
+  if (header?.type !== "session" || typeof header.id !== "string") {
+    throw new Error("Pi session JSONL must start with a session header");
+  }
+  const entries: SessionEntry[] = [];
+  for (const entry of fileEntries.slice(1)) {
+    if (entry.type === "session") {
+      throw new Error(
+        "Pi session JSONL must contain exactly one session header",
+      );
+    }
+    entries.push(entry);
+  }
+  if (
+    header.version !== undefined &&
+    header.version > CURRENT_SESSION_VERSION
+  ) {
+    throw new UnsupportedPiSessionVersionError(
+      `Pi session version is newer than supported version ${CURRENT_SESSION_VERSION}`,
+    );
+  }
+  // v1 entries do not have graph fields until Pi migrates them.
+  migrateSessionEntries(fileEntries);
+  if (header.version !== CURRENT_SESSION_VERSION) {
+    throw new UnsupportedPiSessionVersionError(
+      "Pi session could not be migrated to the current version",
+    );
+  }
+  validatePiSessionEntries(entries);
+  return { header, entries };
+}

--- a/turbo/scripts/run-isolated-test.d.mts
+++ b/turbo/scripts/run-isolated-test.d.mts
@@ -1,0 +1,1 @@
+export function runInIsolatedProcess(testFileUrl: string): Promise<boolean>;

--- a/turbo/scripts/run-isolated-test.mjs
+++ b/turbo/scripts/run-isolated-test.mjs
@@ -8,8 +8,7 @@ import { expect, onTestFinished } from "vitest";
 
 /**
  * Return true after the owned child has executed this test's assertions.
- * @param {string} testFileUrl
- * @returns {Promise<boolean>}
+ * @type {typeof import("./run-isolated-test.d.mts").runInIsolatedProcess}
  */
 export async function runInIsolatedProcess(testFileUrl) {
   const fullName = expect.getState().currentTestName;
@@ -58,7 +57,7 @@ export async function runInIsolatedProcess(testFileUrl) {
       maxBuffer: 10 * 1024 * 1024,
     },
   );
-  // Nonzero exits/timeouts throw; a zero-test probe cannot pass either.
+  // Nonzero exits/timeouts throw; a probe that selects no tests fails too.
   expect(stdout).toContain("OKOU_ISOLATED_TEST_COMPLETED");
   return true;
 }

--- a/turbo/scripts/run-isolated-test.mjs
+++ b/turbo/scripts/run-isolated-test.mjs
@@ -1,0 +1,64 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { expect, onTestFinished } from "vitest";
+
+/**
+ * Return true after the owned child has executed this test's assertions.
+ * @param {string} testFileUrl
+ * @returns {Promise<boolean>}
+ */
+export async function runInIsolatedProcess(testFileUrl) {
+  const fullName = expect.getState().currentTestName;
+  if (!fullName) {
+    throw new Error("Expected an active isolated test");
+  }
+  if (process.env.OKOU_ISOLATED_TEST_NAME === fullName) {
+    onTestFinished(() => {
+      process.stdout.write("OKOU_ISOLATED_TEST_COMPLETED\n");
+    });
+    return false;
+  }
+  const testFile = fileURLToPath(testFileUrl);
+  let cwd = dirname(testFile);
+  while (!existsSync(join(cwd, "vitest.config.ts"))) {
+    const parent = dirname(cwd);
+    if (parent === cwd) {
+      throw new Error("Isolated test has no workspace Vitest config");
+    }
+    cwd = parent;
+  }
+  // Vitest displays suites with " > " but filters them joined by spaces.
+  const pattern = fullName
+    .replaceAll(" > ", " ")
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // A same-thread timeout cannot interrupt synchronous traversal. Threads
+  // keep the probe in one child process, fully stopped by its kill deadline.
+  const { stdout } = await promisify(execFile)(
+    process.execPath,
+    [
+      fileURLToPath(
+        new URL("../node_modules/vitest/vitest.mjs", import.meta.url),
+      ),
+      "run",
+      testFile,
+      "--pool=threads",
+      "--maxWorkers=1",
+      "--testNamePattern",
+      `^${pattern}$`,
+    ],
+    {
+      cwd,
+      env: { ...process.env, OKOU_ISOLATED_TEST_NAME: fullName },
+      timeout: 120_000,
+      killSignal: "SIGKILL",
+      maxBuffer: 10 * 1024 * 1024,
+    },
+  );
+  // Nonzero exits/timeouts throw; a zero-test probe cannot pass either.
+  expect(stdout).toContain("OKOU_ISOLATED_TEST_COMPLETED");
+  return true;
+}


### PR DESCRIPTION
A hash-correct native Pi history can contain cyclic parent links and synchronously hang H0/H2 inspection or persisted RPC startup. Validate every parent component in iterative O(n) time before traversal, rejecting duplicate IDs and malformed structure with sanitized errors.

The shared parser retains Pi 0.84.1's official migrations and valid multiple roots, orphan termination, forward references, extension payloads, branch metadata, and existing settled/pending semantics. RPC startup validates file bytes and session identity before the SDK can migrate/write the file, then validates the actual SDK-loaded entries before creating the runtime.

Closes #31902. Part of #31901.

### Validation

- Focused runtime coverage: structural rejection, 30,000-deep chains plus 30,000 branches, legacy/complex histories, direct RPC file protection, and existing API/RPC/session/Stage 1/compaction regressions.
- API boundary coverage: hash-correct H0/H2 rejection without provider fallback or canonical promotion, valid history recovery, permanent Stage 1 invalid-source classification, native/public/Fast routing, session continuity, and billing regressions.
- CLI handoff and Pi loop tests, including all three ownership modes preserving installed bytes after invalid downloads.
- Hang-sensitive probes run in an owned child process with a 120-second kill deadline; success requires executed rejection assertions and successful child completion, never a timeout.
- Affected runtime/API/CLI lint and type checks, runtime build/public declaration boundary, scoped Knip, formatting, and whitespace checks.
- Full repository verification is delegated to PR and protected merge-group CI. No SDK upgrade, schema/migration, policy, model, credential, billing, memory publication, or release changes.
