### PR TITLE
chore(api): remove expected queue claim warning

### DIFF
--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -5119,10 +5119,8 @@ const createQueuedRunForChatCallback$ = command(
     const runResult = settledRunResult.value;
     if (isQueueFirstRunClaimLost(runResult)) {
       signal.throwIfAborted();
-      log.warn("Auto-send lost the queued-message launch claim", {
-        threadId: input.runInput.threadId,
-        userMessageId: input.runInput.queuedMessage.id,
-      });
+      // Claim loss is expected exactly-one-winner arbitration; structured
+      // queue-first timing telemetry remains the diagnostic source.
       return null;
     }
     if (


### PR DESCRIPTION
## Summary

- remove the terminal callback auto-send warning for expected queue-first claim loss
- keep cancellation handling and the immediate no-launch return unchanged
- document existing structured queue-first timing telemetry as the diagnostic source

## Why

Production evidence in #32138 confirms that each warning represented an expected loser after another dispatcher atomically won the launch claim and completed the run. Treating that arbitration outcome as an application warning is a production-proven false positive. Retrying would risk duplicate launches or violate a winning recall.

## Validation

- `pnpm exec prettier --check apps/api/src/signals/services/internal-chat-run-callback.service.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- repository-wide runtime-source search confirms the exact warning string is absent
- focused diff confirms the other auto-send warnings and structured queue-first telemetry are unchanged
- full local Vitest suite not run per the issue contract; the PR pipeline is the authoritative validation matrix

Closes #32138
