### PR TITLE
fix(runner): expose api transport failure causes

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2634,6 +2634,7 @@ dependencies = [
  "hex",
  "http-body 1.1.0",
  "httpmock",
+ "hyper 1.11.1",
  "idna",
  "libc",
  "nbd-cow",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -73,6 +73,7 @@ futures-util = "0.3"
 hex = "0.4"
 hmac = "0.13.0"
 httpmock = "0.8"
+hyper = "1"
 idna = "1"
 libc = "0.2"
 nix = { version = "0.31", default-features = false }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -32,6 +32,7 @@ tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 flate2 = { workspace = true }
 futures-util = { workspace = true }
+hyper = { workspace = true }
 reqwest = { workspace = true }
 rustix = { workspace = true, features = ["process", "time"] }
 hex = { workspace = true }

--- a/crates/runner/src/error.rs
+++ b/crates/runner/src/error.rs
@@ -170,10 +170,56 @@ impl ApiFailureKind {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiTransportCause {
+    Timeout,
+    ConnectionRefused,
+    ConnectionReset,
+    ConnectionAborted,
+    NetworkUnreachable,
+    HostUnreachable,
+    NotConnected,
+    BrokenPipe,
+    UnexpectedEof,
+    HttpIncompleteMessage,
+    HttpCanceled,
+    HttpClosed,
+    HttpParse,
+    HttpBodyWriteAborted,
+    HttpShutdown,
+    Io,
+    Unknown,
+}
+
+impl ApiTransportCause {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::ConnectionRefused => "connection_refused",
+            Self::ConnectionReset => "connection_reset",
+            Self::ConnectionAborted => "connection_aborted",
+            Self::NetworkUnreachable => "network_unreachable",
+            Self::HostUnreachable => "host_unreachable",
+            Self::NotConnected => "not_connected",
+            Self::BrokenPipe => "broken_pipe",
+            Self::UnexpectedEof => "unexpected_eof",
+            Self::HttpIncompleteMessage => "http_incomplete_message",
+            Self::HttpCanceled => "http_canceled",
+            Self::HttpClosed => "http_closed",
+            Self::HttpParse => "http_parse",
+            Self::HttpBodyWriteAborted => "http_body_write_aborted",
+            Self::HttpShutdown => "http_shutdown",
+            Self::Io => "io",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApiTransportError {
     pub request: ApiRequestContext,
     pub failure_kind: ApiFailureKind,
+    pub failure_cause: ApiTransportCause,
     pub summary: String,
 }
 
@@ -181,8 +227,10 @@ impl std::fmt::Display for ApiTransportError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}: send API request failed: {}",
-            self.request.endpoint_label, self.summary
+            "{}: send API request failed: {}; cause={}",
+            self.request.endpoint_label,
+            self.summary,
+            self.failure_cause.as_str()
         )
     }
 }

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -202,19 +202,19 @@ async fn run_forwarder(
             Err(error) => {
                 if !warned_source_read_failure {
                     match &error {
-                        RunnerError::ApiTransport(error) => warn!(
+                        RunnerError::ApiTransport(api_error) => warn!(
                             run_id = %run_id,
                             error = %error,
-                            endpoint = error.request.endpoint_label,
-                            method = %error.request.method,
-                            host = %error.request.host,
-                            path = %error.request.path,
-                            client_request_id = %error.request.client_request_id,
-                            client_session_id = %error.request.client_session_id,
-                            client_version = %error.request.client_version,
-                            failure_kind = error.failure_kind.as_str(),
-                            failure_cause = error.failure_cause.as_str(),
-                            error_summary = %error.summary,
+                            endpoint = api_error.request.endpoint_label,
+                            method = %api_error.request.method,
+                            host = %api_error.request.host,
+                            path = %api_error.request.path,
+                            client_request_id = %api_error.request.client_request_id,
+                            client_session_id = %api_error.request.client_session_id,
+                            client_version = %api_error.request.client_version,
+                            failure_kind = api_error.failure_kind.as_str(),
+                            failure_cause = api_error.failure_cause.as_str(),
+                            error_summary = %api_error.summary,
                             "active-input source read failed; retrying"
                         ),
                         _ => {

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -18,6 +18,7 @@ use crate::active_input::{
     ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, ActiveInputBatch, ActiveInputSource,
     ApiActiveInputRecovery, local_active_input_delivery_id,
 };
+use crate::error::RunnerError;
 use crate::ids::RunId;
 
 const ACTIVE_INPUT_READ_RETRY_INTERVAL: Duration = Duration::from_millis(250);
@@ -200,7 +201,26 @@ async fn run_forwarder(
             },
             Err(error) => {
                 if !warned_source_read_failure {
-                    warn!(run_id = %run_id, error = %error, "active-input source read failed; retrying");
+                    match &error {
+                        RunnerError::ApiTransport(error) => warn!(
+                            run_id = %run_id,
+                            error = %error,
+                            endpoint = error.request.endpoint_label,
+                            method = %error.request.method,
+                            host = %error.request.host,
+                            path = %error.request.path,
+                            client_request_id = %error.request.client_request_id,
+                            client_session_id = %error.request.client_session_id,
+                            client_version = %error.request.client_version,
+                            failure_kind = error.failure_kind.as_str(),
+                            failure_cause = error.failure_cause.as_str(),
+                            error_summary = %error.summary,
+                            "active-input source read failed; retrying"
+                        ),
+                        _ => {
+                            warn!(run_id = %run_id, error = %error, "active-input source read failed; retrying")
+                        }
+                    }
                     warned_source_read_failure = true;
                 }
                 true

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -694,6 +694,7 @@ async fn run_in_sandbox_retrieves_reservation_after_lost_first_response() {
         })
         .expect("active-input transport failure should be logged");
     assert_eq!(event.fields["endpoint"], "reserve active inputs");
+    assert!(event.fields["error"].starts_with("api error: "));
     assert_eq!(event.fields["failure_kind"], "request");
     assert_eq!(event.fields["failure_cause"], "http_incomplete_message");
     let event_debug = format!("{event:#?}");

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -631,13 +631,17 @@ async fn run_in_sandbox_retrieves_reservation_after_lost_first_response() {
     let api_url = server.url();
     let notifications = ActiveInputNotifications::new();
     let source = api_active_input_source(
-        api_url,
+        api_url.clone(),
         run_id,
         &notifications,
         "active-input-lost-reserve-response-test",
     );
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
 
     let run_task = tokio::spawn(async move {
         run_in_sandbox(
@@ -667,6 +671,7 @@ async fn run_in_sandbox_retrieves_reservation_after_lost_first_response() {
         .unwrap()
         .unwrap()
         .unwrap();
+    drop(guard);
     assert!(result.failure.is_none());
     let requests = server.assert_finished_with_requests().await;
     assert_eq!(requests.len(), 2);
@@ -678,6 +683,22 @@ async fn run_in_sandbox_retrieves_reservation_after_lost_first_response() {
     let calls = overrides.process_control_calls();
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].message_id, DELIVERY_ID);
+    let event = captured
+        .entries()
+        .into_iter()
+        .find(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|message| message == "active-input source read failed; retrying")
+        })
+        .expect("active-input transport failure should be logged");
+    assert_eq!(event.fields["endpoint"], "reserve active inputs");
+    assert_eq!(event.fields["failure_kind"], "request");
+    assert_eq!(event.fields["failure_cause"], "http_incomplete_message");
+    let event_debug = format!("{event:#?}");
+    assert!(!event_debug.contains("runner-token"));
+    assert!(!event_debug.contains(&api_url));
 }
 
 #[tokio::test]

--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -1,3 +1,4 @@
+use std::error::Error as _;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -14,7 +15,8 @@ use uuid::Uuid;
 
 use crate::config::normalize_api_base_url;
 use crate::error::{
-    ApiFailureKind, ApiRequestContext, ApiTransportError, RunnerError, RunnerResult,
+    ApiFailureKind, ApiRequestContext, ApiTransportCause, ApiTransportError, RunnerError,
+    RunnerResult,
 };
 
 /// Default timeout for API requests (covers large claim payloads).
@@ -338,10 +340,12 @@ fn request_context(
 
 fn api_transport_error(context: ApiRequestContext, error: reqwest::Error) -> RunnerError {
     let failure_kind = api_failure_kind(&error);
+    let failure_cause = api_transport_cause(&error);
     let summary = sanitize_api_error_summary(error.without_url().to_string());
     RunnerError::ApiTransport(Box::new(ApiTransportError {
         request: context,
         failure_kind,
+        failure_cause,
         summary,
     }))
 }
@@ -357,6 +361,74 @@ fn api_failure_kind(error: &reqwest::Error) -> ApiFailureKind {
         ApiFailureKind::Request
     } else {
         ApiFailureKind::Unknown
+    }
+}
+
+fn api_transport_cause(error: &reqwest::Error) -> ApiTransportCause {
+    if error.is_timeout() {
+        return ApiTransportCause::Timeout;
+    }
+
+    // A concrete operating-system cause is more actionable than its protocol
+    // wrapper. Keep the first typed Hyper cause only as a fallback while
+    // walking deeper sources; never inspect dependency-owned error text.
+    let mut source = error.source();
+    let mut hyper_cause = None;
+    let mut saw_io = false;
+    while let Some(error) = source {
+        if let Some(error) = error.downcast_ref::<std::io::Error>() {
+            if let Some(cause) = api_io_cause(error.kind()) {
+                return cause;
+            }
+            saw_io = true;
+        }
+        if let Some(error) = error.downcast_ref::<hyper::Error>() {
+            hyper_cause = hyper_cause.or_else(|| api_hyper_cause(error));
+        }
+        source = error.source();
+    }
+
+    if let Some(cause) = hyper_cause {
+        cause
+    } else if saw_io {
+        ApiTransportCause::Io
+    } else {
+        ApiTransportCause::Unknown
+    }
+}
+
+fn api_io_cause(kind: std::io::ErrorKind) -> Option<ApiTransportCause> {
+    match kind {
+        std::io::ErrorKind::TimedOut => Some(ApiTransportCause::Timeout),
+        std::io::ErrorKind::ConnectionRefused => Some(ApiTransportCause::ConnectionRefused),
+        std::io::ErrorKind::ConnectionReset => Some(ApiTransportCause::ConnectionReset),
+        std::io::ErrorKind::ConnectionAborted => Some(ApiTransportCause::ConnectionAborted),
+        std::io::ErrorKind::NetworkUnreachable => Some(ApiTransportCause::NetworkUnreachable),
+        std::io::ErrorKind::HostUnreachable => Some(ApiTransportCause::HostUnreachable),
+        std::io::ErrorKind::NotConnected => Some(ApiTransportCause::NotConnected),
+        std::io::ErrorKind::BrokenPipe => Some(ApiTransportCause::BrokenPipe),
+        std::io::ErrorKind::UnexpectedEof => Some(ApiTransportCause::UnexpectedEof),
+        _ => None,
+    }
+}
+
+fn api_hyper_cause(error: &hyper::Error) -> Option<ApiTransportCause> {
+    if error.is_timeout() {
+        Some(ApiTransportCause::Timeout)
+    } else if error.is_incomplete_message() {
+        Some(ApiTransportCause::HttpIncompleteMessage)
+    } else if error.is_canceled() {
+        Some(ApiTransportCause::HttpCanceled)
+    } else if error.is_closed() {
+        Some(ApiTransportCause::HttpClosed)
+    } else if error.is_parse() {
+        Some(ApiTransportCause::HttpParse)
+    } else if error.is_body_write_aborted() {
+        Some(ApiTransportCause::HttpBodyWriteAborted)
+    } else if error.is_shutdown() {
+        Some(ApiTransportCause::HttpShutdown)
+    } else {
+        None
     }
 }
 
@@ -395,9 +467,11 @@ fn sanitize_api_error_summary(summary: String) -> String {
 mod tests {
     use api_contracts::generated::routes;
     use reqwest::header::AUTHORIZATION;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
     use super::*;
+    use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer};
 
     fn http_client(api_url: &str) -> HttpClient {
         HttpClient::new(HttpClientConfig {
@@ -664,6 +738,7 @@ mod tests {
         );
         assert_eq!(error.failure_kind, ApiFailureKind::Timeout);
         assert_eq!(error.failure_kind.as_str(), "timeout");
+        assert_eq!(error.failure_cause, ApiTransportCause::Timeout);
         assert!(
             !error.summary.contains(&api_url),
             "summary should not include full URL: {}",
@@ -674,6 +749,84 @@ mod tests {
             "summary should not include token or body: {}",
             error.summary
         );
+    }
+
+    #[tokio::test]
+    async fn send_connection_refused_exposes_stable_io_cause() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+
+        let error = http_client(&api_url)
+            .request_route(routes::runners::heartbeat::HEARTBEAT, "runner-token")
+            .send("heartbeat")
+            .await
+            .unwrap_err();
+        let error = api_transport_error(error);
+
+        assert_eq!(error.failure_kind, ApiFailureKind::Connect);
+        assert_eq!(error.failure_cause, ApiTransportCause::ConnectionRefused);
+        assert!(error.to_string().contains("cause=connection_refused"));
+    }
+
+    #[tokio::test]
+    async fn send_premature_http_disconnect_exposes_stable_protocol_cause() {
+        let server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+
+        let error = http_client(&server.url())
+            .request_route(routes::runners::heartbeat::HEARTBEAT, "runner-token")
+            .json(&serde_json::json!({}))
+            .send("heartbeat")
+            .await
+            .unwrap_err();
+        server.assert_finished().await;
+        let error = api_transport_error(error);
+
+        assert_eq!(error.failure_kind, ApiFailureKind::Request);
+        assert_eq!(
+            error.failure_cause,
+            ApiTransportCause::HttpIncompleteMessage
+        );
+    }
+
+    #[tokio::test]
+    async fn send_invalid_tls_peer_does_not_infer_tls_from_error_text() {
+        const QUERY_SECRET: &str = "query-sensitive-value";
+        const BODY_SECRET: &str = "body-sensitive-value";
+        const BEARER_SECRET: &str = "bearer-sensitive-value";
+        const PEER_BYTES: &str = "peer-sensitive-value";
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!(
+            "https://{}/private?credential={QUERY_SECRET}",
+            listener.local_addr().unwrap()
+        );
+        let server_task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut first_client_byte = [0_u8; 1];
+            socket.read_exact(&mut first_client_byte).await.unwrap();
+            socket.write_all(PEER_BYTES.as_bytes()).await.unwrap();
+            socket.shutdown().await.unwrap();
+        });
+
+        let error = http_client("http://127.0.0.1")
+            .authenticated_request(reqwest::Method::POST, url, BEARER_SECRET)
+            .json(&serde_json::json!({"secret": BODY_SECRET}))
+            .send("tls diagnostic")
+            .await
+            .unwrap_err();
+        server_task.await.unwrap();
+        let error = api_transport_error(error);
+
+        assert_eq!(error.failure_cause, ApiTransportCause::Io);
+        assert_eq!(error.request.path, "/private");
+        let diagnostic = format!("{error:?} {error}");
+        for secret in [QUERY_SECRET, BODY_SECRET, BEARER_SECRET, PEER_BYTES] {
+            assert!(
+                !diagnostic.contains(secret),
+                "transport diagnostic should exclude sensitive request and peer data: {diagnostic}"
+            );
+        }
     }
 
     #[test]

--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -468,7 +468,7 @@ mod tests {
     use api_contracts::generated::routes;
     use reqwest::header::AUTHORIZATION;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpListener;
+    use tokio::net::{TcpListener, TcpSocket};
 
     use super::*;
     use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer};
@@ -753,9 +753,9 @@ mod tests {
 
     #[tokio::test]
     async fn send_connection_refused_exposes_stable_io_cause() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let api_url = format!("http://{}", listener.local_addr().unwrap());
-        drop(listener);
+        let socket = TcpSocket::new_v4().unwrap();
+        socket.bind("127.0.0.1:0".parse().unwrap()).unwrap();
+        let api_url = format!("http://{}", socket.local_addr().unwrap());
 
         let error = http_client(&api_url)
             .request_route(routes::runners::heartbeat::HEARTBEAT, "runner-token")

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1107,6 +1107,7 @@ fn log_retryable_poll_failure(
             client_session_id = %request.client_session_id,
             client_version = %request.client_version,
             failure_kind = api_error.failure_kind.as_str(),
+            failure_cause = api_error.failure_cause.as_str(),
             error_summary = %api_error.summary,
             poll_reason,
             consecutive_failures = observation.consecutive_failures,
@@ -1127,6 +1128,7 @@ fn log_retryable_poll_failure(
         client_session_id = %request.client_session_id,
         client_version = %request.client_version,
         failure_kind = api_error.failure_kind.as_str(),
+        failure_cause = api_error.failure_cause.as_str(),
         error_summary = %api_error.summary,
         poll_reason,
         consecutive_failures = observation.consecutive_failures,
@@ -1151,6 +1153,7 @@ fn log_poll_failure(reason: PollReason, error: &RunnerError) {
                 client_session_id = %request.client_session_id,
                 client_version = %request.client_version,
                 failure_kind = api_error.failure_kind.as_str(),
+                failure_cause = api_error.failure_cause.as_str(),
                 error_summary = %api_error.summary,
                 poll_reason,
                 "poll failed"
@@ -1210,6 +1213,7 @@ fn log_heartbeat_failure(state: &HeartbeatState, error: &RunnerError) {
             client_session_id = %request.client_session_id,
             client_version = %request.client_version,
             failure_kind = api_error.failure_kind.as_str(),
+            failure_cause = api_error.failure_cause.as_str(),
             error_summary = %api_error.summary,
             runner_id = %state.runner_id,
             runner_group = %state.group,
@@ -1273,6 +1277,7 @@ fn log_retryable_heartbeat_failure(
             client_session_id = %request.client_session_id,
             client_version = %request.client_version,
             failure_kind = api_error.failure_kind.as_str(),
+            failure_cause = api_error.failure_cause.as_str(),
             error_summary = %api_error.summary,
             runner_id = %state.runner_id,
             runner_group = %state.group,
@@ -1299,6 +1304,7 @@ fn log_retryable_heartbeat_failure(
         client_session_id = %request.client_session_id,
         client_version = %request.client_version,
         failure_kind = api_error.failure_kind.as_str(),
+        failure_cause = api_error.failure_cause.as_str(),
         error_summary = %api_error.summary,
         runner_id = %state.runner_id,
         runner_group = %state.group,
@@ -2429,6 +2435,14 @@ mod tests {
         )
     }
 
+    fn synthetic_transport_cause(failure_kind: ApiFailureKind) -> crate::error::ApiTransportCause {
+        match failure_kind {
+            ApiFailureKind::Timeout => crate::error::ApiTransportCause::Timeout,
+            ApiFailureKind::Connect => crate::error::ApiTransportCause::ConnectionRefused,
+            _ => crate::error::ApiTransportCause::Unknown,
+        }
+    }
+
     fn poll_transport_error(failure_kind: ApiFailureKind) -> RunnerError {
         RunnerError::ApiTransport(Box::new(ApiTransportError {
             request: crate::error::ApiRequestContext {
@@ -2441,6 +2455,7 @@ mod tests {
                 client_version: env!("CARGO_PKG_VERSION").to_string(),
             },
             failure_kind,
+            failure_cause: synthetic_transport_cause(failure_kind),
             summary: format!("synthetic {} failure", failure_kind.as_str()),
         }))
     }
@@ -2457,6 +2472,7 @@ mod tests {
                 client_version: env!("CARGO_PKG_VERSION").to_string(),
             },
             failure_kind,
+            failure_cause: synthetic_transport_cause(failure_kind),
             summary: format!("synthetic {} failure", failure_kind.as_str()),
         }))
     }
@@ -2547,6 +2563,10 @@ mod tests {
                 env!("CARGO_PKG_VERSION")
             );
             assert_eq!(event_field(event, "failure_kind"), failure_kind.as_str());
+            assert_eq!(
+                event_field(event, "failure_cause"),
+                synthetic_transport_cause(failure_kind).as_str()
+            );
             assert_eq!(event_field(event, "consecutive_failures"), "1");
             assert_eq!(event_field(event, "failure_elapsed_ms"), "0");
             assert_eq!(event_field(event, "will_retry"), "true");
@@ -2657,6 +2677,7 @@ mod tests {
         assert_eq!(event.level, Level::WARN);
         assert_eq!(event_field(event, "mode"), "stopping");
         assert_eq!(event_field(event, "failure_kind"), "timeout");
+        assert_eq!(event_field(event, "failure_cause"), "timeout");
         assert!(!event.fields.contains_key("will_retry"));
         assert!(provider.heartbeat_failure_episode.lock().await.is_none());
     }
@@ -2869,6 +2890,10 @@ mod tests {
                     env!("CARGO_PKG_VERSION")
                 );
                 assert_eq!(event_field(event, "failure_kind"), failure_kind.as_str());
+                assert_eq!(
+                    event_field(event, "failure_cause"),
+                    synthetic_transport_cause(failure_kind).as_str()
+                );
                 assert_eq!(event_field(event, "poll_reason"), expected_reason);
                 assert_eq!(event_field(event, "consecutive_failures"), "1");
                 assert_eq!(event_field(event, "failure_elapsed_ms"), "0");

--- a/crates/runner/src/provider/connector_runtime_sync.rs
+++ b/crates/runner/src/provider/connector_runtime_sync.rs
@@ -301,6 +301,7 @@ fn log_connector_runtime_sync_api_failure(
                         client_session_id = %request.client_session_id,
                         client_version = %request.client_version,
                         failure_kind = api_error.failure_kind.as_str(),
+                        failure_cause = api_error.failure_cause.as_str(),
                         error_summary = %api_error.summary,
                         transport_retry_attempted,
                         reason = "api_error",
@@ -774,6 +775,7 @@ impl ConnectorRuntimeSyncCore {
                     client_session_id = %request.client_session_id,
                     client_version = %request.client_version,
                     failure_kind = error.failure_kind.as_str(),
+                    failure_cause = error.failure_cause.as_str(),
                     error_summary = %error.summary,
                     attempt = 1,
                     max_attempts = 2,
@@ -2556,6 +2558,11 @@ mod tests {
             ["timeout", "connect", "request", "body", "unknown"].contains(&failure_kind.as_str()),
             "unexpected failure kind; event={event:#?}"
         );
+        let failure_cause = event
+            .fields
+            .get("failure_cause")
+            .unwrap_or_else(|| panic!("missing field failure_cause; event={event:#?}"));
+        assert_eq!(failure_cause, "http_incomplete_message", "event={event:#?}");
         let error_summary = event
             .fields
             .get("error_summary")

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -11,6 +11,7 @@ use tokio::task::JoinHandle;
 use tracing::warn;
 
 use crate::duration::duration_ms;
+use crate::error::RunnerError;
 use crate::http::HttpClient;
 use crate::ids::RunId;
 use crate::resource_budget::ResourceBudget;
@@ -739,8 +740,25 @@ async fn send_telemetry(
         Ok(resp) if !resp.status().is_success() => {
             warn!(run_id = %run_id, status = %resp.status(), "telemetry flush rejected");
         }
-        Err(e) => {
-            warn!(run_id = %run_id, error = %e, "telemetry flush failed");
+        Err(RunnerError::ApiTransport(error)) => {
+            warn!(
+                run_id = %run_id,
+                error = %error,
+                endpoint = error.request.endpoint_label,
+                method = %error.request.method,
+                host = %error.request.host,
+                path = %error.request.path,
+                client_request_id = %error.request.client_request_id,
+                client_session_id = %error.request.client_session_id,
+                client_version = %error.request.client_version,
+                failure_kind = error.failure_kind.as_str(),
+                failure_cause = error.failure_cause.as_str(),
+                error_summary = %error.summary,
+                "telemetry flush failed"
+            );
+        }
+        Err(error) => {
+            warn!(run_id = %run_id, error = %error, "telemetry flush failed");
         }
         _ => {}
     }
@@ -749,6 +767,10 @@ async fn send_telemetry(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tracing::{Level, instrument::WithSubscriber};
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::CapturedEvents;
+
     use crate::http::HttpClientConfig;
     use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, json_response};
     use crate::types::{
@@ -1315,6 +1337,51 @@ mod tests {
         assert!(request.contains(r#""action_type":"storage_cache_background_fill_filled""#));
         assert!(request.contains(r#""duration_ms":42"#));
         assert!(request.contains(r#""success":true"#));
+    }
+
+    #[tokio::test]
+    async fn transport_failure_logs_stable_cause_and_safe_request_context() {
+        let server = RawHttpTestServer::spawn(vec![RawHttpAction::Disconnect]).await;
+        let api_url = server.url();
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+
+        send_telemetry(
+            &http_client_for_api_url(&api_url),
+            RunId::nil(),
+            "telemetry-sensitive-token",
+            None,
+            vec![sandbox_op(
+                "telemetry-sensitive-action",
+                Duration::from_millis(1),
+                true,
+                None,
+                None,
+                None,
+            )],
+        )
+        .with_subscriber(subscriber)
+        .await;
+        server.assert_finished().await;
+
+        let event = captured
+            .entries()
+            .into_iter()
+            .find(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_some_and(|message| message == "telemetry flush failed")
+            })
+            .expect("telemetry transport failure should be logged");
+        assert_eq!(event.level, Level::WARN);
+        assert_eq!(event.fields["endpoint"], "telemetry");
+        assert_eq!(event.fields["failure_kind"], "request");
+        assert_eq!(event.fields["failure_cause"], "http_incomplete_message");
+        let event_debug = format!("{event:#?}");
+        assert!(!event_debug.contains("telemetry-sensitive-token"));
+        assert!(!event_debug.contains("telemetry-sensitive-action"));
+        assert!(!event_debug.contains(&api_url));
     }
 
     #[tokio::test]

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -740,26 +740,24 @@ async fn send_telemetry(
         Ok(resp) if !resp.status().is_success() => {
             warn!(run_id = %run_id, status = %resp.status(), "telemetry flush rejected");
         }
-        Err(RunnerError::ApiTransport(error)) => {
-            warn!(
+        Err(error) => match &error {
+            RunnerError::ApiTransport(api_error) => warn!(
                 run_id = %run_id,
                 error = %error,
-                endpoint = error.request.endpoint_label,
-                method = %error.request.method,
-                host = %error.request.host,
-                path = %error.request.path,
-                client_request_id = %error.request.client_request_id,
-                client_session_id = %error.request.client_session_id,
-                client_version = %error.request.client_version,
-                failure_kind = error.failure_kind.as_str(),
-                failure_cause = error.failure_cause.as_str(),
-                error_summary = %error.summary,
+                endpoint = api_error.request.endpoint_label,
+                method = %api_error.request.method,
+                host = %api_error.request.host,
+                path = %api_error.request.path,
+                client_request_id = %api_error.request.client_request_id,
+                client_session_id = %api_error.request.client_session_id,
+                client_version = %api_error.request.client_version,
+                failure_kind = api_error.failure_kind.as_str(),
+                failure_cause = api_error.failure_cause.as_str(),
+                error_summary = %api_error.summary,
                 "telemetry flush failed"
-            );
-        }
-        Err(error) => {
-            warn!(run_id = %run_id, error = %error, "telemetry flush failed");
-        }
+            ),
+            _ => warn!(run_id = %run_id, error = %error, "telemetry flush failed"),
+        },
         _ => {}
     }
 }
@@ -1376,6 +1374,7 @@ mod tests {
             .expect("telemetry transport failure should be logged");
         assert_eq!(event.level, Level::WARN);
         assert_eq!(event.fields["endpoint"], "telemetry");
+        assert!(event.fields["error"].starts_with("api error: "));
         assert_eq!(event.fields["failure_kind"], "request");
         assert_eq!(event.fields["failure_cause"], "http_incomplete_message");
         let event_debug = format!("{event:#?}");


### PR DESCRIPTION
## Summary

- classify Runner-to-API transport failures with a bounded Runner-owned cause derived only from public reqwest, Hyper, and standard I/O types
- add `failure_cause` to heartbeat, connector runtime sync, active-input, telemetry, and existing provider transport diagnostics
- cover timeout, connection refusal, premature HTTP disconnect, invalid TLS peers, caller behavior, and diagnostic redaction through real local transport boundaries

## Compatibility and exclusions

- keeps `ApiFailureKind` as the sole retry-policy input and does not change timeouts, retry cadence, delivery, or fallback behavior
- does not change API schemas, request payloads, queues, Guest protocols, persisted state, or rollout requirements
- never inspects or emits raw dependency source/debug strings; unsupported detail, including TLS or DNS without a stable public signal, remains generic or unknown

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner --all-features -- --test-threads=4` (3508 passed, 25 ignored)
- repository pre-commit and commit-message hooks

Closes #32100
