### PR TITLE
test(api): isolate thread runtime priority catalog fixtures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -1554,11 +1554,17 @@ interface SelectedThreadConnectorFixture extends EntitledChatActor {
 async function selectedThreadConnectorFixture(
   title: string,
 ): Promise<SelectedThreadConnectorFixture> {
-  const entitled = await entitledChatActor();
+  // A unique version still shares the active source with other test files.
+  // Own the source so their catalog setup cannot invalidate this projection.
+  mockEnv(
+    "R2_USER_STORAGES_BUCKET_NAME",
+    `test-thread-runtime-context-${randomUUID()}`,
+  );
   await installApiTestConnectorCatalog({
     catalogVersion: `api-test-thread-runtime-overlap-${randomUUID()}`,
     runtimeProjection: true,
   });
+  const entitled = await entitledChatActor();
   const connection = await connectors.connectManualGrant(
     entitled.actor,
     "openai",


### PR DESCRIPTION
## Summary

- Give each `selectedThreadConnectorFixture()` invocation a UUID-owned catalog source before catalog and actor setup.
- Keep the runtime projection stable when another API test file installs the default catalog, preserving the intended overlap and error-priority scenarios.
- Retain all existing assertions and production behavior. No timeout, retry, concurrency configuration, API, or schema changes.

Closes #32275

## Root cause

The fixture randomized `catalogVersion` but still wrote the shared default source. Another file's global catalog setup could replace that active version, making the runtime projection unavailable. Run catalog selection then fell back to the external reader, where the hook intended to fail thread selection also rejected catalog selection. Production correctly prioritizes catalog rejection over abort (#31406), so the test captured `thread selection below abort` in Sentry.

A controlled local experiment replaced the default catalog after fixture creation: the original fixture reproduced the exact reported Sentry assertion, and the source-isolated fixture passed under the identical interference. The temporary interference was removed before submission; only source ownership and setup ordering remain in the diff.

## Validation

Using a fresh, migrated local PostgreSQL database after `scripts/prepare.sh` synchronized the environment:

- Prettier on the changed file: passed.
- `pnpm -F api lint`: passed.
- `pnpm -F api check-types`: passed.
- `pnpm knip --workspace api`: passed.
- The three fixture consumers (overlap, abort/thread priority, thread/provider priority): passed, including a final focused run on the submitted diff.
- Controlled interference experiment: red before the fix, green after it.
- `git diff --check`: passed.
- Commit hooks: repository-wide Knip and all 15 Turbo type/dependency-build tasks passed; formatting and commit-message validation passed.

Expanded validation (not fully green): the complete chat-events, run-lifecycle, chat-threads, and connector-catalog files with `--maxWorkers=4` ran all 502 tests: 499 passed, two Pi status polls expired, and one unrelated RUN-03 test hit its 5 s deadline. The two Pi cases passed focused rechecks alongside the three changed-fixture cases. The RUN-03 test still timed out alone with its file, production dependencies, and test infrastructure unchanged from main, and without importing the changed chat file. This independent local baseline limitation is tracked in #32299; no assertions, timeouts, or selected CI cases were weakened. CI remains the full-suite validation gate.

## Risks

The test bucket also namespaces mocked storage operations. The overlap test continues through claim and cancellation with the new bucket. Existing test teardown clears the environment override. Production performance and deployment compatibility are unchanged.
