### PR TITLE
test(api): isolate built-in cooldown fixture

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -1030,6 +1030,12 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
         retryAfterSeconds: 60,
       }),
     ).resolves.toStrictEqual({ outcome: "recorded" });
+    await expect(
+      resolveBuiltInModelRouteFixture(context, claimed.selectedModel),
+    ).resolves.toMatchObject({
+      provider_type: primary.provider_type,
+      upstream_model: primary.upstream_model,
+    });
   });
 
   it("monotonically extends concurrent bounded reports from receipt time", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -11,7 +11,10 @@ import { createBddApi, expectApiError } from "./helpers/api-bdd";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import { createRunReadsApi } from "./helpers/api-bdd-run-reads";
-import { setRunModelProviderFixture } from "../../../test-fixtures/agent-runs";
+import {
+  setRunModelProviderFixture,
+  setRunModelRuntimeRouteFixture,
+} from "../../../test-fixtures/agent-runs";
 import {
   holdBuiltInModelRouteLockFixture,
   withBuiltInModelRuntimeRouteCandidateUnavailableForTest,
@@ -1006,10 +1009,19 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     if (!primary) {
       throw new Error("Expected a built-in model primary route");
     }
+    const fixtureRoute = {
+      ...primary,
+      upstream_model: `fixture-${randomUUID()}`,
+    };
+    await setRunModelRuntimeRouteFixture({
+      runId: claimed.runId,
+      modelRuntimeProvider: fixtureRoute.provider_type,
+      modelRuntimeModel: fixtureRoute.upstream_model,
+    });
     registerBuiltInCandidateCooldownCleanup(
       context,
       claimed.selectedModel,
-      primary,
+      fixtureRoute,
     );
 
     await expect(


### PR DESCRIPTION
## Summary

- give the canonical built-in discriminator test a UUID-owned persisted runtime route identity
- register cooldown cleanup against the same owned composite identity
- preserve the real runner failure-report API, database write, and canonical discriminator coverage

## Scope

Test-state isolation only. Production cooldown behavior, API contracts, database schema, and deployment behavior are unchanged.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-runtime-state.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=2`
- targeted two-test parallel regression repeated 5 times
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- repository pre-commit hooks

Closes #31917
