### PR TITLE
fix: use primary color for workflow slashes

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
@@ -119,7 +119,7 @@ export function SlashWorkflowMenu({
                 }}
               >
                 <span className="w-full truncate font-mono text-sm text-foreground">
-                  <span className="text-brand-text">/</span>
+                  <span className="text-primary">/</span>
                   {workflow.name.slice(0, matchStart)}
                   {query && matchStart !== -1 && (
                     <span className="text-brand-text/60">


### PR DESCRIPTION
## Summary

- use the primary color token for slash prefixes in workflow suggestions
- keep the existing workflow-name match highlighting unchanged

## Verification

- `pnpm exec prettier --check apps/platform/src/views/okou-page/slash-workflow.tsx`
- `pnpm -F @okouai/app exec oxlint --deny-warnings src/views/okou-page/slash-workflow.tsx`
- `pnpm -F @okouai/app exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings src/views/okou-page/slash-workflow.tsx`
- `pnpm -F @okouai/app exec eslint src/views/okou-page/slash-workflow.tsx --max-warnings 0 --cache --cache-strategy content --cache-location .eslintcache`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-workflows.test.tsx --maxWorkers=1 --silent=passed-only` (10 tests passed)

Local browser verification was not run; the PR pipeline will provide the full check and preview coverage.
