### PR TITLE
refactor(desktop): own driver generations and command admission

### DIFF
--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -226,6 +226,11 @@ export class ComputerUseSnapshotStore {
 
   constructor(private readonly maxEntries = DEFAULT_SNAPSHOT_STORE_LIMIT) {}
 
+  clear(): void {
+    this.snapshots.clear();
+    this.latestByApp.clear();
+  }
+
   set(metadata: ComputerUseSnapshotMetadata): void {
     const key = this.key(metadata.app, metadata.snapshotId);
     if (this.snapshots.has(key)) {

--- a/turbo/apps/desktop/src/computer-use-driver.ts
+++ b/turbo/apps/desktop/src/computer-use-driver.ts
@@ -1,0 +1,208 @@
+import type { ComputerUsePermissionProvider } from "./computer-use-permissions";
+import { createComputerUseDrain } from "./computer-use-lifecycle-deadline";
+import {
+  ComputerUseSnapshotStore,
+  executeComputerUseCommand,
+  type ComputerUseCommand,
+  type ComputerUseCommandExecutionResult,
+} from "./computer-use-accessibility";
+import type {
+  ComputerUseNativeBackend,
+  ComputerUseNativeShutdownReason,
+} from "./computer-use-native";
+import type { ComputerUsePermissionState } from "./computer-use-types";
+
+export interface ComputerUseDriver {
+  readonly id: string;
+  readonly createBackend: () => ComputerUseNativeBackend;
+}
+
+interface DriverGeneration {
+  readonly driver: ComputerUseDriver;
+  readonly generation: number;
+  readonly backend: ComputerUseNativeBackend;
+  readonly snapshots: ComputerUseSnapshotStore;
+  readonly drained: Promise<void>;
+  readonly resolveDrained: () => void;
+  leases: number;
+  disposal: Promise<void> | null;
+}
+
+export interface ComputerUseCommandSession {
+  getPermissions(): Promise<ComputerUsePermissionState>;
+  executeCommand(
+    command: ComputerUseCommand,
+    permissions: ComputerUsePermissionState,
+  ): Promise<ComputerUseCommandExecutionResult>;
+  release(): void;
+}
+
+/** Owns native resources, including passive permission probes, for one generation. */
+export class ComputerUseDriverController {
+  private context: DriverGeneration | null = null;
+  private retirement: Promise<void> | null = null;
+  private retiringContext: DriverGeneration | null = null;
+  private nextGeneration = 0;
+  private active = false;
+  private permissionsPaused = false;
+  private closed = false;
+
+  constructor(
+    private driver: ComputerUseDriver,
+    private readonly platform: NodeJS.Platform = process.platform,
+  ) {}
+
+  get generation(): number | null {
+    return this.context?.generation ?? null;
+  }
+
+  private prepare(): DriverGeneration {
+    if (this.closed || this.retirement) {
+      throw new Error("Computer Use driver retirement is not complete");
+    }
+    if (!this.context) {
+      const { promise, resolve } = createComputerUseDrain();
+      this.context = {
+        driver: this.driver,
+        generation: ++this.nextGeneration,
+        backend: this.driver.createBackend(),
+        snapshots: new ComputerUseSnapshotStore(),
+        drained: promise,
+        resolveDrained: resolve,
+        leases: 0,
+        disposal: null,
+      };
+    }
+    return this.context;
+  }
+
+  activate(): void {
+    this.prepare();
+    this.active = true;
+    this.permissionsPaused = false;
+  }
+
+  pausePermissions(): void {
+    this.permissionsPaused = true;
+  }
+
+  async withPermissionProvider<T>(
+    read: (provider: ComputerUsePermissionProvider) => Promise<T>,
+  ): Promise<T | null> {
+    if (this.closed || this.retirement || this.permissionsPaused) return null;
+    // Creating the selected driver's probe context does not admit commands.
+    const context = this.prepare();
+    const release = this.lease(context);
+    try {
+      const result = await read(context.backend);
+      return this.context === context ? result : null;
+    } finally {
+      release();
+    }
+  }
+
+  acquireCommand(): ComputerUseCommandSession {
+    const context = this.context;
+    if (!this.active || !context) {
+      throw new Error("Computer Use driver is not ready");
+    }
+    return {
+      getPermissions: () => context.backend.getPermissions(),
+      executeCommand: async (command, permissions) => {
+        const { app, snapshotId } = command.payload;
+        if (
+          typeof app === "string" &&
+          typeof snapshotId === "string" &&
+          !context.snapshots.get(app, snapshotId)
+        ) {
+          return {
+            status: "failed",
+            error: {
+              code: "unsupported_command",
+              message: `Snapshot not found for ${app}: ${snapshotId}`,
+            },
+          };
+        }
+        return executeComputerUseCommand(command, permissions, {
+          nativeBackend: context.backend,
+          snapshotStore: context.snapshots,
+          platform: this.platform,
+        });
+      },
+      release: this.lease(context),
+    };
+  }
+
+  private lease(context: DriverGeneration): () => void {
+    context.leases++;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      context.leases--;
+      if (this.context !== context && context.leases === 0) {
+        context.resolveDrained();
+      }
+    };
+  }
+
+  retire(reason: ComputerUseNativeShutdownReason = "dispose"): Promise<void> {
+    this.active = false;
+    this.permissionsPaused = true;
+    if (reason !== "dispose") this.closed = true;
+    if (this.retirement) {
+      if (reason !== "dispose" && this.retiringContext) {
+        return this.dispose(this.retiringContext, reason);
+      }
+      return this.retirement;
+    }
+    const context = this.context;
+    this.context = null;
+    if (!context) return Promise.resolve();
+    this.retiringContext = context;
+    if (context.leases === 0) context.resolveDrained();
+    const retirement = (async () => {
+      // Quit may terminate native work; a healthy replacement must drain it.
+      if (reason === "dispose") await context.drained;
+      await this.dispose(context, reason);
+    })();
+    this.retirement = retirement;
+    void retirement.then(
+      () => {
+        if (this.retirement === retirement) {
+          this.retirement = null;
+          this.retiringContext = null;
+        }
+      },
+      () => {
+        // Keep failed cleanup owned. A retry must not overlap the old backend.
+      },
+    );
+    return retirement;
+  }
+
+  private dispose(
+    context: DriverGeneration,
+    reason: ComputerUseNativeShutdownReason,
+  ): Promise<void> {
+    context.disposal ??= context.backend.dispose(reason).then(() => {
+      context.snapshots.clear();
+    });
+    return context.disposal;
+  }
+
+  /** Called only after the lifecycle owner has proved retirement and intent. */
+  select(driver: ComputerUseDriver): void {
+    if (this.context || this.retirement || this.closed) {
+      throw new Error(
+        "Computer Use driver is still owned by the old generation",
+      );
+    }
+    this.driver = driver;
+    this.permissionsPaused = false;
+  }
+
+  resumePermissions(): void {
+    if (!this.closed && !this.retirement) this.permissionsPaused = false;
+  }
+}

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -113,12 +113,18 @@ function createRuntime(
     getPermissions() {
       return { accessibility: true, screenRecording: false };
     },
-    async executeCommand(command, permissions) {
-      if (options.executeCommand) {
-        return options.executeCommand(command, permissions);
-      }
-      return { status: "succeeded", result: {} };
-    },
+    acquireCommand: () => ({
+      getPermissions: async () => ({
+        accessibility: true,
+        screenRecording: false,
+      }),
+      async executeCommand(command, permissions) {
+        if (options.executeCommand)
+          return options.executeCommand(command, permissions);
+        return { status: "succeeded", result: {} };
+      },
+      release() {},
+    }),
     ...(options.onCommandFailure
       ? { onCommandFailure: options.onCommandFailure }
       : {}),

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -1,3 +1,4 @@
+import { createComputerUseDrain } from "./computer-use-lifecycle-deadline";
 import os from "node:os";
 import type {
   ComputerUseCommand,
@@ -19,6 +20,7 @@ import {
 } from "./computer-use-startup-gate";
 import { resolveComputerUseApiBaseUrl } from "./desktop-api-base-url";
 import type { DesktopClientHeaderInjector } from "./desktop-client-headers";
+import type { ComputerUseCommandSession } from "./computer-use-driver";
 
 const HEARTBEAT_POLL_MS = 2_000;
 const COMMAND_COLD_POLL_MS = 5_000;
@@ -61,16 +63,16 @@ interface ComputerUseHostRuntimeOptions {
   readonly addClientHeaders: DesktopClientHeaderInjector;
   readonly getPermissions: () => MaybePromise<ComputerUsePermissionState>;
   readonly getSupportedCapabilities?: () => readonly string[];
-  readonly executeCommand: (
-    command: ComputerUseCommand,
-    permissions: ComputerUsePermissionState,
-  ) => Promise<ComputerUseCommandExecutionResult>;
+  readonly acquireCommand: () => ComputerUseCommandSession;
   readonly onCommandFailure?: (args: {
     readonly command: ComputerUseCommand;
     readonly failure: ComputerUseCommandFailure;
   }) => void;
   readonly onChange?: () => void;
-  readonly setTimeout?: typeof setTimeout;
+  readonly setTimeout?: (
+    callback: () => void,
+    delayMs: number,
+  ) => ReturnType<typeof setTimeout>;
   readonly clearTimeout?: typeof clearTimeout;
 }
 
@@ -237,12 +239,13 @@ export class ComputerUseHostRuntime {
   private readonly addClientHeaders: DesktopClientHeaderInjector;
   private readonly getPermissions: ComputerUseHostRuntimeOptions["getPermissions"];
   private readonly getSupportedCapabilities: () => readonly string[];
-  private readonly executeCommand: ComputerUseHostRuntimeOptions["executeCommand"];
   private readonly onCommandFailure: NonNullable<
     ComputerUseHostRuntimeOptions["onCommandFailure"]
   >;
   private readonly onChange: () => void;
-  private readonly scheduleTimeout: typeof setTimeout;
+  private readonly scheduleTimeout: NonNullable<
+    ComputerUseHostRuntimeOptions["setTimeout"]
+  >;
   private readonly clearScheduledTimeout: typeof clearTimeout;
   private running = false;
   private heartbeatTimer: NodeJS.Timeout | null = null;
@@ -250,6 +253,10 @@ export class ComputerUseHostRuntime {
   private recoveryTimer: NodeJS.Timeout | null = null;
   private commandExecutionRunning = false;
   private draining = false;
+  private sessionGeneration = 0;
+  private pauseGeneration = 0;
+  private commandDrained = createComputerUseDrain();
+  private readonly commandRequests = new Set<Promise<Response>>();
   private lastCommandActivityAtMs: number | null = null;
   private lastCommandCompletionAtMs: number | null = null;
   private hostToken: string | null = null;
@@ -266,6 +273,7 @@ export class ComputerUseHostRuntime {
   };
 
   constructor(options: ComputerUseHostRuntimeOptions) {
+    this.acquireCommand = options.acquireCommand;
     this.apiBaseUrl = resolveComputerUseApiBaseUrl(options.platformUrl);
     this.installationId = options.installationId;
     this.hostName = options.hostName;
@@ -279,21 +287,25 @@ export class ComputerUseHostRuntime {
       (() => {
         return SUPPORTED_COMPUTER_USE_CAPABILITIES;
       });
-    this.executeCommand = options.executeCommand;
     this.onCommandFailure = options.onCommandFailure ?? (() => {});
     this.onChange = options.onChange ?? (() => {});
     this.scheduleTimeout = options.setTimeout ?? setTimeout;
     this.clearScheduledTimeout = options.clearTimeout ?? clearTimeout;
   }
 
+  private readonly acquireCommand: ComputerUseHostRuntimeOptions["acquireCommand"];
+
   async start(): Promise<void> {
     if (this.running) {
       return;
     }
     this.running = true;
+    this.sessionGeneration++;
+    const generation = this.sessionGeneration;
     this.draining = false;
     try {
       const nextDelay = await this.startHost();
+      if (generation !== this.sessionGeneration) return;
       if (nextDelay === null) {
         this.running = false;
         return;
@@ -301,12 +313,15 @@ export class ComputerUseHostRuntime {
       this.scheduleHeartbeat(nextDelay);
       this.scheduleCommandPoll(this.commandPollDelayMs());
     } catch (error) {
-      this.handleRuntimeFailure("start", error);
+      if (generation === this.sessionGeneration)
+        this.handleRuntimeFailure("start", error);
     }
   }
 
   async stop(): Promise<void> {
     this.running = false;
+    this.sessionGeneration++;
+    this.pauseGeneration++;
     this.draining = false;
     this.clearHeartbeatTimer();
     this.clearCommandTimer();
@@ -332,14 +347,32 @@ export class ComputerUseHostRuntime {
   }
 
   async drainAndStop(): Promise<void> {
-    this.draining = true;
-    this.clearCommandTimer();
-    while (this.commandExecutionRunning) {
-      await new Promise<void>((resolve) => {
-        this.scheduleTimeout(resolve, 50);
-      });
-    }
+    await this.pauseAndDrainCommands();
     await this.stop();
+  }
+
+  /** Close admission synchronously, retaining heartbeat and host authorization. */
+  async pauseAndDrainCommands(): Promise<() => void> {
+    this.draining = true;
+    const pause = ++this.pauseGeneration;
+    const session = this.sessionGeneration;
+    this.clearCommandTimer();
+    if (this.state.recovery?.phase === "command_poll")
+      this.clearRecoveryTimer();
+    if (this.commandExecutionRunning) await this.commandDrained.promise;
+    // Request deadlines do not prove that the underlying transport retired.
+    await Promise.allSettled([...this.commandRequests]);
+    return () => {
+      if (
+        !this.running ||
+        session !== this.sessionGeneration ||
+        pause !== this.pauseGeneration
+      )
+        return;
+      this.draining = false;
+      this.clearRecoveryState("command_poll");
+      this.scheduleCommandPoll(0);
+    };
   }
 
   getState(): ComputerUseHostRuntimeState {
@@ -595,8 +628,10 @@ export class ComputerUseHostRuntime {
   }
 
   private async recoverStart(): Promise<void> {
+    const generation = this.sessionGeneration;
     try {
       const nextDelay = await this.startHost();
+      if (generation !== this.sessionGeneration) return;
       if (nextDelay === null) {
         this.running = false;
         return;
@@ -604,13 +639,17 @@ export class ComputerUseHostRuntime {
       this.scheduleHeartbeat(nextDelay);
       this.scheduleCommandPoll(this.commandPollDelayMs());
     } catch (error) {
-      this.handleRuntimeFailure("start", error);
+      if (generation === this.sessionGeneration)
+        this.handleRuntimeFailure("start", error);
     }
   }
 
   private async recoverHeartbeat(): Promise<void> {
+    const generation = this.sessionGeneration;
     try {
-      if (!this.hostToken || !(await this.heartbeat())) {
+      const online = this.hostToken && (await this.heartbeat());
+      if (generation !== this.sessionGeneration) return;
+      if (!online) {
         this.running = false;
         this.clearCommandTimer();
         return;
@@ -618,7 +657,8 @@ export class ComputerUseHostRuntime {
       this.scheduleHeartbeat(HEARTBEAT_POLL_MS);
       this.scheduleCommandPoll(0);
     } catch (error) {
-      this.handleRuntimeFailure("heartbeat", error);
+      if (generation === this.sessionGeneration)
+        this.handleRuntimeFailure("heartbeat", error);
     }
   }
 
@@ -643,35 +683,55 @@ export class ComputerUseHostRuntime {
   }
 
   private async heartbeatLoop(): Promise<void> {
+    const generation = this.sessionGeneration;
     try {
-      if (!this.hostToken || !(await this.heartbeat())) {
+      const online = this.hostToken && (await this.heartbeat());
+      if (generation !== this.sessionGeneration) return;
+      if (!online) {
         this.running = false;
         this.clearCommandTimer();
         return;
       }
       this.scheduleHeartbeat(HEARTBEAT_POLL_MS);
     } catch (error) {
-      this.handleRuntimeFailure("heartbeat", error);
+      if (generation === this.sessionGeneration)
+        this.handleRuntimeFailure("heartbeat", error);
     }
   }
 
   private async commandLoop(): Promise<void> {
-    if (this.commandExecutionRunning) {
+    if (
+      !this.running ||
+      this.draining ||
+      !this.hostToken ||
+      this.commandExecutionRunning
+    ) {
       return;
     }
     this.commandExecutionRunning = true;
+    const generation = this.sessionGeneration;
+    this.commandDrained = createComputerUseDrain();
+    let commandSession: ComputerUseCommandSession | undefined;
     let scheduleNextPoll = true;
     let pollImmediately = false;
     try {
-      pollImmediately = (await this.claimAndExecuteCommand()) === "completed";
+      commandSession = this.acquireCommand();
+      pollImmediately =
+        (await this.claimAndExecuteCommand(commandSession)) === "completed";
     } catch (error) {
       scheduleNextPoll =
+        generation === this.sessionGeneration &&
         this.handleRuntimeFailure("command_poll", error) !==
-        "scheduled_recovery";
+          "scheduled_recovery";
     } finally {
+      // Keep the generation leased even if a request's Promise.race timed out.
+      await Promise.allSettled([...this.commandRequests]);
+      commandSession?.release();
       this.commandExecutionRunning = false;
+      this.commandDrained.resolve();
       if (
         scheduleNextPoll &&
+        generation === this.sessionGeneration &&
         this.running &&
         !this.draining &&
         this.hostToken &&
@@ -702,17 +762,29 @@ export class ComputerUseHostRuntime {
   }
 
   private async startHost(): Promise<number | null> {
+    const generation = this.sessionGeneration;
     this.setState({ status: "connecting", lastError: null });
+    const runtimeBody = await this.runtimeBody();
+    if (!this.running || generation !== this.sessionGeneration) return null;
     const response = await this.sessionFetch(
       `${this.apiBaseUrl}/api/computer-use/hosts/start`,
       {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(await this.runtimeBody()),
+        body: JSON.stringify(runtimeBody),
       },
     );
+    if (!this.running || generation !== this.sessionGeneration) {
+      if (response.ok) {
+        const body = (await response.json()) as ComputerUseHostStartResponse;
+        await this.stopHost(body.hostToken);
+      }
+      return null;
+    }
     if (response.status === 401) {
-      if (await this.hasAuthenticatedSession()) {
+      const authenticated = await this.hasAuthenticatedSession();
+      if (!this.running || generation !== this.sessionGeneration) return null;
+      if (authenticated) {
         this.setState({
           status: "needs_organization",
           lastError: COMPUTER_USE_NEEDS_ORGANIZATION_MESSAGE,
@@ -751,6 +823,10 @@ export class ComputerUseHostRuntime {
     }
 
     const body = (await response.json()) as ComputerUseHostStartResponse;
+    if (!this.running || generation !== this.sessionGeneration) {
+      await this.stopHost(body.hostToken);
+      return null;
+    }
     this.hostToken = body.hostToken;
     this.lastCommandActivityAtMs = null;
     this.lastCommandCompletionAtMs = null;
@@ -779,6 +855,7 @@ export class ComputerUseHostRuntime {
     readonly label: string;
     readonly timeoutMs: number;
     readonly request: (signal: AbortSignal) => Promise<Response>;
+    readonly commandRequest?: boolean;
   }): Promise<Response> {
     const { label, timeoutMs, request } = args;
     const timeoutMessage = () => {
@@ -791,6 +868,13 @@ export class ComputerUseHostRuntime {
       }
       throw error;
     });
+    if (args.commandRequest) {
+      this.commandRequests.add(requestPromise);
+      void requestPromise.then(
+        () => this.commandRequests.delete(requestPromise),
+        () => this.commandRequests.delete(requestPromise),
+      );
+    }
     let timer: NodeJS.Timeout | null = null;
     const timeoutPromise = new Promise<never>((_resolve, reject) => {
       timer = this.scheduleTimeout(() => {
@@ -810,17 +894,22 @@ export class ComputerUseHostRuntime {
   }
 
   private async heartbeat(): Promise<boolean> {
+    const generation = this.sessionGeneration;
     const response = await this.runHostRequestWithTimeout({
       label: "heartbeat",
       timeoutMs: HEARTBEAT_REQUEST_TIMEOUT_MS,
       request: async (signal) => {
+        const body = await this.runtimeBody();
+        if (!this.running || generation !== this.sessionGeneration)
+          throw new Error("Computer Use heartbeat was superseded");
         return await this.hostFetch("/api/computer-use/heartbeat", {
           method: "POST",
-          body: JSON.stringify(await this.runtimeBody()),
+          body: JSON.stringify(body),
           signal,
         });
       },
     });
+    if (!this.running || generation !== this.sessionGeneration) return false;
     if (response.status === 401) {
       this.deactivateInvalidHostToken("heartbeat");
       return false;
@@ -853,10 +942,14 @@ export class ComputerUseHostRuntime {
     return true;
   }
 
-  private async claimAndExecuteCommand(): Promise<"idle" | "completed"> {
+  private async claimAndExecuteCommand(
+    commandSession: ComputerUseCommandSession,
+  ): Promise<"idle" | "completed"> {
+    const generation = this.sessionGeneration;
     const next = await this.runHostRequestWithTimeout({
       label: "command poll",
       timeoutMs: COMMAND_POLL_REQUEST_TIMEOUT_MS,
+      commandRequest: true,
       request: async (signal) => {
         return await this.hostFetch("/api/computer-use/host/commands/next", {
           method: "POST",
@@ -867,6 +960,7 @@ export class ComputerUseHostRuntime {
         });
       },
     });
+    if (!this.running || generation !== this.sessionGeneration) return "idle";
     if (next.status === 401) {
       this.deactivateInvalidHostToken("command_poll");
       return "idle";
@@ -878,8 +972,13 @@ export class ComputerUseHostRuntime {
       );
     }
     const body = (await next.json()) as ComputerUseHostNextResponse;
+    if (!this.running || generation !== this.sessionGeneration) return "idle";
     if (body.status === "idle") {
-      if (!this.running || !this.hostToken) {
+      if (
+        !this.running ||
+        generation !== this.sessionGeneration ||
+        !this.hostToken
+      ) {
         return "idle";
       }
       this.clearRecoveryState("command_poll");
@@ -893,9 +992,11 @@ export class ComputerUseHostRuntime {
 
     let completed: ComputerUseCommandExecutionResult;
     try {
-      completed = await this.executeCommand(
+      const permissions = await commandSession.getPermissions();
+      if (!this.running || generation !== this.sessionGeneration) return "idle";
+      completed = await commandSession.executeCommand(
         body.command,
-        await this.getPermissions(),
+        permissions,
       );
     } catch (error) {
       completed = commandFailureFromError(error);
@@ -912,11 +1013,19 @@ export class ComputerUseHostRuntime {
     if (completed.status === "failed") {
       this.onCommandFailure({ command: body.command, failure: completed });
     }
-    if (!this.running || !this.hostToken) {
+    if (
+      !this.running ||
+      generation !== this.sessionGeneration ||
+      !this.hostToken
+    ) {
       return "idle";
     }
-    await this.completeCommandWithRetry(body.command.id, completed);
-    if (!this.running || !this.hostToken) {
+    await this.completeCommandWithRetry(body.command.id, completed, generation);
+    if (
+      !this.running ||
+      generation !== this.sessionGeneration ||
+      !this.hostToken
+    ) {
       return "idle";
     }
     const commandActivityAtMs = Date.now();
@@ -934,6 +1043,7 @@ export class ComputerUseHostRuntime {
   private async completeCommandWithRetry(
     commandId: string,
     completed: ComputerUseCommandExecutionResult,
+    generation: number,
   ): Promise<void> {
     let lastError: Error | null = null;
     for (
@@ -941,10 +1051,12 @@ export class ComputerUseHostRuntime {
       attempt <= COMMAND_COMPLETION_MAX_ATTEMPTS;
       attempt++
     ) {
+      if (!this.running || generation !== this.sessionGeneration) return;
       try {
         const response = await this.runHostRequestWithTimeout({
           label: "command completion",
           timeoutMs: COMMAND_COMPLETION_REQUEST_TIMEOUT_MS,
+          commandRequest: true,
           request: async (signal) => {
             return await this.hostFetch(
               `/api/computer-use/host/commands/${commandId}/complete`,
@@ -956,6 +1068,7 @@ export class ComputerUseHostRuntime {
             );
           },
         });
+        if (!this.running || generation !== this.sessionGeneration) return;
         if (response.ok) {
           return;
         }

--- a/turbo/apps/desktop/src/computer-use-lifecycle-deadline.ts
+++ b/turbo/apps/desktop/src/computer-use-lifecycle-deadline.ts
@@ -1,0 +1,43 @@
+export interface ComputerUseLifecycleTimers {
+  readonly setTimeout: (
+    callback: () => void,
+    delayMs: number,
+  ) => ReturnType<typeof setTimeout>;
+  readonly clearTimeout: typeof clearTimeout;
+}
+
+/** Bounds the caller's wait; the caller still owns and must retire late work. */
+export async function withComputerUseDeadline<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+  timers: ComputerUseLifecycleTimers = { setTimeout, clearTimeout },
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = timers.setTimeout(() => {
+          reject(
+            new Error(
+              "Computer Use driver transition timed out; admission remains closed",
+            ),
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    timers.clearTimeout(timer);
+  }
+}
+
+export function createComputerUseDrain(): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -584,6 +584,8 @@ const DEFAULT_RUNTIME_SHUTDOWN_GRACE_MS = 1_000;
 
 class ComputerUseNativeRuntimeClient {
   private runtime: ComputerUseNativeRuntimeProcess | null = null;
+  private readonly retiringRuntimes =
+    new Set<ComputerUseNativeRuntimeProcess>();
   private requestCounter = 0;
   private state: ComputerUseNativeRuntimeClientState = "open";
   private readonly pending = new Map<string, PendingRuntimeRequest>();
@@ -608,8 +610,16 @@ class ComputerUseNativeRuntimeClient {
     // tracks completion only and swallows the outcome so a single rejected
     // request never poisons the chain for the requests queued behind it.
     this.queuedRequestCount += 1;
-    const run = this.queueTail.then(() => {
+    const run = this.queueTail.then(async () => {
       this.queuedRequestCount -= 1;
+      for (const runtime of this.retiringRuntimes) {
+        if (!(await this.waitForRuntimeClose(runtime))) {
+          throw new ComputerUseNativeHelperError(
+            "accessibility_unavailable",
+            "Previous native Computer Use runtime has not exited",
+          );
+        }
+      }
       // Disposal may start while this request is waiting behind another one.
       // Re-check at dispatch time so a queued request cannot respawn a helper
       // after shutdown has begun.
@@ -641,6 +651,7 @@ class ComputerUseNativeRuntimeClient {
         if (this.runtime === runtime) {
           this.runtime = null;
         }
+        this.retiringRuntimes.add(runtime);
         runtime.stopReason = "timeout_replace";
         runtime.terminalErrorReported = true;
         this.signalRuntime(runtime, "SIGKILL");
@@ -699,14 +710,18 @@ class ComputerUseNativeRuntimeClient {
     this.state = "closing";
     this.rejectAll(this.closedError());
     const runtime = this.runtime;
-    this.disposePromise = (
-      runtime ? this.stopRuntime(runtime, reason) : Promise.resolve()
-    ).finally(() => {
-      if (this.runtime === runtime) {
-        this.runtime = null;
-      }
-      this.state = "closed";
-    });
+    const runtimes = new Set(this.retiringRuntimes);
+    if (runtime) runtimes.add(runtime);
+    this.disposePromise = Promise.all(
+      [...runtimes].map((owned) => this.stopRuntime(owned, reason)),
+    )
+      .then(() => {})
+      .finally(() => {
+        if (this.runtime === runtime) {
+          this.runtime = null;
+        }
+        this.state = "closed";
+      });
     return this.disposePromise;
   }
 
@@ -896,19 +911,18 @@ class ComputerUseNativeRuntimeClient {
     }
 
     runtime.terminalErrorReported = true;
-    this.reportRuntimeError(
-      new ComputerUseNativeHelperError(
-        "accessibility_unavailable",
-        "Native Computer Use runtime did not exit after SIGKILL",
-      ),
-      {
-        mode: "serve",
-        requestKind: "runtime",
-        stage: "shutdown",
-        terminationReason: reason,
-        stderr: runtime.stderr.trim(),
-      },
+    const error = new ComputerUseNativeHelperError(
+      "accessibility_unavailable",
+      "Native Computer Use runtime did not exit after SIGKILL",
     );
+    this.reportRuntimeError(error, {
+      mode: "serve",
+      requestKind: "runtime",
+      stage: "shutdown",
+      terminationReason: reason,
+      stderr: runtime.stderr.trim(),
+    });
+    throw error;
   }
 
   private signalRuntime(
@@ -977,6 +991,7 @@ class ComputerUseNativeRuntimeClient {
   }
 
   private markRuntimeClosed(runtime: ComputerUseNativeRuntimeProcess): void {
+    this.retiringRuntimes.delete(runtime);
     if (runtime.closed) {
       return;
     }

--- a/turbo/apps/desktop/src/computer-use-permissions.ts
+++ b/turbo/apps/desktop/src/computer-use-permissions.ts
@@ -1,13 +1,18 @@
-import {
-  createComputerUseNativeBackend,
-  type ComputerUseNativeBackend,
-} from "./computer-use-native";
+import type { ComputerUseNativeBackend } from "./computer-use-native";
 import {
   defaultComputerUseAutomationPermissionState,
   normalizeComputerUsePermissionState,
   type ComputerUseAutomationPermissionTarget,
   type ComputerUsePermissionState,
 } from "./computer-use-types";
+
+export type ComputerUsePermissionProvider = Pick<
+  ComputerUseNativeBackend,
+  | "getPermissions"
+  | "requestAccessibilityPermission"
+  | "requestScreenRecordingPermission"
+  | "probeAutomationPermission"
+>;
 
 const DEFAULT_COMPUTER_USE_PERMISSION_STATE: ComputerUsePermissionState =
   Object.freeze({
@@ -16,86 +21,100 @@ const DEFAULT_COMPUTER_USE_PERMISSION_STATE: ComputerUsePermissionState =
     automation: defaultComputerUseAutomationPermissionState(),
   });
 
-let nativeBackend: ComputerUseNativeBackend | null = null;
-let currentPermissionState = DEFAULT_COMPUTER_USE_PERMISSION_STATE;
+export function createComputerUsePermissions(
+  withProvider: <T>(
+    read: (provider: ComputerUsePermissionProvider) => Promise<T>,
+  ) => Promise<T | null>,
+) {
+  let currentPermissionState = DEFAULT_COMPUTER_USE_PERMISSION_STATE;
 
-export function setComputerUsePermissionNativeBackend(
-  backend: ComputerUseNativeBackend,
-): void {
-  nativeBackend = backend;
-}
+  function getComputerUsePermissionState(): ComputerUsePermissionState {
+    return currentPermissionState;
+  }
 
-function getNativeBackend(): ComputerUseNativeBackend {
-  nativeBackend ??= createComputerUseNativeBackend();
-  return nativeBackend;
-}
+  async function refreshComputerUsePermissionState(): Promise<ComputerUsePermissionState> {
+    const permissions = await withProvider((provider) =>
+      provider.getPermissions(),
+    );
+    if (!permissions) return currentPermissionState;
+    currentPermissionState = normalizeComputerUsePermissionState({
+      ...permissions,
+      automation: currentPermissionState.automation,
+    });
+    return currentPermissionState;
+  }
 
-export function getComputerUsePermissionState(): ComputerUsePermissionState {
-  return currentPermissionState;
-}
+  async function requestComputerUseAccessibilityPermission(): Promise<ComputerUsePermissionState> {
+    const permissions = await withProvider((provider) =>
+      provider.requestAccessibilityPermission(),
+    );
+    if (!permissions) return currentPermissionState;
+    currentPermissionState = normalizeComputerUsePermissionState({
+      ...permissions,
+      automation: currentPermissionState.automation,
+    });
+    return currentPermissionState;
+  }
 
-export async function refreshComputerUsePermissionState(): Promise<ComputerUsePermissionState> {
-  const permissions = await getNativeBackend().getPermissions();
-  currentPermissionState = normalizeComputerUsePermissionState({
-    ...permissions,
-    automation: currentPermissionState.automation,
-  });
-  return currentPermissionState;
-}
+  async function requestComputerUseScreenRecordingPermission(): Promise<ComputerUsePermissionState> {
+    const automation = currentPermissionState.automation;
+    const permissions = await withProvider((provider) =>
+      provider.requestScreenRecordingPermission(),
+    );
+    if (!permissions) return currentPermissionState;
+    currentPermissionState = normalizeComputerUsePermissionState({
+      ...permissions,
+      automation,
+    });
+    return currentPermissionState;
+  }
 
-export async function requestComputerUseAccessibilityPermission(): Promise<ComputerUsePermissionState> {
-  const permissions = await getNativeBackend().requestAccessibilityPermission();
-  currentPermissionState = normalizeComputerUsePermissionState({
-    ...permissions,
-    automation: currentPermissionState.automation,
-  });
-  return currentPermissionState;
-}
-
-export async function requestComputerUseScreenRecordingPermission(): Promise<ComputerUsePermissionState> {
-  const automation = currentPermissionState.automation;
-  const permissions =
-    await getNativeBackend().requestScreenRecordingPermission();
-  currentPermissionState = normalizeComputerUsePermissionState({
-    ...permissions,
-    automation,
-  });
-  return currentPermissionState;
-}
-
-export async function probeComputerUseAutomationPermission(
-  target: ComputerUseAutomationPermissionTarget,
-): Promise<ComputerUsePermissionState> {
-  const result = await getNativeBackend().probeAutomationPermission(target);
-  currentPermissionState = normalizeComputerUsePermissionState({
-    ...currentPermissionState,
-    automation: {
-      ...defaultComputerUseAutomationPermissionState(),
-      ...currentPermissionState.automation,
-      [target]: {
-        ...result,
-        updatedAt: new Date().toISOString(),
+  async function probeComputerUseAutomationPermission(
+    target: ComputerUseAutomationPermissionTarget,
+  ): Promise<ComputerUsePermissionState> {
+    const result = await withProvider((provider) =>
+      provider.probeAutomationPermission(target),
+    );
+    if (!result) return currentPermissionState;
+    currentPermissionState = normalizeComputerUsePermissionState({
+      ...currentPermissionState,
+      automation: {
+        ...defaultComputerUseAutomationPermissionState(),
+        ...currentPermissionState.automation,
+        [target]: {
+          ...result,
+          updatedAt: new Date().toISOString(),
+        },
       },
-    },
-  });
-  return currentPermissionState;
-}
+    });
+    return currentPermissionState;
+  }
 
-export function recordComputerUseAutomationPermissionDenied(
-  target: ComputerUseAutomationPermissionTarget,
-  reason: string,
-): ComputerUsePermissionState {
-  currentPermissionState = normalizeComputerUsePermissionState({
-    ...currentPermissionState,
-    automation: {
-      ...defaultComputerUseAutomationPermissionState(),
-      ...currentPermissionState.automation,
-      [target]: {
-        status: "denied",
-        updatedAt: new Date().toISOString(),
-        reason,
+  function recordComputerUseAutomationPermissionDenied(
+    target: ComputerUseAutomationPermissionTarget,
+    reason: string,
+  ): ComputerUsePermissionState {
+    currentPermissionState = normalizeComputerUsePermissionState({
+      ...currentPermissionState,
+      automation: {
+        ...defaultComputerUseAutomationPermissionState(),
+        ...currentPermissionState.automation,
+        [target]: {
+          status: "denied",
+          updatedAt: new Date().toISOString(),
+          reason,
+        },
       },
-    },
-  });
-  return currentPermissionState;
+    });
+    return currentPermissionState;
+  }
+
+  return {
+    getComputerUsePermissionState,
+    refreshComputerUsePermissionState,
+    requestComputerUseAccessibilityPermission,
+    requestComputerUseScreenRecordingPermission,
+    probeComputerUseAutomationPermission,
+    recordComputerUseAutomationPermissionDenied,
+  };
 }

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.test.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.test.ts
@@ -42,6 +42,7 @@ function createFakeRuntime(options: { readonly hangOnStop?: boolean } = {}) {
       }
       state = hostState("offline");
     }),
+    pauseAndDrainCommands: async () => () => {},
     getState: () => state,
   };
 }
@@ -146,7 +147,7 @@ describe("ComputerUseRuntimeController", () => {
 
     await controller.start({ userInitiated: true });
     expect(runtime.start).toHaveBeenCalledTimes(2);
-    expect(createRuntime).toHaveBeenCalledOnce();
+    expect(createRuntime).toHaveBeenCalledTimes(2);
   });
 
   it("drains active work before marking the host offline", async () => {

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.ts
@@ -1,3 +1,12 @@
+import type {
+  ComputerUseDriver,
+  ComputerUseDriverController,
+} from "./computer-use-driver";
+import type { ComputerUseNativeShutdownReason } from "./computer-use-native";
+import {
+  withComputerUseDeadline,
+  type ComputerUseLifecycleTimers,
+} from "./computer-use-lifecycle-deadline";
 import type { DesktopAuthState } from "./desktop-bridge";
 import { resolveComputerUseStartupGate } from "./computer-use-startup-gate";
 import {
@@ -14,6 +23,7 @@ interface ComputerUseRuntimeLike {
   start(): Promise<void>;
   stop(): Promise<void>;
   drainAndStop(): Promise<void>;
+  pauseAndDrainCommands(): Promise<() => void>;
   getState(): ComputerUseHostRuntimeState;
 }
 
@@ -31,6 +41,9 @@ interface ComputerUseRuntimeControllerOptions {
   /** Zero-arg "something changed" signal; defaults to a no-op. */
   readonly onChange?: () => void;
   readonly quitStopTimeoutMs?: number;
+  readonly driver?: ComputerUseDriverController;
+  readonly transitionTimeoutMs?: number;
+  readonly lifecycleTimers?: ComputerUseLifecycleTimers;
 }
 
 /**
@@ -52,8 +65,20 @@ export class ComputerUseRuntimeController {
   private blockedHostState: ComputerUseHostRuntimeState | null = null;
   private manualStopRequested = false;
   private quitStopStarted = false;
+  private intent = 0;
+  private stopping: Promise<void> = Promise.resolve();
+  private starting: Promise<void> | null = null;
+  private readonly transitions = new Map<ComputerUseDriver, Promise<void>>();
+  private transitionTail: Promise<void> = Promise.resolve();
+  private readonly driver: ComputerUseDriverController | undefined;
+  private readonly transitionTimeoutMs: number;
+  private readonly lifecycleTimers: ComputerUseLifecycleTimers | undefined;
+  private quitPromise: Promise<void> | null = null;
 
   constructor(options: ComputerUseRuntimeControllerOptions) {
+    this.lifecycleTimers = options.lifecycleTimers;
+    this.driver = options.driver;
+    this.transitionTimeoutMs = options.transitionTimeoutMs ?? 30_000;
     this.createRuntime = options.createRuntime;
     this.refreshPermissions = options.refreshPermissions;
     this.getAuthState = options.getAuthState;
@@ -64,11 +89,13 @@ export class ComputerUseRuntimeController {
   }
 
   getHostState(): ComputerUseHostRuntimeState {
-    return (
+    const state =
       this.runtime?.getState() ??
       this.blockedHostState ??
-      OFFLINE_COMPUTER_USE_HOST_STATE
-    );
+      OFFLINE_COMPUTER_USE_HOST_STATE;
+    return this.isTransitioning()
+      ? { ...state, driverTransitioning: true }
+      : state;
   }
 
   isRuntimeOnline(): boolean {
@@ -81,52 +108,172 @@ export class ComputerUseRuntimeController {
    * Non-user-initiated starts are suppressed after a manual stop.
    */
   async start(
-    options: { readonly userInitiated?: boolean } = {},
+    options: {
+      readonly userInitiated?: boolean;
+      readonly signal?: AbortSignal;
+    } = {},
   ): Promise<void> {
-    if (this.manualStopRequested && options.userInitiated !== true) {
+    if (
+      this.quitStopStarted ||
+      (this.manualStopRequested && options.userInitiated !== true)
+    )
       return;
-    }
+    options.signal?.throwIfAborted();
     this.manualStopRequested = false;
+    if (this.starting) return this.starting;
+    const intent = this.intent;
+    const abort = () => {
+      if (intent !== this.intent) return;
+      this.supersede();
+      this.detachRuntime();
+    };
+    options.signal?.addEventListener("abort", abort, { once: true });
+    const start = this.startRuntime(intent, this.transitionTail);
+    this.starting = start;
+    try {
+      await start;
+    } finally {
+      options.signal?.removeEventListener("abort", abort);
+      if (this.starting === start) this.starting = null;
+    }
+  }
 
+  private async startRuntime(
+    intent: number,
+    transitions: Promise<void>,
+  ): Promise<void> {
+    await withComputerUseDeadline(
+      this.stopping,
+      this.transitionTimeoutMs,
+      this.lifecycleTimers,
+    );
+    await transitions;
+    if (intent !== this.intent) return;
+    this.driver?.resumePermissions();
     const permissions = await this.refreshPermissions();
+    if (intent !== this.intent) return;
     if (!hasRequiredComputerUsePermissions(permissions)) {
       await this.detachRuntime();
       return;
     }
     const authState = await this.getAuthState();
+    if (intent !== this.intent) return;
     const startupGate = resolveComputerUseStartupGate({
       authState,
       permissions,
     });
     if (startupGate.status !== "ready") {
       await this.detachRuntime();
+      if (intent !== this.intent) return;
       if (startupGate.status === "blocked") {
         this.blockedHostState = startupGate.host;
         this.onChange();
       }
       return;
     }
-
     this.blockedHostState = null;
-    this.runtime ??= this.createRuntime();
-    await this.runtime.start();
-    this.setHostRuntimeOnline(this.runtime.getState().status === "online");
+    this.driver?.activate();
+    const runtime = (this.runtime ??= this.createRuntime());
+    await runtime.start();
+    if (intent !== this.intent) return;
+    this.setHostRuntimeOnline(runtime.getState().status === "online");
+  }
+
+  /** Serialized native replacement; it never changes host/plugin online state on success. */
+  transitionDriver(driver: ComputerUseDriver): Promise<void> {
+    const existing = this.transitions.get(driver);
+    if (existing) return existing;
+    if (!this.driver || this.quitStopStarted) {
+      return Promise.reject(
+        new Error("Computer Use driver transitions are unavailable"),
+      );
+    }
+    const intent = this.intent;
+    const pendingStart = this.starting;
+    const initialRuntime = this.runtime;
+    // Close admission before awaiting any preceding transition.
+    const initialDrain = initialRuntime?.pauseAndDrainCommands();
+    this.driver.pausePermissions();
+    let expired = false;
+    const checkIntent = () => {
+      if (expired || intent !== this.intent)
+        throw new Error("Computer Use driver transition was superseded");
+    };
+    const work = (async () => {
+      await this.transitionTail;
+      await pendingStart;
+      checkIntent();
+      const runtime = this.runtime;
+      this.driver?.pausePermissions();
+      const resume = await (runtime === initialRuntime
+        ? initialDrain
+        : runtime?.pauseAndDrainCommands());
+      checkIntent();
+      await this.driver?.retire();
+      checkIntent();
+      this.driver?.select(driver);
+      if (runtime && !this.manualStopRequested) {
+        const permissions = await this.refreshPermissions();
+        checkIntent();
+        if (!hasRequiredComputerUsePermissions(permissions))
+          throw new Error("Computer Use permissions are unavailable");
+        this.driver?.activate();
+        resume?.();
+      }
+    })();
+    const transition = withComputerUseDeadline(
+      work,
+      this.transitionTimeoutMs,
+      this.lifecycleTimers,
+    ).catch((error: unknown) => {
+      expired = true;
+      // A failure withdraws the host rather than advertising empty legacy capabilities.
+      if (intent === this.intent) {
+        this.manualStopRequested = true;
+        this.supersede();
+        this.detachRuntime();
+        this.blockedHostState = {
+          ...OFFLINE_COMPUTER_USE_HOST_STATE,
+          status: "error",
+          lastError: error instanceof Error ? error.message : String(error),
+        };
+      }
+      throw error;
+    });
+    this.transitions.set(driver, transition);
+    this.transitionTail = transition.then(
+      () => {},
+      () => {},
+    );
+    void this.transitionTail.then(() => {
+      this.transitions.delete(driver);
+      this.onChange();
+    });
+    this.onChange();
+    return transition;
+  }
+
+  isTransitioning(): boolean {
+    return this.transitions.size > 0;
   }
 
   /** User-initiated stop; suppresses auto-restarts until the next manual start. */
   async stop(): Promise<void> {
     this.manualStopRequested = true;
-    this.setHostRuntimeOnline(false);
-    await this.runtime?.stop();
-    this.onChange();
+    this.supersede();
+    await withComputerUseDeadline(
+      this.detachRuntime(),
+      this.transitionTimeoutMs,
+      this.lifecycleTimers,
+    );
   }
 
   /** Stops admitting work, lets the active command finish, then stops. */
   async drainAndStop(): Promise<void> {
     this.manualStopRequested = true;
+    this.supersede();
     await this.runtime?.drainAndStop();
-    this.setHostRuntimeOnline(false);
-    this.onChange();
+    await this.detachRuntime();
   }
 
   /**
@@ -134,7 +281,25 @@ export class ComputerUseRuntimeController {
    * a completed sign-in), so a subsequent start builds a fresh runtime.
    */
   async stopForAuthChange(): Promise<void> {
-    await this.detachRuntime();
+    this.supersede();
+    await withComputerUseDeadline(
+      this.detachRuntime(),
+      this.transitionTimeoutMs,
+      this.lifecycleTimers,
+    );
+  }
+
+  /** Auth completion preserves manual Stop intent and cannot revive superseded work. */
+  async startForAuthChange(signal: AbortSignal): Promise<void> {
+    this.supersede();
+    const intent = this.intent;
+    await withComputerUseDeadline(
+      this.detachRuntime(),
+      this.transitionTimeoutMs,
+      this.lifecycleTimers,
+    );
+    signal.throwIfAborted();
+    if (intent === this.intent) await this.start({ signal });
   }
 
   /** Clears a stale blocked host state once required permissions are missing. */
@@ -152,33 +317,49 @@ export class ComputerUseRuntimeController {
    * Idempotent: concurrent quit paths (before-quit, quit-and-install) share
    * one stop attempt.
    */
-  async stopForQuit(): Promise<void> {
-    if (this.quitStopStarted) {
-      return;
-    }
+  stopForQuit(
+    reason: ComputerUseNativeShutdownReason = "app_quit",
+  ): Promise<void> {
+    if (this.quitPromise) return this.quitPromise;
     this.quitStopStarted = true;
+    this.supersede();
     const runtime = this.runtime;
-    if (!runtime) {
-      return;
-    }
-    this.setHostRuntimeOnline(false);
-    await Promise.race([
-      runtime.stop(),
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, this.quitStopTimeoutMs);
-      }),
-    ]);
+    this.runtime = null;
+    if (runtime) this.setHostRuntimeOnline(false);
+    const stop = runtime?.stop() ?? Promise.resolve();
+    // Native disposal has its own process shutdown bound. Do not gate it on HTTP stop.
+    const retirement = this.driver?.retire(reason) ?? Promise.resolve();
+    this.quitPromise = Promise.all([
+      withComputerUseDeadline(
+        stop,
+        this.quitStopTimeoutMs,
+        this.lifecycleTimers,
+      ).catch(() => {}),
+      retirement,
+    ]).then(() => {});
+    return this.quitPromise;
   }
 
-  private async detachRuntime(): Promise<void> {
+  private supersede(): void {
+    this.intent++;
+    this.starting = null;
+    this.driver?.pausePermissions();
+  }
+
+  private detachRuntime(): Promise<void> {
+    const intent = this.intent;
     const runtime = this.runtime;
     this.runtime = null;
     this.blockedHostState = null;
     this.setHostRuntimeOnline(false);
-    try {
-      await runtime?.stop();
-    } finally {
-      this.onChange();
-    }
+    const stop = runtime?.stop() ?? Promise.resolve();
+    const retirement = this.driver?.retire() ?? Promise.resolve();
+    const cleanup = Promise.all([this.stopping, stop, retirement]).then(() => {
+      if (intent === this.intent && !this.quitStopStarted)
+        this.driver?.resumePermissions();
+    });
+    this.stopping = cleanup;
+    void cleanup.then(this.onChange, this.onChange);
+    return cleanup;
   }
 }

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -101,6 +101,7 @@ export interface ComputerUseRuntimeErrorLogEntry {
 }
 
 export interface ComputerUseHostRuntimeState {
+  readonly driverTransitioning?: boolean;
   readonly status: ComputerUseHostRuntimeStatus;
   readonly hostId: string | null;
   readonly lastHeartbeatAt: string | null;

--- a/turbo/apps/desktop/src/desktop-auto-update-policy.ts
+++ b/turbo/apps/desktop/src/desktop-auto-update-policy.ts
@@ -22,7 +22,10 @@ export function shouldDeferDesktopUpdate(
   hostState: ComputerUseHostRuntimeState,
   nowMs = Date.now(),
 ): boolean {
-  if (isRecentTimestamp(hostState.lastCommandAt, nowMs)) {
+  if (
+    hostState.driverTransitioning ||
+    isRecentTimestamp(hostState.lastCommandAt, nowMs)
+  ) {
     return true;
   }
 

--- a/turbo/apps/desktop/src/desktop-computer-use-api.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-api.ts
@@ -1,3 +1,9 @@
+import { COMPUTER_USE_PLUGIN_CALL_KIND } from "@okouai/api-contracts/contracts/computer-use-plugins";
+import type {
+  ComputerUseCommand,
+  ComputerUseCommandExecutionResult,
+} from "./computer-use-accessibility";
+import type { ComputerUseDriverController } from "./computer-use-driver";
 import {
   ComputerUseHostRuntime,
   type ComputerUseHostFetch,
@@ -13,8 +19,13 @@ import {
 export function createDesktopComputerUseHostRuntime(
   options: Omit<
     ConstructorParameters<typeof ComputerUseHostRuntime>[0],
-    "sessionFetch"
-  >,
+    "sessionFetch" | "acquireCommand"
+  > & {
+    readonly driver: ComputerUseDriverController;
+    readonly executePluginCommand: (
+      command: ComputerUseCommand,
+    ) => Promise<ComputerUseCommandExecutionResult>;
+  },
   auth: {
     readonly product: DesktopProduct;
     readonly session: DesktopSessionCookieSource;
@@ -23,6 +34,16 @@ export function createDesktopComputerUseHostRuntime(
 ): ComputerUseHostRuntime {
   return new ComputerUseHostRuntime({
     ...options,
+    acquireCommand: () => {
+      const native = options.driver.acquireCommand();
+      return {
+        ...native,
+        executeCommand: (command, permissions) =>
+          command.kind === COMPUTER_USE_PLUGIN_CALL_KIND
+            ? options.executePluginCommand(command)
+            : native.executeCommand(command, permissions),
+      };
+    },
     // Okou shares the App session's bearer, refresh and sign-out lifetime.
     // Zero keeps its existing Computer Use cookie and token retry policy.
     sessionFetch:

--- a/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
@@ -1,0 +1,900 @@
+import { DesktopRecorderController } from "./desktop-recorder-controller";
+import { createRecorderNativeBackend } from "./desktop-recorder-native";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DesktopMcpPluginManager } from "./desktop-mcp-plugin";
+import { ChildProcess } from "node:child_process";
+import * as childProcess from "node:child_process";
+import { PassThrough } from "node:stream";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { resolveDesktopConfig } from "./config";
+import { DesktopAuthSession } from "./desktop-auth-session";
+import {
+  buildDesktopAuthConsumeUrl,
+  buildDesktopAuthSelectOrgUrl,
+  buildDesktopAuthTokenUrl,
+} from "./desktop-auth";
+import { createDesktopClientHeaderInjector } from "./desktop-client-headers";
+import { createDesktopComputerUseHostRuntime } from "./desktop-computer-use-api";
+import {
+  ComputerUseDriverController,
+  type ComputerUseDriver,
+} from "./computer-use-driver";
+import { createComputerUseNativeBackend } from "./computer-use-native";
+import { createComputerUsePermissions } from "./computer-use-permissions";
+import { ComputerUseRuntimeController } from "./computer-use-runtime-controller";
+import {
+  SUPPORTED_COMPUTER_USE_CAPABILITIES,
+  type ComputerUseCommand,
+} from "./computer-use-accessibility";
+import { shouldDeferDesktopUpdate } from "./desktop-auto-update-policy";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof childProcess>();
+  return { ...actual, spawn: vi.fn() };
+});
+
+const realChildProcess =
+  await vi.importActual<typeof childProcess>("node:child_process");
+
+const api = "https://api.vm0.ai";
+const server = setupServer();
+const cleanups: (() => Promise<void>)[] = [];
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+  vi.restoreAllMocks();
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+/** Only the host's scheduling boundary is controlled; promises and HTTP stay real. */
+function controlledTimers() {
+  const pending = new Map<
+    ReturnType<typeof setTimeout>,
+    { delay: number | undefined; run: () => void }
+  >();
+  const schedule = Object.assign(
+    (run: () => void, delay?: number) => {
+      const timer = setTimeout(() => {}, 2 ** 30);
+      timer.unref();
+      pending.set(timer, { delay, run });
+      return timer;
+    },
+    { __promisify__: setTimeout.__promisify__ },
+  );
+  const clear = (
+    timer: ReturnType<typeof setTimeout> | string | number | undefined,
+  ) => {
+    if (typeof timer === "object") pending.delete(timer);
+    clearTimeout(timer);
+  };
+  return {
+    schedule,
+    clear,
+    count: (delay: number) =>
+      [...pending.values()].filter((item) => item.delay === delay).length,
+    take(delay: number) {
+      const entry = [...pending].find(([, item]) => item.delay === delay);
+      if (!entry) throw new Error(`No timer scheduled for ${delay}ms`);
+      clear(entry[0]);
+      return entry[1].run;
+    },
+    run(delay: number) {
+      this.take(delay)();
+    },
+    close() {
+      for (const timer of pending.keys()) clear(timer);
+    },
+  };
+}
+
+interface NativeRequest {
+  readonly id: string;
+  readonly kind: string;
+  readonly payload: Record<string, unknown>;
+}
+
+function nativeProcesses(events: string[]) {
+  const pauses = new Map<string, ReturnType<typeof pause>>();
+  const active = new Set<ChildProcess>();
+  const closeReached = deferred<void>();
+  let holdClose = false;
+  let created = 0;
+  function pause(kind: string) {
+    const gate = { reached: deferred<void>(), resume: deferred<void>() };
+    pauses.set(kind, gate);
+    return gate;
+  }
+  vi.mocked(childProcess.spawn).mockImplementation((command, args, options) => {
+    if (command !== "/test/computer-use-helper")
+      return realChildProcess.spawn(command, args, options);
+    const generation = ++created;
+    events.push(`create:${generation}`);
+    const child = new ChildProcess();
+    child.kill = () => true;
+    const input = new PassThrough();
+    const output = new PassThrough();
+    child.stdin = input;
+    child.stdout = output;
+    child.stderr = new PassThrough();
+    active.add(child);
+    input.on("data", (chunk: Buffer) => {
+      const request: NativeRequest = JSON.parse(chunk.toString());
+      const reply = async () => {
+        events.push(`${generation}:${request.kind}`);
+        const gate = pauses.get(request.kind);
+        if (gate) {
+          pauses.delete(request.kind);
+          gate.reached.resolve();
+          await gate.resume.promise;
+        }
+        let result: Record<string, unknown> = {};
+        if (request.kind.startsWith("permissions."))
+          result = { accessibility: true, screenRecording: true };
+        if (request.kind === "apps.list")
+          result = {
+            apps: [{ name: `generation-${generation}`, bundleId: "test.app" }],
+          };
+        if (request.kind === "app.state")
+          result = {
+            app: request.payload.app,
+            snapshotId: request.payload.snapshotId,
+            screenshot: "data:image/png;base64,abc123",
+            screenshotMimeType: "image/png",
+            screenshotSource: "window",
+            screenshotSourceName: "Test",
+            screenshotWidth: 800,
+            screenshotHeight: 600,
+            screenshotSourceBounds: { x: 0, y: 0, width: 800, height: 600 },
+            windowId: 123,
+            windowFrame: { x: 0, y: 0, width: 800, height: 600 },
+            elements: [
+              {
+                id: `element-${generation}`,
+                role: "AXButton",
+                name: "Open",
+                actions: ["AXPress"],
+              },
+            ],
+          };
+        output.write(
+          `${JSON.stringify({ id: request.id, status: "succeeded", result })}\n`,
+        );
+      };
+      void reply();
+    });
+    input.on("finish", () => {
+      events.push(`dispose:${generation}`);
+      closeReached.resolve();
+      if (!holdClose) {
+        active.delete(child);
+        child.emit("close", 0, null);
+      }
+    });
+    return child;
+  });
+  return {
+    pause,
+    closeReached,
+    holdClose: () => {
+      holdClose = true;
+    },
+    get created() {
+      return created;
+    },
+    get active() {
+      return active.size;
+    },
+    close() {
+      holdClose = false;
+      for (const child of active) child.emit("close", 0, null);
+      active.clear();
+    },
+  };
+}
+
+function desktop(
+  options: {
+    transitionTimeoutMs?: number;
+    nativeShutdownGraceMs?: number;
+    expectedQuitError?: string;
+    plugin?: DesktopMcpPluginManager;
+  } = {},
+) {
+  const events: string[] = [];
+  const native = nativeProcesses(events);
+  const timers = controlledTimers();
+  const config = resolveDesktopConfig(undefined, "okou");
+  const session = { cookies: { get: async () => [] } };
+  const addClientHeaders = createDesktopClientHeaderInjector({
+    product: "okou",
+    clientVersion: "1.2.3",
+  });
+  const authSession = new DesktopAuthSession({
+    product: "okou",
+    apiBaseUrl: api,
+    cookieUrls: [config.webUrl, config.platformUrl],
+    cookieSource: session,
+    addClientHeaders,
+    tokenUrl: buildDesktopAuthTokenUrl(config.authUrl),
+    selectOrgUrl: buildDesktopAuthSelectOrgUrl(config.authUrl, true),
+    consumeUrl: (code, id) =>
+      buildDesktopAuthConsumeUrl(config.authUrl, code, id),
+    runAuthWindow: async () => "app-token",
+  });
+  const driverDefinition: ComputerUseDriver = {
+    id: "okou",
+    createBackend: () =>
+      createComputerUseNativeBackend({
+        helperPath: "/test/computer-use-helper",
+        shutdownGraceMs: options.nativeShutdownGraceMs ?? 100,
+      }),
+  };
+  const driver = new ComputerUseDriverController(driverDefinition, "darwin");
+  const permissions = createComputerUsePermissions((read) =>
+    driver.withPermissionProvider(read),
+  );
+  const requests: {
+    path: string;
+    body: unknown;
+    authorization: string | null;
+  }[] = [];
+  const heartbeat = deferred<void>();
+  const releaseRequests: (() => void)[] = [];
+  let hostStarts = 0;
+  server.use(
+    http.all(`${api}/*`, async ({ request }) => {
+      const path = new URL(request.url).pathname;
+      requests.push({
+        path,
+        body: request.method === "POST" ? await request.json() : null,
+        authorization: request.headers.get("authorization"),
+      });
+      if (path === "/api/auth/me")
+        return HttpResponse.json({
+          userId: "user",
+          email: "test@example.test",
+          orgId: "org",
+        });
+      if (path === "/api/org")
+        return HttpResponse.json({ id: "org", name: "Workspace" });
+      if (path.endsWith("/hosts/start"))
+        return HttpResponse.json({
+          hostId: `host-${++hostStarts}`,
+          hostToken: "host-token",
+        });
+      if (path.endsWith("/heartbeat")) heartbeat.resolve();
+      return HttpResponse.json({ status: "idle" });
+    }),
+  );
+  const online: boolean[] = [];
+  const stateWaiters: (() => void)[] = [];
+  const notify = () => {
+    options.plugin?.setHostRuntimeOnline(controller.isRuntimeOnline());
+    for (const resolve of stateWaiters.splice(0)) resolve();
+  };
+  const controller = new ComputerUseRuntimeController({
+    driver,
+    createRuntime: () =>
+      createDesktopComputerUseHostRuntime(
+        {
+          platformUrl: config.platformUrl,
+          installationId: "00000000-0000-4000-8000-000000000001",
+          hostName: "test-host",
+          appVersion: "1.2.3",
+          addClientHeaders,
+          hostFetch: (input, init) => fetch(input, init),
+          getPermissions: permissions.refreshComputerUsePermissionState,
+          onChange: notify,
+          getSupportedCapabilities: () => [
+            ...SUPPORTED_COMPUTER_USE_CAPABILITIES,
+            ...(options.plugin?.getCapabilities() ?? []),
+          ],
+          driver,
+          executePluginCommand: async (command) => {
+            if (!options.plugin)
+              throw new Error("No plugin configured in this fixture");
+            return options.plugin.execute(command);
+          },
+          setTimeout: timers.schedule,
+          clearTimeout: timers.clear,
+        },
+        { product: "okou", session, getAuthSession: () => authSession },
+      ),
+    refreshPermissions: permissions.refreshComputerUsePermissionState,
+    getAuthState: () => authSession.getAuthState(),
+    setHostRuntimeOnline: (value) => {
+      online.push(value);
+      options.plugin?.setHostRuntimeOnline(value);
+    },
+    onChange: notify,
+    transitionTimeoutMs: options.transitionTimeoutMs,
+    lifecycleTimers: {
+      setTimeout: timers.schedule,
+      clearTimeout: timers.clear,
+    },
+  });
+  cleanups.push(async () => {
+    for (const release of releaseRequests) release();
+    native.close();
+    const quit = controller.stopForQuit();
+    if (options.expectedQuitError)
+      await expect(quit).rejects.toThrow(options.expectedQuitError);
+    else await quit;
+    timers.close();
+  });
+  function claim(command: ComputerUseCommand) {
+    const reached = deferred<void>();
+    const response = deferred<void>();
+    const completed = deferred<Record<string, unknown>>();
+    const completeResponse = deferred<void>();
+    releaseRequests.push(() => {
+      response.resolve();
+      completeResponse.resolve();
+    });
+    server.use(
+      http.post(`${api}/api/computer-use/host/commands/next`, async () => {
+        events.push("claim");
+        reached.resolve();
+        await response.promise;
+        return HttpResponse.json({ status: "command", command });
+      }),
+      http.post<never, Record<string, unknown>>(
+        `${api}/api/computer-use/host/commands/${command.id}/complete`,
+        async ({ request }) => {
+          const body: Record<string, unknown> = await request.json();
+          events.push("completion");
+          completed.resolve(body);
+          await completeResponse.promise;
+          return HttpResponse.json({ ok: true });
+        },
+      ),
+    );
+    return { reached, response, completed, completeResponse };
+  }
+  return {
+    async waitForHostState(status: string) {
+      while (controller.getHostState().status !== status)
+        await new Promise<void>((resolve) => stateWaiters.push(resolve));
+    },
+    controller,
+    driver,
+    driverDefinition,
+    permissions,
+    native,
+    events,
+    timers,
+    requests,
+    heartbeat,
+    online,
+    claim,
+  };
+}
+
+function pluginFixture() {
+  const dir = mkdtempSync(path.join(tmpdir(), "driver-plugin-"));
+  const script = path.join(dir, "server.cjs");
+  writeFileSync(
+    script,
+    `
+const readline = require("node:readline");
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.id === undefined) return;
+  const result = request.method === "initialize"
+    ? { protocolVersion: request.params.protocolVersion, capabilities: { tools: {} }, serverInfo: { name: "fixture", version: "1" } }
+    : request.method === "tools/list"
+      ? { tools: [{ name: "pid", inputSchema: { type: "object" } }] }
+      : { content: [{ type: "text", text: String(process.pid) }] };
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
+});
+`,
+  );
+  const ready = deferred<void>();
+  const manager = new DesktopMcpPluginManager({
+    preferencesPath: path.join(dir, "preferences.json"),
+    resolveShellPath: async () => null,
+    onChange: () => {
+      if (manager.getState().servers[0]?.status === "running") ready.resolve();
+    },
+  });
+  manager.load();
+  manager.importServersJson(
+    JSON.stringify({
+      mcpServers: { fixture: { command: process.execPath, args: [script] } },
+    }),
+  );
+  manager.setServerEnabled("fixture", true);
+  manager.setFeatureEnabled(true);
+  cleanups.push(async () => {
+    manager.setHostRuntimeOnline(false);
+    manager.stop();
+    rmSync(dir, { recursive: true, force: true });
+  });
+  return { manager, ready: ready.promise };
+}
+
+function recorderFixture() {
+  const dir = mkdtempSync(path.join(tmpdir(), "driver-recorder-"));
+  const helperPath = path.join(dir, "recorder.cjs");
+  writeFileSync(
+    helperPath,
+    `#!${process.execPath}
+const readline = require("node:readline");
+let status = "idle";
+readline.createInterface({ input: process.stdin }).on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.kind === "recorder.start") status = "recording";
+  if (request.kind === "recorder.pause") status = "paused";
+  if (request.kind === "recorder.resume") status = "recording";
+  const result = request.kind === "recorder.prepare"
+    ? { sessionId: String(process.pid), width: 800, height: 600, geometry: { originX: 0, originY: 0, widthPoints: 800, heightPoints: 600, scale: 1 } }
+    : { status, elapsedMs: 1000 };
+  process.stdout.write(JSON.stringify({ id: request.id, status: "succeeded", result }) + "\\n");
+});
+`,
+  );
+  chmodSync(helperPath, 0o755);
+  const backend = createRecorderNativeBackend({ helperPath });
+  const recorder = new DesktopRecorderController({
+    createBackend: () => backend,
+    createOutputPath: () => path.join(dir, "recording.mp4"),
+    canDeliver: async () => true,
+    deliver: async () => {
+      throw new Error("Recording delivery is outside this fixture");
+    },
+    openReview: () => {},
+  });
+  recorder.setFeatureEnabled(true);
+  cleanups.push(async () => {
+    backend.dispose();
+    rmSync(dir, { recursive: true, force: true });
+  });
+  return recorder;
+}
+
+const action: ComputerUseCommand = {
+  id: "command-1",
+  kind: "keyboard.type_text",
+  payload: { app: "test.app", text: "hello" },
+};
+
+describe("production driver generation and admission wiring", () => {
+  it("drains delayed claim, permission, action, capture and completion on the original generation while the host stays alive", async () => {
+    const app = desktop();
+    await app.controller.start();
+    const command = app.claim(action);
+    app.timers.run(5_000);
+    await command.reached.promise;
+    const permission = app.native.pause("permissions.state");
+    const write = app.native.pause("keyboard.type_text");
+    const capture = app.native.pause("app.state");
+    const switchDriver = app.controller.transitionDriver(app.driverDefinition);
+    expect(app.controller.transitionDriver(app.driverDefinition)).toBe(
+      switchDriver,
+    );
+    expect(shouldDeferDesktopUpdate(app.controller.getHostState())).toBe(true);
+    command.response.resolve();
+    await permission.reached.promise;
+    expect(app.native.created).toBe(1);
+    permission.resume.resolve();
+    await write.reached.promise;
+    app.timers.run(2_000);
+    await app.heartbeat.promise;
+    expect(app.controller.getHostState().hostId).toBe("host-1");
+    expect(app.online).toEqual([true]);
+    expect(app.timers.count(5_000)).toBe(0);
+    write.resume.resolve();
+    await capture.reached.promise;
+    expect(app.events).not.toContain("dispose:1");
+    capture.resume.resolve();
+    expect(await command.completed.promise).toMatchObject({
+      status: "succeeded",
+      result: { app: "test.app", action: { app: "test.app" } },
+    });
+    expect(app.native.created).toBe(1);
+    expect(app.events).not.toContain("dispose:1");
+    command.completeResponse.resolve();
+    await switchDriver;
+    expect(app.events.indexOf("completion")).toBeLessThan(
+      app.events.indexOf("dispose:1"),
+    );
+    expect(app.events.indexOf("dispose:1")).toBeLessThan(
+      app.events.indexOf("create:2"),
+    );
+    expect(app.native.active).toBe(1);
+    expect(app.driver.generation).toBe(2);
+    expect(app.online).toEqual([true]);
+    expect(app.timers.count(0)).toBe(1);
+    expect(app.controller.getHostState()).toMatchObject({
+      status: "online",
+      hostId: "host-1",
+    });
+    for (const request of app.requests.filter(
+      (request) =>
+        request.path.endsWith("/heartbeat") ||
+        request.path.endsWith("/hosts/start"),
+    )) {
+      expect(request.body).toMatchObject({
+        supportedCapabilities: [...SUPPORTED_COMPUTER_USE_CAPABILITIES],
+      });
+    }
+  });
+  it("rejects an explicit snapshot from a retired generation before any new native action", async () => {
+    const app = desktop();
+    await app.controller.start();
+    const command = app.claim({
+      id: "capture",
+      kind: "app.state",
+      payload: { app: "test.app" },
+    });
+    app.timers.run(5_000);
+    command.response.resolve();
+    const completed = await command.completed.promise;
+    const result = completed.result as { snapshotId: string };
+    const transition = app.controller.transitionDriver(app.driverDefinition);
+    command.completeResponse.resolve();
+    await transition;
+    const old = app.claim({
+      ...action,
+      id: "stale",
+      payload: { ...action.payload, snapshotId: result.snapshotId },
+    });
+    app.timers.run(0);
+    old.response.resolve();
+    expect(await old.completed.promise).toMatchObject({
+      status: "failed",
+      error: { code: "unsupported_command" },
+    });
+    expect(app.events).not.toContain("2:keyboard.type_text");
+    old.completeResponse.resolve();
+  });
+  it.each(["stop", "auth", "quit", "update"] as const)(
+    "lets %s supersede a delayed host registration",
+    async (reason) => {
+      const app = desktop();
+      const registration = deferred<void>();
+      const response = deferred<void>();
+      const stopped = deferred<void>();
+      server.use(
+        http.post(`${api}/api/computer-use/hosts/start`, async () => {
+          registration.resolve();
+          await response.promise;
+          return HttpResponse.json({
+            hostId: "late-host",
+            hostToken: "late-token",
+          });
+        }),
+        http.post(`${api}/api/computer-use/host/stop`, ({ request }) => {
+          expect(request.headers.get("authorization")).toBe(
+            "Bearer late-token",
+          );
+          stopped.resolve();
+          return HttpResponse.json({});
+        }),
+      );
+      const start = app.controller.start();
+      await registration.promise;
+      if (reason === "stop") await app.controller.stop();
+      if (reason === "auth") await app.controller.stopForAuthChange();
+      if (reason === "quit") await app.controller.stopForQuit();
+      if (reason === "update")
+        await app.controller.stopForQuit("update_relaunch");
+      response.resolve();
+      await start;
+      await stopped.promise;
+      expect(app.controller.getHostState().status).toBe("offline");
+      expect(app.online).not.toContain(true);
+      expect(app.timers.count(5_000)).toBe(0);
+      expect(app.native.active).toBe(0);
+    },
+  );
+  it("waits for native disposal acknowledgment before publishing a replacement", async () => {
+    const app = desktop();
+    await app.controller.start();
+    app.native.holdClose();
+    const transition = app.controller.transitionDriver(app.driverDefinition);
+    await app.native.closeReached.promise;
+    expect(app.driver.generation).toBeNull();
+    expect(app.native.created).toBe(1);
+    await app.permissions.refreshComputerUsePermissionState();
+    expect(
+      app.events.filter((event) => event === "1:permissions.state"),
+    ).toHaveLength(2);
+    app.native.close();
+    await transition;
+    expect(app.native.created).toBe(2);
+  });
+  it("keeps the permission request UX available after a manual stop without restarting commands", async () => {
+    const app = desktop();
+    await app.controller.start();
+    await app.controller.stop();
+    await app.permissions.requestComputerUseAccessibilityPermission();
+    expect(app.events).toContain("2:permissions.request_accessibility");
+    await app.controller.start();
+    expect(app.controller.getHostState().status).toBe("offline");
+    await app.controller.start({ userInitiated: true });
+    expect(app.controller.getHostState().status).toBe("online");
+  });
+  it("does not revive a start whose first permission read finishes after Stop", async () => {
+    const app = desktop();
+    const permission = app.native.pause("permissions.state");
+    const start = app.controller.start();
+    await permission.reached.promise;
+    const stop = app.controller.stop();
+    permission.resume.resolve();
+    await Promise.all([start, stop]);
+    expect(app.controller.getHostState().status).toBe("offline");
+    expect(app.requests).toEqual([]);
+    expect(app.native.active).toBe(0);
+    await app.controller.start();
+    expect(app.native.created).toBe(1);
+  });
+
+  it("serializes a replacement requested while the initial permission gate is pending", async () => {
+    const app = desktop();
+    const permission = app.native.pause("permissions.state");
+    const start = app.controller.start();
+    await permission.reached.promise;
+    const transition = app.controller.transitionDriver(app.driverDefinition);
+    permission.resume.resolve();
+    await Promise.all([start, transition]);
+    expect(app.driver.generation).toBe(2);
+    expect(app.native.active).toBe(1);
+    expect(app.controller.getHostState().status).toBe("online");
+    expect(app.timers.count(0)).toBe(1);
+  });
+
+  it.each(["stop", "auth", "quit", "update"] as const)(
+    "lets %s supersede a transition with an in-flight action",
+    async (reason) => {
+      const app = desktop();
+      await app.controller.start();
+      const write = app.native.pause("keyboard.type_text");
+      const command = app.claim(action);
+      app.timers.run(5_000);
+      command.response.resolve();
+      await write.reached.promise;
+      const transition = app.controller.transitionDriver(app.driverDefinition);
+      const rejected = expect(transition).rejects.toThrow("superseded");
+      const stop =
+        reason === "stop"
+          ? app.controller.stop()
+          : reason === "auth"
+            ? app.controller.stopForAuthChange()
+            : app.controller.stopForQuit(
+                reason === "update" ? "update_relaunch" : "app_quit",
+              );
+      write.resume.resolve();
+      await stop;
+      await rejected;
+      expect(app.controller.getHostState().status).toBe("offline");
+      expect(app.native.created).toBe(1);
+      expect(app.native.active).toBe(0);
+      expect(
+        app.events.filter((event) => event === "1:keyboard.type_text"),
+      ).toHaveLength(1);
+      expect(app.timers.count(0)).toBe(0);
+    },
+  );
+
+  it.each(["claim", "permission", "action", "capture", "completion"] as const)(
+    "fails closed on a hung %s without releasing cleanup ownership or replaying",
+    async (phase) => {
+      const app = desktop({ transitionTimeoutMs: 1_234 });
+      await app.controller.start();
+      const gate =
+        phase === "permission"
+          ? app.native.pause("permissions.state")
+          : phase === "action"
+            ? app.native.pause("keyboard.type_text")
+            : phase === "capture"
+              ? app.native.pause("app.state")
+              : null;
+      const command = app.claim(action);
+      app.timers.run(5_000);
+      await command.reached.promise;
+      if (phase !== "claim") command.response.resolve();
+      if (gate) await gate.reached.promise;
+      if (phase === "completion") await command.completed.promise;
+      const transition = app.controller.transitionDriver(app.driverDefinition);
+      const rejected = expect(transition).rejects.toThrow("timed out");
+      app.timers.run(1_234);
+      await rejected;
+      expect(app.controller.getHostState().status).toBe("error");
+      expect(app.native.created).toBe(1);
+      expect(app.events).not.toContain("dispose:1");
+      const start = app.controller.start({ userInitiated: true });
+      const startRejected = expect(start).rejects.toThrow("timed out");
+      app.timers.run(1_234);
+      await startRejected;
+      expect(app.native.created).toBe(1);
+      command.response.resolve();
+      gate?.resume.resolve();
+      command.completeResponse.resolve();
+      await app.controller.stop();
+      expect(app.native.active).toBe(0);
+      expect(
+        app.events.filter((event) => event === "1:keyboard.type_text").length,
+      ).toBeLessThanOrEqual(1);
+      expect(app.timers.count(0)).toBe(0);
+      await app.controller.start({ userInitiated: true });
+      expect(app.driver.generation).toBe(2);
+      expect(app.controller.getHostState().status).toBe("online");
+    },
+  );
+
+  it("serializes different requests and resumes one polling path after the last replacement", async () => {
+    const app = desktop();
+    await app.controller.start();
+    const other: ComputerUseDriver = {
+      ...app.driverDefinition,
+      id: "replacement-fixture",
+    };
+    const first = app.controller.transitionDriver(app.driverDefinition);
+    const second = app.controller.transitionDriver(other);
+    await Promise.all([first, second]);
+    expect(app.driver.generation).toBe(3);
+    expect(app.native.active).toBe(1);
+    expect(app.timers.count(0)).toBe(1);
+    expect(app.events.filter((event) => event.startsWith("dispose:"))).toEqual([
+      "dispose:1",
+      "dispose:2",
+    ]);
+    expect(app.online).toEqual([true]);
+  });
+  it("preserves a real stdio MCP process and dispatches plugin commands after resume", async () => {
+    const plugin = pluginFixture();
+    const app = desktop({ plugin: plugin.manager });
+    await app.controller.start();
+    await plugin.ready;
+    const command: ComputerUseCommand = {
+      id: "plugin",
+      kind: "plugin.call",
+      payload: { plugin: "mcp", server: "fixture", tool: "pid", arguments: {} },
+    };
+    const before = await plugin.manager.execute(command);
+    expect(before.status).toBe("succeeded");
+    await app.controller.transitionDriver(app.driverDefinition);
+    expect(plugin.manager.getState().servers[0]?.status).toBe("running");
+    const queued = app.claim(command);
+    app.timers.run(0);
+    queued.response.resolve();
+    expect(await queued.completed.promise).toEqual(before);
+    queued.completeResponse.resolve();
+    expect(app.online).toEqual([true]);
+  });
+
+  it("preserves manual Stop when a late sign-in completion arrives", async () => {
+    const app = desktop();
+    await app.controller.start();
+    await app.controller.stop();
+    await app.controller.startForAuthChange(new AbortController().signal);
+    expect(app.controller.getHostState().status).toBe("offline");
+    expect(app.native.created).toBe(1);
+  });
+  it("keeps a separate recorder session alive across native driver retirement", async () => {
+    const app = desktop();
+    const recorder = recorderFixture();
+    await app.controller.start();
+    await recorder.prepare({
+      sourceId: "display:1",
+      sourceKind: "display",
+      systemAudio: false,
+      microphone: false,
+    });
+    await recorder.start();
+    const sessionId = recorder.getState().sessionId;
+    expect(recorder.getState().status).toBe("recording");
+    await app.controller.transitionDriver(app.driverDefinition);
+    await recorder.refreshRecordingStatus();
+    expect(recorder.getState()).toMatchObject({
+      status: "recording",
+      sessionId,
+    });
+    await recorder.pause();
+    await recorder.resume();
+    expect(recorder.getState()).toMatchObject({
+      status: "recording",
+      sessionId,
+    });
+    expect(app.driver.generation).toBe(2);
+  });
+  it("refuses replacement when native process exit cannot be confirmed", async () => {
+    const app = desktop({
+      nativeShutdownGraceMs: 0,
+      expectedQuitError: "did not exit after SIGKILL",
+    });
+    await app.controller.start();
+    app.native.holdClose();
+    await expect(
+      app.controller.transitionDriver(app.driverDefinition),
+    ).rejects.toThrow("did not exit after SIGKILL");
+    expect(app.controller.getHostState().status).toBe("error");
+    expect(app.driver.generation).toBeNull();
+    await expect(app.controller.start({ userInitiated: true })).rejects.toThrow(
+      "did not exit after SIGKILL",
+    );
+    expect(app.native.created).toBe(1);
+    expect(app.native.active).toBe(1);
+    app.native.close();
+  });
+
+  it("does not register a host when the auth lifetime aborts during readiness", async () => {
+    const app = desktop();
+    const reached = deferred<void>();
+    const response = deferred<void>();
+    server.use(
+      http.get(`${api}/api/auth/me`, async () => {
+        reached.resolve();
+        await response.promise;
+        return HttpResponse.json({
+          userId: "user",
+          email: "test@example.test",
+          orgId: "org",
+        });
+      }),
+    );
+    const auth = new AbortController();
+    const start = app.controller.startForAuthChange(auth.signal);
+    await reached.promise;
+    auth.abort();
+    response.resolve();
+    await start;
+    await app.controller.stop();
+    expect(app.controller.getHostState().status).toBe("offline");
+    expect(
+      app.requests.some((request) => request.path.endsWith("/hosts/start")),
+    ).toBe(false);
+    expect(app.native.active).toBe(0);
+  });
+  it("blocks a recovery callback already queued before the admission pause", async () => {
+    const app = desktop();
+    await app.controller.start();
+    let claims = 0;
+    server.use(
+      http.post(`${api}/api/computer-use/host/commands/next`, () => {
+        claims++;
+        return new HttpResponse(null, { status: 503 });
+      }),
+    );
+    app.timers.run(5_000);
+    await app.waitForHostState("recovering");
+    const heartbeat = app.timers.take(2_000);
+    const recovery = app.timers.take(2_000);
+    app.native.holdClose();
+    const transition = app.controller.transitionDriver(app.driverDefinition);
+    await app.native.closeReached.promise;
+    recovery();
+    expect(claims).toBe(1);
+    expect(app.native.created).toBe(1);
+    app.native.close();
+    await transition;
+    expect(app.timers.count(0)).toBe(1);
+    heartbeat();
+    await app.heartbeat.promise;
+    expect(app.controller.getHostState().status).toBe("online");
+    expect(claims).toBe(1);
+  });
+});

--- a/turbo/apps/desktop/src/desktop-computer-use-runtime.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-runtime.test.ts
@@ -1,3 +1,5 @@
+import { ComputerUseDriverController } from "./computer-use-driver";
+import { createComputerUseNativeBackend } from "./computer-use-native";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -104,7 +106,11 @@ function createDesktop(product: "okou" | "zero" = "okou") {
         addClientHeaders,
         hostFetch: (input, init) => fetch(input, init),
         getPermissions: options.getPermissions ?? (() => permissions),
-        executeCommand: async () => ({ status: "succeeded", result: {} }),
+        driver: new ComputerUseDriverController({
+          id: "okou",
+          createBackend: () => createComputerUseNativeBackend(),
+        }),
+        executePluginCommand: async () => ({ status: "succeeded", result: {} }),
       },
       {
         product: config.identity.product,

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -17,15 +17,8 @@ import {
   shell,
   type MenuItemConstructorOptions,
 } from "electron";
-import {
-  ComputerUseSnapshotStore,
-  SUPPORTED_COMPUTER_USE_CAPABILITIES,
-  executeComputerUseCommand,
-} from "./computer-use-accessibility";
-import {
-  COMPUTER_USE_PLUGIN_CALL_KIND,
-  isComputerUseMcpPluginCallPayload,
-} from "@okouai/api-contracts/contracts/computer-use-plugins";
+import { SUPPORTED_COMPUTER_USE_CAPABILITIES } from "./computer-use-accessibility";
+import { isComputerUseMcpPluginCallPayload } from "@okouai/api-contracts/contracts/computer-use-plugins";
 import {
   MAC_AUTOMATION_SETTINGS_URL,
   createAutomationPermissionDeniedPrompt,
@@ -61,19 +54,9 @@ import type {
 } from "./desktop-recorder-types";
 import { buildWindowOptions } from "./desktop-recorder-window-options";
 import { areaToGlobal } from "./desktop-recorder-overlay-geometry";
-import {
-  getComputerUsePermissionState,
-  probeComputerUseAutomationPermission,
-  refreshComputerUsePermissionState,
-  recordComputerUseAutomationPermissionDenied,
-  requestComputerUseAccessibilityPermission,
-  requestComputerUseScreenRecordingPermission,
-  setComputerUsePermissionNativeBackend,
-} from "./computer-use-permissions";
-import {
-  createComputerUseNativeBackend,
-  type ComputerUseNativeShutdownReason,
-} from "./computer-use-native";
+import { createComputerUsePermissions } from "./computer-use-permissions";
+import { ComputerUseDriverController } from "./computer-use-driver";
+import { createComputerUseNativeBackend } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
 import desktopBrandAssets from "./desktop-brand-assets.json";
 import { createDesktopClientHeaderInjector } from "./desktop-client-headers";
@@ -164,8 +147,6 @@ const MAC_SCREEN_RECORDING_SETTINGS_URL =
   "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture";
 let mainWindow: BrowserWindow | null = null;
 let appIsQuitting = false;
-let computerUseNativeBackendDisposed = false;
-let computerUseNativeBackendDisposePromise: Promise<void> | null = null;
 let computerUseQuitPreparationPromise: Promise<void> | null = null;
 let computerUseQuitPreparationComplete = false;
 let desktopTray: DesktopTrayController | null = null;
@@ -184,11 +165,23 @@ let filesystemPluginManager: DesktopFilesystemPluginManager | null = null;
 let mcpPluginManager: DesktopMcpPluginManager | null = null;
 let desktopAutoUpdates: DesktopAutoUpdatesController | null = null;
 const desktopAuthStartGate = createDesktopAuthStartGate();
-const computerUseSnapshotStore = new ComputerUseSnapshotStore();
-const computerUseNativeBackend = createComputerUseNativeBackend({
-  onRuntimeError: captureDesktopNativeHelperError,
+const computerUseDriver = new ComputerUseDriverController({
+  id: "okou",
+  createBackend: () =>
+    createComputerUseNativeBackend({
+      onRuntimeError: captureDesktopNativeHelperError,
+    }),
 });
-setComputerUsePermissionNativeBackend(computerUseNativeBackend);
+const {
+  getComputerUsePermissionState,
+  refreshComputerUsePermissionState,
+  requestComputerUseAccessibilityPermission,
+  requestComputerUseScreenRecordingPermission,
+  probeComputerUseAutomationPermission,
+  recordComputerUseAutomationPermissionDenied,
+} = createComputerUsePermissions((read) =>
+  computerUseDriver.withPermissionProvider(read),
+);
 const automationPermissionPrompt = createAutomationPermissionDeniedPrompt({
   sourceLabel: config.identity.displayName,
   showDialog: async (options) => {
@@ -312,6 +305,7 @@ const developerTools = new DeveloperToolsController({
   },
 });
 const computerUseController = new ComputerUseRuntimeController({
+  driver: computerUseDriver,
   createRuntime: createComputerUseHostRuntime,
   refreshPermissions: refreshComputerUsePermissionState,
   getAuthState: () => getAuthSession().getAuthState(),
@@ -673,17 +667,12 @@ function createComputerUseHostRuntime(): ComputerUseHostRuntime {
       addClientHeaders: addDesktopClientHeaders,
       getPermissions: refreshComputerUsePermissionState,
       getSupportedCapabilities: supportedComputerUseCapabilities,
-      executeCommand: (command, permissions) => {
-        if (command.kind === COMPUTER_USE_PLUGIN_CALL_KIND) {
-          if (isComputerUseMcpPluginCallPayload(command.payload)) {
-            return ensureMcpPluginManager().execute(command);
-          }
-          return ensureFilesystemPluginManager().execute(command);
+      driver: computerUseDriver,
+      executePluginCommand: (command) => {
+        if (isComputerUseMcpPluginCallPayload(command.payload)) {
+          return ensureMcpPluginManager().execute(command);
         }
-        return executeComputerUseCommand(command, permissions, {
-          nativeBackend: computerUseNativeBackend,
-          snapshotStore: computerUseSnapshotStore,
-        });
+        return ensureFilesystemPluginManager().execute(command);
       },
       onCommandFailure: automationPermissionPrompt,
       onChange: notifyComputerUseChanged,
@@ -961,28 +950,11 @@ function refreshComputerUsePermissionsForState(): void {
     });
 }
 
-function disposeComputerUseNativeBackend(
-  reason: ComputerUseNativeShutdownReason,
-): Promise<void> {
-  if (computerUseNativeBackendDisposed) {
-    return Promise.resolve();
-  }
-  if (!computerUseNativeBackendDisposePromise) {
-    computerUseNativeBackendDisposePromise = computerUseNativeBackend
-      .dispose(reason)
-      .finally(() => {
-        computerUseNativeBackendDisposed = true;
-      });
-  }
-  return computerUseNativeBackendDisposePromise;
-}
-
 async function prepareForQuitAndInstall(): Promise<void> {
   quitConfirmation.allowQuitWithoutConfirmation();
   appIsQuitting = true;
   releaseKeepAwake();
-  await computerUseController.stopForQuit();
-  await disposeComputerUseNativeBackend("update_relaunch");
+  await computerUseController.stopForQuit("update_relaunch");
 }
 
 // Bootstrap contract: the auto-updater is owned by bootstrap.ts so it keeps
@@ -1415,15 +1387,10 @@ async function verifyDesktopSmokeBridge(): Promise<void> {
 async function maybeStartComputerUseAfterAuth(
   signal: AbortSignal,
 ): Promise<void> {
-  await computerUseController.stopForAuthChange();
+  await computerUseController.startForAuthChange(signal);
   signal.throwIfAborted();
   notifyAuthChanged();
-  const permissions = await refreshComputerUsePermissionState();
-  signal.throwIfAborted();
   notifyComputerUseChanged();
-  if (hasRequiredComputerUsePermissions(permissions)) {
-    await computerUseController.start({ userInitiated: true });
-  }
 }
 
 async function shouldOpenComputerUseSetupWindowOnLaunch(): Promise<boolean> {
@@ -1523,21 +1490,14 @@ if (!hasSingleInstanceLock) {
     appIsQuitting = true;
     releaseKeepAwake();
     globalShortcut.unregisterAll();
-    if (
-      computerUseQuitPreparationComplete ||
-      (computerUseNativeBackendDisposed &&
-        !computerUseController.quitStopRequired())
-    ) {
+    if (computerUseQuitPreparationComplete) {
       return;
     }
     event.preventDefault();
     if (!computerUseQuitPreparationPromise) {
       computerUseQuitPreparationPromise = (async () => {
         try {
-          if (computerUseController.quitStopRequired()) {
-            await computerUseController.stopForQuit();
-          }
-          await disposeComputerUseNativeBackend("app_quit");
+          await computerUseController.stopForQuit();
         } catch (error) {
           console.error("Unable to prepare Computer Use for app quit", error);
         } finally {


### PR DESCRIPTION
## Summary

Desktop currently shares one permanent native backend and snapshot store, while a host start or claim can finish after Stop. Introduce a generation owner and lease each command before its claim request through permission checks, action, post-action capture, and completion reporting. Production registers only the existing Okou driver.

A serialized driver replacement pauses and drains admission without stopping the authorized cloud host, heartbeat, MCP processes, or recorder. Retire the old backend and snapshot mappings before admitting a replacement; a timed-out drain or unconfirmed process exit fails closed and retains cleanup ownership. Stop, auth/workspace changes, Quit, and update supersede pending work, and auth completion preserves Manual Stop. Permission probes are explicitly scoped to the selected owner while the signed-host setup/request experience remains available.

## Contracts and scope

- Preserve public commands, payloads, results, default native capabilities, and auth/header routing. A new generation rejects an explicit old snapshot before dispatch.
- Treat driver transitions as busy for automatic updates. Only healthy replacement uses pause/drain/resume; failures withdraw the host instead of publishing an empty capability list.
- Native shutdown now rejects if process exit is unconfirmed, and retains timed-out helper processes until they exit. This is required to prove retirement before another executor starts.
- No CUA package/runtime, selector, persisted preference, API/DB migration, Swift-shell change, production operation, or release.
- Based on fetched/rebased `main` at `40a3e98ef4b5ec3b61bd1570b1d08aed79d9afe4`. Reviewed the latest 100 open PRs (24 returned): #31838 and #31835 remain Swift drafts; #32171 has retirement document/contract overlap. None is a functional dependency.

## Verification

- Prettier, Desktop lint, Desktop TypeScript check, and workspace-scoped Knip passed.
- Targeted Desktop regression run passed: 19 files / 297 tests covering host, native helper client, runtime/auth wiring, command/snapshot/window behavior, startup, updater/bootstrap, MCP, and recorder. The final driver integration suite passed all 26 cases after adding the queued-recovery race.
- Driver integration tests use the real lifecycle controller, driver owner, permission store, native client, executor, auth session, and host. Only native process/HTTP boundaries and owned timers are controlled. Additional stdio fixtures verify the same MCP PID and recorder session survive replacement.
- Electron CJS build and bootstrap bundle guard passed.
- No full local Vitest suite or local dev server was run. Required PR/merge-group CI remains the merge gate.

Interactive macOS TCC, signed-package behavior, and real application automation remain hardware acceptance items; these tests do not claim that acceptance.

Closes #32263
