### PR TITLE
fix: default voice input to gemini 3.1 flash-lite

### DIFF
--- a/docs/voice-input-benchmark.md
+++ b/docs/voice-input-benchmark.md
@@ -3,9 +3,10 @@
 Use one deployed PR App/API commit, one ordinary test organization, and a fixed
 audio corpus. Enable `voiceInputV2` and `_debug` at `/_/lab`, then choose **Voice
 input model** in **Settings → Debug**. The selection is a per-member preference
-scoped to the current organization. **Default** clears it and uses Gemini 3.6
-Flash. Changing the Debug switch only controls access to the settings and timing
-diagnostics; a saved model preference remains effective.
+scoped to the current organization. An unset preference or **Default** uses
+Gemini 3.1 Flash-Lite (`google/gemini-3.1-flash-lite`); choosing **Default** clears
+the saved preference. Changing the Debug switch only controls access to the
+settings and timing diagnostics; a saved model preference remains effective.
 
 Lab overrides already apply to every registered switch. The voice transcription
 and polish endpoints now honor those overrides without an additional staff-org
@@ -20,13 +21,13 @@ Gemini 3.8 Flash was the latest Gemini 3.x Flash in that catalog. Names in the
 picker refer to explicit model IDs; record the date and upstream response IDs
 as well, since providers can update an endpoint behind an existing ID.
 
-| Models                                                           | Provider path                           | Processing                                                                                                                                                                              |
-| ---------------------------------------------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Gemini 2.5 Flash-Lite, 3.1 Flash-Lite, 3.6 Flash, 3.8 Flash      | OpenRouter chat completions             | Short audio: combined transcription and polish; long audio: parallel chunk transcription, then polish with the selected model                                                           |
-| OpenAI GPT Audio, GPT Audio Mini                                 | OpenRouter chat completions             | Short audio: combined transcription and polish; long audio: selected model transcribes chunks, then Gemini 3.6 Flash polishes the text. JSON is prompt-constrained and server-validated |
-| Qwen3 ASR Flash, ASR 1.7B, ASR 0.6B                              | OpenRouter audio transcriptions         | Transcription, then Gemini 3.6 Flash polish                                                                                                                                             |
-| OpenAI GPT Transcribe, GPT-4o Transcribe, GPT-4o Mini Transcribe | OpenRouter audio transcriptions         | Transcription, then Gemini 3.6 Flash polish                                                                                                                                             |
-| ElevenLabs Scribe v2                                             | fal synchronous speech-to-text endpoint | Transcription, then Gemini 3.6 Flash polish                                                                                                                                             |
+| Models                                                           | Provider path                           | Processing                                                                                                                                                                                   |
+| ---------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Gemini 2.5 Flash-Lite, 3.1 Flash-Lite, 3.6 Flash, 3.8 Flash      | OpenRouter chat completions             | Short audio: combined transcription and polish; long audio: parallel chunk transcription, then polish with the selected model                                                                |
+| OpenAI GPT Audio, GPT Audio Mini                                 | OpenRouter chat completions             | Short audio: combined transcription and polish; long audio: selected model transcribes chunks, then Gemini 3.1 Flash-Lite polishes the text. JSON is prompt-constrained and server-validated |
+| Qwen3 ASR Flash, ASR 1.7B, ASR 0.6B                              | OpenRouter audio transcriptions         | Transcription, then Gemini 3.1 Flash-Lite polish                                                                                                                                             |
+| OpenAI GPT Transcribe, GPT-4o Transcribe, GPT-4o Mini Transcribe | OpenRouter audio transcriptions         | Transcription, then Gemini 3.1 Flash-Lite polish                                                                                                                                             |
+| ElevenLabs Scribe v2                                             | fal synchronous speech-to-text endpoint | Transcription, then Gemini 3.1 Flash-Lite polish                                                                                                                                             |
 
 The API uses its existing `OPENROUTER_API_KEY` and, for Scribe, `FAL_KEY`.
 Unavailable credentials or provider errors produce an explicit failure; a
@@ -34,10 +35,16 @@ comparison never silently changes to another transcription model. The existing
 audio-input quota, duration limits, and successful-use accounting still apply.
 
 GPT Audio's pure-text polish requests returned upstream HTTP 400 during the
