### PR TITLE
chore: publish the approved emboss deboss resource

### DIFF
--- a/.github/emboss-deboss-release/emboss-deboss-release.json
+++ b/.github/emboss-deboss-release/emboss-deboss-release.json
@@ -1,0 +1,16 @@
+{
+  "source": {
+    "repo": "vm0-ai/vm0-skills",
+    "commit": "e6966525e5e809b6c8c2c57918ebb1ca43ee89eb",
+    "directory": "illustration-template/emboss-deboss"
+  },
+  "resource": {
+    "id": "image-style:emboss-deboss",
+    "archiveRoot": "illustration-template",
+    "packagePath": "illustration-template/emboss-deboss",
+    "storageId": "9a73f277-b6e7-4878-a92b-89c07154f5d6",
+    "expectedVersionId": "e84748dd61e087cc15f12d9f9ecf19d68de790d747e0075b3f9bb6be38975e95",
+    "expectedSha256": "f1c1be0b1cf711a8c61945f928206d700b54d71969711f0551403d20c360d3f8",
+    "archiveUrl": "https://a.okou.io/u98yi0to32.gz"
+  }
+}

--- a/.github/emboss-deboss-release/prebuilt/publication.json
+++ b/.github/emboss-deboss-release/prebuilt/publication.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "repo": "vm0-ai/vm0-skills",
+    "commit": "e6966525e5e809b6c8c2c57918ebb1ca43ee89eb",
+    "directory": "illustration-template/emboss-deboss"
+  },
+  "resource": {
+    "id": "image-style:emboss-deboss",
+    "archiveRoot": "illustration-template",
+    "packagePath": "illustration-template/emboss-deboss",
+    "storageId": "9a73f277-b6e7-4878-a92b-89c07154f5d6",
+    "versionId": "e84748dd61e087cc15f12d9f9ecf19d68de790d747e0075b3f9bb6be38975e95",
+    "archive": {
+      "path": "emboss-deboss.tar.gz",
+      "sha256": "f1c1be0b1cf711a8c61945f928206d700b54d71969711f0551403d20c360d3f8",
+      "byteSize": 2855348
+    },
+    "totalSize": 2865976,
+    "fileCount": 6,
+    "files": [
+      {
+        "path": "illustration-template/emboss-deboss/SKILL.md",
+        "hash": "fd7d4127c5f3c8d859a864e03972c0fce9d53d4eea7bf66eb284cf60a593c769",
+        "size": 9428
+      },
+      {
+        "path": "illustration-template/emboss-deboss/ref-beyond-ivory.jpg",
+        "hash": "4f27f3422750891c01ba394492e59276a87a23334528c8f77635d71ae4237221",
+        "size": 460055
+      },
+      {
+        "path": "illustration-template/emboss-deboss/ref-moon-boat-no-text.jpg",
+        "hash": "cc7023daa8fd5567b16065278e82e7ee576be24ad3c4f8016f25f3db46abfafe",
+        "size": 429243
+      },
+      {
+        "path": "illustration-template/emboss-deboss/ref-moon-mooring-indigo.jpg",
+        "hash": "6c092392380cb9cd0aff2c9728cc14ec6f0542a449ce9bb8f985c826d599d852",
+        "size": 978991
+      },
+      {
+        "path": "illustration-template/emboss-deboss/ref-weightless-indigo.jpg",
+        "hash": "e5da441a3fd5cf14411a0bdac7cef62ef3d3fd3fa6c62e18ca681e2942dd8828",
+        "size": 456130
+      },
+      {
+        "path": "illustration-template/emboss-deboss/ref-wind-space-blush.jpg",
+        "hash": "10b593875c329c0f424f9d025dafa1b6476312a38ae7b33c16024b2fc4e422a2",
+        "size": 532129
+      }
+    ]
+  }
+}

