### PR TITLE
chore(runner): classify closed active-input logs

### DIFF
--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -5,7 +5,9 @@ use std::io;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use guest_contracts::active_input::{ActiveInputDecodeError, decode_active_input};
+use guest_contracts::active_input::{
+    ACTIVE_INPUT_CLOSED_DIAGNOSTIC, ActiveInputDecodeError, decode_active_input,
+};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use tokio::sync::{mpsc, watch};
@@ -549,7 +551,7 @@ impl ActiveInputController {
         }
         if state.lifecycle != Lifecycle::Open {
             return ActiveInputControlOutcome::Rejected {
-                diagnostic: "active input is closed",
+                diagnostic: ACTIVE_INPUT_CLOSED_DIAGNOSTIC,
             };
         }
         if state.deliveries_by_id.len() >= ACTIVE_INPUT_DELIVERY_ID_CAPACITY {
@@ -597,7 +599,7 @@ impl ActiveInputController {
                 state.deliveries_by_id.remove(frame.delivery_id());
                 state.lifecycle = Lifecycle::Closed;
                 ActiveInputControlOutcome::Rejected {
-                    diagnostic: "active input is closed",
+                    diagnostic: ACTIVE_INPUT_CLOSED_DIAGNOSTIC,
                 }
             }
         }

