### PR TITLE
fix(presentation): make fresh screenshots fast and distinct

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -352,6 +352,7 @@ install_packages() {
   apt-get update
   apt-get install -y \
     procps wget git ripgrep jq file iproute2 sudo ffmpeg \
+    libreoffice-impress poppler-utils \
     fonts-noto-core fonts-noto-cjk fonts-noto-color-emoji \
     libnss3 p11-kit-modules tzdata-legacy unzip \
     nodejs \

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -323,6 +323,11 @@ check_required_executable "/usr/bin/mkdir" "mkdir"
 # Media workflows rely on ffmpeg being available in fresh agent runtimes.
 check_required_executable "/usr/bin/ffmpeg" "ffmpeg"
 
+# Presentation screenshot workflows must not install these large dependencies
+# inside every fresh agent runtime.
+check_required_executable "/usr/bin/soffice" "LibreOffice"
+check_required_executable "/usr/bin/pdftocairo" "Poppler pdftocairo"
+
 # Browser screenshots and exports need system fallbacks for multilingual text.
 check_bin "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf" "Noto Sans"
 check_bin "/usr/share/fonts/truetype/noto/NotoSansArabic-Regular.ttf" "Noto Sans Arabic"

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -587,6 +587,27 @@ wait
     }
 
     #[test]
