### PR TITLE
fix(platform): align pinned chat tab order with visual layout

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-pin-order.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-pin-order.test.tsx
@@ -97,7 +97,7 @@ function dragEvent(
   );
 }
 
-test("keyboard reorder is optimistic and survives the matching persisted event", async () => {
+test("keyboard reorder follows visual tab order and survives the matching persisted event", async () => {
   const caseId = 61;
   const pending = context.mocks.deferred<void>();
   const requested = context.mocks.deferred<ChatThreadEvent>();
@@ -116,10 +116,23 @@ test("keyboard reorder is optimistic and survives the matching persisted event",
   );
   const { stream, snapshot } = await prepare(caseId);
   const grip = handle("Last pin");
+  const row = slot("Last pin");
+  const link = queryAllByRoleFast("link", row)[0];
+  const menuButton = queryAllByRoleFast("button", row).find((button) => {
+    return button.getAttribute("aria-label") === "Open chat menu";
+  });
   const user = userEvent.setup();
   act(() => {
     grip.focus();
   });
+  await user.keyboard("{Tab}");
+  expect(link).toHaveFocus();
+  await user.keyboard("{Tab}");
+  expect(menuButton).toHaveFocus();
+  await user.keyboard("{Shift>}{Tab}{/Shift}");
+  expect(link).toHaveFocus();
+  await user.keyboard("{Shift>}{Tab}{/Shift}");
+  expect(grip).toHaveFocus();
   await user.keyboard(" ");
   await user.keyboard("{ArrowUp}");
   expect(screen.queryByRole("menu")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.tsx
@@ -174,12 +174,12 @@ export function PinnedThreadRow({
           : undefined
       }
     >
-      {children}
       {reorderable && (
         <div className="pointer-events-none absolute left-0 top-0 h-8 w-8 overflow-hidden">
           <ThreadDragHandle signals={signals} dragSignals={dragSignals} />
         </div>
       )}
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Tabbing through a pinned chat visited its title, then the right-hand menu, then the left-hand drag handle. Render the handle before the row content so focus follows the visual order: drag handle → title → menu, with the reverse order for Shift+Tab.

Extend the existing page-level keyboard reorder test to check both directions before picking up, moving, and persisting a pin.

## Verification

- Formatting, scoped ESLint/oxlint (including type-aware lint), Platform type checks, and Platform Knip passed.
- The Tab regression fails against the original component and passes with the fix.
- All PR CI checks passed on `179cd80e345a8e00c400195140895cf23450fd95`, including all eight App test shards.
- Local `sidebar-pin-order.test.tsx`: 11 passed, 1 failed during initial page setup. The unchanged remote pointer-drag cancellation case also fails in isolation with the original component restored; the full App suite passed in PR CI.
- Browser PASS: forward/reverse Tab across adjacent pinned rows; Enter/Escape menu operation and focus restoration; Space/ArrowUp/Space reorder with focus retained; Escape cancellation; reordered pins persist after reload. Drag-handle and menu hover feedback also checked.
- Tested [the PR preview](https://pr-32016-app-okou-app-preview.vm0.workers.dev/) in Chromium 151 at 1440×900, with `stableChatThreadNavigation` enabled, two pinned chats, and one regular chat. Onboarding was completed through the preview API. The deployed merge commit `1612ad5e9d243677ff298e9bb535d8d119c64947` includes the PR head above.
- [Browser screenshot: focused drag handle](https://a.okou.io/8afvjbszir.png)
