### PR TITLE
feat(app): add create commands to the chat composer

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1859,8 +1859,6 @@
         "chooseStyle": "Stil wählen",
         "chooseTemplate": "Vorlage wählen",
         "exit": "Erstellungsmodus verlassen",
-        "illustration": "Illustration erstellen",
-        "illustrationPlaceholder": "Beschreibe die gewünschte Illustration…",
         "image": "Bild erstellen",
         "imagePlaceholder": "Beschreibe das gewünschte Bild…",
         "presentation": "Präsentation erstellen",

--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1855,6 +1855,21 @@
     "composer": {
       "agentSuggestions": "Agenten",
       "configureModel": "Modell konfigurieren",
+      "create": {
+        "chooseStyle": "Stil wählen",
+        "chooseTemplate": "Vorlage wählen",
+        "exit": "Erstellungsmodus verlassen",
+        "illustration": "Illustration erstellen",
+        "illustrationPlaceholder": "Beschreibe die gewünschte Illustration…",
+        "image": "Bild erstellen",
+        "imagePlaceholder": "Beschreibe das gewünschte Bild…",
+        "presentation": "Präsentation erstellen",
+        "presentationPlaceholder": "Worum geht es in deiner Präsentation?",
+        "settingsAdjusted": "Einige Videoeinstellungen wurden an dieses Modell angepasst",
+        "title": "Erstellen",
+        "video": "Video erstellen",
+        "videoPlaceholder": "Beschreibe das gewünschte Video…"
+      },
       "createWorkflow": "Workflow erstellen",
       "imageModelForThisChat": "Bildmodell für diesen Chat",
       "message": "Nachricht",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1859,8 +1859,6 @@
         "chooseStyle": "Choose style",
         "chooseTemplate": "Choose template",
         "exit": "Exit create mode",
-        "illustration": "Create illustration",
-        "illustrationPlaceholder": "Describe the illustration you want to create…",
         "image": "Create image",
         "imagePlaceholder": "Describe the image you want to create…",
         "presentation": "Create presentation",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1855,6 +1855,21 @@
     "composer": {
       "agentSuggestions": "Agents",
       "configureModel": "Configure model",
+      "create": {
+        "chooseStyle": "Choose style",
+        "chooseTemplate": "Choose template",
+        "exit": "Exit create mode",
+        "illustration": "Create illustration",
+        "illustrationPlaceholder": "Describe the illustration you want to create…",
+        "image": "Create image",
+        "imagePlaceholder": "Describe the image you want to create…",
+        "presentation": "Create presentation",
+        "presentationPlaceholder": "What is your presentation about?",
+        "settingsAdjusted": "Some video settings were adjusted for this model",
+        "title": "Create",
+        "video": "Create video",
+        "videoPlaceholder": "Describe the video you want to create…"
+      },
       "createWorkflow": "Create workflow",
       "imageModelForThisChat": "Image model for this chat",
       "message": "Message",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1884,6 +1884,21 @@
     "composer": {
       "agentSuggestions": "Agentes",
       "configureModel": "Configurar modelo",
+      "create": {
+        "chooseStyle": "Elegir estilo",
+        "chooseTemplate": "Elegir plantilla",
+        "exit": "Salir del modo de creación",
+        "illustration": "Crear ilustración",
+        "illustrationPlaceholder": "Describe la ilustración que quieres crear…",
+        "image": "Crear imagen",
+        "imagePlaceholder": "Describe la imagen que quieres crear…",
+        "presentation": "Crear presentación",
+        "presentationPlaceholder": "¿De qué trata tu presentación?",
+        "settingsAdjusted": "Se han ajustado algunas opciones de vídeo para este modelo",
+        "title": "Crear",
+        "video": "Crear vídeo",
+        "videoPlaceholder": "Describe el vídeo que quieres crear…"
+      },
       "createWorkflow": "Crear flujo de trabajo",
       "imageModelForThisChat": "Modelo de imagen para este chat",
       "message": "Mensaje",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1888,8 +1888,6 @@
         "chooseStyle": "Elegir estilo",
         "chooseTemplate": "Elegir plantilla",
         "exit": "Salir del modo de creación",
-        "illustration": "Crear ilustración",
-        "illustrationPlaceholder": "Describe la ilustración que quieres crear…",
         "image": "Crear imagen",
         "imagePlaceholder": "Describe la imagen que quieres crear…",
         "presentation": "Crear presentación",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1888,8 +1888,6 @@
         "chooseStyle": "Choisir un style",
         "chooseTemplate": "Choisir un modèle",
         "exit": "Quitter le mode création",
-        "illustration": "Créer une illustration",
-        "illustrationPlaceholder": "Décrivez l’illustration à créer…",
         "image": "Créer une image",
         "imagePlaceholder": "Décrivez l’image à créer…",
         "presentation": "Créer une présentation",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1884,6 +1884,21 @@
     "composer": {
       "agentSuggestions": "Agents",
       "configureModel": "Configurer le modèle",
+      "create": {
+        "chooseStyle": "Choisir un style",
+        "chooseTemplate": "Choisir un modèle",
+        "exit": "Quitter le mode création",
+        "illustration": "Créer une illustration",
+        "illustrationPlaceholder": "Décrivez l’illustration à créer…",
+        "image": "Créer une image",
+        "imagePlaceholder": "Décrivez l’image à créer…",
+        "presentation": "Créer une présentation",
+        "presentationPlaceholder": "Quel est le sujet de votre présentation ?",
+        "settingsAdjusted": "Certains paramètres vidéo ont été adaptés à ce modèle",
+        "title": "Créer",
+        "video": "Créer une vidéo",
+        "videoPlaceholder": "Décrivez la vidéo à créer…"
+      },
       "createWorkflow": "Créer un workflow",
       "imageModelForThisChat": "Modèle d’image pour cette discussion",
       "message": "Message",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1859,8 +1859,6 @@
         "chooseStyle": "शैली चुनें",
         "chooseTemplate": "टेम्पलेट चुनें",
         "exit": "बनाने के मोड से बाहर निकलें",
-        "illustration": "चित्रण बनाएँ",
-        "illustrationPlaceholder": "आप जो चित्रण बनाना चाहते हैं उसका वर्णन करें…",
         "image": "छवि बनाएँ",
         "imagePlaceholder": "आप जो छवि बनाना चाहते हैं उसका वर्णन करें…",
         "presentation": "प्रस्तुति बनाएँ",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1855,6 +1855,21 @@
     "composer": {
       "agentSuggestions": "एजेंट",
       "configureModel": "मॉडल कॉन्फ़िगर करें",
+      "create": {
+        "chooseStyle": "शैली चुनें",
+        "chooseTemplate": "टेम्पलेट चुनें",
+        "exit": "बनाने के मोड से बाहर निकलें",
+        "illustration": "चित्रण बनाएँ",
+        "illustrationPlaceholder": "आप जो चित्रण बनाना चाहते हैं उसका वर्णन करें…",
+        "image": "छवि बनाएँ",
+        "imagePlaceholder": "आप जो छवि बनाना चाहते हैं उसका वर्णन करें…",
+        "presentation": "प्रस्तुति बनाएँ",
+        "presentationPlaceholder": "आपकी प्रस्तुति का विषय क्या है?",
+        "settingsAdjusted": "इस मॉडल के लिए कुछ वीडियो सेटिंग समायोजित की गई हैं",
+        "title": "बनाएँ",
+        "video": "वीडियो बनाएँ",
+        "videoPlaceholder": "आप जो वीडियो बनाना चाहते हैं उसका वर्णन करें…"
+      },
       "createWorkflow": "वर्कफ़्लो बनाएँ",
       "imageModelForThisChat": "इस चैट के लिए इमेज मॉडल",
       "message": "संदेश",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1852,6 +1852,21 @@
     "composer": {
       "agentSuggestions": "Agen",
       "configureModel": "Konfigurasikan model",
+      "create": {
+        "chooseStyle": "Pilih gaya",
+        "chooseTemplate": "Pilih templat",
+        "exit": "Keluar dari mode pembuatan",
+        "illustration": "Buat ilustrasi",
+        "illustrationPlaceholder": "Jelaskan ilustrasi yang ingin Anda buat…",
+        "image": "Buat gambar",
+        "imagePlaceholder": "Jelaskan gambar yang ingin Anda buat…",
+        "presentation": "Buat presentasi",
+        "presentationPlaceholder": "Apa topik presentasi Anda?",
+        "settingsAdjusted": "Beberapa pengaturan video disesuaikan untuk model ini",
+        "title": "Buat",
+        "video": "Buat video",
+        "videoPlaceholder": "Jelaskan video yang ingin Anda buat…"
+      },
       "createWorkflow": "Buat alur kerja",
       "imageModelForThisChat": "Model gambar untuk chat ini",
       "message": "Pesan",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1856,8 +1856,6 @@
         "chooseStyle": "Pilih gaya",
         "chooseTemplate": "Pilih templat",
         "exit": "Keluar dari mode pembuatan",
-        "illustration": "Buat ilustrasi",
-        "illustrationPlaceholder": "Jelaskan ilustrasi yang ingin Anda buat…",
         "image": "Buat gambar",
         "imagePlaceholder": "Jelaskan gambar yang ingin Anda buat…",
         "presentation": "Buat presentasi",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1884,6 +1884,21 @@
     "composer": {
       "agentSuggestions": "Agenti",
       "configureModel": "Configura modello",
+      "create": {
+        "chooseStyle": "Scegli stile",
+        "chooseTemplate": "Scegli modello",
+        "exit": "Esci dalla modalità creazione",
+        "illustration": "Crea illustrazione",
+        "illustrationPlaceholder": "Descrivi l’illustrazione che vuoi creare…",
+        "image": "Crea immagine",
+        "imagePlaceholder": "Descrivi l’immagine che vuoi creare…",
+        "presentation": "Crea presentazione",
+        "presentationPlaceholder": "Di cosa tratta la tua presentazione?",
+        "settingsAdjusted": "Alcune impostazioni video sono state adattate a questo modello",
+        "title": "Crea",
+        "video": "Crea video",
+        "videoPlaceholder": "Descrivi il video che vuoi creare…"
+      },
       "createWorkflow": "Crea flusso di lavoro",
       "imageModelForThisChat": "Modello di immagini per questa chat",
       "message": "Messaggio",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1888,8 +1888,6 @@
         "chooseStyle": "Scegli stile",
         "chooseTemplate": "Scegli modello",
         "exit": "Esci dalla modalità creazione",
-        "illustration": "Crea illustrazione",
-        "illustrationPlaceholder": "Descrivi l’illustrazione che vuoi creare…",
         "image": "Crea immagine",
         "imagePlaceholder": "Descrivi l’immagine che vuoi creare…",
         "presentation": "Crea presentazione",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1856,8 +1856,6 @@
         "chooseStyle": "スタイルを選択",
         "chooseTemplate": "テンプレートを選択",
         "exit": "作成モードを終了",
-        "illustration": "イラストを作成",
-        "illustrationPlaceholder": "作成したいイラストを説明してください…",
         "image": "画像を作成",
         "imagePlaceholder": "作成したい画像を説明してください…",
         "presentation": "プレゼンテーションを作成",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1852,6 +1852,21 @@
     "composer": {
       "agentSuggestions": "エージェント",
       "configureModel": "モデルの構成",
+      "create": {
+        "chooseStyle": "スタイルを選択",
+        "chooseTemplate": "テンプレートを選択",
+        "exit": "作成モードを終了",
+        "illustration": "イラストを作成",
+        "illustrationPlaceholder": "作成したいイラストを説明してください…",
+        "image": "画像を作成",
+        "imagePlaceholder": "作成したい画像を説明してください…",
+        "presentation": "プレゼンテーションを作成",
+        "presentationPlaceholder": "プレゼンテーションのテーマは何ですか？",
+        "settingsAdjusted": "このモデルに合わせて一部の動画設定を調整しました",
+        "title": "作成",
+        "video": "動画を作成",
+        "videoPlaceholder": "作成したい動画を説明してください…"
+      },
       "createWorkflow": "ワークフローの作成",
       "imageModelForThisChat": "このチャットの画像モデル",
       "message": "メッセージ",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1856,8 +1856,6 @@
         "chooseStyle": "스타일 선택",
         "chooseTemplate": "템플릿 선택",
         "exit": "만들기 모드 종료",
-        "illustration": "일러스트 만들기",
-        "illustrationPlaceholder": "만들고 싶은 일러스트를 설명하세요…",
         "image": "이미지 만들기",
         "imagePlaceholder": "만들고 싶은 이미지를 설명하세요…",
         "presentation": "프레젠테이션 만들기",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1852,6 +1852,21 @@
     "composer": {
       "agentSuggestions": "에이전트",
       "configureModel": "모델 구성",
+      "create": {
+        "chooseStyle": "스타일 선택",
+        "chooseTemplate": "템플릿 선택",
+        "exit": "만들기 모드 종료",
+        "illustration": "일러스트 만들기",
+        "illustrationPlaceholder": "만들고 싶은 일러스트를 설명하세요…",
+        "image": "이미지 만들기",
+        "imagePlaceholder": "만들고 싶은 이미지를 설명하세요…",
+        "presentation": "프레젠테이션 만들기",
+        "presentationPlaceholder": "프레젠테이션의 주제는 무엇인가요?",
+        "settingsAdjusted": "이 모델에 맞게 일부 동영상 설정을 조정했습니다",
+        "title": "만들기",
+        "video": "동영상 만들기",
+        "videoPlaceholder": "만들고 싶은 동영상을 설명하세요…"
+      },
       "createWorkflow": "워크플로 생성",
       "imageModelForThisChat": "이 채팅의 이미지 모델",
       "message": "메시지",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1888,8 +1888,6 @@
         "chooseStyle": "Escolher estilo",
         "chooseTemplate": "Escolher modelo",
         "exit": "Sair do modo de criação",
-        "illustration": "Criar ilustração",
-        "illustrationPlaceholder": "Descreva a ilustração que você quer criar…",
         "image": "Criar imagem",
         "imagePlaceholder": "Descreva a imagem que você quer criar…",
         "presentation": "Criar apresentação",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1884,6 +1884,21 @@
     "composer": {
       "agentSuggestions": "Agentes",
       "configureModel": "Configurar modelo",
+      "create": {
+        "chooseStyle": "Escolher estilo",
+        "chooseTemplate": "Escolher modelo",
+        "exit": "Sair do modo de criação",
+        "illustration": "Criar ilustração",
+        "illustrationPlaceholder": "Descreva a ilustração que você quer criar…",
+        "image": "Criar imagem",
+        "imagePlaceholder": "Descreva a imagem que você quer criar…",
+        "presentation": "Criar apresentação",
+        "presentationPlaceholder": "Qual é o tema da sua apresentação?",
+        "settingsAdjusted": "Algumas configurações de vídeo foram ajustadas para este modelo",
+        "title": "Criar",
+        "video": "Criar vídeo",
+        "videoPlaceholder": "Descreva o vídeo que você quer criar…"
+      },
       "createWorkflow": "Criar fluxo de trabalho",
       "imageModelForThisChat": "Modelo de imagem para este chat",
       "message": "Mensagem",

--- a/turbo/apps/platform/src/signals/okou-page/composer-create.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-create.ts
@@ -6,10 +6,9 @@ import type { WorkflowComposerSignals } from "./tiptap-workflow-composer.ts";
 import type { ComposerUiSignalGroups } from "./chat-composer.ts";
 
 export const COMPOSER_CREATE_MODES = [
-  "image",
   "video",
   "presentation",
-  "illustration",
+  "image",
 ] as const;
 
 export type ComposerCreateMode = (typeof COMPOSER_CREATE_MODES)[number];
@@ -31,11 +30,6 @@ export function composerCreateModeLabel(mode: ComposerCreateMode): string {
         return $.chat.composer.create.presentation;
       });
     }
-    case "illustration": {
-      return i18n.t(($) => {
-        return $.chat.composer.create.illustration;
-      });
-    }
   }
 }
 
@@ -54,11 +48,6 @@ export function composerCreatePlaceholder(mode: ComposerCreateMode): string {
     case "presentation": {
       return i18n.t(($) => {
         return $.chat.composer.create.presentationPlaceholder;
-      });
-    }
-    case "illustration": {
-      return i18n.t(($) => {
-        return $.chat.composer.create.illustrationPlaceholder;
       });
     }
   }

--- a/turbo/apps/platform/src/signals/okou-page/composer-create.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-create.ts
@@ -1,0 +1,109 @@
+import { command, computed, state } from "ccstate";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { i18n } from "../../i18n/index.ts";
+import type { WorkflowComposerSignals } from "./tiptap-workflow-composer.ts";
+import type { ComposerUiSignalGroups } from "./chat-composer.ts";
+
+export const COMPOSER_CREATE_MODES = [
+  "image",
+  "video",
+  "presentation",
+  "illustration",
+] as const;
+
+export type ComposerCreateMode = (typeof COMPOSER_CREATE_MODES)[number];
+
+export function composerCreateModeLabel(mode: ComposerCreateMode): string {
+  switch (mode) {
+    case "image": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.image;
+      });
+    }
+    case "video": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.video;
+      });
+    }
+    case "presentation": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.presentation;
+      });
+    }
+    case "illustration": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.illustration;
+      });
+    }
+  }
+}
+
+export function composerCreatePlaceholder(mode: ComposerCreateMode): string {
+  switch (mode) {
+    case "image": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.imagePlaceholder;
+      });
+    }
+    case "video": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.videoPlaceholder;
+      });
+    }
+    case "presentation": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.presentationPlaceholder;
+      });
+    }
+    case "illustration": {
+      return i18n.t(($) => {
+        return $.chat.composer.create.illustrationPlaceholder;
+      });
+    }
+  }
+}
+
+export function createComposerCreateSignals(
+  composer: WorkflowComposerSignals,
+  ui: ComposerUiSignalGroups,
+) {
+  const internalMode$ = state<ComposerCreateMode | null>(null);
+  const enabled$ = computed((get) => {
+    return get(featureSwitch$)[FeatureSwitchKey.ComposerCreateCommands];
+  });
+  const mode$ = computed((get) => {
+    return get(enabled$) ? get(internalMode$) : null;
+  });
+  const setMode$ = command(({ get, set }, mode: ComposerCreateMode | null) => {
+    if (!get(enabled$)) {
+      return;
+    }
+    const range = get(composer.activeSlashRange$);
+    if (mode && range) {
+      const head = composer.editor.state.selection.head;
+      composer.editor
+        .chain()
+        .focus()
+        .deleteRange({ from: head - (range.end - range.start), to: head })
+        .run();
+    }
+    set(internalMode$, mode);
+    set(composer.closeSuggestionMenu$);
+    set(ui.model.setModelPickerOpen$, false);
+    set(
+      ui.model.setMediaModelCategory$,
+      mode === "image" || mode === "video" ? mode : null,
+    );
+    set(ui.videoOptions.setVideoOptionsOpen$, false);
+    if (mode !== "video") {
+      set(ui.videoOptions.setVideoRunOptions$, {});
+    }
+    set(composer.focus$);
+  });
+  return { enabled$, mode$, setMode$ };
+}
+
+export type ComposerCreateSignals = ReturnType<
+  typeof createComposerCreateSignals
+>;

