### PR TITLE
fix(api): fail incomplete pi api-first no-tool output

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -4982,6 +4982,8 @@ function piResponsesContentSse(args: {
   readonly sequence: number;
   readonly includeReasoning?: boolean;
   readonly observedServiceTier?: string | null;
+  readonly incomplete?: boolean;
+  readonly usage?: Parameters<typeof piResponsesTextSse>[2];
 }): string {
   const responseId = `resp_pi_content_${args.sequence.toString()}`;
   const output: Record<string, unknown>[] = [];
@@ -5086,16 +5088,23 @@ function piResponsesContentSse(args: {
     );
   }
   events.push({
-    type: "response.completed",
+    type: args.incomplete ? "response.incomplete" : "response.completed",
     response: {
       id: responseId,
       object: "response",
-      status: "completed",
+      status: args.incomplete ? "incomplete" : "completed",
+      ...(args.incomplete
+        ? { incomplete_details: { reason: "max_output_tokens" } }
+        : {}),
       output,
       ...(args.observedServiceTier === undefined
         ? {}
         : { service_tier: args.observedServiceTier }),
-      usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+      usage: args.usage ?? {
+        input_tokens: 5,
+        output_tokens: 3,
+        total_tokens: 8,
+      },
     },
   });
   return events
@@ -5311,6 +5320,7 @@ async function cancelBeforeLatePiResult(
   actor: ApiTestUser,
   runId: string,
   releaseProvider: () => void,
+  usagePricingResolution?: UsagePricingFixture["resolution"],
 ): Promise<void> {
   // No public API holds the lifecycle transaction open; this scoped lock
   // makes cancellation commit before a completed provider result publishes.
@@ -5322,7 +5332,12 @@ async function cancelBeforeLatePiResult(
     lock.release();
     await lock.done;
   });
-  const cancellation = api.requestCancelRun(actor, runId, [200]);
+  const cancellation = api.requestCancelRun(
+    actor,
+    runId,
+    [200],
+    usagePricingResolution,
+  );
   await expect.poll(lock.waiterCount).toBe(1);
   releaseProvider();
   await expect.poll(lock.waiterCount).toBe(2);
@@ -5494,6 +5509,61 @@ function mockPiCheckpointObjectStore(): Map<string, Buffer> {
     );
   });
   return objects;
