### PR TITLE
fix(runner): retire sandbox after prefetch start timeout

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -23,7 +23,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::codex_model_catalog_prefetch::{
-    StartedCodexModelCatalogPrefetch, is_eligible as is_codex_model_catalog_prefetch_eligible,
+    CodexModelCatalogPrefetchStart, StartedCodexModelCatalogPrefetch,
+    is_eligible as is_codex_model_catalog_prefetch_eligible,
 };
 use super::diagnostics::{
     AgentBootstrapAbnormalExitLogContext, AgentEnvDiagnostics, AgentStdoutStreamDiagnostics,
@@ -1130,11 +1131,28 @@ impl PreparedRunInputs {
 
 pub(super) enum PreparedGuestRuntime {
     Ready(StartedCodexModelCatalogPrefetch),
+    SandboxUnusable(RunnerError),
     Failed(RunnerError),
     Cancelled,
 }
 
 impl PreparedGuestRuntime {
+    async fn start_codex_model_catalog_prefetch(
+        sandbox: &dyn Sandbox,
+        context: &ExecutionContext,
+        reuse_result: SandboxReuseResult,
+        cancel: &CancellationToken,
+        telemetry: &mut JobTelemetry,
+    ) -> Self {
+        match StartedCodexModelCatalogPrefetch::start(sandbox, context, reuse_result, cancel).await
+        {
+            CodexModelCatalogPrefetchStart::Usable(prefetch) => Self::Ready(prefetch),
+            CodexModelCatalogPrefetchStart::SandboxUnusable(unusable) => {
+                Self::SandboxUnusable(unusable.record_and_into_error(telemetry).into())
+            }
+        }
+    }
+
     pub(super) async fn prepare_for_codex_model_catalog_prefetch(
         sandbox: &dyn Sandbox,
         context: &ExecutionContext,
@@ -1160,6 +1178,30 @@ impl PreparedGuestRuntime {
         )
     }
 
+    pub(super) async fn prepare_without_codex_model_catalog_prefetch(
+        sandbox: &dyn Sandbox,
+        context: &ExecutionContext,
+        restore_guest_state: bool,
+        cancel: &CancellationToken,
+        telemetry: &mut JobTelemetry,
+    ) -> Self {
+        match prepare_guest_runtime_state_phase(
+            sandbox,
+            context,
+            restore_guest_state,
+            cancel,
+            telemetry,
+        )
+        .await
+        {
+            GuestRuntimeStatePreparation::Ready => {
+                Self::Ready(StartedCodexModelCatalogPrefetch::disabled())
+            }
+            GuestRuntimeStatePreparation::Failed(error) => Self::Failed(error),
+            GuestRuntimeStatePreparation::Cancelled => Self::Cancelled,
+        }
+    }
+
     async fn prepare(
         sandbox: &dyn Sandbox,
         context: &ExecutionContext,
@@ -1177,10 +1219,16 @@ impl PreparedGuestRuntime {
         )
         .await
         {
-            GuestRuntimeStatePreparation::Ready => Self::Ready(
-                StartedCodexModelCatalogPrefetch::start(sandbox, context, reuse_result, cancel)
-                    .await,
-            ),
+            GuestRuntimeStatePreparation::Ready => {
+                Self::start_codex_model_catalog_prefetch(
+                    sandbox,
+                    context,
+                    reuse_result,
+                    cancel,
+                    telemetry,
+                )
+                .await
+            }
             GuestRuntimeStatePreparation::Failed(error) => Self::Failed(error),
             GuestRuntimeStatePreparation::Cancelled => Self::Cancelled,
         }
@@ -1558,10 +1606,16 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // taking ownership of model-catalog prefetch supervision.
     let prepared_guest_runtime = match prepared_guest_runtime {
         Some(prepared) => prepared,
-        None if guest_state_prepared => PreparedGuestRuntime::Ready(
-            StartedCodexModelCatalogPrefetch::start(sandbox, context, start.reuse_result, &cancel)
-                .await,
-        ),
+        None if guest_state_prepared => {
+            PreparedGuestRuntime::start_codex_model_catalog_prefetch(
+                sandbox,
+                context,
+                start.reuse_result,
+                &cancel,
+                telemetry,
+            )
+            .await
+        }
         None => {
             PreparedGuestRuntime::prepare(
                 sandbox,
@@ -1576,6 +1630,12 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     };
     let mut model_catalog_prefetch = match prepared_guest_runtime {
         PreparedGuestRuntime::Ready(prefetch) => prefetch.supervise(sandbox),
+        PreparedGuestRuntime::SandboxUnusable(error) => {
+            if let Some(prepared) = prepared_storage.as_mut() {
+                prepared.delivery.cancel_and_drain(telemetry).await;
+            }
+            return Err(error);
+        }
         PreparedGuestRuntime::Failed(error) => {
             if let Some(prepared) = prepared_storage.as_mut() {
                 prepared.delivery.cancel_and_drain(telemetry).await;

--- a/crates/runner/src/executor/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/codex_model_catalog_prefetch.rs
@@ -5,7 +5,8 @@ use std::time::{Duration, Instant};
 use futures_util::FutureExt;
 use sandbox::{
     ExecOutputLimits, ExecTermination, GuestProcessCancelHandle, GuestProcessHandle, ProcessExit,
-    ProcessOutputMode, Sandbox, StartProcessRequest,
+    ProcessOutputMode, Sandbox, SandboxError, SandboxOperation, SandboxOperationTimeoutStage,
+    StartProcessRequest,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -55,6 +56,16 @@ struct PrefetchOutcome {
     error: Option<&'static str>,
 }
 
+pub(super) enum CodexModelCatalogPrefetchStart {
+    Usable(StartedCodexModelCatalogPrefetch),
+    SandboxUnusable(UnusableCodexModelCatalogPrefetchStart),
+}
+
+pub(super) struct UnusableCodexModelCatalogPrefetchStart {
+    error: SandboxError,
+    started_at: Instant,
+}
+
 pub(super) struct StartedCodexModelCatalogPrefetch {
     handle: Option<GuestProcessHandle>,
     cancel: Option<GuestProcessCancelHandle>,
@@ -78,15 +89,26 @@ impl StartedCodexModelCatalogPrefetch {
         context: &ExecutionContext,
         reuse_result: SandboxReuseResult,
         cancel: &CancellationToken,
-    ) -> Self {
+    ) -> CodexModelCatalogPrefetchStart {
         let started_at = Instant::now();
         if !is_eligible(context, reuse_result) {
-            return Self::without_process(started_at, None);
+            return CodexModelCatalogPrefetchStart::Usable(Self::disabled_at(started_at));
+        }
+        if cancel.is_cancelled() {
+            return CodexModelCatalogPrefetchStart::Usable(Self::without_process(
+                started_at,
+                Some(PrefetchOutcome {
+                    duration: started_at.elapsed(),
+                    success: false,
+                    error: Some("start_cancelled"),
+                }),
+            ));
         }
 
         let request = StartProcessRequest {
             cmd: PREFETCH_COMMAND,
             timeout: PREFETCH_GUEST_TIMEOUT,
+            start_timeout: PREFETCH_HOST_START_TIMEOUT,
             env: &[],
             sudo: false,
             output: ProcessOutputMode::buffered(ExecOutputLimits::separate(
@@ -94,61 +116,58 @@ impl StartedCodexModelCatalogPrefetch {
                 PREFETCH_STDERR_LIMIT_BYTES,
             )),
         };
-        let result = tokio::select! {
-            biased;
-            result = tokio::time::timeout(
-                PREFETCH_HOST_START_TIMEOUT,
-                sandbox.start_process(&request),
-            ) => match result {
-                Ok(result) => result,
-                Err(_) => {
-                    warn!("timed out starting Codex model catalog prefetch");
-                    return Self::without_process(
-                        started_at,
-                        Some(PrefetchOutcome {
-                            duration: started_at.elapsed(),
-                            success: false,
-                            error: Some("start_timed_out"),
-                        }),
-                    );
-                }
-            },
-            () = cancel.cancelled() => {
-                return Self::without_process(
+        let result = sandbox.start_process(&request).await;
+
+        match result {
+            Ok(mut handle) => {
+                let process_cancel = handle.take_cancel_handle();
+                let outcome = cancel.is_cancelled().then(|| PrefetchOutcome {
+                    duration: started_at.elapsed(),
+                    success: false,
+                    error: Some("start_cancelled"),
+                });
+                CodexModelCatalogPrefetchStart::Usable(Self {
+                    handle: Some(handle),
+                    cancel: process_cancel,
+                    wait_deadline: Some(Instant::now() + PREFETCH_HOST_WAIT_TIMEOUT),
+                    started_at,
+                    outcome,
+                    recorded: false,
+                })
+            }
+            Err(error) if is_safe_start_timeout(&error) => {
+                warn!("timed out before writing Codex model catalog prefetch start request");
+                CodexModelCatalogPrefetchStart::Usable(Self::without_process(
                     started_at,
                     Some(PrefetchOutcome {
                         duration: started_at.elapsed(),
                         success: false,
-                        error: Some("start_cancelled"),
+                        error: Some("start_timed_out"),
                     }),
-                );
+                ))
             }
-        };
-
-        match result {
-            Ok(mut handle) => {
-                let cancel = handle.take_cancel_handle();
-                Self {
-                    handle: Some(handle),
-                    cancel,
-                    wait_deadline: Some(Instant::now() + PREFETCH_HOST_WAIT_TIMEOUT),
-                    started_at,
-                    outcome: None,
-                    recorded: false,
-                }
+            Err(error) if is_unusable_sandbox_start_timeout(&error) => {
+                warn!(error = %error, "Codex model catalog prefetch start timed out after write boundary");
+                CodexModelCatalogPrefetchStart::SandboxUnusable(
+                    UnusableCodexModelCatalogPrefetchStart { error, started_at },
+                )
             }
             Err(error) => {
                 warn!(error = %error, "failed to start Codex model catalog prefetch");
-                Self::without_process(
+                CodexModelCatalogPrefetchStart::Usable(Self::without_process(
                     started_at,
                     Some(PrefetchOutcome {
                         duration: started_at.elapsed(),
                         success: false,
                         error: Some("start_failed"),
                     }),
-                )
+                ))
             }
         }
+    }
+
+    pub(super) fn disabled() -> Self {
+        Self::disabled_at(Instant::now())
     }
 
     pub(super) fn supervise(self, sandbox: &dyn Sandbox) -> CodexModelCatalogPrefetch<'_> {
@@ -182,6 +201,45 @@ impl StartedCodexModelCatalogPrefetch {
             recorded: false,
         }
     }
+
+    fn disabled_at(started_at: Instant) -> Self {
+        Self::without_process(started_at, None)
+    }
+}
+
+impl UnusableCodexModelCatalogPrefetchStart {
+    pub(super) fn record_and_into_error(self, telemetry: &mut JobTelemetry) -> SandboxError {
+        telemetry.record(
+            PREFETCH_ACTION,
+            self.started_at.elapsed(),
+            false,
+            Some("start_timed_out"),
+        );
+        self.error
+    }
+}
+
+fn is_safe_start_timeout(error: &SandboxError) -> bool {
+    matches!(
+        error,
+        SandboxError::OperationTimeout {
+            operation: SandboxOperation::StartProcess,
+            stage: SandboxOperationTimeoutStage::BeforeFrameWrite,
+            ..
+        }
+    )
+}
+
+fn is_unusable_sandbox_start_timeout(error: &SandboxError) -> bool {
+    matches!(
+        error,
+        SandboxError::OperationTimeout {
+            operation: SandboxOperation::StartProcess,
+            stage: SandboxOperationTimeoutStage::FrameWrite
+                | SandboxOperationTimeoutStage::AwaitingTerminalResponse,
+            ..
+        }
+    )
 }
 
 impl<'a> CodexModelCatalogPrefetch<'a> {

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -139,6 +139,8 @@ const RUNNER_FRESH_SANDBOX_START_RUNTIME_FINALIZE: &str =
 const RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE: &str =
     "runner_fresh_sandbox_retry_without_workspace_image";
 const RUNNER_FRESH_SANDBOX_DNS_READINESS_RETRY: &str = "runner_fresh_sandbox_dns_readiness_retry";
+const RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_CODEX_PREFETCH: &str =
+    "runner_fresh_sandbox_retry_without_codex_prefetch";
 
 const WORKSPACE_IMAGE_PREPARE_INVALID_WORKING_DIR: &str =
     "workspace_image_prepare_invalid_working_dir";
@@ -535,6 +537,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
     .await;
     let mut used_retry = false;
     let mut used_workspace_fallback = false;
+    let mut codex_model_catalog_prefetch = true;
     let mut dns_replacement: Option<DnsReadinessReplacement> = None;
     let prepared = loop {
         let result = create_started_sandbox(
@@ -549,6 +552,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 sandbox_prepared,
                 reuse_result,
                 cancel: &controls.cancel,
+                codex_model_catalog_prefetch,
             },
         )
         .await;
@@ -592,6 +596,8 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         let retry_guest_dns = failure.retry == SandboxPrepareRetry::GuestDnsReadiness;
         let retry_without_workspace =
             failure.retry == SandboxPrepareRetry::WithoutWorkspaceImage && cache_hit;
+        let retry_without_codex_prefetch =
+            failure.retry == SandboxPrepareRetry::WithoutCodexModelCatalogPrefetch;
         if !failure.cleanup_completed {
             if retry_guest_dns {
                 telemetry.record(
@@ -617,6 +623,18 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                     sandbox_id = %sandbox_id,
                     "workspace image fallback suppressed after uncertain cleanup"
                 );
+            } else if retry_without_codex_prefetch {
+                telemetry.record(
+                    RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_CODEX_PREFETCH,
+                    Duration::ZERO,
+                    false,
+                    Some(SANDBOX_PREPARE_RETRY_CLEANUP_UNCERTAIN),
+                );
+                warn!(
+                    run_id = %context.run_id,
+                    sandbox_id = %sandbox_id,
+                    "Codex prefetch sandbox replacement suppressed after uncertain cleanup"
+                );
             }
             let error = failure.error;
             telemetry.record(
@@ -628,7 +646,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
             cancel_prepared_storage(&mut controls, telemetry).await;
             return Err(error);
         }
-        if !retry_guest_dns && !retry_without_workspace {
+        if !retry_guest_dns && !retry_without_workspace && !retry_without_codex_prefetch {
             let error = failure.error;
             telemetry.record(
                 "runner_fresh_sandbox_prepare",
@@ -648,6 +666,22 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 "guest DNS readiness failed; retrying with a fresh sandbox attachment"
             );
             dns_replacement = Some(DnsReadinessReplacement::new(cache_hit));
+        }
+
+        if retry_without_codex_prefetch {
+            warn!(
+                run_id = %context.run_id,
+                sandbox_id = %sandbox_id,
+                error = %failure.error,
+                "Codex prefetch start crossed the write boundary; retrying with prefetch disabled"
+            );
+            telemetry.record(
+                RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_CODEX_PREFETCH,
+                Duration::ZERO,
+                true,
+                None,
+            );
+            codex_model_catalog_prefetch = false;
         }
 
         if cache_hit {
@@ -750,6 +784,7 @@ enum SandboxPrepareRetry {
     None,
     WithoutWorkspaceImage,
     GuestDnsReadiness,
+    WithoutCodexModelCatalogPrefetch,
 }
 
 pub(super) struct NewSandboxHooks<'a> {
@@ -763,6 +798,7 @@ struct StartSandboxOptions<'a> {
     sandbox_prepared: Option<&'a SandboxPreparedNotifier>,
     reuse_result: SandboxReuseResult,
     cancel: &'a CancellationToken,
+    codex_model_catalog_prefetch: bool,
 }
 
 impl SandboxPrepareError {
@@ -794,6 +830,15 @@ impl SandboxPrepareError {
             },
             cleanup_completed,
             invalidate_consumed_workspace_cache: suppress_replacement,
+        }
+    }
+
+    fn without_codex_model_catalog_prefetch(error: RunnerError, cleanup_completed: bool) -> Self {
+        Self {
+            error,
+            retry: SandboxPrepareRetry::WithoutCodexModelCatalogPrefetch,
+            cleanup_completed,
+            invalidate_consumed_workspace_cache: false,
         }
     }
 
@@ -1055,6 +1100,7 @@ async fn create_started_sandbox(
         sandbox_prepared,
         reuse_result,
         cancel,
+        codex_model_catalog_prefetch,
     } = options;
     let sandbox_config = SandboxConfig {
         id: sandbox_id,
@@ -1246,7 +1292,7 @@ async fn create_started_sandbox(
     );
     telemetry.record("sandbox_create", t.elapsed(), true, None);
 
-    let mut prepared_guest_runtime =
+    let mut prepared_guest_runtime = if codex_model_catalog_prefetch {
         PreparedGuestRuntime::prepare_for_codex_model_catalog_prefetch(
             sandbox.as_ref(),
             context,
@@ -1255,7 +1301,51 @@ async fn create_started_sandbox(
             cancel,
             telemetry,
         )
-        .await;
+        .await
+    } else {
+        Some(
+            PreparedGuestRuntime::prepare_without_codex_model_catalog_prefetch(
+                sandbox.as_ref(),
+                context,
+                params.restore_guest_state,
+                cancel,
+                telemetry,
+            )
+            .await,
+        )
+    };
+    prepared_guest_runtime = match prepared_guest_runtime {
+        Some(PreparedGuestRuntime::SandboxUnusable(error)) => {
+            let unregister_completed = match unregister_proxy_registry(
+                config,
+                &source_ip,
+                context.run_id,
+            )
+            .await
+            {
+                Ok(()) => true,
+                Err(unregister_error) => {
+                    warn!(
+                        run_id = %context.run_id,
+                        error = %unregister_error,
+                        "failed to unregister sandbox from proxy after Codex prefetch start timeout"
+                    );
+                    false
+                }
+            };
+            network_log_session
+                .close_for_upload(context.run_id, &config.network_log_drain)
+                .await;
+            let destroy_completed = destroy_sandbox_panic_safe(factory, sandbox)
+                .await
+                .is_completed();
+            return Err(SandboxPrepareError::without_codex_model_catalog_prefetch(
+                error,
+                unregister_completed && destroy_completed,
+            ));
+        }
+        prepared_guest_runtime => prepared_guest_runtime,
+    };
 
     let mount_started = Instant::now();
     let mount_result = ensure_workspace_drive_mounted(sandbox.as_ref(), context.run_id).await;

--- a/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use api_contracts::generated::types::runners::runs::CodexRuntimeConfig;
 use sandbox::{
     ExecTermination, ProcessExit, ProcessOutputMode, SandboxError, SandboxOperation,
-    SandboxOperationReason,
+    SandboxOperationReason, SandboxOperationTimeoutStage,
 };
 use sandbox_mock::MockLifecycleGate;
 use tokio::sync::Notify;
@@ -12,7 +12,7 @@ use tokio::sync::Notify;
 use crate::executor::EXIT_SIGKILL;
 use crate::executor::agent_run::{RunControls, RunStart, run_in_sandbox};
 use crate::executor::codex_model_catalog_prefetch::{
-    PREFETCH_HOST_START_TIMEOUT, StartedCodexModelCatalogPrefetch,
+    CodexModelCatalogPrefetchStart, PREFETCH_HOST_START_TIMEOUT, StartedCodexModelCatalogPrefetch,
 };
 use crate::executor::tests::support::{
     RUN_IN_SANDBOX_TEST_TIMEOUT, create_overridden_sandbox, minimal_context, sandbox_exec_error,
@@ -39,6 +39,25 @@ fn sandbox_start_error(message: impl Into<String>) -> SandboxError {
         operation: SandboxOperation::StartProcess,
         reason: SandboxOperationReason::Guest,
         message: message.into(),
+    }
+}
+
+fn sandbox_start_timeout(stage: SandboxOperationTimeoutStage) -> SandboxError {
+    SandboxError::OperationTimeout {
+        operation: SandboxOperation::StartProcess,
+        stage,
+        timeout_ms: u64::try_from(PREFETCH_HOST_START_TIMEOUT.as_millis()).unwrap(),
+    }
+}
+
+fn expect_usable_prefetch(
+    start: CodexModelCatalogPrefetchStart,
+) -> StartedCodexModelCatalogPrefetch {
+    match start {
+        CodexModelCatalogPrefetchStart::Usable(started) => started,
+        CodexModelCatalogPrefetchStart::SandboxUnusable(_) => {
+            panic!("prefetch start unexpectedly made the sandbox unusable")
+        }
     }
 }
 
@@ -89,13 +108,15 @@ async fn run_prefetch_state_machine(
     ));
     let mut telemetry = test_telemetry(&config, &context);
 
-    let started = StartedCodexModelCatalogPrefetch::start(
-        &*sandbox,
-        &context,
-        SandboxReuseResult::PoolMiss,
-        &cancellation,
-    )
-    .await;
+    let started = expect_usable_prefetch(
+        StartedCodexModelCatalogPrefetch::start(
+            &*sandbox,
+            &context,
+            SandboxReuseResult::PoolMiss,
+            &cancellation,
+        )
+        .await,
+    );
     let mut prefetch = started.supervise(&*sandbox);
     prefetch.race(async {}).await;
     prefetch.record_outcome(&mut telemetry);
@@ -107,7 +128,7 @@ async fn run_prefetch_state_machine(
 }
 
 async fn finish_started_prefetch(
-    started: StartedCodexModelCatalogPrefetch,
+    started: CodexModelCatalogPrefetchStart,
     sandbox: Arc<sandbox_mock::MockSandbox>,
     scenario: &str,
     expected_success: bool,
@@ -117,7 +138,7 @@ async fn finish_started_prefetch(
     let config = test_executor_config(dir.path()).await;
     let context = codex_oauth_context();
     let mut telemetry = test_telemetry(&config, &context);
-    let mut prefetch = started.supervise(&*sandbox);
+    let mut prefetch = expect_usable_prefetch(started).supervise(&*sandbox);
     prefetch.record_outcome(&mut telemetry);
     prefetch.record_outcome(&mut telemetry);
     prefetch.finish(&mut telemetry).await;
@@ -180,10 +201,15 @@ async fn codex_catalog_prefetch_start_observes_run_cancellation() {
         .await
         .expect("prefetch should enter process start");
     cancel.cancel();
+    assert!(
+        !run_task.is_finished(),
+        "cancellation must not drop an in-flight process start"
+    );
+    prefetch_gate.release_one();
 
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
         .await
-        .expect("cancelled prefetch start should not hold the run open")
+        .expect("cancelled prefetch start should finish after provider ownership returns")
         .unwrap()
         .unwrap();
 
@@ -191,19 +217,20 @@ async fn codex_catalog_prefetch_start_observes_run_cancellation() {
         result.failure.as_ref().map(|failure| failure.exit_code),
         Some(EXIT_SIGKILL)
     );
-    assert!(overrides.start_process_calls().is_empty());
+    assert_eq!(overrides.start_process_calls().len(), 1);
     assert!(overrides.start_agent_process_calls().is_empty());
-    assert!(overrides.wait_process_calls().is_empty());
+    assert_eq!(overrides.wait_process_calls().len(), 1);
     assert!(overrides.process_cancel_calls().is_empty());
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn codex_catalog_prefetch_start_timeout_does_not_delay_agent() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    let process_start_gate = MockLifecycleGate::new();
-    overrides.set_start_process_lifecycle_gate(process_start_gate.clone());
+    overrides.push_start_process_error(sandbox_start_timeout(
+        SandboxOperationTimeoutStage::BeforeFrameWrite,
+    ));
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let run_task = spawn_run_in_sandbox_test(
         sandbox,
@@ -212,19 +239,55 @@ async fn codex_catalog_prefetch_start_timeout_does_not_delay_agent() {
         tokio_util::sync::CancellationToken::new(),
     );
 
-    process_start_gate
-        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
-        .await
-        .expect("prefetch should enter process start");
-    overrides.clear_start_process_lifecycle_gate();
-    tokio::time::advance(PREFETCH_HOST_START_TIMEOUT).await;
-    tokio::task::yield_now().await;
-
     let result = run_task.await.unwrap().unwrap();
     assert!(result.failure.is_none());
-    assert!(overrides.start_process_calls().is_empty());
+    let process_calls = overrides.start_process_calls();
+    assert_eq!(process_calls.len(), 1);
+    assert_eq!(process_calls[0].start_timeout, PREFETCH_HOST_START_TIMEOUT);
     let start_calls = overrides.start_agent_process_calls();
     assert_eq!(start_calls.len(), 1);
+}
+
+#[tokio::test]
+async fn codex_catalog_prefetch_post_write_timeout_stops_direct_run_before_agent() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_process_error(sandbox_start_timeout(
+        SandboxOperationTimeoutStage::AwaitingTerminalResponse,
+    ));
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let context = codex_oauth_context();
+    let mut telemetry = test_telemetry(&config, &context);
+
+    let error = run_in_sandbox(
+        &*sandbox,
+        &context,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .err()
+    .expect("direct run cannot replace a sandbox after post-write timeout");
+
+    assert!(error.to_string().contains("awaiting terminal response"));
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert!(overrides.wait_process_calls().is_empty());
+    assert!(overrides.process_cancel_calls().is_empty());
+    assert_prefetch_outcome(
+        &telemetry,
+        false,
+        Some("start_timed_out"),
+        "post_write_timeout",
+    );
 }
 
 #[tokio::test]
@@ -254,6 +317,11 @@ async fn codex_catalog_prefetch_records_start_cancellation() {
         .await
         .expect("prefetch should enter process start");
     cancel.cancel();
+    assert!(
+        !start_task.is_finished(),
+        "cancellation must retain the provider start future"
+    );
+    start_gate.release_one();
 
     let started = start_task.await.unwrap();
     finish_started_prefetch(
@@ -266,34 +334,23 @@ async fn codex_catalog_prefetch_records_start_cancellation() {
     .await;
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn codex_catalog_prefetch_records_start_timeout() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    let start_gate = MockLifecycleGate::new();
-    overrides.set_start_process_lifecycle_gate(start_gate.clone());
+    overrides.push_start_process_error(sandbox_start_timeout(
+        SandboxOperationTimeoutStage::BeforeFrameWrite,
+    ));
     let sandbox = Arc::new(sandbox_mock::MockSandbox::with_overrides(
         "test",
         Arc::clone(&overrides),
     ));
-    let start_sandbox = Arc::clone(&sandbox);
-    let start_task = tokio::spawn(async move {
-        StartedCodexModelCatalogPrefetch::start(
-            &*start_sandbox,
-            &codex_oauth_context(),
-            SandboxReuseResult::PoolMiss,
-            &tokio_util::sync::CancellationToken::new(),
-        )
-        .await
-    });
-
-    start_gate
-        .wait_entered(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
-        .await
-        .expect("prefetch should enter process start");
-    tokio::time::advance(PREFETCH_HOST_START_TIMEOUT).await;
-    tokio::task::yield_now().await;
-
-    let started = start_task.await.unwrap();
+    let started = StartedCodexModelCatalogPrefetch::start(
+        &*sandbox,
+        &codex_oauth_context(),
+        SandboxReuseResult::PoolMiss,
+        &tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
     finish_started_prefetch(
         started,
         sandbox,
@@ -444,13 +501,15 @@ async fn codex_catalog_prefetch_prefers_guest_duration_and_falls_back_to_host_el
         Arc::clone(&overrides),
     ));
     let mut telemetry = test_telemetry(&config, &context);
-    let started = StartedCodexModelCatalogPrefetch::start(
-        &*sandbox,
-        &context,
-        SandboxReuseResult::PoolMiss,
-        &tokio_util::sync::CancellationToken::new(),
-    )
-    .await;
+    let started = expect_usable_prefetch(
+        StartedCodexModelCatalogPrefetch::start(
+            &*sandbox,
+            &context,
+            SandboxReuseResult::PoolMiss,
+            &tokio_util::sync::CancellationToken::new(),
+        )
+        .await,
+    );
     tokio::time::sleep(Duration::from_millis(5)).await;
     let prefetch = started.supervise(&*sandbox);
     prefetch.finish(&mut telemetry).await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -184,6 +184,14 @@ fn guest_dns_readiness_failure(
     }
 }
 
+fn process_start_timeout(stage: sandbox::SandboxOperationTimeoutStage) -> SandboxError {
+    SandboxError::OperationTimeout {
+        operation: sandbox::SandboxOperation::StartProcess,
+        stage,
+        timeout_ms: 1_000,
+    }
+}
+
 #[tokio::test]
 async fn execute_inner_happy_path() {
     let dir = tempfile::tempdir().unwrap();
@@ -462,6 +470,109 @@ async fn execute_new_sandbox_notifies_after_successful_prepare() {
 
     assert_eq!(outcome.exit_code(), 0);
     assert_eq!(notifications.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_replaces_post_write_prefetch_timeout_before_workload() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_process_error(process_start_timeout(
+        sandbox::SandboxOperationTimeoutStage::AwaitingTerminalResponse,
+    ));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let context = codex_oauth_context();
+    let params = JobParams {
+        restore_guest_state: true,
+        ..default_params()
+    };
+    let mut telemetry = test_telemetry(&config, &context);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &context,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &params,
+        &mut telemetry,
+        CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.exit_code(), 0);
+    assert_eq!(overrides.create_configs().len(), 2);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.guest_state_restore_calls().len(), 2);
+    assert_eq!(overrides.workspace_drive_mount_calls(), 1);
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
+    assert_telemetry_action(
+        &telemetry,
+        "runner_codex_model_catalog_prefetch",
+        false,
+        Some("start_timed_out"),
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_without_codex_prefetch",
+        true,
+        None,
+    );
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
+async fn execute_new_sandbox_suppresses_prefetch_replacement_after_uncertain_cleanup() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_process_error(process_start_timeout(
+        sandbox::SandboxOperationTimeoutStage::FrameWrite,
+    ));
+    overrides.push_destroy_panic("destroy failed");
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let context = codex_oauth_context();
+    let mut telemetry = test_telemetry(&config, &context);
+
+    let error = execute_new_sandbox(
+        &factory,
+        &context,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        CancellationToken::new(),
+    )
+    .await
+    .err()
+    .expect("uncertain cleanup must suppress replacement");
+
+    assert!(matches!(
+        error,
+        RunnerError::Sandbox(SandboxError::OperationTimeout {
+            operation: sandbox::SandboxOperation::StartProcess,
+            stage: sandbox::SandboxOperationTimeoutStage::FrameWrite,
+            ..
+        })
+    ));
+    assert_eq!(overrides.create_configs().len(), 1);
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_eq!(overrides.workspace_drive_mount_calls(), 0);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_without_codex_prefetch",
+        false,
+        Some("cleanup_uncertain"),
+    );
+    assert_proxy_registry_empty(dir.path()).await;
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -494,6 +494,92 @@ async fn workspace_mount_retry_starts_a_new_codex_catalog_prefetch_owner() {
 }
 
 #[tokio::test]
+async fn post_write_prefetch_timeout_replaces_consumed_cache_hit_with_fresh_workspace() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+    let cache = WorkspaceImageCache::new(runner_paths.clone());
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache.clone());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_process_error(SandboxError::OperationTimeout {
+        operation: sandbox::SandboxOperation::StartProcess,
+        stage: sandbox::SandboxOperationTimeoutStage::AwaitingTerminalResponse,
+        timeout_ms: 1_000,
+    });
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let mut context = codex_oauth_context();
+    let session_id = "00000000-0000-4000-8000-000000032219";
+    set_reuse_and_session_identity(&mut context, session_id, r#"{"type":"init"}"#);
+    let params = JobParams {
+        workspace_disk_mb: 16,
+        ..default_params()
+    };
+    let expected_seed = seed_workspace_image_cache(&cache, &runner_paths, session_id, 16).await;
+    let mut telemetry = test_telemetry(&config, &context);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &context,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &params,
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.exit_code(), 0);
+    assert!(outcome.workspace_image.is_none());
+    let configs = overrides.create_configs();
+    assert_eq!(configs.len(), 2);
+    assert_eq!(
+        configs[0].workspace_drive,
+        Some(sandbox::WorkspaceDriveConfig {
+            size_mb: 16,
+            seed_image: Some(sandbox::WorkspaceDriveSeedImage::Move(
+                expected_seed.clone(),
+            )),
+        })
+    );
+    assert_eq!(
+        configs[1].workspace_drive,
+        Some(sandbox::WorkspaceDriveConfig {
+            size_mb: 16,
+            seed_image: None,
+        })
+    );
+    assert!(!expected_seed.exists());
+    assert_eq!(overrides.destroy_call_count(), 1);
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.start_agent_process_calls().len(), 1);
+    assert_eq!(
+        telemetry
+            .pending_ops_snapshot()
+            .iter()
+            .filter(|(action, _, _)| action == "runner_codex_model_catalog_prefetch")
+            .count(),
+        1
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_without_codex_prefetch",
+        true,
+        None,
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_without_workspace_image",
+        true,
+        None,
+    );
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
 async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() {
     let dir = tempfile::tempdir().unwrap();
     let runner_paths = RunnerPaths::new(dir.path().join("runner"));

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -8,16 +8,16 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use guest_contracts::workspace_mount::WORKSPACE_DRIVE_MOUNT_REQUEST_DEADLINE;
 use sandbox::{
-    CodexSessionCleanupRequest, CopyFileOptions, CopyFileResult, ExecRequest, ExecResult,
-    GuestAgentProcessHandle, GuestAgentStartTiming, GuestMemorySnapshot, GuestProcessCancelHandle,
-    GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, GuestStateRestoreRequest,
-    GuestStateRestoreTimezone, ProcessControlAck, ProcessControlFailureKind,
-    ProcessControlGuestStatus, ProcessControlOutcome, ProcessControlWriteState, ProcessExit,
-    ProcessOutputMode, Sandbox, SandboxConfig, SandboxError, SandboxFinalExecParkHandoff,
-    SandboxFinalExecParkHandoffOutcome, SandboxFinalExecParkHandoffPoint,
-    SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome, SandboxFinalExecParkStage,
-    SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome, SandboxIdleTransition,
-    SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
+    CodexSessionCleanupRequest, CopyFileOptions, CopyFileResult, DEFAULT_PROCESS_START_TIMEOUT,
+    ExecRequest, ExecResult, GuestAgentProcessHandle, GuestAgentStartTiming, GuestMemorySnapshot,
+    GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter,
+    GuestStateRestoreRequest, GuestStateRestoreTimezone, ProcessControlAck,
+    ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlOutcome,
+    ProcessControlWriteState, ProcessExit, ProcessOutputMode, Sandbox, SandboxConfig, SandboxError,
+    SandboxFinalExecParkHandoff, SandboxFinalExecParkHandoffOutcome,
+    SandboxFinalExecParkHandoffPoint, SandboxFinalExecParkObserver, SandboxFinalExecParkOutcome,
+    SandboxFinalExecParkStage, SandboxFinalExecParkSubstage, SandboxFinalExecParkSubstageOutcome,
+    SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
     SandboxParkNonReusableReason, SandboxParkOutcome, SandboxStartObserver, SandboxStartStage,
     SessionHistoryIdentityVerifyRequest, SevereMemoryRetentionDiagnostics,
     StartAgentProcessRequest, StartProcessRequest, StorageManifestRequest, WriteFileEntry,
@@ -85,8 +85,6 @@ use state::{
 
 /// Timeout for waiting for the guest to connect via vsock after start.
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-/// Timeout for receiving a process start acknowledgement from the guest.
-const PROCESS_START_ACK_TIMEOUT: Duration = Duration::from_secs(30);
 /// Timeout for graceful shutdown via vsock.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -631,6 +629,7 @@ impl SandboxNetwork {
 struct ProcessStartContractRequest<'a> {
     command: &'a str,
     timeout_ms: u32,
+    start_timeout: Duration,
     env: &'a [(&'a str, &'a str)],
     sudo: bool,
     output: ProcessOutputMode,
@@ -1954,7 +1953,7 @@ impl FirecrackerSandbox {
                     stdin_bytes: None,
                     control,
                     stream_queue_capacity: process_stream_queue_capacity(request.output),
-                    start_timeout: PROCESS_START_ACK_TIMEOUT,
+                    start_timeout: request.start_timeout,
                 })
                 .await
         };
@@ -2774,6 +2773,7 @@ impl Sandbox for FirecrackerSandbox {
                 ProcessStartContractRequest {
                     command: request.cmd,
                     timeout_ms: request.timeout_ms(),
+                    start_timeout: request.start_timeout,
                     env: request.env,
                     sudo: request.sudo,
                     output: request.output,
@@ -2796,6 +2796,7 @@ impl Sandbox for FirecrackerSandbox {
                 ProcessStartContractRequest {
                     command: "",
                     timeout_ms: request.timeout_ms(),
+                    start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
                     env: request.env,
                     sudo: false,
                     output: request.output,

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -2317,6 +2317,7 @@ async fn start_process_output_rejects_invalid_stream_configuration() {
         let error = match sandbox
             .start_process(&StartProcessRequest {
                 cmd: "agent",
+                start_timeout: sandbox::DEFAULT_PROCESS_START_TIMEOUT,
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
@@ -2354,6 +2355,7 @@ async fn start_process_output_accepts_maximum_queue_capacity() {
     };
     let request = StartProcessRequest {
         cmd: "agent",
+        start_timeout: sandbox::DEFAULT_PROCESS_START_TIMEOUT,
         timeout: Duration::from_secs(5),
         env: &[],
         sudo: false,
@@ -2393,6 +2395,143 @@ async fn start_process_output_accepts_maximum_queue_capacity() {
     assert_eq!(
         exit.termination,
         sandbox::ExecTermination::Exited { exit_code: 0 }
+    );
+}
+
+#[tokio::test]
+async fn start_process_timeout_before_write_preserves_guest_connection() {
+    let sandbox = test_sandbox_with_state(SandboxState::Running);
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let timed_out_request = StartProcessRequest {
+        cmd: "prefetch",
+        timeout: Duration::from_secs(5),
+        start_timeout: Duration::ZERO,
+        env: &[],
+        sudo: false,
+        output: ProcessOutputMode::buffered(sandbox::EXEC_OUTPUT_LIMIT_1_MIB),
+    };
+
+    let error = match sandbox.start_process(&timed_out_request).await {
+        Ok(_) => panic!("zero-deadline process start should time out"),
+        Err(error) => error,
+    };
+    match error {
+        SandboxError::OperationTimeout {
+            operation,
+            stage,
+            timeout_ms,
+        } => {
+            assert_eq!(operation, SandboxOperation::StartProcess);
+            assert_eq!(
+                stage,
+                sandbox::SandboxOperationTimeoutStage::BeforeFrameWrite
+            );
+            assert_eq!(timeout_ms, 0);
+        }
+        other => panic!("expected pre-write process-start timeout, got {other:?}"),
+    }
+    assert_eq!(
+        guest.try_read(&mut [0u8; 1]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+
+    let request = StartProcessRequest {
+        start_timeout: Duration::from_secs(1),
+        ..timed_out_request
+    };
+    let start_process = sandbox.start_process(&request);
+    let acknowledge_start = async {
+        let start = read_vsock_message(&mut guest).await;
+        assert_eq!(start.msg_type, vsock_proto::MSG_EXEC_START);
+        let payload = vsock_proto::encode_exec_started(73).unwrap();
+        let response =
+            vsock_proto::encode(vsock_proto::MSG_EXEC_STARTED, start.seq, &payload).unwrap();
+        guest.write_all(&response).await.unwrap();
+        start.seq
+    };
+    let (handle, exec_seq) = tokio::join!(start_process, acknowledge_start);
+    let handle = handle.unwrap();
+    let payload = vsock_proto::encode_exec_result(
+        vsock_proto::ExecTermination::Exited { exit_code: 0 },
+        1,
+        vsock_proto::ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: false,
+        },
+        vsock_proto::ExecCapturedOutput::Captured {
+            bytes: b"",
+            truncated: false,
+        },
+        "",
+    )
+    .unwrap();
+    let response = vsock_proto::encode(vsock_proto::MSG_EXEC_RESULT, exec_seq, &payload).unwrap();
+    guest.write_all(&response).await.unwrap();
+    sandbox
+        .wait_process(handle, Duration::from_secs(1))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn start_process_timeout_after_write_rejects_later_guest_operation() {
+    let sandbox = test_sandbox_with_state(SandboxState::Running);
+    let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+    let start_timeout = Duration::from_millis(20);
+    let request = StartProcessRequest {
+        cmd: "prefetch",
+        timeout: Duration::from_secs(5),
+        start_timeout,
+        env: &[],
+        sudo: false,
+        output: ProcessOutputMode::buffered(sandbox::EXEC_OUTPUT_LIMIT_1_MIB),
+    };
+
+    let error = match sandbox.start_process(&request).await {
+        Ok(_) => panic!("unacknowledged process start should time out"),
+        Err(error) => error,
+    };
+    match error {
+        SandboxError::OperationTimeout {
+            operation,
+            stage,
+            timeout_ms,
+        } => {
+            assert_eq!(operation, SandboxOperation::StartProcess);
+            assert_eq!(
+                stage,
+                sandbox::SandboxOperationTimeoutStage::AwaitingTerminalResponse
+            );
+            assert_eq!(timeout_ms, 20);
+        }
+        other => panic!("expected post-write process-start timeout, got {other:?}"),
+    }
+    let start = read_vsock_message(&mut guest).await;
+    assert_eq!(start.msg_type, vsock_proto::MSG_EXEC_START);
+    let cancel = read_vsock_message(&mut guest).await;
+    assert_eq!(cancel.msg_type, vsock_proto::MSG_EXEC_CANCEL);
+    assert_eq!(cancel.seq, start.seq);
+
+    let later_error = match sandbox
+        .exec(&ExecRequest {
+            cmd: "true",
+            timeout: Duration::from_secs(1),
+            env: &[],
+            sudo: false,
+            expected_exit_codes: &[],
+            stdin_bytes: None,
+            output_limits: sandbox::EXEC_OUTPUT_LIMIT_1_MIB,
+        })
+        .await
+    {
+        Ok(_) => panic!("post-write timeout connection must reject later operations"),
+        Err(error) => error,
+    };
+    assert!(
+        later_error
+            .to_string()
+            .contains("normal operations are not available on this connection"),
+        "got: {later_error}"
     );
 }
 

--- a/crates/sandbox-mock/src/call_records.rs
+++ b/crates/sandbox-mock/src/call_records.rs
@@ -141,6 +141,8 @@ pub struct StartProcessCall {
     pub cmd: String,
     /// Timeout passed to `StartProcessRequest.timeout`.
     pub timeout: Duration,
+    /// Start acknowledgement deadline passed to `StartProcessRequest.start_timeout`.
+    pub start_timeout: Duration,
     /// Environment variable names and values from `StartProcessRequest.env`.
     pub env: Vec<(String, String)>,
     /// Whether the process request was made with sudo privileges.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -1321,6 +1321,7 @@ impl Sandbox for MockSandbox {
                 .push(StartProcessCall {
                     cmd: request.cmd.to_string(),
                     timeout: request.timeout,
+                    start_timeout: request.start_timeout,
                     env: request
                         .env
                         .iter()
@@ -1362,6 +1363,7 @@ impl Sandbox for MockSandbox {
         let process_request = StartProcessRequest {
             cmd: "",
             timeout: request.timeout,
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             env: request.env,
             sudo: false,
             output: request.output,

--- a/crates/sandbox-mock/src/tests/process.rs
+++ b/crates/sandbox-mock/src/tests/process.rs
@@ -1,4 +1,5 @@
 use super::*;
+use ::sandbox::DEFAULT_PROCESS_START_TIMEOUT;
 use std::sync::Arc;
 
 #[tokio::test]
@@ -9,6 +10,7 @@ async fn overrides_record_start_process_output_modes_in_order() {
     let buffered = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -21,6 +23,7 @@ async fn overrides_record_start_process_output_modes_in_order() {
     let streamed = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -36,6 +39,7 @@ async fn overrides_record_start_process_output_modes_in_order() {
             StartProcessCall {
                 cmd: "agent".to_string(),
                 timeout: Duration::from_secs(5),
+                start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
                 env: Vec::new(),
                 sudo: false,
                 output: ProcessOutputMode::buffered(EXEC_OUTPUT_LIMIT_1_MIB),
@@ -43,6 +47,7 @@ async fn overrides_record_start_process_output_modes_in_order() {
             StartProcessCall {
                 cmd: "agent".to_string(),
                 timeout: Duration::from_secs(5),
+                start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
                 env: Vec::new(),
                 sudo: false,
                 output: ProcessOutputMode::stream(),
@@ -62,6 +67,7 @@ async fn start_process_emits_queued_stdout_chunks() {
     let mut handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -95,6 +101,7 @@ async fn process_stream_capacity_overflow_retains_one_chunk_and_marks_exit() {
     let mut handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -128,6 +135,7 @@ async fn start_agent_process_returns_mandatory_control_handle() {
     let without_control = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -371,6 +379,7 @@ async fn start_process_validates_stream_configuration() {
         let error = match sandbox
             .start_process(&StartProcessRequest {
                 cmd: "agent",
+                start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
@@ -399,6 +408,7 @@ async fn start_process_validates_stream_configuration() {
     let handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -420,6 +430,7 @@ async fn start_process_rejects_invalid_env_key() {
     let result = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[("1BAD", "x")],
             sudo: false,
@@ -456,6 +467,7 @@ async fn queued_start_process_errors_are_consumed_fifo() {
     let sandbox = MockSandbox::with_overrides("test", Arc::clone(&overrides));
     let request = StartProcessRequest {
         cmd: "agent",
+        start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
         timeout: Duration::from_secs(5),
         env: &[],
         sudo: false,
@@ -502,6 +514,7 @@ async fn start_process_lifecycle_gate_blocks_before_recording_or_cancellation() 
             sandbox
                 .start_process(&StartProcessRequest {
                     cmd: "blocked-agent",
+                    start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
                     timeout: Duration::from_secs(5),
                     env: &[],
                     sudo: false,
@@ -527,6 +540,7 @@ async fn start_process_lifecycle_gate_blocks_before_recording_or_cancellation() 
         sandbox
             .start_process(&StartProcessRequest {
                 cmd: "next-agent",
+                start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
                 timeout: Duration::from_secs(5),
                 env: &[],
                 sudo: false,
@@ -551,6 +565,7 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
     let invalid_start = sandbox
         .start_process(&StartProcessRequest {
             cmd: "invalid-agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[("1BAD", "value")],
             sudo: false,
@@ -564,6 +579,7 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
     let first_handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "first-agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -577,6 +593,7 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
     let second_handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "second-agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -589,6 +606,7 @@ async fn process_result_cancellations_are_success_only_and_fifo() {
     let mut invalid_wait_handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "invalid-wait-agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -636,6 +654,7 @@ async fn wait_process_rejects_consumed_guest_process_handle() {
     let mut handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -671,6 +690,7 @@ async fn wait_process_returns_queued_process_exit() {
     let handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -697,6 +717,7 @@ async fn wait_process_default_exit_is_unchanged_without_queued_exit() {
     let handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -753,6 +774,7 @@ async fn wait_process_lifecycle_gate_blocks_until_released() {
     let handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -784,6 +806,7 @@ async fn wait_process_lifecycle_gate_clear_only_affects_future_waits() {
     let first_handle = first_sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -809,6 +832,7 @@ async fn wait_process_lifecycle_gate_clear_only_affects_future_waits() {
     let second_handle = second_sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,
@@ -845,6 +869,7 @@ async fn process_cancel_releases_wait_process_lifecycle_gate() {
     let mut handle = sandbox
         .start_process(&StartProcessRequest {
             cmd: "agent",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_secs(5),
             env: &[],
             sudo: false,

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -57,12 +57,12 @@ pub use snapshot::{
     PendingSnapshotPublish, SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider,
 };
 pub use types::{
-    CodexSessionCleanupRequest, CopyFileOptions, CopyFileResult, EXEC_OUTPUT_LIMIT_1_MIB,
-    EXEC_OUTPUT_LIMIT_7_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult,
-    ExecTermination, GuestAgentProcessHandle, GuestAgentStartTiming, GuestProcessCancelHandle,
-    GuestProcessControlHandle, GuestProcessControlOutcomeFuture, GuestProcessHandle,
-    GuestProcessWaiter, GuestStateRestoreRequest, GuestStateRestoreTimezone, ProcessControlAck,
-    ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlOutcome,
+    CodexSessionCleanupRequest, CopyFileOptions, CopyFileResult, DEFAULT_PROCESS_START_TIMEOUT,
+    EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_7_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits,
+    ExecRequest, ExecResult, ExecTermination, GuestAgentProcessHandle, GuestAgentStartTiming,
+    GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessControlOutcomeFuture,
+    GuestProcessHandle, GuestProcessWaiter, GuestStateRestoreRequest, GuestStateRestoreTimezone,
+    ProcessControlAck, ProcessControlFailureKind, ProcessControlGuestStatus, ProcessControlOutcome,
     ProcessControlWriteState, ProcessExit, ProcessOutputChunk, ProcessOutputMode,
     ProcessOutputReceiver, SessionHistoryIdentityVerifyRequest, StartAgentProcessRequest,
     StartProcessRequest, StorageManifestRequest, WriteFileEntry,

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -7,6 +7,9 @@ use std::time::{Duration, Instant};
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 
+/// Default host deadline for starting a supervised guest process.
+pub const DEFAULT_PROCESS_START_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Capture budgets for stdout/stderr returned by [`ExecRequest`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ExecOutputLimits {
@@ -216,6 +219,9 @@ pub struct StartProcessRequest<'a> {
     pub cmd: &'a str,
     /// Guest-side process timeout.
     pub timeout: Duration,
+    /// Host deadline for writing the start request and receiving the guest
+    /// process-start acknowledgement.
+    pub start_timeout: Duration,
     /// Environment variables passed to the command. Keys must satisfy the vm0
     /// guest shell exec env key contract.
     pub env: &'a [(&'a str, &'a str)],
@@ -1248,6 +1254,7 @@ mod tests {
     fn start_process_timeout_ms_rounds_nonzero_submillisecond_up() {
         let req = StartProcessRequest {
             cmd: "true",
+            start_timeout: DEFAULT_PROCESS_START_TIMEOUT,
             timeout: Duration::from_nanos(1),
             env: &[],
             sudo: false,

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -68,7 +68,7 @@ pub(crate) mod test_support {
     use std::sync::atomic::AtomicU8;
     use std::time::Duration;
 
-    use crate::Shared;
+    use crate::{FrameWriteObserver, Shared};
 
     use super::frame::ExecOperationFrameWriteGuard;
     use super::handle::SupervisedExecHandle;
@@ -109,6 +109,22 @@ pub(crate) mod test_support {
             request,
             after_start_write,
             start_timeout_cancel_write_timeout,
+            FrameWriteObserver::default(),
+        )
+        .await
+    }
+
+    pub(crate) async fn start_supervised_exec_with_write_observer(
+        shared: &Arc<Shared>,
+        request: SupervisedExecRequest<'_>,
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<SupervisedExecHandle> {
+        start_supervised_exec_on_shared_with_after_start_write_and_cancel_timeout(
+            shared,
+            request,
+            std::future::ready(()),
+            super::EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT,
+            write_observer,
         )
         .await
     }

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -424,46 +424,52 @@ where
             }
         }
         _ = time::sleep_until(deadline) => {
-            let Some(_reservation) = admit_exec_cancel_frame(shared, route_id)? else {
-                return Err(io::Error::new(
-                    io::ErrorKind::ConnectionReset,
-                    "supervised exec route was replaced before start-timeout cancel",
-                ));
-            };
-            shared.remove_operation(route_id);
-            registration_guard.disarm();
             let seq = route_id.wire_seq();
-            let payload = vsock_proto::encode_exec_cancel();
-            let cancel_result = tokio::time::timeout(
-                start_timeout_cancel_write_timeout,
-                write_frame(
-                    shared,
-                    MSG_EXEC_CANCEL,
-                    seq,
-                    &payload,
-                    Some(diagnostic.frame("start-timeout-cancel")),
-                    None,
-                    FrameWriteObserver::default(),
-                ),
-            )
-            .await
-            .unwrap_or_else(|_| {
+            let cancel_result = async {
+                let Some(_reservation) = admit_exec_cancel_frame(shared, route_id)? else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::ConnectionReset,
+                        "supervised exec route was replaced before start-timeout cancel",
+                    ));
+                };
+                shared.remove_operation(route_id);
+                registration_guard.disarm();
+                let payload = vsock_proto::encode_exec_cancel();
+                tokio::time::timeout(
+                    start_timeout_cancel_write_timeout,
+                    write_frame(
+                        shared,
+                        MSG_EXEC_CANCEL,
+                        seq,
+                        &payload,
+                        Some(diagnostic.frame("start-timeout-cancel")),
+                        None,
+                        FrameWriteObserver::default(),
+                    ),
+                )
+                .await
+                .unwrap_or_else(|_| {
+                    shared.poison_connection();
+                    Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "supervised exec start timeout cancel write timed out",
+                    ))
+                })
+            }
+            .await;
+            start_cancel_on_drop.disarm();
+            // Cleanup failure must not erase the post-write timeout classification.
+            if let Err(error) = cancel_result {
                 tracing::warn!(
                     seq = seq,
                     label = %diagnostic.label_log,
                     process_class = diagnostic.process_class,
                     operation_kind = diagnostic.operation_kind,
                     elapsed_ms = diagnostic.elapsed_ms(),
-                    "supervised exec start timeout cancel write timed out"
+                    error = %error,
+                    "supervised exec start timeout cancellation failed"
                 );
-                shared.poison_connection();
-                Err(supervised_start_timeout_error(
-                    RequestTimeoutStage::AwaitingTerminalResponse,
-                    request.start_timeout,
-                ))
-            });
-            start_cancel_on_drop.disarm();
-            cancel_result?;
+            }
             return Err(supervised_start_timeout_error(
                 RequestTimeoutStage::AwaitingTerminalResponse,
                 request.start_timeout,

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -1,6 +1,7 @@
 use std::future::{Future, ready};
 use std::io;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use guest_contracts::codex_session_cleanup::{
@@ -21,7 +22,9 @@ use vsock_proto::{
     MSG_EXEC_CANCEL,
 };
 
-use crate::{CompositeNormalOperation, FrameWriteObserver, Shared};
+use crate::{
+    CompositeNormalOperation, FrameWriteObserver, RequestTimeoutError, RequestTimeoutStage, Shared,
+};
 
 use super::frame::{admit_exec_cancel_frame, write_exec_start_frame, write_frame};
 use super::handle::{
@@ -42,6 +45,41 @@ use super::{EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT, SMALL_EXEC_CAPTUR
 
 fn exec_start_timeout_error() -> io::Error {
     io::Error::new(io::ErrorKind::TimedOut, "exec start timeout")
+}
+
+#[derive(Debug, Default)]
+struct SupervisedStartProgress {
+    stage: AtomicU8,
+}
+
+impl SupervisedStartProgress {
+    const BEFORE_FRAME_WRITE: u8 = 0;
+    const FRAME_WRITE: u8 = 1;
+    const AWAITING_TERMINAL_RESPONSE: u8 = 2;
+
+    fn mark_frame_write(&self) {
+        self.stage.store(Self::FRAME_WRITE, Ordering::Release);
+    }
+
+    fn mark_awaiting_terminal_response(&self) {
+        self.stage
+            .store(Self::AWAITING_TERMINAL_RESPONSE, Ordering::Release);
+    }
+
+    fn timeout_stage(&self) -> RequestTimeoutStage {
+        match self.stage.load(Ordering::Acquire) {
+            Self::BEFORE_FRAME_WRITE => RequestTimeoutStage::BeforeFrameWrite,
+            Self::FRAME_WRITE => RequestTimeoutStage::FrameWrite,
+            _ => RequestTimeoutStage::AwaitingTerminalResponse,
+        }
+    }
+}
+
+fn supervised_start_timeout_error(stage: RequestTimeoutStage, timeout: Duration) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        RequestTimeoutError::new(stage, timeout),
+    )
 }
 
 fn exec_start_deadline(timeout: Duration) -> io::Result<Instant> {
@@ -207,6 +245,7 @@ pub(crate) async fn start_supervised_process_on_shared(
         ready(()),
         EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT,
         ExecStreamQueueKind::ProcessOutput,
+        FrameWriteObserver::default(),
     )
     .await
 }
@@ -224,6 +263,7 @@ where
         request,
         after_start_write,
         EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT,
+        FrameWriteObserver::default(),
     )
     .await
 }
@@ -235,6 +275,7 @@ pub(in crate::exec_operation) async fn start_supervised_exec_on_shared_with_afte
     request: SupervisedExecRequest<'_>,
     after_start_write: F,
     start_timeout_cancel_write_timeout: Duration,
+    start_write_observer: FrameWriteObserver,
 ) -> io::Result<SupervisedExecHandle>
 where
     F: Future<Output = ()>,
@@ -245,6 +286,7 @@ where
         after_start_write,
         start_timeout_cancel_write_timeout,
         ExecStreamQueueKind::Events,
+        start_write_observer,
     )
     .await
 }
@@ -255,10 +297,17 @@ async fn start_supervised_exec_on_shared_with_stream_queue_kind<F>(
     after_start_write: F,
     start_timeout_cancel_write_timeout: Duration,
     stream_queue_kind: ExecStreamQueueKind,
+    start_write_observer: FrameWriteObserver,
 ) -> io::Result<SupervisedExecHandle>
 where
     F: Future<Output = ()>,
 {
+    if request.start_timeout.is_zero() {
+        return Err(supervised_start_timeout_error(
+            RequestTimeoutStage::BeforeFrameWrite,
+            request.start_timeout,
+        ));
+    }
     let stream_queue_capacity = stream_queue_capacity_for(
         request.stdout,
         request.stderr,
@@ -295,6 +344,7 @@ where
     )
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
     let deadline = exec_start_deadline(request.start_timeout)?;
+    let start_progress = Arc::new(SupervisedStartProgress::default());
 
     let (start_tx, start_rx) = oneshot::channel();
     let ExecOperationRegistration {
@@ -327,6 +377,7 @@ where
         route_id,
         diagnostic.clone(),
     );
+    let write_progress = Arc::clone(&start_progress);
     let start_write_result = time::timeout_at(
         deadline,
         write_exec_start_frame(
@@ -336,16 +387,22 @@ where
             &diagnostic,
             tracks_normal_operation,
             FrameWriteObserver::default(),
-            FrameWriteObserver::default(),
+            FrameWriteObserver::new(move || {
+                write_progress.mark_frame_write();
+                start_write_observer.record_write_start()
+            }),
         ),
     )
     .await
-    .map_err(|_| exec_start_timeout_error())
+    .map_err(|_| {
+        supervised_start_timeout_error(start_progress.timeout_stage(), request.start_timeout)
+    })
     .and_then(|result| result);
     if let Err(error) = start_write_result {
         start_cancel_on_drop.disarm();
         return Err(error);
     }
+    start_progress.mark_awaiting_terminal_response();
     after_start_write.await;
 
     let (pid, start_timing) = tokio::select! {
@@ -400,16 +457,16 @@ where
                     "supervised exec start timeout cancel write timed out"
                 );
                 shared.poison_connection();
-                Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "supervised exec start timeout cancel write timed out",
+                Err(supervised_start_timeout_error(
+                    RequestTimeoutStage::AwaitingTerminalResponse,
+                    request.start_timeout,
                 ))
             });
             start_cancel_on_drop.disarm();
             cancel_result?;
-            return Err(io::Error::new(
-                io::ErrorKind::TimedOut,
-                "supervised exec start acknowledgement timeout",
+            return Err(supervised_start_timeout_error(
+                RequestTimeoutStage::AwaitingTerminalResponse,
+                request.start_timeout,
             ));
         }
     };

--- a/crates/vsock-host/src/exec_operation/start.rs
+++ b/crates/vsock-host/src/exec_operation/start.rs
@@ -302,12 +302,6 @@ async fn start_supervised_exec_on_shared_with_stream_queue_kind<F>(
 where
     F: Future<Output = ()>,
 {
-    if request.start_timeout.is_zero() {
-        return Err(supervised_start_timeout_error(
-            RequestTimeoutStage::BeforeFrameWrite,
-            request.start_timeout,
-        ));
-    }
     let stream_queue_capacity = stream_queue_capacity_for(
         request.stdout,
         request.stderr,
@@ -343,6 +337,12 @@ where
         },
     )
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+    if request.start_timeout.is_zero() {
+        return Err(supervised_start_timeout_error(
+            RequestTimeoutStage::BeforeFrameWrite,
+            request.start_timeout,
+        ));
+    }
     let deadline = exec_start_deadline(request.start_timeout)?;
     let start_progress = Arc::new(SupervisedStartProgress::default());
 

--- a/crates/vsock-host/src/tests/exec_operation/supervised/timeout.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/timeout.rs
@@ -1,9 +1,10 @@
 use std::io;
+use std::os::fd::AsRawFd;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use nix::sys::socket::{setsockopt, sockopt};
+use nix::sys::socket::{Shutdown, setsockopt, shutdown, sockopt};
 use tokio::io::AsyncWriteExt;
 use vsock_proto::{
     ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
@@ -502,6 +503,44 @@ async fn supervised_exec_start_ack_timeout_cancel_write_is_bounded() {
         Ok(n) => panic!("bounded cancel write must not send after timing out; read {n} bytes"),
         Err(err) => panic!("unexpected read error after bounded cancel timeout: {err}"),
     }
+}
+
+#[tokio::test]
+async fn supervised_exec_start_ack_timeout_preserves_stage_when_cancel_write_fails() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let result = exec_operation_impl::test_support::start_supervised_exec_after_start_write(
+        &host.shared,
+        SupervisedExecRequest {
+            start_timeout: START_ACK_TEST_TIMEOUT,
+            ..supervised_request("start-timeout-broken-cancel")
+        },
+        async {
+            let start = read_guest_message(&mut guest).await;
+            assert_eq!(start.msg_type, MSG_EXEC_START);
+            // Keep the guest-to-host side open so only the cancel write fails.
+            shutdown(guest.as_raw_fd(), Shutdown::Read).unwrap();
+        },
+        Duration::from_secs(1),
+    )
+    .await;
+    let error = match result {
+        Ok(_) => panic!("unacknowledged start should time out"),
+        Err(error) => error,
+    };
+
+    assert_request_timeout(
+        &error,
+        RequestTimeoutStage::AwaitingTerminalResponse,
+        START_ACK_TEST_TIMEOUT,
+    );
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/exec_operation/supervised/timeout.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/timeout.rs
@@ -1,7 +1,9 @@
 use std::io;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
+use nix::sys::socket::{setsockopt, sockopt};
 use tokio::io::AsyncWriteExt;
 use vsock_proto::{
     ExecTermination, MSG_EXEC_CANCEL, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
@@ -9,17 +11,30 @@ use vsock_proto::{
 };
 
 use super::super::super::support::{
-    assert_connection_accepts_exec_operation, is_connected, normal_operation_readiness,
-    operation_count, read_guest_message, send_discarded_exec_result, send_exec_started,
-    setup_host_and_guest, wait_for_operation_count,
+    assert_connection_accepts_exec_operation, host_from_stream, is_connected, make_pair,
+    mock_handshake, normal_operation_readiness, operation_count, read_guest_message,
+    send_discarded_exec_result, send_exec_started, setup_host_and_guest, wait_for_operation_count,
 };
 use super::support::supervised_request;
 use crate::exec_operation as exec_operation_impl;
 use crate::operation_tracker::NormalOperationReadiness;
-use crate::{SupervisedExecControl, SupervisedExecRequest};
+use crate::{
+    FrameWriteObserver, RequestTimeoutError, RequestTimeoutStage, SupervisedExecControl,
+    SupervisedExecRequest,
+};
 
 const START_ACK_TEST_TIMEOUT: Duration = Duration::from_millis(50);
 const AGENT_READY_TEST_TIMEOUT: Duration = Duration::from_millis(200);
+
+fn assert_request_timeout(error: &io::Error, stage: RequestTimeoutStage, timeout: Duration) {
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    let timeout_error = error
+        .get_ref()
+        .and_then(|source| source.downcast_ref::<RequestTimeoutError>())
+        .expect("timeout should expose its request stage");
+    assert_eq!(timeout_error.stage(), stage);
+    assert_eq!(timeout_error.timeout(), timeout);
+}
 
 #[tokio::test]
 async fn supervised_exec_terminal_wait_timeout_does_not_send_cancel() {
@@ -65,7 +80,11 @@ async fn supervised_exec_start_ack_timeout_sends_cancel() {
         Ok(_) => panic!("supervised exec should time out before exec_started"),
         Err(err) => err,
     };
-    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_request_timeout(
+        &err,
+        RequestTimeoutStage::AwaitingTerminalResponse,
+        START_ACK_TEST_TIMEOUT,
+    );
     assert_eq!(operation_count(&host), 0);
 
     let start = read_guest_message(&mut guest).await;
@@ -111,7 +130,11 @@ async fn supervised_agent_ready_timeout_after_started_sends_cancel() {
         Ok(_) => panic!("Agent start should time out before exec_agent_ready"),
         Err(err) => err,
     };
-    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    assert_request_timeout(
+        &err,
+        RequestTimeoutStage::AwaitingTerminalResponse,
+        AGENT_READY_TEST_TIMEOUT,
+    );
     assert_eq!(operation_count(&host), 0);
     let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
@@ -143,8 +166,11 @@ async fn supervised_exec_start_timeout_before_write_preserves_connection() {
         Ok(_) => panic!("supervised exec should time out while waiting for the writer"),
         Err(err) => err,
     };
-    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
-    assert_eq!(err.to_string(), "exec start timeout");
+    assert_request_timeout(
+        &err,
+        RequestTimeoutStage::BeforeFrameWrite,
+        START_ACK_TEST_TIMEOUT,
+    );
     assert_eq!(operation_count(&host), 0);
     assert_eq!(
         normal_operation_readiness(&host),
@@ -165,6 +191,66 @@ async fn supervised_exec_start_timeout_before_write_preserves_connection() {
         Err(err) => panic!("unexpected read error after releasing the writer: {err}"),
     }
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn supervised_exec_start_timeout_during_write_reports_frame_write() {
+    let (host_stream, mut guest) = make_pair();
+    setsockopt(&host_stream, sockopt::SndBuf, &4096usize).unwrap();
+    let host_task = tokio::spawn(async move { host_from_stream(host_stream).await.unwrap() });
+    mock_handshake(&mut guest).await;
+    let host = Arc::new(host_task.await.unwrap());
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        let stdin_bytes = vec![0xA5; vsock_proto::MAX_EXEC_STDIN_BYTES];
+        tokio::spawn(async move {
+            exec_operation_impl::test_support::start_supervised_exec_with_write_observer(
+                &host.shared,
+                SupervisedExecRequest {
+                    stdin_bytes: Some(&stdin_bytes),
+                    start_timeout: START_ACK_TEST_TIMEOUT,
+                    ..supervised_request("blocked-start-write")
+                },
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while write_start_count.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("supervised start should reach the frame write boundary");
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("blocked supervised start write should respect its deadline")
+        .unwrap();
+    let error = match result {
+        Ok(_) => panic!("blocked supervised start write should time out"),
+        Err(error) => error,
+    };
+    assert_request_timeout(
+        &error,
+        RequestTimeoutStage::FrameWrite,
+        START_ACK_TEST_TIMEOUT,
+    );
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert!(!is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
 }
 
 #[tokio::test]
@@ -207,10 +293,10 @@ async fn supervised_exec_start_timeout_is_not_restarted_after_write() {
         Ok(_) => panic!("elapsed start deadline must win before a late acknowledgement"),
         Err(err) => err,
     };
-    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
-    assert_eq!(
-        err.to_string(),
-        "supervised exec start acknowledgement timeout"
+    assert_request_timeout(
+        &err,
+        RequestTimeoutStage::AwaitingTerminalResponse,
+        START_ACK_TEST_TIMEOUT,
     );
     let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
@@ -398,10 +484,10 @@ async fn supervised_exec_start_ack_timeout_cancel_write_is_bounded() {
         Ok(_) => panic!("supervised exec should fail when start-timeout cancel write is blocked"),
         Err(err) => err,
     };
-    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
-    assert_eq!(
-        err.to_string(),
-        "supervised exec start timeout cancel write timed out"
+    assert_request_timeout(
+        &err,
+        RequestTimeoutStage::AwaitingTerminalResponse,
+        START_ACK_TEST_TIMEOUT,
     );
     assert_eq!(operation_count(&host), 0);
     host.wait_until_closed(Duration::from_secs(5))

--- a/crates/vsock-host/src/tests/exec_operation/supervised/validation.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/validation.rs
@@ -116,7 +116,7 @@ async fn supervised_exec_zero_start_timeout_does_not_send_frame() {
             ..supervised_request("zero-start-timeout")
         },
         io::ErrorKind::TimedOut,
-        "exec start timeout",
+        "request timeout",
     )
     .await;
 }


### PR DESCRIPTION
## Summary

- move the Codex model-catalog prefetch start deadline into the supervised sandbox process-start contract
- preserve typed timeout stages so pre-write timeouts remain best-effort while partial/post-write timeouts retire the unsafe sandbox
- replace a retired fresh sandbox once with prefetch disabled, while preserving guest-state restore and consumed workspace-cache fallback behavior

## Scope

- keeps the existing one-second prefetch start budget
- adds no sandbox creation or workspace image copy to the successful startup path
- does not change the guest wire protocol or broaden replacement to unrelated process-start failures

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo check --manifest-path crates/Cargo.toml --profile local -p sandbox -p sandbox-mock -p vsock-host -p sandbox-fc -p runner --all-targets --all-features`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p sandbox -p sandbox-mock -p vsock-host -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml --profile local -p sandbox -p sandbox-mock -p vsock-host -p sandbox-fc -p runner --all-features --no-deps`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p runner -p sandbox --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p sandbox-fc --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p sandbox-mock -p vsock-host --all-targets --all-features`

Closes #32219
