### PR TITLE
fix(platform): handle expected client failures and unsupported browsers

### DIFF
--- a/turbo/apps/platform/scripts/check-localized-ui.mjs
+++ b/turbo/apps/platform/scripts/check-localized-ui.mjs
@@ -266,7 +266,7 @@ function getLocaleIndependentShellAllowedLiterals() {
       "locale-independent accessibility label for the copy-free app skeleton",
     ],
     [
-      "src/views/unsupported-browser-page.tsx\u0000Update your browser to continue",
+      "src/views/unsupported-browser-page.tsx\u0000Use a supported browser to continue",
       "English-only browser compatibility shell outside localized app bootstrap",
     ],
     [
@@ -287,6 +287,10 @@ function getLocaleIndependentShellAllowedLiterals() {
     ],
     [
       "src/views/unsupported-browser-page.tsx\u0000does not support your current browser version. Update your browser to continue.",
+      "English-only browser compatibility shell outside localized app bootstrap",
+    ],
+    [
+      "src/views/unsupported-browser-page.tsx\u0000does not support this browser on your device. Update your browser, or try another browser or device.",
       "English-only browser compatibility shell outside localized app bootstrap",
     ],
   ];

--- a/turbo/apps/platform/src/__tests__/platform-entrypoint.test.ts
+++ b/turbo/apps/platform/src/__tests__/platform-entrypoint.test.ts
@@ -1,4 +1,4 @@
-import { waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { startPlatformEntrypoint } from "../lib/platform-entrypoint.ts";
@@ -25,7 +25,7 @@ async function stopApplication(): Promise<void> {
 }
 
 describe("platform entrypoint", () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     googleAdsRequestedAfterApplicationStart = false;
     context.mocks.browser.url("https://app.vm0.ai/");
     context.mocks.clerk();
@@ -51,14 +51,53 @@ describe("platform entrypoint", () => {
         return appendChild(node);
       },
     );
-
-    startPlatformEntrypoint();
-    await waitForApplicationStart();
   });
 
   afterEach(stopApplication);
 
-  it("starts the application before requesting Google Ads", () => {
+  it("starts the application before requesting Google Ads", async () => {
+    context.mocks.browser.userAgent(
+      "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Mobile Safari/537.36",
+    );
+    vi.stubGlobal("SharedWorker", class extends EventTarget {});
+    startPlatformEntrypoint();
+    await waitForApplicationStart();
     expect(googleAdsRequestedAfterApplicationStart).toBeTruthy();
+    expect(
+      screen.queryByRole("heading", { name: /browser to continue/ }),
+    ).toBeNull();
+  });
+
+  it.each([138, 142, 143])(
+    "shows browser guidance before bootstrap on Android Chrome %s without SharedWorker",
+    async (version) => {
+      context.mocks.browser.userAgent(
+        `Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${version}.0.0.0 Mobile Safari/537.36`,
+      );
+      vi.stubGlobal("SharedWorker", undefined);
+      startPlatformEntrypoint();
+      await expect(
+        screen.findByRole("heading", {
+          name: "Use a supported browser to continue",
+        }),
+      ).resolves.toBeVisible();
+      expect(
+        document.querySelector('a[href="https://www.google.com/chrome/"]'),
+      ).toBeVisible();
+      expect(context.mocks.sentry().initializations).toHaveLength(0);
+      expect(context.mocks.sentry().reports).toHaveLength(0);
+    },
+  );
+
+  it("keeps version upgrade guidance for an older browser with SharedWorker", async () => {
+    context.mocks.browser.userAgent(
+      "Mozilla/5.0 Chrome/110.0.0.0 Safari/537.36",
+    );
+    vi.stubGlobal("SharedWorker", class extends EventTarget {});
+    startPlatformEntrypoint();
+    await expect(
+      screen.findByRole("heading", { name: "Update Chrome to continue" }),
+    ).resolves.toBeVisible();
+    expect(context.mocks.sentry().initializations).toHaveLength(0);
   });
 });

