### PR TITLE
fix(app): prevent microphone dimming when switching chat threads

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8532,11 +8532,9 @@ function MicButton({
   const voiceLevelFill = `${Math.round((voiceLevel / 3) * 100)}%`;
 
   const signal = useGet(pageSignal$);
-  const disabled =
-    starting ||
-    transcribing ||
-    (voiceInputV2Enabled && voiceDraftStatus === undefined) ||
-    (!recording && !quotaResolved);
+  const draftLoading = voiceInputV2Enabled && voiceDraftStatus === undefined;
+  const actionDisabled =
+    starting || transcribing || (!recording && !quotaResolved);
   const status = {
     recording,
     starting,
@@ -8561,14 +8559,15 @@ function MicButton({
             variant="quiet"
             size="icon-sm"
             iconSize="md"
-            className={cn(
-              "relative shrink-0",
-              (recording || starting || transcribing) &&
-                "bg-[#2E9E9F] text-white hover:bg-[#279394] hover:text-white",
-            )}
+            className={cn("relative shrink-0", {
+              // Background draft checks should not dim the mic on thread switches.
+              "disabled:opacity-100": draftLoading && !actionDisabled,
+              "bg-[#2E9E9F] text-white hover:bg-[#279394] hover:text-white":
+                recording || starting || transcribing,
+            })}
             data-composer-voice-toggle
             onClick={handleClick}
-            disabled={disabled}
+            disabled={actionDisabled || draftLoading}
             aria-label={micButtonAriaLabel(status)}
             aria-busy={starting || transcribing}
             aria-keyshortcuts={


### PR DESCRIPTION
Switching chat threads briefly dimmed the microphone while the destination voice draft loaded. Keep its normal opacity during that background check, while preserving native disabled behavior and the existing feedback for quota loading, microphone startup, and transcription.

Closes #32255

## Validation

- Prettier; Platform lint (including Oxlint, type-aware Oxlint, and ESLint); Platform production/test/build-config type checks; scoped Knip.
- 18 tests passed across the existing `chat-capability-voice-draft-loading`, `chat-capability-voice-quota`, and `chat-capability-voice-isolation` page integration suites (`vitest run` with these three files and `--maxWorkers=1 --silent=passed-only`).
- Verified the shared Button's class merging and emitted Tailwind CSS in local Chromium: draft loading stays at opacity `1` and rejects clicks; ordinary disabled states retain opacity `0.5`.

This is a presentation-only change using existing loading/isolation coverage. The Chromium check used an isolated CSS fixture; authenticated chat navigation has not been visually exercised. Full local Vitest and a local dev server were not run, per the task instructions.
