### PR TITLE
fix(presentation): decode github app private key

### DIFF
--- a/.github/scripts/decode-github-app-private-key.sh
+++ b/.github/scripts/decode-github-app-private-key.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+decoded_key="$(base64 --decode)"
+decoded_key="${decoded_key//$'\r'/}"
+
+if [[ -z "$decoded_key" ]]; then
+  echo "GitHub App private key decoded to an empty value" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$decoded_key" |
+  openssl pkey -check -noout >/dev/null 2>&1; then
+  echo "GitHub App private key is not a valid PEM key" >&2
+  exit 1
+fi
+
+printf '%s' "${decoded_key//$'\n'/\\n}"

--- a/.github/scripts/tests/decode-github-app-private-key-test.sh
+++ b/.github/scripts/tests/decode-github-app-private-key-test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+decoder="$repo_root/.github/scripts/decode-github-app-private-key.sh"
+workflow="$repo_root/.github/workflows/publish-presentation-template-archives.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+for command in base64 openssl rg; do
+  command -v "$command" >/dev/null || fail "$command is required"
+done
+
+private_key="$(
+  openssl genpkey \
+    -algorithm RSA \
+    -pkeyopt rsa_keygen_bits:2048 \
+    2>/dev/null
+)"
+encoded_key="$(printf '%s\n' "$private_key" | base64 -w 0)"
+escaped_key="$(printf '%s' "$encoded_key" | bash "$decoder")"
+round_trip_key="$(printf '%b' "$escaped_key")"
+
+if [[ "$round_trip_key" != "$private_key" ]]; then
+  fail "decoded private key did not survive escaped-newline output"
+fi
+
+if printf 'not-base64!' | bash "$decoder" >/dev/null 2>&1; then
+  fail "invalid Base64 input must fail"
+fi
+
+not_a_key="$(printf 'not a private key' | base64 -w 0)"
+if printf '%s' "$not_a_key" | bash "$decoder" >/dev/null 2>&1; then
+  fail "decoded non-key input must fail"
+fi
+
+rg --quiet --fixed-strings \
+  'SOURCE_PRIVATE_KEY_BASE64: ${{ secrets.OKOU_GITHUB_APP_PRIVATE_KEY }}' \
+  "$workflow" || fail "workflow must read the canonical Base64 private key secret"
+rg --quiet --fixed-strings \
+  'bash .github/scripts/decode-github-app-private-key.sh' \
+  "$workflow" || fail "workflow must decode the private key before token creation"
+rg --quiet --fixed-strings \
+  'private-key: ${{ steps.source-private-key.outputs.private-key }}' \
+  "$workflow" || fail "token action must consume the decoded private key"
+
+if rg --quiet --fixed-strings \
+  'private-key: ${{ secrets.OKOU_GITHUB_APP_PRIVATE_KEY }}' \
+  "$workflow"; then
+  fail "token action must not receive the Base64 secret directly"
+fi
+
+echo "decode-github-app-private-key-test: ok"

--- a/.github/workflows/publish-presentation-template-archives.yml
+++ b/.github/workflows/publish-presentation-template-archives.yml
@@ -33,12 +33,25 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
 
+      - name: Decode GitHub App private key
+        id: source-private-key
+        env:
+          SOURCE_PRIVATE_KEY_BASE64: ${{ secrets.OKOU_GITHUB_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          private_key="$(
+            printf '%s' "$SOURCE_PRIVATE_KEY_BASE64" |
+              bash .github/scripts/decode-github-app-private-key.sh
+          )"
+          printf '::add-mask::%s\n' "$private_key"
+          printf 'private-key=%s\n' "$private_key" >> "$GITHUB_OUTPUT"
+
       - name: Create read token for Template-artifact
         id: source-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.OKOU_GITHUB_APP_ID }}
-          private-key: ${{ secrets.OKOU_GITHUB_APP_PRIVATE_KEY }}
+          private-key: ${{ steps.source-private-key.outputs.private-key }}
           owner: vm0-ai
           repositories: Template-artifact
           permission-contents: read


### PR DESCRIPTION
## Summary

- decode the canonical Base64-encoded GitHub App private key before passing it to `actions/create-github-app-token`
- validate that the decoded value is a real PEM private key and fail before authentication when configuration is invalid
- cover valid round-trip decoding, invalid Base64, invalid key material, and workflow wiring

## Production evidence

The production publisher failed before checkout or publication in both runs below with `ERR_OSSL_UNSUPPORTED` while parsing the private key:

- https://github.com/vm0-ai/vm0/actions/runs/34040366333
- https://github.com/vm0-ai/vm0/actions/runs/34041822696

`OKOU_GITHUB_APP_PRIVATE_KEY` follows the API runtime's Base64 key contract, while `actions/create-github-app-token` expects PEM (escaped newlines are accepted). Both failed runs stopped in the build job before any archive or production storage write.

## Verification

- `bash .github/scripts/tests/decode-github-app-private-key-test.sh`
- `bash -n .github/scripts/decode-github-app-private-key.sh .github/scripts/tests/decode-github-app-private-key-test.sh`
- `.github/scripts/tests/implicit-npm-audit-test.sh`
- actionlint 1.7.12 on `.github/workflows/publish-presentation-template-archives.yml`
- `git diff --check`

## After merge

Dispatch the publisher once from `main`, then verify all 23 Presentation template production heads against the exact `Template-artifact/main` source commit recorded by the run.
