### PR TITLE
test(e2e): align zendesk probe with firewall auth

### DIFF
--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -533,12 +533,11 @@ runner_e2e_wait_for_firewall_log() {
                     | select(
                         .firewall_name == $firewallName and
                         .host == $host and
-                        .action == "BLOCK" and
                         (.firewall_error // null) != null
                     ) ]
                     | select(length > 0)' \
                 <<<"$last_logs"); then
-                echo "Firewall ${firewall_name@Q} on ${host@Q} reported an authentication error for run ${run_id}" >&2
+                echo "Firewall ${firewall_name@Q} on ${host@Q} reported an error for run ${run_id}" >&2
                 echo "Matching network telemetry: ${failed_logs}" >&2
                 echo "Last network telemetry: ${last_logs}" >&2
                 return 1

--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -504,10 +504,11 @@ runner_e2e_wait_for_firewall_log() {
     local timeout_seconds="${6:-90}"
     local started_at=$SECONDS
     local last_logs='[]'
+    local failed_logs='[]'
 
     while ((SECONDS - started_at < timeout_seconds)); do
-        if last_logs=$(runner_e2e_network_logs "$run_id" 2>&1) &&
-            jq -e \
+        if last_logs=$(runner_e2e_network_logs "$run_id" 2>&1); then
+            if jq -e \
                 --arg firewallName "$firewall_name" \
                 --arg host "$host" \
                 --arg expectedUrlRewrite "$expected_url_rewrite" \
@@ -521,8 +522,27 @@ runner_e2e_wait_for_firewall_log() {
                     ($expectedUrlRewrite == "ignore" or
                         .auth_url_rewrite == ($expectedUrlRewrite == "true")))' \
                 <<<"$last_logs" >/dev/null; then
-            printf '%s\n' "$last_logs"
-            return 0
+                printf '%s\n' "$last_logs"
+                return 0
+            fi
+
+            if failed_logs=$(jq -ce \
+                --arg firewallName "$firewall_name" \
+                --arg host "$host" '
+                    [ .[]
+                    | select(
+                        .firewall_name == $firewallName and
+                        .host == $host and
+                        .action == "BLOCK" and
+                        (.firewall_error // null) != null
+                    ) ]
+                    | select(length > 0)' \
+                <<<"$last_logs"); then
+                echo "Firewall ${firewall_name@Q} on ${host@Q} reported an authentication error for run ${run_id}" >&2
+                echo "Matching network telemetry: ${failed_logs}" >&2
+                echo "Last network telemetry: ${last_logs}" >&2
+                return 1
+            fi
         fi
         sleep 2
     done

--- a/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
+++ b/e2e/tests/03-runner/run-t03-firewall-zendesk.bats
@@ -39,11 +39,11 @@ set -euo pipefail
 printf 'ZENDESK_API_TOKEN=%s\n' "$ZENDESK_API_TOKEN"
 printf 'ZENDESK_EMAIL=%s\n' "$ZENDESK_EMAIL"
 printf 'ZENDESK_SUBDOMAIN=%s\n' "$ZENDESK_SUBDOMAIN"
-# A Zendesk response is outside this test's contract. Use the real templated
-# authority so credential injection follows the normal upstream binding path,
-# while keeping the request on IPv4 and bounding the third-party wait.
+# A Zendesk response is outside this test's contract. Keep the request on the
+# real IPv4 authority and outlive the proxy's 10-second firewall-auth deadline,
+# so auth reaches a decision before this shell can complete the run.
 curl_status=0
-curl --ipv4 --silent --show-error --max-time 5 \
+curl --ipv4 --silent --show-error --max-time 15 \
     --output /dev/null \
     "https://__SUBDOMAIN__.zendesk.com/api/v2/users/me.json" || curl_status=$?
 printf 'ZENDESK_REQUEST_SENT=%s\n' "$curl_status"


### PR DESCRIPTION
## Summary

- keep the Zendesk guest request alive beyond the proxy's bounded firewall-auth operation so the run cannot finish first
- fail the firewall ALLOW waiter immediately when the expected connector and host already report a definitive firewall error
- preserve the fresh Zendesk authority, exact secret assertion, direct upstream binding, and non-fatal third-party response outcome

Production API admission, runner lifecycle, connector metadata, the 90-second telemetry observation ceiling, and transition-specific firewall coverage are unchanged.

Closes #32235

## Testing

- `cd e2e && ./test/libs/bats/bin/bats --count tests/03-runner/run-t03-firewall-zendesk.bats`
- `bash -n e2e/helpers/runner-api.bash`
- `shellcheck -e SC2034 e2e/helpers/runner-api.bash` (`TEST_ID` is consumed by callers after this helper is sourced)
- focused shell behavior check for ALLOW success, matching-error failure including `ALLOW + firewall_error`, and ALLOW-first ordering
- `./scripts/check-file-size.sh e2e/helpers/runner-api.bash e2e/tests/03-runner/run-t03-firewall-zendesk.bats`
- `git diff --check`
- `lefthook run pre-commit --file e2e/helpers/runner-api.bash --file e2e/tests/03-runner/run-t03-firewall-zendesk.bats`

The full `03-runner` integration is CI-only because it requires the PR preview, temporary connector account, provisioned runner fleet, guest, and mitm add-on. The PR pipeline is the authoritative end-to-end validation.
