### PR TITLE
test(python): cover fail-closed sse discard paths

### DIFF
--- a/crates/runner/mitm-addon/tests/test_anthropic_messages.py
+++ b/crates/runner/mitm-addon/tests/test_anthropic_messages.py
@@ -8,6 +8,24 @@ from usage import (
     create_anthropic_messages_sse_usage_extractor,
     create_model_json_response_inspector,
 )
+from usage.model_http import ModelHttpFailureEvidence
+
+
+class _RecordingFailureObserver:
+    def __init__(self) -> None:
+        self.observed: list[ModelHttpFailureEvidence] = []
+
+    def needs_sse_event(self, event_name: str | None) -> bool:
+        return True
+
+    def observe(self, evidence: ModelHttpFailureEvidence) -> None:
+        self.observed.append(evidence)
+
+    def observe_json(self, evidence: ModelHttpFailureEvidence) -> None:
+        raise AssertionError(f"unexpected JSON evidence: {evidence}")
+
+    def finish(self) -> None:
+        return None
 
 
 def _create_parser_with_parse_errors():
@@ -149,6 +167,31 @@ class TestAnthropicSseUsageExtractor:
         assert usage["model"] == "claude-sonnet-4-6"
         assert usage["tokens.input"] == 21
         assert usage["tokens.output"] == 1
+
+    def test_discarded_failure_event_emits_invalid_evidence_and_recovers(self):
+        failure_observer = _RecordingFailureObserver()
+        parse, usage = create_anthropic_messages_sse_usage_extractor(
+            failure_observer=failure_observer
+        )
+
+        parse(
+            b"event: error\n"
+            b'data: {"type":"error","error":{\n' + b"x" * 4097 + b"\n\n"
+            b"event: error\n"
+            b'data: {"type":"error","error":{"type":"api_error"}}\n\n'
+        )
+
+        assert usage == {}
+        assert failure_observer.observed == [
+            ModelHttpFailureEvidence(event_name="error"),
+            ModelHttpFailureEvidence(
+                event_name="error",
+                payload_type="error",
+                failure_codes=("api_error",),
+                has_error=True,
+                is_valid=True,
+            ),
+        ]
 
     def test_finish_flushes_message_start_without_blank_line(self):
         parse, usage = create_anthropic_messages_sse_usage_extractor()

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -1867,6 +1867,40 @@ def test_sse_failure_is_reported_before_response_hook(
         mitm_addon.response(flow)
 
 
+def test_discarded_sse_failure_settles_unknown_before_later_failure(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    model_provider_failure_api,
+):
+    body = (
+        b"event: response.failed\n"
+        b'data: {"type":"response.failed","response":{\n' + b"x" * 4097 + b"\n\n"
+        b"event: response.failed\n"
+        b'data: {"type":"response.failed","response":{'
+        b'"error":{"code":"server_error"}}}\n\n'
+    )
+    flow = _make_flow(
+        real_flow,
+        tmp_path / "proxy.jsonl",
+        request_path="/v1/responses",
+        response_body=body,
+        response_headers=header_map({"content-type": "text/event-stream"}),
+    )
+    model_provider_failure.admit_flow(flow)
+    mitm_addon.responseheaders(flow)
+    stream = response_stream(flow)
+    stream(body)
+    stream(b"")
+
+    assert _reported_payloads(model_provider_failure_api) == []
+
+    with mitm_ctx():
+        mitm_addon.response(flow)
+
+    assert _reported_payloads(model_provider_failure_api) == []
+
+
 def test_json_failure_is_reported_at_stream_end_before_response_hook(
     tmp_path,
     real_flow,

--- a/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
+++ b/crates/runner/mitm-addon/tests/test_openai_chat_completions_usage.py
@@ -150,6 +150,39 @@ def test_canonical_sse_deltas_skip_selective_extraction_across_framing_variants(
     ]
 
 
+def test_discarded_failure_event_emits_invalid_evidence_and_recovers():
+    observer = _RecordingFailureObserver()
+    scanner, parsed_usage = (
+        openai_chat_completions.create_openai_chat_completions_sse_usage_extractor(
+            failure_observer=observer
+        )
+    )
+
+    scanner(
+        b"event: chunk\n"
+        b'data: {"object":"chat.completion.chunk","padding":"'
+        + b"x" * openai_chat_completions._CHAT_COMPLETIONS_SSE_FAST_PATH_MAX_BYTES
+        + b"\n"
+        + b"x" * 4097
+        + b"\n\n"
+        b"event: chunk\n"
+        b'data: {"object":"chat.completion.chunk","choices":[{'
+        b'"error":{"metadata":{"error_type":"provider_overloaded"}}}]}\n\n'
+    )
+
+    assert parsed_usage == {}
+    assert observer.observed == [
+        ModelHttpFailureEvidence(event_name="chunk"),
+        ModelHttpFailureEvidence(
+            event_name="chunk",
+            failure_codes=("provider_overloaded",),
+            has_error=True,
+            has_choices=True,
+            is_valid=True,
+        ),
+    ]
+
+
 def test_sse_fast_path_bound_is_inclusive_and_overflow_replays_once():
     finish_calls, tracked_finish = _track_chat_extractor_finishes()
     exact = _canonical_delta_with_size(

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -94,6 +94,32 @@ class TestOpenAIResponsesSseUsageExtractor:
             "tokens.output": 0,
         }
 
+    def test_discarded_failure_event_emits_invalid_evidence_and_recovers(self):
+        failure_observer = _IgnoringDeltaFailureObserver()
+        parse, usage = create_openai_responses_sse_usage_extractor(
+            failure_observer=failure_observer
+        )
+
+        parse(
+            b"event: response.failed\n"
+            b'data: {"type":"response.failed","response":{\n' + b"x" * 4097 + b"\n\n"
+            b"event: response.failed\n"
+            b'data: {"type":"response.failed","response":{'
+            b'"error":{"code":"server_error"}}}\n\n'
+        )
+
+        assert usage == {}
+        assert failure_observer.observed == [
+            ModelHttpFailureEvidence(event_name="response.failed"),
+            ModelHttpFailureEvidence(
+                event_name="response.failed",
+                payload_type="response.failed",
+                failure_codes=("server_error",),
+                has_error=True,
+                is_valid=True,
+            ),
+        ]
+
     @pytest.mark.parametrize(
         ("event_type", "event_prefix"),
         [


### PR DESCRIPTION
## Summary

- cover bounded SSE control-line discards in the OpenAI Responses, Chat Completions, and Anthropic provider handlers
- assert each handler emits invalid failure evidence and cleanly parses a later valid failure event
- prove the full HTTP pipeline keeps an ambiguous discarded event settled as unknown and does not report a later provider failure

## Scope

This is a test-only change. It does not modify provider parsing, failure reporting, APIs, persisted data, dependencies, or deployment behavior.

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_openai_responses_sse.py tests/test_openai_chat_completions_usage.py tests/test_anthropic_messages.py tests/test_model_provider_failure_reporting.py` (263 passed)
- `uv run --no-sync python -m pytest tests/` (7,326 passed)
- temporarily removed each provider `on_event_discard()` observer call independently; each corresponding new test failed, then the production code was restored

Closes #32233
