### PR TITLE
test(guest-agent): isolate sandbox telemetry overrides

### DIFF
--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -520,21 +520,6 @@ mod tests {
         guest_common::log::clear_system_log_file();
     }
 
-    struct SandboxOpsOverrideGuard;
-
-    impl SandboxOpsOverrideGuard {
-        fn set(path: &std::path::Path) -> Self {
-            guest_common::telemetry::set_sandbox_ops_log_file(path);
-            Self
-        }
-    }
-
-    impl Drop for SandboxOpsOverrideGuard {
-        fn drop(&mut self) {
-            guest_common::telemetry::clear_sandbox_ops_log_file();
-        }
-    }
-
     fn test_http_client(server: &httpmock::MockServer) -> Result<HttpClient, AgentError> {
         HttpClient::with_api_config(
             server.base_url(),
@@ -614,6 +599,7 @@ mod tests {
     async fn snapshot_rejects_empty_prepare_response_before_upload_or_commit()
     -> Result<(), AgentError> {
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         disable_system_log();
         let server = MockServer::start();
 
@@ -684,7 +670,7 @@ mod tests {
 
         let telemetry_dir = tempfile::tempdir().unwrap();
         let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::with_override(&telemetry_path).await;
 
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -778,7 +764,7 @@ mod tests {
 
         let telemetry_dir = tempfile::tempdir().unwrap();
         let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::with_override(&telemetry_path).await;
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
@@ -908,7 +894,7 @@ mod tests {
 
         let telemetry_dir = tempfile::tempdir().unwrap();
         let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::with_override(&telemetry_path).await;
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
@@ -1024,7 +1010,7 @@ mod tests {
 
         let telemetry_dir = tempfile::tempdir().unwrap();
         let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::with_override(&telemetry_path).await;
 
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -1123,7 +1109,7 @@ mod tests {
 
         let telemetry_dir = tempfile::tempdir().unwrap();
         let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::with_override(&telemetry_path).await;
 
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -1210,7 +1196,7 @@ mod tests {
 
         let telemetry_dir = tempfile::tempdir().unwrap();
         let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::with_override(&telemetry_path).await;
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
@@ -1318,7 +1304,7 @@ mod tests {
 
         let telemetry_dir = tempfile::tempdir().unwrap();
         let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::with_override(&telemetry_path).await;
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
@@ -1392,7 +1378,7 @@ mod tests {
 
         let telemetry_dir = tempfile::tempdir().unwrap();
         let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::with_override(&telemetry_path).await;
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
@@ -1460,6 +1446,7 @@ mod tests {
     #[tokio::test]
     async fn snapshot_requires_upload_urls_for_new_version() -> Result<(), AgentError> {
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         disable_system_log();
         let server = MockServer::start();
 

--- a/crates/guest-agent/src/checkpoint/artifact.rs
+++ b/crates/guest-agent/src/checkpoint/artifact.rs
@@ -448,21 +448,6 @@ mod tests {
 
     const REQUEST_OVERLAP_TIMEOUT: Duration = Duration::from_secs(5);
 
-    struct SandboxOpsOverrideGuard;
-
-    impl SandboxOpsOverrideGuard {
-        fn set(path: &std::path::Path) -> Self {
-            guest_common::telemetry::set_sandbox_ops_log_file(path);
-            Self
-        }
-    }
-
-    impl Drop for SandboxOpsOverrideGuard {
-        fn drop(&mut self) {
-            guest_common::telemetry::clear_sandbox_ops_log_file();
-        }
-    }
-
     fn assert_artifact_hash_failure(telemetry_path: &std::path::Path, expected_error: &str) {
         let expected_error = expected_error
             .strip_prefix("checkpoint: ")
@@ -501,7 +486,7 @@ mod tests {
     async fn artifact_snapshot_preflight_error(mount: &std::path::Path) -> String {
         let telemetry_dir = tempfile::tempdir().unwrap();
         let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::with_override(&telemetry_path).await;
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -647,6 +632,7 @@ mod tests {
 
     #[tokio::test]
     async fn maintenance_recovery_preserves_parent_before_any_storage_publication() {
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -715,6 +701,7 @@ mod tests {
 
     #[tokio::test]
     async fn maintenance_success_forwards_exact_validation_attestation() {
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let storage_id = "1d09f0c9-a5c6-4f21-9664-d80a3ca3ae63";
@@ -873,6 +860,7 @@ mod tests {
     #[tokio::test]
     async fn artifact_snapshot_missing_mount_fails_before_storage_api_calls() {
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -926,6 +914,7 @@ mod tests {
         };
 
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        let mut sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         guest_common::log::clear_system_log_file();
 
         let dir = tempfile::tempdir().unwrap();
@@ -953,7 +942,7 @@ mod tests {
 
         let telemetry_dir = tempfile::tempdir().unwrap();
         let telemetry_path = telemetry_dir.path().join("sandbox-ops.jsonl");
-        let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(&telemetry_path);
+        sandbox_ops_guard.install_override(&telemetry_path);
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -1121,6 +1110,7 @@ mod tests {
     #[tokio::test]
     async fn artifact_snapshot_explicit_fail_policy_missing_mount_fails() {
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -1165,6 +1155,7 @@ mod tests {
     #[tokio::test]
     async fn artifact_snapshot_later_missing_mount_fails_before_any_storage_api_calls() {
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -1221,6 +1212,7 @@ mod tests {
     #[tokio::test]
     async fn artifact_snapshot_pipelines_overlap_and_preserve_result_order() {
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let dir = tempfile::tempdir().unwrap();
         let workspace_mount = dir.path().join("workspace");
         let memory_mount = dir.path().join("memory");
@@ -1283,6 +1275,7 @@ mod tests {
     #[tokio::test]
     async fn artifact_snapshot_preserve_policy_missing_mount_preserves_parent_version() {
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -1335,6 +1328,7 @@ mod tests {
     #[tokio::test]
     async fn artifact_snapshot_policy_still_fails_on_non_not_found_root_error() {
         let _system_log_state_guard = crate::lock_system_log_test_state_async().await;
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)

--- a/crates/guest-agent/src/checkpoint/mod.rs
+++ b/crates/guest-agent/src/checkpoint/mod.rs
@@ -398,6 +398,7 @@ mod tests {
 
     #[tokio::test]
     async fn checkpoint_missing_mount_fails_before_final_completion() {
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let server = MockServer::start();
         let dir = tempfile::tempdir().unwrap();
         let guest_paths = crate::paths::GuestPaths::from_runtime_dir(dir.path().join("runtime"));
@@ -465,6 +466,7 @@ mod tests {
 
     #[tokio::test]
     async fn maintenance_success_rejects_partial_tree_before_storage_publication() {
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -543,6 +545,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn maintenance_recovery_checkpoint_preserves_parent_after_partial_apply() {
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -642,6 +645,7 @@ mod tests {
 
     #[tokio::test]
     async fn ordinary_recovery_checkpoint_still_snapshots_changed_artifacts() {
+        let _sandbox_ops_guard = crate::SandboxOpsTestGuard::lock().await;
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -247,6 +247,46 @@ pub mod workload_containment;
 static SYSTEM_LOG_TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[cfg(test)]
+static SANDBOX_OPS_TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[cfg(test)]
+pub(crate) struct SandboxOpsTestGuard {
+    _ownership: tokio::sync::MutexGuard<'static, ()>,
+    override_installed: bool,
+}
+
+#[cfg(test)]
+impl SandboxOpsTestGuard {
+    pub(crate) async fn lock() -> Self {
+        let ownership = SANDBOX_OPS_TEST_MUTEX.lock().await;
+        Self {
+            _ownership: ownership,
+            override_installed: false,
+        }
+    }
+
+    pub(crate) async fn with_override(path: &std::path::Path) -> Self {
+        let mut guard = Self::lock().await;
+        guard.install_override(path);
+        guard
+    }
+
+    pub(crate) fn install_override(&mut self, path: &std::path::Path) {
+        guest_common::telemetry::set_sandbox_ops_log_file(path);
+        self.override_installed = true;
+    }
+}
+
+#[cfg(test)]
+impl Drop for SandboxOpsTestGuard {
+    fn drop(&mut self) {
+        if self.override_installed {
+            guest_common::telemetry::clear_sandbox_ops_log_file();
+        }
+    }
+}
+
+#[cfg(test)]
 pub(crate) fn lock_system_log_test_state() -> tokio::sync::MutexGuard<'static, ()> {
     SYSTEM_LOG_TEST_MUTEX.blocking_lock()
 }


### PR DESCRIPTION
## Summary

- centralize ownership of the process-global sandbox-operation telemetry override in a test-only guard
- serialize artifact snapshot producers that could otherwise write into another test's active telemetry sink
- support acquiring the guard before installing an override for tests that intentionally produce earlier sandbox-operation events

## Scope

- test-only synchronization in the `guest-agent` library test binary
- artifact snapshot and checkpoint tests that enter the sandbox-operation producer path
- no production behavior, protocol, persistence, or API changes
- separate binary and integration-test processes remain unchanged because they do not share this process-global state

## Validation

- `cargo fmt --all -- --check`
- both affected exact telemetry assertion tests individually
- `cargo test --profile local -p guest-agent --lib` (3 consecutive runs, 649 tests each)
- `cargo test --profile local -p guest-agent` (2 consecutive runs)
- `cargo clippy --profile local -p guest-agent --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local -p guest-agent --no-deps`
- repository pre-commit hooks, including workspace Rust docs and Clippy

Closes #31980
