### PR TITLE
docs(guest-write-file): correct private-mode usage syntax

### DIFF
--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -16,7 +16,12 @@ struct Args {
     path: Option<PathBuf>,
 }
 
-const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path> | guest-write-file --batch [--private]";
+const USAGE: &str = concat!(
+    "usage: guest-write-file [--append] [--] <path>\n",
+    "       guest-write-file --create-parents [--] <path>\n",
+    "       guest-write-file --private [--append] [--] <path>\n",
+    "       guest-write-file --batch [--private]",
+);
 
 fn parse_args<I>(args: I) -> Result<Args, String>
 where
@@ -237,7 +242,9 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 /// matching `std::env::args().skip(1)`. The accepted syntax is:
 ///
 /// ```text
-/// guest-write-file [--private] [--append | --create-parents] [--] <path>
+/// guest-write-file [--append] [--] <path>
+/// guest-write-file --create-parents [--] <path>
+/// guest-write-file --private [--append] [--] <path>
 /// guest-write-file --batch [--private]
 /// ```
 ///
@@ -251,6 +258,10 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 /// private file helpers, ensuring parent directories are private, creating
 /// missing parent directories even with `--append`, and rejecting symlinked
 /// parent components.
+/// `--append` and `--create-parents` cannot be used together. `--private` and
+/// `--create-parents` cannot be used together because private mode already
+/// creates missing parent directories, including when combined with
+/// `--append`.
 ///
 /// `--batch` reads a `vsock-proto` `write_files` payload from stdin and writes
 /// every entry with create-parent and truncate semantics. Combined with

--- a/crates/guest-write-file/src/main.rs
+++ b/crates/guest-write-file/src/main.rs
@@ -3,7 +3,9 @@
 //! Accepted syntax:
 //!
 //! ```text
-//! guest-write-file [--private] [--append | --create-parents] [--] <path>
+//! guest-write-file [--append] [--] <path>
+//! guest-write-file --create-parents [--] <path>
+//! guest-write-file --private [--append] [--] <path>
 //! guest-write-file --batch [--private]
 //! ```
 //!
@@ -14,6 +16,9 @@
 //! Private mode writes through the guest runtime private file helpers, ensuring
 //! parent directories are private, creating missing parent directories even
 //! with append mode, and rejecting symlinked parent components.
+//! `--append` and `--create-parents` cannot be combined. `--private` and
+//! `--create-parents` cannot be combined; private mode creates missing parent
+//! directories, including when used with `--append`.
 //! Batch mode reads a `vsock-proto` `write_files` payload from stdin and writes
 //! every entry with create-parent and truncate semantics. Private batch mode
 //! applies private runtime-file semantics to every entry.

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -7,7 +7,12 @@ use std::sync::mpsc::{self, Receiver};
 use std::time::{Duration, Instant};
 
 const BIN: &str = env!("CARGO_BIN_EXE_guest-write-file");
-const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path> | guest-write-file --batch [--private]";
+const USAGE: &str = concat!(
+    "usage: guest-write-file [--append] [--] <path>\n",
+    "       guest-write-file --create-parents [--] <path>\n",
+    "       guest-write-file --private [--append] [--] <path>\n",
+    "       guest-write-file --batch [--private]",
+);
 const HELPER_KILL_TIMEOUT: Duration = Duration::from_secs(1);
 const CHILD_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(1);
 


### PR DESCRIPTION
## Summary

- Correct the `guest-write-file` diagnostic usage text to show only valid option combinations.
- Align the public `run_cli` and binary documentation with the existing parser behavior.
- Synchronize the integration-test usage expectation while preserving the existing rejection coverage.

## Scope

This is a documentation-only change. It does not modify argument validation, runtime file operations, vsock caller behavior, protocols, or persisted state.

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo test --locked --profile local -p guest-write-file --test integration private_mode_rejects_create_parents -- --exact`
- `cd crates && cargo test --locked --profile local -p guest-write-file`
- `cd crates && cargo clippy --locked --profile local --all-targets --all-features`
- `cd crates && cargo doc --locked --profile local --workspace --all-features --no-deps`

Closes #32279
