### PR TITLE
fix(video): reject conflicting byteplus frame and reference inputs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -584,6 +584,97 @@ describe("POST /api/video-io/generate", () => {
     expect(calledBytePlus).toBeFalsy();
   });
 
+  it.each([
+    {
+      firstFrameImageUrl: "https://example.com/first.png",
+      imageUrls: ["https://example.com/reference.png"],
+    },
+    {
+      firstFrameImageUrl: "https://example.com/first.png",
+      videoUrls: ["https://example.com/reference.mp4"],
+    },
+    {
+      firstFrameImageUrl: "https://example.com/first.png",
+      audioUrls: ["https://example.com/reference.mp3"],
+    },
+    {
+      lastFrameImageUrl: "https://example.com/last.png",
+      imageUrls: ["https://example.com/reference.png"],
+    },
+    {
+      lastFrameImageUrl: "https://example.com/last.png",
+      videoUrls: ["https://example.com/reference.mp4"],
+    },
+    {
+      lastFrameImageUrl: "https://example.com/last.png",
+      audioUrls: ["https://example.com/reference.mp3"],
+    },
+    {
+      first_frame_image_url: " https://example.com/first.png ",
+      reference_video_urls: ["https://example.com/reference.mp4"],
+    },
+    {
+      model: "dreamina-seedance-2.5",
+      firstFrameImageUrl: "https://example.com/first.png",
+      lastFrameImageUrl: "https://example.com/last.png",
+      imageUrls: ["https://example.com/reference.png"],
+      videoUrls: ["https://example.com/reference.mp4"],
+      audioUrls: ["https://example.com/reference.mp3"],
+    },
+    {
+      model: "dreamina-seedance-2.0-fast",
+      firstFrameImageUrl: "https://example.com/first.png",
+      imageUrls: ["https://example.com/reference.png"],
+    },
+    {
+      model: "dreamina-seedance-2.0-mini",
+      firstFrameImageUrl: "https://example.com/first.png",
+      imageUrls: ["https://example.com/reference.png"],
+    },
+    {
+      model: "seedance-1.5-pro",
+      firstFrameImageUrl: "https://example.com/first.png",
+      imageUrls: ["https://example.com/reference.png"],
+    },
+  ])(
+    "rejects conflicting BytePlus frame and reference inputs %# before starting a job",
+    async (inputs) => {
+      const fixture = await seedVideoFixture({ credits: 0 });
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+      let calledBytePlus = false;
+      server.use(
+        http.post(BYTEPLUS_VIDEO_TASKS_URL, () => {
+          calledBytePlus = true;
+          return HttpResponse.json({ id: "unexpected-byteplus-task" });
+        }),
+      );
+
+      const app = createVideoIoTestApp(fixture.pricingResolution);
+      const response = await app.request("/api/video-io/generate", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          prompt: "animate the supplied media",
+          ...inputs,
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({
+        error: {
+          code: "BAD_REQUEST",
+          message:
+            "BytePlus frame images and reference media cannot be combined. Choose either first/last frames or reference images, videos, and audio.",
+        },
+      });
+      expect(calledBytePlus).toBeFalsy();
+      expect(context.mocks.ably.createTokenRequest).not.toHaveBeenCalled();
+      expect(context.mocks.ably.publish).not.toHaveBeenCalled();
+      expect(context.mocks.s3.send).not.toHaveBeenCalled();
+      await expect(orgCredits(fixture)).resolves.toBe(0);
+    },
+  );
+
   it("returns 402 when the org has no spendable credits", async () => {
     const fixture = await seedVideoFixture({ credits: 0 });
     mocks.clerk.session(fixture.userId, fixture.orgId);
@@ -1757,16 +1848,74 @@ describe("POST /api/video-io/generate", () => {
     expect(asRecord(content[1]).role).toBeUndefined();
   });
 
+  it("submits Dreamina first and last frames without reference media", async () => {
+    const fixture = await seedVideoFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const firstFrame = ownedArtifactReference(fixture.userId, "first.png");
+    const lastFrame = ownedArtifactReference(fixture.userId, "last.png");
+    let observedBody: unknown = null;
+    server.use(
+      http.post(BYTEPLUS_VIDEO_TASKS_URL, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({
+          id: "dreamina-frame-task",
+          status: "queued",
+        });
+      }),
+    );
+
+    const response = await createVideoIoTestApp(
+      fixture.pricingResolution,
+    ).request("/api/video-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "animate between the opening and closing frames",
+        firstFrameImageUrl: firstFrame.url,
+        lastFrameImageUrl: lastFrame.url,
+        imageUrls: [],
+        videoUrls: [],
+        audioUrls: [],
+        generateAudio: true,
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    expect(observedBody).toMatchObject({
+      generate_audio: true,
+      content: [
+        {
+          type: "text",
+          text: "animate between the opening and closing frames",
+        },
+        {
+          type: "image_url",
+          image_url: { url: expect.any(String) },
+          role: "first_frame",
+        },
+        {
+          type: "image_url",
+          image_url: { url: expect.any(String) },
+          role: "last_frame",
+        },
+      ],
+    });
+    const content = asRecord(observedBody).content;
+    if (!Array.isArray(content)) {
+      throw new Error("Expected BytePlus content array");
+    }
+    expectPresignedArtifactReference(
+      asRecord(asRecord(content[1]).image_url).url,
+      firstFrame.key,
+    );
+    expectPresignedArtifactReference(
+      asRecord(asRecord(content[2]).image_url).url,
+      lastFrame.key,
+    );
+  });
+
   it("submits multimodal Dreamina references and charges with-video pricing", async () => {
     const fixture = await seedVideoFixture({ credits: 10_000 });
-    const firstFrameReference = ownedArtifactReference(
-      fixture.userId,
-      "first.png",
-    );
-    const lastFrameReference = ownedArtifactReference(
-      fixture.userId,
-      "last.png",
-    );
     const imageReference = ownedArtifactReference(
       fixture.userId,
       "reference.png",
@@ -1829,8 +1978,6 @@ describe("POST /api/video-io/generate", () => {
         imageUrls: [imageReference.url],
         videoUrls: [videoReference.url],
         audioUrls: [audioReference.url],
-        firstFrameImageUrl: firstFrameReference.url,
-        lastFrameImageUrl: lastFrameReference.url,
         seed: 42,
       }),
     });
@@ -1873,16 +2020,6 @@ describe("POST /api/video-io/generate", () => {
         {
           type: "image_url",
           image_url: { url: expect.any(String) },
-          role: "first_frame",
-        },
-        {
-          type: "image_url",
-          image_url: { url: expect.any(String) },
-          role: "last_frame",
-        },
-        {
-          type: "image_url",
-          image_url: { url: expect.any(String) },
           role: "reference_image",
         },
         {
@@ -1903,22 +2040,14 @@ describe("POST /api/video-io/generate", () => {
     }
     expectPresignedArtifactReference(
       asRecord(asRecord(providerContent[1]).image_url).url,
-      firstFrameReference.key,
-    );
-    expectPresignedArtifactReference(
-      asRecord(asRecord(providerContent[2]).image_url).url,
-      lastFrameReference.key,
-    );
-    expectPresignedArtifactReference(
-      asRecord(asRecord(providerContent[3]).image_url).url,
       imageReference.key,
     );
     expectPresignedArtifactReference(
-      asRecord(asRecord(providerContent[4]).video_url).url,
+      asRecord(asRecord(providerContent[2]).video_url).url,
       videoReference.key,
     );
     expectPresignedArtifactReference(
-      asRecord(asRecord(providerContent[5]).audio_url).url,
+      asRecord(asRecord(providerContent[3]).audio_url).url,
       audioReference.key,
     );
 

--- a/turbo/apps/api/src/signals/routes/video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/video-io-generate.ts
@@ -21,6 +21,7 @@ import { publicBrand$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import { env } from "../../lib/env";
+import { badRequestMessage } from "../../lib/error";
 import { db$, type ReadonlyDb } from "../external/db";
 import { createBuiltInGenerationRealtimeSubscription } from "../external/realtime";
 import {
@@ -446,6 +447,25 @@ const submitVideoProviderWebhookJob$ = command(
   },
 );
 
+function parseVideoSubmissionOptions(body: VideoIoGenerateRequest) {
+  const options = parseVideoOptions(body);
+  if ("status" in options) {
+    return options;
+  }
+  if (
+    videoProviderForModel(options.model) === "byteplus" &&
+    (options.firstFrameImageUrl || options.lastFrameImageUrl) &&
+    (options.referenceImageUrls.length > 0 ||
+      options.inputVideoUrls.length > 0 ||
+      options.referenceAudioUrls.length > 0)
+  ) {
+    return badRequestMessage(
+      "BytePlus frame images and reference media cannot be combined. Choose either first/last frames or reference images, videos, and audio.",
+    );
+  }
+  return options;
+}
+
 const postVideoInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
   const db = get(db$);
@@ -470,7 +490,7 @@ const postVideoInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   // The run's model is a default, not an override: it applies only when the
   // request names no model of its own. A caller that asks for a specific model
   // — because the user asked for it in the prompt — gets that model.
-  const options = parseVideoOptions(
+  const options = parseVideoSubmissionOptions(
     runVideoModel === null || namesVideoModel(bodyResult.data)
       ? bodyResult.data
       : withDefaultRunVideoModel(bodyResult.data, runVideoModel),

--- a/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
+++ b/turbo/apps/cli/src/commands/generate/__tests__/video.test.ts
@@ -16,7 +16,6 @@ import { videoCommand } from "../video";
 
 const VIDEO_URL = "http://localhost:3000/api/video-io/generate";
 const FIRST_FRAME_URL = "https://example.com/first.png";
-const LAST_FRAME_URL = "https://example.com/last.png";
 const VIDEO_RESULT = {
   id: "video-file-id",
   filename: "video-video-fi.mp4",
@@ -185,12 +184,6 @@ describe("okou generate video command", () => {
   it("should generate a video and print the /f file URL", async () => {
     server.use(
       stubBillingStatus(true),
-      http.get(FIRST_FRAME_URL, () => {
-        return imageResponse(900, 1600);
-      }),
-      http.get(LAST_FRAME_URL, () => {
-        return imageResponse(900, 1600);
-      }),
       http.post(VIDEO_URL, async ({ request }) => {
         expect(request.headers.get("authorization")).toBe("Bearer test-token");
         expect(request.headers.get("content-type")).toBe("application/json");
@@ -207,8 +200,6 @@ describe("okou generate video command", () => {
           imageUrls: ["https://example.com/reference.png"],
           videoUrls: ["https://example.com/reference.mp4"],
           audioUrls: ["https://example.com/reference.mp3"],
-          firstFrameImageUrl: FIRST_FRAME_URL,
-          lastFrameImageUrl: LAST_FRAME_URL,
         });
 
         return HttpResponse.json(VIDEO_RESULT);
@@ -241,10 +232,6 @@ describe("okou generate video command", () => {
       "https://example.com/reference.mp4",
       "--audio-url",
       "https://example.com/reference.mp3",
-      "--first-frame-image-url",
-      FIRST_FRAME_URL,
-      "--last-frame-image-url",
-      LAST_FRAME_URL,
     ]);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
@@ -416,6 +403,10 @@ describe("okou generate video command", () => {
     expect(helpOutput).toContain("--first-frame-image-url");
     expect(helpOutput).toContain("--last-frame-image-url");
     expect(helpOutput).toContain("--json");
+    expect(helpOutput).toContain(
+      "first/last frame inputs cannot be combined with",
+    );
+    expect(helpOutput).toContain("Choose one input mode before generating.");
     expect(helpOutput).toContain("Provider: 'built-in' to run Okou's pipeline");
   });
 

--- a/turbo/apps/cli/src/commands/shared/video-generate.ts
+++ b/turbo/apps/cli/src/commands/shared/video-generate.ts
@@ -456,11 +456,13 @@ Notes:
   - Charges org credits after successful video generation
   - Uses MiniMax, BytePlus ModelArk, and fal.ai video models with configured usage pricing
   - Omitting --model generates with ${DEFAULT_VIDEO_MODEL_ALIAS}
+  - BytePlus/Seedance: first/last frame inputs cannot be combined with
+    reference image/video/audio inputs. Choose one input mode before generating.
 
 Models:
   - Dreamina Seedance 2.5: dreamina-seedance-2.5. Supports 4s-30s,
     480p/720p/1080p, optional audio, up to 30 image references, and up to
-    10 video and 10 audio references, plus first/last frames.
+    10 video and 10 audio references, or first/last frames.
   - Dreamina Seedance 2.0: dreamina-seedance-2.0,
     dreamina-seedance-2.0-fast, dreamina-seedance-2.0-mini.
     Supports 4s-15s,


### PR DESCRIPTION
BytePlus rejects requests that combine first/last-frame images with reference images, videos, or audio. Validate this combination after model and input normalization, returning HTTP 400 with the existing `BAD_REQUEST` code and guidance to choose one input mode, before credit checks, admission, job creation, or provider dispatch.

CLI help now states the same restriction and describes Seedance 2.5 frames as an alternative to reference media. Validation is limited to new submissions so completion callbacks can still parse previously saved jobs. Regression coverage includes frame/reference combinations, aliases, BytePlus model variants, zero-credit rejection without external side effects, and valid frame-only and reference-only requests.

Fixes #32126.
Related Gen Skill guidance: https://github.com/vm0-ai/vm0-skills/pull/336.

## Validation

- API video route integration tests: 44 passed (`pnpm --filter api exec vitest run src/signals/routes/__tests__/video-io-generate.test.ts --maxWorkers=1`), using a dedicated local PostgreSQL database and mocked providers.
- CLI video integration tests: 13 passed (`pnpm --filter @okouai/cli exec vitest run src/commands/generate/__tests__/video.test.ts`).
- API and CLI workspace type checks and Knip passed; changed-file Oxlint, type-aware Oxlint, ESLint, Prettier, and `git diff --check` passed.

No full Vitest suite, local app dev server, or real media generation was run.
