### PR TITLE
feat(connectors): add reckon oauth refresh provider

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -146,7 +146,7 @@ const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const PREVIOUS_CONNECTOR_CATALOG_MAX_RAW_BYTES = 32 * 1024 * 1024;
 const EXPECTED_CAPABILITY_DIGEST =
-  "sha256:ba6cd8d86ddd94a1e27f1118b3ca2c6135fd29e1d2e9be54ee670dd861087190";
+  "sha256:a63c2242883709d4f171afc518ad7a4c15ceb5687e8be1ec5800699014ee4718";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -116,6 +116,7 @@ import { posthogProvider } from "./connectors/posthog/provider";
 import { paypalProvider } from "./connectors/paypal/provider";
 import { quickbooksProvider } from "./connectors/quickbooks/provider";
 import { rampProvider } from "./connectors/ramp/provider";
+import { reckonProvider } from "./connectors/reckon/provider";
 import { playstationProvider } from "./connectors/playstation/provider";
 import { spotifyProvider } from "./connectors/spotify/provider";
 import { steamProvider } from "./connectors/steam/provider";
@@ -1057,6 +1058,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES = [
   externalCodeRefreshProviderEntry("playstation", "api", playstationProvider),
   authCodeRefreshProviderEntry("quickbooks", "oauth", quickbooksProvider),
   refreshProviderEntry("ramp", "api-token", rampProvider),
+  refreshProviderEntry("reckon", "oauth-refresh-token", reckonProvider),
   authCodeRefreshProviderEntry("reddit", "oauth", redditProvider),
   authCodeRefreshProviderEntry("sentry", "oauth", sentryProvider),
   authCodeTokenRevokeProviderEntry("slack", "oauth", slackProvider),

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/reckon.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/reckon.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse, http } from "msw";
+import { refreshReckonAccessToken } from "../reckon/api-token";
+import { server } from "../../__tests__/test-server";
+
+const RECKON_TOKEN_URL = "https://identity.reckon.com/connect/token";
+const EXPECTED_AUTHORIZATION = `Basic ${Buffer.from(
+  "client-id:client-secret",
+).toString("base64")}`;
+
+function testRefreshSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
+describe("connector/providers/reckon", () => {
+  it("refreshes a token with Basic auth and the registered redirect URI", async () => {
+    let authorization: string | null = null;
+    let contentType: string | null = null;
+    let body = "";
+    server.use(
+      http.post(RECKON_TOKEN_URL, async ({ request }) => {
+        authorization = request.headers.get("authorization");
+        contentType = request.headers.get("content-type");
+        body = await request.text();
+        return HttpResponse.json({
+          access_token: "new-reckon-access-token",
+          refresh_token: "new-reckon-refresh-token",
+          expires_in: 10800,
+          token_type: "Bearer",
+        });
+      }),
+    );
+
+    await expect(
+      refreshReckonAccessToken(
+        {
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          redirectUri: "https://example.com/reckon/callback",
+          refreshToken: "old-refresh-token",
+        },
+        testRefreshSignal(),
+      ),
+    ).resolves.toEqual({
+      accessToken: "new-reckon-access-token",
+      refreshToken: "new-reckon-refresh-token",
+      expiresIn: 10800,
+    });
+    expect(authorization).toBe(EXPECTED_AUTHORIZATION);
+    expect(contentType).toContain("application/x-www-form-urlencoded");
+    const parameters = new URLSearchParams(body);
+    expect(parameters.get("grant_type")).toBe("refresh_token");
+    expect(parameters.get("refresh_token")).toBe("old-refresh-token");
+    expect(parameters.get("redirect_uri")).toBe(
+      "https://example.com/reckon/callback",
+    );
+    expect(body).not.toContain("client_secret");
+  });
+
+  it("rejects an HTTP error without exposing credentials", async () => {
+    server.use(
+      http.post(RECKON_TOKEN_URL, () => {
+        return new HttpResponse(null, { status: 401 });
+      }),
+    );
+
+    await expect(
+      refreshReckonAccessToken(
+        {
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          redirectUri: "https://example.com/reckon/callback",
+          refreshToken: "old-refresh-token",
+        },
+        testRefreshSignal(),
+      ),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("rejects an OAuth error response", async () => {
+    server.use(
+      http.post(RECKON_TOKEN_URL, () => {
+        return HttpResponse.json({
+          error: "invalid_grant",
+          error_description: "Refresh token expired",
+        });
+      }),
+    );
+
+    await expect(
+      refreshReckonAccessToken(
+        {
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          redirectUri: "https://example.com/reckon/callback",
+          refreshToken: "old-refresh-token",
+        },
+        testRefreshSignal(),
+      ),
+    ).rejects.toThrow("Refresh token expired");
+  });
+
+  it("rejects a successful response without an access token", async () => {
+    server.use(
+      http.post(RECKON_TOKEN_URL, () => {
+        return HttpResponse.json({});
+      }),
+    );
+
+    await expect(
+      refreshReckonAccessToken(
+        {
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          redirectUri: "https://example.com/reckon/callback",
+          refreshToken: "old-refresh-token",
+        },
+        testRefreshSignal(),
+      ),
+    ).rejects.toThrow("No access token in Reckon token response");
+  });
+
+  it("rejects an invalid token response shape", async () => {
+    server.use(
+      http.post(RECKON_TOKEN_URL, () => {
+        return HttpResponse.json({ access_token: 17 });
+      }),
+    );
+
+    await expect(
+      refreshReckonAccessToken(
+        {
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          redirectUri: "https://example.com/reckon/callback",
+          refreshToken: "old-refresh-token",
+        },
+        testRefreshSignal(),
+      ),
+    ).rejects.toThrow("Invalid Reckon token response");
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/reckon/api-token.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/reckon/api-token.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+import { ProviderHttpError, ProviderResponseError } from "../../provider-error";
+
+const RECKON_TOKEN_URL = "https://identity.reckon.com/connect/token";
+
+interface ReckonTokenResult {
+  readonly accessToken: string;
+  readonly refreshToken?: string;
+  readonly expiresIn?: number;
+}
+
+export async function refreshReckonAccessToken(
+  args: {
+    readonly clientId: string;
+    readonly clientSecret: string;
+    readonly redirectUri: string;
+    readonly refreshToken: string;
+  },
+  signal: AbortSignal,
+): Promise<ReckonTokenResult> {
+  const response = await fetch(RECKON_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${args.clientId}:${args.clientSecret}`).toString("base64")}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: args.refreshToken,
+      redirect_uri: args.redirectUri,
+    }),
+    signal,
+  });
+  if (!response.ok) {
+    throw new ProviderHttpError(
+      `Reckon access token refresh failed: ${response.status}`,
+      response.status,
+    );
+  }
+
+  const parsed = z
+    .object({
+      access_token: z.string().min(1).optional(),
+      refresh_token: z.string().min(1).optional(),
+      expires_in: z.number().positive().optional(),
+      error: z.string().min(1).optional(),
+      error_description: z.string().min(1).optional(),
+    })
+    .safeParse(await response.json());
+  if (!parsed.success) {
+    throw new ProviderResponseError("Invalid Reckon token response");
+  }
+  if (parsed.data.error !== undefined) {
+    throw new ProviderResponseError(
+      parsed.data.error_description ?? parsed.data.error,
+    );
+  }
+  if (parsed.data.access_token === undefined) {
+    throw new ProviderResponseError("No access token in Reckon token response");
+  }
+  return {
+    accessToken: parsed.data.access_token,
+    ...(parsed.data.refresh_token === undefined
+      ? {}
+      : { refreshToken: parsed.data.refresh_token }),
+    ...(parsed.data.expires_in === undefined
+      ? {}
+      : { expiresIn: parsed.data.expires_in }),
+  };
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/reckon/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/reckon/provider.ts
@@ -1,0 +1,30 @@
+import type { RefreshTokenAccessProvider } from "../../types";
+import { refreshReckonAccessToken } from "./api-token";
+
+export const reckonProvider = {
+  access: {
+    kind: "refresh-token",
+    refresh: async (args, signal: AbortSignal) => {
+      const token = await refreshReckonAccessToken(
+        {
+          clientId: args.inputs.clientId,
+          clientSecret: args.inputs.clientSecret,
+          redirectUri: args.inputs.redirectUri,
+          refreshToken: args.inputs.refreshToken,
+        },
+        signal,
+      );
+      return {
+        outputs: {
+          accessToken: token.accessToken,
+          ...(token.refreshToken === undefined
+            ? {}
+            : { refreshToken: token.refreshToken }),
+        },
+        ...(token.expiresIn === undefined
+          ? {}
+          : { expiresIn: token.expiresIn }),
+      };
+    },
+  } satisfies RefreshTokenAccessProvider<"reckon", "oauth-refresh-token">,
+};

--- a/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
@@ -1527,6 +1527,31 @@ export const CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS = [
     },
   },
   {
+    connectorSlug: "reckon",
+    authMethodId: "oauth-refresh-token",
+    contract: {
+      client: {
+        kind: "none",
+      },
+      grant: {
+        kind: "manual",
+        callbackOrigin: null,
+        outputNames: [],
+        startOptionNames: [],
+      },
+      access: {
+        kind: "refresh-token",
+        inputNames: ["clientId", "clientSecret", "redirectUri", "refreshToken"],
+        outputNames: ["accessToken", "refreshToken"],
+        platformSecrets: [],
+      },
+      revoke: {
+        kind: "none",
+        inputNames: [],
+      },
+    },
+  },
+  {
     connectorSlug: "reddit",
     authMethodId: "oauth",
     contract: {


### PR DESCRIPTION
## Summary

- Add the Reckon OAuth 2.0 refresh-token provider for the `reckon` connector.
- Register the exact manual auth contract: client ID, client secret, redirect URI, and refresh token inputs; access and rotated refresh token outputs; no revoke handler.
- Add MSW coverage for Basic client authentication, form-encoded refresh requests, HTTP errors, OAuth errors, missing tokens, and invalid response shapes.

## Official contract

- Token endpoint: `https://identity.reckon.com/connect/token`
- Refresh requests use HTTP Basic `client_id:client_secret` and `application/x-www-form-urlencoded` with `grant_type=refresh_token`, `refresh_token`, and the registered `redirect_uri`.
- The connector bundle separately injects the Reckon Azure subscription key at the trusted firewall boundary.
- Reckon documents revocation as two calls requiring client credentials; the current vm0 manual-auth runtime has no safe user-input client binding for revoke, so the connector declares `revoke: none` rather than exposing an incomplete lifecycle.

## Validation

- `pnpm exec vitest run src/auth-providers/connectors/__tests__/reckon.test.ts` — 5 passed.
- `pnpm run check-types` in `packages/connectors` — passed.
- Targeted ESLint — passed.
- `git diff --check` — passed.

This is the runtime prerequisite for the separate vm0-connectors Reckon bundle.