### PR TITLE
fix: handle thread number shortcuts in safari web apps

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/thread-number-shortcuts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/thread-number-shortcuts.ts
@@ -8,6 +8,15 @@ const standaloneDisplayMode$ = state(false);
 const shortcutHintPhase$ = state<"idle" | "pending" | "visible">("idle");
 const resetShortcutHintHold$ = resetSignal();
 
+export const threadNumberShortcutModifier$ = computed(() => {
+  // Safari's macOS web apps consume Command+1-9 before dispatching DOM events.
+  // iPadOS can report a Macintosh user agent, but has multiple touch points.
+  return /Macintosh.*Version\/[\d.]+.*Safari\//.test(navigator.userAgent) &&
+    navigator.maxTouchPoints <= 1
+    ? "ctrl+mod"
+    : "mod";
+});
+
 export const threadNumberShortcutsEnabled$ = computed((get) => {
   return get(stableChatThreadNavigationEnabled$) && get(standaloneDisplayMode$);
 });
@@ -36,8 +45,10 @@ const revealThreadNumberShortcutHints$ = command(
 const updateThreadNumberShortcutModifiers$ = command(
   ({ get, set }, event: KeyboardEvent, signal: AbortSignal) => {
     const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+    const allowControlWithMeta =
+      get(threadNumberShortcutModifier$) === "ctrl+mod";
     const modifierHeld = isMac
-      ? event.metaKey && !event.ctrlKey
+      ? event.metaKey && (!event.ctrlKey || allowControlWithMeta)
       : event.ctrlKey && !event.metaKey;
     if (
       !get(threadNumberShortcutsEnabled$) ||
@@ -119,8 +130,9 @@ export const threadNumberShortcutIndex$ = command(
     ) {
       return undefined;
     }
+    const modifier = get(threadNumberShortcutModifier$);
     for (let index = 0; index < 9; index++) {
-      if (matchShortcut(`mod+${index + 1}`, event)) {
+      if (matchShortcut(`${modifier}+${index + 1}`, event)) {
         return index;
       }
     }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
@@ -130,18 +130,31 @@ function installSearchResources() {
 
 test.each([
   {
-    platform: "Mac",
-    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    platform: "Mac Chrome",
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36",
     modifiers: { metaKey: true, ctrlKey: false },
+    numberModifiers: { metaKey: true, ctrlKey: false },
+    firstHint: ["⌘", "1"],
+  },
+  {
+    platform: "Mac Safari",
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6.2 Safari/605.1.15",
+    modifiers: { metaKey: true, ctrlKey: false },
+    numberModifiers: { metaKey: true, ctrlKey: true },
+    firstHint: ["⌃", "⌘", "1"],
   },
   {
     platform: "Windows",
     userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
     modifiers: { metaKey: false, ctrlKey: true },
+    numberModifiers: { metaKey: false, ctrlKey: true },
+    firstHint: ["Ctrl", "1"],
   },
 ])(
   "Limit empty search to 25 current chats and open the ninth result on $platform",
-  async ({ userAgent, modifiers }) => {
+  async ({ userAgent, modifiers, numberModifiers, firstHint }) => {
     context.mocks.browser.userAgent(userAgent);
     context.mocks.browser.matchMedia((query) => {
       return (
@@ -191,6 +204,13 @@ test.each([
         "9",
       ]);
     });
+    expect(
+      [...queryAllByRoleFast("option", dialog)[0]!.querySelectorAll("kbd")].map(
+        (keycap) => {
+          return keycap.textContent;
+        },
+      ),
+    ).toStrictEqual(firstHint);
     fireEvent.keyUp(search, { key: modifiers.metaKey ? "Meta" : "Control" });
     await waitFor(() => {
       expect(numberedHints(dialog)).toStrictEqual([]);
@@ -205,7 +225,7 @@ test.each([
     fireEvent.keyDown(search, {
       key: "9",
       code: "Digit9",
-      ...modifiers,
+      ...numberModifiers,
       shiftKey: false,
     });
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
@@ -32,27 +32,62 @@ function hintKeys(container: ParentNode): string[] {
       return keycap.textContent ?? "";
     })
     .filter((label) => {
-      return /^(?:Ctrl|⌘|[1-9])$/.test(label);
+      return /^(?:Ctrl|⌃|⌘|[1-9])$/.test(label);
     });
 }
 
 test.each([
   {
-    platform: "Mac",
-    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    platform: "Mac Chrome",
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36",
+    maxTouchPoints: 0,
     modifier: "Meta",
-    label: "⌘",
+    additionalModifier: "",
+    releaseModifiers: "{/Meta}",
+    label: ["⌘"],
+  },
+  {
+    platform: "Mac Safari",
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6.2 Safari/605.1.15",
+    maxTouchPoints: 0,
+    modifier: "Meta",
+    additionalModifier: "{Control>}",
+    releaseModifiers: "{/Control}{/Meta}",
+    label: ["⌃", "⌘"],
+  },
+  {
+    platform: "iPad Safari with a desktop user agent",
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.6.2 Safari/605.1.15",
+    maxTouchPoints: 5,
+    modifier: "Meta",
+    additionalModifier: "",
+    releaseModifiers: "{/Meta}",
+    label: ["⌘"],
   },
   {
     platform: "Windows",
     userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    maxTouchPoints: 0,
     modifier: "Control",
-    label: "Ctrl",
+    additionalModifier: "",
+    releaseModifiers: "{/Control}",
+    label: ["Ctrl"],
   },
 ])(
   "Reveal the first nine thread shortcuts after holding the modifier for 500 ms on $platform",
-  async ({ userAgent, modifier, label }) => {
+  async ({
+    userAgent,
+    maxTouchPoints,
+    modifier,
+    additionalModifier,
+    releaseModifiers,
+    label,
+  }) => {
     context.mocks.browser.userAgent(userAgent);
+    context.mocks.browser.maxTouchPoints(maxTouchPoints);
     context.mocks.browser.matchMedia((query) => {
       return (
         query === "(display-mode: standalone)" || query === "(min-width: 48rem)"
@@ -94,22 +129,28 @@ test.each([
     await user.keyboard(`{${modifier}>}`);
     expect(hintKeys(list)).toStrictEqual([]);
     await waitFor(() => {
-      expect(hintKeys(list)).toHaveLength(18);
+      expect(hintKeys(list)).toHaveLength(9 * (label.length + 1));
     });
     expect(now() - pressedAt).toBeGreaterThanOrEqual(500);
     expect(hintKeys(list)).toStrictEqual(
       Array.from({ length: 9 }, (_, index) => {
-        return [label, String(index + 1)];
+        return [...label, String(index + 1)];
       }).flat(),
     );
-    await user.keyboard(`9{/${modifier}}`);
+    if (additionalModifier) {
+      await user.keyboard(additionalModifier);
+    }
+    expect(hintKeys(list)).toHaveLength(9 * (label.length + 1));
+    await user.keyboard(`9${releaseModifiers}`);
     await waitFor(() => {
       expect(pathname()).toBe(`/chats/${threads[4]!.id}`);
     });
     expect(hintKeys(list)).toStrictEqual([]);
 
     // A known shortcut can be used immediately, without waiting for its hint.
-    await user.keyboard(`{${modifier}>}1{/${modifier}}`);
+    await user.keyboard(
+      `{${modifier}>}${additionalModifier}1${releaseModifiers}`,
+    );
     await waitFor(() => {
       expect(pathname()).toBe(`/chats/${threads[0]!.id}`);
     });

--- a/turbo/apps/platform/src/views/okou-page/thread-number-shortcut-hint.tsx
+++ b/turbo/apps/platform/src/views/okou-page/thread-number-shortcut-hint.tsx
@@ -1,6 +1,9 @@
 import { useGet } from "ccstate-react";
 import { getShortcutParts } from "@okouai/ui";
-import { threadNumberShortcutHintsVisible$ } from "../../signals/okou-page/thread-number-shortcuts.ts";
+import {
+  threadNumberShortcutHintsVisible$,
+  threadNumberShortcutModifier$,
+} from "../../signals/okou-page/thread-number-shortcuts.ts";
 
 export function ThreadNumberShortcutHint({
   shortcutNumber,
@@ -8,6 +11,7 @@ export function ThreadNumberShortcutHint({
   readonly shortcutNumber: number | undefined;
 }) {
   const visible = useGet(threadNumberShortcutHintsVisible$);
+  const modifier = useGet(threadNumberShortcutModifier$);
   if (!visible || shortcutNumber === undefined) {
     return null;
   }
@@ -17,7 +21,7 @@ export function ThreadNumberShortcutHint({
       aria-hidden="true"
       className="pointer-events-none inline-flex shrink-0 animate-thread-number-shortcut-hint items-center gap-1 motion-reduce:animate-none"
     >
-      {getShortcutParts(`mod+${shortcutNumber}`).map((part) => {
+      {getShortcutParts(`${modifier}+${shortcutNumber}`).map((part) => {
         return (
           <kbd
             key={part}


### PR DESCRIPTION
Safari on macOS consumes Command+1–9 before delivering DOM keyboard events, so the installed web app shows thread-number hints without opening a chat or search result. Use Control+Command+1–9 for macOS Safari, with the displayed hints and both handlers sharing the same modifier. Holding Command still reveals the full shortcut, and adding Control keeps the hints visible.

Chrome, Windows, and iPad keep their existing shortcuts. The feature remains limited to standalone mode with stable chat navigation enabled.

## Verification

- On macOS 26.6.2 / Safari 26.6.2, native keyboard input into an installed Add to Dock event viewer confirmed that Command+1 is consumed before DOM delivery and Control+Command+1–9 all deliver the expected digit keydown events. [Browser evidence](https://a.okou.io/dxvw7xmhyt.png).
- Both affected page integration test files pass: 16 tests covering list navigation, search selection, hints, and platform behavior.
- Platform static checks pass: formatting, asset/emoji/localization/build checks, Oxlint, type-aware lint, ESLint, production/test/build-config type checks, and scoped Knip.

The native Safari check verifies browser event delivery; the navigation checks run through the full application page test harness.
