### PR TITLE
test(platform): synchronize snapshot measurement setup

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-dialog.test.tsx
@@ -545,9 +545,13 @@ test("Inspect empty IndexedDB storage before the first snapshot arrives", async 
 });
 
 test("Measure the threads inside a singleton snapshot on demand", async () => {
+  const snapshotRequested = context.mocks.deferred<void>();
   const agentId = crypto.randomUUID();
   context.mocks.data.agents([{ agentId }]);
   context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    if (!snapshotRequested.settled()) {
+      snapshotRequested.resolve();
+    }
     return respond(200, {
       chatThreads: ["Snapshot 文 😀", "Second thread", "Third thread"].map(
         (title) => {
@@ -579,6 +583,9 @@ test("Measure the threads inside a singleton snapshot on demand", async () => {
     featureSwitches: { [FeatureSwitchKey.OkouDebug]: true },
     sharedWorkerTestTransport: "message-port",
   });
+  // Page content can render before the message-port bootstrap reaches the
+  // snapshot fixture. Start the DOM wait after that network boundary.
+  await snapshotRequested.promise;
   await screen.findByText("Snapshot 文 😀");
   const rail = await screen.findByTestId("labeled-nav-rail");
   click(within(rail).getByLabelText("Test User"));


### PR DESCRIPTION
## Summary

Stabilize the Settings snapshot measurement test by waiting for its snapshot request before starting the DOM lookup. With the real MessagePort transport, `setupPage` can finish while authenticated snapshot bootstrap is still pending; under coverage load, the DOM lookup can exhaust its one-second timeout before the snapshot mock is reached.

Use a signal-owned deferred resolved by the existing snapshot handler, with an idempotent settlement guard for repeated requests. Keep the MessagePort transport and all storage measurement assertions intact.

Failure: https://github.com/vm0-ai/vm0/actions/runs/33964791041/job/101302930690

## Verification

- Reproduced the original missing-title failure in 4 of 8 diagnostic repetitions under concurrent coverage; the synchronized version passed all 27 tests in the same two-file setup.
- Final patch: both snapshot tests passed in five separate Vitest runs (10 executions), and all 19 Settings dialog tests passed with V8 coverage.
- Passed targeted Prettier, ESLint, Oxlint (including type-aware checks), platform test TypeScript checking, and platform Knip.
- Normal commit hooks passed formatting, repository Knip, all 15 selected Turbo type-check/build tasks, file-size checking, and commitlint on the latest base.

Detailed diagnosis: https://a.okou.io/eodxk2w12w.md
