### PR TITLE
refactor(api): rename residual observability values

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2086,7 +2086,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         span_kind: "top_level",
       }),
     );
-    expect(observedActionTypes).not.toContain("api_dispatch_check_vm0_credits");
+    expect(observedActionTypes).not.toContain(
+      "api_dispatch_check_built_in_credits",
+    );
     expect(observedActionTypes).not.toContain("api_dispatch_notify_runner_job");
 
     for (const actionType of API_DISPATCH_ATOMIC_PERSISTENCE_ACTION_TYPES) {
@@ -8430,7 +8432,7 @@ describe("RUN-02: model provider selection and built-in admission", () => {
     );
     expectApiDispatchSpanKind(
       timingEvents,
-      ["api_dispatch_check_vm0_credits"],
+      ["api_dispatch_check_built_in_credits"],
       "nested",
     );
     expectApiDispatchSpanKind(

--- a/turbo/apps/api/src/signals/routes/billing-checkout.ts
+++ b/turbo/apps/api/src/signals/routes/billing-checkout.ts
@@ -107,7 +107,7 @@ const adminRequired = Object.freeze({
 const SIGNUP_ATTRIBUTION_KEY = "signup_attribution";
 const USAGE_PACK_PLAN_ENDING_MESSAGE =
   "Your Plan is scheduled to end before this usage pack change can take effect. Restore your Plan first, then try again.";
-const log = logger("api:zero:billing-checkout");
+const log = logger("api:billing-checkout");
 
 type UsagePackSubscriptionChangePreviewResult = Awaited<
   ReturnType<typeof previewUsagePackSubscriptionChange>

--- a/turbo/apps/api/src/signals/routes/integrations-phone-download-file.ts
+++ b/turbo/apps/api/src/signals/routes/integrations-phone-download-file.ts
@@ -14,7 +14,7 @@ import { agentPhoneFilenameFromMediaUrl } from "../services/agentphone.service";
 import type { RouteEntry } from "../route-entry";
 import { tapError } from "../utils";
 
-const log = logger("api:zero:integrations:phone:download-file");
+const log = logger("api:integrations:phone:download-file");
 const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
 
 function jsonResponse(status: number, message: string, code: string): Response {

--- a/turbo/apps/api/src/signals/routes/org-invite.ts
+++ b/turbo/apps/api/src/signals/routes/org-invite.ts
@@ -38,7 +38,7 @@ import {
 import type { RouteEntry } from "../route-entry";
 import { withBillingClerkRateLimit } from "./billing-clerk-rate-limit";
 
-const log = logger("api:zero:org-invite");
+const log = logger("api:org-invite");
 
 const adminRequired = Object.freeze({
   status: 403 as const,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -5800,7 +5800,7 @@ async function checkFinalRunAdmission(
 ): Promise<CreateRunErrorResult | null> {
   if (args.enforceBuiltInCredits) {
     return await args.timing.measure(
-      "api_dispatch_check_vm0_credits",
+      "api_dispatch_check_built_in_credits",
       "nested",
       async () => {
         const availability = await resolveOrgCreditAvailability({

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -211,7 +211,7 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_resolve_agent_execution_lookup_agent"
   | "api_dispatch_resolve_agent_execution_lookup_session_snapshot"
   | "api_dispatch_resolve_agent_execution_resolve_session_history"
-  | "api_dispatch_check_vm0_credits"
+  | "api_dispatch_check_built_in_credits"
   | "api_dispatch_insert_run_with_concurrency"
   | "api_dispatch_build_runner_job_payload"
   | "api_dispatch_prepare_pi_launch_resources"

--- a/turbo/apps/api/src/signals/services/chat-first-assistant-event-metric.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-first-assistant-event-metric.service.ts
@@ -11,7 +11,7 @@ import { now } from "../../lib/time";
 import { tapError } from "../utils";
 import { writeRunMetadata } from "./agent-run-metadata-write.service";
 
-const L = logger("api:zero:chat-first-assistant-message-metric");
+const L = logger("api:chat-first-assistant-message-metric");
 
 export function recordFirstAssistantEventEligibility(args: {
   readonly runId: string;

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -50,7 +50,7 @@ import {
   canonicalChatEventUserMessage,
 } from "./canonical-chat-event-read.service";
 
-const log = logger("api:zero:chat-title");
+const log = logger("api:chat-title");
 const TITLE_CONTEXT_CHAR_CAP = 150;
 const TITLE_PRIOR_MESSAGE_CAP = 10;
 const FOLLOWUP_CONTEXT_CHAR_CAP = 700;

--- a/turbo/apps/api/src/signals/services/codex-auth-json-paste-handler.ts
+++ b/turbo/apps/api/src/signals/services/codex-auth-json-paste-handler.ts
@@ -154,8 +154,8 @@ export async function handleCodexAuthJsonPaste(
 ) {
   const log = logger(
     args.scope === "personal"
-      ? "api:zero-me-model-providers"
-      : "api:zero-model-providers",
+      ? "api:personal-model-providers"
+      : "api:org-model-providers",
   );
   const logContext =
     args.scope === "personal"


### PR DESCRIPTION
## Summary

Renames exactly eight externally emitted observability values to retire residual internal product vocabulary without changing the observed behavior.

Closes #32242. Part of #32157. This follows the atomic-cutover precedent established by #31842 / #31846.

## What changed

- Renamed the built-in-credit dispatch operation consistently in its typed action union, emitter, positive span assertion, and path-specific non-emission assertion.
- Renamed seven API logger contexts. Their scope selection, logging levels, messages, structured fields, and error behavior are unchanged.
- Preserved dispatch span ownership, nesting, timing boundaries, and `span_kind` values byte-for-byte apart from the mapped literal.

## Query migration mapping

| Old emitted value | New emitted value |
|---|---|
| `api_dispatch_check_vm0_credits` | `api_dispatch_check_built_in_credits` |
| `api:zero-me-model-providers` | `api:personal-model-providers` |
| `api:zero-model-providers` | `api:org-model-providers` |
| `api:zero:billing-checkout` | `api:billing-checkout` |
| `api:zero:integrations:phone:download-file` | `api:integrations:phone:download-file` |
| `api:zero:org-invite` | `api:org-invite` |
| `api:zero:chat-first-assistant-message-metric` | `api:chat-first-assistant-message-metric` |
| `api:zero:chat-title` | `api:chat-title` |

## Operational disposition

The pre-dispatch check recorded on #32242 covered the 72-hour window `2026-09-04T09:30:33Z`–`2026-09-07T09:30:33Z`:

- `api_dispatch_check_vm0_credits` emitted 2,014 production events in `vm0-sandbox-op-log-prod`; `api_dispatch_check_built_in_credits` emitted zero.
- All seven old logger contexts and all seven replacement logger contexts emitted zero in `vm0-web-logs-prod`.
- Both datasets retain three days, so retained historical events keep their old values and the mixed-data window is bounded to 72 hours.
- Repository and GitHub organization code searches found no external code consumer of an old value.
- The available Axiom provider token can query datasets but returns provider-level 403 responses for saved monitors, dashboards, starred queries, and views even though Okou connector policy permits those reads. This residual visibility limit is accepted under #31842.

No external Axiom object was modified blindly. There is no dual emission or compatibility path. If an unenumerable saved consumer goes quiet after deployment, the table above is the query migration reference.

## Live caller and overlap audit

- Branched from current `origin/main` at `37ecac453955cf28e6c0e17c7124ae59d265b361` after refreshing the issue's earlier `7949605c72b83863469b7ce8081caf650b15c686` snapshot.
- Re-resolved the complete producer, typed action, test assertion, logger module, exported symbol, and caller inventory before editing.
- Checked all 36 open PRs. #32304 overlaps `agent-run-create.service.ts`, #32305 overlaps `run-lifecycle.bdd.test.ts`, and #32292 overlaps both, but each current patch touches unrelated lines. The two open PRs with more than 100 changed files were fully paginated and have no overlap.

## Verification

- Focused Prettier write/check on all nine changed files: passed.
- `pnpm -F api lint`: passed.
- `pnpm -F api check-types`: passed all API TypeScript programs.
- `TZ=UTC pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=1 -t 'emits api dispatch timing for exact-empty direct dispatch runs|claims built-in model runs with billable model firewall and usage provider'`: 2 passed, 202 skipped.
- Mechanical substitution proof: formatting `origin/main` after only the eight mappings reproduces every changed file exactly.
- All eight old values have zero matches in tracked current source. The new dispatch value appears exactly at the union, emitter, positive assertion, and non-emission assertion; each replacement logger context appears exactly once at its intended emitter.
- `git diff --check`: passed.

No full local Vitest suite or local development server was run.

## Boundaries honored

- No Axiom dataset, `op_type` field, dimension, `vm0.db.*` attribute, service name, or other deployed identity changed.
- No admission, credit resolution, model-provider, auth-json parsing, persistence, logging severity, or error behavior changed.
- No classifier, manifest, baseline, compatibility branch, dual emit, residual-name scanner, or old-name absence test was added.
- No production release, deployment, API promotion, external Axiom mutation, or post-deploy verification is part of this PR.
