### PR TITLE
fix(chat): validate snapshot watermark cursors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -43,6 +43,7 @@ import {
   startChatEventInsertTransactionFixture,
 } from "../../../test-fixtures/chat-events";
 import {
+  deleteChatThreadEventMarkerFixture,
   holdChatThreadEventInsertTransactionFixture,
   insertChatThreadEventTransactionFixture,
   setChatThreadVideoModelFixture,
@@ -388,13 +389,34 @@ function stateFromAuthorizationUrl(authorizationUrl: string): string {
   return state;
 }
 
-async function allThreadEvents(actor: ApiTestUser) {
-  const response = await chat.requestThreadEvents(actor, {}, [200]);
+async function threadEventPage(actor: ApiTestUser, sinceSeqId?: number) {
+  const response = await chat.requestThreadEvents(
+    actor,
+    sinceSeqId === undefined ? {} : { sinceSeqId },
+    [200],
+  );
   expect(response.status).toBe(200);
   if (response.status !== 200) {
     throw new Error("Expected chat thread events to load");
   }
-  return response.body.events;
+  return response.body;
+}
+
+async function expectExpiredThreadEventCursor(
+  actor: ApiTestUser,
+  sinceSeqId: number,
+): Promise<void> {
+  const response = await chat.requestThreadEvents(actor, { sinceSeqId }, [410]);
+  expect(response.body).toStrictEqual({
+    error: {
+      message: "Chat thread events cursor has expired",
+      code: "CHAT_THREAD_EVENTS_EXPIRED",
+    },
+  });
+}
+
+async function allThreadEvents(actor: ApiTestUser) {
+  return (await threadEventPage(actor)).events;
 }
 
 type ThreadArtifacts = Awaited<ReturnType<typeof chat.listThreadArtifacts>>;
@@ -913,6 +935,242 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     });
   });
 