--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -512,7 +512,10 @@ impl ActiveInputController {
     /// disabled, or closed inputs are rejected. A bounded backlog returns
     /// [`ActiveInputControlOutcome::QueueFull`] so callers can distinguish
     /// backpressure from validation rejection. Callers should branch on the
-    /// outcome variant rather than treating diagnostic text as a stable protocol.
+    /// outcome variant rather than treating diagnostic text as a stable
+    /// protocol. The one exception is
+    /// [`ACTIVE_INPUT_CLOSED_DIAGNOSTIC`], which Runner uses to classify the
+    /// expected closed-lifecycle race for logging.
     pub fn handle_control_payload(&self, payload: &[u8]) -> ActiveInputControlOutcome {
         let ActiveInputMode::Enabled(_) = &self.inner.mode else {
             return ActiveInputControlOutcome::Rejected {

--- a/crates/guest-contracts/src/active_input.rs
+++ b/crates/guest-contracts/src/active_input.rs
@@ -10,7 +10,9 @@
 //!
 //! Runner encodes borrowed delivery IDs and text through this module before
 //! process-control transport. Guest-agent decodes the bytes into owned,
-//! validated values before applying run-scoped queue and receipt policy.
+//! validated values before applying run-scoped queue and receipt policy. This
+//! module also owns the stable closed-lifecycle diagnostic that survives the
+//! generic process-control rejection boundary.
 
 use std::fmt;
 use std::io::{self, Write};
@@ -19,6 +21,12 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 const ACTIVE_INPUT_TYPE: &str = "active-input";
+
+/// Stable diagnostic returned when Guest active-input admission has closed.
+///
+/// Runner uses this value to classify the expected close race separately from
+/// other application-level rejections.
+pub const ACTIVE_INPUT_CLOSED_DIAGNOSTIC: &str = "active input is closed";
 
 #[derive(Serialize)]
 struct ActiveInputEncodeWire<'a> {

--- a/crates/runner/src/executor/active_input.rs
+++ b/crates/runner/src/executor/active_input.rs
@@ -6,13 +6,13 @@ use api_contracts::generated::types::runners::runs::active_inputs::{
     receipt::Response as ActiveInputReceiptResponse,
     reserve::{Response as ActiveInputReserveResponse, ResponseRejectedReason},
 };
-use guest_contracts::active_input::encode_active_input;
+use guest_contracts::active_input::{ACTIVE_INPUT_CLOSED_DIAGNOSTIC, encode_active_input};
 use sandbox::{
     GuestProcessControlHandle, ProcessControlFailureKind, ProcessControlGuestStatus,
     ProcessControlOutcome, ProcessControlWriteState, Sandbox,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::active_input::{
     ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, ActiveInputBatch, ActiveInputSource,
@@ -327,6 +327,15 @@ fn classify_control_outcome(
                 uncertain_disposition(mode)
             }
             ProcessControlGuestStatus::Inactive => ForwardDisposition::Stop,
+            ProcessControlGuestStatus::Rejected if diagnostic == ACTIVE_INPUT_CLOSED_DIAGNOSTIC => {
+                info!(
+                    run_id = %run_id,
+                    outcome = "closed",
+                    diagnostic = %diagnostic,
+                    "active-input control stopped"
+                );
+                ForwardDisposition::Stop
+            }
             ProcessControlGuestStatus::NonceMismatch
             | ProcessControlGuestStatus::Unsupported
             | ProcessControlGuestStatus::Rejected => {

--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use guest_contracts::active_input::encode_active_input;
+use guest_contracts::active_input::{ACTIVE_INPUT_CLOSED_DIAGNOSTIC, encode_active_input};
+use tracing::Level;
+use tracing_subscriber::prelude::*;
 
 use crate::active_input::{
     ACTIVE_INPUT_CONTROL_PAYLOAD_MAX_BYTES, API_ACTIVE_INPUT_RECHECK_INTERVAL,
@@ -13,8 +15,8 @@ use crate::executor::active_input::{
 };
 use crate::executor::agent_run::{RunControls, RunStart, run_in_sandbox};
 use crate::executor::tests::support::{
-    RUN_IN_SANDBOX_TEST_TIMEOUT, create_overridden_sandbox, minimal_context,
-    sandbox_read_file_error, test_executor_config, test_telemetry,
+    CapturedEvent, CapturedEvents, RUN_IN_SANDBOX_TEST_TIMEOUT, create_overridden_sandbox,
+    minimal_context, sandbox_read_file_error, test_executor_config, test_telemetry,
 };
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
@@ -72,6 +74,114 @@ fn api_active_input_source(
         "sandbox-token".to_string(),
         notifications.subscribe(run_id),
     )
+}
+
+async fn run_local_active_input_rejection(diagnostic: &str) -> Vec<CapturedEvent> {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let wait_gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&wait_gate),
+    ));
+    overrides.push_process_control_outcome(sandbox::ProcessControlOutcome::GuestStatus {
+        status: sandbox::ProcessControlGuestStatus::Rejected,
+        diagnostic: diagnostic.to_string(),
+    });
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let ctx = minimal_context();
+    let group_dir = dir.path().join("active-inputs");
+    LocalQueue::new(group_dir.clone())
+        .write_active_input_sync(&ActiveInputEntry {
+            run_id: ctx.run_id,
+            sequence: 1,
+            text: "late follow-up".to_string(),
+        })
+        .unwrap();
+    let source = ActiveInputSource::local_queue(LocalQueue::new(group_dir), ctx.run_id);
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let release_overrides = Arc::clone(&overrides);
+    let release_task = tokio::spawn(async move {
+        assert!(
+            release_overrides
+                .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
+                .await
+        );
+        wait_gate.notify_one();
+    });
+
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    let result = tokio::time::timeout(
+        RUN_IN_SANDBOX_TEST_TIMEOUT,
+        run_in_sandbox(
+            &*sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(cancel, Some(source)),
+        ),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    drop(guard);
+    release_task.await.unwrap();
+
+    assert!(result.failure.is_none());
+    assert_eq!(overrides.process_control_calls().len(), 1);
+    captured.entries()
+}
+
+fn active_input_stop_event(events: &[CapturedEvent]) -> &CapturedEvent {
+    let mut matching = events.iter().filter(|event| {
+        event
+            .fields
+            .get("message")
+            .is_some_and(|message| message == "active-input control stopped")
+    });
+    let event = matching
+        .next()
+        .unwrap_or_else(|| panic!("missing active-input stop event; captured={events:#?}"));
+    assert!(
+        matching.next().is_none(),
+        "expected one active-input stop event; captured={events:#?}"
+    );
+    event
+}
+
+fn assert_event_field(event: &CapturedEvent, field: &str, expected: &str) {
+    assert_eq!(
+        event.fields.get(field).map(String::as_str),
+        Some(expected),
+        "field {field} mismatch; event={event:#?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_classifies_active_input_rejection_logs() {
+    let closed_events = run_local_active_input_rejection(ACTIVE_INPUT_CLOSED_DIAGNOSTIC).await;
+    let closed = active_input_stop_event(&closed_events);
+    assert_eq!(closed.level, Level::INFO);
+    assert_event_field(closed, "run_id", "00000000-0000-0000-0000-000000000000");
+    assert_event_field(closed, "outcome", "closed");
+    assert_event_field(closed, "diagnostic", ACTIVE_INPUT_CLOSED_DIAGNOSTIC);
+
+    let rejected_events = run_local_active_input_rejection("unexpected rejection").await;
+    let rejected = active_input_stop_event(&rejected_events);
+    assert_eq!(rejected.level, Level::WARN);
+    assert_event_field(rejected, "run_id", "00000000-0000-0000-0000-000000000000");
+    assert_event_field(rejected, "outcome", "rejected");
+    assert_event_field(rejected, "diagnostic", "unexpected rejection");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- define the Guest active-input closed diagnostic in the shared Guest contract
- log that expected closed-lifecycle race at info with an explicit `closed` outcome
- keep unexpected Guest rejections at warning and cover both paths through `run_in_sandbox`

## Scope

This changes observability only. Active-input delivery, retry, and stop behavior remain unchanged. It does not change the process-control protocol, public APIs, persisted data, or database schema.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p guest-contracts -p guest-agent -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml --profile local -p guest-contracts -p guest-agent -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner --bin runner run_in_sandbox_classifies_active_input_rejection_logs`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent --test codex_app_server_backend_active_input_after_completion`
- The affected-crate all-target/all-feature run passed Guest tests and 3512 Runner tests, then reproduced one unrelated existing network-log child-reap synchronization race tracked in #32224.

Closes #32111
