### PR TITLE
fix(api): retain sanitized fal webhook failure diagnostics

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -256,6 +256,19 @@ export default [
     },
   },
   {
+    files: ["src/signals/routes/webhooks-built-in-generations.ts"],
+    rules: {
+      "api/no-logger-info": [
+        "error",
+        {
+          allowedMessages: [
+            "Fal built-in generation webhook reported failed generation",
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: [
       "src/signals/services/pi-memory-stage1-worker.service.ts",
       "src/signals/services/pi-memory-phase2-worker.service.ts",

--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -1185,7 +1185,7 @@ vi.mock("../signals/external/axiom", async () => {
   };
 });
 
-vi.mock("@axiomhq/js", () => {
+function createAxiomSdkMock() {
   return {
     Axiom: vi.fn<(...args: AxiomSdkConstructorArguments) => AxiomSdkClientMock>(
       function (options) {
@@ -1209,9 +1209,11 @@ vi.mock("@axiomhq/js", () => {
       },
     ),
   };
-});
+}
 
-vi.mock("@axiomhq/logging", () => {
+vi.mock("@axiomhq/js", createAxiomSdkMock);
+
+function createAxiomLoggingMock() {
   return {
     EVENT: Symbol("EVENT"),
     Logger: vi.fn<
@@ -1233,7 +1235,26 @@ vi.mock("@axiomhq/logging", () => {
       return transport;
     }),
   };
-});
+}
+
+vi.mock("@axiomhq/logging", createAxiomLoggingMock);
+
+// Logging integration tests import the application logger after entering this
+// scope so both SDKs and the logger's cached instances belong to that test.
+export async function withRealAxiomLoggingForTest(
+  runTest: () => Promise<void>,
+): Promise<void> {
+  vi.doUnmock("@axiomhq/logging");
+  vi.doUnmock("@axiomhq/js");
+  vi.resetModules();
+  await Promise.resolve()
+    .then(runTest)
+    .finally(() => {
+      vi.doMock("@axiomhq/js", createAxiomSdkMock);
+      vi.doMock("@axiomhq/logging", createAxiomLoggingMock);
+      vi.resetModules();
+    });
+}
 
 export function getApiTestMocks(): ApiTestMocks {
   return apiTestMocks;

--- a/turbo/apps/api/src/lib/__tests__/log-axiom-transport.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log-axiom-transport.test.ts
@@ -1,0 +1,142 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, onTestFinished } from "vitest";
+
+import { withRealAxiomLoggingForTest } from "../../__tests__/mocks";
+import { testContext } from "../../__tests__/test-context";
+import { server } from "../../mocks/server";
+
+const context = testContext();
+const FAILURE_MESSAGE =
+  "Fal built-in generation webhook reported failed generation";
+
+describe("Axiom logging transport", () => {
+  it("sends Fal info/warn diagnostics with the default SDK transport and restores mocks", async () => {
+    const sentEvents: unknown[] = [];
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/vm0-web-logs-dev/ingest",
+        async ({ request }) => {
+          expect(request.headers.get("content-type")).toBe(
+            "application/x-ndjson",
+          );
+          const body = await request.text();
+          const events = body.split("\n").map((line): unknown => {
+            return JSON.parse(line);
+          });
+          sentEvents.push(...events);
+          return HttpResponse.json({
+            ingested: events.length,
+            failed: 0,
+            failures: [],
+            processedBytes: body.length,
+            blocksCreated: 1,
+            walLength: 0,
+          });
+        },
+      ),
+    );
+
+    await withRealAxiomLoggingForTest(async () => {
+      // These imports must follow the SDK switch to avoid reusing the logger's
+      // singleton or environment overrides from the centralized mock setup.
+      const {
+        logger,
+        flushLogs,
+        __resetForTest: resetLogs,
+      } = await import("../log");
+      const { mockEnv, clearMockedEnv } = await import("../env");
+      mockEnv("AXIOM_TOKEN_TELEMETRY", "xaat-fal-logging-test");
+      mockEnv("AXIOM_DATASET_SUFFIX", "dev");
+      mockEnv("OKOU_DEBUG", "");
+      resetLogs();
+
+      const fields = {
+        provider: "fal",
+        generationId: "test-generation",
+        type: "image",
+        providerStatus: "ERROR",
+        providerHttpStatus: 422,
+        providerErrorType: "content_policy_violation",
+        failureKind: "output_safety_blocked",
+        failureStage: "output",
+        classificationSource: "normalized_message_exact",
+        publicErrorCode: "GENERATION_OUTPUT_SAFETY_BLOCKED",
+        retryPolicy: "manual_once",
+        billingDisposition: "not_charged",
+        artifactRecorded: false,
+        usageRecorded: false,
+        admissionStatus: "failed",
+        expected: true,
+      };
+      const unknownFields = {
+        ...fields,
+        providerHttpStatus: undefined,
+        providerErrorType: "unknown",
+        failureKind: "unknown",
+        failureStage: "unknown",
+        classificationSource: "fallback",
+        publicErrorCode: "GENERATION_FAILED",
+        retryPolicy: "retry_once",
+        expected: false,
+      };
+
+      const cleanupLogs = async (): Promise<void> => {
+        await flushLogs();
+        resetLogs();
+        clearMockedEnv();
+      };
+      await Promise.resolve()
+        .then(() => {
+          const log = logger("BuiltInGenerationWebhooks");
+          log.debug(FAILURE_MESSAGE, fields);
+          log.info(FAILURE_MESSAGE, fields);
+          log.warn(FAILURE_MESSAGE, unknownFields);
+        })
+        .then(cleanupLogs, async (error: unknown) => {
+          await cleanupLogs();
+          throw error;
+        });
+
+      expect(sentEvents).toStrictEqual([
+        expect.objectContaining({
+          level: "info",
+          message: FAILURE_MESSAGE,
+          source: "api",
+          fields: { ...fields, context: "BuiltInGenerationWebhooks" },
+        }),
+        expect.objectContaining({
+          level: "warn",
+          message: FAILURE_MESSAGE,
+          source: "api",
+          fields: {
+            provider: "fal",
+            generationId: "test-generation",
+            type: "image",
+            providerStatus: "ERROR",
+            providerErrorType: "unknown",
+            failureKind: "unknown",
+            failureStage: "unknown",
+            classificationSource: "fallback",
+            publicErrorCode: "GENERATION_FAILED",
+            retryPolicy: "retry_once",
+            billingDisposition: "not_charged",
+            artifactRecorded: false,
+            usageRecorded: false,
+            admissionStatus: "failed",
+            expected: false,
+            context: "BuiltInGenerationWebhooks",
+          },
+        }),
+      ]);
+    });
+
+    const { logger, __resetForTest: resetLogs } = await import("../log");
+    onTestFinished(resetLogs);
+    logger("RestoredAxiomMock").info("restored logging mock");
+    expect(context.mocks.axiomLogging.info).toHaveBeenCalledWith(
+      "restored logging mock",
+      expect.objectContaining({ context: "RestoredAxiomMock" }),
+    );
+    expect(sentEvents).toHaveLength(2);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-io-generate.test.ts
@@ -1492,10 +1492,13 @@ describe("POST /api/image-io/generate", () => {
     {
       detailShape: "a string detail",
       detail: FAL_OUTPUT_SAFETY_FILTER_MESSAGE,
+      providerErrorType: "unknown",
     },
     {
       detailShape: "Pydantic detail entries",
+      providerErrorType: "content_policy_violation",
       detail: [
+        { type: "file_download_error", msg: "Unrelated provider diagnostic" },
         {
           type: "content_policy_violation",
           loc: ["body", "prompt"],
@@ -1509,7 +1512,7 @@ describe("POST /api/image-io/generate", () => {
     },
   ])(
     "maps Fal output safety failures from $detailShape without charging or retaining private diagnostics",
-    async ({ detail }) => {
+    async ({ detail, providerErrorType }) => {
       const fixture = await seedImageFixture({ credits: 1000 });
       const pricingFixture = await createScopedImagePricing({
         configured: GPT_IMAGE_1_PRICING,
@@ -1561,7 +1564,10 @@ describe("POST /api/image-io/generate", () => {
           },
         },
       };
-      await postFalWebhookEnvelope(app, initialRequestUrl, webhookPayload);
+      await Promise.all([
+        postFalWebhookEnvelope(app, initialRequestUrl, webhookPayload),
+        postFalWebhookEnvelope(app, initialRequestUrl, webhookPayload),
+      ]);
       await flushWaitUntilForTest();
 
       const expectedError = {
@@ -1594,16 +1600,17 @@ describe("POST /api/image-io/generate", () => {
       // second terminal failure event.
       await postFalWebhookEnvelope(app, initialRequestUrl, webhookPayload);
       await flushWaitUntilForTest();
-      const debugFailureLogs =
-        context.mocks.axiomLogging.debug.mock.calls.filter(([message]) => {
+      const infoFailureLogs = context.mocks.axiomLogging.info.mock.calls.filter(
+        ([message]) => {
           return message === FAL_FAILURE_LOG_MESSAGE;
-        });
+        },
+      );
       const warnFailureLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
         ([message]) => {
           return message === FAL_FAILURE_LOG_MESSAGE;
         },
       );
-      expect(debugFailureLogs).toStrictEqual([
+      expect(infoFailureLogs).toStrictEqual([
         [
           FAL_FAILURE_LOG_MESSAGE,
           expect.objectContaining({
@@ -1613,7 +1620,7 @@ describe("POST /api/image-io/generate", () => {
             type: "image",
             providerStatus: "ERROR",
             providerHttpStatus: 422,
-            providerErrorType: undefined,
+            providerErrorType,
             failureKind: "output_safety_blocked",
             failureStage: "output",
             classificationSource: "normalized_message_exact",
@@ -1628,11 +1635,16 @@ describe("POST /api/image-io/generate", () => {
         ],
       ]);
       expect(warnFailureLogs).toHaveLength(0);
+      expect(
+        context.mocks.axiomLogging.debug.mock.calls.filter(([message]) => {
+          return message === FAL_FAILURE_LOG_MESSAGE;
+        }),
+      ).toHaveLength(0);
 
       const publicAndLogSurfaces = JSON.stringify({
         realtime: context.mocks.ably.publish.mock.calls,
         status: statusBody,
-        debugFailureLogs,
+        infoFailureLogs,
         warnFailureLogs,
       });
       for (const privateValue of [
@@ -1920,11 +1932,11 @@ describe("POST /api/image-io/generate", () => {
       });
 
       const expectedLoggingMock = expected
-        ? context.mocks.axiomLogging.debug
+        ? context.mocks.axiomLogging.info
         : context.mocks.axiomLogging.warn;
       const unexpectedLoggingMock = expected
         ? context.mocks.axiomLogging.warn
-        : context.mocks.axiomLogging.debug;
+        : context.mocks.axiomLogging.info;
       const failureLogs = expectedLoggingMock.mock.calls.filter(([message]) => {
         return message === FAL_FAILURE_LOG_MESSAGE;
       });
@@ -1958,6 +1970,11 @@ describe("POST /api/image-io/generate", () => {
         ],
       ]);
       expect(unexpectedFailureLogs).toHaveLength(0);
+      expect(
+        context.mocks.axiomLogging.debug.mock.calls.filter(([message]) => {
+          return message === FAL_FAILURE_LOG_MESSAGE;
+        }),
+      ).toHaveLength(0);
 
       const publicAndLogSurfaces = JSON.stringify({
         realtime: context.mocks.ably.publish.mock.calls,
@@ -1988,131 +2005,238 @@ describe("POST /api/image-io/generate", () => {
     },
   );
 
-  it("keeps near-match Fal diagnostics on the sanitized unknown-failure fallback", async () => {
-    const fixture = await seedImageFixture({ credits: 1000 });
-    const pricingFixture = await createScopedImagePricing({
-      configured: GPT_IMAGE_1_PRICING,
-    });
-    mocks.clerk.session(fixture.userId, fixture.orgId);
-    let observedRequestUrl: string | null = null;
-    server.use(
-      http.post(FAL_GPT_IMAGE_1_URL, ({ request }) => {
-        observedRequestUrl = request.url;
-        return HttpResponse.json(falQueueHandle("unknown-failure"));
-      }),
-    );
-
-    const app = createImageIoTestApp(pricingFixture.resolution);
-    const response = await app.request("/api/image-io/generate", {
-      method: "POST",
-      headers: authHeaders(),
-      body: JSON.stringify({ prompt: "private-unknown-failure-prompt" }),
-    });
-    expect(response.status).toBe(202);
-    const generationId = readAcceptedGenerationId(
-      await response.json(),
-      "image",
-      fixture.userId,
-    );
-
-    await postFalWebhookEnvelope(app, observedRequestUrl, {
+  it.each([
+    {
+      caseName: "near-match safety text",
       status: "FAILED",
+      wrapper: "payload",
       error: "Unexpected status code: 422",
-      payload: {
-        detail: [
-          {
-            // Missing final punctuation is deliberately not an exact match.
-            type: "content_policy_violation",
-            loc: ["body", "prompt"],
-            msg: "The generated image was blocked by the safety filter",
-            input: {
-              prompt: "private-unknown-failure-prompt",
-              image_url: "https://private.example/reference-unknown.png",
-            },
-          },
-        ],
+      detail: [
+        {
+          type: "content_policy_violation",
+          loc: ["body", "prompt"],
+          // Missing punctuation must not change the public classification.
+          msg: "The generated image was blocked by the safety filter",
+        },
+      ],
+      providerErrorType: "content_policy_violation",
+      providerHttpStatus: 422,
+    },
+    {
+      caseName: "changed provider text and location",
+      status: "ERROR",
+      wrapper: "data",
+      error: "Invalid status code: 422",
+      detail: {
+        type: "file_download_error",
+        loc: ["private-provider-location"],
+        msg: "private-provider-message https://private.example/input",
+        ctx: { credential: "private-provider-token" },
       },
-    });
-    await flushWaitUntilForTest();
+      providerErrorType: "file_download_error",
+      providerHttpStatus: 422,
+    },
+    {
+      caseName: "missing messages and an unknown first type",
+      status: "ERROR",
+      wrapper: "response",
+      error: "Unexpected status code: 422",
+      detail: [
+        { type: "file_download_error:private-provider-token" },
+        { type: "image_load_error" },
+      ],
+      providerErrorType: "image_load_error",
+      providerHttpStatus: 422,
+    },
+    {
+      caseName: "the documented legacy validation envelope",
+      status: "ERROR",
+      wrapper: "payload",
+      error: "Invalid status code: 422",
+      detail: [
+        {
+          type: "value_error.missing",
+          loc: ["body", "prompt"],
+          msg: "field required",
+        },
+      ],
+      providerErrorType: "value_error.missing",
+      providerHttpStatus: 422,
+    },
+    {
+      caseName: "an unknown type and out-of-range HTTP status",
+      status: "ERROR",
+      wrapper: "payload",
+      error: "Unexpected status code: 999",
+      detail: [
+        {
+          type: "file_download_error:private-provider-token",
+          msg: "private-provider-message",
+        },
+      ],
+      providerErrorType: "unknown",
+      providerHttpStatus: undefined,
+    },
+    {
+      caseName: "empty diagnostics and a non-string error",
+      status: "ERROR",
+      wrapper: "payload",
+      error: { message: "private-provider-message" },
+      detail: null,
+      providerErrorType: "unknown",
+      providerHttpStatus: undefined,
+    },
+    {
+      caseName: "free-form detail and trailing error text",
+      status: "ERROR",
+      wrapper: "payload",
+      error: "Invalid status code: 422 private-provider-token",
+      detail: "private-provider-message https://private.example/input",
+      providerErrorType: "unknown",
+      providerHttpStatus: undefined,
+    },
+  ])(
+    "retains safe Fal diagnostics for $caseName without changing the public fallback",
+    async ({
+      status,
+      wrapper,
+      error,
+      detail,
+      providerErrorType,
+      providerHttpStatus,
+    }) => {
+      const fixture = await seedImageFixture({ credits: 1000 });
+      const pricingFixture = await createScopedImagePricing({
+        configured: GPT_IMAGE_1_PRICING,
+      });
+      mocks.clerk.session(fixture.userId, fixture.orgId);
+      let observedRequestUrl: string | null = null;
+      server.use(
+        http.post(FAL_GPT_IMAGE_1_URL, ({ request }) => {
+          observedRequestUrl = request.url;
+          return HttpResponse.json(falQueueHandle("unknown-failure"));
+        }),
+      );
 
-    const expectedError = {
-      message: "Image generation failed.",
-      code: "GENERATION_FAILED",
-    };
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      `built-in-generation:${generationId}`,
-      expect.objectContaining({
+      const app = createImageIoTestApp(pricingFixture.resolution);
+      const response = await app.request("/api/image-io/generate", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ prompt: "private-unknown-failure-prompt" }),
+      });
+      expect(response.status).toBe(202);
+      const generationId = readAcceptedGenerationId(
+        await response.json(),
+        "image",
+        fixture.userId,
+      );
+
+      await postFalWebhookEnvelope(app, observedRequestUrl, {
+        status,
+        error,
+        request_id: "private-fal-request-id",
+        gateway_request_id: "private-fal-gateway-request-id",
+        [wrapper]: {
+          detail,
+          input: {
+            prompt: "private-unknown-failure-prompt",
+            image_url: "https://private.example/reference-unknown.png",
+          },
+        },
+      });
+      await flushWaitUntilForTest();
+
+      const expectedError = {
+        message: "Image generation failed.",
+        code: "GENERATION_FAILED",
+      };
+      expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+        `built-in-generation:${generationId}`,
+        expect.objectContaining({
+          generationId,
+          type: "image",
+          status: "failed",
+          error: expectedError,
+        }),
+      );
+      const statusResponse = await app.request(
+        `/api/built-in-generations/${generationId}`,
+        { headers: authHeaders() },
+      );
+      expect(statusResponse.status).toBe(200);
+      const statusBody: unknown = await statusResponse.json();
+      expect(statusBody).toMatchObject({
         generationId,
         type: "image",
         status: "failed",
         error: expectedError,
-      }),
-    );
-    const statusResponse = await app.request(
-      `/api/built-in-generations/${generationId}`,
-      { headers: authHeaders() },
-    );
-    expect(statusResponse.status).toBe(200);
-    const statusBody: unknown = await statusResponse.json();
-    expect(statusBody).toMatchObject({
-      generationId,
-      type: "image",
-      status: "failed",
-      error: expectedError,
-    });
+      });
 
-    const debugFailureLogs = context.mocks.axiomLogging.debug.mock.calls.filter(
-      ([message]) => {
-        return message === FAL_FAILURE_LOG_MESSAGE;
-      },
-    );
-    const warnFailureLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
-      ([message]) => {
-        return message === FAL_FAILURE_LOG_MESSAGE;
-      },
-    );
-    expect(debugFailureLogs).toHaveLength(0);
-    expect(warnFailureLogs).toStrictEqual([
-      [
-        FAL_FAILURE_LOG_MESSAGE,
-        expect.objectContaining({
-          context: "BuiltInGenerationWebhooks",
-          provider: "fal",
-          generationId,
-          type: "image",
-          providerStatus: "FAILED",
-          providerHttpStatus: 422,
-          providerErrorType: undefined,
-          failureKind: "unknown",
-          failureStage: "unknown",
-          classificationSource: "fallback",
-          publicErrorCode: "GENERATION_FAILED",
-          retryPolicy: "retry_once",
-          billingDisposition: "not_charged",
-          artifactRecorded: false,
-          usageRecorded: false,
-          admissionStatus: "failed",
-          expected: false,
-        }),
-      ],
-    ]);
-    const publicAndLogSurfaces = JSON.stringify({
-      realtime: context.mocks.ably.publish.mock.calls,
-      status: statusBody,
-      debugFailureLogs,
-      warnFailureLogs,
-    });
-    for (const privateValue of [
-      "private-unknown-failure-prompt",
-      "private.example",
-      "Unexpected status code: 422",
-      "blocked by the safety filter",
-    ]) {
-      expect(publicAndLogSurfaces).not.toContain(privateValue);
-    }
-    expect(context.mocks.s3.send).not.toHaveBeenCalled();
-    await expect(orgCredits(fixture)).resolves.toBe(1000);
-  });
+      const debugFailureLogs =
+        context.mocks.axiomLogging.debug.mock.calls.filter(([message]) => {
+          return message === FAL_FAILURE_LOG_MESSAGE;
+        });
+      const warnFailureLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
+        ([message]) => {
+          return message === FAL_FAILURE_LOG_MESSAGE;
+        },
+      );
+      const infoFailureLogs = context.mocks.axiomLogging.info.mock.calls.filter(
+        ([message]) => {
+          return message === FAL_FAILURE_LOG_MESSAGE;
+        },
+      );
+      expect(debugFailureLogs).toHaveLength(0);
+      expect(infoFailureLogs).toHaveLength(0);
+      expect(warnFailureLogs).toStrictEqual([
+        [
+          FAL_FAILURE_LOG_MESSAGE,
+          expect.objectContaining({
+            context: "BuiltInGenerationWebhooks",
+            provider: "fal",
+            generationId,
+            type: "image",
+            providerStatus: status,
+            providerHttpStatus,
+            providerErrorType,
+            failureKind: "unknown",
+            failureStage: "unknown",
+            classificationSource: "fallback",
+            publicErrorCode: "GENERATION_FAILED",
+            retryPolicy: "retry_once",
+            billingDisposition: "not_charged",
+            artifactRecorded: false,
+            usageRecorded: false,
+            admissionStatus: "failed",
+            expected: false,
+          }),
+        ],
+      ]);
+      const publicAndLogSurfaces = JSON.stringify({
+        realtime: context.mocks.ably.publish.mock.calls,
+        status: statusBody,
+        debugFailureLogs,
+        infoFailureLogs,
+        warnFailureLogs,
+      });
+      for (const privateValue of [
+        "private-unknown-failure-prompt",
+        "private.example",
+        "Unexpected status code: 422",
+        "Invalid status code:",
+        "blocked by the safety filter",
+        "private-provider-message",
+        "private-provider-token",
+        "private-provider-location",
+        "private-fal-request-id",
+        "private-fal-gateway-request-id",
+      ]) {
+        expect(publicAndLogSurfaces).not.toContain(privateValue);
+      }
+      expect(context.mocks.s3.send).not.toHaveBeenCalled();
+      await expect(orgCredits(fixture)).resolves.toBe(1000);
+    },
+  );
 
   it("does not complete a job after the status route times it out", async () => {
     const fixture = await seedImageFixture({ credits: 1000 });

--- a/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/video-io-generate.test.ts
@@ -55,6 +55,8 @@ const FAL_STATUS_URL =
 const FAL_RESPONSE_URL =
   "https://queue.fal.run/fal-ai/veo3.1/fast/requests/video-request/response";
 const FAL_VIDEO_URL = "https://v3b.fal.media/files/video-output.mp4";
+const FAL_FAILURE_LOG_MESSAGE =
+  "Fal built-in generation webhook reported failed generation";
 const KLING_V3_4K_MODEL = "fal-ai/kling-video/v3/4k/text-to-video";
 const KLING_V3_4K_QUEUE_URL = `https://queue.fal.run/${KLING_V3_4K_MODEL}`;
 const KLING_STATUS_URL =
@@ -337,11 +339,22 @@ async function postFalWebhook(
   requestUrl: string | null,
   payload: unknown,
 ): Promise<void> {
+  await postFalWebhookEnvelope(app, requestUrl, {
+    status: "COMPLETED",
+    payload,
+  });
+}
+
+async function postFalWebhookEnvelope(
+  app: ReturnType<typeof createVideoIoTestApp>,
+  requestUrl: string | null,
+  payload: unknown,
+): Promise<void> {
   const url = new URL(readFalWebhookUrl(requestUrl));
   const response = await app.request(`${url.pathname}${url.search}`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ status: "COMPLETED", payload }),
+    body: JSON.stringify(payload),
   });
   expect(response.status).toBe(200);
 }
@@ -2359,9 +2372,143 @@ describe("POST /api/video-io/generate", () => {
       requestId: "video-request",
     });
 
+    await postFalWebhookEnvelope(app, observedRequestUrl, {
+      status: "ERROR",
+      error: "Invalid status code: 422",
+      payload: { detail: [{ type: "file_download_error" }] },
+    });
+    const afterLateFailure = await app.request(
+      `/api/built-in-generations/${generationId}`,
+      { headers: { authorization: `Bearer ${token}` } },
+    );
+    expect(afterLateFailure.status).toBe(200);
+    await expect(afterLateFailure.json()).resolves.toMatchObject({
+      status: "completed",
+      result: body,
+    });
+    for (const level of ["info", "warn", "debug"] as const) {
+      expect(
+        context.mocks.axiomLogging[level].mock.calls.filter(([message]) => {
+          return message === FAL_FAILURE_LOG_MESSAGE;
+        }),
+      ).toHaveLength(0);
+    }
+
     // creditsCharged 1504 = 8 seconds at the audio rate (188/s); the silent
     // rate would charge 1000, so the exact balance drop pins the category.
     await expect(orgCredits(fixture)).resolves.toBe(10_000 - 1504);
+  });
+
+  it("retains safe Fal video failure diagnostics without changing the public error or charging", async () => {
+    const fixture = await seedVideoFixture();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    let observedRequestUrl: string | null = null;
+    server.use(
+      http.post(FAL_VEO_FAST_QUEUE_URL, ({ request }) => {
+        observedRequestUrl = request.url;
+        return HttpResponse.json({
+          request_id: "private-fal-video-request",
+          status_url: FAL_STATUS_URL,
+          response_url: FAL_RESPONSE_URL,
+        });
+      }),
+    );
+    const app = createVideoIoTestApp(fixture.pricingResolution);
+    const response = await app.request("/api/video-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        prompt: "private-video-prompt",
+        model: "veo3.1-fast",
+        duration: "8s",
+      }),
+    });
+    expect(response.status).toBe(202);
+    const generationId = readAcceptedGenerationId(
+      await response.json(),
+      "video",
+      fixture.userId,
+    );
+    const payload = {
+      status: "ERROR",
+      error: "Invalid status code: 422",
+      request_id: "private-fal-video-request",
+      payload: {
+        detail: [
+          {
+            type: "file_download_error",
+            msg: "private-video-provider-message",
+            input: { url: "https://private.example/input-video.mp4" },
+          },
+        ],
+      },
+    };
+    await postFalWebhookEnvelope(app, observedRequestUrl, payload);
+    await postFalWebhookEnvelope(app, observedRequestUrl, payload);
+    await flushWaitUntilForTest();
+
+    const statusResponse = await app.request(
+      `/api/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    const statusBody: unknown = await statusResponse.json();
+    const expectedError = {
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Generation failed",
+    };
+    expect(statusBody).toMatchObject({
+      generationId,
+      status: "failed",
+      error: expectedError,
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `built-in-generation:${generationId}`,
+      expect.objectContaining({ status: "failed", error: expectedError }),
+    );
+    const failureLogs = context.mocks.axiomLogging.warn.mock.calls.filter(
+      ([message]) => {
+        return message === FAL_FAILURE_LOG_MESSAGE;
+      },
+    );
+    expect(failureLogs).toStrictEqual([
+      [
+        FAL_FAILURE_LOG_MESSAGE,
+        expect.objectContaining({
+          provider: "fal",
+          generationId,
+          type: "video",
+          providerHttpStatus: 422,
+          providerErrorType: "file_download_error",
+          failureKind: "unknown",
+          publicErrorCode: "INTERNAL_SERVER_ERROR",
+          expected: false,
+        }),
+      ],
+    ]);
+    for (const level of ["info", "debug"] as const) {
+      expect(
+        context.mocks.axiomLogging[level].mock.calls.filter(([message]) => {
+          return message === FAL_FAILURE_LOG_MESSAGE;
+        }),
+      ).toHaveLength(0);
+    }
+    const publicAndLogSurfaces = JSON.stringify({
+      statusBody,
+      realtime: context.mocks.ably.publish.mock.calls,
+      failureLogs,
+    });
+    for (const privateValue of [
+      "private-video-prompt",
+      "private-video-provider-message",
+      "private-fal-video-request",
+      "private.example",
+      "Invalid status code:",
+    ]) {
+      expect(publicAndLogSurfaces).not.toContain(privateValue);
+    }
+    expect(context.mocks.s3.send).not.toHaveBeenCalled();
+    await expect(orgCredits(fixture)).resolves.toBe(10_000);
   });
 
   it("generates video files with the recommended Kling 4K model", async () => {

--- a/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts
@@ -276,13 +276,14 @@ function falPayloadBody(payload: unknown): FalWebhookPayload | null {
   };
 }
 
-const FAL_UNEXPECTED_STATUS_CODE = /^Unexpected status code: ([1-5]\d{2})$/u;
+const FAL_STATUS_CODE_ERROR =
+  /^(?:Invalid|Unexpected) status code: ([1-5]\d{2})$/u;
 
 function falProviderHttpStatus(error: unknown): number | undefined {
   if (typeof error !== "string") {
     return undefined;
   }
-  const match = FAL_UNEXPECTED_STATUS_CODE.exec(error.trim());
+  const match = FAL_STATUS_CODE_ERROR.exec(error.trim());
   return match ? Number(match[1]) : undefined;
 }
 
@@ -532,6 +533,37 @@ const FAL_STRUCTURED_FAILURE_RULES: readonly FalStructuredFailureRule[] = [
   },
 ];
 
+function allowedFalProviderErrorType(value: unknown): string | undefined {
+  const rule = FAL_STRUCTURED_FAILURE_RULES.find((candidate) => {
+    return candidate.providerErrorType === value;
+  });
+  if (rule) {
+    return rule.providerErrorType;
+  }
+  // Legacy validation type in Fal's documented ERROR webhook envelope:
+  // https://fal.ai/docs/documentation/model-apis/inference/webhooks
+  if (value === "value_error.missing") {
+    return "value_error.missing";
+  }
+  return undefined;
+}
+
+function falProviderErrorTypeForLog(body: unknown): string | undefined {
+  if (!isRecord(body)) {
+    return undefined;
+  }
+  const entries = Array.isArray(body.detail) ? body.detail : [body.detail];
+  for (const entry of entries) {
+    if (isRecord(entry)) {
+      const providerErrorType = allowedFalProviderErrorType(entry.type);
+      if (providerErrorType !== undefined) {
+        return providerErrorType;
+      }
+    }
+  }
+  return undefined;
+}
+
 function falFailureLocationMatches(
   location: readonly (string | number)[],
   expected: string,
@@ -552,18 +584,20 @@ function falGenerationFailure(
   type: BuiltInGenerationWebhookJob["type"],
   payload: FalWebhookPayload,
 ): FalGenerationFailure {
+  const providerErrorType = falProviderErrorTypeForLog(payload.body);
   const diagnostics = isRecord(payload.body)
     ? falFailureDetailDiagnostics(payload.body.detail)
     : [];
-  if (
-    type === "image" &&
-    diagnostics.some((diagnostic) => {
-      return (
-        diagnostic.message ===
-        normalizeFalFailureMessage(FAL_OUTPUT_SAFETY_FILTER_MESSAGE)
-      );
-    })
-  ) {
+  const outputSafetyDiagnostic =
+    type === "image"
+      ? diagnostics.find((diagnostic) => {
+          return (
+            diagnostic.message ===
+            normalizeFalFailureMessage(FAL_OUTPUT_SAFETY_FILTER_MESSAGE)
+          );
+        })
+      : undefined;
+  if (outputSafetyDiagnostic) {
     return {
       error: {
         message: FAL_OUTPUT_SAFETY_FILTER_MESSAGE,
@@ -575,7 +609,9 @@ function falGenerationFailure(
       classificationSource: "normalized_message_exact",
       expected: true,
       providerHttpStatus: payload.providerHttpStatus,
-      providerErrorType: undefined,
+      providerErrorType:
+        allowedFalProviderErrorType(outputSafetyDiagnostic.providerErrorType) ??
+        providerErrorType,
     };
   }
   if (type === "image") {
@@ -615,7 +651,7 @@ function falGenerationFailure(
       classificationSource: "fallback",
       expected: false,
       providerHttpStatus: payload.providerHttpStatus,
-      providerErrorType: undefined,
+      providerErrorType,
     };
   }
   return {
@@ -629,7 +665,7 @@ function falGenerationFailure(
     classificationSource: "fallback",
     expected: false,
     providerHttpStatus: payload.providerHttpStatus,
-    providerErrorType: undefined,
+    providerErrorType,
   };
 }
 
@@ -1412,7 +1448,7 @@ const postFalBuiltInGenerationWebhook$ = command(
           type: job.type,
           providerStatus: status,
           providerHttpStatus: failure.providerHttpStatus,
-          providerErrorType: failure.providerErrorType,
+          providerErrorType: failure.providerErrorType ?? "unknown",
           failureKind: failure.kind,
           failureStage: failure.stage,
           classificationSource: failure.classificationSource,
@@ -1425,7 +1461,7 @@ const postFalBuiltInGenerationWebhook$ = command(
           expected: failure.expected,
         };
         if (failure.expected) {
-          L.debug(
+          L.info(
             "Fal built-in generation webhook reported failed generation",
             fields,
           );


### PR DESCRIPTION
Known Fal webhook failures currently use debug logs, which the default Axiom transport filters before ingestion. Recognized provider error types are also discarded when provider messages no longer match the public-error classification rules.

Emit expected terminal failures at info and retain warn for unknown or provider failures. Preserve diagnostic types using the existing classification-rule allowlist plus the documented `value_error.missing` value, independently of public-error matching. Accept both `Invalid status code` and `Unexpected status code` wrappers, and use an explicit `unknown` diagnostic fallback. Existing public errors, retry policies, and terminal-transition guards are preserved; raw provider payloads and free-form error text are not added to logs.

## Fallbacks

The following behaviors are in `turbo/apps/api/src/signals/routes/webhooks-built-in-generations.ts` and handle external Fal diagnostics. They do not bridge old and new vm0 deployments; DB/API, runner/sandbox, and web/app version-skew windows do not apply.

- `allowedFalProviderErrorType` also accepts the exact `value_error.missing` type shown in [Fal's documented ERROR webhook](https://fal.ai/docs/documentation/model-apis/inference/webhooks#response-errors). This retains a safe diagnostic from that provider format without adding a new public-error classification.
- `falProviderHttpStatus` / `FAL_STATUS_CODE_ERROR` accept the documented `Invalid status code: NNN` spelling alongside the existing `Unexpected status code: NNN` spelling. Only complete strings containing a 100–599 status produce a numeric diagnostic; missing or other free-form errors leave it absent.
- `falProviderErrorTypeForLog`, `falGenerationFailure`, and `postFalBuiltInGenerationWebhook$` retain the first allowlisted type from an object or array detail when its message/location cannot be classified. The output-safety path prefers the matched diagnostic's allowlisted type, then falls back to that extracted type. Missing, malformed, or unrecognized types become the fixed log value `unknown`; they never become raw provider text or a guessed public failure class.

Surface: Fal webhook -> API observability. These are ongoing external-data handling rules, with no deployment removal timer or temporary rollout follow-up. A future removal would require evidence that Fal no longer emits the relevant format or permits the missing diagnostic; this PR establishes no such removal gate. The existing generic image/video public-error fallbacks are unchanged.

## Validation

- 205 tests passed across six focused API route and logging test files, including error payload variants, privacy, duplicate callbacks, and late failures after completion.
- A real Axiom SDK integration test inspects the HTTP ingest body, verifying default level filtering, field retention, and restoration of centralized mocks.
- Passed formatting, `pnpm -F api lint`, `pnpm -F api check-types`, and `pnpm exec knip --workspace apps/api`.

Production collection should be checked after deployment using the fixed failure message at both info and warn levels. Production log verification has not been performed for this change.

Refs #32127
