### PR TITLE
fix(platform): preserve markdown artifact link presentation

### DIFF
--- a/docs/chat-cards.md
+++ b/docs/chat-cards.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Most chat cards turn a specially recognized link inside a `ChatEvent` into a
+Action cards turn a specially recognized link inside a `ChatEvent` into a
 rich, interactive React surface. The message remains the transport: an agent or
 another producer can emit a normal URL, Markdown link, or relative platform
 path, and the platform upgrades that link into a typed card when its path
@@ -23,7 +23,9 @@ ChatEvent content
 
 This design keeps message content portable while allowing the platform to add
 loading states, live data, actions, and other rich interaction without putting
-state creation inside React render.
+state creation inside React render. Artifact resources use the same registration
+boundary while preserving the Markdown link or image syntax that chooses their
+presentation.
 
 ## Failure Recovery Classification
 
@@ -81,11 +83,28 @@ Current link-backed card patterns include:
 - `/mail/drafts/:mailDraftId`
 - `/browsers/:threadId`
 - platform artifact URLs such as legacy `/f/...` and `/artifacts/.../.../...`
-  paths, plus hosted site URLs that support an inline preview. Flat V2 artifact
+  paths, plus hosted site URLs that support a preview. Flat V2 artifact
   paths such as `/artifacts/97ngzkxdyn.mp4` require a complete URL with an
   allowed VM0 origin.
 
 Recognized billing-plan links render as rich upgrade cards.
+
+Artifact recognition does not choose its presentation. After Markdown parsing,
+each supported artifact `<a>` or `<img>` node registers its URL in the owning
+thread's artifact registry and receives the same `ArtifactSignals` object as
+other occurrences of that URL. Its original tag and label remain on the node:
+
+- `[label](url)` and bare URLs parsed as links remain text links. A normal click
+  opens the artifact's existing lightbox or active split view; modified clicks
+  retain native link navigation.
+- `![label](url)` renders an image or the resource's corresponding preview card.
+- URLs inside code remain code. Artifact recognition does not rewrite source
+  lines, discard surrounding prose, or turn fenced hosted-site URLs into cards.
+
+Resource state does not contain a link/card presentation flag. The same image
+can appear as a link and a preview in one event while sharing its resource URL
+and load state. Artifacts carried out of folded work history retain their
+original nodes, so folding does not change links into cards.
 
 A path such as `/chats/:threadId` can use the same design when a chat-thread
 card is introduced: add an exact parser for the path, derive a canonical
@@ -113,7 +132,9 @@ closed, and the parser must not infer missing authorization or target data.
 
 `chatEventTreePlan` extracts renderable content from a `ChatEvent` and passes it
 to `eventBodyPlan`. The parser separates normal Markdown from recognized cards.
-The current thread ID and server-derived primary agent ID are supplied as
+Artifact occurrences are recognized on the parsed Markdown tree instead of
+being converted to action slots by this scanner. The current thread ID and
+server-derived primary agent ID are supplied as
 immutable planning context. Parsing is synchronous and does not query an API or
 database.
 
@@ -199,10 +220,11 @@ registry and resource model.
 ### 5. Render the matching React component
 
 `MarkdownCardView` in
