### PR TITLE
feat(platform): find agents by name in workspace search

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/agents.json
@@ -618,8 +618,9 @@
     "resultCount_other": "{{count}} Ergebnisse",
     "searchAgents": "Suchagenten...",
     "searching": "Suche...",
-    "searchWorkspace": "Chats, Nachrichten, Workflows und Artefakte durchsuchen...",
+    "searchWorkspace": "Arbeitsbereich durchsuchen...",
     "sections": {
+      "agents": "Agenten",
       "artifacts": "Artefakte",
       "chats": "Chats",
       "messages": "Nachrichten",

--- a/turbo/apps/platform/src/i18n/locales/en-US/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/agents.json
@@ -618,8 +618,9 @@
     "resultCount_other": "{{count}} results",
     "searchAgents": "Search agents...",
     "searching": "Searching...",
-    "searchWorkspace": "Search chats, messages, workflows, and artifacts...",
+    "searchWorkspace": "Search workspace...",
     "sections": {
+      "agents": "Agents",
       "artifacts": "Artifacts",
       "chats": "Chats",
       "messages": "Messages",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/agents.json
@@ -619,8 +619,9 @@
     "resultCount_other": "{{count}} resultados",
     "searchAgents": "Buscar agentes...",
     "searching": "Buscando...",
-    "searchWorkspace": "Buscar chats, mensajes, flujos de trabajo y artefactos...",
+    "searchWorkspace": "Buscar en el espacio de trabajo...",
     "sections": {
+      "agents": "Agentes",
       "artifacts": "Artefactos",
       "chats": "Conversaciones",
       "messages": "Mensajes",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/agents.json
@@ -619,8 +619,9 @@
     "resultCount_other": "{{count}} résultats",
     "searchAgents": "Rechercher des agents...",
     "searching": "Recherche...",
-    "searchWorkspace": "Rechercher des chats, messages, workflows et artefacts...",
+    "searchWorkspace": "Rechercher dans l’espace de travail...",
     "sections": {
+      "agents": "Agents",
       "artifacts": "Artefacts",
       "chats": "Chats",
       "messages": "Messages",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/agents.json
@@ -618,8 +618,9 @@
     "resultCount_other": "{{count}} परिणाम",
     "searchAgents": "खोज एजेंट...",
     "searching": "खोज जारी है...",
-    "searchWorkspace": "चैट, संदेश, वर्कफ़्लो और आर्टिफ़ैक्ट खोजें...",
+    "searchWorkspace": "वर्कस्पेस में खोजें...",
     "sections": {
+      "agents": "एजेंट",
       "artifacts": "आर्टिफ़ैक्ट्स",
       "chats": "चैट",
       "messages": "संदेश",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/agents.json
@@ -617,8 +617,9 @@
     "resultCount_other": "{{count}} hasil",
     "searchAgents": "Cari agen...",
     "searching": "Mencari...",
-    "searchWorkspace": "Cari chat, pesan, alur kerja, dan artefak...",
+    "searchWorkspace": "Cari di ruang kerja...",
     "sections": {
+      "agents": "Agen",
       "artifacts": "Artefak",
       "chats": "Chat",
       "messages": "Pesan",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/agents.json
@@ -619,8 +619,9 @@
     "resultCount_other": "{{count}} risultati",
     "searchAgents": "Cerca agenti...",
     "searching": "Ricerca in corso...",
-    "searchWorkspace": "Cerca chat, messaggi, flussi di lavoro e artefatti...",
+    "searchWorkspace": "Cerca nello spazio di lavoro...",
     "sections": {
+      "agents": "Agenti",
       "artifacts": "Artefatti",
       "chats": "Chat",
       "messages": "Messaggi",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/agents.json
@@ -617,8 +617,9 @@
     "resultCount_other": "{{count}} 件の結果",
     "searchAgents": "エージェントを検索...",
     "searching": "検索中...",
-    "searchWorkspace": "チャット、メッセージ、ワークフロー、アーティファクトを検索...",
+    "searchWorkspace": "ワークスペースを検索...",
     "sections": {
+      "agents": "エージェント",
       "artifacts": "アーティファクト",
       "chats": "チャット",
       "messages": "メッセージ",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/agents.json
@@ -617,8 +617,9 @@
     "resultCount_other": "결과 {{count}}개",
     "searchAgents": "에이전트 검색...",
     "searching": "검색 중...",
-    "searchWorkspace": "채팅, 메시지, 워크플로, 아티팩트 검색...",
+    "searchWorkspace": "워크스페이스 검색...",
     "sections": {
+      "agents": "에이전트",
       "artifacts": "아티팩트",
       "chats": "채팅",
       "messages": "메시지",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/agents.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/agents.json
@@ -619,8 +619,9 @@
     "resultCount_other": "{{count}} resultados",
     "searchAgents": "Buscar agentes...",
     "searching": "Pesquisando...",
-    "searchWorkspace": "Buscar chats, mensagens, fluxos de trabalho e artefatos...",
+    "searchWorkspace": "Pesquisar no espaço de trabalho...",
     "sections": {
+      "agents": "Agentes",
       "artifacts": "Artefatos",
       "chats": "Conversas",
       "messages": "Mensagens",

--- a/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
@@ -152,6 +152,7 @@ export type ThreeColumnSearchFilter =
   | "all"
   | "chats"
   | "messages"
+  | "agents"
   | "workflows"
   | "artifacts";
 

--- a/turbo/apps/platform/src/signals/okou-page/three-column-search-resources.ts
+++ b/turbo/apps/platform/src/signals/okou-page/three-column-search-resources.ts
@@ -1,4 +1,6 @@
 import { computed } from "ccstate";
+import type { AgentResponse } from "@okouai/api-contracts/contracts/agents";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   artifactCatalogContract,
   type ArtifactSummary,
@@ -6,7 +8,9 @@ import {
 import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows";
 
 import { accept } from "../../lib/accept.ts";
+import { agents$ } from "../agent.ts";
 import { apiClient$ } from "../api-client.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import {
   createImageLoadSignals,
   type ImageLoadSignals,
@@ -15,6 +19,33 @@ import { allVisibleWorkflows$ } from "../workflows-page/workflows-signals.ts";
 import { chatListQuery$ } from "./sidebar-state.ts";
 
 const MAX_RESOURCE_SEARCH_RESULTS = 25;
+
+interface ThreeColumnAgentSearchResult {
+  readonly query: string;
+  readonly agents: readonly AgentResponse[];
+}
+
+export const workspaceAgentSearchEnabled$ = computed((get) => {
+  return get(featureSwitch$)[FeatureSwitchKey.WorkspaceAgentSearch];
+});
+
+export const threeColumnAgentSearchResults$ = computed(
+  async (get): Promise<ThreeColumnAgentSearchResult> => {
+    const query = get(chatListQuery$).trim().toLowerCase();
+    if (!get(workspaceAgentSearchEnabled$) || !query) {
+      return { query, agents: [] };
+    }
+    const agents = await get(agents$);
+    return {
+      query,
+      agents: agents
+        .filter((agent) => {
+          return agent.displayName?.toLowerCase().includes(query) ?? false;
+        })
+        .slice(0, MAX_RESOURCE_SEARCH_RESULTS),
+    };
+  },
+);
 
 interface ThreeColumnWorkflowSearchResult {
   readonly query: string;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/keyboard-shortcut-hints.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/keyboard-shortcut-hints.test.tsx
@@ -17,7 +17,7 @@ const context = testContext();
 const featureSwitches = {
   [FeatureSwitchKey.StableChatThreadNavigation]: true,
 } as const;
-const SEARCH_LABEL = "Search chats, messages, workflows, and artifacts...";
+const SEARCH_LABEL = "Search workspace...";
 
 const platforms = [
   {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
@@ -8,6 +8,10 @@ import {
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { artifactCatalogContract } from "@okouai/api-contracts/contracts/artifact-catalog";
 import {
+  agentsByIdContract,
+  agentsMainContract,
+} from "@okouai/api-contracts/contracts/agents";
+import {
   workflowsCollectionContract,
   workflowsDetailContract,
   type WorkflowSummary,
@@ -36,7 +40,7 @@ const context = testContext();
 const featureSwitches = {
   [FeatureSwitchKey.StableChatThreadNavigation]: true,
 } as const;
-const SEARCH_LABEL = "Search chats, messages, workflows, and artifacts...";
+const SEARCH_LABEL = "Search workspace...";
 
 async function openSearch(modifiers = { ctrlKey: true, metaKey: false }) {
   fireEvent.keyDown(document.body, {
@@ -67,6 +71,32 @@ function searchResultTitles(dialog: HTMLElement): string[] {
 }
 
 function installSearchResources() {
+  const agent = {
+    agentId: "c7000000-0000-4000-a000-000000000002",
+    displayName: "Budget agent",
+    ownerId: "test-user",
+    description: null,
+    sound: null,
+    avatarUrl: null,
+    modelProviderId: null,
+    selectedModel: null,
+    preferPersonalProvider: false,
+    visibility: "private" as const,
+  };
+  context.mocks.api(agentsMainContract.list, ({ respond }) => {
+    return respond(200, [
+      { ...agent, agentId: CHAT_LIST_AGENT_ID, displayName: "List agent" },
+      agent,
+    ]);
+  });
+  context.mocks.api(agentsByIdContract.get, ({ params, respond }) => {
+    return respond(200, {
+      ...agent,
+      agentId: params.id,
+      displayName:
+        params.id === agent.agentId ? agent.displayName : "List agent",
+    });
+  });
   const workflow: WorkflowSummary = {
     id: "f7000000-0000-4000-a000-000000000001",
     agentId: CHAT_LIST_AGENT_ID,
@@ -124,7 +154,7 @@ function installSearchResources() {
       }),
     );
   });
-  return { workflow, artifact };
+  return { agent, workflow, artifact };
 }
 
 test.each([
@@ -438,10 +468,16 @@ test("Search shortcuts preserve typing and ignore invalid combinations", async (
 test.each([
   {
     filter: "All",
-    titles: ["Budget planning", "Budget review", "Budget report"],
-    hints: ["1", "2", "3"],
-    digit: "3",
+    titles: [
+      "Budget planning",
+      "Budget agent",
+      "Budget review",
+      "Budget report",
+    ],
+    hints: ["1", "2", "3", "4"],
+    digit: "4",
   },
+  { filter: "Agents", titles: ["Budget agent"], hints: ["1"], digit: "1" },
   { filter: "Workflows", titles: ["Budget review"], hints: ["1"], digit: "1" },
 ])(
   "Open a resource from numbered search results in $filter",
@@ -456,22 +492,26 @@ test.each([
       caseId: 29,
       threads: [titleMatch],
     });
-    const { workflow, artifact } = installSearchResources();
+    const { agent, workflow, artifact } = installSearchResources();
     await setupPage({
       context,
       path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
       auth: workspace.auth,
-      featureSwitches,
+      featureSwitches: {
+        ...featureSwitches,
+        [FeatureSwitchKey.WorkspaceAgentSearch]: true,
+      },
     });
     const { dialog, search } = await openSearch();
     await fill(search, "budget");
     await waitFor(() => {
       expect(searchResultTitles(dialog)).toStrictEqual([
         "Budget planning",
+        "Budget agent",
         "Budget review",
         "Budget report",
       ]);
-      expect(numberedHints(dialog)).toStrictEqual(["1", "2", "3"]);
+      expect(numberedHints(dialog)).toStrictEqual(["1", "2", "3", "4"]);
     });
     const tab = queryAllByRoleFast("tab", dialog).find((item) => {
       return item.textContent === filter;
@@ -491,9 +531,13 @@ test.each([
       shiftKey: false,
     });
     const expectedPath =
-      filter === "Workflows" ? `/workflows/${workflow.id}` : "/artifacts";
-    const expectedArtifact = filter === "Workflows" ? null : artifact.id;
-    const expectedTab = filter === "Workflows" ? null : "file";
+      filter === "Agents"
+        ? `/agents/${agent.agentId}/chat`
+        : filter === "Workflows"
+          ? `/workflows/${workflow.id}`
+          : "/artifacts";
+    const expectedArtifact = filter === "All" ? artifact.id : null;
+    const expectedTab = filter === "All" ? "file" : null;
     await waitFor(() => {
       expect(pathname()).toBe(expectedPath);
       const searchParams = new URL(window.location.href).searchParams;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -822,11 +822,9 @@ test("Find conversations by title in workspace search", async () => {
   });
 
   const dialog = await screen.findByRole("dialog", {
-    name: "Search chats, messages, workflows, and artifacts...",
+    name: "Search workspace...",
   });
-  const search = within(dialog).getByPlaceholderText(
-    "Search chats, messages, workflows, and artifacts...",
-  );
+  const search = within(dialog).getByPlaceholderText("Search workspace...");
 
   await fill(search, "research");
 
@@ -850,7 +848,7 @@ test("Find conversations by title in workspace search", async () => {
   await waitFor(() => {
     expect(
       screen.queryByRole("dialog", {
-        name: "Search chats, messages, workflows, and artifacts...",
+        name: "Search workspace...",
       }),
     ).not.toBeInTheDocument();
     expect(document.title).toBe("Support escalation | VM0");
@@ -894,13 +892,13 @@ test("Hide and show the chat list without losing workspace search", async () => 
 
   expect(searchEvent.defaultPrevented).toBeTruthy();
   const dialog = await screen.findByRole("dialog", {
-    name: "Search chats, messages, workflows, and artifacts...",
+    name: "Search workspace...",
   });
   fireEvent.keyDown(dialog, { key: "Escape", code: "Escape" });
   await waitFor(() => {
     expect(
       screen.queryByRole("dialog", {
-        name: "Search chats, messages, workflows, and artifacts...",
+        name: "Search workspace...",
       }),
     ).not.toBeInTheDocument();
   });
@@ -1707,11 +1705,9 @@ test("Open and use workspace search with the keyboard", async () => {
   });
 
   const dialog = await screen.findByRole("dialog", {
-    name: "Search chats, messages, workflows, and artifacts...",
+    name: "Search workspace...",
   });
-  const search = within(dialog).getByPlaceholderText(
-    "Search chats, messages, workflows, and artifacts...",
-  );
+  const search = within(dialog).getByPlaceholderText("Search workspace...");
 
   await fill(search, "support");
 
@@ -1725,7 +1721,7 @@ test("Open and use workspace search with the keyboard", async () => {
   await waitFor(() => {
     expect(
       screen.queryByRole("dialog", {
-        name: "Search chats, messages, workflows, and artifacts...",
+        name: "Search workspace...",
       }),
     ).not.toBeInTheDocument();
     expect(document.title).toBe("Support escalation | VM0");
@@ -1772,7 +1768,7 @@ test("Show current shortcuts without stacking help over workspace search", async
   });
 
   const dialog = await screen.findByRole("dialog", {
-    name: "Search chats, messages, workflows, and artifacts...",
+    name: "Search workspace...",
   });
 
   fireEvent.keyDown(document.body, { key: "?", shiftKey: true });
@@ -1808,7 +1804,7 @@ test("Open workspace search once from a focused composer shortcut", async () => 
   expect(repeatedEvent.defaultPrevented).toBeFalsy();
   expect(
     screen.queryByRole("dialog", {
-      name: "Search chats, messages, workflows, and artifacts...",
+      name: "Search workspace...",
     }),
   ).not.toBeInTheDocument();
 
@@ -1824,7 +1820,7 @@ test("Open workspace search once from a focused composer shortcut", async () => 
 
   expect(event.defaultPrevented).toBeTruthy();
   const dialog = await screen.findByRole("dialog", {
-    name: "Search chats, messages, workflows, and artifacts...",
+    name: "Search workspace...",
   });
   expect(dialog).toBeInTheDocument();
 });
@@ -1851,7 +1847,7 @@ test("Open workspace search from a mobile viewport", async () => {
   });
 
   const dialog = await screen.findByRole("dialog", {
-    name: "Search chats, messages, workflows, and artifacts...",
+    name: "Search workspace...",
   });
   expect(dialog).toBeInTheDocument();
 });
@@ -2426,12 +2422,10 @@ test("Search workspace chats and messages", async () => {
   click(within(list).getByLabelText("Search workspace"));
 
   const dialog = await screen.findByRole("dialog", {
-    name: "Search chats, messages, workflows, and artifacts...",
+    name: "Search workspace...",
   });
   await fill(
-    within(dialog).getByPlaceholderText(
-      "Search chats, messages, workflows, and artifacts...",
-    ),
+    within(dialog).getByPlaceholderText("Search workspace..."),
     "deploy",
   );
 
@@ -2451,9 +2445,7 @@ test("Search workspace chats and messages", async () => {
   expect(within(dialog).getByText("Incident response")).toBeInTheDocument();
 
   await fill(
-    within(dialog).getByPlaceholderText(
-      "Search chats, messages, workflows, and artifacts...",
-    ),
+    within(dialog).getByPlaceholderText("Search workspace..."),
     "missing",
   );
   await waitFor(() => {
@@ -2462,9 +2454,7 @@ test("Search workspace chats and messages", async () => {
   });
 
   await fill(
-    within(dialog).getByPlaceholderText(
-      "Search chats, messages, workflows, and artifacts...",
-    ),
+    within(dialog).getByPlaceholderText("Search workspace..."),
     "deploy",
   );
   click(buttonByText("Chats", dialog));
@@ -2480,7 +2470,7 @@ test("Search workspace chats and messages", async () => {
     expect(pathname()).toBe(`/chats/${RESEARCH_THREAD_ID}`);
     expect(
       screen.queryByRole("dialog", {
-        name: "Search chats, messages, workflows, and artifacts...",
+        name: "Search workspace...",
       }),
     ).not.toBeInTheDocument();
   });
@@ -2587,7 +2577,7 @@ test("Show useful search-result ages and an illustrated empty state", async () =
   click(within(list).getByLabelText("Search workspace"));
 
   const dialog = await screen.findByRole("dialog", {
-    name: "Search chats, messages, workflows, and artifacts...",
+    name: "Search workspace...",
   });
 
   const rowFor = async (title: string): Promise<HTMLElement> => {
@@ -2615,9 +2605,7 @@ test("Show useful search-result ages and an illustrated empty state", async () =
   expect(archived).toHaveTextContent(/[A-Z][a-z]{2} \d{1,2},/u);
 
   await fill(
-    within(dialog).getByPlaceholderText(
-      "Search chats, messages, workflows, and artifacts...",
-    ),
+    within(dialog).getByPlaceholderText("Search workspace..."),
     "nothing matches this",
   );
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
@@ -23,7 +23,7 @@ const context = testContext();
 const featureSwitches = {
   [FeatureSwitchKey.StableChatThreadNavigation]: true,
 } as const;
-const SEARCH_LABEL = "Search chats, messages, workflows, and artifacts...";
+const SEARCH_LABEL = "Search workspace...";
 
 function hintKeys(container: ParentNode): string[] {
   return [...container.querySelectorAll("kbd")]

--- a/turbo/apps/platform/src/views/okou-page/__tests__/workspace-agent-search.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/workspace-agent-search.test.tsx
@@ -1,0 +1,183 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import {
+  agentsByIdContract,
+  type AgentResponse,
+} from "@okouai/api-contracts/contracts/agents";
+import {
+  click,
+  fill,
+  queryAllByRoleFast,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const RESEARCH_AGENT_ID = "c0000000-0000-4000-a000-000000000002";
+const SUPPORT_AGENT_ID = "c0000000-0000-4000-a000-000000000003";
+const SEARCH_LABEL = "Search workspace...";
+const MAC_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36";
+
+function prepareAgents() {
+  context.mocks.browser.userAgent(MAC_USER_AGENT);
+  const agents: AgentResponse[] = [
+    { agentId: DEFAULT_AGENT_ID, displayName: "Zero" },
+    { agentId: RESEARCH_AGENT_ID, displayName: "Research Agent" },
+    {
+      agentId: SUPPORT_AGENT_ID,
+      displayName: "Support Agent",
+      description: "Research customer questions",
+    },
+    {
+      agentId: "c0000000-0000-4000-a000-000000000004",
+      displayName: null,
+      description: "Research without a display name",
+    },
+  ].map((agent) => {
+    return {
+      ownerId: "test-user-123",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      modelProviderId: null,
+      selectedModel: null,
+      preferPersonalProvider: false,
+      visibility: "public",
+      ...agent,
+    };
+  });
+  context.mocks.data.agents(agents);
+  context.mocks.api(agentsByIdContract.get, ({ params, respond }) => {
+    const agent = agents.find((candidate) => {
+      return candidate.agentId === params.id;
+    });
+    if (!agent) {
+      throw new Error(`Unexpected agent ${params.id}`);
+    }
+    return respond(200, agent);
+  });
+}
+
+async function openSearch() {
+  await screen.findByTestId("chat-list-column");
+  fireEvent.keyDown(document.body, {
+    key: "f",
+    code: "KeyF",
+    metaKey: true,
+    shiftKey: true,
+  });
+  const dialog = await screen.findByRole("dialog", { name: SEARCH_LABEL });
+  return {
+    dialog,
+    search: within(dialog).getByPlaceholderText(SEARCH_LABEL),
+  };
+}
+
+test("Find workspace agents by name and open their chat", async () => {
+  prepareAgents();
+  await setupPage({
+    context,
+    path: `/agents/${DEFAULT_AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.WorkspaceAgentSearch]: true },
+  });
+  const { dialog, search } = await openSearch();
+
+  await fill(search, "  REseaRCH  ");
+  await expect(
+    within(dialog).findByRole("option", { name: "Research Agent" }),
+  ).resolves.toBeVisible();
+  expect(within(dialog).getByText("1 result")).toBeVisible();
+  expect(within(dialog).queryByText("Support Agent")).toBeNull();
+
+  const agentsTab = queryAllByRoleFast("tab", dialog).find((tab) => {
+    return tab.textContent === "Agents";
+  });
+  if (!agentsTab) {
+    throw new Error("Expected Agents search filter");
+  }
+  click(agentsTab);
+  expect(agentsTab).toHaveAttribute("aria-selected", "true");
+  expect(
+    within(dialog).getByRole("option", { name: "Research Agent" }),
+  ).toBeVisible();
+
+  await fill(search, RESEARCH_AGENT_ID);
+  await expect(
+    within(dialog).findByText("No results found"),
+  ).resolves.toBeVisible();
+  expect(within(dialog).getByText("0 results")).toBeVisible();
+
+  await fill(search, "zero");
+  await expect(
+    within(dialog).findByRole("option", { name: "Zero" }),
+  ).resolves.toBeVisible();
+
+  await fill(search, " ");
+  await expect(
+    within(dialog).findByText("No results found"),
+  ).resolves.toBeVisible();
+  expect(within(dialog).queryByRole("option")).toBeNull();
+
+  await fill(search, "Support");
+  const result = await within(dialog).findByRole("option", {
+    name: "Support Agent",
+  });
+  click(result);
+  await waitFor(() => {
+    expect(pathname()).toBe(`/agents/${SUPPORT_AGENT_ID}/chat`);
+  });
+  await expect(
+    screen.findByText("Chats with Support Agent"),
+  ).resolves.toBeVisible();
+  expect(screen.queryByRole("dialog", { name: SEARCH_LABEL })).toBeNull();
+});
+
+test("Keep agents out of workspace search when the feature is disabled", async () => {
+  prepareAgents();
+  await setupPage({
+    context,
+    path: `/agents/${DEFAULT_AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.WorkspaceAgentSearch]: false },
+  });
+  const { dialog, search } = await openSearch();
+
+  await fill(search, "research");
+  await expect(
+    within(dialog).findByText("No results found"),
+  ).resolves.toBeVisible();
+  expect(within(dialog).queryByRole("option")).toBeNull();
+  expect(
+    queryAllByRoleFast("tab", dialog).map((tab) => {
+      return tab.textContent;
+    }),
+  ).not.toContain("Agents");
+});
+
+test("Limit matching agents to the workspace search result size", async () => {
+  context.mocks.browser.userAgent(MAC_USER_AGENT);
+  context.mocks.data.agents([
+    { agentId: DEFAULT_AGENT_ID, displayName: "Zero" },
+    ...Array.from({ length: 30 }, (_, index) => {
+      return {
+        agentId: `c1000000-0000-4000-a000-${(index + 1).toString().padStart(12, "0")}`,
+        displayName: `Analyst ${index + 1}`,
+      };
+    }),
+  ]);
+  await setupPage({
+    context,
+    path: `/agents/${DEFAULT_AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.WorkspaceAgentSearch]: true },
+  });
+  const { dialog, search } = await openSearch();
+
+  await fill(search, "analyst");
+  await expect(within(dialog).findByText("25 results")).resolves.toBeVisible();
+  expect(within(dialog).getAllByRole("option")).toHaveLength(25);
+  expect(within(dialog).getByText("Analyst 25")).toBeVisible();
+  expect(within(dialog).queryByText("Analyst 26")).toBeNull();
+});

--- a/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
@@ -73,8 +73,10 @@ import { ThreadNumberShortcutHint } from "./thread-number-shortcut-hint.tsx";
 import { equalSets } from "../../lib/equality.ts";
 import { AgentAvatarImg } from "./sidebar-shared.tsx";
 import {
+  threeColumnAgentSearchResults$,
   threeColumnArtifactSearchResults$,
   threeColumnWorkflowSearchResults$,
+  workspaceAgentSearchEnabled$,
   type ThreeColumnArtifactSearchItem,
 } from "../../signals/okou-page/three-column-search-resources.ts";
 import { ArtifactThumbnailImage } from "./artifact-thumbnail.tsx";
@@ -608,6 +610,34 @@ const SPOTLIGHT_RESOURCE_ICON_CLASS =
   "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-50 text-muted-foreground";
 const SPOTLIGHT_ARTIFACT_THUMBNAIL_WIDTH_PX = 64;
 
+function SpotlightAgentCommandItem({
+  agent,
+  onSelect,
+  shortcutNumber,
+}: {
+  readonly agent: SubagentInfo;
+  readonly onSelect: () => void;
+  readonly shortcutNumber: number | undefined;
+}) {
+  return (
+    <CommandItem
+      value={`spotlight-agent-${agent.agentId}`}
+      onSelect={onSelect}
+      className={SPOTLIGHT_ROW_CLASS}
+    >
+      <AgentAvatarImg
+        name={agent.agentId}
+        alt=""
+        className={SPOTLIGHT_AVATAR_CLASS}
+      />
+      <span className="min-w-0 flex-1 truncate text-left text-sm text-foreground">
+        {agentDialogLabel(agent)}
+      </span>
+      <ThreadNumberShortcutHint shortcutNumber={shortcutNumber} />
+    </CommandItem>
+  );
+}
+
 function SpotlightWorkflowCommandItem({
   workflow,
   onSelect,
@@ -832,6 +862,7 @@ function SpotlightSearchFilterBar({
   readonly onSelect: (filter: ThreeColumnSearchFilter) => void;
 }) {
   const { t } = useTranslation("agents");
+  const agentSearchEnabled = useGet(workspaceAgentSearchEnabled$);
   const options: readonly {
     readonly value: ThreeColumnSearchFilter;
     readonly label: string;
@@ -852,6 +883,12 @@ function SpotlightSearchFilterBar({
       value: "messages",
       label: t(($) => {
         return $.sidebar.sections.messages;
+      }),
+    },
+    {
+      value: "agents",
+      label: t(($) => {
+        return $.sidebar.sections.agents;
       }),
     },
     {
@@ -877,6 +914,9 @@ function SpotlightSearchFilterBar({
         className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
       >
         {options.map((option) => {
+          if (option.value === "agents" && !agentSearchEnabled) {
+            return null;
+          }
           return (
             <SpotlightFilterButton
               key={option.value}
@@ -907,6 +947,7 @@ function SpotlightSearchFilterBar({
 interface SpotlightSearchResultsProps {
   readonly threads: readonly WorkspaceSearchChatThread[];
   readonly messages: readonly ChatSearchResult[];
+  readonly agents: readonly SubagentInfo[];
   readonly workflows: readonly WorkflowSummary[];
   readonly artifacts: readonly ThreeColumnArtifactSearchItem[];
   readonly threadMap: ReadonlyMap<string, WorkspaceSearchChatThread>;
@@ -915,6 +956,7 @@ interface SpotlightSearchResultsProps {
   readonly searching: boolean;
   readonly showNoResults: boolean;
   readonly onSelectChatThread: (threadId: string) => void;
+  readonly onSelectAgent: (agentId: string) => void;
   readonly onSelectWorkflow: (workflowId: string) => void;
   readonly onSelectArtifact: (artifact: ThreeColumnArtifactSearchItem) => void;
 }
@@ -961,24 +1003,29 @@ function spotlightVisibleSearchIsPending({
   showThreads,
   threadSearching,
   showMessages,
+  showAgents,
   showWorkflows,
   showArtifacts,
   messageSearching,
+  agentSearching,
   workflowSearching,
   artifactSearching,
 }: {
   readonly showThreads: boolean;
   readonly threadSearching: boolean;
   readonly showMessages: boolean;
+  readonly showAgents: boolean;
   readonly showWorkflows: boolean;
   readonly showArtifacts: boolean;
   readonly messageSearching: boolean;
+  readonly agentSearching: boolean;
   readonly workflowSearching: boolean;
   readonly artifactSearching: boolean;
 }): boolean {
   return (
     (showThreads && threadSearching) ||
     (showMessages && messageSearching) ||
+    (showAgents && agentSearching) ||
     (showWorkflows && workflowSearching) ||
     (showArtifacts && artifactSearching)
   );
@@ -987,6 +1034,7 @@ function spotlightVisibleSearchIsPending({
 function SpotlightSearchResults({
   threads,
   messages,
+  agents,
   workflows,
   artifacts,
   threadMap,
@@ -995,6 +1043,7 @@ function SpotlightSearchResults({
   searching,
   showNoResults,
   onSelectChatThread,
+  onSelectAgent,
   onSelectWorkflow,
   onSelectArtifact,
 }: SpotlightSearchResultsProps) {
@@ -1049,11 +1098,25 @@ function SpotlightSearchResults({
             />
           );
         })}
+        {agents.map((agent, index) => {
+          return (
+            <SpotlightAgentCommandItem
+              shortcutNumber={shortcutNumber(
+                threads.length + messages.length + index,
+              )}
+              key={agent.agentId}
+              agent={agent}
+              onSelect={() => {
+                return onSelectAgent(agent.agentId);
+              }}
+            />
+          );
+        })}
         {workflows.map((workflow, index) => {
           return (
             <SpotlightWorkflowCommandItem
               shortcutNumber={shortcutNumber(
-                threads.length + messages.length + index,
+                threads.length + messages.length + agents.length + index,
               )}
               key={workflow.id}
               workflow={workflow}
@@ -1067,7 +1130,11 @@ function SpotlightSearchResults({
           return (
             <SpotlightArtifactCommandItem
               shortcutNumber={shortcutNumber(
-                threads.length + messages.length + workflows.length + index,
+                threads.length +
+                  messages.length +
+                  agents.length +
+                  workflows.length +
+                  index,
               )}
               key={artifact.id}
               artifact={artifact}
@@ -1116,12 +1183,14 @@ export function ThreeColumnSearchDialog({
   open,
   onOpenChange,
   onSelectChatThread,
+  onSelectAgent,
   onSelectWorkflow,
   onSelectArtifact,
 }: {
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
   readonly onSelectChatThread: (threadId: string) => void;
+  readonly onSelectAgent: (agentId: string) => void;
   readonly onSelectWorkflow: (workflowId: string) => void;
   readonly onSelectArtifact: (artifact: ThreeColumnArtifactSearchItem) => void;
 }) {
@@ -1134,6 +1203,8 @@ export function ThreeColumnSearchDialog({
   const shortcutIndex = useSet(threadNumberShortcutIndex$);
   const threadMap = useGet(workspaceSearchChatThreadMap$);
   const messageLoadable = useLoadable(workspaceSearchChatMessages$);
+  const agentLoadable = useLoadable(threeColumnAgentSearchResults$);
+  const agentSearchEnabled = useGet(workspaceAgentSearchEnabled$);
   const workflowLoadable = useLoadable(threeColumnWorkflowSearchResults$);
   const artifactLoadable = useLoadable(threeColumnArtifactSearchResults$);
   const activeThreadIds = useLastResolved(sidebarActiveThreadIds$, {
@@ -1157,6 +1228,13 @@ export function ThreeColumnSearchDialog({
       return result.chatMessages;
     },
   );
+  const agentMatches = spotlightRowsFromLoadable(
+    agentLoadable,
+    trimmedQuery,
+    (result) => {
+      return result.agents;
+    },
+  );
   const workflowMatches = spotlightRowsFromLoadable(
     workflowLoadable,
     trimmedQuery,
@@ -1173,27 +1251,33 @@ export function ThreeColumnSearchDialog({
   );
   const showThreads = spotlightFilterShows(filter, "chats");
   const showMessages = spotlightFilterShows(filter, "messages");
+  const showAgents =
+    agentSearchEnabled && spotlightFilterShows(filter, "agents");
   const showWorkflows = spotlightFilterShows(filter, "workflows");
   const showArtifacts = spotlightFilterShows(filter, "artifacts");
   const visibleThreads = showThreads ? threadMatches : [];
   const visibleMessages = showMessages ? messageMatches : [];
+  const visibleAgents = showAgents ? agentMatches : [];
   const visibleWorkflows = showWorkflows ? workflowMatches : [];
   const visibleArtifacts = showArtifacts ? artifactMatches : [];
   const resultCount =
     visibleThreads.length +
     visibleMessages.length +
+    visibleAgents.length +
     visibleWorkflows.length +
     visibleArtifacts.length;
   const visibleSearching = spotlightVisibleSearchIsPending({
     showThreads,
     threadSearching: spotlightLoadableIsSearching(threadLoadable, trimmedQuery),
     showMessages,
+    showAgents,
     showWorkflows,
     showArtifacts,
     messageSearching: spotlightLoadableIsSearching(
       messageLoadable,
       trimmedQuery,
     ),
+    agentSearching: spotlightLoadableIsSearching(agentLoadable, trimmedQuery),
     workflowSearching: spotlightLoadableIsSearching(
       workflowLoadable,
       trimmedQuery,
@@ -1207,6 +1291,10 @@ export function ThreeColumnSearchDialog({
   const selectThread = (threadId: string) => {
     onOpenChange(false);
     onSelectChatThread(threadId);
+  };
+  const selectAgent = (agentId: string) => {
+    onOpenChange(false);
+    onSelectAgent(agentId);
   };
   const selectWorkflow = (workflowId: string) => {
     onOpenChange(false);
@@ -1226,6 +1314,11 @@ export function ThreeColumnSearchDialog({
     ...visibleMessages.map((message) => {
       return () => {
         selectThread(message.chatThreadId);
+      };
+    }),
+    ...visibleAgents.map((agent) => {
+      return () => {
+        selectAgent(agent.agentId);
       };
     }),
     ...visibleWorkflows.map((workflow) => {
@@ -1289,6 +1382,7 @@ export function ThreeColumnSearchDialog({
         <SpotlightSearchResults
           threads={visibleThreads}
           messages={visibleMessages}
+          agents={visibleAgents}
           workflows={visibleWorkflows}
           artifacts={visibleArtifacts}
           threadMap={threadMap}
@@ -1297,6 +1391,7 @@ export function ThreeColumnSearchDialog({
           searching={visibleSearching}
           showNoResults={showNoResults}
           onSelectChatThread={selectThread}
+          onSelectAgent={selectAgent}
           onSelectWorkflow={selectWorkflow}
           onSelectArtifact={selectArtifact}
         />

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -711,6 +711,11 @@ function ThreeColumnSearchDialogContainer() {
           pathParams: { threadId },
         });
       }}
+      onSelectAgent={(agentId) => {
+        navigate("/agents/:agentId/chat", {
+          pathParams: { agentId },
+        });
+      }}
       onSelectWorkflow={(workflowId) => {
         navigate("/workflows/:workflowId", {
           pathParams: { workflowId },

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -58,6 +58,7 @@ export enum FeatureSwitchKey {
   FollowUpOptimize = "followUpOptimize",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   StableChatThreadNavigation = "stableChatThreadNavigation",
+  WorkspaceAgentSearch = "workspaceAgentSearch",
   ChatThreadPinShortcut = "chatThreadPinShortcut",
   SidebarSubscriptionUsage = "_sidebarSubscriptionUsage",
   PinnedAgentAvatar64 = "pinnedAgentAvatar64",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -415,6 +415,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.WorkspaceAgentSearch]: {
+    maintainer: "ethan@okou.ai",
+    description: "Find agents by name in workspace search",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatThreadPinShortcut]: {
     maintainer: "ethan@okou.ai",
     description:


### PR DESCRIPTION
## Summary

Workspace search (`Cmd/Ctrl+Shift+F`) can now find visible agents by display name and open their chat page. The Agents filter and All results reuse the existing `agents$` computed, apply trimmed, case-insensitive substring matching, and exclude descriptions and agent IDs from matching. Agent results participate in result counts, keyboard selection, and numbered shortcuts, with the same 25-result limit as other resource searches.

Use a concise workspace search placeholder and translate the new filter in all supported locales. The `workspaceAgentSearch` feature switch initially enables the feature for staff organizations.

## Verification

- Platform and core lint and type checks; platform localization checks; scoped Knip; formatting and commitlint.
- 62 focused page tests cover name-only matching, empty queries, the result limit, navigation, feature-off behavior, and mixed-result shortcut ordering. One existing sidebar read-state test failed in the two-worker batch and passed unchanged in isolation; the new search tests pass with an explicit Mac browser fixture.
- All 31 existing core feature-switch tests pass.
- PR CI passes, including the Turbo gate, platform checks, and coverage.
- Browser acceptance on [the deployed preview](https://pr-32208-app-okou-app-preview.vm0.workers.dev): the Agents filter is absent with the switch off and appears with it enabled; a mixed-case query with surrounding spaces matches both test agents; clicking a result and selecting it with ArrowDown/Enter open the corresponding agent chat and close the dialog; an unmatched query shows zero results. Desktop (1440 x 900) and narrow (390 x 844) layouts were visually checked.
- The preview build at `60f2e8ed0512e0da67b5b4a2516ffb893904a9ae` includes this PR's head, `dcd57d57f2388cc07c2d14f974c2a3b489ea7eb4`. No local development server was started.
