### PR TITLE
fix(python): reject non-utf-8 catalog response headers

### DIFF
--- a/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
+++ b/crates/runner/mitm-addon/src/codex_model_catalog_cache.py
@@ -364,9 +364,19 @@ def _is_responses_path(original_url: str) -> bool:
     return parsed.path == _RESPONSES_PATH or parsed.path.startswith(f"{_RESPONSES_PATH}/")
 
 
+def _strict_utf8_bytes(value: str) -> bytes | None:
+    try:
+        return value.encode()
+    except UnicodeEncodeError:
+        return None
+
+
 def _usable_etag_value(value: str) -> str | None:
     value = value.strip()
-    if not value or value == "*" or len(value.encode()) > _MAX_ETAG_BYTES:
+    if not value or value == "*":
+        return None
+    encoded = _strict_utf8_bytes(value)
+    if encoded is None or len(encoded) > _MAX_ETAG_BYTES:
         return None
     opaque = value[2:] if value.startswith("W/") else value
     if (
@@ -746,8 +756,11 @@ def _response_headers_bypass_reason(
     if encoding != _IDENTITY_ENCODING and not (allow_brotli and encoding == _BROTLI_ENCODING):
         return "response_encoding"
     content_type = headers.get("Content-Type", "")
-    if len(content_type.encode()) > _MAX_CONTENT_TYPE_BYTES or not _content_type_is_json(
-        content_type
+    encoded_content_type = _strict_utf8_bytes(content_type)
+    if (
+        encoded_content_type is None
+        or len(encoded_content_type) > _MAX_CONTENT_TYPE_BYTES
+        or not _content_type_is_json(content_type)
     ):
         return "response_content_type"
     if _response_cache_control_is_unsafe(headers):

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_coordination.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_coordination.py
@@ -195,6 +195,19 @@ async def test_non_utf8_identity_headers_release_singleflight_follower(
     await asyncio.wait_for(follower_prepare, timeout=0.1)
     assert follower.response is None
     assert follower.request.headers["Accept-Encoding"] == "identity"
+
+    capacity_owners = [
+        catalog_flow(real_flow, version=f"{version}-capacity-{index}")
+        for index in range(catalog_cache.MAX_IN_FLIGHT_REQUESTS - 1)
+    ]
+    for capacity_owner in capacity_owners:
+        await prepare_miss(capacity_owner)
+        capacity_telemetry: dict[str, object] = {}
+        catalog_cache.add_network_log_fields(capacity_owner, capacity_telemetry)
+        assert capacity_telemetry == {}
+    for capacity_owner in capacity_owners:
+        catalog_cache.handle_error(capacity_owner)
+
     owner_telemetry: dict[str, object] = {}
     catalog_cache.add_network_log_fields(owner, owner_telemetry)
     validation_latency = owner_telemetry.pop("model_catalog_cache_validation_latency_ms")

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_coordination.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_coordination.py
@@ -4,12 +4,14 @@ import asyncio
 from unittest.mock import patch
 
 import pytest
+from mitmproxy import http
 from mitmproxy.flow import Error
 
 import codex_model_catalog_cache as catalog_cache
 import mitm_addon
 from tests.codex_model_catalog_cache_helpers import (
     CATALOG_BODY,
+    CATALOG_ETAG,
     catalog_flow,
     catalog_response,
     finish_response,
@@ -141,6 +143,79 @@ async def test_non_cacheable_identity_headers_release_singleflight_follower(real
         "model_catalog_cache_upstream_encoding": "identity",
     }
     catalog_cache.handle_error(follower)
+
+
+@pytest.mark.parametrize(
+    ("content_type", "etag", "reason"),
+    [
+        pytest.param(
+            b"application/json",
+            b'"\xff"',
+            "response_etag",
+            id="etag",
+        ),
+        pytest.param(
+            b"application/\xffjson",
+            CATALOG_ETAG.encode(),
+            "response_content_type",
+            id="content-type",
+        ),
+    ],
+)
+async def test_non_utf8_identity_headers_release_singleflight_follower(
+    real_flow,
+    content_type: bytes,
+    etag: bytes,
+    reason: str,
+):
+    version = f"non-utf8-{reason}"
+    owner = catalog_flow(real_flow, version=version)
+    await prepare_miss(owner)
+    follower = catalog_flow(real_flow, version=version)
+    follower_prepare = asyncio.create_task(
+        catalog_cache.prepare_request(follower, request_end_stream=True)
+    )
+    await asyncio.sleep(0)
+    assert not follower_prepare.done()
+
+    owner.response = catalog_response()
+    upstream_body = owner.response.raw_content
+    owner.response.headers = http.Headers(
+        [
+            (b"Content-Type", content_type),
+            (b"Content-Length", str(len(CATALOG_BODY)).encode()),
+            (b"ETag", etag),
+        ]
+    )
+
+    mitm_addon.responseheaders(owner)
+
+    assert owner.response.status_code == 200
+    assert owner.response.raw_content == upstream_body
+    await asyncio.wait_for(follower_prepare, timeout=0.1)
+    assert follower.response is None
+    assert follower.request.headers["Accept-Encoding"] == "identity"
+    owner_telemetry: dict[str, object] = {}
+    catalog_cache.add_network_log_fields(owner, owner_telemetry)
+    validation_latency = owner_telemetry.pop("model_catalog_cache_validation_latency_ms")
+    assert isinstance(validation_latency, int)
+    assert validation_latency >= 0
+    assert owner_telemetry == {
+        "model_catalog_cache_status": "model_catalog_cold_not_stored",
+        "model_catalog_cache_bypass_reason": reason,
+        "model_catalog_cache_upstream_encoding": "identity",
+    }
+
+    follower_body = b'{"models":[{"slug":"replacement"}]}'
+    follower.response = catalog_response(body=follower_body)
+    assert (await finish_response(follower))["model_catalog_cache_status"] == (
+        "model_catalog_cold_stored"
+    )
+
+    hit = catalog_flow(real_flow, version=version)
+    await catalog_cache.prepare_request(hit, request_end_stream=True)
+    assert hit.response is not None
+    assert hit.response.content == follower_body
 
 
 async def test_unsolicited_encoded_response_releases_follower_as_identity_owner(real_flow):

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_lifecycle.py
@@ -205,6 +205,7 @@ async def test_non_utf8_authenticated_models_etag_does_not_change_in_flight_owne
 
     mitm_addon.responseheaders(signal)
 
+    await asyncio.sleep(0)
     assert not follower_prepare.done()
     signal_telemetry: dict[str, object] = {}
     catalog_cache.add_network_log_fields(signal, signal_telemetry)

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_lifecycle.py
@@ -1,8 +1,10 @@
 """Integration coverage for Codex model catalog cache entry lifecycle."""
 
+import asyncio
 import json
 from unittest.mock import patch
 
+from mitmproxy import http
 from mitmproxy.flow import Error
 
 import codex_model_catalog_cache as catalog_cache
@@ -11,6 +13,8 @@ from tests.codex_model_catalog_cache_helpers import (
     CATALOG_BODY,
     CATALOG_ETAG,
     catalog_flow,
+    catalog_response,
+    finish_response,
     install_catalog,
     prepare_miss,
     responses_flow,
@@ -148,6 +152,72 @@ async def test_failed_responses_etag_does_not_invalidate_catalog(real_flow):
     telemetry: dict[str, object] = {}
     catalog_cache.add_network_log_fields(failed_response, telemetry)
     assert telemetry == {}
+
+
+async def test_non_utf8_authenticated_models_etag_does_not_change_entry(real_flow):
+    with patch.object(catalog_cache.time, "monotonic", return_value=100.0) as monotonic:
+        await install_catalog(catalog_flow(real_flow))
+
+        monotonic.return_value = 150.0
+        signal = responses_flow(real_flow)
+        assert signal.response is not None
+        signal.response.headers = http.Headers(
+            [
+                (b"Content-Type", b"text/event-stream"),
+                (b"x-models-etag", b'"\xff"'),
+            ]
+        )
+
+        mitm_addon.responseheaders(signal)
+
+        signal_telemetry: dict[str, object] = {}
+        catalog_cache.add_network_log_fields(signal, signal_telemetry)
+        assert signal_telemetry == {}
+        preserved_hit = catalog_flow(real_flow)
+        await catalog_cache.prepare_request(preserved_hit, request_end_stream=True)
+        assert preserved_hit.response is not None
+        assert preserved_hit.response.content == CATALOG_BODY
+
+        monotonic.return_value = 161.0
+        expired = catalog_flow(real_flow)
+        await prepare_miss(expired)
+        catalog_cache.handle_error(expired)
+
+
+async def test_non_utf8_authenticated_models_etag_does_not_change_in_flight_owner(real_flow):
+    owner = catalog_flow(real_flow, version="invalid-signal-owner")
+    await prepare_miss(owner)
+    follower = catalog_flow(real_flow, version="invalid-signal-owner")
+    follower_prepare = asyncio.create_task(
+        catalog_cache.prepare_request(follower, request_end_stream=True)
+    )
+    await asyncio.sleep(0)
+    assert not follower_prepare.done()
+
+    signal = responses_flow(real_flow)
+    assert signal.response is not None
+    signal.response.headers = http.Headers(
+        [
+            (b"Content-Type", b"text/event-stream"),
+            (b"x-models-etag", b'"\xff"'),
+        ]
+    )
+
+    mitm_addon.responseheaders(signal)
+
+    assert not follower_prepare.done()
+    signal_telemetry: dict[str, object] = {}
+    catalog_cache.add_network_log_fields(signal, signal_telemetry)
+    assert signal_telemetry == {}
+
+    owner_body = b'{"models":[{"slug":"unaffected-owner"}]}'
+    owner.response = catalog_response(body=owner_body)
+    assert (await finish_response(owner))["model_catalog_cache_status"] == (
+        "model_catalog_cold_stored"
+    )
+    await asyncio.wait_for(follower_prepare, timeout=0.1)
+    assert follower.response is not None
+    assert follower.response.content == owner_body
 
 
 async def test_fresh_hit_changes_count_bound_eviction_order(real_flow):


### PR DESCRIPTION
## Summary

- reject surrogate-bearing Codex catalog ETag and Content-Type values through the cache's existing not-stored paths
- ignore an unusable authenticated `x-models-etag` without changing cached entries or in-flight ownership
- cover raw mitmproxy header bytes through hook-level owner/follower and lifecycle integration tests

## Scope

- no public API, persisted state, runner protocol, dependency, telemetry schema, or deployment-order changes
- no broad response-hook exception handling; only `UnicodeEncodeError` from strict header-value encoding is converted into an unusable external value

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest -q tests/test_codex_model_catalog_cache_coordination.py tests/test_codex_model_catalog_cache_lifecycle.py tests/test_codex_model_catalog_cache_responses.py` (76 passed)
- `uv run --no-sync python -m pytest tests/` (7296 passed)

Closes #32081
