### PR TITLE
docs(nbd-cow): document nbd-cow error variant semantics

### DIFF
--- a/crates/nbd-cow/src/error.rs
+++ b/crates/nbd-cow/src/error.rs
@@ -8,25 +8,57 @@ pub use crate::protocol_impl::ProtocolError;
 /// Error type returned by `nbd-cow` operations.
 #[derive(Debug, thiserror::Error)]
 pub enum NbdCowError {
+    /// An error while decoding or validating an NBD transmission-protocol
+    /// request. The contained [`ProtocolError`] identifies the protocol
+    /// violation.
     #[error("protocol error: {0}")]
     Protocol(#[from] ProtocolError),
 
+    /// An operating-system I/O failure encountered while using the device,
+    /// COW files, sockets, or related resources. The contained
+    /// [`std::io::Error`] preserves the underlying error kind and details.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// A requested byte range extends beyond the configured device size.
+    ///
+    /// The operation starts at `offset`, spans `length` bytes, and is checked
+    /// against `device_size`.
     #[error("offset {offset} + length {length} exceeds device size {device_size}")]
     OutOfBounds {
+        /// Byte offset at which the requested operation begins.
         offset: u64,
+        /// Number of bytes in the requested operation.
         length: u64,
+        /// Total device size, in bytes, used for the bounds check.
         device_size: u64,
     },
 
+    /// Malformed or otherwise unusable generic-netlink data encountered while
+    /// communicating with the kernel. The string contains a diagnostic for
+    /// the userspace parsing or validation failure; unlike
+    /// [`Self::NetlinkErrno`], this variant is not a kernel-reported errno.
     #[error("netlink error: {0}")]
     Netlink(String),
 
+    /// A generic-netlink request received a kernel-reported operating-system
+    /// errno. The errno and its human-readable message are available for
+    /// callers that need to classify a specific kernel response, such as
+    /// `EBUSY` from [`crate::netlink::connect_device`].
     #[error("netlink errno {errno}: {message}")]
-    NetlinkErrno { errno: i32, message: String },
+    NetlinkErrno {
+        /// Positive operating-system errno returned by the kernel.
+        errno: i32,
+        /// Human-readable operating-system error description for `errno`.
+        message: String,
+    },
 
+    /// No NBD device could be acquired for the operation.
+    ///
+    /// This can represent an exhausted or unavailable device-pool scan, an
+    /// inactive pool, or exhausted retries after devices reported `EBUSY`.
+    /// It is a broad availability error and does not by itself guarantee that
+    /// retrying is appropriate.
     #[error("no free NBD device found")]
     NoFreeDevice,
 }


### PR DESCRIPTION
## Summary

- Document all six public `NbdCowError` variants.
- Describe the byte-range fields in `OutOfBounds` and the errno/message payload in `NetlinkErrno`.
- Clarify the distinction between malformed netlink data and kernel-reported netlink errno responses, and document the broad non-guaranteed-retry meaning of `NoFreeDevice`.

Closes #32211

## Scope

This is a documentation-only change in `crates/nbd-cow/src/error.rs`. It does not change public types or field names, display strings, error matching, retry behavior, or runtime logic. No tests or deployment/migration behavior were changed.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml -p nbd-cow -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p nbd-cow --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p nbd-cow --no-deps`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p nbd-cow` — 245 unit tests, 11 dispatch tests, 2 pool tests, and 2 public API tests passed; 13 host-dependent integration tests remained ignored by their existing configuration.