--- a/turbo/apps/platform/src/lib/__tests__/sentry-reporting.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/sentry-reporting.test.ts
@@ -1,0 +1,172 @@
+import type { BrowserOptions, ErrorEvent } from "@sentry/browser";
+import { expect, test } from "vitest";
+
+import { testContext } from "../../signals/__tests__/test-helpers.ts";
+import { SharedDatabaseHttpError } from "../../shared-database/http-error.ts";
+import {
+  deserializeSharedDatabaseError,
+  serializeSharedDatabaseError,
+} from "../../shared-database/protocol.ts";
+import { initSharedDatabaseWorkerSentry } from "../../shared-database/worker-sentry.ts";
+import { ApiError } from "../api-error.ts";
+import { captureSentryLogError } from "../sentry-config.ts";
+import { initSentry } from "../sentry.ts";
+
+const context = testContext();
+const SAFARI_PERMISSION_MESSAGE =
+  "The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.";
+const WEBKIT_MEDIA_MESSAGE =
+  "this.mediaController.media.addEventListener is not a function";
+const WEBKIT_SAFARI_MESSAGE = `${WEBKIT_MEDIA_MESSAGE}. (In 'this.mediaController.media.addEventListener(eventType,this,true)', 'this.mediaController.media.addEventListener' is undefined)`;
+
+// Exercise the SDK hooks installed by the production page/worker entrypoints.
+// The external Sentry mock records capture attempts; beforeSend owns delivery.
+function startSentry(
+  runtime: "page" | "shared-worker",
+): NonNullable<BrowserOptions["beforeSend"]> {
+  const sentry = context.mocks.sentry();
+  if (runtime === "page") {
+    initSentry();
+  } else {
+    initSharedDatabaseWorkerSentry();
+  }
+  const beforeSend = sentry.initializations.at(-1)?.options?.beforeSend;
+  if (!beforeSend) {
+    throw new Error("Expected the production Sentry delivery hook");
+  }
+  return beforeSend;
+}
+
+test.each(["page", "shared-worker"] as const)(
+  "filters expected raw and wrapped captures in %s",
+  async (runtime) => {
+    const beforeSend = startSentry(runtime);
+    const expected = [
+      new Error("Connection to server unavailable"),
+      new Error("Channel attach timed out"),
+      new DOMException("Permission denied by system", "NotAllowedError"),
+      new DOMException(SAFARI_PERMISSION_MESSAGE, "NotAllowedError"),
+      new Error("NotAllowedError: Permission denied by system"),
+      new TypeError(WEBKIT_MEDIA_MESSAGE),
+      new TypeError(WEBKIT_SAFARI_MESSAGE),
+      new SharedDatabaseHttpError(401),
+      new SharedDatabaseHttpError(426),
+      new ApiError("Unauthorized", "UNAUTHORIZED", 401),
+      new ApiError("Client update required", "CLIENT_UPGRADE_REQUIRED", 426),
+    ];
+    for (const error of expected) {
+      const transferred = deserializeSharedDatabaseError(
+        serializeSharedDatabaseError(error),
+      );
+      for (const captured of [
+        error,
+        transferred,
+        new Error("Voice draft recording failed", {
+          cause: new Error("Operation failed", { cause: transferred }),
+        }),
+      ]) {
+        captureSentryLogError("ExpectedFailure", [
+          "Operation failed",
+          captured,
+        ]);
+        const report = context.mocks.sentry().reports.at(-1);
+        expect(report).toMatchObject({ type: "exception", error: captured });
+        const event: ErrorEvent = {
+          type: undefined,
+          exception: { values: [{ type: "Error", value: "Operation failed" }] },
+        };
+        await expect(
+          Promise.resolve(beforeSend(event, { originalException: captured })),
+        ).resolves.toBeNull();
+      }
+    }
+  },
+);
+
+test.each(["page", "shared-worker"] as const)(
+  "filters native and linked exceptions without an original object in %s",
+  async (runtime) => {
+    const beforeSend = startSentry(runtime);
+    for (const exception of [
+      { type: "Error", value: "Connection to server unavailable" },
+      { type: "Error", value: "Channel attach timed out" },
+      { type: "NotAllowedError", value: SAFARI_PERMISSION_MESSAGE },
+      { type: "Error", value: "NotAllowedError: Permission denied by system" },
+      { type: "TypeError", value: WEBKIT_MEDIA_MESSAGE },
+      { type: "TypeError", value: WEBKIT_SAFARI_MESSAGE },
+    ]) {
+      const event: ErrorEvent = {
+        type: undefined,
+        exception: {
+          values: [
+            exception,
+            { type: "Error", value: "Voice draft recording failed" },
+          ],
+        },
+      };
+      await expect(Promise.resolve(beforeSend(event, {}))).resolves.toBeNull();
+    }
+  },
+);
+
+test.each(["page", "shared-worker"] as const)(
+  "preserves unexpected failures in %s",
+  async (runtime) => {
+    const beforeSend = startSentry(runtime);
+    for (const error of [
+      new Error("Voice draft recording failed", {
+        cause: new Error("Storage write failed"),
+      }),
+      new DOMException("Recorder failed", "NotReadableError"),
+      new Error("Transcription failed"),
+      new Error("Ably subscription callback failed"),
+      new Error("Channel attach timed out while running application code"),
+      new TypeError("audio.addEventListener is not a function"),
+      new Error("Unexpected Chat Event schema version null"),
+      new SharedDatabaseHttpError(500),
+      new ApiError("Internal server error", "INTERNAL_SERVER_ERROR", 500),
+      deserializeSharedDatabaseError(
+        serializeSharedDatabaseError(
+          new ApiError("Internal server error", "INTERNAL_SERVER_ERROR", 500),
+        ),
+      ),
+      deserializeSharedDatabaseError(
+        serializeSharedDatabaseError(new SharedDatabaseHttpError(500)),
+      ),
+    ]) {
+      const event: ErrorEvent = {
+        type: undefined,
+        exception: { values: [{ type: error.name, value: error.message }] },
+      };
+      await expect(
+        Promise.resolve(
+          beforeSend(event, {
+            originalException: new Error("Operation failed", { cause: error }),
+          }),
+        ),
+      ).resolves.toBe(event);
+      await expect(Promise.resolve(beforeSend(event, {}))).resolves.toBe(event);
+    }
+    const event: ErrorEvent = {
+      type: undefined,
+      contexts: { response: { status_code: 500 } },
+    };
+    await expect(Promise.resolve(beforeSend(event, {}))).resolves.toBe(event);
+    await expect(
+      Promise.resolve(
+        beforeSend(
+          { type: undefined, contexts: { response: { status_code: 401 } } },
+          {},
+        ),
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      Promise.resolve(
+        beforeSend(
+          { type: undefined, contexts: { response: { status_code: 426 } } },
+          {},
+        ),
+      ),
+    ).resolves.toBeNull();
+  },
+);

--- a/turbo/apps/platform/src/lib/browser-support.ts
+++ b/turbo/apps/platform/src/lib/browser-support.ts
@@ -16,9 +16,7 @@ function supportsAppleVersion(match: RegExpExecArray): boolean {
   return major > 16 || (major === 16 && minor >= 4);
 }
 
-export function browserUpgradeForUserAgent(
-  userAgent: string,
-): BrowserUpgrade | null {
+function browserUpgradeForUserAgent(userAgent: string): BrowserUpgrade | null {
   const iosMatch = /\b(?:iPhone|iPad|iPod)\b.*\bOS (\d+)(?:_(\d+))?/.exec(
     userAgent,
   );
@@ -68,5 +66,19 @@ export function browserUpgradeForUserAgent(
         };
   }
 
+  return null;
+}
+
+export function browserUpgradeRequired(): BrowserUpgrade | null {
+  const versionUpgrade = browserUpgradeForUserAgent(navigator.userAgent);
+  if (versionUpgrade) {
+    return versionUpgrade;
+  }
+  if (typeof SharedWorker !== "function") {
+    return {
+      actionUrl: "https://www.google.com/chrome/",
+      target: "browser",
+    };
+  }
   return null;
 }

--- a/turbo/apps/platform/src/lib/platform-entrypoint.ts
+++ b/turbo/apps/platform/src/lib/platform-entrypoint.ts
@@ -1,6 +1,6 @@
 import "./preview-bypass-cookie-bootstrap.ts";
 import "./accept-browser.ts";
-import { browserUpgradeForUserAgent } from "./browser-support.ts";
+import { browserUpgradeRequired } from "./browser-support.ts";
 import { initGoogleAds } from "./google-ads.ts";
 import { initSentry } from "./sentry.ts";
 import { captureFirstSkeletonPaint, initPostHog } from "./posthog.ts";
@@ -79,7 +79,7 @@ function startApplication(): void {
 
 export function startPlatformEntrypoint(): void {
   window.__appBootstrapModuleReady = performance.now();
-  const browserUpgrade = browserUpgradeForUserAgent(navigator.userAgent);
+  const browserUpgrade = browserUpgradeRequired();
   if (browserUpgrade) {
     const rootElement = document.getElementById("root");
     if (!rootElement) {

--- a/turbo/apps/platform/src/lib/sentry-config.ts
+++ b/turbo/apps/platform/src/lib/sentry-config.ts
@@ -1,8 +1,10 @@
 import { isDesktopAuthFlow } from "./desktop-auth-flow.ts";
 import * as Sentry from "@sentry/browser";
 import type { BrowserOptions, Contexts, User } from "@sentry/browser";
+import { CLIENT_FORCE_UPGRADE_STATUS } from "@okouai/api-contracts/contracts/client-headers";
 
 import { setLogErrorHandler } from "../signals/log.ts";
+import { SharedDatabaseHttpError } from "../shared-database/http-error.ts";
 import { ApiError } from "./api-error.ts";
 import { resolvePlatformRuntimeConfig } from "./platform-host.ts";
 
@@ -34,6 +36,52 @@ export function sentryLogContext(
   context: SentryLoggerContext,
 ): SentryLogContextArgument {
   return { [SENTRY_LOG_CONTEXT]: context };
+}
+
+const EXPECTED_ERROR_MESSAGES: ReadonlySet<string> = new Set([
+  // Ably already owns reconnect, resubscribe, and catch-up.
+  "Connection to server unavailable",
+  "Channel attach timed out",
+  // Some browser/SDK paths stringify the original permission error.
+  "NotAllowedError: Permission denied",
+  "NotAllowedError: Permission denied by system",
+  "NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.",
+  // WebKit's native media controls, outside application recording code.
+  "this.mediaController.media.addEventListener is not a function",
+  "this.mediaController.media.addEventListener is not a function. (In 'this.mediaController.media.addEventListener(eventType,this,true)', 'this.mediaController.media.addEventListener' is undefined)",
+]);
+
+function isExpectedErrorDescription(
+  name: string | undefined,
+  message: string | undefined,
+): boolean {
+  return (
+    name === "NotAllowedError" ||
+    (message !== undefined && EXPECTED_ERROR_MESSAGES.has(message))
+  );
+}
+
+function isExpectedError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  while (
+    (error instanceof Error || error instanceof DOMException) &&
+    !seen.has(error)
+  ) {
+    seen.add(error);
+    if (
+      (error instanceof ApiError &&
+        error.status >= 400 &&
+        error.status < 500) ||
+      (error instanceof SharedDatabaseHttpError &&
+        (error.status === 401 ||
+          error.status === CLIENT_FORCE_UPGRADE_STATUS)) ||
+      isExpectedErrorDescription(error.name, error.message)
+    ) {
+      return true;
+    }
+    error = "cause" in error ? error.cause : undefined;
+  }
+  return false;
 }
 
 export function createPlatformSentryOptions(
@@ -90,10 +138,14 @@ export function createPlatformSentryOptions(
         return null;
       }
 
-      // ApiError thrown by accept() — surfaced through toast notifications and
-      // not actionable in Sentry.
-      const original = hint?.originalException;
-      if (original instanceof ApiError) {
+      // Preserve classification through logger wrappers and MessagePort errors.
+      if (
+        isExpectedError(hint?.originalException) ||
+        isExpectedErrorDescription(undefined, event.message) ||
+        event.exception?.values?.some((exception) => {
+          return isExpectedErrorDescription(exception.type, exception.value);
+        })
+      ) {
         return null;
       }
 
@@ -155,8 +207,8 @@ export function captureSentryLogError(
   const capturedArgs = args.filter((arg) => {
     return !isSentryLogContextArgument(arg);
   });
-  const error = capturedArgs.find((arg): arg is Error => {
-    return arg instanceof Error;
+  const error = capturedArgs.find((arg): arg is Error | DOMException => {
+    return arg instanceof Error || arg instanceof DOMException;
   });
   if (error) {
     Sentry.captureException(error, captureContext);

--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -11,6 +11,8 @@ import {
 } from "../../signals/__tests__/test-helpers.ts";
 import { createChildAbortController } from "../../signals/utils.ts";
 import { mockNow } from "../../lib/time.ts";
+import { ApiError } from "../../lib/api-error.ts";
+import { SharedDatabaseHttpError } from "../http-error.ts";
 import type {
   SharedDatabaseBridgeEvents,
   SharedDatabasePortLike,
@@ -188,6 +190,87 @@ function connectProtocolTransport(
     workerPort,
   };
 }
+
+test("preserve a rejected 401 through the port and allow a later query to succeed", async () => {
+  initializeWorker();
+  const { bridge } = connectProtocolTransport(context.signal);
+  await bridge.registerTab(context.signal);
+  let denied = true;
+  const key = dataKey(crypto.randomUUID());
+  const recoveredRow = row(key.threadId, 1);
+  context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
+    if (denied) {
+      return respond(401, {
+        error: { code: "UNAUTHORIZED", message: "Unauthorized" },
+      });
+    }
+    return respond(
+      200,
+      chatEventRowsResponse(
+        query.sinceSeqId === 0 ? [recoveredRow] : [],
+        query,
+      ),
+    );
+  });
+  const query = {
+    dataKey: key,
+    afterSeqId: null,
+    consistency: "catch-up",
+  } as const;
+  const failed = bridge.query(query, context.signal);
+  await expect(failed).rejects.toBeInstanceOf(SharedDatabaseHttpError);
+  await expect(failed).rejects.toMatchObject({ status: 401 });
+  denied = false;
+  await expect(bridge.query(query, context.signal)).resolves.toStrictEqual([
+    recoveredRow,
+  ]);
+});
+
+test.each([401, 426, 500])(
+  "preserve HTTP status %s on query errors across MessagePort",
+  async (status) => {
+    initializeWorker();
+    const { bridge } = connectProtocolTransport(context.signal);
+    await bridge.registerTab(context.signal);
+    context.mocks.http.get("*/api/chat-threads/snapshot", () => {
+      return Response.json(
+        { error: { code: "REQUEST_FAILED", message: "Request failed" } },
+        { status },
+      );
+    });
+    const failed = bridge.query(
+      {
+        dataKey: { kind: "chat-thread-event" },
+        afterSeqId: null,
+        consistency: "catch-up",
+      },
+      context.signal,
+    );
+    await expect(failed).rejects.toBeInstanceOf(SharedDatabaseHttpError);
+    await expect(failed).rejects.toMatchObject({ status });
+  },
+);
+
+test.each([401, 426])(
+  "preserve API error classification for computed HTTP %s across MessagePort",
+  async (status) => {
+    initializeWorker();
+    const { bridge } = connectProtocolTransport(context.signal);
+    await bridge.registerTab(context.signal);
+    context.mocks.http.get("*/api/indicators", () => {
+      return Response.json(
+        { error: { code: "REQUEST_FAILED", message: "Request failed" } },
+        { status },
+      );
+    });
+    const failed = bridge.getComputed("chat-thread-indicators");
+    await expect(failed).rejects.toBeInstanceOf(ApiError);
+    await expect(failed).rejects.toMatchObject({
+      status,
+      code: "REQUEST_FAILED",
+    });
+  },
+);
 
 test("Keep concurrent shared chat loads independent", async () => {
   initializeWorker();

--- a/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
@@ -137,6 +137,12 @@ function startRuntime(
       getVercelProtectionBypass: () => {
         return vercelProtectionBypass;
       },
+      onForceUpgrade: () => {
+        events.push({
+          type: "worker-unavailable",
+          reason: "force-upgrade-required",
+        });
+      },
     });
   };
   const runtime = new SharedDatabaseWorkerRuntime(
@@ -159,6 +165,101 @@ async function queryRuntime<TKey extends SharedDatabaseDataKey>(
 ): Promise<SharedDatabaseQueryResult<TKey>> {
   return await runtime.query(query, signal);
 }
+
+test.each(["catch-up", "rows", "snapshot"] as const)(
+  "treat a headerless 426 from %s as an upgrade request",
+  async (operation) => {
+    const { runtime, events } = startRuntime();
+    const response = () => {
+      return Response.json(
+        {
+          error: {
+            code: "CLIENT_UPGRADE_REQUIRED",
+            message: "Client update required",
+          },
+        },
+        { status: 426 },
+      );
+    };
+    const threadId = crypto.randomUUID();
+    if (operation === "catch-up") {
+      context.mocks.http.post("*/api/chat/events/catch-up", response);
+    } else {
+      context.mocks.http.get(
+        operation === "rows"
+          ? "*/api/chat-threads/:threadId/event-rows"
+          : "*/api/chat-threads/:threadId/event-snapshot",
+        response,
+      );
+    }
+    const request =
+      operation === "catch-up"
+        ? runtime.catchUpChatEvents([threadId], context.signal)
+        : runtime.query(
+            {
+              dataKey: chatEventKey(threadId),
+              afterSeqId: null,
+              consistency: "catch-up",
+            },
+            context.signal,
+          );
+    await expect(request).rejects.toMatchObject({
+      name: "SharedDatabaseHttpError",
+      status: 426,
+    });
+    expect(events).toContainEqual({
+      type: "worker-unavailable",
+      reason: "force-upgrade-required",
+    });
+  },
+);
+
+test.each(["catch-up", "rows", "snapshot"] as const)(
+  "still reject a successful %s response missing the schema header",
+  async (operation) => {
+    const { runtime, events } = startRuntime();
+    const threadId = crypto.randomUUID();
+    if (operation === "catch-up") {
+      context.mocks.http.post("*/api/chat/events/catch-up", () => {
+        return Response.json({
+          events: { [threadId]: [] },
+          notFoundThreads: [],
+        });
+      });
+    } else if (operation === "rows") {
+      context.mocks.http.get("*/api/chat-threads/:threadId/event-rows", () => {
+        return Response.json(chatEventRowsResponse([], { sinceSeqId: 0 }));
+      });
+    } else {
+      context.mocks.http.get(
+        "*/api/chat-threads/:threadId/event-snapshot",
+        () => {
+          return Response.json({
+            url: SNAPSHOT_URL,
+            lastEventId: null,
+            lastSeqId: 0,
+            expiresInSeconds: 3600,
+          });
+        },
+      );
+    }
+    const request =
+      operation === "catch-up"
+        ? runtime.catchUpChatEvents([threadId], context.signal)
+        : runtime.query(
+            {
+              dataKey: chatEventKey(threadId),
+              afterSeqId: null,
+              consistency: "catch-up",
+            },
+            context.signal,
+          );
+    await expect(request).rejects.toThrow(
+      "Unexpected Chat Event schema version null",
+    );
+    expect(events).toStrictEqual([]);
+  },
+);
 
 test("Keep cached chat data isolated by user and workspace", async () => {
   const firstIdentity = identity();

--- a/turbo/apps/platform/src/shared-database/http-error.ts
+++ b/turbo/apps/platform/src/shared-database/http-error.ts
@@ -1,0 +1,6 @@
+export class SharedDatabaseHttpError extends Error {
+  constructor(readonly status: number) {
+    super(`Shared database request failed with status ${status}`);
+    this.name = "SharedDatabaseHttpError";
+  }
+}

--- a/turbo/apps/platform/src/shared-database/protocol.ts
+++ b/turbo/apps/platform/src/shared-database/protocol.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { ApiError } from "../lib/api-error.ts";
+import { SharedDatabaseHttpError } from "./http-error.ts";
 import { computedKeySchema } from "./computed-key.ts";
 import {
   sharedDatabaseDataKeySchema,
@@ -6,6 +8,17 @@ import {
 } from "./data-key.ts";
 
 const requestIdSchema = z.string().min(1);
+
+const sharedDatabaseErrorSchema = z
+  .object({
+    name: z.string(),
+    message: z.string(),
+    status: z.number().int().optional(),
+    code: z.string().optional(),
+  })
+  .strict();
+
+type SerializedSharedDatabaseError = z.infer<typeof sharedDatabaseErrorSchema>;
 
 const registerTabMessageSchema = z
   .object({ type: z.literal("register-tab") })
@@ -39,12 +52,7 @@ const tokenErrorMessageSchema = z
   .object({
     type: z.literal("token-error"),
     requestId: requestIdSchema,
-    error: z
-      .object({
-        name: z.string(),
-        message: z.string(),
-      })
-      .strict(),
+    error: sharedDatabaseErrorSchema,
   })
   .strict();
 
@@ -81,20 +89,39 @@ export function redactSharedDatabaseClientMessageForLog(
   return { ...message, token: "[redacted]" };
 }
 
-export function serializeSharedDatabaseError(error: unknown): {
-  readonly name: string;
-  readonly message: string;
-} {
+export function serializeSharedDatabaseError(
+  error: unknown,
+): SerializedSharedDatabaseError {
+  if (error instanceof ApiError) {
+    return {
+      name: error.name,
+      message: error.message,
+      status: error.status,
+      code: error.code,
+    };
+  }
+  if (error instanceof SharedDatabaseHttpError) {
+    return { name: error.name, message: error.message, status: error.status };
+  }
   if (error instanceof Error || error instanceof DOMException) {
     return { name: error.name, message: error.message };
   }
   return { name: Error.name, message: String(error) };
 }
 
-export function deserializeSharedDatabaseError(error: {
-  readonly name: string;
-  readonly message: string;
-}): Error {
+export function deserializeSharedDatabaseError(
+  error: SerializedSharedDatabaseError,
+): Error {
+  if (error.name === "SharedDatabaseHttpError" && error.status !== undefined) {
+    return new SharedDatabaseHttpError(error.status);
+  }
+  if (
+    error.name === "ApiError" &&
+    error.status !== undefined &&
+    error.code !== undefined
+  ) {
+    return new ApiError(error.message, error.code, error.status);
+  }
   const result = new Error(error.message);
   result.name = error.name;
   return result;
@@ -112,12 +139,7 @@ const errorMessageSchema = z
   .object({
     type: z.literal("error"),
     requestId: requestIdSchema,
-    error: z
-      .object({
-        name: z.string(),
-        message: z.string(),
-      })
-      .strict(),
+    error: sharedDatabaseErrorSchema,
   })
   .strict();
 

--- a/turbo/apps/platform/src/shared-database/worker-runtime.ts
+++ b/turbo/apps/platform/src/shared-database/worker-runtime.ts
@@ -8,6 +8,7 @@ import {
   type ChatEventRow,
 } from "@okouai/api-contracts/contracts/chat-event-rows";
 import type { ChatEventCursor } from "@okouai/api-contracts/contracts/chat-event-schema-version";
+import { CLIENT_FORCE_UPGRADE_STATUS } from "@okouai/api-contracts/contracts/client-headers";
 import type {
   AppRouter,
   InitClientArgs,
@@ -50,6 +51,7 @@ import {
   CHAT_EVENT_SCHEMA_VERSION_HEADERS,
 } from "./chat-event-schema-version.ts";
 import type { SharedDatabaseWorkerMessage } from "./protocol.ts";
+import { SharedDatabaseHttpError } from "./http-error.ts";
 type SharedDatabaseContractClient<TContract extends AppRouter> =
   InitClientReturn<TContract, InitClientArgs>;
 
@@ -125,13 +127,6 @@ interface SharedDatabaseWorkerRuntimeOptions {
   readonly identity: SharedDatabaseIdentity;
   readonly emit: (message: WorkerRuntimeEvent) => void;
   readonly createContractClient: ApiClientFactory;
-}
-
-class SharedDatabaseHttpError extends Error {
-  constructor(readonly status: number) {
-    super(`Shared database request failed with status ${status}`);
-    this.name = "SharedDatabaseHttpError";
-  }
 }
 
 class ChatThreadNotFoundError extends Error {
@@ -372,7 +367,10 @@ export class SharedDatabaseWorkerRuntime {
       fetchOptions: { signal },
     });
     signal.throwIfAborted();
-    if (response.status === 401) {
+    if (
+      response.status === 401 ||
+      response.status === CLIENT_FORCE_UPGRADE_STATUS
+    ) {
       throw new SharedDatabaseHttpError(response.status);
     }
     assertChatEventSchemaVersion(response.headers);
@@ -745,7 +743,7 @@ export class SharedDatabaseWorkerRuntime {
         fetchOptions: { signal },
       });
       signal.throwIfAborted();
-      if (page.status === 401) {
+      if (page.status === 401 || page.status === CLIENT_FORCE_UPGRADE_STATUS) {
         throw new SharedDatabaseHttpError(page.status);
       }
       assertChatEventSchemaVersion(page.headers);
@@ -799,7 +797,10 @@ export class SharedDatabaseWorkerRuntime {
       fetchOptions: { signal },
     });
     signal.throwIfAborted();
-    if (snapshot.status === 401) {
+    if (
+      snapshot.status === 401 ||
+      snapshot.status === CLIENT_FORCE_UPGRADE_STATUS
+    ) {
       throw new SharedDatabaseHttpError(snapshot.status);
     }
     assertChatEventSchemaVersion(snapshot.headers);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-expected-failures.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-expected-failures.test.tsx
@@ -1,0 +1,114 @@
+import { voiceIoQuotaContract } from "@okouai/api-contracts/contracts/voice-io-quota";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { screen } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
+
+import { click, fill, setupPage } from "../../../__tests__/page-helper.ts";
+import { initSentry } from "../../../lib/sentry.ts";
+import {
+  context,
+  findEnabledButton,
+  installRunChat,
+  RUN_PATH,
+} from "./chat-run-test-fixtures.ts";
+
+test.each(["direct", "message-port"] as const)(
+  "show the upgrade dialog for headerless event-row 426 using %s transport",
+  async (transport) => {
+    installRunChat();
+    context.mocks.http.get("*/api/chat-threads/:threadId/event-rows", () => {
+      return Response.json(
+        {
+          error: {
+            code: "CLIENT_UPGRADE_REQUIRED",
+            message: "Client update required",
+          },
+        },
+        { status: 426 },
+      );
+    });
+    await setupPage({
+      context,
+      path: RUN_PATH,
+      sharedWorkerTestTransport: transport,
+    });
+    await expect(
+      screen.findByRole("dialog", { name: "Update required" }),
+    ).resolves.toBeVisible();
+    await expect(findEnabledButton("Refresh")).resolves.toBeVisible();
+  },
+);
+
+test.each([false, true])(
+  "keep microphone guidance and retry after permission denial with voice drafts %s",
+  async (voiceDrafts) => {
+    installRunChat();
+    context.mocks.api(voiceIoQuotaContract.get, ({ respond }) => {
+      return respond(200, { allowed: true, count: 0, limit: 60 });
+    });
+    context.mocks.browser.voiceInput({ rms: 0.12 });
+    const denied = new DOMException(
+      "Permission denied by system",
+      "NotAllowedError",
+    );
+    vi.spyOn(navigator.mediaDevices, "getUserMedia").mockRejectedValueOnce(
+      denied,
+    );
+    const consoleErrors: unknown[][] = [];
+    const consoleError = vi.spyOn(console, "error");
+    const original = consoleError.getMockImplementation();
+    if (!original) {
+      throw new Error("Expected the shared console error guard");
+    }
+    consoleError.mockImplementation((...args: unknown[]) => {
+      if (args.includes(denied)) {
+        consoleErrors.push(args);
+        return;
+      }
+      original(...args);
+    });
+    const sentry = context.mocks.sentry();
+    initSentry();
+    await setupPage({
+      context,
+      path: RUN_PATH,
+      featureSwitches: { [FeatureSwitchKey.VoiceInputV2]: voiceDrafts },
+    });
+    const composer = screen.getByRole("textbox", { name: "Message" });
+    await fill(composer, "Keep these notes.");
+    click(await findEnabledButton("Voice input"));
+    await expect(
+      screen.findByText(
+        "Microphone access was denied. Allow microphone access and try again.",
+      ),
+    ).resolves.toBeVisible();
+    const retry = await findEnabledButton("Voice input");
+    expect(composer).toHaveTextContent("Keep these notes.");
+    expect(consoleErrors).not.toHaveLength(0);
+    const report = sentry.reports.find((candidate) => {
+      return candidate.type === "exception" && candidate.error === denied;
+    });
+    expect(report).toBeDefined();
+    const beforeSend = sentry.initializations.at(-1)?.options?.beforeSend;
+    if (!beforeSend || report?.type !== "exception") {
+      throw new Error(
+        "Expected the microphone capture and Sentry delivery hook",
+      );
+    }
+    await expect(
+      Promise.resolve(
+        beforeSend(
+          {
+            type: undefined,
+            exception: {
+              values: [{ type: denied.name, value: denied.message }],
+            },
+          },
+          { originalException: report.error },
+        ),
+      ),
+    ).resolves.toBeNull();
+    click(retry);
+    await expect(findEnabledButton("Stop recording")).resolves.toBeVisible();
+  },
+);

--- a/turbo/apps/platform/src/views/unsupported-browser-page.tsx
+++ b/turbo/apps/platform/src/views/unsupported-browser-page.tsx
@@ -10,8 +10,8 @@ import { detach, Reason } from "../signals/utils.ts";
 
 const UPGRADE_COPY = {
   browser: {
-    action: "Update browser",
-    title: "Update your browser to continue",
+    action: "Get the latest Chrome",
+    title: "Use a supported browser to continue",
   },
   chrome: {
     action: "Update Chrome",
@@ -75,9 +75,9 @@ function UnsupportedBrowserPage({
           <h1 className="text-base leading-6 font-semibold">{copy.title}</h1>
           <p className="text-sm leading-[22px] text-muted-foreground">
             {assistantName}
-            {
-              " does not support your current browser version. Update your browser to continue."
-            }
+            {upgrade.target === "browser"
+              ? " does not support this browser on your device. Update your browser, or try another browser or device."
+              : " does not support your current browser version. Update your browser to continue."}
           </p>
         </div>
         <a


### PR DESCRIPTION
## Summary

Expected connectivity, permission, and client-version failures no longer produce Sentry errors. Existing reconnect, microphone guidance, request rejection, and user-controlled update flows continue to handle them. Browsers missing a required capability now reach the existing unsupported-browser page before application bootstrap.

- Filter the exact Ably connection-unavailable and attach-timeout messages, microphone `NotAllowedError` outcomes (including stringified and chained causes), and the observed WebKit media-controls error and Safari wording in the shared page/worker Sentry policy.
- Preserve HTTP status and API error codes across MessagePort serialization, so 401 and 426 remain classified after deserialization and outer error wrapping. Genuine application, recorder/storage/transcription, protocol, and 5xx failures remain reportable.
- Handle HTTP 426 before checking Chat Event schema headers in catch-up, row, and snapshot requests. Keep the existing force-upgrade notification and manual refresh dialog.
- Check actual `SharedWorker` availability alongside the existing browser version checks. Present ordinary update/browser/device guidance using the existing compatibility page, including its pre-bootstrap English-copy policy.

## Root cause correction for #32148

`assertChatEventSchemaVersion()` reads an HTTP response header. The API compatibility middleware returns HTTP 426 without that header. Checking the header before the status turned an intentional upgrade response into `Unexpected Chat Event schema version null`. The observed PLATFORM-AQ events followed event-row HTTP 426 responses. This change corrects the response handling order; successful responses with missing or incompatible schema headers still fail and remain reportable. No database migration is needed.

## Verification

- 47 focused Platform tests passed across Sentry delivery hooks, worker runtime, MessagePort, browser entrypoint, and chat page integration tests.
- Coverage includes rejected 401 followed by a successful later query; direct and MessagePort 426 upgrade dialogs; legacy and draft voice permission guidance and retry; raw/serialized/wrapped expected errors; and retained 500, protocol, recorder, storage, transcription, and unrelated TypeError reporting.
- Platform formatting, lint (including localized UI, build configuration, i18n, Oxlint, and ESLint), type checking, and Knip passed.
- Full verification is delegated to the PR pipeline, as requested; no full local Vitest suite or local dev server was run.

Closes #32140
Closes #32141
Closes #32145
Closes #32147
Closes #32148
Closes #32151
Closes #32152
