### PR TITLE
feat: add noyo client credentials provider

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-connector-catalog.test.ts
@@ -146,7 +146,7 @@ const DEFAULT_API_VERSION = apiPackage.version;
 const ZERO_DIGEST = `sha256:${"0".repeat(64)}`;
 const PREVIOUS_CONNECTOR_CATALOG_MAX_RAW_BYTES = 32 * 1024 * 1024;
 const EXPECTED_CAPABILITY_DIGEST =
-  "sha256:bc53f9b2cd4e4f8f4021879612f524a44a676455f1266e70d5ab7f3da4e65aa2";
+  "sha256:dc794c1167865d737412da7275be82d46074c9557c6efc60ce1c5cac959150f0";
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const SLACK_OAUTH_TOKEN_URL = "https://slack.com/api/oauth.v2.access";

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -96,6 +96,7 @@ import { notionProvider } from "./connectors/notion/provider";
 import { netsuiteProvider } from "./connectors/netsuite/provider";
 import { optimizelyCmpProvider } from "./connectors/optimizely-cmp/provider";
 import { otoProvider } from "./connectors/oto/provider";
+import { noyoProvider } from "./connectors/noyo/provider";
 import { outlookCalendarProvider } from "./connectors/outlook-calendar/provider";
 import { outlookMailProvider } from "./connectors/outlook-mail/provider";
 import { resourceGuruProvider } from "./connectors/resource-guru/provider";
@@ -1055,6 +1056,7 @@ const CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES = [
     optimizelyCmpProvider,
   ),
   refreshProviderEntry("oto", "api-token", otoProvider),
