### PR TITLE
feat(voice): allow 60-minute voice input recordings

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts
@@ -630,6 +630,41 @@ function segmentForm(
 }
 
 describe("POST /api/voice-io/transcribe/segment", () => {
+  it("accepts the 60-minute recording boundary and rejects longer recordings", async () => {
+    mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    await enabledActor();
+    server.use(
+      http.post(OPENROUTER_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  transcript: "Recorded speech.",
+                  language: "en",
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+    const headers = { authorization: "Bearer clerk-session" };
+    await accept(
+      client().segment({
+        headers,
+        body: segmentForm([audioFile(1)], "", false, 60 * 60),
+      }),
+      [200],
+    );
+    const tooLong = await client().segment({
+      headers,
+      body: segmentForm([audioFile(2)], "", false, 60 * 60 + 1),
+    });
+    expect(tooLong.status).toBe(400);
+  });
+
   it.each(["openai/gpt-audio", "openai/gpt-audio-mini"] as const)(
     "finishes a saved transcript with a text-capable model when %s has no remaining audio",
     async (model) => {

--- a/turbo/packages/api-contracts/src/contracts/voice-io-transcribe.ts
+++ b/turbo/packages/api-contracts/src/contracts/voice-io-transcribe.ts
@@ -10,12 +10,16 @@ const c = initContract();
 export const VOICE_IO_TRANSCRIBE_MAX_CONTEXT_CHARS = 8_000;
 export const VOICE_IO_TRANSCRIBE_MAX_EDITOR_CONTEXT_CHARS = 1_000;
 export const VOICE_IO_TRANSCRIBE_MAX_SEGMENT_SECONDS = 75;
+const VOICE_IO_TRANSCRIBE_MAX_RECORDING_SECONDS = 60 * 60;
 
 export const voiceIoTranscribeSegmentOptionsSchema = z.object({
   previousTranscript: z.string().max(VOICE_IO_POLISH_MAX_TEXT_CHARS),
   final: z.boolean(),
   overlapDurationSeconds: z.number().min(0).max(2).default(0),
-  totalDurationSeconds: z.number().nonnegative().max(300),
+  totalDurationSeconds: z
+    .number()
+    .nonnegative()
+    .max(VOICE_IO_TRANSCRIBE_MAX_RECORDING_SECONDS),
 });
 
 export type VoiceIoTranscribeSegmentOptions = z.infer<


### PR DESCRIPTION
## Summary

- raise the Voice Input V2 total recording limit from 5 minutes to 60 minutes
- keep the existing 75-second segment, 2-second overlap, plan quota, and Voice Input V1 limits unchanged
- cover the exact 3,600-second boundary and rejection beyond it through the segment API

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/voice-io-transcribe.test.ts --maxWorkers=2` (38 passed)
- `pnpm exec prettier --check packages/api-contracts/src/contracts/voice-io-transcribe.ts apps/api/src/signals/routes/__tests__/voice-io-transcribe.test.ts`
- `pnpm -F @okouai/api-contracts lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api lint`
- `pnpm -F @okouai/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=3072 TSC_CHECKERS=1 pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm exec knip --workspace api --workspace @okouai/api-contracts --no-progress`

No full local Vitest suite or local development server was run.
