### PR TITLE
fix(sandbox): extend healthy balloon settling

### DIFF
--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3602,8 +3602,8 @@ fn idle_transition_error(
 // building a fully-initialised `FirecrackerSandbox` (which pulls in the
 // network pool, NBD COW device, firecracker child process, etc.).
 
-/// Maximum time to wait for balloon inflation before pausing vCPUs.
-const BALLOON_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Initial time to wait for balloon inflation before considering an extension.
+const BALLOON_SETTLE_INITIAL_TIMEOUT: Duration = Duration::from_secs(5);
 /// Additional wait when the balloon is still making progress and the
 /// guest reports enough unused memory to finish reclaiming safely.
 const BALLOON_SETTLE_PROGRESS_GRACE: Duration = Duration::from_secs(5);
@@ -3936,8 +3936,8 @@ enum PhysicalParkOutcome {
 /// **before** pausing. Returns when `actual_mib >= target_mib`, when
 /// the remaining deficit is within [`balloon_settle_tolerance_mib`],
 /// when guest pressure indicates further reclaim is unsafe, or after
-/// [`BALLOON_SETTLE_TIMEOUT`]. A severe deficit that is still progressing with
-/// enough unused guest memory gets repeated
+/// [`BALLOON_SETTLE_INITIAL_TIMEOUT`]. A severe deficit that is still progressing
+/// with enough unused guest memory gets repeated
 /// [`BALLOON_SETTLE_PROGRESS_GRACE`] extensions up to
 /// [`BALLOON_SETTLE_MAX_TIMEOUT`]. The returned outcome rejects only the existing
 /// severe-deficit classification. Errors from stats fetching are non-fatal —
@@ -3962,7 +3962,7 @@ async fn wait_for_balloon_with_optional_handoff(
 ) -> BalloonSettleWaitResult {
     let tolerance_mib = balloon_settle_tolerance_mib(target_mib);
     let mut summary = BalloonSettleSummary::new(target_mib);
-    let mut settle_timeout = BALLOON_SETTLE_TIMEOUT;
+    let mut settle_timeout = BALLOON_SETTLE_INITIAL_TIMEOUT;
     let mut deadline = summary.started_at + settle_timeout;
     let max_deadline = summary.started_at + BALLOON_SETTLE_MAX_TIMEOUT;
     let mut fast_poll_intervals = BALLOON_SETTLE_FAST_POLL_INTERVALS.into_iter();

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -3604,9 +3604,11 @@ fn idle_transition_error(
 
 /// Maximum time to wait for balloon inflation before pausing vCPUs.
 const BALLOON_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
-/// Additional bounded wait when the balloon is still making progress and the
+/// Additional wait when the balloon is still making progress and the
 /// guest reports enough unused memory to finish reclaiming safely.
 const BALLOON_SETTLE_PROGRESS_GRACE: Duration = Duration::from_secs(5);
+/// Absolute upper bound for balloon inflation across all progress extensions.
+const BALLOON_SETTLE_MAX_TIMEOUT: Duration = Duration::from_secs(30);
 /// Fast-start poll intervals while waiting for balloon inflation.
 const BALLOON_SETTLE_FAST_POLL_INTERVALS: [Duration; 7] = [
     Duration::from_millis(25),
@@ -3846,34 +3848,48 @@ fn log_balloon_settle_timeout(
     summary: &BalloonSettleSummary,
     outcome: &SandboxParkOutcome,
 ) {
-    warn!(
-        id = %log_id,
-        actual = ?summary.last_actual_mib,
-        target = target_mib,
-        deficit_mib = ?summary.last_deficit_mib,
-        tolerance_mib,
-        elapsed_ms = summary.elapsed_ms(),
-        sample_count = summary.sample_count,
-        requested_target_mib = summary.requested_target_mib,
-        first_observed_target_mib = ?summary.first_observed_target_mib,
-        observed_target_mib = ?summary.last_observed_target_mib,
-        target_observed = summary.target_observed,
-        first_actual_mib = ?summary.first_actual_mib,
-        max_actual_mib = ?summary.max_actual_mib,
-        actual_delta_mib = ?summary.actual_delta_mib(),
-        reported_free_mib = ?summary.reported_free_mib(),
-        reported_available_mib = ?summary.reported_available_mib(),
-        reported_total_mib = ?summary.reported_total_mib(),
-        reason = summary.reason(),
-        admission_action = park_admission_action(outcome),
-        "balloon inflate incomplete after {}s, pausing anyway",
-        settle_timeout.as_secs()
-    );
+    macro_rules! emit_timeout {
+        ($level:expr) => {
+            tracing::event!(
+                $level,
+                id = %log_id,
+                actual = ?summary.last_actual_mib,
+                target = target_mib,
+                deficit_mib = ?summary.last_deficit_mib,
+                tolerance_mib,
+                elapsed_ms = summary.elapsed_ms(),
+                sample_count = summary.sample_count,
+                requested_target_mib = summary.requested_target_mib,
+                first_observed_target_mib = ?summary.first_observed_target_mib,
+                observed_target_mib = ?summary.last_observed_target_mib,
+                target_observed = summary.target_observed,
+                first_actual_mib = ?summary.first_actual_mib,
+                max_actual_mib = ?summary.max_actual_mib,
+                actual_delta_mib = ?summary.actual_delta_mib(),
+                reported_free_mib = ?summary.reported_free_mib(),
+                reported_available_mib = ?summary.reported_available_mib(),
+                reported_total_mib = ?summary.reported_total_mib(),
+                reason = summary.reason(),
+                admission_action = park_admission_action(outcome),
+                "balloon inflate incomplete after {}s, pausing anyway",
+                settle_timeout.as_secs()
+            );
+        };
+    }
+
+    if summary.reason() == "actual_progressing_timeout"
+        && matches!(outcome, SandboxParkOutcome::Reusable)
+    {
+        emit_timeout!(tracing::Level::INFO);
+    } else {
+        emit_timeout!(tracing::Level::WARN);
+    }
 }
 
 fn log_balloon_settle_progress_grace(
     log_id: &str,
     target_mib: u32,
+    progress_grace: Duration,
     summary: &BalloonSettleSummary,
 ) {
     info!(
@@ -3886,7 +3902,7 @@ fn log_balloon_settle_progress_grace(
         previous_actual_mib = ?summary.previous_actual_mib,
         reported_free_mib = ?summary.reported_free_mib(),
         reported_available_mib = ?summary.reported_available_mib(),
-        grace_ms = duration_ms(BALLOON_SETTLE_PROGRESS_GRACE),
+        grace_ms = duration_ms(progress_grace),
         "balloon inflation still progressing, extending settle deadline"
     );
 }
@@ -3921,10 +3937,11 @@ enum PhysicalParkOutcome {
 /// the remaining deficit is within [`balloon_settle_tolerance_mib`],
 /// when guest pressure indicates further reclaim is unsafe, or after
 /// [`BALLOON_SETTLE_TIMEOUT`]. A severe deficit that is still progressing with
-/// enough unused guest memory gets one bounded
-/// [`BALLOON_SETTLE_PROGRESS_GRACE`]. The returned outcome rejects only the
-/// existing severe-deficit classification. Errors from stats fetching are
-/// non-fatal — we log and proceed to pause.
+/// enough unused guest memory gets repeated
+/// [`BALLOON_SETTLE_PROGRESS_GRACE`] extensions up to
+/// [`BALLOON_SETTLE_MAX_TIMEOUT`]. The returned outcome rejects only the existing
+/// severe-deficit classification. Errors from stats fetching are non-fatal —
+/// we log and proceed to pause.
 #[cfg(test)]
 async fn wait_for_balloon_with_outcome(
     client: &ApiClient,
@@ -3947,15 +3964,16 @@ async fn wait_for_balloon_with_optional_handoff(
     let mut summary = BalloonSettleSummary::new(target_mib);
     let mut settle_timeout = BALLOON_SETTLE_TIMEOUT;
     let mut deadline = summary.started_at + settle_timeout;
-    let mut progress_grace_used = false;
+    let max_deadline = summary.started_at + BALLOON_SETTLE_MAX_TIMEOUT;
     let mut fast_poll_intervals = BALLOON_SETTLE_FAST_POLL_INTERVALS.into_iter();
     loop {
-        if tokio::time::Instant::now() >= deadline {
-            if !progress_grace_used && summary.can_extend_for_progress() {
-                progress_grace_used = true;
-                settle_timeout += BALLOON_SETTLE_PROGRESS_GRACE;
-                deadline = summary.started_at + settle_timeout;
-                log_balloon_settle_progress_grace(log_id, target_mib, &summary);
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            if now < max_deadline && summary.can_extend_for_progress() {
+                let progress_grace = BALLOON_SETTLE_PROGRESS_GRACE.min(max_deadline - now);
+                deadline = now + progress_grace;
+                settle_timeout = deadline - summary.started_at;
+                log_balloon_settle_progress_grace(log_id, target_mib, progress_grace, &summary);
             } else {
                 let outcome = summary.park_outcome();
                 log_balloon_settle_timeout(

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -4570,7 +4570,7 @@ where
         }
     }
 
-    tokio::time::advance(BALLOON_SETTLE_TIMEOUT).await;
+    tokio::time::advance(BALLOON_SETTLE_INITIAL_TIMEOUT).await;
     tokio::time::resume();
     let output = future.await;
     drop(guard);
@@ -4612,7 +4612,8 @@ async fn advance_balloon_wait_to_progress_grace<F>(
     wait_for_balloon_sample_count(future.as_mut(), captured, 2).await;
     tokio::time::pause();
 
-    tokio::time::advance(BALLOON_SETTLE_TIMEOUT - BALLOON_SETTLE_FAST_POLL_INTERVALS[0]).await;
+    tokio::time::advance(BALLOON_SETTLE_INITIAL_TIMEOUT - BALLOON_SETTLE_FAST_POLL_INTERVALS[0])
+        .await;
     tokio::time::resume();
     loop {
         if has_captured_event(
@@ -5038,7 +5039,7 @@ async fn wait_for_balloon_follows_exact_bounded_poll_schedule() {
         }
     }
 
-    tokio::time::advance(BALLOON_SETTLE_TIMEOUT).await;
+    tokio::time::advance(BALLOON_SETTLE_INITIAL_TIMEOUT).await;
     tokio::time::resume();
     let outcome = wait.await;
     drop(guard);
@@ -5365,7 +5366,8 @@ async fn wait_for_balloon_reusable_progressing_timeout_logs_at_info() {
     tokio::time::resume();
     wait_for_balloon_sample_count(wait.as_mut(), &captured, 2).await;
     tokio::time::pause();
-    tokio::time::advance(BALLOON_SETTLE_TIMEOUT - BALLOON_SETTLE_FAST_POLL_INTERVALS[0]).await;
+    tokio::time::advance(BALLOON_SETTLE_INITIAL_TIMEOUT - BALLOON_SETTLE_FAST_POLL_INTERVALS[0])
+        .await;
     tokio::time::resume();
     let outcome = wait.await;
     drop(guard);
@@ -5527,7 +5529,7 @@ async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
     let mut api = MockLifecycleApi::with_stats(
         std::collections::VecDeque::new(),
         std::collections::VecDeque::from([MockBalloonStatsReply::DelayedOk(
-            BALLOON_SETTLE_TIMEOUT + Duration::from_secs(1),
+            BALLOON_SETTLE_INITIAL_TIMEOUT + Duration::from_secs(1),
             MockBalloonStats::new(target_mib, target_mib),
         )]),
     );
@@ -5549,7 +5551,7 @@ async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
     );
 
     tokio::time::pause();
-    tokio::time::advance(BALLOON_SETTLE_TIMEOUT).await;
+    tokio::time::advance(BALLOON_SETTLE_INITIAL_TIMEOUT).await;
     tokio::time::resume();
     let outcome = wait.await;
     drop(guard);

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -4577,37 +4577,42 @@ where
     (output, captured.entries())
 }
 
+async fn wait_for_balloon_sample_count<F>(
+    mut future: std::pin::Pin<&mut F>,
+    captured: &CapturedEvents,
+    expected_sample_count: usize,
+) where
+    F: Future,
+{
+    loop {
+        let sample_count = captured_message_count(&captured.entries(), "waiting for balloon");
+        if sample_count == expected_sample_count {
+            return;
+        }
+        tokio::select! {
+            _ = future.as_mut() => {
+                panic!(
+                    "balloon wait completed after {sample_count} samples, expected {expected_sample_count}"
+                );
+            }
+            () = tokio::task::yield_now() => {}
+        }
+    }
+}
+
 async fn advance_balloon_wait_to_progress_grace<F>(
     mut future: std::pin::Pin<&mut F>,
     captured: &CapturedEvents,
 ) where
-    F: Future<Output = BalloonSettleResult>,
+    F: Future,
 {
-    for expected_sample_count in 1..=2 {
-        if expected_sample_count == 2 {
-            tokio::time::advance(BALLOON_SETTLE_FAST_POLL_INTERVALS[0]).await;
-            tokio::time::resume();
-        }
-        loop {
-            let sample_count = captured_message_count(&captured.entries(), "waiting for balloon");
-            if sample_count == expected_sample_count {
-                break;
-            }
-            tokio::select! {
-                outcome = future.as_mut() => {
-                    panic!(
-                        "balloon wait completed after {sample_count} samples, expected {expected_sample_count}; outcome={outcome:?}"
-                    );
-                }
-                () = tokio::task::yield_now() => {}
-            }
-        }
-        if expected_sample_count == 2 {
-            tokio::time::pause();
-        }
-    }
+    wait_for_balloon_sample_count(future.as_mut(), captured, 1).await;
+    tokio::time::advance(BALLOON_SETTLE_FAST_POLL_INTERVALS[0]).await;
+    tokio::time::resume();
+    wait_for_balloon_sample_count(future.as_mut(), captured, 2).await;
+    tokio::time::pause();
 
-    tokio::time::advance(BALLOON_SETTLE_TIMEOUT).await;
+    tokio::time::advance(BALLOON_SETTLE_TIMEOUT - BALLOON_SETTLE_FAST_POLL_INTERVALS[0]).await;
     tokio::time::resume();
     loop {
         if has_captured_event(
@@ -4618,8 +4623,39 @@ async fn advance_balloon_wait_to_progress_grace<F>(
             return;
         }
         tokio::select! {
-            outcome = future.as_mut() => {
-                panic!("balloon wait completed without progress grace; outcome={outcome:?}");
+            _ = future.as_mut() => {
+                panic!("balloon wait completed without progress grace");
+            }
+            () = tokio::task::yield_now() => {}
+        }
+    }
+}
+
+async fn advance_balloon_wait_to_next_progress_grace<F>(
+    mut future: std::pin::Pin<&mut F>,
+    captured: &CapturedEvents,
+    expected_sample_count: usize,
+    expected_grace_count: usize,
+) where
+    F: Future,
+{
+    wait_for_balloon_sample_count(future.as_mut(), captured, expected_sample_count).await;
+    tokio::time::advance(BALLOON_SETTLE_PROGRESS_GRACE).await;
+    tokio::time::resume();
+    loop {
+        let grace_count = captured_message_count(
+            &captured.entries(),
+            "balloon inflation still progressing, extending settle deadline",
+        );
+        if grace_count == expected_grace_count {
+            tokio::time::pause();
+            return;
+        }
+        tokio::select! {
+            _ = future.as_mut() => {
+                panic!(
+                    "balloon wait completed after {grace_count} grace intervals, expected {expected_grace_count}"
+                );
             }
             () = tokio::task::yield_now() => {}
         }
@@ -5027,13 +5063,16 @@ async fn wait_for_balloon_extends_deadline_for_recent_safe_progress() {
     let target_mib = 4096 - balloon::MIN_GUEST_MIB;
     let initial_stats =
         MockBalloonStats::new(target_mib, 256).with_memory(mib(3840), mib(3940), mib(3940));
-    let progressing_stats =
+    let first_progressing_stats =
+        MockBalloonStats::new(target_mib, 1200).with_memory(mib(3000), mib(3300), mib(3940));
+    let second_progressing_stats =
         MockBalloonStats::new(target_mib, 2314).with_memory(mib(2136), mib(2265), mib(3940));
     let api = MockLifecycleApi::with_stats(
         std::collections::VecDeque::new(),
         std::collections::VecDeque::from([
             MockBalloonStatsReply::Ok(initial_stats),
-            MockBalloonStatsReply::Ok(progressing_stats),
+            MockBalloonStatsReply::Ok(first_progressing_stats),
+            MockBalloonStatsReply::Ok(second_progressing_stats),
             MockBalloonStatsReply::Ok(MockBalloonStats::new(target_mib, target_mib)),
         ]),
     );
@@ -5047,6 +5086,7 @@ async fn wait_for_balloon_extends_deadline_for_recent_safe_progress() {
     tokio::pin!(wait);
 
     advance_balloon_wait_to_progress_grace(wait.as_mut(), &captured).await;
+    advance_balloon_wait_to_next_progress_grace(wait.as_mut(), &captured, 3, 2).await;
     tokio::time::resume();
     let outcome = wait.await;
     drop(guard);
@@ -5057,17 +5097,24 @@ async fn wait_for_balloon_extends_deadline_for_recent_safe_progress() {
         outcome.telemetry_outcome,
         SandboxFinalExecParkSubstageOutcome::TargetReached
     );
+    assert_eq!(
+        captured_message_count(
+            &events,
+            "balloon inflation still progressing, extending settle deadline"
+        ),
+        2
+    );
     let event = captured_event(
         &events,
         "balloon inflation still progressing, extending settle deadline",
     );
     assert_eq!(event.level, Level::INFO);
-    assert_event_field(event, "actual", "Some(2314)");
+    assert_event_field(event, "actual", "Some(1200)");
     assert_event_field(event, "target", "3072");
-    assert_event_field(event, "deficit_mib", "Some(758)");
+    assert_event_field(event, "deficit_mib", "Some(1872)");
     assert_event_field(event, "previous_actual_mib", "Some(256)");
-    assert_event_field(event, "reported_free_mib", "Some(2136)");
-    assert_event_field(event, "reported_available_mib", "Some(2265)");
+    assert_event_field(event, "reported_free_mib", "Some(3000)");
+    assert_event_field(event, "reported_available_mib", "Some(3300)");
     assert_event_field(event, "grace_ms", "5000");
     assert!(!has_captured_event(
         &events,
@@ -5076,18 +5123,21 @@ async fn wait_for_balloon_extends_deadline_for_recent_safe_progress() {
 }
 
 #[tokio::test]
-async fn wait_for_balloon_progress_grace_remains_bounded() {
+async fn wait_for_balloon_progress_extensions_stop_when_progress_stalls() {
     let target_mib = 4096 - balloon::MIN_GUEST_MIB;
     let initial_stats =
         MockBalloonStats::new(target_mib, 256).with_memory(mib(3840), mib(3940), mib(3940));
-    let progressing_stats =
+    let first_progressing_stats =
+        MockBalloonStats::new(target_mib, 1200).with_memory(mib(3000), mib(3300), mib(3940));
+    let second_progressing_stats =
         MockBalloonStats::new(target_mib, 2314).with_memory(mib(2136), mib(2265), mib(3940));
     let api = MockLifecycleApi::with_stats(
         std::collections::VecDeque::new(),
         std::collections::VecDeque::from([
             MockBalloonStatsReply::Ok(initial_stats),
-            MockBalloonStatsReply::Ok(progressing_stats.clone()),
-            MockBalloonStatsReply::Ok(progressing_stats),
+            MockBalloonStatsReply::Ok(first_progressing_stats),
+            MockBalloonStatsReply::Ok(second_progressing_stats.clone()),
+            MockBalloonStatsReply::Ok(second_progressing_stats),
         ]),
     );
     let client = ApiClient::new(api.socket_path()).unwrap();
@@ -5100,18 +5150,8 @@ async fn wait_for_balloon_progress_grace_remains_bounded() {
     tokio::pin!(wait);
 
     advance_balloon_wait_to_progress_grace(wait.as_mut(), &captured).await;
-    loop {
-        let sample_count = captured_message_count(&captured.entries(), "waiting for balloon");
-        if sample_count == 3 {
-            break;
-        }
-        tokio::select! {
-            outcome = &mut wait => {
-                panic!("balloon wait completed before the grace sample; outcome={outcome:?}");
-            }
-            () = tokio::task::yield_now() => {}
-        }
-    }
+    advance_balloon_wait_to_next_progress_grace(wait.as_mut(), &captured, 3, 2).await;
+    wait_for_balloon_sample_count(wait.as_mut(), &captured, 4).await;
     tokio::time::advance(BALLOON_SETTLE_PROGRESS_GRACE).await;
     tokio::time::resume();
     let outcome = wait.await;
@@ -5128,15 +5168,91 @@ async fn wait_for_balloon_progress_grace_remains_bounded() {
             &events,
             "balloon inflation still progressing, extending settle deadline"
         ),
-        1
+        2
     );
     let event = captured_event(
         &events,
-        "balloon inflate incomplete after 10s, pausing anyway",
+        "balloon inflate incomplete after 15s, pausing anyway",
     );
     assert_eq!(event.level, Level::WARN);
     assert_event_field(event, "actual", "Some(2314)");
     assert_event_field(event, "deficit_mib", "Some(758)");
+    assert_event_field(event, "reason", "severe_deficit");
+    assert_event_field(event, "admission_action", "reject_and_destroy");
+}
+
+#[tokio::test]
+async fn wait_for_balloon_progress_extensions_stop_at_absolute_timeout() {
+    let target_mib = 4096 - balloon::MIN_GUEST_MIB;
+    let slow_stats_entered = Arc::new(Notify::new());
+    let slow_stats_release = Arc::new(Notify::new());
+    let progressing_stats = |actual_mib| {
+        MockBalloonStats::new(target_mib, actual_mib).with_memory(mib(4096), mib(4096), mib(4096))
+    };
+    let api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([
+            MockBalloonStatsReply::Ok(progressing_stats(0)),
+            MockBalloonStatsReply::Ok(progressing_stats(100)),
+            MockBalloonStatsReply::Ok(progressing_stats(200)),
+            MockBalloonStatsReply::Ok(progressing_stats(300)),
+            MockBalloonStatsReply::Ok(progressing_stats(400)),
+            MockBalloonStatsReply::Ok(progressing_stats(500)),
+            MockBalloonStatsReply::GatedOk {
+                entered: Arc::clone(&slow_stats_entered),
+                release: Arc::clone(&slow_stats_release),
+                stats: progressing_stats(600),
+            },
+        ]),
+    );
+    let client = ApiClient::new(api.socket_path()).unwrap();
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    tokio::time::pause();
+    let wait = wait_for_balloon_with_outcome(&client, target_mib, "absolute-progress-timeout");
+    tokio::pin!(wait);
+
+    advance_balloon_wait_to_progress_grace(wait.as_mut(), &captured).await;
+    for (sample_count, grace_count) in [(3, 2), (4, 3), (5, 4), (6, 5)] {
+        advance_balloon_wait_to_next_progress_grace(
+            wait.as_mut(),
+            &captured,
+            sample_count,
+            grace_count,
+        )
+        .await;
+    }
+    tokio::select! {
+        () = slow_stats_entered.notified() => {}
+        _ = wait.as_mut() => panic!("balloon wait completed before the final bounded request"),
+    }
+    tokio::time::advance(BALLOON_SETTLE_PROGRESS_GRACE).await;
+    tokio::time::resume();
+    let outcome = wait.await;
+    slow_stats_release.notify_waiters();
+    drop(guard);
+    let events = captured.entries();
+
+    expect_severe_memory_retention(outcome.park_outcome);
+    assert_eq!(
+        outcome.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::Deadline
+    );
+    assert_eq!(
+        captured_message_count(
+            &events,
+            "balloon inflation still progressing, extending settle deadline"
+        ),
+        5
+    );
+    let event = captured_event(
+        &events,
+        "balloon inflate incomplete after 30s, pausing anyway",
+    );
+    assert_eq!(event.level, Level::WARN);
+    assert_event_field(event, "actual", "Some(500)");
     assert_event_field(event, "reason", "severe_deficit");
     assert_event_field(event, "admission_action", "reject_and_destroy");
 }
@@ -5222,6 +5338,52 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
     assert_event_field(event, "max_actual_mib", "Some(800)");
     assert_event_field(event, "actual_delta_mib", "Some(0)");
     assert_event_field(event, "reason", "actual_stalled");
+    assert_event_field(event, "admission_action", "reuse");
+}
+
+#[tokio::test]
+async fn wait_for_balloon_reusable_progressing_timeout_logs_at_info() {
+    let target_mib = 2048 - balloon::MIN_GUEST_MIB;
+    let api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([
+            MockBalloonStatsReply::Ok(MockBalloonStats::new(target_mib, 700)),
+            MockBalloonStatsReply::Ok(MockBalloonStats::new(target_mib, 800)),
+        ]),
+    );
+    let client = ApiClient::new(api.socket_path()).unwrap();
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    tokio::time::pause();
+    let wait = wait_for_balloon_with_outcome(&client, target_mib, "reusable-progress-timeout");
+    tokio::pin!(wait);
+
+    wait_for_balloon_sample_count(wait.as_mut(), &captured, 1).await;
+    tokio::time::advance(BALLOON_SETTLE_FAST_POLL_INTERVALS[0]).await;
+    tokio::time::resume();
+    wait_for_balloon_sample_count(wait.as_mut(), &captured, 2).await;
+    tokio::time::pause();
+    tokio::time::advance(BALLOON_SETTLE_TIMEOUT - BALLOON_SETTLE_FAST_POLL_INTERVALS[0]).await;
+    tokio::time::resume();
+    let outcome = wait.await;
+    drop(guard);
+    let events = captured.entries();
+
+    assert_eq!(outcome.park_outcome, SandboxParkOutcome::Reusable);
+    assert_eq!(
+        outcome.telemetry_outcome,
+        SandboxFinalExecParkSubstageOutcome::Deadline
+    );
+    let event = captured_event(
+        &events,
+        "balloon inflate incomplete after 5s, pausing anyway",
+    );
+    assert_eq!(event.level, Level::INFO);
+    assert_event_field(event, "actual", "Some(800)");
+    assert_event_field(event, "deficit_mib", "Some(224)");
+    assert_event_field(event, "reason", "actual_progressing_timeout");
     assert_event_field(event, "admission_action", "reuse");
 }
 
@@ -5640,6 +5802,69 @@ async fn exact_handoff_interrupts_in_flight_balloon_settle() {
     );
     assert_eq!(patches[0].path, "/balloon");
     assert_eq!(patches[1].path, "/vm");
+}
+
+#[tokio::test]
+async fn exact_handoff_interrupts_balloon_settle_after_multiple_progress_extensions() {
+    let target_mib = 4096 - balloon::MIN_GUEST_MIB;
+    let stats_entered = Arc::new(Notify::new());
+    let stats_release = Arc::new(Notify::new());
+    let initial_stats =
+        MockBalloonStats::new(target_mib, 256).with_memory(mib(3840), mib(3940), mib(3940));
+    let first_progressing_stats =
+        MockBalloonStats::new(target_mib, 1200).with_memory(mib(3000), mib(3300), mib(3940));
+    let second_progressing_stats =
+        MockBalloonStats::new(target_mib, 2314).with_memory(mib(2136), mib(2265), mib(3940));
+    let api = MockLifecycleApi::with_stats(
+        std::collections::VecDeque::new(),
+        std::collections::VecDeque::from([
+            MockBalloonStatsReply::Ok(initial_stats),
+            MockBalloonStatsReply::Ok(first_progressing_stats),
+            MockBalloonStatsReply::Ok(second_progressing_stats),
+            MockBalloonStatsReply::GatedOk {
+                entered: Arc::clone(&stats_entered),
+                release: Arc::clone(&stats_release),
+                stats: MockBalloonStats::new(target_mib, target_mib),
+            },
+        ]),
+    );
+    let client = ApiClient::new(api.socket_path()).unwrap();
+    let handoff = SandboxFinalExecParkHandoff::new();
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    tokio::time::pause();
+    let wait = wait_for_balloon_with_optional_handoff(
+        &client,
+        target_mib,
+        "handoff-after-progress-extensions",
+        Some(&handoff),
+    );
+    tokio::pin!(wait);
+
+    advance_balloon_wait_to_progress_grace(wait.as_mut(), &captured).await;
+    advance_balloon_wait_to_next_progress_grace(wait.as_mut(), &captured, 3, 2).await;
+    tokio::select! {
+        () = stats_entered.notified() => {}
+        _ = wait.as_mut() => panic!("balloon wait completed before handoff was requested"),
+    }
+    assert!(handoff.request());
+    tokio::time::resume();
+    let outcome = tokio::time::timeout(Duration::from_secs(1), wait)
+        .await
+        .expect("handoff should wake the extended balloon request");
+    stats_release.notify_waiters();
+    drop(guard);
+
+    assert!(matches!(outcome, BalloonSettleWaitResult::Handoff));
+    assert_eq!(
+        captured_message_count(
+            &captured.entries(),
+            "balloon inflation still progressing, extending settle deadline"
+        ),
+        2
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- extend Firecracker balloon settling in repeated five-second windows while current target, progress, and guest memory evidence remains safe
- cap total settling at 30 seconds and keep every statistics request and exact-successor handoff bounded by the active deadline
- log reusable progressing timeouts at INFO while preserving WARN diagnostics for stalled, unavailable, target-mismatch, and non-reusable outcomes
- cover multi-window success, progress loss, the absolute deadline with a blocked statistics request, logging severity, and handoff after multiple extensions

## Exclusions

- no change to balloon targets, tolerance, pressure thresholds, severe-retention thresholds, or Runner destroy behavior
- no API, queue, database, persisted-state, or Runner/Guest protocol change
- no throughput-based deadline prediction or real-metal CI scenario change

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p sandbox-fc --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local -p sandbox-fc --all-features --no-deps`
- `cargo test --profile local -p sandbox-fc --all-targets --all-features`
- `cargo xtask check-rust-path-attributes`
- repository pre-commit Rust formatting, workspace documentation, Clippy, and file-size checks

Closes #32113
