### PR TITLE
fix(desktop): remove preparing symbol background

### DIFF
--- a/turbo/apps/desktop/src/renderer/assets/okou-symbol-light.test.ts
+++ b/turbo/apps/desktop/src/renderer/assets/okou-symbol-light.test.ts
@@ -5,9 +5,19 @@ const okouSymbolSvg = readFileSync(
   new URL("./okou-symbol-light.svg", import.meta.url),
   "utf8",
 );
+const desktopStyles = readFileSync(
+  new URL("../styles.css", import.meta.url),
+  "utf8",
+);
 
 describe("Okou desktop symbol", () => {
   it("ships without a background rectangle", () => {
     expect(okouSymbolSvg).not.toContain("<rect");
+  });
+
+  it("keeps the Preparing mark transparent", () => {
+    expect(desktopStyles).toContain(
+      ".desktop-product-okou .desktop-brand-mark-init,",
+    );
   });
 });

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -1134,6 +1134,7 @@ button {
   animation: brand-mark-breathe 3.4s ease-in-out infinite;
 }
 
+.desktop-product-okou .desktop-brand-mark-init,
 .desktop-product-okou .desktop-brand-mark-hero {
   border-radius: 0;
   background: transparent;


### PR DESCRIPTION
## Summary
- render the Okou Preparing symbol without its rounded container or shadow
- retain the existing Zero startup styling
- add regression coverage for the Okou Preparing style contract

## Scope check
- Online hero was already transparent for Okou.
- Offline hero and signed-in setup chip still use the rounded mark; they are intentionally unchanged in this focused PR.

## Validation
- stylesheet contract check
- `git diff --check`
- Desktop package checks will run in CI; this checkout has no `node_modules` for local package commands.