### PR TITLE
fix(mitm-addon): redact whitespace-separated url userinfo

### DIFF
--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -8,6 +8,7 @@ _URLSPLIT_LEADING_STRIP_CHARACTERS = "".join(chr(codepoint) for codepoint in ran
 _URLSPLIT_REMOVABLE_CHARACTERS = "\t\r\n"
 _SPECIAL_URL_SCHEMES = ("http", "https")
 _SPECIAL_URL_SEPARATORS = "/\\"
+_MALFORMED_AUTHORITY_PREFIX_CHARACTERS = f"{_SPECIAL_URL_SEPARATORS} \v\f"
 
 
 def _normalize_for_urlsplit(value: str) -> str:
@@ -48,7 +49,9 @@ def _sanitize_malformed_authority_for_network_log(
     if not has_special_scheme and not is_protocol_relative:
         return None
 
-    authority_path = parts.path.lstrip(_SPECIAL_URL_SEPARATORS)
+    # SP, VT, and FF survive urlsplit preprocessing when embedded after the
+    # scheme. Treat them only as part of the leading malformed separator run.
+    authority_path = parts.path.lstrip(_MALFORMED_AUTHORITY_PREFIX_CHARACTERS)
     cut_points = [
         index
         for separator in _SPECIAL_URL_SEPARATORS

--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -39,9 +39,9 @@ def _sanitize_url_text_fallback_for_network_log(value: str) -> str:
 def _sanitize_malformed_authority_for_network_log(
     value: str, parts: urllib.parse.SplitResult
 ) -> str | None:
-    # A mixed separator run can leave only backslashes in netloc while the
-    # actual authority-like segment lands in path.
-    if parts.netloc.strip(_SPECIAL_URL_SEPARATORS):
+    # A mixed separator run can leave separators or retained whitespace in
+    # netloc while the actual authority-like segment lands in path.
+    if parts.netloc.strip(_MALFORMED_AUTHORITY_PREFIX_CHARACTERS):
         return None
 
     has_special_scheme = parts.scheme in _SPECIAL_URL_SCHEMES

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -203,6 +203,11 @@ class TestLogProxyEntry:
                 id="form-feed-before-separators",
             ),
             pytest.param(
+                "https:// /user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="space-inside-separator-prefix",
+            ),
+            pytest.param(
                 "https:////first@user:pass@example.com/path?token=secret#fragment",
                 "https://example.com/path",
                 id="multiple-at-signs",

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -188,6 +188,21 @@ class TestLogProxyEntry:
                 id="embedded-urlsplit-controls",
             ),
             pytest.param(
+                "https: //user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="space-before-separators",
+            ),
+            pytest.param(
+                "https:\v//user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="vertical-tab-before-separators",
+            ),
+            pytest.param(
+                "https:\f//user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="form-feed-before-separators",
+            ),
+            pytest.param(
                 "https:////first@user:pass@example.com/path?token=secret#fragment",
                 "https://example.com/path",
                 id="multiple-at-signs",

--- a/crates/runner/mitm-addon/tests/test_response_handler_logging.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_logging.py
@@ -278,6 +278,10 @@ def test_response_log_serializes_common_metadata_independent_of_firewall_context
             "https://target.example.com:9443/path?access_token=secret#fragment",
         ),
         (
+            "https: //user:pass@target.example.com:9443/path?access_token=secret#fragment",
+            "https://target.example.com:9443/path?access_token=secret#fragment",
+        ),
+        (
             "https://target.example.com:9443/users/alice@example.com?access_token=secret#fragment",
             "https://target.example.com:9443/users/alice@example.com?access_token=secret#fragment",
         ),

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -86,9 +86,23 @@ def test_rejects_invalid_url_before_open(tmp_path, sync_usage_executor):
     )
 
 
-def test_rejects_malformed_sensitive_url_without_logging_credentials(tmp_path, sync_usage_executor):
+@pytest.mark.parametrize(
+    "raw_url",
+    [
+        pytest.param(
+            "https:////user:pass@api.vm0.ai/path?token=secret#frag",
+            id="extra-slashes",
+        ),
+        pytest.param(
+            "https: //user:pass@api.vm0.ai/path?token=secret#frag",
+            id="space-before-separators",
+        ),
+    ],
+)
+def test_rejects_malformed_sensitive_url_without_logging_credentials(
+    tmp_path, sync_usage_executor, raw_url
+):
     proxy_log = tmp_path / "proxy.jsonl"
-    raw_url = "https:////user:pass@api.vm0.ai/path?token=secret#frag"
     sanitized_url = "https://api.vm0.ai/path"
     payload = {"runId": "run-1", "events": []}
     payload_bytes = len(json.dumps(payload).encode())


### PR DESCRIPTION
## Summary

- treat space, vertical tab, and form feed as part of the leading malformed HTTP(S) authority prefix before persistent-log URL rendering
- recover safely when a mixed prefix is split between `netloc` and `path`, while keeping slash and reverse-solidus as the only authority/path cut points
- cover proxy JSONL, invalid-webhook diagnostics, and network-log rendering while preserving raw request metadata

## Scope

- log rendering only
- no request URL, validation, retry, delivery accounting, firewall, billing, schema, protocol, dependency, or migration changes
- proxy/webhook query and fragment removal and network-log query and fragment retention remain unchanged

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_logging_utils.py tests/test_webhook_http_delivery.py tests/test_response_handler_logging.py` (149 passed)
- `uv run --no-sync python -m pytest tests/` (7,282 passed)
- Python 3.12.3 and 3.14.0 malformed-prefix matrix checks (781 prefixes each)
- `git diff --check`
- repository pre-commit hook

Closes #32000
