### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/artifact-image-viewer.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/artifact-image-viewer.test.tsx
@@ -28,7 +28,7 @@ function artifactFile(
     size: 1024,
     url,
     createdAt: "2026-03-10T00:00:01Z",
-    googleDriveSync: { status: "not_synced" },
+    googleDriveSync: { status: "not_synced", accountReady: true },
     ...overrides,
   };
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-test-helpers.ts
@@ -62,7 +62,7 @@ export function artifactFile(
     size: 1024,
     url: publicArtifactUrl(filename),
     createdAt: "2026-03-10T00:00:01Z",
-    googleDriveSync: { status: "not_synced" },
+    googleDriveSync: { status: "not_synced", accountReady: true },
     ...overrides,
   };
 }

--- a/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/okou-page/artifact-actions.tsx
@@ -248,10 +248,6 @@ function useGoogleDriveAvailability(
       ? null
       : getOnlyAvailableCatalogBrowserAuthMethodDetail(googleDriveConnector);
   const accountReady = syncTarget?.accountReady === true;
-  // Remove the default-connector fallback after pre-accountReady APIs are
-  // outside the serving and rollback window.
-  const legacyDefaultAccountReady =
-    googleDriveConnected && syncTarget?.disconnected !== true;
 
   return {
     connectorListLoaded:
@@ -261,7 +257,7 @@ function useGoogleDriveAvailability(
     googleDriveAuthMethod,
     googleDriveConnected,
     googleDriveConnector,
-    googleDriveReady: accountReady || legacyDefaultAccountReady,
+    googleDriveReady: accountReady,
   };
 }
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../chat-threads";
 
 describe("google drive artifact recovery contract", () => {
-  it("keeps account readiness additive across API and Platform versions", () => {
+  it("requires account readiness on every connected sync status", () => {
     const legacyNotSynced = { status: "not_synced" } as const;
     const accountReadyNotSynced = {
       status: "not_synced",
@@ -28,8 +28,10 @@ describe("google drive artifact recovery contract", () => {
     });
 
     expect(
-      chatThreadArtifactGoogleDriveSyncSchema.parse(legacyNotSynced),
-    ).toStrictEqual(legacyNotSynced);
+      chatThreadArtifactGoogleDriveSyncSchema.safeParse(legacyNotSynced)
+        .success,
+    ).toBe(false);
+    // An App bundle built before the marker keeps its own tolerant parser.
     expect(previousNotSyncedSchema.parse(accountReadyNotSynced)).toStrictEqual(
       legacyNotSynced,
     );

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -237,10 +237,11 @@ const chatThreadArtifactGoogleDriveRecoverySchema = z.discriminatedUnion(
 );
 
 const chatThreadArtifactGoogleDriveAccountReadyShape = {
-  // New App -> old API fallback. Current APIs always emit this marker after
-  // resolving the thread account, credentials, and agent authorization.
-  // Keep it optional while pre-marker APIs remain available for rollback.
-  accountReady: z.literal(true).optional(),
+  /**
+   * Emitted after the thread account, credentials, and agent authorization
+   * resolve. The disconnected variant carries no readiness marker.
+   */
+  accountReady: z.literal(true),
 };
 
 const chatThreadArtifactGoogleDriveSyncSchema = z.discriminatedUnion("status", [


### PR DESCRIPTION
Removes the new-App-to-old-API `accountReady` fallback on the Google Drive artifact sync status. This is the candidate that yesterday's run had to defer purely because open PR #31780 was editing the same file; that PR merged on `2026-09-05T03:57:42Z`.

## Cohort — Google Drive artifact sync `accountReady`

**Old boundary:** #31316 added an `accountReady` marker to the artifact sync status so the App could tell "this thread's Drive account is resolved and authorized" apart from "some Drive connector is connected". During rollout a newly promoted App could still reach a pre-marker API, so the contract kept `accountReady` optional and the App fell back to `googleDriveConnected && syncTarget?.disconnected !== true` — the old default-connector heuristic that ignores per-thread account selection.

**New boundary:** `accountReady: z.literal(true)` is required on the three connected sync variants, and `googleDriveReady` reads the marker directly.

Removed:
- `.optional()` and the rollout comment on `accountReady` in `chatThreadArtifactGoogleDriveAccountReadyShape`
- `legacyDefaultAccountReady` and its use in `googleDriveReady` in `artifact-actions.tsx`
- the compatibility half of the contract test, which asserted that the pre-marker shape `{ status: "not_synced" }` parses; it now asserts the opposite

Fixture updates: two typed literals in `artifact-image-viewer.test.tsx` and `chat-attachment-test-helpers.ts` now carry `accountReady: true`.

**Deliberately kept:**
- `syncTarget?.accountReady === true` in `artifact-actions.tsx`, and the equivalent reads in `artifact-sidebar.tsx` and `attachment-chips.tsx`. With the field required, `undefined` now means only "no sync target" or "the `disconnected` variant", which carries no readiness marker by design. These are live states, not rollout compatibility.
- The `connectorListLoaded` second clause, which covers an absent `syncTarget` rather than an old API.
- The forward-compatibility half of the contract test, which shows an older App bundle's own parser tolerates the added field. That is still true and still worth asserting; only the backward half was expired.

**Windows:** both applicable windows are satisfied.
- Canonical window 1 (old API drained).
- Canonical window 2 (App/web client, 24 hours after the replacement App version is available in production): **62.6 hours** elapsed.

**Rollout evidence (observed):**
- #31316 merged `2026-09-03T05:29:24Z` (`65d4ac58bb3`).
- First `api/production` deployment containing it: `12b2532a64`, `2026-09-03T06:23:13Z`; first `app/production` deployment: the same SHA at `2026-09-03T06:26:16Z`. Both confirmed with `git merge-base --is-ancestor` walking each deployment list forward from oldest.
- **34 further `api/production`** and **31 further `app/production`** deployments have been promoted since.

**Source evidence that the current API always sets the marker:** `resolveGoogleDriveArtifactSyncStatus` in `turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts` returns `accountReady: true` on all three non-disconnected branches — `unknown`, `synced`, and `not_synced` — and the `disconnected` branch returns `{ status, recovery }`, which the contract's `disconnected` variant does not include in the readiness shape. No connected path omits the marker.

**Axiom:** no route-level signal applies. The discriminator is the presence of one key inside a nested response object, and `vm0-request-log-prod` records `path_template`, `method`, `status`, and client headers but not response bodies. Recorded as a deliberate non-use rather than a zero-count claim.

**MaskDB:** not applicable. No schema, column, or persisted payload changes; the sync status is computed per request.

## Explicitly deferred

- **AgentPhone brandless connect.** The path validates a request signature from sub-floor App builds, which the client-version census has repeatedly shown are still transmitting.
- **Queued-launch-context brand reads** for Telegram, AgentPhone, and Feishu. MaskDB's projection still does not expose `public_brand` on the context tables.
- **`clerk-production-topology.ts`** and **`connector-oauth-device-auth.service.ts`** rollout notes — newly inventoried, not yet dated to a production rollout.
- **`chat-threads.ts` snapshot `selectedVideoModel` / `selectedImageModel`** — gate includes cached IndexedDB rows resyncing, which is persisted browser data.
- **#29908**, **#26519**, **#27786**, the `pi-api-first-turn-config` drain gates, `browser-session` PK contraction, `model-provider-account` expansions, and the artifact-object fallbacks — unchanged product or evidence gates.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F @okouai/app lint`, `pnpm -F @okouai/api-contracts lint` (no new warnings)
- `pnpm -F @okouai/api-contracts check-types`, `pnpm -F @okouai/app check-types`, `pnpm -F api check-types`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F @okouai/api-contracts exec vitest run` — 678 passing across 38 files
- `pnpm -F @okouai/app exec vitest run` on `chat-navigation-artifact-drive` + `artifact-image-viewer` (5) and `chat-attachment-artifact-viewer` + `chat-navigation-artifact-sidebar` + `chat-run-artifact-carryover` (24)
- `pnpm -F api exec vitest run` on `artifact-catalog.bdd` + `artifacts.bdd` (35) and `chat-threads.bdd` (36) — against a local Postgres with `timezone=UTC`

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.