+  it("validates and paginates snapshot cursors without marker rows", async () => {
+    mockEnv("CRON_SECRET", CHAT_THREAD_SNAPSHOT_CRON_SECRET);
+    const actor = bdd.user();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped chat actor");
+    }
+    await api.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "Snapshot cursor agent",
+    });
+    const firstEventId = randomUUID();
+    const thread = await chat.createThread(actor, {
+      agentId: agent.agentId,
+      title: "Snapshot cursor thread",
+      eventId: firstEventId,
+    });
+
+    const [firstEvent] = await allThreadEvents(actor);
+    if (!firstEvent || firstEvent.id !== firstEventId) {
+      throw new Error("Expected the initial chat-thread lifecycle event");
+    }
+    await expect(
+      threadEventPage(actor, firstEvent.seqId),
+    ).resolves.toStrictEqual({
+      events: [],
+      hasMore: false,
+    });
+
+    // Reusing the event ID commits the reserved sequence without inserting a
+    // second event, matching an allocation gap from a failed/idempotent write.
+    await chat.renameThread(
+      actor,
+      thread.id,
+      "Reserve a lifecycle event gap",
+      firstEventId,
+    );
+    await expectExpiredThreadEventCursor(actor, firstEvent.seqId + 1);
+
+    const snapshotMarkerEventId = randomUUID();
+    await chat.renameThread(
+      actor,
+      thread.id,
+      "Create the snapshot marker",
+      snapshotMarkerEventId,
+    );
+    const preSnapshotEvents = await allThreadEvents(actor);
+    const snapshotMarkerEvent = preSnapshotEvents.find((event) => {
+      return event.id === snapshotMarkerEventId;
+    });
+    if (!snapshotMarkerEvent) {
+      throw new Error("Expected the snapshot marker event");
+    }
+    expect(
+      preSnapshotEvents.map((event) => {
+        return event.seqId;
+      }),
+    ).toStrictEqual([firstEvent.seqId, firstEvent.seqId + 2]);
+
+    await compactChatThreadSnapshots();
+    const snapshot = await chat.getThreadSnapshot(actor);
+    expect(snapshot.latestEventId).toBe(snapshotMarkerEvent.id);
+    expect(snapshot.latestSeqId).toBe(snapshotMarkerEvent.seqId);
+
+    // The unbounded read proves that the covered cursor row still physically
+    // exists even though the snapshot watermark makes it intentionally stale.
+    expect(
+      (await allThreadEvents(actor)).some((event) => {
+        return event.id === firstEvent.id;
+      }),
+    ).toBeTruthy();
+    await expectExpiredThreadEventCursor(actor, firstEvent.seqId);
+
+    if (snapshot.latestEventId === null || snapshot.latestSeqId === null) {
+      throw new Error("Expected a non-empty snapshot cursor");
+    }
+    await deleteChatThreadEventMarkerFixture({
+      userId: actor.userId,
+      orgId: actor.orgId,
+      eventId: snapshot.latestEventId,
+      seqId: snapshot.latestSeqId,
+    });
+
+    const held = await holdChatThreadEventInsertTransactionFixture({
+      userId: actor.userId,
+      orgId: actor.orgId,
+      chatThreadId: thread.id,
+      agentId: agent.agentId,
+      title: "Committed after the snapshot cursor read",
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      held.release();
+      await held.done;
+    });
+
+    await expect(
+      threadEventPage(actor, snapshot.latestSeqId),
+    ).resolves.toStrictEqual({
+      events: [],
+      hasMore: false,
+    });
+
+    held.release();
+    await held.done;
+    await expect(
+      threadEventPage(actor, snapshot.latestSeqId),
+    ).resolves.toStrictEqual({
+      events: [expect.objectContaining({ id: held.event.id })],
+      hasMore: false,
+    });
+
+    const laterEventId = randomUUID();
+    await chat.renameThread(
+      actor,
+      thread.id,
+      "Later real lifecycle event",
+      laterEventId,
+    );
+    const afterHeldCursor = await threadEventPage(actor, held.event.seqId);
+    const [laterEvent] = afterHeldCursor.events;
+    if (!laterEvent || laterEvent.id !== laterEventId) {
+      throw new Error("Expected the later lifecycle event");
+    }
+    expect(afterHeldCursor.hasMore).toBeFalsy();
+
+    await chat.renameThread(
+      actor,
+      thread.id,
+      "Reserve a post-snapshot gap",
+      laterEventId,
+    );
+    const postSnapshotGapSeqId = laterEvent.seqId + 1;
+    await expectExpiredThreadEventCursor(actor, postSnapshotGapSeqId);
+
+    const nextRealEventId = randomUUID();
+    await chat.renameThread(
+      actor,
+      thread.id,
+      "Real event after the allocation gap",
+      nextRealEventId,
+    );
+    const afterLaterCursor = await threadEventPage(actor, laterEvent.seqId);
+    const [nextRealEvent] = afterLaterCursor.events;
+    if (!nextRealEvent || nextRealEvent.id !== nextRealEventId) {
+      throw new Error("Expected the real lifecycle event after the gap");
+    }
+    expect(nextRealEvent.seqId).toBe(postSnapshotGapSeqId + 1);
+    expect(afterLaterCursor.hasMore).toBeFalsy();
+
+    await expect(
+      threadEventPage(actor, nextRealEvent.seqId),
+    ).resolves.toStrictEqual({
+      events: [],
+      hasMore: false,
+    });
+
+    const peer = bdd.user({ orgId: actor.orgId });
+    const peerAgent = await bdd.createAgent(peer, {
+      displayName: "Cross-user cursor agent",
+    });
+    await chat.createThread(peer, {
+      agentId: peerAgent.agentId,
+      title: "Cross-user cursor thread",
+    });
+    await expectExpiredThreadEventCursor(peer, nextRealEvent.seqId);
+
+    const otherOrgActor = bdd.user({ userId: actor.userId });
+    await api.ensureOrgModelProvider(otherOrgActor);
+    const otherOrgAgent = await bdd.createAgent(otherOrgActor, {
+      displayName: "Cross-organization cursor agent",
+    });
+    await chat.createThread(otherOrgActor, {
+      agentId: otherOrgAgent.agentId,
+      title: "Cross-organization cursor thread",
+    });
+    await expectExpiredThreadEventCursor(otherOrgActor, nextRealEvent.seqId);
+    await expectExpiredThreadEventCursor(actor, 999_999);
+
+    const lifecyclePageSize = 1000;
+    const expectedTailEventIds = [
+      held.event.id,
+      laterEvent.id,
+      nextRealEvent.id,
+    ];
+    const paginationEvents = Array.from(
+      {
+        length: lifecyclePageSize - expectedTailEventIds.length + 1,
+      },
+      (_, index) => {
+        return {
+          id: randomUUID(),
+          title: `Pagination lifecycle event ${index}`,
+        };
+      },
+    );
+    await Promise.all(
+      paginationEvents.map(async (event) => {
+        await chat.renameThread(actor, thread.id, event.title, event.id);
+      }),
+    );
+    expectedTailEventIds.push(
+      ...paginationEvents.map((event) => {
+        return event.id;
+      }),
+    );
+
+    const firstPage = await threadEventPage(actor, snapshot.latestSeqId);
+    expect(firstPage.events).toHaveLength(lifecyclePageSize);
+    expect(firstPage.hasMore).toBeTruthy();
+    const firstPageCursor = firstPage.events.at(-1);
+    if (!firstPageCursor) {
+      throw new Error("Expected the first snapshot tail page cursor");
+    }
+
+    const secondPage = await threadEventPage(actor, firstPageCursor.seqId);
+    expect(secondPage.events).toHaveLength(1);
+    expect(secondPage.hasMore).toBeFalsy();
+
+    const pagedEvents = [...firstPage.events, ...secondPage.events];
+    const pagedSeqIds = pagedEvents.map((event) => {
+      return event.seqId;
+    });
+    expect(pagedSeqIds).toStrictEqual(
+      [...pagedSeqIds].sort((left, right) => {
+        return left - right;
+      }),
+    );
+    const pagedEventIds = pagedEvents.map((event) => {
+      return event.id;
+    });
+    expect(new Set(pagedEventIds).size).toBe(expectedTailEventIds.length);
+    expect([...pagedEventIds].sort()).toStrictEqual(
+      [...expectedTailEventIds].sort(),
+    );
+  }, 90_000);
+
   it("keeps concurrent thread event sequence reservation atomic through commit", async () => {
     const owner = bdd.user();
     if (!owner.orgId) {
@@ -1143,12 +1401,22 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       Date.parse(liveCreateEvent.createdAt) + 7 * DAY_MS;
     mockNow(retentionBoundary);
     await compactChatThreadSnapshots();
-    const retainedBoundaryCursor = await chat.requestThreadEvents(
+    expect(
+      (await allThreadEvents(actor)).some((event) => {
+        return event.id === liveCreateEvent.id;
+      }),
+    ).toBeTruthy();
+    const coveredBoundaryCursor = await chat.requestThreadEvents(
       actor,
       { sinceSeqId: liveCreateEvent.seqId },
-      [200],
+      [410],
     );
-    expect(retainedBoundaryCursor.status).toBe(200);
+    expect(coveredBoundaryCursor.body).toStrictEqual({
+      error: {
+        message: "Chat thread events cursor has expired",
+        code: "CHAT_THREAD_EVENTS_EXPIRED",
+      },
+    });
 
     mockNow(retentionBoundary + 1);
     const retentionCompact = await compactChatThreadSnapshots();
@@ -1167,12 +1435,17 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
 
     mockNow(Date.parse(deletedCreateEvent.createdAt) + 7 * DAY_MS + 1);
     await compactChatThreadSnapshots();
-    const retainedDeletedAgentAnchor = await chat.requestThreadEvents(
+    const coveredDeletedAgentCursor = await chat.requestThreadEvents(
       actor,
       { sinceSeqId: deletedCreateEvent.seqId },
-      [200],
+      [410],
     );
-    expect(retainedDeletedAgentAnchor.status).toBe(200);
+    expect(coveredDeletedAgentCursor.body).toStrictEqual({
+      error: {
+        message: "Chat thread events cursor has expired",
+        code: "CHAT_THREAD_EVENTS_EXPIRED",
+      },
+    });
     expect(
       (await allThreadEvents(actor)).some((event) => {
         return event.agentId === deletedAgent.agentId;

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -419,6 +419,65 @@ async function allThreadEvents(actor: ApiTestUser) {
   return (await threadEventPage(actor)).events;
 }
 
+async function createSnapshotCursorScenario(label: string) {
+  mockEnv("CRON_SECRET", CHAT_THREAD_SNAPSHOT_CRON_SECRET);
+  const actor = bdd.user();
+  if (!actor.orgId) {
+    throw new Error("Expected an organization-scoped chat actor");
+  }
+  await api.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName: `${label} agent`,
+  });
+  const firstEventId = randomUUID();
+  const thread = await chat.createThread(actor, {
+    agentId: agent.agentId,
+    title: `${label} thread`,
+    eventId: firstEventId,
+  });
+  const markerEventId = randomUUID();
+  await chat.renameThread(actor, thread.id, `${label} marker`, markerEventId);
+
+  const events = await allThreadEvents(actor);
+  const firstEvent = events.find((event) => {
+    return event.id === firstEventId;
+  });
+  const markerEvent = events.find((event) => {
+    return event.id === markerEventId;
+  });
+  if (!firstEvent || !markerEvent) {
+    throw new Error("Expected snapshot cursor lifecycle events");
+  }
+
+  await compactChatThreadSnapshots();
+  const snapshot = await chat.getThreadSnapshot(actor);
+  const { latestEventId, latestSeqId } = snapshot;
+  expect(latestEventId).toBe(markerEvent.id);
+  expect(latestSeqId).toBe(markerEvent.seqId);
+  if (latestEventId === null || latestSeqId === null) {
+    throw new Error("Expected a non-empty snapshot cursor");
+  }
+  return {
+    actor,
+    orgId: actor.orgId,
+    agent,
+    thread,
+    firstEvent,
+    snapshot: { latestEventId, latestSeqId },
+  };
+}
+
+async function deleteSnapshotCursorMarker(
+  scenario: Awaited<ReturnType<typeof createSnapshotCursorScenario>>,
+): Promise<void> {
+  await deleteChatThreadEventMarkerFixture({
+    userId: scenario.actor.userId,
+    orgId: scenario.orgId,
+    eventId: scenario.snapshot.latestEventId,
+    seqId: scenario.snapshot.latestSeqId,
+  });
+}
+
 type ThreadArtifacts = Awaited<ReturnType<typeof chat.listThreadArtifacts>>;
 
 function expectDriveStatuses(
@@ -935,33 +994,26 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     });
   });
 
-  it("validates and paginates snapshot cursors without marker rows", async () => {
-    mockEnv("CRON_SECRET", CHAT_THREAD_SNAPSHOT_CRON_SECRET);
+  it("keeps no-snapshot cursors anchored to real scoped rows", async () => {
     const actor = bdd.user();
-    if (!actor.orgId) {
-      throw new Error("Expected an organization-scoped chat actor");
-    }
     await api.ensureOrgModelProvider(actor);
     const agent = await bdd.createAgent(actor, {
-      displayName: "Snapshot cursor agent",
+      displayName: "No-snapshot cursor agent",
     });
     const firstEventId = randomUUID();
     const thread = await chat.createThread(actor, {
       agentId: agent.agentId,
-      title: "Snapshot cursor thread",
+      title: "No-snapshot cursor thread",
       eventId: firstEventId,
     });
-
     const [firstEvent] = await allThreadEvents(actor);
     if (!firstEvent || firstEvent.id !== firstEventId) {
       throw new Error("Expected the initial chat-thread lifecycle event");
     }
+
     await expect(
       threadEventPage(actor, firstEvent.seqId),
-    ).resolves.toStrictEqual({
-      events: [],
-      hasMore: false,
-    });
+    ).resolves.toStrictEqual({ events: [], hasMore: false });
 
     // Reusing the event ID commits the reserved sequence without inserting a
     // second event, matching an allocation gap from a failed/idempotent write.
@@ -972,31 +1024,11 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       firstEventId,
     );
     await expectExpiredThreadEventCursor(actor, firstEvent.seqId + 1);
+  });
 
-    const snapshotMarkerEventId = randomUUID();
-    await chat.renameThread(
-      actor,
-      thread.id,
-      "Create the snapshot marker",
-      snapshotMarkerEventId,
-    );
-    const preSnapshotEvents = await allThreadEvents(actor);
-    const snapshotMarkerEvent = preSnapshotEvents.find((event) => {
-      return event.id === snapshotMarkerEventId;
-    });
-    if (!snapshotMarkerEvent) {
-      throw new Error("Expected the snapshot marker event");
-    }
-    expect(
-      preSnapshotEvents.map((event) => {
-        return event.seqId;
-      }),
-    ).toStrictEqual([firstEvent.seqId, firstEvent.seqId + 2]);
-
-    await compactChatThreadSnapshots();
-    const snapshot = await chat.getThreadSnapshot(actor);
-    expect(snapshot.latestEventId).toBe(snapshotMarkerEvent.id);
-    expect(snapshot.latestSeqId).toBe(snapshotMarkerEvent.seqId);
+  it("reads an exact markerless snapshot watermark atomically", async () => {
+    const scenario = await createSnapshotCursorScenario("Markerless cursor");
+    const { actor, agent, firstEvent, snapshot, thread } = scenario;
 
     // The unbounded read proves that the covered cursor row still physically
     // exists even though the snapshot watermark makes it intentionally stale.
@@ -1006,20 +1038,11 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       }),
     ).toBeTruthy();
     await expectExpiredThreadEventCursor(actor, firstEvent.seqId);
-
-    if (snapshot.latestEventId === null || snapshot.latestSeqId === null) {
-      throw new Error("Expected a non-empty snapshot cursor");
-    }
-    await deleteChatThreadEventMarkerFixture({
-      userId: actor.userId,
-      orgId: actor.orgId,
-      eventId: snapshot.latestEventId,
-      seqId: snapshot.latestSeqId,
-    });
+    await deleteSnapshotCursorMarker(scenario);
 
     const held = await holdChatThreadEventInsertTransactionFixture({
       userId: actor.userId,
-      orgId: actor.orgId,
+      orgId: scenario.orgId,
       chatThreadId: thread.id,
       agentId: agent.agentId,
       title: "Committed after the snapshot cursor read",
@@ -1032,10 +1055,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
 
     await expect(
       threadEventPage(actor, snapshot.latestSeqId),
-    ).resolves.toStrictEqual({
-      events: [],
-      hasMore: false,
-    });
+    ).resolves.toStrictEqual({ events: [], hasMore: false });
 
     held.release();
     await held.done;
@@ -1045,6 +1065,12 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       events: [expect.objectContaining({ id: held.event.id })],
       hasMore: false,
     });
+  });
+
+  it("validates real cursors after a markerless snapshot watermark", async () => {
+    const scenario = await createSnapshotCursorScenario("Real cursor");
+    const { actor, snapshot, thread } = scenario;
+    await deleteSnapshotCursorMarker(scenario);
 
     const laterEventId = randomUUID();
     await chat.renameThread(
@@ -1053,12 +1079,15 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       "Later real lifecycle event",
       laterEventId,
     );
-    const afterHeldCursor = await threadEventPage(actor, held.event.seqId);
-    const [laterEvent] = afterHeldCursor.events;
+    const afterSnapshotCursor = await threadEventPage(
+      actor,
+      snapshot.latestSeqId,
+    );
+    const [laterEvent] = afterSnapshotCursor.events;
     if (!laterEvent || laterEvent.id !== laterEventId) {
       throw new Error("Expected the later lifecycle event");
     }
-    expect(afterHeldCursor.hasMore).toBeFalsy();
+    expect(afterSnapshotCursor.hasMore).toBeFalsy();
 
     await chat.renameThread(
       actor,
@@ -1091,7 +1120,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       hasMore: false,
     });
 
-    const peer = bdd.user({ orgId: actor.orgId });
+    const peer = bdd.user({ orgId: scenario.orgId });
     const peerAgent = await bdd.createAgent(peer, {
       displayName: "Cross-user cursor agent",
     });
@@ -1112,17 +1141,15 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     });
     await expectExpiredThreadEventCursor(otherOrgActor, nextRealEvent.seqId);
     await expectExpiredThreadEventCursor(actor, 999_999);
