### PR TITLE
chore(core): require opt-in for large pinned agent avatars

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -459,7 +459,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show 64px avatars in the horizontal pinned-agent grid with three cards per row.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PersonalModelProviderAccounts]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary

Remove the staff-organization allowlist from `pinnedAgentAvatar64`, so the 64×64 pinned-agent layout requires explicit opt-in for every organization. Staff users without an override get the default 36×36 layout; existing explicit overrides remain effective.

## Verification

- Feature-switch tests: 31 passed.
- Verified both flag evaluators with staff and ordinary organizations: default off, explicit true/false overrides respected, and Lab rollout stage `alpha`.
- Core lint and formatting passed; pre-commit Knip, repository type checks (15 tasks), and commitlint passed.
