### PR TITLE
test(platform): await chat metadata startup before navigation

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-metadata.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-metadata.test.tsx
@@ -190,6 +190,7 @@ async function expectReadyChat(title: string): Promise<HTMLElement> {
 
 test("Late thread details do not replace the conversation the user chose", async () => {
   const availableThreadList = context.mocks.deferred<void>();
+  const abandonedDetailsRequested = context.mocks.deferred<void>();
   const abandonedDetails = context.mocks.deferred<void>();
   const user = userEvent.setup({ delay: null });
 
@@ -209,6 +210,7 @@ test("Late thread details do not replace the conversation the user chose", async
     chatThreadMetadataContract.get,
     async ({ params, respond }) => {
       if (params.id === FIRST_THREAD_ID) {
+        abandonedDetailsRequested.resolve();
         await abandonedDetails.promise;
         return respond(
           200,
@@ -222,13 +224,16 @@ test("Late thread details do not replace the conversation the user chose", async
     },
   );
 
-  await startPage({
+  const page = await startPage({
     context,
     path: `/chats/${FIRST_THREAD_ID}`,
     auth: isolatedAuth(),
   });
 
+  // Keep the old details in flight before making another conversation available.
+  await abandonedDetailsRequested.promise;
   availableThreadList.resolve(undefined);
+  await page.ready;
   const chosenLink = await findLink("Chosen conversation");
   await user.click(chosenLink);
   const chosenRegion = await expectReadyChat("Chosen conversation");


### PR DESCRIPTION
The delayed-thread-details regression started its one-second link query immediately after `startPage()`, which can return while the startup skeleton is still visible. In the reported CI failure, the query timed out before the conversation list rendered.

Wait for the abandoned metadata request to be in flight before releasing the thread snapshot, then await the existing `page.ready` boundary before locating the chosen conversation. This makes the intended request ordering explicit and preserves the existing navigation and stale-title assertions. The change is confined to one test.

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-metadata.test.tsx --maxWorkers=2 --silent=passed-only`: five consecutive successful runs, 15/15 tests.
- Prettier, Oxlint, type-aware Oxlint, ESLint, Platform type checks, and Platform-scoped Knip passed.
- [PR CI test-app (6)](https://github.com/vm0-ai/vm0/actions/runs/33968113755/job/101311754974) passed all 25 files / 171 tests, including the original failing case (1.823 seconds). The Turbo gate and all 51 executed PR checks passed.
- The unchanged target passed once locally. The original timeout was observed in CI; it was not reproduced in that local baseline run.

## Failure evidence

- [Reported failure: test-app (6)](https://github.com/vm0-ai/vm0/actions/runs/33967274176/job/101309524523): `chat-metadata.test.tsx` / `Late thread details do not replace the conversation the user chose`, `Could not find link named Chosen conversation`, with the startup skeleton still rendered.
- The same test source passed in the [preceding merge-group job](https://github.com/vm0-ai/vm0/actions/runs/33966841037/job/101308386902) and [PR job](https://github.com/vm0-ai/vm0/actions/runs/33966985328/job/101308770623). The failed merge-group commit changed only `settings-dialog.test.tsx`.
- `ci-gate-turbo` reports the shard failure. The HTTP 500 warnings occur in later, passing tests; the failed job contains no unhandled rejection or teardown `AbortError` report.
