### PR TITLE
fix(runner): keep shared reactor work independently scheduled

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
-use futures_util::future::BoxFuture;
-use tracing::info;
+use tokio_util::task::AbortOnDropHandle;
+use tracing::{Instrument, info};
 
 use super::active_runs::ActiveRuns;
 use crate::config::ProfileConfig;
@@ -26,19 +26,19 @@ use crate::workspace_image_cache::{
 pub(super) const HEARTBEAT_PERIOD: Duration = Duration::from_secs(10);
 const WORKSPACE_CACHE_COMMIT_WAIT: Duration = Duration::from_secs(2);
 
-/// References needed to collect and send a heartbeat.
+/// Shared inputs owned by independently scheduled heartbeat work.
 ///
 /// Avoids passing 8+ arguments through `send_heartbeat`.
 #[derive(Clone)]
-pub(super) struct HeartbeatContext<'a> {
-    idle_pool: &'a Arc<tokio::sync::Mutex<IdlePool>>,
+pub(super) struct HeartbeatContext {
+    idle_pool: Arc<tokio::sync::Mutex<IdlePool>>,
     runner_identity: RunnerProcessIdentity,
-    group: &'a str,
-    profiles: &'a BTreeMap<String, ProfileConfig>,
-    budget: &'a ResourceBudget,
-    provider: &'a dyn JobProvider,
+    group: Arc<str>,
+    profiles: Arc<BTreeMap<String, ProfileConfig>>,
+    budget: Arc<ResourceBudget>,
+    provider: Arc<dyn JobProvider>,
     workspace_cache: Option<WorkspaceImageCache>,
-    active_runs: &'a ActiveRuns,
+    active_runs: ActiveRuns,
     workspace_cache_snapshot: WorkspaceCacheStateSnapshot,
 }
 
@@ -47,38 +47,38 @@ pub(super) struct HeartbeatContextInit<'a> {
     pub(super) runner_identity: RunnerProcessIdentity,
     pub(super) group: &'a str,
     pub(super) profiles: &'a BTreeMap<String, ProfileConfig>,
-    pub(super) budget: &'a ResourceBudget,
-    pub(super) provider: &'a dyn JobProvider,
+    pub(super) budget: &'a Arc<ResourceBudget>,
+    pub(super) provider: Arc<dyn JobProvider>,
     pub(super) workspace_cache: Option<WorkspaceImageCache>,
     pub(super) active_runs: &'a ActiveRuns,
     pub(super) workspace_cache_snapshot: WorkspaceCacheStateSnapshot,
 }
 
