### PR TITLE
fix(desktop): move okou authentication to an isolated app session

### DIFF
--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -50,6 +50,7 @@
     "@okouai/typescript-config": "workspace:*",
     "electron": "42.5.1",
     "happy-dom": "^20.11.6",
+    "msw": "^2.13.2",
     "oxlint": "^1.75.0",
     "sharp": "0.35.0",
     "tsup": "^8.5.1",

--- a/turbo/apps/desktop/src/bootstrap-degraded.test.ts
+++ b/turbo/apps/desktop/src/bootstrap-degraded.test.ts
@@ -56,6 +56,7 @@ vi.mock("@sentry/electron/main", () => ({
 }));
 
 const originalPlatform = process.platform;
+const originalArch = process.arch;
 
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, "platform", { value: platform });
@@ -65,6 +66,7 @@ function productionConfig(): DesktopConfig {
   return {
     platformUrl: new URL("https://app.vm0.ai"),
     webUrl: new URL("https://app.vm0.ai"),
+    authUrl: new URL("https://www.vm0.ai"),
     environment: "production",
     identity: {
       product: "zero",
@@ -77,6 +79,7 @@ function productionConfig(): DesktopConfig {
       authScheme: "vm0-desktop",
     },
     sessionPartition: "persist:desktop",
+    authPartition: "persist:desktop",
     allowedAppOrigins: new Set(["https://app.vm0.ai"]),
   };
 }
@@ -96,12 +99,14 @@ async function enterDegradedMode(error: unknown): Promise<void> {
 beforeEach(() => {
   vi.resetModules();
   setPlatform("darwin");
+  Object.defineProperty(process, "arch", { value: "arm64" });
   mocks.app.isPackaged = true;
   mocks.app.requestSingleInstanceLock.mockReturnValue(true);
   mocks.app.getPath.mockReturnValue(mkdtempSync(join(tmpdir(), "bootstrap-")));
   delete process.env.SENTRY_DSN_DESKTOP;
   return () => {
     setPlatform(originalPlatform);
+    Object.defineProperty(process, "arch", { value: originalArch });
   };
 });
 

--- a/turbo/apps/desktop/src/bootstrap.test.ts
+++ b/turbo/apps/desktop/src/bootstrap.test.ts
@@ -21,6 +21,7 @@ vi.mock("./config", () => ({
   resolveDesktopConfig: () => ({
     platformUrl: new URL("https://app.okou.ai"),
     webUrl: new URL("https://www.vm0.ai"),
+    authUrl: new URL("https://app.okou.ai"),
     environment: "production",
     identity: {
       product: "okou",
@@ -33,6 +34,7 @@ vi.mock("./config", () => ({
       authScheme: "ai.okou.desktop",
     },
     sessionPartition: "persist:vm0-desktop-production",
+    authPartition: "persist:okou-desktop-auth-test",
     allowedAppOrigins: new Set(["https://app.okou.ai"]),
   }),
 }));

--- a/turbo/apps/desktop/src/config.ts
+++ b/turbo/apps/desktop/src/config.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { DesktopProduct } from "@okouai/api-contracts/contracts/client-headers";
@@ -30,9 +31,11 @@ interface DesktopRuntimeConfig {
 export interface DesktopConfig {
   readonly platformUrl: URL;
   readonly webUrl: URL;
+  readonly authUrl: URL;
   readonly environment: DesktopEnvironment;
   readonly identity: DesktopIdentity;
   readonly sessionPartition: string;
+  readonly authPartition: string;
   readonly allowedAppOrigins: ReadonlySet<string>;
 }
 
@@ -231,12 +234,28 @@ export function resolveDesktopConfig(
   const platformUrl = parsePlatformUrl(platformUrlSource, product);
   const environment = environmentForPlatformUrl(platformUrl, hasExplicitUrl);
 
+  const sessionPartition = `persist:vm0-desktop-${environment}`;
+  const authUrl =
+    product === "okou"
+      ? new URL(
+          environment === "production"
+            ? desktopIdentities.okou.defaultPlatformUrl
+            : platformUrl.origin,
+        )
+      : deriveCompanionUrl(platformUrl, "www");
   return {
     platformUrl,
     webUrl: deriveCompanionUrl(platformUrl, "www"),
+    authUrl,
     environment,
     identity: identityForEnvironment(product, environment),
-    sessionPartition: `persist:vm0-desktop-${environment}`,
+    sessionPartition,
+    // Keep Clerk and App credentials in their own store. Signing out can clear
+    // it completely without touching native preferences, recordings or plugins.
+    authPartition:
+      product === "okou"
+        ? `persist:okou-desktop-auth-${createHash("sha256").update(authUrl.origin).digest("hex")}`
+        : sessionPartition,
     allowedAppOrigins: allowedOriginsForPlatformUrl(platformUrl),
   };
 }

--- a/turbo/apps/desktop/src/desktop-auth-electron.ts
+++ b/turbo/apps/desktop/src/desktop-auth-electron.ts
@@ -2,11 +2,12 @@ import type { IpcMainInvokeEvent } from "electron";
 import { BrowserWindow, ipcMain } from "electron";
 import type { DesktopAuthState } from "./desktop-bridge";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
+import type { DesktopAuthWindow } from "./desktop-auth-window";
 import { isDesktopRendererUrl } from "./desktop-renderer-url";
 
 interface DesktopAuthIpcOptions {
   readonly rendererUrl: string;
-  readonly allowedAppOrigins: ReadonlySet<string>;
+  readonly authWindow: DesktopAuthWindow;
 }
 
 interface DesktopAuthNativeApi {
@@ -14,7 +15,6 @@ interface DesktopAuthNativeApi {
   readonly openSignIn: () => void;
   readonly openOrgSelection: () => Promise<void>;
   readonly signOut: () => Promise<void>;
-  readonly completeSignIn: (token: string) => Promise<void> | void;
 }
 
 interface DesktopAuthCompleteSignInPayload {
@@ -41,19 +41,6 @@ export function installDesktopAuthIpc(
     }
   };
 
-  const assertDesktopAuthPage = (event: IpcMainInvokeEvent): void => {
-    const rawUrl = event.senderFrame?.url ?? "";
-    try {
-      const url = new URL(rawUrl);
-      if (options.allowedAppOrigins.has(url.origin)) {
-        return;
-      }
-    } catch {
-      // Fall through to the error below.
-    }
-    throw new Error("Desktop auth completion is unavailable on this page");
-  };
-
   const parseCompleteSignInPayload = (
     value: unknown,
   ): DesktopAuthCompleteSignInPayload => {
@@ -62,7 +49,8 @@ export function installDesktopAuthIpc(
       value === null ||
       !("token" in value) ||
       typeof value.token !== "string" ||
-      value.token.length === 0
+      value.token.length === 0 ||
+      /[\s\p{Cc}]/u.test(value.token)
     ) {
       throw new Error("Desktop auth completion requires a token");
     }
@@ -88,9 +76,8 @@ export function installDesktopAuthIpc(
   ipcMain.handle(
     DESKTOP_AUTH_CHANNELS.completeSignIn,
     async (event, payload: unknown) => {
-      assertDesktopAuthPage(event);
       const parsed = parseCompleteSignInPayload(payload);
-      await api.completeSignIn(parsed.token);
+      options.authWindow.completeSignIn(event, parsed.token);
     },
   );
 }

--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -42,6 +42,7 @@ function createSession(product: "okou" | "zero" = "okou") {
   const windows: DesktopAuthWindowRequest[] = [];
   const replies: Promise<string | null>[] = [];
   const completed: string[] = [];
+  const changes: (string | null)[] = [];
   const cookiesRead: string[] = [];
   const session = new DesktopAuthSession({
     product,
@@ -70,11 +71,14 @@ function createSession(product: "okou" | "zero" = "okou") {
       windows.push(request);
       return await (replies.shift() ?? Promise.resolve(null));
     },
+    onChange: () => {
+      changes.push(session.getCachedToken());
+    },
     onAuthCompleted: () => {
       completed.push("completed");
     },
   });
-  return { session, windows, replies, completed, cookiesRead };
+  return { session, windows, replies, completed, cookiesRead, changes };
 }
 
 function identityHandlers(
@@ -130,7 +134,6 @@ describe("Okou App session authority", () => {
     expect(requests).toEqual([]);
     expect(cookiesRead).toEqual([]);
     expect(windows.map((w) => w.url)).toEqual([
-      "https://app.okou.ai/desktop-auth/token",
       "https://app.okou.ai/desktop-auth/token",
     ]);
   });
@@ -221,6 +224,31 @@ describe("Okou App session authority", () => {
       expect(windows).toHaveLength(2);
     },
   );
+
+  it("notifies subscribers of a failed App refresh and waits for explicit sign-in", async () => {
+    const { session, replies, windows, changes } = createSession();
+    identityHandlers();
+    replies.push(Promise.resolve("expired"), Promise.resolve(null));
+    await session.getToken();
+    server.use(
+      http.get(
+        `${api}/api/protected`,
+        () => new HttpResponse(null, { status: 401 }),
+      ),
+    );
+    expect(
+      (await session.fetchWithSessionAuth(new URL(`${api}/api/protected`)))
+        .status,
+    ).toBe(401);
+    expect(changes).toEqual(["expired", null]);
+    expect(await session.getAuthState()).toEqual(signedOut);
+    expect(await session.getToken({ forceRefresh: true })).toBeNull();
+    expect(windows).toHaveLength(2);
+    replies.push(Promise.resolve("explicit"));
+    await session.consumeCode("new-code");
+    expect(session.getCachedToken()).toBe("explicit");
+    expect(windows).toHaveLength(3);
+  });
 
   it("refreshes the entire identity pair when the organization read rejects the old token", async () => {
     const { session, replies } = createSession();

--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -1,549 +1,441 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  CLIENT_REQUEST_ID_HEADER,
-  CLIENT_SESSION_ID_HEADER,
-  CLIENT_TYPE_DESKTOP,
-  CLIENT_TYPE_HEADER,
-  CLIENT_VERSION_HEADER,
-} from "@okouai/api-contracts/contracts/client-headers";
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
 import { DesktopAuthSession } from "./desktop-auth-session";
+import { resolveDesktopConfig } from "./config";
 import {
-  createDesktopClientHeaderInjector,
-  type DesktopClientHeaderInjector,
-} from "./desktop-client-headers";
-import type { DesktopSessionCookieSource } from "./desktop-session-cookies";
+  buildDesktopAuthConsumeUrl,
+  buildDesktopAuthSelectOrgUrl,
+  buildDesktopAuthTokenUrl,
+} from "./desktop-auth";
+import { createDesktopClientHeaderInjector } from "./desktop-client-headers";
+import type { DesktopAuthWindowRequest } from "./desktop-auth-window";
 
-const TOKEN_URL = "https://www.vm0.ai/desktop-auth/token";
-const SELECT_ORG_URL = "https://www.vm0.ai/desktop-auth/select-org";
+const api = "https://api.vm0.ai";
+const signedOut = { status: "signed_out", user: null, organization: null };
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+  server.resetHandlers();
+  vi.clearAllMocks();
+});
+afterAll(() => server.close());
 
-function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
-  return new Response(JSON.stringify(body), {
-    headers: { "content-type": "application/json" },
-    ...init,
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
   });
+  return { promise, resolve };
 }
 
-function uuidSequence(...values: readonly string[]): () => string {
-  let index = 0;
-  return () => {
-    const value = values[index];
-    index += 1;
-    if (!value) {
-      throw new Error("UUID sequence exhausted");
-    }
-    return value;
-  };
-}
-
-function createSession(
-  options: { readonly addClientHeaders?: DesktopClientHeaderInjector } = {},
-) {
-  const onChange = vi.fn();
-  const onAuthCompleted = vi.fn(async () => {});
-  const cookieSource: DesktopSessionCookieSource = {
-    cookies: {
-      async get() {
-        return [];
+function createSession(product: "okou" | "zero" = "okou") {
+  const config = resolveDesktopConfig(undefined, product);
+  const windows: DesktopAuthWindowRequest[] = [];
+  const replies: Promise<string | null>[] = [];
+  const completed: string[] = [];
+  const cookiesRead: string[] = [];
+  const session = new DesktopAuthSession({
+    product,
+    apiBaseUrl: api,
+    cookieUrls: [config.webUrl, config.platformUrl],
+    cookieSource: {
+      cookies: {
+        get: async ({ url }) => {
+          cookiesRead.push(url);
+          return [
+            { name: "__session", value: "legacy-user" },
+            { name: "preview", value: "access" },
+          ];
+        },
       },
     },
-  };
-  const runAuthWindow = vi.fn(
-    async (_request: {
-      readonly url: string;
-      readonly visible: boolean;
-      readonly allowInteractiveFallbacks: boolean;
-    }) => {},
-  );
-  const session = new DesktopAuthSession({
-    apiBaseUrl: "https://api.vm0.ai",
-    cookieUrls: [new URL("https://www.vm0.ai"), new URL("https://app.vm0.ai")],
-    cookieSource,
-    addClientHeaders: options.addClientHeaders ?? (() => {}),
-    tokenUrl: TOKEN_URL,
-    consumeUrl: (code, handoffId) => {
-      const url = new URL("https://www.vm0.ai/desktop-auth/consume");
-      url.searchParams.set("code", code);
-      if (handoffId) {
-        url.searchParams.set("handoffId", handoffId);
-      }
-      return url.toString();
+    addClientHeaders: createDesktopClientHeaderInjector({
+      clientVersion: "0.46.28",
+      product,
+    }),
+    tokenUrl: buildDesktopAuthTokenUrl(config.authUrl),
+    selectOrgUrl: buildDesktopAuthSelectOrgUrl(config.authUrl, true),
+    consumeUrl: (code, id) =>
+      buildDesktopAuthConsumeUrl(config.authUrl, code, id),
+    runAuthWindow: async (request) => {
+      windows.push(request);
+      return await (replies.shift() ?? Promise.resolve(null));
     },
-    selectOrgUrl: SELECT_ORG_URL,
-    runAuthWindow,
-    onChange,
-    onAuthCompleted,
+    onAuthCompleted: () => {
+      completed.push("completed");
+    },
   });
-  return { session, runAuthWindow, onChange, onAuthCompleted };
+  return { session, windows, replies, completed, cookiesRead };
 }
 
-afterEach(() => {
-  vi.unstubAllGlobals();
+function identityHandlers(
+  options: { orgId?: string; observed?: string[] } = {},
+) {
+  server.use(
+    http.get(`${api}/api/auth/me`, ({ request }) => {
+      const token = request.headers.get("authorization");
+      options.observed?.push(`me:${token}`);
+      expect(request.headers.get("cookie")).toBeNull();
+      return HttpResponse.json({
+        userId: token,
+        email: "app@example.test",
+        orgId: "app-org",
+      });
+    }),
+    http.get(`${api}/api/org`, ({ request }) => {
+      const token = request.headers.get("authorization");
+      options.observed?.push(`org:${token}`);
+      expect(request.headers.get("cookie")).toBeNull();
+      return HttpResponse.json({
+        id: options.orgId ?? "app-org",
+        name: "App workspace",
+      });
+    }),
+  );
+}
+
+describe("Okou App session authority", () => {
+  it("requires a fresh App token before any native request despite legacy cookie-only API success", async () => {
+    const { session, windows, cookiesRead } = createSession();
+    const requests: string[] = [];
+    server.use(
+      http.get(`${api}/*`, ({ request }) => {
+        requests.push(request.url);
+        return HttpResponse.json({
+          userId: "legacy-user",
+          orgId: "legacy-org",
+        });
+      }),
+    );
+    expect(await session.getAuthState()).toEqual(signedOut);
+    expect(
+      (
+        await session.fetchWithSessionAuth(new URL(`${api}/api/protected`), {
+          headers: {
+            cookie: "__session=legacy",
+            authorization: "Bearer injected",
+          },
+        })
+      ).status,
+    ).toBe(401);
+    expect(requests).toEqual([]);
+    expect(cookiesRead).toEqual([]);
+    expect(windows.map((w) => w.url)).toEqual([
+      "https://app.okou.ai/desktop-auth/token",
+      "https://app.okou.ai/desktop-auth/token",
+    ]);
+  });
+
+  it("restores matching user/org under one bearer and preserves native client headers", async () => {
+    const { session, replies, cookiesRead } = createSession();
+    const observed: string[] = [];
+    identityHandlers({ observed });
+    replies.push(Promise.resolve("fresh"));
+    expect(await session.getAuthState()).toEqual({
+      status: "signed_in",
+      user: { userId: "Bearer fresh", email: "app@example.test" },
+      organization: { id: "app-org", name: "App workspace" },
+    });
+    server.use(
+      http.post(`${api}/api/protected`, async ({ request }) => {
+        expect(request.headers.get("authorization")).toBe("Bearer fresh");
+        expect(request.headers.get("cookie")).toBeNull();
+        expect(request.headers.get("x-client-type")).toBe("Desktop");
+        expect(request.headers.get("x-client-version")).toBe("0.46.28");
+        return HttpResponse.json(await request.json());
+      }),
+    );
+    const response = await session.fetchWithSessionAuth(
+      new URL(`${api}/api/protected`),
+      {
+        method: "POST",
+        body: JSON.stringify({ action: "test" }),
+        headers: { cookie: "legacy", authorization: "Bearer wrong" },
+      },
+    );
+    expect(await response.json()).toEqual({ action: "test" });
+    expect(observed).toEqual(["me:Bearer fresh", "org:Bearer fresh"]);
+    expect(cookiesRead).toEqual([]);
+  });
+
+  it("rejects mismatching bearer user/org responses before exposing a cached token", async () => {
+    const { session, replies } = createSession();
+    identityHandlers({ orgId: "other-org" });
+    replies.push(Promise.resolve("fresh"));
+    expect(await session.getAuthState()).toEqual(signedOut);
+    expect(session.getCachedToken()).toBeNull();
+  });
+
+  it("does one bounded App refresh after 401 without a cookie-only retry", async () => {
+    const { session, replies, windows } = createSession();
+    identityHandlers();
+    replies.push(Promise.resolve("expired"), Promise.resolve("fresh"));
+    await session.getToken();
+    const tokens: (string | null)[] = [];
+    server.use(
+      http.get(`${api}/api/protected`, ({ request }) => {
+        const token = request.headers.get("authorization");
+        tokens.push(token);
+        return new HttpResponse(null, {
+          status: token === "Bearer fresh" ? 200 : 401,
+        });
+      }),
+    );
+    expect(
+      (await session.fetchWithSessionAuth(new URL(`${api}/api/protected`)))
+        .status,
+    ).toBe(200);
+    expect(tokens).toEqual(["Bearer expired", "Bearer fresh"]);
+    expect(windows).toHaveLength(2);
+  });
+
+  it.each([null, "rejected"])(
+    "clears rejected credentials when refresh delivers %s",
+    async (refreshed) => {
+      const { session, replies, windows } = createSession();
+      identityHandlers();
+      replies.push(Promise.resolve("expired"), Promise.resolve(refreshed));
+      await session.getToken();
+      let count = 0;
+      server.use(
+        http.get(`${api}/api/protected`, () => {
+          count++;
+          return new HttpResponse(null, { status: 401 });
+        }),
+      );
+      expect(
+        (await session.fetchWithSessionAuth(new URL(`${api}/api/protected`)))
+          .status,
+      ).toBe(401);
+      expect(session.getCachedToken()).toBeNull();
+      expect(count).toBe(refreshed ? 2 : 1);
+      expect(windows).toHaveLength(2);
+    },
+  );
+
+  it("refreshes the entire identity pair when the organization read rejects the old token", async () => {
+    const { session, replies } = createSession();
+    identityHandlers();
+    replies.push(Promise.resolve("old"));
+    await session.getToken();
+    const observed: string[] = [];
+    identityHandlers({ observed });
+    server.use(
+      http.get(`${api}/api/org`, ({ request }) => {
+        const token = request.headers.get("authorization");
+        observed.push(`org:${token}`);
+        return token === "Bearer old"
+          ? new HttpResponse(null, { status: 401 })
+          : HttpResponse.json({ id: "app-org", name: "new workspace" });
+      }),
+    );
+    replies.push(Promise.resolve("new"));
+    expect(await session.getAuthState()).toMatchObject({
+      status: "signed_in",
+      user: { userId: "Bearer new" },
+      organization: { name: "new workspace" },
+    });
+    expect(observed).toEqual([
+      "me:Bearer old",
+      "org:Bearer old",
+      "me:Bearer new",
+      "org:Bearer new",
+    ]);
+  });
+
+  it("coalesces refreshes and recognizes a new delivery even if the token bytes are identical", async () => {
+    const { session, replies, windows, completed } = createSession();
+    identityHandlers();
+    const reply = deferred<string | null>();
+    replies.push(reply.promise);
+    const first = session.getToken();
+    const second = session.getToken();
+    reply.resolve("same");
+    expect(await Promise.all([first, second])).toEqual(["same", "same"]);
+    replies.push(Promise.resolve("same"));
+    expect(await session.getToken({ forceRefresh: true })).toBe("same");
+    expect(windows).toHaveLength(2);
+    expect(completed).toEqual([]);
+    replies.push(Promise.resolve(null));
+    expect(await session.getToken({ forceRefresh: true })).toBeNull();
+    expect(session.getCachedToken()).toBeNull();
+  });
+
+  it("invalidates a late refresh on sign-out and accepts only a subsequent explicit flow", async () => {
+    const { session, replies, windows, completed } = createSession();
+    identityHandlers();
+    const reply = deferred<string | null>();
+    replies.push(reply.promise);
+    const refresh = session.getToken();
+    session.signOut();
+    reply.resolve("late");
+    expect(await refresh).toBeNull();
+    expect(windows[0]?.signal.aborted).toBe(true);
+    expect(await session.getAuthState()).toEqual(signedOut);
+    expect(await session.getToken({ forceRefresh: true })).toBeNull();
+    replies.push(Promise.resolve("explicit"));
+    await session.consumeCode("new-code", "handoff-id");
+    expect(session.getCachedToken()).toBe("explicit");
+    expect(completed).toEqual(["completed"]);
+    expect(windows[1]?.url).toBe(
+      "https://app.okou.ai/desktop-auth/consume?code=new-code&handoffId=handoff-id",
+    );
+  });
+
+  it("discards a superseded consume and keeps the latest organization operation", async () => {
+    const { session, replies, windows, completed } = createSession();
+    identityHandlers();
+    const reply = deferred<string | null>();
+    replies.push(reply.promise);
+    const old = session.consumeCode("old");
+    const rejected = expect(old).rejects.toThrow();
+    expect(await session.getAuthState()).toMatchObject({
+      status: "signing_in",
+    });
+    replies.push(Promise.resolve("latest"));
+    await session.selectOrganization();
+    reply.resolve("late");
+    await rejected;
+    expect(session.getCachedToken()).toBe("latest");
+    expect(completed).toEqual(["completed"]);
+    expect(windows[0]?.signal.aborted).toBe(true);
+    expect(windows[1]?.url).toBe(
+      "https://app.okou.ai/desktop-auth/select-org?force=true",
+    );
+  });
+
+  it("cannot publish an identity whose delayed API validation outlives sign-out", async () => {
+    const { session, replies, completed } = createSession();
+    identityHandlers();
+    const entered = deferred<void>();
+    const reply = deferred<void>();
+    server.use(
+      http.get(`${api}/api/org`, async () => {
+        entered.resolve();
+        await reply.promise;
+        return HttpResponse.json({ id: "app-org", name: "late" });
+      }),
+    );
+    replies.push(Promise.resolve("late"));
+    const consume = session.consumeCode("code");
+    const rejected = expect(consume).rejects.toThrow();
+    await entered.promise;
+    session.signOut();
+    reply.resolve();
+    await rejected;
+    expect(await session.getAuthState()).toEqual(signedOut);
+    expect(session.getCachedToken()).toBeNull();
+    expect(completed).toEqual([]);
+  });
+
+  it("keeps a new callback identity when it supersedes cold-start restoration", async () => {
+    const { session, replies, windows } = createSession();
+    identityHandlers();
+    const old = deferred<string | null>();
+    replies.push(old.promise);
+    const restore = session.getToken();
+    replies.push(Promise.resolve("callback-user"));
+    await session.consumeCode("callback-code");
+    old.resolve("old-user");
+    expect(await restore).toBeNull();
+    expect(session.getCachedToken()).toBe("callback-user");
+    expect(windows[0]?.signal.aborted).toBe(true);
+  });
+
+  it("rejects a newly delivered bearer that the identity API no longer accepts", async () => {
+    const { session, replies, completed } = createSession();
+    server.use(
+      http.get(
+        `${api}/api/auth/me`,
+        () => new HttpResponse(null, { status: 401 }),
+      ),
+    );
+    replies.push(Promise.resolve("revoked"));
+    expect(await session.getAuthState()).toEqual(signedOut);
+    expect(session.getCachedToken()).toBeNull();
+    expect(completed).toEqual([]);
+  });
+
+  it("does not leak a bearer to a non-API request origin", async () => {
+    const { session, replies } = createSession();
+    identityHandlers();
+    replies.push(Promise.resolve("fresh"));
+    await expect(
+      session.fetchWithSessionAuth(new URL("https://untrusted.test/api")),
+    ).rejects.toThrow("Invalid Desktop API origin");
+  });
 });
 
-describe("DesktopAuthSession", () => {
-  it("returns the cached token without opening a window", async () => {
-    const { session, runAuthWindow } = createSession();
-    session.completeSignIn("cached");
-
-    expect(await session.getToken()).toBe("cached");
-    expect(runAuthWindow).not.toHaveBeenCalled();
-  });
-
-  it("exposes the cached token without refreshing", () => {
-    const { session, runAuthWindow } = createSession();
-
-    expect(session.getCachedToken()).toBeNull();
-    session.completeSignIn("cached");
-
-    expect(session.getCachedToken()).toBe("cached");
-    expect(runAuthWindow).not.toHaveBeenCalled();
-  });
-
-  it("stores the token and fires onChange on completeSignIn", async () => {
-    const { session, onChange } = createSession();
-
-    session.completeSignIn("tok");
-
-    expect(onChange).toHaveBeenCalledOnce();
-    expect(await session.getToken()).toBe("tok");
-  });
-
-  it("clears cached auth and suppresses hidden refresh after sign out", async () => {
-    const { session, runAuthWindow, onChange } = createSession();
-    session.completeSignIn("cached");
-    session.signOut();
-    session.completeSignIn("late");
-    const fetch = vi.fn(async () => new Response(null, { status: 401 }));
-    vi.stubGlobal("fetch", fetch);
-
-    expect(session.getCachedToken()).toBeNull();
-    expect(await session.getToken({ forceRefresh: true })).toBeNull();
-    expect(await session.getAuthState()).toEqual({
-      status: "signed_out",
-      user: null,
-      organization: null,
-    });
-    expect(fetch).not.toHaveBeenCalled();
-    expect(runAuthWindow).not.toHaveBeenCalled();
-    expect(onChange).toHaveBeenCalledTimes(2);
-  });
-
-  it("accepts sign-in completions after a new consume flow starts", async () => {
-    const { session, runAuthWindow } = createSession();
-    session.signOut();
-    runAuthWindow.mockImplementation(async () => {
-      session.completeSignIn("fresh");
-    });
-
-    await session.consumeCode("code-123");
-
-    expect(session.getCachedToken()).toBe("fresh");
-  });
-
-  it("returns the freshly delivered token on a forced refresh", async () => {
-    const { session, runAuthWindow } = createSession();
-    runAuthWindow.mockImplementation(async () => {
-      session.completeSignIn("fresh");
-    });
-
-    const token = await session.getToken({ forceRefresh: true });
-
-    expect(token).toBe("fresh");
-    expect(runAuthWindow).toHaveBeenCalledWith({
-      url: TOKEN_URL,
-      visible: false,
-      allowInteractiveFallbacks: false,
-    });
-  });
-
-  it("returns null when the refresh window delivers no token (R3)", async () => {
-    const { session, runAuthWindow } = createSession();
-    // Window navigates to completion but never calls completeSignIn.
-    runAuthWindow.mockImplementation(async () => {});
-
-    const token = await session.getToken({ forceRefresh: true });
-
-    expect(token).toBeNull();
-    expect(runAuthWindow).toHaveBeenCalledOnce();
-  });
-
-  it("coalesces concurrent refreshes and re-runs after settling", async () => {
-    const { session, runAuthWindow } = createSession();
-    let releaseWindow: () => void = () => {};
-    runAuthWindow.mockImplementationOnce(
-      () =>
-        new Promise<void>((resolve) => {
-          releaseWindow = resolve;
-        }),
-    );
-
-    const first = session.getToken({ forceRefresh: true });
-    const second = session.getToken({ forceRefresh: true });
-    session.completeSignIn("fresh");
-    releaseWindow();
-    const [firstToken, secondToken] = await Promise.all([first, second]);
-
-    expect(firstToken).toBe("fresh");
-    expect(secondToken).toBe("fresh");
-    expect(runAuthWindow).toHaveBeenCalledOnce();
-
-    // The single-flight guard is cleared in `finally`, so a later refresh
-    // opens a new window instead of reusing the settled promise.
-    runAuthWindow.mockImplementation(async () => {
-      session.completeSignIn("fresh-2");
-    });
-    expect(await session.getToken({ forceRefresh: true })).toBe("fresh-2");
-    expect(runAuthWindow).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not restart dependent runtimes after a background refresh", async () => {
-    const { session, runAuthWindow, onAuthCompleted } = createSession();
-    runAuthWindow.mockImplementation(async () => {
-      session.completeSignIn("fresh");
-    });
-
-    await session.getToken({ forceRefresh: true });
-
-    expect(onAuthCompleted).not.toHaveBeenCalled();
-  });
-
-  it("runs onAuthCompleted after a consume flow", async () => {
-    const { session, runAuthWindow, onAuthCompleted } = createSession();
-
-    await session.consumeCode("code-123");
-
-    expect(runAuthWindow).toHaveBeenCalledWith({
-      url: "https://www.vm0.ai/desktop-auth/consume?code=code-123",
-      visible: false,
-      allowInteractiveFallbacks: true,
-    });
-    expect(onAuthCompleted).toHaveBeenCalledOnce();
-    expect(runAuthWindow.mock.invocationCallOrder[0]).toBeLessThan(
-      onAuthCompleted.mock.invocationCallOrder[0] ?? Infinity,
-    );
-  });
-
-  it("carries handoff id into the consume flow", async () => {
-    const { session, runAuthWindow } = createSession();
-    const handoffId = "550e8400-e29b-41d4-a716-446655440000";
-
-    await session.consumeCode("code-123", handoffId);
-
-    expect(runAuthWindow).toHaveBeenCalledWith({
-      url: `https://www.vm0.ai/desktop-auth/consume?code=code-123&handoffId=${handoffId}`,
-      visible: false,
-      allowInteractiveFallbacks: true,
-    });
-  });
-
-  it("reports signing-in state while a consume flow is pending", async () => {
-    const { session, runAuthWindow, onAuthCompleted } = createSession();
-    let finishAuthWindow: () => void = () => {};
-    runAuthWindow.mockImplementationOnce(() => {
-      return new Promise<void>((resolve) => {
-        finishAuthWindow = resolve;
-      });
-    });
-
-    const consumePromise = session.consumeCode("code-123");
-
-    expect(await session.getAuthState()).toEqual({
-      status: "signing_in",
-      user: null,
-      organization: null,
-    });
-
-    session.completeSignIn("fresh");
-    finishAuthWindow();
-    await consumePromise;
-
-    expect(onAuthCompleted).toHaveBeenCalledOnce();
-  });
-
-  it("clears signing-in state when a consume flow fails", async () => {
-    const { session, runAuthWindow } = createSession();
-    runAuthWindow
-      .mockRejectedValueOnce(new Error("consume failed"))
-      .mockResolvedValueOnce(undefined);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response(null, { status: 401 })),
-    );
-
-    await expect(session.consumeCode("code-123")).rejects.toThrow(
-      "consume failed",
-    );
-
-    expect(await session.getAuthState()).toEqual({
-      status: "signed_out",
-      user: null,
-      organization: null,
-    });
-  });
-
-  it("runs onAuthCompleted after a visible org-selection flow", async () => {
-    const { session, runAuthWindow, onAuthCompleted } = createSession();
-
-    await session.selectOrganization();
-
-    expect(runAuthWindow).toHaveBeenCalledWith({
-      url: SELECT_ORG_URL,
-      visible: true,
-      allowInteractiveFallbacks: true,
-    });
-    expect(onAuthCompleted).toHaveBeenCalledOnce();
-  });
-
-  it("derives signed-in state with an organization", async () => {
-    const { session } = createSession();
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: string | URL | Request) => {
-        const url = String(input);
-        if (url.endsWith("/api/auth/me")) {
-          return jsonResponse({ userId: "u1", email: "u@example.com" });
-        }
-        return jsonResponse({ id: "o1", name: "Org One", slug: "org-one" });
-      }),
-    );
-
-    expect(await session.getAuthState()).toEqual({
-      status: "signed_in",
-      user: { userId: "u1", email: "u@example.com" },
-      organization: { id: "o1", name: "Org One" },
-    });
-  });
-
-  it("retries auth state with cookies when the cached token is rejected", async () => {
-    const { session } = createSession({
-      addClientHeaders: createDesktopClientHeaderInjector({
-        clientVersion: "1.2.3",
-        createUuid: uuidSequence(
-          "session-id",
-          "request-id-1",
-          "request-id-2",
-          "request-id-3",
-        ),
-      }),
-    });
-    const observedAuthorization: (string | null)[] = [];
-    const observedClientHeaders: Array<{
-      readonly requestId: string | null;
-      readonly sessionId: string | null;
-      readonly type: string | null;
-      readonly version: string | null;
-    }> = [];
-    session.completeSignIn("stale");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-        const headers = new Headers(init?.headers);
-        observedAuthorization.push(headers.get("authorization"));
-        observedClientHeaders.push({
-          requestId: headers.get(CLIENT_REQUEST_ID_HEADER),
-          sessionId: headers.get(CLIENT_SESSION_ID_HEADER),
-          type: headers.get(CLIENT_TYPE_HEADER),
-          version: headers.get(CLIENT_VERSION_HEADER),
+describe("Zero compatibility", () => {
+  it("retains cookie-only restoration and WWW auth routes", async () => {
+    const { session, windows, cookiesRead, replies } = createSession("zero");
+    server.use(
+      http.get(`${api}/api/auth/me`, ({ request }) => {
+        expect(request.headers.get("cookie")).toContain(
+          "__session=legacy-user",
+        );
+        return HttpResponse.json({
+          userId: "zero-user",
+          email: "zero@example.test",
         });
-        const url = String(input);
-        if (url.endsWith("/api/auth/me") && headers.has("authorization")) {
-          return new Response(null, { status: 401 });
-        }
-        if (url.endsWith("/api/auth/me")) {
-          return jsonResponse({ userId: "u1", email: "u@example.com" });
-        }
-        return jsonResponse({ id: "o1", name: "Org One", slug: "org-one" });
       }),
+      http.get(`${api}/api/org`, () =>
+        HttpResponse.json({ id: "zero-org", name: "Zero" }),
+      ),
     );
-
-    expect(await session.getAuthState()).toEqual({
+    expect(await session.getAuthState()).toMatchObject({
       status: "signed_in",
-      user: { userId: "u1", email: "u@example.com" },
-      organization: { id: "o1", name: "Org One" },
+      user: { userId: "zero-user" },
     });
-    expect(observedAuthorization).toStrictEqual(["Bearer stale", null, null]);
-    expect(observedClientHeaders).toStrictEqual([
-      {
-        requestId: "request-id-1",
-        sessionId: "session-id",
-        type: CLIENT_TYPE_DESKTOP,
-        version: "1.2.3",
-      },
-      {
-        requestId: "request-id-2",
-        sessionId: "session-id",
-        type: CLIENT_TYPE_DESKTOP,
-        version: "1.2.3",
-      },
-      {
-        requestId: "request-id-3",
-        sessionId: "session-id",
-        type: CLIENT_TYPE_DESKTOP,
-        version: "1.2.3",
-      },
-    ]);
-    expect(session.getCachedToken()).toBeNull();
+    expect(windows).toHaveLength(0);
+    expect(cookiesRead).toContain("https://www.vm0.ai/");
+    replies.push(Promise.resolve("zero-token"));
+    await session.selectOrganization();
+    expect(windows[0]?.url).toBe(
+      "https://www.vm0.ai/desktop-auth/select-org?force=true",
+    );
+    expect(session.getCachedToken()).toBe("zero-token");
   });
 
-  it("refreshes the desktop token and retries auth state after a 401", async () => {
-    const { session, runAuthWindow } = createSession();
-    const observedAuthorization: (string | null)[] = [];
-    runAuthWindow.mockImplementation(async () => {
-      session.completeSignIn("fresh");
-    });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-        const headers = new Headers(init?.headers);
-        observedAuthorization.push(headers.get("authorization"));
-        const url = String(input);
-        if (
-          url.endsWith("/api/auth/me") &&
-          headers.get("authorization") === "Bearer fresh"
-        ) {
-          return jsonResponse({ userId: "u1", email: "u@example.com" });
-        }
-        if (url.endsWith("/api/auth/me")) {
-          return new Response(null, { status: 401 });
-        }
-        return jsonResponse({ id: "o1", name: "Org One", slug: "org-one" });
+  it("retains Zero cookie retry after bearer rejection", async () => {
+    const { session, replies } = createSession("zero");
+    replies.push(Promise.resolve("zero-token"));
+    await session.getToken();
+    const tokens: (string | null)[] = [];
+    server.use(
+      http.get(`${api}/api/protected`, ({ request }) => {
+        tokens.push(request.headers.get("authorization"));
+        return new HttpResponse(null, {
+          status: request.headers.has("authorization") ? 401 : 200,
+        });
       }),
     );
-
-    expect(await session.getAuthState()).toEqual({
-      status: "signed_in",
-      user: { userId: "u1", email: "u@example.com" },
-      organization: { id: "o1", name: "Org One" },
-    });
-    expect(runAuthWindow).toHaveBeenCalledWith({
-      url: TOKEN_URL,
-      visible: false,
-      allowInteractiveFallbacks: false,
-    });
-    expect(observedAuthorization).toStrictEqual([
-      null,
-      "Bearer fresh",
-      "Bearer fresh",
-    ]);
+    expect(
+      (await session.fetchWithSessionAuth(new URL(`${api}/api/protected`)))
+        .status,
+    ).toBe(200);
+    expect(tokens).toEqual(["Bearer zero-token", null]);
   });
 
-  it("mints a fresh token and retries a request when the bearer and the cookies are both rejected", async () => {
-    // The recorder uploads the video, then its click track. The token is
-    // short-lived, so after a long upload the second request can arrive with
-    // an expired bearer; its cookies do not answer for the API either. The
-    // request has to recover on its own rather than fail the delivery.
-    const { session, runAuthWindow } = createSession();
-    const observedAuthorization: (string | null)[] = [];
-    session.completeSignIn("expired");
-    runAuthWindow.mockImplementation(async () => {
-      session.completeSignIn("fresh");
+  it("clears pending callbacks on sign-out", () => {
+    const { session } = createSession("zero");
+    session.queuePendingCallback({ code: "code", handoffId: null });
+    expect(session.takePendingCallback()).toEqual({
+      code: "code",
+      handoffId: null,
     });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
-        const headers = new Headers(init?.headers);
-        observedAuthorization.push(headers.get("authorization"));
-        return headers.get("authorization") === "Bearer fresh"
-          ? jsonResponse({ id: "upload-1" })
-          : new Response(null, { status: 401 });
-      }),
-    );
-
-    const response = await session.fetchWithSessionAuth(
-      new URL("https://api.vm0.ai/api/uploads/prepare"),
-      { method: "POST", body: "{}" },
-    );
-
-    expect(response.status).toBe(200);
-    expect(observedAuthorization).toStrictEqual([
-      "Bearer expired",
-      null,
-      "Bearer fresh",
-    ]);
-    expect(runAuthWindow).toHaveBeenCalledOnce();
-    expect(session.getCachedToken()).toBe("fresh");
-  });
-
-  it("hands back the 401 when a refresh yields no token", async () => {
-    const { session, runAuthWindow } = createSession();
-    session.completeSignIn("expired");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response(null, { status: 401 })),
-    );
-
-    const response = await session.fetchWithSessionAuth(
-      new URL("https://api.vm0.ai/api/uploads/prepare"),
-    );
-
-    expect(response.status).toBe(401);
-    expect(runAuthWindow).toHaveBeenCalledOnce();
-    expect(session.getCachedToken()).toBeNull();
-  });
-
-  it("derives signed-in state with a null organization on 404", async () => {
-    const { session } = createSession();
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: string | URL | Request) => {
-        const url = String(input);
-        if (url.endsWith("/api/auth/me")) {
-          return jsonResponse({ userId: "u1", email: "u@example.com" });
-        }
-        return new Response(null, { status: 404 });
-      }),
-    );
-
-    expect(await session.getAuthState()).toEqual({
-      status: "signed_in",
-      user: { userId: "u1", email: "u@example.com" },
-      organization: null,
-    });
-  });
-
-  it("clears the cached token when auth state returns 401", async () => {
-    const { session, runAuthWindow } = createSession();
-    session.completeSignIn("stale");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response(null, { status: 401 })),
-    );
-
-    const state = await session.getAuthState();
-
-    expect(state).toEqual({
-      status: "signed_out",
-      user: null,
-      organization: null,
-    });
-    // Auth-state checks now make one hidden refresh attempt before settling on
-    // signed out.
-    expect(runAuthWindow).toHaveBeenCalledOnce();
-  });
-
-  it("consumes a handed callback fire-and-forget", async () => {
-    const { session, runAuthWindow, onAuthCompleted } = createSession();
-    const onError = vi.fn();
-
-    session.consumeCallback({ code: "code-abc", handoffId: "h-1" }, onError);
-
-    await vi.waitFor(() => {
-      expect(onAuthCompleted).toHaveBeenCalledOnce();
-    });
-    expect(runAuthWindow).toHaveBeenCalledOnce();
-    expect(runAuthWindow.mock.calls[0]?.[0].url).toContain("code-abc");
-    expect(onError).not.toHaveBeenCalled();
-  });
-
-  it("routes consume failures for a handed callback to onError", async () => {
-    const { session, runAuthWindow } = createSession();
-    runAuthWindow.mockRejectedValue(new Error("consume failed"));
-    const onError = vi.fn();
-
-    session.consumeCallback({ code: "code-abc", handoffId: null }, onError);
-
-    await vi.waitFor(() => {
-      expect(onError).toHaveBeenCalledOnce();
-    });
+    expect(session.takePendingCallback()).toBeNull();
+    session.queuePendingCallback({ code: "late", handoffId: null });
+    session.signOut();
+    expect(session.takePendingCallback()).toBeNull();
   });
 });

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -351,7 +351,15 @@ export class DesktopAuthSession {
       if (!interactive && signal.aborted) return null;
       throw error;
     } finally {
-      if (this.lifetime === lifetime) this.setSigningIn(false);
+      if (this.lifetime === lifetime) {
+        if (this.product === "okou" && !this.token) {
+          // Notify renderer/tray subscribers, and keep their reads from
+          // reopening a failed hidden restore until explicit sign-in.
+          this.restoreEnabled = false;
+          this.onChange();
+        }
+        this.setSigningIn(false);
+      }
     }
   }
 
@@ -467,6 +475,7 @@ export class DesktopAuthSession {
       init,
     );
     if (retried.status === 401) {
+      this.restoreEnabled = false;
       this.token = null;
       this.appState = signedOutDesktopAuthState();
       this.onChange();

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -1,3 +1,6 @@
+import { authContract } from "@okouai/api-contracts/contracts/auth";
+import type { DesktopProduct } from "@okouai/api-contracts/contracts/client-headers";
+import type { DesktopAuthWindowRequest } from "./desktop-auth-window";
 import type { DesktopAuthState } from "./desktop-bridge";
 import type { DesktopAuthCallback } from "./desktop-auth";
 import type { DesktopClientHeaderInjector } from "./desktop-client-headers";
@@ -20,36 +23,26 @@ interface ZeroOrgResponse {
   readonly name: string;
 }
 
-/**
- * Injected auth-window driver: the core behavior seam, analogous to
- * `ComputerUseHostRuntime`'s `sessionFetch`. The production implementation wraps
- * all the Electron window machinery (create window, navigation policy, wait for
- * the completion navigation, load the URL) and resolves once the window reaches
- * a completion navigation. The token does NOT flow back through here — it is
- * delivered out-of-band via `completeSignIn` (the single global auth IPC).
- */
-type RunAuthWindow = (request: {
-  readonly url: string;
-  readonly visible: boolean;
-  readonly allowInteractiveFallbacks: boolean;
-}) => Promise<void>;
+type RunAuthWindow = (
+  request: DesktopAuthWindowRequest,
+) => Promise<string | null>;
 
 interface DesktopAuthSessionOptions {
+  readonly product: DesktopProduct;
   /** Pre-resolved API base URL (`resolveComputerUseApiBaseUrl(platformUrl)`). */
   readonly apiBaseUrl: string;
   /**
-   * Cookie-merge URLs for auth-state requests, in precedence order
-   * (`[webUrl, platformUrl]`). The per-request URL is appended internally so
-   * its cookies win last, matching the original `[webUrl, platformUrl, requestUrl]`.
+   * Existing Zero-only cookie precedence: [webUrl, platformUrl, requestUrl].
+   * Okou never reads these cookies, including the API origin cookie jar.
    */
   readonly cookieUrls: readonly URL[];
   readonly cookieSource: DesktopSessionCookieSource;
   readonly addClientHeaders: DesktopClientHeaderInjector;
-  /** `buildDesktopAuthTokenUrl(webUrl)`. */
+  /** `buildDesktopAuthTokenUrl(authUrl)`. */
   readonly tokenUrl: string;
-  /** `buildDesktopAuthConsumeUrl(webUrl, code, handoffId)`. */
+  /** `buildDesktopAuthConsumeUrl(authUrl, code, handoffId)`. */
   readonly consumeUrl: (code: string, handoffId: string | null) => string;
-  /** `buildDesktopAuthSelectOrgUrl(webUrl, true)`. */
+  /** `buildDesktopAuthSelectOrgUrl(authUrl, true)`. */
   readonly selectOrgUrl: string;
   readonly runAuthWindow: RunAuthWindow;
   /** Zero-arg "something changed" signal; defaults to a no-op. */
@@ -59,7 +52,7 @@ interface DesktopAuthSessionOptions {
    * caller can restart dependent runtimes. Background token refresh does NOT
    * trigger it.
    */
-  readonly onAuthCompleted?: () => Promise<void> | void;
+  readonly onAuthCompleted?: (signal: AbortSignal) => Promise<void> | void;
 }
 
 function signedOutDesktopAuthState(): DesktopAuthState {
@@ -84,6 +77,7 @@ function signingInDesktopAuthState(): DesktopAuthState {
  * mirroring `ComputerUseHostRuntime`'s dependency-injection shape.
  */
 export class DesktopAuthSession {
+  private readonly product: DesktopProduct;
   private readonly apiBaseUrl: string;
   private readonly cookieUrls: readonly URL[];
   private readonly cookieSource: DesktopSessionCookieSource;
@@ -96,15 +90,20 @@ export class DesktopAuthSession {
   private readonly selectOrgUrl: string;
   private readonly runAuthWindow: RunAuthWindow;
   private readonly onChange: () => void;
-  private readonly onAuthCompleted: () => Promise<void> | void;
+  private readonly onAuthCompleted: (
+    signal: AbortSignal,
+  ) => Promise<void> | void;
 
   private token: string | null = null;
+  private lifetime = new AbortController();
+  private appState: DesktopAuthState = signedOutDesktopAuthState();
   private readonly tokenRefresh = singleFlight(() => this.refreshToken());
   private pendingCallback: DesktopAuthCallback | null = null;
   private signingIn = false;
-  private acceptsSignInCompletions = true;
+  private restoreEnabled = true;
 
   constructor(options: DesktopAuthSessionOptions) {
+    this.product = options.product;
     this.apiBaseUrl = options.apiBaseUrl;
     this.cookieUrls = options.cookieUrls;
     this.cookieSource = options.cookieSource;
@@ -120,10 +119,11 @@ export class DesktopAuthSession {
   async getToken(options?: {
     readonly forceRefresh?: boolean;
   }): Promise<string | null> {
+    if (this.signingIn) return null;
     if (!options?.forceRefresh && this.token) {
       return this.token;
     }
-    if (!this.acceptsSignInCompletions) {
+    if (!this.restoreEnabled) {
       return null;
     }
     return await this.refresh();
@@ -138,6 +138,9 @@ export class DesktopAuthSession {
     requestUrl: URL,
     init?: RequestInit,
   ): Promise<Response> {
+    if (this.product === "okou") {
+      return await this.fetchWithAppAuth(requestUrl, init);
+    }
     const response = await fetch(requestUrl, {
       ...init,
       headers: await this.headersFor(requestUrl, init?.headers),
@@ -179,8 +182,12 @@ export class DesktopAuthSession {
     if (this.signingIn) {
       return signingInDesktopAuthState();
     }
-    if (!this.acceptsSignInCompletions) {
+    if (!this.restoreEnabled) {
       return signedOutDesktopAuthState();
+    }
+
+    if (this.product === "okou") {
+      return await this.getAppAuthState();
     }
 
     // With a cached token, a rejected request already refreshes and retries
@@ -236,20 +243,14 @@ export class DesktopAuthSession {
     };
   }
 
-  completeSignIn(token: string): void {
-    if (!this.acceptsSignInCompletions) {
-      return;
-    }
-    this.token = token;
-    this.onChange();
-  }
-
   signOut(): void {
+    this.lifetime.abort();
     this.token = null;
+    this.appState = signedOutDesktopAuthState();
     this.tokenRefresh.clear();
     this.pendingCallback = null;
     this.signingIn = false;
-    this.acceptsSignInCompletions = false;
+    this.restoreEnabled = false;
     this.onChange();
   }
 
@@ -257,29 +258,13 @@ export class DesktopAuthSession {
     code: string,
     handoffId: string | null = null,
   ): Promise<void> {
-    this.acceptsSignInCompletions = true;
-    this.setSigningIn(true);
-    try {
-      await this.runAuthWindow({
-        url: this.consumeUrl(code, handoffId),
-        visible: false,
-        allowInteractiveFallbacks: true,
-      });
-    } finally {
-      this.setSigningIn(false);
-    }
-
-    await this.onAuthCompleted();
+    this.tokenRefresh.clear();
+    await this.authenticate(this.consumeUrl(code, handoffId), true, false);
   }
 
   async selectOrganization(): Promise<void> {
-    this.acceptsSignInCompletions = true;
-    await this.runAuthWindow({
-      url: this.selectOrgUrl,
-      visible: true,
-      allowInteractiveFallbacks: true,
-    });
-    await this.onAuthCompleted();
+    this.tokenRefresh.clear();
+    await this.authenticate(this.selectOrgUrl, true, true);
   }
 
   /**
@@ -308,18 +293,185 @@ export class DesktopAuthSession {
   }
 
   private async refreshToken(): Promise<string | null> {
-    const before = this.token;
-    await this.runAuthWindow({
-      url: this.tokenUrl,
-      visible: false,
-      allowInteractiveFallbacks: false,
+    try {
+      return await this.authenticate(this.tokenUrl, false, false);
+    } catch (error) {
+      // A failed App restoration requires explicit sign-in, never another
+      // identity source. Interactive failures still reject to the caller.
+      if (this.product === "okou") return null;
+      throw error;
+    }
+  }
+
+  private async authenticate(
+    url: string,
+    interactive: boolean,
+    visible: boolean,
+  ): Promise<string | null> {
+    this.lifetime.abort();
+    const lifetime = new AbortController();
+    this.lifetime = lifetime;
+    this.restoreEnabled = true;
+    this.token = null;
+    this.appState = signedOutDesktopAuthState();
+    this.setSigningIn(interactive);
+    // The lifetime also owns validation requests after the window closes.
+    const signal = AbortSignal.any([
+      lifetime.signal,
+      AbortSignal.timeout(30_000),
+    ]);
+    try {
+      const token = await this.runAuthWindow({
+        url,
+        visible,
+        allowInteractiveFallbacks: interactive,
+        signal,
+      });
+      signal.throwIfAborted();
+      if (!token) return null;
+      if (this.product === "okou") {
+        const state = await this.readAppIdentity(token, signal);
+        signal.throwIfAborted();
+        if (state.status !== "signed_in") return null;
+        this.appState = state;
+      }
+      this.token = token;
+      this.onChange();
+      if (interactive) {
+        this.setSigningIn(false);
+        await this.onAuthCompleted(lifetime.signal);
+        lifetime.signal.throwIfAborted();
+      }
+      return token;
+    } catch (error) {
+      if (this.lifetime === lifetime) {
+        this.token = null;
+        this.appState = signedOutDesktopAuthState();
+      }
+      if (!interactive && signal.aborted) return null;
+      throw error;
+    } finally {
+      if (this.lifetime === lifetime) this.setSigningIn(false);
+    }
+  }
+
+  private async appRequest(
+    requestUrl: URL,
+    token: string,
+    signal: AbortSignal,
+    init?: RequestInit,
+  ): Promise<Response> {
+    if (requestUrl.origin !== new URL(this.apiBaseUrl).origin) {
+      throw new Error("Invalid Desktop API origin");
+    }
+    signal.throwIfAborted();
+    const headers = new Headers(init?.headers);
+    headers.delete("cookie");
+    headers.set("authorization", `Bearer ${token}`);
+    this.addClientHeaders(headers);
+    const response = await fetch(requestUrl, {
+      ...init,
+      headers,
+      credentials: "omit",
+      redirect: "error",
+      signal: init?.signal ? AbortSignal.any([signal, init.signal]) : signal,
     });
-    const after = this.token;
-    // completeSignIn() is the token's only write path. If the refresh window
-    // reached a completion navigation without ever delivering a token, the
-    // token is unchanged, so surface an explicit null instead of the stale
-    // value the 401 retry would otherwise resend.
-    return after === before ? null : after;
+    signal.throwIfAborted();
+    return response;
+  }
+
+  private async readAppIdentity(
+    token: string,
+    signal: AbortSignal,
+  ): Promise<DesktopAuthState> {
+    const me = await this.appRequest(
+      new URL(AUTH_ME_PATH, this.apiBaseUrl),
+      token,
+      signal,
+    );
+    if (me.status === 401) return signedOutDesktopAuthState();
+    if (!me.ok) throw new Error(`Desktop auth status failed: ${me.status}`);
+    const user = authContract.me.responses[200].parse(await me.json());
+    signal.throwIfAborted();
+    if (!user.userId || !user.orgId) return signedOutDesktopAuthState();
+    // Both reads use the identical server-verified bearer; never refresh only
+    // the second half of the user/workspace pair.
+    const org = await this.appRequest(
+      new URL(ZERO_ORG_PATH, this.apiBaseUrl),
+      token,
+      signal,
+    );
+    if (org.status === 401 || org.status === 404)
+      return signedOutDesktopAuthState();
+    if (!org.ok)
+      throw new Error(`Desktop organization status failed: ${org.status}`);
+    const organization: unknown = await org.json();
+    signal.throwIfAborted();
+    if (
+      typeof organization !== "object" ||
+      organization === null ||
+      !("id" in organization) ||
+      organization.id !== user.orgId ||
+      !("name" in organization) ||
+      typeof organization.name !== "string"
+    ) {
+      return signedOutDesktopAuthState();
+    }
+    return {
+      status: "signed_in",
+      user: { userId: user.userId, email: user.email },
+      organization: { id: user.orgId, name: organization.name },
+    };
+  }
+
+  private async getAppAuthState(): Promise<DesktopAuthState> {
+    if (!this.token) {
+      await this.getToken();
+      return this.appState;
+    }
+    const lifetime = this.lifetime;
+    try {
+      const state = await this.readAppIdentity(this.token, lifetime.signal);
+      lifetime.signal.throwIfAborted();
+      if (state.status === "signed_in") return state;
+      await this.getToken({ forceRefresh: true });
+      return this.appState;
+    } catch (error) {
+      if (lifetime.signal.aborted) return signedOutDesktopAuthState();
+      throw error;
+    }
+  }
+
+  private async fetchWithAppAuth(
+    requestUrl: URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const token = await this.getToken();
+    if (!token || token !== this.token)
+      return new Response(null, { status: 401 });
+    const lifetime = this.lifetime;
+    const response = await this.appRequest(
+      requestUrl,
+      token,
+      lifetime.signal,
+      init,
+    );
+    if (response.status !== 401) return response;
+    // No cookie-only retry. One App refresh and at most one authenticated retry.
+    const refreshed = await this.getToken({ forceRefresh: true });
+    if (!refreshed || refreshed !== this.token) return response;
+    const retried = await this.appRequest(
+      requestUrl,
+      refreshed,
+      this.lifetime.signal,
+      init,
+    );
+    if (retried.status === 401) {
+      this.token = null;
+      this.appState = signedOutDesktopAuthState();
+      this.onChange();
+    }
+    return retried;
   }
 
   private setSigningIn(value: boolean): void {

--- a/turbo/apps/desktop/src/desktop-auth-window.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-window.test.ts
@@ -1,0 +1,520 @@
+import { EventEmitter } from "node:events";
+import type { BrowserWindowConstructorOptions } from "electron";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveDesktopConfig } from "./config";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { DesktopAuthWindow } from "./desktop-auth-window";
+import { DesktopAuthSession } from "./desktop-auth-session";
+import { installDesktopAuthIpc } from "./desktop-auth-electron";
+import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
+
+interface Frame {
+  url: string;
+}
+interface Contents extends EventEmitter {
+  mainFrame: Frame;
+  destroyed: boolean;
+  popup: (details: { url: string }) => { action: string };
+}
+interface TestWindow extends EventEmitter {
+  webContents: Contents;
+  options: BrowserWindowConstructorOptions;
+  destroyed: boolean;
+  close: () => void;
+}
+interface InvokeEvent {
+  sender: Contents;
+  senderFrame: Frame;
+}
+type Handler = (event: InvokeEvent, payload?: unknown) => unknown;
+const electron = vi.hoisted(() => ({
+  windows: [] as TestWindow[],
+  handlers: new Map<string, Handler>(),
+  storage: new Map<string, string[]>(),
+}));
+vi.mock("electron", async () => {
+  const { EventEmitter } = await import("node:events");
+  class WebContents extends EventEmitter {
+    mainFrame = { url: "about:blank" };
+    destroyed = false;
+    popup = (_details: { url: string }) => ({ action: "deny" });
+    isDestroyed() {
+      return this.destroyed;
+    }
+    setWindowOpenHandler(
+      handler: (details: { url: string }) => { action: string },
+    ) {
+      this.popup = handler;
+    }
+  }
+  class BrowserWindow extends EventEmitter {
+    webContents = new WebContents();
+    destroyed = false;
+    constructor(readonly options: BrowserWindowConstructorOptions) {
+      super();
+      electron.windows.push(this);
+    }
+    async loadURL(url: string) {
+      this.webContents.mainFrame.url = url;
+    }
+    isDestroyed() {
+      return this.destroyed;
+    }
+    close() {
+      this.destroyed = true;
+      this.emit("closed");
+    }
+    show() {}
+    focus() {}
+    isMinimized() {
+      return false;
+    }
+  }
+  return {
+    BrowserWindow,
+    session: {
+      fromPartition: (partition: string) => ({
+        clearStorageData: async () => {
+          electron.storage.delete(partition);
+        },
+      }),
+    },
+    ipcMain: {
+      handle: (channel: string, handler: Handler) =>
+        electron.handlers.set(channel, handler),
+    },
+  };
+});
+
+const origin = "https://app.okou.ai";
+const rendererUrl = "vm0-desktop://renderer/index.html";
+const controllers: AbortController[] = [];
+afterEach(() => {
+  for (const controller of controllers.splice(0)) controller.abort();
+  electron.windows.length = 0;
+  electron.handlers.clear();
+  electron.storage.clear();
+  vi.clearAllMocks();
+});
+function setup(timeoutMs = 30_000, product: "okou" | "zero" = "zero") {
+  const config = resolveDesktopConfig(undefined, product);
+  const external: string[] = [];
+  const driver = new DesktopAuthWindow({
+    authOrigin: origin,
+    partition: config.authPartition,
+    timeoutMs,
+    windowOptions: () => ({
+      webPreferences: {
+        sandbox: true,
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    }),
+    openExternal: (url) => {
+      external.push(url);
+    },
+  });
+  const session = new DesktopAuthSession({
+    product,
+    apiBaseUrl: "https://api.vm0.ai",
+    cookieUrls: [],
+    cookieSource: { cookies: { get: async () => [] } },
+    addClientHeaders: () => {},
+    tokenUrl: `${origin}/desktop-auth/token`,
+    consumeUrl: () => `${origin}/desktop-auth/consume`,
+    selectOrgUrl: `${origin}/desktop-auth/select-org`,
+    runAuthWindow: (request) => driver.run(request),
+  });
+  installDesktopAuthIpc(
+    {
+      getState: () => session.getAuthState(),
+      openSignIn: () => {},
+      openOrgSelection: () => session.selectOrganization(),
+      signOut: async () => session.signOut(),
+    },
+    { rendererUrl, authWindow: driver },
+  );
+  return { driver, session, external };
+}
+function currentWindow(): TestWindow {
+  const window = electron.windows.at(-1);
+  if (!window) throw new Error("Auth window was not created");
+  return window;
+}
+function navigate(window: TestWindow, path: string) {
+  const url = new URL(path, origin).toString();
+  window.webContents.mainFrame.url = url;
+  window.webContents.emit("did-navigate", {}, url);
+}
+async function deliver(
+  window: TestWindow,
+  payload: unknown = { token: "fresh" },
+  override?: Partial<InvokeEvent>,
+) {
+  const handler = electron.handlers.get(DESKTOP_AUTH_CHANNELS.completeSignIn);
+  if (!handler) throw new Error("IPC was not installed");
+  return await handler(
+    {
+      sender: window.webContents,
+      senderFrame: window.webContents.mainFrame,
+      ...override,
+    },
+    payload,
+  );
+}
+function run(
+  driver: DesktopAuthWindow,
+  path = "/desktop-auth/token",
+  interactive = false,
+) {
+  const controller = new AbortController();
+  controllers.push(controller);
+  const pending = driver.run({
+    url: `${origin}${path}`,
+    visible: interactive,
+    allowInteractiveFallbacks: interactive,
+    signal: controller.signal,
+  });
+  return { pending, controller, window: currentWindow() };
+}
+
+describe("Desktop authentication IPC and document lifecycle", () => {
+  it.each(["/desktop-auth/token", "/desktop-auth/select-org"])(
+    "accepts only the live main frame at %s and waits for document completion",
+    async (path) => {
+      const { driver } = setup();
+      const { pending, window } = run(driver, path, true);
+      let completed = false;
+      void pending.then(() => {
+        completed = true;
+      });
+      await deliver(window);
+      expect(completed).toBe(false);
+      expect(window.destroyed).toBe(false);
+      expect(window.options.webPreferences).toMatchObject({
+        sandbox: true,
+        contextIsolation: true,
+        nodeIntegration: false,
+      });
+      // App's server acknowledgement occurs between IPC resolution and this
+      // full-document navigation. IPC alone cannot close the window or succeed.
+      navigate(window, "/");
+      expect(await pending).toBe("fresh");
+      expect(window.destroyed).toBe(true);
+      await expect(deliver(window)).rejects.toThrow("no longer active");
+    },
+  );
+
+  it.each(["/", "/en", "/de/", "/ja", "/es/"])(
+    "rejects completion navigation %s without a new token",
+    async (path) => {
+      const { driver } = setup();
+      const { pending, window } = run(driver);
+      const rejected = expect(pending).rejects.toThrow("without a token");
+      navigate(window, path);
+      await rejected;
+    },
+  );
+
+  it.each([
+    rendererUrl,
+    "https://www.vm0.ai/desktop-auth/token",
+    "https://api.vm0.ai/desktop-auth/token",
+    "https://evil.test/desktop-auth/token",
+    `${origin}/desktop-auth/callback`,
+    `${origin}/desktop-auth/consume`,
+    `${origin}/`,
+    `${origin}/desktop-auth/token/`,
+  ])("rejects delivery at %s", async (url) => {
+    const { driver } = setup();
+    const { pending, controller, window } = run(driver);
+    window.webContents.mainFrame.url = url;
+    await expect(deliver(window)).rejects.toThrow("unavailable on this page");
+    const rejected = expect(pending).rejects.toThrow("cancelled");
+    controller.abort();
+    await rejected;
+  });
+
+  it("rejects another webContents and subframes even with the exact allowed URL", async () => {
+    const { driver } = setup();
+    const { pending, window } = run(driver);
+    const other = Object.assign(new EventEmitter(), {
+      mainFrame: { url: `${origin}/desktop-auth/token` },
+      destroyed: false,
+      popup: () => ({ action: "deny" }),
+    });
+    await expect(
+      deliver(window, { token: "foreign" }, { sender: other }),
+    ).rejects.toThrow("unavailable on this page");
+    await expect(
+      deliver(
+        window,
+        { token: "iframe" },
+        { senderFrame: { url: `${origin}/desktop-auth/token` } },
+      ),
+    ).rejects.toThrow("unavailable on this page");
+    await deliver(window);
+    navigate(window, "/");
+    expect(await pending).toBe("fresh");
+  });
+
+  it.each([
+    null,
+    undefined,
+    "token",
+    {},
+    { token: "" },
+    { token: "  " },
+    { token: "header\ninjection" },
+    { token: 1 },
+  ])("rejects malformed IPC payload %j", async (payload) => {
+    const { driver } = setup();
+    const { pending, window } = run(driver);
+    const handler = electron.handlers.get(
+      DESKTOP_AUTH_CHANNELS.completeSignIn,
+    )!;
+    await expect(
+      Promise.resolve().then(() =>
+        handler(
+          {
+            sender: window.webContents,
+            senderFrame: window.webContents.mainFrame,
+          },
+          payload,
+        ),
+      ),
+    ).rejects.toThrow("requires a token");
+    await deliver(window);
+    navigate(window, "/");
+    expect(await pending).toBe("fresh");
+  });
+
+  it.each(["closed", "cancelled", "timeout"])(
+    "rejects late IPC after %s even after token delivery",
+    async (reason) => {
+      const { driver } = setup(reason === "timeout" ? 5 : 30_000);
+      const { pending, controller, window } = run(driver);
+      const rejected = expect(pending).rejects.toThrow();
+      await deliver(window);
+      if (reason === "closed") window.close();
+      if (reason === "cancelled") controller.abort();
+      await rejected;
+      await expect(deliver(window, { token: "late" })).rejects.toThrow(
+        "no longer active",
+      );
+    },
+  );
+
+  it("supersedes an old window and rejects its completion against the new operation", async () => {
+    const { driver } = setup();
+    const old = run(driver);
+    const rejected = expect(old.pending).rejects.toThrow("cancelled");
+    const next = run(driver);
+    await rejected;
+    await expect(deliver(old.window)).rejects.toThrow(
+      "unavailable on this page",
+    );
+    await deliver(next.window, { token: "new" });
+    navigate(next.window, "/");
+    expect(await next.pending).toBe("new");
+  });
+
+  it("sign-out invalidates the real session and staged IPC token before document navigation", async () => {
+    const { session } = setup();
+    const pending = session.consumeCode("code");
+    const rejected = expect(pending).rejects.toThrow();
+    const window = currentWindow();
+    navigate(window, "/desktop-auth/token");
+    await deliver(window);
+    expect(session.getCachedToken()).toBeNull();
+    session.signOut();
+    await rejected;
+    await expect(deliver(window)).rejects.toThrow("no longer active");
+    expect(session.getCachedToken()).toBeNull();
+    expect(await session.getAuthState()).toMatchObject({
+      status: "signed_out",
+    });
+  });
+
+  it("does not reuse the previously cached bearer when a new window only navigates", async () => {
+    const { session } = setup();
+    const initial = session.getToken();
+    const first = currentWindow();
+    await deliver(first, { token: "previous" });
+    navigate(first, "/");
+    expect(await initial).toBe("previous");
+    const next = session.getToken({ forceRefresh: true });
+    const rejected = expect(next).rejects.toThrow("without a token");
+    navigate(currentWindow(), "/");
+    await rejected;
+    expect(session.getCachedToken()).toBeNull();
+  });
+
+  it.each(["/desktop-auth/start", "/desktop-auth/select-org"])(
+    "ends a signed-out hidden restore at %s with no token",
+    async (path) => {
+      const { driver } = setup();
+      const { pending, window } = run(driver);
+      navigate(window, path);
+      expect(await pending).toBeNull();
+    },
+  );
+
+  it("restricts navigation and redirects to the exact configured auth origin", async () => {
+    const { driver, external } = setup();
+    const { pending, window } = run(driver);
+    for (const url of [
+      "https://www.vm0.ai/desktop-auth/token",
+      "https://api.vm0.ai/desktop-auth/token",
+      "https://app.okou.ai.evil.test/desktop-auth/token",
+    ]) {
+      for (const event of ["will-navigate", "will-redirect"]) {
+        let prevented = false;
+        window.webContents.emit(
+          event,
+          {
+            preventDefault: () => {
+              prevented = true;
+            },
+          },
+          url,
+        );
+        expect(prevented).toBe(true);
+      }
+    }
+    let prevented = false;
+    window.webContents.emit(
+      "will-navigate",
+      {
+        preventDefault: () => {
+          prevented = true;
+        },
+      },
+      `${origin}/desktop-auth/select-org`,
+    );
+    expect(prevented).toBe(false);
+    expect(window.webContents.popup({ url: "https://example.test" })).toEqual({
+      action: "deny",
+    });
+    expect(external).toContain("https://example.test/");
+    await deliver(window);
+    navigate(window, "/");
+    expect(await pending).toBe("fresh");
+  });
+
+  it("rejects duplicate token delivery within the same operation", async () => {
+    const { driver } = setup();
+    const { pending, window } = run(driver);
+    await deliver(window);
+    await expect(deliver(window, { token: "replacement" })).rejects.toThrow(
+      "already delivered",
+    );
+    navigate(window, "/");
+    expect(await pending).toBe("fresh");
+  });
+  it("ignores consumed status and SPA navigation until full document completion", async () => {
+    const { driver } = setup();
+    const { pending, window } = run(driver);
+    let completed = false;
+    void pending.then(() => {
+      completed = true;
+    });
+    window.webContents.emit("ipc-message", {}, "consumed");
+    window.webContents.emit("did-navigate-in-page", {}, `${origin}/`);
+    await deliver(window);
+    expect(completed).toBe(false);
+    navigate(window, "/");
+    expect(await pending).toBe("fresh");
+  });
+
+  it("reports a load failure without echoing credential-bearing URLs or descriptions", async () => {
+    const { driver } = setup();
+    const { pending, window } = run(driver);
+    const rejected = expect(pending).rejects.toThrow(
+      "Desktop auth page failed: -2",
+    );
+    window.webContents.emit(
+      "did-fail-load",
+      {},
+      -2,
+      "secret-token",
+      `${origin}/?code=secret-code`,
+      true,
+    );
+    await rejected;
+    await expect(deliver(window)).rejects.toThrow("no longer active");
+  });
+  it("clears the isolated App/Clerk store and preserves native profile data", async () => {
+    const config = resolveDesktopConfig(undefined, "okou");
+    const { driver } = setup(30_000, "okou");
+    electron.storage.set(config.sessionPartition, [
+      "host-registration",
+      "preferences",
+      "recordings",
+      "plugins",
+      "legacy-www-cookies",
+    ]);
+    electron.storage.set(config.authPartition, [
+      "app-session",
+      "clerk-client",
+      "app-localstorage",
+    ]);
+    const { pending, window } = run(driver);
+    expect(window.options.webPreferences?.partition).toBe(config.authPartition);
+    const rejected = expect(pending).rejects.toThrow("cancelled");
+    await driver.clearStorage();
+    await rejected;
+    expect(electron.storage.has(config.authPartition)).toBe(false);
+    expect(electron.storage.get(config.sessionPartition)).toEqual([
+      "host-registration",
+      "preferences",
+      "recordings",
+      "plugins",
+      "legacy-www-cookies",
+    ]);
+    await expect(deliver(window)).rejects.toThrow("no longer active");
+  });
+
+  it("validates an App bearer after real IPC and full document completion", async () => {
+    const requests: string[] = [];
+    const server = setupServer(
+      http.get("https://api.vm0.ai/api/auth/me", ({ request }) => {
+        requests.push(`me:${request.headers.get("authorization")}`);
+        expect(request.headers.get("cookie")).toBeNull();
+        return HttpResponse.json({
+          userId: "app-user",
+          email: "app@example.test",
+          orgId: "app-org",
+        });
+      }),
+      http.get("https://api.vm0.ai/api/org", ({ request }) => {
+        requests.push(`org:${request.headers.get("authorization")}`);
+        return HttpResponse.json({ id: "app-org", name: "App" });
+      }),
+    );
+    server.listen({ onUnhandledRequest: "error" });
+    try {
+      const { session } = setup(30_000, "okou");
+      const pending = session.consumeCode("code");
+      const window = currentWindow();
+      navigate(window, "/desktop-auth/token");
+      await deliver(window);
+      expect(session.getCachedToken()).toBeNull();
+      expect(requests).toEqual([]);
+      navigate(window, "/");
+      await pending;
+      expect(session.getCachedToken()).toBe("fresh");
+      expect(requests).toEqual(["me:Bearer fresh", "org:Bearer fresh"]);
+      await expect(deliver(window, { token: "stale" })).rejects.toThrow(
+        "no longer active",
+      );
+      session.signOut();
+      expect(await session.getAuthState()).toMatchObject({
+        status: "signed_out",
+      });
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/turbo/apps/desktop/src/desktop-auth-window.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-window.test.ts
@@ -306,6 +306,20 @@ describe("Desktop authentication IPC and document lifecycle", () => {
     },
   );
 
+  it("settles closure without accessing a destroyed BrowserWindow native getter", async () => {
+    const { driver } = setup();
+    const { pending, window } = run(driver);
+    const rejected = expect(pending).rejects.toThrow("window closed");
+    // Electron marks the native window destroyed before emitting closed.
+    Object.defineProperty(window, "webContents", {
+      get: () => {
+        throw new Error("Object has been destroyed");
+      },
+    });
+    expect(() => window.close()).not.toThrow();
+    await rejected;
+  });
+
   it("supersedes an old window and rejects its completion against the new operation", async () => {
     const { driver } = setup();
     const old = run(driver);

--- a/turbo/apps/desktop/src/desktop-auth-window.ts
+++ b/turbo/apps/desktop/src/desktop-auth-window.ts
@@ -132,6 +132,8 @@ export class DesktopAuthWindow {
     window: BrowserWindow,
     request: DesktopAuthWindowRequest,
   ): Promise<string | null> {
+    // The native BrowserWindow getter is unavailable during the closed event.
+    const contents = window.webContents;
     return new Promise((resolve, reject) => {
       let settled = false;
       let token: string | null = null;
@@ -141,8 +143,8 @@ export class DesktopAuthWindow {
         this.active = null;
         clearTimeout(timeout);
         request.signal.removeEventListener("abort", cancel);
-        window.webContents.off("did-navigate", navigate);
-        window.webContents.off("did-fail-load", failed);
+        contents.off("did-navigate", navigate);
+        contents.off("did-fail-load", failed);
         window.off("closed", closed);
         if (!window.isDestroyed()) window.close();
         if (error) reject(error);
@@ -197,8 +199,8 @@ export class DesktopAuthWindow {
         },
       };
       request.signal.addEventListener("abort", cancel, { once: true });
-      window.webContents.on("did-navigate", navigate);
-      window.webContents.on("did-fail-load", failed);
+      contents.on("did-navigate", navigate);
+      contents.on("did-fail-load", failed);
       window.on("closed", closed);
       void window.loadURL(request.url).catch((error: unknown) => {
         if (!isElectronNavigationAborted(error)) {

--- a/turbo/apps/desktop/src/desktop-auth-window.ts
+++ b/turbo/apps/desktop/src/desktop-auth-window.ts
@@ -1,0 +1,210 @@
+import {
+  BrowserWindow,
+  session,
+  type BrowserWindowConstructorOptions,
+  type IpcMainInvokeEvent,
+} from "electron";
+import {
+  isDesktopAuthCompletionNavigation,
+  isDesktopAuthSelectOrgNavigation,
+  isDesktopAuthStartNavigation,
+  isElectronNavigationAborted,
+} from "./desktop-auth";
+import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
+import { showAndFocusWindow } from "./desktop-window-lifecycle";
+
+export interface DesktopAuthWindowRequest {
+  readonly url: string;
+  readonly visible: boolean;
+  readonly allowInteractiveFallbacks: boolean;
+  readonly signal: AbortSignal;
+}
+
+interface AuthWindowOptions {
+  readonly authOrigin: string;
+  readonly partition: string;
+  readonly windowOptions: () => BrowserWindowConstructorOptions;
+  readonly openExternal: (url: string) => void;
+  readonly timeoutMs?: number;
+}
+
+interface ActiveAuthWindow {
+  readonly window: BrowserWindow;
+  readonly signal: AbortSignal;
+  readonly deliver: (token: string) => void;
+  readonly cancel: () => void;
+}
+
+/** Owns the IPC capability and the staged token until document completion. */
+export class DesktopAuthWindow {
+  private active: ActiveAuthWindow | null = null;
+  private readonly origins: ReadonlySet<string>;
+
+  constructor(private readonly options: AuthWindowOptions) {
+    this.origins = new Set([options.authOrigin]);
+  }
+
+  completeSignIn(event: IpcMainInvokeEvent, token: string): void {
+    const active = this.active;
+    if (!active || active.signal.aborted || active.window.isDestroyed()) {
+      throw new Error("Desktop auth operation is no longer active");
+    }
+    const contents = active.window.webContents;
+    if (
+      contents.isDestroyed() ||
+      event.sender !== contents ||
+      event.senderFrame !== contents.mainFrame
+    ) {
+      throw new Error("Desktop auth completion is unavailable on this page");
+    }
+    const url = new URL(contents.mainFrame.url);
+    if (
+      url.origin !== this.options.authOrigin ||
+      !["/desktop-auth/token", "/desktop-auth/select-org"].includes(
+        url.pathname,
+      )
+    ) {
+      throw new Error("Desktop auth completion is unavailable on this page");
+    }
+    active.deliver(token);
+  }
+
+  run(request: DesktopAuthWindowRequest): Promise<string | null> {
+    request.signal.throwIfAborted();
+    if (!isAllowedAppNavigation(request.url, this.origins)) {
+      throw new Error("Invalid Desktop auth origin");
+    }
+    this.active?.cancel();
+    const options = this.options.windowOptions();
+    const window = new BrowserWindow({
+      ...options,
+      webPreferences: {
+        ...options.webPreferences,
+        partition: this.options.partition,
+      },
+      show: request.visible,
+      width: request.visible ? 520 : 480,
+      height: 640,
+      skipTaskbar: !request.visible,
+    });
+    this.installPolicy(window);
+    return this.waitForCompletion(window, request);
+  }
+
+  async clearStorage(): Promise<void> {
+    this.active?.cancel();
+    await session.fromPartition(this.options.partition).clearStorageData({
+      storages: [
+        "cookies",
+        "localstorage",
+        "indexdb",
+        "serviceworkers",
+        "cachestorage",
+      ],
+    });
+  }
+
+  private installPolicy(window: BrowserWindow): void {
+    const external = (url: string) => {
+      const decision = decideWindowOpen(url, new Set());
+      if (decision.action === "open-external") {
+        this.options.openExternal(decision.url);
+      }
+    };
+    window.webContents.on("will-navigate", (event, url) => {
+      if (!isAllowedAppNavigation(url, this.origins)) {
+        event.preventDefault();
+        external(url);
+      }
+    });
+    window.webContents.on("will-redirect", (event, url) => {
+      if (!isAllowedAppNavigation(url, this.origins)) {
+        event.preventDefault();
+      }
+    });
+    window.webContents.setWindowOpenHandler(({ url }) => {
+      external(url);
+      return { action: "deny" };
+    });
+  }
+
+  private waitForCompletion(
+    window: BrowserWindow,
+    request: DesktopAuthWindowRequest,
+  ): Promise<string | null> {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      let token: string | null = null;
+      const finish = (result: string | null, error?: Error) => {
+        if (settled) return;
+        settled = true;
+        this.active = null;
+        clearTimeout(timeout);
+        request.signal.removeEventListener("abort", cancel);
+        window.webContents.off("did-navigate", navigate);
+        window.webContents.off("did-fail-load", failed);
+        window.off("closed", closed);
+        if (!window.isDestroyed()) window.close();
+        if (error) reject(error);
+        else resolve(result);
+      };
+      const cancel = () =>
+        finish(null, new Error("Desktop auth operation cancelled"));
+      const closed = () =>
+        finish(null, new Error("Desktop auth window closed"));
+      const navigate = (_event: Electron.Event, url: string) => {
+        if (
+          !request.allowInteractiveFallbacks &&
+          (isDesktopAuthStartNavigation(url, this.origins) ||
+            isDesktopAuthSelectOrgNavigation(url, this.origins))
+        ) {
+          finish(null);
+        } else if (isDesktopAuthSelectOrgNavigation(url, this.origins)) {
+          showAndFocusWindow(window);
+        } else if (isDesktopAuthCompletionNavigation(url, this.origins)) {
+          // App navigates only after token IPC and the handoff acknowledgement.
+          // A landing page without a token is never proof of authentication.
+          finish(
+            token,
+            token
+              ? undefined
+              : new Error("Desktop auth completed without a token"),
+          );
+        }
+      };
+      const failed = (
+        _event: Electron.Event,
+        code: number,
+        _description: string,
+        _url: string,
+        mainFrame: boolean,
+      ) => {
+        if (mainFrame && code !== -3) {
+          finish(null, new Error(`Desktop auth page failed: ${code}`));
+        }
+      };
+      const timeout = setTimeout(() => {
+        finish(null, new Error("Desktop auth window timed out"));
+      }, this.options.timeoutMs ?? 30_000);
+      this.active = {
+        window,
+        signal: request.signal,
+        cancel,
+        deliver: (value) => {
+          if (settled || token !== null)
+            throw new Error("Desktop auth token already delivered");
+          token = value;
+        },
+      };
+      request.signal.addEventListener("abort", cancel, { once: true });
+      window.webContents.on("did-navigate", navigate);
+      window.webContents.on("did-fail-load", failed);
+      window.on("closed", closed);
+      void window.loadURL(request.url).catch((error: unknown) => {
+        if (!isElectronNavigationAborted(error)) {
+          finish(null, new Error("Desktop auth page could not load"));
+        }
+      });
+    });
+  }
+}

--- a/turbo/apps/desktop/src/desktop-auth.ts
+++ b/turbo/apps/desktop/src/desktop-auth.ts
@@ -86,11 +86,11 @@ export function parseDesktopAuthCallbackArgv(
 }
 
 export function buildDesktopAuthConsumeUrl(
-  webUrl: URL,
+  authUrl: URL,
   code: string,
   handoffId: string | null = null,
 ): string {
-  const consumeUrl = new URL(DESKTOP_AUTH_CONSUME_PATH, webUrl);
+  const consumeUrl = new URL(DESKTOP_AUTH_CONSUME_PATH, authUrl);
   consumeUrl.searchParams.set("code", code);
   if (handoffId) {
     consumeUrl.searchParams.set("handoffId", handoffId);
@@ -99,10 +99,10 @@ export function buildDesktopAuthConsumeUrl(
 }
 
 export function buildDesktopAuthSelectOrgUrl(
-  webUrl: URL,
+  authUrl: URL,
   forceSelection = false,
 ): string {
-  const selectOrgUrl = new URL(DESKTOP_AUTH_SELECT_ORG_PATH, webUrl);
+  const selectOrgUrl = new URL(DESKTOP_AUTH_SELECT_ORG_PATH, authUrl);
   if (forceSelection) {
     selectOrgUrl.searchParams.set(
       DESKTOP_AUTH_FORCE_ORG_SELECTION_PARAM,
@@ -113,16 +113,16 @@ export function buildDesktopAuthSelectOrgUrl(
 }
 
 export function buildDesktopAuthStartUrl(
-  webUrl: URL,
+  authUrl: URL,
   authScheme: string,
 ): string {
-  const startUrl = new URL(DESKTOP_AUTH_START_WEB_PATH, webUrl);
+  const startUrl = new URL(DESKTOP_AUTH_START_WEB_PATH, authUrl);
   startUrl.searchParams.set(DESKTOP_AUTH_CALLBACK_SCHEME_PARAM, authScheme);
   return startUrl.toString();
 }
 
-export function buildDesktopAuthTokenUrl(webUrl: URL): string {
-  return new URL(DESKTOP_AUTH_TOKEN_PATH, webUrl).toString();
+export function buildDesktopAuthTokenUrl(authUrl: URL): string {
+  return new URL(DESKTOP_AUTH_TOKEN_PATH, authUrl).toString();
 }
 
 export function isDesktopAuthStartNavigation(

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -76,6 +76,7 @@ const originalArch = process.arch;
 const productionConfig: DesktopConfig = {
   platformUrl: new URL("https://app.vm0.ai"),
   webUrl: new URL("https://www.vm0.ai"),
+  authUrl: new URL("https://app.okou.ai"),
   environment: "production",
   identity: {
     product: "zero",
@@ -88,6 +89,7 @@ const productionConfig: DesktopConfig = {
     authScheme: "vm0",
   },
   sessionPartition: "persist:vm0-desktop-production",
+  authPartition: "persist:okou-desktop-auth-test",
   allowedAppOrigins: new Set(["https://app.vm0.ai"]),
 };
 

--- a/turbo/apps/desktop/src/desktop-environment-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-environment-entry-points.test.ts
@@ -60,6 +60,8 @@ const config = resolveDesktopConfig(
 if (
   config.identity.product !== process.env.TEST_EXPECTED_PRODUCT ||
   config.platformUrl.toString() !== process.env.TEST_EXPECTED_PLATFORM_URL ||
+  config.authUrl.origin !== (config.identity.product === "okou" ? (config.environment === "production" ? "https://app.okou.ai" : config.platformUrl.origin) : config.webUrl.origin) ||
+  (config.identity.product === "okou" ? config.authPartition === config.sessionPartition : config.authPartition !== config.sessionPartition) ||
   config.environment !== process.env.TEST_EXPECTED_ENVIRONMENT ||
   config.identity.displayName !== process.env.TEST_EXPECTED_DISPLAY_NAME ||
   config.sessionPartition !== process.env.TEST_EXPECTED_SESSION_PARTITION

--- a/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
+++ b/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
@@ -5,6 +5,7 @@ import type {
   DesktopComputerUseState,
 } from "./computer-use-types";
 import type { DesktopAuthState } from "./desktop-bridge";
+import { DesktopAuthWindow } from "./desktop-auth-window";
 import { DESKTOP_AUTH_CHANNELS } from "./desktop-auth-ipc-channels";
 import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-channels";
 import { DESKTOP_RECORDER_CHANNELS } from "./desktop-recorder-ipc-channels";
@@ -62,7 +63,6 @@ interface MockBrowserWindow {
 
 const rendererUrl = "vm0-desktop://renderer/index.html";
 const recorderUrl = "vm0-desktop://renderer/recorder.html?mode=bar";
-const allowedAppUrl = "https://app.vm0.ai/desktop-auth/callback";
 const blockedAppUrl = "https://evil.example/desktop-auth/callback";
 
 beforeEach(() => {
@@ -336,7 +336,12 @@ describe("Desktop IPC boundary", () => {
 
     installDesktopAuthIpc(api, {
       rendererUrl,
-      allowedAppOrigins: new Set(["https://app.vm0.ai"]),
+      authWindow: new DesktopAuthWindow({
+        authOrigin: "https://app.vm0.ai",
+        partition: "persist:desktop-test",
+        windowOptions: () => ({}),
+        openExternal: () => {},
+      }),
     });
 
     for (const channel of [
@@ -354,38 +359,6 @@ describe("Desktop IPC boundary", () => {
     expect(api.openSignIn).not.toHaveBeenCalled();
     expect(api.openOrgSelection).not.toHaveBeenCalled();
     expect(api.signOut).not.toHaveBeenCalled();
-  });
-
-  it("protects auth handlers by renderer URL, allowed app origins, and token payloads", async () => {
-    const { installDesktopAuthIpc } = await import("./desktop-auth-electron");
-    const api = createDesktopAuthApi();
-
-    installDesktopAuthIpc(api, {
-      rendererUrl,
-      allowedAppOrigins: new Set(["https://app.vm0.ai"]),
-    });
-
-    await expect(
-      invokeIpc(DESKTOP_AUTH_CHANNELS.getState, allowedAppUrl),
-    ).rejects.toThrow("Desktop auth is unavailable on this page");
-    await expect(
-      invokeIpc(DESKTOP_AUTH_CHANNELS.completeSignIn, blockedAppUrl, {
-        token: "desktop_token",
-      }),
-    ).rejects.toThrow("Desktop auth completion is unavailable on this page");
-    await expect(
-      invokeIpc(DESKTOP_AUTH_CHANNELS.completeSignIn, allowedAppUrl, {
-        token: "",
-      }),
-    ).rejects.toThrow("Desktop auth completion requires a token");
-
-    await invokeIpc(DESKTOP_AUTH_CHANNELS.getState, rendererUrl);
-    await invokeIpc(DESKTOP_AUTH_CHANNELS.completeSignIn, allowedAppUrl, {
-      token: "desktop_token",
-    });
-
-    expect(api.getState).toHaveBeenCalledOnce();
-    expect(api.completeSignIn).toHaveBeenCalledWith("desktop_token");
   });
 
   it("protects developer tools handlers by renderer URL and validates payloads", async () => {
@@ -537,7 +510,6 @@ function createDesktopAuthApi(): {
   readonly openSignIn: ReturnType<typeof vi.fn<() => void>>;
   readonly openOrgSelection: ReturnType<typeof vi.fn<() => Promise<void>>>;
   readonly signOut: ReturnType<typeof vi.fn<() => Promise<void>>>;
-  readonly completeSignIn: ReturnType<typeof vi.fn<(token: string) => void>>;
 } {
   return {
     getState: vi.fn(() => {
@@ -550,7 +522,6 @@ function createDesktopAuthApi(): {
     openSignIn: vi.fn(() => {}),
     openOrgSelection: vi.fn(async () => {}),
     signOut: vi.fn(async () => {}),
-    completeSignIn: vi.fn(() => {}),
   };
 }
 

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -99,6 +99,7 @@ import {
 } from "./desktop-smoke-test";
 import { installDesktopTray, type DesktopTrayController } from "./desktop-tray";
 import { DesktopAuthSession } from "./desktop-auth-session";
+import { DesktopAuthWindow } from "./desktop-auth-window";
 import {
   installDesktopAuthIpc,
   notifyDesktopAuthChanged,
@@ -113,9 +114,7 @@ import {
   buildDesktopAuthStartUrl,
   buildDesktopAuthTokenUrl,
   createDesktopAuthStartGate,
-  isDesktopAuthCompletionNavigation,
   isElectronNavigationAborted,
-  isDesktopAuthSelectOrgNavigation,
   isDesktopAuthStartNavigation,
   parseDesktopAuthCallback,
   parseDesktopAuthCallbackArgv,
@@ -135,7 +134,7 @@ import {
   desktopRendererUrl,
   isDesktopRendererUrl,
 } from "./desktop-renderer-url";
-import { decideWindowOpen, isAllowedAppNavigation } from "./window-policy";
+import { decideWindowOpen } from "./window-policy";
 
 const config = resolveDesktopConfig();
 const desktopApiBaseUrl = resolveComputerUseApiBaseUrl(config.platformUrl);
@@ -144,26 +143,18 @@ const addDesktopClientHeaders = createDesktopClientHeaderInjector({
   product: config.identity.product,
 });
 const desktopAuthStartUrl = buildDesktopAuthStartUrl(
-  config.webUrl,
+  config.authUrl,
   config.identity.authScheme,
 );
 const desktopAuthSelectOrgUrl = buildDesktopAuthSelectOrgUrl(
-  config.webUrl,
+  config.authUrl,
   true,
 );
-const desktopAuthTokenUrl = buildDesktopAuthTokenUrl(config.webUrl);
+const desktopAuthTokenUrl = buildDesktopAuthTokenUrl(config.authUrl);
 const localRendererUrl = desktopRendererUrl();
 const localRecorderUrl = desktopRecorderUrl("bar");
 const ZERO_FEATURE_SWITCHES_PATH = "/api/feature-switches";
 const noAllowedAppOrigins: ReadonlySet<string> = new Set();
-const ELECTRON_ERR_ABORTED = -3;
-const DESKTOP_SIGN_OUT_STORAGES = [
-  "cookies",
-  "localstorage",
-  "indexdb",
-  "serviceworkers",
-  "cachestorage",
-] as const;
 const SCREEN_RECORDING_POLL_INTERVAL_MS = 1000;
 const MAC_ACCESSIBILITY_SETTINGS_URL =
   "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
@@ -437,25 +428,13 @@ function notifyDeveloperToolsChanged(): void {
   }
 }
 
-async function runAuthWindow(request: {
-  readonly url: string;
-  readonly visible: boolean;
-  readonly allowInteractiveFallbacks: boolean;
-}): Promise<void> {
-  const authWindow = new BrowserWindow({
-    ...browserWindowOptions(),
-    show: request.visible,
-    width: request.visible ? 520 : 480,
-    height: 640,
-    skipTaskbar: !request.visible,
-  });
-  installAuthConsumeWindowPolicy(authWindow);
-  const pending = waitForAuthConsumeWindow(authWindow, {
-    allowInteractiveFallbacks: request.allowInteractiveFallbacks,
-  });
-  await loadAuthUrl(authWindow, request.url);
-  await pending;
-}
+const authWindow = new DesktopAuthWindow({
+  authOrigin: config.authUrl.origin,
+  partition: config.authPartition,
+  windowOptions: () => browserWindowOptions(),
+  openExternal,
+});
+let authStorageClearing: Promise<void> | null = null;
 
 let authSession: DesktopAuthSession | null = null;
 let pendingDesktopAuthCallback: DesktopAuthCallback | null = null;
@@ -471,14 +450,19 @@ function getAuthSession(): DesktopAuthSession {
 
   authSession = new DesktopAuthSession({
     apiBaseUrl: desktopApiBaseUrl,
+    product: config.identity.product,
     cookieUrls: [config.webUrl, config.platformUrl],
     cookieSource: session.fromPartition(config.sessionPartition),
     addClientHeaders: addDesktopClientHeaders,
     tokenUrl: desktopAuthTokenUrl,
     consumeUrl: (code, handoffId) =>
-      buildDesktopAuthConsumeUrl(config.webUrl, code, handoffId),
+      buildDesktopAuthConsumeUrl(config.authUrl, code, handoffId),
     selectOrgUrl: desktopAuthSelectOrgUrl,
-    runAuthWindow,
+    runAuthWindow: async (request) => {
+      await authStorageClearing;
+      request.signal.throwIfAborted();
+      return await authWindow.run(request);
+    },
     onChange: notifyAuthChanged,
     onAuthCompleted: maybeStartComputerUseAfterAuth,
   });
@@ -1014,16 +998,15 @@ export const notifyDesktopAutoUpdatesInstalled: DesktopMainModule["notifyDesktop
     applyApplicationMenu();
   };
 
-async function clearDesktopAuthStorage(): Promise<void> {
-  await session.fromPartition(config.sessionPartition).clearStorageData({
-    storages: [...DESKTOP_SIGN_OUT_STORAGES],
-  });
-}
-
 async function signOutDesktopSession(): Promise<void> {
-  await clearDesktopAuthStorage();
   getAuthSession().signOut();
-  await computerUseController.stopForAuthChange();
+  authStorageClearing = (authStorageClearing ?? Promise.resolve()).then(
+    async () => {
+      await authWindow.clearStorage();
+      await computerUseController.stopForAuthChange();
+    },
+  );
+  await authStorageClearing;
 }
 
 function installDesktopAuth(): void {
@@ -1035,11 +1018,10 @@ function installDesktopAuth(): void {
       },
       openOrgSelection: () => getAuthSession().selectOrganization(),
       signOut: signOutDesktopSession,
-      completeSignIn: (token) => getAuthSession().completeSignIn(token),
     },
     {
       rendererUrl: localRendererUrl,
-      allowedAppOrigins: config.allowedAppOrigins,
+      authWindow,
     },
   );
 }
@@ -1206,18 +1188,8 @@ function logComputerUseLaunchError(error: unknown): void {
   console.error("Desktop Computer Use launch setup check failed", error);
 }
 
-async function loadAuthUrl(window: BrowserWindow, url: string): Promise<void> {
-  try {
-    await window.loadURL(url);
-  } catch (error) {
-    if (!isElectronNavigationAborted(error)) {
-      throw error;
-    }
-  }
-}
-
 function openDesktopAuthStart(rawUrl: string): boolean {
-  if (!isDesktopAuthStartNavigation(rawUrl, config.allowedAppOrigins)) {
+  if (!isDesktopAuthStartNavigation(rawUrl, new Set([config.authUrl.origin]))) {
     return false;
   }
 
@@ -1364,6 +1336,7 @@ async function createMainWindow(): Promise<BrowserWindow> {
 
 interface DesktopSmokeBridgeState {
   readonly auth: boolean;
+  readonly authCompletionRejected: boolean;
   readonly computerUse: boolean;
   readonly developerTools: boolean;
   readonly identity: DesktopIdentityInfo | null;
@@ -1390,6 +1363,8 @@ function isDesktopSmokeBridgeState(
     value !== null &&
     "auth" in value &&
     typeof value.auth === "boolean" &&
+    "authCompletionRejected" in value &&
+    typeof value.authCompletionRejected === "boolean" &&
     "computerUse" in value &&
     typeof value.computerUse === "boolean" &&
     "developerTools" in value &&
@@ -1402,12 +1377,13 @@ function isDesktopSmokeBridgeState(
 async function verifyDesktopSmokeBridge(): Promise<void> {
   const window = await createMainWindow();
   const rawState: unknown = await window.webContents.executeJavaScript(
-    `({
+    `(async () => ({
       auth: typeof window.vm0DesktopAuth === "object",
+      authCompletionRejected: await window.vm0DesktopAuth.completeSignIn({ token: "smoke-test-token" }).then(() => false, () => true),
       computerUse: typeof window.vm0DesktopComputerUse === "object",
       developerTools: typeof window.vm0DesktopDeveloperTools === "object",
       identity: window.vm0DesktopIdentity ?? null,
-    })`,
+    }))()`,
     true,
   );
 
@@ -1420,6 +1396,7 @@ async function verifyDesktopSmokeBridge(): Promise<void> {
   const state = rawState;
   if (
     !state.auth ||
+    !state.authCompletionRejected ||
     !state.computerUse ||
     !state.developerTools ||
     !state.identity ||
@@ -1433,126 +1410,14 @@ async function verifyDesktopSmokeBridge(): Promise<void> {
   }
 }
 
-function installAuthConsumeWindowPolicy(window: BrowserWindow): void {
-  window.webContents.on("will-navigate", (event, url) => {
-    if (isAllowedAppNavigation(url, config.allowedAppOrigins)) {
-      return;
-    }
-    event.preventDefault();
-    const decision = decideWindowOpen(url, noAllowedAppOrigins);
-    if (decision.action === "open-external") {
-      openExternal(decision.url);
-    }
-  });
-
-  window.webContents.setWindowOpenHandler(({ url }) => {
-    const decision = decideWindowOpen(url, noAllowedAppOrigins);
-    if (decision.action === "open-external") {
-      openExternal(decision.url);
-    }
-    return { action: "deny" };
-  });
-}
-
-function waitForAuthConsumeWindow(
-  window: BrowserWindow,
-  options: { readonly allowInteractiveFallbacks: boolean },
+async function maybeStartComputerUseAfterAuth(
+  signal: AbortSignal,
 ): Promise<void> {
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    let closed = false;
-    const timeout = setTimeout(() => {
-      rejectAuth(new Error("Desktop auth consume timed out"));
-    }, 30_000);
-
-    const cleanup = (): void => {
-      clearTimeout(timeout);
-      if (!closed && !window.isDestroyed()) {
-        window.webContents.off("did-navigate", handleNavigation);
-        window.webContents.off("did-fail-load", handleLoadFailure);
-        window.off("closed", handleClosed);
-      }
-    };
-
-    const resolveAuth = (): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup();
-      if (!window.isDestroyed()) {
-        window.close();
-      }
-      resolve();
-    };
-
-    const rejectAuth = (error: Error): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup();
-      if (!window.isDestroyed()) {
-        window.close();
-      }
-      reject(error);
-    };
-
-    const handleNavigation = (_event: Electron.Event, url: string): void => {
-      if (
-        !options.allowInteractiveFallbacks &&
-        isDesktopAuthStartNavigation(url, config.allowedAppOrigins)
-      ) {
-        resolveAuth();
-        return;
-      }
-      if (isDesktopAuthSelectOrgNavigation(url, config.allowedAppOrigins)) {
-        if (options.allowInteractiveFallbacks) {
-          showAndFocusWindow(window);
-          return;
-        }
-        resolveAuth();
-        return;
-      }
-      if (isDesktopAuthCompletionNavigation(url, config.allowedAppOrigins)) {
-        resolveAuth();
-      }
-    };
-
-    const handleLoadFailure = (
-      _event: Electron.Event,
-      errorCode: number,
-      errorDescription: string,
-      _validatedUrl: string,
-      isMainFrame: boolean,
-    ): void => {
-      if (errorCode === ELECTRON_ERR_ABORTED) {
-        return;
-      }
-      if (isMainFrame) {
-        rejectAuth(
-          new Error(
-            `Desktop auth consume failed: ${errorCode} ${errorDescription}`,
-          ),
-        );
-      }
-    };
-
-    const handleClosed = (): void => {
-      closed = true;
-      rejectAuth(new Error("Desktop auth consume window closed"));
-    };
-
-    window.webContents.on("did-navigate", handleNavigation);
-    window.webContents.on("did-fail-load", handleLoadFailure);
-    window.on("closed", handleClosed);
-  });
-}
-
-async function maybeStartComputerUseAfterAuth(): Promise<void> {
   await computerUseController.stopForAuthChange();
+  signal.throwIfAborted();
   notifyAuthChanged();
   const permissions = await refreshComputerUsePermissionState();
+  signal.throwIfAborted();
   notifyComputerUseChanged();
   if (hasRequiredComputerUsePermissions(permissions)) {
     await computerUseController.start({ userInitiated: true });

--- a/turbo/apps/desktop/src/window-policy.test.ts
+++ b/turbo/apps/desktop/src/window-policy.test.ts
@@ -2576,3 +2576,67 @@ describe("computer use desktop runtime", () => {
     });
   });
 });
+
+describe("explicit Desktop auth origin", () => {
+  it.each([
+    ["okou", undefined, "https://app.okou.ai"],
+    ["okou", "https://app.vm0.ai", "https://app.okou.ai"],
+    ["okou", "https://staging-app.omby.ai", "https://staging-app.omby.ai"],
+    ["okou", "https://pr-123-app.omby.ai", "https://pr-123-app.omby.ai"],
+    [
+      "okou",
+      "https://app.vm7.ai:8443/path?query=1#hash",
+      "https://app.vm7.ai:8443",
+    ],
+    ["okou", "https://custom.example/path", "https://custom.example"],
+    ["okou", "http://localhost:3002", "http://localhost:3002"],
+    ["okou", "http://127.0.0.1:3002", "http://127.0.0.1:3002"],
+    ["zero", undefined, "https://www.vm0.ai"],
+    ["zero", "https://staging-app.omby.ai", "https://staging-www.omby.ai"],
+    ["zero", "https://pr-123-app.omby.ai", "https://pr-123-www.omby.ai"],
+    ["zero", "https://app.vm7.ai:8443", "https://www.vm7.ai:8443"],
+    ["zero", "http://localhost:3002", "http://localhost:3000"],
+  ])(
+    "routes every %s auth entry for %s to %s",
+    (product, platformUrl, origin) => {
+      const config = resolveDesktopConfig(platformUrl, product);
+      expect(config.authUrl.origin).toBe(origin);
+      expect(
+        buildDesktopAuthStartUrl(config.authUrl, config.identity.authScheme),
+      ).toBe(
+        `${origin}/desktop-auth/start?callbackScheme=${config.identity.authScheme}`,
+      );
+      expect(
+        buildDesktopAuthConsumeUrl(config.authUrl, "code", "handoff"),
+      ).toBe(`${origin}/desktop-auth/consume?code=code&handoffId=handoff`);
+      expect(buildDesktopAuthTokenUrl(config.authUrl)).toBe(
+        `${origin}/desktop-auth/token`,
+      );
+      expect(buildDesktopAuthSelectOrgUrl(config.authUrl, true)).toBe(
+        `${origin}/desktop-auth/select-org?force=true`,
+      );
+      if (product === "okou")
+        expect(config.authPartition).not.toBe(config.sessionPartition);
+      else expect(config.authPartition).toBe(config.sessionPartition);
+    },
+  );
+
+  it("keeps production API, Marketing and update identity independent from App auth", () => {
+    const config = resolveDesktopConfig(undefined, "okou");
+    expect(resolveComputerUseApiBaseUrl(config.platformUrl)).toBe(
+      "https://api.vm0.ai",
+    );
+    expect(config.webUrl.origin).toBe("https://www.vm0.ai");
+    expect(config.identity.authScheme).toBe("ai.okou.desktop");
+    expect(config.identity.updateLine).toBe("ai-okou-desktop");
+    expect(config.sessionPartition).toBe("persist:vm0-desktop-production");
+    expect(
+      resolveDesktopConfig("https://app.okou.ai", "okou").authPartition,
+    ).toBe(config.authPartition);
+    expect(
+      resolveDesktopConfig("https://pr-123-app.omby.ai", "okou").authPartition,
+    ).not.toBe(
+      resolveDesktopConfig("https://pr-124-app.omby.ai", "okou").authPartition,
+    );
+  });
+});

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -549,6 +549,9 @@ importers:
       happy-dom:
         specifier: ^20.11.6
         version: 20.11.6
+      msw:
+        specifier: ^2.13.2
+        version: 2.13.2(@types/node@24.3.0)(@typescript/typescript6@6.0.2)
       oxlint:
         specifier: ^1.75.0
         version: 1.75.0(oxlint-tsgolint@7.0.2001)


### PR DESCRIPTION
## Summary

Okou Desktop currently builds authentication URLs from Marketing and can restore a legacy WWW/API cookie identity before consulting the App session. Move every native authentication entry to an explicit App origin, and accept native identity only after the live auth window delivers a bearer and the API confirms a matching user/workspace under that same bearer.

Closes #32061. Implements the client cutover slice of EPIC #31956.

## Invariants and caller inventory

- `authUrl` is independent of Marketing `webUrl` and the native API base: production Okou uses `https://app.okou.ai`; staging, PR, custom and local environments use their configured App origin. Zero keeps its derived WWW origin. Production native API remains `https://api.vm0.ai`.
- Startup/system-browser and tray sign-in share the explicit start URL. Callback consume, hidden restore/401 refresh, workspace selection and auth navigation all use the explicit origin. The only remaining runtime `config.webUrl` reference supplies the unchanged Zero cookie policy; Okou never reads it or the API cookie jar.
- Okou has an origin-isolated persistent **auth partition**, separate from the unchanged native partition. This deliberately starts without copied legacy credentials and permits one explicit sign-in after migration. Sign-out immediately aborts the generation and clears the bearer, then serializes clearing the App/Clerk auth store and stopping the dependent runtime. Native preferences, host registration, recordings and plugins remain outside that store. Zero retains its existing partition and cookie policy.
- `DesktopAuthWindow` owns one live window, its exact webContents and main frame, the exact auth origin and token/select-org route, and the operation AbortSignal. Malformed/control-character payloads, other windows/frames/routes and late/duplicate completions reject. Sandbox and context isolation remain enabled.
- Tokens are staged until full-document completion. IPC receipt, `consumed`, SPA navigation, closure or a landing-page navigation without a new token cannot establish a native identity. This preserves App's deployed order: fresh-token IPC, handoff `completed` acknowledgement when present, then document navigation.
- Okou's `/api/auth/me` and `/api/org` reads are pinned to the same bearer and validate the response organization against `me.orgId`. Tokens are exposed to native consumers only after validation. API requests strip ambient/caller cookies, retain client headers and disallow redirects or another API origin. A 401 triggers at most one App refresh and one authenticated retry; no cookie-only retry or legacy-origin fallback. Failed App authentication notifies renderer/tray subscribers and requires the next explicit sign-in, preventing observer reads from repeatedly reopening a failed hidden restore.
- `rg` inventory covered main startup/tray/callback, session and API consumers, Electron IPC/preload/renderer, runtime-config/build entry points, bootstrap/updater, package smoke, scripts and native sources. The only canonical native source on the implementation base is the existing Computer Use/recorder helper; it contains no independent auth consumer. Hosted routes, protocols, callbacks, API contracts, DB, TTL, updater identities and UI are unchanged.

## Live baseline and overlap

- Actual fetched `origin/main` base: `7a9252039ee467efca9bdc1878e5bf7aa74c96cf`.
- Stable production Desktop feed: `0.46.28`, `okou-desktop-v0.46.28`, release commit `f9dddef37d114f08e6f45680290a4d49a606c679`. Independently read the live `ai-okou-desktop/stable/darwin/arm64/RELEASES.json` feed and GitHub release on 2026-09-07 (Asia/Shanghai).
- #31835 remains OPEN, head `5156aa04b828f504a2ef7feeb9926262702f8e8a`.
- #31838 was OPEN at implementation start, head `c79b8b0cbe9c970667fa478c45bd801220359b15`; it remains OPEN and advanced to `21246043dd71d4d140dec3f41e7e569b87ac11fc` during this work.
- Neither rewrite was canonical when implementation started. Neither PR was modified, delayed, merged or given ordering priority. Later-merging native consumers must adopt this explicit-origin, bearer-authority and active-window contract when rebased.

## Validation

Focused tests cover the full environment/URL matrix, Zero restoration and cookie retry, legacy-cookie-only profiles, consistent bearer user/org, expired/rejected tokens, coalesced refreshes, identical freshly delivered token bytes, cold-start/callback supersession, delayed validation after sign-out, exact window/frame/path ownership, malformed payloads, closure/cancel/timeout/sign-out/supersede, tokenless document navigation and storage isolation. HTTP uses MSW; Electron is mocked at its runtime boundary. The packaged smoke now exercises the real preload/IPC path and requires completion from the main Desktop renderer to reject.

Commands run from `turbo/` with repository-pinned pnpm 10.33.4:

```sh
corepack pnpm -F @okouai/desktop exec vitest run src/desktop-auth-session.test.ts src/desktop-auth-window.test.ts src/desktop-ipc-boundary.test.ts src/window-policy.test.ts src/desktop-environment-entry-points.test.ts src/preload.test.ts src/bootstrap.test.ts src/bootstrap-degraded.test.ts src/bootstrap-imports.test.ts src/desktop-auto-updates.test.ts src/desktop-update-feed.test.ts src/desktop-client-headers.test.ts src/desktop-smoke-test.test.ts src/desktop-tray.test.ts --maxWorkers=1 --silent=passed-only
corepack pnpm -F @okouai/desktop check-types
corepack pnpm -F @okouai/desktop lint
corepack pnpm exec knip --workspace apps/desktop
corepack pnpm -F @okouai/desktop build:native
corepack pnpm -F @okouai/desktop build:electron
corepack pnpm -F @okouai/desktop build:mcp-filesystem
corepack pnpm -F @okouai/desktop build:renderer
node apps/desktop/scripts/check-bootstrap-bundle.mjs
```

- 211 tests across 14 targeted files passed on the current head (31.75s). Desktop types/lint, scoped Knip, changed-file Prettier and `git diff --check` passed.
- Electron/bootstrap, MCP and renderer builds: passed. Native helper build reports its existing macOS-only skip on this Linux runner; real macOS packaging/launch smoke must pass in the Desktop PR pipeline.
- Initial local checks found a removed-but-still-used import, a stale test URL slash expectation and the existing degraded-bootstrap test's implicit arm64 assumption. Fixed the import/test expectations and made the macOS architecture explicit. A top-level build attempt hit the runner's pnpm 12 wrapper; running each unchanged build target directly through repository-pinned Corepack succeeded.
- No full local Vitest suite or local dev server.
- Current-head PR CI passed for `a53b255a6d99b887f31d645c8224e399cad853ef`: [Turbo](https://github.com/vm0-ai/vm0/actions/runs/34066264488), [Crates](https://github.com/vm0-ai/vm0/actions/runs/34066264532), and [Security Scanning](https://github.com/vm0-ai/vm0/actions/runs/34066264586), including all three required `ci-gate-*` checks.
- [Desktop macOS CI](https://github.com/vm0-ai/vm0/actions/runs/34066264486) passed on the current head: 542 Desktop tests across 48 files; 118 native helper tests across 21 suites; default, explicit Okou production, and PR preview artifacts each built, passed artifact verification, and launched successfully through `node apps/desktop/scripts/smoke-test-packaged-app.js`. These are unsigned CI artifacts and do not establish a real authenticated Clerk handoff.
- Current head: `a53b255a6d99b887f31d645c8224e399cad853ef`. [Tracked current-head self-review](https://github.com/vm0-ai/vm0/pull/32062#issuecomment-5562877944): LGTM. All current-head PR checks and packaged smoke passed. Re-admitted to the normal protected merge queue with the reviewed head as the match guard; final merge-group checks remain required.
- The review also verified Electron 42.5.1 closes a BrowserWindow after marking its native object destroyed. The auth window now retains its webContents EventEmitter for teardown; a failing-then-passing regression proves close settles the pending auth promise without reading a destroyed native getter.
- A final caller review found a missing subscriber notification on failed background refresh. The added regression failed on the previous head and passed after the focused fix; Desktop types/lint, formatting, diff checks and Electron/bootstrap build also passed again. GitHub rejected the repair push while the old head was queued, so this PR was normally dequeued to apply the verified fix. No protection was bypassed, no other PR was touched, and no discarded merge-group job was rerun.

## Remaining gate and authority

**No production authority.** This thread owns one focused PR through normal protected-queue MERGED status only. No release tooling, release PR merge, production deployment approval, manifest promotion, Desktop version bump or production operation is included.

Lancy explicitly accepted the still-unfinished Slice A authenticated hosted-browser takeover on 2026-09-07 and requested a release before personally verifying the released Desktop. That gate is **not passed**. Real released login/refresh/workspace switching, independent controller acceptance and exact release inclusion remain controller/user post-merge and post-release responsibilities. Mocked tests and packaged bridge smoke do not claim a real authenticated Clerk handoff.