+  refreshProviderEntry("noyo", "api-token", noyoProvider),
   authCodeRefreshProviderEntry("resource-guru", "oauth", resourceGuruProvider),
   authCodeRefreshProviderEntry(
     "outlook-calendar",

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/connector-backlog.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/connector-backlog.test.ts
@@ -15,6 +15,7 @@ import {
   refreshDatadogToken,
 } from "../datadog/oauth";
 import { refreshNetSuiteAccessToken } from "../netsuite/api-token";
+import { fetchNoyoAccessToken } from "../noyo/api-token";
 import { fetchPayPalAccessToken } from "../paypal/api-token";
 import { fetchRampAccessToken } from "../ramp/api-token";
 import { refreshWorkdayAccessToken } from "../workday/api-token";
@@ -282,6 +283,38 @@ describe("connector backlog auth providers", () => {
         signal,
       ),
     ).resolves.toEqual({ accessToken: "paypal-token", expiresIn: 3600 });
+  });
+
+  it("gets a Noyo client-credentials token with JSON authentication", async () => {
+    let authorization: string | null = null;
+    let body: string | null = null;
+    server.use(
+      http.post(
+        "https://accounts.noyo.com/auth/public/token",
+        async ({ request }) => {
+          authorization = request.headers.get("authorization");
+          body = await request.text();
+          return HttpResponse.json({
+            access_token: "noyo-token",
+            expires_in: 864000,
+          });
+        },
+      ),
+    );
+
+    await expect(
+      fetchNoyoAccessToken(
+        {
+          clientId: "client-id",
+          clientSecret: "client-secret",
+        },
+        signal,
+      ),
+    ).resolves.toEqual({ accessToken: "noyo-token", expiresIn: 864000 });
+    expect(authorization).toBe(
+      `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`,
+    );
+    expect(body).toBe(JSON.stringify({ grant_type: "client_credentials" }));
   });
 
   it("gets a Ramp client-credentials token with requested scopes", async () => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/connector-backlog.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/connector-backlog.test.ts
@@ -15,7 +15,6 @@ import {
   refreshDatadogToken,
 } from "../datadog/oauth";
 import { refreshNetSuiteAccessToken } from "../netsuite/api-token";
-import { fetchNoyoAccessToken } from "../noyo/api-token";
 import { fetchPayPalAccessToken } from "../paypal/api-token";
 import { fetchRampAccessToken } from "../ramp/api-token";
 import { refreshWorkdayAccessToken } from "../workday/api-token";
@@ -283,38 +282,6 @@ describe("connector backlog auth providers", () => {
         signal,
       ),
     ).resolves.toEqual({ accessToken: "paypal-token", expiresIn: 3600 });
-  });
-
-  it("gets a Noyo client-credentials token with JSON authentication", async () => {
-    let authorization: string | null = null;
-    let body: string | null = null;
-    server.use(
-      http.post(
-        "https://accounts.noyo.com/auth/public/token",
-        async ({ request }) => {
-          authorization = request.headers.get("authorization");
-          body = await request.text();
-          return HttpResponse.json({
-            access_token: "noyo-token",
-            expires_in: 864000,
-          });
-        },
-      ),
-    );
-
-    await expect(
-      fetchNoyoAccessToken(
-        {
-          clientId: "client-id",
-          clientSecret: "client-secret",
-        },
-        signal,
-      ),
-    ).resolves.toEqual({ accessToken: "noyo-token", expiresIn: 864000 });
-    expect(authorization).toBe(
-      `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`,
-    );
-    expect(body).toBe(JSON.stringify({ grant_type: "client_credentials" }));
   });
 
   it("gets a Ramp client-credentials token with requested scopes", async () => {

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/noyo.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/noyo.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse, http } from "msw";
+
+import type { ConnectorAuthMethodRuntimeConfig } from "../../../connector-config";
+import { refreshConnectorAuthProviderAccessTokenWithMethod } from "../../connector-auth";
+import { server } from "../../__tests__/test-server";
+
+const NOYO_PROVIDER_METHOD = {
+  storage: {
+    version: 1,
+    secrets: ["NOYO_CLIENT_SECRET", "NOYO_ACCESS_TOKEN"],
+    variables: [
+      "NOYO_FULFILLMENT_HOST",
+      "NOYO_TRACKING_HOST",
+      "NOYO_CLIENT_ID",
+    ],
+  },
+  grant: {
+    kind: "manual",
+    fields: {
+      NOYO_FULFILLMENT_HOST: {
+        publicId: "fulfillmentHost",
+        label: "Fulfillment API host",
+        required: true,
+        storage: "variable",
+      },
+      NOYO_TRACKING_HOST: {
+        publicId: "trackingHost",
+        label: "Tracking API host",
+        required: true,
+        storage: "variable",
+      },
+      NOYO_CLIENT_ID: {
+        publicId: "clientId",
+        label: "Client ID",
+        required: true,
+        storage: "variable",
+      },
+      NOYO_CLIENT_SECRET: {
+        publicId: "clientSecret",
+        label: "Client Secret",
+        required: true,
+        storage: "secret",
+      },
+    },
+  },
+  access: {
+    kind: "refresh-token",
+    envBindings: {
+      NOYO_ACCESS_TOKEN: "$secrets.NOYO_ACCESS_TOKEN",
+      NOYO_FULFILLMENT_HOST: "$vars.NOYO_FULFILLMENT_HOST",
+      NOYO_TRACKING_HOST: "$vars.NOYO_TRACKING_HOST",
+    },
+    inputs: {
+      clientId: "$vars.NOYO_CLIENT_ID",
+      clientSecret: "$secrets.NOYO_CLIENT_SECRET",
+    },
+    outputs: { accessToken: "$secrets.NOYO_ACCESS_TOKEN" },
+    refreshableSecrets: ["NOYO_ACCESS_TOKEN"],
+  },
+  revoke: { kind: "none" },
+} as const satisfies ConnectorAuthMethodRuntimeConfig;
+
+describe("connector/providers/noyo", () => {
+  it("refreshes through the catalog contract with expiry in seconds", async () => {
+    let authorization: string | null = null;
+    let contentType: string | null = null;
+    let body: unknown;
+    server.use(
+      http.post(
+        "https://accounts.noyo.com/auth/public/token",
+        async ({ request }) => {
+          authorization = request.headers.get("authorization");
+          contentType = request.headers.get("content-type");
+          body = await request.json();
+          return HttpResponse.json({
+            access_token: "noyo-token",
+            expires_in: 864000,
+            token_type: "Bearer",
+          });
+        },
+      ),
+    );
+
+    await expect(
+      refreshConnectorAuthProviderAccessTokenWithMethod(
+        {
+          connectorSlug: "noyo",
+          authMethodId: "api-token",
+          method: NOYO_PROVIDER_METHOD,
+          inputs: { clientId: "client-id", clientSecret: "client-secret" },
+        },
+        new AbortController().signal,
+      ),
+    ).resolves.toEqual({
+      outputs: { accessToken: "noyo-token" },
+      expiresIn: 864,
+    });
+    expect(authorization).toBe(
+      `Basic ${Buffer.from("client-id:client-secret").toString("base64")}`,
+    );
+    expect(contentType).toBe("application/json");
+    expect(body).toEqual({ grant_type: "client_credentials" });
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/noyo.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/noyo.test.ts
@@ -3,6 +3,7 @@ import { HttpResponse, http } from "msw";
 
 import type { ConnectorAuthMethodRuntimeConfig } from "../../../connector-config";
 import { refreshConnectorAuthProviderAccessTokenWithMethod } from "../../connector-auth";
+import { ProviderResponseError } from "../../provider-error";
 import { server } from "../../__tests__/test-server";
 
 const NOYO_PROVIDER_METHOD = {
@@ -101,5 +102,36 @@ describe("connector/providers/noyo", () => {
     );
     expect(contentType).toBe("application/json");
     expect(body).toEqual({ grant_type: "client_credentials" });
+  });
+
+  it.each([
+    { label: "malformed JSON", body: "private-provider-response" },
+    {
+      label: "an invalid token payload",
+      body: JSON.stringify({ access_token: "private-provider-token" }),
+    },
+  ])("classifies $label as an upstream response failure", async ({ body }) => {
+    server.use(
+      http.post("https://accounts.noyo.com/auth/public/token", () => {
+        return new HttpResponse(body, {
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    const refresh = refreshConnectorAuthProviderAccessTokenWithMethod(
+      {
+        connectorSlug: "noyo",
+        authMethodId: "api-token",
+        method: NOYO_PROVIDER_METHOD,
+        inputs: { clientId: "client-id", clientSecret: "client-secret" },
+      },
+      new AbortController().signal,
+    );
+    await expect(refresh).rejects.toBeInstanceOf(ProviderResponseError);
+    await expect(refresh).rejects.toHaveProperty(
+      "message",
+      "Invalid Noyo access token response",
+    );
   });
 });

--- a/turbo/packages/connectors/src/auth-providers/connectors/noyo/api-token.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/noyo/api-token.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+import { ProviderHttpError, ProviderResponseError } from "../../provider-error";
+
+const TOKEN_URL = "https://accounts.noyo.com/auth/public/token";
+
+const noyoAccessTokenResponseSchema = z.object({
+  access_token: z.string().min(1),
+  expires_in: z.number().positive(),
+});
+
+export async function fetchNoyoAccessToken(
+  args: {
+    readonly clientId: string;
+    readonly clientSecret: string;
+  },
+  signal: AbortSignal,
+): Promise<{ readonly accessToken: string; readonly expiresIn: number }> {
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${args.clientId}:${args.clientSecret}`).toString("base64")}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ grant_type: "client_credentials" }),
+    signal,
+  });
+  if (!response.ok) {
+    throw new ProviderHttpError(
+      `Noyo access token request failed: ${response.status}`,
+      response.status,
+    );
+  }
+  const parsed = noyoAccessTokenResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new ProviderResponseError("Invalid Noyo access token response");
+  }
+  return {
+    accessToken: parsed.data.access_token,
+    expiresIn: parsed.data.expires_in,
+  };
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/noyo/api-token.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/noyo/api-token.ts
@@ -37,6 +37,7 @@ export async function fetchNoyoAccessToken(
   }
   return {
     accessToken: parsed.data.access_token,
-    expiresIn: parsed.data.expires_in,
+    // Noyo reports milliseconds; connector providers expose expiry in seconds.
+    expiresIn: parsed.data.expires_in / 1000,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/noyo/api-token.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/noyo/api-token.ts
@@ -31,7 +31,16 @@ export async function fetchNoyoAccessToken(
       response.status,
     );
   }
-  const parsed = noyoAccessTokenResponseSchema.safeParse(await response.json());
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new ProviderResponseError("Invalid Noyo access token response");
+    }
+    throw error;
+  }
+  const parsed = noyoAccessTokenResponseSchema.safeParse(payload);
   if (!parsed.success) {
     throw new ProviderResponseError("Invalid Noyo access token response");
   }

--- a/turbo/packages/connectors/src/auth-providers/connectors/noyo/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/noyo/provider.ts
@@ -1,0 +1,21 @@
+import type { RefreshTokenAccessProvider } from "../../types";
+import { fetchNoyoAccessToken } from "./api-token";
+
+export const noyoProvider = {
+  access: {
+    kind: "refresh-token",
+    refresh: async (args, signal: AbortSignal) => {
+      const token = await fetchNoyoAccessToken(
+        {
+          clientId: args.inputs.clientId,
+          clientSecret: args.inputs.clientSecret,
+        },
+        signal,
+      );
+      return {
+        outputs: { accessToken: token.accessToken },
+        expiresIn: token.expiresIn,
+      };
+    },
+  } satisfies RefreshTokenAccessProvider<"noyo", "api-token">,
+};

--- a/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
@@ -1363,6 +1363,31 @@ export const CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS = [
     },
   },
   {
+    connectorSlug: "noyo",
+    authMethodId: "api-token",
+    contract: {
+      client: {
+        kind: "none",
+      },
+      grant: {
+        kind: "manual",
+        callbackOrigin: null,
+        outputNames: [],
+        startOptionNames: [],
+      },
+      access: {
+        kind: "refresh-token",
+        inputNames: ["clientId", "clientSecret"],
+        outputNames: ["accessToken"],
+        platformSecrets: [],
+      },
+      revoke: {
+        kind: "none",
+        inputNames: [],
+      },
+    },
+  },
+  {
     connectorSlug: "resource-guru",
     authMethodId: "oauth",
     contract: {


### PR DESCRIPTION
## Summary

Add Noyo client-credentials authentication through the existing `api-token` refresh provider. Users supply their client ID and client secret; the runtime obtains and renews the Bearer token used by [vm0-ai/vm0-connectors#3835](https://github.com/vm0-ai/vm0-connectors/pull/3835).

Noyo reports `expires_in` in milliseconds. Normalize that value to the provider interface's seconds so `864000` becomes 864 seconds rather than 10 days, allowing the runtime to renew the token before it expires. Update the executable-capability digest fixture for the new provider registration.

Malformed JSON and invalid token payloads produce a sanitized `ProviderResponseError`. The existing runtime treats this as a temporary upstream failure, preserving the connection instead of incorrectly requiring reconnection. Transport failures and cancellation retain their original error types.

## Authentication contract

The [official authentication guide](https://docs.noyo.com/docs/introduction/getting-started/authentication.md) documents:

- POST `https://accounts.noyo.com/auth/public/token`.
- HTTP Basic authentication using `client_id:client_secret`.
- JSON body `{"grant_type":"client_credentials"}`.
- A short-lived `access_token` and `expires_in` in milliseconds.

The provider matches #3835's `clientId` / `clientSecret` inputs and `accessToken` output. Connector availability requires this provider in the serving API and the companion catalog to be published and synchronized.

## Validation

- `pnpm -F @okouai/connectors exec vitest run src/auth-providers/connectors/__tests__/noyo.test.ts src/auth-providers/connectors/__tests__/connector-backlog.test.ts --reporter=dot --silent=passed-only` — 11 tests passed.
- The Noyo tests call the registered provider with the companion catalog contract and verify request authentication, JSON body, token output, expiry in seconds, and sanitized upstream-response errors. The expiry and malformed-JSON regressions both failed before their respective fixes.
- `pnpm -F @okouai/connectors check-types` — passed.
- `pnpm -F @okouai/connectors lint` — passed.
- `pnpm exec knip --workspace packages/connectors` — passed.
- Prettier and `git diff --check` — passed.
- The catalog API test file passed all 112 tests in the PR pipeline after the capability-digest update; the digest is unaffected by the error-handling fix.

The latest commit's broader repository checks run in the PR pipeline. No live Noyo credentials were used.

## Follow-up issues

- #32291 tracks the same existing malformed-JSON issue in PayPal, Ramp, and NetSuite. This PR fixes Noyo only.
- #32277 tracks the independent pinned-sidebar initialization failure observed during CI. The affected app shard passed a same-commit rerun; that rerun does not resolve the underlying issue.
