### PR TITLE
fix(platform): align folded chat response rows

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
@@ -11,6 +11,7 @@ import {
   findButton,
   installRunChat,
   promptEvent,
+  publishRunUpdate,
   queryButton,
   readyChat,
   RUN_PATH,
@@ -79,6 +80,13 @@ test.each([
     await findButton("Collapse work history");
     expect(document.querySelector("[data-chat-run-work-preview]")).toBeNull();
     expect(screen.getByText("Step 1")).toBeVisible();
+    expect(screen.getByText(`Step ${count}`)).toBeVisible();
+    expect(queryButton("Copy message", main)).toBeVisible();
+    expect(
+      document.querySelector(
+        "[data-chat-run-status-tail] [data-thinking-indicator]",
+      ),
+    ).toBeVisible();
 
     click(await findButton("Collapse work history"));
     await waitFor(() => {
@@ -86,8 +94,65 @@ test.each([
         document.querySelectorAll("[data-chat-run-work-preview]"),
       ).toHaveLength(expected.length);
     });
+    expect(screen.getByText(`Step ${count}`)).toBeVisible();
+    expect(queryButton("Copy message", main)).toBeVisible();
+    expect(
+      document.querySelector(
+        "[data-chat-run-status-tail] [data-thinking-indicator]",
+      ),
+    ).toBeVisible();
   },
 );
+
+test("Keep work history open and keyboard focus in place when another output arrives", async () => {
+  const events = [
+    promptEvent({
+      id: "focused-history-input",
+      runId: RUN_ID,
+      seqId: 1,
+      text: "Check every step",
+    }),
+    assistantEvent({
+      id: "focused-history-first",
+      runId: RUN_ID,
+      seqId: 2,
+      text: "Checked the dependencies",
+    }),
+    assistantEvent({
+      id: "focused-history-second",
+      runId: RUN_ID,
+      seqId: 3,
+      text: "Checked the boundaries",
+    }),
+  ];
+  installRunChat({ chatEvents: events, activeRunIds: [RUN_ID] });
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+  click(await findButton("Expand work history"));
+  const collapse = await findButton("Collapse work history");
+  collapse.focus();
+
+  events.push(
+    assistantEvent({
+      id: "focused-history-third",
+      runId: RUN_ID,
+      seqId: 4,
+      text: "The checks are complete",
+    }),
+  );
+  publishRunUpdate();
+
+  await expect(
+    screen.findByText("The checks are complete"),
+  ).resolves.toBeVisible();
+  expect(screen.getByText("Checked the dependencies")).toBeVisible();
+  expect(screen.getByText("Checked the boundaries")).toBeVisible();
+  await expect(findButton("Collapse work history")).resolves.toHaveFocus();
+});
 
 test("Keep a card-only output in the collapsed history preview", async () => {
   installRunChat({

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -7,12 +7,14 @@ export const CHAT_THREAD_CONTENT_MAIN_CLASS =
 export const CHAT_THREAD_MESSAGE_LIST_CLASS =
   "w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4 overflow-visible";
 
-// The message list owns the 24px gap between turns. History, main result and
-// status tail each use the same 8px stack gap, without section-specific padding.
+// Turns use 24px, response sections use 8px, and related items within a section
+// use 4px. Section spacing must not become the density of a history/list row.
 export const CHAT_THREAD_RESPONSE_STACK_CLASS = "flex min-w-0 flex-col gap-2";
+export const CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS =
+  "flex min-w-0 flex-col gap-2 group-data-[run-work-folding]/chat:gap-1";
 
-// The folding boundary enables one shared line box. Vertical padding centers
-// the original 15px * 1.7 line in 36px; additional lines grow naturally.
+// Standalone response lines share a 36px frame around the original 15px * 1.7
+// line. Dense history previews and follow-up items keep their own line metrics.
 export const CHAT_THREAD_RESPONSE_LINE_CLASS =
   "group-data-[run-work-folding]/chat:h-auto group-data-[run-work-folding]/chat:min-h-9 group-data-[run-work-folding]/chat:py-[calc((2.25rem-1lh)/2)] group-data-[run-work-folding]/chat:leading-[1.59375rem]";
 

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -7,8 +7,14 @@ export const CHAT_THREAD_CONTENT_MAIN_CLASS =
 export const CHAT_THREAD_MESSAGE_LIST_CLASS =
   "w-full max-w-[900px] mx-auto flex flex-col gap-6 pb-4 overflow-visible";
 
-// The message list owns spacing between rows; nested assistant stacks use an
-// 8px gap between blocks. Bodies and action rows add no vertical padding.
+// The message list owns the 24px gap between turns. History, main result and
+// status tail each use the same 8px stack gap, without section-specific padding.
+export const CHAT_THREAD_RESPONSE_STACK_CLASS = "flex min-w-0 flex-col gap-2";
+
+// The folding boundary enables one shared line box. Vertical padding centers
+// the original 15px * 1.7 line in 36px; additional lines grow naturally.
+export const CHAT_THREAD_RESPONSE_LINE_CLASS =
+  "group-data-[run-work-folding]/chat:h-auto group-data-[run-work-folding]/chat:min-h-9 group-data-[run-work-folding]/chat:py-[calc((2.25rem-1lh)/2)] group-data-[run-work-folding]/chat:leading-[1.59375rem]";
 
 export const CHAT_THREAD_USER_MESSAGE_ROW_CLASS =
   "flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
@@ -20,7 +26,7 @@ export const CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS =
   "flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
 export const CHAT_THREAD_ASSISTANT_AVATAR_FRAME_CLASS =
-  "h-7 w-7 shrink-0 overflow-hidden rounded-xl @[900px]:mt-0.5 @[900px]:h-9 @[900px]:w-9";
+  "h-7 w-7 shrink-0 overflow-hidden rounded-xl @[900px]:mt-0.5 @[900px]:h-9 @[900px]:w-9 @[900px]:group-data-[run-work-folding]/chat:mt-0";
 
 export const CHAT_THREAD_ASSISTANT_AVATAR_IMAGE_CLASS =
   "h-7 w-7 rounded-full object-cover object-top @[900px]:h-9 @[900px]:w-9";

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -321,6 +321,8 @@ import {
   CHAT_THREAD_CONTENT_MAIN_CLASS,
   CHAT_THREAD_MESSAGE_LIST_CLASS,
   CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
+  CHAT_THREAD_RESPONSE_LINE_CLASS,
+  CHAT_THREAD_RESPONSE_STACK_CLASS,
   CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS,
   CHAT_THREAD_USER_MESSAGE_ROW_CLASS,
 } from "./chat-message-surface.tsx";
@@ -3178,13 +3180,18 @@ function ChatThreadEmptyState({ thread }: { thread: ChatPanelSignals }) {
 }
 
 function ChatThreadEventsMain({ thread }: { thread: ChatPanelSignals }) {
+  const runWorkFoldingEnabled =
+    useGet(featureSwitch$)[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
   const renderedGroupsReady =
     useLastResolved(thread.visibleRenderedChatGroupsReady$) ?? false;
   const scrollContentOnRef = useSet(thread.scrollContentOnRef$);
   const sharingPhase = useGet(thread.sharing.phase$);
 
   return (
-    <main className={CHAT_THREAD_CONTENT_MAIN_CLASS}>
+    <main
+      data-run-work-folding={runWorkFoldingEnabled || undefined}
+      className={cn(CHAT_THREAD_CONTENT_MAIN_CLASS, "group/chat")}
+    >
       <div
         ref={scrollContentOnRef}
         data-message-container
@@ -3698,6 +3705,7 @@ function RunSectionDivider({
     <div
       className={cn(
         "flex min-h-5 items-center gap-2",
+        CHAT_THREAD_RESPONSE_LINE_CLASS,
         labelPosition === "right" && "flex-row-reverse",
       )}
     >
@@ -3866,8 +3874,10 @@ function RunWorkSectionRow({
       ) : null}
     </>
   );
-  const className =
-    "inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground";
+  const className = cn(
+    "inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground",
+    CHAT_THREAD_RESPONSE_LINE_CLASS,
+  );
   return (
     <div data-chat-run-work className="-mx-2">
       {collapsible ? (
@@ -4741,6 +4751,7 @@ function ShimmerText({
       ref={setRef}
       className={cn(
         "okou-shimmer-text h-5 min-w-0 flex-1 truncate text-[0.8125rem] leading-5",
+        "group-data-[run-work-folding]/chat:h-auto group-data-[run-work-folding]/chat:leading-[inherit]",
         className,
       )}
       aria-label={ariaLabel}
@@ -4854,8 +4865,18 @@ function InlineThinkingRow({
   serverThinkingLabel?: ServerThinkingLabel;
 }) {
   return (
-    <div className="flex items-center gap-2 h-5">
-      <ThinkingLoader blockStyle={blockStyle} spinnerEnabled={spinnerEnabled} />
+    <div
+      className={cn(
+        "flex items-center gap-2 h-5",
+        CHAT_THREAD_RESPONSE_LINE_CLASS,
+      )}
+    >
+      <span className="inline-flex shrink-0 items-center justify-center group-data-[run-work-folding]/chat:w-3.5">
+        <ThinkingLoader
+          blockStyle={blockStyle}
+          spinnerEnabled={spinnerEnabled}
+        />
+      </span>
       <ThinkingLabel
         isQueued={isQueued}
         thinkingLabel={thinkingLabel}
@@ -4901,7 +4922,7 @@ function FinishedRunRow({
         : donePhrase;
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className={CHAT_THREAD_RESPONSE_STACK_CLASS}>
       <RunSectionDivider label={label} />
       {source ? (
         <RecommendedFollowupList thread={thread} source={source} />
@@ -5119,7 +5140,7 @@ function ThinkingIndicator({
     return null;
   }
 
-  // Shared inline row with fixed h-5 to prevent layout jump on transition
+  // Active and finished states share the response line metrics.
   if (thinkingIndicatorUsesStatusRow(mode)) {
     return (
       <AssistantThinkingStatusRow
@@ -7452,7 +7473,7 @@ function visibleRunIndicatorMode(
   return mode;
 }
 
-type PagedAssistantTimelineItem =
+type PagedAssistantHistoryItem =
   | {
       readonly kind: "assistant";
       readonly event: EnrichedChatEvent;
@@ -7463,16 +7484,20 @@ type PagedAssistantTimelineItem =
       readonly change: RunModelChange;
     }
   | {
+      readonly kind: "run-work-preview";
+      readonly event: EnrichedChatEvent;
+    };
+
+type PagedAssistantTimelineItem =
+  | PagedAssistantHistoryItem
+  | {
       readonly kind: "completed-work";
       readonly control: CompletedWorkFoldControl;
     }
   | {
       readonly kind: "run-work";
       readonly control: RunWorkSectionControl;
-    }
-  | {
-      readonly kind: "run-work-preview";
-      readonly event: EnrichedChatEvent;
+      readonly historyItems: readonly PagedAssistantHistoryItem[];
     }
   | {
       readonly kind: "run-work-main";
@@ -7482,7 +7507,7 @@ type PagedAssistantTimelineItem =
 
 function assistantTimelineItems(
   events: readonly EnrichedChatEvent[],
-): PagedAssistantTimelineItem[] {
+): PagedAssistantHistoryItem[] {
   return events.filter(isRenderableAssistantEvent).map((event) => {
     return { kind: "assistant", event };
   });
@@ -7491,9 +7516,9 @@ function assistantTimelineItems(
 function foldedRunWorkTimelineItems(
   groups: readonly ChatEventGroup[],
   modelChanges: ReadonlyMap<string, RunModelChange>,
-): PagedAssistantTimelineItem[] {
+): PagedAssistantHistoryItem[] {
   return groups.flatMap((group) => {
-    return group.events.flatMap((event): PagedAssistantTimelineItem[] => {
+    return group.events.flatMap((event): PagedAssistantHistoryItem[] => {
       const change = modelChanges.get(event.id);
       if (change !== undefined) {
         return [{ kind: "model-change", eventId: event.id, change }];
@@ -7538,21 +7563,24 @@ function buildPagedAssistantTimeline({
     return items;
   }
 
-  items.push({ kind: "run-work", control: runWorkSection });
+  const historyItems: PagedAssistantHistoryItem[] = [];
   if (runWorkSection.expanded) {
-    items.push(
+    historyItems.push(
       ...foldedRunWorkTimelineItems(runWorkSection.hiddenGroups, modelChanges),
     );
   } else {
-    items.push(
+    historyItems.push(
       ...runWorkSection.previewMessages.map(
-        (event): PagedAssistantTimelineItem => {
+        (event): PagedAssistantHistoryItem => {
           return { kind: "run-work-preview", event };
         },
       ),
     );
   }
-  items.push(...assistantTimelineItems(group.events.slice(0, anchorIndex)));
+  historyItems.push(
+    ...assistantTimelineItems(group.events.slice(0, anchorIndex)),
+  );
+  items.push({ kind: "run-work", control: runWorkSection, historyItems });
   const anchorEvent = group.events[anchorIndex];
   if (anchorEvent !== undefined) {
     items.push({
@@ -7599,14 +7627,20 @@ function PagedAssistantTimeline({
     }
     if (item.kind === "run-work") {
       return (
-        <RunWorkSectionRow
-          key={`run-work:control:${item.control.anchorEventId}`}
-          startTime={item.control.startTime}
-          endTime={item.control.endTime}
-          collapsible={item.control.collapsible}
-          expanded={item.control.expanded}
-          onToggle={item.control.onToggle}
-        />
+        <div
+          key="run-work:history"
+          data-chat-run-work-history
+          className={CHAT_THREAD_RESPONSE_STACK_CLASS}
+        >
+          <RunWorkSectionRow
+            startTime={item.control.startTime}
+            endTime={item.control.endTime}
+            collapsible={item.control.collapsible}
+            expanded={item.control.expanded}
+            onToggle={item.control.onToggle}
+          />
+          <PagedAssistantTimeline items={item.historyItems} thread={thread} />
+        </div>
       );
     }
     if (item.kind === "run-work-preview") {
@@ -7617,13 +7651,13 @@ function PagedAssistantTimeline({
         <div
           key={item.event.id}
           data-chat-run-work-main
-          className="flex min-w-0 flex-col gap-2"
+          className={CHAT_THREAD_RESPONSE_STACK_CLASS}
         >
           <PagedAssistantEventItem event={item.event} thread={thread} />
           {item.artifactCards.length === 0 ? null : (
             <div
               data-chat-run-work-remaining-artifacts
-              className="flex min-w-0 flex-col gap-2"
+              className={CHAT_THREAD_RESPONSE_STACK_CLASS}
             >
               {item.artifactCards.map((card) => {
                 return (
@@ -7709,7 +7743,10 @@ function PagedRunWorkAssistantContent({
       />
       {(statusTailEvents?.length ?? 0) > 0 ||
       visibleIndicatorMode !== undefined ? (
-        <div data-chat-run-status-tail className="flex min-w-0 flex-col gap-2">
+        <div
+          data-chat-run-status-tail
+          className={CHAT_THREAD_RESPONSE_STACK_CLASS}
+        >
           {statusTailEvents?.length ? (
             statusTailEvents.map((event) => {
               return (
@@ -7784,7 +7821,7 @@ function PagedAssistantGroup({
     >
       <div className={CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS}>
         <AssistantBubbleAvatar thread={thread} />
-        <div className="relative flex flex-col gap-2">
+        <div className={cn("relative", CHAT_THREAD_RESPONSE_STACK_CLASS)}>
           {runGroupFolds?.map((fold) => {
             return <RunGroupFoldRow key={fold.fold.key} control={fold} />;
           })}
@@ -7853,6 +7890,7 @@ function PagedAssistantEventItem({
   ) {
     return (
       <ChatAssistantMessageBody
+        className={CHAT_THREAD_RESPONSE_LINE_CLASS}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
       >

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -322,6 +322,7 @@ import {
   CHAT_THREAD_MESSAGE_LIST_CLASS,
   CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
   CHAT_THREAD_RESPONSE_LINE_CLASS,
+  CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS,
   CHAT_THREAD_RESPONSE_STACK_CLASS,
   CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS,
   CHAT_THREAD_USER_MESSAGE_ROW_CLASS,
@@ -4484,7 +4485,7 @@ function RecommendedFollowupList({
               "group flex text-left transition-colors",
               showFollowupCards
                 ? "min-h-24 flex-[0_0_min(22rem,calc(100cqw-4rem))] self-stretch snap-center items-start rounded-[var(--okou-card-radius)] border border-border/70 bg-card p-4 shadow-sm hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                : "min-h-10 w-full items-center gap-2 rounded-lg px-2 py-2 hover:bg-state-hover",
+                : "min-h-10 w-full items-center gap-2 rounded-lg px-2 py-2 hover:bg-state-hover group-data-[run-work-folding]/chat:min-h-8 group-data-[run-work-folding]/chat:py-1",
             )}
             onClick={() => {
               handleSelect(followup, followupIndex);
@@ -4922,7 +4923,7 @@ function FinishedRunRow({
         : donePhrase;
 
   return (
-    <div className={CHAT_THREAD_RESPONSE_STACK_CLASS}>
+    <div className={CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS}>
       <RunSectionDivider label={label} />
       {source ? (
         <RecommendedFollowupList thread={thread} source={source} />
@@ -7630,7 +7631,7 @@ function PagedAssistantTimeline({
         <div
           key="run-work:history"
           data-chat-run-work-history
-          className={CHAT_THREAD_RESPONSE_STACK_CLASS}
+          className={CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS}
         >
           <RunWorkSectionRow
             startTime={item.control.startTime}

--- a/turbo/apps/platform/src/views/okou-page/run-work-message-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/run-work-message-preview.tsx
@@ -1,6 +1,8 @@
+import { cn } from "@okouai/ui";
 import type { Element, Root } from "hast";
 import { useTranslation } from "react-i18next";
 import type { EnrichedChatEvent } from "../../signals/chat-page/chat-event.ts";
+import { CHAT_THREAD_RESPONSE_LINE_CLASS } from "./chat-message-surface.tsx";
 
 const blockTags: ReadonlySet<string> = new Set([
   "address",
@@ -68,7 +70,10 @@ export function RunWorkMessagePreview({ event }: { event: EnrichedChatEvent }) {
   return (
     <div
       data-chat-run-work-preview
-      className="flex h-5 min-w-0 max-w-full items-center gap-2 text-[13px] leading-5 text-muted-foreground/60"
+      className={cn(
+        "flex h-5 min-w-0 max-w-full items-center gap-2 text-[13px] leading-5 text-muted-foreground/60",
+        CHAT_THREAD_RESPONSE_LINE_CLASS,
+      )}
     >
       <span aria-hidden className="shrink-0">
         •

--- a/turbo/apps/platform/src/views/okou-page/run-work-message-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/run-work-message-preview.tsx
@@ -1,8 +1,6 @@
-import { cn } from "@okouai/ui";
 import type { Element, Root } from "hast";
 import { useTranslation } from "react-i18next";
 import type { EnrichedChatEvent } from "../../signals/chat-page/chat-event.ts";
-import { CHAT_THREAD_RESPONSE_LINE_CLASS } from "./chat-message-surface.tsx";
 
 const blockTags: ReadonlySet<string> = new Set([
   "address",
@@ -70,10 +68,7 @@ export function RunWorkMessagePreview({ event }: { event: EnrichedChatEvent }) {
   return (
     <div
       data-chat-run-work-preview
-      className={cn(
-        "flex h-5 min-w-0 max-w-full items-center gap-2 text-[13px] leading-5 text-muted-foreground/60",
-        CHAT_THREAD_RESPONSE_LINE_CLASS,
-      )}
+      className="flex h-5 min-w-0 max-w-full items-center gap-2 text-[13px] leading-5 text-muted-foreground/60"
     >
       <span aria-hidden className="shrink-0">
         •


### PR DESCRIPTION
## Summary

With `chatRunWorkFolding` enabled, switching between Working/Worked, Thinking, completion hints, and assistant output changes row height and misaligns the avatar. Give these standalone rows a shared 36px frame using Tailwind, the original 25.5px body line height, and vertical padding calculated from `1lh`. Multiline content grows naturally and keeps its 8px paragraph spacing. Align the wide-layout avatar with the first line and give both Thinking loaders the same 14px icon slot as Working.

Keep dense information inside a section compact: collapsed history previews retain their original 20px rows, with a 4px gap between the history heading and previews and between previews. Flat follow-up buttons use 4px vertical padding and a 32px minimum height, growing naturally when they wrap. Completion-to-follow-up spacing is 4px. Response sections retain 8px separation, and message-list turns retain 24px separation. These rules use the existing folding boundary; the switch-off layout and mobile follow-up cards keep their existing metrics.

Represent history as a stable container alongside the main result and latest status tail. Preserve the three-message preview, message → remaining artifacts → action bar ordering, latest-response status-tail lifecycle, and steer boundaries. Keep history mounted as the main output advances so keyboard focus survives streaming updates.

## Verification

- Formatting, platform lint, and Knip passed locally. Latest-head CI passed all 61 checks, including type checks, all application test shards, deployment, and CI gates.
- 60 targeted tests passed across history, previews, status tails, steer, follow-ups, and thread metadata. The PR includes a streaming-focus regression for the stable history container.
- Browser-tested the deployed PR at merge commit `55ea3f11aeb4fdb7db7d418e5dcae467f001bc37`: history with three previews shrinks from 168px to 108px; preview rows are 20px with 4px gaps; single-line follow-ups shrink from 40px to 32px. Worked, main output, and completion retain their 36px frame and zero first-line avatar offset.
- Verified history expand/collapse and follow-up selection. At 390px, wrapped follow-ups grow to 56px with the same 4px vertical padding; body line height stays 25.5px and paragraph spacing stays 8px, with no horizontal overflow. Folding off retains 40px follow-up rows and unpadded body text.
- Screenshots: [desktop density](https://a.okou.io/169syziwr4.png), [narrow multiline layout](https://a.okou.io/gsc3f08l5v.png).
- Preview: https://pr-31913-app-okou-app-preview.vm0.workers.dev/chats/2b980e03-5f7e-4a29-88d4-d89cc401d87c. Recreated mock-run fixtures after preview DB reset, using `layout-31913-5585646+clerk_test@example.com`, onboarding bypass, and Stripe TEST checkout. Checked 1440×1000 and 390×1000 with folding on/off; final folding and Thinking-spinner switches are enabled.
