### PR TITLE
fix(ci): preserve cross-revision host cpu fairness locks

### DIFF
--- a/.github/scripts/runner-behavior-host-cpu-fairness.sh
+++ b/.github/scripts/runner-behavior-host-cpu-fairness.sh
@@ -53,8 +53,13 @@ ROOTFS_HASH=$2
 EXECUTION_KEY=$3
 BASE_DIR="/var/lib/vm0-runner/host-cpu-fairness/${EXECUTION_KEY}"
 UNIT="runner-host-cpu-managed-${EXECUTION_KEY}"
-LOCK_DIR="/run/lock/runner-host-cpu-fairness"
-LOCK_FD=""
+# Pre-R5c and interim workflow revisions can share this host. Acquire both
+# stable per-CPU inode namespaces in this order and never unlink their files.
+LOCK_DIRS=(
+  "/run/lock/vm0-host-cpu-fairness"
+  "/run/lock/runner-host-cpu-fairness"
+)
+LOCK_FDS=()
 
 case "$EXECUTION_KEY" in
   ''|*[!a-zA-Z0-9._-]*)
@@ -63,14 +68,19 @@ case "$EXECUTION_KEY" in
     ;;
 esac
 
+release_lock_fds() {
+  local lock_fd
+  for lock_fd in "$@"; do
+    flock --unlock "$lock_fd" || true
+    exec {lock_fd}>&-
+  done
+}
+
 cleanup() {
   sudo systemctl stop "${UNIT}.service" 2>/dev/null || true
   sudo rm -f -- "$TEST_BIN"
   sudo rm -rf -- "$BASE_DIR"
-  if [ -n "$LOCK_FD" ]; then
-    flock --unlock "$LOCK_FD" || true
-    exec {LOCK_FD}>&-
-  fi
+  release_lock_fds "${LOCK_FDS[@]}"
 }
 trap cleanup EXIT
 
