### PR TITLE
docs(guest-session-prune): document paginated codex support

### DIFF
--- a/crates/guest-session-prune/src/lib.rs
+++ b/crates/guest-session-prune/src/lib.rs
@@ -1,8 +1,8 @@
 //! Bounded native session-history selection for guest checkpoints.
 //!
 //! The crate retains structurally valid native compact generations for Claude
-//! Code and legacy Codex rollouts without changing their native session IDs or
-//! modifying live JSONL files.
+//! Code and legacy or paginated Codex rollouts without changing their native
+//! session IDs or modifying live JSONL files.
 
 mod codex;
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Update the `guest-session-prune` crate overview to describe support for legacy and paginated Codex rollouts.
- Keep the wording aligned with the public `select_codex_compact_generation` contract.

## Scope

This PR changes only crate-level Rustdoc in `crates/guest-session-prune/src/lib.rs`. It does not change selector behavior, tests, metadata parsing, runtime callers, dependencies, migrations, or generated files.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-session-prune --all-targets --all-features`
- `cd crates && cargo test -p guest-session-prune`
- `cd crates && cargo doc --workspace --all-features --no-deps`

Closes #31847
