### PR TITLE
feat(runner): publish explicit blank sandbox inventory

### DIFF
--- a/.github/scripts/resolve-production-rollback-target.sh
+++ b/.github/scripts/resolve-production-rollback-target.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly CHAT_EVENT_FAILURE_REASON_READER_COMMIT=c093e0ffdab988d2a8a071809f90d87fa3e79f20
 readonly CHAT_EVENT_FAILURE_REASON_READER_RELEASE=89c6a521944e2ac8550da424f164db08f4f80f0c
+readonly BLANK_SANDBOX_STATUS_READER_COMMIT=febec8a3399be74b0f14a89cb9f42e39dd5ce69f
 
 fail() {
   echo "::error::$*" >&2
@@ -45,6 +46,9 @@ if ! git merge-base --is-ancestor \
 fi
 
 release_tags=$(git tag --points-at "$TARGET_COMMIT" | grep -E -- '-v[0-9]' || true)
+if ! git merge-base --is-ancestor "$BLANK_SANDBOX_STATUS_READER_COMMIT" "$TARGET_COMMIT"; then
+  fail "Target commit predates the blank sandbox status reader: ${BLANK_SANDBOX_STATUS_READER_COMMIT}."
+fi
 if [ -z "$release_tags" ]; then
   fail "Target commit has no release tags: ${TARGET_COMMIT}"
 fi
@@ -82,6 +86,9 @@ runner_tag=$(runner_image_release_tag "$runner_version")
 runner_tag_commit=$(git rev-list -n 1 "$runner_tag" || true)
 if [ -z "$runner_tag_commit" ] || ! git merge-base --is-ancestor "$runner_tag_commit" "$TARGET_COMMIT"; then
   fail "Runner release ${runner_tag} is not reachable from ${TARGET_COMMIT}."
+fi
+if ! git merge-base --is-ancestor "$BLANK_SANDBOX_STATUS_READER_COMMIT" "$runner_tag_commit"; then
+  fail "Runner release ${runner_tag} predates the blank sandbox status reader: ${BLANK_SANDBOX_STATUS_READER_COMMIT}."
 fi
 
 runner_matrix=$("${script_dir}/runner-host-architecture-groups.sh" target-matrix)

--- a/.github/scripts/tests/resolve-production-rollback-target-test.sh
+++ b/.github/scripts/tests/resolve-production-rollback-target-test.sh
@@ -24,6 +24,12 @@ case "${1:-}" in
   merge-base)
     if [ "${3:-}" = "c093e0ffdab988d2a8a071809f90d87fa3e79f20" ]; then
       [ "${MOCK_READER_FLOOR_VALID:-1}" = "1" ]
