### PR TITLE
fix(runner): warn on unacknowledged promotion drains

### DIFF
--- a/.github/scripts/tests/runner-promotion-ansible-test.sh
+++ b/.github/scripts/tests/runner-promotion-ansible-test.sh
@@ -8,6 +8,7 @@ inventory="$script_dir/fixtures/runner-promotion-local.ini"
 promote_playbook="$repo_root/ansible/playbooks/promote-runner.yml"
 rollback_playbook="$repo_root/ansible/playbooks/rollback-runner.yml"
 gc_task="$repo_root/ansible/tasks/garbage-collect-runner.yml"
+release_workflow="$repo_root/.github/workflows/release-please.yml"
 
 if ! command -v ansible-playbook >/dev/null; then
   echo "ansible-playbook is required" >&2
@@ -37,6 +38,16 @@ assert_line_count() {
   fi
 }
 
+assert_tree_contains() {
+  local dir=$1
+  local expected=$2
+  if ! grep -RFq -- "$expected" "$dir"; then
+    echo "expected files under ${dir} to contain: ${expected}" >&2
+    find "$dir" -type f -maxdepth 1 -print -exec cat {} \; >&2
+    exit 1
+  fi
+}
+
 case "$(uname -m)" in
   x86_64)
     runner_target=x86_64-unknown-linux-musl
@@ -58,6 +69,7 @@ trap cleanup EXIT
 
 test_home="$tmp/home"
 data_dir="$tmp/vm0-runner"
+fake_bin="$data_dir/fake-bin"
 runner_release=v999.0.0
 runner_bin_dir="$data_dir/bin/$runner_release"
 invocation_log="$data_dir/runner-invocations"
@@ -67,6 +79,7 @@ mkdir -p \
   "$data_dir/locks" \
   "$data_dir/runners/$runner_release" \
   "$gc_arrivals" \
+  "$fake_bin" \
   "$runner_bin_dir"
 
 fake_runner="$runner_bin_dir/runner"
@@ -81,7 +94,25 @@ printf '%s\n' "$*" >> "$invocation_log"
 case "${1:-}" in
   service)
     case "${2:-}" in
-      install|wait-running|drain)
+      install)
+        exit 0
+        ;;
+      wait-running)
+        if [ -f "$data_dir/fail-wait-running" ]; then
+          echo "target readiness failed" >&2
+          exit 41
+        fi
+        exit 0
+        ;;
+      drain)
+        service_name=${4:-}
+        if [ -f "$data_dir/fail-drain-$service_name" ]; then
+          echo "drain acknowledgement timed out for $service_name" >&2
+          exit 42
+        fi
+        exit 0
+        ;;
+      stop)
         exit 0
         ;;
     esac
@@ -131,6 +162,41 @@ exit 1
 EOF
 chmod +x "$fake_runner"
 
+fake_systemctl="$fake_bin/systemctl"
+cat > "$fake_systemctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+data_dir="$(cd "$(dirname "$0")/.." && pwd)"
+printf '%s\n' "$*" >> "$data_dir/systemctl-invocations"
+
+if [ -f "$data_dir/fail-service-discovery" ]; then
+  echo "systemctl discovery unavailable" >&2
+  exit 43
+fi
+
+case "${1:-}" in
+  list-units)
+    cat <<'UNITS'
+vm0-runner-v999.0.0.service loaded active running VM0 target
+vm0-runner-v100.0.0.service loaded active running VM0 old running
+vm0-runner-v101.0.0.service loaded activating start VM0 old activating
+UNITS
+    ;;
+  list-unit-files)
+    cat <<'UNITS'
+vm0-runner-v999.0.0.service enabled
+vm0-runner-v102.0.0.service enabled
+UNITS
+    ;;
+  *)
+    echo "unexpected systemctl invocation: $*" >&2
+    exit 44
+    ;;
+esac
+EOF
+chmod +x "$fake_systemctl"
+
 for playbook in "$promote_playbook" "$rollback_playbook"; do
   HOME="$test_home" \
     ANSIBLE_CONFIG="$ansible_config" \
@@ -147,17 +213,32 @@ if grep -Fq -- "flock" "$gc_task"; then
   exit 1
 fi
 
-if ! HOME="$test_home" \
-  ANSIBLE_CONFIG="$ansible_config" \
-  ANSIBLE_NOCOLOR=1 \
-  ansible-playbook \
-    -i "$inventory" \
-    --forks 2 \
-    -e "data_dir=$data_dir" \
-    -e "runner_host_env_file=$tmp/host.env" \
-    -e "runner_version=999.0.0" \
-    -e "runner_target=$runner_target" \
-    "$promote_playbook" >"$tmp/promote-output" 2>&1; then
+run_promotion() {
+  local output=$1
+  local warning_dir=$2
+  HOME="$test_home" \
+    PATH="$fake_bin:$PATH" \
+    ANSIBLE_CONFIG="$ansible_config" \
+    ANSIBLE_NOCOLOR=1 \
+    ansible-playbook \
+      -i "$inventory" \
+      --forks 2 \
+      -e "data_dir=$data_dir" \
+      -e "runner_host_env_file=$tmp/host.env" \
+      -e "runner_version=999.0.0" \
+      -e "runner_target=$runner_target" \
+      -e "promotion_warning_dir=$warning_dir" \
+      "$promote_playbook" >"$output" 2>&1
+}
+
+reset_case() {
+  rm -f "$invocation_log" "$data_dir/systemctl-invocations"
+  find "$gc_arrivals" -mindepth 1 -maxdepth 1 -type f -delete
+}
+
+normal_warning_dir="$tmp/normal-warnings"
+mkdir -p "$normal_warning_dir"
+if ! run_promotion "$tmp/promote-output" "$normal_warning_dir"; then
   cat "$tmp/promote-output" >&2
   exit 1
 fi
@@ -167,5 +248,70 @@ assert_line_count "$invocation_log" 2 \
 assert_line_count "$invocation_log" 4 "doctor --name $runner_release"
 assert_line_count "$invocation_log" 2 \
   "service wait-running --name $runner_release --timeout-secs 120"
