### PR TITLE
ci(presentation): use active github app credentials

### DIFF
--- a/.github/workflows/publish-presentation-template-archives.yml
+++ b/.github/workflows/publish-presentation-template-archives.yml
@@ -37,8 +37,8 @@ jobs:
         id: source-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.VM0_GITHUB_APP_ID }}
-          private-key: ${{ secrets.VM0_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.OKOU_GITHUB_APP_ID }}
+          private-key: ${{ secrets.OKOU_GITHUB_APP_PRIVATE_KEY }}
           owner: vm0-ai
           repositories: Template-artifact
           permission-contents: read


### PR DESCRIPTION
## Summary

- use the active canonical Okou GitHub App credentials for the cross-repository Template-artifact checkout
- preserve the existing repository allowlist and read-only contents permission

## Context

The first production publication attempt, [run 34040366333](https://github.com/vm0-ai/vm0/actions/runs/34040366333), stopped before checkout because the legacy `VM0_GITHUB_APP_PRIVATE_KEY` could not be decoded. The canonical `OKOU_GITHUB_APP_PRIVATE_KEY` was refreshed on 2026-09-02 and belongs with the canonical `OKOU_GITHUB_APP_ID` variable.

No archive build or production write ran during the failed attempt.

## Verification

- actionlint 1.7.12 passed for `publish-presentation-template-archives.yml`
- `.github/scripts/tests/implicit-npm-audit-test.sh` passed
