### PR TITLE
fix(presentation): validate shared template shells

### DIFF
--- a/.github/scripts/__tests__/publish-presentation-template-archives.test.mjs
+++ b/.github/scripts/__tests__/publish-presentation-template-archives.test.mjs
@@ -46,7 +46,7 @@ async function createTemplateFixture(sourceDir, release) {
     ),
     writeFile(path.join(templateDir, "design-system.md"), "# Design system\n"),
     writeFile(
-      path.join(templateDir, "layouts/_shell.html"),
+      path.join(templateDir, "layouts/shared-shell.html"),
       `<link rel="stylesheet" href="../color-systems/${release.defaultColorSystem}.css">\n`,
     ),
     writeFile(

--- a/.github/scripts/presentation-template-release/archive.mjs
+++ b/.github/scripts/presentation-template-release/archive.mjs
@@ -33,7 +33,7 @@ function requiredTemplateFiles(release) {
   return [
     "SKILL.md",
     "design-system.md",
-    "layouts/_shell.html",
+    "layouts/shared-shell.html",
     `color-systems/${release.defaultColorSystem}.css`,
   ];
 }


### PR DESCRIPTION
## Summary

- validate the current `layouts/shared-shell.html` presentation package contract
- update the release-tool integration fixture to exercise the shared shell layout

## Context

All 23 presentation templates in `vm0-ai/Template-artifact@b4b701ae1b65fb2e6b510b4aa5840eb87e3ed4a6` use `layouts/shared-shell.html`. The production publication workflow still required the removed `layouts/_shell.html`, so its build job could not package the current template source.

## Verification

- `PRESENTATION_TEMPLATE_RELEASE_TOOL=<isolated tool> node --test .github/scripts/__tests__/publish-presentation-template-archives.test.mjs` (2/2 passed)
- built all 23 packages from current `Template-artifact/main`
- verified all 23 generated archives and their extracted file manifests
