### PR TITLE
fix(api): suppress expected execution timeout warnings

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -19159,7 +19159,7 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       }
     }
 
-    const oversizedInputFailures = [
+    const globallySuppressedFailures = [
       await completeFailure({ failureReason: "input_too_large" }),
       await completeFailure({
         modelProvider: "built-in",
@@ -19169,8 +19169,17 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
         failureReason: "input_too_large",
         persistedModelProvider: "legacy-unknown-provider",
       }),
+      await completeFailure({ failureReason: "execution_timeout" }),
+      await completeFailure({
+        modelProvider: "built-in",
+        failureReason: "execution_timeout",
+      }),
+      await completeFailure({
+        failureReason: "execution_timeout",
+        persistedModelProvider: "legacy-unknown-provider",
+      }),
     ];
-    for (const { runId } of oversizedInputFailures) {
+    for (const { runId } of globallySuppressedFailures) {
       for (const level of axiomLevels) {
         expect(matchingLogCalls(level, "Run failed", runId)).toHaveLength(0);
       }
@@ -19191,7 +19200,6 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       }),
       await completeFailure({}),
       await completeFailure({ failureReason: "session_history_limit" }),
-      await completeFailure({ failureReason: "execution_timeout" }),
       await completeFailure({ failureReason: "unsupported_model" }),
     ];
     for (const control of visibleControls) {

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -208,7 +208,8 @@ function shouldSuppressKnownFailureLog(
   failureReason: KnownRunFailureReason,
 ): boolean {
   switch (failureReason) {
-    case "input_too_large": {
+    case "input_too_large":
+    case "execution_timeout": {
       return true;
     }
     case "insufficient_credits":
@@ -231,7 +232,6 @@ function shouldSuppressKnownFailureLog(
       );
     }
     case "session_history_limit":
-    case "execution_timeout":
     case "unsupported_model": {
       return false;
     }


### PR DESCRIPTION
## Summary

- suppress the generic API `Run failed` application log for structured `execution_timeout` completions
- keep the policy provider-neutral while preserving warning visibility for missing and unknown failure reasons
- cover non-built-in, built-in, and legacy/unknown provider state through the existing completion-webhook integration test

## Behavior preserved

- failed run state, raw error, and persisted `failureReason`
- user-facing execution-timeout recovery
- runner timeout enforcement and structured info-level terminal telemetry
- existing warning behavior for reasonless, unknown, and intentionally visible failures

## Excluded

- timeout duration or early stall detection changes
- legacy raw-error matching for log suppression
- replacement API info events or runner logging changes

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (205 passed)
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `git diff --check`
- pre-commit hooks: Prettier, full Knip, full Turbo type checks, file-size check, and commitlint

Closes #32108
