### PR TITLE
perf(python): bound accept-encoding negotiation work

### DIFF
--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -1,14 +1,19 @@
 """Request-side response encoding negotiation for body-inspected flows."""
 
 import re
+from collections.abc import Iterable, Iterator
 from decimal import Decimal, InvalidOperation
-from typing import Literal
+from typing import Final, Literal
 
 from mitmproxy import http
 
 import body_decoding
 
 _ACCEPT_ENCODING = "Accept-Encoding"
+_RAW_ACCEPT_ENCODING: Final = b"accept-encoding"
+# Accept an inclusive 64 KiB aggregate of matching raw values. This bounds
+# addon-owned negotiation work after mitmproxy has parsed the request head.
+_MAX_ACCEPT_ENCODING_VALUE_BYTES: Final = 64 * 1024
 _IDENTITY = "identity"
 _WILDCARD = "*"
 _STREAM_DECODABLE_ENCODINGS = body_decoding.stream_decodable_content_encodings()
@@ -22,6 +27,7 @@ type ResponseEncodingNegotiationOutcome = Literal[
     "already_stream_decodable",
     "rewritten_stream_decodable",
     "preserved_client_constraints",
+    "preserved_work_budget",
 ]
 
 
@@ -35,13 +41,17 @@ def normalize_accept_encoding_for_body_inspection(
     provide the needed bounded-output behavior. Brotli participates under the
     documented soft output-limit contract in ``body_decoding``.
 
-    The helper preserves explicit requester rejections.  When ``identity`` and
-    every supported compression coding are rejected, the original header remains
-    unchanged and the actual response might not support bounded streaming
-    inspection.  Callers must use the response's ``Content-Encoding`` to decide
-    whether incremental body inspection is available. The return value records
-    whether the request was already safe, rewritten, or preserved by constraint.
+    The helper preserves explicit requester rejections. When ``identity`` and
+    every supported compression coding are rejected, or the matching raw values
+    exceed the parser's work budget, the original header remains unchanged and
+    the actual response might not support bounded streaming inspection. Callers
+    must use the response's ``Content-Encoding`` to decide whether incremental
+    body inspection is available. The return value records whether the request
+    was already safe, rewritten, or preserved and why.
     """
+    if not _accept_encoding_values_within_budget(headers):
+        return "preserved_work_budget"
+
     values = headers.get_all(_ACCEPT_ENCODING)
     if not values:
         headers[_ACCEPT_ENCODING] = _IDENTITY
@@ -57,13 +67,12 @@ def normalize_accept_encoding_for_body_inspection(
     wildcard_rejected = False
 
     for raw_value in values:
-        for raw_coding in raw_value.split(","):
-            name, q_value = _parse_coding(raw_coding)
+        for raw_coding in _iter_delimited(raw_value, ","):
+            name, q_value, q_text = _parse_coding(raw_coding)
             if not name:
                 continue
 
             accepted = q_value is None or q_value > _MIN_Q_VALUE
-            q_text = _q_text(raw_coding)
 
             if name == _IDENTITY:
                 if accepted:
@@ -118,45 +127,66 @@ def normalize_accept_encoding_for_body_inspection(
     return "already_stream_decodable"
 
 
-def _parse_coding(raw_coding: str) -> tuple[str, Decimal | None]:
-    parts = raw_coding.split(";")
-    name = parts[0].strip(_HTTP_OWS_CHARS).lower()
-    q_value = _parse_q_value(parts[1:])
-    return name, q_value
+def _accept_encoding_values_within_budget(headers: http.Headers) -> bool:
+    """Bound matching raw values before mitmproxy decodes them."""
+    remaining_bytes = _MAX_ACCEPT_ENCODING_VALUE_BYTES
+    for raw_name, raw_value in headers.fields:
+        if raw_name.lower() != _RAW_ACCEPT_ENCODING:
+            continue
+        if len(raw_value) > remaining_bytes:
+            return False
+        remaining_bytes -= len(raw_value)
+    return True
 
 
-def _parse_q_value(parameters: list[str]) -> Decimal | None:
+def _iter_delimited(value: str, delimiter: str, *, start: int = 0) -> Iterator[str]:
+    while True:
+        end = value.find(delimiter, start)
+        if end == -1:
+            yield value[start:]
+            return
+        yield value[start:end]
+        start = end + len(delimiter)
+
+
+def _parse_coding(raw_coding: str) -> tuple[str, Decimal | None, str | None]:
+    parameter_separator = raw_coding.find(";")
+    if parameter_separator == -1:
+        name = raw_coding.strip(_HTTP_OWS_CHARS).lower()
+        return name, None, None
+    name = raw_coding[:parameter_separator].strip(_HTTP_OWS_CHARS).lower()
+    q_value, q_text = _parse_q_value(
+        _iter_delimited(raw_coding, ";", start=parameter_separator + 1)
+    )
+    return name, q_value, q_text
+
+
+def _parse_q_value(parameters: Iterable[str]) -> tuple[Decimal | None, str | None]:
     saw_q_value = False
     parsed_q_value: Decimal | None = None
+    parsed_q_text: str | None = None
     for parameter in parameters:
         parameter = parameter.strip(_HTTP_OWS_CHARS)
         if not parameter:
-            return _INVALID_Q_VALUE
+            return _INVALID_Q_VALUE, None
         key, separator, value = parameter.partition("=")
         if not separator or key.strip(_HTTP_OWS_CHARS).lower() != "q":
-            return _INVALID_Q_VALUE
+            return _INVALID_Q_VALUE, None
         if saw_q_value:
-            return _INVALID_Q_VALUE
+            return _INVALID_Q_VALUE, None
         saw_q_value = True
         q_text = value.strip(_HTTP_OWS_CHARS)
         if not _Q_VALUE_PATTERN.fullmatch(q_text):
-            return _INVALID_Q_VALUE
+            return _INVALID_Q_VALUE, None
         try:
             q_value = Decimal(q_text)
         except InvalidOperation:
-            return _INVALID_Q_VALUE
+            return _INVALID_Q_VALUE, None
         if not q_value.is_finite() or q_value < _MIN_Q_VALUE or q_value > _MAX_Q_VALUE:
-            return _INVALID_Q_VALUE
+            return _INVALID_Q_VALUE, None
         parsed_q_value = q_value
-    return parsed_q_value
-
-
-def _q_text(raw_coding: str) -> str | None:
-    for parameter in raw_coding.split(";")[1:]:
-        key, separator, value = parameter.strip(_HTTP_OWS_CHARS).partition("=")
-        if separator and key.strip(_HTTP_OWS_CHARS).lower() == "q":
-            return value.strip(_HTTP_OWS_CHARS)
-    return None
+        parsed_q_text = q_text
+    return parsed_q_value, parsed_q_text
 
 
 def _format_coding(name: str, q_text: str | None) -> str:

--- a/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_inspection_risk.py
@@ -255,15 +255,19 @@ class TestResponseEncodingInspectionRisk:
         assert metadata_keys.STREAM_BUFFER in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
 
+    @pytest.mark.parametrize(
+        "negotiation_outcome",
+        ["preserved_client_constraints", "preserved_work_budget"],
+    )
     def test_unknown_connector_encoding_does_not_retain_unusable_fallback(
-        self, real_flow, tmp_path, mitm_ctx
+        self, real_flow, tmp_path, mitm_ctx, negotiation_outcome: str
     ) -> None:
         flow = make_x_pipeline_flow(
             real_flow,
             tmp_path,
             content_encoding="private-encoding-value",
         )
-        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = "preserved_client_constraints"
+        flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] = negotiation_outcome
 
         with mitm_ctx():
             mitm_addon.responseheaders(flow)
@@ -273,7 +277,7 @@ class TestResponseEncodingInspectionRisk:
         assert entry["decode_skip_reason"] == "unsupported content encoding"
         assert entry["firewall_billable"] is True
         assert entry["inspection_disposition"] == "fail_closed"
-        assert entry["request_encoding_negotiation"] == "preserved_client_constraints"
+        assert entry["request_encoding_negotiation"] == negotiation_outcome
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert response_stream(flow)(b"unknown-connector-encoding") == b""

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -20,12 +20,18 @@ _X_FIREWALL_NAME = "x"
 _X_HOST = "api.x.com"
 _X_PATH = "/2/users/by"
 _ACCEPT_ENCODING = "Accept-Encoding"
+_MAX_ACCEPT_ENCODING_VALUE_BYTES = 64 * 1024
 _WEBSOCKET_HEADER_WORK_LIMIT = 8 * 1024
 _WEBSOCKET_KEY = "dGhlIHNhbXBsZSBub25jZQ=="
 _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) HeadlessChrome/126.0.0.0 Safari/537.36"
 )
+
+
+class _DecodeGuardAcceptEncoding(bytes):
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("over-budget Accept-Encoding must not be decoded")
 
 
 @pytest.mark.parametrize(
@@ -299,6 +305,51 @@ def test_normalization_reports_bounded_negotiation_outcome(
     )
 
 
+def test_normalization_accepts_exact_raw_value_budget(headers) -> None:
+    raw_value = (
+        "gzip," * ((_MAX_ACCEPT_ENCODING_VALUE_BYTES - len("zstd  ")) // len("gzip,")) + "zstd  "
+    )
+    assert len(raw_value.encode()) == _MAX_ACCEPT_ENCODING_VALUE_BYTES
+    request_headers = headers((_ACCEPT_ENCODING, raw_value))
+
+    outcome = response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(
+        request_headers
+    )
+
+    assert outcome == "rewritten_stream_decodable"
+    assert request_headers.get_all(_ACCEPT_ENCODING) == ["gzip"]
+
+
+def test_normalization_preserves_first_over_budget_raw_value_without_decoding() -> None:
+    guarded_value = _DecodeGuardAcceptEncoding(b"x" * (_MAX_ACCEPT_ENCODING_VALUE_BYTES + 1))
+    original_fields = ((b"aCcEpT-EnCoDiNg", guarded_value),)
+    request_headers = http.Headers(original_fields)
+
+    outcome = response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(
+        request_headers
+    )
+
+    assert outcome == "preserved_work_budget"
+    assert request_headers.fields == original_fields
+
+
+def test_normalization_combines_repeated_raw_value_budget_without_decoding() -> None:
+    guarded_first = _DecodeGuardAcceptEncoding(b"x" * (_MAX_ACCEPT_ENCODING_VALUE_BYTES // 2))
+    guarded_second = _DecodeGuardAcceptEncoding(b"y" * (_MAX_ACCEPT_ENCODING_VALUE_BYTES // 2 + 1))
+    original_fields = (
+        (b"Accept-Encoding", guarded_first),
+        (b"accept-encoding", guarded_second),
+    )
+    request_headers = http.Headers(original_fields)
+
+    outcome = response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(
+        request_headers
+    )
+
+    assert outcome == "preserved_work_budget"
+    assert request_headers.fields == original_fields
+
+
 def test_explicit_normalized_encodings_create_stream_decode_sessions(headers) -> None:
     supported_encodings = body_decoding.stream_decodable_content_encodings()
     request_headers = headers(
@@ -475,6 +526,41 @@ async def test_billable_model_provider_request_normalizes_accept_encoding_before
     )
 
 
+async def test_billable_model_provider_request_preserves_over_budget_accept_encoding(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _model_provider_registry(tmp_path)
+    guarded_value = _DecodeGuardAcceptEncoding(b"x" * (_MAX_ACCEPT_ENCODING_VALUE_BYTES + 1))
+    accept_encoding_field = (b"Accept-Encoding", guarded_value)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host=_MODEL_PROVIDER_HOST,
+        path=_MODEL_PROVIDER_PATH,
+        method="POST",
+        request_headers=http.Headers(
+            [
+                (b"Host", _MODEL_PROVIDER_HOST.encode()),
+                accept_encoding_field,
+            ]
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert accept_encoding_field in flow.request.headers.fields
+    assert flow.request.headers["Authorization"] == "Bearer x"
+    assert flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] == "preserved_work_budget"
+
+
 async def test_billable_model_provider_without_accept_encoding_sets_identity(
     tmp_path: Path,
     real_flow: Callable[..., http.HTTPFlow],
@@ -640,6 +726,52 @@ async def test_header_phase_stream_safe_auth_normalizes_accept_encoding_before_a
 
     auth_fetch.assert_awaited_once()
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, br"
+
+
+async def test_header_phase_stream_safe_auth_preserves_over_budget_accept_encoding(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _connector_registry(
+        tmp_path,
+        firewall_name=_X_FIREWALL_NAME,
+        host=_X_HOST,
+        path=_X_PATH,
+        billable=True,
+        capture_network_bodies=True,
+    )
+    guarded_value = _DecodeGuardAcceptEncoding(b"x" * (_MAX_ACCEPT_ENCODING_VALUE_BYTES + 1))
+    accept_encoding_field = (b"aCcEpT-EnCoDiNg", guarded_value)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host=_X_HOST,
+        path=_X_PATH,
+        method="GET",
+        request_headers=http.Headers(
+            [
+                (b"Host", _X_HOST.encode()),
+                accept_encoding_field,
+                (b"Content-Length", str(mitm_addon.STREAM_BUFFER_LIMIT + 1).encode()),
+            ]
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        await await_requestheaders_result(requestheaders_result)
+        assert accept_encoding_field in flow.request.headers.fields
+        assert flow.request.headers["Authorization"] == "Bearer x"
+        assert flow.metadata[metadata_keys.RESPONSE_ENCODING_NEGOTIATION] == "preserved_work_budget"
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert accept_encoding_field in flow.request.headers.fields
 
 
 async def test_header_phase_auth_fallback_restores_encoding_negotiation(


### PR DESCRIPTION
## Summary

- enforce an inclusive 64 KiB aggregate raw `Accept-Encoding` value budget before mitmproxy decodes matching fields
- preserve over-budget requester fields with the distinct `preserved_work_budget` diagnostic outcome
- stream comma and semicolon traversal and retain validated qvalue text in one pass
- cover exact and repeated-field boundaries, both request entry paths, and response-time fail-closed diagnostics

## Compatibility and exclusions

- inputs through 64 KiB retain the existing negotiation semantics
- over-budget inputs are forwarded unchanged; the actual response `Content-Encoding` remains authoritative and still fails closed when it cannot be inspected safely
- this is runner-local flow metadata with no API, queue, persisted-state, or cross-deployment contract change
- mitmproxy's request-head buffering before addon hooks and global limits for unrelated header values remain outside this PR

## Diagnostic

The benchmark used genuine mitmproxy `Headers` with repeated valid `gzip` codings followed by `zstd`; input construction was excluded and each row is the median of five calls under the committed CPython 3.14 environment. Benchmark code and wall-clock assertions are not included in CI.

| Raw value bytes | Before | After | After outcome |
| ---: | ---: | ---: | --- |
| 29 | 0.006 ms | 0.006 ms | `rewritten_stream_decodable` |
| 65,534 | 4.307 ms | 4.228 ms | `rewritten_stream_decodable` |
| 1,048,574 | 90.077 ms | <0.001 ms | `preserved_work_budget` |
| 3,145,724 | 260.972 ms | <0.001 ms | `preserved_work_budget` |

At 1,048,574 bytes, additional `tracemalloc` peak allocation fell from 11.746 MiB to 0.000046 MiB.

## Validation

- `uv run --no-sync python -m pytest tests/test_response_encoding_negotiation.py tests/test_response_encoding_inspection_risk.py` (110 passed)
- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` (0 errors, 0 warnings)
- `uv run --no-sync python -m pytest tests/` (7282 passed)

Closes #32001
