### PR TITLE
feat(platform): fade clipped sidebar chat titles and scroll them on hover

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/sidebar-thread-title.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-thread-title.ts
@@ -1,0 +1,64 @@
+import { command } from "ccstate";
+import { onRef } from "../utils.ts";
+
+/**
+ * Titles travel at one speed instead of in one duration, so a barely clipped
+ * title and a heavily clipped one read as the same gesture rather than one
+ * crawling and the other flashing past.
+ */
+const TITLE_SCROLL_PX_PER_SECOND = 37;
+const MIN_TITLE_SCROLL_MS = 780;
+const MAX_TITLE_SCROLL_MS = 4200;
+
+function titleScrollDurationMs(distance: number): number {
+  return Math.round(
+    Math.min(
+      MAX_TITLE_SCROLL_MS,
+      Math.max(
+        MIN_TITLE_SCROLL_MS,
+        (distance / TITLE_SCROLL_PX_PER_SECOND) * 1000,
+      ),
+    ),
+  );
+}
+
+function writeTitleOverflow(element: HTMLElement): void {
+  const distance = element.scrollWidth - element.clientWidth;
+  element.style.setProperty("--okou-nav-title-overflow", `${distance}px`);
+  element.style.setProperty(
+    "--okou-nav-title-duration",
+    `${titleScrollDurationMs(distance)}ms`,
+  );
+}
+
+/**
+ * Publishes how much of a sidebar thread title is cut off. The stylesheet
+ * derives both the fade mask and the hover travel from that one number, so a
+ * title that fits gets neither without a second code path.
+ *
+ * The observer watches the box for sidebar width changes and the text for
+ * renames and late web-font metrics. Neither remounts the element, so the ref
+ * on its own would leave a stale distance behind.
+ */
+export const sidebarThreadTitleOverflowRef$ = onRef(
+  command((_context, element: HTMLElement, signal: AbortSignal) => {
+    writeTitleOverflow(element);
+
+    const observer = new ResizeObserver(() => {
+      writeTitleOverflow(element);
+    });
+    observer.observe(element);
+    const text = element.firstElementChild;
+    if (text) {
+      observer.observe(text);
+    }
+
+    signal.addEventListener(
+      "abort",
+      () => {
+        observer.disconnect();
+      },
+      { once: true },
+    );
+  }),
+);

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -614,6 +614,77 @@ body {
   --color-sidebar: hsl(var(--sidebar));
 }
 
