### PR TITLE
fix(runner): preserve helper recovery and pending cleanup ownership

### DIFF
--- a/crates/runner/src/child_cleanup.rs
+++ b/crates/runner/src/child_cleanup.rs
@@ -1,6 +1,86 @@
 use tokio::runtime::Handle;
 use tracing::warn;
 
+/// Retains a child through an async reap and its cancellation fallback.
+pub(crate) struct ChildReaper {
+    label: &'static str,
+    child: Option<tokio::process::Child>,
+    #[cfg(test)]
+    gate: Option<ReapGate>,
+}
+
+impl ChildReaper {
+    pub(crate) fn new(label: &'static str, child: tokio::process::Child) -> Self {
+        Self {
+            label,
+            child: Some(child),
+            #[cfg(test)]
+            gate: None,
+        }
+    }
+
+    pub(crate) async fn reap(mut self) -> std::io::Result<()> {
+        let child = self
+            .child
+            .as_mut()
+            .ok_or_else(|| std::io::Error::other("child reaper lost its owned child"))?;
+        let _progress = crate::cleanup_progress::CleanupProgress::start(
+            self.label,
+            "child_reap",
+            crate::cleanup_progress::CleanupIdentity::Process(child.id()),
+        );
+        if let Err(error) = child.start_kill() {
+            warn!(label = self.label, pid = child.id(), %error, "failed to kill child before reaping");
+        }
+        #[cfg(test)]
+        if let Some(gate) = self.gate.take() {
+            gate.wait().await;
+        }
+        child.wait().await?;
+        self.child = None;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_gate(mut self, gate: Option<ReapGate>) -> Self {
+        self.gate = gate;
+        self
+    }
+}
+
+impl Drop for ChildReaper {
+    fn drop(&mut self) {
+        kill_and_reap_child_on_drop(self.label, &mut self.child);
+    }
+}
+
+/// Controls completion at the real child wait boundary, not lifecycle logic.
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct ReapGate {
+    pub(crate) entered: std::sync::Arc<tokio::sync::Notify>,
+    pub(crate) release: std::sync::Arc<tokio::sync::Semaphore>,
+}
+
+#[cfg(test)]
+impl ReapGate {
+    pub(crate) fn new() -> Self {
+        Self {
+            entered: Default::default(),
+            release: std::sync::Arc::new(tokio::sync::Semaphore::new(0)),
+        }
+    }
+
+    pub(crate) async fn wait(&self) {
+        self.entered.notify_one();
+        self.release
+            .acquire()
+            .await
+            .expect("reap gate closed")
+            .forget();
+    }
+}
+
 /// Kill a child from a synchronous drop fallback and reap it on the active runtime.
 ///
 /// Normal async shutdown paths should still use explicit `wait().await`. This

--- a/crates/runner/src/cleanup_progress.rs
+++ b/crates/runner/src/cleanup_progress.rs
@@ -1,0 +1,66 @@
+//! Observation of required cleanup, without timing out its ownership.
+
+use std::time::{Duration, Instant};
+
+use tokio_util::task::AbortOnDropHandle;
+use tracing::{Instrument, warn};
+
+const WARNING_INTERVAL: Duration = Duration::from_secs(30);
+
+pub(crate) enum CleanupIdentity {
+    Runner,
+    Process(Option<u32>),
+    Run(crate::ids::RunId),
+}
+
+/// Dropping this observer stops diagnostics, never the cleanup it describes.
+pub(crate) struct CleanupProgress {
+    started: Instant,
+    _observer: AbortOnDropHandle<()>,
+}
+
+impl CleanupProgress {
+    pub(crate) fn start(
+        component: &'static str,
+        phase: &'static str,
+        identity: CleanupIdentity,
+    ) -> Self {
+        let started = Instant::now();
+        // Axiom serializes event fields, not inherited span fields. Keep the
+        // authoritative safe identity on the warning itself.
+        let (pid, run_id) = match identity {
+            CleanupIdentity::Runner => (Some(std::process::id()), None),
+            CleanupIdentity::Process(pid) => (pid, None),
+            CleanupIdentity::Run(run_id) => (None, Some(run_id.to_string())),
+        };
+        let observer = tokio::spawn(
+            async move {
+                let mut tick = tokio::time::interval_at(
+                    tokio::time::Instant::now() + WARNING_INTERVAL,
+                    WARNING_INTERVAL,
+                );
+                tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    tick.tick().await;
+                    warn!(
+                        component,
+                        phase,
+                        pid,
+                        run_id = run_id.as_deref(),
+                        elapsed_ms = crate::duration::duration_ms(started.elapsed()),
+                        "required cleanup still pending"
+                    );
+                }
+            }
+            .in_current_span(),
+        );
+        Self {
+            started,
+            _observer: AbortOnDropHandle::new(observer),
+        }
+    }
+
+    pub(crate) fn elapsed(&self) -> Duration {
+        self.started.elapsed()
+    }
+}

--- a/crates/runner/src/cmd/start/mitm_restart.rs
+++ b/crates/runner/src/cmd/start/mitm_restart.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use tracing::{error, info, warn};
 
-use crate::error::RunnerResult;
+use crate::error::{RunnerError, RunnerResult};
 use crate::proxy;
 use crate::retry::RetryState;
 
@@ -13,11 +13,43 @@ pub(super) const MITM_BACKOFF_MAX: Duration = Duration::from_secs(30);
 /// Stop retrying mitmproxy after this many consecutive failures.
 pub(super) const MITM_MAX_CONSECUTIVE_FAILURES: u32 = 20;
 
-pub(super) type MitmRestartHandle = tokio::task::JoinHandle<RunnerResult<proxy::ManagedMitmdump>>;
+pub(super) type MitmRestartHandle =
+    tokio::task::JoinHandle<Result<proxy::ManagedMitmdump, proxy::MitmRestartError>>;
+
+/// Startup failures may retry, but an unknown old-child cleanup outcome must
+/// stop recovery instead of racing a new child against the fallback reaper.
+pub(super) async fn recv_mitm_restart(
+    handle: &mut Option<MitmRestartHandle>,
+) -> RunnerResult<Result<proxy::ManagedMitmdump, String>> {
+    let Some(task) = handle.as_mut() else {
+        return std::future::pending().await;
+    };
+    let result = task.await;
+    *handle = None;
+    match result {
+        Ok(Ok(child)) => Ok(Ok(child)),
+        Ok(Err(proxy::MitmRestartError::Startup(error))) => Ok(Err(error.to_string())),
+        Ok(Err(proxy::MitmRestartError::Cleanup(error))) => Err(RunnerError::Internal(format!(
+            "old mitmdump cleanup failed: {error}"
+        ))),
+        Err(error) => Err(RunnerError::Internal(format!(
+            "mitmproxy recovery task failed: {error}"
+        ))),
+    }
+}
+
+pub(super) fn stop_mitm_retries(
+    crash_rx: &mut tokio::sync::mpsc::Receiver<()>,
+    retry: &mut RetryState<MitmRestartHandle>,
+) {
+    crash_rx.close();
+    while crash_rx.try_recv().is_ok() {}
+    retry.clear_timer();
+}
 
 /// Spawn a background mitm restart task when the backoff timer fires
 /// and no restart is already in flight.
