### PR TITLE
test(runner): synchronize network-log child cleanup

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
@@ -178,7 +178,7 @@ async fn assert_network_log_eof_stops_runner(component: NetworkLogTestComponent)
         !run_handle.is_finished(),
         "blocked final heartbeat should hold teardown open",
     );
-    assert_child_reaped(component.label(), pid, starttime).await;
+    wait_for_child_cleanup(component.label(), pid, starttime).await;
     assert!(
         env.cancel.is_cancelled(),
         "{} EOF should stop discovery",
@@ -206,7 +206,7 @@ async fn assert_network_log_read_error_stops_runner(component: NetworkLogTestCom
         "{} read error should drive runner teardown",
         component.label(),
     );
-    assert_child_reaped(component.label(), pid, starttime).await;
+    wait_for_child_cleanup(component.label(), pid, starttime).await;
     assert!(
         env.cancel.is_cancelled(),
         "{} read error should stop discovery",
@@ -386,7 +386,7 @@ async fn cancelled_reactor_does_not_abort_owned_network_log_child_cleanup() {
     run_handle.abort();
     assert!(run_handle.await.unwrap_err().is_cancelled());
     gate.release.add_permits(1);
-    wait_for_abnormal_child_cleanup(pid, starttime).await;
+    wait_for_child_cleanup("dns", pid, starttime).await;
 }
 
 #[tokio::test]
@@ -474,7 +474,7 @@ async fn mitm_recovery_panic_stops_runner_instead_of_retrying_unknown_cleanup() 
     assert_run_error_contains(run_handle, "mitmproxy recovery task failed").await;
     assert!(env.cancel.is_cancelled());
     assert!(crash_tx.is_closed());
-    wait_for_abnormal_child_cleanup(pid, starttime).await;
+    wait_for_child_cleanup("mitmdump", pid, starttime).await;
 }
 
 #[tokio::test]
@@ -793,9 +793,9 @@ async fn assert_child_reaped(component: &str, pid: u32, starttime: u64) {
     );
 }
 
-// Abnormal task termination transfers reaping to the Drop fallback. Unlike
-// normal shutdown's join, that fallback promises eventual process removal.
-async fn wait_for_abnormal_child_cleanup(pid: u32, starttime: u64) {
+// Independently owned cleanup promises eventual process removal. Joined
+// cleanup paths use assert_child_reaped to enforce the stronger postcondition.
+async fn wait_for_child_cleanup(component: &str, pid: u32, starttime: u64) {
     tokio::time::timeout(Duration::from_secs(2), async {
         while crate::process::read_process_stat(pid)
             .await
@@ -805,7 +805,7 @@ async fn wait_for_abnormal_child_cleanup(pid: u32, starttime: u64) {
         }
     })
     .await
-    .expect("abnormal cleanup should eventually reap its owned child");
+    .unwrap_or_else(|_| panic!("{component} cleanup should eventually reap its owned child"));
 }
 
 async fn assert_run_error_contains(

--- a/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/shutdown.rs
@@ -805,7 +805,11 @@ async fn wait_for_child_cleanup(component: &str, pid: u32, starttime: u64) {
         }
     })
     .await
-    .unwrap_or_else(|_| panic!("{component} cleanup should eventually reap its owned child"));
+    .unwrap_or_else(|_| {
+        panic!(
+            "{component} cleanup did not reap child pid {pid} with start time {starttime} within 2s"
+        )
+    });
 }
 
 async fn assert_run_error_contains(


### PR DESCRIPTION
## Summary

- wait boundedly for independently owned DNS and kmsg child cleanup in EOF and read-error shutdown tests
- keep the final heartbeat blocked while verifying real PID/start-time removal
- retain immediate child-reaped assertions after explicitly joined cleanup

## Scope

This is a test-only synchronization change. It does not change Runner production behavior, cleanup ownership, shutdown ordering, timeouts, APIs, protocols, persisted state, configuration, or deployment compatibility.

## Validation

- Reproduced the pre-fix DNS EOF failure on iteration 159 of repeated exact execution.
- Post-fix repeated exact execution: 300 passes each for DNS EOF, DNS read error, kmsg EOF, and kmsg read error (1200 total).
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner --bin runner cmd::start::tests::main_loop::shutdown` — 20 passed
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner --all-targets --all-features` — 3512 passed, 25 pre-existing ignored, plus 1 guest-inventory integration test passed
- Pre-commit Cargo formatting, Clippy, rustdoc, file-size, and commit-message hooks passed

Closes #32224
