### PR TITLE
fix(platform): keep the microphone button stable when switching conversations

### DIFF
--- a/turbo/apps/platform/src/signals/external/voice-draft-store.ts
+++ b/turbo/apps/platform/src/signals/external/voice-draft-store.ts
@@ -111,14 +111,15 @@ export async function createVoiceDraftRecording(
   );
 }
 
+/** Append one PCM chunk and return the recording as stored afterwards. */
 export async function appendVoiceDraftSamples(
   key: string,
   id: string,
   sequence: number,
   samples: Float32Array,
-): Promise<void> {
+): Promise<VoiceDraftRecordingRecord> {
   const database = await openVoiceDraftRecordingDatabase();
-  await withCleanup(
+  return await withCleanup(
     runIndexedDbTransaction(
       {
         database: "voice_drafts",
@@ -141,16 +142,13 @@ export async function appendVoiceDraftSamples(
             .objectStore("chunks")
             .add(samples.slice().buffer, [key, id, sequence]),
         );
-        await track(
-          drafts.put(
-            {
-              ...recording,
-              chunkCount: sequence + 1,
-              sampleCount: recording.sampleCount + samples.length,
-            },
-            key,
-          ),
-        );
+        const appended = {
+          ...recording,
+          chunkCount: sequence + 1,
+          sampleCount: recording.sampleCount + samples.length,
+        };
+        await track(drafts.put(appended, key));
+        return appended;
       },
     ),
     () => {

--- a/turbo/apps/platform/src/signals/okou-page/composer-voice-input.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-voice-input.ts
@@ -12,7 +12,6 @@ import {
   onRef,
   onRejection,
   settle,
-  withCleanup,
   createChildAbortController,
 } from "../utils.ts";
 import { voiceInputV2Enabled$ } from "../external/feature-switch.ts";
@@ -49,6 +48,12 @@ interface ComposerVoiceInputState {
   readonly status: "idle" | "recording" | "failed";
   readonly recording: VoiceDraftRecordingRecord | null;
   readonly message?: string;
+}
+// The recording this composer last created, appended to, or removed under a
+// storage key. Storage is only read for a key this composer has not changed.
+interface OwnedVoiceDraftRecording {
+  readonly key: string;
+  readonly recording: VoiceDraftRecordingRecord | null;
 }
 export type ComposerVoiceInputSignals = ReturnType<
   typeof createComposerVoiceInputSignals
@@ -113,27 +118,36 @@ function createVoiceDraftData(draftTarget: string) {
     const identity = await get(authenticatedIdentity$);
     return JSON.stringify([identity.userId, identity.orgId, draftTarget]);
   });
-  const revision$ = state(0);
-  // A successful text handoff consumes this recording even if local deletion
-  // fails. Keep that domain fact so Retry cannot insert the same text twice.
-  const deliveredRecordingId$ = state<string | null>(null);
+  const storedRecording$ = computed(
+    async (get): Promise<VoiceDraftRecordingRecord | null> => {
+      const key = await get(storageKey$);
+      return await readVoiceDraftRecording(key);
+    },
+  );
+  const ownedRecording$ = state<OwnedVoiceDraftRecording | null>(null);
+  // Mutations record their own outcome, so the recording never waits for a
+  // second storage read after this composer has changed it.
   const recording$ = computed(
     async (get): Promise<VoiceDraftRecordingRecord | null> => {
       if (!get(voiceInputV2Enabled$)) {
         return null;
       }
-      get(revision$);
-      const deliveredId = get(deliveredRecordingId$);
+      const owned = get(ownedRecording$);
       const key = await get(storageKey$);
-      const recording = await readVoiceDraftRecording(key);
-      return recording?.id === deliveredId ? null : recording;
+      return owned?.key === key ? owned.recording : await get(storedRecording$);
     },
   );
-  const reload$ = command(({ set }) => {
-    set(revision$, (value) => {
-      return value + 1;
-    });
-  });
+  // Retry reads storage again so a failed restore can recover and a recording
+  // saved by another composer for the same target can be transcribed.
+  const restoreRecording$ = command(
+    async ({ get, set }, signal: AbortSignal) => {
+      const key = await get(storageKey$);
+      signal.throwIfAborted();
+      const recording = await readVoiceDraftRecording(key);
+      signal.throwIfAborted();
+      set(ownedRecording$, { key, recording });
+    },
+  );
   const capture = createVoiceDraftCaptureSignals();
   const captureError$ = state<unknown>(null);
   const state$ = computed(async (get): Promise<ComposerVoiceInputState> => {
@@ -158,9 +172,9 @@ function createVoiceDraftData(draftTarget: string) {
   });
   return {
     storageKey$,
-    deliveredRecordingId$,
+    ownedRecording$,
     recording$,
-    reload$,
+    restoreRecording$,
     capture,
     captureError$,
     state$,
@@ -176,7 +190,7 @@ function createVoiceDraftTranscription(
   readEditorContext$: Command<VoiceIoEditorContext, []>,
   lastAssistantMessage$: Computed<string | undefined>,
 ) {
-  const { recording$, storageKey$, deliveredRecordingId$, reload$ } = data;
+  const { recording$, storageKey$, ownedRecording$ } = data;
   const incremental = createVoiceDraftTranscriptionSignals({
     storageKey$,
     readContext$: command(({ get, set }) => {
@@ -206,13 +220,14 @@ function createVoiceDraftTranscription(
     }
 
     signal.throwIfAborted();
-    set(deliveredRecordingId$, recording.id);
+    // A successful text handoff consumes this recording even if local deletion
+    // fails, so Retry cannot insert the same text twice.
+    set(ownedRecording$, { key, recording: null });
     const removed = await settle(
       deleteVoiceDraftRecording(key, recording.id),
       signal,
     );
     signal.throwIfAborted();
-    set(reload$);
     if (!removed.ok) {
       L.error("Voice recording cleanup failed", removed.error);
       toast.error(
@@ -238,24 +253,24 @@ function createVoiceDraftMutations(
   appendTranscription$: Command<Promise<void>, [boolean, AbortSignal]>,
   cancelTranscription$: VoiceDraftCommand,
 ) {
-  const { recording$, storageKey$, reload$, capture, captureError$ } = data;
+  const { recording$, storageKey$, ownedRecording$, capture, captureError$ } =
+    data;
   const discard$ = command(async ({ get, set }, signal: AbortSignal) => {
     await set(cancelTranscription$, signal);
     signal.throwIfAborted();
     const recording = await get(recording$);
     signal.throwIfAborted();
-    if (recording) {
-      const key = await get(storageKey$);
-      signal.throwIfAborted();
-      await withVoiceDraftFailureToast(
-        deleteVoiceDraftRecording(key, recording.id),
-        signal,
-      );
-      signal.throwIfAborted();
+    if (!recording) {
+      return;
     }
-    set(reload$);
-    await get(recording$);
+    const key = await get(storageKey$);
     signal.throwIfAborted();
+    await withVoiceDraftFailureToast(
+      deleteVoiceDraftRecording(key, recording.id),
+      signal,
+    );
+    signal.throwIfAborted();
+    set(ownedRecording$, { key, recording: null });
   });
   const start$ = command(async ({ get, set }, signal: AbortSignal) => {
     const quota = await get(audioInputQuota$);
@@ -272,17 +287,19 @@ function createVoiceDraftMutations(
       signal,
     );
     signal.throwIfAborted();
-    set(reload$);
+    set(ownedRecording$, { key, recording });
     if (recording.id !== id) {
       return;
     }
     await set(initializeTranscription$, signal);
     const removeEmptyRecording = async () => {
+      // Storage orders this read after every committed chunk write, so audio
+      // that was still being saved when capture stopped is kept.
       const current = await readVoiceDraftRecording(key);
       if (current?.id === id && current.sampleCount === 0) {
         await deleteVoiceDraftRecording(key, id);
+        set(ownedRecording$, { key, recording: null });
       }
-      set(reload$);
     };
     set(captureError$, null);
     const started = await withVoiceDraftFailureToast(
@@ -291,7 +308,17 @@ function createVoiceDraftMutations(
           capture.start$,
           {
             append: async (samples, sequence) => {
-              await appendVoiceDraftSamples(key, id, sequence, samples);
+              const appended = await appendVoiceDraftSamples(
+                key,
+                id,
+                sequence,
+                samples,
+              );
+              set(ownedRecording$, (owned) => {
+                return owned?.recording?.id === id
+                  ? { key, recording: appended }
+                  : owned;
+              });
               signal.throwIfAborted();
               await set(appendTranscription$, false, signal);
             },
@@ -300,7 +327,6 @@ function createVoiceDraftMutations(
               toast.error(voiceDraftStorageFailedMessage());
               set(captureError$, error);
               set(capture.cancel$);
-              set(reload$);
             },
           },
           signal,
@@ -316,11 +342,9 @@ function createVoiceDraftMutations(
     }
   });
   const finish$ = command(async ({ get, set }, signal: AbortSignal) => {
-    const finished = await withCleanup(
-      withVoiceDraftFailureToast(set(capture.finish$, signal), signal),
-      () => {
-        return set(reload$);
-      },
+    const finished = await withVoiceDraftFailureToast(
+      set(capture.finish$, signal),
+      signal,
     );
     signal.throwIfAborted();
     if (finished && !get(captureError$)) {
@@ -336,7 +360,7 @@ function createVoiceActionBindings(
   legacyToggle$: ReturnType<typeof createLegacyVoiceToggle>,
   watch$: VoiceDraftCommand,
 ) {
-  const { state$, capture, reload$ } = data;
+  const { state$, capture, restoreRecording$ } = data;
   const { start$, finish$, discard$, transcribe$ } = mutations;
   const internalOwner$ = state<AbortController | null>(null);
   const owner$ = computed((get) => {
@@ -387,7 +411,7 @@ function createVoiceActionBindings(
       } else if (resolvedAction === "discard") {
         await set(discard$, signal);
       } else {
-        set(reload$);
+        await set(restoreRecording$, signal);
         await set(transcribe$, signal);
       }
       signal.throwIfAborted();
@@ -403,7 +427,6 @@ function createVoiceActionBindings(
           set(capture.cancel$);
           set(internalOwner$, null);
           set(element$, null);
-          set(reload$);
         },
         { once: true },
       );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-loading.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-loading.test.tsx
@@ -1,4 +1,5 @@
 import { agentDraftContract } from "@okouai/api-contracts/contracts/agent-draft";
+import { chatThreadDraftContract } from "@okouai/api-contracts/contracts/chat-threads";
 import { voiceIoQuotaContract } from "@okouai/api-contracts/contracts/voice-io-quota";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { act, screen, waitFor } from "@testing-library/react";
@@ -18,10 +19,12 @@ import {
   NEW_CHAT_PATH,
   queryButton,
   RUN_PATH,
+  RUN_THREAD_ID,
 } from "./chat-run-test-fixtures.ts";
 
 const flags = { [FeatureSwitchKey.VoiceInputV2]: true } as const;
 const OTHER_AGENT_ID = "c0000000-0000-4000-a000-000000000802";
+const OTHER_THREAD_ID = "b0000000-0000-4000-a000-000000000803";
 
 vi.mock("idb", async () => {
   return { ...(await vi.importActual<typeof import("idb")>("idb")) };
@@ -378,4 +381,89 @@ test("Preserve an explicit draft clear while the server baseline is pending", as
   await findEnabledButton("Send");
   expect(editor).toHaveTextContent("Voice note.");
   expect(editor).not.toHaveTextContent("Old saved notes.");
+});
+
+test("Keep voice input enabled while switching conversations", async () => {
+  const lifecycle = installRunChat({ threadTitle: "First conversation" });
+  context.mocks.browser.voiceInput({ rms: 0.12 });
+  context.mocks.api(voiceIoQuotaContract.get, ({ respond }) => {
+    return respond(200, { allowed: true, count: 0, limit: 60 });
+  });
+  context.mocks.http.post("*/api/voice-io/transcribe/segment", () => {
+    return HttpResponse.json({
+      transcript: "voice note",
+      polishedText: "Voice note.",
+      language: "en-US",
+    });
+  });
+  lifecycle.setThreadList([
+    {
+      id: RUN_THREAD_ID,
+      title: "First conversation",
+      agent: { id: AGENT_ID, avatarUrl: null },
+      createdAt: "2026-08-01T10:00:00.000Z",
+      updatedAt: "2026-08-01T10:02:00.000Z",
+      pinnedAt: null,
+    },
+    {
+      id: OTHER_THREAD_ID,
+      title: "Second conversation",
+      agent: { id: AGENT_ID, avatarUrl: null },
+      createdAt: "2026-08-01T10:01:00.000Z",
+      updatedAt: "2026-08-01T10:01:00.000Z",
+      pinnedAt: null,
+    },
+  ]);
+  context.mocks.api(chatThreadDraftContract.get, ({ params, respond }) => {
+    return respond(
+      200,
+      textContinuityDraft(
+        params.id === RUN_THREAD_ID
+          ? "First conversation."
+          : "Second conversation.",
+      ),
+    );
+  });
+
+  await setupPage({ context, path: RUN_PATH, featureSwitches: flags });
+  await findEnabledButton("Voice input");
+
+  const requested = context.mocks.deferred<void>();
+  const ready = context.mocks.deferred<void>();
+  const openDatabase = idb.openDB;
+  vi.spyOn(idb, "openDB").mockImplementation(
+    async (name, version, callbacks) => {
+      if (name === "okou-voice-drafts") {
+        if (!requested.settled()) {
+          requested.resolve();
+        }
+        await ready.promise;
+      }
+      return await openDatabase(name, version, callbacks);
+    },
+  );
+
+  click(await findLink("Second conversation"));
+  await requested.promise;
+  await waitFor(() => {
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveTextContent(
+      "Second conversation.",
+    );
+  });
+  // The stored draft of the new conversation is still being read.
+  expect(queryButton("Voice input")).toBeEnabled();
+  expect(queryButton("Retry")).toBeNull();
+
+  ready.resolve();
+  click(await findEnabledButton("Voice input"));
+  click(await findEnabledButton("Stop recording"));
+  await waitFor(() => {
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveTextContent(
+      "Voice note.",
+    );
+  });
+  expect(screen.getByRole("textbox", { name: "Message" })).toHaveTextContent(
+    "Second conversation.",
+  );
+  await findEnabledButton("Voice input");
 });

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8512,11 +8512,13 @@ function MicButton({
   signals: ComposerSignals;
   actions: ComposerActions;
 }) {
-  const available = useLastResolved(audioInputAvailable$) ?? false;
+  const available = useGet(audioInputAvailable$);
   const quotaState = useLoadableState(audioInputQuota$);
   const quotaResolved = useLastResolved(audioInputQuota$) !== undefined;
   const voiceInputV2Enabled = useGet(voiceInputV2Enabled$);
-  const voiceDraftStatus = useResolved(signals.voice.state$)?.status;
+  // The last resolved status keeps this control stable while a composer
+  // target reads its stored draft; run$ awaits that read before acting.
+  const voiceDraftStatus = useLastResolved(signals.voice.state$)?.status;
   const sttRecording = useGet(sttRecording$);
   const sttStarting = useGet(sttStarting$);
   const sttTranscribing = useGet(sttTranscribing$);


### PR DESCRIPTION
Closes #32255

Switching conversations briefly dimmed the composer microphone button. Every conversation switch builds a new composer, and `MicButton` gated `disabled` on `useResolved(voice.state$)`, which drops to loading while the new target's stored voice draft is read from IndexedDB. The voice draft data also re-read storage through a revision counter after every mutation and on unmount, so the same loading flip happened after start, stop, retry, and discard.

## Changes

- `MicButton` reads the voice draft status with `useLastResolved`, so a target change keeps the last status until the new read resolves. `run$` already awaits that read before choosing start or retry. Microphone availability is a synchronous computed and is read with `useGet`, so a freshly mounted button no longer renders empty for one pass.
- The voice draft recording is derived instead of reloaded. Storage is read once per storage key through an async computed, and each mutation (create, append, delete, delivery) records the recording it owns as state. `revision$`, `reload$`, `deliveredRecordingId$`, and the reload on unmount are removed.
- `appendVoiceDraftSamples` returns the stored recording so the append callback records the committed sample count without another read.
- Retry reads storage again on purpose: a failed restore can recover, and a recording saved by another composer for the same target (for example the forward dialog) stays transcribable.
- `ComposerFooter` keeps `useResolved`, so a pending target still shows the ordinary toolbar rather than another conversation's Retry controls, as the existing loading tests require.

## Verification

- New page test: switching between two conversations keeps `Voice input` enabled while the second conversation's stored draft read is still pending, and recording afterwards inserts the transcript into that conversation.
- The ten `chat-capability-voice-*` page-test files (89 tests) plus `chat-expected-failures`, `sidebar`, `preferences-page`, and `org-billing-tab` (92 tests) pass locally in batches of at most five files. Two forwarding cases timed out once inside a five-file batch and passed when that file ran alone.
- Platform `check-types`, oxlint, type-aware oxlint, eslint on the changed files, prettier, and `knip --workspace apps/platform` pass.
