### PR TITLE
fix(billing): reconcile already-refunded usage pack charges

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -232,6 +232,7 @@ export interface ApiTestMocks {
       readonly create: AsyncMock;
     };
     readonly refunds: {
+      readonly list: AsyncMock;
       readonly create: AsyncMock;
       readonly retrieve: AsyncMock;
     };
@@ -439,6 +440,7 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
     refunds: {
+      list: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       create: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       retrieve: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
@@ -1019,6 +1021,7 @@ vi.mock("stripe", async (importOriginal) => {
           create: apiTestMocks.stripe.invoiceItems.create,
         },
         refunds: {
+          list: apiTestMocks.stripe.refunds.list,
           create: apiTestMocks.stripe.refunds.create,
           retrieve: apiTestMocks.stripe.refunds.retrieve,
         },
@@ -1352,6 +1355,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.stripe.invoices.pay.mockReset();
   apiTestMocks.stripe.invoices.voidInvoice.mockReset();
   apiTestMocks.stripe.invoiceItems.create.mockReset();
+  apiTestMocks.stripe.refunds.list.mockReset();
   apiTestMocks.stripe.refunds.create.mockReset();
   apiTestMocks.stripe.refunds.retrieve.mockReset();
   apiTestMocks.stripe.creditNotes.list.mockReset();

--- a/turbo/apps/api/src/signals/external/stripe-client.ts
+++ b/turbo/apps/api/src/signals/external/stripe-client.ts
@@ -237,6 +237,9 @@ export interface StripeRefund {
   readonly id: string;
   readonly status: string | null;
   readonly failure_reason?: string | null;
+  readonly amount: number;
+  readonly payment_intent: StripeRef;
+  readonly metadata: Record<string, string> | null;
 }
 
 export interface StripeCreditNote {
@@ -678,6 +681,11 @@ export interface StripeCheckoutSessionsApi {
 }
 
 export interface StripeRefundsApi {
+  list(params: {
+    readonly payment_intent: string;
+    readonly limit: number;
+    readonly starting_after?: string;
+  }): Promise<StripeList<StripeRefund>>;
   retrieve(id: string): Promise<StripeRefund>;
   create(
     params: {

--- a/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-checkout.test.ts
@@ -6677,7 +6677,10 @@ describe("usage pack allocation management", () => {
     readonly paymentIntentId: string;
   }
 
-  async function setupInvitationPreviewContext(emailPrefix: string): Promise<{
+  async function setupInvitationPreviewContext(
+    emailPrefix: string,
+    actor = createOrgFixture(TEST_STAFF_ORG_ID),
+  ): Promise<{
     readonly fixture: ManagedUsagePackFixture;
     readonly existingMemberUserId: string;
     readonly email: string;
@@ -6687,9 +6690,11 @@ describe("usage pack allocation management", () => {
       clearMockNow();
     });
     const existingMemberUserId = `user_${randomUUID()}`;
-    const fixture = await seedManagedUsagePack([
-      { userId: existingMemberUserId, usagePackUsd: 20 },
-    ]);
+    const fixture = await seedManagedUsagePack(
+      [{ userId: existingMemberUserId, usagePackUsd: 20 }],
+      "pro",
+      actor,
+    );
     const email = `${emailPrefix}-${randomUUID()}@example.test`;
     context.mocks.clerk.organizations.getOrganizationMembershipList.mockResolvedValue(
       {
@@ -6710,9 +6715,11 @@ describe("usage pack allocation management", () => {
     return { fixture, existingMemberUserId, email };
   }
 
-  async function beginInvitationPurchase(): Promise<InvitationPurchaseFixture> {
+  async function beginInvitationPurchase(
+    actor = createOrgFixture(TEST_STAFF_ORG_ID),
+  ): Promise<InvitationPurchaseFixture> {
     const { fixture, existingMemberUserId, email } =
-      await setupInvitationPreviewContext("invitee");
+      await setupInvitationPreviewContext("invitee", actor);
     const paymentIntentId = `pi_invite_${randomUUID()}`;
     mockUsagePackChangePreviews(1000, 2000);
     const preview = await accept(
@@ -6972,6 +6979,7 @@ describe("usage pack allocation management", () => {
     setUsagePackPrices();
     mockUsagePackCatalog();
     context.mocks.stripe.invoices.list.mockResolvedValue({ data: [] });
+    context.mocks.stripe.subscriptions.list.mockResolvedValue({ data: [] });
     mockOptionalEnv("STRIPE_SECRET_KEY", "sk_usage_pack_change");
     mockOptionalEnv("STRIPE_WEBHOOK_SECRET", STRIPE_WEBHOOK_SECRET);
   });
@@ -14380,6 +14388,243 @@ describe("usage pack allocation management", () => {
     expect(context.mocks.stripe.refunds.retrieve).toHaveBeenCalledWith(
       stripeRefundId,
     );
+  });
+
+  async function prepareAlreadyRefundedMember(
+    sourceType: "invoice" | "payment_intent",
+  ) {
+    const actor = createOrgFixture();
+    let fixture: ManagedUsagePackFixture;
+    let userId: string;
+    let paymentIntentId: string;
+    if (sourceType === "payment_intent") {
+      const purchase = await beginInvitationPurchase(actor);
+      const invitationId = `inv_${randomUUID()}`;
+      userId = `user_${randomUUID()}`;
+      await payInvitationPurchase(purchase, invitationId);
+      context.mocks.stripe.subscriptions.update.mockResolvedValue({});
+      await postClerkInvitationAccepted({ purchase, invitationId, userId });
+      fixture = purchase.fixture;
+      paymentIntentId = purchase.paymentIntentId;
+      context.mocks.stripe.subscriptions.retrieve.mockResolvedValue(
+        managedUsagePackSubscription(
+          fixture,
+          new Map([[TEST_PRICE_USAGE_PACK_20, 2]]),
+        ),
+      );
+    } else {
+      userId = actor.userId;
+      fixture = await seedManagedUsagePack(
+        [{ userId, usagePackUsd: 20 }],
+        "pro",
+        actor,
+      );
+      paymentIntentId = `pi_${randomUUID()}`;
+      context.mocks.stripe.creditNotes.preview.mockResolvedValue({
+        id: `cn_preview_${randomUUID()}`,
+        status: "issued",
+        pre_payment_amount: 0,
+        post_payment_amount: 500,
+        refunds: [],
+      });
+      context.mocks.stripe.invoices.retrieve.mockResolvedValue({
+        payments: {
+          data: [
+            {
+              status: "paid",
+              amount_paid: 2000,
+              payment: {
+                type: "payment_intent",
+                payment_intent: paymentIntentId,
+              },
+            },
+          ],
+        },
+      });
+    }
+    await usagePackStateAction({
+      action: "set-grant-remaining",
+      orgId: fixture.orgId,
+      userId,
+      grantType: "purchased",
+      remainingAmount: 5000,
+      prepareRefund: true,
+      refundState: {
+        status: "processing",
+        refundedAmountCents: null,
+        stripeCreditNoteId: null,
+        stripeRefundId: null,
+        attempt: 1,
+        failureReason: null,
+      },
+    });
+    const state = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    const localRefund = state.refunds.find((refund) => {
+      return refund.userId === userId;
+    });
+    if (!localRefund) {
+      throw new Error("Expected a prepared member refund");
+    }
+    const existingRefund = {
+      id: `re_${randomUUID()}`,
+      status: "succeeded",
+      amount: 500,
+      payment_intent: paymentIntentId,
+      metadata: {
+        purpose: "usage_pack_member_credit_refund",
+        orgId: fixture.orgId,
+        userId,
+        creditGrantId: localRefund.creditGrantId,
+      },
+    };
+    context.mocks.stripe.refunds.create.mockRejectedValue(
+      new StripeSDK.errors.StripeInvalidRequestError({
+        type: "invalid_request_error",
+        code: "charge_already_refunded",
+        message: "Charge has already been refunded.",
+      }),
+    );
+    context.mocks.stripe.creditNotes.create.mockResolvedValue({
+      id: `cn_${randomUUID()}`,
+      status: "issued",
+      pre_payment_amount: 0,
+      post_payment_amount: 500,
+      refunds: [{ amount_refunded: 500, refund: existingRefund.id }],
+    });
+    return { fixture, userId, existingRefund };
+  }
+
+  it.each(["invoice", "payment_intent"] as const)(
+    "recovers an already-refunded %s charge and stops retrying",
+    async (sourceType) => {
+      const { fixture, userId, existingRefund } =
+        await prepareAlreadyRefundedMember(sourceType);
+      const unrelatedRefund = {
+        ...existingRefund,
+        id: `re_other_${randomUUID()}`,
+        amount: 100,
+      };
+      context.mocks.stripe.refunds.list
+        .mockResolvedValueOnce({ data: [unrelatedRefund], has_more: true })
+        .mockResolvedValueOnce({ data: [existingRefund], has_more: false });
+
+      await runBillingReconciliation(fixture.orgId);
+      await runBillingReconciliation(fixture.orgId);
+
+      const state = await readUsagePackState(
+        fixture.orgId,
+        fixture.usagePackSubscriptionId,
+      );
+      expect(state.refunds).toContainEqual(
+        expect.objectContaining({
+          userId,
+          status: "succeeded",
+          stripeRefundId: existingRefund.id,
+          refundedAmountCents: 500,
+          failureReason: null,
+        }),
+      );
+      expect(context.mocks.stripe.refunds.create).toHaveBeenCalledTimes(1);
+      expect(context.mocks.stripe.refunds.list).toHaveBeenLastCalledWith({
+        payment_intent: existingRefund.payment_intent,
+        limit: 100,
+        starting_after: unrelatedRefund.id,
+      });
+      if (sourceType === "invoice") {
+        expect(context.mocks.stripe.creditNotes.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            refunds: [{ refund: existingRefund.id, amount_refunded: 500 }],
+          }),
+          expect.any(Object),
+        );
+      } else {
+        expect(context.mocks.stripe.creditNotes.create).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each(["amount", "ownership", "status", "ambiguous"])(
+    "stops already-refunded charge retries for an unresolved %s mismatch",
+    async (mismatch) => {
+      const { fixture, userId, existingRefund } =
+        await prepareAlreadyRefundedMember("payment_intent");
+      const refund = {
+        ...existingRefund,
+        amount: mismatch === "amount" ? 1000 : existingRefund.amount,
+        status: mismatch === "status" ? "pending" : existingRefund.status,
+        metadata: {
+          ...existingRefund.metadata,
+          creditGrantId:
+            mismatch === "ownership"
+              ? randomUUID()
+              : existingRefund.metadata.creditGrantId,
+        },
+      };
+      context.mocks.stripe.refunds.list.mockResolvedValue({
+        data:
+          mismatch === "ambiguous"
+            ? [refund, { ...refund, id: `re_other_${randomUUID()}` }]
+            : [refund],
+        has_more: false,
+      });
+
+      await runBillingReconciliation(fixture.orgId);
+      await runBillingReconciliation(fixture.orgId);
+
+      const state = await readUsagePackState(
+        fixture.orgId,
+        fixture.usagePackSubscriptionId,
+      );
+      expect(state.refunds).toContainEqual(
+        expect.objectContaining({
+          userId,
+          status: "failed",
+          stripeRefundId: null,
+          refundedAmountCents: null,
+          failureReason:
+            mismatch === "ambiguous"
+              ? "stripe_charge_already_refunded_ambiguous"
+              : "stripe_charge_already_refunded_unmatched",
+        }),
+      );
+      expect(context.mocks.stripe.refunds.create).toHaveBeenCalledTimes(1);
+      expect(context.mocks.stripe.refunds.list).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("retries a failed Stripe refund lookup without claiming a terminal outcome", async () => {
+    const { fixture, userId, existingRefund } =
+      await prepareAlreadyRefundedMember("payment_intent");
+    context.mocks.stripe.refunds.list
+      .mockRejectedValueOnce(new Error("Stripe temporarily unavailable"))
+      .mockResolvedValueOnce({ data: [existingRefund], has_more: false });
+
+    await runBillingReconciliation(fixture.orgId);
+    const pending = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(pending.refunds).toContainEqual(
+      expect.objectContaining({ userId, status: "processing", attempt: 1 }),
+    );
+    await runBillingReconciliation(fixture.orgId);
+    const reconciled = await readUsagePackState(
+      fixture.orgId,
+      fixture.usagePackSubscriptionId,
+    );
+    expect(reconciled.refunds).toContainEqual(
+      expect.objectContaining({
+        userId,
+        status: "succeeded",
+        stripeRefundId: existingRefund.id,
+      }),
+    );
+    const requests = context.mocks.stripe.refunds.create.mock.calls;
+    expect(requests).toHaveLength(2);
+    expect(requests[1]).toStrictEqual(requests[0]);
   });
 
   it("reconciles acceptance when the Stripe projection response is lost", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/org-delete-billing.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-delete-billing.test.ts
@@ -170,7 +170,13 @@ function creditNote(
     refunds: [
       {
         amount_refunded: amount,
-        refund: { id: `re_${id}`, status: refundStatus },
+        refund: {
+          id: `re_${id}`,
+          status: refundStatus,
+          amount,
+          payment_intent: null,
+          metadata: {},
+        },
       },
     ],
   };

--- a/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
+++ b/turbo/apps/api/src/signals/services/usage-pack-credit-refund.service.ts
@@ -11,6 +11,7 @@ import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
 import {
   getStripeClient,
+  stripeErrorInfo,
   type StripeClient,
   type StripeCreditNote,
   type StripeCreditNoteParams,
@@ -468,21 +469,14 @@ async function processPaymentIntentRefund(
   const stripe = getStripeClient();
   const refund = row.stripeRefundId
     ? await stripe.refunds.retrieve(row.stripeRefundId)
-    : await stripe.refunds.create(
-        {
-          payment_intent: row.stripePaymentIntentId,
-          amount: row.requestedAmountCents,
-          metadata: {
-            purpose: "usage_pack_member_credit_refund",
-            orgId: row.orgId,
-            userId: row.userId,
-            creditGrantId: row.creditGrantId,
-          },
-        },
-        {
-          idempotencyKey: `usage-pack-credit-refund:${row.creditGrantId}:${row.attempt}`,
-        },
-      );
+    : await createOrReconcileRefund(db, stripe, row, {
+        paymentIntentId: row.stripePaymentIntentId,
+        amountCents: row.requestedAmountCents,
+        idempotencyKey: `usage-pack-credit-refund:${row.creditGrantId}:${row.attempt}`,
+      });
+  if (!refund) {
+    return;
+  }
   const state = await applyStripeRefundState(db, row, refund);
   if (state === "succeeded") {
     await markRefundSucceeded(db, row, refund.id, row.requestedAmountCents);
@@ -604,20 +598,103 @@ async function loadOrCreateInvoiceRefund(
   if (!paymentIntentId) {
     return null;
   }
-  return await stripe.refunds.create(
-    {
+  return await createOrReconcileRefund(db, stripe, row, {
+    paymentIntentId,
+    amountCents: refundAmountCents,
+    idempotencyKey: `usage-pack-credit-refund:${row.creditGrantId}:${row.attempt}:refund`,
+  });
+}
+
+async function reconcileAlreadyRefundedCharge(
+  db: Pick<Db, "update">,
+  stripe: StripeClient,
+  row: UsagePackCreditRefundRow,
+  paymentIntentId: string,
+  amountCents: number,
+): Promise<StripeRefund | null> {
+  let startingAfter: string | undefined;
+  let matchingRefund: StripeRefund | null = null;
+  do {
+    const page = await stripe.refunds.list({
       payment_intent: paymentIntentId,
-      amount: refundAmountCents,
-      metadata: {
-        purpose: "usage_pack_member_credit_refund",
-        orgId: row.orgId,
-        userId: row.userId,
-        creditGrantId: row.creditGrantId,
+      limit: 100,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+    for (const refund of page.data) {
+      if (
+        refund.status !== "succeeded" ||
+        refund.amount !== amountCents ||
+        stripeRefId(refund.payment_intent) !== paymentIntentId ||
+        refund.metadata?.purpose !== "usage_pack_member_credit_refund" ||
+        refund.metadata.creditGrantId !== row.creditGrantId ||
+        refund.metadata.orgId !== row.orgId ||
+        refund.metadata.userId !== row.userId
+      ) {
+        continue;
+      }
+      if (matchingRefund) {
+        await markRefundFailed(
+          db,
+          row,
+          "stripe_charge_already_refunded_ambiguous",
+        );
+        return null;
+      }
+      matchingRefund = refund;
+    }
+    if (!page.has_more) {
+      break;
+    }
+    const lastRefundId = page.data.at(-1)?.id;
+    if (!lastRefundId || lastRefundId === startingAfter) {
+      throw new Error("Stripe refund pagination did not advance");
+    }
+    startingAfter = lastRefundId;
+  } while (startingAfter);
+
+  if (!matchingRefund) {
+    await markRefundFailed(db, row, "stripe_charge_already_refunded_unmatched");
+  }
+  return matchingRefund;
+}
+
+async function createOrReconcileRefund(
+  db: Pick<Db, "update">,
+  stripe: StripeClient,
+  row: UsagePackCreditRefundRow,
+  args: {
+    readonly paymentIntentId: string;
+    readonly amountCents: number;
+    readonly idempotencyKey: string;
+  },
+): Promise<StripeRefund | null> {
+  const result = await settle(
+    stripe.refunds.create(
+      {
+        payment_intent: args.paymentIntentId,
+        amount: args.amountCents,
+        metadata: {
+          purpose: "usage_pack_member_credit_refund",
+          orgId: row.orgId,
+          userId: row.userId,
+          creditGrantId: row.creditGrantId,
+        },
       },
-    },
-    {
-      idempotencyKey: `usage-pack-credit-refund:${row.creditGrantId}:${row.attempt}:refund`,
-    },
+      { idempotencyKey: args.idempotencyKey },
+    ),
+  );
+  if (result.ok) {
+    return result.value;
+  }
+  if (stripeErrorInfo(result.error)?.code !== "charge_already_refunded") {
+    throw result.error;
+  }
+  return await reconcileAlreadyRefundedCharge(
+    db,
+    stripe,
+    row,
+    args.paymentIntentId,
+    args.amountCents,
   );
 }
 


### PR DESCRIPTION
When Stripe returns `charge_already_refunded`, usage-pack reconciliation currently leaves the local row processing and retries every billing sweep. Reconcile the existing payment-intent refunds instead: only a unique successful refund with the exact amount and grant, organization, user, and purpose metadata is accepted. Invoice refunds then continue through credit-note reconciliation; unverified or ambiguous matches enter a terminal state requiring manual recovery.

The change preserves the existing creation idempotency keys and keeps temporary lookup failures retryable. Existing pending/processing rows are handled by normal reconciliation after deployment; no schema migration is required.

Fixes #32132.

Validation passed: formatting, API lint, API type checks, API Knip, and 9 focused API integration cases. The cases cover invoice and PaymentIntent recovery, pagination, repeated processing, mismatched amount/ownership/status, ambiguous matches, temporary lookup failure, and the existing removal/in-flight refund paths. Full Vitest is left to the PR pipeline.

Production verification: the MaskDB production gateway does not expose `usage_pack_credit_refunds`, and Axiom raw querying is denied in this session. No production records or Stripe payments were changed. Deployment verification must check remaining processing rows and any `stripe_charge_already_refunded_*` manual-recovery outcomes.
