### PR TITLE
test(platform): avoid stale stop button handle

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-state.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-state.test.tsx
@@ -323,9 +323,13 @@ test("Manage work waiting in the queue", async () => {
   );
   publishRunUpdate();
   await expect(screen.findByText("Queued audit")).resolves.toBeVisible();
-  await expect(findButton("Stop")).resolves.toBeVisible();
+  await waitFor(() => {
+    expect(queryButton("Stop")).toBeVisible();
+  });
 
-  click(await findButton("Stop"));
+  const stopButton = requiredButton("Stop", document.body);
+  expect(stopButton).toBeVisible();
+  click(stopButton);
   events.push(
     cancelledEvent({ id: "second-cancelled", runId: RUN_B, seqId: 10 }),
     {


### PR DESCRIPTION
## Summary

- keep the queued-run Stop assertion bound to the current DOM instead of an element returned by an earlier async query
- synchronously re-read and click the visible Stop button so a render between awaits cannot leave the test holding a detached node
- preserve the existing queued cancellation and follow-up behavior without changing production code, timeouts, or test coverage

## Validation

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-run-state.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit hook: Prettier, full Knip, full Turbo type checking, file-size check
- CI-equivalent app shard: the target test passed; the local shard reported unrelated five-second timeouts across ten other test files while the shared host load average exceeded 80

Closes #32252
