### PR TITLE
fix(pi-memory): decouple maintenance runs from default agents

### DIFF
--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -35,6 +35,7 @@ import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentSessions } from "@okouai/db/schema/agent-session";
 import { agents } from "@okouai/db/schema/agent";
 import { blobs } from "@okouai/db/schema/blob";
+import { piMemoryPhase2Jobs } from "@okouai/db/schema/pi-memory-phase2-job";
 import { runnerJobQueue } from "@okouai/db/schema/runner-job-queue";
 import {
   runnerState,
@@ -47,7 +48,6 @@ import {
   eq,
   gt,
   inArray,
-  isNotNull,
   lt,
   lte,
   notInArray,
@@ -827,7 +827,7 @@ interface ClaimedRun {
   readonly id: string;
   readonly userId: string;
   readonly orgId: string;
-  readonly agentId: string;
+  readonly agentId: string | null;
   readonly prompt: string;
   readonly appendSystemPrompt: string | null;
   readonly vars: unknown;
@@ -918,24 +918,36 @@ async function getClaimableJob(
         appendSystemPrompt: agentRuns.appendSystemPrompt,
         vars: agentRuns.vars,
       },
+      maintenanceRunId: piMemoryPhase2Jobs.maintenanceRunId,
     })
     .from(runnerJobQueue)
     .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
     .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
+    .leftJoin(
+      piMemoryPhase2Jobs,
+      and(
+        eq(piMemoryPhase2Jobs.maintenanceRunId, agentRuns.id),
+        eq(piMemoryPhase2Jobs.orgId, agentRuns.orgId),
+        eq(piMemoryPhase2Jobs.userId, agentRuns.userId),
+        eq(piMemoryPhase2Jobs.status, "leased"),
+      ),
+    )
     .where(
       and(
         eq(runnerJobQueue.runId, runId),
         gt(runnerJobQueue.expiresAt, sql`now()`),
-        isNotNull(agentSessions.agentId),
       ),
     )
     .limit(1);
   signal.throwIfAborted();
 
-  if (jobWithRun?.run.agentId) {
+  if (
+    jobWithRun &&
+    (jobWithRun.run.agentId !== null || jobWithRun.maintenanceRunId === runId)
+  ) {
     return {
-      ...jobWithRun,
-      run: { ...jobWithRun.run, agentId: jobWithRun.run.agentId },
+      job: jobWithRun.job,
+      run: jobWithRun.run,
     };
   }
   return notFound("Job not found in queue");
@@ -1385,6 +1397,7 @@ async function refreshClaimNetworkPolicies(args: {
   Pick<StoredExecutionContext, "networkPolicies" | "networkPolicyRefreshes">
 > {
   const storedNetworkPolicies = args.storedContext.networkPolicies ?? {};
+  assertClaimConnectorIdentity(args.run, args.storedContext);
   if (Object.keys(storedNetworkPolicies).length === 0) {
     return {
       networkPolicies: args.storedContext.networkPolicies,
@@ -1409,6 +1422,11 @@ async function refreshClaimNetworkPolicies(args: {
         },
         path: "no_builtin_targets",
       };
+    }
+    if (args.run.agentId === null) {
+      throw new Error(
+        "Connector network policy refresh requires an Agent identity",
+      );
     }
 
     const scope = {
@@ -1495,6 +1513,20 @@ async function refreshClaimNetworkPolicies(args: {
       path: selected.path,
     };
   });
+}
+
+function assertClaimConnectorIdentity(
+  run: ClaimedRun,
+  storedContext: StoredExecutionContext,
+): void {
+  if (
+    run.agentId === null &&
+    storedContext.connectorRuntimeTargets.length > 0
+  ) {
+    throw new Error(
+      "Private Pi memory maintenance run cannot use connector runtime targets",
+    );
+  }
 }
 
 type StoredResumeSessionWithHistoryRef = Extract<

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-maintenance.boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-maintenance.boundary.test.ts
@@ -13,12 +13,11 @@ import { promisify } from "node:util";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
-import { z } from "zod";
-import { piLaunchConfigSchema } from "@okouai/api-contracts/contracts/runners";
+import { executionContextSchema } from "@okouai/api-contracts/contracts/runners";
 import { agents } from "@okouai/db/schema/agent";
 import { agentRuns } from "@okouai/db/schema/agent-run";
+import { agentSessions } from "@okouai/db/schema/agent-session";
 import { piMemoryPhase2Jobs } from "@okouai/db/schema/pi-memory-phase2-job";
-import { runnerJobQueue } from "@okouai/db/schema/runner-job-queue";
 import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
 import { checkpoints } from "@okouai/db/schema/checkpoint";
 import { piMemoryPhase2Checkpoints } from "@okouai/db/schema/pi-memory-phase2-checkpoint";
@@ -27,7 +26,7 @@ import { storageVersionLineage } from "@okouai/db/schema/storage-version-lineage
 import { storages } from "@okouai/db/schema/storage";
 import { usageEvent } from "@okouai/db/schema/usage-event";
 import { createStore } from "ccstate";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
@@ -38,7 +37,7 @@ import { testContext } from "../../../__tests__/test-context";
 import { db } from "../../../lib/db";
 import { mockOptionalEnv } from "../../../lib/env";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
-import { generateSandboxToken } from "../../auth/tokens";
+import { runnersRoutes } from "../../routes/runners";
 import { webhooksAgentCompleteRoutes } from "../../routes/webhooks-agent-complete";
 import { webhooksAgentHealthUsageTelemetryRoutes } from "../../routes/webhooks-agent-health-usage-telemetry";
 import { webhooksAgentStorageRoutes } from "../../routes/webhooks-agent-storage";
@@ -47,7 +46,6 @@ import {
   advancePiMemoryPhase2InputRevision,
   notifyPiMemoryPhase2ExternalHeadChange,
 } from "../pi-memory-phase2-job.service";
-import { DEFAULT_AGENT_NAME } from "../default-agent-profile";
 import { executePiMemoryPhase2Work$ } from "../pi-memory-phase2-worker.service";
 import {
   piMemoryPhase2MaintenanceCallbackPayloadSchema,
@@ -62,12 +60,15 @@ import {
   setPhase2StorageHead,
 } from "./pi-memory-phase2-job.test-fixture";
 
-// #31937 requires infrastructure-only fault injection and exact control/usage
-// evidence. Public APIs cannot create lost ACKs, revoked in-flight claims, or
-// historical leases, and must not expose these private rows. Real routes still
-// own authentication, generic publication, usage ingestion, and completion.
+// #31937 and #32266 require infrastructure-only fault injection and exact
+// control/usage evidence. Public APIs cannot create lost ACKs, revoked
+// in-flight claims, historical leases, or Phase 2 cron state, and must not
+// expose these private rows. Real routes still own Runner claim authentication,
+// generic publication, usage ingestion, and completion.
 const context = testContext();
 const guestEnvironment = guestBoundaryEnvironment();
+const OFFICIAL_RUNNER_AUTHORIZATION =
+  "Bearer vm0_official_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
 const repo = resolve(
   fileURLToPath(new URL("../../../../../../..", import.meta.url)),
 );
@@ -178,6 +179,7 @@ function sse(response: ServerResponse, index: number, failure: boolean) {
 
 type Fault =
   | "none"
+  | "maintenance_agent_missing_retry"
   | "represented_no_diff"
   | "commit_ack"
   | "complete_transaction"
@@ -188,6 +190,84 @@ type Fault =
   | "invalid_marker"
   | "observer"
   | "new_input";
+
+type BoundaryScope = Awaited<ReturnType<typeof createPhase2TestScope>>;
+
+function phase2JobSeed(fault: Fault, dispatchTime: Date) {
+  if (fault !== "maintenance_agent_missing_retry") {
+    return { updatedAt: dispatchTime };
+  }
+  return {
+    status: "retryable_failure" as const,
+    retryCount: 1,
+    retryAt: new Date(dispatchTime.getTime() - 1),
+    lastErrorClass: "maintenance_agent_missing",
+    updatedAt: new Date(dispatchTime.getTime() - 1),
+  };
+}
+
+async function assertHistoricalMissingAgentRetry(args: {
+  readonly fault: Fault;
+  readonly scope: BoundaryScope;
+  readonly dispatchTime: Date;
+  readonly runId: string;
+}): Promise<void> {
+  if (args.fault !== "maintenance_agent_missing_retry") {
+    return;
+  }
+  await expect(
+    createStore().set(
+      executePiMemoryPhase2Work$,
+      {
+        scope: args.scope,
+        currentTime: new Date(args.dispatchTime.getTime() + 1),
+      },
+      context.signal,
+    ),
+  ).resolves.toStrictEqual({ outcome: "dispatched", runId: args.runId });
+  await expect(
+    db()
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.orgId, args.scope.orgId),
+          eq(agentRuns.userId, args.scope.userId),
+        ),
+      ),
+  ).resolves.toStrictEqual([{ id: args.runId }]);
+}
+
+async function claimMaintenanceRun(
+  app: ReturnType<typeof createAppWithRoutes>,
+  runId: string,
+) {
+  const response = await app.request(`/api/runners/jobs/${runId}/claim`, {
+    method: "POST",
+    headers: {
+      authorization: OFFICIAL_RUNNER_AUTHORIZATION,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      runnerIdentity: {
+        runnerId: randomUUID(),
+        heartbeatGeneration: 1,
+      },
+      capabilities: { piModelConfigGenerations: [1, 2, 3] },
+    }),
+  });
+  const body: unknown = await response.json();
+  expect(response.status, JSON.stringify(body)).toBe(200);
+  const execution = executionContextSchema.parse(body);
+  if (!execution.piLaunchConfig?.maintenance || !execution.piModelConfig) {
+    throw new Error("Claimed run is missing Pi maintenance context");
+  }
+  return {
+    execution,
+    maintenance: execution.piLaunchConfig.maintenance,
+    piLaunchConfig: execution.piLaunchConfig,
+  };
+}
 
 async function launch(fault: Fault, noDiff = false) {
   const scope = await createPhase2TestScope(`boundary-${fault}`, {
@@ -259,21 +339,16 @@ async function launch(fault: Fault, noDiff = false) {
     await setPhase2StorageHead(scope, baseVersion);
   }
   await seedOrgMetadata({ orgId: scope.orgId, tier: "pro", credits: 100_000 });
-  const agentId = randomUUID();
-  await db().insert(agents).values({
-    id: agentId,
-    orgId: scope.orgId,
-    owner: scope.userId,
-    name: DEFAULT_AGENT_NAME,
-    visibility: "public",
-  });
-  const cleanup: { runId?: string } = {};
+  const cleanup: { runId?: string; sessionId?: string } = {};
   onTestFinished(async () => {
     await db().delete(usageEvent).where(eq(usageEvent.orgId, scope.orgId));
-    if (cleanup.runId) {
+    if (cleanup.sessionId) {
+      await db()
+        .delete(agentSessions)
+        .where(eq(agentSessions.id, cleanup.sessionId));
+    } else if (cleanup.runId) {
       await db().delete(agentRuns).where(eq(agentRuns.id, cleanup.runId));
     }
-    await db().delete(agents).where(eq(agents.id, agentId));
   });
   await seedBuiltInModelKey(context, "gpt-5.6-terra");
   context.mocks.s3.getSignedUrl.mockResolvedValue(
@@ -282,11 +357,12 @@ async function launch(fault: Fault, noDiff = false) {
   if (!noDiff || fault === "represented_no_diff") {
     await insertPhase2Candidates(scope, [candidate]);
   }
-  await insertPendingPhase2Job(scope, { updatedAt: nowDate() });
+  const dispatchTime = nowDate();
+  await insertPendingPhase2Job(scope, phase2JobSeed(fault, dispatchTime));
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   const result = await createStore().set(
     executePiMemoryPhase2Work$,
-    { scope, currentTime: nowDate() },
+    { scope, currentTime: dispatchTime },
     context.signal,
   );
   expect(result.outcome).toBe("dispatched");
@@ -294,12 +370,40 @@ async function launch(fault: Fault, noDiff = false) {
     throw new Error("Maintenance dispatch failed");
   }
   cleanup.runId = result.runId;
-  // Runner activation is the only run-state fixture. Guest creates all session
-  // metadata, checkpoint requests, completion state and control settlement.
-  await db()
-    .update(agentRuns)
-    .set({ status: "running" })
+  const [maintenanceRunIdentity] = await db()
+    .select({
+      sessionId: agentRuns.sessionId,
+      chatThreadId: agentRuns.chatThreadId,
+    })
+    .from(agentRuns)
     .where(eq(agentRuns.id, result.runId));
+  if (!maintenanceRunIdentity) {
+    throw new Error("Missing maintenance run identity");
+  }
+  cleanup.sessionId = maintenanceRunIdentity.sessionId;
+  await expect(
+    db()
+      .select({ agentId: agentSessions.agentId })
+      .from(agentSessions)
+      .where(eq(agentSessions.id, maintenanceRunIdentity.sessionId)),
+  ).resolves.toStrictEqual([{ agentId: null }]);
+  expect(maintenanceRunIdentity.chatThreadId).toBeNull();
+  await expect(
+    db()
+      .select({ id: agents.id })
+      .from(agents)
+      .where(eq(agents.orgId, scope.orgId)),
+  ).resolves.toStrictEqual([]);
+  await assertHistoricalMissingAgentRetry({
+    fault,
+    scope,
+    dispatchTime,
+    runId: result.runId,
+  });
+  await expect(readPhase2Job(scope)).resolves.toMatchObject({
+    status: "leased",
+    maintenanceRunId: result.runId,
+  });
   const [callback] = await db()
     .select()
     .from(agentRunCallbacks)
@@ -307,13 +411,6 @@ async function launch(fault: Fault, noDiff = false) {
   const binding = piMemoryPhase2MaintenanceCallbackPayloadSchema.parse(
     callback?.payload,
   );
-  const [queued] = await db()
-    .select()
-    .from(runnerJobQueue)
-    .where(eq(runnerJobQueue.runId, result.runId));
-  const execution = z
-    .object({ piLaunchConfig: piLaunchConfigSchema })
-    .parse(queued?.executionContext);
   const trigger = `maintenance_observer_${scope.memoryStorageId.replaceAll("-", "")}`;
   async function releaseObserver() {
     if (fault === "observer") {
@@ -372,6 +469,7 @@ async function launch(fault: Fault, noDiff = false) {
   const app = createAppWithRoutes({
     signal: context.signal,
     routes: [
+      ...runnersRoutes,
       ...webhooksAgentCompleteRoutes,
       ...webhooksAgentHealthUsageTelemetryRoutes,
       ...webhooksAgentStorageRoutes,
@@ -544,7 +642,23 @@ async function launch(fault: Fault, noDiff = false) {
       Body: Readable.from([object]),
     });
   });
-  const token = generateSandboxToken(scope.userId, result.runId, scope.orgId);
+  const { execution, maintenance, piLaunchConfig } = await claimMaintenanceRun(
+    app,
+    result.runId,
+  );
+  expect(execution.connectorRuntimeTargets).toStrictEqual([]);
+  expect(execution.piModelConfig).toMatchObject({
+    provider: "openai",
+    model: "gpt-5.6-terra",
+    api: "openai-responses",
+  });
+  expect(maintenance).toMatchObject({
+    memoryStorageId: scope.memoryStorageId,
+    claimedBaseVersionId: baseVersion.versionId,
+    leaseToken: binding.leaseToken,
+    selected: binding.selected,
+  });
+  const token = execution.sandboxToken;
   const quote = (value: string) => {
     return `'${value.replaceAll("'", String.raw`'\''`)}'`;
   };
@@ -570,7 +684,7 @@ async function launch(fault: Fault, noDiff = false) {
           missingRootPolicy: "fail",
         },
       ]),
-      piLaunchConfig: JSON.stringify(execution.piLaunchConfig),
+      piLaunchConfig: JSON.stringify(piLaunchConfig),
       piModelConfig: JSON.stringify({
         provider: "openai",
         model: "gpt-5.6-terra",
@@ -745,6 +859,7 @@ async function assertUsageReplay(
 describe("private maintenance across CLI, Guest, generic checkpoint and real PostgreSQL", () => {
   it.each([
     "none",
+    "maintenance_agent_missing_retry",
     "commit_ack",
     "complete_transaction",
     "complete_ack",

--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts
@@ -4,13 +4,15 @@ import { PI_MEMORY_ROOT } from "@okouai/api-contracts/contracts/runners";
 import { agents } from "@okouai/db/schema/agent";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
+import { agentSessions } from "@okouai/db/schema/agent-session";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { checkpoints } from "@okouai/db/schema/checkpoint";
 import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
 import { storageVersionLineage } from "@okouai/db/schema/storage-version-lineage";
 import { storages, storageVersions } from "@okouai/db/schema/storage";
 import { conversations } from "@okouai/db/schema/agent-run-session-conversation";
 import { createStore } from "ccstate";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { testContext } from "../../../__tests__/test-context";
@@ -19,7 +21,6 @@ import { mockOptionalEnv } from "../../../lib/env";
 import { withMockNowForTest } from "../../../lib/time";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { seedBuiltInModelKey } from "../../routes/__tests__/helpers/runtime-state";
-import { DEFAULT_AGENT_NAME } from "../default-agent-profile";
 import { failPiMemoryPhase2Job } from "../pi-memory-phase2-job.service";
 import { handlePiMemoryPhase2MaintenanceCallback } from "../pi-memory-phase2-maintenance.service";
 import { executePiMemoryPhase2Work$ } from "../pi-memory-phase2-worker.service";
@@ -33,6 +34,30 @@ import {
   readPhase2Job,
   setPhase2StorageHead,
 } from "./pi-memory-phase2-job.test-fixture";
+
+async function deleteRunSessionsForScope(scope: {
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<void> {
+  const sessions = await db()
+    .select({ id: agentRuns.sessionId })
+    .from(agentRuns)
+    .where(
+      and(eq(agentRuns.orgId, scope.orgId), eq(agentRuns.userId, scope.userId)),
+    );
+  if (sessions.length > 0) {
+    await db()
+      .delete(agentSessions)
+      .where(
+        inArray(
+          agentSessions.id,
+          sessions.map((session) => {
+            return session.id;
+          }),
+        ),
+      );
+  }
+}
 
 describe("Pi memory Phase 2 sandbox dispatcher", () => {
   it("does not claim when no control job is ready", async () => {
@@ -49,11 +74,20 @@ describe("Pi memory Phase 2 sandbox dispatcher", () => {
     expect(result).toStrictEqual({ outcome: "no_work" });
   });
 
-  it("preserves candidates when first-party run admission cannot be resolved", async () => {
+  it("retries a due maintenance_agent_missing job without creating an Agent", async () => {
     const now = new Date("2026-09-05T02:00:00.000Z");
-    const scope = await createPhase2TestScope("sandbox-admission-failure", {
+    const scope = await createPhase2TestScope("sandbox-missing-agent-retry", {
       emptyBase: true,
     });
+    onTestFinished(async () => {
+      await deleteRunSessionsForScope(scope);
+    });
+    await seedOrgMetadata({
+      orgId: scope.orgId,
+      tier: "pro",
+      credits: 100_000,
+    });
+    await seedBuiltInModelKey(testContext(), "gpt-5.6-terra");
     const sessionId = randomUUID();
     await insertPhase2Candidates(scope, [
       {
@@ -62,7 +96,14 @@ describe("Pi memory Phase 2 sandbox dispatcher", () => {
         rolloutSummary: "bounded private evidence",
       },
     ]);
-    await insertPendingPhase2Job(scope, { updatedAt: now });
+    await insertPendingPhase2Job(scope, {
+      status: "retryable_failure",
+      retryCount: 1,
+      retryAt: new Date(now.getTime() - 1),
+      lastErrorClass: "maintenance_agent_missing",
+      updatedAt: new Date(now.getTime() - 1),
+    });
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
     const store = createStore();
 
     const result = await withMockNowForTest(now, async () => {
@@ -73,16 +114,51 @@ describe("Pi memory Phase 2 sandbox dispatcher", () => {
       );
     });
 
-    expect(result).toStrictEqual({
-      outcome: "failed",
-      errorClass: "maintenance_agent_missing",
-    });
-    const job = await readPhase2Job(scope);
-    expect(job).toMatchObject({
-      status: "retryable_failure",
-      maintenanceRunId: null,
-      sandboxLeaseToken: null,
+    expect(result.outcome).toBe("dispatched");
+    if (result.outcome !== "dispatched") {
+      throw new Error("Expected due retry dispatch");
+    }
+    await expect(
+      store.set(
+        executePiMemoryPhase2Work$,
+        { scope, currentTime: new Date(now.getTime() + 1) },
+        testContext().signal,
+      ),
+    ).resolves.toStrictEqual({ outcome: "dispatched", runId: result.runId });
+    await expect(
+      db()
+        .select({ id: agentRuns.id })
+        .from(agentRuns)
+        .where(
+          and(
+            eq(agentRuns.orgId, scope.orgId),
+            eq(agentRuns.userId, scope.userId),
+          ),
+        ),
+    ).resolves.toStrictEqual([{ id: result.runId }]);
+    const [run] = await db()
+      .select({ sessionId: agentRuns.sessionId })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, result.runId));
+    const [maintenanceSession] = run
+      ? await db()
+          .select({ agentId: agentSessions.agentId })
+          .from(agentSessions)
+          .where(eq(agentSessions.id, run.sessionId))
+      : [];
+    expect(maintenanceSession?.agentId).toBeNull();
+    await expect(
+      db()
+        .select({ id: agents.id })
+        .from(agents)
+        .where(eq(agents.orgId, scope.orgId)),
+    ).resolves.toStrictEqual([]);
+    await expect(readPhase2Job(scope)).resolves.toMatchObject({
+      status: "leased",
+      maintenanceRunId: result.runId,
       retryCount: 1,
+      retryAt: null,
+      lastErrorClass: null,
     });
     const [candidate] = await db()
       .select({ rawMemory: piMemoryStage1Candidates.rawMemory })
@@ -146,24 +222,8 @@ describe("Pi memory Phase 2 sandbox dispatcher", () => {
       tier: "pro",
       credits: 100_000,
     });
-    const agentId = randomUUID();
-    await db().insert(agents).values({
-      id: agentId,
-      orgId: scope.orgId,
-      owner: scope.userId,
-      name: DEFAULT_AGENT_NAME,
-      visibility: "public",
-    });
     onTestFinished(async () => {
-      await db()
-        .delete(agentRuns)
-        .where(
-          and(
-            eq(agentRuns.orgId, scope.orgId),
-            eq(agentRuns.userId, scope.userId),
-          ),
-        );
-      await db().delete(agents).where(eq(agents.id, agentId));
+      await deleteRunSessionsForScope(scope);
     });
     await seedBuiltInModelKey(testContext(), "gpt-5.6-terra");
     await insertPhase2Candidates(scope, [
@@ -225,7 +285,7 @@ describe("Pi memory Phase 2 sandbox dispatcher", () => {
     );
   });
 
-  it("dispatches one isolated threadless run with the exact private claim", async () => {
+  it("dispatches one isolated threadless run after a shared public Agent source", async () => {
     const now = new Date("2026-09-05T02:00:00.000Z");
     const scope = await createPhase2TestScope("sandbox-dispatch", {
       emptyBase: true,
@@ -236,20 +296,50 @@ describe("Pi memory Phase 2 sandbox dispatcher", () => {
       credits: 100_000,
     });
     const agentId = randomUUID();
+    const sourceSessionId = randomUUID();
+    const sourceThreadId = randomUUID();
+    const sourceRunId = randomUUID();
+    const agentOwnerId = `${scope.userId}-agent-owner`;
     await db().insert(agents).values({
       id: agentId,
       orgId: scope.orgId,
-      owner: scope.userId,
-      name: DEFAULT_AGENT_NAME,
+      owner: agentOwnerId,
+      name: "shared-pi-agent",
       visibility: "public",
     });
-    const cleanup = { maintenanceRunId: undefined as string | undefined };
+    await db().insert(agentSessions).values({
+      id: sourceSessionId,
+      orgId: scope.orgId,
+      userId: scope.userId,
+      agentId,
+    });
+    await db().insert(chatThreads).values({
+      id: sourceThreadId,
+      userId: scope.userId,
+      agentId,
+      title: "Shared Pi source",
+    });
+    await db().insert(agentRuns).values({
+      id: sourceRunId,
+      sessionId: sourceSessionId,
+      orgId: scope.orgId,
+      userId: scope.userId,
+      status: "completed",
+      prompt: "Remember this from a shared public Agent.",
+      triggerSource: "agent",
+      autonomyBudget: 0,
+      chatThreadId: sourceThreadId,
+      completedAt: now,
+    });
+    await db()
+      .update(chatThreads)
+      .set({
+        agentSessionId: sourceSessionId,
+        agentSessionRunId: sourceRunId,
+      })
+      .where(eq(chatThreads.id, sourceThreadId));
     onTestFinished(async () => {
-      if (cleanup.maintenanceRunId) {
-        await db()
-          .delete(agentRuns)
-          .where(eq(agentRuns.id, cleanup.maintenanceRunId));
-      }
+      await deleteRunSessionsForScope(scope);
       await db().delete(agents).where(eq(agents.id, agentId));
     });
     await seedBuiltInModelKey(testContext(), "gpt-5.6-terra");
@@ -257,6 +347,7 @@ describe("Pi memory Phase 2 sandbox dispatcher", () => {
     const [sourceHistoryHash] = await insertPhase2Candidates(scope, [
       {
         piSessionId: sessionId,
+        sourceRunId,
         rawMemory: "candidate stays inside the private launch payload",
         rolloutSummary: "evidence stays inside the private launch payload",
       },
@@ -277,9 +368,9 @@ describe("Pi memory Phase 2 sandbox dispatcher", () => {
     if (result.outcome !== "dispatched") {
       throw new Error("Expected maintenance run dispatch");
     }
-    cleanup.maintenanceRunId = result.runId;
     const [run] = await db()
       .select({
+        sessionId: agentRuns.sessionId,
         status: agentRuns.status,
         error: agentRuns.error,
         triggerSource: agentRuns.triggerSource,
@@ -301,6 +392,29 @@ describe("Pi memory Phase 2 sandbox dispatcher", () => {
         writeback: true,
         missingRootPolicy: "fail",
       }),
+    ]);
+    const [maintenanceSession] = run
+      ? await db()
+          .select({ agentId: agentSessions.agentId })
+          .from(agentSessions)
+          .where(eq(agentSessions.id, run.sessionId))
+      : [];
+    expect(maintenanceSession?.agentId).toBeNull();
+    await expect(
+      db()
+        .select({ id: agents.id })
+        .from(agents)
+        .where(
+          and(eq(agents.orgId, scope.orgId), eq(agents.owner, scope.userId)),
+        ),
+    ).resolves.toStrictEqual([]);
+    await expect(
+      db()
+        .select({ id: agents.id, name: agents.name, owner: agents.owner })
+        .from(agents)
+        .where(eq(agents.orgId, scope.orgId)),
+    ).resolves.toStrictEqual([
+      { id: agentId, name: "shared-pi-agent", owner: agentOwnerId },
     ]);
     const [callback] = await db()
       .select({

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -602,7 +602,20 @@ interface ResolvedAgentExecution {
   readonly resumeSessionIdentity?: SessionExecutionIdentity;
 }
 
+interface ResolvedPrivateMaintenanceExecution extends Omit<
+  ResolvedAgentExecution,
+  "agentId" | "agentName"
+> {
+  readonly agentId: null;
+  readonly agentName?: never;
+}
+
+type ResolvedRunExecution =
+  | ResolvedAgentExecution
+  | ResolvedPrivateMaintenanceExecution;
+
 interface ProductAgentExecutionPlan {
+  readonly identity: "agent" | "pi-memory-phase2-maintenance";
   readonly content: AgentExecutionConfig;
 }
 
@@ -1703,7 +1716,7 @@ function withPinnedPiContinuationMemory(
 }
 
 function artifactsForRun(args: {
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
   readonly framework: SupportedFramework;
   readonly piSandbox: PiModelConfig | undefined;
   readonly includeAutoMemory: boolean;
@@ -6097,9 +6110,9 @@ function resolveAgentExecution(
   userId: string,
   orgId: string,
   options: ResolveAgentExecutionOptions,
-): Computed<Promise<ResolvedAgentExecution | CreateRunErrorResult>> {
+): Computed<Promise<ResolvedRunExecution | CreateRunErrorResult>> {
   return computed(
-    async (get): Promise<ResolvedAgentExecution | CreateRunErrorResult> => {
+    async (get): Promise<ResolvedRunExecution | CreateRunErrorResult> => {
       const testOnlyResolver = options.testOnlyResolveDirectRun;
       if (testOnlyResolver) {
         if (!body.sessionId && !body.agentId) {
@@ -6136,6 +6149,17 @@ function resolveAgentExecution(
         throw new Error(
           "Product Agent execution plan is required for canonical resolution",
         );
+      }
+      if (
+        productAgentExecutionPlan.identity === "pi-memory-phase2-maintenance"
+      ) {
+        return {
+          agentId: null,
+          ownerUserId: userId,
+          orgId,
+          content: productAgentExecutionPlan.content,
+          artifacts: [],
+        };
       }
       if (body.sessionId) {
         const sessionId = body.sessionId;
@@ -6281,7 +6305,7 @@ function agentRunModelProviderValues(
 }
 
 function prepareLaunchRunIdentity(args: {
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
 }): LaunchRunIdentity {
   return {
     runId: randomUUID(),
@@ -6360,7 +6384,7 @@ interface LaunchRunRowsArgs {
   readonly orgId: string;
   readonly identity: LaunchRunIdentity;
   readonly status: LaunchRunStatus;
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
   readonly body: CreateRunBody;
   readonly runStorageMounts: readonly PersistedStorageMount[] | undefined;
   readonly sessionStorageMounts: readonly PersistedStorageMount[] | undefined;
@@ -6385,7 +6409,7 @@ interface LaunchSessionValues {
   readonly id: string;
   readonly userId: string;
   readonly orgId: string;
-  readonly agentId: string;
+  readonly agentId: string | null;
   readonly storageMounts: PersistedStorageMount[] | null;
   readonly conversationId: null;
 }
@@ -6554,7 +6578,7 @@ async function buildStoredExecutionContextDraft(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly chatThreadId: string | undefined;
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
   readonly body: CreateRunBody;
   readonly framework: SupportedFramework;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
@@ -7032,7 +7056,7 @@ interface BuildRunnerJobPayloadInput {
   readonly run: Pick<RunRecord, "id" | "sessionId" | "shouldCreateSession">;
   readonly userId: string;
   readonly orgId: string;
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
   readonly body: CreateRunBody;
   readonly artifacts: readonly ContextArtifact[];
   readonly framework: SupportedFramework;
@@ -8667,7 +8691,7 @@ export const BEFORE_DISPATCH_CANCELLED_ERROR =
 
 interface PreparedRunContext {
   readonly body: CreateRunBody;
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
   readonly framework: SupportedFramework;
   readonly piSandbox: PiModelConfig | undefined;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
@@ -8915,7 +8939,7 @@ async function loadRunConnectorContexts(
 async function buildResolvedRunBody(
   args: {
     readonly initialBody: CreateRunBody;
-    readonly resolved: ResolvedAgentExecution;
+    readonly resolved: ResolvedRunExecution;
     readonly persistedEnvironment: PersistedRunEnvironmentSnapshot;
     readonly featureSwitchContext: FeatureSwitchContext;
     readonly canonicalOkouRuntime: boolean;
@@ -8960,7 +8984,7 @@ async function buildResolvedRunBody(
 }
 
 function validateRunEnvironmentReferences(args: {
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
   readonly body: CreateRunBody;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly connectorContext: ConnectorRuntimeContext;
@@ -9037,7 +9061,7 @@ function preparedRunAdditionalVolumes(args: {
   readonly skillsRoot: string;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly body: CreateRunBody;
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
   readonly officialWorkflowRun: OfficialWorkflowRunObservation | undefined;
 }): PreparedAdditionalVolumes {
   const bodyAdditionalVolumes = args.body.additionalVolumes;
@@ -9074,7 +9098,7 @@ function preparedRunAdditionalVolumes(args: {
 
 interface PreparedRunBodyContext {
   readonly body: CreateRunBody;
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
   readonly connectorScope: EffectiveConnectorScope;
   readonly requestedFramework: SupportedFramework;
   readonly featureSwitchContext: FeatureSwitchContext;
@@ -9180,6 +9204,27 @@ function agentRunResolutionOptions(
   ) {
     throw new Error(
       "Agent run preparation cannot mix product and direct-run resolution",
+    );
+  }
+  const privateMaintenanceIdentity =
+    productAgentExecutionPlan?.identity === "pi-memory-phase2-maintenance";
+  if (
+    privateMaintenanceIdentity !==
+    (args.piMemoryPhase2Maintenance !== undefined)
+  ) {
+    throw new Error(
+      "Pi memory maintenance payload and execution identity must match",
+    );
+  }
+  if (
+    privateMaintenanceIdentity &&
+    (args.body.agentId !== undefined ||
+      args.body.sessionId !== undefined ||
+      args.chatThreadId !== undefined ||
+      args.piExecution !== true)
+  ) {
+    throw new Error(
+      "Pi memory maintenance runs must use a private threadless identity",
     );
   }
   return {
@@ -9665,7 +9710,7 @@ function prepareRunOutputMetadata(args: {
   readonly piSandbox: PiModelConfig | undefined;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly body: CreateRunBody;
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
   readonly officialWorkflowRun: OfficialWorkflowRunObservation | undefined;
 }): {
   readonly artifacts: readonly ContextArtifact[];
@@ -9777,9 +9822,9 @@ function prepareRunContexts(
 }
 
 function resolveCompatibleDirectResumeSession(args: {
-  readonly resolved: ResolvedAgentExecution;
+  readonly resolved: ResolvedRunExecution;
   readonly next: SessionExecutionIdentity;
-}): ResolvedAgentExecution {
+}): ResolvedRunExecution {
   const previous = args.resolved.resumeSessionIdentity;
   return previous && canReuseSession(previous, args.next)
     ? args.resolved

--- a/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-runs-create.service.ts
@@ -981,6 +981,7 @@ function buildCreateAgentRunArgs(args: {
     args.featureSwitchContext,
   );
   const productAgentExecutionPlan = {
+    identity: "agent" as const,
     content: buildAgentExecutionConfig(args.agent.name),
   };
   return {

--- a/turbo/apps/api/src/signals/services/official-workflow-run.service.ts
+++ b/turbo/apps/api/src/signals/services/official-workflow-run.service.ts
@@ -298,7 +298,7 @@ function lockedInstallationMatches(
   args: {
     readonly orgId: string;
     readonly userId: string;
-    readonly agentId: string;
+    readonly agentId: string | null;
   },
 ): boolean {
   return (
@@ -399,7 +399,7 @@ export async function validateOfficialWorkflowRunForInsert(
     readonly observation: OfficialWorkflowRunObservation | undefined;
     readonly orgId: string;
     readonly userId: string;
-    readonly agentId: string;
+    readonly agentId: string | null;
     readonly automationId: string | undefined;
     readonly runStorageMounts: readonly PersistedStorageMount[] | undefined;
     readonly allowMissingMountsForFailedRun: boolean;

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-worker.service.ts
@@ -1,5 +1,4 @@
 import { PI_MEMORY_ROOT } from "@okouai/api-contracts/contracts/runners";
-import { agents } from "@okouai/db/schema/agent";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { piMemoryPhase2Jobs } from "@okouai/db/schema/pi-memory-phase2-job";
 import { command } from "ccstate";
@@ -12,7 +11,6 @@ import { settle } from "../utils";
 import { createAgentRun$ } from "./agent-run-create.service";
 import { dispatchRunCallbacks } from "./agent-run-callback.service";
 import { resolveBuiltInModelRuntimeRoute } from "./built-in-model-runtime-route.service";
-import { DEFAULT_AGENT_NAME } from "./default-agent-profile";
 import {
   claimPiMemoryPhase2Job,
   failPiMemoryPhase2Job,
@@ -172,17 +170,6 @@ const dispatchClaim$ = command(
     signal: AbortSignal,
   ): Promise<PiMemoryPhase2WorkerResult> => {
     const { db, claim } = input;
-    const [agent] = await db
-      .select({ id: agents.id })
-      .from(agents)
-      .where(
-        and(eq(agents.orgId, claim.orgId), eq(agents.name, DEFAULT_AGENT_NAME)),
-      )
-      .limit(1);
-    signal.throwIfAborted();
-    if (!agent) {
-      return await failClaim(db, claim, nowDate(), "maintenance_agent_missing");
-    }
     const route = await resolveBuiltInModelRuntimeRoute(
       db,
       PI_MEMORY_PHASE2_MODEL,
@@ -213,7 +200,6 @@ const dispatchClaim$ = command(
         userId: claim.userId,
         orgId: claim.orgId,
         body: {
-          agentId: agent.id,
           prompt: "Run first-party Pi memory maintenance.",
           triggerSource: "agent",
           artifacts: [
@@ -251,10 +237,11 @@ const dispatchClaim$ = command(
         ],
         includeOkouTokenSecret: false,
         productAgentExecutionPlan: {
+          identity: "pi-memory-phase2-maintenance",
           content: {
             version: "1",
-            // Pi is the sandbox execution overlay; the canonical Agent
-            // definition still needs a supported base framework.
+            // Pi is the sandbox execution overlay; run preparation still
+            // needs a supported base framework.
             agent: { framework: "claude-code" },
           },
         },

--- a/turbo/apps/api/src/test-fixtures/thread-bound-run-admission.ts
+++ b/turbo/apps/api/src/test-fixtures/thread-bound-run-admission.ts
@@ -92,6 +92,7 @@ export async function createUnassociatedThreadBoundAgentRunFixture(
       },
       apiStartTime: now(),
       productAgentExecutionPlan: {
+        identity: "agent",
         content: buildAgentExecutionConfig("thread-run-invariant-agent"),
       },
       piExecution: false,


### PR DESCRIPTION
## Summary

- introduce an explicit internal `pi-memory-phase2-maintenance` execution identity that is bound to the claimed organization and user without requiring a persisted Agent row
- dispatch Phase 2 as a private, threadless run backed by the existing nullable `agent_sessions.agent_id` relationship, while preserving the exact storage base, selected candidates, lease/callback fence, built-in model route, empty connector scope, and Pi maintenance flags
- cover organizations with no default Agent, historical `maintenance_agent_missing` retries, and shared/public interactive source Agents without creating user-visible Agent side effects

## Design rationale

`agent_sessions.agent_id` is already nullable, so the product execution plan now discriminates ordinary Agent-backed runs from the narrow Pi maintenance identity. Only a matching Phase 2 maintenance payload may select the private identity, and that path rejects Agent/session IDs, chat threads, or non-Pi execution. Ordinary Agent and session resolution remains unchanged and strict.

The private identity derives `orgId` and `ownerUserId` from the already-claimed Phase 2 dispatch arguments. Runner claim admits a nullable Agent identity only when the active Phase 2 control row binds that same run, organization, and user; ordinary orphaned sessions remain unavailable, and connector runtime targets fail closed for the private identity. It does not select an arbitrary tenant Agent, borrow an Agent across organizations, or create, rename, or delete Agent rows. Official-workflow admission continues to fail closed for a nullable Agent identity if an observation is ever present.

## Blast radius

- audited every `productAgentExecutionPlan` constructor: the normal product route remains Agent-backed, the Phase 2 worker uses the new private identity, and the thread-bound invariant fixture explicitly stays Agent-backed
- audited downstream `resolved.agentId` consumers, Runner poll/claim/connector refresh, run/session reads, source-run identity, callbacks, checkpoint publication, and recovery; the Runner gate is narrowed to the active same-tenant Phase 2 binding
- rechecked all open PR files; #32292 touches only an unrelated image-recognition prompt in the same service, while the previously overlapping #32273 rename is now incorporated from live `main`

## Validation

- `pnpm vitest --run apps/api/src/signals/services/__tests__/pi-memory-phase2-worker.service.test.ts` (5 passed)
- `pnpm --filter api exec vitest run --config vitest.maintenance.config.ts` (13 passed with the latest Guest build and real Runner claim route)
- `pnpm exec vitest --run apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'dispatches, scopes, and claims runs through CLI PATs'` (1 passed; 203 skipped)
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm knip --workspace api`
- Prettier on all changed files and `git diff --check`

## Rollout and non-goals

- no schema migration, backfill, production data mutation, or user-visible Agent lifecycle change
- due `retryable_failure` rows carrying the historical `maintenance_agent_missing` class recover through the existing claim/retry state machine; terminal rows are not re-armed
- model-route failures, genuine launch failures, stale/replaced leases, callback/checkpoint faults, storage lineage and last-writer-wins behavior, recursion exclusion, and existing retry limits remain unchanged
- production release and parent EPIC acceptance remain controller-owned

Closes #32266
Related #31067
