### PR TITLE
fix(platform): reveal thread shortcuts on modifier hold

### DIFF
--- a/turbo/apps/platform/src/signals/keyboard-shortcut-hints.ts
+++ b/turbo/apps/platform/src/signals/keyboard-shortcut-hints.ts
@@ -1,0 +1,91 @@
+import { command, computed, state } from "ccstate";
+import { delay } from "signal-timers";
+import { stableChatThreadNavigationEnabled$ } from "./external/feature-switch.ts";
+import { onDomEventFn, resetSignal } from "./utils.ts";
+
+const internalKeyboardShortcutHintPhase$ = state<
+  "idle" | "pending" | "visible"
+>("idle");
+const resetKeyboardShortcutHintHold$ = resetSignal();
+
+export const keyboardShortcutHintsVisible$ = computed((get) => {
+  return (
+    get(stableChatThreadNavigationEnabled$) &&
+    get(internalKeyboardShortcutHintPhase$) === "visible"
+  );
+});
+
+export const hideKeyboardShortcutHints$ = command(({ get, set }) => {
+  if (get(internalKeyboardShortcutHintPhase$) === "idle") {
+    return;
+  }
+  set(resetKeyboardShortcutHintHold$);
+  set(internalKeyboardShortcutHintPhase$, "idle");
+});
+
+const showKeyboardShortcutHints$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    await delay(500, { signal });
+    set(internalKeyboardShortcutHintPhase$, "visible");
+  },
+);
+
+const updateKeyboardShortcutHintModifiers$ = command(
+  ({ get, set }, event: KeyboardEvent, signal: AbortSignal) => {
+    const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+    const modifierHeld = isMac
+      ? event.metaKey
+      : event.ctrlKey && !event.metaKey;
+    if (
+      !get(stableChatThreadNavigationEnabled$) ||
+      !modifierHeld ||
+      event.shiftKey ||
+      event.altKey ||
+      event.isComposing ||
+      event.keyCode === 229 ||
+      (event.type === "keydown" &&
+        event.key !== "Meta" &&
+        event.key !== "Control")
+    ) {
+      set(hideKeyboardShortcutHints$);
+      return;
+    }
+    if (event.repeat || get(internalKeyboardShortcutHintPhase$) !== "idle") {
+      return;
+    }
+
+    const holdSignal = set(resetKeyboardShortcutHintHold$, signal);
+    set(internalKeyboardShortcutHintPhase$, "pending");
+    return set(showKeyboardShortcutHints$, holdSignal);
+  },
+);
+
+export const setupKeyboardShortcutHints$ = command(
+  ({ set }, signal: AbortSignal) => {
+    const updateModifiers = onDomEventFn((event: KeyboardEvent) => {
+      return set(updateKeyboardShortcutHintModifiers$, event, signal);
+    });
+    const clearModifiers = onDomEventFn(() => {
+      set(hideKeyboardShortcutHints$);
+    });
+    document.addEventListener("keydown", updateModifiers, {
+      capture: true,
+      signal,
+    });
+    document.addEventListener("keyup", updateModifiers, {
+      capture: true,
+      signal,
+    });
+    window.addEventListener("blur", clearModifiers, { signal });
+    document.addEventListener(
+      "visibilitychange",
+      onDomEventFn(() => {
+        if (document.visibilityState === "hidden") {
+          set(hideKeyboardShortcutHints$);
+        }
+      }),
+      { signal },
+    );
+    signal.addEventListener("abort", clearModifiers, { once: true });
+  },
+);

--- a/turbo/apps/platform/src/signals/okou-page/nav.ts
+++ b/turbo/apps/platform/src/signals/okou-page/nav.ts
@@ -5,6 +5,7 @@ import { localStorageSignals } from "../external/local-storage.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 import { setupGlobalShortcut } from "../../lib/setup-global-shortcut.ts";
 import { GLOBAL_KEYBOARD_SHORTCUTS } from "../../lib/global-keyboard-shortcuts.ts";
