### PR TITLE
fix(pi): own pending-tool handoff through native settlement

### DIFF
--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -16,6 +16,7 @@ async fn run_settlement_case(
     run_id: &str,
     assistant_message: &Value,
     expected_result: &str,
+    expected_assistant_text: Option<&str>,
     base_path: &OsStr,
     original_directory: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -167,13 +168,27 @@ fi
                 .cloned(),
         );
     }
-    let assistant = delivered_events
+    let assistants: Vec<_> = delivered_events
         .iter()
-        .find(|event| event["type"] == "assistant")
-        .ok_or_else(|| std::io::Error::other("assistant event was not delivered"))?;
+        .filter(|event| event["type"] == "assistant")
+        .collect();
+    if let Some(text) = expected_assistant_text {
+        assert_eq!(assistants.len(), 1);
+        assert_eq!(
+            assistants
+                .first()
+                .and_then(|assistant| assistant.pointer("/message/content/0/text")),
+            Some(&Value::String(text.to_string()))
+        );
+    } else {
+        assert!(assistants.is_empty());
+    }
     assert_eq!(
-        assistant.pointer("/message/content/0/text"),
-        Some(&Value::String("ignored assistant text".to_string()))
+        delivered_events
+            .iter()
+            .filter(|event| event["type"] == "result")
+            .count(),
+        1
     );
     let terminal = delivered_events
         .iter()
@@ -203,6 +218,7 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
             "timestamp": 1,
         }),
         "API Error: Overloaded",
+        Some("ignored assistant text"),
         &base_path,
         &original_directory,
     )
@@ -220,6 +236,22 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
             "timestamp": 1,
         }),
         "Pi model turn aborted",
+        Some("ignored assistant text"),
+        &base_path,
+        &original_directory,
+    )
+    .await?;
+    // This fixture is also asserted against actual official RPC output by the
+    // TypeScript pending-tool cancellation test (only its timestamp is normalized).
+    let [assistant_end, settlement]: [Value; 2] = serde_json::from_str(include_str!(
+        "../../../turbo/packages/pi-agent-runtime/src/test/fixtures/pending-tool-abort.json"
+    ))?;
+    assert_eq!(settlement["type"], "agent_settled");
+    run_settlement_case(
+        "00000000-0000-4000-8000-000000000126",
+        &assistant_end["message"],
+        "This operation was aborted",
+        None,
         &base_path,
         &original_directory,
     )

--- a/turbo/packages/pi-agent-runtime/package.json
+++ b/turbo/packages/pi-agent-runtime/package.json
@@ -33,6 +33,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
+    "msw": "^2.13.2",
     "@types/node": "^24.3.0",
     "@okouai/eslint-config": "workspace:*",
     "@okouai/typescript-config": "workspace:*",