+  });
 
+  it("paginates a markerless snapshot tail without gaps or duplicates", async () => {
+    const scenario = await createSnapshotCursorScenario("Paginated cursor");
+    const { actor, snapshot, thread } = scenario;
+    await deleteSnapshotCursorMarker(scenario);
     const lifecyclePageSize = 1000;
-    const expectedTailEventIds = [
-      held.event.id,
-      laterEvent.id,
-      nextRealEvent.id,
-    ];
     const paginationEvents = Array.from(
-      {
-        length: lifecyclePageSize - expectedTailEventIds.length + 1,
-      },
+      { length: lifecyclePageSize + 1 },
       (_, index) => {
         return {
           id: randomUUID(),
@@ -1133,11 +1160,6 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     await Promise.all(
       paginationEvents.map(async (event) => {
         await chat.renameThread(actor, thread.id, event.title, event.id);
-      }),
-    );
-    expectedTailEventIds.push(
-      ...paginationEvents.map((event) => {
-        return event.id;
       }),
     );
 
@@ -1163,6 +1185,9 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       }),
     );
     const pagedEventIds = pagedEvents.map((event) => {
+      return event.id;
+    });
+    const expectedTailEventIds = paginationEvents.map((event) => {
       return event.id;
     });
     expect(new Set(pagedEventIds).size).toBe(expectedTailEventIds.length);

--- a/turbo/apps/api/src/signals/services/chat-thread-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-event.service.ts
@@ -1,5 +1,5 @@
-import { and, asc, eq, exists, gt, sql } from "drizzle-orm";
-import { alias } from "drizzle-orm/pg-core";
+import { and, asc, eq, exists, gt, gte, notExists, sql } from "drizzle-orm";
+import { alias, unionAll } from "drizzle-orm/pg-core";
 import type {
   ChatThreadEvent,
   ChatThreadServiceTier,
@@ -183,6 +183,40 @@ type ChatThreadEventRow = {
   readonly createdAt: Date;
 };
 
+const chatThreadEventSelection = Object.freeze({
+  id: chatThreadEvents.id,
+  seqId: chatThreadEvents.seqId,
+  kind: chatThreadEvents.kind,
+  chatThreadId: chatThreadEvents.chatThreadId,
+  agentId: chatThreadEvents.agentId,
+  title: chatThreadEvents.title,
+  pinOrder: chatThreadEvents.pinOrder,
+  selectedModel: chatThreadEvents.selectedModel,
+  serviceTier: chatThreadEvents.serviceTier,
+  computerUseHostId: chatThreadEvents.computerUseHostId,
+  cloudBrowserEnabled: chatThreadEvents.cloudBrowserEnabled,
+  selectedVideoModel: chatThreadEvents.selectedVideoModel,
+  selectedImageModel: chatThreadEvents.selectedImageModel,
+  createdAt: chatThreadEvents.createdAt,
+});
+
+const pageChatThreadEventSelection = Object.freeze({
+  id: pageChatThreadEvent.id,
+  seqId: pageChatThreadEvent.seqId,
+  kind: pageChatThreadEvent.kind,
+  chatThreadId: pageChatThreadEvent.chatThreadId,
+  agentId: pageChatThreadEvent.agentId,
+  title: pageChatThreadEvent.title,
+  pinOrder: pageChatThreadEvent.pinOrder,
+  selectedModel: pageChatThreadEvent.selectedModel,
+  serviceTier: pageChatThreadEvent.serviceTier,
+  computerUseHostId: pageChatThreadEvent.computerUseHostId,
+  cloudBrowserEnabled: pageChatThreadEvent.cloudBrowserEnabled,
+  selectedVideoModel: pageChatThreadEvent.selectedVideoModel,
+  selectedImageModel: pageChatThreadEvent.selectedImageModel,
+  createdAt: pageChatThreadEvent.createdAt,
+});
+
 export function chatThreadServiceTierFromCodex(
   codexServiceTier: CodexServiceTier | null,
 ): ChatThreadServiceTier | null {
@@ -216,6 +250,85 @@ function toApiChatThreadEvent(
   };
 }
 
+async function getChatThreadEventRowsAfterCursor(
+  db: ReadonlyDb,
+  args: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly sinceSeqId: number;
+  },
+): Promise<readonly ChatThreadEventRow[] | null> {
+  const validCursor = db.$with("valid_cursor").as(
+    unionAll(
+      db
+        .select({ seqId: cursorChatThreadEvent.seqId })
+        .from(cursorChatThreadEvent)
+        .where(
+          and(
+            eq(cursorChatThreadEvent.userId, args.userId),
+            eq(cursorChatThreadEvent.orgId, args.orgId),
+            eq(cursorChatThreadEvent.seqId, args.sinceSeqId),
+            notExists(
+              db
+                .select({ userId: chatThreadSnapshots.userId })
+                .from(chatThreadSnapshots)
+                .where(
+                  and(
+                    eq(chatThreadSnapshots.userId, args.userId),
+                    eq(chatThreadSnapshots.orgId, args.orgId),
+                    gte(chatThreadSnapshots.latestEventSeqId, args.sinceSeqId),
+                  ),
+                ),
+            ),
+          ),
+        ),
+      db
+        .select({
+          seqId: sql`${chatThreadSnapshots.latestEventSeqId}`
+            .mapWith(chatThreadEvents.seqId)
+            .as("seq_id"),
+        })
+        .from(chatThreadSnapshots)
+        .where(
+          and(
+            eq(chatThreadSnapshots.userId, args.userId),
+            eq(chatThreadSnapshots.orgId, args.orgId),
+            eq(chatThreadSnapshots.latestEventSeqId, args.sinceSeqId),
+          ),
+        ),
+    ),
+  );
+
+  // Validation and page selection share one statement snapshot so a cursor
+  // cannot cross an append or compaction boundary between the two checks.
+  const cursorRows = await db
+    .with(validCursor)
+    .select({ event: pageChatThreadEventSelection })
+    .from(validCursor)
+    .leftJoin(
+      pageChatThreadEvent,
+      and(
+        eq(pageChatThreadEvent.userId, args.userId),
+        eq(pageChatThreadEvent.orgId, args.orgId),
+        gt(pageChatThreadEvent.seqId, validCursor.seqId),
+        exists(
+          db
+            .select({ id: agents.id })
+            .from(agents)
+            .where(eq(agents.id, pageChatThreadEvent.agentId)),
+        ),
+      ),
+    )
+    .orderBy(asc(pageChatThreadEvent.seqId))
+    .limit(CHAT_THREAD_EVENTS_PAGE_SIZE + 1);
+  if (cursorRows.length === 0) {
+    return null;
+  }
+  return cursorRows.flatMap((row) => {
+    return row.event ? [row.event] : [];
+  });
+}
+
 export async function getChatThreadEventsSince(
   db: ReadonlyDb,
   args: {
@@ -232,79 +345,19 @@ export async function getChatThreadEventsSince(
   | { readonly kind: "expired" }
 > {
   let rows: readonly ChatThreadEventRow[];
-  const cursorPredicate =
-    args.sinceSeqId === undefined
-      ? undefined
-      : eq(cursorChatThreadEvent.seqId, args.sinceSeqId);
-  if (cursorPredicate !== undefined) {
-    // Keep a valid cursor row when its page is empty.
-    const cursorRows = await db
-      .select({
-        event: {
-          id: pageChatThreadEvent.id,
-          seqId: pageChatThreadEvent.seqId,
-          kind: pageChatThreadEvent.kind,
-          chatThreadId: pageChatThreadEvent.chatThreadId,
-          agentId: pageChatThreadEvent.agentId,
-          title: pageChatThreadEvent.title,
-          pinOrder: pageChatThreadEvent.pinOrder,
-          selectedModel: pageChatThreadEvent.selectedModel,
-          serviceTier: pageChatThreadEvent.serviceTier,
-          computerUseHostId: pageChatThreadEvent.computerUseHostId,
-          cloudBrowserEnabled: pageChatThreadEvent.cloudBrowserEnabled,
-          selectedVideoModel: pageChatThreadEvent.selectedVideoModel,
-          selectedImageModel: pageChatThreadEvent.selectedImageModel,
-          createdAt: pageChatThreadEvent.createdAt,
-        },
-      })
-      .from(cursorChatThreadEvent)
-      .leftJoin(
-        pageChatThreadEvent,
-        and(
-          eq(pageChatThreadEvent.userId, args.userId),
-          eq(pageChatThreadEvent.orgId, args.orgId),
-          gt(pageChatThreadEvent.seqId, cursorChatThreadEvent.seqId),
-          exists(
-            db
-              .select({ id: agents.id })
-              .from(agents)
-              .where(eq(agents.id, pageChatThreadEvent.agentId)),
-          ),
-        ),
-      )
-      .where(
-        and(
-          eq(cursorChatThreadEvent.userId, args.userId),
-          eq(cursorChatThreadEvent.orgId, args.orgId),
-          cursorPredicate,
-        ),
-      )
-      .orderBy(asc(pageChatThreadEvent.seqId))
-      .limit(CHAT_THREAD_EVENTS_PAGE_SIZE + 1);
-    if (cursorRows.length === 0) {
+  if (args.sinceSeqId !== undefined) {
+    const cursorRows = await getChatThreadEventRowsAfterCursor(db, {
+      userId: args.userId,
+      orgId: args.orgId,
+      sinceSeqId: args.sinceSeqId,
+    });
+    if (cursorRows === null) {
       return { kind: "expired" };
     }
-    rows = cursorRows.flatMap((row) => {
-      return row.event ? [row.event] : [];
-    });
+    rows = cursorRows;
   } else {
     rows = await db
-      .select({
-        id: chatThreadEvents.id,
-        seqId: chatThreadEvents.seqId,
-        kind: chatThreadEvents.kind,
-        chatThreadId: chatThreadEvents.chatThreadId,
-        agentId: chatThreadEvents.agentId,
-        title: chatThreadEvents.title,
-        pinOrder: chatThreadEvents.pinOrder,
-        selectedModel: chatThreadEvents.selectedModel,
-        serviceTier: chatThreadEvents.serviceTier,
-        computerUseHostId: chatThreadEvents.computerUseHostId,
-        cloudBrowserEnabled: chatThreadEvents.cloudBrowserEnabled,
-        selectedVideoModel: chatThreadEvents.selectedVideoModel,
-        selectedImageModel: chatThreadEvents.selectedImageModel,
-        createdAt: chatThreadEvents.createdAt,
-      })
+      .select(chatThreadEventSelection)
       .from(chatThreadEvents)
       .where(
         and(

--- a/turbo/apps/api/src/test-fixtures/chat-thread-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-thread-events.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { chatThreadEvents } from "@okouai/db/schema/chat-thread-event";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
-import { count, eq, sql } from "drizzle-orm";
+import { and, count, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "../lib/db";
@@ -145,6 +145,33 @@ export async function insertChatThreadEventTransactionFixture(
     throw new Error("Expected the chat-thread event insert");
   }
   return event;
+}
+
+/**
+ * Removes the exact snapshot anchor that Slice 1 must tolerate. No production
+ * endpoint can construct this state while the current compactor intentionally
+ * retains marker rows, so the route regression test owns this narrow fixture.
+ */
+export async function deleteChatThreadEventMarkerFixture(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly eventId: string;
+  readonly seqId: number;
+}): Promise<void> {
+  const deleted = await db()
+    .delete(chatThreadEvents)
+    .where(
+      and(
+        eq(chatThreadEvents.userId, args.userId),
+        eq(chatThreadEvents.orgId, args.orgId),
+        eq(chatThreadEvents.id, args.eventId),
+        eq(chatThreadEvents.seqId, args.seqId),
+      ),
+    )
+    .returning({ id: chatThreadEvents.id });
+  if (deleted.length !== 1) {
+    throw new Error("Expected one chat-thread snapshot marker to be deleted");
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- validate lifecycle-event cursors against the same-scope snapshot watermark in the same SQL statement that selects the next page
- allow an exact snapshot watermark without a retained marker row while rejecting covered, allocation-gap, future, and cross-scope cursors
- add focused BDD coverage for markerless empty and non-empty tails, real post-snapshot cursors, scope isolation, and pagination without omissions or duplicates

## Scope

- reader and focused test changes only
- does not change snapshot compaction or marker pruning behavior
- does not add migrations or change schemas, API contracts, client persistence/retry behavior, or production data

## Testing

- `pnpm prettier --check apps/api/src/signals/services/chat-thread-event.service.ts apps/api/src/test-fixtures/chat-thread-events.ts apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'returns chat thread snapshot and lifecycle events with cursor expiry|keeps no-snapshot cursors anchored to real scoped rows|reads an exact markerless snapshot watermark atomically|validates real cursors after a markerless snapshot watermark|paginates a markerless snapshot tail without gaps or duplicates|preserves UTC snapshot and event cutoff boundaries outside UTC'`

Fixes #32254
