### PR TITLE
feat(core): enable the compact model menu for staff

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/feature-switches.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feature-switches.test.ts
@@ -17,7 +17,7 @@ function client() {
 }
 
 describe("/api/feature-switches", () => {
-  it("defaults the compact model menu to Bingjie without enabling other staff users", async () => {
+  it("defaults the compact model menu to Bingjie and the staff org while excluding other orgs", async () => {
     const clerk = createRouteMocks(context).clerk;
     const headers = { authorization: "Bearer clerk-session" };
     clerk.session(
@@ -30,14 +30,17 @@ describe("/api/feature-switches", () => {
       owner.body.effectiveSwitches[FeatureSwitchKey.ModelPickerMenu],
     ).toBeTruthy();
 
-    clerk.session(
-      `user_${randomUUID()}`,
-      "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
-      "org:member",
-    );
+    const staffUserId = `user_${randomUUID()}`;
+    clerk.session(staffUserId, "org_3ANttyrbWYJk6JKRSTRLEsbsDLe", "org:member");
     const staff = await accept(client().get({ headers }), [200]);
     expect(
       staff.body.effectiveSwitches[FeatureSwitchKey.ModelPickerMenu],
+    ).toBeTruthy();
+
+    clerk.session(staffUserId, `org_${randomUUID()}`, "org:member");
+    const nonStaffOrg = await accept(client().get({ headers }), [200]);
+    expect(
+      nonStaffOrg.body.effectiveSwitches[FeatureSwitchKey.ModelPickerMenu],
     ).toBeFalsy();
   });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -277,6 +277,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledUserHashes: ["032a75d8"], // Bingjie's account, including API contexts without email
     enabledEmailHashes: ["6490c77f", "9fd4ee92"], // bingjie@okou.ai, bingjie@vm0.ai
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ChatPreference]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
## Summary

Enable the existing compact model picker by default in the internal staff workspace using `STAFF_ORG_ID_HASHES`. Keep Bingjie's existing account targeting, the disabled global default, and user overrides.

Extend the feature-switch API regression test to verify Bingjie's access, a staff member's access, and the same member returning to the disabled default in a non-staff workspace. This only changes rollout targeting; the UI and image/video settings are unchanged.

## Verification

- Prettier, affected Core/API lint, Knip, and repository type checks passed.
- Updated API integration coverage; execution is delegated to PR CI because this sandbox has no local PostgreSQL service.
