### PR TITLE
fix(pi): recover api first-turn deadlines in sandbox

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -10172,6 +10172,8 @@ describe("CHAT-02: model-first provider policies", () => {
     );
     expect(beforeSandbox).toStrictEqual([]);
     await flushWaitUntilForTest();
+    // Pending late-attempt usage is intentionally absent from public usage
+    // summaries, so inspect this run's uniquely owned ledger rows directly.
     await expect(readRunUsageEventsFixture(run.runId)).resolves.toMatchObject([
       { category: "tokens.input", quantity: 5, status: "pending" },
       { category: "tokens.output", quantity: 3, status: "pending" },
@@ -10325,6 +10327,8 @@ describe("CHAT-02: model-first provider policies", () => {
       usagePricingResolution,
     });
     await providerEntered.promise;
+    // No public API can deterministically hold this lifecycle transaction
+    // across the coordination cap; this run-owned fixture isolates that race.
     const lifecycleLock = await holdPiApiFirstTurnLifecycleLockFixture({
       runId: run.runId,
       signal: context.signal,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -255,6 +255,8 @@ const runStateStore = createStore();
 const STAFF_ORG_ID = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
 const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "okou web upload-file -f <path>";
 const RUN_TIME_BUDGET_STEER_AT_MS = 115 * 60 * 1000;
+const API_FIRST_TURN_OWNERSHIP_BUDGET_MS = 45_000;
+const API_FIRST_TURN_COORDINATION_BUDGET_MS = 55_000;
 const PI_API_FIRST_TURN_USAGE_NAMESPACE =
   "26e1c547-485d-4438-bf6d-4b77959da0cb";
 const STANDARD_TERRA_API_KEY_BDD_ROUTES = [
@@ -5778,6 +5780,104 @@ function mockPiResourceArchiveDownloads(unavailable = false): void {
   );
 }
 
+function warningCallsForRun(runId: string): readonly unknown[] {
+  return context.mocks.axiomLogging.warn.mock.calls.filter((call) => {
+    return (
+      call[0] !== "Run summary generation returned null (API key missing?)" &&
+      JSON.stringify(call).includes(runId)
+    );
+  });
+}
+
+async function completeSandboxFirstPiRun(args: {
+  readonly actor: ApiTestUser;
+  readonly answer: string;
+  readonly checkpointObjects: Map<string, Buffer>;
+  readonly claim: Awaited<ReturnType<typeof claimChatRun>>;
+  readonly prompt: string;
+  readonly run: { readonly runId: string; readonly threadId: string };
+  readonly usagePricingResolution: UsagePricingFixture["resolution"];
+}): Promise<void> {
+  const sessionKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${args.run.runId}/session.jsonl`;
+  const h0 = args.checkpointObjects.get(sessionKey);
+  if (!h0) {
+    throw new Error("Expected authoritative sandbox-first H0");
+  }
+  const session = MemoryPiSession.fromJsonl(h0.toString("utf8"));
+  session.appendMessage({
+    role: "user",
+    content: args.prompt,
+    timestamp: 1,
+  });
+  session.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text: args.answer }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "gpt-5.6-terra",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 2,
+  });
+  const h2 = session.toJsonl();
+  const h2Hash = createHash("sha256").update(h2).digest("hex");
+  await webhooks.requestAgentCheckpointPrepareHistory(
+    {
+      runId: args.run.runId,
+      hash: h2Hash,
+      rawSize: Buffer.byteLength(h2),
+      encodedSize: Buffer.byteLength(h2),
+      encoding: "identity",
+    },
+    args.claim.sandboxHeaders,
+    [200],
+  );
+  args.checkpointObjects.set(
+    `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${h2Hash}.blob`,
+    Buffer.from(h2, "utf8"),
+  );
+  await webhooks.requestAgentEvents(
+    {
+      runId: args.run.runId,
+      events: [
+        {
+          type: "assistant",
+          sequenceNumber: 1,
+          message: { content: [{ type: "text", text: args.answer }] },
+        },
+        { type: "result", sequenceNumber: 2, result: args.answer },
+      ],
+    },
+    args.claim.sandboxHeaders,
+    [200],
+  );
+  await webhooks.requestAgentComplete(
+    {
+      runId: args.run.runId,
+      exitCode: 0,
+      lastEventSequence: 2,
+      checkpoint: {
+        cliAgentType: "pi",
+        cliAgentSessionId: args.run.threadId,
+        cliAgentSessionHistoryHash: h2Hash,
+      },
+    },
+    args.claim.sandboxHeaders,
+    [200],
+    undefined,
+    args.usagePricingResolution,
+  );
+  await waitForRunStatus(args.actor, args.run.runId, "completed", 5000);
+  await flushWaitUntilForTest();
+}
+
 async function queueCapabilityProvenPiRun(args: {
   readonly actor: ApiTestUser;
   readonly agentId: string;
@@ -9888,6 +9988,460 @@ describe("CHAT-02: model-first provider policies", () => {
       expect(visibleOutput).toContain(visible);
     }
     await expectNoPrivatePublicOutput();
+  }, 90_000);
+
+  it("transfers authoritative H0 when API ownership expires before provider transport", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const resourceEntered = createDeferredPromise<void>(context.signal);
+    const releaseResource = createDeferredPromise<void>(context.signal);
+    server.use(
+      http.get(PI_RESOURCE_ARCHIVE_DOWNLOAD_URL, async ({ request }) => {
+        if (!resourceEntered.settled()) {
+          resourceEntered.resolve(undefined);
+        }
+        await releaseResource.promise;
+        const objectKey = new URL(request.url).searchParams.get("object");
+        if (!objectKey) {
+          throw new Error("Expected Pi resource archive object identity");
+        }
+        return new HttpResponse(piS3Object(objectKey), {
+          headers: { "content-type": "application/gzip" },
+        });
+      }),
+    );
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", () => {
+        modelCalls += 1;
+        return nativeCodexSseResponse(
+          piResponsesTextSse("must not become H1", modelCalls),
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const prompt = "replay the original pre-provider prompt in Sandbox";
+    const { anchor, anchorClaim, run, usagePricingResolution } =
+      await queueCapabilityProvenPiRun({
+        actor,
+        agentId,
+        runnerGroup,
+        prompt,
+      });
+    const apiStartedAt = now();
+    mockNow(apiStartedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+      usagePricingResolution,
+    });
+    await resourceEntered.promise;
+    const claimed = await claimChatRun(runnerGroup, run.runId);
+    const activeInputEventId = randomUUID();
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: run.threadId,
+        prompt: "deliver this input once after deadline transfer",
+        clientEventId: activeInputEventId,
+      },
+      [201],
+    );
+    const reserved = await api.reserveRunnerActiveInputs(
+      claimed.claim.sandboxToken,
+      run.runId,
+    );
+    if (reserved.outcome !== "reserved") {
+      throw new Error("Expected deadline-bound active input to be reserved");
+    }
+
+    mockNow(apiStartedAt + API_FIRST_TURN_OWNERSHIP_BUDGET_MS);
+    releaseResource.resolve(undefined);
+    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.get(manifestKey);
+      })
+      .toBeInstanceOf(Buffer);
+
+    expect(modelCalls).toBe(0);
+    const manifest = piApiFirstTurnManifestSchema.parse(
+      JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
+    );
+    expect(manifest).toMatchObject({
+      schemaVersion: 3,
+      outcome: "ownership-transfer",
+      mode: "sandbox-first",
+      baseSession: { sessionId: run.threadId, sha256: null },
+      sandboxEventSequenceStart: 1,
+    });
+    const h0 = checkpointObjects.get(
+      `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`,
+    );
+    if (!h0) {
+      throw new Error("Expected pre-provider deadline H0");
+    }
+    expect(
+      MemoryPiSession.fromJsonl(h0.toString("utf8")).buildSessionContext()
+        .messages,
+    ).toHaveLength(0);
+    expect(claimed.claim.prompt).toBe(prompt);
+    expect(claimed.claim.piLaunchConfig?.apiFirstTurn.deadlineAt).toBe(
+      apiStartedAt + API_FIRST_TURN_COORDINATION_BUDGET_MS,
+    );
+    await expect(
+      api.reserveRunnerActiveInputs(claimed.claim.sandboxToken, run.runId),
+    ).resolves.toStrictEqual(reserved);
+    await expect(
+      api.recordRunnerActiveInputDelivery(
+        claimed.claim.sandboxToken,
+        run.runId,
+        reserved.deliveryId,
+      ),
+    ).resolves.toStrictEqual({ outcome: "delivered" });
+    const activeInputEvents = await chat.listThreadEvents(actor, run.threadId);
+    expect(
+      activeInputEvents.events.filter((event) => {
+        return event.revokesEventId === activeInputEventId;
+      }),
+    ).toHaveLength(1);
+    expect(warningCallsForRun(run.runId)).toStrictEqual([]);
+    await cancelChatRun(actor, run.runId, claimed.sandboxHeaders);
+  }, 90_000);
+
+  it("discards a late API success and completes once from sandbox-first H0", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    const lateApiAnswer = "late API answer must remain usage-only";
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", async () => {
+        modelCalls += 1;
+        providerEntered.resolve(undefined);
+        await releaseProvider.promise;
+        return nativeCodexSseResponse(
+          piResponsesTextSse(lateApiAnswer, modelCalls),
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const prompt = "complete the timed-out prompt once in Sandbox";
+    const { anchor, anchorClaim, run, usagePricingResolution } =
+      await queueCapabilityProvenPiRun({
+        actor,
+        agentId,
+        runnerGroup,
+        prompt,
+      });
+    const apiStartedAt = now();
+    mockNow(apiStartedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+      usagePricingResolution,
+    });
+    await providerEntered.promise;
+
+    mockNow(apiStartedAt + API_FIRST_TURN_OWNERSHIP_BUDGET_MS - 2000);
+    releaseProvider.resolve(undefined);
+    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.get(manifestKey);
+      })
+      .toBeInstanceOf(Buffer);
+
+    expect(modelCalls).toBe(1);
+    const manifest = piApiFirstTurnManifestSchema.parse(
+      JSON.parse(checkpointObjects.get(manifestKey)?.toString("utf8") ?? "{}"),
+    );
+    expect(manifest).toMatchObject({
+      schemaVersion: 3,
+      outcome: "ownership-transfer",
+      mode: "sandbox-first",
+      baseSession: { sessionId: run.threadId, sha256: null },
+      sandboxEventSequenceStart: 1,
+    });
+    const beforeSandbox = eventBackedContents(
+      (await chat.listThreadEvents(actor, run.threadId)).events,
+      run.runId,
+    );
+    expect(beforeSandbox).toStrictEqual([]);
+    await flushWaitUntilForTest();
+    await expect(readRunUsageEventsFixture(run.runId)).resolves.toMatchObject([
+      { category: "tokens.input", quantity: 5, status: "pending" },
+      { category: "tokens.output", quantity: 3, status: "pending" },
+    ]);
+
+    const claimed = await claimChatRun(runnerGroup, run.runId);
+    expect(claimed.claim.prompt).toBe(prompt);
+    const sandboxAnswer = "Sandbox owns the only visible answer";
+    await completeSandboxFirstPiRun({
+      actor,
+      answer: sandboxAnswer,
+      checkpointObjects,
+      claim: claimed,
+      prompt,
+      run,
+      usagePricingResolution,
+    });
+    await expectTerraApiFollowUpUsage(run.runId);
+
+    const completedEvents = (await chat.listThreadEvents(actor, run.threadId))
+      .events;
+    expect(
+      eventBackedContents(completedEvents, run.runId).filter((message) => {
+        return message.content === sandboxAnswer;
+      }),
+    ).toHaveLength(1);
+    expect(JSON.stringify(completedEvents)).not.toContain(lateApiAnswer);
+    expect(
+      completedEvents.filter((event) => {
+        return (
+          event.runId === run.runId &&
+          isChatRunTerminalEventType(event.eventType)
+        );
+      }),
+    ).toMatchObject([{ eventType: "run.completed" }]);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "completed",
+    });
+    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+      "Pi API first-turn outcome",
+      expect.objectContaining({
+        runId: run.runId,
+        outcome: "discarded_late_provider_result",
+        reason: "api_attempt_timed_out",
+      }),
+    );
+    expect(context.mocks.axiomLogging.debug).toHaveBeenCalledWith(
+      "Pi API first-turn outcome",
+      expect.objectContaining({
+        runId: run.runId,
+        handoffOwner: "sandbox",
+        outcome: "sandbox_retry_started",
+      }),
+    );
+    expect(warningCallsForRun(run.runId)).toStrictEqual([]);
+  }, 90_000);
+
+  it("lets canonical cancellation win the deadline ownership boundary", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", async () => {
+        modelCalls += 1;
+        providerEntered.resolve(undefined);
+        await releaseProvider.promise;
+        return nativeCodexSseResponse(
+          piResponsesTextSse("cancelled late API result", modelCalls),
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const { anchor, anchorClaim, run, usagePricingResolution } =
+      await queueCapabilityProvenPiRun({
+        actor,
+        agentId,
+        runnerGroup,
+        prompt: "cancel at the timeout transfer boundary",
+      });
+    const apiStartedAt = now();
+    mockNow(apiStartedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+      usagePricingResolution,
+    });
+    await providerEntered.promise;
+
+    mockNow(apiStartedAt + API_FIRST_TURN_OWNERSHIP_BUDGET_MS - 2000);
+    await cancelBeforeLatePiResult(
+      actor,
+      run.runId,
+      () => {
+        releaseProvider.resolve(undefined);
+      },
+      usagePricingResolution,
+    );
+    await flushWaitUntilForTest();
+
+    expect(modelCalls).toBe(1);
+    await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+      status: "cancelled",
+    });
+    expectNoPiApiFirstTurnArtifacts(run.runId, checkpointObjects);
+    expect(
+      eventBackedContents(
+        (await chat.listThreadEvents(actor, run.threadId)).events,
+        run.runId,
+      ),
+    ).toStrictEqual([]);
+    await expectTerraApiFollowUpUsage(run.runId);
+    await api.requestClaimRunnerJob(true, run.runId, [404], {
+      capabilities: { piModelConfigGenerations: [1, 2, 3] },
+    });
+    expect(warningCallsForRun(run.runId)).toStrictEqual([]);
+  }, 90_000);
+
+  it("fails once when deadline handoff cannot settle by the coordination cap", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", async () => {
+        modelCalls += 1;
+        providerEntered.resolve(undefined);
+        await releaseProvider.promise;
+        return nativeCodexSseResponse(
+          piResponsesTextSse("late result before handoff expiry", modelCalls),
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const { anchor, anchorClaim, run, usagePricingResolution } =
+      await queueCapabilityProvenPiRun({
+        actor,
+        agentId,
+        runnerGroup,
+        prompt: "expire the bounded handoff publication",
+      });
+    const apiStartedAt = now();
+    mockNow(apiStartedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+      usagePricingResolution,
+    });
+    await providerEntered.promise;
+    const lifecycleLock = await holdPiApiFirstTurnLifecycleLockFixture({
+      runId: run.runId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      lifecycleLock.release();
+      await lifecycleLock.done;
+    });
+
+    mockNow(apiStartedAt + API_FIRST_TURN_OWNERSHIP_BUDGET_MS - 2000);
+    releaseProvider.resolve(undefined);
+    await expect.poll(lifecycleLock.waiterCount).toBe(1);
+    mockNow(apiStartedAt + API_FIRST_TURN_COORDINATION_BUDGET_MS);
+    lifecycleLock.release();
+    await lifecycleLock.done;
+    await waitForRunStatus(actor, run.runId, "failed", 5000);
+    await flushWaitUntilForTest();
+
+    expect(modelCalls).toBe(1);
+    expectNoPiApiFirstTurnArtifacts(run.runId, checkpointObjects);
+    await expectTerraApiFollowUpUsage(run.runId);
+    expect(warningCallsForRun(run.runId)).toHaveLength(1);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "Pi API first-turn outcome",
+      expect.objectContaining({
+        runId: run.runId,
+        outcome: "terminal_failure",
+        recoveryReason: "api_attempt_timed_out",
+      }),
+    );
+    const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+    expect(
+      events.filter((event) => {
+        return (
+          event.runId === run.runId &&
+          isChatRunTerminalEventType(event.eventType)
+        );
+      }),
+    ).toMatchObject([{ eventType: "run.failed" }]);
+  }, 90_000);
+
+  it("emits one canonical warning when the sandbox retry fails", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    mockPiResourceArchiveDownloads();
+    const providerEntered = createDeferredPromise<void>(context.signal);
+    const releaseProvider = createDeferredPromise<void>(context.signal);
+    let modelCalls = 0;
+    server.use(
+      http.post("https://api.openai.com/v1/responses", async () => {
+        modelCalls += 1;
+        providerEntered.resolve(undefined);
+        await releaseProvider.promise;
+        return nativeCodexSseResponse(
+          piResponsesTextSse("discarded before Sandbox failure", modelCalls),
+        );
+      }),
+    );
+    const checkpointObjects = mockPiCheckpointObjectStore();
+    const { anchor, anchorClaim, run, usagePricingResolution } =
+      await queueCapabilityProvenPiRun({
+        actor,
+        agentId,
+        runnerGroup,
+        prompt: "let the single Sandbox recovery fail",
+      });
+    const apiStartedAt = now();
+    mockNow(apiStartedAt);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+      usagePricingResolution,
+    });
+    await providerEntered.promise;
+    mockNow(apiStartedAt + API_FIRST_TURN_OWNERSHIP_BUDGET_MS - 2000);
+    releaseProvider.resolve(undefined);
+    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+    await expect
+      .poll(() => {
+        return checkpointObjects.get(manifestKey);
+      })
+      .toBeInstanceOf(Buffer);
+    const claimed = await claimChatRun(runnerGroup, run.runId);
+
+    await webhooks.requestAgentComplete(
+      {
+        runId: run.runId,
+        exitCode: 1,
+        error: "Sandbox retry failed",
+      },
+      claimed.sandboxHeaders,
+      [200],
+      undefined,
+      usagePricingResolution,
+    );
+    await waitForRunStatus(actor, run.runId, "failed", 5000);
+    await flushWaitUntilForTest();
+
+    expect(modelCalls).toBe(1);
+    await expectTerraApiFollowUpUsage(run.runId);
+    expect(warningCallsForRun(run.runId)).toHaveLength(1);
+    expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+      "Run failed",
+      expect.objectContaining({
+        runId: run.runId,
+        error: "Sandbox retry failed",
+      }),
+    );
+    const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+    expect(
+      events.filter((event) => {
+        return (
+          event.runId === run.runId &&
+          isChatRunTerminalEventType(event.eventType)
+        );
+      }),
+    ).toMatchObject([{ eventType: "run.failed" }]);
   }, 90_000);
 
   it("transfers pre-provider active input through one stable sandbox-first delivery", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-activation.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-activation.service.ts
@@ -18,13 +18,15 @@ const startPiApiFirstTurn$ = command(function startPiApiFirstTurn(
   { set },
   activation: NonNullable<PendingRunActivation["piApiFirstTurn"]>,
 ): void {
-  const deadlineAt =
+  const coordinationDeadlineAt =
     activation.executionContext.piLaunchConfig.apiFirstTurn.deadlineAt;
+  // waitUntil owns only the bounded API-to-Sandbox coordination window.
+  // A successful Sandbox transfer continues under the runner lifecycle.
   waitUntil(
     set(
       dispatchConfiguredPiApiFirstTurn$,
       activation,
-      AbortSignal.timeout(Math.max(1, deadlineAt - now())),
+      AbortSignal.timeout(Math.max(1, coordinationDeadlineAt - now())),
     ),
   );
 });

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -260,7 +260,7 @@ import {
 } from "./pi-resource-snapshot.service";
 import { readMemorySummaryProjection } from "./memory-summary-projection.service";
 import {
-  PI_API_FIRST_TURN_TIMEOUT_MS,
+  PI_API_FIRST_TURN_COORDINATION_TIMEOUT_MS,
   PI_API_FIRST_TURN_URL_TTL_SECONDS,
   piApiFirstTurnObjectKey,
   requirePiApiFirstTurnExecutionContext,
@@ -7349,7 +7349,8 @@ function preparePiLaunchResources(
               ),
               manifestUrl,
               sessionUrl,
-              deadlineAt: args.apiStartTime + PI_API_FIRST_TURN_TIMEOUT_MS,
+              deadlineAt:
+                args.apiStartTime + PI_API_FIRST_TURN_COORDINATION_TIMEOUT_MS,
               baseSession: piBaseSession(resumeSession, sessionId),
               sandboxEventSequenceStart: 1,
             },

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -72,6 +72,7 @@ interface CompleteAgentRunInput {
   readonly body: WebhookCompleteBody;
   readonly allowCheckpointlessSuccess?: boolean;
   readonly executionOwner?: "api-first";
+  readonly suppressFailureLog?: boolean;
 }
 
 export interface TerminalSideEffectsInput {
@@ -173,13 +174,13 @@ const L = logger("webhook:complete");
 function logStandardTerraApiKeyPiSandboxOutcome(
   input: CompleteAgentRunInput,
   commit: CompletionCommit,
-): void {
+): boolean {
   if (
     input.executionOwner === "api-first" ||
     commit.run.launchSnapshot?.framework !== "pi" ||
     !isStandardTerraApiKeyPiProviderType(commit.run.modelProvider)
   ) {
-    return;
+    return false;
   }
   const details = {
     runId: input.body.runId,
@@ -199,9 +200,10 @@ function logStandardTerraApiKeyPiSandboxOutcome(
   } as const;
   if (commit.responseStatus === "completed") {
     L.debug("Pi API first-turn outcome", details);
-    return;
+    return false;
   }
   L.warn("Pi API first-turn outcome", details);
+  return true;
 }
 
 function shouldSuppressKnownFailureLog(
@@ -236,6 +238,36 @@ function shouldSuppressKnownFailureLog(
     case "unsupported_model": {
       return false;
     }
+  }
+}
+
+function logAgentRunCompletionOutcome(
+  input: CompleteAgentRunInput,
+  commit: CompletionCommit,
+): void {
+  const loggedPiSandboxFailure = logStandardTerraApiKeyPiSandboxOutcome(
+    input,
+    commit,
+  );
+  if (commit.responseStatus === "completed") {
+    L.debug("Run completed successfully", { runId: input.body.runId });
+    return;
+  }
+  if (loggedPiSandboxFailure) {
+    return;
+  }
+  if (commit.transitionFailureKind === "missing-checkpoint") {
+    L.warn("Run failed because checkpoint was not found", {
+      runId: input.body.runId,
+      error: commit.transitionError,
+    });
+    return;
+  }
+  if (
+    !input.suppressFailureLog &&
+    !shouldSuppressFailureLog(commit.run, commit.transitionFailureReason)
+  ) {
+    logRunFailure(input, commit);
   }
 }
 
@@ -998,19 +1030,7 @@ export const completeAgentRun$ = command(
             : {}),
         },
       });
-      logStandardTerraApiKeyPiSandboxOutcome(input, commit);
-      if (commit.responseStatus === "completed") {
-        L.debug("Run completed successfully", { runId: input.body.runId });
-      } else if (commit.transitionFailureKind === "missing-checkpoint") {
-        L.warn("Run failed because checkpoint was not found", {
-          runId: input.body.runId,
-          error: commit.transitionError,
-        });
-      } else if (
-        !shouldSuppressFailureLog(commit.run, commit.transitionFailureReason)
-      ) {
-        logRunFailure(input, commit);
-      }
+      logAgentRunCompletionOutcome(input, commit);
     } else if (
       commit.run.status === "completed" ||
       commit.run.status === "failed"

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn-config.ts
@@ -29,7 +29,11 @@ export interface PiApiFirstTurnActivation {
   };
 }
 
-export const PI_API_FIRST_TURN_TIMEOUT_MS = 45_000;
+export const PI_API_FIRST_TURN_API_OWNERSHIP_TIMEOUT_MS = 45_000;
+const PI_API_FIRST_TURN_HANDOFF_SETTLEMENT_TIMEOUT_MS = 10_000;
+export const PI_API_FIRST_TURN_COORDINATION_TIMEOUT_MS =
+  PI_API_FIRST_TURN_API_OWNERSHIP_TIMEOUT_MS +
+  PI_API_FIRST_TURN_HANDOFF_SETTLEMENT_TIMEOUT_MS;
 export const PI_API_FIRST_TURN_URL_TTL_SECONDS = 6 * 60 * 60;
 
 export function requirePiApiFirstTurnExecutionContext(
@@ -101,7 +105,9 @@ export function refreshPiApiFirstTurnDeadline<
       ...launchConfig,
       apiFirstTurn: {
         ...slot,
-        deadlineAt: apiStartTime + PI_API_FIRST_TURN_TIMEOUT_MS,
+        // The wire deadline is the absolute API-to-Sandbox coordination cap.
+        // API ownership ends earlier and is derived from apiStartTime.
+        deadlineAt: apiStartTime + PI_API_FIRST_TURN_COORDINATION_TIMEOUT_MS,
       },
     },
   } as T;

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -2145,13 +2145,16 @@ export const runPiApiFirstTurn$ = command(
           }
         : undefined;
     }
-    apiAttemptController.abort(executed.error);
     const activeInputBeforeProvider =
       executed.error instanceof PiApiFirstTurnActiveInputBeforeProviderError;
     let failure = normalizedApiFirstTurnFailure(
       executed.error,
       apiAttemptSignal,
     );
+    // Classify the failure before closing any residual attempt work. Aborting
+    // the private controller first would misclassify every raw API failure as
+    // an ownership deadline and incorrectly replay it in Sandbox.
+    apiAttemptController.abort(executed.error);
     const resourceFallbackReason = activeInputBeforeProvider
       ? null
       : eligibleSandboxFallbackReason(

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -77,6 +77,7 @@ import {
   SESSION_HISTORY_ENCODING_ZSTD,
 } from "./session-history-blobs";
 import {
+  PI_API_FIRST_TURN_API_OWNERSHIP_TIMEOUT_MS,
   piApiFirstTurnObjectKey,
   type PiApiFirstTurnActivation,
 } from "./pi-api-first-turn-config";
@@ -645,6 +646,10 @@ interface PreparedApiFirstTurn {
   readonly turn: PiApiFirstTurnResult;
 }
 
+interface ApiFirstTurnCommitProgress {
+  started: boolean;
+}
+
 type ApiFirstTurnExecutionContext =
   PiApiFirstTurnActivation["executionContext"];
 type ApiFirstTurnLaunchConfig =
@@ -760,7 +765,15 @@ function validateApiFirstTurnLaunch(args: ApiFirstTurnContext): {
   return { executionContext, launchConfig, sessionId };
 }
 
-function validateApiFirstTurnLifecycleCommit(
+function apiFirstTurnApiDeadlineAt(
+  executionContext: ApiFirstTurnExecutionContext,
+): number {
+  return (
+    executionContext.apiStartTime + PI_API_FIRST_TURN_API_OWNERSHIP_TIMEOUT_MS
+  );
+}
+
+function validateApiFirstTurnLifecycle(
   args: ApiFirstTurnContext,
   state: ApiFirstTurnLifecycleState | null,
   expectedIdentity: ApiFirstTurnCommitIdentity,
@@ -785,13 +798,52 @@ function validateApiFirstTurnLifecycleCommit(
       "Pi API first-turn immutable launch identity changed before commit",
     );
   }
-  if (now() + MODEL_COMMIT_BUDGET_MS >= expectedIdentity.deadlineAt) {
+  return state;
+}
+
+function validateApiFirstTurnApiCommit(
+  args: ApiFirstTurnContext,
+  state: ApiFirstTurnLifecycleState | null,
+  expectedIdentity: ApiFirstTurnCommitIdentity,
+  message: string,
+): ApiFirstTurnLifecycleState {
+  const committable = validateApiFirstTurnLifecycle(
+    args,
+    state,
+    expectedIdentity,
+    message,
+  );
+  if (
+    now() + MODEL_COMMIT_BUDGET_MS >=
+    apiFirstTurnApiDeadlineAt(args.activation.executionContext)
+  ) {
     throw piApiFirstTurnError(
       "PI_API_FIRST_TURN_DEADLINE_EXCEEDED",
       "Pi API first turn has no remaining commit budget",
     );
   }
-  return state;
+  return committable;
+}
+
+function validateApiFirstTurnHandoffCommit(
+  args: ApiFirstTurnContext,
+  state: ApiFirstTurnLifecycleState | null,
+  expectedIdentity: ApiFirstTurnCommitIdentity,
+  message: string,
+): ApiFirstTurnLifecycleState {
+  const committable = validateApiFirstTurnLifecycle(
+    args,
+    state,
+    expectedIdentity,
+    message,
+  );
+  if (now() >= expectedIdentity.deadlineAt) {
+    throw piApiFirstTurnError(
+      "PI_API_FIRST_TURN_DEADLINE_EXCEEDED",
+      "Pi API first-turn coordination deadline elapsed during handoff",
+    );
+  }
+  return committable;
 }
 
 const loadApiFirstTurnResource$ = command(
@@ -1125,18 +1177,34 @@ async function observeDiscardedProviderResult(
   operation: Promise<PiApiFirstTurnResult>,
   args: ApiFirstTurnContext,
   ownership: PiApiFirstTurnOwnership,
+  reason: "api_attempt_timed_out" | "aborted_execution",
 ): Promise<void> {
   const late = await settleIncludingAbort(operation);
   if (late.ok) {
-    await recordApiFirstTurnUsage(args, late.value);
-    L.warn("Pi API first-turn outcome", {
+    L.debug("Pi API first-turn outcome", {
       runId: args.activation.runId,
       ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
       outcome: "discarded_late_provider_result",
-      reason: "aborted_execution",
+      reason,
       ownershipStage: ownership.stage,
     });
+    await recordApiFirstTurnUsage(args, late.value);
   }
+}
+
+async function discardCompletedProviderResult(
+  turn: PiApiFirstTurnResult,
+  args: ApiFirstTurnContext,
+  ownership: PiApiFirstTurnOwnership,
+): Promise<void> {
+  L.debug("Pi API first-turn outcome", {
+    runId: args.activation.runId,
+    ...piApiFirstTurnOutcomeTelemetry(args.activation.executionContext),
+    outcome: "discarded_late_provider_result",
+    reason: "api_attempt_timed_out",
+    ownershipStage: ownership.stage,
+  });
+  await recordApiFirstTurnUsage(args, turn);
 }
 
 function validateApiModelTurnOutcome(turn: PiApiFirstTurnResult): void {
@@ -1159,24 +1227,27 @@ function validateApiModelTurnOutcome(turn: PiApiFirstTurnResult): void {
   }
 }
 
+interface ExecuteApiModelTurnArgs {
+  readonly activation: PiApiFirstTurnActivation;
+  readonly context: ApiFirstTurnContext;
+  readonly commitIdentity: ApiFirstTurnCommitIdentity;
+  readonly model: PiAgentModelConfig;
+  readonly resourceSnapshot: PiResourceSnapshot;
+  readonly sessionJsonl: string;
+  readonly sessionId: string;
+  readonly ownership: PiApiFirstTurnOwnership;
+}
+
 async function executeApiModelTurn(
-  args: {
-    readonly activation: PiApiFirstTurnActivation;
-    readonly context: ApiFirstTurnContext;
-    readonly commitIdentity: ApiFirstTurnCommitIdentity;
-    readonly launchConfig: ApiFirstTurnLaunchConfig;
-    readonly model: PiAgentModelConfig;
-    readonly resourceSnapshot: PiResourceSnapshot;
-    readonly sessionJsonl: string;
-    readonly sessionId: string;
-    readonly ownership: PiApiFirstTurnOwnership;
-  },
+  args: ExecuteApiModelTurnArgs,
   signal: AbortSignal,
 ): Promise<{
   readonly startedAt: number;
   readonly turn: PiApiFirstTurnResult;
 }> {
-  const modelDeadline = args.launchConfig.deadlineAt - MODEL_COMMIT_BUDGET_MS;
+  const modelDeadline =
+    apiFirstTurnApiDeadlineAt(args.activation.executionContext) -
+    MODEL_COMMIT_BUDGET_MS;
   if (now() >= modelDeadline) {
     throw piApiFirstTurnError(
       "PI_API_FIRST_TURN_DEADLINE_EXCEEDED",
@@ -1184,10 +1255,10 @@ async function executeApiModelTurn(
     );
   }
   const startedAt = now();
-  const modelSignal = AbortSignal.any([
-    signal,
-    AbortSignal.timeout(Math.max(1, modelDeadline - now())),
-  ]);
+  const modelDeadlineSignal = AbortSignal.timeout(
+    Math.max(1, modelDeadline - now()),
+  );
+  const modelSignal = AbortSignal.any([signal, modelDeadlineSignal]);
   const operation = runPiApiFirstTurn(
     {
       cwd: CANONICAL_WORKING_DIR,
@@ -1208,7 +1279,7 @@ async function executeApiModelTurn(
       providerRequestBoundary: async (markProviderRequestMayHaveStarted) => {
         await withApiFirstTurnLifecycle(args.context, async (tx) => {
           modelSignal.throwIfAborted();
-          const state = validateApiFirstTurnLifecycleCommit(
+          const state = validateApiFirstTurnApiCommit(
             args.context,
             await readApiFirstTurnLifecycleState(tx, args.activation.runId),
             args.commitIdentity,
@@ -1230,7 +1301,14 @@ async function executeApiModelTurn(
   if (!executed.ok) {
     if (modelSignal.aborted) {
       waitUntil(
-        observeDiscardedProviderResult(operation, args.context, args.ownership),
+        observeDiscardedProviderResult(
+          operation,
+          args.context,
+          args.ownership,
+          modelDeadlineSignal.aborted
+            ? "api_attempt_timed_out"
+            : "aborted_execution",
+        ),
       );
     }
     if (
@@ -1268,6 +1346,15 @@ async function executeApiModelTurn(
     );
   }
   const turn = executed.value;
+  if (now() >= modelDeadline) {
+    waitUntil(
+      discardCompletedProviderResult(turn, args.context, args.ownership),
+    );
+    throw piApiFirstTurnError(
+      "PI_API_FIRST_TURN_DEADLINE_EXCEEDED",
+      "Pi API first-turn provider result arrived after its commit deadline",
+    );
+  }
   await recordApiFirstTurnUsage(args.context, turn);
   validateApiModelTurnOutcome(turn);
   return { startedAt, turn };
@@ -1341,7 +1428,10 @@ type PiSandboxFallbackReason =
   | "PI_API_PREHEAT_FAILED"
   | "PI_API_RESOURCE_PREPARATION_FAILED";
 
-type PiSandboxFirstReason = PiSandboxFallbackReason | "active_input";
+type PiSandboxFirstReason =
+  | PiSandboxFallbackReason
+  | "active_input"
+  | "api_attempt_timed_out";
 
 function eligibleSandboxFallbackReason(
   args: {
@@ -1428,28 +1518,9 @@ const publishSandboxFallback$ = command(async function publishSandboxFallback(
     validateApiFirstTurnLaunch(args);
   const commitIdentity = apiFirstTurnCommitIdentity(args);
   signal.throwIfAborted();
-  const loadedSession = await set(
-    loadResumeSessionJsonl$,
-    {
-      db: args.db,
-      resumeSession: executionContext.resumeSession,
-    },
-    signal,
-  );
-  validateResumeSession({
-    loaded: loadedSession,
-    expectedBaseSession: launchConfig.baseSession,
-    sessionId,
-  });
-  const sessionJsonl = materializeApiFirstTurnH0({
-    apiStartTime: executionContext.apiStartTime,
-    loadedSession,
-    sessionId,
-  });
-  const session = validateSandboxFallbackSession(sessionJsonl, sessionId);
   await withApiFirstTurnLifecycle(args, async (tx) => {
     signal.throwIfAborted();
-    const state = validateApiFirstTurnLifecycleCommit(
+    const state = validateApiFirstTurnHandoffCommit(
       args,
       await readApiFirstTurnLifecycleState(tx, args.activation.runId),
       commitIdentity,
@@ -1461,6 +1532,25 @@ const publishSandboxFallback$ = command(async function publishSandboxFallback(
         "Pi active-input sandbox-first transfer lost its durable delivery",
       );
     }
+    const loadedSession = await set(
+      loadResumeSessionJsonl$,
+      {
+        db: args.db,
+        resumeSession: executionContext.resumeSession,
+      },
+      signal,
+    );
+    validateResumeSession({
+      loaded: loadedSession,
+      expectedBaseSession: launchConfig.baseSession,
+      sessionId,
+    });
+    const sessionJsonl = materializeApiFirstTurnH0({
+      apiStartTime: executionContext.apiStartTime,
+      loadedSession,
+      sessionId,
+    });
+    const session = validateSandboxFallbackSession(sessionJsonl, sessionId);
     const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
     const sessionKey = piApiFirstTurnObjectKey(
       args.activation.runId,
@@ -1494,6 +1584,12 @@ const publishSandboxFallback$ = command(async function publishSandboxFallback(
         "Pi sandbox fallback H0 failed read-after-write validation",
       );
     }
+    validateApiFirstTurnHandoffCommit(
+      args,
+      state,
+      commitIdentity,
+      "Pi sandbox-first transfer lost commit eligibility before publication",
+    );
     const manifest = ownershipTransferManifest({
       mode: "sandbox-first",
       baseSession: launchConfig.baseSession,
@@ -1555,7 +1651,6 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
       activation: args.activation,
       context: args,
       commitIdentity,
-      launchConfig,
       model,
       resourceSnapshot,
       sessionJsonl,
@@ -1672,16 +1767,20 @@ const commitApiFirstTurn$ = command(async function commitApiFirstTurn(
   { get, set },
   args: ApiFirstTurnContext,
   prepared: PreparedApiFirstTurn,
+  commitProgress: ApiFirstTurnCommitProgress,
   signal: AbortSignal,
 ): Promise<CompleteSideEffectsInput | undefined> {
   return await withApiFirstTurnLifecycle(args, async (tx) => {
     signal.throwIfAborted();
-    const state = validateApiFirstTurnLifecycleCommit(
+    const state = validateApiFirstTurnApiCommit(
       args,
       await readApiFirstTurnLifecycleState(tx, args.activation.runId),
       prepared.commitIdentity,
       "Pi API first turn lost commit eligibility after the provider request",
     );
+    // Once any H1 commit side effect can begin, a later timeout must fail
+    // terminally instead of replaying H0 over potentially published state.
+    commitProgress.started = true;
     const hasActiveInput = state.activeDeliveryId !== null;
     const transferMode: PiApiFirstTurnOwnershipTransferMode | null = prepared
       .turn.handoffRequired
@@ -1781,11 +1880,12 @@ const executeApiFirstTurn$ = command(async function executeApiFirstTurn(
   { set },
   args: ApiFirstTurnContext,
   ownership: PiApiFirstTurnOwnership,
+  commitProgress: ApiFirstTurnCommitProgress,
   signal: AbortSignal,
 ): Promise<CompleteSideEffectsInput | undefined> {
   const prepared = await set(prepareApiFirstTurn$, args, ownership, signal);
   const committed = await settle(
-    set(commitApiFirstTurn$, args, prepared, signal),
+    set(commitApiFirstTurn$, args, prepared, commitProgress, signal),
     signal,
   );
   if (!committed.ok) {
@@ -1842,16 +1942,30 @@ function normalizedSandboxFallbackFailure(
 
 async function settleApiFirstTurnExecution<T>(
   execution: Promise<T>,
-  signal: AbortSignal,
+  executionSignal: AbortSignal,
+  coordinationSignal: AbortSignal,
 ) {
   const executed = await settleIncludingAbort(execution);
-  if (executed.ok || !signal.aborted) {
+  if (executed.ok || !executionSignal.aborted) {
     return executed;
   }
   return {
     ok: false as const,
-    error: signal.reason ?? executed.error,
+    error:
+      executionSignal.reason ?? coordinationSignal.reason ?? executed.error,
   };
+}
+
+function piApiFirstTurnHandoffSignal(
+  activation: PiApiFirstTurnActivation,
+  coordinationSignal: AbortSignal,
+): AbortSignal {
+  const coordinationDeadlineAt =
+    activation.executionContext.piLaunchConfig.apiFirstTurn.deadlineAt;
+  return AbortSignal.any([
+    coordinationSignal,
+    AbortSignal.timeout(Math.max(1, coordinationDeadlineAt - now())),
+  ]);
 }
 
 async function canonicalApiFirstTurnCancellationWon(
@@ -1882,11 +1996,69 @@ function logCanonicalApiFirstTurnCancellation(
   });
 }
 
+function logApiFirstTurnAttemptTimedOut(
+  activation: PiApiFirstTurnActivation,
+  ownership: PiApiFirstTurnOwnership,
+  failure: PiApiFirstTurnError,
+): void {
+  L.debug("Pi API first-turn outcome", {
+    runId: activation.runId,
+    ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
+    outcome: "api_attempt_timed_out",
+    reason: failure.code,
+    ownershipStage: ownership.stage,
+  });
+}
+
+function sandboxFirstPublicationOutcome(reason: PiSandboxFirstReason): {
+  readonly outcome:
+    | "ownership_transfer"
+    | "sandbox_fallback"
+    | "sandbox_retry_started";
+  readonly reason: string;
+} {
+  switch (reason) {
+    case "api_attempt_timed_out": {
+      return {
+        outcome: "sandbox_retry_started",
+        reason: "api_attempt_timed_out",
+      };
+    }
+    case "active_input": {
+      return {
+        outcome: "ownership_transfer",
+        reason: "active_input_sandbox_first",
+      };
+    }
+    case "PI_API_COMPACTION_PREFLIGHT_REQUIRED": {
+      return { outcome: "ownership_transfer", reason: "compaction_preflight" };
+    }
+    default: {
+      return { outcome: "sandbox_fallback", reason };
+    }
+  }
+}
+
+function logSandboxFirstPublication(
+  activation: PiApiFirstTurnActivation,
+  ownership: PiApiFirstTurnOwnership,
+  reason: PiSandboxFirstReason,
+): void {
+  L.debug("Pi API first-turn outcome", {
+    runId: activation.runId,
+    ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
+    handoffOwner: "sandbox",
+    ...sandboxFirstPublicationOutcome(reason),
+    ownershipStage: ownership.stage,
+  });
+}
+
 const failApiFirstTurn$ = command(async function failApiFirstTurn(
   { set },
   args: ApiFirstTurnContext,
   failure: PiApiFirstTurnError,
   ownership: PiApiFirstTurnOwnership,
+  suppressCompletionFailureLog: boolean,
 ): Promise<DispatchCompleteSideEffectsInput | undefined> {
   const failureSignal = AbortSignal.timeout(FAILURE_COMMIT_TIMEOUT_MS);
   return await withApiFirstTurnLifecycle(args, async (tx) => {
@@ -1910,6 +2082,7 @@ const failApiFirstTurn$ = command(async function failApiFirstTurn(
           runId: args.activation.runId,
         },
         executionOwner: "api-first",
+        suppressFailureLog: suppressCompletionFailureLog,
         body: {
           runId: args.activation.runId,
           exitCode: 1,
@@ -1943,8 +2116,25 @@ export const runPiApiFirstTurn$ = command(
   ): Promise<DispatchCompleteSideEffectsInput | undefined> => {
     const context: ApiFirstTurnContext = { db: set(writeDb$), activation };
     const ownership = createPiApiFirstTurnOwnership();
+    const commitProgress: ApiFirstTurnCommitProgress = { started: false };
+    const apiAttemptController = new AbortController();
+    const apiDeadlineAt = apiFirstTurnApiDeadlineAt(
+      activation.executionContext,
+    );
+    const apiAttemptSignal = AbortSignal.any([
+      signal,
+      apiAttemptController.signal,
+      AbortSignal.timeout(Math.max(1, apiDeadlineAt - now())),
+    ]);
     const executed = await settleApiFirstTurnExecution(
-      set(executeApiFirstTurn$, context, ownership, signal),
+      set(
+        executeApiFirstTurn$,
+        context,
+        ownership,
+        commitProgress,
+        apiAttemptSignal,
+      ),
+      apiAttemptSignal,
       signal,
     );
     if (executed.ok) {
@@ -1955,9 +2145,13 @@ export const runPiApiFirstTurn$ = command(
           }
         : undefined;
     }
+    apiAttemptController.abort(executed.error);
     const activeInputBeforeProvider =
       executed.error instanceof PiApiFirstTurnActiveInputBeforeProviderError;
-    let failure = normalizedApiFirstTurnFailure(executed.error, signal);
+    let failure = normalizedApiFirstTurnFailure(
+      executed.error,
+      apiAttemptSignal,
+    );
     const resourceFallbackReason = activeInputBeforeProvider
       ? null
       : eligibleSandboxFallbackReason(
@@ -1967,42 +2161,47 @@ export const runPiApiFirstTurn$ = command(
           },
           signal,
         );
+    const coordinationDeadlineAt =
+      activation.executionContext.piLaunchConfig.apiFirstTurn.deadlineAt;
+    const apiOwnershipExpired =
+      failure.code === "PI_API_FIRST_TURN_DEADLINE_EXCEEDED" &&
+      !commitProgress.started &&
+      !signal.aborted;
+    const apiAttemptTimedOut =
+      apiOwnershipExpired && now() < coordinationDeadlineAt;
     const sandboxFirstReason: PiSandboxFirstReason | null =
-      activeInputBeforeProvider ? "active_input" : resourceFallbackReason;
+      activeInputBeforeProvider
+        ? "active_input"
+        : apiAttemptTimedOut
+          ? "api_attempt_timed_out"
+          : resourceFallbackReason;
     if (sandboxFirstReason) {
+      if (apiAttemptTimedOut) {
+        logApiFirstTurnAttemptTimedOut(activation, ownership, failure);
+      }
+      const handoffSignal = piApiFirstTurnHandoffSignal(activation, signal);
       const fallback = await settleApiFirstTurnExecution(
-        set(publishSandboxFallback$, context, sandboxFirstReason, signal),
+        set(
+          publishSandboxFallback$,
+          context,
+          sandboxFirstReason,
+          handoffSignal,
+        ),
+        handoffSignal,
         signal,
       );
       if (fallback.ok) {
-        L.debug("Pi API first-turn outcome", {
-          runId: activation.runId,
-          ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
-          handoffOwner: "sandbox",
-          outcome:
-            sandboxFirstReason === "active_input"
-              ? "ownership_transfer"
-              : sandboxFirstReason === "PI_API_COMPACTION_PREFLIGHT_REQUIRED"
-                ? "ownership_transfer"
-                : "sandbox_fallback",
-          reason:
-            sandboxFirstReason === "active_input"
-              ? "active_input_sandbox_first"
-              : sandboxFirstReason === "PI_API_COMPACTION_PREFLIGHT_REQUIRED"
-                ? "compaction_preflight"
-                : sandboxFirstReason,
-          ownershipStage: ownership.stage,
-        });
+        logSandboxFirstPublication(activation, ownership, sandboxFirstReason);
         return undefined;
       }
-      failure = normalizedSandboxFallbackFailure(fallback.error, signal);
+      failure = normalizedSandboxFallbackFailure(fallback.error, handoffSignal);
     }
     if (await canonicalApiFirstTurnCancellationWon(context)) {
       if (
         executed.error instanceof PiApiFirstTurnCanonicalCancellationError &&
         ownership.stage === "provider-may-have-started"
       ) {
-        L.warn("Pi API first-turn outcome", {
+        L.debug("Pi API first-turn outcome", {
           runId: activation.runId,
           ...piApiFirstTurnOutcomeTelemetry(activation.executionContext),
           outcome: "discarded_late_provider_result",
@@ -2022,7 +2221,16 @@ export const runPiApiFirstTurn$ = command(
       ...(resourceFallbackReason
         ? { fallbackReason: resourceFallbackReason }
         : {}),
+      ...(apiAttemptTimedOut
+        ? { recoveryReason: "api_attempt_timed_out" }
+        : {}),
     });
-    return set(failApiFirstTurn$, context, failure, ownership);
+    return set(
+      failApiFirstTurn$,
+      context,
+      failure,
+      ownership,
+      apiOwnershipExpired,
+    );
   },
 );

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.test.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.test.ts
@@ -216,6 +216,71 @@ describe("Pi API first-turn handoff loader", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
+  it("accepts a sandbox-first manifest after the API budget but before coordination expires", async () => {
+    const sessionDir = await mkdtemp(join(tmpdir(), "pi-handoff-loader-"));
+    temporaryDirectories.push(sessionDir);
+    const apiDeadlineAt = 46_000;
+    const coordinationDeadlineAt = 56_000;
+    let now = 1_000;
+    const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+      if (String(input).endsWith("manifest.json")) {
+        return now < apiDeadlineAt
+          ? new Response(null, { status: 404 })
+          : Response.json(
+              manifestV3(EMPTY_SESSION_JSONL, "sandbox-first", 1, null),
+            );
+      }
+      return new Response(EMPTY_SESSION_JSONL);
+    });
+    const runtime: HandoffRuntime = {
+      fetch: fetchMock as typeof fetch,
+      now: () => {
+        return now;
+      },
+      async sleep(milliseconds) {
+        now += milliseconds;
+      },
+    };
+
+    const restored = await resolvePiApiFirstTurnHandoff({
+      config: config(coordinationDeadlineAt, 1, null),
+      sessionDir,
+      sessionId: SESSION_ID,
+      runtime,
+    });
+
+    expect(now).toBeGreaterThanOrEqual(apiDeadlineAt);
+    expect(now).toBeLessThan(coordinationDeadlineAt);
+    expect(restored.ownershipTransferMode).toBe("sandbox-first");
+    expect(await readFile(restored.sessionFile, "utf8")).toBe(
+      EMPTY_SESSION_JSONL,
+    );
+  });
+
+  it("keeps accepting the previous 45-second wire deadline", async () => {
+    const sessionDir = await mkdtemp(join(tmpdir(), "pi-handoff-loader-"));
+    temporaryDirectories.push(sessionDir);
+    const fetchMock = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+      return String(input).endsWith("manifest.json")
+        ? Response.json(
+            manifestV3(EMPTY_SESSION_JSONL, "sandbox-first", 1, null),
+          )
+        : new Response(EMPTY_SESSION_JSONL);
+    });
+
+    const restored = await resolvePiApiFirstTurnHandoff({
+      config: config(46_000, 1, null),
+      sessionDir,
+      sessionId: SESSION_ID,
+      runtime: fixedRuntime(fetchMock as typeof fetch),
+    });
+
+    expect(restored.ownershipTransferMode).toBe("sandbox-first");
+    expect(await readFile(restored.sessionFile, "utf8")).toBe(
+      EMPTY_SESSION_JSONL,
+    );
+  });
+
   it.each([1, 2] as const)(
     "rejects retired manifest V%s before downloading a session",
     async (schemaVersion) => {

--- a/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
+++ b/turbo/apps/cli/src/lib/pi-api-first-turn-handoff.ts
@@ -388,7 +388,7 @@ async function restoreSession(args: {
   return sessionFile;
 }
 
-/** Poll one shared deadline and restore the validated H1 checkpoint. */
+/** Poll the wire coordination deadline and restore the validated checkpoint. */
 export async function resolvePiApiFirstTurnHandoff(args: {
   readonly config: PiApiFirstTurnConfig;
   readonly sessionDir: string;


### PR DESCRIPTION
## Summary

- Keep Pi API-first as the initial route with a 45-second ownership budget and the existing 2-second H1 commit reserve.
- Use a separate signal and the remaining 55-second coordination window to publish validated authoritative H0 through the existing V3 `sandbox-first` handoff.
- Reject late API results from product state while retaining usage accounting, lifecycle-lock, cancellation, and exactly-once active-input guarantees.
- Record successful timeout recovery and discarded late results at debug level, with one warning owner for terminal recovery failures.

This is a permanent ownership transition for a real reachable deadline, not a compatibility fallback.

## Compatibility and safety

- The wire schema is unchanged: V1 continues to use `deadlineAt`, now as the 55-second coordination cap, and V3 continues to use `mode: "sandbox-first"`.
- A current CLI accepts the previous 45-second deadline, while the unchanged reader behavior accepts a manifest published between 45 and 55 seconds.
- Timeout replay is disabled once any API H1 commit side effect can begin, preventing H0 replay over potentially published API state.
- Provider work may occur in both API and Sandbox, but only the lifecycle winner can publish product-visible events, checkpoints, tools, or terminal state.
- Raw provider and billing failures are classified before the private attempt controller is closed, so only actual deadline exhaustion enters the ownership transfer.

## Verification

- `pnpm --filter ./apps/api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t "keeps Terra first-turn billing|fails Terra first-turn billing|transfers authoritative H0|discards a late API success|lets canonical cancellation win the deadline|fails once when deadline handoff|emits one canonical warning|transfers pre-provider active input|publishes text H1 once|lets canonical cancellation win before provider ownership|does not fabricate usage when cancellation|bills one late OpenRouter result|keeps API completion terminal|fails Pi after one model request|hands a Terra resource failure"` (15 passed)
- `pnpm --filter @okouai/cli exec vitest run src/lib/pi-api-first-turn-handoff.test.ts` (30 passed)
- `pnpm --filter @okouai/api-contracts exec vitest run src/contracts/runners.test.ts src/contracts/__tests__/runners.test.ts` (109 passed)
- `pnpm --filter @okouai/pi-agent-runtime exec vitest run src/rpc.test.ts src/rpc-cancellation.test.ts` (14 passed)
- `pnpm --filter ./apps/api run lint`
- `pnpm --filter ./apps/api run check-types`
- `pnpm --filter ./apps/cli run lint`
- `pnpm --filter ./apps/cli run check-types`
- `pnpm exec knip --workspace api --workspace @okouai/cli`

## Rollout

- Before production promotion, verify the deployed API function duration exceeds the 55-second coordination cap with operational margin.
- No database migration, feature switch, or production release is included.

Fixes #32119
