### PR TITLE
feat: register shot grammar video templates

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -3557,13 +3557,16 @@
       },
       "video": {
         "chinese-ink-art": "Chinesische Tuschemalerei",
+        "cursor-led-variant-world": "Cursorgesteuerte Variantenwelt",
         "cyberpunk-anime": "Cyberpunk-Anime",
         "epic-grandeur": "Epische Größe",
         "fashion-editorial": "Moderedaktion",
         "gourmet-documentary": "Gourmet-Dokumentarfilm",
         "hand-drawn-fantasy-anime": "Handgezeichneter Fantasy-Anime",
         "japanese-wabi-sabi": "Japanisches Wabi-Sabi",
+        "kinetic-editorial-collage": "Kinetische Editorial-Collage",
         "luxury-product": "Luxusprodukt-Makro",
+        "poster-tableau-dissolve": "Poster-Tableau-Auflösung",
         "shortform-viral": "Kurzform Viral",
         "sports-performance-ad": "Sportleistungsanzeige"
       }

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -3549,13 +3549,16 @@
       },
       "video": {
         "chinese-ink-art": "Chinese Ink Painting",
+        "cursor-led-variant-world": "Cursor-Led Variant World",
         "cyberpunk-anime": "Cyberpunk Anime",
         "epic-grandeur": "Epic Grandeur",
         "fashion-editorial": "Fashion Editorial",
         "gourmet-documentary": "Gourmet Documentary",
         "hand-drawn-fantasy-anime": "Hand Drawn Fantasy Anime",
         "japanese-wabi-sabi": "Japanese Wabi-Sabi",
+        "kinetic-editorial-collage": "Kinetic Editorial Collage",
         "luxury-product": "Luxury Product Macro",
+        "poster-tableau-dissolve": "Poster-Tableau Dissolve",
         "shortform-viral": "Shortform Viral",
         "sports-performance-ad": "Sports Performance Ad"
       }

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -3607,13 +3607,16 @@
       },
       "video": {
         "chinese-ink-art": "Pintura china a tinta",
+        "cursor-led-variant-world": "Mundo de variantes guiado por cursor",
         "cyberpunk-anime": "Cyberpunk Anime",
         "epic-grandeur": "Grandeza épica",
         "fashion-editorial": "Editorial de moda",
         "gourmet-documentary": "Documental Gourmet",
         "hand-drawn-fantasy-anime": "Anime de fantasía dibujado a mano",
         "japanese-wabi-sabi": "Wabi-Sabi japonés",
+        "kinetic-editorial-collage": "Collage editorial cinético",
         "luxury-product": "Macro de productos de lujo",
+        "poster-tableau-dissolve": "Disolución de escenas tipo póster",
         "shortform-viral": "Viral de forma corta",
         "sports-performance-ad": "Anuncio de rendimiento deportivo"
       }

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -3607,13 +3607,16 @@
       },
       "video": {
         "chinese-ink-art": "Peinture à l'encre chinoise",
+        "cursor-led-variant-world": "Univers de variantes piloté par curseur",
         "cyberpunk-anime": "Anime cyberpunk",
         "epic-grandeur": "Grandeur épique",
         "fashion-editorial": "Éditorial de mode",
         "gourmet-documentary": "Documentaire gastronomique",
         "hand-drawn-fantasy-anime": "Anime fantastique dessiné à la main",
         "japanese-wabi-sabi": "Wabi-Sabi japonais",
+        "kinetic-editorial-collage": "Collage éditorial cinétique",
         "luxury-product": "Macro produit de luxe",
+        "poster-tableau-dissolve": "Fondu de tableaux-affiches",
         "shortform-viral": "Viral court format",
         "sports-performance-ad": "Publicité de performance sportive"
       }

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -3557,13 +3557,16 @@
       },
       "video": {
         "chinese-ink-art": "चीनी स्याही चित्रकारी",
+        "cursor-led-variant-world": "कर्सर-चालित वैरिएंट वर्ल्ड",
         "cyberpunk-anime": "साइबरपंक एनीमे",
         "epic-grandeur": "महाकाव्य भव्यता",
         "fashion-editorial": "फैशन संपादकीय",
         "gourmet-documentary": "रुचिकर वृत्तचित्र",
         "hand-drawn-fantasy-anime": "हाथ से बनाई गई काल्पनिक एनीमे",
         "japanese-wabi-sabi": "जापानी वाबी-सबी",
+        "kinetic-editorial-collage": "काइनेटिक एडिटोरियल कोलाज",
         "luxury-product": "लक्जरी उत्पाद मैक्रो",
+        "poster-tableau-dissolve": "पोस्टर-टेबलो डिसॉल्व",
         "shortform-viral": "शॉर्टफॉर्म वायरल",
         "sports-performance-ad": "खेल प्रदर्शन विज्ञापन"
       }

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -3549,13 +3549,16 @@
       },
       "video": {
         "chinese-ink-art": "Lukisan Tinta Tiongkok",
+        "cursor-led-variant-world": "Dunia Varian Berpanduan Kursor",
         "cyberpunk-anime": "Anime Cyberpunk",
         "epic-grandeur": "Keagungan Epik",
         "fashion-editorial": "Editorial Mode",
         "gourmet-documentary": "Dokumenter Kuliner",
         "hand-drawn-fantasy-anime": "Anime Fantasi Gambar Tangan",
         "japanese-wabi-sabi": "Wabi-Sabi Jepang",
+        "kinetic-editorial-collage": "Kolase Editorial Kinetik",
         "luxury-product": "Makro Produk Mewah",
+        "poster-tableau-dissolve": "Transisi Larut Tableau Poster",
         "shortform-viral": "Viral Format Pendek",
         "sports-performance-ad": "Iklan Performa Olahraga"
       }

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -3607,13 +3607,16 @@
       },
       "video": {
         "chinese-ink-art": "Pittura a inchiostro cinese",
+        "cursor-led-variant-world": "Mondo di varianti guidato dal cursore",
         "cyberpunk-anime": "Anime cyberpunk",
         "epic-grandeur": "Grandezza epica",
         "fashion-editorial": "Editoriale di moda",
         "gourmet-documentary": "Documentario gastronomico",
         "hand-drawn-fantasy-anime": "Anime fantasy disegnati a mano",
         "japanese-wabi-sabi": "Wabi Sabi giapponese",
+        "kinetic-editorial-collage": "Collage editoriale cinetico",
         "luxury-product": "Macro prodotto di lusso",
+        "poster-tableau-dissolve": "Dissolvenza di tableau poster",
         "shortform-viral": "Virale in forma abbreviata",
         "sports-performance-ad": "Annuncio di prestazioni sportive"
       }

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -3549,13 +3549,16 @@
       },
       "video": {
         "chinese-ink-art": "中国の水墨画",
+        "cursor-led-variant-world": "カーソル駆動バリアントワールド",
         "cyberpunk-anime": "サイバーパンクアニメ",
         "epic-grandeur": "壮大な壮大さ",
         "fashion-editorial": "ファッション社説",
         "gourmet-documentary": "グルメドキュメンタリー",
         "hand-drawn-fantasy-anime": "手描きファンタジーアニメ",
         "japanese-wabi-sabi": "日本のわびさび",
+        "kinetic-editorial-collage": "キネティック・エディトリアル・コラージュ",
         "luxury-product": "高級品マクロ",
+        "poster-tableau-dissolve": "ポスター・タブロー・ディゾルブ",
         "shortform-viral": "短編バイラル",
         "sports-performance-ad": "スポーツパフォーマンス広告"
       }

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -3549,13 +3549,16 @@
       },
       "video": {
         "chinese-ink-art": "중국 먹 그림",
+        "cursor-led-variant-world": "커서 기반 배리언트 월드",
         "cyberpunk-anime": "사이버펑크 애니메이션",
         "epic-grandeur": "서사적 웅장함",
         "fashion-editorial": "패션 에디토리얼",
         "gourmet-documentary": "미식 다큐멘터리",
         "hand-drawn-fantasy-anime": "손그림 판타지 애니메이션",
         "japanese-wabi-sabi": "일본 와비사비",
+        "kinetic-editorial-collage": "키네틱 에디토리얼 콜라주",
         "luxury-product": "럭셔리 제품 매크로",
+        "poster-tableau-dissolve": "포스터 타블로 디졸브",
         "shortform-viral": "쇼트폼 바이럴",
         "sports-performance-ad": "스포츠 퍼포먼스 광고"
       }

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -3607,13 +3607,16 @@
       },
       "video": {
         "chinese-ink-art": "Arte em Tinta Chinesa",
+        "cursor-led-variant-world": "Mundo de Variantes Guiado por Cursor",
         "cyberpunk-anime": "Anime Cyberpunk",
         "epic-grandeur": "Grandeza Épica",
         "fashion-editorial": "Editorial de Moda",
         "gourmet-documentary": "Documentário Gourmet",
         "hand-drawn-fantasy-anime": "Anime de Fantasia Desenhado à Mão",
         "japanese-wabi-sabi": "Wabi-Sabi Japonês",
+        "kinetic-editorial-collage": "Colagem Editorial Cinética",
         "luxury-product": "Produto de Luxo Macro",
+        "poster-tableau-dissolve": "Dissolução de Quadros-Pôster",
         "shortform-viral": "Viral de Formato Curto",
         "sports-performance-ad": "Anúncio de Performance Esportiva"
       }

