### PR TITLE
test(ci): check the current clerk marker after shell preparation

### DIFF
--- a/.github/scripts/tests/prepare-okou-app-worker-shell-test.sh
+++ b/.github/scripts/tests/prepare-okou-app-worker-shell-test.sh
@@ -62,7 +62,7 @@ done
 
 for prepared_shell in "$worker_shell" "$empty_shell" \
   "${tmp_dir}/app.okou.ai-shell" "${tmp_dir}/app.vm0.ai-shell"; do
-  if grep -Fq '__VM0_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__' \
+  if grep -Fq '__OKOU_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__' \
     "${prepared_shell}/index.html"; then
     echo "expected the primary app domain marker to be replaced: $prepared_shell" >&2
     exit 1


### PR DESCRIPTION
Closes #31909. Repairs the post-merge test acceptance gap in #31900.

The Worker shell test checked the retired primary-domain marker after #31904 renamed the fixture and production marker. Prepared HTML containing a valid domain plus an unresolved current marker could therefore pass. Update only the residual assertion literal to `__OKOU_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__`.

## Validation

- The existing real shell test passes: `bash .github/scripts/tests/prepare-okou-app-worker-shell-test.sh`.
- The same test passes with inherited `CLERK_PRODUCTION_PRIMARY_APP_DOMAIN=inherited.invalid`, retaining unset, empty, explicit Okou, explicit VM0, invalid-input, asset-copy, and artifact-validation coverage.
- In temporary copies, append the unresolved current marker after confirming the rendered domain is correct. The original assertion exits 0; the corrected assertion exits 1 with `expected the primary app domain marker to be replaced`. The probe ran with the invalid inherited environment, was removed, and is not committed.
- Scoped checks pass: `shfmt -d -i 2 -ci -sr` (3.8.0), ShellCheck (0.9.0), and `bash -n` on the changed test; the repository file-size check and `git diff --check` also pass.
- A complete tracked-source search, including hidden `.github` paths, finds zero old primary-domain markers. The diff is one literal in one test; no production script or workflow definition changes.
- Checked all 18 open PRs for overlap, including every paginated file of #31905; none touches the affected test or related marker paths.

No full local Vitest suite or development server was run. Required PR and merge-group checks will be verified through the normal protected pipeline.
