### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -912,18 +912,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crunchy"


### PR DESCRIPTION
## Summary

- Refresh the Rust lockfile with the latest compatible dependency versions.
- Update `crossbeam-channel` from 0.5.16 to 0.5.17.
- Update `crossbeam-utils` from 0.8.22 to 0.8.23.

## Deferred updates

- `generic-array` remains at 0.14.7 because `crypto-common` 0.1.7 requires that exact version through the `digest` dependency chain.
- `zstd` remains at 0.13.3 because `guest-agent` requires `^0.13`; 0.14 is a semver-major update outside the declared range.

## Manual manifest changes

None.

## Validation

- `cargo +stable test --locked --workspace --exclude runner --profile local`
- `cargo +stable test --locked --quiet --profile local -p ably-subscriber -p guest-agent -p guest-download` on the final dependency lockfile
- `cargo +stable check --locked --quiet --profile local -p runner --tests` on the final dependency lockfile
- `codex_app_server_event_delivery_byte_overload_terminates_promptly` passed 5 consecutive runs with a short private temporary directory

The full workspace test command reached the local 3.8 GiB no-swap memory limit while compiling the `runner` test binary (the kernel killed `rustc` at approximately 3.70 GiB RSS), before any `runner` test assertion ran. The split validation above covers all non-`runner` workspace tests and compilation of every `runner` test target. An initial `guest-agent` failure was traced to a 110-byte temporary Unix socket path exceeding the platform path limit; it passed consistently with a short private temporary directory and required no code change.
