### PR TITLE
test(api): isolate mutable connector catalog fixture

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -2142,6 +2142,12 @@ describe("CHAT-02: thread connector account selection", () => {
   });
 
   it("starts the run when the runtime catalog no longer contains the selected built-in", async () => {
+    // Catalog rows are global by source, so isolate mutations from parallel test files.
+    mockEnv(
+      "R2_USER_STORAGES_BUCKET_NAME",
+      `test-chat-retired-catalog-connector-${randomUUID()}`,
+    );
+    await installApiTestConnectorCatalog({ runtimeProjection: true });
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const orgId = actor.orgId;
     if (!orgId) {
@@ -2188,9 +2194,6 @@ describe("CHAT-02: thread connector account selection", () => {
       [200],
     );
 
-    onTestFinished(async () => {
-      await installApiTestConnectorCatalog();
-    });
     const catalogVersion = `api-test-without-openai-${randomUUID()}`;
     const catalogWithoutOpenAi = {
       ...API_TEST_CONNECTOR_CATALOG,


### PR DESCRIPTION
## Summary

- isolate the retired built-in connector chat test behind a unique connector catalog source
- install the runtime projection explicitly so the test has no ordering dependency
- remove the redundant shared-catalog teardown restore

## Root cause

The failure in [test-api (6)](https://github.com/vm0-ai/vm0/actions/runs/34079890595/job/101613099778) is a test-isolation race. Parallel API test workers install their connector catalog fixtures against the same source ID. This test reads that source's active catalog identity before updating its compatibility row; if another worker reinstalls the default catalog in between, the old compatibility row is deleted and the guarded update affects zero rows.

Giving this mutating scenario its own source keeps other workers from replacing its persisted catalog rows. Installing the runtime projection explicitly also makes the scenario independent of earlier tests in the file.

## Validation

- `pnpm vitest run --project=api apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'starts the run when the runtime catalog no longer contains the selected built-in' --reporter=dot` (5 consecutive passes)
- `pnpm vitest run --project=api --shard=6/8 --coverage.enabled --coverage.reporter=json` (29 files, 766 tests passed)
- targeted Prettier, Oxlint, and ESLint checks for the changed file
