### PR TITLE
fix(guest-agent): bound private maintenance usage reads

### DIFF
--- a/crates/guest-agent/src/maintenance_usage.rs
+++ b/crates/guest-agent/src/maintenance_usage.rs
@@ -4,6 +4,8 @@ use crate::{constants, error::AgentError, run_context::GuestRuntime};
 use api_contracts::generated::types::webhooks::agent::pi_memory_phase2::usage::Request;
 use std::path::Path;
 
+const MAX_MAINTENANCE_USAGE_BYTES: usize = 256 * 1024;
+
 fn invalid_usage() -> AgentError {
     AgentError::Execution("Invalid private maintenance usage".into())
 }
@@ -24,20 +26,19 @@ pub async fn report_for_runtime(runtime: &GuestRuntime) -> Result<(), AgentError
     }
     let path =
         Path::new(runtime.paths.pi_launch_payload_file()).with_file_name("maintenance-usage.json");
-    let metadata = match std::fs::symlink_metadata(&path) {
-        Ok(metadata) => metadata,
+    let bytes = match guest_contracts::runtime_paths::read_private_bounded(
+        path,
+        MAX_MAINTENANCE_USAGE_BYTES,
+    ) {
+        Ok(Some(bytes)) => bytes,
         // No provider response is incurred on the engine's early no-diff path.
         // Old commit-pinned CLIs can also omit it through queue residence, the
         // two-hour execution budget, and bounded finalization. Remove that
         // allowance under #31067 once old queued and active contexts drain.
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Ok(None) => return Ok(()),
         Err(_) => return Err(invalid_usage()),
     };
-    if !metadata.is_file() || metadata.len() > 256 * 1024 {
-        return Err(invalid_usage());
-    }
-    let usage: Request = serde_json::from_slice(&std::fs::read(path).map_err(|_| invalid_usage())?)
-        .map_err(|_| invalid_usage())?;
+    let usage: Request = serde_json::from_slice(&bytes).map_err(|_| invalid_usage())?;
     if usage.run_id != runtime.config.run_id
         || usage.attempts.is_empty()
         || usage.attempts.len() > 256

--- a/crates/guest-agent/tests/maintenance_usage.rs
+++ b/crates/guest-agent/tests/maintenance_usage.rs
@@ -1,0 +1,192 @@
+//! Integration coverage for the private Pi maintenance usage boundary.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use api_contracts::generated::types::webhooks::agent::pi_memory_phase2::usage::{
+    Request, RequestAttempt, RequestAttemptUsage,
+};
+use guest_agent::env::{GuestConfig, GuestConfigRaw};
+use guest_agent::http::HttpClient;
+use guest_agent::paths::GuestPaths;
+use guest_agent::run_context::GuestRuntime;
+use httpmock::Mock;
+use httpmock::prelude::*;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+const RUN_ID: &str = "maintenance-usage-integration";
+const USAGE_PATH: &str = "/api/webhooks/agent/pi-memory-phase2/usage";
+
+fn write_run_payload(runtime_dir: &Path) -> TestResult<PathBuf> {
+    let path = runtime_dir
+        .join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME)
+        .join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    let payload = guest_contracts::env::RunPayload {
+        pi_launch_config: r#"{"schemaVersion":2,"maintenance":{}}"#.to_string(),
+        ..guest_contracts::env::RunPayload::default()
+    };
+    guest_contracts::runtime_paths::write_private(&path, serde_json::to_vec(&payload)?)?;
+    Ok(path)
+}
+
+fn test_runtime(root: &Path, server: &MockServer) -> TestResult<GuestRuntime> {
+    let runtime_dir = root.join("runtime");
+    let run_payload_file = write_run_payload(&runtime_dir)?;
+    let config = GuestConfig::from_raw(GuestConfigRaw {
+        run_id: RUN_ID.to_string(),
+        api_url: server.base_url(),
+        api_token: "test-token".to_string(),
+        cli_agent_type: "pi".to_string(),
+        home: Some(root.join("home").to_string_lossy().into_owned()),
+        run_payload_file: run_payload_file.to_string_lossy().into_owned(),
+        guest_runtime_dir: Some(runtime_dir.clone()),
+        ..GuestConfigRaw::default()
+    })?;
+    let http =
+        HttpClient::with_api_config(server.base_url(), "test-token", "", RUN_ID, Duration::ZERO)?;
+    Ok(GuestRuntime {
+        config,
+        paths: GuestPaths::from_runtime_dir(runtime_dir),
+        http,
+        workload_containment: None,
+        process_control_endpoint: None,
+    })
+}
+
+fn usage_path(runtime: &GuestRuntime) -> PathBuf {
+    Path::new(runtime.paths.pi_launch_payload_file()).with_file_name("maintenance-usage.json")
+}
+
+fn usage_request() -> Request {
+    Request {
+        schema_version: 1,
+        run_id: RUN_ID.to_string(),
+        memory_storage_id: "01234567-89ab-cdef-0123-456789abcdef".to_string(),
+        lease_token: "11111111-2222-4333-8444-555555555555".to_string(),
+        claimed_revision: 7,
+        claimed_base_version_id: "base-version".to_string(),
+        selection_digest: "a".repeat(64),
+        attempts: vec![RequestAttempt {
+            response_id: "response-1".to_string(),
+            usage: RequestAttemptUsage {
+                input: 11,
+                output: 12,
+                cache_read: 13,
+                cache_write: 14,
+                reasoning: 15,
+            },
+        }],
+    }
+}
+
+fn usage_mock<'a>(server: &'a MockServer) -> Mock<'a> {
+    server.mock(|when, then| {
+        when.method(POST).path(USAGE_PATH);
+        then.status(200);
+    })
+}
+
+async fn assert_invalid_without_post(runtime: &GuestRuntime, usage: &Mock<'_>) -> TestResult {
+    let error = match guest_agent::maintenance_usage::report_for_runtime(runtime).await {
+        Ok(()) => return Err("unsafe maintenance usage was accepted".into()),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error.to_string(),
+        "execution: Invalid private maintenance usage"
+    );
+    usage.assert_calls(0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn valid_private_journal_is_posted() -> TestResult {
+    let server = MockServer::start();
+    let temp = tempfile::tempdir()?;
+    let runtime = test_runtime(temp.path(), &server)?;
+    let request = usage_request();
+    guest_contracts::runtime_paths::write_private(
+        usage_path(&runtime),
+        serde_json::to_vec(&request)?,
+    )?;
+    let expected = serde_json::to_value(&request)?;
+    let usage = server.mock(|when, then| {
+        when.method(POST)
+            .path(USAGE_PATH)
+            .header("Authorization", "Bearer test-token")
+            .header("Content-Type", "application/json")
+            .json_body(expected);
+        then.status(200);
+    });
+
+    guest_agent::maintenance_usage::report_for_runtime(&runtime).await?;
+
+    usage.assert_calls(1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn missing_journal_preserves_compatibility_without_posting() -> TestResult {
+    let server = MockServer::start();
+    let temp = tempfile::tempdir()?;
+    let runtime = test_runtime(temp.path(), &server)?;
+    let usage = usage_mock(&server);
+
+    guest_agent::maintenance_usage::report_for_runtime(&runtime).await?;
+
+    usage.assert_calls(0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn oversized_private_journal_is_rejected_without_posting() -> TestResult {
+    let server = MockServer::start();
+    let temp = tempfile::tempdir()?;
+    let runtime = test_runtime(temp.path(), &server)?;
+    guest_contracts::runtime_paths::write_private(
+        usage_path(&runtime),
+        vec![b'x'; 256 * 1024 + 1],
+    )?;
+    let usage = usage_mock(&server);
+
+    assert_invalid_without_post(&runtime, &usage).await
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlinked_journal_is_rejected_without_reading_target() -> TestResult {
+    use std::os::unix::fs::symlink;
+
+    let server = MockServer::start();
+    let temp = tempfile::tempdir()?;
+    let runtime = test_runtime(temp.path(), &server)?;
+    let target = temp.path().join("outside-usage.json");
+    let target_bytes = serde_json::to_vec(&usage_request())?;
+    std::fs::write(&target, &target_bytes)?;
+    guest_contracts::runtime_paths::ensure_parent_dir(usage_path(&runtime))?;
+    symlink(&target, usage_path(&runtime))?;
+    let usage = usage_mock(&server);
+
+    assert_invalid_without_post(&runtime, &usage).await?;
+
+    assert_eq!(std::fs::read(target)?, target_bytes);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn permissive_journal_is_rejected_without_posting() -> TestResult {
+    use std::os::unix::fs::PermissionsExt;
+
+    let server = MockServer::start();
+    let temp = tempfile::tempdir()?;
+    let runtime = test_runtime(temp.path(), &server)?;
+    let path = usage_path(&runtime);
+    guest_contracts::runtime_paths::write_private(&path, serde_json::to_vec(&usage_request())?)?;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))?;
+    let usage = usage_mock(&server);
+
+    assert_invalid_without_post(&runtime, &usage).await
+}


### PR DESCRIPTION
## Summary

- read the private maintenance usage journal through the canonical descriptor-bound, no-follow, size-bounded API
- preserve the existing missing-journal compatibility path and validation/reporting behavior
- add guest-agent integration coverage for valid, missing, oversized, symlinked, and overly permissive journal files

## Scope

This does not change the maintenance usage API schema, the CLI writer, UI behavior, or rollout behavior.

## Validation

- `cargo test --profile local -p guest-agent --test maintenance_usage` (5 passed)
- `cargo test --profile local -p guest-agent`
- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p guest-agent --all-targets --all-features`
- `cargo doc --profile local -p guest-agent --all-features --no-deps`
- pre-commit hooks: workspace Rust formatting, Clippy, documentation, file-size, and commit-message checks

Closes #31979
