### PR TITLE
test(runner): cover dns startup recovery

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -39,6 +39,7 @@
 //! cancellation/teardown ownership rules.
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -379,6 +380,122 @@ struct StartupFailureResources<'a> {
     dns_handle: dns::DnsProxy,
     memory_prefetch: &'a mut prefetch::MemoryPrefetchTasks,
     status: &'a StatusTracker,
+}
+
+struct DnsStartupResources<'a> {
+    runtime_provider: &'a dyn RuntimeProvider,
+    mitm: &'a mut proxy::MitmProxy,
+    kmsg_handle: kmsg_log::KmsgHandle,
+    memory_prefetch: &'a mut prefetch::MemoryPrefetchTasks,
+    network_log_manager: NetworkLogManager,
+    host_cpu_placement: sandbox::HostCpuPlacementConfig,
+}
+
+async fn start_runtime_with_dns<F, Fut>(
+    resources: DnsStartupResources<'_>,
+    mut start_dns: F,
+) -> RunnerResult<(Box<dyn SandboxRuntime>, dns::DnsProxy, kmsg_log::KmsgHandle)>
+where
+    F: FnMut(dns::DnsPortReservation, String, NetworkLogManager) -> Fut,
+    Fut: Future<Output = std::io::Result<dns::DnsProxy>>,
+{
+    let DnsStartupResources {
+        runtime_provider,
+        mitm,
+        kmsg_handle,
+        memory_prefetch,
+        network_log_manager,
+        host_cpu_placement,
+    } = resources;
+
+    const DNS_START_MAX_ATTEMPTS: usize = 3;
+    let mut dns_start_attempt = 1;
+    loop {
+        let dns_port_reservation =
+            dns::reserve_port().map_err(|e| RunnerError::Internal(format!("dns port: {e}")))?;
+        let dns_port = dns_port_reservation.port();
+        let mut runtime = runtime_provider
+            .create_runtime(sandbox::RuntimeConfig {
+                proxy_port: Some(mitm.port()),
+                dns_port: Some(dns_port),
+                host_cpu_placement: Some(host_cpu_placement),
+            })
+            .await
+            .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;
+
+        let Some(dns_interface_pattern) = runtime.dns_interface_pattern().await else {
+            memory_prefetch.cancel();
+            runtime.shutdown().await;
+            if let Err(e) = mitm.kill_now().await {
+                warn!(error = %e, "failed to kill proxy after DNS interface resolution failed");
+            }
+            if let Err(error) = kmsg_handle.stop().await {
+                warn!(%error, "failed to clean up network-log helper after startup failure");
+            }
+            memory_prefetch.drain().await;
+            return Err(RunnerError::Internal(
+                "sandbox runtime did not provide DNS interface pattern".into(),
+            ));
+        };
+
+        match start_dns(
+            dns_port_reservation,
+            dns_interface_pattern,
+            network_log_manager.clone(),
+        )
+        .await
+        {
+            Ok(handle) => {
+                if let Err(e) = runtime.activate_dns_readiness().await {
+                    memory_prefetch.cancel();
+                    if let Err(error) = handle.stop().await {
+                        warn!(%error, "failed to clean up network-log helper after startup failure");
+                    }
+                    runtime.shutdown().await;
+                    if let Err(kill_error) = mitm.kill_now().await {
+                        warn!(
+                            error = %kill_error,
+                            "failed to kill proxy after namespace DNS readiness failed"
+                        );
+                    }
+                    if let Err(error) = kmsg_handle.stop().await {
+                        warn!(%error, "failed to clean up network-log helper after startup failure");
+                    }
+                    memory_prefetch.drain().await;
+                    return Err(RunnerError::Internal(format!(
+                        "sandbox runtime DNS readiness: {e}"
+                    )));
+                }
+                return Ok((runtime, handle, kmsg_handle));
+            }
+            Err(e)
+                if e.kind() == std::io::ErrorKind::AddrInUse
+                    && dns_start_attempt < DNS_START_MAX_ATTEMPTS =>
+            {
+                warn!(
+                    attempt = dns_start_attempt,
+                    max_attempts = DNS_START_MAX_ATTEMPTS,
+                    port = dns_port,
+                    error = %e,
+                    "dns proxy port was claimed before dnsmasq could bind; retrying with a fresh runtime",
+                );
+                runtime.shutdown().await;
+                dns_start_attempt += 1;
+            }
+            Err(e) => {
+                memory_prefetch.cancel();
+                runtime.shutdown().await;
+                if let Err(kill_error) = mitm.kill_now().await {
+                    warn!(error = %kill_error, "failed to kill proxy after DNS startup failed");
+                }
+                if let Err(error) = kmsg_handle.stop().await {
+                    warn!(%error, "failed to clean up network-log helper after startup failure");
+                }
+                memory_prefetch.drain().await;
+                return Err(RunnerError::Internal(format!("dns proxy: {e}")));
+            }
+        }
+    }
 }
 
 async fn publish_live_runner_instance_or_shutdown_startup_resources(
@@ -775,94 +892,18 @@ async fn run_start_with_home(
     // interface pattern. If the reserved DNS port is claimed in the small
     // release-before-dnsmasq-bind window, rebuild the runtime with a fresh port
     // so all prewarmed namespace REDIRECT rules stay consistent.
-    const DNS_START_MAX_ATTEMPTS: usize = 3;
-    let mut dns_start_attempt = 1;
-    let (mut runtime, dns_handle) = loop {
-        let dns_port_reservation =
-            dns::reserve_port().map_err(|e| RunnerError::Internal(format!("dns port: {e}")))?;
-        let dns_port = dns_port_reservation.port();
-        let mut runtime = runtime_provider
-            .create_runtime(sandbox::RuntimeConfig {
-                proxy_port: Some(mitm.port()),
-                dns_port: Some(dns_port),
-                host_cpu_placement: Some(host_cpu_placement),
-            })
-            .await
-            .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;
-
-        let Some(dns_interface_pattern) = runtime.dns_interface_pattern().await else {
-            memory_prefetch.cancel();
-            runtime.shutdown().await;
-            if let Err(e) = mitm.kill_now().await {
-                warn!(error = %e, "failed to kill proxy after DNS interface resolution failed");
-            }
-            if let Err(error) = kmsg_handle.stop().await {
-                warn!(%error, "failed to clean up network-log helper after startup failure");
-            }
-            memory_prefetch.drain().await;
-            return Err(RunnerError::Internal(
-                "sandbox runtime did not provide DNS interface pattern".into(),
-            ));
-        };
-
-        match dns::start_on_reserved_port(
-            dns_port_reservation,
-            dns_interface_pattern,
-            network_log_manager.clone(),
-        )
-        .await
-        {
-            Ok(handle) => {
-                if let Err(e) = runtime.activate_dns_readiness().await {
-                    memory_prefetch.cancel();
-                    if let Err(error) = handle.stop().await {
-                        warn!(%error, "failed to clean up network-log helper after startup failure");
-                    }
-                    runtime.shutdown().await;
-                    if let Err(kill_error) = mitm.kill_now().await {
-                        warn!(
-                            error = %kill_error,
-                            "failed to kill proxy after namespace DNS readiness failed"
-                        );
-                    }
-                    if let Err(error) = kmsg_handle.stop().await {
-                        warn!(%error, "failed to clean up network-log helper after startup failure");
-                    }
-                    memory_prefetch.drain().await;
-                    return Err(RunnerError::Internal(format!(
-                        "sandbox runtime DNS readiness: {e}"
-                    )));
-                }
-                break (runtime, handle);
-            }
-            Err(e)
-                if e.kind() == std::io::ErrorKind::AddrInUse
-                    && dns_start_attempt < DNS_START_MAX_ATTEMPTS =>
-            {
-                warn!(
-                    attempt = dns_start_attempt,
-                    max_attempts = DNS_START_MAX_ATTEMPTS,
-                    port = dns_port,
-                    error = %e,
-                    "dns proxy port was claimed before dnsmasq could bind; retrying with a fresh runtime",
-                );
-                runtime.shutdown().await;
-                dns_start_attempt += 1;
-            }
-            Err(e) => {
-                memory_prefetch.cancel();
-                runtime.shutdown().await;
-                if let Err(kill_error) = mitm.kill_now().await {
-                    warn!(error = %kill_error, "failed to kill proxy after DNS startup failed");
-                }
-                if let Err(error) = kmsg_handle.stop().await {
-                    warn!(%error, "failed to clean up network-log helper after startup failure");
-                }
-                memory_prefetch.drain().await;
-                return Err(RunnerError::Internal(format!("dns proxy: {e}")));
-            }
-        }
-    };
+    let (mut runtime, dns_handle, kmsg_handle) = start_runtime_with_dns(
+        DnsStartupResources {
+            runtime_provider,
+            mitm: &mut mitm,
+            kmsg_handle,
+            memory_prefetch: &mut memory_prefetch,
+            network_log_manager: network_log_manager.clone(),
+            host_cpu_placement,
+        },
+        dns::start_on_reserved_port,
+    )
+    .await?;
     let network_log_drain = NetworkLogDrainCoordinator::new(vec![
         kmsg_handle.drain_producer(),
         dns_handle.drain_producer(),

--- a/crates/runner/src/cmd/start/tests/main_loop/startup.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/startup.rs
@@ -202,7 +202,7 @@ fn scripted_dns_starter(
     String,
     NetworkLogManager,
 ) -> std::future::Ready<std::io::Result<crate::dns::DnsProxy>> {
-    let outcomes = Arc::new(Mutex::new(VecDeque::from(outcomes)));
+    let mut outcomes = VecDeque::from(outcomes);
     move |reservation, _interface_pattern, _network_log_manager| {
         let port = reservation.port();
         drop(reservation);
@@ -211,8 +211,6 @@ fn scripted_dns_starter(
             .unwrap_or_else(|e| e.into_inner())
             .push(DnsStartupEvent::DnsStarted { port });
         let outcome = outcomes
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
             .pop_front()
             .expect("DNS startup outcome should be scripted");
         std::future::ready(match outcome {

--- a/crates/runner/src/cmd/start/tests/main_loop/startup.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/startup.rs
@@ -6,6 +6,7 @@ use super::super::support::{
 use crate::provider::{ClaimedJob, CompletionAuth, JobCandidate};
 use crate::types::HeartbeatState;
 use async_trait::async_trait;
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -96,6 +97,136 @@ impl sandbox::RuntimeProvider for CountingRuntimeProvider {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum DnsStartupEvent {
+    RuntimeCreated {
+        id: usize,
+        proxy_port: u16,
+        dns_port: u16,
+    },
+    DnsStarted {
+        port: u16,
+    },
+    ReadinessActivated {
+        id: usize,
+    },
+    RuntimeShutdown {
+        id: usize,
+    },
+}
+
+struct DnsStartupRecordingProvider {
+    next_id: AtomicUsize,
+    events: Arc<Mutex<Vec<DnsStartupEvent>>>,
+}
+
+impl DnsStartupRecordingProvider {
+    fn new(events: Arc<Mutex<Vec<DnsStartupEvent>>>) -> Self {
+        Self {
+            next_id: AtomicUsize::new(0),
+            events,
+        }
+    }
+}
+
+struct DnsStartupRecordingRuntime {
+    id: usize,
+    events: Arc<Mutex<Vec<DnsStartupEvent>>>,
+}
+
+#[async_trait]
+impl sandbox::SandboxRuntime for DnsStartupRecordingRuntime {
+    async fn create_factory(
+        &self,
+        _config: sandbox::FactoryConfig,
+    ) -> sandbox::Result<Box<dyn sandbox::SandboxFactory>> {
+        panic!("DNS startup tests do not create factories")
+    }
+
+    async fn dns_interface_pattern(&self) -> Option<String> {
+        Some("vm0-ve-test-*".into())
+    }
+
+    async fn activate_dns_readiness(&self) -> sandbox::Result<()> {
+        self.events
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(DnsStartupEvent::ReadinessActivated { id: self.id });
+        Ok(())
+    }
+
+    async fn shutdown(&mut self) {
+        self.events
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(DnsStartupEvent::RuntimeShutdown { id: self.id });
+    }
+}
+
+#[async_trait]
+impl sandbox::RuntimeProvider for DnsStartupRecordingProvider {
+    async fn create_runtime(
+        &self,
+        config: sandbox::RuntimeConfig,
+    ) -> sandbox::Result<Box<dyn sandbox::SandboxRuntime>> {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let proxy_port = config
+            .proxy_port
+            .expect("DNS startup should propagate the MITM port");
+        let dns_port = config
+            .dns_port
+            .expect("DNS startup should propagate the reserved port");
+        assert!(
+            config.host_cpu_placement.is_some(),
+            "DNS startup should propagate host CPU placement"
+        );
+        self.events.lock().unwrap_or_else(|e| e.into_inner()).push(
+            DnsStartupEvent::RuntimeCreated {
+                id,
+                proxy_port,
+                dns_port,
+            },
+        );
+        Ok(Box::new(DnsStartupRecordingRuntime {
+            id,
+            events: Arc::clone(&self.events),
+        }))
+    }
+}
+
+fn scripted_dns_starter(
+    outcomes: Vec<Option<std::io::ErrorKind>>,
+    events: Arc<Mutex<Vec<DnsStartupEvent>>>,
+) -> impl FnMut(
+    crate::dns::DnsPortReservation,
+    String,
+    NetworkLogManager,
+) -> std::future::Ready<std::io::Result<crate::dns::DnsProxy>> {
+    let outcomes = Arc::new(Mutex::new(VecDeque::from(outcomes)));
+    move |reservation, _interface_pattern, _network_log_manager| {
+        let port = reservation.port();
+        drop(reservation);
+        events
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(DnsStartupEvent::DnsStarted { port });
+        let outcome = outcomes
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .pop_front()
+            .expect("DNS startup outcome should be scripted");
+        std::future::ready(match outcome {
+            Some(kind) => Err(std::io::Error::new(kind, "scripted DNS startup failure")),
+            None => Ok(crate::dns::DnsProxy::noop_on_port(port)),
+        })
+    }
+}
+
+fn test_host_cpu_placement() -> sandbox::HostCpuPlacementConfig {
+    sandbox::HostCpuPlacementConfig::new(1, 1, sandbox::HostCpuPlacementMode::PreferManaged)
+        .unwrap()
+}
+
 struct BlockingFactoryRuntime {
     entered: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
     release: tokio::sync::Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
@@ -149,6 +280,219 @@ async fn status_mode_if_exists(status_path: &std::path::Path) -> Option<String> 
         .get("mode")
         .and_then(serde_json::Value::as_str)
         .map(str::to_string)
+}
+
+#[tokio::test]
+async fn dns_startup_rebuilds_runtime_after_port_race() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let runtime_provider = DnsStartupRecordingProvider::new(Arc::clone(&events));
+    let (mut mitm, _mitm_crash_rx) = crate::proxy::MitmProxy::noop();
+    let mut memory_prefetch = crate::prefetch::MemoryPrefetchTasks::empty();
+
+    let (mut runtime, dns_handle, kmsg_handle) = start_runtime_with_dns(
+        DnsStartupResources {
+            runtime_provider: &runtime_provider,
+            mitm: &mut mitm,
+            kmsg_handle: crate::kmsg_log::KmsgHandle::noop(),
+            memory_prefetch: &mut memory_prefetch,
+            network_log_manager: NetworkLogManager::new(),
+            host_cpu_placement: test_host_cpu_placement(),
+        },
+        scripted_dns_starter(
+            vec![Some(std::io::ErrorKind::AddrInUse), None],
+            Arc::clone(&events),
+        ),
+    )
+    .await
+    .expect("second DNS startup attempt should succeed");
+
+    let replacement_port = {
+        let events = events.lock().unwrap_or_else(|e| e.into_inner());
+        let [
+            DnsStartupEvent::RuntimeCreated {
+                id: first_id,
+                proxy_port: first_proxy_port,
+                dns_port: first_dns_port,
+            },
+            DnsStartupEvent::DnsStarted {
+                port: first_start_port,
+            },
+            DnsStartupEvent::RuntimeShutdown {
+                id: first_shutdown_id,
+            },
+            DnsStartupEvent::RuntimeCreated {
+                id: second_id,
+                proxy_port: second_proxy_port,
+                dns_port: second_dns_port,
+            },
+            DnsStartupEvent::DnsStarted {
+                port: second_start_port,
+            },
+            DnsStartupEvent::ReadinessActivated { id: readiness_id },
+        ] = events.as_slice()
+        else {
+            panic!("unexpected DNS startup event sequence: {events:?}");
+        };
+        assert_eq!(*first_id, 0);
+        assert_eq!(*first_proxy_port, 0);
+        assert_eq!(*first_dns_port, *first_start_port);
+        assert_eq!(*first_shutdown_id, 0);
+        assert_eq!(*second_id, 1);
+        assert_eq!(*second_proxy_port, 0);
+        assert_eq!(*second_dns_port, *second_start_port);
+        assert_eq!(*readiness_id, 1);
+        *second_dns_port
+    };
+    assert_eq!(dns_handle.port(), replacement_port);
+
+    dns_handle.stop().await.unwrap();
+    runtime.shutdown().await;
+    kmsg_handle.stop().await.unwrap();
+    mitm.kill_now().await.unwrap();
+    memory_prefetch.cancel();
+    memory_prefetch.drain().await;
+}
+
+#[tokio::test]
+async fn dns_startup_stops_after_three_port_races() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let runtime_provider = DnsStartupRecordingProvider::new(Arc::clone(&events));
+    let (mut mitm, _mitm_crash_rx) = crate::proxy::MitmProxy::noop();
+    let mut memory_prefetch = crate::prefetch::MemoryPrefetchTasks::empty();
+
+    let error = match start_runtime_with_dns(
+        DnsStartupResources {
+            runtime_provider: &runtime_provider,
+            mitm: &mut mitm,
+            kmsg_handle: crate::kmsg_log::KmsgHandle::noop(),
+            memory_prefetch: &mut memory_prefetch,
+            network_log_manager: NetworkLogManager::new(),
+            host_cpu_placement: test_host_cpu_placement(),
+        },
+        scripted_dns_starter(
+            vec![
+                Some(std::io::ErrorKind::AddrInUse),
+                Some(std::io::ErrorKind::AddrInUse),
+                Some(std::io::ErrorKind::AddrInUse),
+            ],
+            Arc::clone(&events),
+        ),
+    )
+    .await
+    {
+        Ok(_) => panic!("third DNS port race should be terminal"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("scripted DNS startup failure"));
+    let events = events.lock().unwrap_or_else(|e| e.into_inner());
+    assert_eq!(events.len(), 9, "unexpected DNS startup events: {events:?}");
+    let (attempts, remainder) = events.as_chunks::<3>();
+    assert!(remainder.is_empty());
+    for (expected_id, attempt) in attempts.iter().enumerate() {
+        let [
+            DnsStartupEvent::RuntimeCreated {
+                id,
+                proxy_port,
+                dns_port,
+            },
+            DnsStartupEvent::DnsStarted { port },
+            DnsStartupEvent::RuntimeShutdown { id: shutdown_id },
+        ] = attempt
+        else {
+            panic!("unexpected DNS startup attempt events: {attempt:?}");
+        };
+        assert_eq!(*id, expected_id);
+        assert_eq!(*proxy_port, 0);
+        assert_eq!(*dns_port, *port);
+        assert_eq!(*shutdown_id, expected_id);
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn non_port_dns_failure_cleans_owned_startup_resources_without_retry() {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let runtime_provider = DnsStartupRecordingProvider::new(Arc::clone(&events));
+
+    let mut mitm_child = tokio::process::Command::new("sleep");
+    mitm_child.arg("60").kill_on_drop(true);
+    let mitm_child = mitm_child.spawn().expect("spawn test MITM child");
+    let mitm_pid = mitm_child.id().expect("test MITM child should have pid");
+    let mitm_starttime = crate::process::read_process_stat(mitm_pid)
+        .await
+        .expect("test MITM child should be visible")
+        .starttime;
+    let (mut mitm, _mitm_crash_rx) = crate::proxy::MitmProxy::noop();
+    mitm.set_child_for_test(mitm_child);
+
+    let mut kmsg_child = tokio::process::Command::new("cat");
+    kmsg_child
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true);
+    let kmsg_child = kmsg_child.spawn().expect("spawn test kmsg child");
+    let kmsg_pid = kmsg_child.id().expect("test kmsg child should have pid");
+    let kmsg_starttime = crate::process::read_process_stat(kmsg_pid)
+        .await
+        .expect("test kmsg child should be visible")
+        .starttime;
+    let kmsg_handle =
+        crate::kmsg_log::KmsgHandle::from_test_child(kmsg_child, NetworkLogManager::new())
+            .expect("create test kmsg handle");
+
+    let prefetch_cancel = CancellationToken::new();
+    let task_cancel = prefetch_cancel.clone();
+    let (cancelled_tx, cancelled_rx) = tokio::sync::oneshot::channel();
+    let prefetch_handle = tokio::spawn(async move {
+        task_cancel.cancelled().await;
+        let _ = cancelled_tx.send(());
+    });
+    let mut memory_prefetch =
+        crate::prefetch::MemoryPrefetchTasks::from_test_handle(prefetch_cancel, prefetch_handle);
+
+    let error = match start_runtime_with_dns(
+        DnsStartupResources {
+            runtime_provider: &runtime_provider,
+            mitm: &mut mitm,
+            kmsg_handle,
+            memory_prefetch: &mut memory_prefetch,
+            network_log_manager: NetworkLogManager::new(),
+            host_cpu_placement: test_host_cpu_placement(),
+        },
+        scripted_dns_starter(vec![Some(std::io::ErrorKind::Other)], Arc::clone(&events)),
+    )
+    .await
+    {
+        Ok(_) => panic!("non-port DNS failure should be terminal"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("scripted DNS startup failure"));
+    assert_eq!(
+        events.lock().unwrap_or_else(|e| e.into_inner()).len(),
+        3,
+        "non-port DNS failure should not be retried"
+    );
+    cancelled_rx
+        .await
+        .expect("prefetch task should observe cancellation");
+    assert_eq!(memory_prefetch.task_count(), 0);
+    assert_ne!(
+        crate::process::read_process_stat(mitm_pid)
+            .await
+            .map(|stat| stat.starttime),
+        Some(mitm_starttime),
+        "terminal DNS failure should reap the MITM child"
+    );
+    assert_ne!(
+        crate::process::read_process_stat(kmsg_pid)
+            .await
+            .map(|stat| stat.starttime),
+        Some(kmsg_starttime),
+        "terminal DNS failure should reap the kmsg child"
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/dns/mod.rs
+++ b/crates/runner/src/dns/mod.rs
@@ -24,5 +24,5 @@ mod port;
 mod proxy;
 
 pub(crate) use log::{DnsReadinessLogObservation, inspect_readiness_log_segment};
-pub(crate) use port::reserve_port;
+pub(crate) use port::{DnsPortReservation, reserve_port};
 pub use proxy::{DnsProxy, start_on_reserved_port};

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::process::Stdio;
 
 use tokio::io::AsyncReadExt;
@@ -58,9 +59,14 @@ impl DnsProxy {
     /// Create a noop handle for testing. No `dnsmasq` process is spawned.
     #[cfg(test)]
     pub fn noop() -> Self {
+        Self::noop_on_port(0)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn noop_on_port(port: u16) -> Self {
         Self {
             process: NetworkLogProcess::noop("dnsmasq", "dns"),
-            port: 0,
+            port,
         }
     }
 
@@ -137,12 +143,28 @@ async fn try_start(
     // exits during spawn.
     crate::parent_death::configure_parent_death_signal(&mut command);
 
-    let mut child = command.spawn()?;
-
     // Give dnsmasq a moment to bind, then verify it's still running.
     // Catches port-already-in-use, missing binary (spawn itself errors),
     // and bad config that causes immediate exit.
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    try_start_with_grace(command, port, network_log_manager, |_| async {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    })
+    .await
+}
+
+async fn try_start_with_grace<F, Fut>(
+    mut command: tokio::process::Command,
+    port: u16,
+    network_log_manager: NetworkLogManager,
+    startup_grace: F,
+) -> std::io::Result<DnsProxy>
+where
+    F: FnOnce(Option<u32>) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let mut child = command.spawn()?;
+
+    startup_grace(child.id()).await;
     match child.try_wait() {
         Ok(Some(status)) => {
             let stderr = read_child_stderr(&mut child).await;
@@ -271,6 +293,101 @@ mod tests {
         assert_eq!(
             dnsmasq_immediate_exit_error_kind(stderr),
             std::io::ErrorKind::Other
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn early_child_failure_is_reaped_before_returning() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let mut command = tokio::process::Command::new("sh");
+        command
+            .args([
+                "-c",
+                "printf 'dnsmasq: Address already in use\\n' >&2; exit 1",
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let observed_pid = Arc::new(AtomicU32::new(0));
+        let grace_pid = Arc::clone(&observed_pid);
+
+        let error =
+            match try_start_with_grace(command, 5353, NetworkLogManager::new(), move |pid| {
+                let pid = pid.expect("test child should have a process id");
+                grace_pid.store(pid, Ordering::SeqCst);
+                async move {
+                    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                        loop {
+                            if crate::process::read_process_stat(pid)
+                                .await
+                                .is_some_and(|stat| stat.state == 'Z')
+                            {
+                                break;
+                            }
+                            tokio::task::yield_now().await;
+                        }
+                    })
+                    .await
+                    .expect("test child should exit before the startup probe");
+                }
+            })
+            .await
+            {
+                Ok(_) => panic!("early child failure should not produce a DNS proxy"),
+                Err(error) => error,
+            };
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AddrInUse);
+        assert!(error.to_string().contains("Address already in use"));
+        let pid = observed_pid.load(Ordering::SeqCst);
+        assert!(
+            crate::process::read_process_stat(pid).await.is_none(),
+            "failed startup child should be reaped before returning"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn running_child_is_transferred_to_proxy_ownership() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let mut command = tokio::process::Command::new("sh");
+        command
+            .args(["-c", "exec cat >&2"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let observed_pid = Arc::new(AtomicU32::new(0));
+        let grace_pid = Arc::clone(&observed_pid);
+
+        let proxy = try_start_with_grace(command, 5353, NetworkLogManager::new(), move |pid| {
+            grace_pid.store(
+                pid.expect("test child should have a process id"),
+                Ordering::SeqCst,
+            );
+            async {}
+        })
+        .await
+        .expect("running child should produce a DNS proxy");
+        let pid = observed_pid.load(Ordering::SeqCst);
+        let starttime = crate::process::read_process_stat(pid)
+            .await
+            .expect("running child should remain owned by the DNS proxy")
+            .starttime;
+
+        assert_eq!(proxy.port(), 5353);
+        proxy.stop().await.unwrap();
+        assert_ne!(
+            crate::process::read_process_stat(pid)
+                .await
+                .map(|stat| stat.starttime),
+            Some(starttime),
+            "stopped DNS proxy should reap its child"
         );
     }
 }


### PR DESCRIPTION
## Summary

- extract the existing runtime and DNS startup retry loop behind a private DNS-start seam
- cover runtime replacement, port propagation, readiness, retry limits, and terminal cleanup
- verify early DNS child failures are reaped while successful children transfer to `DnsProxy`

## Scope

- preserves the production `dnsmasq` arguments and 100 ms startup grace period
- preserves the existing three-attempt `AddrInUse` policy and cleanup ordering
- does not change public APIs, protocols, configuration, or deployment behavior

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p runner --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner`
- repository pre-commit hooks: Cargo fmt, workspace Cargo doc, workspace Cargo clippy, and file-size checks

Closes #32213
