### PR TITLE
fix(api): bill built-in deepseek pi first turns

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -15,6 +15,7 @@ import {
 import { replayChatThreadEvents } from "@okouai/core/chat-thread-event-replay";
 import { avatarTemplateStylePresetId } from "@okouai/core/avatar-template";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS } from "@okouai/api-contracts/contracts/model-price-tiers";
 import {
   DEFAULT_IMAGE_MODEL,
   DEFAULT_IMAGE_MODEL_ENV,
@@ -257,6 +258,12 @@ const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "okou web upload-file -f <path>";
 const RUN_TIME_BUDGET_STEER_AT_MS = 115 * 60 * 1000;
 const PI_API_FIRST_TURN_USAGE_NAMESPACE =
   "26e1c547-485d-4438-bf6d-4b77959da0cb";
+const PI_API_FIRST_TURN_BASE_USAGE_CATEGORIES = [
+  "tokens.input",
+  "tokens.output",
+  "tokens.cache_read",
+  "tokens.cache_creation",
+] as const;
 const STANDARD_TERRA_API_KEY_BDD_ROUTES = [
   {
     name: "OpenAI",
@@ -329,6 +336,10 @@ const TERRA_USAGE_PRICING = [
     unitSize: 1_000_000,
   };
 });
+type PiApiFirstTurnUsageProvider =
+  | "deepseek-v4-flash"
+  | "deepseek-v4-pro"
+  | "gpt-5.6-terra";
 const RUN_TIME_BUDGET_MESSAGE = `This runner has a hard maximum runtime of 2 hours. The current run has been active for 115 minutes, leaving approximately 5 minutes before it is terminated.
 
 An active goal allows unfinished work to continue in a later run. An existing goal already provides that continuity and remains unchanged. If no goal exists, the unfinished outcome needs to be captured in a new goal before this run ends.
@@ -608,9 +619,10 @@ function totalChargedCredits(
   }, 0);
 }
 
-async function expectTerraApiFirstTurnUsage(
+async function expectPiApiFirstTurnUsage(
   runId: string,
   sessionBytes: Buffer,
+  provider: PiApiFirstTurnUsageProvider,
 ): Promise<void> {
   const firstSession = MemoryPiSession.fromJsonl(sessionBytes.toString("utf8"));
   const firstAssistant = [...firstSession.buildSessionContext().messages]
@@ -626,7 +638,7 @@ async function expectTerraApiFirstTurnUsage(
     cacheRead: 3,
     cacheWrite: 2,
   });
-  await expectTerraApiUsage(runId, "", {
+  await expectPiApiUsage(runId, provider, "", {
     input: 5,
     output: 3,
     cacheRead: 3,
@@ -634,7 +646,7 @@ async function expectTerraApiFirstTurnUsage(
   });
 }
 
-function terraApiFirstTurnUsageEvents(
+function piApiFirstTurnUsageEvents(
   runId: string,
   responseSourceId: string,
 ): readonly {
@@ -658,8 +670,9 @@ function terraApiFirstTurnUsageEvents(
   });
 }
 
-async function expectTerraApiUsage(
+async function expectPiApiUsage(
   runId: string,
+  provider: PiApiFirstTurnUsageProvider,
   suffix: "" | ".fast" | ".long_context" | ".long_context.fast",
   expected: {
     readonly input: number;
@@ -680,7 +693,7 @@ async function expectTerraApiUsage(
     })
     .map(([category, quantity]) => {
       return expect.objectContaining({
-        provider: "gpt-5.6-terra",
+        provider,
         category: `${category}${suffix}`,
         quantity,
         status: "processed",
@@ -690,6 +703,19 @@ async function expectTerraApiUsage(
     });
   expect(usageRows).toStrictEqual(expectedRows);
   expect(totalChargedCredits(usageRows)).toBeGreaterThan(0);
+}
+
+async function expectTerraApiUsage(
+  runId: string,
+  suffix: "" | ".fast" | ".long_context" | ".long_context.fast",
+  expected: {
+    readonly input: number;
+    readonly output: number;
+    readonly cacheRead: number;
+    readonly cacheCreation: number;
+  },
+): Promise<void> {
+  await expectPiApiUsage(runId, "gpt-5.6-terra", suffix, expected);
 }
 
 async function expectTerraApiFollowUpUsage(
@@ -716,6 +742,27 @@ async function createTerraUsagePricingResolution(): Promise<
 > {
   const pricing = await createUsagePricingFixture({
     configured: TERRA_USAGE_PRICING,
+  });
+  onTestFinished(pricing.cleanup);
+  return pricing.resolution;
+}
+
+async function createPiApiFirstTurnUsagePricingResolution(
+  provider: PiApiFirstTurnUsageProvider,
+): Promise<UsagePricingFixture["resolution"]> {
+  if (provider === "gpt-5.6-terra") {
+    return await createTerraUsagePricingResolution();
+  }
+  const pricing = await createUsagePricingFixture({
+    configured: PI_API_FIRST_TURN_BASE_USAGE_CATEGORIES.map((category) => {
+      return {
+        kind: "model",
+        provider,
+        category,
+        unitPrice: 1,
+        unitSize: 1_000_000,
+      };
+    }),
   });
   onTestFinished(pricing.cleanup);
   return pricing.resolution;
@@ -5785,6 +5832,7 @@ async function queueCapabilityProvenPiRun(args: {
   readonly prompt: string;
   readonly codexServiceTier?: "fast";
   readonly terraRoute?: "openai" | "openrouter";
+  readonly selectedModel?: PiApiFirstTurnUsageProvider;
 }): Promise<{
   readonly anchor: { readonly runId: string; readonly threadId: string };
   readonly anchorClaim: Awaited<ReturnType<typeof claimChatRun>>;
@@ -5809,16 +5857,17 @@ async function queueCapabilityProvenPiRun(args: {
     );
   }
   const anchorClaim = await claimChatRun(args.runnerGroup, anchor.runId);
+  const selectedModel = args.selectedModel ?? "gpt-5.6-terra";
   let withModelRoute = async <T>(work: () => Promise<T>): Promise<T> => {
     return await work();
   };
   if (args.terraRoute === "openrouter") {
     withModelRoute = await configureBuiltInPiModelOnOpenRouter(
       args.actor,
-      "gpt-5.6-terra",
+      selectedModel,
     );
   } else {
-    await configureBuiltInPiModel(args.actor, "gpt-5.6-terra");
+    await configureBuiltInPiModel(args.actor, selectedModel);
   }
   await updateFeatureSwitchesForUser(
     context,
@@ -5830,14 +5879,15 @@ async function queueCapabilityProvenPiRun(args: {
         : {}),
     },
   );
-  const usagePricingResolution = await createTerraUsagePricingResolution();
+  const usagePricingResolution =
+    await createPiApiFirstTurnUsagePricingResolution(selectedModel);
   const run = await withModelRoute(async () => {
     return await sendChatRun(
       args.actor,
       {
         agentId: args.agentId,
         prompt: args.prompt,
-        model: "gpt-5.6-terra",
+        model: selectedModel,
         ...(args.codexServiceTier === undefined
           ? {}
           : { runOptions: { codexServiceTier: args.codexServiceTier } }),
@@ -7641,7 +7691,8 @@ describe("CHAT-02: model-first provider policies", () => {
     "runs the Pi API first turn once for %s and resumes canonical JSONL",
     async (selectedModel) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
-      const usagePricingResolution = await createTerraUsagePricingResolution();
+      const usagePricingResolution =
+        await createPiApiFirstTurnUsagePricingResolution(selectedModel);
       const orgId = actor.orgId;
       if (!orgId) {
         throw new Error("Expected entitled chat actor to have an org");
@@ -7679,7 +7730,7 @@ describe("CHAT-02: model-first provider policies", () => {
             );
           }
           const usage =
-            selectedModel === "gpt-5.6-terra" && sequence === 0
+            sequence === 0
               ? {
                   input_tokens: 10,
                   output_tokens: 3,
@@ -7743,9 +7794,11 @@ describe("CHAT-02: model-first provider policies", () => {
       if (!firstSessionBytes) {
         throw new Error("Expected the first Pi run to persist native H1");
       }
-      if (selectedModel === "gpt-5.6-terra") {
-        await expectTerraApiFirstTurnUsage(first.runId, firstSessionBytes);
-      }
+      await expectPiApiFirstTurnUsage(
+        first.runId,
+        firstSessionBytes,
+        selectedModel,
+      );
       const firstSessionHash = createHash("sha256")
         .update(firstSessionBytes)
         .digest("hex");
@@ -7785,9 +7838,12 @@ describe("CHAT-02: model-first provider policies", () => {
       await waitForRunStatus(actor, second.runId, "completed");
       await flushWaitUntilForTest();
       expect(modelRequests).toHaveLength(2);
-      if (selectedModel === "gpt-5.6-terra") {
-        await expectTerraApiFollowUpUsage(second.runId);
-      }
+      await expectPiApiUsage(second.runId, selectedModel, "", {
+        input: 5,
+        output: 3,
+        cacheRead: 0,
+        cacheCreation: 0,
+      });
       const secondModelInput = JSON.stringify(modelRequests[1]?.body);
       expect(occurrences(secondModelInput, firstPrompt)).toBe(1);
       expect(occurrences(secondModelInput, modelAnswers[0] ?? "")).toBe(1);
@@ -7949,6 +8005,8 @@ describe("CHAT-02: model-first provider policies", () => {
     async (selectedModel) => {
       const { actor, agentId } = await entitledChatActor();
       const orgId = requireOrgId(actor);
+      const usagePricingResolution =
+        await createPiApiFirstTurnUsagePricingResolution(selectedModel);
       const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
         actor,
         selectedModel,
@@ -7978,11 +8036,16 @@ describe("CHAT-02: model-first provider policies", () => {
       );
 
       const run = await withOpenRouterRoute(async () => {
-        return await sendChatRun(actor, {
-          agentId,
-          prompt: `run ${selectedModel} on its managed fallback`,
-          model: selectedModel,
-        });
+        return await sendChatRun(
+          actor,
+          {
+            agentId,
+            prompt: `run ${selectedModel} on its managed fallback`,
+            model: selectedModel,
+          },
+          "vm0",
+          usagePricingResolution,
+        );
       });
       await waitForRunStatus(actor, run.runId, "completed", 10_000);
       await flushWaitUntilForTest();
@@ -7997,196 +8060,233 @@ describe("CHAT-02: model-first provider policies", () => {
       await expect(
         readRunLaunchSnapshotFixture(context, run.runId),
       ).resolves.toMatchObject({ launch_snapshot: { framework: "pi" } });
+      await expectPiApiUsage(run.runId, selectedModel, "", {
+        input: 5,
+        output: 3,
+        cacheRead: 0,
+        cacheCreation: 0,
+      });
       const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
       expect(claim.status).toBe(404);
     },
     90_000,
   );
 
-  it("keeps Terra first-turn billing idempotent for matching usage identities", async () => {
-    const { actor, agentId } = await entitledChatActor();
-    const orgId = requireOrgId(actor);
-    const usagePricingResolution = await createTerraUsagePricingResolution();
-    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
-    );
-    mockPiResourceArchiveDownloads();
-    mockPiCheckpointObjectStore();
+  it.each([
+    {
+      name: "Terra",
+      selectedModel: "gpt-5.6-terra",
+      providerUrl: "https://api.openai.com/v1/responses",
+    },
+    {
+      name: "DeepSeek Flash",
+      selectedModel: "deepseek-v4-flash",
+      providerUrl: "https://api.deepseek.com/responses",
+    },
+  ] as const)(
+    "keeps $name first-turn billing idempotent for matching usage identities",
+    async ({ selectedModel, providerUrl }) => {
+      const { actor, agentId } = await entitledChatActor();
+      const orgId = requireOrgId(actor);
+      const usagePricingResolution =
+        await createPiApiFirstTurnUsagePricingResolution(selectedModel);
+      await configureBuiltInPiModel(actor, selectedModel);
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: true },
+      );
+      mockPiResourceArchiveDownloads();
+      mockPiCheckpointObjectStore();
 
-    const providerEntered = createDeferredPromise<void>(context.signal);
-    const releaseProvider = createDeferredPromise<void>(context.signal);
-    onTestFinished(() => {
-      if (!releaseProvider.settled()) {
-        releaseProvider.resolve(undefined);
-      }
-    });
-    let modelCalls = 0;
-    server.use(
-      http.post("https://api.openai.com/v1/responses", async () => {
-        modelCalls += 1;
-        if (!providerEntered.settled()) {
-          providerEntered.resolve(undefined);
+      const providerEntered = createDeferredPromise<void>(context.signal);
+      const releaseProvider = createDeferredPromise<void>(context.signal);
+      onTestFinished(() => {
+        if (!releaseProvider.settled()) {
+          releaseProvider.resolve(undefined);
         }
-        await releaseProvider.promise;
-        return new HttpResponse(
-          piResponsesTextSse("idempotent Terra billing", 0, {
-            input_tokens: 10,
-            output_tokens: 3,
-            total_tokens: 13,
-            input_tokens_details: {
-              cached_tokens: 3,
-              cache_write_tokens: 2,
-            },
-          }),
-          { headers: { "content-type": "text/event-stream" } },
-        );
-      }),
-    );
-
-    const run = await sendChatRun(
-      actor,
-      {
-        agentId,
-        prompt: "reuse matching Terra billing identities",
-        model: "gpt-5.6-terra",
-      },
-      "vm0",
-      usagePricingResolution,
-    );
-    await providerEntered.promise;
-    const usageEvents = terraApiFirstTurnUsageEvents(
-      run.runId,
-      "resp_pi_api_0",
-    );
-    const idempotencyKeys = usageEvents.map((event) => {
-      return event.idempotencyKey;
-    });
-    onTestFinished(async () => {
-      await deletePiApiFirstTurnUsageEventsFixture(idempotencyKeys);
-    });
-    // No production API can preseed first-turn billing identities before the
-    // provider responds. This run-owned fixture creates the otherwise
-    // unreachable retry state while the public chat API remains under test.
-    await insertPiApiFirstTurnUsageEventsFixture({
-      runId: run.runId,
-      orgId,
-      userId: actor.userId,
-      events: usageEvents,
-    });
-
-    releaseProvider.resolve(undefined);
-    await waitForRunStatus(actor, run.runId, "completed");
-    await flushWaitUntilForTest();
-
-    expect(modelCalls).toBe(1);
-    await expectTerraApiUsage(run.runId, "", {
-      input: 5,
-      output: 3,
-      cacheRead: 3,
-      cacheCreation: 2,
-    });
-  }, 90_000);
-
-  it("fails Terra first-turn billing on a conflicting usage identity", async () => {
-    const { actor, agentId } = await entitledChatActor();
-    const orgId = requireOrgId(actor);
-    const usagePricingResolution = await createTerraUsagePricingResolution();
-    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
-    );
-    mockPiResourceArchiveDownloads();
-    mockPiCheckpointObjectStore();
-
-    const providerEntered = createDeferredPromise<void>(context.signal);
-    const releaseProvider = createDeferredPromise<void>(context.signal);
-    onTestFinished(() => {
-      if (!releaseProvider.settled()) {
-        releaseProvider.resolve(undefined);
-      }
-    });
-    let modelCalls = 0;
-    server.use(
-      http.post("https://api.openai.com/v1/responses", async () => {
-        modelCalls += 1;
-        if (!providerEntered.settled()) {
-          providerEntered.resolve(undefined);
-        }
-        await releaseProvider.promise;
-        return new HttpResponse(
-          piResponsesTextSse("conflicting Terra billing", 0, {
-            input_tokens: 10,
-            output_tokens: 3,
-            total_tokens: 13,
-            input_tokens_details: {
-              cached_tokens: 3,
-              cache_write_tokens: 2,
-            },
-          }),
-          { headers: { "content-type": "text/event-stream" } },
-        );
-      }),
-    );
-
-    const run = await sendChatRun(
-      actor,
-      {
-        agentId,
-        prompt: "reject a conflicting Terra billing identity",
-        model: "gpt-5.6-terra",
-      },
-      "vm0",
-      usagePricingResolution,
-    );
-    await providerEntered.promise;
-    const usageEvents = terraApiFirstTurnUsageEvents(
-      run.runId,
-      "resp_pi_api_0",
-    );
-    const [expectedEvent] = usageEvents;
-    if (!expectedEvent) {
-      throw new Error("Expected a Terra billing identity fixture");
-    }
-    onTestFinished(async () => {
-      await deletePiApiFirstTurnUsageEventsFixture(
-        usageEvents.map((event) => {
-          return event.idempotencyKey;
+      });
+      let modelCalls = 0;
+      server.use(
+        http.post(providerUrl, async () => {
+          modelCalls += 1;
+          if (!providerEntered.settled()) {
+            providerEntered.resolve(undefined);
+          }
+          await releaseProvider.promise;
+          return new HttpResponse(
+            piResponsesTextSse(`idempotent ${selectedModel} billing`, 0, {
+              input_tokens: 10,
+              output_tokens: 3,
+              total_tokens: 13,
+              input_tokens_details: {
+                cached_tokens: 3,
+                cache_write_tokens: 2,
+              },
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          );
         }),
       );
-    });
-    // No production API can preseed a conflicting first-turn billing identity
-    // before the provider responds. This run-owned fixture creates that
-    // otherwise unreachable state while the public chat API remains under test.
-    await insertPiApiFirstTurnUsageEventsFixture({
-      runId: run.runId,
-      orgId,
-      userId: actor.userId,
-      events: [{ ...expectedEvent, quantity: expectedEvent.quantity + 1 }],
-    });
 
-    releaseProvider.resolve(undefined);
-    await waitForRunStatus(actor, run.runId, "failed");
-    await flushWaitUntilForTest();
+      const run = await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt: `reuse matching ${selectedModel} billing identities`,
+          model: selectedModel,
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+      await providerEntered.promise;
+      const usageEvents = piApiFirstTurnUsageEvents(run.runId, "resp_pi_api_0");
+      const idempotencyKeys = usageEvents.map((event) => {
+        return event.idempotencyKey;
+      });
+      onTestFinished(async () => {
+        await deletePiApiFirstTurnUsageEventsFixture(idempotencyKeys);
+      });
+      // No production API can preseed first-turn billing identities before the
+      // provider responds. This run-owned fixture creates the otherwise
+      // unreachable retry state while the public chat API remains under test.
+      await insertPiApiFirstTurnUsageEventsFixture({
+        runId: run.runId,
+        orgId,
+        userId: actor.userId,
+        provider: selectedModel,
+        events: usageEvents,
+      });
 
-    expect(modelCalls).toBe(1);
-    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
-      status: "failed",
-      error: expect.stringContaining("[PI_API_MODEL_FAILED]"),
-    });
-    // Public usage summaries omit unprocessed rows. Inspect this run's unique
-    // rows only to prove the failed transaction added no partial billing data.
-    await expect(readRunUsageEventsFixture(run.runId)).resolves.toStrictEqual([
-      expect.objectContaining({
-        category: expectedEvent.category,
-        quantity: expectedEvent.quantity + 1,
-      }),
-    ]);
-  }, 90_000);
+      releaseProvider.resolve(undefined);
+      await waitForRunStatus(actor, run.runId, "completed");
+      await flushWaitUntilForTest();
+
+      expect(modelCalls).toBe(1);
+      await expectPiApiUsage(run.runId, selectedModel, "", {
+        input: 5,
+        output: 3,
+        cacheRead: 3,
+        cacheCreation: 2,
+      });
+    },
+    90_000,
+  );
+
+  it.each([
+    {
+      name: "Terra",
+      selectedModel: "gpt-5.6-terra",
+      providerUrl: "https://api.openai.com/v1/responses",
+    },
+    {
+      name: "DeepSeek Pro",
+      selectedModel: "deepseek-v4-pro",
+      providerUrl: "https://api.deepseek.com/responses",
+    },
+  ] as const)(
+    "fails $name first-turn billing on a conflicting usage identity",
+    async ({ selectedModel, providerUrl }) => {
+      const { actor, agentId } = await entitledChatActor();
+      const orgId = requireOrgId(actor);
+      const usagePricingResolution =
+        await createPiApiFirstTurnUsagePricingResolution(selectedModel);
+      await configureBuiltInPiModel(actor, selectedModel);
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: true },
+      );
+      mockPiResourceArchiveDownloads();
+      mockPiCheckpointObjectStore();
+
+      const providerEntered = createDeferredPromise<void>(context.signal);
+      const releaseProvider = createDeferredPromise<void>(context.signal);
+      onTestFinished(() => {
+        if (!releaseProvider.settled()) {
+          releaseProvider.resolve(undefined);
+        }
+      });
+      let modelCalls = 0;
+      server.use(
+        http.post(providerUrl, async () => {
+          modelCalls += 1;
+          if (!providerEntered.settled()) {
+            providerEntered.resolve(undefined);
+          }
+          await releaseProvider.promise;
+          return new HttpResponse(
+            piResponsesTextSse(`conflicting ${selectedModel} billing`, 0, {
+              input_tokens: 10,
+              output_tokens: 3,
+              total_tokens: 13,
+              input_tokens_details: {
+                cached_tokens: 3,
+                cache_write_tokens: 2,
+              },
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          );
+        }),
+      );
+
+      const run = await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt: `reject a conflicting ${selectedModel} billing identity`,
+          model: selectedModel,
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+      await providerEntered.promise;
+      const usageEvents = piApiFirstTurnUsageEvents(run.runId, "resp_pi_api_0");
+      const [expectedEvent] = usageEvents;
+      if (!expectedEvent) {
+        throw new Error(`Expected a ${selectedModel} billing identity fixture`);
+      }
+      onTestFinished(async () => {
+        await deletePiApiFirstTurnUsageEventsFixture(
+          usageEvents.map((event) => {
+            return event.idempotencyKey;
+          }),
+        );
+      });
+      // No production API can preseed a conflicting first-turn billing identity
+      // before the provider responds. This run-owned fixture creates that
+      // otherwise unreachable state while the public chat API remains under test.
+      await insertPiApiFirstTurnUsageEventsFixture({
+        runId: run.runId,
+        orgId,
+        userId: actor.userId,
+        provider: selectedModel,
+        events: [{ ...expectedEvent, quantity: expectedEvent.quantity + 1 }],
+      });
+
+      releaseProvider.resolve(undefined);
+      await waitForRunStatus(actor, run.runId, "failed");
+      await flushWaitUntilForTest();
+
+      expect(modelCalls).toBe(1);
+      await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+        status: "failed",
+        error: expect.stringContaining("[PI_API_MODEL_FAILED]"),
+      });
+      // Public usage summaries omit unprocessed rows. Inspect this run's unique
+      // rows only to prove the failed transaction added no partial billing data.
+      await expect(readRunUsageEventsFixture(run.runId)).resolves.toStrictEqual(
+        [
+          expect.objectContaining({
+            category: expectedEvent.category,
+            provider: selectedModel,
+            quantity: expectedEvent.quantity + 1,
+          }),
+        ],
+      );
+    },
+    90_000,
+  );
 
   it("resumes pre-migration OpenRouter Chat JSONL through API-first Responses", async () => {
     const { actor, agentId } = await entitledChatActor();
@@ -8361,10 +8461,15 @@ describe("CHAT-02: model-first provider policies", () => {
     ).toBeFalsy();
   }, 90_000);
 
-  it("reuses one OpenRouter Responses Pi session across standard, fast, and standard Terra turns", async () => {
+  it("reuses one OpenRouter Responses Pi session across standard, fast, and long-context Terra turns", async () => {
     const { actor, agentId } = await entitledChatActor();
     const orgId = requireOrgId(actor);
     const usagePricingResolution = await createTerraUsagePricingResolution();
+    const longContextInputTokens =
+      MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS["gpt-5.6-terra"];
+    if (longContextInputTokens === undefined) {
+      throw new Error("Expected the Terra long-context pricing threshold");
+    }
     const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
       actor,
       "gpt-5.6-terra",
@@ -8382,12 +8487,12 @@ describe("CHAT-02: model-first provider policies", () => {
     const prompts = [
       "start standard Terra in the canonical Pi session",
       "continue fast Terra in the same Pi session",
-      "return to standard Terra in the same Pi session",
+      "continue long-context Terra in the same Pi session",
     ] as const;
     const answers = [
       "first standard Terra answer",
       "fast Terra answer",
-      "second standard Terra answer",
+      "long-context Terra answer",
     ] as const;
     const modelRequests: unknown[] = [];
     const observedTiers = ["default", "priority", "flex"] as const;
@@ -8408,15 +8513,21 @@ describe("CHAT-02: model-first provider policies", () => {
             piResponsesTextSse(
               answer,
               requestIndex,
-              {
-                input_tokens: 10,
-                output_tokens: 3,
-                total_tokens: 13,
-                input_tokens_details: {
-                  cached_tokens: 3,
-                  cache_write_tokens: 2,
-                },
-              },
+              requestIndex === 2
+                ? {
+                    input_tokens: longContextInputTokens,
+                    output_tokens: 3,
+                    total_tokens: longContextInputTokens + 3,
+                  }
+                : {
+                    input_tokens: 10,
+                    output_tokens: 3,
+                    total_tokens: 13,
+                    input_tokens_details: {
+                      cached_tokens: 3,
+                      cache_write_tokens: 2,
+                    },
+                  },
               observedTiers[requestIndex],
             ),
             { headers: { "content-type": "text/event-stream" } },
@@ -8555,11 +8666,11 @@ describe("CHAT-02: model-first provider policies", () => {
       cacheRead: 3,
       cacheCreation: 2,
     });
-    await expectTerraApiUsage(returned.runId, "", {
-      input: 5,
+    await expectTerraApiUsage(returned.runId, ".long_context", {
+      input: longContextInputTokens,
       output: 3,
-      cacheRead: 3,
-      cacheCreation: 2,
+      cacheRead: 0,
+      cacheCreation: 0,
     });
 
     const visibleTurns = [
@@ -10532,17 +10643,46 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(claim.status).toBe(404);
   }, 90_000);
 
-  it("bills one late OpenRouter result from its observed tier after cancellation wins", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    mockPiResourceArchiveDownloads();
-    const providerEntered = createDeferredPromise<void>(context.signal);
-    const releaseProvider = createDeferredPromise<void>(context.signal);
-    let modelCalls = 0;
-    const modelRequests: unknown[] = [];
-    server.use(
-      http.post(
-        "https://openrouter.ai/api/v1/responses",
-        async ({ request }) => {
+  it.each([
+    {
+      name: "OpenRouter Terra",
+      selectedModel: "gpt-5.6-terra",
+      providerUrl: "https://openrouter.ai/api/v1/responses",
+      observedServiceTier: "default",
+      codexServiceTier: "fast",
+      terraRoute: "openrouter",
+      inputTokens: 10,
+      expectedInput: 5,
+    },
+    {
+      name: "built-in DeepSeek Flash",
+      selectedModel: "deepseek-v4-flash",
+      providerUrl: "https://api.deepseek.com/responses",
+      observedServiceTier: "priority",
+      codexServiceTier: undefined,
+      terraRoute: undefined,
+      inputTokens: 300_000,
+      expectedInput: 299_995,
+    },
+  ] as const)(
+    "bills one late $name result exactly once after cancellation wins",
+    async ({
+      selectedModel,
+      providerUrl,
+      observedServiceTier,
+      codexServiceTier,
+      terraRoute,
+      inputTokens,
+      expectedInput,
+    }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockPiResourceArchiveDownloads();
+      const providerEntered = createDeferredPromise<void>(context.signal);
+      const releaseProvider = createDeferredPromise<void>(context.signal);
+      let modelCalls = 0;
+      const modelRequests: unknown[] = [];
+      server.use(
+        http.post(providerUrl, async ({ request }) => {
           modelCalls += 1;
           modelRequests.push(await request.json());
           if (!providerEntered.settled()) {
@@ -10554,89 +10694,95 @@ describe("CHAT-02: model-first provider policies", () => {
               "result blocked before publication",
               modelCalls,
               {
-                input_tokens: 10,
+                input_tokens: inputTokens,
                 output_tokens: 3,
-                total_tokens: 13,
+                total_tokens: inputTokens + 3,
                 input_tokens_details: {
                   cached_tokens: 3,
                   cache_write_tokens: 2,
                 },
               },
-              "default",
+              observedServiceTier,
             ),
             { headers: { "content-type": "text/event-stream" } },
           );
-        },
-      ),
-    );
-    const checkpointObjects = mockPiCheckpointObjectStore();
-    const { anchor, anchorClaim, run, usagePricingResolution } =
-      await queueCapabilityProvenPiRun({
-        actor,
-        agentId,
-        runnerGroup,
-        prompt: "let cancellation commit before API publication",
-        codexServiceTier: "fast",
-        terraRoute: "openrouter",
+        }),
+      );
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      const { anchor, anchorClaim, run, usagePricingResolution } =
+        await queueCapabilityProvenPiRun({
+          actor,
+          agentId,
+          runnerGroup,
+          prompt: "let cancellation commit before API publication",
+          ...(codexServiceTier === undefined ? {} : { codexServiceTier }),
+          ...(terraRoute === undefined ? {} : { terraRoute }),
+          selectedModel,
+        });
+      await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
+      await providerEntered.promise;
+      const lifecycleLock = await holdPiApiFirstTurnLifecycleLockFixture({
+        runId: run.runId,
+        signal: context.signal,
       });
-    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
-    await providerEntered.promise;
-    const lifecycleLock = await holdPiApiFirstTurnLifecycleLockFixture({
-      runId: run.runId,
-      signal: context.signal,
-    });
-    onTestFinished(async () => {
+      onTestFinished(async () => {
+        lifecycleLock.release();
+        await lifecycleLock.done;
+      });
+
+      const cancellation = api.requestCancelRun(
+        actor,
+        run.runId,
+        [200],
+        usagePricingResolution,
+      );
+      await expect.poll(lifecycleLock.waiterCount).toBe(1);
+      releaseProvider.resolve(undefined);
+      await expect.poll(lifecycleLock.waiterCount).toBe(2);
       lifecycleLock.release();
       await lifecycleLock.done;
-    });
+      await cancellation;
+      await flushWaitUntilForTest();
 
-    const cancellation = api.requestCancelRun(
-      actor,
-      run.runId,
-      [200],
-      usagePricingResolution,
-    );
-    await expect.poll(lifecycleLock.waiterCount).toBe(1);
-    releaseProvider.resolve(undefined);
-    await expect.poll(lifecycleLock.waiterCount).toBe(2);
-    lifecycleLock.release();
-    await lifecycleLock.done;
-    await cancellation;
-    await flushWaitUntilForTest();
-
-    expect(modelCalls).toBe(1);
-    expect(
-      z
-        .object({ service_tier: z.literal("priority") })
-        .passthrough()
-        .parse(modelRequests[0]).service_tier,
-    ).toBe("priority");
-    await expectTerraApiUsage(run.runId, "", {
-      input: 5,
-      output: 3,
-      cacheRead: 3,
-      cacheCreation: 2,
-    });
-    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
-      status: "cancelled",
-    });
-    expect(
-      checkpointObjects.has(
-        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
-      ),
-    ).toBeFalsy();
-    expect(
-      checkpointObjects.has(
-        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
-      ),
-    ).toBeFalsy();
-    expect(
-      eventBackedContents(
-        (await chat.listThreadEvents(actor, run.threadId)).events,
-        run.runId,
-      ),
-    ).toHaveLength(0);
-  }, 90_000);
+      expect(modelCalls).toBe(1);
+      if (selectedModel === "gpt-5.6-terra") {
+        expect(
+          z
+            .object({ service_tier: z.literal("priority") })
+            .passthrough()
+            .parse(modelRequests[0]).service_tier,
+        ).toBe("priority");
+      } else {
+        expect(modelRequests[0]).not.toHaveProperty("service_tier");
+      }
+      await expectPiApiUsage(run.runId, selectedModel, "", {
+        input: expectedInput,
+        output: 3,
+        cacheRead: 3,
+        cacheCreation: 2,
+      });
+      await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+        status: "cancelled",
+      });
+      expect(
+        checkpointObjects.has(
+          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`,
+        ),
+      ).toBeFalsy();
+      expect(
+        checkpointObjects.has(
+          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
+        ),
+      ).toBeFalsy();
+      expect(
+        eventBackedContents(
+          (await chat.listThreadEvents(actor, run.threadId)).events,
+          run.runId,
+        ),
+      ).toHaveLength(0);
+    },
+    90_000,
+  );
 
   it("keeps API completion terminal when it wins the lifecycle lock before cancellation", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
@@ -11897,6 +12043,131 @@ describe("CHAT-02: model-first provider policies", () => {
     await flushWaitUntilForTest();
     expect(modelCalls).toBe(2);
   }, 150_000);
+
+  it("keeps DeepSeek API-first and Sandbox usage as separate billable rows", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const orgId = requireOrgId(actor);
+    const selectedModel = "deepseek-v4-flash";
+    const usagePricingResolution =
+      await createPiApiFirstTurnUsagePricingResolution(selectedModel);
+    await configureBuiltInPiModel(actor, selectedModel);
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId },
+      { [FeatureSwitchKey.PiLoop]: true },
+    );
+    mockPiResourceArchiveDownloads();
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.deepseek.com/responses", () => {
+        modelCalls += 1;
+        return new HttpResponse(
+          piResponsesContentSse({
+            blocks: [
+              {
+                type: "toolCall",
+                callId: "call_deepseek_sandbox",
+                name: "bash",
+                arguments: { command: "true" },
+              },
+            ],
+            sequence: modelCalls,
+            usage: {
+              input_tokens: 10,
+              output_tokens: 3,
+              total_tokens: 13,
+              input_tokens_details: {
+                cached_tokens: 3,
+                cache_write_tokens: 2,
+              },
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }),
+    );
+
+    const run = await sendChatRun(
+      actor,
+      {
+        agentId,
+        prompt: "hand a built-in DeepSeek tool response to Sandbox",
+        model: selectedModel,
+      },
+      "vm0",
+      usagePricingResolution,
+    );
+    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.has(manifestKey);
+      })
+      .toBe(true);
+    await flushWaitUntilForTest();
+    expect(modelCalls).toBe(1);
+
+    const claimed = await claimChatRun(runnerGroup, run.runId);
+    expect(claimed.claim.piModelConfig).toMatchObject({
+      provider: "deepseek",
+      api: "openai-responses",
+    });
+    expect(claimed.claim.piModelConfig).not.toHaveProperty("serviceTier");
+    const sandboxUsageEvent = {
+      idempotencyKey: randomUUID(),
+      kind: "model" as const,
+      provider: selectedModel,
+      category: "tokens.output",
+      quantity: 2,
+    };
+    const sandboxUsageReceipts = await Promise.all([
+      webhooks.requestAgentUsageEvent(
+        { runId: run.runId, events: [sandboxUsageEvent] },
+        claimed.sandboxHeaders,
+        [200],
+        usagePricingResolution,
+      ),
+      webhooks.requestAgentUsageEvent(
+        { runId: run.runId, events: [sandboxUsageEvent] },
+        claimed.sandboxHeaders,
+        [200],
+        usagePricingResolution,
+      ),
+    ]);
+    expect(
+      sandboxUsageReceipts.map((receipt) => {
+        return receipt.body;
+      }),
+    ).toStrictEqual([{ success: true }, { success: true }]);
+    await api.requestCancelRun(actor, run.runId, [200], usagePricingResolution);
+    await waitForRunStatus(actor, run.runId, "cancelled");
+    await failChatRun(run.runId, claimed.sandboxHeaders, "Run cancelled");
+    await flushWaitUntilForTest();
+    const combinedUsage = await readRunUsageEventsFixture(run.runId);
+    expect(
+      combinedUsage.filter((row) => {
+        return row.category === "tokens.output" && row.quantity === 3;
+      }),
+    ).toHaveLength(1);
+    expect(
+      combinedUsage.filter((row) => {
+        return row.category === "tokens.output" && row.quantity === 2;
+      }),
+    ).toHaveLength(1);
+    expect(combinedUsage).toHaveLength(5);
+    expect(
+      combinedUsage.every((row) => {
+        return (
+          row.provider === selectedModel &&
+          row.status === "processed" &&
+          row.billingError === null &&
+          !row.category.includes(".fast") &&
+          !row.category.includes(".long_context")
+        );
+      }),
+    ).toBeTruthy();
+    expect(totalChargedCredits(combinedUsage)).toBeGreaterThan(0);
+  }, 90_000);
 
   it("publishes OpenRouter Responses blocks, hands tools to H2, and checkpoints Pi memory notes", async () => {
     if (await runInIsolatedProcess(import.meta.url)) {
@@ -14434,6 +14705,8 @@ describe("CHAT-02: model-first provider policies", () => {
 
   it("runs built-in DeepSeek through the native Pi API credential", async () => {
     const { actor, agentId } = await entitledChatActor();
+    const usagePricingResolution =
+      await createPiApiFirstTurnUsagePricingResolution("deepseek-v4-flash");
     const keyFixtureId = randomUUID();
     const requestedApiKey = `built-in-key-bdd-dev-seed-${keyFixtureId}`;
 
@@ -14504,11 +14777,16 @@ describe("CHAT-02: model-first provider policies", () => {
         }),
       );
 
-      const run = await sendChatRun(actor, {
-        agentId,
-        prompt: "run with the selected built-in DeepSeek provider",
-        model: "deepseek-v4-flash",
-      });
+      const run = await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt: "run with the selected built-in DeepSeek provider",
+          model: "deepseek-v4-flash",
+        },
+        "vm0",
+        usagePricingResolution,
+      );
       runId = run.runId;
       await waitForRunStatus(actor, run.runId, "completed");
       await flushWaitUntilForTest();
@@ -14517,6 +14795,12 @@ describe("CHAT-02: model-first provider policies", () => {
       expect(modelRequests[0]?.body).toMatchObject({
         model: "deepseek-v4-flash",
         stream: true,
+      });
+      await expectPiApiUsage(run.runId, "deepseek-v4-flash", "", {
+        input: 5,
+        output: 3,
+        cacheRead: 0,
+        cacheCreation: 0,
       });
       const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
       expect(claim.status).toBe(404);

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn-usage.service.ts
@@ -12,6 +12,13 @@ import type { Db } from "../external/db";
 const PI_API_FIRST_TURN_USAGE_NAMESPACE =
   "26e1c547-485d-4438-bf6d-4b77959da0cb";
 const TERRA_MODEL = "gpt-5.6-terra";
+const DEEPSEEK_FLASH_MODEL = "deepseek-v4-flash";
+const DEEPSEEK_PRO_MODEL = "deepseek-v4-pro";
+
+type PiApiFirstTurnUsageProvider =
+  | typeof TERRA_MODEL
+  | typeof DEEPSEEK_FLASH_MODEL
+  | typeof DEEPSEEK_PRO_MODEL;
 
 function terraLongContextMinimumInputTokens(): number {
   const minimum = MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS[TERRA_MODEL];
@@ -69,7 +76,7 @@ function idempotencyKey(namespace: string, parts: readonly string[]): string {
   return uuidv5(JSON.stringify(parts), namespace);
 }
 
-function piApiFirstTurnUsageEntries(
+function terraApiFirstTurnUsageEntries(
   turn: PiApiFirstTurnResult,
   fast: boolean,
 ): readonly PiApiFirstTurnUsageEntry[] {
@@ -105,6 +112,51 @@ function piApiFirstTurnUsageEntries(
   });
 }
 
+/** DeepSeek pricing uses only base token categories, independent of Pi tiers. */
+function deepSeekApiFirstTurnUsageEntries(
+  turn: PiApiFirstTurnResult,
+): readonly PiApiFirstTurnUsageEntry[] {
+  const usage = turn.assistantMessage.usage;
+  return (
+    [
+      {
+        category: "tokens.input",
+        quantity: usageQuantity(usage.input, "input"),
+      },
+      {
+        category: "tokens.output",
+        quantity: usageQuantity(usage.output, "output"),
+      },
+      {
+        category: "tokens.cache_read",
+        quantity: usageQuantity(usage.cacheRead, "cache-read"),
+      },
+      {
+        category: "tokens.cache_creation",
+        quantity: usageQuantity(usage.cacheWrite, "cache-creation"),
+      },
+    ] satisfies readonly {
+      readonly category: PiUsageCategoryBase;
+      readonly quantity: number;
+    }[]
+  ).filter((entry) => {
+    return entry.quantity > 0;
+  });
+}
+
+function piApiFirstTurnUsageProvider(
+  provider: string | undefined,
+): PiApiFirstTurnUsageProvider | null {
+  if (
+    provider === TERRA_MODEL ||
+    provider === DEEPSEEK_FLASH_MODEL ||
+    provider === DEEPSEEK_PRO_MODEL
+  ) {
+    return provider;
+  }
+  return null;
+}
+
 function isFastPiApiFirstTurn(args: RecordPiApiFirstTurnUsageArgs): boolean {
   if (args.piProvider === "openrouter") {
     return (
@@ -117,9 +169,9 @@ function isFastPiApiFirstTurn(args: RecordPiApiFirstTurnUsageArgs): boolean {
 }
 
 /**
- * Persist API-owned Terra billing usage before any lifecycle commit. The
- * response identity keeps retries and late cancellation observers converged on
- * the same immutable ledger rows. Sandbox provider calls keep their independent
+ * Persist API-owned billing usage before any lifecycle commit. The response
+ * identity keeps retries and late cancellation observers converged on the same
+ * immutable ledger rows. Sandbox provider calls keep their independent
  * MITM-owned delivery identities.
  */
 export async function recordPiApiFirstTurnUsage(
@@ -129,14 +181,15 @@ export async function recordPiApiFirstTurnUsage(
   const hasBillableModelProvider = args.billableFirewalls.some((firewall) => {
     return firewall.startsWith("model-provider:");
   });
-  if (!hasBillableModelProvider || args.modelUsageProvider !== TERRA_MODEL) {
+  const provider = piApiFirstTurnUsageProvider(args.modelUsageProvider);
+  if (!hasBillableModelProvider || provider === null) {
     return;
   }
   const responseSourceId = sourceId(args.turn);
-  const entries = piApiFirstTurnUsageEntries(
-    args.turn,
-    isFastPiApiFirstTurn(args),
-  );
+  const entries =
+    provider === TERRA_MODEL
+      ? terraApiFirstTurnUsageEntries(args.turn, isFastPiApiFirstTurn(args))
+      : deepSeekApiFirstTurnUsageEntries(args.turn);
   const usageRows = entries.map((entry) => {
     return {
       runId: args.runId,
@@ -148,7 +201,7 @@ export async function recordPiApiFirstTurnUsage(
       orgId: args.orgId,
       userId: args.userId,
       kind: "model",
-      provider: TERRA_MODEL,
+      provider,
       category: entry.category,
       quantity: entry.quantity,
     } as const;

--- a/turbo/apps/api/src/test-fixtures/chat-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-events.ts
@@ -3120,6 +3120,7 @@ export async function insertPiApiFirstTurnUsageEventsFixture(args: {
   readonly runId: string;
   readonly orgId: string;
   readonly userId: string;
+  readonly provider: string;
   readonly events: readonly {
     readonly idempotencyKey: string;
     readonly category: string;
@@ -3136,7 +3137,7 @@ export async function insertPiApiFirstTurnUsageEventsFixture(args: {
           orgId: args.orgId,
           userId: args.userId,
           kind: "model",
-          provider: "gpt-5.6-terra",
+          provider: args.provider,
           category: event.category,
           quantity: event.quantity,
         };


### PR DESCRIPTION
## Summary

- admit only the exact Built-in DeepSeek Flash and Pro logical providers to the API-owned Pi first-turn usage recorder when their model firewall is billable
- persist DeepSeek usage under its exact logical provider with base input, output, cache-read, and cache-creation token categories while leaving Terra fast and long-context accounting unchanged
- cover retries, deterministic ID collisions, cancellation, native and fallback credentials, and independent settlement of API-first and later Sandbox/MITM usage

## Ownership and non-goals

- the API continues to own only the API-first response; Sandbox/MITM continues to own later provider responses under its separate identity namespace
- no routing, provider selection, pricing, tiers, allowances, entitlements, schemas, migrations, historical backfill, release, or production-verification behavior changes

## Verification

- targeted `chat-events.bdd.test.ts` Pi API-first cases: 18 passed, 215 skipped
- `pnpm -F api run check-types`
- `pnpm -F api run lint`
- `pnpm exec knip --workspace api --no-progress`
- Prettier check for the three changed files
- `git diff --check origin/main...HEAD`

Closes #32293
