### PR TITLE
feat(connectors): add resource guru oauth provider

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -146,7 +146,7 @@ const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const PREVIOUS_CONNECTOR_CATALOG_MAX_RAW_BYTES = 32 * 1024 * 1024;
 const EXPECTED_CAPABILITY_DIGEST =
-  "sha256:d93687a2d56312f36c56e3232f93bc928cebbeb626c1de6fa51f0bbf09cb4c97";
+  "sha256:ba6cd8d86ddd94a1e27f1118b3ca2c6135fd29e1d2e9be54ee670dd861087190";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -96,6 +96,7 @@ import { notionProvider } from "./connectors/notion/provider";
 import { netsuiteProvider } from "./connectors/netsuite/provider";
 import { outlookCalendarProvider } from "./connectors/outlook-calendar/provider";
 import { outlookMailProvider } from "./connectors/outlook-mail/provider";
+import { resourceGuruProvider } from "./connectors/resource-guru/provider";
 import { redditProvider } from "./connectors/reddit/provider";
 import { intervalsIcuProvider } from "./connectors/intervals-icu/provider";
 import { sentryProvider } from "./connectors/sentry/provider";
@@ -1044,6 +1045,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES = [
     nintendoSwitchParentalControlsProvider,
   ),
   authCodeRefreshProviderEntry("notion", "oauth", notionProvider),
