### PR TITLE
feat(api): force app.vm0.ai clients to upgrade to v0.857.0

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -1115,7 +1115,6 @@ describe("createApp", () => {
           },
         });
 
-        expect(MINIMUM_WEB_CLIENT_VERSION).toBe("0.843.1");
         expect(response.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
         await expect(response.json()).resolves.toStrictEqual({
           error: "Client update required",
@@ -1159,25 +1158,28 @@ describe("createApp", () => {
       expect(response.headers.get("cache-control")).toBe("no-store");
     });
 
-    it("force-upgrades an older app client before current route matching", async () => {
-      const app = createApp({
-        signal: context.signal,
-        routes: TEST_APP_ROUTES,
-      });
-      const response = await app.request("/api/chat-threads", {
-        method: "GET",
-        headers: {
-          [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
-          [CLIENT_VERSION_HEADER]: "0.621.0",
-        },
-      });
+    it.each(["0.621.0", "0.843.1", "0.855.1", "0.856.0"])(
+      "force-upgrades App %s before current route matching",
+      async (version) => {
+        const app = createApp({
+          signal: context.signal,
+          routes: TEST_APP_ROUTES,
+        });
+        const response = await app.request("/api/chat-threads", {
+          method: "GET",
+          headers: {
+            [CLIENT_TYPE_HEADER]: CLIENT_TYPE_APP,
+            [CLIENT_VERSION_HEADER]: version,
+          },
+        });
 
-      expect(response.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
-      await expect(response.json()).resolves.toStrictEqual({
-        error: "Client update required",
-      });
-      expect(response.headers.get("cache-control")).toBe("no-store");
-    });
+        expect(response.status).toBe(CLIENT_FORCE_UPGRADE_STATUS);
+        await expect(response.json()).resolves.toStrictEqual({
+          error: "Client update required",
+        });
+        expect(response.headers.get("cache-control")).toBe("no-store");
+      },
+    );
 
     it.each([
       MINIMUM_WEB_CLIENT_VERSION,

--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,3 +1,3 @@
 {
-  "minimumSupportedVersion": "0.843.1"
+  "minimumSupportedVersion": "0.857.0"
 }


### PR DESCRIPTION
## Summary
Raise the Web App compatibility floor from `0.843.1` to the already deployed `0.857.0`, so stale browser bundles must refresh on their next handled API request.

Linghan requested a client force upgrade after the production "Additional verification required" investigation found that already-loaded `0.855.1` pages were still active after the login fix deployed. The verified target contains #32216, which handles Clerk `needs_second_factor` and `needs_client_trust` continuations. This PR applies the explicitly requested `0.857.0` floor to the shared App client contract used by app.vm0.ai and app.okou.ai.

## Production verification
- Re-fetched `origin/main` and based this branch on `e068f4512ba61b694f5651676eedb43170f58374`. The production commit is an ancestor of that ref, and #32216's merge commit `a9edf5029c0c6ba6f06d0fa1609f11371f3f3d0e` is an ancestor of the production commit.
- At **2026-09-07 08:54:43 UTC**, GET https://app.vm0.ai/sign-in (following its redirect to app.okou.ai) and GET https://app.okou.ai/sign-in both returned HTTP 200 HTML with `okou-app-version=0.857.0` and `okou-app-git-commit-sha=9fd53c47daba5922b0a5de5abcb4b82f44f0a2f8`.
- The matching [App Worker production deployment](https://github.com/vm0-ai/vm0/actions/runs/34100842030/job/101679175050) succeeded at **08:46:57 UTC / 16:46:57 Beijing time**. GitHub deployment `6305127457` records production success for the same commit at 08:46:58 UTC.
- The deployed commit's `turbo/apps/platform/package.json` also declares `0.857.0`. The served production HTML and successful deployment establish that it is live; package metadata alone is not the deployment evidence. This uses the authoritative deployment/build-artifact fallback while browser access is off.
- Checked every file in all 25 currently open PRs: none modifies the compatibility floor.

## Changes and impact
- `turbo/apps/api/src/lib/web-client-compatibility.json`: increase `minimumSupportedVersion` from `0.843.1` to `0.857.0`.
- `turbo/apps/api/src/__tests__/app-factory.test.ts`: remove a stale assertion pinning the old floor and extend the existing HTTP rejection case to cover `0.843.1`, `0.855.1`, and `0.856.0`. Existing cases continue to cover the target, build metadata, newer versions, prereleases, and client-type containment.

Once the API change is deployed, identified App clients advertising a parseable version below the floor receive `426 Upgrade Required` with `Cache-Control: no-store` before route matching. The existing update dialog requires a refresh to load a supported build. Idle pages, or login continuations making only Clerk requests, discover this requirement only after a handled App API request; this does not reload pages automatically. CLI, Desktop, runner, and missing/unparseable-version behavior are unchanged.

API production deployment is a separate step owned by the Production Release thread; merging this PR alone does not enforce the new floor in production.

## Validation
- Passed Prettier 3.6.2 checks for both changed files.
- Passed focused JSON shape, explicit stable target, monotonic floor, production artifact/version, and Git ancestry checks.
- Passed TypeScript syntax parsing, the repository file-size check, and `git diff --check`.
- Self-reviewed the complete diff and the directly coupled compatibility middleware/tests. No new runtime branch or fallback is introduced.
- API route integration tests, full type/lint checks, and broader verification will run in PR CI. No local Vitest suite or dev server was run, per the requested validation scope.