+/* Sidebar thread titles.
+
+   A title that does not fit fades out instead of ending in an ellipsis, and
+   hovering or focusing its row scrolls the text to its end and stops there.
+
+   `--okou-nav-title-overflow` is the only measured input; the mask and the
+   travel are both derived from it, which is what makes an edge fade exactly
+   when content is cut off at it: at rest only the right edge is masked, at the
+   end of the travel only the left one, and a title that fits gets neither.
+   `sidebarThreadTitleOverflowRef$` writes it together with the duration. */
+@property --okou-nav-title-shift {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0px;
+}
+
+.okou-nav-title {
+  --okou-nav-title-overflow: 0px;
+  --okou-nav-title-duration: 780ms;
+  --okou-nav-title-fade: 24px;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  mask-image: linear-gradient(
+    90deg,
+    transparent 0,
+    #000
+      clamp(
+        0px,
+        calc(-1 * var(--okou-nav-title-shift)),
+        var(--okou-nav-title-fade)
+      ),
+    #000
+      calc(
+        100% -
+          clamp(
+            0px,
+            calc(var(--okou-nav-title-overflow) + var(--okou-nav-title-shift)),
+            var(--okou-nav-title-fade)
+          )
+      ),
+    transparent 100%
+  );
+  mask-repeat: no-repeat;
+  mask-size: 100% 100%;
+  transition: --okou-nav-title-shift 660ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.okou-nav-title > span {
+  display: block;
+  width: max-content;
+  white-space: nowrap;
+  transform: translateX(var(--okou-nav-title-shift));
+}
+
+/* The delay keeps a pointer sweeping down the list from setting every row in
+   motion; leaving has none, so the title snaps back under the next row. */
+.okou-nav-title-row:hover .okou-nav-title,
+.okou-nav-title-row:focus-visible .okou-nav-title {
+  --okou-nav-title-shift: calc(-1 * var(--okou-nav-title-overflow));
+  transition: --okou-nav-title-shift var(--okou-nav-title-duration)
+    cubic-bezier(0.33, 0, 0.2, 1) 750ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .okou-nav-title-row:hover .okou-nav-title,
+  .okou-nav-title-row:focus-visible .okou-nav-title {
+    --okou-nav-title-shift: 0px;
+  }
+}
+
 /* Morandi outline buttons */
 .okou-app .okou-btn-morandi {
   background-color: hsl(var(--gray-50));

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -807,9 +807,9 @@ test("Fade a clipped chat title and pace its scroll by the hidden distance", asy
     path: `/chats/${EXISTING_THREAD_ID}`,
   });
 
-  expect(
-    await within(sidebar()).findByText("Release plan"),
-  ).toBeInTheDocument();
+  await expect(
+    within(sidebar()).findByText("Release plan"),
+  ).resolves.toBeInTheDocument();
 
   const clipped = titleFadeBox("Quarterly launch narrative");
   expect(clipped.style.getPropertyValue("--okou-nav-title-overflow")).toBe(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -439,6 +439,73 @@ function createDataTransferStub(
   } as unknown as DataTransfer;
 }
 
+const SIDEBAR_TITLE_BOX_WIDTH = 160;
+const SIDEBAR_TITLE_CHARACTER_WIDTH = 9;
+
+function restoreElementProperty(
+  name: string,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(HTMLElement.prototype, name, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(HTMLElement.prototype, name);
+}
+
+/**
+ * happy-dom measures every box as zero-width, which leaves the title fade with
+ * no input. Give the title box a fixed width and its text a width per
+ * character, so one title overflows the box and the other fits inside it.
+ */
+function stubSidebarTitleLayout(): void {
+  const clientWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientWidth",
+  );
+  const scrollWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollWidth",
+  );
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get(this: HTMLElement): number {
+      return this.classList.contains("okou-nav-title")
+        ? SIDEBAR_TITLE_BOX_WIDTH
+        : 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+    configurable: true,
+    get(this: HTMLElement): number {
+      if (!this.classList.contains("okou-nav-title")) {
+        return 0;
+      }
+      return Math.max(
+        SIDEBAR_TITLE_BOX_WIDTH,
+        (this.textContent?.length ?? 0) * SIDEBAR_TITLE_CHARACTER_WIDTH,
+      );
+    },
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      restoreElementProperty("clientWidth", clientWidth);
+      restoreElementProperty("scrollWidth", scrollWidth);
+    },
+    { once: true },
+  );
+}
+
+/** The clipping box a title is faded and scrolled inside. */
+function titleFadeBox(title: string): HTMLElement {
+  const box = within(sidebar()).getByText(title).parentElement;
+  if (!box) {
+    throw new Error(`${title} title fade box not found`);
+  }
+  return box;
+}
+
 function threadRowByTitle(
   title: string,
   container: HTMLElement = sidebar(),
@@ -715,6 +782,41 @@ test("Delete a chat after reviewing the impact", async () => {
     ).not.toBeInTheDocument();
     expect(within(sidebar()).getByText("Incident notes")).toBeInTheDocument();
   });