-`turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx` is the single
-dispatch the markdown renderer uses for `data.card` nodes. It selects the
-component by the card's discriminated `kind` and passes the signals object
-directly:
+`turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx` renders action
+slots and explicit artifact preview cards. Artifact links and image tiles use
+their original Markdown renderers and read the same signals. For a card,
+the renderer selects the component by its discriminated `kind` and passes the
+signals object directly:
 
 ```tsx
 case "permission-action": {
@@ -465,6 +487,7 @@ registry.
 - `turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts`
 - `turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts`
 - `turbo/apps/platform/src/signals/chat-page/artifact-card-signals.ts`
+- `turbo/apps/platform/src/signals/chat-page/markdown-artifacts.ts`
 - `turbo/apps/platform/src/signals/chat-page/connector-action-block.ts`
 - `turbo/apps/platform/src/signals/chat-page/connector-account-action-block.ts`
 - `turbo/apps/platform/src/signals/chat-page/permission-action-block.ts`

--- a/turbo/apps/platform/src/lib/media-url.ts
+++ b/turbo/apps/platform/src/lib/media-url.ts
@@ -4,10 +4,6 @@ export function isImageUrl(href: string): boolean {
   return /\.(png|jpe?g|gif|webp|svg|bmp|avif)(?:\?|#|$)/i.test(href);
 }
 
-export function isVideoUrl(href: string): boolean {
-  return /\.(mp4|webm|mov|ogv)(?:\?|#|$)/i.test(href);
-}
-
 /**
  * Only `http:` / `https:` URLs are safe to render as `<img src>` or `<video src>`.
  * Blocks `javascript:`, `data:`, `file:`, etc. in assistant-rendered markdown.

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -140,6 +140,7 @@ import {
   embedMermaidSignals,
   type MermaidDiagramRegistry,
 } from "../mermaid-diagram.ts";
+import { embedMarkdownArtifacts$ } from "./markdown-artifacts.ts";
 import {
   createImageLoadRegistry,
   embedImageLoadSignals,
@@ -1778,8 +1779,6 @@ interface EventTreeRegistries {
 }
 
 function createCardRefRegistrar({
-  chatActionContext,
-  artifactCardSignals,
   connectorCardSignals,
   connectorAccountActionCardSignals,
   permissionCardSignals,
@@ -1792,13 +1791,6 @@ function createCardRefRegistrar({
   return command(
     ({ set }, descriptor: CardDescriptorBlock): MarkdownCardRef => {
       switch (descriptor.type) {
-        case "artifact": {
-          return {
-            kind: descriptor.type,
-            signals: set(artifactCardSignals.register$, descriptor.descriptor),
-            threadId: chatActionContext.threadId,
-          };
-        }
         case "connector-action": {
           return {
             kind: descriptor.type,
@@ -1879,6 +1871,42 @@ interface RichEventTreePlan {
   readonly descriptors: readonly CardDescriptorBlock[];
 }
 
+function createEventTreeParser(registries: EventTreeRegistries) {
+  const {
+    chatActionContext,
+    mermaidDiagrams,
+    artifactCardSignals,
+    imageLoads,
+  } = registries;
+  const registerCardRef$ = createCardRefRegistrar(registries);
+  return command(({ set }, plan: RichEventTreePlan): Root => {
+    const cards = new Map<string, MarkdownCardRef>();
+    for (const descriptor of plan.descriptors) {
+      cards.set(
+        markdownCardKey(cardSlotUrl(descriptor)),
+        set(registerCardRef$, descriptor),
+      );
+    }
+    const tree = parseMarkdownTree(plan.treeSource, {
+      mermaid: true,
+      cards,
+    });
+    embedMermaidSignals(tree, (code) => {
+      return set(mermaidDiagrams.register$, code);
+    });
+    set(
+      embedMarkdownArtifacts$,
+      tree,
+      artifactCardSignals,
+      chatActionContext.threadId,
+    );
+    embedImageLoadSignals(tree, (url) => {
+      return set(imageLoads.register$, url);
+    });
+    return tree;
+  });
+}
+
 function planEventTreeUpdates(
   events: readonly ChatEvent[],
   current: ReadonlyMap<string, EventTree>,
@@ -1942,7 +1970,7 @@ function markPendingEventTreesFailed(
 }
 
 function createEventTreeSignals(registries: EventTreeRegistries) {
-  const { chatActionContext, mermaidDiagrams, imageLoads } = registries;
+  const { chatActionContext } = registries;
 
   const internalEventTrees$ = state<ReadonlyMap<string, EventTree>>(new Map());
   const eventTrees$ = computed((get): ReadonlyMap<string, Root> => {
@@ -1964,7 +1992,7 @@ function createEventTreeSignals(registries: EventTreeRegistries) {
     return errors;
   });
 
-  const registerCardRef$ = createCardRefRegistrar(registries);
+  const parseEventTree$ = createEventTreeParser(registries);
   const parseRichEventTrees$ = command(
     async (
       { get, set },
@@ -1985,23 +2013,7 @@ function createEventTreeSignals(registries: EventTreeRegistries) {
         ) {
           continue;
         }
-        const cards = new Map<string, MarkdownCardRef>();
-        for (const descriptor of plan.descriptors) {
-          cards.set(
-            markdownCardKey(cardSlotUrl(descriptor)),
-            set(registerCardRef$, descriptor),
-          );
-        }
-        const tree = parseMarkdownTree(plan.treeSource, {
-          mermaid: true,
-          cards,
-        });
-        embedMermaidSignals(tree, (code) => {
-          return set(mermaidDiagrams.register$, code);
-        });
-        embedImageLoadSignals(tree, (url) => {
-          return set(imageLoads.register$, url);
-        });
+        const tree = set(parseEventTree$, plan);
         parsed ??= new Map(pending);
         parsed.set(plan.eventId, {
           content: plan.content,

--- a/turbo/apps/platform/src/signals/chat-page/markdown-artifacts.ts
+++ b/turbo/apps/platform/src/signals/chat-page/markdown-artifacts.ts
@@ -1,0 +1,55 @@
+import { command } from "ccstate";
+import type { Element, Root } from "hast";
+import { SKIP, visit } from "unist-util-visit";
+
+import type {
+  ArtifactCardSignalsRegistry,
+  ArtifactDescriptor,
+} from "./artifact-card-signals.ts";
+import {
+  classifyChatAttachment,
+  isPreviewableChatUrl,
+  previewAttachmentFromUrl,
+} from "./parse-body-blocks.ts";
+
+function markdownArtifact(node: Element): ArtifactDescriptor | undefined {
+  const url =
+    node.tagName === "a"
+      ? node.properties.href
+      : node.tagName === "img"
+        ? node.properties.src
+        : undefined;
+  if (typeof url !== "string" || !isPreviewableChatUrl(url)) {
+    return undefined;
+  }
+  const attachment = previewAttachmentFromUrl(url);
+  return { ...attachment, kind: classifyChatAttachment(attachment) };
+}
+
+/** Resource identity is shared; each occurrence keeps its Markdown tag and label. */
+export const embedMarkdownArtifacts$ = command(
+  (
+    { set },
+    tree: Root,
+    registry: ArtifactCardSignalsRegistry,
+    threadId: string,
+  ) => {
+    visit(tree, "element", (node) => {
+      if (node.data?.card) {
+        return SKIP;
+      }
+      const descriptor = markdownArtifact(node);
+      if (descriptor) {
+        node.data = {
+          ...node.data,
+          card: {
+            kind: "artifact",
+            signals: set(registry.register$, descriptor),
+            threadId,
+          },
+        };
+      }
+      return undefined;
+    });
+  },
+);

--- a/turbo/apps/platform/src/signals/chat-page/markdown-card-ref.ts
+++ b/turbo/apps/platform/src/signals/chat-page/markdown-card-ref.ts
@@ -9,8 +9,10 @@ import type { PermissionSignals } from "./permission-card-signals.ts";
 import type { PlanUpgradeSignals } from "./plan-upgrade-block.ts";
 
 /**
- * The signals behind one card slot in an event's markdown tree. Slots resolve
- * against cards registered ahead of parsing; the ref rides on the hast node's
+ * The signals behind one resource occurrence in an event's markdown tree.
+ * Action slots resolve against cards registered ahead of parsing; artifact
+ * links and images register after parsing and keep their original tags.
+ * The ref rides on the hast node's
  * `data`, which `rehype-raw` cannot produce, so quoted HTML cannot forge one.
  */
 export type MarkdownCardRef =
@@ -41,7 +43,7 @@ export type MarkdownCardRef =
 
 declare module "hast" {
   interface Data {
-    /** Set by the pipeline's card pass: the card a slot paragraph stands for. */
+    /** Resource signals for an action slot, artifact link, or artifact image. */
     card?: MarkdownCardRef;
   }
 }

--- a/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
+++ b/turbo/apps/platform/src/signals/chat-page/parse-body-blocks.ts
@@ -26,10 +26,7 @@ import {
   parsePlanUpgradeUrl,
   type PlanUpgradeDescriptor,
 } from "./plan-upgrade-block.ts";
-import type {
-  ArtifactDescriptor,
-  ArtifactKind,
-} from "./artifact-card-signals.ts";
+import type { ArtifactKind } from "./artifact-card-signals.ts";
 import { parseMailDraftUrl, type MailDraftDescriptor } from "./mail-draft.ts";
 import {
   parseBrowserSessionUrl,
@@ -56,11 +53,6 @@ export interface ParsedMarkdownBlock {
 
 export type ParsedBodyBlock =
   | ParsedMarkdownBlock
-  | {
-      type: "artifact";
-      resourceKey: string;
-      descriptor: ArtifactDescriptor;
-    }
   | {
       type: "connector-action";
       resourceKey: string;
@@ -115,16 +107,9 @@ interface ChatAttachmentDescriptor {
   contentType?: string;
 }
 
-type ExtractedPreviewUrl = {
-  url: string;
-  source: "markdown-link" | "bare-url" | "preview-url-line";
-  title?: string;
-};
-
 type OpenMarkdownFence = {
   marker: "`" | "~";
   length: number;
-  lines: string[];
 };
 
 interface ParseBodyBlocksOptions {
@@ -314,21 +299,6 @@ function filenameFromUrl(url: string): string {
     return "file";
   }
   return last;
-}
-
-function isBodyPreviewKind(kind: string): kind is BodyPreviewKind {
-  return (
-    kind === "image" ||
-    kind === "video" ||
-    kind === "audio" ||
-    kind === "markdown" ||
-    kind === "text" ||
-    kind === "json" ||
-    kind === "csv" ||
-    kind === "pdf" ||
-    kind === "html" ||
-    kind === "file"
-  );
 }
 
 export function contentTypeForBodyPreviewKind(kind: BodyPreviewKind): string {
@@ -521,7 +491,7 @@ function hostedSiteAttachment(
   };
 }
 
