### PR TITLE
perf: run type checks with two checkers

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -443,6 +443,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
+    env:
+      TSC_CHECKERS: "2"
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260825
     steps:
@@ -500,6 +502,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: needs.detect-turbo-ts-checks.outputs.turbo-ts-checks-needed == 'true'
+    env:
+      TSC_CHECKERS: "2"
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260825
     steps:

--- a/docs/testing/api-testing.md
+++ b/docs/testing/api-testing.md
@@ -190,12 +190,14 @@ scripts under `scripts/`) resolve `typescript` to the `@typescript/typescript6`
 compatibility package, which ships the 6.0 API and a `tsc6` binary. Do not
 import from `@typescript/native`; it has no API until TypeScript 7.1.
 
-The API `core` and `tests` programs pass `--checkers $(node
-../../scripts/tsc-checkers.mjs)`: one checker per 4 GiB of RAM, capped by the
-CPU count and by 4, so a 2 vCPU / 4 GiB sandbox runs one checker (peak RSS
-≈ 3 GiB) and a 4 vCPU / 16 GiB CI runner runs four. Set `TSC_CHECKERS` to
-override it. On macOS with a hard-linked pnpm store, run `tsc` with
-`--singleThreaded` until the next TypeScript 7 stable includes the
-parallel-loading realpath fix (typescript-go #4262).
+Every native `tsc` invocation in the API and app type-check scripts passes
+`--checkers $(node ../../scripts/tsc-checkers.mjs)`. By default, the helper uses
+one checker per 4 GiB of RAM, capped by the CPU count and by 4, so a 2 vCPU /
+4 GiB sandbox runs one checker. The GitHub `lint-type-app` and `lint-type-api`
+jobs and the Lefthook type check set `TSC_CHECKERS=2` to reduce peak memory
+while retaining parallel checking. Set `TSC_CHECKERS` explicitly to override
+the machine-sized default for other runs. On macOS with a hard-linked pnpm
+store, run `tsc` with `--singleThreaded` until the next TypeScript 7 stable
+includes the parallel-loading realpath fix (typescript-go #4262).
 
 Run one Vitest process at a time.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -34,10 +34,10 @@ pre-commit:
             fail_text: "Knip found unused code. Run 'cd turbo && pnpm knip' to see details."
             timeout: "60s"
           - name: check-types
-            run: pnpm check-types
+            run: TSC_CHECKERS=2 pnpm check-types
             root: turbo/
             glob: "turbo/**/*.{ts,tsx}"
-            fail_text: "TypeScript errors found. Run 'cd turbo && pnpm check-types' to see details."
+            fail_text: "TypeScript errors found. Run 'cd turbo && TSC_CHECKERS=2 pnpm check-types' to see details."
             timeout: "300s"
     - name: crates
       group:

--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -15,11 +15,11 @@
     "check-types": "pnpm run check-types:deps && pnpm run check-types:boundaries && pnpm run check-types:gateways && pnpm run check-types:core && pnpm run check-types:bootstrap && pnpm run check-types:tests && pnpm run check-types:bootstrap-wiring",
     "check-types:deps": "pnpm --filter @okouai/pi-agent-runtime run build",
     "check-types:boundaries": "node scripts/check-typecheck-boundaries.mjs",
-    "check-types:gateways": "tsc -p tsconfig.gateways.json",
+    "check-types:gateways": "tsc -p tsconfig.gateways.json --checkers $(node ../../scripts/tsc-checkers.mjs)",
     "check-types:core": "tsc -p tsconfig.core.json --checkers $(node ../../scripts/tsc-checkers.mjs)",
-    "check-types:bootstrap": "tsc -p tsconfig.bootstrap.json",
+    "check-types:bootstrap": "tsc -p tsconfig.bootstrap.json --checkers $(node ../../scripts/tsc-checkers.mjs)",
     "check-types:tests": "tsc -p tsconfig.tests.json --noEmit --checkers $(node ../../scripts/tsc-checkers.mjs)",
-    "check-types:bootstrap-wiring": "tsc -p tsconfig.bootstrap-wiring.json --noEmit"
+    "check-types:bootstrap-wiring": "tsc -p tsconfig.bootstrap-wiring.json --noEmit --checkers $(node ../../scripts/tsc-checkers.mjs)"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.1121.0",

--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -18,7 +18,7 @@
     "lint:localized-ui": "node --test scripts/check-localized-ui.node.mjs && node scripts/check-localized-ui.mjs",
     "lint:static-assets": "node scripts/check-static-assets.mjs",
     "lint": "pnpm lint:static-assets && pnpm lint:emoji-data && pnpm lint:localized-ui && pnpm lint:build-config && pnpm lint:i18n && oxlint --deny-warnings && oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings && eslint . --max-warnings 0 --cache --cache-strategy content --cache-location .eslintcache",
-    "check-types": "tsc -p tsconfig.production.json --noEmit && tsc -p tsconfig.tests.json --noEmit && tsc -p tsconfig.build-config.json --noEmit"
+    "check-types": "tsc -p tsconfig.production.json --noEmit --checkers $(node ../../scripts/tsc-checkers.mjs) && tsc -p tsconfig.tests.json --noEmit --checkers $(node ../../scripts/tsc-checkers.mjs) && tsc -p tsconfig.build-config.json --noEmit --checkers $(node ../../scripts/tsc-checkers.mjs)"
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.8.1",


### PR DESCRIPTION
## Summary

- pin the `lint-type-app` and `lint-type-api` GitHub Actions jobs to two TypeScript 7 checker workers
- run the Lefthook type check with the same two-checker override
- route every native `tsc` invocation in the app and API type-check scripts through the existing checker helper
- preserve the machine-sized default for direct runs that do not set `TSC_CHECKERS`

## Rationale

The app measurements on the TypeScript 7 migration showed that two checkers matched or slightly improved four-checker wall time while lowering peak RSS by roughly 400-800 MiB. The API did not have a same-runner two-checker data point, so its existing CI memory summary remains the authoritative measurement after this change.

## Verification

- `pnpm dlx prettier@3.6.2 --check .github/workflows/turbo.yml lefthook.yml turbo/apps/api/package.json turbo/apps/platform/package.json`
- `GOMAXPROCS=1 go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/turbo.yml`
- `pnpm dlx lefthook@2.1.12 validate`
- `TSC_CHECKERS=2 node turbo/scripts/tsc-checkers.mjs` (prints `2`)
- static invariant check: all five API and all three app native `tsc` invocations use `tsc-checkers.mjs`
- commit title validated with `@commitlint/cli@20.5.0`
- `git diff --check`

The full app and API type checks were not run in the 3.8 GiB local sandbox because these are the memory-heavy programs being changed. The PR's `lint-type-app` and `lint-type-api` jobs provide the complete validation and before/after memory summaries.
