### PR TITLE
perf(runner): back off active input retries

### DIFF
--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -22,6 +22,8 @@ use crate::ids::RunId;
 
 const ACTIVE_INPUT_READ_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 const ACTIVE_INPUT_CONTROL_TIMEOUT: Duration = Duration::from_secs(1);
+pub(super) const ACTIVE_INPUT_CONTROL_RETRY_INITIAL_INTERVAL: Duration = Duration::from_millis(250);
+pub(super) const ACTIVE_INPUT_CONTROL_RETRY_MAX_INTERVAL: Duration = Duration::from_secs(4);
 const ACTIVE_INPUT_JOURNAL_READ_TIMEOUT: Duration = Duration::from_secs(5);
 const ACTIVE_INPUT_RECEIPT_RECOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 const FIRST_ACTIVE_INPUT_SEQUENCE: u64 = 1;
@@ -85,6 +87,11 @@ enum ForwardDisposition {
     Retry,
     Suppress,
     Stop,
+}
+
+struct PreparedActiveInput {
+    delivery_id: String,
+    payload: Vec<u8>,
 }
 
 async fn run_forwarder(
@@ -227,40 +234,8 @@ async fn forward_with_retry(
     job_cancel: &CancellationToken,
     stop: &CancellationToken,
 ) -> ForwardDisposition {
-    let mut warn_retryable_failure = true;
-    loop {
-        let disposition = forward_once(
-            run_id,
-            delivery_id,
-            text,
-            mode,
-            control,
-            warn_retryable_failure,
-        )
-        .await;
-        if !matches!(disposition, ForwardDisposition::Retry) {
-            return disposition;
-        }
-        warn_retryable_failure = false;
-        tokio::select! {
-            biased;
-            () = stop.cancelled() => return ForwardDisposition::Stop,
-            () = job_cancel.cancelled() => return ForwardDisposition::Stop,
-            () = tokio::time::sleep(ACTIVE_INPUT_READ_RETRY_INTERVAL) => {}
-        }
-    }
-}
-
-async fn forward_once(
-    run_id: RunId,
-    delivery_id: &str,
-    text: &str,
-    mode: DeliveryMode,
-    control: &GuestProcessControlHandle,
-    warn_retryable_failure: bool,
-) -> ForwardDisposition {
-    let bytes = match encode_active_input(delivery_id, text) {
-        Ok(bytes) if bytes.len() <= ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES => bytes,
+    let payload = match encode_active_input(delivery_id, text) {
+        Ok(payload) if payload.len() <= ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES => payload,
         Ok(_) => {
             warn!(
                 run_id = %run_id,
@@ -279,8 +254,42 @@ async fn forward_once(
             return ForwardDisposition::Stop;
         }
     };
+    let prepared = PreparedActiveInput {
+        delivery_id: delivery_id.to_owned(),
+        payload,
+    };
+    let mut warn_retryable_failure = true;
+    let mut retry_interval = ACTIVE_INPUT_CONTROL_RETRY_INITIAL_INTERVAL;
+    loop {
+        let disposition =
+            forward_once(run_id, &prepared, mode, control, warn_retryable_failure).await;
+        if !matches!(disposition, ForwardDisposition::Retry) {
+            return disposition;
+        }
+        warn_retryable_failure = false;
+        tokio::select! {
+            biased;
+            () = stop.cancelled() => return ForwardDisposition::Stop,
+            () = job_cancel.cancelled() => return ForwardDisposition::Stop,
+            () = tokio::time::sleep(retry_interval) => {}
+        }
+        retry_interval = (retry_interval * 2).min(ACTIVE_INPUT_CONTROL_RETRY_MAX_INTERVAL);
+    }
+}
+
+async fn forward_once(
+    run_id: RunId,
+    prepared: &PreparedActiveInput,
+    mode: DeliveryMode,
+    control: &GuestProcessControlHandle,
+    warn_retryable_failure: bool,
+) -> ForwardDisposition {
     let outcome = control
-        .control_owned_outcome(delivery_id.to_owned(), bytes, ACTIVE_INPUT_CONTROL_TIMEOUT)
+        .control_owned_outcome(
+            prepared.delivery_id.clone(),
+            prepared.payload.clone(),
+            ACTIVE_INPUT_CONTROL_TIMEOUT,
+        )
         .await;
     classify_control_outcome(run_id, mode, outcome, warn_retryable_failure)
 }

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -124,8 +124,8 @@ async fn run_forwarder(
                     let delivery_id = local_active_input_delivery_id(run_id, entry.sequence);
                     let disposition = forward_with_retry(
                         run_id,
-                        &delivery_id,
-                        &entry.text,
+                        delivery_id,
+                        entry.text,
                         DeliveryMode::Local,
                         &control,
                         &job_cancel,
@@ -155,8 +155,8 @@ async fn run_forwarder(
                     } else {
                         let disposition = forward_with_retry(
                             run_id,
-                            &delivery_id,
-                            &prompt,
+                            delivery_id.clone(),
+                            prompt,
                             DeliveryMode::Api,
                             &control,
                             &job_cancel,
@@ -227,14 +227,14 @@ async fn run_forwarder(
 
 async fn forward_with_retry(
     run_id: RunId,
-    delivery_id: &str,
-    text: &str,
+    delivery_id: String,
+    text: String,
     mode: DeliveryMode,
     control: &GuestProcessControlHandle,
     job_cancel: &CancellationToken,
     stop: &CancellationToken,
 ) -> ForwardDisposition {
-    let payload = match encode_active_input(delivery_id, text) {
+    let payload = match encode_active_input(&delivery_id, &text) {
         Ok(payload) if payload.len() <= ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES => payload,
         Ok(_) => {
             warn!(
@@ -254,8 +254,9 @@ async fn forward_with_retry(
             return ForwardDisposition::Stop;
         }
     };
+    drop(text);
     let prepared = PreparedActiveInput {
-        delivery_id: delivery_id.to_owned(),
+        delivery_id,
         payload,
     };
     let mut warn_retryable_failure = true;

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -1,8 +1,15 @@
 use std::sync::Arc;
+use std::time::Duration;
+
+use guest_contracts::active_input::encode_active_input;
 
 use crate::active_input::{
-    API_ACTIVE_INPUT_RECHECK_INTERVAL, ActiveInputNotifications, ActiveInputSource,
+    ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, API_ACTIVE_INPUT_RECHECK_INTERVAL,
+    ActiveInputNotifications, ActiveInputSource, identified_active_input_payload_len,
     local_active_input_delivery_id,
+};
+use crate::executor::active_input::{
+    ACTIVE_INPUT_CONTROL_RETRY_INITIAL_INTERVAL, ACTIVE_INPUT_CONTROL_RETRY_MAX_INTERVAL,
 };
 use crate::executor::agent_run::{RunControls, RunStart, run_in_sandbox};
 use crate::executor::tests::support::{
@@ -991,10 +998,12 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
         Arc::clone(&wait_gate),
     ));
-    for status in [
-        sandbox::ProcessControlGuestStatus::QueueFull,
-        sandbox::ProcessControlGuestStatus::SinkUnavailable,
-    ] {
+    for attempt in 0..7 {
+        let status = if attempt % 2 == 0 {
+            sandbox::ProcessControlGuestStatus::QueueFull
+        } else {
+            sandbox::ProcessControlGuestStatus::SinkUnavailable
+        };
         overrides.push_process_control_outcome(sandbox::ProcessControlOutcome::GuestStatus {
             status,
             diagnostic: "retryable guest backpressure".to_string(),
@@ -1003,10 +1012,17 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
     let run_id = ctx.run_id;
+    let payload_overhead = identified_active_input_payload_len("").unwrap();
+    let prompt = "x".repeat(ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES - payload_overhead);
+    let expected_payload = encode_active_input(DELIVERY_ID, &prompt).unwrap();
+    assert_eq!(
+        expected_payload.len(),
+        ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES
+    );
     let server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(json_response(
         "200 OK",
         &format!(
-            r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"retry guest backpressure"}}"#,
+            r#"{{"outcome":"reserved","deliveryId":"{DELIVERY_ID}","eventIds":["{EVENT_ID}"],"prompt":"{prompt}"}}"#,
         ),
     ))])
     .await;
@@ -1038,11 +1054,40 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
         .await
     });
 
+    let retry_delays = [
+        ACTIVE_INPUT_CONTROL_RETRY_INITIAL_INTERVAL,
+        Duration::from_millis(500),
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+        ACTIVE_INPUT_CONTROL_RETRY_MAX_INTERVAL,
+        ACTIVE_INPUT_CONTROL_RETRY_MAX_INTERVAL,
+        ACTIVE_INPUT_CONTROL_RETRY_MAX_INTERVAL,
+    ];
+    let scheduling_margin = Duration::from_millis(10);
     assert!(
         overrides
-            .wait_for_process_control_calls(3, RUN_IN_SANDBOX_TEST_TIMEOUT)
+            .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
             .await
     );
+    tokio::time::pause();
+    let mut previous_attempt_at = tokio::time::Instant::now();
+    for (index, expected_delay) in retry_delays.into_iter().enumerate() {
+        assert!(
+            overrides
+                .wait_for_process_control_calls(index + 2, Duration::from_secs(30))
+                .await,
+            "control did not retry after backoff interval {index}"
+        );
+        let attempted_at = tokio::time::Instant::now();
+        let elapsed = attempted_at.duration_since(previous_attempt_at);
+        assert!(
+            elapsed >= expected_delay && elapsed <= expected_delay + scheduling_margin,
+            "retry interval {index} was {elapsed:?}, expected {expected_delay:?}"
+        );
+        previous_attempt_at = attempted_at;
+    }
+
+    tokio::time::resume();
     wait_gate.notify_one();
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
         .await
@@ -1052,12 +1097,12 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
     assert!(result.failure.is_none());
     server.assert_finished().await;
     let calls = overrides.process_control_calls();
-    assert_eq!(calls.len(), 3);
+    assert_eq!(calls.len(), retry_delays.len() + 1);
     assert!(calls.iter().all(|call| call.message_id == DELIVERY_ID));
     assert!(
         calls
-            .windows(2)
-            .all(|pair| pair[0].payload == pair[1].payload)
+            .iter()
+            .all(|call| call.payload.as_slice() == expected_payload)
     );
 }
 


### PR DESCRIPTION
## Summary

- prepare and validate each active-input control payload once before retrying
- replace fixed 250 ms retry polling with exponential backoff capped at 4 seconds
- cover near-limit payload reuse and retry cadence through the Runner executor integration path

## Compatibility

- preserves the existing Runner/Guest payload and process-control contracts
- preserves delivery IDs, cancellation priority, and definitely-not-written versus possibly-written handling
- does not add a finite retry budget or coordinated rollout requirement

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner --bin runner executor::tests::agent_run_tests::active_input::run_in_sandbox_retries_guest_backpressure_with_same_id -- --exact`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner --bin runner` (3452 passed, 25 ignored)
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --no-deps`

Closes #31998
