### PR TITLE
fix(platform): support long-press pin reordering on touch screens

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-pin-order.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-pin-order.ts
@@ -29,6 +29,7 @@ import {
   registerOptimisticChatThreadEvent$,
 } from "./chat-thread-event-sourcing.ts";
 import { registerPinnedThreadDragSession$ } from "./chat-thread-pin-drag-lifecycle.ts";
+import { createPinnedThreadTouchDrag } from "./chat-thread-pin-touch.ts";
 
 export const pinnedThreadReorderEnabled$ = computed((get) => {
   return get(stableChatThreadNavigationEnabled$) && !get(chatThreadOnlyUnread$);
@@ -134,6 +135,8 @@ interface PinDragPointer {
   readonly x: number;
   readonly y: number;
   readonly width: number;
+  readonly offsetX: number;
+  readonly offsetY: number;
 }
 
 interface PinDragPreview extends PinDragPointer {
@@ -166,6 +169,10 @@ export interface PinnedThreadDragSignals {
   readonly step$: Command<void, [-1 | 1]>;
   readonly drop$: Command<Promise<void>, [AbortSignal]>;
   readonly dropPointer$: Command<Promise<void>, [AbortSignal]>;
+  readonly startTouch$: Command<
+    Promise<void>,
+    [HTMLElement, TouchEvent, AbortSignal]
+  >;
 }
 
 function createPinDragInteraction(
@@ -259,20 +266,39 @@ function createPinDragInteraction(
     })!;
     return { ...pointer, title: source.title };
   });
-  return { cancel$, cancelKeyboard$, mount$, start$, preview$ };
+  const movePointer$ = command(({ get, set }, x: number, y: number) => {
+    const pointer = get(pointer$);
+    if (pointer && get(drag$)) {
+      set(pointer$, { ...pointer, x, y });
+    }
+  });
+  return { cancel$, cancelKeyboard$, mount$, start$, preview$, movePointer$ };
 }
 
 function createPinDragRowMount(
   internalDrag$: State<PinDrag | null>,
   start$: PinnedThreadDragSignals["start$"],
+  cancelTouch$: Command<void, [string]>,
 ) {
   return onRef(
-    command(({ set }, row: HTMLElement, signal: AbortSignal) => {
+    command(({ get, set }, row: HTMLElement, signal: AbortSignal) => {
       const threadId = row.dataset.threadId;
       const handle = row.querySelector(".okou-thread-drag-handle");
       if (!threadId || !(handle instanceof HTMLElement)) {
         throw new Error("Missing pinned thread drag elements");
       }
+      // Safari needs a non-passive listener before touchstart to let a later
+      // long press prevent scrolling. Pending holds still allow native swipes.
+      row.addEventListener(
+        "touchmove",
+        (event) => {
+          const drag = get(internalDrag$);
+          if (drag?.threadId === threadId && !drag.keyboard) {
+            event.preventDefault();
+          }
+        },
+        { signal, passive: false },
+      );
       const cleanup = draggable({
         element: handle,
         getInitialData: () => {
@@ -290,10 +316,19 @@ function createPinDragRowMount(
             x: location.current.input.clientX,
             y: location.current.input.clientY,
             width: row.getBoundingClientRect().width,
+            offsetX: 16,
+            offsetY: 16,
           });
         },
       });
-      signal.addEventListener("abort", cleanup, { once: true });
+      signal.addEventListener(
+        "abort",
+        () => {
+          cleanup();
+          set(cancelTouch$, threadId);
+        },
+        { once: true },
+      );
     }),
   );
 }
@@ -417,7 +452,7 @@ export function createPinnedThreadDragSignals(): PinnedThreadDragSignals {
       ? drag
       : null;
   });
