### PR TITLE
docs(rust): update stale guest-agent cli entrypoint references

### DIFF
--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -267,9 +267,10 @@ pub struct ActiveInputController {
 
 /// Single-consumer CLI follow-up side of active input for one guest-agent run.
 ///
-/// `execute_cli_with_active_input` consumes this writer for the lifetime of one
-/// CLI execution. It yields accepted follow-up input frames and observes the
-/// same terminal close signal as the paired [`ActiveInputController`].
+/// [`crate::cli::execute_cli_with_active_input_for_config`] consumes this writer
+/// for the lifetime of one CLI execution. It yields accepted follow-up input
+/// frames and observes the same terminal close signal as the paired
+/// [`ActiveInputController`].
 #[derive(Debug)]
 pub struct ActiveInputWriter {
     controller: ActiveInputController,

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -1,7 +1,7 @@
 //! Claude Code command construction.
 //!
 //! This module owns argv shape and mock binary selection. Runtime process
-//! spawning stays in `execute_cli`.
+//! spawning stays in the shared CLI execution path.
 
 use guest_common::log_info;
 

--- a/crates/guest-agent/src/cli/diagnostics.rs
+++ b/crates/guest-agent/src/cli/diagnostics.rs
@@ -1,7 +1,7 @@
 //! Raw CLI stderr diagnostic tail collection.
 //!
 //! This module keeps stderr collection bounded and intentionally leaves final
-//! secret masking to the `execute_cli` caller.
+//! secret masking to the shared CLI execution path.
 
 use guest_contracts::cli_stderr_diagnostics::{
     CLI_STDERR_OMITTED_LONG_LINE, CLI_STDERR_RESULT_MAX_LINE_BYTES, CLI_STDERR_RESULT_MAX_LINES,

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -13,10 +13,11 @@
 //! - `jsonl_result`: shared terminal result parsing for JSONL CLI backends.
 //! - `termination`: process-group termination FSM.
 //!
-//! `execute_cli` owns the shared Claude Code/Pi JSONL subprocess orchestration,
-//! while `codex_app_server_backend` owns the Codex JSON-RPC lifecycle. Each path
-//! retains ownership of its process, event delivery, heartbeat races, and child
-//! reaping until completion.
+//! [`execute_cli_with_controls_for_config_started_at`] enters the shared Claude
+//! Code/Pi JSONL subprocess orchestration implemented by the private
+//! `execute_cli_inner`, while `codex_app_server_backend` owns the Codex JSON-RPC
+//! lifecycle. Each path retains ownership of its process, event delivery,
+//! heartbeat races, and child reaping until completion.
 
 mod child_env;
 mod child_exit_notifier;
@@ -303,9 +304,10 @@ pub enum HeartbeatStatus {
 
     /// The heartbeat task itself failed, such as a task panic or join error.
     ///
-    /// `execute_cli` surfaces this as a guest-agent execution error and may
-    /// terminate the CLI process group if no earlier control-path termination
-    /// is already in progress.
+    /// The shared [`execute_cli_with_controls_for_config_started_at`] execution
+    /// path surfaces this as a guest-agent execution error and may terminate
+    /// the CLI process group if no earlier control-path termination is already
+    /// in progress.
     TaskFailed(String),
 }
 

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -1,9 +1,9 @@
 //! CLI process-group termination state machine.
 //!
-//! `execute_cli` owns the select-loop orchestration and decides when external
-//! events happen. This module owns the termination policy state transitions,
-//! process-group signal side effects, diagnostics, and post-result cleanup
-//! deadlines for those events.
+//! The shared CLI execution path owns the select-loop orchestration and decides
+//! when external events happen. This module owns the termination policy state
+//! transitions, process-group signal side effects, diagnostics, and post-result
+//! cleanup deadlines for those events.
 
 use super::process_group::ChildProcessGroup;
 use crate::error::AgentError;
@@ -105,7 +105,7 @@ impl TerminationState {
     /// event. Only the initial Idle -> SigtermPending transition should
     /// fire -- later events (or a result that races a CLI exit) must
     /// not re-arm. Single source of truth consumed by both the
-    /// production guard in `execute_cli` and the FSM unit tests.
+    /// production guard in the shared CLI select loop and the FSM unit tests.
     fn should_arm_post_result(self, cli_exited: bool) -> bool {
         matches!(self, TerminationState::Idle) && !cli_exited
     }


### PR DESCRIPTION
## Summary

- Replace stale `execute_cli` and `execute_cli_with_active_input` documentation references with the current guest-agent execution boundaries.
- Preserve the Claude Code/Pi shared JSONL versus Codex app-server ownership split.
- Add intra-doc links for the current public execution and active-input entrypoints.

## Scope

This PR changes documentation comments only in five `crates/guest-agent/src` Rust files. It does
not change runtime behavior, public signatures, tests, migrations, persisted data, compatibility
paths, or deployment configuration.

Closes #32075

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent --profile local --no-deps`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent --lib --quiet` (651 passed)
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p guest-agent --all-targets --quiet -- -D warnings`
- Exact-symbol search confirms neither removed entrypoint name remains under `crates/guest-agent/src`.
