### PR TITLE
feat(platform): add a compact composer model menu

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads-create.test.ts
@@ -933,85 +933,89 @@ describe("POST /api/zero/chat-threads", () => {
     });
   });
 
-  it("inherits priority from the run's chat thread and allows an explicit standard override", async () => {
-    const fixture = await seedAgent();
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.CodexFastMode]: true,
-    });
-    const sourceToken = okouToken({
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-      capabilities: ["chat-thread:read", "chat-thread:write"],
-    });
-    const source = await accept(
-      threadsClient().create({
-        headers: { authorization: `Bearer ${sourceToken}` },
-        body: {
-          agentId: fixture.agentId,
-          title: "Priority source",
-          model: PRIORITY_MODEL,
-          serviceTier: "priority",
-        },
-      }),
-      [201],
-    );
-    expect(source.body.serviceTier).toBe("priority");
-
-    const { runId } = await store.set(
-      seedRun$,
-      {
-        orgId: fixture.orgId,
+  it.each([FeatureSwitchKey.CodexFastMode, FeatureSwitchKey.ModelPickerMenu])(
+    "inherits priority from the run's chat thread and allows an explicit standard override with %s",
+    async (fastSwitch) => {
+      const fixture = await seedAgent();
+      await updateFeatureSwitchesForUser(context, fixture, {
+        [FeatureSwitchKey.CodexFastMode]: false,
+        [fastSwitch]: true,
+      });
+      const sourceToken = okouToken({
         userId: fixture.userId,
-        composeId: fixture.agentId,
-        triggerSource: "web",
-        chatThreadId: source.body.id,
-        selectedModel: PRIORITY_MODEL,
-      },
-      context.signal,
-    );
-    const inheritedToken = okouToken({
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-      capabilities: ["chat-thread:read", "chat-thread:write"],
-      runId,
-    });
+        orgId: fixture.orgId,
+        capabilities: ["chat-thread:read", "chat-thread:write"],
+      });
+      const source = await accept(
+        threadsClient().create({
+          headers: { authorization: `Bearer ${sourceToken}` },
+          body: {
+            agentId: fixture.agentId,
+            title: "Priority source",
+            model: PRIORITY_MODEL,
+            serviceTier: "priority",
+          },
+        }),
+        [201],
+      );
+      expect(source.body.serviceTier).toBe("priority");
 
-    const inherited = await accept(
-      threadsClient().create({
-        headers: { authorization: `Bearer ${inheritedToken}` },
-        body: { agentId: fixture.agentId, title: "Inherited priority" },
-      }),
-      [201],
-    );
-    expect(inherited.body).toMatchObject({
-      selectedModel: PRIORITY_MODEL,
-      serviceTier: "priority",
-    });
-    const inheritedMetadata = await accept(
-      metadataClient().get({
-        headers: { authorization: `Bearer ${inheritedToken}` },
-        params: { id: inherited.body.id },
-      }),
-      [200],
-    );
-    expect(inheritedMetadata.body.serviceTier).toBe("priority");
-
-    const standard = await accept(
-      threadsClient().create({
-        headers: { authorization: `Bearer ${inheritedToken}` },
-        body: {
-          agentId: fixture.agentId,
-          title: "Explicit standard",
-          serviceTier: null,
+      const { runId } = await store.set(
+        seedRun$,
+        {
+          orgId: fixture.orgId,
+          userId: fixture.userId,
+          composeId: fixture.agentId,
+          triggerSource: "web",
+          chatThreadId: source.body.id,
+          selectedModel: PRIORITY_MODEL,
         },
-      }),
-      [201],
-    );
-    expect(standard.body).toMatchObject({
-      selectedModel: PRIORITY_MODEL,
-      serviceTier: null,
-    });
-  });
+        context.signal,
+      );
+      const inheritedToken = okouToken({
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        capabilities: ["chat-thread:read", "chat-thread:write"],
+        runId,
+      });
+
+      const inherited = await accept(
+        threadsClient().create({
+          headers: { authorization: `Bearer ${inheritedToken}` },
+          body: { agentId: fixture.agentId, title: "Inherited priority" },
+        }),
+        [201],
+      );
+      expect(inherited.body).toMatchObject({
+        selectedModel: PRIORITY_MODEL,
+        serviceTier: "priority",
+      });
+      const inheritedMetadata = await accept(
+        metadataClient().get({
+          headers: { authorization: `Bearer ${inheritedToken}` },
+          params: { id: inherited.body.id },
+        }),
+        [200],
+      );
+      expect(inheritedMetadata.body.serviceTier).toBe("priority");
+
+      const standard = await accept(
+        threadsClient().create({
+          headers: { authorization: `Bearer ${inheritedToken}` },
+          body: {
+            agentId: fixture.agentId,
+            title: "Explicit standard",
+            serviceTier: null,
+          },
+        }),
+        [201],
+      );
+      expect(standard.body).toMatchObject({
+        selectedModel: PRIORITY_MODEL,
+        serviceTier: null,
+      });
+    },
+  );
 
   it("rejects an omitted model when the token has no run model to inherit", async () => {
     const fixture = await seedAgent();

--- a/turbo/apps/api/src/signals/routes/__tests__/feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feature-switches.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it } from "vitest";
@@ -16,6 +17,30 @@ function client() {
 }
 
 describe("/api/feature-switches", () => {
+  it("defaults the compact model menu to Bingjie without enabling other staff users", async () => {
+    const clerk = createRouteMocks(context).clerk;
+    const headers = { authorization: "Bearer clerk-session" };
+    clerk.session(
+      "user_3EWY21Oe3f15kfs3yYmbGgDb3NV",
+      `org_${randomUUID()}`,
+      "org:member",
+    );
+    const owner = await accept(client().get({ headers }), [200]);
+    expect(
+      owner.body.effectiveSwitches[FeatureSwitchKey.ModelPickerMenu],
+    ).toBeTruthy();
+
+    clerk.session(
+      `user_${randomUUID()}`,
+      "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      "org:member",
+    );
+    const staff = await accept(client().get({ headers }), [200]);
+    expect(
+      staff.body.effectiveSwitches[FeatureSwitchKey.ModelPickerMenu],
+    ).toBeFalsy();
+  });
+
   it("persists and activates a user override for a non-staff org", async () => {
     createRouteMocks(context).clerk.session(
       "user_nonstaff_feature_switch_test",

--- a/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-policies.test.ts
@@ -1050,66 +1050,70 @@ describe("GET/PUT /api/model-policies", () => {
     });
   });
 
-  it("stores priority with a GPT 5.6 user model preference", async () => {
-    const fixture = await seedFixture();
-    useSession(fixture);
-    const client = apiClient();
-    const preferenceClient = setupApp({
-      context,
-      routes: userModelPreferenceRoutes,
-    })(userModelPreferenceContract);
-    const listResponse = await accept(
-      client.list({ headers: authHeaders() }),
-      [200],
-    );
-    const updates = toUpdate(listResponse.body).map((policy) => {
-      return policy.model === "gpt-5.6-sol"
-        ? {
-            ...policy,
-            defaultProviderType: "built-in" as const,
-            credentialScope: "org" as const,
-            modelProviderId: null,
-          }
-        : policy;
-    });
-    await accept(
-      client.update({
-        headers: authHeaders(),
-        body: { policies: updates },
-      }),
-      [200],
-    );
+  it.each([FeatureSwitchKey.CodexFastMode, FeatureSwitchKey.ModelPickerMenu])(
+    "stores priority with a GPT 5.6 user model preference with %s",
+    async (fastSwitch) => {
+      const fixture = await seedFixture();
+      useSession(fixture);
+      const client = apiClient();
+      const preferenceClient = setupApp({
+        context,
+        routes: userModelPreferenceRoutes,
+      })(userModelPreferenceContract);
+      const listResponse = await accept(
+        client.list({ headers: authHeaders() }),
+        [200],
+      );
+      const updates = toUpdate(listResponse.body).map((policy) => {
+        return policy.model === "gpt-5.6-sol"
+          ? {
+              ...policy,
+              defaultProviderType: "built-in" as const,
+              credentialScope: "org" as const,
+              modelProviderId: null,
+            }
+          : policy;
+      });
+      await accept(
+        client.update({
+          headers: authHeaders(),
+          body: { policies: updates },
+        }),
+        [200],
+      );
 
-    const switchOff = await accept(
-      preferenceClient.update({
-        headers: authHeaders(),
-        body: { selectedModel: "gpt-5.6-sol", serviceTier: "priority" },
-      }),
-      [400],
-    );
-    expect(switchOff.body.error.message).toBe(
-      "Codex fast mode is not enabled for this workspace",
-    );
+      const switchOff = await accept(
+        preferenceClient.update({
+          headers: authHeaders(),
+          body: { selectedModel: "gpt-5.6-sol", serviceTier: "priority" },
+        }),
+        [400],
+      );
+      expect(switchOff.body.error.message).toBe(
+        "Codex fast mode is not enabled for this workspace",
+      );
 
-    await updateFeatureSwitchesForUser(context, fixture, {
-      [FeatureSwitchKey.CodexFastMode]: true,
-    });
-    const priority = await accept(
-      preferenceClient.update({
-        headers: authHeaders(),
-        body: { selectedModel: "gpt-5.6-sol", serviceTier: "priority" },
-      }),
-      [200],
-    );
-    expect(priority.body).toMatchObject({
-      selectedModel: "gpt-5.6-sol",
-      serviceTier: "priority",
-    });
-    expect(
-      (await accept(preferenceClient.get({ headers: authHeaders() }), [200]))
-        .body.serviceTier,
-    ).toBe("priority");
-  });
+      await updateFeatureSwitchesForUser(context, fixture, {
+        [FeatureSwitchKey.CodexFastMode]: false,
+        [fastSwitch]: true,
+      });
+      const priority = await accept(
+        preferenceClient.update({
+          headers: authHeaders(),
+          body: { selectedModel: "gpt-5.6-sol", serviceTier: "priority" },
+        }),
+        [200],
+      );
+      expect(priority.body).toMatchObject({
+        selectedModel: "gpt-5.6-sol",
+        serviceTier: "priority",
+      });
+      expect(
+        (await accept(preferenceClient.get({ headers: authHeaders() }), [200]))
+          .body.serviceTier,
+      ).toBe("priority");
+    },
+  );
 
   it("stores a member video default independent of the run model", async () => {
     const fixture = await seedFixture();

--- a/turbo/apps/api/src/signals/routes/user-model-preference.ts
+++ b/turbo/apps/api/src/signals/routes/user-model-preference.ts
@@ -5,8 +5,7 @@ import {
 } from "@okouai/api-contracts/contracts/model-providers";
 import type { UserPreferenceChangedPayload } from "@okouai/api-contracts/contracts/realtime";
 import { userModelPreferenceContract } from "@okouai/api-contracts/contracts/user-model-preference";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
 
 import { badRequestMessage } from "../../lib/error";
 import { publishUserPreferenceChangedForUserSafely } from "../external/realtime";
@@ -68,9 +67,7 @@ const updateUserModelPreferenceInner$ = command(
         userFeatureSwitchContext(auth.orgId, auth.userId),
       );
       signal.throwIfAborted();
-      if (
-        !isFeatureEnabled(FeatureSwitchKey.CodexFastMode, featureSwitchContext)
-      ) {
+      if (!isCodexFastModeEnabled(featureSwitchContext)) {
         return badRequestMessage(
           "Codex fast mode is not enabled for this workspace",
         );

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -146,6 +146,7 @@ import {
   type FeatureSwitchContext,
 } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
 import { buildGenerationTemplatePrompt } from "../../lib/generation-template-prompt";
 import {
   additionalVolumesForRun,
@@ -1071,10 +1072,7 @@ async function resolveNormalSendFeatureSwitches(
 ): Promise<NormalSendFeatureSwitches> {
   const context = await loadUserFeatureSwitchContext(db, orgId, userId);
   return {
-    codexFastModeEnabled: isFeatureEnabled(
-      FeatureSwitchKey.CodexFastMode,
-      context,
-    ),
+    codexFastModeEnabled: isCodexFastModeEnabled(context),
     presentationTemplatesEnabled: isFeatureEnabled(
       FeatureSwitchKey.PresentationTemplates,
       context,

--- a/turbo/apps/api/src/signals/services/chat-run-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-run-event.service.ts
@@ -1,5 +1,4 @@
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
 
 import { badRequestMessage } from "../../lib/error";
 import type { Db } from "../external/db";
@@ -38,10 +37,7 @@ export async function resolveRunChatThreadModelContext(params: {
     userId: params.userId,
     threadId: params.threadId,
     persistRequestedCodexServiceTier: false,
-    codexFastModeEnabled: isFeatureEnabled(
-      FeatureSwitchKey.CodexFastMode,
-      featureSwitchContext,
-    ),
+    codexFastModeEnabled: isCodexFastModeEnabled(featureSwitchContext),
   });
   if (!resolved) {
     return badRequestMessage("Chat thread not found");

--- a/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/goal-queue-drain.service.ts
@@ -1,7 +1,6 @@
+import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
 import { command } from "ccstate";
 import { isBuiltInModelProviderType } from "@okouai/api-contracts/contracts/model-providers";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { badRequestMessage } from "../../lib/error";
 import { logger } from "../../lib/log";
@@ -266,10 +265,7 @@ async function resolveGoalThreadModelContext(
         userId: args.goal.userId,
         threadId: args.goal.threadId,
         persistRequestedCodexServiceTier: false,
-        codexFastModeEnabled: isFeatureEnabled(
-          FeatureSwitchKey.CodexFastMode,
-          featureSwitchContext,
-        ),
+        codexFastModeEnabled: isCodexFastModeEnabled(featureSwitchContext),
       });
       return resolved ?? badRequestMessage("Chat thread not found");
     },

--- a/turbo/apps/api/src/signals/services/model-selection.service.ts
+++ b/turbo/apps/api/src/signals/services/model-selection.service.ts
@@ -19,8 +19,7 @@ import {
 } from "@okouai/api-contracts/contracts/model-provider-gateways";
 import type { ChatThreadServiceTier } from "@okouai/api-contracts/contracts/chat-threads";
 import type { SupportedFramework } from "@okouai/core/frameworks";
-import { isFeatureEnabled } from "@okouai/core/feature-switch";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
 import { modelProviders } from "@okouai/db/schema/model-provider";
 import {
   modelProviderConnections,
@@ -395,10 +394,7 @@ export async function resolveDefaultModelFirstPin(
           selectedModel: preferredRoute.selectedModel,
           codexFastModeEnabled:
             featureSwitchContext !== null &&
-            isFeatureEnabled(
-              FeatureSwitchKey.CodexFastMode,
-              featureSwitchContext,
-            ),
+            isCodexFastModeEnabled(featureSwitchContext),
         })
           ? "priority"
           : null;
@@ -738,7 +734,7 @@ export async function validateCodexServiceTier(params: {
     params.orgId,
     params.userId,
   );
-  if (!isFeatureEnabled(FeatureSwitchKey.CodexFastMode, featureSwitchContext)) {
+  if (!isCodexFastModeEnabled(featureSwitchContext)) {
     return badRequestMessage(
       "Codex fast mode is not enabled for this workspace",
     );

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -17,6 +17,7 @@ import {
   type FeatureSwitchContext,
 } from "@okouai/core/feature-switch";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
 import { isPiAgentModelSupported } from "@okouai/pi-agent-runtime";
 
 import type { BuiltInModelRuntimeRoute } from "./built-in-model-runtime-route.service";
@@ -182,7 +183,7 @@ export function shouldUsePiExecution(args: {
       args.modelProviderType,
       args.builtInModelRuntimeRoute,
     ) &&
-    isFeatureEnabled(FeatureSwitchKey.CodexFastMode, args.featureSwitchContext);
+    isCodexFastModeEnabled(args.featureSwitchContext);
   const isPiModelProvider =
     isBuiltInModelProviderType(args.modelProviderType) ||
     args.modelProviderType === "custom-openai-responses" ||

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4949,6 +4949,15 @@
         "inheritDefault": "Von der Standardeinstellung der Organisation übernehmen",
         "loadError": "Modelle können nicht geladen werden.",
         "loading": "Modelle werden geladen...",
+        "menu": {
+          "adjustSettings": "Einstellungen für {{model}} anpassen",
+          "backToChatModels": "Zurück zu Chatmodellen",
+          "backToModels": "Zurück zu Modellen",
+          "cancel": "Abbrechen",
+          "changeModel": "{{category}}-Modell ändern, {{model}}",
+          "chatSettings": "Chateinstellungen",
+          "confirm": "Bestätigen"
+        },
         "models": "Modelle",
         "noConfiguredModels": "Keine konfigurierten Modelle",
         "priceTiers": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4941,6 +4941,15 @@
         "inheritDefault": "Inherit from org default",
         "loadError": "Unable to load models.",
         "loading": "Loading models...",
+        "menu": {
+          "adjustSettings": "Adjust {{model}} settings",
+          "backToChatModels": "Back to chat models",
+          "backToModels": "Back to models",
+          "cancel": "Cancel",
+          "changeModel": "Change {{category}} model, {{model}}",
+          "chatSettings": "Chat settings",
+          "confirm": "Confirm"
+        },
         "models": "Models",
         "noConfiguredModels": "No configured models",
         "priceTiers": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5003,6 +5003,15 @@
         "inheritDefault": "Heredar el valor predeterminado de la organización",
         "loadError": "No se pudieron cargar los modelos.",
         "loading": "Cargando modelos...",
+        "menu": {
+          "adjustSettings": "Ajustar la configuración de {{model}}",
+          "backToChatModels": "Volver a los modelos de chat",
+          "backToModels": "Volver a los modelos",
+          "cancel": "Cancelar",
+          "changeModel": "Cambiar modelo de {{category}}, {{model}}",
+          "chatSettings": "Configuración del chat",
+          "confirm": "Confirmar"
+        },
         "models": "Modelos",
         "noConfiguredModels": "Sin modelos configurados",
         "priceTiers": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5003,6 +5003,15 @@
         "inheritDefault": "Hériter des paramètres par défaut de l'organisation",
         "loadError": "Impossible de charger les modèles.",
         "loading": "Chargement des modèles...",
+        "menu": {
+          "adjustSettings": "Ajuster les paramètres de {{model}}",
+          "backToChatModels": "Retour aux modèles de chat",
+          "backToModels": "Retour aux modèles",
+          "cancel": "Annuler",
+          "changeModel": "Changer le modèle {{category}}, {{model}}",
+          "chatSettings": "Paramètres du chat",
+          "confirm": "Confirmer"
+        },
         "models": "Modèles",
         "noConfiguredModels": "Aucun modèle configuré",
         "priceTiers": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4949,6 +4949,15 @@
         "inheritDefault": "ऑर्ग डिफॉल्ट से इनहेरिट करें",
         "loadError": "मॉडल लोड करने में असमर्थ.",
         "loading": "मॉडल लोड हो रहे हैं...",
+        "menu": {
+          "adjustSettings": "{{model}} की सेटिंग समायोजित करें",
+          "backToChatModels": "चैट मॉडल पर वापस जाएँ",
+          "backToModels": "मॉडल पर वापस जाएँ",
+          "cancel": "रद्द करें",
+          "changeModel": "{{category}} मॉडल बदलें, {{model}}",
+          "chatSettings": "चैट सेटिंग",
+          "confirm": "पुष्टि करें"
+        },
         "models": "मॉडल",
         "noConfiguredModels": "कोई कॉन्फ़िगर मॉडल नहीं",
         "priceTiers": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4941,6 +4941,15 @@
         "inheritDefault": "Warisi dari default organisasi",
         "loadError": "Tidak dapat memuat model.",
         "loading": "Memuat model...",
+        "menu": {
+          "adjustSettings": "Sesuaikan pengaturan {{model}}",
+          "backToChatModels": "Kembali ke model chat",
+          "backToModels": "Kembali ke model",
+          "cancel": "Batal",
+          "changeModel": "Ubah model {{category}}, {{model}}",
+          "chatSettings": "Pengaturan chat",
+          "confirm": "Konfirmasi"
+        },
         "models": "Model",
         "noConfiguredModels": "Tidak ada model yang dikonfigurasi",
         "priceTiers": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5003,6 +5003,15 @@
         "inheritDefault": "Eredita dall'impostazione predefinita dell'organizzazione",
         "loadError": "Impossibile caricare i modelli.",
         "loading": "Caricamento modelli...",
+        "menu": {
+          "adjustSettings": "Modifica le impostazioni di {{model}}",
+          "backToChatModels": "Torna ai modelli di chat",
+          "backToModels": "Torna ai modelli",
+          "cancel": "Annulla",
+          "changeModel": "Cambia modello di {{category}}, {{model}}",
+          "chatSettings": "Impostazioni della chat",
+          "confirm": "Conferma"
+        },
         "models": "Modelli",
         "noConfiguredModels": "Nessun modello configurato",
         "priceTiers": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4941,6 +4941,15 @@
         "inheritDefault": "組織のデフォルトから継承",
         "loadError": "モデルをロードできません。",
         "loading": "モデルをロード中...",
+        "menu": {
+          "adjustSettings": "{{model}} の設定を調整",
+          "backToChatModels": "チャットモデルに戻る",
+          "backToModels": "モデルに戻る",
+          "cancel": "キャンセル",
+          "changeModel": "{{category}}モデルを変更、{{model}}",
+          "chatSettings": "チャット設定",
+          "confirm": "確認"
+        },
         "models": "モデル",
         "noConfiguredModels": "設定されたモデルはありません",
         "priceTiers": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4941,6 +4941,15 @@
         "inheritDefault": "조직 기본값 상속",
         "loadError": "모델을 불러올 수 없습니다.",
         "loading": "모델 불러오는 중...",
+        "menu": {
+          "adjustSettings": "{{model}} 설정 조정",
+          "backToChatModels": "채팅 모델로 돌아가기",
+          "backToModels": "모델로 돌아가기",
+          "cancel": "취소",
+          "changeModel": "{{category}} 모델 변경, {{model}}",
+          "chatSettings": "채팅 설정",
+          "confirm": "확인"
+        },
         "models": "모델",
         "noConfiguredModels": "구성된 모델 없음",
         "priceTiers": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5003,6 +5003,15 @@
         "inheritDefault": "Herdar o padrão da organização",
         "loadError": "Não foi possível carregar os modelos.",
         "loading": "Carregando modelos...",
+        "menu": {
+          "adjustSettings": "Ajustar configurações de {{model}}",
+          "backToChatModels": "Voltar aos modelos de chat",
+          "backToModels": "Voltar aos modelos",
+          "cancel": "Cancelar",
+          "changeModel": "Alterar modelo de {{category}}, {{model}}",
+          "chatSettings": "Configurações de chat",
+          "confirm": "Confirmar"
+        },
         "models": "Modelos",
         "noConfiguredModels": "Nenhum modelo configurado",
         "priceTiers": {

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -113,6 +113,10 @@ export const composerImageAnnotationEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ComposerImageAnnotation] ?? false;
 });
 
+export const modelPickerMenuEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.ModelPickerMenu] ?? false;
+});
+
 export const codexFastModeEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
 });

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -6,6 +6,7 @@ import {
 } from "@okouai/core/feature-switch";
 import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
 import { clerk$ } from "../auth";
 import { appVersion$ } from "../app-version.ts";
 import { accept } from "../../lib/accept.ts";
@@ -118,7 +119,7 @@ export const modelPickerMenuEnabled$ = computed((get): boolean => {
 });
 
 export const codexFastModeEnabled$ = computed((get): boolean => {
-  return get(featureSwitch$)[FeatureSwitchKey.CodexFastMode] ?? false;
+  return isCodexFastModeEnabled({ overrides: get(featureSwitch$) });
 });
 
 export const chatRunWorkFoldingEnabled$ = computed((get): boolean => {

--- a/turbo/apps/platform/src/signals/okou-page/chat-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/chat-composer.ts
@@ -15,6 +15,7 @@ import {
 import { readableAttachmentResourceUrl } from "../../views/okou-page/attachment-url.ts";
 import { createAvatarTemplatePickerSignals } from "./avatar-template-picker.ts";
 import { createImportedPresentationTemplateSignals } from "./presentation-template-library.ts";
+import { createModelPickerMenuSignals } from "./model-picker-menu.ts";
 import type { VideoRunOptionsPatch } from "./video-run-options.ts";
 
 // ---------------------------------------------------------------------------
@@ -324,6 +325,7 @@ function createBasicComposerUiSignals() {
   const { desktopModelPickerLayout$, desktopModelPickerLifecycleRef$ } =
     createDesktopModelPickerLayoutSignals();
   const internalModelPickerOpen$ = state(false);
+  const menu = createModelPickerMenuSignals();
   // Every viewport drives this from the same category strip. Null means the
   // chat models. It survives close the way the old composer track kept its
   // expanded category -- the video options chip and the temporary-model notice
@@ -334,6 +336,9 @@ function createBasicComposerUiSignals() {
   });
   const setModelPickerOpen$ = command(({ set }, open: boolean) => {
     set(internalModelPickerOpen$, open);
+    if (!open) {
+      set(menu.reset$);
+    }
   });
   const mediaModelCategory$ = computed((get) => {
     return get(internalMediaModelCategory$);
@@ -345,6 +350,7 @@ function createBasicComposerUiSignals() {
   );
   return {
     model: {
+      menu,
       modelPickerOpen$,
       setModelPickerOpen$,
       mediaModelCategory$,

--- a/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
+++ b/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
@@ -1,0 +1,78 @@
+import { command, computed, state } from "ccstate";
+import { onRef } from "../utils.ts";
+import type { ModelProviderSelection } from "../../views/okou-page/components/model-provider-picker.tsx";
+
+type ModelPickerCategory = "chat" | "image" | "video";
+
+type ModelPickerMenuPage =
+  | { readonly kind: "overview" }
+  | { readonly kind: "models"; readonly category: ModelPickerCategory }
+  | {
+      readonly kind: "settings";
+      readonly selection: ModelProviderSelection;
+      readonly from: "overview" | "models";
+    };
+
+/** One navigation and unconfirmed draft per composer, including split chats. */
+export function createModelPickerMenuSignals() {
+  const internalPage$ = state<ModelPickerMenuPage>({ kind: "overview" });
+  const page$ = computed((get) => {
+    return get(internalPage$);
+  });
+  const reset$ = command(({ set }) => {
+    set(internalPage$, { kind: "overview" });
+  });
+  const showModels$ = command(({ set }, category: ModelPickerCategory) => {
+    set(internalPage$, { kind: "models", category });
+  });
+  const editSettings$ = command(
+    (
+      { set },
+      selection: ModelProviderSelection,
+      from: "overview" | "models",
+    ) => {
+      set(internalPage$, { kind: "settings", selection, from });
+    },
+  );
+  const setFast$ = command(({ get, set }, fast: boolean) => {
+    const page = get(internalPage$);
+    if (page.kind === "settings") {
+      set(internalPage$, {
+        ...page,
+        selection: {
+          selectedModel: page.selection.selectedModel,
+          ...(fast ? { codexServiceTier: "fast" } : {}),
+        },
+      });
+    }
+  });
+  const back$ = command(({ get, set }) => {
+    const page = get(internalPage$);
+    set(
+      internalPage$,
+      page.kind === "settings" && page.from === "models"
+        ? { kind: "models", category: "chat" }
+        : { kind: "overview" },
+    );
+  });
+  const focusPanelRef$ = onRef(
+    command((_context, element: HTMLElement, _signal: AbortSignal) => {
+      element
+        .querySelector<HTMLButtonElement>("button:not(:disabled)")
+        ?.focus();
+    }),
+  );
+  return {
+    page$,
+    reset$,
+    showModels$,
+    editSettings$,
+    setFast$,
+    back$,
+    focusPanelRef$,
+  };
+}
+
+export type ModelPickerMenuSignals = ReturnType<
+  typeof createModelPickerMenuSignals
+>;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-media-models.test.tsx
@@ -829,3 +829,81 @@ test("Choose a video model for the current thread", async () => {
     "dreamina-seedance-2-0-260128",
   ]);
 });
+
+test.each(["desktop", "mobile"])(
+  "Choose image and video models from the compact overview on %s",
+  async (viewport) => {
+    if (viewport === "desktop") {
+      setDesktopViewport();
+    } else {
+      setMobileViewport();
+    }
+    installModelEnvironment();
+    mockThread({
+      selectedModel: DEFAULT_RUN_MODEL,
+      selectedImageModel: null,
+      selectedVideoModel: null,
+    });
+    const images: (ImageModel | null)[] = [];
+    const videos: (VideoModel | null)[] = [];
+    context.mocks.api(
+      chatThreadImageModelContract.update,
+      ({ body, respond }) => {
+        images.push(body.model);
+        return respond(204);
+      },
+    );
+    context.mocks.api(
+      chatThreadVideoModelContract.update,
+      ({ body, respond }) => {
+        videos.push(body.model);
+        return respond(204);
+      },
+    );
+    await setupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ModelPickerMenu]: true },
+    });
+    await findComposerEditor();
+    await waitFor(() => {
+      expect(mediaModelRow("Claude Fable 5.1")).toBeVisible();
+    });
+    click(mediaModelRow("Claude Fable 5.1"));
+    await screen.findByRole("region", { name: "Models" });
+    click(mediaModelRow("Change Image model, Nano Banana 2"));
+    await screen.findByRole("region", { name: "Image models" });
+    expectSelected("Nano Banana 2");
+    click(mediaModelRow("GPT Image 1"));
+    await waitFor(() => {
+      expect(images).toStrictEqual(["gpt-image-1"]);
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("region", { name: "Image models" }),
+      ).not.toBeInTheDocument();
+    });
+    click(mediaModelRow("Claude Fable 5.1"));
+    await screen.findByRole("region", { name: "Models" });
+    expect(mediaModelRow("Change Image model, GPT Image 1")).toBeVisible();
+    click(
+      mediaModelRow(
+        `Change Video model, ${VIDEO_MODEL_CONFIGS[DEFAULT_VIDEO_MODEL].label}`,
+      ),
+    );
+    await screen.findByRole("region", { name: "Video models" });
+    click(mediaModelRow("Seedance 2.0"));
+    await waitFor(() => {
+      expect(videos).toStrictEqual(["dreamina-seedance-2-0-260128"]);
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("region", { name: "Video models" }),
+      ).not.toBeInTheDocument();
+    });
+    click(mediaModelRow("Claude Fable 5.1"));
+    await screen.findByRole("region", { name: "Models" });
+    expect(mediaModelRow("Change Video model, Seedance 2.0")).toBeVisible();
+    expect(mediaModelRow("Change Chat model, Claude Fable 5.1")).toBeVisible();
+  },
+);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
@@ -522,3 +522,160 @@ test("Let an existing thread send while model availability is reconciling", asyn
   ).resolves.toBeVisible();
   expect(sentPrompts).toHaveLength(1);
 });
+
+test("Confirm a chat model and Fast together from the compact menu", async () => {
+  installNewChat(["gpt-5.6-sol", "gpt-5.6-luna"], "gpt-5.6-sol");
+  await setupPage({
+    context,
+    path: NEW_CHAT_PATH,
+    featureSwitches: {
+      [FeatureSwitchKey.ModelPickerMenu]: true,
+      [FeatureSwitchKey.CodexFastMode]: true,
+      [FeatureSwitchKey.NewChatDefaultModelAction]: true,
+    },
+  });
+  await readyComposer();
+  click(await findButton("GPT 5.6 Sol"));
+  const overview = await screen.findByRole("region", { name: "Models" });
+  click(buttonNamed("Change Chat model, GPT 5.6 Sol", overview));
+  const list = await screen.findByRole("region", { name: "Chat models" });
+  click(buttonNamed("GPT 5.6 Luna", list));
+  const settings = await screen.findByRole("region", { name: "Chat settings" });
+  await expect(findButton("GPT 5.6 Sol")).resolves.toBeVisible();
+  click(screen.getByRole("switch", { name: "Fast" }));
+  click(buttonNamed("Confirm", settings));
+  await expect(findButton("GPT 5.6 Luna Fast")).resolves.toBeVisible();
+  const updated = screen.getByRole("region", { name: "Models" });
+  expect(
+    buttonNamed("Change Chat model, GPT 5.6 Luna", updated),
+  ).toHaveTextContent("Fast");
+  click(buttonNamed("Adjust GPT 5.6 Luna settings", updated));
+  await screen.findByRole("region", { name: "Chat settings" });
+  expect(screen.getByRole("switch", { name: "Fast" })).toBeChecked();
+});
+
+test("Discard unconfirmed Fast changes and return along the menu path", async () => {
+  const user = userEvent.setup({ delay: null });
+  installNewChat(["gpt-5.6-sol", "gpt-5.6-luna"], "gpt-5.6-sol");
+  await setupPage({
+    context,
+    path: NEW_CHAT_PATH,
+    featureSwitches: {
+      [FeatureSwitchKey.ModelPickerMenu]: true,
+      [FeatureSwitchKey.CodexFastMode]: true,
+    },
+  });
+  await readyComposer();
+  click(await findButton("GPT 5.6 Sol"));
+  let overview = await screen.findByRole("region", { name: "Models" });
+  click(buttonNamed("Adjust GPT 5.6 Sol settings", overview));
+  await screen.findByRole("region", { name: "Chat settings" });
+  click(screen.getByRole("switch", { name: "Fast" }));
+  await user.keyboard("{Escape}");
+  overview = await screen.findByRole("region", { name: "Models" });
+  click(buttonNamed("Adjust GPT 5.6 Sol settings", overview));
+  await screen.findByRole("region", { name: "Chat settings" });
+  expect(screen.getByRole("switch", { name: "Fast" })).not.toBeChecked();
+  click(
+    buttonNamed(
+      "Cancel",
+      screen.getByRole("region", { name: "Chat settings" }),
+    ),
+  );
+  overview = await screen.findByRole("region", { name: "Models" });
+  click(buttonNamed("Change Chat model, GPT 5.6 Sol", overview));
+  const list = await screen.findByRole("region", { name: "Chat models" });
+  click(buttonNamed("GPT 5.6 Luna", list));
+  await screen.findByRole("region", { name: "Chat settings" });
+  await user.keyboard("{Escape}");
+  await screen.findByRole("region", { name: "Chat models" });
+  await user.keyboard("{Escape}");
+  await screen.findByRole("region", { name: "Models" });
+  await user.keyboard("{Escape}");
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("region", { name: "Models" }),
+    ).not.toBeInTheDocument();
+  });
+  click(await findButton("GPT 5.6 Sol"));
+  await screen.findByRole("region", { name: "Models" });
+});
+
+test("Keep unavailable routes disabled and open plan comparison from the compact menu", async () => {
+  installNewChat(
+    ["deepseek-v4-flash", "claude-fable-5-1", "gpt-5.6-sol"],
+    "deepseek-v4-flash",
+  );
+  context.mocks.data.orgModelPolicies([
+    modelPolicy("deepseek-v4-flash", 1, { default: true }),
+    modelPolicy("claude-fable-5-1", 2),
+    {
+      ...modelPolicy("gpt-5.6-sol", 3),
+      routeStatus: "missing_provider",
+      routeStatusReason: "No provider available",
+    },
+  ]);
+  context.mocks.api(billingStatusContract.get, ({ respond }) => {
+    return respond(200, limitedFreeBillingStatus());
+  });
+  await setupPage({
+    context,
+    path: NEW_CHAT_PATH,
+    featureSwitches: { [FeatureSwitchKey.ModelPickerMenu]: true },
+  });
+  await readyComposer();
+  click(await findButton("DeepSeek V4 Flash"));
+  const overview = await screen.findByRole("region", { name: "Models" });
+  click(buttonNamed("Change Chat model, DeepSeek V4 Flash", overview));
+  const list = await screen.findByRole("region", { name: "Chat models" });
+  expect(buttonNamed("GPT 5.6 Sol", list)).toBeDisabled();
+  expect(buttonNamed("Claude Fable 5.1", list)).toHaveTextContent("Pro");
+  click(buttonNamed("Claude Fable 5.1", list));
+  const dialog = await screen.findByRole("dialog", { name: "Choose a plan" });
+  click(buttonNamed("Close", dialog));
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("dialog", { name: "Choose a plan" }),
+    ).not.toBeInTheDocument();
+  });
+  await expect(findButton("DeepSeek V4 Flash")).resolves.toBeVisible();
+});
+
+test("Navigate the compact menu by keyboard and discard a dismissed draft", async () => {
+  const user = userEvent.setup({ delay: null });
+  context.mocks.browser.matchMedia((query) => {
+    return query === "(min-width: 640px)";
+  });
+  installNewChat(["gpt-5.6-sol"], "gpt-5.6-sol");
+  await setupPage({
+    context,
+    path: NEW_CHAT_PATH,
+    featureSwitches: {
+      [FeatureSwitchKey.ModelPickerMenu]: true,
+      [FeatureSwitchKey.CodexFastMode]: true,
+    },
+  });
+  const composer = await readyComposer();
+  click(await findButton("GPT 5.6 Sol"));
+  const overview = await screen.findByRole("region", { name: "Models" });
+  const settingsButton = buttonNamed("Adjust GPT 5.6 Sol settings", overview);
+  await user.keyboard("{ArrowDown}");
+  expect(settingsButton).toHaveFocus();
+  await user.keyboard("{Enter}");
+  await screen.findByRole("region", { name: "Chat settings" });
+  await user.keyboard("{ArrowDown}");
+  expect(screen.getByRole("switch", { name: "Fast" })).toHaveFocus();
+  await user.keyboard(" ");
+  expect(screen.getByRole("switch", { name: "Fast" })).toBeChecked();
+  await user.click(composer);
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("region", { name: "Chat settings" }),
+    ).not.toBeInTheDocument();
+  });
+  click(await findButton("GPT 5.6 Sol"));
+  const reopened = await screen.findByRole("region", { name: "Models" });
+  click(buttonNamed("Adjust GPT 5.6 Sol settings", reopened));
+  await screen.findByRole("region", { name: "Chat settings" });
+  expect(screen.getByRole("switch", { name: "Fast" })).not.toBeChecked();
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
@@ -523,14 +523,14 @@ test("Let an existing thread send while model availability is reconciling", asyn
   expect(sentPrompts).toHaveLength(1);
 });
 