-function isPreviewableChatUrl(url: string): boolean {
+export function isPreviewableChatUrl(url: string): boolean {
   return isPlatformFileUrl(url) || isHostedSiteUrl(url);
 }
 
@@ -542,157 +512,21 @@ export function previewAttachmentFromUrl(
   return { filename, url };
 }
 
-function markdownImageLine(url: string, alt: string): string {
-  const escapedAlt = alt
-    .replace(/\\/g, String.raw`\\`)
-    .replace(/\]/g, String.raw`\]`);
-  return `![${escapedAlt}](${url})`;
-}
-
-type ExtractedPreviewLineRender =
-  | {
-      renderKind: "markdown";
-      line: string;
-    }
-  | {
-      renderKind: "preview";
-      preview: {
-        filename: string;
-        url: string;
-        kind: BodyPreviewKind;
-      };
-    };
-
-function renderExtractedPreviewLine(
-  extracted: ExtractedPreviewUrl,
-  line: string,
-): ExtractedPreviewLineRender {
-  const { title, url } = extracted;
-  const attachment = previewAttachmentFromUrl(url, title);
-  const kind = classifyChatAttachment(attachment);
-  const previewable = isPreviewableChatUrl(url);
-
-  if (
-    extracted.source === "markdown-link" &&
-    (kind === "image" || (kind === "video" && !previewable))
-  ) {
-    return { renderKind: "markdown", line };
-  }
-
-  if (kind === "image" && previewable) {
-    return {
-      renderKind: "markdown",
-      line: markdownImageLine(url, attachment.filename),
-    };
-  }
-
-  if (isBodyPreviewKind(kind) && previewable) {
-    return {
-      renderKind: "preview",
-      preview: { filename: attachment.filename, url, kind },
-    };
-  }
-
-  return { renderKind: "markdown", line };
-}
-
-function renderFencedHostedSitePreview(
-  contentLines: readonly string[],
-): ExtractedPreviewLineRender | null {
-  const nonEmptyLines = contentLines.filter((line) => {
-    return line.trim().length > 0;
-  });
-  if (nonEmptyLines.length !== 1) {
-    return null;
-  }
-
-  const line = nonEmptyLines[0]!;
-  const extracted = extractPreviewUrlFromLine(line);
-  if (!extracted || !isHostedSiteUrl(extracted.url)) {
-    return null;
-  }
-
-  const rendered = renderExtractedPreviewLine(extracted, line);
-  return rendered.renderKind === "preview" && rendered.preview.kind === "html"
-    ? rendered
-    : null;
-}
-
-type MarkdownFenceLineResult =
-  | {
-      kind: "pending";
-      openFence: OpenMarkdownFence | null;
-    }
-  | {
-      kind: "markdown";
-      openFence: null;
-      lines: readonly string[];
-    }
-  | {
-      kind: "preview";
-      openFence: null;
-      preview: {
-        filename: string;
-        url: string;
-        kind: BodyPreviewKind;
-      };
-    };
-
-function renderOpenMarkdownFence(
-  openFence: OpenMarkdownFence,
-  previews: boolean,
-): MarkdownFenceLineResult {
-  const renderedFence = previews
-    ? renderFencedHostedSitePreview(openFence.lines.slice(1))
-    : null;
-
-  if (renderedFence?.renderKind === "preview") {
-    return {
-      kind: "preview",
-      openFence: null,
-      preview: renderedFence.preview,
-    };
-  }
-
-  return { kind: "markdown", openFence: null, lines: openFence.lines };
-}
-
-function parseMarkdownFenceLine(
+function nextMarkdownFence(
   line: string,
   openFence: OpenMarkdownFence | null,
-  previews: boolean,
-): MarkdownFenceLineResult | null {
-  const trimmedLine = line.trim();
-  const fenceMatch = trimmedLine.match(/^(`{3,}|~{3,})/);
-  if (!fenceMatch) {
-    if (!openFence) {
-      return null;
-    }
-
-    openFence.lines.push(line);
-    return { kind: "pending", openFence };
+): OpenMarkdownFence | null {
+  const fence = line.trim().match(/^(`{3,}|~{3,})/)?.[1];
+  if (!fence) {
+    return openFence;
   }
-
-  const fence = fenceMatch[1]!;
   const marker = fence.startsWith("`") ? "`" : "~";
   if (!openFence) {
-    return {
-      kind: "pending",
-      openFence: { marker, length: fence.length, lines: [line] },
-    };
+    return { marker, length: fence.length };
   }
-
-  if (openFence.marker !== marker || fence.length < openFence.length) {
-    openFence.lines.push(line);
-    return { kind: "pending", openFence };
-  }
-
-  const result = renderOpenMarkdownFence(openFence, previews);
-  if (result.kind === "markdown") {
-    return { ...result, lines: [...openFence.lines, line] };
-  }
-
-  return result;
+  return openFence.marker === marker && fence.length >= openFence.length
+    ? null
+    : openFence;
 }
 
 function stripMarkdownLineDecorations(value: string): string {
@@ -764,38 +598,6 @@ function extractUrlTokens(value: string): string[] {
   ).filter((url, index, list) => {
     return url.length > 0 && list.indexOf(url) === index;
   });
-}
-
-function extractPreviewUrlFromLine(line: string): ExtractedPreviewUrl | null {
-  const candidate = stripMarkdownLineDecorations(line);
-  const markdownLinkMatch = candidate.match(
-    new RegExp(String.raw`^\[([^\]]+)\]\((${URL_TOKEN_PATTERN})\)$`),
-  );
-  const bareUrlMatch = candidate.match(new RegExp(`^(${URL_TOKEN_PATTERN})$`));
-  if (markdownLinkMatch?.[2]) {
-    return {
-      url: trimPreviewUrl(markdownLinkMatch[2]),
-      source: "markdown-link",
-      title: markdownLinkMatch[1]?.trim(),
-    };
-  }
-  if (bareUrlMatch?.[1]) {
-    return {
-      url: trimPreviewUrl(bareUrlMatch[1]),
-      source: "bare-url",
-    };
-  }
-
-  const urls = extractUrlTokens(candidate);
-
-  if (urls.length === 1 && isPreviewableChatUrl(urls[0]!)) {
-    return {
-      url: urls[0]!,
-      source: "preview-url-line",
-    };
-  }
-
-  return null;
 }
 
 function extractActionUrlFromLine(line: string): string | null {
@@ -1095,32 +897,11 @@ function parseBodyBlocks(
     keptLines.push(...nextLines);
   };
 
-  const pushPreviewBlock = (
-    preview: Extract<MarkdownFenceLineResult, { kind: "preview" }>["preview"],
-  ) => {
-    flushMarkdownBuffer();
-    blocks.push({
-      type: "artifact",
-      resourceKey: preview.url,
-      descriptor: preview,
-    });
-  };
-
-  const applyFenceLineResult = (result: MarkdownFenceLineResult) => {
-    openFence = result.openFence;
-    if (result.kind === "markdown") {
-      pushMarkdownLines(result.lines);
-      return;
-    }
-    if (result.kind === "preview") {
-      pushPreviewBlock(result.preview);
-    }
-  };
-
   for (const [lineIndex, line] of lines.entries()) {
-    const fenceResult = parseMarkdownFenceLine(line, openFence, previews);
-    if (fenceResult) {
-      applyFenceLineResult(fenceResult);
+    const nextFence = nextMarkdownFence(line, openFence);
+    if (openFence !== null || nextFence !== null) {
+      openFence = nextFence;
+      pushMarkdownLines([line]);
       continue;
     }
 
@@ -1148,31 +929,9 @@ function parseBodyBlocks(
       continue;
     }
 
-    const extracted = previews ? extractPreviewUrlFromLine(line) : null;
-    if (!extracted) {
-      markdownBuffer.push(line);
-      keptLines.push(line);
-      continue;
-    }
-
-    const renderedLine = renderExtractedPreviewLine(extracted, line);
-    if (renderedLine.renderKind === "markdown") {
-      markdownBuffer.push(renderedLine.line);
-      keptLines.push(renderedLine.line);
-      continue;
-    }
-
-    flushMarkdownBuffer();
-    blocks.push({
-      type: "artifact",
-      resourceKey: renderedLine.preview.url,
-      descriptor: renderedLine.preview,
-    });
+    pushMarkdownLines([line]);
   }
 
-  if (openFence) {
-    applyFenceLineResult(renderOpenMarkdownFence(openFence, previews));
-  }
   flushMarkdownBuffer();
 
   const cleanContent = keptLines.join("\n").trim();
@@ -1192,9 +951,6 @@ export type CardDescriptorBlock = Exclude<ParsedBodyBlock, ParsedMarkdownBlock>;
 /** The URL a card's slot stands on, and the key its signals are looked up by. */
 export function cardSlotUrl(block: CardDescriptorBlock): string {
   switch (block.type) {
-    case "artifact": {
-      return block.descriptor.url;
-    }
     case "connector-action": {
       return block.descriptor.originalUrl;
     }
@@ -1246,9 +1002,8 @@ interface EventBodyPlan {
 
 /**
  * Plans one event body. The line scanner in `parseBodyBlocks` stays the sole
- * authority on which URLs become cards — fences, tables and inline labels
- * behave exactly as before — and this only re-joins its output into a single
- * document instead of a block list.
+ * authority on action-card slots. Artifact links and images stay in the
+ * original Markdown; their resources are registered on the parsed nodes.
  */
 export function eventBodyPlan(
   content: string,

--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -50,7 +50,7 @@ export interface RunWorkSection {
 type RunWorkArtifactCard = Extract<
   MarkdownCardRef,
   { readonly kind: "artifact" }
->;
+> & { readonly tree: Root };
 
 export interface RunWorkFolding {
   readonly visibleGroups: ChatEventGroup[];
@@ -116,7 +116,11 @@ function artifactCardsInTree(
   const cards: RunWorkArtifactCard[] = [];
   const visit = (node: Root | Element): void => {
     if (node.type === "element" && node.data?.card?.kind === "artifact") {
-      cards.push(node.data.card);
+      cards.push({
+        ...node.data.card,
+        tree: { type: "root", children: [node] },
+      });
+      return;
     }
     for (const child of node.children) {
       if (child.type === "element") {

--- a/turbo/apps/platform/src/signals/image-load.ts
+++ b/turbo/apps/platform/src/signals/image-load.ts
@@ -1,7 +1,7 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import type { Element, Root } from "hast";
 
-import { isImageUrl, isSafeMediaUrl } from "../lib/media-url.ts";
+import { isSafeMediaUrl } from "../lib/media-url.ts";
 
 /**
  * Load state of one presented image. The owner that prepares an image for
@@ -78,18 +78,11 @@ function mediaImageUrl(node: Element): string | undefined {
     const src = node.properties.src;
     return typeof src === "string" && isSafeMediaUrl(src) ? src : undefined;
   }
-  if (node.tagName === "a") {
-    const href = node.properties.href;
-    return typeof href === "string" && isSafeMediaUrl(href) && isImageUrl(href)
-      ? href
-      : undefined;
-  }
   return undefined;
 }
 
 /**
- * Attach load signals to every node the media renderers show as an inline
- * image preview: `<img>` elements and links whose destination is an image.
+ * Attach load signals to image nodes on surfaces without artifact signals.
  */
 export function embedImageLoadSignals(
   tree: Root,
@@ -97,7 +90,7 @@ export function embedImageLoadSignals(
 ): void {
   const visitNode = (node: Root | Element): void => {
     for (const child of node.children) {
-      if (child.type !== "element") {
+      if (child.type !== "element" || child.data?.card) {
         continue;
       }
       const url = mediaImageUrl(child);

--- a/turbo/apps/platform/src/signals/okou-page/markdown-artifact-preview.ts
+++ b/turbo/apps/platform/src/signals/okou-page/markdown-artifact-preview.ts
@@ -1,0 +1,44 @@
+import { command } from "ccstate";
+
+import type { MarkdownCardRef } from "../chat-page/markdown-card-ref.ts";
+import {
+  openAudioLightbox$,
+  openDocumentLightbox$,
+  openFileLightbox$,
+  openImageLightbox$,
+  openVideoLightbox$,
+} from "./attachment-chips.ts";
+
+/** Links use the same preview commands and resource state as artifact cards. */
+export const openMarkdownArtifact$ = command(
+  ({ set }, card: Extract<MarkdownCardRef, { kind: "artifact" }>) => {
+    const { signals, threadId } = card;
+    const { filename, url, kind } = signals;
+    switch (kind) {
+      case "image": {
+        set(openImageLightbox$, { threadId, url });
+        return;
+      }
+      case "video": {
+        set(openVideoLightbox$, { filename, url });
+        return;
+      }
+      case "audio": {
+        set(openAudioLightbox$, { filename, url });
+        return;
+      }
+      case "file": {
+        set(openFileLightbox$, { filename, url });
+        return;
+      }
+      default: {
+        set(openDocumentLightbox$, {
+          filename,
+          url,
+          kind,
+          text$: signals.text$,
+        });
+      }
+    }
+  },
+);

--- a/turbo/apps/platform/src/views/components/rich-markdown.tsx
+++ b/turbo/apps/platform/src/views/components/rich-markdown.tsx
@@ -1,6 +1,6 @@
 import "../css/vendor/uiw-react-markdown-preview-5.2.0.css";
 import { CopyButton } from "@okouai/ui";
-import { useGet, useSet } from "ccstate-react";
+import { useGet, useLastResolved, useSet } from "ccstate-react";
 import type { Element, Root } from "hast";
 import { toJsxRuntime } from "hast-util-to-jsx-runtime";
 import { Loader2, Image } from "lucide-react";
@@ -12,8 +12,10 @@ import {
   parseMarkdownTree,
 } from "../../lib/markdown/pipeline.ts";
 import { openImageLightbox$ } from "../../signals/okou-page/attachment-chips.ts";
+import { openMarkdownArtifact$ } from "../../signals/okou-page/markdown-artifact-preview.ts";
+import type { ArtifactSignals } from "../../signals/chat-page/artifact-card-signals.ts";
 import type { ImageLoadSignals } from "../../signals/image-load.ts";
-import { isImageUrl, isSafeMediaUrl, isVideoUrl } from "../../lib/media-url.ts";
+import { isImageUrl, isSafeMediaUrl } from "../../lib/media-url.ts";
 import { MarkdownCardView } from "../okou-page/chat-body-cards.tsx";
 import { MarkdownColorPreview } from "./markdown-color-preview.tsx";
 import { MarkdownFrame } from "./markdown-frame.tsx";
@@ -58,10 +60,12 @@ function PlainLink({ href, children, ...rest }: MarkdownAnchorProps) {
 
 function MediaImage({
   src,
+  url,
   alt,
   load,
 }: {
-  src: string;
+  src: string | undefined;
+  url: string;
   alt: string;
   load: ImageLoadSignals;
 }) {
@@ -84,7 +88,7 @@ function MediaImage({
         const threadId = event.currentTarget.closest<HTMLElement>(
           "[data-chat-thread-container-id]",
         )?.dataset.chatThreadContainerId;
-        openImageLightbox(threadId ? { threadId, url: src } : src);
+        openImageLightbox(threadId ? { threadId, url } : url);
       }}
       className="my-1 inline-grid aspect-[10/9] w-[200px] max-w-full cursor-pointer grid-cols-[minmax(0,1fr)] grid-rows-[minmax(0,1fr)] align-top overflow-hidden rounded-lg border border-foreground/10 bg-muted/30"
     >
@@ -100,59 +104,74 @@ function MediaImage({
           )}
         </span>
       )}
-      <img
-        key={src}
-        src={src}
-        alt={alt}
-        loading="lazy"
-        onLoad={markLoaded}
-        onError={markFailed}
-        className={`col-start-1 row-start-1 block h-full w-full min-h-0 min-w-0 object-contain ${
-          showPlaceholder ? "opacity-0" : ""
-        }`}
-      />
+      {src !== undefined && (
+        <img
+          key={src}
+          src={src}
+          alt={alt}
+          loading="lazy"
+          onLoad={markLoaded}
+          onError={markFailed}
+          className={`col-start-1 row-start-1 block h-full w-full min-h-0 min-w-0 object-contain ${
+            showPlaceholder ? "opacity-0" : ""
+          }`}
+        />
+      )}
     </button>
   );
 }
 
 function MediaLink({ href, children, ...rest }: MarkdownAnchorProps) {
-  if (!href || !isSafeMediaUrl(href)) {
-    return (
-      <PlainLink href={href} {...rest}>
-        {children}
-      </PlainLink>
-    );
-  }
-
-  if (isImageUrl(href)) {
-    const load = rest.node?.data?.imageLoadSignals;
-    if (load) {
-      const alt = typeof children === "string" ? children : "";
-      return <MediaImage src={href} alt={alt} load={load} />;
-    }
-    // A tree parsed during render carries no load signals; the destination
-    // stays an ordinary link.
-    return (
-      <PlainLink href={href} {...rest}>
-        {children}
-      </PlainLink>
-    );
-  }
-
-  if (isVideoUrl(href)) {
-    return (
-      <video
-        src={href}
-        controls
-        className="max-h-96 max-w-full my-1 rounded-lg border border-foreground/10"
-      />
-    );
-  }
-
+  const openArtifact = useSet(openMarkdownArtifact$);
+  const openImageLightbox = useSet(openImageLightbox$);
+  const card = rest.node?.data?.card;
   return (
-    <PlainLink href={href} {...rest}>
+    <PlainLink
+      href={href}
+      {...rest}
+      onClick={(event) => {
+        if (
+          event.defaultPrevented ||
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey
+        ) {
+          return;
+        }
+        if (card?.kind === "artifact") {
+          event.preventDefault();
+          openArtifact(card);
+        } else if (href && isSafeMediaUrl(href) && isImageUrl(href)) {
+          event.preventDefault();
+          const threadId = event.currentTarget.closest<HTMLElement>(
+            "[data-chat-thread-container-id]",
+          )?.dataset.chatThreadContainerId;
+          openImageLightbox(threadId ? { threadId, url: href } : href);
+        }
+      }}
+    >
       {children}
     </PlainLink>
+  );
+}
+
+function ArtifactImage({
+  signals,
+  alt,
+}: {
+  signals: ArtifactSignals;
+  alt: string;
+}) {
+  const src = useLastResolved(signals.resourceUrl$);
+  return (
+    <MediaImage
+      src={src}
+      url={signals.url}
+      alt={alt}
+      load={signals.previewImageLoad}
+    />
   );
 }
 
@@ -180,11 +199,50 @@ function PlainImageRenderer(props: MarkdownImageProps) {
 
 function MediaImageRenderer(props: MarkdownImageProps) {
   const { src, alt, ...rest } = props;
+  const card = props.node?.data?.card;
+  if (card?.kind === "artifact") {
+    return card.signals.kind === "image" ? (
+      <ArtifactImage signals={card.signals} alt={alt ?? ""} />
+    ) : (
+      <MarkdownCardView card={card} label={alt} />
+    );
+  }
   const load = props.node?.data?.imageLoadSignals;
   if (typeof src === "string" && isSafeMediaUrl(src) && load) {
-    return <MediaImage src={src} alt={alt ?? ""} load={load} />;
+    return <MediaImage src={src} url={src} alt={alt ?? ""} load={load} />;
   }
   return <img {...omitMarkdownNodeProp(rest)} src={src} alt={alt} />;
+}
+
+function containsBlockArtifact(node: Element): boolean {
+  return node.children.some((child) => {
+    if (child.type !== "element") {
+      return false;
+    }
+    const card = child.data?.card;
+    return (
+      (child.tagName === "img" &&
+        card?.kind === "artifact" &&
+        card.signals.kind !== "image") ||
+      containsBlockArtifact(child)
+    );
+  });
+}
+
+function MediaParagraphRenderer({
+  children,
+  node,
+  ...props
+}: ComponentPropsWithoutRef<"p"> & MarkdownNodeProp) {
+  // Document cards contain block elements, which cannot live inside a <p>.
+  if (node && containsBlockArtifact(node)) {
+    return (
+      <div {...props} className="okou-markdown-card">
+        {children}
+      </div>
+    );
+  }
+  return <p {...props}>{children}</p>;
 }
 
 function MarkdownSpanRenderer(props: MarkdownSpanProps) {
@@ -241,6 +299,7 @@ const PLAIN_MARKDOWN_COMPONENTS = {
 
 const MEDIA_MARKDOWN_COMPONENTS = {
   table: ResponsiveTable,
+  p: MediaParagraphRenderer,
   a: MediaLinkRenderer,
   img: MediaImageRenderer,
   span: MarkdownSpanRenderer,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-artifact-viewer.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-artifact-viewer.test.tsx
@@ -12,6 +12,7 @@ import {
   findNamedButton,
   findNamedLink,
   getNamedButton,
+  getNamedLink,
   mockAttachmentChat,
   mockPrivateUrlSequence,
   mockSplitAttachmentChats,
@@ -104,7 +105,7 @@ test("A composer image preview does not replace an open artifact sidebar", async
 
   await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
 
-  click(await findNamedLink("Open html preview for Workspace guide"));
+  click(await findNamedLink("Workspace guide"));
   click(await findNamedButton("Open in split view"));
   const sidebar = await screen.findByTestId("artifact-sidebar");
   expect(
@@ -159,9 +160,7 @@ test("An open artifact sidebar reuses one pane", async () => {
 
   await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
 
-  const sitePreview = await findNamedLink(
-    "Open html preview for Reference site",
-  );
+  const sitePreview = await findNamedLink("Reference site");
   click(sitePreview);
   click(await findNamedButton("Open in split view"));
   const sidebar = await screen.findByTestId("artifact-sidebar");
@@ -176,7 +175,7 @@ test("An open artifact sidebar reuses one pane", async () => {
     within(sidebar).getByTestId("artifact-sidebar-body-html"),
   ).toBeVisible();
 
-  click(getNamedButton("Open audio preview for walkthrough.mp3"));
+  click(getNamedLink("Walkthrough"));
   await waitFor(() => {
     expect(
       within(sidebar).getByTestId("artifact-sidebar-body-audio"),
@@ -192,7 +191,7 @@ test("Artifact thumbnails fall back to a usable live preview", async () => {
   mockAttachmentChat(context, {
     chatEvents: [
       assistantMessage(
-        `[Thumbnail success](${firstSite})\n\n[Thumbnail fallback](${secondSite})`,
+        `![Thumbnail success](${firstSite})\n\n![Thumbnail fallback](${secondSite})`,
       ),
     ],
     artifacts: [

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-message-previews.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-message-previews.test.tsx
@@ -112,7 +112,7 @@ test("A rich artifact preview requires a complete address", async () => {
           `Incomplete: ${incomplete}`,
           `Root relative: ${rootRelative}`,
           "Complete:",
-          complete,
+          `![Complete video](${complete})`,
         ].join("\n\n"),
       ),
     ],
@@ -139,7 +139,7 @@ test("A short Okou artifact link opens as a rich preview", async () => {
 
   await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
 
-  const preview = await findNamedLink("Open pdf preview for a1b2c3d4e5.pdf");
+  const preview = await findNamedLink("Open the review brief");
   expect(preview).toHaveAttribute("href", shortArtifact);
   click(preview);
   await waitFor(() => {
@@ -246,7 +246,7 @@ test("Only exact trusted public links receive rich attachment previews", async (
 
   await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
 
-  const sitePreview = await findNamedLink("Open html preview for Current site");
+  const sitePreview = await findNamedLink("Current site");
   expect(sitePreview).toHaveAttribute("href", currentSite);
   click(sitePreview);
   await waitFor(() => {
@@ -257,7 +257,7 @@ test("Only exact trusted public links receive rich attachment previews", async (
   });
   await closeFocusedPreview();
 
-  const pdfPreview = getNamedLink("Open pdf preview for report.pdf");
+  const pdfPreview = getNamedLink("Artifact PDF");
   expect(pdfPreview).toHaveAttribute("href", artifactPdf);
   click(pdfPreview);
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-artifact-sidebar.test.tsx
@@ -120,7 +120,7 @@ async function setupGeneratedOfficePreview(
       {
         id: `message-${filename}`,
         role: "assistant",
-        content: `[${filename}](${url})`,
+        content: `![${filename}](${url})`,
         runId: "navigation-artifact-run",
         seqId: 1,
         createdAt: "2026-09-01T12:00:00.000Z",
@@ -174,7 +174,7 @@ test("Keep attachment cards closed until the user selects one", async () => {
       {
         id: "navigation-completed-artifact",
         role: "assistant",
-        content: "[completed.pdf](/f/navigation/completed/completed.pdf)",
+        content: "![completed.pdf](/f/navigation/completed/completed.pdf)",
         runId: "navigation-completed-work",
         runEventId: "completed-artifact-event",
         sequenceNumber: 1,
@@ -200,7 +200,7 @@ test("Keep attachment cards closed until the user selects one", async () => {
       {
         id: "navigation-running-artifact",
         role: "assistant",
-        content: "[running.pdf](/f/navigation/running/running.pdf)",
+        content: "![running.pdf](/f/navigation/running/running.pdf)",
         runId: "navigation-running-work",
         runEventId: "running-artifact-event",
         sequenceNumber: 1,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { expect, test } from "vitest";
 
-import { queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
+import { click, queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import { setupPage } from "./chat-lifecycle-test-helpers.ts";
 import type { MockChatEventInput } from "./chat-event-test-helpers.ts";
 import {
@@ -101,7 +101,7 @@ test("Carry an artifact referenced only by history below the main result", async
       id: "history-only-artifact",
       runId: RUN_ID,
       seqId: 2,
-      text: `Generated supporting evidence.\n\n${reportUrl}`,
+      text: `Generated supporting evidence.\n\n![Report](${reportUrl})`,
     }),
     assistantEvent({
       id: "history-only-main",
@@ -135,6 +135,41 @@ test("Carry an artifact referenced only by history below the main result", async
   expect(viewAgentProfileLinks()).toHaveLength(1);
 });
 
+test("A carried image link keeps its label and opens the image preview", async () => {
+  const url = artifactUrl("linked-evidence", "evidence.png");
+  await setupArtifactRun([
+    assistantEvent({
+      id: "linked-artifact-history",
+      runId: RUN_ID,
+      seqId: 2,
+      text: `Review [**Supporting evidence**](${url}) before continuing.`,
+    }),
+    assistantEvent({
+      id: "linked-artifact-main",
+      runId: RUN_ID,
+      seqId: 3,
+      text: "Final linked evidence summary",
+    }),
+  ]);
+
+  const link = await waitFor(() => {
+    const link = queryAllByRoleFast("link").find((candidate) => {
+      return candidate.textContent === "Supporting evidence";
+    });
+    if (!link) {
+      throw new Error("Expected the carried evidence link");
+    }
+    return link;
+  });
+  expect(link).toHaveAttribute("href", url);
+  expect(link.querySelector("strong")).toHaveTextContent("Supporting evidence");
+  expectDocumentOrder(screen.getByText("Final linked evidence summary"), link);
+  click(link);
+  await expect(
+    screen.findByTestId("attachment-lightbox-image"),
+  ).resolves.toHaveAttribute("src", url);
+});
+
 test("Keep completed result actions before recommended followups", async () => {
   const reportUrl = artifactUrl("followup-report", "followup-report.pdf");
   installRunChat({
@@ -149,7 +184,7 @@ test("Keep completed result actions before recommended followups", async () => {
         id: "followup-actions-history",
         runId: RUN_ID,
         seqId: 2,
-        text: `Generated the supporting report.\n\n${reportUrl}`,
+        text: `Generated the supporting report.\n\n![Report](${reportUrl})`,
       }),
       assistantEvent({
         id: "followup-actions-main",
@@ -214,19 +249,29 @@ test("Subtract final artifacts after ordered URL deduplication", async () => {
       id: "artifact-difference-first-history",
       runId: RUN_ID,
       seqId: 2,
-      text: ["First historical output", appendixUrl, repeatedUrl].join("\n\n"),
+      text: [
+        "First historical output",
+        `![Appendix](${appendixUrl})`,
+        `![Report](${repeatedUrl})`,
+      ].join("\n\n"),
     }),
     assistantEvent({
       id: "artifact-difference-second-history",
       runId: RUN_ID,
       seqId: 3,
-      text: ["Second historical output", repeatedUrl, sourceUrl].join("\n\n"),
+      text: [
+        "Second historical output",
+        `![Report](${repeatedUrl})`,
+        `![Source](${sourceUrl})`,
+      ].join("\n\n"),
     }),
     assistantEvent({
       id: "artifact-difference-main",
       runId: RUN_ID,
       seqId: 4,
-      text: ["Final artifact summary", repeatedUrl].join("\n\n"),
+      text: ["Final artifact summary", `![Report](${repeatedUrl})`].join(
+        "\n\n",
+      ),
     }),
   ]);
 
@@ -252,13 +297,13 @@ test("Keep artifacts with the same filename distinct when their URLs differ", as
       id: "same-name-first-history",
       runId: RUN_ID,
       seqId: 2,
-      text: `First report version\n\n${firstUrl}`,
+      text: `First report version\n\n![Report](${firstUrl})`,
     }),
     assistantEvent({
       id: "same-name-second-history",
       runId: RUN_ID,
       seqId: 3,
-      text: `Second report version\n\n${secondUrl}`,
+      text: `Second report version\n\n![Report](${secondUrl})`,
     }),
     assistantEvent({
       id: "same-name-main",
@@ -349,7 +394,7 @@ test("Carry artifacts across every run in the same run group", async () => {
           id: "earlier-run-artifact",
           runId: RUN_ID,
           seqId: 2,
-          text: `Earlier run output\n\n${earlierUrl}`,
+          text: `Earlier run output\n\n![Report](${earlierUrl})`,
         }),
       ),
       inRunGroup(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
@@ -227,7 +227,7 @@ test.each(["completed", "failed", "cancelled"] as const)(
         ...[
           "## Review\n\nChecked **dependencies** and `tests`.",
           "![Dependency chart](https://example.com/dependencies.png)",
-          "https://cdn.vm7.io/artifacts/history-preview/report/report.pdf",
+          "![report.pdf](https://cdn.vm7.io/artifacts/history-preview/report/report.pdf)",
           "The review is ready",
         ].map((text, index) => {
           return assistantEvent({

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
@@ -387,7 +387,7 @@ test("Count one output.message once when Markdown renders multiple child blocks"
         text: [
           "Final package",
           "![Package chart](https://example.com/package-chart.png)",
-          artifactUrl,
+          `![Package](${artifactUrl})`,
           "[Compare plans](/?settings=billing&billingView=plans)",
         ].join("\n\n"),
       }),
@@ -483,7 +483,8 @@ const finalOutputDocuments = [
   },
   {
     label: "an artifact card",
-    content: "https://cdn.vm7.io/artifacts/tests/run-folding/final-report.pdf",
+    content:
+      "![Report](https://cdn.vm7.io/artifacts/tests/run-folding/final-report.pdf)",
     find: () => {
       return findLink("Open pdf preview for final-report.pdf");
     },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-status-tail.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-status-tail.test.tsx
@@ -53,7 +53,7 @@ function resultEvents(): MockChatEventInput[] {
       id: "supporting-artifact",
       runId: RUN_A,
       seqId: 2,
-      text: "https://cdn.vm7.io/artifacts/status-tail/evidence/report.pdf",
+      text: "![Report](https://cdn.vm7.io/artifacts/status-tail/evidence/report.pdf)",
     }),
     assistantEvent({
       id: "first-result",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-steer.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-steer.test.tsx
@@ -43,7 +43,7 @@ function resultEvents(): MockChatEventInput[] {
       id: "review-artifact",
       runId: RUN_A,
       seqId: 2,
-      text: "https://cdn.vm7.io/artifacts/steer/review/report.pdf",
+      text: "![Report](https://cdn.vm7.io/artifacts/steer/review/report.pdf)",
       createdAt: createdAt(1),
     }),
     assistantEvent({
@@ -236,7 +236,7 @@ test("Keep separate history previews, artifacts and actions on both sides of a s
         id: "history-artifact",
         runId: RUN_A,
         seqId: 2,
-        text: "https://cdn.vm7.io/artifacts/steer/review/report.pdf",
+        text: "![Report](https://cdn.vm7.io/artifacts/steer/review/report.pdf)",
         createdAt: createdAt(1),
       }),
       ...oldHistory.map((text, index) => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-artifacts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-artifacts.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { expect, test } from "vitest";
+
+import { click, setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  ATTACHMENT_THREAD_ID,
+  findNamedLink,
+  getNamedButton,
+  getNamedLink,
+  mockAttachmentChat,
+  publicArtifactUrl,
+} from "./chat-attachment-test-helpers.ts";
+
+const context = testContext();
+
+function installMessage(content: string) {
+  mockAttachmentChat(context, {
+    chatEvents: [
+      {
+        id: "markdown-artifact-message",
+        role: "assistant",
+        content,
+        runId: "markdown-artifact-run",
+        runEventId: "markdown-artifact-output",
+        sequenceNumber: 1,
+        createdAt: "2026-09-07T00:00:00Z",
+      },
+    ],
+  });
+}
+
+async function closePreview() {
+  click(getNamedButton("Close"));
+  await waitFor(() => {
+    expect(screen.queryByTestId("attachment-lightbox")).toBeNull();
+  });
+}
+
+test("One image keeps distinct link labels and image previews in the same message", async () => {
+  const url = publicArtifactUrl("evidence.png");
+  installMessage(
+    [
+      `Before [**Key screenshot**](${url}) after.`,
+      "",
+      `![Embedded screenshot](${url})`,
+      "",
+      `![Repeated screenshot](${url})`,
+      "",
+      `- [List screenshot](${url})`,
+      "",
+      `> [Quoted screenshot](${url})`,
+      "",
+      "| Evidence | Result |",
+      "| --- | --- |",
+      `| [Table screenshot](${url}) | Passed |`,
+      "",
+      "[Reference screenshot][evidence]",
+      "",
+      `[evidence]: ${url}`,
+    ].join("\n"),
+  );
+
+  await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
+
+  const link = await findNamedLink("Key screenshot");
+  expect(link).toHaveAttribute("href", url);
+  expect(link.querySelector("strong")).toHaveTextContent("Key screenshot");
+  expect(link.closest("p")).toHaveTextContent("Before Key screenshot after.");
+  expect(getNamedLink("List screenshot").closest("li")).toBeVisible();
+  expect(getNamedLink("Quoted screenshot").closest("blockquote")).toBeVisible();
+  expect(getNamedLink("Table screenshot").closest("td")).toBeVisible();
+  expect(getNamedLink("Reference screenshot")).toHaveAttribute("href", url);
+
+  const embedded = await screen.findByAltText("Embedded screenshot");
+  const repeated = screen.getByAltText("Repeated screenshot");
+  expect(screen.getAllByTestId("markdown-image-preview-loading")).toHaveLength(
+    2,
+  );
+  fireEvent.load(embedded);
+  // Repeated occurrences observe the resource's completed image load.
+  expect(screen.queryByTestId("markdown-image-preview-loading")).toBeNull();
+  expect(embedded).toBeVisible();
+  expect(repeated).toBeVisible();
+  click(link);
+  await expect(
+    screen.findByTestId("attachment-lightbox-image"),
+  ).resolves.toHaveAttribute("src", url);
+  await closePreview();
+
+  const imageAction = embedded.closest("button");
+  if (!imageAction) {
+    throw new Error("Expected an image preview action");
+  }
+  click(imageAction);
+  await expect(
+    screen.findByTestId("attachment-lightbox-image"),
+  ).resolves.toHaveAttribute("src", url);
+});
+
+test("Bare platform URLs stay links and fenced URLs stay code", async () => {
+  const url = publicArtifactUrl("bare-evidence.png");
+  const site = "https://literal-site.sites.vm7.io";
+  installMessage(
+    ["Evidence URL:", "", url, "", "```text", site, "```"].join("\n"),
+  );
+
+  await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
+
+  const link = await findNamedLink(url);
+  expect(link).toHaveAttribute("href", url);
+  const code = screen.getByText(site);
+  expect(code.closest("pre")).toBeVisible();
+  click(link);
+  await expect(
+    screen.findByTestId("attachment-lightbox-image"),
+  ).resolves.toHaveAttribute("src", url);
+});
+
+test("A platform document has both a text link and an explicit preview card", async () => {
+  const url = "https://a.okou.io/a1b2c3d4e5.pdf";
+  installMessage(
+    `Read [the brief](${url}) before approving.\n\n![Brief preview](${url})`,
+  );
+
+  await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
+
+  const link = await findNamedLink("the brief");
+  const card = getNamedLink("Open pdf preview for a1b2c3d4e5.pdf");
+  expect(link.closest("p")).toHaveTextContent(
+    "Read the brief before approving.",
+  );
+  expect(card).toBeVisible();
+  click(link);
+  const dialog = await screen.findByRole("dialog");
+  await expect(
+    within(dialog).findByTitle("a1b2c3d4e5.pdf preview"),
+  ).resolves.toHaveAttribute("src", `${url}#navpanes=0`);
+  await closePreview();
+  click(card);
+  await expect(
+    screen.findByTitle("a1b2c3d4e5.pdf preview"),
+  ).resolves.toHaveAttribute("src", `${url}#navpanes=0`);
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-content.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-content.test.tsx
@@ -221,10 +221,12 @@ test("Fenced code stays readable for known and unknown languages", async () => {
   expect(unknownCode).toBeVisible();
 });
 
-test("Linked images and videos appear inline", async () => {
+test("Media links keep their text while image syntax shows a preview", async () => {
   const chat = createMarkdownChatFixture(context);
   const source = [
     "[Product screenshot](https://media.example.com/product.png)",
+    "",
+    "![Embedded screenshot](https://media.example.com/product.png)",
     "",
     "[Walkthrough video](https://media.example.com/walkthrough.mp4)",
   ].join("\n");
@@ -242,21 +244,24 @@ test("Linked images and videos appear inline", async () => {
   });
 
   const image = await screen.findByRole("img", {
-    name: "Product screenshot",
+    name: "Embedded screenshot",
   });
   fireEvent.load(image);
   expect(image).toBeVisible();
   expect(image).toHaveAttribute("src", "https://media.example.com/product.png");
 
   const frame = markdownFrameFor(image);
-  const video = frame.querySelector("video");
-  expect(video).not.toBeNull();
-  expect(video).toBeVisible();
-  expect(video).toHaveAttribute(
-    "src",
-    "https://media.example.com/walkthrough.mp4",
-  );
-  expect(video).toHaveAttribute("controls");
+  const links = queryAllByRoleFast("link", frame);
+  expect(
+    links.find((link) => {
+      return link.textContent === "Product screenshot";
+    }),
+  ).toHaveAttribute("href", "https://media.example.com/product.png");
+  expect(
+    links.find((link) => {
+      return link.textContent === "Walkthrough video";
+    }),
+  ).toHaveAttribute("href", "https://media.example.com/walkthrough.mp4");
 });
 
 test("Raw message content cannot impersonate Platform controls", async () => {

--- a/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-body-cards.tsx
@@ -275,14 +275,24 @@ export function ChatVideoPreviewButton({
 }
 
 /**
- * The body cards an event's markdown tree can stand a slot on. `MarkdownCardView`
- * is the single dispatch the markdown renderer uses for `data.card` nodes.
+ * Renders action slots and explicit artifact preview cards. Artifact links and
+ * image tiles keep their own Markdown renderers while sharing these signals.
  */
-export function MarkdownCardView({ card }: { card: MarkdownCardRef }) {
+export function MarkdownCardView({
+  card,
+  label,
+}: {
+  card: MarkdownCardRef;
+  label?: string;
+}) {
   switch (card.kind) {
     case "artifact": {
       return (
-        <ArtifactCardView signals={card.signals} threadId={card.threadId} />
+        <ArtifactCardView
+          signals={card.signals}
+          threadId={card.threadId}
+          label={label}
+        />
       );
     }
     case "connector-action": {
@@ -318,9 +328,11 @@ export function MarkdownCardView({ card }: { card: MarkdownCardRef }) {
 function ArtifactCardView({
   signals,
   threadId,
+  label,
 }: {
   signals: ArtifactSignals;
   threadId: string;
+  label?: string;
 }) {
   const { t } = useTranslation();
   const openFileLightbox = useSet(openAttachmentFileLightbox$);
@@ -391,7 +403,7 @@ function ArtifactCardView({
   return (
     <AttachmentPreview
       attachment={{
-        filename: signals.filename,
+        filename: signals.kind === "html" && label ? label : signals.filename,
         url: signals.url,
         contentType: contentTypeForBodyPreviewKind(signals.kind),
         ...(previewImagePending ? { previewImagePending: true } : {}),

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -123,7 +123,6 @@ import {
   CHAT_INLINE_VIDEO_ATTACHMENT_PREVIEW_CLASS,
   ChatImagePreviewLink,
   ChatVideoPreviewButton,
-  MarkdownCardView,
 } from "./chat-body-cards.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 import { ChatConversationLocator } from "./chat-conversation-locator.tsx";
@@ -7663,7 +7662,7 @@ function PagedAssistantTimeline({
               {item.artifactCards.map((card) => {
                 return (
                   <div key={card.signals.url} className="okou-markdown-card">
-                    <MarkdownCardView card={card} />
+                    <MarkdownEventBody tree={card.tree} mediaPreview />
                   </div>
                 );
               })}

--- a/turbo/apps/platform/src/views/okou-page/run-work-message-preview.tsx
+++ b/turbo/apps/platform/src/views/okou-page/run-work-message-preview.tsx
@@ -30,8 +30,8 @@ function previewText(event: EnrichedChatEvent, fallback: string): string {
   const visit = (node: Root | Element): void => {
     if (node.type === "element") {
       const card = node.data?.card;
-      if (card !== undefined) {
-        parts.push(card.kind === "artifact" ? card.signals.filename : fallback);
+      if (card !== undefined && card.kind !== "artifact") {
+        parts.push(fallback);
         return;
       }
       if (node.tagName === "img") {


### PR DESCRIPTION
## Summary

A platform image link such as `[Key screenshot](https://a.okou.io/si85qzfk5e.png)` currently becomes an image tile, breaking inline prose and rows of links. Preserve the original Markdown presentation: links keep their labels and open the existing artifact preview when clicked; explicit image syntax renders an image or the resource's preview card.

- Remove the artifact URL rewriting from body preprocessing, including bare URLs and fenced hosted-site URLs.
- Register platform resources on parsed link/image nodes, sharing one `ArtifactSignals` object per URL while retaining each occurrence's tag and label.
- Preserve the original artifact node when carrying resources out of folded run history. Keep action-card parsing on its existing path.

## Verification

- Targeted app tests: 102 cases across Markdown rendering, attachment previews, artifact navigation, run history, steering, and artifact carryover passed. One code-copy test timed out in a concurrent batch and passed when its file ran alone.
- App TypeScript checks passed.
- Formatting, app localization/build/static-asset checks, both Oxlint passes, ESLint, Knip, and commitlint passed.
- The full PR pipeline passed at `c020f16` (78 passing checks and 20 intentional skips).
- Browser-tested the deployed PR runtime at `baad2aa`; the final `c020f16` commit only updates test fixtures and its exact-head App deployment also passed. Testing used Chromium 152 at 1440x1000, completed onboarding, no feature switches, and the deterministic preview runner. Confirmed that normal Markdown links remain inline links, explicit image syntax renders the preview card, both open the same lightbox, modified clicks retain native link behavior, and list/quote/table/code formatting remains intact.

Screenshots: [rendered Markdown](https://a.okou.io/g0d1p9d2os.png) · [link-opened lightbox](https://a.okou.io/ux9yjd6i6v.png)
