### PR TITLE
refactor(image-recognition): add the canonical api route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
@@ -36,7 +36,7 @@ const mocks = createRouteMocks(context);
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const STARTING_CREDITS = 1000;
 const EXPECTED_CHARGE = 3;
-const RECOGNITION_PRICING_ROWS = [
+const IMAGE_RECOGNITION_PRICING_ROWS = [
   {
     kind: "image-recognition",
     provider: "xiaomi/mimo-v2.5",
@@ -60,7 +60,7 @@ const RECOGNITION_PRICING_ROWS = [
   },
 ] as const;
 
-interface RecognitionActor extends ApiTestUser {
+interface ImageRecognitionActor extends ApiTestUser {
   readonly orgId: string;
   readonly runId: string;
 }
@@ -73,7 +73,7 @@ interface StoredObject {
 }
 
 function okouToken(
-  actor: RecognitionActor,
+  actor: ImageRecognitionActor,
   capabilities: readonly Capability[] = ["image-recognition:write"],
 ): string {
   return createRunsApi(context).okouTokenForRunWithCapabilities(
@@ -83,10 +83,10 @@ function okouToken(
   );
 }
 
-async function seedActor(): Promise<RecognitionActor> {
+async function seedImageRecognitionActor(): Promise<ImageRecognitionActor> {
   const actor = createBddApi(context).user();
   if (!actor.orgId) {
-    throw new Error("Recognition tests require an organization");
+    throw new Error("Image recognition tests require an organization");
   }
   await seedOrgMetadata({
     orgId: actor.orgId,
@@ -94,7 +94,7 @@ async function seedActor(): Promise<RecognitionActor> {
     credits: STARTING_CREDITS,
   });
   const api = createRunsApi(context);
-  const name = `recognition-${randomUUID().slice(0, 8)}`;
+  const name = `image-recognition-${randomUUID().slice(0, 8)}`;
   const compose = await api.createDirectAgent(actor, {
     version: "1.0",
     agents: {
@@ -120,13 +120,13 @@ async function seedActor(): Promise<RecognitionActor> {
   return { ...actor, orgId: actor.orgId, runId: run.runId };
 }
 
-async function seedAdmittedActor(): Promise<RecognitionActor> {
+async function seedAdmittedImageRecognitionActor(): Promise<ImageRecognitionActor> {
   await seedBuiltInDefaultModelKey(context);
   const bdd = createBddApi(context);
   const api = createRunsApi(context);
   const actor = bdd.user();
   if (!actor.orgId) {
-    throw new Error("Recognition tests require an organization");
+    throw new Error("Image recognition tests require an organization");
   }
   bdd.acceptAgentStorageWrites();
   api.configureRunnerGroup();
@@ -171,35 +171,42 @@ function setStoredObjects(objects: readonly StoredObject[]): void {
   );
 }
 
-function requestRecognition(args: {
-  readonly token?: string;
-  readonly fileId: string;
-  readonly prompt?: string;
-  readonly clientRequestId?: string;
-  readonly usagePricingResolution?: UsagePricingFixture["resolution"];
-}) {
+function requestImageRecognition(
+  args: {
+    readonly token?: string;
+    readonly fileId: string;
+    readonly prompt?: string;
+    readonly clientRequestId?: string;
+    readonly usagePricingResolution?: UsagePricingFixture["resolution"];
+  },
+  operation: "imageRecognition" | "recognize" = "imageRecognition",
+) {
   const headers = {
     ...(args.token ? { authorization: `Bearer ${args.token}` } : {}),
     ...(args.clientRequestId
       ? { "x-vm0-client-request-id": args.clientRequestId }
       : {}),
   };
-  return setupApp({
+  const client = setupApp({
     context,
     routes: imageRecognitionRoutes,
     usagePricingResolution: args.usagePricingResolution,
-  })(imageRecognitionContract).recognize({
+  })(imageRecognitionContract);
+  const request = {
     headers,
     body: {
       fileId: args.fileId,
       prompt: args.prompt ?? "Describe this image",
     },
-  });
+  };
+  return operation === "imageRecognition"
+    ? client.imageRecognition(request)
+    : client.recognize(request);
 }
 
-async function createConfiguredRecognitionPricing(): Promise<UsagePricingFixture> {
+async function createConfiguredImageRecognitionPricing(): Promise<UsagePricingFixture> {
   const pricing = await createUsagePricingFixture({
-    configured: RECOGNITION_PRICING_ROWS,
+    configured: IMAGE_RECOGNITION_PRICING_ROWS,
   });
   onTestFinished(async () => {
     await pricing.cleanup();
@@ -207,9 +214,9 @@ async function createConfiguredRecognitionPricing(): Promise<UsagePricingFixture
   return pricing;
 }
 
-async function createMissingRecognitionPricing(): Promise<UsagePricingFixture> {
+async function createMissingImageRecognitionPricing(): Promise<UsagePricingFixture> {
   const pricing = await createUsagePricingFixture({
-    missing: RECOGNITION_PRICING_ROWS,
+    missing: IMAGE_RECOGNITION_PRICING_ROWS,
   });
   onTestFinished(async () => {
     await pricing.cleanup();
@@ -217,22 +224,22 @@ async function createMissingRecognitionPricing(): Promise<UsagePricingFixture> {
   return pricing;
 }
 
-async function seedBilling(
-  actor: RecognitionActor,
+async function seedImageRecognitionBilling(
+  actor: ImageRecognitionActor,
 ): Promise<UsagePricingFixture> {
   await seedOrgMetadata({
     orgId: actor.orgId,
     tier: "pro",
     credits: STARTING_CREDITS,
   });
-  return await createConfiguredRecognitionPricing();
+  return await createConfiguredImageRecognitionPricing();
 }
 
 function mockClerkUserLookup(): void {
   context.mocks.clerk.users.getUserList.mockResolvedValue({ data: [] });
 }
 
-async function readUsageRecord(actor: RecognitionActor) {
+async function readUsageRecord(actor: ImageRecognitionActor) {
   mockClerkUserLookup();
   mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
   const response = await accept(
@@ -251,7 +258,7 @@ async function readUsageRecord(actor: RecognitionActor) {
   return response.body.rows;
 }
 
-async function expectNoUsage(actor: RecognitionActor): Promise<void> {
+async function expectNoUsage(actor: ImageRecognitionActor): Promise<void> {
   await expect(
     store.set(
       readUsageStorageCounts$,
@@ -261,7 +268,7 @@ async function expectNoUsage(actor: RecognitionActor): Promise<void> {
   ).resolves.toStrictEqual({ raw: 0, hourly: 0 });
 }
 
-describe("POST /api/recognize", () => {
+describe("POST /api/image-recognition", () => {
   it("recognizes one owned image and settles each real invocation", async () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     const requestBodies: unknown[] = [];
@@ -283,8 +290,8 @@ describe("POST /api/recognize", () => {
         });
       }),
     );
-    const actor = await seedActor();
-    const pricing = await seedBilling(actor);
+    const actor = await seedImageRecognitionActor();
+    const pricing = await seedImageRecognitionBilling(actor);
     const fileId = randomUUID();
     setStoredObjects([
       { userId: actor.userId, id: fileId, filename: "screen.png", size: 1024 },
@@ -292,7 +299,7 @@ describe("POST /api/recognize", () => {
     const clientRequestId = randomUUID();
 
     for (let invocation = 0; invocation < 2; invocation += 1) {
-      const response = await requestRecognition({
+      const response = await requestImageRecognition({
         token: okouToken(actor),
         fileId,
         prompt: "Read the warning",
@@ -362,15 +369,15 @@ describe("POST /api/recognize", () => {
         });
       }),
     );
-    const actor = await seedAdmittedActor();
-    const pricing = await createConfiguredRecognitionPricing();
+    const actor = await seedAdmittedImageRecognitionActor();
+    const pricing = await createConfiguredImageRecognitionPricing();
     await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 0 });
     const fileId = randomUUID();
     setStoredObjects([
       { userId: actor.userId, id: fileId, filename: "screen.png", size: 1024 },
     ]);
 
-    const response = await requestRecognition({
+    const response = await requestImageRecognition({
       token: okouToken(actor),
       fileId,
       usagePricingResolution: pricing.resolution,
@@ -392,20 +399,20 @@ describe("POST /api/recognize", () => {
   });
 
   it("enforces agent-only capability authorization before object access", async () => {
-    const actor = await seedActor();
+    const actor = await seedImageRecognitionActor();
     const fileId = randomUUID();
 
-    const unauthenticated = await requestRecognition({ fileId });
+    const unauthenticated = await requestImageRecognition({ fileId });
     expect(unauthenticated.status).toBe(401);
 
-    const missingCapability = await requestRecognition({
+    const missingCapability = await requestImageRecognition({
       token: okouToken(actor, ["file:write"]),
       fileId,
     });
     expect(missingCapability.status).toBe(403);
 
     mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
-    const sessionResponse = await requestRecognition({
+    const sessionResponse = await requestImageRecognition({
       token: "clerk-session",
       fileId,
     });
@@ -414,7 +421,7 @@ describe("POST /api/recognize", () => {
   });
 
   it("rejects non-owned and invalid uploaded image metadata", async () => {
-    const actor = await seedActor();
+    const actor = await seedImageRecognitionActor();
     const otherUserFileId = randomUUID();
     const gifId = randomUUID();
     const emptyId = randomUUID();
@@ -444,7 +451,7 @@ describe("POST /api/recognize", () => {
       { fileId: oversizedId, status: 413, code: "IMAGE_TOO_LARGE" },
     ] as const;
     for (const testCase of cases) {
-      const response = await requestRecognition({
+      const response = await requestImageRecognition({
         token,
         fileId: testCase.fileId,
       });
@@ -465,15 +472,15 @@ describe("POST /api/recognize", () => {
         return HttpResponse.json({});
       }),
     );
-    const actor = await seedActor();
-    const configuredPricing = await createConfiguredRecognitionPricing();
+    const actor = await seedImageRecognitionActor();
+    const configuredPricing = await createConfiguredImageRecognitionPricing();
     const fileId = randomUUID();
     setStoredObjects([
       { userId: actor.userId, id: fileId, filename: "screen.jpg", size: 100 },
     ]);
     await seedOrgMetadata({ orgId: actor.orgId, tier: "pro", credits: 0 });
 
-    const noCredits = await requestRecognition({
+    const noCredits = await requestImageRecognition({
       token: okouToken(actor),
       fileId,
       usagePricingResolution: configuredPricing.resolution,
@@ -485,8 +492,8 @@ describe("POST /api/recognize", () => {
       tier: "pro",
       credits: STARTING_CREDITS,
     });
-    const missingPricing = await createMissingRecognitionPricing();
-    const noPricing = await requestRecognition({
+    const missingPricing = await createMissingImageRecognitionPricing();
+    const noPricing = await requestImageRecognition({
       token: okouToken(actor),
       fileId,
       usagePricingResolution: missingPricing.resolution,
@@ -518,14 +525,14 @@ describe("POST /api/recognize", () => {
         );
       }),
     );
-    const actor = await seedActor();
-    const pricing = await seedBilling(actor);
+    const actor = await seedImageRecognitionActor();
+    const pricing = await seedImageRecognitionBilling(actor);
     const fileId = randomUUID();
     setStoredObjects([
       { userId: actor.userId, id: fileId, filename: "broken.png", size: 12 },
     ]);
 
-    const response = await requestRecognition({
+    const response = await requestImageRecognition({
       token: okouToken(actor),
       fileId,
       usagePricingResolution: pricing.resolution,
@@ -535,7 +542,7 @@ describe("POST /api/recognize", () => {
     expect(responseText).toContain("INVALID_IMAGE");
     expect(responseText).not.toContain("raw-provider-secret-detail");
 
-    const malformedType = await requestRecognition({
+    const malformedType = await requestImageRecognition({
       token: okouToken(actor),
       fileId,
       usagePricingResolution: pricing.resolution,
@@ -552,8 +559,8 @@ describe("POST /api/recognize", () => {
       { prompt_tokens: 10 },
       { completion_tokens: 10 },
     ] as const;
-    const actor = await seedActor();
-    const pricing = await seedBilling(actor);
+    const actor = await seedImageRecognitionActor();
+    const pricing = await seedImageRecognitionBilling(actor);
     const fileId = randomUUID();
     setStoredObjects([
       { userId: actor.userId, id: fileId, filename: "screen.webp", size: 12 },
@@ -573,7 +580,7 @@ describe("POST /api/recognize", () => {
           });
         }),
       );
-      const response = await requestRecognition({
+      const response = await requestImageRecognition({
         token: okouToken(actor),
         fileId,
         usagePricingResolution: pricing.resolution,
@@ -614,15 +621,15 @@ describe("POST /api/recognize", () => {
         });
       }),
     );
-    const actor = await seedActor();
-    const pricing = await seedBilling(actor);
+    const actor = await seedImageRecognitionActor();
+    const pricing = await seedImageRecognitionBilling(actor);
     const fileId = randomUUID();
     setStoredObjects([
       { userId: actor.userId, id: fileId, filename: "screen.png", size: 12 },
     ]);
 
     for (let invocation = 0; invocation < 2; invocation += 1) {
-      const response = await requestRecognition({
+      const response = await requestImageRecognition({
         token: okouToken(actor),
         fileId,
         usagePricingResolution: pricing.resolution,
@@ -638,8 +645,8 @@ describe("POST /api/recognize", () => {
 
   it("does not return text when settlement reports a billing error", async () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    const actor = await seedActor();
-    const pricing = await seedBilling(actor);
+    const actor = await seedImageRecognitionActor();
+    const pricing = await seedImageRecognitionBilling(actor);
     const pricingIdentity = pricing.resolution.find((entry) => {
       return (
         entry.kind === "image-recognition" &&
@@ -647,7 +654,9 @@ describe("POST /api/recognize", () => {
       );
     });
     if (!pricingIdentity) {
-      throw new Error("Recognition pricing fixture requires a lookup identity");
+      throw new Error(
+        "Image recognition pricing fixture requires a lookup identity",
+      );
     }
     server.use(
       http.post(OPENROUTER_URL, async () => {
@@ -672,7 +681,7 @@ describe("POST /api/recognize", () => {
       { userId: actor.userId, id: fileId, filename: "screen.png", size: 12 },
     ]);
 
-    const response = await requestRecognition({
+    const response = await requestImageRecognition({
       token: okouToken(actor),
       fileId,
       usagePricingResolution: pricing.resolution,
@@ -688,5 +697,29 @@ describe("POST /api/recognize", () => {
         context.signal,
       ),
     ).resolves.toStrictEqual({ raw: 2, hourly: 0 });
+  });
+});
+
+describe("POST /api/recognize compatibility", () => {
+  it("keeps pre-switch CLI requests on the canonical authenticated behavior", async () => {
+    const actor = await seedImageRecognitionActor();
+    const fileId = randomUUID();
+    const request = {
+      token: okouToken(actor),
+      fileId,
+    };
+    setStoredObjects([]);
+
+    const canonical = await requestImageRecognition(request);
+    const compatibility = await requestImageRecognition(request, "recognize");
+
+    expect(compatibility.status).toBe(404);
+    expect({
+      status: compatibility.status,
+      body: compatibility.body,
+    }).toStrictEqual({
+      status: canonical.status,
+      body: canonical.body,
+    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/image-recognition.ts
+++ b/turbo/apps/api/src/signals/routes/image-recognition.ts
@@ -7,32 +7,51 @@ import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import { imageRecognition$ } from "../services/image-recognition.service";
 
-const recognitionBody$ = bodyResultOf(imageRecognitionContract.recognize);
+const imageRecognitionBody$ = bodyResultOf(
+  imageRecognitionContract.imageRecognition,
+);
 
-const recognizeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
-  const auth = get(organizationAuthContext$);
-  if (auth.tokenType !== "agent") {
-    throw new Error("Image recognition route requires run authentication");
-  }
-  const bodyResult = await get(recognitionBody$);
-  signal.throwIfAborted();
-  if (!bodyResult.ok) {
-    return bodyResult.response;
-  }
-  return await set(imageRecognition$, { auth, body: bodyResult.data }, signal);
-});
+const imageRecognitionInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    if (auth.tokenType !== "agent") {
+      throw new Error("Image recognition route requires run authentication");
+    }
+    const bodyResult = await get(imageRecognitionBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    return await set(
+      imageRecognition$,
+      { auth, body: bodyResult.data },
+      signal,
+    );
+  },
+);
+
+const imageRecognitionHandler$ = authRoute(
+  {
+    accept: ["agent"],
+    requireOrganization: true,
+    missingOrganizationStatus: 401,
+    requiredCapability: "image-recognition:write",
+  },
+  imageRecognitionInner$,
+);
 
 export const imageRecognitionRoutes: readonly RouteEntry[] = [
   {
+    route: imageRecognitionContract.imageRecognition,
+    handler: imageRecognitionHandler$,
+  },
+  // Compatibility for immutable commit-addressed CLI artifacts that still call
+  // `/api/recognize`. Keep until the canonical CLI and first-party guidance
+  // have shipped, every pre-switch execution context has drained through queue,
+  // execution, and finalization, and supported external callers no longer use
+  // the old path. Remove in the evidence-backed cleanup phase tracked by #26929.
+  {
     route: imageRecognitionContract.recognize,
-    handler: authRoute(
-      {
-        accept: ["agent"],
-        requireOrganization: true,
-        missingOrganizationStatus: 401,
-        requiredCapability: "image-recognition:write",
-      },
-      recognizeInner$,
-    ),
+    handler: imageRecognitionHandler$,
   },
 ];

--- a/turbo/packages/api-contracts/src/contracts/__tests__/image-recognition.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/image-recognition.test.ts
@@ -3,12 +3,38 @@ import { describe, expect, it } from "vitest";
 import {
   IMAGE_RECOGNITION_MAX_PROMPT_CHARS,
   IMAGE_RECOGNITION_MAX_TEXT_CHARS,
+  imageRecognitionContract,
   imageRecognitionMimeTypeSchema,
   imageRecognitionRequestSchema,
   imageRecognitionResponseSchema,
 } from "../image-recognition";
 
 describe("image recognition contract", () => {
+  it("declares the canonical and compatibility API paths", () => {
+    expect({
+      canonical: {
+        method: imageRecognitionContract.imageRecognition.method,
+        path: imageRecognitionContract.imageRecognition.path,
+      },
+      compatibility: {
+        method: imageRecognitionContract.recognize.method,
+        path: imageRecognitionContract.recognize.path,
+      },
+    }).toStrictEqual({
+      canonical: { method: "POST", path: "/api/image-recognition" },
+      compatibility: { method: "POST", path: "/api/recognize" },
+    });
+    expect(imageRecognitionContract.recognize.headers).toBe(
+      imageRecognitionContract.imageRecognition.headers,
+    );
+    expect(imageRecognitionContract.recognize.body).toBe(
+      imageRecognitionContract.imageRecognition.body,
+    );
+    expect(imageRecognitionContract.recognize.responses).toBe(
+      imageRecognitionContract.imageRecognition.responses,
+    );
+  });
+
   it("accepts one owned file id and a trimmed prompt", () => {
     expect(
       imageRecognitionRequestSchema.parse({

--- a/turbo/packages/api-contracts/src/contracts/image-recognition.ts
+++ b/turbo/packages/api-contracts/src/contracts/image-recognition.ts
@@ -37,7 +37,7 @@ export type ImageRecognitionResponse = z.infer<
   typeof imageRecognitionResponseSchema
 >;
 
-const recognitionResponses = {
+const imageRecognitionResponses = {
   200: imageRecognitionResponseSchema,
   400: apiErrorSchema,
   401: apiErrorSchema,
@@ -50,14 +50,22 @@ const recognitionResponses = {
   503: apiErrorSchema,
 } as const;
 
+const imageRecognitionRoute = {
+  method: "POST" as const,
+  headers: authHeadersSchema,
+  body: imageRecognitionRequestSchema,
+  responses: imageRecognitionResponses,
+  summary: "Recognize one owned image through a managed multimodal model",
+};
+
 export const imageRecognitionContract = c.router({
+  imageRecognition: {
+    ...imageRecognitionRoute,
+    path: "/api/image-recognition",
+  },
   recognize: {
-    method: "POST",
+    ...imageRecognitionRoute,
     path: "/api/recognize",
-    headers: authHeadersSchema,
-    body: imageRecognitionRequestSchema,
-    responses: recognitionResponses,
-    summary: "Recognize one owned image through a managed multimodal model",
   },
 });
 


### PR DESCRIPTION
Closes #32167

## Summary

- Add `POST /api/image-recognition` as the canonical `imageRecognition` contract operation and register it in the existing image-recognition route slice.
- Retain `POST /api/recognize` as one explicit compatibility operation that shares the canonical request and response schemas, authenticated handler, organization requirement, capability gate, and service behavior.
- Move the comprehensive route suite to the canonical operation and keep one focused compatibility-path integration test.

## Fallbacks

- `turbo/apps/api/src/signals/routes/image-recognition.ts:imageRecognitionRoutes` — retains `POST /api/recognize` for immutable commit-addressed CLI artifacts and explicitly supported external callers while the additive canonical API ships first. Surface: old CLI execution contexts -> new API, bounded by the maximum queue, execution, and finalization drain plus the external-support gate. Remove only after the canonical CLI and first-party guidance have shipped, every pre-switch execution context has drained, and supported external callers no longer use the old path; the evidence-backed cleanup phase is tracked by #26929 and will create its dedicated removal issue just in time.

## Verification

- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/image-recognition.test.ts` (5 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/image-recognition.test.ts` (10 passed)
- `pnpm -F api exec vitest run src/__tests__/api-namespace-compatibility.test.ts` (2 passed)
- `pnpm -F @okouai/cli exec vitest run src/commands/recognize/__tests__/index.test.ts` (5 passed)
- `pnpm -F @okouai/api-contracts exec vitest run src/runtime-api-schema/__tests__/schema.test.ts` (3 passed)
- `pnpm -F @okouai/api-contracts run lint`
- `pnpm -F api run lint`
- `pnpm -F @okouai/api-contracts run check-types`
- `pnpm -F api run check-types`
- `pnpm -F @okouai/cli run check-types`
- `pnpm knip --workspace packages/api-contracts`
- `pnpm knip --workspace apps/api`
- `pnpm -F @okouai/api-contracts run build:runtime-api-schema -- --out /tmp/vm0-image-recognition-runtime-api-schema.json`
- Focused Prettier check and `git diff --check`

## Not included

- No CLI command, alias, client-path, help, example, prompt, or capability-map changes; `client.recognize` continues to call `/api/recognize`.
- No branded route aliases, generic alias table/helper, registry rewrite, feature switch, migration, or behavior changes outside this route boundary.
- No removal of `/api/recognize`, production release, or later #26929 phase.
