### PR TITLE
fix(pi): reconcile cancellation and input at native settlement

### DIFF
--- a/crates/guest-agent/tests/pi_cli_settlement_errors.rs
+++ b/crates/guest-agent/tests/pi_cli_settlement_errors.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 async fn run_settlement_case(
     run_id: &str,
-    assistant_message: &Value,
+    assistant_messages: &[Value],
     expected_result: &str,
     expected_assistant_text: Option<&str>,
     base_path: &OsStr,
@@ -27,13 +27,15 @@ async fn run_settlement_case(
     let assistant_event_path = tmp.path().join("pi-assistant-event.jsonl");
     std::fs::write(
         &assistant_event_path,
-        format!(
-            "{}\n",
-            serde_json::json!({
-                "type": "message_end",
-                "message": assistant_message,
+        assistant_messages
+            .iter()
+            .map(|message| {
+                format!(
+                    "{}\n",
+                    serde_json::json!({ "type": "message_end", "message": message })
+                )
             })
-        ),
+            .collect::<String>(),
     )?;
 
     let npx = bin_dir.join("npx");
@@ -207,7 +209,7 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
     let original_directory = std::env::current_dir()?;
     run_settlement_case(
         "00000000-0000-4000-8000-000000000124",
-        &serde_json::json!({
+        &[serde_json::json!({
             "role": "assistant",
             "content": [{ "type": "text", "text": "ignored assistant text" }],
             "model": "deepseek-v4-flash",
@@ -216,7 +218,7 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
             "stopReason": "error",
             "errorMessage": "API Error: Overloaded",
             "timestamp": 1,
-        }),
+        })],
         "API Error: Overloaded",
         Some("ignored assistant text"),
         &base_path,
@@ -225,7 +227,7 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
     .await?;
     run_settlement_case(
         "00000000-0000-4000-8000-000000000125",
-        &serde_json::json!({
+        &[serde_json::json!({
             "role": "assistant",
             "content": [{ "type": "text", "text": "ignored assistant text" }],
             "model": "deepseek-v4-flash",
@@ -234,7 +236,7 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
             "stopReason": "aborted",
             "errorMessage": "",
             "timestamp": 1,
-        }),
+        })],
         "Pi model turn aborted",
         Some("ignored assistant text"),
         &base_path,
@@ -249,7 +251,22 @@ async fn guest_preserves_pi_error_and_aborted_settlement_results()
     assert_eq!(settlement["type"], "agent_settled");
     run_settlement_case(
         "00000000-0000-4000-8000-000000000126",
-        &assistant_end["message"],
+        std::slice::from_ref(&assistant_end["message"]),
+        "This operation was aborted",
+        None,
+        &base_path,
+        &original_directory,
+    )
+    .await?;
+    // A normal stop already reached Guest when cancellation wins during
+    // settlement preparation. Guest must replace its cached terminal outcome.
+    let [success, aborted, settlement]: [Value; 3] = serde_json::from_str(include_str!(
+        "../../../turbo/packages/pi-agent-runtime/src/test/fixtures/pending-tool-settlement-abort.json"
+    ))?;
+    assert_eq!(settlement["type"], "agent_settled");
+    run_settlement_case(
+        "00000000-0000-4000-8000-000000000127",
+        &[success["message"].clone(), aborted["message"].clone()],
         "This operation was aborted",
         None,
         &base_path,

--- a/turbo/packages/pi-agent-runtime/src/pending-tool-cancellation.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/pending-tool-cancellation.test.ts
@@ -288,11 +288,29 @@ describe("native pending-tool cancellation", () => {
           return event === "agent_settled";
         }),
       ).toHaveLength(1);
-      expect(session.messages.at(-1)).toMatchObject({
+      expect(
+        session.messages
+          .filter((message) => {
+            return message.role === "assistant";
+          })
+          .at(-1),
+      ).toMatchObject({
         role: "assistant",
         stopReason: "aborted",
       });
-      expect(session.pendingMessageCount).toBe(2);
+      expect(session.pendingMessageCount).toBe(0);
+      const cancelledHistory =
+        SessionManager.open(file).buildSessionContext().messages;
+      for (const text of ["acknowledged steering", "acknowledged follow-up"]) {
+        expect(
+          cancelledHistory.filter((message) => {
+            return (
+              message.role === "user" &&
+              JSON.stringify(message.content).includes(text)
+            );
+          }),
+        ).toHaveLength(1);
+      }
       expect(session.agent.signal).toBeUndefined();
       await expect(resumePiApiFirstTurn(session)).rejects.toThrow(
         "no pending tool calls",
@@ -452,10 +470,22 @@ describe("native pending-tool cancellation", () => {
       cancelled.promise,
     ]);
     expect(requests).toBe(1);
-    expect(session.messages.at(-1)).toMatchObject({ stopReason: "aborted" });
-    expect(session.getSteeringMessages()).toContain(
-      "accepted during native end",
-    );
+    expect(
+      session.messages
+        .filter((message) => {
+          return message.role === "assistant";
+        })
+        .at(-1),
+    ).toMatchObject({ stopReason: "aborted" });
+    expect(session.getSteeringMessages()).toEqual([]);
+    expect(
+      session.messages.filter((message) => {
+        return (
+          message.role === "user" &&
+          JSON.stringify(message.content).includes("accepted during native end")
+        );
+      }),
+    ).toHaveLength(1);
     expect(events).not.toContain("auto_retry_start");
     expect(events).not.toContain("compaction_start");
     expect(
@@ -638,7 +668,7 @@ describe("native pending-tool cancellation", () => {
     ).toHaveLength(1);
   }, 150_000);
 
-  it("does not compact or consume an end-handler queue after cancellation", async () => {
+  it("persists an end-handler queue without compaction or execution after cancellation", async () => {
     if (await runInIsolatedProcess(import.meta.url)) return;
     const requests = observeRequests(270_000);
     const { session, events } = await fixture({
@@ -656,10 +686,24 @@ describe("native pending-tool cancellation", () => {
     await resumePiApiFirstTurn(session);
     await abort;
     expect(requests).toHaveLength(1);
-    expect(session.getFollowUpMessages()).toEqual([
-      "owned end-handler follow-up",
-    ]);
-    expect(session.messages.at(-1)).toMatchObject({ stopReason: "aborted" });
+    expect(session.getFollowUpMessages()).toEqual([]);
+    expect(
+      session.messages.filter((message) => {
+        return (
+          message.role === "user" &&
+          JSON.stringify(message.content).includes(
+            "owned end-handler follow-up",
+          )
+        );
+      }),
+    ).toHaveLength(1);
+    expect(
+      session.messages
+        .filter((message) => {
+          return message.role === "assistant";
+        })
+        .at(-1),
+    ).toMatchObject({ stopReason: "aborted" });
     expect(events).not.toContain("compaction_start");
     expect(
       events.filter((event) => {

--- a/turbo/packages/pi-agent-runtime/src/rpc-cancellation.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/rpc-cancellation.test.ts
@@ -7,7 +7,7 @@ import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { MemoryPiSession } from "./session-memory";
 
@@ -19,16 +19,30 @@ const FIXTURE = fileURLToPath(
 // the fixture tool's cooperative boundary; official commands still use stdin.
 const EXTENSION = `import { writeFile } from "node:fs/promises";
 export default function (pi) {
-  if (process.argv[3] === "tool") pi.on("agent_settled", async () => {
+  if (process.argv[3] !== "http") pi.on("agent_settled", async (_event, ctx) => {
     await new Promise((resolve) => {
       const release = (message) => {
-        if (message === "release-settlement") {
+        if (message === "release-settlement" || message === "release-settlement-abort") {
+          if (message === "release-settlement-abort") ctx.abort();
           process.off("message", release);
           resolve();
         }
       };
       process.on("message", release);
       process.send({ type: "settling" });
+    });
+  });
+  if (process.argv[3] === "cancelled-input") pi.on("message_start", async (event, ctx) => {
+    if (event.message.role !== "user" || !ctx.signal?.aborted) return;
+    await new Promise((resolve) => {
+      const release = (message) => {
+        if (message === "release-input") {
+          process.off("message", release);
+          resolve();
+        }
+      };
+      process.on("message", release);
+      process.send({ type: "persisting-cancelled" });
     });
   });
   pi.registerTool({
@@ -56,215 +70,549 @@ export default function (pi) {
   });
 }`;
 
+async function rpcFixture(boundary: string) {
+  const root = await mkdtemp(join(tmpdir(), "pi-pending-rpc-"));
+  const effect = join(root, "effect.txt");
+  const extensions = join(root, "agent", "extensions");
+  await mkdir(extensions, { recursive: true });
+  await writeFile(join(extensions, "controlled.js"), EXTENSION);
+  const memory = MemoryPiSession.create({ cwd: root, id: SESSION_ID });
+  memory.appendMessage({
+    role: "user",
+    content: "original handoff",
+    timestamp: 1,
+  });
+  memory.appendMessage(
+    fauxAssistantMessage(
+      fauxToolCall("controlled", { path: effect }, { id: "call-0" }),
+      { stopReason: "toolUse", timestamp: 2 },
+    ),
+  );
+  await writeFile(join(root, "session.jsonl"), memory.toJsonl());
+  const child = spawn(
+    process.execPath,
+    ["--import", import.meta.resolve("tsx"), FIXTURE, root, boundary],
+    {
+      cwd: root,
+      stdio: ["pipe", "pipe", "pipe", "ipc"],
+      // The parent owns a real kill deadline; no same-thread timeout can make
+      // an unowned/hung native continuation look like successful settlement.
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    },
+  );
+  const { stdin, stdout, stderr: errorStream } = child;
+  if (!stdin || !stdout || !errorStream)
+    throw new Error("RPC fixture requires piped stdio");
+  const exit = once(child, "exit");
+  const lines = createInterface({ input: stdout, crlfDelay: Infinity });
+  const iterator = lines[Symbol.asyncIterator]();
+  const records: Array<Record<string, unknown>> = [];
+  const notifications: unknown[] = [];
+  let stderr = "";
+  errorStream.setEncoding("utf8").on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  child.on("message", (message) => {
+    notifications.push(message);
+  });
+  const send = (command: Record<string, unknown>) => {
+    stdin.write(`${JSON.stringify(command)}\n`);
+  };
+  const response = async (id: string) => {
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done) throw new Error(`RPC host exited before ${id}: ${stderr}`);
+      const record = JSON.parse(next.value) as Record<string, unknown>;
+      records.push(record);
+      if (record.type === "response" && record.id === id) return record;
+    }
+  };
+  onTestFinished(async () => {
+    if (child.exitCode === null && child.signalCode === null)
+      child.kill("SIGKILL");
+    await exit;
+    lines.close();
+    await rm(root, { recursive: true, force: true });
+  });
+  const notification = async (type: string) => {
+    for (;;) {
+      const found = notifications.find((message) => {
+        return (
+          typeof message === "object" &&
+          message !== null &&
+          "type" in message &&
+          message.type === type
+        );
+      });
+      if (found) return found;
+      await Promise.race([
+        once(child, "message"),
+        exit.then(() => {
+          throw new Error(`RPC host exited before ${type}: ${stderr}`);
+        }),
+      ]);
+    }
+  };
+  const settled = async () => {
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done)
+        throw new Error(`RPC host exited before settlement: ${stderr}`);
+      const record = JSON.parse(next.value) as Record<string, unknown>;
+      records.push(record);
+      if (record.type === "agent_settled") return;
+    }
+  };
+  const reopen = async () => {
+    stdin.end();
+    expect(await exit, stderr).toEqual([0, null]);
+    return MemoryPiSession.fromJsonl(
+      await readFile(join(root, "session.jsonl"), "utf8"),
+    );
+  };
+  return {
+    root,
+    effect,
+    child,
+    stdin,
+    exit,
+    records,
+    notifications,
+    send,
+    response,
+    notification,
+    settled,
+    reopen,
+  };
+}
+
+async function heldSettlement(boundary = "tool") {
+  const rpc = await rpcFixture(boundary);
+  rpc.send({ id: "startup", type: "prompt", message: "original handoff" });
+  expect(await rpc.response("startup")).toMatchObject({ success: true });
+  await rpc.notification("tool-start");
+  rpc.child.send("release-tool");
+  await rpc.notification("settling");
+  rpc.send({ id: "held", type: "get_state" });
+  expect(await rpc.response("held")).toMatchObject({
+    data: { isStreaming: true, pendingMessageCount: 0 },
+  });
+  expect(await readFile(rpc.effect, "utf8")).toBe("completed side effect");
+  return rpc;
+}
+
+function assistantEnds(records: Array<Record<string, unknown>>) {
+  return records.filter((record) => {
+    const message = record.message;
+    return (
+      record.type === "message_end" &&
+      typeof message === "object" &&
+      message !== null &&
+      "role" in message &&
+      message.role === "assistant"
+    );
+  });
+}
+
+function assertSettlement(
+  rpc: Awaited<ReturnType<typeof rpcFixture>>,
+  requests: number,
+) {
+  expect(
+    rpc.records.filter((record) => {
+      return record.type === "agent_settled";
+    }),
+  ).toHaveLength(1);
+  for (const [type, count] of [
+    ["tool-start", 1],
+    ["http-start", requests],
+    ["settling", 1],
+  ] as const) {
+    expect(
+      rpc.notifications.filter((message) => {
+        return (
+          typeof message === "object" &&
+          message !== null &&
+          "type" in message &&
+          message.type === type
+        );
+      }),
+    ).toHaveLength(count);
+  }
+}
+
 describe("official pending-tool RPC cancellation", () => {
+  it("reconciles the first abort and duplicate abort inside successful settlement", async () => {
+    const rpc = await heldSettlement();
+    rpc.send({ id: "abort", type: "abort" });
+    rpc.send({ id: "duplicate-abort", type: "abort" });
+    rpc.send({ id: "aborting", type: "get_state" });
+    expect(await rpc.response("aborting")).toMatchObject({
+      data: { isStreaming: true },
+    });
+    expect(
+      rpc.records.some((record) => {
+        return record.id === "abort" || record.type === "agent_settled";
+      }),
+    ).toBe(false);
+    rpc.child.send("release-settlement");
+    expect(await rpc.response("abort")).toMatchObject({ success: true });
+    expect(await rpc.response("duplicate-abort")).toMatchObject({
+      success: true,
+    });
+    const assistants = assistantEnds(rpc.records);
+    expect(assistants).toHaveLength(2);
+    expect(assistants[0]).toMatchObject({ message: { stopReason: "stop" } });
+    expect(assistants[1]).toMatchObject({ message: { stopReason: "aborted" } });
+    const settledIndex = rpc.records.findIndex((record) => {
+      return record.type === "agent_settled";
+    });
+    expect(rpc.records.indexOf(assistants[1]!)).toBeLessThan(settledIndex);
+    expect(settledIndex).toBeLessThan(
+      rpc.records.findIndex((record) => {
+        return record.id === "abort";
+      }),
+    );
+    const expected: unknown = JSON.parse(
+      await readFile(
+        new URL(
+          "./test/fixtures/pending-tool-settlement-abort.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    );
+    expect([
+      ...assistants.map((record) => {
+        const message = record.message;
+        if (typeof message !== "object" || message === null)
+          throw new Error("Expected assistant");
+        return { type: "message_end", message: { ...message, timestamp: 0 } };
+      }),
+      { type: "agent_settled" },
+    ]).toEqual(expected);
+    assertSettlement(rpc, 1);
+    const memory = await rpc.reopen();
+    expect(memory.buildSessionContext().messages.at(-1)).toMatchObject({
+      stopReason: "aborted",
+    });
+    expect(
+      memory.buildSessionContext().messages.filter((message) => {
+        return message.role === "assistant" && message.stopReason === "aborted";
+      }),
+    ).toHaveLength(1);
+  }, 30_000);
+
+  it.each([
+    { type: "steer" },
+    { type: "follow_up" },
+    { type: "prompt", streamingBehavior: "steer" },
+    { type: "prompt", streamingBehavior: "followUp" },
+  ])(
+    "persists first $type/$streamingBehavior accepted during settlement before EOF",
+    async (command) => {
+      const rpc = await heldSettlement();
+      rpc.send({ ...command, id: "input", message: "accepted while settling" });
+      expect(await rpc.response("input")).toMatchObject({ success: true });
+      rpc.send({ id: "queued", type: "get_state" });
+      expect(await rpc.response("queued")).toMatchObject({
+        data: { isStreaming: true, pendingMessageCount: 1 },
+      });
+      rpc.child.send("release-settlement");
+      await rpc.settled();
+      rpc.send({ id: "idle", type: "get_state" });
+      expect(await rpc.response("idle")).toMatchObject({
+        data: { isStreaming: false, pendingMessageCount: 0 },
+      });
+      assertSettlement(rpc, 2);
+      const memory = await rpc.reopen();
+      expect(
+        memory.buildSessionContext().messages.filter((message) => {
+          return (
+            message.role === "user" &&
+            JSON.stringify(message.content).includes("accepted while settling")
+          );
+        }),
+      ).toHaveLength(1);
+      expect(memory.buildSessionContext().messages.at(-1)).toMatchObject({
+        role: "assistant",
+        stopReason: "stop",
+      });
+      expect(assistantEnds(rpc.records)).toHaveLength(2);
+    },
+    30_000,
+  );
+
+  it.each(["rpc", "extension"])(
+    "persists accepted input when %s cancellation wins and explicitly rejects closed admission",
+    async (cancellation) => {
+      const rpc = await heldSettlement("cancelled-input");
+      rpc.send({
+        id: "input",
+        type: "steer",
+        message: "accepted while settling",
+      });
+      expect(await rpc.response("input")).toMatchObject({ success: true });
+      if (cancellation === "rpc") {
+        rpc.send({ id: "abort", type: "abort" });
+        rpc.send({ id: "aborting", type: "get_state" });
+        expect(await rpc.response("aborting")).toMatchObject({
+          data: { isStreaming: true },
+        });
+      }
+      rpc.child.send(
+        cancellation === "rpc"
+          ? "release-settlement"
+          : "release-settlement-abort",
+      );
+      await rpc.notification("persisting-cancelled");
+      for (const command of [
+        { type: "steer" },
+        { type: "follow_up" },
+        { type: "prompt", streamingBehavior: "steer" },
+      ]) {
+        rpc.send({
+          ...command,
+          id: "closed",
+          message: "not accepted after cancellation decision",
+        });
+        expect(await rpc.response("closed")).toMatchObject({
+          success: false,
+          error: expect.stringContaining("settling"),
+        });
+      }
+      rpc.child.send("release-input");
+      await rpc.settled();
+      if (cancellation === "rpc")
+        expect(await rpc.response("abort")).toMatchObject({ success: true });
+      rpc.send({ id: "idle", type: "get_state" });
+      expect(await rpc.response("idle")).toMatchObject({
+        data: { isStreaming: false, pendingMessageCount: 0 },
+      });
+      assertSettlement(rpc, 1);
+      const memory = await rpc.reopen();
+      const messages = memory.buildSessionContext().messages;
+      expect(
+        messages.filter((message) => {
+          return (
+            message.role === "user" &&
+            JSON.stringify(message.content).includes("accepted while settling")
+          );
+        }),
+      ).toHaveLength(1);
+      expect(
+        messages.some((message) => {
+          return (
+            message.role === "user" &&
+            JSON.stringify(message.content).includes(
+              "not accepted after cancellation decision",
+            )
+          );
+        }),
+      ).toBe(false);
+      expect(messages.at(-1)).toMatchObject({ stopReason: "aborted" });
+      expect(
+        messages.filter((message) => {
+          return (
+            message.role === "assistant" && message.stopReason === "aborted"
+          );
+        }),
+      ).toHaveLength(1);
+    },
+    30_000,
+  );
+
+  it("drains late steering before follow-ups in native order without repeating settlement hooks", async () => {
+    const rpc = await heldSettlement();
+    for (const [type, message] of [
+      ["follow_up", "follow-up one"],
+      ["steer", "steering one"],
+      ["steer", "steering two"],
+      ["follow_up", "follow-up two"],
+    ]) {
+      rpc.send({ id: "input", type, message });
+      expect(await rpc.response("input")).toMatchObject({ success: true });
+    }
+    rpc.child.send("release-settlement");
+    await rpc.settled();
+    assertSettlement(rpc, 5);
+    const memory = await rpc.reopen();
+    const users = memory.buildSessionContext().messages.filter((message) => {
+      return message.role === "user";
+    });
+    expect(
+      users.map((message) => {
+        return message.content;
+      }),
+    ).toEqual([
+      "original handoff",
+      [{ type: "text", text: "steering one" }],
+      [{ type: "text", text: "steering two" }],
+      [{ type: "text", text: "follow-up one" }],
+      [{ type: "text", text: "follow-up two" }],
+    ]);
+    expect(memory.buildSessionContext().messages.at(-1)).toMatchObject({
+      stopReason: "stop",
+    });
+  }, 30_000);
+
   it.each(["tool", "http"])(
     "acknowledges abort only after the owned %s boundary settles",
     async (boundary) => {
-      const root = await mkdtemp(join(tmpdir(), "pi-pending-rpc-"));
-      const effect = join(root, "effect.txt");
-      const extensions = join(root, "agent", "extensions");
-      await mkdir(extensions, { recursive: true });
-      await writeFile(join(extensions, "controlled.js"), EXTENSION);
-      const memory = MemoryPiSession.create({ cwd: root, id: SESSION_ID });
-      memory.appendMessage({
-        role: "user",
-        content: "original handoff",
-        timestamp: 1,
+      const {
+        root,
+        effect,
+        child,
+        stdin,
+        exit,
+        records,
+        notifications,
+        send,
+        response,
+      } = await rpcFixture(boundary);
+      send({ id: "state", type: "get_state" });
+      expect(await response("state")).toMatchObject({
+        success: true,
+        data: { sessionId: SESSION_ID },
       });
-      memory.appendMessage(
-        fauxAssistantMessage(
-          fauxToolCall("controlled", { path: effect }, { id: "call-0" }),
-          { stopReason: "toolUse", timestamp: 2 },
-        ),
-      );
-      await writeFile(join(root, "session.jsonl"), memory.toJsonl());
-      const child = spawn(
-        process.execPath,
-        ["--import", import.meta.resolve("tsx"), FIXTURE, root, boundary],
-        {
-          cwd: root,
-          stdio: ["pipe", "pipe", "pipe", "ipc"],
-          // The parent owns a real kill deadline; no same-thread timeout can make
-          // an unowned/hung native continuation look like successful settlement.
-          timeout: 20_000,
-          killSignal: "SIGKILL",
-        },
-      );
-      const { stdin, stdout, stderr: errorStream } = child;
-      if (!stdin || !stdout || !errorStream)
-        throw new Error("RPC fixture requires piped stdio");
-      const exit = once(child, "exit");
-      const lines = createInterface({ input: stdout, crlfDelay: Infinity });
-      const iterator = lines[Symbol.asyncIterator]();
-      const records: Array<Record<string, unknown>> = [];
-      const notifications: unknown[] = [];
-      let stderr = "";
-      errorStream.setEncoding("utf8").on("data", (chunk: string) => {
-        stderr += chunk;
+      const started = once(child, "message");
+      send({ id: "startup", type: "prompt", message: "original handoff" });
+      expect(await response("startup")).toMatchObject({
+        command: "prompt",
+        success: true,
       });
-      child.on("message", (message) => {
-        notifications.push(message);
+      expect((await started)[0]).toMatchObject({ type: "tool-start" });
+      send({
+        id: "busy",
+        type: "prompt",
+        message: "unowned concurrent prompt",
       });
-      const send = (command: Record<string, unknown>) => {
-        stdin.write(`${JSON.stringify(command)}\n`);
-      };
-      const response = async (id: string) => {
-        for (;;) {
-          const next = await iterator.next();
-          if (next.done)
-            throw new Error(`RPC host exited before ${id}: ${stderr}`);
-          const record = JSON.parse(next.value) as Record<string, unknown>;
-          records.push(record);
-          if (record.type === "response" && record.id === id) return record;
-        }
-      };
-      try {
-        send({ id: "state", type: "get_state" });
-        expect(await response("state")).toMatchObject({
-          success: true,
-          data: { sessionId: SESSION_ID },
+      expect(await response("busy")).toMatchObject({ success: false });
+      send({
+        id: "steer",
+        type: "steer",
+        message: "acknowledged active input",
+      });
+      expect(await response("steer")).toMatchObject({ success: true });
+      if (boundary === "http") {
+        const requested = once(child, "message");
+        child.send("release-tool");
+        expect((await requested)[0]).toMatchObject({
+          type: "http-start",
+          count: 1,
         });
-        const started = once(child, "message");
-        send({ id: "startup", type: "prompt", message: "original handoff" });
-        expect(await response("startup")).toMatchObject({
-          command: "prompt",
-          success: true,
-        });
-        expect((await started)[0]).toMatchObject({ type: "tool-start" });
-        send({
-          id: "busy",
-          type: "prompt",
-          message: "unowned concurrent prompt",
-        });
-        expect(await response("busy")).toMatchObject({ success: false });
-        send({
-          id: "steer",
-          type: "steer",
-          message: "acknowledged active input",
-        });
-        expect(await response("steer")).toMatchObject({ success: true });
-        if (boundary === "http") {
-          const requested = once(child, "message");
-          child.send("release-tool");
-          expect((await requested)[0]).toMatchObject({
-            type: "http-start",
-            count: 1,
-          });
-        }
-        const cancelled = once(child, "message");
-        send({ id: "abort", type: "abort" });
-        send({ id: "duplicate-abort", type: "abort" });
-        expect((await cancelled)[0]).toMatchObject({
-          type: boundary === "tool" ? "tool-aborted" : "http-aborted",
-        });
-        if (boundary === "tool") {
-          send({ id: "held", type: "get_state" });
-          expect(await response("held")).toMatchObject({
-            data: { isStreaming: true },
-          });
-          expect(
-            records.some((record) => {
-              return record.id === "abort" || record.type === "agent_settled";
-            }),
-          ).toBe(false);
-          const settling = once(child, "message");
-          child.send("release-tool");
-          expect((await settling)[0]).toMatchObject({ type: "settling" });
-          send({ id: "settlement-held", type: "get_state" });
-          expect(await response("settlement-held")).toMatchObject({
-            data: { isStreaming: true },
-          });
-          expect(
-            records.some((record) => {
-              return record.id === "abort" || record.type === "agent_settled";
-            }),
-          ).toBe(false);
-          child.send("release-settlement");
-        }
-        expect(await response("abort")).toMatchObject({
-          command: "abort",
-          success: true,
-        });
-        expect(await response("duplicate-abort")).toMatchObject({
-          command: "abort",
-          success: true,
-        });
-        send({ id: "idle", type: "get_state" });
-        expect(await response("idle")).toMatchObject({
-          data: { isStreaming: false },
+      }
+      const cancelled = once(child, "message");
+      send({ id: "abort", type: "abort" });
+      send({ id: "duplicate-abort", type: "abort" });
+      expect((await cancelled)[0]).toMatchObject({
+        type: boundary === "tool" ? "tool-aborted" : "http-aborted",
+      });
+      if (boundary === "tool") {
+        send({ id: "held", type: "get_state" });
+        expect(await response("held")).toMatchObject({
+          data: { isStreaming: true },
         });
         expect(
-          records.filter((record) => {
+          records.some((record) => {
+            return record.id === "abort" || record.type === "agent_settled";
+          }),
+        ).toBe(false);
+        const settling = once(child, "message");
+        child.send("release-tool");
+        expect((await settling)[0]).toMatchObject({ type: "settling" });
+        send({ id: "settlement-held", type: "get_state" });
+        expect(await response("settlement-held")).toMatchObject({
+          data: { isStreaming: true },
+        });
+        expect(
+          records.some((record) => {
+            return record.id === "abort" || record.type === "agent_settled";
+          }),
+        ).toBe(false);
+        child.send("release-settlement");
+      }
+      expect(await response("abort")).toMatchObject({
+        command: "abort",
+        success: true,
+      });
+      expect(await response("duplicate-abort")).toMatchObject({
+        command: "abort",
+        success: true,
+      });
+      send({ id: "idle", type: "get_state" });
+      expect(await response("idle")).toMatchObject({
+        data: { isStreaming: false },
+      });
+      expect(
+        records.filter((record) => {
+          return record.type === "agent_settled";
+        }),
+      ).toHaveLength(1);
+      const assistants = records.filter((record) => {
+        const message = record.message;
+        return (
+          record.type === "message_end" &&
+          typeof message === "object" &&
+          message !== null &&
+          "role" in message &&
+          message.role === "assistant"
+        );
+      });
+      expect(assistants).toHaveLength(1);
+      expect(assistants[0]).toMatchObject({
+        message: { stopReason: "aborted" },
+      });
+      if (boundary === "tool") {
+        const terminal = assistants[0]?.message;
+        if (typeof terminal !== "object" || terminal === null)
+          throw new Error("Expected native aborted assistant");
+        const expected: unknown = JSON.parse(
+          await readFile(
+            new URL("./test/fixtures/pending-tool-abort.json", import.meta.url),
+            "utf8",
+          ),
+        );
+        expect([
+          { type: "message_end", message: { ...terminal, timestamp: 0 } },
+          records.find((record) => {
             return record.type === "agent_settled";
           }),
-        ).toHaveLength(1);
-        const assistants = records.filter((record) => {
-          const message = record.message;
+        ]).toEqual(expected);
+      }
+      const requestCount = () => {
+        return notifications.filter((message) => {
           return (
-            record.type === "message_end" &&
             typeof message === "object" &&
             message !== null &&
-            "role" in message &&
-            message.role === "assistant"
+            "type" in message &&
+            message.type === "http-start"
           );
+        }).length;
+      };
+      expect(requestCount()).toBe(boundary === "http" ? 1 : 0);
+      if (boundary === "tool")
+        await expect(readFile(effect)).rejects.toMatchObject({
+          code: "ENOENT",
         });
-        expect(assistants).toHaveLength(1);
-        expect(assistants[0]).toMatchObject({
-          message: { stopReason: "aborted" },
-        });
-        if (boundary === "tool") {
-          const terminal = assistants[0]?.message;
-          if (typeof terminal !== "object" || terminal === null)
-            throw new Error("Expected native aborted assistant");
-          const expected: unknown = JSON.parse(
-            await readFile(
-              new URL(
-                "./test/fixtures/pending-tool-abort.json",
-                import.meta.url,
-              ),
-              "utf8",
-            ),
-          );
-          expect([
-            { type: "message_end", message: { ...terminal, timestamp: 0 } },
-            records.find((record) => {
-              return record.type === "agent_settled";
-            }),
-          ]).toEqual(expected);
-        }
-        const requestCount = () => {
-          return notifications.filter((message) => {
-            return (
-              typeof message === "object" &&
-              message !== null &&
-              "type" in message &&
-              message.type === "http-start"
-            );
-          }).length;
-        };
-        expect(requestCount()).toBe(boundary === "http" ? 1 : 0);
-        if (boundary === "tool")
-          await expect(readFile(effect)).rejects.toMatchObject({
-            code: "ENOENT",
-          });
-        else
-          expect(await readFile(effect, "utf8")).toBe("completed side effect");
-        stdin.end();
-        expect(await exit, stderr).toEqual([0, null]);
-        const persisted = MemoryPiSession.fromJsonl(
-          await readFile(join(root, "session.jsonl"), "utf8"),
-        );
-        expect(persisted.getSessionId()).toBe(SESSION_ID);
-        expect(persisted.buildSessionContext().messages.at(-1)).toMatchObject({
-          stopReason: "aborted",
-        });
-      } finally {
-        if (child.exitCode === null && child.signalCode === null)
-          child.kill("SIGKILL");
-        await exit;
-        lines.close();
-        await rm(root, { recursive: true, force: true });
-      }
+      else expect(await readFile(effect, "utf8")).toBe("completed side effect");
+      stdin.end();
+      expect(await exit).toEqual([0, null]);
+      const persisted = MemoryPiSession.fromJsonl(
+        await readFile(join(root, "session.jsonl"), "utf8"),
+      );
+      expect(persisted.getSessionId()).toBe(SESSION_ID);
+      expect(
+        persisted
+          .buildSessionContext()
+          .messages.filter((message) => {
+            return message.role === "assistant";
+          })
+          .at(-1),
+      ).toMatchObject({
+        stopReason: "aborted",
+      });
     },
     30_000,
   );

--- a/turbo/packages/pi-agent-runtime/src/test/fixtures/pending-tool-settlement-abort.json
+++ b/turbo/packages/pi-agent-runtime/src/test/fixtures/pending-tool-settlement-abort.json
@@ -1,0 +1,66 @@
+[
+  {
+    "type": "message_end",
+    "message": {
+      "role": "assistant",
+      "content": [],
+      "api": "openai-responses",
+      "provider": "openai",
+      "model": "gpt-5.6-terra",
+      "usage": {
+        "input": 5,
+        "output": 2,
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "reasoning": 0,
+        "totalTokens": 7,
+        "cost": {
+          "input": 0.000009999999999999999,
+          "output": 0.000024,
+          "cacheRead": 0,
+          "cacheWrite": 0,
+          "total": 0.000034
+        }
+      },
+      "stopReason": "stop",
+      "timestamp": 0,
+      "responseId": "response_fixture",
+      "rawStopReason": "completed"
+    }
+  },
+  {
+    "type": "message_end",
+    "message": {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": ""
+        }
+      ],
+      "api": "openai-responses",
+      "provider": "openai",
+      "model": "gpt-5.6-terra",
+      "usage": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheWrite": 0,
+        "totalTokens": 0,
+        "cost": {
+          "input": 0,
+          "output": 0,
+          "cacheRead": 0,
+          "cacheWrite": 0,
+          "total": 0
+        }
+      },
+      "stopReason": "aborted",
+      "errorMessage": "This operation was aborted",
+      "timestamp": 0
+    }
+  },
+  {
+    "type": "agent_settled"
+  }
+]

--- a/turbo/patches/@earendil-works__pi-agent-core@0.84.1.patch
+++ b/turbo/patches/@earendil-works__pi-agent-core@0.84.1.patch
@@ -7,7 +7,36 @@ diff --git a/dist/agent.js b/dist/agent.js
  import { getDefaultStreamFn } from "./stream-fn.js";
  function defaultConvertToLlm(messages) {
      return messages.filter((message) => message.role === "user" || message.role === "assistant" || message.role === "toolResult");
-@@ -254,6 +254,36 @@
+@@ -171,12 +171,19 @@ export class Agent {
+     }
+     /** Queue a message to be injected after the current assistant turn finishes. */
+     steer(message) {
++        this.assertQueueAdmission();
+         this.steeringQueue.enqueue(message);
+     }
+     /** Queue a message to run only after the agent would otherwise stop. */
+     followUp(message) {
++        this.assertQueueAdmission();
+         this.followUpQueue.enqueue(message);
+     }
++    assertQueueAdmission() {
++        if (this.activeRun?.acceptingMessages === false) {
++            throw new Error("Agent is settling. Wait for completion before submitting input.");
++        }
++    }
+     /** Remove all queued steering messages. */
+     clearSteeringQueue() {
+         this.steeringQueue.clear();
+@@ -200,7 +207,7 @@ export class Agent {
+     }
+     /** Abort the current run, if one is active. */
+     abort() {
+-        this.activeRun?.abortController.abort();
++        if (this.activeRun?.acceptingMessages !== false) this.activeRun?.abortController.abort();
+     }
+     /**
+      * Resolve when the current run and all awaited event listeners have finished.
+@@ -254,6 +261,53 @@ export class Agent {
          }
          await this.runContinuation();
      }
@@ -21,45 +50,88 @@ diff --git a/dist/agent.js b/dist/agent.js
 +        await this.runWithLifecycle(async (signal) => {
 +            options.onStart?.();
 +            await runAgentLoopPendingTools(context, pending, this.createLoopConfig(), (event) => this.processEvents(event), signal, this.streamFunction);
++            await this.handlePendingPostRun(signal, options.afterRun);
++        }, options);
++    }
++    async handlePendingPostRun(signal, afterRun) {
++        if (signal.aborted && this._state.messages.at(-1)?.stopReason === "aborted") return;
++        signal.throwIfAborted();
++        while (await afterRun?.(signal)) {
++            await this.runPendingContinuation(signal);
 +            if (signal.aborted && this._state.messages.at(-1)?.stopReason === "aborted") return;
 +            signal.throwIfAborted();
-+            while (await options.afterRun?.(signal)) {
-+                signal.throwIfAborted();
-+                const lastMessage = this._state.messages.at(-1);
-+                if (lastMessage?.role === "assistant") {
-+                    const steering = this.steeringQueue.drain();
-+                    const messages = steering.length > 0 ? steering : this.followUpQueue.drain();
-+                    if (messages.length === 0) throw new Error("Cannot continue from message role: assistant");
-+                    await runAgentLoop(messages, this.createContextSnapshot(), this.createLoopConfig({ skipInitialSteeringPoll: steering.length > 0 }), (event) => this.processEvents(event), signal, this.streamFunction);
-+                }
-+                else {
-+                    await runAgentLoopContinue(this.createContextSnapshot(), this.createLoopConfig(), (event) => this.processEvents(event), signal, this.streamFunction);
-+                }
-+                if (signal.aborted && this._state.messages.at(-1)?.stopReason === "aborted") return;
-+                signal.throwIfAborted();
++        }
++        signal.throwIfAborted();
++    }
++    async runPendingContinuation(signal) {
++        signal.throwIfAborted();
++        if (this._state.messages.at(-1)?.role === "assistant") {
++            const steering = this.steeringQueue.drain();
++            const messages = steering.length > 0 ? steering : this.followUpQueue.drain();
++            if (messages.length === 0) throw new Error("Cannot continue from message role: assistant");
++            await runAgentLoop(messages, this.createContextSnapshot(), this.createLoopConfig({ skipInitialSteeringPoll: steering.length > 0 }), (event) => this.processEvents(event), signal, this.streamFunction);
++        }
++        else {
++            await runAgentLoopContinue(this.createContextSnapshot(), this.createLoopConfig(), (event) => this.processEvents(event), signal, this.streamFunction);
++        }
++    }
++    async persistCancelledQueue() {
++        // Admission is closed. Preserve accepted input through native events,
++        // without starting another turn, tool, provider, retry or compaction.
++        while (this.hasQueuedMessages()) {
++            const steering = this.steeringQueue.drain();
++            const messages = steering.length > 0 ? steering : this.followUpQueue.drain();
++            for (const message of messages) {
++                await this.processEvents({ type: "message_start", message });
++                await this.processEvents({ type: "message_end", message });
 +            }
-+            signal.throwIfAborted();
-+        }, options.onSettled);
++        }
 +    }
      normalizePromptInput(input, images) {
          if (Array.isArray(input)) {
              return input;
-@@ -323,7 +353,7 @@
+@@ -323,7 +377,7 @@ export class Agent {
              getFollowUpMessages: async () => this.followUpQueue.drain(),
          };
      }
 -    async runWithLifecycle(executor) {
-+    async runWithLifecycle(executor, onSettled) {
++    async runWithLifecycle(executor, settlement) {
          if (this.activeRun) {
              throw new Error("Agent is already processing.");
          }
-@@ -343,7 +373,12 @@
+@@ -343,7 +397,38 @@ export class Agent {
              await this.handleRunFailure(error, abortController.signal.aborted);
          }
          finally {
 -            this.finishRun();
 +            try {
-+                if (onSettled) await onSettled();
++                if (settlement) {
++                    // Extension preparation runs once, even if it accepts more input.
++                    await settlement.beforeSettled?.();
++                    for (;;) {
++                        if (abortController.signal.aborted) {
++                            this.activeRun.acceptingMessages = false;
++                            await this.persistCancelledQueue();
++                            const assistant = this._state.messages.findLast((message) => message.role === "assistant");
++                            if (assistant?.stopReason !== "aborted") {
++                                await this.handleRunFailure(abortController.signal.reason, true);
++                            }
++                            break;
++                        }
++                        if (!this.hasQueuedMessages()) break;
++                        try {
++                            await this.runPendingContinuation(abortController.signal);
++                            await this.handlePendingPostRun(abortController.signal, settlement.afterRun);
++                        }
++                        catch (error) {
++                            await this.handleRunFailure(error, abortController.signal.aborted);
++                        }
++                    }
++                    // No await between the final decision, public settlement and
++                    // finishRun. Reentrant input must receive explicit non-acceptance.
++                    this.activeRun.acceptingMessages = false;
++                    settlement.onSettled?.();
++                }
 +            }
 +            finally {
 +                this.finishRun();
@@ -70,16 +142,28 @@ diff --git a/dist/agent.js b/dist/agent.js
 diff --git a/dist/agent.d.ts b/dist/agent.d.ts
 --- a/dist/agent.d.ts
 +++ b/dist/agent.d.ts
-@@ -109,6 +109,12 @@
+@@ -84,6 +84,7 @@ export declare class Agent {
+     steer(message: AgentMessage): void;
+     /** Queue a message to run only after the agent would otherwise stop. */
+     followUp(message: AgentMessage): void;
++    private assertQueueAdmission;
+     /** Remove all queued steering messages. */
+     clearSteeringQueue(): void;
+     /** Remove all queued follow-up messages. */
+@@ -109,6 +110,16 @@ export declare class Agent {
      prompt(input: string, images?: ImageContent[]): Promise<void>;
      /** Continue from the current transcript. The last message must be a user or tool-result message. */
      continue(): Promise<void>;
-+    /** Local pinned integration; callbacks run inside the native abort/idle owner. */
++    /** Local pinned integration; prepare once, reconcile cancellation/input, then commit synchronously. */
 +    continuePendingTools(options?: {
 +        onStart?: () => void;
 +        afterRun?: (signal: AbortSignal) => Promise<boolean>;
-+        onSettled?: () => Promise<void>;
++        beforeSettled?: () => Promise<void>;
++        onSettled?: () => void;
 +    }): Promise<void>;
++    private handlePendingPostRun;
++    private runPendingContinuation;
++    private persistCancelledQueue;
      private normalizePromptInput;
      private runPromptMessages;
      private runContinuation;

--- a/turbo/patches/@earendil-works__pi-coding-agent@0.84.1.patch
+++ b/turbo/patches/@earendil-works__pi-coding-agent@0.84.1.patch
@@ -15,24 +15,7 @@ index 3078895bedba898ce26c439b6123425834ca2586..2ad6a42c60d6277dd0ab49c3e972eaa4
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
-@@ -324,13 +324,14 @@
-         this._resolveIdleWait = undefined;
-         resolve();
-     }
--    async _emitAgentSettled() {
--        this._isAgentRunActive = false;
-+    async _emitAgentSettled(keepActive = false) {
-+        if (!keepActive) this._isAgentRunActive = false;
-         try {
-             await this._extensionRunner.emit({ type: "agent_settled" });
-             this._emit({ type: "agent_settled" });
-         }
-         finally {
-+            if (keepActive) this._isAgentRunActive = false;
-             this._resolveIdleWaitIfIdle();
-         }
-     }
-@@ -741,6 +742,25 @@
+@@ -741,6 +741,35 @@ export class AgentSession {
      // =========================================================================
      // Prompting
      // =========================================================================
@@ -47,18 +30,28 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
 +                options?.preflightResult?.(true);
 +            },
 +            afterRun: (signal) => this._handlePostAgentRun(signal),
-+            onSettled: async () => {
++            beforeSettled: async () => {
++                this._flushPendingBashMessages();
++                await this._extensionRunner.emit({ type: "agent_settled" });
++            },
++            onSettled: () => {
 +                this._lastAssistantMessage = undefined;
 +                this._systemPromptOverride = undefined;
 +                this._flushPendingBashMessages();
-+                await this._emitAgentSettled(true);
++                try {
++                    this._emit({ type: "agent_settled" });
++                }
++                finally {
++                    this._isAgentRunActive = false;
++                    this._resolveIdleWaitIfIdle();
++                }
 +            },
 +        });
 +    }
      async _runAgentPrompt(messages) {
          this._isAgentRunActive = true;
          try {
-@@ -755,13 +775,14 @@
+@@ -755,13 +784,14 @@ export class AgentSession {
              await this._emitAgentSettled();
          }
      }
@@ -75,7 +68,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
              return true;
          }
          if (msg.stopReason === "error" && this._retryAttempt > 0) {
-@@ -773,7 +794,8 @@
+@@ -773,7 +803,8 @@ export class AgentSession {
              });
              this._retryAttempt = 0;
          }
@@ -85,7 +78,41 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
              return true;
          }
          // The agent loop drains both queues before emitting agent_end. Any messages
-@@ -1171,10 +1193,10 @@
+@@ -1014,8 +1045,6 @@ export class AgentSession {
+      * Internal: Queue a steering message (already expanded, no extension command check).
+      */
+     async _queueSteer(text, images) {
+-        this._steeringMessages.push(text);
+-        this._emitQueueUpdate();
+         const content = [{ type: "text", text }];
+         if (images) {
+             content.push(...images);
+@@ -1025,13 +1054,13 @@ export class AgentSession {
+             content,
+             timestamp: Date.now(),
+         });
++        this._steeringMessages.push(text);
++        this._emitQueueUpdate();
+     }
+     /**
+      * Internal: Queue a follow-up message (already expanded, no extension command check).
+      */
+     async _queueFollowUp(text, images) {
+-        this._followUpMessages.push(text);
+-        this._emitQueueUpdate();
+         const content = [{ type: "text", text }];
+         if (images) {
+             content.push(...images);
+@@ -1041,6 +1070,8 @@ export class AgentSession {
+             content,
+             timestamp: Date.now(),
+         });
++        this._followUpMessages.push(text);
++        this._emitQueueUpdate();
+     }
+     /**
+      * Throw an error if the text is an extension command.
+@@ -1171,10 +1202,10 @@ export class AgentSession {
          await this.waitForIdle();
      }
      async waitForIdle() {
@@ -99,7 +126,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
      }
      // =========================================================================
      // Model Management
-@@ -1507,7 +1529,8 @@
+@@ -1507,7 +1538,8 @@ export class AgentSession {
       * @param assistantMessage The assistant message to check
       * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
       */
@@ -109,7 +136,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
          const settings = this.settingsManager.getCompactionSettings();
          if (!settings.enabled)
              return false;
-@@ -1537,7 +1560,7 @@
+@@ -1537,7 +1569,7 @@ export class AgentSession {
          if (sameModel && (isContextOverflow(assistantMessage, contextWindow) || recoverableLength)) {
              const willRetry = assistantMessage.stopReason !== "stop";
              if (!willRetry) {
@@ -118,7 +145,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
              }
              if (this._overflowRecoveryAttempted) {
                  this._emit({
-@@ -1557,7 +1580,7 @@
+@@ -1557,7 +1589,7 @@ export class AgentSession {
              if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
                  this.agent.state.messages = messages.slice(0, -1);
              }
@@ -127,7 +154,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
          }
          // Case 2: Threshold - context is getting large
          // For error messages or all-zero usage messages, estimate from the last valid response.
-@@ -1585,14 +1608,15 @@
+@@ -1585,14 +1617,15 @@ export class AgentSession {
              contextTokens = directContextTokens;
          }
          if (shouldCompact(contextTokens, contextWindow, settings)) {
@@ -145,7 +172,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
          const settings = this.settingsManager.getCompactionSettings();
          let started = false;
          try {
-@@ -1600,6 +1624,7 @@
+@@ -1600,6 +1633,7 @@ export class AgentSession {
                  return false;
              }
              const { model: requestModel, apiKey, headers, env } = await this._getSummarizationRequestAuth(this.model);
@@ -153,7 +180,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
              const pathEntries = this.sessionManager.getBranch();
              const preparation = prepareCompaction(pathEntries, settings);
              if (!preparation) {
-@@ -1608,6 +1633,8 @@
+@@ -1608,6 +1642,8 @@ export class AgentSession {
              this._emit({ type: "compaction_start", reason });
              this._autoCompactionAbortController = new AbortController();
              started = true;
@@ -162,7 +189,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
              let extensionCompaction;
              let fromExtension = false;
              if (this._extensionRunner.hasHandlers("session_before_compact")) {
-@@ -1618,7 +1645,7 @@
+@@ -1618,7 +1654,7 @@ export class AgentSession {
                      customInstructions: undefined,
                      reason,
                      willRetry,
@@ -171,7 +198,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
                  }));
                  if (extensionResult?.cancel) {
                      this._emit({
-@@ -1635,6 +1662,7 @@
+@@ -1635,6 +1671,7 @@ export class AgentSession {
                      fromExtension = true;
                  }
              }
@@ -179,7 +206,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
              let summary;
              let firstKeptEntryId;
              let tokensBefore;
-@@ -1650,14 +1678,14 @@
+@@ -1650,14 +1687,14 @@ export class AgentSession {
              }
              else {
                  // Generate compaction result
@@ -196,7 +223,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
                  this._emit({
                      type: "compaction_end",
                      reason,
-@@ -1715,7 +1743,7 @@
+@@ -1715,7 +1752,7 @@ export class AgentSession {
                      type: "compaction_end",
                      reason,
                      result: undefined,
@@ -205,7 +232,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
                      willRetry: false,
                      errorMessage: reason === "overflow"
                          ? `Context overflow recovery failed: ${errorMessage}`
-@@ -2118,7 +2146,8 @@
+@@ -2118,7 +2155,8 @@ export class AgentSession {
       * Prepare a retryable error for continuation with exponential backoff.
       * @returns true if the caller should continue the agent, false otherwise
       */
@@ -215,7 +242,7 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
          const settings = this.settingsManager.getRetrySettings();
          if (!settings.enabled) {
              return false;
-@@ -2145,7 +2174,7 @@
+@@ -2145,7 +2183,7 @@ export class AgentSession {
          // Wait with exponential backoff (abortable)
          this._retryAbortController = new AbortController();
          try {
@@ -227,11 +254,11 @@ diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
 diff --git a/dist/core/agent-session.d.ts b/dist/core/agent-session.d.ts
 --- a/dist/core/agent-session.d.ts
 +++ b/dist/core/agent-session.d.ts
-@@ -341,6 +341,8 @@
+@@ -341,6 +341,8 @@ export declare class AgentSession {
      private _normalizePromptSnippet;
      private _normalizePromptGuidelines;
      private _rebuildSystemPrompt;
-+    /** Resume unresolved handoff tools under one native abort/settlement lifecycle. */
++    /** Resume unresolved tools; settlement extensions prepare once before native cancellation/input reconciliation and public settlement. */
 +    continuePendingTools(options?: Pick<PromptOptions, "preflightResult">): Promise<void>;
      private _runAgentPrompt;
      private _handlePostAgentRun;

--- a/turbo/patches/pi-pending-tools.md
+++ b/turbo/patches/pi-pending-tools.md
@@ -19,7 +19,31 @@ These run within the original lifecycle through the integration callbacks;
 existing post-run path. Optional signals on shared session helpers identify
 the pending operation; retry/compaction retain their own explicit abort controls
 while also observing that native owner. A fresh explicit prompt obtains a new
-signal. Unconsumed steering/follow-up input stays in the native queues.
+signal.
+
+For this entrypoint, extension `agent_settled` handlers are awaited preparation,
+called once per owner while both native lifecycles remain busy. They can queue
+input or request cancellation through the supported, non-waiting `ctx.abort()`;
+they must not wait for their own owner to become idle. New turns caused by that
+input retain ordinary turn/message hooks, but do not re-enter settlement
+handlers. The public `agent_settled` event is the terminal commit notification.
+
+After preparation, the same owner reconciles cancellation first. Otherwise it
+drains accepted input in native steering/follow-up order, including post-run
+retry/compaction, and rechecks after every await. An empty queue and un-aborted
+signal close admission synchronously with public settlement and owner release.
+There is no asynchronous callback after this decision.
+
+When cancellation wins, native queue admission closes before awaited message
+callbacks. Accepted input is drained once into native message events and JSONL,
+without a new turn, tool, HTTP request, retry or compaction. The final assistant
+outcome is aborted before the sole public settlement. If a provider already
+emitted an aborted assistant, retain that fact instead of appending a duplicate;
+subsequently accepted input can follow it in history. A fresh prompt sees those
+messages as persisted context, never as a revived pending queue. Input arriving
+after admission closes receives the existing RPC error response, before queue
+display state changes. Guest therefore retains its existing failed-delivery
+path; successful acknowledgements never rely on a future prompt or process.
 
 Cancellation gates surround awaited context conversion, auth, turn preparation,
 and prepared-tool entry. Started tools and event callbacks are joined even if

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -86,13 +86,13 @@ overrides:
 
 patchedDependencies:
   '@earendil-works/pi-agent-core@0.84.1':
-    hash: 554d597b60149c6bc6cd8bff1aaf7783431dc79303b1ad6cd83e35ea05c50f0c
+    hash: c16c1735f34a3f1f5bba3dc1d7a80a78b1c9324f00b6ff1813916883f8a4ac11
     path: patches/@earendil-works__pi-agent-core@0.84.1.patch
   '@earendil-works/pi-ai@0.84.1':
     hash: e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55
     path: patches/@earendil-works__pi-ai@0.84.1.patch
   '@earendil-works/pi-coding-agent@0.84.1':
-    hash: c6d2545cf9fa43d9845d3d4041705f01e30ea2fa9468f276f494506e59b3b6a7
+    hash: ec82bfdbfcd840a2287feaaa6f4b3533743b1723225eb3823464f6b7ffe7c913
     path: patches/@earendil-works__pi-coding-agent@0.84.1.patch
 
 importers:
@@ -370,7 +370,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=c6d2545cf9fa43d9845d3d4041705f01e30ea2fa9468f276f494506e59b3b6a7)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=ec82bfdbfcd840a2287feaaa6f4b3533743b1723225eb3823464f6b7ffe7c913)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1153,7 +1153,7 @@ importers:
         version: 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
-        version: 0.84.1(patch_hash=c6d2545cf9fa43d9845d3d4041705f01e30ea2fa9468f276f494506e59b3b6a7)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+        version: 0.84.1(patch_hash=ec82bfdbfcd840a2287feaaa6f4b3533743b1723225eb3823464f6b7ffe7c913)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@okouai/api-contracts':
         specifier: workspace:*
         version: link:../api-contracts
@@ -11215,7 +11215,7 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@earendil-works/pi-agent-core@0.84.1(patch_hash=554d597b60149c6bc6cd8bff1aaf7783431dc79303b1ad6cd83e35ea05c50f0c)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
+  '@earendil-works/pi-agent-core@0.84.1(patch_hash=c16c1735f34a3f1f5bba3dc1d7a80a78b1c9324f00b6ff1813916883f8a4ac11)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-ai': 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-telemetry': 0.84.1
@@ -11257,9 +11257,9 @@ snapshots:
     dependencies:
       '@earendil-works/pi-protocol': 0.84.2
 
-  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=c6d2545cf9fa43d9845d3d4041705f01e30ea2fa9468f276f494506e59b3b6a7)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.84.1(patch_hash=ec82bfdbfcd840a2287feaaa6f4b3533743b1723225eb3823464f6b7ffe7c913)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.84.1(patch_hash=554d597b60149c6bc6cd8bff1aaf7783431dc79303b1ad6cd83e35ea05c50f0c)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
+      '@earendil-works/pi-agent-core': 0.84.1(patch_hash=c16c1735f34a3f1f5bba3dc1d7a80a78b1c9324f00b6ff1813916883f8a4ac11)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-ai': 0.84.1(patch_hash=e5308d9f3e3abf237b28f3b607b5f41e4535fe10f23a6c59d6c4a5fbf896be55)(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.1)(zod@4.3.6)
       '@earendil-works/pi-client': 0.84.2
       '@earendil-works/pi-protocol': 0.84.2


### PR DESCRIPTION
## Summary

An otherwise successful pending-tool continuation could accept its first abort or input while an extension held `agent_settled`, then publish success without reconciling either. Abort acknowledged success with a persisted `stop`; acknowledged input remained only in an SDK queue and disappeared after clean stdin EOF.

Keep the Pi 0.84.1 native owner through one awaited settlement preparation, reconcile cancellation before accepted input, and commit public settlement synchronously with admission closure. Uncancelled input follows native queue/continuation/persistence order. If cancellation wins, accepted input is persisted once through native message events without another tool, provider request, retry or compaction; later input receives the existing RPC failure response before queue display state changes. Supported extension `ctx.abort()` remains non-waiting, and settlement handlers run once rather than recursively for queued turns.

The original executor, graph validation, handoff modes, photon and provider binding patches remain intact. Paired declarations and lockfile patch hashes are updated. This is the focused acceptance repair for #31915 under #31901; production release and the API-only no-tool length slice are outside this PR.

Closes #31930

## Verification

- Reproduced both defects against the previous patches before applying the fix: first late abort lacked an aborted terminal; all four accepted input forms remained pending.
- Official stdin/stdout RPC regression file: **10 passed**, using real extension loading, temporary JSONL, MSW, deterministic barriers and a parent-owned kill deadline. Covers first/duplicate abort after successful tool/provider completion, first steer/follow-up/queued prompt, cancellation plus accepted input, closed-admission errors, native ordering, one settlement hook/event, and clean EOF/reopen durability.
- Runtime cancellation/session/history/memory/graph files: **71 passed**. Retains the original tool/pre-HTTP/in-flight HTTP, sequential/parallel, callback joining, retry/compaction, fresh-signal and reopen coverage. Three cancelled-queue assertions now verify immediate persistence rather than leaving accepted input in memory.
- CLI loop and API-first handoff files: **51 passed**, including the three handoff modes and existing routing/metadata contracts. One original 10-second RPC deadline failed during initial Rust compilation; the unchanged test passed alone and both complete focused files then passed, without changing timeouts.
- Guest settlement projection and stalled-stdin cancellation integration tests: **2 passed**; active-input receipt integration tests: **8 passed**. Guest consumes the normalized real RPC late-abort fixture to prove an earlier `stop` is replaced before the sole failed terminal result.
- Runtime/CLI type checks, lint, scoped Knip, runtime declarations/build and CLI build passed. Rust format, affected Guest Clippy and documentation checks passed; changed-file formatting and `git diff --check` passed.
- Frozen pnpm install passed. All three patches applied to official npm 0.84.1 tarballs; every patched file matched the installed runtime byte-for-byte. Photon and account binding remain unchanged.

No full local Vitest suite or dev server was run. Broad validation remains with required PR and merge-group CI. Cancellation remains cooperative: completed external effects are retained and non-cooperative work still depends on Guest's existing termination/reaping bound.