+assert_line_count "$invocation_log" 0 "service drain --name $runner_release"
+for old_release in v100.0.0 v101.0.0 v102.0.0; do
+  assert_line_count "$invocation_log" 2 "service drain --name $old_release"
+done
+if find "$normal_warning_dir" -mindepth 1 -maxdepth 1 -type f -print -quit | grep -q .; then
+  echo "normal promotion unexpectedly wrote warnings" >&2
+  find "$normal_warning_dir" -type f -maxdepth 1 -print -exec cat {} \; >&2
+  exit 1
+fi
+
+reset_case
+touch "$data_dir/fail-drain-v101.0.0"
+drain_warning_dir="$tmp/drain-warnings"
+mkdir -p "$drain_warning_dir"
+if ! run_promotion "$tmp/drain-warning-output" "$drain_warning_dir"; then
+  cat "$tmp/drain-warning-output" >&2
+  exit 1
+fi
+rm -f "$data_dir/fail-drain-v101.0.0"
+
+for old_release in v100.0.0 v101.0.0 v102.0.0; do
+  assert_line_count "$invocation_log" 2 "service drain --name $old_release"
+done
+assert_tree_contains "$drain_warning_dir" '"service": "vm0-runner-v101.0.0.service"'
+assert_tree_contains "$drain_warning_dir" '"version": "v101.0.0"'
+assert_tree_contains "$drain_warning_dir" '"state": "drain_failed"'
+assert_tree_contains "$drain_warning_dir" '"error": "drain acknowledgement timed out for v101.0.0"'
+
+reset_case
+touch "$data_dir/fail-service-discovery"
+discovery_warning_dir="$tmp/discovery-warnings"
+mkdir -p "$discovery_warning_dir"
+if ! run_promotion "$tmp/discovery-warning-output" "$discovery_warning_dir"; then
+  cat "$tmp/discovery-warning-output" >&2
+  exit 1
+fi
+rm -f "$data_dir/fail-service-discovery"
+
+assert_line_count "$invocation_log" 0 "service drain --name v100.0.0"
+assert_line_count "$invocation_log" 2 \
+  "gc --keep-latest 6 --protect-version $runner_release"
+assert_tree_contains "$discovery_warning_dir" '"service": "vm0-runner-*.service"'
+assert_tree_contains "$discovery_warning_dir" '"state": "enumeration_failed"'
+assert_tree_contains "$discovery_warning_dir" '"error": "systemctl discovery unavailable"'
+
+reset_case
+touch "$data_dir/fail-wait-running"
+readiness_warning_dir="$tmp/readiness-warnings"
+mkdir -p "$readiness_warning_dir"
+if run_promotion "$tmp/readiness-failure-output" "$readiness_warning_dir"; then
+  echo "target readiness failure unexpectedly succeeded" >&2
+  cat "$tmp/readiness-failure-output" >&2
+  exit 1
+fi
+rm -f "$data_dir/fail-wait-running"
+assert_contains "$tmp/readiness-failure-output" \
+  "Runner $runner_release failed readiness or health checks."
+
+assert_contains "$release_workflow" "id: promote-runner"
+assert_contains "$release_workflow" 'shell: bash'
+assert_contains "$release_workflow" 'GITHUB_STEP_SUMMARY'
+assert_contains "$release_workflow" \
+  "steps.promote-runner.outputs.has_warnings != 'true'"
+assert_contains "$release_workflow" \
+  "steps.promote-runner.outputs.has_warnings == 'true'"
 
 echo "runner-promotion-ansible-test: ok"

--- a/.github/scripts/tests/runner-promotion-ansible-test.sh
+++ b/.github/scripts/tests/runner-promotion-ansible-test.sh
@@ -10,10 +10,12 @@ rollback_playbook="$repo_root/ansible/playbooks/rollback-runner.yml"
 gc_task="$repo_root/ansible/tasks/garbage-collect-runner.yml"
 release_workflow="$repo_root/.github/workflows/release-please.yml"
 
-if ! command -v ansible-playbook >/dev/null; then
-  echo "ansible-playbook is required" >&2
-  exit 1
-fi
+for command in ansible-playbook yq; do
+  if ! command -v "$command" >/dev/null; then
+    echo "$command is required" >&2
+    exit 1
+  fi
+done
 
 assert_contains() {
   local file=$1
@@ -313,5 +315,76 @@ assert_contains "$release_workflow" \
   "steps.promote-runner.outputs.has_warnings != 'true'"
 assert_contains "$release_workflow" \
   "steps.promote-runner.outputs.has_warnings == 'true'"
+
+promotion_script="$(
+  yq -r '.jobs.promote-runner-production.steps[] | select(.id == "promote-runner") | .run' \
+    "$release_workflow"
+)"
+cat > "$fake_bin/ansible-playbook" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$PROMOTION_WORKFLOW_CASE" in
+  empty)
+    ;;
+  warnings)
+    cp "$PROMOTION_TEST_WARNING_SOURCE/"*.json "$RUNNER_TEMP/runner-promotion-warnings/"
+    ;;
+  missing-directory)
+    rmdir "$RUNNER_TEMP/runner-promotion-warnings"
+    ;;
+  *)
+    echo "unexpected workflow test case: $PROMOTION_WORKFLOW_CASE" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$fake_bin/ansible-playbook"
+
+run_promotion_workflow() (
+  local case_name=$1
+  local work_dir="$tmp/workflow-$case_name"
+  mkdir -p "$work_dir"
+  cd "$repo_root"
+  PATH="$fake_bin:$PATH" \
+    RUNNER_TEMP="$work_dir" \
+    GITHUB_OUTPUT="$work_dir/output" \
+    GITHUB_STEP_SUMMARY="$work_dir/summary" \
+    RUNNER_HOSTS=promotion-test \
+    AWS_METAL_RUNNER_USER=runner-test \
+    SENTRY_DSN_RUNNER='' \
+    AXIOM_TOKEN_TELEMETRY='' \
+    RUNNER_VERSION=999.0.0 \
+    RUNNER_TARGET="$runner_target" \
+    PROMOTION_WORKFLOW_CASE="$case_name" \
+    PROMOTION_TEST_WARNING_SOURCE="$drain_warning_dir" \
+    bash --noprofile --norc -e -o pipefail -c "$promotion_script" >"$work_dir/log" 2>&1
+)
+
+for workflow_case in empty warnings; do
+  if ! run_promotion_workflow "$workflow_case"; then
+    cat "$tmp/workflow-$workflow_case/log" >&2
+    exit 1
+  fi
+done
+assert_line_count "$tmp/workflow-empty/output" 1 'has_warnings=false'
+assert_line_count "$tmp/workflow-warnings/output" 1 'has_warnings=true'
+assert_contains "$tmp/workflow-warnings/summary" '## Runner promotion warnings'
+assert_contains "$tmp/workflow-warnings/summary" \
+  '"error": "drain acknowledgement timed out for v101.0.0"'
+for host in runner-promotion-a runner-promotion-b; do
+  assert_contains "$tmp/workflow-warnings/summary" "\"host\": \"$host\""
+done
+
+if run_promotion_workflow missing-directory; then
+  echo "warning discovery failure unexpectedly succeeded" >&2
+  cat "$tmp/workflow-missing-directory/log" >&2
+  exit 1
+fi
+if [ -s "$tmp/workflow-missing-directory/output" ]; then
+  echo "warning discovery failure must not publish a success output" >&2
+  cat "$tmp/workflow-missing-directory/output" >&2
+  exit 1
+fi
 
 echo "runner-promotion-ansible-test: ok"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2450,6 +2450,7 @@ jobs:
           echo "Resolved ${host_count} metal host(s) for ${RUNNER_HOST_GROUP_ID}"
 
       - name: Promote runner on production hosts with Ansible
