### PR TITLE
fix(pi): prompt intermediate progress updates

### DIFF
--- a/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
@@ -32,6 +32,14 @@ const EMPTY_RESOURCE_SNAPSHOT = {
   skills: [],
 };
 
+const INTERMEDIATE_COMMENTARY_PROMPT = `## Intermediate commentary
+
+As you work, provide brief intermediate text messages to the user. These messages are how you collaborate with the user while working - stating assumptions and sharing updates. Keep them concise and easy to scan. Their purpose is to make your work easy for the user to understand and verify.
+
+If the user's request requires calling tools, start with a brief intermediate message before the first tool call. During longer work, provide additional updates at meaningful points.
+
+Do not put a final response, such as a blocking or clarifying question, in an intermediate message. Intermediate messages are only for partial updates, partial results, or non-blocking context that can provide value while you continue working. An intermediate update does not end the task; continue working when more work remains. The final answer must always be fully self-contained.`;
+
 const MEMORY_TOOL_SCHEMAS = [
   {
     name: "memories_list",
@@ -433,6 +441,49 @@ async function startResponsesProvider(
 }
 
 describe("official Pi AgentSession runtime", () => {
+  it.each(["api-first", "sandbox"] as const)(
+    "appends intermediate commentary guidance in %s sessions",
+    async (mode) => {
+      const root = await mkdtemp(join(tmpdir(), "pi-commentary-prompt-"));
+      onTestFinished(async () => {
+        await rm(root, { recursive: true });
+      });
+      const callerPrompt = "Caller instructions stay authoritative.";
+      const discoveredPrompt = "Discovered Sandbox instructions remain loaded.";
+      if (mode === "sandbox") {
+        await writeFile(join(root, "APPEND_SYSTEM.md"), discoveredPrompt);
+      }
+      const appendedPrompt =
+        mode === "api-first" ? callerPrompt : discoveredPrompt;
+      const created = await createPiAgentSessionForRuntime({
+        cwd: join(root, "workspace"),
+        agentDir: root,
+        sessionManager: SessionManager.inMemory(join(root, "workspace"), {
+          id: randomUUID(),
+        }),
+        model: TERRA_MODEL,
+        appendSystemPrompt: mode === "api-first" ? callerPrompt : null,
+        resourceSnapshot:
+          mode === "api-first" ? EMPTY_RESOURCE_SNAPSHOT : undefined,
+      });
+
+      try {
+        expect(created.session.systemPrompt).toContain(
+          INTERMEDIATE_COMMENTARY_PROMPT,
+        );
+        expect(
+          created.session.systemPrompt.match(/## Intermediate commentary/gu),
+        ).toHaveLength(1);
+        expect(
+          created.session.systemPrompt.indexOf(INTERMEDIATE_COMMENTARY_PROMPT),
+        ).toBeLessThan(created.session.systemPrompt.indexOf(appendedPrompt));
+        expect(created.session.systemPrompt).toContain(appendedPrompt);
+      } finally {
+        created.session.dispose();
+      }
+    },
+  );
+
   it.each([
     {
       name: "standard subscription",

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.ts
@@ -28,6 +28,14 @@ import { piAgentStreamForConfig, resolvePiAgentModel } from "./model";
 import { piPreheatedResourceLoaderOptions } from "./resources";
 import type { PiAgentModelConfig } from "./types";
 
+const PI_INTERMEDIATE_COMMENTARY_PROMPT = `## Intermediate commentary
+
+As you work, provide brief intermediate text messages to the user. These messages are how you collaborate with the user while working - stating assumptions and sharing updates. Keep them concise and easy to scan. Their purpose is to make your work easy for the user to understand and verify.
+
+If the user's request requires calling tools, start with a brief intermediate message before the first tool call. During longer work, provide additional updates at meaningful points.
+
+Do not put a final response, such as a blocking or clarifying question, in an intermediate message. Intermediate messages are only for partial updates, partial results, or non-blocking context that can provide value while you continue working. An intermediate update does not end the task; continue working when more work remains. The final answer must always be fully self-contained.`;
+
 function initializePiSessionResourceRegistry(): void {
   // Vite's SSR bundle otherwise keeps Pi's registry behind only the lazy
   // Codex adapter initializer, while AgentSession.dispose() remains eager.
@@ -138,9 +146,18 @@ export async function createPiAgentSessionForRuntime(args: {
         })
       : [];
   const appendSystemPrompt = [
+    PI_INTERMEDIATE_COMMENTARY_PROMPT,
     ...(args.appendSystemPrompt === null ? [] : [args.appendSystemPrompt]),
     ...(memoryRecall.block === null ? [] : [memoryRecall.block]),
   ];
+  const sandboxResourceLoaderOptions =
+    args.appendSystemPrompt === null && memoryRecall.block === null
+      ? {
+          appendSystemPromptOverride(base: string[]) {
+            return [PI_INTERMEDIATE_COMMENTARY_PROMPT, ...base];
+          },
+        }
+      : { appendSystemPrompt };
   const model = resolvePiAgentModel(args.model);
   if (!model) {
     throw new Error(
@@ -177,9 +194,7 @@ export async function createPiAgentSessionForRuntime(args: {
           snapshot: args.resourceSnapshot,
           appendSystemPrompt,
         })
-      : appendSystemPrompt.length === 0
-        ? undefined
-        : { appendSystemPrompt },
+      : sandboxResourceLoaderOptions,
   });
   const created = await createAgentSessionFromServices({
     services,


### PR DESCRIPTION
## Summary

- add Codex-aligned intermediate commentary guidance to every Pi runtime session
- preserve caller prompts, memory ordering, and Sandbox APPEND_SYSTEM.md discovery
- keep the existing assistant text event and persistence behavior unchanged

## Verification

- pnpm -F @okouai/pi-agent-runtime exec vitest run src/session-runtime.test.ts --maxWorkers=4 --silent=passed-only
- pnpm -F @okouai/pi-agent-runtime lint
- pnpm -F @okouai/pi-agent-runtime check-types
- pnpm -F @okouai/pi-agent-runtime build
- pnpm knip --workspace @okouai/pi-agent-runtime

## Scope

This is a best-effort model-authored commentary improvement toward #32174. It does not add deterministic product-owned progress and does not close the broader issue.

Refs #32174