### PR TITLE
refactor(runtime): neutralize private test markers

### DIFF
--- a/crates/guest-agent/src/cli/pi_rpc.rs
+++ b/crates/guest-agent/src/cli/pi_rpc.rs
@@ -116,10 +116,9 @@
 //! cancellable stdin write itself, that write returns an interruption error
 //! before an abort can be written; this is a distinct early-write failure path.
 //! The final guest control result records `Run cancelled by user` and the
-//! `UserCancellation` termination reason. Current Pi tool-result events do not
-//! carry a `vm0_user_cancelled` field: that marker was removed with Chat Tool
-//! Activity in #30215. Claude-only replay filtering is enabled outside this
-//! module; Pi does not set `replay_user_messages`.
+//! `UserCancellation` termination reason. Pi tool-result events remain ordinary
+//! tool results. Claude-only replay filtering is enabled outside this module;
+//! Pi does not set `replay_user_messages`.
 //!
 //! ## Record admission and projection
 //!
@@ -207,8 +206,7 @@
 //! Tool-result text blocks retain their text. Image blocks become base64 image
 //! sources with `mimeType` mapped to `media_type` and `data` mapped to
 //! `data`; unsupported result content blocks are omitted. The resulting `user`
-//! event is a tool result, not a replayable prompt, and has no
-//! `vm0_user_cancelled` field.
+//! event is classified as a tool result rather than a replayable prompt.
 //!
 //! ## Terminal result and failure ownership
 //!

