### PR TITLE
test(runner): cover partial unit write cleanup

### DIFF
--- a/crates/runner/src/cmd/service/unit_file.rs
+++ b/crates/runner/src/cmd/service/unit_file.rs
@@ -290,6 +290,14 @@ pub(super) fn cleanup_unit_staging_files(path: &Path) -> RunnerResult<()> {
 /// the unit in a broken state. The staging file is unique so concurrent
 /// installs for the same unit do not share a writable temp path.
 pub(super) fn write_unit_file(path: &Path, content: &str) -> RunnerResult<()> {
+    write_unit_file_with(path, content, |file, content| file.write_all(content))
+}
+
+fn write_unit_file_with(
+    path: &Path,
+    content: &str,
+    write: impl Fn(&mut std::fs::File, &[u8]) -> std::io::Result<()>,
+) -> RunnerResult<()> {
     for _ in 0..UNIT_STAGING_MAX_ATTEMPTS {
         let attempt = UNIT_STAGING_COUNTER.fetch_add(1, Ordering::Relaxed);
         let tmp = unit_staging_path(path, attempt)?;
@@ -320,7 +328,7 @@ pub(super) fn write_unit_file(path: &Path, content: &str) -> RunnerResult<()> {
                 )));
             }
         }
-        if let Err(e) = file.write_all(content.as_bytes()) {
+        if let Err(e) = write(&mut file, content.as_bytes()) {
             let _ = std::fs::remove_file(&tmp);
             return Err(RunnerError::Internal(format!(
                 "write {}: {e}",
@@ -805,6 +813,45 @@ mod tests {
         let path = dir.path().join("vm0-runner-test.service");
         write_unit_file(&path, "content").unwrap();
         assert_no_unit_staging_files(dir.path(), "vm0-runner-test.service");
+    }
+
+    #[test]
+    fn write_unit_file_cleans_up_staging_on_partial_write_failure() {
+        const SECRET: &str = "sentinel-partial-unit-secret";
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("vm0-runner-test.service");
+        let original = b"[Unit]\nDescription=existing\n";
+        std::fs::write(&path, original).unwrap();
+        let secret_prefix = format!("[Service]\nEnvironment=\"TOKEN={SECRET}");
+        let replacement = format!("{secret_prefix}\"\nExecStart=/bin/true\n");
+
+        let result = write_unit_file_with(&path, &replacement, |file, content| {
+            file.write_all(content.get(..secret_prefix.len()).unwrap())?;
+            Err(std::io::Error::other("injected partial write failure"))
+        });
+
+        let error = result.unwrap_err().to_string();
+        assert!(
+            error.contains("injected partial write failure"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), original);
+        assert_no_unit_staging_files(dir.path(), "vm0-runner-test.service");
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
+            let entry = entry.unwrap();
+            if !entry.file_type().unwrap().is_file() {
+                continue;
+            }
+            let content = std::fs::read(entry.path()).unwrap();
+            assert!(
+                !content
+                    .windows(SECRET.len())
+                    .any(|window| window == SECRET.as_bytes()),
+                "residual file {} contains the secret",
+                entry.path().display()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep the production `write_unit_file` entry point while adding a private seam for the staging write operation
- deterministically write a secret-bearing prefix and then fail to cover write-error cleanup
- verify the existing unit remains unchanged and no staging or secret-bearing residual file survives

## Scope

- no public API, runtime behavior, dependency, protocol, persistence, migration, or rollout changes
- existing success, concurrent-writer, permission, and rename-failure coverage remains intact

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner cmd::service::unit_file::tests::write_unit_file_cleans_up_staging_on_partial_write_failure -- --exact`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --no-deps`
- mutation check: the focused test fails with a residual `.tmp@...` file when write-error cleanup is temporarily removed, then passes after restoration
- pre-commit Rust formatting, workspace Clippy, and workspace rustdoc hooks

Closes #31997