--- a/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
@@ -30,7 +30,14 @@ import {
   semanticChatEventsFromChatEvents,
   type ChatRunModelSelection,
 } from "../chat-page/chat-event-state.ts";
-import { messageDocumentToDisplayText } from "./user-message-document-codec.ts";
+import {
+  createEditorDocumentSnapshot,
+  messageDocumentToDisplayText,
+} from "./user-message-document-codec.ts";
+import {
+  createComposerCreateSignals,
+  type ComposerCreateSignals,
+} from "./composer-create.ts";
 import {
   createWorkflowComposerSignals,
   type WorkflowComposerSignals,
@@ -250,6 +257,7 @@ interface ComposerTemplateSignals
 }
 
 export interface ComposerSignals {
+  readonly create: ComposerCreateSignals;
   readonly agentId: string;
   readonly editor: ComposerEditorSignals;
   readonly voice: ComposerVoiceInputSignals;
@@ -542,6 +550,7 @@ export function createComposerSignals(
     },
     feedback,
   );
+  const create = createComposerCreateSignals(workflowComposer, ui);
   const voice = createComposerVoiceInput(
     options,
     workflowComposer,
@@ -552,7 +561,7 @@ export function createComposerSignals(
     eventSignals,
     workflowComposer,
     ui.videoOptions,
-    voice,
+    { voice, create },
   );
   const fileInput = createComposerFileInputSignals();
   const workflowPrompt = createComposerWorkflowPromptSignals(
@@ -590,6 +599,7 @@ export function createComposerSignals(
 
   return {
     agentId: options.agentId,
+    create,
     editor: composerEditorSignals(workflowComposer, options.singleLineOnMobile),
     voice,
     feedback: workflowComposer.feedback,
@@ -816,7 +826,10 @@ function createComposerSubmissionSignals(
   eventSignals: ReturnType<typeof createComposerChatEventSignals>,
   workflowComposer: WorkflowComposerSignals,
   videoOptions: ComposerVideoOptionsSignals,
-  voice: ComposerVoiceInputSignals,
+  {
+    voice,
+    create,
+  }: { voice: ComposerVoiceInputSignals; create: ComposerCreateSignals },
 ) {
   const { state$: voiceState$, owner$ } = voice;
   const draft = options.draft.signals;
@@ -870,14 +883,39 @@ function createComposerSubmissionSignals(
       if (!get(draft.attachmentUploadsReady$)) {
         return false;
       }
-      const videoRunOptions = await set(readVideoRunOptions$, signal);
+      const mode = get(create.mode$);
+      const videoRunOptions =
+        mode !== null && mode !== "video"
+          ? undefined
+          : await set(readVideoRunOptions$, signal);
+      signal.throwIfAborted();
+      const instruction = mode
+        ? `Create ${mode === "illustration" || mode === "image" ? "an" : "a"} ${mode}.`
+        : null;
+      const document = submission.editorDocument.toEditorDocument();
+      const editorDocument = instruction
+        ? createEditorDocumentSnapshot(
+            workflowComposer.editor.schema.nodeFromJSON({
+              ...document,
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: instruction }],
+                },
+                ...(document.content ?? []),
+              ],
+            }),
+          )
+        : submission.editorDocument;
       return await set(
         options.submitMessage$,
         action,
         {
-          prompt: visiblePrompt,
+          prompt: instruction
+            ? `${instruction}\n\n${visiblePrompt}`
+            : visiblePrompt,
           generationTemplate: get(draft.generationTemplate$),
-          editorDocument: submission.editorDocument,
+          editorDocument,
           videoRunOptions,
         },
         signal,

--- a/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
+++ b/turbo/apps/platform/src/signals/okou-page/composer-signals.ts
@@ -890,7 +890,7 @@ function createComposerSubmissionSignals(
           : await set(readVideoRunOptions$, signal);
       signal.throwIfAborted();
       const instruction = mode
-        ? `Create ${mode === "illustration" || mode === "image" ? "an" : "a"} ${mode}.`
+        ? `Create ${mode === "image" ? "an" : "a"} ${mode}.`
         : null;
       const document = submission.editorDocument.toEditorDocument();
       const editorDocument = instruction

--- a/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
+++ b/turbo/apps/platform/src/signals/okou-page/tiptap-workflow-composer.ts
@@ -232,7 +232,11 @@ export interface WorkflowComposerSignals {
 
 export type OpenComposerTemplatePickerIntent =
   | { readonly kind: "insert"; readonly category: string }
-  | { readonly kind: "edit-selected"; readonly category: string }
+  | {
+      readonly kind: "edit-selected";
+      readonly category: string;
+      readonly position: number;
+    }
   | { readonly kind: "edit-legacy"; readonly category: string };
 
 export type ComposerTemplateAttachmentType =
@@ -1576,28 +1580,21 @@ function createInlineTemplateNode(
       return `Select ${attachment.title} ${attachment.type} template`;
     },
     addNodeView() {
-      return ({ node, getPos, editor }) => {
-        const selectSelf = (): boolean => {
+      return ({ node, getPos }) => {
+        const openTemplate = (category: string): void => {
           const position = getPos();
           if (typeof position !== "number") {
-            return false;
+            return;
           }
-          editor.view.dispatch(
-            editor.state.tr.setSelection(
-              NodeSelection.create(editor.state.doc, position),
-            ),
-          );
-          return true;
+          runtime.openTemplate({
+            kind: "edit-selected",
+            category,
+            position,
+          });
         };
         return createInlineTemplateNodeView(
           node,
-          {
-            openTemplate: (category) => {
-              if (selectSelf()) {
-                runtime.openTemplate({ kind: "edit-selected", category });
-              }
-            },
-          },
+          { openTemplate },
           runtime.localizedUi,
         );
       };
@@ -2464,6 +2461,7 @@ function createTemplateCommands(
       set(legacyReplacementPending$, intent.kind === "edit-legacy");
       let referenceValue: GenerationTemplateRequest | null = null;
       if (intent.kind === "edit-selected") {
+        editor.commands.setNodeSelection(intent.position);
         referenceValue = set(readSelectedTemplate$) ?? null;
       } else if (intent.kind === "edit-legacy") {
         referenceValue = get(draft.generationTemplate$) ?? null;

--- a/turbo/apps/platform/src/signals/okou-page/workflow-composer-domain.ts
+++ b/turbo/apps/platform/src/signals/okou-page/workflow-composer-domain.ts
@@ -43,7 +43,9 @@ export function findActiveSlashWorkflowRange(
   }
 
   const beforeCaret = value.slice(0, caretIndex);
-  const match = /(?:^|\s)\/([a-z0-9-]*)$/i.exec(beforeCaret);
+  const match = /(?:^|\s)\/((?:create\s+[a-z]*)|[a-z0-9-]*)$/i.exec(
+    beforeCaret,
+  );
   if (!match) {
     return null;
   }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -1,0 +1,250 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect, test } from "vitest";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@okouai/core";
+import {
+  IMAGE_MODEL_CONFIGS,
+  PUBLIC_IMAGE_MODELS,
+} from "@okouai/core/image-model-catalog";
+import type {
+  UserMessageDocument,
+  ChatRunOptionsRequest,
+} from "@okouai/api-contracts/contracts/chat-threads";
+import {
+  click,
+  fill,
+  queryAllByRoleFast,
+  setupPage,
+} from "../../../__tests__/page-helper.ts";
+import { mockChatLifecycle } from "./chat-test-helpers.ts";
+import {
+  AGENT_ID,
+  composerInlineTemplates,
+  context,
+  findComposerEditor,
+  mockAgent,
+  mockBillingCapabilities,
+  mockOrgModelRoutes,
+  selectTemplate,
+} from "./chat-composer-test-helpers.ts";
+
+function setupModels(): void {
+  mockAgent();
+  mockOrgModelRoutes("claude-fable-5-1");
+  mockBillingCapabilities({ supportByok: true, restrictedVm0Models: false });
+  context.mocks.data.userModelPreference({
+    selectedModel: "claude-fable-5-1",
+    serviceTier: null,
+    selectedImageModel: "gpt-image-2",
+    selectedVideoModel: "dreamina-seedance-2-0-260128",
+    updatedAt: "2026-09-07T00:00:00.000Z",
+  });
+}
+
+function button(label: string, container: ParentNode = document): HTMLElement {
+  const result = queryAllByRoleFast("button", container).find((item) => {
+    return (
+      item.getAttribute("aria-label") === label ||
+      item.textContent?.trim() === label
+    );
+  });
+  if (!result) {
+    throw new Error(`Expected button ${label}`);
+  }
+  return result;
+}
+
+async function setupComposer(enabled = true): Promise<HTMLElement> {
+  await setupPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+    featureSwitches: { [FeatureSwitchKey.ComposerCreateCommands]: enabled },
+  });
+  return await findComposerEditor();
+}
+
+async function chooseCommand(
+  editor: HTMLElement,
+  text: string,
+  label: string,
+): Promise<void> {
+  await fill(editor, text);
+  const menu = await screen.findByTestId("slash-workflow-menu");
+  click(button(label, menu));
+  await waitFor(() => {
+    expect(screen.getByTestId("composer-create-mode")).toHaveTextContent(label);
+  });
+}
+
+test("Create commands stay hidden until enabled", async () => {
+  setupModels();
+  const editor = await setupComposer(false);
+  await fill(editor, "/");
+  expect(screen.queryByTestId("slash-workflow-menu")).toBeNull();
+  expect(screen.queryByTestId("composer-create-mode")).toBeNull();
+});
+
+test("Choose a video command with the keyboard and submit the selected video settings", async () => {
+  setupModels();
+  const submissions: {
+    userMessage?: UserMessageDocument;
+    runOptions?: ChatRunOptionsRequest;
+  }[] = [];
+  mockChatLifecycle(context, {
+    onRunCreate: (body) => {
+      submissions.push(body);
+    },
+  });
+  const editor = await setupComposer();
+  const user = userEvent.setup({ delay: null });
+  await fill(editor, "A train crossing the mountains /create video");
+  await screen.findByTestId("slash-workflow-menu");
+  await user.keyboard("{Enter}");
+  await waitFor(() => {
+    expect(screen.getByTestId("composer-create-mode")).toHaveTextContent(
+      "Create video",
+    );
+  });
+  expect(editor).toHaveTextContent("A train crossing the mountains");
+  expect(editor).not.toHaveTextContent("/create");
+  expect(submissions).toHaveLength(0);
+  const videoPicker = await screen.findByRole("combobox", {
+    name: "Video models",
+  });
+  expect(videoPicker).toHaveTextContent("Seedance 2.0");
+  click(screen.getByRole("combobox", { name: "Ratio" }));
+  click(await screen.findByRole("option", { name: "9:16" }));
+  await waitFor(() => {
+    expect(screen.getByRole("combobox", { name: "Ratio" })).toHaveTextContent(
+      "9:16",
+    );
+  });
+  click(button("Send"));
+  await waitFor(() => {
+    expect(submissions).toHaveLength(1);
+  });
+  const sent = submissions[0];
+  expect(sent?.userMessage?.parts).toStrictEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringContaining("Create a video."),
+      }),
+    ]),
+  );
+  expect(JSON.stringify(sent?.userMessage)).toContain(
+    "A train crossing the mountains",
+  );
+  expect(sent?.runOptions?.video).toMatchObject({ aspectRatio: "9:16" });
+});
+
+test("Image mode selects image models and exiting preserves the prompt", async () => {
+  setupModels();
+  const editor = await setupComposer();
+  await chooseCommand(editor, "A quiet garden /create image", "Create image");
+  const picker = await screen.findByRole("combobox", { name: "Image models" });
+  click(picker);
+  const model = PUBLIC_IMAGE_MODELS.find((candidate) => {
+    return candidate !== "gpt-image-2";
+  });
+  if (!model) {
+    throw new Error("Expected another public image model");
+  }
+  click(
+    await screen.findByRole("option", {
+      name: IMAGE_MODEL_CONFIGS[model].label,
+    }),
+  );
+  await waitFor(() => {
+    expect(picker).toHaveTextContent(IMAGE_MODEL_CONFIGS[model].label);
+  });
+  click(button("Exit create mode"));
+  await screen.findByRole("combobox", { name: "Claude Fable 5.1" });
+  expect(screen.queryByTestId("composer-create-mode")).toBeNull();
+  expect(editor).toHaveTextContent("A quiet garden");
+});
+
+test("Presentation mode replaces its one selected template without adding a second", async () => {
+  setupModels();
+  const editor = await setupComposer();
+  const [first, replacement] = PRESENTATION_TEMPLATE_PICKER_ITEMS;
+  if (!first || !replacement) {
+    throw new Error("Expected two presentation templates");
+  }
+  await chooseCommand(
+    editor,
+    "Our launch /create presentation",
+    "Create presentation",
+  );
+  click(button("Choose template"));
+  await screen.findByRole("dialog");
+  click(await screen.findByLabelText(`Select template ${first.title}`));
+  await waitFor(() => {
+    expect(button(first.title)).toBeInTheDocument();
+  });
+  click(button(first.title));
+  await screen.findByRole("dialog");
+  click(await screen.findByLabelText(`Select template ${replacement.title}`));
+  await waitFor(() => {
+    expect(button(replacement.title)).toBeInTheDocument();
+  });
+  expect(composerInlineTemplates()).toHaveLength(1);
+  expect(composerInlineTemplates()[0]).toHaveTextContent(replacement.title);
+  expect(editor).toHaveTextContent("Our launch");
+});
+
+test("Multiple templates keep a generic toolbar label and all references survive sending", async () => {
+  setupModels();
+  const submissions: UserMessageDocument[] = [];
+  mockChatLifecycle(context, {
+    onRunCreate: (body) => {
+      if (body.userMessage) {
+        submissions.push(body.userMessage);
+      }
+    },
+  });
+  const editor = await setupComposer();
+  const user = userEvent.setup({ delay: null });
+  const [first, second] = PRESENTATION_TEMPLATE_PICKER_ITEMS;
+  if (!first || !second) {
+    throw new Error("Expected two presentation templates");
+  }
+  await selectTemplate(user, first);
+  await selectTemplate(user, second);
+  await user.click(editor);
+  await user.paste(" /create presentation");
+  const menu = await screen.findByTestId("slash-workflow-menu");
+  click(button("Create presentation", menu));
+  await waitFor(() => {
+    expect(button("Choose template")).toBeInTheDocument();
+  });
+  expect(composerInlineTemplates()).toHaveLength(2);
+  click(button("Send"));
+  await waitFor(() => {
+    expect(submissions).toHaveLength(1);
+  });
+  expect(
+    submissions[0]?.parts
+      .filter((part) => {
+        return part.type === "template";
+      })
+      .map((part) => {
+        return part.titleSnapshot;
+      }),
+  ).toStrictEqual([first.title, second.title]);
+});
+
+test("Illustration mode opens the style gallery directly", async () => {
+  setupModels();
+  const editor = await setupComposer();
+  await chooseCommand(editor, "/create illustration", "Create illustration");
+  click(button("Choose style"));
+  const dialog = await screen.findByRole("dialog");
+  await waitFor(() => {
+    const tab = queryAllByRoleFast("tab", dialog).find((item) => {
+      return item.textContent?.trim() === "Illustration";
+    });
+    expect(tab).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -164,6 +164,47 @@ test("Image mode selects image models and exiting preserves the prompt", async (
   expect(editor).toHaveTextContent("A quiet garden");
 });
 
+test("Image mode sends when the model menu is still open", async () => {
+  setupModels();
+  const user = userEvent.setup({ delay: null });
+  const submissions: UserMessageDocument[] = [];
+  mockChatLifecycle(context, {
+    onRunCreate: (body) => {
+      if (body.userMessage) {
+        submissions.push(body.userMessage);
+      }
+    },
+  });
+  const editor = await setupComposer();
+  await chooseCommand(editor, "A quiet garden /create image", "Create image");
+  await waitFor(() => {
+    expect(screen.queryByTestId("slash-workflow-menu")).toBeNull();
+  });
+  const picker = screen.getByRole("combobox", { name: "Image models" });
+  await user.click(picker);
+  await waitFor(() => {
+    expect(picker).toHaveAttribute("aria-controls");
+  });
+  const listboxId = picker.getAttribute("aria-controls");
+  if (!listboxId) {
+    throw new Error("Expected image model listbox id");
+  }
+  const listbox = await waitFor(() => {
+    const element = document.getElementById(listboxId);
+    expect(element).toHaveAttribute("role", "listbox");
+    return element as HTMLElement;
+  });
+  const popupPortal = listbox.closest("[data-base-ui-portal]");
+  expect(
+    popupPortal?.querySelector(":scope > [data-base-ui-inert]"),
+  ).toBeNull();
+  const send = button("Send");
+  await user.click(send);
+  await waitFor(() => {
+    expect(submissions).toHaveLength(1);
+  });
+});
+
 test("Presentation mode replaces its one selected template without adding a second", async () => {
   setupModels();
   const editor = await setupComposer();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -183,22 +183,8 @@ test("Image mode sends when the model menu is still open", async () => {
   });
   const picker = screen.getByRole("combobox", { name: "Image models" });
   await user.click(picker);
-  await waitFor(() => {
-    expect(picker).toHaveAttribute("aria-controls");
-  });
-  const listboxId = picker.getAttribute("aria-controls");
-  if (!listboxId) {
-    throw new Error("Expected image model listbox id");
-  }
-  const listbox = await waitFor(() => {
-    const element = document.getElementById(listboxId);
-    expect(element).toHaveAttribute("role", "listbox");
-    return element as HTMLElement;
-  });
-  const popupPortal = listbox.closest("[data-base-ui-portal]");
-  expect(
-    popupPortal?.querySelector(":scope > [data-base-ui-inert]"),
-  ).toBeNull();
+  const modelListbox = await screen.findByRole("listbox");
+  expect(modelListbox).toBeInTheDocument();
   const send = button("Send");
   await user.click(send);
   await waitFor(() => {
@@ -305,7 +291,6 @@ test("Create suggestions expose one image command that opens the style gallery",
       return item.textContent?.trim() === "Create image";
     }),
   ).toHaveLength(1);
-  expect(menu).not.toHaveTextContent("Create illustration");
   click(button("Create image", menu));
   click(button("Choose style"));
   const dialog = await screen.findByRole("dialog");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -45,8 +45,7 @@ function setupModels(): void {
 function button(label: string, container: ParentNode = document): HTMLElement {
   const result = queryAllByRoleFast("button", container).find((item) => {
     return (
-      item.getAttribute("aria-label") === label ||
-      item.textContent?.trim() === label
+      (item.getAttribute("aria-label") ?? item.textContent?.trim()) === label
     );
   });
   if (!result) {
@@ -233,6 +232,25 @@ test("Multiple templates keep a generic toolbar label and all references survive
         return part.titleSnapshot;
       }),
   ).toStrictEqual([first.title, second.title]);
+});
+
+test("Presentation recognizes an existing template picked before entering create mode", async () => {
+  setupModels();
+  const editor = await setupComposer();
+  const user = userEvent.setup({ delay: null });
+  const first = PRESENTATION_TEMPLATE_PICKER_ITEMS[0];
+  if (!first) {
+    throw new Error("Expected a presentation template");
+  }
+  await selectTemplate(user, first);
+  await user.click(editor);
+  await user.paste(" /create presentation");
+  const menu = await screen.findByTestId("slash-workflow-menu");
+  click(button("Create presentation", menu));
+  await waitFor(() => {
+    expect(button(first.title)).toBeInTheDocument();
+  });
+  expect(composerInlineTemplates()).toHaveLength(1);
 });
 
 test("Illustration mode opens the style gallery directly", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -138,10 +138,11 @@ test("Choose a video command with the keyboard and submit the selected video set
   expect(sent?.runOptions?.video).toMatchObject({ aspectRatio: "9:16" });
 });
 
-test("Image mode selects image models and exiting preserves the prompt", async () => {
+test("Image mode combines styles and image models while preserving the prompt", async () => {
   setupModels();
   const editor = await setupComposer();
   await chooseCommand(editor, "A quiet garden /create image", "Create image");
+  expect(button("Choose style")).toBeInTheDocument();
   const picker = await screen.findByRole("combobox", { name: "Image models" });
   click(picker);
   const model = PUBLIC_IMAGE_MODELS.find((candidate) => {
@@ -294,10 +295,18 @@ test("Presentation recognizes an existing template picked before entering create
   expect(composerInlineTemplates()).toHaveLength(1);
 });
 
-test("Illustration mode opens the style gallery directly", async () => {
+test("Create suggestions expose one image command that opens the style gallery", async () => {
   setupModels();
   const editor = await setupComposer();
-  await chooseCommand(editor, "/create illustration", "Create illustration");
+  await fill(editor, "/create");
+  const menu = await screen.findByTestId("slash-workflow-menu");
+  expect(
+    queryAllByRoleFast("button", menu).filter((item) => {
+      return item.textContent?.trim() === "Create image";
+    }),
+  ).toHaveLength(1);
+  expect(menu).not.toHaveTextContent("Create illustration");
+  click(button("Create image", menu));
   click(button("Choose style"));
   const dialog = await screen.findByRole("dialog");
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -6753,9 +6753,11 @@ function TemplatePickerButton({
     },
   });
   const templateMode =
-    createMode === "presentation" || createMode === "illustration"
-      ? createMode
-      : null;
+    createMode === "presentation"
+      ? "presentation"
+      : createMode === "image"
+        ? "illustration"
+        : null;
   const singleTemplate =
     templateMode &&
     templates.length === 1 &&

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -2,6 +2,12 @@ import {
   useComposerActions,
   type ComposerActions,
 } from "./composer-actions.ts";
+import { useEditorState } from "@tiptap/react";
+import {
+  ComposerCreateHeader,
+  ComposerCreateImageModelPicker,
+  ComposerCreateVideoModelPicker,
+} from "./composer-create.tsx";
 import type { ComposerVoiceInputStatus } from "../../signals/okou-page/composer-voice-input.ts";
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
@@ -51,6 +57,7 @@ import {
   ArrowUp,
   Bolt,
   Check,
+  ChevronDown,
   Download,
   Globe,
   Image as ImageIcon,
@@ -268,7 +275,11 @@ import {
   sttVoiceLevel$,
 } from "../../signals/voice-io/voice-io-stt.ts";
 import { readChatMessageFromClipboard } from "../../signals/okou-page/clipboard.ts";
-import { shouldUseUserMessage } from "../../signals/okou-page/user-message-document-codec.ts";
+import {
+  INLINE_TEMPLATE_NODE_NAME,
+  TEMPLATE_ATTACHMENT_NODE_NAME,
+  shouldUseUserMessage,
+} from "../../signals/okou-page/user-message-document-codec.ts";
 import { WebsiteTemplatePreviewDialogSlot } from "./website-template-preview-dialog.tsx";
 import { ReplaceComposerDraftDialog } from "./replace-composer-draft-dialog.tsx";
 import {
@@ -6709,13 +6720,69 @@ function TemplatePickerButton({
   );
   const category = useGet(signals.template.templatePickerCategory$);
   const referenceValue = useGet(signals.template.templatePickerReferenceValue$);
+  const createMode = useGet(signals.create.mode$);
+  const templates = useEditorState({
+    editor: signals.editor.editor,
+    selector: ({ editor }) => {
+      const result: {
+        title: string;
+        category: string;
+        position: number;
+        legacy: boolean;
+      }[] = [];
+      editor.state.doc.descendants((node, position) => {
+        if (
+          node.type.name === INLINE_TEMPLATE_NODE_NAME ||
+          node.type.name === TEMPLATE_ATTACHMENT_NODE_NAME
+        ) {
+          const title: unknown = node.attrs.title;
+          const category: unknown = node.attrs.category;
+          if (typeof title === "string" && typeof category === "string") {
+            result.push({
+              title,
+              category,
+              position,
+              legacy: node.type.name === TEMPLATE_ATTACHMENT_NODE_NAME,
+            });
+          }
+          return false;
+        }
+        return true;
+      });
+      return result;
+    },
+  });
+  const templateMode =
+    createMode === "presentation" || createMode === "illustration"
+      ? createMode
+      : null;
+  const singleTemplate =
+    templateMode &&
+    templates.length === 1 &&
+    templates[0]?.category === templateMode
+      ? templates[0]
+      : undefined;
+  const templateLabel =
+    singleTemplate?.title ??
+    (templateMode === "illustration"
+      ? t(($) => {
+          return $.chat.composer.create.chooseStyle;
+        })
+      : templateMode === "presentation"
+        ? t(($) => {
+            return $.chat.composer.create.chooseTemplate;
+          })
+        : t(($) => {
+            return $.artifacts.templates.template;
+          }));
   const setOpen = useSet(signals.template.setTemplatePickerOpen$);
   const setReferenceValue = useSet(
     signals.template.setTemplatePickerReferenceValue$,
   );
   const openTemplatePicker = useSet(signals.template.openTemplatePicker$);
   const cardThemeIdBySlug = useGet(signals.template.templateCardThemeIdBySlug$);
-  const selectedCategory = resolveTemplatePickerCategory(category);
+  const selectedCategory =
+    templateMode ?? resolveTemplatePickerCategory(category);
   const prewarmPicker = () => {
     prewarmTemplatePreviewImages(
       runtime,
@@ -6735,31 +6802,51 @@ function TemplatePickerButton({
             <Button
               type="button"
               variant="quiet"
-              size="icon-sm"
+              size={templateMode ? "sm" : "icon-sm"}
               iconSize="md"
-              className="shrink-0"
-              aria-label={t(($) => {
-                return $.artifacts.templates.template;
-              })}
+              className={
+                templateMode
+                  ? "min-w-0 max-w-[13rem] gap-1 font-normal"
+                  : "shrink-0"
+              }
+              aria-label={templateLabel}
               aria-pressed={false}
               onPointerEnter={prewarmPicker}
               onFocus={prewarmPicker}
               onPointerDown={prewarmPicker}
               onClick={() => {
                 prewarmPicker();
+                if (singleTemplate && !singleTemplate.legacy) {
+                  signals.editor.editor.commands.setNodeSelection(
+                    singleTemplate.position,
+                  );
+                }
                 openTemplatePicker({
-                  kind: "insert",
+                  kind: singleTemplate
+                    ? singleTemplate.legacy
+                      ? "edit-legacy"
+                      : "edit-selected"
+                    : "insert",
                   category: selectedCategory,
                 });
               }}
             >
-              <SwatchBook size={18} aria-hidden="true" />
+              {templateMode ? (
+                <>
+                  <span className="min-w-0 truncate">{templateLabel}</span>
+                  <ChevronDown
+                    size={12}
+                    className="shrink-0 opacity-50"
+                    aria-hidden
+                  />
+                </>
+              ) : (
+                <SwatchBook size={18} aria-hidden="true" />
+              )}
             </Button>
           </TooltipTrigger>
           <TooltipContent side="top" className="text-xs">
-            {t(($) => {
-              return $.artifacts.templates.template;
-            })}
+            {templateLabel}
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
@@ -9633,6 +9720,18 @@ function ComposerExistingMediaModelPickerSlot({
 }
 
 function ComposerModelPickerSlot({ signals }: { signals: ComposerSignals }) {
+  const createMode = useGet(signals.create.mode$);
+  if (createMode === "image" && signals.imageModel) {
+    return <ComposerCreateImageModelPicker model={signals.imageModel} />;
+  }
+  if (createMode === "video" && signals.videoModel) {
+    return (
+      <ComposerCreateVideoModelPicker
+        model={signals.videoModel}
+        signals={signals}
+      />
+    );
+  }
   const imageModelSignals = signals.imageModel;
   const videoModelSignals = signals.videoModel;
   if (imageModelSignals && videoModelSignals) {
@@ -10647,7 +10746,7 @@ function ComposerFooter({
         />
       ) : (
         <>
-          <div className="flex items-center gap-1 text-muted-foreground sm:gap-1.5">
+          <div className="flex min-w-0 items-center gap-1 text-muted-foreground sm:gap-1.5">
             <ComposerAttachButton signals={signals} />
             <ComposerTemplatePickerSlot signals={signals} />
             <ComposerWorkflowPromptSlot signals={signals} />
@@ -10657,7 +10756,7 @@ function ComposerFooter({
                 not which model the composer points at. */}
             <ComposerVideoOptionsChip signals={signals} />
           </div>
-          <div className="flex items-center gap-1 sm:gap-2">
+          <div className="flex shrink-0 items-center gap-1 sm:gap-2">
             <ComposerModelPickerSlot signals={signals} />
             <MicButton signals={signals} actions={actions} />
             <ComposerSendControl signals={signals} actions={actions} />
@@ -10678,7 +10777,7 @@ function ComposerCard({ signals }: { signals: ComposerSignals }) {
   return (
     <Card
       className={cn(
-        "okou-composer relative z-10 overflow-visible",
+        "okou-composer @container/composer relative z-10 overflow-visible",
         dragOver && "outline outline-2 outline-blue-400/60",
       )}
       onDrop={(event) => {
@@ -10705,6 +10804,7 @@ function ComposerCard({ signals }: { signals: ComposerSignals }) {
       <CardContent className="p-0">
         <div ref={actions.bind} className="flex flex-col">
           <ComposerImportedTemplateUrlRefreshLifecycle signals={signals} />
+          <ComposerCreateHeader signals={signals} />
           <ComposerAttachments signals={signals} />
           <ComposerInputSlot signals={signals} actions={actions} />
           {/* Edge inset is 16px on all four sides so it matches the editor's

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -6820,19 +6820,17 @@ function TemplatePickerButton({
               onPointerDown={prewarmPicker}
               onClick={() => {
                 prewarmPicker();
-                if (singleTemplate && !singleTemplate.legacy) {
-                  signals.editor.editor.commands.setNodeSelection(
-                    singleTemplate.position,
-                  );
-                }
-                openTemplatePicker({
-                  kind: singleTemplate
+                openTemplatePicker(
+                  singleTemplate
                     ? singleTemplate.legacy
-                      ? "edit-legacy"
-                      : "edit-selected"
-                    : "insert",
-                  category: selectedCategory,
-                });
+                      ? { kind: "edit-legacy", category: selectedCategory }
+                      : {
+                          kind: "edit-selected",
+                          category: selectedCategory,
+                          position: singleTemplate.position,
+                        }
+                    : { kind: "insert", category: selectedCategory },
+                );
               }}
             >
               {templateMode ? (

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -6726,7 +6726,7 @@ function TemplatePickerButton({
     selector: ({ editor }) => {
       const result: {
         title: string;
-        category: string;
+        type: string;
         position: number;
         legacy: boolean;
       }[] = [];
@@ -6736,11 +6736,11 @@ function TemplatePickerButton({
           node.type.name === TEMPLATE_ATTACHMENT_NODE_NAME
         ) {
           const title: unknown = node.attrs.title;
-          const category: unknown = node.attrs.category;
-          if (typeof title === "string" && typeof category === "string") {
+          const type: unknown = node.attrs.templateType;
+          if (typeof title === "string" && typeof type === "string") {
             result.push({
               title,
-              category,
+              type,
               position,
               legacy: node.type.name === TEMPLATE_ATTACHMENT_NODE_NAME,
             });
@@ -6759,7 +6759,7 @@ function TemplatePickerButton({
   const singleTemplate =
     templateMode &&
     templates.length === 1 &&
-    templates[0]?.category === templateMode
+    templates[0]?.type === templateMode
       ? templates[0]
       : undefined;
   const templateLabel =
@@ -6782,7 +6782,9 @@ function TemplatePickerButton({
   const openTemplatePicker = useSet(signals.template.openTemplatePicker$);
   const cardThemeIdBySlug = useGet(signals.template.templateCardThemeIdBySlug$);
   const selectedCategory =
-    templateMode ?? resolveTemplatePickerCategory(category);
+    templateMode === "presentation"
+      ? "slides"
+      : (templateMode ?? resolveTemplatePickerCategory(category));
   const prewarmPicker = () => {
     prewarmTemplatePreviewImages(
       runtime,

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -10718,6 +10718,9 @@ function ComposerFooter({
   signals: ComposerSignals;
   actions: ComposerActions;
 }) {
+  const createMode = useGet(signals.create.mode$);
+  const narrowVideoGap =
+    createMode === "video" ? "@max-[328px]/composer:gap-0" : undefined;
   const voiceInputV2Enabled = useGet(voiceInputV2Enabled$);
   const voiceDraft = useResolved(signals.voice.state$);
   const capture = useGet(signals.voice.capture$);
@@ -10732,7 +10735,13 @@ function ComposerFooter({
             ? "recording"
             : voiceDraft?.status;
   return (
-    <div className="flex items-center justify-between gap-1 px-4 pb-4 pt-1 sm:gap-2">
+    <div
+      className={cn(
+        "flex items-center justify-between gap-1 px-4 pb-4 pt-1 sm:gap-2",
+        narrowVideoGap,
+        createMode === "video" && "@max-[328px]/composer:px-3",
+      )}
+    >
       {voiceInputV2Enabled &&
       status &&
       status !== "idle" &&
@@ -10746,7 +10755,12 @@ function ComposerFooter({
         />
       ) : (
         <>
-          <div className="flex min-w-0 items-center gap-1 text-muted-foreground sm:gap-1.5">
+          <div
+            className={cn(
+              "flex min-w-0 items-center gap-1 text-muted-foreground sm:gap-1.5",
+              narrowVideoGap,
+            )}
+          >
             <ComposerAttachButton signals={signals} />
             <ComposerTemplatePickerSlot signals={signals} />
             <ComposerWorkflowPromptSlot signals={signals} />
@@ -10756,7 +10770,12 @@ function ComposerFooter({
                 not which model the composer points at. */}
             <ComposerVideoOptionsChip signals={signals} />
           </div>
-          <div className="flex shrink-0 items-center gap-1 sm:gap-2">
+          <div
+            className={cn(
+              "flex shrink-0 items-center gap-1 sm:gap-2",
+              narrowVideoGap,
+            )}
+          >
             <ComposerModelPickerSlot signals={signals} />
             <MicButton signals={signals} actions={actions} />
             <ComposerSendControl signals={signals} actions={actions} />

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -10722,7 +10722,7 @@ function ComposerFooter({
 }) {
   const createMode = useGet(signals.create.mode$);
   const narrowVideoGap =
-    createMode === "video" ? "@max-[328px]/composer:gap-0" : undefined;
+    createMode === "video" ? "@max-[344px]/composer:gap-0" : undefined;
   const voiceInputV2Enabled = useGet(voiceInputV2Enabled$);
   const voiceDraft = useResolved(signals.voice.state$);
   const capture = useGet(signals.voice.capture$);
@@ -10741,7 +10741,7 @@ function ComposerFooter({
       className={cn(
         "flex items-center justify-between gap-1 px-4 pb-4 pt-1 sm:gap-2",
         narrowVideoGap,
-        createMode === "video" && "@max-[328px]/composer:px-3",
+        createMode === "video" && "@max-[344px]/composer:px-3",
       )}
     >
       {voiceInputV2Enabled &&

--- a/turbo/apps/platform/src/views/okou-page/composer-create.tsx
+++ b/turbo/apps/platform/src/views/okou-page/composer-create.tsx
@@ -88,7 +88,8 @@ function MediaModelSelect<Model extends string>({
   readonly onChange: (model: Model) => void;
 }) {
   return (
-    <Select value={value} onValueChange={onChange}>
+    // Keep adjacent composer actions tappable while the model menu is open.
+    <Select value={value} onValueChange={onChange} modal={false}>
       <SelectTrigger
         aria-label={label}
         className="h-8 w-8 shrink-0 gap-1 border-transparent bg-transparent px-0 text-sm text-muted-foreground hover:bg-state-hover @min-[600px]/composer:w-auto @min-[600px]/composer:max-w-[11rem] @min-[600px]/composer:px-2 [&>[data-slot=select-icon]]:hidden @min-[600px]/composer:[&>[data-slot=select-icon]]:block"

--- a/turbo/apps/platform/src/views/okou-page/composer-create.tsx
+++ b/turbo/apps/platform/src/views/okou-page/composer-create.tsx
@@ -1,0 +1,209 @@
+import type { ReactNode } from "react";
+import { useGet, useLastResolved, useSet } from "ccstate-react";
+import { useTranslation } from "react-i18next";
+import { X } from "lucide-react";
+import { toast } from "@okouai/ui/components/ui/sonner";
+import { resolveVideoRunOptions } from "../../signals/okou-page/video-run-options.ts";
+import { Button } from "@okouai/ui";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@okouai/ui/components/ui/select";
+import {
+  IMAGE_MODEL_CONFIGS,
+  PUBLIC_IMAGE_MODELS,
+} from "@okouai/core/image-model-catalog";
+import {
+  VIDEO_MODEL_CONFIGS,
+  PUBLIC_VIDEO_MODELS,
+} from "@okouai/core/video-model-catalog";
+import type {
+  ComposerSignals,
+  ComposerImageModelSignals,
+  ComposerVideoModelSignals,
+} from "../../signals/okou-page/composer-signals.ts";
+import { composerCreateModeLabel } from "../../signals/okou-page/composer-create.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { COMPOSER_CREATE_ICONS } from "./slash-workflow.tsx";
+import {
+  ImageModelBrandIcon,
+  VideoModelBrandIcon,
+} from "./components/model-provider-picker.tsx";
+
+export function ComposerCreateHeader({
+  signals,
+}: {
+  readonly signals: ComposerSignals;
+}) {
+  const { t } = useTranslation();
+  const mode = useGet(signals.create.mode$);
+  const setMode = useSet(signals.create.setMode$);
+  if (!mode) {
+    return null;
+  }
+  const Icon = COMPOSER_CREATE_ICONS[mode];
+  return (
+    <div
+      className="flex items-center gap-2 px-4 pt-3 text-sm font-medium"
+      data-testid="composer-create-mode"
+    >
+      <Icon size={18} className="text-muted-foreground" aria-hidden />
+      <span className="min-w-0 flex-1 truncate">
+        {composerCreateModeLabel(mode)}
+      </span>
+      <Button
+        type="button"
+        variant="quiet"
+        size="icon-sm"
+        aria-label={t(($) => {
+          return $.chat.composer.create.exit;
+        })}
+        onClick={() => {
+          setMode(null);
+        }}
+      >
+        <X size={16} />
+      </Button>
+    </div>
+  );
+}
+
+function MediaModelSelect<Model extends string>({
+  value,
+  models,
+  label,
+  modelLabel,
+  modelIcon,
+  onChange,
+}: {
+  readonly value: Model;
+  readonly models: readonly Model[];
+  readonly label: string;
+  readonly modelLabel: (model: Model) => string;
+  readonly modelIcon: (model: Model) => ReactNode;
+  readonly onChange: (model: Model) => void;
+}) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger
+        aria-label={label}
+        className="h-8 w-8 shrink-0 gap-1 border-transparent bg-transparent px-0 text-sm text-muted-foreground hover:bg-state-hover sm:w-auto sm:max-w-[11rem] sm:px-2 [&>[data-slot=select-icon]]:hidden sm:[&>[data-slot=select-icon]]:block"
+      >
+        <SelectValue>
+          <span className="flex min-w-0 items-center justify-center gap-1.5 sm:justify-start">
+            {modelIcon(value)}
+            <span className="hidden truncate sm:block">
+              {modelLabel(value)}
+            </span>
+          </span>
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent side="top" align="end">
+        {models.map((model) => {
+          return (
+            <SelectItem key={model} value={model}>
+              <span className="flex items-center gap-2">
+                {modelIcon(model)}
+                {modelLabel(model)}
+              </span>
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export function ComposerCreateImageModelPicker({
+  model,
+}: {
+  readonly model: ComposerImageModelSignals;
+}) {
+  const { t } = useTranslation();
+  const value = useLastResolved(model.effectiveImageModel$);
+  const setModel = useSet(model.setImageModel$);
+  const signal = useGet(pageSignal$);
+  if (!value) {
+    return null;
+  }
+  return (
+    <MediaModelSelect
+      value={value}
+      models={PUBLIC_IMAGE_MODELS}
+      label={t(($) => {
+        return $.settings.models.picker.imageModels;
+      })}
+      modelLabel={(item) => {
+        return IMAGE_MODEL_CONFIGS[item].label;
+      }}
+      modelIcon={(item) => {
+        return <ImageModelBrandIcon model={item} />;
+      }}
+      onChange={(next) => {
+        detach(setModel(next, signal), Reason.DomCallback);
+      }}
+    />
+  );
+}
+
+export function ComposerCreateVideoModelPicker({
+  model,
+  signals,
+}: {
+  readonly model: ComposerVideoModelSignals;
+  readonly signals: ComposerSignals;
+}) {
+  const { t } = useTranslation();
+  const value = useLastResolved(model.effectiveVideoModel$);
+  const setModel = useSet(model.setVideoModel$);
+  const patch = useGet(signals.videoOptions.videoRunOptions$);
+  const signal = useGet(pageSignal$);
+  if (!value) {
+    return null;
+  }
+  return (
+    <MediaModelSelect
+      value={value}
+      models={PUBLIC_VIDEO_MODELS}
+      label={t(($) => {
+        return $.settings.models.picker.videoModels;
+      })}
+      modelLabel={(item) => {
+        return VIDEO_MODEL_CONFIGS[item].label;
+      }}
+      modelIcon={(item) => {
+        return <VideoModelBrandIcon model={item} />;
+      }}
+      onChange={(next) => {
+        detach(
+          (async () => {
+            await setModel(next, signal);
+            signal.throwIfAborted();
+            const resolved = resolveVideoRunOptions(patch, next);
+            const adjusted =
+              (patch.aspectRatio !== undefined &&
+                patch.aspectRatio !== resolved.aspectRatio) ||
+              (patch.resolution !== undefined &&
+                patch.resolution !== resolved.resolution) ||
+              (patch.duration !== undefined &&
+                patch.duration !== resolved.duration) ||
+              (patch.generateAudio !== undefined &&
+                patch.generateAudio !== resolved.generateAudio);
+            if (adjusted) {
+              toast.info(
+                t(($) => {
+                  return $.chat.composer.create.settingsAdjusted;
+                }),
+              );
+            }
+          })(),
+          Reason.DomCallback,
+        );
+      }}
+    />
+  );
+}

--- a/turbo/apps/platform/src/views/okou-page/composer-create.tsx
+++ b/turbo/apps/platform/src/views/okou-page/composer-create.tsx
@@ -91,12 +91,12 @@ function MediaModelSelect<Model extends string>({
     <Select value={value} onValueChange={onChange}>
       <SelectTrigger
         aria-label={label}
-        className="h-8 w-8 shrink-0 gap-1 border-transparent bg-transparent px-0 text-sm text-muted-foreground hover:bg-state-hover sm:w-auto sm:max-w-[11rem] sm:px-2 [&>[data-slot=select-icon]]:hidden sm:[&>[data-slot=select-icon]]:block"
+        className="h-8 w-8 shrink-0 gap-1 border-transparent bg-transparent px-0 text-sm text-muted-foreground hover:bg-state-hover @min-[600px]/composer:w-auto @min-[600px]/composer:max-w-[11rem] @min-[600px]/composer:px-2 [&>[data-slot=select-icon]]:hidden @min-[600px]/composer:[&>[data-slot=select-icon]]:block"
       >
         <SelectValue>
-          <span className="flex min-w-0 items-center justify-center gap-1.5 sm:justify-start">
+          <span className="flex min-w-0 items-center justify-center gap-1.5 @min-[600px]/composer:justify-start">
             {modelIcon(value)}
-            <span className="hidden truncate sm:block">
+            <span className="hidden truncate @min-[600px]/composer:block">
               {modelLabel(value)}
             </span>
           </span>

--- a/turbo/apps/platform/src/views/okou-page/composer-video-options.tsx
+++ b/turbo/apps/platform/src/views/okou-page/composer-video-options.tsx
@@ -1,11 +1,18 @@
 import type { ReactNode } from "react";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, SlidersHorizontal, Volume2, VolumeX } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@okouai/ui/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@okouai/ui/components/ui/select";
 import { Slider } from "@okouai/ui/components/ui/slider";
 import { Switch } from "@okouai/ui/components/ui/switch";
 import { Button, cn } from "@okouai/ui";
@@ -349,12 +356,118 @@ function VideoSettingsPane({
   );
 }
 
+function VideoToolbarField<Option extends string>({
+  label,
+  value,
+  values,
+  onChange,
+}: {
+  readonly label: string;
+  readonly value: Option;
+  readonly values: readonly Option[];
+  readonly onChange: (value: Option) => void;
+}) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger
+        aria-label={label}
+        disabled={values.length < 2}
+        className="h-8 w-auto gap-1 border-transparent bg-transparent px-2 text-xs text-muted-foreground hover:bg-state-hover [&>[data-slot=select-icon]>svg]:size-3"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent side="top" align="start">
+        {values.map((option) => {
+          return (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function VideoToolbar({
+  resolved,
+  config,
+  onChange,
+}: {
+  readonly resolved: ResolvedVideoGenerationOptions;
+  readonly config: VideoModelConfig;
+  readonly onChange: (next: ResolvedVideoGenerationOptions) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="hidden shrink-0 items-center gap-0.5 @min-[760px]/composer:flex">
+      <div className="mx-1 h-4 w-px bg-border/60" />
+      <VideoToolbarField
+        label={t(($) => {
+          return $.chat.templates.videoOptionsRatio;
+        })}
+        value={resolved.aspectRatio}
+        values={config.aspectRatios}
+        onChange={(aspectRatio) => {
+          return onChange({ ...resolved, aspectRatio });
+        }}
+      />
+      <VideoToolbarField
+        label={t(($) => {
+          return $.chat.templates.videoOptionsResolution;
+        })}
+        value={resolved.resolution}
+        values={config.resolutions}
+        onChange={(resolution) => {
+          return onChange({ ...resolved, resolution });
+        }}
+      />
+      <VideoToolbarField
+        label={t(($) => {
+          return $.chat.templates.videoOptionsDuration;
+        })}
+        value={resolved.duration}
+        values={config.durations}
+        onChange={(duration) => {
+          return onChange({ ...resolved, duration });
+        }}
+      />
+      {config.supportsGenerateAudio && (
+        <Button
+          type="button"
+          variant="quiet"
+          size="icon-sm"
+          aria-label={t(($) => {
+            return $.chat.templates.videoOptionsAudio;
+          })}
+          aria-pressed={resolved.generateAudio}
+          showTooltip
+          onClick={() => {
+            return onChange({
+              ...resolved,
+              generateAudio: !resolved.generateAudio,
+            });
+          }}
+        >
+          {resolved.generateAudio ? (
+            <Volume2 size={16} />
+          ) : (
+            <VolumeX size={16} />
+          )}
+        </Button>
+      )}
+    </div>
+  );
+}
+
 function ComposerVideoOptionsChipBody({
   signals,
   videoModelSignals,
+  toolbar = false,
 }: {
   readonly signals: ComposerSignals;
   readonly videoModelSignals: ComposerVideoModelSignals;
+  readonly toolbar?: boolean;
 }) {
   const { t } = useTranslation();
   const open = useGet(signals.videoOptions.videoOptionsOpen$);
@@ -372,50 +485,83 @@ function ComposerVideoOptionsChipBody({
   const spec = videoRunOptionsText(resolved);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      {/* The chip is a text control in the composer's icon row, so it is a
-          `quiet` `sm` Button: same h-8 height and radius as the icon buttons
-          beside it, with the regular weight the rest of the row reads at. */}
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="quiet"
-          size="sm"
-          className={cn(
-            "shrink-0 gap-1 font-normal",
-            "data-popup-open:bg-state-hover data-popup-open:text-foreground",
-          )}
-          aria-label={t(
-            ($) => {
-              return $.chat.templates.videoOptionsLabel;
-            },
-            { spec },
-          )}
-        >
-          <span className="tabular-nums">{spec}</span>
-          <ChevronDown className="shrink-0 opacity-50" aria-hidden />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        side="top"
-        sideOffset={6}
-        // The gap between panels matches this padding, so the pane is evenly
-        // spaced on every side; that 6px is also what sets the panel radius.
-        className="w-[17.5rem] p-1.5"
-        aria-label={t(($) => {
-          return $.chat.templates.videoOptions;
-        })}
-      >
-        <VideoSettingsPane
+    <>
+      {toolbar && (
+        <VideoToolbar
           resolved={resolved}
           config={config}
           onChange={(next) => {
-            setPatch(videoRunOptionsPatch(next, model));
+            return setPatch(videoRunOptionsPatch(next, model));
           }}
         />
-      </PopoverContent>
-    </Popover>
+      )}
+      <Popover open={open} onOpenChange={setOpen}>
+        {/* The chip is a text control in the composer's icon row, so it is a
+          `quiet` `sm` Button: same h-8 height and radius as the icon buttons
+          beside it, with the regular weight the rest of the row reads at. */}
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="quiet"
+            size="sm"
+            className={cn(
+              "shrink-0 gap-1 font-normal",
+              toolbar &&
+                "w-8 px-0 @min-[520px]/composer:w-auto @min-[520px]/composer:px-2 @min-[760px]/composer:hidden",
+              "data-popup-open:bg-state-hover data-popup-open:text-foreground",
+            )}
+            aria-label={t(
+              ($) => {
+                return $.chat.templates.videoOptionsLabel;
+              },
+              { spec },
+            )}
+          >
+            {toolbar && (
+              <SlidersHorizontal
+                size={16}
+                className="@min-[520px]/composer:hidden"
+                aria-hidden
+              />
+            )}
+            <span
+              className={cn(
+                "tabular-nums",
+                toolbar && "hidden @min-[520px]/composer:inline",
+              )}
+            >
+              {spec}
+            </span>
+            <ChevronDown
+              className={cn(
+                "shrink-0 opacity-50",
+                toolbar && "hidden @min-[520px]/composer:block",
+              )}
+              aria-hidden
+            />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          side="top"
+          sideOffset={6}
+          // The gap between panels matches this padding, so the pane is evenly
+          // spaced on every side; that 6px is also what sets the panel radius.
+          className="w-[17.5rem] p-1.5"
+          aria-label={t(($) => {
+            return $.chat.templates.videoOptions;
+          })}
+        >
+          <VideoSettingsPane
+            resolved={resolved}
+            config={config}
+            onChange={(next) => {
+              setPatch(videoRunOptionsPatch(next, model));
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+    </>
   );
 }
 
@@ -428,24 +574,32 @@ function ComposerVideoOptionsChipBody({
  * actually in effect, so an illegal combination — the one the generation
  * endpoint has to reject with a 400 — cannot be selected here.
  *
- * It follows the picker's desktop category: the settings only mean anything for
- * a video run, and the desktop tab strip is the only control that selects one.
+ * Create video exposes these controls in the toolbar, with a compact popover
+ * when space is limited. Ordinary chat follows the desktop picker's category.
  */
 export function ComposerVideoOptionsChip({
   signals,
 }: {
   readonly signals: ComposerSignals;
 }) {
+  const createMode = useGet(signals.create.mode$);
   const desktopLayout = useGet(signals.model.desktopModelPickerLayout$);
   const mediaModelCategory = useGet(signals.model.mediaModelCategory$);
   const videoModelSignals = signals.videoModel;
-  if (!desktopLayout || mediaModelCategory !== "video" || !videoModelSignals) {
+  if (
+    createMode !== "video" &&
+    (!desktopLayout || mediaModelCategory !== "video")
+  ) {
+    return null;
+  }
+  if (!videoModelSignals) {
     return null;
   }
   return (
     <ComposerVideoOptionsChipBody
       signals={signals}
       videoModelSignals={videoModelSignals}
+      toolbar={createMode === "video"}
     />
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
@@ -1,12 +1,31 @@
 // Slash-workflow domain helpers and the suggestion menu, shared by the chat
 // composer. Kept in its own module so the textarea composer and the TipTap
 // workflow composer can both reuse them without an import cycle.
-import { ChevronRight, FileText } from "lucide-react";
+import {
+  ChevronRight,
+  FileText,
+  Image,
+  Video,
+  Presentation,
+  Palette,
+} from "lucide-react";
 import { cn, PopoverContent } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { Link } from "../router/link.tsx";
 import type { ComposerSlashWorkflow } from "../../signals/okou-page/workflow-composer-domain.ts";
+
+import {
+  composerCreateModeLabel,
+  type ComposerCreateMode,
+} from "../../signals/okou-page/composer-create.ts";
+
+export const COMPOSER_CREATE_ICONS = {
+  image: Image,
+  video: Video,
+  presentation: Presentation,
+  illustration: Palette,
+} as const;
 
 function slashWorkflowOptionId(workflowId: string): string {
   return `slash-workflow-option-${workflowId}`;
@@ -40,7 +59,7 @@ export function composerSuggestionCollisionPadding():
 }
 
 export function scrollSlashWorkflowIntoView(
-  workflow: ComposerSlashWorkflow | undefined,
+  workflow: Pick<ComposerSlashWorkflow, "id"> | undefined,
 ): void {
   if (!workflow) {
     return;
@@ -54,8 +73,59 @@ export function scrollSlashWorkflowIntoView(
   });
 }
 
+function SlashCreateGroup({
+  modes,
+  selectedIndex,
+  onSelect,
+}: {
+  readonly modes: readonly ComposerCreateMode[];
+  readonly selectedIndex: number;
+  readonly onSelect: (mode: ComposerCreateMode) => void;
+}) {
+  const { t } = useTranslation();
+  if (modes.length === 0) {
+    return null;
+  }
+  return (
+    <>
+      <div className="px-2.5 py-2 text-xs font-medium text-muted-foreground">
+        {t(($) => {
+          return $.chat.composer.create.title;
+        })}
+      </div>
+      <div className="px-1.5 pb-1.5">
+        {modes.map((mode, index) => {
+          const Icon = COMPOSER_CREATE_ICONS[mode];
+          return (
+            <button
+              key={mode}
+              id={slashWorkflowOptionId(mode)}
+              type="button"
+              className={cn(
+                "flex w-full items-center gap-2 rounded px-2 py-2 text-left text-sm transition-colors",
+                index === selectedIndex ? "bg-accent" : "hover:bg-state-hover",
+              )}
+              onPointerDown={(event) => {
+                event.preventDefault();
+              }}
+              onClick={() => {
+                onSelect(mode);
+              }}
+            >
+              <Icon size={16} aria-hidden />
+              {composerCreateModeLabel(mode)}
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
 export function SlashWorkflowMenu({
   workflows,
+  createModes,
+  onSelectCreate,
   query,
   loading,
   selectedIndex,
@@ -63,6 +133,8 @@ export function SlashWorkflowMenu({
   onSelect,
 }: {
   readonly workflows: readonly ComposerSlashWorkflow[];
+  readonly createModes: readonly ComposerCreateMode[];
+  readonly onSelectCreate: (mode: ComposerCreateMode) => void;
   readonly query: string;
   readonly loading: boolean;
   readonly selectedIndex: number;
@@ -85,65 +157,72 @@ export function SlashWorkflowMenu({
       className="flex h-[min(16rem,var(--available-height))] w-[300px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0 md:h-[min(20rem,var(--available-height))]"
       data-testid="slash-workflow-menu"
     >
-      <div className="px-2.5 pt-2 pb-2 text-xs font-medium text-muted-foreground">
-        {t(($) => {
-          return $.chat.composer.workflows.title;
-        })}
-      </div>
-      {loading ? (
-        <div className="px-2.5 py-2 text-sm text-muted-foreground">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <SlashCreateGroup
+          modes={createModes}
+          selectedIndex={selectedIndex}
+          onSelect={onSelectCreate}
+        />
+        <div className="px-2.5 pt-2 pb-2 text-xs font-medium text-muted-foreground">
           {t(($) => {
-            return $.chat.composer.workflows.loading;
+            return $.chat.composer.workflows.title;
           })}
         </div>
-      ) : workflows.length > 0 ? (
-        <div className="min-h-0 flex-1 overflow-y-auto px-1.5 pb-1.5">
-          {workflows.map((workflow, index) => {
-            const selected = index === selectedIndex;
-            const matchStart = workflow.name
-              .toLowerCase()
-              .indexOf(query.toLowerCase());
-            const matchEnd = matchStart + query.length;
-            return (
-              <button
-                id={slashWorkflowOptionId(workflow.id)}
-                key={workflow.id}
-                type="button"
-                className={cn(
-                  "flex w-full flex-col items-start gap-0.5 rounded px-2 py-1.5 text-left transition-colors",
-                  selected ? "bg-accent" : "hover:bg-state-hover",
-                )}
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  onSelect(workflow);
-                }}
-              >
-                <span className="w-full truncate font-mono text-sm text-foreground">
-                  <span className="text-brand-text">/</span>
-                  {workflow.name.slice(0, matchStart)}
-                  {query && matchStart !== -1 && (
-                    <span className="text-brand-text/60">
-                      {workflow.name.slice(matchStart, matchEnd)}
+        {loading ? (
+          <div className="px-2.5 py-2 text-sm text-muted-foreground">
+            {t(($) => {
+              return $.chat.composer.workflows.loading;
+            })}
+          </div>
+        ) : workflows.length > 0 ? (
+          <div className="px-1.5 pb-1.5">
+            {workflows.map((workflow, index) => {
+              const selected = index + createModes.length === selectedIndex;
+              const matchStart = workflow.name
+                .toLowerCase()
+                .indexOf(query.toLowerCase());
+              const matchEnd = matchStart + query.length;
+              return (
+                <button
+                  id={slashWorkflowOptionId(workflow.id)}
+                  key={workflow.id}
+                  type="button"
+                  className={cn(
+                    "flex w-full flex-col items-start gap-0.5 rounded px-2 py-1.5 text-left transition-colors",
+                    selected ? "bg-accent" : "hover:bg-state-hover",
+                  )}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    onSelect(workflow);
+                  }}
+                >
+                  <span className="w-full truncate font-mono text-sm text-foreground">
+                    <span className="text-brand-text">/</span>
+                    {workflow.name.slice(0, matchStart)}
+                    {query && matchStart !== -1 && (
+                      <span className="text-brand-text/60">
+                        {workflow.name.slice(matchStart, matchEnd)}
+                      </span>
+                    )}
+                    {workflow.name.slice(query ? matchEnd : 0)}
+                  </span>
+                  {workflow.description && (
+                    <span className="w-full truncate text-xs text-muted-foreground/70">
+                      {workflow.description}
                     </span>
                   )}
-                  {workflow.name.slice(query ? matchEnd : 0)}
-                </span>
-                {workflow.description && (
-                  <span className="w-full truncate text-xs text-muted-foreground/70">
-                    {workflow.description}
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      ) : (
-        <div className="px-2.5 pt-1 pb-2.5 text-sm text-muted-foreground">
-          {t(($) => {
-            return $.chat.composer.workflows.empty;
-          })}
-        </div>
-      )}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="px-2.5 pt-1 pb-2.5 text-sm text-muted-foreground">
+            {t(($) => {
+              return $.chat.composer.workflows.empty;
+            })}
+          </div>
+        )}
+      </div>
       {showWorkflowsPageLink && (
         <div className="shrink-0 border-t border-border/60 bg-popover/95 p-1">
           <Link

--- a/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/okou-page/slash-workflow.tsx
@@ -7,7 +7,6 @@ import {
   Image,
   Video,
   Presentation,
-  Palette,
 } from "lucide-react";
 import { cn, PopoverContent } from "@okouai/ui";
 import { useTranslation } from "react-i18next";
@@ -24,7 +23,6 @@ export const COMPOSER_CREATE_ICONS = {
   image: Image,
   video: Video,
   presentation: Presentation,
-  illustration: Palette,
 } as const;
 
 function slashWorkflowOptionId(workflowId: string): string {

--- a/turbo/apps/platform/src/views/okou-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/tiptap-workflow-composer.tsx
@@ -25,6 +25,13 @@ import {
 } from "./slash-workflow.tsx";
 import type { ComposerPasteEvent } from "./composer-input-types.ts";
 
+import {
+  COMPOSER_CREATE_MODES,
+  composerCreateModeLabel,
+  composerCreatePlaceholder,
+  type ComposerCreateMode,
+} from "../../signals/okou-page/composer-create.ts";
+
 function isMacKeyboard(): boolean {
   return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
 }
@@ -160,6 +167,7 @@ function WorkflowComposerPlaceholder({
   sending: boolean | undefined;
 }) {
   useTranslation();
+  const createMode = useGet(composer.create.mode$);
   const hasInput = useGet(composer.editor.hasInput$);
   const hasEditorContent = useEditorState({
     editor: composer.editor.editor,
@@ -180,7 +188,9 @@ function WorkflowComposerPlaceholder({
       }`}
       aria-hidden="true"
     >
-      {workflowComposerPlaceholder(sending)}
+      {createMode
+        ? composerCreatePlaceholder(createMode)
+        : workflowComposerPlaceholder(sending)}
     </div>
   );
 }
@@ -288,6 +298,8 @@ interface ComposerSuggestionMenuState {
   readonly selectedIndex: number;
   readonly close: () => void;
   readonly workflows: readonly ComposerSlashWorkflow[];
+  readonly createModes: readonly ComposerCreateMode[];
+  readonly selectCreate: (mode: ComposerCreateMode) => void;
   readonly workflowQuery: string;
   readonly workflowsLoading: boolean;
   readonly showWorkflows: boolean;
@@ -300,6 +312,30 @@ interface ComposerSuggestionMenuState {
   readonly handleKeyDown: (event: KeyboardEvent) => boolean;
 }
 
+function useComposerCreateSuggestions(
+  composer: ComposerSignals,
+  query: string | undefined,
+): readonly ComposerCreateMode[] {
+  useTranslation();
+  const enabled = useGet(composer.create.enabled$);
+  if (!enabled || query === undefined) {
+    return [];
+  }
+  return COMPOSER_CREATE_MODES.filter((mode) => {
+    if (
+      (mode === "image" && !composer.imageModel) ||
+      (mode === "video" && !composer.videoModel)
+    ) {
+      return false;
+    }
+    const normalized = query.toLowerCase().trim();
+    return (
+      `create ${mode}`.includes(normalized) ||
+      composerCreateModeLabel(mode).toLowerCase().includes(normalized)
+    );
+  });
+}
+
 function useComposerSuggestionMenu({
   composer,
   onKeyDown,
@@ -307,7 +343,9 @@ function useComposerSuggestionMenu({
   readonly composer: ComposerSignals;
   readonly onKeyDown: (event: KeyboardEventLike) => void;
 }): ComposerSuggestionMenuState {
+  const selectCreate = useSet(composer.create.setMode$);
   const slashRange = useGet(composer.suggestion.activeSlashRange$);
+  const createModes = useComposerCreateSuggestions(composer, slashRange?.query);
   const chatThreadRange = useGet(
     composer.suggestion.activeChatThreadSuggestionRange$,
   );
@@ -353,43 +391,39 @@ function useComposerSuggestionMenu({
       ? chatThreadRange
       : null;
   const suggestionCount = showWorkflows
-    ? workflowSuggestions.length
+    ? createModes.length + workflowSuggestions.length
     : agents.length + chatThreads.length;
-
-  function selectWorkflow(workflow: ComposerSlashWorkflow): void {
-    insertWorkflow(workflow);
-  }
-
-  function selectAgent(agent: ComposerAgentSuggestion): void {
-    insertAgent(agent);
-  }
-
-  function selectChatThread(chatThread: ComposerChatThreadSuggestion): void {
-    insertChatThread(chatThread);
-  }
 
   function selectSuggestion(index: number): void {
     if (showWorkflows) {
-      const workflow = workflowSuggestions[index];
+      const createMode = createModes[index];
+      if (createMode) {
+        selectCreate(createMode);
+        return;
+      }
+      const workflow = workflowSuggestions[index - createModes.length];
       if (workflow) {
-        selectWorkflow(workflow);
+        insertWorkflow(workflow);
       }
       return;
     }
     const agent = agents[index];
     if (agent) {
-      selectAgent(agent);
+      insertAgent(agent);
       return;
     }
     const chatThread = chatThreads[index - agents.length];
     if (chatThread) {
-      selectChatThread(chatThread);
+      insertChatThread(chatThread);
     }
   }
 
   function scrollSuggestionIntoView(index: number): void {
     if (showWorkflows) {
-      scrollSlashWorkflowIntoView(workflowSuggestions[index]);
+      const mode = createModes[index];
+      scrollSlashWorkflowIntoView(
+        mode ? { id: mode } : workflowSuggestions[index - createModes.length],
+      );
     }
   }
 
@@ -413,15 +447,17 @@ function useComposerSuggestionMenu({
     selectedIndex,
     close,
     workflows: workflowSuggestions,
+    createModes,
+    selectCreate,
     workflowQuery: slashRange?.query ?? "",
     workflowsLoading: workflowsLoadable.state === "loading",
     showWorkflows,
     agents,
     chatThreads,
     showMentions,
-    selectWorkflow,
-    selectAgent,
-    selectChatThread,
+    selectWorkflow: insertWorkflow,
+    selectAgent: insertAgent,
+    selectChatThread: insertChatThread,
     handleKeyDown,
   };
 }
@@ -530,6 +566,8 @@ export function TiptapWorkflowComposer({
       {suggestionMenu.showWorkflows && (
         <SlashWorkflowMenu
           workflows={suggestionMenu.workflows}
+          createModes={suggestionMenu.createModes}
+          onSelectCreate={suggestionMenu.selectCreate}
           query={suggestionMenu.workflowQuery}
           loading={suggestionMenu.workflowsLoading}
           selectedIndex={suggestionMenu.selectedIndex}

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -73,6 +73,7 @@ export enum FeatureSwitchKey {
   IntroVideo = "introVideo",
   ChatTranslation = "chatTranslation",
   VoiceInputV2 = "voiceInputV2",
+  ComposerCreateCommands = "composerCreateCommands",
   ComposerImageAnnotation = "composerImageAnnotation",
   GradientColorThemes = "gradientColorThemes",
   AvatarComposerV2 = "avatarComposerV2",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -45,6 +45,12 @@ export interface FeatureSwitchContext {
  * Registry of all feature switches
  */
 const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
+  [FeatureSwitchKey.ComposerCreateCommands]: {
+    maintainer: "bingjie@okou.ai",
+    description: "Create commands and mode-specific composer controls",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.Dummy]: {
     maintainer: "ethan@vm0.ai",
     description: "Test-only feature switch for flag system validation",


### PR DESCRIPTION
Choosing `/create video`, `/create presentation`, or `/create image` now opens a creation mode in the chat composer while preserving the draft and its attachments.

- Keep video ratio, resolution, duration, and supported audio controls beside the existing footer tools, with a compact settings popover when space is limited. The model picker on the right selects video models in Video mode.
- Consolidate the previous Image and Illustration commands into one `Create image` command. It opens the illustration style gallery through `Choose style` and replaces the chat model picker with the image model picker.
- Expand the Presentation template entry into `Choose template`. For both Presentation and Image, show a template/style name and chevron only when the current draft contains exactly one matching template; keep the generic label for multiple templates. Reuse the existing large category gallery for choosing and replacing templates.
- Keep image and video model menus non-modal so adjacent composer actions remain tappable while a menu is open, including the Send button on touch devices.
- Support mouse and keyboard command selection, remove only the selected command text, and preserve structured template references when sending the creation request.

Rollout: `composerCreateCommands` is enabled for staff organizations and disabled by default elsewhere. Enable it in `/_/lab` for preview acceptance, then type `/create` in the composer.

Validation: the focused create-composer suite passes all 8 tests. Platform app type checking, focused ESLint, Prettier, and the generated i18n consistency check pass. The broader test suites run in the PR pipeline; no local dev server was started.

Browser acceptance passed on the exact PR preview at 1280x900 and 390x844. The `/create` menu contains exactly `Create video`, `Create presentation`, and `Create image`. Image mode exposes `Choose style` plus `Image models`; selecting a style preserves its structured template reference. Video mode exposes its settings plus `Video models`. Both modes create the thread and event successfully (`201` for both requests). On mobile, Send remains actionable on the first click while the Image models menu is still open (`201` for both requests). The deployment log resolves head `1bfeab9220e0108de4a30617b9c856a24c217f1f` to the preview alias below.

[Preview](https://pr-32296-app-okou-app-preview.vm0.workers.dev) · [Final create menu](https://a.okou.io/io2h5odioe.png) · [Final image mode](https://a.okou.io/3c04cqbvu6.png) · [Final video mode](https://a.okou.io/uk5v6v5yqq.png) · [Final mobile image-model send check](https://a.okou.io/fbfv1gn1a3.png)
