### PR TITLE
fix(connectors): sanitize malformed token responses

### DIFF
--- a/turbo/packages/connectors/src/auth-providers/__tests__/token-response-errors.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/__tests__/token-response-errors.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "vitest";
+import { HttpResponse, http } from "msw";
+
+import type { ConnectorAuthMethodRuntimeConfig } from "../../connector-config";
+import {
+  exchangeConnectorAuthCodeWithMethod,
+  refreshConnectorAuthProviderAccessTokenWithMethod,
+} from "../connector-auth";
+import { ProviderResponseError } from "../provider-error";
+import { server } from "./test-server";
+
+interface ProviderCase {
+  readonly slug: string;
+  readonly methodId: string;
+  readonly url: string;
+  readonly inputs: Readonly<Record<string, string>>;
+  readonly rotates: boolean;
+  readonly clientEnv?: string;
+}
+
+const PROVIDERS: readonly ProviderCase[] = [
+  {
+    slug: "paypal",
+    methodId: "api-token",
+    url: "https://api-m.paypal.com/v1/oauth2/token",
+    inputs: { clientId: "client-id", clientSecret: "client-secret" },
+    rotates: false,
+  },
+  {
+    slug: "ramp",
+    methodId: "api-token",
+    url: "https://api.ramp.com/developer/v1/token",
+    inputs: {
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      scope: "transactions:read",
+    },
+    rotates: false,
+  },
+  {
+    slug: "netsuite",
+    methodId: "api-token",
+    url: "https://test-account.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/token",
+    inputs: {
+      accountSubdomain: "test-account",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      refreshToken: "refresh-token",
+    },
+    rotates: true,
+  },
+  {
+    slug: "reckon",
+    methodId: "oauth-refresh-token",
+    url: "https://identity.reckon.com/connect/token",
+    inputs: {
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      redirectUri: "https://example.com/callback",
+      refreshToken: "refresh-token",
+    },
+    rotates: true,
+  },
+  {
+    slug: "resource-guru",
+    methodId: "oauth",
+    url: "https://api.resourceguruapp.com/oauth/token",
+    inputs: { refreshToken: "refresh-token" },
+    rotates: true,
+    clientEnv: "RESOURCE_GURU",
+  },
+  {
+    slug: "optimizely-cmp",
+    methodId: "oauth",
+    url: "https://accounts.cmp.optimizely.com/o/oauth2/v1/token",
+    inputs: { refreshToken: "refresh-token" },
+    rotates: true,
+    clientEnv: "OPTIMIZELY_CMP",
+  },
+];
+
+const AUTH_CLIENT = {
+  clientRegistration: "static",
+  clientType: "confidential",
+  clientId: "client-id",
+  clientSecret: "client-secret",
+} as const;
+
+function secretRef(name: string) {
+  return `$secrets.TEST_${name.toUpperCase()}` as const;
+}
+
+function selection(provider: ProviderCase) {
+  const outputs = {
+    accessToken: secretRef("accessToken"),
+    ...(provider.rotates ? { refreshToken: secretRef("refreshToken") } : {}),
+  };
+  const inputNames = Object.keys(provider.inputs);
+  const shared: Pick<
+    ConnectorAuthMethodRuntimeConfig,
+    "storage" | "access" | "revoke"
+  > = {
+    storage: {
+      version: 1,
+      secrets: [
+        ...new Set(
+          [...inputNames, ...Object.keys(outputs)].map((name) => {
+            return `TEST_${name.toUpperCase()}`;
+          }),
+        ),
+      ],
+      variables: [],
+    },
+    access: {
+      kind: "refresh-token",
+      inputs: Object.fromEntries(
+        inputNames.map((name) => {
+          return [name, secretRef(name)];
+        }),
+      ),
+      outputs,
+      refreshableSecrets: ["TEST_ACCESSTOKEN"],
+      envBindings: {},
+    },
+    revoke:
+      provider.slug === "optimizely-cmp"
+        ? {
+            kind: "token-revoke",
+            inputs: { refreshToken: secretRef("refreshToken") },
+          }
+        : { kind: "none" },
+  };
+  const method: ConnectorAuthMethodRuntimeConfig = provider.clientEnv
+    ? {
+        ...shared,
+        client: {
+          clientRegistration: "static",
+          clientType: "confidential",
+          clientIdEnv: `${provider.clientEnv}_OAUTH_CLIENT_ID`,
+          clientSecretEnv: `${provider.clientEnv}_OAUTH_CLIENT_SECRET`,
+        },
+        grant: {
+          kind: "auth-code",
+          callbackOrigin: "web",
+          scopes: [],
+          outputs,
+        },
+      }
+    : {
+        ...shared,
+        grant: {
+          kind: "manual",
+          fields: Object.fromEntries(
+            inputNames.map((name) => {
+              return [
+                `TEST_${name.toUpperCase()}`,
+                {
+                  publicId: name,
+                  label: name,
+                  required: true,
+                  storage: "secret" as const,
+                },
+              ];
+            }),
+          ),
+        },
+      };
+  return {
+    connectorSlug: provider.slug,
+    authMethodId: provider.methodId,
+    method,
+    inputs: provider.inputs,
+    ...(provider.clientEnv ? { authClient: AUTH_CLIENT } : {}),
+  };
+}
+
+const INVALID_RESPONSES = [
+  { label: "malformed JSON", body: "PRIVATE123" },
+  {
+    label: "invalid token types",
+    body: JSON.stringify({ access_token: 42, expires_in: 3600 }),
+  },
+  {
+    label: "missing required tokens",
+    body: JSON.stringify({ expires_in: 3600 }),
+  },
+];
+
+describe.each(PROVIDERS)("registered $slug token responses", (provider) => {
+  it.each(INVALID_RESPONSES)(
+    "sanitizes $label as an upstream response error",
+    async ({ body }) => {
+      server.use(
+        http.post(provider.url, () => {
+          return new HttpResponse(body);
+        }),
+      );
+      const refresh = refreshConnectorAuthProviderAccessTokenWithMethod(
+        selection(provider),
+        new AbortController().signal,
+      );
+      await expect(refresh).rejects.toBeInstanceOf(ProviderResponseError);
+      await expect(refresh).rejects.toHaveProperty(
+        "message",
+        expect.not.stringContaining("PRIVATE123"),
+      );
+      await expect(refresh).rejects.toHaveProperty(
+        "message",
+        expect.not.stringContaining("access_token"),
+      );
+    },
+  );
+
+  it("preserves successful token outputs, rotation and expiry", async () => {
+    server.use(
+      http.post(provider.url, () => {
+        return HttpResponse.json({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 3600,
+        });
+      }),
+    );
+    await expect(
+      refreshConnectorAuthProviderAccessTokenWithMethod(
+        selection(provider),
+        new AbortController().signal,
+      ),
+    ).resolves.toMatchObject({
+      outputs: {
+        accessToken: "new-access",
+        ...(provider.rotates ? { refreshToken: "new-refresh" } : {}),
+      },
+      expiresIn: 3600,
+    });
+  });
+
+  it("preserves HTTP failure status", async () => {
+    server.use(
+      http.post(provider.url, () => {
+        return HttpResponse.json({ error: "invalid_grant" }, { status: 401 });
+      }),
+    );
+    await expect(
+      refreshConnectorAuthProviderAccessTokenWithMethod(
+        selection(provider),
+        new AbortController().signal,
+      ),
+    ).rejects.toHaveProperty("status", 401);
+  });
+
+  it("preserves network failures", async () => {
+    server.use(
+      http.post(provider.url, () => {
+        return HttpResponse.error();
+      }),
+    );
+    await expect(
+      refreshConnectorAuthProviderAccessTokenWithMethod(
+        selection(provider),
+        new AbortController().signal,
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("preserves cancellation while reading the response body", async () => {
+    const abort = new DOMException("Response body cancelled", "AbortError");
+    server.use(
+      http.post(provider.url, () => {
+        return new HttpResponse(
+          new ReadableStream({
+            start(controller) {
+              controller.error(abort);
+            },
+          }),
+        );
+      }),
+    );
+    await expect(
+      refreshConnectorAuthProviderAccessTokenWithMethod(
+        selection(provider),
+        new AbortController().signal,
+      ),
+    ).rejects.toBe(abort);
+  });
+});
+
+describe.each(
+  PROVIDERS.filter((provider) => {
+    return provider.clientEnv;
+  }),
+)("registered $slug code exchange", (provider) => {
+  it.each(INVALID_RESPONSES)(
+    "sanitizes $label before fetching user information",
+    async ({ body }) => {
+      server.use(
+        http.post(provider.url, () => {
+          return new HttpResponse(body);
+        }),
+      );
+      await expect(
+        exchangeConnectorAuthCodeWithMethod({
+          ...selection(provider),
+          authClient: AUTH_CLIENT,
+          code: "authorization-code",
+          redirectUri: "https://example.com/callback",
+          authorizationUrl: null,
+          state: "state",
+          codeVerifier: undefined,
+          oauthContext: undefined,
+        }),
+      ).rejects.toBeInstanceOf(ProviderResponseError);
+    },
+  );
+});

--- a/turbo/packages/connectors/src/auth-providers/__tests__/token-response-errors.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/__tests__/token-response-errors.test.ts
@@ -186,8 +186,21 @@ const INVALID_RESPONSES = [
   },
 ];
 
+function invalidResponses(provider: ProviderCase) {
+  if (provider.slug === "optimizely-cmp") {
+    return [
+      ...INVALID_RESPONSES,
+      {
+        label: "a missing refresh token",
+        body: JSON.stringify({ access_token: "PRIVATE123", expires_in: 3600 }),
+      },
+    ];
+  }
+  return INVALID_RESPONSES;
+}
+
 describe.each(PROVIDERS)("registered $slug token responses", (provider) => {
-  it.each(INVALID_RESPONSES)(
+  it.each(invalidResponses(provider))(
     "sanitizes $label as an upstream response error",
     async ({ body }) => {
       server.use(
@@ -290,7 +303,7 @@ describe.each(
     return provider.clientEnv;
   }),
 )("registered $slug code exchange", (provider) => {
-  it.each(INVALID_RESPONSES)(
+  it.each(invalidResponses(provider))(
     "sanitizes $label before fetching user information",
     async ({ body }) => {
       server.use(

--- a/turbo/packages/connectors/src/auth-providers/connectors/netsuite/api-token.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/netsuite/api-token.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-import { ProviderHttpError, ProviderResponseError } from "../../provider-error";
+import { ProviderHttpError } from "../../provider-error";
+import { parseProviderTokenResponse } from "../../token-response";
 
 const ACCOUNT_SUBDOMAIN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/i;
 
@@ -35,19 +36,18 @@ export async function refreshNetSuiteAccessToken(
       response.status,
     );
   }
-  const parsed = z
-    .object({
+  const data = await parseProviderTokenResponse(
+    response,
+    z.object({
       access_token: z.string().min(1),
       refresh_token: z.string().min(1).optional(),
       expires_in: z.number().positive().optional(),
-    })
-    .safeParse(await response.json());
-  if (!parsed.success) {
-    throw new ProviderResponseError("Invalid NetSuite token response");
-  }
+    }),
+    "Invalid NetSuite token response",
+  );
   return {
-    accessToken: parsed.data.access_token,
-    refreshToken: parsed.data.refresh_token,
-    expiresIn: parsed.data.expires_in,
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/optimizely-cmp/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/optimizely-cmp/oauth.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
 import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
+import { ProviderResponseError } from "../../provider-error";
+import { parseProviderTokenResponse } from "../../token-response";
 
 const OPTIMIZELY_CMP_AUTHORIZATION_URL =
   "https://accounts.cmp.optimizely.com/o/oauth2/v1/auth";
@@ -65,7 +67,11 @@ async function requestToken(
     await throwOAuthError("Optimizely CMP", operation, response);
   }
 
-  const data = tokenResponseSchema.parse(await response.json());
+  const data = await parseProviderTokenResponse(
+    response,
+    tokenResponseSchema,
+    "Invalid Optimizely CMP token response",
+  );
   if (data.error) {
     throw new Error(data.error_description ?? data.error);
   }
@@ -110,10 +116,14 @@ export async function exchangeOptimizelyCmpCode(
   );
 
   if (!data.access_token) {
-    throw new Error("No access token in Optimizely CMP response");
+    throw new ProviderResponseError(
+      "No access token in Optimizely CMP response",
+    );
   }
   if (!data.refresh_token) {
-    throw new Error("No refresh token in Optimizely CMP response");
+    throw new ProviderResponseError(
+      "No refresh token in Optimizely CMP response",
+    );
   }
 
   return {
@@ -144,10 +154,12 @@ export async function refreshOptimizelyCmpToken(
   );
 
   if (!data.access_token) {
-    throw new Error("No access token in Optimizely CMP refresh response");
+    throw new ProviderResponseError(
+      "No access token in Optimizely CMP refresh response",
+    );
   }
   if (!data.refresh_token) {
-    throw new Error(
+    throw new ProviderResponseError(
       "No rotated refresh token in Optimizely CMP refresh response",
     );
   }

--- a/turbo/packages/connectors/src/auth-providers/connectors/paypal/api-token.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/paypal/api-token.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-import { ProviderHttpError, ProviderResponseError } from "../../provider-error";
+import { ProviderHttpError } from "../../provider-error";
+import { parseProviderTokenResponse } from "../../token-response";
 
 const TOKEN_URL = "https://api-m.paypal.com/v1/oauth2/token";
 
@@ -26,17 +27,16 @@ export async function fetchPayPalAccessToken(
       response.status,
     );
   }
-  const parsed = z
-    .object({
+  const data = await parseProviderTokenResponse(
+    response,
+    z.object({
       access_token: z.string().min(1),
       expires_in: z.number().positive(),
-    })
-    .safeParse(await response.json());
-  if (!parsed.success) {
-    throw new ProviderResponseError("Invalid PayPal access token response");
-  }
+    }),
+    "Invalid PayPal access token response",
+  );
   return {
-    accessToken: parsed.data.access_token,
-    expiresIn: parsed.data.expires_in,
+    accessToken: data.access_token,
+    expiresIn: data.expires_in,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/ramp/api-token.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/ramp/api-token.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-import { ProviderHttpError, ProviderResponseError } from "../../provider-error";
+import { ProviderHttpError } from "../../provider-error";
+import { parseProviderTokenResponse } from "../../token-response";
 
 const TOKEN_URL = "https://api.ramp.com/developer/v1/token";
 
@@ -30,17 +31,16 @@ export async function fetchRampAccessToken(
       response.status,
     );
   }
-  const parsed = z
-    .object({
+  const data = await parseProviderTokenResponse(
+    response,
+    z.object({
       access_token: z.string().min(1),
       expires_in: z.number().positive(),
-    })
-    .safeParse(await response.json());
-  if (!parsed.success) {
-    throw new ProviderResponseError("Invalid Ramp access token response");
-  }
+    }),
+    "Invalid Ramp access token response",
+  );
   return {
-    accessToken: parsed.data.access_token,
-    expiresIn: parsed.data.expires_in,
+    accessToken: data.access_token,
+    expiresIn: data.expires_in,
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/reckon/api-token.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/reckon/api-token.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { ProviderHttpError, ProviderResponseError } from "../../provider-error";
+import { parseProviderTokenResponse } from "../../token-response";
 
 const RECKON_TOKEN_URL = "https://identity.reckon.com/connect/token";
 
@@ -39,33 +40,28 @@ export async function refreshReckonAccessToken(
     );
   }
 
-  const parsed = z
-    .object({
+  const data = await parseProviderTokenResponse(
+    response,
+    z.object({
       access_token: z.string().min(1).optional(),
       refresh_token: z.string().min(1).optional(),
       expires_in: z.number().positive().optional(),
       error: z.string().min(1).optional(),
       error_description: z.string().min(1).optional(),
-    })
-    .safeParse(await response.json());
-  if (!parsed.success) {
-    throw new ProviderResponseError("Invalid Reckon token response");
+    }),
+    "Invalid Reckon token response",
+  );
+  if (data.error !== undefined) {
+    throw new ProviderResponseError(data.error_description ?? data.error);
   }
-  if (parsed.data.error !== undefined) {
-    throw new ProviderResponseError(
-      parsed.data.error_description ?? parsed.data.error,
-    );
-  }
-  if (parsed.data.access_token === undefined) {
+  if (data.access_token === undefined) {
     throw new ProviderResponseError("No access token in Reckon token response");
   }
   return {
-    accessToken: parsed.data.access_token,
-    ...(parsed.data.refresh_token === undefined
+    accessToken: data.access_token,
+    ...(data.refresh_token === undefined
       ? {}
-      : { refreshToken: parsed.data.refresh_token }),
-    ...(parsed.data.expires_in === undefined
-      ? {}
-      : { expiresIn: parsed.data.expires_in }),
+      : { refreshToken: data.refresh_token }),
+    ...(data.expires_in === undefined ? {} : { expiresIn: data.expires_in }),
   };
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/resource-guru/oauth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/resource-guru/oauth.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import type { ConnectorAuthCodeGrantConfig } from "@okouai/connectors/connector-config";
 import { throwOAuthError } from "../../oauth/error";
 import { effectiveOAuthScopes, reportedOAuthScopes } from "../../oauth/scope";
+import { ProviderResponseError } from "../../provider-error";
+import { parseProviderTokenResponse } from "../../token-response";
 
 const RESOURCE_GURU_TOKEN_URL = "https://api.resourceguruapp.com/oauth/token";
 
@@ -86,12 +88,18 @@ export async function exchangeResourceGuruCode(
     await throwOAuthError("Resource Guru", "exchange", response);
   }
 
-  const data = tokenResponseSchema.parse(await response.json());
+  const data = await parseProviderTokenResponse(
+    response,
+    tokenResponseSchema,
+    "Invalid Resource Guru token response",
+  );
   if (data.error) {
     throw new Error(data.error_description ?? data.error);
   }
   if (!data.access_token) {
-    throw new Error("No access token in Resource Guru response");
+    throw new ProviderResponseError(
+      "No access token in Resource Guru response",
+    );
   }
 
   return {
@@ -128,12 +136,18 @@ export async function refreshResourceGuruToken(
     await throwOAuthError("Resource Guru", "refresh", response);
   }
 
-  const data = tokenResponseSchema.parse(await response.json());
+  const data = await parseProviderTokenResponse(
+    response,
+    tokenResponseSchema,
+    "Invalid Resource Guru token response",
+  );
   if (data.error) {
     throw new Error(data.error_description ?? data.error);
   }
   if (!data.access_token) {
-    throw new Error("No access token in Resource Guru refresh response");
+    throw new ProviderResponseError(
+      "No access token in Resource Guru refresh response",
+    );
   }
 
   return {

--- a/turbo/packages/connectors/src/auth-providers/token-response.ts
+++ b/turbo/packages/connectors/src/auth-providers/token-response.ts
@@ -1,0 +1,25 @@
+import type { z } from "zod";
+
+import { ProviderResponseError } from "./provider-error";
+
+export async function parseProviderTokenResponse<T>(
+  response: Response,
+  schema: z.ZodType<T>,
+  failureMessage: string,
+): Promise<T> {
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new ProviderResponseError(failureMessage);
+    }
+    throw error;
+  }
+
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    throw new ProviderResponseError(failureMessage);
+  }
+  return parsed.data;
+}


### PR DESCRIPTION
## Summary

Closes #32291.

A successful token endpoint response containing malformed JSON currently escapes as SyntaxError in PayPal, Ramp, NetSuite, Reckon, Resource Guru and Optimizely CMP. Resource Guru and CMP also propagate schema errors or generic errors for incomplete token payloads. The firewall runtime then marks a temporary upstream failure as requiring reconnection, and JSON parse messages can expose response fragments in logs.

Decode and validate those token responses through a narrow shared boundary that emits a static ProviderResponseError. The runtime already treats that error as an upstream failure, preserving the connection for retry. Resource Guru and CMP code exchange use the same sanitized boundary.

The decoder catches JSON SyntaxError only, preserving network errors and response-body cancellation. Existing HTTP/OAuth status handling, request authentication, token rotation, scopes and expiry semantics are retained.

## Validation

- New registered-provider/MSW regressions: **16 failed before the fix**; all 50 now pass. They cover malformed JSON, invalid/missing tokens, successful outputs and rotation, HTTP status, network failure, body-stream cancellation and OAuth code exchange.
- New regression plus connector-backlog, Resource Guru, Reckon and CMP files: **71 tests passed across 5 files**.
- `pnpm -F @okouai/connectors check-types` — passed.
- `pnpm -F @okouai/connectors lint` — passed.
- `pnpm exec knip --workspace packages/connectors` — passed.
- Changed-file Prettier and `git diff --check` — passed.
- Existing firewall-auth API integration coverage exercises upstream failures followed by successful retry without reconnecting; broader API validation runs in the PR pipeline. No live provider credentials were used.
