### PR TITLE
feat(pi): learn memory from agent chat threads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2422,6 +2422,141 @@ async function requestSendEventWithBearer(
   );
 }
 
+async function expectAgentTokenThreadOwnershipBoundaries(args: {
+  readonly agentId: string;
+  readonly orgId: string;
+  readonly sourceToken: string;
+}): Promise<void> {
+  const crossUser = bdd.user({ orgId: args.orgId });
+  const crossUserThread = await chat.createThread(crossUser, {
+    agentId: args.agentId,
+  });
+  const crossUserSend = await requestSendEventWithBearer(
+    args.sourceToken,
+    {
+      agentId: args.agentId,
+      threadId: crossUserThread.id,
+      prompt: "reject cross-user delegated memory admission",
+    },
+    [404],
+  );
+  expect(crossUserSend.status).toBe(404);
+
+  const crossOrg = await entitledChatActor();
+  const crossOrgThread = await chat.createThread(crossOrg.actor, {
+    agentId: crossOrg.agentId,
+  });
+  const crossOrgSend = await requestSendEventWithBearer(
+    args.sourceToken,
+    {
+      agentId: crossOrg.agentId,
+      threadId: crossOrgThread.id,
+      prompt: "reject cross-org delegated memory admission",
+    },
+    [404],
+  );
+  expect(crossOrgSend.status).toBe(404);
+
+  const unownedThreadSend = await requestSendEventWithBearer(
+    args.sourceToken,
+    {
+      agentId: args.agentId,
+      threadId: randomUUID(),
+      prompt: "reject unowned-thread delegated memory admission",
+    },
+    [404],
+  );
+  expect(unownedThreadSend.status).toBe(404);
+}
+
+async function expectAgentChatProvenance(args: {
+  readonly actor: ApiTestUser;
+  readonly agentId: string;
+  readonly delegatedEventId: string;
+  readonly delegatedRunId: string;
+  readonly orgId: string;
+  readonly source: { readonly runId: string; readonly threadId: string };
+  readonly targetThreadId: string;
+}): Promise<void> {
+  const delegatedState = await runStateStore.set(
+    readAgentRunState$,
+    {
+      orgId: args.orgId,
+      userId: args.actor.userId,
+      runId: args.delegatedRunId,
+    },
+    context.signal,
+  );
+  expect(delegatedState.agent_run).toMatchObject({ triggerSource: "agent" });
+  const delegatedMessages = await waitForThreadMessages(
+    args.actor,
+    args.targetThreadId,
+    (events) => {
+      return userMessages(events).some((event) => {
+        return event.id === args.delegatedEventId;
+      });
+    },
+  );
+  const delegatedInput = userMessages(delegatedMessages.events).find(
+    (event): event is PromptMessage => {
+      return (
+        event.eventType === "input.prompt" && event.id === args.delegatedEventId
+      );
+    },
+  );
+  expect(delegatedInput?.userMessage.parts).toContainEqual({
+    type: "source",
+    kind: "agent",
+    runId: args.source.runId,
+    threadId: args.source.threadId,
+    agentId: args.agentId,
+    titleSnapshot: "New thread",
+    href: `/chats/${args.source.threadId}#run-${args.source.runId}`,
+  });
+}
+
+async function expectExactPrivatePiMemoryAdmission(args: {
+  readonly orgId: string;
+  readonly runId: string;
+  readonly userId: string;
+}): Promise<void> {
+  // Stage 1 candidates intentionally have no production read API. After the
+  // real send and completion paths run, this focused fixture proves the exact
+  // private admission identity without controlling the behavior under test.
+  const conversation = await readPiConversationIdentityFixture(args.runId);
+  const candidate = await readPiMemoryStage1CandidateFixture({
+    orgId: args.orgId,
+    userId: args.userId,
+  });
+  if (!candidate) {
+    throw new Error("Expected delegated Pi history to create a candidate");
+  }
+  expect(candidate).toMatchObject({
+    orgId: args.orgId,
+    userId: args.userId,
+    memoryStorageName: "memory",
+    piSessionId: conversation.piSessionId,
+    sourceRunId: args.runId,
+    sourceHistoryHash: conversation.sourceHistoryHash,
+    status: "pending",
+  });
+  expect(
+    candidate.eligibleAt.getTime() - candidate.sourceCompletedAt.getTime(),
+  ).toBe(60_000);
+  expect(sandboxOperationEventsForRun(args.runId)).toContainEqual(
+    expect.objectContaining({
+      op_type: "pi_memory_stage1_candidate_admission",
+      candidate_outcome: "created",
+      memory_storage_id: candidate.memoryStorageId,
+      pi_session_id: conversation.piSessionId,
+      source_history_hash: conversation.sourceHistoryHash,
+    }),
+  );
+  await expect(
+    readmitPiMemoryStage1CandidateFixture(args.runId),
+  ).resolves.toMatchObject({ outcome: "exact_retry" });
+}
+
 describe("CHAT-02: web chat send and client ids", () => {
   it("creates a web chat run with client-provided ids", async () => {
     const { actor, agentId } = await entitledChatActor();
@@ -6989,47 +7124,6 @@ describe("CHAT-02: model-first provider policies", () => {
     const sourceToken = okouTokenFromClaim(sourceClaim.claim);
     const targetThread = await chat.createThread(actor, { agentId });
 
-    const crossUser = bdd.user({ orgId });
-    const crossUserThread = await chat.createThread(crossUser, {
-      agentId,
-    });
-    const crossUserSend = await requestSendEventWithBearer(
-      sourceToken,
-      {
-        agentId,
-        threadId: crossUserThread.id,
-        prompt: "reject cross-user delegated memory admission",
-      },
-      [404],
-    );
-    expect(crossUserSend.status).toBe(404);
-
-    const crossOrg = await entitledChatActor();
-    const crossOrgThread = await chat.createThread(crossOrg.actor, {
-      agentId: crossOrg.agentId,
-    });
-    const crossOrgSend = await requestSendEventWithBearer(
-      sourceToken,
-      {
-        agentId: crossOrg.agentId,
-        threadId: crossOrgThread.id,
-        prompt: "reject cross-org delegated memory admission",
-      },
-      [404],
-    );
-    expect(crossOrgSend.status).toBe(404);
-
-    const unownedThreadSend = await requestSendEventWithBearer(
-      sourceToken,
-      {
-        agentId,
-        threadId: randomUUID(),
-        prompt: "reject unowned-thread delegated memory admission",
-      },
-      [404],
-    );
-    expect(unownedThreadSend.status).toBe(404);
-
     const usagePricingResolution = await createTerraUsagePricingResolution();
     mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);
     await configureBuiltInPiModel(actor, "gpt-5.6-terra");
@@ -7070,82 +7164,32 @@ describe("CHAT-02: model-first provider policies", () => {
       [201],
       usagePricingResolution,
     );
+    expect(delegated.status).toBe(201);
     if (delegated.status !== 201 || delegated.body.runId === null) {
       throw new Error("Expected the delegated Pi prompt to launch a run");
     }
     const delegatedRunId = delegated.body.runId;
     await waitForRunStatus(actor, delegatedRunId, "completed", 10_000);
     await flushWaitUntilForTest();
-
-    const delegatedState = await runStateStore.set(
-      readAgentRunState$,
-      {
-        orgId,
-        userId: actor.userId,
-        runId: delegatedRunId,
-      },
-      context.signal,
-    );
-    expect(delegatedState.agent_run).toMatchObject({ triggerSource: "agent" });
-    const delegatedMessages = await waitForThreadMessages(
+    await expectAgentChatProvenance({
       actor,
-      targetThread.id,
-      (events) => {
-        return userMessages(events).some((event) => {
-          return event.id === delegatedEventId;
-        });
-      },
-    );
-    const delegatedInput = userMessages(delegatedMessages.events).find(
-      (event): event is PromptMessage => {
-        return (
-          event.eventType === "input.prompt" && event.id === delegatedEventId
-        );
-      },
-    );
-    expect(delegatedInput?.userMessage.parts).toContainEqual({
-      type: "source",
-      kind: "agent",
-      runId: source.runId,
-      threadId: source.threadId,
       agentId,
-      titleSnapshot: "New thread",
-      href: `/chats/${source.threadId}#run-${source.runId}`,
+      delegatedEventId,
+      delegatedRunId,
+      orgId,
+      source,
+      targetThreadId: targetThread.id,
     });
-
-    const conversation =
-      await readPiConversationIdentityFixture(delegatedRunId);
-    const candidate = await readPiMemoryStage1CandidateFixture({
+    await expectExactPrivatePiMemoryAdmission({
       orgId,
       userId: actor.userId,
+      runId: delegatedRunId,
     });
-    if (!candidate) {
-      throw new Error("Expected delegated Pi history to create a candidate");
-    }
-    expect(candidate).toMatchObject({
+    await expectAgentTokenThreadOwnershipBoundaries({
+      agentId,
       orgId,
-      userId: actor.userId,
-      memoryStorageName: "memory",
-      piSessionId: conversation.piSessionId,
-      sourceRunId: delegatedRunId,
-      sourceHistoryHash: conversation.sourceHistoryHash,
-      status: "pending",
+      sourceToken,
     });
-    expect(
-      candidate.eligibleAt.getTime() - candidate.sourceCompletedAt.getTime(),
-    ).toBe(60_000);
-    expect(sandboxOperationEventsForRun(delegatedRunId)).toContainEqual(
-      expect.objectContaining({
-        op_type: "pi_memory_stage1_candidate_admission",
-        candidate_outcome: "created",
-        memory_storage_id: candidate.memoryStorageId,
-        pi_session_id: conversation.piSessionId,
-        source_history_hash: conversation.sourceHistoryHash,
-      }),
-    );
-    await expect(
-      readmitPiMemoryStage1CandidateFixture(delegatedRunId),
-    ).resolves.toMatchObject({ outcome: "exact_retry" });
 
     await cancelChatRun(actor, source.runId, sourceClaim.sandboxHeaders);
   }, 90_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1502,8 +1502,14 @@ function modelProviderConnectionsClient() {
   );
 }
 
-function chatEventsClient() {
-  return setupApp({ context, routes: chatEventsRoutes })(chatEventsContract);
+function chatEventsClient(
+  usagePricingResolution?: UsagePricingFixture["resolution"],
+) {
+  return setupApp({
+    context,
+    routes: chatEventsRoutes,
+    usagePricingResolution,
+  })(chatEventsContract);
 }
 
 function chatThreadsClient() {
@@ -2395,10 +2401,11 @@ async function requestSendEventWithBearer(
     readonly runOptions?: ChatRunOptionsRequest;
     readonly userMessage?: UserMessageInputDocument;
   },
-  statuses: readonly (201 | 400 | 401 | 403 | 409)[],
+  statuses: readonly (201 | 400 | 401 | 403 | 404 | 409)[],
+  usagePricingResolution?: UsagePricingFixture["resolution"],
 ) {
   return await accept(
-    chatEventsClient().send({
+    chatEventsClient(usagePricingResolution).send({
       headers: { authorization: `Bearer ${token}` },
       body: {
         ...body,
@@ -6923,11 +6930,16 @@ describe("CHAT-02: model-first provider policies", () => {
     }
   }, 90_000);
 
-  it("keeps webhook completion admission prerequisites and recursion exclusions", async () => {
+  it("keeps webhook completion failure and non-interactive source exclusions", async () => {
     const cases = [
       ["failed status", {}, true],
-      ["agent Stage 1 recursion", { triggerSource: "agent" as const }, false],
-      ["agent Phase 2 recursion", { triggerSource: "agent" as const }, false],
+      ["goal controller", { triggerSource: "goal" as const }, false],
+      [
+        "scheduled automation",
+        { triggerSource: "automation-schedule" as const },
+        false,
+      ],
+      ["webhook", { triggerSource: "webhook" as const }, false],
     ] as const;
     for (const [name, inputs, fails] of cases) {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
@@ -6935,6 +6947,7 @@ describe("CHAT-02: model-first provider policies", () => {
       const run = await sendChatRun(actor, {
         agentId,
         prompt: `preserve ${name} completion exclusion`,
+        model: "claude-sonnet-5",
       });
       const claimed = await claimChatRun(runnerGroup, run.runId);
       await setRunLaunchSnapshotFixture(run.runId, {
@@ -6963,6 +6976,180 @@ describe("CHAT-02: model-first provider policies", () => {
     }
   }, 90_000);
 
+  it("admits an exact Pi history from an agent-authenticated same-owner chat send", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const orgId = requireOrgId(actor);
+    await bdd.updateAgentMetadata(actor, agentId, { visibility: "public" });
+    const source = await sendChatRun(actor, {
+      agentId,
+      prompt: "delegate an eligible Pi memory turn",
+      model: "claude-sonnet-5",
+    });
+    const sourceClaim = await claimChatRun(runnerGroup, source.runId);
+    const sourceToken = okouTokenFromClaim(sourceClaim.claim);
+    const targetThread = await chat.createThread(actor, { agentId });
+
+    const crossUser = bdd.user({ orgId });
+    const crossUserThread = await chat.createThread(crossUser, {
+      agentId,
+    });
+    const crossUserSend = await requestSendEventWithBearer(
+      sourceToken,
+      {
+        agentId,
+        threadId: crossUserThread.id,
+        prompt: "reject cross-user delegated memory admission",
+      },
+      [404],
+    );
+    expect(crossUserSend.status).toBe(404);
+
+    const crossOrg = await entitledChatActor();
+    const crossOrgThread = await chat.createThread(crossOrg.actor, {
+      agentId: crossOrg.agentId,
+    });
+    const crossOrgSend = await requestSendEventWithBearer(
+      sourceToken,
+      {
+        agentId: crossOrg.agentId,
+        threadId: crossOrgThread.id,
+        prompt: "reject cross-org delegated memory admission",
+      },
+      [404],
+    );
+    expect(crossOrgSend.status).toBe(404);
+
+    const unownedThreadSend = await requestSendEventWithBearer(
+      sourceToken,
+      {
+        agentId,
+        threadId: randomUUID(),
+        prompt: "reject unowned-thread delegated memory admission",
+      },
+      [404],
+    );
+    expect(unownedThreadSend.status).toBe(404);
+
+    const usagePricingResolution = await createTerraUsagePricingResolution();
+    mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);
+    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    mockPiResourceArchiveDownloads();
+    mockPiCheckpointObjectStore();
+    server.use(
+      http.post("https://api.openai.com/v1/responses", () => {
+        return new HttpResponse(
+          piResponsesTextSse("delegated memory admission answer", 0, {
+            input_tokens: 10,
+            output_tokens: 3,
+            total_tokens: 13,
+            input_tokens_details: {
+              cached_tokens: 3,
+              cache_write_tokens: 2,
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+
+    const delegatedEventId = randomUUID();
+    const delegated = await requestSendEventWithBearer(
+      sourceToken,
+      {
+        agentId,
+        clientEventId: delegatedEventId,
+        threadId: targetThread.id,
+        prompt: "learn this stable preference from delegated work",
+        model: "gpt-5.6-terra",
+      },
+      [201],
+      usagePricingResolution,
+    );
+    if (delegated.status !== 201 || delegated.body.runId === null) {
+      throw new Error("Expected the delegated Pi prompt to launch a run");
+    }
+    const delegatedRunId = delegated.body.runId;
+    await waitForRunStatus(actor, delegatedRunId, "completed", 10_000);
+    await flushWaitUntilForTest();
+
+    const delegatedState = await runStateStore.set(
+      readAgentRunState$,
+      {
+        orgId,
+        userId: actor.userId,
+        runId: delegatedRunId,
+      },
+      context.signal,
+    );
+    expect(delegatedState.agent_run).toMatchObject({ triggerSource: "agent" });
+    const delegatedMessages = await waitForThreadMessages(
+      actor,
+      targetThread.id,
+      (events) => {
+        return userMessages(events).some((event) => {
+          return event.id === delegatedEventId;
+        });
+      },
+    );
+    const delegatedInput = userMessages(delegatedMessages.events).find(
+      (event): event is PromptMessage => {
+        return (
+          event.eventType === "input.prompt" && event.id === delegatedEventId
+        );
+      },
+    );
+    expect(delegatedInput?.userMessage.parts).toContainEqual({
+      type: "source",
+      kind: "agent",
+      runId: source.runId,
+      threadId: source.threadId,
+      agentId,
+      titleSnapshot: "New thread",
+      href: `/chats/${source.threadId}#run-${source.runId}`,
+    });
+
+    const conversation =
+      await readPiConversationIdentityFixture(delegatedRunId);
+    const candidate = await readPiMemoryStage1CandidateFixture({
+      orgId,
+      userId: actor.userId,
+    });
+    if (!candidate) {
+      throw new Error("Expected delegated Pi history to create a candidate");
+    }
+    expect(candidate).toMatchObject({
+      orgId,
+      userId: actor.userId,
+      memoryStorageName: "memory",
+      piSessionId: conversation.piSessionId,
+      sourceRunId: delegatedRunId,
+      sourceHistoryHash: conversation.sourceHistoryHash,
+      status: "pending",
+    });
+    expect(
+      candidate.eligibleAt.getTime() - candidate.sourceCompletedAt.getTime(),
+    ).toBe(60_000);
+    expect(sandboxOperationEventsForRun(delegatedRunId)).toContainEqual(
+      expect.objectContaining({
+        op_type: "pi_memory_stage1_candidate_admission",
+        candidate_outcome: "created",
+        memory_storage_id: candidate.memoryStorageId,
+        pi_session_id: conversation.piSessionId,
+        source_history_hash: conversation.sourceHistoryHash,
+      }),
+    );
+    await expect(
+      readmitPiMemoryStage1CandidateFixture(delegatedRunId),
+    ).resolves.toMatchObject({ outcome: "exact_retry" });
+
+    await cancelChatRun(actor, source.runId, sourceClaim.sandboxHeaders);
+  }, 90_000);
+
   it("admits exact Pi web histories with immutable launch policy and stale-lease fencing", async () => {
     const { actor, agentId } = await entitledChatActor();
     const orgId = requireOrgId(actor);
@@ -6982,20 +7169,36 @@ describe("CHAT-02: model-first provider policies", () => {
         generationEnabled: false,
       }),
     ).toBe("generation_disabled");
-    // Valid Pi H2 completion requires a Chat Thread, so this defensive
-    // admission-only prerequisite is covered directly at its service boundary.
+    // A classified Web Chat source must still own a Chat Thread. The actual
+    // threadless Phase 2 maintenance route is covered by the boundary test.
     expect(
       piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({
         chatThreadId: null,
       }),
     ).toBe("missing_chat_thread");
+    expect(
+      piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({
+        triggerSource: "agent",
+      }),
+    ).toBeNull();
+    expect(
+      piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({
+        triggerSource: "agent",
+        chatThreadId: null,
+      }),
+    ).toBe("missing_chat_thread");
+    expect(
+      piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({
+        triggerSource: null,
+      }),
+    ).toBe("source_not_web_chat");
     for (const triggerSource of triggerSourceSchema.options) {
-      if (triggerSource === "web") {
+      if (triggerSource === "web" || triggerSource === "agent") {
         continue;
       }
       expect(
         piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({ triggerSource }),
-      ).toBe("source_not_web");
+      ).toBe("source_not_web_chat");
     }
     const usagePricingResolution = await createTerraUsagePricingResolution();
     mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-maintenance.boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-maintenance.boundary.test.ts
@@ -778,6 +778,41 @@ describe("private maintenance across CLI, Guest, generic checkpoint and real Pos
         expect(run.checkpointRows).toHaveLength(1);
         expect(run.run?.status).toBe("completed");
       }
+      expect(run.run).toMatchObject({
+        triggerSource: "agent",
+        chatThreadId: null,
+      });
+      await expect(
+        db()
+          .select({ sourceRunId: piMemoryStage1Candidates.sourceRunId })
+          .from(piMemoryStage1Candidates)
+          .where(eq(piMemoryStage1Candidates.sourceRunId, run.runId)),
+      ).resolves.toStrictEqual([]);
+      if (fault === "none") {
+        const terminal = run.requests.find((request) => {
+          return request.path.endsWith("/complete") && request.status === 200;
+        });
+        if (!terminal) {
+          throw new Error("Missing actual maintenance terminal request");
+        }
+        for (let retry = 0; retry < 2; retry++) {
+          const replay = await run.app.request(terminal.path, {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${run.token}`,
+              "content-type": "application/json",
+            },
+            body: terminal.body,
+          });
+          expect(replay.status).toBe(200);
+        }
+        await expect(
+          db()
+            .select({ sourceRunId: piMemoryStage1Candidates.sourceRunId })
+            .from(piMemoryStage1Candidates)
+            .where(eq(piMemoryStage1Candidates.sourceRunId, run.runId)),
+        ).resolves.toStrictEqual([]);
+      }
       if (fault === "observer") {
         expect(run.job?.lastMaintenanceCheckpointId).toBeNull();
         await run.releaseObserver();

--- a/turbo/apps/api/src/signals/services/pi-memory-stage1-candidate.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-stage1-candidate.service.ts
@@ -1,5 +1,6 @@
 import { and, eq, gt, sql } from "drizzle-orm";
 
+import { triggerSourceSchema } from "@okouai/api-contracts/contracts/logs";
 import { MEMORY_ARTIFACT_NAME } from "@okouai/core/storage-names";
 import { blobs } from "@okouai/db/schema/blob";
 import { conversations } from "@okouai/db/schema/conversation";
@@ -10,6 +11,7 @@ import type { Tx } from "../../lib/db-types";
 import { nowDate } from "../../lib/time";
 import { advancePiMemoryPhase2InputRevision } from "./pi-memory-phase2-job.service";
 import { newStorageS3Location } from "./storage-s3-prefix.utils";
+import { isWebChatTriggerSource } from "./chat-trigger-source.service";
 
 export type PiMemoryStage1AdmissionSkipReason =
   | "generation_disabled"
@@ -17,7 +19,7 @@ export type PiMemoryStage1AdmissionSkipReason =
   | "missing_chat_thread"
   | "not_completed"
   | "not_pi"
-  | "source_not_web"
+  | "source_not_web_chat"
   | "stale_source";
 
 export type PiMemoryStage1Admission =
@@ -60,8 +62,9 @@ export function getPiMemoryStage1AdmissionPrerequisiteSkipReason(
   if (!args.generationEnabled) {
     return "generation_disabled";
   }
-  if (args.triggerSource !== "web") {
-    return "source_not_web";
+  const triggerSource = triggerSourceSchema.safeParse(args.triggerSource);
+  if (!triggerSource.success || !isWebChatTriggerSource(triggerSource.data)) {
+    return "source_not_web_chat";
   }
   if (args.chatThreadId === null) {
     return "missing_chat_thread";

--- a/turbo/apps/api/src/test-fixtures/agent-runs.ts
+++ b/turbo/apps/api/src/test-fixtures/agent-runs.ts
@@ -90,7 +90,7 @@ export async function setRunLaunchSnapshotFixture(
 export async function setRunPiMemoryAdmissionInputsFixture(
   runId: string,
   inputs: {
-    readonly triggerSource?: "agent" | "web";
+    readonly triggerSource?: TriggerSource;
     readonly chatThreadId?: string | null;
   },
 ): Promise<void> {

--- a/turbo/apps/api/src/test-fixtures/pi-memory-stage1-candidates.ts
+++ b/turbo/apps/api/src/test-fixtures/pi-memory-stage1-candidates.ts
@@ -127,6 +127,8 @@ export async function readPiMemoryStage1CandidateFixture(args: {
       memoryStorageId: piMemoryStage1Candidates.memoryStorageId,
       memoryStorageName: storages.name,
       memoryStorageS3Prefix: storages.s3Prefix,
+      orgId: piMemoryStage1Candidates.orgId,
+      userId: piMemoryStage1Candidates.userId,
       piSessionId: piMemoryStage1Candidates.piSessionId,
       sourceRunId: piMemoryStage1Candidates.sourceRunId,
       sourceHistoryHash: piMemoryStage1Candidates.sourceHistoryHash,


### PR DESCRIPTION
## Summary

- admit completed, generation-enabled, thread-bound Pi runs from both canonical Web Chat sources (`web` and `agent`) by reusing `isWebChatTriggerSource`
- continue rejecting threadless/internal agent runs and every non-interactive trigger source, with the skip reason renamed to `source_not_web_chat`
- prove the behavior with a real run-scoped agent-authenticated cross-thread send, the existing Web control, the full trigger exclusion matrix, and an actual Phase 2 maintenance terminal plus replay

## Preserved boundaries

- Stage 1 exact-history capture, idle timing, duplicate/replacement handling, and stale-lease fencing are unchanged
- recall/mount, extraction, Phase 2 consolidation/checkpointing, citations, correction/forget, storage lineage, and last-writer-wins semantics are unchanged
- no migration, backfill, historical replay, feature switch, production flag, or production data change

## Validation

- `pnpm --filter api check-types`
- `pnpm --filter api lint`
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts apps/api/src/signals/services/__tests__/pi-memory-maintenance.boundary.test.ts apps/api/src/signals/services/pi-memory-stage1-candidate.service.ts apps/api/src/test-fixtures/agent-runs.ts apps/api/src/test-fixtures/pi-memory-stage1-candidates.ts`
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'keeps webhook completion failure and non-interactive source exclusions|admits an exact Pi history from an agent-authenticated same-owner chat send|admits exact Pi web histories with immutable launch policy and stale-lease fencing' --reporter=dot`
- `cargo build --manifest-path crates/Cargo.toml --profile local -p guest-agent -j 2`
- `pnpm --dir turbo --filter @okouai/pi-agent-runtime build`
- `DATABASE_URL=... pnpm --filter api exec vitest run --config vitest.maintenance.config.ts -t 'settles changed output exactly once through none' --reporter=dot`

## MaskDB impact upper bound

For the half-open window `2026-08-31T00:00:00Z` to `2026-09-07T02:48:38Z`, MaskDB contains 445 completed, thread-bound, agent-triggered Pi runs: Terra 296, DeepSeek V4 Pro 148, and other 1. Because immutable generation admission is not completely visible, this is an upper bound, not an exact count of newly admitted candidates.

Closes #32091