+    fn template_installs_and_verifies_presentation_renderers() {
+        for package in ["libreoffice-impress", "poppler-utils"] {
+            assert!(
+                template_build_installs_apt_package(package),
+                "build-template.sh should install {package} into sandbox templates"
+            );
+        }
+
+        for (path, name) in [
+            ("/usr/bin/soffice", "LibreOffice"),
+            ("/usr/bin/pdftocairo", "Poppler pdftocairo"),
+        ] {
+            let check = format!(r#"check_required_executable "{path}" "{name}""#);
+            assert!(
+                VERIFY_SCRIPT.contains(&check),
+                "verify-rootfs.sh should verify {name} is present in sandbox images"
+            );
+        }
+    }
+
+    #[test]
     fn template_installs_and_verifies_legacy_timezone_links() {
         assert!(
             template_build_installs_apt_package("tzdata-legacy"),

--- a/turbo/apps/cli/src/commands/presentation/__tests__/screenshot.test.ts
+++ b/turbo/apps/cli/src/commands/presentation/__tests__/screenshot.test.ts
@@ -22,8 +22,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { presentationCommand } from "../index";
 
 const state = {
-  /** Boxes the fake browser reports for the slide selector. */
+  /** Nodes the fake browser reports for the slide selector. */
   slides: [] as unknown[],
+  activeSlide: 0,
   installed: new Set(["soffice", "pdftocairo"]),
   deckPages: 3,
   size: { width: 1600, height: 900 },
@@ -190,8 +191,12 @@ function fakeBrowser(args: readonly string[]): string {
       }
       return "1";
     }
+    if (expression.includes("scrollIntoView")) {
+      state.activeSlide = Number(/const index=(\d+)/u.exec(expression)?.[1]);
+      return state.activeSlide.toString();
+    }
     return expression.includes("querySelectorAll")
-      ? JSON.stringify(JSON.stringify(state.slides))
+      ? state.slides.length.toString()
       : "1";
   }
   if (verb === "screenshot" && args[4] !== undefined) {
@@ -199,7 +204,7 @@ function fakeBrowser(args: readonly string[]): string {
       args[4],
       Buffer.concat([
         png(state.size.width, state.size.height),
-        Buffer.from([state.backgroundReady ? 1 : 0]),
+        Buffer.from([state.activeSlide, state.backgroundReady ? 1 : 0]),
       ]),
     );
   }
@@ -266,6 +271,7 @@ describe("okou presentation screenshot", () => {
     workDir = mkdtempSync(join(tmpdir(), "okou-shot-"));
     outDir = join(workDir, "pages");
     state.slides = [];
+    state.activeSlide = 0;
     state.installed = new Set(["soffice", "pdftocairo"]);
     state.deckPages = 3;
     state.size = { width: 1600, height: 900 };
@@ -442,7 +448,7 @@ describe("okou presentation screenshot", () => {
     ).toBe(false);
   });
 
-  it("captures one page per slide in an HTML deck", async () => {
+  it("captures distinct pages inside a nested HTML deck scroller", async () => {
     state.slides = [
       { top: 0, left: 0 },
       { top: 900, left: 0 },
@@ -452,7 +458,13 @@ describe("okou presentation screenshot", () => {
 
     await run("--input", join(workDir, "deck.html"), "--out", outDir);
 
-    expect(readdirSync(outDir)).toHaveLength(3);
+    const pages = readdirSync(outDir).sort();
+    expect(pages).toHaveLength(3);
+    expect([
+      readFileSync(join(outDir, "page-001.png")).at(-2),
+      readFileSync(join(outDir, "page-002.png")).at(-2),
+      readFileSync(join(outDir, "page-003.png")).at(-2),
+    ]).toEqual([0, 1, 2]);
   });
 
   it("waits for CSS background images before keeping a capture", async () => {

--- a/turbo/apps/cli/src/commands/presentation/screenshot.ts
+++ b/turbo/apps/cli/src/commands/presentation/screenshot.ts
@@ -666,9 +666,9 @@ async function captureDeck(
 
 // --- HTML sources -----------------------------------------------------------
 
-interface SlideBox {
-  readonly top: number;
-  readonly left: number;
+interface SlideTarget {
+  readonly selector: string;
+  readonly index: number;
 }
 
 function browser(session: string) {
@@ -730,22 +730,22 @@ function htmlSources(input: string): { url: string; label: string }[] {
   return [{ url: pathToFileURL(path).href, label: basename(path) }];
 }
 
-function slideBoxes(
+function slideTargets(
   page: ReturnType<typeof browser>,
   selector: string,
-): SlideBox[] {
+): SlideTarget[] {
   if (selector === "") {
-    return [{ top: 0, left: 0 }];
+    return [{ selector, index: 0 }];
   }
-  const found = page.evaluate(`(()=>{
-    const nodes=[...document.querySelectorAll(${JSON.stringify(selector)})];
-    return JSON.stringify(nodes.map(n=>{const b=n.getBoundingClientRect();
-      return {top:Math.round(b.top+window.scrollY),left:Math.round(b.left+window.scrollX)};}));
-  })()`);
-  if (!Array.isArray(found) || found.length < 2) {
-    return [{ top: 0, left: 0 }];
+  const count = page.evaluate(
+    `document.querySelectorAll(${JSON.stringify(selector)}).length`,
+  );
+  if (typeof count !== "number" || !Number.isInteger(count) || count < 2) {
+    return [{ selector: "", index: 0 }];
   }
-  return found as SlideBox[];
+  return Array.from({ length: count }, (_, index) => {
+    return { selector, index };
+  });
 }
 
 function captureHtml(options: Options, outDir: string): string[] {
@@ -766,10 +766,10 @@ function captureHtml(options: Options, outDir: string): string[] {
       page.call(["open", source.url]);
       page.call(["eval", SETTLE]);
 
-      for (const box of slideBoxes(page, options.slides)) {
+      for (const slide of slideTargets(page, options.slides)) {
         const file = `page-${(files.length + 1).toString().padStart(3, "0")}.png`;
         const target = childPath(outDir, file);
-        capturePage(page, box, target, options);
+        capturePage(page, slide, target, options);
         files.push(file);
       }
     }
@@ -781,7 +781,7 @@ function captureHtml(options: Options, outDir: string): string[] {
 
 function capturePage(
   page: ReturnType<typeof browser>,
-  box: SlideBox,
+  slide: SlideTarget,
   target: string,
   options: Options,
 ): void {
@@ -793,9 +793,18 @@ function capturePage(
         page.call(["eval", SETTLE]);
       }
       // An element-scoped screenshot returns the page background for a slide
-      // below the fold, so scroll it to the viewport origin and capture that.
+      // below the fold. scrollIntoView reaches a nested deck scroller as well
+      // as the window, then an ordinary viewport capture includes the page.
       page.evaluate(
-        `(()=>{window.scrollTo(${box.left.toString()},${box.top.toString()});return window.scrollY})()`,
+        slide.selector === ""
+          ? "(()=>{window.scrollTo(0,0);return window.scrollY})()"
+          : `(()=>{
+          const index=${slide.index.toString()};
+          const node=document.querySelectorAll(${JSON.stringify(slide.selector)}).item(index);
+          if(!(node instanceof Element))throw new Error("Slide disappeared before capture");
+          node.scrollIntoView({block:"start",inline:"start",behavior:"instant"});
+          return index;
+        })()`,
       );
       page.evaluate(NEXT_FRAME);
 


### PR DESCRIPTION
## Summary

- preinstall LibreOffice Impress and Poppler in fresh runner rootfs images so presentation screenshots do not download roughly 92 MB of packages in every new agent sandbox
- address HTML slide targets by selector and index, then call `scrollIntoView` so capture reaches nested deck scrollers instead of repeatedly rendering slide 1
- assert both the runner image contract and distinct multi-slide screenshot output

## Why

Three fresh presentation-template reversals spent about 12-17 minutes bootstrapping screenshot dependencies. The PPTX path downloaded around 60 packages (roughly 92 MB) per sandbox. All tested assembled HTML decks also reported the correct page count while capturing the first slide repeatedly because `window.scrollTo` did not move the nested `.deck` scroller.

This moves the fixed renderer cost into the reusable runner image and makes each HTML capture explicitly select its slide inside the actual scroll container.

## Validation

- `pnpm --filter @okouai/cli exec vitest run src/commands/presentation/__tests__/screenshot.test.ts` (14/14)
- built CLI against a real three-slide nested scroller: three 320x180 PNGs with three distinct SHA-256 hashes
- `pnpm --filter @okouai/cli run check-types`
- `pnpm --filter @okouai/cli run lint`
- `pnpm --filter @okouai/cli run build`
- `cargo check -p runner --tests`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `bash -n crates/runner/scripts/build-template.sh crates/runner/scripts/verify-rootfs.sh`
- `git diff --check`

The local 4 GB sandbox could compile all runner test code but could not link the full runner test binary; the repository pre-commit hook's concurrent full-workspace TypeScript/Rust gates hit the same memory ceiling. PR CI remains the execution gate for those full checks.

Related template-package optimization: https://github.com/vm0-ai/Template-artifact/pull/63
