### PR TITLE
test(e2e): stop zendesk probe from forcing public sink

### DIFF
--- a/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
+++ b/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
@@ -39,13 +39,11 @@ set -euo pipefail
 printf 'ZENDESK_API_TOKEN=%s\n' "$ZENDESK_API_TOKEN"
 printf 'ZENDESK_EMAIL=%s\n' "$ZENDESK_EMAIL"
 printf 'ZENDESK_SUBDOMAIN=%s\n' "$ZENDESK_SUBDOMAIN"
-# Raw DNS has dedicated runner coverage. Pin the public sink so this test owns
-# only firewall classification and authentication resolution, never whether a
-# live Zendesk tenant answers. The request host still carries the resolved
-# variable base, which is what the firewall matches on.
+# A Zendesk response is outside this test's contract. Use the real templated
+# authority so credential injection follows the normal upstream binding path,
+# while keeping the request on IPv4 and bounding the third-party wait.
 curl_status=0
-curl --silent --show-error --max-time 5 \
-    --resolve '__SUBDOMAIN__.zendesk.com:443:8.8.8.8' \
+curl --ipv4 --silent --show-error --max-time 5 \
     --output /dev/null \
     "https://__SUBDOMAIN__.zendesk.com/api/v2/users/me.json" || curl_status=$?
 printf 'ZENDESK_REQUEST_SENT=%s\n' "$curl_status"


### PR DESCRIPTION
## Summary

- stop forcing the Zendesk firewall probe through the unrelated `8.8.8.8` peer
- restore the probe's IPv4-only real-authority path so upstream binding follows production behavior
- keep curl transport status non-fatal and retain the exact dynamic-host and token-injection telemetry assertions

The runner's fail-closed upstream binding logic, shared E2E helpers, timeout, and sibling connector probes are unchanged.

Closes #31992

## Testing

- `cd e2e && ./test/libs/bats/bin/bats --count tests/03-runner/run-t03-firewall-zendesk.bats`
- `./scripts/check-file-size.sh e2e/tests/03-runner/run-t03-firewall-zendesk.bats`
- `git diff --check`
- `lefthook run pre-commit`

The full `03-runner` test is CI-only by project policy because it requires the PR preview, temporary organizations and credentials, and the provisioned runner fleet. The PR pipeline is the authoritative end-to-end validation.
