### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1854,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3736,9 +3736,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+checksum = "af5546be8f5378d5414f83733f5c9a2526f4645829edbc1c41790aeef1b38e8b"
 dependencies = [
  "base64 0.23.1",
  "flate2",
@@ -3754,9 +3754,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
 dependencies = [
  "base64 0.23.1",
  "http 1.5.0",


### PR DESCRIPTION
## Summary

- Refresh the Rust lockfile with the latest compatible dependency versions.
- Update `ipnet` from 2.12.1 to 2.12.2.
- Update `ureq` from 3.4.0 to 3.4.1.
- Update `ureq-proto` from 0.6.1 to 0.6.2.

## Deferred updates

- `generic-array` remains at 0.14.7 because `crypto-common` 0.1.7 requires that exact version through the `digest` dependency chain.
- `zstd` remains at 0.13.3 because `guest-agent` requires `^0.13`; 0.14 is a semver-major update outside the declared range.

## Manual manifest changes

None.

## Validation

- Passed: `cargo +stable test --locked --workspace --exclude runner --profile local` with the updated dependency set.
- Passed on the final `main` base: `cargo +stable test --locked --profile local -p guest-download` (90 library tests, 9 binary tests, 77 integration tests, and doctests).
- Passed on the final `main` base: `cargo +stable check --locked --profile local -p runner --tests`.

The full `runner` test binary cannot be linked reliably in the local 3.8 GiB no-swap environment, so all non-`runner` tests were executed and every `runner` test target was compiled. During a combined-cache rerun, the 16 GiB workspace volume reached 100% usage and `ld` received `SIGBUS` before tests ran; rerunning the final validations with isolated clean caches passed.