--- a/turbo/packages/core/src/__tests__/video-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/video-template-items.spec.ts
@@ -17,6 +17,9 @@ describe("video template items", () => {
     "video-template:hand-drawn-fantasy-anime",
     "video-template:cyberpunk-anime",
     "video-template:chinese-ink-art",
+    "video-template:cursor-led-variant-world",
+    "video-template:poster-tableau-dissolve",
+    "video-template:kinetic-editorial-collage",
   ];
 
   it("resolve every video template against the resource registry", () => {

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -342,6 +342,30 @@ const VIDEO_TEMPLATE_REGISTRY: readonly VideoTemplateRegistryEntry[] = [
       "Chinese ink-wash video style with monochrome brush texture, white space, mist, and calm classical-poetry mood.",
     source: videoTemplateSource("video-template/chinese-ink-art"),
   },
+  {
+    id: "video-template:cursor-led-variant-world",
+    kind: "video-template",
+    name: "Cursor-Led Variant World",
+    description:
+      "Fixed front-facing catalog film where a visible cursor selects variants and each selection re-themes the hero, exact title, palette, and motif world.",
+    source: videoTemplateSource("video-template/cursor-led-variant-world"),
+  },
+  {
+    id: "video-template:poster-tableau-dissolve",
+    kind: "video-template",
+    name: "Poster-Tableau Dissolve",
+    description:
+      "Flat editorial title film of locked poster tableaux joined by geometry-aware dissolves while one recurring subject travels in one screen direction.",
+    source: videoTemplateSource("video-template/poster-tableau-dissolve"),
+  },
+  {
+    id: "video-template:kinetic-editorial-collage",
+    kind: "video-template",
+    name: "Kinetic Editorial Collage",
+    description:
+      "Fast modular editorial collage where one persistent asset inventory repacks around oversized exact typography through object-carried handoffs.",
+    source: videoTemplateSource("video-template/kinetic-editorial-collage"),
+  },
 ];
 
 // These targets mirror each skill's `od.mode` in the pinned Open Design commit.

--- a/turbo/packages/core/src/video-template-items.ts
+++ b/turbo/packages/core/src/video-template-items.ts
@@ -37,6 +37,12 @@ const VIDEO_TEMPLATE_PREVIEW_IMAGES: Readonly<Record<string, string>> = {
     "https://static.vm0.io/vm0/artifact-templates/video/40ab801f-16bc-4e29-8370-6b10cd394e30/thumbnail-shortform-viral.jpg",
   "sports-performance-ad":
     "https://static.vm0.io/vm0/artifact-templates/video/5a95669a-b86c-4817-9d82-250da7509b54/thumbnail-athletic-motivation.jpg",
+  "cursor-led-variant-world":
+    "https://static.vm0.io/vm0/artifact-templates/video/ba839737-b025-4b32-994e-f2084018a3cc/thumbnail-cursor-led-variant-world.jpg",
+  "poster-tableau-dissolve":
+    "https://static.vm0.io/vm0/artifact-templates/video/8684bf6d-daf4-45c4-a287-163d48724867/thumbnail-poster-tableau-dissolve.jpg",
+  "kinetic-editorial-collage":
+    "https://static.vm0.io/vm0/artifact-templates/video/40667930-5be5-4894-a592-0d052ae35996/thumbnail-kinetic-editorial-collage.jpg",
 };
 
 const VIDEO_TEMPLATE_CARD_PREVIEW_IMAGES: Readonly<Record<string, string>> = {
@@ -60,6 +66,12 @@ const VIDEO_TEMPLATE_CARD_PREVIEW_IMAGES: Readonly<Record<string, string>> = {
     "https://static.vm0.io/vm0/artifact-templates/video/1d690a29-2be1-404b-9698-638f18685513/template-card-video-cyberpunk-anime-480x270.jpg",
   "chinese-ink-art":
     "https://static.vm0.io/vm0/artifact-templates/video/0bad21ee-4b92-4ea0-ad15-5453573aad7b/template-card-video-chinese-ink-art-480x270.jpg",
+  "cursor-led-variant-world":
+    "https://static.vm0.io/vm0/artifact-templates/video/ba839737-b025-4b32-994e-f2084018a3cc/card-cursor-led-variant-world-480x270.jpg",
+  "poster-tableau-dissolve":
+    "https://static.vm0.io/vm0/artifact-templates/video/8684bf6d-daf4-45c4-a287-163d48724867/card-poster-tableau-dissolve-480x270.jpg",
+  "kinetic-editorial-collage":
+    "https://static.vm0.io/vm0/artifact-templates/video/40667930-5be5-4894-a592-0d052ae35996/card-kinetic-editorial-collage-480x270.jpg",
 };
 
 const VIDEO_TEMPLATE_PREVIEW_VIDEOS: Readonly<Record<string, string>> = {
@@ -83,6 +95,12 @@ const VIDEO_TEMPLATE_PREVIEW_VIDEOS: Readonly<Record<string, string>> = {
     "https://static.vm0.io/vm0/artifact-templates/video/4bac1319-dba7-47a0-bc1b-4d1e932f71fd/video-4bac1319.mp4",
   "sports-performance-ad":
     "https://static.vm0.io/vm0/artifact-templates/video/104ad36a-4d0c-472b-8416-d04cc2f06e75/video-104ad36a.mp4",
+  "cursor-led-variant-world":
+    "https://static.vm0.io/vm0/artifact-templates/video/ba839737-b025-4b32-994e-f2084018a3cc/preview-cursor-led-variant-world.mp4",
+  "poster-tableau-dissolve":
+    "https://static.vm0.io/vm0/artifact-templates/video/8684bf6d-daf4-45c4-a287-163d48724867/preview-poster-tableau-dissolve.mp4",
+  "kinetic-editorial-collage":
+    "https://static.vm0.io/vm0/artifact-templates/video/40667930-5be5-4894-a592-0d052ae35996/preview-kinetic-editorial-collage.mp4",
 };
 
 const VIDEO_TEMPLATE_PREVIEW_WEBMS: Readonly<Record<string, string>> = {
@@ -106,6 +124,12 @@ const VIDEO_TEMPLATE_PREVIEW_WEBMS: Readonly<Record<string, string>> = {
     "https://static.vm0.io/vm0/artifact-templates/video/0b1dbbb8-782e-451d-87e9-6652f60116bf/shortform-viral.webm",
   "sports-performance-ad":
     "https://static.vm0.io/vm0/artifact-templates/video/a6dab950-dddc-4116-9bc3-624265b35c12/sports-performance-ad.webm",
+  "cursor-led-variant-world":
+    "https://static.vm0.io/vm0/artifact-templates/video/ba839737-b025-4b32-994e-f2084018a3cc/preview-cursor-led-variant-world.webm",
+  "poster-tableau-dissolve":
+    "https://static.vm0.io/vm0/artifact-templates/video/8684bf6d-daf4-45c4-a287-163d48724867/preview-poster-tableau-dissolve.webm",
+  "kinetic-editorial-collage":
+    "https://static.vm0.io/vm0/artifact-templates/video/40667930-5be5-4894-a592-0d052ae35996/preview-kinetic-editorial-collage.webm",
 };
 
 function videoTemplateSlug(entry: VideoTemplateRegistryEntry): string {


### PR DESCRIPTION
## Summary

- register three shot-grammar templates in the canonical video-template registry
- add picker thumbnails plus MP4/WebM hover previews for each template
- add all three picker names to the 10 existing onboarding locales
- extend the registry-order test so missing metadata or preview media fails immediately

New selectable IDs:

- `video-template:cursor-led-variant-world`
- `video-template:poster-tableau-dissolve`
- `video-template:kinetic-editorial-collage`

## Dependencies

This PR has two functional dependencies that should land first so the picker never exposes a missing skill or media URL:

- Skills: https://github.com/vm0-ai/vm0-skills/pull/334
- Append-only preview media: https://github.com/vm0-ai/static-files/pull/196

## Validation

- `pnpm --filter @okouai/core exec vitest run src/__tests__/video-template-items.spec.ts` — 2 passed
- targeted platform tests for video options, template media, and onboarding — 37 passed
- `pnpm --filter @okouai/core check-types`
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/core lint`
- Prettier passed for all changed TypeScript and locale files
- all locale JSON files contain all three new IDs

No full Vitest run or local development server was started.

## Preview examples

- Cursor-Led Variant World: https://a.okou.io/vba6mod1s9.mp4
- Poster-Tableau Dissolve: https://a.okou.io/0nbjj7enf0.mp4
- Kinetic Editorial Collage: https://a.okou.io/71asn1eu6t.mp4

The X reference supplied for the third template was analysis-only. It is not passed into generation or redistributed as a picker preview.
