### PR TITLE
refactor(api): neutralize built-in model test vocabulary

### DIFF
--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -10,7 +10,7 @@ entry points. The current suite covers:
 - Clerk-backed sign-up and sign-in through the platform-owned Auth v2 UI;
 - onboarding, chat submission, runner dispatch, and the assistant result through
   the deployed web application;
-- real Claude BYOK, vm0 built-in Codex, and vm0 built-in Pi execution, including
+- real Claude BYOK, built-in Codex, and built-in Pi execution, including
   public usage attribution;
 - active-run cancellation through the public run and chat-events APIs;
 - ordinary and empty chat attachments across continuation, plus runner-mounted
@@ -85,7 +85,7 @@ The number is a stable file identifier, not an execution order. Test titles
 should describe behavior without repeating the file identifier.
 
 The workflow also prepares dedicated real-Codex and real-Claude identities.
-Use the Codex identity for vm0 built-in model billing coverage and the Claude
+Use the Codex identity for built-in model billing coverage and the Claude
 identity for BYOK coverage so provider policy and usage assertions remain
 isolated. The shared mock-runner identity starts with `UTC` as its timezone.
 Runner BATS must not mutate shared account-level preferences from parallel

--- a/e2e/helpers/runner-api.bash
+++ b/e2e/helpers/runner-api.bash
@@ -291,7 +291,7 @@ runner_e2e_wait_for_usage_event() {
         sleep 2
     done
 
-    echo "Timed out waiting for vm0 usage from ${provider@Q} for run ${run_id}" >&2
+    echo "Timed out waiting for usage from ${provider@Q} for run ${run_id}" >&2
     echo "Last chat events: ${last_events}" >&2
     return 1
 }
@@ -350,13 +350,13 @@ runner_e2e_assert_no_usage_for_thread() {
                 .runId != $runId or .eventType != "usage.recorded"
             )
         ' <<<"$events" >/dev/null; then
-            echo "Run ${run_id} unexpectedly emitted a vm0 usage event: ${events}" >&2
+            echo "Run ${run_id} unexpectedly emitted a usage event: ${events}" >&2
             return 1
         fi
         if ! jq -e --arg threadId "$thread_id" '
             all(.rows[]?; .threadId != $threadId)
         ' <<<"$record" >/dev/null; then
-            echo "Thread ${thread_id} unexpectedly appeared in vm0 usage records: ${record}" >&2
+            echo "Thread ${thread_id} unexpectedly appeared in usage records: ${record}" >&2
             return 1
         fi
         if ((SECONDS - started_at >= observation_seconds)); then
