### PR TITLE
fix(workflows): preserve recurring schedules across insufficient credits

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
@@ -29,6 +29,7 @@ import {
 } from "./helpers/chat-event";
 import { seedOrgMembership$ } from "./helpers/org-membership";
 import { createRouteMocks } from "./helpers/route-test";
+import { seedBuiltInModelKey } from "./helpers/runtime-state";
 import { testWorkflowAutomationExecutionRoutes } from "../test-workflow-automation-execution";
 import { agentsRoutes } from "../agents";
 import { workflowAutomationsRoutes } from "../workflow-automations";
@@ -55,6 +56,8 @@ const WORKFLOW_NAME = "scheduler-workflow";
 
 interface Scenario {
   readonly actor: ApiTestUser;
+  readonly customerId: string;
+  readonly subscriptionId: string;
   readonly orgId: string;
   readonly userId: string;
   readonly agentId: string;
@@ -105,7 +108,7 @@ async function setup(
   } = {},
 ): Promise<Scenario> {
   const runnerGroup = runsApi.configureRunnerGroup();
-  const { actor } = await wf.setupWorkflowOrg({
+  const { actor, customerId, subscriptionId } = await wf.setupWorkflowOrg({
     timezone: options.timezone,
     tier: options.tier,
   });
@@ -123,6 +126,8 @@ async function setup(
   context.mocks.s3.send.mockResolvedValue({});
   return {
     actor,
+    customerId,
+    subscriptionId,
     orgId: actor.orgId,
     userId: actor.userId,
     agentId: agent.agentId,
@@ -248,6 +253,7 @@ async function completeRunThroughSandbox(
   scenario: Scenario,
   runId: string,
   exitCode: number,
+  failureReason?: "insufficient_credits",
 ): Promise<void> {
   await runsApi.heartbeatRunner(scenario.runnerGroup);
   const claim = await runsApi.claimRunnerJob(runId);
@@ -256,6 +262,12 @@ async function completeRunThroughSandbox(
     {
       runId,
       exitCode,
+      ...(failureReason
+        ? {
+            failureReason,
+            error: "Insufficient credits. Add credits to continue.",
+          }
+        : {}),
       checkpoint: {
         cliAgentType: "claude-code",
         cliAgentSessionId: `workflow-automation-cli-${runId}`,
@@ -759,6 +771,112 @@ describe("okou workflow automation scheduler", () => {
     );
     expect(replacementThreadId).not.toBe(firstThreadId);
     await disableAutomation(replacement.automationId);
+  });
+
+  it.each(["loop", "cron"] as const)(
+    "keeps a credit-blocked %s automation enabled and resumes after billing recovers",
+    async (scheduleType) => {
+      const scenario = await setup();
+      await seedBuiltInModelKey(context, "claude-sonnet-5");
+      await runsApi.updateOrgModelPolicies(scenario.actor, [
+        {
+          model: "claude-sonnet-5",
+          isDefault: true,
+          defaultProviderType: "built-in",
+          credentialScope: "org",
+          modelProviderId: null,
+        },
+      ]);
+      const created = await accept(
+        automationsClient().create({
+          headers: authHeaders(),
+          params: { workflowId: scenario.workflowId },
+          body: {
+            schedule:
+              scheduleType === "loop"
+                ? { type: "loop", intervalSeconds: 300 }
+                : {
+                    type: "cron",
+                    cronExpression: "*/5 * * * *",
+                    timezone: "UTC",
+                  },
+          },
+        }),
+        [201],
+      );
+      // Let the paid entitlement expire through the production time boundary.
+      mockNow(now() + 100 * 86_400_000);
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const threadId = await executeDueWorkflowAutomations(created.body.id);
+        await expect(workflowRunMessages(threadId)).resolves.toHaveLength(0);
+        const automation = await wf.readAutomation(created.body.id);
+        expect(automation.enabled).toBeTruthy();
+        if (!automation.nextRunAt) {
+          throw new Error("Expected a credit-blocked automation to recur");
+        }
+        expect(Date.parse(automation.nextRunAt)).toBeGreaterThan(now());
+        mockNow(Date.parse(automation.nextRunAt));
+      }
+
+      await runsApi.grantProEntitlement(scenario.actor, {
+        customerId: scenario.customerId,
+        subscriptionId: scenario.subscriptionId,
+      });
+      const threadId = await executeDueWorkflowAutomations(created.body.id);
+      const run = await onlyWorkflowRunMessage(threadId);
+      expect((await wf.readAutomation(created.body.id)).enabled).toBeTruthy();
+      await runsApi.requestCancelRun(scenario.actor, run.runId, [200]);
+      await disableAutomation(created.body.id);
+    },
+  );
+
+  it("keeps recurring after three runs stop for insufficient credits", async () => {
+    const scenario = await setup();
+    const automation = await createDueLoopAutomation(scenario, 300);
+    const seenRunIds = new Set<string>();
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const threadId = await executeDueWorkflowAutomations(
+        automation.automationId,
+      );
+      const run = (await workflowRunMessages(threadId)).find((message) => {
+        return !seenRunIds.has(message.runId);
+      });
+      if (!run) {
+        throw new Error("Expected a new scheduled run");
+      }
+      seenRunIds.add(run.runId);
+      await completeRunThroughSandbox(
+        scenario,
+        run.runId,
+        1,
+        "insufficient_credits",
+      );
+      await expect
+        .poll(async () => {
+          const read = await wf.readAutomation(automation.automationId);
+          return { enabled: read.enabled, nextRunAt: read.nextRunAt };
+        })
+        .toStrictEqual({ enabled: true, nextRunAt: expect.any(String) });
+      const read = await wf.readAutomation(automation.automationId);
+      if (!read.nextRunAt) {
+        throw new Error("Expected the next run after insufficient credits");
+      }
+      mockNow(Date.parse(read.nextRunAt));
+    }
+
+    const threadId = await executeDueWorkflowAutomations(
+      automation.automationId,
+    );
+    const messages = await workflowRunMessages(threadId);
+    expect(messages).toHaveLength(4);
+    const recovered = messages.find((message) => {
+      return !seenRunIds.has(message.runId);
+    });
+    if (!recovered) {
+      throw new Error("Expected the automation to recover on its next run");
+    }
+    await completeRunThroughSandbox(scenario, recovered.runId, 0);
+    await disableAutomation(automation.automationId);
   });
 
   it("auto-disables an automation after three consecutive failures", async () => {

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -250,6 +250,24 @@ function shouldSuppressFailureLog(
   return shouldSuppressKnownFailureLog(run, knownFailureReason.data);
 }
 
+function logRunFailure(
+  input: CompleteAgentRunInput,
+  commit: CompletionCommit,
+): void {
+  const isCreditError =
+    commit.transitionFailureReason === "insufficient_credits";
+  const logFailure = isCreditError ? L.debug : L.warn;
+  logFailure(
+    isCreditError ? "Run stopped: insufficient credits" : "Run failed",
+    {
+      runId: input.body.runId,
+      exitCode: input.body.exitCode,
+      error: commit.transitionError,
+      failureReason: commit.transitionFailureReason,
+    },
+  );
+}
+
 function checkpointInputForCompletion(
   input: CompleteAgentRunInput,
 ): AgentCheckpointInput | null {
@@ -993,12 +1011,7 @@ export const completeAgentRun$ = command(
       } else if (
         !shouldSuppressFailureLog(commit.run, commit.transitionFailureReason)
       ) {
-        L.warn("Run failed", {
-          runId: input.body.runId,
-          exitCode: input.body.exitCode,
-          error: commit.transitionError,
-          failureReason: commit.transitionFailureReason,
-        });
+        logRunFailure(input, commit);
       }
     } else if (
       commit.run.status === "completed" ||

--- a/turbo/apps/api/src/signals/services/workflow-automation-poller.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-poller.service.ts
@@ -194,14 +194,17 @@ async function recordPreRunFailure(
     error: failureMessage(error),
   };
   if (isCreditError) {
-    log.warn("Workflow automation skipped: insufficient credits", context);
+    log.debug("Workflow automation skipped: insufficient credits", context);
   } else {
     log.error("Workflow automation pre-run failed", context);
   }
 
   const failureTime = nowDate();
-  const newFailureCount = automation.consecutiveFailures + 1;
-  const shouldDisable = newFailureCount >= MAX_CONSECUTIVE_FAILURES;
+  const newFailureCount = isCreditError
+    ? automation.consecutiveFailures
+    : automation.consecutiveFailures + 1;
+  const shouldDisable =
+    !isCreditError && newFailureCount >= MAX_CONSECUTIVE_FAILURES;
   const nextRunAt = advanceAfterPreRunFailure(
     automation,
     failureTime,

--- a/turbo/apps/api/src/signals/services/workflow-automation-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-run-callback.service.ts
@@ -1,4 +1,5 @@
 import { command } from "ccstate";
+import { agentRuns } from "@okouai/db/schema/agent-run";
 import { workflowAutomations } from "@okouai/db/schema/workflow";
 import { and, eq } from "drizzle-orm";
 import { writeDb$, type Db } from "../external/db";
@@ -53,7 +54,8 @@ function parseWorkflowAutomationPayload(
  * Advance a workflow schedule automation after its run completes: cron advances to
  * the next occurrence from the completion time, loop by its interval; a
  * disabled automation (e.g. a claimed one-time automation) does not recur. Consecutive
- * failures auto-disable the automation after three. It is keyed on
+ * unexpected failures auto-disable the automation after three. Insufficient
+ * credits leave the schedule enabled for its next occurrence. It is keyed on
  * `workflow_automations`.
  */
 export async function handleWorkflowAutomationInternalCallback(
@@ -85,11 +87,27 @@ export async function handleWorkflowAutomationInternalCallback(
   }
 
   const completedAt = nowDate();
+  const [failedRun] =
+    input.callback.status === "failed"
+      ? await db
+          .select({ failureReason: agentRuns.failureReason })
+          .from(agentRuns)
+          .where(
+            and(
+              eq(agentRuns.id, input.callback.runId),
+              eq(agentRuns.orgId, automation.orgId),
+            ),
+          )
+          .limit(1)
+      : [];
+  signal?.throwIfAborted();
+  const isCreditError = failedRun?.failureReason === "insufficient_credits";
   const consecutiveFailures =
     input.callback.status === "completed"
       ? 0
-      : automation.consecutiveFailures + 1;
-  const shouldDisable = consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
+      : automation.consecutiveFailures + (isCreditError ? 0 : 1);
+  const shouldDisable =
+    !isCreditError && consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
   const nextRunAt = advanceTimeAutomationAfterCompletion({
     scheduleType: payload.kind,
     cronExpression:

--- a/turbo/apps/api/src/signals/services/workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-queue-drain.service.ts
@@ -298,7 +298,11 @@ async function handleWorkflowLaunchResult(
   if (!failed) {
     return null;
   }
-  log.warn("Workflow queue event rejected after run creation failure", {
+  const logRejection =
+    result.response.body.error.code === "INSUFFICIENT_CREDITS"
+      ? log.debug
+      : log.warn;
+  logRejection("Workflow queue event rejected after run creation failure", {
     eventId: event.id,
     chatThreadId: event.chatThreadId,
     code: result.response.body.error.code,


### PR DESCRIPTION
Recurring workflow automations count insufficient-credit admission rejections and runtime failures toward the three-failure auto-disable threshold. Once disabled, later billing recovery cannot start their next occurrence.

Exclude the structured insufficient-credit outcome from the failure counter in both the pre-run poller and run-completion callback, and keep advancing recurring schedules. Completed runs still reset the counter, while unexpected failures retain the existing three-failure limit. Poller, queue, and completion logs classify insufficient credits at debug level under the API logging convention; user-facing errors remain intact.

Fixes #32109.

The callback reads the existing persisted run failure reason, so no callback payload or database schema changes are needed. Explicitly disabled and one-time automations keep their existing semantics. Already-disabled historical rows are not automatically re-enabled because the stored enabled flag alone does not establish permission to resume them.

Validation passed: formatting, API lint, API type checks, API Knip, and 5 focused API integration cases. The cases cover cron/loop rejection across three insufficient-credit attempts followed by recovery through the Stripe invoice webhook, three runtime insufficient-credit failures followed by success, the existing three-unexpected-failures disable rule, and one-time schedule behavior. Full Vitest is left to the PR pipeline.

Read-only production check: no current disabled schedule rows with at least three consecutive failures were updated on or after the original review window start (`2026-09-03T16:00:00Z`). This does not reconstruct rows that were later re-enabled or deleted; no production schedules were modified.
