### PR TITLE
fix(desktop): require app bearer for okou computer use requests

### DIFF
--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -152,6 +152,8 @@ describe("Okou App session authority", () => {
       http.post(`${api}/api/protected`, async ({ request }) => {
         expect(request.headers.get("authorization")).toBe("Bearer fresh");
         expect(request.headers.get("cookie")).toBeNull();
+        expect(request.credentials).toBe("omit");
+        expect(request.redirect).toBe("error");
         expect(request.headers.get("x-client-type")).toBe("Desktop");
         expect(request.headers.get("x-client-version")).toBe("0.46.28");
         return HttpResponse.json(await request.json());
@@ -163,6 +165,8 @@ describe("Okou App session authority", () => {
         method: "POST",
         body: JSON.stringify({ action: "test" }),
         headers: { cookie: "legacy", authorization: "Bearer wrong" },
+        credentials: "include",
+        redirect: "follow",
       },
     );
     expect(await response.json()).toEqual({ action: "test" });

--- a/turbo/apps/desktop/src/desktop-computer-use-api.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-api.ts
@@ -1,9 +1,43 @@
-import type { ComputerUseHostFetch } from "./computer-use-host";
+import {
+  ComputerUseHostRuntime,
+  type ComputerUseHostFetch,
+} from "./computer-use-host";
+import type { DesktopProduct } from "@okouai/api-contracts/contracts/client-headers";
+import type { DesktopAuthSession } from "./desktop-auth-session";
 import type { DesktopClientHeaderInjector } from "./desktop-client-headers";
 import {
   headersWithSessionCookies,
   type DesktopSessionCookieSource,
 } from "./desktop-session-cookies";
+
+export function createDesktopComputerUseHostRuntime(
+  options: Omit<
+    ConstructorParameters<typeof ComputerUseHostRuntime>[0],
+    "sessionFetch"
+  >,
+  auth: {
+    readonly product: DesktopProduct;
+    readonly session: DesktopSessionCookieSource;
+    readonly getAuthSession: () => DesktopAuthSession;
+  },
+): ComputerUseHostRuntime {
+  return new ComputerUseHostRuntime({
+    ...options,
+    // Okou shares the App session's bearer, refresh and sign-out lifetime.
+    // Zero keeps its existing Computer Use cookie and token retry policy.
+    sessionFetch:
+      auth.product === "okou"
+        ? (input, init) =>
+            auth.getAuthSession().fetchWithSessionAuth(new URL(input), init)
+        : createDesktopComputerUseSessionFetch({
+            platformUrl: options.platformUrl,
+            session: auth.session,
+            addClientHeaders: options.addClientHeaders,
+            getCachedAuthToken: () => auth.getAuthSession().getCachedToken(),
+            getAuthToken: (options) => auth.getAuthSession().getToken(options),
+          }),
+  });
+}
 
 export function createDesktopComputerUseSessionFetch(params: {
   readonly platformUrl: URL;

--- a/turbo/apps/desktop/src/desktop-computer-use-runtime.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-runtime.test.ts
@@ -1,0 +1,400 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { resolveDesktopConfig } from "./config";
+import { DesktopAuthSession } from "./desktop-auth-session";
+import {
+  buildDesktopAuthConsumeUrl,
+  buildDesktopAuthSelectOrgUrl,
+  buildDesktopAuthTokenUrl,
+} from "./desktop-auth";
+import type { DesktopAuthWindowRequest } from "./desktop-auth-window";
+import { createDesktopClientHeaderInjector } from "./desktop-client-headers";
+import { createDesktopComputerUseHostRuntime } from "./desktop-computer-use-api";
+import type { ComputerUseHostRuntime } from "./computer-use-host";
+import type { ComputerUsePermissionState } from "./computer-use-types";
+
+const api = "https://api.vm0.ai";
+const startUrl = `${api}/api/computer-use/hosts/start`;
+const permissions = { accessibility: true, screenRecording: true };
+const server = setupServer();
+const runtimes: ComputerUseHostRuntime[] = [];
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(async () => {
+  for (const runtime of runtimes.splice(0)) await runtime.stop();
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function createDesktop(product: "okou" | "zero" = "okou") {
+  const config = resolveDesktopConfig(undefined, product);
+  const windows: DesktopAuthWindowRequest[] = [];
+  const replies: Promise<string | null>[] = [];
+  const cookieReads: string[] = [];
+  const requests: Request[] = [];
+  const nativeSession = {
+    cookies: {
+      get: async ({ url }: { url: string }) => {
+        cookieReads.push(url);
+        return [{ name: "__session", value: "legacy-user" }];
+      },
+    },
+  };
+  const addClientHeaders = createDesktopClientHeaderInjector({
+    product,
+    clientVersion: "1.2.3",
+  });
+  const authSession = new DesktopAuthSession({
+    product,
+    apiBaseUrl: api,
+    cookieUrls: [config.webUrl, config.platformUrl],
+    cookieSource: nativeSession,
+    addClientHeaders,
+    tokenUrl: buildDesktopAuthTokenUrl(config.authUrl),
+    selectOrgUrl: buildDesktopAuthSelectOrgUrl(config.authUrl, true),
+    consumeUrl: (code, id) =>
+      buildDesktopAuthConsumeUrl(config.authUrl, code, id),
+    runAuthWindow: async (request) => {
+      windows.push(request);
+      return await (replies.shift() ?? Promise.resolve(null));
+    },
+  });
+  server.use(
+    http.all(`${api}/*`, ({ request }) => {
+      requests.push(request);
+      switch (new URL(request.url).pathname) {
+        case "/api/auth/me":
+          return HttpResponse.json({
+            userId: "app-user",
+            email: "app@example.test",
+            orgId: "app-org",
+          });
+        case "/api/org":
+          return HttpResponse.json({ id: "app-org", name: "App workspace" });
+        case "/api/computer-use/hosts/start":
+          return hostStarted();
+        default:
+          return HttpResponse.json({ status: "idle" });
+      }
+    }),
+  );
+  function createRuntime(
+    options: {
+      platformUrl?: URL;
+      getPermissions?: () => Promise<ComputerUsePermissionState>;
+    } = {},
+  ) {
+    // This is the same construction entry point used by main.ts. Keep both
+    // the runtime and auth session real so an alternate request policy fails.
+    const runtime = createDesktopComputerUseHostRuntime(
+      {
+        platformUrl: options.platformUrl ?? config.platformUrl,
+        installationId: "00000000-0000-4000-8000-000000000001",
+        hostName: "test-host",
+        appVersion: "1.2.3",
+        addClientHeaders,
+        hostFetch: (input, init) => fetch(input, init),
+        getPermissions: options.getPermissions ?? (() => permissions),
+        executeCommand: async () => ({ status: "succeeded", result: {} }),
+      },
+      {
+        product: config.identity.product,
+        session: nativeSession,
+        getAuthSession: () => authSession,
+      },
+    );
+    runtimes.push(runtime);
+    return runtime;
+  }
+  return {
+    authSession,
+    windows,
+    replies,
+    cookieReads,
+    requests,
+    createRuntime,
+  };
+}
+
+function hostStarted() {
+  return HttpResponse.json({ hostId: "host-1", hostToken: "host-token" });
+}
+
+function expectAppRequest(request: Request) {
+  expect(new URL(request.url).origin).toBe(api);
+  expect(request.headers.get("cookie")).toBeNull();
+  expect(request.credentials).toBe("omit");
+  expect(request.redirect).toBe("error");
+  expect(request.headers.get("x-client-product")).toBe("okou");
+  expect(request.headers.get("x-client-type")).toBe("Desktop");
+  expect(request.headers.get("x-client-version")).toBe("1.2.3");
+  expect(request.headers.get("x-client-session-id")).toBeTruthy();
+  expect(request.headers.get("x-client-request-id")).toBeTruthy();
+}
+
+describe("production Okou Computer Use session wiring", () => {
+  it("leaves host start and the auth probe unauthenticated with only native cookies", async () => {
+    const desktop = createDesktop();
+    const runtime = desktop.createRuntime();
+    await runtime.start();
+    expect(runtime.getState().status).toBe("unauthenticated");
+    expect(desktop.requests).toEqual([]);
+    expect(desktop.cookieReads).toEqual([]);
+    expect(desktop.windows.map((window) => window.url)).toEqual([
+      "https://app.okou.ai/desktop-auth/token",
+    ]);
+  });
+
+  it("starts under the validated App bearer and required client headers", async () => {
+    const desktop = createDesktop();
+    desktop.replies.push(Promise.resolve("app-token"));
+    const runtime = desktop.createRuntime();
+    await runtime.start();
+    expect(runtime.getState()).toMatchObject({
+      status: "online",
+      hostId: "host-1",
+    });
+    expect(
+      desktop.requests.map((request) => new URL(request.url).pathname),
+    ).toEqual(["/api/auth/me", "/api/org", "/api/computer-use/hosts/start"]);
+    for (const request of desktop.requests) {
+      expectAppRequest(request);
+      expect(request.headers.get("authorization")).toBe("Bearer app-token");
+    }
+    expect(desktop.cookieReads).toEqual([]);
+  });
+
+  it.each(["fresh", null, "rejected"])(
+    "bounds a 401 refresh delivering %s without a cookie request or probe bypass",
+    async (refreshed) => {
+      const desktop = createDesktop();
+      desktop.replies.push(
+        Promise.resolve("expired"),
+        Promise.resolve(refreshed),
+      );
+      await desktop.authSession.getToken();
+      const starts: Request[] = [];
+      server.use(
+        http.post(startUrl, ({ request }) => {
+          starts.push(request);
+          return request.headers.get("authorization") === "Bearer fresh"
+            ? hostStarted()
+            : new HttpResponse(null, { status: 401 });
+        }),
+      );
+      const runtime = desktop.createRuntime();
+      await runtime.start();
+      expect(runtime.getState().status).toBe(
+        refreshed === "fresh" ? "online" : "unauthenticated",
+      );
+      expect(
+        starts.map((request) => request.headers.get("authorization")),
+      ).toEqual(
+        refreshed
+          ? ["Bearer expired", `Bearer ${refreshed}`]
+          : ["Bearer expired"],
+      );
+      for (const request of [...desktop.requests, ...starts])
+        expectAppRequest(request);
+      expect(
+        new Set(
+          starts.map((request) => request.headers.get("x-client-request-id")),
+        ).size,
+      ).toBe(starts.length);
+      expect(desktop.windows.map((window) => window.url)).toEqual([
+        "https://app.okou.ai/desktop-auth/token",
+        "https://app.okou.ai/desktop-auth/token",
+      ]);
+      expect(desktop.cookieReads).toEqual([]);
+    },
+  );
+
+  it("refuses redirects from host registration without exposing credentials to the target", async () => {
+    const desktop = createDesktop();
+    desktop.replies.push(Promise.resolve("app-token"));
+    const leaked: string[] = [];
+    server.use(
+      http.post(startUrl, () =>
+        HttpResponse.redirect("https://untrusted.test/host", 307),
+      ),
+      http.all("https://untrusted.test/*", ({ request }) => {
+        leaked.push(request.url);
+        return hostStarted();
+      }),
+    );
+    const runtime = desktop.createRuntime();
+    await runtime.start();
+    expect(runtime.getState().hostId).toBeNull();
+    expect(runtime.getState().status).not.toBe("online");
+    expect(leaked).toEqual([]);
+    expect(desktop.cookieReads).toEqual([]);
+  });
+
+  it("pins a runtime request to the auth session's exact API origin", async () => {
+    const desktop = createDesktop();
+    desktop.replies.push(Promise.resolve("app-token"));
+    const runtime = desktop.createRuntime({
+      platformUrl: new URL("https://api.vm0.ai:444"),
+    });
+    await runtime.start();
+    expect(runtime.getState()).toMatchObject({
+      hostId: null,
+      lastError: "Invalid Desktop API origin",
+    });
+    expect(desktop.requests.map((request) => request.url)).toEqual([
+      `${api}/api/auth/me`,
+      `${api}/api/org`,
+    ]);
+    expect(desktop.cookieReads).toEqual([]);
+  });
+
+  it("blocks an existing runtime after synchronous sign-out while startup is awaiting permissions", async () => {
+    const desktop = createDesktop();
+    desktop.replies.push(Promise.resolve("app-token"));
+    await desktop.authSession.getToken();
+    desktop.requests.length = 0;
+    const entered = deferred<void>();
+    const release = deferred<ComputerUsePermissionState>();
+    const runtime = desktop.createRuntime({
+      getPermissions: () => {
+        entered.resolve();
+        return release.promise;
+      },
+    });
+    const starting = runtime.start();
+    await entered.promise;
+    desktop.authSession.signOut();
+    release.resolve(permissions);
+    await starting;
+    expect(runtime.getState().status).toBe("unauthenticated");
+    expect(desktop.requests).toEqual([]);
+    expect(desktop.cookieReads).toEqual([]);
+    expect(desktop.windows).toHaveLength(1);
+  });
+
+  it("cancels an in-flight host start and cannot restart through cookies after sign-out", async () => {
+    const desktop = createDesktop();
+    desktop.replies.push(Promise.resolve("app-token"));
+    await desktop.authSession.getToken();
+    desktop.requests.length = 0;
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const starts: Request[] = [];
+    server.use(
+      http.post(startUrl, async ({ request }) => {
+        starts.push(request);
+        entered.resolve();
+        await release.promise;
+        return hostStarted();
+      }),
+    );
+    const runtime = desktop.createRuntime();
+    const starting = runtime.start();
+    await entered.promise;
+    desktop.authSession.signOut();
+    release.resolve();
+    await starting;
+    expect(runtime.getState().hostId).toBeNull();
+    expect(starts[0]?.signal.aborted).toBe(true);
+    await runtime.stop();
+    await runtime.start();
+    expect(runtime.getState().status).toBe("unauthenticated");
+    expect(starts).toHaveLength(1);
+    expect(desktop.requests).toEqual([]);
+    expect(desktop.cookieReads).toEqual([]);
+  });
+
+  it("discards a late refresh delivery after sign-out before runtime teardown", async () => {
+    const desktop = createDesktop();
+    desktop.replies.push(Promise.resolve("expired"));
+    await desktop.authSession.getToken();
+    desktop.requests.length = 0;
+    const reply = deferred<string | null>();
+    desktop.replies.push(reply.promise);
+    let starts = 0;
+    server.use(
+      http.post(startUrl, () => {
+        starts++;
+        return new HttpResponse(null, { status: 401 });
+      }),
+    );
+    const runtime = desktop.createRuntime();
+    const starting = runtime.start();
+    // The queued window is the observable refresh boundary, not a timer.
+    await expect.poll(() => desktop.windows.length).toBe(2);
+    desktop.authSession.signOut();
+    reply.resolve("late-token");
+    await starting;
+    expect(runtime.getState().status).toBe("unauthenticated");
+    expect(desktop.authSession.getCachedToken()).toBeNull();
+    expect(starts).toBe(1);
+    expect(desktop.requests).toEqual([]);
+    expect(desktop.cookieReads).toEqual([]);
+    expect(desktop.windows[1]?.signal.aborted).toBe(true);
+  });
+});
+
+describe("production Zero Computer Use session wiring", () => {
+  it("retains cookie-only host registration without App restoration", async () => {
+    const desktop = createDesktop("zero");
+    const runtime = desktop.createRuntime();
+    await runtime.start();
+    expect(runtime.getState().status).toBe("online");
+    expect(desktop.windows).toEqual([]);
+    expect(desktop.cookieReads).toEqual(["https://app.vm0.ai/", startUrl]);
+    expect(desktop.requests).toHaveLength(1);
+    expect(desktop.requests[0]?.headers.get("authorization")).toBeNull();
+    expect(desktop.requests[0]?.headers.get("cookie")).toBe(
+      "__session=legacy-user",
+    );
+  });
+
+  it.each([null, "expired"])(
+    "retains cookies on the initial %s bearer attempt and the WWW refresh retry",
+    async (initial) => {
+      const desktop = createDesktop("zero");
+      if (initial) {
+        desktop.replies.push(Promise.resolve(initial));
+        await desktop.authSession.getToken();
+      }
+      desktop.replies.push(Promise.resolve("fresh"));
+      const starts: Request[] = [];
+      server.use(
+        http.post(startUrl, ({ request }) => {
+          starts.push(request);
+          return request.headers.get("authorization") === "Bearer fresh"
+            ? hostStarted()
+            : new HttpResponse(null, { status: 401 });
+        }),
+      );
+      const runtime = desktop.createRuntime();
+      await runtime.start();
+      expect(runtime.getState().status).toBe("online");
+      expect(
+        starts.map((request) => request.headers.get("authorization")),
+      ).toEqual([initial ? `Bearer ${initial}` : null, "Bearer fresh"]);
+      expect(starts.map((request) => request.headers.get("cookie"))).toEqual([
+        "__session=legacy-user",
+        "__session=legacy-user",
+      ]);
+      expect(desktop.windows.map((window) => window.url)).toEqual(
+        Array(initial ? 2 : 1).fill("https://www.vm0.ai/desktop-auth/token"),
+      );
+      expect(desktop.cookieReads).toEqual([
+        "https://app.vm0.ai/",
+        startUrl,
+        "https://app.vm0.ai/",
+        startUrl,
+      ]);
+    },
+  );
+});

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -35,7 +35,7 @@ import {
   notifyDesktopComputerUseChanged,
 } from "./computer-use-electron";
 import {
-  ComputerUseHostRuntime,
+  type ComputerUseHostRuntime,
   readSystemHostName,
   resolveComputerUseApiBaseUrl,
 } from "./computer-use-host";
@@ -80,7 +80,7 @@ import { checkForDesktopUpdates } from "./desktop-auto-updates";
 import { createDesktopClientHeaderInjector } from "./desktop-client-headers";
 import type { DesktopMainModule } from "./desktop-main-module";
 import { DesktopComputerUseAutoStartSupervisor } from "./desktop-computer-use-autostart";
-import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
+import { createDesktopComputerUseHostRuntime } from "./desktop-computer-use-api";
 import { readOrCreateComputerUseInstallationId } from "./desktop-computer-use-installation";
 import { DesktopFilesystemPluginManager } from "./desktop-filesystem-plugin";
 import { DesktopMcpPluginManager } from "./desktop-mcp-plugin";
@@ -659,39 +659,39 @@ function createComputerUseHostRuntime(): ComputerUseHostRuntime {
   const installationId = readOrCreateComputerUseInstallationId(
     desktopPreferencesPath(),
   );
-  return new ComputerUseHostRuntime({
-    platformUrl: config.platformUrl,
-    installationId,
-    hostName: readSystemHostName(config.identity.displayName),
-    appVersion: app.getVersion(),
-    sessionFetch: createDesktopComputerUseSessionFetch({
+  return createDesktopComputerUseHostRuntime(
+    {
       platformUrl: config.platformUrl,
-      session: desktopSession,
+      installationId,
+      hostName: readSystemHostName(config.identity.displayName),
+      appVersion: app.getVersion(),
+      hostFetch: (input, init) => {
+        return fetch(input, init);
+      },
       addClientHeaders: addDesktopClientHeaders,
-      getCachedAuthToken: () => getAuthSession().getCachedToken(),
-      getAuthToken: (options) => getAuthSession().getToken(options),
-    }),
-    hostFetch: (input, init) => {
-      return fetch(input, init);
-    },
-    addClientHeaders: addDesktopClientHeaders,
-    getPermissions: refreshComputerUsePermissionState,
-    getSupportedCapabilities: supportedComputerUseCapabilities,
-    executeCommand: (command, permissions) => {
-      if (command.kind === COMPUTER_USE_PLUGIN_CALL_KIND) {
-        if (isComputerUseMcpPluginCallPayload(command.payload)) {
-          return ensureMcpPluginManager().execute(command);
+      getPermissions: refreshComputerUsePermissionState,
+      getSupportedCapabilities: supportedComputerUseCapabilities,
+      executeCommand: (command, permissions) => {
+        if (command.kind === COMPUTER_USE_PLUGIN_CALL_KIND) {
+          if (isComputerUseMcpPluginCallPayload(command.payload)) {
+            return ensureMcpPluginManager().execute(command);
+          }
+          return ensureFilesystemPluginManager().execute(command);
         }
-        return ensureFilesystemPluginManager().execute(command);
-      }
-      return executeComputerUseCommand(command, permissions, {
-        nativeBackend: computerUseNativeBackend,
-        snapshotStore: computerUseSnapshotStore,
-      });
+        return executeComputerUseCommand(command, permissions, {
+          nativeBackend: computerUseNativeBackend,
+          snapshotStore: computerUseSnapshotStore,
+        });
+      },
+      onCommandFailure: automationPermissionPrompt,
+      onChange: notifyComputerUseChanged,
     },
-    onCommandFailure: automationPermissionPrompt,
-    onChange: notifyComputerUseChanged,
-  });
+    {
+      product: config.identity.product,
+      session: desktopSession,
+      getAuthSession,
+    },
+  );
 }
 
 async function startComputerUseRuntime(


### PR DESCRIPTION
## Problem and change

Closes #32063. Repairs the remaining native-request acceptance failure in #32061, under EPIC #31956.

The canonical Computer Use runtime could register a host or pass its auth probe using native partition cookies without an App bearer, including after sign-out invalidated the bearer but before runtime teardown. `main.ts` now constructs that runtime through `createDesktopComputerUseHostRuntime`, which routes Okou session requests directly through the existing `DesktopAuthSession.fetchWithSessionAuth`. Zero continues using the unchanged Computer Use cookie transport.

## Invariants and caller inventory

- Okou uses the current App-delivered, identity-validated bearer. Missing App sessions return unauthenticated without reading or sending native/caller cookies. There is no second auth state machine or legacy-origin fallback.
- The shared session owns exact API-origin checks, caller authorization/cookie replacement, `credentials: omit`, `redirect: error`, Desktop client headers, one bounded App refresh and one bearer-only retry, and synchronous sign-out cancellation.
- The production construction entry point and real `ComputerUseHostRuntime` are exercised together with the real `DesktopAuthSession` and MSW. Runtime tests cover both host registration and the subsequent auth-probe behavior, cookie-only profiles, refresh success/failure, redirects, origin mismatch, and sign-out before dispatch, during a request, and during refresh. Zero cookie-only and cached/absent-bearer refresh regressions also run through this entry point.
- Repo-wide searches covered `createDesktopComputerUseSessionFetch`, `sessionFetch`, `getCachedAuthToken`, `getAuthToken`, `getCachedToken`, `fetchWithSessionAuth`, cookie helpers, native requests, and runtime constructors. The two Computer Use session consumers are `startHost` and `hasAuthenticatedSession`. Recorder preparation/completion and developer feature-switch requests already use the shared session. Host-token heartbeat/command/stop requests, presigned recording uploads, local renderer file loading, telemetry, and update transport do not derive user identity from native cookies. Canonical Swift code on this base is the native helper, not either open rewrite.
- Scope is four Desktop source/test files. No API, App/Marketing, Clerk/DNS, database, native profile/host registration, update identity, release version, or force-upgrade change.

## Baselines and overlap

- Fetched `origin/main` base: `21c1b15d7d6b4dede89fb7e9bc0e23c534b50b45`, the protected merge of #32062.
- Live stable Desktop: `0.46.28`, verified through the production `ai-okou-desktop` stable update feed; tag `okou-desktop-v0.46.28` resolves to release commit `f9dddef37d114f08e6f45680290a4d49a606c679`.
- Implementation-time overlap: #31835 OPEN at `5156aa04b828f504a2ef7feeb9926262702f8e8a`; #31838 OPEN at `21246043dd71d4d140dec3f41e7e569b87ac11fc`. Inventory only; neither was modified or used as a merge-order dependency. Later rewrites adopt the canonical contract when rebasing.

## Validation

Commands below ran from `turbo/` unless stated otherwise:

```sh
corepack pnpm -F @okouai/desktop exec vitest run src/desktop-computer-use-runtime.test.ts src/desktop-computer-use-api.test.ts src/computer-use-host.test.ts src/computer-use-runtime-controller.test.ts src/desktop-computer-use-autostart.test.ts src/desktop-launch-computer-use.test.ts src/desktop-auth-session.test.ts src/desktop-auth-window.test.ts src/desktop-ipc-boundary.test.ts src/desktop-recorder-delivery.test.ts src/desktop-developer-tools-controller.test.ts src/desktop-client-headers.test.ts src/desktop-environment-entry-points.test.ts src/bootstrap-imports.test.ts src/desktop-smoke-test.test.ts --maxWorkers=1 --silent=passed-only
corepack pnpm -F @okouai/desktop check-types
corepack pnpm -F @okouai/desktop lint
corepack pnpm exec knip --workspace apps/desktop
corepack pnpm exec prettier --check apps/desktop/src/main.ts apps/desktop/src/desktop-computer-use-api.ts apps/desktop/src/desktop-computer-use-runtime.test.ts apps/desktop/src/desktop-auth-session.test.ts
corepack pnpm -F @okouai/desktop build:native
corepack pnpm -F @okouai/desktop build:electron
corepack pnpm -F @okouai/desktop build:mcp-filesystem
corepack pnpm -F @okouai/desktop build:renderer
node apps/desktop/scripts/check-bootstrap-bundle.mjs
```

- PASS: 178 tests across 15 targeted files, including 13 new runtime integration cases; typecheck, lint, Knip, format, Electron/MCP/renderer builds, and bootstrap bundle guard.
- `build:native` exits successfully with its existing Linux/macOS-only skip. Actual macOS native tests and packaged smoke are required from the Desktop PR pipeline; local Linux builds are not a claim of macOS package execution.
- Regression sensitivity: temporarily routed the construction entry point back through the old cookie policy and ran `corepack pnpm -F @okouai/desktop exec vitest run src/desktop-computer-use-runtime.test.ts -t 'only native cookies|synchronous sign-out' --maxWorkers=1 --silent=passed-only`. Both selected tests failed with `online` instead of `unauthenticated`; restored the fix before the final passing checks. No mutation is committed.
- Repo-root `git diff --check` and staged diff check passed. No full local Vitest suite or local development server ran.
- PASS: required PR checks `ci-gate-turbo` ([run](https://github.com/vm0-ai/vm0/actions/runs/34067860835)), `ci-gate-crates` ([run](https://github.com/vm0-ai/vm0/actions/runs/34067860845)), and `ci-gate-security` ([run](https://github.com/vm0-ai/vm0/actions/runs/34067860854)).
- PASS: [Desktop macOS CI](https://github.com/vm0-ai/vm0/actions/runs/34067860857), exact head `6949ab28549851e2b2d9169aee0c51e3fbf2ece1`: `pnpm -F @okouai/desktop test` (555 tests in 49 files), `pnpm -F @okouai/desktop test:native` (118 tests in 21 suites), and all default-configuration, explicit Okou production, and PR-preview artifact verification/launch smoke steps. Each packaged launch uses `node apps/desktop/scripts/smoke-test-packaged-app.js`. All three artifacts are unsigned CI candidates; this is not released-Desktop login evidence.
- Protected queue admission succeeded with `gh pr merge 32064 --repo vm0-ai/vm0 --auto --match-head-commit 6949ab28549851e2b2d9169aee0c51e3fbf2ece1`; no direct/admin merge or bypass. PASS: merge-group `ci-gate-turbo` ([run](https://github.com/vm0-ai/vm0/actions/runs/34068236586)), `ci-gate-security` ([run](https://github.com/vm0-ai/vm0/actions/runs/34068236571)), and `ci-gate-crates` ([run](https://github.com/vm0-ai/vm0/actions/runs/34068236547)). GitHub confirms `MERGED` at `2026-09-07T00:01:38Z`, merge SHA `60adb1e283e4850a48aad38a75b104ccb98f580e`; final reviewed head `6949ab28549851e2b2d9169aee0c51e3fbf2ece1` ([tracked LGTM](https://github.com/vm0-ai/vm0/pull/32064#issuecomment-5563133886)). No CI retries, branch rebases, or queue recovery were needed.

## Remaining acceptance and authority

This implementation thread has **no production authority**. It will not bump/publish Desktop, promote manifests, invoke `/release-production`, merge a release PR, or approve production deployment.

Authenticated hosted-browser takeover remains unverified; Lancy explicitly accepted that residual risk on 2026-09-07 as a pre-release prerequisite waiver, not a passed test. Real login, refresh, organization selection, and legacy compatibility against the newly released Desktop remain controller/Lancy-owned post-release gates. The controller independently accepts the merged repair and verifies release-candidate inclusion of both #32062 and this PR. #32061 and the EPIC remain subject to that acceptance.