@@ -99,19 +109,26 @@ fi
 
 read -r SELECTION_HASH _ < <(printf '%s' "$EXECUTION_KEY" | cksum)
 START_INDEX=$((SELECTION_HASH % ${#CPU_CANDIDATES[@]}))
-sudo install -d -m 0755 -o "$(id -u)" -g "$(id -g)" "$LOCK_DIR"
+sudo install -d -m 0755 -o "$(id -u)" -g "$(id -g)" "${LOCK_DIRS[@]}"
 
 SELECTED_CPU=""
 for ((offset = 0; offset < ${#CPU_CANDIDATES[@]}; offset++)); do
   candidate_index=$(((START_INDEX + offset) % ${#CPU_CANDIDATES[@]}))
   candidate_cpu=${CPU_CANDIDATES[$candidate_index]}
-  exec {candidate_lock_fd}>"${LOCK_DIR}/cpu-${candidate_cpu}.lock"
-  if flock --nonblock "$candidate_lock_fd"; then
-    SELECTED_CPU=$candidate_cpu
-    LOCK_FD=$candidate_lock_fd
-    break
-  fi
-  exec {candidate_lock_fd}>&-
+  candidate_lock_fds=()
+  for lock_dir in "${LOCK_DIRS[@]}"; do
+    exec {candidate_lock_fd}>"${lock_dir}/cpu-${candidate_cpu}.lock"
+    if flock --nonblock "$candidate_lock_fd"; then
+      candidate_lock_fds+=("$candidate_lock_fd")
+      continue
+    fi
+    exec {candidate_lock_fd}>&-
+    release_lock_fds "${candidate_lock_fds[@]}"
+    continue 2
+  done
+  SELECTED_CPU=$candidate_cpu
+  LOCK_FDS=("${candidate_lock_fds[@]}")
+  break
 done
 if [ -z "$SELECTED_CPU" ]; then
   echo "no online host CPU is available for the fairness test" >&2

--- a/.github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh
+++ b/.github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh
@@ -1,0 +1,447 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+fairness_script=${1:-"${repo_root}/.github/scripts/runner-behavior-host-cpu-fairness.sh"}
+tmp_dir=$(mktemp -d)
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+[ -f "$fairness_script" ] || fail "fairness wrapper not found: $fairness_script"
+command -v flock >/dev/null || fail "flock is required"
+
+fake_bin="${tmp_dir}/bin"
+test_bin="${tmp_dir}/host-cpu-fairness-test"
+rootfs_hash=0000000000000000000000000000000000000000000000000000000000000000
+online_cpus=$'# CPU,ONLINE\n0,Y\n1,Y\n2,Y'
+mkdir -p "$fake_bin"
+
+cat >"${fake_bin}/scp" <<'FAKE_SCP'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ "$#" -eq 2 ] || {
+  echo "unexpected scp invocation: $*" >&2
+  exit 1
+}
+destination=${2#*:}
+case "$destination" in
+  /tmp/runner-host-cpu-fairness-*) ;;
+  *)
+    echo "unexpected remote binary path: $destination" >&2
+    exit 1
+    ;;
+esac
+cp -- "$1" "${MOCK_CASE_DIR}/remote-bin"
+FAKE_SCP
+
+cat >"${fake_bin}/ssh" <<'FAKE_SSH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ "$#" -ge 4 ] || {
+  echo "unexpected ssh invocation: $*" >&2
+  exit 1
+}
+shift
+[ "$1" = bash ] && [ "$2" = -s ] && [ "$3" = -- ] || {
+  echo "unexpected ssh command: $*" >&2
+  exit 1
+}
+shift 3
+
+remote_arguments=("$@")
+case "${remote_arguments[0]:-}" in
+  /tmp/runner-host-cpu-fairness-*)
+    remote_arguments[0]="${MOCK_CASE_DIR}/remote-bin"
+    ;;
+esac
+remote_source=$(cat)
+remote_source=${remote_source//"/run/lock/vm0-host-cpu-fairness"/"${MOCK_LOCK_ROOT}/pre-r5c"}
+remote_source=${remote_source//"/run/lock/runner-host-cpu-fairness"/"${MOCK_LOCK_ROOT}/interim"}
+remote_source=${remote_source//"/var/lib/vm0-runner/host-cpu-fairness"/"${MOCK_CASE_DIR}/base"}
+remote_source=${remote_source//"/var/lib/vm0-runner/firecracker"/"${MOCK_FIXTURE_ROOT}/firecracker"}
+remote_source=${remote_source//"/var/lib/vm0-runner/images"/"${MOCK_FIXTURE_ROOT}/images"}
+bash -s -- "${remote_arguments[@]}" <<<"$remote_source"
+FAKE_SSH
+
+cat >"${fake_bin}/sudo" <<'FAKE_SUDO'
+#!/usr/bin/env bash
+set -euo pipefail
+exec "$@"
+FAKE_SUDO
+
+cat >"${fake_bin}/lscpu" <<'FAKE_LSCPU'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$*" = "--parse=CPU,ONLINE" ] || {
+  echo "unexpected lscpu invocation: $*" >&2
+  exit 1
+}
+printf '%s\n' "$MOCK_LSCPU_OUTPUT"
+FAKE_LSCPU
+
+cat >"${fake_bin}/systemd" <<'FAKE_SYSTEMD'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'systemd 254 (254)\n'
+FAKE_SYSTEMD
+
+cat >"${fake_bin}/systemctl" <<'FAKE_SYSTEMCTL'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+FAKE_SYSTEMCTL
+
+cat >"${fake_bin}/modprobe" <<'FAKE_MODPROBE'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+FAKE_MODPROBE
+
+cat >"${fake_bin}/systemd-run" <<'FAKE_SYSTEMD_RUN'
+#!/usr/bin/env bash
+set -euo pipefail
+
+selected_cpu=""
+saw_wait=false
+for argument in "$@"; do
+  case "$argument" in
+    --wait) saw_wait=true ;;
+    --property=AllowedCPUs=*) selected_cpu=${argument##*=} ;;
+  esac
+done
+[ "$saw_wait" = true ] || {
+  echo "systemd-run did not wait for the child" >&2
+  exit 1
+}
+[ -n "$selected_cpu" ] || {
+  echo "systemd-run did not receive AllowedCPUs" >&2
+  exit 1
+}
+case " $* " in
+  *" --ignored --test-threads=1 --nocapture ") ;;
+  *)
+    echo "host CPU fairness test arguments changed" >&2
+    exit 1
+    ;;
+esac
+printf '%s\n' "$selected_cpu" >"${MOCK_CASE_DIR}/child-cpu"
+
+if [ -n "${MOCK_CHILD_ENTER_FIFO:-}" ]; then
+  printf 'entered\n' >"$MOCK_CHILD_ENTER_FIFO"
+  IFS= read -r release <"$MOCK_CHILD_RELEASE_FIFO"
+  [ "$release" = release ]
+fi
+FAKE_SYSTEMD_RUN
+
+printf '#!/usr/bin/env bash\nexit 0\n' >"$test_bin"
+chmod +x "$test_bin" "${fake_bin}"/*
+
+prepare_case() {
+  local case_root=$1
+  local fixture_root="${case_root}/fixtures"
+  mkdir -p \
+    "${case_root}/locks/pre-r5c" \
+    "${case_root}/locks/interim" \
+    "${fixture_root}/firecracker/v1" \
+    "${fixture_root}/images/${rootfs_hash}"
+  : >"${fixture_root}/firecracker/v1/firecracker"
+  : >"${fixture_root}/firecracker/v1/vmlinux-test"
+  : >"${fixture_root}/images/${rootfs_hash}/rootfs.ext4"
+}
+
+job_ref_for_start_index() {
+  local prefix=$1
+  local run_id=$2
+  local desired_index=$3
+  local candidate_count=$4
+  local suffix checksum candidate execution_key
+
+  for ((suffix = 0; suffix < 1000; suffix++)); do
+    candidate="${prefix}-${suffix}"
+    execution_key="${candidate}-${run_id}-1"
+    checksum=$(printf '%s' "$execution_key" | cksum)
+    checksum=${checksum%% *}
+    if [ $((checksum % candidate_count)) -eq "$desired_index" ]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+  fail "could not derive a deterministic selection key"
+}
+
+run_invocation() {
+  local case_root=$1
+  local invocation_name=$2
+  local job_ref=$3
+  local run_id=$4
+  local invocation_dir="${case_root}/${invocation_name}"
+
+  mkdir -p "$invocation_dir"
+  env \
+    PATH="${fake_bin}:$PATH" \
+    MOCK_CASE_DIR="$invocation_dir" \
+    MOCK_LOCK_ROOT="${case_root}/locks" \
+    MOCK_FIXTURE_ROOT="${case_root}/fixtures" \
+    MOCK_LSCPU_OUTPUT="$online_cpus" \
+    MOCK_CHILD_ENTER_FIFO="${MOCK_CHILD_ENTER_FIFO:-}" \
+    MOCK_CHILD_RELEASE_FIFO="${MOCK_CHILD_RELEASE_FIFO:-}" \
+    METAL_USER=test-user \
+    HOST=test-host \
+    JOB_REF="$job_ref" \
+    DEFAULT_ROOTFS_HASH="$rootfs_hash" \
+    TEST_BIN="$test_bin" \
+    GITHUB_RUN_ID="$run_id" \
+    GITHUB_RUN_ATTEMPT=1 \
+    timeout 15 bash "$fairness_script"
+}
+
+assert_selected_cpu() {
+  local output_file=$1
+  local invocation_dir=$2
+  local expected_cpu=$3
+  local reason=$4
+
+  grep -Fxq "HOST_CPU_SELECTED_CPU=${expected_cpu}" "$output_file" ||
+    fail "$reason"
+  [ "$(cat "${invocation_dir}/child-cpu")" = "$expected_cpu" ] ||
+    fail "AllowedCPUs did not match selected CPU ${expected_cpu}"
+}
+
+assert_existing_lock_available() {
+  local lock_file=$1
+  local reason=$2
+  local probe_fd
+
+  [ -e "$lock_file" ] || fail "lock file was unlinked: $lock_file"
+  exec {probe_fd}>"$lock_file"
+  if ! flock --nonblock "$probe_fd"; then
+    exec {probe_fd}>&-
+    fail "$reason"
+  fi
+  flock --unlock "$probe_fd"
+  exec {probe_fd}>&-
+}
+
+assert_lock_held() {
+  local lock_file=$1
+  local reason=$2
+  local probe_fd
+
+  [ -e "$lock_file" ] || fail "expected held lock file: $lock_file"
+  exec {probe_fd}>"$lock_file"
+  if flock --nonblock "$probe_fd"; then
+    flock --unlock "$probe_fd"
+    exec {probe_fd}>&-
+    fail "$reason"
+  fi
+  exec {probe_fd}>&-
+}
+
+test_pre_r5c_holder() (
+  local case_root="${tmp_dir}/pre-r5c-holder"
+  local output="${case_root}/invocation.out"
+  local errors="${case_root}/invocation.err"
+  local job_ref holder_fd
+  prepare_case "$case_root"
+
+  exec {holder_fd}>"${case_root}/locks/pre-r5c/cpu-1.lock"
+  flock --nonblock "$holder_fd" || fail "could not acquire pre-R5c fixture lock"
+  job_ref=$(job_ref_for_start_index pre-r5c 101 0 2)
+
+  run_invocation "$case_root" invocation "$job_ref" 101 >"$output" 2>"$errors" || {
+    sed 's/^/  /' "$errors" >&2
+    fail "repaired invocation failed with a pre-R5c holder"
+  }
+  # The #31906 single-interim-namespace implementation selects CPU 1 here.
+  assert_selected_cpu "$output" "${case_root}/invocation" 2 \
+    "pre-R5c holder did not rotate selection to the free candidate"
+  assert_existing_lock_available \
+    "${case_root}/locks/pre-r5c/cpu-2.lock" \
+    "pre-R5c CPU 2 lock remained held after exit"
+  assert_existing_lock_available \
+    "${case_root}/locks/interim/cpu-2.lock" \
+    "interim CPU 2 lock remained held after exit"
+)
+
+test_interim_holder_and_partial_release() (
+  local case_root="${tmp_dir}/interim-holder"
+  local output="${case_root}/invocation.out"
+  local errors="${case_root}/invocation.err"
+  local entered_fifo="${case_root}/child-entered"
+  local release_fifo="${case_root}/child-release"
+  local job_ref invocation_pid="" holder_fd entry_fd release_fd marker
+  local pre_inode interim_inode
+
+  cleanup_case() {
+    if [ -n "$invocation_pid" ]; then
+      kill "$invocation_pid" 2>/dev/null || true
+      wait "$invocation_pid" 2>/dev/null || true
+    fi
+  }
+  trap cleanup_case EXIT
+
+  prepare_case "$case_root"
+  mkfifo "$entered_fifo" "$release_fifo"
+  exec {entry_fd}<>"$entered_fifo"
+  exec {release_fd}<>"$release_fifo"
+  exec {holder_fd}>"${case_root}/locks/interim/cpu-1.lock"
+  flock --nonblock "$holder_fd" || fail "could not acquire interim fixture lock"
+  job_ref=$(job_ref_for_start_index interim 102 0 2)
+
+  MOCK_CHILD_ENTER_FIFO="$entered_fifo" \
+    MOCK_CHILD_RELEASE_FIFO="$release_fifo" \
+    run_invocation "$case_root" invocation "$job_ref" 102 \
+    >"$output" 2>"$errors" &
+  invocation_pid=$!
+  IFS= read -r -t 5 marker <&"$entry_fd" || {
+    sed 's/^/  /' "$errors" >&2
+    fail "child did not start for interim contention case"
+  }
+  [ "$marker" = entered ] || fail "invalid child entry marker"
+
+  assert_selected_cpu "$output" "${case_root}/invocation" 2 \
+    "interim holder did not rotate selection to the free candidate"
+  [ -e "${case_root}/locks/pre-r5c/cpu-1.lock" ] ||
+    fail "legacy-first partial acquisition was not attempted"
+  assert_existing_lock_available \
+    "${case_root}/locks/pre-r5c/cpu-1.lock" \
+    "partial pre-R5c acquisition was not released before rotation"
+  assert_lock_held "${case_root}/locks/pre-r5c/cpu-2.lock" \
+    "pre-R5c selected lock was not held through child execution"
+  assert_lock_held "${case_root}/locks/interim/cpu-2.lock" \
+    "interim selected lock was not held through child execution"
+
+  pre_inode=$(stat -c '%i' "${case_root}/locks/pre-r5c/cpu-2.lock")
+  interim_inode=$(stat -c '%i' "${case_root}/locks/interim/cpu-2.lock")
+  printf 'release\n' >&"$release_fd"
+  wait "$invocation_pid" || {
+    sed 's/^/  /' "$errors" >&2
+    fail "interim contention invocation failed after child release"
+  }
+  invocation_pid=""
+
+  [ "$(stat -c '%i' "${case_root}/locks/pre-r5c/cpu-2.lock")" = "$pre_inode" ] ||
+    fail "pre-R5c lock inode changed during exit"
+  [ "$(stat -c '%i' "${case_root}/locks/interim/cpu-2.lock")" = "$interim_inode" ] ||
+    fail "interim lock inode changed during exit"
+  assert_existing_lock_available \
+    "${case_root}/locks/pre-r5c/cpu-2.lock" \
+    "pre-R5c selected lock remained held after child exit"
+  assert_existing_lock_available \
+    "${case_root}/locks/interim/cpu-2.lock" \
+    "interim selected lock remained held after child exit"
+  cleanup_case
+  trap - EXIT
+)
+
+test_repaired_holder() (
+  local case_root="${tmp_dir}/repaired-holder"
+  local holder_output="${case_root}/holder.out"
+  local holder_errors="${case_root}/holder.err"
+  local contender_output="${case_root}/contender.out"
+  local contender_errors="${case_root}/contender.err"
+  local entered_fifo="${case_root}/child-entered"
+  local release_fifo="${case_root}/child-release"
+  local holder_job_ref contender_job_ref holder_pid="" entry_fd release_fd marker
+
+  cleanup_case() {
+    if [ -n "$holder_pid" ]; then
+      kill "$holder_pid" 2>/dev/null || true
+      wait "$holder_pid" 2>/dev/null || true
+    fi
+  }
+  trap cleanup_case EXIT
+
+  prepare_case "$case_root"
+  mkfifo "$entered_fifo" "$release_fifo"
+  exec {entry_fd}<>"$entered_fifo"
+  exec {release_fd}<>"$release_fifo"
+  holder_job_ref=$(job_ref_for_start_index repaired-holder 103 0 2)
+  contender_job_ref=$(job_ref_for_start_index repaired-contender 104 0 2)
+
+  MOCK_CHILD_ENTER_FIFO="$entered_fifo" \
+    MOCK_CHILD_RELEASE_FIFO="$release_fifo" \
+    run_invocation "$case_root" holder "$holder_job_ref" 103 \
+    >"$holder_output" 2>"$holder_errors" &
+  holder_pid=$!
+  IFS= read -r -t 5 marker <&"$entry_fd" || {
+    sed 's/^/  /' "$holder_errors" >&2
+    fail "repaired holder child did not start"
+  }
+  [ "$marker" = entered ] || fail "invalid repaired holder entry marker"
+  assert_selected_cpu "$holder_output" "${case_root}/holder" 1 \
+    "first repaired invocation did not select the first candidate"
+  assert_lock_held "${case_root}/locks/pre-r5c/cpu-1.lock" \
+    "repaired holder did not retain the pre-R5c lock"
+  assert_lock_held "${case_root}/locks/interim/cpu-1.lock" \
+    "repaired holder did not retain the interim lock"
+
+  run_invocation "$case_root" contender "$contender_job_ref" 104 \
+    >"$contender_output" 2>"$contender_errors" || {
+    sed 's/^/  /' "$contender_errors" >&2
+    fail "contender failed while another repaired invocation held CPU 1"
+  }
+  assert_selected_cpu "$contender_output" "${case_root}/contender" 2 \
+    "another repaired holder did not force rotation"
+
+  printf 'release\n' >&"$release_fd"
+  wait "$holder_pid" || {
+    sed 's/^/  /' "$holder_errors" >&2
+    fail "repaired holder failed after child release"
+  }
+  holder_pid=""
+  assert_existing_lock_available \
+    "${case_root}/locks/pre-r5c/cpu-1.lock" \
+    "repaired holder retained the pre-R5c lock after exit"
+  assert_existing_lock_available \
+    "${case_root}/locks/interim/cpu-1.lock" \
+    "repaired holder retained the interim lock after exit"
+  cleanup_case
+  trap - EXIT
+)
+
+test_all_busy_failure() (
+  local case_root="${tmp_dir}/all-busy"
+  local output="${case_root}/invocation.out"
+  local errors="${case_root}/invocation.err"
+  local job_ref legacy_fd interim_fd
+  prepare_case "$case_root"
+
+  exec {legacy_fd}>"${case_root}/locks/pre-r5c/cpu-1.lock"
+  exec {interim_fd}>"${case_root}/locks/interim/cpu-2.lock"
+  flock --nonblock "$legacy_fd" || fail "could not acquire CPU 1 fixture lock"
+  flock --nonblock "$interim_fd" || fail "could not acquire CPU 2 fixture lock"
+  job_ref=$(job_ref_for_start_index all-busy 105 0 2)
+
+  if run_invocation "$case_root" invocation "$job_ref" 105 \
+    >"$output" 2>"$errors"; then
+    fail "all-busy invocation unexpectedly succeeded"
+  fi
+  grep -Fq "no online host CPU is available for the fairness test" "$errors" || {
+    sed 's/^/  /' "$errors" >&2
+    fail "all-busy failure was not visible"
+  }
+  if grep -q '^HOST_CPU_SELECTED_CPU=' "$output"; then
+    fail "all-busy invocation reported a selected CPU"
+  fi
+  assert_existing_lock_available \
+    "${case_root}/locks/pre-r5c/cpu-2.lock" \
+    "all-busy partial acquisition was not released"
+)
+
+test_pre_r5c_holder
+test_interim_holder_and_partial_release
+test_repaired_holder
+test_all_busy_failure
+
+echo "runner-behavior-host-cpu-fairness-test: ok"


### PR DESCRIPTION
## Summary

- acquire the stable pre-R5c and interim per-CPU lock in a fixed order for every fairness candidate
- release every partial candidate acquisition before rotating, then retain both selected locks through the complete `systemd-run --wait` child lifetime
- unlock and close both descriptors at exit without unlinking either lock file
- add deterministic local wrapper coverage for pre-R5c, interim, and repaired holders; free-candidate rotation; all-busy failure; partial release; child lifetime; and exit release with stable inodes

Closes #31919. Part of #32157.

## Compatibility behavior

The shared host can execute historical GitHub workflow revisions concurrently. The repaired invocation therefore respects both `/run/lock/vm0-host-cpu-fairness/cpu-N.lock` and `/run/lock/runner-host-cpu-fairness/cpu-N.lock`; using only either namespace would split the inode-based exclusion domain.

## Fallbacks

- `.github/scripts/runner-behavior-host-cpu-fairness.sh:LOCK_DIRS` — bridges pre-R5c and interim CI checkouts on a shared metal host. Surface: historical CI checkout -> host-local per-CPU lock inode. This is an always-on external coordination boundary, not a time-bounded product rollout branch, because historical workflow revisions remain rerunnable. Removal requires a separately authorized issue and verified drain proving neither earlier namespace can execute on the shared fleet; no removal is authorized by this PR.

## Verification

- `bash .github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh`
- the same regression entrypoint against merge `003db2336542de3fc504cbbc64e9ea26ec88a109` fails as expected with `pre-R5c holder did not rotate selection to the free candidate`
- `shellcheck .github/scripts/runner-behavior-host-cpu-fairness.sh .github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh`
- `bash -n .github/scripts/runner-behavior-host-cpu-fairness.sh .github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh`
- `bash .github/scripts/tests/crates-detect-workflow-test.sh`
- `bash .github/scripts/tests/rust-ci-memory-workflow-test.sh`
- `bash .github/scripts/check-workflow-shell-compatibility.sh`
- `./scripts/check-file-size.sh .github/scripts/runner-behavior-host-cpu-fairness.sh .github/scripts/tests/runner-behavior-host-cpu-fairness-test.sh`
- `git diff --check origin/main...HEAD`

The local controller container initially lacked `/dev/fd`, which the unchanged Bash process substitutions in the existing wrapper require. Verification temporarily provided the standard `/dev/fd -> /proc/self/fd` link and removed it afterward. No full Vitest suite or development server was run, and no production host or production operation was accessed.
