### PR TITLE
fix(ci): sync catalog after production api deploy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1352,6 +1352,50 @@ jobs:
           skip-finish: "true"
           skip-setup: "true"
 
+      - name: Reconcile production connector catalog (best effort)
+        shell: bash
+        env:
+          API_DEPLOYMENT_URL: ${{ steps.deploy.outputs.url }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if ! response=$(vercel curl /api/cron/sync-connector-catalog \
+            --deployment "$API_DEPLOYMENT_URL" \
+            --token "$VERCEL_TOKEN" \
+            -- \
+            --fail-with-body \
+            --show-error \
+            --silent \
+            --max-time 120 \
+            --header "Authorization: Bearer ${CRON_SECRET}"); then
+            echo "::warning::Connector catalog reconcile request failed; the scheduled cron will retry"
+            exit 0
+          fi
+
+          if ! summary=$(jq -c '{
+            outcome,
+            hasActive: (.active != null),
+            lastAttemptOutcome: .lastAttempt.outcome,
+            filtering: {
+              stale: .filtering.stale,
+              filteredAuthMethodCount: (.filtering.filteredAuthMethods | length)
+            }
+          }' <<< "$response"); then
+            echo "::warning::Connector catalog reconcile returned invalid JSON; the scheduled cron will retry"
+            exit 0
+          fi
+
+          echo "Connector catalog reconcile: ${summary}"
+          if ! jq -e '
+            .state == "current"
+            and .active != null
+            and .filtering.stale == false
+          ' <<< "$response" >/dev/null; then
+            echo "::warning::Connector catalog is not ready; the scheduled cron will retry"
+          fi
+
       - name: Resolve Vercel dashboard URL
         id: vercel-dashboard
         if: ${{ steps.deploy.outputs.url != '' }}

--- a/turbo/apps/api/src/__tests__/release-please-config.test.ts
+++ b/turbo/apps/api/src/__tests__/release-please-config.test.ts
@@ -325,6 +325,82 @@ describe("release-please API deployment graph", () => {
     expect(promoteApiProductionJob).toContain('skip-setup: "true"');
   });
 
+  it("reconciles the connector catalog immediately after API deployment", () => {
+    const workflow = readText(".github/workflows/release-please.yml");
+    const promoteApiProductionJob = workflowJobBlock(
+      workflow,
+      "promote-api-production",
+    );
+    const deployStep = promoteApiProductionJob.indexOf(
+      "- name: Deploy API Production",
+    );
+    const reconcileStep = promoteApiProductionJob.indexOf(
+      "- name: Reconcile production connector catalog (best effort)",
+    );
+    const finishStep = promoteApiProductionJob.indexOf(
+      "- name: Finish GitHub Deployment",
+    );
+
+    expect(deployStep).toBeGreaterThan(-1);
+    expect(reconcileStep).toBeGreaterThan(deployStep);
+    expect(finishStep).toBeGreaterThan(reconcileStep);
+    expect(promoteApiProductionJob).not.toContain(
+      "- name: Verify production App and API domains",
+    );
+    expect(promoteApiProductionJob).not.toContain(
+      "- name: Check staged API health",
+    );
+    expect(promoteApiProductionJob).not.toContain(
+      "- name: Promote API Production",
+    );
+
+    const deployBlock = promoteApiProductionJob.slice(
+      deployStep,
+      reconcileStep,
+    );
+    expect(deployBlock).not.toContain('skip-domain: "true"');
+    expect(deployBlock.match(/- name:/g)).toHaveLength(1);
+    expect(promoteApiProductionJob).not.toContain(
+      "uses: ./.github/actions/vercel-promote",
+    );
+
+    const reconcileBlock = promoteApiProductionJob.slice(
+      reconcileStep,
+      finishStep,
+    );
+    expect(reconcileBlock).toContain("shell: bash");
+    expect(reconcileBlock).toContain(
+      `API_DEPLOYMENT_URL: \${{ steps.deploy.outputs.url }}`,
+    );
+    expect(reconcileBlock).toContain(
+      "vercel curl /api/cron/sync-connector-catalog",
+    );
+    expect(reconcileBlock).toContain('--deployment "$API_DEPLOYMENT_URL"');
+    expect(reconcileBlock).toContain(
+      `--header "Authorization: Bearer \${CRON_SECRET}"`,
+    );
+    expect(reconcileBlock).not.toContain("for attempt in");
+    expect(reconcileBlock).not.toContain("sleep ");
+    expect(reconcileBlock).not.toContain("exit 1");
+    expect(reconcileBlock).toContain("::warning::");
+    expect(reconcileBlock).toContain("the scheduled cron will retry");
+    expect(reconcileBlock).toContain("--max-time 120");
+    expect(reconcileBlock).toContain("hasActive: (.active != null)");
+    expect(reconcileBlock).toContain(
+      "lastAttemptOutcome: .lastAttempt.outcome",
+    );
+    expect(reconcileBlock).toContain("stale: .filtering.stale");
+    expect(reconcileBlock).toContain(
+      "filteredAuthMethodCount: (.filtering.filteredAuthMethods | length)",
+    );
+    expect(reconcileBlock).not.toContain("capabilityDigest:");
+    expect(reconcileBlock).not.toContain("catalogVersion:");
+    expect(reconcileBlock).not.toContain("catalogDigest:");
+    expect(reconcileBlock).toContain('.state == "current"');
+    expect(reconcileBlock).toContain(".active != null");
+    expect(reconcileBlock).toContain(".filtering.stale == false");
+  });
+
   it("keeps Vercel setup enabled for other deployment callers", () => {
     const action = readText(".github/actions/vercel-deploy/action.yml");
     const skipSetupInputStart = action.indexOf("  skip-setup:\n");


### PR DESCRIPTION
## Summary

- make one best-effort connector catalog reconciliation call immediately after production API deployment
- target the exact deployment URL instead of waiting for the mutable production cron path
- warn on request, response, or readiness problems without failing the release
- cover immediate ordering and non-blocking behavior without changing production traffic switching

## Behavior

The production API release now follows:

`deploy production → best-effort reconcile current catalog → finish deployment`

A valid response is summarized with fixed low-cardinality fields and checked for current, active, non-stale state. Request failure, invalid JSON, or a non-ready result emits a warning and the release continues. The existing once-per-minute cron remains the recovery path.

## Compatibility

- no `skip-domain` input and no new release `vercel-promote` step
- no release retry loop or sleep
- no connector catalog schema, source identity, reader fallback, API response, or runtime changes
- generation-specific snapshots continue to coexist by `sourceId`
- no preview workflow refactor and no restoration of post-deploy domain verification removed by #31215

## Validation

- `pnpm exec prettier --check ../.github/workflows/release-please.yml apps/api/src/__tests__/release-please-config.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm -F api exec vitest run src/__tests__/release-please-config.test.ts`
- `git diff --check`

Closes #32122