+});
+
+test("Fade a clipped chat title and pace its scroll by the hidden distance", async () => {
+  stubSidebarTitleLayout();
+  prepareDefaultAgent();
+  mockSidebarThreadStory([
+    // 26 characters, so 234px of text in a 160px box.
+    createThread(EXISTING_THREAD_ID, "Quarterly launch narrative"),
+    createThread(AUTOMATION_THREAD_ID, "Release plan"),
+  ]);
+
+  await setupSidebarPage({
+    context,
+    path: `/chats/${EXISTING_THREAD_ID}`,
+  });
+
+  expect(
+    await within(sidebar()).findByText("Release plan"),
+  ).toBeInTheDocument();
+
+  const clipped = titleFadeBox("Quarterly launch narrative");
+  expect(clipped.style.getPropertyValue("--okou-nav-title-overflow")).toBe(
+    "74px",
+  );
+  expect(clipped.style.getPropertyValue("--okou-nav-title-duration")).toBe(
+    "2000ms",
+  );
+
+  const fitting = titleFadeBox("Release plan");
+  expect(fitting.style.getPropertyValue("--okou-nav-title-overflow")).toBe(
+    "0px",
+  );
+  expect(fitting.style.getPropertyValue("--okou-nav-title-duration")).toBe(
+    "780ms",
+  );
 });
 
 test("Filter the chat list to unread conversations", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -454,9 +454,8 @@ function restoreElementProperty(
 }
 
 /**
- * happy-dom measures every box as zero-width, which leaves the title fade with
- * no input. Give the title box a fixed width and its text a width per
- * character, so one title overflows the box and the other fits inside it.
+ * Gives the title box a fixed width and its text a width per character, so one
+ * title overflows the box and the other fits inside it.
  */
 function stubSidebarTitleLayout(): void {
   const clientWidth = Object.getOwnPropertyDescriptor(
@@ -784,6 +783,16 @@ test("Delete a chat after reviewing the impact", async () => {
   });
 });
 
+/**
+ * Deliberate exception to `docs/testing/testing-external-behavior.md`. The fade
+ * and the hover travel are a mask and a transform derived from measured text
+ * width, and happy-dom has no layout engine: it reports every box as
+ * zero-width and paints nothing, so neither the state nor the result exists on
+ * the page surface here. The measured distance is the only place the behavior
+ * is observable, and it is worth pinning because both the fade and the travel
+ * are derived from it — a wrong distance fades a title that fits, or stops the
+ * scroll before the end.
+ */
 test("Fade a clipped chat title and pace its scroll by the hidden distance", async () => {
   stubSidebarTitleLayout();
   prepareDefaultAgent();

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -65,6 +65,7 @@ import {
   type SidebarChatThreadWindow,
 } from "../../signals/chat-page/sidebar-chat-thread-scroll.ts";
 import type { SidebarChatThreadItemSignals } from "../../signals/chat-page/sidebar-chat-thread-item.ts";
+import { sidebarThreadTitleOverflowRef$ } from "../../signals/chat-page/sidebar-thread-title.ts";
 import {
   currentChatAgentScope$,
   currentChatAgentId$,
@@ -373,6 +374,7 @@ function ChatThreadItemLink({
   const select = useSet(signals.select$);
   const openRename = useSet(signals.openRename$);
   const pageSignal = useGet(pageSignal$);
+  const measureTitle = useSet(sidebarThreadTitleOverflowRef$);
 
   return (
     <Link
@@ -392,7 +394,7 @@ function ChatThreadItemLink({
         e.preventDefault();
         detach(openRename(pageSignal), Reason.DomCallback);
       }}
-      className={`col-span-2 col-start-1 row-start-1 grid h-8 grid-cols-subgrid items-center rounded-lg pl-2 text-left text-sm leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+      className={`okou-nav-title-row col-span-2 col-start-1 row-start-1 grid h-8 grid-cols-subgrid items-center rounded-lg pl-2 text-left text-sm leading-5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
         isHighlighted
           ? "bg-state-selected text-sidebar-foreground font-medium"
           : isUnread
@@ -402,11 +404,13 @@ function ChatThreadItemLink({
     >
       <span className="flex min-w-0 items-center gap-2 pr-8">
         <ChatThreadListPaneIcon signals={signals} />
-        <span className="okou-nav-copy min-w-0 truncate">
-          {title ??
-            t(($) => {
-              return $.chat.newChat;
-            })}
+        <span className="okou-nav-copy okou-nav-title" ref={measureTitle}>
+          <span>
+            {title ??
+              t(($) => {
+                return $.chat.newChat;
+              })}
+          </span>
         </span>
       </span>
       <ThreadNumberShortcutHint


### PR DESCRIPTION
## What

A sidebar chat title that does not fit ended in an ellipsis and stayed cut off. It now fades out at the edge instead, and hovering or focusing the row scrolls the text to its end and stops there — one pass, no loop. The leading pane icon and the trailing 32px action reserve do not move.

Design was reviewed and approved on a standalone mock before implementation, including the scroll pace: https://okou-sidebar-title-fade.sites.vm0.io

## How

`sidebarThreadTitleOverflowRef$` (`signals/chat-page/sidebar-thread-title.ts`) publishes the one measured input — how far the title is cut off — as `--okou-nav-title-overflow`, plus the duration that distance implies.

The stylesheet derives both the mask and the travel from that number, which is what makes the behaviour fall out without branching:

- at rest only the right edge is masked;
- at the end of the travel only the left one;
- a title that fits gets neither, because both clamps collapse at `0px`.

The travel itself is a registered `@property` length, so the transform and the mask stay in lockstep through the transition rather than drifting as two independent animations.

A `ResizeObserver` covers sidebar width changes, renames, and late web-font metrics — none of which remount the element, so the ref alone would leave a stale distance behind.

## Behaviour details

- Pace is `37px/s` clamped to `780ms`–`4200ms`, so long and short titles read as the same gesture instead of one crawling and the other flashing past.
- `750ms` delay before it starts, none on the way back, so sweeping a pointer down the list does not set every row in motion.
- `prefers-reduced-motion: reduce` keeps the fade and drops the travel.

## Testing

`sidebar.test.tsx` — "Fade a clipped chat title and pace its scroll by the hidden distance": with a stubbed title layout, a 26-character title in a 160px box publishes `74px` / `2000ms` and a title that fits publishes `0px` / the `780ms` floor.

The mask and travel were verified in a browser against the exact CSS block in this diff (measured shift `-58px`, left edge masked at the end of travel, right edge unmasked, short title unmasked throughout).

No feature switch: this refines an existing element rather than adding a user-facing surface.
