### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/signals/services/pi-api-first-turn-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn-config.ts
@@ -51,6 +51,7 @@ export function requirePiApiFirstTurnExecutionContext(
 ): PiApiFirstTurnActivation["executionContext"] {
   if (
     context.apiStartTime === undefined ||
+    context.billableFirewalls === undefined ||
     context.piLaunchConfig === undefined ||
     context.piModelConfig === undefined ||
     context.piSessionId === undefined
@@ -59,11 +60,7 @@ export function requirePiApiFirstTurnExecutionContext(
   }
   return {
     apiStartTime: context.apiStartTime,
-    // A pre-#31157 API can leave this stored billing snapshot absent during its
-    // rollback window and the two-hour runner/Sandbox drain plus finalization.
-    // Treat that old context as non-billable; remove after production proves no
-    // executable Pi context omits the field. Follow-up: #31161.
-    billableFirewalls: context.billableFirewalls ?? [],
+    billableFirewalls: context.billableFirewalls,
     encryptedSecrets: context.encryptedSecrets,
     environment: context.environment,
     modelUsageProvider: context.modelUsageProvider,


### PR DESCRIPTION
Removes the Pi API-first missing-`billableFirewalls` compatibility branch. Closes the removal gate in #31161.

## Cohort — Pi API-first stored billing snapshot

**Old boundary:** #31157 made Pi API-first billing distinguish built-in model-provider traffic from custom gateway traffic by reading the API-owned `billableFirewalls` snapshot on the stored execution context. A context written by a pre-#31157 API omits the field, so `requirePiApiFirstTurnExecutionContext` normalized the absence to an empty list — treating that old context as non-billable.

**New boundary:** the Pi API-first activation path requires the snapshot. `billableFirewalls` joins the existing incomplete-context guard and is read directly.

Removed:
- `billableFirewalls: context.billableFirewalls ?? []` and its rollout comment

Added:
- `context.billableFirewalls === undefined` to the `Pi API first-turn execution context is incomplete` guard, so a context that somehow lacked the snapshot fails closed instead of being silently billed as empty

**Deliberately not changed:** `billableFirewalls` stays `.optional()` on the shared stored-execution-context and runner-job schemas in `runners.ts`. Those schemas cover every run kind, not just Pi API-first, so requiring it contract-wide would be wrong. The issue's scope asks for the *activation path* to require the current shape, which is what this does.

**Window:** canonical window 1 for the old API writer, plus canonical window 3 (2 h) for a runner/Sandbox that outlives it, plus bounded finalization — exactly the gate the comment named.

**Rollout evidence (observed):**
- #31157 merged `2026-09-02T16:19:43Z` (`e8cd4dba2e5`).
- First `api/production` deployment containing it: `8a2e79bb7f`, `2026-09-02T17:03:46Z`, confirmed with `git merge-base --is-ancestor` walking the deployment list forward from oldest.
- **53 further `api/production` deployments** have been promoted since.
- Elapsed: **~100 hours (4.2 days)** against a bound of the rollback window plus a two-hour guest runtime budget and finalization.

**MaskDB evidence (read-only, `vm0-prod-ro`, structured API only)** — this is the decisive proof for the drain query the issue requires ("a read-only production query confirms there are no non-terminal Pi runs whose stored execution context omits `billableFirewalls`"):
- `agent_runs` exposes `status` and `created_at` as unmasked and filterable. The stored execution context itself is masked, so the field cannot be filtered directly; the equivalent and stronger proof is that **no run created before the cutover is still non-terminal**, since only a non-terminal run can activate a Pi first turn.
- Grouped count over `created_at < 2026-09-02T17:03:46Z`: **`completed` 199,260, `failed` 3,951, `cancelled` 3,464, `timeout` 104 — 206,779 rows, all terminal.** Zero `queued`, `running`, or otherwise non-terminal.
- Freshness: the newest `agent_runs` row observed is `2026-09-06T21:03:01Z`, seconds before this run, so this is live production state rather than a stale snapshot.
- No row-level data is reproduced here; only aggregate counts by status and timestamps.

**Source evidence that current writers always set it:** `agent-run-create.service.ts` types `billableFirewalls` as `readonly string[]` on its context shapes and populates it unconditionally on every branch — `[]` where nothing is billable, and the accumulated list otherwise.

**Axiom:** no route-level signal applies. The discriminator is the presence of one key inside a masked stored payload, not a request attribute. Recorded as a deliberate non-use rather than a zero-count claim; the deployment chain and the MaskDB census above carry this cohort.

## Explicitly deferred

- **`pi-memory-phase2-checkpoint.service.ts` schema probe (#31067).** Its migration reached production only at `2026-09-06T01:05:56Z`, about 20 hours before this run, and the parent EPIC is still actively landing changes.
- **`clerk-production-topology.ts` rollback branch.** It is the explicit rollback lever for the VM0-to-Okou auth topology cutover, and #27750 has not recorded the gate as closed; open PR #31602 is still landing rename work.
- **AgentPhone brandless connect.** The path validates a request signature from sub-floor App builds that the client census keeps showing as active.
- **Queued-launch-context brand reads** for Telegram, AgentPhone, and Feishu. MaskDB's projection still does not expose `public_brand` on those context tables.
- **#29908**, **#26519**, **#27786**, **#28449 residue**, `browser-session` PK contraction (also blocked by open PR #31905 squashing migrations), `model-provider-account` expansions, and the artifact-object fallbacks — unchanged product or evidence gates.

Two entries were also **retired from the ledger** this run after re-reading them: the `workflow-automation-poller` and `artifact-catalog` comments describe why the current design is shaped the way it is, not a removable branch, and `connector-oauth-device-auth` no longer contains a previous-API reference.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F api lint` (no new warnings), `pnpm -F api check-types`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F api exec vitest run` on `chat-events.bdd` (228) and `run-lifecycle.bdd` (205) — the two suites that exercise the Pi API-first activation path — against a local Postgres with `timezone=UTC`

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.

Closes #31161.