-impl<'a> HeartbeatContext<'a> {
-    pub(super) fn new(init: HeartbeatContextInit<'a>) -> Self {
+impl HeartbeatContext {
+    pub(super) fn new(init: HeartbeatContextInit<'_>) -> Self {
         Self {
-            idle_pool: init.idle_pool,
+            idle_pool: Arc::clone(init.idle_pool),
             runner_identity: init.runner_identity,
-            group: init.group,
-            profiles: init.profiles,
-            budget: init.budget,
+            group: Arc::from(init.group),
+            profiles: Arc::new(init.profiles.clone()),
+            budget: Arc::clone(init.budget),
             provider: init.provider,
             workspace_cache: init.workspace_cache,
-            active_runs: init.active_runs,
+            active_runs: init.active_runs.clone(),
             workspace_cache_snapshot: init.workspace_cache_snapshot,
         }
     }
 }
 
-/// Single-flight heartbeat work polled alongside the main reactor.
+/// Single-flight heartbeat work scheduled independently of the main reactor.
 ///
-/// Trigger handlers only call [`request`](Self::request). The active future is
-/// kept outside `tokio::select!`, so other ready branches neither await nor
-/// cancel it. Any number of triggers during one send collapse into one
+/// Trigger handlers only call [`request`](Self::request). The task continues
+/// even while a reactor branch awaits a resource also used by heartbeat work.
+/// Any number of triggers during one send collapse into one
 /// follow-up built from live state when that send starts.
-pub(super) struct HeartbeatController<'a> {
-    context: HeartbeatContext<'a>,
-    in_flight: Option<BoxFuture<'a, ()>>,
+pub(super) struct HeartbeatController {
+    context: HeartbeatContext,
+    in_flight: Option<AbortOnDropHandle<()>>,
     pending: Option<HeartbeatRequest>,
     next_snapshot_sequence: u64,
 }
@@ -129,8 +129,8 @@ impl HeartbeatRequest {
     }
 }
 
-impl<'a> HeartbeatController<'a> {
-    pub(super) fn new(context: HeartbeatContext<'a>) -> Self {
+impl HeartbeatController {
+    pub(super) fn new(context: HeartbeatContext) -> Self {
         Self {
             context,
             in_flight: None,
@@ -184,13 +184,18 @@ impl<'a> HeartbeatController<'a> {
         self.in_flight.is_some()
     }
 
-    /// Wait for the stored future from an enabled `tokio::select!` branch.
+    /// Observe the task from an enabled `tokio::select!` branch.
     pub(super) async fn wait_for_send(&mut self) -> RunnerResult<()> {
         let send = self.in_flight.as_mut().ok_or_else(|| {
             RunnerError::Internal("heartbeat wait requires an active send".to_string())
         })?;
-        send.await;
-        Ok(())
+        let result = send.await;
+        if result.is_err() {
+            // Teardown must not poll a completed JoinHandle a second time.
+            self.in_flight = None;
+            self.pending = None;
+        }
+        result.map_err(|error| RunnerError::Internal(format!("heartbeat task failed: {error}")))
     }
 
     /// Clear a completed send and start one live-state follow-up when dirty.
@@ -226,11 +231,14 @@ impl<'a> HeartbeatController<'a> {
     /// Hard stopping calls this before provider shutdown. Awaiting the bounded
     /// request preserves local ordering without assuming that dropping a
     /// client future retracts a request already queued remotely.
-    pub(super) async fn drain(&mut self) {
-        if let Some(send) = self.in_flight.take() {
-            send.await;
-        }
+    pub(super) async fn drain(&mut self) -> RunnerResult<()> {
         self.pending = None;
+        if let Some(send) = self.in_flight.take() {
+            send.await.map_err(|error| {
+                RunnerError::Internal(format!("heartbeat task failed: {error}"))
+            })?;
+        }
+        Ok(())
     }
 
     pub(super) fn into_next_snapshot_sequence(self) -> u64 {
@@ -246,9 +254,12 @@ impl<'a> HeartbeatController<'a> {
         })?;
         self.next_snapshot_sequence = next_snapshot_sequence;
         let context = self.context.clone();
-        self.in_flight = Some(Box::pin(async move {
-            send_heartbeat(&context, mode, snapshot_sequence, request).await;
-        }));
+        self.in_flight = Some(AbortOnDropHandle::new(tokio::spawn(
+            async move {
+                send_heartbeat(&context, mode, snapshot_sequence, request).await;
+            }
+            .in_current_span(),
+        )));
         Ok(())
     }
 }
@@ -422,7 +433,7 @@ impl WorkspaceCacheStateSnapshot {
 /// Collect current runner state, refresh the local workspace-cache snapshot, and
 /// send a heartbeat to the server.
 async fn send_heartbeat(
-    hb: &HeartbeatContext<'_>,
+    hb: &HeartbeatContext,
     mode: RunnerMode,
     snapshot_sequence: u64,
     request: HeartbeatRequest,
@@ -431,11 +442,11 @@ async fn send_heartbeat(
     let mut state = collect_heartbeat_state(
         HeartbeatSnapshotMetadata {
             runner_identity: hb.runner_identity,
-            group: hb.group,
+            group: &hb.group,
             sequence: snapshot_sequence,
         },
-        hb.profiles,
-        hb.budget,
+        &hb.profiles,
+        &hb.budget,
         &pool,
         mode,
     );
@@ -443,13 +454,13 @@ async fn send_heartbeat(
     let cache_change = request.workspace_cache_change.as_ref();
     let previous_workspace_states = cache_change.map(|_| {
         hb.workspace_cache_snapshot
-            .current_held_workspace_states(hb.active_runs, None)
+            .current_held_workspace_states(&hb.active_runs, None)
     });
     let refresh = if request.refresh_workspace_cache {
         refresh_workspace_cache_snapshot_after_change(
             &hb.workspace_cache_snapshot,
             hb.workspace_cache.as_ref(),
-            hb.profiles,
+            &hb.profiles,
             cache_change,
         )
         .await
@@ -460,9 +471,9 @@ async fn send_heartbeat(
         }
     };
     state.held_sandbox_states =
-        filter_current_held_sandbox_states(state.held_sandbox_states, hb.active_runs, None);
+        filter_current_held_sandbox_states(state.held_sandbox_states, &hb.active_runs, None);
     state.held_workspace_states =
-        filter_current_held_workspace_states(refresh.states, hb.active_runs, None);
+        filter_current_held_workspace_states(refresh.states, &hb.active_runs, None);
     if let Some(change) = cache_change
         && !request.force_send
         && previous_workspace_states
@@ -1107,7 +1118,7 @@ mod tests {
         let cache = WorkspaceImageCache::new(paths.clone());
         seed_workspace_cache_state(&cache, &paths, reuse_key, "2026-06-01T00:00:00.000Z").await;
         let profiles = test_profiles();
-        let budget = ResourceBudget::new(8, 32768, 1.0, 4);
+        let budget = Arc::new(ResourceBudget::new(8, 32768, 1.0, 4));
         let active_runs = test_active_runs();
         let (provider, _) = MockJobProvider::new(tokio_util::sync::CancellationToken::new());
         let workspace_cache_snapshot = WorkspaceCacheStateSnapshot::new();
@@ -1123,7 +1134,7 @@ mod tests {
             group: "vm0/test",
             profiles: &profiles,
             budget: &budget,
-            provider: provider.as_ref(),
+            provider,
             workspace_cache: Some(cache),
             active_runs: &active_runs,
             workspace_cache_snapshot: workspace_cache_snapshot.clone(),
@@ -1183,7 +1194,7 @@ mod tests {
         let cache = WorkspaceImageCache::new(paths.clone());
         seed_workspace_cache_state(&cache, &paths, reuse_key, "2026-06-01T00:00:00.000Z").await;
         let profiles = test_profiles();
-        let budget = ResourceBudget::new(8, 32768, 1.0, 4);
+        let budget = Arc::new(ResourceBudget::new(8, 32768, 1.0, 4));
         let active_runs = test_active_runs();
         let (provider, handle) = MockJobProvider::new(tokio_util::sync::CancellationToken::new());
         let workspace_cache_snapshot = WorkspaceCacheStateSnapshot::new();
@@ -1213,7 +1224,7 @@ mod tests {
             group: "vm0/test",
             profiles: &profiles,
             budget: &budget,
-            provider: provider.as_ref(),
+            provider,
             workspace_cache: Some(cache),
             active_runs: &active_runs,
             workspace_cache_snapshot,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -25,15 +25,18 @@
 //! - lifecycle signals are registered before slow startup work;
 //! - discovery is pinned across `select!` ticks so heartbeat and lifecycle
 //!   branches do not restart polling;
-//! - heartbeat work is pinned and single-flight so its I/O does not stall the
-//!   main reactor or overlap a newer snapshot;
+//! - heartbeat and status retry tasks run independently of the reactor so its
+//!   inline resource waits cannot strand a queued task ahead of it;
 //! - workspace-cache watcher work is pinned across reactor turns so async
 //!   metadata classification cannot lose already-drained kernel events;
-//! - routine workspace-cache GC is pinned and process-local single-flight, and
+//! - routine workspace-cache GC is independently scheduled and single-flight, and
 //!   its host-global cadence is coordinated through the capacity lock;
 //! - the first routine heartbeat tick is deferred;
 //! - teardown drains heartbeat work and drops discovery before provider
 //!   shutdown.
+//!
+//! See `docs/runner-reactor-progress.md` for the shared-resource audit and
+//! cancellation/teardown ownership rules.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -44,9 +47,9 @@ use clap::Args;
 use futures_util::future::BoxFuture;
 use sandbox::{RuntimeProvider, SandboxRuntime};
 use tokio::sync::mpsc;
-use tokio::task::JoinSet;
+use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{Instrument, error, info, warn};
 use uuid::Uuid;
 
 use crate::duration::duration_ms as saturated_duration_ms;
@@ -80,7 +83,7 @@ use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 use crate::runner_process_identity::RunnerProcessIdentity;
-use crate::status::{StatusResult, StatusTracker, remove_stale_status_file};
+use crate::status::{StatusTracker, remove_stale_status_file};
 use crate::workspace_image_cache::{
     WorkspaceCacheChange, WorkspaceCacheWatcher, WorkspaceImageCache,
 };
@@ -171,20 +174,25 @@ async fn sleep_until_optional_instant(deadline: Option<Instant>) {
     }
 }
 
-enum RoutineHeartbeatTrigger {
+enum MaintenanceTrigger {
     Interval(tokio::time::Interval),
     #[cfg(test)]
     Manual(mpsc::UnboundedReceiver<()>),
 }
 
-impl RoutineHeartbeatTrigger {
-    fn interval() -> Self {
-        let mut interval = tokio::time::interval_at(
-            tokio::time::Instant::now() + HEARTBEAT_PERIOD,
-            HEARTBEAT_PERIOD,
-        );
+impl MaintenanceTrigger {
+    fn interval(period: Duration) -> Self {
+        let mut interval = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         Self::Interval(interval)
+    }
+
+    fn reset(&mut self) {
+        match self {
+            Self::Interval(interval) => interval.reset(),
+            #[cfg(test)]
+            Self::Manual(_) => {}
+        }
     }
 
     async fn tick(&mut self) {
@@ -197,7 +205,7 @@ impl RoutineHeartbeatTrigger {
                 receiver
                     .recv()
                     .await
-                    .expect("manual routine heartbeat sender should remain open");
+                    .expect("manual maintenance sender should remain open");
             }
         }
     }
@@ -230,30 +238,40 @@ async fn next_workspace_cache_change(
     }
 }
 
-type WorkspaceCacheGcFuture = BoxFuture<'static, RunnerResult<Option<u64>>>;
-
-fn workspace_cache_gc_future(cache: WorkspaceImageCache) -> WorkspaceCacheGcFuture {
-    Box::pin(async move { cache.try_routine_gc(WORKSPACE_CACHE_GC_PERIOD).await })
+// Maintenance tasks are joined during teardown, not aborted: filesystem work
+// may continue after its async future is dropped. If the reactor itself is
+// cancelled, these tasks retain their locks until their work completes.
+fn workspace_cache_gc_task(cache: WorkspaceImageCache) -> JoinHandle<()> {
+    tokio::spawn(
+        async move {
+            match cache.try_routine_gc(WORKSPACE_CACHE_GC_PERIOD).await {
+                Ok(Some(freed_bytes)) if freed_bytes > 0 => {
+                    info!(freed_bytes, "periodic workspace image cache GC completed");
+                }
+                Ok(Some(_) | None) => {}
+                Err(error) => warn!(%error, "periodic workspace image cache GC failed"),
+            }
+        }
+        .in_current_span(),
+    )
 }
 
-async fn next_workspace_cache_gc(
-    future: &mut Option<WorkspaceCacheGcFuture>,
-) -> RunnerResult<Option<u64>> {
-    match future {
-        Some(future) => future.await,
-        None => std::future::pending().await,
-    }
+fn status_retry_task(status: Arc<StatusTracker>) -> JoinHandle<()> {
+    tokio::spawn(
+        async move {
+            if let Err(error) = status.retry_unpublished_snapshot().await {
+                warn!(%error, "failed to retry unpublished runner status");
+            }
+        }
+        .in_current_span(),
+    )
 }
 
-type StatusRetryFuture = BoxFuture<'static, StatusResult<()>>;
-
-fn status_retry_future(status: Arc<StatusTracker>) -> StatusRetryFuture {
-    Box::pin(async move { status.retry_unpublished_snapshot().await })
-}
-
-async fn next_status_retry(future: &mut Option<StatusRetryFuture>) -> StatusResult<()> {
-    match future {
-        Some(future) => future.await,
+async fn next_maintenance_task(task: &mut Option<JoinHandle<()>>, name: &str) -> RunnerResult<()> {
+    match task {
+        Some(task) => task
+            .await
+            .map_err(|error| RunnerError::Internal(format!("{name} task failed: {error}"))),
         None => std::future::pending().await,
     }
 }
@@ -972,6 +990,7 @@ async fn run_start_with_home(
             before_initial_workspace_cache_scan: None,
             after_initial_workspace_cache_scan: None,
             manual_routine_heartbeat_rx: None,
+            manual_workspace_cache_gc_rx: None,
         },
     };
 
@@ -1108,6 +1127,7 @@ struct RunTestHooks {
     before_initial_workspace_cache_scan: Option<StartLoopTestGate>,
     after_initial_workspace_cache_scan: Option<StartLoopTestGate>,
     manual_routine_heartbeat_rx: Option<mpsc::UnboundedReceiver<()>>,
+    manual_workspace_cache_gc_rx: Option<mpsc::UnboundedReceiver<()>>,
 }
 
 enum SignalSource {
@@ -1127,6 +1147,7 @@ enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
     RoutineHeartbeatRequested { mode: RunnerMode },
     WorkspaceCacheChangeObserved,
+    MaintenanceDrainEntered,
     DestroyTasksDrainEntered,
     DestroyTasksDrainCompleted,
     FinalizingCapacityWaitEntered { run_id: RunId },
@@ -1839,11 +1860,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // -----------------------------------------------------------------------
     #[cfg(test)]
     let mut heartbeat_tick = match test_hooks.manual_routine_heartbeat_rx.take() {
-        Some(receiver) => RoutineHeartbeatTrigger::Manual(receiver),
-        None => RoutineHeartbeatTrigger::interval(),
+        Some(receiver) => MaintenanceTrigger::Manual(receiver),
+        None => MaintenanceTrigger::interval(HEARTBEAT_PERIOD),
     };
     #[cfg(not(test))]
-    let mut heartbeat_tick = RoutineHeartbeatTrigger::interval();
+    let mut heartbeat_tick = MaintenanceTrigger::interval(HEARTBEAT_PERIOD);
 
     // -----------------------------------------------------------------------
     // Main loop
@@ -1883,7 +1904,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         group: &runner.group,
         profiles: &runner.profiles,
         budget: &capacity.budget,
-        provider: &*provider_state.provider,
+        provider: Arc::clone(&provider_state.provider),
         workspace_cache: exec_config.workspace_cache.clone(),
         active_runs: &active_runs,
         workspace_cache_snapshot: workspace_cache_snapshot.clone(),
@@ -1983,19 +2004,21 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         Duration::from_secs(1),
     );
     blank_pool_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    let mut workspace_cache_gc_tick = tokio::time::interval_at(
-        tokio::time::Instant::now() + WORKSPACE_CACHE_GC_PERIOD,
-        WORKSPACE_CACHE_GC_PERIOD,
-    );
-    workspace_cache_gc_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    #[cfg(test)]
+    let mut workspace_cache_gc_tick = match test_hooks.manual_workspace_cache_gc_rx.take() {
+        Some(receiver) => MaintenanceTrigger::Manual(receiver),
+        None => MaintenanceTrigger::interval(WORKSPACE_CACHE_GC_PERIOD),
+    };
+    #[cfg(not(test))]
+    let mut workspace_cache_gc_tick = MaintenanceTrigger::interval(WORKSPACE_CACHE_GC_PERIOD);
     let mut workspace_cache_reconciliation_tick = tokio::time::interval_at(
         tokio::time::Instant::now() + WORKSPACE_CACHE_RECONCILIATION_INITIAL_DELAY,
         WORKSPACE_CACHE_RECONCILIATION_PERIOD,
     );
     workspace_cache_reconciliation_tick
         .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    let mut workspace_cache_gc_fut = None;
-    let mut status_retry_fut = None;
+    let mut workspace_cache_gc_handle = None;
+    let mut status_retry_handle = None;
     let mut draining_idle_pool_drained = false;
     let mut pending_finalizing_candidate = None;
     let mut terminal_error = None;
@@ -2047,7 +2070,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     if transitioned {
                         // Live observability: fire an immediate "stopping"
                         // heartbeat before teardown removes the runner.
-                        heartbeat.flush(RunnerMode::Stopping).await?;
+                        if let Err(error) = heartbeat.flush(RunnerMode::Stopping).await {
+                            terminal_error = Some(error);
+                            break;
+                        }
                     }
                     continue;
                 }
@@ -2197,13 +2223,20 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     heartbeat.request(live_mode)?;
                 }
             }
-            // The active heartbeat future is pinned in the controller so
-            // network and state-refresh waits yield to every other reactor
-            // branch instead of being awaited by a trigger handler.
+            // Observe independently scheduled heartbeat work without cancelling
+            // it when another branch wins or waits for a shared resource.
             result = heartbeat.wait_for_send(), if heartbeat_sending => {
-                result?;
                 let live_mode = *mode_rx.borrow();
-                heartbeat.finish_send(live_mode)?;
+                if let Err(error) = result.and_then(|()| heartbeat.finish_send(live_mode)) {
+                    handle_stopping_signal(
+                        "heartbeat task failure",
+                        &provider_state.cancel,
+                        &provider_state.cancel_tokens,
+                        &lifecycle,
+                    ).await;
+                    terminal_error = Some(error);
+                    break;
+                }
             }
             (watcher, result) = next_workspace_cache_change(&mut workspace_cache_change_fut) => {
                 match result {
@@ -2238,32 +2271,38 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     )?;
                 }
             }
-            result = next_workspace_cache_gc(&mut workspace_cache_gc_fut) => {
-                workspace_cache_gc_fut = None;
+            result = next_maintenance_task(&mut workspace_cache_gc_handle, "workspace cache GC") => {
+                workspace_cache_gc_handle = None;
                 workspace_cache_gc_tick.reset();
-                match result {
-                    Ok(Some(freed_bytes)) if freed_bytes > 0 => info!(
-                        freed_bytes,
-                        "periodic workspace image cache GC completed"
-                    ),
-                    Ok(Some(_) | None) => {}
-                    Err(error) => warn!(
-                        error = %error,
-                        "periodic workspace image cache GC failed"
-                    ),
+                if let Err(error) = result {
+                    handle_stopping_signal(
+                        "workspace cache GC task failure",
+                        &provider_state.cancel,
+                        &provider_state.cancel_tokens,
+                        &lifecycle,
+                    ).await;
+                    terminal_error = Some(error);
+                    break;
                 }
             }
-            result = next_status_retry(&mut status_retry_fut) => {
-                status_retry_fut = None;
+            result = next_maintenance_task(&mut status_retry_handle, "status retry") => {
+                status_retry_handle = None;
                 if let Err(error) = result {
-                    warn!(%error, "failed to retry unpublished runner status");
+                    handle_stopping_signal(
+                        "status retry task failure",
+                        &provider_state.cancel,
+                        &provider_state.cancel_tokens,
+                        &lifecycle,
+                    ).await;
+                    terminal_error = Some(error);
+                    break;
                 }
             }
             _ = workspace_cache_gc_tick.tick() => {
-                if workspace_cache_gc_fut.is_none()
+                if workspace_cache_gc_handle.is_none()
                     && let Some(cache) = exec_config.workspace_cache.clone()
                 {
-                    workspace_cache_gc_fut = Some(workspace_cache_gc_future(cache));
+                    workspace_cache_gc_handle = Some(workspace_cache_gc_task(cache));
                 }
             }
             // Mode changes (signals)
@@ -2359,8 +2398,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             _ = heartbeat_tick.tick() => {
                 let live_mode = *mode_rx.borrow();
                 heartbeat.request(live_mode)?;
-                if status_retry_fut.is_none() {
-                    status_retry_fut = Some(status_retry_future(Arc::clone(&shared.status)));
+                if status_retry_handle.is_none() {
+                    status_retry_handle = Some(status_retry_task(Arc::clone(&shared.status)));
                 }
                 #[cfg(test)]
                 test_hooks
@@ -2448,7 +2487,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // -----------------------------------------------------------------------
     // Shutdown — drain idle pool, release discovery resources, then drain running jobs
     // -----------------------------------------------------------------------
-    drop(workspace_cache_gc_fut);
     let teardown = TeardownTimer::start();
     memory_prefetch.cancel();
     teardown.event("memory_prefetch_cancelled");
@@ -2458,14 +2496,31 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     teardown.phase_complete("blank_pool_shutdown", phase);
 
     let phase = teardown.phase_start("heartbeat_drain");
-    heartbeat.drain().await;
-    if let Some(retry) = status_retry_fut.take()
-        && let Err(error) = retry.await
-    {
-        warn!(%error, "failed to finish runner status retry during teardown");
+    if let Err(error) = heartbeat.drain().await {
+        error!(%error, "failed to drain heartbeat task");
+        terminal_error.get_or_insert(error);
     }
     let final_heartbeat_sequence = heartbeat.into_next_snapshot_sequence();
     teardown.phase_complete("heartbeat_drain", phase);
+
+    let phase = teardown.phase_start("maintenance_drain");
+    #[cfg(test)]
+    test_hooks
+        .test_observer
+        .record(StartLoopEvent::MaintenanceDrainEntered);
+    for (name, task) in [
+        ("status retry", &mut status_retry_handle),
+        ("workspace cache GC", &mut workspace_cache_gc_handle),
+    ] {
+        if task.is_some()
+            && let Err(error) = next_maintenance_task(task, name).await
+        {
+            error!(%error, "failed to drain maintenance task");
+            terminal_error.get_or_insert(error);
+        }
+        *task = None;
+    }
+    teardown.phase_complete("maintenance_drain", phase);
 
     // Drop the pinned discover future before provider shutdown so any
     // provider-local discovery resources are released first. This also keeps

--- a/crates/runner/src/cmd/start/tests/main_loop/mod.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/mod.rs
@@ -3,6 +3,7 @@ mod drain_resume;
 mod exact_reuse_speculation;
 mod heartbeat;
 mod job_flow;
+mod shared_resource_progress;
 mod shutdown;
 mod startup;
 mod telemetry;

--- a/crates/runner/src/cmd/start/tests/main_loop/shared_resource_progress.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/shared_resource_progress.rs
@@ -1,0 +1,340 @@
+use std::future::{Future, poll_fn};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Poll;
+
+use super::super::super::*;
+use super::super::support::{
+    MockRunEnv, minimal_context, mock_run_config, push_job, test_profiles, wait_discover_entered,
+};
+
+async fn assert_stopped_status(env: &MockRunEnv) {
+    // run_start owns the final channel transition; run() publishes the final
+    // disk snapshot after its owned tasks and resources have been drained.
+    assert_eq!(env.lifecycle.current_mode(), RunnerMode::Stopping);
+    let persisted: serde_json::Value = serde_json::from_str(
+        &tokio::fs::read_to_string(env._temp_dir.path().join("status.json"))
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(persisted["mode"], "stopped");
+}
+
+// Drive a real reactor until its currently ready branches have been consumed.
+// Keeping the outer future pinned lets these tests force the historical schedule:
+// a retained waiter queues, another branch wins, and inline work awaits its lock.
+async fn drive_ready_reactor(reactor: Pin<&mut impl Future<Output = RunnerResult<()>>>) {
+    let mut reactor = std::pin::pin!(tokio::task::unconstrained(reactor));
+    poll_fn(|cx| {
+        assert!(reactor.as_mut().poll(cx).is_pending());
+        Poll::Ready(())
+    })
+    .await;
+    tokio::task::yield_now().await;
+}
+
+#[tokio::test]
+async fn queued_heartbeat_allows_budget_pressure_and_drain_to_progress() {
+    let (mut config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let (trigger, receiver) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_routine_heartbeat_rx = Some(receiver);
+    let mut reactor = Box::pin(run(config));
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited during startup: {result:?}"),
+        () = wait_discover_entered(&env, Duration::from_secs(5)) => {}
+    }
+
+    let holder = env.idle_pool.lock().await;
+    trigger.send(()).unwrap();
+    drive_ready_reactor(reactor.as_mut()).await;
+    let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+    trigger.send(()).unwrap();
+    drive_ready_reactor(reactor.as_mut()).await;
+    drop(holder);
+
+    // A concurrent finalizer must be able to acquire the pool even while the
+    // reactor is waiting for admission capacity.
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited while running: {result:?}"),
+        guard = tokio::time::timeout(Duration::from_secs(2), env.idle_pool.lock()) => {
+            drop(guard.expect("pool waiter must progress after the holder releases"));
+        }
+    }
+    assert!(env.handle.heartbeat_count() > 0);
+    drop(lease);
+    env.drain();
+    tokio::time::timeout(Duration::from_secs(5), reactor)
+        .await
+        .expect("budget-pressure reactor must drain")
+        .unwrap();
+    assert_stopped_status(&env).await;
+}
+
+#[tokio::test]
+async fn queued_heartbeat_allows_fresh_admission_to_progress() {
+    let (mut config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let (trigger, receiver) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_routine_heartbeat_rx = Some(receiver);
+    let mut reactor = Box::pin(run(config));
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited during startup: {result:?}"),
+        () = wait_discover_entered(&env, Duration::from_secs(5)) => {}
+    }
+
+    let holder = env.idle_pool.lock().await;
+    trigger.send(()).unwrap();
+    drive_ready_reactor(reactor.as_mut()).await;
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    drive_ready_reactor(reactor.as_mut()).await;
+    drop(holder);
+
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited before job completion: {result:?}"),
+        completed = env.handle.wait_completion(run_id, Duration::from_secs(5)) => {
+            assert!(completed.is_some(), "fresh admission must complete after pool contention ends");
+        }
+    }
+    assert_eq!(env.handle.claim_candidates().len(), 1);
+    env.drain();
+    tokio::time::timeout(Duration::from_secs(5), reactor)
+        .await
+        .expect("reactor must drain after fresh admission")
+        .unwrap();
+}
+
+#[tokio::test]
+async fn queued_heartbeat_allows_zero_job_drain_to_progress() {
+    let (mut config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let (trigger, receiver) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_routine_heartbeat_rx = Some(receiver);
+    let mut reactor = Box::pin(run(config));
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited during startup: {result:?}"),
+        () = wait_discover_entered(&env, Duration::from_secs(5)) => {}
+    }
+
+    let holder = env.idle_pool.lock().await;
+    trigger.send(()).unwrap();
+    drive_ready_reactor(reactor.as_mut()).await;
+    env.drain();
+    drive_ready_reactor(reactor.as_mut()).await;
+    drop(holder);
+
+    tokio::time::timeout(Duration::from_secs(5), reactor)
+        .await
+        .expect("zero-job drain must finish after pool contention ends")
+        .unwrap();
+    assert_stopped_status(&env).await;
+}
+
+#[tokio::test]
+async fn queued_status_retry_allows_drain_without_unpublished_state() {
+    let (mut config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let status = Arc::clone(&config.shared.status);
+    let (trigger, receiver) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_routine_heartbeat_rx = Some(receiver);
+    let mut reactor = Box::pin(run(config));
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited during startup: {result:?}"),
+        () = wait_discover_entered(&env, Duration::from_secs(5)) => {}
+    }
+
+    let holder = status.hold_state_for_test().await;
+    trigger.send(()).unwrap();
+    drive_ready_reactor(reactor.as_mut()).await;
+    env.drain();
+    drive_ready_reactor(reactor.as_mut()).await;
+    drop(holder);
+
+    tokio::time::timeout(Duration::from_secs(5), reactor)
+        .await
+        .expect("status retry must not strand lifecycle publication")
+        .unwrap();
+    let persisted: serde_json::Value = serde_json::from_str(
+        &tokio::fs::read_to_string(env._temp_dir.path().join("status.json"))
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(persisted["mode"], "stopped");
+}
+
+#[tokio::test]
+async fn queued_status_persistence_allows_newer_drain_snapshot_to_publish() {
+    let (mut config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let started = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Semaphore::new(0));
+    let path = env._temp_dir.path().join("status.json");
+    let status = Arc::new(StatusTracker::new_with_atomic_write_gate(
+        path.clone(),
+        3, // Initial and Running snapshots precede this ordered external write.
+        Arc::clone(&started),
+        Arc::clone(&release),
+    ));
+    config.shared.status = Arc::clone(&status);
+    let (trigger, receiver) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_routine_heartbeat_rx = Some(receiver);
+    let mut reactor = Box::pin(run(config));
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited during startup: {result:?}"),
+        () = wait_discover_entered(&env, Duration::from_secs(5)) => {}
+    }
+
+    let writer = tokio::spawn(async move { status.set_mode(RunnerMode::Running).await });
+    tokio::time::timeout(Duration::from_secs(2), started.notified())
+        .await
+        .expect("external status writer must reach the persistence gate");
+    trigger.send(()).unwrap();
+    drive_ready_reactor(reactor.as_mut()).await;
+    env.drain();
+    drive_ready_reactor(reactor.as_mut()).await;
+    release.add_permits(1);
+
+    // Less than the persistence timeout: progress cannot rely on the queued
+    // retry timing out and forcing the runner into error teardown.
+    tokio::time::timeout(Duration::from_secs(2), reactor)
+        .await
+        .expect("queued persistence must progress after its predecessor completes")
+        .unwrap();
+    writer.await.unwrap().unwrap();
+    let persisted: serde_json::Value =
+        serde_json::from_str(&tokio::fs::read_to_string(path).await.unwrap()).unwrap();
+    assert_eq!(persisted["mode"], "stopped");
+}
+
+#[tokio::test]
+async fn heartbeat_task_panic_stops_claiming_and_runs_common_teardown() {
+    let (mut config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let (trigger, receiver) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_routine_heartbeat_rx = Some(receiver);
+    let mut reactor = Box::pin(run(config));
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited during startup: {result:?}"),
+        () = wait_discover_entered(&env, Duration::from_secs(5)) => {}
+    }
+    env.handle.panic_next_heartbeat();
+    trigger.send(()).unwrap();
+    let error = tokio::time::timeout(Duration::from_secs(5), reactor)
+        .await
+        .expect("heartbeat owner failure must finish teardown")
+        .unwrap_err();
+    assert!(error.to_string().contains("heartbeat task failed"));
+    assert!(env.cancel.is_cancelled());
+    assert_stopped_status(&env).await;
+    assert!(env.handle.claim_candidates().is_empty());
+    let heartbeats = env.handle.heartbeats.lock().unwrap();
+    assert_eq!(heartbeats.last().unwrap().mode, "stopping");
+}
+
+#[tokio::test]
+async fn routine_gc_progresses_while_the_reactor_waits_for_the_idle_pool() {
+    let (mut config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Semaphore::new(0));
+    let paths = RunnerPaths::new(env._temp_dir.path().join("cache-runner"));
+    let capacity_path =
+        crate::paths::workspace_image_cache_capacity_lock_path(&paths.base_dir().join("locks"));
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(
+        WorkspaceImageCache::new(paths)
+            .with_routine_gc_test_gate(Arc::clone(&entered), Arc::clone(&release)),
+    );
+    let (trigger, receiver) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_workspace_cache_gc_rx = Some(receiver);
+    let mut reactor = Box::pin(run(config));
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited during startup: {result:?}"),
+        () = wait_discover_entered(&env, Duration::from_secs(5)) => {}
+    }
+    trigger.send(()).unwrap();
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited before GC: {result:?}"),
+        result = tokio::time::timeout(Duration::from_secs(2), entered.notified()) => {
+            result.expect("routine GC must acquire the capacity lock");
+        }
+    }
+    let pool_holder = env.idle_pool.lock().await;
+    env.drain();
+    drive_ready_reactor(reactor.as_mut()).await;
+    release.add_permits(1);
+
+    // Deliberately do not poll the reactor. The GC owner must complete real
+    // filesystem work and retain the capacity lock through its completion marker.
+    let capacity_holder = tokio::time::timeout(
+        Duration::from_secs(2),
+        crate::lock::acquire(capacity_path.clone()),
+    )
+    .await
+    .expect("routine GC must progress independently")
+    .unwrap();
+    assert!(capacity_holder.metadata().unwrap().len() > 0);
+    drop(capacity_holder);
+    drop(pool_holder);
+    tokio::time::timeout(Duration::from_secs(5), reactor)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_stopped_status(&env).await;
+}
+
+#[tokio::test]
+async fn teardown_joins_routine_gc_before_releasing_its_capacity_lock() {
+    let (mut config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Semaphore::new(0));
+    let paths = RunnerPaths::new(env._temp_dir.path().join("cache-runner"));
+    let capacity_path =
+        crate::paths::workspace_image_cache_capacity_lock_path(&paths.base_dir().join("locks"));
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(
+        WorkspaceImageCache::new(paths)
+            .with_routine_gc_test_gate(Arc::clone(&entered), Arc::clone(&release)),
+    );
+    let (trigger, receiver) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_workspace_cache_gc_rx = Some(receiver);
+    let mut reactor = Box::pin(run(config));
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited during startup: {result:?}"),
+        () = wait_discover_entered(&env, Duration::from_secs(5)) => {}
+    }
+    trigger.send(()).unwrap();
+    tokio::select! {
+        result = &mut reactor => panic!("reactor exited before GC: {result:?}"),
+        result = tokio::time::timeout(Duration::from_secs(2), entered.notified()) => {
+            result.expect("routine GC must reach the lock-held gate");
+        }
+    }
+    // Repeated ticks cannot start a second GC while this owner is held.
+    trigger.send(()).unwrap();
+    trigger.send(()).unwrap();
+    drive_ready_reactor(reactor.as_mut()).await;
+    env.trigger_stopping().await;
+    tokio::select! {
+        result = &mut reactor => panic!("teardown abandoned unfinished GC: {result:?}"),
+        () = env.start_observer.wait_for(
+            Duration::from_secs(2),
+            "maintenance drain",
+            |event| matches!(event, StartLoopEvent::MaintenanceDrainEntered).then_some(()),
+        ) => {}
+    }
+    drive_ready_reactor(reactor.as_mut()).await;
+    assert!(matches!(
+        crate::lock::try_acquire_or_busy(capacity_path.clone())
+            .await
+            .unwrap(),
+        crate::lock::TryLock::Busy
+    ));
+    release.add_permits(1);
+    tokio::time::timeout(Duration::from_secs(5), reactor)
+        .await
+        .expect("GC completion must unblock teardown")
+        .unwrap();
+    let capacity_holder = crate::lock::acquire(capacity_path).await.unwrap();
+    assert!(capacity_holder.metadata().unwrap().len() > 0);
+    assert_stopped_status(&env).await;
+}

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -303,6 +303,7 @@ fn build_mock_run_config_with_runtime(
             before_initial_workspace_cache_scan: None,
             after_initial_workspace_cache_scan: None,
             manual_routine_heartbeat_rx: None,
+            manual_workspace_cache_gc_rx: None,
         },
     };
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -393,7 +393,7 @@ impl ApiProvider {
             if let Some(pruned) = outcome.pruned {
                 Self::log_direct_candidate_pruned("pop", pruned);
                 if outcome.candidate.is_none() {
-                    self.poll_wakeups.request_immediate_poll().await;
+                    self.poll_wakeups.request_immediate_poll();
                 }
             }
             let candidate = outcome.candidate?;
@@ -407,7 +407,7 @@ impl ApiProvider {
                 retry_after_ms = duration_ms(retry_after),
                 "ably: direct candidate skipped during claim cooldown"
             );
-            self.poll_wakeups.request_immediate_poll().await;
+            self.poll_wakeups.request_immediate_poll();
             if self.cancel.is_cancelled() {
                 return None;
             }
@@ -417,13 +417,11 @@ impl ApiProvider {
     async fn schedule_claim_retry_after_poll(&self, polled_with_exclusions: bool) {
         let snapshot = self.claim_cooldowns.snapshot().await;
         if let Some(retry_after) = snapshot.retry_after {
-            self.poll_wakeups
-                .request_deferred_poll_after(retry_after)
-                .await;
+            self.poll_wakeups.request_deferred_poll_after(retry_after);
         } else if polled_with_exclusions {
             // Every exclusion expired while the HTTP poll was in flight.
             // Re-poll once without the stale exclusions instead of waiting for the normal cadence.
-            self.poll_wakeups.request_immediate_poll().await;
+            self.poll_wakeups.request_immediate_poll();
         }
     }
 
@@ -450,7 +448,7 @@ impl ApiProvider {
                     cooldown_capacity = CLAIM_COOLDOWN_CAPACITY,
                     "claim failed, candidate cooling down"
                 );
-                self.poll_wakeups.request_immediate_poll().await;
+                self.poll_wakeups.request_immediate_poll();
             }
             ClaimCooldownRecord::Saturated { active_count } => {
                 self.claim_cooldowns.block_all(POLL_FAST).await;
@@ -467,9 +465,7 @@ impl ApiProvider {
                     cooldown_capacity = CLAIM_COOLDOWN_CAPACITY,
                     "claim failed, candidate cooldown capacity reached"
                 );
-                self.poll_wakeups
-                    .request_deferred_poll_after(POLL_FAST)
-                    .await;
+                self.poll_wakeups.request_deferred_poll_after(POLL_FAST);
             }
         }
     }
@@ -690,7 +686,7 @@ impl JobProvider for ApiProvider {
                 }
                 direct = self.wait_for_direct_candidate() => {
                     if let Some(direct) = direct {
-                        self.poll_wakeups.request_immediate_poll().await;
+                        self.poll_wakeups.request_immediate_poll();
                         let run_id = direct.run_id();
                         let profile = direct.profile_name().to_owned();
                         info!(
@@ -724,9 +720,11 @@ impl JobProvider for ApiProvider {
                     http_request_elapsed,
                 }) => {
                     if let Some(retry_after) = self.claim_cooldowns.remaining(job.run_id).await {
-                        self.poll_wakeups
-                            .record_poll_result(due, PollOutcome::Empty, POLL_WAKEUP_RETRY)
-                            .await;
+                        self.poll_wakeups.record_poll_result(
+                            due,
+                            PollOutcome::Empty,
+                            POLL_WAKEUP_RETRY,
+                        );
                         warn!(
                             run_id = %job.run_id,
                             retry_after_ms = duration_ms(retry_after),
@@ -736,10 +734,11 @@ impl JobProvider for ApiProvider {
                         self.schedule_claim_retry_after_poll(true).await;
                         continue;
                     }
-                    let record = self
-                        .poll_wakeups
-                        .record_poll_result(due, PollOutcome::JobFound, POLL_WAKEUP_RETRY)
-                        .await;
+                    let record = self.poll_wakeups.record_poll_result(
+                        due,
+                        PollOutcome::JobFound,
+                        POLL_WAKEUP_RETRY,
+                    );
                     if record.defer_job_return() {
                         info!(
                             run_id = %job.run_id,
@@ -779,16 +778,20 @@ impl JobProvider for ApiProvider {
                     return Some(candidate);
                 }
                 Ok(PollApiResult { job: None, .. }) => {
-                    self.poll_wakeups
-                        .record_poll_result(due, PollOutcome::Empty, POLL_WAKEUP_RETRY)
-                        .await;
+                    self.poll_wakeups.record_poll_result(
+                        due,
+                        PollOutcome::Empty,
+                        POLL_WAKEUP_RETRY,
+                    );
                     self.schedule_claim_retry_after_poll(!excluded_run_ids.is_empty())
                         .await;
                 }
                 Err(e) => {
-                    self.poll_wakeups
-                        .record_poll_result(due, PollOutcome::Failure, POLL_WAKEUP_RETRY)
-                        .await;
+                    self.poll_wakeups.record_poll_result(
+                        due,
+                        PollOutcome::Failure,
+                        POLL_WAKEUP_RETRY,
+                    );
                     self.record_poll_failure_at(reason, &e, Instant::now())
                         .await;
                 }
@@ -883,7 +886,7 @@ impl JobProvider for ApiProvider {
             Ok(None) => {
                 self.claim_cooldowns.remove(run_id).await;
                 info!(run_id = %run_id, "job unavailable, skipping");
-                self.poll_wakeups.request_immediate_poll().await;
+                self.poll_wakeups.request_immediate_poll();
                 None
             }
             Err(e) => {
@@ -908,9 +911,7 @@ impl JobProvider for ApiProvider {
     }
 
     async fn defer_poll_until(&self, deadline: Instant) {
-        self.poll_wakeups
-            .request_deferred_poll_until(deadline)
-            .await;
+        self.poll_wakeups.request_deferred_poll_until(deadline);
     }
 
     async fn shutdown(&self) {
@@ -3555,7 +3556,7 @@ mod tests {
                 },
                 async {
                     server.next_request("status poll request").await;
-                    wakeups.request_immediate_poll().await;
+                    wakeups.request_immediate_poll();
                     release_status_tx.send(()).unwrap();
 
                     server.next_request("empty poll request").await;
@@ -3567,7 +3568,7 @@ mod tests {
                         assert_eq!(episode.started_at, started_at);
                         assert_eq!(episode.consecutive_failures, 1);
                     }
-                    wakeups.request_immediate_poll().await;
+                    wakeups.request_immediate_poll();
                     release_empty_tx.send(()).unwrap();
 
                     server.next_request("job poll request after recovery").await;
@@ -3843,9 +3844,7 @@ mod tests {
             .wait_for_poll_due(&CancellationToken::new(), POLL_SLOW, POLL_FAST)
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY)
-            .await;
+        wakeups.record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY);
         let provider = api_provider_for_test(
             server.base_url(),
             CancellationToken::new(),
@@ -3923,9 +3922,7 @@ mod tests {
             .wait_for_poll_due(&CancellationToken::new(), POLL_SLOW, POLL_FAST)
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY)
-            .await;
+        wakeups.record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY);
         let provider = api_provider_for_test(
             server.base_url(),
             CancellationToken::new(),
@@ -4004,9 +4001,7 @@ mod tests {
             .wait_for_poll_due(&CancellationToken::new(), POLL_SLOW, POLL_FAST)
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY)
-            .await;
+        wakeups.record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY);
         let provider = api_provider_for_test(
             server.base_url(),
             CancellationToken::new(),
@@ -4053,9 +4048,7 @@ mod tests {
             .wait_for_poll_due(&CancellationToken::new(), POLL_SLOW, POLL_FAST)
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY)
-            .await;
+        wakeups.record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY);
         let provider =
             api_provider_for_test(api_url, CancellationToken::new(), Arc::clone(&wakeups));
         push_direct_candidate_for_test(
@@ -4134,9 +4127,7 @@ mod tests {
             .wait_for_poll_due(&CancellationToken::new(), POLL_SLOW, POLL_FAST)
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY)
-            .await;
+        wakeups.record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY);
         let cancel = CancellationToken::new();
         let provider = api_provider_for_test(api_url, cancel.clone(), Arc::clone(&wakeups));
         push_direct_candidate_for_test(
@@ -4277,7 +4268,6 @@ mod tests {
         assert_eq!(event_field(event, "active_cooldowns"), "1");
         let deferred_poll_at = wakeups
             .snapshot()
-            .await
             .deferred_poll_at
             .expect("saturation should defer HTTP polling");
         assert!(
@@ -4405,9 +4395,7 @@ mod tests {
         let discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
 
         server.next_request("first deferred poll request").await;
-        wakeups
-            .request_deferred_poll_after_for_test(Duration::ZERO)
-            .await;
+        wakeups.request_deferred_poll_after_for_test(Duration::ZERO);
         release_first_tx.send(()).unwrap();
 
         let discovered = tokio::time::timeout(Duration::from_secs(1), discover_task)

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -16,11 +16,11 @@
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
 use std::time::{Duration, Instant as StdInstant};
 
 use futures_util::{StreamExt, stream::FuturesUnordered};
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -107,7 +107,9 @@ impl PollRecord {
 /// - Generations prevent an HTTP poll result from clearing wakeups that arrived
 ///   after that poll started.
 pub(super) struct PollWakeups {
-    inner: Mutex<PollWakeupsInner>,
+    // State-only critical sections must not enqueue an async waiter retained
+    // inside discover(): an inline reactor callback also updates this state.
+    inner: StdMutex<PollWakeupsInner>,
     notify: Notify,
 }
 
@@ -144,7 +146,7 @@ struct ScheduledPoll {
 impl PollWakeups {
     pub(super) fn new(ably_connected: bool) -> Self {
         Self {
-            inner: Mutex::new(PollWakeupsInner {
+            inner: StdMutex::new(PollWakeupsInner {
                 ably_connected,
                 poll_now: true,
                 deferred_poll_at: None,
@@ -156,41 +158,43 @@ impl PollWakeups {
         }
     }
 
-    pub(super) async fn mark_ably_connected(&self) {
-        self.inner.lock().await.ably_connected = true;
+    fn lock_inner(&self) -> MutexGuard<'_, PollWakeupsInner> {
+        self.inner.lock().unwrap_or_else(|error| error.into_inner())
+    }
+
+    pub(super) fn mark_ably_connected(&self) {
+        self.lock_inner().ably_connected = true;
         self.notify.notify_waiters();
     }
 
-    pub(super) async fn mark_ably_disconnected(&self) {
-        self.inner.lock().await.ably_connected = false;
+    pub(super) fn mark_ably_disconnected(&self) {
+        self.lock_inner().ably_connected = false;
         self.notify.notify_waiters();
     }
 
-    pub(super) async fn request_immediate_poll(&self) {
-        let mut inner = self.inner.lock().await;
+    pub(super) fn request_immediate_poll(&self) {
+        let mut inner = self.lock_inner();
         inner.poll_now = true;
         inner.bump_generation();
         self.notify.notify_waiters();
     }
 
-    pub(super) async fn request_deferred_poll_after(&self, delay: Duration) {
+    pub(super) fn request_deferred_poll_after(&self, delay: Duration) {
         let now = tokio::time::Instant::now();
-        self.request_deferred_poll_capped_at(now + delay, now + DEFERRED_POLL_MAX)
-            .await;
+        self.request_deferred_poll_capped_at(now + delay, now + DEFERRED_POLL_MAX);
     }
 
-    pub(super) async fn request_deferred_poll_until(&self, deadline: StdInstant) {
+    pub(super) fn request_deferred_poll_until(&self, deadline: StdInstant) {
         let now = tokio::time::Instant::now();
-        self.request_deferred_poll_capped_at(deadline.into(), now + DEFERRED_POLL_MAX)
-            .await;
+        self.request_deferred_poll_capped_at(deadline.into(), now + DEFERRED_POLL_MAX);
     }
 
-    async fn request_deferred_poll_capped_at(
+    fn request_deferred_poll_capped_at(
         &self,
         at: tokio::time::Instant,
         cap_at: tokio::time::Instant,
     ) {
-        let mut inner = self.inner.lock().await;
+        let mut inner = self.lock_inner();
         let cap_at = *inner.deferred_poll_cap_at.get_or_insert(cap_at);
         let at = at.min(cap_at);
         if inner.deferred_poll_at.is_none_or(|existing| at > existing) {
@@ -202,23 +206,23 @@ impl PollWakeups {
     }
 
     #[cfg(test)]
-    async fn request_deferred_poll_at(&self, at: tokio::time::Instant) {
-        self.request_deferred_poll_capped_at(at, at).await;
+    fn request_deferred_poll_at(&self, at: tokio::time::Instant) {
+        self.request_deferred_poll_capped_at(at, at);
     }
 
     #[cfg(test)]
-    pub(super) async fn request_deferred_poll_after_for_test(&self, delay: Duration) {
-        self.request_deferred_poll_after(delay).await;
+    pub(super) fn request_deferred_poll_after_for_test(&self, delay: Duration) {
+        self.request_deferred_poll_after(delay);
     }
 
-    pub(super) async fn record_poll_result(
+    pub(super) fn record_poll_result(
         &self,
         due: PollDue,
         outcome: PollOutcome,
         wakeup_retry_delay: Duration,
     ) -> PollRecord {
         let mut should_notify = false;
-        let mut inner = self.inner.lock().await;
+        let mut inner = self.lock_inner();
         let has_new_wakeup = inner.generation != due.generation;
         // A deferred wakeup that arrives while an HTTP poll is in flight
         // must be honored before returning a newly found job to this runner.
@@ -271,7 +275,7 @@ impl PollWakeups {
             notified.as_mut().enable();
 
             let scheduled = {
-                let mut inner = self.inner.lock().await;
+                let mut inner = self.lock_inner();
                 let now = tokio::time::Instant::now();
                 if inner.deferred_poll_at.is_some_and(|at| at <= now) {
                     inner.deferred_poll_at = None;
@@ -309,7 +313,7 @@ impl PollWakeups {
                 }
                 () = &mut notified => {}
                 () = tokio::time::sleep_until(scheduled.at) => {
-                    if let Some(due) = self.consume_scheduled(scheduled).await {
+                    if let Some(due) = self.consume_scheduled(scheduled) {
                         return Some(due);
                     }
                 }
@@ -354,8 +358,8 @@ impl PollWakeups {
         scheduled
     }
 
-    async fn consume_scheduled(&self, scheduled: ScheduledPoll) -> Option<PollDue> {
-        let mut inner = self.inner.lock().await;
+    fn consume_scheduled(&self, scheduled: ScheduledPoll) -> Option<PollDue> {
+        let mut inner = self.lock_inner();
         let now = tokio::time::Instant::now();
 
         let is_due = match scheduled.reason {
@@ -405,8 +409,8 @@ impl PollWakeups {
     }
 
     #[cfg(test)]
-    pub(super) async fn snapshot(&self) -> PollWakeupsSnapshot {
-        let inner = self.inner.lock().await;
+    pub(super) fn snapshot(&self) -> PollWakeupsSnapshot {
+        let inner = self.lock_inner();
         PollWakeupsSnapshot {
             ably_connected: inner.ably_connected,
             poll_now: inner.poll_now,
@@ -576,25 +580,25 @@ async fn run_supervisor(config: SupervisorTaskConfig) {
                             info!("ably reconnected");
                         }
                         disconnect.mark_connected();
-                        config.poll_wakeups.mark_ably_connected().await;
+                        config.poll_wakeups.mark_ably_connected();
                     }
                     Some(ably_subscriber::Event::Disconnected { reason }) => {
                         let reason = reason.unwrap_or_else(|| "unknown".to_string());
                         disconnect.record_disconnected(reason.clone());
-                        config.poll_wakeups.mark_ably_disconnected().await;
+                        config.poll_wakeups.mark_ably_disconnected();
                         info!(reason = %reason, "ably disconnected, switching to fast poll");
                     }
                     Some(ably_subscriber::Event::Error { code, message }) => {
                         error!(code, message = %message, "ably fatal error, will reconnect");
                         disconnect.record_disconnected(message.clone());
-                        config.poll_wakeups.mark_ably_disconnected().await;
+                        config.poll_wakeups.mark_ably_disconnected();
                         ably = None;
                         ably_retry.schedule();
                     }
                     None => {
                         warn!("ably subscription closed, will reconnect");
                         disconnect.record_disconnected("subscription closed".to_string());
-                        config.poll_wakeups.mark_ably_disconnected().await;
+                        config.poll_wakeups.mark_ably_disconnected();
                         ably = None;
                         ably_retry.schedule();
                     }
@@ -605,11 +609,11 @@ async fn run_supervisor(config: SupervisorTaskConfig) {
                 match handle_ably_connect_result(result, &mut ably, &mut ably_retry) {
                     Ok(()) => {
                         disconnect.mark_connected();
-                        config.poll_wakeups.mark_ably_connected().await;
+                        config.poll_wakeups.mark_ably_connected();
                     }
                     Err(reason) => {
                         disconnect.record_disconnected(reason);
-                        config.poll_wakeups.mark_ably_disconnected().await;
+                        config.poll_wakeups.mark_ably_disconnected();
                     }
                 }
             }
@@ -733,7 +737,7 @@ async fn handle_ably_message_with_connector_runtime_sync(
 
     match action {
         JobNotificationAction::WakeNow => {
-            poll_wakeups.request_immediate_poll().await;
+            poll_wakeups.request_immediate_poll();
         }
         JobNotificationAction::Direct(candidate) => {
             enqueue_direct_candidate(*candidate, direct_candidates, poll_wakeups).await;
@@ -811,7 +815,7 @@ async fn enqueue_direct_candidate(
                 fallback_poll_requested = true,
                 "ably: direct candidate inbox full, waking poll"
             );
-            poll_wakeups.request_immediate_poll().await;
+            poll_wakeups.request_immediate_poll();
         }
     }
 }
@@ -1206,7 +1210,7 @@ mod tests {
             .await;
 
         assert_eq!(poll_reason(reason), Some(PollReason::Immediate));
-        let snapshot = wakeups.snapshot().await;
+        let snapshot = wakeups.snapshot();
         assert!(snapshot.ably_connected);
         assert!(!snapshot.poll_now);
     }
@@ -1223,10 +1227,8 @@ mod tests {
             .await
             .unwrap();
 
-        wakeups
-            .record_poll_result(reason, PollOutcome::Failure, Duration::from_secs(5))
-            .await;
-        let snapshot = wakeups.snapshot().await;
+        wakeups.record_poll_result(reason, PollOutcome::Failure, Duration::from_secs(5));
+        let snapshot = wakeups.snapshot();
         assert!(snapshot.wakeup_retry_at.is_some());
 
         tokio::time::sleep(Duration::from_secs(5)).await;
@@ -1251,9 +1253,7 @@ mod tests {
             )
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5))
-            .await;
+        wakeups.record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5));
 
         tokio::time::sleep(Duration::from_secs(5)).await;
         let due = wakeups
@@ -1266,10 +1266,8 @@ mod tests {
             .unwrap();
         assert_eq!(due.reason(), PollReason::Fast);
 
-        wakeups
-            .record_poll_result(due, PollOutcome::Failure, Duration::from_secs(5))
-            .await;
-        assert!(wakeups.snapshot().await.wakeup_retry_at.is_none());
+        wakeups.record_poll_result(due, PollOutcome::Failure, Duration::from_secs(5));
+        assert!(wakeups.snapshot().wakeup_retry_at.is_none());
     }
 
     #[tokio::test(start_paused = true)]
@@ -1283,9 +1281,7 @@ mod tests {
             )
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5))
-            .await;
+        wakeups.record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5));
 
         let wakeups_for_wait = Arc::clone(&wakeups);
         let cancel = CancellationToken::new();
@@ -1310,9 +1306,7 @@ mod tests {
             )
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5))
-            .await;
+        wakeups.record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5));
 
         let wakeups_for_wait = Arc::clone(&wakeups);
         let cancel = CancellationToken::new();
@@ -1337,9 +1331,7 @@ mod tests {
             )
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5))
-            .await;
+        wakeups.record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5));
 
         let wakeups_for_wait = Arc::clone(&wakeups);
         let cancel = CancellationToken::new();
@@ -1351,7 +1343,7 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(4)).await;
         assert!(!wait.is_finished());
 
-        wakeups.mark_ably_disconnected().await;
+        wakeups.mark_ably_disconnected();
         tokio::time::sleep(Duration::from_secs(4)).await;
         assert!(!wait.is_finished());
         tokio::time::sleep(Duration::from_secs(1)).await;
@@ -1370,9 +1362,7 @@ mod tests {
             )
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5))
-            .await;
+        wakeups.record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5));
 
         let wakeups_for_wait = Arc::clone(&wakeups);
         let cancel = CancellationToken::new();
@@ -1384,7 +1374,7 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(4)).await;
         assert!(!wait.is_finished());
 
-        wakeups.mark_ably_connected().await;
+        wakeups.mark_ably_connected();
         tokio::time::sleep(Duration::from_secs(29)).await;
         assert!(!wait.is_finished());
         tokio::time::sleep(Duration::from_secs(1)).await;
@@ -1404,11 +1394,9 @@ mod tests {
             .await
             .unwrap();
 
-        wakeups
-            .record_poll_result(reason, PollOutcome::JobFound, Duration::from_secs(5))
-            .await;
+        wakeups.record_poll_result(reason, PollOutcome::JobFound, Duration::from_secs(5));
 
-        assert!(wakeups.snapshot().await.poll_now);
+        assert!(wakeups.snapshot().poll_now);
         let reason = wakeups
             .wait_for_poll_due(
                 &CancellationToken::new(),
@@ -1430,21 +1418,15 @@ mod tests {
             )
             .await;
 
-        wakeups
-            .request_deferred_poll_after(Duration::from_secs(2))
-            .await;
+        wakeups.request_deferred_poll_after(Duration::from_secs(2));
         let first_deadline = wakeups
             .snapshot()
-            .await
             .deferred_poll_at
             .expect("first defer deadline");
         tokio::time::sleep(Duration::from_secs(1)).await;
-        wakeups
-            .request_deferred_poll_after(Duration::from_secs(2))
-            .await;
+        wakeups.request_deferred_poll_after(Duration::from_secs(2));
         let extended_deadline = wakeups
             .snapshot()
-            .await
             .deferred_poll_at
             .expect("extended defer deadline");
 
@@ -1471,12 +1453,9 @@ mod tests {
         let wakeups = PollWakeups::new(true);
         let deadline = StdInstant::now() + Duration::from_secs(2);
 
-        wakeups.request_deferred_poll_until(deadline).await;
+        wakeups.request_deferred_poll_until(deadline);
 
-        assert_eq!(
-            wakeups.snapshot().await.deferred_poll_at,
-            Some(deadline.into())
-        );
+        assert_eq!(wakeups.snapshot().deferred_poll_at, Some(deadline.into()));
     }
 
     #[tokio::test(start_paused = true)]
@@ -1490,22 +1469,14 @@ mod tests {
             )
             .await;
 
-        wakeups
-            .request_deferred_poll_after(Duration::from_secs(2))
-            .await;
-        let cap = wakeups
-            .snapshot()
-            .await
-            .deferred_poll_cap_at
-            .expect("defer cap");
+        wakeups.request_deferred_poll_after(Duration::from_secs(2));
+        let cap = wakeups.snapshot().deferred_poll_cap_at.expect("defer cap");
         for _ in 0..9 {
             tokio::time::sleep(Duration::from_secs(1)).await;
-            wakeups
-                .request_deferred_poll_after(Duration::from_secs(2))
-                .await;
+            wakeups.request_deferred_poll_after(Duration::from_secs(2));
         }
 
-        let snapshot = wakeups.snapshot().await;
+        let snapshot = wakeups.snapshot();
         assert_eq!(snapshot.deferred_poll_at, Some(cap));
         assert_eq!(snapshot.deferred_poll_cap_at, Some(cap));
         tokio::time::sleep_until(cap).await;
@@ -1530,19 +1501,14 @@ mod tests {
             )
             .await;
 
-        wakeups
-            .request_deferred_poll_after(Duration::from_secs(2))
-            .await;
+        wakeups.request_deferred_poll_after(Duration::from_secs(2));
         let initial_cap = wakeups
             .snapshot()
-            .await
             .deferred_poll_cap_at
             .expect("initial defer cap");
         for _ in 0..9 {
             tokio::time::sleep(Duration::from_secs(1)).await;
-            wakeups
-                .request_deferred_poll_after(Duration::from_secs(2))
-                .await;
+            wakeups.request_deferred_poll_after(Duration::from_secs(2));
         }
 
         tokio::time::sleep_until(initial_cap).await;
@@ -1554,14 +1520,12 @@ mod tests {
             )
             .await;
         assert_eq!(poll_reason(reason), Some(PollReason::Deferred));
-        let snapshot = wakeups.snapshot().await;
+        let snapshot = wakeups.snapshot();
         assert!(snapshot.deferred_poll_at.is_none());
         assert!(snapshot.deferred_poll_cap_at.is_none());
 
-        wakeups
-            .request_deferred_poll_after(Duration::from_secs(2))
-            .await;
-        let snapshot = wakeups.snapshot().await;
+        wakeups.request_deferred_poll_after(Duration::from_secs(2));
+        let snapshot = wakeups.snapshot();
         let next_deadline = snapshot
             .deferred_poll_at
             .expect("next defer deadline should be scheduled");
@@ -1583,14 +1547,10 @@ mod tests {
             )
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(initial, PollOutcome::JobFound, Duration::from_secs(5))
-            .await;
-        assert!(wakeups.snapshot().await.poll_now);
+        wakeups.record_poll_result(initial, PollOutcome::JobFound, Duration::from_secs(5));
+        assert!(wakeups.snapshot().poll_now);
 
-        wakeups
-            .request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2))
-            .await;
+        wakeups.request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2));
 
         let wakeups_for_wait = Arc::clone(&wakeups);
         let cancel = CancellationToken::new();
@@ -1607,7 +1567,7 @@ mod tests {
 
         tokio::time::sleep(Duration::from_secs(2)).await;
         assert_eq!(poll_reason(wait.await.unwrap()), Some(PollReason::Deferred));
-        assert!(!wakeups.snapshot().await.poll_now);
+        assert!(!wakeups.snapshot().poll_now);
     }
 
     #[tokio::test(start_paused = true)]
@@ -1621,12 +1581,8 @@ mod tests {
             )
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(initial, PollOutcome::Failure, Duration::from_secs(1))
-            .await;
-        wakeups
-            .request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2))
-            .await;
+        wakeups.record_poll_result(initial, PollOutcome::Failure, Duration::from_secs(1));
+        wakeups.request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2));
 
         tokio::time::sleep(Duration::from_secs(1)).await;
         let wakeups_for_wait = Arc::clone(&wakeups);
@@ -1659,12 +1615,10 @@ mod tests {
             .unwrap();
 
         let deferred_at = tokio::time::Instant::now() + Duration::from_secs(2);
-        wakeups.request_deferred_poll_at(deferred_at).await;
-        wakeups
-            .record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5))
-            .await;
+        wakeups.request_deferred_poll_at(deferred_at);
+        wakeups.record_poll_result(due, PollOutcome::Empty, Duration::from_secs(5));
 
-        assert_eq!(wakeups.snapshot().await.deferred_poll_at, Some(deferred_at));
+        assert_eq!(wakeups.snapshot().deferred_poll_at, Some(deferred_at));
     }
 
     #[tokio::test(start_paused = true)]
@@ -1679,15 +1633,11 @@ mod tests {
             .await
             .unwrap();
 
-        wakeups
-            .request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2))
-            .await;
-        let record = wakeups
-            .record_poll_result(due, PollOutcome::JobFound, Duration::from_secs(5))
-            .await;
+        wakeups.request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2));
+        let record = wakeups.record_poll_result(due, PollOutcome::JobFound, Duration::from_secs(5));
 
         assert!(record.defer_job_return());
-        assert!(wakeups.snapshot().await.deferred_poll_at.is_some());
+        assert!(wakeups.snapshot().deferred_poll_at.is_some());
     }
 
     #[tokio::test(start_paused = true)]
@@ -1701,12 +1651,8 @@ mod tests {
             )
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(initial, PollOutcome::Empty, Duration::from_secs(5))
-            .await;
-        wakeups
-            .request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2))
-            .await;
+        wakeups.record_poll_result(initial, PollOutcome::Empty, Duration::from_secs(5));
+        wakeups.request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2));
         tokio::time::sleep(Duration::from_secs(2)).await;
         let due = wakeups
             .wait_for_poll_due(
@@ -1717,9 +1663,7 @@ mod tests {
             .await
             .unwrap();
 
-        let record = wakeups
-            .record_poll_result(due, PollOutcome::JobFound, Duration::from_secs(5))
-            .await;
+        let record = wakeups.record_poll_result(due, PollOutcome::JobFound, Duration::from_secs(5));
 
         assert!(!record.defer_job_return());
     }
@@ -1735,13 +1679,9 @@ mod tests {
             )
             .await
             .unwrap();
-        wakeups
-            .record_poll_result(initial, PollOutcome::Empty, Duration::from_secs(5))
-            .await;
+        wakeups.record_poll_result(initial, PollOutcome::Empty, Duration::from_secs(5));
 
-        wakeups
-            .request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2))
-            .await;
+        wakeups.request_deferred_poll_at(tokio::time::Instant::now() + Duration::from_secs(2));
         tokio::time::sleep(Duration::from_secs(2)).await;
         let deferred = wakeups
             .wait_for_poll_due(
@@ -1752,11 +1692,9 @@ mod tests {
             .await
             .unwrap();
 
-        wakeups
-            .record_poll_result(deferred, PollOutcome::Empty, Duration::from_secs(5))
-            .await;
+        wakeups.record_poll_result(deferred, PollOutcome::Empty, Duration::from_secs(5));
 
-        assert!(wakeups.snapshot().await.deferred_poll_at.is_none());
+        assert!(wakeups.snapshot().deferred_poll_at.is_none());
     }
 
     #[test]
@@ -2059,7 +1997,7 @@ mod tests {
             Some(super::super::RunnerPreferenceClaimState::Active)
         );
         assert_no_direct_candidate(&direct_candidates).await;
-        assert!(!wakeups.snapshot().await.poll_now);
+        assert!(!wakeups.snapshot().poll_now);
     }
 
     #[tokio::test]
@@ -2161,7 +2099,7 @@ mod tests {
         handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
         assert_no_direct_candidate(&direct_candidates).await;
-        let snapshot = wakeups.snapshot().await;
+        let snapshot = wakeups.snapshot();
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_none());
     }
@@ -2190,7 +2128,7 @@ mod tests {
         handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
         assert_no_direct_candidate(&direct_candidates).await;
-        let snapshot = wakeups.snapshot().await;
+        let snapshot = wakeups.snapshot();
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_none());
     }
@@ -2218,7 +2156,7 @@ mod tests {
         handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
         assert_no_direct_candidate(&direct_candidates).await;
-        assert!(wakeups.snapshot().await.poll_now);
+        assert!(wakeups.snapshot().poll_now);
     }
 
     #[tokio::test]
@@ -2245,7 +2183,7 @@ mod tests {
         handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
         assert_no_direct_candidate(&direct_candidates).await;
-        assert!(wakeups.snapshot().await.poll_now);
+        assert!(wakeups.snapshot().poll_now);
     }
 
     #[tokio::test]
@@ -2288,7 +2226,7 @@ mod tests {
 
         let candidate = pop_direct_candidate(&direct_candidates).await;
         assert_eq!(candidate.profile_name(), "vm0/default");
-        assert!(wakeups.snapshot().await.poll_now);
+        assert!(wakeups.snapshot().poll_now);
     }
 
     #[tokio::test]
@@ -2332,7 +2270,7 @@ mod tests {
                 .parse::<RunId>()
                 .unwrap()
         );
-        assert!(!wakeups.snapshot().await.poll_now);
+        assert!(!wakeups.snapshot().poll_now);
     }
 
     #[tokio::test]
@@ -2352,7 +2290,7 @@ mod tests {
 
         handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
-        let snapshot = wakeups.snapshot().await;
+        let snapshot = wakeups.snapshot();
         assert_no_direct_candidate(&direct_candidates).await;
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_none());

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -94,6 +94,7 @@ pub struct MockJobProvider {
     heartbeat_notify: Arc<Notify>,
     heartbeat_control: Arc<MockOperationControl>,
     heartbeat_max_in_flight: Arc<AtomicUsize>,
+    panic_next_heartbeat: Arc<AtomicBool>,
     claim_control: Arc<MockOperationControl>,
     completion_control: Arc<MockOperationControl>,
     completion_after_finalization: Arc<AtomicBool>,
@@ -119,6 +120,7 @@ pub struct MockProviderHandle {
     heartbeat_notify: Arc<Notify>,
     heartbeat_control: Arc<MockOperationControl>,
     heartbeat_max_in_flight: Arc<AtomicUsize>,
+    panic_next_heartbeat: Arc<AtomicBool>,
     claim_control: Arc<MockOperationControl>,
     completion_control: Arc<MockOperationControl>,
     completion_after_finalization: Arc<AtomicBool>,
@@ -311,6 +313,7 @@ impl MockJobProvider {
         let heartbeat_notify = Arc::new(Notify::new());
         let heartbeat_control = Arc::new(MockOperationControl::default());
         let heartbeat_max_in_flight = Arc::new(AtomicUsize::new(0));
+        let panic_next_heartbeat = Arc::new(AtomicBool::new(false));
         let claim_control = Arc::new(MockOperationControl::default());
         let completion_control = Arc::new(MockOperationControl::default());
         let completion_after_finalization = Arc::new(AtomicBool::new(false));
@@ -332,6 +335,7 @@ impl MockJobProvider {
             heartbeat_notify: Arc::clone(&heartbeat_notify),
             heartbeat_control: Arc::clone(&heartbeat_control),
             heartbeat_max_in_flight: Arc::clone(&heartbeat_max_in_flight),
+            panic_next_heartbeat: Arc::clone(&panic_next_heartbeat),
             claim_control: Arc::clone(&claim_control),
             completion_control: Arc::clone(&completion_control),
             completion_after_finalization: Arc::clone(&completion_after_finalization),
@@ -351,6 +355,7 @@ impl MockJobProvider {
             heartbeat_notify,
             heartbeat_control,
             heartbeat_max_in_flight,
+            panic_next_heartbeat,
             claim_control,
             completion_control,
             completion_after_finalization,
@@ -486,6 +491,10 @@ impl MockProviderHandle {
     /// Block heartbeat calls after recording their submitted state.
     pub fn block_heartbeats(&self) {
         self.heartbeat_control.block();
+    }
+
+    pub fn panic_next_heartbeat(&self) {
+        self.panic_next_heartbeat.store(true, Ordering::SeqCst);
     }
 
     /// Release all currently blocked heartbeat calls and allow later calls.
@@ -665,6 +674,10 @@ impl JobProvider for MockJobProvider {
     }
 
     async fn heartbeat(&self, state: &HeartbeatState) {
+        assert!(
+            !self.panic_next_heartbeat.swap(false, Ordering::SeqCst),
+            "injected heartbeat panic"
+        );
         self.heartbeat_control
             .run_while_blocked(|in_flight| {
                 self.heartbeat_max_in_flight

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -420,7 +420,7 @@ impl StatusTracker {
     }
 
     #[cfg(test)]
-    fn new_with_atomic_write_gate(
+    pub(crate) fn new_with_atomic_write_gate(
         path: PathBuf,
         generation: u64,
         started: std::sync::Arc<tokio::sync::Notify>,
@@ -439,6 +439,11 @@ impl StatusTracker {
     #[cfg(test)]
     pub(crate) fn idle_info_update_request_count(&self) -> u64 {
         self.idle_info_update_requests.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn hold_state_for_test(&self) -> impl Drop + '_ {
+        self.state.lock().await
     }
 
     /// Transition the reported lifecycle mode and flush the status file.

--- a/crates/runner/src/workspace_image_cache/gc.rs
+++ b/crates/runner/src/workspace_image_cache/gc.rs
@@ -107,6 +107,15 @@ impl WorkspaceImageCache {
             return Ok(None);
         }
 
+        #[cfg(test)]
+        if let Some((entered, release)) = &self.routine_gc_test_gate {
+            entered.notify_one();
+            release
+                .acquire()
+                .await
+                .expect("routine GC gate closed")
+                .forget();
+        }
         let freed_bytes = self.gc_locked(false).await?;
         capacity_lock.write_all(b"\0")?;
         Ok(Some(freed_bytes))

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -123,6 +123,8 @@ pub(crate) struct WorkspaceImageCache {
     session_history_sidecar_export_permits: Arc<Semaphore>,
     #[cfg(test)]
     prepare_lock_test_gate: Option<WorkspaceImagePrepareLockTestGate>,
+    #[cfg(test)]
+    routine_gc_test_gate: Option<(Arc<tokio::sync::Notify>, Arc<Semaphore>)>,
 }
 
 #[cfg(test)]
@@ -266,6 +268,7 @@ impl WorkspaceImageCache {
                 MAX_SESSION_HISTORY_SIDECAR_EXPORT_CONCURRENCY,
             )),
             prepare_lock_test_gate: None,
+            routine_gc_test_gate: None,
         }
     }
 
@@ -303,6 +306,16 @@ impl WorkspaceImageCache {
 
     pub(crate) fn paths(&self) -> &RunnerPaths {
         &self.inner.paths
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_routine_gc_test_gate(
+        mut self,
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<Semaphore>,
+    ) -> Self {
+        self.routine_gc_test_gate = Some((entered, release));
+        self
     }
 
     #[cfg(test)]

--- a/docs/runner-reactor-progress.md
+++ b/docs/runner-reactor-progress.md
@@ -1,0 +1,72 @@
+# Runner reactor progress
+
+The runner reactor (`crates/runner/src/cmd/start/mod.rs`) selects between
+discovery, lifecycle changes, job completion, and maintenance. Some selected
+branches await shared resources inline. Work that uses those same resources must
+be able to progress independently of the reactor.
+
+## A retained future is not an independent task
+
+Keeping a future outside `tokio::select!` preserves its progress when another
+branch wins, but only the reactor polls that future. This can deadlock even when
+no mutex guard crosses an await:
+
+1. A retained heartbeat future queues for the idle-pool mutex.
+2. Another branch wins. Inline admission or drain queues for that mutex too.
+3. The current holder releases the mutex. Tokio's FIFO mutex reserves progress
+   for the heartbeat waiter.
+4. The reactor is awaiting its own lock request, so it cannot poll the heartbeat
+   waiter ahead of it. Other waiters, including finalizers, also stop progressing.
+
+Status retry has the same dependency through the status-state mutex and ordered
+persistence. The state-lock case does not require an earlier failed file write.
+Persistence timeouts do not bound a wait that happens before persistence starts.
+
+## Ownership and shutdown
+
+| Work                       | Owner and progress rule                                                                                                                                                                                  | Shutdown                                                                                                                                                                                                                                                                                                                          |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Heartbeat                  | One independently scheduled task; triggers coalesce into at most one pending request. The next send uses live state and lifecycle mode. Shared immutable configuration is allocated once per controller. | Natural drain flushes a Stopping snapshot. Common teardown joins the active send before provider shutdown. Abnormal controller drop aborts the task; dropping a client request does not retract a remote request, so snapshot generation/sequence fencing remains required.                                                       |
+| Status retry               | One independently scheduled task. State generations, ordered persistence, and atomic-write continuation remain authoritative.                                                                            | Join the retry before final status publication. If the reactor itself is cancelled, the task retains ownership until it finishes.                                                                                                                                                                                                 |
+| Routine workspace-cache GC | One independently scheduled task, with host-global cadence and exclusion enforced by the capacity lock.                                                                                                  | Join before dependent teardown. Do not abort the task during normal shutdown: filesystem deletion may outlive a dropped async future. If the reactor itself is cancelled, the task retains its locks through completion rather than releasing them over unfinished I/O. Process/runtime termination remains an abnormal boundary. |
+| Poll wakeups               | Short synchronous mutex sections protect only in-memory scheduling state. No I/O, await, or long nested work is permitted under this lock.                                                               | Notification registration before state recheck, generation fencing, deferred-poll caps, and cancellation remain unchanged.                                                                                                                                                                                                        |
+
+Task join failures stop the reactor through its existing lifecycle and common
+teardown path and are returned as terminal errors. Ordinary optional GC or status
+retry errors remain warnings. Runtime task ownership does not make an individual
+filesystem or network operation infinitely fast or cancellation-safe.
+
+## Other retained-work audit
+
+- Discovery remains pinned across reactor turns: restarting it on each tick
+  would reset polling timers and discard provider-local state. The direct inbox
+  releases its batch lock before returning a candidate; inline batch updates
+  follow a completed discovery. Claim cooldown updates have no shared retained
+  lock holder that depends on the reactor to resume. PollWakeups is synchronous
+  because both retained discovery and inline callbacks access its state.
+- Workspace-cache watcher work remains retained with ownership of its watcher
+  and drained filesystem events. Its classification does not own an idle-pool or
+  status waiter needed by an inline reactor branch.
+- Active-run and budget locks protect short synchronous state updates.
+- Active/idle transfers and cancellation retain their existing ownership gates:
+  contested gates are not awaited while holding the idle pool.
+
+New branches must be checked against both lock holders and queued waiters. Do not
+spawn discovery unconditionally or change admission/reuse policy to work around
+resource ownership problems.
+
+## Coverage and remaining incident work
+
+`cmd/start/tests/main_loop/shared_resource_progress.rs` drives the real `run()`
+entry point under forced pool, status-state, and persistence-ordering contention.
+It also checks heartbeat-owner failure and GC progress/completion ownership.
+Existing heartbeat tests cover coalescing, monotonic sequences, live-mode
+follow-ups, and no overlapping requests; provider tests cover wakeup scheduling
+and generation/defer semantics.
+
+This is the reactor-progress slice [#32050](https://github.com/vm0-ai/vm0/issues/32050)
+of [#32040](https://github.com/vm0-ai/vm0/issues/32040). Separate follow-ups track
+[helper recovery and outstanding cleanup](https://github.com/vm0-ai/vm0/issues/32051),
+[warn-only promotion drain diagnostics](https://github.com/vm0-ai/vm0/issues/32052),
+and [live-runner metric filtering](https://github.com/vm0-ai/vm0/issues/32053).
+These are not fixed by changing reactor task scheduling.


### PR DESCRIPTION
## Problem

Retained heartbeat and status-retry futures share resources with inline reactor branches. A queued Tokio mutex waiter can receive the next FIFO permit while the reactor is blocked behind it, so neither the retained work nor other pool waiters/finalizers can progress. Four positive regressions reproduced the original failures through the real `run()` entry point. Routine GC and discovery wakeup state also need deliberate progress ownership.

## Changes

- Schedule one owned heartbeat task independently of the reactor. Preserve coalesced triggers, live-mode follow-ups, snapshot generation/sequence fencing, and orderly stopping flush/drain. Immutable configuration is shared, not copied per tick.
- Run status retry and routine workspace-cache GC as single-flight maintenance tasks. Join them during orderly teardown; retain GC locks through filesystem completion rather than aborting an unfinished deletion.
- Make PollWakeups' bounded, state-only critical sections synchronous. Preserve notify registration/recheck, generation fencing, defer caps and discovery gating.
- Route new task-owner failures through lifecycle stopping and common resource teardown. Optional maintenance operation errors remain warnings.
- Add eight real-runner regressions and document the retained-future/shared-resource audit.

## Scope and risks

No API, queue, status schema, deployment setting, admission policy, or reuse policy change. No new compatibility fallback. Existing old/new runner protocol compatibility is unchanged.

The main risks are task ownership during panic/cancellation, heartbeat ordering, and GC completion before teardown. A slow filesystem can still delay orderly GC completion; this change does not add a blanket timeout or claim to repair unbounded helper/OS waits. Maintenance tasks intentionally finish with their locks if the reactor future itself is abnormally cancelled; process/runtime termination remains abnormal. Heartbeat abnormal drop aborts local work but cannot retract a request already sent remotely.

Closes #32050. Part of #32040 (parent remains open).

Separate delivery slices: #32051 (helper recovery/outstanding cleanup, depends on this slice), #32052 (warn-only promotion drain diagnostics), #32053 (live-runner metric filtering). No production runner operations were performed.

## Validation

- Before the fix: four real-runner regression scenarios failed with blocked progress/timeouts.
- `cargo test --profile local -p runner --bin runner shared_resource_progress -- --nocapture`: 8 passed.
- `cargo fmt --all -- --check`.
- `cargo clippy --profile local -p runner --all-targets --all-features -- -D warnings`.
- `RUSTDOCFLAGS="-D warnings" cargo doc --profile local -p runner --all-features --no-deps`.
- `cargo test --profile local -p runner --all-features -- --test-threads=4`: 3,461 runner tests and 1 integration test passed. The 25 pre-existing ignored outer-harness entries are isolated child-process entrypoints exercised by parent tests; no new skips.
- `pnpm exec prettier --check ../docs/runner-reactor-progress.md` and `git diff --check`.

Unrelated local environment note: post-pull DB migration is blocked by two pre-existing lease-classification rows. No database data was modified; Rust validation does not use that database.
