### PR TITLE
fix(platform): isolate markdown parsing and support underline

### DIFF
--- a/turbo/apps/platform/src/lib/markdown/pipeline.ts
+++ b/turbo/apps/platform/src/lib/markdown/pipeline.ts
@@ -1,5 +1,5 @@
 import type { Data, Element, ElementContent, Root, RootContent } from "hast";
-import { Marked, Renderer, type Token, type Tokens } from "marked";
+import { marked, Marked, Renderer, type Token, type Tokens } from "marked";
 import { normalizeUri } from "micromark-util-sanitize-uri";
 import rehypeAttrs from "rehype-attr";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
@@ -111,6 +111,8 @@ declare module "hast" {
 type MarkdownCard = NonNullable<Data["card"]>;
 
 interface MarkdownParseOptions {
+  /** Enable the isolated display parser and its explicit underline extension. */
+  readonly underline?: boolean;
   /**
    * Replace closed ```mermaid fences with diagram marker nodes. Only surfaces
    * whose trees are prepared by a command enable this — the command resolves
@@ -517,7 +519,8 @@ export function parseMarkdownTree(
   source: string,
   options: MarkdownParseOptions,
 ): Root {
-  const html = markdownParser.parse(source, {
+  const parser = options.underline ? markdownParser : marked;
+  const html = parser.parse(source, {
     async: false,
     renderer: options.mermaid ? createMarkedRenderer() : null,
   });

--- a/turbo/apps/platform/src/lib/markdown/pipeline.ts
+++ b/turbo/apps/platform/src/lib/markdown/pipeline.ts
@@ -19,12 +19,14 @@ import {
 import { findHexRgbColors } from "./hex-rgb-color.ts";
 import { rehypeRewriteHandle } from "./uiw-nodes.ts";
 
+const UNDERLINE_TOKEN_TYPE = "underline";
+
 // Tiptap registers editor-only tokenizers on the default Marked instance.
 // Display parsing owns its extensions so mounting an editor cannot change it.
 const markdownParser: Readonly<Marked> = new Marked({
   extensions: [
     {
-      name: "underline",
+      name: UNDERLINE_TOKEN_TYPE,
       level: "inline",
       start(source) {
         return source.indexOf("++");
@@ -59,7 +61,7 @@ const markdownParser: Readonly<Marked> = new Marked({
               continue;
             }
             return {
-              type: "underline",
+              type: UNDERLINE_TOKEN_TYPE,
               raw: source.slice(0, index + 2),
               tokens: this.lexer.inlineTokens(content),
             };

--- a/turbo/apps/platform/src/lib/markdown/pipeline.ts
+++ b/turbo/apps/platform/src/lib/markdown/pipeline.ts
@@ -1,5 +1,5 @@
 import type { Data, Element, ElementContent, Root, RootContent } from "hast";
-import { marked, Renderer, type Token, type Tokens } from "marked";
+import { Marked, Renderer, type Token, type Tokens } from "marked";
 import { normalizeUri } from "micromark-util-sanitize-uri";
 import rehypeAttrs from "rehype-attr";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
@@ -18,6 +18,64 @@ import {
 } from "../rehype-mermaid.ts";
 import { findHexRgbColors } from "./hex-rgb-color.ts";
 import { rehypeRewriteHandle } from "./uiw-nodes.ts";
+
+// Tiptap registers editor-only tokenizers on the default Marked instance.
+// Display parsing owns its extensions so mounting an editor cannot change it.
+const markdownParser: Readonly<Marked> = new Marked({
+  extensions: [
+    {
+      name: "underline",
+      level: "inline",
+      start(source) {
+        return source.indexOf("++");
+      },
+      tokenizer(source) {
+        if (this.lexer.state.inRawBlock || !/^\+\+\S/u.test(source)) {
+          return undefined;
+        }
+        for (let index = 2; index < source.length; index++) {
+          if (source[index] === "\\") {
+            index++;
+            continue;
+          }
+          // A code span owns its delimiters; ++ inside it is literal text.
+          if (source[index] === "`") {
+            const remaining = source.slice(index);
+            const code = /^(`+)([^`]|[^`][\s\S]*?[^`])\1(?!`)/u.exec(remaining);
+            const run = /^`+/u.exec(remaining);
+            if (code) {
+              index += code[0].length - 1;
+            } else if (run) {
+              index += run[0].length - 1;
+            }
+            continue;
+          }
+          if (source.startsWith("++", index)) {
+            const content = source.slice(2, index);
+            if (content === "") {
+              return undefined;
+            }
+            if (/\s$/u.test(content)) {
+              continue;
+            }
+            return {
+              type: "underline",
+              raw: source.slice(0, index + 2),
+              tokens: this.lexer.inlineTokens(content),
+            };
+          }
+        }
+        return undefined;
+      },
+      renderer(token) {
+        if (token.tokens === undefined) {
+          throw new Error("Underline token is missing its inline tokens");
+        }
+        return `<u>${this.parser.parseInline(token.tokens)}</u>`;
+      },
+    },
+  ],
+});
 
 /**
  * Markers the pipeline puts on a node so the view can swap it for a component.
@@ -457,7 +515,7 @@ export function parseMarkdownTree(
   source: string,
   options: MarkdownParseOptions,
 ): Root {
-  const html = marked.parse(source, {
+  const html = markdownParser.parse(source, {
     async: false,
     renderer: options.mermaid ? createMarkedRenderer() : null,
   });

--- a/turbo/apps/platform/src/lib/markdown/plain-markdown.ts
+++ b/turbo/apps/platform/src/lib/markdown/plain-markdown.ts
@@ -13,12 +13,12 @@ const BLOCK_SYNTAX =
  */
 export function createPlainMarkdownTree(
   source: string,
-  options: { readonly mathEnabled: boolean },
+  options: { readonly mathEnabled: boolean; readonly underline?: boolean },
 ): Root | null {
   if (
     source.trim() !== source ||
     source.includes("\r") ||
-    source.includes("++") ||
+    (options.underline && source.includes("++")) ||
     INLINE_RICH_SYNTAX.test(source) ||
     (options.mathEnabled && source.includes("$")) ||
     AUTOLINK.test(source)

--- a/turbo/apps/platform/src/lib/markdown/plain-markdown.ts
+++ b/turbo/apps/platform/src/lib/markdown/plain-markdown.ts
@@ -18,6 +18,7 @@ export function createPlainMarkdownTree(
   if (
     source.trim() !== source ||
     source.includes("\r") ||
+    source.includes("++") ||
     INLINE_RICH_SYNTAX.test(source) ||
     (options.mathEnabled && source.includes("$")) ||
     AUTOLINK.test(source)

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -89,6 +89,7 @@ import { debounceCommand } from "../command-scheduling.ts";
 import {
   codexFastModeEnabled$,
   featureSwitch$,
+  richMarkdownUnderlineEnabled$,
 } from "../external/feature-switch.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
@@ -1862,6 +1863,7 @@ function createCardRefRegistrar({
 
 interface EventTree {
   readonly content: string;
+  readonly underline: boolean;
   readonly tree: Root | undefined;
   readonly error: boolean;
 }
@@ -1871,6 +1873,7 @@ interface RichEventTreePlan {
   readonly content: string;
   readonly treeSource: string;
   readonly descriptors: readonly CardDescriptorBlock[];
+  readonly underline: boolean;
 }
 
 function createEventTreeParser(registries: EventTreeRegistries) {
@@ -1892,6 +1895,7 @@ function createEventTreeParser(registries: EventTreeRegistries) {
     const tree = parseMarkdownTree(plan.treeSource, {
       mermaid: true,
       cards,
+      underline: plan.underline,
     });
     embedMermaidSignals(tree, (code) => {
       return set(mermaidDiagrams.register$, code);
@@ -1913,6 +1917,7 @@ function planEventTreeUpdates(
   events: readonly ChatEvent[],
   current: ReadonlyMap<string, EventTree>,
   chatActionContext: ChatActionContext,
+  underline: boolean,
 ): {
   readonly next: Map<string, EventTree> | undefined;
   readonly richPlans: RichEventTreePlan[];
@@ -1921,7 +1926,11 @@ function planEventTreeUpdates(
   const richPlans: RichEventTreePlan[] = [];
   for (const event of events) {
     const content = chatEventTreeContent(event);
-    if (content === null || current.get(event.id)?.content === content) {
+    const previous = current.get(event.id);
+    if (
+      content === null ||
+      (previous?.content === content && previous.underline === underline)
+    ) {
       continue;
     }
     const plan = chatEventTreePlan(event, chatActionContext);
@@ -1930,11 +1939,13 @@ function planEventTreeUpdates(
     }
     const plainTree = createPlainMarkdownTree(plan.treeSource, {
       mathEnabled: false,
+      underline,
     });
     next ??= new Map(current);
     if (plainTree !== null) {
       next.set(event.id, {
         content: plan.content,
+        underline,
         tree: plainTree,
         error: false,
       });
@@ -1944,10 +1955,11 @@ function planEventTreeUpdates(
     // body loads. This pending identity also deduplicates concurrent ensures.
     next.set(event.id, {
       content: plan.content,
+      underline,
       tree: undefined,
       error: false,
     });
-    richPlans.push({ eventId: event.id, ...plan });
+    richPlans.push({ eventId: event.id, ...plan, underline });
   }
   return { next, richPlans };
 }
@@ -1961,6 +1973,7 @@ function markPendingEventTreesFailed(
     const entry = current.get(plan.eventId);
     if (
       entry?.content === plan.content &&
+      entry.underline === plan.underline &&
       entry.tree === undefined &&
       !entry.error
     ) {
@@ -2010,6 +2023,7 @@ function createEventTreeSignals(registries: EventTreeRegistries) {
         const pendingEntry = pending.get(plan.eventId);
         if (
           pendingEntry?.content !== plan.content ||
+          pendingEntry.underline !== plan.underline ||
           pendingEntry.tree !== undefined ||
           pendingEntry.error
         ) {
@@ -2019,6 +2033,7 @@ function createEventTreeSignals(registries: EventTreeRegistries) {
         parsed ??= new Map(pending);
         parsed.set(plan.eventId, {
           content: plan.content,
+          underline: plan.underline,
           tree,
           error: false,
         });
@@ -2048,6 +2063,7 @@ function createEventTreeSignals(registries: EventTreeRegistries) {
         events,
         current,
         chatActionContext,
+        get(richMarkdownUnderlineEnabled$),
       );
       if (next) {
         set(internalEventTrees$, next);

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -126,6 +126,10 @@ export const chatRunWorkFoldingEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.ChatRunWorkFolding] ?? false;
 });
 
+export const richMarkdownUnderlineEnabled$ = computed((get): boolean => {
+  return get(featureSwitch$)[FeatureSwitchKey.RichMarkdownUnderline] ?? false;
+});
+
 export const avatarNeckSweaterEnabled$ = computed((get): boolean => {
   return get(featureSwitch$)[FeatureSwitchKey.AvatarNeckSweater] ?? false;
 });

--- a/turbo/apps/platform/src/signals/markdown-preview-tree.ts
+++ b/turbo/apps/platform/src/signals/markdown-preview-tree.ts
@@ -9,6 +9,7 @@ import {
   embedMermaidSignals,
 } from "./mermaid-diagram.ts";
 import type { TextPreviewComputed } from "./text-preview.ts";
+import { richMarkdownUnderlineEnabled$ } from "./external/feature-switch.ts";
 
 export type MarkdownPreviewTreeComputed = Computed<Promise<Root>>;
 
@@ -29,15 +30,20 @@ export function createMarkdownPreviewTree(
     // The preview's error surface can explicitly retry preparation without
     // replacing an otherwise unchanged file.
     get(richMarkdownRetryVersion$);
+    const underline = get(richMarkdownUnderlineEnabled$);
     const ownerSignal = "aborted" in owner ? owner : get(owner);
     const source = await get(text$);
     ownerSignal.throwIfAborted();
-    const plainTree = createPlainMarkdownTree(source, { mathEnabled: false });
+    const plainTree = createPlainMarkdownTree(source, {
+      mathEnabled: false,
+      underline,
+    });
     if (plainTree !== null) {
       return plainTree;
     }
     const tree = parseMarkdownTree(source, {
       mermaid: true,
+      underline,
     });
     ownerSignal.throwIfAborted();
     embedMermaidSignals(tree, (code) => {

--- a/turbo/apps/platform/src/signals/shared-thread-page/shared-thread-page-setup.ts
+++ b/turbo/apps/platform/src/signals/shared-thread-page/shared-thread-page-setup.ts
@@ -16,6 +16,7 @@ import { pathParams$ } from "../route.ts";
 import { updatePage$ } from "../react-router.ts";
 import { setPageSignal$ } from "../page-signal.ts";
 import { createSharedThreadRichContentSignals } from "./shared-thread-rich-content.ts";
+import { richMarkdownUnderlineEnabled$ } from "../external/feature-switch.ts";
 
 export const setupSharedThreadPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -29,6 +30,7 @@ export const setupSharedThreadPage$ = command(
       signal,
     );
     let sharedThread: SharedDisplayThread | null = null;
+    const underline = get(richMarkdownUnderlineEnabled$);
     if (result.status === 200) {
       const messages: SharedDisplayThread["messages"][number][] = [];
       const richMessages: (typeof result.body.messages)[number][] = [];
@@ -39,6 +41,7 @@ export const setupSharedThreadPage$ = command(
         }
         const tree = createPlainMarkdownTree(message.content, {
           mathEnabled: false,
+          underline,
         });
         if (tree === null) {
           richMessages.push(message);

--- a/turbo/apps/platform/src/signals/shared-thread-page/shared-thread-rich-content.ts
+++ b/turbo/apps/platform/src/signals/shared-thread-page/shared-thread-rich-content.ts
@@ -13,6 +13,7 @@ import {
 } from "../mermaid-diagram.ts";
 import { retryRichMarkdown$ } from "../rich-markdown-retry.ts";
 import { tapError } from "../utils.ts";
+import { richMarkdownUnderlineEnabled$ } from "../external/feature-switch.ts";
 
 export interface SharedThreadRichContentState {
   readonly status: "loading" | "error" | "ready";
@@ -45,43 +46,47 @@ export function createSharedThreadRichContentSignals(
     return get(internalState$);
   });
 
-  const load$ = command(async ({ set }, signal: AbortSignal): Promise<void> => {
-    set(internalState$, (current): SharedThreadRichContentState => {
-      return { status: "loading", trees: current.trees };
-    });
-    const trees = await tapError(
-      (async (): Promise<ReadonlyMap<number, Root>> => {
-        // Keep parser failures on the promise consumed by `tapError`.
-        await Promise.resolve();
-        signal.throwIfAborted();
-        const next = new Map<number, Root>();
-        for (const message of messages) {
-          const tree = parseMarkdownTree(message.content, {
-            mermaid: true,
+  const load$ = command(
+    async ({ get, set }, signal: AbortSignal): Promise<void> => {
+      const underline = get(richMarkdownUnderlineEnabled$);
+      set(internalState$, (current): SharedThreadRichContentState => {
+        return { status: "loading", trees: current.trees };
+      });
+      const trees = await tapError(
+        (async (): Promise<ReadonlyMap<number, Root>> => {
+          // Keep parser failures on the promise consumed by `tapError`.
+          await Promise.resolve();
+          signal.throwIfAborted();
+          const next = new Map<number, Root>();
+          for (const message of messages) {
+            const tree = parseMarkdownTree(message.content, {
+              mermaid: true,
+              underline,
+            });
+            embedMermaidSignals(tree, (code) => {
+              return set(mermaidDiagrams.register$, code);
+            });
+            embedImageLoadSignals(tree, (url) => {
+              return set(imageLoads.register$, url);
+            });
+            next.set(message.messageIndex, tree);
+          }
+          signal.throwIfAborted();
+          return next;
+        })(),
+        () => {
+          set(internalState$, (current): SharedThreadRichContentState => {
+            return { status: "error", trees: current.trees };
           });
-          embedMermaidSignals(tree, (code) => {
-            return set(mermaidDiagrams.register$, code);
-          });
-          embedImageLoadSignals(tree, (url) => {
-            return set(imageLoads.register$, url);
-          });
-          next.set(message.messageIndex, tree);
-        }
-        signal.throwIfAborted();
-        return next;
-      })(),
-      () => {
-        set(internalState$, (current): SharedThreadRichContentState => {
-          return { status: "error", trees: current.trees };
-        });
-      },
-    );
-    signal.throwIfAborted();
-    if (trees === undefined) {
-      return;
-    }
-    set(internalState$, { status: "ready", trees });
-  });
+        },
+      );
+      signal.throwIfAborted();
+      if (trees === undefined) {
+        return;
+      }
+      set(internalState$, { status: "ready", trees });
+    },
+  );
 
   const retry$ = command(({ set }): Promise<void> => {
     ownerSignal.throwIfAborted();

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -1,5 +1,6 @@
 import type { Root } from "hast";
 import type { CSSProperties } from "react";
+import { useGet } from "ccstate-react";
 
 import { i18n } from "../../i18n/index.ts";
 import {
@@ -8,6 +9,7 @@ import {
 } from "../../lib/markdown/plain-markdown.ts";
 import { MarkdownTextWithColorPreviews } from "./markdown-color-preview.tsx";
 import { MarkdownFrame } from "./markdown-frame.tsx";
+import { richMarkdownUnderlineEnabled$ } from "../../signals/external/feature-switch.ts";
 import {
   Markdown as RichMarkdown,
   MarkdownEventBody as RichMarkdownEventBody,
@@ -124,7 +126,10 @@ export function Markdown({
   escapeHtml = false,
   ...props
 }: MarkdownProps) {
-  const tree = createPlainMarkdownTree(props.source, { mathEnabled: false });
+  const tree = createPlainMarkdownTree(props.source, {
+    mathEnabled: false,
+    underline: useGet(richMarkdownUnderlineEnabled$),
+  });
   if (tree !== null && !escapeHtml) {
     return (
       <PlainMarkdown

--- a/turbo/apps/platform/src/views/components/rich-markdown.tsx
+++ b/turbo/apps/platform/src/views/components/rich-markdown.tsx
@@ -20,6 +20,7 @@ import { MarkdownCardView } from "../okou-page/chat-body-cards.tsx";
 import { MarkdownColorPreview } from "./markdown-color-preview.tsx";
 import { MarkdownFrame } from "./markdown-frame.tsx";
 import { MermaidDiagramView } from "./mermaid-diagram.tsx";
+import { richMarkdownUnderlineEnabled$ } from "../../signals/external/feature-switch.ts";
 
 type MarkdownNodeProp = { node?: Element };
 type MarkdownAnchorProps = ComponentPropsWithoutRef<"a"> & MarkdownNodeProp;
@@ -377,10 +378,9 @@ export function Markdown({
   readonly mediaPreview?: boolean;
   readonly escapeHtml?: boolean;
 }) {
-  const tree = parseMarkdownTree(
-    escapeHtml ? escapeHtmlTags(source) : source,
-    {},
-  );
+  const tree = parseMarkdownTree(escapeHtml ? escapeHtmlTags(source) : source, {
+    underline: useGet(richMarkdownUnderlineEnabled$),
+  });
   return (
     <MarkdownTreeFrame
       className={className}

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-message-previews.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-message-previews.test.tsx
@@ -5,6 +5,7 @@ import type {
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { HttpResponse } from "msw";
 import { expect, test } from "vitest";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import {
   click,
@@ -352,7 +353,11 @@ test("Persisted chat attachments open in the appropriate preview", async () => {
   const clipboard = context.mocks.browser.clipboardWriteText();
   const downloads = context.mocks.browser.blobDownload();
 
-  await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
+  await setupPage({
+    context,
+    path: `/chats/${ATTACHMENT_THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.RichMarkdownUnderline]: true },
+  });
 
   await expect(
     screen.findByText("Files from the completed review"),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-message-previews.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-message-previews.test.tsx
@@ -338,7 +338,7 @@ test("Persisted chat attachments open in the appropriate preview", async () => {
     return HttpResponse.text("metric,value\nlatency,42");
   });
   context.mocks.http.get("https://private-files.example/notes.md", () => {
-    return HttpResponse.text("# Review notes\n\nEverything is ready.");
+    return HttpResponse.text("# Review notes\n\n++Everything is ready.++");
   });
   context.mocks.http.get("https://private-files.example/summary.txt", () => {
     return HttpResponse.text("Plain text summary");
@@ -398,6 +398,7 @@ test("Persisted chat attachments open in the appropriate preview", async () => {
 
   click(getNamedButton("Open markdown preview for notes.md"));
   await expect(screen.findByText("Review notes")).resolves.toBeVisible();
+  expect(screen.getByText("Everything is ready.").tagName).toBe("U");
   click(await findNamedLink("Share"));
   await waitFor(() => {
     expect(clipboard.writes).toContain(markdownShareUrl);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-underline.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-underline.test.tsx
@@ -1,0 +1,230 @@
+import { act, screen } from "@testing-library/react";
+import {
+  agentInstructionsContract,
+  agentsByIdContract,
+} from "@okouai/api-contracts/contracts/agents";
+import { expect, test } from "vitest";
+import { marked } from "marked";
+
+import { click, setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { createMarkdownChatFixture } from "./markdown-page-test-helpers.ts";
+
+const context = testContext();
+
+test("A global tokenizer without a renderer cannot break chat Markdown", async () => {
+  const defaults = marked.defaults;
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      marked.setOptions(defaults);
+    },
+    { once: true },
+  );
+  marked.use({
+    extensions: [
+      {
+        name: "editorOnly",
+        level: "inline",
+        start(source) {
+          return source.indexOf("::");
+        },
+        tokenizer(source) {
+          const match = /^::(.+?)::/u.exec(source);
+          return match
+            ? { type: "editorOnly", raw: match[0], text: match[1] }
+            : undefined;
+        },
+      },
+    ],
+  });
+  const chat = createMarkdownChatFixture(context);
+  const rows = [
+    chat.outputMessage("**Readable** ::extension text::", { seqId: 1 }),
+    chat.runCompleted({ seqId: 2 }),
+  ];
+  chat.install({
+    rows: () => {
+      return rows;
+    },
+  });
+
+  await setupPage({ context, path: chat.path, host: "app.vm0.ai" });
+
+  const bold = await screen.findByText("Readable");
+  expect(bold.tagName).toBe("STRONG");
+  expect(bold.parentElement).toHaveTextContent("Readable ::extension text::");
+});
+
+test.each(["++Underlined text++", "**Prefix** ++Underlined text++"])(
+  "Underline renders without first opening an editor: %s",
+  async (source) => {
+    const chat = createMarkdownChatFixture(context);
+    const rows = [
+      chat.outputMessage(source, { seqId: 1 }),
+      chat.runCompleted({ seqId: 2 }),
+    ];
+    chat.install({
+      rows: () => {
+        return rows;
+      },
+    });
+
+    await setupPage({ context, path: chat.path, host: "app.vm0.ai" });
+
+    const underline = await screen.findByText("Underlined text");
+    expect(underline.tagName).toBe("U");
+  },
+);
+
+test("Underline preserves nested Markdown, literal code and escaped delimiters", async () => {
+  const chat = createMarkdownChatFixture(context);
+  const source = [
+    "++**Nested bold** and [Nested link](https://example.com)++",
+    "",
+    "**++Nested underline++**",
+    "",
+    "++`C++` and escaped \\+\\+ markers++",
+    "",
+    "`++Inline literal++` and \\+\\+Escaped literal\\+\\+ and C++ / i++",
+    "",
+    "<code>++HTML code literal++</code>",
+    "",
+    "```text",
+    "++Block literal++",
+    "```",
+    "",
+    "++&lt;literal&gt; &amp; **safe**++",
+  ].join("\n");
+  const rows = [
+    chat.outputMessage(source, { seqId: 1 }),
+    chat.runCompleted({ seqId: 2 }),
+  ];
+  chat.install({
+    rows: () => {
+      return rows;
+    },
+  });
+
+  await setupPage({ context, path: chat.path, host: "app.vm0.ai" });
+
+  const bold = await screen.findByText("Nested bold");
+  expect(bold.tagName).toBe("STRONG");
+  expect(bold.closest("u")).not.toBeNull();
+  expect(screen.getByText("Nested link").closest("u")).not.toBeNull();
+  expect(screen.getByText("Nested underline").closest("strong")).not.toBeNull();
+  const code = screen.getByText("C++", { selector: "code" });
+  expect(code.closest("u")).toHaveTextContent("C++ and escaped ++ markers");
+  expect(screen.getByText("++Inline literal++").closest("code")).not.toBeNull();
+  expect(screen.getByText("++Block literal++").closest("code")).not.toBeNull();
+  expect(
+    screen.getByText("++HTML code literal++").closest("code"),
+  ).not.toBeNull();
+  expect(screen.getByText(/Escaped literal/).textContent).toContain(
+    "++Escaped literal++ and C++ / i++",
+  );
+  expect(screen.getByText("safe").closest("u")).toHaveTextContent(
+    "<literal> & safe",
+  );
+});
+
+test("A streaming underline remains readable until its closing delimiter arrives", async () => {
+  const chat = createMarkdownChatFixture(context);
+  const rows = [
+    chat.outputMessage("++Streaming text", {
+      id: "streaming-underline",
+      runEventId: "streaming-underline",
+      seqId: 1,
+    }),
+  ];
+  chat.install({
+    rows: () => {
+      return rows;
+    },
+  });
+
+  await setupPage({ context, path: chat.path, host: "app.vm0.ai" });
+
+  await expect(screen.findByText("++Streaming text")).resolves.toBeVisible();
+  rows[0] = chat.outputMessage("++Streaming text++", {
+    id: "streaming-underline",
+    runEventId: "streaming-underline",
+    seqId: 2,
+    sequenceNumber: 1,
+  });
+  rows.push(chat.runCompleted({ seqId: 3, sequenceNumber: 2 }));
+  context.mocks.ably.trigger(chat.realtimeTopic);
+
+  const underline = await screen.findByText("Streaming text");
+  expect(underline.tagName).toBe("U");
+});
+
+test("Opening and reopening an instructions editor does not change chat parsing", async () => {
+  const chat = createMarkdownChatFixture(context);
+  const source =
+    "**Result** ++Stable underline++\n\n3. Stable list item\n4. Next item\n\n- [x] Completed task";
+  const rows = [
+    chat.outputMessage(source, { seqId: 1 }),
+    chat.runCompleted({ seqId: 2 }),
+  ];
+  chat.install({
+    rows: () => {
+      return rows;
+    },
+  });
+  context.mocks.api(agentInstructionsContract.get, ({ respond }) => {
+    return respond(200, {
+      filename: "AGENTS.md",
+      content: "++Editor underline++\n\n1. Editor list",
+    });
+  });
+
+  const agentId = "c0000000-0000-4000-a000-000000000071";
+  context.mocks.api(agentsByIdContract.get, ({ respond }) => {
+    return respond(200, {
+      agentId,
+      avatarUrl: null,
+      description: "Markdown instructions",
+      displayName: "Markdown Agent",
+      modelProviderId: null,
+      ownerId: "test-user-123",
+      preferPersonalProvider: false,
+      selectedModel: null,
+      sound: null,
+      visibility: "private",
+    });
+  });
+  await setupPage({
+    context,
+    path: `/agents/${agentId}?tab=instructions`,
+    host: "app.vm0.ai",
+  });
+
+  for (let visit = 0; visit < 2; visit++) {
+    const editor = await screen.findByLabelText("Instructions editor");
+    expect(editor.querySelector("u")).toHaveTextContent("Editor underline");
+    click(await screen.findByText("Rich content"));
+    const currentPrefix = visit === 0 ? "Stable" : `Fresh ${visit - 1}`;
+    expect(
+      (await screen.findByText(`${currentPrefix} underline`)).tagName,
+    ).toBe("U");
+    expect(screen.getByText(`${currentPrefix} list item`).tagName).toBe("LI");
+    // A new event forces parsing after the editor has registered its extensions.
+    rows.push(
+      chat.outputMessage(source.replaceAll("Stable", `Fresh ${visit}`), {
+        seqId: 3 + visit,
+      }),
+    );
+    context.mocks.ably.trigger(chat.realtimeTopic);
+    expect((await screen.findByText(`Fresh ${visit} underline`)).tagName).toBe(
+      "U",
+    );
+    expect(screen.getByText(`Fresh ${visit} list item`).tagName).toBe("LI");
+    act(() => {
+      window.history.back();
+    });
+  }
+  await expect(
+    screen.findByLabelText("Instructions editor"),
+  ).resolves.toBeVisible();
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-underline.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-underline.test.tsx
@@ -1,16 +1,41 @@
-import { act, screen } from "@testing-library/react";
+import { act, screen, waitFor, within } from "@testing-library/react";
+import { featureSwitchesContract } from "@okouai/api-contracts/contracts/feature-switches";
 import {
   agentInstructionsContract,
   agentsByIdContract,
 } from "@okouai/api-contracts/contracts/agents";
 import { expect, test } from "vitest";
 import { marked } from "marked";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { click, setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createMarkdownChatFixture } from "./markdown-page-test-helpers.ts";
 
 const context = testContext();
+const featureSwitches = {
+  [FeatureSwitchKey.RichMarkdownUnderline]: true,
+} as const;
+
+test.each([
+  { source: "++Plain underline++", text: "++Plain underline++" },
+  { source: "**Prefix** ++Rich underline++", text: "++Rich underline++" },
+])("Underline stays literal by default: $source", async ({ source, text }) => {
+  const chat = createMarkdownChatFixture(context);
+  const rows = [
+    chat.outputMessage(source, { seqId: 1 }),
+    chat.runCompleted({ seqId: 2 }),
+  ];
+  chat.install({
+    rows: () => {
+      return rows;
+    },
+  });
+  await setupPage({ context, path: chat.path, host: "app.vm0.ai" });
+  const content = await screen.findByText(text);
+  expect(content).toBeVisible();
+  expect(content.closest("u")).toBeNull();
+});
 
 test("A global tokenizer without a renderer cannot break chat Markdown", async () => {
   const defaults = marked.defaults;
@@ -49,7 +74,12 @@ test("A global tokenizer without a renderer cannot break chat Markdown", async (
     },
   });
 
-  await setupPage({ context, path: chat.path, host: "app.vm0.ai" });
+  await setupPage({
+    context,
+    path: chat.path,
+    host: "app.vm0.ai",
+    featureSwitches,
+  });
 
   const bold = await screen.findByText("Readable");
   expect(bold.tagName).toBe("STRONG");
@@ -70,7 +100,12 @@ test.each(["++Underlined text++", "**Prefix** ++Underlined text++"])(
       },
     });
 
-    await setupPage({ context, path: chat.path, host: "app.vm0.ai" });
+    await setupPage({
+      context,
+      path: chat.path,
+      host: "app.vm0.ai",
+      featureSwitches,
+    });
 
     const underline = await screen.findByText("Underlined text");
     expect(underline.tagName).toBe("U");
@@ -106,7 +141,12 @@ test("Underline preserves nested Markdown, literal code and escaped delimiters",
     },
   });
 
-  await setupPage({ context, path: chat.path, host: "app.vm0.ai" });
+  await setupPage({
+    context,
+    path: chat.path,
+    host: "app.vm0.ai",
+    featureSwitches,
+  });
 
   const bold = await screen.findByText("Nested bold");
   expect(bold.tagName).toBe("STRONG");
@@ -143,7 +183,12 @@ test("A streaming underline remains readable until its closing delimiter arrives
     },
   });
 
-  await setupPage({ context, path: chat.path, host: "app.vm0.ai" });
+  await setupPage({
+    context,
+    path: chat.path,
+    host: "app.vm0.ai",
+    featureSwitches,
+  });
 
   await expect(screen.findByText("++Streaming text")).resolves.toBeVisible();
   rows[0] = chat.outputMessage("++Streaming text++", {
@@ -157,6 +202,60 @@ test("A streaming underline remains readable until its closing delimiter arrives
 
   const underline = await screen.findByText("Streaming text");
   expect(underline.tagName).toBe("U");
+});
+
+test("Changing the underline switch in Lab refreshes a previously opened chat", async () => {
+  const chat = createMarkdownChatFixture(context);
+  const rows = [
+    chat.outputMessage("++Rollout text++", { seqId: 1 }),
+    chat.runCompleted({ seqId: 2 }),
+  ];
+  chat.install({
+    rows: () => {
+      return rows;
+    },
+  });
+  let effectiveSwitches: Record<string, boolean> = {
+    [FeatureSwitchKey.Lab]: true,
+    [FeatureSwitchKey.RichMarkdownUnderline]: false,
+  };
+  await setupPage({
+    context,
+    path: "/_/lab",
+    featureSwitches: effectiveSwitches,
+  });
+  context.mocks.api(featureSwitchesContract.get, ({ respond }) => {
+    return respond(200, { switches: effectiveSwitches, effectiveSwitches });
+  });
+  context.mocks.api(featureSwitchesContract.update, ({ body, respond }) => {
+    effectiveSwitches = { ...effectiveSwitches, ...body.switches };
+    return respond(200, { switches: effectiveSwitches, effectiveSwitches });
+  });
+
+  for (const enabled of [true, false]) {
+    const row = (
+      await screen.findByText(FeatureSwitchKey.RichMarkdownUnderline)
+    ).closest("li");
+    if (!row) {
+      throw new Error("Expected the underline feature row");
+    }
+    const control = within(row).getByRole("switch");
+    click(control);
+    await waitFor(() => {
+      expect(control).toHaveAttribute("aria-checked", String(enabled));
+    });
+    await act(() => {
+      window.history.pushState({}, "", chat.path);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    const content = await screen.findByText(
+      enabled ? "Rollout text" : "++Rollout text++",
+    );
+    expect(content.tagName).toBe(enabled ? "U" : "P");
+    await act(() => {
+      window.history.back();
+    });
+  }
 });
 
 test("Opening and reopening an instructions editor does not change chat parsing", async () => {
@@ -198,6 +297,7 @@ test("Opening and reopening an instructions editor does not change chat parsing"
     context,
     path: `/agents/${agentId}?tab=instructions`,
     host: "app.vm0.ai",
+    featureSwitches,
   });
 
   for (let visit = 0; visit < 2; visit++) {

--- a/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-presentation.test.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/__tests__/shared-thread-presentation.test.tsx
@@ -1,6 +1,8 @@
 import { sharedThreadsContract } from "@okouai/api-contracts/contracts/shared-threads";
 import { screen, waitFor, within } from "@testing-library/react";
 import { expect, test } from "vitest";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { setupPage } from "../../../__tests__/page-helper.ts";
 
 import { platformOkouWordmarkLightImg } from "../../../lib/static-assets.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -8,9 +10,51 @@ import {
   getLinkByName,
   setupSharedThreadPage,
   sharedThread,
+  SHARED_THREAD_ID,
 } from "./shared-thread-test-helpers.ts";
 
 const context = testContext();
+
+test.each([false, true])(
+  "Shared Markdown respects the underline switch: %s",
+  async (enabled) => {
+    context.mocks.api(sharedThreadsContract.get, ({ respond }) => {
+      return respond(
+        200,
+        sharedThread({
+          messages: [
+            {
+              messageIndex: 0,
+              role: "assistant",
+              content: "++Shared plain++",
+              runIndex: 0,
+            },
+            {
+              messageIndex: 1,
+              role: "assistant",
+              content: "**Prefix** ++Shared rich++",
+              runIndex: 0,
+            },
+          ],
+        }),
+      );
+    });
+    await setupPage({
+      context,
+      path: `/share/threads/${SHARED_THREAD_ID}`,
+      auth: null,
+      featureSwitches: { [FeatureSwitchKey.RichMarkdownUnderline]: enabled },
+    });
+    const plain = await screen.findByText(
+      enabled ? "Shared plain" : "++Shared plain++",
+    );
+    const rich = await screen.findByText(
+      enabled ? "Shared rich" : "++Shared rich++",
+    );
+    expect(plain.tagName).toBe(enabled ? "U" : "P");
+    expect(rich.tagName).toBe(enabled ? "U" : "P");
+  },
+);
 
 test("A brand-only public title is not repeated", async () => {
   context.mocks.api(sharedThreadsContract.get, ({ respond }) => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -53,6 +53,7 @@ export enum FeatureSwitchKey {
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   ChatErrorRecovery = "chatErrorRecovery",
   ChatRunWorkFolding = "chatRunWorkFolding",
+  RichMarkdownUnderline = "richMarkdownUnderline",
   ProgressiveArtifactPreview = "progressiveArtifactPreview",
   ChatThinkingSpinner = "chatThinkingSpinner",
   FollowUpOptimize = "followUpOptimize",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -371,6 +371,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.RichMarkdownUnderline]: {
+    maintainer: "bingjie@okou.ai",
+    description:
+      "Render ++underline++ with an isolated Markdown parser. Refresh the page after changing this switch.",
+    enabled: false,
+  },
   [FeatureSwitchKey.ProgressiveArtifactPreview]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
Opening an instructions editor registers Tiptap-only tokenizers on the global Marked instance. Subsequent chat rendering can throw on `underline`, and ordered-list output can change depending on whether the editor has been opened.

Behind `richMarkdownUnderline`, give display parsing its own Marked instance and register the underline tokenizer and renderer together. `++text++` renders through the plain-text shortcut, nested formatting, streamed closing delimiters, one-off Markdown, file previews, and shared conversations. Escapes and code remain literal; existing Mermaid, card, and HAST processing is retained.

## Rollout

- `richMarkdownUnderline` is off by default for everyone, including staff, and is maintained by `bingjie@okou.ai`. Enable it through Lab and refresh the page to complete the parser transition.
- When off, the original parser and plain-text shortcut remain active. Chat cache entries include the parsing mode so returning to an existing chat after toggling the switch reparses unchanged messages correctly.
- #32312 requires this switch before enabling its additional editor extensions.

Fixes #32150 when the rollout is enabled.

## Verification

- 12 targeted page integration cases passed, covering disabled/enabled parsing, nested and streamed underline, editor isolation, Markdown attachment previews, shared conversations, and toggling the switch in Lab before returning to the same chat.
- All 31 existing core feature-switch tests passed.
- Changed-file formatting, ESLint, Oxlint including type-aware rules, and localized UI lint; Platform production/test/build-config and core TypeScript checks; Platform/core-scoped Knip.
- Production Vite build passed with test Clerk publishable keys and Sentry upload disabled. No full local Vitest suite or dev server was run.
