### PR TITLE
fix(platform): simplify model picker settings and focus

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -4953,12 +4953,9 @@
         "loading": "Modelle werden geladen...",
         "menu": {
           "adjustSettings": "Einstellungen für {{model}} anpassen",
-          "backToChatModels": "Zurück zu Chatmodellen",
           "backToModels": "Zurück zu Modellen",
-          "cancel": "Abbrechen",
           "changeModel": "{{category}}-Modell ändern, {{model}}",
-          "chatSettings": "Chateinstellungen",
-          "confirm": "Bestätigen"
+          "chatSettings": "Chateinstellungen"
         },
         "models": "Modelle",
         "noConfiguredModels": "Keine konfigurierten Modelle",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -4945,12 +4945,9 @@
         "loading": "Loading models...",
         "menu": {
           "adjustSettings": "Adjust {{model}} settings",
-          "backToChatModels": "Back to chat models",
           "backToModels": "Back to models",
-          "cancel": "Cancel",
           "changeModel": "Change {{category}} model, {{model}}",
-          "chatSettings": "Chat settings",
-          "confirm": "Confirm"
+          "chatSettings": "Chat settings"
         },
         "models": "Models",
         "noConfiguredModels": "No configured models",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5007,12 +5007,9 @@
         "loading": "Cargando modelos...",
         "menu": {
           "adjustSettings": "Ajustar la configuración de {{model}}",
-          "backToChatModels": "Volver a los modelos de chat",
           "backToModels": "Volver a los modelos",
-          "cancel": "Cancelar",
           "changeModel": "Cambiar modelo de {{category}}, {{model}}",
-          "chatSettings": "Configuración del chat",
-          "confirm": "Confirmar"
+          "chatSettings": "Configuración del chat"
         },
         "models": "Modelos",
         "noConfiguredModels": "Sin modelos configurados",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5007,12 +5007,9 @@
         "loading": "Chargement des modèles...",
         "menu": {
           "adjustSettings": "Ajuster les paramètres de {{model}}",
-          "backToChatModels": "Retour aux modèles de chat",
           "backToModels": "Retour aux modèles",
-          "cancel": "Annuler",
           "changeModel": "Changer le modèle {{category}}, {{model}}",
-          "chatSettings": "Paramètres du chat",
-          "confirm": "Confirmer"
+          "chatSettings": "Paramètres du chat"
         },
         "models": "Modèles",
         "noConfiguredModels": "Aucun modèle configuré",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -4953,12 +4953,9 @@
         "loading": "मॉडल लोड हो रहे हैं...",
         "menu": {
           "adjustSettings": "{{model}} की सेटिंग समायोजित करें",
-          "backToChatModels": "चैट मॉडल पर वापस जाएँ",
           "backToModels": "मॉडल पर वापस जाएँ",
-          "cancel": "रद्द करें",
           "changeModel": "{{category}} मॉडल बदलें, {{model}}",
-          "chatSettings": "चैट सेटिंग",
-          "confirm": "पुष्टि करें"
+          "chatSettings": "चैट सेटिंग"
         },
         "models": "मॉडल",
         "noConfiguredModels": "कोई कॉन्फ़िगर मॉडल नहीं",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -4945,12 +4945,9 @@
         "loading": "Memuat model...",
         "menu": {
           "adjustSettings": "Sesuaikan pengaturan {{model}}",
-          "backToChatModels": "Kembali ke model chat",
           "backToModels": "Kembali ke model",
-          "cancel": "Batal",
           "changeModel": "Ubah model {{category}}, {{model}}",
-          "chatSettings": "Pengaturan chat",
-          "confirm": "Konfirmasi"
+          "chatSettings": "Pengaturan chat"
         },
         "models": "Model",
         "noConfiguredModels": "Tidak ada model yang dikonfigurasi",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5007,12 +5007,9 @@
         "loading": "Caricamento modelli...",
         "menu": {
           "adjustSettings": "Modifica le impostazioni di {{model}}",
-          "backToChatModels": "Torna ai modelli di chat",
           "backToModels": "Torna ai modelli",
-          "cancel": "Annulla",
           "changeModel": "Cambia modello di {{category}}, {{model}}",
-          "chatSettings": "Impostazioni della chat",
-          "confirm": "Conferma"
+          "chatSettings": "Impostazioni della chat"
         },
         "models": "Modelli",
         "noConfiguredModels": "Nessun modello configurato",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -4945,12 +4945,9 @@
         "loading": "モデルをロード中...",
         "menu": {
           "adjustSettings": "{{model}} の設定を調整",
-          "backToChatModels": "チャットモデルに戻る",
           "backToModels": "モデルに戻る",
-          "cancel": "キャンセル",
           "changeModel": "{{category}}モデルを変更、{{model}}",
-          "chatSettings": "チャット設定",
-          "confirm": "確認"
+          "chatSettings": "チャット設定"
         },
         "models": "モデル",
         "noConfiguredModels": "設定されたモデルはありません",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -4945,12 +4945,9 @@
         "loading": "모델 불러오는 중...",
         "menu": {
           "adjustSettings": "{{model}} 설정 조정",
-          "backToChatModels": "채팅 모델로 돌아가기",
           "backToModels": "모델로 돌아가기",
-          "cancel": "취소",
           "changeModel": "{{category}} 모델 변경, {{model}}",
-          "chatSettings": "채팅 설정",
-          "confirm": "확인"
+          "chatSettings": "채팅 설정"
         },
         "models": "모델",
         "noConfiguredModels": "구성된 모델 없음",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5007,12 +5007,9 @@
         "loading": "Carregando modelos...",
         "menu": {
           "adjustSettings": "Ajustar configurações de {{model}}",
-          "backToChatModels": "Voltar aos modelos de chat",
           "backToModels": "Voltar aos modelos",
-          "cancel": "Cancelar",
           "changeModel": "Alterar modelo de {{category}}, {{model}}",
-          "chatSettings": "Configurações de chat",
-          "confirm": "Confirmar"
+          "chatSettings": "Configurações de chat"
         },
         "models": "Modelos",
         "noConfiguredModels": "Nenhum modelo configurado",

