### PR TITLE
fix(firewall): attribute auth fetch deadlines

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -42,6 +42,7 @@ Proxy CONNECT response headers and h11 incomplete events are bounded at 64 KiB. 
 body is bounded at ``MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES`` (256 KiB). One monotonic
 ``FIREWALL_AUTH_FETCH_DEADLINE_SECONDS`` deadline (10 seconds by default) covers DNS, connection
 racing, proxy CONNECT, TLS, request writing, response headers, and the bounded response body.
+Deadline errors retain the active phase from that closed transport vocabulary.
 """
 
 import asyncio
@@ -59,6 +60,7 @@ import urllib.request
 from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from email.message import Message
+from enum import StrEnum
 from typing import NamedTuple, Protocol, TypeGuard
 
 import h11
@@ -105,8 +107,24 @@ class FirewallAuthResponseTooLargeError(Exception):
     """Raised when /firewall/auth returns a response body above the local cap."""
 
 
+class FirewallAuthFetchPhase(StrEnum):
+    """Bounded transport phase active when a firewall auth fetch deadline expires."""
+
+    DNS = "dns"
+    CONNECT = "connect"
+    PROXY_CONNECT = "proxy_connect"
+    TLS = "tls"
+    REQUEST_WRITE = "request_write"
+    RESPONSE_HEADERS = "response_headers"
+    RESPONSE_BODY = "response_body"
+
+
 class FirewallAuthDeadlineExceededError(Exception):
     """Raised when one /firewall/auth request exceeds its total lifetime."""
+
+    def __init__(self, phase: FirewallAuthFetchPhase):
+        super().__init__(f"Firewall auth fetch deadline exceeded during {phase.value}")
+        self.phase = phase
 
 
 class FirewallAuthApiError(Exception):
@@ -149,6 +167,11 @@ class _ConnectedStream(NamedTuple):
     reader: asyncio.StreamReader
     writer: asyncio.StreamWriter
     socket: socket.socket
+
+
+@dataclass
+class _FirewallAuthFetchProgress:
+    phase: FirewallAuthFetchPhase = FirewallAuthFetchPhase.DNS
 
 
 @dataclass(frozen=True)
@@ -588,13 +611,20 @@ async def _establish_proxy_tunnel(
         raise ValueError("Firewall auth HTTP proxy sent data before TLS")
 
 
-async def _open_stream(plan: _ConnectionPlan) -> _ConnectedStream:
+async def _open_stream(
+    plan: _ConnectionPlan,
+    progress: _FirewallAuthFetchProgress,
+) -> _ConnectedStream:
+    progress.phase = FirewallAuthFetchPhase.DNS
     addresses = await _resolve_addresses(plan.connect_host, plan.connect_port)
+    progress.phase = FirewallAuthFetchPhase.CONNECT
     sock = await _open_connected_socket(addresses)
     try:
         if plan.use_proxy_tunnel:
+            progress.phase = FirewallAuthFetchPhase.PROXY_CONNECT
             await _establish_proxy_tunnel(sock, plan)
         if plan.origin_scheme == "https":
+            progress.phase = FirewallAuthFetchPhase.TLS
             reader, writer = await asyncio.open_connection(
                 sock=sock,
                 limit=_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES,
@@ -645,9 +675,11 @@ def _response_headers(event: h11.Response | h11.InformationalResponse) -> Messag
 async def _read_http_response(
     reader: asyncio.StreamReader,
     connection: h11.Connection,
+    progress: _FirewallAuthFetchProgress,
 ) -> _HttpResponse:
     response_event: h11.Response | h11.InformationalResponse | None = None
     body = bytearray()
+    progress.phase = FirewallAuthFetchPhase.RESPONSE_HEADERS
     while True:
         event = connection.next_event()
         if event is h11.NEED_DATA:
@@ -666,6 +698,7 @@ async def _read_http_response(
             continue
         if isinstance(event, h11.Response):
             response_event = event
+            progress.phase = FirewallAuthFetchPhase.RESPONSE_BODY
             continue
         if isinstance(event, h11.Data):
             if response_event is None:
@@ -692,13 +725,15 @@ async def _perform_http_request(
     req: urllib.request.Request,
     plan: _ConnectionPlan,
     body: bytes,
+    progress: _FirewallAuthFetchProgress,
 ) -> _HttpResponse:
-    stream = await _open_stream(plan)
+    stream = await _open_stream(plan, progress)
     connection = h11.Connection(
         h11.CLIENT,
         max_incomplete_event_size=_MAX_FIREWALL_AUTH_RESPONSE_HEADER_BYTES,
     )
     try:
+        progress.phase = FirewallAuthFetchPhase.REQUEST_WRITE
         stream.writer.write(
             connection.send(
                 h11.Request(
@@ -711,7 +746,7 @@ async def _perform_http_request(
         stream.writer.write(connection.send(h11.Data(data=body)))
         stream.writer.write(connection.send(h11.EndOfMessage()))
         await stream.writer.drain()
-        response = await _read_http_response(stream.reader, connection)
+        response = await _read_http_response(stream.reader, connection, progress)
         stream.writer.close()
         with suppress(OSError):
             await stream.writer.wait_closed()
@@ -987,15 +1022,14 @@ async def fetch_firewall_headers(
     )
     req = platform_api.make_api_request(url, body, request.sandbox_token)
     plan = _build_connection_plan(req)
+    progress = _FirewallAuthFetchProgress()
     timeout = asyncio.timeout(FIREWALL_AUTH_FETCH_DEADLINE_SECONDS)
     try:
         async with timeout:
-            response = await _perform_http_request(req, plan, body)
+            response = await _perform_http_request(req, plan, body, progress)
     except TimeoutError:
         if timeout.expired():
-            raise FirewallAuthDeadlineExceededError(
-                "Firewall auth fetch deadline exceeded"
-            ) from None
+            raise FirewallAuthDeadlineExceededError(progress.phase) from None
         raise
     except h11.ProtocolError:
         raise ValueError("Firewall auth HTTP protocol error") from None

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_client.py
@@ -1836,10 +1836,11 @@ class TestFirewallAuthAsyncTransport:
             patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.1),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
             mitm_ctx(api_url="http://firewall-auth.invalid"),
-            pytest.raises(auth_client.FirewallAuthDeadlineExceededError),
+            pytest.raises(auth_client.FirewallAuthDeadlineExceededError) as exc_info,
         ):
             await auth_client.fetch_firewall_headers(firewall_auth_request())
 
+        assert exc_info.value.phase is auth_client.FirewallAuthFetchPhase.CONNECT
         assert [address[0] for address in connect_probe.attempted_addresses] == list(pending_hosts)
         assert {address[0] for address in connect_probe.cancelled_addresses} == set(pending_hosts)
         assert connect_probe.max_active_count == 3
@@ -1903,9 +1904,43 @@ class TestFirewallAuthAsyncTransport:
             await asyncio.wait_for(request_received.wait(), timeout=2.0)
             await asyncio.wait_for(peer_closed.wait(), timeout=2.0)
 
-        assert str(exc_info.value) == "Firewall auth fetch deadline exceeded"
+        assert exc_info.value.phase is auth_client.FirewallAuthFetchPhase.RESPONSE_BODY
+        assert str(exc_info.value) == ("Firewall auth fetch deadline exceeded during response_body")
         assert "sensitive-encrypted-secrets" not in str(exc_info.value)
         assert "sensitive-sandbox-token" not in str(exc_info.value)
+
+    async def test_total_deadline_attributes_a_stalled_response_header_wait(self, mitm_ctx):
+        request_received = asyncio.Event()
+        peer_closed = asyncio.Event()
+
+        async def handle_client(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            await _read_raw_http_request(reader)
+            request_received.set()
+            with suppress(ConnectionResetError):
+                while await reader.read(64 * 1024):
+                    pass
+            peer_closed.set()
+            await _close_test_writer(writer)
+
+        async with _run_test_server(handle_client) as port:
+            with (
+                mitm_ctx(api_url=f"http://127.0.0.1:{port}"),
+                patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.1),
+                patch.object(platform_api, "VERCEL_BYPASS", ""),
+                pytest.raises(auth_client.FirewallAuthDeadlineExceededError) as exc_info,
+            ):
+                await auth_client.fetch_firewall_headers(firewall_auth_request())
+
+            await asyncio.wait_for(request_received.wait(), timeout=2.0)
+            await asyncio.wait_for(peer_closed.wait(), timeout=2.0)
+
+        assert exc_info.value.phase is auth_client.FirewallAuthFetchPhase.RESPONSE_HEADERS
+        assert str(exc_info.value) == (
+            "Firewall auth fetch deadline exceeded during response_headers"
+        )
 
     async def test_total_deadline_aborts_a_stalled_tls_handshake(self, mitm_ctx):
         handshake_started = asyncio.Event()
@@ -1938,12 +1973,14 @@ class TestFirewallAuthAsyncTransport:
                 patch.dict(os.environ, proxy_environment),
                 mitm_ctx(api_url=f"https://127.0.0.1:{port}"),
                 patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.5),
-                pytest.raises(auth_client.FirewallAuthDeadlineExceededError),
+                pytest.raises(auth_client.FirewallAuthDeadlineExceededError) as exc_info,
             ):
                 await auth_client.fetch_firewall_headers(firewall_auth_request())
 
             await asyncio.wait_for(handshake_started.wait(), timeout=2.0)
             await asyncio.wait_for(peer_closed.wait(), timeout=2.0)
+
+        assert exc_info.value.phase is auth_client.FirewallAuthFetchPhase.TLS
 
     async def test_total_deadline_cancels_dns_lookup_before_connect(self, mitm_ctx):
         class BlockingResolver:
@@ -1977,10 +2014,11 @@ class TestFirewallAuthAsyncTransport:
             patch.object(auth_client, "_dns_resolver", resolver),
             patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.05),
             mitm_ctx(api_url="http://firewall-auth.invalid"),
-            pytest.raises(auth_client.FirewallAuthDeadlineExceededError),
+            pytest.raises(auth_client.FirewallAuthDeadlineExceededError) as exc_info,
         ):
             await auth_client.fetch_firewall_headers(firewall_auth_request())
 
+        assert exc_info.value.phase is auth_client.FirewallAuthFetchPhase.DNS
         assert resolver.started.is_set()
         assert resolver.cancelled.is_set()
 
@@ -2036,6 +2074,11 @@ class TestFirewallAuthAsyncTransport:
         assert all(
             isinstance(result, auth_client.FirewallAuthDeadlineExceededError)
             for result in shared_results
+        )
+        assert all(
+            result.phase is auth_client.FirewallAuthFetchPhase.RESPONSE_BODY
+            for result in shared_results
+            if isinstance(result, auth_client.FirewallAuthDeadlineExceededError)
         )
         assert len({id(result) for result in shared_results}) == 1
         assert retry["headers"] == {}
@@ -2303,12 +2346,14 @@ class TestFirewallAuthAsyncTransport:
                 patch.object(auth_client, "FIREWALL_AUTH_FETCH_DEADLINE_SECONDS", 0.1),
                 patch.object(platform_api, "VERCEL_BYPASS", ""),
                 mitm_ctx(api_url="https://platform.example"),
-                pytest.raises(auth_client.FirewallAuthDeadlineExceededError),
+                pytest.raises(auth_client.FirewallAuthDeadlineExceededError) as exc_info,
             ):
                 await auth_client.fetch_firewall_headers(firewall_auth_request())
 
             await asyncio.wait_for(connect_received.wait(), timeout=2.0)
             await asyncio.wait_for(proxy_peer_closed.wait(), timeout=2.0)
+
+        assert exc_info.value.phase is auth_client.FirewallAuthFetchPhase.PROXY_CONNECT
 
     async def test_https_proxy_connect_preserves_origin_tls_and_isolates_credentials(
         self,

--- a/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth_handling.py
@@ -1101,8 +1101,14 @@ class TestHandleFirewallRequest:
                 ConnectionResetError("connection reset"),
                 "connection reset",
             ),
+            (
+                auth_client.FirewallAuthDeadlineExceededError(
+                    auth_client.FirewallAuthFetchPhase.RESPONSE_HEADERS
+                ),
+                "Firewall auth fetch deadline exceeded during response_headers",
+            ),
         ],
-        ids=["url-error", "socket-timeout", "connection-reset"],
+        ids=["url-error", "socket-timeout", "connection-reset", "deadline-phase"],
     )
     async def test_auth_endpoint_transport_failure_returns_502(
         self,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -19,6 +19,7 @@ import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
+import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise, settle } from "../../utils";
 import {
   basicTemplate,
@@ -77,6 +78,32 @@ const TERMINAL_RUN_STATUSES = [
   "cancelled",
   "timeout",
 ] as const satisfies readonly TestTerminalRunStatus[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function firewallAuthTimingEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      if (!isRecord(event) || event.run_id !== runId) {
+        return false;
+      }
+      return (
+        event.op_type === "firewall_auth_prepare" ||
+        event.op_type === "firewall_auth_resolve" ||
+        event.op_type === "firewall_auth_admit"
+      );
+    });
+  });
+}
 
 async function firewallRun(existingActor?: ApiTestUser): Promise<{
   readonly actor: ApiTestUser;
@@ -246,7 +273,9 @@ describe("FW-1: firewall auth boundaries", () => {
 describe("FW-2: template resolution without connector refresh", () => {
   it("resolves secret, var, and basic templates across headers, base, and query", async () => {
     const fw = createFirewallApi(context);
-    const { headers } = await firewallRun();
+    const { headers, runId } = await firewallRun();
+
+    context.mocks.axiom.sdkIngest.mockClear();
 
     const resolved = await fw.requestFirewallAuth(
       headers,
@@ -305,6 +334,42 @@ describe("FW-2: template resolution without connector refresh", () => {
     expect(resolved.body.resolvedSecrets).toContain("BASE_SECRET");
     expect(resolved.body.resolvedSecrets).toContain("QUERY_SECRET");
     expect(resolved.body.resolvedSecrets).toContain("SCRAPENINJA_TOKEN");
+
+    await flushWaitUntilForTest();
+    const timingEvents = firewallAuthTimingEventsForRun(runId);
+    expect(
+      timingEvents.map((event) => {
+        return event.op_type;
+      }),
+    ).toStrictEqual([
+      "firewall_auth_prepare",
+      "firewall_auth_resolve",
+      "firewall_auth_admit",
+    ]);
+    for (const event of timingEvents) {
+      expect(event).toStrictEqual(
+        expect.objectContaining({
+          source: "api",
+          sandbox_type: "runner",
+          run_id: runId,
+          duration_ms: expect.any(Number),
+          success: true,
+        }),
+      );
+      expect(Number.isFinite(event.duration_ms)).toBeTruthy();
+      expect(Number(event.duration_ms)).toBeGreaterThanOrEqual(0);
+    }
+    const serializedTimingEvents = JSON.stringify(timingEvents);
+    for (const sensitiveValue of [
+      "secret-value",
+      "rapidapi-secret",
+      "base-secret",
+      "query-secret",
+      "encryptedSecrets",
+      "authHeaders",
+    ]) {
+      expect(serializedTimingEvents).not.toContain(sensitiveValue);
+    }
   });
 
   it("reports unresolvable template references as connector-not-configured", async () => {
@@ -1725,7 +1790,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     onTestFinished(() => {
       mockOptionalEnv("FIREWALL_AUTH_REFRESH_TIMEOUT_MS", undefined);
     });
-    const { actor, headers } = await firewallRun();
+    const { actor, headers, runId } = await firewallRun();
     await fw.seedTestConnector(actor, {
       connectorSlug: "test-oauth",
       authMethod: "oauth",
@@ -1753,6 +1818,7 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
       })),
     };
 
+    context.mocks.axiom.sdkIngest.mockClear();
     const timedOut = await fw.requestFirewallAuth(headers, body, [502]);
     if (timedOut.status !== 502) {
       throw new Error("Expected the refresh timeout to fail with 502");
@@ -1760,6 +1826,20 @@ describe("FW-4: connector refresh and replacement snapshots", () => {
     expect(timedOut.body.error.code).toBe("TOKEN_REFRESH_FAILED");
     expect(timedOut.body.error.failureReason).toBe("upstream_provider");
     expect(timedOut.body.error.connectors).toStrictEqual(["test-oauth"]);
+
+    await flushWaitUntilForTest();
+    expect(firewallAuthTimingEventsForRun(runId)).toStrictEqual([
+      expect.objectContaining({
+        op_type: "firewall_auth_prepare",
+        run_id: runId,
+        success: true,
+      }),
+      expect.objectContaining({
+        op_type: "firewall_auth_resolve",
+        run_id: runId,
+        success: false,
+      }),
+    ]);
 
     // The connector was not flagged for reconnect: with the normal timeout
     // restored and a fast provider, the next call refreshes successfully.

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { performance } from "node:perf_hooks";
 
 import {
   getSecretNameForType,
@@ -73,7 +74,8 @@ import { logger } from "../../lib/log";
 import { nowDate } from "../../lib/time";
 import type { SandboxAuth } from "../../types/auth";
 import type { Db } from "../external/db";
-import { settle, tapError } from "../utils";
+import { recordSandboxOperations } from "../external/sandbox-op-log";
+import { safeSync, settle, tapError } from "../utils";
 import {
   decryptPersistentSecretsMap,
   decryptStoredSecretValue,
@@ -278,6 +280,27 @@ type ResolveFirewallAuthResult =
         };
       };
     };
+
+type FirewallAuthTimingActionType =
+  | "firewall_auth_prepare"
+  | "firewall_auth_resolve"
+  | "firewall_auth_admit";
+const FIREWALL_AUTH_SANDBOX_TYPE = "runner";
+
+interface FirewallAuthTimingRecord {
+  readonly actionType: FirewallAuthTimingActionType;
+  readonly durationMs: number;
+  readonly success: boolean;
+}
+
+type PreparedFirewallAuthRequest =
+  | {
+      readonly ok: true;
+      readonly referenced: ReferencedAuthKeys;
+      readonly prepared: PreparedFirewallAuth;
+      readonly billableExpiresAt: number | undefined;
+    }
+  | { readonly ok: false; readonly response: ResolveFirewallAuthResult };
 
 function connectorNotConfigured(): ResolveFirewallAuthResult {
   return {
@@ -660,6 +683,49 @@ const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 const REFRESH_BUFFER_SECS = 60;
 const DEFAULT_ACCESS_TOKEN_EXPIRES_IN_SECS = 15 * 60;
 const TEMPLATE_RE = /\$\{\{\s*(secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
+
+async function measureFirewallAuthStage<T>(
+  records: FirewallAuthTimingRecord[],
+  actionType: FirewallAuthTimingActionType,
+  operation: () => Promise<T>,
+  isSuccess: (result: T) => boolean,
+): Promise<T> {
+  const startedAt = performance.now();
+  let success = false;
+  return await (async () => {
+    const result = await operation();
+    success = isSuccess(result);
+    return result;
+  })().finally(() => {
+    records.push({
+      actionType,
+      durationMs: Math.max(0, performance.now() - startedAt),
+      success,
+    });
+  });
+}
+
+function recordFirewallAuthTimings(
+  runId: string,
+  records: readonly FirewallAuthTimingRecord[],
+): void {
+  const result = safeSync(() => {
+    recordSandboxOperations(
+      records.map((record) => {
+        return {
+          sandboxType: FIREWALL_AUTH_SANDBOX_TYPE,
+          actionType: record.actionType,
+          durationMs: record.durationMs,
+          success: record.success,
+          runId,
+        };
+      }),
+    );
+  });
+  if ("error" in result) {
+    L.warn("Failed to record firewall auth timings", { runId });
+  }
+}
 
 function inferAccessSourceType(accessSourceKey: string): AccessSecretSource {
   return modelProviderTypeForProviderKey(accessSourceKey)
@@ -5633,20 +5699,20 @@ function matchedConnectorSourceConflicts(args: {
   });
 }
 
-export async function resolveFirewallAuth(
+async function prepareFirewallAuthRequest(
   db: Db,
   auth: SandboxAuth,
   body: FirewallAuthBody,
-): Promise<ResolveFirewallAuthResult> {
+): Promise<PreparedFirewallAuthRequest> {
   const matchedFirewall = body.matchedFirewall;
   const customConnectorId = matchedFirewall?.customConnectorId;
   const run = await findFirewallAuthRun(db, auth);
   if (!run) {
     L.warn(`[${auth.runId}] Run not found for firewall auth`);
-    return badRequestMessage("Run not found");
+    return { ok: false, response: badRequestMessage("Run not found") };
   }
   if (!firewallAuthRunIsActive(run.status)) {
-    return forbiddenTerminalRun();
+    return { ok: false, response: forbiddenTerminalRun() };
   }
   const orgId = run.orgId;
   const forceRefreshStartedAtMicros =
@@ -5665,15 +5731,18 @@ export async function resolveFirewallAuth(
       referencedSecretKeys: referenced.secrets,
     })
   ) {
-    return badRequestMessage(
-      "Matched connector source does not match secret metadata",
-    );
+    return {
+      ok: false,
+      response: badRequestMessage(
+        "Matched connector source does not match secret metadata",
+      ),
+    };
   }
-  let preparation;
+  let preparation: FirewallAuthPreparation<PreparedFirewallAuth>;
   if (customConnectorId) {
     const sourceId = matchedFirewall.sourceId;
     if (sourceId === undefined) {
-      return connectorNotConfigured();
+      return { ok: false, response: connectorNotConfigured() };
     }
     preparation = await prepareCurrentCustomConnectorFirewallAuth({
       db,
@@ -5696,7 +5765,7 @@ export async function resolveFirewallAuth(
     });
   }
   if (!preparation.ok) {
-    return preparation.response;
+    return { ok: false, response: preparation.response };
   }
   const billableCacheExpiry = await resolveBillableFirewallCacheExpiry({
     db,
@@ -5705,28 +5774,88 @@ export async function resolveFirewallAuth(
     firewallBillable: body.firewallBillable,
   });
   if ("status" in billableCacheExpiry) {
-    return billableCacheExpiry;
+    return { ok: false, response: billableCacheExpiry };
   }
-  const resolution = await resolveFirewallAuthMaterial({
-    db,
-    auth,
-    body,
+  return {
+    ok: true,
     referenced,
     prepared: preparation.prepared,
-  });
+    billableExpiresAt: billableCacheExpiry.expiresAt,
+  };
+}
+
+async function resolveFirewallAuthWithTimings(
+  db: Db,
+  auth: SandboxAuth,
+  body: FirewallAuthBody,
+  timingRecords: FirewallAuthTimingRecord[],
+): Promise<ResolveFirewallAuthResult> {
+  const preparation = await measureFirewallAuthStage(
+    timingRecords,
+    "firewall_auth_prepare",
+    async () => {
+      return await prepareFirewallAuthRequest(db, auth, body);
+    },
+    (result) => {
+      return result.ok;
+    },
+  );
+  if (!preparation.ok) {
+    return preparation.response;
+  }
+  const resolution = await measureFirewallAuthStage(
+    timingRecords,
+    "firewall_auth_resolve",
+    async () => {
+      return await resolveFirewallAuthMaterial({
+        db,
+        auth,
+        body,
+        referenced: preparation.referenced,
+        prepared: preparation.prepared,
+      });
+    },
+    (result) => {
+      return result.ok;
+    },
+  );
   if (!resolution.ok) {
     return resolution.response;
   }
   const finalized = finalizeFirewallAuth({
     body,
-    referenced,
+    referenced: preparation.referenced,
     material: resolution.material,
-    billableExpiresAt: billableCacheExpiry.expiresAt,
+    billableExpiresAt: preparation.billableExpiresAt,
   });
   if (finalized.status !== 200) {
     return finalized;
   }
-  return (await admitFirewallAuthResponse(db, auth))
-    ? finalized
-    : forbiddenTerminalRun();
+  const admitted = await measureFirewallAuthStage(
+    timingRecords,
+    "firewall_auth_admit",
+    async () => {
+      return await admitFirewallAuthResponse(db, auth);
+    },
+    (result) => {
+      return result;
+    },
+  );
+  return admitted ? finalized : forbiddenTerminalRun();
+}
+
+export async function resolveFirewallAuth(
+  db: Db,
+  auth: SandboxAuth,
+  body: FirewallAuthBody,
+): Promise<ResolveFirewallAuthResult> {
+  const timingRecords: FirewallAuthTimingRecord[] = [];
+  return await resolveFirewallAuthWithTimings(
+    db,
+    auth,
+    body,
+    timingRecords,
+  ).finally(() => {
+    recordFirewallAuthTimings(auth.runId, timingRecords);
+  });
 }


### PR DESCRIPTION
## Summary

- attribute runner firewall-auth deadline failures to a closed DNS/connect/proxy/TLS/request/response phase
- emit ordered, run-associated API timings for preparation, resolution, and final admission through the existing sandbox-operation sink
- preserve the existing deadline, retry, cache, response, refresh, cancellation, and socket-cleanup behavior

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/` (7322 passed)
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts` against a freshly migrated isolated database (63 passed)

## Compatibility

This is additive observability only. It changes no API schema, database schema, queue payload, persisted state, environment variable, timeout, or retry policy, so mixed runner/API deployment versions remain compatible.

Closes #32107
