### PR TITLE
perf(runner): prewarm capacity-scaled blank sandboxes

### DIFF
--- a/crates/runner/src/cmd/start/blank_pool.rs
+++ b/crates/runner/src/cmd/start/blank_pool.rs
@@ -11,7 +11,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::factory_lifecycle::SharedFactory;
-use super::idle_lifecycle::{SharedIdlePool, set_idle_status_snapshot};
+use super::idle_lifecycle::{
+    IdleDestroyTracker, SharedIdlePool, set_idle_status_snapshot, spawn_idle_destroy_job,
+};
 use crate::config::ProfileConfig;
 use crate::idle_pool::{ParkResult, ParkedIdleCandidate};
 use crate::lifecycle::RunnerMode;
@@ -216,6 +218,7 @@ impl BlankPoolReplenisher {
         result: BlankPrepareResult,
         idle_pool: &SharedIdlePool,
         status: &StatusTracker,
+        idle_destroy_tracker: &IdleDestroyTracker,
     ) {
         let Some(plan) = self.plan.as_ref() else {
             if let BlankPrepareResult::Ready(candidate) = result {
@@ -254,7 +257,11 @@ impl BlankPoolReplenisher {
                             outcome = "replaced",
                             "blank sandbox refill completed"
                         );
-                        evicted.run_with_context("blank_pool_replaced").await;
+                        spawn_idle_destroy_job(
+                            idle_destroy_tracker,
+                            evicted,
+                            "blank_pool_replaced",
+                        );
                     }
                     ParkResult::Rejected(rejected) => {
                         info!(
@@ -264,10 +271,15 @@ impl BlankPoolReplenisher {
                             "blank sandbox refill suppressed"
                         );
                         let (payload, lease) = rejected.into_active_destroy_parts();
-                        payload
-                            .finalize_workspace_and_destroy("blank_pool_rejected")
-                            .await;
-                        drop(lease);
+                        idle_destroy_tracker.spawn_cleanup(
+                            async move {
+                                payload
+                                    .finalize_workspace_and_destroy("blank_pool_rejected")
+                                    .await;
+                                drop(lease);
+                            },
+                            "blank_pool_rejected",
+                        );
                     }
                 }
             }
@@ -559,6 +571,7 @@ mod tests {
         )));
         let temp = tempfile::tempdir().unwrap();
         let status = StatusTracker::new(temp.path().join("status.json"), 7, None, None);
+        let idle_destroy_tracker = IdleDestroyTracker::new(Arc::new(tokio::sync::Notify::new()));
         let admission = PreSpawnAdmission::new(4).unwrap();
         let mut replenisher = BlankPoolReplenisher::new(&profiles, &factories, &budget, 0, None);
 
@@ -571,7 +584,7 @@ mod tests {
             .await
             .expect("preparation should be active");
         replenisher
-            .finish_preparation(result, &idle_pool, &status)
+            .finish_preparation(result, &idle_pool, &status, &idle_destroy_tracker)
             .await;
 
         let mut pool = idle_pool.lock().await;
@@ -586,5 +599,6 @@ mod tests {
         assert_eq!(budget.allocated(), (0, 0, 0));
         assert!(admission.try_acquire_background(4).unwrap().is_some());
         replenisher.shutdown().await;
+        idle_destroy_tracker.close_and_wait().await;
     }
 }

--- a/crates/runner/src/cmd/start/blank_pool.rs
+++ b/crates/runner/src/cmd/start/blank_pool.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
 use sandbox::{Sandbox, SandboxConfig, SandboxId, SandboxParkOutcome};
@@ -16,7 +17,7 @@ use super::idle_lifecycle::{
     IdleDestroyTracker, SharedIdlePool, set_idle_status_snapshot, spawn_idle_destroy_job,
 };
 use crate::config::ProfileConfig;
-use crate::idle_pool::{ParkResult, ParkedIdleCandidate};
+use crate::idle_pool::{DestroyOutcome, IdleDestroyJob, ParkResult, ParkedIdleCandidate};
 use crate::lifecycle::RunnerMode;
 use crate::pre_spawn_admission::{BackgroundPreSpawnAdmissionLease, PreSpawnAdmission};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
@@ -24,6 +25,7 @@ use crate::status::StatusTracker;
 use crate::workspace_mount::ensure_workspace_drive_mounted;
 
 const TARGET_PERCENT: usize = 10;