--- a/turbo/packages/pi-agent-runtime/src/pending-tool-cancellation.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/pending-tool-cancellation.test.ts
@@ -1,0 +1,882 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  fauxAssistantMessage,
+  fauxToolCall,
+  Type,
+} from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+  type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import { getBuiltinModel } from "@earendil-works/pi-ai/providers/all";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+} from "vitest";
+
+import { runInIsolatedProcess } from "../../../scripts/run-isolated-test.mjs";
+import { resumePiApiFirstTurn } from "./rpc";
+import { MemoryPiSession } from "./session-memory";
+
+const server = setupServer();
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+});
+afterEach(() => {
+  server.resetHandlers();
+});
+afterAll(() => {
+  server.close();
+});
+const ENDPOINT = "https://pending-tools.example/v1/responses";
+const PARAMETERS = Type.Object({ path: Type.String() });
+const SESSION_ID = "00000000-0000-4000-8000-000000000915";
+
+function barrier<T = void>() {
+  let release!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+function completedResponse(inputTokens = 5) {
+  return HttpResponse.text(
+    `data: ${JSON.stringify({
+      type: "response.completed",
+      response: {
+        id: "response_fixture",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: "message_fixture",
+            role: "assistant",
+            status: "completed",
+            content: [
+              { type: "output_text", text: "complete", annotations: [] },
+            ],
+          },
+        ],
+        usage: {
+          input_tokens: inputTokens,
+          output_tokens: 2,
+          total_tokens: inputTokens + 2,
+        },
+      },
+    })}\n\n`,
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+async function fixture(args: {
+  tool: ToolDefinition<typeof PARAMETERS>;
+  count?: number;
+  length?: boolean;
+  resolved?: boolean;
+  compactable?: boolean;
+}) {
+  const root = await mkdtemp(join(tmpdir(), "pi-pending-cancel-"));
+  onTestFinished(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+  const file = join(root, "session.jsonl");
+  const effect = join(root, "effect.txt");
+  const memory = MemoryPiSession.create({ cwd: root, id: SESSION_ID });
+  if (args.compactable) {
+    memory.appendMessage({
+      role: "user",
+      content: "earlier synthetic question",
+      timestamp: 0,
+    });
+    memory.appendMessage(
+      fauxAssistantMessage("earlier synthetic answer ".repeat(25_000), {
+        timestamp: 0,
+      }),
+    );
+  }
+  memory.appendMessage({
+    role: "user",
+    content: "original handoff",
+    timestamp: 1,
+  });
+  memory.appendMessage(
+    fauxAssistantMessage(
+      Array.from({ length: args.count ?? 1 }, (_, index) => {
+        return fauxToolCall(
+          "controlled",
+          { path: effect },
+          { id: `call-${index}` },
+        );
+      }),
+      { stopReason: args.length ? "length" : "toolUse", timestamp: 2 },
+    ),
+  );
+  if (args.resolved)
+    memory.appendMessage({
+      role: "toolResult",
+      toolCallId: "call-0",
+      toolName: "controlled",
+      content: [{ type: "text", text: "already resolved" }],
+      isError: false,
+      timestamp: 3,
+    });
+  await writeFile(file, memory.toJsonl());
+  const model = {
+    ...getBuiltinModel("openai", "gpt-5.6-terra"),
+    baseUrl: "https://pending-tools.example/v1",
+  };
+  const modelRuntime = await ModelRuntime.create({
+    allowModelNetwork: false,
+    modelsPath: null,
+    refreshOnCreate: false,
+  });
+  modelRuntime.registerProvider("openai", {
+    name: "openai",
+    api: "openai-responses",
+    apiKey: "synthetic-key",
+    baseUrl: model.baseUrl,
+    models: [model],
+  });
+  const reopen = async () => {
+    const { session } = await createAgentSession({
+      cwd: root,
+      agentDir: join(root, "agent"),
+      sessionManager: SessionManager.open(file),
+      model,
+      modelRuntime,
+      settingsManager: SettingsManager.inMemory({}, { projectTrusted: true }),
+      tools: ["controlled"],
+      customTools: [args.tool],
+    });
+    onTestFinished(() => {
+      session.dispose();
+    });
+    return session;
+  };
+  const session = await reopen();
+  const events: string[] = [];
+  session.subscribe((event) => {
+    events.push(event.type);
+  });
+  return { session, file, effect, events, reopen };
+}
+
+function tool(
+  execute: ToolDefinition<typeof PARAMETERS>["execute"],
+  executionMode: "sequential" | "parallel" = "parallel",
+): ToolDefinition<typeof PARAMETERS> {
+  return {
+    name: "controlled",
+    label: "controlled",
+    description: "A cooperative fixture with a real file effect",
+    parameters: PARAMETERS,
+    executionMode,
+    execute,
+  };
+}
+
+function observeRequests(inputTokens = 5) {
+  const bodies: string[] = [];
+  server.use(
+    http.post(ENDPOINT, async ({ request }) => {
+      bodies.push(await request.text());
+      return completedResponse(inputTokens);
+    }),
+  );
+  return bodies;
+}
+
+describe("native pending-tool cancellation", () => {
+  it.each(["sequential", "parallel"] as const)(
+    "owns %s tools, duplicate abort, queued input, settlement and reopen",
+    async (mode) => {
+      if (await runInIsolatedProcess(import.meta.url)) return;
+      const requests = observeRequests();
+      const started = barrier();
+      const aborted = barrier();
+      const releaseTools = barrier();
+      const ending = barrier();
+      const releaseEnd = barrier();
+      const signals: AbortSignal[] = [];
+      const { session, file, effect, events, reopen } = await fixture({
+        count: 2,
+        tool: tool(async (_id, args, signal) => {
+          if (!signal) throw new Error("Tool requires native ownership");
+          signals.push(signal);
+          signal.addEventListener(
+            "abort",
+            () => {
+              aborted.release();
+            },
+            { once: true },
+          );
+          if (signals.length === (mode === "parallel" ? 2 : 1))
+            started.release();
+          await releaseTools.promise;
+          signal.throwIfAborted();
+          await writeFile(args.path, "side effect");
+          return { content: [{ type: "text", text: "written" }], details: {} };
+        }, mode),
+      });
+      let settledAbort = false;
+      let settledAgent = false;
+      const unsubscribe = session.agent.subscribe(async (event) => {
+        if (event.type === "agent_end") {
+          ending.release();
+          await releaseEnd.promise;
+        }
+      });
+      const run = resumePiApiFirstTurn(session, {
+        preflightResult(success) {
+          expect(success).toBe(true);
+          expect(session.isStreaming).toBe(true);
+          expect(session.agent.signal).toBeInstanceOf(AbortSignal);
+        },
+      });
+      await started.promise;
+      await expect(resumePiApiFirstTurn(session)).rejects.toThrow(
+        "already processing",
+      );
+      await expect(
+        session.prompt("concurrent unqueued prompt"),
+      ).rejects.toThrow("already processing");
+      await session.prompt("acknowledged steering", {
+        streamingBehavior: "steer",
+      });
+      await session.followUp("acknowledged follow-up");
+      const abort = session.abort().then(() => {
+        settledAbort = true;
+      });
+      const duplicateAbort = session.abort();
+      const idle = session.agent.waitForIdle().then(() => {
+        settledAgent = true;
+      });
+      await aborted.promise;
+      expect(settledAbort).toBe(false);
+      expect(
+        signals.every((signal) => {
+          return signal === signals[0] && signal.aborted;
+        }),
+      ).toBe(true);
+      releaseTools.release();
+      await ending.promise;
+      expect(settledAbort).toBe(false);
+      expect(settledAgent).toBe(false);
+      expect(session.isStreaming).toBe(true);
+      releaseEnd.release();
+      await Promise.all([run, abort, duplicateAbort, idle]);
+      unsubscribe();
+      expect(requests).toHaveLength(0);
+      await expect(readFile(effect)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(
+        events.filter((event) => {
+          return event === "agent_settled";
+        }),
+      ).toHaveLength(1);
+      expect(session.messages.at(-1)).toMatchObject({
+        role: "assistant",
+        stopReason: "aborted",
+      });
+      expect(session.pendingMessageCount).toBe(2);
+      expect(session.agent.signal).toBeUndefined();
+      await expect(resumePiApiFirstTurn(session)).rejects.toThrow(
+        "no pending tool calls",
+      );
+      const cancelledSession = await reopen();
+      expect(cancelledSession.sessionId).toBe(SESSION_ID);
+      await expect(resumePiApiFirstTurn(cancelledSession)).rejects.toThrow(
+        "no pending tool calls",
+      );
+      const freshSignals: AbortSignal[] = [];
+      session.agent.subscribe((event, signal) => {
+        if (event.type === "agent_start") freshSignals.push(signal);
+      });
+      await session.prompt("fresh explicit prompt");
+      expect(freshSignals[0]).not.toBe(signals[0]);
+      expect(freshSignals[0]?.aborted).toBe(false);
+      expect(session.pendingMessageCount).toBe(0);
+      expect(signals).toHaveLength(mode === "parallel" ? 2 : 1);
+      const persisted =
+        SessionManager.open(file).buildSessionContext().messages;
+      for (const text of [
+        "original handoff",
+        "acknowledged steering",
+        "acknowledged follow-up",
+        "fresh explicit prompt",
+      ]) {
+        expect(
+          persisted.filter((message) => {
+            return (
+              message.role === "user" &&
+              JSON.stringify(message.content).includes(text)
+            );
+          }),
+        ).toHaveLength(1);
+      }
+      expect(
+        persisted.filter((message) => {
+          return (
+            message.role === "toolResult" && message.toolCallId === "call-0"
+          );
+        }),
+      ).toHaveLength(1);
+      const reopenedSession = await reopen();
+      await reopenedSession.prompt("continue reopened history");
+      expect(signals).toHaveLength(mode === "parallel" ? 2 : 1);
+    },
+    150_000,
+  );
+
+  it.each(["prepare", "context", "convert", "auth", "payload"] as const)(
+    "starts no HTTP after cancellation at the %s barrier",
+    async (boundary) => {
+      if (await runInIsolatedProcess(import.meta.url)) return;
+      const requests = observeRequests();
+      const entered = barrier();
+      const release = barrier();
+      const { session, effect, events } = await fixture({
+        tool: tool(async (_id, args) => {
+          await writeFile(args.path, "completed before cancellation");
+          return { content: [{ type: "text", text: "done" }], details: {} };
+        }),
+      });
+      const block = async () => {
+        entered.release();
+        await release.promise;
+      };
+      if (boundary === "prepare") {
+        const previous = session.agent.prepareNextTurnWithContext;
+        session.agent.prepareNextTurnWithContext = async (...args) => {
+          const value = await previous?.(...args);
+          await block();
+          return value;
+        };
+      } else if (boundary === "context") {
+        const previous = session.agent.transformContext;
+        session.agent.transformContext = async (messages, signal) => {
+          const value = await previous?.(messages, signal);
+          await block();
+          return value ?? messages;
+        };
+      } else if (boundary === "convert") {
+        const previous = session.agent.convertToLlm;
+        session.agent.convertToLlm = async (messages) => {
+          const value = await previous(messages);
+          await block();
+          return value;
+        };
+      } else if (boundary === "auth") {
+        const previous = session.agent.getApiKey;
+        session.agent.getApiKey = async (provider) => {
+          const value = await previous?.(provider);
+          await block();
+          return value;
+        };
+      } else {
+        session.agent.onPayload = async () => {
+          await block();
+        };
+      }
+      const run = resumePiApiFirstTurn(session);
+      await entered.promise;
+      const abort = session.abort();
+      release.release();
+      await Promise.all([run, abort]);
+      expect(requests).toHaveLength(0);
+      expect(await readFile(effect, "utf8")).toBe(
+        "completed before cancellation",
+      );
+      expect(session.messages.at(-1)).toMatchObject({ stopReason: "aborted" });
+      expect(
+        events.filter((event) => {
+          return event === "agent_settled";
+        }),
+      ).toHaveLength(1);
+    },
+    150_000,
+  );
+
+  it("cancels in-flight HTTP and does not revive agent-end queued input", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) return;
+    const requested = barrier();
+    const cancelled = barrier();
+    let requests = 0;
+    server.use(
+      http.post(ENDPOINT, async ({ request }) => {
+        requests += 1;
+        request.signal.addEventListener(
+          "abort",
+          () => {
+            cancelled.release();
+          },
+          { once: true },
+        );
+        requested.release();
+        await cancelled.promise;
+        return HttpResponse.json(
+          { error: { message: "synthetic retryable failure" } },
+          { status: 503 },
+        );
+      }),
+    );
+    const { session, events } = await fixture({
+      tool: tool(async () => {
+        return { content: [{ type: "text", text: "done" }], details: {} };
+      }),
+    });
+    session.agent.subscribe(async (event) => {
+      if (event.type === "agent_end")
+        await session.steer("accepted during native end");
+    });
+    const run = resumePiApiFirstTurn(session);
+    await requested.promise;
+    await Promise.all([
+      session.abort(),
+      session.abort(),
+      run,
+      cancelled.promise,
+    ]);
+    expect(requests).toBe(1);
+    expect(session.messages.at(-1)).toMatchObject({ stopReason: "aborted" });
+    expect(session.getSteeringMessages()).toContain(
+      "accepted during native end",
+    );
+    expect(events).not.toContain("auto_retry_start");
+    expect(events).not.toContain("compaction_start");
+    expect(
+      events.filter((event) => {
+        return event === "agent_settled";
+      }),
+    ).toHaveLength(1);
+  }, 150_000);
+
+  it("does not start prepared parallel calls when an asynchronous before hook is cancelled", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) return;
+    const requests = observeRequests();
+    const preparing = barrier();
+    const release = barrier();
+    let executions = 0;
+    const { session } = await fixture({
+      count: 2,
+      tool: tool(async () => {
+        executions += 1;
+        return { content: [], details: {} };
+      }),
+    });
+    session.agent.beforeToolCall = async ({ toolCall }, signal) => {
+      expect(signal).toBe(session.agent.signal);
+      if (toolCall.id === "call-1") {
+        preparing.release();
+        await release.promise;
+      }
+      return undefined;
+    };
+    const run = resumePiApiFirstTurn(session);
+    await preparing.promise;
+    const abort = session.abort();
+    release.release();
+    await Promise.all([run, abort]);
+    expect(executions).toBe(0);
+    expect(requests).toHaveLength(0);
+    expect(session.messages.at(-1)).toMatchObject({ stopReason: "aborted" });
+  }, 150_000);
+
+  it.each([false, true])(
+    "preserves unresolved ordering, hooks, metadata and truncated-argument refusal (length=%s)",
+    async (length) => {
+      if (await runInIsolatedProcess(import.meta.url)) return;
+      const requests = observeRequests();
+      const ordering: string[] = [];
+      const definition = tool(async (id, args, signal, update) => {
+        expect(signal?.aborted).toBe(false);
+        ordering.push(`execute:${id}`);
+        update?.({ content: [{ type: "text", text: "partial" }], details: {} });
+        await writeFile(args.path, id);
+        return {
+          content: [{ type: "text", text: id }],
+          details: { original: true },
+          addedToolNames: ["discovered"],
+        };
+      }, "sequential");
+      definition.prepareArguments = (args) => {
+        ordering.push("prepare");
+        if (
+          typeof args !== "object" ||
+          args === null ||
+          !("path" in args) ||
+          typeof args.path !== "string"
+        )
+          throw new Error("Expected a fixture path");
+        return { path: args.path };
+      };
+      const { session, effect, file } = await fixture({
+        tool: definition,
+        count: 3,
+        resolved: true,
+        length,
+      });
+      session.agent.beforeToolCall = async ({ toolCall }, signal) => {
+        expect(signal).toBe(session.agent.signal);
+        ordering.push(`before:${toolCall.id}`);
+        return undefined;
+      };
+      session.agent.afterToolCall = async ({ toolCall }, signal) => {
+        expect(signal).toBe(session.agent.signal);
+        ordering.push(`after:${toolCall.id}`);
+        return { details: { hooked: true } };
+      };
+      const updates: string[] = [];
+      const replay: string[] = [];
+      session.subscribe((event) => {
+        if (event.type === "tool_execution_update")
+          updates.push(event.toolCallId);
+        if (event.type === "message_start" && event.message.role === "user")
+          replay.push("user");
+        if (
+          event.type === "message_start" &&
+          event.message.role === "assistant" &&
+          event.message.stopReason === "toolUse"
+        )
+          replay.push("assistant");
+      });
+      await resumePiApiFirstTurn(session);
+      expect(requests).toHaveLength(1);
+      expect(replay).toEqual([]);
+      const results = SessionManager.open(file)
+        .buildSessionContext()
+        .messages.filter((message) => {
+          return message.role === "toolResult";
+        });
+      expect(
+        results.map((message) => {
+          return message.toolCallId;
+        }),
+      ).toEqual(["call-0", "call-1", "call-2"]);
+      if (length) {
+        expect(ordering).toEqual([]);
+        expect(results.slice(1)).toMatchObject([
+          { isError: true },
+          { isError: true },
+        ]);
+        await expect(readFile(effect)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      } else {
+        expect(ordering).toEqual([
+          "prepare",
+          "before:call-1",
+          "execute:call-1",
+          "after:call-1",
+          "prepare",
+          "before:call-2",
+          "execute:call-2",
+          "after:call-2",
+        ]);
+        expect(updates).toEqual(["call-1", "call-2"]);
+        expect(results.slice(1)).toMatchObject([
+          { details: { hooked: true }, addedToolNames: ["discovered"] },
+          { details: { hooked: true }, addedToolNames: ["discovered"] },
+        ]);
+        expect(await readFile(effect, "utf8")).toBe("call-2");
+      }
+    },
+    150_000,
+  );
+  it("keeps native cancellation through the retry scheduling boundary", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) return;
+    let requests = 0;
+    server.use(
+      http.post(ENDPOINT, () => {
+        requests += 1;
+        return HttpResponse.json(
+          { error: { message: "synthetic overload" } },
+          { status: 503 },
+        );
+      }),
+    );
+    const { session, events } = await fixture({
+      tool: tool(async () => {
+        return { content: [], details: {} };
+      }),
+    });
+    let abort: Promise<void> | undefined;
+    let ownedSignal: AbortSignal | undefined;
+    session.agent.subscribe((event, signal) => {
+      if (event.type === "agent_start") ownedSignal = signal;
+    });
+    session.subscribe((event) => {
+      if (event.type === "auto_retry_start") {
+        expect(session.agent.signal).toBe(ownedSignal);
+        abort = session.abort();
+      }
+    });
+    await resumePiApiFirstTurn(session);
+    expect(abort).toBeDefined();
+    await abort;
+    expect(requests).toBe(1);
+    expect(events).not.toContain("compaction_start");
+    expect(session.messages.at(-1)).toMatchObject({ stopReason: "aborted" });
+    expect(
+      events.filter((event) => {
+        return event === "agent_settled";
+      }),
+    ).toHaveLength(1);
+  }, 150_000);
+
+  it("does not compact or consume an end-handler queue after cancellation", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) return;
+    const requests = observeRequests(270_000);
+    const { session, events } = await fixture({
+      tool: tool(async () => {
+        return { content: [], details: {} };
+      }),
+    });
+    let abort: Promise<void> | undefined;
+    session.agent.subscribe(async (event) => {
+      if (event.type === "agent_end" && !abort) {
+        await session.followUp("owned end-handler follow-up");
+        abort = session.abort();
+      }
+    });
+    await resumePiApiFirstTurn(session);
+    await abort;
+    expect(requests).toHaveLength(1);
+    expect(session.getFollowUpMessages()).toEqual([
+      "owned end-handler follow-up",
+    ]);
+    expect(session.messages.at(-1)).toMatchObject({ stopReason: "aborted" });
+    expect(events).not.toContain("compaction_start");
+    expect(
+      events.filter((event) => {
+        return event === "agent_settled";
+      }),
+    ).toHaveLength(1);
+  }, 150_000);
+
+  it("joins started parallel tools even when an awaited event listener fails", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) return;
+    const requests = observeRequests();
+    const secondStarted = barrier();
+    const releaseSecond = barrier();
+    const listenerFailed = barrier();
+    const { session, events } = await fixture({
+      count: 2,
+      tool: tool(async (id) => {
+        if (id === "call-1") {
+          secondStarted.release();
+          await releaseSecond.promise;
+        }
+        return { content: [], details: {} };
+      }),
+    });
+    session.agent.subscribe((event) => {
+      if (
+        event.type === "tool_execution_end" &&
+        event.toolCallId === "call-0"
+      ) {
+        listenerFailed.release();
+        throw new Error("synthetic persistence-listener failure");
+      }
+    });
+    let finished = false;
+    const run = resumePiApiFirstTurn(session).then(() => {
+      finished = true;
+    });
+    await Promise.all([secondStarted.promise, listenerFailed.promise]);
+    expect(finished).toBe(false);
+    expect(session.isStreaming).toBe(true);
+    releaseSecond.release();
+    await run;
+    expect(requests).toHaveLength(0);
+    expect(session.messages.at(-1)).toMatchObject({ stopReason: "error" });
+    expect(
+      events.filter((event) => {
+        return event === "agent_settled";
+      }),
+    ).toHaveLength(1);
+  }, 150_000);
+  it("cancels compaction scheduled after the provider turn with the original native owner", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) return;
+    const requests = observeRequests(270_000);
+    const { session, events } = await fixture({
+      compactable: true,
+      tool: tool(async () => {
+        return { content: [], details: {} };
+      }),
+    });
+    let originalSignal: AbortSignal | undefined;
+    let abort: Promise<void> | undefined;
+    let compactionAborted = false;
+    session.agent.subscribe((event, signal) => {
+      if (event.type === "agent_start") originalSignal = signal;
+    });
+    session.subscribe((event) => {
+      if (event.type === "compaction_start") {
+        expect(session.agent.signal).toBe(originalSignal);
+        expect(session.isStreaming).toBe(true);
+        abort = session.abort();
+      }
+      if (event.type === "compaction_end") compactionAborted = event.aborted;
+    });
+    await resumePiApiFirstTurn(session);
+    expect(abort).toBeDefined();
+    await abort;
+    expect(compactionAborted).toBe(true);
+    expect(requests).toHaveLength(1);
+    expect(session.messages.at(-1)).toMatchObject({ stopReason: "aborted" });
+    expect(
+      events.filter((event) => {
+        return event === "agent_settled";
+      }),
+    ).toHaveLength(1);
+  }, 150_000);
+
+  it("persists parallel results in call order when completion order differs", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) return;
+    const requests = observeRequests();
+    const secondEnded = barrier();
+    const finished: string[] = [];
+    const { session, file } = await fixture({
+      count: 2,
+      tool: tool(async (id, args) => {
+        if (id === "call-0") await secondEnded.promise;
+        await writeFile(`${args.path}-${id}`, id);
+        return { content: [{ type: "text", text: id }], details: {} };
+      }),
+    });
+    session.agent.subscribe((event) => {
+      if (event.type === "tool_execution_end") {
+        finished.push(event.toolCallId);
+        if (event.toolCallId === "call-1") secondEnded.release();
+      }
+    });
+    await resumePiApiFirstTurn(session);
+    expect(finished).toEqual(["call-1", "call-0"]);
+    expect(requests).toHaveLength(1);
+    expect(
+      SessionManager.open(file)
+        .buildSessionContext()
+        .messages.filter((message) => {
+          return message.role === "toolResult";
+        })
+        .map((message) => {
+          return message.toolCallId;
+        }),
+    ).toEqual(["call-0", "call-1"]);
+  }, 150_000);
+
+  it("joins partial-update callbacks before reporting their failure", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) return;
+    const requests = observeRequests();
+    const failed = barrier();
+    const held = barrier();
+    const release = barrier();
+    const { session } = await fixture({
+      tool: tool(async (_id, _args, _signal, update) => {
+        update?.({ content: [{ type: "text", text: "first" }], details: {} });
+        update?.({ content: [{ type: "text", text: "second" }], details: {} });
+        return { content: [], details: {} };
+      }),
+    });
+    session.agent.subscribe(async (event) => {
+      if (event.type === "tool_execution_update") {
+        if (
+          event.partialResult.content[0]?.type === "text" &&
+          event.partialResult.content[0].text === "first"
+        ) {
+          failed.release();
+          throw new Error("synthetic update-listener failure");
+        }
+        held.release();
+        await release.promise;
+      }
+    });
+    let finished = false;
+    const run = resumePiApiFirstTurn(session).then(() => {
+      finished = true;
+    });
+    await Promise.all([failed.promise, held.promise]);
+    expect(finished).toBe(false);
+    expect(session.isStreaming).toBe(true);
+    release.release();
+    await run;
+    expect(requests).toHaveLength(0);
+    expect(session.messages.at(-1)).toMatchObject({ stopReason: "error" });
+  }, 150_000);
+  it("retains normal retry and late queued input within the same successful native owner", async () => {
+    if (await runInIsolatedProcess(import.meta.url)) return;
+    let requests = 0;
+    server.use(
+      http.post(ENDPOINT, () => {
+        requests += 1;
+        if (requests === 1)
+          return HttpResponse.json(
+            { error: { message: "synthetic overload" } },
+            { status: 503 },
+          );
+        return completedResponse();
+      }),
+    );
+    let executions = 0;
+    const { session, events, file } = await fixture({
+      tool: tool(async () => {
+        executions += 1;
+        return { content: [], details: {} };
+      }),
+    });
+    const signals: AbortSignal[] = [];
+    let queued = false;
+    session.agent.subscribe(async (event, signal) => {
+      if (event.type === "agent_start") signals.push(signal);
+      if (event.type === "agent_end" && requests === 2 && !queued) {
+        queued = true;
+        await session.followUp("late acknowledged input");
+      }
+    });
+    await resumePiApiFirstTurn(session);
+    expect(requests).toBe(3);
+    expect(executions).toBe(1);
+    expect(signals).toHaveLength(3);
+    expect(
+      signals.every((signal) => {
+        return signal === signals[0] && !signal.aborted;
+      }),
+    ).toBe(true);
+    expect(
+      events.filter((event) => {
+        return event === "auto_retry_start";
+      }),
+    ).toHaveLength(1);
+    expect(
+      events.filter((event) => {
+        return event === "agent_settled";
+      }),
+    ).toHaveLength(1);
+    expect(session.messages.at(-1)).toMatchObject({ stopReason: "stop" });
+    expect(
+      SessionManager.open(file)
+        .buildSessionContext()
+        .messages.filter((message) => {
+          return (
+            message.role === "user" &&
+            JSON.stringify(message.content).includes("late acknowledged input")
+          );
+        }),
+    ).toHaveLength(1);
+  }, 150_000);
+});

