### PR TITLE
fix(platform): preserve connector account card layout while loading

### DIFF
--- a/e2e/playwright/regressions/connector-card-scroll.ts
+++ b/e2e/playwright/regressions/connector-card-scroll.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { webkit, type Page } from "@playwright/test";
+
+// Run against a prepared preview thread with an authenticated storage state:
+// pnpm exec tsx playwright/regressions/connector-card-scroll.ts \
+//   <app-origin> <api-origin> <thread-id> <storage-state.json> <output-dir> <card-count>
+// The thread must overflow the viewport and contain resolved account cards.
+// Keep the storage-state file private; only screenshots and geometry are saved.
+
+function measure(page: Page) {
+  return page.evaluate(() => {
+    const container = document.querySelector("[data-scroll-container]");
+    if (!container) {
+      throw new Error("Expected a chat scroll container");
+    }
+    return {
+      scrollTop: container.scrollTop,
+      scrollHeight: container.scrollHeight,
+      clientHeight: container.clientHeight,
+      cards: Array.from(
+        document.querySelectorAll(
+          '[data-testid^="connector-account-action-card"]',
+        ),
+      ).map((card) => {
+        const frame = card.closest(".okou-markdown-card");
+        if (!frame) {
+          throw new Error("Expected a rendered account card");
+        }
+        const rect = frame.getBoundingClientRect();
+        return { top: rect.top, height: rect.height };
+      }),
+    };
+  });
+}
+
+async function main() {
+  const [appOrigin, apiOrigin, threadId, storageState, outputDir, count] =
+    process.argv.slice(2);
+  assert(
+    appOrigin && apiOrigin && threadId && storageState && outputDir && count,
+  );
+  const expectedCards = Number(count);
+  assert(Number.isInteger(expectedCards) && expectedCards > 0);
+  await mkdir(outputDir, { recursive: true });
+
+  const browser = await webkit.launch();
+  try {
+    for (const viewport of [
+      { width: 1440, height: 900 },
+      { width: 390, height: 844 },
+    ]) {
+      const context = await browser.newContext({ storageState, viewport });
+      context.setDefaultTimeout(30_000);
+      const page = await context.newPage();
+      for (const cache of ["cold", "warm"]) {
+        let release: () => void;
+        const pendingAccount = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const releaseAccount = () => release();
+        await page.route(
+          (url) =>
+            url.origin === apiOrigin &&
+            /^\/api\/connector-accounts\/[0-9a-f-]{36}$/u.test(url.pathname),
+          async (route) => {
+            const response = await route.fetch();
+            await pendingAccount;
+            await route.fulfill({ response });
+          },
+        );
+        const label = `webkit-${viewport.width}-${cache}`;
+        try {
+          await page.goto(new URL(`/chats/${threadId}`, appOrigin).href);
+          await page.waitForFunction((cardCount) => {
+            const scroll = document.querySelector("[data-scroll-container]");
+            return (
+              document.querySelectorAll(
+                '[data-testid="connector-account-action-card-loading"]',
+              ).length === cardCount &&
+              scroll &&
+              scroll.scrollHeight > scroll.clientHeight &&
+              Math.abs(
+                scroll.scrollHeight - scroll.clientHeight - scroll.scrollTop,
+              ) <= 1
+            );
+          }, expectedCards);
+          await page.evaluate(() => document.fonts.ready.then(() => undefined));
+          const before = await measure(page);
+          await page.screenshot({
+            path: path.join(outputDir, `${label}-loading.png`),
+          });
+          releaseAccount();
+          await page.waitForFunction(
+            (cardCount) =>
+              document.querySelectorAll(
+                '[data-testid="connector-account-action-card"]',
+              ).length === cardCount,
+            expectedCards,
+          );
+          await page.evaluate(
+            () =>
+              new Promise<void>((resolve) => {
+                requestAnimationFrame(() =>
+                  requestAnimationFrame(() => resolve()),
+                );
+              }),
+          );
+          const after = await measure(page);
+          await page.screenshot({
+            path: path.join(outputDir, `${label}-ready.png`),
+          });
+          const result = { label, before, after };
+          await writeFile(
+            path.join(outputDir, `${label}.json`),
+            JSON.stringify(result, null, 2),
+          );
+          console.log(JSON.stringify(result));
+          assert.equal(
+            after.scrollHeight,
+            before.scrollHeight,
+            `${label}: transcript height changed`,
+          );
+          assert(
+            Math.abs(after.scrollTop - before.scrollTop) <= 1,
+            `${label}: loading moved the reading position`,
+          );
+          assert.deepEqual(
+            after.cards,
+            before.cards,
+            `${label}: account cards moved or resized`,
+          );
+          assert(
+            Math.abs(
+              after.scrollHeight - after.clientHeight - after.scrollTop,
+            ) <= 1,
+            `${label}: lost the bottom position`,
+          );
+        } finally {
+          releaseAccount();
+          await page.unrouteAll({ behavior: "wait" });
+        }
+      }
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connector-account-action-card.tsx
@@ -18,9 +18,21 @@ import { detach, Reason } from "../../signals/utils.ts";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { CustomConnectorIcon } from "./components/settings/custom-connector-icon.tsx";
 
-const ACCOUNT_ACTION_CARD_HEIGHT_CLASS = "h-[136px] sm:h-[88px]";
-
 export function ConnectorAccountActionCard({
+  signals,
+}: {
+  readonly signals: ConnectorAccountActionSignals;
+}) {
+  // Keep the frame mounted while async states replace their content. WebKit can
+  // clamp the chat's scroll position if the card collapses during a DOM commit.
+  return (
+    <div className="okou-chat-card h-[136px] w-full sm:h-[88px]">
+      <ConnectorAccountActionCardContent signals={signals} />
+    </div>
+  );
+}
+
+function ConnectorAccountActionCardContent({
   signals,
 }: {
   readonly signals: ConnectorAccountActionSignals;
@@ -48,10 +60,7 @@ function ConnectorAccountActionCardLoading() {
   return (
     <div
       data-testid="connector-account-action-card-loading"
-      className={cn(
-        "okou-chat-card flex w-full items-center justify-center p-3",
-        ACCOUNT_ACTION_CARD_HEIGHT_CLASS,
-      )}
+      className="flex h-full w-full items-center justify-center p-3"
     >
       <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
     </div>
@@ -68,10 +77,7 @@ function ConnectorAccountActionCardError({
   return (
     <div
       data-testid="connector-account-action-card-error"
-      className={cn(
-        "okou-chat-card flex w-full items-center gap-3 p-3",
-        ACCOUNT_ACTION_CARD_HEIGHT_CLASS,
-      )}
+      className="flex h-full w-full items-center gap-3 p-3"
     >
       <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
       <div className="min-w-0 flex-1 line-clamp-3 text-sm leading-5 text-muted-foreground">
@@ -111,10 +117,7 @@ function UnavailableConnectorAccountActionCard() {
   return (
     <div
       data-testid="connector-account-action-card-unavailable"
-      className={cn(
-        "okou-chat-card flex w-full items-center gap-3 p-3",
-        ACCOUNT_ACTION_CARD_HEIGHT_CLASS,
-      )}
+      className="flex h-full w-full items-center gap-3 p-3"
     >
       <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">
         <AlertCircle size={22} />
@@ -224,10 +227,7 @@ function ReadyConnectorAccountActionCard({
   return (
     <div
       data-testid="connector-account-action-card"
-      className={cn(
-        "okou-chat-card flex w-full flex-col justify-between gap-3 p-3 text-left sm:flex-row sm:items-center",
-        ACCOUNT_ACTION_CARD_HEIGHT_CLASS,
-      )}
+      className="flex h-full w-full flex-col justify-between gap-3 p-3 text-left sm:flex-row sm:items-center"
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40 text-muted-foreground">


### PR DESCRIPTION
## Summary

Prevent a refreshed thread from jumping away from the bottom when a connector account switch card finishes loading in WebKit. Keep one fixed-height card frame mounted across loading, error, unavailable, and ready states, preserving the existing 136px mobile / 88px desktop layout and account-switch behavior.

The fixed heights from #31855 match before and after loading, but replacing the loading component briefly removes its entire box. WebKit clamps the scroll offset during that DOM removal, and the unchanged final content height does not trigger scroll restoration. The persistent frame prevents that temporary collapse.

## Verification

[PR-Verify report with screenshots, fixture, and measurements](https://github.com/vm0-ai/vm0/pull/31914#issuecomment-5551721586)

- Added a repeatable real-WebKit preview regression command. The same command fails against the previous deployment (685 → 493, a 192px jump) and passes against this PR for desktop/mobile cold and warm loads (0px change).
- Verified long replies with selected cards completely above the viewport: desktop 2421 → 2421 and mobile 5205 → 5205, including captures after startup overlays fully disappear.
- Verified Chromium at both widths, WebKit loading → error → retry and loading → unavailable, and the actual Switch action with saved account selection and a completed callback run.
- 77 CI checks pass. Formatting, affected-file ESLint/Oxlint, app and E2E TypeScript, app Knip, and 11 focused existing tests also pass. The new WebKit command is a manual preview regression harness, not part of the default Chromium CI project.

BrowserStack real-device sessions remain unavailable because the connected endpoint configuration cannot route WebDriver session creation. This verifies WebKit engine behavior; it does not claim real iPhone Safari coverage.