+const EXACT_IDLE_CAPACITY_YIELD_AGE: Duration = Duration::from_secs(30 * 60);
 
 struct BlankPoolPlan {
     profile_name: String,
@@ -48,8 +50,14 @@ struct BlankPrepareInput {
     profile: ProfileConfig,
     factory: SharedFactory,
     device_rate_limits: Option<sandbox::DeviceRateLimits>,
-    budget_lease: BudgetLease,
+    budget: BlankPrepareBudget,
     pre_spawn_lease: BackgroundPreSpawnAdmissionLease,
+    idle_destroy_tracker: IdleDestroyTracker,
+}
+
+enum BlankPrepareBudget {
+    Available(BudgetLease),
+    RetiringExact(Box<IdleDestroyJob>),
 }
 
 enum BackgroundStageResult<T, E> {
@@ -60,7 +68,10 @@ enum BackgroundStageResult<T, E> {
 }
 
 pub(super) enum BlankPrepareResult {
-    Ready(Box<ParkedIdleCandidate>),
+    Ready {
+        candidate: Box<ParkedIdleCandidate>,
+        retired_exact: bool,
+    },
     Failed(BlankPrepareFailure),
 }
 
@@ -116,6 +127,8 @@ impl BlankPoolReplenisher {
         idle_pool: &SharedIdlePool,
         budget: &Arc<ResourceBudget>,
         admission: &PreSpawnAdmission,
+        status: &StatusTracker,
+        idle_destroy_tracker: &IdleDestroyTracker,
     ) {
         if !self.attempt_requested || self.task.is_some() || mode != RunnerMode::Running {
             return;
@@ -124,80 +137,123 @@ impl BlankPoolReplenisher {
         let Some(plan) = self.plan.as_ref() else {
             return;
         };
-        let (inventory, total_idle) = {
-            let pool = idle_pool.lock().await;
-            (pool.blank_len(), pool.len())
-        };
-        if inventory >= plan.target {
-            return;
-        }
-        if plan.max_idle > 0 && total_idle >= plan.max_idle {
-            info!(
-                target = plan.target,
-                inventory,
-                total_idle,
-                outcome = "idle_pool_full",
-                "blank sandbox refill suppressed"
-            );
-            return;
-        }
+        let (inventory, pre_spawn_lease, prepare_budget, retired_snapshot) = {
+            let mut pool = idle_pool.lock().await;
+            let inventory = pool.blank_len();
+            let total_idle = pool.len();
+            if inventory >= plan.target {
+                return;
+            }
 
-        let pre_spawn_lease = match admission.try_acquire_background(plan.profile.vcpu) {
-            Ok(Some(lease)) => lease,
-            Ok(None) => {
-                info!(
-                    target = plan.target,
+            let pre_spawn_lease = match admission.try_acquire_background(plan.profile.vcpu) {
+                Ok(Some(lease)) => lease,
+                Ok(None) => {
+                    info!(
+                        target = plan.target,
+                        inventory,
+                        outcome = "pre_spawn_unavailable",
+                        "blank sandbox refill suppressed"
+                    );
+                    return;
+                }
+                Err(error) => {
+                    warn!(
+                        target = plan.target,
+                        inventory,
+                        outcome = "pre_spawn_error",
+                        error = %error,
+                        "blank sandbox refill suppressed"
+                    );
+                    return;
+                }
+            };
+
+            let ordinary_budget = if plan.max_idle > 0 && total_idle >= plan.max_idle {
+                Err("idle_pool_full")
+            } else {
+                match ResourceBudget::try_reserve_lease(
+                    budget,
+                    plan.profile.vcpu,
+                    plan.profile.memory_mb,
+                ) {
+                    Some(lease)
+                        if budget.can_afford(plan.headroom_vcpu, plan.headroom_memory_mb) =>
+                    {
+                        Ok(lease)
+                    }
+                    Some(lease) => {
+                        drop(lease);
+                        Err("headroom_reserved")
+                    }
+                    None => Err("resource_unavailable"),
+                }
+            };
+
+            match ordinary_budget {
+                Ok(lease) => (
                     inventory,
-                    outcome = "pre_spawn_unavailable",
-                    "blank sandbox refill suppressed"
-                );
-                return;
-            }
-            Err(error) => {
-                warn!(
-                    target = plan.target,
-                    inventory,
-                    outcome = "pre_spawn_error",
-                    error = %error,
-                    "blank sandbox refill suppressed"
-                );
-                return;
+                    pre_spawn_lease,
+                    BlankPrepareBudget::Available(lease),
+                    None,
+                ),
+                Err(blocked_by) => {
+                    let Some((job, idle_age)) = pool.evict_oldest_exact_for_blank(
+                        Instant::now(),
+                        EXACT_IDLE_CAPACITY_YIELD_AGE,
+                        &plan.profile_name,
+                        &plan.device_rate_limits,
+                        plan.profile.vcpu,
+                        plan.profile.memory_mb,
+                    ) else {
+                        info!(
+                            target = plan.target,
+                            inventory,
+                            total_idle,
+                            outcome = blocked_by,
+                            aged_exact_eligible = false,
+                            "blank sandbox refill suppressed"
+                        );
+                        return;
+                    };
+                    let snapshot = pool.status_snapshot();
+                    idle_destroy_tracker.notify_reuse_state();
+                    info!(
+                        target = plan.target,
+                        inventory,
+                        total_idle,
+                        blocked_by,
+                        idle_age_seconds = idle_age.as_secs(),
+                        "retiring aged exact sandbox for blank capacity"
+                    );
+                    (
+                        inventory,
+                        pre_spawn_lease,
+                        BlankPrepareBudget::RetiringExact(Box::new(job)),
+                        Some(snapshot),
+                    )
+                }
             }
         };
-        let Some(budget_lease) =
-            ResourceBudget::try_reserve_lease(budget, plan.profile.vcpu, plan.profile.memory_mb)
-        else {
-            info!(
-                target = plan.target,
-                inventory,
-                outcome = "resource_unavailable",
-                "blank sandbox refill suppressed"
-            );
-            return;
-        };
-        if !budget.can_afford(plan.headroom_vcpu, plan.headroom_memory_mb) {
-            info!(
-                target = plan.target,
-                inventory,
-                outcome = "headroom_reserved",
-                "blank sandbox refill suppressed"
-            );
-            return;
+        if let Some(snapshot) = retired_snapshot {
+            set_idle_status_snapshot(status, snapshot).await;
         }
 
         let task_cancel = pre_spawn_lease.cancellation_token();
+        let retired_exact = matches!(&prepare_budget, BlankPrepareBudget::RetiringExact(_));
         let input = BlankPrepareInput {
             profile_name: plan.profile_name.clone(),
             profile: plan.profile.clone(),
             factory: Arc::clone(&plan.factory),
             device_rate_limits: plan.device_rate_limits.clone(),
-            budget_lease,
+            budget: prepare_budget,
             pre_spawn_lease,
+            idle_destroy_tracker: idle_destroy_tracker.clone(),
         };
         info!(
             profile = %input.profile_name,
             target = plan.target,
             inventory,
+            retired_exact,
             "preparing blank sandbox"
         );
         self.task_cancel = Some(task_cancel.clone());
@@ -230,13 +286,16 @@ impl BlankPoolReplenisher {
         idle_destroy_tracker: &IdleDestroyTracker,
     ) {
         let Some(plan) = self.plan.as_ref() else {
-            if let BlankPrepareResult::Ready(candidate) = result {
+            if let BlankPrepareResult::Ready { candidate, .. } = result {
                 destroy_candidate(*candidate, "blank_pool_disabled").await;
             }
             return;
         };
         match result {
-            BlankPrepareResult::Ready(candidate) => {
+            BlankPrepareResult::Ready {
+                candidate,
+                retired_exact,
+            } => {
                 let (park_result, snapshot, inventory) = {
                     let mut pool = idle_pool.lock().await;
                     let result = pool.park(*candidate);
@@ -252,6 +311,7 @@ impl BlankPoolReplenisher {
                         info!(
                             target = plan.target,
                             inventory,
+                            retired_exact,
                             outcome = "parked",
                             "blank sandbox refill completed"
                         );
@@ -263,6 +323,7 @@ impl BlankPoolReplenisher {
                         info!(
                             target = plan.target,
                             inventory,
+                            retired_exact,
                             outcome = "replaced",
                             "blank sandbox refill completed"
                         );
@@ -276,6 +337,7 @@ impl BlankPoolReplenisher {
                         info!(
                             target = plan.target,
                             inventory,
+                            retired_exact,
                             outcome = "pool_rejected",
                             "blank sandbox refill suppressed"
                         );
@@ -318,7 +380,7 @@ impl BlankPoolReplenisher {
             cancel.cancel();
         }
         if let Some(result) = self.wait_for_preparation().await
-            && let BlankPrepareResult::Ready(candidate) = result
+            && let BlankPrepareResult::Ready { candidate, .. } = result
         {
             destroy_candidate(*candidate, "blank_pool_shutdown").await;
         }
@@ -393,10 +455,28 @@ async fn prepare_blank_sandbox(
         profile,
         factory,
         device_rate_limits,
-        budget_lease,
+        budget,
         pre_spawn_lease,
+        idle_destroy_tracker,
     } = input;
+    let retired_exact = matches!(&budget, BlankPrepareBudget::RetiringExact(_));
     let mut pre_spawn_lease = Some(pre_spawn_lease);
+    let budget_lease = match budget {
+        BlankPrepareBudget::Available(lease) => lease,
+        BlankPrepareBudget::RetiringExact(job) => {
+            match retire_exact_before_blank(
+                *job,
+                &cancel,
+                &mut pre_spawn_lease,
+                &idle_destroy_tracker,
+            )
+            .await
+            {
+                Ok(lease) => lease,
+                Err(failure) => return BlankPrepareResult::Failed(failure),
+            }
+        }
+    };
     let sandbox_id = SandboxId::new_v4();
     let config = SandboxConfig {
         id: sandbox_id,
@@ -492,14 +572,17 @@ async fn prepare_blank_sandbox(
     match run_background_stage(sandbox.park(), &cancel, &mut pre_spawn_lease).await {
         BackgroundStageResult::Completed(Ok(SandboxParkOutcome::Reusable)) => {
             drop(pre_spawn_lease.take());
-            BlankPrepareResult::Ready(Box::new(ParkedIdleCandidate::blank(
-                sandbox,
-                factory,
-                budget_lease,
-                sandbox_id,
-                profile_name,
-                device_rate_limits,
-            )))
+            BlankPrepareResult::Ready {
+                candidate: Box::new(ParkedIdleCandidate::blank(
+                    sandbox,
+                    factory,
+                    budget_lease,
+                    sandbox_id,
+                    profile_name,
+                    device_rate_limits,
+                )),
+                retired_exact,
+            }
         }
         BackgroundStageResult::Completed(Ok(SandboxParkOutcome::NonReusable(reason))) => {
             drop(pre_spawn_lease.take());
@@ -531,6 +614,44 @@ async fn prepare_blank_sandbox(
             BlankPrepareResult::Failed(BlankPrepareFailure {
                 stage: "park",
                 error: Some("sandbox park panicked".into()),
+            })
+        }
+    }
+}
+
+async fn retire_exact_before_blank(
+    job: IdleDestroyJob,
+    cancel: &CancellationToken,
+    pre_spawn_lease: &mut Option<BackgroundPreSpawnAdmissionLease>,
+    idle_destroy_tracker: &IdleDestroyTracker,
+) -> Result<BudgetLease, BlankPrepareFailure> {
+    let cleanup = job.run_retaining_lease("blank_pool_aged_exact");
+    tokio::pin!(cleanup);
+    let (cancelled, result) = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            drop(pre_spawn_lease.take());
+            (true, cleanup.await)
+        }
+        result = &mut cleanup => (false, result),
+    };
+    if result.workspace_cache_promoted {
+        idle_destroy_tracker.notify_reuse_state();
+    }
+    if cancelled || cancel.is_cancelled() {
+        drop(result.budget_lease);
+        return Err(BlankPrepareFailure {
+            stage: "retire_exact",
+            error: None,
+        });
+    }
+    match result.outcome {
+        DestroyOutcome::Completed => Ok(result.budget_lease),
+        DestroyOutcome::Uncertain => {
+            drop(result.budget_lease);
+            Err(BlankPrepareFailure {
+                stage: "retire_exact",
+                error: Some("aged exact sandbox cleanup was uncertain".into()),
             })
         }
     }
@@ -617,6 +738,7 @@ async fn destroy_candidate(candidate: ParkedIdleCandidate, context: &'static str
 mod tests {
     use super::*;
 
+    use crate::idle_pool::test_support::ParkedIdleCandidateBuilder;
     use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
 
     fn profile(vcpu: u32, memory_mb: u32) -> ProfileConfig {
@@ -659,7 +781,14 @@ mod tests {
         let mut replenisher = BlankPoolReplenisher::new(&profiles, &factories, &budget, 0, None);
 
         replenisher
-            .maybe_start(RunnerMode::Running, &idle_pool, &budget, &admission)
+            .maybe_start(
+                RunnerMode::Running,
+                &idle_pool,
+                &budget,
+                &admission,
+                &status,
+                &idle_destroy_tracker,
+            )
             .await;
         assert!(replenisher.is_preparing());
         let result = replenisher
@@ -681,6 +810,260 @@ mod tests {
         }
         assert_eq!(budget.allocated(), (0, 0, 0));
         assert!(admission.try_acquire_background(4).unwrap().is_some());
+        replenisher.shutdown().await;
+        idle_destroy_tracker.close_and_wait().await;
+    }
+
+    #[tokio::test]
+    async fn aged_exact_capacity_is_converted_to_blanks_one_at_a_time() {
+        let mut profiles = BTreeMap::new();
+        profiles.insert("vm0/default".to_owned(), profile(2, 4096));
+        let blank_factory: SharedFactory =
+            Arc::new(Box::new(sandbox_mock::MockSandboxFactory::new()));
+        let mut factories = BTreeMap::new();
+        factories.insert("vm0/default".to_owned(), (blank_factory, true));
+        let budget = Arc::new(ResourceBudget::new(32, 65_536, 1.0, 0));
+        let mut pool = IdlePool::new_with_parking_gate(
+            IdlePoolConfig { max_idle: 2 },
+            ParkingGate::new_open(),
+        );
+        let exact_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+        exact_overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+        let exact_factory: SharedFactory = Arc::new(Box::new(
+            sandbox_mock::MockSandboxFactory::with_overrides(exact_overrides),
+        ));
+        let now = Instant::now();
+        for (reuse_key, idle_for) in [
+            ("older-exact", Duration::from_secs(40 * 60)),
+            ("newer-exact", Duration::from_secs(30 * 60)),
+        ] {
+            let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+            let candidate = ParkedIdleCandidateBuilder::new(reuse_key, lease)
+                .with_factory(Arc::clone(&exact_factory))
+                .build();
+            assert!(matches!(
+                pool.park_at_for_test(candidate, now - idle_for),
+                ParkResult::Parked
+            ));
+        }
+        let idle_pool = Arc::new(tokio::sync::Mutex::new(pool));
+        let temp = tempfile::tempdir().unwrap();
+        let status_path = temp.path().join("status.json");
+        let status = StatusTracker::new(status_path.clone(), 2, None, None);
+        let reuse_state_notify = Arc::new(tokio::sync::Notify::new());
+        let idle_destroy_tracker = IdleDestroyTracker::new(Arc::clone(&reuse_state_notify));
+        let admission = PreSpawnAdmission::new(2).unwrap();
+        let mut replenisher = BlankPoolReplenisher::new(&profiles, &factories, &budget, 2, None);
+
+        replenisher
+            .maybe_start(
+                RunnerMode::Running,
+                &idle_pool,
+                &budget,
+                &admission,
+                &status,
+                &idle_destroy_tracker,
+            )
+            .await;
+        destroy_gate
+            .wait_entered(1, Duration::from_secs(2))
+            .await
+            .expect("first exact destroy should start");
+        tokio::time::timeout(Duration::from_secs(2), reuse_state_notify.notified())
+            .await
+            .expect("exact removal should request an immediate heartbeat");
+        assert_eq!(idle_pool.lock().await.held_reuse_keys(), ["newer-exact"]);
+        let status_json = tokio::fs::read_to_string(status_path).await.unwrap();
+        assert!(!status_json.contains("older-exact"));
+        assert!(status_json.contains("newer-exact"));
+
+        replenisher.request_attempt();
+        replenisher
+            .maybe_start(
+                RunnerMode::Running,
+                &idle_pool,
+                &budget,
+                &admission,
+                &status,
+                &idle_destroy_tracker,
+            )
+            .await;
+        assert_eq!(idle_pool.lock().await.held_reuse_keys(), ["newer-exact"]);
+
+        destroy_gate.release_many(1);
+        let first = replenisher.wait_for_preparation().await.unwrap();
+        replenisher
+            .finish_preparation(first, &idle_pool, &status, &idle_destroy_tracker)
+            .await;
+        assert_eq!(idle_pool.lock().await.blank_len(), 1);
+
+        replenisher
+            .maybe_start(
+                RunnerMode::Running,
+                &idle_pool,
+                &budget,
+                &admission,
+                &status,
+                &idle_destroy_tracker,
+            )
+            .await;
+        destroy_gate
+            .wait_entered(2, Duration::from_secs(2))
+            .await
+            .expect("second exact destroy should start only after the first conversion");
+        assert_eq!(idle_pool.lock().await.blank_len(), 1);
+
+        destroy_gate.release_many(1);
+        let second = replenisher.wait_for_preparation().await.unwrap();
+        replenisher
+            .finish_preparation(second, &idle_pool, &status, &idle_destroy_tracker)
+            .await;
+        let mut pool = idle_pool.lock().await;
+        assert_eq!(pool.len(), 2);
+        assert_eq!(pool.blank_len(), 2);
+        let destroy = pool.drain();
+        drop(pool);
+        for job in destroy {
+            job.run().await;
+        }
+        assert_eq!(budget.allocated(), (0, 0, 0));
+        replenisher.shutdown().await;
+        idle_destroy_tracker.close_and_wait().await;
+    }
+
+    #[tokio::test]
+    async fn uncertain_aged_exact_cleanup_does_not_create_a_blank() {
+        let mut profiles = BTreeMap::new();
+        profiles.insert("vm0/default".to_owned(), profile(2, 4096));
+        let blank_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let blank_factory: SharedFactory = Arc::new(Box::new(
+            sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&blank_overrides)),
+        ));
+        let mut factories = BTreeMap::new();
+        factories.insert("vm0/default".to_owned(), (blank_factory, true));
+        let budget = Arc::new(ResourceBudget::new(12, 24_576, 1.0, 0));
+        let mut pool = IdlePool::new_with_parking_gate(
+            IdlePoolConfig { max_idle: 1 },
+            ParkingGate::new_open(),
+        );
+        let exact_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        exact_overrides.push_destroy_panic("simulated aged exact destroy panic");
+        let exact_factory: SharedFactory = Arc::new(Box::new(
+            sandbox_mock::MockSandboxFactory::with_overrides(exact_overrides),
+        ));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let candidate = ParkedIdleCandidateBuilder::new("aged-exact", lease)
+            .with_factory(exact_factory)
+            .build();
+        assert!(matches!(
+            pool.park_at_for_test(candidate, Instant::now() - EXACT_IDLE_CAPACITY_YIELD_AGE,),
+            ParkResult::Parked
+        ));
+        let idle_pool = Arc::new(tokio::sync::Mutex::new(pool));
+        let temp = tempfile::tempdir().unwrap();
+        let status = StatusTracker::new(temp.path().join("status.json"), 1, None, None);
+        let idle_destroy_tracker = IdleDestroyTracker::new(Arc::new(tokio::sync::Notify::new()));
+        let admission = PreSpawnAdmission::new(2).unwrap();
+        let mut replenisher = BlankPoolReplenisher::new(&profiles, &factories, &budget, 1, None);
+
+        replenisher
+            .maybe_start(
+                RunnerMode::Running,
+                &idle_pool,
+                &budget,
+                &admission,
+                &status,
+                &idle_destroy_tracker,
+            )
+            .await;
+        let result = replenisher.wait_for_preparation().await.unwrap();
+        assert!(matches!(
+            result,
+            BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "retire_exact",
+                error: Some(_),
+            })
+        ));
+        assert!(blank_overrides.create_configs().is_empty());
+        assert_eq!(budget.allocated(), (0, 0, 0));
+        assert_eq!(idle_pool.lock().await.len(), 0);
+        replenisher.shutdown().await;
+        idle_destroy_tracker.close_and_wait().await;
+    }
+
+    #[tokio::test]
+    async fn foreground_admission_preempts_blank_conversion_during_exact_destroy() {
+        let mut profiles = BTreeMap::new();
+        profiles.insert("vm0/default".to_owned(), profile(2, 4096));
+        let blank_factory: SharedFactory =
+            Arc::new(Box::new(sandbox_mock::MockSandboxFactory::new()));
+        let mut factories = BTreeMap::new();
+        factories.insert("vm0/default".to_owned(), (blank_factory, true));
+        let budget = Arc::new(ResourceBudget::new(12, 24_576, 1.0, 0));
+        let mut pool = IdlePool::new_with_parking_gate(
+            IdlePoolConfig { max_idle: 1 },
+            ParkingGate::new_open(),
+        );
+        let exact_overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+        exact_overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+        let exact_factory: SharedFactory = Arc::new(Box::new(
+            sandbox_mock::MockSandboxFactory::with_overrides(exact_overrides),
+        ));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let candidate = ParkedIdleCandidateBuilder::new("aged-exact", lease)
+            .with_factory(exact_factory)
+            .build();
+        assert!(matches!(
+            pool.park_at_for_test(candidate, Instant::now() - EXACT_IDLE_CAPACITY_YIELD_AGE,),
+            ParkResult::Parked
+        ));
+        let idle_pool = Arc::new(tokio::sync::Mutex::new(pool));
+        let temp = tempfile::tempdir().unwrap();
+        let status = StatusTracker::new(temp.path().join("status.json"), 1, None, None);
+        let idle_destroy_tracker = IdleDestroyTracker::new(Arc::new(tokio::sync::Notify::new()));
+        let admission = PreSpawnAdmission::new(2).unwrap();
+        let mut replenisher = BlankPoolReplenisher::new(&profiles, &factories, &budget, 1, None);
+
+        replenisher
+            .maybe_start(
+                RunnerMode::Running,
+                &idle_pool,
+                &budget,
+                &admission,
+                &status,
+                &idle_destroy_tracker,
+            )
+            .await;
+        destroy_gate
+            .wait_entered(1, Duration::from_secs(2))
+            .await
+            .expect("aged exact destroy should start");
+
+        let foreground_cancel = CancellationToken::new();
+        let foreground = tokio::time::timeout(
+            Duration::from_secs(2),
+            admission.acquire(2, &foreground_cancel),
+        )
+        .await
+        .expect("foreground admission should not wait for exact destroy")
+        .unwrap();
+        assert!(replenisher.is_preparing());
+        assert_eq!(budget.allocated().2, 1);
+
+        destroy_gate.release_many(1);
+        let result = replenisher.wait_for_preparation().await.unwrap();
+        assert!(matches!(
+            result,
+            BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "retire_exact",
+                error: None,
+            })
+        ));
+        drop(foreground);
+        assert_eq!(budget.allocated(), (0, 0, 0));
+        assert_eq!(idle_pool.lock().await.len(), 0);
         replenisher.shutdown().await;
         idle_destroy_tracker.close_and_wait().await;
     }

--- a/crates/runner/src/cmd/start/blank_pool.rs
+++ b/crates/runner/src/cmd/start/blank_pool.rs
@@ -55,6 +55,7 @@ enum BackgroundStageResult<T> {
     Completed(sandbox::Result<T>),
     CancelledBeforeStart,
     CancelledAfterStart(sandbox::Result<T>),
+    Panicked,
 }
 
 pub(super) enum BlankPrepareResult {
@@ -443,6 +444,14 @@ async fn prepare_blank_sandbox(
                 error: None,
             });
         }
+        BackgroundStageResult::Panicked => {
+            drop(pre_spawn_lease.take());
+            destroy_sandbox(&factory, sandbox).await;
+            return BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "start",
+                error: Some("sandbox start panicked".into()),
+            });
+        }
     }
 
     match run_background_stage(sandbox.park(), &cancel, &mut pre_spawn_lease).await {
@@ -481,6 +490,14 @@ async fn prepare_blank_sandbox(
                 error: None,
             })
         }
+        BackgroundStageResult::Panicked => {
+            drop(pre_spawn_lease.take());
+            destroy_sandbox(&factory, sandbox).await;
+            BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "park",
+                error: Some("sandbox park panicked".into()),
+            })
+        }
     }
 }
 
@@ -516,27 +533,35 @@ async fn run_background_stage<T>(
         drop(pre_spawn_lease.take());
         return BackgroundStageResult::CancelledBeforeStart;
     }
+    let stage = AssertUnwindSafe(stage).catch_unwind();
     tokio::pin!(stage);
     tokio::select! {
         biased;
         result = &mut stage => {
-            if cancel.is_cancelled() {
-                drop(pre_spawn_lease.take());
-                BackgroundStageResult::CancelledAfterStart(result)
-            } else {
-                BackgroundStageResult::Completed(result)
+            match result {
+                Ok(result) if cancel.is_cancelled() => {
+                    drop(pre_spawn_lease.take());
+                    BackgroundStageResult::CancelledAfterStart(result)
+                }
+                Ok(result) => BackgroundStageResult::Completed(result),
+                Err(_) => BackgroundStageResult::Panicked,
             }
         }
         _ = cancel.cancelled() => {
             drop(pre_spawn_lease.take());
-            BackgroundStageResult::CancelledAfterStart(stage.await)
+            match stage.await {
+                Ok(result) => BackgroundStageResult::CancelledAfterStart(result),
+                Err(_) => BackgroundStageResult::Panicked,
+            }
         }
     }
 }
 
 async fn destroy_sandbox(factory: &SharedFactory, mut sandbox: Box<dyn Sandbox>) {
-    if let Err(error) = sandbox.stop().await {
-        warn!(error = %error, "failed to stop blank sandbox");
+    match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => warn!(error = %error, "failed to stop blank sandbox"),
+        Err(_) => warn!("blank sandbox stop panicked"),
     }
     if AssertUnwindSafe(factory.destroy(sandbox))
         .catch_unwind()

--- a/crates/runner/src/cmd/start/blank_pool.rs
+++ b/crates/runner/src/cmd/start/blank_pool.rs
@@ -1,0 +1,590 @@
+//! Best-effort, capacity-scaled preparation of tenant-free parked sandboxes.
+
+use std::collections::BTreeMap;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+
+use futures_util::FutureExt;
+use sandbox::{Sandbox, SandboxConfig, SandboxId, SandboxParkOutcome};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use super::factory_lifecycle::SharedFactory;
+use super::idle_lifecycle::{SharedIdlePool, set_idle_status_snapshot};
+use crate::config::ProfileConfig;
+use crate::idle_pool::{ParkResult, ParkedIdleCandidate};
+use crate::lifecycle::RunnerMode;
+use crate::pre_spawn_admission::{BackgroundPreSpawnAdmissionLease, PreSpawnAdmission};
+use crate::resource_budget::{BudgetLease, ResourceBudget};
+use crate::status::StatusTracker;
+
+const TARGET_PERCENT: usize = 10;
+
+struct BlankPoolPlan {
+    profile_name: String,
+    profile: ProfileConfig,
+    factory: SharedFactory,
+    target: usize,
+    max_idle: usize,
+    headroom_vcpu: u32,
+    headroom_memory_mb: u32,
+    device_rate_limits: Option<sandbox::DeviceRateLimits>,
+}
+
+pub(super) struct BlankPoolReplenisher {
+    plan: Option<BlankPoolPlan>,
+    task: Option<JoinHandle<BlankPrepareResult>>,
+    task_cancel: Option<CancellationToken>,
+    attempt_requested: bool,
+}
+
+struct BlankPrepareInput {
+    profile_name: String,
+    profile: ProfileConfig,
+    factory: SharedFactory,
+    device_rate_limits: Option<sandbox::DeviceRateLimits>,
+    budget_lease: BudgetLease,
+    pre_spawn_lease: BackgroundPreSpawnAdmissionLease,
+}
+
+pub(super) enum BlankPrepareResult {
+    Ready(Box<ParkedIdleCandidate>),
+    Failed(BlankPrepareFailure),
+}
+
+pub(super) struct BlankPrepareFailure {
+    stage: &'static str,
+    error: Option<String>,
+}
+
+impl BlankPoolReplenisher {
+    pub(super) fn new(
+        profiles: &BTreeMap<String, ProfileConfig>,
+        factories: &BTreeMap<String, (SharedFactory, bool)>,
+        budget: &Arc<ResourceBudget>,
+        max_idle: usize,
+        device_rate_limits: Option<sandbox::DeviceRateLimits>,
+    ) -> Self {
+        let plan = select_plan(profiles, factories, budget, max_idle, device_rate_limits);
+        if let Some(plan) = plan.as_ref() {
+            info!(
+                profile = %plan.profile_name,
+                target = plan.target,
+                "blank sandbox pool initialized"
+            );
+        } else {
+            info!(
+                target = 0,
+                "blank sandbox pool disabled by effective capacity"
+            );
+        }
+        Self {
+            plan,
+            task: None,
+            task_cancel: None,
+            attempt_requested: true,
+        }
+    }
+
+    pub(super) fn request_attempt(&mut self) {
+        self.attempt_requested = true;
+    }
+
+    pub(super) fn cancel_if_inactive(&self, mode: RunnerMode) {
+        if mode != RunnerMode::Running
+            && let Some(cancel) = self.task_cancel.as_ref()
+        {
+            cancel.cancel();
+        }
+    }
+
+    pub(super) async fn maybe_start(
+        &mut self,
+        mode: RunnerMode,
+        idle_pool: &SharedIdlePool,
+        budget: &Arc<ResourceBudget>,
+        admission: &PreSpawnAdmission,
+    ) {
+        if !self.attempt_requested || self.task.is_some() || mode != RunnerMode::Running {
+            return;
+        }
+        self.attempt_requested = false;
+        let Some(plan) = self.plan.as_ref() else {
+            return;
+        };
+        let (inventory, total_idle) = {
+            let pool = idle_pool.lock().await;
+            (pool.blank_len(), pool.len())
+        };
+        if inventory >= plan.target {
+            return;
+        }
+        if plan.max_idle > 0 && total_idle >= plan.max_idle {
+            info!(
+                target = plan.target,
+                inventory,
+                total_idle,
+                outcome = "idle_pool_full",
+                "blank sandbox refill suppressed"
+            );
+            return;
+        }
+
+        let pre_spawn_lease = match admission.try_acquire_background(plan.profile.vcpu) {
+            Ok(Some(lease)) => lease,
+            Ok(None) => {
+                info!(
+                    target = plan.target,
+                    inventory,
+                    outcome = "pre_spawn_unavailable",
+                    "blank sandbox refill suppressed"
+                );
+                return;
+            }
+            Err(error) => {
+                warn!(
+                    target = plan.target,
+                    inventory,
+                    outcome = "pre_spawn_error",
+                    error = %error,
+                    "blank sandbox refill suppressed"
+                );
+                return;
+            }
+        };
+        let Some(budget_lease) =
+            ResourceBudget::try_reserve_lease(budget, plan.profile.vcpu, plan.profile.memory_mb)
+        else {
+            info!(
+                target = plan.target,
+                inventory,
+                outcome = "resource_unavailable",
+                "blank sandbox refill suppressed"
+            );
+            return;
+        };
+        if !budget.can_afford(plan.headroom_vcpu, plan.headroom_memory_mb) {
+            info!(
+                target = plan.target,
+                inventory,
+                outcome = "headroom_reserved",
+                "blank sandbox refill suppressed"
+            );
+            return;
+        }
+
+        let task_cancel = pre_spawn_lease.cancellation_token();
+        let input = BlankPrepareInput {
+            profile_name: plan.profile_name.clone(),
+            profile: plan.profile.clone(),
+            factory: Arc::clone(&plan.factory),
+            device_rate_limits: plan.device_rate_limits.clone(),
+            budget_lease,
+            pre_spawn_lease,
+        };
+        info!(
+            profile = %input.profile_name,
+            target = plan.target,
+            inventory,
+            "preparing blank sandbox"
+        );
+        self.task_cancel = Some(task_cancel.clone());
+        self.task = Some(tokio::spawn(prepare_blank_sandbox(input, task_cancel)));
+    }
+
+    pub(super) fn is_preparing(&self) -> bool {
+        self.task.is_some()
+    }
+
+    pub(super) async fn wait_for_preparation(&mut self) -> Option<BlankPrepareResult> {
+        let task = self.task.as_mut()?;
+        let result = task.await;
+        self.task = None;
+        self.task_cancel = None;
+        Some(match result {
+            Ok(result) => result,
+            Err(error) => BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "task",
+                error: Some(error.to_string()),
+            }),
+        })
+    }
+
+    pub(super) async fn finish_preparation(
+        &mut self,
+        result: BlankPrepareResult,
+        idle_pool: &SharedIdlePool,
+        status: &StatusTracker,
+    ) {
+        let Some(plan) = self.plan.as_ref() else {
+            if let BlankPrepareResult::Ready(candidate) = result {
+                destroy_candidate(*candidate, "blank_pool_disabled").await;
+            }
+            return;
+        };
+        match result {
+            BlankPrepareResult::Ready(candidate) => {
+                let (park_result, snapshot, inventory) = {
+                    let mut pool = idle_pool.lock().await;
+                    let result = pool.park(*candidate);
+                    let snapshot = matches!(result, ParkResult::Parked | ParkResult::Replaced(_))
+                        .then(|| pool.status_snapshot());
+                    (result, snapshot, pool.blank_len())
+                };
+                if let Some(snapshot) = snapshot {
+                    set_idle_status_snapshot(status, snapshot).await;
+                }
+                match park_result {
+                    ParkResult::Parked => {
+                        info!(
+                            target = plan.target,
+                            inventory,
+                            outcome = "parked",
+                            "blank sandbox refill completed"
+                        );
+                        if inventory < plan.target {
+                            self.attempt_requested = true;
+                        }
+                    }
+                    ParkResult::Replaced(evicted) => {
+                        info!(
+                            target = plan.target,
+                            inventory,
+                            outcome = "replaced",
+                            "blank sandbox refill completed"
+                        );
+                        evicted.run_with_context("blank_pool_replaced").await;
+                    }
+                    ParkResult::Rejected(rejected) => {
+                        info!(
+                            target = plan.target,
+                            inventory,
+                            outcome = "pool_rejected",
+                            "blank sandbox refill suppressed"
+                        );
+                        let (payload, lease) = rejected.into_active_destroy_parts();
+                        payload
+                            .finalize_workspace_and_destroy("blank_pool_rejected")
+                            .await;
+                        drop(lease);
+                    }
+                }
+            }
+            BlankPrepareResult::Failed(failure) => {
+                if let Some(error) = failure.error {
+                    warn!(
+                        target = plan.target,
+                        stage = failure.stage,
+                        outcome = "failed",
+                        error = %error,
+                        "blank sandbox refill failed"
+                    );
+                } else {
+                    info!(
+                        target = plan.target,
+                        stage = failure.stage,
+                        outcome = "cancelled",
+                        "blank sandbox refill cancelled"
+                    );
+                }
+            }
+        }
+    }
+
+    pub(super) async fn shutdown(mut self) {
+        if let Some(cancel) = self.task_cancel.as_ref() {
+            cancel.cancel();
+        }
+        if let Some(result) = self.wait_for_preparation().await
+            && let BlankPrepareResult::Ready(candidate) = result
+        {
+            destroy_candidate(*candidate, "blank_pool_shutdown").await;
+        }
+    }
+}
+
+fn select_plan(
+    profiles: &BTreeMap<String, ProfileConfig>,
+    factories: &BTreeMap<String, (SharedFactory, bool)>,
+    budget: &ResourceBudget,
+    max_idle: usize,
+    device_rate_limits: Option<sandbox::DeviceRateLimits>,
+) -> Option<BlankPoolPlan> {
+    let headroom_vcpu = profiles.values().map(|profile| profile.vcpu).max()?;
+    let headroom_memory_mb = profiles.values().map(|profile| profile.memory_mb).max()?;
+    let (profile_name, profile, capacity) = profiles
+        .iter()
+        .filter_map(|(name, profile)| {
+            let capacity = profile_capacity(profile, budget);
+            factories
+                .contains_key(name)
+                .then_some((name, profile, capacity))
+        })
+        .max_by(|left, right| left.2.cmp(&right.2).then_with(|| right.0.cmp(left.0)))?;
+    let target = blank_pool_target(capacity, max_idle);
+    if target == 0 {
+        return None;
+    }
+    let (factory, _) = factories.get(profile_name)?;
+    Some(BlankPoolPlan {
+        profile_name: profile_name.clone(),
+        profile: profile.clone(),
+        factory: Arc::clone(factory),
+        target,
+        max_idle,
+        headroom_vcpu,
+        headroom_memory_mb,
+        device_rate_limits,
+    })
+}
+
+fn profile_capacity(profile: &ProfileConfig, budget: &ResourceBudget) -> usize {
+    let resource_capacity = std::cmp::min(
+        budget.effective_vcpu() as usize / profile.vcpu as usize,
+        budget.effective_memory_mb() as usize / profile.memory_mb as usize,
+    );
+    if budget.max_concurrent() == 0 {
+        resource_capacity
+    } else {
+        resource_capacity.min(budget.max_concurrent())
+    }
+}
+
+fn blank_pool_target(capacity: usize, max_idle: usize) -> usize {
+    if capacity < 2 {
+        return 0;
+    }
+    let target = ((capacity + TARGET_PERCENT / 2) / TARGET_PERCENT).min(capacity - 1);
+    if max_idle == 0 {
+        target
+    } else {
+        target.min(max_idle)
+    }
+}
+
+async fn prepare_blank_sandbox(
+    input: BlankPrepareInput,
+    cancel: CancellationToken,
+) -> BlankPrepareResult {
+    let BlankPrepareInput {
+        profile_name,
+        profile,
+        factory,
+        device_rate_limits,
+        budget_lease,
+        pre_spawn_lease,
+    } = input;
+    let sandbox_id = SandboxId::new_v4();
+    let config = SandboxConfig {
+        id: sandbox_id,
+        resources: sandbox::ResourceLimits {
+            cpu_count: profile.vcpu,
+            memory_mb: profile.memory_mb,
+        },
+        device_rate_limits: device_rate_limits.clone(),
+        workspace_drive: Some(sandbox::WorkspaceDriveConfig {
+            size_mb: profile.workspace_disk_mb,
+            seed_image: None,
+        }),
+    };
+    let mut sandbox = match create_or_cancel(&factory, config, &cancel).await {
+        Some(Ok(sandbox)) => sandbox,
+        Some(Err(error)) => {
+            return BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "create",
+                error: Some(error.to_string()),
+            });
+        }
+        None => {
+            return BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "create",
+                error: None,
+            });
+        }
+    };
+
+    let start_result = start_or_cancel(sandbox.as_mut(), &cancel).await;
+    match start_result {
+        Some(Ok(())) => {}
+        Some(Err(error)) => {
+            drop(pre_spawn_lease);
+            destroy_sandbox(&factory, sandbox).await;
+            return BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "start",
+                error: Some(error.to_string()),
+            });
+        }
+        None => {
+            drop(pre_spawn_lease);
+            destroy_sandbox(&factory, sandbox).await;
+            return BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "start",
+                error: None,
+            });
+        }
+    }
+
+    let park_result = park_or_cancel(sandbox.as_mut(), &cancel).await;
+    match park_result {
+        Some(Ok(SandboxParkOutcome::Reusable)) => {
+            drop(pre_spawn_lease);
+            BlankPrepareResult::Ready(Box::new(ParkedIdleCandidate::blank(
+                sandbox,
+                factory,
+                budget_lease,
+                sandbox_id,
+                profile_name,
+                device_rate_limits,
+            )))
+        }
+        Some(Ok(SandboxParkOutcome::NonReusable(reason))) => {
+            drop(pre_spawn_lease);
+            destroy_sandbox(&factory, sandbox).await;
+            BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "park_non_reusable",
+                error: Some(reason.as_str().to_owned()),
+            })
+        }
+        Some(Err(error)) => {
+            drop(pre_spawn_lease);
+            destroy_sandbox(&factory, sandbox).await;
+            BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "park",
+                error: Some(error.to_string()),
+            })
+        }
+        None => {
+            drop(pre_spawn_lease);
+            destroy_sandbox(&factory, sandbox).await;
+            BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "park",
+                error: None,
+            })
+        }
+    }
+}
+
+async fn create_or_cancel(
+    factory: &SharedFactory,
+    config: SandboxConfig,
+    cancel: &CancellationToken,
+) -> Option<sandbox::Result<Box<dyn Sandbox>>> {
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => None,
+        result = factory.create(config) => Some(result),
+    }
+}
+
+async fn start_or_cancel(
+    sandbox: &mut dyn Sandbox,
+    cancel: &CancellationToken,
+) -> Option<sandbox::Result<()>> {
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => None,
+        result = sandbox.start() => Some(result),
+    }
+}
+
+async fn park_or_cancel(
+    sandbox: &mut dyn Sandbox,
+    cancel: &CancellationToken,
+) -> Option<sandbox::Result<SandboxParkOutcome>> {
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => None,
+        result = sandbox.park() => Some(result),
+    }
+}
+
+async fn destroy_sandbox(factory: &SharedFactory, mut sandbox: Box<dyn Sandbox>) {
+    if let Err(error) = sandbox.stop().await {
+        warn!(error = %error, "failed to stop blank sandbox");
+    }
+    if AssertUnwindSafe(factory.destroy(sandbox))
+        .catch_unwind()
+        .await
+        .is_err()
+    {
+        warn!("blank sandbox destroy panicked");
+    }
+}
+
+async fn destroy_candidate(candidate: ParkedIdleCandidate, context: &'static str) {
+    let (payload, lease) = candidate.into_active_destroy_parts();
+    payload.finalize_workspace_and_destroy(context).await;
+    drop(lease);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
+
+    fn profile(vcpu: u32, memory_mb: u32) -> ProfileConfig {
+        ProfileConfig {
+            rootfs_hash: "rootfs".into(),
+            snapshot_hash: "snapshot".into(),
+            vcpu,
+            memory_mb,
+            rootfs_disk_mb: 8192,
+            workspace_disk_mb: 10240,
+        }
+    }
+
+    #[test]
+    fn target_scales_with_capacity_and_operator_cap() {
+        assert_eq!(blank_pool_target(0, 0), 0);
+        assert_eq!(blank_pool_target(1, 0), 0);
+        assert_eq!(blank_pool_target(2, 0), 0);
+        assert_eq!(blank_pool_target(5, 0), 1);
+        assert_eq!(blank_pool_target(62, 0), 6);
+        assert_eq!(blank_pool_target(62, 4), 4);
+    }
+
+    #[tokio::test]
+    async fn replenisher_creates_parks_and_publishes_one_blank_sandbox() {
+        let mut profiles = BTreeMap::new();
+        profiles.insert("vm0/default".to_owned(), profile(2, 4096));
+        let factory: SharedFactory = Arc::new(Box::new(sandbox_mock::MockSandboxFactory::new()));
+        let mut factories = BTreeMap::new();
+        factories.insert("vm0/default".to_owned(), (factory, true));
+        let budget = Arc::new(ResourceBudget::new(16, 32_768, 1.0, 0));
+        let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
+            IdlePoolConfig { max_idle: 0 },
+            ParkingGate::new_open(),
+        )));
+        let temp = tempfile::tempdir().unwrap();
+        let status = StatusTracker::new(temp.path().join("status.json"), 7, None, None);
+        let admission = PreSpawnAdmission::new(4).unwrap();
+        let mut replenisher = BlankPoolReplenisher::new(&profiles, &factories, &budget, 0, None);
+
+        replenisher
+            .maybe_start(RunnerMode::Running, &idle_pool, &budget, &admission)
+            .await;
+        assert!(replenisher.is_preparing());
+        let result = replenisher
+            .wait_for_preparation()
+            .await
+            .expect("preparation should be active");
+        replenisher
+            .finish_preparation(result, &idle_pool, &status)
+            .await;
+
+        let mut pool = idle_pool.lock().await;
+        assert_eq!(pool.blank_len(), 1);
+        assert_eq!(pool.status_snapshot().idle_sandboxes.len(), 1);
+        assert!(pool.held_sandbox_states().is_empty());
+        let destroy = pool.drain();
+        drop(pool);
+        for job in destroy {
+            job.run().await;
+        }
+        assert_eq!(budget.allocated(), (0, 0, 0));
+        assert!(admission.try_acquire_background(4).unwrap().is_some());
+        replenisher.shutdown().await;
+    }
+}

