### PR TITLE
fix: place chat shortcut hints after row actions

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.tsx
@@ -191,7 +191,7 @@ export function PinnedThreadRow({
       : undefined;
   return (
     <div
-      className="group relative okou-thread-reorder-row"
+      className="group relative grid grid-cols-[minmax(0,1fr)_auto] okou-thread-reorder-row"
       data-reorderable={reorderable || undefined}
       data-dragging={
         drag?.threadId === signals.threadId

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -374,7 +374,7 @@ function ChatThreadItemLink({
         e.preventDefault();
         detach(openRename(pageSignal), Reason.DomCallback);
       }}
-      className={`flex h-8 items-center gap-2 rounded-lg py-2 pl-2 pr-8 text-left text-sm leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+      className={`col-span-2 col-start-1 row-start-1 grid h-8 grid-cols-subgrid items-center rounded-lg pl-2 text-left text-sm leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
         isHighlighted
           ? "bg-state-selected text-sidebar-foreground font-medium"
           : isUnread
@@ -382,7 +382,7 @@ function ChatThreadItemLink({
             : "text-sidebar-foreground hover:bg-state-hover"
       }`}
     >
-      <span className="flex min-w-0 flex-1 items-center gap-2">
+      <span className="flex min-w-0 items-center gap-2 pr-8">
         <ChatThreadListPaneIcon signals={signals} />
         <span className="okou-nav-copy min-w-0 truncate">
           {title ??
@@ -391,7 +391,9 @@ function ChatThreadItemLink({
             })}
         </span>
       </span>
-      <ThreadNumberShortcutHint shortcutNumber={shortcutNumber} />
+      <span className="flex items-center pr-2 empty:hidden">
+        <ThreadNumberShortcutHint shortcutNumber={shortcutNumber} />
+      </span>
     </Link>
   );
 }
@@ -408,7 +410,7 @@ function ChatThreadItem({
   return (
     <PinnedThreadRow signals={signals} dragSignals={dragSignals}>
       <ChatThreadItemLink signals={signals} shortcutNumber={shortcutNumber} />
-      <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
+      <div className="pointer-events-none relative col-start-1 row-start-1 flex h-8 w-8 items-center justify-center justify-self-end">
         <ChatThreadMenu signals={signals} />
       </div>
     </PinnedThreadRow>


### PR DESCRIPTION
Move chat thread shortcut hints to the right of the menu and state indicators when the modifier is held. Shared grid columns reserve each hint's natural width while the title truncates within its available space.

The menu remains a separate button, and the link still spans the full row. Existing hint timing, shortcut handling, hover feedback, and pinned-thread drag structure are preserved.

## Verification

- Prettier, targeted ESLint/Oxlint, platform type checks, and platform Knip passed.
- Thread number shortcut tests passed (7 tests). Pinned-thread reorder tests passed on an isolated file run (10 tests); the initial two-file run had one initial page-load timeout.
- All GitHub CI gates passed.
- Browser PASS on the [PR preview](https://pr-31994-app-okou-app-preview.vm0.workers.dev), deployed merge commit `4a1d74863fff58f4fdc5aa7c7208b355cb1aeaf8` containing PR head `cac356a5828bdffc88ac052831e961dfd9780188`: hints follow the pinned indicator and hover menu, long titles truncate without overlap, menus open without navigation, releasing the modifier restores the original row geometry, and Ctrl+3 opens the third thread. No page errors were reported.
- Browser fixture: Chromium, 1440 × 1000, standalone display mode emulated, `stableChatThreadNavigation` enabled, four test threads in a fresh preview account. Onboarding was bypassed and Stripe test checkout enabled fixture creation; no assistant run was started. No local dev server or full local Vitest suite was started.

[View the verified layout screenshot](https://a.okou.io/fwjd64icz8.png)