+        id: promote-runner
         env:
           RUNNER_HOSTS: ${{ steps.matrix-hosts.outputs.hosts }}
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
@@ -2457,7 +2458,10 @@ jobs:
           AXIOM_TOKEN_TELEMETRY: ${{ secrets.AXIOM_TOKEN_TELEMETRY }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
           RUNNER_TARGET: ${{ matrix.target }}
+        shell: bash
         run: |
+          promotion_warning_dir="${RUNNER_TEMP}/runner-promotion-warnings"
+          mkdir -p "$promotion_warning_dir"
           cd ansible
           ansible-playbook \
             -i "${RUNNER_HOSTS}," \
@@ -2468,7 +2472,24 @@ jobs:
             -e "axiom_dataset_suffix=prod" \
             -e "runner_version=${RUNNER_VERSION}" \
             -e "runner_target=${RUNNER_TARGET}" \
+            -e "promotion_warning_dir=${promotion_warning_dir}" \
             -v
+
+          mapfile -d '' warning_files < <(
+            find "$promotion_warning_dir" -type f -name '*.json' -print0 | sort -z
+          )
+          if (( ${#warning_files[@]} > 0 )); then
+            echo "has_warnings=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Runner promotion warnings"
+              echo
+              for warning_file in "${warning_files[@]}"; do
+                sed 's/^/    /' "$warning_file"
+              done
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "has_warnings=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Global health check (non-blocking)
         id: global-doctor
@@ -2502,7 +2523,7 @@ jobs:
           echo "text=$text" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack - Success
-        if: ${{ success() && steps.slack-start.outputs.ts && steps.global-doctor.outputs.has_warnings != 'true' }}
+        if: ${{ success() && steps.slack-start.outputs.ts && steps.promote-runner.outputs.has_warnings != 'true' && steps.global-doctor.outputs.has_warnings != 'true' }}
         uses: slackapi/slack-github-action@v4.0.0
         with:
           method: chat.update
@@ -2518,7 +2539,7 @@ jobs:
                   text: "*Runner RS* ✅ Promoted to production\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🏗️ Target: `${{ matrix.target }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>\n🔄 <${{ github.server_url }}/${{ github.repository }}/issues/${{ vars.ROLLBACK_ISSUE_NUMBER }}|Rollback Dashboard>"
 
       - name: Notify Slack - Success with warnings
-        if: ${{ success() && steps.slack-start.outputs.ts && steps.global-doctor.outputs.has_warnings == 'true' }}
+        if: ${{ success() && steps.slack-start.outputs.ts && (steps.promote-runner.outputs.has_warnings == 'true' || steps.global-doctor.outputs.has_warnings == 'true') }}
         uses: slackapi/slack-github-action@v4.0.0
         with:
           method: chat.update

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2475,9 +2475,9 @@ jobs:
             -e "promotion_warning_dir=${promotion_warning_dir}" \
             -v
 
-          mapfile -d '' warning_files < <(
-            find "$promotion_warning_dir" -type f -name '*.json' -print0 | sort -z
-          )
+          warning_manifest="${RUNNER_TEMP}/runner-promotion-warning-files"
+          find "$promotion_warning_dir" -type f -name '*.json' -print0 | sort -z > "$warning_manifest"
+          mapfile -d '' warning_files < "$warning_manifest"
           if (( ${#warning_files[@]} > 0 )); then
             echo "has_warnings=true" >> "$GITHUB_OUTPUT"
             {

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -83,21 +83,105 @@
     # ========================================
     # Phase 5: Drain old runners + Cleanup
     # ========================================
+    - name: Initialize runner promotion warnings
+      set_fact:
+        runner_promotion_warnings: []
+
     - name: Find runner services to drain
       shell: |
-        (
-          systemctl list-units 'vm0-runner-*.service' --state=running --plain --no-legend | awk '{print $1}'
-          systemctl list-unit-files 'vm0-runner-*.service' --state=enabled --plain --no-legend | awk '{print $1}'
-        ) | sed 's/^vm0-runner-//;s/\.service$//' | sort -u
+        set -euo pipefail
+        loaded_units="$(
+          systemctl list-units 'vm0-runner-*.service' --all --plain --no-legend |
+            awk '{print $1}'
+        )"
+        enabled_units="$(
+          systemctl list-unit-files 'vm0-runner-*.service' --state=enabled,enabled-runtime --plain --no-legend |
+            awk '{print $1}'
+        )"
+        printf '%s\n%s\n' "$loaded_units" "$enabled_units" |
+          sed 's/^vm0-runner-//;s/\.service$//' |
+          sed '/^$/d' |
+          sort -u
+      args:
+        executable: /bin/bash
       register: runner_service_candidates
       changed_when: false
-      ignore_errors: true
+      failed_when: false
+
+    - name: Record runner service discovery warning
+      set_fact:
+        runner_promotion_warnings: >-
+          {{
+            runner_promotion_warnings + [{
+              'host': inventory_hostname,
+              'service': 'vm0-runner-*.service',
+              'version': 'unknown',
+              'targetVersion': runner_release,
+              'stage': 'discovery',
+              'state': 'enumeration_failed',
+              'returnCode': runner_service_candidates.rc,
+              'error': (
+                runner_service_candidates.stderr
+                | default(runner_service_candidates.stdout, true)
+                | default(runner_service_candidates.msg, true)
+                | default('runner service discovery failed', true)
+                | trim
+              )
+            }]
+          }}
+      when: runner_service_candidates.rc != 0
 
     - name: Drain old runner services
       command: "{{ bin_dir }}/runner service drain --name {{ item }}"
       loop: "{{ runner_service_candidates.stdout_lines | default([]) }}"
-      when: item != runner_release
-      ignore_errors: true
+      when:
+        - runner_service_candidates.rc == 0
+        - item != runner_release
+      register: runner_drain_results
+      failed_when: false
+
+    - name: Record old runner drain warnings
+      set_fact:
+        runner_promotion_warnings: >-
+          {{
+            runner_promotion_warnings + [{
+              'host': inventory_hostname,
+              'service': 'vm0-runner-' ~ item.item ~ '.service',
+              'version': item.item,
+              'targetVersion': runner_release,
+              'stage': 'drain',
+              'state': 'drain_failed',
+              'returnCode': item.rc,
+              'error': (
+                item.stderr
+                | default(item.stdout, true)
+                | default(item.msg, true)
+                | default('runner service drain failed', true)
+                | trim
+              )
+            }]
+          }}
+      loop: "{{ runner_drain_results.results | default([]) }}"
+      when:
+        - not (item.skipped | default(false))
+        - (item.rc | default(0) | int) != 0
+
+    - name: Report runner promotion warnings
+      debug:
+        msg: "{{ item | to_json }}"
+      loop: "{{ runner_promotion_warnings }}"
+
+    - name: Write runner promotion warnings for the controller
+      copy:
+        content: "{{ runner_promotion_warnings | to_nice_json }}\n"
+        dest: >-
+          {{ promotion_warning_dir | default('') }}/{{ inventory_hostname | hash('sha256') }}.json
+        mode: "0600"
+      delegate_to: localhost
+      become: false
+      when:
+        - (promotion_warning_dir | default('') | length) > 0
+        - (runner_promotion_warnings | length) > 0
 
     - name: Garbage collect old artifacts
       include_tasks: ../tasks/garbage-collect-runner.yml

--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -21,6 +21,9 @@
 //! verified, [`wait_for_drain_signal_convergence`] keeps the transition
 //! fail-closed while it either signals the active replacement or observes a
 //! state that no longer needs a signal.
+//! After signal delivery, [`wait_for_drain_acknowledgement`] requires the
+//! captured live process and status generation to report Draining/Stopping,
+//! or observes service/process exit. It does not wait for active runs.
 //!
 //! ## Drain rollback boundary
 //!
@@ -77,7 +80,9 @@ use tokio::time::Instant;
 use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::live_runner_instances::{self, LiveRunnerInstance};
 use crate::paths::HomePaths;
+use crate::status_file;
 
 use super::drain_override::{
     DrainRestartOverrideWrite, remove_drain_restart_override, write_drain_restart_override,
@@ -92,11 +97,13 @@ use super::systemctl::{
 };
 use super::{
     RunnerServiceUnit, ServiceFuture, acquire_service_lock, read_unit_config_path,
-    selected_config_base_dir,
+    selected_config_base_dir, selected_config_live_instance,
 };
 
 const DRAIN_SIGNAL_CONVERGENCE_TIMEOUT: Duration = Duration::from_secs(10);
 const DRAIN_SIGNAL_CONVERGENCE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const DRAIN_ACKNOWLEDGEMENT_TIMEOUT: Duration = Duration::from_secs(10);
+const DRAIN_ACKNOWLEDGEMENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const RESUME_ACKNOWLEDGEMENT_TIMEOUT: Duration = Duration::from_secs(10);
 const RESUME_ACKNOWLEDGEMENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
@@ -163,6 +170,10 @@ trait ServiceDrainOps {
         unit: &'a RunnerServiceUnit,
         enablement: SystemdUnitEnablement,
     ) -> ServiceFuture<'a, ()>;
+    fn read_unit_config_path<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, Option<std::path::PathBuf>>;
 }
 
 trait ServiceResumeOps {
@@ -273,6 +284,13 @@ impl ServiceDrainOps for RealServiceDrainOps {
         enablement: SystemdUnitEnablement,
     ) -> ServiceFuture<'a, ()> {
         Box::pin(async move { restore_unit_enablement(unit, enablement).await })
+    }
+
+    fn read_unit_config_path<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, Option<std::path::PathBuf>> {
+        Box::pin(async move { read_unit_config_path(unit).await })
     }
 }
 
@@ -571,10 +589,60 @@ fn drain_signal_convergence_timeout_error(
     )
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DrainSignalConvergence {
+    SignalDelivered,
+    ServiceStopped,
+}
+
+#[derive(serde::Deserialize)]
+struct DrainStatusFile {
+    mode: String,
+    started_at: String,
+    updated_at: String,
+}
+
+struct DrainStatusSnapshot {
+    mode: String,
+    started_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+async fn read_drain_status(base_dir: &Path) -> RunnerResult<DrainStatusSnapshot> {
+    let path = status_file::path(base_dir);
+    let file = status_file::read_as::<DrainStatusFile>(base_dir)
+        .await
+        .map_err(|error| RunnerError::Internal(error.to_string()))?
+        .ok_or_else(|| RunnerError::Internal(format!("{} not found", path.display())))?;
+    let started_at = chrono::DateTime::parse_from_rfc3339(&file.started_at)
+        .map(|value| value.with_timezone(&chrono::Utc))
+        .map_err(|error| {
+            RunnerError::Internal(format!(
+                "parse started_at {:?} in {}: {error}",
+                file.started_at,
+                path.display()
+            ))
+        })?;
+    let updated_at = chrono::DateTime::parse_from_rfc3339(&file.updated_at)
+        .map(|value| value.with_timezone(&chrono::Utc))
+        .map_err(|error| {
+            RunnerError::Internal(format!(
+                "parse updated_at {:?} in {}: {error}",
+                file.updated_at,
+                path.display()
+            ))
+        })?;
+    Ok(DrainStatusSnapshot {
+        mode: file.mode,
+        started_at,
+        updated_at,
+    })
+}
+
 async fn wait_for_drain_signal_convergence(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceDrainOps,
-) -> RunnerResult<()> {
+) -> RunnerResult<DrainSignalConvergence> {
     let deadline = Instant::now() + DRAIN_SIGNAL_CONVERGENCE_TIMEOUT;
     let mut last_active_state = "unknown".to_string();
 
@@ -604,7 +672,7 @@ async fn wait_for_drain_signal_convergence(
                 active_state = %state.active_state(),
                 "runner exited before drain signal convergence"
             );
-            return Ok(());
+            return Ok(DrainSignalConvergence::ServiceStopped);
         }
         if state.active_state() == "deactivating" {
             // Restart=no was verified before signal delivery. While systemd is
@@ -614,7 +682,7 @@ async fn wait_for_drain_signal_convergence(
                 unit = %unit.unit_name(),
                 "runner is deactivating with Restart=no applied; drain signal not needed"
             );
-            return Ok(());
+            return Ok(DrainSignalConvergence::ServiceStopped);
         }
 
         let now = Instant::now();
@@ -634,7 +702,7 @@ async fn wait_for_drain_signal_convergence(
         match signal_result {
             ServiceSignalOutcome::Sent => {
                 info!(unit = %unit.unit_name(), "sent SIGUSR1 (drain) during signal convergence");
-                return Ok(());
+                return Ok(DrainSignalConvergence::SignalDelivered);
             }
             ServiceSignalOutcome::AlreadyGone => {}
         }
@@ -654,7 +722,7 @@ async fn wait_for_drain_signal_convergence(
 async fn drain_with_ops(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceDrainOps,
-) -> RunnerResult<()> {
+) -> RunnerResult<DrainSignalConvergence> {
     let initial_state = ops
         .lifecycle_state(unit, DRAIN_SIGNAL_CONVERGENCE_TIMEOUT)
         .await?;
@@ -751,7 +819,7 @@ async fn drain_with_ops(
         }
     }
 
-    if should_signal {
+    let convergence = if should_signal {
         // The lifecycle query above can race against the runner exiting or an
         // already-committed auto-restart timer. Once the main process is gone,
         // retain fail-closed state and converge instead of rolling protections
@@ -763,18 +831,227 @@ async fn drain_with_ops(
                     error = %error,
                     "initial drain signal failed; retaining Restart=no while converging"
                 );
-                wait_for_drain_signal_convergence(unit, ops).await?;
+                wait_for_drain_signal_convergence(unit, ops).await?
             }
             Ok(ServiceSignalOutcome::Sent) => {
                 info!(unit = %unit.unit_name(), "sent SIGUSR1 (drain)");
+                DrainSignalConvergence::SignalDelivered
             }
             Ok(ServiceSignalOutcome::AlreadyGone) => {
-                wait_for_drain_signal_convergence(unit, ops).await?;
+                wait_for_drain_signal_convergence(unit, ops).await?
             }
         }
-    }
+    } else {
+        DrainSignalConvergence::ServiceStopped
+    };
 
-    Ok(())
+    Ok(convergence)
+}
+
+struct DrainAcknowledgementTarget {
+    instance: LiveRunnerInstance,
+    started_at: chrono::DateTime<chrono::Utc>,
+}
+
+async fn capture_drain_acknowledgement_target(
+    unit: &RunnerServiceUnit,
+    home: &HomePaths,
+    ops: &mut impl ServiceDrainOps,
+) -> RunnerResult<DrainAcknowledgementTarget> {
+    let config_path = ops.read_unit_config_path(unit).await?.ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "{} does not select a runner --config path — cannot observe drain acknowledgement",
+            unit.unit_name()
+        ))
+    })?;
+    let instance = selected_config_live_instance(unit, &config_path, home)
+        .await?
+        .ok_or_else(|| {
+            RunnerError::Internal(format!(
+                "cannot resolve a live runner instance for {} from selected config {} — cannot observe drain acknowledgement",
+                unit.unit_name(),
+                config_path.display()
+            ))
+        })?;
+    let status = read_drain_status(&instance.base_dir)
+        .await
+        .map_err(|error| {
+            RunnerError::Internal(format!(
+                "cannot read status.json for {} before drain: {error}",
+                unit.unit_name()
+            ))
+        })?;
+    let instance_published_at = chrono::DateTime::parse_from_rfc3339(&instance.started_at)
+        .map(|value| value.with_timezone(&chrono::Utc))
+        .map_err(|error| {
+            RunnerError::Internal(format!(
+                "cannot parse live runner instance started_at {:?} for {} before drain: {error}",
+                instance.started_at,
+                unit.unit_name()
+            ))
+        })?;
+    // Startup publishes the live-process record before its initial status.
+    // Reject a leftover status file that the selected process has not updated.
+    if status.updated_at < instance_published_at {
+        return Err(RunnerError::Internal(format!(
+            "status.json for {} predates the selected live process (status updated_at={}, live instance started_at={}) — cannot observe drain acknowledgement",
+            unit.unit_name(),
+            status.updated_at,
+            instance_published_at
+        )));
+    }
+    Ok(DrainAcknowledgementTarget {
+        instance,
+        started_at: status.started_at,
+    })
+}
+
+fn drain_acknowledgement_timeout_error(
+    unit: &RunnerServiceUnit,
+    last_observation: &str,
+) -> RunnerError {
+    RunnerError::Internal(format!(
+        "timed out after {}s waiting for {} to acknowledge drain (last observation: {last_observation}); Restart=no remains applied",
+        DRAIN_ACKNOWLEDGEMENT_TIMEOUT.as_secs(),
+        unit.unit_name()
+    ))
+}
+
+async fn wait_for_next_drain_observation(deadline: Instant) {
+    let now = Instant::now();
+    if now < deadline {
+        tokio::time::sleep(std::cmp::min(
+            DRAIN_ACKNOWLEDGEMENT_POLL_INTERVAL,
+            deadline - now,
+        ))
+        .await;
+    }
+}
+
+async fn wait_for_drain_acknowledgement(
+    unit: &RunnerServiceUnit,
+    home: &HomePaths,
+    target: Result<DrainAcknowledgementTarget, RunnerError>,
+    ops: &mut impl ServiceDrainOps,
+) -> RunnerResult<()> {
+    let deadline = Instant::now() + DRAIN_ACKNOWLEDGEMENT_TIMEOUT;
+    let mut last_observation = "not observed".to_string();
+
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(drain_acknowledgement_timeout_error(unit, &last_observation));
+        }
+
+        let state = ops
+            .lifecycle_state(unit, deadline - now)
+            .await
+            .map_err(|error| {
+                RunnerError::Internal(format!(
+                    "cannot read systemd lifecycle state for {} while waiting for drain acknowledgement: {error}; Restart=no remains applied",
+                    unit.unit_name()
+                ))
+            })?;
+        if !state.is_active_like() || state.active_state() == "deactivating" {
+            info!(
+                unit = %unit.unit_name(),
+                active_state = %state.active_state(),
+                "runner acknowledged drain by stopping"
+            );
+            return Ok(());
+        }
+
+        let target = match &target {
+            Ok(target) => target,
+            Err(error) => {
+                last_observation = format!(
+                    "ActiveState={:?}, acknowledgement target unavailable: {error}",
+                    state.active_state()
+                );
+                wait_for_next_drain_observation(deadline).await;
+                continue;
+            }
+        };
+
+        match live_runner_instances::is_current(home, &target.instance).await {
+            Ok(true) => {}
+            Ok(false) => {
+                last_observation = format!(
+                    "ActiveState={:?}, captured runner process identity is no longer current",
+                    state.active_state()
+                );
+                wait_for_next_drain_observation(deadline).await;
+                continue;
+            }
+            Err(error) => {
+                last_observation = format!(
+                    "ActiveState={:?}, cannot verify runner process identity: {error}",
+                    state.active_state()
+                );
+                wait_for_next_drain_observation(deadline).await;
+                continue;
+            }
+        }
+
+        match read_drain_status(&target.instance.base_dir).await {
+            Ok(status) => {
+                if status.started_at != target.started_at {
+                    return Err(RunnerError::Internal(format!(
+                        "{} status generation changed before drain acknowledgement (started_at changed from {} to {}); Restart=no remains applied",
+                        unit.unit_name(),
+                        target.started_at,
+                        status.started_at
+                    )));
+                }
+                match status.mode.as_str() {
+                    "draining" | "stopping" | "stopped" => {
+                        info!(
+                            unit = %unit.unit_name(),
+                            mode = %status.mode,
+                            "runner acknowledged drain"
+                        );
+                        return Ok(());
+                    }
+                    "starting" | "running" => {
+                        last_observation = format!(
+                            "ActiveState={:?}, mode={:?}, started_at={}",
+                            state.active_state(),
+                            status.mode,
+                            status.started_at
+                        );
+                    }
+                    mode => {
+                        return Err(RunnerError::Internal(format!(
+                            "{} reported invalid mode {mode:?} while acknowledging drain; Restart=no remains applied",
+                            unit.unit_name()
+                        )));
+                    }
+                }
+            }
+            Err(error) => {
+                last_observation = format!(
+                    "ActiveState={:?}, cannot read status.json: {error}",
+                    state.active_state()
+                );
+            }
+        }
+
+        wait_for_next_drain_observation(deadline).await;
+    }
+}
+
+async fn drain_and_wait_with_ops(
+    unit: &RunnerServiceUnit,
+    home: &HomePaths,
+    ops: &mut impl ServiceDrainOps,
+) -> RunnerResult<()> {
+    let target = capture_drain_acknowledgement_target(unit, home, ops).await;
+    match drain_with_ops(unit, ops).await? {
+        DrainSignalConvergence::SignalDelivered => {
+            wait_for_drain_acknowledgement(unit, home, target, ops).await
+        }
+        DrainSignalConvergence::ServiceStopped => Ok(()),
+    }
 }
 
 fn resume_acknowledgement_timeout_error(unit: &RunnerServiceUnit) -> RunnerError {
@@ -982,15 +1259,16 @@ async fn resume_with_ops(
     resume_after_preflight_with_ops(unit, &base_dir, status.started_at, ops).await
 }
 
-/// `service drain` — send SIGUSR1 and disable the unit without waiting for active jobs.
+/// `service drain` — send SIGUSR1, observe acknowledgement, and disable the unit
+/// without waiting for active jobs to finish.
 ///
 /// The command may wait for systemd operations and bounded drain-signal
-/// convergence before returning.
+/// convergence, followed by bounded same-process lifecycle acknowledgement.
 pub(super) async fn run_drain(args: DrainArgs) -> RunnerResult<()> {
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;
     let home = HomePaths::new()?;
     let _service_lock = acquire_service_lock(&unit, &home).await?;
-    drain_with_ops(&unit, &mut RealServiceDrainOps).await
+    drain_and_wait_with_ops(&unit, &home, &mut RealServiceDrainOps).await
 }
 
 /// `service resume` — send SIGUSR2, re-enable unit.
@@ -1026,6 +1304,13 @@ mod tests {
 
     fn test_status_content(mode: &str, started_at: &str) -> String {
         format!(r#"{{"mode":"{mode}","active_runs":[],"started_at":"{started_at}"}}"#)
+    }
+
+    fn drain_status_content(mode: &str, started_at: &str) -> String {
+        let updated_at = chrono::Utc::now().to_rfc3339();
+        format!(
+            r#"{{"mode":"{mode}","active_runs":[],"started_at":"{started_at}","updated_at":"{updated_at}"}}"#
+        )
     }
 
     fn active_results(count: usize) -> VecDeque<RunnerResult<bool>> {
@@ -1064,6 +1349,16 @@ mod tests {
         .unwrap();
     }
 
+    async fn write_drain_status(base_dir: &Path, mode: &str, started_at: &str) {
+        tokio::fs::create_dir_all(base_dir).await.unwrap();
+        tokio::fs::write(
+            base_dir.join("status.json"),
+            drain_status_content(mode, started_at),
+        )
+        .await
+        .unwrap();
+    }
+
     async fn publish_test_live_runner(
         home: &HomePaths,
         config_path: &Path,
@@ -1080,6 +1375,24 @@ mod tests {
         )
         .await
         .unwrap()
+    }
+
+    async fn setup_drain_target(
+        mode: &str,
+    ) -> (
+        tempfile::TempDir,
+        HomePaths,
+        PathBuf,
+        PathBuf,
+        crate::live_runner_instances::LiveRunnerInstanceHandle,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let config_path = dir.path().join("runner.yaml");
+        let base_dir = home.runners_dir().join("runner-test");
+        let handle = publish_test_live_runner(&home, &config_path, &base_dir).await;
+        write_drain_status(&base_dir, mode, TEST_RUNNER_STARTED_AT).await;
+        (dir, home, config_path, base_dir, handle)
     }
 
     async fn resume_after_preflight_for_test(ops: &mut FakeResumeOps) -> RunnerResult<()> {
@@ -1105,6 +1418,8 @@ mod tests {
         restart_policy_results: VecDeque<RunnerResult<String>>,
         signal_results: VecDeque<RunnerResult<ServiceSignalOutcome>>,
         signal_timeouts: Vec<Duration>,
+        config_path: Option<PathBuf>,
+        status_update_on_signal: Option<(PathBuf, String)>,
         disable_error: bool,
         restore_enablement_error: bool,
     }
@@ -1141,6 +1456,8 @@ mod tests {
                 restart_policy_results: VecDeque::from([Ok("no".to_string())]),
                 signal_results: signal_results(ServiceSignalOutcome::Sent, 1),
                 signal_timeouts: Vec::new(),
+                config_path: Some(PathBuf::from("/tmp/runner-config.yaml")),
+                status_update_on_signal: None,
                 disable_error: false,
                 restore_enablement_error: false,
             }
@@ -1252,11 +1569,22 @@ mod tests {
             _unit: &'a RunnerServiceUnit,
         ) -> ServiceFuture<'a, ServiceSignalOutcome> {
             self.events.push("signal_drain");
-            Box::pin(std::future::ready(
-                self.signal_results
-                    .pop_front()
-                    .expect("missing fake drain signal result"),
-            ))
+            let result = self
+                .signal_results
+                .pop_front()
+                .expect("missing fake drain signal result");
+            let sent = matches!(&result, Ok(ServiceSignalOutcome::Sent));
+            let status_update = if sent {
+                self.status_update_on_signal.take()
+            } else {
+                None
+            };
+            Box::pin(async move {
+                if let Some((path, content)) = status_update {
+                    tokio::fs::write(path, content).await.unwrap();
+                }
+                result
+            })
         }
 
         fn signal_drain_bounded<'a>(
@@ -1297,6 +1625,14 @@ mod tests {
             } else {
                 Ok(())
             }))
+        }
+
+        fn read_unit_config_path<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, Option<PathBuf>> {
+            self.events.push("read_config_path");
+            Box::pin(std::future::ready(Ok(self.config_path.clone())))
         }
     }
 