-  const { cancel$, cancelKeyboard$, mount$, start$, preview$ } =
+  const { cancel$, cancelKeyboard$, mount$, start$, preview$, movePointer$ } =
     createPinDragInteraction(internalDrag$, drag$);
   const { placement$, target$ } = createPinDragPlacement(internalDrag$, drag$);
   const step$ = command(({ get, set }, direction: -1 | 1) => {
@@ -438,6 +473,44 @@ export function createPinnedThreadDragSignals(): PinnedThreadDragSignals {
       await set(drop$, signal);
     }
   });
+  const moveTouch$ = command(
+    ({ get, set }, row: HTMLElement, x: number, y: number) => {
+      if (!get(drag$)) {
+        return false;
+      }
+      set(movePointer$, x, y);
+      const zone = row.closest('[data-testid="pinned-thread-drop-zone"]');
+      const bounds = zone?.getBoundingClientRect();
+      const list = zone?.querySelector(
+        '[data-testid="sidebar-chat-threads-virtual-list"]',
+      );
+      if (
+        !bounds ||
+        !list ||
+        x < bounds.left ||
+        x > bounds.right ||
+        y < bounds.top ||
+        y > bounds.bottom
+      ) {
+        return false;
+      }
+      set(
+        target$,
+        Math.floor(
+          (y - list.getBoundingClientRect().top) /
+            CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
+        ),
+      );
+      return true;
+    },
+  );
+  const { startTouch$, cancelRow$ } = createPinnedThreadTouchDrag({
+    drag$,
+    start$,
+    drop$,
+    cancel$,
+    move$: moveTouch$,
+  });
   const announcement$ = computed((get) => {
     const drag = get(drag$);
     if (!drag?.keyboard) {
@@ -457,13 +530,14 @@ export function createPinnedThreadDragSignals(): PinnedThreadDragSignals {
     placement$,
     preview$,
     mount$,
-    mountRow$: createPinDragRowMount(internalDrag$, start$),
+    mountRow$: createPinDragRowMount(internalDrag$, start$, cancelRow$),
     mountDropZone$: createPinDragDropZoneMount(internalDrag$, drag$, target$),
     cancelKeyboard$,
     start$,
     step$,
     drop$,
     dropPointer$,
+    startTouch$,
     announcement$,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-pin-touch.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-pin-touch.ts
@@ -1,0 +1,180 @@
+import { command, state, type Command } from "ccstate";
+import { timeout } from "signal-timers";
+import { createChildAbortController, createDeferredPromise } from "../utils.ts";
+import type { PinnedThreadDragSignals } from "./chat-thread-pin-order.ts";
+
+const LONG_PRESS_MS = 300;
+const SCROLL_TOLERANCE_PX = 10;
+
+type TouchDragActions = Pick<
+  PinnedThreadDragSignals,
+  "drag$" | "start$" | "drop$"
+> & {
+  cancel$: Command<void, []>;
+  move$: Command<boolean, [HTMLElement, number, number]>;
+};
+
+export function createPinnedThreadTouchDrag(actions: TouchDragActions) {
+  const session$ = state<{
+    threadId: string;
+    controller: AbortController;
+  } | null>(null);
+  const cancelRow$ = command(({ get }, threadId: string) => {
+    const session = get(session$);
+    if (session?.threadId === threadId) {
+      session.controller.abort();
+    }
+  });
+  const startTouch$ = command(
+    async (
+      { get, set },
+      row: HTMLElement,
+      event: TouchEvent,
+      signal: AbortSignal,
+    ) => {
+      get(session$)?.controller.abort();
+      const touch = event.touches[0];
+      const threadId = row.dataset.threadId;
+      const link = row.querySelector("a[data-sidebar-chat-thread-id]");
+      if (
+        event.touches.length !== 1 ||
+        !touch ||
+        !threadId ||
+        !(event.target instanceof Node) ||
+        !link?.contains(event.target)
+      ) {
+        return;
+      }
+
+      signal.throwIfAborted();
+      const controller = createChildAbortController(signal);
+      const session = { threadId, controller };
+      const options = { signal: controller.signal };
+      const finished = createDeferredPromise<boolean>(controller.signal);
+      const document = row.ownerDocument;
+      let activated = false;
+      set(session$, session);
+      controller.signal.addEventListener(
+        "abort",
+        () => {
+          if (get(session$) === session) {
+            set(session$, null);
+            if (activated) {
+              set(actions.cancel$);
+            }
+          }
+        },
+        { once: true },
+      );
+
+      timeout(
+        () => {
+          const bounds = row.getBoundingClientRect();
+          set(actions.start$, threadId, {
+            x: touch.clientX,
+            y: touch.clientY,
+            width: bounds.width,
+            offsetX: bounds.left - touch.clientX,
+            offsetY: bounds.top - touch.clientY - 6,
+          });
+          activated = get(actions.drag$)?.threadId === threadId;
+        },
+        LONG_PRESS_MS,
+        options,
+      );
+
+      document.addEventListener(
+        "touchmove",
+        (moveEvent) => {
+          const position = Array.from(moveEvent.touches).find((item) => {
+            return item.identifier === touch.identifier;
+          });
+          if (!position || moveEvent.touches.length !== 1) {
+            controller.abort();
+            return;
+          }
+          if (activated) {
+            moveEvent.preventDefault();
+            set(actions.move$, row, position.clientX, position.clientY);
+          } else if (
+            Math.hypot(
+              position.clientX - touch.clientX,
+              position.clientY - touch.clientY,
+            ) > SCROLL_TOLERANCE_PX
+          ) {
+            // Leave the browser in charge of a swipe that starts before pickup.
+            controller.abort();
+          }
+        },
+        { ...options, passive: false },
+      );
+      document.addEventListener(
+        "touchend",
+        (endEvent) => {
+          const position = Array.from(endEvent.changedTouches).find((item) => {
+            return item.identifier === touch.identifier;
+          });
+          if (!position) {
+            return;
+          }
+          if (activated) {
+            // Suppress the compatibility click that would open the conversation.
+            endEvent.preventDefault();
+          }
+          finished.resolve(
+            activated &&
+              set(actions.move$, row, position.clientX, position.clientY),
+          );
+        },
+        { ...options, passive: false },
+      );
+      bindTouchCancellation(
+        row,
+        () => {
+          controller.abort();
+        },
+        controller.signal,
+      );
+
+      const shouldDrop = await finished.promise;
+      signal.throwIfAborted();
+      controller.signal.throwIfAborted();
+      const dropping = shouldDrop
+        ? set(actions.drop$, signal)
+        : Promise.resolve();
+      controller.abort();
+      await dropping;
+    },
+  );
+  return { startTouch$, cancelRow$ };
+}
+
+function bindTouchCancellation(
+  row: HTMLElement,
+  cancel: () => void,
+  signal: AbortSignal,
+) {
+  const document = row.ownerDocument;
+  const options = { signal };
+  document.addEventListener(
+    "touchstart",
+    (event) => {
+      if (event.touches.length > 1) {
+        cancel();
+      }
+    },
+    options,
+  );
+  document.addEventListener("touchcancel", cancel, options);
+  document.addEventListener("scroll", cancel, { ...options, capture: true });
+  document.defaultView?.addEventListener("blur", cancel, options);
+  for (const type of ["contextmenu", "dragstart"] as const) {
+    row.addEventListener(
+      type,
+      (event) => {
+        event.preventDefault();
+      },
+      { ...options, capture: true },
+    );
+  }
+}

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-pin-order.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-pin-order.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import {
   chatThreadPinOrderContract,
@@ -96,6 +96,142 @@ function dragEvent(
     ),
   );
 }
+
+function threadLink(title: string) {
+  const link = sidebarThreadLinks().find((item) => {
+    return item.textContent?.includes(title);
+  });
+  if (!link) {
+    throw new Error(`Missing thread link: ${title}`);
+  }
+  return link;
+}
+
+function touchEvent(
+  type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
+  target: Element,
+  clientY: number,
+  clientX = 50,
+) {
+  const touch = new Touch({ identifier: 1, target, clientX, clientY });
+  const event = new TouchEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    touches: type === "touchend" || type === "touchcancel" ? [] : [touch],
+    changedTouches: [touch],
+  });
+  fireEvent(target, event);
+  return event;
+}
+
+test("long pressing the pinned row reorders it without a navigation click", async () => {
+  context.mocks.api(chatThreadPinOrderContract.reorder, ({ respond }) => {
+    return respond(204);
+  });
+  await prepare(73);
+  vi.spyOn(
+    screen.getByTestId("pinned-thread-drop-zone"),
+    "getBoundingClientRect",
+  ).mockReturnValue(new DOMRect(0, 0, 300, 500));
+  const link = threadLink("Last pin");
+  const pathname = window.location.pathname;
+  touchEvent("touchstart", link, 90);
+  const preview = await screen.findByTestId("pinned-thread-drag-preview");
+  expect(preview).toHaveTextContent("Last pin");
+  expect(touchEvent("touchmove", link, 52).defaultPrevented).toBeTruthy();
+  expect(screen.getByTestId("pinned-thread-drop-placeholder")).toHaveStyle({
+    transform: "translateY(36px)",
+  });
+  expect(touchEvent("touchend", link, 52).defaultPrevented).toBeTruthy();
+  await waitFor(() => {
+    expect(sidebarThreadTitles()).toStrictEqual([
+      "First pin",
+      "Last pin",
+      "Second pin",
+      "Regular thread",
+    ]);
+  });
+  expect(preview).not.toBeInTheDocument();
+  expect(window.location.pathname).toBe(pathname);
+});
+
+test("a tap or an early swipe leaves touch scrolling available and cancels pickup", async () => {
+  await prepare(74);
+  const link = threadLink("Last pin");
+  touchEvent("touchstart", link, 90);
+  expect(touchEvent("touchend", link, 90).defaultPrevented).toBeFalsy();
+  touchEvent("touchstart", link, 90);
+  expect(touchEvent("touchmove", link, 52).defaultPrevented).toBeFalsy();
+  touchEvent("touchend", link, 52);
+
+  // A subsequent pickup is the completion boundary for the cancelled holds.
+  const next = threadLink("Second pin");
+  touchEvent("touchstart", next, 52);
+  const preview = await screen.findByTestId("pinned-thread-drag-preview");
+  expect(preview).toHaveTextContent("Second pin");
+  touchEvent("touchcancel", next, 52);
+  expect(preview).not.toBeInTheDocument();
+  expect(sidebarThreadTitles()).toStrictEqual([
+    "First pin",
+    "Second pin",
+    "Last pin",
+    "Regular thread",
+  ]);
+});
+
+test("releasing a touch drag outside the sidebar leaves the pin order intact", async () => {
+  await prepare(75);
+  vi.spyOn(
+    screen.getByTestId("pinned-thread-drop-zone"),
+    "getBoundingClientRect",
+  ).mockReturnValue(new DOMRect(0, 0, 300, 500));
+  const link = threadLink("Last pin");
+  touchEvent("touchstart", link, 90);
+  const preview = await screen.findByTestId("pinned-thread-drag-preview");
+  touchEvent("touchmove", link, 52);
+  expect(screen.getByTestId("pinned-thread-drop-placeholder")).toHaveStyle({
+    transform: "translateY(36px)",
+  });
+  touchEvent("touchend", link, 52, 350);
+  await waitFor(() => {
+    expect(preview).not.toBeInTheDocument();
+  });
+  expect(sidebarThreadTitles()).toStrictEqual([
+    "First pin",
+    "Second pin",
+    "Last pin",
+    "Regular thread",
+  ]);
+});
+
+test("collapsing the list cancels a touch pickup before it can reorder after remount", async () => {
+  await prepare(76);
+  touchEvent("touchstart", threadLink("Last pin"), 90);
+  const title = document.querySelector(".okou-nav-recent-label");
+  if (!title) {
+    throw new Error("Missing chat list header");
+  }
+  fireEvent.click(title);
+  expect(
+    screen.queryByTestId("sidebar-chat-threads-virtual-list"),
+  ).not.toBeInTheDocument();
+  fireEvent.click(title);
+  await waitFor(() => {
+    expect(threadLink("First pin")).toBeInTheDocument();
+  });
+  const next = threadLink("First pin");
+  touchEvent("touchstart", next, 16);
+  const preview = await screen.findByTestId("pinned-thread-drag-preview");
+  expect(preview).toHaveTextContent("First pin");
+  touchEvent("touchcancel", next, 16);
+  expect(preview).not.toBeInTheDocument();
+  expect(sidebarThreadTitles()).toStrictEqual([
+    "First pin",
+    "Second pin",
+    "Last pin",
+    "Regular thread",
+  ]);
+});
 
 test("keyboard reorder follows visual tab order and survives the matching persisted event", async () => {
   const caseId = 61;

--- a/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.css
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.css
@@ -6,6 +6,7 @@
 
 .okou-thread-drag-handle {
   opacity: 0;
+  pointer-events: none;
   transform: translateX(-14px);
   transition:
     transform 120ms ease-out,
@@ -13,7 +14,6 @@
 }
 
 .okou-thread-reorder-row[data-reorderable]:is(
-    :hover,
     :has(.okou-thread-drag-handle:focus-visible),
     [data-dragging]
   )
@@ -23,12 +23,12 @@
 }
 
 .okou-thread-reorder-row:is(
-    :hover,
     :has(.okou-thread-drag-handle:focus-visible),
     [data-dragging]
   )
   .okou-thread-drag-handle {
   opacity: 1;
+  pointer-events: auto;
   transform: translateX(0);
   transition-duration: 160ms;
 }
@@ -41,13 +41,25 @@
   opacity: 0;
 }
 
-@media (pointer: coarse) {
-  .okou-thread-reorder-row[data-reorderable] > a {
+@media (hover: hover) and (pointer: fine) {
+  .okou-thread-reorder-row[data-reorderable]:hover > a {
     padding-left: 32px;
+    transition-duration: 160ms;
   }
-  .okou-thread-drag-handle {
+  .okou-thread-reorder-row:hover .okou-thread-drag-handle {
     opacity: 1;
-    transform: none;
+    pointer-events: auto;
+    transform: translateX(0);
+    transition-duration: 160ms;
+  }
+}
+
+@media (any-pointer: coarse) {
+  .okou-thread-reorder-row[data-reorderable] > a {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+    touch-action: manipulation;
   }
 }
 

--- a/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.tsx
@@ -159,10 +159,22 @@ export function PinnedThreadRow({
   const pinned = useGet(signals.pinned$);
   const drag = useGet(dragSignals.drag$);
   const mountRow = useSet(dragSignals.mountRow$);
+  const startTouch = useSet(dragSignals.startTouch$);
+  const signal = useGet(pageSignal$);
   const reorderable = enabled && pinned;
   return (
     <div
       ref={reorderable ? mountRow : undefined}
+      onTouchStart={
+        reorderable
+          ? (event) => {
+              detach(
+                startTouch(event.currentTarget, event.nativeEvent, signal),
+                Reason.DomCallback,
+              );
+            }
+          : undefined
+      }
       className="group relative grid grid-cols-[minmax(0,1fr)_auto] okou-thread-reorder-row"
       data-thread-id={signals.threadId}
       data-reorderable={reorderable || undefined}
@@ -222,7 +234,7 @@ export function PinnedThreadDragPreview({
       className="pointer-events-none fixed left-0 top-0 z-50 flex h-8 max-w-64 items-center gap-2 rounded-lg border border-border bg-popover px-2 text-sm text-popover-foreground shadow-sm"
       style={{
         width: preview.width,
-        transform: `translate(${preview.x + 16}px, ${preview.y + 16}px)`,
+        transform: `translate(${preview.x + preview.offsetX}px, ${preview.y + preview.offsetY}px)`,
       }}
     >
       <GripVertical size={16} className="shrink-0 text-muted-foreground" />


### PR DESCRIPTION
## Summary

Pinned chats currently reserve space for a permanently visible drag handle on touch screens. Hide idle touch handles and let users pick up the conversation row after a 300 ms hold, with a lifted preview and the existing drop placeholder.

Swiping before pickup keeps native scrolling available; taps and the row menu keep their normal behavior. Releasing outside the sidebar, cancelling the touch, or unmounting the row cancels the gesture. The existing reorder state, persistence, feature flag, desktop handles, keyboard sorting, and Move up/Move down menu actions are reused.

## Verification

- Targeted sidebar pin-order regression file: 16 tests passed, including four new touch cases.
- Formatting, ESLint, Oxlint (including type-aware rules), platform TypeScript checks and platform Knip analysis passed.
- All PR CI checks passed on `4920c3748de739c3afef31f426b7371727a1d171`.
- [PR preview](https://pr-32032-app-okou-app-preview.vm0.workers.dev): verified with Chromium touch input at an iPhone 15 viewport (393 × 852), using 3 pinned and 17 regular test chats. Idle handles are hidden and row padding matches; long-press sorting, early swipes, normal taps, the row menu, and cancellation outside the sidebar passed. The API recorded the reorder events, and the order survived reload.
- Preview App/API both deployed GitHub test merge `9fb3327f0392b8e16d856fc8972cb9b3cde5b0f8`. `stableChatThreadNavigation` was enabled via Lab. Fixtures used a disposable account with onboarding bypassed. Physical iOS/WebKit verification is recorded below.

Screenshots: [Idle mobile sidebar](https://a.okou.io/yt61rifekm.png) · [During a long-press drag](https://a.okou.io/50howopxi9.png)

## BrowserStack real-device verification

Verified the unchanged PR head `4920c3748de739c3afef31f426b7371727a1d171` on a physical **iPhone 16 running iOS 18.5 / Safari 18.5**, using native XCUITest touch input. All core interaction assertions passed:

- Idle handles are hidden and do not intercept touches.
- A row lifts after approximately 305 ms. Long-press sorting succeeds in both directions without scrolling the list, navigating, or opening an iOS link preview.
- A swipe beginning before pickup scrolls the list (285 px observed) without changing its order.
- A short tap opens the expected conversation.
- Releasing outside the sidebar cancels the drag and removes the preview without saving a new order or navigating.
- Holding the trailing menu icon does not start dragging. A short tap opens the menu with Move up / Move down available.
- The dragged order survives a full page reload.

[BrowserStack session and full recording](https://automate.browserstack.com/builds/2a6f4260109ac205d9e72d78d1b8a67646a74a7b/sessions/85ffa32c02ffa1def2912de45976d2aa0716de41) · [Reorder recording excerpts](https://a.okou.io/2arigo8oyi.mp4)

Preview setup: the same disposable account and 3 pinned / 17 regular chat fixtures, with `stableChatThreadNavigation` enabled. BrowserStack's `preventCrossSiteTracking` was set to `false` and a cookie scoped to the preview API host enabled the preview guard across the separate App/API sites. The session was stopped after verification. All 98 CI checks remain passed or skipped; no code changes were needed for the core checks.

**Additional visual observation:** holding the trailing menu icon can select nearby regular-chat text in Safari ([screenshot](https://a.okou.io/qern78mqch.png)). A normal tap still opens the menu, and row long-press sorting is unaffected. This behavior has not been compared against `main`, so it is not classified as a regression introduced by this PR.
