### PR TITLE
perf(mitm-addon): bulk-validate discarded utf-8 strings

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -51,9 +51,23 @@ _INTERNAL_PATH_MARKERS = frozenset(
     )
 )
 _JSON_CONTROL_CHAR_MAX = 0x20
-# These are the only bytes that can change discarded string state. Non-ASCII
-# bytes stay on the bytewise path so UTF-8 validation remains unchanged.
+# These are the only bytes that can change discarded string state while
+# scanning an ordinary ASCII prefix.
 _DISCARDED_STRING_STATE_BYTE_RE = re.compile(rb'[\x00-\x1f"\\\x80-\xff]')
+# Possessive repetition validates discarded raw UTF-8 without retaining the
+# matched span or backtracking over it.
+_DISCARDED_STRING_UTF8_SPAN_RE = re.compile(
+    rb"(?:"
+    rb"[\x20-\x21\x23-\x5b\x5d-\x7f]"
+    rb"|[\xc2-\xdf][\x80-\xbf]"
+    rb"|\xe0[\xa0-\xbf][\x80-\xbf]"
+    rb"|[\xe1-\xec\xee-\xef][\x80-\xbf]{2}"
+    rb"|\xed[\x80-\x9f][\x80-\xbf]"
+    rb"|\xf0[\x90-\xbf][\x80-\xbf]{2}"
+    rb"|[\xf1-\xf3][\x80-\xbf]{3}"
+    rb"|\xf4[\x80-\x8f][\x80-\xbf]{2}"
+    rb")*+"
+)
 _UTF8_ONE_BYTE_MAX = 0x80
 _UTF8_CONT_MIN = 0x80
 _UTF8_CONT_MAX = 0xBF
@@ -71,7 +85,7 @@ _UTF8_SURROGATE_MIN = 0xD800
 _UTF8_SURROGATE_MAX = 0xDFFF
 _DEFAULT_MAX_DEPTH = 256
 _SLOW_SCALAR_BYTES_PER_WORK_UNIT = 32
-_DISCARDED_ASCII_BYTES_PER_WORK_UNIT = 64 * 1024
+_DISCARDED_STRING_BULK_BYTES_PER_WORK_UNIT = 64 * 1024
 JSON_WORK_LIMIT_EXCEEDED = "work limit exceeded"
 JSON_INTEGER_VALUE_LIMIT_EXCEEDED = "integer value limit exceeded"
 _JSON_STRING_OR_CONTAINER_RE = re.compile(rb'"(?:\\.|[^"\\])*"|[{}\[\]]', re.DOTALL)
@@ -372,7 +386,7 @@ class JsonSelectiveExtractor:
         self._literal: _LiteralState | None = None
         self._work_units_used = 0
         self._slow_work_bytes_remaining = 0
-        self._discarded_ascii_work_bytes_remaining = 0
+        self._discarded_string_bulk_work_bytes_remaining = 0
 
     def reset(self) -> None:
         """Reset document state while retaining the fixed observation configuration."""
@@ -393,7 +407,7 @@ class JsonSelectiveExtractor:
         self._literal = None
         self._work_units_used = 0
         self._slow_work_bytes_remaining = 0
