### PR TITLE
perf(api): avoid duplicate global chat queue sweeps

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -8,7 +8,7 @@ import {
   type ChatEvent,
   type UserMessageInputDocument,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { testBrowserReconcileContract } from "@okouai/api-contracts/contracts/test-browser-reconcile";
+import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
 import type { SupportedRunModel } from "@okouai/api-contracts/contracts/model-providers";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
 import type { RunFailureReasonToken } from "@okouai/api-contracts/contracts/run-failure-reasons";
@@ -56,7 +56,7 @@ import {
   useSecretKmsProbe,
 } from "./helpers/secret-kms-probe";
 import { seedBuiltInModelKey } from "./helpers/runtime-state";
-import { testBrowserReconcileRoutes } from "../test-browser-reconcile";
+import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 import { goalsRoutes } from "../goals";
 
 /**
@@ -572,9 +572,9 @@ async function expectCancellationRecoveryPending(
     .toBe(expected);
 }
 
-function cancellationRecoveryReconcileClient() {
-  return setupApp({ context, routes: testBrowserReconcileRoutes })(
-    testBrowserReconcileContract,
+function cancellationRecoveryCleanupClient() {
+  return setupApp({ context, routes: testCronCleanupSandboxesStateRoutes })(
+    testCronCleanupSandboxesStateContract,
   );
 }
 
@@ -583,9 +583,12 @@ async function reconcileCancellationRecoveryFixtures(
   ...additionalChatThreadIds: string[]
 ): Promise<void> {
   await accept(
-    cancellationRecoveryReconcileClient().reconcile({
+    cancellationRecoveryCleanupClient().cleanup({
       body: {
-        chat_thread_ids: [chatThreadId, ...additionalChatThreadIds],
+        chatThreadIds: [chatThreadId, ...additionalChatThreadIds],
+        runIds: [],
+        orgIds: [],
+        exportJobIds: [],
       },
     }),
     [200],

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -8,7 +8,7 @@ import {
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import { cronOfficialWorkflowCatalogContract } from "@okouai/api-contracts/contracts/cron";
-import { testBrowserReconcileContract } from "@okouai/api-contracts/contracts/test-browser-reconcile";
+import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
 import {
   OFFICIAL_WORKFLOW_CATALOG_SCHEMA_VERSION,
   type OfficialWorkflowBlueprint,
@@ -93,7 +93,7 @@ import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automati
 import { workflowAutomationsRoutes } from "../workflow-automations";
 import { webhooksWorkflowAutomationsRoutes } from "../webhooks-workflow-automations";
 import { workflowsRoutes } from "../workflows";
-import { testBrowserReconcileRoutes } from "../test-browser-reconcile";
+import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 import {
   acknowledgeDetachedForTest,
   createDeferredPromise,
@@ -1184,16 +1184,21 @@ function storageClient() {
   })(testSystemStoragePresignedUrlCacheStateContract);
 }
 
-function staleQueueReconcileClient() {
-  return setupApp({ context, routes: testBrowserReconcileRoutes })(
-    testBrowserReconcileContract,
+function staleQueueCleanupClient() {
+  return setupApp({ context, routes: testCronCleanupSandboxesStateRoutes })(
+    testCronCleanupSandboxesStateContract,
   );
 }
 
 async function reconcileStaleQueuedMessages(threadId: string): Promise<void> {
   await accept(
-    staleQueueReconcileClient().reconcile({
-      body: { chat_thread_ids: [threadId] },
+    staleQueueCleanupClient().cleanup({
+      body: {
+        chatThreadIds: [threadId],
+        runIds: [],
+        orgIds: [],
+        exportJobIds: [],
+      },
     }),
     [200],
   );

--- a/turbo/apps/api/src/signals/routes/cron-browser-reconcile.ts
+++ b/turbo/apps/api/src/signals/routes/cron-browser-reconcile.ts
@@ -2,8 +2,6 @@ import { cronBrowserReconcileContract } from "@okouai/api-contracts/contracts/cr
 import { command } from "ccstate";
 
 import type { RouteEntry } from "../route-entry";
-import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
-import { drainStaleChatThreadQueues$ } from "../services/chat-thread-queue-drain.service";
 import { reconcileBrowsers$ } from "../services/browser.service";
 import { cronUnauthorized, hasValidCronSecret$ } from "./cron-auth";
 
@@ -13,12 +11,6 @@ const reconcileBrowsersRoute$ = command(
       return cronUnauthorized();
     }
     const body = await set(reconcileBrowsers$, signal);
-    signal.throwIfAborted();
-    await set(
-      drainStaleChatThreadQueues$,
-      { dispatchFailedCallbacks: dispatchFailedRunCallbacks },
-      signal,
-    );
     signal.throwIfAborted();
     return { status: 200 as const, body };
   },

--- a/turbo/apps/api/src/signals/routes/test-browser-reconcile.ts
+++ b/turbo/apps/api/src/signals/routes/test-browser-reconcile.ts
@@ -4,8 +4,6 @@ import { command } from "ccstate";
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
-import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
-import { drainStaleChatThreadQueues$ } from "../services/chat-thread-queue-drain.service";
 import { reconcileBrowserFixtures$ } from "../services/browser.service";
 import {
   isTestEndpointAllowed,
@@ -27,15 +25,6 @@ const reconcileBrowserFixturesRoute$ = command(
     const body = await set(
       reconcileBrowserFixtures$,
       bodyResult.data.chat_thread_ids,
-      signal,
-    );
-    signal.throwIfAborted();
-    await set(
-      drainStaleChatThreadQueues$,
-      {
-        dispatchFailedCallbacks: dispatchFailedRunCallbacks,
-        chatThreadIds: bodyResult.data.chat_thread_ids,
-      },
       signal,
     );
     signal.throwIfAborted();


### PR DESCRIPTION
## Summary

Both minute crons currently run the same two global chat-queue safety scans. Remove the sweep from browser reconciliation and its fixture route so `cleanup-sandboxes` owns the once-per-minute sweep. Managed browsers already outlive runs and no longer participate in thread admission blocking (`chat-active-run.service.ts`). Existing cancellation-recovery and workflow tests now invoke the scoped cleanup fixture to exercise that owner.

In the 24-hour trace window ending 2026-09-06 15:33:14 UTC, the two scans ran 5,758 times and accumulated 87.0 minutes of DB-client span duration. Browser reconciliation accounted for 2,878 calls and 44.1 minutes. Removing that invocation should roughly halve scan frequency; this is an estimate from historical traces, not a deployed latency or CPU benchmark.

The shared repair sweep retains its existing limit of 20 candidates per invocation and its allocation between stale work and expired cancellation recovery. Recovery now depends on the cleanup cron; under a saturated backlog, one invocation offers fewer recovery attempts than two independent invocations. Normal enqueue and callback-driven queue draining remain in place. Verify stale-queue age and expired-cancellation recovery after deployment.

## Verification

- Prettier, changed-file Oxlint/ESLint, API type checks, and Knip passed.
- Existing browser, sandbox-cleanup, chat-callback, and official-workflow route suites: 167 tests passed using an isolated local PostgreSQL database configured for UTC.
- Full workspace tests are left to the PR pipeline.