+  authCodeRefreshProviderEntry("resource-guru", "oauth", resourceGuruProvider),
   authCodeRefreshProviderEntry(
     "outlook-calendar",
     "oauth",

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/resource-guru.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/resource-guru.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse, http } from "msw";
+
+import { server } from "../../__tests__/test-server";
+import {
+  buildResourceGuruAuthorizationUrl,
+  exchangeResourceGuruCode,
+  refreshResourceGuruToken,
+} from "../resource-guru/oauth";
+import { authCodeGrantFixture } from "./auth-code-grant-fixture";
+
+const TOKEN_URL = "https://api.resourceguruapp.com/oauth/token";
+const USER_URL = "https://api.resourceguruapp.com/v1/me";
+
+describe("connector/providers/resource-guru", () => {
+  it("builds an authorization URL with the requested read scopes", () => {
+    const url = buildResourceGuruAuthorizationUrl(
+      authCodeGrantFixture(["users:read", "reports:read"]),
+      "client-id",
+      "https://app.vm0.ai/oauth/callback",
+      "oauth-state",
+    );
+    const params = new URL(url).searchParams;
+
+    expect(
+      url.startsWith("https://api.resourceguruapp.com/oauth/authorize?"),
+    ).toBe(true);
+    expect(params.get("client_id")).toBe("client-id");
+    expect(params.get("redirect_uri")).toBe(
+      "https://app.vm0.ai/oauth/callback",
+    );
+    expect(params.get("response_type")).toBe("code");
+    expect(params.get("scope")).toBe("users:read reports:read");
+    expect(params.get("state")).toBe("oauth-state");
+  });
+
+  it("exchanges a code and resolves the Resource Guru user", async () => {
+    server.use(
+      http.post(TOKEN_URL, async ({ request }) => {
+        const body = new URLSearchParams(await request.text());
+        expect(body.get("client_id")).toBe("client-id");
+        expect(body.get("client_secret")).toBe("client-secret");
+        expect(body.get("code")).toBe("authorization-code");
+        expect(body.get("grant_type")).toBe("authorization_code");
+        expect(body.get("redirect_uri")).toBe(
+          "https://app.vm0.ai/oauth/callback",
+        );
+        return HttpResponse.json({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 604800,
+          scope: "users:read reports:read",
+        });
+      }),
+      http.get(USER_URL, ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer access-token",
+        );
+        return HttpResponse.json({
+          id: 42,
+          first_name: "Ada",
+          last_name: "Lovelace",
+          email: "ada@example.com",
+        });
+      }),
+    );
+
+    await expect(
+      exchangeResourceGuruCode(
+        authCodeGrantFixture(["users:read", "reports:read"]),
+        "client-id",
+        "client-secret",
+        "authorization-code",
+        "https://app.vm0.ai/oauth/callback",
+      ),
+    ).resolves.toEqual({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresIn: 604800,
+      scopes: ["users:read", "reports:read"],
+      userInfo: {
+        id: "42",
+        username: "Ada Lovelace",
+        email: "ada@example.com",
+      },
+    });
+  });
+
+  it("refreshes with the refresh token and preserves a rotated token", async () => {
+    server.use(
+      http.post(TOKEN_URL, async ({ request }) => {
+        const body = new URLSearchParams(await request.text());
+        expect(body.get("client_id")).toBe("client-id");
+        expect(body.get("client_secret")).toBe("client-secret");
+        expect(body.get("grant_type")).toBe("refresh_token");
+        expect(body.get("refresh_token")).toBe("old-refresh-token");
+        return HttpResponse.json({
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+          expires_in: 604800,
+          scope: "users:read",
+        });
+      }),
+    );
+
+    await expect(
+      refreshResourceGuruToken(
+        "client-id",
+        "client-secret",
+        "old-refresh-token",
+        new AbortController().signal,
+      ),
+    ).resolves.toEqual({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresIn: 604800,
+      scopes: ["users:read"],
+    });
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/resource-guru/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/resource-guru/oauth.ts
@@ -1,0 +1,179 @@
+import { z } from "zod";
+
+import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
+import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
+
+const RESOURCE_GURU_TOKEN_URL = "https://api.resourceguruapp.com/oauth/token";
+
+const RESOURCE_GURU_AUTHORIZATION_URL =
+  "https://api.resourceguruapp.com/oauth/authorize";
+
+const RESOURCE_GURU_USER_URL = "https://api.resourceguruapp.com/v1/me";
+
+interface ResourceGuruUserInfo {
+  readonly id: string;
+  readonly username: string | null;
+  readonly email: string | null;
+}
+
+interface ResourceGuruTokenResult {
+  readonly accessToken: string;
+  readonly refreshToken: string | null;
+  readonly expiresIn?: number;
+  readonly scopes: string[];
+  readonly userInfo: ResourceGuruUserInfo;
+}
+
+interface ResourceGuruRefreshResult {
+  readonly accessToken: string;
+  readonly refreshToken: string | null;
+  readonly expiresIn?: number;
+  readonly scopes: string[] | null;
+}
+
+const tokenResponseSchema = z.object({
+  access_token: z.string().optional(),
+  refresh_token: z.string().nullable().optional(),
+  expires_in: z.number().optional(),
+  scope: z.string().optional(),
+  token_type: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+});
+
+/** Build the Resource Guru OAuth authorization URL. */
+export function buildResourceGuruAuthorizationUrl(
+  authCodeGrant: ConnectorAuthCodeGrantConfig,
+  clientId: string,
+  redirectUri: string,
+  state: string,
+): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: authCodeGrant.scopes.join(" "),
+    state,
+  });
+
+  return `${RESOURCE_GURU_AUTHORIZATION_URL}?${params.toString()}`;
+}
+
+/** Exchange an authorization code and resolve the authenticated user. */
+export async function exchangeResourceGuruCode(
+  authCodeGrant: ConnectorAuthCodeGrantConfig,
+  clientId: string,
+  clientSecret: string,
+  code: string,
+  redirectUri: string,
+): Promise<ResourceGuruTokenResult> {
+  const response = await fetch(RESOURCE_GURU_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      grant_type: "authorization_code",
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  if (!response.ok) {
+    await throwOAuthError("Resource Guru", "exchange", response);
+  }
+
+  const data = tokenResponseSchema.parse(await response.json());
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+  if (!data.access_token) {
+    throw new Error("No access token in Resource Guru response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
+    userInfo: await fetchResourceGuruUserInfo(data.access_token),
+  };
+}
+
+/** Refresh a Resource Guru access token using the rotated refresh token. */
+export async function refreshResourceGuruToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+  signal: AbortSignal,
+): Promise<ResourceGuruRefreshResult> {
+  const response = await fetch(RESOURCE_GURU_TOKEN_URL, {
+    signal,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    await throwOAuthError("Resource Guru", "refresh", response);
+  }
+
+  const data = tokenResponseSchema.parse(await response.json());
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+  if (!data.access_token) {
+    throw new Error("No access token in Resource Guru refresh response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token ?? null,
+    expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
+  };
+}
+
+async function fetchResourceGuruUserInfo(
+  accessToken: string,
+): Promise<ResourceGuruUserInfo> {
+  const response = await fetch(RESOURCE_GURU_USER_URL, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Resource Guru user info fetch failed: ${response.status}`);
+  }
+
+  const data = z
+    .object({
+      id: z.number().int().positive(),
+      first_name: z.string(),
+      last_name: z.string(),
+      email: z.string(),
+    })
+    .parse(await response.json());
+
+  const name = [data.first_name, data.last_name]
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join(" ");
+
+  return {
+    id: String(data.id),
+    username: name || data.email,
+    email: data.email,
+  };
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/resource-guru/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/resource-guru/oauth.ts
@@ -167,7 +167,9 @@ async function fetchResourceGuruUserInfo(
     .parse(await response.json());
 
   const name = [data.first_name, data.last_name]
-    .map((part) => part.trim())
+    .map((part) => {
+      return part.trim();
+    })
     .filter(Boolean)
     .join(" ");
 

--- a/turbo/packages/connectors/src/auth-providers/connectors/resource-guru/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/resource-guru/provider.ts
@@ -1,0 +1,58 @@
+import type { AuthCodeConnectorAuthProvider } from "../../types";
+import { oauthRefreshResultToProviderResult } from "../../oauth/types";
+import {
+  buildResourceGuruAuthorizationUrl,
+  exchangeResourceGuruCode,
+  refreshResourceGuruToken,
+} from "./oauth";
+
+export const resourceGuruProvider: AuthCodeConnectorAuthProvider<"resource-guru"> =
+  {
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args.authClient;
+        return buildResourceGuruAuthorizationUrl(
+          args.authCodeGrant,
+          clientId,
+          args.redirectUri,
+          args.state,
+        );
+      },
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args.authClient;
+        const result = await exchangeResourceGuruCode(
+          args.authCodeGrant,
+          clientId,
+          clientSecret,
+          args.code,
+          args.redirectUri,
+        );
+
+        return {
+          outputs: {
+            accessToken: result.accessToken,
+            refreshToken: result.refreshToken,
+          },
+          expiresIn: result.expiresIn,
+          scopes: result.scopes,
+          userInfo: result.userInfo,
+        };
+      },
+    },
+    access: {
+      kind: "refresh-token",
+      refresh: async (args, signal) => {
+        const { clientId, clientSecret } = args.authClient;
+        return oauthRefreshResultToProviderResult(
+          await refreshResourceGuruToken(
+            clientId,
+            clientSecret,
+            args.inputs.refreshToken,
+            signal,
+          ),
+        );
+      },
+    },
+    revoke: { kind: "none" },
+  };

--- a/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
@@ -1311,6 +1311,33 @@ export const CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS = [
     },
   },
   {
+    connectorSlug: "resource-guru",
+    authMethodId: "oauth",
+    contract: {
+      client: {
+        kind: "static-confidential-env",
+        clientIdEnv: "RESOURCE_GURU_OAUTH_CLIENT_ID",
+        clientSecretEnv: "RESOURCE_GURU_OAUTH_CLIENT_SECRET",
+      },
+      grant: {
+        kind: "auth-code",
+        callbackOrigin: "web",
+        outputNames: ["accessToken", "refreshToken"],
+        startOptionNames: [],
+      },
+      access: {
+        kind: "refresh-token",
+        inputNames: ["refreshToken"],
+        outputNames: ["accessToken", "refreshToken"],
+        platformSecrets: [],
+      },
+      revoke: {
+        kind: "none",
+        inputNames: [],
+      },
+    },
+  },
+  {
     connectorSlug: "outlook-calendar",
     authMethodId: "oauth",
     contract: {


### PR DESCRIPTION
## Summary

- Add the Resource Guru OAuth 2.0 authorization-code provider.
- Register the provider's static confidential client contract and runtime handler.
- Exchange and refresh tokens through Resource Guru's documented form-encoded token endpoint, preserving rotated refresh tokens.
- Resolve the authenticated user through `GET /v1/me`.
- Add focused MSW coverage for authorization URL construction, code exchange, user identity, and refresh.

## Authentication contract

Resource Guru documents confidential OAuth applications at:

- https://resourceguruapp.com/docs/api
- https://resourceguruapp.com/docs/api/openapi.json
- https://app.resourceguruapp.com/developers

The provider uses:

- Authorization URL: `https://api.resourceguruapp.com/oauth/authorize`
- Token URL: `https://api.resourceguruapp.com/oauth/token`
- Form-encoded authorization-code and refresh-token requests
- `RESOURCE_GURU_OAUTH_CLIENT_ID` and `RESOURCE_GURU_OAUTH_CLIENT_SECRET` static confidential client environment variables
- `accessToken` and `refreshToken` outputs, including rotated refresh tokens

Resource Guru documents seven-day access-token expiration and refresh tokens. HTTP Basic authentication is intentionally not implemented because the provider documents it as exploration-only, without an SLA, and subject to disabling without warning.

## Validation

- `pnpm --filter @okouai/connectors check-types`
- `pnpm --filter @okouai/connectors exec vitest run src/auth-providers/connectors/__tests__/resource-guru.test.ts`

The connector catalog change that consumes this provider is submitted separately in the `vm0-ai/vm0-connectors` repository.