--- a/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
+++ b/crates/guest-agent/tests/codex_app_server_oversized_event_delivery.rs
@@ -92,11 +92,6 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
         .collect::<Vec<_>>();
     assert_eq!(delivered.len(), 12);
     assert!(
-        delivered
-            .iter()
-            .all(|event| event.get("vm0_delivery").is_none())
-    );
-    assert!(
         requests
             .iter()
             .all(|request| !request.body.contains("[vm0:")
@@ -236,7 +231,6 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
         .find(|event| event["type"] == "warning")
         .ok_or("normal warning was not delivered")?;
     assert_eq!(warning["message"], "guest-mock-codex warning 999");
-    assert!(warning.get("vm0_delivery").is_none());
 
     let local_events = read_jsonl(runtime.paths.agent_log_file())?;
     let local_agent = delivered_item(&local_events, "oversized-agent-message")?;
@@ -246,7 +240,6 @@ async fn codex_app_server_reduces_oversized_events_before_delivery()
     assert!(local_text.len() > MAX_REQUEST_BYTES);
     assert!(local_text.contains(SECRET));
     assert!(!local_text.contains(DELIVERY_MARKER));
-    assert!(local_agent.get("vm0_delivery").is_none());
     let local_plan = local_events
         .iter()
         .find(|event| event["type"] == "turn.plan.updated")

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -64,26 +64,26 @@ pub const SIGKILL_EXIT: i32 = 137;
 /// Normal clean exit. Reap should never fire on this path.
 pub const CLEAN_EXIT: i32 = 0;
 
-pub const MOCK_TERMINATION_READY_EVENT: &str = "vm0_mock_termination_ready";
-pub const MOCK_CODEX_TURN_START_READY_FILE: &str = ".vm0-mock-codex-turn-start-ready";
-pub const MOCK_CODEX_TURN_START_READY_EVENT: &str = "vm0_mock_codex_turn_start_ready";
+pub const MOCK_TERMINATION_READY_EVENT: &str = "guest_mock_termination_ready";
+pub const MOCK_CODEX_TURN_START_READY_FILE: &str = ".guest-mock-codex-turn-start-ready";
+pub const MOCK_CODEX_TURN_START_READY_EVENT: &str = "guest_mock_codex_turn_start_ready";
 pub const MOCK_CODEX_TURN_COMPLETE_BEFORE_HEARTBEAT_READY_FILE: &str =
-    ".vm0-mock-codex-turn-complete-before-heartbeat-ready";
-pub const MOCK_CODEX_SESSION_HISTORY_READY_FILE: &str = ".vm0-mock-codex-session-history-ready";
-pub const MOCK_CODEX_SESSION_HISTORY_READY_EVENT: &str = "vm0_mock_codex_session_history_ready";
-pub const MOCK_CODEX_TURN_STEER_READY_FILE: &str = ".vm0-mock-codex-turn-steer-ready";
-pub const MOCK_CODEX_TURN_STEER_READY_EVENT: &str = "vm0_mock_codex_turn_steer_ready";
-pub const MOCK_CODEX_TURN_STEER_RELEASE_SOCKET: &str = ".vm0-mock-codex-turn-steer-release.sock";
+    ".guest-mock-codex-turn-complete-before-heartbeat-ready";
+pub const MOCK_CODEX_SESSION_HISTORY_READY_FILE: &str = ".guest-mock-codex-session-history-ready";
+pub const MOCK_CODEX_SESSION_HISTORY_READY_EVENT: &str = "guest_mock_codex_session_history_ready";
+pub const MOCK_CODEX_TURN_STEER_READY_FILE: &str = ".guest-mock-codex-turn-steer-ready";
+pub const MOCK_CODEX_TURN_STEER_READY_EVENT: &str = "guest_mock_codex_turn_steer_ready";
+pub const MOCK_CODEX_TURN_STEER_RELEASE_SOCKET: &str = ".guest-mock-codex-turn-steer-release.sock";
 pub const MOCK_CODEX_EVENT_DELIVERY_LARGE_RELEASE_SOCKET: &str =
-    ".vm0-mock-codex-event-delivery-large-release.sock";
-pub const MOCK_CODEX_ACTIVE_TURN_READY_FILE: &str = ".vm0-mock-codex-active-turn-ready";
-pub const MOCK_CODEX_ACTIVE_TURN_READY_EVENT: &str = "vm0_mock_codex_active_turn_ready";
-pub const MOCK_CODEX_TURN_INTERRUPT_READY_FILE: &str = ".vm0-mock-codex-turn-interrupt-ready";
-pub const MOCK_CODEX_TURN_INTERRUPT_READY_EVENT: &str = "vm0_mock_codex_turn_interrupt_ready";
-pub const MOCK_POST_RESULT_READY_EVENT: &str = "vm0_mock_post_result_ready";
-pub const MOCK_POST_RESULT_ACTIVITY_ONE_EVENT: &str = "vm0_mock_post_result_activity_1_ready";
-pub const MOCK_POST_RESULT_ACTIVITY_TWO_EVENT: &str = "vm0_mock_post_result_activity_2_ready";
-pub const MOCK_POST_RESULT_LIVENESS_EVENT: &str = "vm0_mock_post_result_stale_deadline_survived";
+    ".guest-mock-codex-event-delivery-large-release.sock";
+pub const MOCK_CODEX_ACTIVE_TURN_READY_FILE: &str = ".guest-mock-codex-active-turn-ready";
+pub const MOCK_CODEX_ACTIVE_TURN_READY_EVENT: &str = "guest_mock_codex_active_turn_ready";
+pub const MOCK_CODEX_TURN_INTERRUPT_READY_FILE: &str = ".guest-mock-codex-turn-interrupt-ready";
+pub const MOCK_CODEX_TURN_INTERRUPT_READY_EVENT: &str = "guest_mock_codex_turn_interrupt_ready";
+pub const MOCK_POST_RESULT_READY_EVENT: &str = "guest_mock_post_result_ready";
+pub const MOCK_POST_RESULT_ACTIVITY_ONE_EVENT: &str = "guest_mock_post_result_activity_1_ready";
+pub const MOCK_POST_RESULT_ACTIVITY_TWO_EVENT: &str = "guest_mock_post_result_activity_2_ready";
+pub const MOCK_POST_RESULT_LIVENESS_EVENT: &str = "guest_mock_post_result_stale_deadline_survived";
 pub const MOCK_POST_RESULT_RELEASE_ONE_SOCKET: &str = ".vm0-post-result-release-1.sock";
 pub const MOCK_POST_RESULT_RELEASE_TWO_SOCKET: &str = ".vm0-post-result-release-2.sock";
 

--- a/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
@@ -21,7 +21,7 @@ async fn heartbeat_panic_reap_escalates_to_sigkill_when_sigterm_ignored()
     let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
-    let sigterm_ignored_marker = tmp.path().join(".vm0-mock-sigterm-ignored");
+    let sigterm_ignored_marker = tmp.path().join(".guest-mock-sigterm-ignored");
     let heartbeat = common::spawn_heartbeat_monitor(async move {
         common::wait_for_path(&sigterm_ignored_marker, Duration::from_secs(5))
             .await

--- a/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
@@ -21,7 +21,7 @@ async fn heartbeat_failure_reap_escalates_to_sigkill_when_sigterm_ignored()
     let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
-    let sigterm_ignored_marker = tmp.path().join(".vm0-mock-sigterm-ignored");
+    let sigterm_ignored_marker = tmp.path().join(".guest-mock-sigterm-ignored");
     let heartbeat = common::spawn_heartbeat_monitor(async move {
         common::wait_for_path(&sigterm_ignored_marker, Duration::from_secs(5))
             .await

--- a/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
@@ -52,7 +52,7 @@ async fn stuck_tool_reap_escalates_to_sigkill_when_sigterm_ignored()
     .expect("execute_cli did not return within 15s - forced SIGKILL escalation likely broken")?;
 
     assert!(
-        tmp.path().join(".vm0-mock-sigterm-ignored").exists(),
+        tmp.path().join(".guest-mock-sigterm-ignored").exists(),
         "mock did not install SIGTERM ignore marker"
     );
 

--- a/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
@@ -52,7 +52,7 @@ async fn stuck_tool_reap_survives_stdout_eof_before_child_exit()
     .expect("execute_cli did not return within 15s - stdout EOF forced reap likely broken")?;
 
     assert!(
-        tmp.path().join(".vm0-mock-sigterm-ignored").exists(),
+        tmp.path().join(".guest-mock-sigterm-ignored").exists(),
         "mock did not install SIGTERM ignore marker"
     );
 

--- a/crates/guest-mock-claude/src/process/fixtures.rs
+++ b/crates/guest-mock-claude/src/process/fixtures.rs
@@ -18,11 +18,11 @@ use std::time::{Duration, Instant};
 use super::bash_tool_command;
 
 const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
-const TERMINATION_READY_EVENT: &str = "vm0_mock_termination_ready";
-const POST_RESULT_READY_EVENT: &str = "vm0_mock_post_result_ready";
-const POST_RESULT_ACTIVITY_ONE_EVENT: &str = "vm0_mock_post_result_activity_1_ready";
-const POST_RESULT_ACTIVITY_TWO_EVENT: &str = "vm0_mock_post_result_activity_2_ready";
-const POST_RESULT_LIVENESS_EVENT: &str = "vm0_mock_post_result_stale_deadline_survived";
+const TERMINATION_READY_EVENT: &str = "guest_mock_termination_ready";
+const POST_RESULT_READY_EVENT: &str = "guest_mock_post_result_ready";
+const POST_RESULT_ACTIVITY_ONE_EVENT: &str = "guest_mock_post_result_activity_1_ready";
+const POST_RESULT_ACTIVITY_TWO_EVENT: &str = "guest_mock_post_result_activity_2_ready";
+const POST_RESULT_LIVENESS_EVENT: &str = "guest_mock_post_result_stale_deadline_survived";
 const POST_RESULT_RELEASE_ONE_SOCKET: &str = ".vm0-post-result-release-1.sock";
 const POST_RESULT_RELEASE_TWO_SOCKET: &str = ".vm0-post-result-release-2.sock";
 const TRANSCRIPT_FENCE_PADDING_BYTES: usize = 16 * 1024;
@@ -162,7 +162,7 @@ fn ignore_sigterm() {
 
 fn emit_termination_ready_fence() {
     if let Ok(home) = std::env::var("HOME") {
-        let _ = std::fs::write(format!("{home}/.vm0-mock-sigterm-ignored"), b"");
+        let _ = std::fs::write(format!("{home}/.guest-mock-sigterm-ignored"), b"");
     }
     emit_stream_event_fence(TERMINATION_READY_EVENT);
 }

--- a/crates/guest-mock-codex/src/app_server/handlers.rs
+++ b/crates/guest-mock-codex/src/app_server/handlers.rs
@@ -24,21 +24,21 @@ use std::process::Command;
 use std::thread;
 use uuid::Uuid;
 
-const HANG_ON_TURN_START_READY_FILE: &str = ".vm0-mock-codex-turn-start-ready";
-const HANG_ON_TURN_START_READY_EVENT: &str = "vm0_mock_codex_turn_start_ready";
+const HANG_ON_TURN_START_READY_FILE: &str = ".guest-mock-codex-turn-start-ready";
+const HANG_ON_TURN_START_READY_EVENT: &str = "guest_mock_codex_turn_start_ready";
 const TURN_COMPLETE_BEFORE_HEARTBEAT_READY_FILE: &str =
-    ".vm0-mock-codex-turn-complete-before-heartbeat-ready";
+    ".guest-mock-codex-turn-complete-before-heartbeat-ready";
 const TURN_COMPLETE_BEFORE_HEARTBEAT_READY_EVENT: &str =
-    "vm0_mock_codex_turn_complete_before_heartbeat_ready";
-const SESSION_HISTORY_READY_FILE: &str = ".vm0-mock-codex-session-history-ready";
-const SESSION_HISTORY_READY_EVENT: &str = "vm0_mock_codex_session_history_ready";
-const WAIT_ON_TURN_STEER_READY_FILE: &str = ".vm0-mock-codex-turn-steer-ready";
-const WAIT_ON_TURN_STEER_READY_EVENT: &str = "vm0_mock_codex_turn_steer_ready";
-const WAIT_ON_TURN_STEER_RELEASE_SOCKET: &str = ".vm0-mock-codex-turn-steer-release.sock";
+    "guest_mock_codex_turn_complete_before_heartbeat_ready";
+const SESSION_HISTORY_READY_FILE: &str = ".guest-mock-codex-session-history-ready";
+const SESSION_HISTORY_READY_EVENT: &str = "guest_mock_codex_session_history_ready";
+const WAIT_ON_TURN_STEER_READY_FILE: &str = ".guest-mock-codex-turn-steer-ready";
+const WAIT_ON_TURN_STEER_READY_EVENT: &str = "guest_mock_codex_turn_steer_ready";
+const WAIT_ON_TURN_STEER_RELEASE_SOCKET: &str = ".guest-mock-codex-turn-steer-release.sock";
 const EVENT_DELIVERY_LARGE_RELEASE_SOCKET: &str =
-    ".vm0-mock-codex-event-delivery-large-release.sock";
-const TURN_INTERRUPT_READY_FILE: &str = ".vm0-mock-codex-turn-interrupt-ready";
-const TURN_INTERRUPT_READY_EVENT: &str = "vm0_mock_codex_turn_interrupt_ready";
+    ".guest-mock-codex-event-delivery-large-release.sock";
+const TURN_INTERRUPT_READY_FILE: &str = ".guest-mock-codex-turn-interrupt-ready";
+const TURN_INTERRUPT_READY_EVENT: &str = "guest_mock_codex_turn_interrupt_ready";
 const NOTIFICATION_OVERFLOW_COUNT: usize = 129;
 const STDOUT_STREAM_CHUNK_BYTES: usize = 8 * 1024;
 const EVENT_DELIVERY_FLOOD_COUNT: usize = 640;

--- a/crates/guest-mock-codex/src/app_server/mod.rs
+++ b/crates/guest-mock-codex/src/app_server/mod.rs
@@ -15,8 +15,8 @@ use std::thread;
 
 const INVALID_REQUEST: i64 = -32600;
 const METHOD_NOT_FOUND: i64 = -32601;
-const ACTIVE_TURN_READY_FILE: &str = ".vm0-mock-codex-active-turn-ready";
-const ACTIVE_TURN_READY_EVENT: &str = "vm0_mock_codex_active_turn_ready";
+const ACTIVE_TURN_READY_FILE: &str = ".guest-mock-codex-active-turn-ready";
+const ACTIVE_TURN_READY_EVENT: &str = "guest_mock_codex_active_turn_ready";
 
 /// Run the mock Codex app server over process stdio.
 ///

--- a/crates/runner/mitm-addon/src/connector_runtime_metadata.py
+++ b/crates/runner/mitm-addon/src/connector_runtime_metadata.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 type ConnectorRuntimeKind = Literal["builtin", "custom"]
 
-CONNECTOR_RUNTIME_KIND_MARKER = "_vm0ConnectorRuntimeKind"
+CONNECTOR_RUNTIME_KIND_MARKER = "_connectorRuntimeKind"
 
 
 def connector_runtime_kind(firewall: dict) -> ConnectorRuntimeKind | None:

--- a/crates/runner/mitm-addon/src/mitmproxy_compat.py
+++ b/crates/runner/mitm-addon/src/mitmproxy_compat.py
@@ -15,8 +15,8 @@ import websocket_framing
 # another version.
 _SUPPORTED_MITMPROXY_VERSION = "12.2.3"
 _SUPPORTED_WSPROTO_VERSION = "1.3.2"
-_BRIDGE_MARKER_ATTRIBUTE = "_vm0_request_end_stream_bridge"
-_REQUEST_END_STREAM_METADATA = "_vm0_request_end_stream"
+_BRIDGE_MARKER_ATTRIBUTE = "_request_end_stream_bridge"
+_REQUEST_END_STREAM_METADATA = "_request_end_stream"
 
 
 def install_runtime_compatibility() -> None:

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -335,7 +335,7 @@ def resolve_firewall_entries(
 
     Runtime ownership metadata is assigned by the registry rather than trusted
     from source firewall data. Resolution clears any source-provided
-    `_vm0ConnectorRuntimeKind` marker, marks a resolved builtin as `builtin` only
+    `_connectorRuntimeKind` marker, marks a resolved builtin as `builtin` only
     when its name is registered in `connectorRuntimeTargets`, and marks an inline
     custom firewall as `custom` only when its UUID is registered there. Unregistered
     or absent connector identities remain unclassified.

--- a/crates/runner/mitm-addon/src/request_streaming.py
+++ b/crates/runner/mitm-addon/src/request_streaming.py
@@ -18,7 +18,7 @@ import flow_metadata_keys as metadata_keys
 import stream_capture
 from body_limits import STREAM_BUFFER_LIMIT
 
-_REQUEST_STREAM_CALLBACK = "_vm0_request_stream_callback"
+_REQUEST_STREAM_CALLBACK = "_request_stream_callback"
 
 
 def configure_request_stream(

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -46,7 +46,7 @@ _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
 _CONNECTOR_RESPONSE_FINISH = "connector_response_finish"
 _CONNECTOR_RESPONSE_REPORT_ON_INTERRUPTION = "connector_response_report_on_interruption"
-_RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
+_RESPONSE_STREAM_CALLBACK = "_response_stream_callback"
 
 _ANTHROPIC_MESSAGES_SSE_PROTOCOL = "anthropic_messages_sse"
 _OPENAI_CHAT_COMPLETIONS_SSE_PROTOCOL = "openai_chat_completions_sse"

--- a/crates/runner/mitm-addon/src/usage/json_selective.py
+++ b/crates/runner/mitm-addon/src/usage/json_selective.py
@@ -46,8 +46,8 @@ _INTERNAL_PATH_MARKERS = frozenset(
         _UNKNOWN_KEY,
         FIRST_ARRAY_ELEMENT,
         _OTHER_ARRAY_ELEMENT,
-        "\0__vm0_json_unknown_key__",
-        "\0__vm0_json_array_element__",
+        "\0__json_selective_unknown_key__",
+        "\0__json_selective_array_element__",
     )
 )
 _JSON_CONTROL_CHAR_MAX = 0x20

--- a/crates/runner/mitm-addon/src/websocket_framing.py
+++ b/crates/runner/mitm-addon/src/websocket_framing.py
@@ -29,8 +29,8 @@ MAX_AGGREGATE_DECODED_BYTES = 1024 * 1024 * 1024
 MAX_MESSAGE_DATA_FRAMES = 8_192
 
 _EMPTY_DEFLATE_BLOCK = b"\x00\x00\xff\xff"
-_CONNECTION_MARKER_ATTRIBUTE = "_vm0_bounded_websocket_framing"
-_MESSAGE_LIMIT_VIOLATION_ATTRIBUTE = "_vm0_websocket_message_limit_violation"
+_CONNECTION_MARKER_ATTRIBUTE = "_bounded_websocket_framing"
+_MESSAGE_LIMIT_VIOLATION_ATTRIBUTE = "_websocket_message_limit_violation"
 _ORIGINAL_WEBSOCKET_CONNECTION = websocket.WebsocketConnection
 
 _MessageLimitReason = Literal[
@@ -371,8 +371,8 @@ class _BoundedWebsocketConnection(_ORIGINAL_WEBSOCKET_CONNECTION):
             trailing_data,
             conn=conn,
         )
-        self._vm0_message_limit = message_limit
-        self._vm0_bounded_deflates = bounded_deflates
+        self._message_limit = message_limit
+        self._bounded_deflates = bounded_deflates
         self.frame_buf = [self._mutable_fragment()]
 
     @staticmethod
@@ -389,8 +389,8 @@ class _BoundedWebsocketConnection(_ORIGINAL_WEBSOCKET_CONNECTION):
 
     def _clear_partial_state(self) -> None:
         self.frame_buf = [self._mutable_fragment()]
-        self._vm0_message_limit.clear()
-        for extension in self._vm0_bounded_deflates:
+        self._message_limit.clear()
+        for extension in self._bounded_deflates:
             extension.clear()
 
     def events(self) -> Generator[events.Event, None, None]:
@@ -402,7 +402,7 @@ class _BoundedWebsocketConnection(_ORIGINAL_WEBSOCKET_CONNECTION):
                     yield event
                 finally:
                     if isinstance(event, events.Message) and event.message_finished:
-                        self._vm0_message_limit._budget.finish_message()
+                        self._message_limit._budget.finish_message()
                     self._ensure_mutable_fragment()
         finally:
             self._ensure_mutable_fragment()

--- a/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_codex_model_catalog_cache_hooks.py
@@ -415,7 +415,7 @@ async def test_both_firewall_auth_paths_prepare_catalog_cache(
             }
         ),
     )
-    header_flow.metadata["_vm0_request_end_stream"] = True
+    header_flow.metadata["_request_end_stream"] = True
     with (
         mitm_ctx(registry_path=str(header_registry), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers=resolved_headers),
@@ -476,7 +476,7 @@ async def test_prefetch_marker_requires_one_exact_raw_value_across_request_hooks
         path="/backend-api/codex/models?client_version=0.145.0",
         request_headers=request_headers,
     )
-    flow.metadata["_vm0_request_end_stream"] = True
+    flow.metadata["_request_end_stream"] = True
 
     with (
         mitm_ctx(registry_path=str(registry_path), api_url="https://api.vm0.ai"),
@@ -552,7 +552,7 @@ async def test_catalog_wait_revalidates_only_provider_continuation(
         path="/backend-api/codex/models?client_version=0.145.0",
         request_headers=header_map(follower_headers),
     )
-    follower.metadata["_vm0_request_end_stream"] = True
+    follower.metadata["_request_end_stream"] = True
     mark_connected_tls_upstream(
         follower,
         sni="chatgpt.com",
@@ -666,7 +666,7 @@ async def test_cancelled_requestheaders_catalog_follower_releases_usage_tracking
             }
         ),
     )
-    follower.metadata["_vm0_request_end_stream"] = True
+    follower.metadata["_request_end_stream"] = True
     follower_task: asyncio.Task[None] | None = None
     try:
         with (

--- a/crates/runner/mitm-addon/tests/test_json_selective_observations.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_observations.py
@@ -22,8 +22,8 @@ _COMMON_WILDCARD_ARRAY_COUNT_PATHS = {("includes", "*")}
 _COMMON_OBJECT_PRESENCE_PATHS = {(), ("data",)}
 _WILDCARD_INTERNAL_MARKER_KEYS = frozenset(
     (
-        "\0__vm0_json_unknown_key__",
-        "\0__vm0_json_array_element__",
+        "\0__json_selective_unknown_key__",
+        "\0__json_selective_array_element__",
     )
 )
 
@@ -123,9 +123,9 @@ def test_common_extraction_matches_json_loads_across_chunk_sizes():
             b'"meta":{"total_tweet_count":9}}'
         ),
         (
-            b'{"includes":{"\\u0000__vm0_json_unknown_key__":[{"id":"internal-1"}],'
-            b'"\\u0000__vm0_json_array_element__":[{"id":"internal-2"}],'
-            b'"\\u0000__vm0_json_custom":[{"id":"custom-1"},{"id":"custom-2"}]}}'
+            b'{"includes":{"\\u0000__json_selective_unknown_key__":[{"id":"internal-1"}],'
+            b'"\\u0000__json_selective_array_element__":[{"id":"internal-2"}],'
+            b'"\\u0000__json_selective_custom":[{"id":"custom-1"},{"id":"custom-2"}]}}'
         ),
     ]
 
@@ -336,7 +336,7 @@ def test_first_array_element_marker_cannot_match_an_object_key():
     extractor = JsonSelectiveExtractor(scalar_fields={prompt_tokens_path: ScalarField("int")})
 
     extractor.feed(
-        b'{"choices":{"\\u0000__vm0_json_array_element__":{"usage":{"prompt_tokens":99}}}}'
+        b'{"choices":{"\\u0000__json_selective_array_element__":{"usage":{"prompt_tokens":99}}}}'
     )
     result = extractor.finish()
 

--- a/crates/runner/mitm-addon/tests/test_json_selective_strings.py
+++ b/crates/runner/mitm-addon/tests/test_json_selective_strings.py
@@ -566,7 +566,7 @@ def test_wildcard_count_skips_internal_marker_key():
     extractor = JsonSelectiveExtractor(wildcard_array_count_paths={("includes", "*")})
 
     extractor.feed(
-        b'{"includes":{"\\u0000__vm0_json_array_element__":[{"id":"internal"}],'
+        b'{"includes":{"\\u0000__json_selective_array_element__":[{"id":"internal"}],'
         b'"users":[{"id":"u1"}]}}'
     )
     result = extractor.finish()
@@ -579,7 +579,7 @@ def test_wildcard_count_skips_unknown_internal_marker_key():
     extractor = JsonSelectiveExtractor(wildcard_array_count_paths={("includes", "*")})
 
     extractor.feed(
-        b'{"includes":{"\\u0000__vm0_json_unknown_key__":[{"id":"internal"}],'
+        b'{"includes":{"\\u0000__json_selective_unknown_key__":[{"id":"internal"}],'
         b'"users":[{"id":"u1"}]}}'
     )
     result = extractor.finish()

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py
@@ -242,13 +242,13 @@ def _assert_bounded_source_state_cleared(
 ) -> None:
     source = _bounded_source_websocket(running, from_client=from_client)
     assert sum(len(fragment) for fragment in source.frame_buf) == 0
-    assert len(source._vm0_bounded_deflates) == 1
-    bounded_deflate = source._vm0_bounded_deflates[0]
+    assert len(source._bounded_deflates) == 1
+    bounded_deflate = source._bounded_deflates[0]
     assert bounded_deflate._decompressor is None
     assert bounded_deflate._inbound_is_compressible is None
     assert bounded_deflate._inbound_compressed is None
-    assert source._vm0_message_limit._budget.decoded_bytes == 0
-    assert source._vm0_message_limit._budget.data_frames == 0
+    assert source._message_limit._budget.decoded_bytes == 0
+    assert source._message_limit._budget.data_frames == 0
 
 
 async def _assert_compressed_fragmented_message_accepted(
@@ -327,8 +327,8 @@ async def _assert_compressed_fragmented_byte_limit(
 
     assert _message_hooks(prefix) == []
     assert _data_sends(prefix) == []
-    assert source._vm0_message_limit._budget.data_frames == 1
-    assert 0 < source._vm0_message_limit._budget.decoded_bytes < decoded_limit
+    assert source._message_limit._budget.data_frames == 1
+    assert 0 < source._message_limit._budget.decoded_bytes < decoded_limit
 
     over_limit = await _handle_event(
         addon_context,
@@ -373,7 +373,7 @@ async def _assert_compressed_fragmented_frame_limit(
 
     assert _message_hooks(prefix) == []
     assert _data_sends(prefix) == []
-    assert source._vm0_message_limit._budget.data_frames == 1
+    assert source._message_limit._budget.data_frames == 1
 
     over_limit = await _handle_event(
         addon_context,
@@ -815,7 +815,7 @@ async def test_message_frame_limit_counts_frames_across_read_splits(
             accepted,
             from_client=from_client,
         )
-        accepted_budget = accepted_source._vm0_message_limit._budget
+        accepted_budget = accepted_source._message_limit._budget
 
         first_read = await _handle_event(
             addon_context,
@@ -879,7 +879,7 @@ async def test_message_frame_limit_counts_frames_across_read_splits(
             rejected,
             from_client=from_client,
         )
-        rejected_budget = rejected_source._vm0_message_limit._budget
+        rejected_budget = rejected_source._message_limit._budget
 
         first_frame_start = await _handle_event(
             addon_context,
@@ -1079,8 +1079,8 @@ async def test_uncompressed_message_after_deflate_negotiation_clears_state(
             permessage_deflate=_PERMESSAGE_DEFLATE,
         )
         source = _bounded_source_websocket(running, from_client=from_client)
-        assert len(source._vm0_bounded_deflates) == 1
-        bounded_deflate = source._vm0_bounded_deflates[0]
+        assert len(source._bounded_deflates) == 1
+        bounded_deflate = source._bounded_deflates[0]
 
         uncompressed_frame = _peer(from_client=from_client).send(_message_event(contents[0]))
         assert uncompressed_frame[0] & 0x40 == 0
@@ -1101,8 +1101,8 @@ async def test_uncompressed_message_after_deflate_negotiation_clears_state(
         assert sum(len(fragment) for fragment in source.frame_buf) == 0
         assert bounded_deflate._decompressor is None
         assert bounded_deflate._inbound_compressed is None
-        assert source._vm0_message_limit._budget.decoded_bytes == 0
-        assert source._vm0_message_limit._budget.data_frames == 0
+        assert source._message_limit._budget.decoded_bytes == 0
+        assert source._message_limit._budget.data_frames == 0
 
         compressed_frame = _peer(
             from_client=from_client,
@@ -1126,8 +1126,8 @@ async def test_uncompressed_message_after_deflate_negotiation_clears_state(
     assert sum(len(fragment) for fragment in source.frame_buf) == 0
     assert bounded_deflate._decompressor is not None
     assert bounded_deflate._inbound_compressed is None
-    assert source._vm0_message_limit._budget.decoded_bytes == 0
-    assert source._vm0_message_limit._budget.data_frames == 0
+    assert source._message_limit._budget.decoded_bytes == 0
+    assert source._message_limit._budget.data_frames == 0
 
 
 async def test_compression_preserves_context_takeover_and_is_connection_local(
@@ -1159,8 +1159,8 @@ async def test_compression_preserves_context_takeover_and_is_connection_local(
             running.layer.server_ws,
             websocket_framing._BoundedWebsocketConnection,
         )
-        assert len(running.layer.server_ws._vm0_bounded_deflates) == 1
-        bounded_deflate = running.layer.server_ws._vm0_bounded_deflates[0]
+        assert len(running.layer.server_ws._bounded_deflates) == 1
+        bounded_deflate = running.layer.server_ws._bounded_deflates[0]
         first_decompressor = bounded_deflate._decompressor
         assert first_decompressor is not None
 
@@ -1218,8 +1218,8 @@ async def test_compression_releases_negotiated_no_context_takeover_state(
             source_websocket,
             websocket_framing._BoundedWebsocketConnection,
         )
-        assert len(source_websocket._vm0_bounded_deflates) == 1
-        bounded_deflate = source_websocket._vm0_bounded_deflates[0]
+        assert len(source_websocket._bounded_deflates) == 1
+        bounded_deflate = source_websocket._bounded_deflates[0]
 
         for content in contents:
             delivered = await _handle_event(
@@ -1290,13 +1290,13 @@ async def test_malformed_compressed_frame_closes_only_the_rejected_flow(
     rejected_source = rejected.layer.client_ws if from_client else rejected.layer.server_ws
     assert isinstance(rejected_source, websocket_framing._BoundedWebsocketConnection)
     assert sum(len(fragment) for fragment in rejected_source.frame_buf) == 0
-    assert len(rejected_source._vm0_bounded_deflates) == 1
-    bounded_deflate = rejected_source._vm0_bounded_deflates[0]
+    assert len(rejected_source._bounded_deflates) == 1
+    bounded_deflate = rejected_source._bounded_deflates[0]
     assert bounded_deflate._decompressor is None
     assert bounded_deflate._inbound_is_compressible is None
     assert bounded_deflate._inbound_compressed is None
-    assert rejected_source._vm0_message_limit._budget.decoded_bytes == 0
-    assert rejected_source._vm0_message_limit._budget.data_frames == 0
+    assert rejected_source._message_limit._budget.decoded_bytes == 0
+    assert rejected_source._message_limit._budget.data_frames == 0
 
     assert len(_message_hooks(delivered)) == 1
     assert len(_data_sends(delivered)) == 1
@@ -1411,7 +1411,7 @@ async def test_compressed_message_uses_aggregate_output_budget(
             ),
         )
         rejected_source = _bounded_source_websocket(rejected, from_client=True)
-        assert 0 < rejected_source._vm0_message_limit._budget.decoded_bytes < aggregate_limit
+        assert 0 < rejected_source._message_limit._budget.decoded_bytes < aggregate_limit
 
         overflow = await _handle_event(
             addon_context,

--- a/crates/runner/mitm-addon/tests/test_response_handler_cleanup.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler_cleanup.py
@@ -196,8 +196,8 @@ def test_response_does_not_clear_replaced_stream_callback(tmp_path, real_flow, m
     )
 
     mitm_addon.responseheaders(flow)
-    vm0_stream = response_stream(flow)
-    vm0_stream(b'{"model":"claude-sonnet-4-6"}')
+    stream_callback = response_stream(flow)
+    stream_callback(b'{"model":"claude-sonnet-4-6"}')
     flow.response.stream = external_stream
 
     with mitm_ctx():

--- a/crates/runner/mitm-addon/tests/test_response_stream_state_release.py
+++ b/crates/runner/mitm-addon/tests/test_response_stream_state_release.py
@@ -29,7 +29,7 @@ class TestReleaseResponseStreamState:
         response_streaming.release_response_stream_state(flow)
 
         assert flow.response.stream is external_stream
-        assert "_vm0_response_stream_callback" not in flow.metadata
+        assert "_response_stream_callback" not in flow.metadata
         assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
@@ -157,7 +157,7 @@ class TestReleaseResponseStreamState:
         response_streaming.release_response_stream_state(flow)
 
         assert flow.response.stream is False
-        assert "_vm0_response_stream_callback" not in flow.metadata
+        assert "_response_stream_callback" not in flow.metadata
         assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
@@ -180,7 +180,7 @@ class TestReleaseResponseStreamState:
         response_streaming.release_response_stream_state(flow)
 
         assert flow.response is None
-        assert "_vm0_response_stream_callback" not in flow.metadata
+        assert "_response_stream_callback" not in flow.metadata
         assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -42,9 +42,9 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 #
 # Uses a positional sentinel (not an env var) so we don't depend on sudoers
-# allowing env preservation. The sentinel is prefixed with `__vm0_` to make
+# allowing env preservation. The sentinel is prefixed with `__runner_` to make
 # an accidental arg collision vanishingly unlikely.
-readonly UNSHARE_SENTINEL="--__vm0_unshared__"
+readonly UNSHARE_SENTINEL="--__runner_unshared__"
 if [[ "${1:-}" != "$UNSHARE_SENTINEL" ]]; then
   for cmd in sudo unshare; do
     if ! command -v "$cmd" &>/dev/null; then

--- a/crates/runner/scripts/customize-rootfs.sh
+++ b/crates/runner/scripts/customize-rootfs.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-readonly UNSHARE_SENTINEL="--__vm0_unshared__"
+readonly UNSHARE_SENTINEL="--__runner_unshared__"
 if [[ "${1:-}" != "$UNSHARE_SENTINEL" ]]; then
   for cmd in sudo unshare; do
     if ! command -v "$cmd" &>/dev/null; then

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-readonly UNSHARE_SENTINEL="--__vm0_unshared__"
+readonly UNSHARE_SENTINEL="--__runner_unshared__"
 if [[ "${1:-}" != "$UNSHARE_SENTINEL" ]]; then
   for cmd in sudo unshare; do
     if ! command -v "$cmd" &> /dev/null; then

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -1017,7 +1017,7 @@ assert_check_error \
             ("verify-rootfs.sh", VERIFY_SCRIPT),
         ] {
             assert!(
-                script.contains(r#"UNSHARE_SENTINEL="--__vm0_unshared__""#),
+                script.contains(r#"UNSHARE_SENTINEL="--__runner_unshared__""#),
                 "{name} should use a sentinel so sudo does not need to preserve env vars"
             );
             assert!(


### PR DESCRIPTION
## Summary

- rename only runner process-local markers and attributes, preserving connector registry ownership and JSON synthetic-key secrecy
- atomically rename same-build guest mock events and ready files/sockets, plus the rootfs self-reentry sentinel
- remove the three stale `vm0_delivery` absence assertions and rewrite the two Pi RPC tombstone comments as current behavior

## Boundary verification

- traced every scoped runner producer and consumer; none serializes or crosses a production process, persistence, or mixed-version boundary
- preserved input clearing before registry-only `_connectorRuntimeKind` classification
- retained NUL-prefixed JSON synthetic keys and wildcard-observation exclusion coverage
- traced guest coordination values across `guest-agent`, `guest-mock-claude`, and `guest-mock-codex`; they are built and consumed in one test run
- audited 26 open PRs and 428 changed-file entries immediately before commit; exact target-file overlap was zero
- deliberately left current protocol and deployed identities unchanged, including mitmdump options, `VM0_ADDON_EVENT`, `vm0_internal`, `VM0_DF_*`, `VM0E`, `.vm0`, `vm0tmp`, and `__vm0_blank__`
- deliberately left `target/.vm0-mock-package-debug.build-session` unchanged because it is not a ready file or socket in this issue scope

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p guest-agent -p guest-mock-claude -p guest-mock-codex -p runner --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p guest-agent -p guest-mock-claude -p guest-mock-codex -p runner --no-deps`
- 21 focused `guest-agent` integration binaries / 22 cases covering every renamed guest coordination family, including oversized delivery
- `cargo test --manifest-path crates/Cargo.toml --profile local -p guest-mock-codex` (50 integration tests)
- mitm-addon Ruff format/lint, BasedPyright, metadata-key check, and 224 focused pytest cases
- `bash -n` on all three rootfs scripts and ShellCheck with the three unrelated pre-existing SC2034/SC2155 findings excluded
- final scoped old-name scan and `git diff --check`

## Local constraints

- the focused runner unit-test binary was terminated by the 4 GB local environment while compiling (exit 137); the same target passed all-target Clippy, the scripts passed syntax/static checks, and exact-head PR CI remains the final gate
- two unrelated full-package `guest-mock-claude` shell-execution tests require the managed runtime cgroup and returned `tool executor was not launched from the managed runtime cgroup`; all scoped guest coordination integration tests passed

Closes #32241