### PR TITLE
fix(runner): bound resumed idle workspace reclamation

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -928,7 +928,7 @@ async fn run_start_with_home(
         home: home.clone(),
         workspace_cache: Some(
             WorkspaceImageCache::shared(paths.clone(), &home, &group_name)
-                .with_session_history_sidecar_export_host_cpus(host_cpus),
+                .with_promotion_host_cpus(host_cpus),
         ),
     });
 

--- a/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
@@ -156,16 +156,29 @@ impl NetworkLogTestComponent {
             Self::Dns => install_controllable_dns(config).await,
         }
     }
+
+    fn set_reap_gate(self, config: &mut RunConfig, gate: crate::child_cleanup::ReapGate) {
+        match self {
+            Self::Kmsg => config.shutdown.kmsg_handle.set_reap_gate(gate),
+            Self::Dns => config.shutdown.dns_handle.set_reap_gate(gate),
+        }
+    }
 }
 
 async fn assert_network_log_eof_stops_runner(component: NetworkLogTestComponent) {
     let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let (stdin, pid, starttime) = component.install(&mut config).await;
+    let reap_gate = crate::child_cleanup::ReapGate::new();
+    component.set_reap_gate(&mut config, reap_gate.clone());
     env.handle.block_heartbeats();
     let run_handle = tokio::spawn(run(config));
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
     drop(stdin);
+
+    tokio::time::timeout(Duration::from_secs(2), reap_gate.entered.notified())
+        .await
+        .expect("EOF should start child cleanup");
 
     assert!(
         env.handle
@@ -178,26 +191,35 @@ async fn assert_network_log_eof_stops_runner(component: NetworkLogTestComponent)
         !run_handle.is_finished(),
         "blocked final heartbeat should hold teardown open",
     );
-    wait_for_child_cleanup(component.label(), pid, starttime).await;
     assert!(
         env.cancel.is_cancelled(),
         "{} EOF should stop discovery",
         component.label(),
     );
 
+    // Teardown can start while child cleanup is pending. Only run() joining
+    // the cleanup task guarantees that the process has been reaped.
+    reap_gate.release.add_permits(1);
     env.handle.unblock_heartbeats();
     assert_run_error_contains(run_handle, component.eof_error_prefix()).await;
+    assert_child_reaped(component.label(), pid, starttime).await;
 }
 
 async fn assert_network_log_read_error_stops_runner(component: NetworkLogTestComponent) {
     let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let (mut stdin, pid, starttime) = component.install(&mut config).await;
+    let reap_gate = crate::child_cleanup::ReapGate::new();
+    component.set_reap_gate(&mut config, reap_gate.clone());
     env.handle.block_heartbeats();
     let run_handle = tokio::spawn(run(config));
 
     wait_discover_entered(&env, Duration::from_secs(2)).await;
     stdin.write_all(&[0xff, b'\n']).await.unwrap();
     stdin.flush().await.unwrap();
+
+    tokio::time::timeout(Duration::from_secs(2), reap_gate.entered.notified())
+        .await
+        .expect("read error should start child cleanup");
 
     assert!(
         env.handle
@@ -206,15 +228,16 @@ async fn assert_network_log_read_error_stops_runner(component: NetworkLogTestCom
         "{} read error should drive runner teardown",
         component.label(),
     );
-    wait_for_child_cleanup(component.label(), pid, starttime).await;
     assert!(
         env.cancel.is_cancelled(),
         "{} read error should stop discovery",
         component.label(),
     );
 
+    reap_gate.release.add_permits(1);
     env.handle.unblock_heartbeats();
     assert_run_error_contains(run_handle, "ReadError").await;
+    assert_child_reaped(component.label(), pid, starttime).await;
 }
 
 async fn assert_normal_shutdown_reaps_network_log_child(component: NetworkLogTestComponent) {
@@ -234,7 +257,7 @@ async fn assert_normal_shutdown_reaps_network_log_child(component: NetworkLogTes
 }
 
 #[tokio::test]
-async fn kmsg_stdout_eof_stops_runner_and_reaps_child_before_teardown() {
+async fn kmsg_stdout_eof_stops_runner_and_reaps_child_before_exit() {
     assert_network_log_eof_stops_runner(NetworkLogTestComponent::Kmsg).await;
 }
 
@@ -249,7 +272,7 @@ async fn normal_shutdown_cancels_kmsg_and_reaps_child_without_error() {
 }
 
 #[tokio::test]
-async fn dns_stderr_eof_stops_runner_and_reaps_child_before_teardown() {
+async fn dns_stderr_eof_stops_runner_and_reaps_child_before_exit() {
     assert_network_log_eof_stops_runner(NetworkLogTestComponent::Dns).await;
 }
 
@@ -344,12 +367,7 @@ async fn required_monitor_failure_publishes_stopping_before_delayed_child_reap()
         let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let (mut stdin, pid, starttime) = component.install(&mut config).await;
         let gate = crate::child_cleanup::ReapGate::new();
-        match component {
-            NetworkLogTestComponent::Dns => config.shutdown.dns_handle.set_reap_gate(gate.clone()),
-            NetworkLogTestComponent::Kmsg => {
-                config.shutdown.kmsg_handle.set_reap_gate(gate.clone())
-            }
-        }
+        component.set_reap_gate(&mut config, gate.clone());
         let status_path = env._temp_dir.path().join("status.json");
         let run_handle = tokio::spawn(run(config));
         wait_discover_entered(&env, Duration::from_secs(2)).await;

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -523,6 +523,9 @@ pub enum ParkResult {
 mod destroy_tests;
 
 #[cfg(test)]
+mod reclamation_tests;
+
+#[cfg(test)]
 mod park_transition_tests;
 
 #[cfg(test)]

--- a/crates/runner/src/idle_pool/destroy_tests.rs
+++ b/crates/runner/src/idle_pool/destroy_tests.rs
@@ -21,7 +21,7 @@ async fn make_idle_destroy_payload(overrides: Arc<MockSandboxOverrides>) -> Idle
     make_idle_destroy_payload_for(SandboxId::new_v4(), overrides, None).await
 }
 
-async fn make_idle_destroy_payload_for(
+pub(super) async fn make_idle_destroy_payload_for(
     sandbox_id: SandboxId,
     overrides: Arc<MockSandboxOverrides>,
     workspace_promotion: Option<WorkspaceImagePromotionContext>,
@@ -59,7 +59,7 @@ async fn make_idle_destroy_job(
     make_idle_destroy_job_for(SandboxId::new_v4(), overrides, budget_lease, None).await
 }
 
-async fn make_idle_destroy_job_for(
+pub(super) async fn make_idle_destroy_job_for(
     sandbox_id: SandboxId,
     overrides: Arc<MockSandboxOverrides>,
     budget_lease: BudgetLease,

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -499,17 +499,31 @@ impl IdleDestroyPayload {
             factory,
             workspace_promotion,
         } = self.resources;
-        let prepared_promotion = match self.workspace_promotion_policy {
-            WorkspacePromotionPolicy::Promote => {
-                prepare_workspace_image_from_parked_sandbox(
-                    sandbox.as_mut(),
-                    workspace_promotion,
-                    context,
-                )
-                .await
+        // Waiting reclamation jobs must remain parked. The export-only gate is
+        // too late to bound resumed guests and their memory recovery work.
+        let mut reclamation_permit = None;
+        let prepared_promotion = match (self.workspace_promotion_policy, workspace_promotion) {
+            (WorkspacePromotionPolicy::Promote, Some(promotion)) => {
+                match promotion.acquire_idle_workspace_reclamation_permit().await {
+                    Ok(permit) => {
+                        reclamation_permit = Some(permit);
+                        prepare_workspace_image_from_parked_sandbox(
+                            sandbox.as_mut(),
+                            Some(promotion),
+                            context,
+                        )
+                        .await
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "idle workspace reclamation admission failed");
+                        abandon_unpublished_workspace_promotion(Some(promotion), context).await;
+                        None
+                    }
+                }
             }
-            WorkspacePromotionPolicy::AbandonUnpublished(reason) => {
-                abandon_unpublished_workspace_promotion(workspace_promotion, reason).await;
+            (WorkspacePromotionPolicy::Promote, None) => None,
+            (WorkspacePromotionPolicy::AbandonUnpublished(reason), promotion) => {
+                abandon_unpublished_workspace_promotion(promotion, reason).await;
                 None
             }
         };
@@ -526,6 +540,11 @@ impl IdleDestroyPayload {
                 false
             }
         };
+        if stopped {
+            // The guest is no longer running; host publication and destruction
+            // need not hold up the next parked sandbox's reclamation.
+            drop(reclamation_permit.take());
+        }
         let workspace_cache_promoted = match (prepared_promotion, stopped) {
             (Some(promotion), true) => promotion.publish().await,
             (Some(promotion), false) => {
@@ -542,6 +561,8 @@ impl IdleDestroyPayload {
             tracing::warn!("idle sandbox destroy panicked");
             uncertain = true;
         }
+        // A failed stop may leave the guest running until factory destruction.
+        drop(reclamation_permit);
         if uncertain {
             IdleDestroyResult {
                 outcome: DestroyOutcome::Uncertain,

--- a/crates/runner/src/idle_pool/reclamation_tests.rs
+++ b/crates/runner/src/idle_pool/reclamation_tests.rs
@@ -1,0 +1,404 @@
+use std::sync::Arc;
+use std::task::Poll;
+
+use guest_contracts::session_history_identity::{
+    SessionHistorySidecarExportMetadata, SessionHistorySidecarRepresentation,
+};
+use sandbox::{ExecResult, SandboxError, SandboxId};
+use sandbox_mock::{MockLifecycleGate, MockSandbox, MockSandboxOverrides};
+
+use super::destroy_tests::{make_idle_destroy_job_for, make_idle_destroy_payload_for};
+use super::entry::WorkspacePromotionPolicy;
+use super::*;
+use crate::resource_budget::ResourceBudget;
+use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
+use crate::workspace_promotion::prepare_workspace_image_from_active_sandbox;
+use crate::workspace_promotion::test_support::{
+    WorkspacePromotionFixture, test_restored_session_identity,
+};
+
+const WAIT: Duration = Duration::from_secs(5);
+
+async fn sibling_fixture(
+    first: &WorkspacePromotionFixture,
+    key: &str,
+) -> WorkspacePromotionFixture {
+    WorkspacePromotionFixture::new_with_cache(
+        Arc::clone(&first._dir),
+        first.cache.clone(),
+        key,
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn idle_reclamation_holds_from_unpark_through_stop_but_not_host_destroy() {
+    let history = br#"{"type":"message","content":"bounded reclamation"}"#;
+    let identity = test_restored_session_identity("sess-reclamation", history);
+    let first = WorkspacePromotionFixture::new_with_restored_session_identity_and_export_capacity(
+        "thread:reclamation-first",
+        Some(&identity),
+        1,
+    )
+    .await;
+    let second = sibling_fixture(&first, "thread:reclamation-second").await;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let unpark = MockLifecycleGate::new();
+    let exec = MockLifecycleGate::new();
+    let copy = MockLifecycleGate::new();
+    let stop = MockLifecycleGate::new();
+    let destroy = MockLifecycleGate::new();
+    overrides.set_unpark_lifecycle_gate(unpark.clone());
+    overrides.set_exec_lifecycle_gate(exec.clone());
+    overrides.set_copy_file_lifecycle_gate(copy.clone());
+    overrides.set_stop_lifecycle_gate(stop.clone());
+    overrides.set_destroy_lifecycle_gate(destroy.clone());
+    overrides.add_exec_result_matcher(
+        "export-session-history-sidecar",
+        ExecResult::new(
+            0,
+            serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+                representation: SessionHistorySidecarRepresentation::Raw,
+                encoded_size: history.len() as u64,
+            })
+            .unwrap(),
+            Vec::new(),
+        ),
+    );
+    overrides.push_copy_file_result(Ok(history.to_vec()));
+    let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+    let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+    let job = make_idle_destroy_job_for(
+        first.sandbox_id,
+        overrides.clone(),
+        lease,
+        Some(first.promotion),
+    )
+    .await;
+    let task = tokio::spawn(job.run_with_context("soft_drain"));
+    unpark.wait_entered(1, WAIT).await.unwrap();
+
+    let second_overrides = Arc::new(MockSandboxOverrides::new());
+    let second_payload = make_idle_destroy_payload_for(
+        second.sandbox_id,
+        second_overrides.clone(),
+        Some(second.promotion),
+    )
+    .await;
+    let queued = second_payload.finalize_workspace_and_destroy("candidate_admission_oldest");
+    tokio::pin!(queued);
+    assert!(matches!(futures_util::poll!(&mut queued), Poll::Pending));
+    assert_eq!(second_overrides.unpark_call_count(), 0);
+
+    unpark.release_one();
+    exec.wait_entered(1, WAIT).await.unwrap();
+    assert!(matches!(futures_util::poll!(&mut queued), Poll::Pending));
+    assert_eq!(second_overrides.unpark_call_count(), 0);
+    exec.release_one();
+    copy.wait_entered(1, WAIT).await.unwrap();
+    assert!(matches!(futures_util::poll!(&mut queued), Poll::Pending));
+    assert_eq!(second_overrides.unpark_call_count(), 0);
+    copy.release_one();
+    // Sidecar cleanup, then workspace freeze, are both still admitted work.
+    for count in [2, 3] {
+        exec.wait_entered(count, WAIT).await.unwrap();
+        assert!(matches!(futures_util::poll!(&mut queued), Poll::Pending));
+        assert_eq!(second_overrides.unpark_call_count(), 0);
+        exec.release_one();
+    }
+    stop.wait_entered(1, WAIT).await.unwrap();
+    assert!(matches!(futures_util::poll!(&mut queued), Poll::Pending));
+    assert_eq!(second_overrides.unpark_call_count(), 0);
+    stop.release_one();
+    destroy.wait_entered(1, WAIT).await.unwrap();
+
+    let second_result = tokio::time::timeout(WAIT, queued).await.unwrap();
+    assert!(second_result.workspace_cache_promoted);
+    assert_eq!(second_overrides.destroy_call_count(), 1);
+    assert!(
+        !task.is_finished(),
+        "post-stop host cleanup is still blocked"
+    );
+    assert_eq!(budget.allocated(), (2, 4096, 1));
+    destroy.release_one();
+    assert!(tokio::time::timeout(WAIT, task).await.unwrap().unwrap());
+    assert_eq!(budget.allocated(), (0, 0, 0));
+    assert_eq!(
+        WorkspacePromotionFixture::checkout_result(&first.cache, &first.reuse_key).await,
+        WorkspaceCacheCheckoutResult::Hit
+    );
+}
+
+#[tokio::test]
+async fn idle_reclamation_uses_host_cpu_capacity_across_cache_clones() {
+    for (host_cpus, capacity) in [(0, 1), (2, 1), (6, 3), (64, 4)] {
+        let seed = WorkspacePromotionFixture::new("thread:capacity-seed").await;
+        let cache = seed.cache.clone().with_promotion_host_cpus(host_cpus);
+        let unpark = MockLifecycleGate::new();
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        overrides.set_unpark_lifecycle_gate(unpark.clone());
+        let mut jobs = Vec::new();
+        for index in 0..=capacity {
+            let fixture = WorkspacePromotionFixture::new_with_cache(
+                Arc::clone(&seed._dir),
+                cache.clone(),
+                &format!("thread:capacity-{index}"),
+                None,
+            )
+            .await;
+            let payload = make_idle_destroy_payload_for(
+                fixture.sandbox_id,
+                overrides.clone(),
+                Some(fixture.promotion),
+            )
+            .await;
+            jobs.push(Box::pin(
+                payload.finalize_workspace_and_destroy("soft_drain"),
+            ));
+        }
+        for job in &mut jobs {
+            assert!(matches!(futures_util::poll!(job.as_mut()), Poll::Pending));
+        }
+        assert_eq!(unpark.entered_count(), capacity as u64);
+        unpark.release_many(capacity + 1);
+        let results = tokio::time::timeout(WAIT, futures_util::future::join_all(jobs))
+            .await
+            .unwrap();
+        assert!(
+            results
+                .iter()
+                .all(|result| result.outcome == DestroyOutcome::Completed)
+        );
+        // Publication is best effort: concurrent post-stop publishers may skip
+        // the nonblocking cache-capacity lock, but every sandbox must be cleaned up.
+        let promoted = results
+            .iter()
+            .filter(|result| result.workspace_cache_promoted)
+            .count();
+        assert!(promoted > 0);
+        assert_eq!(seed.cache.held_workspace_states().await.len(), promoted);
+        assert_eq!(overrides.destroy_call_count(), (capacity + 1) as u32);
+        seed.promotion.abandon_unpublished("test").await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn idle_reclamation_retains_admission_through_destroy_when_stop_fails() {
+    for panics in [false, true] {
+        let first =
+            WorkspacePromotionFixture::new_with_restored_session_identity_and_export_capacity(
+                "thread:stop-failure",
+                None,
+                1,
+            )
+            .await;
+        let second = sibling_fixture(&first, "thread:after-stop-failure").await;
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        if panics {
+            overrides.push_stop_panic("test stop panic");
+        } else {
+            overrides.push_stop_result(Err(SandboxError::Start {
+                message: "test stop failure".into(),
+            }));
+        }
+        let destroy = MockLifecycleGate::new();
+        overrides.set_destroy_lifecycle_gate(destroy.clone());
+        let payload = make_idle_destroy_payload_for(
+            first.sandbox_id,
+            overrides.clone(),
+            Some(first.promotion),
+        )
+        .await;
+        let task = tokio::spawn(payload.finalize_workspace_and_destroy("soft_drain"));
+        destroy.wait_entered(1, WAIT).await.unwrap();
+        let second_overrides = Arc::new(MockSandboxOverrides::new());
+        let second_payload = make_idle_destroy_payload_for(
+            second.sandbox_id,
+            second_overrides.clone(),
+            Some(second.promotion),
+        )
+        .await;
+        let queued = second_payload.finalize_workspace_and_destroy("idle_destroy");
+        tokio::pin!(queued);
+        assert!(matches!(futures_util::poll!(&mut queued), Poll::Pending));
+        assert_eq!(second_overrides.unpark_call_count(), 0);
+        destroy.release_one();
+        let first_result = tokio::time::timeout(WAIT, task).await.unwrap().unwrap();
+        assert!(!first_result.workspace_cache_promoted);
+        assert_eq!(
+            first_result.outcome,
+            if panics {
+                DestroyOutcome::Uncertain
+            } else {
+                DestroyOutcome::Completed
+            }
+        );
+        assert!(
+            tokio::time::timeout(WAIT, queued)
+                .await
+                .unwrap()
+                .workspace_cache_promoted
+        );
+        assert!(
+            first
+                .cache
+                .held_workspace_states()
+                .await
+                .iter()
+                .all(|state| state.reuse_key != first.reuse_key)
+        );
+    }
+}
+
+#[tokio::test]
+async fn idle_reclamation_failure_releases_admission_after_cleanup() {
+    enum Failure {
+        UnparkError,
+        UnparkPanic,
+        FreezeError,
+        FreezePanic,
+        DestroyPanic,
+    }
+    for failure in [
+        Failure::UnparkError,
+        Failure::UnparkPanic,
+        Failure::FreezeError,
+        Failure::FreezePanic,
+        Failure::DestroyPanic,
+    ] {
+        let first =
+            WorkspacePromotionFixture::new_with_restored_session_identity_and_export_capacity(
+                "thread:preparation-failure",
+                None,
+                1,
+            )
+            .await;
+        let second = sibling_fixture(&first, "thread:after-preparation-failure").await;
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        match failure {
+            Failure::UnparkError => overrides.push_unpark_result(Err(SandboxError::Start {
+                message: "test unpark error".into(),
+            })),
+            Failure::UnparkPanic => overrides.push_unpark_panic("test unpark panic"),
+            Failure::FreezeError => overrides
+                .add_exec_result_matcher("--freeze", ExecResult::new(1, Vec::new(), Vec::new())),
+            Failure::FreezePanic => {
+                overrides.add_exec_panic_matcher("--freeze", "test freeze panic")
+            }
+            Failure::DestroyPanic => {
+                overrides.push_stop_panic("test stop panic");
+                overrides.push_destroy_panic("test destroy panic");
+            }
+        }
+        let payload = make_idle_destroy_payload_for(
+            first.sandbox_id,
+            overrides.clone(),
+            Some(first.promotion),
+        )
+        .await;
+        let result =
+            tokio::time::timeout(WAIT, payload.finalize_workspace_and_destroy("test_failure"))
+                .await
+                .unwrap();
+        assert!(!result.workspace_cache_promoted);
+        assert_eq!(overrides.destroy_call_count(), 1);
+        let next = make_idle_destroy_payload_for(
+            second.sandbox_id,
+            Arc::new(MockSandboxOverrides::new()),
+            Some(second.promotion),
+        )
+        .await;
+        assert!(
+            tokio::time::timeout(WAIT, next.finalize_workspace_and_destroy("test_followup"))
+                .await
+                .unwrap()
+                .workspace_cache_promoted
+        );
+    }
+}
+
+#[tokio::test]
+async fn idle_reclamation_admission_does_not_block_bypass_or_active_promotion() {
+    let first = WorkspacePromotionFixture::new_with_restored_session_identity_and_export_capacity(
+        "thread:blocked-reclamation",
+        None,
+        1,
+    )
+    .await;
+    let abandoned = sibling_fixture(&first, "thread:abandoned-reclamation").await;
+    let history = br#"{"type":"message","content":"active export"}"#;
+    let identity = test_restored_session_identity("sess-active-export", history);
+    let active = WorkspacePromotionFixture::new_with_cache(
+        Arc::clone(&first._dir),
+        first.cache.clone(),
+        "thread:active-promotion",
+        Some(&identity),
+    )
+    .await;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let unpark = MockLifecycleGate::new();
+    overrides.set_unpark_lifecycle_gate(unpark.clone());
+    let payload =
+        make_idle_destroy_payload_for(first.sandbox_id, overrides, Some(first.promotion)).await;
+    let task = tokio::spawn(payload.finalize_workspace_and_destroy("soft_drain"));
+    unpark.wait_entered(1, WAIT).await.unwrap();
+
+    let bypass_overrides = Arc::new(MockSandboxOverrides::new());
+    let missing =
+        make_idle_destroy_payload_for(SandboxId::new_v4(), bypass_overrides.clone(), None).await;
+    let result = tokio::time::timeout(WAIT, missing.finalize_workspace_and_destroy("idle_destroy"))
+        .await
+        .unwrap();
+    assert!(!result.workspace_cache_promoted);
+    let mut abandoned_payload = make_idle_destroy_payload_for(
+        abandoned.sandbox_id,
+        bypass_overrides.clone(),
+        Some(abandoned.promotion),
+    )
+    .await;
+    abandoned_payload.workspace_promotion_policy =
+        WorkspacePromotionPolicy::AbandonUnpublished("test_abandon");
+    let result = tokio::time::timeout(
+        WAIT,
+        abandoned_payload.finalize_workspace_and_destroy("idle_destroy"),
+    )
+    .await
+    .unwrap();
+    assert!(!result.workspace_cache_promoted);
+    assert_eq!(bypass_overrides.unpark_call_count(), 0);
+    assert_eq!(bypass_overrides.destroy_call_count(), 2);
+
+    let sandbox = MockSandbox::new(active.sandbox_id.to_string());
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        0,
+        serde_json::to_vec(&SessionHistorySidecarExportMetadata {
+            representation: SessionHistorySidecarRepresentation::Raw,
+            encoded_size: history.len() as u64,
+        })
+        .unwrap(),
+        Vec::new(),
+    )));
+    sandbox.push_copy_file_result(Ok(history.to_vec()));
+    let prepared = tokio::time::timeout(
+        WAIT,
+        prepare_workspace_image_from_active_sandbox(
+            &sandbox,
+            Some(active.promotion),
+            "active_finalization",
+        ),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    prepared.abandon("test").await;
+    assert!(!task.is_finished());
+    unpark.release_one();
+    assert!(
+        tokio::time::timeout(WAIT, task)
+            .await
+            .unwrap()
+            .unwrap()
+            .workspace_cache_promoted
+    );
+}

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -1575,6 +1575,12 @@ impl WorkspaceImageLease {
 }
 
 impl WorkspaceImagePromotionContext {
+    pub(crate) async fn acquire_idle_workspace_reclamation_permit(
+        &self,
+    ) -> RunnerResult<tokio::sync::OwnedSemaphorePermit> {
+        self.cache.acquire_idle_workspace_reclamation_permit().await
+    }
+
     pub(crate) async fn acquire_session_history_sidecar_export_permit(
         &self,
     ) -> RunnerResult<tokio::sync::OwnedSemaphorePermit> {

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -110,7 +110,7 @@ const WORKSPACE_DRIVE_LAYOUT: &str = "workspace-drive-v1";
 const GIB: u64 = 1024 * 1024 * 1024;
 const MIN_FREE_BYTES_FLOOR: u64 = 50 * GIB;
 const MAX_ENTRY_BYTES_CAP: u64 = 32 * GIB;
-const MAX_SESSION_HISTORY_SIDECAR_EXPORT_CONCURRENCY: usize = 4;
+const MAX_WORKSPACE_PROMOTION_CONCURRENCY: usize = 4;
 
 #[cfg(test)]
 const TEST_FS_TOTAL_BYTES: u64 = 2_000 * GIB;
@@ -121,6 +121,7 @@ const TEST_FS_AVAILABLE_BYTES: u64 = 1_000 * GIB;
 pub(crate) struct WorkspaceImageCache {
     inner: Arc<WorkspaceImageCacheInner>,
     session_history_sidecar_export_permits: Arc<Semaphore>,
+    idle_workspace_reclamation_permits: Arc<Semaphore>,
     #[cfg(test)]
     prepare_lock_test_gate: Option<WorkspaceImagePrepareLockTestGate>,
     #[cfg(test)]
@@ -237,7 +238,10 @@ impl WorkspaceImageCache {
                     entry_lock_owners: Mutex::new(HashMap::new()),
                 }),
                 session_history_sidecar_export_permits: Arc::new(Semaphore::new(
-                    MAX_SESSION_HISTORY_SIDECAR_EXPORT_CONCURRENCY,
+                    MAX_WORKSPACE_PROMOTION_CONCURRENCY,
+                )),
+                idle_workspace_reclamation_permits: Arc::new(Semaphore::new(
+                    MAX_WORKSPACE_PROMOTION_CONCURRENCY,
                 )),
             }
         }
@@ -265,30 +269,42 @@ impl WorkspaceImageCache {
                 fail_next_session_history_sidecar_metadata_commit: AtomicBool::new(false),
             }),
             session_history_sidecar_export_permits: Arc::new(Semaphore::new(
-                MAX_SESSION_HISTORY_SIDECAR_EXPORT_CONCURRENCY,
+                MAX_WORKSPACE_PROMOTION_CONCURRENCY,
+            )),
+            idle_workspace_reclamation_permits: Arc::new(Semaphore::new(
+                MAX_WORKSPACE_PROMOTION_CONCURRENCY,
             )),
             prepare_lock_test_gate: None,
             routine_gc_test_gate: None,
         }
     }
 
-    fn with_session_history_sidecar_export_capacity(mut self, capacity: usize) -> Self {
+    fn with_promotion_capacity(mut self, capacity: usize) -> Self {
         self.session_history_sidecar_export_permits = Arc::new(Semaphore::new(capacity.max(1)));
+        self.idle_workspace_reclamation_permits = Arc::new(Semaphore::new(capacity.max(1)));
         self
     }
 
-    pub(crate) fn with_session_history_sidecar_export_host_cpus(self, host_cpus: usize) -> Self {
-        self.with_session_history_sidecar_export_capacity(
-            (host_cpus / 2).clamp(1, MAX_SESSION_HISTORY_SIDECAR_EXPORT_CONCURRENCY),
-        )
+    pub(crate) fn with_promotion_host_cpus(self, host_cpus: usize) -> Self {
+        self.with_promotion_capacity((host_cpus / 2).clamp(1, MAX_WORKSPACE_PROMOTION_CONCURRENCY))
     }
 
     #[cfg(test)]
-    pub(crate) fn with_session_history_sidecar_export_capacity_for_test(
-        self,
-        capacity: usize,
-    ) -> Self {
-        self.with_session_history_sidecar_export_capacity(capacity)
+    pub(crate) fn with_promotion_capacity_for_test(self, capacity: usize) -> Self {
+        self.with_promotion_capacity(capacity)
+    }
+
+    async fn acquire_idle_workspace_reclamation_permit(
+        &self,
+    ) -> RunnerResult<OwnedSemaphorePermit> {
+        Arc::clone(&self.idle_workspace_reclamation_permits)
+            .acquire_owned()
+            .await
+            .map_err(|error| {
+                RunnerError::Internal(format!(
+                    "idle workspace reclamation admission closed unexpectedly: {error}"
+                ))
+            })
     }
 
     async fn acquire_session_history_sidecar_export_permit(

--- a/crates/runner/src/workspace_promotion/test_support.rs
+++ b/crates/runner/src/workspace_promotion/test_support.rs
@@ -1,5 +1,9 @@
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+use guest_contracts::session_history_identity::{
+    SessionHistoryFramework, SessionHistoryIdentity, SessionHistoryRefKind, SessionHistorySourceRef,
+};
 use sandbox::SandboxId;
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 
 use crate::ids::RunId;
@@ -15,6 +19,31 @@ use crate::workspace_image_cache::{
 pub(crate) const TEST_COMPLETED_AT: &str = "2026-06-03T00:00:00.000Z";
 const TEST_WORKSPACE_IMAGE: &[u8] = b"workspace image";
 pub(crate) const TEST_WORKSPACE_IMAGE_SIZE_BYTES: u64 = TEST_WORKSPACE_IMAGE.len() as u64;
+
+pub(crate) fn test_restored_session_identity(
+    session_id: &str,
+    history: &[u8],
+) -> RestoredSessionIdentity {
+    let metadata = SessionHistoryIdentity::new(
+        SessionHistoryFramework::ClaudeCode,
+        hex::encode(Sha256::digest(session_id.as_bytes())),
+        SessionHistoryRefKind::Blob,
+        hex::encode(Sha256::digest(history)),
+        history.len() as u64,
+        SessionHistorySourceRef::ClaudeCode {
+            config_dir: "/home/user/.claude".to_string(),
+            working_dir: CANONICAL_WORKING_DIR.to_string(),
+            session_id: session_id.to_string(),
+        },
+    )
+    .unwrap();
+    RestoredSessionIdentity::from_final_metadata(
+        metadata,
+        "/home/user/.vm0/guest-agent/runs/run-1/final-session-history-identity.json",
+        "/home/user/.vm0/guest-agent/runs/run-1",
+    )
+    .unwrap()
+}
 
 pub(crate) struct WorkspacePromotionFixture {
     pub(crate) _dir: Arc<tempfile::TempDir>,
@@ -50,7 +79,7 @@ impl WorkspacePromotionFixture {
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
         let cache = WorkspaceImageCache::new(paths.clone())
-            .with_session_history_sidecar_export_capacity_for_test(export_capacity);
+            .with_promotion_capacity_for_test(export_capacity);
 
         Self::new_with_cache(dir, cache, reuse_key, restored_session_identity).await
     }

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -1,4 +1,6 @@
-use super::test_support::{TEST_WORKSPACE_IMAGE_SIZE_BYTES, WorkspacePromotionFixture};
+use super::test_support::{
+    TEST_WORKSPACE_IMAGE_SIZE_BYTES, WorkspacePromotionFixture, test_restored_session_identity,
+};
 use super::*;
 
 use std::os::unix::fs::PermissionsExt;
@@ -13,10 +15,9 @@ use api_contracts::generated::constants::runners::{
 use async_trait::async_trait;
 use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
-    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistoryFramework,
-    SessionHistoryIdentity, SessionHistoryRefKind, SessionHistorySidecarExportFailure,
+    SESSION_HISTORY_SIDECAR_EXPORT_EXIT_WRITE_FAILURE, SessionHistorySidecarExportFailure,
     SessionHistorySidecarExportMetadata, SessionHistorySidecarIoErrorClass,
-    SessionHistorySidecarRepresentation, SessionHistorySourceRef,
+    SessionHistorySidecarRepresentation,
 };
 use sandbox::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestAgentProcessHandle,
@@ -26,7 +27,6 @@ use sandbox::{
 use sandbox_mock::{
     ExecMatcher, MockLifecycleGate, MockSandbox, MockSandboxFactory, MockSandboxOverrides,
 };
-use sha2::{Digest, Sha256};
 use tracing_subscriber::prelude::*;
 use tracing_test_support::{CapturedEvent, CapturedEvents};
 
@@ -58,28 +58,6 @@ async fn mock_sandbox_with_overrides(
         })
         .await
         .expect("create sandbox")
-}
-
-fn test_restored_session_identity(session_id: &str, history: &[u8]) -> RestoredSessionIdentity {
-    let metadata = SessionHistoryIdentity::new(
-        SessionHistoryFramework::ClaudeCode,
-        hex::encode(Sha256::digest(session_id.as_bytes())),
-        SessionHistoryRefKind::Blob,
-        hex::encode(Sha256::digest(history)),
-        history.len() as u64,
-        SessionHistorySourceRef::ClaudeCode {
-            config_dir: "/home/user/.claude".to_string(),
-            working_dir: CANONICAL_WORKING_DIR.to_string(),
-            session_id: session_id.to_string(),
-        },
-    )
-    .unwrap();
-    RestoredSessionIdentity::from_final_metadata(
-        metadata,
-        "/home/user/.vm0/guest-agent/runs/run-1/final-session-history-identity.json",
-        "/home/user/.vm0/guest-agent/runs/run-1",
-    )
-    .unwrap()
 }
 
 async fn prepare_and_publish_workspace_image(

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -125,6 +125,8 @@ pub(crate) struct LifecycleOverrideState {
     /// FIFO queue of stop behaviours consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     pub(crate) stop_behaviors: LifecycleBehaviors<()>,
+    /// Optional gate that blocks every `stop()` entry before its result is consumed.
+    pub(crate) stop_gate: Mutex<Option<MockLifecycleGate>>,
     /// FIFO queue of park results consumed by every sandbox built with
     /// these overrides. Empty queue → default reusable outcome.
     pub(crate) park_behaviors: LifecycleBehaviors<SandboxParkOutcome>,
@@ -140,6 +142,8 @@ pub(crate) struct LifecycleOverrideState {
     /// FIFO queue of unpark results consumed by every sandbox built with
     /// these overrides. Empty queue → default Ok(()).
     pub(crate) unpark_behaviors: LifecycleBehaviors<()>,
+    /// Optional gate that blocks every recorded `unpark()` entry until released.
+    pub(crate) unpark_gate: Mutex<Option<MockLifecycleGate>>,
     /// Optional gate that records and blocks every factory `destroy()` entry
     /// until released.
     pub(crate) destroy_gate: Mutex<Option<MockLifecycleGate>>,
@@ -828,6 +832,16 @@ impl MockSandboxOverrides {
     /// Used by runner tests to exercise panic-safe cleanup boundaries.
     pub fn push_stop_panic(&self, message: impl Into<String>) {
         self.lifecycle.stop_behaviors.push_panic(message);
+    }
+
+    /// Block every `stop()` call before consuming its queued result or panic.
+    pub fn set_stop_lifecycle_gate(&self, gate: MockLifecycleGate) {
+        *self.lifecycle.stop_gate.lock_ignoring_poison() = Some(gate);
+    }
+
+    /// Block every `unpark()` call after recording it and before consuming its result.
+    pub fn set_unpark_lifecycle_gate(&self, gate: MockLifecycleGate) {
+        *self.lifecycle.unpark_gate.lock_ignoring_poison() = Some(gate);
     }
 
     /// Queue a `park()` result applied to the next factory-created sandbox.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -647,6 +647,7 @@ impl Sandbox for MockSandbox {
         let Some(o) = &self.overrides else {
             return Ok(());
         };
+        wait_lifecycle_gate(&o.lifecycle.stop_gate).await;
         o.lifecycle.stop_behaviors.next_result(())
     }
 
@@ -752,6 +753,7 @@ impl Sandbox for MockSandbox {
             .lock_ignoring_poison()
             .push(self.run_control_id.clone());
         *o.lifecycle.unpark_calls.lock_ignoring_poison() += 1;
+        wait_lifecycle_gate(&o.lifecycle.unpark_gate).await;
         o.lifecycle.unpark_behaviors.next_result(())
     }
 

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -47,6 +47,28 @@ telemetry/Axiom dimensions, and distinct hostnames on two hosts running one
 version. Remove any historical query fallback only after its bounded
 observation window expires.
 
+## Idle Workspace Reclamation Concurrency
+
+Workspace promotion uses two independent runner-process-local admission gates,
+each sized as `(host_cpus / 2).clamp(1, 4)`. Cache clones share the gates.
+The existing sidecar export gate covers guest export execution only. Idle
+reclamation additionally acquires admission **before unpark** and holds it
+through export, host copy, cleanup, workspace freeze and sandbox stop. Waiting
+reclamation jobs remain parked.
+
+After a successful stop, cache publication and factory destruction run without
+holding idle admission. If stop fails or panics, admission remains held through
+the factory destruction attempt. Missing or explicitly abandoned promotion
+does not acquire this gate. Normal startup/reuse and active sandbox promotion
+do not acquire idle reclamation admission.
+
+This limits simultaneous resumed idle guests, not total sandboxes or team run
+concurrency. A bulk drain can take longer and retain parked budget leases while
+waiting; capacity-pressure reclamation can consequently take longer too.
+Overlapping runner versions have independent limits. Four is an initial policy,
+not a measured optimum or a guarantee that large-history export/copy latency
+disappears. No operator setting or persistent cache format changes are required.
+
 ## Runner Operator Server Configuration
 
 `runner config` requires the control-plane URL and Runner token through the


### PR DESCRIPTION
## Summary

Closes #32230. Parent: #32193 (remains open).

Idle workspace reclamation currently unparks before the export-only gate. The production evidence in the parent includes 42 unpark starts in about 5 ms during a 44-entry drain, so many resumed guests can perform memory recovery and lifecycle work outside export admission.

- Add separate, clone-shared idle reclamation admission before unpark; retain it through export, copy/cleanup, freeze and stop.
- Use the existing CPU-derived policy for both independent gates: `(host_cpus / 2).clamp(1, 4)` per runner process.
- Release after successful stop, before cache publication and factory destruction. Stop error/panic retains the permit through the destruction attempt.
- Keep normal startup/reuse, active promotion and absent/explicitly abandoned promotion outside idle admission. Existing export-only admission is unchanged.
- Add lifecycle-boundary regression coverage using real temporary workspace caches and durable sandbox-mock gates.

## Failure handling and compatibility

Admission errors are reported and abandon optional promotion while the sandbox remains parked; stop/destroy still runs. Existing best-effort cache publication, sidecar verification and physical cleanup ownership remain intact. Concurrent cache publishers may still skip the existing nonblocking capacity lock.

No API, guest command, cache/sidecar representation, persisted status or deployment protocol changes. No new timeout, normal-reuse balloon-convergence wait, background worker or production configuration change. Rollback is a runner binary rollback; overlapping runner processes have independent caps.

## Risks and remaining work

The gate covers idle promotion during drain/shutdown, capacity-pressure eviction, replacement, profile/device mismatch cleanup, and aged exact-to-blank retirement; it is not drain-only. Bulk drains and aging can take longer while retaining their budget leases. Capacity-pressure eviction already transfers logical budget before physical cleanup, so queued old sandboxes can overlap physically with newly admitted runs for longer; startup/reuse does not wait on this gate directly, but resource contention can still affect latency. Four is a starting policy, not a measured optimum. This bounds resumed idle reclamation, not team run concurrency or total host sandboxes. It does not establish a latency percentage or resolve large-history processing/copy timeouts; those attribution and rollout measurements remain in #32193.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml -p runner -p sandbox-mock --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner -p sandbox-mock --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --profile local -p runner -p sandbox-mock --no-deps`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner -p sandbox-mock -- --quiet`: 3517 runner tests + 1 guest-inventory integration test + 95 sandbox-mock tests passed. The suite reports 25 existing ignored entries; their child-harness configuration is unchanged and no skips were added.
- `cd turbo && pnpm exec prettier --check ../docs/runner-host-configuration.md`
- `git diff --check`

New coverage verifies CPU-derived capacity across clones, no pre-admission unpark, permit retention through every guest/copy/stop phase, parallel post-stop destruction with retained budget ownership, stop/unpark/freeze/destroy failures and panics, bypass behavior, and independent active export progress.

No production deployment or performance benchmark was performed.

## CI regression fix

The coverage failure in [run 34089708953](https://github.com/vm0-ai/vm0/actions/runs/34089708953/job/101640601898) exposed a stale test ordering assumption, not an idle-reclamation failure. Required DNS/kmsg monitor completion starts an owned asynchronous child reaper, while stopping publication and the final heartbeat can proceed before that task finishes. The old EOF/read-error helpers asserted process removal at heartbeat entry, before the shutdown join.

- Reuse the existing real-child reap gate to hold cleanup while asserting that monitor failure still drives stopping/teardown.
- Check PID/start-time removal only after awaiting the runner shutdown result; rename the EOF cases to describe the before-exit contract.
- Cover both DNS and kmsg, for EOF and read errors. No production code, CI settings, timeout increases, or test skips are part of this correction.

Validation of this fix:

- A gated reproduction deterministically failed the old pre-teardown assertion, after releasing and joining cleanup to avoid leaving the test child behind.
- Scoped cargo fmt, Clippy (`--all-targets --all-features -- -D warnings`), and rustdoc (`--all-features --no-deps`, warnings denied) passed.
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner -p sandbox-mock --all-targets --all-features -- --quiet`: 3517 runner tests, 1 guest-inventory integration test, and 95 sandbox-mock tests passed. Existing ignored entries remain unchanged.
- The compiled runner test binary ran all 20 `cmd::start::tests::main_loop::shutdown::` tests for 20 consecutive rounds: 400 passes, no failures.
- Coverage instrumentation was not rerun locally; the pushed head will run the unchanged CI coverage job.

## Rebase validation

Rebased onto `ecbe1ff6cacdb9b251aff1e37217eab41366b158`. The idle-reclamation feature patch is unchanged. Resolved the overlap with #32234 by keeping its shared abnormal-cleanup helper and the gated EOF/read-error tests that assert reaping after shutdown joins.

- Rebased head: `0b1a560fe8f0cd8ba8820079f05971f21c9ff683`.
- Scoped formatting, Clippy (`--all-targets --all-features`, warnings denied), rustdoc (`--all-features --no-deps`, warnings denied), documentation Prettier, and diff whitespace checks passed.
- Scoped all-target/all-feature tests passed: 3526 runner tests + 1 guest-inventory integration test + 95 sandbox-mock tests; 25 existing ignored child-harness entries remain unchanged.
- The freshly compiled runner test binary ran all 20 shutdown tests for 20 consecutive rounds: 400 passes, no failures.
- Current-head CI remains the merge gate; old-head checks are not reused as current-head evidence.