@@ -2102,6 +2438,227 @@ mod tests {
             ops.reload_requirements,
             [SystemdReloadRequirement::dirty().with_drain_override(true)]
         );
+    }
+
+    #[tokio::test]
+    async fn drain_waits_for_same_process_draining_acknowledgement() {
+        let (_dir, home, config_path, base_dir, _handle) = setup_drain_target("running").await;
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: lifecycle_states("active", 2),
+            config_path: Some(config_path),
+            status_update_on_signal: Some((
+                base_dir.join("status.json"),
+                drain_status_content("draining", TEST_RUNNER_STARTED_AT),
+            )),
+            ..FakeDrainOps::default()
+        };
+
+        drain_and_wait_with_ops(&service_unit(), &home, &mut ops)
+            .await
+            .unwrap();
+
+        assert_eq!(ops.events.first(), Some(&"read_config_path"));
+        assert!(ops.events.contains(&"signal_drain"));
+        assert_eq!(ops.events.last(), Some(&"lifecycle_state"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_waits_for_delayed_acknowledgement() {
+        let (_dir, home, config_path, base_dir, _handle) = setup_drain_target("running").await;
+        let status_path = base_dir.join("status.json");
+        let update = tokio::spawn(async move {
+            tokio::time::sleep(DRAIN_ACKNOWLEDGEMENT_POLL_INTERVAL * 2).await;
+            tokio::fs::write(
+                status_path,
+                drain_status_content("draining", TEST_RUNNER_STARTED_AT),
+            )
+            .await
+            .unwrap();
+        });
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: lifecycle_states("active", 10),
+            config_path: Some(config_path),
+            ..FakeDrainOps::default()
+        };
+
+        drain_and_wait_with_ops(&service_unit(), &home, &mut ops)
+            .await
+            .unwrap();
+        update.await.unwrap();
+
+        assert!(
+            ops.events
+                .iter()
+                .filter(|event| **event == "lifecycle_state")
+                .count()
+                >= 3
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_accepts_stopping_with_active_runs() {
+        let (_dir, home, config_path, base_dir, _handle) = setup_drain_target("running").await;
+        let updated_at = chrono::Utc::now().to_rfc3339();
+        let stopping = format!(
+            r#"{{"mode":"stopping","active_runs":[{{"run_id":"00000000-0000-0000-0000-000000000001"}}],"started_at":"{TEST_RUNNER_STARTED_AT}","updated_at":"{updated_at}"}}"#
+        );
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: lifecycle_states("active", 2),
+            config_path: Some(config_path),
+            status_update_on_signal: Some((base_dir.join("status.json"), stopping)),
+            ..FakeDrainOps::default()
+        };
+
+        drain_and_wait_with_ops(&service_unit(), &home, &mut ops)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn drain_accepts_service_exit_after_signal() {
+        let (_dir, home, config_path, _base_dir, _handle) = setup_drain_target("running").await;
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: VecDeque::from([
+                lifecycle_state("active"),
+                lifecycle_state("inactive"),
+            ]),
+            config_path: Some(config_path),
+            ..FakeDrainOps::default()
+        };
+
+        drain_and_wait_with_ops(&service_unit(), &home, &mut ops)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_stale_running_status_times_out_with_observation() {
+        let (_dir, home, config_path, _base_dir, _handle) = setup_drain_target("running").await;
+        let attempts = (DRAIN_ACKNOWLEDGEMENT_TIMEOUT.as_millis()
+            / DRAIN_ACKNOWLEDGEMENT_POLL_INTERVAL.as_millis()) as usize
+            + 2;
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: lifecycle_states("active", attempts),
+            config_path: Some(config_path),
+            ..FakeDrainOps::default()
+        };
+        let started_at = Instant::now();
+
+        let error = drain_and_wait_with_ops(&service_unit(), &home, &mut ops)
+            .await
+            .unwrap_err();
+        let message = error.to_string();
+
+        assert_eq!(Instant::now() - started_at, DRAIN_ACKNOWLEDGEMENT_TIMEOUT);
+        assert!(message.contains("waiting for vm0-runner-test to acknowledge drain"));
+        assert!(message.contains("mode=\"running\""));
+        assert!(message.contains("Restart=no remains applied"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_unreadable_status_times_out_with_read_error() {
+        let (_dir, home, config_path, base_dir, _handle) = setup_drain_target("running").await;
+        let attempts = (DRAIN_ACKNOWLEDGEMENT_TIMEOUT.as_millis()
+            / DRAIN_ACKNOWLEDGEMENT_POLL_INTERVAL.as_millis()) as usize
+            + 2;
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: lifecycle_states("active", attempts),
+            config_path: Some(config_path),
+            status_update_on_signal: Some((base_dir.join("status.json"), "not json".to_string())),
+            ..FakeDrainOps::default()
+        };
+
+        let error = drain_and_wait_with_ops(&service_unit(), &home, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("cannot read status.json"));
+        assert!(error.to_string().contains("Restart=no remains applied"));
+    }
+
+    #[tokio::test]
+    async fn drain_rejects_replaced_status_generation() {
+        let (_dir, home, config_path, base_dir, _handle) = setup_drain_target("running").await;
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: lifecycle_states("active", 2),
+            config_path: Some(config_path),
+            status_update_on_signal: Some((
+                base_dir.join("status.json"),
+                drain_status_content("draining", "2026-08-05T00:00:00Z"),
+            )),
+            ..FakeDrainOps::default()
+        };
+
+        let error = drain_and_wait_with_ops(&service_unit(), &home, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("status generation changed"));
+        assert!(error.to_string().contains("Restart=no remains applied"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_rejects_status_from_noncurrent_process_identity() {
+        let (_dir, home, config_path, _base_dir, handle) = setup_drain_target("running").await;
+        let mut ops = FakeDrainOps {
+            config_path: Some(config_path),
+            lifecycle_state_results: lifecycle_states("active", 100),
+            ..FakeDrainOps::default()
+        };
+        let target = capture_drain_acknowledgement_target(&service_unit(), &home, &mut ops)
+            .await
+            .unwrap();
+        assert!(handle.remove_if_current().await.unwrap());
+
+        let error = wait_for_drain_acknowledgement(&service_unit(), &home, Ok(target), &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("process identity is no longer current")
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_stale_preflight_status_does_not_skip_signal_safeguards() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let config_path = dir.path().join("runner.yaml");
+        let base_dir = home.runners_dir().join("runner-test");
+        let _handle = publish_test_live_runner(&home, &config_path, &base_dir).await;
+        tokio::fs::create_dir_all(&base_dir).await.unwrap();
+        tokio::fs::write(
+            base_dir.join("status.json"),
+            format!(
+                r#"{{"mode":"running","active_runs":[],"started_at":"{TEST_RUNNER_STARTED_AT}","updated_at":"2026-01-01T00:00:00Z"}}"#
+            ),
+        )
+        .await
+        .unwrap();
+        let attempts = (DRAIN_ACKNOWLEDGEMENT_TIMEOUT.as_millis()
+            / DRAIN_ACKNOWLEDGEMENT_POLL_INTERVAL.as_millis()) as usize
+            + 2;
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: lifecycle_states("active", attempts),
+            config_path: Some(config_path),
+            ..FakeDrainOps::default()
+        };
+
+        let error = drain_and_wait_with_ops(&service_unit(), &home, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("predates the selected live process")
+        );
+        assert!(ops.events.contains(&"write_restart_override"));
+        assert!(ops.events.contains(&"restart_policy"));
+        assert!(ops.events.contains(&"signal_drain"));
+        assert!(!ops.events.contains(&"remove_restart_override"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/service/drain_resume.rs
+++ b/crates/runner/src/cmd/service/drain_resume.rs
@@ -973,9 +973,14 @@ async fn wait_for_drain_acknowledgement(
             }
         };
 
-        match live_runner_instances::is_current(home, &target.instance).await {
-            Ok(true) => {}
-            Ok(false) => {
+        let identity_result = tokio::time::timeout(
+            deadline.saturating_duration_since(Instant::now()),
+            live_runner_instances::is_current(home, &target.instance),
+        )
+        .await;
+        match identity_result {
+            Ok(Ok(true)) => {}
+            Ok(Ok(false)) => {
                 last_observation = format!(
                     "ActiveState={:?}, captured runner process identity is no longer current",
                     state.active_state()
@@ -983,7 +988,7 @@ async fn wait_for_drain_acknowledgement(
                 wait_for_next_drain_observation(deadline).await;
                 continue;
             }
-            Err(error) => {
+            Ok(Err(error)) => {
                 last_observation = format!(
                     "ActiveState={:?}, cannot verify runner process identity: {error}",
                     state.active_state()
@@ -991,10 +996,22 @@ async fn wait_for_drain_acknowledgement(
                 wait_for_next_drain_observation(deadline).await;
                 continue;
             }
+            Err(_) => {
+                let observation = format!(
+                    "ActiveState={:?}, process identity observation did not finish",
+                    state.active_state()
+                );
+                return Err(drain_acknowledgement_timeout_error(unit, &observation));
+            }
         }
 
-        match read_drain_status(&target.instance.base_dir).await {
-            Ok(status) => {
+        let status_result = tokio::time::timeout(
+            deadline.saturating_duration_since(Instant::now()),
+            read_drain_status(&target.instance.base_dir),
+        )
+        .await;
+        match status_result {
+            Ok(Ok(status)) => {
                 if status.started_at != target.started_at {
                     return Err(RunnerError::Internal(format!(
                         "{} status generation changed before drain acknowledgement (started_at changed from {} to {}); Restart=no remains applied",
@@ -1028,11 +1045,18 @@ async fn wait_for_drain_acknowledgement(
                     }
                 }
             }
-            Err(error) => {
+            Ok(Err(error)) => {
                 last_observation = format!(
                     "ActiveState={:?}, cannot read status.json: {error}",
                     state.active_state()
                 );
+            }
+            Err(_) => {
+                let observation = format!(
+                    "ActiveState={:?}, status.json observation did not finish",
+                    state.active_state()
+                );
+                return Err(drain_acknowledgement_timeout_error(unit, &observation));
             }
         }
 
@@ -1045,7 +1069,19 @@ async fn drain_and_wait_with_ops(
     home: &HomePaths,
     ops: &mut impl ServiceDrainOps,
 ) -> RunnerResult<()> {
-    let target = capture_drain_acknowledgement_target(unit, home, ops).await;
+    let target = match tokio::time::timeout(
+        DRAIN_ACKNOWLEDGEMENT_TIMEOUT,
+        capture_drain_acknowledgement_target(unit, home, ops),
+    )
+    .await
+    {
+        Ok(target) => target,
+        Err(_) => Err(RunnerError::Internal(format!(
+            "timed out after {}s resolving the acknowledgement target for {} before drain",
+            DRAIN_ACKNOWLEDGEMENT_TIMEOUT.as_secs(),
+            unit.unit_name()
+        ))),
+    };
     match drain_with_ops(unit, ops).await? {
         DrainSignalConvergence::SignalDelivered => {
             wait_for_drain_acknowledgement(unit, home, target, ops).await
@@ -1419,6 +1455,7 @@ mod tests {
         signal_results: VecDeque<RunnerResult<ServiceSignalOutcome>>,
         signal_timeouts: Vec<Duration>,
         config_path: Option<PathBuf>,
+        config_path_pending: bool,
         status_update_on_signal: Option<(PathBuf, String)>,
         disable_error: bool,
         restore_enablement_error: bool,
@@ -1457,6 +1494,7 @@ mod tests {
                 signal_results: signal_results(ServiceSignalOutcome::Sent, 1),
                 signal_timeouts: Vec::new(),
                 config_path: Some(PathBuf::from("/tmp/runner-config.yaml")),
+                config_path_pending: false,
                 status_update_on_signal: None,
                 disable_error: false,
                 restore_enablement_error: false,
@@ -1632,7 +1670,11 @@ mod tests {
             _unit: &'a RunnerServiceUnit,
         ) -> ServiceFuture<'a, Option<PathBuf>> {
             self.events.push("read_config_path");
-            Box::pin(std::future::ready(Ok(self.config_path.clone())))
+            if self.config_path_pending {
+                Box::pin(std::future::pending())
+            } else {
+                Box::pin(std::future::ready(Ok(self.config_path.clone())))
+            }
         }
     }
 
@@ -2654,6 +2696,39 @@ mod tests {
             error
                 .to_string()
                 .contains("predates the selected live process")
+        );
+        assert!(ops.events.contains(&"write_restart_override"));
+        assert!(ops.events.contains(&"restart_policy"));
+        assert!(ops.events.contains(&"signal_drain"));
+        assert!(!ops.events.contains(&"remove_restart_override"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_preflight_timeout_does_not_skip_signal_safeguards() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        let attempts = (DRAIN_ACKNOWLEDGEMENT_TIMEOUT.as_millis()
+            / DRAIN_ACKNOWLEDGEMENT_POLL_INTERVAL.as_millis()) as usize
+            + 2;
+        let mut ops = FakeDrainOps {
+            lifecycle_state_results: lifecycle_states("active", attempts),
+            config_path_pending: true,
+            ..FakeDrainOps::default()
+        };
+        let started_at = Instant::now();
+
+        let error = drain_and_wait_with_ops(&service_unit(), &home, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            Instant::now() - started_at,
+            DRAIN_ACKNOWLEDGEMENT_TIMEOUT * 2
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("resolving the acknowledgement target")
         );
         assert!(ops.events.contains(&"write_restart_override"));
         assert!(ops.events.contains(&"restart_policy"));

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -63,7 +63,7 @@ enum ServiceCommand {
     Install(ServiceRunArgs),
     /// Uninstall the runner service (stop + disable + remove unit)
     Uninstall(ServiceUninstallArgs),
-    /// Drain without waiting for active jobs (may wait for systemd operations and bounded signal convergence)
+    /// Drain without waiting for active jobs (waits for bounded same-process acknowledgement)
     Drain(drain_resume::DrainArgs),
     /// Resume a draining runner (SIGUSR2, reverses `drain` before teardown begins)
     Resume(drain_resume::ResumeArgs),
@@ -606,18 +606,18 @@ async fn uninstall_with_ops(
     ops.uninstall_unit(unit).await
 }
 
-fn selected_config_base_dir_from_live_instances(
+fn selected_config_live_instance_from_instances(
     unit: &RunnerServiceUnit,
     config_path: &Path,
     instances: &[LiveRunnerInstance],
-) -> RunnerResult<Option<PathBuf>> {
+) -> RunnerResult<Option<LiveRunnerInstance>> {
     let matches = instances
         .iter()
         .filter(|instance| instance.config_path == config_path && instance.subcommand == "start")
         .collect::<Vec<_>>();
 
     match matches.as_slice() {
-        [instance] => Ok(Some(instance.base_dir.clone())),
+        [instance] => Ok(Some((*instance).clone())),
         [] => Ok(None),
         _ => Err(RunnerError::Internal(format!(
             "{} has multiple live runner instance records for selected config {}",
@@ -627,13 +627,23 @@ fn selected_config_base_dir_from_live_instances(
     }
 }
 
+async fn selected_config_live_instance(
+    unit: &RunnerServiceUnit,
+    config_path: &Path,
+    home: &HomePaths,
+) -> RunnerResult<Option<LiveRunnerInstance>> {
+    let instances = live_runner_instances::try_list(home).await?;
+    selected_config_live_instance_from_instances(unit, config_path, &instances)
+}
+
 async fn selected_config_base_dir(
     unit: &RunnerServiceUnit,
     config_path: &Path,
     home: &HomePaths,
 ) -> RunnerResult<Option<PathBuf>> {
-    let instances = live_runner_instances::try_list(home).await?;
-    selected_config_base_dir_from_live_instances(unit, config_path, &instances)
+    Ok(selected_config_live_instance(unit, config_path, home)
+        .await?
+        .map(|instance| instance.base_dir))
 }
 
 fn wait_running_timeout_error(
@@ -1439,18 +1449,18 @@ profiles:
     }
 
     #[test]
-    fn readiness_base_dir_waits_without_live_record() {
+    fn selected_config_waits_without_live_record() {
         let unit = RunnerServiceUnit::from_suffix("pr-123-1").unwrap();
 
         let config_path = PathBuf::from("/vm0-runner/runners/pr-123/runner.yaml");
-        let base_dir =
-            selected_config_base_dir_from_live_instances(&unit, &config_path, &[]).unwrap();
+        let instance =
+            selected_config_live_instance_from_instances(&unit, &config_path, &[]).unwrap();
 
-        assert_eq!(base_dir, None);
+        assert_eq!(instance, None);
     }
 
     #[test]
-    fn readiness_base_dir_uses_exact_config_path_during_release_overlap() {
+    fn selected_config_uses_exact_path_during_release_overlap() {
         let unit = RunnerServiceUnit::from_suffix("pr-123-1").unwrap();
         let actual_base_dir = PathBuf::from("/vm0-runner/runners/pr-123");
         let config_path = actual_base_dir.join("runner.yaml");
@@ -1462,14 +1472,16 @@ profiles:
             ),
         ];
 
-        let base_dir =
-            selected_config_base_dir_from_live_instances(&unit, &config_path, &instances).unwrap();
+        let instance =
+            selected_config_live_instance_from_instances(&unit, &config_path, &instances)
+                .unwrap()
+                .unwrap();
 
-        assert_eq!(base_dir, Some(actual_base_dir));
+        assert_eq!(instance.base_dir, actual_base_dir);
     }
 
     #[test]
-    fn readiness_base_dir_rejects_duplicate_live_records() {
+    fn selected_config_rejects_duplicate_live_records() {
         let unit = RunnerServiceUnit::from_suffix("pr-123-1").unwrap();
         let config_path = PathBuf::from("/vm0-runner/runners/pr-123/runner.yaml");
         let instances = vec![
@@ -1483,7 +1495,7 @@ profiles:
             ),
         ];
 
-        let error = selected_config_base_dir_from_live_instances(&unit, &config_path, &instances)
+        let error = selected_config_live_instance_from_instances(&unit, &config_path, &instances)
             .unwrap_err();
 
         assert!(

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -455,7 +455,7 @@ mod tests {
             .join(" ");
 
         assert!(normalized_help.contains(
-            "drain Drain without waiting for active jobs (may wait for systemd operations and bounded signal convergence)"
+            "drain Drain without waiting for active jobs (waits for bounded same-process acknowledgement)"
         ));
     }
 

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -197,11 +197,16 @@ dual-protocol preparation release remains safe for canonical clients.
 
 Runner deployment is draining, not instant. The production promote playbook
 starts the new runner service, verifies it, and then sends a soft-drain signal
-to old runner services. Before that signal arrives, there can be a short overlap
-where both old and new runners are running. After old runners enter draining,
-they stop claiming new runs but keep executing already claimed runs until those
-runs finish. During that drain window, old runners continue calling backend APIs
-with the old protocol.
+to old runner services. Promotion observes a bounded acknowledgement from the
+same live process and status generation: Draining/Stopping, or service/process
+exit. This acknowledgement does not wait for active runs to finish. Discovery,
+signal, status, identity, or acknowledgement failures for an old runner are
+reported as promotion warnings while a healthy new runner remains promoted;
+promotion does not force-kill the old runner. Before the signal arrives, there
+can be a short overlap where both old and new runners are running. After old
+runners enter draining, they stop claiming new runs but keep executing already
+claimed runs until those runs finish. During that drain window, old runners
+continue calling backend APIs with the old protocol.
 
 The backend must support old runner requests until old runners have fully
 drained. Runner changes that require backend support must be staged so a new


### PR DESCRIPTION
## Summary

- make `runner service drain` wait for bounded acknowledgement from the captured live process and status generation after applying the existing restart safeguards
- enumerate loaded, transitional, and enabled old runner services without masking discovery failures, then continue draining siblings while collecting structured warnings
- publish old-runner warnings to the GitHub job summary and reuse the existing Slack “Promoted with warnings” path while keeping target readiness and health failures fatal

## Compatibility and scope

- reads the existing live-instance and `status.json` contracts; no API, database, queue, or status schema changes
- does not wait for active runs, force-stop old runners, or roll back a healthy promoted target
- closes delivery child #32052; parent #32040 remains open for its other delivery slices

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner --all-features` (3,463 unit tests and 1 inventory integration test passed)
- `.github/scripts/tests/runner-promotion-ansible-test.sh`
- `shellcheck .github/scripts/tests/runner-promotion-ansible-test.sh`
- `.github/scripts/check-workflow-shell-compatibility.sh .github/workflows/release-please.yml`
- `actionlint .github/workflows/release-please.yml`
- `git diff --check`

Closes #32052
Relates to #32040
