### PR TITLE
fix: set terra reasoning effort to max

### DIFF
--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -21,7 +21,7 @@ pub(super) fn default_reasoning_effort_for_model(model: &str) -> Option<&'static
     match bare {
         "gpt-6-astra" => Some("max"),
         "gpt-5.6-sol" => Some("max"),
-        "gpt-5.6-terra" => Some("low"),
+        "gpt-5.6-terra" => Some("max"),
         "gpt-5.6-luna" => Some("max"),
         "gpt-5.5" => Some("xhigh"),
         _ => None,
@@ -208,8 +208,8 @@ mod tests {
             ("openai/gpt-5.5", "xhigh"),
             ("gpt-5.6-sol", "max"),
             ("openai/gpt-5.6-sol", "max"),
-            ("gpt-5.6-terra", "low"),
-            ("openai/gpt-5.6-terra", "low"),
+            ("gpt-5.6-terra", "max"),
+            ("openai/gpt-5.6-terra", "max"),
             ("gpt-5.6-luna", "max"),
             ("openai/gpt-5.6-luna", "max"),
         ] {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -12115,7 +12115,7 @@ describe("CHAT-02: model-first provider policies", () => {
     }
     const h1 = h1Bytes.toString("utf8");
     expect(h1).toContain('"type":"thinking_level_change"');
-    expect(h1).toContain('"thinkingLevel":"low"');
+    expect(h1).toContain('"thinkingLevel":"max"');
     expect(h1).not.toContain("serviceTier");
     const h2Session = MemoryPiSession.fromJsonl(h1);
     const h1Assistant = [...h2Session.buildSessionContext().messages]

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -5364,7 +5364,7 @@ function expectApiKeyTerraRequest(
       model: route.runtimeModel,
       stream: true,
       store: false,
-      reasoning: { effort: "low" },
+      reasoning: { effort: "max" },
     },
   });
   const { body } = z
@@ -5416,7 +5416,7 @@ function expectApiKeyTerraSandboxCarrier(
     ...(route.type === "vercel-ai-gateway-codex"
       ? { catalogModel: route.catalogModel }
       : {}),
-    thinkingLevel: "low",
+    thinkingLevel: "max",
     credentialBindings: [
       {
         kind: "api-key",
@@ -5453,7 +5453,7 @@ function expectNativeSubscriptionRequest(
       model: "gpt-5.6-terra",
       stream: true,
       store: false,
-      reasoning: { effort: "low" },
+      reasoning: { effort: "max" },
     },
   });
   const { body } = z
@@ -14938,7 +14938,7 @@ describe("CHAT-02: run-level model overrides", () => {
           provider: "openai-codex",
           baseUrl: "https://chatgpt.com/backend-api",
           model: "gpt-5.6-terra",
-          thinkingLevel: "low",
+          thinkingLevel: "max",
           credentialBindings: [
             {
               kind: "access-token",
@@ -15445,7 +15445,7 @@ describe("CHAT-02: run-level model overrides", () => {
             model: route.runtimeModel,
             stream: true,
             store: false,
-            reasoning: { effort: "low" },
+            reasoning: { effort: "max" },
           },
         });
         expect(request.body).not.toHaveProperty("previous_response_id");

--- a/turbo/apps/api/src/signals/routes/__tests__/pi-memory-stage1-worker.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/pi-memory-stage1-worker.test.ts
@@ -629,7 +629,7 @@ describe("Pi memory Stage 1 worker", () => {
       expect(serialized).not.toContain(fixtures[0]?.pi_session_id);
       expect(invocation.request).toMatchObject({
         model: "gpt-5.6-terra",
-        reasoning: { effort: "low" },
+        reasoning: { effort: "max" },
         text: {
           format: {
             type: "json_schema",

--- a/turbo/apps/api/src/signals/services/pi-memory-stage1-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-stage1-worker.service.ts
@@ -707,7 +707,7 @@ function providerConfig(args: {
     model: args.route.upstreamModel,
     api: "openai-responses" as const,
     dialect: "openai-responses" as const,
-    thinkingLevel: "low" as const,
+    thinkingLevel: "max" as const,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -121,7 +121,7 @@ function piRuntimeContract(args: {
   if (args.selectedModel === "gpt-5.6-terra") {
     return {
       api: "openai-responses",
-      thinkingLevel: "low",
+      thinkingLevel: "max",
       ...(isBuiltInModelProviderType(args.providerType) &&
       args.codexServiceTier === "fast"
         ? { serviceTier: "priority" as const }
@@ -252,7 +252,7 @@ function resolveCodexSubscriptionPiModelConfig(
     provider: "openai-codex",
     baseUrl: endpoint.baseUrl,
     model: "gpt-5.6-terra",
-    thinkingLevel: "low",
+    thinkingLevel: "max",
     credentialBindings: [
       {
         kind: "access-token",
@@ -371,7 +371,7 @@ function resolveStandardTerraApiKeyPiModelConfig(
     ...(route.productProviderType === "vercel-ai-gateway-codex"
       ? { catalogModel: route.catalogModel }
       : {}),
-    thinkingLevel: "low",
+    thinkingLevel: "max",
     credentialBindings: [
       {
         kind: "api-key",

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory-types.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory-types.ts
@@ -1,6 +1,6 @@
 import type { PiAgentModelConfig } from "./types";
 
-export const PI_MEMORY_PHASE2_MAINTENANCE_REASONING = "medium" as const;
+export const PI_MEMORY_PHASE2_MAINTENANCE_REASONING = "max" as const;
 export const PI_MEMORY_PHASE2_WORKSPACE_DIFF_MAX_BYTES = 4 * 1024 * 1024;
 export const PI_MEMORY_PHASE2_MEMORY_MAX_BYTES = 8 * 1024 * 1024;
 export const PI_MEMORY_PHASE2_PREPARED_MAX_BYTES = 128 * 1024 * 1024;

--- a/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/phase2-memory.test.ts
@@ -648,7 +648,7 @@ describe("Pi memory Phase 2 consolidation engine", () => {
     expect(sessions).toStrictEqual([
       {
         toolNames: PI_MEMORY_PHASE2_TOOL_NAMES,
-        thinkingLevel: "medium",
+        thinkingLevel: "max",
         sessionFile: undefined,
         extensions: 0,
         skills: 0,
@@ -668,7 +668,7 @@ describe("Pi memory Phase 2 consolidation engine", () => {
       expect(request.url).toBe("/v1/responses");
       expect(request.body).toMatchObject({
         model: "MODEL_ALIAS_SECRET_31243",
-        reasoning: { effort: "medium" },
+        reasoning: { effort: "max" },
       });
       expect(
         (request.body.tools as Array<{ readonly name: string }>).map((tool) => {

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
@@ -23,7 +23,7 @@ const TERRA_MODEL = {
   model: "gpt-5.6-terra",
   api: "openai-responses" as const,
   dialect: "openai-responses" as const,
-  thinkingLevel: "low" as const,
+  thinkingLevel: "max" as const,
 };
 
 const EMPTY_RESOURCE_SNAPSHOT = {
@@ -520,7 +520,7 @@ describe("official Pi AgentSession runtime", () => {
         config: {
           transport: "sse",
           baseUrl: provider.baseUrl.replace(/\/v1$/, route.basePath),
-          thinkingLevel: "low",
+          thinkingLevel: "max",
           ...(route.dialect === "openai-codex-responses"
             ? {
                 ...(route.tier === undefined
@@ -589,7 +589,7 @@ describe("official Pi AgentSession runtime", () => {
               model: route.model,
               stream: true,
               store: false,
-              reasoning: { effort: "low" },
+              reasoning: { effort: "max" },
             },
           });
           if (route.tier === undefined) {
@@ -869,7 +869,7 @@ describe("official Pi AgentSession runtime", () => {
           url: "/v1/responses",
           body: {
             model: "gpt-5.6-terra",
-            reasoning: { effort: "low" },
+            reasoning: { effort: "max" },
           },
         });
         if (serviceTier === undefined) {
@@ -1037,7 +1037,7 @@ describe("official Pi AgentSession runtime", () => {
     }
   });
 
-  it("uses Terra low thinking for a fresh session", async () => {
+  it("uses Terra max thinking for a fresh session", async () => {
     const sessionManager = SessionManager.inMemory("/home/user/workspace", {
       id: "00000000-0000-4000-8000-000000000124",
     });
@@ -1051,12 +1051,12 @@ describe("official Pi AgentSession runtime", () => {
     });
 
     try {
-      expect(created.session.agent.state.thinkingLevel).toBe("low");
+      expect(created.session.agent.state.thinkingLevel).toBe("max");
       expect(
         sessionManager.getBranch().filter((entry) => {
           return entry.type === "thinking_level_change";
         }),
-      ).toEqual([expect.objectContaining({ thinkingLevel: "low" })]);
+      ).toEqual([expect.objectContaining({ thinkingLevel: "max" })]);
     } finally {
       created.session.dispose();
     }

--- a/turbo/packages/pi-agent-runtime/src/stage1-memory.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/stage1-memory.test.ts
@@ -370,7 +370,7 @@ describe("Pi memory Stage 1 runtime", () => {
       expect(requests).toHaveLength(1);
       expect(requests[0]).toMatchObject({
         model: "gpt-5.6-terra",
-        reasoning: { effort: "low" },
+        reasoning: { effort: "max" },
         text: {
           format: {
             type: "json_schema",

--- a/turbo/packages/pi-agent-runtime/src/stage1-memory.ts
+++ b/turbo/packages/pi-agent-runtime/src/stage1-memory.ts
@@ -397,7 +397,7 @@ export async function runPiMemoryStage1Extraction(
   const message = await consumeAssistantMessage(
     piAgentStreamForConfig(args.model)(model, context, {
       apiKey: args.model.apiKey,
-      reasoning: "low",
+      reasoning: "max",
       samplingParams: {
         max_output_tokens: 32_768,
         text: {


### PR DESCRIPTION
## Summary

- set GPT-5.6 Terra reasoning effort to `max` for Codex and every Pi chat route
- align Pi memory Stage 1 extraction and Phase 2 consolidation with the same Terra `max` policy
- update request, sandbox-carrier, and session-state coverage for the new default

## Verification

- `pnpm -F @okouai/pi-agent-runtime lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/pi-agent-runtime check-types`
- `pnpm -F api check-types`
- `pnpm -F @okouai/pi-agent-runtime exec vitest run src/session-runtime.test.ts src/stage1-memory.test.ts src/phase2-memory.test.ts` (39 tests passed)
- `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-agent default_reasoning_effort_matches_supported_models`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p guest-agent --all-features --no-deps`

The focused API Vitest files require a local PostgreSQL instance and stopped during setup with `ECONNREFUSED :5432`; no test assertions ran locally, so the PR pipeline provides that coverage.
