### PR TITLE
ci(presentation): mint template-artifact tokens with the ci app

### DIFF
--- a/.github/scripts/tests/normalize-github-app-private-key-test.sh
+++ b/.github/scripts/tests/normalize-github-app-private-key-test.sh
@@ -44,7 +44,7 @@ if printf '%s' '-----BEGIN PRIVATE KEY----- invalid -----END PRIVATE KEY-----' |
 fi
 
 rg --quiet --fixed-strings \
-  'SOURCE_PRIVATE_KEY_PEM: ${{ secrets.OKOU_GITHUB_APP_PRIVATE_KEY }}' \
+  'SOURCE_PRIVATE_KEY_PEM: ${{ secrets.OKOU_CI_APP_PRIVATE_KEY }}' \
   "$workflow" || fail "workflow must read the canonical PEM private key secret"
 rg --quiet --fixed-strings \
   'bash .github/scripts/normalize-github-app-private-key.sh' \
@@ -54,7 +54,7 @@ rg --quiet --fixed-strings \
   "$workflow" || fail "token action must consume the normalized private key"
 
 if rg --quiet --fixed-strings \
-  'private-key: ${{ secrets.OKOU_GITHUB_APP_PRIVATE_KEY }}' \
+  'private-key: ${{ secrets.OKOU_CI_APP_PRIVATE_KEY }}' \
   "$workflow"; then
   fail "token action must not receive the secret directly"
 fi

--- a/.github/workflows/publish-presentation-template-archives.yml
+++ b/.github/workflows/publish-presentation-template-archives.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Normalize GitHub App private key
         id: source-private-key
         env:
-          SOURCE_PRIVATE_KEY_PEM: ${{ secrets.OKOU_GITHUB_APP_PRIVATE_KEY }}
+          SOURCE_PRIVATE_KEY_PEM: ${{ secrets.OKOU_CI_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           private_key="$(
@@ -50,7 +50,7 @@ jobs:
         id: source-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.OKOU_GITHUB_APP_ID }}
+          app-id: ${{ vars.OKOU_CI_APP_ID }}
           private-key: ${{ steps.source-private-key.outputs.private-key }}
           owner: vm0-ai
           repositories: Template-artifact


### PR DESCRIPTION
## Summary

- Mint the cross-repository `Template-artifact` read token with the dedicated
  `okou-ci` App (`vars.OKOU_CI_APP_ID`, `secrets.OKOU_CI_APP_PRIVATE_KEY`)
  instead of the preview/development product App.
- Keep the existing owner/repository allowlist, `permission-contents: read`, and
  the private-key normalization step unchanged.

## Why

`Publish Presentation Template Archives` failed on all 5 runs at `Create read
token for Template-artifact` with `Not Found` on
`GET /repos/{owner}/{repo}/installation`. The App authenticated but had no
installation on `vm0-ai/Template-artifact`. The most recent failure ran after
#32043 merged, so private-key normalization was already in place and was not the
cause.

`OKOU_GITHUB_APP_*` at repository scope is the preview/development product App
that `web-api-env` injects into every PR preview and dev API deployment. CI was
borrowing its private key, which can mint tokens for every repository that App is
installed on. `okou-ci` is installed only on `vm0-ai/Template-artifact` with
`Contents: Read-only`, so the credential reaching CI now matches what the job
actually needs.

`OKOU_GITHUB_APP_*` stays in place and is untouched: `web-api-env` still needs it
for preview and development deployments.

## Configuration

- App `okou-ci`, App ID `4856629`, org-owned, installable only on `vm0-ai`.
- Installation scope: `vm0-ai/Template-artifact` only.
- Permissions: `Contents: Read-only` plus the mandatory `Metadata: Read-only`.
  Webhook disabled.
- Repository-scope `OKOU_CI_APP_ID` created `2026-09-07T04:16:32Z`;
  repository-scope secret `OKOU_CI_APP_PRIVATE_KEY` updated `2026-09-07T04:24:45Z`.
  Both verified present by name and scope; no secret value was read.

## Verification

- `actionlint` 1.7.12 passes on the changed workflow.
- `prettier@3.8.1 --check` passes on the changed workflow.
- The diff is limited to the two credential references; no job, permission,
  allowlist, step, or publication behaviour changes.
- End-to-end verification runs after merge: dispatch the workflow from `main`.
  Republishing the already-published `b4b701a` content is safe because
  `database.mjs` short-circuits on `alreadyCurrent` when the storage HEAD already
  equals the computed version id, so the run exercises the new credential without
  repointing anything.

No local Vitest suite or dev server was run, per repository policy.
