### PR TITLE
test(ci): keep exec sandbox alive until teardown

### DIFF
--- a/.github/scripts/runner-behavior-exec-remote.sh
+++ b/.github/scripts/runner-behavior-exec-remote.sh
@@ -682,9 +682,10 @@ DNS_INPUT_TCP_BEFORE=$(rule_packet_count "$DNS_INPUT_TCP_RULE")
 [ -n "$DNS_INPUT_UDP_BEFORE" ] || fail "IPv4 UDP DNS INPUT counter missing"
 [ -n "$DNS_INPUT_TCP_BEFORE" ] || fail "IPv4 TCP DNS INPUT counter missing"
 
-# Submit a long-running job in background (keeps sandbox alive during tests)
+# Keep the sandbox active until the service-stop cleanup assertions run.
 echo "--- Submitting long-running job ---"
-sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &
+sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+  --prompt 'rm -f /tmp/vm0-exec-keepalive && mkfifo /tmp/vm0-exec-keepalive && cat /tmp/vm0-exec-keepalive >/dev/null' &
 SUBMIT_PID=$!
 
 # Wait for OUR runner's sandbox to have a control socket.


### PR DESCRIPTION
## Summary

- replace the runner exec behavior test's fixed 120-second mock job with a FIFO-blocked job
- keep the sandbox alive until the existing service-stop and EXIT cleanup paths terminate it
- prevent slow cold guest builds from losing their control socket during normal sandbox finalization

## Scope

- test infrastructure only
- no production runner changes, retries, timeout increases, or skipped assertions

## Validation

- `bash -n .github/scripts/runner-behavior-exec-remote.sh`
- `shellcheck .github/scripts/runner-behavior-exec-remote.sh`
- `.github/scripts/tests/runner-behavior-durable-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/crates.yml`
- `git diff --check`

Closes #32018
