### PR TITLE
docs(rust): correct heartbeat status summary

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -280,7 +280,7 @@ pub struct CliExecutionResult {
     pub active_input_delivery_ids: Vec<String>,
 }
 
-/// How top-level guest-agent handling should settle a finished CLI execution.
+/// One-shot outcome reported by the heartbeat loop or task while CLI execution is in progress.
 ///
 /// Heartbeat completion signal observed by CLI execution.
 ///


### PR DESCRIPTION
Closes #32073

## Summary

- Correct the public `HeartbeatStatus` rustdoc summary to describe the one-shot heartbeat loop/task outcome observed while CLI execution is in progress.
- Preserve the existing ownership, lifecycle, and variant documentation.

## Scope

This is a documentation-only change to `crates/guest-agent/src/cli/mod.rs`. It does not change runtime behavior, the public API shape, callers, tests, persisted data, or deployment configuration.

## Validation

- `git diff --check`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p guest-agent --no-deps`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p guest-agent --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent`