--- a/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
+++ b/turbo/apps/platform/src/signals/okou-page/model-picker-menu.ts
@@ -1,19 +1,14 @@
 import { command, computed, state } from "ccstate";
 import { onRef } from "../utils.ts";
-import type { ModelProviderSelection } from "../../views/okou-page/components/model-provider-picker.tsx";
 
 type ModelPickerCategory = "chat" | "image" | "video";
 
 type ModelPickerMenuPage =
   | { readonly kind: "overview" }
   | { readonly kind: "models"; readonly category: ModelPickerCategory }
-  | {
-      readonly kind: "settings";
-      readonly selection: ModelProviderSelection;
-      readonly from: "overview" | "models";
-    };
+  | { readonly kind: "settings" };
 
-/** One navigation and unconfirmed draft per composer, including split chats. */
+/** One navigation state per composer, including split chats. */
 export function createModelPickerMenuSignals() {
   const internalPage$ = state<ModelPickerMenuPage>({ kind: "overview" });
   const page$ = computed((get) => {
@@ -25,35 +20,8 @@ export function createModelPickerMenuSignals() {
   const showModels$ = command(({ set }, category: ModelPickerCategory) => {
     set(internalPage$, { kind: "models", category });
   });
-  const editSettings$ = command(
-    (
-      { set },
-      selection: ModelProviderSelection,
-      from: "overview" | "models",
-    ) => {
-      set(internalPage$, { kind: "settings", selection, from });
-    },
-  );
-  const setFast$ = command(({ get, set }, fast: boolean) => {
-    const page = get(internalPage$);
-    if (page.kind === "settings") {
-      set(internalPage$, {
-        ...page,
-        selection: {
-          selectedModel: page.selection.selectedModel,
-          ...(fast ? { codexServiceTier: "fast" } : {}),
-        },
-      });
-    }
-  });
-  const back$ = command(({ get, set }) => {
-    const page = get(internalPage$);
-    set(
-      internalPage$,
-      page.kind === "settings" && page.from === "models"
-        ? { kind: "models", category: "chat" }
-        : { kind: "overview" },
-    );
+  const editSettings$ = command(({ set }) => {
+    set(internalPage$, { kind: "settings" });
   });
   const focusPanelRef$ = onRef(
     command((_context, element: HTMLElement, _signal: AbortSignal) => {
@@ -67,8 +35,6 @@ export function createModelPickerMenuSignals() {
     reset$,
     showModels$,
     editSettings$,
-    setFast$,
-    back$,
     focusPanelRef$,
   };
 }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-model-selection.test.tsx
@@ -523,7 +523,7 @@ test("Let an existing thread send while model availability is reconciling", asyn
   expect(sentPrompts).toHaveLength(1);
 });
 
-test("Confirm a chat model and Fast with only the compact menu switch", async () => {
+test("Switch chat models immediately and adjust Fast from settings", async () => {
   installNewChat(["gpt-5.6-sol", "gpt-5.6-luna"], "gpt-5.6-sol");
   await setupPage({
     context,
@@ -540,21 +540,39 @@ test("Confirm a chat model and Fast with only the compact menu switch", async ()
   click(buttonNamed("Change Chat model, GPT 5.6 Sol", overview));
   const list = await screen.findByRole("region", { name: "Chat models" });
   click(buttonNamed("GPT 5.6 Luna", list));
-  const settings = await screen.findByRole("region", { name: "Chat settings" });
-  await expect(findButton("GPT 5.6 Sol")).resolves.toBeVisible();
-  click(screen.getByRole("switch", { name: "Fast" }));
-  click(buttonNamed("Confirm", settings));
-  await expect(findButton("GPT 5.6 Luna Fast")).resolves.toBeVisible();
+  await expect(findButton("GPT 5.6 Luna")).resolves.toBeVisible();
   const updated = screen.getByRole("region", { name: "Models" });
   expect(
     buttonNamed("Change Chat model, GPT 5.6 Luna", updated),
-  ).toHaveTextContent("Fast");
+  ).toHaveTextContent("Standard");
   click(buttonNamed("Adjust GPT 5.6 Luna settings", updated));
+  await screen.findByRole("region", { name: "Chat settings" });
+  click(screen.getByRole("switch", { name: "Fast" }));
+  await expect(findButton("GPT 5.6 Luna Fast")).resolves.toBeVisible();
+  expect(screen.getByRole("switch", { name: "Fast" })).toBeChecked();
+  click(
+    buttonNamed(
+      "Back to models",
+      screen.getByRole("region", { name: "Chat settings" }),
+    ),
+  );
+  const models = await screen.findByRole("region", { name: "Models" });
+  expect(
+    buttonNamed("Change Chat model, GPT 5.6 Luna", models),
+  ).toHaveTextContent("Fast");
+  click(buttonNamed("Change Chat model, GPT 5.6 Luna", models));
+  const sameModelList = await screen.findByRole("region", {
+    name: "Chat models",
+  });
+  click(buttonNamed("GPT 5.6 Luna", sameModelList));
+  const selected = await screen.findByRole("region", { name: "Models" });
+  await expect(findButton("GPT 5.6 Luna Fast")).resolves.toBeVisible();
+  click(buttonNamed("Adjust GPT 5.6 Luna settings", selected));
   await screen.findByRole("region", { name: "Chat settings" });
   expect(screen.getByRole("switch", { name: "Fast" })).toBeChecked();
 });
 
-test("Discard unconfirmed Fast changes and return along the menu path", async () => {
+test("Keep immediate Fast changes when navigating back through the menu", async () => {
   const user = userEvent.setup({ delay: null });
   installNewChat(["gpt-5.6-sol", "gpt-5.6-luna"], "gpt-5.6-sol");
   await setupPage({
@@ -571,14 +589,21 @@ test("Discard unconfirmed Fast changes and return along the menu path", async ()
   click(buttonNamed("Adjust GPT 5.6 Sol settings", overview));
   await screen.findByRole("region", { name: "Chat settings" });
   click(screen.getByRole("switch", { name: "Fast" }));
+  await expect(findButton("GPT 5.6 Sol Fast")).resolves.toBeVisible();
   await user.keyboard("{Escape}");
   overview = await screen.findByRole("region", { name: "Models" });
+  expect(
+    buttonNamed("Change Chat model, GPT 5.6 Sol", overview),
+  ).toHaveTextContent("Fast");
   click(buttonNamed("Adjust GPT 5.6 Sol settings", overview));
   await screen.findByRole("region", { name: "Chat settings" });
+  expect(screen.getByRole("switch", { name: "Fast" })).toBeChecked();
+  click(screen.getByRole("switch", { name: "Fast" }));
+  await expect(findButton("GPT 5.6 Sol")).resolves.toBeVisible();
   expect(screen.getByRole("switch", { name: "Fast" })).not.toBeChecked();
   click(
     buttonNamed(
-      "Cancel",
+      "Back to models",
       screen.getByRole("region", { name: "Chat settings" }),
     ),
   );
@@ -586,8 +611,9 @@ test("Discard unconfirmed Fast changes and return along the menu path", async ()
   click(buttonNamed("Change Chat model, GPT 5.6 Sol", overview));
   const list = await screen.findByRole("region", { name: "Chat models" });
   click(buttonNamed("GPT 5.6 Luna", list));
-  await screen.findByRole("region", { name: "Chat settings" });
-  await user.keyboard("{Escape}");
+  await expect(findButton("GPT 5.6 Luna")).resolves.toBeVisible();
+  overview = screen.getByRole("region", { name: "Models" });
+  click(buttonNamed("Change Chat model, GPT 5.6 Luna", overview));
   await screen.findByRole("region", { name: "Chat models" });
   await user.keyboard("{Escape}");
   await screen.findByRole("region", { name: "Models" });
@@ -597,8 +623,11 @@ test("Discard unconfirmed Fast changes and return along the menu path", async ()
       screen.queryByRole("region", { name: "Models" }),
     ).not.toBeInTheDocument();
   });
-  click(await findButton("GPT 5.6 Sol"));
-  await screen.findByRole("region", { name: "Models" });
+  click(await findButton("GPT 5.6 Luna"));
+  overview = await screen.findByRole("region", { name: "Models" });
+  click(buttonNamed("Adjust GPT 5.6 Luna settings", overview));
+  await screen.findByRole("region", { name: "Chat settings" });
+  expect(screen.getByRole("switch", { name: "Fast" })).not.toBeChecked();
 });
 
 test("Keep unavailable routes disabled and open plan comparison from the compact menu", async () => {
@@ -641,7 +670,7 @@ test("Keep unavailable routes disabled and open plan comparison from the compact
   await expect(findButton("DeepSeek V4 Flash")).resolves.toBeVisible();
 });
 
-test("Navigate the compact menu by keyboard and discard a dismissed draft", async () => {
+test("Navigate the compact menu by keyboard and retain Fast after dismissal", async () => {
   const user = userEvent.setup({ delay: null });
   context.mocks.browser.matchMedia((query) => {
     return query === "(min-width: 640px)";
@@ -658,7 +687,9 @@ test("Navigate the compact menu by keyboard and discard a dismissed draft", asyn
   const composer = await readyComposer();
   click(await findButton("GPT 5.6 Sol"));
   const overview = await screen.findByRole("region", { name: "Models" });
+  const modelButton = buttonNamed("Change Chat model, GPT 5.6 Sol", overview);
   const settingsButton = buttonNamed("Adjust GPT 5.6 Sol settings", overview);
+  expect(modelButton).toHaveFocus();
   await user.keyboard("{ArrowDown}");
   expect(settingsButton).toHaveFocus();
   await user.keyboard("{Enter}");
@@ -666,6 +697,7 @@ test("Navigate the compact menu by keyboard and discard a dismissed draft", asyn
   await user.keyboard("{ArrowDown}");
   expect(screen.getByRole("switch", { name: "Fast" })).toHaveFocus();
   await user.keyboard(" ");
+  await expect(findButton("GPT 5.6 Sol Fast")).resolves.toBeVisible();
   expect(screen.getByRole("switch", { name: "Fast" })).toBeChecked();
   await user.click(composer);
   await waitFor(() => {
@@ -673,9 +705,9 @@ test("Navigate the compact menu by keyboard and discard a dismissed draft", asyn
       screen.queryByRole("region", { name: "Chat settings" }),
     ).not.toBeInTheDocument();
   });
-  click(await findButton("GPT 5.6 Sol"));
+  click(await findButton("GPT 5.6 Sol Fast"));
   const reopened = await screen.findByRole("region", { name: "Models" });
   click(buttonNamed("Adjust GPT 5.6 Sol settings", reopened));
   await screen.findByRole("region", { name: "Chat settings" });
-  expect(screen.getByRole("switch", { name: "Fast" })).not.toBeChecked();
+  expect(screen.getByRole("switch", { name: "Fast" })).toBeChecked();
 });

--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -220,7 +220,7 @@ function ModelPickerOverview({
             selectedOption?.fastAvailable && value
               ? () => {
                   mediaModelPanel?.onActiveCategoryChange(null);
-                  editSettings(value, "overview");
+                  editSettings();
                 }
               : undefined
           }
@@ -251,16 +251,12 @@ function ChatModelSettings({
   signals,
   options,
   selection,
-  from,
   onChange,
 }: Pick<ModelPickerMenuContentProps, "signals" | "options" | "onChange"> & {
   selection: ModelProviderSelection;
-  from: "overview" | "models";
 }) {
   const { t } = useTranslation();
-  const reset = useSet(signals.reset$);
-  const back = useSet(signals.back$);
-  const setFast = useSet(signals.setFast$);
+  const back = useSet(signals.reset$);
   const option = options.find((candidate) => {
     return candidate.model === selection.selectedModel;
   });
@@ -271,15 +267,9 @@ function ChatModelSettings({
           return $.settings.models.picker.menu.chatSettings;
         })}
         onBack={back}
-        backLabel={
-          from === "models"
-            ? t(($) => {
-                return $.settings.models.picker.menu.backToChatModels;
-              })
-            : t(($) => {
-                return $.settings.models.picker.menu.backToModels;
-              })
-        }
+        backLabel={t(($) => {
+          return $.settings.models.picker.menu.backToModels;
+        })}
       />
       <div className="border-b border-border/60 px-2 py-2.5 text-sm">
         {option?.content ??
@@ -304,33 +294,14 @@ function ChatModelSettings({
             return $.settings.models.picker.fast;
           })}
           checked={selection.codexServiceTier === "fast"}
-          onCheckedChange={setFast}
-          disabled={!option?.fastAvailable}
-        />
-      </div>
-      <div className="flex items-center justify-between border-t border-border/60 px-2 pb-1.5 pt-3">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-muted-foreground hover:text-foreground"
-          onClick={reset}
-        >
-          {t(($) => {
-            return $.settings.models.picker.menu.cancel;
-          })}
-        </Button>
-        <Button
-          size="sm"
-          disabled={!option?.fastAvailable || option.disabled}
-          onClick={() => {
-            onChange(selection);
-            reset();
+          onCheckedChange={(fast) => {
+            onChange({
+              selectedModel: selection.selectedModel,
+              ...(fast ? { codexServiceTier: "fast" } : {}),
+            });
           }}
-        >
-          {t(($) => {
-            return $.settings.models.picker.menu.confirm;
-          })}
-        </Button>
+          disabled={!option?.fastAvailable || option.disabled}
+        />
       </div>
     </>
   );
@@ -346,21 +317,14 @@ function ChatModelList({
   "signals" | "options" | "value" | "onChange"
 >) {
   const { t } = useTranslation();
-  const back = useSet(signals.back$);
   const reset = useSet(signals.reset$);
-  const editSettings = useSet(signals.editSettings$);
   const chooseChat = (option: ModelPickerMenuOption) => {
-    if (option.fastAvailable) {
-      editSettings(
-        value?.selectedModel === option.model
-          ? value
-          : { selectedModel: option.model },
-        "models",
-      );
-    } else {
-      onChange({ selectedModel: option.model });
-      reset();
-    }
+    onChange(
+      value?.selectedModel === option.model
+        ? value
+        : { selectedModel: option.model },
+    );
+    reset();
   };
   return (
     <>
@@ -368,7 +332,7 @@ function ChatModelList({
         label={t(($) => {
           return $.settings.models.picker.chatModels;
         })}
-        onBack={back}
+        onBack={reset}
         backLabel={t(($) => {
           return $.settings.models.picker.menu.backToModels;
         })}
@@ -418,7 +382,6 @@ function MediaModelList({
   categoryId: "image" | "video";
 }) {
   const { t } = useTranslation();
-  const back = useSet(signals.back$);
   const reset = useSet(signals.reset$);
   const category = mediaModelPanel?.categories.find((candidate) => {
     return candidate.id === categoryId;
@@ -432,7 +395,7 @@ function MediaModelList({
             return $.settings.models.picker.models;
           })
         }
-        onBack={back}
+        onBack={reset}
         backLabel={t(($) => {
           return $.settings.models.picker.menu.backToModels;
         })}
@@ -476,7 +439,7 @@ function MediaModelList({
 export function ModelPickerMenuContent(props: ModelPickerMenuContentProps) {
   const { t } = useTranslation();
   const page = useGet(props.signals.page$);
-  const back = useSet(props.signals.back$);
+  const back = useSet(props.signals.reset$);
   const focusPanel = useSet(props.signals.focusPanelRef$);
   let content: ReactNode;
   let label: string;
@@ -489,12 +452,8 @@ export function ModelPickerMenuContent(props: ModelPickerMenuContentProps) {
     label = t(($) => {
       return $.settings.models.picker.menu.chatSettings;
     });
-    content = (
-      <ChatModelSettings
-        {...props}
-        selection={page.selection}
-        from={page.from}
-      />
+    content = props.value && (
+      <ChatModelSettings {...props} selection={props.value} />
     );
   } else if (page.category === "chat") {
     label = t(($) => {
@@ -518,7 +477,7 @@ export function ModelPickerMenuContent(props: ModelPickerMenuContentProps) {
       ref={focusPanel}
       role="region"
       aria-label={label}
-      className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150"
+      className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150 [&_button:focus-visible]:ring-inset [&_button:focus-visible]:ring-offset-0"
       onKeyDown={(event) => {
         if (event.key === "Escape" && page.kind !== "overview") {
           event.preventDefault();


### PR DESCRIPTION
## Summary

Selecting a chat model in the compact composer menu now applies it immediately and returns to the model overview. Chat settings opens only from its explicit settings control, and the Fast switch applies changes immediately without Cancel or Confirm buttons. Settings reads the current selection so it stays consistent with the composer, and reselecting the current model preserves its speed.

Draw focus rings inside menu buttons so the sticky header and scroll containers do not clip them. These fixes remain scoped to the existing ModelPickerMenu feature switch; unused menu translations are removed from all locales.

## Verification

- Platform lint, including localization validation: passed
- Platform TypeScript checks: passed
- Platform Knip analysis: passed
- Model selection and media model page integration tests: 28 passed across 2 files
- Formatting and diff checks: passed
- Chromium preview QA at 1440x900 and 390x844: passed. Verified an immediately applied GPT 5.6 Luna selection returns to the overview, Fast applies from the settings switch and survives dismissal/reopening, and keyboard focus rings remain fully visible with no horizontal overflow.
- All PR CI checks: passed on head `08be9a576a26acd8f353a2624f1a23c0d9b7abf2` (preview merge candidate `301e1d741d18ce57279e54414b48afacb03094aa`).

Preview: https://pr-32238-app-okou-app-preview.vm0.workers.dev/

Browser QA used a new test account with onboarding completed, `modelPickerMenu` enabled, and real-agent execution disabled.