-        self._discarded_ascii_work_bytes_remaining = 0
+        self._discarded_string_bulk_work_bytes_remaining = 0
 
     def accepts_more_input(self) -> bool:
         """Return whether later bytes can still affect this document parser.
@@ -797,18 +811,47 @@ class JsonSelectiveExtractor:
             return i
         work_limited = self.max_work_units is not None
         if _can_bulk_skip_discarded_string_byte(state, chunk[i]):
-            end = self._discarded_ascii_work_span_end(len(chunk), i) if work_limited else len(chunk)
+            end = (
+                self._discarded_string_bulk_work_span_end(len(chunk), i)
+                if work_limited
+                else len(chunk)
+            )
             if self._error:
                 return i
             match = _DISCARDED_STRING_STATE_BYTE_RE.search(chunk, i, end)
             if match is None:
                 if work_limited:
-                    self._discarded_ascii_work_bytes_remaining -= end - i
+                    self._discarded_string_bulk_work_bytes_remaining -= end - i
                 return end
             skipped = match.start() - i
             if work_limited:
-                self._discarded_ascii_work_bytes_remaining -= skipped
+                self._discarded_string_bulk_work_bytes_remaining -= skipped
             return i + skipped
+
+        if _can_bulk_validate_discarded_utf8(state, chunk[i]):
+            end = (
+                self._discarded_string_bulk_work_span_end(len(chunk), i)
+                if work_limited
+                else len(chunk)
+            )
+            if self._error:
+                return i
+            match = _DISCARDED_STRING_UTF8_SPAN_RE.match(chunk, i, end)
+            match_end = match.end() if match is not None else i
+            if match_end > i:
+                if work_limited:
+                    self._discarded_string_bulk_work_bytes_remaining -= match_end - i
+                return match_end
+
+        if _is_discarded_raw_utf8_byte(state, chunk[i]):
+            if work_limited:
+                self._discarded_string_bulk_work_span_end(len(chunk), i)
+                if self._error:
+                    return i
+            self._accept_string_byte(state, chunk[i])
+            if work_limited:
+                self._discarded_string_bulk_work_bytes_remaining -= 1
+            return i + 1
 
         end = self._slow_work_span_end(len(chunk), i) if work_limited else len(chunk)
         if self._error:
@@ -1142,14 +1185,16 @@ class JsonSelectiveExtractor:
             self._slow_work_bytes_remaining = _SLOW_SCALAR_BYTES_PER_WORK_UNIT
         return min(chunk_len, i + self._slow_work_bytes_remaining)
 
-    def _discarded_ascii_work_span_end(self, chunk_len: int, i: int) -> int:
+    def _discarded_string_bulk_work_span_end(self, chunk_len: int, i: int) -> int:
         if self.max_work_units is None:
             return chunk_len
-        if self._discarded_ascii_work_bytes_remaining == 0:
+        if self._discarded_string_bulk_work_bytes_remaining == 0:
             if not self._consume_work_unit():
                 return i
-            self._discarded_ascii_work_bytes_remaining = _DISCARDED_ASCII_BYTES_PER_WORK_UNIT
-        return min(chunk_len, i + self._discarded_ascii_work_bytes_remaining)
+            self._discarded_string_bulk_work_bytes_remaining = (
+                _DISCARDED_STRING_BULK_BYTES_PER_WORK_UNIT
+            )
+        return min(chunk_len, i + self._discarded_string_bulk_work_bytes_remaining)
 
 
 def _is_hex_byte(b: int) -> bool:
@@ -1183,6 +1228,19 @@ def _can_bulk_skip_discarded_string_byte(state: _StringState, b: int) -> bool:
         and not state.unicode_remaining
         and not state.utf8_remaining
         and _is_discarded_ascii_string_byte(b)
+    )
+
+
+def _can_bulk_validate_discarded_utf8(state: _StringState, b: int) -> bool:
+    return not state.utf8_remaining and _is_discarded_raw_utf8_byte(state, b)
+
+
+def _is_discarded_raw_utf8_byte(state: _StringState, b: int) -> bool:
+    return (
+        state.raw is None
+        and not state.escape
+        and not state.unicode_remaining
+        and b >= _UTF8_ONE_BYTE_MAX
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -747,7 +747,7 @@ class TestAnthropicModelJsonResponseInspector:
             "tokens.output": 100,
         }
 
-    def test_large_discarded_utf8_content_stays_within_work_limit(self):
+    def test_large_discarded_utf8_content_stays_within_work_limit(self) -> None:
         content_bytes = 3 * 1024 * 1024
         body = (
             b'{"id":"msg_bulk","model":"claude-sonnet-4-6",'

--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -747,6 +747,25 @@ class TestAnthropicModelJsonResponseInspector:
             "tokens.output": 100,
         }
 
+    def test_large_discarded_utf8_content_stays_within_work_limit(self):
+        content_bytes = 3 * 1024 * 1024
+        body = (
+            b'{"id":"msg_bulk","model":"claude-sonnet-4-6",'
+            b'"content":[{"type":"text","text":"'
+            + b"\xe2\x98\x83" * (content_bytes // 3)
+            + b'"}],"usage":{"input_tokens":50,"output_tokens":100}}'
+        )
+
+        result, error = _inspect_anthropic_json(body)
+
+        assert error is None
+        assert result == {
+            "message_id": "msg_bulk",
+            "model": "claude-sonnet-4-6",
+            "tokens.input": 50,
+            "tokens.output": 100,
+        }
+
     def test_invalid_json_returns_error(self):
         usage, error = _inspect_anthropic_json(b"not json")
         assert usage is None

--- a/crates/runner/mitm-addon/tests/test_json_selective_strings.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_strings.py
@@ -193,6 +193,45 @@ def test_bulk_skips_large_unselected_string_after_escape_without_storing_value()
     assert bytewise_accept_calls < 64
 
 
+@pytest.mark.parametrize(
+    "unit",
+    [
+        pytest.param(b"\xc3\xa9", id="two-byte"),
+        pytest.param(b"\xe2\x98\x83", id="three-byte"),
+        pytest.param(b"\xf0\x9f\x98\x80", id="four-byte"),
+        pytest.param(b"ascii-\xc3\xa9-\xe2\x98\x83-\xf0\x9f\x98\x80", id="mixed"),
+    ],
+)
+def test_bulk_validates_large_unselected_utf8_without_storing_value(unit):
+    bytewise_accept_calls = 0
+    accept_string_byte_code = JsonSelectiveExtractor._accept_string_byte.__code__
+
+    def count_bytewise_accept_calls(frame: FrameType, event: str, _arg: object) -> None:
+        nonlocal bytewise_accept_calls
+        if event == "call" and frame.f_code is accept_string_byte_code:
+            bytewise_accept_calls += 1
+
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+    large_text = unit * ((2 * 1024 * 1024) // len(unit))
+    payload = b'{"content":[{"text":"' + large_text + b'"}],"usage":{"input_tokens":7}}'
+
+    chunk_size = 64 * 1024
+    previous_profile = sys.getprofile()
+    sys.setprofile(count_bytewise_accept_calls)
+    try:
+        for offset in range(0, len(payload), chunk_size):
+            extractor.feed(payload[offset : offset + chunk_size])
+    finally:
+        sys.setprofile(previous_profile)
+    result = extractor.finish()
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 7}
+    assert bytewise_accept_calls < 256
+
+
 def test_bulk_skip_accepts_empty_unselected_key_and_value():
     extractor = JsonSelectiveExtractor(
         scalar_fields={("usage", "input_tokens"): ScalarField("int")}

--- a/crates/runner/mitm-addon/tests/test_json_selective_strings.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_strings.py
@@ -202,7 +202,7 @@ def test_bulk_skips_large_unselected_string_after_escape_without_storing_value()
         pytest.param(b"ascii-\xc3\xa9-\xe2\x98\x83-\xf0\x9f\x98\x80", id="mixed"),
     ],
 )
-def test_bulk_validates_large_unselected_utf8_without_storing_value(unit):
+def test_bulk_validates_large_unselected_utf8_without_storing_value(unit: bytes) -> None:
     bytewise_accept_calls = 0
     accept_string_byte_code = JsonSelectiveExtractor._accept_string_byte.__code__
 
@@ -291,6 +291,7 @@ def test_bulk_skip_preserves_pending_escape_state_across_chunks(first_suffix, se
     [
         pytest.param(b"\xc3\xa9", 1, id="two-byte-split-1"),
         pytest.param(b"\xe2\x98\x83", 1, id="three-byte-split-1"),
+        pytest.param(b"\xe2\x98\x83", 2, id="three-byte-split-2"),
         pytest.param(b"\xf0\x9f\x98\x80", 1, id="four-byte-split-1"),
         pytest.param(b"\xf0\x9f\x98\x80", 2, id="four-byte-split-2"),
         pytest.param(b"\xf0\x9f\x98\x80", 3, id="four-byte-split-3"),
@@ -323,10 +324,42 @@ def test_rejects_invalid_utf8_in_unselected_string():
 
 
 @pytest.mark.parametrize(
+    "encoded",
+    [
+        pytest.param(b"\xc2\x80", id="minimum-two-byte"),
+        pytest.param(b"\xdf\xbf", id="maximum-two-byte"),
+        pytest.param(b"\xe0\xa0\x80", id="minimum-three-byte"),
+        pytest.param(b"\xed\x9f\xbf", id="before-surrogates"),
+        pytest.param(b"\xee\x80\x80", id="after-surrogates"),
+        pytest.param(b"\xef\xbf\xbf", id="maximum-three-byte"),
+        pytest.param(b"\xf0\x90\x80\x80", id="minimum-four-byte"),
+        pytest.param(b"\xf4\x8f\xbf\xbf", id="maximum-four-byte"),
+    ],
+)
+def test_accepts_canonical_utf8_range_boundaries_in_unselected_string(encoded: bytes) -> None:
+    extractor = JsonSelectiveExtractor(
+        scalar_fields={("usage", "input_tokens"): ScalarField("int")}
+    )
+
+    extractor.feed(b'{"content":"' + encoded + b'","usage":{"input_tokens":9}}')
+    result = extractor.finish()
+
+    assert result.complete is True
+    assert result.values == {("usage", "input_tokens"): 9}
+
+
+@pytest.mark.parametrize(
     ("payload", "error"),
     [
+        (b'{"content":"\x80"}', "invalid string"),
+        (b'{"content":"\xc0\x80"}', "invalid string"),
+        (b'{"content":"\xe0\x80\x80"}', "invalid string"),
         (b'{"content":"\xe2\x98"}', "invalid string"),
         (b'{"content":"\xed\xa0\x80"}', "invalid string"),
+        (b'{"content":"\xf0\x80\x80\x80"}', "invalid string"),
+        (b'{"content":"\xf4\x90\x80\x80"}', "invalid string"),
+        (b'{"content":"\xf5\x80\x80\x80"}', "invalid string"),
+        (b'{"content":"\xe2x"}', "invalid string"),
         (b'{"content":"abc\x01"}', "control character in string"),
         (b'{"content":"\\x"}', "invalid string escape"),
         (b'{"content":"\\u12xz"}', "invalid unicode escape"),

--- a/crates/runner/mitm-addon/tests/test_json_selective_work_limit.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_work_limit.py
@@ -13,7 +13,9 @@ from usage.json_selective import JsonSelectiveExtractor, ScalarField
         (b"   null", 5),
         (b'"' + b"\\n" * 17 + b'"', 3),
         (b'"' + b"\xe2\x98\x83" * 11 + b'"', 3),
+        (b'"' + b"x" * (64 * 1024 - 1) + b"\xc3\xa9" + b'"', 4),
         (b'"' + b"x" * (64 * 1024 - 1) + b"\xe2\x98\x83" + b'"', 4),
+        (b'"' + b"x" * (64 * 1024 - 1) + b"\xf0\x9f\x98\x80" + b'"', 4),
         (b'"' + b"x" * (64 * 1024 + 1) + b'"', 4),
     ],
     ids=[
@@ -22,7 +24,9 @@ from usage.json_selective import JsonSelectiveExtractor, ScalarField
         "whitespace",
         "escaped-string",
         "non-ascii-string",
+        "two-byte-crosses-bulk-boundary",
         "utf8-crosses-bulk-boundary",
+        "four-byte-crosses-bulk-boundary",
         "bulk-ascii-string",
     ],
 )

--- a/crates/runner/mitm-addon/tests/test_json_selective_work_limit.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_work_limit.py
@@ -13,6 +13,7 @@ from usage.json_selective import JsonSelectiveExtractor, ScalarField
         (b"   null", 5),
         (b'"' + b"\\n" * 17 + b'"', 3),
         (b'"' + b"\xe2\x98\x83" * 11 + b'"', 3),
+        (b'"' + b"x" * (64 * 1024 - 1) + b"\xe2\x98\x83" + b'"', 4),
         (b'"' + b"x" * (64 * 1024 + 1) + b'"', 4),
     ],
     ids=[
@@ -21,6 +22,7 @@ from usage.json_selective import JsonSelectiveExtractor, ScalarField
         "whitespace",
         "escaped-string",
         "non-ascii-string",
+        "utf8-crosses-bulk-boundary",
         "bulk-ascii-string",
     ],
 )


### PR DESCRIPTION
## Summary

- preserve the existing discarded-ASCII scanner and bulk-validate complete raw UTF-8 spans with a non-capturing possessive bytes pattern
- share deterministic 64 KiB work accounting across discarded ASCII and UTF-8, while keeping selected strings, escapes, controls, malformed bytes, and incomplete boundaries on the existing state machine
- add multi-megabyte deterministic parser coverage, exact 2/3/4-byte UTF-8 range and work-boundary coverage, and production-shaped Anthropic usage extraction

## Behavior and scope

Discarded content remains undecoded and unretained. Pure ASCII continues through the existing fast path. Selected strings and JSON result/error semantics are unchanged; valid discarded UTF-8 is intentionally reweighted from 32-byte slow work to 64 KiB bulk work because it no longer executes Python logic per byte.

There is no API, schema, migration, protocol, persisted-state, dependency, feature-switch, or rollout change.

## Performance

Measured on the repository's locked CPython 3.14.0 with 2,000,000-byte production-shaped JSON content, 64 KiB chunks, one warm-up, and five measured runs. Values are median milliseconds; the baseline is `origin/main` at `266467a02c` loaded in the same process.

| Discarded content | Bytes | Baseline | Current | Speedup |
| --- | ---: | ---: | ---: | ---: |
| ASCII | 2,000,000 | 5.134 ms | 4.978 ms | 1.03x |
| two-byte UTF-8 | 2,000,000 | 570.178 ms | 12.520 ms | 45.54x |
| three-byte UTF-8 | 1,999,998 | 615.081 ms | 14.356 ms | 42.85x |
| four-byte UTF-8 | 2,000,000 | 596.835 ms | 12.643 ms | 47.21x |
| mixed ASCII/UTF-8 | 1,999,999 | 575.514 ms | 16.079 ms | 35.79x |

The benchmark creates `JsonSelectiveExtractor` with trailing selected usage and `max_work_units=65_536`, feeds each payload in 64 KiB chunks, verifies the completed result, and measures `time.perf_counter()` around five complete parses after one warm-up for both modules.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_json_selective_strings.py tests/test_json_selective_work_limit.py tests/test_anthropic_messages.py` — 142 passed
- `uv run --no-sync python -m pytest tests/` — 7,316 passed, 43 pre-existing dependency/Syntax warnings
- deterministic differential harness against `origin/main` — 20,000 randomized valid/invalid byte and chunk-boundary cases matched (seed 32090)
- exhaustive matcher validation — every Unicode scalar plus 100,000 deterministic arbitrary byte strings matched strict UTF-8 and JSON-string rules
- `git diff --check`
- repository pre-commit hooks

Closes #32090