--- a/crates/runner/src/cmd/start/blank_pool.rs
+++ b/crates/runner/src/cmd/start/blank_pool.rs
@@ -1,6 +1,7 @@
 //! Best-effort, capacity-scaled preparation of tenant-free parked sandboxes.
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
@@ -48,6 +49,12 @@ struct BlankPrepareInput {
     device_rate_limits: Option<sandbox::DeviceRateLimits>,
     budget_lease: BudgetLease,
     pre_spawn_lease: BackgroundPreSpawnAdmissionLease,
+}
+
+enum BackgroundStageResult<T> {
+    Completed(sandbox::Result<T>),
+    CancelledBeforeStart,
+    CancelledAfterStart(sandbox::Result<T>),
 }
 
 pub(super) enum BlankPrepareResult {
@@ -387,6 +394,7 @@ async fn prepare_blank_sandbox(
         budget_lease,
         pre_spawn_lease,
     } = input;
+    let mut pre_spawn_lease = Some(pre_spawn_lease);
     let sandbox_id = SandboxId::new_v4();
     let config = SandboxConfig {
         id: sandbox_id,
@@ -400,7 +408,8 @@ async fn prepare_blank_sandbox(
             seed_image: None,
         }),
     };
-    let mut sandbox = match create_or_cancel(&factory, config, &cancel).await {
+    let mut sandbox = match create_or_cancel(&factory, config, &cancel, &mut pre_spawn_lease).await
+    {
         Some(Ok(sandbox)) => sandbox,
         Some(Err(error)) => {
             return BlankPrepareResult::Failed(BlankPrepareFailure {
@@ -416,19 +425,18 @@ async fn prepare_blank_sandbox(
         }
     };
 
-    let start_result = start_or_cancel(sandbox.as_mut(), &cancel).await;
-    match start_result {
-        Some(Ok(())) => {}
-        Some(Err(error)) => {
-            drop(pre_spawn_lease);
+    match run_background_stage(sandbox.start(), &cancel, &mut pre_spawn_lease).await {
+        BackgroundStageResult::Completed(Ok(())) => {}
+        BackgroundStageResult::Completed(Err(error)) => {
+            drop(pre_spawn_lease.take());
             destroy_sandbox(&factory, sandbox).await;
             return BlankPrepareResult::Failed(BlankPrepareFailure {
                 stage: "start",
                 error: Some(error.to_string()),
             });
         }
-        None => {
-            drop(pre_spawn_lease);
+        BackgroundStageResult::CancelledBeforeStart
+        | BackgroundStageResult::CancelledAfterStart(_) => {
             destroy_sandbox(&factory, sandbox).await;
             return BlankPrepareResult::Failed(BlankPrepareFailure {
                 stage: "start",
@@ -437,10 +445,9 @@ async fn prepare_blank_sandbox(
         }
     }
 
-    let park_result = park_or_cancel(sandbox.as_mut(), &cancel).await;
-    match park_result {
-        Some(Ok(SandboxParkOutcome::Reusable)) => {
-            drop(pre_spawn_lease);
+    match run_background_stage(sandbox.park(), &cancel, &mut pre_spawn_lease).await {
+        BackgroundStageResult::Completed(Ok(SandboxParkOutcome::Reusable)) => {
+            drop(pre_spawn_lease.take());
             BlankPrepareResult::Ready(Box::new(ParkedIdleCandidate::blank(
                 sandbox,
                 factory,
@@ -450,24 +457,24 @@ async fn prepare_blank_sandbox(
                 device_rate_limits,
             )))
         }
-        Some(Ok(SandboxParkOutcome::NonReusable(reason))) => {
-            drop(pre_spawn_lease);
+        BackgroundStageResult::Completed(Ok(SandboxParkOutcome::NonReusable(reason))) => {
+            drop(pre_spawn_lease.take());
             destroy_sandbox(&factory, sandbox).await;
             BlankPrepareResult::Failed(BlankPrepareFailure {
                 stage: "park_non_reusable",
                 error: Some(reason.as_str().to_owned()),
             })
         }
-        Some(Err(error)) => {
-            drop(pre_spawn_lease);
+        BackgroundStageResult::Completed(Err(error)) => {
+            drop(pre_spawn_lease.take());
             destroy_sandbox(&factory, sandbox).await;
             BlankPrepareResult::Failed(BlankPrepareFailure {
                 stage: "park",
                 error: Some(error.to_string()),
             })
         }
-        None => {
-            drop(pre_spawn_lease);
+        BackgroundStageResult::CancelledBeforeStart
+        | BackgroundStageResult::CancelledAfterStart(_) => {
             destroy_sandbox(&factory, sandbox).await;
             BlankPrepareResult::Failed(BlankPrepareFailure {
                 stage: "park",
@@ -481,33 +488,49 @@ async fn create_or_cancel(
     factory: &SharedFactory,
     config: SandboxConfig,
     cancel: &CancellationToken,
+    pre_spawn_lease: &mut Option<BackgroundPreSpawnAdmissionLease>,
 ) -> Option<sandbox::Result<Box<dyn Sandbox>>> {
+    if cancel.is_cancelled() {
+        drop(pre_spawn_lease.take());
+        return None;
+    }
+    // Firecracker factory creation owns a cancellation-safe transaction. Do
+    // not drain a cancelled create: it may be waiting on the same COW or netns
+    // resources needed by the foreground request that triggered cancellation.
     tokio::select! {
         biased;
-        _ = cancel.cancelled() => None,
+        _ = cancel.cancelled() => {
+            drop(pre_spawn_lease.take());
+            None
+        }
         result = factory.create(config) => Some(result),
     }
 }
 
-async fn start_or_cancel(
-    sandbox: &mut dyn Sandbox,
+async fn run_background_stage<T>(
+    stage: impl Future<Output = sandbox::Result<T>>,
     cancel: &CancellationToken,
-) -> Option<sandbox::Result<()>> {
-    tokio::select! {
-        biased;
-        _ = cancel.cancelled() => None,
-        result = sandbox.start() => Some(result),
+    pre_spawn_lease: &mut Option<BackgroundPreSpawnAdmissionLease>,
+) -> BackgroundStageResult<T> {
+    if cancel.is_cancelled() {
+        drop(pre_spawn_lease.take());
+        return BackgroundStageResult::CancelledBeforeStart;
     }
-}
-
-async fn park_or_cancel(
-    sandbox: &mut dyn Sandbox,
-    cancel: &CancellationToken,
-) -> Option<sandbox::Result<SandboxParkOutcome>> {
+    tokio::pin!(stage);
     tokio::select! {
         biased;
-        _ = cancel.cancelled() => None,
-        result = sandbox.park() => Some(result),
+        result = &mut stage => {
+            if cancel.is_cancelled() {
+                drop(pre_spawn_lease.take());
+                BackgroundStageResult::CancelledAfterStart(result)
+            } else {
+                BackgroundStageResult::Completed(result)
+            }
+        }
+        _ = cancel.cancelled() => {
+            drop(pre_spawn_lease.take());
+            BackgroundStageResult::CancelledAfterStart(stage.await)
+        }
     }
 }
 

--- a/crates/runner/src/cmd/start/blank_pool.rs
+++ b/crates/runner/src/cmd/start/blank_pool.rs
@@ -21,6 +21,7 @@ use crate::lifecycle::RunnerMode;
 use crate::pre_spawn_admission::{BackgroundPreSpawnAdmissionLease, PreSpawnAdmission};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::status::StatusTracker;
+use crate::workspace_mount::ensure_workspace_drive_mounted;
 
 const TARGET_PERCENT: usize = 10;
 
@@ -51,10 +52,10 @@ struct BlankPrepareInput {
     pre_spawn_lease: BackgroundPreSpawnAdmissionLease,
 }
 
-enum BackgroundStageResult<T> {
-    Completed(sandbox::Result<T>),
+enum BackgroundStageResult<T, E> {
+    Completed(Result<T, E>),
     CancelledBeforeStart,
-    CancelledAfterStart(sandbox::Result<T>),
+    CancelledAfterStart(Result<T, E>),
     Panicked,
 }
 
@@ -454,6 +455,40 @@ async fn prepare_blank_sandbox(
         }
     }
 
+    match run_background_stage(
+        ensure_workspace_drive_mounted(sandbox.as_ref(), sandbox_id),
+        &cancel,
+        &mut pre_spawn_lease,
+    )
+    .await
+    {
+        BackgroundStageResult::Completed(Ok(_)) => {}
+        BackgroundStageResult::Completed(Err(error)) => {
+            drop(pre_spawn_lease.take());
+            destroy_sandbox(&factory, sandbox).await;
+            return BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "workspace_mount",
+                error: Some(error.error.to_string()),
+            });
+        }
+        BackgroundStageResult::CancelledBeforeStart
+        | BackgroundStageResult::CancelledAfterStart(_) => {
+            destroy_sandbox(&factory, sandbox).await;
+            return BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "workspace_mount",
+                error: None,
+            });
+        }
+        BackgroundStageResult::Panicked => {
+            drop(pre_spawn_lease.take());
+            destroy_sandbox(&factory, sandbox).await;
+            return BlankPrepareResult::Failed(BlankPrepareFailure {
+                stage: "workspace_mount",
+                error: Some("workspace drive mount panicked".into()),
+            });
+        }
+    }
+
     match run_background_stage(sandbox.park(), &cancel, &mut pre_spawn_lease).await {
         BackgroundStageResult::Completed(Ok(SandboxParkOutcome::Reusable)) => {
             drop(pre_spawn_lease.take());
@@ -524,11 +559,11 @@ async fn create_or_cancel(
     }
 }
 
-async fn run_background_stage<T>(
-    stage: impl Future<Output = sandbox::Result<T>>,
+async fn run_background_stage<T, E>(
+    stage: impl Future<Output = Result<T, E>>,
     cancel: &CancellationToken,
     pre_spawn_lease: &mut Option<BackgroundPreSpawnAdmissionLease>,
-) -> BackgroundStageResult<T> {
+) -> BackgroundStageResult<T, E> {
     if cancel.is_cancelled() {
         drop(pre_spawn_lease.take());
         return BackgroundStageResult::CancelledBeforeStart;

--- a/crates/runner/src/cmd/start/finalizing_claim.rs
+++ b/crates/runner/src/cmd/start/finalizing_claim.rs
@@ -890,6 +890,7 @@ async fn acquire_fallback_resource(
                 profile_name,
                 device_rate_limits,
                 history_generation_run_id: Some(history_generation_run_id),
+                allow_compatible_blank: false,
                 vcpu,
                 memory_mb,
                 context: "finalizing_fallback_oldest",

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -217,6 +217,9 @@ pub(super) async fn select_idle_entries_for_pressure(
             );
             if fresh_lease.is_none() {
                 for reuse_key in pool.oldest_first_pressure_keys() {
+                    let Some(idle_kind) = pool.entry_kind(&reuse_key) else {
+                        continue;
+                    };
                     let Some(job) = pool.evict_for_pressure(&reuse_key) else {
                         continue;
                     };
@@ -225,6 +228,7 @@ pub(super) async fn select_idle_entries_for_pressure(
                     info!(
                         run_id = %request.run_id,
                         context = request.context,
+                        idle_kind = ?idle_kind,
                         reuse_key_fingerprint = %short_digest(retiring.reuse_key()),
                         reuse_key_kind = reuse_key_kind(retiring.reuse_key()),
                         profile = %retiring.profile_name(),

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -70,6 +70,10 @@ impl IdleDestroyTracker {
         }));
     }
 
+    pub(super) fn notify_reuse_state(&self) {
+        self.reuse_state_notify.notify_one();
+    }
+
     pub(super) async fn close_and_wait(&self) {
         let _ = self.tasks.close();
         self.tasks.wait().await;

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -116,6 +116,7 @@ pub(super) struct IdlePressureRequest<'a> {
     pub(super) profile_name: &'a str,
     pub(super) device_rate_limits: &'a Option<DeviceRateLimits>,
     pub(super) history_generation_run_id: Option<RunId>,
+    pub(super) allow_compatible_blank: bool,
     pub(super) vcpu: u32,
     pub(super) memory_mb: u32,
     pub(super) context: &'static str,
@@ -178,8 +179,8 @@ impl RetiringIdleEntry {
     }
 }
 
-/// Prefer a matching reusable entry; otherwise retire only enough oldest idle
-/// entries for the incoming resource shape.
+/// Prefer a matching exact entry, then an allowed compatible blank; otherwise
+/// retire only enough oldest idle entries for the incoming resource shape.
 ///
 /// The idle pool stays locked while one deterministic oldest-first ordering is
 /// consumed. Resource-budget substitution takes only its short synchronous
@@ -196,12 +197,20 @@ pub(super) async fn select_idle_entries_for_pressure(
 ) -> IdlePressureSelection {
     let (selection, snapshot) = {
         let mut pool = idle_pool.lock().await;
-        if let Some(reservation) = pool.reserve_reusable_for_pressure(
-            request.reuse_key,
-            request.profile_name,
-            request.device_rate_limits,
-            request.history_generation_run_id,
-        ) {
+        let reservation = pool
+            .reserve_reusable_for_pressure(
+                request.reuse_key,
+                request.profile_name,
+                request.device_rate_limits,
+                request.history_generation_run_id,
+            )
+            .or_else(|| {
+                request
+                    .allow_compatible_blank
+                    .then(|| pool.reserve_blank(request.profile_name, request.device_rate_limits))
+                    .flatten()
+            });
+        if let Some(reservation) = reservation {
             drop(retiring_leases);
             let snapshot = pool.status_snapshot();
             (

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -2281,7 +2281,7 @@ pub(super) async fn activate_reserved_idle(
         );
         return cleanup_reserved_for_fresh_fallback(
             reservation.into_destroy_job(),
-            fallback_reuse_result,
+            miss_result,
             "reserved_reuse_session_mismatch",
             ctx,
         )

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -127,7 +127,7 @@ use crate::executor::{
 };
 use crate::guest_timezone::{GuestTimezoneAssumption, GuestTimezoneIntent};
 use crate::idle_pool::{
-    DestroyOutcome, ExactIdleReservationMiss, IdlePoolSnapshot, IdleUnparkResult,
+    DestroyOutcome, ExactIdleReservationMiss, IdlePoolSnapshot, IdleSandboxKind, IdleUnparkResult,
     ReservedIdleSandbox, RestoreReservedIdleResult, ReusableIdleSandbox, SpeculativeIdleSandbox,
     SpeculativeIdleUnparkResult, SpeculativeReparkResult,
 };
@@ -2524,41 +2524,57 @@ async fn try_reuse_from_pool(
         job_lease,
     } = request;
 
-    let started_at = Instant::now();
-    let Some(reuse_key) = context.reuse_key() else {
-        pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
-        return Ok((
-            None,
-            job_lease,
-            SandboxReuseResult::NoReuseKey,
-            None,
-            false,
-            None,
-        ));
+    let reuse_key = context.reuse_key();
+    let miss_result = if reuse_key.is_some() {
+        SandboxReuseResult::PoolMiss
+    } else {
+        SandboxReuseResult::NoReuseKey
     };
+    let started_at = Instant::now();
     // Take the entry under the pool lock, then drop the lock before any awaits
     // so unpark does not block other take/park operations.
-    let taken = {
+    let exact = {
         let mut pool = ctx.idle_pool.lock().await;
-        pool.take_reserved(reuse_key)
+        reuse_key
+            .and_then(|reuse_key| pool.take_reserved(reuse_key))
             .map(|entry| (entry, pool.status_snapshot()))
     };
-    let took_idle_session = taken.is_some();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
     let started_at = Instant::now();
     let claimed_workspace_cache_reuse_key = ctx.spawn_ctx.exec_config.workspace_cache.is_some()
-        && ctx
-            .spawn_ctx
-            .workspace_cache_snapshot
-            .might_contain_workspace_cache_reuse_key(reuse_key);
+        && reuse_key.is_some_and(|reuse_key| {
+            ctx.spawn_ctx
+                .workspace_cache_snapshot
+                .might_contain_workspace_cache_reuse_key(reuse_key)
+        });
     pre_spawn_timing
         .record_phase_elapsed(RunnerPreSpawnPhase::WorkspaceCacheStateLookup, started_at);
+    let taken = match exact {
+        Some(exact) => Some(exact),
+        None if !claimed_workspace_cache_reuse_key => {
+            let mut pool = ctx.idle_pool.lock().await;
+            pool.reserve_blank(profile_name, device_rate_limits)
+                .map(|entry| (entry, pool.status_snapshot()))
+        }
+        None => None,
+    };
+    let took_idle_session = taken.is_some();
     let needs_reuse_state_refresh = took_idle_session || claimed_workspace_cache_reuse_key;
     match taken {
         Some((entry, snapshot))
             if entry.profile_name() == profile_name
                 && entry.device_rate_limits() == device_rate_limits =>
         {
+            let entry_kind = entry.kind();
+            let entry_reuse_key = entry.reuse_key().to_owned();
+            let activation_reuse_result = match entry_kind {
+                IdleSandboxKind::Exact => SandboxReuseResult::Reused,
+                IdleSandboxKind::Blank => miss_result,
+            };
+            let fallback_reuse_result = match entry_kind {
+                IdleSandboxKind::Exact => SandboxReuseResult::PoolMiss,
+                IdleSandboxKind::Blank => miss_result,
+            };
             if let Some(cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref() {
                 let started_at = Instant::now();
                 let validation = entry.validate_workspace_promotion_identity(
@@ -2573,8 +2589,8 @@ async fn try_reuse_from_pool(
                 if let Err(mismatch) = validation {
                     warn!(
                         run_id = %run_id,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
-                        reuse_key_kind = reuse_key_kind(reuse_key),
+                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&entry_reuse_key),
+                        reuse_key_kind = reuse_key_kind(&entry_reuse_key),
                         profile = %profile_name,
                         mismatch = mismatch.as_str(),
                         "workspace promotion identity mismatch, destroying idle sandbox and falling through to fresh create"
@@ -2587,7 +2603,7 @@ async fn try_reuse_from_pool(
                     return Ok((
                         None,
                         job_lease,
-                        SandboxReuseResult::PoolMiss,
+                        fallback_reuse_result,
                         Some(snapshot),
                         needs_reuse_state_refresh,
                         None,
@@ -2607,7 +2623,7 @@ async fn try_reuse_from_pool(
                 return Ok((
                     None,
                     job_lease,
-                    SandboxReuseResult::PoolMiss,
+                    fallback_reuse_result,
                     None,
                     needs_reuse_state_refresh,
                     None,
@@ -2641,7 +2657,7 @@ async fn try_reuse_from_pool(
                 return Ok((
                     None,
                     job_lease,
-                    SandboxReuseResult::PoolMiss,
+                    fallback_reuse_result,
                     None,
                     needs_reuse_state_refresh,
                     None,
@@ -2664,9 +2680,10 @@ async fn try_reuse_from_pool(
                 } => {
                     info!(
                         run_id = %run_id,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
-                        reuse_key_kind = reuse_key_kind(reuse_key),
-                        "reusing idle sandbox for reuse key"
+                        idle_kind = ?entry_kind,
+                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&entry_reuse_key),
+                        reuse_key_kind = reuse_key_kind(&entry_reuse_key),
+                        "activating idle sandbox"
                     );
                     // Idle entry already holds budget. Drop the speculative
                     // fresh-job lease and move the idle lease to the outer job
@@ -2675,7 +2692,7 @@ async fn try_reuse_from_pool(
                     Ok((
                         Some(*sandbox),
                         budget_lease,
-                        SandboxReuseResult::Reused,
+                        activation_reuse_result,
                         Some(snapshot),
                         needs_reuse_state_refresh,
                         Some(transfer_guard),
@@ -2684,8 +2701,9 @@ async fn try_reuse_from_pool(
                 IdleUnparkResult::Failed { destroy_job, error } => {
                     warn!(
                         run_id = %run_id,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
-                        reuse_key_kind = reuse_key_kind(reuse_key),
+                        idle_kind = ?entry_kind,
+                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&entry_reuse_key),
+                        reuse_key_kind = reuse_key_kind(&entry_reuse_key),
                         error = %error,
                         "unpark failed, destroying idle sandbox and falling through to fresh create"
                     );
@@ -2727,10 +2745,11 @@ async fn try_reuse_from_pool(
             }
         }
         Some((stale, snapshot)) if stale.profile_name() == profile_name => {
+            let stale_reuse_key = stale.reuse_key().to_owned();
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
-                reuse_key_kind = reuse_key_kind(reuse_key),
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&stale_reuse_key),
+                reuse_key_kind = reuse_key_kind(&stale_reuse_key),
                 profile = %profile_name,
                 "idle sandbox device rate limiter mismatch, destroying"
             );
@@ -2749,10 +2768,11 @@ async fn try_reuse_from_pool(
             ))
         }
         Some((stale, snapshot)) => {
+            let stale_reuse_key = stale.reuse_key().to_owned();
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
-                reuse_key_kind = reuse_key_kind(reuse_key),
+                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&stale_reuse_key),
+                reuse_key_kind = reuse_key_kind(&stale_reuse_key),
                 old_profile = %stale.profile_name(),
                 new_profile = %profile_name,
                 "idle sandbox profile mismatch, destroying"
@@ -2772,16 +2792,20 @@ async fn try_reuse_from_pool(
             ))
         }
         None => {
-            info!(
-                run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
-                reuse_key_kind = reuse_key_kind(reuse_key),
-                "no idle sandbox found for reuse key"
-            );
+            match reuse_key {
+                Some(reuse_key) => info!(
+                    run_id = %run_id,
+                    reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(reuse_key),
+                    reuse_key_kind = reuse_key_kind(reuse_key),
+                    workspace_cache_possible = claimed_workspace_cache_reuse_key,
+                    "no compatible idle sandbox found for reuse key"
+                ),
+                None => info!(run_id = %run_id, "no compatible blank sandbox found"),
+            }
             Ok((
                 None,
                 job_lease,
-                SandboxReuseResult::PoolMiss,
+                miss_result,
                 None,
                 needs_reuse_state_refresh,
                 None,

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -2577,6 +2577,10 @@ async fn try_reuse_from_pool(
                 IdleSandboxKind::Exact => SandboxReuseResult::PoolMiss,
                 IdleSandboxKind::Blank => miss_result,
             };
+            let unpark_failure_reuse_result = match entry_kind {
+                IdleSandboxKind::Exact => SandboxReuseResult::UnparkFailed,
+                IdleSandboxKind::Blank => miss_result,
+            };
             if let Some(cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref() {
                 let started_at = Instant::now();
                 let validation = entry.validate_workspace_promotion_identity(
@@ -2720,7 +2724,7 @@ async fn try_reuse_from_pool(
                             Ok((
                                 None,
                                 job_lease,
-                                SandboxReuseResult::UnparkFailed,
+                                unpark_failure_reuse_result,
                                 Some(snapshot),
                                 needs_reuse_state_refresh,
                                 None,
@@ -2737,7 +2741,7 @@ async fn try_reuse_from_pool(
                                 "reuse_unpark_failed",
                             );
                             Err(ReuseFromPoolFailure {
-                                reuse_result: SandboxReuseResult::UnparkFailed,
+                                reuse_result: unpark_failure_reuse_result,
                                 error: "idle sandbox cleanup was uncertain; fresh replacement was not started"
                                     .to_owned(),
                             })

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -1645,7 +1645,9 @@ pub(super) async fn rollback_reserved_idle_for_spawn(
         (restore_result, snapshot)
     };
     set_idle_status_snapshot(&ctx.status, snapshot).await;
-    if let RestoreReservedIdleResult::Rejected(destroy_job) = restore_result {
+    if let RestoreReservedIdleResult::Replaced(destroy_job)
+    | RestoreReservedIdleResult::Rejected(destroy_job) = restore_result
+    {
         destroy_idle_jobs_and_wait(
             vec![*destroy_job],
             "finalizing_claim_reserved_idle_rollback",
@@ -1741,7 +1743,8 @@ async fn rollback_exact_speculation_outcome(
                     ctx.spawn_ctx.reuse_state_notify.notify_one();
                     match restore_result {
                         RestoreReservedIdleResult::Restored => None,
-                        RestoreReservedIdleResult::Rejected(destroy_job) => Some(destroy_job),
+                        RestoreReservedIdleResult::Replaced(destroy_job)
+                        | RestoreReservedIdleResult::Rejected(destroy_job) => Some(destroy_job),
                     }
                 }
                 SpeculativeReparkResult::Destroy {
@@ -2188,7 +2191,9 @@ pub(super) async fn activate_reserved_idle(
                 let restore_result = pool.restore_reserved(reservation);
                 let snapshot = pool.status_snapshot();
                 drop(pool);
-                if let RestoreReservedIdleResult::Rejected(destroy_job) = restore_result {
+                if let RestoreReservedIdleResult::Replaced(destroy_job)
+                | RestoreReservedIdleResult::Rejected(destroy_job) = restore_result
+                {
                     spawn_idle_destroy_job(
                         &ctx.idle_destroy_tracker,
                         *destroy_job,

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -2553,7 +2553,9 @@ async fn try_reuse_from_pool(
         Some(exact) => Some(exact),
         None if !claimed_workspace_cache_reuse_key => {
             let mut pool = ctx.idle_pool.lock().await;
-            pool.reserve_blank(profile_name, device_rate_limits)
+            reuse_key
+                .and_then(|reuse_key| pool.take_reserved(reuse_key))
+                .or_else(|| pool.reserve_blank(profile_name, device_rate_limits))
                 .map(|entry| (entry, pool.status_snapshot()))
         }
         None => None,

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -21,10 +21,10 @@
 //!    a required preference resource is not available, the candidate is deferred or retained for a
 //!    later poll rather than claimed.
 //! 2. **Reserve local admission.** Before ordinary claim, hold either a budget lease or a reserved
-//!    idle entry. Exact speculation holds a generation-matching reservation while it prepares the
-//!    sandbox in parallel with claim. A finalizing successor is the deliberate exception: a proof of
-//!    its predecessor's reuse identity allows claim before the predecessor publishes an exact
-//!    sandbox, so no fresh capacity is reserved for this admission.
+//!    exact or blank idle entry. Exact speculation holds a generation-matching reservation while it
+//!    prepares the sandbox in parallel with claim. A finalizing successor is the deliberate
+//!    exception: a proof of its predecessor's reuse identity allows claim before the predecessor
+//!    publishes an exact sandbox, so no fresh capacity is reserved for this admission.
 //! 3. **Register cancellation and recheck lifecycle mode.** The cancellation registration is made
 //!    before claim so provider-side cancellation can find the run, and duplicate registration is
 //!    rejected without overwriting the active executor handle. The mode is checked after local
@@ -64,12 +64,12 @@
 //!   remains the fresh fallback while ordinary idle reuse is attempted; it is either transferred to
 //!   the executor's fresh sandbox or released after no-sandbox completion. If idle reuse wins, the
 //!   idle sandbox's active lease replaces this speculative fresh lease.
-//! - **`Reusable(ReservedIdleActivation)`:** the reservation owns an idle-pool entry removed from
-//!   the pool. Before claim loss it is restored to the pool. After a claim, activation validates
-//!   profile, device limits, reuse key, and workspace-promotion identity, persists `preparing`,
-//!   and then unparks. A status or unpark failure completes the claim without a sandbox and either
-//!   restores or destroys the entry before any fresh fallback; the reservation is not silently
-//!   dropped.
+//! - **`Reusable(ReservedIdleActivation)`:** the reservation owns an exact or blank idle-pool entry
+//!   removed from the pool. Before claim loss it is restored to the pool. After a claim, activation
+//!   preserves exact and workspace-cache priority over blank inventory, validates the applicable
+//!   identity and configuration, persists `preparing`, and then unparks. A status or unpark failure
+//!   completes the claim without a sandbox and either restores or destroys the entry before any
+//!   fresh fallback; the reservation is not silently dropped.
 //! - **`ExactSpeculative(ExactSpeculationReservation)`:** a generation-matching reservation owns
 //!   the idle entry while unpark and guest-state preparation run alongside claim. The idle status
 //!   snapshot remains the visible pool state until the prepared sandbox is committed. A lost claim
@@ -1524,6 +1524,12 @@ async fn acquire_local_admission_resource(
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     ctx: &mut DiscoveredJobContext<'_>,
 ) -> Option<LocalAdmissionResource> {
+    let workspace_cache_possible = ctx.spawn_ctx.exec_config.workspace_cache.is_some()
+        && candidate.reuse_key().is_some_and(|reuse_key| {
+            ctx.spawn_ctx
+                .workspace_cache_snapshot
+                .might_contain_workspace_cache_reuse_key(reuse_key)
+        });
     match select_idle_entries_for_pressure(
         ctx.idle_pool,
         ctx.status,
@@ -1536,6 +1542,7 @@ async fn acquire_local_admission_resource(
             profile_name,
             device_rate_limits,
             history_generation_run_id: None,
+            allow_compatible_blank: !workspace_cache_possible,
             vcpu: job_vcpu,
             memory_mb: job_memory,
             context: "candidate_admission_oldest",
@@ -2170,8 +2177,76 @@ pub(super) async fn activate_reserved_idle(
     } = request;
     let started_at = Instant::now();
     let requested_reuse_key = context.reuse_key();
+    // A matching exact sandbox can park while the provider claim is in
+    // flight. Preserve the normal exact-over-blank priority without giving up
+    // the blank reservation that owns admission capacity during that wait.
+    let (reservation, idle_snapshot) = match (reservation.kind(), requested_reuse_key) {
+        (IdleSandboxKind::Blank, Some(reuse_key)) => {
+            let mut pool = ctx.idle_pool.lock().await;
+            if let Some(exact) = pool.reserve_reusable(reuse_key, profile_name, device_rate_limits)
+            {
+                let restore_result = pool.restore_reserved(reservation);
+                let snapshot = pool.status_snapshot();
+                drop(pool);
+                if let RestoreReservedIdleResult::Rejected(destroy_job) = restore_result {
+                    spawn_idle_destroy_job(
+                        &ctx.idle_destroy_tracker,
+                        *destroy_job,
+                        "reserved_blank_exact_priority_restore_rejected",
+                    );
+                }
+                (exact, snapshot)
+            } else {
+                drop(pool);
+                (reservation, idle_snapshot)
+            }
+        }
+        (IdleSandboxKind::Exact | IdleSandboxKind::Blank, _) => (reservation, idle_snapshot),
+    };
+    let reservation_kind = reservation.kind();
     let reserved_reuse_key = reservation.reuse_key().to_owned();
+    let miss_result = if requested_reuse_key.is_some() {
+        SandboxReuseResult::PoolMiss
+    } else {
+        SandboxReuseResult::NoReuseKey
+    };
+    let activation_reuse_result = match reservation_kind {
+        IdleSandboxKind::Exact => SandboxReuseResult::Reused,
+        IdleSandboxKind::Blank => miss_result,
+    };
+    let fallback_reuse_result = match reservation_kind {
+        IdleSandboxKind::Exact => SandboxReuseResult::PoolMiss,
+        IdleSandboxKind::Blank => miss_result,
+    };
+    let unpark_failure_reuse_result = match reservation_kind {
+        IdleSandboxKind::Exact => SandboxReuseResult::UnparkFailed,
+        IdleSandboxKind::Blank => miss_result,
+    };
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
+
+    let claimed_workspace_cache_reuse_key = if reservation_kind == IdleSandboxKind::Blank {
+        let started_at = Instant::now();
+        let possible = ctx.exec_config.workspace_cache.is_some()
+            && requested_reuse_key.is_some_and(|reuse_key| {
+                ctx.workspace_cache_snapshot
+                    .might_contain_workspace_cache_reuse_key(reuse_key)
+            });
+        pre_spawn_timing
+            .record_phase_elapsed(RunnerPreSpawnPhase::WorkspaceCacheStateLookup, started_at);
+        possible
+    } else {
+        false
+    };
+    if claimed_workspace_cache_reuse_key {
+        return cleanup_reserved_for_fresh_fallback(
+            reservation.into_destroy_job(),
+            fallback_reuse_result,
+            "reserved_blank_workspace_cache_priority",
+            ctx,
+        )
+        .await
+        .into();
+    }
 
     if reservation.profile_name() != profile_name
         || reservation.device_rate_limits() != device_rate_limits
@@ -2186,7 +2261,7 @@ pub(super) async fn activate_reserved_idle(
         );
         return cleanup_reserved_for_fresh_fallback(
             reservation.into_destroy_job(),
-            SandboxReuseResult::PoolMiss,
+            fallback_reuse_result,
             "reserved_reuse_configuration_mismatch",
             ctx,
         )
@@ -2194,12 +2269,9 @@ pub(super) async fn activate_reserved_idle(
         .into();
     }
 
-    if requested_reuse_key != Some(reserved_reuse_key.as_str()) {
-        let reuse_result = if requested_reuse_key.is_none() {
-            SandboxReuseResult::NoReuseKey
-        } else {
-            SandboxReuseResult::PoolMiss
-        };
+    if reservation_kind == IdleSandboxKind::Exact
+        && requested_reuse_key != Some(reserved_reuse_key.as_str())
+    {
         let reuse_key_fingerprint = diagnostic_reuse_key_fingerprint(&reserved_reuse_key);
         warn!(
             run_id = %run_id,
@@ -2209,7 +2281,7 @@ pub(super) async fn activate_reserved_idle(
         );
         return cleanup_reserved_for_fresh_fallback(
             reservation.into_destroy_job(),
-            reuse_result,
+            fallback_reuse_result,
             "reserved_reuse_session_mismatch",
             ctx,
         )
@@ -2239,7 +2311,7 @@ pub(super) async fn activate_reserved_idle(
             );
             return cleanup_reserved_for_fresh_fallback(
                 reservation.into_destroy_job_without_workspace_promotion_for_mismatch(),
-                SandboxReuseResult::PoolMiss,
+                fallback_reuse_result,
                 "reserved_reuse_workspace_promotion_mismatch",
                 ctx,
             )
@@ -2275,7 +2347,7 @@ pub(super) async fn activate_reserved_idle(
         .await;
         return ReservedActivation::CannotStart {
             budget_lease: None,
-            reuse_result: SandboxReuseResult::PoolMiss,
+            reuse_result: fallback_reuse_result,
             error: format!("persist preparing reuse ownership: {error}"),
         };
     }
@@ -2302,14 +2374,15 @@ pub(super) async fn activate_reserved_idle(
         } => {
             info!(
                 run_id = %run_id,
+                idle_kind = ?reservation_kind,
                 reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
                 reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
-                "reusing pre-claim reserved idle sandbox for reuse key"
+                "activating pre-claim reserved idle sandbox"
             );
             ReservedActivation::Ready {
                 reuse_entry: Some(sandbox),
                 active_lease: budget_lease,
-                reuse_result: SandboxReuseResult::Reused,
+                reuse_result: activation_reuse_result,
                 idle_snapshot,
             }
         }
@@ -2323,7 +2396,7 @@ pub(super) async fn activate_reserved_idle(
             );
             let activation = cleanup_reserved_for_fresh_fallback(
                 *destroy_job,
-                SandboxReuseResult::UnparkFailed,
+                unpark_failure_reuse_result,
                 "reserved_reuse_unpark_failed",
                 ctx,
             )

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -181,6 +181,7 @@ impl ExecutorInvocation {
             if let Some(idle_entry) = reuse_entry {
                 executor::execute_job_reuse_with_hooks(
                     idle_entry,
+                    reuse_result,
                     context,
                     &exec_config,
                     &params,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -2063,6 +2063,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 &shared.idle_pool,
                 &capacity.budget,
                 &exec_config.pre_spawn_admission,
+                &shared.status,
+                &idle_destroy_tracker,
             )
             .await;
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -86,6 +86,7 @@ use crate::workspace_image_cache::{
 };
 
 mod active_runs;
+mod blank_pool;
 mod factory_lifecycle;
 mod finalizing_claim;
 mod heartbeat;
@@ -102,6 +103,7 @@ mod sandbox_finalization;
 mod signals;
 
 use active_runs::ActiveRuns;
+use blank_pool::BlankPoolReplenisher;
 use factory_lifecycle::{shutdown_factory_instances, shutdown_runtime, start_factories};
 use heartbeat::{
     HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, HeartbeatController,
@@ -930,6 +932,7 @@ async fn run_start_with_home(
             budget,
             min_vcpu,
             min_memory_mb,
+            max_idle,
             device_rate_limits,
         },
         shared: RunnerSharedState {
@@ -1053,6 +1056,7 @@ struct CapacityPolicy {
     budget: Arc<ResourceBudget>,
     min_vcpu: u32,
     min_memory_mb: u32,
+    max_idle: usize,
     device_rate_limits: Option<sandbox::DeviceRateLimits>,
 }
 
@@ -1967,6 +1971,18 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         #[cfg(test)]
         test_observer: test_hooks.test_observer.clone(),
     };
+    let mut blank_pool = BlankPoolReplenisher::new(
+        &runner.profiles,
+        &factories,
+        &capacity.budget,
+        capacity.max_idle,
+        capacity.device_rate_limits.clone(),
+    );
+    let mut blank_pool_tick = tokio::time::interval_at(
+        tokio::time::Instant::now() + Duration::from_secs(1),
+        Duration::from_secs(1),
+    );
+    blank_pool_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut workspace_cache_gc_tick = tokio::time::interval_at(
         tokio::time::Instant::now() + WORKSPACE_CACHE_GC_PERIOD,
         WORKSPACE_CACHE_GC_PERIOD,
@@ -2004,6 +2020,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         if mode != RunnerMode::Running {
             pending_finalizing_candidate = None;
         }
+        blank_pool.cancel_if_inactive(mode);
         match mode {
             RunnerMode::Starting => {}
             // Stopped should not normally reach here — teardown sets it and
@@ -2040,6 +2057,15 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             }
         }
 
+        blank_pool
+            .maybe_start(
+                mode,
+                &shared.idle_pool,
+                &capacity.budget,
+                &exec_config.pre_spawn_admission,
+            )
+            .await;
+
         // Spawn background restart task when timer fires
         maybe_spawn_mitm_restart(&mut mitm, &mut mitm_crash_rx, &mut mitm_retry).await;
 
@@ -2064,6 +2090,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             .and_then(JobCandidate::runner_preference)
             .map(crate::provider::ActiveRunnerPreference::deadline);
         tokio::select! {
+            result = blank_pool.wait_for_preparation(), if blank_pool.is_preparing() => {
+                if let Some(result) = result {
+                    blank_pool
+                        .finish_preparation(result, &shared.idle_pool, &shared.status)
+                        .await;
+                }
+            }
+            _ = blank_pool_tick.tick() => {
+                blank_pool.request_attempt();
+            }
             // Job discovery via provider (Ably/filesystem wakeups + reconciliation).
             // The future is pinned outside the loop so other reactor branches
             // do not cancel and restart its internal wait timer. See #8747.
@@ -2409,6 +2445,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let teardown = TeardownTimer::start();
     memory_prefetch.cancel();
     teardown.event("memory_prefetch_cancelled");
+
+    let phase = teardown.phase_start("blank_pool_shutdown");
+    blank_pool.shutdown().await;
+    teardown.phase_complete("blank_pool_shutdown", phase);
 
     let phase = teardown.phase_start("heartbeat_drain");
     heartbeat.drain().await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -2093,7 +2093,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             result = blank_pool.wait_for_preparation(), if blank_pool.is_preparing() => {
                 if let Some(result) = result {
                     blank_pool
-                        .finish_preparation(result, &shared.idle_pool, &shared.status)
+                        .finish_preparation(
+                            result,
+                            &shared.idle_pool,
+                            &shared.status,
+                            &idle_destroy_tracker,
+                        )
                         .await;
                 }
             }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -1,7 +1,8 @@
 use super::super::super::*;
 use super::super::support::{
-    context_with_session, minimal_context, mock_run_config, push_job, seed_workspace_cache_state,
-    shutdown, test_profiles, two_profiles, wait_idle_pool_len,
+    context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
+    push_job, seed_workspace_cache_state, shutdown, test_profiles, two_profiles,
+    wait_idle_pool_len,
 };
 
 use crate::paths::RunnerPaths;
@@ -87,6 +88,43 @@ async fn blank_backed_run_becomes_exact_reuse_and_wins_over_refilled_blank() {
     assert_eq!(second.reuse_result, Some(SandboxReuseResult::Reused));
     assert_eq!(second.sandbox_id, Some(blank_sandbox_id));
     assert_eq!(idle_pool.lock().await.blank_len(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn blank_unpark_failure_falls_back_without_changing_cold_attribution() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let calls = Arc::clone(&overrides);
+    overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Unpark,
+        message: "simulated blank unpark failure".into(),
+    }));
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, overrides);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, "session-blank-unpark-failure")),
+    );
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("fresh fallback should complete");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_ne!(completion.sandbox_id, Some(blank_sandbox_id));
+    assert_eq!(calls.unpark_call_count(), 1);
+    assert_eq!(calls.destroy_call_count(), 1);
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -40,6 +40,58 @@ async fn blank_pool_prepares_and_serves_a_job_without_changing_reuse_attribution
 }
 
 #[tokio::test(start_paused = true)]
+async fn blank_backed_run_becomes_exact_reuse_and_wins_over_refilled_blank() {
+    let (config, env) = mock_run_config(test_profiles(), 16, 32_768, 8);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    let reuse_key = "session-blank-to-exact";
+
+    let first_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        first_run_id,
+        "vm0/default",
+        Some(context_with_session(first_run_id, reuse_key)),
+    );
+    let first = env
+        .handle
+        .wait_completion(first_run_id, Duration::from_secs(5))
+        .await
+        .expect("blank-backed job should complete");
+
+    assert_eq!(first.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_eq!(first.sandbox_id, Some(blank_sandbox_id));
+    wait_idle_pool_len(&idle_pool, 2, Duration::from_secs(5)).await;
+    {
+        let pool = idle_pool.lock().await;
+        assert_eq!(pool.blank_len(), 1);
+        assert!(pool.has_reusable(reuse_key, "vm0/default", &None));
+    }
+
+    let second_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        second_run_id,
+        "vm0/default",
+        Some(context_with_session(second_run_id, reuse_key)),
+    );
+    let second = env
+        .handle
+        .wait_completion(second_run_id, Duration::from_secs(5))
+        .await
+        .expect("exact-reuse job should complete");
+
+    assert_eq!(second.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(second.sandbox_id, Some(blank_sandbox_id));
+    assert_eq!(idle_pool.lock().await.blank_len(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn incompatible_profile_fresh_creates_without_consuming_blank_inventory() {
     let (config, env) = mock_run_config(two_profiles(), 16, 32_768, 8);
     let idle_pool = Arc::clone(&config.shared.idle_pool);

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -1,7 +1,8 @@
 use super::super::super::*;
 use super::super::support::{
-    context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
-    push_job, seed_workspace_cache_state, shutdown, test_profiles, two_profiles, wait_budget_count,
+    TestParkedIdleCandidateSpec, context_with_session, minimal_context, mock_run_config,
+    mock_run_config_with_overrides, push_job, seed_idle_pool_with_timing,
+    seed_workspace_cache_state, shutdown, test_profiles, two_profiles, wait_budget_count,
     wait_idle_pool_len,
 };
 
@@ -52,6 +53,64 @@ async fn blank_pool_prepares_and_serves_a_job_without_changing_reuse_attribution
     );
     assert_eq!(completion.sandbox_id, Some(blank_sandbox_id));
     assert_eq!(calls.workspace_drive_mount_calls(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn full_exact_pool_yields_oldest_aged_capacity_to_one_blank() {
+    let (config, env) = mock_run_config(test_profiles(), 12, 24_576, 5);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let now = std::time::Instant::now();
+    for (reuse_key, idle_for) in [
+        ("oldest-aged", Duration::from_secs(45 * 60)),
+        ("newer-aged", Duration::from_secs(31 * 60)),
+        ("young-1", Duration::from_secs(29 * 60)),
+        ("young-2", Duration::from_secs(20 * 60)),
+        ("young-3", Duration::from_secs(10 * 60)),
+    ] {
+        seed_idle_pool_with_timing(
+            &idle_pool,
+            &budget,
+            TestParkedIdleCandidateSpec {
+                reuse_key,
+                profile_name: "vm0/default",
+                vcpu: 2,
+                memory_mb: 4096,
+                history_generation_run_id: None,
+                parked_at: now - idle_for,
+            },
+        )
+        .await;
+    }
+    assert_eq!(budget.allocated().2, 5);
+    let mut pool_changes = idle_pool.lock().await.subscribe_changes();
+    let run_handle = tokio::spawn(run(config));
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if idle_pool.lock().await.blank_len() == 1 {
+                break;
+            }
+            pool_changes
+                .changed()
+                .await
+                .expect("idle pool change channel should remain open");
+        }
+    })
+    .await
+    .expect("aged exact capacity should become a blank sandbox");
+
+    {
+        let pool = idle_pool.lock().await;
+        assert_eq!(pool.len(), 5);
+        assert_eq!(pool.blank_len(), 1);
+        assert!(!pool.has_reusable("oldest-aged", "vm0/default", &None));
+        assert!(pool.has_reusable("newer-aged", "vm0/default", &None));
+        assert!(pool.has_reusable("young-1", "vm0/default", &None));
+    }
+    assert_eq!(budget.allocated().2, 5);
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -178,6 +178,108 @@ async fn foreground_admission_drains_cancelled_blank_start_before_destroy() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn foreground_admission_cancels_blank_create_without_leaking_ownership() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let calls = Arc::clone(&overrides);
+    let create_gate = sandbox_mock::MockLifecycleGate::new();
+    overrides.set_create_lifecycle_gate(create_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+
+    create_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("blank sandbox create should enter the lifecycle gate");
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(
+            run_id,
+            "session-cancelled-blank-create",
+        )),
+    );
+    create_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("foreground create should acquire admission after blank cancellation");
+    assert_eq!(calls.destroy_call_count(), 0);
+    assert_eq!(
+        budget.allocated().2,
+        1,
+        "cancelled blank create must release its resource lease"
+    );
+
+    create_gate.release_many(2);
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("foreground job should complete");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_eq!(calls.destroy_call_count(), 0);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn foreground_admission_drains_cancelled_blank_park_before_destroy() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let calls = Arc::clone(&overrides);
+    let park_gate = sandbox_mock::MockLifecycleGate::new();
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    overrides.set_park_lifecycle_gate(park_gate.clone());
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, overrides);
+    let run_handle = tokio::spawn(run(config));
+
+    park_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("blank sandbox park should enter the lifecycle gate");
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, "session-cancelled-blank-park")),
+    );
+    park_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("foreground job should reach final park while blank park drains");
+    assert_eq!(
+        calls.destroy_call_count(),
+        0,
+        "blank sandbox must remain owned until its in-flight park completes"
+    );
+
+    park_gate.release_many(2);
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("cancelled blank sandbox should enter destroy after park completes");
+    destroy_gate.release_many(2);
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("foreground job should complete");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_eq!(calls.destroy_call_count(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn incompatible_profile_fresh_creates_without_consuming_blank_inventory() {
     let (config, env) = mock_run_config(two_profiles(), 16, 32_768, 8);
     let idle_pool = Arc::clone(&config.shared.idle_pool);

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -1,7 +1,7 @@
 use super::super::super::*;
 use super::super::support::{
     context_with_session, minimal_context, mock_run_config, mock_run_config_with_overrides,
-    push_job, seed_workspace_cache_state, shutdown, test_profiles, two_profiles,
+    push_job, seed_workspace_cache_state, shutdown, test_profiles, two_profiles, wait_budget_count,
     wait_idle_pool_len,
 };
 
@@ -277,6 +277,34 @@ async fn foreground_admission_drains_cancelled_blank_park_before_destroy() {
     assert_eq!(calls.destroy_call_count(), 1);
 
     shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn blank_park_and_stop_panics_keep_budget_owned_through_destroy() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let calls = Arc::clone(&overrides);
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    overrides.push_park_panic("simulated blank park panic");
+    overrides.push_stop_panic("simulated blank stop panic");
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("panicked blank lifecycle should still reach factory destroy");
+    assert_eq!(calls.destroy_call_count(), 1);
+    assert_eq!(
+        budget.allocated().2,
+        1,
+        "blank budget must remain owned until physical destroy completes"
+    );
+
+    destroy_gate.release_many(1);
+    shutdown(&env, run_handle).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -1,0 +1,119 @@
+use super::super::super::*;
+use super::super::support::{
+    context_with_session, minimal_context, mock_run_config, push_job, seed_workspace_cache_state,
+    shutdown, test_profiles, two_profiles, wait_idle_pool_len,
+};
+
+use crate::paths::RunnerPaths;
+use crate::types::{SandboxReuseResult, WorkspaceReuseResult};
+use crate::workspace_image_cache::WorkspaceImageCache;
+
+#[tokio::test(start_paused = true)]
+async fn blank_pool_prepares_and_serves_a_job_without_changing_reuse_attribution() {
+    let (config, env) = mock_run_config(test_profiles(), 16, 32_768, 8);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::NoReuseKey)
+    );
+    assert_eq!(
+        completion.workspace_reuse_result,
+        Some(WorkspaceReuseResult::NotConfigured)
+    );
+    assert_eq!(completion.sandbox_id, Some(blank_sandbox_id));
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn incompatible_profile_fresh_creates_without_consuming_blank_inventory() {
+    let (config, env) = mock_run_config(two_profiles(), 16, 32_768, 8);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/large", Some(minimal_context(run_id)));
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::NoReuseKey)
+    );
+    assert_ne!(completion.sandbox_id, Some(blank_sandbox_id));
+    assert_eq!(idle_pool.lock().await.blank_len(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn workspace_cache_hit_takes_priority_over_compatible_blank_inventory() {
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+    let (mut config, env) = mock_run_config(profiles, 16, 32_768, 8);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = WorkspaceImageCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    let reuse_key = "thread:blank-pool-workspace-priority";
+    seed_workspace_cache_state(
+        &workspace_cache,
+        &runner_paths,
+        reuse_key,
+        "vm0/default",
+        16 * 1024 * 1024,
+    )
+    .await;
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+
+    let run_id = RunId::new_v4();
+    let mut context = context_with_session(run_id, "workspace-priority-session");
+    context.reuse_key = Some(reuse_key.into());
+    push_job(&env, run_id, "vm0/default", Some(context));
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_eq!(
+        completion.workspace_reuse_result,
+        Some(WorkspaceReuseResult::Reused)
+    );
+    assert_ne!(completion.sandbox_id, Some(blank_sandbox_id));
+    assert_eq!(idle_pool.lock().await.blank_len(), 1);
+
+    shutdown(&env, run_handle).await;
+}

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -11,11 +11,26 @@ use crate::workspace_image_cache::WorkspaceImageCache;
 
 #[tokio::test(start_paused = true)]
 async fn blank_pool_prepares_and_serves_a_job_without_changing_reuse_attribution() {
-    let (config, env) = mock_run_config(test_profiles(), 16, 32_768, 8);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let calls = Arc::clone(&overrides);
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, overrides);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let run_handle = tokio::spawn(run(config));
 
     wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    assert_eq!(calls.workspace_drive_mount_calls(), 1);
+    let create_configs = calls.create_configs();
+    assert_eq!(create_configs.len(), 1);
+    assert!(
+        create_configs[0]
+            .workspace_drive
+            .as_ref()
+            .expect("blank sandbox should have a workspace drive")
+            .seed_image
+            .is_none()
+    );
+    assert_eq!(calls.start_run_control_ids(), vec![None]);
+    assert!(calls.run_control_bind_calls().is_empty());
     let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
 
     let run_id = RunId::new_v4();
@@ -36,8 +51,42 @@ async fn blank_pool_prepares_and_serves_a_job_without_changing_reuse_attribution
         Some(WorkspaceReuseResult::NotConfigured)
     );
     assert_eq!(completion.sandbox_id, Some(blank_sandbox_id));
+    assert_eq!(calls.workspace_drive_mount_calls(), 1);
 
     shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn blank_mount_failure_destroys_sandbox_before_releasing_budget() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let calls = Arc::clone(&overrides);
+    let destroy_gate = sandbox_mock::MockLifecycleGate::new();
+    overrides.push_workspace_drive_mount_result(Ok(sandbox::ExecResult::new(
+        64,
+        Vec::new(),
+        b"simulated workspace mount failure".to_vec(),
+    )));
+    overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, overrides);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+
+    destroy_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("failed blank mount should enter factory destroy");
+    assert_eq!(calls.workspace_drive_mount_calls(), 1);
+    assert_eq!(idle_pool.lock().await.blank_len(), 0);
+    assert_eq!(
+        budget.allocated().2,
+        1,
+        "blank budget must remain owned until physical destroy completes"
+    );
+
+    destroy_gate.release_many(1);
+    shutdown(&env, run_handle).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
 }
 
 #[tokio::test(start_paused = true)]
@@ -164,6 +213,58 @@ async fn foreground_admission_drains_cancelled_blank_start_before_destroy() {
     );
 
     start_gate.release_many(2);
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("foreground job should complete");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_eq!(calls.destroy_call_count(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn foreground_admission_drains_cancelled_blank_mount_before_destroy() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let calls = Arc::clone(&overrides);
+    let mount_gate = sandbox_mock::MockLifecycleGate::new();
+    overrides.set_workspace_drive_mount_lifecycle_gate(mount_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, overrides);
+    let run_handle = tokio::spawn(run(config));
+
+    assert!(
+        calls
+            .wait_workspace_drive_mount_call_count(1, Duration::from_secs(5))
+            .await,
+        "blank sandbox mount should enter the lifecycle gate"
+    );
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(
+            run_id,
+            "session-cancelled-blank-mount",
+        )),
+    );
+    assert!(
+        calls
+            .wait_workspace_drive_mount_call_count(2, Duration::from_secs(5))
+            .await,
+        "foreground mount should acquire admission while blank mount drains"
+    );
+    assert_eq!(
+        calls.destroy_call_count(),
+        0,
+        "blank sandbox must remain owned until its in-flight mount completes"
+    );
+
+    mount_gate.release_many(2);
     let completion = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -58,6 +58,121 @@ async fn blank_pool_prepares_and_serves_a_job_without_changing_reuse_attribution
 }
 
 #[tokio::test(start_paused = true)]
+async fn full_capacity_claims_compatible_blank_before_pressure_eviction() {
+    let (config, env) = mock_run_config(test_profiles(), 16, 32_768, 8);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    let parked_at = std::time::Instant::now();
+    for reuse_key in [
+        "capacity-1",
+        "capacity-2",
+        "capacity-3",
+        "capacity-4",
+        "capacity-5",
+        "capacity-6",
+    ] {
+        seed_idle_pool_with_timing(
+            &idle_pool,
+            &budget,
+            TestParkedIdleCandidateSpec {
+                reuse_key,
+                profile_name: "vm0/default",
+                vcpu: 2,
+                memory_mb: 4096,
+                history_generation_run_id: None,
+                parked_at,
+            },
+        )
+        .await;
+    }
+    assert_eq!(budget.allocated().2, 7);
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("full-capacity job should claim the compatible blank");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::NoReuseKey)
+    );
+    assert_eq!(completion.sandbox_id, Some(blank_sandbox_id));
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn exact_idle_that_parks_during_claim_takes_priority_over_reserved_blank() {
+    let (config, env) = mock_run_config(test_profiles(), 16, 32_768, 8);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    env.handle.block_claims();
+
+    let run_id = RunId::new_v4();
+    let reuse_key = "claim-time-exact-priority";
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, reuse_key)),
+    );
+    assert!(
+        env.handle
+            .wait_claim_in_flight(1, Duration::from_secs(5))
+            .await,
+        "provider claim did not reach its boundary"
+    );
+    seed_idle_pool_with_timing(
+        &idle_pool,
+        &budget,
+        TestParkedIdleCandidateSpec {
+            reuse_key,
+            profile_name: "vm0/default",
+            vcpu: 2,
+            memory_mb: 4096,
+            history_generation_run_id: None,
+            parked_at: std::time::Instant::now(),
+        },
+    )
+    .await;
+    let exact_sandbox_id = idle_pool
+        .lock()
+        .await
+        .status_snapshot()
+        .idle_sandboxes
+        .into_iter()
+        .find(|sandbox| sandbox.sandbox_id != blank_sandbox_id)
+        .expect("exact sandbox should be parked during claim")
+        .sandbox_id;
+
+    env.handle.unblock_claims();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should use the exact sandbox that parked during claim");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(completion.sandbox_id, Some(exact_sandbox_id));
+    assert_eq!(idle_pool.lock().await.blank_len(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn full_exact_pool_yields_oldest_aged_capacity_to_one_blank() {
     let (config, env) = mock_run_config(test_profiles(), 12, 24_576, 5);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
@@ -542,6 +657,60 @@ async fn workspace_cache_hit_takes_priority_over_compatible_blank_inventory() {
     );
     assert_ne!(completion.sandbox_id, Some(blank_sandbox_id));
     assert_eq!(idle_pool.lock().await.blank_len(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn claimed_workspace_cache_metadata_takes_priority_over_reserved_blank() {
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+    let (mut config, env) = mock_run_config(profiles, 16, 32_768, 8);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = WorkspaceImageCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    let reuse_key = "thread:blank-pool-claimed-workspace-priority";
+    seed_workspace_cache_state(
+        &workspace_cache,
+        &runner_paths,
+        reuse_key,
+        "vm0/default",
+        16 * 1024 * 1024,
+    )
+    .await;
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+
+    let run_id = RunId::new_v4();
+    let mut context = context_with_session(run_id, "claimed-workspace-priority-session");
+    context.reuse_key = Some(reuse_key.into());
+    env.provider.set_claim_result(run_id, Some(context));
+    env.handle
+        .discover_tx
+        .send(JobCandidate::new(run_id, "vm0/default".into()))
+        .unwrap();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("claimed workspace metadata should override the reserved blank");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_eq!(
+        completion.workspace_reuse_result,
+        Some(WorkspaceReuseResult::Reused)
+    );
+    assert_ne!(completion.sandbox_id, Some(blank_sandbox_id));
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -130,6 +130,54 @@ async fn blank_unpark_failure_falls_back_without_changing_cold_attribution() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn foreground_admission_drains_cancelled_blank_start_before_destroy() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let calls = Arc::clone(&overrides);
+    let start_gate = sandbox_mock::MockLifecycleGate::new();
+    overrides.set_start_lifecycle_gate(start_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, overrides);
+    let run_handle = tokio::spawn(run(config));
+
+    start_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("blank sandbox start should enter the lifecycle gate");
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(
+            run_id,
+            "session-cancelled-blank-start",
+        )),
+    );
+    start_gate
+        .wait_entered(2, Duration::from_secs(5))
+        .await
+        .expect("foreground start should acquire admission while blank start drains");
+    assert_eq!(
+        calls.destroy_call_count(),
+        0,
+        "blank sandbox must remain owned until its in-flight start completes"
+    );
+
+    start_gate.release_many(2);
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("foreground job should complete");
+
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_eq!(calls.destroy_call_count(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn incompatible_profile_fresh_creates_without_consuming_blank_inventory() {
     let (config, env) = mock_run_config(two_profiles(), 16, 32_768, 8);
     let idle_pool = Arc::clone(&config.shared.idle_pool);

--- a/crates/runner/src/cmd/start/tests/idle_reuse/mod.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/mod.rs
@@ -1,3 +1,4 @@
+mod blank_pool;
 mod device_limits;
 mod drain;
 mod parking;

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -2282,6 +2282,107 @@ async fn no_exact_resolution_falls_back_before_predecessor_release() {
     shutdown(&env, run_handle).await;
 }
 
+#[tokio::test(start_paused = true)]
+async fn cancelled_finalizing_activation_restores_exact_over_refilled_blank() {
+    let (mut config, env) = mock_run_config(test_profiles(), 16, 32_768, 8);
+    config.capacity.max_idle = 1;
+    *env.idle_pool.lock().await =
+        IdlePool::new_with_parking_gate(IdlePoolConfig { max_idle: 1 }, env.parking_gate.clone());
+    let budget = Arc::clone(&config.capacity.budget);
+    // Keep ordinary refill below its headroom requirement until exact activation
+    // has reserved the predecessor's sandbox.
+    let occupied = ResourceBudget::try_reserve_lease(&budget, 12, 24_576).unwrap();
+    let reuse_key = "thread:cancelled-exact-blank-refill";
+    let predecessor_run_id = RunId::new_v4();
+    let predecessor = env.active_runs.register(
+        predecessor_run_id,
+        Some(reuse_key.to_owned()),
+        "vm0/default".into(),
+    );
+    let predecessor_reuse = predecessor.reuse_publisher();
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_reuse_key(run_id, reuse_key)));
+    env.handle
+        .discover_tx
+        .send(finalizing_candidate(
+            run_id,
+            reuse_key,
+            predecessor_run_id,
+            TEST_RUNNER_ID,
+            TEST_HEARTBEAT_GENERATION,
+        ))
+        .unwrap();
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    let transfer_guard = cancellation.transfer_guard().await;
+    let cancel_request = cancellation.request_hard_cancellation();
+    tokio::pin!(cancel_request);
+    // Queue cancellation before activation at the real ownership-transfer gate.
+    assert!(futures_util::poll!(&mut cancel_request).is_pending());
+
+    let exact_id = seed_idle_pool_with_history_generation(
+        &env.idle_pool,
+        &budget,
+        reuse_key,
+        "vm0/default",
+        2,
+        4096,
+        predecessor_run_id,
+    )
+    .await;
+    assert!(predecessor_reuse.publish_exact_sandbox());
+    wait_idle_pool_len(&env.idle_pool, 0, Duration::from_secs(5)).await;
+
+    drop(occupied);
+    wait_idle_pool_len(&env.idle_pool, 1, Duration::from_secs(5)).await;
+    assert_eq!(env.idle_pool.lock().await.blank_len(), 1);
+    assert_eq!(budget.allocated().2, 2);
+
+    drop(transfer_guard);
+    assert!(cancel_request.await);
+    env.handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("cancelled finalizing activation should complete");
+    {
+        let pool = env.idle_pool.lock().await;
+        assert!(
+            pool.has_reusable(reuse_key, "vm0/default", &None),
+            "rollback must preserve the exact sandbox when a blank filled its idle slot"
+        );
+        assert_eq!(pool.blank_len(), 0);
+        assert_eq!(
+            pool.status_snapshot().idle_sandboxes[0].sandbox_id,
+            exact_id
+        );
+    }
+    assert_eq!(budget.allocated().2, 1);
+
+    let followup_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        followup_run_id,
+        "vm0/default",
+        Some(context_with_reuse_key(followup_run_id, reuse_key)),
+    );
+    let completion = env
+        .handle
+        .wait_completion(followup_run_id, Duration::from_secs(5))
+        .await
+        .expect("restored exact sandbox should serve the next run");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    assert_eq!(completion.sandbox_id, Some(exact_id));
+
+    drop(predecessor);
+    shutdown(&env, run_handle).await;
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+}
+
 #[tokio::test]
 async fn competing_finalizing_successors_reserve_exact_generation_once() {
     let (config, env) = mock_run_config(test_profiles(), 4, 8192, 2);

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -566,6 +566,41 @@ async fn reusable_claim_without_generation_target_reuses_sandbox() {
 }
 
 #[tokio::test]
+async fn reserved_reuse_claim_without_reuse_key_preserves_no_reuse_attribution() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&env.idle_pool);
+    let reuse_key = "candidate-only-reuse-key";
+    let reserved_sandbox_id =
+        seed_idle_pool(&idle_pool, &budget, reuse_key, "vm0/default", 2, 4096).await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(minimal_context(run_id)));
+    env.handle
+        .discover_tx
+        .send(matching_preference_candidate(run_id, reuse_key))
+        .unwrap();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("claim without a reuse key should fall back to a fresh sandbox");
+    assert_eq!(completion.exit_code, 0);
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::NoReuseKey)
+    );
+    assert_ne!(completion.sandbox_id, Some(reserved_sandbox_id));
+    assert_eq!(idle_pool.lock().await.len(), 0);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
 async fn reserved_reuse_persists_preparing_before_unpark_without_post_unpark_pool_wait() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher(&overrides);

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -244,7 +244,6 @@ async fn telemetry_flush_includes_reuse_hit_claim_phase_spans() {
                 .path("/api/webhooks/agent/telemetry")
                 .body_includes("sandbox_reuse_hit")
                 .body_includes("runner_claim_idle_reuse_lookup")
-                .body_includes("runner_claim_workspace_cache_state_lookup")
                 .body_includes("runner_claim_idle_unpark")
                 .body_includes("runner_claim_task_schedule_wait");
             then.status(200)

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -231,6 +231,7 @@ fn build_mock_run_config_with_runtime(
             )),
             min_vcpu,
             min_memory_mb,
+            max_idle: 10,
             device_rate_limits: None,
         },
         shared: RunnerSharedState {

--- a/crates/runner/src/cmd/start/tests/support/jobs.rs
+++ b/crates/runner/src/cmd/start/tests/support/jobs.rs
@@ -15,10 +15,11 @@ pub(in super::super) fn push_job(
     profile: &str,
     ctx: Option<crate::types::ExecutionContext>,
 ) {
+    let reuse_key = ctx.as_ref().and_then(|context| context.reuse_key.clone());
     env.provider.set_claim_result(run_id, ctx);
     env.handle
         .discover_tx
-        .send(JobCandidate::new(run_id, profile.into()))
+        .send(JobCandidate::new(run_id, profile.into()).with_reuse_key(reuse_key))
         .unwrap();
 }
 

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -58,7 +58,7 @@ pub(crate) use session_history_restore_plan::{
 };
 
 use crate::active_input::ActiveInputSource;
-use agent_run::{PreparedRunInputs, ProcessCancelTimeouts, RunControls};
+use agent_run::{PreparedRunInputs, ProcessCancelTimeouts, RunControls, RunStart};
 use env::validate_execution_context_before_sandbox;
 pub(crate) use env::validate_resume_session_id;
 use sandbox_run::{
@@ -150,7 +150,7 @@ const AGENT_ABNORMAL_EXIT_DIAGNOSTIC_SCRIPT: &str =
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
-use crate::idle_pool::{ReusableIdleSandbox, ReusableIdleSandboxParts};
+use crate::idle_pool::{IdleSandboxKind, ReusableIdleSandbox, ReusableIdleSandboxParts};
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogManager;
 use crate::network_log_manager::NetworkLogSession;
@@ -697,6 +697,7 @@ pub async fn execute_job_reuse(
 ) -> (ExecuteOutcome, JobTelemetry) {
     execute_job_reuse_with_hooks(
         idle_sandbox,
+        SandboxReuseResult::Reused,
         context,
         config,
         params,
@@ -708,6 +709,7 @@ pub async fn execute_job_reuse(
 
 pub(crate) async fn execute_job_reuse_with_hooks(
     idle_sandbox: ReusableIdleSandbox,
+    reuse_result: SandboxReuseResult,
     context: ExecutionContext,
     config: &ExecutorConfig,
     params: &JobParams,
@@ -733,12 +735,17 @@ pub(crate) async fn execute_job_reuse_with_hooks(
         .storage_baseline_observer
         .record(&context, params, &mut telemetry);
 
-    record_reuse_result(&mut telemetry, SandboxReuseResult::Reused);
+    let idle_kind = idle_sandbox.kind();
+    record_reuse_result(&mut telemetry, reuse_result);
+    if idle_kind == IdleSandboxKind::Blank {
+        telemetry.record("sandbox_blank_pool_hit", Duration::ZERO, true, None);
+    }
     record_api_latency("api_to_sandbox_start", &context, &mut telemetry);
 
     let sandbox_id = idle_sandbox.sandbox_id();
     let ReusableIdleSandboxParts {
         sandbox,
+        kind,
         reuse_key: idle_reuse_key,
         source_ip,
         storage_fingerprints: prev_storage,
@@ -812,7 +819,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
         &context,
         &config.api_url,
         &sandbox_id_string,
-        SandboxReuseResult::Reused,
+        reuse_result,
     ) {
         Err(error) => ExecuteOutcome::reused_sandbox_failure(
             ExecutionFailure::from_error(error),
@@ -826,7 +833,18 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                 &source_ip,
                 &context,
                 config,
-                &prev_storage,
+                RunStart {
+                    restore_guest_state: match kind {
+                        IdleSandboxKind::Exact => true,
+                        IdleSandboxKind::Blank => params.restore_guest_state,
+                    },
+                    reuse_result,
+                    workspace_reuse_result: match kind {
+                        IdleSandboxKind::Exact => WorkspaceReuseResult::SandboxReused,
+                        IdleSandboxKind::Blank => blank_workspace_reuse_result(&context, config),
+                    },
+                    prev_storage: (kind == IdleSandboxKind::Exact).then_some(&prev_storage),
+                },
                 &mut telemetry,
                 PreparedRunInputs::new(
                     RunControls::from_cancellation(cancellation, active_input_source)
@@ -843,6 +861,19 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     };
 
     (outcome, telemetry)
+}
+
+fn blank_workspace_reuse_result(
+    context: &ExecutionContext,
+    config: &ExecutorConfig,
+) -> WorkspaceReuseResult {
+    if config.workspace_cache.is_none() {
+        WorkspaceReuseResult::NotConfigured
+    } else if context.reuse_key().is_some() {
+        WorkspaceReuseResult::CacheMiss
+    } else {
+        WorkspaceReuseResult::NoReuseKey
+    }
 }
 
 async fn resolve_reused_workspace_promotion(

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1421,7 +1421,7 @@ pub(super) async fn execute_reused_sandbox(
     source_ip: &str,
     context: &ExecutionContext,
     config: &ExecutorConfig,
-    prev_storage: &crate::storage_fingerprints::StorageFingerprints,
+    start: RunStart<'_>,
     telemetry: &mut JobTelemetry,
     mut inputs: PreparedRunInputs,
 ) -> ExecuteOutcome {
@@ -1435,7 +1435,7 @@ pub(super) async fn execute_reused_sandbox(
     let prepare_started = Instant::now();
     let prepared_storage = prepare_storage(
         context,
-        Some(prev_storage),
+        start.prev_storage,
         config,
         &inputs.controls.cancel,
         telemetry,
@@ -1492,12 +1492,7 @@ pub(super) async fn execute_reused_sandbox(
         },
         context,
         config,
-        RunStart {
-            restore_guest_state: true,
-            reuse_result: SandboxReuseResult::Reused,
-            workspace_reuse_result: WorkspaceReuseResult::SandboxReused,
-            prev_storage: Some(prev_storage),
-        },
+        start,
         telemetry,
         inputs,
     )

--- a/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/proxy_registry.rs
@@ -218,7 +218,12 @@ async fn execute_reused_sandbox_proxy_register_failure_returns_sandbox_before_ag
             &source_ip,
             &ctx,
             &config,
-            &prev_storage,
+            RunStart {
+                restore_guest_state: true,
+                reuse_result: crate::types::SandboxReuseResult::Reused,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::SandboxReused,
+                prev_storage: Some(&prev_storage),
+            },
             &mut telemetry,
             PreparedRunInputs::new(
                 RunControls::new(tokio_util::sync::CancellationToken::new(), None),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -297,7 +297,12 @@ async fn execute_reused_sandbox_drains_archive_when_guest_state_restore_fails() 
             &source_ip,
             &context,
             &config,
-            &previous_storage,
+            RunStart {
+                restore_guest_state: true,
+                reuse_result: crate::types::SandboxReuseResult::Reused,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::SandboxReused,
+                prev_storage: Some(&previous_storage),
+            },
             &mut telemetry,
             PreparedRunInputs::new(
                 RunControls::new(CancellationToken::new(), None),

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -28,10 +28,13 @@ use super::super::{
 };
 use super::support::{
     api_storage, context_with_env, default_params, make_reusable_idle_sandbox, minimal_context,
-    test_executor_config,
+    test_budget_lease, test_executor_config,
 };
 use crate::guest_timezone::GuestTimezoneAssumption;
 use crate::http::{HttpClient, HttpClientConfig};
+use crate::idle_pool::{
+    IdlePool, IdlePoolConfig, IdleUnparkResult, ParkResult, ParkedIdleCandidate,
+};
 use crate::ids::RunId;
 use crate::provider::ApiClaimTiming;
 use crate::resource_budget::ResourceBudget;
@@ -1740,6 +1743,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     context.api_start_time = Some(chrono::Utc::now().timestamp_millis().max(0) as u64);
     let (_outcome, telemetry) = execute_job_reuse_with_hooks(
         idle_sandbox,
+        SandboxReuseResult::Reused,
         context,
         &config,
         &default_params(),
@@ -1797,6 +1801,83 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     assert_lacks_action(&telemetry, "workspace_drive_mount_guest_exec_unavailable");
 }
 
+#[tokio::test]
+async fn execute_job_claims_blank_sandbox_without_changing_cold_path_attribution() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(MockSandboxFactory::new()));
+    let sandbox_id = SandboxId::new_v4();
+    let mut sandbox = factory
+        .create(SandboxConfig {
+            id: sandbox_id,
+            resources: sandbox::ResourceLimits {
+                cpu_count: 2,
+                memory_mb: 2048,
+            },
+            device_rate_limits: None,
+            workspace_drive: None,
+        })
+        .await
+        .unwrap();
+    sandbox.start().await.unwrap();
+    assert_eq!(
+        sandbox.park().await.unwrap(),
+        sandbox::SandboxParkOutcome::Reusable
+    );
+
+    let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 0 });
+    let candidate = ParkedIdleCandidate::blank(
+        sandbox,
+        Arc::clone(&factory),
+        test_budget_lease(),
+        sandbox_id,
+        "vm0/default".into(),
+        None,
+    );
+    assert!(matches!(pool.park(candidate), ParkResult::Parked));
+    let reserved = pool
+        .reserve_blank("vm0/default", &None)
+        .expect("blank sandbox should be compatible");
+    let (idle_sandbox, budget_lease) = match reserved.try_unpark_for_run(RunId::new_v4()).await {
+        IdleUnparkResult::Reused {
+            sandbox,
+            budget_lease,
+        } => (*sandbox, budget_lease),
+        IdleUnparkResult::Failed { error, .. } => {
+            panic!("blank sandbox should unpark: {error}");
+        }
+    };
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (outcome, telemetry) = execute_job_reuse_with_hooks(
+        idle_sandbox,
+        SandboxReuseResult::PoolMiss,
+        minimal_context(),
+        &config,
+        &default_params(),
+        RunCancellationSignals::hard_only(cancel),
+        ExecutionHooks::none(),
+    )
+    .await;
+
+    assert!(outcome.failure.is_none());
+    assert_eq!(
+        outcome.workspace_reuse_result,
+        Some(WorkspaceReuseResult::NotConfigured)
+    );
+    assert_has_action(&telemetry, "sandbox_reuse_miss");
+    assert_has_action(&telemetry, "sandbox_blank_pool_hit");
+    assert_lacks_action(&telemetry, "sandbox_reuse_hit");
+    assert_lacks_action(&telemetry, "runner_fresh_sandbox_factory_create");
+    assert_lacks_action(&telemetry, "runner_fresh_sandbox_start");
+    assert_lacks_action(&telemetry, "runner_guest_state_restore");
+
+    let mut sandbox = outcome.sandbox.expect("sandbox should remain alive");
+    sandbox.stop().await.unwrap();
+    factory.destroy(sandbox).await;
+    drop(budget_lease);
+}
+
 async fn assert_reused_private_write_timeout_telemetry(
     context: crate::types::ExecutionContext,
     stage: SandboxOperationTimeoutStage,
@@ -1822,6 +1903,7 @@ async fn assert_reused_private_write_timeout_telemetry(
     let cancel = tokio_util::sync::CancellationToken::new();
     let (outcome, telemetry) = execute_job_reuse_with_hooks(
         idle_sandbox,
+        SandboxReuseResult::Reused,
         context,
         &config,
         &default_params(),
@@ -1875,6 +1957,7 @@ async fn assert_reused_connector_account_context_failure(
     let cancel = tokio_util::sync::CancellationToken::new();
     let (outcome, telemetry) = execute_job_reuse_with_hooks(
         idle_sandbox,
+        SandboxReuseResult::Reused,
         context,
         &config,
         &default_params(),

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -46,6 +46,7 @@ use crate::telemetry::{
     RunnerResourceBudgetUtilizationBucket, RunnerStartupPath,
 };
 use crate::types::{ExecutionContext, SandboxReuseResult, WorkspaceReuseResult};
+use crate::workspace_mount::ensure_workspace_drive_mounted;
 
 #[test]
 fn elapsed_since_api_start_ms_returns_elapsed_duration() {
@@ -1805,6 +1806,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
 async fn execute_job_claims_blank_sandbox_without_changing_cold_path_attribution() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
+    let params = default_params();
     let factory: Arc<Box<dyn SandboxFactory>> = Arc::new(Box::new(MockSandboxFactory::new()));
     let sandbox_id = SandboxId::new_v4();
     let mut sandbox = factory
@@ -1815,11 +1817,17 @@ async fn execute_job_claims_blank_sandbox_without_changing_cold_path_attribution
                 memory_mb: 2048,
             },
             device_rate_limits: None,
-            workspace_drive: None,
+            workspace_drive: Some(sandbox::WorkspaceDriveConfig {
+                size_mb: params.workspace_disk_mb,
+                seed_image: None,
+            }),
         })
         .await
         .unwrap();
     sandbox.start().await.unwrap();
+    ensure_workspace_drive_mounted(sandbox.as_ref(), sandbox_id)
+        .await
+        .unwrap();
     assert_eq!(
         sandbox.park().await.unwrap(),
         sandbox::SandboxParkOutcome::Reusable
@@ -1854,7 +1862,7 @@ async fn execute_job_claims_blank_sandbox_without_changing_cold_path_attribution
         SandboxReuseResult::PoolMiss,
         minimal_context(),
         &config,
-        &default_params(),
+        &params,
         RunCancellationSignals::hard_only(cancel),
         ExecutionHooks::none(),
     )

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, hash_map::Entry};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use sandbox::{DeviceRateLimits, SandboxId};
 use tokio::sync::watch;
@@ -295,6 +295,42 @@ impl IdlePool {
             .values()
             .filter(|entry| entry.is_blank())
             .count()
+    }
+
+    /// Remove the oldest compatible exact entry that has been idle long enough
+    /// to yield its capacity to a blank sandbox.
+    ///
+    /// Requiring the same profile, device limits, and resource reservation lets
+    /// the replenisher retain the entry's existing budget lease through physical
+    /// cleanup and transfer it to the replacement without changing admission.
+    pub(crate) fn evict_oldest_exact_for_blank(
+        &mut self,
+        now: Instant,
+        min_idle_age: Duration,
+        profile_name: &str,
+        device_rate_limits: &Option<DeviceRateLimits>,
+        vcpu: u32,
+        memory_mb: u32,
+    ) -> Option<(IdleDestroyJob, Duration)> {
+        let (reuse_key, parked_at) = self
+            .entries
+            .iter()
+            .filter(|(_, entry)| {
+                !entry.is_blank()
+                    && entry.profile_name() == profile_name
+                    && entry.device_rate_limits() == device_rate_limits
+                    && entry.budget_lease.vcpu() == vcpu
+                    && entry.budget_lease.memory_mb() == memory_mb
+                    && now.saturating_duration_since(entry.parked_at) >= min_idle_age
+            })
+            .min_by_key(|(reuse_key, entry)| (entry.parked_at, reuse_key.as_str()))
+            .map(|(reuse_key, entry)| (reuse_key.clone(), entry.parked_at))?;
+        let entry = self.entries.remove(&reuse_key)?;
+        self.bump_revision();
+        Some((
+            entry.into_destroy_job(),
+            now.saturating_duration_since(parked_at),
+        ))
     }
 
     pub fn restore_reserved(

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -339,14 +339,29 @@ impl IdlePool {
     ) -> RestoreReservedIdleResult {
         let entry = reservation.entry;
         let reuse_key = entry.reuse_key().to_owned();
-        let has_capacity = self.config.max_idle == 0 || self.entries.len() < self.config.max_idle;
-        if !self.parking_gate.is_open() || !has_capacity || self.entries.contains_key(&reuse_key) {
+        if !self.parking_gate.is_open() || self.entries.contains_key(&reuse_key) {
             return RestoreReservedIdleResult::Rejected(Box::new(entry.into_destroy_job()));
         }
 
+        let mut displaced_blank = None;
+        if self.config.max_idle > 0 && self.entries.len() >= self.config.max_idle {
+            let blank_key = (!entry.is_blank())
+                .then(|| self.oldest_blank_key())
+                .flatten();
+            let Some(blank_key) = blank_key else {
+                return RestoreReservedIdleResult::Rejected(Box::new(entry.into_destroy_job()));
+            };
+            displaced_blank = self.entries.remove(&blank_key);
+        }
+
+        // Restore the original entry, including its idle age, while giving exact
+        // reservations the same priority over blank inventory as newly parked runs.
         self.entries.insert(reuse_key, entry);
         self.bump_revision();
-        RestoreReservedIdleResult::Restored
+        match displaced_blank {
+            Some(blank) => RestoreReservedIdleResult::Replaced(Box::new(blank.into_destroy_job())),
+            None => RestoreReservedIdleResult::Restored,
+        }
     }
 
     /// Evict an entry selected by a pressure ordering captured under the same

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -17,8 +17,9 @@ pub(crate) use entry::{
     ImmediateHandoffCandidate,
 };
 pub use entry::{
-    IdleDestroyJob, IdleEntry, IdleUnparkResult, ParkedIdleCandidate, RejectedParkedIdleCandidate,
-    ReservedIdleSandbox, RestoreReservedIdleResult, ReusableIdleSandbox, ReusableIdleSandboxParts,
+    IdleDestroyJob, IdleEntry, IdleSandboxKind, IdleUnparkResult, ParkedIdleCandidate,
+    RejectedParkedIdleCandidate, ReservedIdleSandbox, RestoreReservedIdleResult,
+    ReusableIdleSandbox, ReusableIdleSandboxParts,
 };
 pub(crate) use entry::{SpeculativeIdleSandbox, SpeculativeIdleUnparkResult};
 pub(crate) use park_transition::{
@@ -127,15 +128,23 @@ impl IdlePool {
         if !self.parking_gate.is_open() {
             return ParkResult::Rejected(candidate.into_rejected());
         }
+        let mut capacity_evicted = None;
         if self.config.max_idle > 0 && self.entries.len() >= self.config.max_idle {
             // At capacity and this reuse key has no existing entry to replace.
             if !self.entries.contains_key(&reuse_key) {
-                return ParkResult::Rejected(candidate.into_rejected());
+                if candidate.is_blank() {
+                    return ParkResult::Rejected(candidate.into_rejected());
+                }
+                let Some(blank_key) = self.oldest_blank_key() else {
+                    return ParkResult::Rejected(candidate.into_rejected());
+                };
+                capacity_evicted = self.entries.remove(&blank_key);
             }
         }
         let entry = candidate.into_idle_entry(parked_at);
-        let result = match self.entries.insert(reuse_key, entry) {
-            Some(evicted) => ParkResult::Replaced(evicted.into_destroy_job()),
+        let replaced = self.entries.insert(reuse_key, entry).or(capacity_evicted);
+        let result = match replaced {
+            Some(entry) => ParkResult::Replaced(entry.into_destroy_job()),
             None => ParkResult::Parked,
         };
         self.bump_revision();
@@ -151,6 +160,9 @@ impl IdlePool {
     }
 
     pub(crate) fn take_reserved(&mut self, reuse_key: &str) -> Option<ReservedIdleSandbox> {
+        if self.entries.get(reuse_key).is_some_and(IdleEntry::is_blank) {
+            return None;
+        }
         self.take(reuse_key)
             .map(|entry| ReservedIdleSandbox { entry })
     }
@@ -162,7 +174,9 @@ impl IdlePool {
         device_rate_limits: &Option<DeviceRateLimits>,
     ) -> bool {
         self.entries.get(reuse_key).is_some_and(|entry| {
-            entry.profile_name() == profile_name && entry.device_rate_limits() == device_rate_limits
+            !entry.is_blank()
+                && entry.profile_name() == profile_name
+                && entry.device_rate_limits() == device_rate_limits
         })
     }
 
@@ -244,16 +258,43 @@ impl IdlePool {
 
     /// Order all current entries for pressure eviction without mutating them.
     pub(crate) fn oldest_first_pressure_keys(&self) -> Vec<String> {
-        let mut ordered_entries: Vec<(Instant, String)> = self
+        let mut ordered_entries: Vec<(bool, Instant, String)> = self
             .entries
             .iter()
-            .map(|(reuse_key, entry)| (entry.parked_at, reuse_key.clone()))
+            .map(|(reuse_key, entry)| (!entry.is_blank(), entry.parked_at, reuse_key.clone()))
             .collect();
         ordered_entries.sort_unstable();
         ordered_entries
             .into_iter()
-            .map(|(_, reuse_key)| reuse_key)
+            .map(|(_, _, reuse_key)| reuse_key)
             .collect()
+    }
+
+    pub(crate) fn reserve_blank(
+        &mut self,
+        profile_name: &str,
+        device_rate_limits: &Option<DeviceRateLimits>,
+    ) -> Option<ReservedIdleSandbox> {
+        let key = self
+            .entries
+            .iter()
+            .filter(|(_, entry)| {
+                entry.is_blank()
+                    && entry.profile_name() == profile_name
+                    && entry.device_rate_limits() == device_rate_limits
+            })
+            .min_by_key(|(_, entry)| entry.parked_at)
+            .map(|(key, _)| key.clone())?;
+        let entry = self.entries.remove(&key)?;
+        self.bump_revision();
+        Some(ReservedIdleSandbox { entry })
+    }
+
+    pub(crate) fn blank_len(&self) -> usize {
+        self.entries
+            .values()
+            .filter(|entry| entry.is_blank())
+            .count()
     }
 
     pub fn restore_reserved(
@@ -283,6 +324,10 @@ impl IdlePool {
             self.bump_revision();
         }
         job
+    }
+
+    pub(crate) fn entry_kind(&self, reuse_key: &str) -> Option<IdleSandboxKind> {
+        self.entries.get(reuse_key).map(IdleEntry::kind)
     }
 
     /// Return a revisioned reuse-key-sorted snapshot suitable for status.json.
@@ -324,6 +369,9 @@ impl IdlePool {
             .entries
             .iter()
             .filter_map(|(reuse_key, entry)| {
+                if entry.is_blank() {
+                    return None;
+                }
                 entry
                     .metadata
                     .last_completed_at
@@ -391,6 +439,14 @@ impl IdlePool {
     fn bump_revision(&mut self) {
         self.revision = self.revision.saturating_add(1);
         self.changes.send_replace(self.revision);
+    }
+
+    fn oldest_blank_key(&self) -> Option<String> {
+        self.entries
+            .iter()
+            .filter(|(_, entry)| entry.is_blank())
+            .min_by_key(|(_, entry)| entry.parked_at)
+            .map(|(key, _)| key.clone())
     }
 }
 

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -334,6 +334,8 @@ pub struct ReservedIdleSandbox {
 
 pub enum RestoreReservedIdleResult {
     Restored,
+    /// The exact reservation was restored; the displaced blank still needs cleanup.
+    Replaced(Box<IdleDestroyJob>),
     Rejected(Box<IdleDestroyJob>),
 }
 

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -20,7 +20,16 @@ use crate::workspace_promotion::{
     abandon_unpublished_workspace_promotion, prepare_workspace_image_from_parked_sandbox,
 };
 
+const BLANK_REUSE_KEY_PREFIX: &str = "__vm0_blank__:";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IdleSandboxKind {
+    Exact,
+    Blank,
+}
+
 pub(super) struct IdleSandboxMetadata {
+    pub(super) kind: IdleSandboxKind,
     pub(super) reuse_key: String,
     /// Identity of the parked sandbox. Survives reuse (next job's `run_id`
     /// differs, but `sandbox_id` stays the same) and is the join key for
@@ -50,8 +59,13 @@ impl IdleSandboxMetadata {
     }
 
     fn with_last_completed_at(mut self, last_completed_at: String) -> Self {
+        debug_assert_eq!(self.kind, IdleSandboxKind::Exact);
         self.last_completed_at = Some(last_completed_at);
         self
+    }
+
+    fn is_blank(&self) -> bool {
+        self.kind == IdleSandboxKind::Blank
     }
 }
 
@@ -131,6 +145,42 @@ impl ParkedIdleCandidate {
     pub(crate) fn with_last_completed_at(mut self, last_completed_at: String) -> Self {
         self.metadata = self.metadata.with_last_completed_at(last_completed_at);
         self
+    }
+
+    pub(crate) fn blank(
+        sandbox: Box<dyn Sandbox>,
+        factory: Arc<Box<dyn SandboxFactory>>,
+        budget_lease: BudgetLease,
+        sandbox_id: SandboxId,
+        profile_name: String,
+        device_rate_limits: Option<DeviceRateLimits>,
+    ) -> Self {
+        let source_ip = sandbox.source_ip().to_owned();
+        Self {
+            resources: IdleSandboxResources {
+                sandbox,
+                factory,
+                workspace_promotion: None,
+            },
+            metadata: IdleSandboxMetadata {
+                kind: IdleSandboxKind::Blank,
+                reuse_key: format!("{BLANK_REUSE_KEY_PREFIX}{sandbox_id}"),
+                sandbox_id,
+                profile_name,
+                device_rate_limits,
+                source_ip,
+                storage_fingerprints: StorageFingerprints::default(),
+                restored_session_identity: None,
+                history_generation_run_id: None,
+                guest_timezone_intent: GuestTimezoneIntent::Unknown,
+                last_completed_at: None,
+            },
+            budget_lease,
+        }
+    }
+
+    pub(super) fn is_blank(&self) -> bool {
+        self.metadata.is_blank()
     }
 
     pub(super) fn into_idle_entry(self, parked_at: Instant) -> IdleEntry {
@@ -311,6 +361,7 @@ pub struct ReusableIdleSandbox {
 
 pub struct ReusableIdleSandboxParts {
     pub sandbox: Box<dyn Sandbox>,
+    pub kind: IdleSandboxKind,
     pub reuse_key: String,
     pub source_ip: String,
     pub storage_fingerprints: StorageFingerprints,
@@ -343,6 +394,10 @@ impl ReusableIdleSandbox {
         self.metadata.restored_session_identity.as_ref()
     }
 
+    pub(crate) fn kind(&self) -> IdleSandboxKind {
+        self.metadata.kind
+    }
+
     pub fn into_parts(self) -> ReusableIdleSandboxParts {
         let Self {
             sandbox,
@@ -351,6 +406,7 @@ impl ReusableIdleSandbox {
             guest_state_prepared,
         } = self;
         let IdleSandboxMetadata {
+            kind,
             reuse_key,
             sandbox_id: _,
             profile_name: _,
@@ -365,6 +421,7 @@ impl ReusableIdleSandbox {
 
         ReusableIdleSandboxParts {
             sandbox,
+            kind,
             reuse_key,
             source_ip,
             storage_fingerprints,
@@ -603,6 +660,10 @@ enum IdleActivationFailure {
 }
 
 impl IdleEntry {
+    pub(super) fn kind(&self) -> IdleSandboxKind {
+        self.metadata.kind
+    }
+
     pub(super) fn reuse_key(&self) -> &str {
         self.metadata.reuse_key()
     }
@@ -613,6 +674,10 @@ impl IdleEntry {
 
     pub fn device_rate_limits(&self) -> &Option<DeviceRateLimits> {
         &self.metadata.device_rate_limits
+    }
+
+    pub(super) fn is_blank(&self) -> bool {
+        self.metadata.is_blank()
     }
 
     #[cfg(test)]
@@ -752,6 +817,10 @@ impl IdleEntry {
 impl ReservedIdleSandbox {
     pub(crate) fn sandbox_id(&self) -> SandboxId {
         self.entry.metadata.sandbox_id
+    }
+
+    pub(crate) fn kind(&self) -> IdleSandboxKind {
+        self.entry.metadata.kind
     }
 
     pub fn reuse_key(&self) -> &str {

--- a/crates/runner/src/idle_pool/park_transition.rs
+++ b/crates/runner/src/idle_pool/park_transition.rs
@@ -327,6 +327,7 @@ impl IdleParkRequest {
         } = self.parts;
 
         let metadata = IdleSandboxMetadata {
+            kind: super::entry::IdleSandboxKind::Exact,
             reuse_key,
             sandbox_id,
             profile_name,

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -26,6 +26,18 @@ fn make_candidate_for_with_lease(
         .build()
 }
 
+fn make_blank_candidate(profile_name: &str, vcpu: u32, memory_mb: u32) -> ParkedIdleCandidate {
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    ParkedIdleCandidate::blank(
+        Box::new(sandbox_mock::MockSandbox::new(sandbox_id.to_string())),
+        Arc::new(Box::new(sandbox_mock::MockSandboxFactory::new())),
+        make_budget_lease(vcpu, memory_mb),
+        sandbox_id,
+        profile_name.to_owned(),
+        None,
+    )
+}
+
 fn park_at(
     pool: &mut IdlePool,
     reuse_key: &str,
@@ -291,6 +303,69 @@ fn park_respects_max_idle() {
     assert_eq!(pool.len(), 2);
 }
 
+#[test]
+fn blank_entries_are_reserved_only_by_compatible_blank_lookup() {
+    let mut pool = IdlePool::new(pool_config(0));
+    let blank = make_blank_candidate("vm0/default", 2, 2048);
+    let blank_key = blank.reuse_key().to_owned();
+    assert!(matches!(pool.park(blank), ParkResult::Parked));
+
+    assert_eq!(pool.blank_len(), 1);
+    assert!(pool.take_reserved(&blank_key).is_none());
+    assert!(
+        pool.reserve_reusable(&blank_key, "vm0/default", &None)
+            .is_none()
+    );
+    assert!(pool.reserve_blank("vm0/large", &None).is_none());
+
+    let reserved = pool
+        .reserve_blank("vm0/default", &None)
+        .expect("compatible blank should reserve");
+    assert_eq!(reserved.kind(), IdleSandboxKind::Blank);
+    assert_eq!(pool.blank_len(), 0);
+}
+
+#[test]
+fn blank_entries_remain_in_status_but_not_heartbeat_state() {
+    let mut pool = IdlePool::new(pool_config(0));
+    assert!(matches!(
+        pool.park(make_blank_candidate("vm0/default", 2, 2048)),
+        ParkResult::Parked
+    ));
+
+    assert_eq!(pool.status_snapshot().idle_sandboxes.len(), 1);
+    assert!(pool.held_sandbox_states().is_empty());
+}
+
+#[test]
+fn completed_exact_entry_replaces_blank_at_max_idle() {
+    let mut pool = IdlePool::new(pool_config(1));
+    assert!(matches!(
+        pool.park(make_blank_candidate("vm0/default", 2, 2048)),
+        ParkResult::Parked
+    ));
+
+    let result = pool.park(make_candidate_for("session-exact", 2, 2048));
+    assert!(matches!(result, ParkResult::Replaced(_)));
+    assert_eq!(pool.blank_len(), 0);
+    assert!(pool.has_reusable("session-exact", "vm0/default", &None));
+}
+
+#[test]
+fn blank_entry_never_replaces_exact_entry_at_max_idle() {
+    let mut pool = IdlePool::new(pool_config(1));
+    assert!(matches!(
+        pool.park(make_candidate_for("session-exact", 2, 2048)),
+        ParkResult::Parked
+    ));
+
+    assert!(matches!(
+        pool.park(make_blank_candidate("vm0/default", 2, 2048)),
+        ParkResult::Rejected(_)
+    ));
+    assert!(pool.has_reusable("session-exact", "vm0/default", &None));
+}
+
 #[tokio::test]
 async fn rejected_parked_idle_candidate_returns_active_owned_lease() {
     let mut pool = IdlePool::new(pool_config(1));
@@ -339,6 +414,33 @@ fn pressure_ordering_evicts_oldest_first() {
     assert_eq!(evicted.budget_vcpu(), 2); // the old one
     assert_eq!(pool.len(), 1);
     assert!(pool.take("new").is_some());
+}
+
+#[test]
+fn pressure_ordering_evicts_blank_before_older_exact_entry() {
+    let mut pool = IdlePool::new(pool_config(0));
+    let now = Instant::now();
+    let exact = make_candidate_for("session-exact", 2, 2048);
+    assert!(matches!(
+        park_at(
+            &mut pool,
+            "session-exact",
+            exact,
+            now - Duration::from_secs(100),
+        ),
+        ParkResult::Parked
+    ));
+    let blank = make_blank_candidate("vm0/default", 2, 2048);
+    let blank_key = blank.reuse_key().to_owned();
+    assert!(matches!(
+        park_at(&mut pool, &blank_key, blank, now),
+        ParkResult::Parked
+    ));
+
+    assert_eq!(
+        pool.oldest_first_pressure_keys(),
+        vec![blank_key, "session-exact".to_owned()]
+    );
 }
 
 #[test]

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -67,6 +67,80 @@ fn park_and_take() {
     assert_eq!(pool.len(), 0);
 }
 
+#[tokio::test]
+async fn blank_capacity_yield_selects_only_the_oldest_compatible_aged_exact() {
+    let now = Instant::now();
+    let min_idle_age = Duration::from_secs(30 * 60);
+    let mut pool = IdlePool::new(pool_config(0));
+    assert!(matches!(
+        pool.park_at_for_test(
+            make_blank_candidate("vm0/default", 2, 2048),
+            now - Duration::from_secs(60 * 60),
+        ),
+        ParkResult::Parked
+    ));
+    assert!(matches!(
+        park_at(
+            &mut pool,
+            "wrong-profile",
+            ParkedIdleCandidateBuilder::new("wrong-profile", make_budget_lease(2, 2048))
+                .with_profile_name("vm0/other")
+                .build(),
+            now - Duration::from_secs(50 * 60),
+        ),
+        ParkResult::Parked
+    ));
+    assert!(matches!(
+        park_at(
+            &mut pool,
+            "wrong-resource",
+            make_candidate_for("wrong-resource", 4, 4096),
+            now - Duration::from_secs(50 * 60),
+        ),
+        ParkResult::Parked
+    ));
+    for (reuse_key, idle_for) in [
+        ("young", Duration::from_secs(29 * 60 + 59)),
+        ("boundary", min_idle_age),
+        ("oldest", Duration::from_secs(45 * 60)),
+    ] {
+        assert!(matches!(
+            park_at(
+                &mut pool,
+                reuse_key,
+                make_candidate_for(reuse_key, 2, 2048),
+                now - idle_for,
+            ),
+            ParkResult::Parked
+        ));
+    }
+
+    let revision = pool.status_snapshot().revision;
+    let (oldest, idle_age) = pool
+        .evict_oldest_exact_for_blank(now, min_idle_age, "vm0/default", &None, 2, 2048)
+        .expect("oldest compatible exact should yield capacity");
+    assert_eq!(oldest.reuse_key(), "oldest");
+    assert_eq!(idle_age, Duration::from_secs(45 * 60));
+    assert_eq!(pool.status_snapshot().revision, revision + 1);
+    oldest.run().await;
+
+    let (boundary, idle_age) = pool
+        .evict_oldest_exact_for_blank(now, min_idle_age, "vm0/default", &None, 2, 2048)
+        .expect("the age boundary should be inclusive");
+    assert_eq!(boundary.reuse_key(), "boundary");
+    assert_eq!(idle_age, min_idle_age);
+    boundary.run().await;
+
+    assert!(
+        pool.evict_oldest_exact_for_blank(now, min_idle_age, "vm0/default", &None, 2, 2048,)
+            .is_none(),
+        "blank, young, and incompatible entries must remain"
+    );
+    for job in pool.drain() {
+        job.run().await;
+    }
+}
+
 #[test]
 fn reusable_reservation_is_exclusive_and_restorable() {
     let mut pool = IdlePool::new(pool_config(0));

--- a/crates/runner/src/idle_pool/test_support.rs
+++ b/crates/runner/src/idle_pool/test_support.rs
@@ -139,6 +139,7 @@ impl ParkedIdleCandidateBuilder {
             workspace_promotion,
         } = self;
         let metadata = IdleSandboxMetadata {
+            kind: super::entry::IdleSandboxKind::Exact,
             reuse_key,
             sandbox_id,
             profile_name,

--- a/crates/runner/src/pre_spawn_admission.rs
+++ b/crates/runner/src/pre_spawn_admission.rs
@@ -5,7 +5,7 @@
 //! avoids host lock files, polling, and cross-process fairness machinery. Exact reuse bypasses the
 //! gate, and post-spawn execution releases its permit so steady-state capacity is unchanged.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::CancellationToken;
@@ -16,6 +16,19 @@ use crate::error::{RunnerError, RunnerResult};
 pub(crate) struct PreSpawnAdmission {
     semaphore: Arc<Semaphore>,
     total_tokens: u32,
+    background: Arc<Mutex<BackgroundAdmissionState>>,
+}
+
+#[derive(Default)]
+struct BackgroundAdmissionState {
+    next_id: u64,
+    real_waiters: usize,
+    active: Option<ActiveBackgroundAdmission>,
+}
+
+struct ActiveBackgroundAdmission {
+    id: u64,
+    cancel: CancellationToken,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -31,9 +44,42 @@ pub(crate) struct PreSpawnAdmissionLease {
     metadata: PreSpawnAdmissionMetadata,
 }
 
+pub(crate) struct BackgroundPreSpawnAdmissionLease {
+    _permit: OwnedSemaphorePermit,
+    background: Arc<Mutex<BackgroundAdmissionState>>,
+    id: u64,
+    cancel: CancellationToken,
+}
+
+struct RealWaiterGuard {
+    background: Arc<Mutex<BackgroundAdmissionState>>,
+}
+
 impl PreSpawnAdmissionLease {
     pub(crate) fn metadata(&self) -> PreSpawnAdmissionMetadata {
         self.metadata
+    }
+}
+
+impl BackgroundPreSpawnAdmissionLease {
+    pub(crate) fn cancellation_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+}
+
+impl Drop for BackgroundPreSpawnAdmissionLease {
+    fn drop(&mut self) {
+        let mut state = lock_background(&self.background);
+        if state.active.as_ref().map(|active| active.id) == Some(self.id) {
+            state.active = None;
+        }
+    }
+}
+
+impl Drop for RealWaiterGuard {
+    fn drop(&mut self) {
+        let mut state = lock_background(&self.background);
+        state.real_waiters -= 1;
     }
 }
 
@@ -47,6 +93,7 @@ impl PreSpawnAdmission {
         Ok(Self {
             semaphore: Arc::new(Semaphore::new(total_tokens as usize)),
             total_tokens,
+            background: Arc::new(Mutex::new(BackgroundAdmissionState::default())),
         })
     }
 
@@ -66,10 +113,24 @@ impl PreSpawnAdmission {
         }
 
         let effective_tokens = requested_tokens.min(self.total_tokens);
-        let immediate = Arc::clone(&self.semaphore).try_acquire_many_owned(effective_tokens);
+        let immediate = {
+            let mut background = lock_background(&self.background);
+            match Arc::clone(&self.semaphore).try_acquire_many_owned(effective_tokens) {
+                Ok(permit) => Ok(permit),
+                Err(_) => {
+                    background.real_waiters += 1;
+                    if let Some(active) = background.active.as_ref() {
+                        active.cancel.cancel();
+                    }
+                    Err(RealWaiterGuard {
+                        background: Arc::clone(&self.background),
+                    })
+                }
+            }
+        };
         let (permit, contended) = match immediate {
             Ok(permit) => (permit, false),
-            Err(_) => {
+            Err(waiter) => {
                 let permit = tokio::select! {
                     biased;
                     _ = cancel.cancelled() => return Err(RunnerError::Cancelled),
@@ -79,6 +140,7 @@ impl PreSpawnAdmission {
                         )))?
                     },
                 };
+                drop(waiter);
                 (permit, true)
             }
         };
@@ -97,6 +159,54 @@ impl PreSpawnAdmission {
             },
         })
     }
+
+    /// Reserve weighted pre-spawn capacity for best-effort background work.
+    ///
+    /// This never waits and admits at most one background owner. A real
+    /// request that cannot acquire immediately cancels the returned token.
+    pub(crate) fn try_acquire_background(
+        &self,
+        requested_tokens: u32,
+    ) -> RunnerResult<Option<BackgroundPreSpawnAdmissionLease>> {
+        if requested_tokens == 0 {
+            return Err(RunnerError::Internal(
+                "background pre-spawn admission request must be positive".into(),
+            ));
+        }
+
+        let effective_tokens = requested_tokens.min(self.total_tokens);
+        let mut background = lock_background(&self.background);
+        if background.real_waiters > 0 || background.active.is_some() {
+            return Ok(None);
+        }
+        let Ok(permit) = Arc::clone(&self.semaphore).try_acquire_many_owned(effective_tokens)
+        else {
+            return Ok(None);
+        };
+        let id = background.next_id;
+        background.next_id = background.next_id.wrapping_add(1);
+        let cancel = CancellationToken::new();
+        background.active = Some(ActiveBackgroundAdmission {
+            id,
+            cancel: cancel.clone(),
+        });
+        drop(background);
+
+        Ok(Some(BackgroundPreSpawnAdmissionLease {
+            _permit: permit,
+            background: Arc::clone(&self.background),
+            id,
+            cancel,
+        }))
+    }
+}
+
+fn lock_background(
+    background: &Mutex<BackgroundAdmissionState>,
+) -> MutexGuard<'_, BackgroundAdmissionState> {
+    background
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 #[cfg(test)]
@@ -224,5 +334,55 @@ mod tests {
         }));
         assert!(panic.is_err());
         admission.acquire(1, &cancel).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn background_admission_is_immediate_and_single_flight() {
+        let admission = PreSpawnAdmission::new(3).unwrap();
+        let background = admission.try_acquire_background(2).unwrap().unwrap();
+
+        assert!(admission.try_acquire_background(1).unwrap().is_none());
+        let cancel = CancellationToken::new();
+        let real = admission.acquire(1, &cancel).await.unwrap();
+        assert!(!real.metadata().contended);
+        drop(real);
+        drop(background);
+        assert!(admission.try_acquire_background(3).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn real_waiter_cancels_background_admission() {
+        let admission = PreSpawnAdmission::new(2).unwrap();
+        let background = admission.try_acquire_background(2).unwrap().unwrap();
+        let background_cancel = background.cancellation_token();
+        let cancel = CancellationToken::new();
+        let mut real = Box::pin(admission.acquire(1, &cancel));
+
+        assert_pending(real.as_mut());
+        assert!(background_cancel.is_cancelled());
+        assert!(admission.try_acquire_background(1).unwrap().is_none());
+
+        drop(background);
+        let real = tokio::time::timeout(TEST_TIMEOUT, real)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(real.metadata().contended);
+    }
+
+    #[tokio::test]
+    async fn cancelled_real_waiter_reopens_background_admission() {
+        let admission = PreSpawnAdmission::new(1).unwrap();
+        let holder_cancel = CancellationToken::new();
+        let holder = admission.acquire(1, &holder_cancel).await.unwrap();
+        let waiter_cancel = CancellationToken::new();
+        let mut waiter = Box::pin(admission.acquire(1, &waiter_cancel));
+
+        assert_pending(waiter.as_mut());
+        waiter_cancel.cancel();
+        assert!(matches!(waiter.await, Err(RunnerError::Cancelled)));
+        drop(holder);
+
+        assert!(admission.try_acquire_background(1).unwrap().is_some());
     }
 }

--- a/crates/sandbox-mock/src/factory_runtime.rs
+++ b/crates/sandbox-mock/src/factory_runtime.rs
@@ -78,6 +78,7 @@ impl SandboxFactory for MockSandboxFactory {
                 .create_configs
                 .lock_ignoring_poison()
                 .push(config.clone());
+            wait_lifecycle_gate(&overrides.factory.create_gate).await;
         }
         if let Some(result) = self.create_results.lock_ignoring_poison().pop_front() {
             result?;

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -120,6 +120,8 @@ pub(crate) struct LifecycleOverrideState {
     /// FIFO queue of start results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     pub(crate) start_results: Mutex<VecDeque<Result<()>>>,
+    /// Optional gate that records and blocks every `start()` entry until released.
+    pub(crate) start_gate: Mutex<Option<MockLifecycleGate>>,
     /// FIFO queue of stop behaviours consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     pub(crate) stop_behaviors: LifecycleBehaviors<()>,
@@ -778,6 +780,11 @@ impl MockSandboxOverrides {
             .start_results
             .lock_ignoring_poison()
             .push_back(result);
+    }
+
+    /// Block every `start()` call with a durable lifecycle gate.
+    pub fn set_start_lifecycle_gate(&self, gate: MockLifecycleGate) {
+        *self.lifecycle.start_gate.lock_ignoring_poison() = Some(gate);
     }
 
     /// Return full run identities bound across all mock sandboxes.

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -260,6 +260,8 @@ pub(crate) struct FactoryOverrideState {
     pub(crate) create_results: Mutex<VecDeque<Result<()>>>,
     /// Sandbox create configs observed across factories built with these overrides.
     pub(crate) create_configs: Mutex<Vec<SandboxConfig>>,
+    /// Optional gate that records and blocks every factory `create()` entry until released.
+    pub(crate) create_gate: Mutex<Option<MockLifecycleGate>>,
 }
 
 /// Shared behavior overrides propagated from runtime → factory → sandbox.
@@ -771,6 +773,11 @@ impl MockSandboxOverrides {
     /// are returned.
     pub fn create_configs(&self) -> Vec<SandboxConfig> {
         self.factory.create_configs.lock_ignoring_poison().clone()
+    }
+
+    /// Block every factory `create()` call with a durable lifecycle gate.
+    pub fn set_create_lifecycle_gate(&self, gate: MockLifecycleGate) {
+        *self.factory.create_gate.lock_ignoring_poison() = Some(gate);
     }
 
     /// Queue a `start()` result applied to the next factory-created sandbox.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -635,6 +635,7 @@ impl Sandbox for MockSandbox {
             .start_run_control_ids
             .lock_ignoring_poison()
             .push(self.run_control_id.clone());
+        wait_lifecycle_gate(&o.lifecycle.start_gate).await;
         o.lifecycle
             .start_results
             .lock_ignoring_poison()


### PR DESCRIPTION
## Summary

- maintain a tenant-free blank sandbox pool whose target scales to the Runner's effective capacity
- reserve a compatible blank before pressure eviction so warm capacity remains usable when the Runner is full
- preserve exact idle and workspace-cache priority while keeping existing cold-miss attribution for blank claims
- restore an exact reservation over a blank that filled its idle slot during asynchronous activation, preserving the original idle age and cleaning up the displaced blank
- make background preparation single-flight, immediate-only, and preemptible by real pre-spawn demand
- when normal refill is blocked, let the oldest compatible exact sandbox yield capacity after 30 minutes idle
- publish exact removal before cleanup, retain its resource lease through physical destruction, and transfer that lease to one newly created blank sandbox

## Capacity-yield policy

- ordinary blank refill always runs first and leaves exact inventory untouched while capacity and `max_idle` allow it
- age-based yield runs only while blank inventory is below target and ordinary refill is blocked by resource capacity, reserved headroom, or `max_idle`
- selection is oldest-first and requires the same profile, device limits, vCPU, and memory shape as the blank plan
- one single-flight workflow removes one exact entry, persists the revisioned idle snapshot, requests an immediate heartbeat, completes normal workspace promotion and physical cleanup, and then creates one tenant-free blank
- a successful replacement re-enters the existing refill loop, which recomputes inventory and eligibility before converting another entry
- a foreground waiter immediately reclaims pre-spawn admission; an already-started exact destroy drains safely, releases its resource lease, and does not create a blank
- uncertain exact cleanup fails closed and never invokes the blank factory

## Existing blank-pool safety

- select the configured profile with the greatest effective capacity and target the nearest 10%, bounded below total capacity and by non-zero `max_idle`
- preserve CPU and memory headroom for the largest configured profile during ordinary refill
- create and mount only an unseeded workspace drive during prewarm
- apply run identity, proxy, connector, secret, storage, session, and tenant workspace state only after a real job claims the blank
- consume compatible exact and possible workspace-cache reuse before blank inventory
- recheck authoritative claim metadata so an exact sandbox that parks during claim, or a late-known workspace-cache hit, still wins over a reserved blank
- preserve `noReuseKey` attribution when candidate metadata advertises reuse but the authoritative claimed context does not
- retire blank entries before unrelated exact entries under foreground pressure

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner` (Runner: 3,484 passed, 25 existing ignored; guest inventory passed)
- focused coverage verifies full-capacity blank admission, exact inventory parking during provider claim, claim-only workspace-cache metadata, authoritative no-reuse attribution, the inclusive 30-minute boundary, compatibility filtering, oldest-first choice, simultaneous eligible entries, one-at-a-time conversion, revisioned status and heartbeat refresh, resource-exhausted and `max_idle`-blocked refill, foreground interruption during exact destruction, and fail-closed uncertain cleanup
- the earlier same-build metal validation on `local-11.gcp.vm3.ai` verified the base mounted blank lifecycle, claim-time activation, foreground priority, cleanup, and refill; the aging change itself is covered locally with injected monotonic park times rather than a 30-minute wall-clock wait

The new main-loop rollback regression failed before the fix and passed afterward. It verifies
that cancelled finalizing activation restores exact inventory over a refilled blank, a subsequent
job reuses the original sandbox, and shutdown releases all resource budget.

## Scope

This PR does not reclassify tenant state in place, pre-prepare tenant storage or workspace images,
batch-retire exact sandboxes, add adaptive demand prediction, or change Runner/API protocols.

Closes #31940
Parent: #24203
