### PR TITLE
feat(runner): distinguish blank sandboxes in doctor and monitoring

### DIFF
--- a/.github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh
+++ b/.github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh
@@ -71,7 +71,7 @@ assert_zero_snapshot() {
   local mode
   local result
 
-  for state in active idle preparing unknown; do
+  for state in active idle blank preparing unknown; do
     assert_line "vm0_runner_sandboxes{state=\"$state\"} 0"
   done
   for mode in starting running draining stopping unknown; do
@@ -187,12 +187,116 @@ test_canonical_idle_field_behavior() {
 
   assert_line 'vm0_runner_sandboxes{state="active"} 0'
   assert_line 'vm0_runner_sandboxes{state="idle"} 1'
+  assert_line 'vm0_runner_sandboxes{state="blank"} 0'
   assert_line 'vm0_runner_sandboxes{state="preparing"} 0'
   assert_line 'vm0_runner_sandboxes{state="unknown"} 0'
   assert_line 'vm0_runner_instances{mode="running"} 3'
   assert_line 'vm0_runner_status_files{result="included"} 3'
   assert_line 'vm0_runner_status_files{result="invalid"} 0'
   assert_line 'vm0_runner_status_collection_success 1'
+}
+
+test_blank_inventory_formats() {
+  local format
+  local idle
+  local blank
+  for format in legacy explicit overlap; do
+    reset_dirs
+    mkdir -p "$runners_dir/current"
+    idle="{\"sandbox_id\":\"$uuid_a\",\"reuse_key\":\"thread:exact\"}"
+    blank="\"blank_sandboxes\":[{\"sandbox_id\":\"$uuid_b\"}],"
+    if [ "$format" != explicit ]; then
+      idle+=",{\"sandbox_id\":\"$uuid_b\",\"reuse_key\":\"__vm0_blank__:$uuid_b\"}"
+    fi
+    if [ "$format" = legacy ]; then
+      blank=""
+    fi
+    printf '%s\n' "{\"mode\":\"running\",$blank\"idle_sandboxes\":[$idle]}" \
+      >"$runners_dir/current/status.json"
+
+    run_collector
+
+    assert_line 'vm0_runner_sandboxes{state="idle"} 1'
+    assert_line 'vm0_runner_sandboxes{state="blank"} 1'
+    assert_line 'vm0_runner_sandboxes{state="active"} 0'
+    assert_line 'vm0_runner_sandboxes{state="preparing"} 0'
+    assert_line 'vm0_runner_sandboxes{state="unknown"} 0'
+    assert_line 'vm0_runner_status_files{result="included"} 1'
+    assert_line 'vm0_runner_status_collection_success 1'
+    assert_stderr_empty
+    if grep -qE "sandbox_id|run_id|reuse_key|__vm0_blank__|$uuid_a|$uuid_b" "$output_file"; then
+      fail "blank inventory leaked identity-level data into metrics"
+    fi
+  done
+}
+
+test_mixed_blank_inventory_deduplicates_by_uuid_and_lifecycle() {
+  reset_dirs
+  mkdir -p "$runners_dir/legacy" "$runners_dir/explicit" "$runners_dir/stopped"
+  cat >"$runners_dir/legacy/status.json" <<EOF
+{
+  "mode": "draining",
+  "active_runs": [
+    {"sandbox_id":"$uuid_b","phase":"running"},
+    {"sandbox_id":"$uuid_d","phase":"preparing"},
+    {"sandbox_id":"$uuid_e","phase":"future-phase"}
+  ],
+  "idle_sandboxes": [
+    {"sandbox_id":"$uuid_a","reuse_key":"__vm0_blank__:$uuid_a"},
+    {"sandbox_id":"$uuid_c","reuse_key":"thread:exact"},
+    {"sandbox_id":"$uuid_g","reuse_key":"__vm0_blank__:$uuid_h"},
+    {"sandbox_id":"$uuid_h"}
+  ]
+}
+EOF
+  cat >"$runners_dir/explicit/status.json" <<EOF
+{
+  "mode": "running",
+  "idle_sandboxes": [{"sandbox_id":"$uuid_f","reuse_key":"overlap"}],
+  "blank_sandboxes": [
+    {"sandbox_id":"$uuid_a"}, {"sandbox_id":"$uuid_b"},
+    {"sandbox_id":"$uuid_c"}, {"sandbox_id":"$uuid_d"},
+    {"sandbox_id":"$uuid_e"}, {"sandbox_id":"$uuid_f"},
+    {"sandbox_id":"00000000000040008000000000000006"}
+  ]
+}
+EOF
+  printf '%s\n' '{"mode":"stopped","blank_sandboxes":null}' \
+    >"$runners_dir/stopped/status.json"
+
+  run_collector
+
+  assert_line 'vm0_runner_sandboxes{state="idle"} 3'
+  assert_line 'vm0_runner_sandboxes{state="blank"} 2'
+  assert_line 'vm0_runner_sandboxes{state="active"} 1'
+  assert_line 'vm0_runner_sandboxes{state="preparing"} 1'
+  assert_line 'vm0_runner_sandboxes{state="unknown"} 1'
+  assert_line 'vm0_runner_status_files{result="included"} 2'
+  assert_line 'vm0_runner_status_files{result="stopped"} 1'
+  assert_line 'vm0_runner_status_collection_success 1'
+  assert_stderr_empty
+}
+
+test_malformed_blank_inventory_invalidates_only_its_status_file() {
+  reset_dirs
+  mkdir -p "$runners_dir/valid" "$runners_dir/invalid"
+  printf '%s\n' "{\"mode\":\"running\",\"idle_sandboxes\":[{\"sandbox_id\":\"$uuid_a\"}]}" \
+    >"$runners_dir/valid/status.json"
+  local blank
+  for blank in null '{}' '"invalid"' '[null]' '[{}]' \
+    '[{"sandbox_id":1}]' '[{"sandbox_id":""}]' '[{"sandbox_id":"not-a-uuid"}]'; do
+    printf '%s\n' "{\"mode\":\"running\",\"blank_sandboxes\":$blank}" \
+      >"$runners_dir/invalid/status.json"
+
+    run_collector
+
+    assert_line 'vm0_runner_sandboxes{state="idle"} 1'
+    assert_line 'vm0_runner_sandboxes{state="blank"} 0'
+    assert_line 'vm0_runner_status_files{result="included"} 1'
+    assert_line 'vm0_runner_status_files{result="invalid"} 1'
+    assert_line 'vm0_runner_status_collection_success 0'
+    grep -q 'invalid/status.json' "$stderr_file" || fail "malformed blank was not reported"
+  done
 }
 
 test_invalid_files_publish_partial_metrics() {
@@ -359,6 +463,9 @@ test_playbook_provisions_collector_identity_and_cadence() {
 test_missing_and_empty_runner_roots_emit_zero_metrics
 test_aggregates_current_and_future_statuses
 test_canonical_idle_field_behavior
+test_blank_inventory_formats
+test_mixed_blank_inventory_deduplicates_by_uuid_and_lifecycle
+test_malformed_blank_inventory_invalidates_only_its_status_file
 test_invalid_files_publish_partial_metrics
 test_rejects_runner_and_status_symlinks
 test_output_is_deterministic_and_replaced_atomically

--- a/ansible/files/vm0-monitoring-runner-status-collect.py
+++ b/ansible/files/vm0-monitoring-runner-status-collect.py
@@ -10,10 +10,10 @@ import uuid
 from collections import Counter
 from pathlib import Path
 
-SANDBOX_STATES = ("active", "idle", "preparing", "unknown")
+SANDBOX_STATES = ("active", "idle", "blank", "preparing", "unknown")
 RUNNER_MODES = ("starting", "running", "draining", "stopping", "unknown")
 STATUS_RESULTS = ("included", "stopped", "invalid")
-STATE_PRECEDENCE = {"unknown": 0, "preparing": 1, "active": 2, "idle": 3}
+STATE_PRECEDENCE = {"blank": -1, "unknown": 0, "preparing": 1, "active": 2, "idle": 3}
 CANONICAL_RUNNERS_DIR_ENV = "OKOU_RUNNERS_DIR"
 DEFAULT_RUNNERS_DIR = "/var/lib/vm0-runner/runners"
 CANONICAL_TEXTFILE_DIR_ENV = "OKOU_MONITORING_TEXTFILE_DIR"
@@ -73,9 +73,24 @@ def parse_status(path: Path) -> tuple[str, list[tuple[str, str]]]:
             )
         sandbox_states.append((sandbox_id, state))
 
-    for entry in parse_collection(status, "idle_sandboxes"):
-        _, sandbox_id = parse_sandbox_entry(entry)
-        sandbox_states.append((sandbox_id, "idle"))
+    blank_ids = {
+        parse_sandbox_entry(entry)[1]
+        for entry in parse_collection(status, "blank_sandboxes")
+    }
+    idle_entries = [
+        parse_sandbox_entry(entry)
+        for entry in parse_collection(status, "idle_sandboxes")
+    ]
+    # Temporary input compatibility; remove in #32084 once supported writers
+    # and retained live status files no longer use synthetic blank reuse keys.
+    for idle, sandbox_id in idle_entries:
+        if idle.get("reuse_key") == f"__vm0_blank__:{idle['sandbox_id']}":
+            blank_ids.add(sandbox_id)
+
+    for _, sandbox_id in idle_entries:
+        if sandbox_id not in blank_ids:
+            sandbox_states.append((sandbox_id, "idle"))
+    sandbox_states.extend((sandbox_id, "blank") for sandbox_id in blank_ids)
 
     return mode, sandbox_states
 

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -276,7 +276,7 @@ impl Warning {
             } => {
                 // Resolved if fresh discovery no longer contains the same
                 // Firecracker observation or sandbox_id is now known (either
-                // tracked as active or parked as idle).
+                // tracked as active or parked as exact/blank inventory).
                 if !fresh_contains_firecracker(
                     fresh,
                     *pid,
@@ -293,7 +293,11 @@ impl Warning {
                             .idle_sandboxes
                             .iter()
                             .any(|v| v.sandbox_id == *sandbox_id);
-                        !(active || idle)
+                        let blank = st
+                            .blank_sandboxes
+                            .iter()
+                            .any(|v| v.sandbox_id == *sandbox_id);
+                        !(active || idle || blank)
                     }
                     None => true,
                 }
@@ -431,6 +435,7 @@ struct StatusInfo {
     started_at: String,
     active_runs: Vec<ActiveRun>,
     idle_sandboxes: Vec<IdleSandbox>,
+    blank_sandboxes: Vec<BlankSandbox>,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
 }
@@ -995,6 +1000,10 @@ struct IdleSandbox {
     sandbox_id: String,
 }
 
+struct BlankSandbox {
+    sandbox_id: String,
+}
+
 /// Returns `true` for modes where proxy absence is expected (not a warning).
 fn is_inactive_mode(mode: &str) -> bool {
     matches!(mode, "stopped" | "draining")
@@ -1005,14 +1014,40 @@ async fn read_status(base_dir: &Path) -> Option<StatusInfo> {
         .await
         .ok()
         .flatten()?;
+    let mut blank_ids: HashSet<&str> = file
+        .blank_sandboxes
+        .iter()
+        .map(|sandbox| sandbox.sandbox_id.as_str())
+        .collect();
+    // Temporary input compatibility for pre-split writers. Remove in #32084
+    // after supported writers and retained live status files have migrated.
+    for sandbox in file.idle_sandboxes() {
+        if sandbox.reuse_key.strip_prefix("__vm0_blank__:") == Some(sandbox.sandbox_id.as_str()) {
+            blank_ids.insert(&sandbox.sandbox_id);
+        }
+    }
     let idle_sandboxes = file
         .idle_sandboxes()
         .iter()
+        .filter(|sandbox| !blank_ids.contains(sandbox.sandbox_id.as_str()))
         .map(|sandbox| IdleSandbox {
             reuse_key: sandbox.reuse_key.clone(),
             sandbox_id: sandbox.sandbox_id.clone(),
         })
         .collect();
+    let active_ids: HashSet<&str> = file
+        .active_runs
+        .iter()
+        .map(|run| run.sandbox_id.as_str())
+        .collect();
+    let mut blank_sandboxes: Vec<BlankSandbox> = blank_ids
+        .into_iter()
+        .filter(|sandbox_id| !active_ids.contains(sandbox_id))
+        .map(|sandbox_id| BlankSandbox {
+            sandbox_id: sandbox_id.to_owned(),
+        })
+        .collect();
+    blank_sandboxes.sort_by(|a, b| a.sandbox_id.cmp(&b.sandbox_id));
     let active_runs = file
         .active_runs
         .into_iter()
@@ -1028,6 +1063,7 @@ async fn read_status(base_dir: &Path) -> Option<StatusInfo> {
         started_at: file.started_at,
         active_runs,
         idle_sandboxes,
+        blank_sandboxes,
         proxy_port: file.proxy_port,
         dns_port: file.dns_port,
     })
@@ -1150,7 +1186,7 @@ fn correlate_jobs(
         });
     }
 
-    // Known sandboxes = active + idle. FCs with sandbox_ids outside this set
+    // Known sandboxes = active + exact idle + blank. FCs outside this set
     // are flagged as orphans not reflected in status.json.
     for fc in &my_fcs {
         let known = status
@@ -1159,6 +1195,10 @@ fn correlate_jobs(
             .any(|r| r.sandbox_id == fc.sandbox_id)
             || status
                 .idle_sandboxes
+                .iter()
+                .any(|v| v.sandbox_id == fc.sandbox_id)
+            || status
+                .blank_sandboxes
                 .iter()
                 .any(|v| v.sandbox_id == fc.sandbox_id);
         if !known {
@@ -1446,14 +1486,8 @@ fn print_report(
             println!("    Jobs:    0 active");
         }
 
-        // Idle sandboxes (keep-alive)
-        if let Some(st) = &r.status
-            && !st.idle_sandboxes.is_empty()
-        {
-            println!("    Idle:    {} sandboxes", st.idle_sandboxes.len());
-            for sandbox in &st.idle_sandboxes {
-                println!("{}", format_idle_sandbox_diagnostic_line(sandbox));
-            }
+        if let Some(st) = &r.status {
+            print!("{}", format_parked_sandbox_diagnostics(st));
         }
 
         // Per-runner warnings
@@ -1494,6 +1528,31 @@ fn format_idle_sandbox_diagnostic_line(sandbox: &IdleSandbox) -> String {
         "      - reuse key {} -> sandbox {}",
         sandbox.reuse_key, sandbox.sandbox_id
     )
+}
+
+fn format_parked_sandbox_diagnostics(status: &StatusInfo) -> String {
+    let mut output = String::new();
+    if !status.idle_sandboxes.is_empty() {
+        let _ = writeln!(
+            output,
+            "    Idle:    {} exact sandboxes",
+            status.idle_sandboxes.len()
+        );
+        for sandbox in &status.idle_sandboxes {
+            let _ = writeln!(output, "{}", format_idle_sandbox_diagnostic_line(sandbox));
+        }
+    }
+    if !status.blank_sandboxes.is_empty() {
+        let _ = writeln!(
+            output,
+            "    Blank:   {} sandboxes",
+            status.blank_sandboxes.len()
+        );
+        for sandbox in &status.blank_sandboxes {
+            let _ = writeln!(output, "      - sandbox {}", sandbox.sandbox_id);
+        }
+    }
+    output
 }
 
 /// Format an ISO 8601 timestamp as a human-readable relative duration.
@@ -1636,6 +1695,7 @@ printf '%s\n' \
 
         assert!(status.active_runs.is_empty());
         assert!(status.idle_sandboxes.is_empty());
+        assert!(status.blank_sandboxes.is_empty());
     }
 
     #[tokio::test]
@@ -1714,6 +1774,68 @@ printf '%s\n' \
         assert!(read_status(dir.path()).await.is_none());
     }
 
+    #[tokio::test]
+    async fn read_status_rejects_malformed_blank_sandboxes() {
+        let dir = tempfile::tempdir().unwrap();
+        for blank_sandboxes in [
+            serde_json::json!(null),
+            serde_json::json!({}),
+            serde_json::json!([null]),
+            serde_json::json!([{}]),
+            serde_json::json!([{"sandbox_id": 1}]),
+        ] {
+            let content = serde_json::json!({
+                "mode": "running",
+                "started_at": "2026-01-01T00:00:00.000Z",
+                "blank_sandboxes": blank_sandboxes,
+            });
+            std::fs::write(dir.path().join("status.json"), content.to_string()).unwrap();
+            assert!(read_status(dir.path()).await.is_none(), "{content}");
+        }
+    }
+
+    #[tokio::test]
+    async fn read_status_does_not_infer_blank_from_unrelated_prefix_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = serde_json::json!({
+            "mode": "running",
+            "started_at": "2026-01-01T00:00:00.000Z",
+            "idle_sandboxes": [
+                {"sandbox_id": "S1", "reuse_key": "__vm0_blank__:different-id"},
+                {"sandbox_id": "S2", "reuse_key": "thread:__vm0_blank__:S2"},
+            ],
+            "blank_sandboxes": [],
+        });
+        std::fs::write(dir.path().join("status.json"), content.to_string()).unwrap();
+        let status = read_status(dir.path()).await.unwrap();
+        assert_eq!(status.idle_sandboxes.len(), 2);
+        assert!(status.blank_sandboxes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_status_claimed_blank_is_only_an_active_job() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = serde_json::json!({
+            "mode": "running",
+            "started_at": "2026-01-01T00:00:00.000Z",
+            "active_runs": [{
+                "run_id": "R1", "sandbox_id": "S1", "phase": "running",
+                "phase_started_at": "2026-01-01T00:00:00.000Z",
+            }],
+            "idle_sandboxes": [{"sandbox_id": "S1", "reuse_key": "__vm0_blank__:S1"}],
+            "blank_sandboxes": [{"sandbox_id": "S1"}],
+        });
+        std::fs::write(dir.path().join("status.json"), content.to_string()).unwrap();
+        let status = read_status(dir.path()).await.unwrap();
+        let (jobs, warnings) =
+            correlate_jobs(&status, dir.path(), &[fc_info(101, "S1", dir.path())]);
+        assert!(status.idle_sandboxes.is_empty());
+        assert!(status.blank_sandboxes.is_empty());
+        assert!(warnings.is_empty());
+        assert_eq!(jobs.len(), 1);
+        assert!(matches!(&jobs[0].status, JobStatus::Running { run_id, .. } if run_id == "R1"));
+    }
+
     #[test]
     fn active_run_unknown_phase_defaults_running() {
         let active = ActiveRun {
@@ -1784,6 +1906,7 @@ printf '%s\n' \
                     sandbox_id: sbid.into(),
                 })
                 .collect(),
+            blank_sandboxes: vec![],
             proxy_port: None,
             dns_port: None,
         }
@@ -3125,6 +3248,72 @@ printf '%s\n' \
         assert!(report.base_dir.is_some(), "test config should load");
         assert!(report.status.is_some(), "test status should load");
         report
+    }
+
+    #[tokio::test]
+    async fn report_distinguishes_owned_blank_inventory_across_status_versions() {
+        for parked in [
+            serde_json::json!({
+                "idle_sandboxes": [
+                    {"reuse_key": "thread:exact", "sandbox_id": "exact-id"},
+                    {"reuse_key": "__vm0_blank__:blank-id", "sandbox_id": "blank-id"},
+                ],
+            }),
+            serde_json::json!({
+                "idle_sandboxes": [{"reuse_key": "thread:exact", "sandbox_id": "exact-id"}],
+                "blank_sandboxes": [{"sandbox_id": "blank-id"}],
+            }),
+            serde_json::json!({
+                "idle_sandboxes": [
+                    {"reuse_key": "thread:exact", "sandbox_id": "exact-id"},
+                    {"reuse_key": "__vm0_blank__:blank-id", "sandbox_id": "blank-id"},
+                    {"reuse_key": "overlapping-mirror", "sandbox_id": "blank-id"},
+                ],
+                "blank_sandboxes": [{"sandbox_id": "blank-id"}, {"sandbox_id": "blank-id"}],
+            }),
+        ] {
+            let fixture = doctor_report_fixture("draining", None, None);
+            let mut content = parked;
+            content["mode"] = serde_json::json!("draining");
+            content["started_at"] = serde_json::json!("2026-01-01T00:00:00.000Z");
+            std::fs::write(fixture.base_dir.join("status.json"), content.to_string()).unwrap();
+            let runner = live_runner_instance(
+                std::process::id(),
+                fixture.config_path.clone(),
+                fixture.base_dir.clone(),
+            );
+            let firecrackers = vec![
+                fc_info(101, "blank-id", &fixture.base_dir),
+                fc_info(102, "exact-id", &fixture.base_dir),
+            ];
+            let report = build_runner_report(&runner, None, &firecrackers, &[], &[], &[]).await;
+            assert!(
+                report.jobs.is_empty(),
+                "unclaimed inventory must not become jobs"
+            );
+            assert!(report.warnings.is_empty());
+            let status = report.status.as_ref().unwrap();
+            assert_eq!(status.idle_sandboxes.len(), 1);
+            assert_eq!(status.blank_sandboxes.len(), 1);
+            assert_eq!(
+                format_parked_sandbox_diagnostics(status),
+                concat!(
+                    "    Idle:    1 exact sandboxes\n",
+                    "      - reuse key thread:exact -> sandbox exact-id\n",
+                    "    Blank:   1 sandboxes\n",
+                    "      - sandbox blank-id\n",
+                )
+            );
+
+            let fresh = fresh_with_firecracker(101, "blank-id", &fixture.base_dir);
+            let warning = Warning::FirecrackerNotInStatus {
+                pid: 101,
+                sandbox_id: "blank-id".into(),
+                base_dir: fixture.base_dir.clone(),
+                generation: fresh.firecrackers[0].generation,
+            };
+            assert!(!warning.persists(None, &fresh, &[], None).await);
+        }
     }
 
     fn mitm_proc(pid: u32, port: u16) -> process::MitmproxyProcessInfo {

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -79,8 +79,8 @@ enum Warning {
         sandbox_id: String,
         base_dir: PathBuf,
     },
-    /// A firecracker process exists but its sandbox_id is not tracked in
-    /// either `active_runs` or `idle_sandboxes` for this runner.
+    /// A firecracker process exists but its sandbox_id is not tracked as
+    /// active, exact idle, or blank inventory for this runner.
     FirecrackerNotInStatus {
         pid: u32,
         sandbox_id: String,

--- a/crates/runner/src/status_file.rs
+++ b/crates/runner/src/status_file.rs
@@ -90,6 +90,8 @@ pub(crate) struct StatusForDoctor {
     #[serde(default)]
     idle_sandboxes: Vec<StatusIdleSandbox>,
     #[serde(default)]
+    pub(crate) blank_sandboxes: Vec<StatusBlankSandbox>,
+    #[serde(default)]
     pub(crate) proxy_port: Option<u16>,
     #[serde(default)]
     pub(crate) dns_port: Option<u16>,
@@ -126,6 +128,11 @@ pub(crate) struct StatusActiveRun {
 #[derive(Debug, Deserialize)]
 pub(crate) struct StatusIdleSandbox {
     pub(crate) reuse_key: String,
+    pub(crate) sandbox_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StatusBlankSandbox {
     pub(crate) sandbox_id: String,
 }
 

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -238,9 +238,52 @@ every versioned runner directory. Status schema changes must cover those
 old/new combinations rather than treating the file as process-private state.
 
 Current status writers publish `idle_sandboxes` and omit the field when the
-collection is empty. Current maintenance readers and the host monitoring
-collector read only `idle_sandboxes`; a status file without the canonical
-collection is treated as containing no idle sandboxes.
+collection is empty. Blank-enabled writers currently encode ready blanks there
+using `reuse_key: "__vm0_blank__:<sandbox_id>"`. A ready blank has no run ID or
+tenant reuse identity. The migration tracked by [#32071](https://github.com/vm0-ai/vm0/issues/32071)
+separates exact and blank identity without changing shared pool lifecycle rules.
+
+The reader bridge ([#32082](https://github.com/vm0-ai/vm0/issues/32082)) lets doctor
+and the host collector also read `blank_sandboxes: [{"sandbox_id": "..."}]`.
+Missing collections default to empty; malformed present collections are invalid.
+Legacy recognition is confined to input normalization and requires the entire
+reuse key to match the reserved prefix plus that entry's sandbox ID. Other
+prefix-like reuse keys remain exact. Explicit blank IDs suppress same-file idle
+mirrors, and duplicate blank IDs count once. Doctor lists exact reuse keys under
+Idle and sandbox-ID-only entries under Blank, recognizes both as owned processes,
+and never treats an unclaimed blank as an active job. Active mappings take
+priority over duplicate blanks. The writer is unchanged in the bridge release.
+
+The collector exports `vm0_runner_sandboxes{state="blank"}` (including zero).
+`state="idle"` now counts exact inventory only; total parked inventory is the
+sum of `idle` and `blank`. Active, preparing and unknown counts keep their meaning.
+Use `sum by (instance) (vm0_runner_sandboxes{state=~"idle|blank"})` for a per-host
+parked total; replace/group additional host identity labels as needed. Summing
+all states gives total recorded sandbox inventory. UUID deduplication across
+non-stopped version files uses `idle > active > preparing > unknown > blank`:
+an active/claimed record supersedes a duplicate old blank, preserving the existing
+priority between non-blank states. Stopped files are excluded. Sandbox IDs, run
+IDs and reuse keys are never metric labels. Existing Grafana panels selecting
+only `idle` will now show exact inventory; this change does not edit dashboards.
+
+The collector is installed by host provisioning, independently of Runner
+releases. Both its systemd timer and Alloy textfile scrape run every 15 seconds.
+Before enabling the explicit-only writer in
+[#32083](https://github.com/vm0-ai/vm0/issues/32083), verify bridge-capable doctor
+and collector deployment on every supported host and establish a compatible
+rollback floor using the actual reader commit/release ancestry. The target
+Runner's doctor runs during rollback, so an old-reader/new-writer combination
+must be excluded by these gates. Old writers remain readable by bridge readers
+during draining; neither merging this bridge nor releasing Runner proves the
+independent collector is installed. No writer rollout or rollback floor is
+changed by the bridge PR.
+
+Remove legacy prefix recognition only under
+[#32084](https://github.com/vm0-ai/vm0/issues/32084), after all supported live and
+rollback writers publish explicit blanks, old versions have drained, and relevant
+retained non-stopped status files no longer contain synthetic entries. Record
+deployment/file evidence and enforce rollback eligibility before removing it.
+Keep absent-collection support for genuinely exact-only historical status files.
 
 The proxy registry and embedded mitm-addon are also a runner-private contract.
 The runner binary embeds the addon sources, recreates the addon directory and


### PR DESCRIPTION
## Summary

- Distinguish exact idle and tenant-free blank inventory in doctor, including initial ownership correlation and delayed warning rechecks. Blank lines show sandbox ID only and never create active jobs.
- Accept current legacy blank entries and future ID-only `blank_sandboxes`. Normalize same-file overlap and deduplicate blanks; active mappings supersede duplicate blanks.
- Export `vm0_runner_sandboxes{state="blank"}`, including zero, from the independently provisioned host collector. Preserve UUID deduplication, stopped exclusion, malformed-input reporting, bounded labels and atomic publication.
- **Metric semantics:** idle now means exact inventory; parked total is idle + blank. Existing idle-only Grafana queries will show exact inventory. No dashboard edits.

Closes #32082.

Delivery parent: #32071 (under #24203). This is the reader-first slice, not the completed identity migration. #32083 changes the typed pool/writer after reader rollout and rollback gates; #32084 removes temporary legacy parsing after writer retirement gates. This PR does not satisfy those deployment gates.

## Fallbacks

- `crates/runner/src/cmd/doctor.rs:read_status` recognizes only the complete legacy `__vm0_blank__:<sandbox_id>` identity from old writers and normalizes it into sandbox-ID-only doctor inventory. Surface: new doctor -> old host-local status. Remove in #32084 after all supported live/rollback writers use explicit blanks, old instances drain and relevant retained non-stopped files migrate.
- `ansible/files/vm0-monitoring-runner-status-collect.py:parse_status` performs equivalent legacy-input normalization for the independently deployed collector. Same writer/retained-file removal gate and #32084; this is not a new synthetic writer projection.
- `status_file.rs:StatusForDoctor.blank_sandboxes` and collector `parse_collection` treat an omitted blank collection as empty for previous writers and legitimately empty inventory. Malformed present collections still invalidate the status. Keep absent-collection semantics for historical/empty statuses; only the legacy identity normalization above is temporary.

## Compatibility and exclusions

The pool and status writer are unchanged, so existing readers can still read bridge-version output. The explicit-only writer is gated in #32083 on bridge-capable doctor/collector deployment and an enforced compatible rollback floor. Merging/releasing this PR alone is not evidence of installed collector state.

No changes to startup, pool sizing, aging, resource leases, scheduling, API/heartbeat, database or guest behavior. No production deployment or live dashboard verification.

## Validation

Validated the rebased head `89b8fbd2dd267882362ec15f994cbf2bf977bbc5`:

- From `crates`: `cargo fmt --all -- --check`.
- `cargo clippy --profile local -p runner --all-targets --all-features -- -D warnings`.
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local -p runner --all-features --no-deps`.
- `cargo test --profile local -p runner --all-features -- --test-threads=4 --quiet`: **3507 binary tests and 1 guest-inventory integration test passed**; 25 pre-existing ignored entries unchanged, no new ignores.
- `bash -n .github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh` and the collector shell regression suite passed, including legacy/explicit/mixed overlap, UUID normalization, lifecycle precedence, malformed blanks and zero series.
- Existing project Ruff binary: `format --check` and `check` on the collector passed.
- Prettier check of `docs/deployment-compatibility.md` and `git diff --check` passed.

## Rebase and prior CI context

Rebased onto main `5efc454857`. Main removed the migration-only residual brand-name classifier in #32179, so the obsolete classifier-only follow-up commit was dropped instead of restoring the deleted tool. The current PR contains only the five reader, collector, regression-test and deployment-documentation files; it has no TypeScript tooling changes.

The earlier unrelated sidebar-pin-order CI failure was recorded in #32098: the test remained at the application skeleton during setup, before long press. Its standalone rerun previously passed all 16 tests; that did not establish the root cause or repeatability. No platform/workflow change, test skip or timeout increase was added to this PR for that failure. CI status is evaluated separately for the current head.
