### PR TITLE
fix: derive chat preference progress from shared invocations

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/settings/cloud-browser-preference.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/cloud-browser-preference.ts
@@ -1,14 +1,17 @@
 import { command, computed, state } from "ccstate";
 
 import { cloudBrowserEnabledByDefault$ } from "../../cloud-browser-preference.ts";
+import { pageSignal$ } from "../../page-signal.ts";
 import { updateUserPreference$ } from "./user-preferences.ts";
 
-const internalPendingCloudBrowserEnabledByDefault$ = state<boolean | null>(
-  null,
-);
+const internalCloudBrowserSubmission$ = state<{
+  readonly enabled: boolean;
+  readonly signal: AbortSignal;
+} | null>(null);
 
-export const pendingCloudBrowserEnabledByDefault$ = computed((get) => {
-  return get(internalPendingCloudBrowserEnabledByDefault$);
+export const submittedCloudBrowserEnabledByDefault$ = computed((get) => {
+  const submission = get(internalCloudBrowserSubmission$);
+  return submission?.signal === get(pageSignal$) ? submission.enabled : null;
 });
 
 export const updateCloudBrowserEnabledByDefault$ = command(
@@ -17,14 +20,13 @@ export const updateCloudBrowserEnabledByDefault$ = command(
     enabled: boolean,
     signal: AbortSignal,
   ): Promise<void> => {
-    set(internalPendingCloudBrowserEnabledByDefault$, enabled);
+    signal.throwIfAborted();
+    set(internalCloudBrowserSubmission$, { enabled, signal });
     await set(
       updateUserPreference$,
       { cloudBrowserEnabledByDefault: enabled },
       signal,
-    ).finally(() => {
-      set(internalPendingCloudBrowserEnabledByDefault$, null);
-    });
+    );
     signal.throwIfAborted();
     await get(cloudBrowserEnabledByDefault$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/okou-page/settings/default-model-preference.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/default-model-preference.ts
@@ -6,24 +6,32 @@ import {
   updateUserModelPreference$,
   userModelPreference$,
 } from "../../external/user-model-preference.ts";
+import { pageSignal$ } from "../../page-signal.ts";
 
-interface PendingDefaultModelSelection {
+interface DefaultModelSubmission {
   readonly selection: ModelProviderSelection | null;
+  readonly signal: AbortSignal;
 }
 
-const internalPendingDefaultModelSelection$ =
-  state<PendingDefaultModelSelection | null>(null);
+const internalDefaultModelSubmission$ = state<DefaultModelSubmission | null>(
+  null,
+);
 
-export const pendingDefaultModelSelection$ = computed((get) => {
-  return get(internalPendingDefaultModelSelection$);
+export const defaultModelSubmission$ = computed((get) => {
+  const submission = get(internalDefaultModelSubmission$);
+  return submission?.signal === get(pageSignal$)
+    ? { selection: submission.selection }
+    : null;
 });
 
-const persistDefaultModelPreference$ = command(
+export const updateDefaultModelPreference$ = command(
   async (
     { get, set },
     selection: ModelProviderSelection | null,
     signal: AbortSignal,
   ): Promise<void> => {
+    signal.throwIfAborted();
+    set(internalDefaultModelSubmission$, { selection, signal });
     await set(
       updateUserModelPreference$,
       {
@@ -36,20 +44,5 @@ const persistDefaultModelPreference$ = command(
     set(reloadUserModelPreference$);
     await get(userModelPreference$);
     signal.throwIfAborted();
-  },
-);
-
-export const updateDefaultModelPreference$ = command(
-  (
-    { set },
-    selection: ModelProviderSelection | null,
-    signal: AbortSignal,
-  ): Promise<void> => {
-    set(internalPendingDefaultModelSelection$, { selection });
-    return set(persistDefaultModelPreference$, selection, signal).finally(
-      () => {
-        set(internalPendingDefaultModelSelection$, null);
-      },
-    );
   },
 );

--- a/turbo/apps/platform/src/signals/okou-page/settings/send-mode-preference.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/send-mode-preference.ts
@@ -2,17 +2,17 @@ import { command, computed, state } from "ccstate";
 import type { SendMode } from "@okouai/api-contracts/contracts/user-preferences";
 
 import { sendMode$ } from "../../send-mode.ts";
+import { pageSignal$ } from "../../page-signal.ts";
 import { updateUserPreference$ } from "./user-preferences.ts";
 
-/**
- * Tracks the send mode value most recently submitted via updateSendMode$.
- * Used by the view to show an optimistic spinner on the correct button.
- * Cleared automatically when the command completes or fails.
- */
-const internalPendingSendMode$ = state<SendMode | null>(null);
+const internalSendModeSubmission$ = state<{
+  readonly value: SendMode;
+  readonly signal: AbortSignal;
+} | null>(null);
 
-export const pendingSendMode$ = computed((get) => {
-  return get(internalPendingSendMode$);
+export const submittedSendMode$ = computed((get) => {
+  const submission = get(internalSendModeSubmission$);
+  return submission?.signal === get(pageSignal$) ? submission.value : null;
 });
 
 /**
@@ -21,12 +21,9 @@ export const pendingSendMode$ = computed((get) => {
  */
 export const updateSendMode$ = command(
   async ({ get, set }, value: SendMode, signal: AbortSignal) => {
-    set(internalPendingSendMode$, value);
-    await set(updateUserPreference$, { sendMode: value }, signal).finally(
-      () => {
-        set(internalPendingSendMode$, null);
-      },
-    );
+    signal.throwIfAborted();
+    set(internalSendModeSubmission$, { value, signal });
+    await set(updateUserPreference$, { sendMode: value }, signal);
     signal.throwIfAborted();
     await get(sendMode$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-preference-actions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-preference-actions.test.tsx
@@ -1,0 +1,311 @@
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import {
+  userModelPreferenceContract,
+  type UserModelPreferenceResponse,
+} from "@okouai/api-contracts/contracts/user-model-preference";
+import {
+  userPreferencesContract,
+  type UserPreferencesResponse,
+} from "@okouai/api-contracts/contracts/user-preferences";
+import { screen, waitFor, within } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import {
+  click,
+  queryAllByRoleFast,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+const STANDARD = "GPT 5.6 Sol";
+const INHERIT = "Inherit from org default";
+
+function initialPreference(): UserModelPreferenceResponse {
+  return {
+    selectedModel: "gpt-5.6-sol",
+    serviceTier: null,
+    selectedVideoModel: null,
+    selectedImageModel: null,
+    updatedAt: "2026-09-06T00:00:00.000Z",
+  };
+}
+
+function getButton(dialog: HTMLElement, name: string): HTMLElement {
+  const button = queryAllByRoleFast("button", dialog).find((candidate) => {
+    return (
+      candidate.textContent?.trim() === name ||
+      candidate.getAttribute("aria-label") === name
+    );
+  });
+  if (!button) {
+    throw new Error(`Settings button not found: ${name}`);
+  }
+  return button;
+}
+
+async function openChatSettings(): Promise<HTMLElement> {
+  await setupPage({
+    context,
+    path: "/?settings=chat",
+    host: "app.vm0.ai",
+    featureSwitches: {
+      [FeatureSwitchKey.ChatPreference]: true,
+      [FeatureSwitchKey.CodexFastMode]: true,
+    },
+  });
+  const dialog = await screen.findByRole("dialog", { name: "Settings" });
+  await waitFor(() => {
+    expect(
+      within(dialog).getByRole("combobox", { name: STANDARD }),
+    ).toBeEnabled();
+  });
+  return dialog;
+}
+
+async function chooseModel(dialog: HTMLElement, current: string, next: string) {
+  click(within(dialog).getByRole("combobox", { name: current }));
+  click(await screen.findByRole("option", { name: next }));
+}
+
+async function remountChatSection(dialog: HTMLElement) {
+  click(getButton(dialog, "Preference"));
+  await within(dialog).findByRole("heading", { name: "Preference" });
+  click(getButton(dialog, "Chat"));
+  await within(dialog).findByRole("heading", { name: "Chat" });
+}
+
+function expectLockedSelection(dialog: HTMLElement, name: string) {
+  expect(within(dialog).getByLabelText(name)).toBeVisible();
+  expect(within(dialog).queryByRole("combobox", { name })).toBeNull();
+}
+
+test.each(["save", "refresh", "failure"] as const)(
+  "The default model stays locked across section changes until %s settles",
+  async (boundary) => {
+    let preference = initialPreference();
+    let saved = false;
+    let failSave = boundary === "failure";
+    const started = context.mocks.deferred<void>();
+    const release = context.mocks.deferred<void>();
+    context.mocks.api(
+      userModelPreferenceContract.get,
+      async ({ respond, withSignal }) => {
+        if (saved && boundary === "refresh" && !started.settled()) {
+          started.resolve();
+          await withSignal(release.promise);
+        }
+        return respond(200, preference);
+      },
+    );
+    context.mocks.api(
+      userModelPreferenceContract.update,
+      async ({ body, respond, withSignal }) => {
+        if (boundary !== "refresh" && !started.settled()) {
+          started.resolve();
+          await withSignal(release.promise);
+        }
+        if (failSave) {
+          return respond(500, {
+            error: {
+              message: "Model preference save failed",
+              code: "INTERNAL_SERVER_ERROR",
+            },
+          });
+        }
+        preference = {
+          ...preference,
+          selectedModel: body.selectedModel,
+          serviceTier: body.serviceTier,
+        };
+        saved = true;
+        return respond(200, preference);
+      },
+    );
+    const dialog = await openChatSettings();
+    await chooseModel(dialog, STANDARD, INHERIT);
+    await started.promise;
+    await remountChatSection(dialog);
+    await within(dialog).findByLabelText(INHERIT);
+    expectLockedSelection(dialog, INHERIT);
+
+    release.resolve();
+    const expected = boundary === "failure" ? STANDARD : INHERIT;
+    await waitFor(() => {
+      expect(
+        within(dialog).getByRole("combobox", { name: expected }),
+      ).toBeEnabled();
+    });
+    failSave = false;
+    const next = expected === STANDARD ? INHERIT : STANDARD;
+    await chooseModel(dialog, expected, next);
+    await waitFor(() => {
+      expect(
+        within(dialog).getByRole("combobox", { name: next }),
+      ).toBeEnabled();
+    });
+  },
+);
+
+test("A model save survives closing and reopening settings", async () => {
+  context.mocks.data.userModelPreference(initialPreference());
+  const started = context.mocks.deferred<void>();
+  const release = context.mocks.deferred<void>();
+  context.mocks.api(
+    userModelPreferenceContract.update,
+    async ({ body, respond, withSignal }) => {
+      started.resolve();
+      await withSignal(release.promise);
+      const preference = {
+        ...initialPreference(),
+        selectedModel: body.selectedModel,
+        serviceTier: body.serviceTier,
+      };
+      context.mocks.data.userModelPreference(preference);
+      return respond(200, preference);
+    },
+  );
+
+  const dialog = await openChatSettings();
+  await chooseModel(dialog, STANDARD, INHERIT);
+  await started.promise;
+  await waitFor(() => {
+    expect(
+      within(dialog).getByRole("switch", { name: "Cloud browser" }),
+    ).not.toHaveAttribute("aria-disabled", "true");
+    expect(getButton(dialog, "⌘ Enter")).toBeEnabled();
+  });
+  click(within(dialog).getByLabelText("Close"));
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
+  });
+
+  const rail = await screen.findByTestId("labeled-nav-rail");
+  click(within(rail).getByLabelText("Test User"));
+  const menu = await screen.findByRole("menu");
+  click(within(menu).getByText("Settings"));
+  const reopened = await screen.findByRole("dialog", { name: "Settings" });
+  click(getButton(reopened, "Chat"));
+  await within(reopened).findByRole("heading", { name: "Chat" });
+  expectLockedSelection(reopened, INHERIT);
+
+  release.resolve();
+  await waitFor(() => {
+    expect(
+      within(reopened).getByRole("combobox", { name: INHERIT }),
+    ).toBeEnabled();
+  });
+});
+
+function initialUserPreferences(): UserPreferencesResponse {
+  return {
+    timezone: "Etc/UTC",
+    locale: "en-US",
+    translationLanguage: null,
+    supportedLocales: ["en-US"],
+    pinnedAgentIds: [],
+    sendMode: "enter",
+    cloudBrowserEnabledByDefault: true,
+    theme: "system",
+    colorTheme: "blue-horizon",
+    captureNetworkBodiesRemaining: 0,
+    voiceInputModel: null,
+  };
+}
+
+test.each([
+  { setting: "send mode", boundary: "save", chatEnabled: true },
+  { setting: "send mode", boundary: "refresh", chatEnabled: true },
+  { setting: "send mode", boundary: "failure", chatEnabled: true },
+  { setting: "cloud browser", boundary: "save", chatEnabled: true },
+  { setting: "cloud browser", boundary: "refresh", chatEnabled: true },
+  { setting: "cloud browser", boundary: "failure", chatEnabled: true },
+  { setting: "send mode", boundary: "save", chatEnabled: false },
+] as const)(
+  "$setting stays selected and locked through $boundary (chat enabled: $chatEnabled)",
+  async ({ setting, boundary, chatEnabled }) => {
+    let preferences = initialUserPreferences();
+    let saved = false;
+    const started = context.mocks.deferred<void>();
+    const release = context.mocks.deferred<void>();
+    context.mocks.api(
+      userPreferencesContract.get,
+      async ({ respond, withSignal }) => {
+        if (saved && boundary === "refresh") {
+          started.resolve();
+          await withSignal(release.promise);
+        }
+        return respond(200, preferences);
+      },
+    );
+    context.mocks.api(
+      userPreferencesContract.update,
+      async ({ body, respond, withSignal }) => {
+        if (boundary !== "refresh") {
+          started.resolve();
+          await withSignal(release.promise);
+        }
+        if (boundary === "failure") {
+          return respond(500, {
+            error: {
+              message: "Preference save failed",
+              code: "INTERNAL_SERVER_ERROR",
+            },
+          });
+        }
+        preferences = { ...preferences, ...body };
+        saved = true;
+        return respond(200, preferences);
+      },
+    );
+    await setupPage({
+      context,
+      path: "/?settings=chat",
+      host: "app.vm0.ai",
+      featureSwitches: { [FeatureSwitchKey.ChatPreference]: chatEnabled },
+    });
+    const dialog = await screen.findByRole("dialog", { name: "Settings" });
+    const control = () => {
+      return setting === "send mode"
+        ? getButton(dialog, "⌘ Enter")
+        : within(dialog).getByRole("switch", { name: "Cloud browser" });
+    };
+    const selectionAttribute =
+      setting === "send mode" ? "aria-pressed" : "aria-checked";
+    const submittedSelection = setting === "send mode" ? "true" : "false";
+    const isDisabled = () => {
+      return setting === "send mode"
+        ? [control(), getButton(dialog, "Enter")].every((element) => {
+            return element.hasAttribute("disabled");
+          })
+        : control().getAttribute("aria-disabled") === "true";
+    };
+    await waitFor(() => {
+      expect(isDisabled()).toBeFalsy();
+    });
+    click(control());
+    await started.promise;
+    const expectSubmittedValue = () => {
+      expect(isDisabled()).toBeTruthy();
+      expect(control()).toHaveAttribute(selectionAttribute, submittedSelection);
+    };
+    await waitFor(expectSubmittedValue);
+
+    if (chatEnabled) {
+      await remountChatSection(dialog);
+    } else {
+      click(getButton(dialog, "General"));
+      await within(dialog).findByRole("heading", { name: "General" });
+      click(getButton(dialog, "Preference"));
+      await within(dialog).findByRole("heading", { name: "Preference" });
+    }
+    expectSubmittedValue();
+    release.resolve();
+    await waitFor(() => {
+      expect(isDisabled()).toBeFalsy();
+    });
+    const selected =
+      setting === "send mode" ? boundary !== "failure" : boundary === "failure";
+    expect(control()).toHaveAttribute(selectionAttribute, String(selected));
+  },
+);

--- a/turbo/apps/platform/src/views/okou-page/components/settings/chat-preference-actions.ts
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/chat-preference-actions.ts
@@ -1,0 +1,50 @@
+import { useGet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+
+import {
+  defaultModelSubmission$,
+  updateDefaultModelPreference$,
+} from "../../../../signals/okou-page/settings/default-model-preference.ts";
+import {
+  submittedCloudBrowserEnabledByDefault$,
+  updateCloudBrowserEnabledByDefault$,
+} from "../../../../signals/okou-page/settings/cloud-browser-preference.ts";
+import {
+  submittedSendMode$,
+  updateSendMode$,
+} from "../../../../signals/okou-page/settings/send-mode-preference.ts";
+
+export type ChatPreferenceActions = ReturnType<typeof useChatPreferenceActions>;
+
+/** Share invocation state across settings sections and dialog visibility. */
+export function useChatPreferenceActions() {
+  const [modelLoadable, updateModel] = useLoadableSet(
+    updateDefaultModelPreference$,
+  );
+  const modelSubmission = useGet(defaultModelSubmission$);
+  const [cloudBrowserLoadable, updateCloudBrowser] = useLoadableSet(
+    updateCloudBrowserEnabledByDefault$,
+  );
+  const cloudBrowserSubmission = useGet(submittedCloudBrowserEnabledByDefault$);
+  const [sendModeLoadable, updateSendMode] = useLoadableSet(updateSendMode$);
+  const sendModeSubmission = useGet(submittedSendMode$);
+
+  return {
+    model: {
+      update: updateModel,
+      submission: modelLoadable.state === "loading" ? modelSubmission : null,
+    },
+    cloudBrowser: {
+      update: updateCloudBrowser,
+      submission:
+        cloudBrowserLoadable.state === "loading"
+          ? cloudBrowserSubmission
+          : null,
+    },
+    sendMode: {
+      update: updateSendMode,
+      submission:
+        sendModeLoadable.state === "loading" ? sendModeSubmission : null,
+    },
+  };
+}

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/chat-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/chat-section.tsx
@@ -1,5 +1,4 @@
 import { useGet, useLastResolved, useLoadable } from "ccstate-react";
-import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import { Cpu, Globe, Keyboard, Loader2 } from "lucide-react";
 import { cn } from "@okouai/ui";
@@ -14,40 +13,30 @@ import { sendMode$ } from "../../../../../signals/send-mode.ts";
 import { cloudBrowserEnabledByDefault$ } from "../../../../../signals/cloud-browser-preference.ts";
 import { detach, Reason } from "../../../../../signals/utils.ts";
 import { resolveModelFirstStoredUserSelection } from "../../../../../signals/okou-page/model-default-selection.ts";
-import {
-  pendingDefaultModelSelection$,
-  updateDefaultModelPreference$,
-} from "../../../../../signals/okou-page/settings/default-model-preference.ts";
-import {
-  updateSendMode$,
-  pendingSendMode$,
-} from "../../../../../signals/okou-page/settings/send-mode-preference.ts";
-import {
-  pendingCloudBrowserEnabledByDefault$,
-  updateCloudBrowserEnabledByDefault$,
-} from "../../../../../signals/okou-page/settings/cloud-browser-preference.ts";
 import { ModelProviderPicker } from "../../model-provider-picker.tsx";
+import type { ChatPreferenceActions } from "../chat-preference-actions.ts";
 import { PreferenceCardRow } from "../preference-card-row.tsx";
 
 const SEND_OPTIONS: readonly SendMode[] = ["enter", "cmd-enter"];
 
-function DefaultModelPreference() {
+function DefaultModelPreference({
+  action,
+}: {
+  action: ChatPreferenceActions["model"];
+}) {
   const { t } = useTranslation();
   const userPreference = useLastResolved(userModelPreference$);
   const policies = useLastResolved(orgModelPolicies$);
   const codexFastModeEnabled = useGet(codexFastModeEnabled$);
-  const pending = useGet(pendingDefaultModelSelection$);
-  const [updateLoadable, updatePreference] = useLoadableSet(
-    updateDefaultModelPreference$,
-  );
+  const { submission, update: updatePreference } = action;
   const pageSignal = useGet(pageSignal$);
   const current = resolveModelFirstStoredUserSelection({
     userPreference,
     policies,
     codexFastModeEnabled,
   });
-  const effective = pending === null ? current : pending.selection;
-  const mutating = updateLoadable.state === "loading";
+  const effective = submission === null ? current : submission.selection;
+  const mutating = submission !== null;
 
   const handleChange = (selection: Parameters<typeof updatePreference>[0]) => {
     detach(updatePreference(selection, pageSignal), Reason.DomCallback);
@@ -77,18 +66,19 @@ function DefaultModelPreference() {
   );
 }
 
-function CloudBrowserDefaultPreference() {
+function CloudBrowserDefaultPreference({
+  action,
+}: {
+  action: ChatPreferenceActions["cloudBrowser"];
+}) {
   const { t } = useTranslation();
   const preferenceLoadable = useLoadable(cloudBrowserEnabledByDefault$);
   const current =
     preferenceLoadable.state === "hasData" ? preferenceLoadable.data : true;
-  const pending = useGet(pendingCloudBrowserEnabledByDefault$);
-  const [updateLoadable, updatePreference] = useLoadableSet(
-    updateCloudBrowserEnabledByDefault$,
-  );
+  const { submission, update: updatePreference } = action;
   const pageSignal = useGet(pageSignal$);
-  const mutating = updateLoadable.state === "loading";
-  const effective = pending ?? current;
+  const mutating = submission !== null;
+  const effective = submission ?? current;
 
   const handleToggle = (checked: boolean) => {
     detach(updatePreference(checked, pageSignal), Reason.DomCallback);
@@ -116,15 +106,17 @@ function CloudBrowserDefaultPreference() {
   );
 }
 
-export function SendModePreference() {
+export function SendModePreference({
+  action,
+}: {
+  action: ChatPreferenceActions["sendMode"];
+}) {
   const { t } = useTranslation();
   const prefsLoadable = useLoadable(sendMode$);
   const current: SendMode =
     prefsLoadable.state === "hasData" ? prefsLoadable.data : "enter";
-  const [saveModeLoadable, saveSendMode] = useLoadableSet(updateSendMode$);
+  const { submission: saving, update: saveSendMode } = action;
   const pageSignal = useGet(pageSignal$);
-  const pendingMode = useGet(pendingSendMode$);
-  const saving = saveModeLoadable.state === "loading" ? pendingMode : null;
 
   const handleChange = (value: SendMode) => {
     detach(saveSendMode(value, pageSignal), Reason.DomCallback);
@@ -189,12 +181,12 @@ export function SendModePreference() {
   );
 }
 
-export function ChatSection() {
+export function ChatSection({ actions }: { actions: ChatPreferenceActions }) {
   return (
     <div className="flex flex-col gap-3">
-      <DefaultModelPreference />
-      <CloudBrowserDefaultPreference />
-      <SendModePreference />
+      <DefaultModelPreference action={actions.model} />
+      <CloudBrowserDefaultPreference action={actions.cloudBrowser} />
+      <SendModePreference action={actions.sendMode} />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/sections/preference-section.tsx
@@ -20,6 +20,7 @@ import { LanguageSettings } from "../language-settings.tsx";
 import { ColorThemeSettings } from "../color-theme-settings.tsx";
 import { PreferenceCardRow } from "../preference-card-row.tsx";
 import { SendModePreference } from "./chat-section.tsx";
+import type { ChatPreferenceActions } from "../chat-preference-actions.ts";
 
 const THEME_OPTIONS: readonly {
   value: ThemePreference;
@@ -94,7 +95,11 @@ function AppearanceBlock() {
   );
 }
 
-export function PreferenceSection() {
+export function PreferenceSection({
+  sendModeAction,
+}: {
+  sendModeAction: ChatPreferenceActions["sendMode"];
+}) {
   const { t } = useTranslation();
   const featureSwitches = useGet(featureSwitch$);
   const chatPreferenceEnabled =
@@ -135,7 +140,7 @@ export function PreferenceSection() {
               return $.settings.preferences.send.description;
             })}
           />
-          <SendModePreference />
+          <SendModePreference action={sendModeAction} />
         </section>
       ) : null}
 

--- a/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/settings-dialog.tsx
@@ -47,12 +47,20 @@ import { BillingSection } from "./sections/billing-section.tsx";
 import { CreditBalanceSection } from "./sections/credit-balance-section.tsx";
 import { UsageRecordsSection } from "./sections/usage-records-section.tsx";
 import { InvoicesSection } from "./sections/invoices-section.tsx";
+import {
+  useChatPreferenceActions,
+  type ChatPreferenceActions,
+} from "./chat-preference-actions.ts";
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 
 interface SettingsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+}
+
+interface SettingsActionsProps {
+  actions: ChatPreferenceActions;
 }
 
 interface SidebarItem {
@@ -67,11 +75,11 @@ interface SidebarGroup {
 }
 
 const SECTION_COMPONENTS = {
-  preference: () => {
-    return <PreferenceSection />;
+  preference: ({ actions }: SettingsActionsProps) => {
+    return <PreferenceSection sendModeAction={actions.sendMode} />;
   },
-  chat: () => {
-    return <ChatSection />;
+  chat: ({ actions }: SettingsActionsProps) => {
+    return <ChatSection actions={actions} />;
   },
   model: () => {
     return <ModelSection />;
@@ -97,22 +105,33 @@ const SECTION_COMPONENTS = {
   invoices: () => {
     return <InvoicesSection />;
   },
-} as const satisfies Record<SettingsSection, () => ReactNode>;
+} as const satisfies Record<
+  SettingsSection,
+  (props: SettingsActionsProps) => ReactNode
+>;
 
-function SectionContent({ section }: { section: SettingsSection }) {
+function SectionContent({
+  section,
+  actions,
+}: SettingsActionsProps & { section: SettingsSection }) {
   const Component = SECTION_COMPONENTS[section];
-  return <Component />;
+  return <Component actions={actions} />;
 }
 
 export function SettingsDialog(props: SettingsDialogProps) {
+  const actions = useChatPreferenceActions();
   const standalonePlans = useGet(billingPlansStandalone$);
   if (props.open && standalonePlans) {
     return <BillingSection standalonePlans />;
   }
-  return <SettingsDialogSurface {...props} />;
+  return <SettingsDialogSurface {...props} actions={actions} />;
 }
 
-function SettingsDialogSurface({ open, onOpenChange }: SettingsDialogProps) {
+function SettingsDialogSurface({
+  open,
+  onOpenChange,
+  actions,
+}: SettingsDialogProps & SettingsActionsProps) {
   const { t } = useTranslation();
   const activeSection = useGet(settingsActiveSection$);
   const setActiveSection = useSet(setSettingsActiveSection$);
@@ -408,7 +427,7 @@ function SettingsDialogSurface({ open, onOpenChange }: SettingsDialogProps) {
               </p>
             </header>
             <div className="flex-1 overflow-y-auto px-4 sm:px-10 pb-10 pt-4 sm:pt-6 [scrollbar-gutter:stable]">
-              <SectionContent section={resolvedSection} />
+              <SectionContent section={resolvedSection} actions={actions} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Switching settings sections or reopening the dialog during a preference save recreated the row's loading state while its request kept running. The shared pending value could also be cleared before a refresh finished, allowing another edit or reverting the optimistic selection.

Own the default-model, cloud-browser, and send-mode `useLoadableSet` invocations in the stable `SettingsDialog` component. Both Chat and the legacy Preference send-mode row share those bindings. Store only submitted input associated with its page; derive optimistic values and disabled controls from the invocation's loadable, covering the complete save and refetch Promise. Remove the manual pending cleanup from all three commands.

## Verification

- 11 new Router/page integration cases passed: section changes, close/reopen, slow saves and refreshes, failure recovery, subsequent model saves, independent controls, and the legacy send-mode entry.
- All 9 existing preference-page tests passed.
- The default-model section-switch, send-mode refresh, and cloud-browser refresh regressions all fail against the unchanged base implementation.
- Formatting, Platform lint stages, Platform type checks, and Platform-scoped Knip passed. Full local Vitest and a local dev server were not run; the PR pipeline provides broader validation.
