### PR TITLE
fix(auth): reset add-account sign-in when reopening dialog

### DIFF
--- a/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
+++ b/turbo/apps/platform/src/signals/auth-v2/sign-in-flow.ts
@@ -951,6 +951,7 @@ function createResourceCommands(
   atoms: SignInFlowAtoms,
   runtime: SignInFlowRuntime,
   startCooldown$: Command<void, [string, AbortSignal]>,
+  restart$: Command<void, []>,
   dependencies: AuthV2SignInFlowDependencies,
 ): {
   readonly applyResource$: ApplySignInResourceCommand;
@@ -1054,6 +1055,11 @@ function createResourceCommands(
 
       signal.throwIfAborted();
       set(atoms.accounts$, discoverAuthV2ExistingAccounts(clerk));
+      if (get(atoms.useAnotherAccount$)) {
+        // Add-account opens a fresh flow even if Clerk retains an earlier attempt.
+        set(restart$);
+        return;
+      }
       await set(applyResource$, clerk.client.signIn, signal);
       signal.throwIfAborted();
     },
@@ -1826,6 +1832,7 @@ export function createAuthV2SignInSignals(
 ): AuthV2SignInSignals {
   const atoms = createSignInFlowAtoms();
   const runtime = createSignInFlowRuntime();
+  const formCommands = createFormCommands(atoms, runtime);
   const startCooldown$ = createStartCooldownCommand(
     signInResendCooldown,
     atoms,
@@ -1835,6 +1842,7 @@ export function createAuthV2SignInSignals(
     atoms,
     runtime,
     startCooldown$,
+    formCommands.restart$,
     dependencies,
   );
   const submitOperation$ = createSubmitOperation$(
@@ -1853,7 +1861,6 @@ export function createAuthV2SignInSignals(
     applyResource$,
     startCooldown$,
   );
-  const formCommands = createFormCommands(atoms, runtime);
   const runGoogleOneTap$ = createGoogleOneTapCommand(
     atoms,
     runtime,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -21,6 +21,7 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import {
   click,
+  fill,
   queryAllByRoleFast,
   setupPage,
 } from "../../../__tests__/page-helper.ts";
@@ -1312,6 +1313,81 @@ test("Open Add account without leaving the current page", async () => {
   expect(window.location.href).toBe(originalUrl);
 });
 
+test.each(["Password", "Verification code"])(
+  "Reset Add account after closing the %s step",
+  async (step) => {
+    mockedClerk.clientSignInCreate.mockImplementation((params) => {
+      mockSignInResource({
+        identifier: params.identifier,
+        status: "needs_first_factor",
+        supportedFirstFactors: [{ strategy: "password" }],
+      });
+      return Promise.resolve(mockedClerk.client.signIn);
+    });
+    mockedClerk.signInAttemptFirstFactor.mockImplementation(() => {
+      mockSignInResource({
+        identifier: "second.account@example.test",
+        secondFactorVerificationStatus: "unverified",
+        secondFactorVerificationStrategy: "email_code",
+        status: "needs_client_trust",
+        supportedSecondFactors: [
+          {
+            emailAddressId: "email_second",
+            safeIdentifier: "s***@example.test",
+            strategy: "email_code",
+          },
+        ],
+      });
+      return Promise.resolve(mockedClerk.client.signIn);
+    });
+
+    await setupAddAccountPage();
+    const originalUrl = window.location.href;
+    const dialog = await openAuthV2AddAccountDialog();
+    const identifier = await within(dialog).findByLabelText("Email address");
+    await fill(identifier, "second.account@example.test");
+    fireEvent.submit(containingForm(identifier));
+
+    const password = await within(dialog).findByLabelText("Password");
+    await fill(password, "correct-password");
+    if (step === "Verification code") {
+      fireEvent.submit(containingForm(password));
+      const code = await within(dialog).findByLabelText("Verification code");
+      await fill(code, "12");
+      await userEvent.keyboard("{Escape}");
+    } else {
+      click(buttonByLabel("Close", dialog));
+    }
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("auth-v2-add-account-dialog"),
+      ).not.toBeInTheDocument();
+    });
+
+    const reopenedDialog = await openAuthV2AddAccountDialog();
+    const freshIdentifier =
+      await within(reopenedDialog).findByLabelText("Email address");
+    expect(freshIdentifier).toHaveValue("");
+    expect(
+      within(reopenedDialog).queryByLabelText("Password"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(reopenedDialog).queryByLabelText("Verification code"),
+    ).not.toBeInTheDocument();
+    expect(mockedClerk.setActive).not.toHaveBeenCalled();
+    expect(window.location.href).toBe(originalUrl);
+
+    await fill(freshIdentifier, "third.account@example.test");
+    fireEvent.submit(containingForm(freshIdentifier));
+    const freshPassword =
+      await within(reopenedDialog).findByLabelText("Password");
+    expect(freshPassword).toHaveValue("");
+    expect(mockedClerk.clientSignInCreate).toHaveBeenLastCalledWith({
+      identifier: "third.account@example.test",
+    });
+  },
+);
+
 test("Continue or restart organization selection while adding an account", async () => {
   await setupAddAccountPage();
   const originalUrl = window.location.href;
@@ -1431,6 +1507,13 @@ test("Cancel an unfinished Add account sign-in", async () => {
     attempt.resolve(mockedClerk.client.signIn);
     await attempt.promise;
   });
+  expect(mockedClerk.setActive).not.toHaveBeenCalled();
+  expect(window.location.href).toBe(originalUrl);
+
+  const reopenedDialog = await openAuthV2AddAccountDialog();
+  const identifierAfterClose =
+    await within(reopenedDialog).findByLabelText("Email address");
+  expect(identifierAfterClose).toHaveValue("");
   expect(mockedClerk.setActive).not.toHaveBeenCalled();
   expect(window.location.href).toBe(originalUrl);
 });


### PR DESCRIPTION
Closing Add account during password or email verification now reopens an empty email form. Initialization honors the existing use-another-account intent and reuses the restart command before applying Clerk's retained sign-in resource, so cancelled attempts cannot resume or activate a completed session on the next open.

Regression coverage exercises the close button, Escape, starting a different account after reopening, and a request that completes after dismissal. Standalone sign-in and OAuth recovery retain their existing behavior.

## Verification

- 76 tests passed across the account menu, sign-in card, authentication recovery, and OAuth page test files.
- All three targeted reopen/cancellation cases fail when the initialization fix is removed and pass with it restored.
- Formatting, scoped Oxlint (including type-aware checks), ESLint, platform TypeScript checks, and platform Knip passed.
- No full local Vitest suite or local dev server was run. Browser verification was not performed; PR CI provides the remaining checks.
