### PR TITLE
perf: avoid duplicate pinned reverse-template guide load

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1696,6 +1696,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(appendSystemPrompt).toContain(
       "./generated/resources/reverse-template/SKILL.md",
     );
+    expect(appendSystemPrompt).toContain(
+      "https://github.com/vm0-ai/Template-artifact/tree/<commit>/reverse-template",
+    );
+    expect(appendSystemPrompt).toContain(
+      "do not pull or compare the registry copy",
+    );
   });
 
   it("advertises intro-video camera tooling only while its rollout switch is on", async () => {

--- a/turbo/packages/core/src/presentation-template-skill.ts
+++ b/turbo/packages/core/src/presentation-template-skill.ts
@@ -6,9 +6,9 @@ import {
 const PRESENTATION_TEMPLATE_RESOURCE_DIR = "./generated/resources";
 
 /**
- * Tell a run how to reach the guide.
+ * Tell a run how to reach one authoritative guide.
  *
- * One sentence pair, carried by the standing agent-tools prompt so that any
+ * This concise instruction rides in the standing agent-tools prompt so any
  * deck reaches these instructions — dropped in the chat box, picked through
  * the import dialog, or asked for in words — without a user-visible message
  * having to spell the pull out.
@@ -16,7 +16,8 @@ const PRESENTATION_TEMPLATE_RESOURCE_DIR = "./generated/resources";
 export function presentationTemplateSkillInstruction(): string {
   const skillPath = `${PRESENTATION_TEMPLATE_RESOURCE_DIR}/${PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH}/SKILL.md`;
   return [
-    `Turning an uploaded deck (.pptx, .ppt, or .pdf) into a reusable presentation template follows the ${PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH} guide, which is not mounted as a skill.`,
-    `Pull it first with \`okou resource pull ${PRESENTATION_REVERSE_TEMPLATE_RESOURCE_ID} --dir ${PRESENTATION_TEMPLATE_RESOURCE_DIR}\`, read \`${skillPath}\`, and follow it exactly, including its page-rendering and publish steps.`,
+    `Turning an uploaded deck (.pptx, .ppt, or .pdf) into a reusable presentation template normally follows the ${PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH} guide, which is not mounted as a skill.`,
+    `When the user designates an exact 40-hex commit under \`https://github.com/vm0-ai/Template-artifact/tree/<commit>/${PRESENTATION_REVERSE_TEMPLATE_RESOURCE_PATH}\` as authoritative, read that pinned official guide and its referenced assets directly; do not pull or compare the registry copy.`,
+    `Otherwise, pull the guide first with \`okou resource pull ${PRESENTATION_REVERSE_TEMPLATE_RESOURCE_ID} --dir ${PRESENTATION_TEMPLATE_RESOURCE_DIR}\`, read \`${skillPath}\`, and follow it exactly, including its page-rendering and publish steps.`,
   ].join(" ");
 }


### PR DESCRIPTION
## Why

The exact-commit reverse-template benchmark still loads two copies of the same guide: the standing agent-tools prompt first requires the production registry resource, then the worker reads and compares the user-pinned official `Template-artifact` commit.

On the current optimized guide (`f531f430b4702f73c27dbdad8316054e7d4577a6`), the controlled VM0 sample completed in 624.610 seconds—24.610 seconds over the 10-minute target. Its run messages explicitly reported the registry pull and pinned-guide comparison before source analysis. Removing that duplicate authority is therefore a measured critical-path optimization, not a reduction in reversal or QA work.

## What

- Treat an exact 40-hex commit under the official `vm0-ai/Template-artifact` reverse-template path as the single authoritative guide.
- Tell the worker not to pull or compare the registry copy in that narrow pinned mode.
- Preserve the existing registry-first behavior for ordinary PPT, PPTX, and PDF uploads.
- Extend the run-lifecycle prompt contract with the pinned-authority wording.

## Verification

- `pnpm --filter @okouai/core check-types`
- `pnpm --filter @okouai/core lint`
- Direct `presentationTemplateSkillInstruction()` contract assertion: passed
- Targeted lifecycle BDD was attempted twice locally. Both runs stopped before the new assertions at the pre-existing runner-claim fixture with `404 Job not found in queue`; PR CI remains the integration authority.

## Benchmark evidence

- Template guide candidate: https://github.com/vm0-ai/Template-artifact/pull/66
- Controlled benchmark ledger: https://github.com/vm0-ai/Template-artifact/pull/65