-test("Confirm a chat model and Fast together from the compact menu", async () => {
+test("Confirm a chat model and Fast with only the compact menu switch", async () => {
   installNewChat(["gpt-5.6-sol", "gpt-5.6-luna"], "gpt-5.6-sol");
   await setupPage({
     context,
     path: NEW_CHAT_PATH,
     featureSwitches: {
       [FeatureSwitchKey.ModelPickerMenu]: true,
-      [FeatureSwitchKey.CodexFastMode]: true,
+      [FeatureSwitchKey.CodexFastMode]: false,
       [FeatureSwitchKey.NewChatDefaultModelAction]: true,
     },
   });
@@ -562,7 +562,7 @@ test("Discard unconfirmed Fast changes and return along the menu path", async ()
     path: NEW_CHAT_PATH,
     featureSwitches: {
       [FeatureSwitchKey.ModelPickerMenu]: true,
-      [FeatureSwitchKey.CodexFastMode]: true,
+      [FeatureSwitchKey.CodexFastMode]: false,
     },
   });
   await readyComposer();
@@ -652,7 +652,7 @@ test("Navigate the compact menu by keyboard and discard a dismissed draft", asyn
     path: NEW_CHAT_PATH,
     featureSwitches: {
       [FeatureSwitchKey.ModelPickerMenu]: true,
-      [FeatureSwitchKey.CodexFastMode]: true,
+      [FeatureSwitchKey.CodexFastMode]: false,
     },
   });
   const composer = await readyComposer();

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -229,6 +229,7 @@ import {
 import {
   chatRunWorkFoldingEnabled$,
   codexFastModeEnabled$,
+  modelPickerMenuEnabled$,
   customConnectorMcpEnabled$,
   voiceInputV2Enabled$,
 } from "../../signals/external/feature-switch.ts";
@@ -9264,6 +9265,7 @@ function ComposerRunModelPickerControl({
   mediaModelPanel: MediaModelPanelState | undefined;
 }) {
   const { t } = useTranslation();
+  const modelMenuEnabled = useGet(modelPickerMenuEnabled$);
   const modelPickerOpen = useGet(signals.model.modelPickerOpen$);
   const setModelPickerOpen = useSet(signals.model.setModelPickerOpen$);
   const setLifecycleRef = useSet(signals.model.desktopModelPickerLifecycleRef$);
@@ -9276,6 +9278,7 @@ function ComposerRunModelPickerControl({
           return $.chat.composer.selectModel;
         })}
         triggerClassName={composerModelPickerTriggerClassName()}
+        menuSignals={modelMenuEnabled ? signals.model.menu : undefined}
         compactTrigger
         mobileIconTrigger
         open={modelPickerOpen}

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -1,0 +1,535 @@
+import type { KeyboardEvent, ReactNode } from "react";
+import { useGet, useSet } from "ccstate-react";
+import {
+  ArrowLeft,
+  Check,
+  ChevronRight,
+  Cpu,
+  SlidersHorizontal,
+} from "lucide-react";
+import { Button, Switch, cn } from "@okouai/ui";
+import {
+  getCanonicalModelDisplayName,
+  type SupportedRunModel,
+} from "@okouai/api-contracts/contracts/model-providers";
+import { useTranslation } from "react-i18next";
+import type { ModelPickerMenuSignals } from "../../../signals/okou-page/model-picker-menu.ts";
+import { PriceTierBadge } from "./model-picker-price-tier.tsx";
+import {
+  getMediaModelPriceTierLabel,
+  getModelBrandIconType,
+} from "./settings/provider-ui-config.ts";
+import { ProviderIcon } from "./settings/provider-icons.tsx";
+import type {
+  MediaModelPanelState,
+  ModelProviderSelection,
+} from "./model-provider-picker.tsx";
+
+interface ModelPickerMenuOption {
+  readonly model: SupportedRunModel;
+  readonly label: string;
+  readonly content: ReactNode;
+  readonly disabled: boolean;
+  readonly fastAvailable: boolean;
+}
+
+function MenuHeader({
+  label,
+  onBack,
+  backLabel,
+}: {
+  label: string;
+  onBack?: () => void;
+  backLabel?: string;
+}) {
+  return (
+    <div className="sticky top-0 z-10 flex h-7 items-center gap-1 bg-card px-2 text-xs text-muted-foreground">
+      {onBack && (
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="-ml-1 h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+          aria-label={backLabel}
+          onClick={onBack}
+        >
+          <ArrowLeft size={14} aria-hidden="true" />
+        </Button>
+      )}
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function CurrentModelRow({
+  model,
+  category,
+  icon,
+  summary,
+  onChange,
+  onSettings,
+}: {
+  model: string;
+  category: string;
+  icon: ReactNode;
+  summary?: string;
+  onChange: () => void;
+  onSettings?: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="relative h-12 rounded-lg">
+      <Button
+        variant="ghost"
+        className={cn(
+          "h-full w-full justify-start gap-2 px-2 pr-7 text-left font-normal text-foreground",
+          onSettings && "pr-16",
+        )}
+        aria-label={t(
+          ($) => {
+            return $.settings.models.picker.menu.changeModel;
+          },
+          { category, model },
+        )}
+        onClick={onChange}
+      >
+        <span className="flex w-5 shrink-0 items-center justify-center">
+          {icon}
+        </span>
+        <span className="flex min-w-0 flex-1 flex-col gap-px">
+          <span className="truncate text-[13px] leading-[19px]">{model}</span>
+          <span className="truncate text-[11px] leading-[14px] text-muted-foreground">
+            {category}
+            {summary && <> · {summary}</>}
+          </span>
+        </span>
+        <ChevronRight
+          size={13}
+          aria-hidden="true"
+          className="absolute right-2 text-muted-foreground"
+        />
+      </Button>
+      {onSettings && (
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="absolute right-7 top-1/2 h-7 w-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          aria-label={t(
+            ($) => {
+              return $.settings.models.picker.menu.adjustSettings;
+            },
+            { model },
+          )}
+          onClick={onSettings}
+        >
+          <SlidersHorizontal size={15} aria-hidden="true" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/** Keep arrow navigation in the same order as the menu's tabbable controls. */
+function moveMenuFocus(event: KeyboardEvent<HTMLDivElement>): void {
+  if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+    return;
+  }
+  const controls = Array.from(
+    event.currentTarget.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), [role="switch"]:not([data-disabled])',
+    ),
+  );
+  const current = controls.findIndex((button) => {
+    return button === event.target;
+  });
+  if (controls.length === 0 || current === -1) {
+    return;
+  }
+  event.preventDefault();
+  const next =
+    event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? controls.length - 1
+        : (current + (event.key === "ArrowDown" ? 1 : -1) + controls.length) %
+          controls.length;
+  controls[next]?.focus();
+}
+
+interface ModelPickerMenuContentProps {
+  signals: ModelPickerMenuSignals;
+  value: ModelProviderSelection | null;
+  placeholder: string;
+  options: readonly ModelPickerMenuOption[];
+  mediaModelPanel: MediaModelPanelState | undefined;
+  onChange: (selection: ModelProviderSelection) => void;
+}
+
+function ModelPickerOverview({
+  signals,
+  value,
+  placeholder,
+  options,
+  mediaModelPanel,
+}: Omit<ModelPickerMenuContentProps, "onChange">) {
+  const { t } = useTranslation();
+  const showModels = useSet(signals.showModels$);
+  const editSettings = useSet(signals.editSettings$);
+  const selectedOption = options.find((option) => {
+    return option.model === value?.selectedModel;
+  });
+  const chatLabel =
+    selectedOption?.label ??
+    (value ? getCanonicalModelDisplayName(value.selectedModel) : placeholder);
+  const chatIconType = value
+    ? getModelBrandIconType(value.selectedModel)
+    : undefined;
+  const speedLabel =
+    value?.codexServiceTier === "fast"
+      ? t(($) => {
+          return $.settings.models.picker.fast;
+        })
+      : t(($) => {
+          return $.settings.models.picker.standard;
+        });
+  return (
+    <>
+      <MenuHeader
+        label={t(($) => {
+          return $.settings.models.picker.models;
+        })}
+      />
+      <div className="flex flex-col gap-0.5">
+        <CurrentModelRow
+          model={chatLabel}
+          category={t(($) => {
+            return $.settings.models.picker.categoryChat;
+          })}
+          icon={
+            chatIconType ? (
+              <ProviderIcon type={chatIconType} size={17} />
+            ) : (
+              <Cpu size={17} />
+            )
+          }
+          summary={selectedOption?.fastAvailable ? speedLabel : undefined}
+          onChange={() => {
+            mediaModelPanel?.onActiveCategoryChange(null);
+            showModels("chat");
+          }}
+          onSettings={
+            selectedOption?.fastAvailable && value
+              ? () => {
+                  mediaModelPanel?.onActiveCategoryChange(null);
+                  editSettings(value, "overview");
+                }
+              : undefined
+          }
+        />
+        {mediaModelPanel?.categories.map((category) => {
+          const selected = category.options.find((option) => {
+            return option.selected;
+          });
+          return (
+            <CurrentModelRow
+              key={category.id}
+              model={selected?.label ?? category.label}
+              category={category.tabLabel}
+              icon={selected?.icon}
+              onChange={() => {
+                mediaModelPanel.onActiveCategoryChange(category.id);
+                showModels(category.id);
+              }}
+            />
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+function ChatModelSettings({
+  signals,
+  options,
+  selection,
+  from,
+  onChange,
+}: Pick<ModelPickerMenuContentProps, "signals" | "options" | "onChange"> & {
+  selection: ModelProviderSelection;
+  from: "overview" | "models";
+}) {
+  const { t } = useTranslation();
+  const reset = useSet(signals.reset$);
+  const back = useSet(signals.back$);
+  const setFast = useSet(signals.setFast$);
+  const option = options.find((candidate) => {
+    return candidate.model === selection.selectedModel;
+  });
+  return (
+    <>
+      <MenuHeader
+        label={t(($) => {
+          return $.settings.models.picker.menu.chatSettings;
+        })}
+        onBack={back}
+        backLabel={
+          from === "models"
+            ? t(($) => {
+                return $.settings.models.picker.menu.backToChatModels;
+              })
+            : t(($) => {
+                return $.settings.models.picker.menu.backToModels;
+              })
+        }
+      />
+      <div className="border-b border-border/60 px-2 py-2.5 text-sm">
+        {option?.content ??
+          getCanonicalModelDisplayName(selection.selectedModel)}
+      </div>
+      <div className="flex items-center justify-between gap-3 px-2 py-4">
+        <div>
+          <span className="text-[13px]">
+            {t(($) => {
+              return $.settings.models.picker.fast;
+            })}
+          </span>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            {t(($) => {
+              return $.settings.models.picker.fastImpact;
+            })}
+          </p>
+        </div>
+        <Switch
+          size="compact"
+          aria-label={t(($) => {
+            return $.settings.models.picker.fast;
+          })}
+          checked={selection.codexServiceTier === "fast"}
+          onCheckedChange={setFast}
+          disabled={!option?.fastAvailable}
+        />
+      </div>
+      <div className="flex items-center justify-between border-t border-border/60 px-2 pb-1.5 pt-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-foreground"
+          onClick={reset}
+        >
+          {t(($) => {
+            return $.settings.models.picker.menu.cancel;
+          })}
+        </Button>
+        <Button
+          size="sm"
+          disabled={!option?.fastAvailable || option.disabled}
+          onClick={() => {
+            onChange(selection);
+            reset();
+          }}
+        >
+          {t(($) => {
+            return $.settings.models.picker.menu.confirm;
+          })}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function ChatModelList({
+  signals,
+  options,
+  value,
+  onChange,
+}: Pick<
+  ModelPickerMenuContentProps,
+  "signals" | "options" | "value" | "onChange"
+>) {
+  const { t } = useTranslation();
+  const back = useSet(signals.back$);
+  const reset = useSet(signals.reset$);
+  const editSettings = useSet(signals.editSettings$);
+  const chooseChat = (option: ModelPickerMenuOption) => {
+    if (option.fastAvailable) {
+      editSettings(
+        value?.selectedModel === option.model
+          ? value
+          : { selectedModel: option.model },
+        "models",
+      );
+    } else {
+      onChange({ selectedModel: option.model });
+      reset();
+    }
+  };
+  return (
+    <>
+      <MenuHeader
+        label={t(($) => {
+          return $.settings.models.picker.chatModels;
+        })}
+        onBack={back}
+        backLabel={t(($) => {
+          return $.settings.models.picker.menu.backToModels;
+        })}
+      />
+      <div className="flex max-h-[284px] flex-col gap-0.5 overflow-y-auto overscroll-contain py-1">
+        {options.length === 0 && (
+          <p className="px-2 py-2 text-sm text-muted-foreground">
+            {t(($) => {
+              return $.settings.models.picker.noConfiguredModels;
+            })}
+          </p>
+        )}
+        {options.map((option) => {
+          return (
+            <Button
+              key={option.model}
+              variant="ghost"
+              className="relative h-9 w-full justify-start px-2 pr-8 text-left font-normal text-foreground"
+              aria-label={option.label}
+              aria-pressed={value?.selectedModel === option.model}
+              disabled={option.disabled}
+              onClick={() => {
+                chooseChat(option);
+              }}
+            >
+              {option.content}
+              {value?.selectedModel === option.model && (
+                <Check
+                  size={15}
+                  aria-hidden="true"
+                  className="absolute right-2"
+                />
+              )}
+            </Button>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+function MediaModelList({
+  signals,
+  mediaModelPanel,
+  categoryId,
+}: Pick<ModelPickerMenuContentProps, "signals" | "mediaModelPanel"> & {
+  categoryId: "image" | "video";
+}) {
+  const { t } = useTranslation();
+  const back = useSet(signals.back$);
+  const reset = useSet(signals.reset$);
+  const category = mediaModelPanel?.categories.find((candidate) => {
+    return candidate.id === categoryId;
+  });
+  return (
+    <>
+      <MenuHeader
+        label={
+          category?.label ??
+          t(($) => {
+            return $.settings.models.picker.models;
+          })
+        }
+        onBack={back}
+        backLabel={t(($) => {
+          return $.settings.models.picker.menu.backToModels;
+        })}
+      />
+      <div className="flex max-h-[284px] flex-col gap-0.5 overflow-y-auto overscroll-contain py-1">
+        {category?.options.map((option) => {
+          return (
+            <Button
+              key={option.key}
+              variant="ghost"
+              className="relative h-9 w-full justify-start gap-2 px-2 pr-8 text-left font-normal text-foreground"
+              aria-label={option.label}
+              aria-pressed={option.selected}
+              aria-current={option.selected ? "true" : undefined}
+              onClick={() => {
+                option.onSelect();
+                reset();
+              }}
+            >
+              {option.icon}
+              <span className="min-w-0 truncate">{option.label}</span>
+              <PriceTierBadge
+                tier={option.priceTier}
+                description={getMediaModelPriceTierLabel(option.priceTier)}
+              />
+              {option.selected && (
+                <Check
+                  size={15}
+                  aria-hidden="true"
+                  className="absolute right-2"
+                />
+              )}
+            </Button>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+export function ModelPickerMenuContent(props: ModelPickerMenuContentProps) {
+  const { t } = useTranslation();
+  const page = useGet(props.signals.page$);
+  const back = useSet(props.signals.back$);
+  const focusPanel = useSet(props.signals.focusPanelRef$);
+  let content: ReactNode;
+  let label: string;
+  if (page.kind === "overview") {
+    label = t(($) => {
+      return $.settings.models.picker.models;
+    });
+    content = <ModelPickerOverview {...props} />;
+  } else if (page.kind === "settings") {
+    label = t(($) => {
+      return $.settings.models.picker.menu.chatSettings;
+    });
+    content = (
+      <ChatModelSettings
+        {...props}
+        selection={page.selection}
+        from={page.from}
+      />
+    );
+  } else if (page.category === "chat") {
+    label = t(($) => {
+      return $.settings.models.picker.chatModels;
+    });
+    content = <ChatModelList {...props} />;
+  } else {
+    label =
+      page.category === "image"
+        ? t(($) => {
+            return $.settings.models.picker.imageModels;
+          })
+        : t(($) => {
+            return $.settings.models.picker.videoModels;
+          });
+    content = <MediaModelList {...props} categoryId={page.category} />;
+  }
+  return (
+    <div
+      key={page.kind === "models" ? page.category : page.kind}
+      ref={focusPanel}
+      role="region"
+      aria-label={label}
+      className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150"
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && page.kind !== "overview") {
+          event.preventDefault();
+          event.stopPropagation();
+          back();
+        } else {
+          moveMenuFocus(event);
+        }
+      }}
+    >
+      {content}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-price-tier.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-price-tier.tsx
@@ -1,0 +1,30 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@okouai/ui";
+import type { ModelPriceTier } from "./settings/provider-ui-config.ts";
+
+export function PriceTierBadge({
+  tier,
+  description,
+}: {
+  tier: ModelPriceTier;
+  description: string;
+}) {
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="shrink-0 cursor-help text-xs font-medium text-muted-foreground underline decoration-dotted decoration-muted-foreground/50 underline-offset-2 hover:text-foreground hover:decoration-muted-foreground">
+            {tier}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          {description}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
@@ -7,6 +7,7 @@ import {
 } from "ccstate-react";
 import {
   Check,
+  ChevronDown,
   Cpu,
   Image as ImageIcon,
   MessageCircle,
@@ -14,6 +15,10 @@ import {
   Zap,
 } from "lucide-react";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Button,
   Select,
   SelectContent,
   SelectGroup,
@@ -71,6 +76,10 @@ import {
 } from "./settings/provider-ui-config";
 import { ProviderIcon } from "./settings/provider-icons";
 import { settingsIconAssetUrl } from "./settings/settings-icon-assets";
+
+import type { ModelPickerMenuSignals } from "../../../signals/okou-page/model-picker-menu.ts";
+import { PriceTierBadge } from "./model-picker-price-tier.tsx";
+import { ModelPickerMenuContent } from "./model-picker-menu.tsx";
 
 export interface ModelProviderSelection {
   selectedModel: SupportedRunModel;
@@ -145,6 +154,8 @@ interface ModelProviderPickerProps {
   codexFastModeEnabled?: boolean;
   /** Media-model category panel state for composer callers. */
   mediaModelPanel?: MediaModelPanelState;
+  /** Composer-owned navigation for the compact model menu rollout. */
+  menuSignals?: ModelPickerMenuSignals;
   /** Model omitted from this caller's list of available choices. */
   excludedModel?: SupportedRunModel;
 }
@@ -162,29 +173,6 @@ const CODEX_FAST_SELECTED_PREFIX = "__codex_fast_selected__:";
 // the disabled variant to stop the measuring item from bleeding through.
 const MEASURABLE_HIDDEN_SELECT_ITEM_CLASS =
   "absolute left-0 top-0 h-8 w-px overflow-hidden opacity-0 data-[disabled]:opacity-0 pointer-events-none";
-
-function PriceTierBadge({
-  tier,
-  description,
-}: {
-  tier: ModelPriceTier;
-  description: string;
-}) {
-  return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="shrink-0 cursor-help text-xs font-medium text-muted-foreground underline decoration-dotted decoration-muted-foreground/50 underline-offset-2 hover:text-foreground hover:decoration-muted-foreground">
-            {tier}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          {description}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
 
 function ByokBadge() {
   const { t } = useTranslation();
@@ -1342,6 +1330,8 @@ function SubscribedExplicitModelFirstModelPickerContent({
   fastLabel,
   mediaModelPanel,
   excludedModel,
+  menuSignals,
+  onMenuChange,
 }: {
   value: ModelProviderSelection | null;
   placeholder: string;
@@ -1349,12 +1339,27 @@ function SubscribedExplicitModelFirstModelPickerContent({
   fastLabel: string;
   mediaModelPanel: MediaModelPanelState | undefined;
   excludedModel: SupportedRunModel | undefined;
+  menuSignals: ModelPickerMenuSignals | undefined;
+  onMenuChange: (selection: ModelProviderSelection) => void;
 }) {
   const { t } = useTranslation();
   const policiesLoadable = useLastLoadable(orgModelPolicies$);
   const modelCapabilities =
     useLastResolved(modelPlanCapabilities$) ?? DEFAULT_MODEL_PLAN_CAPABILITIES;
   if (policiesLoadable.state !== "hasData") {
+    if (menuSignals) {
+      return (
+        <div className="px-2 py-2 text-sm text-muted-foreground" role="status">
+          {policiesLoadable.state === "loading"
+            ? t(($) => {
+                return $.settings.models.picker.loading;
+              })
+            : t(($) => {
+                return $.settings.models.picker.loadError;
+              })}
+        </div>
+      );
+    }
     return (
       <ModelFirstModelPickerMessageContent
         value={value}
@@ -1382,6 +1387,35 @@ function SubscribedExplicitModelFirstModelPickerContent({
     fastLabel,
     excludedModel,
   });
+  if (menuSignals) {
+    return (
+      <ModelPickerMenuContent
+        signals={menuSignals}
+        value={state.selection}
+        placeholder={placeholder}
+        mediaModelPanel={mediaModelPanel}
+        onChange={onMenuChange}
+        options={state.policies.map((policy) => {
+          return {
+            model: policy.model,
+            label:
+              policy.modelLabel || getCanonicalModelDisplayName(policy.model),
+            content: (
+              <ModelFirstPolicyRowContent
+                policy={policy}
+                modelCapabilities={modelCapabilities}
+              />
+            ),
+            disabled: policy.routeStatus !== "valid",
+            fastAvailable:
+              codexFastModeEnabled &&
+              policy.routeStatus === "valid" &&
+              isCodexFastModeModel(policy.model),
+          };
+        })}
+      />
+    );
+  }
   return (
     <ModelFirstModelPickerContentLayout
       selectValue={state.selectValue}
@@ -1413,15 +1447,7 @@ function EnabledExplicitModelFirstModelPicker(
     codexFastModeEnabled: props.codexFastModeEnabled ?? false,
     fastLabel: props.fastLabel,
   });
-  const handleRawValueChange = (raw: string) => {
-    const selection = modelFirstSelectionFromInteraction(
-      raw,
-      state.selection,
-      props.codexFastModeEnabled ?? false,
-    );
-    if (selection === undefined) {
-      return;
-    }
+  const handleSelectionChange = (selection: ModelProviderSelection | null) => {
     detach(
       (async () => {
         const result = await resolveSelection(
@@ -1440,19 +1466,78 @@ function EnabledExplicitModelFirstModelPicker(
       Reason.DomCallback,
     );
   };
+  const handleRawValueChange = (raw: string) => {
+    const selection = modelFirstSelectionFromInteraction(
+      raw,
+      state.selection,
+      props.codexFastModeEnabled ?? false,
+    );
+    if (selection !== undefined) {
+      handleSelectionChange(selection);
+    }
+  };
+  const content = (
+    <SubscribedExplicitModelFirstModelPickerContent
+      value={props.value}
+      placeholder={props.placeholder}
+      codexFastModeEnabled={props.codexFastModeEnabled ?? false}
+      fastLabel={props.fastLabel}
+      mediaModelPanel={props.mediaModelPanel}
+      excludedModel={props.excludedModel}
+      menuSignals={props.menuSignals}
+      onMenuChange={handleSelectionChange}
+    />
+  );
+  if (props.menuSignals) {
+    return (
+      <Popover
+        open={props.open}
+        onOpenChange={props.onOpenChange}
+        modal={props.modal}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            aria-label={state.triggerAriaLabel}
+            className={cn(
+              "h-9 w-full justify-start gap-2 rounded-lg text-sm font-normal",
+              props.triggerClassName,
+            )}
+          >
+            <span data-slot="select-value" className="min-w-0">
+              <ModelFirstTriggerLabel
+                selection={state.selection}
+                placeholder={props.placeholder}
+                mobileIcon={props.mobileIconTrigger}
+                codexFastModeEnabled={props.codexFastModeEnabled ?? false}
+                fastLabel={props.fastLabel}
+              />
+            </span>
+            <span data-slot="select-icon">
+              <ChevronDown
+                size={16}
+                className="shrink-0 opacity-50"
+                aria-hidden="true"
+              />
+            </span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          side="top"
+          align="end"
+          collisionPadding={8}
+          aria-label={props.placeholder}
+          className="w-[304px] max-w-[calc(100vw-16px)] max-h-[var(--available-height)] overflow-y-auto overscroll-contain p-1"
+        >
+          {content}
+        </PopoverContent>
+      </Popover>
+    );
+  }
   return (
     <ModelFirstSelectPicker
       state={state}
-      content={
-        <SubscribedExplicitModelFirstModelPickerContent
-          value={props.value}
-          placeholder={props.placeholder}
-          codexFastModeEnabled={props.codexFastModeEnabled ?? false}
-          fastLabel={props.fastLabel}
-          mediaModelPanel={props.mediaModelPanel}
-          excludedModel={props.excludedModel}
-        />
-      }
+      content={content}
       placeholder={props.placeholder}
       triggerClassName={props.triggerClassName}
       mobileIconTrigger={props.mobileIconTrigger}
@@ -1478,6 +1563,7 @@ export function ModelProviderPicker({
   disabled = false,
   codexFastModeEnabled = false,
   mediaModelPanel,
+  menuSignals,
   excludedModel,
 }: ModelProviderPickerProps) {
   const { t } = useTranslation();
@@ -1514,6 +1600,7 @@ export function ModelProviderPicker({
       codexFastModeEnabled={codexFastModeEnabled}
       fastLabel={fastLabel}
       excludedModel={excludedModel}
+      menuSignals={menuSignals}
       {...(mediaModelPanel ? { mediaModelPanel } : {})}
     />
   );

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -32,39 +32,6 @@ describe("FeatureSwitchKey", () => {
 });
 
 describe("isFeatureEnabled", () => {
-  it("defaults the compact model menu to Bingjie without enabling the staff org", () => {
-    for (const ctx of [
-      { userId: "user_3EWY21Oe3f15kfs3yYmbGgDb3NV" },
-      { email: "bingjie@okou.ai" },
-      { email: "bingjie@vm0.ai" },
-    ]) {
-      expect(isFeatureEnabled(FeatureSwitchKey.ModelPickerMenu, ctx)).toBe(
-        true,
-      );
-      expect(getAllFeatureStates(ctx)[FeatureSwitchKey.ModelPickerMenu]).toBe(
-        true,
-      );
-      expect(
-        isFeatureEnabled(FeatureSwitchKey.ModelPickerMenu, {
-          ...ctx,
-          overrides: { [FeatureSwitchKey.ModelPickerMenu]: false },
-        }),
-      ).toBe(false);
-    }
-    for (const ctx of [
-      {},
-      { email: "another-user@example.com" },
-      { orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe" },
-    ]) {
-      expect(isFeatureEnabled(FeatureSwitchKey.ModelPickerMenu, ctx)).toBe(
-        false,
-      );
-      expect(getAllFeatureStates(ctx)[FeatureSwitchKey.ModelPickerMenu]).toBe(
-        false,
-      );
-    }
-  });
-
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
     expect(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -32,6 +32,39 @@ describe("FeatureSwitchKey", () => {
 });
 
 describe("isFeatureEnabled", () => {
+  it("defaults the compact model menu to Bingjie without enabling the staff org", () => {
+    for (const ctx of [
+      { userId: "user_3EWY21Oe3f15kfs3yYmbGgDb3NV" },
+      { email: "bingjie@okou.ai" },
+      { email: "bingjie@vm0.ai" },
+    ]) {
+      expect(isFeatureEnabled(FeatureSwitchKey.ModelPickerMenu, ctx)).toBe(
+        true,
+      );
+      expect(getAllFeatureStates(ctx)[FeatureSwitchKey.ModelPickerMenu]).toBe(
+        true,
+      );
+      expect(
+        isFeatureEnabled(FeatureSwitchKey.ModelPickerMenu, {
+          ...ctx,
+          overrides: { [FeatureSwitchKey.ModelPickerMenu]: false },
+        }),
+      ).toBe(false);
+    }
+    for (const ctx of [
+      {},
+      { email: "another-user@example.com" },
+      { orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe" },
+    ]) {
+      expect(isFeatureEnabled(FeatureSwitchKey.ModelPickerMenu, ctx)).toBe(
+        false,
+      );
+      expect(getAllFeatureStates(ctx)[FeatureSwitchKey.ModelPickerMenu]).toBe(
+        false,
+      );
+    }
+  });
+
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
     expect(

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -46,6 +46,7 @@ export enum FeatureSwitchKey {
   ZoomConnector = "zoomConnector",
   WorkdayConnector = "workdayConnector",
   CodexFastMode = "_fastModel",
+  ModelPickerMenu = "modelPickerMenu",
   NewChatDefaultModelAction = "newChatDefaultModelAction",
   CloudBrowserPreference = "cloudBrowserPreference",
   RealAgentInPreview = "_realAgentInPreview",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -275,6 +275,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show a compact overview of chat, image, and video models with nested model lists and Fast settings.",
     enabled: false,
+    enabledUserHashes: ["032a75d8"], // Bingjie's account, including API contexts without email
+    enabledEmailHashes: ["6490c77f", "9fd4ee92"], // bingjie@okou.ai, bingjie@vm0.ai
   },
   [FeatureSwitchKey.NewChatDefaultModelAction]: {
     maintainer: "lancy@vm0.ai",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -270,6 +270,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ModelPickerMenu]: {
+    maintainer: "bingjie@okou.ai",
+    description:
+      "Show a compact overview of chat, image, and video models with nested model lists and Fast settings.",
+    enabled: false,
+  },
   [FeatureSwitchKey.NewChatDefaultModelAction]: {
     maintainer: "lancy@vm0.ai",
     description:

--- a/turbo/packages/core/src/model-feature-switch.ts
+++ b/turbo/packages/core/src/model-feature-switch.ts
@@ -1,0 +1,10 @@
+import { FeatureSwitchKey } from "./feature-switch-key";
+import { isFeatureEnabled, type FeatureSwitchContext } from "./feature-switch";
+
+/** The compact menu includes Fast; the existing rollout still serves other users. */
+export function isCodexFastModeEnabled(ctx: FeatureSwitchContext): boolean {
+  return (
+    isFeatureEnabled(FeatureSwitchKey.ModelPickerMenu, ctx) ||
+    isFeatureEnabled(FeatureSwitchKey.CodexFastMode, ctx)
+  );
+}


### PR DESCRIPTION
## Summary

Bingjie gets a compact composer model menu through one `modelPickerMenu` switch. The 304 px overview follows [the supplied design](https://model-menu-12134959.okou.app/): Chat, Image, and Video show their current models, each row opens its model list, and supported chat models expose Fast settings. The switch includes Fast access in both UI and API; `_fastModel` does not need to be enabled separately.

Fast and chat-model changes stay in a composer-local draft until Confirm. Cancel and outside dismissal discard the draft; Back and Escape follow the entry path. The menu reuses existing model policies, brand icons, pricing hints, plan restrictions, and media-selection callbacks, with keyboard navigation and all supported locales.

## Scope and rollout

- Default targeting includes only Bingjie's current account ID and verified `bingjie@okou.ai` / `bingjie@vm0.ai` email identities. Global and staff-org-wide defaults remain off for the new menu. Lab retains the existing per-user override mechanism.
- A shared Fast-access helper covers saved defaults, thread creation, sends, queued continuations, and runtime selection. Model support, provider routing, and billing restrictions remain enforced.
- Existing image/video **model choices** already persist in threads and personal preferences. Their catalogs and persistence paths are reused. Generation parameters and storage are unchanged.
- The reference's Effort control has no corresponding conversation/preference field, so it is outside this UI change. No API fields or database migrations are added. Fast keeps the current `1.5× model speed · 2.5× credit usage` description.
- Picker callers outside the composer keep their existing layout.

## Fallbacks

- `ComposerRunModelPickerControl` / `EnabledExplicitModelFirstModelPicker` retain the existing selector while the new flag is off or absent. Surface: composer UI; window: none, non-GA feature switch. Remove the old-layout branch during flag graduation.
- Overview/settings/list display uses canonical model names, category labels, or the existing placeholder when optional selection/policy display data is absent. These defaults do not choose another model or enable an unavailable route. Surface: optional UI data; no version-skew window or temporary removal condition.
- `isCodexFastModeEnabled` also honors the existing `_fastModel` rollout for users outside the new-menu cohort. This is active product policy, not cross-version compatibility; remove the alternative when that flag is retired. No version-migration fallback is introduced.

## Validation

- All 98 reported PR checks completed without failures on `da812efeeeeb75cb04ae61b12a89e39d1697105a`, including all eight API test shards and the required CI gates.
- Targeted composer model/media page coverage passed: confirmation, cancellation, dismissal, keyboard navigation, restricted routes, and desktop/mobile media selection. The four chat-menu cases also passed locally with the legacy Fast flag explicitly off.
- API route tests cover Bingjie-only targeting, plus saved priority defaults and thread inheritance under each Fast-access flag independently.
- API, Platform, and Core type checks; affected formatting, Oxlint/type-aware lint, ESLint; Core lint/tests; localization checks; and scoped Knip passed. No full local Vitest or local dev server was used.

## UI walkthrough — PASS

[Open the acceptance preview](https://pr-32036-app-okou-app-preview.vm0.workers.dev/?x-vercel-protection-bypass=jAdTONWK3jqOzLaGJYjS4kINOvXBRmvB&x-vercel-set-bypass-cookie=true).

Tested PR head: `da812efeeeeb75cb04ae61b12a89e39d1697105a`. Both deployment jobs checked out merge artifact `a1a0dae90f3c6e0173e82aea8abccaac8824a6f4`, whose PR parent is that head; the browser's commit metadata matched the artifact. App and API origins came from this PR's deployment logs; API: `https://pr-32036-api.vm6.ai`.

Fixture: `model-picker-32036-0906+clerk_test@example.com`, separate free-tier preview org, Chrome 151, 1440 × 960 and 393 × 852. Onboarding was completed through the preview API because it is outside this test. Preview protection was bypassed on the owned App/API origins. No content or component behavior was mocked; no chat runs or generation jobs were started.

| Checkpoint | Result |
| --- | --- |
| New flag off | PASS — original selector and categories remain usable. |
| Single flag | PASS — Lab and API both show `modelPickerMenu=true`, `_fastModel=false`, `_realAgentInPreview=false`. |
| Confirm and reload | PASS — select GPT 5.6 Luna, enable Fast, Confirm; preference GET returns `gpt-5.6-luna` / `priority`; reloading restores Fast. |
| Draft/navigation | PASS — Cancel and outside dismissal discard edits; nested Escape returns settings → chat list → overview → closed. ArrowDown/Space operate Fast; End reaches the last media model. |
| Plan restrictions | PASS — selecting a restricted model opens plan comparison and keeps the current model. Invalid-route disabling is covered by page integration tests. |
| Media choices | PASS — GPT Image 2 and Veo 3.1 fast selections update the overview; existing video options remain separate. |
| Layout | PASS — light/dark desktop and dark mobile overview/settings/lists fit; overview is 304 × 186 px; mobile lists flip to available space without horizontal overflow. |

[Desktop](https://a.okou.io/9vm2hhluk8.png) · [Mobile](https://a.okou.io/ggikfa0nb3.png) · [Fast after reload](https://a.okou.io/2uh198a99u.png) · [Light theme](https://a.okou.io/yl1rr5igtd.png) · [Mobile list](https://a.okou.io/o2ry0phuhf.png)
