### PR TITLE
feat(core): roll out avatar neck and sweater

### DIFF
--- a/e2e/playwright/tests/create-agent.spec.ts
+++ b/e2e/playwright/tests/create-agent.spec.ts
@@ -122,7 +122,9 @@ test("avatar composer keeps a stable dialog and compact option rows", async ({
   await composer.getByRole("button", { name: "Next step" }).click();
   await expect(composer.getByText("Color", { exact: true })).toBeVisible();
   await expectStableDialog();
-  // The Sweater step only exists behind `avatarNeckSweater`, which is off for
-  // the non-staff org this runs against. Covered in settings-tab.test.tsx.
+
+  await composer.getByRole("button", { name: "Next step" }).click();
+  await expect(composer.getByText("Sweater", { exact: true })).toBeVisible();
+  await expectStableDialog();
   await composer.getByRole("button", { name: "Cancel" }).click();
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx
@@ -238,7 +238,9 @@ test.each(["preset:0", "svg:r3s2h4c1f5h"])(
     const dialog = await screen.findByRole("dialog", { name: "Edit avatar" });
     expect(within(dialog).getByText("Face")).toBeVisible();
     expect(within(dialog).queryByText("Angle")).not.toBeInTheDocument();
-    expect(renderedAvatarSvgLayerSrcs(dialog).slice(0, 4)).toStrictEqual([
+    expect(renderedAvatarSvgLayerSrcs(dialog).slice(0, 6)).toStrictEqual([
+      expect.stringContaining("/avatar-svg-v2/"),
+      expect.stringContaining("/avatar-svg-v2/"),
       expect.stringContaining("/avatar-svg-v2/"),
       expect.stringContaining("/avatar-svg-v2/"),
       expect.stringContaining("/avatar-svg-v2/"),
@@ -270,8 +272,10 @@ test.each(["preset:0", "svg:r3s2h4c1f5h"])(
     const reopened = await screen.findByRole("dialog", { name: "Edit avatar" });
     click(within(reopened).getByLabelText("Randomize avatar"));
     await waitForAvatarFeedback(reopened);
-    const composerLayerSrcs = renderedAvatarSvgLayerSrcs(reopened).slice(0, 4);
+    const composerLayerSrcs = renderedAvatarSvgLayerSrcs(reopened).slice(0, 6);
     expect(composerLayerSrcs).toStrictEqual([
+      expect.stringContaining("/avatar-svg-v2/"),
+      expect.stringContaining("/avatar-svg-v2/"),
       expect.stringContaining("/avatar-svg-v2/"),
       expect.stringContaining("/avatar-svg-v2/"),
       expect.stringContaining("/avatar-svg-v2/"),
@@ -346,12 +350,15 @@ test("Offer avatar creation instead of editing when the agent has no avatar", as
   ).resolves.toBeVisible();
 });
 
-test("Load only the visible avatar SVG layers", async () => {
+test("Load only the four head layers when neck and sweater are disabled", async () => {
   prepareAgentProfile(null);
   await setupPage({
     context,
     path: `/agents/${AGENT_ID}?tab=profile`,
-    featureSwitches: { [FeatureSwitchKey.AvatarComposerV2]: true },
+    featureSwitches: {
+      [FeatureSwitchKey.AvatarComposerV2]: true,
+      [FeatureSwitchKey.AvatarNeckSweater]: false,
+    },
   });
 
   click(await findCreateCustomAvatarButton());
@@ -367,15 +374,12 @@ test("Load only the visible avatar SVG layers", async () => {
   expect(layerSrcs.filter(isNeckOrSweaterLayer)).toStrictEqual([]);
 });
 
-test("Add the neck and sweater layers once the switch is on", async () => {
+test("Load the released neck and sweater layers by default", async () => {
   prepareAgentProfile(null);
   await setupPage({
     context,
     path: `/agents/${AGENT_ID}?tab=profile`,
-    featureSwitches: {
-      [FeatureSwitchKey.AvatarComposerV2]: true,
-      [FeatureSwitchKey.AvatarNeckSweater]: true,
-    },
+    featureSwitches: { [FeatureSwitchKey.AvatarComposerV2]: true },
   });
 
   click(await findCreateCustomAvatarButton());

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -209,11 +209,13 @@ test("The agent header opens avatar customization on the current avatar", async 
   click(labelledButton("Customize avatar"));
 
   const dialog = await screen.findByRole("dialog", { name: "Edit avatar" });
-  expect(renderedAvatarSvgLayerSrcs(dialog).slice(0, 4)).toStrictEqual([
+  expect(renderedAvatarSvgLayerSrcs(dialog).slice(0, 6)).toStrictEqual([
+    expect.stringContaining("/neck/deep.svg"),
     expect.stringContaining("/hairs/oval/rounded-crop-green-rear.svg"),
     expect.stringContaining("/faces/oval-deep.svg"),
     expect.stringContaining("/hairs/oval/rounded-crop-green-front.svg"),
     expect.stringContaining("/expressions/neutral-smile-oval.svg"),
+    expect.stringContaining("/sweater/lime.svg"),
   ]);
 });
 

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -42,6 +42,7 @@ describe("isFeatureEnabled", () => {
       isFeatureEnabled(FeatureSwitchKey.GoogleFormsWorkflowAutomations, {}),
     ).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.FollowUpOptimize, {})).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.AvatarNeckSweater, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -362,6 +363,9 @@ describe("getFeatureSwitchMetadata", () => {
       metadata[FeatureSwitchKey.NotionWorkflowAutomations].rolloutStage,
     ).toBe("released");
     expect(metadata[FeatureSwitchKey.FollowUpOptimize].rolloutStage).toBe(
+      "released",
+    );
+    expect(metadata[FeatureSwitchKey.AvatarNeckSweater].rolloutStage).toBe(
       "released",
     );
     expect(metadata[FeatureSwitchKey.Banking].rolloutStage).toBe("beta");

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -330,10 +330,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ming@vm0.ai",
     description:
       "Give composer avatars a shared neck and sweater, scaling each head so every chin meets the same collar.",
-    enabled: false,
-    // Staff first: this redraws every avatar that already exists, not just
-    // newly created ones, so the whole population changes the moment it widens.
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ChatTranslation]: {
     maintainer: "yuma@vm0.ai",


### PR DESCRIPTION
## Summary

- release `avatarNeckSweater` to all users by enabling its global default and removing the staff-only rollout list
- assert the switch is globally enabled and classified as Released
- update profile, team, and create-agent coverage for the released six-layer avatar path while retaining explicit switch-off coverage

## Verification

- `pnpm exec prettier --write packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts ../e2e/playwright/tests/create-agent.spec.ts apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx apps/platform/src/views/okou-page/__tests__/settings-tab.test.tsx`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` (31 passed)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/settings-tab.test.tsx src/views/team-page/__tests__/team-navigation.test.tsx src/views/agents-page/__tests__/agents-management.test.tsx` (34 passed)
- `pnpm knip --workspace @okouai/core`
- `pnpm knip --workspace @okouai/app`
- `pnpm check-types` in `e2e`
- `git diff --check`

The Playwright flow requires a deployed app environment and is left to the PR pipeline.