-YouTube pilot. Its long-recording path therefore selects Gemini 3.6 Flash for
-polish before making requests; this is an explicit pipeline choice, not an
-error-triggered retry with another transcription model. Debug headers report both
-models. Short GPT Audio requests keep their combined audio-based path.
+YouTube pilot. Its long-recording path therefore selects the shared default
+Gemini text model for polish before making requests; this is an explicit
+pipeline choice, not an error-triggered retry with another transcription model.
+Debug headers report both models. Short GPT Audio requests keep their combined
+audio-based path.
+
+The historical YouTube pilot in [PR #31982](https://github.com/vm0-ai/vm0/pull/31982)
+used Gemini 3.6 Flash as its default and shared text-polish model. Its recorded
+commits, model IDs, and results describe that configuration; the current default
+change does not revise those measurements or rerun that benchmark.
 
 ## Corpus
 

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
@@ -27,6 +27,7 @@ const mocks = createRouteMocks(context);
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 
 interface OpenRouterRequest {
+  readonly model: string;
   readonly reasoning?: {
     readonly effort?: string;
     readonly enabled?: boolean;
@@ -192,7 +193,7 @@ describe("POST /api/voice-io/transcribe", () => {
     await accept(
       preferencesClient().update({
         headers,
-        body: { voiceInputModel: "google/gemini-3.8-flash" },
+        body: { voiceInputModel: "google/gemini-3.6-flash" },
       }),
       [200],
     );
@@ -230,9 +231,9 @@ describe("POST /api/voice-io/transcribe", () => {
       language: "en",
     });
     expect(models).toStrictEqual([
-      "google/gemini-3.8-flash",
-      "google/gemini-3.8-flash",
-      "google/gemini-3.8-flash",
+      "google/gemini-3.6-flash",
+      "google/gemini-3.6-flash",
+      "google/gemini-3.6-flash",
     ]);
   });
 
@@ -294,7 +295,11 @@ describe("POST /api/voice-io/transcribe", () => {
         }),
         [200],
       );
-      expect(models).toStrictEqual([model, model, "google/gemini-3.6-flash"]);
+      expect(models).toStrictEqual([
+        model,
+        model,
+        "google/gemini-3.1-flash-lite",
+      ]);
       expect(response.body).toStrictEqual({
         transcript: "Ship Monday Ship Monday",
         polishedText: "Ship Monday.",
@@ -302,7 +307,7 @@ describe("POST /api/voice-io/transcribe", () => {
       });
       expect(response.headers.get("X-Voice-Input-Model")).toBe(model);
       expect(response.headers.get("X-Voice-Polish-Model")).toBe(
-        "google/gemini-3.6-flash",
+        "google/gemini-3.1-flash-lite",
       );
     },
   );
@@ -364,6 +369,11 @@ describe("POST /api/voice-io/transcribe", () => {
     },
     {
       model: "google/gemini-3.1-flash-lite",
+      reasoning: "minimal",
+      maxTokens: 65_536,
+    },
+    {
+      model: "google/gemini-3.6-flash",
       reasoning: "minimal",
       maxTokens: 65_536,
     },
@@ -506,10 +516,12 @@ describe("POST /api/voice-io/transcribe", () => {
             }
           : { model, input_audio: { format: "wav" }, response_format: "json" },
       );
-      expect(polishRequest).toMatchObject({ model: "google/gemini-3.6-flash" });
+      expect(polishRequest).toMatchObject({
+        model: "google/gemini-3.1-flash-lite",
+      });
       expect(response.headers.get("X-Voice-Input-Model")).toBe(model);
       expect(response.headers.get("X-Voice-Polish-Model")).toBe(
-        "google/gemini-3.6-flash",
+        "google/gemini-3.1-flash-lite",
       );
       expect(response.headers.get("Server-Timing")).toContain(
         "voice_transcribe;dur=",
@@ -573,7 +585,9 @@ describe("POST /api/voice-io/transcribe", () => {
       [200],
     );
     expect(response.body.polishedText).toBe("Hello.");
-    expect(providerRequest).toMatchObject({ model: "google/gemini-3.6-flash" });
+    expect(providerRequest).toMatchObject({
+      model: "google/gemini-3.1-flash-lite",
+    });
   });
 
   it.each([
@@ -750,7 +764,7 @@ describe("POST /api/voice-io/transcribe", () => {
       language: "en-US",
     });
     expect(providerRequest).toMatchObject({
-      model: "google/gemini-3.6-flash",
+      model: "google/gemini-3.1-flash-lite",
       max_tokens: 65_536,
       reasoning: { effort: "minimal" },
       temperature: 0,
@@ -920,11 +934,21 @@ describe("POST /api/voice-io/transcribe", () => {
 
   it("uses transcript-only audio processing and one global polish for a long single file", async () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    await enabledActor();
+    const actor = await enabledActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId },
+      { [FeatureSwitchKey.OkouDebug]: true },
+    );
     const schemaNames: string[] = [];
+    const models: string[] = [];
     server.use(
       http.post(OPENROUTER_URL, async ({ request }) => {
         const body = (await request.json()) as OpenRouterRequest;
+        models.push(body.model);
         const reasoningError = rejectDisabledReasoning(body);
         if (reasoningError) {
           return reasoningError;
@@ -965,6 +989,16 @@ describe("POST /api/voice-io/transcribe", () => {
       "voice_transcript",
       "polished_voice_transcript",
     ]);
+    expect(models).toStrictEqual([
+      "google/gemini-3.1-flash-lite",
+      "google/gemini-3.1-flash-lite",
+    ]);
+    expect(response.headers.get("X-Voice-Input-Model")).toBe(
+      "google/gemini-3.1-flash-lite",
+    );
+    expect(response.headers.get("X-Voice-Polish-Model")).toBe(
+      "google/gemini-3.1-flash-lite",
+    );
   });
 
   it("rejects more files than the five-minute chunk policy can produce", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/preferences-page.test.tsx
@@ -18,7 +18,7 @@ const context = testContext();
 
 test("Debug preferences restore, change, and reset the voice input model", async () => {
   const updates = mockPreferences({
-    voiceInputModel: "google/gemini-3.8-flash",
+    voiceInputModel: "google/gemini-3.6-flash",
   });
   await setupPage({
     context,
@@ -29,7 +29,7 @@ test("Debug preferences restore, change, and reset the voice input model", async
     name: "Voice input model",
   });
   await waitFor(() => {
-    return expect(picker).toHaveTextContent("Gemini 3.8 Flash");
+    return expect(picker).toHaveTextContent("Gemini 3.6 Flash");
   });
   click(picker);
   click(await screen.findByRole("option", { name: "ElevenLabs Scribe v2" }));
@@ -41,10 +41,12 @@ test("Debug preferences restore, change, and reset the voice input model", async
   });
   click(picker);
   click(
-    await screen.findByRole("option", { name: "Default (Gemini 3.6 Flash)" }),
+    await screen.findByRole("option", {
+      name: "Default (Gemini 3.1 Flash-Lite)",
+    }),
   );
   await waitFor(() => {
-    return expect(picker).toHaveTextContent("Default (Gemini 3.6 Flash)");
+    return expect(picker).toHaveTextContent("Default (Gemini 3.1 Flash-Lite)");
   });
   expect(updates).toContainEqual({ voiceInputModel: null });
 });

--- a/turbo/packages/api-contracts/src/contracts/voice-input-models.ts
+++ b/turbo/packages/api-contracts/src/contracts/voice-input-models.ts
@@ -71,4 +71,4 @@ export const voiceInputModelIdSchema = z.enum(
 );
 
 export const DEFAULT_VOICE_INPUT_MODEL =
-  "google/gemini-3.6-flash" satisfies MultimodalVoiceInputModelId;
+  "google/gemini-3.1-flash-lite" satisfies MultimodalVoiceInputModelId;


### PR DESCRIPTION
## Summary

Use Gemini 3.1 Flash-Lite (`google/gemini-3.1-flash-lite`) as the shared voice input v2 default when no preference is saved or the user selects Default. Explicit preferences remain effective, including Gemini 3.6 Flash; long GPT Audio recordings and dedicated STT models continue using the shared text-capable model for polish.

Update route and settings integration coverage and current benchmark instructions. The historical models, commits, and measurements from #31982 remain unchanged.

## Verification

- Voice transcription API integration tests: 30 passed (real local PostgreSQL, MSW provider boundaries).
- Preferences page integration tests: 9 passed.
- Formatting and commitlint passed.
- Full repository lint passed with the required 3072 MiB heap and concurrency 1 (14 tasks).
- Full repository type checking passed (15 tasks); Knip passed.
- Local hook verification uses a temporary 600-second Knip timeout and restores the standalone tool PATH so Turbo can reuse the completed type checks. All applicable pre-commit jobs run for the four changed files; repository hook configuration is unchanged.
- Full test and deployment checks run in the PR pipeline.
