### PR TITLE
chore(desktop): transfer zero retirement ownership

### DIFF
--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -220,7 +220,7 @@ working for those builds:
   path and neither branded form took any, including from the Zero installs that
   have been polling this API since the policy went `hard`. #31088 removed those
   rows, so the neutral path above is the one that has to keep resolving.
-  #26364 tracks the Zero install base itself.
+  #26368 tracks the installed Zero drain and retirement of these dependencies.
 
 This does not submit or publish the app to the Mac App Store. The App Store
 Connect API key is only used as notarytool authentication for Apple's

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -73,7 +73,7 @@ export const desktopUpdatesContract = c.router({
     responses: {
       200: desktopZeroMigrationPolicySchema,
     },
-    summary: "Get the remotely controlled Zero Desktop migration policy",
+    summary: "Get the Zero Desktop migration policy for installed clients",
   },
   releasePage: {
     method: "GET",

--- a/turbo/packages/db/scripts/legacy-database-identity-manifest.ts
+++ b/turbo/packages/db/scripts/legacy-database-identity-manifest.ts
@@ -81,10 +81,10 @@ const publicBrandDisposition = {
 const desktopDisposition = {
   classification: "retain",
   reason:
-    "Zero remains a supported Desktop product identity during the measured Computer Use migration and rollback window.",
-  ownerIssue: "#26364",
+    "Zero remains an installed Desktop product identity during the measured Computer Use drain and retirement window.",
+  ownerIssue: "#26368",
   writerStopCondition:
-    "The #26370 hard stop is production-accepted and no supported Zero Desktop version can register or refresh a Computer Use host.",
+    "The Zero hard stop remains production-active and #26368 verifies that no supported Zero Desktop version can register or refresh a Computer Use host.",
   drainEvidence:
     "Aggregate host telemetry has zero Zero-product heartbeats and commands for 14 consecutive days after the hard stop, with zero active rollback dependency.",
   removalGate:

--- a/turbo/packages/eslint-rules/scripts/residual-brand-name-manifest.ts
+++ b/turbo/packages/eslint-rules/scripts/residual-brand-name-manifest.ts
@@ -134,7 +134,7 @@ export const RESIDUAL_BRAND_BOUNDARY_FILE_RULES = [
     id: "desktop-identity/desktop-app",
     paths: /^turbo\/apps\/desktop\//u,
     reason:
-      "Desktop keeps a supported Zero product identity during the Computer Use migration and rollback window, owned by #26364, #26368, and #26370.",
+      "Desktop keeps the installed Zero product identity through the measured drain and retirement window owned by #26368.",
   },
   {
     category: "external-identity",
@@ -497,7 +497,7 @@ export const RESIDUAL_BRAND_BOUNDARY_OCCURRENCE_RULES = [
     category: "desktop-identity",
     id: "desktop-identity/desktop-product-line",
     reason:
-      "Desktop product and update-line identities are matched by installed clients; #26364, #26368, and #26370 own the hard stop.",
+      "Desktop product and update-line identities are matched by installed clients; #26368 owns their retention and retirement gates.",
     tokenPattern:
       /^(?:DESKTOP_[A-Z0-9_]*ZERO(?:_[A-Z0-9_]+)?|[Dd]esktopZero[A-Za-z0-9]*)$/u,
   },
@@ -1041,7 +1041,7 @@ export const RESIDUAL_BRAND_BOUNDARY_OCCURRENCE_RULES = [
     id: "desktop-identity/desktop-release-artifact",
     paths: TEST_AND_FIXTURE_PATHS,
     reason:
-      "Zero-darwin-arm64-1.2.3.zip is the published Desktop release artifact attached to a GitHub release, and desktop-updates.test.ts uses it to prove the final Okou feed refuses to serve a Zero artifact. The asset exists under that filename on a release this repository cannot rewrite, and #26364, #26368, and #26370 own Desktop identity.",
+      "Zero-darwin-arm64-1.2.3.zip is the published Desktop release artifact attached to a GitHub release, and desktop-updates.test.ts uses it to prove the final Okou feed refuses to serve a Zero artifact. The asset exists under that filename on a release this repository cannot rewrite, and #26368 owns the retained Desktop identity and artifact evidence.",
     tokens: ["Zero-darwin-arm64-1"],
   },
   {


### PR DESCRIPTION
## Summary

- transfer the retained Zero Desktop identity and drain ownership to #26368
- describe the migration-policy endpoint as an installed-client dependency instead of a remote control
- point the Desktop runbook and residual-identity manifests at the remaining retirement gate

## Safety

This is an ownership and documentation-only change. It does not change the hard migration-policy value, endpoint, schema, Zero identity, or Okou download route. Installed Zero clients continue to receive `{ "schemaVersion": 1, "mode": "hard" }`.

## Verification

- `pnpm exec prettier --write apps/desktop/README.md packages/api-contracts/src/contracts/desktop-updates.ts packages/db/scripts/legacy-database-identity-manifest.ts packages/eslint-rules/scripts/residual-brand-name-manifest.ts`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F @okouai/api-contracts check-types`
- `pnpm -F @okouai/db lint`
- `pnpm -F @okouai/db check-types`
- `pnpm -F @okouai/eslint-rules lint`
- `pnpm -F @okouai/eslint-rules check-types`
- `pnpm -F @okouai/db exec vitest run scripts/legacy-database-identity-inventory.test.ts --silent=passed-only` (22 passed)
- `pnpm -F @okouai/eslint-rules exec vitest run scripts/residual-brand-name-inventory.test.ts --silent=passed-only` (10 passed)
- `pnpm knip --workspace @okouai/api-contracts --workspace @okouai/db --workspace @okouai/eslint-rules`

## Tracking

The staged rollout and hard-stop activation in #26370 are complete. #26368 remains open for the measured installed-client drain and eventual compatibility retirement. This PR deliberately does not retire either live server-side dependency.
