### PR TITLE
refactor(platform): use shadcn primitives in the selection toolbar

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
@@ -81,7 +81,7 @@ function FeedbackToolbar({
       <Button
         type="button"
         variant="quiet"
-        size="sm"
+        size="xs"
         onClick={onCopy}
         aria-keyshortcuts="c"
         className="text-foreground"
@@ -96,7 +96,7 @@ function FeedbackToolbar({
       <Button
         type="button"
         variant="quiet"
-        size="sm"
+        size="xs"
         onClick={onProvideFeedback}
         aria-keyshortcuts="q"
         className="text-foreground"
@@ -113,7 +113,7 @@ function FeedbackToolbar({
           <Button
             type="button"
             variant="quiet"
-            size="sm"
+            size="xs"
             onClick={onForward}
             aria-keyshortcuts="f"
             className="text-foreground"
@@ -265,7 +265,7 @@ function TranslationAction({
     <Button
       type="button"
       variant="quiet"
-      size="sm"
+      size="xs"
       disabled={translating}
       onClick={() => {
         detach(translate(pageSignal), Reason.DomCallback);

--- a/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-feedback-selection.tsx
@@ -11,7 +11,10 @@ import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import {
+  Button,
   getShortcutParts,
+  Kbd,
+  KbdGroup,
   Popover,
   PopoverAnchor,
   PopoverContent,
@@ -51,18 +54,13 @@ function anchorStyle(selection: ChatThreadFeedbackSelection): CSSProperties {
 
 function ShortcutHint({ shortcut }: { readonly shortcut: string }) {
   return (
-    <span aria-hidden="true" className="ml-0.5 inline-flex items-center gap-1">
+    <KbdGroup aria-hidden="true">
       {getShortcutParts(shortcut).map((part) => {
         return (
-          <kbd
-            key={part}
-            className='inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-background px-1 text-[10px] font-medium leading-none text-muted-foreground shadow-[inset_0_-1px_0_hsl(var(--border)),0_0_0_1px_hsl(var(--border))] font-["-apple-system",BlinkMacSystemFont,"Segoe_UI",system-ui,sans-serif]'
-          >
-            {part.length === 1 ? part.toUpperCase() : part}
-          </kbd>
+          <Kbd key={part}>{part.length === 1 ? part.toUpperCase() : part}</Kbd>
         );
       })}
-    </span>
+    </KbdGroup>
   );
 }
 
@@ -80,46 +78,52 @@ function FeedbackToolbar({
   const { t } = useTranslation();
   return (
     <div className="flex items-center gap-0.5">
-      <button
+      <Button
         type="button"
+        variant="quiet"
+        size="sm"
         onClick={onCopy}
         aria-keyshortcuts="c"
-        className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
+        className="text-foreground"
       >
-        <Copy size={14} />
+        <Copy />
         {t(($) => {
           return $.chat.actions.copy;
         })}
         <ShortcutHint shortcut="c" />
-      </button>
+      </Button>
       <div className="h-4 w-px bg-border" />
-      <button
+      <Button
         type="button"
+        variant="quiet"
+        size="sm"
         onClick={onProvideFeedback}
         aria-keyshortcuts="q"
-        className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
+        className="text-foreground"
       >
-        <MessageCircle size={14} />
+        <MessageCircle />
         {t(($) => {
           return $.chat.feedback.quote;
         })}
         <ShortcutHint shortcut="q" />
-      </button>
+      </Button>
       {onForward ? (
         <>
           <div className="h-4 w-px bg-border" />
-          <button
+          <Button
             type="button"
+            variant="quiet"
+            size="sm"
             onClick={onForward}
             aria-keyshortcuts="f"
-            className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground"
+            className="text-foreground"
           >
-            <Forward size={14} />
+            <Forward />
             {t(($) => {
               return $.chat.forward.action;
             })}
             <ShortcutHint shortcut="f" />
-          </button>
+          </Button>
         </>
       ) : null}
       {translation ? (
@@ -258,25 +262,27 @@ function TranslationAction({
   const translate = useSet(feedback.translate$);
   const translating = useTranslationLoading(feedback);
   return (
-    <button
+    <Button
       type="button"
+      variant="quiet"
+      size="sm"
       disabled={translating}
       onClick={() => {
         detach(translate(pageSignal), Reason.DomCallback);
       }}
       aria-keyshortcuts="t"
-      className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-state-hover hover:text-accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
+      className="text-foreground"
     >
       {translating ? (
-        <Loader2 size={14} className="animate-spin" aria-hidden />
+        <Loader2 className="animate-spin" aria-hidden />
       ) : (
-        <Languages size={14} />
+        <Languages />
       )}
       {t(($) => {
         return $.chat.translation.action;
       })}
       <ShortcutHint shortcut="t" />
-    </button>
+    </Button>
   );
 }
 

--- a/turbo/packages/ui/src/components/ui/kbd.tsx
+++ b/turbo/packages/ui/src/components/ui/kbd.tsx
@@ -1,0 +1,28 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "../../lib/utils";
+
+function Kbd({ className, ...props }: ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 [&_svg:not([class*='size-'])]:size-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function KbdGroup({ className, ...props }: ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+export { Kbd, KbdGroup };

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -15,6 +15,7 @@ export {
 export { Checkbox } from "./components/ui/checkbox";
 export { CopyButton, type CopyButtonProps } from "./components/ui/copy-button";
 export { Input } from "./components/ui/input";
+export { Kbd, KbdGroup } from "./components/ui/kbd";
 export {
   MultiSelectCombobox,
   type ComboboxOption,


### PR DESCRIPTION
The selected-text toolbar uses handwritten native buttons with 12px labels, 14px icons, and custom 10px keycaps. Replace these with the shared `Button` size and alignment rules and the official shadcn `base-vega` `Kbd`/`KbdGroup` primitives so Copy, Quote, Forward, and Translate use consistent control sizing. Use the existing `xs` button size to keep the three primary actions inside a 375px viewport.

Remove the toolbar's custom keycap font stack, forced line height, inset shadow, and local icon sizes. Keep the selection handlers, shortcuts, translation loading behavior, and popover anchoring intact. The existing layout already used flex centering; no vertical pixel offset was found or added.

Reference: https://ui.shadcn.com/docs/components/base/kbd#button

Validation:
- PASS — CI on `5c916f4d4ea9a6a1f1b6378c605d5560be0535c9`: 78 successful checks, 20 skipped, no failures or pending checks. Includes full platform type checks and tests: https://github.com/vm0-ai/vm0/actions/runs/34025680077
- PASS — Local Prettier, `git diff --check`, shared UI lint/type checks, changed-file platform lint (including type-aware checks), and scoped Knip.
- PASS — Desktop at 1280 × 900: shared 28px buttons, 16px icons, and 20px keycaps are vertically centered. Hover styles work for Copy, Quote, Forward, and the optional Translate action.
- PASS — Native selection and Copy followed by native paste reproduce the exact selected passage; the Q shortcut opens the quote composer; Forward opens the populated destination dialog.
- PASS — Three primary actions at 375 × 812: toolbar bounds are x=5–371.47px and document width is 375px, with no horizontal overflow.

Browser target: App https://pr-32008-app-okou-app-preview.vm0.workers.dev with API https://pr-32008-api.vm6.ai, deployed from the head above. Tested in headed Chromium 152 on Linux with an isolated Clerk test account and one mock assistant response. Onboarding was skipped through “I will explore on my own”; `_realAgentInPreview` remained off. `chatTranslation` was temporarily enabled to check its desktop rendering and hover, then restored to off; translation service output was not part of this visual check.

Desktop detail:

![Selection toolbar with standard button and keycap alignment](https://a.okou.io/0h0bowzs9x.png)

[375px viewport screenshot](https://a.okou.io/fz3oxd88qp.png)
