### PR TITLE
refactor(platform): rename remaining internal brand identifiers

### DIFF
--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -275,7 +275,7 @@ const embeddedIndexTemplate = builtIndexTemplate
   .replace(
     "</head>",
     [
-      '<link id="vm0-main-stylesheet" rel="preload" as="style" href="https://static.okou.io/okou-app/assets/index-Test1234.css" />',
+      '<link id="okou-main-stylesheet" rel="preload" as="style" href="https://static.okou.io/okou-app/assets/index-Test1234.css" />',
       '<link rel="modulepreload" href="https://static.okou.io/okou-app/assets/vendor-Test1234.js" />',
       "</head>",
     ].join("\n"),

--- a/.github/scripts/tests/verify-okou-app-runtime-test.sh
+++ b/.github/scripts/tests/verify-okou-app-runtime-test.sh
@@ -33,8 +33,8 @@ cat > "$html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
 <meta name="okou-app-version" content="0.812.5">
-<link id="vm0-main-stylesheet" rel="preload" as="style" crossorigin href="https://static.test/okou-app/assets/index-QrSt7890.css">
-<script id="vm0-main-stylesheet-loader"></script>
+<link id="okou-main-stylesheet" rel="preload" as="style" crossorigin href="https://static.test/okou-app/assets/index-QrSt7890.css">
+<script id="okou-main-stylesheet-loader"></script>
 <script type="module" crossorigin src="https://static.test/okou-app/assets/app-AbCd1234.js"></script>
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-IjKl9012.js">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-EfGh5678.js">
@@ -44,8 +44,8 @@ cat > "$old_html_source" <<'HTML'
 <!doctype html>
 <meta name="okou-app-git-commit-sha" content="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb">
 <meta name="okou-app-version" content="0.812.4">
-<link id="vm0-main-stylesheet" rel="preload" as="style" crossorigin href="https://static.test/okou-app/assets/index-Old12345.css">
-<script id="vm0-main-stylesheet-loader"></script>
+<link id="okou-main-stylesheet" rel="preload" as="style" crossorigin href="https://static.test/okou-app/assets/index-Old12345.css">
+<script id="okou-main-stylesheet-loader"></script>
 <script type="module" crossorigin src="https://static.test/okou-app/assets/app-Old12345.js"></script>
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/rolldown-runtime-Old12345.js">
 <link rel="modulepreload" crossorigin href="https://static.test/okou-app/assets/vendor-Old12345.js">

--- a/.github/scripts/verify-okou-app-runtime.sh
+++ b/.github/scripts/verify-okou-app-runtime.sh
@@ -105,8 +105,8 @@ COMMIT_SHA_META_NAME = "okou-app-git-commit-sha"
 VERSION_META_NAME = "okou-app-version"
 RUNTIME_META_NAMES = {COMMIT_SHA_META_NAME, VERSION_META_NAME}
 COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
-MAIN_STYLESHEET_ID = "vm0-main-stylesheet"
-MAIN_STYLESHEET_LOADER_SCRIPT_ID = "vm0-main-stylesheet-loader"
+MAIN_STYLESHEET_ID = "okou-main-stylesheet"
+MAIN_STYLESHEET_LOADER_SCRIPT_ID = "okou-main-stylesheet-loader"
 
 
 class AppDocumentParser(HTMLParser):

--- a/turbo/apps/platform/scripts/app-resource-priority-html.ts
+++ b/turbo/apps/platform/scripts/app-resource-priority-html.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from "vite";
 
-const MAIN_STYLESHEET_ID = "vm0-main-stylesheet";
-const MAIN_STYLESHEET_LOADER_SCRIPT_ID = "vm0-main-stylesheet-loader";
+const MAIN_STYLESHEET_ID = "okou-main-stylesheet";
+const MAIN_STYLESHEET_LOADER_SCRIPT_ID = "okou-main-stylesheet-loader";
 
 function matchingTags(
   htmlSource: string,

--- a/turbo/apps/platform/scripts/check-build-config.node.ts
+++ b/turbo/apps/platform/scripts/check-build-config.node.ts
@@ -391,9 +391,9 @@ function assertApplicationStylesheetPreload(htmlSource: string): void {
   const criticalStyleIndex = htmlSource.indexOf(
     '<style id="app-bootstrap-critical-styles">',
   );
-  const stylesheetIndex = htmlSource.indexOf('id="vm0-main-stylesheet"');
+  const stylesheetIndex = htmlSource.indexOf('id="okou-main-stylesheet"');
   const stylesheetLoaderIndex = htmlSource.indexOf(
-    'id="vm0-main-stylesheet-loader"',
+    'id="okou-main-stylesheet-loader"',
   );
   const clerkCoreIndex = htmlSource.indexOf('id="okou-clerk-core-script"');
   const clerkBootstrapIndex = htmlSource.indexOf(
@@ -413,7 +413,7 @@ function assertApplicationStylesheetPreload(htmlSource: string): void {
   assert.ok(skeletonIndex > headEndIndex);
   assert.match(
     htmlSource,
-    /<link id="vm0-main-stylesheet" rel="preload" as="style"[^>]*>/u,
+    /<link id="okou-main-stylesheet" rel="preload" as="style"[^>]*>/u,
   );
   assert.equal((htmlSource.match(/<link rel="stylesheet"/gu) ?? []).length, 0);
   assert.doesNotMatch(htmlSource, /\sfetchpriority=/u);

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1692,7 +1692,7 @@ details > summary {
   width: 82px;
 }
 
-.owf-diagram-node-zero {
+.owf-diagram-node-okou {
   top: 45px;
   left: 277px;
   width: 72px;

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -2483,7 +2483,7 @@ function applyPresentationTemplateThumbnailTheme(
   themeVariables: PresentationTemplateThemeVariables,
 ): void {
   const root = host.shadowRoot?.querySelector<HTMLElement>(
-    ".vm0-shadow-preview-root",
+    ".presentation-template-shadow-preview-root",
   );
   if (root === undefined || root === null) {
     return;
@@ -2524,7 +2524,7 @@ function renderPresentationTemplateShadowThumbnail(
       position: relative;
       width: 100%;
     }
-    .vm0-shadow-preview-root {
+    .presentation-template-shadow-preview-root {
       background: #fff;
       height: 100%;
       inset: 0;
@@ -2534,10 +2534,10 @@ function renderPresentationTemplateShadowThumbnail(
       user-select: none;
       width: 100%;
     }
-    .vm0-shadow-preview-root *,
-    .vm0-shadow-preview-root *:hover,
-    .vm0-shadow-preview-root *:focus,
-    .vm0-shadow-preview-root *:focus-visible {
+    .presentation-template-shadow-preview-root *,
+    .presentation-template-shadow-preview-root *:hover,
+    .presentation-template-shadow-preview-root *:focus,
+    .presentation-template-shadow-preview-root *:focus-visible {
       caret-color: transparent !important;
       outline: 0 !important;
       pointer-events: none !important;
@@ -2550,13 +2550,13 @@ function renderPresentationTemplateShadowThumbnail(
     if (clone instanceof HTMLStyleElement && clone.textContent !== null) {
       clone.textContent = clone.textContent.replaceAll(
         ":root",
-        ":host, .vm0-shadow-preview-root",
+        ":host, .presentation-template-shadow-preview-root",
       );
     }
     shadow.append(clone);
   }
   const root = document.createElement("div");
-  root.className = "vm0-shadow-preview-root";
+  root.className = "presentation-template-shadow-preview-root";
   root.append(
     ...Array.from(doc.body.childNodes).map((node) => {
       return node.cloneNode(true);

--- a/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
+++ b/turbo/apps/platform/src/views/onboarding/onboarding-workflow-diagram.tsx
@@ -365,7 +365,7 @@ export function WorkflowPreviewDiagram({
         ) : null}
         <WorkflowDiagramNode
           label=""
-          className="owf-diagram-node-zero"
+          className="owf-diagram-node-okou"
           iconClassName="owf-diagram-avatar"
         >
           <span className="owf-diagram-okou-icon" aria-hidden="true">

--- a/turbo/docs/react.md
+++ b/turbo/docs/react.md
@@ -62,14 +62,15 @@ function SidebarNavContent() {
   // ...renders nav content
 }
 
-export function Sidebar() {
-  // Zero async subscriptions — renders exactly once on page load
+export function Sidebar({ isDesktop }: { isDesktop: boolean }) {
+  // No async subscriptions at this level
   return (
-    <VM0ClerkProvider>
-      <SidebarNavContent />
-      <ManagePinnedAgentsDialogContainer />
-      <BillingDialog />
-    </VM0ClerkProvider>
+    <>
+      {isDesktop ? <ThreeColumnNav /> : <ExpandedSidebar />}
+      <ThreeColumnSearchDialogContainer />
+      <PinAgentDialogContainer />
+      <ChatThreadDialogs />
+    </>
   );
 }
 ```

--- a/turbo/packages/eslint-rules/src/ccstate/__tests__/prefer-ui-components.test.ts
+++ b/turbo/packages/eslint-rules/src/ccstate/__tests__/prefer-ui-components.test.ts
@@ -52,7 +52,7 @@ ruleTester.run("prefer-ui-components", rule, {
     {
       code: `
         const card = (
-          <button className="zero-card flex flex-col p-4 text-left hover:bg-state-hover">
+          <button className="sample-card flex flex-col p-4 text-left hover:bg-state-hover">
             {body}
           </button>
         );


### PR DESCRIPTION
Closes #32240.
Part of #32157.

## Summary

- Rename the remaining repository-local onboarding and presentation-preview CSS/DOM classes, moving every producer and consumer together.
- Rename the generated main-stylesheet and loader HTML IDs across the Vite transform, build assertions, worker fixture, runtime verifier, and verifier fixtures.
- Replace the branded ESLint RuleTester fixture class with a neutral sample and update the React performance example to the current `Sidebar` composition.

## Behavior and boundaries

- The stylesheet loader still preloads the same asset, activates it on the same load event, and resolves after the same two animation frames.
- The runtime verifier still waits for served/canonical build metadata equality before strictly validating one stylesheet, one loader, exact assets, and exact preload attributes. No dual matching or compatibility fallback was added.
- Shadow DOM selectors, `:root` rewriting, pointer isolation, and theme-variable application are unchanged apart from the atomic class rename.
- No persisted key, public VM0 brand/logo, Desktop asset, static object key, deployment identity, classifier, baseline, lint policy, or old-name absence test is changed or added.
- Open-PR inventory remains #32204/#32069 on `chat-composer.tsx` and #32045 on `src/views/css/index.css`; their current patches do not touch this PR's hunks and are not functional dependencies.

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/eslint-rules lint`
- `pnpm -F @okouai/eslint-rules check-types`
- `pnpm exec knip --workspace @okouai/app --workspace @okouai/eslint-rules`
- `pnpm -F @okouai/app lint:build-config` (12 passed on the rebased tree)
- `pnpm -F @okouai/eslint-rules exec vitest run src/ccstate/__tests__/prefer-ui-components.test.ts` (11 passed)
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-presentation-gallery.test.tsx src/views/onboarding/__tests__/onboarding-flow.test.tsx` (37 passed)
- `bash .github/scripts/tests/verify-okou-app-runtime-test.sh`
- `bash .github/scripts/tests/okou-app-worker-test.sh`
- Focused Prettier check, `bash -n` for affected shell scripts, and `git diff --check`

Full Vitest and a local dev server were intentionally not run; the protected PR pipeline owns the complete gate.
