### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,16 +113,16 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.27.1"
-CLAUDE_CODE_VERSION="2.1.261"
+CLAUDE_CODE_VERSION="2.1.263"
 CODEX_CLI_VERSION="0.153.4"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.3.1"
 AGENT_BROWSER_VERSION="0.33.0-vm0.1"
 AGENT_BROWSER_LINUX_X64_SHA256="a9e3fbe24c537960b9ac0d1f358224a10eb70d87a619aec7bcb1175222a46a18"
 AGENT_BROWSER_LINUX_ARM64_SHA256="6a74dba04c299a69d564eae5aff67adc2ffc6fda5ddf672994ff75b73d64a9fe"
-PNPM_VERSION="11.25.0"
-CHROMIUM_VERSION="152.0.7977.75-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260903T220410Z"
+PNPM_VERSION="12.3.4"
+CHROMIUM_VERSION="152.0.7977.82-1~deb12u1"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260905T234553Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.261` to `2.1.263`.
- Update pnpm from `11.25.0` to `12.3.4`.
- Update Chromium from `152.0.7977.75-1~deb12u1` to `152.0.7977.82-1~deb12u1`.
- Advance the Debian security snapshot from `20260903T220410Z` to `20260905T234553Z`.

Go, Codex CLI, Google Workspace CLI, xurl, and the vm0 agent-browser fork remain current. Node.js 24 remains the current LTS major, and PostgreSQL 18 remains the current supported major.

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check origin/main...HEAD`
- `CARGO_BUILD_JOBS=1 cargo check --manifest-path crates/Cargo.toml --profile local -p runner --tests`
- Confirmed Claude Code 2.1.263 standalone binaries and manifest entries for linux-x64 and linux-arm64.
- Confirmed pnpm 12.3.4 supports Node.js 18 or newer and executed the published package successfully.
- Confirmed Chromium, Chromium Common, and Chromium Sandbox `152.0.7977.82-1~deb12u1` for amd64 and arm64 in the pinned Debian security snapshot.