### PR TITLE
feat(connectors): add oto auth provider

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -146,7 +146,7 @@ const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const PREVIOUS_CONNECTOR_CATALOG_MAX_RAW_BYTES = 32 * 1024 * 1024;
 const EXPECTED_CAPABILITY_DIGEST =
-  "sha256:d3b33ea71c1a98a0276a71e7bf32562210cff53270846e22f35befb31a8fccd6";
+  "sha256:2d9e7f474334493b5b7c85e7f3a953c67676e87e5d1eaf8487c965e682aa6067";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -94,6 +94,7 @@ import { nintendoSwitchParentalControlsProvider } from "./connectors/nintendo-sw
 import { nintendoStoreProvider } from "./connectors/nintendo-store/provider";
 import { notionProvider } from "./connectors/notion/provider";
 import { netsuiteProvider } from "./connectors/netsuite/provider";
+import { otoProvider } from "./connectors/oto/provider";
 import { outlookCalendarProvider } from "./connectors/outlook-calendar/provider";
 import { outlookMailProvider } from "./connectors/outlook-mail/provider";
 import { resourceGuruProvider } from "./connectors/resource-guru/provider";
@@ -1047,6 +1048,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES = [
     nintendoSwitchParentalControlsProvider,
   ),
   authCodeRefreshProviderEntry("notion", "oauth", notionProvider),
