### PR TITLE
feat(connectors): add optimizely cmp oauth provider

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -94,6 +94,7 @@ import { nintendoSwitchParentalControlsProvider } from "./connectors/nintendo-sw
 import { nintendoStoreProvider } from "./connectors/nintendo-store/provider";
 import { notionProvider } from "./connectors/notion/provider";
 import { netsuiteProvider } from "./connectors/netsuite/provider";
+import { optimizelyCmpProvider } from "./connectors/optimizely-cmp/provider";
 import { outlookCalendarProvider } from "./connectors/outlook-calendar/provider";
 import { outlookMailProvider } from "./connectors/outlook-mail/provider";
 import { resourceGuruProvider } from "./connectors/resource-guru/provider";
@@ -1047,6 +1048,11 @@ const CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES = [
     nintendoSwitchParentalControlsProvider,
   ),
   authCodeRefreshProviderEntry("notion", "oauth", notionProvider),
+  authCodeRefreshTokenRevokeProviderEntry(
+    "optimizely-cmp",
+    "oauth",
+    optimizelyCmpProvider,
+  ),
   authCodeRefreshProviderEntry("resource-guru", "oauth", resourceGuruProvider),
   authCodeRefreshProviderEntry(
     "outlook-calendar",

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/optimizely-cmp.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/optimizely-cmp.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse, http } from "msw";
+
+import { server } from "../../__tests__/test-server";
+import { authCodeGrantFixture } from "./auth-code-grant-fixture";
+import {
+  buildOptimizelyCmpAuthorizationUrl,
+  exchangeOptimizelyCmpCode,
+  refreshOptimizelyCmpToken,
+  revokeOptimizelyCmpRefreshToken,
+} from "../optimizely-cmp/oauth";
+
+const AUTHORIZATION_URL =
+  "https://accounts.cmp.optimizely.com/o/oauth2/v1/auth";
+const TOKEN_URL = "https://accounts.cmp.optimizely.com/o/oauth2/v1/token";
+const USERINFO_URL = "https://accounts.cmp.optimizely.com/o/oauth2/v1/userinfo";
+const REVOKE_URL = "https://accounts.welcomesoftware.com/o/oauth2/v1/revoke";
+
+function authCodeGrant() {
+  return authCodeGrantFixture(["openid", "profile", "offline_access"]);
+}
+
+describe("connector/providers/optimizely-cmp", () => {
+  it("builds the documented authorization URL", () => {
+    const url = new URL(
+      buildOptimizelyCmpAuthorizationUrl(
+        authCodeGrant(),
+        "client-id",
+        "https://app.vm0.ai/connectors/optimizely-cmp/callback",
+        "oauth-state",
+      ),
+    );
+
+    expect(`${url.origin}${url.pathname}`).toBe(AUTHORIZATION_URL);
+    expect(url.searchParams.get("client_id")).toBe("client-id");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://app.vm0.ai/connectors/optimizely-cmp/callback",
+    );
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("scope")).toBe("openid profile offline_access");
+    expect(url.searchParams.get("state")).toBe("oauth-state");
+  });
+
+  it("exchanges a code and resolves the CMP user", async () => {
+    let tokenBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(TOKEN_URL, async ({ request }) => {
+        expect(request.headers.get("content-type")).toContain(
+          "application/json",
+        );
+        tokenBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 3599,
+          token_type: "Bearer",
+        });
+      }),
+      http.get(USERINFO_URL, ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer access-token",
+        );
+        return HttpResponse.json({
+          sub: "cmp-user-123",
+          name: "CMP User",
+          email: "cmp@example.com",
+        });
+      }),
+    );
+
+    await expect(
+      exchangeOptimizelyCmpCode(
+        authCodeGrant(),
+        "client-id",
+        "client-secret",
+        "authorization-code",
+        "https://app.vm0.ai/connectors/optimizely-cmp/callback",
+      ),
+    ).resolves.toEqual({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresIn: 3599,
+      scopes: ["openid", "profile", "offline_access"],
+      userInfo: {
+        id: "cmp-user-123",
+        username: "CMP User",
+        email: "cmp@example.com",
+      },
+    });
+    expect(tokenBody).toEqual({
+      client_id: "client-id",
+      client_secret: "client-secret",
+      code: "authorization-code",
+      grant_type: "authorization_code",
+      redirect_uri: "https://app.vm0.ai/connectors/optimizely-cmp/callback",
+    });
+  });
+
+  it("refreshes the single-use token and returns the rotated refresh token", async () => {
+    server.use(
+      http.post(TOKEN_URL, async ({ request }) => {
+        expect(await request.json()).toEqual({
+          client_id: "client-id",
+          client_secret: "client-secret",
+          grant_type: "refresh_token",
+          refresh_token: "old-refresh-token",
+        });
+        return HttpResponse.json({
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+          expires_in: 3599,
+        });
+      }),
+    );
+
+    await expect(
+      refreshOptimizelyCmpToken(
+        "client-id",
+        "client-secret",
+        "old-refresh-token",
+        new AbortController().signal,
+      ),
+    ).resolves.toEqual({
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresIn: 3599,
+      scopes: null,
+    });
+  });
+
+  it("rejects a refresh response without the rotated refresh token", async () => {
+    server.use(
+      http.post(TOKEN_URL, () => {
+        return HttpResponse.json({ access_token: "new-access-token" });
+      }),
+    );
+
+    await expect(
+      refreshOptimizelyCmpToken(
+        "client-id",
+        "client-secret",
+        "old-refresh-token",
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow(
+      "No rotated refresh token in Optimizely CMP refresh response",
+    );
+  });
+
+  it("revokes the refresh token using the documented legacy endpoint", async () => {
+    let revokeBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(REVOKE_URL, async ({ request }) => {
+        revokeBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ msg: "success" });
+      }),
+    );
+
+    await expect(
+      revokeOptimizelyCmpRefreshToken(
+        "client-id",
+        "client-secret",
+        "refresh-token",
+        new AbortController().signal,
+      ),
+    ).resolves.toBeUndefined();
+    expect(revokeBody).toEqual({
+      token: "refresh-token",
+      token_type_hint: "refresh_token",
+      client_id: "client-id",
+      client_secret: "client-secret",
+    });
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/optimizely-cmp/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/optimizely-cmp/oauth.ts
@@ -1,0 +1,216 @@
+import { z } from "zod";
+
+import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
+import { throwOAuthError } from "../../oauth/error";
+import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
+
+const OPTIMIZELY_CMP_AUTHORIZATION_URL =
+  "https://accounts.cmp.optimizely.com/o/oauth2/v1/auth";
+const OPTIMIZELY_CMP_TOKEN_URL =
+  "https://accounts.cmp.optimizely.com/o/oauth2/v1/token";
+const OPTIMIZELY_CMP_USERINFO_URL =
+  "https://accounts.cmp.optimizely.com/o/oauth2/v1/userinfo";
+// Optimizely's current CMP documentation specifies the legacy hostname for
+// RFC 7009 revocation while the authorization and token endpoints use the
+// current accounts.cmp.optimizely.com hostname.
+const OPTIMIZELY_CMP_REVOKE_URL =
+  "https://accounts.welcomesoftware.com/o/oauth2/v1/revoke";
+
+interface OptimizelyCmpUserInfo {
+  readonly id: string;
+  readonly username: string | null;
+  readonly email: string | null;
+}
+
+interface OptimizelyCmpTokenResult {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly expiresIn?: number;
+  readonly scopes: readonly string[];
+  readonly userInfo: OptimizelyCmpUserInfo;
+}
+
+interface OptimizelyCmpRefreshResult {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly expiresIn?: number;
+  readonly scopes: readonly string[] | null;
+}
+
+const tokenResponseSchema = z.object({
+  access_token: z.string().optional(),
+  refresh_token: z.string().nullable().optional(),
+  expires_in: z.number().optional(),
+  scope: z.string().optional(),
+  token_type: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+});
+
+type TokenRequest = Readonly<Record<string, string>>;
+
+async function requestToken(
+  body: TokenRequest,
+  operation: "exchange" | "refresh",
+  signal?: AbortSignal,
+): Promise<z.infer<typeof tokenResponseSchema>> {
+  const response = await fetch(OPTIMIZELY_CMP_TOKEN_URL, {
+    ...(signal === undefined ? {} : { signal }),
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    await throwOAuthError("Optimizely CMP", operation, response);
+  }
+
+  const data = tokenResponseSchema.parse(await response.json());
+  if (data.error) {
+    throw new Error(data.error_description ?? data.error);
+  }
+  return data;
+}
+
+/** Build the Optimizely CMP authorization URL. */
+export function buildOptimizelyCmpAuthorizationUrl(
+  authCodeGrant: ConnectorAuthCodeGrantConfig,
+  clientId: string,
+  redirectUri: string,
+  state: string,
+): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: authCodeGrant.scopes.join(" "),
+    state,
+  });
+
+  return `${OPTIMIZELY_CMP_AUTHORIZATION_URL}?${params.toString()}`;
+}
+
+/** Exchange an authorization code and resolve the authorized CMP user. */
+export async function exchangeOptimizelyCmpCode(
+  authCodeGrant: ConnectorAuthCodeGrantConfig,
+  clientId: string,
+  clientSecret: string,
+  code: string,
+  redirectUri: string,
+): Promise<OptimizelyCmpTokenResult> {
+  const data = await requestToken(
+    {
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      grant_type: "authorization_code",
+      redirect_uri: redirectUri,
+    },
+    "exchange",
+  );
+
+  if (!data.access_token) {
+    throw new Error("No access token in Optimizely CMP response");
+  }
+  if (!data.refresh_token) {
+    throw new Error("No refresh token in Optimizely CMP response");
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
+    scopes: effectiveOAuthScopes(data.scope, authCodeGrant.scopes, " "),
+    userInfo: await fetchOptimizelyCmpUserInfo(data.access_token),
+  };
+}
+
+/** Refresh the access token and preserve CMP's single-use token rotation. */
+export async function refreshOptimizelyCmpToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+  signal: AbortSignal,
+): Promise<OptimizelyCmpRefreshResult> {
+  const data = await requestToken(
+    {
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    },
+    "refresh",
+    signal,
+  );
+
+  if (!data.access_token) {
+    throw new Error("No access token in Optimizely CMP refresh response");
+  }
+  if (!data.refresh_token) {
+    throw new Error(
+      "No rotated refresh token in Optimizely CMP refresh response",
+    );
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
+    scopes: reportedOAuthScopes(data.scope, " "),
+  };
+}
+
+/** Revoke the single-use refresh token through CMP's documented endpoint. */
+export async function revokeOptimizelyCmpRefreshToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const response = await fetch(OPTIMIZELY_CMP_REVOKE_URL, {
+    signal,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      token: refreshToken,
+      token_type_hint: "refresh_token",
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+
+  if (!response.ok) {
+    await throwOAuthError("Optimizely CMP", "revoke", response);
+  }
+}
+
+async function fetchOptimizelyCmpUserInfo(
+  accessToken: string,
+): Promise<OptimizelyCmpUserInfo> {
+  const response = await fetch(OPTIMIZELY_CMP_USERINFO_URL, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    await throwOAuthError("Optimizely CMP", "userinfo", response);
+  }
+
+  const data = z
+    .object({
+      sub: z.string().optional(),
+      name: z.string().nullable().optional(),
+      preferred_username: z.string().nullable().optional(),
+      email: z.string().nullable().optional(),
+    })
+    .parse(await response.json());
+
+  if (!data.sub) {
+    throw new Error("No user id in Optimizely CMP userinfo response");
+  }
+
+  return {
+    id: data.sub,
+    username: data.preferred_username ?? data.name ?? data.email ?? null,
+    email: data.email ?? null,
+  };
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/optimizely-cmp/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/optimizely-cmp/provider.ts
@@ -1,0 +1,69 @@
+import type { AuthCodeConnectorAuthProvider } from "../../types";
+import { oauthRefreshResultToProviderResult } from "../../oauth/types";
+import {
+  buildOptimizelyCmpAuthorizationUrl,
+  exchangeOptimizelyCmpCode,
+  refreshOptimizelyCmpToken,
+  revokeOptimizelyCmpRefreshToken,
+} from "./oauth";
+
+export const optimizelyCmpProvider: AuthCodeConnectorAuthProvider<"optimizely-cmp"> =
+  {
+    grant: {
+      kind: "auth-code",
+      buildAuthUrl: (args) => {
+        const { clientId } = args.authClient;
+        return buildOptimizelyCmpAuthorizationUrl(
+          args.authCodeGrant,
+          clientId,
+          args.redirectUri,
+          args.state,
+        );
+      },
+      exchangeCode: async (args) => {
+        const { clientId, clientSecret } = args.authClient;
+        const result = await exchangeOptimizelyCmpCode(
+          args.authCodeGrant,
+          clientId,
+          clientSecret,
+          args.code,
+          args.redirectUri,
+        );
+        return {
+          outputs: {
+            accessToken: result.accessToken,
+            refreshToken: result.refreshToken,
+          },
+          expiresIn: result.expiresIn,
+          scopes: result.scopes,
+          userInfo: result.userInfo,
+        };
+      },
+    },
+    access: {
+      kind: "refresh-token",
+      refresh: async (args, signal) => {
+        const { clientId, clientSecret } = args.authClient;
+        return oauthRefreshResultToProviderResult(
+          await refreshOptimizelyCmpToken(
+            clientId,
+            clientSecret,
+            args.inputs.refreshToken,
+            signal,
+          ),
+        );
+      },
+    },
+    revoke: {
+      kind: "token-revoke",
+      revokeToken: async (args, signal) => {
+        const { clientId, clientSecret } = args.authClient;
+        await revokeOptimizelyCmpRefreshToken(
+          clientId,
+          clientSecret,
+          args.inputs.refreshToken,
+          signal,
+        );
+      },
+    },
+  };

--- a/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
@@ -1311,6 +1311,33 @@ export const CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS = [
     },
   },
   {
+    connectorSlug: "optimizely-cmp",
+    authMethodId: "oauth",
+    contract: {
+      client: {
+        kind: "static-confidential-env",
+        clientIdEnv: "OPTIMIZELY_CMP_OAUTH_CLIENT_ID",
+        clientSecretEnv: "OPTIMIZELY_CMP_OAUTH_CLIENT_SECRET",
+      },
+      grant: {
+        kind: "auth-code",
+        callbackOrigin: "web",
+        outputNames: ["accessToken", "refreshToken"],
+        startOptionNames: [],
+      },
+      access: {
+        kind: "refresh-token",
+        inputNames: ["refreshToken"],
+        outputNames: ["accessToken", "refreshToken"],
+        platformSecrets: [],
+      },
+      revoke: {
+        kind: "token-revoke",
+        inputNames: ["refreshToken"],
+      },
+    },
+  },
+  {
     connectorSlug: "resource-guru",
     authMethodId: "oauth",
     contract: {


### PR DESCRIPTION
## Summary
- add the executable OAuth 2.0 provider for the Optimizely Content Marketing Platform connector
- support the documented authorization-code, rotated refresh-token, userinfo, and refresh-token revocation flows
- register the provider contract so the runtime cannot silently downgrade this connector to an unsupported auth implementation

## Official contract
- Authorization and token endpoints: `https://accounts.cmp.optimizely.com/o/oauth2/v1/{auth,token}`
- Userinfo endpoint: `https://accounts.cmp.optimizely.com/o/oauth2/v1/userinfo`
- Revocation endpoint: `https://accounts.welcomesoftware.com/o/oauth2/v1/revoke`, as specified by the current CMP documentation
- Callback origin: web; production app callback is `https://app.vm0.ai/connectors/optimizely-cmp/callback`
- OAuth client configuration names: `OPTIMIZELY_CMP_OAUTH_CLIENT_ID` and `OPTIMIZELY_CMP_OAUTH_CLIENT_SECRET`

## Validation
- `pnpm --filter @okouai/connectors check-types`
- `pnpm --filter @okouai/connectors exec vitest run src/auth-providers/connectors/__tests__/optimizely-cmp.test.ts`
- `pnpm --filter @okouai/connectors lint`
