### PR TITLE
fix(runner): preserve literal systemd service paths

### DIFF
--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -197,6 +197,45 @@ fn systemd_run_cpu_delegation_property_args() -> [String; 2] {
     ]
 }
 
+fn systemd_run_command(
+    unit: &RunnerServiceUnit,
+    exe_path: &Path,
+    config_path: &Path,
+    env_vars: &[String],
+    local: bool,
+) -> tokio::process::Command {
+    let mut command = tokio::process::Command::new("systemd-run");
+    command
+        .arg(format!("--unit={}", unit.unit_name()))
+        .arg(format!("--description=VM0 Runner ({})", unit.unit_name()))
+        .arg("--expand-environment=no")
+        .args([
+            "--property=Type=exec",
+            "--property=Restart=on-failure",
+            "--property=RestartSec=5",
+            "--property=StandardOutput=journal",
+            "--property=StandardError=journal",
+            "--property=KillSignal=SIGTERM",
+            "--property=TimeoutStopSec=300",
+        ])
+        .arg(systemd_run_limit_nofile_property_arg());
+    for property in systemd_run_cpu_delegation_property_args() {
+        command.arg(property);
+    }
+    command.arg(format!("--property=SyslogIdentifier={}", unit.unit_name()));
+    for entry in env_vars {
+        command.arg(format!("--setenv={entry}"));
+    }
+    command
+        .arg(exe_path)
+        .args(["start", "--config"])
+        .arg(config_path);
+    if local {
+        command.arg("--local");
+    }
+    command
+}
+
 type ServiceFuture<'a, T> = Pin<Box<dyn Future<Output = RunnerResult<T>> + 'a>>;
 
 async fn restore_service_state_after_reload_failure(
@@ -320,41 +359,19 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     validate_systemd_path("config path", &config_path)?;
     reconcile_drain_restart_override_removal(&unit, DrainOverrideReloadPolicy::Unbounded).await?;
 
-    let unit_arg = format!("--unit={}", unit.unit_name());
-    let desc_arg = format!("--description=VM0 Runner ({})", unit.unit_name());
-    let syslog_arg = format!("--property=SyslogIdentifier={}", unit.unit_name());
-    let nofile_arg = systemd_run_limit_nofile_property_arg();
-    let [delegate_arg, delegate_subgroup_arg] = systemd_run_cpu_delegation_property_args();
+    let unit_for_start = unit.clone();
     with_service_activation_image_artifacts(
         &unit,
         &config_path,
         &home,
         |snapshot_path| async move {
-            let mut cmd = tokio::process::Command::new("systemd-run");
-            cmd.args([
-                &*unit_arg,
-                &*desc_arg,
-                "--property=Type=exec",
-                "--property=Restart=on-failure",
-                "--property=RestartSec=5",
-                "--property=StandardOutput=journal",
-                "--property=StandardError=journal",
-                "--property=KillSignal=SIGTERM",
-                "--property=TimeoutStopSec=300",
-                &*nofile_arg,
-                &*delegate_arg,
-                &*delegate_subgroup_arg,
-                &*syslog_arg,
-            ]);
-            for entry in &args.env {
-                cmd.arg(format!("--setenv={entry}"));
-            }
-            cmd.arg(&exe_path)
-                .args(["start", "--config"])
-                .arg(&snapshot_path);
-            if args.local {
-                cmd.arg("--local");
-            }
+            let mut cmd = systemd_run_command(
+                &unit_for_start,
+                &exe_path,
+                &snapshot_path,
+                &args.env,
+                args.local,
+            );
 
             let status = cmd
                 .status()
@@ -1490,6 +1507,39 @@ profiles:
             [
                 "--property=Delegate=cpu".to_string(),
                 "--property=DelegateSubgroup=control".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn systemd_run_preserves_literal_dollar_paths_and_environment() {
+        let command = systemd_run_command(
+            &service_unit(),
+            Path::new("/opt/vm0-${BUILD}/vm0-runner"),
+            Path::new("/srv/vm0-${TENANT}/runner.yaml"),
+            &["LITERAL=${VALUE}".to_string()],
+            true,
+        );
+        let args = command
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_str().unwrap())
+            .collect::<Vec<_>>();
+
+        assert!(args.contains(&"--expand-environment=no"));
+        assert!(args.contains(&"--setenv=LITERAL=${VALUE}"));
+        let executable_index = args
+            .iter()
+            .position(|arg| *arg == "/opt/vm0-${BUILD}/vm0-runner")
+            .unwrap();
+        assert_eq!(
+            &args[executable_index..],
+            [
+                "/opt/vm0-${BUILD}/vm0-runner",
+                "start",
+                "--config",
+                "/srv/vm0-${TENANT}/runner.yaml",
+                "--local",
             ]
         );
     }

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -1526,15 +1526,24 @@ profiles:
             .map(|arg| arg.to_str().unwrap())
             .collect::<Vec<_>>();
 
-        assert!(args.contains(&"--expand-environment=no"));
-        assert!(args.contains(&"--setenv=LITERAL=${VALUE}"));
-        let executable_index = args
-            .iter()
-            .position(|arg| *arg == "/opt/vm0-${BUILD}/vm0-runner")
-            .unwrap();
         assert_eq!(
-            &args[executable_index..],
+            args,
             [
+                "--unit=vm0-runner-test",
+                "--description=VM0 Runner (vm0-runner-test)",
+                "--expand-environment=no",
+                "--property=Type=exec",
+                "--property=Restart=on-failure",
+                "--property=RestartSec=5",
+                "--property=StandardOutput=journal",
+                "--property=StandardError=journal",
+                "--property=KillSignal=SIGTERM",
+                "--property=TimeoutStopSec=300",
+                "--property=LimitNOFILE=524288:524288",
+                "--property=Delegate=cpu",
+                "--property=DelegateSubgroup=control",
+                "--property=SyslogIdentifier=vm0-runner-test",
+                "--setenv=LITERAL=${VALUE}",
                 "/opt/vm0-${BUILD}/vm0-runner",
                 "start",
                 "--config",

--- a/crates/runner/src/cmd/service/unit_file.rs
+++ b/crates/runner/src/cmd/service/unit_file.rs
@@ -59,10 +59,12 @@ fn escape_systemd_value(input: &str) -> String {
 ///
 /// User-controllable values (`ExecStart=` paths, `Environment=` values) go
 /// through [`escape_systemd_value`] so that input cannot break out of the
-/// quotes or trigger systemd specifier expansion. `unit` is not escaped
-/// because [`RunnerServiceUnit`] already restricts it to lowercase alphanumeric,
-/// hyphens, and dots — no `%`, `\`, `"`, or other systemd special chars
-/// can reach `Description=` or `SyslogIdentifier=`.
+/// quotes or trigger systemd specifier expansion. The `:` command prefix also
+/// disables environment expansion for `ExecStart=`, preserving literal dollar
+/// signs in paths without changing `Environment=` values. `unit` is not
+/// escaped because [`RunnerServiceUnit`] already restricts it to lowercase
+/// alphanumeric, hyphens, and dots — no `%`, `\`, `"`, or other systemd
+/// special chars can reach `Description=` or `SyslogIdentifier=`.
 pub(super) fn generate_unit_file(
     unit: &RunnerServiceUnit,
     exe_path: &Path,
@@ -88,7 +90,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=\"{exe}\" start --config \"{config}\"{local_flag}
+ExecStart=:\"{exe}\" start --config \"{config}\"{local_flag}
 Restart=on-failure
 RestartSec=5
 KillSignal=SIGTERM
@@ -457,7 +459,7 @@ mod tests {
         );
         assert!(content.contains("Description=VM0 Runner (vm0-runner-v0.1.0)"));
         assert!(content.contains(
-            "ExecStart=\"/var/lib/vm0-runner/bin/v0.1.0/vm0-runner\" start --config \"/home/ubuntu/runner.yaml\"\n"
+            "ExecStart=:\"/var/lib/vm0-runner/bin/v0.1.0/vm0-runner\" start --config \"/home/ubuntu/runner.yaml\"\n"
         ));
         assert!(!content.contains("User="));
         assert!(content.contains("SyslogIdentifier=vm0-runner-v0.1.0"));
@@ -509,7 +511,7 @@ mod tests {
             false,
         );
         assert!(content.contains(
-            "ExecStart=\"/opt/my runner/vm0-runner\" start --config \"/opt/my config/runner.yaml\""
+            "ExecStart=:\"/opt/my runner/vm0-runner\" start --config \"/opt/my config/runner.yaml\""
         ));
         assert!(!content.contains("User="));
     }
@@ -524,7 +526,7 @@ mod tests {
             true,
         );
         assert!(content.contains(
-            "ExecStart=\"/usr/bin/runner\" start --config \"/etc/runner.yaml\" --local\n"
+            "ExecStart=:\"/usr/bin/runner\" start --config \"/etc/runner.yaml\" --local\n"
         ));
     }
 
@@ -623,8 +625,29 @@ mod tests {
             false,
         );
         assert!(content.contains(
-            r#"ExecStart="/opt/runner-v1%%2.0/bin/runner" start --config "/etc/cache%%20.yaml""#
+            r#"ExecStart=:"/opt/runner-v1%%2.0/bin/runner" start --config "/etc/cache%%20.yaml""#
         ));
+    }
+
+    #[test]
+    fn generated_exec_start_preserves_literal_dollar_paths() {
+        let config_path = Path::new("/srv/vm0-${TENANT}/runner.yaml");
+        let content = generate_unit_file(
+            &service_unit("v0.1.0"),
+            Path::new("/opt/vm0-${BUILD}/vm0-runner"),
+            config_path,
+            &["LITERAL=${VALUE}".to_string()],
+            false,
+        );
+
+        assert!(content.contains(
+            r#"ExecStart=:"/opt/vm0-${BUILD}/vm0-runner" start --config "/srv/vm0-${TENANT}/runner.yaml""#
+        ));
+        assert!(content.contains(r#"Environment="LITERAL=${VALUE}""#));
+        assert_eq!(
+            crate::cmd::service::unit_config::parse_unit_config_path(&content),
+            Some(config_path.to_path_buf())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- disable systemd command environment expansion for persistent runner units with the `:` executable prefix
- construct transient `systemd-run` commands with `--expand-environment=no`
- preserve literal dollar-bearing executable, activation-config, and environment values with regression coverage for generated unit read-back

## Scope

This fixes both supported runner service launch modes because they pass the same executable and activation snapshot paths through systemd's command expansion boundary.

The change intentionally does not add `$$` path encoding or selected-unit parser decoding, reject valid dollar-bearing paths, change environment assignment serialization, or alter any persisted/API/runner protocol.

## Validation

- `cargo fmt --all -- --check`
- `cargo xtask check-rust-path-attributes`
- `cargo test --profile local -p runner cmd::service` (268 passed, 2 existing ignored child-test entries)
- `cargo clippy --profile local -p runner --all-targets --all-features`
- `cargo doc --profile local -p runner --all-features --no-deps`
- `cargo test --profile local -p runner` (3448 passed, 25 existing ignored scenarios; guest inventory 1 passed)
- pre-commit workspace Rust format, Clippy, docs, file-size, and commitlint hooks

Closes #31860