--- a/turbo/packages/pi-agent-runtime/src/rpc-cancellation.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/rpc-cancellation.test.ts
@@ -1,0 +1,271 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+
+import { MemoryPiSession } from "./session-memory";
+
+const SESSION_ID = "00000000-0000-4000-8000-000000000915";
+const FIXTURE = fileURLToPath(
+  new URL("./test/fixtures/pending-tool-rpc.ts", import.meta.url),
+);
+// Loaded by the real extension loader in the actual RPC host. IPC controls only
+// the fixture tool's cooperative boundary; official commands still use stdin.
+const EXTENSION = `import { writeFile } from "node:fs/promises";
+export default function (pi) {
+  if (process.argv[3] === "tool") pi.on("agent_settled", async () => {
+    await new Promise((resolve) => {
+      const release = (message) => {
+        if (message === "release-settlement") {
+          process.off("message", release);
+          resolve();
+        }
+      };
+      process.on("message", release);
+      process.send({ type: "settling" });
+    });
+  });
+  pi.registerTool({
+    name: "controlled", label: "controlled", description: "Cooperative fixture",
+    parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+    async execute(_id, args, signal) {
+      if (!signal) throw new Error("Missing native tool signal");
+      const aborted = () => process.send({ type: "tool-aborted" });
+      signal.addEventListener("abort", aborted, { once: true });
+      await new Promise((resolve) => {
+        const release = (message) => {
+          if (message === "release-tool") {
+            process.off("message", release);
+            resolve();
+          }
+        };
+        process.on("message", release);
+        process.send({ type: "tool-start" });
+      });
+      signal.removeEventListener("abort", aborted);
+      signal.throwIfAborted();
+      await writeFile(args.path, "completed side effect");
+      return { content: [{ type: "text", text: "done" }], details: {} };
+    }
+  });
+}`;
+
+describe("official pending-tool RPC cancellation", () => {
+  it.each(["tool", "http"])(
+    "acknowledges abort only after the owned %s boundary settles",
+    async (boundary) => {
+      const root = await mkdtemp(join(tmpdir(), "pi-pending-rpc-"));
+      const effect = join(root, "effect.txt");
+      const extensions = join(root, "agent", "extensions");
+      await mkdir(extensions, { recursive: true });
+      await writeFile(join(extensions, "controlled.js"), EXTENSION);
+      const memory = MemoryPiSession.create({ cwd: root, id: SESSION_ID });
+      memory.appendMessage({
+        role: "user",
+        content: "original handoff",
+        timestamp: 1,
+      });
+      memory.appendMessage(
+        fauxAssistantMessage(
+          fauxToolCall("controlled", { path: effect }, { id: "call-0" }),
+          { stopReason: "toolUse", timestamp: 2 },
+        ),
+      );
+      await writeFile(join(root, "session.jsonl"), memory.toJsonl());
+      const child = spawn(
+        process.execPath,
+        ["--import", import.meta.resolve("tsx"), FIXTURE, root, boundary],
+        {
+          cwd: root,
+          stdio: ["pipe", "pipe", "pipe", "ipc"],
+          // The parent owns a real kill deadline; no same-thread timeout can make
+          // an unowned/hung native continuation look like successful settlement.
+          timeout: 20_000,
+          killSignal: "SIGKILL",
+        },
+      );
+      const { stdin, stdout, stderr: errorStream } = child;
+      if (!stdin || !stdout || !errorStream)
+        throw new Error("RPC fixture requires piped stdio");
+      const exit = once(child, "exit");
+      const lines = createInterface({ input: stdout, crlfDelay: Infinity });
+      const iterator = lines[Symbol.asyncIterator]();
+      const records: Array<Record<string, unknown>> = [];
+      const notifications: unknown[] = [];
+      let stderr = "";
+      errorStream.setEncoding("utf8").on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      child.on("message", (message) => {
+        notifications.push(message);
+      });
+      const send = (command: Record<string, unknown>) => {
+        stdin.write(`${JSON.stringify(command)}\n`);
+      };
+      const response = async (id: string) => {
+        for (;;) {
+          const next = await iterator.next();
+          if (next.done)
+            throw new Error(`RPC host exited before ${id}: ${stderr}`);
+          const record = JSON.parse(next.value) as Record<string, unknown>;
+          records.push(record);
+          if (record.type === "response" && record.id === id) return record;
+        }
+      };
+      try {
+        send({ id: "state", type: "get_state" });
+        expect(await response("state")).toMatchObject({
+          success: true,
+          data: { sessionId: SESSION_ID },
+        });
+        const started = once(child, "message");
+        send({ id: "startup", type: "prompt", message: "original handoff" });
+        expect(await response("startup")).toMatchObject({
+          command: "prompt",
+          success: true,
+        });
+        expect((await started)[0]).toMatchObject({ type: "tool-start" });
+        send({
+          id: "busy",
+          type: "prompt",
+          message: "unowned concurrent prompt",
+        });
+        expect(await response("busy")).toMatchObject({ success: false });
+        send({
+          id: "steer",
+          type: "steer",
+          message: "acknowledged active input",
+        });
+        expect(await response("steer")).toMatchObject({ success: true });
+        if (boundary === "http") {
+          const requested = once(child, "message");
+          child.send("release-tool");
+          expect((await requested)[0]).toMatchObject({
+            type: "http-start",
+            count: 1,
+          });
+        }
+        const cancelled = once(child, "message");
+        send({ id: "abort", type: "abort" });
+        send({ id: "duplicate-abort", type: "abort" });
+        expect((await cancelled)[0]).toMatchObject({
+          type: boundary === "tool" ? "tool-aborted" : "http-aborted",
+        });
+        if (boundary === "tool") {
+          send({ id: "held", type: "get_state" });
+          expect(await response("held")).toMatchObject({
+            data: { isStreaming: true },
+          });
+          expect(
+            records.some((record) => {
+              return record.id === "abort" || record.type === "agent_settled";
+            }),
+          ).toBe(false);
+          const settling = once(child, "message");
+          child.send("release-tool");
+          expect((await settling)[0]).toMatchObject({ type: "settling" });
+          send({ id: "settlement-held", type: "get_state" });
+          expect(await response("settlement-held")).toMatchObject({
+            data: { isStreaming: true },
+          });
+          expect(
+            records.some((record) => {
+              return record.id === "abort" || record.type === "agent_settled";
+            }),
+          ).toBe(false);
+          child.send("release-settlement");
+        }
+        expect(await response("abort")).toMatchObject({
+          command: "abort",
+          success: true,
+        });
+        expect(await response("duplicate-abort")).toMatchObject({
+          command: "abort",
+          success: true,
+        });
+        send({ id: "idle", type: "get_state" });
+        expect(await response("idle")).toMatchObject({
+          data: { isStreaming: false },
+        });
+        expect(
+          records.filter((record) => {
+            return record.type === "agent_settled";
+          }),
+        ).toHaveLength(1);
+        const assistants = records.filter((record) => {
+          const message = record.message;
+          return (
+            record.type === "message_end" &&
+            typeof message === "object" &&
+            message !== null &&
+            "role" in message &&
+            message.role === "assistant"
+          );
+        });
+        expect(assistants).toHaveLength(1);
+        expect(assistants[0]).toMatchObject({
+          message: { stopReason: "aborted" },
+        });
+        if (boundary === "tool") {
+          const terminal = assistants[0]?.message;
+          if (typeof terminal !== "object" || terminal === null)
+            throw new Error("Expected native aborted assistant");
+          const expected: unknown = JSON.parse(
+            await readFile(
+              new URL(
+                "./test/fixtures/pending-tool-abort.json",
+                import.meta.url,
+              ),
+              "utf8",
+            ),
+          );
+          expect([
+            { type: "message_end", message: { ...terminal, timestamp: 0 } },
+            records.find((record) => {
+              return record.type === "agent_settled";
+            }),
+          ]).toEqual(expected);
+        }
+        const requestCount = () => {
+          return notifications.filter((message) => {
+            return (
+              typeof message === "object" &&
+              message !== null &&
+              "type" in message &&
+              message.type === "http-start"
+            );
+          }).length;
+        };
+        expect(requestCount()).toBe(boundary === "http" ? 1 : 0);
+        if (boundary === "tool")
+          await expect(readFile(effect)).rejects.toMatchObject({
+            code: "ENOENT",
+          });
+        else
+          expect(await readFile(effect, "utf8")).toBe("completed side effect");
+        stdin.end();
+        expect(await exit, stderr).toEqual([0, null]);
+        const persisted = MemoryPiSession.fromJsonl(
+          await readFile(join(root, "session.jsonl"), "utf8"),
+        );
+        expect(persisted.getSessionId()).toBe(SESSION_ID);
+        expect(persisted.buildSessionContext().messages.at(-1)).toMatchObject({
+          stopReason: "aborted",
+        });
+      } finally {
+        if (child.exitCode === null && child.signalCode === null)
+          child.kill("SIGKILL");
+        await exit;
+        lines.close();
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+    30_000,
+  );
+});

--- a/turbo/packages/pi-agent-runtime/src/rpc.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/rpc.test.ts
@@ -328,8 +328,8 @@ describe("Pi API first-turn sandbox resume", () => {
     expect(execute).toHaveBeenCalledExactlyOnceWith(
       TOOL_CALL_ID,
       { path: "/home/user/.pi/agent/skills/example/SKILL.md" },
-      undefined,
-      undefined,
+      expect.any(AbortSignal),
+      expect.any(Function),
       expect.anything(),
     );
     expect(session.messages.at(-1)).toMatchObject({
@@ -431,8 +431,8 @@ describe("Pi API first-turn sandbox resume", () => {
     expect(execute).toHaveBeenCalledExactlyOnceWith(
       TOOL_CALL_ID,
       { command },
-      undefined,
-      undefined,
+      expect.any(AbortSignal),
+      expect.any(Function),
       expect.anything(),
     );
     expect(faux.state.callCount).toBe(1);

--- a/turbo/packages/pi-agent-runtime/src/rpc.ts
+++ b/turbo/packages/pi-agent-runtime/src/rpc.ts
@@ -1,12 +1,5 @@
 import { readFileSync } from "node:fs";
 
-import type {
-  AssistantMessage,
-  Message,
-  ToolCall,
-  ToolResultMessage,
-} from "@earendil-works/pi-ai";
-import { validateToolArguments } from "@earendil-works/pi-ai";
 import {
   createAgentSessionRuntime,
   runRpcMode,
@@ -84,164 +77,35 @@ function createRuntimeFactory(args: {
   };
 }
 
-interface InternalAgentSession {
-  _runAgentPrompt(messages: Message[]): Promise<void>;
-}
-
-function pendingToolCalls(session: AgentSession): {
-  readonly assistant: AssistantMessage | null;
-  readonly calls: ToolCall[];
-} {
-  const messages = session.agent.state.messages;
-  let lastAssistant: (typeof messages)[number] | undefined;
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (message?.role === "assistant") {
-      lastAssistant = message;
-      break;
-    }
-  }
-  if (lastAssistant?.role !== "assistant") {
-    return { assistant: null, calls: [] };
-  }
-  const resolvedIds = new Set(
-    messages.flatMap((message) => {
-      return message.role === "toolResult" ? [message.toolCallId] : [];
-    }),
-  );
-  return {
-    assistant: lastAssistant,
-    calls: lastAssistant.content.filter((content): content is ToolCall => {
-      return content.type === "toolCall" && !resolvedIds.has(content.id);
-    }),
-  };
-}
-
-async function executePendingToolCalls(
-  session: AgentSession,
-): Promise<ToolResultMessage[]> {
-  const tools = new Map(
-    session.agent.state.tools.map((tool) => {
-      return [tool.name, tool] as const;
-    }),
-  );
-  const pending = pendingToolCalls(session);
-  const errorResult = (call: ToolCall, message: string): ToolResultMessage => {
-    return {
-      role: "toolResult",
-      toolCallId: call.id,
-      toolName: call.name,
-      content: [{ type: "text", text: message }],
-      isError: true,
-      timestamp: Date.now(),
-    };
-  };
-  if (pending.assistant?.stopReason === "length") {
-    return pending.calls.map((call) => {
-      return errorResult(
-        call,
-        `Tool call "${call.name}" was not executed: the response hit the output token limit, so its arguments may be truncated. Re-issue the tool call with complete arguments.`,
-      );
-    });
-  }
-  const execute = async (call: ToolCall): Promise<ToolResultMessage> => {
-    const tool = tools.get(call.name);
-    try {
-      if (!tool) {
-        throw new Error(`Tool "${call.name}" is not available in the sandbox`);
-      }
-      const preparedCall = tool.prepareArguments
-        ? {
-            ...call,
-            arguments: tool.prepareArguments(
-              call.arguments,
-            ) as ToolCall["arguments"],
-          }
-        : call;
-      const value = await tool.execute(
-        call.id,
-        validateToolArguments(tool, preparedCall),
-      );
-      return {
-        role: "toolResult",
-        toolCallId: call.id,
-        toolName: call.name,
-        content: value.content ?? [],
-        details: value.details,
-        usage: value.usage,
-        ...(value.addedToolNames?.length
-          ? { addedToolNames: value.addedToolNames }
-          : {}),
-        isError: false,
-        timestamp: Date.now(),
-      };
-    } catch (error) {
-      return errorResult(
-        call,
-        error instanceof Error ? error.message : String(error),
-      );
-    }
-  };
-  const calls = pending.calls;
-  if (
-    calls.some((call) => {
-      return tools.get(call.name)?.executionMode === "sequential";
-    })
-  ) {
-    const results: ToolResultMessage[] = [];
-    for (const call of calls) {
-      results.push(await execute(call));
-    }
-    return results;
-  }
-  return await Promise.all(calls.map(execute));
-}
-
 export async function resumePiApiFirstTurn(
   session: AgentSession,
+  options?: Parameters<AgentSession["continuePendingTools"]>[0],
 ): Promise<void> {
-  const internal = session as unknown as InternalAgentSession;
-  const pending = pendingToolCalls(session);
-  if (pending.calls.length === 0) {
-    throw new Error("Pi handoff session contains no pending tool calls");
-  }
-  const toolResults = await executePendingToolCalls(session);
-  await internal._runAgentPrompt(toolResults);
-}
-
-function replaceFirstPrompt(
-  session: AgentSession,
-  continuation: () => Promise<void>,
-): void {
-  const originalPrompt = session.prompt.bind(session);
-  session.prompt = async (_text, options) => {
-    session.prompt = originalPrompt;
-    options?.preflightResult?.(true);
-    await continuation();
-  };
+  await session.continuePendingTools(options);
 }
 
 function installOwnershipTransferStartup(
   session: AgentSession,
   mode: PiSandboxOwnershipTransferMode,
 ): void {
-  switch (mode) {
-    case "sandbox-first": {
-      return;
-    }
-    case "pending-tool-continuation": {
-      replaceFirstPrompt(session, async () => {
-        await resumePiApiFirstTurn(session);
-      });
-      return;
-    }
-    case "settled-session-continuation": {
-      replaceFirstPrompt(session, () => {
-        return Promise.resolve();
-      });
-      return;
-    }
+  if (mode === "sandbox-first") {
+    return;
   }
+  const originalPrompt = session.prompt.bind(session);
+  session.prompt = async (_text, options) => {
+    if (mode === "pending-tool-continuation") {
+      await resumePiApiFirstTurn(session, {
+        preflightResult(success) {
+          // Both native owners are established before ordinary input or RPC ack.
+          session.prompt = originalPrompt;
+          options?.preflightResult?.(success);
+        },
+      });
+    } else {
+      session.prompt = originalPrompt;
+      options?.preflightResult?.(true);
+    }
+  };
 }
 
 /** Run Pi's official AgentSession RPC host until stdin closes. */

--- a/turbo/packages/pi-agent-runtime/src/test/fixtures/pending-tool-abort.json
+++ b/turbo/packages/pi-agent-runtime/src/test/fixtures/pending-tool-abort.json
@@ -1,0 +1,37 @@
+[
+  {
+    "type": "message_end",
+    "message": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": ""
+        }
+      ],
+      "api": "openai-responses",
+      "provider": "openai",
+      "model": "gpt-5.6-terra",
+      "usage": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "totalTokens": 0,
+        "cost": {
+          "input": 0,
+          "output": 0,
+          "cacheRead": 0,
+          "cacheWrite": 0,
+          "total": 0
+        }
+      },
+      "stopReason": "aborted",
+      "errorMessage": "This operation was aborted",
+      "timestamp": 0
+    }
+  },
+  {
+    "type": "agent_settled"
+  }
+]

--- a/turbo/packages/pi-agent-runtime/src/test/fixtures/pending-tool-rpc.ts
+++ b/turbo/packages/pi-agent-runtime/src/test/fixtures/pending-tool-rpc.ts
@@ -1,0 +1,75 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { join } from "node:path";
+
+import { runPiOfficialRpcMode } from "../../rpc";
+
+const root = process.argv[2];
+const boundary = process.argv[3];
+if (!root) throw new Error("The RPC fixture requires a temporary directory");
+let requests = 0;
+const server = setupServer(
+  http.post(
+    "https://pending-tools.example/v1/responses",
+    async ({ request }) => {
+      requests += 1;
+      process.send?.({ type: "http-start", count: requests });
+      if (boundary === "http" && requests === 1) {
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener(
+            "abort",
+            () => {
+              process.send?.({ type: "http-aborted" });
+              resolve();
+            },
+            { once: true },
+          );
+        });
+        return HttpResponse.json(
+          { error: { message: "synthetic retryable error" } },
+          { status: 503 },
+        );
+      }
+      return HttpResponse.text(
+        `data: ${JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "response_fixture",
+            object: "response",
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                id: "message_fixture",
+                role: "assistant",
+                status: "completed",
+                content: [
+                  { type: "output_text", text: "complete", annotations: [] },
+                ],
+              },
+            ],
+            usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+          },
+        })}\n\n`,
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    },
+  ),
+);
+server.listen({ onUnhandledRequest: "error" });
+await runPiOfficialRpcMode({
+  cwd: root,
+  agentDir: join(root, "agent"),
+  sessionDir: root,
+  sessionId: "00000000-0000-4000-8000-000000000915",
+  sessionFile: join(root, "session.jsonl"),
+  appendSystemPrompt: null,
+  ownershipTransferMode: "pending-tool-continuation",
+  model: {
+    provider: "openai",
+    model: "gpt-5.6-terra",
+    dialect: "openai-responses",
+    apiKey: "synthetic-key",
+    baseUrl: "https://pending-tools.example/v1",
+  },
+});

--- a/turbo/patches/@earendil-works__pi-agent-core@0.84.1.patch
+++ b/turbo/patches/@earendil-works__pi-agent-core@0.84.1.patch
@@ -1,0 +1,304 @@
+diff --git a/dist/agent.js b/dist/agent.js
+--- a/dist/agent.js
++++ b/dist/agent.js
+@@ -1,4 +1,4 @@
+-import { runAgentLoop, runAgentLoopContinue } from "./agent-loop.js";
++import { getPendingToolContinuation, runAgentLoop, runAgentLoopContinue, runAgentLoopPendingTools } from "./agent-loop.js";
+ import { getDefaultStreamFn } from "./stream-fn.js";
+ function defaultConvertToLlm(messages) {
+     return messages.filter((message) => message.role === "user" || message.role === "assistant" || message.role === "toolResult");
+@@ -254,6 +254,36 @@
+         }
+         await this.runContinuation();
+     }
++    /** Local pinned integration: retain one native owner through session settlement. */
++    async continuePendingTools(options = {}) {
++        if (this.activeRun) {
++            throw new Error("Agent is already processing. Wait for completion before continuing.");
++        }
++        const context = this.createContextSnapshot();
++        const pending = getPendingToolContinuation(context);
++        await this.runWithLifecycle(async (signal) => {
++            options.onStart?.();
++            await runAgentLoopPendingTools(context, pending, this.createLoopConfig(), (event) => this.processEvents(event), signal, this.streamFunction);
++            if (signal.aborted && this._state.messages.at(-1)?.stopReason === "aborted") return;
++            signal.throwIfAborted();
++            while (await options.afterRun?.(signal)) {
++                signal.throwIfAborted();
++                const lastMessage = this._state.messages.at(-1);
++                if (lastMessage?.role === "assistant") {
++                    const steering = this.steeringQueue.drain();
++                    const messages = steering.length > 0 ? steering : this.followUpQueue.drain();
++                    if (messages.length === 0) throw new Error("Cannot continue from message role: assistant");
++                    await runAgentLoop(messages, this.createContextSnapshot(), this.createLoopConfig({ skipInitialSteeringPoll: steering.length > 0 }), (event) => this.processEvents(event), signal, this.streamFunction);
++                }
++                else {
++                    await runAgentLoopContinue(this.createContextSnapshot(), this.createLoopConfig(), (event) => this.processEvents(event), signal, this.streamFunction);
++                }
++                if (signal.aborted && this._state.messages.at(-1)?.stopReason === "aborted") return;
++                signal.throwIfAborted();
++            }
++            signal.throwIfAborted();
++        }, options.onSettled);
++    }
+     normalizePromptInput(input, images) {
+         if (Array.isArray(input)) {
+             return input;
+@@ -323,7 +353,7 @@
+             getFollowUpMessages: async () => this.followUpQueue.drain(),
+         };
+     }
+-    async runWithLifecycle(executor) {
++    async runWithLifecycle(executor, onSettled) {
+         if (this.activeRun) {
+             throw new Error("Agent is already processing.");
+         }
+@@ -343,7 +373,12 @@
+             await this.handleRunFailure(error, abortController.signal.aborted);
+         }
+         finally {
+-            this.finishRun();
++            try {
++                if (onSettled) await onSettled();
++            }
++            finally {
++                this.finishRun();
++            }
+         }
+     }
+     async handleRunFailure(error, aborted) {
+diff --git a/dist/agent.d.ts b/dist/agent.d.ts
+--- a/dist/agent.d.ts
++++ b/dist/agent.d.ts
+@@ -109,6 +109,12 @@
+     prompt(input: string, images?: ImageContent[]): Promise<void>;
+     /** Continue from the current transcript. The last message must be a user or tool-result message. */
+     continue(): Promise<void>;
++    /** Local pinned integration; callbacks run inside the native abort/idle owner. */
++    continuePendingTools(options?: {
++        onStart?: () => void;
++        afterRun?: (signal: AbortSignal) => Promise<boolean>;
++        onSettled?: () => Promise<void>;
++    }): Promise<void>;
+     private normalizePromptInput;
+     private runPromptMessages;
+     private runContinuation;
+diff --git a/dist/agent-loop.js b/dist/agent-loop.js
+--- a/dist/agent-loop.js
++++ b/dist/agent-loop.js
+@@ -69,18 +69,42 @@
+     await runLoop(currentContext, newMessages, config, signal, emit, streamFn ?? getDefaultStreamFn());
+     return newMessages;
+ }
++/** Validate the current handoff without replaying any transcript message. */
++export function getPendingToolContinuation(context) {
++    const index = context.messages.findLastIndex((message) => message.role === "assistant");
++    const assistant = context.messages[index];
++    const suffix = context.messages.slice(index + 1);
++    if (!assistant || suffix.some((message) => message.role !== "toolResult") ||
++        (assistant.stopReason !== "toolUse" && assistant.stopReason !== "length")) {
++        throw new Error("Pi handoff session contains no pending tool calls");
++    }
++    const resolved = new Set(suffix.map((message) => message.toolCallId));
++    const calls = assistant.content.filter((content) => content.type === "toolCall" && !resolved.has(content.id));
++    if (calls.length === 0) {
++        throw new Error("Pi handoff session contains no pending tool calls");
++    }
++    return { assistant, calls };
++}
++/** Resume the unresolved tool suffix using the ordinary executor and turn pipeline. */
++export async function runAgentLoopPendingTools(context, pending, config, emit, signal, streamFn) {
++    const newMessages = [];
++    await emit({ type: "agent_start" });
++    await emit({ type: "turn_start" });
++    await runLoop(context, newMessages, config, signal, emit, streamFn, pending);
++    return newMessages;
++}
+ function createAgentStream() {
+     return new EventStream((event) => event.type === "agent_end", (event) => (event.type === "agent_end" ? event.messages : []));
+ }
+ /**
+  * Main loop logic shared by agentLoop and agentLoopContinue.
+  */
+-async function runLoop(initialContext, newMessages, initialConfig, signal, emit, streamFunction) {
++async function runLoop(initialContext, newMessages, initialConfig, signal, emit, streamFunction, pendingTools) {
+     let currentContext = initialContext;
+     let config = initialConfig;
+     let firstTurn = true;
+     // Check for steering messages at start (user may have typed while waiting)
+-    let pendingMessages = (await config.getSteeringMessages?.()) || [];
++    let pendingMessages = pendingTools ? [] : (await config.getSteeringMessages?.()) || [];
+     // Outer loop: continues when queued follow-up messages arrive after agent would stop
+     while (true) {
+         let hasMoreToolCalls = true;
+@@ -102,16 +126,19 @@
+                 }
+                 pendingMessages = [];
+             }
+-            // Stream assistant response
+-            const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFunction);
+-            newMessages.push(message);
++            signal?.throwIfAborted();
++            // A handoff already persisted its assistant; only new messages emit/persist.
++            const pending = pendingTools;
++            pendingTools = undefined;
++            const message = pending?.assistant ?? await streamAssistantResponse(currentContext, config, signal, emit, streamFunction);
++            if (!pending) newMessages.push(message);
+             if (message.stopReason === "error" || message.stopReason === "aborted") {
+                 await emit({ type: "turn_end", message, toolResults: [] });
+                 await emit({ type: "agent_end", messages: newMessages });
+                 return;
+             }
+             // Check for tool calls
+-            const toolCalls = message.content.filter((c) => c.type === "toolCall");
++            const toolCalls = pending?.calls ?? message.content.filter((c) => c.type === "toolCall");
+             const toolResults = [];
+             hasMoreToolCalls = false;
+             if (toolCalls.length > 0) {
+@@ -120,7 +147,7 @@
+                 // them all instead of executing potentially borked calls.
+                 const executedToolBatch = message.stopReason === "length"
+                     ? await failToolCallsFromTruncatedMessage(toolCalls, emit)
+-                    : await executeToolCalls(currentContext, message, config, signal, emit);
++                    : await executeToolCalls(currentContext, message, config, signal, emit, toolCalls);
+                 toolResults.push(...executedToolBatch.messages);
+                 hasMoreToolCalls = !executedToolBatch.terminate;
+                 for (const result of toolResults) {
+@@ -129,6 +156,7 @@
+                 }
+             }
+             await emit({ type: "turn_end", message, toolResults });
++            signal?.throwIfAborted();
+             const nextTurnContext = {
+                 message,
+                 toolResults,
+@@ -136,6 +164,7 @@
+                 newMessages,
+             };
+             const nextTurnSnapshot = await config.prepareNextTurn?.(nextTurnContext);
++            signal?.throwIfAborted();
+             if (nextTurnSnapshot) {
+                 currentContext = nextTurnSnapshot.context ?? currentContext;
+                 config = {
+@@ -157,8 +186,10 @@
+                 await emit({ type: "agent_end", messages: newMessages });
+                 return;
+             }
++            signal?.throwIfAborted();
+             pendingMessages = (await config.getSteeringMessages?.()) || [];
+         }
++        signal?.throwIfAborted();
+         // Agent would stop here. Check for follow-up messages.
+         const followUpMessages = (await config.getFollowUpMessages?.()) || [];
+         if (followUpMessages.length > 0) {
+@@ -176,13 +207,16 @@
+  * This is where AgentMessage[] gets transformed to Message[] for the LLM.
+  */
+ async function streamAssistantResponse(context, config, signal, emit, streamFunction) {
++    signal?.throwIfAborted();
+     // Apply context transform if configured (AgentMessage[] → AgentMessage[])
+     let messages = context.messages;
+     if (config.transformContext) {
+         messages = await config.transformContext(messages, signal);
+     }
++    signal?.throwIfAborted();
+     // Convert to LLM-compatible messages (AgentMessage[] → Message[])
+     const llmMessages = await config.convertToLlm(messages);
++    signal?.throwIfAborted();
+     // Build LLM context
+     const llmContext = {
+         systemPrompt: context.systemPrompt,
+@@ -191,6 +225,7 @@
+     };
+     // Resolve API key (important for expiring tokens)
+     const resolvedApiKey = (config.getApiKey ? await config.getApiKey(config.model.provider) : undefined) || config.apiKey;
++    signal?.throwIfAborted();
+     const response = await streamFunction(config.model, llmContext, {
+         ...config,
+         apiKey: resolvedApiKey,
+@@ -284,8 +319,7 @@
+ /**
+  * Execute tool calls from an assistant message.
+  */
+-async function executeToolCalls(currentContext, assistantMessage, config, signal, emit) {
+-    const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall");
++async function executeToolCalls(currentContext, assistantMessage, config, signal, emit, toolCalls) {
+     const hasSequentialToolCall = toolCalls.some((tc) => currentContext.tools?.find((t) => t.name === tc.name)?.executionMode === "sequential");
+     if (config.toolExecution === "sequential" || hasSequentialToolCall) {
+         return executeToolCallsSequential(currentContext, assistantMessage, toolCalls, config, signal, emit);
+@@ -362,7 +396,7 @@
+             break;
+         }
+     }
+-    const orderedFinalizedCalls = await Promise.all(finalizedCalls.map((entry) => (typeof entry === "function" ? entry() : Promise.resolve(entry))));
++    const orderedFinalizedCalls = await settleAll(finalizedCalls.map((entry) => (typeof entry === "function" ? entry() : Promise.resolve(entry))));
+     const messages = [];
+     for (const finalized of orderedFinalizedCalls) {
+         const toolResultMessage = createToolResultMessage(finalized);
+@@ -374,6 +408,14 @@
+         terminate: shouldTerminateToolBatch(orderedFinalizedCalls),
+     };
+ }
++// A failed tool/event must not release the owner while siblings are still running.
++async function settleAll(promises) {
++    const settled = await Promise.allSettled(promises);
++    return settled.map((entry) => {
++        if (entry.status === "rejected") throw entry.reason;
++        return entry.value;
++    });
++}
+ function shouldTerminateToolBatch(finalizedCalls) {
+     return finalizedCalls.length > 0 && finalizedCalls.every((finalized) => finalized.result.terminate === true);
+ }
+@@ -400,6 +442,7 @@
+         };
+     }
+     try {
++        signal?.throwIfAborted();
+         const preparedToolCall = prepareToolCallArguments(tool, toolCall);
+         const validatedArgs = validateToolArguments(tool, preparedToolCall);
+         if (config.beforeToolCall) {
+@@ -454,6 +497,7 @@
+     const updateEvents = [];
+     let acceptingUpdates = true;
+     try {
++        signal?.throwIfAborted();
+         const result = await prepared.tool.execute(prepared.toolCall.id, prepared.args, signal, (partialResult) => {
+             if (!acceptingUpdates)
+                 return;
+@@ -466,12 +510,12 @@
+             })));
+         });
+         acceptingUpdates = false;
+-        await Promise.all(updateEvents);
++        await settleAll(updateEvents);
+         return { result, isError: false };
+     }
+     catch (error) {
+         acceptingUpdates = false;
+-        await Promise.all(updateEvents);
++        await settleAll(updateEvents);
+         return {
+             result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
+             isError: true,
+diff --git a/dist/agent-loop.d.ts b/dist/agent-loop.d.ts
+--- a/dist/agent-loop.d.ts
++++ b/dist/agent-loop.d.ts
+@@ -2,7 +2,7 @@
+  * Agent loop that works with AgentMessage throughout.
+  * Transforms to Message[] only at the LLM call boundary.
+  */
+-import { EventStream } from "@earendil-works/pi-ai";
++import { type AssistantMessage, type ToolCall, EventStream } from "@earendil-works/pi-ai";
+ import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, StreamFn } from "./types.ts";
+ export type AgentEventSink = (event: AgentEvent) => Promise<void> | void;
+ /**
+@@ -21,4 +21,7 @@
+ export declare function agentLoopContinue(context: AgentContext, config: AgentLoopConfig, signal: AbortSignal | undefined, streamFn: StreamFn): EventStream<AgentEvent, AgentMessage[]>;
+ export declare function runAgentLoop(prompts: AgentMessage[], context: AgentContext, config: AgentLoopConfig, emit: AgentEventSink, signal: AbortSignal | undefined, streamFn: StreamFn): Promise<AgentMessage[]>;
+ export declare function runAgentLoopContinue(context: AgentContext, config: AgentLoopConfig, emit: AgentEventSink, signal: AbortSignal | undefined, streamFn: StreamFn): Promise<AgentMessage[]>;
++/** Local pinned pending-tool integration. */
++export declare function getPendingToolContinuation(context: AgentContext): { assistant: AssistantMessage; calls: ToolCall[] };
++export declare function runAgentLoopPendingTools(context: AgentContext, pending: { assistant: AssistantMessage; calls: ToolCall[] }, config: AgentLoopConfig, emit: AgentEventSink, signal: AbortSignal, streamFn: StreamFn): Promise<AgentMessage[]>;
+ //# sourceMappingURL=agent-loop.d.ts.map
+\ No newline at end of file

--- a/turbo/patches/@earendil-works__pi-coding-agent@0.84.1.patch
+++ b/turbo/patches/@earendil-works__pi-coding-agent@0.84.1.patch
@@ -12,3 +12,227 @@ index 3078895bedba898ce26c439b6123425834ca2586..2ad6a42c60d6277dd0ab49c3e972eaa4
              return photonModule;
          }
          catch {
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -324,13 +324,14 @@
+         this._resolveIdleWait = undefined;
+         resolve();
+     }
+-    async _emitAgentSettled() {
+-        this._isAgentRunActive = false;
++    async _emitAgentSettled(keepActive = false) {
++        if (!keepActive) this._isAgentRunActive = false;
+         try {
+             await this._extensionRunner.emit({ type: "agent_settled" });
+             this._emit({ type: "agent_settled" });
+         }
+         finally {
++            if (keepActive) this._isAgentRunActive = false;
+             this._resolveIdleWaitIfIdle();
+         }
+     }
+@@ -741,6 +742,25 @@
+     // =========================================================================
+     // Prompting
+     // =========================================================================
++    /** Local pinned API for an API-owned assistant's unresolved tools. */
++    async continuePendingTools(options) {
++        if (this.isStreaming || this.agent.state.isStreaming || this.isCompacting) {
++            throw new Error("Agent is already processing. Wait for completion before continuing.");
++        }
++        await this.agent.continuePendingTools({
++            onStart: () => {
++                this._isAgentRunActive = true;
++                options?.preflightResult?.(true);
++            },
++            afterRun: (signal) => this._handlePostAgentRun(signal),
++            onSettled: async () => {
++                this._lastAssistantMessage = undefined;
++                this._systemPromptOverride = undefined;
++                this._flushPendingBashMessages();
++                await this._emitAgentSettled(true);
++            },
++        });
++    }
+     async _runAgentPrompt(messages) {
+         this._isAgentRunActive = true;
+         try {
+@@ -755,13 +775,14 @@
+             await this._emitAgentSettled();
+         }
+     }
+-    async _handlePostAgentRun() {
++    async _handlePostAgentRun(signal) {
++        signal?.throwIfAborted();
+         const msg = this._lastAssistantMessage;
+         this._lastAssistantMessage = undefined;
+         if (!msg) {
+             return false;
+         }
+-        if (this._isRetryableError(msg) && (await this._prepareRetry(msg))) {
++        if (this._isRetryableError(msg) && (await this._prepareRetry(msg, signal))) {
+             return true;
+         }
+         if (msg.stopReason === "error" && this._retryAttempt > 0) {
+@@ -773,7 +794,8 @@
+             });
+             this._retryAttempt = 0;
+         }
+-        if (await this._checkCompaction(msg)) {
++        signal?.throwIfAborted();
++        if (await this._checkCompaction(msg, true, signal)) {
+             return true;
+         }
+         // The agent loop drains both queues before emitting agent_end. Any messages
+@@ -1171,10 +1193,10 @@
+         await this.waitForIdle();
+     }
+     async waitForIdle() {
+-        if (this.isIdle) {
+-            return;
++        if (!this.isIdle) {
++            await this._getIdleWaitPromise();
+         }
+-        await this._getIdleWaitPromise();
++        await this.agent.waitForIdle();
+     }
+     // =========================================================================
+     // Model Management
+@@ -1507,7 +1529,8 @@
+      * @param assistantMessage The assistant message to check
+      * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
+      */
+-    async _checkCompaction(assistantMessage, skipAbortedCheck = true) {
++    async _checkCompaction(assistantMessage, skipAbortedCheck = true, signal) {
++        signal?.throwIfAborted();
+         const settings = this.settingsManager.getCompactionSettings();
+         if (!settings.enabled)
+             return false;
+@@ -1537,7 +1560,7 @@
+         if (sameModel && (isContextOverflow(assistantMessage, contextWindow) || recoverableLength)) {
+             const willRetry = assistantMessage.stopReason !== "stop";
+             if (!willRetry) {
+-                return await this._runAutoCompaction("overflow", false);
++                return await this._runAutoCompaction("overflow", false, signal);
+             }
+             if (this._overflowRecoveryAttempted) {
+                 this._emit({
+@@ -1557,7 +1580,7 @@
+             if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
+                 this.agent.state.messages = messages.slice(0, -1);
+             }
+-            return await this._runAutoCompaction("overflow", willRetry);
++            return await this._runAutoCompaction("overflow", willRetry, signal);
+         }
+         // Case 2: Threshold - context is getting large
+         // For error messages or all-zero usage messages, estimate from the last valid response.
+@@ -1585,14 +1608,15 @@
+             contextTokens = directContextTokens;
+         }
+         if (shouldCompact(contextTokens, contextWindow, settings)) {
+-            return await this._runAutoCompaction("threshold", false);
++            return await this._runAutoCompaction("threshold", false, signal);
+         }
+         return false;
+     }
+     /**
+      * Internal: Run auto-compaction with events.
+      */
+-    async _runAutoCompaction(reason, willRetry) {
++    async _runAutoCompaction(reason, willRetry, signal) {
++        signal?.throwIfAborted();
+         const settings = this.settingsManager.getCompactionSettings();
+         let started = false;
+         try {
+@@ -1600,6 +1624,7 @@
+                 return false;
+             }
+             const { model: requestModel, apiKey, headers, env } = await this._getSummarizationRequestAuth(this.model);
++            signal?.throwIfAborted();
+             const pathEntries = this.sessionManager.getBranch();
+             const preparation = prepareCompaction(pathEntries, settings);
+             if (!preparation) {
+@@ -1608,6 +1633,8 @@
+             this._emit({ type: "compaction_start", reason });
+             this._autoCompactionAbortController = new AbortController();
+             started = true;
++            const compactionSignal = signal ? AbortSignal.any([signal, this._autoCompactionAbortController.signal]) : this._autoCompactionAbortController.signal;
++            compactionSignal.throwIfAborted();
+             let extensionCompaction;
+             let fromExtension = false;
+             if (this._extensionRunner.hasHandlers("session_before_compact")) {
+@@ -1618,7 +1645,7 @@
+                     customInstructions: undefined,
+                     reason,
+                     willRetry,
+-                    signal: this._autoCompactionAbortController.signal,
++                    signal: compactionSignal,
+                 }));
+                 if (extensionResult?.cancel) {
+                     this._emit({
+@@ -1635,6 +1662,7 @@
+                     fromExtension = true;
+                 }
+             }
++            compactionSignal.throwIfAborted();
+             let summary;
+             let firstKeptEntryId;
+             let tokensBefore;
+@@ -1650,14 +1678,14 @@
+             }
+             else {
+                 // Generate compaction result
+-                const compactResult = await compact(preparation, requestModel, apiKey, headers, undefined, this._autoCompactionAbortController.signal, this.thinkingLevel, this.agent.streamFunction, env, this.settingsManager.getRetrySettings(), this._summarizationRetryCallbacks({ source: "compaction", reason }));
++                const compactResult = await compact(preparation, requestModel, apiKey, headers, undefined, compactionSignal, this.thinkingLevel, this.agent.streamFunction, env, this.settingsManager.getRetrySettings(), this._summarizationRetryCallbacks({ source: "compaction", reason }));
+                 summary = compactResult.summary;
+                 firstKeptEntryId = compactResult.firstKeptEntryId;
+                 tokensBefore = compactResult.tokensBefore;
+                 usage = compactResult.usage;
+                 details = compactResult.details;
+             }
+-            if (this._autoCompactionAbortController.signal.aborted) {
++            if (compactionSignal.aborted) {
+                 this._emit({
+                     type: "compaction_end",
+                     reason,
+@@ -1715,7 +1743,7 @@
+                     type: "compaction_end",
+                     reason,
+                     result: undefined,
+-                    aborted: false,
++                    aborted: signal?.aborted === true,
+                     willRetry: false,
+                     errorMessage: reason === "overflow"
+                         ? `Context overflow recovery failed: ${errorMessage}`
+@@ -2118,7 +2146,8 @@
+      * Prepare a retryable error for continuation with exponential backoff.
+      * @returns true if the caller should continue the agent, false otherwise
+      */
+-    async _prepareRetry(message) {
++    async _prepareRetry(message, signal) {
++        signal?.throwIfAborted();
+         const settings = this.settingsManager.getRetrySettings();
+         if (!settings.enabled) {
+             return false;
+@@ -2145,7 +2174,7 @@
+         // Wait with exponential backoff (abortable)
+         this._retryAbortController = new AbortController();
+         try {
+-            await sleep(delayMs, this._retryAbortController.signal);
++            await sleep(delayMs, signal ? AbortSignal.any([signal, this._retryAbortController.signal]) : this._retryAbortController.signal);
+         }
+         catch {
+             // Aborted during sleep - emit end event so UI can clean up
+diff --git a/dist/core/agent-session.d.ts b/dist/core/agent-session.d.ts
+--- a/dist/core/agent-session.d.ts
++++ b/dist/core/agent-session.d.ts
+@@ -341,6 +341,8 @@
+     private _normalizePromptSnippet;
+     private _normalizePromptGuidelines;
+     private _rebuildSystemPrompt;
++    /** Resume unresolved handoff tools under one native abort/settlement lifecycle. */
++    continuePendingTools(options?: Pick<PromptOptions, "preflightResult">): Promise<void>;
+     private _runAgentPrompt;
+     private _handlePostAgentRun;
+     /**

--- a/turbo/patches/pi-pending-tools.md
+++ b/turbo/patches/pi-pending-tools.md
@@ -1,0 +1,44 @@
+# Pi 0.84.1 pending-tool integration
+
+`AgentSession.continuePendingTools()` is a local additive API, paired with
+`Agent.continuePendingTools()` and their declarations. Upstream `continue()`
+and both low-level continuation APIs reject a trailing assistant; consuming
+queued input is not an equivalent handoff. Keep the version pinned at 0.84.1.
+
+The entrypoint validates the current assistant and its unresolved calls, then
+claims native Agent ownership before session startup acknowledgement or any
+awaited event/tool work. The existing loop handles the pending assistant's
+tools without emitting or appending that assistant or its original user again.
+It retains argument preparation, hooks, sequential/parallel execution, partial
+updates, result metadata, persistence, turn preparation, and the length guard.
+
+The Agent's native abort controller remains active through AgentSession's
+post-run retry/compaction/queue handling and awaited terminal extension hooks.
+These run within the original lifecycle through the integration callbacks;
+`finishRun()` releases it only afterwards. Normal prompt calls retain their
+existing post-run path. Optional signals on shared session helpers identify
+the pending operation; retry/compaction retain their own explicit abort controls
+while also observing that native owner. A fresh explicit prompt obtains a new
+signal. Unconsumed steering/follow-up input stays in the native queues.
+
+Cancellation gates surround awaited context conversion, auth, turn preparation,
+and prepared-tool entry. Started tools and event callbacks are joined even if
+a sibling fails. Interrupted/unstarted calls retain upstream history handling;
+there is no second result journal, replay engine, or checkpoint format.
+
+Cancellation is cooperative: completed external effects are not rolled back,
+and a tool that ignores cancellation can delay settlement. Guest's existing
+10-second RPC abort acknowledgement deadline and child termination/reaping
+remain authoritative; this patch changes neither the protocol nor that bound.
+
+`pending-tool-cancellation.test.ts` uses real sessions/files, MSW and barriers in
+owned child tests. `rpc-cancellation.test.ts` drives the official stdin/stdout
+host with a separate kill deadline, including delayed settlement extensions.
+Its normalized aborted terminal fixture is also consumed by Guest's public
+CLI settlement integration test. Existing memory, route, handoff-mode and
+history-validation tests cover the surrounding contracts.
+
+When editing the integration, change the matching compiled JS and `.d.ts`
+patch hunks together, regenerate the pnpm patch hashes, and verify a frozen
+install plus the runtime/CLI type, build and focused test checks. Preserve the
+independent photon and provider account-binding patches.

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -85,11 +85,14 @@ overrides:
   zod: 4.3.6
 
 patchedDependencies:
+  '@earendil-works/pi-agent-core@0.84.1':
+    hash: 554d597b60149c6bc6cd8bff1aaf7783431dc79303b1ad6cd83e35ea05c50f0c
+    path: patches/@earendil-works__pi-agent-core@0.84.1.patch
   '@earendil-works/pi-ai@0.84.1':
     hash: e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55
     path: patches/@earendil-works__pi-ai@0.84.1.patch
   '@earendil-works/pi-coding-agent@0.84.1':
-    hash: 370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289
+    hash: c6d2545cf9fa43d9845d3d4041705f01e30ea2fa9468f276f494506e59b3b6a7
     path: patches/@earendil-works__pi-coding-agent@0.84.1.patch
 
 importers:
@@ -367,7 +370,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=c6d2545cf9fa43d9845d3d4041705f01e30ea2fa9468f276f494506e59b3b6a7)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1150,7 +1153,7 @@ importers:
         version: 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=c6d2545cf9fa43d9845d3d4041705f01e30ea2fa9468f276f494506e59b3b6a7)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@okouai/api-contracts':
         specifier: workspace:*
         version: link:../api-contracts
@@ -1161,6 +1164,9 @@ importers:
         specifier: '>=2.8.3'
         version: 2.9.0
     devDependencies:
+      msw:
+        specifier: ^2.13.2
+        version: 2.13.2(@types/node@24.3.0)(@typescript/typescript6@6.0.2)
       '@okouai/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -11209,7 +11215,7 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@earendil-works/pi-agent-core@0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
+  '@earendil-works/pi-agent-core@0.84.1(patch_hash=554d597b60149c6bc6cd8bff1aaf7783431dc79303b1ad6cd83e35ea05c50f0c)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-ai': 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-telemetry': 0.84.1
@@ -11251,9 +11257,9 @@ snapshots:
     dependencies:
       '@earendil-works/pi-protocol': 0.84.2
 
-  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=370d127fc0fe07e83cb02a268bacca9e657803d556da65be8c0e43e5cb980289)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=c6d2545cf9fa43d9845d3d4041705f01e30ea2fa9468f276f494506e59b3b6a7)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+      '@earendil-works/pi-agent-core': 0.84.1(patch_hash=554d597b60149c6bc6cd8bff1aaf7783431dc79303b1ad6cd83e35ea05c50f0c)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-ai': 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-client': 0.84.2
       '@earendil-works/pi-protocol': 0.84.2

--- a/turbo/pnpm-workspace.yaml
+++ b/turbo/pnpm-workspace.yaml
@@ -106,6 +106,7 @@ overrides:
   zod: 4.3.6
 
 patchedDependencies:
+  "@earendil-works/pi-agent-core@0.84.1": patches/@earendil-works__pi-agent-core@0.84.1.patch
   "@earendil-works/pi-ai@0.84.1": patches/@earendil-works__pi-ai@0.84.1.patch
   "@earendil-works/pi-coding-agent@0.84.1": patches/@earendil-works__pi-coding-agent@0.84.1.patch
 


### PR DESCRIPTION
## Summary

An API-owned pending-tool handoff could acknowledge startup and native abort before its tools had a native run owner, allowing a later file effect or provider request after cancellation. Resume it through a typed `AgentSession.continuePendingTools()` entrypoint that owns the native Agent and session until terminal settlement.

Closes #31915. Parent: #31901.

- Add matching JS/declaration patches to pinned Pi 0.84.1 and update their lock hashes. Reuse the native executor, hooks, tool events, result ordering and persistence without replaying the original user or assistant. Remove the host executor and private `_runAgentPrompt` cast.
- Keep one native signal through tools, context/auth preparation, HTTP, retry/compaction, late queued input and awaited settlement callbacks. Join parallel tools and partial-update callbacks even when a sibling fails; acknowledge abort only after owned work settles.
- Preserve the length/tool argument guard, partial results, added-tool metadata, memory-note effects, session identity, all three handoff modes, and the existing active-input and model-route contracts. Native retry and queued continuation also remain covered on the successful path.

## Validation

- Focused runtime/RPC/history suite: **72 passed** across `rpc-cancellation`, `pending-tool-cancellation`, `session-runtime`, `rpc`, `session-validation`, and `session-memory`. Subsequent real-reopen and successful retry/late-input cases: **3 passed** (two strengthened cases and one additional case).
- Actual official RPC stdin/stdout assertions cover startup/busy/steer/duplicate-abort acknowledgements, held tools and settlement extensions, in-flight HTTP cancellation, one aborted assistant and one `agent_settled`. The normalized actual terminal fixture is shared with Guest's public result projection test.
- Deterministic native session barriers cover sequential/parallel tools, preparation, context conversion, auth, payload, retry, compaction, event failures, fresh signals and real JSONL reopening. New HTTP fixtures use MSW; hang-sensitive cases run in owned children with kill deadlines.
- CLI handoff/agent-loop checks: **49 cases verified**. Four existing 10-second RPC deadlines fired during competing local compilation/type checks; all four passed unchanged in a focused rerun. No timeout changes.
- Guest settlement and stalled-stdin cancellation integration tests passed; affected Guest fmt, Clippy and documentation checks passed.
- Runtime lint/types/build and public declaration boundary, CLI types/build, scoped runtime/CLI Knip, formatting and diff checks passed. The built CLI contains the native entrypoint. Frozen pnpm install, patch dry application against the official 0.84.1 packages, and all patch hashes were verified.
- Historical #31902 acceptance is retained: merge `9a84dc87ccba2f12c6e8e7e16bbc6eea1d4c8501`, [controller review](https://github.com/vm0-ai/vm0/pull/31910#pullrequestreview-5121051015); its focused history regressions remain green.

## Compatibility and limits

The additive implementation and declarations ship together in the CLI/runtime artifact. SDK versions, handoff/Rust protocols, persisted formats, provider/account/tier and billing policies are unchanged. The photon and provider account-binding patches are preserved.

Cancellation remains cooperative: completed external effects are not rolled back. Tools that ignore the signal retain the existing Guest abort deadline and termination/reaping fallback. Full repository validation belongs to PR and merge-group CI; no local full Vitest suite, dev server or production action was used.
