### PR TITLE
test(platform): split voice recording recovery scenarios

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx
@@ -19,7 +19,6 @@ import {
 } from "./chat-run-test-fixtures.ts";
 
 const secondContext = testContext();
-const thirdContext = testContext();
 interface RecordingDatabase extends DBSchema {
   drafts: {
     key: string;
@@ -85,24 +84,32 @@ async function uploadedAudio(request: Request): Promise<ArrayBuffer> {
 
 const flags = { [FeatureSwitchKey.VoiceInputV2]: true } as const;
 
-test.each([RUN_PATH, NEW_CHAT_PATH])(
-  "Recover committed PCM after reloading during recording at %s",
-  async (path) => {
+test.each([
+  { path: RUN_PATH, reloadAt: "recording" },
+  { path: NEW_CHAT_PATH, reloadAt: "recording" },
+  { path: RUN_PATH, reloadAt: "failed retries" },
+  { path: NEW_CHAT_PATH, reloadAt: "failed retries" },
+])(
+  "Recover committed PCM across a reload ($reloadAt) at $path",
+  async ({ path, reloadAt }) => {
     const firstPage = createChildAbortController(context.signal);
-    const secondPage = createChildAbortController(secondContext.signal);
     const capture = context.mocks.deferred<(samples: Float32Array) => void>();
     context.mocks.browser.voiceInput({
       rms: 0.12,
       onPcmCapture: capture.resolve,
+      finalPcmSamples: new Float32Array(0),
     });
     installVoiceBoundaries();
     const uploads: ArrayBuffer[] = [];
-    const retries = Array.from({ length: 2 }, () => {
-      return {
-        requested: context.mocks.deferred<void>(),
-        response: context.mocks.deferred<void>(),
-      };
-    });
+    const retries = Array.from(
+      { length: reloadAt === "failed retries" ? 2 : 0 },
+      () => {
+        return {
+          requested: context.mocks.deferred<void>(),
+          response: context.mocks.deferred<void>(),
+        };
+      },
+    );
     context.mocks.http.post(
       "*/api/voice-io/transcribe/segment",
       async ({ request }) => {
@@ -131,37 +138,42 @@ test.each([RUN_PATH, NEW_CHAT_PATH])(
     click(await findEnabledButton("Voice input"));
     const emit = await capture.promise;
     emit(new Float32Array(4096).fill(0.25));
-    await findEnabledButton("Stop recording");
     await waitFor(async () => {
       await expect(savedRecording()).resolves.toMatchObject({
         sampleCount: 4096,
         chunkCount: 1,
       });
     });
-    unload(firstPage);
-    await setupPage({
-      context: { ...secondContext, signal: secondPage.signal },
-      path,
-      featureSwitches: flags,
-    });
+    await findEnabledButton("Stop recording");
+    // Keep interrupted capture and repeated transcription failures independent:
+    // each case needs only one reload before its successful recovery.
+    if (reloadAt === "recording") {
+      unload(firstPage);
+      await setupPage({ context: secondContext, path, featureSwitches: flags });
+    }
     for (const retry of retries) {
-      click(await findEnabledButton("Retry"));
+      const action = retry === retries[0] ? "Stop recording" : "Retry";
+      click(await findEnabledButton(action));
       await retry.requested.promise;
       await screen.findByText("Transcribing...");
       retry.response.resolve();
       await findEnabledButton("Retry");
     }
+    if (reloadAt === "failed retries") {
+      unload(firstPage);
+      await setupPage({ context: secondContext, path, featureSwitches: flags });
+    }
+    const retryButton = await findEnabledButton("Retry");
     expect(queryButton("Stop recording")).toBeNull();
-    unload(secondPage);
-    await setupPage({ context: thirdContext, path, featureSwitches: flags });
-    click(await findEnabledButton("Retry"));
+    click(retryButton);
     await findEnabledButton("Voice input");
     expect(screen.getByRole("textbox", { name: "Message" })).toHaveTextContent(
       "Recovered audio.",
     );
-    expect(uploads).toHaveLength(3);
-    expect(uploads[1]).toStrictEqual(uploads[0]);
-    expect(uploads[2]).toStrictEqual(uploads[0]);
+    expect(uploads).toHaveLength(retries.length + 1);
+    for (const upload of uploads.slice(1)) {
+      expect(upload).toStrictEqual(uploads[0]);
+    }
     const samples = decodeVoiceDraftPcmWav(uploads[0]!);
     expect(samples).toHaveLength(4096);
     expect(samples?.at(-1)).toBeCloseTo(0.25, 4);


### PR DESCRIPTION
## Status: Draft, stability verification incomplete

The user explicitly authorized this Draft submission despite the local timeout failures below so CI can provide additional evidence. This is not ready to merge, and no merge was authorized. The proposed split has not yet been demonstrated to eliminate the reported flake.

Relates to #32314. The issue remains open until stability is verified.

## Problem

The committed-PCM recovery test intermittently exceeds the default 5-second timeout. It combines capture, three full page bootstraps, two failed transcriptions and eventual recovery. After environment preparation, temporary local diagnostics reached the second page bootstrap at 5164 ms, before finishing the original scenario. The precise slow stage in the reported CI run is unknown.

## Changes

- Split the compound sequence into interrupted-recording recovery and recovery after two failed transcription attempts, each on existing-chat and new-chat routes.
- Each case now performs one reload and two full page bootstraps. Interrupted capture recovers directly; the post-failure case retains gated 503 responses and byte-identical uploads across its retry and reload.
- Keep real capture and IndexedDB persistence, recording readiness, decoded PCM assertions, recovered text delivery, and saved-recording cleanup. Configure an empty final mock PCM chunk so stopping capture preserves the same 4096-sample fixture.

Only this integration test file changes. No production code, timeout, test skip, internal-module mock, global helper, or CI configuration changes.

## Validation

Environment preparation and database migrations passed. Static checks passed for the submitted file:

- `pnpm -F @okouai/app lint`
- `pnpm exec prettier --check apps/platform/src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx`
- `pnpm -F @okouai/app exec oxlint src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx --deny-warnings`
- `pnpm -F @okouai/app exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx`
- `pnpm -F @okouai/app exec eslint src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx --max-warnings 0`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace apps/platform`
- `git diff --check`

Normal commit hooks also passed: Prettier, full-repository `pnpm knip`, full-repository `pnpm check-types` (15/15 tasks), file-size validation, and commitlint. No hooks were bypassed.

Commands below ran from `turbo`, with one Vitest process and one worker at a time and the unchanged default test timeout.

Standalone run: **12/12 passed**, changed scenarios took 3687, 2590, 2369 and 1772 ms:

```sh
RAYON_NUM_THREADS=2 pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx --maxWorkers=1 --reporter=verbose --silent=passed-only
```

Subsequent broader run: **32/37 passed, five timeouts**, including two changed recovery cases and three unchanged forwarding/incremental cases:

```sh
RAYON_NUM_THREADS=2 pnpm vitest run --project=@okouai/app apps/platform/src/views/okou-page/__tests__/chat-capability-voice-recording.test.tsx apps/platform/src/views/okou-page/__tests__/chat-capability-voice-incremental.test.tsx apps/platform/src/views/okou-page/__tests__/chat-capability-voice-forwarding.test.tsx apps/platform/src/views/okou-page/__tests__/chat-capability-voice-safari-startup.test.tsx --maxWorkers=1 --reporter=verbose --silent=passed-only
```

The final standalone run without the local compiler-thread cap also timed out in one case (11/12 passed). The 12-CPU host reported load averages of 45–59 and 33–61 runnable tasks. Contention is a contributor, not proof that every failure is environmental or that this change is sufficient. `RAYON_NUM_THREADS` was command-local; no repository setting was changed.

## Risks and remaining work

- The original combined two-reload sequence is now decomposed; there is no longer one case covering interruption followed by failed retries and a second reload together.
- Four shorter cases replace two longer cases, increasing aggregate setup work while reducing the work inside each timeout budget.
- Obtain current-head CI results and investigate remaining relevant failures before claiming stability or considering readiness. Keep this PR Draft in the meantime.
