### PR TITLE
refactor(connectors): remove single-account compatibility contract

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agent-custom-connectors.test.ts
@@ -665,10 +665,7 @@ describe("PUT /api/agents/:id/custom-connectors", () => {
     await connectors.updateAgentCustomConnectors(actor, agent.agentId, [
       connector.id,
     ]);
-    await connectors.disconnectSingleCustomConnectorAccount(
-      actor,
-      connector.id,
-    );
+    await connectors.deleteDefaultCustomConnectorAccount(actor, connector.id);
 
     const updated = await connectors.updateAgentCustomConnectors(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -922,7 +922,7 @@ describe("AGENT-01 and AGENT-02", () => {
     );
     expect(cleared.grants).toStrictEqual([]);
 
-    await api.disconnectSingleCustomConnectorAccount(admin, connector.id);
+    await api.deleteDefaultCustomConnectorAccount(admin, connector.id);
     const afterDisconnect = await api.listCustomConnectors(admin);
     expect(
       afterDisconnect.connectors.find((candidate) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -556,13 +556,14 @@ describe("POST /api/zero/chat-threads", () => {
           target: { kind: "builtin", connectorSlug: "openai" },
         },
       }),
-      connectorAccountsClient().disconnectSingleAccount({
+      connectorAccountsClient().delete({
         headers: { authorization: "Bearer clerk-session" },
+        params: { connectionId: connection.id },
         body: { target: { kind: "builtin", connectorSlug: "openai" } },
       }),
     ]);
     expect([200, 400]).toContain(concurrentSelectionWrite.status);
-    expect(concurrentDisconnect.status).toBe(204);
+    expect(concurrentDisconnect.status).toBe(200);
     const afterDisconnect = await accept(
       connectorSelectionsClient().get({
         headers: { authorization: `Bearer ${token}` },
@@ -695,15 +696,19 @@ describe("POST /api/zero/chat-threads", () => {
     );
 
     createRouteMocks(context).clerk.session(fixture.userId, fixture.orgId);
-    for (const customConnectorId of [httpConnector.id, mcpConnector.id]) {
+    for (const [customConnectorId, connectionId] of [
+      [httpConnector.id, httpConnectionId],
+      [mcpConnector.id, mcpConnectionId],
+    ] as const) {
       await accept(
-        connectorAccountsClient().disconnectSingleAccount({
+        connectorAccountsClient().delete({
           headers: { authorization: "Bearer clerk-session" },
+          params: { connectionId },
           body: {
             target: { kind: "custom", customConnectorId },
           },
         }),
-        [204],
+        [200],
       );
     }
     const afterDisconnect = await accept(

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -3533,6 +3533,8 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       actor,
       "google-drive",
       "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: connected.id },
     );
     await connectorsApi.completeOauthCallback("google-drive", {
       code: "drive-reconnected",
@@ -3612,6 +3614,8 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       actor,
       "google-drive",
       "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: connected.id },
     );
     await connectorsApi.completeOauthCallback("google-drive", {
       code: "drive-reconnected-again",

--- a/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cli-auth.bdd.test.ts
@@ -12,11 +12,13 @@ import {
   makeCodexJwt,
 } from "./helpers/api-bdd-auth-device";
 import { createAuthDeviceSupportApi } from "./helpers/api-bdd-auth-device-support";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 
 const context = testContext();
 const bdd = createBddApi(context);
 const authDevice = createAuthDeviceApiActions(context);
 const support = createAuthDeviceSupportApi(context);
+const connectors = createConnectorBddApi(context);
 
 const DEVICE_CODE_EXPIRY_MS = 16 * 60 * 1000;
 const DEFAULT_TEST_EMAIL = "dev+clerk_test+serial@vm0-e2e.ai";
@@ -528,8 +530,16 @@ describe("CLI-TEST: test-connector", () => {
       connectorSlug: "test-oauth",
       orgId: actor.orgId,
     });
-    const apiState = await support.readConnectorBySlug(actor, "test-oauth");
-    expect(apiState.authMethod).toBe("api");
+    const accounts = await connectors.listBuiltinConnectorAccounts(
+      actor,
+      "test-oauth",
+    );
+    expect(accounts).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: oauthState.id, authMethod: "oauth" }),
+        expect.objectContaining({ authMethod: "api" }),
+      ]),
+    );
 
     await authDevice.requestTestConnector(
       { email: "custom@test.com" },

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-accounts.test.ts
@@ -783,17 +783,6 @@ describe("connector account lifecycle routes", () => {
     );
     expect(accounts.body.connections).toHaveLength(2);
 
-    const disconnect = await accept(
-      accountClient().disconnectSingleAccount({
-        headers: authHeaders(),
-        body: { target: { kind: "builtin", connectorSlug: "openai" } },
-      }),
-      [409],
-    );
-    expect(disconnect.body.error.message).toBe(
-      "Multiple connector accounts require an exact choice",
-    );
-
     const preserved = await accept(
       accountClient().connections({
         headers: authHeaders(),
@@ -807,160 +796,6 @@ describe("connector account lifecycle routes", () => {
         return account.isDefault;
       }),
     ).toHaveLength(1);
-  });
-
-  it("reuses an explicit single account and rejects an ambiguous target", async () => {
-    await seedFixture();
-
-    const first = await accept(
-      connectorClient().connect({
-        headers: authHeaders(),
-        params: { connectorSlug: "openai" },
-        body: {
-          authMethod: "api-token",
-          account: { intent: "single-account" },
-          values: { apiKey: "sk-single-first" },
-        },
-      }),
-      [200],
-    );
-    const replaced = await accept(
-      connectorClient().connect({
-        headers: authHeaders(),
-        params: { connectorSlug: "openai" },
-        body: {
-          authMethod: "api-token",
-          account: { intent: "single-account" },
-          values: { apiKey: "sk-single-replaced" },
-        },
-      }),
-      [200],
-    );
-    expect(replaced.body.id).toBe(first.body.id);
-
-    const sibling = await accept(
-      connectorClient().connect({
-        headers: authHeaders(),
-        params: { connectorSlug: "openai" },
-        body: {
-          authMethod: "api-token",
-          account: { intent: "add", displayName: "Sibling" },
-          values: { apiKey: "sk-single-sibling" },
-        },
-      }),
-      [200],
-    );
-    expect(sibling.body.id).not.toBe(first.body.id);
-
-    const ambiguous = await accept(
-      connectorClient().connect({
-        headers: authHeaders(),
-        params: { connectorSlug: "openai" },
-        body: {
-          authMethod: "api-token",
-          account: { intent: "single-account" },
-          values: { apiKey: "sk-single-ambiguous" },
-        },
-      }),
-      [409],
-    );
-    expect(ambiguous.body.error.message).toBe(
-      "Multiple connector accounts require an exact choice",
-    );
-
-    const omittedIntent = await accept(
-      connectorClient().connect({
-        headers: authHeaders(),
-        params: { connectorSlug: "openai" },
-        body: {
-          authMethod: "api-token",
-          values: { apiKey: "sk-omitted-ambiguous" },
-        },
-      }),
-      [409],
-    );
-    expect(omittedIntent.body.error.message).toBe(
-      "Multiple connector accounts require an exact choice",
-    );
-
-    const accounts = await accept(
-      accountClient().connections({
-        headers: authHeaders(),
-        query: { kind: "builtin", connectorSlug: "openai", limit: 100 },
-      }),
-      [200],
-    );
-    expect(accounts.body.connections).toHaveLength(2);
-  });
-
-  it("serializes concurrent single-account writes and disconnects", async () => {
-    await seedFixture();
-
-    const responses = await Promise.all(
-      ["first", "second"].map((suffix) => {
-        return accept(
-          connectorClient().connect({
-            headers: authHeaders(),
-            params: { connectorSlug: "openai" },
-            body: {
-              authMethod: "api-token",
-              account: { intent: "single-account" },
-              values: { apiKey: `sk-single-concurrent-${suffix}` },
-            },
-          }),
-          [200],
-        );
-      }),
-    );
-    expect(
-      responses.map((response) => {
-        return response.status;
-      }),
-    ).toStrictEqual([200, 200]);
-    expect(responses[1]?.body.id).toBe(responses[0]?.body.id);
-
-    const accounts = await accept(
-      accountClient().connections({
-        headers: authHeaders(),
-        query: { kind: "builtin", connectorSlug: "openai", limit: 100 },
-      }),
-      [200],
-    );
-    expect(accounts.body.connections).toHaveLength(1);
-    expect(accounts.body.connections[0]).toMatchObject({
-      id: responses[0]?.body.id,
-      displayName: null,
-      isDefault: true,
-    });
-
-    const disconnects = await Promise.all([
-      accountClient().disconnectSingleAccount({
-        headers: authHeaders(),
-        body: { target: { kind: "builtin", connectorSlug: "openai" } },
-      }),
-      accountClient().disconnectSingleAccount({
-        headers: authHeaders(),
-        body: { target: { kind: "builtin", connectorSlug: "openai" } },
-      }),
-    ]);
-    expect(
-      disconnects
-        .map((response) => {
-          return response.status;
-        })
-        .sort((left, right) => {
-          return left - right;
-        }),
-    ).toStrictEqual([204, 404]);
-
-    const disconnectedAccounts = await accept(
-      accountClient().connections({
-        headers: authHeaders(),
-        query: { kind: "builtin", connectorSlug: "openai", limit: 100 },
-      }),
-      [200],
-    );
-    expect(disconnectedAccounts.body.connections).toStrictEqual([]);
   });
 
   it("paginates and searches more than one hundred accounts", async () => {
@@ -1537,22 +1372,6 @@ describe("connector account lifecycle routes", () => {
         },
       ]);
 
-      const safeDisconnect = await accept(
-        accountClient().disconnectSingleAccount({
-          headers: authHeaders(),
-          body: {
-            target: {
-              kind: "custom",
-              customConnectorId: definition.body.id,
-            },
-          },
-        }),
-        [409],
-      );
-      expect(safeDisconnect.body.error.message).toBe(
-        "Multiple connector accounts require an exact choice",
-      );
-
       const work = accounts.body.connections.find((account) => {
         return account.displayName === null;
       });
@@ -1657,9 +1476,10 @@ describe("connector account lifecycle routes", () => {
         { id: work.id, displayName: null, isDefault: true },
       ]);
 
-      const disconnects = await Promise.all([
-        accountClient().disconnectSingleAccount({
+      await accept(
+        accountClient().delete({
           headers: authHeaders(),
+          params: { connectionId: work.id },
           body: {
             target: {
               kind: "custom",
@@ -1667,25 +1487,8 @@ describe("connector account lifecycle routes", () => {
             },
           },
         }),
-        accountClient().disconnectSingleAccount({
-          headers: authHeaders(),
-          body: {
-            target: {
-              kind: "custom",
-              customConnectorId: definition.body.id,
-            },
-          },
-        }),
-      ]);
-      expect(
-        disconnects
-          .map((response) => {
-            return response.status;
-          })
-          .sort((left, right) => {
-            return left - right;
-          }),
-      ).toStrictEqual([204, 404]);
+        [200],
+      );
       const disconnected = await accept(
         accountClient().connections({
           headers: authHeaders(),

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
@@ -47,7 +47,7 @@ interface ConnectedFixture {
 
 const trackConnectedFixture = createFixtureTracker<ConnectedFixture>(
   async (fixture) => {
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       fixture.actor,
       fixture.connectorSlug,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-by-slug-get.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-by-slug-get.test.ts
@@ -68,6 +68,7 @@ async function connectOpenai(fixture: AuthenticatedFixture): Promise<void> {
       params: { connectorSlug: "openai" },
       body: {
         authMethod: "api-token",
+        account: { intent: "add" },
         values: { apiKey: "sk-test-token" },
       },
       headers: authHeaders(),
@@ -78,15 +79,29 @@ async function connectOpenai(fixture: AuthenticatedFixture): Promise<void> {
 
 async function deleteOpenai(fixture: AuthenticatedFixture): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
-  await accept(
-    setupApp({ context, routes: connectorAccountRoutes })(
-      connectorAccountsContract,
-    ).disconnectSingleAccount({
-      headers: authHeaders(),
-      body: { target: { kind: "builtin", connectorSlug: "openai" } },
-    }),
-    [204, 404],
+  const client = setupApp({ context, routes: connectorAccountRoutes })(
+    connectorAccountsContract,
   );
+  const accounts = await accept(
+    client.connections({
+      headers: authHeaders(),
+      query: { kind: "builtin", connectorSlug: "openai" },
+    }),
+    [200, 404],
+  );
+  if (accounts.status === 404) {
+    return;
+  }
+  for (const account of accounts.body.connections) {
+    await accept(
+      client.delete({
+        headers: authHeaders(),
+        params: { connectionId: account.id },
+        body: { target: { kind: "builtin", connectorSlug: "openai" } },
+      }),
+      [200],
+    );
+  }
 }
 
 describe("GET /api/connectors/:connectorSlug", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -300,7 +300,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     const bdd = createBddApi(context);
 
     const session = await connectorsApi.startExternalCode(actor, "aws", "cli", {
-      intent: "single-account",
+      intent: "add",
     });
     expect(session).toMatchObject({
       connectorSlug: "aws",
@@ -457,7 +457,7 @@ describe("CONN-02: external-code session lifecycle", () => {
       "cli",
       { intent: "reconnect", connectionId: complete.connector.id },
     );
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(actor, "aws");
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "aws");
     const rejectedReconnect = await connectorsApi.requestExternalCodeComplete(
       actor,
       "aws",
@@ -619,7 +619,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     const readBack = await connectorsApi.readConnectorBySlug(actor, "aws");
     expect(readBack.id).toBe(retried.connector.id);
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(actor, "aws");
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "aws");
   });
 
   it("returns generic external-code copy when the PlayStation NPSSO token is rejected", async () => {
@@ -777,7 +777,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     expectNoVisibleSecret(storedSecrets, "bdd-nintendo-session-token");
     expectNoVisibleSecret(storedSecrets, "bdd-nintendo-access-token");
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       actor,
       "nintendo-store",
     );
@@ -930,7 +930,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     if (!replacementState) {
       throw new Error("Expected replacement Nintendo authorization state");
     }
-    await connectorsApi.completeExternalCode(
+    const replacementComplete = await connectorsApi.completeExternalCode(
       actor,
       "nintendo-switch-parental-controls",
       {
@@ -943,14 +943,23 @@ describe("CONN-02: external-code session lifecycle", () => {
     expect(provider.federatedSmartDeviceIds[1]).not.toBe(
       provider.federatedSmartDeviceIds[0],
     );
+    expect(replacementComplete.connector.id).not.toBe(complete.connector.id);
+    expect(provider.logoutBodies).toStrictEqual([]);
+
+    await connectorsApi.deleteBuiltinConnectorAccount(
+      actor,
+      "nintendo-switch-parental-controls",
+      complete.connector.id,
+    );
     expect(provider.logoutBodies).toStrictEqual([
       { smartDeviceId: provider.federatedSmartDeviceIds[0] },
     ]);
 
     provider.failLogout();
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteBuiltinConnectorAccount(
       actor,
       "nintendo-switch-parental-controls",
+      replacementComplete.connector.id,
     );
     expect(
       provider.tokenBodies.map((body) => {
@@ -1035,7 +1044,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     expect(secondComplete.connector.slug).toBe("aws");
     expect(provider.tokenRequests).toHaveLength(2);
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(actor, "aws");
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "aws");
   });
 
   it("expires external-code sessions past their deadline, including stale completing claims", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-list.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-list.test.ts
@@ -54,6 +54,7 @@ async function connectGitlab(fixture: AuthenticatedFixture): Promise<void> {
       params: { connectorSlug: "gitlab" },
       body: {
         authMethod: "api-token",
+        account: { intent: "add" },
         values: {
           accessToken: "gl-test-token",
           host: "gitlab.example.com",
@@ -70,15 +71,29 @@ async function deleteConnector(
   connectorSlug: "gitlab" | "openai",
 ): Promise<void> {
   mocks.clerk.session(fixture.userId, fixture.orgId);
-  await accept(
-    setupApp({ context, routes: connectorAccountRoutes })(
-      connectorAccountsContract,
-    ).disconnectSingleAccount({
-      headers: authHeaders(),
-      body: { target: { kind: "builtin", connectorSlug } },
-    }),
-    [204, 404],
+  const client = setupApp({ context, routes: connectorAccountRoutes })(
+    connectorAccountsContract,
   );
+  const accounts = await accept(
+    client.connections({
+      headers: authHeaders(),
+      query: { kind: "builtin", connectorSlug },
+    }),
+    [200, 404],
+  );
+  if (accounts.status === 404) {
+    return;
+  }
+  for (const account of accounts.body.connections) {
+    await accept(
+      client.delete({
+        headers: authHeaders(),
+        params: { connectionId: account.id },
+        body: { target: { kind: "builtin", connectorSlug } },
+      }),
+      [200],
+    );
+  }
 }
 
 describe("GET /api/connectors", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-manual-grant-connect.test.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 
 import { connectorAccountsContract } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
-  CLIENT_FORCE_UPGRADE_STATUS,
   CLIENT_TYPE_APP,
   CLIENT_TYPE_CLI,
   CLIENT_TYPE_HEADER,
@@ -192,7 +191,11 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { connectorSlug: "openai" },
-        body: { authMethod: "api-token", values: { apiKey: "sk-test" } },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add" },
+          values: { apiKey: "sk-test" },
+        },
         headers: {},
       }),
       [401],
@@ -210,7 +213,11 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { connectorSlug: "openai" },
-        body: { authMethod: "api-token", values: { apiKey: "sk-test" } },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add" },
+          values: { apiKey: "sk-test" },
+        },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [401],
@@ -235,53 +242,6 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     expect(response.status).toBe(400);
   });
 
-  it("requires identified CLI callers to send account-explicit intent", async () => {
-    await seedFixture();
-    const app = createApp({ signal: context.signal, routes: TEST_APP_ROUTES });
-    const request = (account?: { intent: "single-account" }) => {
-      return app.request("/api/connectors/openai/manual-grant", {
-        method: "POST",
-        headers: {
-          ...cliAuthHeaders(),
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          authMethod: "api-token",
-          values: { apiKey: "sk-retired-cli" },
-          ...(account ? { account } : {}),
-        }),
-      });
-    };
-
-    const omitted = await request();
-    expect(omitted.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
-    await expect(omitted.json()).resolves.toStrictEqual({
-      error: {
-        message: "Update the CLI to connect this connector",
-        code: "CLI_CONNECTOR_ACCOUNT_INTENT_RETIRED",
-      },
-    });
-
-    const singleton = await request({ intent: "single-account" });
-    expect(singleton.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
-    await expect(singleton.json()).resolves.toStrictEqual({
-      error: {
-        message: "Update the CLI to connect this connector",
-        code: "CLI_CONNECTOR_ACCOUNT_INTENT_RETIRED",
-      },
-    });
-
-    const list = await accept(
-      setupApp({ context, routes: connectorsRoutes })(
-        connectorsMainContract,
-      ).list({ headers: authHeaders() }),
-      [200],
-    );
-    expect(list.body.connectors).not.toContainEqual(
-      expect.objectContaining({ slug: "openai" }),
-    );
-  });
-
   it("accepts server-authored identity syntax before catalog rejection", async () => {
     await seedFixture();
     const connectorSlug = "server-authored-connector";
@@ -293,7 +253,11 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { connectorSlug },
-        body: { authMethod, values: { apiKey: "secret" } },
+        body: {
+          authMethod,
+          account: { intent: "add" },
+          values: { apiKey: "secret" },
+        },
         headers: authHeaders(),
       }),
       [400],
@@ -390,7 +354,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     );
   });
 
-  it("preserves App single-account manual grants with connector-owned state", async () => {
+  it("stores App manual grants in connector-owned state", async () => {
     const fixture = await seedFixture();
     const client = setupApp({ context, routes: connectorsRoutes })(
       connectorManualGrantContract,
@@ -401,7 +365,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "openai" },
         body: {
           authMethod: "api-token",
-          account: { intent: "single-account" },
+          account: { intent: "add" },
           values: { apiKey: " sk-test\n" },
         },
         headers: appAuthHeaders(),
@@ -576,6 +540,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "zendesk" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             apiToken: " zendesk\n-token ",
             email: " support@example.com ",
@@ -629,6 +594,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "zendesk" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             apiToken: "zendesk-token",
             email: "support@example.com",
@@ -687,6 +653,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "zendesk" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             apiToken: "zendesk-token",
             email: "support@example.com",
@@ -724,7 +691,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
       encryptedValue: "owner-value",
       description: "owner description",
     });
-    await seedConnectorStorageRow(context, {
+    const existingConnectionId = await seedConnectorStorageRow(context, {
       orgId: fixture.orgId,
       userId: fixture.userId,
       connectorSlug: "openai",
@@ -740,6 +707,10 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         headers: authHeaders(),
         body: {
           authMethod: "api-token",
+          account: {
+            intent: "reconnect",
+            connectionId: existingConnectionId,
+          },
           values: { apiKey: "replacement" },
         },
       }),
@@ -801,6 +772,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "insforge" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             apiKey: "ik_test-key",
             domain: "https://9ksx253h.us-west.insforge.app/api/",
@@ -831,6 +803,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "lark" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             appId: " cli_a123 ",
             appSecret: " lark-app-secret\n",
@@ -862,6 +835,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "lark" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             appId: "cli_old",
             appSecret: "old-lark-app-secret",
@@ -877,6 +851,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "lark" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             appId: "cli_new",
             appSecret: "new-lark-app-secret",
@@ -909,6 +884,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "test-oauth" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             apiToken: "old-manual-test-oauth-token",
             inputVariable: "old-input-variable",
@@ -925,6 +901,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "test-oauth" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             apiToken: "manual-test-oauth-token",
             inputVariable: "manual-input-variable",
@@ -950,6 +927,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "gitlab" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             accessToken: "old-token",
             host: "gitlab.example.com",
@@ -965,6 +943,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "gitlab" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: { accessToken: "new-token" },
         },
         headers: { authorization: "Bearer clerk-session" },
@@ -991,6 +970,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "openai" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: { OPENAI_TOKEN: "sk-private" },
         },
         headers: { authorization: "Bearer clerk-session" },
@@ -1014,6 +994,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "openai" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             apiKey: "sk-test",
             unknownField: "secret-value-should-not-echo",
@@ -1040,7 +1021,11 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { connectorSlug: "openai" },
-        body: { authMethod: "api-token", values: {} },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add" },
+          values: {},
+        },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [400],
@@ -1059,7 +1044,11 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { connectorSlug: "openai" },
-        body: { authMethod: "api-token", values: { apiKey: " \n\t " } },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add" },
+          values: { apiKey: " \n\t " },
+        },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [400],
@@ -1078,7 +1067,11 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { connectorSlug: "github" },
-        body: { authMethod: "api-token", values: {} },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add" },
+          values: {},
+        },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [400],
@@ -1098,7 +1091,11 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { connectorSlug: "stripe" },
-        body: { authMethod: "oauth", values: { apiKey: "sk_test_key" } },
+        body: {
+          authMethod: "oauth",
+          account: { intent: "add" },
+          values: { apiKey: "sk_test_key" },
+        },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [400],
@@ -1120,6 +1117,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "bentoml" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             apiToken: "bento-token",
             endpoint: "https://example.bentoml.test",
@@ -1146,7 +1144,11 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     const response = await accept(
       client.connect({
         params: { connectorSlug: "cloudflare" },
-        body: { authMethod: "api-token", values: {} },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add" },
+          values: {},
+        },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [403],
@@ -1169,7 +1171,11 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
     await accept(
       client.connect({
         params: { connectorSlug: "openai" },
-        body: { authMethod: "api-token", values: { apiKey: "sk-test" } },
+        body: {
+          authMethod: "api-token",
+          account: { intent: "add" },
+          values: { apiKey: "sk-test" },
+        },
         headers: { authorization: "Bearer clerk-session" },
       }),
       [200],
@@ -1200,6 +1206,7 @@ describe("POST /api/connectors/:connectorSlug/manual-grant", () => {
         params: { connectorSlug: "bentoml" },
         body: {
           authMethod: "api-token",
+          account: { intent: "add" },
           values: {
             apiToken: "bento-token",
             endpoint: "https://example.bentoml.test",

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-oauth-start.test.ts
@@ -716,7 +716,6 @@ function expectCloudflareAuthorizationScopes(authorizationUrl: URL): void {
 async function requestOauthStart(
   connectorSlug: string,
   options: {
-    readonly accountIntent?: "add" | "single-account";
     readonly authMethod?: ConnectorAuthMethodId;
     readonly authenticated?: boolean;
     readonly callbackTarget?: "app";
@@ -738,7 +737,7 @@ async function requestOauthStart(
     headers,
     body: JSON.stringify({
       authMethod: options.authMethod ?? "oauth",
-      account: { intent: options.accountIntent ?? "single-account" },
+      account: { intent: "add" },
       ...(options.callbackTarget
         ? { callbackTarget: options.callbackTarget }
         : {}),
@@ -1029,7 +1028,6 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
 
   it("returns the future connection id for an unnamed account addition", async () => {
     const response = await requestOauthStart("test-oauth", {
-      accountIntent: "add",
       authenticated: true,
     });
 
@@ -1356,7 +1354,6 @@ describe("POST /api/connectors/:connectorSlug/oauth/start", () => {
     mockAuthenticatedSession();
 
     const response = await requestOauthStart("airtable", {
-      accountIntent: "add",
       callbackTarget: "app",
       headers: authHeaders(),
       origin: OKOU_API_ORIGIN,

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
@@ -51,7 +51,7 @@ function mockSteamRuntimeEnv(): void {
 
 async function startSteamOpenId(
   actor: TestActor,
-  account: ConnectorAccountMutationIntent = { intent: "single-account" },
+  account: ConnectorAccountMutationIntent = { intent: "add" },
 ): Promise<URL> {
   mockSession(actor);
   const response = await accept(
@@ -284,7 +284,8 @@ describe("Steam OpenID connector", () => {
     expect(connector.body).toStrictEqual(initial.body);
 
     const replacementAuthorizationUrl = await startSteamOpenId(actor, {
-      intent: "single-account",
+      intent: "reconnect",
+      connectionId: initial.body.id,
     });
     await completeSteamOpenIdCallback(replacementAuthorizationUrl);
     mockSession(actor);
@@ -311,7 +312,7 @@ describe("Steam OpenID connector", () => {
       ).start({
         params: { connectorSlug: "github" },
         headers: authHeaders(),
-        body: { authMethod: "oauth", account: { intent: "single-account" } },
+        body: { authMethod: "oauth", account: { intent: "add" } },
       }),
       [400],
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-scope-diff.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-scope-diff.test.ts
@@ -135,10 +135,7 @@ describe("GET /api/connectors/:connectorSlug/scope-diff", () => {
 
     expectApiError(response.body);
     expect(response.body.error.code).toBe("NOT_FOUND");
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
-      actor,
-      "openai",
-    );
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "openai");
   });
 
   it("returns an empty diff when stored scopes match current scopes exactly", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -31,7 +31,7 @@ import {
   installApiTestConnectorCatalog,
   replaceApiTestConnectorCatalogFilteredAuthMethods,
 } from "../../../test-fixtures/connector-catalog";
-import { generateSandboxToken, generateOkouToken } from "../../auth/tokens";
+import { generateOkouToken } from "../../auth/tokens";
 import { createDeferredPromise } from "../../utils";
 import {
   createBddApi,
@@ -408,10 +408,7 @@ describe("CONN-01 and CHAIN-CONNECTOR: connector discovery and manual grant life
       storedScopes: [],
     });
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
-      actor,
-      "openai",
-    );
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "openai");
 
     const deleted = await connectorsApi.requestReadConnectorBySlug(
       actor,
@@ -586,7 +583,7 @@ describe("CONN-02: OAuth start and callback", () => {
     expect(failedConnector.body.error.code).toBe("NOT_FOUND");
   });
 
-  it("preserves legacy intents and allows explicit sibling adds across OAuth callbacks", async () => {
+  it("supports exact reconnect and sibling adds across OAuth callbacks", async () => {
     mockGitHubConnectorOAuth();
 
     const bdd = createBddApi(context);
@@ -604,23 +601,6 @@ describe("CONN-02: OAuth start and callback", () => {
       actor,
       "github",
     );
-
-    const singleAccountStart = await connectorsApi.startOauth(
-      actor,
-      "github",
-      "oauth",
-      undefined,
-      { intent: "single-account" },
-    );
-    await connectorsApi.completeOauthCallback("github", {
-      code: "github-single-account-code",
-      state: stateFromAuthorizationUrl(singleAccountStart.authorizationUrl),
-    });
-    const singleAccountConnection = await connectorsApi.readConnectorBySlug(
-      actor,
-      "github",
-    );
-    expect(singleAccountConnection.id).toBe(initialConnection.id);
 
     const reconnectStart = await connectorsApi.startOauth(
       actor,
@@ -903,7 +883,7 @@ describe("CONN-02: OAuth device authorization", () => {
       "test-oauth-device",
       "oauth",
       undefined,
-      { intent: "single-account" },
+      { intent: "add" },
     );
     expect(session).toMatchObject({
       connectorSlug: "test-oauth-device",
@@ -985,7 +965,7 @@ describe("CONN-02: OAuth device authorization", () => {
       undefined,
       { intent: "reconnect", connectionId: poll.connector.id },
     );
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       actor,
       "test-oauth-device",
     );
@@ -1160,10 +1140,7 @@ describe("CONN-02: OAuth device authorization", () => {
       }),
     );
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
-      actor,
-      "stripe",
-    );
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "stripe");
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 
@@ -1391,7 +1368,7 @@ describe("CONN-02: OAuth device authorization", () => {
       "test-device:test-oauth-device-api-client:read:test",
     );
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       actor,
       "test-oauth-device",
     );
@@ -1442,7 +1419,7 @@ describe("CONN-02: OAuth device authorization", () => {
     expect(rePoll.connector.id).toBe(completed.connector.id);
     expect(provider.tokenBodies).toHaveLength(tokenCallsBeforeRePoll);
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       actor,
       "test-oauth-device",
     );
@@ -1793,10 +1770,7 @@ describe("CONN-02: OAuth device authorization", () => {
     expect(JSON.stringify(base44Connector)).not.toContain(
       "base44-access-token",
     );
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
-      actor,
-      "base44",
-    );
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "base44");
 
     const slockProvider = mockSlockOAuthProvider();
     const slockSession = await connectorsApi.startDeviceAuth(
@@ -1848,7 +1822,7 @@ describe("CONN-02: OAuth device authorization", () => {
     const slockExpiryMs = Date.parse(slockConnector.tokenExpiresAt);
     expect(slockExpiryMs).toBeGreaterThan(now() + 850_000);
     expect(slockExpiryMs).toBeLessThanOrEqual(now() + 900_000);
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(actor, "slock");
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "slock");
 
     mockSlockOAuthProvider({ deviceCode: "userinfo-error" });
     const failing = await connectorsApi.startDeviceAuth(
@@ -2205,10 +2179,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       connectorsApi.readCustomConnector(admin, created.id),
     ).resolves.toMatchObject({ connected: false });
 
-    await connectorsApi.disconnectSingleCustomConnectorAccount(
-      admin,
-      created.id,
-    );
+    await connectorsApi.deleteDefaultCustomConnectorAccount(admin, created.id);
     await expect(
       connectorsApi.readCustomConnector(admin, created.id),
     ).resolves.toMatchObject({ connected: false });
@@ -2385,14 +2356,14 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       storageVersion: 3,
     });
 
-    await connectorsApi.disconnectSingleCustomConnectorAccount(admin, http.id);
-    await connectorsApi.disconnectSingleCustomConnectorAccount(admin, mcp.id);
+    await connectorsApi.deleteDefaultCustomConnectorAccount(admin, http.id);
+    await connectorsApi.deleteDefaultCustomConnectorAccount(admin, mcp.id);
     await connectorsApi.deleteCustomConnector(admin, http.id);
     await connectorsApi.deleteCustomConnector(admin, mcp.id);
     await bdd.deleteAgent(admin, agent.agentId);
   });
 
-  it("uses explicit single-account semantics for HTTP and MCP custom connectors", async () => {
+  it("uses exact reconnect semantics for HTTP and MCP custom connectors", async () => {
     const admin = createBddApi(context).user({ orgRole: "org:admin" });
     await connectorsApi.updateFeatureSwitches(admin, {
       [FeatureSwitchKey.CustomConnectorMcp]: true,
@@ -2426,15 +2397,25 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
         connected: true,
         connectedAccountId: expect.any(String),
       });
+      if (connected.status !== 200 || !connected.body.connectedAccountId) {
+        throw new Error("Expected a connected custom connector account");
+      }
+      const connectedAccountId = connected.body.connectedAccountId;
 
       const replaced = await connectorsApi.requestSetCustomConnectorValues(
         admin,
         connector.id,
         [{ key: "secret", kind: "secret", value: "replacement-secret" }],
         [200],
-        { intent: "single-account" },
+        {
+          intent: "reconnect",
+          connectionId: connectedAccountId,
+        },
       );
-      expect(replaced.body).toMatchObject({ connected: true });
+      expect(replaced.body).toMatchObject({
+        connected: true,
+        connectedAccountId,
+      });
 
       const sibling = await connectorsApi.requestSetCustomConnectorValues(
         admin,
@@ -2445,17 +2426,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       );
       expect(sibling.body).toMatchObject({ connected: true });
 
-      const ambiguous = await connectorsApi.requestSetCustomConnectorValues(
-        admin,
-        connector.id,
-        [{ key: "secret", kind: "secret", value: "ambiguous-secret" }],
-        [409],
-        { intent: "single-account" },
-      );
-      expectApiError(ambiguous.body);
-      expect(ambiguous.body.error.message).toBe(
-        "Multiple connector accounts require an exact choice",
-      );
       await expect(
         connectorsApi.readCustomConnector(admin, connector.id),
       ).resolves.toMatchObject({ connected: true });
@@ -2676,6 +2646,10 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       member,
       created.id,
       agent.agentId,
+      {
+        intent: "reconnect",
+        connectionId: initialStorage.connector.id,
+      },
     );
     await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
       code: "bdd-custom-oauth-replacement-code",
@@ -2744,10 +2718,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
         connectionId: initialStorage.connector.id,
       },
     );
-    await connectorsApi.disconnectSingleCustomConnectorAccount(
-      member,
-      created.id,
-    );
+    await connectorsApi.deleteDefaultCustomConnectorAccount(member, created.id);
     const removedReconnect =
       await connectorsApi.completeCustomConnectorOAuth2CallbackResult({
         code: "bdd-custom-oauth-removed-reconnect-code",
@@ -2920,6 +2891,13 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       code: "oauth-to-manual-code",
       state: stateFromAuthorizationUrl(authorizationUrl),
     });
+    const [oauthAccount] = await connectorsApi.listCustomConnectorAccounts(
+      admin,
+      created.id,
+    );
+    if (!oauthAccount) {
+      throw new Error("Expected the custom OAuth account");
+    }
     await expect(
       connectorsApi.readCustomConnector(admin, created.id),
     ).resolves.toMatchObject({ connected: true, storageVersion: 1 });
@@ -2949,9 +2927,12 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       },
     );
     expect(manual).toMatchObject({ connected: false, storageVersion: 2 });
-    await connectorsApi.setCustomConnectorValues(admin, created.id, [
-      { key: "api_key", kind: "secret", value: "manual-api-key" },
-    ]);
+    await connectorsApi.setCustomConnectorValues(
+      admin,
+      created.id,
+      [{ key: "api_key", kind: "secret", value: "manual-api-key" }],
+      { intent: "reconnect", connectionId: oauthAccount.id },
+    );
 
     const oauthAgain = await connectorsApi.updateCustomConnector(
       admin,
@@ -3189,7 +3170,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       }),
     ).toMatchObject({ connected: false });
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(peer, "github");
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(peer, "github");
     await connectorsApi.deleteCustomConnector(admin, connector.id);
   });
 
@@ -3330,10 +3311,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expectApiError(blockedStart.body);
     expect(blockedStart.body.error.code).toBe("FORBIDDEN");
 
-    await connectorsApi.disconnectSingleCustomConnectorAccount(
-      member,
-      created.id,
-    );
+    await connectorsApi.deleteDefaultCustomConnectorAccount(member, created.id);
     await connectorsApi.deleteCustomConnector(admin, created.id);
     await bdd.deleteAgent(member, agent.agentId);
   });
@@ -4965,10 +4943,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       created.id,
     ]);
 
-    await connectorsApi.disconnectSingleCustomConnectorAccount(
-      admin,
-      created.id,
-    );
+    await connectorsApi.deleteDefaultCustomConnectorAccount(admin, created.id);
     const afterDisconnect = await connectorsApi.listCustomConnectors(admin);
     expect(
       afterDisconnect.find((connector) => {
@@ -5165,9 +5140,12 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       },
     ]);
 
-    await connectorsApi.setCustomConnectorValues(admin, created.id, [
-      { key: "api_key", kind: "secret", value: "updated-secret" },
-    ]);
+    await connectorsApi.setCustomConnectorValues(
+      admin,
+      created.id,
+      [{ key: "api_key", kind: "secret", value: "updated-secret" }],
+      { intent: "reconnect", connectionId: parent.connector.id },
+    );
     const updatedParent = await readCustomConnectorCredentialStorageParent(
       context,
       {
@@ -5227,10 +5205,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       storageVersion: 1,
     });
 
-    await connectorsApi.disconnectSingleCustomConnectorAccount(
-      admin,
-      created.id,
-    );
+    await connectorsApi.deleteDefaultCustomConnectorAccount(admin, created.id);
     await expect(
       readCustomConnectorCredentialStorageParent(context, {
         orgId: requiredOrgId(admin),
@@ -5527,6 +5502,12 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
         { key: "note", kind: "variable", value: "invalid\u0000value" },
       ],
       [500],
+      storageBeforeFailure.connector
+        ? {
+            intent: "reconnect",
+            connectionId: storageBeforeFailure.connector.id,
+          }
+        : { intent: "add" },
     );
     expect(failed.status).toBe(500);
     await expect(
@@ -5582,6 +5563,13 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
         value: "legacy-value",
       },
     ]);
+    const [initialAccount] = await connectorsApi.listCustomConnectorAccounts(
+      admin,
+      created.id,
+    );
+    if (!initialAccount) {
+      throw new Error("Expected the versioned custom connector account");
+    }
 
     const compatible = await connectorsApi.updateCustomConnector(
       admin,
@@ -5644,6 +5632,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       created.id,
       [{ key: "replacement", kind: "secret", value: "partial-replacement" }],
       [400],
+      { intent: "reconnect", connectionId: initialAccount.id },
     );
     expectApiError(partialRecovery.body);
     expect(partialRecovery.body.error.message).toContain(
@@ -5661,6 +5650,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
           value: "replacement-secret",
         },
       ],
+      { intent: "reconnect", connectionId: initialAccount.id },
     );
     expect(recovered).toMatchObject({
       connected: true,
@@ -6168,7 +6158,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       ],
     });
 
-    await connectorsApi.disconnectSingleCustomConnectorAccount(
+    await connectorsApi.deleteDefaultCustomConnectorAccount(
       admin,
       saved.connector.id,
     );
@@ -6225,15 +6215,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       expectApiError(secretSet.body);
       expect(secretSet.body.error.code).toBe("UNAUTHORIZED");
 
-      const disconnect =
-        await connectorsApi.requestDisconnectSingleCustomConnectorAccount(
-          actor,
-          connectorId,
-          [401],
-        );
-      expectApiError(disconnect.body);
-      expect(disconnect.body.error.code).toBe("UNAUTHORIZED");
-
       const oauthStart = await connectorsApi.requestStartCustomConnectorOAuth2(
         actor,
         connectorId,
@@ -6242,20 +6223,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       expectApiError(oauthStart.body);
       expect(oauthStart.body.error.code).toBe("UNAUTHORIZED");
     }
-
-    const sandboxActor = bdd.user();
-    if (!sandboxActor.orgId) {
-      throw new Error("Expected an org-scoped sandbox actor");
-    }
-    const runId = randomUUID();
-    const disconnect =
-      await connectorsApi.requestDisconnectSingleCustomConnectorAccountWithToken(
-        generateSandboxToken(sandboxActor.userId, runId, sandboxActor.orgId),
-        connectorId,
-        [403],
-      );
-    expectApiError(disconnect.body);
-    expect(disconnect.body.error.code).toBe("FORBIDDEN");
   });
 
   it("invalidates every organization member for definitions and only the owner for credentials", async () => {
@@ -6291,10 +6258,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expectCustomConnectorInvalidations([admin.userId, member.userId]);
 
     clearConnectorInvalidationMocks();
-    await connectorsApi.disconnectSingleCustomConnectorAccount(
-      admin,
-      created.id,
-    );
+    await connectorsApi.deleteDefaultCustomConnectorAccount(admin, created.id);
     expectCustomConnectorInvalidations([admin.userId]);
 
     clearConnectorInvalidationMocks();
@@ -6586,10 +6550,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expectApiError(blockedGrant.body);
     expect(blockedGrant.body.error.code).toBe("FORBIDDEN");
 
-    await connectorsApi.disconnectSingleCustomConnectorAccount(
-      admin,
-      created.id,
-    );
+    await connectorsApi.deleteDefaultCustomConnectorAccount(admin, created.id);
     await expect(
       connectorsApi.readCustomConnector(admin, created.id),
     ).resolves.toMatchObject({ connected: false });
@@ -7304,17 +7265,6 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     expectApiError(missing.body);
     expect(missing.body.error.message).toBe("Custom connector not found");
 
-    const missingDisconnect =
-      await connectorsApi.requestDisconnectSingleCustomConnectorAccount(
-        admin,
-        randomUUID(),
-        [404],
-      );
-    expectApiError(missingDisconnect.body);
-    expect(missingDisconnect.body.error.message).toBe(
-      "Connector target not found",
-    );
-
     await connectorsApi.setCustomConnectorSecret(
       member,
       shared.id,
@@ -7328,10 +7278,19 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       shared.id,
       "admin-secret-value",
     );
+    const [adminAccount] = await connectorsApi.listCustomConnectorAccounts(
+      admin,
+      shared.id,
+    );
+    if (!adminAccount) {
+      throw new Error("Expected the admin custom connector account");
+    }
     await connectorsApi.setCustomConnectorSecret(
       admin,
       shared.id,
       "admin-secret-value-rotated",
+      [200],
+      { intent: "reconnect", connectionId: adminAccount.id },
     );
     const adminList = await connectorsApi.listCustomConnectors(admin);
     expect(
@@ -7351,10 +7310,7 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
       readConnected(adminInOtherOrg, otherOrg.id),
     ).resolves.toBeTruthy();
 
-    await connectorsApi.disconnectSingleCustomConnectorAccount(
-      admin,
-      shared.id,
-    );
+    await connectorsApi.deleteDefaultCustomConnectorAccount(admin, shared.id);
     await expect(readConnected(admin, shared.id)).resolves.toBeFalsy();
     await expect(readConnected(member, shared.id)).resolves.toBeTruthy();
     await expect(
@@ -7709,6 +7665,8 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       actor,
       "test-oauth",
       "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: supplemental.id },
     );
     expect(
       new URL(omittedStart.authorizationUrl).searchParams.get("scope"),
@@ -7735,7 +7693,7 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       connectionStatus: "connected",
     });
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       actor,
       "test-oauth",
     );
@@ -7757,11 +7715,25 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       displayName: "OAuth Connector Agent",
     });
 
+    const manualConnection = await connectorsApi.connectManualGrant(
+      actor,
+      "test-oauth",
+      "api-token",
+      {
+        apiToken: "bdd-manual-test-oauth-token",
+        inputVariable: "bdd-input-variable",
+        tenantId: "bdd-manual-tenant",
+      },
+    );
+    const manual = await connectorsApi.readConnectorBySlug(actor, "test-oauth");
+    expect(manual.authMethod).toBe("api-token");
+
     const start = await connectorsApi.startOauth(
       actor,
       "test-oauth",
       "oauth",
       agent.agentId,
+      { intent: "reconnect", connectionId: manualConnection.id },
     );
     const authorizationUrl = new URL(start.authorizationUrl);
     expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
@@ -7771,14 +7743,6 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       "test-oauth-client",
     );
     const state = stateFromAuthorizationUrl(start.authorizationUrl);
-
-    await connectorsApi.connectManualGrant(actor, "test-oauth", "api-token", {
-      apiToken: "bdd-manual-test-oauth-token",
-      inputVariable: "bdd-input-variable",
-      tenantId: "bdd-manual-tenant",
-    });
-    const manual = await connectorsApi.readConnectorBySlug(actor, "test-oauth");
-    expect(manual.authMethod).toBe("api-token");
 
     const success = await connectorsApi.completeOauthCallback("test-oauth", {
       code: "bdd-test-oauth-code",
@@ -7864,7 +7828,13 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       accessToken: "bdd-test-oauth-api-access-token",
       refreshToken: "bdd-test-oauth-api-refresh",
     });
-    const apiStart = await connectorsApi.startOauth(actor, "test-oauth", "api");
+    const apiStart = await connectorsApi.startOauth(
+      actor,
+      "test-oauth",
+      "api",
+      undefined,
+      { intent: "reconnect", connectionId: oauthConnector.id },
+    );
     const apiState = stateFromAuthorizationUrl(apiStart.authorizationUrl);
     await connectorsApi.completeOauthCallback("test-oauth", {
       code: "bdd-test-oauth-api-code",
@@ -7893,7 +7863,7 @@ describe("CONN-02: test-oauth auth-code journey", () => {
     );
     expectNoVisibleSecret(apiListed, "bdd-test-oauth-api-access-token");
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       actor,
       "test-oauth",
     );
@@ -7925,6 +7895,8 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       actor,
       "test-oauth",
       "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: initial.id },
     );
     await connectorsApi.completeOauthCallback("test-oauth", {
       code: "bdd-rollback-oauth-code",
@@ -7970,7 +7942,10 @@ describe("CONN-02: test-oauth auth-code journey", () => {
         inputVariable: "bdd-failed-replacement-input\u0000",
         tenantId: "bdd-failed-replacement-tenant",
       },
-      { statuses: [500] },
+      {
+        statuses: [500],
+        account: { intent: "reconnect", connectionId: oauthConnector.id },
+      },
     );
     expect(failed.status).toBe(500);
     await expect(
@@ -7989,6 +7964,8 @@ describe("CONN-02: test-oauth auth-code journey", () => {
         inputVariable: "bdd-successful-replacement-input",
         tenantId: "bdd-successful-replacement-tenant",
       },
+      undefined,
+      { intent: "reconnect", connectionId: oauthConnector.id },
     );
     expect(manual).toMatchObject({
       id: oauthConnector.id,
@@ -8021,7 +7998,7 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       "TEST_OAUTH_API_TOKEN_INPUT_VAR",
     ]);
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       actor,
       "test-oauth",
     );
@@ -8071,6 +8048,8 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       actor,
       "test-oauth",
       "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: explicitExpiry.id },
     );
     const defaultBefore = now();
     await connectorsApi.completeOauthCallback("test-oauth", {
@@ -8127,6 +8106,8 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       actor,
       "test-oauth",
       "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: defaultExpiry.id },
     );
     const tokenFail = await connectorsApi.completeOauthCallback("test-oauth", {
       code: "bdd-code-token-fail",
@@ -8157,6 +8138,8 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       actor,
       "test-oauth",
       "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: defaultExpiry.id },
     );
     const userinfoFail = await connectorsApi.completeOauthCallback(
       "test-oauth",
@@ -8197,18 +8180,19 @@ describe("CONN-02: test-oauth auth-code journey", () => {
       code: "bdd-code-replacement-account",
       state: stateFromAuthorizationUrl(replacementStart.authorizationUrl),
     });
-    const replacementAccount = await connectorsApi.readConnectorBySlug(
-      actor,
-      "test-oauth",
-    );
+    const replacementAccounts =
+      await connectorsApi.listBuiltinConnectorAccounts(actor, "test-oauth");
+    const replacementAccount = replacementAccounts.find((account) => {
+      return account.externalId === "bdd-test-oauth-replacement-user";
+    });
     expect(replacementAccount).toMatchObject({
-      id: defaultExpiry.id,
       externalId: "bdd-test-oauth-replacement-user",
       externalUsername: "bdd-test-oauth-replacement",
       externalEmail: "bdd-test-oauth-replacement@example.test",
     });
+    expect(replacementAccount?.id).not.toBe(defaultExpiry.id);
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(actor, "slack");
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "slack");
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 });
@@ -8256,6 +8240,8 @@ describe("CONN-02: device-auth method switching", () => {
       actor,
       "test-oauth-device",
       "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: apiPoll.connector.id },
     );
     const oauthPoll = await connectorsApi.pollDeviceAuth(
       actor,
@@ -8296,7 +8282,7 @@ describe("CONN-02: device-auth method switching", () => {
       }),
     );
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       actor,
       "test-oauth-device",
     );
@@ -8373,9 +8359,6 @@ describe("CONN-02: GitHub installation link after connector OAuth", () => {
       null,
     );
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
-      admin,
-      "github",
-    );
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(admin, "github");
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -177,10 +177,9 @@ function createConnectorCleanup(
   return async () => {
     mockEnv("R2_USER_STORAGES_BUCKET_NAME", bucket);
     mockApiTestConnectorProviderConfiguration();
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       actor,
       connectorSlug,
-      [204, 404],
     );
   };
 }
@@ -2624,9 +2623,12 @@ describe("connector catalog valid lifecycle", () => {
 
     const actor = bdd.user();
     onTestFinished(createConnectorCleanup(actor, "agora"));
-    await connectorsApi.connectManualGrant(actor, "agora", "legacy", {
-      credential: "legacy-catalog-secret",
-    });
+    const legacyConnection = await connectorsApi.connectManualGrant(
+      actor,
+      "agora",
+      "legacy",
+      { credential: "legacy-catalog-secret" },
+    );
 
     const replacement = buildRelease({
       version: "2026-07-15.external-replacement-method",
@@ -2667,6 +2669,8 @@ describe("connector catalog valid lifecycle", () => {
       "agora",
       "current",
       { credential: "current-catalog-secret" },
+      undefined,
+      { intent: "reconnect", connectionId: legacyConnection.id },
     );
     expect(connected).toMatchObject({
       slug: "agora",
@@ -2715,7 +2719,7 @@ describe("connector catalog valid lifecycle", () => {
     const filtered = await syncCatalog();
     expect(filtered.body.filtering.filteredAuthMethods).toHaveLength(2);
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(actor, "agora");
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "agora");
     const secretsAfterDelete = await readUserSecrets(context, {
       orgId: actor.orgId ?? "",
       userId: actor.userId,
@@ -2762,9 +2766,12 @@ describe("connector catalog valid lifecycle", () => {
 
     const actor = bdd.user();
     onTestFinished(createConnectorCleanup(actor, "agora"));
-    await connectorsApi.connectManualGrant(actor, "agora", "legacy", {
-      credential: "legacy-catalog-secret",
-    });
+    const legacyConnection = await connectorsApi.connectManualGrant(
+      actor,
+      "agora",
+      "legacy",
+      { credential: "legacy-catalog-secret" },
+    );
 
     const removed = buildRelease({
       version: "2026-07-15.external-stored-method-removed",
@@ -2792,14 +2799,16 @@ describe("connector catalog valid lifecycle", () => {
       "agora",
       "current",
       { credential: "current-catalog-secret" },
-      { statuses: [200] },
+      {
+        statuses: [200],
+        account: {
+          intent: "reconnect",
+          connectionId: legacyConnection.id,
+        },
+      },
     );
     expect(replacement.status).toBe(200);
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
-      actor,
-      "agora",
-      [204],
-    );
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "agora");
 
     routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
     const secrets = await readUserSecrets(context, {
@@ -2840,9 +2849,12 @@ describe("connector catalog valid lifecycle", () => {
 
     const actor = bdd.user();
     onTestFinished(createConnectorCleanup(actor, "gmail"));
-    await connectorsApi.connectManualGrant(actor, "gmail", "legacy", {
-      credential: "legacy-gmail-secret",
-    });
+    const legacyConnection = await connectorsApi.connectManualGrant(
+      actor,
+      "gmail",
+      "legacy",
+      { credential: "legacy-gmail-secret" },
+    );
 
     mockGmailConnectorOAuth({ email: "removed-method@example.test" });
     const replacement = buildRelease({
@@ -2861,7 +2873,13 @@ describe("connector catalog valid lifecycle", () => {
     serveObjects(catalogObjects([initial, replacement], replacement));
     await syncCatalog();
 
-    const oauth = await connectorsApi.startOauth(actor, "gmail", "oauth");
+    const oauth = await connectorsApi.startOauth(
+      actor,
+      "gmail",
+      "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: legacyConnection.id },
+    );
     const state = new URL(oauth.authorizationUrl).searchParams.get("state");
     if (!state) {
       throw new Error("Expected Gmail authorization state");
@@ -3929,7 +3947,7 @@ describe("connector catalog valid lifecycle", () => {
         headers,
         body: {
           authMethod: "openid",
-          account: { intent: "single-account" },
+          account: { intent: "add" },
         },
       }),
       [200],
@@ -4124,7 +4142,7 @@ describe("connector catalog valid lifecycle", () => {
       code: "catalog-slack-code",
       state,
     });
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(actor, "slack");
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "slack");
     expect(revokeCalls).toBe(1);
     expect(context.mocks.s3.send).toHaveBeenCalledTimes(callsBeforeAction);
   });
@@ -4233,7 +4251,19 @@ describe("connector catalog valid lifecycle", () => {
       firstStorageState.connector?.id,
     );
 
-    const secondStart = await connectorsApi.startOauth(actor, "slack", "oauth");
+    if (!firstStorageState.connector) {
+      throw new Error("Expected first-release Slack connector storage");
+    }
+    const secondStart = await connectorsApi.startOauth(
+      actor,
+      "slack",
+      "oauth",
+      undefined,
+      {
+        intent: "reconnect",
+        connectionId: firstStorageState.connector.id,
+      },
+    );
     const secondState = new URL(secondStart.authorizationUrl).searchParams.get(
       "state",
     );
@@ -4341,6 +4371,10 @@ describe("connector catalog valid lifecycle", () => {
       code: "initial",
       state: initialState,
     });
+    const initialConnection = await connectorsApi.readConnectorBySlug(
+      actor,
+      "gmail",
+    );
 
     mockNow(new Date("2026-07-15T10:00:00.000Z"));
     bdd.acceptAgentStorageWrites();
@@ -4430,6 +4464,8 @@ describe("connector catalog valid lifecycle", () => {
       actor,
       "gmail",
       "oauth",
+      undefined,
+      { intent: "reconnect", connectionId: initialConnection.id },
     );
     const replacementState = new URL(
       replacementOauth.authorizationUrl,

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-oauth-state-cleanup.test.ts
@@ -33,7 +33,7 @@ async function startGithubOauth(marker: string): Promise<string> {
     ).start({
       params: { connectorSlug: "github" },
       headers: { authorization: "Bearer clerk-session" },
-      body: { authMethod: "oauth", account: { intent: "single-account" } },
+      body: { authMethod: "oauth", account: { intent: "add" } },
     }),
     [200],
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -2189,7 +2189,7 @@ describe("Feishu integration", () => {
       customConnectorOAuthClient.start({
         headers: { authorization: "Bearer clerk-session" },
         params: { id: managedConnector.id },
-        body: { account: { intent: "single-account" } },
+        body: { account: { intent: "add" } },
       }),
       [403],
     );
@@ -2272,7 +2272,7 @@ describe("Feishu integration", () => {
         params: { id: managedConnector.id },
         body: {
           values: [],
-          account: { intent: "single-account" },
+          account: { intent: "add" },
         },
       }),
       [403],
@@ -2314,22 +2314,6 @@ describe("Feishu integration", () => {
       [403],
     );
     expect(managedProposal.body.error.message).toBe(
-      "This connector is managed by its integration",
-    );
-
-    const managedAccountDisconnect = await accept(
-      connectorAccountsClient().disconnectSingleAccount({
-        headers: { authorization: "Bearer clerk-session" },
-        body: {
-          target: {
-            kind: "custom",
-            customConnectorId: managedConnector.id,
-          },
-        },
-      }),
-      [403],
-    );
-    expect(managedAccountDisconnect.body.error.message).toBe(
       "This connector is managed by its integration",
     );
 
@@ -2482,51 +2466,6 @@ describe("Feishu integration", () => {
       },
     });
 
-    const persistedSingletonState = `managed-feishu-${randomUUID()}`;
-    await seedCustomConnectorOAuthStateContext(context, {
-      state: persistedSingletonState,
-      orgId: requireValue(member.orgId, "Expected an organization"),
-      userId: member.userId,
-      customConnectorId: managedConnector.id,
-      storageVersion: managedConnector.storageVersion,
-      redirectUri: `${APP_ORIGIN}/connectors/feishu/callback`,
-      oauthContext: {
-        version: 2,
-        authMode: "oauth",
-        connectorId: managedConnector.id,
-        storageVersion: managedConnector.storageVersion,
-        providerContext: {
-          provider: "feishu",
-          completionTarget: "feishu",
-          installationId,
-          expectedOpenId: "ou_oauth_user",
-        },
-      },
-    });
-    await expect(
-      readConnectorOAuthAccountMutation(context, persistedSingletonState),
-    ).resolves.toMatchObject({
-      account_mutation: { intent: "single-account" },
-    });
-    oauthUserOpenId = "ou_oauth_user";
-    clearConnectorInvalidationMocks();
-    const persistedSingletonResponse = await oauthApp.request(
-      `${feishuOauthContract.callback.path}?${new URLSearchParams({
-        code: "persisted-singleton-feishu-code",
-        responseMode: "json",
-        state: persistedSingletonState,
-      })}`,
-    );
-    expect(persistedSingletonResponse.status).toBe(200);
-    expectCustomConnectorInvalidations([member.userId]);
-    await expect(persistedSingletonResponse.json()).resolves.toStrictEqual({
-      redirectUrl: `https://applink.feishu.cn/client/bot/open?appId=${appId}`,
-    });
-    expect(oauthTokenRedirectUris).toStrictEqual([
-      `${APP_ORIGIN}/connectors/feishu/callback`,
-      `${APP_ORIGIN}/connectors/feishu/callback`,
-    ]);
-
     const legacyReplacementOpenId = "ou_legacy_replacement_user";
     oauthUserOpenId = legacyReplacementOpenId;
     clearConnectorInvalidationMocks();
@@ -2546,7 +2485,6 @@ describe("Feishu integration", () => {
     expect(legacyCallbackResponse.status).toBe(200);
     expectCustomConnectorInvalidations([member.userId]);
     expect(oauthTokenRedirectUris).toStrictEqual([
-      `${APP_ORIGIN}/connectors/feishu/callback`,
       `${APP_ORIGIN}/connectors/feishu/callback`,
       `${FEISHU_CALLBACK_ORIGIN}/api/integrations/feishu/oauth/callback`,
     ]);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -1455,28 +1455,42 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
           params: { id: connectorId },
           body: {
             values: [{ key: "secret", kind: "secret", value }],
-            account: { intent: "single-account" },
+            account: { intent: "add" },
           },
         }),
         [200],
       );
     },
 
-    async disconnectSingleCustomConnectorAccount(
+    async deleteDefaultCustomConnectorAccount(
       actor: ApiTestUser,
       connectorId: string,
     ): Promise<void> {
       const client = setupAppWithRoutes({ context, routes: authOrgRoutes })(
         connectorAccountsContract,
       );
+      const accounts = await accept(
+        client.connections({
+          headers: authenticate(actor),
+          query: { kind: "custom", customConnectorId: connectorId },
+        }),
+        [200],
+      );
+      const account = accounts.body.connections.find((candidate) => {
+        return candidate.isDefault;
+      });
+      if (!account) {
+        return;
+      }
       await accept(
-        client.disconnectSingleAccount({
+        client.delete({
+          params: { connectionId: account.id },
           headers: authenticate(actor),
           body: {
             target: { kind: "custom", customConnectorId: connectorId },
           },
         }),
-        [204],
+        [200],
       );
     },
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -1812,21 +1812,30 @@ export function createConnectorBddApi(context: TestContext) {
       return response.body;
     },
 
-    async disconnectSingleBuiltinConnectorAccount(
+    async deleteDefaultBuiltinConnectorAccount(
       actor: ApiTestUser,
       connectorSlug: ConnectorSlug,
-      statuses: readonly (204 | 401 | 404 | 409)[] = [204],
     ): Promise<void> {
       const client = setupApp({ context, routes: connectorAccountRoutes })(
         connectorAccountsContract,
       );
-      await accept(
-        client.disconnectSingleAccount({
+      const response = await accept(
+        client.connections({
           headers: authenticate(actor),
-          body: { target: { kind: "builtin", connectorSlug } },
+          query: { kind: "builtin", connectorSlug, limit: 100 },
         }),
-        statuses,
+        [200, 404],
       );
+      if (response.status === 404) {
+        return;
+      }
+      const account = response.body.connections.find((candidate) => {
+        return candidate.isDefault;
+      });
+      if (!account) {
+        return;
+      }
+      await api.deleteBuiltinConnectorAccount(actor, connectorSlug, account.id);
     },
 
     async listBuiltinConnectorAccounts(
@@ -1954,7 +1963,7 @@ export function createConnectorBddApi(context: TestContext) {
             values,
             ...(options.agentId ? { agentId: options.agentId } : {}),
             ...(options.authorizeAgent ? { authorizeAgent: true } : {}),
-            account: options.account ?? { intent: "single-account" },
+            account: options.account ?? { intent: "add" },
           },
         }),
         options.statuses,
@@ -1966,14 +1975,18 @@ export function createConnectorBddApi(context: TestContext) {
       connectorSlug: ConnectorSlug,
       authMethod: ConnectorAuthMethodId,
       values: Readonly<Record<string, string>>,
-      agentId?: string,
+      ...options: readonly [
+        agentId?: string,
+        account?: ConnectorAccountMutationIntent,
+      ]
     ): Promise<ConnectorResponse> {
+      const [agentId, account = { intent: "add" }] = options;
       const response = await api.requestManualGrant(
         actor,
         connectorSlug,
         authMethod,
         values,
-        { statuses: [200], agentId, authorizeAgent: true },
+        { statuses: [200], agentId, authorizeAgent: true, account },
       );
       expectStatus(response, 200);
       return response.body;
@@ -2005,7 +2018,7 @@ export function createConnectorBddApi(context: TestContext) {
             ...(options.callbackTarget
               ? { callbackTarget: options.callbackTarget }
               : {}),
-            account: options.account ?? { intent: "single-account" },
+            account: options.account ?? { intent: "add" },
           },
         }),
         options.statuses,
@@ -2196,8 +2209,7 @@ export function createConnectorBddApi(context: TestContext) {
         account?: ConnectorAccountMutationIntent,
       ]
     ) {
-      const [options, statuses, account = { intent: "single-account" }] =
-        request;
+      const [options, statuses, account = { intent: "add" }] = request;
       const client = setupApp({
         context,
         routes: connectorsOauthDeviceAuthRoutes,
@@ -2217,7 +2229,7 @@ export function createConnectorBddApi(context: TestContext) {
       connectorSlug: ConnectorSlug,
       authMethod: ConnectorAuthMethodId,
       options?: Readonly<Record<string, string>>,
-      account: ConnectorAccountMutationIntent = { intent: "single-account" },
+      account: ConnectorAccountMutationIntent = { intent: "add" },
     ): Promise<ConnectorOauthDeviceAuthSessionStartResponse> {
       const response = await api.requestDeviceAuthStart(
         actor,
@@ -2274,7 +2286,7 @@ export function createConnectorBddApi(context: TestContext) {
       connectorSlug: ConnectorSlug,
       authMethod: ConnectorAuthMethodId,
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 409 | 500)[],
-      account: ConnectorAccountMutationIntent = { intent: "single-account" },
+      account: ConnectorAccountMutationIntent = { intent: "add" },
     ) {
       const client = setupApp({
         context,
@@ -2587,6 +2599,7 @@ export function createConnectorBddApi(context: TestContext) {
       connectorId: string,
       value: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[],
+      account: ConnectorAccountMutationIntent = { intent: "add" },
     ) {
       const client = setupApp({
         context,
@@ -2598,7 +2611,7 @@ export function createConnectorBddApi(context: TestContext) {
           headers: authenticate(actor),
           body: {
             values: [{ key: "secret", kind: "secret", value }],
-            account: { intent: "single-account" },
+            account,
           },
         }),
         statuses,
@@ -2610,12 +2623,14 @@ export function createConnectorBddApi(context: TestContext) {
       connectorId: string,
       value: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 500)[] = [200],
+      account: ConnectorAccountMutationIntent = { intent: "add" },
     ): Promise<void> {
       await api.requestSetCustomConnectorSecret(
         actor,
         connectorId,
         value,
         statuses,
+        account,
       );
     },
 
@@ -2624,7 +2639,7 @@ export function createConnectorBddApi(context: TestContext) {
       connectorId: string,
       values: readonly CustomConnectorValueInput[],
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 409 | 500)[],
-      account: ConnectorAccountMutationIntent = { intent: "single-account" },
+      account: ConnectorAccountMutationIntent = { intent: "add" },
     ) {
       const client = setupApp({
         context,
@@ -2657,56 +2672,42 @@ export function createConnectorBddApi(context: TestContext) {
       return response.body;
     },
 
-    async requestDisconnectSingleCustomConnectorAccount(
-      actor: ApiTestUser | null,
+    async deleteCustomConnectorAccount(
+      actor: ApiTestUser,
       connectorId: string,
-      statuses: readonly (204 | 400 | 401 | 403 | 404 | 409)[],
-    ) {
+      connectionId: string,
+    ): Promise<void> {
       const client = setupApp({
         context,
         routes: connectorAccountRoutes,
       })(connectorAccountsContract);
-      return await accept(
-        client.disconnectSingleAccount({
+      await accept(
+        client.delete({
+          params: { connectionId },
           headers: authenticate(actor),
           body: {
             target: { kind: "custom", customConnectorId: connectorId },
           },
         }),
-        statuses,
+        [200],
       );
     },
 
-    async disconnectSingleCustomConnectorAccount(
+    async deleteDefaultCustomConnectorAccount(
       actor: ApiTestUser,
       connectorId: string,
-      statuses: readonly (204 | 400 | 401 | 404 | 409)[] = [204],
     ): Promise<void> {
-      await api.requestDisconnectSingleCustomConnectorAccount(
+      const accounts = await api.listCustomConnectorAccounts(
         actor,
         connectorId,
-        statuses,
       );
-    },
-
-    async requestDisconnectSingleCustomConnectorAccountWithToken(
-      token: string,
-      connectorId: string,
-      statuses: readonly (204 | 400 | 401 | 403 | 404 | 409)[],
-    ) {
-      const client = setupApp({
-        context,
-        routes: connectorAccountRoutes,
-      })(connectorAccountsContract);
-      return await accept(
-        client.disconnectSingleAccount({
-          headers: { authorization: `Bearer ${token}` },
-          body: {
-            target: { kind: "custom", customConnectorId: connectorId },
-          },
-        }),
-        statuses,
-      );
+      const account = accounts.find((candidate) => {
+        return candidate.isDefault;
+      });
+      if (!account) {
+        return;
+      }
+      await api.deleteCustomConnectorAccount(actor, connectorId, account.id);
     },
 
     async requestStartCustomConnectorOAuth2(
@@ -2714,7 +2715,7 @@ export function createConnectorBddApi(context: TestContext) {
       connectorId: string,
       statuses: readonly (200 | 400 | 401 | 403 | 404 | 409 | 500 | 502)[],
       agentId?: string,
-      account: ConnectorAccountMutationIntent = { intent: "single-account" },
+      account: ConnectorAccountMutationIntent = { intent: "add" },
     ) {
       const client = setupApp({
         context,
@@ -2754,7 +2755,7 @@ export function createConnectorBddApi(context: TestContext) {
       actor: ApiTestUser,
       connectorId: string,
       baseUrl: string,
-      account: ConnectorAccountMutationIntent = { intent: "single-account" },
+      account: ConnectorAccountMutationIntent = { intent: "add" },
     ): Promise<string> {
       const client = setupApp({
         baseUrl,

--- a/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/mail.test.ts
@@ -675,9 +675,10 @@ describe("POST /api/mail/drafts/link", () => {
       "Connect and authorize Gmail for this agent first",
     );
 
-    await connectors.disconnectSingleBuiltinConnectorAccount(
+    await connectors.deleteBuiltinConnectorAccount(
       fixture.actor,
       "gmail",
+      connectorId,
     );
     await expect(
       readThreadConnectorSelectionState(context, {
@@ -686,7 +687,7 @@ describe("POST /api/mail/drafts/link", () => {
       }),
     ).resolves.toBeFalsy();
 
-    const disconnectSingleCustomConnectorAccountId = randomUUID();
+    const deleteDefaultCustomConnectorAccountId = randomUUID();
     const deleteCustomConnectorId = randomUUID();
     await seedCustomConnectorRuntimeConnectors(context, {
       orgId: fixture.actor.orgId ?? "",
@@ -694,7 +695,7 @@ describe("POST /api/mail/drafts/link", () => {
       agentId: fixture.agent.agentId,
       customConnectors: [
         {
-          id: disconnectSingleCustomConnectorAccountId,
+          id: deleteDefaultCustomConnectorAccountId,
           slug: "_disconnect-selection-cleanup",
           displayName: "Disconnect selection cleanup",
           prefixTemplate: "https://disconnect-selection.example.com/",
@@ -711,7 +712,7 @@ describe("POST /api/mail/drafts/link", () => {
       await readCustomConnectorCredentialStorageParent(context, {
         orgId: fixture.actor.orgId ?? "",
         userId: fixture.actor.userId,
-        customConnectorId: disconnectSingleCustomConnectorAccountId,
+        customConnectorId: deleteDefaultCustomConnectorAccountId,
       });
     const disconnectMemberConnectorId = disconnectCustomStorage.connector?.id;
     if (!disconnectMemberConnectorId) {
@@ -720,11 +721,11 @@ describe("POST /api/mail/drafts/link", () => {
     await seedCustomThreadConnectorSelection(context, {
       chatThreadId: fixture.thread.id,
       connectorId: disconnectMemberConnectorId,
-      customConnectorId: disconnectSingleCustomConnectorAccountId,
+      customConnectorId: deleteDefaultCustomConnectorAccountId,
     });
-    await connectors.disconnectSingleCustomConnectorAccount(
+    await connectors.deleteDefaultCustomConnectorAccount(
       fixture.actor,
-      disconnectSingleCustomConnectorAccountId,
+      deleteDefaultCustomConnectorAccountId,
     );
     await expect(
       readThreadConnectorSelectionState(context, {
@@ -760,7 +761,7 @@ describe("POST /api/mail/drafts/link", () => {
     ).resolves.toBeFalsy();
     await connectors.deleteCustomConnector(
       fixture.actor,
-      disconnectSingleCustomConnectorAccountId,
+      deleteDefaultCustomConnectorAccountId,
     );
   });
 
@@ -1017,7 +1018,7 @@ describe("POST /api/mail/drafts/link", () => {
     const gmail = mockGmailDraftApi();
     const linked = await linkDraft(fixture);
 
-    await connectors.disconnectSingleBuiltinConnectorAccount(
+    await connectors.deleteDefaultBuiltinConnectorAccount(
       fixture.actor,
       "gmail",
     );
@@ -1067,6 +1068,11 @@ describe("POST /api/mail/drafts/link", () => {
       code: "okou-mail-replacement-account-code",
       state,
     });
+    await connectors.deleteBuiltinConnectorAccount(
+      fixture.actor,
+      "gmail",
+      fixture.gmail.id,
+    );
 
     const detached = await accept(
       client().getDraft({
@@ -1110,6 +1116,11 @@ describe("POST /api/mail/drafts/link", () => {
       code: "replace-original-mail-account",
       state: replacementState,
     });
+    await connectors.deleteBuiltinConnectorAccount(
+      fixture.actor,
+      "gmail",
+      fixture.gmail.id,
+    );
 
     const recoveredConnectorId = await addGmailAccount(fixture, {
       accessToken: "recovered-gmail-token",

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -1472,7 +1472,17 @@ async function connectStripeOAuthForOfficialWorkflow(
     code: args.code,
     state,
   });
-  return (await connectors.readConnectorBySlug(actor, "stripe")).id;
+  const accounts = await connectors.listBuiltinConnectorAccounts(
+    actor,
+    "stripe",
+  );
+  const connected = accounts.find((account) => {
+    return account.externalId === args.accountId;
+  });
+  if (!connected) {
+    throw new Error(`Expected Stripe account ${args.accountId}`);
+  }
+  return connected.id;
 }
 
 function configureResultEmailRecipient(actor: ApiTestUser): void {
@@ -6636,7 +6646,7 @@ describe.sequential("Official Workflow installations", () => {
     ]);
   });
 
-  it("revalidates a prepared Stripe transition after the same connector changes accounts", async () => {
+  it("revalidates a prepared Stripe transition after the default account changes", async () => {
     installCatalogStorageFixture();
     const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
     const definitionName = `api-test-stripe-binding-race-${suffix}`;
@@ -6701,7 +6711,12 @@ describe.sequential("Official Workflow installations", () => {
       accountId: "acct_official_after",
       code: `stripe-after-${suffix}`,
     });
-    expect(reconnectedId).toBe(connectorId);
+    expect(reconnectedId).not.toBe(connectorId);
+    await connectors.deleteBuiltinConnectorAccount(
+      actor,
+      "stripe",
+      connectorId,
+    );
     await resumeStructureTransitionPromotion();
     await olderWorker;
 
@@ -6738,7 +6753,7 @@ describe.sequential("Official Workflow installations", () => {
         kind: "event",
         eventType: "stripe-invoice-paid",
         eventConfig: expect.objectContaining({
-          connectorId,
+          connectorId: reconnectedId,
           stripeAccountId: "acct_official_after",
           mode: "live",
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -788,6 +788,24 @@ function availableCustomConnectorRuntime(
   return result;
 }
 
+async function defaultCustomConnectorAccountId(
+  connectorApi: ReturnType<typeof createConnectorBddApi>,
+  actor: ApiTestUser,
+  customConnectorId: string,
+): Promise<string> {
+  const accounts = await connectorApi.listCustomConnectorAccounts(
+    actor,
+    customConnectorId,
+  );
+  const account = accounts.find((candidate) => {
+    return candidate.isDefault;
+  });
+  if (!account) {
+    throw new Error("Expected a default custom connector account");
+  }
+  return account.id;
+}
+
 function customConnectorRuntimeAuthBody(
   runtime: AvailableCustomConnectorRuntime,
   encryptedSecrets: string,
@@ -9656,9 +9674,12 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
-    await connectors.connectManualGrant(actor, "gitlab", "api-token", {
-      accessToken: "glpat-bdd",
-    });
+    const gitlabConnection = await connectors.connectManualGrant(
+      actor,
+      "gitlab",
+      "api-token",
+      { accessToken: "glpat-bdd" },
+    );
     await api.enableAgentConnectors(actor, agentId, ["gitlab"]);
 
     const withoutHost = await api.createRun(actor, {
@@ -9677,10 +9698,17 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     });
 
     // Reconnecting with the optional variable threads it into the next run.
-    await connectors.connectManualGrant(actor, "gitlab", "api-token", {
-      accessToken: "glpat-bdd",
-      host: "gitlab.example.com",
-    });
+    await connectors.connectManualGrant(
+      actor,
+      "gitlab",
+      "api-token",
+      {
+        accessToken: "glpat-bdd",
+        host: "gitlab.example.com",
+      },
+      undefined,
+      { intent: "reconnect", connectionId: gitlabConnection.id },
+    );
     const withHost = await api.createRun(actor, {
       agentId,
       prompt: "use gitlab with the optional host",
@@ -11064,6 +11092,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       { key: "secret", kind: "secret", value: "custom-secret-value" },
       { key: "tenant", kind: "variable", value: "acme" },
     ]);
+    const customConnectionId = await defaultCustomConnectorAccountId(
+      connectors,
+      actor,
+      custom.id,
+    );
     const wrongTargetConnection = await connectors.connectManualGrant(
       actor,
       "figma",
@@ -11208,6 +11241,8 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       actor,
       custom.id,
       "updated-custom-secret-value",
+      [200],
+      { intent: "reconnect", connectionId: customConnectionId },
     );
     const currentUpdatedAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
@@ -11265,6 +11300,8 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       actor,
       custom.id,
       "recovered-custom-secret-value",
+      [200],
+      { intent: "reconnect", connectionId: customConnectionId },
     );
     const recoveredAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
@@ -11328,14 +11365,19 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       code: "CONNECTOR_NOT_CONFIGURED",
     });
 
-    await connectors.setCustomConnectorValues(actor, custom.id, [
-      {
-        key: "secret",
-        kind: "secret",
-        value: "restored-custom-secret-value",
-      },
-      { key: "tenant", kind: "variable", value: "changed" },
-    ]);
+    await connectors.setCustomConnectorValues(
+      actor,
+      custom.id,
+      [
+        {
+          key: "secret",
+          kind: "secret",
+          value: "restored-custom-secret-value",
+        },
+        { key: "tenant", kind: "variable", value: "changed" },
+      ],
+      { intent: "reconnect", connectionId: customConnectionId },
+    );
     const restoredCredentialsAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       missingCredentialsAuthBody,
@@ -11522,7 +11564,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       code: "CONNECTOR_NOT_CONFIGURED",
     });
 
-    await connectors.disconnectSingleCustomConnectorAccount(actor, custom.id);
+    await connectors.deleteDefaultCustomConnectorAccount(actor, custom.id);
     const [deletedExactRuntime] = await api.syncConnectorRuntime(run.runId, {
       targets: [target],
     });
@@ -12022,6 +12064,11 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       userId: actor.userId,
       customConnectors: [runtimeConnector],
     });
+    const runtimeConnectionId = await defaultCustomConnectorAccountId(
+      connectors,
+      actor,
+      runtimeConnector.id,
+    );
     const listedRuntimeConnectors =
       await connectors.listCustomConnectors(actor);
     expect(
@@ -12040,13 +12087,18 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await connectors.updateAgentCustomConnectors(actor, agentId, [
       runtimeConnector.id,
     ]);
-    await connectors.setCustomConnectorValues(actor, runtimeConnector.id, [
-      {
-        key: "optional_secret",
-        kind: "secret",
-        value: "canonical-runtime-secret",
-      },
-    ]);
+    await connectors.setCustomConnectorValues(
+      actor,
+      runtimeConnector.id,
+      [
+        {
+          key: "optional_secret",
+          kind: "secret",
+          value: "canonical-runtime-secret",
+        },
+      ],
+      { intent: "reconnect", connectionId: runtimeConnectionId },
+    );
 
     const run = await api.createRun(actor, {
       agentId,
@@ -13387,10 +13439,22 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(kms.decryptCalls).toBe(1);
 
     context.mocks.ably.publish.mockClear();
-    await connectors.setCustomConnectorValues(actor, saved.connector.id, [
-      { key: "subdomain", kind: "variable", value: "later-run" },
-      { key: "scope", kind: "variable", value: "later-scope" },
-    ]);
+    await connectors.setCustomConnectorValues(
+      actor,
+      saved.connector.id,
+      [
+        { key: "subdomain", kind: "variable", value: "later-run" },
+        { key: "scope", kind: "variable", value: "later-scope" },
+      ],
+      {
+        intent: "reconnect",
+        connectionId: await defaultCustomConnectorAccountId(
+          connectors,
+          actor,
+          saved.connector.id,
+        ),
+      },
+    );
     expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
       "connector-runtime-sync",
       expect.anything(),
@@ -13568,8 +13632,12 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       tenant: `\${{ secrets.${tenantVarKey} }}`,
     });
 
+    const runtimeTarget = customConnectorRuntimeRegistration(
+      claim,
+      saved.connector.id,
+    );
     const [runtimeResult] = await api.syncConnectorRuntime(run.runId, {
-      targets: [customConnectorRuntimeRegistration(claim, saved.connector.id)],
+      targets: [runtimeTarget],
     });
     const runtime = availableCustomConnectorRuntime(runtimeResult);
     const { api: runtimeApi, body: runtimeAuthBody } =
@@ -13592,13 +13660,25 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     }
     expect(missingHeaderAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
 
-    await connectors.setCustomConnectorValues(actor, saved.connector.id, [
+    await connectors.setCustomConnectorValues(
+      actor,
+      saved.connector.id,
+      [
+        {
+          key: "secondary_token",
+          kind: "secret",
+          value: "optional-secondary",
+        },
+      ],
       {
-        key: "secondary_token",
-        kind: "secret",
-        value: "optional-secondary",
+        intent: "reconnect",
+        connectionId: await defaultCustomConnectorAccountId(
+          connectors,
+          actor,
+          saved.connector.id,
+        ),
       },
-    ]);
+    );
     const restoredAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       runtimeAuthBody,
@@ -13862,6 +13942,14 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
           value: "rewritten-reconnect-required-secret",
         },
       ],
+      {
+        intent: "reconnect",
+        connectionId: await defaultCustomConnectorAccountId(
+          connectors,
+          actor,
+          saved.connector.id,
+        ),
+      },
     );
     expect(reconnected).toMatchObject({ connected: true });
     await expect(
@@ -13929,7 +14017,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       ],
       agentId,
     });
-    await connectors.disconnectSingleCustomConnectorAccount(
+    await connectors.deleteDefaultCustomConnectorAccount(
       actor,
       saved.connector.id,
     );
@@ -13968,10 +14056,17 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, incompleteRun.runId, [200]);
 
     const longSubdomain = "a".repeat(55);
-    await connectors.setCustomConnectorValues(actor, saved.connector.id, [
-      { key: "api_key", kind: "secret", value: "recovered-key" },
-      { key: "subdomain", kind: "variable", value: longSubdomain },
-    ]);
+    const recoveredConnection = await connectors.setCustomConnectorValues(
+      actor,
+      saved.connector.id,
+      [
+        { key: "api_key", kind: "secret", value: "recovered-key" },
+        { key: "subdomain", kind: "variable", value: longSubdomain },
+      ],
+    );
+    if (!recoveredConnection.connectedAccountId) {
+      throw new Error("Expected the recovered custom connector account");
+    }
 
     const fixedPrefix = "very-long-fixed-prefix-for-custom-runtime-";
     await connectors.updateCustomConnector(actor, saved.connector.id, {
@@ -14005,9 +14100,15 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     await api.requestCancelRun(actor, unroutableRun.runId, [200]);
 
-    await connectors.setCustomConnectorValues(actor, saved.connector.id, [
-      { key: "subdomain", kind: "variable", value: "version-two" },
-    ]);
+    await connectors.setCustomConnectorValues(
+      actor,
+      saved.connector.id,
+      [{ key: "subdomain", kind: "variable", value: "version-two" }],
+      {
+        intent: "reconnect",
+        connectionId: recoveredConnection.connectedAccountId,
+      },
+    );
 
     const recoveredRun = await api.createRun(actor, {
       agentId,
@@ -14120,13 +14221,25 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     }
     expect(missingQueryAuth.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
 
-    await connectors.setCustomConnectorValues(actor, saved.connector.id, [
+    await connectors.setCustomConnectorValues(
+      actor,
+      saved.connector.id,
+      [
+        {
+          key: "tenant",
+          kind: "variable",
+          value: "restored-tenant",
+        },
+      ],
       {
-        key: "tenant",
-        kind: "variable",
-        value: "restored-tenant",
+        intent: "reconnect",
+        connectionId: await defaultCustomConnectorAccountId(
+          connectors,
+          actor,
+          saved.connector.id,
+        ),
       },
-    ]);
+    );
     const restoredAuth = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       runtimeAuthBody,

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-automation-events.test.ts
@@ -1117,7 +1117,7 @@ describe("Stripe automation event webhook", () => {
       EXECUTED_EXECUTION,
     );
 
-    await connectors.disconnectSingleBuiltinConnectorAccount(
+    await connectors.deleteDefaultBuiltinConnectorAccount(
       scenario.actor,
       "stripe",
     );
@@ -1580,23 +1580,6 @@ describe("Stripe automation event webhook", () => {
       expect(result.inputEvents).toHaveLength(0);
     });
 
-    it("when the connected account changes", async () => {
-      const { scenario } =
-        await setupPendingLifecycleDelivery("changed_account");
-      const changed = await connectStripeOAuth(
-        scenario.actor,
-        `acct_stripe_changed_${randomUUID()}`,
-      );
-      expect(changed.id).toBe(scenario.connector.id);
-      const result = await executeLifecycleDelivery(scenario);
-      expect(result.execution).toStrictEqual(TERMINALLY_SKIPPED_EXECUTION);
-      expect((await readStripeAutomation(scenario)).health).toMatchObject({
-        lastDeliveryStatus: "skipped",
-        warning: null,
-      });
-      expect(result.inputEvents).toHaveLength(0);
-    });
-
     it("when the thread account selection changes", async () => {
       const { scenario } =
         await setupPendingLifecycleDelivery("thread_selection");
@@ -1634,12 +1617,12 @@ describe("Stripe automation event webhook", () => {
     it("when the connection changes from live mode to test mode", async () => {
       const { accountId, scenario } =
         await setupPendingLifecycleDelivery("test_mode");
-      const testConnection = await connectStripeOAuth(
+      await reconnectStripeOAuthAccount(
         scenario.actor,
+        scenario.connector.id,
         accountId,
         false,
       );
-      expect(testConnection.id).toBe(scenario.connector.id);
       const result = await executeLifecycleDelivery(scenario);
       expect(result.execution).toStrictEqual(TERMINALLY_SKIPPED_EXECUTION);
       expect((await readStripeAutomation(scenario)).health).toMatchObject({
@@ -1652,7 +1635,7 @@ describe("Stripe automation event webhook", () => {
     it("when the connector is deleted", async () => {
       const { scenario } =
         await setupPendingLifecycleDelivery("deleted_connector");
-      await connectors.disconnectSingleBuiltinConnectorAccount(
+      await connectors.deleteDefaultBuiltinConnectorAccount(
         scenario.actor,
         "stripe",
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/stripe-invoice-paid-workflow-automation-readiness.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/stripe-invoice-paid-workflow-automation-readiness.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
+import type { ConnectorAccountMutationIntent } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   testStripeInvoicePaidFixtureContract,
   type TestStripeInvoicePaidFixtureState,
@@ -37,6 +38,7 @@ interface StripeAutomationScenario {
 }
 
 interface StripeOAuthOptions {
+  readonly account?: ConnectorAccountMutationIntent;
   readonly accountId?: string;
   readonly accessToken?: string;
   readonly code?: string;
@@ -143,7 +145,13 @@ async function connectStripeOAuth(
       : { accessToken: options.accessToken }),
     ...(options.livemode === undefined ? {} : { livemode: options.livemode }),
   });
-  const started = await connectors.startOauth(actor, "stripe", "oauth");
+  const started = await connectors.startOauth(
+    actor,
+    "stripe",
+    "oauth",
+    undefined,
+    options.account,
+  );
   const state = new URL(started.authorizationUrl).searchParams.get("state");
   if (!state) {
     throw new Error("Expected Stripe OAuth state");
@@ -429,6 +437,10 @@ describe("Stripe invoice-paid workflow automation readiness", () => {
       [201],
     );
     const reconnected = await connectStripeOAuth(scenario.actor, {
+      account: {
+        intent: "reconnect",
+        connectionId: initial.connector.id,
+      },
       accountId: STRIPE_ACCOUNT_ID,
       livemode: true,
       code: "stripe-same-account-reconnect",
@@ -453,7 +465,22 @@ describe("Stripe invoice-paid workflow automation readiness", () => {
       accountId: "acct_different_workflow",
       livemode: true,
     });
+    const accounts = await connectors.listBuiltinConnectorAccounts(
+      scenario.actor,
+      "stripe",
+    );
+    const replacement = accounts.find((account) => {
+      return account.externalId === "acct_different_workflow";
+    });
+    if (!replacement) {
+      throw new Error("Expected the replacement Stripe account");
+    }
     expect(reconnected.connector.id).toBe(initial.connector.id);
+    await connectors.deleteBuiltinConnectorAccount(
+      scenario.actor,
+      "stripe",
+      initial.connector.id,
+    );
 
     const enabled = await accept(
       enableStripeAutomationRequest(scenario, created.body.id),
@@ -462,7 +489,7 @@ describe("Stripe invoice-paid workflow automation readiness", () => {
     expect(enabled.body).toMatchObject({
       enabled: true,
       eventConfig: {
-        connectorId: initial.connector.id,
+        connectorId: replacement.id,
         stripeAccountId: "acct_different_workflow",
         mode: "live",
       },
@@ -477,6 +504,10 @@ describe("Stripe invoice-paid workflow automation readiness", () => {
       [201],
     );
     const reconnected = await connectStripeOAuth(scenario.actor, {
+      account: {
+        intent: "reconnect",
+        connectionId: initial.connector.id,
+      },
       accountId: STRIPE_ACCOUNT_ID,
       livemode: false,
     });
@@ -496,7 +527,7 @@ describe("Stripe invoice-paid workflow automation readiness", () => {
       createStripeAutomationRequest(scenario),
       [201],
     );
-    await connectors.disconnectSingleBuiltinConnectorAccount(
+    await connectors.deleteDefaultBuiltinConnectorAccount(
       scenario.actor,
       "stripe",
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -372,7 +372,7 @@ describe("FW-2: template resolution without connector refresh", () => {
       "X-Email": "current@example.test",
     });
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(actor, "jira");
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(actor, "jira");
     const disconnected = await fw.requestFirewallAuth(headers, body, [424]);
     if (disconnected.status !== 424) {
       throw new Error("Expected disconnected builtin connector auth to fail");
@@ -1292,7 +1292,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       "X-AWS-Session-Token": oldCredentials.sessionToken,
     });
 
-    await connectors.disconnectSingleBuiltinConnectorAccount(actor, "aws");
+    await connectors.deleteDefaultBuiltinConnectorAccount(actor, "aws");
   });
 
   it("classifies invalid_grant refresh failures as reconnect-required and recovers", async () => {
@@ -2202,6 +2202,7 @@ describe("FW-7: client-unconfigured and mixed-reason refresh failures", () => {
 describe("FW-8: static access tokens and unavailable sources", () => {
   it("requires reconnect for expired static tokens and syncs current ones", async () => {
     const fw = createFirewallApi(context);
+    const connectors = createConnectorBddApi(context);
     const { actor, headers } = await firewallRun();
     await fw.seedTestConnector(actor, {
       connectorSlug: "test-oauth-device",
@@ -2227,13 +2228,32 @@ describe("FW-8: static access tokens and unavailable sources", () => {
     expect(expired.body.error.failureReason).toBe("reconnect_required");
     expect(expired.body.error.connectors).toStrictEqual(["test-oauth-device"]);
 
+    const [expiredAccount] = await connectors.listBuiltinConnectorAccounts(
+      actor,
+      "test-oauth-device",
+    );
+    if (!expiredAccount) {
+      throw new Error("Expected the expired device account");
+    }
+    await connectors.deleteBuiltinConnectorAccount(
+      actor,
+      "test-oauth-device",
+      expiredAccount.id,
+    );
+
     await fw.seedTestConnector(actor, {
       connectorSlug: "test-oauth-device",
       authMethod: "oauth",
       accessToken: "current-device",
       expiresIn: 3600,
     });
-    const synced = await fw.requestFirewallAuth(headers, body, [200]);
+    const currentBody = {
+      ...body,
+      ...(await exactSecretConnectorSources(actor, {
+        TEST_OAUTH_DEVICE_TOKEN: "test-oauth-device",
+      })),
+    };
+    const synced = await fw.requestFirewallAuth(headers, currentBody, [200]);
     if (synced.status !== 200) {
       throw new Error("Expected current static token to resolve");
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -552,11 +552,20 @@ async function connectGmail(
     code: "gmail-code",
     state,
   });
-  const connector = await connectorsApi.readConnectorBySlug(actor, "gmail");
+  const connector = (
+    await connectorsApi.listBuiltinConnectorAccounts(actor, "gmail")
+  ).find((candidate) => {
+    return account?.intent === "reconnect"
+      ? candidate.id === account.connectionId
+      : candidate.externalId === subject;
+  });
+  if (!connector) {
+    throw new Error("Expected the connected Gmail account");
+  }
   expect(connector).toMatchObject({
     authMethod: "oauth",
     externalEmail: gmailEmail,
-    slug: "gmail",
+    target: { kind: "builtin", connectorSlug: "gmail" },
   });
   return connector.id;
 }
@@ -790,7 +799,7 @@ async function completeRunThroughSandbox(
 }
 
 describe("POST /api/webhooks/gmail", () => {
-  it("invalidates Gmail label ids when OAuth replaces the connector identity", async () => {
+  it("invalidates Gmail label ids when the selected account is replaced", async () => {
     configureGmailEnv();
     configureGmailWatchMock();
     configureGmailLabelsMockSequence([
@@ -823,15 +832,17 @@ describe("POST /api/webhooks/gmail", () => {
       eventConfig: { resolvedLabelId: "Label_old_account" },
     });
 
-    await connectGmail(actor, uniqueGmailEmail(), "gmail-label-account-two");
-    const replacementConnection = await connectorsApi.readConnectorBySlug(
+    const replacementConnectionId = await connectGmail(
+      actor,
+      uniqueGmailEmail(),
+      "gmail-label-account-two",
+    );
+    expect(replacementConnectionId).not.toBe(initialConnection.id);
+    await connectorsApi.deleteBuiltinConnectorAccount(
       actor,
       "gmail",
+      initialConnection.id,
     );
-    expect(replacementConnection).toMatchObject({
-      id: initialConnection.id,
-      externalId: "gmail-label-account-two",
-    });
     const updated = await readAutomation(actor, created.body.id);
     if (
       updated.kind !== "event" ||
@@ -842,7 +853,7 @@ describe("POST /api/webhooks/gmail", () => {
     expect(updated.eventConfig).not.toHaveProperty("resolvedLabelId");
   });
 
-  it("rejects an in-flight Gmail event after the connector identity changes", async () => {
+  it("rejects an in-flight Gmail event after the selected account is removed", async () => {
     const oldEmail = uniqueGmailEmail();
     const newEmail = uniqueGmailEmail();
     configureGmailEnv();
@@ -876,7 +887,11 @@ describe("POST /api/webhooks/gmail", () => {
     );
 
     const { actor, workflowId } = await setupFixture();
-    await connectGmail(actor, oldEmail, "gmail-race-account-one");
+    const initialConnectionId = await connectGmail(
+      actor,
+      oldEmail,
+      "gmail-race-account-one",
+    );
     await configureWorkspaceModelProvider(actor);
     const created = await accept(
       automationsClient().create({
@@ -906,6 +921,11 @@ describe("POST /api/webhooks/gmail", () => {
     );
     await labelLookupStarted.promise;
     await connectGmail(actor, newEmail, "gmail-race-account-two");
+    await connectorsApi.deleteBuiltinConnectorAccount(
+      actor,
+      "gmail",
+      initialConnectionId,
+    );
     releaseLabelLookup.resolve();
 
     const response = await webhookRequest;
@@ -929,7 +949,7 @@ describe("POST /api/webhooks/gmail", () => {
     );
   });
 
-  it("keeps same-account watch state and drops it when reconnect changes accounts", async () => {
+  it("keeps same-account watch state and drops it when the account switches", async () => {
     const gmailEmail = uniqueGmailEmail();
     configureGmailEnv();
     const watch = configureGmailWatchMock();
@@ -983,15 +1003,17 @@ describe("POST /api/webhooks/gmail", () => {
     expectResponseStatus(sameAccountEvent, 200);
     expect(sameAccountEvent.body).toMatchObject({ watchStates: 1 });
 
-    await connectGmail(actor, `replacement-${gmailEmail}`, "gmail-account-two");
-    const replacementConnection = await connectorsApi.readConnectorBySlug(
+    const replacementConnectionId = await connectGmail(
+      actor,
+      `replacement-${gmailEmail}`,
+      "gmail-account-two",
+    );
+    expect(replacementConnectionId).not.toBe(initialConnection.id);
+    await connectorsApi.deleteBuiltinConnectorAccount(
       actor,
       "gmail",
+      initialConnection.id,
     );
-    expect(replacementConnection).toMatchObject({
-      id: initialConnection.id,
-      externalId: "gmail-account-two",
-    });
     const oldAccountEvent = await postGmailWebhook(
       gmailPushBody({
         emailAddress: renamedGmailEmail,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-calendar.test.ts
@@ -1025,7 +1025,7 @@ describe("POST /api/webhooks/google-calendar", () => {
     ).resolves.toMatchObject({ status: 401 });
   });
 
-  it("replaces Calendar principal state and stops the captured old channel", async () => {
+  it("switches Calendar principal accounts and stops the captured old channel", async () => {
     const firstAccessToken = "calendar-principal-first-token";
     const refreshedAccessToken = "calendar-principal-refreshed-token";
     const replacementAccessToken = "calendar-principal-replacement-token";
@@ -1092,12 +1092,29 @@ describe("POST /api/webhooks/google-calendar", () => {
     });
     await wf.connectConnector(scenario.actor, "google-calendar");
 
+    const replacementAccount = (
+      await connectorsApi.listBuiltinConnectorAccounts(
+        scenario.actor,
+        "google-calendar",
+      )
+    ).find((account) => {
+      return account.externalId === "calendar-principal-replacement-subject";
+    });
+    if (!replacementAccount) {
+      throw new Error("Expected the replacement Calendar account");
+    }
+    await connectorsApi.deleteBuiltinConnectorAccount(
+      scenario.actor,
+      "google-calendar",
+      initialConnection.id,
+    );
+
     const replacementConnection = await connectorsApi.readConnectorBySlug(
       scenario.actor,
       "google-calendar",
     );
     expect(replacementConnection).toMatchObject({
-      id: initialConnection.id,
+      id: replacementAccount.id,
       externalId: "calendar-principal-replacement-subject",
     });
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-google-forms.test.ts
@@ -1050,7 +1050,7 @@ describe("Google Forms Pub/Sub webhook", () => {
       "google-forms",
       "oauth",
       agentId,
-      { intent: "single-account" },
+      { intent: "add" },
     );
     const replaceState = new URL(
       replaceOauth.authorizationUrl,
@@ -1066,17 +1066,40 @@ describe("Google Forms Pub/Sub webhook", () => {
       actor,
       "google-forms",
     );
-    expect(replacedAccounts).toStrictEqual([
-      expect.objectContaining({
-        id: firstConnector.id,
-        externalEmail: "bdd-google-forms-replaced@example.test",
+    const replacementAccount = replacedAccounts.find((account) => {
+      return account.externalEmail === "bdd-google-forms-replaced@example.test";
+    });
+    if (!replacementAccount) {
+      throw new Error("Expected the replacement Google Forms account");
+    }
+    expect(replacementAccount.id).not.toBe(firstConnector.id);
+    expect(replacedAccounts).toHaveLength(2);
+    expect(formsApi.watchIds).toHaveLength(2);
+
+    const deletedFirst = await accept(
+      connectorAccountsClient().delete({
+        headers: authHeaders(),
+        params: { connectionId: firstConnector.id },
+        body: {
+          target: { kind: "builtin", connectorSlug: "google-forms" },
+        },
       }),
-    ]);
+      [200],
+    );
+    expect(deletedFirst.body).toStrictEqual({
+      deletedConnectionId: firstConnector.id,
+      resolvedSelectionCount: 0,
+      promotedDefaultConnectionId: replacementAccount.id,
+    });
     expect(formsApi.watchIds).toHaveLength(3);
     const replacementWatchId = formsApi.watchIds[2];
     if (!replacementWatchId) {
       throw new Error("Expected a replacement Google Forms watch");
     }
+    expect(formsApi.stoppedWatchIds).toStrictEqual([
+      secondWatchId,
+      firstWatchId,
+    ]);
     const replacedAccountPush = await postWebhook(
       formsPushBody("pubsub-replaced-account", firstWatchId),
     );
@@ -1088,7 +1111,7 @@ describe("Google Forms Pub/Sub webhook", () => {
     const deletedLast = await accept(
       connectorAccountsClient().delete({
         headers: authHeaders(),
-        params: { connectionId: firstConnector.id },
+        params: { connectionId: replacementAccount.id },
         body: {
           target: { kind: "builtin", connectorSlug: "google-forms" },
         },
@@ -1096,12 +1119,13 @@ describe("Google Forms Pub/Sub webhook", () => {
       [200],
     );
     expect(deletedLast.body).toStrictEqual({
-      deletedConnectionId: firstConnector.id,
+      deletedConnectionId: replacementAccount.id,
       resolvedSelectionCount: 0,
       promotedDefaultConnectionId: null,
     });
     expect(formsApi.stoppedWatchIds).toStrictEqual([
       secondWatchId,
+      firstWatchId,
       replacementWatchId,
     ]);
     const removedLastAccountPush = await postWebhook(

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -2107,7 +2107,7 @@ describe("okou workflow automations", () => {
       ),
     );
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       scenario.actor,
       "google-forms",
     );
@@ -3322,7 +3322,7 @@ describe("okou workflow automations", () => {
           return;
         }
         deleteConnector = false;
-        await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+        await connectorsApi.deleteDefaultBuiltinConnectorAccount(
           scenario.actor,
           "google-calendar",
         );
@@ -3536,7 +3536,7 @@ describe("okou workflow automations", () => {
       }),
       [201],
     );
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       scenario.actor,
       "google-calendar",
     );
@@ -4171,7 +4171,7 @@ describe("okou workflow automations", () => {
       [201],
     );
 
-    await connectorsApi.disconnectSingleBuiltinConnectorAccount(
+    await connectorsApi.deleteDefaultBuiltinConnectorAccount(
       scenario.actor,
       "gmail",
     );

--- a/turbo/apps/api/src/signals/routes/cli-auth-test.ts
+++ b/turbo/apps/api/src/signals/routes/cli-auth-test.ts
@@ -311,6 +311,7 @@ const createTestConnector$ = command(
         userId,
         runtimeMethod: resolved.runtimeMethod,
         snapshot: resolved.snapshot,
+        account: { intent: "add" },
         outputs: testConnectorTokenOutputs({
           connectorSlug,
           authMethodId: authMethod,

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -5,7 +5,7 @@ import {
   type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
 
-import { badRequestMessage, conflict, notFound } from "../../lib/error";
+import { badRequestMessage, notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
@@ -339,14 +339,8 @@ const deleteInner$ = command(
             signal,
           );
     signal.throwIfAborted();
-    if (typeof result === "string") {
-      if (result === "missing") {
-        return notFound("Connector account not found");
-      }
-      if (result === "ambiguous") {
-        return conflict("Multiple connector accounts require an exact choice");
-      }
-      throw new Error("Exact connector account deletion returned no result");
+    if (result === "missing") {
+      return notFound("Connector account not found");
     }
     if (result.kind === "missing" || result.kind === "managed") {
       return notFound("Connector account not found");

--- a/turbo/apps/api/src/signals/routes/connector-accounts.ts
+++ b/turbo/apps/api/src/signals/routes/connector-accounts.ts
@@ -6,7 +6,6 @@ import {
 } from "@okouai/api-contracts/contracts/connector-accounts";
 
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
-import { logger } from "../../lib/log";
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
@@ -27,17 +26,11 @@ import {
   connectorScopeDiff,
   deleteConnectorLocalState$,
 } from "../services/connector-data.service";
-import {
-  deleteCustomConnectorAccount$,
-  disconnectCustomConnector$,
-  integrationManagedCustomConnectorMutationForbidden,
-} from "../services/custom-connector.service";
+import { deleteCustomConnectorAccount$ } from "../services/custom-connector.service";
 import { reconcileGmailWatchesForUser } from "../services/gmail-automation-event.service";
 import { reconcileGoogleCalendarWatchesForUser } from "../services/google-calendar-automation-event.service";
 import { reconcileGoogleFormsWatchesForUser } from "../services/google-forms-automation-event.service";
 import { reconcileGoogleMeetSubscriptionsForUser } from "../services/google-meet-automation-event.service";
-
-const log = logger("api:connector-account-mutation");
 
 function targetFromQuery(
   query: ConnectorAccountTarget,
@@ -305,127 +298,6 @@ const deletionImpactInner$ = computed(async (get) => {
   };
 });
 
-type SingleAccountDisconnectOutcome =
-  | "missing"
-  | "ambiguous"
-  | "managed"
-  | "deleted";
-
-function observeSingleAccountDisconnect(args: {
-  readonly targetKind: ConnectorAccountTarget["kind"];
-  readonly outcome: SingleAccountDisconnectOutcome;
-  readonly accountCardinality?: "zero" | "one" | "multiple";
-}): void {
-  log.debug("Resolved single-account connector disconnect", {
-    targetKind: args.targetKind,
-    outcome: args.outcome,
-    ...(args.accountCardinality
-      ? { accountCardinality: args.accountCardinality }
-      : {}),
-  });
-}
-
-const disconnectSingleAccountInner$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
-    const auth = get(organizationAuthContext$);
-    const body = await get(
-      bodyResultOf(connectorAccountsContract.disconnectSingleAccount),
-    );
-    signal.throwIfAborted();
-    if (!body.ok) {
-      return body.response;
-    }
-
-    if (body.data.target.kind === "builtin") {
-      const result = await set(
-        deleteConnectorLocalState$,
-        {
-          orgId: auth.orgId,
-          userId: auth.userId,
-          connectorSlug: body.data.target.connectorSlug,
-        },
-        signal,
-      );
-      signal.throwIfAborted();
-      if (result === "deleted") {
-        observeSingleAccountDisconnect({
-          targetKind: "builtin",
-          outcome: "deleted",
-          accountCardinality: "one",
-        });
-        return { status: 204 as const, body: undefined };
-      }
-      if (result === "missing") {
-        observeSingleAccountDisconnect({
-          targetKind: "builtin",
-          outcome: "missing",
-          accountCardinality: "zero",
-        });
-        return notFound("Connector account not found");
-      }
-      if (result === "ambiguous") {
-        observeSingleAccountDisconnect({
-          targetKind: "builtin",
-          outcome: "ambiguous",
-          accountCardinality: "multiple",
-        });
-        return conflict("Multiple connector accounts require an exact choice");
-      }
-      throw new Error(
-        "Single-account built-in deletion returned an exact-account result",
-      );
-    }
-
-    const result = await set(
-      disconnectCustomConnector$,
-      {
-        orgId: auth.orgId,
-        userId: auth.userId,
-        connectorId: body.data.target.customConnectorId,
-        requireAccount: true,
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-    if (result === "deleted") {
-      observeSingleAccountDisconnect({
-        targetKind: "custom",
-        outcome: "deleted",
-        accountCardinality: "one",
-      });
-      return { status: 204 as const, body: undefined };
-    }
-    if (result === "missing-account") {
-      observeSingleAccountDisconnect({
-        targetKind: "custom",
-        outcome: "missing",
-        accountCardinality: "zero",
-      });
-      return notFound("Connector account not found");
-    }
-    if (result === "missing-definition") {
-      observeSingleAccountDisconnect({
-        targetKind: "custom",
-        outcome: "missing",
-      });
-      return notFound("Connector target not found");
-    }
-    if (result === "ambiguous") {
-      observeSingleAccountDisconnect({
-        targetKind: "custom",
-        outcome: "ambiguous",
-        accountCardinality: "multiple",
-      });
-      return conflict("Multiple connector accounts require an exact choice");
-    }
-    observeSingleAccountDisconnect({
-      targetKind: "custom",
-      outcome: "managed",
-    });
-    return integrationManagedCustomConnectorMutationForbidden();
-  },
-);
-
 const deleteInner$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
     const auth = get(organizationAuthContext$);
@@ -534,10 +406,6 @@ export const connectorAccountRoutes: readonly RouteEntry[] = [
   {
     route: connectorAccountsContract.deletionImpact,
     handler: authRoute(readAuth, deletionImpactInner$),
-  },
-  {
-    route: connectorAccountsContract.disconnectSingleAccount,
-    handler: authRoute(writeAuth, disconnectSingleAccountInner$),
   },
   {
     route: connectorAccountsContract.delete,

--- a/turbo/apps/api/src/signals/routes/connectors.ts
+++ b/turbo/apps/api/src/signals/routes/connectors.ts
@@ -9,11 +9,6 @@ import {
   connectorsMainContract,
   connectorsSearchContract,
 } from "@okouai/api-contracts/contracts/connectors";
-import {
-  CLIENT_FORCE_UPGRADE_STATUS,
-  CLIENT_TYPE_CLI,
-  CLIENT_TYPE_HEADER,
-} from "@okouai/api-contracts/contracts/client-headers";
 import type { PublicConnectorCatalogDetail } from "@okouai/api-contracts/contracts/connector-catalog";
 import { connectorGrantScopes } from "@okouai/connectors/connector-auth-method";
 
@@ -262,21 +257,6 @@ const connectManualGrantConnectorInner$ = command(
     signal.throwIfAborted();
     if (!bodyResult.ok) {
       return bodyResult.response;
-    }
-    if (
-      get(request$).header(CLIENT_TYPE_HEADER) === CLIENT_TYPE_CLI &&
-      (!bodyResult.data.account ||
-        bodyResult.data.account.intent === "single-account")
-    ) {
-      return {
-        status: CLIENT_FORCE_UPGRADE_STATUS,
-        body: {
-          error: {
-            message: "Update the CLI to connect this connector",
-            code: "CLI_CONNECTOR_ACCOUNT_INTENT_RETIRED",
-          },
-        },
-      };
     }
     const agentTarget = await set(
       validateConnectorAuthorizationTarget$,

--- a/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-connector-credential-storage-state.ts
@@ -515,7 +515,7 @@ async function seedCustomOAuthStateContext(
     orgId: body.org_id,
     redirectUri: body.redirect_uri,
     oauthContext: JSON.stringify(body.oauth_context),
-    accountMutation: { intent: "single-account" },
+    accountMutation: { intent: "add" },
     expiresAt: connectorOAuthStateExpiresAt(),
   });
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/test-cron-delete-cleanups-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-delete-cleanups-state.ts
@@ -120,7 +120,7 @@ async function seedConnectorStates(
         userId: body.marker,
         orgId: body.marker,
         redirectUri: "https://example.test/oauth/callback",
-        accountMutation: { intent: "single-account" as const },
+        accountMutation: { intent: "add" as const },
         expiresAt: new Date(expiredStart + index),
       };
     },
@@ -137,7 +137,7 @@ async function seedConnectorStates(
       userId: body.marker,
       orgId: body.marker,
       redirectUri: "https://example.test/oauth/callback",
-      accountMutation: { intent: "single-account" },
+      accountMutation: { intent: "add" },
       expiresAt: cutoff,
     },
     {
@@ -147,7 +147,7 @@ async function seedConnectorStates(
       userId: body.marker,
       orgId: body.marker,
       redirectUri: "https://example.test/oauth/callback",
-      accountMutation: { intent: "single-account" },
+      accountMutation: { intent: "add" },
       expiresAt: new Date(cutoff.getTime() + 60 * 60_000),
     },
   ]);

--- a/turbo/apps/api/src/signals/services/connector-account-mutation.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-mutation.service.ts
@@ -1,7 +1,4 @@
-import {
-  connectorAccountMutationIntentSchema,
-  type ConnectorAccountMutationIntent,
-} from "@okouai/api-contracts/contracts/connector-accounts";
+import { connectorAccountMutationIntentSchema } from "@okouai/api-contracts/contracts/connector-accounts";
 import { sql, type SQLWrapper } from "drizzle-orm";
 
 import { zodDriverValueDecoder } from "../../lib/db-structured-result";
@@ -9,16 +6,6 @@ import { zodDriverValueDecoder } from "../../lib/db-structured-result";
 const storedConnectorAccountMutationDecoder = zodDriverValueDecoder(
   connectorAccountMutationIntentSchema,
 );
-
-export type ConnectorAccountMutation =
-  | { readonly intent: "target-only-client-singleton" }
-  | ConnectorAccountMutationIntent;
-
-export function normalizeConnectorAccountMutation(
-  intent: ConnectorAccountMutationIntent | undefined,
-): ConnectorAccountMutation {
-  return intent ?? { intent: "target-only-client-singleton" };
-}
 
 export function storedConnectorAccountMutationSelection(
   accountMutation: SQLWrapper,

--- a/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-account-resolution.service.ts
@@ -3,18 +3,8 @@ import {
   type ConnectorAccountTarget,
 } from "@okouai/api-contracts/contracts/connector-accounts";
 import { connectors } from "@okouai/db/schema/connector";
-import {
-  and,
-  eq,
-  inArray,
-  isNotNull,
-  lte,
-  or,
-  sql,
-  type SQL,
-} from "drizzle-orm";
+import { and, eq, inArray, isNotNull, or, type SQL } from "drizzle-orm";
 
-import { pgIntegerDecoder } from "../../lib/db-structured-result";
 import { logger } from "../../lib/log";
 import type { ReadonlyDb } from "../external/db";
 
@@ -22,8 +12,7 @@ const L = logger("connector-account-resolution");
 
 export type ConnectorAccountSelectionMode =
   | { readonly kind: "exact"; readonly sourceId: string }
-  | { readonly kind: "default" }
-  | { readonly kind: "target-only-client-singleton" };
+  | { readonly kind: "default" };
 
 export interface ConnectorAccountResolutionRequest {
   readonly target: ConnectorAccountTarget;
@@ -190,55 +179,6 @@ async function loadDefaultRows(
     );
 }
 
-async function loadTargetOnlyClientSingletonRows(
-  db: ReadonlyDb,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly requests: readonly ConnectorAccountResolutionRequest[];
-  },
-): Promise<readonly ConnectorAccountIdentityRow[]> {
-  const targets = args.requests.flatMap((request) => {
-    return request.selection.kind === "target-only-client-singleton"
-      ? [request.target]
-      : [];
-  });
-  if (targets.length === 0) {
-    return [];
-  }
-  const ranked = db.$with("target_only_connector_account_candidates").as(
-    db
-      .select({
-        ...identitySelection(),
-        selectionRank: sql`row_number() over (
-            partition by ${connectors.connectorSlug}, ${connectors.customConnectorId}
-            order by ${connectors.id}
-          )::integer`
-          .mapWith(pgIntegerDecoder)
-          .as("selection_rank"),
-      })
-      .from(connectors)
-      .where(
-        and(
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          targetCondition(targets),
-        ),
-      ),
-  );
-  return await db
-    .with(ranked)
-    .select({
-      authMethod: ranked.authMethod,
-      connectorId: ranked.connectorId,
-      connectorSlug: ranked.connectorSlug,
-      customConnectorId: ranked.customConnectorId,
-      storageVersion: ranked.storageVersion,
-    })
-    .from(ranked)
-    .where(lte(ranked.selectionRank, 2));
-}
-
 function rowsByTarget(
   rows: readonly ConnectorAccountIdentityRow[],
 ): ReadonlyMap<string, readonly ConnectorAccountIdentityRow[]> {
@@ -279,24 +219,16 @@ export async function resolveConnectorAccounts(
     return new Map();
   }
   const normalizedRequests = [...requests.values()];
-  const [exactRows, defaultRows, targetOnlyClientSingletonRows] =
-    await Promise.all([
-      loadExactRows(db, { ...args, requests: normalizedRequests }),
-      loadDefaultRows(db, { ...args, requests: normalizedRequests }),
-      loadTargetOnlyClientSingletonRows(db, {
-        ...args,
-        requests: normalizedRequests,
-      }),
-    ]);
+  const [exactRows, defaultRows] = await Promise.all([
+    loadExactRows(db, { ...args, requests: normalizedRequests }),
+    loadDefaultRows(db, { ...args, requests: normalizedRequests }),
+  ]);
   const exactById = new Map(
     exactRows.map((row) => {
       return [row.connectorId, row] as const;
     }),
   );
   const defaultByTarget = rowsByTarget(defaultRows);
-  const targetOnlyClientSingletonByTarget = rowsByTarget(
-    targetOnlyClientSingletonRows,
-  );
   const resolutions = new Map<string, ConnectorAccountResolution>();
   for (const [key, request] of requests) {
     if (request.selection.kind === "exact") {
@@ -312,17 +244,9 @@ export async function resolveConnectorAccounts(
       );
       continue;
     }
-    const rows =
-      request.selection.kind === "default"
-        ? defaultByTarget.get(key)
-        : targetOnlyClientSingletonByTarget.get(key);
+    const rows = defaultByTarget.get(key);
     if (!rows || rows.length === 0) {
-      resolutions.set(
-        key,
-        request.selection.kind === "default"
-          ? { kind: "missing-default" }
-          : { kind: "missing" },
-      );
+      resolutions.set(key, { kind: "missing-default" });
     } else if (rows.length > 1) {
       resolutions.set(key, { kind: "ambiguous" });
     } else {
@@ -372,11 +296,6 @@ export async function resolveConnectorAccounts(
     defaultRequestCount: normalizedRequests.filter((request) => {
       return request.selection.kind === "default";
     }).length,
-    targetOnlyClientSingletonRequestCount: normalizedRequests.filter(
-      (request) => {
-        return request.selection.kind === "target-only-client-singleton";
-      },
-    ).length,
     ...outcomeCounts,
   });
   return resolutions;

--- a/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-connection-write.service.ts
@@ -1,11 +1,13 @@
-import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/connector-accounts";
+import type {
+  ConnectorAccountMutationIntent,
+  ConnectorAccountTarget,
+} from "@okouai/api-contracts/contracts/connector-accounts";
 import { connectors } from "@okouai/db/schema/connector";
 import { and, eq, sql } from "drizzle-orm";
 
 import type { Tx } from "../../lib/db-types";
 import { logger } from "../../lib/log";
 import { deleteConnectorOwnedCredentialRows } from "./connector-credential-storage-write.service";
-import type { ConnectorAccountMutation } from "./connector-account-mutation.service";
 import { lockConnectorAccountTarget } from "./auth-state-lock.service";
 
 const log = logger("api:connector-account-mutation");
@@ -126,7 +128,7 @@ function connectorConnectionMutationOutcome(
 function observeConnectorConnectionMutation(
   args: {
     readonly targetKind: ConnectorAccountTarget["kind"];
-    readonly intent: ConnectorAccountMutation["intent"];
+    readonly intent: ConnectorAccountMutationIntent["intent"];
     readonly selectedCount: number;
   },
   resolution: ConnectorConnectionMutationResolution,
@@ -182,7 +184,7 @@ export async function resolveConnectorConnectionMutation(
     readonly orgId: string;
     readonly userId: string;
     readonly target: ConnectorAccountTarget;
-    readonly mutation: ConnectorAccountMutation;
+    readonly mutation: ConnectorAccountMutationIntent;
     readonly allowSiblings: boolean;
     readonly matchExternalId?: string;
   },
@@ -261,29 +263,17 @@ export async function resolveConnectorConnectionMutation(
     .for("update")
     .limit(2);
   let resolution: ConnectorConnectionMutationResolution;
-  if (args.mutation.intent === "add") {
-    if (existing.length > 0 && !args.allowSiblings) {
-      resolution = { kind: "sibling-disabled" };
-    } else {
-      resolution = {
-        kind: "ready",
-        mutation: {
-          kind: "insert",
-          displayName: args.mutation.displayName ?? null,
-          isDefault: existing.length === 0,
-        },
-      };
-    }
-  } else if (existing.length > 1) {
-    resolution = { kind: "ambiguous" };
+  if (existing.length > 0 && !args.allowSiblings) {
+    resolution = { kind: "sibling-disabled" };
   } else {
-    const [singleton] = existing;
-    resolution = singleton
-      ? { kind: "ready", mutation: { kind: "update", existing: singleton } }
-      : {
-          kind: "ready",
-          mutation: { kind: "insert", displayName: null, isDefault: true },
-        };
+    resolution = {
+      kind: "ready",
+      mutation: {
+        kind: "insert",
+        displayName: args.mutation.displayName ?? null,
+        isDefault: existing.length === 0,
+      },
+    };
   }
   return observeConnectorConnectionMutation(
     {

--- a/turbo/apps/api/src/signals/services/connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-data.service.ts
@@ -110,7 +110,6 @@ import {
   type ConnectorConnectionMutationResolution,
   type StoredConnectorConnectionRow as StoredConnectorRow,
 } from "./connector-connection-write.service";
-import { normalizeConnectorAccountMutation } from "./connector-account-mutation.service";
 import { reprojectWorkflowAutomationsForOwner } from "./workflow-automation-account-projection.service";
 
 const log = logger("api:connector-data");
@@ -906,7 +905,7 @@ async function reconcileAccountBoundAutomationWatches(
 }
 
 type ConnectorAccountForDeletion =
-  | { readonly kind: "missing" | "ambiguous" }
+  | { readonly kind: "missing" }
   | {
       readonly kind: "resolved";
       readonly connector: {
@@ -922,7 +921,7 @@ async function loadConnectorAccountForDeletion(
     readonly orgId: string;
     readonly userId: string;
     readonly connectorSlug: string;
-    readonly sourceId?: string;
+    readonly sourceId: string;
   },
   signal: AbortSignal,
 ): Promise<ConnectorAccountForDeletion> {
@@ -931,15 +930,10 @@ async function loadConnectorAccountForDeletion(
     userId: args.userId,
     request: {
       target: { kind: "builtin", connectorSlug: args.connectorSlug },
-      selection: args.sourceId
-        ? { kind: "exact", sourceId: args.sourceId }
-        : { kind: "target-only-client-singleton" },
+      selection: { kind: "exact", sourceId: args.sourceId },
     },
   });
   signal.throwIfAborted();
-  if (resolution.kind === "ambiguous") {
-    return { kind: "ambiguous" };
-  }
   if (resolution.kind !== "resolved") {
     return { kind: "missing" };
   }
@@ -980,22 +974,8 @@ async function prepareBuiltinConnectorAccountDeletion(
   );
 }
 
-function completedConnectorDeletionResult(
-  exactAccount: boolean,
-  deletion: {
-    readonly resolvedSelectionCount: number;
-    readonly promotedDefaultConnectionId: string | null;
-  },
-) {
-  return exactAccount
-    ? { kind: "deleted" as const, ...deletion }
-    : ("deleted" as const);
-}
-
 type DeleteConnectorLocalStateResult =
-  | "deleted"
   | "missing"
-  | "ambiguous"
   | {
       readonly kind: "deleted";
       readonly resolvedSelectionCount: number;
@@ -1006,7 +986,7 @@ interface DeleteConnectorLocalStateArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly connectorSlug: string;
-  readonly sourceId?: string;
+  readonly sourceId: string;
   readonly snapshot?: ConnectorRuntimeSnapshot | null;
 }
 
@@ -1330,10 +1310,12 @@ export const deleteConnectorLocalState$ = command(
     }
     signal.throwIfAborted();
 
-    return completedConnectorDeletionResult(
-      args.sourceId !== undefined,
-      deleteResult.deletion,
-    );
+    return {
+      kind: "deleted",
+      resolvedSelectionCount: deleteResult.deletion.resolvedSelectionCount,
+      promotedDefaultConnectionId:
+        deleteResult.deletion.promotedDefaultConnectionId,
+    };
   },
 );
 
@@ -1481,7 +1463,7 @@ async function commitManualGrantConnector(
     readonly userId: string;
     readonly runtimeMethod: ConnectorRuntimeMethod;
     readonly snapshot: ConnectorRuntimeSnapshot;
-    readonly account?: ConnectorAccountMutationIntent;
+    readonly account: ConnectorAccountMutationIntent;
     readonly prepared: PreparedManualGrantConnect;
     readonly encryptedSecrets: readonly EncryptedManualGrantSecret[];
     readonly featureSwitchContext: FeatureSwitchContext;
@@ -1502,7 +1484,7 @@ async function commitManualGrantConnector(
       kind: "builtin",
       connectorSlug: args.runtimeMethod.connectorSlug,
     },
-    mutation: normalizeConnectorAccountMutation(args.account),
+    mutation: args.account,
     allowSiblings: true,
   });
   signal.throwIfAborted();
@@ -1590,7 +1572,7 @@ export const connectManualGrantConnector$ = command(
       readonly runtimeMethod: ConnectorRuntimeMethod;
       readonly snapshot: ConnectorRuntimeSnapshot;
       readonly values: Readonly<Record<string, string>>;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: ConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ): Promise<ConnectManualGrantConnectorResult> => {
@@ -1670,7 +1652,7 @@ export const connectNoAuthConnector$ = command(
       readonly userId: string;
       readonly runtimeMethod: ConnectorRuntimeMethod;
       readonly snapshot: ConnectorRuntimeSnapshot;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: ConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ): Promise<ConnectNoAuthConnectorResult> => {
@@ -1693,7 +1675,7 @@ export const connectNoAuthConnector$ = command(
           kind: "builtin",
           connectorSlug: args.runtimeMethod.connectorSlug,
         },
-        mutation: normalizeConnectorAccountMutation(args.account),
+        mutation: args.account,
         allowSiblings: true,
       });
       signal.throwIfAborted();
@@ -2163,12 +2145,12 @@ async function upsertPreparedConnectorTokenState(
 }
 
 function isExplicitReconnectIdentityMismatch(args: {
-  readonly account?: ConnectorAccountMutationIntent;
+  readonly account: ConnectorAccountMutationIntent;
   readonly existing: StoredConnectorRow | null;
   readonly nextExternalId: string;
 }): boolean {
   return (
-    args.account?.intent === "reconnect" &&
+    args.account.intent === "reconnect" &&
     args.existing?.externalId !== null &&
     args.existing?.externalId !== undefined &&
     args.existing.externalId !== args.nextExternalId
@@ -2220,7 +2202,7 @@ async function loadPendingConnectorTokenRevokeForTokenConnect(
 }
 
 function authorizedExternalIdForMutation(args: {
-  readonly mutation: ReturnType<typeof normalizeConnectorAccountMutation>;
+  readonly mutation: ConnectorAccountMutationIntent;
   readonly matchExistingExternalIdentity: boolean | undefined;
   readonly externalId: string;
 }): string | undefined {
@@ -2241,7 +2223,7 @@ interface CommitConnectorTokenConnectionArgs {
   readonly oauthRequestedScopes: readonly string[];
   readonly oauthGrantedScopes: readonly string[];
   readonly tokenExpiresAt: Date | null;
-  readonly account?: ConnectorAccountMutationIntent;
+  readonly account: ConnectorAccountMutationIntent;
   readonly matchExistingExternalIdentity?: boolean;
   readonly insertConnectionId?: string;
 }
@@ -2345,7 +2327,7 @@ async function commitConnectorTokenConnection(
   | ConnectorConnectionMutationFailure
   | { readonly status: "identityMismatch" }
 > {
-  const mutation = normalizeConnectorAccountMutation(args.account);
+  const mutation = args.account;
   const resolution = await resolveConnectorConnectionMutation(args.db, {
     orgId: args.orgId,
     userId: args.userId,
@@ -2463,7 +2445,7 @@ export const upsertConnectorTokenConnection$ = command(
       readonly oauthGrantedScopes: readonly string[];
       readonly expiresIn?: number;
       readonly extraConnectorSecrets?: Readonly<Record<string, string>>;
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: ConnectorAccountMutationIntent;
       readonly matchExistingExternalIdentity?: boolean;
       readonly insertConnectionId?: string;
     },

--- a/turbo/apps/api/src/signals/services/connector-external-code.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-external-code.service.ts
@@ -48,7 +48,6 @@ import {
 } from "./connector-action-resolver.service";
 import {
   connectorById,
-  connectorBySlug,
   connectorConnectionWriteRejection,
   upsertConnectorTokenConnection$,
 } from "./connector-data.service";
@@ -670,25 +669,19 @@ const completedExternalCodeSessionResponse$ = command(
     const response = await completeSessionResponse(
       {
         connectorLoader: () => {
-          // Previous API releases completed sessions without an exact
-          // connector ID. Preserve their single-account replay until the old
-          // API rollback targets and persisted sessions drain; remove with
-          // #29777 after its contraction gate passes.
+          if (!args.session.completedConnectorId) {
+            throw new Error(
+              "Completed external-code session is missing its connector ID",
+            );
+          }
           return get(
-            args.session.completedConnectorId
-              ? connectorById({
-                  orgId: args.orgId,
-                  userId: args.userId,
-                  connectorSlug: args.method.connectorSlug,
-                  connectorId: args.session.completedConnectorId,
-                  snapshot: args.method.snapshot,
-                })
-              : connectorBySlug({
-                  orgId: args.orgId,
-                  userId: args.userId,
-                  connectorSlug: args.method.connectorSlug,
-                  snapshot: args.method.snapshot,
-                }),
+            connectorById({
+              orgId: args.orgId,
+              userId: args.userId,
+              connectorSlug: args.method.connectorSlug,
+              connectorId: args.session.completedConnectorId,
+              snapshot: args.method.snapshot,
+            }),
           );
         },
       },

--- a/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-oauth-device-auth.service.ts
@@ -50,7 +50,6 @@ import {
 } from "./connector-action-resolver.service";
 import {
   connectorById,
-  connectorBySlug,
   connectorConnectionWriteRejection,
   upsertConnectorTokenConnection$,
 } from "./connector-data.service";
@@ -880,25 +879,19 @@ const completedDeviceSessionResponse$ = command(
     const response = await completeSessionResponse(
       {
         connectorLoader: () => {
-          // Previous API releases completed sessions without an exact
-          // connector ID. Preserve their single-account replay until the old
-          // API rollback targets and persisted sessions drain; remove with
-          // #29777 after its contraction gate passes.
+          if (!args.session.completedConnectorId) {
+            throw new Error(
+              "Completed OAuth device session is missing its connector ID",
+            );
+          }
           return get(
-            args.session.completedConnectorId
-              ? connectorById({
-                  orgId: args.orgId,
-                  userId: args.userId,
-                  connectorSlug: args.method.connectorSlug,
-                  connectorId: args.session.completedConnectorId,
-                  snapshot: args.method.snapshot,
-                })
-              : connectorBySlug({
-                  orgId: args.orgId,
-                  userId: args.userId,
-                  connectorSlug: args.method.connectorSlug,
-                  snapshot: args.method.snapshot,
-                }),
+            connectorById({
+              orgId: args.orgId,
+              userId: args.userId,
+              connectorSlug: args.method.connectorSlug,
+              connectorId: args.session.completedConnectorId,
+              snapshot: args.method.snapshot,
+            }),
           );
         },
       },

--- a/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector-credential-storage.service.ts
@@ -9,9 +9,7 @@ import {
   upsertConnectorOwnedSecret,
   upsertConnectorOwnedVariable,
 } from "./connector-credential-storage-write.service";
-import { resolveConnectorAccount } from "./connector-account-resolution.service";
 import { prepareConnectorAccountDeletion } from "./connector-account-lifecycle.service";
-import { lockConnectorAccountTarget } from "./auth-state-lock.service";
 
 export type PreparedCustomConnectorValue =
   | {
@@ -87,45 +85,6 @@ export async function upsertCustomConnectorStoredValues(
     }
     signal.throwIfAborted();
   }
-}
-
-export async function deleteCustomConnectorMemberConnection(
-  db: Tx,
-  args: CustomConnectorMemberConnection,
-  signal: AbortSignal,
-): Promise<"deleted" | "missing" | "ambiguous"> {
-  await lockConnectorAccountTarget(db, {
-    orgId: args.orgId,
-    userId: args.userId,
-    target: { kind: "custom", customConnectorId: args.connectorId },
-  });
-  signal.throwIfAborted();
-  const resolution = await resolveConnectorAccount(db, {
-    orgId: args.orgId,
-    userId: args.userId,
-    request: {
-      target: { kind: "custom", customConnectorId: args.connectorId },
-      selection: { kind: "target-only-client-singleton" },
-    },
-  });
-  signal.throwIfAborted();
-  if (resolution.kind === "ambiguous") {
-    return "ambiguous";
-  }
-  if (resolution.kind !== "resolved") {
-    return "missing";
-  }
-  await deleteCustomConnectorMemberConnectionById(
-    db,
-    {
-      orgId: args.orgId,
-      userId: args.userId,
-      connectorId: args.connectorId,
-      memberConnectorId: resolution.account.connectorId,
-    },
-    signal,
-  );
-  return "deleted";
 }
 
 export async function deleteCustomConnectorMemberConnectionById(

--- a/turbo/apps/api/src/signals/services/custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/custom-connector.service.ts
@@ -54,7 +54,6 @@ import {
   type CustomConnectorDefinitionRow,
 } from "./custom-connector-definition-selection";
 import {
-  deleteCustomConnectorMemberConnection,
   deleteCustomConnectorMemberConnectionExact,
   type PreparedCustomConnectorValue,
   upsertCustomConnectorStoredValues,
@@ -93,7 +92,6 @@ import {
   type ReadyConnectorConnectionMutation,
   writeConnectorConnectionMetadata,
 } from "./connector-connection-write.service";
-import { normalizeConnectorAccountMutation } from "./connector-account-mutation.service";
 import type { Tx } from "../../lib/db-types";
 
 const L = logger("CustomConnectorService");
@@ -2826,7 +2824,7 @@ interface SetCustomConnectorValuesArgs {
   readonly userId: string;
   readonly connectorId: string;
   readonly values: readonly CustomConnectorValueInput[];
-  readonly account?: ConnectorAccountMutationIntent;
+  readonly account: ConnectorAccountMutationIntent;
 }
 
 interface CustomConnectorValueWriteState {
@@ -2890,7 +2888,7 @@ async function prepareCustomConnectorValueWrite(args: {
       kind: "custom",
       customConnectorId: args.request.connectorId,
     },
-    mutation: normalizeConnectorAccountMutation(args.request.account),
+    mutation: args.request.account,
     allowSiblings: true,
   });
   if (resolution.kind !== "ready") {
@@ -3030,7 +3028,7 @@ export const setCustomConnectorValues$ = command(
       readonly userId: string;
       readonly connectorId: string;
       readonly values: readonly CustomConnectorValueInput[];
-      readonly account?: ConnectorAccountMutationIntent;
+      readonly account: ConnectorAccountMutationIntent;
     },
     signal: AbortSignal,
   ): Promise<
@@ -3132,103 +3130,6 @@ export const setCustomConnectorValues$ = command(
       }),
       connectedAccountId: writeResult.connectedAccountId,
     };
-  },
-);
-
-type DisconnectCustomConnectorResult =
-  | "deleted"
-  | "missing-definition"
-  | "missing-account"
-  | "ambiguous"
-  | "managed";
-
-export const disconnectCustomConnector$ = command(
-  async (
-    { set },
-    args: {
-      readonly orgId: string;
-      readonly userId: string;
-      readonly connectorId: string;
-      readonly requireAccount?: true;
-    },
-    signal: AbortSignal,
-  ): Promise<DisconnectCustomConnectorResult> => {
-    const writeDb = set(writeDb$);
-    let postCommitAbort: CapturedConnectorClientInvalidationAbort | undefined;
-    const disconnected = await commitConnectorRuntimeMutation(
-      writeDb.transaction(async (tx) => {
-        const [connector] = await tx
-          .select({
-            id: orgCustomConnectors.id,
-            oauthProviderAdapter:
-              orgCustomConnectorOauthConfigs.providerAdapter,
-          })
-          .from(orgCustomConnectors)
-          .leftJoin(
-            orgCustomConnectorOauthConfigs,
-            and(
-              eq(
-                orgCustomConnectorOauthConfigs.connectorId,
-                orgCustomConnectors.id,
-              ),
-              eq(
-                orgCustomConnectorOauthConfigs.orgId,
-                orgCustomConnectors.orgId,
-              ),
-            ),
-          )
-          .where(
-            and(
-              eq(orgCustomConnectors.id, args.connectorId),
-              eq(orgCustomConnectors.orgId, args.orgId),
-            ),
-          )
-          .for("update", { of: orgCustomConnectors })
-          .limit(1);
-        signal.throwIfAborted();
-        if (!connector) {
-          return "missing-definition" as const;
-        }
-        if (
-          isIntegrationManagedCustomConnectorProviderAdapter(
-            connector.oauthProviderAdapter,
-          )
-        ) {
-          return "managed" as const;
-        }
-        return await deleteCustomConnectorMemberConnection(tx, args, signal);
-      }),
-      (result) => {
-        return result === "deleted"
-          ? {
-              db: writeDb,
-              scope: { orgId: args.orgId, userId: args.userId },
-              targets: [
-                { kind: "custom", customConnectorId: args.connectorId },
-              ],
-            }
-          : undefined;
-      },
-    );
-    if (signal.aborted) {
-      postCommitAbort = { reason: signal.reason };
-    }
-    const outcome =
-      disconnected === "missing"
-        ? args.requireAccount
-          ? ("missing-account" as const)
-          : ("deleted" as const)
-        : disconnected;
-    if (outcome !== "deleted") {
-      signal.throwIfAborted();
-      return outcome;
-    }
-    await publishCustomConnectorUserInvalidationAfterCommit(
-      args.userId,
-      signal,
-      postCommitAbort,
-    );
-    return "deleted";
   },
 );
 
@@ -3718,6 +3619,7 @@ export const saveCustomConnectorProposal$ = command(
           userId: args.userId,
           connectorId: connector.id,
           values: args.values,
+          account: { intent: "add" },
         },
         signal,
       );

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-accounts.test.ts
@@ -61,16 +61,10 @@ describe("connector account contracts", () => {
     ).toBe(false);
   });
 
-  it("distinguishes single-account, add, and exact reconnect intent", () => {
-    expect(
-      connectorAccountMutationIntentSchema.parse({
-        intent: "single-account",
-      }),
-    ).toStrictEqual({ intent: "single-account" });
+  it("distinguishes add and exact reconnect intent", () => {
     expect(
       connectorAccountMutationIntentSchema.safeParse({
         intent: "single-account",
-        connectionId,
       }).success,
     ).toBe(false);
     expect(
@@ -126,20 +120,20 @@ describe("connector account contracts", () => {
     ).toBe(false);
   });
 
-  it("preserves manual grant inputs and declares the CLI retirement response", () => {
+  it("requires explicit account intent for manual grants", () => {
     expect(
       connectorManualGrantContract.connect.body.safeParse({
         authMethod: "api-token",
         values: { apiKey: "test" },
       }).success,
-    ).toBe(true);
+    ).toBe(false);
     expect(
       connectorManualGrantContract.connect.body.safeParse({
         authMethod: "api-token",
         account: { intent: "single-account" },
         values: { apiKey: "test" },
       }).success,
-    ).toBe(true);
+    ).toBe(false);
     expect(
       connectorManualGrantContract.connect.body.safeParse({
         authMethod: "api-token",
@@ -152,14 +146,6 @@ describe("connector account contracts", () => {
         authMethod: "api-token",
         account: { intent: "reconnect", connectionId },
         values: { apiKey: "test" },
-      }).success,
-    ).toBe(true);
-    expect(
-      connectorManualGrantContract.connect.responses[426].safeParse({
-        error: {
-          message: "Update the CLI to connect this connector",
-          code: "CLI_CONNECTOR_ACCOUNT_INTENT_RETIRED",
-        },
       }).success,
     ).toBe(true);
   });
@@ -330,27 +316,6 @@ describe("connector account contracts", () => {
       connectorAccountsContract.delete.body.safeParse({
         target: { kind: "builtin", connectorSlug: "github" },
         selectionResolution: { kind: "clear" },
-      }).success,
-    ).toBe(false);
-  });
-
-  it("accepts only a target for safe single-account disconnect", () => {
-    expect(
-      connectorAccountsContract.disconnectSingleAccount.body.parse({
-        target: { kind: "builtin", connectorSlug: "github" },
-      }),
-    ).toStrictEqual({
-      target: { kind: "builtin", connectorSlug: "github" },
-    });
-    expect(
-      connectorAccountsContract.disconnectSingleAccount.body.parse({
-        target: { kind: "custom", customConnectorId },
-      }),
-    ).toStrictEqual({ target: { kind: "custom", customConnectorId } });
-    expect(
-      connectorAccountsContract.disconnectSingleAccount.body.safeParse({
-        target: { kind: "builtin", connectorSlug: "github" },
-        connectionId,
       }).success,
     ).toBe(false);
   });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
@@ -489,7 +489,7 @@ describe("connector client request contracts", () => {
 });
 
 describe("connector path parameter contracts", () => {
-  it("keeps concrete connector URLs unchanged", async () => {
+  it("builds concrete connector URLs", async () => {
     const paths: string[] = [];
     const config = {
       baseUrl: "https://api.example.test",
@@ -503,12 +503,11 @@ describe("connector path parameter contracts", () => {
       },
     };
 
-    await initClient(connectorAccountsContract, config).disconnectSingleAccount(
-      {
-        headers: {},
-        body: { target: { kind: "builtin", connectorSlug: "github" } },
-      },
-    );
+    await initClient(connectorAccountsContract, config).delete({
+      params: { connectionId: connector.id },
+      headers: {},
+      body: { target: { kind: "builtin", connectorSlug: "github" } },
+    });
     await initClient(connectorAccountsContract, config).scopeDiff({
       params: { connectionId: connector.id },
       query: { connectorSlug: "github" },
@@ -525,7 +524,7 @@ describe("connector path parameter contracts", () => {
     });
 
     expect(paths).toStrictEqual([
-      "https://api.example.test/api/connector-accounts/single-account",
+      `https://api.example.test/api/connector-accounts/${connector.id}`,
       `https://api.example.test/api/connector-accounts/${connector.id}/scope-diff?connectorSlug=github`,
       "https://api.example.test/api/connector-catalog/github/permissions",
       "https://api.example.test/api/connectors/github/callback?responseMode=json",

--- a/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-accounts.ts
@@ -101,11 +101,6 @@ export const connectorAccountMutationIntentSchema = z.discriminatedUnion(
   [
     z
       .object({
-        intent: z.literal("single-account"),
-      })
-      .strict(),
-    z
-      .object({
         intent: z.literal("add"),
         displayName: connectorAccountDisplayNameSchema.optional(),
       })
@@ -320,21 +315,6 @@ export const connectorAccountsContract = c.router({
       404: apiErrorSchema,
     },
     summary: "Plan deletion of an exact connector account",
-  },
-  disconnectSingleAccount: {
-    method: "DELETE",
-    path: "/api/connector-accounts/single-account",
-    headers: authHeadersSchema,
-    body: connectorAccountExactTargetBodySchema,
-    responses: {
-      204: c.noBody(),
-      400: apiErrorSchema,
-      401: apiErrorSchema,
-      403: apiErrorSchema,
-      404: apiErrorSchema,
-      409: apiErrorSchema,
-    },
-    summary: "Disconnect a safe single connector account",
   },
   delete: {
     method: "DELETE",

--- a/turbo/packages/api-contracts/src/contracts/connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/connectors.ts
@@ -139,7 +139,7 @@ export const connectorManualGrantContract = c.router({
       authMethod: connectorAuthMethodIdSchema,
       agentId: z.uuid().optional(),
       authorizeAgent: z.literal(true).optional(),
-      account: connectorAccountMutationIntentSchema.optional(),
+      account: connectorAccountMutationIntentSchema,
       values: z.record(z.string(), z.string()),
     }),
     responses: {
@@ -149,7 +149,6 @@ export const connectorManualGrantContract = c.router({
       403: apiErrorSchema,
       404: apiErrorSchema,
       409: apiErrorSchema,
-      426: apiErrorSchema,
       500: apiErrorSchema,
     },
     summary: "Connect a connector with a manual grant",


### PR DESCRIPTION
## Summary

- remove the retired `single-account` mutation intent and target-only disconnect API from public connector contracts
- require explicit `add` or exact `reconnect` mutations across manual, OAuth, device, external-code, and custom connector writes
- remove target-only account lookup/deletion fallbacks while preserving exact and deterministic default-account reads
- require completed asynchronous authorization sessions to retain their exact connector account ID
- update integration coverage to model multi-account replacement as add, select/promote, and exact delete

## Exclusions

- no UI or user-flow changes
- no schema migration or feature flag; migration 1078 and the released client floor are prerequisites
- no changes to deterministic default-account reads or exact account permissions

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @okouai/api-contracts test -- --runInBand` (677 passed)
- `pnpm -F @okouai/db test:migration-consistency`
- changed API connector/account/automation test set (1,074 passed; one unrelated chat snapshot cron assertion is affected by reused local DB state)
- `pnpm -F api exec vitest run --maxWorkers=1 --silent=passed-only src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (205 passed)
- exact Google Drive reconnect regression (passed)

Closes #29777

Parent: #28571
