### PR TITLE
refactor: resolve connector diagnostics from active runtime state

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
@@ -21,6 +21,7 @@ import {
   manualHttpCustomConnectorCreateBody,
 } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
+import { createFirewallApi } from "./helpers/api-bdd-firewall";
 import {
   seedConnectorStorageRow,
   setConnectorDefaultState,
@@ -51,7 +52,11 @@ const store = createStore();
 
 interface ConnectedFixture {
   readonly actor: ApiTestUser;
-  readonly connectorSlug: "github" | "reap" | "removed-connector";
+  readonly connectorSlug:
+    | "cloudflare"
+    | "github"
+    | "reap"
+    | "removed-connector";
 }
 
 const trackConnectedFixture = createFixtureTracker<ConnectedFixture>(
@@ -725,8 +730,18 @@ describe("POST /api/connectors/diagnostics/check", () => {
       const runBase = "https://prod.api.reap.global/v1";
       const changedBase = "https://changed.api.reap.global/v1";
       const connectorId = await connectReap(owner, runBase);
+      const firewallApi = createFirewallApi(context);
+      await firewallApi.provisionRunReadyOrg(owner);
+      await firewallApi.seedTestConnector(owner, {
+        connectorSlug: "cloudflare",
+        authMethod: "oauth",
+        accessToken: "cloudflare-test-access-token",
+      });
+      await trackConnectedFixture(
+        Promise.resolve({ actor: owner, connectorSlug: "cloudflare" }),
+      );
       const { runId, agentId } = await createOwnedRun(owner, {
-        builtinConnectorSlugs: ["reap"],
+        builtinConnectorSlugs: ["reap", "cloudflare"],
       });
       const request = {
         mode: "url" as const,
@@ -766,37 +781,46 @@ describe("POST /api/connectors/diagnostics/check", () => {
 
       await runsApi.applyUserPermissionGrant(owner, {
         agentId,
-        connectorSlug: "reap",
-        permission: "read",
+        connectorSlug: "cloudflare",
+        permission: "dns-firewall.write",
         action: "allow",
         expiresIn: "1h",
       });
+      const expiringRequest = {
+        mode: "url" as const,
+        method: "POST",
+        url: "https://api.cloudflare.com/client/v4/accounts/test/dns_firewall/rules",
+      };
       const allowed = await checkWithToken(
         okouToken(owner, runId, ["connector:read", "agent-run:read"]),
-        request,
+        expiringRequest,
       );
       expect(allowed.body).toMatchObject({
+        outcome: "resolved",
+        connector: { connectorSlug: "cloudflare" },
         permission: {
           permissions: [
             {
-              name: "read",
+              name: "dns-firewall.write",
               policy: { outcome: "allow", basis: "allow-list" },
             },
           ],
         },
       });
 
-      mockNow(new Date("2026-09-07T10:00:00.000Z"));
+      mockNow(new Date("2026-09-07T09:00:00.000Z"));
       const expired = await checkWithToken(
         okouToken(owner, runId, ["connector:read", "agent-run:read"]),
-        request,
+        expiringRequest,
       );
       expect(expired.body).toMatchObject({
+        outcome: "resolved",
+        connector: { connectorSlug: "cloudflare" },
         permission: {
           permissions: [
             {
-              name: "read",
-              policy: { outcome: "allow", basis: "allow-list" },
+              name: "dns-firewall.write",
+              policy: { outcome: "deny", basis: "deny-list" },
             },
           ],
         },

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
@@ -1122,11 +1122,33 @@ describe("POST /api/connectors/diagnostics/check", () => {
     expect(context.mocks.axiom.query).not.toHaveBeenCalled();
   });
 
-  it("distinguishes missing legacy registration from terminal stale state", async () => {
+  it("propagates malformed registration and distinguishes missing from terminal state", async () => {
     const actor = bdd.user();
     await seedAdminMembership(actor);
     const { runId } = await createOwnedRun(actor);
     const token = okouToken(actor, runId, ["connector:read", "agent-run:read"]);
+
+    await accept(
+      stateClient().action({
+        body: {
+          action: "corrupt-connector-diagnostic-registration",
+          run_id: runId,
+        },
+      }),
+      [200],
+    );
+    const malformed = await accept(
+      client().check({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          mode: "environment",
+          environmentName: "GH_TOKEN",
+        },
+      }),
+      [500],
+    );
+    expect(malformed.body).toStrictEqual({ error: "Internal server error" });
+
     await accept(
       stateClient().action({
         body: {

--- a/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connector-check.test.ts
@@ -2,19 +2,24 @@ import { randomUUID } from "node:crypto";
 
 import {
   type ConnectorCheckRequest,
+  type ConnectorCheckRequestBody,
   connectorCheckContract,
 } from "@okouai/api-contracts/contracts/connector-check";
+import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
 import { createStore } from "ccstate";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { accept, testContext } from "../../../__tests__/test-context";
 import { setupApp } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
-import { now } from "../../../lib/time";
+import { mockNow, now, withMockNowForTest } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createAuthDeviceApiActions } from "./helpers/api-bdd-auth-device";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
-import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
+import {
+  createConnectorBddApi,
+  manualHttpCustomConnectorCreateBody,
+} from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
 import {
   seedConnectorStorageRow,
@@ -29,8 +34,12 @@ import {
 } from "./helpers/org-membership";
 import { createFixtureTracker, createRouteMocks } from "./helpers/route-test";
 import { connectorCheckRoutes } from "../connector-check";
+import { testCronCleanupSandboxesStateRoutes } from "../test-cron-cleanup-sandboxes-state";
 
-const TEST_APP_ROUTES = Object.freeze([...connectorCheckRoutes]);
+const TEST_APP_ROUTES = Object.freeze([
+  ...connectorCheckRoutes,
+  ...testCronCleanupSandboxesStateRoutes,
+]);
 
 const context = testContext();
 const mocks = createRouteMocks(context);
@@ -60,8 +69,12 @@ const trackOrgMembershipFixture = createFixtureTracker<OrgMembershipFixture>(
 );
 
 function client() {
-  return setupApp({ context, routes: connectorCheckRoutes })(
-    connectorCheckContract,
+  return setupApp({ context, routes: TEST_APP_ROUTES })(connectorCheckContract);
+}
+
+function stateClient() {
+  return setupApp({ context, routes: TEST_APP_ROUTES })(
+    testCronCleanupSandboxesStateContract,
   );
 }
 
@@ -90,7 +103,7 @@ async function checkWithSession(
   );
 }
 
-async function checkWithToken(token: string, body: ConnectorCheckRequest) {
+async function checkWithToken(token: string, body: ConnectorCheckRequestBody) {
   return await accept(
     client().check({
       headers: { authorization: `Bearer ${token}` },
@@ -166,7 +179,13 @@ async function connectReap(
   return connector.id;
 }
 
-async function createOwnedRun(actor: ApiTestUser): Promise<string> {
+async function createOwnedRun(
+  actor: ApiTestUser,
+  options: {
+    readonly builtinConnectorSlugs?: readonly string[];
+    readonly customConnectorIds?: readonly string[];
+  } = {},
+): Promise<{ readonly runId: string; readonly agentId: string }> {
   bdd.acceptAgentStorageWrites();
   runsApi.acceptStorageDownloads();
   runsApi.acceptTelemetryIngest();
@@ -177,12 +196,26 @@ async function createOwnedRun(actor: ApiTestUser): Promise<string> {
     displayName: `Connector check ${randomUUID()}`,
     visibility: "private",
   });
+  if (options.builtinConnectorSlugs) {
+    await runsApi.enableAgentConnectors(
+      actor,
+      agent.agentId,
+      options.builtinConnectorSlugs,
+    );
+  }
+  if (options.customConnectorIds) {
+    await connectorsApi.updateAgentCustomConnectors(
+      actor,
+      agent.agentId,
+      options.customConnectorIds,
+    );
+  }
   const run = await runsApi.createRun(actor, {
     agentId: agent.agentId,
     prompt: "Create a connector check fixture",
     modelProvider: "anthropic-api-key",
   });
-  return run.runId;
+  return { runId: run.runId, agentId: agent.agentId };
 }
 
 beforeEach(() => {
@@ -194,10 +227,11 @@ beforeEach(() => {
 
 describe("POST /api/connectors/diagnostics/check", () => {
   it("requires organization auth and both agent capabilities", async () => {
+    const runBase = "https://prod.api.reap.global/v1";
     const body = {
       mode: "url" as const,
-      method: "POST",
-      url: "https://slack.com/api/chat.postMessage",
+      method: "GET",
+      url: `${runBase}/users`,
     };
     const unauthenticated = await accept(
       client().check({ headers: {}, body }),
@@ -217,7 +251,10 @@ describe("POST /api/connectors/diagnostics/check", () => {
 
     const actor = bdd.user();
     await seedAdminMembership(actor);
-    const runId = await createOwnedRun(actor);
+    await connectReap(actor, runBase);
+    const { runId } = await createOwnedRun(actor, {
+      builtinConnectorSlugs: ["reap"],
+    });
     const withoutConnectorRead = await accept(
       client().check({
         headers: {
@@ -246,23 +283,9 @@ describe("POST /api/connectors/diagnostics/check", () => {
       message: "Missing required capability: agent-run:read",
     });
 
-    context.mocks.axiom.query.mockResolvedValue([
-      {
-        runId,
-        firewalls: [{ kind: "builtin", name: "slack" }],
-        networkPolicyEntries: [
-          {
-            name: "slack",
-            policy: {
-              allow: [],
-              deny: ["chat:write"],
-              ask: [],
-              unknownPolicy: "ask",
-            },
-          },
-        ],
-      },
-    ]);
+    context.mocks.axiom.query.mockRejectedValue(
+      new Error("Axiom connector diagnostics must not be queried"),
+    );
     const allowed = await checkWithToken(
       okouToken(actor, runId, ["connector:read", "agent-run:read"]),
       body,
@@ -271,21 +294,21 @@ describe("POST /api/connectors/diagnostics/check", () => {
       outcome: "resolved",
       mode: "url",
       connector: {
-        connectorSlug: "slack",
-        label: "Slack",
+        connectorSlug: "reap",
+        label: "Reap",
       },
       run: { status: "configured" },
       permission: {
         kind: "matched",
         permissions: [
           {
-            name: "chat:write",
-            policy: { outcome: "deny", basis: "deny-list" },
+            name: "read",
+            policy: { outcome: "allow", basis: "allow-list" },
           },
         ],
       },
     });
-    expect(context.mocks.axiom.query).toHaveBeenCalledTimes(1);
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
   });
 
   it("enforces strict bodies and returns sanitized unsafe-input outcomes", async () => {
@@ -695,351 +718,462 @@ describe("POST /api/connectors/diagnostics/check", () => {
     }
   });
 
-  it("uses only an owned agent run snapshot, including dynamic bases and final policies", async () => {
-    const owner = bdd.user();
-    const runId = await createOwnedRun(owner);
-    await seedAdminMembership(owner);
-    const token = okouToken(owner, runId, ["connector:read", "agent-run:read"]);
-    const runBase = "https://prod.api.reap.global/v1";
-    const secondRunBase = "https://sandbox.api.reap.global/v1";
-    context.mocks.axiom.query.mockResolvedValue([
-      {
-        runId,
-        firewalls: [
-          {
-            kind: "builtin",
-            name: "reap",
-            baseUrlVars: { REAP_API_BASE_URL: runBase },
-          },
-          {
-            kind: "builtin",
-            name: "reap",
-            baseUrlVars: { REAP_API_BASE_URL: secondRunBase },
-          },
-        ],
-        networkPolicyEntries: [
-          {
-            name: "reap",
-            policy: {
-              allow: [],
-              deny: [],
-              ask: ["read"],
-              unknownPolicy: "deny",
+  it("uses pinned builtin registration state with current permission and account authority", async () => {
+    await withMockNowForTest(new Date("2026-09-07T08:00:00.000Z"), async () => {
+      const owner = bdd.user();
+      await seedAdminMembership(owner);
+      const runBase = "https://prod.api.reap.global/v1";
+      const changedBase = "https://changed.api.reap.global/v1";
+      const connectorId = await connectReap(owner, runBase);
+      const { runId, agentId } = await createOwnedRun(owner, {
+        builtinConnectorSlugs: ["reap"],
+      });
+      const request = {
+        mode: "url" as const,
+        method: "GET",
+        url: `${runBase}/users`,
+      };
+      context.mocks.axiom.query.mockRejectedValue(
+        new Error("Axiom connector diagnostics must not be queried"),
+      );
+
+      await runsApi.applyUserPermissionGrant(owner, {
+        agentId,
+        connectorSlug: "reap",
+        permission: "read",
+        action: "deny",
+      });
+
+      const initial = await checkWithToken(
+        okouToken(owner, runId, ["connector:read", "agent-run:read"]),
+        request,
+      );
+      expect(initial.body).toMatchObject({
+        outcome: "resolved",
+        connector: { connectorSlug: "reap" },
+        run: { status: "configured", bases: [runBase] },
+        base: runBase,
+        permission: {
+          kind: "matched",
+          permissions: [
+            {
+              name: "read",
+              policy: { outcome: "deny", basis: "deny-list" },
             },
-          },
-        ],
-      },
-    ]);
-
-    const urlResult = await checkWithToken(token, {
-      mode: "url",
-      method: "GET",
-      url: `${runBase}/users`,
-    });
-    expect(urlResult.body).toMatchObject({
-      outcome: "resolved",
-      connector: { connectorSlug: "reap" },
-      run: { status: "configured", bases: [runBase, secondRunBase] },
-      base: runBase,
-      permission: {
-        kind: "matched",
-        permissions: [
-          {
-            name: "read",
-            policy: { outcome: "ask", basis: "ask-list" },
-          },
-        ],
-      },
-    });
-
-    const environmentResult = await checkWithToken(token, {
-      mode: "environment",
-      environmentName: "REAP_API_KEY",
-      permission: "write",
-    });
-    expect(environmentResult.body).toMatchObject({
-      outcome: "resolved",
-      connector: { connectorSlug: "reap" },
-      run: { status: "configured", bases: [runBase, secondRunBase] },
-      permission: { outcome: "allow", basis: "not-blocked" },
-    });
-
-    const unknownEndpoint = await checkWithToken(token, {
-      mode: "url",
-      method: "OPTIONS",
-      url: `${runBase}/not-a-real-endpoint`,
-    });
-    expect(unknownEndpoint.body).toMatchObject({
-      outcome: "resolved",
-      connector: { connectorSlug: "reap" },
-      permission: {
-        kind: "unknown-endpoint",
-        policy: { outcome: "deny", basis: "unknown-policy" },
-      },
-    });
-
-    const notConfiguredEnvironment = await checkWithToken(token, {
-      mode: "environment",
-      environmentName: "GH_TOKEN",
-      permission: "contents:read",
-    });
-    expect(notConfiguredEnvironment.body).toMatchObject({
-      outcome: "resolved",
-      connector: { connectorSlug: "github" },
-      run: { status: "not-configured" },
-      permission: {
-        outcome: "unavailable",
-        basis: "connector-not-configured",
-      },
-    });
-
-    const globalFallbackDenied = await checkWithToken(token, {
-      mode: "url",
-      method: "GET",
-      url: "https://api.github.com/repos/vm0-ai/vm0",
-    });
-    expect(globalFallbackDenied.body).toStrictEqual({
-      outcome: "no-match",
-      scope: "run",
-    });
-
-    context.mocks.axiom.query.mockResolvedValue([
-      {
-        runId,
-        firewalls: [
-          {
-            kind: "builtin",
-            name: "reap",
-            baseUrlVars: { REAP_API_BASE_URL: "http://127.0.0.1" },
-          },
-        ],
-      },
-    ]);
-    const rejectedDynamicBase = await checkWithToken(token, {
-      mode: "url",
-      method: "GET",
-      url: "http://127.0.0.1/users",
-      connectorSlug: "reap",
-    });
-    expect(rejectedDynamicBase.body).toMatchObject({
-      outcome: "unresolved-dynamic-base",
-      connector: { connectorSlug: "reap" },
-    });
-
-    context.mocks.axiom.query.mockResolvedValue([
-      {
-        runId,
-        firewalls: [
-          {
-            kind: "builtin",
-            name: "reap",
-            baseUrlVars: { REAP_API_BASE_URL: runBase },
-          },
-        ],
-      },
-    ]);
-    const unavailablePolicies = await checkWithToken(token, {
-      mode: "environment",
-      environmentName: "REAP_API_KEY",
-      permission: "read",
-    });
-    expect(unavailablePolicies.body).toMatchObject({
-      outcome: "resolved",
-      connector: { connectorSlug: "reap" },
-      run: { status: "configured", bases: [runBase] },
-      permission: {
-        outcome: "unavailable",
-        basis: "policies-unavailable",
-      },
-    });
-
-    context.mocks.axiom.query.mockResolvedValue([]);
-    const missingSnapshot = await checkWithToken(token, {
-      mode: "environment",
-      environmentName: "REAP_API_KEY",
-    });
-    expect(missingSnapshot.body).toStrictEqual({
-      outcome: "run-context-unavailable",
-    });
-
-    const intruder = bdd.user({ orgId: requireOrgId(owner) });
-    await seedAdminMembership(intruder);
-    const wrongOwner = await accept(
-      client().check({
-        headers: {
-          authorization: `Bearer ${okouToken(intruder, runId, [
-            "connector:read",
-            "agent-run:read",
-          ])}`,
+          ],
         },
-        body: {
-          mode: "environment",
-          environmentName: "REAP_API_KEY",
+      });
+
+      await runsApi.applyUserPermissionGrant(owner, {
+        agentId,
+        connectorSlug: "reap",
+        permission: "read",
+        action: "allow",
+        expiresIn: "1h",
+      });
+      const allowed = await checkWithToken(
+        okouToken(owner, runId, ["connector:read", "agent-run:read"]),
+        request,
+      );
+      expect(allowed.body).toMatchObject({
+        permission: {
+          permissions: [
+            {
+              name: "read",
+              policy: { outcome: "allow", basis: "allow-list" },
+            },
+          ],
         },
-      }),
-      [404],
-    );
-    expect(wrongOwner.body.error).toStrictEqual({
-      code: "NOT_FOUND",
-      message: "Agent run not found",
+      });
+
+      mockNow(new Date("2026-09-07T10:00:00.000Z"));
+      const expired = await checkWithToken(
+        okouToken(owner, runId, ["connector:read", "agent-run:read"]),
+        request,
+      );
+      expect(expired.body).toMatchObject({
+        permission: {
+          permissions: [
+            {
+              name: "read",
+              policy: { outcome: "allow", basis: "allow-list" },
+            },
+          ],
+        },
+      });
+
+      await connectorsApi.connectManualGrant(
+        owner,
+        "reap",
+        "api-token",
+        {
+          apiKey: "reap-updated-api-key",
+          apiBaseUrl: changedBase,
+        },
+        undefined,
+        { intent: "reconnect", connectionId: connectorId },
+      );
+      await setConnectorDefaultState(context, {
+        orgId: requireOrgId(owner),
+        userId: owner.userId,
+        connectorId,
+        isDefault: false,
+      });
+
+      const pinned = await checkWithToken(
+        okouToken(owner, runId, ["connector:read", "agent-run:read"]),
+        request,
+      );
+      expect(pinned.body).toMatchObject({
+        outcome: "resolved",
+        base: runBase,
+        run: { status: "configured", bases: [runBase] },
+      });
+      const changed = await checkWithToken(
+        okouToken(owner, runId, ["connector:read", "agent-run:read"]),
+        { ...request, url: `${changedBase}/users` },
+      );
+      expect(changed.body).toStrictEqual({ outcome: "no-match", scope: "run" });
+
+      await setConnectorCredentialStorageState(context, {
+        connectorSlug: "reap",
+        orgId: requireOrgId(owner),
+        storageVersion: 2,
+        userId: owner.userId,
+      });
+      const unavailable = await checkWithToken(
+        okouToken(owner, runId, ["connector:read", "agent-run:read"]),
+        request,
+      );
+      expect(unavailable.body).toMatchObject({
+        outcome: "resolved",
+        connector: { connectorSlug: "reap" },
+        run: { status: "configured", bases: [runBase] },
+        permission: {
+          permissions: [
+            {
+              name: "read",
+              policy: {
+                outcome: "unavailable",
+                basis: "policies-unavailable",
+              },
+            },
+          ],
+        },
+      });
+
+      const intruder = bdd.user({ orgId: requireOrgId(owner) });
+      await seedAdminMembership(intruder);
+      const wrongOwner = await accept(
+        client().check({
+          headers: {
+            authorization: `Bearer ${okouToken(intruder, runId, [
+              "connector:read",
+              "agent-run:read",
+            ])}`,
+          },
+          body: request,
+        }),
+        [404],
+      );
+      expect(wrongOwner.body.error).toStrictEqual({
+        code: "NOT_FOUND",
+        message: "Agent run not found",
+      });
+      expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+      await setConnectorCredentialStorageState(context, {
+        connectorSlug: "reap",
+        orgId: requireOrgId(owner),
+        storageVersion: 1,
+        userId: owner.userId,
+      });
+      await setConnectorDefaultState(context, {
+        orgId: requireOrgId(owner),
+        userId: owner.userId,
+        connectorId,
+        isDefault: true,
+      });
     });
   });
 
-  it("diagnoses historical and execution inline entries without exposing their source snapshot", async () => {
+  it("keeps legacy requests builtin-only and resolves admitted custom targets on explicit requests", async () => {
     const actor = bdd.user();
-    const runId = await createOwnedRun(actor);
     await seedAdminMembership(actor);
-    const token = okouToken(actor, runId, ["connector:read", "agent-run:read"]);
-    const inlineBase = "https://legacy-github.example.com";
-    context.mocks.axiom.query.mockResolvedValue([
-      {
-        runId,
-        firewalls: [
-          {
-            name: "github",
-            apis: [
-              {
-                base: inlineBase,
-                permissions: [
-                  {
-                    name: "repository.read",
-                    rules: ["GET /repos/{owner}/{repo}"],
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            kind: "inline",
-            name: "github",
-            apis: [
-              {
-                id: "github:inline:0",
-                base: inlineBase,
-                hostPolicy: { kind: "publicDestination" },
-                auth: {
-                  headerEntries: [
-                    {
-                      name: "Authorization",
-                      value: `Bearer \${{ secrets.GITHUB_TOKEN }}`,
-                    },
-                  ],
-                },
-                permissions: [
-                  {
-                    name: "issues.write",
-                    rules: ["POST /repos/{owner}/{repo}/issues"],
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            name: "github",
-            apis: [
-              {
-                base: "https://api.github.com",
-                permissions: [
-                  {
-                    name: "repository.read",
-                    rules: ["GET /repos/{owner}/{repo}"],
-                  },
-                ],
-              },
-            ],
-          },
-          { kind: "builtin", name: "unknown-non-connector" },
-        ],
-        networkPolicyEntries: [
-          {
-            name: "github",
-            policy: {
-              allow: ["repository.read"],
-              deny: [],
-              ask: ["issues.write"],
-              unknownPolicy: "deny",
-            },
-          },
-        ],
-      },
-    ]);
+    const pinnedHost = "prod.api.reap.global";
+    const changedHost = "changed.api.reap.global";
+    const runBase = `https://${pinnedHost}/v1`;
+    await connectReap(actor, runBase);
 
-    const result = await checkWithToken(token, {
+    const customBody = manualHttpCustomConnectorCreateBody({
+      displayName: "Run Reap Overlay",
+      slug: `_run-reap-overlay-${randomUUID().slice(0, 8)}`,
+      prefixTemplates: ["https://{{variables.host}}/v1/"],
+      permissionBundleRef: "builtin:slack@1",
+    });
+    const custom = await connectorsApi.createCustomConnector(actor, {
+      ...customBody,
+      fields: [
+        ...customBody.fields,
+        {
+          key: "host",
+          label: "Host",
+          kind: "variable",
+          required: true,
+        },
+      ],
+    });
+    const connectedCustom = await connectorsApi.setCustomConnectorValues(
+      actor,
+      custom.id,
+      [
+        { key: "secret", kind: "secret", value: "custom-secret-before" },
+        { key: "host", kind: "variable", value: pinnedHost },
+      ],
+    );
+    if (!connectedCustom.connectedAccountId) {
+      throw new Error("Expected a connected custom connector account");
+    }
+    const customConnectionId = connectedCustom.connectedAccountId;
+    const { runId, agentId } = await createOwnedRun(actor, {
+      builtinConnectorSlugs: ["reap"],
+      customConnectorIds: [custom.id],
+    });
+    const token = okouToken(actor, runId, ["connector:read", "agent-run:read"]);
+    const url = `${runBase}/chat.postMessage`;
+    context.mocks.axiom.query.mockRejectedValue(
+      new Error("Axiom connector diagnostics must not be queried"),
+    );
+
+    const legacy = await checkWithToken(token, {
       mode: "url",
       method: "POST",
-      url: `${inlineBase}/repos/vm0-ai/vm0/issues?query-private=1#fragment-private`,
-      connectorSlug: "github",
+      url,
     });
-    expect(result.body).toMatchObject({
+    expect(legacy.body).toMatchObject({
       outcome: "resolved",
-      connector: { connectorSlug: "github" },
-      environmentNames: null,
-      run: {
-        status: "configured",
-        bases: ["https://api.github.com", inlineBase],
+      connector: { connectorSlug: "reap" },
+    });
+    expect(JSON.stringify(legacy.body)).not.toContain(custom.id);
+
+    const customRequest = {
+      mode: "url" as const,
+      method: "POST",
+      url,
+      target: { kind: "custom" as const, customConnectorId: custom.id },
+    };
+    const selected = await checkWithToken(token, customRequest);
+    expect(selected.body).toMatchObject({
+      outcome: "resolved",
+      connector: {
+        target: { kind: "custom", customConnectorId: custom.id },
+        label: "Run Reap Overlay",
+        visibility: "available",
+        credentialResolution: "network-boundary",
       },
-      relativePath: "/repos/vm0-ai/vm0/issues",
+      run: { status: "configured", bases: [runBase] },
+      base: runBase,
+      relativePath: "/chat.postMessage",
       permission: {
         kind: "matched",
         permissions: [
           {
-            name: "issues.write",
-            policy: { outcome: "ask", basis: "ask-list" },
+            name: "chat:write",
+            policy: { outcome: "deny", basis: "deny-list" },
           },
         ],
       },
     });
-    const serialized = JSON.stringify(result.body);
+    const serialized = JSON.stringify(selected.body);
     for (const forbidden of [
-      "query-private",
-      "fragment-private",
-      "runId",
-      "networkPolicies",
-      '"allow":',
-      '"deny":',
-      '"ask":',
-      "repository.read",
-      "unknown-non-connector",
+      "custom-secret-before",
+      customConnectionId,
       "Authorization",
-      "secrets.GITHUB_TOKEN",
+      "sourceId",
+      "baseUrlVars",
+      "networkPolicy",
+      "secrets.secret",
     ]) {
       expect(serialized).not.toContain(forbidden);
     }
 
-    const recoveredEnvironment = await checkWithToken(token, {
-      mode: "url",
-      method: "GET",
-      url: "https://api.github.com/repos/vm0-ai/vm0",
-      connectorSlug: "github",
-    });
-    expect(recoveredEnvironment.body).toMatchObject({
-      outcome: "resolved",
-      connector: { connectorSlug: "github" },
-      environmentNames: ["GITHUB_TOKEN"],
+    const grantResponse =
+      await connectorsApi.requestUpdateAgentCustomConnectorGrants(
+        actor,
+        agentId,
+        [
+          {
+            customConnectorId: custom.id,
+            permissionNames: ["chat:write"],
+          },
+        ],
+        [200],
+      );
+    expect(grantResponse.status).toBe(200);
+    const allowed = await checkWithToken(token, customRequest);
+    expect(allowed.body).toMatchObject({
       permission: {
-        kind: "matched",
         permissions: [
           {
-            name: "repository.read",
+            name: "chat:write",
+            policy: { outcome: "allow", basis: "allow-list" },
+          },
+        ],
+      },
+    });
+    await runsApi.applyUserPermissionGrant(actor, {
+      agentId,
+      connectorSlug: "reap",
+      permission: "write",
+      action: "deny",
+    });
+    const includedCustom = await checkWithToken(token, {
+      mode: "url",
+      method: "POST",
+      url,
+      includeCustomConnectors: true,
+    });
+    expect(includedCustom.body).toMatchObject({
+      outcome: "resolved",
+      connector: {
+        target: { kind: "custom", customConnectorId: custom.id },
+        label: "Run Reap Overlay",
+      },
+      permission: {
+        permissions: [
+          {
+            name: "chat:write",
             policy: { outcome: "allow", basis: "allow-list" },
           },
         ],
       },
     });
 
-    const inlineUnknownEndpoint = await checkWithToken(token, {
-      mode: "url",
-      method: "OPTIONS",
-      url: `${inlineBase}/not-a-real-endpoint`,
-      connectorSlug: "github",
+    await connectorsApi.setCustomConnectorValues(
+      actor,
+      custom.id,
+      [
+        { key: "secret", kind: "secret", value: "custom-secret-after" },
+        { key: "host", kind: "variable", value: changedHost },
+      ],
+      { intent: "reconnect", connectionId: customConnectionId },
+    );
+    await connectorsApi.updateCustomConnector(actor, custom.id, {
+      displayName: "Updated Run Reap Overlay",
+      prefixTemplates: ["https://{{variables.host}}/v2/"],
+      fields: connectedCustom.fields,
+      headerInjections: customBody.headerInjections,
+      queryInjections: customBody.queryInjections,
+      permissionBundleRef: customBody.permissionBundleRef,
     });
-    expect(inlineUnknownEndpoint.body).toMatchObject({
+    const updatedCustomRequest = {
+      ...customRequest,
+      url: `https://${pinnedHost}/v2/chat.postMessage`,
+    };
+    const pinned = await checkWithToken(token, updatedCustomRequest);
+    expect(pinned.body).toMatchObject({
       outcome: "resolved",
-      connector: { connectorSlug: "github" },
-      permission: {
-        kind: "unknown-endpoint",
-        policy: { outcome: "deny", basis: "unknown-policy" },
+      connector: { label: "Updated Run Reap Overlay" },
+      base: `https://${pinnedHost}/v2`,
+      run: {
+        status: "configured",
+        bases: [`https://${pinnedHost}/v2`],
       },
     });
+    const changedBase = await checkWithToken(token, {
+      ...updatedCustomRequest,
+      url: `https://${changedHost}/v2/chat.postMessage`,
+    });
+    expect(changedBase.body).toStrictEqual({
+      outcome: "no-match",
+      scope: "run",
+    });
+
+    const addedAfterLaunch = await connectorsApi.createCustomConnector(
+      actor,
+      manualHttpCustomConnectorCreateBody({
+        displayName: "Added After Launch",
+        slug: `_added-after-launch-${randomUUID().slice(0, 8)}`,
+        prefixTemplates: ["https://after-launch.example.test/"],
+      }),
+    );
+    const notAdmitted = await checkWithToken(token, {
+      mode: "url",
+      method: "GET",
+      url: "https://after-launch.example.test/items",
+      target: {
+        kind: "custom",
+        customConnectorId: addedAfterLaunch.id,
+      },
+    });
+    expect(notAdmitted.body).toStrictEqual({
+      outcome: "target-unavailable",
+      target: { kind: "custom", customConnectorId: addedAfterLaunch.id },
+      reason: "not-admitted",
+    });
+
+    await connectorsApi.deleteCustomConnector(actor, custom.id);
+    const deleted = await checkWithToken(token, updatedCustomRequest);
+    expect(deleted.body).toStrictEqual({
+      outcome: "target-unavailable",
+      target: { kind: "custom", customConnectorId: custom.id },
+      reason: "connector-unavailable",
+    });
+    await connectorsApi.deleteCustomConnector(actor, addedAfterLaunch.id);
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes missing legacy registration from terminal stale state", async () => {
+    const actor = bdd.user();
+    await seedAdminMembership(actor);
+    const { runId } = await createOwnedRun(actor);
+    const token = okouToken(actor, runId, ["connector:read", "agent-run:read"]);
+    await accept(
+      stateClient().action({
+        body: {
+          action: "delete-connector-diagnostic-registration",
+          run_id: runId,
+        },
+      }),
+      [200],
+    );
+
+    const legacy = await checkWithToken(token, {
+      mode: "environment",
+      environmentName: "GH_TOKEN",
+    });
+    expect(legacy.body).toStrictEqual({ outcome: "run-context-unavailable" });
+
+    await accept(
+      stateClient().action({
+        body: {
+          action: "transition-run-terminal",
+          run_id: runId,
+          status: "completed",
+        },
+      }),
+      [200],
+    );
+    const terminal = await accept(
+      client().check({
+        headers: { authorization: `Bearer ${token}` },
+        body: {
+          mode: "environment",
+          environmentName: "GH_TOKEN",
+        },
+      }),
+      [404],
+    );
+    expect(terminal.body.error).toStrictEqual({
+      code: "NOT_FOUND",
+      message: "Agent run not found",
+    });
+    expect(context.mocks.axiom.query).not.toHaveBeenCalled();
+
+    await accept(
+      stateClient().action({
+        body: { action: "delete-run", run_id: runId },
+      }),
+      [200],
+    );
   });
 });

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -27,7 +27,7 @@ import { runUploadedFiles } from "@okouai/db/schema/run-uploaded-file";
 import { runnerJobQueue } from "@okouai/db/schema/runner-job-queue";
 import { usageEvent } from "@okouai/db/schema/usage-event";
 import { command } from "ccstate";
-import { and, eq, inArray, notExists } from "drizzle-orm";
+import { and, eq, inArray, notExists, sql } from "drizzle-orm";
 
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
@@ -279,6 +279,25 @@ async function deleteConnectorDiagnosticRegistrationForAction(
   }
   await db
     .delete(agentRunConnectorDiagnosticRegistrations)
+    .where(eq(agentRunConnectorDiagnosticRegistrations.runId, runId));
+  signal.throwIfAborted();
+  return actionOk();
+}
+
+async function corruptConnectorDiagnosticRegistrationForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const runId = readString(body, "run_id");
+  if (!runId) {
+    return actionBadRequest("run_id is required");
+  }
+  await db
+    .update(agentRunConnectorDiagnosticRegistrations)
+    .set({
+      payload: sql`jsonb_build_object('version', 999, 'targets', '[]'::jsonb)`,
+    })
     .where(eq(agentRunConnectorDiagnosticRegistrations.runId, runId));
   signal.throwIfAborted();
   return actionOk();
@@ -1065,6 +1084,8 @@ const cronCleanupSandboxesActionHandlers = {
     seedConnectorDiagnosticRegistrationForAction,
   "get-connector-diagnostic-registration":
     getConnectorDiagnosticRegistrationForAction,
+  "corrupt-connector-diagnostic-registration":
+    corruptConnectorDiagnosticRegistrationForAction,
   "delete-connector-diagnostic-registration":
     deleteConnectorDiagnosticRegistrationForAction,
   "transition-run-terminal": transitionRunTerminalForAction,

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -296,7 +296,7 @@ async function corruptConnectorDiagnosticRegistrationForAction(
   await db
     .update(agentRunConnectorDiagnosticRegistrations)
     .set({
-      payload: sql`jsonb_build_object('version', 999, 'targets', '[]'::jsonb)`,
+      payload: sql`'null'::jsonb`,
     })
     .where(eq(agentRunConnectorDiagnosticRegistrations.runId, runId));
   signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -268,6 +268,22 @@ async function getConnectorDiagnosticRegistrationForAction(
   });
 }
 
+async function deleteConnectorDiagnosticRegistrationForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const runId = readString(body, "run_id");
+  if (!runId) {
+    return actionBadRequest("run_id is required");
+  }
+  await db
+    .delete(agentRunConnectorDiagnosticRegistrations)
+    .where(eq(agentRunConnectorDiagnosticRegistrations.runId, runId));
+  signal.throwIfAborted();
+  return actionOk();
+}
+
 async function deleteRunForAction(
   db: Db,
   body: Record<string, unknown>,
@@ -1049,6 +1065,8 @@ const cronCleanupSandboxesActionHandlers = {
     seedConnectorDiagnosticRegistrationForAction,
   "get-connector-diagnostic-registration":
     getConnectorDiagnosticRegistrationForAction,
+  "delete-connector-diagnostic-registration":
+    deleteConnectorDiagnosticRegistrationForAction,
   "transition-run-terminal": transitionRunTerminalForAction,
 } satisfies Record<
   CronCleanupSandboxesAction,

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -2,9 +2,18 @@ import type {
   ConnectorCheckDiagnosticResult,
   ConnectorCheckPolicy,
   ConnectorCheckRequest,
+  ConnectorCheckRequestBody,
+  ConnectorCheckResponseBody,
+  ConnectorCheckTargetAwareDiagnosticResult,
+  ConnectorCheckTargetAwareUrlRequest,
 } from "@okouai/api-contracts/contracts/connector-check";
-import type { RunContextResponse } from "@okouai/api-contracts/contracts/run-routes";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
+import {
+  agentRunConnectorDiagnosticRegistrationPayloadSchema,
+  connectorRuntimeTargetKey,
+  type ConnectorRuntimeTarget,
+  type ConnectorRuntimeTargetRegistration,
+} from "@okouai/api-contracts/contracts/runners";
 import {
   connectorAuthMethodRuntimeMetadata,
   type ConnectorRuntimeBindingEntry,
@@ -14,12 +23,19 @@ import {
   matchFirewallRequestDecision,
   type FirewallRequestDecision,
 } from "@okouai/connectors/firewall-rule-matcher";
-import type { NetworkPolicies } from "@okouai/connectors/firewall-types";
+import type {
+  NetworkPolicies,
+  NetworkPolicy,
+} from "@okouai/connectors/firewall-types";
 import { getAllFeatureStates } from "@okouai/core/feature-switch";
+import { agentRunConnectorDiagnosticRegistrations } from "@okouai/db/schema/agent-run-connector-diagnostic-registration";
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { agentSessions } from "@okouai/db/schema/agent-session";
+import { agents } from "@okouai/db/schema/agent";
 import { connectors } from "@okouai/db/schema/connector";
 import { variables } from "@okouai/db/schema/variable";
 import { command } from "ccstate";
-import { and, eq, isNotNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
 
 import { type Db, writeDb$ } from "../external/db";
 import { pgTextDecoder } from "../../lib/db-structured-result";
@@ -34,13 +50,16 @@ import {
   type ParsedConnectorDiagnosticRequest,
 } from "./connector-diagnostic-runtime.service";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
-import { runContext } from "./run-detail.service";
 import {
   getConnectorRuntimeConnector,
   listConnectorRuntimeVisibleSlugs,
   loadConnectorRuntimeSnapshot,
   type ConnectorRuntimeSnapshot,
 } from "./connector-catalog-runtime.service";
+import {
+  resolveConnectorRuntimeDiagnosticTargets,
+  type ConnectorRuntimeDiagnosticResult,
+} from "./connector-runtime-sync.service";
 import type { FirewallRoutingRouteMetadata } from "./connector-server-firewall-catalog.service";
 import {
   connectorCredentialVariableReadCondition,
@@ -50,17 +69,27 @@ import {
 
 type FeatureStates = ReturnType<typeof getAllFeatureStates>;
 
-interface ConnectorCheckIdentity {
+interface ConnectorCheckLegacyIdentity {
   readonly connectorSlug: ConnectorSlug;
   readonly label: string;
   readonly visibility: "available" | "unavailable";
   readonly credentialResolution: "network-boundary" | "none";
 }
 
+interface ConnectorCheckTargetIdentity {
+  readonly target: ConnectorRuntimeTarget;
+  readonly label: string;
+  readonly visibility: "available" | "unavailable";
+  readonly credentialResolution: "network-boundary" | "none";
+}
+
 interface ConnectorCheckRoutingConfig {
-  readonly connectorSlug: ConnectorSlug;
+  readonly target: ConnectorRuntimeTarget;
+  readonly label: string;
+  readonly credentialResolution: "network-boundary" | "none";
   readonly candidates: readonly ConnectorDiagnosticBaseCandidate[];
   readonly hasUnresolvedDynamicBase: boolean;
+  readonly networkPolicy: NetworkPolicy | null | undefined;
 }
 
 interface StoredRuntimeState {
@@ -82,12 +111,26 @@ interface PendingStoredConnectorRuntime {
   readonly storageNameByRuntimeName: ReadonlyMap<string, string>;
 }
 
+type ConnectorCheckTargetUnavailableReason = Extract<
+  ConnectorCheckTargetAwareDiagnosticResult,
+  { readonly outcome: "target-unavailable" }
+>["reason"];
+
+interface RunDiagnosticState {
+  readonly configs: readonly ConnectorCheckRoutingConfig[];
+  readonly admittedTargetKeys: ReadonlySet<string>;
+  readonly unavailableReasonByTargetKey: ReadonlyMap<
+    string,
+    ConnectorCheckTargetUnavailableReason
+  >;
+}
+
 type ConnectorCheckTimeline =
   | { readonly kind: "stored"; readonly state: StoredRuntimeState }
-  | { readonly kind: "run"; readonly context: RunContextResponse };
+  | { readonly kind: "run"; readonly state: RunDiagnosticState };
 
 interface ResolveConnectorCheckArgs {
-  readonly request: ConnectorCheckRequest;
+  readonly request: ConnectorCheckRequestBody;
   readonly orgId: string;
   readonly userId: string;
   readonly stateSource:
@@ -98,7 +141,7 @@ interface ResolveConnectorCheckArgs {
 type ResolveConnectorCheckResult =
   | {
       readonly kind: "ok";
-      readonly diagnostic: ConnectorCheckDiagnosticResult;
+      readonly diagnostic: ConnectorCheckResponseBody;
     }
   | { readonly kind: "not-found" };
 
@@ -106,19 +149,6 @@ interface DecisionPermission {
   readonly name: string;
   readonly rules: readonly string[];
 }
-
-type RunContextFirewall = RunContextResponse["firewalls"][number];
-type RunContextBuiltinFirewall = Extract<
-  RunContextFirewall,
-  { kind: "builtin" }
->;
-type RunContextInlineFirewall = Extract<RunContextFirewall, { apis: unknown }>;
-type RunContextInlinePermission =
-  RunContextInlineFirewall["apis"][number]["permissions"] extends
-    | readonly (infer Permission)[]
-    | undefined
-    ? Permission
-    : never;
 
 interface ConnectorCheckCatalogContext {
   readonly snapshot: ConnectorRuntimeSnapshot;
@@ -146,10 +176,10 @@ function connectorCredentialResolution(
     : "none";
 }
 
-function connectorIdentity(
+function builtinTargetIdentity(
   connectorSlug: ConnectorSlug,
   catalogContext: ConnectorCheckCatalogContext,
-): ConnectorCheckIdentity {
+): ConnectorCheckTargetIdentity {
   const connector = getConnectorRuntimeConnector(
     catalogContext.snapshot,
     connectorSlug,
@@ -158,7 +188,7 @@ function connectorIdentity(
     throw new Error(`Missing connector runtime metadata: ${connectorSlug}`);
   }
   return {
-    connectorSlug,
+    target: { kind: "builtin", connectorSlug },
     label: connector.catalogConnector.label,
     visibility: catalogContext.visibleConnectorSlugs.has(connectorSlug)
       ? "available"
@@ -167,6 +197,21 @@ function connectorIdentity(
       catalogContext.snapshot,
       connectorSlug,
     ),
+  };
+}
+
+function targetIdentity(
+  config: ConnectorCheckRoutingConfig,
+  catalogContext: ConnectorCheckCatalogContext,
+): ConnectorCheckTargetIdentity {
+  if (config.target.kind === "builtin") {
+    return builtinTargetIdentity(config.target.connectorSlug, catalogContext);
+  }
+  return {
+    target: config.target,
+    label: config.label,
+    visibility: "available",
+    credentialResolution: config.credentialResolution,
   };
 }
 
@@ -364,7 +409,7 @@ function configsToDecisionFirewalls(
 ) {
   return configs.map((config) => {
     return {
-      name: config.connectorSlug,
+      name: connectorRuntimeTargetKey(config.target),
       apis: config.candidates.map((candidate) => {
         return {
           base: candidate.decisionBase,
@@ -380,162 +425,257 @@ function configFromCatalogView(
   view: ConnectorDiagnosticCatalogView,
   baseUrlVars: Readonly<Record<string, string>> | null,
   allowStructuralDynamic: boolean,
+  networkPolicy?: NetworkPolicy | null,
 ): ConnectorCheckRoutingConfig {
   const result = buildConnectorDiagnosticBaseCandidates(view, baseUrlVars, {
     allowStructuralDynamic,
   });
   return {
-    connectorSlug: view.connectorSlug,
+    target: { kind: "builtin", connectorSlug: view.connectorSlug },
+    label: view.label,
+    credentialResolution:
+      view.executionMetadata.secretPlaceholderNames.length > 0
+        ? "network-boundary"
+        : "none",
     candidates: result.candidates,
     hasUnresolvedDynamicBase: result.hasUnresolvedDynamicBase,
+    networkPolicy,
   };
 }
 
-function runContextPermissionRoutes(
-  permissions: readonly RunContextInlinePermission[] | undefined,
+function customDiagnosticRoutes(
+  permissions: Extract<
+    ConnectorRuntimeDiagnosticResult,
+    {
+      readonly target: { readonly kind: "custom" };
+      readonly state: "available";
+    }
+  >["apis"][number]["permissions"],
 ): FirewallRoutingRouteMetadata[] {
-  const routes: FirewallRoutingRouteMetadata[] = [];
-  const seenPermissionNames = new Set<string>();
-  for (const permission of permissions ?? []) {
-    if (seenPermissionNames.has(permission.name)) {
-      continue;
-    }
-    seenPermissionNames.add(permission.name);
-    for (const rule of permission.rules) {
-      routes.push({ permissionName: permission.name, rule });
-    }
-  }
-  return routes;
-}
-
-function sameStrings(
-  left: readonly string[],
-  right: readonly string[],
-): boolean {
-  return (
-    left.length === right.length &&
-    left.every((value, index) => {
-      return value === right[index];
-    })
-  );
-}
-
-function inlineApiEnvironmentNames(
-  base: string,
-  view: ConnectorDiagnosticCatalogView | null,
-): readonly string[] | null {
-  if (!view) {
-    return null;
-  }
-  const matches = view.apis.filter((api) => {
-    return api.base === base;
+  return permissions.flatMap((permission) => {
+    return permission.rules.map((rule) => {
+      return { permissionName: permission.name, rule };
+    });
   });
-  const [first, ...others] = matches;
-  if (!first) {
-    return null;
-  }
-  return others.every((api) => {
-    return sameStrings(first.environmentNames, api.environmentNames);
-  })
-    ? first.environmentNames
-    : null;
 }
 
-function configFromInlineRunContext(
-  firewall: RunContextInlineFirewall,
-  connectorSlug: ConnectorSlug,
-  view: ConnectorDiagnosticCatalogView | null,
+function configFromCustomRuntime(
+  runtime: Extract<
+    ConnectorRuntimeDiagnosticResult,
+    {
+      readonly target: { readonly kind: "custom" };
+      readonly state: "available";
+    }
+  >,
 ): ConnectorCheckRoutingConfig {
   return {
-    connectorSlug,
-    candidates: firewall.apis.map((api) => {
+    target: runtime.target,
+    label: runtime.label,
+    credentialResolution: runtime.credentialResolution,
+    candidates: runtime.apis.map((api) => {
       return {
         sourceBase: api.base,
         decisionBase: api.base,
         displayBase: baseKey(api.base),
-        routes: runContextPermissionRoutes(api.permissions),
-        environmentNames: inlineApiEnvironmentNames(api.base, view),
+        routes: customDiagnosticRoutes(api.permissions),
+        environmentNames: null,
       };
     }),
     hasUnresolvedDynamicBase: false,
+    networkPolicy: runtime.networkPolicy,
   };
 }
 
-function completeRunBaseUrlVars(
-  firewall: RunContextBuiltinFirewall,
-  requiredNames: readonly string[],
-): Readonly<Record<string, string>> | null {
-  if (requiredNames.length === 0) {
-    return {};
-  }
-  if (!("baseUrlVars" in firewall) || !firewall.baseUrlVars) {
-    return null;
-  }
-  const values: Record<string, string> = {};
-  for (const name of requiredNames) {
-    const value = firewall.baseUrlVars[name];
-    if (!value) {
-      return null;
-    }
-    values[name] = value;
-  }
-  return values;
+interface RunDiagnosticRegistration {
+  readonly agentId: string;
+  readonly targets: readonly ConnectorRuntimeTargetRegistration[];
 }
 
-async function loadRunRoutingConfigs(
-  runContext: RunContextResponse,
-  snapshot: ConnectorRuntimeSnapshot,
-): Promise<ConnectorCheckRoutingConfig[]> {
-  const viewPromises = new Map<
-    ConnectorSlug,
-    Promise<ConnectorDiagnosticCatalogView | null>
-  >();
-  const loadView = (
-    connectorSlug: ConnectorSlug,
-  ): Promise<ConnectorDiagnosticCatalogView | null> => {
-    let promise = viewPromises.get(connectorSlug);
-    if (!promise) {
-      promise = loadConnectorDiagnosticCatalogView(
-        snapshot.serverFirewalls,
-        connectorSlug,
-      );
-      viewPromises.set(connectorSlug, promise);
+type LoadRunDiagnosticRegistrationResult =
+  | {
+      readonly kind: "available";
+      readonly registration: RunDiagnosticRegistration;
     }
-    return promise;
-  };
+  | { readonly kind: "missing" }
+  | { readonly kind: "not-found" };
 
-  const configs: ConnectorCheckRoutingConfig[] = [];
-  for (const firewall of runContext.firewalls) {
-    if (!snapshot.serverFirewalls.has(firewall.name)) {
-      continue;
-    }
-    const connectorSlug = firewall.name;
-    const view = await loadView(connectorSlug);
-    if ("apis" in firewall) {
-      configs.push(configFromInlineRunContext(firewall, connectorSlug, view));
-      continue;
-    }
-    if (!view) {
-      throw new Error(`Missing builtin firewall metadata for ${connectorSlug}`);
-    }
-    const baseUrlVars = completeRunBaseUrlVars(firewall, view.baseUrlVarNames);
-    configs.push(configFromCatalogView(view, baseUrlVars, false));
+async function loadRunDiagnosticRegistration(
+  db: Db,
+  args: {
+    readonly runId: string;
+    readonly userId: string;
+    readonly orgId: string;
+  },
+): Promise<LoadRunDiagnosticRegistrationResult> {
+  const [row] = await db
+    .select({
+      agentId: agents.id,
+      payload: agentRunConnectorDiagnosticRegistrations.payload,
+    })
+    .from(agentRuns)
+    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
+    .innerJoin(agents, eq(agents.id, agentSessions.agentId))
+    .leftJoin(
+      agentRunConnectorDiagnosticRegistrations,
+      eq(agentRunConnectorDiagnosticRegistrations.runId, agentRuns.id),
+    )
+    .where(
+      and(
+        eq(agentRuns.id, args.runId),
+        eq(agentRuns.userId, args.userId),
+        eq(agentRuns.orgId, args.orgId),
+        inArray(agentRuns.status, ["queued", "pending", "running"]),
+      ),
+    )
+    .limit(1);
+  if (!row) {
+    return { kind: "not-found" };
   }
+  if (!row.payload) {
+    return { kind: "missing" };
+  }
+  const payload = agentRunConnectorDiagnosticRegistrationPayloadSchema.parse(
+    row.payload,
+  );
+  return {
+    kind: "available",
+    registration: { agentId: row.agentId, targets: payload.targets },
+  };
+}
 
-  const merged = new Map<ConnectorSlug, ConnectorCheckRoutingConfig>();
-  for (const config of configs) {
-    const existing = merged.get(config.connectorSlug);
-    merged.set(config.connectorSlug, {
-      connectorSlug: config.connectorSlug,
-      candidates: existing
-        ? [...existing.candidates, ...config.candidates]
-        : config.candidates,
-      hasUnresolvedDynamicBase:
-        (existing?.hasUnresolvedDynamicBase ?? false) ||
-        config.hasUnresolvedDynamicBase,
+function targetAwareUrlRequest(
+  request: ConnectorCheckRequestBody,
+): request is ConnectorCheckTargetAwareUrlRequest {
+  return (
+    request.mode === "url" &&
+    ("includeCustomConnectors" in request || "target" in request)
+  );
+}
+
+function runtimeTargetsForRequest(
+  registration: RunDiagnosticRegistration,
+  request: ConnectorCheckRequestBody,
+): readonly ConnectorRuntimeTargetRegistration[] {
+  if (!targetAwareUrlRequest(request)) {
+    return registration.targets.filter((target) => {
+      return target.kind === "builtin";
     });
   }
-  return [...merged.values()];
+  const includeCustomConnectors =
+    request.includeCustomConnectors === true ||
+    request.target?.kind === "custom";
+  return registration.targets.filter((target) => {
+    return target.kind === "builtin" || includeCustomConnectors;
+  });
+}
+
+function unavailableRuntimeReason(
+  runtime: Exclude<
+    ConnectorRuntimeDiagnosticResult,
+    { readonly state: "available" }
+  >,
+): ConnectorCheckTargetUnavailableReason {
+  return runtime.reason;
+}
+
+function isBuiltinDiagnosticRuntime(
+  runtime: ConnectorRuntimeDiagnosticResult,
+): runtime is Extract<
+  ConnectorRuntimeDiagnosticResult,
+  { readonly target: { readonly kind: "builtin" } }
+> {
+  return runtime.target.kind === "builtin";
+}
+
+function isCustomAvailableDiagnosticRuntime(
+  runtime: ConnectorRuntimeDiagnosticResult,
+): runtime is Extract<
+  ConnectorRuntimeDiagnosticResult,
+  { readonly label: string }
+> {
+  return "label" in runtime;
+}
+
+async function loadRunDiagnosticState(args: {
+  readonly db: Db;
+  readonly scope: RunDiagnosticRegistration;
+  readonly request: ConnectorCheckRequestBody;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly snapshot: ConnectorRuntimeSnapshot;
+}): Promise<RunDiagnosticState> {
+  const targets = runtimeTargetsForRequest(args.scope, args.request);
+  const runtimes =
+    targets.length === 0
+      ? []
+      : await resolveConnectorRuntimeDiagnosticTargets({
+          db: args.db,
+          scope: {
+            orgId: args.orgId,
+            userId: args.userId,
+            agentId: args.scope.agentId,
+          },
+          targets,
+        });
+  const runtimeByTargetKey = new Map(
+    runtimes.map((runtime) => {
+      return [connectorRuntimeTargetKey(runtime.target), runtime] as const;
+    }),
+  );
+
+  const configs: ConnectorCheckRoutingConfig[] = [];
+  const unavailableReasonByTargetKey = new Map<
+    string,
+    ConnectorCheckTargetUnavailableReason
+  >();
+  for (const registration of targets) {
+    const key = connectorRuntimeTargetKey(registration);
+    const runtime = runtimeByTargetKey.get(key);
+    if (!runtime) {
+      throw new Error(`Missing connector runtime diagnostic result: ${key}`);
+    }
+    if (isCustomAvailableDiagnosticRuntime(runtime)) {
+      configs.push(configFromCustomRuntime(runtime));
+      continue;
+    }
+    if (!isBuiltinDiagnosticRuntime(runtime)) {
+      unavailableReasonByTargetKey.set(key, unavailableRuntimeReason(runtime));
+      continue;
+    }
+    const connectorSlug = runtime.target.connectorSlug;
+    const view = await loadConnectorDiagnosticCatalogView(
+      args.snapshot.serverFirewalls,
+      connectorSlug,
+    );
+    if (!view) {
+      unavailableReasonByTargetKey.set(key, "connector-unavailable");
+      continue;
+    }
+    const networkPolicy =
+      runtime.state === "available" ? runtime.networkPolicy : null;
+    if (runtime.state !== "available") {
+      unavailableReasonByTargetKey.set(key, unavailableRuntimeReason(runtime));
+    }
+    configs.push(
+      configFromCatalogView(
+        view,
+        registration.kind === "builtin"
+          ? (registration.baseUrlVars ?? null)
+          : null,
+        false,
+        networkPolicy,
+      ),
+    );
+  }
+  return {
+    configs,
+    admittedTargetKeys: new Set(
+      args.scope.targets.map((target) => {
+        return connectorRuntimeTargetKey(target);
+      }),
+    ),
+    unavailableReasonByTargetKey,
+  };
 }
 
 async function catalogConfig(
@@ -766,36 +906,42 @@ function runStatus(
 
 function unavailablePolicy(
   timeline: ConnectorCheckTimeline,
-  configured: boolean,
+  config: ConnectorCheckRoutingConfig | undefined,
 ): ConnectorCheckPolicy | null {
   if (timeline.kind === "stored") {
     return { outcome: "unavailable", basis: "not-run-scoped" };
   }
-  if (!configured) {
+  if (!config) {
     return { outcome: "unavailable", basis: "connector-not-configured" };
   }
-  if (timeline.context.networkPolicies === null) {
+  if (config.networkPolicy === null) {
     return { outcome: "unavailable", basis: "policies-unavailable" };
+  }
+  if (config.networkPolicy === undefined) {
+    throw new Error("Missing run-scoped connector policy state");
   }
   return null;
 }
 
 function permissionPolicy(
-  connectorSlug: ConnectorSlug,
+  config: ConnectorCheckRoutingConfig | undefined,
   permission: string,
   timeline: ConnectorCheckTimeline,
-  configured: boolean,
 ): ConnectorCheckPolicy {
-  const unavailable = unavailablePolicy(timeline, configured);
+  const unavailable = unavailablePolicy(timeline, config);
   if (unavailable) {
     return unavailable;
   }
-  if (timeline.kind !== "run" || timeline.context.networkPolicies === null) {
+  if (
+    timeline.kind !== "run" ||
+    !config ||
+    config.networkPolicy === undefined
+  ) {
     throw new Error("Missing resolved run policy timeline");
   }
-  const policy = timeline.context.networkPolicies[connectorSlug];
-  if (!policy) {
-    return { outcome: "allow", basis: "no-policy" };
+  const policy = config.networkPolicy;
+  if (policy === null) {
+    throw new Error("Missing available connector policy");
   }
   if (policy.deny.includes(permission)) {
     return { outcome: "deny", basis: "deny-list" };
@@ -810,20 +956,19 @@ function permissionPolicy(
 }
 
 function unknownPolicy(
-  connectorSlug: ConnectorSlug,
+  config: ConnectorCheckRoutingConfig,
   timeline: ConnectorCheckTimeline,
-  configured: boolean,
 ): ConnectorCheckPolicy {
-  const unavailable = unavailablePolicy(timeline, configured);
+  const unavailable = unavailablePolicy(timeline, config);
   if (unavailable) {
     return unavailable;
   }
-  if (timeline.kind !== "run" || timeline.context.networkPolicies === null) {
+  if (timeline.kind !== "run" || config.networkPolicy === undefined) {
     throw new Error("Missing resolved run policy timeline");
   }
-  const policy = timeline.context.networkPolicies[connectorSlug];
-  if (!policy) {
-    return { outcome: "allow", basis: "no-policy" };
+  const policy = config.networkPolicy;
+  if (policy === null) {
+    throw new Error("Missing available connector policy");
   }
   switch (policy.unknownPolicy) {
     case "allow": {
@@ -839,7 +984,7 @@ function unknownPolicy(
 }
 
 function decisionPermissionResult(
-  connectorSlug: ConnectorSlug,
+  config: ConnectorCheckRoutingConfig,
   decision: Exclude<
     FirewallRequestDecision,
     { readonly kind: "no_match" | "ambiguous" }
@@ -850,7 +995,7 @@ function decisionPermissionResult(
     if (decision.permission === undefined) {
       return {
         kind: "unknown-endpoint" as const,
-        policy: unknownPolicy(connectorSlug, timeline, true),
+        policy: unknownPolicy(config, timeline),
       };
     }
     return {
@@ -858,12 +1003,7 @@ function decisionPermissionResult(
       permissions: [
         {
           name: decision.permission,
-          policy: permissionPolicy(
-            connectorSlug,
-            decision.permission,
-            timeline,
-            true,
-          ),
+          policy: permissionPolicy(config, decision.permission, timeline),
         },
       ],
     };
@@ -872,7 +1012,7 @@ function decisionPermissionResult(
   if (decision.reason === "unknown_endpoint") {
     return {
       kind: "unknown-endpoint" as const,
-      policy: unknownPolicy(connectorSlug, timeline, true),
+      policy: unknownPolicy(config, timeline),
     };
   }
   if (decision.reason !== "permission_denied") {
@@ -881,16 +1021,18 @@ function decisionPermissionResult(
     );
   }
   const permissions = [...new Set(decision.permissions)].sort().map((name) => {
-    const policy = permissionPolicy(connectorSlug, name, timeline, true);
+    const policy = permissionPolicy(config, name, timeline);
     if (policy.outcome !== "deny" && policy.outcome !== "ask") {
       throw new Error(
-        `Inconsistent blocked permission policy for ${connectorSlug}`,
+        `Inconsistent blocked permission policy for ${connectorRuntimeTargetKey(config.target)}`,
       );
     }
     return { name, policy };
   });
   if (permissions.length === 0) {
-    throw new Error(`Missing blocked permissions for ${connectorSlug}`);
+    throw new Error(
+      `Missing blocked permissions for ${connectorRuntimeTargetKey(config.target)}`,
+    );
   }
   return { kind: "matched" as const, permissions };
 }
@@ -904,7 +1046,7 @@ function displayBaseForDecision(
   });
   if (!candidate) {
     throw new Error(
-      `Missing diagnostic display base for ${config.connectorSlug}`,
+      `Missing diagnostic display base for ${connectorRuntimeTargetKey(config.target)}`,
     );
   }
   return publicConnectorDiagnosticBase(candidate.displayBase);
@@ -932,24 +1074,53 @@ function connectorSlugForEnvironmentName(
 }
 
 function policyMap(timeline: ConnectorCheckTimeline): NetworkPolicies | null {
-  return timeline.kind === "run" ? timeline.context.networkPolicies : null;
+  if (timeline.kind === "stored") {
+    return null;
+  }
+  return Object.fromEntries(
+    timeline.state.configs.flatMap((config) => {
+      return config.networkPolicy
+        ? [[connectorRuntimeTargetKey(config.target), config.networkPolicy]]
+        : [];
+    }),
+  );
 }
 
 function noMatchDiagnostic(
-  requestedConnectorSlug: ConnectorSlug | undefined,
+  requestedTarget: ConnectorRuntimeTarget | undefined,
   configs: readonly ConnectorCheckRoutingConfig[],
   timeline: ConnectorCheckTimeline,
   catalogContext: ConnectorCheckCatalogContext,
-): ConnectorCheckDiagnosticResult {
-  const selectedConfig = requestedConnectorSlug
+  targetAware: boolean,
+): ConnectorCheckTargetAwareDiagnosticResult {
+  const selectedConfig = requestedTarget
     ? configs.find((config) => {
-        return config.connectorSlug === requestedConnectorSlug;
+        return (
+          connectorRuntimeTargetKey(config.target) ===
+          connectorRuntimeTargetKey(requestedTarget)
+        );
       })
     : undefined;
-  if (requestedConnectorSlug && selectedConfig?.hasUnresolvedDynamicBase) {
+  if (requestedTarget && selectedConfig?.hasUnresolvedDynamicBase) {
     return {
       outcome: "unresolved-dynamic-base",
-      connector: connectorIdentity(requestedConnectorSlug, catalogContext),
+      connector: targetIdentity(selectedConfig, catalogContext),
+    };
+  }
+  if (
+    targetAware &&
+    requestedTarget &&
+    !selectedConfig &&
+    timeline.kind === "run"
+  ) {
+    const key = connectorRuntimeTargetKey(requestedTarget);
+    return {
+      outcome: "target-unavailable",
+      target: requestedTarget,
+      reason: timeline.state.admittedTargetKeys.has(key)
+        ? (timeline.state.unavailableReasonByTargetKey.get(key) ??
+          "connector-unavailable")
+        : "not-admitted",
     };
   }
   return {
@@ -960,24 +1131,20 @@ function noMatchDiagnostic(
 
 function ambiguousDiagnostic(
   decision: Extract<FirewallRequestDecision, { readonly kind: "ambiguous" }>,
-  catalogContext: ConnectorCheckCatalogContext,
-): ConnectorCheckDiagnosticResult {
+  configs: readonly ConnectorCheckRoutingConfig[],
+): ConnectorCheckTargetAwareDiagnosticResult {
   return {
     outcome: "ambiguous",
     candidates: decision.candidates.map((candidate) => {
-      if (!isConnectorSlug(catalogContext.snapshot, candidate)) {
-        throw new Error("Matched an unknown connector firewall");
-      }
-      const connector = getConnectorRuntimeConnector(
-        catalogContext.snapshot,
-        candidate,
-      );
-      if (!connector) {
-        throw new Error(`Missing connector runtime metadata: ${candidate}`);
+      const config = configs.find((entry) => {
+        return connectorRuntimeTargetKey(entry.target) === candidate;
+      });
+      if (!config) {
+        throw new Error(`Matched an unknown connector target: ${candidate}`);
       }
       return {
-        connectorSlug: candidate,
-        label: connector.catalogConnector.label,
+        target: config.target,
+        label: config.label,
       };
     }),
   };
@@ -990,16 +1157,15 @@ type UrlEnvironmentSelection =
     }
   | {
       readonly kind: "diagnostic";
-      readonly diagnostic: ConnectorCheckDiagnosticResult;
+      readonly diagnostic: ConnectorCheckTargetAwareDiagnosticResult;
     };
 
 function selectUrlEnvironmentNames(args: {
   readonly catalogContext: ConnectorCheckCatalogContext;
-  readonly connectorSlug: ConnectorSlug;
   readonly config: ConnectorCheckRoutingConfig;
   readonly parsed: ParsedConnectorDiagnosticRequest;
   readonly requestedEnvironmentName: string | undefined;
-  readonly identity: ConnectorCheckIdentity;
+  readonly identity: ConnectorCheckTargetIdentity;
 }): UrlEnvironmentSelection {
   const environmentNames = environmentNamesForWinningCandidates(
     args.config,
@@ -1012,9 +1178,19 @@ function selectUrlEnvironmentNames(args: {
         environmentNames === null ? null : [...environmentNames],
     };
   }
+  if (args.config.target.kind === "custom") {
+    return {
+      kind: "diagnostic",
+      diagnostic: {
+        outcome: "environment-not-owned",
+        connector: args.identity,
+      },
+    };
+  }
+  const connectorSlug = args.config.target.connectorSlug;
   const owned = connectorEnvironmentBindings(
     args.catalogContext.snapshot,
-    args.connectorSlug,
+    connectorSlug,
   ).some((entry) => {
     return entry.envName === args.requestedEnvironmentName;
   });
@@ -1031,7 +1207,7 @@ function selectUrlEnvironmentNames(args: {
     environmentNames !== null &&
     !environmentNameSupportsRoute(
       args.catalogContext.snapshot,
-      args.connectorSlug,
+      connectorSlug,
       args.requestedEnvironmentName,
       environmentNames,
     )
@@ -1052,7 +1228,10 @@ function selectUrlEnvironmentNames(args: {
 }
 
 interface ResolvedUrlDiagnosticArgs {
-  readonly request: Extract<ConnectorCheckRequest, { readonly mode: "url" }>;
+  readonly request: Extract<
+    ConnectorCheckRequestBody,
+    { readonly mode: "url" }
+  >;
   readonly parsed: ParsedConnectorDiagnosticRequest;
   readonly decision: Exclude<
     FirewallRequestDecision,
@@ -1065,7 +1244,7 @@ interface ResolvedUrlDiagnosticArgs {
 
 function resolvedUrlDiagnostic(
   args: ResolvedUrlDiagnosticArgs,
-): ConnectorCheckDiagnosticResult {
+): ConnectorCheckTargetAwareDiagnosticResult {
   const { request, parsed, decision, configs, timeline, catalogContext } = args;
   if (decision.kind === "block" && decision.reason === "unsafe_path") {
     return { outcome: "unsafe-input", reason: "unsafe-path" };
@@ -1079,32 +1258,29 @@ function resolvedUrlDiagnostic(
       `Invalid connector diagnostic decision: ${decision.reason}`,
     );
   }
-  if (!isConnectorSlug(catalogContext.snapshot, decision.firewallName)) {
-    throw new Error("Matched an unknown connector firewall");
-  }
-  const connectorSlug = decision.firewallName;
-  if (
-    request.connectorSlug !== undefined &&
-    connectorSlug !== request.connectorSlug
-  ) {
-    return {
-      outcome: "connector-mismatch",
-      connector: connectorIdentity(connectorSlug, catalogContext),
-    };
-  }
   const config = configs.find((entry) => {
-    return entry.connectorSlug === connectorSlug;
+    return connectorRuntimeTargetKey(entry.target) === decision.firewallName;
   });
   if (!config) {
     throw new Error(
-      `Missing selected connector routing config for ${connectorSlug}`,
+      `Missing selected connector routing config for ${decision.firewallName}`,
     );
   }
+  const requestedTarget = requestedUrlTarget(request);
+  if (
+    requestedTarget &&
+    connectorRuntimeTargetKey(config.target) !==
+      connectorRuntimeTargetKey(requestedTarget)
+  ) {
+    return {
+      outcome: "connector-mismatch",
+      connector: targetIdentity(config, catalogContext),
+    };
+  }
 
-  const identity = connectorIdentity(connectorSlug, catalogContext);
+  const identity = targetIdentity(config, catalogContext);
   const environmentSelection = selectUrlEnvironmentNames({
     catalogContext,
-    connectorSlug,
     config,
     parsed,
     requestedEnvironmentName: request.environmentName,
@@ -1122,18 +1298,35 @@ function resolvedUrlDiagnostic(
     method: parsed.method,
     base: displayBaseForDecision(config, decision.base),
     relativePath: decision.relativePath,
-    permission: decisionPermissionResult(connectorSlug, decision, timeline),
+    permission: decisionPermissionResult(config, decision, timeline),
   };
 }
 
+function requestedUrlTarget(
+  request: Extract<ConnectorCheckRequestBody, { readonly mode: "url" }>,
+): ConnectorRuntimeTarget | undefined {
+  if (targetAwareUrlRequest(request)) {
+    return request.target;
+  }
+  return request.connectorSlug
+    ? { kind: "builtin", connectorSlug: request.connectorSlug }
+    : undefined;
+}
+
 async function resolveUrlMode(
-  request: Extract<ConnectorCheckRequest, { readonly mode: "url" }>,
+  request: Extract<ConnectorCheckRequestBody, { readonly mode: "url" }>,
   parsed: ParsedConnectorDiagnosticRequest,
   timeline: ConnectorCheckTimeline,
   catalogContext: ConnectorCheckCatalogContext,
-): Promise<ConnectorCheckDiagnosticResult> {
-  const requestedConnectorSlug = request.connectorSlug;
+): Promise<ConnectorCheckTargetAwareDiagnosticResult> {
+  const targetAware = targetAwareUrlRequest(request);
+  const requestedTarget = requestedUrlTarget(request);
+  const requestedConnectorSlug =
+    requestedTarget?.kind === "builtin"
+      ? requestedTarget.connectorSlug
+      : undefined;
   if (
+    !targetAware &&
     requestedConnectorSlug !== undefined &&
     !isConnectorSlug(catalogContext.snapshot, requestedConnectorSlug)
   ) {
@@ -1142,33 +1335,56 @@ async function resolveUrlMode(
 
   const configs =
     timeline.kind === "run"
-      ? await loadRunRoutingConfigs(timeline.context, catalogContext.snapshot)
+      ? timeline.state.configs
       : await loadGlobalCatalogConfigs(
           parsed,
           requestedConnectorSlug,
           timeline.state,
           catalogContext.snapshot,
         );
+  if (
+    targetAware &&
+    requestedTarget &&
+    timeline.kind === "run" &&
+    !configs.some((config) => {
+      return (
+        connectorRuntimeTargetKey(config.target) ===
+        connectorRuntimeTargetKey(requestedTarget)
+      );
+    })
+  ) {
+    return noMatchDiagnostic(
+      requestedTarget,
+      configs,
+      timeline,
+      catalogContext,
+      targetAware,
+    );
+  }
   const decision = matchFirewallRequestDecision(
     configsToDecisionFirewalls(configs),
     parsed.method,
     parsed.url,
     policyMap(timeline),
-    requestedConnectorSlug
-      ? { status: "present", value: requestedConnectorSlug }
+    requestedTarget
+      ? {
+          status: "present",
+          value: connectorRuntimeTargetKey(requestedTarget),
+        }
       : { status: "absent" },
   );
 
   if (decision.kind === "no_match") {
     return noMatchDiagnostic(
-      requestedConnectorSlug,
+      requestedTarget,
       configs,
       timeline,
       catalogContext,
+      targetAware,
     );
   }
   if (decision.kind === "ambiguous") {
-    return ambiguousDiagnostic(decision, catalogContext);
+    return ambiguousDiagnostic(decision, configs);
   }
   return resolvedUrlDiagnostic({
     request,
@@ -1180,11 +1396,11 @@ async function resolveUrlMode(
   });
 }
 
-async function resolveEnvironmentMode(
+function resolveEnvironmentMode(
   request: Extract<ConnectorCheckRequest, { readonly mode: "environment" }>,
   timeline: ConnectorCheckTimeline,
   catalogContext: ConnectorCheckCatalogContext,
-): Promise<ConnectorCheckDiagnosticResult> {
+): ConnectorCheckTargetAwareDiagnosticResult {
   const connectorSlug = connectorSlugForEnvironmentName(
     catalogContext.snapshot,
     request.environmentName,
@@ -1192,34 +1408,115 @@ async function resolveEnvironmentMode(
   if (!connectorSlug) {
     return { outcome: "unknown-environment" };
   }
-  const configs =
-    timeline.kind === "run"
-      ? await loadRunRoutingConfigs(timeline.context, catalogContext.snapshot)
-      : [];
+  const configs = timeline.kind === "run" ? timeline.state.configs : [];
   const config = configs.find((entry) => {
-    return entry.connectorSlug === connectorSlug;
+    return (
+      entry.target.kind === "builtin" &&
+      entry.target.connectorSlug === connectorSlug
+    );
   });
   return {
     outcome: "resolved",
     mode: "environment",
-    connector: connectorIdentity(connectorSlug, catalogContext),
+    connector: builtinTargetIdentity(connectorSlug, catalogContext),
     environmentName: request.environmentName,
     run: runStatus(timeline, config),
     permission:
       request.permission === undefined
         ? null
-        : permissionPolicy(
-            connectorSlug,
-            request.permission,
-            timeline,
-            config !== undefined,
-          ),
+        : permissionPolicy(config, request.permission, timeline),
   };
+}
+
+function legacyIdentity(
+  identity: ConnectorCheckTargetIdentity,
+): ConnectorCheckLegacyIdentity {
+  if (identity.target.kind !== "builtin") {
+    throw new Error(
+      "Legacy connector diagnostics cannot contain custom targets",
+    );
+  }
+  return {
+    connectorSlug: identity.target.connectorSlug,
+    label: identity.label,
+    visibility: identity.visibility,
+    credentialResolution: identity.credentialResolution,
+  };
+}
+
+function legacyDiagnostic(
+  diagnostic: ConnectorCheckTargetAwareDiagnosticResult,
+): ConnectorCheckDiagnosticResult {
+  switch (diagnostic.outcome) {
+    case "resolved": {
+      return diagnostic.mode === "url"
+        ? {
+            outcome: diagnostic.outcome,
+            mode: diagnostic.mode,
+            connector: legacyIdentity(diagnostic.connector),
+            environmentNames: diagnostic.environmentNames,
+            run: diagnostic.run,
+            method: diagnostic.method,
+            base: diagnostic.base,
+            relativePath: diagnostic.relativePath,
+            permission: diagnostic.permission,
+          }
+        : {
+            outcome: diagnostic.outcome,
+            mode: diagnostic.mode,
+            connector: legacyIdentity(diagnostic.connector),
+            environmentName: diagnostic.environmentName,
+            run: diagnostic.run,
+            permission: diagnostic.permission,
+          };
+    }
+    case "ambiguous": {
+      return {
+        outcome: diagnostic.outcome,
+        candidates: diagnostic.candidates.map((candidate) => {
+          if (candidate.target.kind !== "builtin") {
+            throw new Error(
+              "Legacy connector diagnostics cannot contain custom candidates",
+            );
+          }
+          return {
+            connectorSlug: candidate.target.connectorSlug,
+            label: candidate.label,
+          };
+        }),
+      };
+    }
+    case "connector-mismatch":
+    case "environment-not-owned":
+    case "unresolved-dynamic-base": {
+      return {
+        outcome: diagnostic.outcome,
+        connector: legacyIdentity(diagnostic.connector),
+      };
+    }
+    case "environment-not-used": {
+      return {
+        outcome: diagnostic.outcome,
+        connector: legacyIdentity(diagnostic.connector),
+        environmentNames: diagnostic.environmentNames,
+      };
+    }
+    case "target-unavailable": {
+      throw new Error("Legacy connector diagnostics cannot be target-aware");
+    }
+    case "unsafe-input":
+    case "unknown-connector":
+    case "unknown-environment":
+    case "no-match":
+    case "run-context-unavailable": {
+      return diagnostic;
+    }
+  }
 }
 
 export const resolveConnectorCheck$ = command(
   async (
-    { get, set },
+    { set },
     args: ResolveConnectorCheckArgs,
     signal: AbortSignal,
   ): Promise<ResolveConnectorCheckResult> => {
@@ -1236,26 +1533,44 @@ export const resolveConnectorCheck$ = command(
     }
 
     const db = set(writeDb$);
-    const snapshot = await loadConnectorRuntimeSnapshot(db);
-    signal.throwIfAborted();
-
-    let timeline: ConnectorCheckTimeline;
+    let runRegistration: RunDiagnosticRegistration | undefined;
     if (args.stateSource.kind === "run") {
-      const runContextResult = await get(
-        runContext(args.stateSource.runId, args.userId, args.orgId),
-      );
+      const registration = await loadRunDiagnosticRegistration(db, {
+        runId: args.stateSource.runId,
+        userId: args.userId,
+        orgId: args.orgId,
+      });
       signal.throwIfAborted();
-      if (runContextResult.kind === "not-found") {
+      if (registration.kind === "not-found") {
         return { kind: "not-found" };
       }
-      if (runContextResult.kind === "no-snapshot") {
+      if (registration.kind === "missing") {
         return {
           kind: "ok",
           diagnostic: { outcome: "run-context-unavailable" },
         };
       }
-      timeline = { kind: "run", context: runContextResult.context };
+      runRegistration = registration.registration;
+    }
+
+    const snapshot = await loadConnectorRuntimeSnapshot(db);
+    signal.throwIfAborted();
+    let timeline: ConnectorCheckTimeline;
+    if (runRegistration) {
+      const state = await loadRunDiagnosticState({
+        db,
+        scope: runRegistration,
+        request: args.request,
+        orgId: args.orgId,
+        userId: args.userId,
+        snapshot,
+      });
+      signal.throwIfAborted();
+      timeline = { kind: "run", state };
     } else {
+      if (args.stateSource.kind !== "stored") {
+        throw new Error("Missing active run diagnostic registration");
+      }
       const state =
         args.request.mode === "url"
           ? await loadStoredRuntimeState(db, {
@@ -1283,7 +1598,7 @@ export const resolveConnectorCheck$ = command(
       snapshot,
       visibleConnectorSlugs: new Set(visibleConnectorSlugs),
     };
-    let diagnostic: ConnectorCheckDiagnosticResult;
+    let diagnostic: ConnectorCheckTargetAwareDiagnosticResult;
     if (args.request.mode === "url") {
       if (!parsed) {
         throw new Error("Missing parsed connector diagnostic request");
@@ -1302,6 +1617,11 @@ export const resolveConnectorCheck$ = command(
       );
     }
     signal.throwIfAborted();
-    return { kind: "ok", diagnostic };
+    return {
+      kind: "ok",
+      diagnostic: targetAwareUrlRequest(args.request)
+        ? diagnostic
+        : legacyDiagnostic(diagnostic),
+    };
   },
 );

--- a/turbo/apps/api/src/signals/services/connector-check.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-check.service.ts
@@ -510,6 +510,7 @@ async function loadRunDiagnosticRegistration(
   const [row] = await db
     .select({
       agentId: agents.id,
+      registrationRunId: agentRunConnectorDiagnosticRegistrations.runId,
       payload: agentRunConnectorDiagnosticRegistrations.payload,
     })
     .from(agentRuns)
@@ -531,7 +532,7 @@ async function loadRunDiagnosticRegistration(
   if (!row) {
     return { kind: "not-found" };
   }
-  if (!row.payload) {
+  if (row.registrationRunId === null) {
     return { kind: "missing" };
   }
   const payload = agentRunConnectorDiagnosticRegistrationPayloadSchema.parse(

--- a/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-runtime-sync.service.ts
@@ -43,10 +43,96 @@ interface CustomTargetSnapshot {
   readonly grant: AgentCustomConnectorGrant | undefined;
 }
 
+type ConnectorRuntimeBuiltinSyncResult = Extract<
+  ConnectorRuntimeSyncResult,
+  { readonly target: { readonly kind: "builtin" } }
+>;
+
+type ConnectorRuntimeCustomSyncResult = Extract<
+  ConnectorRuntimeSyncResult,
+  { readonly target: { readonly kind: "custom" } }
+>;
+
+type ResolvedConnectorRuntimeTarget =
+  | {
+      readonly kind: "builtin";
+      readonly result: ConnectorRuntimeBuiltinSyncResult;
+    }
+  | {
+      readonly kind: "custom";
+      readonly result: ConnectorRuntimeCustomSyncResult;
+      readonly customSnapshot: CustomTargetSnapshot | undefined;
+    };
+
+interface ConnectorRuntimeDiagnosticApi {
+  readonly base: string;
+  readonly permissions: readonly {
+    readonly name: string;
+    readonly rules: readonly string[];
+  }[];
+}
+
+export type ConnectorRuntimeDiagnosticResult =
+  | {
+      readonly target: Extract<
+        ConnectorRuntimeTarget,
+        { readonly kind: "builtin" }
+      >;
+      readonly state: "available";
+      readonly networkPolicy: Extract<
+        ConnectorRuntimeSyncResult,
+        {
+          readonly target: { readonly kind: "builtin" };
+          readonly state: "available";
+        }
+      >["networkPolicy"];
+    }
+  | {
+      readonly target: Extract<
+        ConnectorRuntimeTarget,
+        { readonly kind: "builtin" }
+      >;
+      readonly state: "unresolved";
+      readonly reason: "connector-unavailable";
+    }
+  | {
+      readonly target: Extract<
+        ConnectorRuntimeTarget,
+        { readonly kind: "custom" }
+      >;
+      readonly state: "available";
+      readonly label: string;
+      readonly credentialResolution: "network-boundary" | "none";
+      readonly apis: readonly ConnectorRuntimeDiagnosticApi[];
+      readonly networkPolicy: Extract<
+        ConnectorRuntimeSyncResult,
+        {
+          readonly target: { readonly kind: "custom" };
+          readonly state: "available";
+        }
+      >["networkPolicy"];
+    }
+  | {
+      readonly target: Extract<
+        ConnectorRuntimeTarget,
+        { readonly kind: "custom" }
+      >;
+      readonly state: "unresolved";
+      readonly reason: ConnectorRuntimeCustomUnresolvedReason;
+    }
+  | {
+      readonly target: Extract<
+        ConnectorRuntimeTarget,
+        { readonly kind: "custom" }
+      >;
+      readonly state: "absent";
+      readonly reason: ConnectorRuntimeCustomAbsentReason;
+    };
+
 function customAbsentResult(
   target: Extract<ConnectorRuntimeTarget, { readonly kind: "custom" }>,
   reason: ConnectorRuntimeCustomAbsentReason,
-): ConnectorRuntimeSyncResult {
+): ConnectorRuntimeCustomSyncResult {
   return {
     target,
     state: "absent",
@@ -57,7 +143,7 @@ function customAbsentResult(
 function customUnresolvedResult(
   target: Extract<ConnectorRuntimeTarget, { readonly kind: "custom" }>,
   reason: ConnectorRuntimeCustomUnresolvedReason,
-): ConnectorRuntimeSyncResult {
+): ConnectorRuntimeCustomSyncResult {
   return {
     target,
     state: "unresolved",
@@ -67,7 +153,7 @@ function customUnresolvedResult(
 
 function builtinUnresolvedResult(
   target: Extract<ConnectorRuntimeTarget, { readonly kind: "builtin" }>,
-): ConnectorRuntimeSyncResult {
+): ConnectorRuntimeBuiltinSyncResult {
   return {
     target,
     state: "unresolved",
@@ -194,7 +280,7 @@ async function resolveCustomTarget(args: {
     { readonly kind: "custom" }
   >;
   readonly snapshot: Awaited<ReturnType<typeof loadCustomSnapshot>>;
-}): Promise<ConnectorRuntimeSyncResult> {
+}): Promise<ConnectorRuntimeCustomSyncResult> {
   const target = {
     kind: "custom" as const,
     customConnectorId: args.registration.customConnectorId,
@@ -277,11 +363,11 @@ async function resolveCustomTarget(args: {
   };
 }
 
-export async function resolveConnectorRuntimeTargets(args: {
+async function resolveConnectorRuntimeTargetStates(args: {
   readonly db: Db;
   readonly scope: ConnectorRuntimeScope;
   readonly targets: readonly ConnectorRuntimeTargetRegistration[];
-}): Promise<readonly ConnectorRuntimeSyncResult[]> {
+}): Promise<readonly ResolvedConnectorRuntimeTarget[]> {
   const builtinConnectorSlugs = args.targets.flatMap((target) => {
     return target.kind === "builtin" ? [target.connectorSlug] : [];
   });
@@ -343,15 +429,22 @@ export async function resolveConnectorRuntimeTargets(args: {
     }),
   );
 
-  const results: ConnectorRuntimeSyncResult[] = [];
+  const resolvedTargets: ResolvedConnectorRuntimeTarget[] = [];
   for (const registration of args.targets) {
     if (registration.kind === "custom") {
       if (!customSnapshot) {
         throw new Error("Custom connector runtime snapshot is unavailable");
       }
-      results.push(
-        await resolveCustomTarget({ registration, snapshot: customSnapshot }),
-      );
+      resolvedTargets.push({
+        kind: "custom",
+        result: await resolveCustomTarget({
+          registration,
+          snapshot: customSnapshot,
+        }),
+        customSnapshot: customSnapshot.customTargets.get(
+          registration.customConnectorId,
+        ),
+      });
       continue;
     }
     const target = {
@@ -376,30 +469,144 @@ export async function resolveConnectorRuntimeTargets(args: {
           })
         : undefined;
     const refresh = builtinByTarget.get(connectorRuntimeTargetKey(target));
-    results.push(
-      refresh && credentialAccess?.kind === "ok"
-        ? {
-            target,
-            state: "available",
-            networkPolicy: refresh.networkPolicy,
-            ...(refresh.nextRefreshAt
-              ? { nextSyncAt: refresh.nextRefreshAt }
-              : {}),
-          }
-        : builtinUnresolvedResult(target),
-    );
+    resolvedTargets.push({
+      kind: "builtin",
+      result:
+        refresh && credentialAccess?.kind === "ok"
+          ? {
+              target,
+              state: "available",
+              networkPolicy: refresh.networkPolicy,
+              ...(refresh.nextRefreshAt
+                ? { nextSyncAt: refresh.nextRefreshAt }
+                : {}),
+            }
+          : builtinUnresolvedResult(target),
+    });
   }
+  logResolvedConnectorRuntimeTargets(args.targets, resolvedTargets);
+  return resolvedTargets;
+}
+
+function logResolvedConnectorRuntimeTargets(
+  targets: readonly ConnectorRuntimeTargetRegistration[],
+  resolvedTargets: readonly ResolvedConnectorRuntimeTarget[],
+): void {
   const stateCounts = { available: 0, absent: 0, unresolved: 0 };
-  for (const result of results) {
-    stateCounts[result.state] += 1;
+  for (const target of resolvedTargets) {
+    stateCounts[target.result.state] += 1;
   }
   L.debug("Resolved connector runtime targets", {
-    targetCount: args.targets.length,
-    builtinTargetCount: builtinConnectorSlugs.length,
-    customTargetCount: customRegistrations.length,
+    targetCount: targets.length,
+    builtinTargetCount: targets.filter((target) => {
+      return target.kind === "builtin";
+    }).length,
+    customTargetCount: targets.filter((target) => {
+      return target.kind === "custom";
+    }).length,
     availableCount: stateCounts.available,
     absentCount: stateCounts.absent,
     unresolvedCount: stateCounts.unresolved,
   });
-  return results;
+}
+
+export async function resolveConnectorRuntimeTargets(args: {
+  readonly db: Db;
+  readonly scope: ConnectorRuntimeScope;
+  readonly targets: readonly ConnectorRuntimeTargetRegistration[];
+}): Promise<readonly ConnectorRuntimeSyncResult[]> {
+  const resolvedTargets = await resolveConnectorRuntimeTargetStates(args);
+  return resolvedTargets.map((target) => {
+    return target.result;
+  });
+}
+
+function diagnosticCustomApis(
+  result: Extract<
+    ConnectorRuntimeSyncResult,
+    {
+      readonly target: { readonly kind: "custom" };
+      readonly state: "available";
+    }
+  >,
+): readonly ConnectorRuntimeDiagnosticApi[] {
+  return result.firewall.firewall.apis.map((api) => {
+    return {
+      base: api.base,
+      permissions: (api.permissions ?? []).map((permission) => {
+        return { name: permission.name, rules: [...permission.rules] };
+      }),
+    };
+  });
+}
+
+function diagnosticCustomCredentialResolution(
+  result: Extract<
+    ConnectorRuntimeSyncResult,
+    {
+      readonly target: { readonly kind: "custom" };
+      readonly state: "available";
+    }
+  >,
+): "network-boundary" | "none" {
+  return result.firewall.firewall.apis.some((api) => {
+    return (
+      Object.keys(api.auth.headers ?? {}).length > 0 ||
+      Object.keys(api.auth.query ?? {}).length > 0
+    );
+  })
+    ? "network-boundary"
+    : "none";
+}
+
+export async function resolveConnectorRuntimeDiagnosticTargets(args: {
+  readonly db: Db;
+  readonly scope: ConnectorRuntimeScope;
+  readonly targets: readonly ConnectorRuntimeTargetRegistration[];
+}): Promise<readonly ConnectorRuntimeDiagnosticResult[]> {
+  const resolvedTargets = await resolveConnectorRuntimeTargetStates(args);
+  return resolvedTargets.map((resolved): ConnectorRuntimeDiagnosticResult => {
+    if (resolved.kind === "builtin") {
+      const { result } = resolved;
+      return result.state === "available"
+        ? {
+            target: result.target,
+            state: result.state,
+            networkPolicy: result.networkPolicy,
+          }
+        : {
+            target: result.target,
+            state: result.state,
+            reason: result.reason,
+          };
+    }
+    const { result } = resolved;
+    if (result.state === "absent") {
+      return {
+        target: result.target,
+        state: result.state,
+        reason: result.reason,
+      };
+    }
+    if (result.state === "unresolved") {
+      return {
+        target: result.target,
+        state: result.state,
+        reason: result.reason,
+      };
+    }
+    if (!resolved.customSnapshot) {
+      throw new Error(
+        `Missing custom connector diagnostic metadata: ${result.target.customConnectorId}`,
+      );
+    }
+    return {
+      target: result.target,
+      state: result.state,
+      label: resolved.customSnapshot.row.connector.displayName,
+      credentialResolution: diagnosticCustomCredentialResolution(result),
+      apis: diagnosticCustomApis(result),
+      networkPolicy: result.networkPolicy,
+    };
+  });
 }

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -26,6 +26,7 @@ import {
 } from "@okouai/api-contracts/contracts/connector-catalog";
 import {
   connectorCheckContract,
+  connectorCheckDiagnosticResultSchema,
   type ConnectorCheckDiagnosticResult,
   type ConnectorCheckRequest,
 } from "@okouai/api-contracts/contracts/connector-check";
@@ -220,7 +221,7 @@ export async function diagnoseConnectorCheck(
   const result = await client.check({ body: request });
 
   if (result.status === 200) {
-    return result.body;
+    return connectorCheckDiagnosticResultSchema.parse(result.body);
   }
 
   handleError(result, "Failed to diagnose connector");

--- a/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/connector-client-contract.test.ts
@@ -16,7 +16,9 @@ import { connectorCatalogContract } from "../connector-catalog";
 import { connectorAccountsContract } from "../connector-accounts";
 import {
   connectorCheckDiagnosticResultSchema,
+  connectorCheckRequestBodySchema,
   connectorCheckRequestSchema,
+  connectorCheckResponseBodySchema,
 } from "../connector-check";
 import { connectorsSearchContract } from "../connectors";
 import {
@@ -458,6 +460,85 @@ describe("connector client request contracts", () => {
       }),
     ).toStrictEqual({ ...base, connectorSlug: "github" });
     expect(connectorCheckRequestSchema.parse(base)).toStrictEqual(base);
+  });
+
+  it("separates legacy and target-aware connector check requests", () => {
+    const base = {
+      mode: "url" as const,
+      method: "GET",
+      url: "https://api.example.test/v1/items",
+    };
+    const automatic = { ...base, includeCustomConnectors: true as const };
+    const selected = {
+      ...base,
+      target: {
+        kind: "custom" as const,
+        customConnectorId: "00000000-0000-4000-a000-000000000005",
+      },
+    };
+
+    expect(connectorCheckRequestBodySchema.parse(automatic)).toStrictEqual(
+      automatic,
+    );
+    expect(connectorCheckRequestBodySchema.parse(selected)).toStrictEqual(
+      selected,
+    );
+    expect(() => {
+      connectorCheckRequestSchema.parse(automatic);
+    }).toThrow();
+    expect(() => {
+      connectorCheckRequestBodySchema.parse({
+        ...selected,
+        connectorSlug: "github",
+      });
+    }).toThrow();
+  });
+
+  it("accepts target-aware connector check responses separately", () => {
+    const target = {
+      kind: "custom" as const,
+      customConnectorId: "00000000-0000-4000-a000-000000000005",
+    };
+    const resolved = {
+      outcome: "resolved" as const,
+      mode: "url" as const,
+      connector: {
+        target,
+        label: "Example",
+        visibility: "available" as const,
+        credentialResolution: "network-boundary" as const,
+      },
+      environmentNames: null,
+      run: {
+        status: "configured" as const,
+        bases: ["https://api.example.test/v1"],
+      },
+      method: "GET",
+      base: "https://api.example.test/v1",
+      relativePath: "/items",
+      permission: {
+        kind: "unknown-endpoint" as const,
+        policy: { outcome: "allow" as const, basis: "unknown-policy" as const },
+      },
+    };
+
+    expect(connectorCheckResponseBodySchema.parse(resolved)).toStrictEqual(
+      resolved,
+    );
+    expect(() => {
+      connectorCheckDiagnosticResultSchema.parse(resolved);
+    }).toThrow();
+    expect(
+      connectorCheckResponseBodySchema.parse({
+        outcome: "target-unavailable",
+        target,
+        reason: "not-admitted",
+      }),
+    ).toStrictEqual({
+      outcome: "target-unavailable",
+      target,
+      reason: "not-admitted",
+    });
   });
 
   it("accepts canonical user connector updates", () => {

--- a/turbo/packages/api-contracts/src/contracts/connector-check.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-check.ts
@@ -9,7 +9,7 @@ const c = initContract();
 
 const boundedNameSchema = z.string().min(1).max(255);
 
-export const connectorCheckUrlRequestSchema = z
+const connectorCheckUrlRequestSchema = z
   .object({
     mode: z.literal("url"),
     method: z.string().min(1).max(16),

--- a/turbo/packages/api-contracts/src/contracts/connector-check.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-check.ts
@@ -3,12 +3,13 @@ import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { connectorSlugSchema } from "./connector-identity";
 import { apiErrorSchema } from "./errors";
+import { connectorRuntimeTargetSchema } from "./runners";
 
 const c = initContract();
 
 const boundedNameSchema = z.string().min(1).max(255);
 
-const connectorCheckUrlRequestSchema = z
+export const connectorCheckUrlRequestSchema = z
   .object({
     mode: z.literal("url"),
     method: z.string().min(1).max(16),
@@ -33,6 +34,38 @@ export const connectorCheckRequestSchema = z.discriminatedUnion("mode", [
 
 export type ConnectorCheckRequest = z.infer<typeof connectorCheckRequestSchema>;
 
+export const connectorCheckTargetAwareUrlRequestSchema = z
+  .object({
+    mode: z.literal("url"),
+    method: z.string().min(1).max(16),
+    url: z.string().min(1).max(8192),
+    environmentName: boundedNameSchema.optional(),
+    includeCustomConnectors: z.literal(true).optional(),
+    target: connectorRuntimeTargetSchema.optional(),
+  })
+  .strict()
+  .refine(
+    (request) => {
+      return (
+        request.includeCustomConnectors === true || request.target !== undefined
+      );
+    },
+    { message: "Target-aware connector checks require custom scope or target" },
+  );
+
+export const connectorCheckRequestBodySchema = z.union([
+  connectorCheckUrlRequestSchema,
+  connectorCheckTargetAwareUrlRequestSchema,
+  connectorCheckEnvironmentRequestSchema,
+]);
+
+export type ConnectorCheckTargetAwareUrlRequest = z.infer<
+  typeof connectorCheckTargetAwareUrlRequestSchema
+>;
+export type ConnectorCheckRequestBody = z.infer<
+  typeof connectorCheckRequestBodySchema
+>;
+
 const connectorCheckIdentitySchema = z.object({
   connectorSlug: connectorSlugSchema,
   label: z.string().min(1),
@@ -44,6 +77,22 @@ const connectorCheckCandidateSchema = z.object({
   connectorSlug: connectorSlugSchema,
   label: z.string().min(1),
 });
+
+const connectorCheckTargetIdentitySchema = z
+  .object({
+    target: connectorRuntimeTargetSchema,
+    label: z.string().min(1),
+    visibility: z.enum(["available", "unavailable"]),
+    credentialResolution: z.enum(["network-boundary", "none"]),
+  })
+  .strict();
+
+const connectorCheckTargetCandidateSchema = z
+  .object({
+    target: connectorRuntimeTargetSchema,
+    label: z.string().min(1),
+  })
+  .strict();
 
 const connectorCheckNotScopedRunSchema = z
   .object({ status: z.literal("not-scoped") })
@@ -220,6 +269,51 @@ const connectorCheckRunContextUnavailableSchema = z
   .object({ outcome: z.literal("run-context-unavailable") })
   .strict();
 
+const connectorCheckTargetResolvedUrlSchema = connectorCheckResolvedUrlSchema
+  .extend({ connector: connectorCheckTargetIdentitySchema })
+  .strict();
+
+const connectorCheckTargetResolvedEnvironmentSchema =
+  connectorCheckResolvedEnvironmentSchema
+    .extend({ connector: connectorCheckTargetIdentitySchema })
+    .strict();
+
+const connectorCheckTargetAmbiguousSchema = connectorCheckAmbiguousSchema
+  .extend({ candidates: z.array(connectorCheckTargetCandidateSchema).min(2) })
+  .strict();
+
+const connectorCheckTargetMismatchSchema = connectorCheckMismatchSchema
+  .extend({ connector: connectorCheckTargetIdentitySchema })
+  .strict();
+
+const connectorCheckTargetEnvironmentNotOwnedSchema =
+  connectorCheckEnvironmentNotOwnedSchema
+    .extend({ connector: connectorCheckTargetIdentitySchema })
+    .strict();
+
+const connectorCheckTargetEnvironmentNotUsedSchema =
+  connectorCheckEnvironmentNotUsedSchema
+    .extend({ connector: connectorCheckTargetIdentitySchema })
+    .strict();
+
+const connectorCheckTargetUnresolvedDynamicBaseSchema =
+  connectorCheckUnresolvedDynamicBaseSchema
+    .extend({ connector: connectorCheckTargetIdentitySchema })
+    .strict();
+
+const connectorCheckTargetUnavailableSchema = z
+  .object({
+    outcome: z.literal("target-unavailable"),
+    target: connectorRuntimeTargetSchema,
+    reason: z.enum([
+      "not-admitted",
+      "connector-unavailable",
+      "permission-bundle-unavailable",
+      "runtime-configuration-unavailable",
+    ]),
+  })
+  .strict();
+
 export const connectorCheckDiagnosticResultSchema = z.union([
   connectorCheckResolvedUrlSchema,
   connectorCheckResolvedEnvironmentSchema,
@@ -239,14 +333,42 @@ export type ConnectorCheckDiagnosticResult = z.infer<
   typeof connectorCheckDiagnosticResultSchema
 >;
 
+export const connectorCheckTargetAwareDiagnosticResultSchema = z.union([
+  connectorCheckTargetResolvedUrlSchema,
+  connectorCheckTargetResolvedEnvironmentSchema,
+  connectorCheckUnsafeInputSchema,
+  connectorCheckUnknownConnectorSchema,
+  connectorCheckUnknownEnvironmentSchema,
+  connectorCheckNoMatchSchema,
+  connectorCheckTargetAmbiguousSchema,
+  connectorCheckTargetMismatchSchema,
+  connectorCheckTargetEnvironmentNotOwnedSchema,
+  connectorCheckTargetEnvironmentNotUsedSchema,
+  connectorCheckTargetUnresolvedDynamicBaseSchema,
+  connectorCheckTargetUnavailableSchema,
+  connectorCheckRunContextUnavailableSchema,
+]);
+
+export const connectorCheckResponseBodySchema = z.union([
+  connectorCheckDiagnosticResultSchema,
+  connectorCheckTargetAwareDiagnosticResultSchema,
+]);
+
+export type ConnectorCheckTargetAwareDiagnosticResult = z.infer<
+  typeof connectorCheckTargetAwareDiagnosticResultSchema
+>;
+export type ConnectorCheckResponseBody = z.infer<
+  typeof connectorCheckResponseBodySchema
+>;
+
 export const connectorCheckContract = c.router({
   check: {
     method: "POST",
     path: "/api/connectors/diagnostics/check",
     headers: authHeadersSchema,
-    body: connectorCheckRequestSchema,
+    body: connectorCheckRequestBodySchema,
     responses: {
-      200: connectorCheckDiagnosticResultSchema,
+      200: connectorCheckResponseBodySchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
@@ -27,6 +27,7 @@ export const testCronCleanupSandboxesStateActionBodySchema = z
       "get-export-job",
       "seed-connector-diagnostic-registration",
       "get-connector-diagnostic-registration",
+      "corrupt-connector-diagnostic-registration",
       "delete-connector-diagnostic-registration",
       "transition-run-terminal",
     ]),

--- a/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
@@ -27,6 +27,7 @@ export const testCronCleanupSandboxesStateActionBodySchema = z
       "get-export-job",
       "seed-connector-diagnostic-registration",
       "get-connector-diagnostic-registration",
+      "delete-connector-diagnostic-registration",
       "transition-run-terminal",
     ]),
   })


### PR DESCRIPTION
## Summary

- replace connector-check's Axiom run-context read with the active run diagnostic registration and current runtime authorities
- add target-aware builtin/custom request and response contracts while preserving exact legacy builtin-only requests and CLI behavior
- project current custom routing and policy state through an explicit credential-free adapter without changing runner runtime-sync responses
- distinguish missing legacy registration, stale/foreign runs, unadmitted targets, and unavailable admitted targets

## Rollout compatibility

This is the backend-first slice. Legacy requests remain builtin-only and receive the legacy response family. The released CLI does not send the target-aware fields in this PR. #32165 will activate custom target requests and presentation only after this backend support is deployed; no capability or protocol-version handshake is introduced.

## Exclusions

- no CLI-visible custom connector behavior or output changes
- no custom permission approval flow
- no changes to runner runtime-sync protocol or unrelated run-detail Axiom reads

## Validation

- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F @okouai/cli lint`
- `pnpm -F @okouai/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F @okouai/cli check-types`
- `pnpm -F @okouai/api-contracts check-types`
- pre-commit `pnpm check-types` (15 packages)
- `pnpm knip`
- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/connector-client-contract.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-check.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "uses exact runtime projections and authoritative fallback for mixed sync|injects enabled custom connector firewalls with resolvable org secrets"`
- `pnpm -F @okouai/cli exec vitest run src/commands/connector/__tests__/check.test.ts`
- `pnpm -F @okouai/cli exec vitest run src/commands/connector/__tests__/permission-request.test.ts`

Closes #32164

Parent: #32074

Follow-up: #32165
