### PR TITLE
fix: restore the search dialog chat result limit

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/workspace-chat-search.ts
+++ b/turbo/apps/platform/src/signals/okou-page/workspace-chat-search.ts
@@ -134,7 +134,12 @@ export const threeColumnSearchChatThreads$ = computed(
       return get(workspaceSearchChatThreads$);
     }
     const threads = await get(chatThreads$);
-    return { query, chatThreads: threads.map(workspaceSearchChatThread) };
+    return {
+      query,
+      chatThreads: threads
+        .slice(0, MAX_VISIBLE_CHAT_THREAD_RESULTS)
+        .map(workspaceSearchChatThread),
+    };
   },
 );
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
@@ -138,10 +138,10 @@ test.each([
     modifiers: { metaKey: false, ctrlKey: true },
   },
 ])(
-  "Open the ninth current chat from search on $platform",
+  "Limit empty search to 25 current chats and open the ninth result on $platform",
   async ({ userAgent, modifiers }) => {
     context.mocks.browser.userAgent(userAgent);
-    const threads = Array.from({ length: 11 }, (_, index) => {
+    const threads = Array.from({ length: 30 }, (_, index) => {
       return chatListThread(index + 1, `Chat ${index + 1}`, {
         pinnedAt: index < 2 ? `2026-08-01T00:5${2 - index}:00.000Z` : null,
       });
@@ -156,15 +156,18 @@ test.each([
       auth: workspace.auth,
       featureSwitches,
     });
-    await waitFor(() => {
-      expect(sidebarThreadTitles()).toHaveLength(11);
-    });
-    const expectedTitles = sidebarThreadTitles();
-    expect(expectedTitles.slice(0, 3)).toStrictEqual([
+    const expectedTitles = [
       "Chat 1",
       "Chat 2",
-      "Chat 11",
-    ]);
+      ...Array.from({ length: 23 }, (_, index) => {
+        return `Chat ${30 - index}`;
+      }),
+    ];
+    await waitFor(() => {
+      expect(sidebarThreadTitles().slice(0, 3)).toStrictEqual(
+        expectedTitles.slice(0, 3),
+      );
+    });
     click(fastButton("Hide chat list"));
     const { dialog, search } = await openSearch(modifiers);
     await waitFor(() => {
@@ -197,7 +200,7 @@ test.each([
     });
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).toBeNull();
-      expect(pathname()).toBe(`/chats/${threads[4]!.id}`);
+      expect(pathname()).toBe(`/chats/${threads[23]!.id}`);
     });
     expect(screen.queryByTestId("chat-list-column")).toBeNull();
   },


### PR DESCRIPTION
## Summary

With `stableChatThreadNavigation` enabled, opening search with an empty query renders every current-agent chat because the branch added in #31833 bypasses the existing 25-result limit. Restore that shared limit after current-agent/unread filtering and pinned ordering, before mapping the search rows.

Expand the existing Mac and Windows shortcut tests from 11 to 30 chats. They verify the exact first 25 rendered results, pinned order, the first nine shortcut hints, and navigation to the ninth result.

## Verification

- Both expanded regression cases failed before the fix: 30 rendered results instead of 25.
- Search shortcut page tests: 8/8 passed after the fix, including unread filtering, keyword search, resource navigation, and the disabled feature-switch path.
- Platform lint and all three TypeScript configurations passed.
- Platform-scoped Knip, changed-file Prettier, commitlint, and `git diff --check` passed.