@@ -366,7 +366,7 @@ runner_e2e_assert_no_usage_for_thread() {
     done
 
     jq -cn --arg runId "$run_id" --arg threadId "$thread_id" \
-        '{runId: $runId, threadId: $threadId, vm0UsageCredits: 0}'
+        '{runId: $runId, threadId: $threadId, usageCredits: 0}'
 }
 
 runner_e2e_network_logs() {

--- a/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/run-t10-real-claude-smoke.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Real VM0 built-in Claude and Pi smoke tests through supported model, agent, and chat APIs.
+# Real built-in Claude and Pi smoke tests through supported model, agent, and chat APIs.
 
 load '../../helpers/setup'
 load '../../helpers/runner-chat'
@@ -126,7 +126,7 @@ run_real_claude_steer() {
     printf '%s\n%s\n' "$steer_output" "$successor_output"
 }
 
-@test "vm0 built-in real claude returns a successful answer" {
+@test "built-in real claude returns a successful answer" {
     run runner_api_curl "/api/model-policies"
     assert_success
     run jq -e --arg model "$REAL_CLAUDE_MODEL" '
@@ -152,7 +152,7 @@ run_real_claude_steer() {
     [[ -n "$(runner_chat_field "$output" '.sessionId')" ]]
 }
 
-@test "vm0 built-in real pi loop returns a successful answer" {
+@test "built-in real pi loop returns a successful answer" {
     run runner_api_curl "/api/model-policies"
     assert_success
     run jq -e '
@@ -195,7 +195,7 @@ run_real_claude_steer() {
     assert_success
 }
 
-@test "vm0 built-in real claude steers an active run then starts a successor" {
+@test "built-in real claude steers an active run then starts a successor" {
     local steer_nonce steer_prompt after_complete_nonce after_complete_prompt
     steer_nonce="$(_runner_uuid)"
     steer_prompt="claude-steer-${steer_nonce%%-*}"

--- a/e2e/tests/03-runner/run-t11-real-codex-billing.bats
+++ b/e2e/tests/03-runner/run-t11-real-codex-billing.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Real Codex smoke and vm0 built-in usage attribution through public APIs.
+# Real Codex smoke and built-in usage attribution through public APIs.
 
 load '../../helpers/setup'
 load '../../helpers/runner-chat'
@@ -19,7 +19,7 @@ teardown() {
     runner_e2e_teardown_test
 }
 
-@test "real codex reports vm0 built-in model usage" {
+@test "real codex reports built-in model usage" {
     run create_runner_agent "e2e-real-codex-${TEST_ID}"
     echo "$output"
     assert_success

--- a/e2e/tests/03-runner/run-t24-built-in-provider-fallback.bats
+++ b/e2e/tests/03-runner/run-t24-built-in-provider-fallback.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Deployed VM0 built-in fallback completion after a trusted exact-route cooldown.
+# Deployed built-in fallback completion after a trusted exact-route cooldown.
 
 load '../../helpers/setup'
 load '../../helpers/runner-chat'

--- a/turbo/apps/api/README.md
+++ b/turbo/apps/api/README.md
@@ -8,7 +8,7 @@ open http://localhost:3001
 ```
 
 `GET /` returns the Hono greeting plus the built-in model names backed by
-`vm0_api_keys`. It does not return vendors or API key values.
+`built_in_model_keys`. It does not return vendors or API key values.
 
 Set `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to
 export Hono request spans and `pg` query spans.

--- a/turbo/apps/api/src/scripts/__tests__/dev-seed.test.ts
+++ b/turbo/apps/api/src/scripts/__tests__/dev-seed.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildVm0ApiKeys } from "../dev-seed";
+import { buildBuiltInModelKeys } from "../dev-seed";
 
 function readEnvFrom(
   values: Readonly<Record<string, string | undefined>>,
@@ -13,15 +13,15 @@ function readEnvFrom(
 function buildVendorKeys(
   vendor: string,
   values: Readonly<Record<string, string | undefined>>,
-): ReturnType<typeof buildVm0ApiKeys> {
-  return buildVm0ApiKeys(readEnvFrom(values), () => {
+): ReturnType<typeof buildBuiltInModelKeys> {
+  return buildBuiltInModelKeys(readEnvFrom(values), () => {
     // Suppress expected skip logs for vendors that are not configured in tests.
   }).filter((key) => {
     return key.vendor === vendor;
   });
 }
 
-describe("buildVm0ApiKeys", () => {
+describe("buildBuiltInModelKeys", () => {
   it("falls back to ANTHROPIC_API_KEY for Anthropic dev seed rows", () => {
     const anthropicKeys = buildVendorKeys("anthropic", {
       DEV_MODEL_ANTHROPIC_KEY: "",

--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -738,11 +738,11 @@ type OptionalEnvReader = (name: string) => string | undefined;
 type LineWriter = (message: string) => void;
 
 /**
- * Build vm0_api_keys entries from environment variables.
- * Vendors are derived from all VM0 built-in candidates so new providers are
+ * Build built_in_model_keys entries from environment variables.
+ * Vendors are derived from all built-in candidates so new providers are
  * automatically picked up.
  */
-export function buildVm0ApiKeys(
+export function buildBuiltInModelKeys(
   readEnv: OptionalEnvReader = optionalEnv,
   logLine: LineWriter = writeLine,
 ): (typeof builtInModelKeys.$inferInsert)[] {
@@ -787,9 +787,9 @@ async function devSeed() {
     });
   writeLine(`Seeded ${USAGE_PRICING.length} usage pricing entries`);
 
-  // --- vm0_api_keys (transactional replace) ---
-  writeLine("Seeding vm0_api_keys");
-  const apiKeys = buildVm0ApiKeys();
+  // --- built_in_model_keys (transactional replace) ---
+  writeLine("Seeding built_in_model_keys");
+  const apiKeys = buildBuiltInModelKeys();
   await database.transaction(async (tx) => {
     await tx.delete(builtInModelKeys);
     if (apiKeys.length > 0) {
@@ -797,9 +797,9 @@ async function devSeed() {
     }
   });
   for (const k of apiKeys) {
-    writeLine(`Seeded vm0 API key entry: ${k.vendor}`);
+    writeLine(`Seeded built-in model key entry: ${k.vendor}`);
   }
-  writeLine(`Seeded ${apiKeys.length} vm0 API key entries`);
+  writeLine(`Seeded ${apiKeys.length} built-in model key entries`);
 
   // --- skills (published volumes + seed-skill metadata fallback) ---
   const seedSkillVolumes = getDevSeedSkillVolumes();

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -185,7 +185,7 @@ import {
   holdAgentRunPiExecutionSnapshotFixture,
 } from "../../../test-fixtures/thread-bound-run-admission";
 import {
-  acquireBddVm0ApiKey,
+  acquireBddBuiltInModelKey,
   completeRunWithoutCallbacksFixture,
   deletePiApiFirstTurnUsageEventsFixture,
   holdAgentRunRowLockFixture,
@@ -203,7 +203,7 @@ import {
   readRunOutputLegacyPiEventsFixture,
   readRunOutputMaterializationFixture,
   readRunUsageEventsFixture,
-  releaseBddVm0ApiKey,
+  releaseBddBuiltInModelKey,
   removeChatCallbackPublicBrandFixture,
   replayPendingChatInputQueueEventFixture,
   replacePiSessionHistoryJsonlFixture,
@@ -5974,7 +5974,8 @@ describe("CHAT-02: model-first provider policies", () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const orgId = requireOrgId(actor);
-    // External model admission depends on plan capabilities, not VM0 credits.
+    // External model admission depends on plan capabilities, not built-in
+    // model credit admission.
     await seedOrgMetadata({ orgId, tier: "pro", credits: 0 });
     const { providerId: deepseekId } = await upsertOrgModelProvider(actor, {
       type: "deepseek",
@@ -6082,28 +6083,28 @@ describe("CHAT-02: model-first provider policies", () => {
     // Restore spendable credits before exercising the built-in branch.
     await seedOrgMetadata({ orgId, tier: "pro", credits: 1_000_000 });
 
-    // A vm0 provider pin in an entitled org passes the spendable-credits
+    // A built-in provider pin in an entitled org passes the spendable-credits
     // admission. The outcome past admission is race-dependent on the shared
-    // database: 503 when no vm0 execution key exists (no public provisioning
+    // database: 503 when no built-in model key exists (no public provisioning
     // surface), 201 when another suite's alive legacy test has seeded a
-    // global vm0 key. Both prove the credits-ok admission arm.
+    // global built-in model key. Both prove the credits-ok admission arm.
     await setOrgModelPolicyProviderTypeFixture({
       orgId,
       model: "claude-sonnet-5",
       defaultProviderType: "built-in",
     });
-    const vm0Prompt = "vm0-backed admission with spendable credits";
-    const vm0Send = await requestSendEventRaw(actor, {
+    const builtInPrompt = "built-in admission with spendable credits";
+    const builtInSend = await requestSendEventRaw(actor, {
       agentId,
-      prompt: vm0Prompt,
+      prompt: builtInPrompt,
       userMessage: {
         version: 1,
-        parts: [{ type: "text", text: vm0Prompt }],
+        parts: [{ type: "text", text: builtInPrompt }],
       },
       model: "claude-sonnet-5",
       hasTextContent: true,
     });
-    expect([201, 503]).toContain(vm0Send.status);
+    expect([201, 503]).toContain(builtInSend.status);
     type BuiltInAdmissionObservation =
       | {
           readonly outcome: "route-unavailable";
@@ -6121,15 +6122,15 @@ describe("CHAT-02: model-first provider policies", () => {
           };
           readonly cleanup: { readonly status: number } | null;
         };
-    let vm0Observation: BuiltInAdmissionObservation;
+    let builtInObservation: BuiltInAdmissionObservation;
     let expectedBuiltInObservation: BuiltInAdmissionObservation;
-    if (vm0Send.status === 503) {
-      expectApiError(vm0Send.body);
-      vm0Observation = {
+    if (builtInSend.status === 503) {
+      expectApiError(builtInSend.body);
+      builtInObservation = {
         outcome: "route-unavailable",
         response: {
           status: 503,
-          errorMessage: vm0Send.body.error.message,
+          errorMessage: builtInSend.body.error.message,
         },
         cleanup: null,
       };
@@ -6143,21 +6144,22 @@ describe("CHAT-02: model-first provider policies", () => {
         cleanup: null,
       };
     } else {
-      if (vm0Send.status !== 201) {
+      if (builtInSend.status !== 201) {
         throw new Error("Expected a legal built-in admission outcome");
       }
       if (
-        typeof vm0Send.body !== "object" ||
-        vm0Send.body === null ||
-        !("runId" in vm0Send.body) ||
-        (vm0Send.body.runId !== null && typeof vm0Send.body.runId !== "string")
+        typeof builtInSend.body !== "object" ||
+        builtInSend.body === null ||
+        !("runId" in builtInSend.body) ||
+        (builtInSend.body.runId !== null &&
+          typeof builtInSend.body.runId !== "string")
       ) {
         throw new Error("Expected a built-in admission response body");
       }
-      const runId = vm0Send.body.runId;
+      const runId = builtInSend.body.runId;
       const cancellation =
         runId === null ? null : await api.requestCancelRun(actor, runId, [200]);
-      vm0Observation = {
+      builtInObservation = {
         outcome: "run-created",
         response: { status: 201, runId },
         cleanup: cancellation === null ? null : { status: cancellation.status },
@@ -6168,7 +6170,7 @@ describe("CHAT-02: model-first provider policies", () => {
         cleanup: runId === null ? null : { status: 200 },
       };
     }
-    expect(vm0Observation).toStrictEqual(expectedBuiltInObservation);
+    expect(builtInObservation).toStrictEqual(expectedBuiltInObservation);
   }, 90_000);
 
   it("preserves persisted external model plan-state outcomes", async () => {
@@ -7825,7 +7827,7 @@ describe("CHAT-02: model-first provider policies", () => {
       upstreamModel: "company-terra-production",
     },
   ] as const)(
-    "runs custom Responses gateway $selectedModel through Pi without vm0 model billing",
+    "runs custom Responses gateway $selectedModel through Pi without built-in model billing",
     async ({ selectedModel, upstreamModel }) => {
       const { actor, agentId } = await entitledChatActor();
       const orgId = requireOrgId(actor);
@@ -14424,15 +14426,15 @@ describe("CHAT-02: model-first provider policies", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   }, 90_000);
 
-  it("runs vm0 DeepSeek through the native Pi API credential", async () => {
+  it("runs built-in DeepSeek through the native Pi API credential", async () => {
     const { actor, agentId } = await entitledChatActor();
     const keyFixtureId = randomUUID();
-    const requestedApiKey = `vm0-key-bdd-dev-seed-${keyFixtureId}`;
+    const requestedApiKey = `built-in-key-bdd-dev-seed-${keyFixtureId}`;
 
     // Keep a second DeepSeek fixture owner alive to cover vendor-unique row
     // arbitration instead of relying on another test file's scheduling.
     await seedBuiltInModelKey("deepseek-v4-flash");
-    const selectedApiKey = await acquireBddVm0ApiKey({
+    const selectedApiKey = await acquireBddBuiltInModelKey({
       fixtureId: keyFixtureId,
       vendor: "deepseek",
       apiKey: requestedApiKey,
@@ -14447,11 +14449,11 @@ describe("CHAT-02: model-first provider policies", () => {
         }
       }
     };
-    const releaseVm0DeepSeekKey = async () => {
-      await releaseBddVm0ApiKey({ fixtureId: keyFixtureId });
+    const releaseBuiltInDeepSeekKey = async () => {
+      await releaseBddBuiltInModelKey({ fixtureId: keyFixtureId });
     };
     const cleanupRunAndKeys = async () => {
-      await Promise.all([releaseVm0DeepSeekKey(), cancelRunIfCreated()]);
+      await Promise.all([releaseBuiltInDeepSeekKey(), cancelRunIfCreated()]);
     };
 
     await (async () => {
@@ -14487,7 +14489,10 @@ describe("CHAT-02: model-first provider policies", () => {
             body: await request.json(),
           });
           return new HttpResponse(
-            piResponsesTextSse("vm0 Pi API response", modelRequests.length),
+            piResponsesTextSse(
+              "built-in Pi API response",
+              modelRequests.length,
+            ),
             { headers: { "content-type": "text/event-stream" } },
           );
         }),
@@ -14495,7 +14500,7 @@ describe("CHAT-02: model-first provider policies", () => {
 
       const run = await sendChatRun(actor, {
         agentId,
-        prompt: "run with the selected vm0 DeepSeek provider",
+        prompt: "run with the selected built-in DeepSeek provider",
         model: "deepseek-v4-flash",
       });
       runId = run.runId;
@@ -14520,19 +14525,19 @@ describe("CHAT-02: model-first provider policies", () => {
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const keyFixtureId = randomUUID();
-    const requestedApiKey = `vm0-key-bdd-dev-seed-${keyFixtureId}`;
+    const requestedApiKey = `built-in-key-bdd-dev-seed-${keyFixtureId}`;
     await seedBuiltInModelKey("claude-opus-4-8");
 
     let runId: string | null = null;
 
     onTestFinished(async () => {
       await Promise.all([
-        releaseBddVm0ApiKey({ fixtureId: keyFixtureId }),
+        releaseBddBuiltInModelKey({ fixtureId: keyFixtureId }),
         ...(runId ? [api.requestCancelRun(actor, runId, [200])] : []),
       ]);
     });
 
-    const acquiredApiKey = await acquireBddVm0ApiKey({
+    const acquiredApiKey = await acquireBddBuiltInModelKey({
       fixtureId: keyFixtureId,
       vendor: "anthropic",
       apiKey: requestedApiKey,
@@ -14559,7 +14564,7 @@ describe("CHAT-02: model-first provider policies", () => {
 
     const run = await sendChatRun(actor, {
       agentId,
-      prompt: "run with the selected vm0 provider",
+      prompt: "run with the selected built-in provider",
       model: "claude-opus-4-8",
     });
     runId = run.runId;
@@ -14581,7 +14586,7 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(environment.ANTHROPIC_MODEL).toBe("claude-opus-4-8");
 
     if (!claim.encryptedSecrets) {
-      throw new Error("Expected vm0 claim to carry encrypted secrets");
+      throw new Error("Expected the built-in claim to carry encrypted secrets");
     }
     const resolved = await fw.requestFirewallAuth(
       sandboxHeaders,
@@ -14594,7 +14599,7 @@ describe("CHAT-02: model-first provider policies", () => {
       [200],
     );
     if (resolved.status !== 200) {
-      throw new Error("Expected vm0 firewall auth to resolve");
+      throw new Error("Expected built-in firewall auth to resolve");
     }
     const authorization = resolved.body.headers.Authorization;
     expect(authorization?.startsWith("Bearer ")).toBeTruthy();
@@ -14801,7 +14806,7 @@ describe("CHAT-02: run-level model overrides", () => {
     { name: "Fast", tier: "fast", generation: 3, outcome: "failed" },
     { name: "Fast", tier: "fast", generation: 3, outcome: "cancelled" },
   ] as const)(
-    "hands native $name subscription Terra tools to a generation-$generation Sandbox with $outcome outcome and no VM0 billing",
+    "hands native $name subscription Terra tools to a generation-$generation Sandbox with $outcome outcome and no built-in billing",
     async ({ tier, generation, outcome }) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       const firewall = createFirewallApi(context);
@@ -16959,7 +16964,7 @@ describe("CHAT-02: run-level model overrides", () => {
       actor,
       {
         agentId: agent.agentId,
-        prompt: "use an unsupported vm0 model",
+        prompt: "use an unsupported model",
         clientThreadId: invalidModelThreadId,
         model: "codex" as never,
       },
@@ -22747,7 +22752,7 @@ describe("CHAT-02: run image model snapshot", () => {
 
     const globalDefault = await sendChatRun(actor, {
       agentId,
-      prompt: "image model comes from the vm0 global default",
+      prompt: "image model comes from the global default",
     });
     await expect(
       readRunImageModelSnapshotFixture(globalDefault.runId),
@@ -22871,7 +22876,7 @@ describe("CHAT-02: run image model snapshot", () => {
     const retiredEverywhere = await sendChatRun(actor, {
       agentId,
       threadId: anchor.threadId,
-      prompt: "retired image defaults fall through to the vm0 default",
+      prompt: "retired image defaults fall through to the global default",
     });
     await expect(
       readRunImageModelSnapshotFixture(retiredEverywhere.runId),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/runtime-state.ts
@@ -83,7 +83,7 @@ interface BuiltInModelKeyFixture {
   release(): Promise<void>;
 }
 
-function vm0BuiltInModelKeyFixture(
+function builtInModelKeyFixture(
   context: TestContext,
   fixtureId: string,
   selectedModel: string,
@@ -94,7 +94,7 @@ function vm0BuiltInModelKeyFixture(
       return;
     }
     await postAction(context, {
-      action: "delete-vm0-built-in-model-key",
+      action: "delete-built-in-model-key",
       fixture_id: fixtureId,
     });
     released = true;
@@ -108,13 +108,13 @@ export async function seedBuiltInDefaultModelKey(
 ): Promise<BuiltInModelKeyFixture> {
   const fixtureId = randomUUID();
   const response = await postAction(context, {
-    action: "seed-vm0-built-in-default-model-key",
+    action: "seed-built-in-default-model-key",
     fixture_id: fixtureId,
   });
   if (!response.selected_model) {
     throw new Error("seedBuiltInDefaultModelKey missing selected_model");
   }
-  return vm0BuiltInModelKeyFixture(context, fixtureId, response.selected_model);
+  return builtInModelKeyFixture(context, fixtureId, response.selected_model);
 }
 
 export async function seedBuiltInModelKey(
@@ -123,14 +123,14 @@ export async function seedBuiltInModelKey(
 ): Promise<BuiltInModelKeyFixture> {
   const fixtureId = randomUUID();
   const response = await postAction(context, {
-    action: "seed-vm0-built-in-model-key",
+    action: "seed-built-in-model-key",
     fixture_id: fixtureId,
     selected_model: selectedModel,
   });
   if (!response.selected_model) {
     throw new Error("seedBuiltInModelKey missing selected_model");
   }
-  return vm0BuiltInModelKeyFixture(context, fixtureId, response.selected_model);
+  return builtInModelKeyFixture(context, fixtureId, response.selected_model);
 }
 
 export async function seedBuiltInModelCandidateKeys(
@@ -139,14 +139,14 @@ export async function seedBuiltInModelCandidateKeys(
 ): Promise<BuiltInModelKeyFixture> {
   const fixtureId = randomUUID();
   const response = await postAction(context, {
-    action: "seed-vm0-built-in-model-candidate-keys",
+    action: "seed-built-in-model-candidate-keys",
     fixture_id: fixtureId,
     selected_model: selectedModel,
   });
   if (!response.selected_model) {
     throw new Error("seedBuiltInModelCandidateKeys missing selected_model");
   }
-  return vm0BuiltInModelKeyFixture(context, fixtureId, response.selected_model);
+  return builtInModelKeyFixture(context, fixtureId, response.selected_model);
 }
 
 type BuiltInModelRuntimeRouteFixture = NonNullable<
@@ -158,7 +158,7 @@ export async function resolveBuiltInModelRouteFixture(
   selectedModel: string,
 ): Promise<BuiltInModelRuntimeRouteFixture | null> {
   const response = await postAction(context, {
-    action: "resolve-vm0-built-in-model-route",
+    action: "resolve-built-in-model-route",
     selected_model: selectedModel,
   });
   return response.built_in_model_route ?? null;
@@ -171,7 +171,7 @@ export async function setBuiltInCandidateCooldownFixture(
   unavailableUntil: Date,
 ): Promise<void> {
   await postAction(context, {
-    action: "set-vm0-built-in-candidate-cooldown",
+    action: "set-built-in-candidate-cooldown",
     selected_model: selectedModel,
     provider_type: route.provider_type,
     upstream_model: route.upstream_model,
@@ -186,7 +186,7 @@ export async function deleteBuiltInCandidateCooldownFixture(
   route: BuiltInModelRuntimeRouteFixture,
 ): Promise<void> {
   await postAction(context, {
-    action: "delete-vm0-built-in-candidate-cooldown",
+    action: "delete-built-in-candidate-cooldown",
     selected_model: selectedModel,
     provider_type: route.provider_type,
     upstream_model: route.upstream_model,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7492,7 +7492,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
       visibility: "private",
     });
     const byokPrompt = `suspended BYOK ${randomUUID()}`;
-    const vm0Prompt = `suspended VM0 ${randomUUID()}`;
+    const builtInPrompt = `suspended built-in ${randomUUID()}`;
     await seedOrgMetadata({
       orgId: actor.orgId,
       tier: "pro-suspend",
@@ -7511,18 +7511,18 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expectApiError(rejected.body);
     expect(rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
 
-    // The suspension applies to vm0-built-in runs as well.
-    const vm0Rejected = await api.requestCreateRun(
+    // The suspension applies to built-in model runs as well.
+    const builtInRejected = await api.requestCreateRun(
       actor,
       {
         agentId: agent.agentId,
-        prompt: vm0Prompt,
+        prompt: builtInPrompt,
         modelProvider: "built-in",
       },
       [402],
     );
-    expectApiError(vm0Rejected.body);
-    expect(vm0Rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
+    expectApiError(builtInRejected.body);
+    expect(builtInRejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
 
     const runs = await api.listAgentRuns(actor, {
       status: "queued,pending,running,completed,failed,timeout,cancelled",
@@ -7530,7 +7530,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     });
     expect(
       runs.runs.filter((run) => {
-        return run.prompt === byokPrompt || run.prompt === vm0Prompt;
+        return run.prompt === byokPrompt || run.prompt === builtInPrompt;
       }),
     ).toHaveLength(0);
     const queue = await api.readRunQueue(actor);
@@ -8168,13 +8168,13 @@ describe("RUN-01: agent run authorization and session boundaries", () => {
   });
 });
 
-describe("RUN-02: model provider selection and vm0 admission", () => {
-  it("gates vm0 runs on billing state and on unexpired credit grants", async () => {
+describe("RUN-02: model provider selection and built-in admission", () => {
+  it("gates built-in model runs on billing state and on unexpired credit grants", async () => {
     const bdd = createBddApi(context);
     const api = createRunsApi(context);
 
     // An org that never went through onboarding has no billing state at all,
-    // so vm0 runs are refused before provider resolution.
+    // so built-in model runs are refused before provider resolution.
     const uninitialized = bdd.user();
     bdd.acceptAgentStorageWrites();
     api.configureRunnerGroup();
@@ -8186,7 +8186,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       uninitialized,
       {
         agentId: bareAgent.agentId,
-        prompt: "vm0 run",
+        prompt: "built-in model run",
         modelProvider: "built-in",
       },
       [402],
@@ -8196,7 +8196,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
 
     // The credit expiry is the subscription period end plus one month, so a
     // period that ended two months ago grants credits that are already
-    // expired and never settled — vm0 admission fails whether or not a
+    // expired and never settled — built-in admission fails whether or not a
     // built-in model key happens to resolve.
     const actor = bdd.user();
     await api.grantProEntitlement(actor, {
@@ -8210,7 +8210,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       actor,
       {
         agentId: agent.agentId,
-        prompt: "vm0 run",
+        prompt: "built-in model run",
         modelProvider: "built-in",
       },
       [402],
@@ -8288,7 +8288,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     });
 
     const byokPrompt = `staff suspended BYOK ${randomUUID()}`;
-    const vm0Prompt = `staff suspended VM0 ${randomUUID()}`;
+    const builtInPrompt = `staff suspended built-in ${randomUUID()}`;
     const byokRejected = await api.requestCreateRun(
       actor,
       {
@@ -8300,17 +8300,17 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     );
     expectApiError(byokRejected.body);
     expect(byokRejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
-    const vm0Rejected = await api.requestCreateRun(
+    const builtInRejected = await api.requestCreateRun(
       actor,
       {
         agentId: agent.agentId,
-        prompt: vm0Prompt,
+        prompt: builtInPrompt,
         modelProvider: "built-in",
       },
       [402],
     );
-    expectApiError(vm0Rejected.body);
-    expect(vm0Rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
+    expectApiError(builtInRejected.body);
+    expect(builtInRejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
 
     const runs = await api.listAgentRuns(actor, {
       status: "queued,pending,running,completed,failed,timeout,cancelled",
@@ -8319,7 +8319,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(
       runs.runs.filter((candidate) => {
         return (
-          candidate.prompt === byokPrompt || candidate.prompt === vm0Prompt
+          candidate.prompt === byokPrompt || candidate.prompt === builtInPrompt
         );
       }),
     ).toHaveLength(0);
@@ -8405,7 +8405,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(queue.body.concurrency.active).toBe(0);
   });
 
-  it("claims vm0 runs with billable model firewall and usage provider", async () => {
+  it("claims built-in model runs with billable model firewall and usage provider", async () => {
     const api = createRunsApi(context);
     const selectedModel = await seedBuiltInDefaultModelKey();
     const concreteProvider = getBuiltInConcreteProviderType(selectedModel);
@@ -8419,7 +8419,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
 
     const run = await api.createRun(actor, {
       agentId,
-      prompt: "vm0 built-in model provider",
+      prompt: "built-in model provider",
       modelProvider: "built-in",
     });
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
@@ -8453,7 +8453,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
-  it("claims vm0 GPT 5.6 runs with the selected OpenAI runtime model", async () => {
+  it("claims built-in GPT 5.6 runs with the selected OpenAI runtime model", async () => {
     const api = createRunsApi(context);
     const chat = createChatFilesBddApi(context);
     const selectedModel = "gpt-5.6-sol";
@@ -8474,7 +8474,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       actor,
       {
         agentId,
-        prompt: "vm0 built-in GPT 5.6 model provider",
+        prompt: "built-in GPT 5.6 model provider",
         model: selectedModel,
       },
       [201],
@@ -8522,7 +8522,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, sent.body.runId, [200]);
   });
 
-  it("keeps VM0 DeepSeek admission after a Slack fixture releases its shared key", async () => {
+  it("keeps built-in DeepSeek admission after a Slack fixture releases its shared key", async () => {
     const api = createRunsApi(context);
     const chat = createChatFilesBddApi(context);
     const selectedModel = "deepseek-v4-flash";
@@ -8569,7 +8569,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       actor,
       {
         agentId,
-        prompt: "vm0 DeepSeek admission after shared fixture release",
+        prompt: "built-in DeepSeek admission after shared fixture release",
         model: selectedModel,
       },
       [201],
@@ -8583,7 +8583,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
   });
 
   it.each(["deepseek-v4-flash", "deepseek-v4-pro"] as const)(
-    "claims vm0 %s runs with the Responses adapter",
+    "claims built-in %s runs with the Responses adapter",
     async (selectedModel) => {
       const api = createRunsApi(context);
       const chat = createChatFilesBddApi(context);
@@ -8604,7 +8604,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
         actor,
         {
           agentId,
-          prompt: "vm0 built-in DeepSeek Responses model provider",
+          prompt: "built-in DeepSeek Responses model provider",
           model: selectedModel,
         },
         [201],
@@ -15688,7 +15688,6 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     expect(appendSystemPrompt).toContain("Timezone: America/Los_Angeles");
     expect(claim.userTimezone).toBe("America/Los_Angeles");
 
-    expect(claim.featureFlags).not.toHaveProperty("zeroWebSearch");
     expect(claim.disallowedTools).toStrictEqual(
       EXPECTED_AGENT_RUN_DISALLOWED_TOOLS,
     );
@@ -15789,7 +15788,6 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
 
-    expect(claim.featureFlags).not.toHaveProperty("zeroWebSearch");
     expect(claim.disallowedTools).toStrictEqual(
       EXPECTED_AGENT_RUN_DISALLOWED_TOOLS,
     );
@@ -16042,7 +16040,6 @@ describe("RUN-01: agent runner context, queue promotion, and skills", () => {
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
 
-    expect(claim.featureFlags).not.toHaveProperty("zeroWebSearch");
     expect(claim.disallowedTools).toStrictEqual(
       EXPECTED_AGENT_RUN_DISALLOWED_TOOLS,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-runtime-state.test.ts
@@ -34,14 +34,14 @@ const chat = createChatFilesBddApi(context);
 const runs = createRunsApi(context);
 const reads = createRunReadsApi(context);
 
-interface ClaimedVm0Run {
+interface ClaimedBuiltInRun {
   readonly actor: ReturnType<typeof bdd.user>;
   readonly agentId: string;
   readonly runId: string;
   readonly selectedModel: string;
 }
 
-async function createClaimedVm0Run(): Promise<ClaimedVm0Run> {
+async function createClaimedBuiltInRun(): Promise<ClaimedBuiltInRun> {
   const keyFixture = await seedBuiltInModelCandidateKeys(
     context,
     DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
@@ -79,7 +79,7 @@ async function createClaimedVm0Run(): Promise<ClaimedVm0Run> {
 }
 
 describe("POST /api/test/runtime-state/action", () => {
-  it("keeps overlapping VM0 built-in model-key fixtures independently releasable", async () => {
+  it("keeps overlapping built-in model-key fixtures independently releasable", async () => {
     const first = await seedBuiltInModelKey(context, "gpt-5.6-terra");
     const second = await seedBuiltInModelKey(context, "gpt-5.6-terra");
 
@@ -145,7 +145,7 @@ describe("POST /api/test/runtime-state/action", () => {
   });
 
   it.each(["deepseek-v4-flash", "deepseek-v4-pro"] as const)(
-    "disables Codex apply patch for the VM0 %s OpenRouter fallback",
+    "disables Codex apply patch for the built-in %s OpenRouter fallback",
     async (selectedModel) => {
       await seedBuiltInModelCandidateKeys(context, selectedModel);
       const startedAt = Date.UTC(2026, 7, 23, 0, 0, 0);
@@ -463,7 +463,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     async ({ body, source, cooldownSeconds }) => {
       const startedAt = Date.UTC(2026, 7, 21, 0, 0, 0);
       await withMockNowForTest(startedAt, async () => {
-        const claimed = await createClaimedVm0Run();
+        const claimed = await createClaimedBuiltInRun();
         const primary = await resolveBuiltInModelRouteFixture(
           context,
           claimed.selectedModel,
@@ -541,8 +541,8 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
   it("requires an inclusive 60-second upstream transport streak", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 0, 15, 0);
-    const claimed = await createClaimedVm0Run();
-    const secondClaimed = await createClaimedVm0Run();
+    const claimed = await createClaimedBuiltInRun();
+    const secondClaimed = await createClaimedBuiltInRun();
     const primary = await resolveBuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
@@ -601,7 +601,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
   it("keeps an observation-only route selectable to an in-flight resolver", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 0, 16, 0);
-    const claimed = await createClaimedVm0Run();
+    const claimed = await createClaimedBuiltInRun();
     const primary = await resolveBuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
@@ -637,7 +637,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
   it("does not extend an active cooldown for one transport observation", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 0, 17, 0);
-    const claimed = await createClaimedVm0Run();
+    const claimed = await createClaimedBuiltInRun();
     const primary = await resolveBuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
@@ -678,7 +678,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
   it("restarts after a gap greater than 60 seconds", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 0, 20, 0);
-    const claimed = await createClaimedVm0Run();
+    const claimed = await createClaimedBuiltInRun();
     const primary = await resolveBuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
@@ -713,7 +713,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
   it("keeps an active longer cooldown and clears transport evidence silently", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 0, 25, 0);
-    const claimed = await createClaimedVm0Run();
+    const claimed = await createClaimedBuiltInRun();
     const primary = await resolveBuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
@@ -791,7 +791,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
   it("merges connected receipts when body processing is reversed", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 0, 35, 0);
-    const claimed = await createClaimedVm0Run();
+    const claimed = await createClaimedBuiltInRun();
     const primary = await resolveBuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
@@ -842,7 +842,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
 
   it("ignores an older disjoint receipt without replacing newer evidence", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 0, 45, 0);
-    const claimed = await createClaimedVm0Run();
+    const claimed = await createClaimedBuiltInRun();
     const primary = await resolveBuiltInModelRouteFixture(
       context,
       claimed.selectedModel,
@@ -892,7 +892,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
     "uses receipt time across a route lock wait at $elapsedMs ms",
     async ({ cooldownExpiresAfterMs, elapsedMs, followupOutcome, outcome }) => {
       const startedAt = Date.UTC(2026, 7, 21, 0, 55, 0) + elapsedMs;
-      const claimed = await createClaimedVm0Run();
+      const claimed = await createClaimedBuiltInRun();
       const primary = await resolveBuiltInModelRouteFixture(
         context,
         claimed.selectedModel,
@@ -959,7 +959,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
   it("writes a reported cooldown to the built-in table", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 0, 30, 0);
     await withMockNowForTest(startedAt, async () => {
-      const claimed = await createClaimedVm0Run();
+      const claimed = await createClaimedBuiltInRun();
       const primary = await resolveBuiltInModelRouteFixture(
         context,
         claimed.selectedModel,
@@ -997,7 +997,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
   });
 
   it("records failure cooldowns for the canonical built-in discriminator", async () => {
-    const claimed = await createClaimedVm0Run();
+    const claimed = await createClaimedBuiltInRun();
     await setRunModelProviderFixture({
       runId: claimed.runId,
       modelProvider: "built-in",
@@ -1041,7 +1041,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
   it("monotonically extends concurrent bounded reports from receipt time", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 1, 0, 0);
     await withMockNowForTest(startedAt, async () => {
-      const claimed = await createClaimedVm0Run();
+      const claimed = await createClaimedBuiltInRun();
       const primary = await resolveBuiltInModelRouteFixture(
         context,
         claimed.selectedModel,
@@ -1102,7 +1102,7 @@ describe("POST /api/runners/runs/:runId/model-provider-failures", () => {
   it("rejects untrusted or invalid reports and ignores ineligible runs", async () => {
     const startedAt = Date.UTC(2026, 7, 21, 2, 0, 0);
     await withMockNowForTest(startedAt, async () => {
-      const claimed = await createClaimedVm0Run();
+      const claimed = await createClaimedBuiltInRun();
       const primary = await resolveBuiltInModelRouteFixture(
         context,
         claimed.selectedModel,

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -55,12 +55,12 @@ interface AllowanceEntitlementArgs {
 }
 
 /**
- * An org whose runs can be admitted with the vm0 built-in model key. Tier and
+ * An org whose runs can be admitted with the built-in model key. Tier and
  * credit balance are pinned through the org-metadata fixture; the allowance
  * entitlement (when given), window activation, usage events, and settlement
  * all run through product paths.
  */
-async function vm0AllowanceActor(args: {
+async function builtInAllowanceActor(args: {
   readonly credits: number;
   readonly allowance?: AllowanceEntitlementArgs;
 }): Promise<{
@@ -134,7 +134,7 @@ async function cancelUsageAllowanceSubscription(orgId: string): Promise<void> {
   );
 }
 
-async function createVm0Run(
+async function createBuiltInRun(
   actor: ApiTestUser,
   agentId: string,
   prompt: string,
@@ -216,11 +216,15 @@ async function readVisibleUsageCredits(actor: ApiTestUser): Promise<number> {
 
 describe("Usage Allowance", () => {
   it("applies usage allowance before legacy org credits", async () => {
-    const { actor, agentId } = await vm0AllowanceActor({
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: 10,
       allowance: { shortWindowUnits: 100, weeklyWindowUnits: 200 },
     });
-    const run = await createVm0Run(actor, agentId, "allowance-covered usage");
+    const run = await createBuiltInRun(
+      actor,
+      agentId,
+      "allowance-covered usage",
+    );
     const provider = usageProvider();
     await recordPendingUsage({
       actor,
@@ -236,12 +240,20 @@ describe("Usage Allowance", () => {
   });
 
   it("settles multiple events and runs against shared allowance windows", async () => {
-    const { actor, agentId } = await vm0AllowanceActor({
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: 100,
       allowance: { shortWindowUnits: 100, weeklyWindowUnits: 90 },
     });
-    const firstRun = await createVm0Run(actor, agentId, "batched first run");
-    const secondRun = await createVm0Run(actor, agentId, "batched second run");
+    const firstRun = await createBuiltInRun(
+      actor,
+      agentId,
+      "batched first run",
+    );
+    const secondRun = await createBuiltInRun(
+      actor,
+      agentId,
+      "batched second run",
+    );
     const provider = usageProvider();
     await recordPendingUsageEvents({
       actor,
@@ -274,11 +286,15 @@ describe("Usage Allowance", () => {
   });
 
   it("falls back to org credits after the binding window cap is exhausted", async () => {
-    const { actor, agentId } = await vm0AllowanceActor({
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: 100,
       allowance: { shortWindowUnits: 100, weeklyWindowUnits: 60 },
     });
-    const run = await createVm0Run(actor, agentId, "weekly cap binds first");
+    const run = await createBuiltInRun(
+      actor,
+      agentId,
+      "weekly cap binds first",
+    );
     const provider = usageProvider();
     await recordPendingUsage({
       actor,
@@ -297,13 +313,13 @@ describe("Usage Allowance", () => {
     onTestFinished(() => {
       clearMockNow();
     });
-    const { actor, agentId } = await vm0AllowanceActor({
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: 100,
       allowance: { shortWindowUnits: 100, weeklyWindowUnits: 200 },
     });
     const startedAt = nowDate();
     mockNow(startedAt);
-    const firstRun = await createVm0Run(
+    const firstRun = await createBuiltInRun(
       actor,
       agentId,
       "exhausts short window",
@@ -318,7 +334,11 @@ describe("Usage Allowance", () => {
     await processOrgUsageEvents(actor);
 
     mockNow(addHours(startedAt, 1));
-    const secondRun = await createVm0Run(actor, agentId, "same short window");
+    const secondRun = await createBuiltInRun(
+      actor,
+      agentId,
+      "same short window",
+    );
     await recordPendingUsage({
       actor,
       runId: secondRun.runId,
@@ -335,13 +355,13 @@ describe("Usage Allowance", () => {
     onTestFinished(() => {
       clearMockNow();
     });
-    const { actor, agentId } = await vm0AllowanceActor({
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: 100,
       allowance: { shortWindowUnits: 100, weeklyWindowUnits: 200 },
     });
     const startedAt = nowDate();
     mockNow(startedAt);
-    const firstRun = await createVm0Run(
+    const firstRun = await createBuiltInRun(
       actor,
       agentId,
       "exhausts short window",
@@ -356,7 +376,11 @@ describe("Usage Allowance", () => {
     await processOrgUsageEvents(actor);
 
     mockNow(addHours(startedAt, 6));
-    const secondRun = await createVm0Run(actor, agentId, "fresh short window");
+    const secondRun = await createBuiltInRun(
+      actor,
+      agentId,
+      "fresh short window",
+    );
     await recordPendingUsage({
       actor,
       runId: secondRun.runId,
@@ -373,13 +397,17 @@ describe("Usage Allowance", () => {
     onTestFinished(() => {
       clearMockNow();
     });
-    const { actor, agentId } = await vm0AllowanceActor({
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: 100,
       allowance: { shortWindowUnits: 100, weeklyWindowUnits: 120 },
     });
     const startedAt = nowDate();
     mockNow(startedAt);
-    const firstRun = await createVm0Run(actor, agentId, "first weekly window");
+    const firstRun = await createBuiltInRun(
+      actor,
+      agentId,
+      "first weekly window",
+    );
     const provider = usageProvider();
     await recordPendingUsage({
       actor,
@@ -390,7 +418,11 @@ describe("Usage Allowance", () => {
     await processOrgUsageEvents(actor);
 
     mockNow(addDays(startedAt, 8));
-    const secondRun = await createVm0Run(actor, agentId, "fresh weekly window");
+    const secondRun = await createBuiltInRun(
+      actor,
+      agentId,
+      "fresh weekly window",
+    );
     await recordPendingUsage({
       actor,
       runId: secondRun.runId,
@@ -405,16 +437,16 @@ describe("Usage Allowance", () => {
     await expect(readVisibleUsageCredits(actor)).resolves.toBe(50);
   });
 
-  it("admits vm0 runs with shared debt when allowance remains", async () => {
-    const { actor, agentId } = await vm0AllowanceActor({
+  it("admits built-in model runs with shared debt when allowance remains", async () => {
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: -10,
       allowance: { shortWindowUnits: 10, weeklyWindowUnits: 10 },
     });
 
-    const run = await createVm0Run(
+    const run = await createBuiltInRun(
       actor,
       agentId,
-      "vm0 run admitted by allowance under shared debt",
+      "built-in model run admitted by allowance under shared debt",
     );
 
     expect(run.runId).toStrictEqual(expect.any(String));
@@ -431,16 +463,16 @@ describe("Usage Allowance", () => {
     await expect(readVisibleUsageCredits(actor)).resolves.toBe(10);
   });
 
-  it("rejects vm0 run admission after allowance is exhausted", async () => {
-    const { actor, agentId } = await vm0AllowanceActor({
+  it("rejects built-in model run admission after allowance is exhausted", async () => {
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: 0,
       allowance: { shortWindowUnits: 1, weeklyWindowUnits: 1 },
     });
     const api = createRunsApi(context);
-    const firstRun = await createVm0Run(
+    const firstRun = await createBuiltInRun(
       actor,
       agentId,
-      "vm0 run consumes the only allowance unit",
+      "built-in model run consumes the only allowance unit",
     );
     const provider = usageProvider();
     await recordPendingUsage({
@@ -455,7 +487,7 @@ describe("Usage Allowance", () => {
       actor,
       {
         agentId,
-        prompt: "vm0 run rejected after allowance exhaustion",
+        prompt: "built-in model run rejected after allowance exhaustion",
         modelProvider: "built-in",
       },
       [402],
@@ -466,12 +498,16 @@ describe("Usage Allowance", () => {
   });
 
   it("keeps billable firewall auth available to an admitted run after exhaustion", async () => {
-    const { actor, agentId } = await vm0AllowanceActor({
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: 0,
       allowance: { shortWindowUnits: 2, weeklyWindowUnits: 2 },
     });
     const api = createRunsApi(context);
-    const run = await createVm0Run(actor, agentId, "billable firewall lease");
+    const run = await createBuiltInRun(
+      actor,
+      agentId,
+      "billable firewall lease",
+    );
     const client = setupApp({
       context,
       routes: webhooksAgentFirewallAuthRoutes,
@@ -530,7 +566,7 @@ describe("Usage Allowance", () => {
   });
 
   it("uses run allowance for billable firewall fallback under shared debt", async () => {
-    const { actor, agentId } = await vm0AllowanceActor({
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: -10,
       allowance: { shortWindowUnits: 2, weeklyWindowUnits: 2 },
     });
@@ -568,9 +604,11 @@ describe("Usage Allowance", () => {
   });
 
   it("does not let built-in credit admission bypass workspace suspension", async () => {
-    const { actor, orgId, agentId } = await vm0AllowanceActor({ credits: 1 });
+    const { actor, orgId, agentId } = await builtInAllowanceActor({
+      credits: 1,
+    });
     const api = createRunsApi(context);
-    const run = await createVm0Run(
+    const run = await createBuiltInRun(
       actor,
       agentId,
       "admitted before suspension",
@@ -599,11 +637,15 @@ describe("Usage Allowance", () => {
   });
 
   it("fails an unfunded built-in queue promotion and continues to BYOK", async () => {
-    const { actor, agentId } = await vm0AllowanceActor({ credits: 1 });
+    const { actor, agentId } = await builtInAllowanceActor({ credits: 1 });
     const api = createRunsApi(context);
-    const first = await createVm0Run(actor, agentId, "active built-in one");
-    const second = await createVm0Run(actor, agentId, "active built-in two");
-    const unfunded = await createVm0Run(
+    const first = await createBuiltInRun(actor, agentId, "active built-in one");
+    const second = await createBuiltInRun(
+      actor,
+      agentId,
+      "active built-in two",
+    );
+    const unfunded = await createBuiltInRun(
       actor,
       agentId,
       "queued built-in loses admission",
@@ -720,11 +762,11 @@ describe("Usage Allowance", () => {
   });
 
   it("applies allowance to non-built-in runs inside active allowance windows", async () => {
-    const { actor, agentId } = await vm0AllowanceActor({
+    const { actor, agentId } = await builtInAllowanceActor({
       credits: 100,
       allowance: { shortWindowUnits: 100, weeklyWindowUnits: 200 },
     });
-    await createVm0Run(actor, agentId, "activate allowance windows");
+    await createBuiltInRun(actor, agentId, "activate allowance windows");
 
     const api = createRunsApi(context);
     api.acceptStorageDownloads();
@@ -755,8 +797,14 @@ describe("Usage Allowance", () => {
     });
     const runCreatedAt = nowDate();
     mockNow(runCreatedAt);
-    const { actor, orgId, agentId } = await vm0AllowanceActor({ credits: 100 });
-    const run = await createVm0Run(actor, agentId, "run before entitlement");
+    const { actor, orgId, agentId } = await builtInAllowanceActor({
+      credits: 100,
+    });
+    const run = await createBuiltInRun(
+      actor,
+      agentId,
+      "run before entitlement",
+    );
     mockNow(addHours(runCreatedAt, 1));
     await seedAllowanceEntitlement(actor, orgId, {
       shortWindowUnits: 100,
@@ -780,13 +828,13 @@ describe("Usage Allowance", () => {
     onTestFinished(() => {
       clearMockNow();
     });
-    const { actor, orgId, agentId } = await vm0AllowanceActor({
+    const { actor, orgId, agentId } = await builtInAllowanceActor({
       credits: 100,
       allowance: { shortWindowUnits: 100, weeklyWindowUnits: 200 },
     });
     const startedAt = nowDate();
     mockNow(startedAt);
-    const run = await createVm0Run(
+    const run = await createBuiltInRun(
       actor,
       agentId,
       "run created before allowance cancellation",
@@ -813,18 +861,18 @@ describe("Usage Allowance", () => {
     onTestFinished(() => {
       clearMockNow();
     });
-    const { actor, orgId, agentId } = await vm0AllowanceActor({
+    const { actor, orgId, agentId } = await builtInAllowanceActor({
       credits: 100,
       allowance: { shortWindowUnits: 100, weeklyWindowUnits: 200 },
     });
     const startedAt = nowDate();
     mockNow(startedAt);
-    await createVm0Run(actor, agentId, "activate allowance windows");
+    await createBuiltInRun(actor, agentId, "activate allowance windows");
     const canceledAt = addHours(startedAt, 1);
     mockNow(canceledAt);
     await cancelUsageAllowanceSubscription(orgId);
     mockNow(addHours(startedAt, 2));
-    const run = await createVm0Run(
+    const run = await createBuiltInRun(
       actor,
       agentId,
       "new run after allowance cancellation",
@@ -849,7 +897,9 @@ describe("Usage Allowance", () => {
     });
     const runCreatedAt = nowDate();
     mockNow(runCreatedAt);
-    const { actor, orgId, agentId } = await vm0AllowanceActor({ credits: 100 });
+    const { actor, orgId, agentId } = await builtInAllowanceActor({
+      credits: 100,
+    });
     const api = createRunsApi(context);
     await api.ensureOrgModelProvider(actor);
     // BYOK runs do not receive built-in credit admission, and this run

--- a/turbo/apps/api/src/signals/routes/test-run-fixture.ts
+++ b/turbo/apps/api/src/signals/routes/test-run-fixture.ts
@@ -20,7 +20,7 @@ const c = initContract();
 export const runFixtureContract = c.router({
   create: {
     method: "POST",
-    path: "/api/test/zero-run-fixture",
+    path: "/api/test/agent-run-fixture",
     headers: authHeadersSchema,
     body: runCreateBodySchema,
     responses: {

--- a/turbo/apps/api/src/signals/routes/test-runtime-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-runtime-state.ts
@@ -483,7 +483,7 @@ async function seedBuiltInDefaultModelKey(
 ): Promise<string> {
   const selectedModel = MODEL_PROVIDER_TYPES["built-in"].defaultModel;
   if (!selectedModel) {
-    throw new Error("Expected vm0 to define a default model");
+    throw new Error("Expected the built-in provider to define a default model");
   }
   return await seedBuiltInModelKey(db, fixtureId, selectedModel, signal);
 }
@@ -551,13 +551,13 @@ type BuiltInModelAction = Extract<
   TestRuntimeStateActionBody,
   {
     action:
-      | "seed-vm0-built-in-default-model-key"
-      | "seed-vm0-built-in-model-key"
-      | "seed-vm0-built-in-model-candidate-keys"
-      | "delete-vm0-built-in-model-key"
-      | "resolve-vm0-built-in-model-route"
-      | "set-vm0-built-in-candidate-cooldown"
-      | "delete-vm0-built-in-candidate-cooldown";
+      | "seed-built-in-default-model-key"
+      | "seed-built-in-model-key"
+      | "seed-built-in-model-candidate-keys"
+      | "delete-built-in-model-key"
+      | "resolve-built-in-model-route"
+      | "set-built-in-candidate-cooldown"
+      | "delete-built-in-candidate-cooldown";
   }
 >;
 
@@ -565,19 +565,19 @@ function isBuiltInModelAction(
   body: TestRuntimeStateActionBody,
 ): body is BuiltInModelAction {
   return [
-    "seed-vm0-built-in-default-model-key",
-    "seed-vm0-built-in-model-key",
-    "seed-vm0-built-in-model-candidate-keys",
-    "delete-vm0-built-in-model-key",
-    "resolve-vm0-built-in-model-route",
-    "set-vm0-built-in-candidate-cooldown",
-    "delete-vm0-built-in-candidate-cooldown",
+    "seed-built-in-default-model-key",
+    "seed-built-in-model-key",
+    "seed-built-in-model-candidate-keys",
+    "delete-built-in-model-key",
+    "resolve-built-in-model-route",
+    "set-built-in-candidate-cooldown",
+    "delete-built-in-candidate-cooldown",
   ].includes(body.action);
 }
 
 type SetBuiltInCandidateCooldownAction = Extract<
   BuiltInModelAction,
-  { action: "set-vm0-built-in-candidate-cooldown" }
+  { action: "set-built-in-candidate-cooldown" }
 >;
 
 async function setBuiltInCandidateCooldown(
@@ -605,7 +605,7 @@ async function setBuiltInCandidateCooldown(
 
 type DeleteBuiltInCandidateCooldownAction = Extract<
   BuiltInModelAction,
-  { action: "delete-vm0-built-in-candidate-cooldown" }
+  { action: "delete-built-in-candidate-cooldown" }
 >;
 
 async function deleteBuiltInCandidateCooldown(
@@ -623,13 +623,13 @@ async function deleteBuiltInCandidateCooldown(
     );
 }
 
-async function vm0BuiltInModelActionResponse(
+async function builtInModelActionResponse(
   db: Db,
   body: BuiltInModelAction,
   signal: AbortSignal,
 ) {
   switch (body.action) {
-    case "seed-vm0-built-in-default-model-key": {
+    case "seed-built-in-default-model-key": {
       return {
         status: 200 as const,
         body: {
@@ -642,7 +642,7 @@ async function vm0BuiltInModelActionResponse(
         },
       };
     }
-    case "seed-vm0-built-in-model-key": {
+    case "seed-built-in-model-key": {
       return {
         status: 200 as const,
         body: {
@@ -656,7 +656,7 @@ async function vm0BuiltInModelActionResponse(
         },
       };
     }
-    case "seed-vm0-built-in-model-candidate-keys": {
+    case "seed-built-in-model-candidate-keys": {
       return {
         status: 200 as const,
         body: {
@@ -670,11 +670,11 @@ async function vm0BuiltInModelActionResponse(
         },
       };
     }
-    case "delete-vm0-built-in-model-key": {
+    case "delete-built-in-model-key": {
       await deleteBuiltInModelKey(db, body.fixture_id, signal);
       return { status: 200 as const, body: { ok: true as const } };
     }
-    case "resolve-vm0-built-in-model-route": {
+    case "resolve-built-in-model-route": {
       const route = await resolveBuiltInModelRuntimeRoute(
         db,
         body.selected_model,
@@ -690,12 +690,12 @@ async function vm0BuiltInModelActionResponse(
         },
       };
     }
-    case "set-vm0-built-in-candidate-cooldown": {
+    case "set-built-in-candidate-cooldown": {
       await setBuiltInCandidateCooldown(db, body);
       signal.throwIfAborted();
       return { status: 200 as const, body: { ok: true as const } };
     }
-    case "delete-vm0-built-in-candidate-cooldown": {
+    case "delete-built-in-candidate-cooldown": {
       await deleteBuiltInCandidateCooldown(db, body);
       signal.throwIfAborted();
       return { status: 200 as const, body: { ok: true as const } };
@@ -2590,7 +2590,7 @@ const postRuntimeStateAction$ = command(
       return await compatibilityFixtureActionResponse(db, body, signal);
     }
     if (isBuiltInModelAction(body)) {
-      return await vm0BuiltInModelActionResponse(db, body, signal);
+      return await builtInModelActionResponse(db, body, signal);
     }
     const specializedFixture = await set(
       specializedRuntimeFixtureAction$,

--- a/turbo/apps/api/src/signals/routes/test-slack-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-state.ts
@@ -216,11 +216,11 @@ async function seedBuiltInModelKeys(db: Db, agentId: string): Promise<void> {
   await acquireBuiltInModelKeyFixture(
     db,
     agentId,
-    vm0BuiltInModelKeyRows(agentId),
+    builtInModelKeyRows(agentId),
   );
 }
 
-function vm0BuiltInModelKeyRows(agentId: string) {
+function builtInModelKeyRows(agentId: string) {
   return [
     {
       vendor: getBuiltInVendor(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL),

--- a/turbo/apps/api/src/signals/routes/test-teams-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-teams-state.ts
@@ -257,11 +257,11 @@ async function seedBuiltInModelKeys(db: Db, agentId: string): Promise<void> {
   await db.delete(builtInModelKeys).where(eq(builtInModelKeys.label, agentId));
   await db
     .insert(builtInModelKeys)
-    .values(vm0BuiltInModelKeyRows(agentId))
+    .values(builtInModelKeyRows(agentId))
     .onConflictDoNothing({ target: builtInModelKeys.vendor });
 }
 
-function vm0BuiltInModelKeyRows(agentId: string) {
+function builtInModelKeyRows(agentId: string) {
   return [
     {
       vendor: getBuiltInVendor(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL),
@@ -294,7 +294,7 @@ async function deleteBuiltInModelKeysForSeededDefaultAgent(
     return;
   }
 
-  const apiKeys = vm0BuiltInModelKeyRows(agent.id).map((row) => {
+  const apiKeys = builtInModelKeyRows(agent.id).map((row) => {
     return row.apiKey;
   });
   await db

--- a/turbo/apps/api/src/signals/services/__tests__/agent-draft-write.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-draft-write.service.test.ts
@@ -138,7 +138,7 @@ test("keeps Agent Draft runtime writes free of relation-specific conflict SQL", 
   expect(runtimeSource).not.toMatch(
     /\bonConflict(?:DoNothing|DoUpdate)\b|\bON\s+CONFLICT\b|\bMERGE\b/i,
   );
-  expect(runtimeSource).not.toMatch(/\b(?:zero_agent_drafts|agent_drafts)\b/);
+  expect(runtimeSource).not.toMatch(/\bagent_drafts\b/);
 });
 
 describe.each([

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1476,12 +1476,12 @@ function frameworkForProviderSelection(
   if (!isBuiltInModelProviderType(providerType)) {
     return getFrameworkForType(providerType);
   }
-  const vm0Model =
+  const builtInModel =
     selectedModel ?? MODEL_PROVIDER_TYPES["built-in"].defaultModel;
-  if (!vm0Model) {
+  if (!builtInModel) {
     return null;
   }
-  return getFrameworkForType(getBuiltInConcreteProviderType(vm0Model));
+  return getFrameworkForType(getBuiltInConcreteProviderType(builtInModel));
 }
 
 async function resolveRequestedRunFramework(
@@ -2434,7 +2434,7 @@ async function multiAuthModelProviderEnvironment(
   };
 }
 
-async function vm0ModelProviderEnvironment(
+async function builtInModelProviderEnvironment(
   db: Db,
   selectedModel: string,
   resolvedRoute?: BuiltInModelRuntimeRoute,
@@ -2842,7 +2842,7 @@ async function resolveCandidateModelProviderEnvironment(
       args.selectedModelOverride ??
       row.selectedModel ??
       MODEL_PROVIDER_TYPES["built-in"].defaultModel;
-    const provider = await vm0ModelProviderEnvironment(
+    const provider = await builtInModelProviderEnvironment(
       db,
       selectedModel,
       args.builtInModelRuntimeRoute,
@@ -2913,7 +2913,7 @@ async function resolveModelProviderEnvironment(
   args: ResolveModelProviderEnvironmentArgs,
 ): Promise<ResolvedModelProviderEnvironment | null> {
   if (isBuiltInModelProviderType(args.modelProviderType)) {
-    const provider = await vm0ModelProviderEnvironment(
+    const provider = await builtInModelProviderEnvironment(
       db,
       args.selectedModelOverride ??
         MODEL_PROVIDER_TYPES["built-in"].defaultModel,

--- a/turbo/apps/api/src/signals/services/built-in-model-key-fixture.ts
+++ b/turbo/apps/api/src/signals/services/built-in-model-key-fixture.ts
@@ -7,7 +7,7 @@ import type { Db } from "../external/db";
 import { safeJsonParse } from "../utils";
 
 const BUILT_IN_MODEL_KEY_FIXTURE_LABEL_KIND = "runtime-state-fixture";
-const vm0BuiltInModelKeyFixtureLabelSchema = z.object({
+const builtInModelKeyFixtureLabelSchema = z.object({
   kind: z.literal(BUILT_IN_MODEL_KEY_FIXTURE_LABEL_KIND),
   fixtureIds: z.array(z.string().uuid()).min(1),
   preservedLabel: z.string().nullable().optional(),
@@ -18,7 +18,7 @@ interface BuiltInModelKeyRow {
   readonly apiKey: string;
 }
 
-function vm0BuiltInModelKeyFixtureLabel(
+function builtInModelKeyFixtureLabel(
   fixtureIds: readonly string[],
   preservedLabel?: string | null,
 ): string {
@@ -33,14 +33,14 @@ function parseBuiltInModelKeyFixtureLabel(label: string | null) {
   if (!label) {
     return null;
   }
-  const parsed = vm0BuiltInModelKeyFixtureLabelSchema.safeParse(
+  const parsed = builtInModelKeyFixtureLabelSchema.safeParse(
     safeJsonParse(label),
   );
   return parsed.success ? parsed.data : null;
 }
 
 /**
- * Acquires fixture ownership of vendor-scoped VM0 keys.
+ * Acquires fixture ownership of vendor-scoped built-in model keys.
  *
  * No product API provisions this platform-managed table. Test routes from
  * different integrations share each vendor row, so every owner must be
@@ -58,7 +58,7 @@ export async function acquireBuiltInModelKeyFixture(
         .insert(builtInModelKeys)
         .values({
           ...value,
-          label: vm0BuiltInModelKeyFixtureLabel([fixtureId]),
+          label: builtInModelKeyFixtureLabel([fixtureId]),
         })
         .onConflictDoUpdate({
           target: builtInModelKeys.vendor,
@@ -74,7 +74,7 @@ export async function acquireBuiltInModelKeyFixture(
         });
       if (!row) {
         throw new Error(
-          `Expected VM0 built-in key for vendor: ${value.vendor}`,
+          `Expected built-in model key for vendor: ${value.vendor}`,
         );
       }
 
@@ -93,7 +93,7 @@ export async function acquireBuiltInModelKeyFixture(
       await tx
         .update(builtInModelKeys)
         .set({
-          label: vm0BuiltInModelKeyFixtureLabel(fixtureIds, preservedLabel),
+          label: builtInModelKeyFixtureLabel(fixtureIds, preservedLabel),
           updatedAt: nowDate(),
         })
         .where(eq(builtInModelKeys.id, row.id));
@@ -129,7 +129,7 @@ export async function releaseBuiltInModelKeyFixture(
         await tx
           .update(builtInModelKeys)
           .set({
-            label: vm0BuiltInModelKeyFixtureLabel(
+            label: builtInModelKeyFixtureLabel(
               remainingFixtureIds,
               fixtureLabel.preservedLabel,
             ),

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -72,12 +72,12 @@ import { createUserMessageDocument } from "../signals/services/chat-user-message
 import { createDeferredPromise, onRejection } from "../signals/utils";
 
 /**
- * BDD-scoped vm0 built-in model key prefixes. Fixture acquisition below only accepts
- * keys carrying one of these prefixes.
+ * BDD-scoped built-in model key prefixes. Fixture acquisition below only
+ * accepts keys carrying one of these prefixes.
  */
-const VM0_BDD_API_KEY_PREFIXES = [
-  "vm0-key-bdd-fake-",
-  "vm0-key-bdd-dev-seed-",
+const BDD_BUILT_IN_MODEL_KEY_PREFIXES = [
+  "built-in-key-bdd-fake-",
+  "built-in-key-bdd-dev-seed-",
 ] as const;
 const databasePidRowSchema = z.object({ pid: z.int() });
 const databaseConnectionOwnerRowSchema = z.object({
@@ -1889,27 +1889,27 @@ async function pidIsDirectlyBlockedBy(
 }
 
 /**
- * Acquires bdd-scoped ownership of the platform-managed vm0 API key pool for
- * one vendor.
+ * Acquires bdd-scoped ownership of the platform-managed built-in model key
+ * pool for one vendor.
  *
- * Why product APIs cannot construct this state: vm0_api_keys is a
+ * Why product APIs cannot construct this state: built_in_model_keys is a
  * platform-operations table with no product write surface — keys are
  * provisioned out of band. Keys passed here must carry a
- * VM0_BDD_API_KEY_PREFIXES prefix. The shared fixture service atomically
+ * BDD_BUILT_IN_MODEL_KEY_PREFIXES prefix. The shared fixture service atomically
  * arbitrates the vendor-unique row and prevents one test owner from deleting
  * another owner's key.
  */
-export async function acquireBddVm0ApiKey(args: {
+export async function acquireBddBuiltInModelKey(args: {
   readonly fixtureId: string;
   readonly vendor: string;
   readonly apiKey: string;
 }): Promise<string> {
-  const scoped = VM0_BDD_API_KEY_PREFIXES.some((prefix) => {
+  const scoped = BDD_BUILT_IN_MODEL_KEY_PREFIXES.some((prefix) => {
     return args.apiKey.length > prefix.length && args.apiKey.startsWith(prefix);
   });
   if (!scoped) {
     throw new Error(
-      `acquireBddVm0ApiKey: api key must start with one of ${VM0_BDD_API_KEY_PREFIXES.join(", ")}`,
+      `acquireBddBuiltInModelKey: api key must start with one of ${BDD_BUILT_IN_MODEL_KEY_PREFIXES.join(", ")}`,
     );
   }
   const [acquired] = await acquireBuiltInModelKeyFixture(db(), args.fixtureId, [
@@ -1919,13 +1919,13 @@ export async function acquireBddVm0ApiKey(args: {
     },
   ]);
   if (!acquired) {
-    throw new Error(`Expected VM0 built-in key for vendor: ${args.vendor}`);
+    throw new Error(`Expected built-in model key for vendor: ${args.vendor}`);
   }
   return acquired.apiKey;
 }
 
 /** Releases only this bdd fixture's ownership of its vendor key. */
-export async function releaseBddVm0ApiKey(args: {
+export async function releaseBddBuiltInModelKey(args: {
   readonly fixtureId: string;
 }): Promise<void> {
   await releaseBuiltInModelKeyFixture(db(), args.fixtureId);

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -593,7 +593,7 @@ describe("model-first canonical catalog", () => {
   });
 
   it.each(["deepseek-v4-flash", "deepseek-v4-pro"] as const)(
-    "routes vm0 built-in model %s directly through DeepSeek",
+    "routes built-in model %s directly through DeepSeek",
     (model) => {
       expect(getBuiltInConcreteProviderType(model)).toBe("deepseek");
       expect(getBuiltInVendor(model)).toBe("deepseek");
@@ -609,7 +609,7 @@ describe("model-first canonical catalog", () => {
     "claude-sonnet-5",
     "claude-sonnet-4-6",
   ] as const)(
-    "routes vm0 built-in model %s directly through Anthropic",
+    "routes built-in model %s directly through Anthropic",
     (model) => {
       expect(getBuiltInConcreteProviderType(model)).toBe("anthropic-api-key");
       expect(getBuiltInVendor(model)).toBe("anthropic");
@@ -725,7 +725,7 @@ describe("model-first canonical catalog", () => {
     ).toBe(LIMITED_FREE1_DEFAULT_RUN_MODEL);
   });
 
-  it("exposes VM0 price tiers for built-in reasoning models", () => {
+  it("exposes price tiers for built-in reasoning models", () => {
     expect(BUILT_IN_MODEL_PRICE_TIER).toEqual(
       expect.objectContaining({
         "claude-fable-5-1": "$$$$",
@@ -849,7 +849,7 @@ describe("model selection for Claude-compatible gateway providers", () => {
 });
 
 describe("getBuiltInVisibleModels", () => {
-  it("returns only active VM0 built-in models", () => {
+  it("returns only active built-in models", () => {
     const models = getBuiltInVisibleModels();
     expect(models).toEqual(ACTIVE_RUN_MODELS);
     expect(models).toContain("gpt-5.5");

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -533,7 +533,7 @@ export {
   // Firewall gateway for model providers
   MODEL_PROVIDER_FIREWALL_CONFIGS,
   getModelProviderFirewall,
-  // VM0 built-in provider
+  // Built-in provider
   BUILT_IN_MODEL_TO_PROVIDER,
   BUILT_IN_MODEL_ROUTE_PROVIDERS,
   BUILT_IN_MODEL_ALIAS_TO_MODEL,

--- a/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-price-tiers.ts
@@ -1,5 +1,5 @@
 /**
- * Canonical VM0 built-in run models and Built-in credit price tiers.
+ * Canonical built-in run models and credit price tiers.
  *
  * Keep this module lightweight so public UI surfaces can read price tier data
  * without importing the full model provider contract schema.

--- a/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
@@ -192,7 +192,7 @@ function mpFirewall(
  * Used to auto-generate firewall entries that protect API tokens from sandbox exposure.
  * Excluded: aws-bedrock (dynamic region URLs + SigV4), azure-foundry (dynamic resource URLs).
  *
- * Claude Code gateway providers scope to /v1/messages so vm0-built-in API keys
+ * Claude Code gateway providers scope to /v1/messages so built-in model keys
  * are only injected on LLM inference paths, not vendor admin endpoints.
  */
 export const MODEL_PROVIDER_FIREWALL_CONFIGS = {

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -261,7 +261,7 @@ export function getDefaultOrgModelPolicySeed(
 }
 
 /**
- * Mapping from VM0 built-in model names to their concrete provider type and vendor.
+ * Mapping from built-in model names to their concrete provider type and vendor.
  * Used at build-context time to resolve the meta-provider to a real provider.
  */
 export const BUILT_IN_MODEL_ROUTE_PROVIDERS = {
@@ -413,7 +413,7 @@ export interface BuiltInModelRouteTarget {
   readonly vendor: string;
 }
 
-function vm0PrimaryCandidate(model: string): BuiltInModelRouteCandidate {
+function builtInPrimaryCandidate(model: string): BuiltInModelRouteCandidate {
   if (!isActiveRunModel(model)) {
     throw new Error(
       `Unknown VM0 model "${model}". Valid models: ${Object.keys(BUILT_IN_MODEL_TO_PROVIDER).join(", ")}`,
@@ -548,7 +548,7 @@ export function modelSupportsImageInput(
 }
 
 /**
- * Return the VM0 built-in models visible to callers.
+ * Return the built-in models visible to callers.
  */
 export function getBuiltInVisibleModels(): string[] {
   return [...ACTIVE_RUN_MODELS];
@@ -1100,7 +1100,7 @@ export function getProviderRuntimeModel(
     return model;
   }
   if (isBuiltInModelProviderType(type)) {
-    return vm0PrimaryCandidate(canonical).apiModel ?? canonical;
+    return builtInPrimaryCandidate(canonical).apiModel ?? canonical;
   }
   return PROVIDER_RUNTIME_MODEL_ALIASES[type]?.[canonical] ?? canonical;
 }
@@ -1142,30 +1142,30 @@ export const modelProviderWriteTypeSchema = z.enum(MODEL_PROVIDER_TYPE_IDS);
 export const modelProviderFrameworkSchema = z.enum(["claude-code", "codex"]);
 
 /**
- * Get the concrete provider type for a VM0 built-in model.
- * Throws if the model is not in the VM0 model mapping.
+ * Get the concrete provider type for a built-in model.
+ * Throws if the model is not in the built-in model mapping.
  */
 export function getBuiltInConcreteProviderType(
   model: string,
 ): BuiltInModelRouteProviderType {
-  return vm0PrimaryCandidate(model).concreteType;
+  return builtInPrimaryCandidate(model).concreteType;
 }
 
 /**
- * Get the vendor name for a VM0 built-in model.
+ * Get the vendor name for a built-in model.
  * Used for key pool lookup.
  */
 export function getBuiltInVendor(model: string): string {
-  const providerType = vm0PrimaryCandidate(model).concreteType;
+  const providerType = builtInPrimaryCandidate(model).concreteType;
   return BUILT_IN_MODEL_ROUTE_PROVIDERS[providerType].vendor;
 }
 
 /**
- * Get the upstream API model identifier for a VM0 built-in model.
+ * Get the upstream API model identifier for a built-in model.
  * Falls back to the display name when no override is configured.
  */
 export function getBuiltInApiModel(model: string): string {
-  return vm0PrimaryCandidate(model).apiModel ?? model;
+  return builtInPrimaryCandidate(model).apiModel ?? model;
 }
 
 /**
@@ -1264,7 +1264,7 @@ export function getModelProviderEnvBindings(
 }
 
 /**
- * Get VM0-owned Codex provider metadata for a static model provider.
+ * Get built-in Codex provider metadata for a static model provider.
  */
 export function getModelProviderCodexRuntimeConfig(
   type: ModelProviderType,

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -140,8 +140,8 @@ const unifiedRunRequestSchema = z
     permissionPolicies: firewallPoliciesSchema.optional(),
 
     // Internal: pin provider type for direct CLI runs used by E2E.
-    // The built-in provider is intentionally excluded here because only Zero
-    // runs enforce built-in-provider credits.
+    // The built-in provider is intentionally excluded here because direct CLI
+    // runs do not enforce built-in-provider credits.
     modelProviderType: directRunModelProviderTypeSchema.optional(),
   })
   .strict();
@@ -209,7 +209,7 @@ const runResultSchema = z.object({
 });
 
 /**
- * Run state schema (replaces vm0_start/vm0_result/vm0_error events)
+ * Run state schema for the current lifecycle event contract.
  */
 const runStateSchema = z.object({
   status: runStatusSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-runtime-state.ts
@@ -18,36 +18,36 @@ const builtInModelRuntimeRouteSchema = z.object({
 
 export const testRuntimeStateActionBodySchema = z.discriminatedUnion("action", [
   z.object({
-    action: z.literal("seed-vm0-built-in-default-model-key"),
+    action: z.literal("seed-built-in-default-model-key"),
     fixture_id: z.uuid(),
   }),
   z.object({
-    action: z.literal("seed-vm0-built-in-model-key"),
-    fixture_id: z.uuid(),
-    selected_model: z.string(),
-  }),
-  z.object({
-    action: z.literal("delete-vm0-built-in-model-key"),
-    fixture_id: z.uuid(),
-  }),
-  z.object({
-    action: z.literal("seed-vm0-built-in-model-candidate-keys"),
+    action: z.literal("seed-built-in-model-key"),
     fixture_id: z.uuid(),
     selected_model: z.string(),
   }),
   z.object({
-    action: z.literal("resolve-vm0-built-in-model-route"),
+    action: z.literal("delete-built-in-model-key"),
+    fixture_id: z.uuid(),
+  }),
+  z.object({
+    action: z.literal("seed-built-in-model-candidate-keys"),
+    fixture_id: z.uuid(),
     selected_model: z.string(),
   }),
   z.object({
-    action: z.literal("set-vm0-built-in-candidate-cooldown"),
+    action: z.literal("resolve-built-in-model-route"),
+    selected_model: z.string(),
+  }),
+  z.object({
+    action: z.literal("set-built-in-candidate-cooldown"),
     selected_model: z.string(),
     provider_type: z.string(),
     upstream_model: z.string(),
     unavailable_until: z.iso.datetime(),
   }),
   z.object({
-    action: z.literal("delete-vm0-built-in-candidate-cooldown"),
+    action: z.literal("delete-built-in-candidate-cooldown"),
     selected_model: z.string(),
     provider_type: z.string(),
     upstream_model: z.string(),


### PR DESCRIPTION
## Summary

- rename the scoped built-in-model symbols, test-only action literals, fixture route, prefixes, helpers, and local variables to current terminology
- update stale built-in-path test and documentation wording, including the actual `built_in_model_keys` concept
- remove only the three retired `zeroWebSearch` absence assertions while retaining adjacent current behavior coverage

## Scope boundaries

- preserves `restrictedVm0Models`, `vm0_model_key_id`, `zero_runs_`, persisted `vm0/default` model IDs, numeric-zero names, and public vm0 identities
- leaves `api_dispatch_check_vm0_credits` and the `api:zero-*-model-providers` observability categories to #32242
- adds no compatibility reader, classifier, scanner, baseline, lint rule, or tombstone test
- does not change routing, admission, billing, token, model selection, or credential behavior

## Validation

- Prettier check for all 28 changed files
- `pnpm --filter @okouai/api-contracts lint`
- `pnpm --filter api lint`
- `pnpm --filter @okouai/api-contracts check-types`
- `pnpm --filter api check-types`
- `bash -n e2e/helpers/runner-api.bash`
- 661 focused tests passed across the affected API-contract, dev-seed, fixture, allowance, chat-events, and run-lifecycle suites
- scoped residual-name, preserved-identity, caller, schema, helper, and open-PR overlap scans

Closes #32239
