### PR TITLE
perf(runner): streamline terminal idle finalization

### DIFF
--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -393,9 +393,9 @@ pub(super) async fn destroy_idle_jobs_and_wait(
     jobs: Vec<IdleDestroyJob>,
     context: &'static str,
 ) -> bool {
-    // Destroy in parallel -- each `stop_and_destroy` is ~1-3s (FC shutdown +
-    // cgroup/NBD/netns teardown). Serial destroy blows past shutdown and
-    // budget-pressure recovery budgets on multi-sandbox cleanup.
+    // Destroy in parallel -- cgroup/NBD/netns teardown can still make serial
+    // cleanup exceed shutdown and budget-pressure recovery budgets when many
+    // sandboxes are idle.
     let mut set = JoinSet::new();
     for job in jobs {
         set.spawn(destroy_idle_job(job, context));

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -555,12 +555,12 @@ async fn foreground_admission_drains_cancelled_blank_park_before_destroy() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn blank_park_and_stop_panics_keep_budget_owned_through_destroy() {
+async fn blank_park_and_kill_panics_keep_budget_owned_through_destroy() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let calls = Arc::clone(&overrides);
     let destroy_gate = sandbox_mock::MockLifecycleGate::new();
     overrides.push_park_panic("simulated blank park panic");
-    overrides.push_stop_panic("simulated blank stop panic");
+    overrides.push_kill_panic("simulated blank kill panic");
     overrides.set_destroy_lifecycle_gate(destroy_gate.clone());
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, overrides);
     let budget = Arc::clone(&config.capacity.budget);

--- a/crates/runner/src/idle_pool/destroy_tests.rs
+++ b/crates/runner/src/idle_pool/destroy_tests.rs
@@ -74,28 +74,32 @@ pub(super) async fn make_idle_destroy_job_for(
 }
 
 #[tokio::test]
-async fn idle_destroy_payload_stop_error_completes_after_destroy() {
+async fn idle_destroy_payload_kill_error_completes_after_destroy() {
     let overrides = Arc::new(MockSandboxOverrides::new());
-    overrides.push_stop_result(Err(sandbox::SandboxError::Start {
-        message: "simulated idle stop failure".into(),
+    overrides.push_kill_result(Err(sandbox::SandboxError::Start {
+        message: "simulated idle kill failure".into(),
     }));
     let payload = make_idle_destroy_payload(Arc::clone(&overrides)).await;
 
     let outcome = payload.stop_and_destroy().await;
 
     assert_eq!(outcome, DestroyOutcome::Completed);
+    assert_eq!(overrides.stop_call_count(), 0);
+    assert_eq!(overrides.kill_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 1);
 }
 
 #[tokio::test]
-async fn idle_destroy_payload_stop_panic_is_uncertain_after_destroy() {
+async fn idle_destroy_payload_kill_panic_is_uncertain_after_destroy() {
     let overrides = Arc::new(MockSandboxOverrides::new());
-    overrides.push_stop_panic("simulated idle stop panic");
+    overrides.push_kill_panic("simulated idle kill panic");
     let payload = make_idle_destroy_payload(Arc::clone(&overrides)).await;
 
     let outcome = payload.stop_and_destroy().await;
 
     assert_eq!(outcome, DestroyOutcome::Uncertain);
+    assert_eq!(overrides.stop_call_count(), 0);
+    assert_eq!(overrides.kill_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 1);
 }
 
@@ -149,10 +153,10 @@ async fn idle_destroy_job_destroy_panic_preserves_workspace_cache_and_releases_b
 }
 
 #[tokio::test]
-async fn idle_destroy_job_stop_panic_still_attempts_destroy_and_releases_budget_lease() {
-    let fixture = WorkspacePromotionFixture::new("sess-idle-destroy-stop-panic").await;
+async fn idle_destroy_job_kill_panic_still_attempts_destroy_and_releases_budget_lease() {
+    let fixture = WorkspacePromotionFixture::new("sess-idle-destroy-kill-panic").await;
     let overrides = Arc::new(MockSandboxOverrides::new());
-    overrides.push_stop_panic("simulated idle stop panic");
+    overrides.push_kill_panic("simulated idle kill panic");
     let (budget, lease) = reserved_budget_lease();
     let job = make_idle_destroy_job_for(
         fixture.sandbox_id,
@@ -162,7 +166,7 @@ async fn idle_destroy_job_stop_panic_still_attempts_destroy_and_releases_budget_
     )
     .await;
 
-    let promoted = job.run_with_context("test_stop_panic").await;
+    let promoted = job.run_with_context("test_kill_panic").await;
 
     assert!(!promoted);
     let exec_calls = overrides.exec_calls();
@@ -178,16 +182,16 @@ async fn idle_destroy_job_stop_panic_still_attempts_destroy_and_releases_budget_
 }
 
 #[tokio::test]
-async fn idle_destroy_job_stop_error_still_attempts_destroy_and_releases_budget_lease() {
+async fn idle_destroy_job_kill_error_still_attempts_destroy_and_releases_budget_lease() {
     let overrides = Arc::new(MockSandboxOverrides::new());
-    overrides.push_stop_result(Err(sandbox::SandboxError::Start {
-        message: "simulated idle stop failure".into(),
+    overrides.push_kill_result(Err(sandbox::SandboxError::Start {
+        message: "simulated idle kill failure".into(),
     }));
     let (budget, lease) = reserved_budget_lease();
     assert_eq!(budget.allocated(), (2, 4096, 1));
     let job = make_idle_destroy_job(Arc::clone(&overrides), lease).await;
 
-    let promoted = job.run_with_context("test_stop_error").await;
+    let promoted = job.run_with_context("test_kill_error").await;
 
     assert!(!promoted);
     assert_eq!(overrides.destroy_call_count(), 1);
@@ -195,7 +199,7 @@ async fn idle_destroy_job_stop_error_still_attempts_destroy_and_releases_budget_
 }
 
 #[tokio::test]
-async fn idle_destroy_job_publishes_frozen_workspace_only_after_successful_stop() {
+async fn idle_destroy_job_publishes_frozen_workspace_only_after_successful_kill() {
     let fixture = WorkspacePromotionFixture::new("sess-idle-destroy-promote").await;
     let overrides = Arc::new(MockSandboxOverrides::new());
     let (budget, lease) = reserved_budget_lease();
@@ -210,6 +214,9 @@ async fn idle_destroy_job_publishes_frozen_workspace_only_after_successful_stop(
     let promoted = job.run_with_context("test_idle_destroy_promote").await;
 
     assert!(promoted);
+    assert_eq!(overrides.terminal_unpark_call_count(), 1);
+    assert_eq!(overrides.stop_call_count(), 0);
+    assert_eq!(overrides.kill_call_count(), 1);
     let exec_calls = overrides.exec_calls();
     assert_eq!(exec_calls.len(), 1);
     assert!(
@@ -240,11 +247,11 @@ async fn idle_destroy_job_publishes_frozen_workspace_only_after_successful_stop(
 }
 
 #[tokio::test]
-async fn idle_destroy_job_stop_error_abandons_frozen_workspace_and_still_destroys() {
-    let fixture = WorkspacePromotionFixture::new("sess-idle-destroy-stop-error").await;
+async fn idle_destroy_job_kill_error_abandons_frozen_workspace_and_still_destroys() {
+    let fixture = WorkspacePromotionFixture::new("sess-idle-destroy-kill-error").await;
     let overrides = Arc::new(MockSandboxOverrides::new());
-    overrides.push_stop_result(Err(sandbox::SandboxError::Start {
-        message: "simulated idle stop failure".into(),
+    overrides.push_kill_result(Err(sandbox::SandboxError::Start {
+        message: "simulated idle kill failure".into(),
     }));
     let (budget, lease) = reserved_budget_lease();
     let job = make_idle_destroy_job_for(
@@ -255,9 +262,12 @@ async fn idle_destroy_job_stop_error_abandons_frozen_workspace_and_still_destroy
     )
     .await;
 
-    let promoted = job.run_with_context("test_idle_destroy_stop_error").await;
+    let promoted = job.run_with_context("test_idle_destroy_kill_error").await;
 
     assert!(!promoted);
+    assert_eq!(overrides.terminal_unpark_call_count(), 1);
+    assert_eq!(overrides.stop_call_count(), 0);
+    assert_eq!(overrides.kill_call_count(), 1);
     let exec_calls = overrides.exec_calls();
     assert_eq!(exec_calls.len(), 1);
     assert!(
@@ -271,7 +281,7 @@ async fn idle_destroy_job_stop_error_abandons_frozen_workspace_and_still_destroy
 }
 
 #[tokio::test]
-async fn idle_destroy_job_publication_failure_after_stop_still_destroys() {
+async fn idle_destroy_job_publication_failure_after_kill_still_destroys() {
     let fixture = WorkspacePromotionFixture::new("sess-idle-destroy-publish-error").await;
     let paths = RunnerPaths::new(fixture._dir.path().join("runner"));
     tokio::fs::remove_file(paths.active_workspace_image(&fixture.sandbox_id))
@@ -348,7 +358,10 @@ async fn assert_idle_destroy_job_unpark_failure_skips_workspace_cache_and_still_
 
     assert!(!promoted);
     assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.terminal_unpark_call_count(), 1);
     assert!(overrides.exec_calls().is_empty());
+    assert_eq!(overrides.stop_call_count(), 0);
+    assert_eq!(overrides.kill_call_count(), 1);
     assert_eq!(overrides.destroy_call_count(), 1);
     assert_eq!(budget.allocated(), (0, 0, 0));
     assert!(fixture.cache.held_workspace_states().await.is_empty());

--- a/crates/runner/src/idle_pool/entry.rs
+++ b/crates/runner/src/idle_pool/entry.rs
@@ -482,7 +482,7 @@ pub(crate) struct RetainedIdleDestroyResult {
 }
 
 impl IdleDestroyPayload {
-    /// Stop the sandbox and destroy it via its factory.
+    /// Finalize the idle sandbox and destroy it via its factory.
     #[cfg(test)]
     pub(crate) async fn stop_and_destroy(self) -> DestroyOutcome {
         self.finalize_workspace_and_destroy("idle_destroy")
@@ -528,27 +528,27 @@ impl IdleDestroyPayload {
             }
         };
         let mut uncertain = false;
-        let stopped = match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
+        let terminated = match AssertUnwindSafe(sandbox.kill()).catch_unwind().await {
             Ok(Ok(())) => true,
             Ok(Err(e)) => {
-                tracing::warn!(error = %e, "failed to stop idle sandbox");
+                tracing::warn!(error = %e, "failed to kill idle sandbox");
                 false
             }
             Err(_) => {
-                tracing::warn!("idle sandbox stop panicked");
+                tracing::warn!("idle sandbox kill panicked");
                 uncertain = true;
                 false
             }
         };
-        if stopped {
+        if terminated {
             // The guest is no longer running; host publication and destruction
             // need not hold up the next parked sandbox's reclamation.
             drop(reclamation_permit.take());
         }
-        let workspace_cache_promoted = match (prepared_promotion, stopped) {
+        let workspace_cache_promoted = match (prepared_promotion, terminated) {
             (Some(promotion), true) => promotion.publish().await,
             (Some(promotion), false) => {
-                promotion.abandon("idle_sandbox_stop_failed").await;
+                promotion.abandon("idle_sandbox_kill_failed").await;
                 false
             }
             (None, _) => false,
@@ -561,7 +561,7 @@ impl IdleDestroyPayload {
             tracing::warn!("idle sandbox destroy panicked");
             uncertain = true;
         }
-        // A failed stop may leave the guest running until factory destruction.
+        // A failed kill may leave the guest running until factory destruction.
         drop(reclamation_permit);
         if uncertain {
             IdleDestroyResult {

--- a/crates/runner/src/idle_pool/reclamation_tests.rs
+++ b/crates/runner/src/idle_pool/reclamation_tests.rs
@@ -33,7 +33,7 @@ async fn sibling_fixture(
 }
 
 #[tokio::test]
-async fn idle_reclamation_holds_from_unpark_through_stop_but_not_host_destroy() {
+async fn idle_reclamation_holds_from_terminal_unpark_through_kill_but_not_host_destroy() {
     let history = br#"{"type":"message","content":"bounded reclamation"}"#;
     let identity = test_restored_session_identity("sess-reclamation", history);
     let first = WorkspacePromotionFixture::new_with_restored_session_identity_and_export_capacity(
@@ -47,12 +47,12 @@ async fn idle_reclamation_holds_from_unpark_through_stop_but_not_host_destroy() 
     let unpark = MockLifecycleGate::new();
     let exec = MockLifecycleGate::new();
     let copy = MockLifecycleGate::new();
-    let stop = MockLifecycleGate::new();
+    let kill = MockLifecycleGate::new();
     let destroy = MockLifecycleGate::new();
     overrides.set_unpark_lifecycle_gate(unpark.clone());
     overrides.set_exec_lifecycle_gate(exec.clone());
     overrides.set_copy_file_lifecycle_gate(copy.clone());
-    overrides.set_stop_lifecycle_gate(stop.clone());
+    overrides.set_kill_lifecycle_gate(kill.clone());
     overrides.set_destroy_lifecycle_gate(destroy.clone());
     overrides.add_exec_result_matcher(
         "export-session-history-sidecar",
@@ -100,17 +100,23 @@ async fn idle_reclamation_holds_from_unpark_through_stop_but_not_host_destroy() 
     assert!(matches!(futures_util::poll!(&mut queued), Poll::Pending));
     assert_eq!(second_overrides.unpark_call_count(), 0);
     copy.release_one();
-    // Sidecar cleanup, then workspace freeze, are both still admitted work.
-    for count in [2, 3] {
-        exec.wait_entered(count, WAIT).await.unwrap();
-        assert!(matches!(futures_util::poll!(&mut queued), Poll::Pending));
-        assert_eq!(second_overrides.unpark_call_count(), 0);
-        exec.release_one();
-    }
-    stop.wait_entered(1, WAIT).await.unwrap();
+    // Workspace freeze remains admitted work; guest sidecar cleanup is left
+    // to sandbox destruction.
+    exec.wait_entered(2, WAIT).await.unwrap();
     assert!(matches!(futures_util::poll!(&mut queued), Poll::Pending));
     assert_eq!(second_overrides.unpark_call_count(), 0);
-    stop.release_one();
+    exec.release_one();
+    kill.wait_entered(1, WAIT).await.unwrap();
+    assert!(matches!(futures_util::poll!(&mut queued), Poll::Pending));
+    assert_eq!(second_overrides.unpark_call_count(), 0);
+    assert!(
+        first.cache.held_workspace_states().await.is_empty(),
+        "frozen workspace must remain unpublished until kill succeeds"
+    );
+    assert_eq!(overrides.terminal_unpark_call_count(), 1);
+    assert_eq!(overrides.stop_call_count(), 0);
+    assert_eq!(overrides.kill_call_count(), 1);
+    kill.release_one();
     destroy.wait_entered(1, WAIT).await.unwrap();
 
     let second_result = tokio::time::timeout(WAIT, queued).await.unwrap();
@@ -118,7 +124,7 @@ async fn idle_reclamation_holds_from_unpark_through_stop_but_not_host_destroy() 
     assert_eq!(second_overrides.destroy_call_count(), 1);
     assert!(
         !task.is_finished(),
-        "post-stop host cleanup is still blocked"
+        "post-kill host cleanup is still blocked"
     );
     assert_eq!(budget.allocated(), (2, 4096, 1));
     destroy.release_one();
@@ -170,7 +176,7 @@ async fn idle_reclamation_uses_host_cpu_capacity_across_cache_clones() {
                 .iter()
                 .all(|result| result.outcome == DestroyOutcome::Completed)
         );
-        // Publication is best effort: concurrent post-stop publishers may skip
+        // Publication is best effort: concurrent post-kill publishers may skip
         // the nonblocking cache-capacity lock, but every sandbox must be cleaned up.
         let promoted = results
             .iter()
@@ -184,22 +190,22 @@ async fn idle_reclamation_uses_host_cpu_capacity_across_cache_clones() {
 }
 
 #[tokio::test]
-async fn idle_reclamation_retains_admission_through_destroy_when_stop_fails() {
+async fn idle_reclamation_retains_admission_through_destroy_when_kill_fails() {
     for panics in [false, true] {
         let first =
             WorkspacePromotionFixture::new_with_restored_session_identity_and_export_capacity(
-                "thread:stop-failure",
+                "thread:kill-failure",
                 None,
                 1,
             )
             .await;
-        let second = sibling_fixture(&first, "thread:after-stop-failure").await;
+        let second = sibling_fixture(&first, "thread:after-kill-failure").await;
         let overrides = Arc::new(MockSandboxOverrides::new());
         if panics {
-            overrides.push_stop_panic("test stop panic");
+            overrides.push_kill_panic("test kill panic");
         } else {
-            overrides.push_stop_result(Err(SandboxError::Start {
-                message: "test stop failure".into(),
+            overrides.push_kill_result(Err(SandboxError::Start {
+                message: "test kill failure".into(),
             }));
         }
         let destroy = MockLifecycleGate::new();
@@ -287,7 +293,7 @@ async fn idle_reclamation_failure_releases_admission_after_cleanup() {
                 overrides.add_exec_panic_matcher("--freeze", "test freeze panic")
             }
             Failure::DestroyPanic => {
-                overrides.push_stop_panic("test stop panic");
+                overrides.push_kill_panic("test kill panic");
                 overrides.push_destroy_panic("test destroy panic");
             }
         }

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -24,7 +24,6 @@ use crate::workspace_mount::freeze_workspace_drive;
 
 const SESSION_HISTORY_SIDECAR_EXPORT_TIMEOUT: Duration = Duration::from_secs(30);
 const SESSION_HISTORY_SIDECAR_COPY_TIMEOUT: Duration = Duration::from_secs(30);
-const SESSION_HISTORY_SIDECAR_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 enum WorkspacePromotionAction {
     Promoted,
@@ -33,11 +32,11 @@ enum WorkspacePromotionAction {
 }
 
 /// A workspace image whose guest filesystem is frozen and whose sandbox must
-/// now be stopped and destroyed.
+/// now be terminated and destroyed.
 ///
-/// The active image is not safe to publish until [`Sandbox::stop`] succeeds.
+/// The active image is not safe to publish until sandbox termination succeeds.
 /// Callers must never resume, thaw, or pool the sandbox after preparation.
-#[must_use = "a prepared workspace promotion must be published or abandoned after stopping the sandbox"]
+#[must_use = "a prepared workspace promotion must be published or abandoned after terminating the sandbox"]
 pub(crate) struct PreparedWorkspaceImagePromotion {
     promotion: WorkspaceImagePromotionContext,
     sidecar_source: Option<SessionHistorySidecarSourceGuard>,
@@ -290,8 +289,6 @@ async fn export_session_history_sidecar(
                 error = %e,
                 "workspace image cache session history sidecar export errored"
             );
-            cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason)
-                .await;
             return None;
         }
     };
@@ -342,8 +339,6 @@ async fn export_session_history_sidecar(
                 "workspace image cache session history sidecar export failed"
             );
         }
-        cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason)
-            .await;
         return None;
     }
     let metadata = match serde_json::from_slice::<SessionHistorySidecarExportMetadata>(
@@ -365,19 +360,12 @@ async fn export_session_history_sidecar(
                 reason,
                 "workspace image cache session history sidecar export returned invalid metadata"
             );
-            cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason)
-                .await;
             return None;
         }
     };
-    let Some(entry_guard) = promotion
+    let entry_guard = promotion
         .try_acquire_session_history_sidecar_entry_guard()
-        .await
-    else {
-        cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason)
-            .await;
-        return None;
-    };
+        .await?;
     let tmp_path = entry_guard.session_history_sidecar_tmp_path();
     let source = entry_guard.session_history_sidecar_source(
         tmp_path,
@@ -400,8 +388,6 @@ async fn export_session_history_sidecar(
     {
         Ok(result) => result,
         Err(e) => {
-            cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason)
-                .await;
             sidecar_source.discard().await;
             warn!(
                 run_id = %promotion.run_id(),
@@ -416,7 +402,6 @@ async fn export_session_history_sidecar(
             return None;
         }
     };
-    cleanup_guest_session_history_sidecar_export(sandbox, promotion, &export_path, reason).await;
     if copied.bytes_copied != metadata.encoded_size {
         sidecar_source.discard().await;
         warn!(
@@ -435,50 +420,6 @@ async fn export_session_history_sidecar(
     Some(sidecar_source)
 }
 
-async fn cleanup_guest_session_history_sidecar_export(
-    sandbox: &dyn Sandbox,
-    promotion: &WorkspaceImagePromotionContext,
-    export_path: &str,
-    reason: &'static str,
-) {
-    let command = ["rm -f --".to_string(), quote_shell_arg(export_path)].join(" ");
-    let request = ExecRequest {
-        cmd: &command,
-        timeout: SESSION_HISTORY_SIDECAR_CLEANUP_TIMEOUT,
-        env: &[],
-        sudo: false,
-        expected_exit_codes: &[],
-        stdin_bytes: None,
-        output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
-    };
-    match sandbox
-        .exec_with_diagnostic_label(&request, "session-history-sidecar-cleanup")
-        .await
-    {
-        Ok(result) if helper_exec_succeeded(&result) => {}
-        Ok(result) => warn!(
-            run_id = %promotion.run_id(),
-            sandbox_id = %promotion.sandbox_id(),
-            profile_name = promotion.profile_name(),
-            reuse_key_fingerprint = %crate::paths::short_digest(promotion.reuse_key()),
-            reuse_key_kind = crate::types::reuse_key_kind(promotion.reuse_key()),
-            reason,
-            error = %format_helper_exec_failure("session history sidecar cleanup", &result),
-            "workspace image cache session history sidecar cleanup failed"
-        ),
-        Err(e) => warn!(
-            run_id = %promotion.run_id(),
-            sandbox_id = %promotion.sandbox_id(),
-            profile_name = promotion.profile_name(),
-            reuse_key_fingerprint = %crate::paths::short_digest(promotion.reuse_key()),
-            reuse_key_kind = crate::types::reuse_key_kind(promotion.reuse_key()),
-            reason,
-            error = %e,
-            "workspace image cache session history sidecar cleanup errored"
-        ),
-    }
-}
-
 pub(crate) async fn prepare_workspace_image_from_parked_sandbox(
     sandbox: &mut dyn Sandbox,
     promotion: Option<WorkspaceImagePromotionContext>,
@@ -486,7 +427,10 @@ pub(crate) async fn prepare_workspace_image_from_parked_sandbox(
 ) -> Option<PreparedWorkspaceImagePromotion> {
     let promotion = promotion?;
 
-    match AssertUnwindSafe(sandbox.unpark()).catch_unwind().await {
+    match AssertUnwindSafe(sandbox.unpark_for_terminal_operations())
+        .catch_unwind()
+        .await
+    {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
             warn!(

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -306,6 +306,7 @@ async fn parked_workspace_promotion_unparks_and_freezes_before_publish() {
     .expect("workspace promotion should prepare");
 
     assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.terminal_unpark_call_count(), 1);
     let exec_calls = overrides.exec_calls();
     assert_eq!(exec_calls.len(), 1);
     assert!(exec_calls[0].sudo);
@@ -397,16 +398,14 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
             .unwrap_or_else(|error| panic!("invalid {field}: {error}; event={promotion_event:#?}"));
     }
     let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 3);
+    assert_eq!(exec_calls.len(), 2);
     assert!(exec_calls[0].cmd.contains("export-session-history-sidecar"));
     assert_eq!(exec_calls[0].timeout, Duration::from_secs(30));
     assert_eq!(
         exec_calls[0].env_keys,
         vec![guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV]
     );
-    assert!(exec_calls[1].cmd.contains("rm -f --"));
-    assert!(exec_calls[1].cmd.contains("/session-history-sidecar"));
-    assert!(exec_calls[2].sudo);
+    assert!(exec_calls[1].sudo);
     let copy_calls = sandbox.copy_file_calls();
     assert_eq!(copy_calls.len(), 1);
     assert!(copy_calls[0].path.ends_with("/session-history-sidecar"));
@@ -725,13 +724,12 @@ async fn active_workspace_promotion_rejects_invalid_sidecar_metadata() {
         assert!(promoted, "{name}");
         assert!(sandbox.copy_file_calls().is_empty(), "{name}");
         let exec_calls = sandbox.exec_calls();
-        assert_eq!(exec_calls.len(), 3, "{name}");
+        assert_eq!(exec_calls.len(), 2, "{name}");
         assert!(
             exec_calls[0].cmd.contains("export-session-history-sidecar"),
             "{name}"
         );
-        assert!(exec_calls[1].cmd.contains("rm -f --"), "{name}");
-        assert!(exec_calls[2].sudo, "{name}");
+        assert!(exec_calls[1].sudo, "{name}");
         let event = captured_event(
             &events,
             "workspace image cache session history sidecar export returned invalid metadata",
@@ -1017,7 +1015,7 @@ async fn active_workspace_promotion_classifies_sidecar_export_failures() {
             "{name}: {event:#?}"
         );
         let exec_calls = sandbox.exec_calls();
-        assert_eq!(exec_calls.len(), 3, "{name}");
+        assert_eq!(exec_calls.len(), 2, "{name}");
         assert!(exec_calls[0].expected_exit_codes.is_empty(), "{name}");
     }
 }
@@ -1228,6 +1226,7 @@ async fn parked_workspace_promotion_unpark_error_skips_cache() {
 
     assert!(prepared.is_none());
     assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.terminal_unpark_call_count(), 1);
     assert!(overrides.exec_calls().is_empty());
     assert!(fixture.cache.held_workspace_states().await.is_empty());
 }
@@ -1253,6 +1252,7 @@ async fn parked_workspace_promotion_unpark_error_abandons_consumed_cache_hit() {
 
     assert!(prepared.is_none());
     assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.terminal_unpark_call_count(), 1);
     assert_eq!(
         WorkspacePromotionFixture::checkout_result(&cache, &reuse_key).await,
         WorkspaceCacheCheckoutResult::Miss
@@ -1324,6 +1324,7 @@ async fn parked_workspace_promotion_unpark_panic_skips_cache() {
 
     assert!(prepared.is_none());
     assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.terminal_unpark_call_count(), 1);
     assert!(overrides.exec_calls().is_empty());
     assert!(fixture.cache.held_workspace_states().await.is_empty());
 }
@@ -1349,6 +1350,7 @@ async fn parked_workspace_promotion_guest_freeze_failure_skips_cache() {
 
     assert!(prepared.is_none());
     assert_eq!(overrides.unpark_call_count(), 1);
+    assert_eq!(overrides.terminal_unpark_call_count(), 1);
     assert_eq!(overrides.exec_calls().len(), 1);
     assert!(fixture.cache.held_workspace_states().await.is_empty());
     let event = captured_event(

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -98,6 +98,13 @@ const PROCESS_LOG_READER_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Timeout for guest lifecycle acknowledgements during same-session park/unpark.
 const GUEST_PARK_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum UnparkPurpose {
+    Reuse,
+    TerminalOperations,
+}
+
 /// Independent deadline for terminal diagnostics on an already-severe park.
 const GUEST_MEMORY_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -2127,6 +2134,83 @@ impl FirecrackerSandbox {
             }
         }
     }
+
+    async fn unpark_with_purpose(&mut self, purpose: UnparkPurpose) -> sandbox::Result<()> {
+        if !self.is_parked {
+            if self.park_fence.is_some() {
+                let message = "sandbox has a normal-operation fence while unpark is a no-op";
+                self.park_coordinator.mark_dirty(DirtyReason::new(message));
+                return Err(idle_transition_error(
+                    SandboxIdleTransition::Unpark,
+                    message,
+                ));
+            }
+            if self.park_outcome.is_some() {
+                let message = "sandbox has a recorded park outcome while unpark is a no-op";
+                self.park_coordinator.mark_dirty(DirtyReason::new(message));
+                return Err(idle_transition_error(
+                    SandboxIdleTransition::Unpark,
+                    message,
+                ));
+            }
+            return ensure_unpark_noop_state(&self.park_coordinator);
+        }
+        if self.park_fence.is_none() {
+            let message = "sandbox is parked without a normal-operation fence";
+            self.park_coordinator.mark_dirty(DirtyReason::new(message));
+            return Err(idle_transition_error(
+                SandboxIdleTransition::Unpark,
+                message,
+            ));
+        }
+
+        let guest_rpc_endpoint = self.bind_guest_rpc_endpoint().map_err(|error| {
+            idle_transition_error(
+                SandboxIdleTransition::Unpark,
+                format!("bind guest RPC transport: {error}"),
+            )
+        })?;
+        let coordinator = self.park_coordinator.clone();
+        let guest = Arc::clone(&self.guest);
+        let id = self.id.clone();
+        let api_sock = self.sock_paths.api_sock();
+        let memory_mb = self.config.resources.memory_mb;
+        let state_rx = self.state_tx.subscribe();
+        let is_parked = &mut self.is_parked;
+        let balloon_controller = self.runtime.balloon_mut();
+        let park_fence = &mut self.park_fence;
+        unpark_with_ready_for_operations(
+            &id,
+            &coordinator,
+            || {
+                unpark_inner(
+                    is_parked,
+                    memory_mb,
+                    balloon_controller,
+                    &api_sock,
+                    state_rx,
+                    &id,
+                    purpose,
+                )
+            },
+            || async move {
+                let guest = guest.lock().await.as_ref().cloned().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotConnected,
+                        "guest connection missing during unpark resume",
+                    )
+                })?;
+                guest.resume_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
+            },
+            || {
+                drop(park_fence.take());
+            },
+        )
+        .await?;
+        self.park_outcome = None;
+        self.guest_rpc_endpoint = Some(guest_rpc_endpoint);
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -2310,6 +2394,9 @@ impl Sandbox for FirecrackerSandbox {
     // the reactive controller so active workload is served with full
     // memory again. Ordering: resume before deflate — the guest needs
     // running vCPUs to process the deflate.
+    // `unpark_for_terminal_operations()` shares that readiness sequence but
+    // omits the reactive controller because the lifecycle owner must destroy
+    // the sandbox after its bounded preservation work.
     //
     // Park first closes the sandbox policy gate, then acquires a host-side
     // vsock normal-operation fence before guest lifecycle quiesce. Unpark
@@ -2452,79 +2539,12 @@ impl Sandbox for FirecrackerSandbox {
     }
 
     async fn unpark(&mut self) -> sandbox::Result<()> {
-        if !self.is_parked {
-            if self.park_fence.is_some() {
-                let message = "sandbox has a normal-operation fence while unpark is a no-op";
-                self.park_coordinator.mark_dirty(DirtyReason::new(message));
-                return Err(idle_transition_error(
-                    SandboxIdleTransition::Unpark,
-                    message,
-                ));
-            }
-            if self.park_outcome.is_some() {
-                let message = "sandbox has a recorded park outcome while unpark is a no-op";
-                self.park_coordinator.mark_dirty(DirtyReason::new(message));
-                return Err(idle_transition_error(
-                    SandboxIdleTransition::Unpark,
-                    message,
-                ));
-            }
-            return ensure_unpark_noop_state(&self.park_coordinator);
-        }
-        if self.park_fence.is_none() {
-            let message = "sandbox is parked without a normal-operation fence";
-            self.park_coordinator.mark_dirty(DirtyReason::new(message));
-            return Err(idle_transition_error(
-                SandboxIdleTransition::Unpark,
-                message,
-            ));
-        }
+        self.unpark_with_purpose(UnparkPurpose::Reuse).await
+    }
 
-        let guest_rpc_endpoint = self.bind_guest_rpc_endpoint().map_err(|error| {
-            idle_transition_error(
-                SandboxIdleTransition::Unpark,
-                format!("bind guest RPC transport: {error}"),
-            )
-        })?;
-        let coordinator = self.park_coordinator.clone();
-        let guest = Arc::clone(&self.guest);
-        let id = self.id.clone();
-        let api_sock = self.sock_paths.api_sock();
-        let memory_mb = self.config.resources.memory_mb;
-        let state_rx = self.state_tx.subscribe();
-        let is_parked = &mut self.is_parked;
-        let balloon_controller = self.runtime.balloon_mut();
-        let park_fence = &mut self.park_fence;
-        unpark_with_ready_for_operations(
-            &id,
-            &coordinator,
-            || {
-                unpark_inner(
-                    is_parked,
-                    memory_mb,
-                    balloon_controller,
-                    &api_sock,
-                    state_rx,
-                    &id,
-                )
-            },
-            || async move {
-                let guest = guest.lock().await.as_ref().cloned().ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::NotConnected,
-                        "guest connection missing during unpark resume",
-                    )
-                })?;
-                guest.resume_operations(GUEST_PARK_LIFECYCLE_TIMEOUT).await
-            },
-            || {
-                drop(park_fence.take());
-            },
-        )
-        .await?;
-        self.park_outcome = None;
-        self.guest_rpc_endpoint = Some(guest_rpc_endpoint);
-        Ok(())
+    async fn unpark_for_terminal_operations(&mut self) -> sandbox::Result<()> {
+        self.unpark_with_purpose(UnparkPurpose::TerminalOperations)
+            .await
     }
 
     // -- operations --
@@ -4555,6 +4575,7 @@ async fn unpark_inner(
     api_sock: &std::path::Path,
     state_rx: watch::Receiver<SandboxState>,
     log_id: &str,
+    purpose: UnparkPurpose,
 ) -> sandbox::Result<()> {
     if !*is_parked {
         return Ok(());
@@ -4606,12 +4627,14 @@ async fn unpark_inner(
                 message: format!("balloon deflate: {e}"),
             })?;
 
-        *balloon_controller = Some(balloon::spawn_after_unpark_deflation(
-            client,
-            memory_mb,
-            state_rx,
-            log_id.to_owned(),
-        ));
+        if purpose == UnparkPurpose::Reuse {
+            *balloon_controller = Some(balloon::spawn_after_unpark_deflation(
+                client,
+                memory_mb,
+                state_rx,
+                log_id.to_owned(),
+            ));
+        }
     }
 
     *is_parked = false;

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -6169,6 +6169,7 @@ async fn unpark_resumes_and_deflates() {
         api.socket_path(),
         state_rx.clone(),
         "test-unpark",
+        UnparkPurpose::Reuse,
     )
     .await
     .unwrap();
@@ -6192,6 +6193,42 @@ async fn unpark_resumes_and_deflates() {
     if let Some(h) = controller.take() {
         h.abort();
     }
+}
+
+#[tokio::test]
+async fn terminal_unpark_resumes_and_deflates_without_background_controller() {
+    let mut api = MockLifecycleApi::new(std::collections::VecDeque::new(), None);
+
+    let mut is_parked = true;
+    let mut controller: Option<balloon::ControllerHandle> = None;
+    let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
+
+    unpark_inner(
+        &mut is_parked,
+        2048,
+        &mut controller,
+        api.socket_path(),
+        state_rx,
+        "test-terminal-unpark",
+        UnparkPurpose::TerminalOperations,
+    )
+    .await
+    .unwrap();
+
+    assert!(!is_parked, "is_parked should be cleared");
+    assert!(
+        controller.is_none(),
+        "terminal unpark must not start a background controller"
+    );
+
+    let requests = api.drain_requests();
+    let patches = patches(&requests);
+    assert_eq!(patches.len(), 2, "expected resume followed by deflate");
+    assert_eq!(patches[0].path, "/vm");
+    assert!(patches[0].body.contains("Resumed"));
+    assert_eq!(patches[1].path, "/balloon");
+    let body: serde_json::Value = serde_json::from_str(&patches[1].body).unwrap();
+    assert_eq!(body["amount_mib"].as_u64().unwrap(), 0);
 }
 
 #[tokio::test]
@@ -6239,6 +6276,7 @@ async fn unpark_returns_while_controller_guards_pending_deflation() {
         &api_socket,
         state_rx,
         "test-unpark-lagging-actual",
+        UnparkPurpose::Reuse,
     )
     .await
     .unwrap();
@@ -6294,6 +6332,7 @@ async fn unpark_propagates_deflate_error() {
         api.socket_path(),
         state_rx.clone(),
         "test-unpark-err",
+        UnparkPurpose::Reuse,
     )
     .await;
 
@@ -6329,6 +6368,7 @@ async fn unpark_small_vm_skips_balloon_but_resumes_vcpus() {
         api.socket_path(),
         state_rx.clone(),
         "test-unpark-small",
+        UnparkPurpose::Reuse,
     )
     .await
     .unwrap();
@@ -6399,6 +6439,7 @@ async fn double_unpark_is_idempotent() {
         api.socket_path(),
         state_rx.clone(),
         "du",
+        UnparkPurpose::Reuse,
     )
     .await
     .unwrap();
@@ -6411,6 +6452,7 @@ async fn double_unpark_is_idempotent() {
         api.socket_path(),
         state_rx.clone(),
         "du",
+        UnparkPurpose::Reuse,
     )
     .await
     .unwrap();
@@ -6448,6 +6490,7 @@ async fn unpark_without_park_is_noop() {
         api.socket_path(),
         state_rx.clone(),
         "fresh",
+        UnparkPurpose::Reuse,
     )
     .await
     .unwrap();
@@ -6490,6 +6533,7 @@ async fn park_unpark_park_cycle() {
         api.socket_path(),
         state_rx.clone(),
         "cycle",
+        UnparkPurpose::Reuse,
     )
     .await
     .unwrap();
@@ -6587,6 +6631,7 @@ async fn park_balloon_failure_leaves_flag_false() {
         api.socket_path(),
         state_rx.clone(),
         "test-park-fail",
+        UnparkPurpose::Reuse,
     )
     .await
     .unwrap();
@@ -6654,6 +6699,7 @@ async fn unpark_retry_after_failure_succeeds() {
         api.socket_path(),
         state_rx.clone(),
         "retry",
+        UnparkPurpose::Reuse,
     )
     .await;
     assert_idle_transition(first, SandboxIdleTransition::Unpark);
@@ -6667,6 +6713,7 @@ async fn unpark_retry_after_failure_succeeds() {
         api.socket_path(),
         state_rx.clone(),
         "retry",
+        UnparkPurpose::Reuse,
     )
     .await
     .unwrap();
@@ -6750,6 +6797,7 @@ async fn unpark_resume_http_400_propagates_as_idle_transition() {
         api.socket_path(),
         state_rx.clone(),
         "resume-fail",
+        UnparkPurpose::Reuse,
     )
     .await;
 
@@ -6789,6 +6837,7 @@ async fn unpark_retry_after_partial_failure_resumes_idempotently() {
         api.socket_path(),
         state_rx.clone(),
         "idem",
+        UnparkPurpose::Reuse,
     )
     .await;
     assert_idle_transition(first, SandboxIdleTransition::Unpark);
@@ -6802,6 +6851,7 @@ async fn unpark_retry_after_partial_failure_resumes_idempotently() {
         api.socket_path(),
         state_rx.clone(),
         "idem",
+        UnparkPurpose::Reuse,
     )
     .await
     .unwrap();

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -127,6 +127,11 @@ pub(crate) struct LifecycleOverrideState {
     pub(crate) stop_behaviors: LifecycleBehaviors<()>,
     /// Optional gate that blocks every `stop()` entry before its result is consumed.
     pub(crate) stop_gate: Mutex<Option<MockLifecycleGate>>,
+    /// FIFO queue of kill behaviours consumed by every sandbox built with
+    /// these overrides. Empty queue → default Ok(()).
+    pub(crate) kill_behaviors: LifecycleBehaviors<()>,
+    /// Optional gate that blocks every `kill()` entry before its result is consumed.
+    pub(crate) kill_gate: Mutex<Option<MockLifecycleGate>>,
     /// FIFO queue of park results consumed by every sandbox built with
     /// these overrides. Empty queue → default reusable outcome.
     pub(crate) park_behaviors: LifecycleBehaviors<SandboxParkOutcome>,
@@ -154,6 +159,12 @@ pub(crate) struct LifecycleOverrideState {
     pub(crate) park_calls: Mutex<u32>,
     /// Total `unpark()` calls across all sandboxes built from this override set.
     pub(crate) unpark_calls: Mutex<u32>,
+    /// Total terminal-only `unpark()` calls across all attached sandboxes.
+    pub(crate) terminal_unpark_calls: Mutex<u32>,
+    /// Total `stop()` calls across all attached sandboxes.
+    pub(crate) stop_calls: Mutex<u32>,
+    /// Total `kill()` calls across all attached sandboxes.
+    pub(crate) kill_calls: Mutex<u32>,
     /// Total factory `destroy()` calls across all factories built from this
     /// override set.
     pub(crate) destroy_calls: Mutex<u32>,
@@ -839,6 +850,23 @@ impl MockSandboxOverrides {
         *self.lifecycle.stop_gate.lock_ignoring_poison() = Some(gate);
     }
 
+    /// Queue a `kill()` result applied to the next factory-created sandbox.
+    /// Consumed FIFO across all sandboxes; empty queue → default Ok(()).
+    pub fn push_kill_result(&self, result: Result<()>) {
+        self.lifecycle.kill_behaviors.push_result(result);
+    }
+
+    /// Queue a `kill()` panic applied to the next factory-created sandbox.
+    /// Used by runner tests to exercise panic-safe cleanup boundaries.
+    pub fn push_kill_panic(&self, message: impl Into<String>) {
+        self.lifecycle.kill_behaviors.push_panic(message);
+    }
+
+    /// Block every `kill()` call before consuming its queued result or panic.
+    pub fn set_kill_lifecycle_gate(&self, gate: MockLifecycleGate) {
+        *self.lifecycle.kill_gate.lock_ignoring_poison() = Some(gate);
+    }
+
     /// Block every `unpark()` call after recording it and before consuming its result.
     pub fn set_unpark_lifecycle_gate(&self, gate: MockLifecycleGate) {
         *self.lifecycle.unpark_gate.lock_ignoring_poison() = Some(gate);
@@ -917,6 +945,21 @@ impl MockSandboxOverrides {
     /// Total `unpark()` calls across all sandboxes built from this override set.
     pub fn unpark_call_count(&self) -> u32 {
         *self.lifecycle.unpark_calls.lock_ignoring_poison()
+    }
+
+    /// Total terminal-only `unpark()` calls across all attached sandboxes.
+    pub fn terminal_unpark_call_count(&self) -> u32 {
+        *self.lifecycle.terminal_unpark_calls.lock_ignoring_poison()
+    }
+
+    /// Total `stop()` calls across all attached sandboxes.
+    pub fn stop_call_count(&self) -> u32 {
+        *self.lifecycle.stop_calls.lock_ignoring_poison()
+    }
+
+    /// Total `kill()` calls across all attached sandboxes.
+    pub fn kill_call_count(&self) -> u32 {
+        *self.lifecycle.kill_calls.lock_ignoring_poison()
     }
 
     /// Total factory `destroy()` calls across all factories built from this

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -647,12 +647,18 @@ impl Sandbox for MockSandbox {
         let Some(o) = &self.overrides else {
             return Ok(());
         };
+        *o.lifecycle.stop_calls.lock_ignoring_poison() += 1;
         wait_lifecycle_gate(&o.lifecycle.stop_gate).await;
         o.lifecycle.stop_behaviors.next_result(())
     }
 
     async fn kill(&mut self) -> Result<()> {
-        Ok(())
+        let Some(o) = &self.overrides else {
+            return Ok(());
+        };
+        *o.lifecycle.kill_calls.lock_ignoring_poison() += 1;
+        wait_lifecycle_gate(&o.lifecycle.kill_gate).await;
+        o.lifecycle.kill_behaviors.next_result(())
     }
 
     /// Mock park: bumps the override `park_calls` counter on every call (so
@@ -755,6 +761,13 @@ impl Sandbox for MockSandbox {
         *o.lifecycle.unpark_calls.lock_ignoring_poison() += 1;
         wait_lifecycle_gate(&o.lifecycle.unpark_gate).await;
         o.lifecycle.unpark_behaviors.next_result(())
+    }
+
+    async fn unpark_for_terminal_operations(&mut self) -> Result<()> {
+        if let Some(o) = &self.overrides {
+            *o.lifecycle.terminal_unpark_calls.lock_ignoring_poison() += 1;
+        }
+        self.unpark().await
     }
 
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult> {

--- a/crates/sandbox-mock/src/tests/lifecycle.rs
+++ b/crates/sandbox-mock/src/tests/lifecycle.rs
@@ -165,9 +165,11 @@ async fn overrides_count_park_and_unpark_calls_across_factory_sandboxes() {
 
     first.unpark().await.unwrap();
     second.unpark().await.unwrap();
+    first.unpark_for_terminal_operations().await.unwrap();
 
     assert_eq!(overrides.park_call_count(), 3);
-    assert_eq!(overrides.unpark_call_count(), 2);
+    assert_eq!(overrides.unpark_call_count(), 3);
+    assert_eq!(overrides.terminal_unpark_call_count(), 1);
 }
 
 #[tokio::test]
@@ -225,6 +227,21 @@ async fn lifecycle_behaviors_are_consumed_fifo_and_default_to_success() {
         .stop()
         .await
         .expect("empty stop behavior queue should default to success");
+    assert_eq!(overrides.stop_call_count(), 3);
+
+    overrides.push_kill_result(Err(SandboxError::Start {
+        message: "queued kill failure".into(),
+    }));
+    let err = sandbox
+        .kill()
+        .await
+        .expect_err("queued kill behavior should fail");
+    assert!(err.to_string().contains("queued kill failure"));
+    sandbox
+        .kill()
+        .await
+        .expect("empty kill behavior queue should default to success");
+    assert_eq!(overrides.kill_call_count(), 2);
 }
 
 #[tokio::test]

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -698,6 +698,21 @@ pub trait Sandbox: Send + Sync + Any {
         Ok(())
     }
 
+    /// Unpark only for terminal guest operations before destroying the sandbox.
+    ///
+    /// This has the same operation-readiness contract as [`unpark`](Self::unpark),
+    /// but providers may omit background work whose only purpose is serving a
+    /// future active workload. After this call succeeds, the lifecycle owner
+    /// must run only the bounded terminal operations needed to preserve state,
+    /// then terminate and destroy the sandbox without returning it to a pool or
+    /// binding another run.
+    ///
+    /// Providers that do not distinguish terminal finalization from normal
+    /// reuse preserve compatibility by performing a full unpark.
+    async fn unpark_for_terminal_operations(&mut self) -> Result<()> {
+        self.unpark().await
+    }
+
     // -- operations --
     //
     // Operations that start new guest work require the sandbox to be running

--- a/docs/runner-host-configuration.md
+++ b/docs/runner-host-configuration.md
@@ -53,14 +53,18 @@ Workspace promotion uses two independent runner-process-local admission gates,
 each sized as `(host_cpus / 2).clamp(1, 4)`. Cache clones share the gates.
 The existing sidecar export gate covers guest export execution only. Idle
 reclamation additionally acquires admission **before unpark** and holds it
-through export, host copy, cleanup, workspace freeze and sandbox stop. Waiting
-reclamation jobs remain parked.
+through terminal unpark, export, host copy, workspace freeze and immediate
+sandbox termination. Waiting reclamation jobs remain parked. Terminal unpark
+does not start the reactive balloon controller used by future active workloads,
+and the temporary guest sidecar is left for sandbox destruction instead of a
+separate guest cleanup command.
 
-After a successful stop, cache publication and factory destruction run without
-holding idle admission. If stop fails or panics, admission remains held through
-the factory destruction attempt. Missing or explicitly abandoned promotion
-does not acquire this gate. Normal startup/reuse and active sandbox promotion
-do not acquire idle reclamation admission.
+After successful termination, cache publication and factory destruction run
+without holding idle admission. If termination fails or panics, publication is
+abandoned and admission remains held through the factory destruction attempt.
+Missing or explicitly abandoned promotion does not acquire this gate. Normal
+startup/reuse and active sandbox promotion do not acquire idle reclamation
+admission.
 
 This limits simultaneous resumed idle guests, not total sandboxes or team run
 concurrency. A bulk drain can take longer and retain parked budget leases while


### PR DESCRIPTION
## Summary

- add a terminal-only sandbox unpark contract that preserves guest operation readiness while allowing Firecracker to omit the reactive balloon controller
- finalize idle sandboxes with immediate termination after session-history export, host copy, and workspace freeze, and publish caches only after termination succeeds
- remove the redundant guest-side sidecar cleanup command while retaining host staging cleanup and reclamation admission boundaries

## Scope

- normal idle reuse still performs the full unpark path and starts the reactive balloon controller
- active sandbox finalization still uses graceful stop
- no guest protocol, persistent cache format, or operator configuration changes

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-features --no-deps`
- `cargo test -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets --all-features --quiet`
- repository pre-commit hooks, including workspace-wide Rust Clippy and Rustdoc

Closes #32268

Parent issue: #32193