+}
+
+function expectNoPiApiFirstTurnArtifacts(
+  runId: string,
+  objects: ReadonlyMap<string, Buffer>,
+): void {
+  const prefix = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${runId}/`;
+  const artifactKeys = [`${prefix}session.jsonl`, `${prefix}manifest.json`];
+  for (const key of artifactKeys) {
+    expect(objects.has(key)).toBeFalsy();
+  }
+  // Terminal cleanup deletes temporary objects. Inspect the external writes
+  // too, so a briefly published H1 or manifest cannot pass this assertion.
+  const writes = context.mocks.s3.send.mock.calls.flatMap(([command]) => {
+    const candidate = command as PiCheckpointS3Command;
+    const key = piS3ObjectKey(candidate);
+    return candidate.constructor?.name === "PutObjectCommand" &&
+      key !== undefined &&
+      artifactKeys.includes(key)
+      ? [key]
+      : [];
+  });
+  expect(writes).toStrictEqual([]);
+}
+
+async function expectPiApiFirstTurnTerminalWithoutOutput(
+  actor: ApiTestUser,
+  run: { readonly runId: string; readonly threadId: string },
+  status: "failed" | "cancelled",
+): Promise<void> {
+  const terminal = await api.readRun(actor, run.runId);
+  expect(terminal).toMatchObject({
+    status,
+    ...(status === "failed"
+      ? {
+          error:
+            "[PI_API_MODEL_OUTPUT_INCOMPLETE] Pi API first-turn model output is incomplete",
+        }
+      : {}),
+  });
+  expect(terminal.result).toBeFalsy();
+  const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+  expect(eventBackedContents(events, run.runId)).toStrictEqual([]);
+  expect(
+    events
+      .filter((event) => {
+        return (
+          event.runId === run.runId &&
+          isChatRunTerminalEventType(event.eventType)
+        );
+      })
+      .map((event) => {
+        return event.eventType;
+      }),
+  ).toStrictEqual([`run.${status}`]);
 }
 
 const PI_RESOURCE_ARCHIVE_DOWNLOAD_URL =
@@ -9789,6 +9859,544 @@ describe("CHAT-02: model-first provider policies", () => {
         return message.content === answer;
       }),
     ).toHaveLength(1);
+  }, 90_000);
+
+  it.each([
+    { name: "text below cap", content: "text", atCap: false },
+    { name: "text at cap", content: "text", atCap: true },
+    { name: "empty", content: "empty", atCap: false },
+    { name: "thinking-only", content: "thinking", atCap: false },
+  ] as const)(
+    "fails incomplete Pi $name output once after recording consumed Built-in usage",
+    async ({ content, atCap }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const usagePricingResolution = await createTerraUsagePricingResolution();
+      await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+      await authDeviceSupport.updateFeatureSwitches(actor, {
+        [FeatureSwitchKey.PiLoop]: true,
+      });
+      mockPiResourceArchiveDownloads();
+      const objects = mockPiCheckpointObjectStore();
+      const consumedAgentEvents: { runId: string; eventType: string }[] = [];
+      const requests: unknown[] = [];
+      let outputTokens = 0;
+      const partialText = `private-incomplete-answer-${randomUUID()}`;
+      server.use(
+        http.post(
+          "https://api.axiom.co/v1/datasets/agent-run-events/ingest",
+          async ({ request }) => {
+            const events = z
+              .array(z.object({ runId: z.string(), eventType: z.string() }))
+              .parse(await request.json());
+            consumedAgentEvents.push(...events);
+            return HttpResponse.json({
+              ingested: events.length,
+              failed: 0,
+              processedBytes: 123,
+            });
+          },
+        ),
+        http.post(
+          "https://api.openai.com/v1/responses",
+          async ({ request }) => {
+            const body = await request.json();
+            requests.push(body);
+            const { max_output_tokens: cap } = z
+              .object({ max_output_tokens: z.number().int().positive() })
+              .parse(body);
+            expect(cap).toBeGreaterThan(3);
+            outputTokens = atCap ? cap : 3;
+            return nativeCodexSseResponse(
+              piResponsesContentSse({
+                sequence: requests.length,
+                blocks:
+                  content === "text"
+                    ? [{ type: "text", text: partialText }]
+                    : [],
+                includeReasoning: content === "thinking",
+                incomplete: true,
+                usage: {
+                  input_tokens: 10,
+                  output_tokens: outputTokens,
+                  total_tokens: 10 + outputTokens,
+                  input_tokens_details: {
+                    cached_tokens: 3,
+                    cache_write_tokens: 2,
+                  },
+                },
+              }),
+            );
+          },
+        ),
+      );
+      const run = await sendChatRun(
+        actor,
+        {
+          agentId,
+          model: "gpt-5.6-terra",
+          prompt: "finish one API-first answer",
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+      await waitForRunStatus(actor, run.runId, "failed");
+      await flushWaitUntilForTest();
+      await expectPiApiFirstTurnTerminalWithoutOutput(actor, run, "failed");
+      expectNoPiApiFirstTurnArtifacts(run.runId, objects);
+      expect(
+        [...objects.keys()].filter((key) => {
+          return key.includes("/blobs/");
+        }),
+      ).toStrictEqual([]);
+      expect(requests).toHaveLength(1);
+      // The existing run-scoped usage observation is the only billing ledger
+      // surface; public usage summaries cannot prove per-category exactness.
+      await expectTerraApiUsage(run.runId, "", {
+        input: 5,
+        output: outputTokens,
+        cacheRead: 3,
+        cacheCreation: 2,
+      });
+      expect(context.mocks.ably.channelGet).toHaveBeenCalledWith(
+        `runner-group:${runnerGroup}`,
+      );
+      expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
+        runId: run.runId,
+        mode: "hard",
+      });
+      await api.heartbeatRunner(runnerGroup);
+      await api.requestClaimRunnerJob(true, run.runId, [404], {
+        capabilities: { piModelConfigGenerations: [1, 2, 3] },
+      });
+      const sandboxHeaders = {
+        authorization: `Bearer ${api.sandboxTokenForRun(actor, run.runId)}`,
+      };
+      await webhooks.requestAgentComplete(
+        { runId: run.runId, exitCode: 0 },
+        sandboxHeaders,
+        [200],
+      );
+      await flushWaitUntilForTest();
+      await expectPiApiFirstTurnTerminalWithoutOutput(actor, run, "failed");
+      await expectTerraApiUsage(run.runId, "", {
+        input: 5,
+        output: outputTokens,
+        cacheRead: 3,
+        cacheCreation: 2,
+      });
+      expect(requests).toHaveLength(1);
+      expect(
+        consumedAgentEvents.filter((event) => {
+          return event.runId === run.runId;
+        }),
+      ).toStrictEqual([]);
+      const telemetry = JSON.stringify([
+        ...context.mocks.axiomLogging.debug.mock.calls,
+        ...context.mocks.axiomLogging.warn.mock.calls,
+      ]);
+      expect(telemetry).not.toContain(partialText);
+    },
+    90_000,
+  );
+
+  it.each(USER_OWNED_TERRA_FAST_BDD_ROUTES)(
+    "fails incomplete Pi $name Fast output without Built-in billing or provider substitution",
+    async (route) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      await configureUserOwnedTerraPiModel(actor, route);
+      mockPiResourceArchiveDownloads();
+      const objects = mockPiCheckpointObjectStore();
+      const requests: string[] = [];
+      server.use(
+        ...USER_OWNED_TERRA_FAST_BDD_ROUTES.map((candidate) => {
+          return http.post(candidate.endpoint, ({ request }) => {
+            requests.push(request.url);
+            return nativeCodexSseResponse(
+              piResponsesContentSse({
+                sequence: requests.length,
+                blocks: [
+                  { type: "text", text: "incomplete user-owned answer" },
+                ],
+                incomplete: true,
+              }),
+            );
+          });
+        }),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        model: "gpt-5.6-terra",
+        prompt: "finish the user-owned turn",
+        runOptions: { codexServiceTier: "fast" },
+      });
+      await waitForRunStatus(actor, run.runId, "failed");
+      await flushWaitUntilForTest();
+      await expectPiApiFirstTurnTerminalWithoutOutput(actor, run, "failed");
+      await expectNoBuiltInModelUsage(run.runId);
+      expectNoPiApiFirstTurnArtifacts(run.runId, objects);
+      expect(
+        [...objects.keys()].filter((key) => {
+          return key.includes("/blobs/");
+        }),
+      ).toStrictEqual([]);
+      await api.heartbeatRunner(runnerGroup);
+      await api.requestClaimRunnerJob(true, run.runId, [404], {
+        capabilities: { piModelConfigGenerations: [1, 2, 3] },
+      });
+      expect(requests).toStrictEqual([route.endpoint]);
+    },
+    90_000,
+  );
+
+  it.each(["in-flight", "late-result"] as const)(
+    "keeps canonical cancellation ahead of incomplete Pi output at the %s boundary",
+    async (phase) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockPiResourceArchiveDownloads();
+      const objects = mockPiCheckpointObjectStore();
+      const entered = createDeferredPromise<void>(context.signal);
+      const release = createDeferredPromise<void>(context.signal);
+      let requests = 0;
+      server.use(
+        http.post("https://api.openai.com/v1/responses", async () => {
+          requests += 1;
+          if (!entered.settled()) {
+            entered.resolve(undefined);
+          }
+          await release.promise;
+          return nativeCodexSseResponse(
+            piResponsesContentSse({
+              sequence: requests,
+              blocks: [{ type: "text", text: "incomplete cancelled answer" }],
+              incomplete: true,
+            }),
+          );
+        }),
+      );
+      const { anchor, anchorClaim, run, usagePricingResolution } =
+        await queueCapabilityProvenPiRun({
+          actor,
+          agentId,
+          runnerGroup,
+          prompt: "cancel an incomplete API-first turn",
+        });
+      await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+        usagePricingResolution,
+      });
+      await entered.promise;
+      if (phase === "late-result") {
+        await cancelBeforeLatePiResult(
+          actor,
+          run.runId,
+          () => {
+            release.resolve(undefined);
+          },
+          usagePricingResolution,
+        );
+      } else {
+        await api.requestCancelRun(
+          actor,
+          run.runId,
+          [200],
+          usagePricingResolution,
+        );
+        release.resolve(undefined);
+      }
+      await flushWaitUntilForTest();
+      await expectPiApiFirstTurnTerminalWithoutOutput(actor, run, "cancelled");
+      expectNoPiApiFirstTurnArtifacts(run.runId, objects);
+      if (phase === "late-result") {
+        await expectTerraApiFollowUpUsage(run.runId);
+      } else {
+        await expectNoBuiltInModelUsage(run.runId);
+      }
+      await api.requestClaimRunnerJob(true, run.runId, [404], {
+        capabilities: { piModelConfigGenerations: [1, 2, 3] },
+      });
+      expect(requests).toBe(1);
+    },
+    90_000,
+  );
+
+  it("fails incomplete Pi output while preserving undelivered active-input ownership", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const objects = mockPiCheckpointObjectStore();
+    const entered = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<void>(context.signal);
+    const requests: unknown[] = [];
+    server.use(
+      http.post("https://api.openai.com/v1/responses", async ({ request }) => {
+        requests.push(await request.json());
+        if (!entered.settled()) {
+          entered.resolve(undefined);
+        }
+        await release.promise;
+        return nativeCodexSseResponse(
+          piResponsesContentSse({
+            sequence: requests.length,
+            blocks: [
+              {
+                type: "text",
+                text:
+                  requests.length === 1
+                    ? "incomplete before accepted steer"
+                    : "completed the separately queued input",
+              },
+            ],
+            incomplete: requests.length === 1,
+          }),
+        );
+      }),
+    );
+    const { anchor, anchorClaim, run, usagePricingResolution } =
+      await queueCapabilityProvenPiRun({
+        actor,
+        agentId,
+        runnerGroup,
+        prompt: "hold the incomplete API-first turn",
+      });
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+      usagePricingResolution,
+    });
+    await entered.promise;
+    const claimed = await claimChatRun(runnerGroup, run.runId);
+    const activeInputEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: run.threadId,
+        prompt: "keep this accepted input",
+        clientEventId: activeInputEventId,
+      },
+      [201],
+    );
+    const reserved = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      run.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected in-flight active input to be reserved");
+    }
+    expect(reserved.prompt).toContain("keep this accepted input");
+    release.resolve(undefined);
+    await waitForRunStatus(actor, run.runId, "failed");
+    await flushWaitUntilForTest();
+    await expectPiApiFirstTurnTerminalWithoutOutput(actor, run, "failed");
+    expectNoPiApiFirstTurnArtifacts(run.runId, objects);
+    await expect(
+      api.reserveRunnerActiveInputs(claimed.claim.sandboxToken, run.runId),
+    ).resolves.toStrictEqual({ outcome: "terminal" });
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        run.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toMatchObject({ outcome: "rejected" });
+    const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+    expect(
+      events.filter((event) => {
+        return event.id === activeInputEventId;
+      }),
+    ).toHaveLength(1);
+    const replacements = events.filter((event) => {
+      return event.revokesEventId === activeInputEventId;
+    });
+    expect(replacements).toHaveLength(1);
+    const successor = replacements[0];
+    if (!successor?.runId) {
+      throw new Error("Expected undelivered input to retain queue ownership");
+    }
+    expect(successor.runId).not.toBe(run.runId);
+    // Terminal failure releases the accepted input into its own queued run.
+    // That explicit input owns the second request; the failed turn is not retried.
+    await waitForRunStatus(actor, successor.runId, "completed");
+    expect(eventBackedContents(events, successor.runId)).toMatchObject([
+      { content: "completed the separately queued input" },
+    ]);
+    expect(JSON.stringify(requests[1])).toContain("keep this accepted input");
+    expect(JSON.stringify(requests[1])).not.toContain(
+      "incomplete before accepted steer",
+    );
+    await expectTerraApiFollowUpUsage(run.runId);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith("cancel", {
+      runId: run.runId,
+      mode: "hard",
+    });
+    expect(requests).toHaveLength(2);
+  }, 90_000);
+
+  it("preserves ordinary Pi stop checkpoints and length with pending tools after incomplete output fails", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const usagePricingResolution = await createTerraUsagePricingResolution();
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+    await authDeviceSupport.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.PiLoop]: true,
+    });
+    mockPiResourceArchiveDownloads();
+    const objects = mockPiCheckpointObjectStore();
+    const requests: unknown[] = [];
+    const answer = "the last complete canonical answer";
+    const incompleteAnswer = "discarded incomplete canonical answer";
+    const callId = `call_length_${randomUUID()}`;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", async ({ request }) => {
+        requests.push(await request.json());
+        return nativeCodexSseResponse(
+          piResponsesContentSse({
+            sequence: requests.length,
+            incomplete: requests.length !== 1,
+            blocks:
+              requests.length === 3
+                ? [
+                    {
+                      type: "toolCall",
+                      callId,
+                      name: "bash",
+                      arguments: {
+                        command: "printf incomplete-tool-must-not-run",
+                      },
+                    },
+                  ]
+                : [
+                    {
+                      type: "text",
+                      text: requests.length === 1 ? answer : incompleteAnswer,
+                    },
+                  ],
+          }),
+        );
+      }),
+    );
+    const first = await sendChatRun(
+      actor,
+      {
+        agentId,
+        model: "gpt-5.6-terra",
+        prompt: "create the last complete checkpoint",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
+    await waitForRunStatus(actor, first.runId, "completed");
+    await flushWaitUntilForTest();
+    expect(requests).toHaveLength(1);
+    const firstEvents = (await chat.listThreadEvents(actor, first.threadId))
+      .events;
+    expect(eventBackedContents(firstEvents, first.runId)).toMatchObject([
+      { content: answer },
+    ]);
+    expect(
+      firstEvents.filter((event) => {
+        return (
+          event.runId === first.runId &&
+          isChatRunTerminalEventType(event.eventType)
+        );
+      }),
+    ).toMatchObject([{ eventType: "run.completed" }]);
+    await expectTerraApiFollowUpUsage(first.runId);
+    const blobEntries = [...objects.entries()].filter(([key]) => {
+      return key.includes("/blobs/");
+    });
+    expect(blobEntries).toHaveLength(1);
+    const h0 = blobEntries[0]?.[1];
+    if (!h0) {
+      throw new Error("Expected the ordinary stop checkpoint");
+    }
+    const h0Hash = createHash("sha256").update(h0).digest("hex");
+
+    const failed = await sendChatRun(
+      actor,
+      {
+        agentId,
+        threadId: first.threadId,
+        prompt: "produce incomplete output on the existing session",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
+    await waitForRunStatus(actor, failed.runId, "failed");
+    await flushWaitUntilForTest();
+    await expectPiApiFirstTurnTerminalWithoutOutput(actor, failed, "failed");
+    expectNoPiApiFirstTurnArtifacts(failed.runId, objects);
+    expect(
+      [...objects.entries()].filter(([key]) => {
+        return key.includes("/blobs/");
+      }),
+    ).toStrictEqual(blobEntries);
+    expect(requests).toHaveLength(2);
+
+    // Only this explicit user request continues the last successful H0. The
+    // failed turn cannot publish a new canonical checkpoint or start a retry.
+    const next = await sendChatRun(
+      actor,
+      {
+        agentId,
+        threadId: first.threadId,
+        prompt: "continue the preserved canonical session with tools",
+      },
+      "vm0",
+      usagePricingResolution,
+    );
+    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${next.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return objects.get(manifestKey);
+      })
+      .toBeInstanceOf(Buffer);
+    await flushWaitUntilForTest();
+    const manifestBytes = objects.get(manifestKey);
+    if (!manifestBytes) {
+      throw new Error("Expected pending-tool ownership transfer");
+    }
+    expect(
+      piApiFirstTurnManifestSchema.parse(
+        JSON.parse(manifestBytes.toString("utf8")),
+      ),
+    ).toMatchObject({
+      outcome: "ownership-transfer",
+      mode: "pending-tool-continuation",
+      baseSession: { sessionId: first.threadId, sha256: h0Hash },
+    });
+    const claimed = await claimChatRun(runnerGroup, next.runId);
+    expect(claimed.claim.resumeSession).toMatchObject({
+      sessionId: first.threadId,
+      historyRef: { hash: h0Hash },
+    });
+    const h1 = objects.get(
+      `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${next.runId}/session.jsonl`,
+    );
+    if (!h1) {
+      throw new Error("Expected length plus pending-tool H1");
+    }
+    const pending = MemoryPiSession.fromJsonl(h1.toString("utf8"))
+      .buildSessionContext()
+      .messages.at(-1);
+    expect(pending).toMatchObject({
+      role: "assistant",
+      stopReason: "length",
+      content: [expect.objectContaining({ type: "toolCall", name: "bash" })],
+    });
+    expect(occurrences(JSON.stringify(requests[2]), answer)).toBe(1);
+    expect(JSON.stringify(requests[2])).not.toContain(incompleteAnswer);
+    expect(
+      [...objects.entries()].filter(([key]) => {
+        return key.includes("/blobs/");
+      }),
+    ).toStrictEqual(blobEntries);
+    const events = (await chat.listThreadEvents(actor, next.threadId)).events;
+    expect(
+      events.filter((event) => {
+        return (
+          event.runId === next.runId &&
+          isChatRunTerminalEventType(event.eventType)
+        );
+      }),
+    ).toStrictEqual([]);
+    await cancelChatRun(actor, next.runId, claimed.sandboxHeaders);
+    expect(requests).toHaveLength(3);
   }, 90_000);
 
   it("fails Pi after one model request without claiming Sandbox or replaying the model", async () => {

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -105,6 +105,7 @@ type PiApiFirstTurnErrorCode =
   | "PI_API_FIRST_TURN_DEADLINE_EXCEEDED"
   | "PI_API_FIRST_TURN_NOT_COMMITTABLE"
   | "PI_API_MODEL_FAILED"
+  | "PI_API_MODEL_OUTPUT_INCOMPLETE"
   | "PI_API_MODEL_CREDENTIAL_INVALID"
   | "PI_API_PROMPT_UNSUPPORTED"
   | "PI_API_PREHEAT_FAILED"
@@ -1127,6 +1128,26 @@ async function observeDiscardedProviderResult(
   }
 }
 
+function validateApiModelTurnOutcome(turn: PiApiFirstTurnResult): void {
+  if (turn.assistantMessage.stopReason === "length" && !turn.handoffRequired) {
+    throw piApiFirstTurnError(
+      "PI_API_MODEL_OUTPUT_INCOMPLETE",
+      "Pi API first-turn model output is incomplete",
+    );
+  }
+  if (
+    turn.assistantMessage.stopReason === "error" ||
+    turn.assistantMessage.stopReason === "aborted"
+  ) {
+    throw piApiFirstTurnError(
+      "PI_API_MODEL_FAILED",
+      `Pi API first-turn model stopped with ${turn.assistantMessage.stopReason}`,
+      undefined,
+      turn.assistantMessage.failureReason,
+    );
+  }
+}
+
 async function executeApiModelTurn(
   args: {
     readonly activation: PiApiFirstTurnActivation;
@@ -1237,17 +1258,7 @@ async function executeApiModelTurn(
   }
   const turn = executed.value;
   await recordApiFirstTurnUsage(args.context, turn);
-  if (
-    turn.assistantMessage.stopReason === "error" ||
-    turn.assistantMessage.stopReason === "aborted"
-  ) {
-    throw piApiFirstTurnError(
-      "PI_API_MODEL_FAILED",
-      `Pi API first-turn model stopped with ${turn.assistantMessage.stopReason}`,
-      undefined,
-      turn.assistantMessage.failureReason,
-    );
-  }
+  validateApiModelTurnOutcome(turn);
   return { startedAt, turn };
 }
 


### PR DESCRIPTION
## summary

- reject a pi api-first no-tool `length` result with the fixed sanitized `PI_API_MODEL_OUTPUT_INCOMPLETE` error after consumed usage is recorded and before h1 validation or publication.
- reuse the existing failure owner, cancellation precedence and prepared-sandbox shutdown. retain ordinary `stop`, pending-tool handoff and historical checkpoint semantics.
- add public-route protocol bdd for text below/at the output cap, empty/thinking-only output, built-in and user-owned billing, cancellation races, released active input and canonical history preservation. an accepted queued input continues in its own run; the failed turn is never retried.

## verification

- public-route `chat-events.bdd.test.ts`: 115 focused model-first, native, fast, account, session and memory cases passed, including all 12 added cases.
- existing `pending-tool-cancellation.test.ts` ordering/refusal matrix: 2 cases passed.
- `pnpm -F api check-types` and `pnpm -F api lint` passed.
- `pnpm exec knip --workspace apps/api`, prettier for both changed files and `git diff --check` passed.

Closes #31944
