### PR TITLE
fix(python): track set and dict display hashing failures

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/visitor.py
@@ -796,7 +796,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             return
         self.visit(node.value)
 
-    def _visit_sequence_expression(self, node: ast.List | ast.Tuple | ast.Set) -> None:
+    def _visit_sequence_expression(self, node: ast.List | ast.Tuple) -> None:
         for element in node.elts:
             self._record_metadata_merge_key_violations(element)
         self.generic_visit(node)
@@ -808,7 +808,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._visit_sequence_expression(node)
 
     def visit_Set(self, node: ast.Set) -> None:
-        self._visit_sequence_expression(node)
+        for element in node.elts:
+            self._record_metadata_merge_key_violations(element)
+        for element in node.elts:
+            self.visit(element)
+            if not isinstance(element, ast.Starred):
+                self._record_implicit_exception_aliases()
 
     def visit_Dict(self, node: ast.Dict) -> None:
         node_is_metadata_merge = self._is_metadata_merge_value(node)
@@ -816,7 +821,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             self._record_metadata_merge_key_violations(key)
             if key is not None or not node_is_metadata_merge:
                 self._record_metadata_merge_key_violations(value)
-        self.generic_visit(node)
+        for key, value in zip(node.keys, node.values, strict=True):
+            if key is not None:
+                self.visit(key)
+            self.visit(value)
+            if key is not None:
+                self._record_implicit_exception_aliases()
 
     def visit_BinOp(self, node: ast.BinOp) -> None:
         if not self._is_metadata_merge_value(node):

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/display_hashing_flow.base.py.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/display_hashing_flow.base.py.txt
@@ -1,0 +1,77 @@
+def set_hash_failure(flow):
+    try:
+        metadata = flow.metadata
+        {metadata}
+        metadata = {}
+    except TypeError:
+        return metadata["sandbox_run_id"]
+
+
+def dict_hash_failure(flow):
+    try:
+        metadata = flow.metadata
+        {metadata: 1}
+        metadata = {}
+    except TypeError:
+        return metadata["firewall_name"]
+
+
+def repeated_set_failures_under_with(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        {metadata}
+        {metadata}
+        metadata = {}
+    return metadata["original_url"]
+
+
+def set_failure_before_later_entry_rebind(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        {metadata, (metadata := frozenset())}
+        metadata = {}
+    return metadata["capture_body"]
+
+
+def dict_failure_before_later_entry_rebind(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        {metadata: 1, "external": (metadata := {})}
+        metadata = {}
+    return metadata["sandbox_proxy_log_path"]
+
+
+def dict_value_rebinds_before_key_hashing(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        {metadata: (metadata := {})}
+    return metadata["sandbox_run_id"]
+
+
+def dict_pairs_follow_source_order(flow, manager):
+    metadata = {}
+    with manager:
+        {
+            (metadata := flow.metadata): (metadata := {}),
+            (metadata := flow.metadata): 1,
+        }
+        metadata = {}
+    return metadata["network_log_target"]
+
+
+def deterministic_rebind_precedes_display_hashing(flow, manager):
+    metadata = flow.metadata
+    with manager:
+        metadata = {}
+        {metadata}
+        {metadata: 1}
+    return metadata["firewall_name"]
+
+
+def unpack_operations_do_not_add_failure_paths(flow, manager, values, mapping):
+    metadata = flow.metadata
+    with manager:
+        {*values}
+        {**mapping}
+        metadata = {}
+    return metadata["original_url"]

--- a/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/display_hashing_flow.expected.txt
+++ b/crates/runner/mitm-addon/tests/fixtures/flow_metadata_key_linter/display_hashing_flow.expected.txt
@@ -1,0 +1,6 @@
+display_hashing_flow.py:7: use metadata_keys.SANDBOX_RUN_ID for flow.metadata access
+display_hashing_flow.py:16: use metadata_keys.FIREWALL_NAME for flow.metadata access
+display_hashing_flow.py:25: use metadata_keys.ORIGINAL_URL for flow.metadata access
+display_hashing_flow.py:33: use metadata_keys.CAPTURE_BODY for flow.metadata access
+display_hashing_flow.py:41: use metadata_keys.SANDBOX_PROXY_LOG_PATH for flow.metadata access
+display_hashing_flow.py:59: use metadata_keys.NETWORK_LOG_TARGET for flow.metadata access

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -335,6 +335,17 @@ def test_registered_flow_metadata_guard_tracks_implicit_exception_paths(tmp_path
     )
 
 
+def test_registered_flow_metadata_guard_tracks_display_hashing_paths(tmp_path):
+    source_path = tmp_path / "display_hashing_flow.py"
+    _write_python_source(source_path, "display_hashing_flow.base.py.txt")
+
+    violations = flow_metadata_key_linter.metadata_key_violations(source_path)
+
+    assert _normalized_violations(source_path, violations) == _expected_lines(
+        "display_hashing_flow.expected.txt"
+    )
+
+
 def test_registered_flow_metadata_guard_tracks_match_reachability(tmp_path):
     source_path = tmp_path / "match_reachability.py"
     _write_python_source(source_path, "match_reachability.base.py.txt")


### PR DESCRIPTION
## Summary

- record possible set-element hashing failures after each ordinary element expression
- traverse dictionary entries in key/value order and record explicit-key hashing failures after each value
- add exact-output public linter coverage for handlers, suppressing contexts, ordered rebinds, and diagnostic de-duplication

## Scope

This change only strengthens the flow-metadata source linter. Starred set expansion and dictionary-unpack operation failures remain unchanged and out of scope. There are no API, schema, deployment, or runtime runner changes.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_flow_metadata_key_contract.py` (25 passed)
- `./scripts/check-flow-metadata-keys.py`
- `uv run --no-sync python -m pytest tests/` (7,277 passed)
- `git diff --check`

Closes #32002
