### PR TITLE
feat(platform): enlarge pinned agent avatars behind a feature switch

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -1030,7 +1030,7 @@ test("Mount only the sidebar for the current viewport", async () => {
   expect(screen.getAllByTestId("sidebar-scroll-area")).toHaveLength(1);
 });
 
-test("Keep pin management usable with many pinned agents", async () => {
+test.each([false, true])("Keep pin overflow usable (%s)", async (large) => {
   const pinnedAgentIds = prepareOverflowingPinnedAgents();
   const preferencesGate = context.mocks.deferred<void>();
   context.mocks.api(userPreferencesContract.get, async ({ respond }) => {
@@ -1064,6 +1064,7 @@ test("Keep pin management usable with many pinned agents", async () => {
   await setupSidebarPage({
     context,
     path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.PinnedAgentAvatar64]: large },
   });
 
   const pinnedSection = await screen.findByTestId("pinned-agents-horizontal");
@@ -1099,17 +1100,22 @@ test("Keep pin management usable with many pinned agents", async () => {
   if (!pinAgent) {
     throw new Error("Pin agent button not found");
   }
-  // Cards render as Zero, Research, Support, Operations, Pin, Analytics,
-  // Billing, so Pin closes the first row and the rest wrap after it.
-  const fourthAgent = pinnedAgentLink(grid, "Operations Agent");
-  const fifthAgent = pinnedAgentLink(grid, "Analytics Agent");
+  // Pin closes the first row at either avatar size; remaining agents wrap.
+  const beforePin = pinnedAgentLink(
+    grid,
+    large ? "Research Agent" : "Operations Agent",
+  );
+  const afterPin = pinnedAgentLink(
+    grid,
+    large ? "Support Agent" : "Analytics Agent",
+  );
 
   expect(
-    fourthAgent.compareDocumentPosition(pinAgent) &
+    beforePin.compareDocumentPosition(pinAgent) &
       Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   expect(
-    pinAgent.compareDocumentPosition(fifthAgent) &
+    pinAgent.compareDocumentPosition(afterPin) &
       Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
 });
@@ -2310,7 +2316,11 @@ test("Search, pin, and open an agent from the pin manager", async () => {
     return [researchThread];
   });
 
-  await setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
+  await setupSidebarPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.PinnedAgentAvatar64]: true },
+  });
 
   const grid = await screen.findByTestId("pinned-agents-grid");
   click(screen.getByLabelText("Pin an agent"));

--- a/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-pinned.tsx
@@ -7,6 +7,7 @@ import {
   useLastLoadable,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { Plus, ChevronRight, Pin, PinOff, CheckCheck } from "lucide-react";
 import {
   Tooltip,
@@ -47,6 +48,7 @@ import { unreadAgentIds$ } from "../../signals/chat-page/chat-thread-indicators-
 import { markAgentThreadsRead$ } from "../../signals/chat-page/sidebar-unread-threads.ts";
 import { refreshSidebarChatThreadLayoutOnRef$ } from "../../signals/chat-page/sidebar-chat-thread-scroll.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { equalSets } from "../../lib/equality.ts";
 import { AgentAvatarImg } from "./sidebar-shared.tsx";
@@ -66,7 +68,11 @@ const pinnedAgentGridCardFrameClassName =
 // baseline onto different device pixels.
 const pinnedAgentGridLabelFrameClassName = "h-3.5 leading-[14px]";
 
-function PinnedAgentGridSkeletonCard() {
+function PinnedAgentGridSkeletonCard({
+  avatarClassName,
+}: {
+  readonly avatarClassName: string;
+}) {
   const refreshLayoutRef = useSet(refreshSidebarChatThreadLayoutOnRef$);
   return (
     <div
@@ -75,7 +81,7 @@ function PinnedAgentGridSkeletonCard() {
       data-testid="pinned-agent-skeleton"
       className={pinnedAgentGridCardFrameClassName}
     >
-      <span className="flex h-9 w-9 shrink-0">
+      <span className={`flex shrink-0 ${avatarClassName}`}>
         <Skeleton className="h-full w-full rounded-full" />
       </span>
       <Skeleton
@@ -244,20 +250,21 @@ function PinnedAgentDragHandle() {
 }
 
 /**
- * A grid tile is only a fifth of the sidebar wide, so almost every agent name
- * is truncated down to a few characters. The tile carries a hover tooltip with
+ * Grid tiles truncate agent names to fit the sidebar. Each carries a tooltip with
  * the full name — a native `title` is too slow and too easy to miss for a label
  * that is unreadable by default. The tooltip is disabled while a reorder drag
  * is in flight so it never floats over the drop carets.
  */
 function PinnedAgentGridCard({
   agent,
+  avatarClassName,
   isPrimarySelected,
   hasUnread,
   isReorderable,
   dropSide,
 }: {
   readonly agent: PinnedGridAgent;
+  readonly avatarClassName: string;
   readonly isPrimarySelected: boolean;
   readonly hasUnread: boolean;
   readonly isReorderable: boolean;
@@ -358,7 +365,7 @@ function PinnedAgentGridCard({
         />
       )}
       <span
-        className={`relative flex h-9 w-9 shrink-0 ${
+        className={`relative flex shrink-0 ${avatarClassName} ${
           isDragging ? "opacity-0" : ""
         }`}
       >
@@ -456,6 +463,8 @@ export function PinnedAgentListSection({
 }: {
   layout?: "vertical" | "horizontal";
 }) {
+  const largeAvatars =
+    useGet(featureSwitch$)[FeatureSwitchKey.PinnedAgentAvatar64];
   const refreshLayoutRef = useSet(refreshSidebarChatThreadLayoutOnRef$);
   const { t } = useTranslation("agents");
   const activeRoute = useGet(activeRoute$);
@@ -491,11 +500,18 @@ export function PinnedAgentListSection({
   const selectedAgentId = routeAgentId ?? sidebarAgentId;
 
   if (layout === "horizontal") {
+    const avatarClassName = largeAvatars ? "h-16 w-16" : "h-9 w-9";
+    const agentsBeforePin = largeAvatars ? 2 : 4;
     const horizontalPinnedAgents =
       pinnedAgentsLoadable.state === "loading" ? null : displayedPinnedAgents;
     const pinnedAgentCards =
       horizontalPinnedAgents === null
-        ? [<PinnedAgentGridSkeletonCard key="loading" />]
+        ? [
+            <PinnedAgentGridSkeletonCard
+              key="loading"
+              avatarClassName={avatarClassName}
+            />,
+          ]
         : horizontalPinnedAgents.map((agent) => {
             const isPrimarySelected =
               isChatRoute(activeRoute) && selectedAgentId === agent.agentId;
@@ -512,6 +528,7 @@ export function PinnedAgentListSection({
               >
                 <PinnedAgentGridCard
                   agent={agent}
+                  avatarClassName={avatarClassName}
                   isPrimarySelected={isPrimarySelected}
                   hasUnread={hasUnread}
                   isReorderable={isPinned && !isDefaultAgent}
@@ -534,10 +551,12 @@ export function PinnedAgentListSection({
           })}
         </span>
         <div
-          className="grid min-w-0 grid-cols-5 items-start gap-x-1 gap-y-2.5"
+          className={`grid min-w-0 items-start gap-x-1 gap-y-2.5 ${
+            largeAvatars ? "grid-cols-3" : "grid-cols-5"
+          }`}
           data-testid="pinned-agents-grid"
         >
-          {pinnedAgentCards.slice(0, 4)}
+          {pinnedAgentCards.slice(0, agentsBeforePin)}
           {horizontalPinnedAgents !== null && (
             <button
               type="button"
@@ -549,7 +568,9 @@ export function PinnedAgentListSection({
               })}
               className="flex w-full min-w-0 flex-col items-center gap-1.5 rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
             >
-              <span className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-[hsl(var(--gray-300))]">
+              <span
+                className={`flex shrink-0 items-center justify-center rounded-full border border-dashed border-[hsl(var(--gray-300))] ${avatarClassName}`}
+              >
                 <Plus size={18} />
               </span>
               <span
@@ -562,7 +583,7 @@ export function PinnedAgentListSection({
               </span>
             </button>
           )}
-          {pinnedAgentCards.slice(4)}
+          {pinnedAgentCards.slice(agentsBeforePin)}
         </div>
       </div>
     );

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -60,6 +60,7 @@ export enum FeatureSwitchKey {
   StableChatThreadNavigation = "stableChatThreadNavigation",
   ChatThreadPinShortcut = "chatThreadPinShortcut",
   SidebarSubscriptionUsage = "_sidebarSubscriptionUsage",
+  PinnedAgentAvatar64 = "pinnedAgentAvatar64",
   PersonalModelProviderAccounts = "_multipleSubscriptions",
   FeishuIntegration = "_feishuIntegration",
   CustomConnectorMcp = "customConnectorMcp",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -453,6 +453,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.PinnedAgentAvatar64]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show 64px avatars in the horizontal pinned-agent grid with three cards per row.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.PersonalModelProviderAccounts]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

The horizontal **Pinned agents** section currently renders 36×36 avatars. With `pinnedAgentAvatar64` enabled, it renders 64×64 avatars in a three-column grid so the larger artwork fits the 300px sidebar. Loading placeholders and the Pin target use the same dimensions, and Pin remains in the first row.

The switch is enabled for staff organizations and off by default for everyone else. Turning it off preserves the existing 36×36, five-column layout; the mobile vertical list keeps its current sizing.

## Verification

- Expanded the existing pin-overflow integration scenario to cover both switch states, including loading and the Pin target's position.
- Exercise searching, pinning, and opening an agent with the switch enabled.
- Passed lint and type checking for `@okouai/app`, `@okouai/core`, and their required dependency workspaces (12 tasks).
- Passed Knip for `apps/platform` and `packages/core`, formatting, and commitlint.
- Passed all 31 tests in `packages/core/src/__tests__/feature-switch.test.ts` and the 3 targeted sidebar integration cases above.
- Full Vitest and deployment checks run in the PR pipeline; no local dev server was started.

## Browser verification

Verified the deployed PR head `2b2051444aff8b0cbcdc22493f19355ee37fc4c1` at https://pr-32067-app-okou-app-preview.vm0.workers.dev with a fresh development account.

- Switch off: 36×36 avatars and five columns.
- Switch on: both agent avatars and the Pin target measure exactly 64×64, with three 89px columns and no horizontal overflow.
- Pinned two additional agents: Okou, David, and Pin stay in the first row; Research wraps onto the next row. Pinning and opening an agent work.
- At a 390×844 mobile viewport, the vertical sidebar retains its 20×20 agent avatars and agent navigation works.
- All PR checks passed.

![Pinned agents with 64px avatars](https://a.okou.io/l6ps49jytf.png)
