### PR TITLE
refactor: remove retired fable 5 runtime definitions

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -104,7 +104,7 @@ fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
 fn default_claude_effort_for_model(model: &str) -> Option<&'static str> {
     let bare = model.strip_prefix("anthropic/").unwrap_or(model);
     match bare {
-        "claude-fable-5-1" | "claude-fable-5.1" | "claude-fable-5" | "fable" => Some("max"),
+        "claude-fable-5-1" | "claude-fable-5.1" | "fable" => Some("max"),
         _ => None,
     }
 }
@@ -362,9 +362,9 @@ mod tests {
     fn build_claude_args_fable_defaults_effort_max() {
         for model in [
             "claude-fable-5-1",
+            "claude-fable-5.1",
+            "anthropic/claude-fable-5-1",
             "anthropic/claude-fable-5.1",
-            "claude-fable-5",
-            "anthropic/claude-fable-5",
             "fable",
         ] {
             let args = build_claude_args_for_model_test(model);

--- a/crates/guest-agent/src/failure_diagnostics.rs
+++ b/crates/guest-agent/src/failure_diagnostics.rs
@@ -364,7 +364,7 @@ fn classify_cli_failure_reason(
     }
     // Subscription/usage limits are an expected quota state for both Codex
     // (ChatGPT plan "usage limit" or API billing "quota exceeded") and Claude
-    // Code (Max plan "session limit" / "weekly limit" / Fable model limit /
+    // Code (Max plan "session limit" / "weekly limit" /
     // org monthly spend limit), so classify them regardless of framework where
     // the wording is shared. This lets the runner log these expected outcomes
     // at info instead of error.
@@ -374,9 +374,7 @@ fn classify_cli_failure_reason(
         || normalized.contains("session limit")
         || normalized.contains("weekly limit")
         || (matches!(framework, AgentFramework::ClaudeCode)
-            && (normalized.contains("fable 5 requires usage credits")
-                || normalized.contains("reached your fable 5 limit")
-                || is_claude_subscription_access_disabled_error(&normalized)
+            && (is_claude_subscription_access_disabled_error(&normalized)
                 || is_claude_monthly_spend_limit_error(&normalized)))
     {
         return Some(FailureReason::UsageLimit);

--- a/crates/guest-agent/src/failure_diagnostics/tests.rs
+++ b/crates/guest-agent/src/failure_diagnostics/tests.rs
@@ -1533,22 +1533,6 @@ fn cli_failure_reason_classifies_claude_usage_limit() {
 }
 
 #[test]
-fn cli_failure_reason_classifies_claude_fable_limits() {
-    for message in [
-        "Fable 5 requires usage credits. /model to switch models.",
-        "You've reached your Fable 5 limit. /model to switch models.",
-    ] {
-        let reason = classify_cli_failure_reason(AgentFramework::ClaudeCode, message);
-
-        assert_eq!(
-            reason,
-            Some(FailureReason::UsageLimit),
-            "message: {message}"
-        );
-    }
-}
-
-#[test]
 fn cli_failure_reason_classifies_claude_subscription_access_disabled_as_usage_limit() {
     let reason = classify_cli_failure_reason(
         AgentFramework::ClaudeCode,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -213,10 +213,6 @@ describe("model-first canonical catalog", () => {
     expect(isLimitedFree1RestrictedRunModel("anthropic/claude-fable-5.1")).toBe(
       true,
     );
-    expect(isLimitedFree1RestrictedRunModel("claude-fable-5")).toBe(true);
-    expect(isLimitedFree1RestrictedRunModel("anthropic/claude-fable-5")).toBe(
-      true,
-    );
     expect(isLimitedFree1RestrictedRunModel("claude-opus-5")).toBe(true);
     expect(isLimitedFree1RestrictedRunModel("anthropic/claude-opus-5")).toBe(
       true,
@@ -548,12 +544,6 @@ describe("model-first canonical catalog", () => {
     expect(
       getProviderRuntimeModel("vercel-ai-gateway", "claude-fable-5-1"),
     ).toBe("anthropic/claude-fable-5.1");
-    expect(
-      getProviderRuntimeModel("openrouter-api-key", "claude-fable-5"),
-    ).toBe("anthropic/claude-fable-5");
-    expect(getProviderRuntimeModel("vercel-ai-gateway", "claude-fable-5")).toBe(
-      "anthropic/claude-fable-5",
-    );
     expect(getProviderRuntimeModel("openai-api-key", "gpt-5.5")).toBe(
       "gpt-5.5",
     );
@@ -614,7 +604,6 @@ describe("model-first canonical catalog", () => {
 
   it.each([
     "claude-fable-5-1",
-    "claude-fable-5",
     "claude-opus-5",
     "claude-opus-4-8",
     "claude-sonnet-5",
@@ -632,7 +621,6 @@ describe("model-first canonical catalog", () => {
   it("defines two statically compilable built-in model routes for every active model", () => {
     expect(Object.keys(BUILT_IN_MODEL_TO_PROVIDER)).toEqual([
       "claude-fable-5-1",
-      "claude-fable-5",
       "claude-opus-5",
       "claude-opus-4-8",
       "claude-sonnet-5",
@@ -894,8 +882,6 @@ describe("model image input support", () => {
     "openai/gpt-6-astra",
     "claude-fable-5-1",
     "anthropic/claude-fable-5.1",
-    "claude-fable-5",
-    "anthropic/claude-fable-5",
     "claude-opus-5",
     "anthropic/claude-opus-5",
     "claude-sonnet-4-6",

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -179,6 +179,8 @@ const SUPPORTED_RUN_MODEL_SET: ReadonlySet<string> = new Set(
   SUPPORTED_RUN_MODELS,
 );
 
+type ActiveRunModel = Exclude<SupportedRunModel, "claude-fable-5">;
+
 // Historical IDs remain in the wire schemas and billing catalog. Availability
 // is a separate product decision, including for provider-prefixed aliases.
 export const RETIRED_RUN_MODEL_MESSAGE =
@@ -199,7 +201,7 @@ export function getRunModelAccess(
 
 export function isActiveRunModel(
   model: string | null | undefined,
-): model is SupportedRunModel {
+): model is ActiveRunModel {
   return isSupportedRunModel(model) && getRunModelAccess(model) === "allowed";
 }
 
@@ -261,9 +263,6 @@ export function getDefaultOrgModelPolicySeed(
 /**
  * Mapping from VM0 built-in model names to their concrete provider type and vendor.
  * Used at build-context time to resolve the meta-provider to a real provider.
- *
- * NOTE: Defined before MODEL_PROVIDER_TYPES so the built-in entry can derive
- * its models list from this mapping via Object.keys().
  */
 export const BUILT_IN_MODEL_ROUTE_PROVIDERS = {
   "anthropic-api-key": { vendor: "anthropic" },
@@ -291,9 +290,8 @@ interface ModelConfig {
   ];
 }
 
-// Key order is load-bearing: `Object.keys()` preserves insertion order and
-// `MODEL_PROVIDER_TYPES["built-in"].models` is derived from it, which in turn drives
-// the order models appear in the Built-in model dropdown.
+// Execution routes contain only active models. Historical recognition and
+// retirement validation must not depend on a model retaining an executable route.
 export const BUILT_IN_MODEL_TO_PROVIDER = {
   "claude-fable-5-1": {
     candidates: [
@@ -301,15 +299,6 @@ export const BUILT_IN_MODEL_TO_PROVIDER = {
       {
         concreteType: "openrouter-api-key",
         apiModel: "anthropic/claude-fable-5.1",
-      },
-    ],
-  },
-  "claude-fable-5": {
-    candidates: [
-      { concreteType: "anthropic-api-key" },
-      {
-        concreteType: "openrouter-api-key",
-        apiModel: "anthropic/claude-fable-5",
       },
     ],
   },
@@ -415,7 +404,7 @@ export const BUILT_IN_MODEL_TO_PROVIDER = {
       },
     ],
   },
-} as const satisfies Record<SupportedRunModel, ModelConfig>;
+} as const satisfies Record<ActiveRunModel, ModelConfig>;
 
 export interface BuiltInModelRouteTarget {
   readonly selectedModel: SupportedRunModel;
@@ -425,7 +414,7 @@ export interface BuiltInModelRouteTarget {
 }
 
 function vm0PrimaryCandidate(model: string): BuiltInModelRouteCandidate {
-  if (!isSupportedRunModel(model)) {
+  if (!isActiveRunModel(model)) {
     throw new Error(
       `Unknown VM0 model "${model}". Valid models: ${Object.keys(BUILT_IN_MODEL_TO_PROVIDER).join(", ")}`,
     );
@@ -436,7 +425,7 @@ function vm0PrimaryCandidate(model: string): BuiltInModelRouteCandidate {
 export function getBuiltInModelRouteCandidates(
   model: string,
 ): readonly BuiltInModelRouteTarget[] {
-  if (!isSupportedRunModel(model)) {
+  if (!isActiveRunModel(model)) {
     throw new Error(
       `Unknown VM0 model "${model}". Valid models: ${Object.keys(BUILT_IN_MODEL_TO_PROVIDER).join(", ")}`,
     );
@@ -470,7 +459,7 @@ export const BUILT_IN_MODEL_ALIAS_TO_MODEL = {
   "anthropic/claude-opus-4.8": "claude-opus-4-8",
   "anthropic/claude-sonnet-5": "claude-sonnet-5",
   "anthropic/claude-sonnet-4.6": "claude-sonnet-4-6",
-} as const satisfies Record<string, keyof typeof BUILT_IN_MODEL_TO_PROVIDER>;
+} as const satisfies Record<string, SupportedRunModel>;
 
 const BUILT_IN_MODEL_ALIAS_LOOKUP: Readonly<Record<string, string>> =
   BUILT_IN_MODEL_ALIAS_TO_MODEL;
@@ -503,9 +492,7 @@ export function isLimitedFree1RestrictedRunModel(
 }
 
 export const ACTIVE_RUN_MODELS: readonly SupportedRunModel[] =
-  SUPPORTED_RUN_MODELS.filter((model) => {
-    return getRunModelAccess(model) === "allowed";
-  });
+  SUPPORTED_RUN_MODELS.filter(isActiveRunModel);
 
 export type ModelImageInputSupport = "supported" | "unsupported" | "unknown";
 
@@ -513,13 +500,11 @@ const IMAGE_INPUT_SUPPORTED_MODELS = new Set([
   "gpt-6-astra",
   "openai/gpt-6-astra",
   "claude-fable-5-1",
-  "claude-fable-5",
   "claude-opus-5",
   "claude-opus-4-8",
   "claude-sonnet-5",
   "claude-sonnet-4-6",
   "anthropic/claude-fable-5.1",
-  "anthropic/claude-fable-5",
   "anthropic/claude-opus-5",
   "anthropic/claude-opus-4.8",
   "anthropic/claude-sonnet-5",
@@ -977,13 +962,6 @@ const MODEL_FIRST_PROVIDER_COMPATIBILITY = {
     "openrouter-api-key",
     "vercel-ai-gateway",
   ],
-  "claude-fable-5": [
-    "built-in",
-    "claude-code-oauth-token",
-    "anthropic-api-key",
-    "openrouter-api-key",
-    "vercel-ai-gateway",
-  ],
   "claude-opus-5": [
     "built-in",
     "claude-code-oauth-token",
@@ -1048,14 +1026,13 @@ const MODEL_FIRST_PROVIDER_COMPATIBILITY = {
   ],
   "deepseek-v4-flash": ["built-in", "deepseek"],
   "deepseek-v4-pro": ["built-in", "deepseek"],
-} as const satisfies Record<SupportedRunModel, readonly ModelProviderType[]>;
+} as const satisfies Record<ActiveRunModel, readonly ModelProviderType[]>;
 
 const PROVIDER_RUNTIME_MODEL_ALIASES: Partial<
-  Record<ModelProviderType, Partial<Record<SupportedRunModel, string>>>
+  Record<ModelProviderType, Partial<Record<ActiveRunModel, string>>>
 > = {
   "openrouter-api-key": {
     "claude-fable-5-1": "anthropic/claude-fable-5.1",
-    "claude-fable-5": "anthropic/claude-fable-5",
     "claude-opus-5": "anthropic/claude-opus-5",
     "claude-opus-4-8": "anthropic/claude-opus-4.8",
     "claude-sonnet-5": "anthropic/claude-sonnet-5",
@@ -1063,7 +1040,6 @@ const PROVIDER_RUNTIME_MODEL_ALIASES: Partial<
   },
   "vercel-ai-gateway": {
     "claude-fable-5-1": "anthropic/claude-fable-5.1",
-    "claude-fable-5": "anthropic/claude-fable-5",
     "claude-opus-5": "anthropic/claude-opus-5",
     "claude-opus-4-8": "anthropic/claude-opus-4.8",
     "claude-sonnet-5": "anthropic/claude-sonnet-5",
@@ -1120,7 +1096,7 @@ export function getProviderRuntimeModel(
   model: string,
 ): string {
   const canonical = normalizeRunModelId(model);
-  if (!isSupportedRunModel(canonical)) {
+  if (!isActiveRunModel(canonical)) {
     return model;
   }
   if (isBuiltInModelProviderType(type)) {


### PR DESCRIPTION
## Summary

Remove Claude Fable 5's obsolete Built-in route candidates, provider compatibility entries, outbound runtime aliases, image-input metadata, guest effort override, and model-specific usage-limit classifier after #31790's retirement deployment and drain. Keep Fable 5.1 routing and all existing guest aliases, including `fable`.

Execution maps now require active model IDs, while historical wire recognition and retirement validation remain independent of executable routes. The API continues to reject explicit and persisted queued retired selections. This is code-only cleanup: no migration, production data write, production release, or Astra policy change.

## Production and compatibility evidence

Read-only checks on September 7, 2026 (04:36–04:40 UTC):

- Fully paginated configuration reads: 31,793 policies, 6,212 member records, 152,355 threads, 7,164 agents and 6,617 providers. Each contained **zero** canonical or provider-prefixed Fable 5 selections. Fable 5.1 remains present in 4,637 policies.
- **Zero** queued, pending or running Fable 5 runs; both `agent_run_queue` and `runner_job_queue` were empty. Terminal `timeout` records were explicitly distinguished from active work.
- 4,074 historical Fable 5 runs remain: 3,743 completed, 211 failed, 118 cancelled and 2 timed out. Latest completion: August 31, 2026 at 06:37:18 UTC. All five result pages were read and one row was cross-checked with an independent equality query. These are a complete current query, not the earlier 333-row inspection.
- Source-masked custom gateway mappings and encrypted queue payloads were not queried. Retirement still applies at policy, explicit selection and final/queued admission boundaries regardless of the route.
- [Retirement release](https://github.com/vm0-ai/vm0/actions/runs/33942931396) deployed artifact `30aadb42008af91a999faac6170262dd1de881cb`, which contains #31790. API promotion completed at 04:04:45 UTC on September 5; App and Runner promotion completed by 04:06:16 UTC. More than 48 hours elapsed before this cleanup, exceeding the approximately two-day client and two-hour runner windows.
- The current production schema pointer identifies API `1.558.0`, artifact `61fc38fb7c244e0d1f605e0f29ddb54889ec0de8`, which still contains retirement enforcement and App floor `0.843.1`. A live API health request returned 200; the same request advertising App `0.843.0` returned 426. The supported floor's App artifact includes retirement.

## Intentionally retained references

| Location | Purpose |
| --- | --- |
| `model-price-tiers.ts`: `SUPPORTED_RUN_MODELS` and `BUILT_IN_MODEL_PRICE_TIER` | Parse historical canonical IDs and show the original price tier. These do not expose a selectable model. |
| `model-providers.ts`: `SUPPORTED_RUN_MODEL_LABELS`, `BUILT_IN_MODEL_ALIAS_TO_MODEL`, `CANONICAL_RUN_MODEL_ALIASES` | Preserve historical identity and provider-prefixed normalization. In particular, removing the Built-in alias would undermine the existing retirement check. |
| `model-providers.ts`: `ActiveRunModel`, `getRunModelAccess`, `RETIRED_RUN_MODEL_MESSAGE`, request refinement | Enforce the retired-model boundary and keep execution maps limited to active models. |
| `core/src/model-display-name.ts` | Display both historical canonical and provider-prefixed records as Claude Fable 5. |
| Platform `provider-ui-config.ts`: `MODEL_BRAND_ICON` | Keep the icon lookup total over the historical-aware `SupportedRunModel` presentation contract. `ModelPickerOverview` renders a stored selected value even when it is absent from current options; this lookup does not configure execution routes. |
| API `dev-seed.ts`: Fable 5 `usageGroup` | Preserve the four original billing categories. Production still has all four pricing rows; cache-read `unit_price` is 1,250 for Fable 5 versus 313 for Fable 5.1 (both per 1,000,000 tokens). Do not relabel historical usage or replace these rates. |
| Contract tests in `model-providers.test.ts` | Exercise historical schema recognition, labels, aliases and price tiers. Stale runtime, image capability and plan-restriction cases are removed. |
| API `model-policies.test.ts`, `chat-threads-model-selection.test.ts`, `run-lifecycle.bdd.test.ts` | Preserve fail-closed rejection of new selections and canonical/provider-prefixed queued selections. |
| `db/scripts/migrations/010-custom-model-gateways/backfill.ts` | Executed migration history; left intact along with migration journals. |
| Eight changelogs (Guest; current, June and July API/App; Core) | Preserve fourteen existing Fable 5 release-history entries. |

Loose `Claude Fable 5` regular expressions in `chat-composer-media-models.test.tsx` (two assertions) and `org-providers-tab.test.tsx` (one assertion) match existing Fable 5.1 fixtures. The escaped `Claude Fable 5\.1` expression in `chat-composer-model-selection.test.tsx` also explicitly selects the successor. They do not represent retired model selections. No retired execution reference remains in guest-agent source or tests; its changelog remains historical.

## Validation

- Shared model contracts: **150 passed**.
- API model policies, member preference, thread selection and runtime-state routes: **74 passed** across three files using a real local PostgreSQL database.
- Persisted canonical/provider-prefixed retired queued admission: **2 passed** (focused existing BDD cases).
- Core display-name tests: **8 passed**; model resolution, media picker and provider settings page tests: **39 passed**.
- Guest CLI argument tests: **23 passed**; failure diagnostics: **101 passed**. Successor aliases include canonical/dotted names, provider-prefixed forms and generic `fable`.
- Changed TypeScript Prettier and workspace lint; repository type checking (**15/15 tasks**) and Knip; Rust formatting, guest all-target Clippy and guest documentation checks: **passed**.
- Initial local runner-claim failures came from the newly created PostgreSQL database using `Asia/Shanghai`: UTC `expires_at` values compared against `now()` appeared expired. The dedicated local test database was set to UTC; all 74 API tests then passed. Initial page timeouts passed when each affected file ran alone after Rust compilation, without test or timeout changes.
- No full local Vitest run or local development server. Broad verification and protected merge remain governed by the PR pipeline.

- Final [protected merge-group validation](https://github.com/vm0-ai/vm0/actions/runs/34086383532): **85 checks passed**, 11 workflow-selected skips, all three required gates green; merged at 05:27:19 UTC on September 7 as `785a8f86e9f531445c1c25ffc46509d59dbddc58`. The initial unrelated navigation assertion failure and unchanged-head follow-up evidence are recorded in [the CI follow-up](https://github.com/vm0-ai/vm0/pull/32210#issuecomment-5565411540).
