### PR TITLE
refactor(image-recognition): migrate first-party guidance to canonical command

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
@@ -578,8 +578,9 @@ describe("custom model provider gateway routes", () => {
         },
       });
       expect(deepseekClaim.appendSystemPrompt).toContain(
-        'okou recognize --file <image-path> --prompt "<instruction>"',
+        'okou image-recognition --file <image-path> --prompt "<instruction>"',
       );
+      expect(deepseekClaim.appendSystemPrompt).not.toContain("okou recognize");
 
       await runs.requestCancelRun(actor, deepseekRunId, [200]);
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8742,7 +8742,10 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       );
     }
     expect(unsupported.claim.appendSystemPrompt ?? "").toContain(
-      'okou recognize --file <image-path> --prompt "<instruction>"',
+      'okou image-recognition --file <image-path> --prompt "<instruction>"',
+    );
+    expect(unsupported.claim.appendSystemPrompt ?? "").not.toContain(
+      "okou recognize",
     );
     expect(verifyOkouToken(unsupportedToken)?.capabilities).toContain(
       "image-recognition:write",
@@ -8755,7 +8758,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       throw new Error("Expected the supported-model run to expose OKOU_TOKEN");
     }
     expect(supported.claim.appendSystemPrompt ?? "").not.toContain(
-      "okou recognize",
+      "okou image-recognition",
     );
     expect(verifyOkouToken(supportedToken)?.capabilities).not.toContain(
       "image-recognition:write",
@@ -8768,7 +8771,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       throw new Error("Expected the unknown-model run to expose OKOU_TOKEN");
     }
     expect(unknown.claim.appendSystemPrompt ?? "").not.toContain(
-      "okou recognize",
+      "okou image-recognition",
     );
     expect(verifyOkouToken(unknownToken)?.capabilities).not.toContain(
       "image-recognition:write",

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -406,7 +406,7 @@ type DbTransaction = Tx;
 const CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT =
   "If you use the built-in image generation tool and it saves generated output image file(s) to local paths, upload each output file you intend to show with `okou web upload-file -f <path>` before telling the web chat user the image is available. Quote the path when needed. Do not provide only sandbox-local paths, because users cannot open local files.";
 const ZERO_IMAGE_RECOGNITION_PROMPT =
-  '# Image Recognition Fallback\n\nThis run\'s selected model cannot inspect images directly. To inspect one local PNG, JPEG, or WebP image up to 20 MB, run `okou recognize --file <image-path> --prompt "<instruction>"`.';
+  '# Image Recognition Fallback\n\nThis run\'s selected model cannot inspect images directly. To inspect one local PNG, JPEG, or WebP image up to 20 MB, run `okou image-recognition --file <image-path> --prompt "<instruction>"`.';
 const RESTRICTED_EXPLICIT_CONTENT_PROMPT = [
   "# Restricted Explicit Content",
   "",

--- a/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
@@ -845,11 +845,11 @@ describe("registerCommands", () => {
       "Recognize an image?",
     );
     expect(buildHelpText(decodeSandboxTokenPayload(eligibleToken))).toContain(
-      "okou recognize --file",
+      "okou image-recognition --file",
     );
     expect(
       buildHelpText(decodeSandboxTokenPayload(eligibleToken)),
-    ).not.toContain("okou image-recognition --file");
+    ).not.toContain("okou recognize --file");
   });
 
   it("should show billing help examples only for billing capabilities", () => {

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -615,8 +615,8 @@ export function buildHelpText(
       payload,
     ),
     ...commandExampleIfVisible(
-      "recognize",
-      '  Recognize an image?    okou recognize --file ./image.png --prompt "Describe it"',
+      "image-recognition",
+      '  Recognize an image?    okou image-recognition --file ./image.png --prompt "Describe it"',
       payload,
     ),
     ...commandExampleIfVisible(


### PR DESCRIPTION
## Summary

- switch eligible text-only run fallback guidance to `okou image-recognition`
- use the canonical command identity and spelling in capability-aware root help
- update focused CLI and API coverage while preserving image-capable and unknown-model eligibility boundaries

## Compatibility

- retain the hidden, directly invocable `okou recognize` compatibility command and `okou help recognize`
- retain canonical `POST /api/image-recognition` and compatibility `POST /api/recognize` client routing
- change no capability, model eligibility, auth, upload, schema, MIME/size, model, pricing, billing, settlement, error, or stdout behavior

## Validation

- `pnpm exec prettier --check` on all five changed files
- `pnpm -F @okouai/cli lint`
- `pnpm -F api lint`
- `pnpm -F @okouai/cli check-types`
- `pnpm -F api check-types`
- `pnpm knip --workspace @okouai/cli --workspace api`
- `pnpm -F @okouai/cli build`
- `pnpm -F api build`
- runtime API schema compatibility against `runtime-api-schema-prod/current.json` with 0 findings
- CLI focused suites: 3 files, 105 tests passed
- API model-provider gateway suite: 8 tests passed
- API run-lifecycle image-recognition eligibility case: 1 test passed
- API image-recognition canonical and compatibility route suite: 10 tests passed
- scoped live-source search confirms first-party writers no longer emit `okou recognize` while compatibility implementation, tests, and drain comments remain

Closes #32271
Parent: #26929