### PR TITLE
feat(connectors): add procountor m2m token provider

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -146,7 +146,7 @@ const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const PREVIOUS_CONNECTOR_CATALOG_MAX_RAW_BYTES = 32 * 1024 * 1024;
 const EXPECTED_CAPABILITY_DIGEST =
-  "sha256:a63c2242883709d4f171afc518ad7a4c15ceb5687e8be1ec5800699014ee4718";
+  "sha256:d3b33ea71c1a98a0276a71e7bf32562210cff53270846e22f35befb31a8fccd6";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -114,6 +114,7 @@ import { supabaseProvider } from "./connectors/supabase/provider";
 import { metaAdsProvider } from "./connectors/meta-ads/provider";
 import { posthogProvider } from "./connectors/posthog/provider";
 import { paypalProvider } from "./connectors/paypal/provider";
+import { procountorProvider } from "./connectors/procountor/provider";
 import { quickbooksProvider } from "./connectors/quickbooks/provider";
 import { rampProvider } from "./connectors/ramp/provider";
 import { reckonProvider } from "./connectors/reckon/provider";
@@ -1055,6 +1056,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES = [
   authCodeRefreshProviderEntry("outlook-mail", "oauth", outlookMailProvider),
   authCodeRefreshProviderEntry("posthog", "oauth", posthogProvider),
   refreshProviderEntry("paypal", "api-token", paypalProvider),
+  refreshProviderEntry("procountor", "api-token", procountorProvider),
   externalCodeRefreshProviderEntry("playstation", "api", playstationProvider),
   authCodeRefreshProviderEntry("quickbooks", "oauth", quickbooksProvider),
   refreshProviderEntry("ramp", "api-token", rampProvider),

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/procountor.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/procountor.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse, http } from "msw";
+
+import { server } from "../../__tests__/test-server";
+import { ProviderResponseError } from "../../provider-error";
+import { fetchProcountorAccessToken } from "../procountor/api-token";
+
+const PROCOUNTOR_TOKEN_URL = "https://api.procountor.com/api/oauth/token";
+
+function testRefreshSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
+describe("connector/providers/procountor", () => {
+  it("exchanges the M2M API key with the official client-credentials form", async () => {
+    let contentType: string | null = null;
+    let body = "";
+    server.use(
+      http.post(PROCOUNTOR_TOKEN_URL, async ({ request }) => {
+        contentType = request.headers.get("content-type");
+        body = await request.text();
+        return HttpResponse.json({
+          access_token: "procountor-access-token",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    await expect(
+      fetchProcountorAccessToken(
+        {
+          apiKey: "api-key",
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          redirectUri: "https://example.com/procountor/callback",
+        },
+        testRefreshSignal(),
+      ),
+    ).resolves.toEqual({
+      accessToken: "procountor-access-token",
+      expiresIn: 3600,
+    });
+    expect(contentType).toContain("application/x-www-form-urlencoded");
+    const parameters = new URLSearchParams(body);
+    expect(parameters.get("grant_type")).toBe("client_credentials");
+    expect(parameters.get("api_key")).toBe("api-key");
+    expect(parameters.get("client_id")).toBe("client-id");
+    expect(parameters.get("client_secret")).toBe("client-secret");
+    expect(parameters.get("redirect_uri")).toBe(
+      "https://example.com/procountor/callback",
+    );
+    expect(body).not.toContain("Authorization");
+  });
+
+  it("rejects an HTTP error without exposing credentials", async () => {
+    server.use(
+      http.post(PROCOUNTOR_TOKEN_URL, () => {
+        return new HttpResponse(null, { status: 401 });
+      }),
+    );
+
+    await expect(
+      fetchProcountorAccessToken(
+        {
+          apiKey: "api-key",
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          redirectUri: "https://example.com/procountor/callback",
+        },
+        testRefreshSignal(),
+      ),
+    ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("rejects malformed JSON responses", async () => {
+    server.use(
+      http.post(PROCOUNTOR_TOKEN_URL, () => {
+        return new HttpResponse("not-json", {
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    await expect(
+      fetchProcountorAccessToken(
+        {
+          apiKey: "api-key",
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          redirectUri: "https://example.com/procountor/callback",
+        },
+        testRefreshSignal(),
+      ),
+    ).rejects.toBeInstanceOf(ProviderResponseError);
+  });
+
+  it("rejects a successful response without a complete token", async () => {
+    server.use(
+      http.post(PROCOUNTOR_TOKEN_URL, () => {
+        return HttpResponse.json({ access_token: "token" });
+      }),
+    );
+
+    await expect(
+      fetchProcountorAccessToken(
+        {
+          apiKey: "api-key",
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          redirectUri: "https://example.com/procountor/callback",
+        },
+        testRefreshSignal(),
+      ),
+    ).rejects.toThrow("Invalid Procountor access token response");
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/procountor/api-token.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/procountor/api-token.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+import { ProviderHttpError, ProviderResponseError } from "../../provider-error";
+
+const PROCOUNTOR_TOKEN_URL = "https://api.procountor.com/api/oauth/token";
+
+interface ProcountorTokenResult {
+  readonly accessToken: string;
+  readonly expiresIn: number;
+}
+
+export async function fetchProcountorAccessToken(
+  args: {
+    readonly apiKey: string;
+    readonly clientId: string;
+    readonly clientSecret: string;
+    readonly redirectUri: string;
+  },
+  signal: AbortSignal,
+): Promise<ProcountorTokenResult> {
+  const response = await fetch(PROCOUNTOR_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: args.clientId,
+      client_secret: args.clientSecret,
+      redirect_uri: args.redirectUri,
+      api_key: args.apiKey,
+    }),
+    signal,
+  });
+  if (!response.ok) {
+    throw new ProviderHttpError(
+      `Procountor access token request failed: ${response.status}`,
+      response.status,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new ProviderResponseError("Invalid Procountor access token response");
+  }
+  const parsed = z
+    .object({
+      access_token: z.string().min(1),
+      expires_in: z.number().positive(),
+    })
+    .safeParse(payload);
+  if (!parsed.success) {
+    throw new ProviderResponseError("Invalid Procountor access token response");
+  }
+  return {
+    accessToken: parsed.data.access_token,
+    expiresIn: parsed.data.expires_in,
+  };
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/procountor/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/procountor/provider.ts
@@ -1,0 +1,23 @@
+import type { RefreshTokenAccessProvider } from "../../types";
+import { fetchProcountorAccessToken } from "./api-token";
+
+export const procountorProvider = {
+  access: {
+    kind: "refresh-token",
+    refresh: async (args, signal: AbortSignal) => {
+      const token = await fetchProcountorAccessToken(
+        {
+          apiKey: args.inputs.apiKey,
+          clientId: args.inputs.clientId,
+          clientSecret: args.inputs.clientSecret,
+          redirectUri: args.inputs.redirectUri,
+        },
+        signal,
+      );
+      return {
+        outputs: { accessToken: token.accessToken },
+        expiresIn: token.expiresIn,
+      };
+    },
+  } satisfies RefreshTokenAccessProvider<"procountor", "api-token">,
+};

--- a/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
@@ -1417,6 +1417,31 @@ export const CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS = [
     },
   },
   {
+    connectorSlug: "procountor",
+    authMethodId: "api-token",
+    contract: {
+      client: {
+        kind: "none",
+      },
+      grant: {
+        kind: "manual",
+        callbackOrigin: null,
+        outputNames: [],
+        startOptionNames: [],
+      },
+      access: {
+        kind: "refresh-token",
+        inputNames: ["apiKey", "clientId", "clientSecret", "redirectUri"],
+        outputNames: ["accessToken"],
+        platformSecrets: [],
+      },
+      revoke: {
+        kind: "none",
+        inputNames: [],
+      },
+    },
+  },
+  {
     connectorSlug: "playstation",
     authMethodId: "api",
     contract: {


### PR DESCRIPTION
## Summary

Closes #32056.

Add the vm0-side auth provider required by the Procountor connector. Procountor's official M2M flow uses a stable API key together with client credentials, but the API key must be exchanged server-side for a short-lived Bearer access token.

## Implementation

- Add the `procountor` / `api-token` refresh provider.
- POST form-encoded `grant_type=client_credentials`, `client_id`, `client_secret`, `redirect_uri`, and `api_key` to the fixed official HTTPS token endpoint.
- Return only the official `access_token` and `expires_in` response fields.
- Keep credentials out of URLs and error messages; reject HTTP, malformed JSON, and incomplete responses.
- Register the exact runtime capability contract with no platform secrets and no user-controlled token host.

## Validation

- `pnpm --filter @okouai/connectors check-types`
- `pnpm --filter @okouai/connectors exec vitest run src/auth-providers/connectors/__tests__/procountor.test.ts`
- `pnpm --filter @okouai/connectors lint`
