### PR TITLE
fix(platform): wait for skeleton before page readiness

### DIFF
--- a/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
+++ b/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
@@ -71,6 +71,7 @@ test("Authentication is ready before Platform content becomes interactive", asyn
   clerkLoad.resolve();
   await pageReady;
 
+  expect(skeleton).toHaveAttribute("aria-hidden", "true");
   await expect(
     screen.findByRole("heading", { name: "Agents" }),
   ).resolves.toBeInTheDocument();

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -411,9 +411,8 @@ function waitForFirstPageContent(signal: AbortSignal): {
     skeletonHasMounted ||= skeleton !== null;
     if (
       pageHasRendered &&
-      (!skeletonHasMounted ||
-        skeleton === null ||
-        skeleton.getAttribute("aria-hidden") === "true")
+      skeletonHasMounted &&
+      (skeleton === null || skeleton.getAttribute("aria-hidden") === "true")
     ) {
       settle();
     }


### PR DESCRIPTION
## Summary

- require Platform page readiness to observe the application skeleton before accepting its hidden or removed state
- assert in the existing authentication startup integration flow that `setupPage()` returns only after the observed skeleton is hidden

## Why

`setupPage()` could resolve when its render callback ran before React committed the skeleton. The skeleton could then mount afterward, allowing page tests to continue against a loading-only DOM. This matches the intermittent pinned-sidebar CI failure captured in #32098.

## Scope

- test infrastructure and page-level integration coverage only
- no production UI, user flow, API, schema, timeout, retry, sleep, skip, or CI coverage change

## Validation

- `scripts/prepare.sh`
- `pnpm -F @okouai/app exec vitest run src/__tests__/authentication-startup.test.tsx src/views/okou-page/__tests__/sidebar-pin-order.test.tsx --maxWorkers=2 --silent=passed-only` (24 passed)
- `pnpm vitest run --project=@okouai/app --maxWorkers=4 --silent=passed-only` (1575 passed)
- `pnpm exec prettier --check apps/platform/src/__tests__/page-helper.ts apps/platform/src/__tests__/authentication-startup.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit hooks: Prettier, repository-wide Knip, repository-wide TypeScript checks, file-size check, and commitlint

Closes #32098
