### PR TITLE
style(platform): widen the labeled nav rail to 72px

### DIFF
--- a/turbo/apps/platform/src/views/components/avatar.tsx
+++ b/turbo/apps/platform/src/views/components/avatar.tsx
@@ -8,12 +8,12 @@ import { cn } from "@okouai/ui";
  */
 const THUMBNAIL_SIZE = {
   sm: "h-6 w-6",
-  // The labeled navigation rail draws its marks inside the same 36px chip as
-  // its icon buttons: `sm` reads timid against a 19px glyph in that box, and
-  // `md` leaves two pixels of chip around the mark, which is too little for
-  // the hover background to register. 28px is the step that fits both.
-  "sm+": "h-7 w-7",
   md: "h-8 w-8",
+  // Fills a `size="icon"` button edge to edge. The labeled navigation rail
+  // hangs its marks off such a button beside 36px nav chips: at any smaller
+  // step the button's hover background frames the mark in grey instead of the
+  // mark simply being the button.
+  "md+": "h-9 w-9",
   lg: "h-10 w-10",
   xl: "h-12 w-12",
 } as const;
@@ -23,16 +23,19 @@ const THUMBNAIL_SIZE = {
 // Same ratio the file-preview icon already uses (20px/5px, 40px/10px).
 const THUMBNAIL_RADIUS = {
   sm: "rounded-[6px]",
-  "sm+": "rounded-[7px]",
   md: "rounded-[8px]",
+  // The one step off the quarter ratio, which would ask for 9px here. `md+`
+  // covers a `rounded-lg` button exactly, and a radius larger than the
+  // button's leaves four grey slivers of it showing at the corners.
+  "md+": "rounded-[8px]",
   lg: "rounded-[10px]",
   xl: "rounded-[12px]",
 } as const;
 
 const THUMBNAIL_INITIAL_TEXT = {
   sm: "text-[11px]",
-  "sm+": "text-xs",
   md: "text-xs",
+  "md+": "text-[13px]",
   lg: "text-sm",
   xl: "text-base",
 } as const;

--- a/turbo/apps/platform/src/views/components/avatar.tsx
+++ b/turbo/apps/platform/src/views/components/avatar.tsx
@@ -8,6 +8,11 @@ import { cn } from "@okouai/ui";
  */
 const THUMBNAIL_SIZE = {
   sm: "h-6 w-6",
+  // The labeled navigation rail draws its marks inside the same 36px chip as
+  // its icon buttons: `sm` reads timid against a 19px glyph in that box, and
+  // `md` leaves two pixels of chip around the mark, which is too little for
+  // the hover background to register. 28px is the step that fits both.
+  "sm+": "h-7 w-7",
   md: "h-8 w-8",
   lg: "h-10 w-10",
   xl: "h-12 w-12",
@@ -18,6 +23,7 @@ const THUMBNAIL_SIZE = {
 // Same ratio the file-preview icon already uses (20px/5px, 40px/10px).
 const THUMBNAIL_RADIUS = {
   sm: "rounded-[6px]",
+  "sm+": "rounded-[7px]",
   md: "rounded-[8px]",
   lg: "rounded-[10px]",
   xl: "rounded-[12px]",
@@ -25,6 +31,7 @@ const THUMBNAIL_RADIUS = {
 
 const THUMBNAIL_INITIAL_TEXT = {
   sm: "text-[11px]",
+  "sm+": "text-xs",
   md: "text-xs",
   lg: "text-sm",
   xl: "text-base",

--- a/turbo/apps/platform/src/views/okou-page/org-switcher.tsx
+++ b/turbo/apps/platform/src/views/okou-page/org-switcher.tsx
@@ -331,7 +331,11 @@ export function OrgSwitcherCompact() {
           size="icon"
           className="relative"
         >
-          <WorkspaceLogo name={orgName} imageUrl={currentOrg?.imageUrl} />
+          <WorkspaceLogo
+            name={orgName}
+            imageUrl={currentOrg?.imageUrl}
+            size="sm+"
+          />
           <PendingInvitationsBadge />
         </Button>
       </DropdownMenuTrigger>

--- a/turbo/apps/platform/src/views/okou-page/org-switcher.tsx
+++ b/turbo/apps/platform/src/views/okou-page/org-switcher.tsx
@@ -334,7 +334,7 @@ export function OrgSwitcherCompact() {
           <WorkspaceLogo
             name={orgName}
             imageUrl={currentOrg?.imageUrl}
-            size="sm+"
+            size="md+"
           />
           <PendingInvitationsBadge />
         </Button>

--- a/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
@@ -236,7 +236,7 @@ function renderAccountTrigger(
           imageUrl={display.imageUrl}
           name={display.name}
           initial={display.initial}
-          size="sm+"
+          size="md+"
           shape={avatarShape}
         />
       </Button>

--- a/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-account.tsx
@@ -236,7 +236,7 @@ function renderAccountTrigger(
           imageUrl={display.imageUrl}
           name={display.name}
           initial={display.initial}
-          size="sm"
+          size="sm+"
           shape={avatarShape}
         />
       </Button>

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -517,10 +517,10 @@ function LabeledRailLink({
       aria-label={label}
       aria-current={isActive ? "page" : undefined}
       title={caption}
-      className="group flex w-full flex-col items-center gap-1 no-underline"
+      className="group flex w-full flex-col items-center gap-0.5 no-underline"
     >
       <span
-        className={`relative inline-flex h-8 w-9 items-center justify-center rounded-lg transition-colors duration-200 ${
+        className={`relative inline-flex size-9 items-center justify-center rounded-lg transition-colors duration-200 ${
           isActive
             ? "bg-state-selected text-sidebar-foreground"
             : "text-sidebar-foreground hover:bg-state-hover group-hover:bg-state-hover"
@@ -544,7 +544,7 @@ function LabeledRailLink({
         )}
       </span>
       <span
-        className={`max-w-full truncate px-0.5 text-[9px] font-medium leading-[14px] ${
+        className={`max-w-full truncate px-0.5 text-[10px] font-medium leading-[14px] ${
           isActive
             ? "okou-nav-copy text-sidebar-foreground"
             : "okou-nav-copy-muted text-sidebar-foreground/60 new-ui:text-sidebar-foreground/70"
@@ -635,7 +635,7 @@ function LabeledNavRail() {
   return (
     <aside
       data-testid="labeled-nav-rail"
-      className="okou-nav okou-nav-rail hidden md:flex h-full w-[68px] shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar-rail px-1.5 pb-2 pt-3"
+      className="okou-nav okou-nav-rail hidden md:flex h-full w-[72px] shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar-rail px-1.5 pb-2 pt-3"
     >
       <div className="okou-desktop-titlebar-drag-region" aria-hidden="true" />
       <div className="mb-3 shrink-0">

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -459,6 +459,13 @@ function ExpandedFooter() {
 
 // --- Three-column (Slack-style) layout ---
 
+/* Everything in the rail is a 36px square, so centring it in the 72px column
+   leaves 18px down either side. The vertical padding matches that, which is
+   what puts the workspace logo and the account mark the same distance from
+   the corner they sit in as from the edge beside them. */
+const RAIL_FRAME =
+  "okou-nav okou-nav-rail hidden md:flex h-full w-[72px] shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar-rail px-1.5 py-[18px]";
+
 function LabeledRailLink({
   id,
   navPath,
@@ -633,10 +640,7 @@ function LabeledNavRail() {
     onNavSelect(id);
   };
   return (
-    <aside
-      data-testid="labeled-nav-rail"
-      className="okou-nav okou-nav-rail hidden md:flex h-full w-[72px] shrink-0 flex-col items-center border-r-[0.7px] border-sidebar-border bg-sidebar-rail px-1.5 pb-2 pt-3"
-    >
+    <aside data-testid="labeled-nav-rail" className={RAIL_FRAME}>
       <div className="okou-desktop-titlebar-drag-region" aria-hidden="true" />
       <div className="mb-3 shrink-0">
         <OrgSwitcherCompact />


### PR DESCRIPTION
## What

Sizing pass over the labeled navigation rail, from design review on the shipped rail.

| | Before | After |
|---|---|---|
| Rail width | 68px | **72px** |
| Nav icon button | 36×32 (rectangle) | **36×36 (square)** |
| Caption | 9px | **10px** |
| Caption gap under the icon | 4px | **2px** |
| Workspace logo / account mark | 24px | **36px (fills its button)** |
| Rail vertical padding | 12px top / 8px bottom | **18px, matching the horizontal inset** |

## Why

- **The icon hover was not square.** `h-8 w-9` painted the hover and selected background as a 36×32 rectangle. Squaring at 36×36 also lines the nav column up with the workspace logo and the account mark, which already sit in 36px `size="icon"` buttons — the rail becomes one consistent column of 36px rounded squares.
- **Captions were too small to scan** at 9px. 10px is the largest step that still keeps `Connectors` clear of the truncation edge inside the rail; 11px clips it. Measured every shipped locale in Geist 500 against the old and new content box: no label crosses from fitting to truncating, and the ones that ellipsize at 10px (`de-DE Integrationen`, `pt-BR Fluxos de trabalho`, `ja-JP アーティファクト`, …) already ellipsized at 9px.
- **Caption spacing.** At a 4px gap the caption floated between its own icon and the next one. 2px under the icon against 12px between items makes each item read as a single block.
- **Identity marks were framed by their own hover.** At 24px inside a 36px button, hovering the workspace logo or the account mark drew a grey frame *around* the mark. They now fill the button edge to edge, so the mark simply is the button and the hover background is covered — no frame, and both match the nav chips beside them.
- **Vertical padding.** A 36px square centred in a 72px column already sits 18px off either side, so the aside's padding moves to 18px top and bottom. The logo and the account mark now keep the same distance from the edge above and below them as from the edges beside them.

## Components touched

`LabeledRailLink` is local to `sidebar.tsx`, so the rail geometry stays there (the aside's classes are lifted into `RAIL_FRAME`).

The one shared component in the diff is the thumbnail scale in `views/components/avatar.tsx`, which gains an additive `"md+"` (36px) step. Its radius is deliberately 8px rather than the scale's usual constant quarter (9px): `md+` covers a `rounded-lg` button exactly, and a radius larger than the button's would leave four grey slivers of the hover background at the corners.

**Consumers of the changed size — both intended:**

- `okou-page/org-switcher.tsx:OrgSwitcherCompact` and `okou-page/sidebar-account.tsx:renderAccountTrigger(collapsed)` — the two marks in the labeled nav rail. This is the surface the change is for.
- `onboarding/onboarding-shell.tsx:217,223` — the same two components render onboarding's floating mobile workspace and account marks (`sm:hidden`). They grow 24px → 36px there too and lose the same grey hover frame. Intended: they are the identical collapsed/compact chrome pair, they fill the same 36px `size="icon"` button, and the surface is mobile-only so hover does not apply.

The non-collapsed `OrgSwitcher` and `AccountDropdown` rows keep `sm` (24px) and are unchanged.

## Review

Sign in to the preview and look at the rail on desktop (`md` and up), in both light and dark. Hover each of the six nav items to confirm the background is a square, hover the logo and the avatar to confirm no grey frame appears around them, and check that no caption truncates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
