### PR TITLE
test(platform): wait for pinned sidebar cache initialization

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
@@ -1,11 +1,13 @@
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { agentsMainContract } from "@okouai/api-contracts/contracts/agents";
 import {
   chatThreadMetadataContract,
   chatThreadsContract,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { expect, test } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { computerUseHostsContract } from "@okouai/api-contracts/contracts/computer-use";
 
 import {
   queryAllByRoleFast,
@@ -26,6 +28,82 @@ import {
 } from "./chat-list-test-helpers.ts";
 
 const context = testContext();
+
+beforeEach(() => {
+  context.mocks.api(computerUseHostsContract.list, ({ respond }) => {
+    return respond(200, { hosts: [] });
+  });
+});
+
+test("Cached pins load after storage opens without waiting for remote synchronization", async () => {
+  const auth = chatListAuth(81);
+  const pinnedAt = "2026-09-01T00:00:00Z";
+  const cached = [
+    chatListThread(1, "First cached pin", { pinnedAt, pinOrder: "a0" }),
+    chatListThread(2, "Second cached pin", { pinnedAt, pinOrder: "a1" }),
+    chatListThread(3, "Regular cached chat"),
+  ];
+  await seedChatListCache(81, auth, cached);
+  const [database] = await indexedDB.databases();
+  const opened = context.mocks.deferred<void>();
+  let deliverOpen: (() => void) | undefined;
+  let released = false;
+  const open = indexedDB.open.bind(indexedDB);
+  vi.spyOn(indexedDB, "open").mockImplementation((name, version) => {
+    const request = open(name, version);
+    if (name === database?.name) {
+      const dispatch = request.dispatchEvent.bind(request);
+      vi.spyOn(request, "dispatchEvent").mockImplementation((event) => {
+        if (event.type === "success" && !released) {
+          deliverOpen = () => {
+            dispatch(event);
+          };
+          opened.resolve();
+          return true;
+        }
+        return dispatch(event);
+      });
+    }
+    return request;
+  });
+  const releaseStorage = () => {
+    released = true;
+    deliverOpen?.();
+    deliverOpen = undefined;
+  };
+  context.signal.addEventListener("abort", releaseStorage, { once: true });
+  const remote = context.mocks.deferred<void>();
+  const { eventsRequested } = installChatListStream(context, {
+    caseId: 81,
+    snapshot: cached,
+    remoteGate: remote.promise,
+  });
+  installChatListAgent(context);
+
+  await setupPage({
+    context,
+    path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
+    auth,
+    featureSwitches: { [FeatureSwitchKey.StableChatThreadNavigation]: true },
+  });
+  await opened.promise;
+  expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
+    "aria-hidden",
+    "true",
+  );
+  expect(sidebarThreadTitles()).toStrictEqual([]);
+
+  act(releaseStorage);
+  await eventsRequested;
+  await waitFor(() => {
+    expect(sidebarThreadTitles()).toStrictEqual([
+      "First cached pin",
+      "Second cached pin",
+      "Regular cached chat",
+    ]);
+  });
+  expect(remote.settled()).toBeFalsy();
+});
 
 test("Cached conversations appear before remote synchronization", async () => {
   const auth = chatListAuth(1);
@@ -67,7 +145,7 @@ test("A complete cached conversation list remains navigable", async () => {
   });
   await seedChatListCache(3, auth, cached);
   const remote = context.mocks.deferred<void>();
-  installChatListStream(context, {
+  const { eventsRequested } = installChatListStream(context, {
     caseId: 3,
     snapshot: cached,
     remoteGate: remote.promise,
@@ -79,6 +157,7 @@ test("A complete cached conversation list remains navigable", async () => {
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
   });
+  await eventsRequested;
 
   const expected = Array.from({ length: 26 }, (_, offset) => {
     return `Cached conversation ${26 - offset}`;
@@ -105,7 +184,7 @@ test("Rename dialog uses the latest cached title", async () => {
   await seedChatListCache(11, auth, [cached], [rename]);
   const remote = context.mocks.deferred<void>();
   const detail = context.mocks.deferred<void>();
-  installChatListStream(context, {
+  const { eventsRequested } = installChatListStream(context, {
     caseId: 11,
     snapshot: [cached],
     events: [rename],
@@ -127,6 +206,7 @@ test("Rename dialog uses the latest cached title", async () => {
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
   });
+  await eventsRequested;
 
   await waitFor(() => {
     expect(sidebarThreadTitles()).toStrictEqual(["Cached renamed title"]);
@@ -199,7 +279,7 @@ test("The unread filter applies to cached conversations", async () => {
   const read = chatListThread(16, "Read cached conversation");
   await seedChatListCache(16, auth, [unread, read]);
   const remote = context.mocks.deferred<void>();
-  installChatListStream(context, {
+  const { eventsRequested } = installChatListStream(context, {
     caseId: 16,
     snapshot: [unread, read],
     remoteGate: remote.promise,
@@ -216,6 +296,7 @@ test("The unread filter applies to cached conversations", async () => {
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
   });
+  await eventsRequested;
 
   await waitFor(() => {
     expect(sidebarThreadTitles()).toStrictEqual([

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-pin-order.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-pin-order.test.tsx
@@ -7,6 +7,7 @@ import {
   type ChatThreadEvent,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { computerUseHostsContract } from "@okouai/api-contracts/contracts/computer-use";
 import {
   click,
   queryAllByRoleFast,
@@ -44,6 +45,9 @@ async function prepare(caseId: number, enabled = true, tied = false) {
   ];
   await seedChatListCache(caseId, auth, snapshot);
   installChatListAgent(context);
+  context.mocks.api(computerUseHostsContract.list, ({ respond }) => {
+    return respond(200, { hosts: [] });
+  });
   const stream = installChatListStream(context, { caseId, snapshot });
   await setupPage({
     context,
@@ -51,6 +55,9 @@ async function prepare(caseId: number, enabled = true, tied = false) {
     auth,
     featureSwitches: { [FeatureSwitchKey.StableChatThreadNavigation]: enabled },
   });
+  // The shell can be ready while storage is still opening. Catch-up reaches
+  // the event endpoint after reading the seeded cache; still assert the DOM.
+  await stream.eventsRequested;
   await waitFor(() => {
     return expect(sidebarThreadTitles()).toStrictEqual([
       "First pin",


### PR DESCRIPTION
## Summary

- Wait for the existing chat-thread event-request boundary before asserting seeded sidebar rows. Page-shell readiness deliberately does not imply IndexedDB cache hydration.
- Complete the pin/cache page stories with a typed empty computer-use hosts response.
- Add a real-page regression that holds IndexedDB open success and remote responses independently: the shell becomes ready first, then cached pins render in order after storage release without waiting for the network.
- Apply the same existing boundary to cached navigation, rename, and unread-filter stories.

Closes #32277

No production behavior, UI, shared page helper, API, migration, timeout, retry, skip, or CI concurrency changes.

## Validation

Passed: affected-file formatting and lint checks, full `pnpm -F @okouai/app lint`, full app type checks, and `pnpm knip --workspace apps/platform`. Normal commit hooks additionally passed repository-wide `pnpm knip`, `pnpm check-types` (15 tasks), formatting, file-size checks, and commitlint. The focused pin/cache/authentication set passed 30/30 twice during implementation; all 22 tests in the final changed files also passed in the latest broader run.

Latest expanded command, from `turbo/`:

```sh
VITE_AXIOM_CLIENT_TELEMETRY_TOKEN='' pnpm -F @okouai/app exec vitest run \
  src/views/okou-page/__tests__/sidebar-pin-order.test.tsx \
  src/views/okou-page/__tests__/chat-list-cache.test.tsx \
  src/__tests__/authentication-startup.test.tsx \
  src/views/okou-page/__tests__/sidebar-virtualization.test.tsx \
  src/views/okou-page/__tests__/sidebar.test.tsx \
  src/views/okou-page/__tests__/chat-offline-cache.test.tsx \
  --maxWorkers=2 --silent=passed-only
```

**80 passed / 3 failed.** All 37 cases in pin-order, cached-list, authentication-startup, and offline-cache passed. The command-only empty telemetry credential keeps local production-host fixtures from ingesting into Axiom; no persisted environment file was modified and no tests were bypassed.

## Known validation failures

Submitted first at the user's explicit request; **not represented as merge-ready**. Remaining failures in unchanged files are tracked in #32324:

- `Wait for styles before mounting the virtual viewport`: 5000 ms total-test timeout.
- `Browse a long sidebar chat history`: 5000 ms total-test timeout.
- `Move to the next relevant agent with a shortcut`: initial Support Agent element unavailable.

The two timeout cases also reproduced with both edits removed at main base `9fd53c47daba5922b0a5de5abcb4b82f44f0a2f8`; the shortcut failure has not independently been established on clean source. Do not treat the entire expanded suite as passing or claim these separate failures are fixed.