-pub(super) async fn maybe_spawn_mitm_restart(
+pub(super) fn maybe_spawn_mitm_restart(
     mitm: &mut proxy::MitmProxy,
     crash_rx: &mut tokio::sync::mpsc::Receiver<()>,
     retry: &mut RetryState<MitmRestartHandle>,
@@ -33,10 +65,8 @@ pub(super) async fn maybe_spawn_mitm_restart(
     // `stopping` Arc, locked to `true` before kill — so this only
     // sweeps pre-existing entries.
     while crash_rx.try_recv().is_ok() {}
-    retry.handle = Some(match mitm.begin_restart().await {
-        Ok(params) => tokio::spawn(params.spawn()),
-        Err(error) => tokio::spawn(async move { Err(error) }),
-    });
+    let params = mitm.begin_restart();
+    retry.handle = Some(tokio::spawn(params.spawn()));
 }
 
 /// Handle the result of a background mitm restart task.
@@ -92,25 +122,23 @@ pub(super) fn handle_mitm_restart_result(
 pub(super) async fn finish_mitm_restart_before_shutdown(
     mitm: &mut proxy::MitmProxy,
     retry: &mut RetryState<MitmRestartHandle>,
-) {
-    let Some(handle) = retry.handle.take() else {
-        return;
-    };
+) -> RunnerResult<()> {
+    if retry.handle.is_none() {
+        return Ok(());
+    }
 
     info!("waiting for in-flight mitmproxy restart before shutdown");
-    match handle.await {
-        Ok(Ok(child)) => {
+    match recv_mitm_restart(&mut retry.handle).await? {
+        Ok(child) => {
             info!("mitmproxy restart completed during shutdown");
             mitm.complete_restart(child);
             retry.on_success();
         }
-        Ok(Err(e)) => {
+        Err(e) => {
             warn!(error = %e, "mitmproxy restart failed during shutdown");
         }
-        Err(e) => {
-            warn!(error = %e, "mitmproxy restart task failed during shutdown");
-        }
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -119,7 +147,6 @@ mod tests {
     use std::time::Instant;
 
     use super::*;
-    use crate::retry::recv_retry;
 
     /// Create a MitmProxy for testing (does not start mitmdump).
     async fn test_mitm() -> (
@@ -163,7 +190,7 @@ mod tests {
         let future_deadline = Instant::now() + Duration::from_secs(60);
         retry.restart_at = Some(future_deadline);
 
-        maybe_spawn_mitm_restart(&mut mitm, &mut crash_rx, &mut retry).await;
+        maybe_spawn_mitm_restart(&mut mitm, &mut crash_rx, &mut retry);
 
         assert_eq!(retry.restart_at, Some(future_deadline));
         assert!(retry.handle.is_none());
@@ -172,7 +199,7 @@ mod tests {
         crash_tx.try_send(()).unwrap();
         retry.restart_at = Some(Instant::now() - Duration::from_secs(1));
 
-        maybe_spawn_mitm_restart(&mut mitm, &mut crash_rx, &mut retry).await;
+        maybe_spawn_mitm_restart(&mut mitm, &mut crash_rx, &mut retry);
 
         assert!(retry.restart_at.is_none());
         assert_eq!(
@@ -187,7 +214,7 @@ mod tests {
         let in_flight_deadline = Instant::now() - Duration::from_secs(1);
         retry.restart_at = Some(in_flight_deadline);
 
-        maybe_spawn_mitm_restart(&mut mitm, &mut crash_rx, &mut retry).await;
+        maybe_spawn_mitm_restart(&mut mitm, &mut crash_rx, &mut retry);
 
         assert_eq!(retry.restart_at, Some(in_flight_deadline));
         assert_eq!(
@@ -196,7 +223,7 @@ mod tests {
         );
         assert_eq!(crash_rx.try_recv(), Ok(()));
 
-        let result = recv_retry(&mut retry.handle).await;
+        let result = recv_mitm_restart(&mut retry.handle).await.unwrap();
         assert!(retry.handle.is_none());
         assert!(result.is_err());
 
@@ -313,7 +340,9 @@ mod tests {
             Ok(proxy::ManagedMitmdump::unmanaged(child))
         }));
 
-        finish_mitm_restart_before_shutdown(&mut mitm, &mut retry).await;
+        finish_mitm_restart_before_shutdown(&mut mitm, &mut retry)
+            .await
+            .unwrap();
 
         assert!(retry.handle.is_none());
         assert!(
@@ -332,10 +361,14 @@ mod tests {
             Some(MITM_MAX_CONSECUTIVE_FAILURES),
         );
         retry.handle = Some(tokio::spawn(async {
-            Err(crate::error::RunnerError::Internal("spawn failed".into()))
+            Err(proxy::MitmRestartError::Startup(
+                crate::error::RunnerError::Internal("spawn failed".into()),
+            ))
         }));
 
-        finish_mitm_restart_before_shutdown(&mut mitm, &mut retry).await;
+        finish_mitm_restart_before_shutdown(&mut mitm, &mut retry)
+            .await
+            .unwrap();
 
         assert!(retry.handle.is_none());
         assert!(mitm.usage_flush_target().is_none());

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -2421,8 +2421,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     }
                 }
             }
-            // Mitmproxy restart timer
-            () = sleep_until_retry(&mitm_retry.restart_at) => {}
+            // A late crash can arm a timer during recovery. Keep that request,
+            // but do not spin on an expired timer while its owner is in flight.
+            () = sleep_until_retry(&mitm_retry.restart_at), if mitm_retry.handle.is_none() => {}
             // Heartbeat: report runner state to the server
             _ = heartbeat_tick.tick() => {
                 let live_mode = *mode_rx.borrow();
@@ -2651,7 +2652,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         }
                     }
                 }
-                () = sleep_until_retry(&mitm_retry.restart_at) => {}
+                () = sleep_until_retry(&mitm_retry.restart_at), if mitm_retry.handle.is_none() => {}
             }
         }
     }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -80,7 +80,7 @@ use crate::provider::{
 };
 use crate::proxy;
 use crate::resource_budget::ResourceBudget;
-use crate::retry::{RetryState, recv_retry, sleep_until_retry};
+use crate::retry::{RetryState, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationRegistration, RunCancellationRegistry};
 use crate::runner_process_identity::RunnerProcessIdentity;
 use crate::status::{StatusTracker, remove_stale_status_file};
@@ -120,6 +120,7 @@ use job_spawn::{SpawnContext, handle_job_result};
 use mitm_restart::{
     MITM_BACKOFF_INITIAL, MITM_BACKOFF_MAX, MITM_MAX_CONSECUTIVE_FAILURES, MitmRestartHandle,
     finish_mitm_restart_before_shutdown, handle_mitm_restart_result, maybe_spawn_mitm_restart,
+    recv_mitm_restart, stop_mitm_retries,
 };
 use orphan_reap::{
     OrphanReapMode, OrphanReapProcessDiscovery, OrphanedActiveRuns, reap_orphaned_active_runs,
@@ -297,8 +298,12 @@ impl TeardownTimer {
         Self::duration_ms(self.start.elapsed())
     }
 
-    fn phase_start(&self, phase: &'static str) -> Instant {
-        let phase_start = Instant::now();
+    fn phase_start(&self, phase: &'static str) -> crate::cleanup_progress::CleanupProgress {
+        let phase_start = crate::cleanup_progress::CleanupProgress::start(
+            "runner",
+            phase,
+            crate::cleanup_progress::CleanupIdentity::Runner,
+        );
         info!(
             phase,
             elapsed_ms = self.elapsed_ms(),
@@ -307,7 +312,11 @@ impl TeardownTimer {
         phase_start
     }
 
-    fn phase_complete(&self, phase: &'static str, phase_start: Instant) {
+    fn phase_complete(
+        &self,
+        phase: &'static str,
+        phase_start: crate::cleanup_progress::CleanupProgress,
+    ) {
         info!(
             phase,
             phase_ms = Self::duration_ms(phase_start.elapsed()),
@@ -386,12 +395,16 @@ async fn publish_live_runner_instance_or_shutdown_startup_resources(
         Err(e) => {
             resources.memory_prefetch.cancel();
             resources.provider.shutdown().await;
-            resources.dns_handle.stop().await;
+            if let Err(error) = resources.dns_handle.stop().await {
+                warn!(%error, "failed to clean up network-log helper after startup failure");
+            }
             resources.runtime.shutdown().await;
             if let Err(kill_error) = resources.mitm.kill_now().await {
                 warn!(error = %kill_error, "failed to kill proxy after live runner instance publish failed");
             }
-            resources.kmsg_handle.stop().await;
+            if let Err(error) = resources.kmsg_handle.stop().await {
+                warn!(%error, "failed to clean up network-log helper after startup failure");
+            }
             resources.memory_prefetch.drain().await;
             if let Err(status_error) = resources.status.set_mode(RunnerMode::Stopped).await {
                 warn!(
@@ -410,14 +423,18 @@ async fn shutdown_startup_resources_after_startup_failure(
 ) {
     resources.memory_prefetch.cancel();
     resources.provider.shutdown().await;
-    resources.dns_handle.stop().await;
+    if let Err(error) = resources.dns_handle.stop().await {
+        warn!(%error, "failed to clean up network-log helper after startup failure");
+    }
     if let Some(runtime) = resources.runtime {
         runtime.shutdown().await;
     }
     if let Err(e) = resources.mitm.kill_now().await {
         warn!(error = %e, context, "failed to kill proxy after startup failed");
     }
-    resources.kmsg_handle.stop().await;
+    if let Err(error) = resources.kmsg_handle.stop().await {
+        warn!(%error, "failed to clean up network-log helper after startup failure");
+    }
     resources.memory_prefetch.drain().await;
     if let Err(error) = resources.status.set_mode(RunnerMode::Stopped).await {
         warn!(%error, context, "failed to persist stopped status after startup failure");
@@ -779,7 +796,9 @@ async fn run_start_with_home(
             if let Err(e) = mitm.kill_now().await {
                 warn!(error = %e, "failed to kill proxy after DNS interface resolution failed");
             }
-            kmsg_handle.stop().await;
+            if let Err(error) = kmsg_handle.stop().await {
+                warn!(%error, "failed to clean up network-log helper after startup failure");
+            }
             memory_prefetch.drain().await;
             return Err(RunnerError::Internal(
                 "sandbox runtime did not provide DNS interface pattern".into(),
@@ -796,7 +815,9 @@ async fn run_start_with_home(
             Ok(handle) => {
                 if let Err(e) = runtime.activate_dns_readiness().await {
                     memory_prefetch.cancel();
-                    handle.stop().await;
+                    if let Err(error) = handle.stop().await {
+                        warn!(%error, "failed to clean up network-log helper after startup failure");
+                    }
                     runtime.shutdown().await;
                     if let Err(kill_error) = mitm.kill_now().await {
                         warn!(
@@ -804,7 +825,9 @@ async fn run_start_with_home(
                             "failed to kill proxy after namespace DNS readiness failed"
                         );
                     }
-                    kmsg_handle.stop().await;
+                    if let Err(error) = kmsg_handle.stop().await {
+                        warn!(%error, "failed to clean up network-log helper after startup failure");
+                    }
                     memory_prefetch.drain().await;
                     return Err(RunnerError::Internal(format!(
                         "sandbox runtime DNS readiness: {e}"
@@ -832,7 +855,9 @@ async fn run_start_with_home(
                 if let Err(kill_error) = mitm.kill_now().await {
                     warn!(error = %kill_error, "failed to kill proxy after DNS startup failed");
                 }
-                kmsg_handle.stop().await;
+                if let Err(error) = kmsg_handle.stop().await {
+                    warn!(%error, "failed to clean up network-log helper after startup failure");
+                }
                 memory_prefetch.drain().await;
                 return Err(RunnerError::Internal(format!("dns proxy: {e}")));
             }
@@ -1635,13 +1660,12 @@ impl RequiredNetworkLogComponent {
 async fn handle_required_network_log_completion(
     component: RequiredNetworkLogComponent,
     result: Result<DrainableLineReaderExit, tokio::task::JoinError>,
-    reap_child: impl std::future::Future<Output = ()>,
     cancel: &CancellationToken,
     cancel_tokens: &RunCancellationRegistry,
     lifecycle: &LifecycleController,
 ) -> Option<RunnerError> {
     let mode = lifecycle.current_mode();
-    let terminal_error = if matches!(mode, RunnerMode::Stopping | RunnerMode::Stopped) {
+    if matches!(mode, RunnerMode::Stopping | RunnerMode::Stopped) {
         None
     } else {
         let message = component.terminal_message(&result);
@@ -1653,10 +1677,7 @@ async fn handle_required_network_log_completion(
         );
         handle_stopping_signal(component.stop_source(), cancel, cancel_tokens, lifecycle).await;
         Some(RunnerError::Internal(message))
-    };
-
-    reap_child.await;
-    terminal_error
+    }
 }
 
 async fn run(config: RunConfig) -> RunnerResult<()> {
@@ -2095,7 +2116,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             .await;
 
         // Spawn background restart task when timer fires
-        maybe_spawn_mitm_restart(&mut mitm, &mut mitm_crash_rx, &mut mitm_retry).await;
+        maybe_spawn_mitm_restart(&mut mitm, &mut mitm_crash_rx, &mut mitm_retry);
 
         let can_discover = if matches!(mode, RunnerMode::Running) {
             // A selected finalizing successor can claim against an exact
@@ -2323,10 +2344,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 ).await;
             }
             result = kmsg_handle.wait() => {
+                kmsg_handle.start_child_cleanup();
                 if let Some(error) = handle_required_network_log_completion(
                     RequiredNetworkLogComponent::Kmsg,
                     result,
-                    kmsg_handle.kill_and_reap_child(),
                     &provider_state.cancel,
                     &provider_state.cancel_tokens,
                     &lifecycle,
@@ -2335,10 +2356,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 }
             }
             result = dns_handle.wait() => {
+                dns_handle.start_child_cleanup();
                 if let Some(error) = handle_required_network_log_completion(
                     RequiredNetworkLogComponent::Dns,
                     result,
-                    dns_handle.kill_and_reap_child(),
                     &provider_state.cancel,
                     &provider_state.cancel_tokens,
                     &lifecycle,
@@ -2378,7 +2399,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 ).await;
             }
             // Mitmproxy crash detection
-            _ = mitm_crash_rx.recv() => {
+            Some(()) = mitm_crash_rx.recv() => {
                 error!(
                     r#type = "usage_underbilling",
                     reason = "mitm_restart_in_memory_usage_risk",
@@ -2389,8 +2410,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 mitm_retry.schedule();
             }
             // Mitmproxy restart result (background task)
-            result = recv_retry(&mut mitm_retry.handle) => {
-                handle_mitm_restart_result(result, &mut mitm, &mut mitm_retry);
+            result = recv_mitm_restart(&mut mitm_retry.handle) => {
+                match result {
+                    Ok(result) => handle_mitm_restart_result(result, &mut mitm, &mut mitm_retry),
+                    Err(error) => {
+                        stop_mitm_retries(&mut mitm_crash_rx, &mut mitm_retry);
+                        handle_stopping_signal("mitm-recovery", &provider_state.cancel,
+                            &provider_state.cancel_tokens, &lifecycle).await;
+                        terminal_error = Some(error);
+                    }
+                }
             }
             // Mitmproxy restart timer
             () = sleep_until_retry(&mitm_retry.restart_at) => {}
@@ -2491,6 +2520,20 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     memory_prefetch.cancel();
     teardown.event("memory_prefetch_cancelled");
 
+    // Discovery may complete with None on cancellation before the mode-change
+    // branch wins. Publish Stopping before any prolonged teardown in that case.
+    // Ending discovery must not turn an otherwise natural job drain into hard
+    // cancellation; keep lifecycle signal handling authoritative for that.
+    let phase = teardown.phase_start("status_stopping");
+    lifecycle.close_parking();
+    if let Err(error) = shared.status.set_mode(RunnerMode::Stopping).await {
+        error!(%error, "failed to publish stopping status before teardown");
+        terminal_error.get_or_insert_with(|| {
+            RunnerError::Internal(format!("persist stopping status before teardown: {error}"))
+        });
+    }
+    teardown.phase_complete("status_stopping", phase);
+
     let phase = teardown.phase_start("blank_pool_shutdown");
     blank_pool.shutdown().await;
     teardown.phase_complete("blank_pool_shutdown", phase);
@@ -2567,7 +2610,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     if remaining > 0 {
         info!(remaining, "waiting for running jobs to finish");
         while !jobs.is_empty() {
-            maybe_spawn_mitm_restart(&mut mitm, &mut mitm_crash_rx, &mut mitm_retry).await;
+            maybe_spawn_mitm_restart(&mut mitm, &mut mitm_crash_rx, &mut mitm_retry);
 
             tokio::select! {
                 result = jobs.join_next() => {
@@ -2587,7 +2630,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     test_hooks.test_observer.notify_usage_flush_requested();
                     mitm.request_usage_flush();
                 }
-                _ = mitm_crash_rx.recv() => {
+                Some(()) = mitm_crash_rx.recv() => {
                     error!(
                         r#type = "usage_underbilling",
                         reason = "mitm_restart_in_memory_usage_risk",
@@ -2597,8 +2640,16 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     );
                     mitm_retry.schedule();
                 }
-                result = recv_retry(&mut mitm_retry.handle) => {
-                    handle_mitm_restart_result(result, &mut mitm, &mut mitm_retry);
+                result = recv_mitm_restart(&mut mitm_retry.handle) => {
+                    match result {
+                        Ok(result) => handle_mitm_restart_result(result, &mut mitm, &mut mitm_retry),
+                        Err(error) => {
+                            stop_mitm_retries(&mut mitm_crash_rx, &mut mitm_retry);
+                            handle_stopping_signal("mitm-recovery", &provider_state.cancel,
+                                &provider_state.cancel_tokens, &lifecycle).await;
+                            terminal_error.get_or_insert(error);
+                        }
+                    }
                 }
                 () = sleep_until_retry(&mitm_retry.restart_at) => {}
             }
@@ -2635,7 +2686,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     exec_config.background_fill.shutdown().await;
     teardown.phase_complete("background_fill_shutdown", phase);
     let phase = teardown.phase_start("finish_mitm_restart");
-    finish_mitm_restart_before_shutdown(&mut mitm, &mut mitm_retry).await;
+    if let Err(error) = finish_mitm_restart_before_shutdown(&mut mitm, &mut mitm_retry).await {
+        error!(%error, "failed to finish mitmproxy recovery");
+        terminal_error.get_or_insert(error);
+    }
     teardown.phase_complete("finish_mitm_restart", phase);
     if let Some(handler_task) = signal_handler_task.take() {
         abort_signal_handler_task(handler_task, "shutdown").await;
@@ -2651,7 +2705,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Runtime shutdown owns those filters, so it must follow DNS shutdown to
     // avoid exposing the wildcard listener between the two cleanup phases.
     let phase = teardown.phase_start("dns_stop");
-    dns_handle.stop().await;
+    if let Err(error) = dns_handle.stop().await {
+        error!(%error, "DNS cleanup failed during shutdown");
+        terminal_error.get_or_insert(error);
+    }
     teardown.phase_complete("dns_stop", phase);
 
     shutdown_runtime(runtime.as_mut(), Some(&teardown)).await;
@@ -2710,7 +2767,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Stop the kmsg monitor and wait for the `dmesg -w` child process
     // to be killed and reaped.
     let phase = teardown.phase_start("kmsg_stop");
-    kmsg_handle.stop().await;
+    if let Err(error) = kmsg_handle.stop().await {
+        error!(%error, "kmsg cleanup failed during shutdown");
+        terminal_error.get_or_insert(error);
+    }
     teardown.phase_complete("kmsg_stop", phase);
     let phase = teardown.phase_start("memory_prefetch_drain");
     memory_prefetch.drain().await;

--- a/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
@@ -45,6 +45,42 @@ async fn shutdown_completes_without_deadlock() {
 }
 
 #[tokio::test]
+async fn discovery_end_publishes_stopping_without_cancelling_active_job() {
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    let token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("job should enter its process wait");
+
+    drop(env.handle.discover_tx);
+    wait_status_mode(&status_path, "stopping", Duration::from_secs(5)).await;
+    assert!(!token.is_cancelled(), "ending discovery is not a hard stop");
+    assert!(!run_handle.is_finished(), "active job still owns its drain");
+    wait_gate.release_one();
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "discovery end should drain the active job normally",
+    )
+    .await;
+    let completions = env.handle.completions.lock().unwrap();
+    let completion = completions
+        .iter()
+        .find(|entry| entry.run_id == run_id)
+        .unwrap();
+    assert_eq!(completion.exit_code, 0);
+    assert!(completion.error.is_none());
+}
+
+#[tokio::test]
 async fn shutdown_drains_memory_prefetch_before_stopped() {
     let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let status_path = env._temp_dir.path().join("status.json");
@@ -229,6 +265,8 @@ async fn dns_monitor_task_panic_stops_runner_and_cancels_active_job() {
     overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     let (mut config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
     let (_stdin, pid, starttime) = install_controllable_dns(&mut config).await;
+    let reap_gate = crate::child_cleanup::ReapGate::new();
+    config.shutdown.dns_handle.set_reap_gate(reap_gate.clone());
     let panic_trigger = config
         .shutdown
         .dns_handle
@@ -271,10 +309,20 @@ async fn dns_monitor_task_panic_stops_runner_and_cancels_active_job() {
         !run_handle.is_finished(),
         "blocked final heartbeat should hold teardown open",
     );
-    assert_child_reaped("dns", pid, starttime).await;
+    tokio::time::timeout(Duration::from_secs(2), reap_gate.entered.notified())
+        .await
+        .unwrap();
+    wait_status_mode(
+        &env._temp_dir.path().join("status.json"),
+        "stopping",
+        Duration::from_secs(2),
+    )
+    .await;
+    reap_gate.release.add_permits(1);
 
     env.handle.unblock_heartbeats();
     assert_run_error_contains(run_handle, "dns monitor task failed").await;
+    assert_child_reaped("dns", pid, starttime).await;
     wait_cancel_token_removed(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
 
     let completions = env.handle.completions.lock().unwrap();
@@ -288,6 +336,209 @@ async fn dns_monitor_task_panic_stops_runner_and_cancels_active_job() {
 #[tokio::test]
 async fn normal_shutdown_cancels_dns_and_reaps_child_without_error() {
     assert_normal_shutdown_reaps_network_log_child(NetworkLogTestComponent::Dns).await;
+}
+
+#[tokio::test]
+async fn required_monitor_failure_publishes_stopping_before_delayed_child_reap() {
+    for component in [NetworkLogTestComponent::Dns, NetworkLogTestComponent::Kmsg] {
+        let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+        let (mut stdin, pid, starttime) = component.install(&mut config).await;
+        let gate = crate::child_cleanup::ReapGate::new();
+        match component {
+            NetworkLogTestComponent::Dns => config.shutdown.dns_handle.set_reap_gate(gate.clone()),
+            NetworkLogTestComponent::Kmsg => {
+                config.shutdown.kmsg_handle.set_reap_gate(gate.clone())
+            }
+        }
+        let status_path = env._temp_dir.path().join("status.json");
+        let run_handle = tokio::spawn(run(config));
+        wait_discover_entered(&env, Duration::from_secs(2)).await;
+        stdin.write_all(&[0xff, b'\n']).await.unwrap();
+        stdin.flush().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), gate.entered.notified())
+            .await
+            .unwrap();
+        wait_status_mode(&status_path, "stopping", Duration::from_secs(2)).await;
+        assert!(env.cancel.is_cancelled());
+        assert!(
+            !run_handle.is_finished(),
+            "cleanup must remain owned until the child wait finishes"
+        );
+        gate.release.add_permits(1);
+        assert_run_error_contains(run_handle, "ReadError").await;
+        assert_child_reaped(component.label(), pid, starttime).await;
+        wait_status_mode(&status_path, "stopped", Duration::from_secs(2)).await;
+    }
+}
+
+#[tokio::test]
+async fn cancelled_reactor_does_not_abort_owned_network_log_child_cleanup() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let (mut stdin, pid, starttime) = install_controllable_dns(&mut config).await;
+    let gate = crate::child_cleanup::ReapGate::new();
+    config.shutdown.dns_handle.set_reap_gate(gate.clone());
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    stdin.write_all(&[0xff, b'\n']).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), gate.entered.notified())
+        .await
+        .unwrap();
+    run_handle.abort();
+    assert!(run_handle.await.unwrap_err().is_cancelled());
+    gate.release.add_permits(1);
+    wait_for_abnormal_child_cleanup(pid, starttime).await;
+}
+
+#[tokio::test]
+async fn mitm_recovery_keeps_lifecycle_live_and_shutdown_joins_old_child_cleanup() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let child = tokio::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .unwrap();
+    let pid = child.id().unwrap();
+    let starttime = crate::process::read_process_stat(pid)
+        .await
+        .unwrap()
+        .starttime;
+    let gate = crate::child_cleanup::ReapGate::new();
+    config.proxy.mitm.set_child_for_test(child);
+    config.proxy.mitm.set_reap_gate_for_test(gate.clone());
+    let (crash_tx, crash_rx) = mpsc::channel(1);
+    config.proxy.mitm_crash_rx = crash_rx;
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    crash_tx.send(()).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(3), gate.entered.notified())
+        .await
+        .unwrap();
+    env.trigger_stopping().await;
+    wait_status_mode(&status_path, "stopping", Duration::from_secs(2)).await;
+    assert!(
+        !run_handle.is_finished(),
+        "shutdown must join the restart's old-child cleanup"
+    );
+    gate.release.add_permits(1);
+    // The noop proxy has no replacement runtime. Its startup failure still
+    // follows cleanup and is handled without abandoning the old process.
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(3),
+        "restart cleanup did not finish",
+    )
+    .await;
+    assert_child_reaped("mitmdump", pid, starttime).await;
+}
+
+#[tokio::test]
+async fn mitm_recovery_panic_stops_runner_instead_of_retrying_unknown_cleanup() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let child = tokio::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .unwrap();
+    let pid = child.id().unwrap();
+    let starttime = crate::process::read_process_stat(pid)
+        .await
+        .unwrap()
+        .starttime;
+    let gate = crate::child_cleanup::ReapGate::new();
+    config.proxy.mitm.set_child_for_test(child);
+    config.proxy.mitm.set_reap_gate_for_test(gate.clone());
+    let (crash_tx, crash_rx) = mpsc::channel(1);
+    config.proxy.mitm_crash_rx = crash_rx;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    crash_tx.send(()).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(3), gate.entered.notified())
+        .await
+        .unwrap();
+    // A duplicate notification must not create another restart after failure.
+    crash_tx.send(()).await.unwrap();
+    gate.release.close();
+    assert_run_error_contains(run_handle, "mitmproxy recovery task failed").await;
+    assert!(env.cancel.is_cancelled());
+    assert!(crash_tx.is_closed());
+    wait_for_abnormal_child_cleanup(pid, starttime).await;
+}
+
+#[tokio::test]
+async fn prolonged_teardown_warns_without_completing_or_abandoning_cleanup() {
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::CapturedEvents;
+
+    let captured = CapturedEvents::default();
+    let _subscriber =
+        tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+    tracing::callsite::rebuild_interest_cache();
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let cancel = CancellationToken::new();
+    let child_cancel = cancel.clone();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let task = tokio::spawn(async move {
+        child_cancel.cancelled().await;
+        release_rx.await.unwrap();
+    });
+    config.shutdown.memory_prefetch =
+        crate::prefetch::MemoryPrefetchTasks::from_test_handle(cancel, task);
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    env.trigger_stopping().await;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if captured.entries().iter().any(|event| {
+                event.fields.get("message").map(String::as_str) == Some("teardown phase started")
+                    && event.fields.get("phase").map(String::as_str)
+                        == Some("memory_prefetch_drain")
+            }) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    tokio::time::pause();
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(31)).await;
+    tokio::task::yield_now().await;
+    let events = captured.entries();
+    let warning = events
+        .iter()
+        .find(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("required cleanup still pending")
+                && event.fields.get("phase").map(String::as_str) == Some("memory_prefetch_drain")
+        })
+        .expect("held teardown must identify its pending phase");
+    assert_eq!(warning.level, tracing::Level::WARN);
+    assert_eq!(
+        warning.fields.get("component").map(String::as_str),
+        Some("runner")
+    );
+    assert!(warning.fields.contains_key("elapsed_ms"));
+    assert!(!run_handle.is_finished());
+    tokio::time::resume();
+    release_tx.send(()).unwrap();
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(2),
+        "cleanup completion should finish teardown",
+    )
+    .await;
+    captured.clear();
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(31)).await;
+    tokio::task::yield_now().await;
+    assert!(
+        !captured.entries().iter().any(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("required cleanup still pending")
+        }),
+        "completed cleanup must not leave warning tasks alive"
+    );
+    tokio::time::resume();
 }
 
 /// SIGTERM while a job is in flight: per-job cancellation fires, the
@@ -526,6 +777,21 @@ async fn assert_child_reaped(component: &str, pid: u32, starttime: u64) {
         Some(starttime),
         "{component} child pid {pid} with start time {starttime} was not reaped",
     );
+}
+
+// Abnormal task termination transfers reaping to the Drop fallback. Unlike
+// normal shutdown's join, that fallback promises eventual process removal.
+async fn wait_for_abnormal_child_cleanup(pid: u32, starttime: u64) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while crate::process::read_process_stat(pid)
+            .await
+            .is_some_and(|stat| stat.starttime == starttime)
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("abnormal cleanup should eventually reap its owned child");
 }
 
 async fn assert_run_error_contains(

--- a/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
@@ -413,6 +413,20 @@ async fn mitm_recovery_keeps_lifecycle_live_and_shutdown_joins_old_child_cleanup
     tokio::time::timeout(Duration::from_secs(3), gate.entered.notified())
         .await
         .unwrap();
+    crash_tx.send(()).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while crash_tx.capacity() == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("reactor should consume the late crash notification");
+    // An expired retry timer must not busy-loop while old-child cleanup is
+    // still owned. Only the timer is advanced; the real child gate stays held.
+    tokio::time::pause();
+    tokio::time::advance(Duration::from_secs(2)).await;
+    tokio::task::yield_now().await;
+    tokio::time::resume();
     env.trigger_stopping().await;
     wait_status_mode(&status_path, "stopping", Duration::from_secs(2)).await;
     assert!(

--- a/crates/runner/src/cmd/start/tests/teardown_timer.rs
+++ b/crates/runner/src/cmd/start/tests/teardown_timer.rs
@@ -16,6 +16,11 @@ fn event_with_message<'a>(events: &'a [CapturedEvent], message: &str) -> &'a Cap
 }
 
 fn register_teardown_timer_callsites() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .unwrap();
+    let _guard = runtime.enter();
     let timer = TeardownTimer::start();
     let phase = timer.phase_start("warmup_phase");
     timer.phase_complete("warmup_phase", phase);
@@ -23,8 +28,8 @@ fn register_teardown_timer_callsites() {
     info!(total_teardown_ms = timer.elapsed_ms(), "runner stopped");
 }
 
-#[test]
-fn teardown_timer_emits_structured_timing_fields() {
+#[tokio::test]
+async fn teardown_timer_emits_structured_timing_fields() {
     let captured = CapturedEvents::default();
     let subscriber = tracing_subscriber::registry().with(captured.clone());
     let _guard = tracing::subscriber::set_default(subscriber);

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -25,15 +25,21 @@ impl DnsProxy {
         self.process.wait().await
     }
 
-    /// Kill dnsmasq when necessary and wait for it to be reaped.
-    pub(crate) async fn kill_and_reap_child(&mut self) {
-        self.process.kill_and_reap_child().await;
+    /// Start owned child cleanup without waiting for its completion.
+    pub(crate) fn start_child_cleanup(&mut self) {
+        self.process.start_child_cleanup();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_reap_gate(&mut self, gate: crate::child_cleanup::ReapGate) {
+        self.process.set_reap_gate(gate);
     }
 
     /// Stop the DNS proxy and wait for cleanup.
-    pub async fn stop(self) {
-        self.process.stop().await;
+    pub async fn stop(self) -> crate::error::RunnerResult<()> {
+        self.process.stop().await?;
         info!("dns proxy stopped");
+        Ok(())
     }
 
     /// Return the port dnsmasq is listening on.

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1222,6 +1222,7 @@ async fn create_started_sandbox(
                 dns_drain_status = network_log_observation.drain_status("dns"),
                 kmsg_drain_status = network_log_observation.drain_status("kmsg"),
                 writer_backpressure_observed = network_log_observation.writer_backpressure_observed(),
+                writer_failed = network_log_observation.writer_failed(),
                 "guest DNS readiness network log observation"
             );
         }

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -40,15 +40,21 @@ impl KmsgHandle {
         self.process.wait().await
     }
 
-    /// Kill the dmesg child when necessary and wait for it to be reaped.
-    pub(crate) async fn kill_and_reap_child(&mut self) {
-        self.process.kill_and_reap_child().await;
+    /// Start owned child cleanup without waiting for its completion.
+    pub(crate) fn start_child_cleanup(&mut self) {
+        self.process.start_child_cleanup();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_reap_gate(&mut self, gate: crate::child_cleanup::ReapGate) {
+        self.process.set_reap_gate(gate);
     }
 
     /// Stop the kmsg monitor and wait for cleanup.
-    pub async fn stop(self) {
-        self.process.stop().await;
+    pub async fn stop(self) -> crate::error::RunnerResult<()> {
+        self.process.stop().await?;
         info!("kmsg monitor stopped");
+        Ok(())
     }
 
     /// Create a noop handle for testing. No `dmesg` process is spawned.

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -5,6 +5,7 @@ mod bounded_command;
 mod byte_size;
 mod ca;
 mod child_cleanup;
+mod cleanup_progress;
 mod cmd;
 mod config;
 mod deps;

--- a/crates/runner/src/network_log_manager.rs
+++ b/crates/runner/src/network_log_manager.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use tokio::sync::mpsc::error::TrySendError;
@@ -47,6 +48,7 @@ struct Inner {
 struct WriteGate {
     started: Arc<Notify>,
     release: Arc<Semaphore>,
+    blocking: bool,
 }
 
 #[cfg(test)]
@@ -68,12 +70,14 @@ pub struct NetworkLogSession {
     path: Arc<Path>,
     generation: u64,
     closed: bool,
+    writer_failed: Arc<AtomicBool>,
 }
 
 /// Failure-scoped state observed while closing one network-log session.
 pub struct NetworkLogCloseObservation {
     drain: crate::network_log_drain::NetworkLogDrainReport,
     writer_backpressure_observed: bool,
+    writer_failed: bool,
 }
 
 impl NetworkLogCloseObservation {
@@ -83,6 +87,10 @@ impl NetworkLogCloseObservation {
 
     pub(crate) fn writer_backpressure_observed(&self) -> bool {
         self.writer_backpressure_observed
+    }
+
+    pub(crate) fn writer_failed(&self) -> bool {
+        self.writer_failed
     }
 }
 
@@ -102,10 +110,9 @@ impl NetworkLogSession {
         run_id: RunId,
         drain: &NetworkLogDrainCoordinator,
     ) -> NetworkLogCloseObservation {
-        let current = self
-            .manager
-            .begin_session_drain(&self.source_ip, &self.path, self.generation)
-            .await;
+        let current =
+            self.manager
+                .begin_session_drain(&self.source_ip, &self.path, self.generation);
         let drain = if current {
             drain
                 .drain(NetworkLogDrainContext {
@@ -118,17 +125,36 @@ impl NetworkLogSession {
         } else {
             Default::default()
         };
-        let writer_backpressure_observed = self
-            .manager
-            .finalize_session(&self.source_ip, &self.path, self.generation)
-            .await;
+        let writer_backpressure_observed =
+            self.manager
+                .finalize_session(&self.source_ip, &self.path, self.generation);
         #[cfg(test)]
         self.manager.before_close_upload_flush_for_test().await;
-        self.manager.flush_path(&self.path).await;
+        {
+            use tracing::Instrument;
+            async {
+                let _progress = crate::cleanup_progress::CleanupProgress::start(
+                    "network_log",
+                    "accepted_write_flush",
+                    crate::cleanup_progress::CleanupIdentity::Run(run_id),
+                );
+                self.manager.flush_path(&self.path).await;
+            }
+            .instrument(tracing::info_span!(
+                "network_log_flush", %run_id, source_ip = %self.source_ip,
+                path = %self.path.display(), generation = self.generation
+            ))
+            .await;
+        }
         self.closed = true;
+        let writer_failed = self.writer_failed.load(Ordering::Acquire);
+        if writer_failed {
+            warn!(%run_id, path = %self.path.display(), "network log session closed with write failures");
+        }
         NetworkLogCloseObservation {
             drain,
             writer_backpressure_observed,
+            writer_failed,
         }
     }
 }
@@ -139,17 +165,8 @@ impl Drop for NetworkLogSession {
             return;
         }
 
-        let manager = self.manager.clone();
-        let source_ip = self.source_ip.clone();
-        let path = Arc::clone(&self.path);
-        let generation = self.generation;
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            std::mem::drop(handle.spawn(async move {
-                manager
-                    .finalize_session(&source_ip, &path, generation)
-                    .await;
-            }));
-        }
+        self.manager
+            .finalize_session(&self.source_ip, &self.path, self.generation);
     }
 }
 
@@ -161,7 +178,11 @@ impl NetworkLogManager {
     #[cfg(test)]
     pub(crate) fn new_with_write_gate(started: Arc<Notify>, release: Arc<Semaphore>) -> Self {
         Self::new_for_test(
-            Some(WriteGate { started, release }),
+            Some(WriteGate {
+                started,
+                release,
+                blocking: false,
+            }),
             None,
             WriterConfig::default(),
         )
@@ -173,7 +194,15 @@ impl NetworkLogManager {
         release: Arc<Semaphore>,
         writer_config: WriterConfig,
     ) -> Self {
-        Self::new_for_test(Some(WriteGate { started, release }), None, writer_config)
+        Self::new_for_test(
+            Some(WriteGate {
+                started,
+                release,
+                blocking: false,
+            }),
+            None,
+            writer_config,
+        )
     }
 
     #[cfg(test)]
@@ -213,24 +242,21 @@ impl NetworkLogManager {
         source_ip: impl Into<String>,
         path: PathBuf,
     ) -> NetworkLogSession {
-        let registration = self
-            .inner
-            .state
-            .register_source_ip(source_ip.into(), path)
-            .await;
+        let registration = self.inner.state.register_source_ip(source_ip.into(), path);
         NetworkLogSession {
             manager: self.clone(),
             source_ip: registration.source_ip,
             path: registration.path,
             generation: registration.generation,
             closed: false,
+            writer_failed: registration.writer_failed,
         }
     }
 
     /// Remove a source mapping immediately.
     #[cfg(test)]
     pub async fn unregister_source_ip(&self, source_ip: &str) {
-        self.inner.state.unregister_source_ip(source_ip).await;
+        self.inner.state.unregister_source_ip(source_ip);
     }
 
     /// Accept a JSON network-log row for a source IP.
@@ -252,7 +278,7 @@ impl NetworkLogManager {
             }
         };
 
-        let Some(snapshot) = self.inner.state.source_snapshot(source_ip).await else {
+        let Some(snapshot) = self.inner.state.source_snapshot(source_ip) else {
             return false;
         };
         let writer_pool = self.writer_pool();
@@ -265,8 +291,7 @@ impl NetworkLogManager {
             Err(TrySendError::Full(sender)) => {
                 self.inner
                     .state
-                    .mark_writer_backpressure(source_ip, &snapshot)
-                    .await;
+                    .mark_writer_backpressure(source_ip, &snapshot);
                 match sender.reserve_owned().await {
                     Ok(permit) => permit,
                     Err(_) => {
@@ -291,7 +316,6 @@ impl NetworkLogManager {
             .inner
             .state
             .try_accept_snapshot(source_ip, &snapshot, line)
-            .await
         else {
             return false;
         };
@@ -302,7 +326,6 @@ impl NetworkLogManager {
     fn writer_pool(&self) -> &WriterPool {
         self.inner.writers.get_or_init(|| {
             WriterPool::start(
-                self.inner.state.completion_handle(),
                 self.inner.writer_config.normalized(),
                 #[cfg(test)]
                 self.inner.write_gate.clone(),
@@ -310,18 +333,16 @@ impl NetworkLogManager {
         })
     }
 
-    async fn begin_session_drain(&self, source_ip: &str, path: &Path, generation: u64) -> bool {
+    fn begin_session_drain(&self, source_ip: &str, path: &Path, generation: u64) -> bool {
         self.inner
             .state
             .begin_session_drain(source_ip, path, generation)
-            .await
     }
 
-    async fn finalize_session(&self, source_ip: &str, path: &Path, generation: u64) -> bool {
+    fn finalize_session(&self, source_ip: &str, path: &Path, generation: u64) -> bool {
         self.inner
             .state
             .finalize_session(source_ip, path, generation)
-            .await
     }
 
     /// Wait until all currently accepted Rust-side writes for `path` finish.
@@ -367,7 +388,7 @@ mod tests {
     }
 
     async fn source_ip_registered(manager: &NetworkLogManager, source_ip: &str) -> bool {
-        manager.inner.state.source_ip_registered(source_ip).await
+        manager.inner.state.source_ip_registered(source_ip)
     }
 
     async fn wait_source_ip_unregistered(manager: &NetworkLogManager, source_ip: &str) {
@@ -381,6 +402,183 @@ mod tests {
                 "source IP {source_ip} stayed registered after session drop",
             );
             tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn writer_panic_does_not_strand_accepted_sessions_or_flush_waiters() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_path = dir.path().join("first.jsonl");
+        let second_path = dir.path().join("second.jsonl");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
+        let manager = NetworkLogManager::new_with_write_gate_and_config(
+            Arc::clone(&started),
+            Arc::clone(&release),
+            WriterConfig {
+                shards: 1,
+                ..Default::default()
+            },
+        );
+        let first = manager
+            .register_source_ip("10.0.0.1", first_path.clone())
+            .await;
+        let second = manager
+            .register_source_ip("10.0.0.2", second_path.clone())
+            .await;
+        assert!(manager.append_for_ip("10.0.0.1", json!({"row": 1})).await);
+        started.notified().await;
+        // The first batch is owned by the writer; these rows remain queued.
+        assert!(manager.append_for_ip("10.0.0.1", json!({"row": 2})).await);
+        assert!(manager.append_for_ip("10.0.0.2", json!({"row": 3})).await);
+        release.close(); // Fail at the append boundary, unwinding the outer writer.
+        let drain = NetworkLogDrainCoordinator::default();
+        let (first_observation, second_observation, (), ()) =
+            tokio::time::timeout(Duration::from_secs(2), async {
+                tokio::join!(
+                    first.close_for_upload(RunId::new_v4(), &drain),
+                    second.close_for_upload(RunId::new_v4(), &drain),
+                    manager.flush_path(&first_path),
+                    manager.flush_path(&first_path),
+                )
+            })
+            .await
+            .expect("terminated writer must not strand accepted rows or concurrent flush waiters");
+        assert!(first_observation.writer_failed());
+        assert!(second_observation.writer_failed());
+        assert!(!first_path.exists());
+        assert!(!second_path.exists());
+    }
+
+    // Prevent a failing assertion from leaving a real blocking task held while
+    // the test runtime tries to shut down.
+    struct CloseWriteGateOnDrop(Arc<Semaphore>);
+
+    impl Drop for CloseWriteGateOnDrop {
+        fn drop(&mut self) {
+            self.0.close();
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_writer_keeps_blocking_append_owned_until_real_file_completion() {
+        use tracing_subscriber::prelude::*;
+        use tracing_test_support::CapturedEvents;
+
+        let captured = CapturedEvents::default();
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+        tracing::callsite::rebuild_interest_cache();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("network.jsonl");
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Semaphore::new(0));
+        let _release_on_drop = CloseWriteGateOnDrop(Arc::clone(&release));
+        let manager = NetworkLogManager::new_for_test(
+            Some(WriteGate {
+                started: Arc::clone(&started),
+                release: Arc::clone(&release),
+                blocking: true,
+            }),
+            None,
+            WriterConfig {
+                shards: 1,
+                ..Default::default()
+            },
+        );
+        let session = manager.register_source_ip("10.0.0.1", path.clone()).await;
+        assert!(manager.append_for_ip("10.0.0.1", json!({"row": 1})).await);
+        tokio::time::timeout(Duration::from_secs(2), started.notified())
+            .await
+            .unwrap();
+        assert!(manager.append_for_ip("10.0.0.1", json!({"row": 2})).await);
+        let writer = &manager.writer_pool().tasks[0];
+        writer.abort();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !writer.is_finished() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        let drain = NetworkLogDrainCoordinator::noop();
+        let run_id = RunId::new_v4();
+        let close = session.close_for_upload(run_id, &drain);
+        tokio::pin!(close);
+        tokio::select! {
+            biased;
+            _ = &mut close => panic!("outer writer cancellation discharged an active blocking append"),
+            _ = tokio::task::yield_now() => {}
+        }
+        assert!(!path.exists());
+        tokio::time::pause();
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(31)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            captured.entries().iter().any(|event| {
+                event.fields.get("message").map(String::as_str)
+                    == Some("required cleanup still pending")
+                    && event.fields.get("phase").map(String::as_str) == Some("accepted_write_flush")
+                    && event.fields.get("run_id") == Some(&run_id.to_string())
+            }),
+            "delayed flush must identify its run without claiming completion"
+        );
+        tokio::time::resume();
+        release.add_permits(1);
+        let observation = tokio::time::timeout(Duration::from_secs(2), close)
+            .await
+            .unwrap();
+        assert!(
+            observation.writer_failed(),
+            "the queued row was abandoned, not persisted"
+        );
+        assert_eq!(read_json_lines(&path), vec![json!({"row": 1})]);
+    }
+
+    #[tokio::test]
+    async fn blocking_append_failure_is_observed_after_source_mapping_is_removed() {
+        for panic in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("network.jsonl");
+            // A directory is rejected by the actual append boundary.
+            std::fs::create_dir(&path).unwrap();
+            let started = Arc::new(Notify::new());
+            let release = Arc::new(Semaphore::new(0));
+            let _release_on_drop = CloseWriteGateOnDrop(Arc::clone(&release));
+            let manager = NetworkLogManager::new_for_test(
+                Some(WriteGate {
+                    started: Arc::clone(&started),
+                    release: Arc::clone(&release),
+                    blocking: true,
+                }),
+                None,
+                WriterConfig::default(),
+            );
+            let session = manager.register_source_ip("10.0.0.1", path.clone()).await;
+            assert!(manager.append_for_ip("10.0.0.1", json!({"row": 1})).await);
+            tokio::time::timeout(Duration::from_secs(2), started.notified())
+                .await
+                .unwrap();
+            let drain = NetworkLogDrainCoordinator::noop();
+            let close = session.close_for_upload(RunId::new_v4(), &drain);
+            tokio::pin!(close);
+            tokio::select! {
+                biased;
+                _ = &mut close => panic!("close completed before append result"),
+                _ = tokio::task::yield_now() => {}
+            }
+            assert!(!source_ip_registered(&manager, "10.0.0.1").await);
+            if panic {
+                release.close();
+            } else {
+                release.add_permits(1);
+            }
+            let observation = tokio::time::timeout(Duration::from_secs(2), close)
+                .await
+                .unwrap();
+            assert!(observation.writer_failed());
+            assert!(path.is_dir());
         }
     }
 
@@ -699,8 +897,7 @@ mod tests {
             manager
                 .inner
                 .state
-                .source_and_pending_path_share_identity("10.200.0.2", &old_path)
-                .await,
+                .source_and_pending_path_share_identity("10.200.0.2", &old_path),
             "repeated appends should reuse the registered path allocation"
         );
 
@@ -717,8 +914,7 @@ mod tests {
             manager
                 .inner
                 .state
-                .source_and_pending_path_share_identity("10.200.0.2", &new_path)
-                .await,
+                .source_and_pending_path_share_identity("10.200.0.2", &new_path),
             "re-registered source should share its new path allocation"
         );
 
@@ -970,9 +1166,7 @@ mod tests {
         let manager = NetworkLogManager::new();
         let session = manager.register_source_ip("10.200.0.2", path.clone()).await;
 
-        manager
-            .begin_session_drain(&session.source_ip, &session.path, session.generation)
-            .await;
+        manager.begin_session_drain(&session.source_ip, &session.path, session.generation);
         assert!(
             manager
                 .append_for_ip("10.200.0.2", json!({"type":"dns","host":"late.test"}))
@@ -984,9 +1178,7 @@ mod tests {
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0]["host"], "late.test");
 
-        manager
-            .finalize_session(&session.source_ip, &session.path, session.generation)
-            .await;
+        manager.finalize_session(&session.source_ip, &session.path, session.generation);
         assert!(
             !manager
                 .append_for_ip("10.200.0.2", json!({"type":"dns","host":"closed.test"}))
@@ -1004,15 +1196,11 @@ mod tests {
             .register_source_ip("10.200.0.2", old_path.clone())
             .await;
 
-        manager
-            .begin_session_drain(&old.source_ip, &old.path, old.generation)
-            .await;
+        manager.begin_session_drain(&old.source_ip, &old.path, old.generation);
         let _new_session = manager
             .register_source_ip("10.200.0.2", new_path.clone())
             .await;
-        manager
-            .finalize_session(&old.source_ip, &old.path, old.generation)
-            .await;
+        manager.finalize_session(&old.source_ip, &old.path, old.generation);
 
         assert!(
             manager

--- a/crates/runner/src/network_log_manager/state.rs
+++ b/crates/runner/src/network_log_manager/state.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Weak};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, Weak};
 
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::Notify;
 use tracing::warn;
 
 #[derive(Default)]
@@ -22,15 +23,25 @@ enum SourceState {
         path: Arc<Path>,
         generation: u64,
         writer_backpressure_observed: bool,
+        writer_failed: Arc<AtomicBool>,
     },
     Draining {
         path: Arc<Path>,
         generation: u64,
         writer_backpressure_observed: bool,
+        writer_failed: Arc<AtomicBool>,
     },
 }
 
 impl SourceState {
+    fn writer_failed(&self) -> &Arc<AtomicBool> {
+        match self {
+            Self::Active { writer_failed, .. } | Self::Draining { writer_failed, .. } => {
+                writer_failed
+            }
+        }
+    }
+
     fn path(&self) -> &Arc<Path> {
         match self {
             Self::Active { path, .. } | Self::Draining { path, .. } => path,
@@ -79,16 +90,19 @@ pub(super) struct SourceRegistration {
     pub(super) source_ip: String,
     pub(super) path: Arc<Path>,
     pub(super) generation: u64,
+    pub(super) writer_failed: Arc<AtomicBool>,
 }
 
 pub(super) struct SourceSnapshot {
     pub(super) path: Arc<Path>,
     generation: u64,
+    writer_failed: Arc<AtomicBool>,
 }
 
 pub(super) struct AcceptedAppend {
     path: Arc<Path>,
     line: String,
+    completion: PendingWriteCompletion,
 }
 
 impl AcceptedAppend {
@@ -96,73 +110,108 @@ impl AcceptedAppend {
         self.line.len()
     }
 
-    pub(super) fn into_parts(self) -> (Arc<Path>, String) {
-        (self.path, self.line)
+    pub(super) fn into_parts(self) -> (Arc<Path>, String, PendingWriteCompletion) {
+        (self.path, self.line, self.completion)
     }
 }
 
-#[derive(Clone)]
+/// Follows an accepted row through the queue and into the blocking append.
+/// Drop records failure, never successful persistence.
 pub(super) struct PendingWriteCompletion {
     state: Weak<NetworkLogState>,
+    path: Arc<Path>,
+    writer_failed: Arc<AtomicBool>,
+    settled: bool,
 }
 
 impl PendingWriteCompletion {
-    pub(super) async fn complete_path(&self, path: Arc<Path>, count: usize) {
+    /// Preserve one accounting lock per normal path batch.
+    pub(super) fn complete_batch(mut completions: Vec<Self>, success: bool) {
+        let Some(first) = completions.first() else {
+            return;
+        };
+        let state = first.state.upgrade();
+        let path = Arc::clone(&first.path);
+        let count = completions.len();
+        for completion in &mut completions {
+            if !success {
+                completion.writer_failed.store(true, Ordering::Release);
+            }
+            completion.settled = true;
+        }
+        if let Some(state) = state {
+            state.complete_path(path, count);
+        }
+    }
+}
+
+impl Drop for PendingWriteCompletion {
+    fn drop(&mut self) {
+        if self.settled {
+            return;
+        }
+        if !self.writer_failed.swap(true, Ordering::AcqRel) {
+            warn!(path = %self.path.display(), "accepted network log write abandoned by its owner");
+        }
         if let Some(state) = self.state.upgrade() {
-            state.complete_path(path, count).await;
+            state.complete_path(Arc::clone(&self.path), 1);
         }
     }
 }
 
 impl NetworkLogState {
-    pub(super) fn completion_handle(self: &Arc<Self>) -> PendingWriteCompletion {
-        PendingWriteCompletion {
-            state: Arc::downgrade(self),
-        }
+    // Registry/accounting only: no I/O, await or nested work under this lock.
+    fn lock(&self) -> std::sync::MutexGuard<'_, State> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    pub(super) async fn register_source_ip(
+    pub(super) fn register_source_ip(
         &self,
         source_ip: String,
         path: PathBuf,
     ) -> SourceRegistration {
-        let mut state = self.state.lock().await;
+        let mut state = self.lock();
         state.next_generation += 1;
         let generation = state.next_generation;
         let path: Arc<Path> = path.into();
+        let writer_failed = Arc::new(AtomicBool::new(false));
         state.source_paths.insert(
             source_ip.clone(),
             SourceState::Active {
                 path: Arc::clone(&path),
                 generation,
                 writer_backpressure_observed: false,
+                writer_failed: Arc::clone(&writer_failed),
             },
         );
         SourceRegistration {
             source_ip,
             path,
             generation,
+            writer_failed,
         }
     }
 
     #[cfg(test)]
-    pub(super) async fn unregister_source_ip(&self, source_ip: &str) {
-        let mut state = self.state.lock().await;
+    pub(super) fn unregister_source_ip(&self, source_ip: &str) {
+        let mut state = self.lock();
         state.source_paths.remove(source_ip);
     }
 
     #[cfg(test)]
-    pub(super) async fn source_ip_registered(&self, source_ip: &str) -> bool {
-        self.state.lock().await.source_paths.contains_key(source_ip)
+    pub(super) fn source_ip_registered(&self, source_ip: &str) -> bool {
+        self.lock().source_paths.contains_key(source_ip)
     }
 
     #[cfg(test)]
-    pub(super) async fn source_and_pending_path_share_identity(
+    pub(super) fn source_and_pending_path_share_identity(
         &self,
         source_ip: &str,
         path: &Path,
     ) -> bool {
-        let state = self.state.lock().await;
+        let state = self.lock();
         let Some(source) = state.source_paths.get(source_ip) else {
             return false;
         };
@@ -172,24 +221,25 @@ impl NetworkLogState {
         Arc::ptr_eq(source.path(), pending_path)
     }
 
-    pub(super) async fn source_snapshot(&self, source_ip: &str) -> Option<SourceSnapshot> {
-        let state = self.state.lock().await;
+    pub(super) fn source_snapshot(&self, source_ip: &str) -> Option<SourceSnapshot> {
+        let state = self.lock();
         state
             .source_paths
             .get(source_ip)
             .map(|source| SourceSnapshot {
                 path: Arc::clone(source.path()),
                 generation: source.generation(),
+                writer_failed: Arc::clone(source.writer_failed()),
             })
     }
 
-    pub(super) async fn try_accept_snapshot(
-        &self,
+    pub(super) fn try_accept_snapshot(
+        self: &Arc<Self>,
         source_ip: &str,
         snapshot: &SourceSnapshot,
         line: String,
     ) -> Option<AcceptedAppend> {
-        let mut state = self.state.lock().await;
+        let mut state = self.lock();
         let source_state = state.source_paths.get(source_ip)?;
         if !source_state.matches(snapshot.path.as_ref(), snapshot.generation) {
             return None;
@@ -202,15 +252,17 @@ impl NetworkLogState {
         Some(AcceptedAppend {
             path: Arc::clone(&snapshot.path),
             line,
+            completion: PendingWriteCompletion {
+                state: Arc::downgrade(self),
+                path: Arc::clone(&snapshot.path),
+                writer_failed: Arc::clone(&snapshot.writer_failed),
+                settled: false,
+            },
         })
     }
 
-    pub(super) async fn mark_writer_backpressure(
-        &self,
-        source_ip: &str,
-        snapshot: &SourceSnapshot,
-    ) {
-        let mut state = self.state.lock().await;
+    pub(super) fn mark_writer_backpressure(&self, source_ip: &str, snapshot: &SourceSnapshot) {
+        let mut state = self.lock();
         let Some(source_state) = state.source_paths.get_mut(source_ip) else {
             return;
         };
@@ -229,13 +281,13 @@ impl NetworkLogState {
         }
     }
 
-    pub(super) async fn begin_session_drain(
+    pub(super) fn begin_session_drain(
         &self,
         source_ip: &str,
         path: &Path,
         generation: u64,
     ) -> bool {
-        let mut state = self.state.lock().await;
+        let mut state = self.lock();
         let Some(source_state) = state.source_paths.get(source_ip) else {
             return false;
         };
@@ -244,24 +296,21 @@ impl NetworkLogState {
         }
         let path = Arc::clone(source_state.path());
         let writer_backpressure_observed = source_state.writer_backpressure_observed();
+        let writer_failed = Arc::clone(source_state.writer_failed());
         state.source_paths.insert(
             source_ip.to_string(),
             SourceState::Draining {
                 path,
                 generation,
                 writer_backpressure_observed,
+                writer_failed,
             },
         );
         true
     }
 
-    pub(super) async fn finalize_session(
-        &self,
-        source_ip: &str,
-        path: &Path,
-        generation: u64,
-    ) -> bool {
-        let mut state = self.state.lock().await;
+    pub(super) fn finalize_session(&self, source_ip: &str, path: &Path, generation: u64) -> bool {
+        let mut state = self.lock();
         let Some(source_state) = state.source_paths.get(source_ip) else {
             return false;
         };
@@ -276,7 +325,7 @@ impl NetworkLogState {
     pub(super) async fn flush_path(&self, path: &Path) {
         loop {
             let notified = {
-                let state = self.state.lock().await;
+                let state = self.lock();
                 let Some(path_state) = state.pending_paths.get(path) else {
                     return;
                 };
@@ -289,7 +338,7 @@ impl NetworkLogState {
             notified.as_mut().enable();
 
             {
-                let state = self.state.lock().await;
+                let state = self.lock();
                 if !state.pending_paths.contains_key(path) {
                     return;
                 }
@@ -299,12 +348,12 @@ impl NetworkLogState {
         }
     }
 
-    async fn complete_path(&self, path: Arc<Path>, count: usize) {
+    fn complete_path(&self, path: Arc<Path>, count: usize) {
         if count == 0 {
             return;
         }
         let notify = {
-            let mut state = self.state.lock().await;
+            let mut state = self.lock();
             let Some(path_state) = state.pending_paths.get_mut(path.as_ref()) else {
                 warn!(path = %path.display(), "network log write completed for unknown path");
                 return;

--- a/crates/runner/src/network_log_manager/writer.rs
+++ b/crates/runner/src/network_log_manager/writer.rs
@@ -38,11 +38,14 @@ impl Default for WriterConfig {
 
 pub(super) struct WriterPool {
     shards: Vec<mpsc::Sender<AcceptedAppend>>,
+    #[cfg(test)]
+    pub(super) tasks: Vec<tokio::task::AbortHandle>,
 }
 
 struct PathWriteBatch {
     path: Arc<Path>,
     lines: Vec<String>,
+    completions: Vec<PendingWriteCompletion>,
 }
 
 impl WriterConfig {
@@ -57,24 +60,30 @@ impl WriterConfig {
 }
 
 impl WriterPool {
-    pub(super) fn start(
-        completion: PendingWriteCompletion,
-        config: WriterConfig,
-        #[cfg(test)] write_gate: Option<WriteGate>,
-    ) -> Self {
+    pub(super) fn start(config: WriterConfig, #[cfg(test)] write_gate: Option<WriteGate>) -> Self {
         let mut shards = Vec::with_capacity(config.shards);
+        #[cfg(test)]
+        let mut tasks = Vec::with_capacity(config.shards);
         for _ in 0..config.shards {
             let (tx, rx) = mpsc::channel(config.queue_capacity);
             shards.push(tx);
-            std::mem::drop(tokio::spawn(run_writer_shard(
-                completion.clone(),
+            let task = tokio::spawn(run_writer_shard(
                 rx,
                 config,
                 #[cfg(test)]
                 write_gate.clone(),
-            )));
+            ));
+            #[cfg(test)]
+            tasks.push(task.abort_handle());
+            // Channel closure owns normal shard completion; accepted-write
+            // guards own accounting even if the shard unwinds or is cancelled.
+            drop(task);
         }
-        Self { shards }
+        Self {
+            shards,
+            #[cfg(test)]
+            tasks,
+        }
     }
 
     pub(super) fn sender_for_path(&self, path: &Path) -> Option<mpsc::Sender<AcceptedAppend>> {
@@ -90,7 +99,6 @@ impl WriterPool {
 }
 
 async fn run_writer_shard(
-    completion: PendingWriteCompletion,
     mut rx: mpsc::Receiver<AcceptedAppend>,
     config: WriterConfig,
     #[cfg(test)] write_gate: Option<WriteGate>,
@@ -125,7 +133,6 @@ async fn run_writer_shard(
 
         for batch in batches {
             write_path_batch(
-                completion.clone(),
                 batch,
                 #[cfg(test)]
                 write_gate.clone(),
@@ -143,44 +150,58 @@ fn push_accepted_append(
 ) {
     *row_count += 1;
     *byte_count += item.line_len();
-    let (path, line) = item.into_parts();
+    let (path, line, completion) = item.into_parts();
     if let Some(batch) = batches.iter_mut().find(|batch| batch.path == path) {
         batch.lines.push(line);
+        batch.completions.push(completion);
     } else {
         batches.push(PathWriteBatch {
             path,
             lines: vec![line],
+            completions: vec![completion],
         });
     }
 }
 
-async fn write_path_batch(
-    completion: PendingWriteCompletion,
-    batch: PathWriteBatch,
-    #[cfg(test)] write_gate: Option<WriteGate>,
-) {
+async fn write_path_batch(batch: PathWriteBatch, #[cfg(test)] write_gate: Option<WriteGate>) {
     #[cfg(test)]
-    if let Some(gate) = write_gate {
+    if let Some(gate) = &write_gate
+        && !gate.blocking
+    {
         gate.started.notify_one();
         let permit = gate.release.acquire().await.expect("write gate closed");
         permit.forget();
     }
 
     let path = batch.path;
-    let count = batch.lines.len();
     let write_path = Arc::clone(&path);
-    let result =
-        tokio::task::spawn_blocking(move || append_lines(write_path.as_ref(), &batch.lines)).await;
+    let result = tokio::task::spawn_blocking(move || {
+        #[cfg(test)]
+        if let Some(gate) = write_gate
+            && gate.blocking
+        {
+            gate.started.notify_one();
+            tokio::runtime::Handle::current()
+                .block_on(gate.release.acquire())
+                .expect("blocking write gate closed")
+                .forget();
+        }
+        let result = append_lines(write_path.as_ref(), &batch.lines);
+        if let Err(error) = &result {
+            warn!(path = %write_path.display(), %error, "failed to write network log");
+        }
+        // This closure can outlive the async shard. Settle only after physical
+        // I/O completes; unwinding also drops the owned completion guards.
+        PendingWriteCompletion::complete_batch(batch.completions, result.is_ok());
+        result
+    })
+    .await;
 
     match result {
         Ok(Ok(())) => {}
-        Ok(Err(e)) => {
-            warn!(path = %path.display(), error = %e, "failed to write network log")
-        }
+        Ok(Err(_)) => {}
         Err(e) => {
             warn!(path = %path.display(), error = %e, "network log writer task failed");
         }
     }
-
-    completion.complete_path(path, count).await;
 }

--- a/crates/runner/src/network_log_process.rs
+++ b/crates/runner/src/network_log_process.rs
@@ -1,6 +1,8 @@
 use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, warn};
 
 use crate::child_cleanup::kill_and_reap_child_on_drop;
+use crate::error::{RunnerError, RunnerResult};
 use crate::network_log_drain::{DrainableLineReaderExit, NetworkLogDrainProducer};
 
 /// Owns the common post-spawn lifecycle of a required network-log process.
@@ -9,6 +11,9 @@ pub(crate) struct NetworkLogProcess {
     cancel: CancellationToken,
     task: Option<tokio::task::JoinHandle<DrainableLineReaderExit>>,
     child: Option<tokio::process::Child>,
+    child_cleanup: Option<tokio::task::JoinHandle<std::io::Result<()>>>,
+    #[cfg(test)]
+    reap_gate: Option<crate::child_cleanup::ReapGate>,
     drain: NetworkLogDrainProducer,
 }
 
@@ -25,6 +30,9 @@ impl NetworkLogProcess {
             cancel,
             task: Some(task),
             child: Some(child),
+            child_cleanup: None,
+            #[cfg(test)]
+            reap_gate: None,
             drain,
         }
     }
@@ -43,26 +51,59 @@ impl NetworkLogProcess {
         result
     }
 
-    /// Kill the child when necessary and wait for it to be reaped.
-    pub(crate) async fn kill_and_reap_child(&mut self) {
-        let child_reaped = if let Some(ref mut child) = self.child {
-            let _ = child.start_kill();
-            child.wait().await.is_ok()
-        } else {
-            false
+    /// Transfer child cleanup without blocking lifecycle publication. The
+    /// handle is joined by stop; dropping it leaves the reaper progressing.
+    pub(crate) fn start_child_cleanup(&mut self) {
+        let Some(child) = self.child.take() else {
+            return;
         };
-        if child_reaped {
-            self.child = None;
-        }
+        let pid = child.id();
+        let reaper = crate::child_cleanup::ChildReaper::new(self.child_label, child);
+        #[cfg(test)]
+        let reaper = reaper.with_gate(self.reap_gate.take());
+        self.child_cleanup = Some(tokio::spawn(reaper.reap().instrument(tracing::info_span!(
+            "network_log_child_cleanup",
+            component = self.child_label,
+            pid
+        ))));
     }
 
     /// Cancel the monitor task and wait for the child and task to finish.
-    pub(crate) async fn stop(mut self) {
+    pub(crate) async fn stop(mut self) -> RunnerResult<()> {
         self.cancel.cancel();
-        self.kill_and_reap_child().await;
-        if let Some(task) = self.task.take() {
-            let _ = task.await;
+        self.start_child_cleanup();
+        let child_result = if let Some(task) = self.child_cleanup.take() {
+            match task.await {
+                Ok(result) => result.map_err(|error| {
+                    RunnerError::Internal(format!(
+                        "{} child cleanup failed: {error}",
+                        self.child_label
+                    ))
+                }),
+                Err(error) => Err(RunnerError::Internal(format!(
+                    "{} child cleanup task failed: {error}",
+                    self.child_label
+                ))),
+            }
+        } else {
+            Ok(())
+        };
+        let monitor_result = if let Some(task) = self.task.take() {
+            task.await.map(|_| ()).map_err(|error| {
+                RunnerError::Internal(format!(
+                    "{} monitor cleanup failed: {error}",
+                    self.child_label
+                ))
+            })
+        } else {
+            Ok(())
+        };
+        if child_result.is_err()
+            && let Err(error) = &monitor_result
+        {
+            warn!(component = self.child_label, %error, "network-log monitor cleanup failed");
         }
+        child_result.and(monitor_result)
     }
 
     pub(crate) fn drain_producer(&self) -> NetworkLogDrainProducer {
@@ -94,8 +135,15 @@ impl NetworkLogProcess {
                 }
             })),
             child: None,
+            child_cleanup: None,
+            reap_gate: None,
             drain,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_reap_gate(&mut self, gate: crate::child_cleanup::ReapGate) {
+        self.reap_gate = Some(gate);
     }
 
     /// Replace the monitor with a task that panics when triggered.

--- a/crates/runner/src/proxy/managed_process.rs
+++ b/crates/runner/src/proxy/managed_process.rs
@@ -22,6 +22,8 @@ pub(crate) struct ManagedMitmdump {
     leader_reaped: bool,
     launch: Option<tempfile::TempDir>,
     runtime: Option<Arc<MitmdumpRuntime>>,
+    #[cfg(test)]
+    reap_gate: Option<crate::child_cleanup::ReapGate>,
 }
 
 impl ManagedMitmdump {
@@ -42,6 +44,8 @@ impl ManagedMitmdump {
             leader_reaped: false,
             launch: Some(launch),
             runtime: Some(runtime),
+            #[cfg(test)]
+            reap_gate: None,
         })
     }
 
@@ -53,6 +57,7 @@ impl ManagedMitmdump {
             leader_reaped: false,
             launch: None,
             runtime: None,
+            reap_gate: None,
         }
     }
 
@@ -80,6 +85,11 @@ impl ManagedMitmdump {
     }
 
     pub(super) async fn force_stop(mut self) -> RunnerResult<()> {
+        let _progress = crate::cleanup_progress::CleanupProgress::start(
+            "mitmdump",
+            "force_stop",
+            crate::cleanup_progress::CleanupIdentity::Process(self.id()),
+        );
         let is_running = self
             .try_wait()
             .map_err(|error| RunnerError::Internal(format!("check mitmdump process: {error}")))?
@@ -146,11 +156,20 @@ impl ManagedMitmdump {
         let Some(child) = self.child.as_mut() else {
             return Ok(());
         };
+        #[cfg(test)]
+        if let Some(gate) = self.reap_gate.take() {
+            gate.wait().await;
+        }
         child.wait().await.map_err(|error| {
             RunnerError::Internal(format!("wait for killed mitmdump process: {error}"))
         })?;
         self.leader_reaped = true;
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_reap_gate(&mut self, gate: crate::child_cleanup::ReapGate) {
+        self.reap_gate = Some(gate);
     }
 
     async fn close_launch(&mut self) -> RunnerResult<()> {

--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -36,10 +36,12 @@
 //! and prepares addon files, an empty registry, crash channel, and initial
 //! usage state. `start` gives each `mitmdump` process group a private `TMPDIR`
 //! and starts monitor tasks. Unexpected stdout close notifies the runner unless
-//! the child is stopping gracefully. `begin_restart` terminates the old process
-//! group, removes its private launch directory, permanently silences its
-//! monitor, and returns fresh spawn parameters; `complete_restart` stores the
-//! new child. Shutdown writes a usage flush request, signals the addon, waits
+//! the child is stopping gracefully. `begin_restart` transfers the old child
+//! and fresh parameters to an independent recovery task and silences the old
+//! monitor. Recovery reaps the old process tree and removes its private launch
+//! directory before spawning; `complete_restart` stores the new child. Unknown
+//! old-child cleanup failures stop recovery instead of starting another child.
+//! Shutdown writes a usage flush request, signals the addon, waits
 //! boundedly for `usage-pending`, then calls `stop`. Recovery and shutdown only
 //! act on runner-owned private paths and marked processes; legacy shared
 //! `/tmp/_MEI*` paths are deliberately left untouched.
@@ -65,6 +67,7 @@ pub use flush::{
     write_usage_flush_request,
 };
 pub(crate) use managed_process::ManagedMitmdump;
+pub(crate) use process::MitmRestartError;
 pub use process::{MitmProxy, ProxyConfig};
 pub(crate) use registry::{
     ConnectorRuntimeFailCloseOutcome, ConnectorRuntimeRegistryUpdate,

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead};
 use tokio::sync::{Mutex as AsyncMutex, mpsc};
-use tracing::{error, info, warn};
+use tracing::{Instrument, error, info, warn};
 
 use super::flush::{
     MitmJsonlFlushHandle, UsageFlushTarget, new_usage_state_id, usage_flush_state_guard,
@@ -501,9 +501,8 @@ impl MitmProxy {
         }
     }
 
-    /// Prepare for restart: kill any lingering child, permanently silence
-    /// its stdout monitor, and return fresh parameters for
-    /// [`spawn_mitmdump`].
+    /// Transfer any lingering child and fresh parameters to the restart owner,
+    /// permanently silencing the old monitor without waiting for process I/O.
     ///
     /// `stopping` is scoped to a single child. The old flag is set to
     /// `true` (so the old monitor task, which may observe the stdout
@@ -513,37 +512,14 @@ impl MitmProxy {
     /// the incoming process. The new child's monitor starts from a
     /// clean slate and will detect real crashes.
     ///
-    /// The caller should spawn the mitmdump process (potentially in a
-    /// background task) and then call `complete_restart` with the result.
-    pub async fn begin_restart(&mut self) -> RunnerResult<MitmRestartParams> {
-        // Silence the old monitor permanently: after this call, no one
-        // else holds a handle that could reset its `Arc<AtomicBool>`
-        // back to `false`, so the monitor is guaranteed to read `true`
-        // regardless of scheduling order between `kill().await` and
-        // the stdout-pipe drain.
+    /// The caller drives `MitmRestartParams::spawn` in a background task. It
+    /// finishes old-child cleanup before starting the replacement; the caller
+    /// then adopts the result with `complete_restart`.
+    pub fn begin_restart(&mut self) -> MitmRestartParams {
+        // Each monitor keeps its own flag: an old child's delayed EOF must
+        // never be interpreted as a crash of the replacement.
         self.stopping.store(true, Ordering::Release);
-        if let Some(mut child) = self.child.take() {
-            match child.try_wait() {
-                Ok(Some(_status)) => {}
-                Ok(None) => error!(
-                    r#type = "usage_underbilling",
-                    reason = "mitm_restart_in_memory_usage_risk",
-                    underbilling_class = "risk",
-                    component = "runner",
-                    "restarting mitmdump by killing live child; in-memory usage may be lost"
-                ),
-                Err(e) => error!(
-                    r#type = "usage_underbilling",
-                    reason = "mitm_restart_in_memory_usage_risk",
-                    underbilling_class = "risk",
-                    component = "runner",
-                    error = %e,
-                    "failed to query mitmdump status before restart kill; in-memory usage may be lost"
-                ),
-            }
-            child.force_stop().await?;
-        }
-        // Fresh flag for the incoming process's monitor.
+        let old_child = self.child.take();
         let new_stopping = Arc::new(AtomicBool::new(false));
         self.stopping = Arc::clone(&new_stopping);
         let (usage_state_id, usage_state_started_at_ms) = new_usage_state_id();
@@ -553,14 +529,15 @@ impl MitmProxy {
             expected_usage_state_id: usage_state_id.clone(),
             usage_state_started_at_ms,
         };
-        Ok(MitmRestartParams {
+        MitmRestartParams {
+            old_child,
             config: self.config.clone(),
             runtime: self.runtime.clone(),
             port: self.port,
             crash_tx: self.crash_tx.clone(),
             stopping: new_stopping,
             usage_state_id,
-        })
+        }
     }
 
     /// Finish a restart by storing the newly spawned child process.
@@ -638,6 +615,13 @@ impl MitmProxy {
         self.child = Some(ManagedMitmdump::unmanaged(child));
     }
 
+    pub fn set_reap_gate_for_test(&mut self, gate: crate::child_cleanup::ReapGate) {
+        self.child
+            .as_mut()
+            .expect("test child installed")
+            .set_reap_gate(gate);
+    }
+
     pub fn set_addon_dir_for_test(&mut self, addon_dir: PathBuf) {
         self.config.addon_dir = addon_dir;
     }
@@ -654,6 +638,7 @@ impl Drop for MitmProxy {
 /// [`MitmProxy::begin_restart`]. All fields are owned/cloned so the spawn
 /// can happen in a background task without borrowing `MitmProxy`.
 pub(crate) struct MitmRestartParams {
+    old_child: Option<ManagedMitmdump>,
     config: ProxyConfig,
     runtime: Option<Arc<MitmdumpRuntime>>,
     port: u16,
@@ -662,9 +647,38 @@ pub(crate) struct MitmRestartParams {
     usage_state_id: String,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum MitmRestartError {
+    #[error("old mitmdump cleanup failed: {0}")]
+    Cleanup(RunnerError),
+    #[error(transparent)]
+    Startup(#[from] RunnerError),
+}
+
 impl MitmRestartParams {
     /// Spawn mitmdump using these parameters. Suitable for `tokio::spawn`.
-    pub(crate) async fn spawn(self) -> RunnerResult<ManagedMitmdump> {
+    pub(crate) async fn spawn(self) -> Result<ManagedMitmdump, MitmRestartError> {
+        if let Some(mut child) = self.old_child {
+            let pid = child.id();
+            match child.try_wait() {
+                Ok(Some(_)) => {}
+                result => error!(
+                    r#type = "usage_underbilling",
+                    reason = "mitm_restart_in_memory_usage_risk",
+                    underbilling_class = "risk",
+                    component = "runner",
+                    ?result,
+                    "restarting mitmdump without confirmed exit; in-memory usage may be lost"
+                ),
+            }
+            // Includes reaping and launch-directory cleanup. A replacement
+            // must not start while the old process tree is still owned.
+            child
+                .force_stop()
+                .instrument(tracing::info_span!("mitm_old_child_cleanup", pid))
+                .await
+                .map_err(MitmRestartError::Cleanup)?;
+        }
         let runtime = self
             .runtime
             .ok_or_else(|| RunnerError::Internal("missing mitmdump runtime owner".to_string()))?;
@@ -677,7 +691,7 @@ impl MitmRestartParams {
             &self.usage_state_id,
         )
         .await
-        .map_err(MitmdumpStartupFailure::into_runner_error)
+        .map_err(|failure| MitmRestartError::Startup(failure.into_runner_error()))
     }
 }
 
@@ -2123,16 +2137,31 @@ exit 42
         let environment = std::fs::read_to_string(fake_mitmdump.with_extension("env")).unwrap();
         let old_launch = PathBuf::from(environment.lines().next().unwrap());
 
-        let restart = proxy.begin_restart().await.unwrap();
+        let gate = crate::child_cleanup::ReapGate::new();
+        proxy.set_reap_gate_for_test(gate.clone());
+        let restart = proxy.begin_restart();
+        let restart_task = tokio::spawn(restart.spawn());
+        tokio::time::timeout(Duration::from_secs(2), gate.entered.notified())
+            .await
+            .unwrap();
+        assert!(!restart_task.is_finished());
+        assert!(
+            old_launch.exists(),
+            "old launch must remain owned until reaping completes"
+        );
+        assert_eq!(
+            std::fs::read_to_string(fake_mitmdump.with_extension("env")).unwrap(),
+            environment,
+            "replacement must not start before old-child cleanup completes"
+        );
+        gate.release.add_permits(1);
+        let child = restart_task.await.unwrap().unwrap();
 
         assert!(
             wait_for_pid_absent(old_descendant_pid).await,
             "restart left forked descendant {old_descendant_pid} alive"
         );
         assert!(!old_launch.exists(), "restart left old launch directory");
-        assert_no_launch_dirs(&runtime_dir).await;
-
-        let child = restart.spawn().await.unwrap();
         proxy.complete_restart(child);
         proxy.kill_now().await.unwrap();
         assert_no_launch_dirs(&runtime_dir).await;
@@ -2448,7 +2477,7 @@ while True:
         let (mut proxy, _crash_rx) = MitmProxy::noop();
         let old_stopping = Arc::clone(&proxy.stopping);
 
-        let params = proxy.begin_restart().await.unwrap();
+        let params = proxy.begin_restart();
 
         // Old flag is now permanently `true`; any task still holding
         // `old_stopping` (the old monitor) will observe graceful
@@ -2474,9 +2503,9 @@ while True:
     async fn repeated_begin_restart_produces_independent_flags() {
         let (mut proxy, _crash_rx) = MitmProxy::noop();
 
-        let first = proxy.begin_restart().await.unwrap();
-        let second = proxy.begin_restart().await.unwrap();
-        let third = proxy.begin_restart().await.unwrap();
+        let first = proxy.begin_restart();
+        let second = proxy.begin_restart();
+        let third = proxy.begin_restart();
 
         // Every handed-out Arc is distinct.
         assert!(!Arc::ptr_eq(&first.stopping, &second.stopping));
@@ -2499,7 +2528,7 @@ while True:
     #[tokio::test]
     async fn stop_after_begin_restart_targets_current_flag() {
         let (mut proxy, _crash_rx) = MitmProxy::noop();
-        let params = proxy.begin_restart().await.unwrap();
+        let params = proxy.begin_restart();
         let current = Arc::clone(&params.stopping);
         assert!(!current.load(Ordering::Acquire));
 

--- a/docs/runner-reactor-progress.md
+++ b/docs/runner-reactor-progress.md
@@ -55,6 +55,72 @@ New branches must be checked against both lock holders and queued waiters. Do no
 spawn discovery unconditionally or change admission/reuse policy to work around
 resource ownership problems.
 
+## Helper recovery and required cleanup
+
+MITM recovery transfers the old child synchronously into one independently
+scheduled restart task. That task finishes old-child reaping and launch-directory
+cleanup **before** starting a replacement. Each child retains its own stopping
+flag and usage identity. Normal shutdown joins in-flight recovery, adopts any
+replacement, and then uses the existing usage-flush/proxy-stop sequence. Ordinary
+startup failures retain backoff; unknown old-child cleanup failures or recovery
+task panics stop the runner and disable further retries. Managed-child Drop
+remains the abnormal process/launch reconciliation fallback.
+
+DNS/kmsg monitor completion starts independently scheduled child cleanup, then
+the reactor cancels admission and active runs and publishes Stopping. Each
+network-log process retains its cleanup handle for normal shutdown to join;
+dropping the reactor does not abort that reaper. DNS cleanup still precedes
+runtime/filter removal. Cleanup errors are reported instead of logging a
+successful helper stop. Public process/protocol/status schemas are unchanged.
+
+The common teardown entry also publishes Stopping: discovery can return `None`
+on cancellation before the mode-change branch wins. Required cleanup must not
+leave the persisted mode at Running merely because that branch won the race.
+This publication does not turn ordinary discovery exhaustion into hard
+cancellation: active jobs still drain normally unless lifecycle signaling stops
+them.
+
+## Accepted network-log writes
+
+An accepted row owns its pending completion through its bounded shard queue,
+per-path batch and physical blocking append. Normal batch completion still uses
+one accounting lock. Registry/accounting critical sections are synchronous and
+contain no I/O or await; source-generation checks and Notify registration before
+pending-state recheck remain authoritative.
+
+If an outer shard terminates, queued or batched rows that it drops settle as
+**failed**, with a warning and a per-session write-failure observation. Guards
+inside a started blocking append remain there until the real append finishes:
+dropping its async waiter cannot release pending ownership early. Session close
+waits for all accepted writes to settle and reports observed write failures even
+after source attribution has been removed. It does not claim every row was
+persisted when an append failed. Existing best-effort upload and execution-result
+semantics are unchanged; potentially partial batches are not replayed.
+
+## Pending-cleanup diagnostics and candidate disposition
+
+Helper reaping, session accepted-write flush and teardown phases emit
+`required cleanup still pending` every 30 seconds while unfinished. Warnings
+contain component, phase, elapsed milliseconds and a PID or run ID as direct
+event fields (Axiom does not inherit span fields). These observers stop when their
+scope ends; they never cancel cleanup, discharge pending counts or declare
+success. Existing phase-start/completion events remain available. A phase
+completion says that its function returned, not that an earlier reported error
+was repaired.
+
+| Candidate                                     | Verified disposition                                                                                                                                                                                       |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Retained heartbeat/status/GC and PollWakeups  | Independently progressing owners / bounded synchronous state remove the shared-reactor dependency described above.                                                                                         |
+| Inline MITM old-child cleanup                 | Moved into the single-flight restart owner; replacement waits for confirmed old-child cleanup.                                                                                                             |
+| DNS/kmsg monitor failure and reap             | Cancellation and lifecycle publication no longer wait for child cleanup; normal shutdown retains the join.                                                                                                 |
+| Producer drain barriers                       | Request/acknowledgement waits already have bounded, explicit unavailable/timeout outcomes. They do not discharge accepted writes or guarantee data still buffered in the producer/kernel.                  |
+| Pending accounting / outer writer termination | Accepted-write guards settle abandoned work as failed. Regression coverage includes queued rows, multiple paths, concurrent waiters and active blocking I/O.                                               |
+| Ordinary append failure / blocking-task panic | Settles pending with failure evidence, not persistence success. Files remain available for existing best-effort upload/debugging.                                                                          |
+| Genuinely stalled append or filesystem scan   | Required I/O can still wait on the OS. Flush/teardown warnings identify the wait; no timer cancels physical I/O or releases its ownership. Cache scans still depend on filesystem completion.              |
+| Physical park / final host idle publication   | Separate phases. A guest park marker is not proof of completed host publication; the later pool dependency was addressed by the reactor slice. Existing finalization and park regressions remain required. |
+| OS/runtime starvation                         | The incident samples did not establish OOM, sustained CPU starvation or blocked disk writes. No new kernel/runtime guarantee or incident attribution is claimed.                                           |
+| Natural teardown                              | Publishes Stopping before required waits, preserves joins and reports prolonged phases. Real cleanup completion is still required before normal shutdown returns.                                          |
+
 ## Coverage and remaining incident work
 
 `cmd/start/tests/main_loop/shared_resource_progress.rs` drives the real `run()`
@@ -64,9 +130,16 @@ Existing heartbeat tests cover coalescing, monotonic sequences, live-mode
 follow-ups, and no overlapping requests; provider tests cover wakeup scheduling
 and generation/defer semantics.
 
-This is the reactor-progress slice [#32050](https://github.com/vm0-ai/vm0/issues/32050)
-of [#32040](https://github.com/vm0-ai/vm0/issues/32040). Separate follow-ups track
-[helper recovery and outstanding cleanup](https://github.com/vm0-ai/vm0/issues/32051),
+Helper ownership and lifecycle tests run through `run()` with real
+pipe-controlled children and gated child waits. Proxy recovery tests also check
+old-launch cleanup before replacement. NetworkLogManager tests exercise real
+files, shard panic/cancellation, append errors and pending flush observers.
+
+These are the reactor-progress [#32050](https://github.com/vm0-ai/vm0/issues/32050)
+and helper-cleanup [#32051](https://github.com/vm0-ai/vm0/issues/32051) slices
+of [#32040](https://github.com/vm0-ai/vm0/issues/32040). Separate slices track
 [warn-only promotion drain diagnostics](https://github.com/vm0-ai/vm0/issues/32052),
 and [live-runner metric filtering](https://github.com/vm0-ai/vm0/issues/32053).
-These are not fixed by changing reactor task scheduling.
+Neither is replaced by runtime ownership fixes. No matching helper-restart or
+writer-shard-failure marker was found in the two original incidents, so these
+conditional cleanup defects are not presented as their proven production cause.

--- a/docs/runner-reactor-progress.md
+++ b/docs/runner-reactor-progress.md
@@ -65,6 +65,9 @@ replacement, and then uses the existing usage-flush/proxy-stop sequence. Ordinar
 startup failures retain backoff; unknown old-child cleanup failures or recovery
 task panics stop the runner and disable further retries. Managed-child Drop
 remains the abnormal process/launch reconciliation fallback.
+Late crash notifications may retain a follow-up retry, but its timer is not
+polled while recovery is in flight: an already expired timer must not spin the
+reactor while it cannot yet spawn another attempt.
 
 DNS/kmsg monitor completion starts independently scheduled child cleanup, then
 the reactor cancels admission and active runs and publishes Stopping. Each


### PR DESCRIPTION
## Problem

Old MITM stop/reap was awaited before spawning recovery, blocking reactor lifecycle work. DNS/kmsg failure similarly waited for reaping before persisted Stopping could progress. Separately, an outer network-log writer panic could strand accepted pending counts and leave session close waiting forever.

These are conditional defects, not a claim that helper recovery or writer failure caused the original production incidents.

## Changes

- Transfer the old MITM child synchronously into one recovery task; reap and clean its launch directory before starting a replacement. Preserve per-child usage identity, ordinary startup backoff and shutdown adoption. Stop the runner and disable retries on unknown cleanup failure or recovery task panic. Retain late crash notifications but do not poll their retry timer while recovery is in flight, preventing an expired-timer busy-loop.
- Start owned DNS/kmsg child cleanup independently of failure cancellation/lifecycle publication; join it on normal shutdown and report cleanup errors. Common teardown publishes Stopping even when discovery completion wins the mode-change race, without hard-cancelling a natural job drain.
- Carry accepted-write completion guards through bounded queues, path batches and actual blocking appends. Abandoned work settles as failed; an active blocking append remains pending until physical I/O completes. Keep one accounting lock per normal batch and retain per-session failure evidence after source finalization.
- Warn every 30 seconds for prolonged helper reaping, accepted-write flush and teardown phases, with direct component/phase/PID or run-ID fields. Observers never cancel cleanup or claim success.
- Document verified candidate dispositions and OS/filesystem limits in `docs/runner-reactor-progress.md`.

## Scope and risks

No API, persisted schema, runner/guest protocol, UI, promotion or metric changes. No production operations. Optional network-log upload and execution-result semantics remain best-effort; failed or partially written batches are not replayed. Real kernel/filesystem stalls can still delay cleanup; diagnostics are not a force-completion guarantee.

The primary implementation risks are early/double pending settlement, delayed child ownership, replacement ordering, source-generation attribution and observer lifetime. Regression tests exercise real processes and files at controlled external wait boundaries, including outer-task cancellation and panic.

## Verification

- Reproduced the writer-panic pending leak before the accounting fix, then passed the same regression.
- Real run-loop tests cover delayed DNS/kmsg and MITM cleanup, monitor/recovery panic, active-run cancellation, natural discovery exhaustion, abnormal reactor cancellation, lifecycle publication and prolonged teardown warnings.
- Real proxy process-tree/launch tests verify old cleanup precedes replacement. Network-log tests cover queued rows, multiple flush waiters/paths, blocking I/O after outer cancellation, append failure and source-finalization error evidence.
- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local -p runner --all-features --no-deps`
- `cargo test --profile local -p runner --all-features -- --test-threads=4 --quiet` — 3512 binary tests + 1 guest-inventory integration test passed; 25 pre-existing ignored tests unchanged, no new skips.
- Targeted Markdown Prettier and `git diff --check`.

Local DB migration after syncing main remains blocked by the existing Phase 2 checkpoint requiring exact lease classification for 2 rows; no data was reset and this Rust-only change does not depend on it. Hardware/production smoke testing was not performed.

Closes #32051

Parent: #32040. Depends on the already merged #32050 / #32055; promotion warnings (#32052) and live-runner metrics (#32053) are separate slices.