+    elif [ "${3:-}" = "febec8a3399be74b0f14a89cb9f42e39dd5ce69f" ]; then
+      if [ "${4:-}" = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" ]; then
+        [ "${MOCK_BLANK_RUNNER_FLOOR_VALID:-1}" = "1" ]
+      else
+        [ "${MOCK_BLANK_TARGET_FLOOR_VALID:-1}" = "1" ]
+      fi
     else
       [ "${MOCK_ANCESTRY_VALID:-1}" = "1" ]
     fi
@@ -153,6 +159,22 @@ assert_failure \
 [ ! -s "${tmp_dir}/reader-floor.output" ] || fail "incompatible reader target must not publish outputs"
 if grep -qE '^(curl|aws) ' "${tmp_dir}/boundaries.log"; then
   fail "reader-floor rejection must happen before artifact resolution"
+fi
+
+: >"${tmp_dir}/boundaries.log"
+assert_failure "Target commit predates the blank sandbox status reader" \
+  run_resolver "${tmp_dir}/blank-target-floor.output" MOCK_BLANK_TARGET_FLOOR_VALID=0
+[ ! -s "${tmp_dir}/blank-target-floor.output" ] || fail "old blank reader target must not publish outputs"
+if grep -q '^curl ' "${tmp_dir}/boundaries.log"; then
+  fail "blank reader target rejection must precede artifact resolution"
+fi
+
+: >"${tmp_dir}/boundaries.log"
+assert_failure "Runner release runner-rs-v1.2.3 predates the blank sandbox status reader" \
+  run_resolver "${tmp_dir}/blank-runner-floor.output" MOCK_BLANK_RUNNER_FLOOR_VALID=0
+[ ! -s "${tmp_dir}/blank-runner-floor.output" ] || fail "old Runner artifact must not publish outputs"
+if grep -q 'api.github.com/repos/.*/releases/tags/' "${tmp_dir}/boundaries.log"; then
+  fail "blank reader artifact rejection must precede asset resolution"
 fi
 
 release_target_script="${tmp_dir}/resolve-release-target.sh"
@@ -332,7 +354,10 @@ assert_failure \
   bash "$release_tags_script"
 [ ! -s "$duplicate_release_tags_output" ] || fail "duplicate release tags must not publish an output"
 
-ruby -e '
+ruby - \
+  "${repo_root}/.github/workflows/rollback-production.yml" \
+  "${repo_root}/.github/workflows/release-please.yml" \
+  "${repo_root}/.github/workflows/turbo.yml" <<'RUBY'
   require "yaml"
   rollback_config = YAML.safe_load(File.read(ARGV[0]), aliases: true)
   release_config = YAML.safe_load(File.read(ARGV[1]), aliases: true)
@@ -441,9 +466,6 @@ ruby -e '
   artifact_upload_run = artifact_upload_step.fetch("run")
   raise "deploy-app must upload the archived App artifact" unless artifact_upload_run.include?("/dist.tar.gz")
   raise "deploy-app must not upload per-file App artifacts" if artifact_upload_run.include?("aws s3 cp turbo/apps/platform/dist")
-' \
-  "${repo_root}/.github/workflows/rollback-production.yml" \
-  "${repo_root}/.github/workflows/release-please.yml" \
-  "${repo_root}/.github/workflows/turbo.yml"
+RUBY
 
 echo "resolve-production-rollback-target tests passed"

--- a/crates/runner/src/cmd/start/blank_pool.rs
+++ b/crates/runner/src/cmd/start/blank_pool.rs
@@ -801,7 +801,8 @@ mod tests {
 
         let mut pool = idle_pool.lock().await;
         assert_eq!(pool.blank_len(), 1);
-        assert_eq!(pool.status_snapshot().idle_sandboxes.len(), 1);
+        assert!(pool.status_snapshot().idle_sandboxes.is_empty());
+        assert_eq!(pool.status_snapshot().blank_sandboxes.len(), 1);
         assert!(pool.held_sandbox_states().is_empty());
         let destroy = pool.drain();
         drop(pool);

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -106,7 +106,7 @@ pub(super) async fn drain_idle_pool(
 
 pub(super) struct RetiringIdleEntry {
     budget_lease: BudgetLease,
-    reuse_key: String,
+    reuse_key: Option<String>,
     profile_name: String,
 }
 
@@ -158,8 +158,8 @@ impl Deref for ReservedIdleActivation {
 }
 
 impl RetiringIdleEntry {
-    pub(super) fn reuse_key(&self) -> &str {
-        &self.reuse_key
+    pub(super) fn reuse_key(&self) -> Option<&str> {
+        self.reuse_key.as_deref()
     }
 
     pub(super) fn profile_name(&self) -> &str {
@@ -229,11 +229,9 @@ pub(super) async fn select_idle_entries_for_pressure(
                 request.memory_mb,
             );
             if fresh_lease.is_none() {
-                for reuse_key in pool.oldest_first_pressure_keys() {
-                    let Some(idle_kind) = pool.entry_kind(&reuse_key) else {
-                        continue;
-                    };
-                    let Some(job) = pool.evict_for_pressure(&reuse_key) else {
+                for identity in pool.oldest_first_pressure_keys() {
+                    let idle_kind = identity.kind();
+                    let Some(job) = pool.evict_for_pressure(&identity) else {
                         continue;
                     };
                     mutated = true;
@@ -242,8 +240,8 @@ pub(super) async fn select_idle_entries_for_pressure(
                         run_id = %request.run_id,
                         context = request.context,
                         idle_kind = ?idle_kind,
-                        reuse_key_fingerprint = %short_digest(retiring.reuse_key()),
-                        reuse_key_kind = reuse_key_kind(retiring.reuse_key()),
+                        reuse_key_fingerprint = retiring.reuse_key().map(short_digest),
+                        reuse_key_kind = retiring.reuse_key().map(reuse_key_kind),
                         profile = %retiring.profile_name(),
                         vcpu = retiring.budget_vcpu(),
                         memory_mb = retiring.budget_memory_mb(),
@@ -296,20 +294,16 @@ fn try_substitute_retiring_leases(
 }
 
 pub(super) async fn set_idle_status_snapshot(status: &StatusTracker, snapshot: IdlePoolSnapshot) {
-    let result = status
-        .set_idle_info_at_revision(snapshot.revision, snapshot.idle_sandboxes)
-        .await;
+    let revision = snapshot.revision;
+    let result = status.set_idle_snapshot(snapshot).await;
     match result {
         Ok(false) => {
-            info!(
-                revision = snapshot.revision,
-                "ignored stale idle pool status snapshot"
-            );
+            info!(revision, "ignored stale idle pool status snapshot");
         }
         Ok(true) => {}
         Err(error) => {
             warn!(
-                revision = snapshot.revision,
+                revision,
                 %error,
                 "failed to persist idle pool status snapshot"
             );
@@ -323,17 +317,13 @@ pub(super) async fn add_running_run_with_idle_status_snapshot(
     sandbox_id: SandboxId,
     snapshot: IdlePoolSnapshot,
 ) -> StatusResult<()> {
+    let revision = snapshot.revision;
     let applied = status
-        .add_running_run_with_idle_info_at_revision(
-            run_id,
-            sandbox_id,
-            snapshot.revision,
-            snapshot.idle_sandboxes,
-        )
+        .add_running_run_with_idle_snapshot(run_id, sandbox_id, snapshot)
         .await?;
     if !applied {
         info!(
-            revision = snapshot.revision,
+            revision,
             "ignored stale idle pool status snapshot while adding active run"
         );
     }
@@ -346,17 +336,13 @@ pub(super) async fn add_preparing_run_with_idle_status_snapshot(
     sandbox_id: SandboxId,
     snapshot: IdlePoolSnapshot,
 ) -> StatusResult<()> {
+    let revision = snapshot.revision;
     let applied = status
-        .add_preparing_run_with_idle_info_at_revision(
-            run_id,
-            sandbox_id,
-            snapshot.revision,
-            snapshot.idle_sandboxes,
-        )
+        .add_preparing_run_with_idle_snapshot(run_id, sandbox_id, snapshot)
         .await?;
     if !applied {
         info!(
-            revision = snapshot.revision,
+            revision,
             "ignored stale idle pool status snapshot while adding preparing run"
         );
     }
@@ -376,7 +362,7 @@ fn retire_idle_destroy_job(
     job: IdleDestroyJob,
     context: &'static str,
 ) -> RetiringIdleEntry {
-    let reuse_key = job.reuse_key().to_owned();
+    let reuse_key = job.reuse_key().map(str::to_owned);
     let profile_name = job.profile_name().to_owned();
     let (payload, budget_lease) = job.into_retiring_parts();
     tracker.spawn_payload(payload, context);

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -1430,11 +1430,7 @@ async fn exact_speculative_preparation(
 ) -> PreferencePreparation {
     let sandbox_id = reservation.sandbox_id();
     let (reservation, idle_snapshot) = reservation.into_parts();
-    if let Err(error) = ctx
-        .status
-        .set_idle_info_at_revision(idle_snapshot.revision, idle_snapshot.idle_sandboxes.clone())
-        .await
-    {
+    if let Err(error) = ctx.status.set_idle_snapshot(idle_snapshot.clone()).await {
         warn!(%error, "failed to persist exact speculation idle reservation");
         rollback_reserved_idle_for_spawn(
             ReservedIdleActivation::new(reservation, idle_snapshot),
@@ -1939,13 +1935,13 @@ async fn activate_speculated_exact(
         }
     };
 
-    let reserved_reuse_key = sandbox.reuse_key().to_owned();
+    let reserved_reuse_key = sandbox.reuse_key().map(str::to_owned);
     let requested_reuse_key = context.reuse_key();
-    if requested_reuse_key != Some(reserved_reuse_key.as_str()) {
+    if requested_reuse_key != reserved_reuse_key.as_deref() {
         warn!(
             run_id = %run_id,
-            reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
-            reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+            reuse_key_fingerprint = reserved_reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+            reuse_key_kind = reserved_reuse_key.as_deref().map(reuse_key_kind),
             "claimed reuse key does not match speculatively prepared idle sandbox"
         );
         return cleanup_claimed_speculation_for_fresh_fallback(
@@ -1978,8 +1974,8 @@ async fn activate_speculated_exact(
         if let Err(mismatch) = validation {
             warn!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
-                reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+                reuse_key_fingerprint = reserved_reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+                reuse_key_kind = reserved_reuse_key.as_deref().map(reuse_key_kind),
                 profile = %profile_name,
                 mismatch = mismatch.as_str(),
                 "workspace promotion identity mismatch after speculative preparation"
@@ -2104,12 +2100,12 @@ async fn finish_exact_activation(
                 };
             }
 
-            let reuse_key = sandbox.reuse_key().to_owned();
+            let reuse_key = sandbox.reuse_key().map(str::to_owned);
             let (reuse_entry, active_lease) = sandbox.commit(guest_state_prepared);
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reuse_key),
-                reuse_key_kind = reuse_key_kind(&reuse_key),
+                reuse_key_fingerprint = reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+                reuse_key_kind = reuse_key.as_deref().map(reuse_key_kind),
                 "committing speculatively prepared exact-reuse sandbox"
             );
             ExactActivation::Ready {
@@ -2209,7 +2205,7 @@ pub(super) async fn activate_reserved_idle(
         (IdleSandboxKind::Exact | IdleSandboxKind::Blank, _) => (reservation, idle_snapshot),
     };
     let reservation_kind = reservation.kind();
-    let reserved_reuse_key = reservation.reuse_key().to_owned();
+    let reserved_reuse_key = reservation.reuse_key().map(str::to_owned);
     let miss_result = if requested_reuse_key.is_some() {
         SandboxReuseResult::PoolMiss
     } else {
@@ -2256,11 +2252,13 @@ pub(super) async fn activate_reserved_idle(
     if reservation.profile_name() != profile_name
         || reservation.device_rate_limits() != device_rate_limits
     {
-        let reuse_key_fingerprint = diagnostic_reuse_key_fingerprint(&reserved_reuse_key);
+        let reuse_key_fingerprint = reserved_reuse_key
+            .as_deref()
+            .map(diagnostic_reuse_key_fingerprint);
         warn!(
             run_id = %run_id,
-            reuse_key_fingerprint = %reuse_key_fingerprint,
-            reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+            reuse_key_fingerprint,
+            reuse_key_kind = reserved_reuse_key.as_deref().map(reuse_key_kind),
             profile = %profile_name,
             "reserved idle sandbox configuration does not match claimed job, destroying before fresh fallback"
         );
@@ -2275,13 +2273,15 @@ pub(super) async fn activate_reserved_idle(
     }
 
     if reservation_kind == IdleSandboxKind::Exact
-        && requested_reuse_key != Some(reserved_reuse_key.as_str())
+        && requested_reuse_key != reserved_reuse_key.as_deref()
     {
-        let reuse_key_fingerprint = diagnostic_reuse_key_fingerprint(&reserved_reuse_key);
+        let reuse_key_fingerprint = reserved_reuse_key
+            .as_deref()
+            .map(diagnostic_reuse_key_fingerprint);
         warn!(
             run_id = %run_id,
-            reuse_key_fingerprint = %reuse_key_fingerprint,
-            reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+            reuse_key_fingerprint,
+            reuse_key_kind = reserved_reuse_key.as_deref().map(reuse_key_kind),
             "claimed reuse key does not match reserved idle sandbox, destroying before fresh fallback"
         );
         return cleanup_reserved_for_fresh_fallback(
@@ -2308,8 +2308,8 @@ pub(super) async fn activate_reserved_idle(
         if let Err(mismatch) = validation {
             warn!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
-                reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+                reuse_key_fingerprint = reserved_reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+                reuse_key_kind = reserved_reuse_key.as_deref().map(reuse_key_kind),
                 profile = %profile_name,
                 mismatch = mismatch.as_str(),
                 "workspace promotion identity mismatch, destroying reserved idle sandbox before fresh fallback"
@@ -2380,8 +2380,8 @@ pub(super) async fn activate_reserved_idle(
             info!(
                 run_id = %run_id,
                 idle_kind = ?reservation_kind,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
-                reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+                reuse_key_fingerprint = reserved_reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+                reuse_key_kind = reserved_reuse_key.as_deref().map(reuse_key_kind),
                 "activating pre-claim reserved idle sandbox"
             );
             ReservedActivation::Ready {
@@ -2394,8 +2394,8 @@ pub(super) async fn activate_reserved_idle(
         IdleUnparkResult::Failed { destroy_job, error } => {
             warn!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&reserved_reuse_key),
-                reuse_key_kind = reuse_key_kind(&reserved_reuse_key),
+                reuse_key_fingerprint = reserved_reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+                reuse_key_kind = reserved_reuse_key.as_deref().map(reuse_key_kind),
                 error = %error,
                 "reserved idle sandbox unpark failed, destroying before fresh fallback"
             );
@@ -2646,7 +2646,7 @@ async fn try_reuse_from_pool(
                 && entry.device_rate_limits() == device_rate_limits =>
         {
             let entry_kind = entry.kind();
-            let entry_reuse_key = entry.reuse_key().to_owned();
+            let entry_reuse_key = entry.reuse_key().map(str::to_owned);
             let activation_reuse_result = match entry_kind {
                 IdleSandboxKind::Exact => SandboxReuseResult::Reused,
                 IdleSandboxKind::Blank => miss_result,
@@ -2673,8 +2673,8 @@ async fn try_reuse_from_pool(
                 if let Err(mismatch) = validation {
                     warn!(
                         run_id = %run_id,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&entry_reuse_key),
-                        reuse_key_kind = reuse_key_kind(&entry_reuse_key),
+                        reuse_key_fingerprint = entry_reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+                        reuse_key_kind = entry_reuse_key.as_deref().map(reuse_key_kind),
                         profile = %profile_name,
                         mismatch = mismatch.as_str(),
                         "workspace promotion identity mismatch, destroying idle sandbox and falling through to fresh create"
@@ -2765,8 +2765,8 @@ async fn try_reuse_from_pool(
                     info!(
                         run_id = %run_id,
                         idle_kind = ?entry_kind,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&entry_reuse_key),
-                        reuse_key_kind = reuse_key_kind(&entry_reuse_key),
+                        reuse_key_fingerprint = entry_reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+                        reuse_key_kind = entry_reuse_key.as_deref().map(reuse_key_kind),
                         "activating idle sandbox"
                     );
                     // Idle entry already holds budget. Drop the speculative
@@ -2786,8 +2786,8 @@ async fn try_reuse_from_pool(
                     warn!(
                         run_id = %run_id,
                         idle_kind = ?entry_kind,
-                        reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&entry_reuse_key),
-                        reuse_key_kind = reuse_key_kind(&entry_reuse_key),
+                        reuse_key_fingerprint = entry_reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+                        reuse_key_kind = entry_reuse_key.as_deref().map(reuse_key_kind),
                         error = %error,
                         "unpark failed, destroying idle sandbox and falling through to fresh create"
                     );
@@ -2829,11 +2829,11 @@ async fn try_reuse_from_pool(
             }
         }
         Some((stale, snapshot)) if stale.profile_name() == profile_name => {
-            let stale_reuse_key = stale.reuse_key().to_owned();
+            let stale_reuse_key = stale.reuse_key().map(str::to_owned);
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&stale_reuse_key),
-                reuse_key_kind = reuse_key_kind(&stale_reuse_key),
+                reuse_key_fingerprint = stale_reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+                reuse_key_kind = stale_reuse_key.as_deref().map(reuse_key_kind),
                 profile = %profile_name,
                 "idle sandbox device rate limiter mismatch, destroying"
             );
@@ -2852,11 +2852,11 @@ async fn try_reuse_from_pool(
             ))
         }
         Some((stale, snapshot)) => {
-            let stale_reuse_key = stale.reuse_key().to_owned();
+            let stale_reuse_key = stale.reuse_key().map(str::to_owned);
             info!(
                 run_id = %run_id,
-                reuse_key_fingerprint = %diagnostic_reuse_key_fingerprint(&stale_reuse_key),
-                reuse_key_kind = reuse_key_kind(&stale_reuse_key),
+                reuse_key_fingerprint = stale_reuse_key.as_deref().map(diagnostic_reuse_key_fingerprint),
+                reuse_key_kind = stale_reuse_key.as_deref().map(reuse_key_kind),
                 old_profile = %stale.profile_name(),
                 new_profile = %profile_name,
                 "idle sandbox profile mismatch, destroying"
@@ -2916,6 +2916,7 @@ mod tests {
     fn idle_snapshot() -> IdlePoolSnapshot {
         IdlePoolSnapshot {
             revision: 1,
+            blank_sandboxes: vec![],
             idle_sandboxes: vec![IdleSandbox {
                 reuse_key: "sess-removed-from-pool".into(),
                 sandbox_id: SandboxId::new_v4(),

--- a/crates/runner/src/cmd/start/ownership.rs
+++ b/crates/runner/src/cmd/start/ownership.rs
@@ -159,12 +159,16 @@ fn idle_snapshot_contains_sandbox_id(
         .idle_sandboxes
         .iter()
         .any(|idle_sandbox| idle_sandbox.sandbox_id == sandbox_id)
+        || idle_snapshot
+            .blank_sandboxes
+            .iter()
+            .any(|blank| blank.sandbox_id == sandbox_id)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::status::IdleSandbox;
+    use crate::status::{BlankSandbox, IdleSandbox};
 
     async fn status_idle_reuse_keys_and_active_runs(
         status_path: &std::path::Path,
@@ -205,6 +209,7 @@ mod tests {
     fn idle_snapshot(reuse_key: &str, sandbox_id: SandboxId) -> IdlePoolSnapshot {
         IdlePoolSnapshot {
             revision: 1,
+            blank_sandboxes: vec![],
             idle_sandboxes: vec![IdleSandbox {
                 reuse_key: reuse_key.to_string(),
                 sandbox_id,
@@ -353,7 +358,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn orphan_idle_owned_requires_idle_snapshot_membership() {
+    async fn orphan_idle_owned_requires_exact_or_blank_snapshot_membership() {
         let dir = tempfile::tempdir().unwrap();
         let status_path = dir.path().join("status.json");
         let status = StatusTracker::new(status_path.clone(), 4, None, None);
@@ -382,5 +387,27 @@ mod tests {
             vec![(run_id.to_string(), sandbox_id.to_string())]
         );
         assert_eq!(orphans.len(), 1);
+
+        let reconciled = transitions
+            .orphan_reconciled_idle_owned(
+                &orphans,
+                [RunSandbox::new(run_id, sandbox_id)],
+                IdlePoolSnapshot {
+                    revision: 2,
+                    idle_sandboxes: vec![],
+                    blank_sandboxes: vec![BlankSandbox { sandbox_id }],
+                },
+            )
+            .await;
+        assert_eq!(reconciled, vec![RunSandbox::new(run_id, sandbox_id)]);
+        assert_eq!(orphans.len(), 0);
+        let persisted = tokio::fs::read_to_string(&status_path).await.unwrap();
+        let persisted: serde_json::Value = serde_json::from_str(&persisted).unwrap();
+        assert_eq!(persisted["active_runs"], serde_json::json!([]));
+        assert!(persisted.get("idle_sandboxes").is_none());
+        assert_eq!(
+            persisted["blank_sandboxes"],
+            serde_json::json!([{ "sandbox_id": sandbox_id.to_string() }])
+        );
     }
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -32,7 +32,7 @@ async fn blank_pool_prepares_and_serves_a_job_without_changing_reuse_attribution
     );
     assert_eq!(calls.start_run_control_ids(), vec![None]);
     assert!(calls.run_control_bind_calls().is_empty());
-    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
 
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
@@ -55,6 +55,15 @@ async fn blank_pool_prepares_and_serves_a_job_without_changing_reuse_attribution
     assert_eq!(calls.workspace_drive_mount_calls(), 1);
 
     shutdown(&env, run_handle).await;
+    let status: serde_json::Value = serde_json::from_str(
+        &tokio::fs::read_to_string(env._temp_dir.path().join("status.json"))
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(status["mode"], "stopped");
+    assert!(status.get("idle_sandboxes").is_none());
+    assert!(status.get("blank_sandboxes").is_none());
 }
 
 #[tokio::test(start_paused = true)]
@@ -65,7 +74,7 @@ async fn full_capacity_claims_compatible_blank_before_pressure_eviction() {
     let run_handle = tokio::spawn(run(config));
 
     wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
-    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
     let parked_at = std::time::Instant::now();
     for reuse_key in [
         "capacity-1",
@@ -117,7 +126,7 @@ async fn exact_idle_that_parks_during_claim_takes_priority_over_reserved_blank()
     let run_handle = tokio::spawn(run(config));
 
     wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
-    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
     env.handle.block_claims();
 
     let run_id = RunId::new_v4();
@@ -270,7 +279,7 @@ async fn blank_backed_run_becomes_exact_reuse_and_wins_over_refilled_blank() {
     let run_handle = tokio::spawn(run(config));
 
     wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
-    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
     let reuse_key = "session-blank-to-exact";
 
     let first_run_id = RunId::new_v4();
@@ -328,7 +337,7 @@ async fn blank_unpark_failure_falls_back_without_changing_cold_attribution() {
     let run_handle = tokio::spawn(run(config));
 
     wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
-    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
 
     let run_id = RunId::new_v4();
     push_job(
@@ -589,7 +598,7 @@ async fn incompatible_profile_fresh_creates_without_consuming_blank_inventory() 
     let run_handle = tokio::spawn(run(config));
 
     wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
-    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
 
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/large", Some(minimal_context(run_id)));
@@ -637,7 +646,7 @@ async fn workspace_cache_hit_takes_priority_over_compatible_blank_inventory() {
     let run_handle = tokio::spawn(run(config));
 
     wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
-    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
 
     let run_id = RunId::new_v4();
     let mut context = context_with_session(run_id, "workspace-priority-session");
@@ -688,7 +697,7 @@ async fn claimed_workspace_cache_metadata_takes_priority_over_reserved_blank() {
     let run_handle = tokio::spawn(run(config));
 
     wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
-    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().idle_sandboxes[0].sandbox_id;
+    let blank_sandbox_id = idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
 
     let run_id = RunId::new_v4();
     let mut context = context_with_session(run_id, "claimed-workspace-priority-session");

--- a/crates/runner/src/cmd/start/tests/idle_reuse/status.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/status.rs
@@ -69,12 +69,7 @@ async fn reuse_take_clears_idle_status_while_job_is_active() {
     )
     .await;
     let snapshot = idle_pool.lock().await.status_snapshot();
-    assert!(
-        status
-            .set_idle_info_at_revision(snapshot.revision, snapshot.idle_sandboxes)
-            .await
-            .unwrap()
-    );
+    assert!(status.set_idle_snapshot(snapshot.clone()).await.unwrap());
     assert_eq!(
         status_idle_reuse_keys(&status_path).await,
         vec!["sess-reuse-status".to_string()],

--- a/crates/runner/src/cmd/start/tests/support/status.rs
+++ b/crates/runner/src/cmd/start/tests/support/status.rs
@@ -173,12 +173,7 @@ async fn status_idle_reuse_keys_and_active_runs_if_exists(
 
 pub(in super::super) async fn publish_idle_status(pool: &SharedIdlePool, status: &StatusTracker) {
     let snapshot = pool.lock().await.status_snapshot();
-    assert!(
-        status
-            .set_idle_info_at_revision(snapshot.revision, snapshot.idle_sandboxes)
-            .await
-            .unwrap()
-    );
+    assert!(status.set_idle_snapshot(snapshot.clone()).await.unwrap());
 }
 
 pub(in super::super) async fn wait_status_idle_empty_with_active_run(

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -745,8 +745,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     let sandbox_id = idle_sandbox.sandbox_id();
     let ReusableIdleSandboxParts {
         sandbox,
-        kind,
-        reuse_key: idle_reuse_key,
+        identity,
         source_ip,
         storage_fingerprints: prev_storage,
         restored_session_identity: _restored_session_identity,
@@ -754,12 +753,14 @@ pub(crate) async fn execute_job_reuse_with_hooks(
         guest_state_prepared,
     } = idle_sandbox.into_parts();
 
+    let kind = identity.kind();
+    let idle_reuse_key = identity.reuse_key();
     let resume_session_error = validate_resume_session_id(&context).err();
     let claimed_reuse_key = context.reuse_key();
     let expected_promotion_reuse_key = if resume_session_error.is_some() {
-        idle_reuse_key.as_str()
+        idle_reuse_key
     } else {
-        claimed_reuse_key.unwrap_or(idle_reuse_key.as_str())
+        idle_reuse_key.map(|exact_key| claimed_reuse_key.unwrap_or(exact_key))
     };
     let workspace_image = match resolve_reused_workspace_promotion(
         config.workspace_cache.as_ref(),
@@ -882,10 +883,24 @@ async fn resolve_reused_workspace_promotion(
     run_id: RunId,
     sandbox_id: SandboxId,
     params: &JobParams,
-    reuse_key: &str,
+    reuse_key: Option<&str>,
 ) -> Result<Option<WorkspaceImageLease>, Box<ExecutionFailure>> {
     let Some(promotion) = promotion else {
         return Ok(None);
+    };
+    let Some(reuse_key) = reuse_key else {
+        abandon_unpublished_workspace_promotion(
+            Some(promotion),
+            "reuse_workspace_promotion_mismatch",
+        )
+        .await;
+        return Err(workspace_promotion_identity_failure(
+            run_id,
+            sandbox_id,
+            &params.profile_name,
+            WorkspaceImagePromotionIdentityMismatch::ReuseKey,
+        )
+        .into());
     };
     let Some(cache) = cache else {
         promotion

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -5,7 +5,7 @@ use sandbox::{DeviceRateLimits, SandboxId};
 use tokio::sync::watch;
 
 use crate::ids::RunId;
-use crate::status::IdleSandbox;
+use crate::status::{BlankSandbox, IdleSandbox};
 use crate::types::{HeldSandboxState, ReusableSandboxState};
 
 mod entry;
@@ -17,9 +17,9 @@ pub(crate) use entry::{
     ImmediateHandoffCandidate,
 };
 pub use entry::{
-    IdleDestroyJob, IdleEntry, IdleSandboxKind, IdleUnparkResult, ParkedIdleCandidate,
-    RejectedParkedIdleCandidate, ReservedIdleSandbox, RestoreReservedIdleResult,
-    ReusableIdleSandbox, ReusableIdleSandboxParts,
+    IdleDestroyJob, IdleEntry, IdleSandboxIdentity, IdleSandboxKind, IdleUnparkResult,
+    ParkedIdleCandidate, RejectedParkedIdleCandidate, ReservedIdleSandbox,
+    RestoreReservedIdleResult, ReusableIdleSandbox, ReusableIdleSandboxParts,
 };
 pub(crate) use entry::{SpeculativeIdleSandbox, SpeculativeIdleUnparkResult};
 pub(crate) use park_transition::{
@@ -44,20 +44,22 @@ pub struct IdlePoolConfig {
 ///
 /// Status writes happen after dropping the pool lock, so an older snapshot can
 /// otherwise complete after a newer drain/evict write and reintroduce stale
-/// `idle_sandboxes` in status.json.
-#[derive(Clone, Debug)]
+/// entries in either parked collection in status.json.
+#[derive(Clone, Debug, Default)]
 pub struct IdlePoolSnapshot {
     pub revision: u64,
     pub idle_sandboxes: Vec<IdleSandbox>,
+    pub blank_sandboxes: Vec<BlankSandbox>,
 }
 
-/// Pool of idle sandboxes keyed by reuse key.
+/// Shared parked inventory with separate exact reuse-key and blank sandbox-ID indexes.
 ///
 /// After a job reaches a terminal state that is proven reusable, its sandbox
 /// can be parked here instead of being destroyed. A subsequent job for the same
 /// reuse key can reuse the parked sandbox, skipping sandbox creation and startup.
 pub struct IdlePool {
-    entries: HashMap<String, IdleEntry>,
+    exact_entries: HashMap<String, IdleEntry>,
+    blank_entries: HashMap<SandboxId, IdleEntry>,
     config: IdlePoolConfig,
     revision: u64,
     changes: watch::Sender<u64>,
@@ -98,7 +100,8 @@ impl IdlePool {
     pub(crate) fn new_with_parking_gate(config: IdlePoolConfig, parking_gate: ParkingGate) -> Self {
         let (changes, _changes_rx) = watch::channel(0);
         Self {
-            entries: HashMap::new(),
+            exact_entries: HashMap::new(),
+            blank_entries: HashMap::new(),
             config,
             revision: 0,
             changes,
@@ -124,25 +127,25 @@ impl IdlePool {
     }
 
     fn park_at(&mut self, candidate: ParkedIdleCandidate, parked_at: Instant) -> ParkResult {
-        let reuse_key = candidate.reuse_key().to_string();
+        let identity = &candidate.metadata.identity;
         if !self.parking_gate.is_open() {
             return ParkResult::Rejected(candidate.into_rejected());
         }
         let mut capacity_evicted = None;
-        if self.config.max_idle > 0 && self.entries.len() >= self.config.max_idle {
-            // At capacity and this reuse key has no existing entry to replace.
-            if !self.entries.contains_key(&reuse_key) {
+        if self.config.max_idle > 0 && self.len() >= self.config.max_idle {
+            // At capacity and this identity has no existing entry to replace.
+            if !self.contains_identity(identity) {
                 if candidate.is_blank() {
                     return ParkResult::Rejected(candidate.into_rejected());
                 }
                 let Some(blank_key) = self.oldest_blank_key() else {
                     return ParkResult::Rejected(candidate.into_rejected());
                 };
-                capacity_evicted = self.entries.remove(&blank_key);
+                capacity_evicted = self.blank_entries.remove(&blank_key);
             }
         }
         let entry = candidate.into_idle_entry(parked_at);
-        let replaced = self.entries.insert(reuse_key, entry).or(capacity_evicted);
+        let replaced = self.insert_entry(entry).or(capacity_evicted);
         let result = match replaced {
             Some(entry) => ParkResult::Replaced(entry.into_destroy_job()),
             None => ParkResult::Parked,
@@ -152,7 +155,7 @@ impl IdlePool {
     }
 
     pub fn take(&mut self, reuse_key: &str) -> Option<IdleEntry> {
-        let entry = self.entries.remove(reuse_key);
+        let entry = self.exact_entries.remove(reuse_key);
         if entry.is_some() {
             self.bump_revision();
         }
@@ -160,9 +163,6 @@ impl IdlePool {
     }
 
     pub(crate) fn take_reserved(&mut self, reuse_key: &str) -> Option<ReservedIdleSandbox> {
-        if self.entries.get(reuse_key).is_some_and(IdleEntry::is_blank) {
-            return None;
-        }
         self.take(reuse_key)
             .map(|entry| ReservedIdleSandbox { entry })
     }
@@ -173,10 +173,8 @@ impl IdlePool {
         profile_name: &str,
         device_rate_limits: &Option<DeviceRateLimits>,
     ) -> bool {
-        self.entries.get(reuse_key).is_some_and(|entry| {
-            !entry.is_blank()
-                && entry.profile_name() == profile_name
-                && entry.device_rate_limits() == device_rate_limits
+        self.exact_entries.get(reuse_key).is_some_and(|entry| {
+            entry.profile_name() == profile_name && entry.device_rate_limits() == device_rate_limits
         })
     }
 
@@ -189,7 +187,7 @@ impl IdlePool {
         if !self.has_reusable(reuse_key, profile_name, device_rate_limits) {
             return None;
         }
-        let entry = self.entries.remove(reuse_key)?;
+        let entry = self.exact_entries.remove(reuse_key)?;
         self.bump_revision();
         Some(ReservedIdleSandbox { entry })
     }
@@ -217,7 +215,7 @@ impl IdlePool {
         device_rate_limits: &Option<DeviceRateLimits>,
         history_generation_run_id: RunId,
     ) -> Result<ReservedIdleSandbox, ExactIdleReservationMiss> {
-        let entry = match self.entries.entry(reuse_key.to_owned()) {
+        let entry = match self.exact_entries.entry(reuse_key.to_owned()) {
             Entry::Vacant(_) => return Err(ExactIdleReservationMiss::Absent),
             Entry::Occupied(entry) => {
                 if entry.get().profile_name() != profile_name {
@@ -257,11 +255,16 @@ impl IdlePool {
     }
 
     /// Order all current entries for pressure eviction without mutating them.
-    pub(crate) fn oldest_first_pressure_keys(&self) -> Vec<String> {
-        let mut ordered_entries: Vec<(bool, Instant, String)> = self
-            .entries
-            .iter()
-            .map(|(reuse_key, entry)| (!entry.is_blank(), entry.parked_at, reuse_key.clone()))
+    pub(crate) fn oldest_first_pressure_keys(&self) -> Vec<IdleSandboxIdentity> {
+        let mut ordered_entries: Vec<_> = self
+            .entries()
+            .map(|entry| {
+                (
+                    !entry.is_blank(),
+                    entry.parked_at,
+                    entry.metadata.identity.clone(),
+                )
+            })
             .collect();
         ordered_entries.sort_unstable();
         ordered_entries
@@ -276,25 +279,21 @@ impl IdlePool {
         device_rate_limits: &Option<DeviceRateLimits>,
     ) -> Option<ReservedIdleSandbox> {
         let key = self
-            .entries
+            .blank_entries
             .iter()
             .filter(|(_, entry)| {
-                entry.is_blank()
-                    && entry.profile_name() == profile_name
+                entry.profile_name() == profile_name
                     && entry.device_rate_limits() == device_rate_limits
             })
             .min_by_key(|(_, entry)| entry.parked_at)
-            .map(|(key, _)| key.clone())?;
-        let entry = self.entries.remove(&key)?;
+            .map(|(key, _)| *key)?;
+        let entry = self.blank_entries.remove(&key)?;
         self.bump_revision();
         Some(ReservedIdleSandbox { entry })
     }
 
     pub(crate) fn blank_len(&self) -> usize {
-        self.entries
-            .values()
-            .filter(|entry| entry.is_blank())
-            .count()
+        self.blank_entries.len()
     }
 
     /// Remove the oldest compatible exact entry that has been idle long enough
@@ -313,11 +312,10 @@ impl IdlePool {
         memory_mb: u32,
     ) -> Option<(IdleDestroyJob, Duration)> {
         let (reuse_key, parked_at) = self
-            .entries
+            .exact_entries
             .iter()
             .filter(|(_, entry)| {
-                !entry.is_blank()
-                    && entry.profile_name() == profile_name
+                entry.profile_name() == profile_name
                     && entry.device_rate_limits() == device_rate_limits
                     && entry.budget_lease.vcpu() == vcpu
                     && entry.budget_lease.memory_mb() == memory_mb
@@ -325,7 +323,7 @@ impl IdlePool {
             })
             .min_by_key(|(reuse_key, entry)| (entry.parked_at, reuse_key.as_str()))
             .map(|(reuse_key, entry)| (reuse_key.clone(), entry.parked_at))?;
-        let entry = self.entries.remove(&reuse_key)?;
+        let entry = self.exact_entries.remove(&reuse_key)?;
         self.bump_revision();
         Some((
             entry.into_destroy_job(),
@@ -338,25 +336,25 @@ impl IdlePool {
         reservation: ReservedIdleSandbox,
     ) -> RestoreReservedIdleResult {
         let entry = reservation.entry;
-        let reuse_key = entry.reuse_key().to_owned();
-        if !self.parking_gate.is_open() || self.entries.contains_key(&reuse_key) {
+        let identity = &entry.metadata.identity;
+        if !self.parking_gate.is_open() || self.contains_identity(identity) {
             return RestoreReservedIdleResult::Rejected(Box::new(entry.into_destroy_job()));
         }
 
         let mut displaced_blank = None;
-        if self.config.max_idle > 0 && self.entries.len() >= self.config.max_idle {
+        if self.config.max_idle > 0 && self.len() >= self.config.max_idle {
             let blank_key = (!entry.is_blank())
                 .then(|| self.oldest_blank_key())
                 .flatten();
             let Some(blank_key) = blank_key else {
                 return RestoreReservedIdleResult::Rejected(Box::new(entry.into_destroy_job()));
             };
-            displaced_blank = self.entries.remove(&blank_key);
+            displaced_blank = self.blank_entries.remove(&blank_key);
         }
 
         // Restore the original entry, including its idle age, while giving exact
         // reservations the same priority over blank inventory as newly parked runs.
-        self.entries.insert(reuse_key, entry);
+        self.insert_entry(entry);
         self.bump_revision();
         match displaced_blank {
             Some(blank) => RestoreReservedIdleResult::Replaced(Box::new(blank.into_destroy_job())),
@@ -366,39 +364,53 @@ impl IdlePool {
 
     /// Evict an entry selected by a pressure ordering captured under the same
     /// exclusive pool access.
-    pub(crate) fn evict_for_pressure(&mut self, reuse_key: &str) -> Option<IdleDestroyJob> {
-        let job = self
-            .entries
-            .remove(reuse_key)
-            .map(IdleEntry::into_destroy_job);
+    pub(crate) fn evict_for_pressure(
+        &mut self,
+        identity: &IdleSandboxIdentity,
+    ) -> Option<IdleDestroyJob> {
+        let entry = match identity {
+            IdleSandboxIdentity::Exact(reuse_key) => self.exact_entries.remove(reuse_key),
+            IdleSandboxIdentity::Blank(sandbox_id) => self.blank_entries.remove(sandbox_id),
+        };
+        let job = entry.map(IdleEntry::into_destroy_job);
         if job.is_some() {
             self.bump_revision();
         }
         job
     }
 
-    pub(crate) fn entry_kind(&self, reuse_key: &str) -> Option<IdleSandboxKind> {
-        self.entries.get(reuse_key).map(IdleEntry::kind)
-    }
-
-    /// Return a revisioned reuse-key-sorted snapshot suitable for status.json.
+    /// Capture both parked inventories under the same pool revision.
     ///
-    /// Produced in a single iteration so `reuse_key` and `sandbox_id` can never
-    /// drift out of pairing.
+    /// Exact entries are sorted by reuse key and blanks by sandbox ID. The
+    /// shared pool borrow keeps both projections consistent with the revision.
     pub fn status_snapshot(&self) -> IdlePoolSnapshot {
-        let mut sandboxes: Vec<IdleSandbox> =
-            self.entries.values().map(idle_sandbox_for_entry).collect();
+        let mut sandboxes: Vec<IdleSandbox> = self
+            .exact_entries
+            .iter()
+            .map(|(reuse_key, entry)| IdleSandbox {
+                reuse_key: reuse_key.clone(),
+                sandbox_id: entry.metadata.sandbox_id,
+            })
+            .collect();
+        let mut blank_sandboxes: Vec<_> = self
+            .blank_entries
+            .keys()
+            .map(|sandbox_id| BlankSandbox {
+                sandbox_id: *sandbox_id,
+            })
+            .collect();
+        blank_sandboxes.sort_unstable_by_key(|blank| blank.sandbox_id);
         sandboxes.sort_unstable_by(|a, b| a.reuse_key.cmp(&b.reuse_key));
         IdlePoolSnapshot {
             revision: self.revision,
             idle_sandboxes: sandboxes,
+            blank_sandboxes,
         }
     }
 
     /// Return true when the idle pool currently owns `sandbox_id`.
     pub fn contains_sandbox_id(&self, sandbox_id: SandboxId) -> bool {
-        self.entries
-            .values()
+        self.entries()
             .any(|entry| entry.metadata.sandbox_id == sandbox_id)
     }
 
@@ -417,12 +429,9 @@ impl IdlePool {
     /// sandbox IDs — it produces both views from a single iteration.
     pub fn held_sandbox_states(&self) -> Vec<HeldSandboxState> {
         let mut states: Vec<HeldSandboxState> = self
-            .entries
+            .exact_entries
             .iter()
             .filter_map(|(reuse_key, entry)| {
-                if entry.is_blank() {
-                    return None;
-                }
                 entry
                     .metadata
                     .last_completed_at
@@ -443,14 +452,14 @@ impl IdlePool {
 
     #[cfg(test)]
     pub fn held_reuse_keys(&self) -> Vec<String> {
-        let mut reuse_keys: Vec<String> = self.entries.keys().cloned().collect();
+        let mut reuse_keys: Vec<String> = self.exact_entries.keys().cloned().collect();
         reuse_keys.sort_unstable();
         reuse_keys
     }
 
-    /// Number of idle sandboxes in the pool.
+    /// Total exact and blank sandboxes owned by the pool.
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.exact_entries.len() + self.blank_entries.len()
     }
 
     /// Subscribe to pool ownership mutations. The revision is durable for each
@@ -477,9 +486,11 @@ impl IdlePool {
     /// [`crate::lifecycle::RunnerMode::Running`] becomes visible.
     pub fn drain(&mut self) -> Vec<IdleDestroyJob> {
         let jobs: Vec<IdleDestroyJob> = self
-            .entries
+            .exact_entries
             .drain()
-            .map(|(_, entry)| entry.into_destroy_job())
+            .map(|(_, entry)| entry)
+            .chain(self.blank_entries.drain().map(|(_, entry)| entry))
+            .map(IdleEntry::into_destroy_job)
             .collect();
         if !jobs.is_empty() {
             self.bump_revision();
@@ -487,24 +498,38 @@ impl IdlePool {
         jobs
     }
 
+    fn entries(&self) -> impl Iterator<Item = &IdleEntry> {
+        self.exact_entries
+            .values()
+            .chain(self.blank_entries.values())
+    }
+
+    fn contains_identity(&self, identity: &IdleSandboxIdentity) -> bool {
+        match identity {
+            IdleSandboxIdentity::Exact(reuse_key) => self.exact_entries.contains_key(reuse_key),
+            IdleSandboxIdentity::Blank(sandbox_id) => self.blank_entries.contains_key(sandbox_id),
+        }
+    }
+
+    fn insert_entry(&mut self, entry: IdleEntry) -> Option<IdleEntry> {
+        match &entry.metadata.identity {
+            IdleSandboxIdentity::Exact(reuse_key) => {
+                self.exact_entries.insert(reuse_key.clone(), entry)
+            }
+            IdleSandboxIdentity::Blank(sandbox_id) => self.blank_entries.insert(*sandbox_id, entry),
+        }
+    }
+
     fn bump_revision(&mut self) {
         self.revision = self.revision.saturating_add(1);
         self.changes.send_replace(self.revision);
     }
 
-    fn oldest_blank_key(&self) -> Option<String> {
-        self.entries
+    fn oldest_blank_key(&self) -> Option<SandboxId> {
+        self.blank_entries
             .iter()
-            .filter(|(_, entry)| entry.is_blank())
             .min_by_key(|(_, entry)| entry.parked_at)
-            .map(|(key, _)| key.clone())
-    }
-}
-
-fn idle_sandbox_for_entry(entry: &IdleEntry) -> IdleSandbox {
-    IdleSandbox {
-        reuse_key: entry.reuse_key().to_owned(),
-        sandbox_id: entry.metadata.sandbox_id,
+            .map(|(key, _)| *key)
     }
 }
 

--- a/crates/runner/src/idle_pool/destroy_tests.rs
+++ b/crates/runner/src/idle_pool/destroy_tests.rs
@@ -68,7 +68,7 @@ async fn make_idle_destroy_job_for(
     IdleDestroyJob {
         payload: make_idle_destroy_payload_for(sandbox_id, overrides, workspace_promotion).await,
         budget_lease,
-        reuse_key: "session:sess-destroy".into(),
+        reuse_key: Some("session:sess-destroy".into()),
         profile_name: "vm0/default".into(),
     }
 }

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -20,17 +20,44 @@ use crate::workspace_promotion::{
     abandon_unpublished_workspace_promotion, prepare_workspace_image_from_parked_sandbox,
 };
 
-const BLANK_REUSE_KEY_PREFIX: &str = "__vm0_blank__:";
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum IdleSandboxKind {
     Exact,
     Blank,
 }
 
+/// Exact inventory belongs to a reuse identity; a ready blank belongs only to its sandbox.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum IdleSandboxIdentity {
+    Exact(String),
+    Blank(SandboxId),
+}
+
+impl IdleSandboxIdentity {
+    pub(crate) fn kind(&self) -> IdleSandboxKind {
+        match self {
+            Self::Exact(_) => IdleSandboxKind::Exact,
+            Self::Blank(_) => IdleSandboxKind::Blank,
+        }
+    }
+
+    pub(crate) fn reuse_key(&self) -> Option<&str> {
+        match self {
+            Self::Exact(reuse_key) => Some(reuse_key),
+            Self::Blank(_) => None,
+        }
+    }
+
+    fn into_reuse_key(self) -> Option<String> {
+        match self {
+            Self::Exact(reuse_key) => Some(reuse_key),
+            Self::Blank(_) => None,
+        }
+    }
+}
+
 pub(super) struct IdleSandboxMetadata {
-    pub(super) kind: IdleSandboxKind,
-    pub(super) reuse_key: String,
+    pub(super) identity: IdleSandboxIdentity,
     /// Identity of the parked sandbox. Survives reuse (next job's `run_id`
     /// differs, but `sandbox_id` stays the same) and is the join key for
     /// doctor / kill / workspace-dir naming.
@@ -54,18 +81,18 @@ pub(super) struct IdleSandboxMetadata {
 }
 
 impl IdleSandboxMetadata {
-    pub(super) fn reuse_key(&self) -> &str {
-        &self.reuse_key
+    pub(super) fn reuse_key(&self) -> Option<&str> {
+        self.identity.reuse_key()
     }
 
     fn with_last_completed_at(mut self, last_completed_at: String) -> Self {
-        debug_assert_eq!(self.kind, IdleSandboxKind::Exact);
+        debug_assert_eq!(self.identity.kind(), IdleSandboxKind::Exact);
         self.last_completed_at = Some(last_completed_at);
         self
     }
 
     fn is_blank(&self) -> bool {
-        self.kind == IdleSandboxKind::Blank
+        self.identity.kind() == IdleSandboxKind::Blank
     }
 }
 
@@ -133,7 +160,8 @@ pub(crate) struct FinalizingHandoffCandidate {
 }
 
 impl ParkedIdleCandidate {
-    pub(crate) fn reuse_key(&self) -> &str {
+    #[cfg(test)]
+    pub(crate) fn reuse_key(&self) -> Option<&str> {
         self.metadata.reuse_key()
     }
 
@@ -163,8 +191,7 @@ impl ParkedIdleCandidate {
                 workspace_promotion: None,
             },
             metadata: IdleSandboxMetadata {
-                kind: IdleSandboxKind::Blank,
-                reuse_key: format!("{BLANK_REUSE_KEY_PREFIX}{sandbox_id}"),
+                identity: IdleSandboxIdentity::Blank(sandbox_id),
                 sandbox_id,
                 profile_name,
                 device_rate_limits,
@@ -363,8 +390,7 @@ pub struct ReusableIdleSandbox {
 
 pub struct ReusableIdleSandboxParts {
     pub sandbox: Box<dyn Sandbox>,
-    pub kind: IdleSandboxKind,
-    pub reuse_key: String,
+    pub identity: IdleSandboxIdentity,
     pub source_ip: String,
     pub storage_fingerprints: StorageFingerprints,
     pub restored_session_identity: Option<RestoredSessionIdentity>,
@@ -397,7 +423,7 @@ impl ReusableIdleSandbox {
     }
 
     pub(crate) fn kind(&self) -> IdleSandboxKind {
-        self.metadata.kind
+        self.metadata.identity.kind()
     }
 
     pub fn into_parts(self) -> ReusableIdleSandboxParts {
@@ -408,8 +434,7 @@ impl ReusableIdleSandbox {
             guest_state_prepared,
         } = self;
         let IdleSandboxMetadata {
-            kind,
-            reuse_key,
+            identity,
             sandbox_id: _,
             profile_name: _,
             device_rate_limits: _,
@@ -423,8 +448,7 @@ impl ReusableIdleSandbox {
 
         ReusableIdleSandboxParts {
             sandbox,
-            kind,
-            reuse_key,
+            identity,
             source_ip,
             storage_fingerprints,
             restored_session_identity,
@@ -446,7 +470,7 @@ impl ReusableIdleSandbox {
             guest_state_prepared: _,
         } = self;
         let IdleSandboxMetadata {
-            reuse_key,
+            identity,
             profile_name,
             ..
         } = metadata;
@@ -458,7 +482,7 @@ impl ReusableIdleSandbox {
             }
             .into_destroy_payload(WorkspacePromotionPolicy::AbandonUnpublished(reason)),
             budget_lease,
-            reuse_key,
+            reuse_key: identity.into_reuse_key(),
             profile_name,
         }
     }
@@ -562,7 +586,7 @@ impl IdleDestroyPayload {
 pub struct IdleDestroyJob {
     pub(super) payload: IdleDestroyPayload,
     pub(super) budget_lease: BudgetLease,
-    pub(super) reuse_key: String,
+    pub(super) reuse_key: Option<String>,
     pub(super) profile_name: String,
 }
 
@@ -606,8 +630,8 @@ impl IdleDestroyJob {
         (payload, budget_lease)
     }
 
-    pub fn reuse_key(&self) -> &str {
-        &self.reuse_key
+    pub fn reuse_key(&self) -> Option<&str> {
+        self.reuse_key.as_deref()
     }
 
     pub fn profile_name(&self) -> &str {
@@ -662,11 +686,7 @@ enum IdleActivationFailure {
 }
 
 impl IdleEntry {
-    pub(super) fn kind(&self) -> IdleSandboxKind {
-        self.metadata.kind
-    }
-
-    pub(super) fn reuse_key(&self) -> &str {
+    pub(super) fn reuse_key(&self) -> Option<&str> {
         self.metadata.reuse_key()
     }
 
@@ -770,12 +790,16 @@ impl IdleEntry {
         let Some(promotion) = self.resources.workspace_promotion.as_ref() else {
             return Ok(());
         };
+        let reuse_key = self
+            .metadata
+            .reuse_key()
+            .ok_or(WorkspaceImagePromotionIdentityMismatch::ReuseKey)?;
         promotion.validate_expected_identity(
             cache,
             WorkspaceImagePromotionIdentityRequest {
                 sandbox_id: self.metadata.sandbox_id,
                 profile_name: &self.metadata.profile_name,
-                reuse_key: self.metadata.reuse_key(),
+                reuse_key,
                 working_dir,
                 image_size_bytes,
             },
@@ -802,7 +826,7 @@ impl IdleEntry {
             ..
         } = self;
         let IdleSandboxMetadata {
-            reuse_key,
+            identity,
             profile_name,
             ..
         } = metadata;
@@ -810,7 +834,7 @@ impl IdleEntry {
         IdleDestroyJob {
             payload: resources.into_destroy_payload(workspace_promotion_policy),
             budget_lease,
-            reuse_key,
+            reuse_key: identity.into_reuse_key(),
             profile_name,
         }
     }
@@ -822,10 +846,10 @@ impl ReservedIdleSandbox {
     }
 
     pub(crate) fn kind(&self) -> IdleSandboxKind {
-        self.entry.metadata.kind
+        self.entry.metadata.identity.kind()
     }
 
-    pub fn reuse_key(&self) -> &str {
+    pub fn reuse_key(&self) -> Option<&str> {
         self.entry.reuse_key()
     }
 
@@ -896,7 +920,7 @@ impl SpeculativeIdleSandbox {
         self.entry.resources.sandbox.as_ref()
     }
 
-    pub(crate) fn reuse_key(&self) -> &str {
+    pub(crate) fn reuse_key(&self) -> Option<&str> {
         self.entry.reuse_key()
     }
 

--- a/crates/runner/src/idle_pool/park_transition.rs
+++ b/crates/runner/src/idle_pool/park_transition.rs
@@ -327,8 +327,7 @@ impl IdleParkRequest {
         } = self.parts;
 
         let metadata = IdleSandboxMetadata {
-            kind: super::entry::IdleSandboxKind::Exact,
-            reuse_key,
+            identity: super::entry::IdleSandboxIdentity::Exact(reuse_key),
             sandbox_id,
             profile_name,
             device_rate_limits,
@@ -394,13 +393,17 @@ async fn park_idle_transition(
         .map(|verification| verification.runtime_dir.to_owned());
 
     if let Some(promotion) = workspace_promotion.as_ref()
-        && let Err(mismatch) =
-            promotion.validate_stored_cache_identity(WorkspaceImagePromotionIdentityRequest {
-                sandbox_id: metadata.sandbox_id,
-                profile_name: &metadata.profile_name,
-                reuse_key: metadata.reuse_key(),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: workspace_image_size_bytes,
+        && let Err(mismatch) = metadata
+            .reuse_key()
+            .ok_or(crate::workspace_image_cache::WorkspaceImagePromotionIdentityMismatch::ReuseKey)
+            .and_then(|reuse_key| {
+                promotion.validate_stored_cache_identity(WorkspaceImagePromotionIdentityRequest {
+                    sandbox_id: metadata.sandbox_id,
+                    profile_name: &metadata.profile_name,
+                    reuse_key,
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: workspace_image_size_bytes,
+                })
             })
     {
         tracing::warn!(
@@ -588,7 +591,7 @@ impl SpeculativeIdleSandbox {
             budget_lease,
             parked_at,
         } = entry;
-        let reuse_key = metadata.reuse_key.clone();
+        let reuse_key = metadata.reuse_key().map(str::to_owned);
         let profile_name = metadata.profile_name.clone();
         match park_idle_transition(
             IdleParkTransitionInput {
@@ -701,7 +704,7 @@ impl IdleParkFailure {
     /// the resources cannot be cleaned up twice.
     fn into_speculative_destroy_job(
         self,
-        reuse_key: String,
+        reuse_key: Option<String>,
         profile_name: String,
     ) -> (IdleDestroyJob, &'static str, String, bool) {
         let Self {

--- a/crates/runner/src/idle_pool/park_transition_tests.rs
+++ b/crates/runner/src/idle_pool/park_transition_tests.rs
@@ -86,7 +86,7 @@ async fn idle_park_request_success_returns_parked_candidate() {
     };
 
     assert_eq!(overrides.park_call_count(), 1);
-    assert_eq!(candidate.reuse_key(), "session-1");
+    assert_eq!(candidate.reuse_key(), Some("session-1"));
 }
 
 #[tokio::test]
@@ -309,7 +309,7 @@ async fn idle_park_request_success_preserves_reuse_metadata() {
     };
 
     assert_eq!(overrides.park_call_count(), 1);
-    assert_eq!(candidate.reuse_key(), reuse_key);
+    assert_eq!(candidate.reuse_key(), Some(reuse_key));
     assert_eq!(candidate.sandbox_id(), sandbox_id);
     assert_eq!(candidate.metadata.profile_name, profile_name);
     assert_eq!(
@@ -410,7 +410,7 @@ async fn speculative_repark_preserves_original_idle_age_and_metadata() {
     };
 
     assert_eq!(restored.entry.parked_at, original_parked_at);
-    assert_eq!(restored.entry.reuse_key(), reuse_key);
+    assert_eq!(restored.entry.reuse_key(), Some(reuse_key));
     assert_eq!(restored.entry.profile_name(), profile_name);
     assert_eq!(
         restored.entry.device_rate_limits(),

--- a/crates/runner/src/idle_pool/pool_tests.rs
+++ b/crates/runner/src/idle_pool/pool_tests.rs
@@ -44,7 +44,7 @@ fn park_at(
     candidate: ParkedIdleCandidate,
     parked_at: Instant,
 ) -> ParkResult {
-    assert_eq!(candidate.reuse_key(), reuse_key);
+    assert_eq!(candidate.reuse_key(), Some(reuse_key));
     pool.park_at_for_test(candidate, parked_at)
 }
 
@@ -119,7 +119,7 @@ async fn blank_capacity_yield_selects_only_the_oldest_compatible_aged_exact() {
     let (oldest, idle_age) = pool
         .evict_oldest_exact_for_blank(now, min_idle_age, "vm0/default", &None, 2, 2048)
         .expect("oldest compatible exact should yield capacity");
-    assert_eq!(oldest.reuse_key(), "oldest");
+    assert_eq!(oldest.reuse_key(), Some("oldest"));
     assert_eq!(idle_age, Duration::from_secs(45 * 60));
     assert_eq!(pool.status_snapshot().revision, revision + 1);
     oldest.run().await;
@@ -127,7 +127,7 @@ async fn blank_capacity_yield_selects_only_the_oldest_compatible_aged_exact() {
     let (boundary, idle_age) = pool
         .evict_oldest_exact_for_blank(now, min_idle_age, "vm0/default", &None, 2, 2048)
         .expect("the age boundary should be inclusive");
-    assert_eq!(boundary.reuse_key(), "boundary");
+    assert_eq!(boundary.reuse_key(), Some("boundary"));
     assert_eq!(idle_age, min_idle_age);
     boundary.run().await;
 
@@ -381,21 +381,41 @@ fn park_respects_max_idle() {
 fn blank_entries_are_reserved_only_by_compatible_blank_lookup() {
     let mut pool = IdlePool::new(pool_config(0));
     let blank = make_blank_candidate("vm0/default", 2, 2048);
-    let blank_key = blank.reuse_key().to_owned();
+    let blank_id = blank.sandbox_id();
+    assert!(blank.reuse_key().is_none());
     assert!(matches!(pool.park(blank), ParkResult::Parked));
 
     assert_eq!(pool.blank_len(), 1);
-    assert!(pool.take_reserved(&blank_key).is_none());
+    assert!(pool.take_reserved(&blank_id.to_string()).is_none());
     assert!(
-        pool.reserve_reusable(&blank_key, "vm0/default", &None)
+        pool.reserve_reusable(&blank_id.to_string(), "vm0/default", &None)
             .is_none()
     );
     assert!(pool.reserve_blank("vm0/large", &None).is_none());
+
+    // A real exact key that equals a blank's sandbox ID is a different identity.
+    let exact_key = blank_id.to_string();
+    assert!(matches!(
+        pool.park(make_candidate_for(&exact_key, 2, 2048)),
+        ParkResult::Parked
+    ));
+    let exact = pool
+        .reserve_reusable(&exact_key, "vm0/default", &None)
+        .unwrap();
+    assert_eq!(exact.kind(), IdleSandboxKind::Exact);
+    assert_eq!(exact.reuse_key(), Some(exact_key.as_str()));
+    assert_eq!(pool.blank_len(), 1);
+    assert!(matches!(
+        pool.restore_reserved(exact),
+        RestoreReservedIdleResult::Restored
+    ));
 
     let reserved = pool
         .reserve_blank("vm0/default", &None)
         .expect("compatible blank should reserve");
     assert_eq!(reserved.kind(), IdleSandboxKind::Blank);
+    assert_eq!(reserved.sandbox_id(), blank_id);
+    assert!(reserved.reuse_key().is_none());
     assert_eq!(pool.blank_len(), 0);
 }
 
@@ -407,7 +427,8 @@ fn blank_entries_remain_in_status_but_not_heartbeat_state() {
         ParkResult::Parked
     ));
 
-    assert_eq!(pool.status_snapshot().idle_sandboxes.len(), 1);
+    assert!(pool.status_snapshot().idle_sandboxes.is_empty());
+    assert_eq!(pool.status_snapshot().blank_sandboxes.len(), 1);
     assert!(pool.held_sandbox_states().is_empty());
 }
 
@@ -483,7 +504,10 @@ fn pressure_ordering_evicts_oldest_first() {
     let _ = park_at(&mut pool, "new", make_candidate_for("new", 4, 4096), now);
 
     let reuse_keys = pool.oldest_first_pressure_keys();
-    assert_eq!(reuse_keys, vec!["old", "new"]);
+    assert_eq!(
+        reuse_keys,
+        ["old", "new"].map(|key| IdleSandboxIdentity::Exact(key.to_owned()))
+    );
     let evicted = pool.evict_for_pressure(&reuse_keys[0]).unwrap();
     assert_eq!(evicted.budget_vcpu(), 2); // the old one
     assert_eq!(pool.len(), 1);
@@ -505,15 +529,19 @@ fn pressure_ordering_evicts_blank_before_older_exact_entry() {
         ParkResult::Parked
     ));
     let blank = make_blank_candidate("vm0/default", 2, 2048);
-    let blank_key = blank.reuse_key().to_owned();
+    let blank_id = blank.sandbox_id();
+    assert!(blank.reuse_key().is_none());
     assert!(matches!(
-        park_at(&mut pool, &blank_key, blank, now),
+        pool.park_at_for_test(blank, now),
         ParkResult::Parked
     ));
 
     assert_eq!(
         pool.oldest_first_pressure_keys(),
-        vec![blank_key, "session-exact".to_owned()]
+        vec![
+            IdleSandboxIdentity::Blank(blank_id),
+            IdleSandboxIdentity::Exact("session-exact".to_owned())
+        ]
     );
 }
 
@@ -531,7 +559,11 @@ fn pressure_ordering_breaks_equal_park_time_by_reuse_key() {
     }
 
     let reuse_keys = pool.oldest_first_pressure_keys();
-    assert_eq!(reuse_keys, vec!["session-a", "session-m", "session-z"]);
+    assert_eq!(
+        reuse_keys,
+        ["session-a", "session-m", "session-z"]
+            .map(|key| IdleSandboxIdentity::Exact(key.to_owned()))
+    );
 }
 
 #[test]

--- a/crates/runner/src/idle_pool/test_support.rs
+++ b/crates/runner/src/idle_pool/test_support.rs
@@ -139,8 +139,7 @@ impl ParkedIdleCandidateBuilder {
             workspace_promotion,
         } = self;
         let metadata = IdleSandboxMetadata {
-            kind: super::entry::IdleSandboxKind::Exact,
-            reuse_key,
+            identity: super::entry::IdleSandboxIdentity::Exact(reuse_key),
             sandbox_id,
             profile_name,
             device_rate_limits,

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -13,6 +13,7 @@ use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::warn;
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::idle_pool::IdlePoolSnapshot;
 use crate::ids::RunId;
 use crate::lifecycle::RunnerMode;
 
@@ -91,6 +92,12 @@ pub struct IdleSandbox {
     pub sandbox_id: SandboxId,
 }
 
+/// One ready blank, without a tenant reuse key or run identity.
+#[derive(Debug, Clone, Serialize)]
+pub struct BlankSandbox {
+    pub sandbox_id: SandboxId,
+}
+
 #[derive(Debug, Serialize)]
 struct RunnerStatus {
     mode: RunnerMode,
@@ -98,6 +105,8 @@ struct RunnerStatus {
     active_runs: Vec<ActiveRun>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     idle_sandboxes: Vec<IdleSandbox>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    blank_sandboxes: Vec<BlankSandbox>,
     #[serde(skip_serializing_if = "Option::is_none")]
     proxy_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -357,13 +366,12 @@ struct MutableState {
     /// BTreeMap (not HashMap) for deterministic iteration order — status.json
     /// output should be stable across runs for readability and diffing.
     active_runs: BTreeMap<RunId, ActiveRunState>,
-    /// Monotonic idle pool mutation revision last reflected in `idle_sandboxes`.
+    /// Both parked inventories paired with their last applied pool mutation revision.
     ///
     /// Idle pool callers snapshot under the pool lock, drop it, then write
     /// status asynchronously. The revision prevents an older delayed snapshot
     /// from overwriting a newer drain/evict state.
-    idle_revision: u64,
-    idle_sandboxes: Vec<IdleSandbox>,
+    idle_snapshot: IdlePoolSnapshot,
 }
 
 impl StatusTracker {
@@ -391,8 +399,7 @@ impl StatusTracker {
                 generation: 0,
                 mode: RunnerMode::Starting,
                 active_runs: BTreeMap::new(),
-                idle_revision: 0,
-                idle_sandboxes: Vec::new(),
+                idle_snapshot: IdlePoolSnapshot::default(),
             }),
             persistence: Arc::new(PersistenceCoordinator::new()),
             #[cfg(test)]
@@ -504,51 +511,41 @@ impl StatusTracker {
         self.persist_snapshot(snapshot).await
     }
 
-    /// Register a running active run and replace the idle sandbox list in the same
+    /// Register a running active run and replace both parked inventories in the same
     /// status write if the idle snapshot is current.
-    pub async fn add_running_run_with_idle_info_at_revision(
+    pub async fn add_running_run_with_idle_snapshot(
         &self,
         run_id: RunId,
         sandbox_id: SandboxId,
-        revision: u64,
-        idle_sandboxes: Vec<IdleSandbox>,
+        idle_snapshot: IdlePoolSnapshot,
     ) -> StatusResult<bool> {
-        self.add_run_with_idle_info_at_revision(
-            run_id,
-            sandbox_id,
-            ActiveRunPhase::Running,
-            revision,
-            idle_sandboxes,
-        )
-        .await
+        self.add_run_with_idle_snapshot(run_id, sandbox_id, ActiveRunPhase::Running, idle_snapshot)
+            .await
     }
 
-    /// Register a preparing active run and replace the idle sandbox list in the
+    /// Register a preparing active run and replace both parked inventories in the
     /// same status write if the idle snapshot is current.
-    pub async fn add_preparing_run_with_idle_info_at_revision(
+    pub async fn add_preparing_run_with_idle_snapshot(
         &self,
         run_id: RunId,
         sandbox_id: SandboxId,
-        revision: u64,
-        idle_sandboxes: Vec<IdleSandbox>,
+        idle_snapshot: IdlePoolSnapshot,
     ) -> StatusResult<bool> {
-        self.add_run_with_idle_info_at_revision(
+        self.add_run_with_idle_snapshot(
             run_id,
             sandbox_id,
             ActiveRunPhase::Preparing,
-            revision,
-            idle_sandboxes,
+            idle_snapshot,
         )
         .await
     }
 
-    async fn add_run_with_idle_info_at_revision(
+    async fn add_run_with_idle_snapshot(
         &self,
         run_id: RunId,
         sandbox_id: SandboxId,
         phase: ActiveRunPhase,
-        revision: u64,
-        idle_sandboxes: Vec<IdleSandbox>,
+        idle_snapshot: IdlePoolSnapshot,
     ) -> StatusResult<bool> {
         let (applied, snapshot) = {
             let mut state = self.state.lock().await;
@@ -560,7 +557,7 @@ impl StatusTracker {
                     phase_started_at: Utc::now(),
                 },
             );
-            let applied = apply_idle_info_at_revision(&mut state, revision, idle_sandboxes);
+            let applied = apply_idle_snapshot(&mut state, idle_snapshot);
             let snapshot = self.capture_changed_snapshot(&mut state);
             (applied, snapshot)
         };
@@ -636,22 +633,18 @@ impl StatusTracker {
         self.persist_snapshot(snapshot).await
     }
 
-    /// Replace the idle sandbox list only if the snapshot is at least as new as the
+    /// Replace both parked inventories only if the snapshot is at least as new as the
     /// last applied idle-pool mutation revision.
     ///
     /// Returns `false` when a stale async writer lost the race to a newer
     /// snapshot and was intentionally ignored.
-    pub async fn set_idle_info_at_revision(
-        &self,
-        revision: u64,
-        idle_sandboxes: Vec<IdleSandbox>,
-    ) -> StatusResult<bool> {
+    pub async fn set_idle_snapshot(&self, idle_snapshot: IdlePoolSnapshot) -> StatusResult<bool> {
         #[cfg(test)]
         self.idle_info_update_requests
             .fetch_add(1, Ordering::Relaxed);
         let snapshot = {
             let mut state = self.state.lock().await;
-            let applied = apply_idle_info_at_revision(&mut state, revision, idle_sandboxes);
+            let applied = apply_idle_snapshot(&mut state, idle_snapshot);
             if !applied {
                 return Ok(false);
             }
@@ -687,7 +680,8 @@ impl StatusTracker {
             mode: state.mode,
             max_concurrent: self.max_concurrent,
             active_runs,
-            idle_sandboxes: state.idle_sandboxes.clone(),
+            idle_sandboxes: state.idle_snapshot.idle_sandboxes.clone(),
+            blank_sandboxes: state.idle_snapshot.blank_sandboxes.clone(),
             proxy_port: self.proxy_port,
             dns_port: self.dns_port,
             started_at: self.started_at,
@@ -830,16 +824,11 @@ pub async fn remove_stale_status_file(path: &Path) -> RunnerResult<()> {
     }
 }
 
-fn apply_idle_info_at_revision(
-    state: &mut MutableState,
-    revision: u64,
-    idle_sandboxes: Vec<IdleSandbox>,
-) -> bool {
-    if revision < state.idle_revision {
+fn apply_idle_snapshot(state: &mut MutableState, snapshot: IdlePoolSnapshot) -> bool {
+    if snapshot.revision < state.idle_snapshot.revision {
         return false;
     }
-    state.idle_revision = revision;
-    state.idle_sandboxes = idle_sandboxes;
+    state.idle_snapshot = snapshot;
     true
 }
 
@@ -1453,7 +1442,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_idle_info_at_revision_round_trip() {
+    async fn set_idle_snapshot_round_trip() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
         let tracker = StatusTracker::new(path.clone(), 4, None, None);
@@ -1467,9 +1456,9 @@ mod tests {
         let sb2 = SandboxId::new_v4();
         assert!(
             tracker
-                .set_idle_info_at_revision(
-                    1,
-                    vec![
+                .set_idle_snapshot(IdlePoolSnapshot {
+                    revision: 1,
+                    idle_sandboxes: vec![
                         IdleSandbox {
                             reuse_key: "sess-1".into(),
                             sandbox_id: sb1,
@@ -1479,7 +1468,8 @@ mod tests {
                             sandbox_id: sb2,
                         },
                     ],
-                )
+                    ..Default::default()
+                })
                 .await
                 .unwrap()
         );
@@ -1504,25 +1494,27 @@ mod tests {
         tracker.write_initial().await.unwrap();
         assert!(
             tracker
-                .set_idle_info_at_revision(
-                    2,
-                    vec![IdleSandbox {
+                .set_idle_snapshot(IdlePoolSnapshot {
+                    revision: 2,
+                    idle_sandboxes: vec![IdleSandbox {
                         reuse_key: "fresh".into(),
                         sandbox_id: fresh_id,
                     }],
-                )
+                    ..Default::default()
+                })
                 .await
                 .unwrap()
         );
         assert!(
             !tracker
-                .set_idle_info_at_revision(
-                    1,
-                    vec![IdleSandbox {
+                .set_idle_snapshot(IdlePoolSnapshot {
+                    revision: 1,
+                    idle_sandboxes: vec![IdleSandbox {
                         reuse_key: "stale".into(),
                         sandbox_id: stale_id,
                     }],
-                )
+                    ..Default::default()
+                })
                 .await
                 .unwrap()
         );
@@ -1532,6 +1524,112 @@ mod tests {
         assert_eq!(sandboxes.len(), 1);
         assert_eq!(sandboxes[0]["reuse_key"], "fresh");
         assert_eq!(sandboxes[0]["sandbox_id"], fresh_id.to_string());
+    }
+
+    #[tokio::test]
+    async fn blank_claim_restore_and_drain_publish_one_revisioned_inventory() {
+        use crate::idle_pool::test_support::ParkedIdleCandidateBuilder;
+        use crate::idle_pool::{
+            IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate, RestoreReservedIdleResult,
+        };
+        use crate::resource_budget::ResourceBudget;
+        use crate::status_file::{self, StatusForDoctor};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4, None, None);
+        let budget = Arc::new(ResourceBudget::new(16, 32_768, 1.0, 0));
+        let mut pool = IdlePool::new(IdlePoolConfig { max_idle: 2 });
+        let exact_id = SandboxId::new_v4();
+        let blank_id = SandboxId::new_v4();
+        assert!(matches!(
+            pool.park(
+                ParkedIdleCandidateBuilder::new(
+                    "thread:exact",
+                    ResourceBudget::try_reserve_lease(&budget, 2, 2048).unwrap()
+                )
+                .with_sandbox_id(exact_id)
+                .build()
+            ),
+            ParkResult::Parked
+        ));
+        assert!(matches!(
+            pool.park(ParkedIdleCandidate::blank(
+                Box::new(sandbox_mock::MockSandbox::new(blank_id.to_string())),
+                Arc::new(Box::new(sandbox_mock::MockSandboxFactory::new())),
+                ResourceBudget::try_reserve_lease(&budget, 2, 2048).unwrap(),
+                blank_id,
+                "vm0/default".into(),
+                None,
+            )),
+            ParkResult::Parked
+        ));
+
+        let ready = pool.status_snapshot();
+        tracker.set_idle_snapshot(ready.clone()).await.unwrap();
+        let wire = read_status(&path);
+        assert_eq!(
+            wire["idle_sandboxes"],
+            serde_json::json!([{
+                "reuse_key": "thread:exact", "sandbox_id": exact_id.to_string()
+            }])
+        );
+        assert_eq!(
+            wire["blank_sandboxes"],
+            serde_json::json!([{
+                "sandbox_id": blank_id.to_string()
+            }])
+        );
+        let doctor: StatusForDoctor = status_file::read_as(dir.path()).await.unwrap().unwrap();
+        assert_eq!(doctor.idle_sandboxes().len(), 1);
+        assert_eq!(doctor.blank_sandboxes[0].sandbox_id, blank_id.to_string());
+        assert!(doctor.active_runs.is_empty());
+
+        let reservation = pool.reserve_blank("vm0/default", &None).unwrap();
+        assert!(reservation.reuse_key().is_none());
+        let claimed = pool.status_snapshot();
+        let run_id = RunId::new_v4();
+        tracker
+            .add_preparing_run_with_idle_snapshot(run_id, blank_id, claimed.clone())
+            .await
+            .unwrap();
+        assert!(!tracker.set_idle_snapshot(ready).await.unwrap());
+        let wire = read_status(&path);
+        assert!(wire.get("blank_sandboxes").is_none());
+        assert_eq!(wire["idle_sandboxes"].as_array().unwrap().len(), 1);
+        assert_eq!(wire["active_runs"][0]["sandbox_id"], blank_id.to_string());
+        assert_eq!(wire["active_runs"][0]["phase"], "preparing");
+
+        assert!(matches!(
+            pool.restore_reserved(reservation),
+            RestoreReservedIdleResult::Restored
+        ));
+        let restored = pool.status_snapshot();
+        tracker.set_idle_snapshot(restored.clone()).await.unwrap();
+        tracker
+            .remove_run_if_matching(run_id, blank_id)
+            .await
+            .unwrap();
+        assert!(!tracker.set_idle_snapshot(claimed).await.unwrap());
+        let doctor: StatusForDoctor = status_file::read_as(dir.path()).await.unwrap().unwrap();
+        assert!(doctor.active_runs.is_empty());
+        assert_eq!(doctor.idle_sandboxes()[0].sandbox_id, exact_id.to_string());
+        assert_eq!(doctor.blank_sandboxes[0].sandbox_id, blank_id.to_string());
+        assert_eq!(budget.allocated().2, 2);
+
+        let cleanup = pool.drain();
+        tracker
+            .set_idle_snapshot(pool.status_snapshot())
+            .await
+            .unwrap();
+        assert!(!tracker.set_idle_snapshot(restored).await.unwrap());
+        let wire = read_status(&path);
+        assert!(wire.get("idle_sandboxes").is_none());
+        assert!(wire.get("blank_sandboxes").is_none());
+        for job in cleanup {
+            job.run().await;
+        }
+        assert_eq!(budget.allocated().2, 0);
     }
 
     #[tokio::test]
@@ -1545,13 +1643,14 @@ mod tests {
         tracker.write_initial().await.unwrap();
         assert!(
             tracker
-                .set_idle_info_at_revision(
-                    1,
-                    vec![IdleSandbox {
+                .set_idle_snapshot(IdlePoolSnapshot {
+                    revision: 1,
+                    idle_sandboxes: vec![IdleSandbox {
                         reuse_key: "sess-replaced".into(),
                         sandbox_id: original_id,
                     }],
-                )
+                    ..Default::default()
+                })
                 .await
                 .unwrap()
         );
@@ -1564,20 +1663,25 @@ mod tests {
         // Meanwhile the same reuse key is parked again with a newer sandbox.
         assert!(
             tracker
-                .set_idle_info_at_revision(
-                    3,
-                    vec![IdleSandbox {
+                .set_idle_snapshot(IdlePoolSnapshot {
+                    revision: 3,
+                    idle_sandboxes: vec![IdleSandbox {
                         reuse_key: "sess-replaced".into(),
                         sandbox_id: replacement_id,
                     }],
-                )
+                    ..Default::default()
+                })
                 .await
                 .unwrap()
         );
 
         assert!(
             !tracker
-                .set_idle_info_at_revision(delayed_cleanup_revision, delayed_cleanup_snapshot)
+                .set_idle_snapshot(IdlePoolSnapshot {
+                    revision: delayed_cleanup_revision,
+                    idle_sandboxes: delayed_cleanup_snapshot,
+                    ..Default::default()
+                })
                 .await
                 .unwrap()
         );
@@ -1602,26 +1706,30 @@ mod tests {
         tracker.write_initial().await.unwrap();
         assert!(
             tracker
-                .set_idle_info_at_revision(
-                    2,
-                    vec![IdleSandbox {
+                .set_idle_snapshot(IdlePoolSnapshot {
+                    revision: 2,
+                    idle_sandboxes: vec![IdleSandbox {
                         reuse_key: "fresh".into(),
                         sandbox_id: idle_id,
                     }],
-                )
+                    ..Default::default()
+                })
                 .await
                 .unwrap()
         );
         assert!(
             !tracker
-                .add_running_run_with_idle_info_at_revision(
+                .add_running_run_with_idle_snapshot(
                     run_id,
                     active_id,
-                    1,
-                    vec![IdleSandbox {
-                        reuse_key: "stale".into(),
-                        sandbox_id: stale_id,
-                    }],
+                    IdlePoolSnapshot {
+                        revision: 1,
+                        idle_sandboxes: vec![IdleSandbox {
+                            reuse_key: "stale".into(),
+                            sandbox_id: stale_id,
+                        }],
+                        ..Default::default()
+                    }
                 )
                 .await
                 .unwrap()
@@ -1651,14 +1759,17 @@ mod tests {
         tracker.write_initial().await.unwrap();
         assert!(
             tracker
-                .add_preparing_run_with_idle_info_at_revision(
+                .add_preparing_run_with_idle_snapshot(
                     run_id,
                     active_id,
-                    1,
-                    vec![IdleSandbox {
-                        reuse_key: "fresh-create-after-reuse-miss".into(),
-                        sandbox_id: idle_id,
-                    }],
+                    IdlePoolSnapshot {
+                        revision: 1,
+                        idle_sandboxes: vec![IdleSandbox {
+                            reuse_key: "fresh-create-after-reuse-miss".into(),
+                            sandbox_id: idle_id,
+                        }],
+                        ..Default::default()
+                    }
                 )
                 .await
                 .unwrap()
@@ -1677,12 +1788,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_idle_info_at_revision_empty_omitted() {
+    async fn set_idle_snapshot_empty_omitted() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
         let tracker = StatusTracker::new(path.clone(), 4, None, None);
 
-        assert!(tracker.set_idle_info_at_revision(1, vec![]).await.unwrap());
+        assert!(
+            tracker
+                .set_idle_snapshot(IdlePoolSnapshot {
+                    revision: 1,
+                    idle_sandboxes: vec![],
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+        );
 
         let status = read_status(&path);
         assert!(

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -237,11 +237,21 @@ status writer, and the independently deployed host monitoring collector scans
 every versioned runner directory. Status schema changes must cover those
 old/new combinations rather than treating the file as process-private state.
 
-Current status writers publish `idle_sandboxes` and omit the field when the
-collection is empty. Blank-enabled writers currently encode ready blanks there
-using `reuse_key: "__vm0_blank__:<sandbox_id>"`. A ready blank has no run ID or
-tenant reuse identity. The migration tracked by [#32071](https://github.com/vm0-ai/vm0/issues/32071)
-separates exact and blank identity without changing shared pool lifecycle rules.
+Current status writers publish exact inventory in `idle_sandboxes` and ready
+blanks in `blank_sandboxes`, omitting each collection when empty. Exact entries
+contain `reuse_key` and `sandbox_id`; blank entries contain only `sandbox_id`,
+never a run ID or tenant reuse identity. Both collections are captured from one
+pool revision and applied together, including preparing/running ownership
+transitions. Older blank-enabled writers encode blanks in `idle_sandboxes`
+using `reuse_key: "__vm0_blank__:<sandbox_id>"`. The migration tracked by
+[#32071](https://github.com/vm0-ai/vm0/issues/32071) separates these identities
+without changing shared pool lifecycle rules.
+
+Internally, the same `IdlePool` owns exact reuse-key and blank sandbox-ID
+indexes. They share capacity limits, budget ownership, parking gates and a
+mutation revision; they are not independent pools. Exact lookup, exact-first
+restoration, blank-first pressure eviction and conditional exact aging retain
+their existing policies. Heartbeat reuse inventories contain exact entries only.
 
 The reader bridge ([#32082](https://github.com/vm0-ai/vm0/issues/32082)) lets doctor
 and the host collector also read `blank_sandboxes: [{"sandbox_id": "..."}]`.
@@ -252,7 +262,7 @@ prefix-like reuse keys remain exact. Explicit blank IDs suppress same-file idle
 mirrors, and duplicate blank IDs count once. Doctor lists exact reuse keys under
 Idle and sandbox-ID-only entries under Blank, recognizes both as owned processes,
 and never treats an unclaimed blank as an active job. Active mappings take
-priority over duplicate blanks. The writer is unchanged in the bridge release.
+priority over duplicate blanks. The bridge release itself did not change the writer.
 
 The collector exports `vm0_runner_sandboxes{state="blank"}` (including zero).
 `state="idle"` now counts exact inventory only; total parked inventory is the
@@ -268,15 +278,24 @@ only `idle` will now show exact inventory; this change does not edit dashboards.
 
 The collector is installed by host provisioning, independently of Runner
 releases. Both its systemd timer and Alloy textfile scrape run every 15 seconds.
-Before enabling the explicit-only writer in
-[#32083](https://github.com/vm0-ai/vm0/issues/32083), verify bridge-capable doctor
-and collector deployment on every supported host and establish a compatible
-rollback floor using the actual reader commit/release ancestry. The target
-Runner's doctor runs during rollback, so an old-reader/new-writer combination
-must be excluded by these gates. Old writers remain readable by bridge readers
-during draining; neither merging this bridge nor releasing Runner proves the
-independent collector is installed. No writer rollout or rollback floor is
-changed by the bridge PR.
+Before merging/releasing the explicit-only writer in
+[#32083](https://github.com/vm0-ai/vm0/issues/32083), record the following evidence
+on its PR:
+
+- Every supported host has the bridge-capable doctor and collector installed;
+  record the Runner release/commit and installed collector revision or checksum.
+- A successfully deployed reader release contains commit
+  `febec8a3399be74b0f14a89cb9f42e39dd5ce69f` (PR #32092).
+- Supported rollback targets include that reader. The production rollback
+  resolver checks ancestry for both the target commit and the resolved Runner
+  artifact tag, because a newer API release can reuse an older Runner artifact.
+
+These are deployment gates, not claims established by repository tests. The
+target Runner's doctor runs during rollback, so old-reader/new-writer is not a
+supported combination. Bridge readers support old, new and mixed writers
+during draining. Neither merging the bridge nor releasing Runner proves the
+independent collector is installed. Keep the writer PR unmerged until the fleet
+evidence is recorded; no production rollout is authorized by the implementation.
 
 Remove legacy prefix recognition only under
 [#32084](https://github.com/vm0-ai/vm0/issues/32084), after all supported live and


### PR DESCRIPTION
## Summary

Closes #32083. Parent: #32071 (delivery slice 2 of 3).
Prerequisite: #32082 / #32092. Legacy reader cleanup remains #32084.

- Replace fabricated blank reuse keys with `IdleSandboxIdentity::Blank(SandboxId)`; exact inventory retains real reuse keys.
- Keep one `IdlePool` lifecycle/capacity controller with separate exact and blank indexes. Preserve shared limits, budget leases, parking gates, exact/cache priority, blank-first pressure eviction, conditional exact aging, rollback, cancellation and shutdown behavior.
- Publish `idle_sandboxes` (exact entries) and `blank_sandboxes` (ID-only ready blanks) from one revisioned snapshot, including preparing/running ownership transitions. Omit each empty collection and reject stale inventory updates.
- Carry optional reuse identity through activation, promotion and cleanup without inventing a key for blanks. Recognize blank ownership during orphan reconciliation.
- Require the merged reader commit in both production rollback target ancestry and the actual resolved Runner artifact tag.

No scheduling, API, heartbeat protocol, guest, database, pool-size policy, dashboard or UI changes. The bridge reader's legacy input normalization remains in place for mixed old/new writers; this PR does not perform the final cleanup or close the delivery parent.

## Validation

- `cd crates && cargo fmt --all`
- `cd crates && cargo clippy --profile local -p runner --all-targets --all-features -- -D warnings`
- `cd crates && RUSTDOCFLAGS='-D warnings' cargo doc --profile local -p runner --all-features --no-deps`
- `cd crates && cargo test --profile local -p runner --all-features -- --test-threads=4 --quiet`: 3,522 main tests passed, 0 failed, 25 pre-existing ignored entries; guest inventory integration test passed. No ignored/skip annotations were added.
- `bash .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `bash .github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh`
- `bash -n .github/scripts/resolve-production-rollback-target.sh .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `shellcheck -x -P .github/scripts .github/scripts/resolve-production-rollback-target.sh .github/scripts/tests/resolve-production-rollback-target-test.sh`
- `cd turbo && pnpm exec prettier --check ../docs/deployment-compatibility.md`
- `git diff --check`
- Repository pre-commit hooks: workspace-wide Cargo format, Clippy and rustdoc, file-size checks and commitlint passed.

Regression coverage includes real status-file writer/bridge-reader round trips, blank claim/restore/drain and stale revisions, blank orphan reconciliation, exact-key/blank-ID namespace separation, existing full runner lifecycle/priority/aging/cancellation tests, mixed collector inputs, and rejection of an incompatible rollback target or resolved artifact. The resolver regression stubs external commands, including Git ancestry; it does not prove live artifact deployment.

## Deployment readiness — verified before merge

The user explicitly approved merging after the read-only production checks below. This supersedes the initial implementation-only / Draft instruction. No manual production mutation was performed during verification.

- [x] A successfully deployed reader release includes `febec8a3399be74b0f14a89cb9f42e39dd5ce69f` (#32092): `runner-rs-v0.187.0`, commit `d46eb931e0a7e053750a4827204d45782a7565d1`. Its [production promotion](https://github.com/vm0-ai/vm0/actions/runs/34096463292/job/101665385269) succeeded on 2026-09-07; Git ancestry was checked.
- [x] All three production hosts (`prod-11.gcp.vm3.ai`, `prod-12.gcp.vm3.ai`, `prod-13.gcp.vm3.ai`) were inspected over SSH. Each has an active `vm0-runner-v0.187.0.service`; the installed binary reports `runner 0.187.0` and its status is `running`. This binary includes the bridge-capable doctor.
- [x] The installed collector on every host, `/usr/local/bin/vm0-monitoring-runner-status-collect`, has SHA-256 `560cb9b86e29357249582273253716f48be63df93cd6f04f12dabb4ffa499f42`, matching both this PR's collector source and the `runner-rs-v0.187.0` release source. Every collector timer is active.
- [x] The rollback reader floor is enforced for both the target commit and its actual resolved Runner artifact tag. The successfully deployed `runner-rs-v0.187.0` release satisfies both ancestry checks; pre-reader targets/artifacts are rejected by the resolver, with passing regression coverage. This establishes blank-status compatibility, not a guarantee that every historical release satisfies unrelated rollback preconditions.

The older `v0.186.15` processes were observed in `draining` on all three hosts. Their remaining runs do not block this writer rollout because bridge readers retain old-format input support. No old process was killed.

Current reviewed head: `00ce52c6ea690d136f6157acb46c96806fdceeaa`. Both current-head code reviews are LGTM; all three required CI gates and selected tests pass, with no unresolved review threads.

Final legacy-prefix removal remains #32084. It requires all supported live and rollback writers to emit explicit blanks, old versions to finish draining, and relevant retained non-stopped status files to contain no synthetic blank entries. This PR closes only #32083, not parent #32071 or cleanup #32084.
