### PR TITLE
feat(core): roll out follow-up optimization to all users

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1118,6 +1118,18 @@ describe("CHAT-02: completed chat callback", () => {
   it("persists assistant output, reorders threads, titles the thread, recommends follow-ups, notifies, and auto-sends the queued template message", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped chat actor");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      {
+        userId: actor.userId,
+        orgId: actor.orgId,
+        orgRole: actor.orgRole,
+      },
+      { [FeatureSwitchKey.FollowUpOptimize]: false },
+    );
 
     const titlePrompts: string[] = [];
     const followupSystemPrompts: string[] = [];
@@ -1515,21 +1527,9 @@ describe("CHAT-02: completed chat callback", () => {
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
 
-  it("uses the optimized prompt and userMessage semantics for recommended follow-ups", async () => {
+  it("uses the released optimized prompt and userMessage semantics for recommended follow-ups", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped chat actor");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      {
-        userId: actor.userId,
-        orgId: actor.orgId,
-        orgRole: actor.orgRole,
-      },
-      { [FeatureSwitchKey.FollowUpOptimize]: true },
-    );
 
     const style = ILLUSTRATION_TEMPLATE_ITEMS[0];
     if (!style) {
@@ -1691,7 +1691,7 @@ describe("CHAT-02: completed chat callback", () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
     chatCallbacks.mockOpenRouterCompletions((body) => {
       const systemContent = body.messages[0]?.content ?? "";
-      if (systemContent.includes("concise follow-up prompts")) {
+      if (systemContent.includes("recommended follow-up messages")) {
         followupRequests += 1;
         return [
           "[",
@@ -1760,7 +1760,7 @@ describe("CHAT-02: completed chat callback", () => {
         requestsBySite.set("title", record);
         return "Budget Pinning";
       }
-      if (systemContent.includes("concise follow-up prompts")) {
+      if (systemContent.includes("recommended follow-up messages")) {
         requestsBySite.set("followups", record);
         return JSON.stringify([{ prompt: "Keep going", kind: "talk" }]);
       }
@@ -1828,7 +1828,7 @@ describe("CHAT-02: completed chat callback", () => {
       if (systemContent.includes("Generate a short, descriptive title")) {
         return "Truncated Notification";
       }
-      if (systemContent.includes("concise follow-up prompts")) {
+      if (systemContent.includes("recommended follow-up messages")) {
         return JSON.stringify([{ prompt: "Keep going", kind: "talk" }]);
       }
       return "Generated summary";
@@ -1913,7 +1913,7 @@ describe("CHAT-02: completed chat callback", () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
     chatCallbacks.mockOpenRouterCompletions((body) => {
       const systemContent = body.messages[0]?.content ?? "";
-      if (systemContent.includes("concise follow-up prompts")) {
+      if (systemContent.includes("recommended follow-up messages")) {
         followupRequests += 1;
         return {
           content: JSON.stringify([
@@ -1981,7 +1981,7 @@ describe("CHAT-02: completed chat callback", () => {
     chatCallbacks.mockOpenRouterCompletions(async (body) => {
       await openRouterGate.wait();
       const systemContent = body.messages[0]?.content ?? "";
-      if (systemContent.includes("concise follow-up prompts")) {
+      if (systemContent.includes("recommended follow-up messages")) {
         return JSON.stringify([
           { prompt: "Review the queued result", kind: "talk" },
         ]);
@@ -5541,7 +5541,7 @@ describe("CHAT-02: auto-send after failures", () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
     chatCallbacks.mockOpenRouterCompletions(async (body) => {
       const systemContent = body.messages[0]?.content ?? "";
-      if (systemContent.includes("concise follow-up prompts")) {
+      if (systemContent.includes("recommended follow-up messages")) {
         followupRequests += 1;
         await followupGate.wait();
         return JSON.stringify([

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -17015,7 +17015,7 @@ describe("CHAT-02: prior rounds and thread titles", () => {
           upstreamAuthorization = request.headers.get("authorization");
           const payload = openRouterBodySchema.parse(await request.json());
           const systemContent = payload.messages[0]?.content ?? "";
-          if (systemContent.includes("concise follow-up prompts")) {
+          if (systemContent.includes("recommended follow-up messages")) {
             followupRequestBody = payload;
             return HttpResponse.json({
               choices: [
@@ -17214,7 +17214,9 @@ describe("CHAT-02: prior rounds and thread titles", () => {
               {
                 finish_reason: "stop",
                 message: {
-                  content: systemContent.includes("concise follow-up prompts")
+                  content: systemContent.includes(
+                    "recommended follow-up messages",
+                  )
                     ? JSON.stringify([
                         {
                           prompt: "Use the recommended follow-up",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -3048,7 +3048,7 @@ describe("CHAT-01 chat search index", () => {
               {
                 finish_reason: "stop",
                 message: {
-                  content: body.includes("concise follow-up prompts")
+                  content: body.includes("recommended follow-up messages")
                     ? JSON.stringify([
                         { prompt: followupOnlyNeedle, kind: "talk" },
                       ])

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -40,6 +40,7 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.GoogleFormsWorkflowAutomations, {}),
     ).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.FollowUpOptimize, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -204,7 +205,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.FollowUpOptimize]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
@@ -232,7 +232,6 @@ describe("getAllFeatureStates", () => {
     );
     expect(otherOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.FollowUpOptimize]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
@@ -365,6 +364,9 @@ describe("getFeatureSwitchMetadata", () => {
     expect(
       metadata[FeatureSwitchKey.NotionWorkflowAutomations].rolloutStage,
     ).toBe("released");
+    expect(metadata[FeatureSwitchKey.FollowUpOptimize].rolloutStage).toBe(
+      "released",
+    );
     expect(metadata[FeatureSwitchKey.Banking].rolloutStage).toBe("beta");
     expect(metadata[FeatureSwitchKey.IntroVideo].rolloutStage).toBe("alpha");
     expect(metadata[FeatureSwitchKey.AhrefsConnector].rolloutStage).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -400,8 +400,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "lancy@vm0.ai",
     description:
       "Use a concise, language-matched prompt for recommended chat follow-ups.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ResponsiveFollowupCards]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

- release `followUpOptimize` to all users by enabling its global default
- assert the switch is globally enabled and classified as Released
- preserve explicit legacy override coverage while updating affected API BDD mocks for the released prompt

## Verification

- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (31 passed)
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `git diff --check`

Targeted API BDD tests reached the runner-claim fixture locally but could not proceed because the isolated local runner claim returned 404. PR CI remains the integration-test source of truth.
