### PR TITLE
fix(python): keep resolved auth header bytes consistent

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -631,8 +631,8 @@ def _apply_header_query_injection(
     if auth_pairs:
         resolved_fields_by_name: dict[bytes, tuple[bytes, bytes]] = {}
         for header_name, header_value in auth_pairs:
-            encoded_name = header_name.encode()
-            encoded_value = header_value.encode()
+            encoded_name = header_name.encode("ascii")
+            encoded_value = header_value.encode("latin-1")
             normalized_name = encoded_name.lower()
             existing_field = resolved_fields_by_name.get(normalized_name)
             if existing_field is None:

--- a/crates/runner/mitm-addon/src/auth_base_transport.py
+++ b/crates/runner/mitm-addon/src/auth_base_transport.py
@@ -368,10 +368,11 @@ def resolved_auth_header_pairs(headers) -> list[tuple[str, str]]:
     """Validate and filter resolved auth headers before outbound injection.
 
     Each resolved header name and value is validated before any pair is
-    returned; invalid pairs raise ``InvalidResolvedAuthHeaderError``. Transport,
-    authority, and framing headers are then dropped. This helper does not merge
-    with or replace client headers; callers that combine resolved and client
-    headers own that policy.
+    returned; invalid pairs raise ``InvalidResolvedAuthHeaderError``. Accepted
+    names are ASCII and accepted values map one-to-one to wire bytes through
+    Latin-1. Transport, authority, and framing headers are then dropped. This
+    helper does not merge with or replace client headers; callers that combine
+    resolved and client headers own that policy.
     """
     pairs = header_pairs(headers)
     for name, value in pairs:

--- a/crates/runner/mitm-addon/tests/test_auth_header_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_header_injection.py
@@ -46,6 +46,7 @@ async def test_bulk_headers_preserve_semantics_without_per_header_rebuilds(
         "Content-Length": "999",
         "Transfer-Encoding": "chunked",
         "Proxy-Authorization": "Basic filtered",
+        "X-Latin-1": "café",
         **bulk_headers,
     }
     flow = real_flow(
@@ -124,5 +125,6 @@ async def test_bulk_headers_preserve_semantics_without_per_header_rebuilds(
         (b"X-Keep", b"two"),
         (b"X-Bulk-0000", b"resolved-0"),
         (b"Content-Length", b"7"),
+        (b"X-Latin-1", b"caf\xe9"),
         *((name.encode(), value.encode()) for name, value in list(bulk_headers.items())[1:]),
     )

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
@@ -942,6 +942,7 @@ class TestHandleFirewallRequest:
             pytest.param({"Bad\nName": "value"}, id="newline-name"),
             pytest.param({":authority": "evil.example.com"}, id="pseudo-header-name"),
             pytest.param({"X-Test": "bad\r\nX-Injected: value"}, id="newline-value"),
+            pytest.param({"X-Test": "snowman ☃"}, id="non-latin-1-value"),
         ],
     )
     async def test_standard_auth_rejects_malformed_resolved_headers(

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -527,10 +527,17 @@ class TestAuthBaseUrlRewriteForwarding:
         assert upstream.socket.request_header_values("X-Injected") == []
         assert upstream.socket.request_header_values("X-Keep") == []
 
-    async def test_forward_request_rejects_malformed_injected_header(
-        self, real_flow, mitm_ctx, tmp_path
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [
+            pytest.param("bad\r\nX-Injected: value", id="newline"),
+            pytest.param("snowman ☃", id="non-latin-1"),
+        ],
+    )
+    async def test_forward_request_rejects_invalid_injected_header(
+        self, real_flow, mitm_ctx, tmp_path, invalid_value: str
     ):
-        """Malformed resolved auth headers fail before auth.base forwarding."""
+        """Invalid resolved auth headers fail before auth.base forwarding."""
         flow, allow, sandbox_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
             tmp_path,
@@ -544,7 +551,7 @@ class TestAuthBaseUrlRewriteForwarding:
         )
         token_meta["headers"] = {
             "Authorization": "Bearer real-token",
-            "X-Test": "bad\r\nX-Injected: value",
+            "X-Test": invalid_value,
         }
         mock_forward = AsyncMock(return_value=(200, b"ok", {}))
         with (

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -51,6 +51,7 @@ class TestAuthBaseUrlRewriteForwarding:
                 "headers": {
                     "Authorization": "Bearer ${{ secrets.TOKEN }}",
                     "X-Custom": "${{ secrets.CUSTOM }}",
+                    "X-Latin-1": "${{ secrets.LATIN_1 }}",
                 },
                 "query": {"api_key": "${{ secrets.API_KEY }}"},
             },
@@ -58,6 +59,7 @@ class TestAuthBaseUrlRewriteForwarding:
                 "headers": {
                     "Authorization": "Bearer real-token",
                     "X-Custom": "injected-value",
+                    "X-Latin-1": "café",
                 },
                 "query": {"api_key": "resolved-key"},
                 "resolved_secrets": ["WEBHOOK", "API_KEY"],
@@ -107,6 +109,8 @@ class TestAuthBaseUrlRewriteForwarding:
         assert upstream.socket.request_header_values("Host") == ["real.example.com"]
         assert upstream.socket.request_header_values("Authorization") == ["Bearer real-token"]
         assert upstream.socket.request_header_values("X-Custom") == ["injected-value"]
+        assert upstream.socket.request_header_values("X-Latin-1") == ["café"]
+        assert b"X-Latin-1: caf\xe9\r\n" in upstream.socket.sent
         assert upstream.socket.request_header_values("X-Repeat") == []
         assert upstream.socket.request_header_values("X-Keep") == []
         assert upstream.socket.request_header_values("Cookie") == []


### PR DESCRIPTION
## Summary

- encode validated resolved auth header names as ASCII and values as Latin-1 when writing mitmproxy raw header fields
- document the existing one-to-one Latin-1 wire-value contract at the resolved-auth validation boundary
- assert identical raw bytes for an accepted non-ASCII value across ordinary `request`, `requestheaders`, and `auth.base` forwarding
- verify non-Latin-1 resolved values remain fail-closed in ordinary and `auth.base` paths

## Scope

- preserves auth header filtering, batching, override order, and malformed-value failure behavior
- does not change auth.base serialization, APIs, persisted state, runner protocols, UI, dependencies, or migrations

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync python -m pytest tests/test_auth_header_injection.py tests/test_firewall_auth_handling.py tests/test_firewall_rewrite_forwarding.py` (121 passed)
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7,278 passed)

Closes #31991