+import { setupKeyboardShortcutHints$ } from "../keyboard-shortcut-hints.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
 import { setChatShortcutHelpOpen$ } from "../chat-page/chat-shortcut-help.ts";
 import { openThreeColumnSearchDialog$ } from "./sidebar-state.ts";
@@ -106,6 +107,7 @@ function shouldHandleUniversalSearchShortcut(event: KeyboardEvent): boolean {
 export const setupGlobalKeyboardShortcuts$ = command(
   ({ set }, signal: AbortSignal) => {
     set(setupThreadNumberShortcuts$, signal);
+    set(setupKeyboardShortcutHints$, signal);
     setupGlobalShortcut(
       {
         [GLOBAL_KEYBOARD_SHORTCUTS.toggleChatList.binding]: {

--- a/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/okou-page/sidebar-state.ts
@@ -2,6 +2,7 @@ import { command, computed, state } from "ccstate";
 import { debounceCommand } from "../command-scheduling.ts";
 import { localStorageSignals } from "../external/local-storage.ts";
 import { resetSignal } from "../utils.ts";
+import { hideKeyboardShortcutHints$ } from "../keyboard-shortcut-hints.ts";
 
 // ---------------------------------------------------------------------------
 // Chat navigation search query
@@ -196,6 +197,7 @@ export const threeColumnSearchOpen$ = computed((get) => {
 export const setThreeColumnSearchOpen$ = command(({ set }, open: boolean) => {
   if (!open) {
     set(clearChatListQuery$);
+    set(hideKeyboardShortcutHints$);
   }
   set(internalThreeColumnSearchOpen$, open);
 });
@@ -211,6 +213,7 @@ export const setThreeColumnSearchFilter$ = command(
 );
 
 export const openThreeColumnSearchDialog$ = command(({ set }) => {
+  set(hideKeyboardShortcutHints$);
   set(clearChatListQuery$);
   set(internalThreeColumnSearchFilter$, "all");
   set(internalThreeColumnSearchOpen$, true);

--- a/turbo/apps/platform/src/signals/okou-page/thread-number-shortcuts.ts
+++ b/turbo/apps/platform/src/signals/okou-page/thread-number-shortcuts.ts
@@ -1,6 +1,10 @@
 import { command, computed, state } from "ccstate";
 import { matchShortcut } from "@okouai/ui";
 import { stableChatThreadNavigationEnabled$ } from "../external/feature-switch.ts";
+import {
+  hideKeyboardShortcutHints$,
+  keyboardShortcutHintsVisible$,
+} from "../keyboard-shortcut-hints.ts";
 import { onDomEventFn } from "../utils.ts";
 
 const standaloneDisplayMode$ = state(false);
@@ -18,6 +22,12 @@ export const threadNumberShortcutsEnabled$ = computed((get) => {
   return get(stableChatThreadNavigationEnabled$) && get(standaloneDisplayMode$);
 });
 
+export const threadNumberShortcutHintsVisible$ = computed((get) => {
+  return (
+    get(threadNumberShortcutsEnabled$) && get(keyboardShortcutHintsVisible$)
+  );
+});
+
 export const setupThreadNumberShortcuts$ = command(
   ({ set }, signal: AbortSignal) => {
     const displayModes = [
@@ -31,6 +41,7 @@ export const setupThreadNumberShortcuts$ = command(
           return mode.matches;
         }),
       );
+      set(hideKeyboardShortcutHints$);
     });
     updateDisplayMode(undefined);
     for (const mode of displayModes) {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/keyboard-shortcut-hints.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/keyboard-shortcut-hints.test.tsx
@@ -4,6 +4,7 @@ import { expect, test } from "vitest";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import { click, setupPage } from "../../../__tests__/page-helper.ts";
+import { now } from "../../../lib/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
 import { installContinuityWorkspace } from "./chat-continuity-test-helpers.ts";
@@ -26,18 +27,20 @@ const platforms = [
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/152.0.0.0 Safari/537.36",
     modifier: "Meta",
     hints: ["⌘⇧F", "⌘⇧O", "⌘B"],
+    threadHint: "⌘1",
   },
   {
     platform: "Windows",
     userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
     modifier: "Control",
     hints: ["Ctrl+Shift+F", "Ctrl+Shift+O", "Ctrl+B"],
+    threadHint: "Ctrl+1",
   },
 ] as const;
 
 test.each(platforms)(
-  "Discover action shortcuts on hover in a $platform app",
-  async ({ userAgent, hints }) => {
+  "Keep action shortcuts available on hover while holding the thread modifier in a $platform app",
+  async ({ userAgent, modifier, hints, threadHint }) => {
     context.mocks.browser.userAgent(userAgent);
     context.mocks.browser.matchMedia((query) => {
       return (
@@ -77,6 +80,13 @@ test.each(platforms)(
     const searchHover = await screen.findByRole("tooltip", {
       name: `Search workspace ${hints[0]}`,
     });
+    const pressedAt = now();
+    await user.keyboard(`{${modifier}>}`);
+    expect(list.querySelectorAll("kbd")).toHaveLength(0);
+    await waitFor(() => {
+      expect(within(list).getByText(threadHint)).toBeVisible();
+    });
+    expect(now() - pressedAt).toBeGreaterThanOrEqual(500);
     expect(searchHover).toBeVisible();
     expect(composer).toHaveFocus();
     expect(screen.queryByRole("dialog")).toBeNull();
@@ -87,13 +97,12 @@ test.each(platforms)(
       name: `New chat ${hints[1]}`,
     });
     expect(newChatHover).toBeVisible();
+    await user.keyboard(`{/${modifier}}`);
     await waitFor(() => {
-      expect(searchHover).not.toBeVisible();
+      expect(list.querySelectorAll("kbd")).toHaveLength(0);
     });
+    expect(newChatHover).toBeVisible();
     await user.unhover(newChatButton);
-    await waitFor(() => {
-      expect(newChatHover).not.toBeVisible();
-    });
   },
 );
 
@@ -173,13 +182,15 @@ test("Hide thread hints when stable chat navigation is disabled and preserve act
   await screen.findByRole("textbox", { name: "Message" });
   const list = screen.getByTestId("chat-list-column");
   const user = userEvent.setup();
+  await user.keyboard("{Control>}");
   await waitFor(() => {
-    expect(within(list).getByText("Ctrl+1")).toBeInTheDocument();
+    expect(within(list).getByText("Ctrl+1")).toBeVisible();
   });
   response.resolve(undefined);
   await waitFor(() => {
     expect(list.querySelectorAll("kbd")).toHaveLength(0);
   });
+  await user.keyboard("{/Control}");
   await user.hover(fastButton("New chat", list));
   await expect(
     screen.findByRole("tooltip", { name: "New chat Ctrl+Shift+O" }),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
@@ -51,6 +51,7 @@ async function openSearch(modifiers = { ctrlKey: true, metaKey: false }) {
   });
   const dialog = await screen.findByRole("dialog", { name: SEARCH_LABEL });
   const search = within(dialog).getByPlaceholderText(SEARCH_LABEL);
+  fireEvent.keyUp(search, { key: "Shift", ...modifiers, shiftKey: false });
   return { dialog, search };
 }
 
@@ -240,6 +241,17 @@ test.each([
         },
       ),
     ).toStrictEqual(firstHint);
+    fireEvent.keyUp(search, { key: modifiers.metaKey ? "Meta" : "Control" });
+    await waitFor(() => {
+      expect(numberedHints(dialog)).toStrictEqual([]);
+    });
+    fireEvent.keyDown(search, {
+      key: modifiers.metaKey ? "Meta" : "Control",
+      ...modifiers,
+    });
+    await waitFor(() => {
+      expect(numberedHints(dialog)).toHaveLength(9);
+    });
     fireEvent.keyDown(search, {
       key: "9",
       code: "Digit9",
@@ -367,6 +379,7 @@ test("Search numbers follow fresh matches and restart after filtering", async ()
   });
   const { dialog, search } = await openSearch();
   await fill(search, "budget");
+  fireEvent.keyDown(search, { key: "Control", ctrlKey: true });
   await waitFor(() => {
     expect(searchResultTitles(dialog)).toStrictEqual([
       "Budget planning",
@@ -396,7 +409,7 @@ test("Search numbers follow fresh matches and restart after filtering", async ()
   });
 });
 
-test("Search shortcuts preserve typing and ignore invalid combinations", async () => {
+test("Search shortcuts preserve typing and reset hints when focus is lost or the dialog closes", async () => {
   context.mocks.browser.matchMedia((query) => {
     return (
       query === "(display-mode: standalone)" || query === "(min-width: 48rem)"
@@ -446,10 +459,15 @@ test("Search shortcuts preserve typing and ignore invalid combinations", async (
   });
   expect(dialog).toBeInTheDocument();
   expect(search).toHaveValue("");
+  fireEvent.blur(window);
+  await waitFor(() => {
+    expect(numberedHints(dialog)).toStrictEqual([]);
+  });
   search.focus();
   await userEvent.keyboard("19");
   expect(search).toHaveValue("19");
   await fill(search, "");
+  fireEvent.keyDown(search, { key: "Control", ctrlKey: true });
   await waitFor(() => {
     expect(numberedHints(dialog)).toStrictEqual(["1"]);
   });
@@ -462,7 +480,7 @@ test("Search shortcuts preserve typing and ignore invalid combinations", async (
   await waitFor(() => {
     expect(searchResultTitles(reopened)).toStrictEqual(["First chat"]);
   });
-  expect(numberedHints(reopened)).toStrictEqual(["1"]);
+  expect(numberedHints(reopened)).toStrictEqual([]);
 });
 
 test.each([
@@ -504,6 +522,7 @@ test.each([
     });
     const { dialog, search } = await openSearch();
     await fill(search, "budget");
+    fireEvent.keyDown(search, { key: "Control", ctrlKey: true });
     await waitFor(() => {
       expect(searchResultTitles(dialog)).toStrictEqual([
         "Budget planning",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
@@ -8,6 +8,7 @@ import {
   queryAllByRoleFast,
   setupPage,
 } from "../../../__tests__/page-helper.ts";
+import { now } from "../../../lib/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
 import { installContinuityWorkspace } from "./chat-continuity-test-helpers.ts";
@@ -76,7 +77,7 @@ test.each([
     label: "Ctrl+",
   },
 ])(
-  "Label the first nine threads with compact shortcuts and navigate on $platform",
+  "Reveal the first nine thread shortcuts after holding the modifier for 500 ms on $platform",
   async ({
     userAgent,
     maxTouchPoints,
@@ -124,17 +125,31 @@ test.each([
     });
     const list = screen.getByTestId("chat-list-column");
     const user = userEvent.setup();
+    await user.hover(sidebarThreadLinks()[0]!);
+    expect(hintKeys(list)).toStrictEqual([]);
+    const pressedAt = now();
+    await user.keyboard(`{${modifier}>}`);
+    expect(hintKeys(list)).toStrictEqual([]);
+    await waitFor(() => {
+      expect(hintKeys(list)).toHaveLength(9);
+    });
+    expect(now() - pressedAt).toBeGreaterThanOrEqual(500);
     expect(hintKeys(list)).toStrictEqual(
       Array.from({ length: 9 }, (_, index) => {
         return `${label}${index + 1}`;
       }),
     );
-    await user.keyboard(
-      `{${modifier}>}${additionalModifier}9${releaseModifiers}`,
-    );
+    if (additionalModifier) {
+      await user.keyboard(additionalModifier);
+    }
+    expect(hintKeys(list)).toHaveLength(9);
+    await user.keyboard(`9${releaseModifiers}`);
     await waitFor(() => {
       expect(pathname()).toBe(`/chats/${threads[4]!.id}`);
     });
+    expect(hintKeys(list)).toStrictEqual([]);
+
+    // A known shortcut can be used immediately, without waiting for its hint.
     await user.keyboard(
       `{${modifier}>}${additionalModifier}1${releaseModifiers}`,
     );
@@ -143,6 +158,53 @@ test.each([
     });
   },
 );
+
+test("Cancel a short hold and clear hints on release, blur, and visibility loss", async () => {
+  context.mocks.browser.matchMedia((query) => {
+    return (
+      query === "(display-mode: standalone)" || query === "(min-width: 48rem)"
+    );
+  });
+  const visibility = context.mocks.browser.visibilityState("visible");
+  const thread = chatListThread(1, "Hold lifecycle");
+  const workspace = await installContinuityWorkspace(context, {
+    caseId: 41,
+    threads: [thread],
+  });
+  await setupPage({
+    context,
+    path: `/chats/${thread.id}`,
+    auth: workspace.auth,
+    featureSwitches,
+  });
+  await waitFor(() => {
+    expect(sidebarThreadTitles()).toStrictEqual(["Hold lifecycle"]);
+  });
+  const list = screen.getByTestId("chat-list-column");
+  const user = userEvent.setup();
+  await user.keyboard("{Control>}{/Control}");
+  expect(hintKeys(list)).toStrictEqual([]);
+  const pressedAt = now();
+  await user.keyboard("{Control>}");
+  await waitFor(() => {
+    expect(hintKeys(list)).toStrictEqual(["Ctrl+1"]);
+  });
+  expect(now() - pressedAt).toBeGreaterThanOrEqual(500);
+  fireEvent.blur(window);
+  await waitFor(() => {
+    expect(hintKeys(list)).toStrictEqual([]);
+  });
+  await user.keyboard("{/Control}{Control>}");
+  await waitFor(() => {
+    expect(hintKeys(list)).toStrictEqual(["Ctrl+1"]);
+  });
+  visibility.changeTo("hidden");
+  await waitFor(() => {
+    expect(hintKeys(list)).toStrictEqual([]);
+  });
+  visibility.changeTo("visible");
+  await user.keyboard("{/Control}");
+});
 
 test("Keep browser mode free of number shortcuts and react to display mode changes", async () => {
   const media = context.mocks.browser.matchMedia((query) => {
@@ -208,6 +270,7 @@ test("Keep browser mode free of number shortcuts and react to display mode chang
       query === "(min-width: 48rem)"
     );
   });
+  await user.keyboard("{Control>}");
   await waitFor(() => {
     expect(hintKeys(list)).toStrictEqual(["Ctrl+1", "Ctrl+2"]);
   });
@@ -217,7 +280,7 @@ test("Keep browser mode free of number shortcuts and react to display mode chang
   await waitFor(() => {
     expect(hintKeys(list)).toStrictEqual([]);
   });
-  await user.keyboard("{Control>}1{/Control}");
+  await user.keyboard("1{/Control}");
   expect(pathname()).toBe(`/chats/${first.id}`);
   click(sidebarThreadLinks()[0]!);
   await waitFor(() => {
@@ -264,14 +327,16 @@ test("Number filtered threads and give the search dialog priority over the list"
   });
   const list = screen.getByTestId("chat-list-column");
   const user = userEvent.setup();
+  await user.keyboard("{Control>}");
   await waitFor(() => {
     expect(hintKeys(list)).toStrictEqual(["Ctrl+1"]);
   });
-  await user.keyboard("{Control>}{Shift>}f{/Shift}");
+  await user.keyboard("{Shift>}f{/Shift}");
   const dialog = await screen.findByRole("dialog", { name: SEARCH_LABEL });
   await waitFor(() => {
     expect(hintKeys(dialog)).toStrictEqual(["Ctrl+1"]);
   });
+  expect(hintKeys(list)).toStrictEqual([]);
   await user.keyboard("1{/Control}");
   await waitFor(() => {
     expect(screen.queryByRole("dialog")).toBeNull();

--- a/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
@@ -524,8 +524,7 @@ function SpotlightRowMeta({
  * own margin, so the tighter box padding lands the avatar's ink on the same
  * rail as the filter row and the search field's left border.
  */
-const SPOTLIGHT_ROW_CLASS =
-  "group group/shortcut w-full gap-3.5 py-2 pl-1 pr-2";
+const SPOTLIGHT_ROW_CLASS = "group w-full gap-3.5 py-2 pl-1 pr-2";
 
 const SPOTLIGHT_AVATAR_CLASS =
   "h-8 w-8 shrink-0 rounded-lg object-cover object-top";

--- a/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.tsx
@@ -175,7 +175,7 @@ export function PinnedThreadRow({
             }
           : undefined
       }
-      className="group group/shortcut relative grid grid-cols-[minmax(0,1fr)_auto] okou-thread-reorder-row"
+      className="group relative grid grid-cols-[minmax(0,1fr)_auto] okou-thread-reorder-row"
       data-thread-id={signals.threadId}
       data-reorderable={reorderable || undefined}
       data-dragging={

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -409,10 +409,9 @@ function ChatThreadItemLink({
             })}
         </span>
       </span>
-      <ThreadNumberShortcutHint
-        shortcutNumber={shortcutNumber}
-        className="mr-2"
-      />
+      <span className="flex items-center pr-2 empty:hidden">
+        <ThreadNumberShortcutHint shortcutNumber={shortcutNumber} />
+      </span>
     </Link>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/thread-number-shortcut-hint.tsx
+++ b/turbo/apps/platform/src/views/okou-page/thread-number-shortcut-hint.tsx
@@ -1,30 +1,25 @@
 import { useGet } from "ccstate-react";
-import { cn, getShortcutLabel } from "@okouai/ui";
+import { getShortcutLabel } from "@okouai/ui";
 import {
-  threadNumberShortcutsEnabled$,
+  threadNumberShortcutHintsVisible$,
   threadNumberShortcutModifier$,
 } from "../../signals/okou-page/thread-number-shortcuts.ts";
 
 export function ThreadNumberShortcutHint({
   shortcutNumber,
-  className,
 }: {
   readonly shortcutNumber: number | undefined;
-  readonly className?: string;
 }) {
-  const enabled = useGet(threadNumberShortcutsEnabled$);
+  const visible = useGet(threadNumberShortcutHintsVisible$);
   const modifier = useGet(threadNumberShortcutModifier$);
-  if (!enabled || shortcutNumber === undefined) {
+  if (!visible || shortcutNumber === undefined) {
     return null;
   }
 
   return (
     <kbd
       aria-hidden="true"
-      className={cn(
-        'pointer-events-none hidden h-5 min-w-5 shrink-0 items-center justify-center whitespace-nowrap rounded-md bg-background px-1.5 text-[10px] font-medium leading-none text-muted-foreground shadow-[inset_0_-1px_0_hsl(var(--border)),0_0_0_1px_hsl(var(--border))] group-hover/shortcut:inline-flex font-["-apple-system",BlinkMacSystemFont,"Segoe_UI",system-ui,sans-serif]',
-        className,
-      )}
+      className='pointer-events-none inline-flex h-5 min-w-5 shrink-0 items-center justify-center whitespace-nowrap rounded-md bg-background px-1.5 text-[10px] font-medium leading-none text-muted-foreground shadow-[inset_0_-1px_0_hsl(var(--border)),0_0_0_1px_hsl(var(--border))] font-["-apple-system",BlinkMacSystemFont,"Segoe_UI",system-ui,sans-serif]'
     >
       {getShortcutLabel(`${modifier}+${shortcutNumber}`)}
     </kbd>


### PR DESCRIPTION
## Summary

- Stop revealing numbered thread and workspace-search shortcuts on row hover.
- Reveal the compact keycaps only after holding Command for 500 ms on macOS, or Control on Windows/Linux.
- Preserve the existing number-key bindings, Safari Command+Control labels, and action-button hover tooltips.
- Clear active or pending hints on modifier release, disqualifying input, window blur, visibility loss, display-mode changes, and search-dialog boundaries.

## Verification

- `pnpm exec vitest run apps/platform/src/views/okou-page/__tests__/keyboard-shortcut-hints.test.tsx apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx --maxWorkers=2` (22 tests passed)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