+  refreshProviderEntry("oto", "api-token", otoProvider),
   authCodeRefreshProviderEntry("resource-guru", "oauth", resourceGuruProvider),
   authCodeRefreshProviderEntry(
     "outlook-calendar",

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/oto.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/oto.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse, http } from "msw";
+
+import type { ConnectorAuthMethodRuntimeConfig } from "../../../connector-config";
+import { refreshConnectorAuthProviderAccessTokenWithMethod } from "../../connector-auth";
+import { CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS } from "../../provider-capabilities";
+import { ProviderResponseError } from "../../provider-error";
+import { server } from "../../__tests__/test-server";
+import { fetchOtoAccessToken } from "../oto/api-token";
+
+const OTO_REFRESH_TOKEN_URL = "https://api.tryoto.com/rest/v2/refreshToken";
+
+const OTO_PROVIDER_METHOD = {
+  storage: {
+    version: 1,
+    secrets: ["OTO_REFRESH_TOKEN", "OTO_ACCESS_TOKEN"],
+    variables: [],
+  },
+  grant: {
+    kind: "manual",
+    fields: {
+      refreshToken: {
+        publicId: "refreshToken",
+        label: "Refresh Token",
+        required: true,
+        storage: "secret",
+      },
+    },
+  },
+  access: {
+    kind: "refresh-token",
+    envBindings: {
+      OTO_TOKEN: "$secrets.OTO_ACCESS_TOKEN",
+    },
+    inputs: {
+      refreshToken: "$secrets.OTO_REFRESH_TOKEN",
+    },
+    outputs: {
+      accessToken: "$secrets.OTO_ACCESS_TOKEN",
+      refreshToken: "$secrets.OTO_REFRESH_TOKEN",
+    },
+    refreshableSecrets: ["OTO_ACCESS_TOKEN"],
+  },
+  revoke: { kind: "none" },
+} as const satisfies ConnectorAuthMethodRuntimeConfig;
+
+function testRefreshSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
+describe("connector/providers/oto", () => {
+  it("exchanges the official refresh token JSON contract", async () => {
+    let contentType: string | null = null;
+    let accept: string | null = null;
+    let body = "";
+    server.use(
+      http.post(OTO_REFRESH_TOKEN_URL, async ({ request }) => {
+        contentType = request.headers.get("content-type");
+        accept = request.headers.get("accept");
+        body = await request.text();
+        return HttpResponse.json({
+          access_token: "oto-access-token",
+          refresh_token: "oto-rotated-refresh-token",
+          success: true,
+          token_type: "Bearer",
+          expires_in: "3600",
+        });
+      }),
+    );
+
+    await expect(
+      fetchOtoAccessToken(
+        { refreshToken: "oto-refresh-token" },
+        testRefreshSignal(),
+      ),
+    ).resolves.toEqual({
+      accessToken: "oto-access-token",
+      refreshToken: "oto-rotated-refresh-token",
+      expiresIn: 3600,
+    });
+    expect(contentType).toContain("application/json");
+    expect(accept).toBe("application/json");
+    expect(JSON.parse(body)).toEqual({ refresh_token: "oto-refresh-token" });
+  });
+
+  it("is registered as an executable refresh-token provider", async () => {
+    let requestCount = 0;
+    server.use(
+      http.post(OTO_REFRESH_TOKEN_URL, () => {
+        requestCount += 1;
+        return HttpResponse.json({
+          access_token: "oto-access-token",
+          success: true,
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    const registration = CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS.find(
+      (entry) => {
+        return (
+          entry.connectorSlug === "oto" && entry.authMethodId === "api-token"
+        );
+      },
+    );
+    expect(registration?.contract.access).toEqual({
+      kind: "refresh-token",
+      inputNames: ["refreshToken"],
+      outputNames: ["accessToken", "refreshToken"],
+      platformSecrets: [],
+    });
+
+    await expect(
+      refreshConnectorAuthProviderAccessTokenWithMethod(
+        {
+          connectorSlug: "oto",
+          authMethodId: "api-token",
+          method: OTO_PROVIDER_METHOD,
+          inputs: { refreshToken: "oto-refresh-token" },
+        },
+        testRefreshSignal(),
+      ),
+    ).resolves.toEqual({
+      outputs: {
+        accessToken: "oto-access-token",
+        refreshToken: "oto-refresh-token",
+      },
+      expiresIn: 3600,
+    });
+    expect(requestCount).toBe(1);
+  });
+
+  it("rejects malformed successful responses without exposing credentials", async () => {
+    server.use(
+      http.post(OTO_REFRESH_TOKEN_URL, () => {
+        return HttpResponse.json({
+          success: true,
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }),
+    );
+
+    await expect(
+      fetchOtoAccessToken(
+        { refreshToken: "oto-refresh-token" },
+        testRefreshSignal(),
+      ),
+    ).rejects.toBeInstanceOf(ProviderResponseError);
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/oto/api-token.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/oto/api-token.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+import { ProviderHttpError, ProviderResponseError } from "../../provider-error";
+
+const OTO_REFRESH_TOKEN_URL = "https://api.tryoto.com/rest/v2/refreshToken";
+
+const otoRefreshTokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+  refresh_token: z.string().min(1).optional(),
+  token_type: z.string().min(1).optional(),
+  success: z.boolean().optional(),
+  expires_in: z
+    .union([
+      z.number().positive(),
+      z
+        .string()
+        .regex(/^[1-9][0-9]*$/u)
+        .transform(Number),
+    ])
+    .refine((value) => {
+      return value > 0;
+    }),
+});
+
+interface OtoAccessTokenResult {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly expiresIn: number;
+}
+
+export async function fetchOtoAccessToken(
+  args: { readonly refreshToken: string },
+  signal: AbortSignal,
+): Promise<OtoAccessTokenResult> {
+  const response = await fetch(OTO_REFRESH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ refresh_token: args.refreshToken }),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new ProviderHttpError(
+      `OTO access token request failed: ${response.status}`,
+      response.status,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new ProviderResponseError("Invalid OTO access token response");
+  }
+
+  const parsed = otoRefreshTokenResponseSchema.safeParse(payload);
+  if (!parsed.success || parsed.data.success === false) {
+    throw new ProviderResponseError("Invalid OTO access token response");
+  }
+  if (
+    parsed.data.token_type !== undefined &&
+    parsed.data.token_type.toLowerCase() !== "bearer"
+  ) {
+    throw new ProviderResponseError("Invalid OTO access token response");
+  }
+
+  return {
+    accessToken: parsed.data.access_token,
+    refreshToken: parsed.data.refresh_token ?? args.refreshToken,
+    expiresIn: parsed.data.expires_in,
+  };
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/oto/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/oto/provider.ts
@@ -1,0 +1,21 @@
+import type { RefreshTokenAccessProvider } from "../../types";
+import { fetchOtoAccessToken } from "./api-token";
+
+export const otoProvider = {
+  access: {
+    kind: "refresh-token",
+    refresh: async (args, signal: AbortSignal) => {
+      const token = await fetchOtoAccessToken(
+        { refreshToken: args.inputs.refreshToken },
+        signal,
+      );
+      return {
+        outputs: {
+          accessToken: token.accessToken,
+          refreshToken: token.refreshToken,
+        },
+        expiresIn: token.expiresIn,
+      };
+    },
+  } satisfies RefreshTokenAccessProvider<"oto", "api-token">,
+};

--- a/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
@@ -1311,6 +1311,31 @@ export const CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS = [
     },
   },
   {
+    connectorSlug: "oto",
+    authMethodId: "api-token",
+    contract: {
+      client: {
+        kind: "none",
+      },
+      grant: {
+        kind: "manual",
+        callbackOrigin: null,
+        outputNames: [],
+        startOptionNames: [],
+      },
+      access: {
+        kind: "refresh-token",
+        inputNames: ["refreshToken"],
+        outputNames: ["accessToken", "refreshToken"],
+        platformSecrets: [],
+      },
+      revoke: {
+        kind: "none",
+        inputNames: [],
+      },
+    },
+  },
+  {
     connectorSlug: "resource-guru",
     authMethodId: "oauth",
     contract: {


### PR DESCRIPTION
## Summary

- Add the executable OTO manual refresh-token provider used by the official OTO connector.
- Exchange the permanent refresh token at OTO's documented endpoint and preserve rotated refresh tokens.
- Register the provider contract and cover the JSON contract, registry execution, and fail-closed response validation.

## Verification

- `pnpm exec vitest run src/auth-providers/connectors/__tests__/oto.test.ts` (turbo/packages/connectors)
- `pnpm --filter @okouai/connectors check-types`
- `pnpm --filter @okouai/connectors lint`

Official contract: https://help.tryoto.com/en/support/solutions/articles/150000213805-authorization