--- a/.github/emboss-deboss-release/publish.mjs
+++ b/.github/emboss-deboss-release/publish.mjs
@@ -1,0 +1,546 @@
+import { createHash } from "node:crypto";
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import postgres from "postgres";
+import * as tar from "tar";
+
+const metadata = JSON.parse(
+  await readFile(
+    new URL("./emboss-deboss-release.json", import.meta.url),
+    "utf8",
+  ),
+);
+
+const SYSTEM_ORG_ID = "__system__";
+const VOLUME_ORG_USER_ID = "__org__";
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function requiredOption(name) {
+  const value = option(name);
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function compareNames(left, right) {
+  if (left.name < right.name) return -1;
+  if (left.name > right.name) return 1;
+  return 0;
+}
+
+function computeVersionId(storageId, files) {
+  const entries = files.map((file) => `${file.path}:${file.hash}`).sort();
+  return sha256(`storage:${storageId}\n${entries.join("\n")}`);
+}
+
+async function listFiles(rootDir, relativeDir = "") {
+  const entries = await readdir(path.join(rootDir, relativeDir), {
+    withFileTypes: true,
+  });
+  const files = [];
+  for (const entry of entries.sort(compareNames)) {
+    const relativePath = path.posix.join(relativeDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(rootDir, relativePath)));
+    } else if (entry.isFile()) {
+      files.push(relativePath);
+    } else {
+      throw new Error(`Unsupported package entry: ${relativePath}`);
+    }
+  }
+  return files;
+}
+
+async function buildFileManifest(rootDir) {
+  const relativePaths = await listFiles(rootDir);
+  return await Promise.all(
+    relativePaths.map(async (relativePath) => {
+      const filePath = path.join(rootDir, relativePath);
+      const [contents, fileStat] = await Promise.all([
+        readFile(filePath),
+        stat(filePath),
+      ]);
+      return {
+        path: relativePath,
+        hash: sha256(contents),
+        size: fileStat.size,
+      };
+    }),
+  );
+}
+
+async function inspectArchive(archivePath, label) {
+  const root = await mkdtemp(path.join(tmpdir(), `emboss-deboss-${label}-`));
+  try {
+    const seen = new Set();
+    await tar.list({
+      file: archivePath,
+      gzip: true,
+      onReadEntry(entry) {
+        const entryPath = entry.path.replace(/\/$/, "");
+        if (
+          !["File", "Directory"].includes(entry.type) ||
+          path.posix.isAbsolute(entryPath) ||
+          entryPath.split("/").includes("..") ||
+          entryPath.includes("\\") ||
+          seen.has(entryPath) ||
+          !(
+            entryPath === metadata.resource.archiveRoot ||
+            entryPath === metadata.resource.packagePath ||
+            entryPath.startsWith(`${metadata.resource.packagePath}/`)
+          )
+        ) {
+          throw new Error(`${label}: unsupported archive entry ${entry.path}`);
+        }
+        seen.add(entryPath);
+      },
+    });
+    await tar.extract({
+      file: archivePath,
+      cwd: root,
+      gzip: true,
+      strict: true,
+    });
+    const rootEntries = await readdir(root, { withFileTypes: true });
+    if (
+      rootEntries.length !== 1 ||
+      !rootEntries[0].isDirectory() ||
+      rootEntries[0].name !== metadata.resource.archiveRoot
+    ) {
+      throw new Error(
+        `${label}: archive must contain only ${metadata.resource.archiveRoot}/ at its root`,
+      );
+    }
+
+    const archiveRoot = path.join(root, metadata.resource.archiveRoot);
+    const archiveRootEntries = await readdir(archiveRoot, {
+      withFileTypes: true,
+    });
+    const packageName = path.posix.basename(metadata.resource.packagePath);
+    if (
+      archiveRootEntries.length !== 1 ||
+      !archiveRootEntries[0].isDirectory() ||
+      archiveRootEntries[0].name !== packageName
+    ) {
+      throw new Error(
+        `${label}: ${metadata.resource.archiveRoot}/ must contain only ${packageName}/`,
+      );
+    }
+
+    const packageDir = path.join(root, metadata.resource.packagePath);
+    const required = [
+      "SKILL.md",
+      "ref-beyond-ivory.jpg",
+      "ref-moon-boat-no-text.jpg",
+      "ref-moon-mooring-indigo.jpg",
+      "ref-weightless-indigo.jpg",
+      "ref-wind-space-blush.jpg",
+    ];
+    for (const relativePath of required) {
+      const fileStat = await stat(path.join(packageDir, relativePath));
+      if (!fileStat.isFile() || fileStat.size === 0) {
+        throw new Error(`${label}: ${relativePath} is missing or empty`);
+      }
+    }
+    const packageFiles = await listFiles(packageDir);
+    if (JSON.stringify(packageFiles) !== JSON.stringify(required.toSorted())) {
+      throw new Error(
+        `${label}: package must contain exactly the approved six files`,
+      );
+    }
+    const skill = await readFile(path.join(packageDir, "SKILL.md"), "utf8");
+    if (!skill.includes("name: emboss-deboss")) {
+      throw new Error(`${label}: SKILL.md is not the emboss-deboss package`);
+    }
+
+    return {
+      files: await buildFileManifest(root),
+      verification: "approved six-file paper-relief package",
+    };
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function assertPinnedPublication(publication) {
+  if (
+    publication.schemaVersion !== 1 ||
+    JSON.stringify(publication.source) !== JSON.stringify(metadata.source) ||
+    publication.resource.id !== metadata.resource.id ||
+    publication.resource.archiveRoot !== metadata.resource.archiveRoot ||
+    publication.resource.packagePath !== metadata.resource.packagePath ||
+    publication.resource.storageId !== metadata.resource.storageId ||
+    publication.resource.archive.path !== "emboss-deboss.tar.gz"
+  ) {
+    throw new Error("Publication metadata does not match the pinned release");
+  }
+  if (publication.resource.versionId !== metadata.resource.expectedVersionId) {
+    throw new Error("Publication version id does not match the release pin");
+  }
+  if (
+    publication.resource.archive.sha256 !== metadata.resource.expectedSha256
+  ) {
+    throw new Error(
+      "Publication archive digest does not match the release pin",
+    );
+  }
+}
+
+async function verifyBundle(outputDir, label) {
+  const publication = JSON.parse(
+    await readFile(path.join(outputDir, "publication.json"), "utf8"),
+  );
+  assertPinnedPublication(publication);
+
+  const archivePath = path.join(outputDir, publication.resource.archive.path);
+  const archive = await readFile(archivePath);
+  if (
+    archive.byteLength !== publication.resource.archive.byteSize ||
+    sha256(archive) !== publication.resource.archive.sha256
+  ) {
+    throw new Error(
+      `${label}: archive bytes do not match the publication manifest`,
+    );
+  }
+
+  const inspected = await inspectArchive(archivePath, label);
+  const files = inspected.files;
+  if (
+    computeVersionId(publication.resource.storageId, files) !==
+      publication.resource.versionId ||
+    files.length !== publication.resource.fileCount ||
+    files.reduce((sum, file) => sum + file.size, 0) !==
+      publication.resource.totalSize ||
+    JSON.stringify(files) !== JSON.stringify(publication.resource.files)
+  ) {
+    throw new Error(
+      `${label}: extracted files do not match the publication manifest`,
+    );
+  }
+
+  console.log(
+    `VERIFIED ${label} ${publication.resource.id} version=${publication.resource.versionId} sha256=${publication.resource.archive.sha256} files=${publication.resource.fileCount}; ${inspected.verification}`,
+  );
+  return publication;
+}
+
+async function verify() {
+  const outputDir = path.resolve(requiredOption("--output-dir"));
+  await verifyBundle(outputDir, "bundle");
+}
+
+async function bodyToBuffer(body) {
+  if (!body) throw new Error("R2 returned an empty object body");
+  return Buffer.from(await body.transformToByteArray());
+}
+
+function isPreconditionFailure(error) {
+  return (
+    error?.name === "PreconditionFailed" ||
+    error?.$metadata?.httpStatusCode === 412
+  );
+}
+
+async function putImmutable(client, bucket, key, body, contentType) {
+  try {
+    await client.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: body,
+        ContentType: contentType,
+        CacheControl: "public, max-age=31536000, immutable",
+        IfNoneMatch: "*",
+      }),
+    );
+  } catch (error) {
+    if (!isPreconditionFailure(error)) throw error;
+  }
+}
+
+async function getObject(client, bucket, key) {
+  const response = await client.send(
+    new GetObjectCommand({ Bucket: bucket, Key: key }),
+  );
+  return await bodyToBuffer(response.Body);
+}
+
+function assertR2Manifest(actual, expected) {
+  if (
+    actual.version !== expected.version ||
+    actual.totalSize !== expected.totalSize ||
+    actual.fileCount !== expected.fileCount ||
+    JSON.stringify(actual.files) !== JSON.stringify(expected.files) ||
+    Number.isNaN(Date.parse(actual.createdAt))
+  ) {
+    throw new Error("R2 manifest does not match the publication manifest");
+  }
+}
+
+function assertStorageIdentity(storage, expected) {
+  if (
+    storage.id !== expected.id ||
+    storage.name !== expected.name ||
+    storage.org_id !== SYSTEM_ORG_ID ||
+    storage.user_id !== VOLUME_ORG_USER_ID ||
+    storage.s3_prefix !== expected.s3Prefix ||
+    (storage.head_version_id !== null &&
+      storage.head_version_id !== expected.versionId)
+  ) {
+    throw new Error("Production storage has an unexpected identity");
+  }
+}
+
+async function publish() {
+  const outputDir = path.resolve(requiredOption("--output-dir"));
+  const publication = await verifyBundle(outputDir, "publish-input");
+  const pkg = publication.resource;
+  const storageName = `registry-resource@${pkg.id}`;
+  const s3Prefix = `${SYSTEM_ORG_ID}/${pkg.storageId}`;
+  const s3Key = `${s3Prefix}/${pkg.versionId}`;
+  const expectedStorage = {
+    id: pkg.storageId,
+    name: storageName,
+    s3Prefix,
+    versionId: pkg.versionId,
+  };
+  const archive = await readFile(path.join(outputDir, pkg.archive.path));
+
+  const databaseUrl = requiredEnv("DATABASE_URL");
+  const bucket = requiredEnv("R2_USER_STORAGES_BUCKET_NAME");
+  const client = new S3Client({
+    region: "auto",
+    endpoint: `https://${requiredEnv("R2_ACCOUNT_ID")}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: requiredEnv("R2_ACCESS_KEY_ID"),
+      secretAccessKey: requiredEnv("R2_SECRET_ACCESS_KEY"),
+    },
+    requestChecksumCalculation: "WHEN_REQUIRED",
+  });
+  const sql = postgres(databaseUrl, { max: 1 });
+
+  try {
+    const storageRows = await sql`
+      SELECT id, user_id, org_id, name, s3_prefix, head_version_id
+      FROM storages
+      WHERE name = ${storageName} OR id = ${pkg.storageId}
+    `;
+    if (storageRows.length > 1) {
+      throw new Error(
+        "Multiple production storages match the release identity",
+      );
+    }
+    if (storageRows[0]) {
+      assertStorageIdentity(storageRows[0], expectedStorage);
+    }
+
+    const manifest = {
+      version: pkg.versionId,
+      createdAt: new Date().toISOString(),
+      totalSize: pkg.totalSize,
+      fileCount: pkg.fileCount,
+      files: pkg.files,
+    };
+    await putImmutable(
+      client,
+      bucket,
+      `${s3Key}/archive.tar.gz`,
+      archive,
+      "application/gzip",
+    );
+    await putImmutable(
+      client,
+      bucket,
+      `${s3Key}/manifest.json`,
+      `${JSON.stringify(manifest)}\n`,
+      "application/json",
+    );
+
+    const [r2Archive, r2ManifestBuffer] = await Promise.all([
+      getObject(client, bucket, `${s3Key}/archive.tar.gz`),
+      getObject(client, bucket, `${s3Key}/manifest.json`),
+    ]);
+    if (sha256(r2Archive) !== pkg.archive.sha256) {
+      throw new Error("R2 archive digest does not match the release pin");
+    }
+    assertR2Manifest(JSON.parse(r2ManifestBuffer.toString("utf8")), manifest);
+
+    const inspectRoot = await mkdtemp(path.join(tmpdir(), "emboss-deboss-r2-"));
+    const r2ArchivePath = path.join(inspectRoot, "archive.tar.gz");
+    try {
+      await writeFile(r2ArchivePath, r2Archive);
+      await inspectArchive(r2ArchivePath, "r2");
+    } finally {
+      await rm(inspectRoot, { recursive: true, force: true });
+    }
+
+    await sql.begin(async (tx) => {
+      const lockedRows = await tx`
+        SELECT id, user_id, org_id, name, s3_prefix, head_version_id
+        FROM storages
+        WHERE name = ${storageName} OR id = ${pkg.storageId}
+        FOR UPDATE
+      `;
+      if (lockedRows.length > 1) {
+        throw new Error("Storage identity became ambiguous before commit");
+      }
+      if (lockedRows[0]) {
+        assertStorageIdentity(lockedRows[0], expectedStorage);
+      } else {
+        await tx`
+          INSERT INTO storages
+            (id, user_id, name, org_id, s3_prefix, size, file_count)
+          VALUES
+            (
+              ${pkg.storageId},
+              ${VOLUME_ORG_USER_ID},
+              ${storageName},
+              ${SYSTEM_ORG_ID},
+              ${s3Prefix},
+              0,
+              0
+            )
+        `;
+      }
+
+      const versionRows = await tx`
+        SELECT id, storage_id, s3_key, size, archive_size, file_count
+        FROM storage_versions
+        WHERE id = ${pkg.versionId}
+        FOR UPDATE
+      `;
+      const existing = versionRows[0];
+      if (existing) {
+        if (
+          existing.storage_id !== pkg.storageId ||
+          existing.s3_key !== s3Key ||
+          Number(existing.size) !== pkg.totalSize ||
+          Number(existing.archive_size) !== r2Archive.byteLength ||
+          existing.file_count !== pkg.fileCount
+        ) {
+          throw new Error("Existing storage version has a different identity");
+        }
+      } else {
+        await tx`
+          INSERT INTO storage_versions
+            (id, storage_id, s3_key, size, archive_size, file_count, message, created_by)
+          VALUES
+            (
+              ${pkg.versionId},
+              ${pkg.storageId},
+              ${s3Key},
+              ${pkg.totalSize},
+              ${r2Archive.byteLength},
+              ${pkg.fileCount},
+              ${`Emboss & Deboss image style from ${metadata.source.repo}@${metadata.source.commit}`},
+              'github-actions-emboss-deboss-publisher'
+            )
+        `;
+      }
+
+      await tx`
+        UPDATE storages
+        SET
+          head_version_id = ${pkg.versionId},
+          size = ${pkg.totalSize},
+          file_count = ${pkg.fileCount},
+          updated_at = now()
+        WHERE id = ${pkg.storageId}
+      `;
+    });
+
+    const rows = await sql`
+      SELECT
+        s.id,
+        s.user_id,
+        s.org_id,
+        s.name,
+        s.s3_prefix,
+        s.head_version_id,
+        v.id AS version_id,
+        v.s3_key,
+        v.size,
+        v.archive_size,
+        v.file_count
+      FROM storages s
+      JOIN storage_versions v ON v.storage_id = s.id
+      WHERE s.id = ${pkg.storageId} AND v.id = ${pkg.versionId}
+    `;
+    if (rows.length !== 1) {
+      throw new Error("Post-publication database verification failed");
+    }
+    assertStorageIdentity(rows[0], expectedStorage);
+    if (
+      rows[0].head_version_id !== pkg.versionId ||
+      rows[0].version_id !== pkg.versionId ||
+      rows[0].s3_key !== s3Key ||
+      Number(rows[0].size) !== pkg.totalSize ||
+      Number(rows[0].archive_size) !== r2Archive.byteLength ||
+      rows[0].file_count !== pkg.fileCount
+    ) {
+      throw new Error("Published version does not match the release metadata");
+    }
+    await Promise.all([
+      client.send(
+        new HeadObjectCommand({
+          Bucket: bucket,
+          Key: `${s3Key}/archive.tar.gz`,
+        }),
+      ),
+      client.send(
+        new HeadObjectCommand({
+          Bucket: bucket,
+          Key: `${s3Key}/manifest.json`,
+        }),
+      ),
+    ]);
+    console.log(
+      `PUBLISHED ${pkg.id} storage=${pkg.storageId} version=${pkg.versionId} sha256=${pkg.archive.sha256}`,
+    );
+  } finally {
+    await sql.end({ timeout: 5 });
+    client.destroy();
+  }
+}
+
+const mode = process.argv[2];
+if (mode === "verify") {
+  await verify();
+} else if (mode === "publish") {
+  await publish();
+} else {
+  throw new Error("Usage: publish.mjs <verify|publish> --output-dir <path>");
+}

--- a/.github/workflows/one-time-publish-emboss-deboss.yml
+++ b/.github/workflows/one-time-publish-emboss-deboss.yml
@@ -1,0 +1,139 @@
+name: One-time publish Emboss & Deboss image style
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/emboss-deboss-release/**"
+      - ".github/workflows/one-time-publish-emboss-deboss.yml"
+
+concurrency:
+  group: one-time-publish-emboss-deboss-e6966525
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  verify:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.head_ref == 'chore/one-time-publish-emboss-deboss-e6966525'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - name: Check out approved merged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: vm0-ai/vm0-skills
+          ref: e6966525e5e809b6c8c2c57918ebb1ca43ee89eb
+          path: .emboss-deboss-source
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.19.0
+      - name: Verify approved archive against merged source
+        run: |
+          set -euo pipefail
+          source_commit="e6966525e5e809b6c8c2c57918ebb1ca43ee89eb"
+          test "$(git -C .emboss-deboss-source rev-parse HEAD)" = "$source_commit"
+
+          release_dir="$RUNNER_TEMP/emboss-deboss-release"
+          output_dir="$RUNNER_TEMP/emboss-deboss-output"
+          mkdir -p "$release_dir" "$output_dir"
+          cp .github/emboss-deboss-release/publish.mjs "$release_dir/"
+          cp .github/emboss-deboss-release/emboss-deboss-release.json "$release_dir/"
+          cp .github/emboss-deboss-release/prebuilt/publication.json "$output_dir/"
+
+          archive_url=$(jq -r '.resource.archiveUrl' "$release_dir/emboss-deboss-release.json")
+          curl --fail --location --proto '=https' --proto-redir '=https' \
+            "$archive_url" --output "$output_dir/emboss-deboss.tar.gz"
+
+          cd "$release_dir"
+          npm init --yes >/dev/null
+          npm install --ignore-scripts --no-audit --no-fund \
+            @aws-sdk/client-s3@3.1116.0 postgres@3.4.9 tar@7.5.22
+          node publish.mjs verify --output-dir "$output_dir"
+
+          source_tar="$RUNNER_TEMP/emboss-deboss-source.tar"
+          git -C "$GITHUB_WORKSPACE/.emboss-deboss-source" archive --format=tar \
+            "$source_commit" -- illustration-template/emboss-deboss > "$source_tar"
+          gzip --decompress --stdout "$output_dir/emboss-deboss.tar.gz" | cmp - "$source_tar"
+      - name: Upload verified release bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: emboss-deboss-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/emboss-deboss-output
+          if-no-files-found: error
+          retention-days: 30
+
+  publish-production:
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    env:
+      NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+      NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+      R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_USER_STORAGES_BUCKET_NAME: ${{ vars.R2_USER_STORAGES_BUCKET_NAME }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.19.0
+      - name: Download verified release bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: emboss-deboss-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/emboss-deboss-output
+      - name: Publish immutable archive and register version
+        run: |
+          set -euo pipefail
+          : "${NEON_API_KEY:?NEON_API_KEY is required}"
+          : "${NEON_PROJECT_ID:?NEON_PROJECT_ID is required}"
+          : "${R2_ACCOUNT_ID:?R2_ACCOUNT_ID is required}"
+          : "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required}"
+          : "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required}"
+          : "${R2_USER_STORAGES_BUCKET_NAME:?R2_USER_STORAGES_BUCKET_NAME is required}"
+
+          release_dir="$RUNNER_TEMP/emboss-deboss-release"
+          mkdir -p "$release_dir"
+          cp .github/emboss-deboss-release/publish.mjs "$release_dir/"
+          cp .github/emboss-deboss-release/emboss-deboss-release.json "$release_dir/"
+          cd "$release_dir"
+          npm init --yes >/dev/null
+          npm install --ignore-scripts --no-audit --no-fund \
+            @aws-sdk/client-s3@3.1116.0 postgres@3.4.9 tar@7.5.22
+
+          branches=$(curl -fsS \
+            "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches" \
+            -H "Authorization: Bearer ${NEON_API_KEY}")
+          branch_id=$(jq -er '[.branches[] | select(.name == "production") | .id] | if length == 1 then .[0] else error("Expected exactly one production branch") end' <<< "$branches")
+          connection=$(curl -fsS \
+            "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/connection_uri?branch_id=${branch_id}&database_name=neondb&role_name=neondb_owner" \
+            -H "Authorization: Bearer ${NEON_API_KEY}")
+          database_url=$(jq -er '.uri | select(type == "string" and length > 0)' <<< "$connection")
+          mask_value="${database_url//%/%25}"
+          mask_value="${mask_value//$'\r'/%0D}"
+          mask_value="${mask_value//$'\n'/%0A}"
+          printf '::add-mask::%s\n' "$mask_value"
+
+          DATABASE_URL="$database_url" node publish.mjs publish \
+            --output-dir "$RUNNER_TEMP/emboss-deboss-output"
+      - name: Summarize publication
+        run: |
+          printf '### Emboss & Deboss published\n\n- Source: vm0-ai/vm0-skills@e6966525e5e809b6c8c2c57918ebb1ca43ee89eb\n- Immutable R2 archive, six-file manifest, and storage version verified.\n' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/one-time-publish-emboss-deboss.yml
+++ b/.github/workflows/one-time-publish-emboss-deboss.yml
@@ -14,6 +14,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  npm_config_audit: "false"
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
> **Published successfully; closed without merge.** [Run 34037345329](https://github.com/vm0-ai/vm0/actions/runs/34037345329) verified the approved archive, published the immutable R2 objects, and verified the production storage/version rows on 2026-09-06. This PR is retained as the one-time publication audit record.

Publish the approved **Emboss & Deboss** package from [vm0-skills #333](https://github.com/vm0-ai/vm0-skills/pull/333) as `image-style:emboss-deboss` for #32010. This follows the one-time resource publisher pattern used in #29032, including the existing `production` environment protections.

## Publication

The verification job checks out `vm0-ai/vm0-skills@e6966525e5e809b6c8c2c57918ebb1ca43ee89eb`, downloads the prepared archive, verifies its pinned digest, and compares its uncompressed tar bytes with `git archive` from that exact source. It independently verifies every extracted file, package shape, and content-addressed storage version. The 2.8 MB archive remains outside Git to respect the repository file-size limit.

The publisher creates immutable R2 objects with `If-None-Match: *`, downloads and checks both objects, then creates or verifies the storage/version rows in one transaction. Reruns reject identity drift and preserve existing objects. The package contains exactly `SKILL.md` and the five approved reference images under `illustration-template/emboss-deboss/`.

- Owner: `__system__` / `__org__`
- Storage name: `registry-resource@image-style:emboss-deboss`
- Storage ID: `9a73f277-b6e7-4878-a92b-89c07154f5d6`
- Version ID: `e84748dd61e087cc15f12d9f9ecf19d68de790d747e0075b3f9bb6be38975e95`
- Archive SHA-256: `f1c1be0b1cf711a8c61945f928206d700b54d71969711f0551403d20c360d3f8`
- Archive size: 2,855,348 bytes; extracted size: 2,865,976 bytes; files: 6.

## Validation

- Valid package verification and exact merged-source tar comparison passed.
- Five invalid-input cases fail before storage access: archive corruption, file-manifest corruption, changed version, changed source commit, and an escaping archive path.
- Prettier, Node syntax, actionlint 1.7.12 with ShellCheck 0.11.0, the repository implicit-npm-audit and shell-compatibility checks, file-size limits, and staged diff checks passed.

The picker integration stays in draft until this publication and [static-files #195](https://github.com/vm0-ai/static-files/pull/195) are verified.
