### PR TITLE
fix(desktop): serialize update checks

### DIFF
--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -32,8 +32,7 @@
     "ccstate-react": "^5.5.0",
     "lucide-react": "1.30.0",
     "react": "^19.2.6",
-    "react-dom": "^19.2.6",
-    "update-electron-app": "3.2.0"
+    "react-dom": "^19.2.6"
   },
   "devDependencies": {
     "@electron-forge/cli": "7.11.2",

--- a/turbo/apps/desktop/src/bootstrap-degraded.test.ts
+++ b/turbo/apps/desktop/src/bootstrap-degraded.test.ts
@@ -6,6 +6,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DesktopConfig } from "./config";
 
 const mocks = vi.hoisted(() => {
+  type AutoUpdaterListener = (...args: readonly unknown[]) => void;
+  const autoUpdaterListeners = new Map<string, Set<AutoUpdaterListener>>();
+
+  function addAutoUpdaterListener(
+    eventName: string,
+    listener: AutoUpdaterListener,
+  ): void {
+    const listeners = autoUpdaterListeners.get(eventName) ?? new Set();
+    listeners.add(listener);
+    autoUpdaterListeners.set(eventName, listeners);
+  }
+
   return {
     app: {
       isPackaged: true,
@@ -15,39 +27,33 @@ const mocks = vi.hoisted(() => {
       getPath: vi.fn<(name: string) => string>(),
     },
     autoUpdater: {
+      checkForUpdates: vi.fn(),
       quitAndInstall: vi.fn(),
-      on: vi.fn(),
+      setFeedURL: vi.fn(),
+      on: vi.fn(addAutoUpdaterListener),
       once: vi.fn(),
       removeListener: vi.fn(),
     },
+    autoUpdaterListeners,
     dialog: {
       showMessageBox: vi.fn<
         (options: { detail?: string }) => Promise<{ response: number }>
       >(async () => ({ response: 0 })),
     },
-    updateElectronApp:
-      vi.fn<
-        (options: {
-          updateSource: { baseUrl: string };
-          onNotifyUser: (info: { releaseName: string }) => void;
-        }) => void
-      >(),
+    setInterval: vi.fn(),
     sentryInit: vi.fn(),
     sentryCaptureException: vi.fn<(error: unknown) => string>(() => "event"),
   };
 });
 
+vi.mock("node:timers", () => ({
+  setInterval: mocks.setInterval,
+}));
+
 vi.mock("electron", () => ({
   app: mocks.app,
   autoUpdater: mocks.autoUpdater,
   dialog: mocks.dialog,
-}));
-
-vi.mock("update-electron-app", () => ({
-  UpdateSourceType: {
-    StaticStorage: "staticStorage",
-  },
-  updateElectronApp: mocks.updateElectronApp,
 }));
 
 vi.mock("@sentry/electron/main", () => ({
@@ -96,8 +102,15 @@ async function enterDegradedMode(error: unknown): Promise<void> {
   });
 }
 
+function emitAutoUpdaterEvent(eventName: string): void {
+  for (const listener of mocks.autoUpdaterListeners.get(eventName) ?? []) {
+    listener();
+  }
+}
+
 beforeEach(() => {
   vi.resetModules();
+  mocks.autoUpdaterListeners.clear();
   setPlatform("darwin");
   Object.defineProperty(process, "arch", { value: "arm64" });
   mocks.app.isPackaged = true;
@@ -122,22 +135,17 @@ describe("enterDegradedDesktopMode", () => {
     });
 
     expect(mocks.app.quit).toHaveBeenCalled();
-    expect(mocks.updateElectronApp).not.toHaveBeenCalled();
+    expect(mocks.autoUpdater.setFeedURL).not.toHaveBeenCalled();
     expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
   });
 
   it("installs auto-updates and tells the user an update will self-heal", async () => {
     await enterDegradedMode(new Error("boom"));
 
-    expect(mocks.updateElectronApp).toHaveBeenCalledWith(
-      expect.objectContaining({
-        updateSource: expect.objectContaining({
-          baseUrl:
-            "https://api.vm0.ai/api/desktop/updates/zero/stable/darwin/" +
-            process.arch,
-        }),
-      }),
-    );
+    expect(mocks.autoUpdater.setFeedURL).toHaveBeenCalledWith({
+      url: `https://api.vm0.ai/api/desktop/updates/zero/stable/darwin/${process.arch}/RELEASES.json`,
+      serverType: "json",
+    });
     const dialogOptions = mocks.dialog.showMessageBox.mock.calls[0]?.[0];
     expect(dialogOptions?.detail).toContain("installed automatically");
   });
@@ -145,8 +153,7 @@ describe("enterDegradedDesktopMode", () => {
   it("installs a downloaded update without prompting the user", async () => {
     await enterDegradedMode(new Error("boom"));
 
-    const updateOptions = mocks.updateElectronApp.mock.calls[0]?.[0];
-    updateOptions?.onNotifyUser({ releaseName: "v0.22.6" });
+    emitAutoUpdaterEvent("update-downloaded");
 
     await vi.waitFor(() => {
       expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalled();
@@ -160,7 +167,7 @@ describe("enterDegradedDesktopMode", () => {
 
     await enterDegradedMode(new Error("boom"));
 
-    expect(mocks.updateElectronApp).not.toHaveBeenCalled();
+    expect(mocks.autoUpdater.setFeedURL).not.toHaveBeenCalled();
     const dialogOptions = mocks.dialog.showMessageBox.mock.calls[0]?.[0];
     expect(dialogOptions?.detail).toContain("reinstall");
   });

--- a/turbo/apps/desktop/src/bootstrap-degraded.ts
+++ b/turbo/apps/desktop/src/bootstrap-degraded.ts
@@ -123,7 +123,7 @@ export function enterDegradedDesktopMode(options: {
   void app.whenReady().then(async () => {
     // No hooks from the main bundle in degraded mode: report an idle host so
     // a downloaded update installs and relaunches without prompting.
-    const autoUpdatesInstalled = installDesktopAutoUpdates({
+    const autoUpdates = installDesktopAutoUpdates({
       config: options.config,
       apiBaseUrl: options.apiBaseUrl,
       getComputerUseHostState: () => OFFLINE_COMPUTER_USE_HOST_STATE,
@@ -131,7 +131,7 @@ export function enterDegradedDesktopMode(options: {
     });
     await reportDesktopBootstrapFailure(options.error);
     await showDegradedStartupDialog(
-      autoUpdatesInstalled,
+      autoUpdates !== null,
       options.config.identity.displayName,
     );
   });

--- a/turbo/apps/desktop/src/bootstrap-imports.test.ts
+++ b/turbo/apps/desktop/src/bootstrap-imports.test.ts
@@ -8,11 +8,7 @@ import { describe, expect, it } from "vitest";
 // outside the allowlist below — most importantly anything under `@okouai/*`.
 // scripts/check-bootstrap-bundle.mjs re-checks the built bundle.
 
-const ALLOWED_PACKAGES = new Set([
-  "electron",
-  "update-electron-app",
-  "@sentry/electron/main",
-]);
+const ALLOWED_PACKAGES = new Set(["electron", "@sentry/electron/main"]);
 
 // "./main.js" is the runtime require of the main bundle, intentionally
 // external to the bootstrap bundle.

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -3,15 +3,14 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DesktopConfig } from "./config";
 import { OFFLINE_COMPUTER_USE_HOST_STATE } from "./computer-use-types";
 import type { ComputerUseHostRuntimeState } from "./computer-use-types";
-import {
-  checkForDesktopUpdates,
-  installDesktopAutoUpdates,
-} from "./desktop-auto-updates";
+import { installDesktopAutoUpdates } from "./desktop-auto-updates";
+import type { DesktopAutoUpdatesController } from "./desktop-main-module";
 
 const mocks = vi.hoisted(() => {
   type AutoUpdaterListener = (...args: readonly unknown[]) => void;
   const autoUpdaterListeners = new Map<string, Set<AutoUpdaterListener>>();
   const autoUpdaterOnceListeners = new Map<string, Set<AutoUpdaterListener>>();
+  const scheduledUpdateChecks: Array<() => void> = [];
 
   function addAutoUpdaterListener(
     eventName: string,
@@ -44,6 +43,7 @@ const mocks = vi.hoisted(() => {
     autoUpdater: {
       checkForUpdates: vi.fn<() => void>(),
       quitAndInstall: vi.fn(),
+      setFeedURL: vi.fn(),
       on: vi.fn(addAutoUpdaterListener),
       once: vi.fn(addAutoUpdaterOnceListener),
       removeListener: vi.fn(removeAutoUpdaterListener),
@@ -53,21 +53,22 @@ const mocks = vi.hoisted(() => {
     dialog: {
       showMessageBox: vi.fn<() => Promise<{ response: number }>>(),
     },
-    updateElectronApp: vi.fn(),
+    scheduledUpdateChecks,
+    setInterval: vi.fn((callback: () => void) => {
+      scheduledUpdateChecks.push(callback);
+      return 1;
+    }),
   };
 });
+
+vi.mock("node:timers", () => ({
+  setInterval: mocks.setInterval,
+}));
 
 vi.mock("electron", () => ({
   app: mocks.app,
   autoUpdater: mocks.autoUpdater,
   dialog: mocks.dialog,
-}));
-
-vi.mock("update-electron-app", () => ({
-  UpdateSourceType: {
-    StaticStorage: "staticStorage",
-  },
-  updateElectronApp: mocks.updateElectronApp,
 }));
 
 const originalPlatform = process.platform;
@@ -93,10 +94,6 @@ const productionConfig: DesktopConfig = {
   allowedAppOrigins: new Set(["https://app.vm0.ai"]),
 };
 
-interface CapturedUpdateOptions {
-  readonly onNotifyUser: (info: { readonly releaseName: string }) => void;
-}
-
 function stubDesktopAutoUpdatePlatform(
   arch: NodeJS.Architecture = "arm64",
 ): void {
@@ -110,40 +107,35 @@ function stubDesktopAutoUpdatePlatform(
   });
 }
 
-function installAndCaptureUpdateOptions(
+function installAndCaptureAutoUpdates(
   getComputerUseHostState: () => ComputerUseHostRuntimeState,
 ): {
-  readonly updateOptions: CapturedUpdateOptions;
+  readonly autoUpdates: DesktopAutoUpdatesController;
   readonly prepareForQuitAndInstall: ReturnType<typeof vi.fn>;
 } {
   const prepareForQuitAndInstall = vi.fn(async () => {});
+  const autoUpdates = installDesktopAutoUpdates({
+    config: productionConfig,
+    apiBaseUrl: "https://api.vm0.ai",
+    getComputerUseHostState,
+    prepareForQuitAndInstall,
+  });
 
-  expect(
-    installDesktopAutoUpdates({
-      config: productionConfig,
-      apiBaseUrl: "https://api.vm0.ai",
-      getComputerUseHostState,
-      prepareForQuitAndInstall,
-    }),
-  ).toBe(true);
+  if (!autoUpdates) {
+    throw new Error("Expected Desktop auto-updates to install");
+  }
 
-  expect(mocks.updateElectronApp).toHaveBeenCalledTimes(1);
-  const [updateOptions] = mocks.updateElectronApp.mock.calls[0] ?? [];
-  expect(updateOptions).toEqual(
-    expect.objectContaining({
-      notifyUser: true,
-      updateInterval: "30 minutes",
-      updateSource: expect.objectContaining({
-        baseUrl:
-          "https://api.vm0.ai/api/desktop/updates/zero/stable/darwin/arm64",
-      }),
-    }),
+  expect(mocks.autoUpdater.setFeedURL).toHaveBeenCalledExactlyOnceWith({
+    url: "https://api.vm0.ai/api/desktop/updates/zero/stable/darwin/arm64/RELEASES.json",
+    serverType: "json",
+  });
+  expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
+  expect(mocks.setInterval).toHaveBeenCalledExactlyOnceWith(
+    expect.any(Function),
+    30 * 60 * 1000,
   );
 
-  return {
-    updateOptions: updateOptions as CapturedUpdateOptions,
-    prepareForQuitAndInstall,
-  };
+  return { autoUpdates, prepareForQuitAndInstall };
 }
 
 function emitAutoUpdaterEvent(
@@ -160,7 +152,27 @@ function emitAutoUpdaterEvent(
   });
 }
 
-async function flushDownloadedUpdateCallback(): Promise<void> {
+function expectActiveUpdateCheckListenerCount(expected: number): void {
+  for (const eventName of [
+    "update-not-available",
+    "update-available",
+    "error",
+  ]) {
+    expect(mocks.autoUpdaterOnceListeners.get(eventName)?.size ?? 0).toBe(
+      expected,
+    );
+  }
+}
+
+function runScheduledUpdateCheck(): void {
+  const scheduledUpdateCheck = mocks.scheduledUpdateChecks[0];
+  if (!scheduledUpdateCheck) {
+    throw new Error("Expected a scheduled Desktop update check");
+  }
+  scheduledUpdateCheck();
+}
+
+async function flushAsyncCallbacks(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
   await Promise.resolve();
 }
@@ -170,6 +182,7 @@ describe("desktop auto-updates", () => {
     vi.clearAllMocks();
     mocks.autoUpdaterListeners.clear();
     mocks.autoUpdaterOnceListeners.clear();
+    mocks.scheduledUpdateChecks.length = 0;
     mocks.app.isPackaged = true;
     mocks.dialog.showMessageBox.mockResolvedValue({ response: 1 });
     stubDesktopAutoUpdatePlatform();
@@ -186,17 +199,11 @@ describe("desktop auto-updates", () => {
     });
   });
 
-  it("silently restarts after a downloaded update when Computer Use is offline", async () => {
-    const { updateOptions, prepareForQuitAndInstall } =
-      installAndCaptureUpdateOptions(() => OFFLINE_COMPUTER_USE_HOST_STATE);
+  it("configures the feed and starts one immediate check on a 30-minute schedule", () => {
+    installAndCaptureAutoUpdates(() => OFFLINE_COMPUTER_USE_HOST_STATE);
 
-    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
-
-    await vi.waitFor(() => {
-      expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
-      expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
-    });
-    expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
+    expectActiveUpdateCheckListenerCount(1);
+    expect(mocks.scheduledUpdateChecks).toHaveLength(1);
   });
 
   it("does not install auto-updates on Intel Macs", () => {
@@ -209,8 +216,10 @@ describe("desktop auto-updates", () => {
         getComputerUseHostState: () => OFFLINE_COMPUTER_USE_HOST_STATE,
         prepareForQuitAndInstall: vi.fn(async () => {}),
       }),
-    ).toBe(false);
-    expect(mocks.updateElectronApp).not.toHaveBeenCalled();
+    ).toBeNull();
+    expect(mocks.autoUpdater.setFeedURL).not.toHaveBeenCalled();
+    expect(mocks.autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+    expect(mocks.setInterval).not.toHaveBeenCalled();
   });
 
   it("selects the isolated Okou update feed for an Okou identity", () => {
@@ -235,30 +244,28 @@ describe("desktop auto-updates", () => {
         getComputerUseHostState: () => OFFLINE_COMPUTER_USE_HOST_STATE,
         prepareForQuitAndInstall: vi.fn(async () => {}),
       }),
-    ).toBe(true);
-    expect(mocks.updateElectronApp).toHaveBeenCalledWith(
-      expect.objectContaining({
-        updateSource: expect.objectContaining({
-          baseUrl:
-            "https://api.okou.ai/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64",
-        }),
-      }),
-    );
+    ).not.toBeNull();
+    expect(mocks.autoUpdater.setFeedURL).toHaveBeenCalledExactlyOnceWith({
+      url: "https://api.okou.ai/api/desktop/updates/ai-okou-desktop/stable/darwin/arm64/RELEASES.json",
+      serverType: "json",
+    });
   });
 
-  it("checks for updates on request", () => {
-    expect(checkForDesktopUpdates("Zero Computer Use")).toBe(true);
+  it("coalesces a manual request with the startup check", async () => {
+    const { autoUpdates } = installAndCaptureAutoUpdates(
+      () => OFFLINE_COMPUTER_USE_HOST_STATE,
+    );
+
+    expect(autoUpdates.checkForUpdates("Zero Computer Use")).toBe(true);
 
     expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows when requested update checks find no update", async () => {
-    expect(checkForDesktopUpdates("Zero Computer Use")).toBe(true);
+    expectActiveUpdateCheckListenerCount(1);
 
     emitAutoUpdaterEvent("update-not-available");
-    await flushDownloadedUpdateCallback();
+    await flushAsyncCallbacks();
 
-    expect(mocks.dialog.showMessageBox).toHaveBeenCalledWith(
+    expectActiveUpdateCheckListenerCount(0);
+    expect(mocks.dialog.showMessageBox).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
         title: "No Updates Available",
         message: "Zero Computer Use is up to date.",
@@ -266,23 +273,93 @@ describe("desktop auto-updates", () => {
     );
   });
 
-  it("shows when requested update checks fail", async () => {
-    const error = new Error("feed unavailable");
+  it("coalesces a manual request with a scheduled check", async () => {
+    const { autoUpdates } = installAndCaptureAutoUpdates(
+      () => OFFLINE_COMPUTER_USE_HOST_STATE,
+    );
+    emitAutoUpdaterEvent("update-available");
+
+    runScheduledUpdateCheck();
+    expect(autoUpdates.checkForUpdates("Zero Computer Use")).toBe(true);
+
+    expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+    expectActiveUpdateCheckListenerCount(1);
+
+    emitAutoUpdaterEvent("update-not-available");
+    await flushAsyncCallbacks();
+
+    expect(mocks.dialog.showMessageBox).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces rapid manual requests into one check and one result", async () => {
+    const { autoUpdates } = installAndCaptureAutoUpdates(
+      () => OFFLINE_COMPUTER_USE_HOST_STATE,
+    );
+    emitAutoUpdaterEvent("update-available");
+
+    expect(autoUpdates.checkForUpdates("Zero Computer Use")).toBe(true);
+    expect(autoUpdates.checkForUpdates("Zero Computer Use")).toBe(true);
+    expect(autoUpdates.checkForUpdates("Zero Computer Use")).toBe(true);
+
+    expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+    expectActiveUpdateCheckListenerCount(1);
+
+    emitAutoUpdaterEvent("update-not-available");
+    await flushAsyncCallbacks();
+
+    expectActiveUpdateCheckListenerCount(0);
+    expect(mocks.dialog.showMessageBox).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { eventName: "update-available", args: [] },
+    { eventName: "update-not-available", args: [] },
+    { eventName: "error", args: [new Error("feed unavailable")] },
+  ])(
+    "releases state and listeners after $eventName so another manual check can start",
+    async ({ eventName, args }) => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const { autoUpdates } = installAndCaptureAutoUpdates(
+        () => OFFLINE_COMPUTER_USE_HOST_STATE,
+      );
+      emitAutoUpdaterEvent("update-available");
+
+      expect(autoUpdates.checkForUpdates("Zero Computer Use")).toBe(true);
+      expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(2);
+
+      emitAutoUpdaterEvent(eventName, ...args);
+      await flushAsyncCallbacks();
+
+      expectActiveUpdateCheckListenerCount(0);
+      expect(autoUpdates.checkForUpdates("Zero Computer Use")).toBe(true);
+      expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(3);
+      expectActiveUpdateCheckListenerCount(1);
+
+      consoleError.mockRestore();
+    },
+  );
+
+  it("shows genuine errors from a requested check", async () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
-    mocks.autoUpdater.checkForUpdates.mockImplementationOnce(() => {
-      throw error;
-    });
+    const { autoUpdates } = installAndCaptureAutoUpdates(
+      () => OFFLINE_COMPUTER_USE_HOST_STATE,
+    );
+    emitAutoUpdaterEvent("update-available");
 
-    expect(checkForDesktopUpdates("Zero Computer Use")).toBe(false);
-    await flushDownloadedUpdateCallback();
+    expect(autoUpdates.checkForUpdates("Zero Computer Use")).toBe(true);
+    const error = new Error("feed unavailable");
+    emitAutoUpdaterEvent("error", error);
+    await flushAsyncCallbacks();
 
     expect(consoleError).toHaveBeenCalledWith(
       "Desktop update check failed",
       error,
     );
-    expect(mocks.dialog.showMessageBox).toHaveBeenCalledWith(
+    expect(mocks.dialog.showMessageBox).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
         title: "Unable to Check for Updates",
         message: "Zero Computer Use could not check for updates.",
@@ -293,15 +370,59 @@ describe("desktop auto-updates", () => {
     consoleError.mockRestore();
   });
 
-  it("defers without prompting during recent command activity", async () => {
-    const { updateOptions, prepareForQuitAndInstall } =
-      installAndCaptureUpdateOptions(() => ({
-        ...OFFLINE_COMPUTER_USE_HOST_STATE,
-        lastCommandAt: new Date().toISOString(),
-      }));
+  it("cleans up and reports a synchronous requested-check failure", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { autoUpdates } = installAndCaptureAutoUpdates(
+      () => OFFLINE_COMPUTER_USE_HOST_STATE,
+    );
+    emitAutoUpdaterEvent("update-available");
+    const error = new Error("feed unavailable");
+    mocks.autoUpdater.checkForUpdates.mockImplementationOnce(() => {
+      throw error;
+    });
 
-    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
-    await flushDownloadedUpdateCallback();
+    expect(autoUpdates.checkForUpdates("Zero Computer Use")).toBe(false);
+    await flushAsyncCallbacks();
+
+    expectActiveUpdateCheckListenerCount(0);
+    expect(mocks.dialog.showMessageBox).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        title: "Unable to Check for Updates",
+        detail: "feed unavailable",
+      }),
+    );
+    expect(autoUpdates.checkForUpdates("Zero Computer Use")).toBe(true);
+    expect(mocks.autoUpdater.checkForUpdates).toHaveBeenCalledTimes(3);
+
+    consoleError.mockRestore();
+  });
+
+  it("silently restarts after a downloaded update when Computer Use is offline", async () => {
+    const { prepareForQuitAndInstall } = installAndCaptureAutoUpdates(
+      () => OFFLINE_COMPUTER_USE_HOST_STATE,
+    );
+
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-downloaded");
+
+    await vi.waitFor(() => {
+      expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
+      expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("defers without prompting during recent command activity", async () => {
+    const { prepareForQuitAndInstall } = installAndCaptureAutoUpdates(() => ({
+      ...OFFLINE_COMPUTER_USE_HOST_STATE,
+      lastCommandAt: new Date().toISOString(),
+    }));
+
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-downloaded");
+    await flushAsyncCallbacks();
 
     expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
     expect(prepareForQuitAndInstall).not.toHaveBeenCalled();
@@ -313,13 +434,16 @@ describe("desktop auto-updates", () => {
       ...OFFLINE_COMPUTER_USE_HOST_STATE,
       lastCommandAt: new Date().toISOString(),
     };
-    const { updateOptions, prepareForQuitAndInstall } =
-      installAndCaptureUpdateOptions(() => hostState);
+    const { prepareForQuitAndInstall } = installAndCaptureAutoUpdates(
+      () => hostState,
+    );
 
-    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
-    await flushDownloadedUpdateCallback();
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-downloaded");
+    await flushAsyncCallbacks();
 
     hostState = OFFLINE_COMPUTER_USE_HOST_STATE;
+    runScheduledUpdateCheck();
     emitAutoUpdaterEvent("checking-for-update");
 
     await vi.waitFor(() => {
@@ -329,23 +453,32 @@ describe("desktop auto-updates", () => {
     expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
   });
 
-  it("keeps a downloaded update pending across active checks", async () => {
+  it("keeps a downloaded update pending across active scheduled checks", async () => {
     let hostState: ComputerUseHostRuntimeState = {
       ...OFFLINE_COMPUTER_USE_HOST_STATE,
       lastCommandAt: new Date().toISOString(),
     };
-    const { updateOptions, prepareForQuitAndInstall } =
-      installAndCaptureUpdateOptions(() => hostState);
+    const { prepareForQuitAndInstall } = installAndCaptureAutoUpdates(
+      () => hostState,
+    );
 
-    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-downloaded");
+    await flushAsyncCallbacks();
+
+    runScheduledUpdateCheck();
     emitAutoUpdaterEvent("checking-for-update");
+    emitAutoUpdaterEvent("update-not-available");
+    runScheduledUpdateCheck();
     emitAutoUpdaterEvent("checking-for-update");
-    await flushDownloadedUpdateCallback();
+    emitAutoUpdaterEvent("update-not-available");
+    await flushAsyncCallbacks();
 
     expect(prepareForQuitAndInstall).not.toHaveBeenCalled();
     expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
 
     hostState = OFFLINE_COMPUTER_USE_HOST_STATE;
+    runScheduledUpdateCheck();
     emitAutoUpdaterEvent("checking-for-update");
 
     await vi.waitFor(() => {
@@ -357,16 +490,16 @@ describe("desktop auto-updates", () => {
   it("defers when Computer Use activity inspection fails", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     let inspectionFails = true;
-    const { updateOptions, prepareForQuitAndInstall } =
-      installAndCaptureUpdateOptions(() => {
-        if (inspectionFails) {
-          throw new Error("state unavailable");
-        }
-        return OFFLINE_COMPUTER_USE_HOST_STATE;
-      });
+    const { prepareForQuitAndInstall } = installAndCaptureAutoUpdates(() => {
+      if (inspectionFails) {
+        throw new Error("state unavailable");
+      }
+      return OFFLINE_COMPUTER_USE_HOST_STATE;
+    });
 
-    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
-    await flushDownloadedUpdateCallback();
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-downloaded");
+    await flushAsyncCallbacks();
 
     expect(warn).toHaveBeenCalledWith(
       "Unable to inspect Computer Use activity for update",
@@ -377,6 +510,7 @@ describe("desktop auto-updates", () => {
     expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
 
     inspectionFails = false;
+    runScheduledUpdateCheck();
     emitAutoUpdaterEvent("checking-for-update");
 
     await vi.waitFor(() => {
@@ -388,8 +522,9 @@ describe("desktop auto-updates", () => {
   });
 
   it("starts only one install while an update restart is in progress", async () => {
-    const { updateOptions, prepareForQuitAndInstall } =
-      installAndCaptureUpdateOptions(() => OFFLINE_COMPUTER_USE_HOST_STATE);
+    const { prepareForQuitAndInstall } = installAndCaptureAutoUpdates(
+      () => OFFLINE_COMPUTER_USE_HOST_STATE,
+    );
     let finishPreparation: (() => void) | undefined;
     prepareForQuitAndInstall.mockImplementationOnce(
       () =>
@@ -398,14 +533,16 @@ describe("desktop auto-updates", () => {
         }),
     );
 
-    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-downloaded");
     await vi.waitFor(() => {
       expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
     });
 
+    runScheduledUpdateCheck();
     emitAutoUpdaterEvent("checking-for-update");
-    updateOptions.onNotifyUser({ releaseName: "Zero 1.2.3" });
-    await flushDownloadedUpdateCallback();
+    emitAutoUpdaterEvent("update-downloaded");
+    await flushAsyncCallbacks();
 
     expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
     expect(mocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
@@ -416,7 +553,7 @@ describe("desktop auto-updates", () => {
     });
 
     emitAutoUpdaterEvent("checking-for-update");
-    await flushDownloadedUpdateCallback();
+    await flushAsyncCallbacks();
     expect(prepareForQuitAndInstall).toHaveBeenCalledTimes(1);
     expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
   });

--- a/turbo/apps/desktop/src/desktop-auto-updates.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.ts
@@ -1,13 +1,16 @@
+import { setInterval } from "node:timers";
 import { app, autoUpdater, dialog } from "electron";
-import { UpdateSourceType, updateElectronApp } from "update-electron-app";
 
 import type { DesktopConfig } from "./config";
 import { shouldDeferDesktopUpdate } from "./desktop-auto-update-policy";
+import type { DesktopAutoUpdatesController } from "./desktop-main-module";
 import {
   desktopUpdateFeedBaseUrl,
   shouldInstallDesktopAutoUpdates,
 } from "./desktop-update-feed";
 import type { ComputerUseHostRuntimeState } from "./computer-use-types";
+
+const DESKTOP_UPDATE_INTERVAL_MS = 30 * 60 * 1000;
 
 interface DesktopAutoUpdateOptions {
   readonly config: DesktopConfig;
@@ -37,7 +40,6 @@ async function notifyDesktopUpdateCheckFailed(
   displayName: string,
   error: unknown,
 ): Promise<void> {
-  console.error("Desktop update check failed", error);
   await dialog.showMessageBox({
     type: "error",
     buttons: ["OK"],
@@ -59,9 +61,108 @@ function shouldDeferDownloadedUpdate(
   }
 }
 
+type DesktopUpdateCheckOutcome =
+  | { readonly type: "update-available" }
+  | { readonly type: "update-not-available" }
+  | { readonly type: "error"; readonly error: unknown };
+
+interface ActiveDesktopUpdateCheck {
+  manualDisplayName?: string;
+}
+
+function createDesktopUpdateCheckCoordinator(): (
+  manualDisplayName?: string,
+) => boolean {
+  let activeCheck: ActiveDesktopUpdateCheck | undefined;
+
+  autoUpdater.on("error", (error) => {
+    if (!activeCheck) {
+      console.error("Desktop auto-updater error", error);
+    }
+  });
+
+  const requestUpdateCheck = (manualDisplayName?: string): boolean => {
+    if (activeCheck) {
+      if (
+        manualDisplayName !== undefined &&
+        activeCheck.manualDisplayName === undefined
+      ) {
+        activeCheck.manualDisplayName = manualDisplayName;
+      }
+      return true;
+    }
+
+    const check: ActiveDesktopUpdateCheck = { manualDisplayName };
+    activeCheck = check;
+
+    const handleNoUpdate = (): void => {
+      complete({ type: "update-not-available" });
+    };
+    const handleUpdateAvailable = (): void => {
+      complete({ type: "update-available" });
+    };
+    const handleError = (error: Error): void => {
+      complete({ type: "error", error });
+    };
+
+    function cleanup(): void {
+      autoUpdater.removeListener("update-not-available", handleNoUpdate);
+      autoUpdater.removeListener("update-available", handleUpdateAvailable);
+      autoUpdater.removeListener("error", handleError);
+    }
+
+    function complete(outcome: DesktopUpdateCheckOutcome): void {
+      if (activeCheck !== check) {
+        return;
+      }
+
+      cleanup();
+      activeCheck = undefined;
+
+      if (outcome.type === "error") {
+        console.error("Desktop update check failed", outcome.error);
+        if (check.manualDisplayName !== undefined) {
+          void notifyDesktopUpdateCheckFailed(
+            check.manualDisplayName,
+            outcome.error,
+          ).catch((dialogError) => {
+            console.error("Desktop update failure dialog failed", dialogError);
+          });
+        }
+        return;
+      }
+
+      if (
+        outcome.type === "update-not-available" &&
+        check.manualDisplayName !== undefined
+      ) {
+        void notifyNoDesktopUpdatesFound(check.manualDisplayName).catch(
+          (error) => {
+            console.error("Desktop update status dialog failed", error);
+          },
+        );
+      }
+    }
+
+    autoUpdater.once("update-not-available", handleNoUpdate);
+    autoUpdater.once("update-available", handleUpdateAvailable);
+    autoUpdater.once("error", handleError);
+
+    try {
+      autoUpdater.checkForUpdates();
+      return true;
+    } catch (error) {
+      complete({ type: "error", error });
+      return false;
+    }
+  };
+
+  return requestUpdateCheck;
+}
+
 export function installDesktopAutoUpdates(
   options: DesktopAutoUpdateOptions,
-): boolean {
+): DesktopAutoUpdatesController | null {
   if (
     !shouldInstallDesktopAutoUpdates({
       environment: options.config.environment,
@@ -70,7 +171,7 @@ export function installDesktopAutoUpdates(
       arch: process.arch,
     })
   ) {
-    return false;
+    return null;
   }
 
   const baseUrl = desktopUpdateFeedBaseUrl(
@@ -79,7 +180,7 @@ export function installDesktopAutoUpdates(
   );
   if (new URL(baseUrl).protocol !== "https:") {
     console.warn("Desktop auto-updates require an HTTPS feed URL");
-    return false;
+    return null;
   }
 
   let downloadedUpdatePending = false;
@@ -110,61 +211,21 @@ export function installDesktopAutoUpdates(
   };
 
   autoUpdater.on("checking-for-update", tryInstallPendingUpdate);
-
-  updateElectronApp({
-    updateSource: {
-      type: UpdateSourceType.StaticStorage,
-      baseUrl,
-    },
-    updateInterval: "30 minutes",
-    notifyUser: true,
-    onNotifyUser: () => {
-      downloadedUpdatePending = true;
-      tryInstallPendingUpdate();
-    },
+  autoUpdater.on("update-downloaded", () => {
+    downloadedUpdatePending = true;
+    tryInstallPendingUpdate();
   });
-  return true;
-}
 
-export function checkForDesktopUpdates(displayName: string): boolean {
-  const handleNoUpdate = (): void => {
-    cleanup();
-    void notifyNoDesktopUpdatesFound(displayName).catch((error) => {
-      console.error("Desktop update status dialog failed", error);
-    });
+  autoUpdater.setFeedURL({
+    url: `${baseUrl}/RELEASES.json`,
+    serverType: "json",
+  });
+
+  const requestUpdateCheck = createDesktopUpdateCheckCoordinator();
+  requestUpdateCheck();
+  setInterval(requestUpdateCheck, DESKTOP_UPDATE_INTERVAL_MS);
+
+  return {
+    checkForUpdates: (displayName) => requestUpdateCheck(displayName),
   };
-  const handleUpdateAvailable = (): void => {
-    cleanup();
-  };
-  const handleError = (error: Error): void => {
-    cleanup();
-    void notifyDesktopUpdateCheckFailed(displayName, error).catch(
-      (dialogError) => {
-        console.error("Desktop update failure dialog failed", dialogError);
-      },
-    );
-  };
-
-  function cleanup(): void {
-    autoUpdater.removeListener("update-not-available", handleNoUpdate);
-    autoUpdater.removeListener("update-available", handleUpdateAvailable);
-    autoUpdater.removeListener("error", handleError);
-  }
-
-  autoUpdater.once("update-not-available", handleNoUpdate);
-  autoUpdater.once("update-available", handleUpdateAvailable);
-  autoUpdater.once("error", handleError);
-
-  try {
-    autoUpdater.checkForUpdates();
-    return true;
-  } catch (error) {
-    cleanup();
-    void notifyDesktopUpdateCheckFailed(displayName, error).catch(
-      (dialogError) => {
-        console.error("Desktop update failure dialog failed", dialogError);
-      },
-    );
-    return false;
-  }
 }

--- a/turbo/apps/desktop/src/desktop-main-module.ts
+++ b/turbo/apps/desktop/src/desktop-main-module.ts
@@ -9,7 +9,13 @@ export interface DesktopUpdateHooks {
   readonly prepareForQuitAndInstall: () => Promise<void>;
 }
 
+export interface DesktopAutoUpdatesController {
+  readonly checkForUpdates: (displayName: string) => boolean;
+}
+
 export interface DesktopMainModule {
   readonly desktopUpdateHooks: () => DesktopUpdateHooks;
-  readonly notifyDesktopAutoUpdatesInstalled: (installed: boolean) => void;
+  readonly notifyDesktopAutoUpdatesInstalled: (
+    autoUpdates: DesktopAutoUpdatesController | null,
+  ) => void;
 }

--- a/turbo/apps/desktop/src/desktop-update-feed.test.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.test.ts
@@ -58,7 +58,7 @@ describe("desktop update feed", () => {
     ).toBe(false);
   });
 
-  it("builds the static feed base URL used by update-electron-app", () => {
+  it("builds the static Squirrel.Mac feed base URL", () => {
     expect(desktopUpdateFeedBaseUrl("https://api.vm0.ai", "zero")).toBe(
       "https://api.vm0.ai/api/desktop/updates/zero/stable/darwin/arm64",
     );

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -76,9 +76,11 @@ import {
 } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
 import desktopBrandAssets from "./desktop-brand-assets.json";
-import { checkForDesktopUpdates } from "./desktop-auto-updates";
 import { createDesktopClientHeaderInjector } from "./desktop-client-headers";
-import type { DesktopMainModule } from "./desktop-main-module";
+import type {
+  DesktopAutoUpdatesController,
+  DesktopMainModule,
+} from "./desktop-main-module";
 import { DesktopComputerUseAutoStartSupervisor } from "./desktop-computer-use-autostart";
 import { createDesktopComputerUseHostRuntime } from "./desktop-computer-use-api";
 import { readOrCreateComputerUseInstallationId } from "./desktop-computer-use-installation";
@@ -180,7 +182,7 @@ ipcMain.on(DESKTOP_IDENTITY_CHANNEL, (event) => {
 });
 let filesystemPluginManager: DesktopFilesystemPluginManager | null = null;
 let mcpPluginManager: DesktopMcpPluginManager | null = null;
-let desktopAutoUpdatesInstalled = false;
+let desktopAutoUpdates: DesktopAutoUpdatesController | null = null;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 const computerUseSnapshotStore = new ComputerUseSnapshotStore();
 const computerUseNativeBackend = createComputerUseNativeBackend({
@@ -993,8 +995,8 @@ export const desktopUpdateHooks: DesktopMainModule["desktopUpdateHooks"] =
   });
 
 export const notifyDesktopAutoUpdatesInstalled: DesktopMainModule["notifyDesktopAutoUpdatesInstalled"] =
-  (installed) => {
-    desktopAutoUpdatesInstalled = installed;
+  (autoUpdates) => {
+    desktopAutoUpdates = autoUpdates;
     applyApplicationMenu();
   };
 
@@ -1092,11 +1094,11 @@ function requestDesktopQuit(): void {
 }
 
 function requestDesktopUpdateCheck(): void {
-  if (!desktopAutoUpdatesInstalled) {
+  if (!desktopAutoUpdates) {
     return;
   }
 
-  checkForDesktopUpdates(config.identity.displayName);
+  desktopAutoUpdates.checkForUpdates(config.identity.displayName);
 }
 
 function applyApplicationMenu(): void {
@@ -1104,7 +1106,7 @@ function applyApplicationMenu(): void {
     { role: "about" },
     {
       label: "Check for Updates...",
-      enabled: desktopAutoUpdatesInstalled,
+      enabled: desktopAutoUpdates !== null,
       click: requestDesktopUpdateCheck,
     },
     { type: "separator" },

--- a/turbo/apps/desktop/tsup.electron.config.js
+++ b/turbo/apps/desktop/tsup.electron.config.js
@@ -15,7 +15,6 @@ module.exports = defineConfig({
   // runtime instead of inlining it, which would defeat its crash isolation.
   external: ["electron", "./main.js"],
   noExternal: [
-    "update-electron-app",
     "@sentry/electron",
     /^@okouai\//,
     /^@modelcontextprotocol\/sdk\//,

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -500,9 +500,6 @@ importers:
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
-      update-electron-app:
-        specifier: 3.2.0
-        version: 3.2.0
     devDependencies:
       '@electron-forge/cli':
         specifier: 7.11.2
@@ -6607,9 +6604,6 @@ packages:
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
-  github-url-to-object@4.0.6:
-    resolution: {integrity: sha512-NaqbYHMUAlPcmWFdrAB7bcxrNIiiJWJe8s/2+iOc9vlcHlwHqSGrPk+Yi3nu6ebTwgsZEa7igz+NH2vEq3gYwQ==}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -7107,9 +7101,6 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
-
-  is-url@1.2.4:
-    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -9388,9 +9379,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  update-electron-app@3.2.0:
-    resolution: {integrity: sha512-l2e7bzsW+rw70pfyyQeA9E/ofpNY2ZS99XuYxD2qWL4fEy3qMjpqwwgB0me7ESpGogIQE1CM0SaDvKGsK4Jg3Q==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -15290,10 +15278,6 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
-  github-url-to-object@4.0.6:
-    dependencies:
-      is-url: 1.2.4
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -15882,8 +15866,6 @@ snapshots:
   is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@2.1.0: {}
-
-  is-url@1.2.4: {}
 
   is-weakmap@2.0.2: {}
 
@@ -18538,11 +18520,6 @@ snapshots:
       browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  update-electron-app@3.2.0:
-    dependencies:
-      github-url-to-object: 4.0.6
-      ms: 2.1.3
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

- replace dependency-owned update scheduling with Desktop-owned Squirrel.Mac feed setup, startup checking, and the existing 30-minute cadence
- route startup, scheduled, and manual checks through one bootstrap-owned single-flight coordinator, with manual requests joining the active result
- preserve manual no-update/error dialogs, background downloads, Computer Use install deferral, and quit/install single-flight behavior
- remove the unused `update-electron-app` dependency after taking ownership of its updater responsibilities

## Ownership proof

- `desktop-auto-updates.ts` contains the only remaining `autoUpdater.checkForUpdates()` call
- the same `requestUpdateCheck` closure starts the initial check, is registered as the interval callback, and backs the controller passed across the bootstrap-to-main bundle contract
- overlapping requests reuse the active check without adding another underlying call or another terminal-listener set
- `update-available`, `update-not-available`, `error`, and synchronous failures release the active state and remove all three per-check listeners before another check can start

## Validation

- `pnpm exec prettier --check` on all changed files
- `pnpm -F @okouai/desktop lint`
- `pnpm -F @okouai/desktop check-types`
- `pnpm -F @okouai/desktop exec vitest run src/desktop-auto-updates.test.ts src/bootstrap-degraded.test.ts src/bootstrap-imports.test.ts src/desktop-update-feed.test.ts src/bootstrap.test.ts` (5 files, 27 tests)
- `pnpm -F @okouai/desktop build:electron` (including bootstrap bundle guard)
- `pnpm knip --workspace @okouai/desktop`

Repository-wide checks are left to the PR pipeline as required.

Fixes #32079
