### PR TITLE
feat(desktop): package pinned cua runtime and embedded lifecycle

### DIFF
--- a/.github/scripts/tests/deploy-desktop-workflow-test.sh
+++ b/.github/scripts/tests/deploy-desktop-workflow-test.sh
@@ -23,8 +23,8 @@ ruby -e '
 
   canonical_signing_identity = "OKOU_DESKTOP_SIGNING_IDENTITY"
   canonical_writer_counts = {
-    "OKOU_DESKTOP_PRODUCT" => [6, 2],
-    "OKOU_DESKTOP_PLATFORM_URL" => [9, 2],
+    "OKOU_DESKTOP_PRODUCT" => [7, 2],
+    "OKOU_DESKTOP_PLATFORM_URL" => [11, 2],
     canonical_signing_identity => [0, 5],
   }
   canonical_writer_counts.each do |name, expected_counts|
@@ -34,6 +34,12 @@ ruby -e '
 
   detector = desktop.fetch("detect-desktop-version")
   build = desktop.fetch("build-macos")
+  ["default-configuration", "Okou production", "PR preview"].each do |variant|
+    smoke = build.fetch("steps").find { |step| step["name"] == "Smoke test #{variant} artifact launch" }
+    probe = build.fetch("steps").find { |step| step["name"] == "Probe embedded CUA in #{variant} artifact" }
+    raise "Each packaged variant must run the real CUA probe" unless probe && probe.fetch("run").include?("--cua-probe --signed")
+    raise "CUA probe must use the same canonical environment and conditions as ordinary smoke" unless probe["env"] == smoke["env"] && probe["if"] == smoke["if"]
+  end
   deploy = desktop.fetch("deploy-desktop")
   raise "deploy-desktop must depend on version detection" unless deploy.fetch("needs") == "detect-desktop-version"
   raise "deploy-desktop must not use a GitHub environment" if deploy.key?("environment")

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -243,6 +243,9 @@ jobs:
       - name: Smoke test default-configuration artifact launch
         run: node apps/desktop/scripts/smoke-test-packaged-app.js
 
+      - name: Probe embedded CUA in default-configuration artifact
+        run: node apps/desktop/scripts/smoke-test-packaged-app.js --cua-probe --signed
+
       - name: Upload unsigned default-configuration macOS artifact
         uses: actions/upload-artifact@v7
         with:
@@ -391,6 +394,12 @@ jobs:
           OKOU_DESKTOP_PRODUCT: okou
           OKOU_DESKTOP_PLATFORM_URL: https://app.okou.ai
         run: node apps/desktop/scripts/smoke-test-packaged-app.js
+
+      - name: Probe embedded CUA in Okou production artifact
+        env:
+          OKOU_DESKTOP_PRODUCT: okou
+          OKOU_DESKTOP_PLATFORM_URL: https://app.okou.ai
+        run: node apps/desktop/scripts/smoke-test-packaged-app.js --cua-probe --signed
 
       - name: Upload unsigned Okou macOS artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -544,6 +553,12 @@ jobs:
         env:
           OKOU_DESKTOP_PLATFORM_URL: ${{ steps.preview.outputs.platform-url }}
         run: node apps/desktop/scripts/smoke-test-packaged-app.js
+
+      - name: Probe embedded CUA in PR preview artifact
+        if: github.event_name == 'pull_request'
+        env:
+          OKOU_DESKTOP_PLATFORM_URL: ${{ steps.preview.outputs.platform-url }}
+        run: node apps/desktop/scripts/smoke-test-packaged-app.js --cua-probe --signed
 
       - name: Upload unsigned PR preview macOS artifact
         if: github.event_name == 'pull_request'

--- a/turbo/apps/desktop/cua/LICENSE-MIT.txt
+++ b/turbo/apps/desktop/cua/LICENSE-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Cua AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/turbo/apps/desktop/cua/LICENSE-MPL-2.0.txt
+++ b/turbo/apps/desktop/cua/LICENSE-MPL-2.0.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/turbo/apps/desktop/cua/NOTICE-MPL.txt
+++ b/turbo/apps/desktop/cua/NOTICE-MPL.txt
@@ -1,0 +1,3 @@
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/

--- a/turbo/apps/desktop/cua/README.md
+++ b/turbo/apps/desktop/cua/README.md
@@ -34,8 +34,8 @@ duplicate libraries/header. The SDK root/native JS, `@ubjs/core` ESM JS, and
 Other platform packages, source trees, standalone `CuaDriver.app`, and the
 unused `@ubjs/node` native runtime are not shipped.
 
-`pnpm build:cua` uses Python 3's standard library to verify archives before
-extraction, restrict downloads and redirects to official HTTPS hosts, reject
+`pnpm build:cua` uses Python 3's standard library and system curl to verify
+archives before extraction, restrict downloads and redirects to official HTTPS hosts, reject
 unsafe entries/links, check package versions and arm64
 Mach-O headers, and stage `native/dist/cua`. This directory survives tsup's
 `dist` cleanup and Forge copies it to `Contents/Resources/cua`, while still

--- a/turbo/apps/desktop/cua/README.md
+++ b/turbo/apps/desktop/cua/README.md
@@ -1,0 +1,160 @@
+# Experimental embedded CUA runtime (slice 2)
+
+Okou remains the only registered/default Computer Use driver. This slice ships
+a dormant, host-owned runtime and a fixed verification entry point. It does not
+implement a command adapter, Developer selector, preferences, renderer
+diagnostics, or a runtime updater.
+
+## Distribution and integrity
+
+`artifacts.json` is the build lock for the runtime closure. All three CUA
+components are exactly **0.23.2**, source commit
+`e88e9d899ac5effaeae38619527ebaa46b26ce72`. GitHub labels the component release
+prerelease; this integration remains experimental. The SDK is a development
+dependency for public types only. The workspace lock pins its dependencies, but
+the shipped closure is assembled independently from the manifest's verified
+tarballs, without `npm install`, lifecycle scripts, platform auto-selection, or
+workspace symlinks.
+
+| Original archive         | SHA-256                                                            |
+| ------------------------ | ------------------------------------------------------------------ |
+| bare universal daemon    | `0127c82ff17922df4290931a8ebf9b4a8b21656aad24cba6f21ee50e41ed4493` |
+| SDK                      | `adb6e4a80b0a8259c7a03a0918db4e228f3ca48f4a98d13b43a2dfde76de8c82` |
+| arm64 native SDK package | `953991a6805c4b11003cdc75c6e615f4a48c02e68893959af6cbd2e09e299469` |
+| `@ubjs/core` 0.31.0-3    | `74d7950698bdc74569a8e754b2d5dc055a43afdd0647c0171595f9b77e8c7151` |
+| `@ubjs/node` 0.31.0-3    | `e5c18f3cfc46d072f9aa23439644c9c18fac62729e6385aadcc937e458507a09` |
+
+The actual downloaded bytes were checked against these hashes. The SDK and
+native package also match their npm lockfile SHA-512 integrity. The daemon
+archive includes two universal executables plus duplicate universal SDK
+libraries and a C header. Ship the executables (`cua-driver`,
+`cua-cursor-theme`) and use the pinned arm64 npm native libraries; omit the
+duplicate libraries/header. The SDK root/native JS, `@ubjs/core` ESM JS, and
+`@ubjs/node` library resolver retain their original package-relative layout.
+Other platform packages, source trees, standalone `CuaDriver.app`, and the
+unused `@ubjs/node` native runtime are not shipped.
+
+`pnpm build:cua` uses Python 3's standard library to verify archives before
+extraction, reject unsafe entries/links, check package versions and arm64
+Mach-O headers, and stage `native/dist/cua`. This directory survives tsup's
+`dist` cleanup and Forge copies it to `Contents/Resources/cua`, while still
+excluding root `node_modules`. Cache entries are original archives keyed by
+hash and are reverified on every use. No application launch downloads code.
+
+Three integrity domains are intentionally distinct:
+
+1. `artifacts.json` verifies original upstream bytes before extraction.
+2. `payload.json` records every staged unsigned file. The packaged probe checks
+   the complete inventory and hashes before loading the SDK. Signed verification
+   excludes native bytes from that comparison, retaining JS/notice checks.
+3. Both Forge signing and artifact promotion pass the four CUA Mach-O paths
+   explicitly to `@electron/osx-sign` before the outer app seal/notarization.
+   Installed native code is checked by macOS code signing, the native loader,
+   and exact live daemon metadata. Re-signing changes Mach-O bytes; original
+   native hashes must not reject legitimate signed installations.
+
+`LICENSE-MIT.txt`, `LICENSE-MPL-2.0.txt`, `NOTICE-MPL.txt`, `SOURCES.txt`, and
+the upstream native `node-runtime-NOTICE.md` accompany the payload. The native
+compatibility runtime is **MPL-2.0**, and the native package is **MIT AND
+MPL-2.0**. `SOURCES.txt` identifies exact corresponding source and the upstream
+build transformations. No upstream native runtime is modified.
+
+## Runtime ownership
+
+The CJS main bundle keeps native dynamic `import(fileURL)` for the staged ESM
+entry. Loading ordinary Desktop modules does not evaluate CUA. Only the
+explicit host start calls the public `EmbeddedCuaDriverHost.withOptions` and
+`CuaDriver.connect`. It directly spawns the absolute packaged executable with
+the build's real bundle ID, standard permission mode, a private mode-0700
+endpoint directory, and both telemetry flags disabled. Overlay is disabled for
+this lifecycle/probe slice. No history option or history command is enabled.
+
+The released daemon reads persistent Computer History opt-in under `HOME`.
+Only the daemon receives a fresh generation-owned home in its private directory;
+the Electron process environment and macOS responsibility chain are unchanged.
+This prevents inheriting an existing standalone CUA history opt-in. The directory
+is removed after confirmed exit. There is no user-configurable binary, socket,
+environment, permission mode, or generic command route.
+
+SDK startup validates embedded PID/endpoint/protocol ownership. The wrapper
+also requires exact `driverVersion === "0.23.2"` on both the connection and
+client metadata. Starts coalesce. Stop retires admission immediately, aborts
+pending client probes, retains late startup/exit results, destroys the client,
+awaits native stop and the matching exit observer, destroys the host, and then
+removes its private directory. A caller deadline never proves process exit:
+unresolved or failed cleanup keeps that generation owned and blocks replacement.
+Unexpected exit cannot replay a command, revive old readiness, or choose Okou.
+
+## Automated package verification
+
+From `turbo`, the macOS workflow runs both commands on the default,
+production-configured, and PR preview packages:
+
+```sh
+node apps/desktop/scripts/smoke-test-packaged-app.js
+node apps/desktop/scripts/smoke-test-packaged-app.js --cua-probe --signed
+```
+
+The first verifies the normal renderer bridge and reports `cua dormant`.
+The second checks the real package inventory and launches the actual packaged
+Electron main, loads the shipped SDK/native libraries, starts the shipped
+daemon, validates metadata, passively checks permissions, stops, and observes
+cleanup. It never requests TCC grants or captures an image. A missing grant is
+reported as `false` and does not skip load/start/metadata/cleanup. Unsupported
+platform, startup failure, and unproven cleanup fail explicitly. These checks
+run on CI artifacts signed ad-hoc by the existing Forge hook (the artifact
+names say "unsigned" because they lack Developer ID signing/notarization).
+They verify the outer seal before accepting re-signed native bytes, and are
+not installed-app TCC evidence.
+
+The distribution fault test uses fixture archives to inject corruption, unsafe
+entries, version/architecture mismatches, missing files, cache corruption, and
+post-sign byte changes. Lifecycle tests mock only the external SDK/process
+boundary. Neither test substitutes for the real macOS packaged probe.
+
+## Pending signed-host and TCC acceptance (user-owned)
+
+Use a correctly signed/notarized build or designated preview from the normal
+Desktop distribution process. This issue does not authorize a release or
+grant approvals. Quit any existing instance of that same build first.
+
+1. Verify the app with `codesign --verify --deep --strict --verbose=2
+"/Applications/Okou.app"` and `spctl --assess --type execute --verbose=2
+"/Applications/Okou.app"`. Inspect the four nested signatures and confirm
+   the app bundle ID (`ai.okou.desktop`, or `ai.okou.desktop.dev` for preview).
+2. With the source checkout, set `OKOU_DESKTOP_SMOKE_APP_PATH` to that exact
+   app and run the probe wrapper above with `--cua-probe --signed`. This
+   verifies lifecycle/loading; shell-launched evidence alone does not prove
+   LaunchServices responsibility attribution.
+3. Launch the signed app itself through LaunchServices with the fixed host
+   probe environment (macOS `open --env`), without a separate CUA installation:
+
+   ```sh
+   open -n --stdout /tmp/okou-cua-probe.log --stderr /tmp/okou-cua-probe-error.log \
+     --env OKOU_DESKTOP_CUA_PROBE=1 --env OKOU_DESKTOP_SMOKE_TEST=1 \
+     /Applications/Okou.app
+   ```
+
+   Inspect passive grant booleans, `attribution: "host"`, exact version and
+   `cleanup: "confirmed"`. The host label is advisory, not proof of OS TCC
+   attribution. Confirm System Settings and macOS TCC attribution logs identify
+   Okou only. Never approve a separate `CuaDriver.app` entry.
+
+4. The user grants Accessibility and Screen Recording to the signed Okou host,
+   then launches a new probe process (TCC answers may be cached by old children).
+   Only after those grants, repeat the LaunchServices command adding
+   `--env OKOU_DESKTOP_CUA_CAPTURE=1`. This fixed route uses a named public SDK
+   session and `getDesktopState`, ends that session, and saves one PNG at
+   `<this build's userData>/cua-host-probe/screenshot.png` with mode 0600. Logs
+   contain permission/version/cleanup metadata only. The image stays local.
+   `capture: "success"` requires an actual PNG; denied grants report
+   `permission_denied`, and capture errors fail the probe.
+5. Revoke each grant, restart and repeat the passive probe, then regrant and
+   restart. Confirm the old CUA child and its private socket directory disappear
+   after each exit and no standalone CUA identity/daemon is left behind.
+
+Signed installation, actual OS TCC responsibility, authorized screenshot content,
+revocation/regrant behavior and paired real-app comparison remain **pending
+user verification**. An unsigned CI pass does not complete these items or the
+parent Epic. Future upgrades replace this explicit lock through normal Desktop
+distribution and rerun the package/lifecycle checks.

--- a/turbo/apps/desktop/cua/README.md
+++ b/turbo/apps/desktop/cua/README.md
@@ -35,7 +35,8 @@ Other platform packages, source trees, standalone `CuaDriver.app`, and the
 unused `@ubjs/node` native runtime are not shipped.
 
 `pnpm build:cua` uses Python 3's standard library to verify archives before
-extraction, reject unsafe entries/links, check package versions and arm64
+extraction, restrict downloads and redirects to official HTTPS hosts, reject
+unsafe entries/links, check package versions and arm64
 Mach-O headers, and stage `native/dist/cua`. This directory survives tsup's
 `dist` cleanup and Forge copies it to `Contents/Resources/cua`, while still
 excluding root `node_modules`. Cache entries are original archives keyed by

--- a/turbo/apps/desktop/cua/SOURCES.txt
+++ b/turbo/apps/desktop/cua/SOURCES.txt
@@ -1,0 +1,27 @@
+Experimental CUA distribution, version 0.23.2
+
+CUA SDK and daemon: MIT, Copyright (c) 2025 Cua AI, Inc.
+Source: https://github.com/trycua/cua/tree/e88e9d899ac5effaeae38619527ebaa46b26ce72
+License: https://github.com/trycua/cua/blob/e88e9d899ac5effaeae38619527ebaa46b26ce72/LICENSE.md
+
+The native package is MIT AND MPL-2.0. The unmodified
+cua_driver_node_runtime.node is a compatibility build of the Mozilla Public
+License 2.0 N-API runtime from uniffi-bindgen-react-native 0.31.0-3.
+The applicable upstream node-runtime-NOTICE.md is shipped beside that file.
+Corresponding Source Code Form, including the deterministic build transformations:
+https://github.com/trycua/cua/blob/e88e9d899ac5effaeae38619527ebaa46b26ce72/libs/cua-driver/scripts/build-node-runtime.mjs
+https://github.com/jhugman/uniffi-bindgen-react-native/tree/dcb5c4ab2350d57f6d26f5fa81a99c77ed86d449
+https://registry.npmjs.org/uniffi-bindgen-react-native/-/uniffi-bindgen-react-native-0.31.0-3.tgz
+npm source integrity: sha512-br7giBJRr/j00rdMXhOZGMGuDWMAVUcxC9O3lco0KRqzEAxUz00+gegPW5tKamvKbrnj7NB682XUCYrcagtxFA==
+
+@ubjs/core and @ubjs/node 0.31.0-3: MPL-2.0, copyright James Hugman
+and contributors. Their Source Code Form is available at the same pinned
+uniffi-bindgen-react-native commit above and the exact npm tarballs recorded
+in artifacts.json. Only the runtime JavaScript closure is redistributed.
+See LICENSE-MPL-2.0.txt and NOTICE-MPL.txt. No MPL-covered source is modified;
+application code signing may replace only Mach-O signature data.
+
+artifacts.json pins SHA-256 of the original downloaded archives before extraction.
+payload.json inventories the staged, unsigned payload. Re-signing changes native
+bytes: use the application code signature to verify installed native code,
+not the original unsigned native hashes. JavaScript and notices remain unchanged.

--- a/turbo/apps/desktop/cua/artifacts.json
+++ b/turbo/apps/desktop/cua/artifacts.json
@@ -1,0 +1,93 @@
+{
+  "driverVersion": "0.23.2",
+  "target": "darwin-arm64",
+  "experimental": true,
+  "sourceCommit": "e88e9d899ac5effaeae38619527ebaa46b26ce72",
+  "artifacts": [
+    {
+      "id": "daemon",
+      "url": "https://github.com/trycua/cua/releases/download/cua-driver-rs-v0.23.2/cua-driver-rs-0.23.2-darwin-universal-binary.tar.gz",
+      "sha256": "0127c82ff17922df4290931a8ebf9b4a8b21656aad24cba6f21ee50e41ed4493",
+      "destination": ".",
+      "files": ["cua-driver", "cua-cursor-theme"]
+    },
+    {
+      "id": "sdk",
+      "url": "https://github.com/trycua/cua/releases/download/cua-driver-rs-v0.23.2/trycua-cua-driver-0.23.2.tgz",
+      "sha256": "adb6e4a80b0a8259c7a03a0918db4e228f3ca48f4a98d13b43a2dfde76de8c82",
+      "destination": "node_modules/@trycua/cua-driver",
+      "files": [
+        "package/dist/native/cua_driver_contract-ffi.js",
+        "package/dist/index.js",
+        "package/dist/native/cua_driver_contract.js",
+        "package/dist/native/cua_driver_sdk-ffi.js",
+        "package/dist/native/cua_driver_sdk.js",
+        "package/dist/native/index.js",
+        "package/dist/native/node-runtime.js",
+        "package/package.json",
+        "package/README.md"
+      ],
+      "package": "@trycua/cua-driver",
+      "version": "0.23.2"
+    },
+    {
+      "id": "native",
+      "url": "https://github.com/trycua/cua/releases/download/cua-driver-rs-v0.23.2/trycua-cua-driver-darwin-arm64-0.23.2.tgz",
+      "sha256": "953991a6805c4b11003cdc75c6e615f4a48c02e68893959af6cbd2e09e299469",
+      "destination": "node_modules/@trycua/cua-driver-darwin-arm64",
+      "files": [
+        "package/libcua_driver_sdk.dylib",
+        "package/package.json",
+        "package/node-runtime-NOTICE.md",
+        "package/cua_driver_node_runtime.node"
+      ],
+      "package": "@trycua/cua-driver-darwin-arm64",
+      "version": "0.23.2"
+    },
+    {
+      "id": "core",
+      "url": "https://registry.npmjs.org/@ubjs/core/-/core-0.31.0-3.tgz",
+      "sha256": "74d7950698bdc74569a8e754b2d5dc055a43afdd0647c0171595f9b77e8c7151",
+      "destination": "node_modules/@ubjs/core",
+      "files": [
+        "package/dist/esm/async-callbacks.js",
+        "package/dist/esm/async-rust-call.js",
+        "package/dist/esm/callbacks.js",
+        "package/dist/esm/enums.js",
+        "package/dist/esm/errors.js",
+        "package/dist/esm/ffi-converters.js",
+        "package/dist/esm/ffi-types.js",
+        "package/dist/esm/handle-map.js",
+        "package/dist/esm/index.js",
+        "package/dist/esm/objects.js",
+        "package/dist/esm/records.js",
+        "package/dist/esm/result.js",
+        "package/dist/esm/rust-call.js",
+        "package/dist/esm/symbols.js",
+        "package/dist/esm/type-utils.js",
+        "package/package.json",
+        "package/README.md"
+      ],
+      "package": "@ubjs/core",
+      "version": "0.31.0-3"
+    },
+    {
+      "id": "node",
+      "url": "https://registry.npmjs.org/@ubjs/node/-/node-0.31.0-3.tgz",
+      "sha256": "e5c18f3cfc46d072f9aa23439644c9c18fac62729e6385aadcc937e458507a09",
+      "destination": "node_modules/@ubjs/node",
+      "files": [
+        "package/typescript/dist/resolve-lib.js",
+        "package/package.json"
+      ],
+      "package": "@ubjs/node",
+      "version": "0.31.0-3"
+    }
+  ],
+  "nativeCode": [
+    "cua-driver",
+    "cua-cursor-theme",
+    "node_modules/@trycua/cua-driver-darwin-arm64/libcua_driver_sdk.dylib",
+    "node_modules/@trycua/cua-driver-darwin-arm64/cua_driver_node_runtime.node"
+  ]
+}

--- a/turbo/apps/desktop/forge.config.js
+++ b/turbo/apps/desktop/forge.config.js
@@ -1,5 +1,6 @@
 const os = require("node:os");
 const path = require("node:path");
+const { cuaSigningBinaries } = require("./scripts/cua-signing");
 
 const packageMetadata = require("./package.json");
 const desktopBrandAssets = require("./src/desktop-brand-assets.json");
@@ -76,6 +77,7 @@ async function signPackagedDarwinApps(_forgeConfig, packageResult) {
 
     await sign({
       app: appPath,
+      binaries: cuaSigningBinaries(appPath),
       batchCodesignCalls: true,
       identity: codeSigningIdentity,
       identityValidation: codeSigningIdentity !== "-",
@@ -95,6 +97,11 @@ async function signPackagedDarwinApps(_forgeConfig, packageResult) {
 
 module.exports = {
   hooks: {
+    prePackage: async (_forgeConfig, platform, arch) => {
+      if (platform !== "darwin" || arch !== "arm64") {
+        throw new Error("The bundled CUA runtime supports only macOS arm64");
+      }
+    },
     postPackage: signPackagedDarwinApps,
   },
   packagerConfig: {
@@ -113,6 +120,7 @@ module.exports = {
     extraResource: [
       path.join(__dirname, "native", "dist", "native"),
       path.join(__dirname, "dist", "mcp"),
+      path.join(__dirname, "native", "dist", "cua"),
     ],
     protocols: [
       {
@@ -124,6 +132,8 @@ module.exports = {
       /^\/node_modules($|\/)/,
       /^\/src($|\/)/,
       /^\/native($|\/)/,
+      /^\/cua($|\/)/,
+      /^\/\.cache($|\/)/,
       /^\/scripts($|\/)/,
       /^\/\.turbo($|\/)/,
       /^\/\.npmrc$/,

--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -6,7 +6,7 @@
   "main": "dist/bootstrap.js",
   "scripts": {
     "assets:generate": "node scripts/generate-brand-assets.mjs",
-    "build": "pnpm build:native && pnpm build:electron && pnpm build:mcp-filesystem && pnpm build:renderer",
+    "build": "pnpm build:native && pnpm build:cua && pnpm build:electron && pnpm build:mcp-filesystem && pnpm build:renderer",
     "build:electron": "tsup --config tsup.electron.config.js && node scripts/check-bootstrap-bundle.mjs",
     "build:mcp-filesystem": "tsup --config tsup.mcp-filesystem.config.js",
     "build:native": "node scripts/build-native-helper.js",
@@ -20,7 +20,8 @@
     "start": "electron-forge start",
     "test": "vitest run",
     "test:native": "node scripts/test-native-helper.js",
-    "upload:sentry": "node scripts/upload-sentry-artifacts.js"
+    "upload:sentry": "node scripts/upload-sentry-artifacts.js",
+    "build:cua": "python3 scripts/stage-cua-runtime.py"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
@@ -56,6 +57,7 @@
     "@typescript/native": "npm:typescript@7.0.2",
     "typescript": "npm:@typescript/typescript6@6.0.2",
     "vite": "^8.0.16",
-    "vitest": "^4.1.11"
+    "vitest": "^4.1.11",
+    "@trycua/cua-driver": "0.23.2"
   }
 }

--- a/turbo/apps/desktop/scripts/cua-signing.js
+++ b/turbo/apps/desktop/scripts/cua-signing.js
@@ -1,0 +1,10 @@
+const path = require("node:path");
+const manifest = require("../cua/artifacts.json");
+
+function cuaSigningBinaries(appPath) {
+  return manifest.nativeCode.map((file) =>
+    path.join(appPath, "Contents", "Resources", "cua", file),
+  );
+}
+
+module.exports = { cuaSigningBinaries };

--- a/turbo/apps/desktop/scripts/packaged-app-paths.js
+++ b/turbo/apps/desktop/scripts/packaged-app-paths.js
@@ -16,6 +16,7 @@ function packagedAppPaths(options = {}) {
 
   return {
     appBundlePath,
+    cuaRuntimePath: path.join(appBundlePath, "Contents", "Resources", "cua"),
     executablePath: path.join(appBundlePath, "Contents", "MacOS", appName),
     mainBundlePath: path.join(
       appBundlePath,

--- a/turbo/apps/desktop/scripts/sign-and-notarize-packaged-app.mjs
+++ b/turbo/apps/desktop/scripts/sign-and-notarize-packaged-app.mjs
@@ -9,6 +9,7 @@ import { sign } from "@electron/osx-sign";
 
 import desktopNotarizeApiEnvironment from "./desktop-notarize-api-environment.js";
 import desktopSigningIdentityEnvironment from "./desktop-signing-identity-environment.js";
+import cuaSigning from "./cua-signing.js";
 
 const { resolveDesktopNotarizeApiEnvironment } = desktopNotarizeApiEnvironment;
 const { resolveDesktopSigningIdentityEnvironment } =
@@ -82,6 +83,7 @@ if (!notarizeOptions) {
 
 await sign({
   app: options.appPath,
+  binaries: cuaSigning.cuaSigningBinaries(options.appPath),
   batchCodesignCalls: true,
   identity: requiredEnvironmentVariable(
     "OKOU_DESKTOP_SIGNING_IDENTITY",

--- a/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
+++ b/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
@@ -1,18 +1,48 @@
-const { spawn } = require("node:child_process");
+const { spawn, execFileSync } = require("node:child_process");
 const fs = require("node:fs");
+const path = require("node:path");
 
 const { packagedAppPaths } = require("./packaged-app-paths");
 
-const READY_MARKER = "[smoke-test] desktop main ready";
+const cuaProbe = process.argv.includes("--cua-probe");
+const READY_MARKER = cuaProbe
+  ? "[cua-probe] "
+  : "[smoke-test] desktop main ready";
 const LAUNCH_TIMEOUT_MS = 60_000;
 
 if (process.platform !== "darwin") {
   throw new Error("Packaged desktop smoke tests are only supported on macOS.");
 }
 
-const { executablePath, mainBundlePath, mcpBundlePath } = packagedAppPaths({
+const {
+  executablePath,
+  mainBundlePath,
+  mcpBundlePath,
+  cuaRuntimePath,
+  appBundlePath,
+} = packagedAppPaths({
   appBundlePath: process.env.OKOU_DESKTOP_SMOKE_APP_PATH,
 });
+
+if (cuaProbe) {
+  if (process.argv.includes("--signed")) {
+    execFileSync(
+      "codesign",
+      ["--verify", "--deep", "--strict", appBundlePath],
+      { stdio: "inherit" },
+    );
+  }
+  execFileSync(
+    "python3",
+    [
+      path.join(__dirname, "stage-cua-runtime.py"),
+      "--verify",
+      cuaRuntimePath,
+      ...(process.argv.includes("--signed") ? ["--signed"] : []),
+    ],
+    { stdio: "inherit" },
+  );
+}
 
 if (!fs.existsSync(executablePath)) {
   throw new Error(`Packaged app executable was not found at ${executablePath}`);
@@ -86,7 +116,12 @@ console.log(
 );
 
 const child = spawn(executablePath, [], {
-  env: { ...process.env, OKOU_DESKTOP_SMOKE_TEST: "1" },
+  env: {
+    ...process.env,
+    OKOU_DESKTOP_SMOKE_TEST: "1",
+    OKOU_DESKTOP_CUA_PROBE: cuaProbe ? "1" : "0",
+    OKOU_DESKTOP_CUA_CAPTURE: "0",
+  },
   stdio: ["ignore", "pipe", "pipe"],
 });
 
@@ -108,8 +143,14 @@ const timeout = setTimeout(() => {
 child.on("close", (code, signal) => {
   clearTimeout(timeout);
 
-  const succeeded = code === 0 && stdout.includes(READY_MARKER);
+  const succeeded =
+    code === 0 &&
+    stdout.includes(READY_MARKER) &&
+    (cuaProbe
+      ? stdout.includes('"cleanup":"confirmed"')
+      : stdout.includes("[smoke-test] cua dormant"));
   if (succeeded) {
+    if (cuaProbe) console.log(stdout.trim());
     console.log(`Packaged app launched and reported ready: ${executablePath}`);
     return;
   }

--- a/turbo/apps/desktop/scripts/stage-cua-runtime.py
+++ b/turbo/apps/desktop/scripts/stage-cua-runtime.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Assemble the pinned macOS runtime from verified upstream bytes, never npm install."""
+
+import argparse
+import hashlib
+import json
+import platform
+import shutil
+import struct
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path, PurePosixPath
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def download(artifact, cache):
+    cached = cache / artifact["sha256"]
+    if cached.exists():
+        data = cached.read_bytes()
+    else:
+        with urllib.request.urlopen(artifact["url"], timeout=60) as response:
+            data = response.read()
+    if digest(data) != artifact["sha256"]:
+        raise ValueError(f"CUA integrity mismatch: {artifact['id']}")
+    # A cache hit is verified just like a fresh download. Never cache extracted code.
+    cached.write_bytes(data)
+    return cached
+
+
+def safe_path(name):
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts or "\\" in name:
+        raise ValueError(f"Unsafe CUA archive path: {name}")
+    return path
+
+
+def extract(artifact, archive, output):
+    destination = output / safe_path(artifact["destination"])
+    with tarfile.open(archive, "r:gz") as source:
+        members = {}
+        # Validate the entire archive before writing even the selected files.
+        for member in source:
+            safe_path(member.name)
+            if not (member.isfile() or member.isdir()) or member.name in members:
+                raise ValueError(f"Unsafe CUA archive entry: {member.name}")
+            members[member.name] = member
+        for name in artifact["files"]:
+            member = members[name]
+            if not member.isfile():
+                raise ValueError(f"Missing CUA file: {name}")
+            relative = safe_path(name)
+            if "package" in artifact:
+                if relative.parts[0] != "package":
+                    raise ValueError(f"Invalid npm archive root: {name}")
+                relative = PurePosixPath(*relative.parts[1:])
+            target = destination / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with source.extractfile(member) as content:
+                target.write_bytes(content.read())
+            target.chmod(0o755 if member.mode & 0o111 else 0o644)
+    if "package" in artifact:
+        package = json.loads((destination / "package.json").read_text())
+        if (package["name"], package["version"]) != (
+            artifact["package"], artifact["version"]
+        ):
+            raise ValueError(f"CUA package/version mismatch: {artifact['id']}")
+
+
+def verify_arm64(path):
+    data = path.read_bytes()
+    magic = data[:4]
+    if magic == b"\xcf\xfa\xed\xfe":
+        architectures = [struct.unpack_from("<I", data, 4)[0]]
+    elif magic == b"\xca\xfe\xba\xbe":
+        count = struct.unpack_from(">I", data, 4)[0]
+        architectures = [struct.unpack_from(">I", data, 8 + n * 20)[0] for n in range(count)]
+    else:
+        raise ValueError(f"CUA payload is not Mach-O: {path.name}")
+    if 0x0100000C not in architectures:
+        raise ValueError(f"CUA payload lacks arm64: {path.name}")
+
+
+def stage(manifest_path, output, cache):
+    manifest = json.loads(manifest_path.read_text())
+    if manifest["target"] != "darwin-arm64":
+        raise ValueError("CUA distribution supports only darwin-arm64")
+    cache.mkdir(parents=True, exist_ok=True)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="cua-stage-", dir=output.parent) as temporary:
+        staged = Path(temporary) / "cua"
+        staged.mkdir()
+        for artifact in manifest["artifacts"]:
+            extract(artifact, download(artifact, cache), staged)
+        for name in manifest["nativeCode"]:
+            verify_arm64(staged / safe_path(name))
+            (staged / name).chmod(0o755)
+        licenses = staged / "licenses"
+        licenses.mkdir()
+        for source in manifest_path.parent.glob("*.txt"):
+            shutil.copyfile(source, licenses / source.name)
+        shutil.copyfile(manifest_path, staged / "artifacts.json")
+        files = {}
+        for item in sorted(staged.rglob("*")):
+            if item.is_symlink():
+                raise ValueError("CUA staging must not contain symlinks")
+            if item.is_file():
+                files[item.relative_to(staged).as_posix()] = digest(item.read_bytes())
+        (staged / "payload.json").write_text(json.dumps({
+            "driverVersion": manifest["driverVersion"],
+            "files": files,
+        }, indent=2) + "\n")
+        # Only replace a prior output after the complete new payload has passed.
+        if output.exists():
+            shutil.rmtree(output)
+        shutil.move(str(staged), output)
+    print(f"CUA {manifest['driverVersion']} staged: {len(files)} files; upstream SHA-256 verified")
+
+
+def verify_payload(root, signed):
+    manifest = json.loads((root / "artifacts.json").read_text())
+    payload = json.loads((root / "payload.json").read_text())
+    if payload["driverVersion"] != manifest["driverVersion"]:
+        raise ValueError("CUA payload version mismatch")
+    actual = {}
+    for item in root.rglob("*"):
+        if item.is_symlink():
+            raise ValueError("CUA packaged payload contains a symlink")
+        if item.is_file() and item.name != "payload.json":
+            actual[item.relative_to(root).as_posix()] = digest(item.read_bytes())
+    if actual.keys() != payload["files"].keys():
+        raise ValueError("CUA packaged file inventory mismatch")
+    for name, expected in payload["files"].items():
+        if signed and name in manifest["nativeCode"]:
+            continue
+        if actual[name] != expected:
+            raise ValueError(f"CUA packaged integrity mismatch: {name}")
+    for name in manifest["nativeCode"]:
+        verify_arm64(root / safe_path(name))
+        if not (root / name).stat().st_mode & 0o111:
+            raise ValueError(f"CUA native executable bit missing: {name}")
+    print(f"CUA {manifest['driverVersion']} package inventory/architecture verified (signed={signed})")
+
+
+def main():
+    desktop = Path(__file__).resolve().parent.parent
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=desktop / "cua/artifacts.json")
+    parser.add_argument("--out", type=Path, default=desktop / "native/dist/cua")
+    parser.add_argument("--cache", type=Path, default=desktop / ".cache/cua")
+    parser.add_argument("--target", choices=["darwin-arm64"])
+    parser.add_argument("--verify", type=Path)
+    parser.add_argument("--signed", action="store_true")
+    args = parser.parse_args()
+    if args.verify:
+        verify_payload(args.verify, args.signed)
+        return
+    if args.target is None and platform.system() != "Darwin":
+        print("CUA distribution is macOS-only; no runtime staged on this platform")
+        return
+    if args.target is None and platform.machine() != "arm64":
+        raise ValueError("CUA distribution supports only darwin-arm64")
+    stage(args.manifest, args.out, args.cache)
+
+
+if __name__ == "__main__":
+    main()

--- a/turbo/apps/desktop/scripts/stage-cua-runtime.py
+++ b/turbo/apps/desktop/scripts/stage-cua-runtime.py
@@ -3,11 +3,11 @@
 
 import argparse
 import hashlib
-import http.client
 import json
 import platform
 import shutil
 import struct
+import subprocess
 import tarfile
 import tempfile
 from urllib.parse import urljoin, urlsplit
@@ -19,29 +19,33 @@ def digest(data):
 
 
 def fetch_archive(url):
-    # HTTPSConnection cannot open file:// or other local-resource schemes.
+    # curl verifies TLS using the macOS/system trust store. Restrict its protocol
+    # explicitly and handle redirects here rather than enabling --location.
     # Validate each redirect as well as the manifest URL, including its authority.
     authorities = {"github.com", "release-assets.githubusercontent.com", "registry.npmjs.org"}
     for _ in range(6):
         parsed = urlsplit(url)
         if parsed.scheme != "https" or parsed.netloc not in authorities:
             raise ValueError("CUA download URL must use an official HTTPS host")
-        connection = http.client.HTTPSConnection(parsed.netloc, timeout=60)
-        try:
-            target = parsed.path + ("?" + parsed.query if parsed.query else "")
-            connection.request("GET", target)
-            response = connection.getresponse()
-            if response.status in {301, 302, 303, 307, 308}:
-                location = response.getheader("Location")
+        with tempfile.TemporaryDirectory(prefix="cua-download-") as temporary:
+            archive = Path(temporary) / "archive"
+            response = subprocess.run([
+                "curl", "--silent", "--show-error", "--proto", "=https",
+                "--max-time", "60", "--output", str(archive),
+                "--write-out", "%{json}", url,
+            ], capture_output=True, text=True)
+            if response.returncode != 0:
+                raise ValueError("CUA HTTPS download failed")
+            metadata = json.loads(response.stdout)
+            if metadata["http_code"] in {301, 302, 303, 307, 308}:
+                location = metadata["redirect_url"]
                 if not location:
                     raise ValueError("CUA download redirect has no location")
                 url = urljoin(url, location)
                 continue
-            if response.status != 200:
-                raise ValueError(f"CUA download failed: HTTP {response.status}")
-            return response.read()
-        finally:
-            connection.close()
+            if metadata["http_code"] != 200:
+                raise ValueError(f"CUA download failed: HTTP {metadata['http_code']}")
+            return archive.read_bytes()
     raise ValueError("CUA download exceeded the redirect limit")
 
 

--- a/turbo/apps/desktop/scripts/stage-cua-runtime.py
+++ b/turbo/apps/desktop/scripts/stage-cua-runtime.py
@@ -3,13 +3,14 @@
 
 import argparse
 import hashlib
+import http.client
 import json
 import platform
 import shutil
 import struct
 import tarfile
 import tempfile
-import urllib.request
+from urllib.parse import urljoin, urlsplit
 from pathlib import Path, PurePosixPath
 
 
@@ -17,13 +18,39 @@ def digest(data):
     return hashlib.sha256(data).hexdigest()
 
 
+def fetch_archive(url):
+    # HTTPSConnection cannot open file:// or other local-resource schemes.
+    # Validate each redirect as well as the manifest URL, including its authority.
+    authorities = {"github.com", "release-assets.githubusercontent.com", "registry.npmjs.org"}
+    for _ in range(6):
+        parsed = urlsplit(url)
+        if parsed.scheme != "https" or parsed.netloc not in authorities:
+            raise ValueError("CUA download URL must use an official HTTPS host")
+        connection = http.client.HTTPSConnection(parsed.netloc, timeout=60)
+        try:
+            target = parsed.path + ("?" + parsed.query if parsed.query else "")
+            connection.request("GET", target)
+            response = connection.getresponse()
+            if response.status in {301, 302, 303, 307, 308}:
+                location = response.getheader("Location")
+                if not location:
+                    raise ValueError("CUA download redirect has no location")
+                url = urljoin(url, location)
+                continue
+            if response.status != 200:
+                raise ValueError(f"CUA download failed: HTTP {response.status}")
+            return response.read()
+        finally:
+            connection.close()
+    raise ValueError("CUA download exceeded the redirect limit")
+
+
 def download(artifact, cache):
     cached = cache / artifact["sha256"]
     if cached.exists():
         data = cached.read_bytes()
     else:
-        with urllib.request.urlopen(artifact["url"], timeout=60) as response:
-            data = response.read()
+        data = fetch_archive(artifact["url"])
     if digest(data) != artifact["sha256"]:
         raise ValueError(f"CUA integrity mismatch: {artifact['id']}")
     # A cache hit is verified just like a fresh download. Never cache extracted code.

--- a/turbo/apps/desktop/scripts/test-cua-distribution.py
+++ b/turbo/apps/desktop/scripts/test-cua-distribution.py
@@ -1,0 +1,118 @@
+"""Exercise the distribution CLI against real archives/filesystem, without a native SDK mock."""
+
+import hashlib
+import io
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("stage-cua-runtime.py")
+
+
+class DistributionTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.archive = self.root / "input.tgz"
+        self.output = self.root / "output"
+        self.cache = self.root / "cache"
+        self.manifest_path = self.root / "artifacts.json"
+
+    def prepare(self, architecture=b"\x0c\x00\x00\x01", extra=None, version="0.23.2"):
+        files = {
+            "package/package.json": json.dumps({"name": "@trycua/cua-driver", "version": version}).encode(),
+            "package/cua-driver": b"\xcf\xfa\xed\xfe" + architecture + bytes(24),
+            "package/index.js": b"export const version = '0.23.2';",
+        }
+        with tarfile.open(self.archive, "w:gz") as archive:
+            for name, data in files.items():
+                entry = tarfile.TarInfo(name)
+                entry.size = len(data)
+                archive.addfile(entry, io.BytesIO(data))
+            if extra:
+                archive.addfile(extra)
+        self.manifest = {
+            "driverVersion": "0.23.2", "target": "darwin-arm64",
+            "nativeCode": ["cua-driver"],
+            "artifacts": [{
+                "id": "fixture", "url": self.archive.as_uri(),
+                "sha256": hashlib.sha256(self.archive.read_bytes()).hexdigest(),
+                "destination": ".", "files": list(files),
+                "package": "@trycua/cua-driver", "version": "0.23.2",
+            }],
+        }
+        self.manifest_path.write_text(json.dumps(self.manifest))
+
+    def run_stage(self):
+        return subprocess.run([sys.executable, str(SCRIPT), "--target", "darwin-arm64",
+            "--manifest", str(self.manifest_path), "--out", str(self.output),
+            "--cache", str(self.cache)], capture_output=True, text=True)
+
+    def verify(self, signed=False):
+        return subprocess.run([sys.executable, str(SCRIPT), "--verify", str(self.output),
+            *(["--signed"] if signed else [])], capture_output=True, text=True)
+
+    def test_clean_stage_cache_and_signature_domains(self):
+        self.prepare()
+        result = self.run_stage()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.verify().returncode, 0)
+        self.archive.unlink()  # A verified archive cache is sufficient to rebuild.
+        self.assertEqual(self.run_stage().returncode, 0)
+        binary = self.output / "cua-driver"
+        binary.write_bytes(binary.read_bytes() + b"new-code-signature")
+        self.assertNotEqual(self.verify().returncode, 0)
+        self.assertEqual(self.verify(signed=True).returncode, 0)
+        (self.output / "index.js").write_text("corrupt")
+        self.assertNotEqual(self.verify(signed=True).returncode, 0)
+
+    def test_corrupt_download_and_cache_fail_before_extraction(self):
+        self.prepare()
+        self.assertEqual(self.run_stage().returncode, 0)
+        expected = (self.output / "payload.json").read_bytes()
+        cached = self.cache / self.manifest["artifacts"][0]["sha256"]
+        cached.write_bytes(b"corrupt")
+        result = self.run_stage()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("integrity mismatch", result.stderr)
+        self.assertEqual((self.output / "payload.json").read_bytes(), expected)
+        cached.unlink()
+        self.archive.write_bytes(b"corrupt download")
+        self.assertNotEqual(self.run_stage().returncode, 0)
+
+    def test_wrong_version_and_architecture_fail(self):
+        for options in [{"version": "0.23.1"}, {"architecture": b"\x07\x00\x00\x01"}]:
+            with self.subTest(options=options):
+                self.prepare(**options)
+                self.assertNotEqual(self.run_stage().returncode, 0)
+                self.assertFalse(self.output.exists())
+
+    def test_links_and_traversal_are_rejected_before_any_output(self):
+        for name, kind in [("../../outside", tarfile.REGTYPE), ("package/link", tarfile.SYMTYPE), ("package/hardlink", tarfile.LNKTYPE), ("/absolute", tarfile.REGTYPE)]:
+            with self.subTest(name=name):
+                entry = tarfile.TarInfo(name)
+                entry.type = kind
+                entry.linkname = "../../outside"
+                self.prepare(extra=entry)
+                self.assertNotEqual(self.run_stage().returncode, 0)
+                self.assertFalse(self.output.exists())
+
+    def test_missing_selected_resource_and_packaged_symlink_fail(self):
+        self.prepare()
+        self.manifest["artifacts"][0]["files"].append("package/missing")
+        self.manifest_path.write_text(json.dumps(self.manifest))
+        self.assertNotEqual(self.run_stage().returncode, 0)
+        self.prepare()
+        self.assertEqual(self.run_stage().returncode, 0)
+        (self.output / "index.js").unlink()
+        (self.output / "index.js").symlink_to(self.manifest_path)
+        self.assertNotEqual(self.verify(signed=True).returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/turbo/apps/desktop/scripts/test-cua-distribution.py
+++ b/turbo/apps/desktop/scripts/test-cua-distribution.py
@@ -3,6 +3,7 @@
 import hashlib
 import io
 import json
+import os
 import subprocess
 import sys
 import tarfile
@@ -12,25 +13,17 @@ from pathlib import Path
 
 SCRIPT = Path(__file__).with_name("stage-cua-runtime.py")
 
-# Replace only the external HTTPS transport in a fresh CLI process. Archive
+# Replace only the external curl executable in a fresh CLI process. Archive
 # verification, extraction, cache writes, and output publication stay real.
 HTTPS_FIXTURE = """
-import http.client, runpy, sys
+import json, os, sys
 from pathlib import Path
-from types import SimpleNamespace
-data = Path(sys.argv.pop(1)).read_bytes()
-class FixtureConnection:
-    def __init__(self, host, timeout):
-        assert host == 'github.com'
-    def request(self, method, target):
-        assert method == 'GET'
-    def getresponse(self):
-        return SimpleNamespace(status=200, read=lambda: data)
-    def close(self):
-        pass
-http.client.HTTPSConnection = FixtureConnection
-sys.argv.pop(0)
-runpy.run_path(sys.argv[0], run_name='__main__')
+assert sys.argv[sys.argv.index('--proto') + 1] == '=https'
+assert '--insecure' not in sys.argv and '-k' not in sys.argv
+assert '--location' not in sys.argv
+Path(sys.argv[sys.argv.index('--output') + 1]).write_bytes(Path(os.environ['CUA_TEST_DOWNLOAD']).read_bytes())
+redirect = os.environ.get('CUA_TEST_REDIRECT', '')
+print(json.dumps({'http_code': 302 if redirect else 200, 'redirect_url': redirect}))
 """
 
 
@@ -72,13 +65,20 @@ class DistributionTest(unittest.TestCase):
         self.cache.mkdir(exist_ok=True)
         (self.cache / self.manifest["artifacts"][0]["sha256"]).write_bytes(self.archive.read_bytes())
 
-    def run_stage(self, fixture_transport=False):
-        program = [sys.executable]
+    def run_stage(self, fixture_transport=False, redirect=None):
+        environment = dict(os.environ)
         if fixture_transport:
-            program.extend(["-c", HTTPS_FIXTURE, str(self.archive)])
-        return subprocess.run([*program, str(SCRIPT), "--target", "darwin-arm64",
+            binary = self.root / "bin/curl"
+            binary.parent.mkdir(exist_ok=True)
+            binary.write_text(f"#!{sys.executable}\n" + HTTPS_FIXTURE)
+            binary.chmod(0o755)
+            environment["PATH"] = str(binary.parent) + os.pathsep + environment["PATH"]
+            environment["CUA_TEST_DOWNLOAD"] = str(self.archive)
+            if redirect is not None:
+                environment["CUA_TEST_REDIRECT"] = redirect
+        return subprocess.run([sys.executable, str(SCRIPT), "--target", "darwin-arm64",
             "--manifest", str(self.manifest_path), "--out", str(self.output),
-            "--cache", str(self.cache)], capture_output=True, text=True)
+            "--cache", str(self.cache)], capture_output=True, text=True, env=environment)
 
     def verify(self, signed=False):
         return subprocess.run([sys.executable, str(SCRIPT), "--verify", str(self.output),
@@ -125,6 +125,16 @@ class DistributionTest(unittest.TestCase):
                 artifact["url"] = url
                 self.manifest_path.write_text(json.dumps(self.manifest))
                 result = self.run_stage()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("official HTTPS host", result.stderr)
+                self.assertFalse(self.output.exists())
+
+    def test_download_rejects_local_insecure_and_untrusted_redirects(self):
+        for url in [self.archive.as_uri(), "http://github.com/input.tgz", "https://untrusted.invalid/input.tgz"]:
+            with self.subTest(url=url):
+                self.prepare()
+                (self.cache / self.manifest["artifacts"][0]["sha256"]).unlink()
+                result = self.run_stage(fixture_transport=True, redirect=url)
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn("official HTTPS host", result.stderr)
                 self.assertFalse(self.output.exists())

--- a/turbo/apps/desktop/scripts/test-cua-distribution.py
+++ b/turbo/apps/desktop/scripts/test-cua-distribution.py
@@ -12,6 +12,27 @@ from pathlib import Path
 
 SCRIPT = Path(__file__).with_name("stage-cua-runtime.py")
 
+# Replace only the external HTTPS transport in a fresh CLI process. Archive
+# verification, extraction, cache writes, and output publication stay real.
+HTTPS_FIXTURE = """
+import http.client, runpy, sys
+from pathlib import Path
+from types import SimpleNamespace
+data = Path(sys.argv.pop(1)).read_bytes()
+class FixtureConnection:
+    def __init__(self, host, timeout):
+        assert host == 'github.com'
+    def request(self, method, target):
+        assert method == 'GET'
+    def getresponse(self):
+        return SimpleNamespace(status=200, read=lambda: data)
+    def close(self):
+        pass
+http.client.HTTPSConnection = FixtureConnection
+sys.argv.pop(0)
+runpy.run_path(sys.argv[0], run_name='__main__')
+"""
+
 
 class DistributionTest(unittest.TestCase):
     def setUp(self):
@@ -40,16 +61,22 @@ class DistributionTest(unittest.TestCase):
             "driverVersion": "0.23.2", "target": "darwin-arm64",
             "nativeCode": ["cua-driver"],
             "artifacts": [{
-                "id": "fixture", "url": self.archive.as_uri(),
+                "id": "fixture", "url": "https://github.com/trycua/cua/releases/download/test/input.tgz",
                 "sha256": hashlib.sha256(self.archive.read_bytes()).hexdigest(),
                 "destination": ".", "files": list(files),
                 "package": "@trycua/cua-driver", "version": "0.23.2",
             }],
         }
         self.manifest_path.write_text(json.dumps(self.manifest))
+        # Fixture bytes enter through the real content-addressed archive cache.
+        self.cache.mkdir(exist_ok=True)
+        (self.cache / self.manifest["artifacts"][0]["sha256"]).write_bytes(self.archive.read_bytes())
 
-    def run_stage(self):
-        return subprocess.run([sys.executable, str(SCRIPT), "--target", "darwin-arm64",
+    def run_stage(self, fixture_transport=False):
+        program = [sys.executable]
+        if fixture_transport:
+            program.extend(["-c", HTTPS_FIXTURE, str(self.archive)])
+        return subprocess.run([*program, str(SCRIPT), "--target", "darwin-arm64",
             "--manifest", str(self.manifest_path), "--out", str(self.output),
             "--cache", str(self.cache)], capture_output=True, text=True)
 
@@ -83,7 +110,24 @@ class DistributionTest(unittest.TestCase):
         self.assertEqual((self.output / "payload.json").read_bytes(), expected)
         cached.unlink()
         self.archive.write_bytes(b"corrupt download")
-        self.assertNotEqual(self.run_stage().returncode, 0)
+        result = self.run_stage(fixture_transport=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("integrity mismatch", result.stderr)
+        self.assertFalse(cached.exists())
+        self.assertEqual((self.output / "payload.json").read_bytes(), expected)
+
+    def test_download_rejects_local_insecure_and_untrusted_urls(self):
+        for url in [self.archive.as_uri(), "http://github.com/input.tgz", "https://untrusted.invalid/input.tgz"]:
+            with self.subTest(url=url):
+                self.prepare()
+                artifact = self.manifest["artifacts"][0]
+                (self.cache / artifact["sha256"]).unlink()
+                artifact["url"] = url
+                self.manifest_path.write_text(json.dumps(self.manifest))
+                result = self.run_stage()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("official HTTPS host", result.stderr)
+                self.assertFalse(self.output.exists())
 
     def test_wrong_version_and_architecture_fail(self):
         for options in [{"version": "0.23.1"}, {"architecture": b"\x07\x00\x00\x01"}]:

--- a/turbo/apps/desktop/src/cua-distribution.test.ts
+++ b/turbo/apps/desktop/src/cua-distribution.test.ts
@@ -1,0 +1,12 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { expect, it } from "vitest";
+
+it("stages only verified runtime archives and validates packaged integrity across signing", () => {
+  const result = spawnSync(
+    "python3",
+    [path.join(__dirname, "../scripts/test-cua-distribution.py")],
+    { encoding: "utf8" },
+  );
+  expect(result.status, result.stderr).toBe(0);
+});

--- a/turbo/apps/desktop/src/cua-host-probe.ts
+++ b/turbo/apps/desktop/src/cua-host-probe.ts
@@ -1,0 +1,39 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { CuaEmbeddedRuntime } from "./cua-runtime";
+
+/** Runs in the packaged Electron main, after app.whenReady(). No TCC prompts. */
+export async function runCuaHostProbe(
+  runtime: CuaEmbeddedRuntime,
+  capture: boolean,
+  userData: string,
+) {
+  try {
+    const ready = await runtime.start();
+    const permissions = await runtime.probe(capture);
+    if (permissions.screenshot) {
+      const directory = path.join(userData, "cua-host-probe");
+      await mkdir(directory, { recursive: true, mode: 0o700 });
+      await writeFile(
+        path.join(directory, "screenshot.png"),
+        Buffer.from(permissions.screenshot, "base64"),
+        { mode: 0o600 },
+      );
+    }
+    await runtime.stop();
+    return {
+      ...ready,
+      accessibility: permissions.accessibility,
+      screenRecording: permissions.screenRecording,
+      attribution: permissions.attribution,
+      capture: permissions.screenshot
+        ? "success"
+        : capture
+          ? "permission_denied"
+          : "not_requested",
+      cleanup: "confirmed",
+    };
+  } finally {
+    await runtime.dispose();
+  }
+}

--- a/turbo/apps/desktop/src/cua-runtime-files.ts
+++ b/turbo/apps/desktop/src/cua-runtime-files.ts
@@ -1,0 +1,111 @@
+import { createHash } from "node:crypto";
+import { lstat, readFile, realpath } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import artifacts from "../cua/artifacts.json";
+import type {
+  CuaDriver,
+  EmbeddedCuaDriverHost,
+  EmbeddedDriverHostOptions,
+  EmbeddedDriverHostState,
+  EmbeddedPermissionMode,
+} from "@trycua/cua-driver";
+
+export interface CuaSdk {
+  readonly standardPermissionMode: EmbeddedPermissionMode;
+  readonly stoppedState: EmbeddedDriverHostState;
+  createHost(
+    options: EmbeddedDriverHostOptions,
+  ): Pick<
+    EmbeddedCuaDriverHost,
+    "start" | "stop" | "state" | "waitForExit" | "uniffiDestroy"
+  >;
+  connect(
+    socket: string,
+  ): Pick<
+    CuaDriver,
+    | "metadata"
+    | "callTool"
+    | "startSession"
+    | "endSession"
+    | "getDesktopState"
+    | "uniffiDestroy"
+  >;
+}
+
+let sdkLoadAttempted = false;
+
+export function assertCuaDormant(): void {
+  if (sdkLoadAttempted)
+    throw new Error("Default Desktop startup attempted to load CUA");
+}
+
+/** Only called by explicit host start, never while importing Desktop modules. */
+export async function loadPackagedCuaSdk(runtimeRoot: string) {
+  sdkLoadAttempted = true;
+  const root = await realpath(runtimeRoot);
+  const payload: unknown = JSON.parse(
+    await readFile(path.join(root, "payload.json"), "utf8"),
+  );
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    !("driverVersion" in payload) ||
+    payload.driverVersion !== artifacts.driverVersion ||
+    !("files" in payload) ||
+    !payload.files ||
+    typeof payload.files !== "object"
+  )
+    throw new Error("CUA payload manifest is incompatible");
+
+  const expectedFiles = artifacts.artifacts.flatMap((artifact) =>
+    artifact.files.map((file) =>
+      path.join(
+        artifact.destination,
+        artifact.destination === "." ? file : file.slice("package/".length),
+      ),
+    ),
+  );
+  for (const file of expectedFiles) {
+    const absolute = path.join(root, file);
+    if (
+      !(await lstat(absolute)).isFile() ||
+      (await realpath(absolute)) !== absolute
+    )
+      throw new Error("CUA payload contains an external or non-file resource");
+    // Upstream hashes describe pre-sign bytes. Native code is validated by the
+    // app signature/macOS loader after signing, then by the live SDK handshake.
+    if (artifacts.nativeCode.includes(file)) continue;
+    const expected: unknown = Reflect.get(payload.files, file);
+    const actual = createHash("sha256")
+      .update(await readFile(absolute))
+      .digest("hex");
+    if (actual !== expected) throw new Error("CUA payload integrity mismatch");
+  }
+
+  process.env.CUA_DRIVER_RS_TELEMETRY_ENABLED = "0";
+  process.env.CUA_TELEMETRY_ENABLED = "0";
+  // Keep import() native in the CJS main bundle: CUA is ESM and resolves its
+  // own .node/dylib through package-relative paths outside root node_modules.
+  const sdk: typeof import("@trycua/cua-driver") = await import(
+    pathToFileURL(
+      path.join(root, "node_modules/@trycua/cua-driver/dist/index.js"),
+    ).href
+  );
+  return {
+    standardPermissionMode: sdk.EmbeddedPermissionMode.Standard,
+    stoppedState: sdk.EmbeddedDriverHostState.Stopped,
+    createHost(options) {
+      const host = sdk.EmbeddedCuaDriverHost.withOptions(options);
+      if (!sdk.EmbeddedCuaDriverHost.instanceOf(host))
+        throw new Error("Invalid CUA host object");
+      return host;
+    },
+    connect(socket) {
+      const client = sdk.CuaDriver.connect(socket);
+      if (!sdk.CuaDriver.instanceOf(client))
+        throw new Error("Invalid CUA client object");
+      return client;
+    },
+  } satisfies CuaSdk;
+}

--- a/turbo/apps/desktop/src/cua-runtime.test.ts
+++ b/turbo/apps/desktop/src/cua-runtime.test.ts
@@ -1,0 +1,475 @@
+import { stat, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  DriverMetadata,
+  EmbeddedDriverConnection,
+  EmbeddedDriverExit,
+} from "@trycua/cua-driver";
+import { CuaEmbeddedRuntime } from "./cua-runtime";
+import { assertCuaDormant, type CuaSdk } from "./cua-runtime-files";
+import { runCuaHostProbe } from "./cua-host-probe";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+// Only the external SDK/process boundary is replaced. The owner, deadlines,
+// filesystem, host probe, and all generation/retirement logic remain real.
+function externalSdk() {
+  const events: string[] = [];
+  const active = new Set<number>();
+  const entered = deferred<void>();
+  const captureEntered = deferred<void>();
+  const sessions = new Set<string>();
+  const hosts: Array<{
+    connection: EmbeddedDriverConnection;
+    exit: ReturnType<typeof deferred<EmbeddedDriverExit>>;
+    directory: string;
+  }> = [];
+  let startGate: Promise<void> = Promise.resolve();
+  let stopGate: Promise<void> = Promise.resolve();
+  let metadataGate: Promise<void> = Promise.resolve();
+  let captureGate: Promise<void> = Promise.resolve();
+  let editMetadata = (value: DriverMetadata) => value;
+  let editConnection = (value: EmbeddedDriverConnection) => value;
+  let granted = false;
+  let clientDestroyed = false;
+  const sdk: CuaSdk = {
+    standardPermissionMode: 0,
+    stoppedState: 0,
+    createHost(options) {
+      expect(options.permissionMode).toBe(0);
+      expect(options.dangerouslyBypassApprovals).toBe(false);
+      expect(options.environment).toEqual([
+        { name: "CUA_DRIVER_RS_TELEMETRY_ENABLED", value: "0" },
+        { name: "CUA_TELEMETRY_ENABLED", value: "0" },
+        {
+          name: "HOME",
+          value: options.socketPath!.slice(0, -"/driver.sock".length),
+        },
+      ]);
+      expect(options.inheritStderr).toBe(false);
+      const id = hosts.length + 1;
+      const connection: EmbeddedDriverConnection = {
+        socketPath: options.socketPath!,
+        pid: id,
+        generation: `native-${id}`,
+        driverVersion: "0.23.2",
+        contractVersion: "contract",
+        mcpProtocolVersion: "mcp",
+        mcp: { command: options.binaryPath, args: [], environment: [] },
+      };
+      const exit = deferred<EmbeddedDriverExit>();
+      let state = 0;
+      hosts.push({
+        connection,
+        exit,
+        directory: connection.socketPath.slice(0, -"/driver.sock".length),
+      });
+      return {
+        async start() {
+          active.add(id);
+          state = 1;
+          events.push(`start-${id}`);
+          entered.resolve();
+          await startGate;
+          state = 2;
+          return editConnection(connection);
+        },
+        async stop() {
+          events.push(`stop-${id}`);
+          await startGate;
+          await stopGate;
+          active.delete(id);
+          state = 0;
+          exit.resolve({
+            generation: connection.generation,
+            success: true,
+            code: 0,
+          });
+        },
+        state: () => state,
+        waitForExit: () => exit.promise,
+        uniffiDestroy: () => {
+          events.push(`destroy-host-${id}`);
+        },
+      };
+    },
+    connect(socket) {
+      const host = hosts.find((item) => item.connection.socketPath === socket);
+      if (!host) throw new Error("Not a host-owned connection");
+      return {
+        async metadata() {
+          await metadataGate;
+          return editMetadata({
+            ...host.connection,
+            embedded: true,
+            hostBundleId: "ai.okou.desktop",
+            toolsListSchemaVersion: "tools",
+            capabilityVersion: "capabilities",
+          });
+        },
+        async callTool(name, args) {
+          expect(name).toBe("check_permissions");
+          expect(JSON.parse(args)).toEqual({
+            prompt: false,
+            probe_direct_capture: false,
+          });
+          return {
+            text: "",
+            images: [],
+            isError: false,
+            degraded: false,
+            rawJson: "{}",
+            structuredJson: JSON.stringify({
+              accessibility: granted,
+              screen_recording: granted,
+              source: { attribution: "host" },
+            }),
+          };
+        },
+        async startSession({ session }) {
+          if (!granted || !session)
+            throw new Error("Unexpected session allocation without capture");
+          sessions.add(session);
+          return {
+            active: true,
+            revived: false,
+            state: {
+              session,
+              captureScope: 0,
+              effectiveScope: 1,
+              desktopCaptureAuthorized: true,
+              desktopUnlocked: true,
+            },
+          };
+        },
+        async endSession({ session }) {
+          if (!session) throw new Error("Missing host session");
+          sessions.delete(session);
+          events.push("end-session");
+          return { session, active: false };
+        },
+        async getDesktopState({ session }) {
+          if (!session || !sessions.has(session))
+            throw new Error("Unowned capture session");
+          captureEntered.resolve();
+          await captureGate;
+          return {
+            text: "",
+            images: [{ mimeType: "image/png", dataBase64: "iVBORw0KGgo=" }],
+            isError: false,
+            degraded: false,
+            rawJson: "{}",
+          };
+        },
+        uniffiDestroy() {
+          clientDestroyed = true;
+          events.push(`destroy-client-${host.connection.pid}`);
+        },
+      };
+    },
+  };
+  return {
+    sdk,
+    events,
+    active,
+    hosts,
+    entered,
+    captureEntered,
+    sessions,
+    delayStart: (gate: Promise<void>) => {
+      startGate = gate;
+    },
+    delayStop: (gate: Promise<void>) => {
+      stopGate = gate;
+    },
+    delayMetadata: (gate: Promise<void>) => {
+      metadataGate = gate;
+    },
+    delayCapture: (gate: Promise<void>) => {
+      captureGate = gate;
+    },
+    metadata: (edit: typeof editMetadata) => {
+      editMetadata = edit;
+    },
+    connection: (edit: typeof editConnection) => {
+      editConnection = edit;
+    },
+    grant: () => {
+      granted = true;
+    },
+    clientDestroyed: () => clientDestroyed,
+  };
+}
+
+const runtimes: CuaEmbeddedRuntime[] = [];
+function runtime(external = externalSdk(), deadlineMs = 1_000) {
+  const owner = new CuaEmbeddedRuntime({
+    runtimeRoot: "/packaged/cua",
+    hostBundleId: "ai.okou.desktop",
+    loadSdk: async () => external.sdk,
+    deadlineMs,
+  });
+  runtimes.push(owner);
+  return { owner, external };
+}
+afterEach(async () => {
+  await Promise.allSettled(runtimes.splice(0).map((item) => item.dispose()));
+});
+
+describe("embedded CUA host lifecycle", () => {
+  it("is dormant until explicit start and coalesces concurrent starts", async () => {
+    assertCuaDormant();
+    const { owner, external } = runtime();
+    expect(external.active.size).toBe(0);
+    const first = owner.start();
+    expect(owner.start()).toBe(first);
+    expect(await first).toEqual({ generation: 1, driverVersion: "0.23.2" });
+    expect(external.active.size).toBe(1);
+    expect((await stat(external.hosts[0]!.directory)).mode & 0o777).toBe(0o700);
+    await Promise.all([owner.stop(), owner.stop()]);
+    expect(external.active.size).toBe(0);
+    expect(external.events.indexOf("destroy-client-1")).toBeLessThan(
+      external.events.indexOf("stop-1"),
+    );
+    expect(external.events.at(-1)).toBe("destroy-host-1");
+    expect(owner.getState().generation).toBeNull();
+    expect(await owner.start()).toMatchObject({ generation: 2 });
+  });
+
+  it("retires a start before an asynchronously loaded SDK can allocate a child", async () => {
+    const external = externalSdk();
+    const load = deferred<CuaSdk>();
+    const owner = new CuaEmbeddedRuntime({
+      runtimeRoot: "/packaged/cua",
+      hostBundleId: "ai.okou.desktop",
+      loadSdk: () => load.promise,
+    });
+    runtimes.push(owner);
+    const start = owner.start();
+    const rejected = expect(start).rejects.toThrow("CUA startup failed");
+    const stop = owner.stop();
+    load.resolve(external.sdk);
+    await Promise.all([rejected, stop]);
+    expect(external.active.size).toBe(0);
+    expect(external.hosts).toHaveLength(0);
+  });
+
+  it("owns a cancelled native start through its late connection and reaping", async () => {
+    const { owner, external } = runtime();
+    const gate = deferred<void>();
+    external.delayStart(gate.promise);
+    const start = expect(owner.start()).rejects.toThrow("CUA startup failed");
+    await external.entered.promise;
+    const stop = owner.stop();
+    await expect(owner.start()).rejects.toThrow("retirement is unproven");
+    expect(external.active.size).toBe(1);
+    gate.resolve();
+    await Promise.all([start, stop]);
+    expect(external.active.size).toBe(0);
+    expect(owner.getState().generation).toBeNull();
+  });
+
+  it.each([
+    ["version", (m: DriverMetadata) => ({ ...m, driverVersion: "0.23.3" })],
+    ["pid", (m: DriverMetadata) => ({ ...m, pid: 987 })],
+    ["embedding", (m: DriverMetadata) => ({ ...m, embedded: false })],
+    [
+      "identity",
+      (m: DriverMetadata) => ({ ...m, hostBundleId: "com.trycua.driver" }),
+    ],
+    [
+      "protocol",
+      (m: DriverMetadata) => ({ ...m, mcpProtocolVersion: "incompatible" }),
+    ],
+  ] as const)(
+    "rejects incompatible %s metadata and cleans up",
+    async (_name, edit) => {
+      const { owner, external } = runtime();
+      external.metadata(edit);
+      await expect(owner.start()).rejects.toThrow("CUA startup failed");
+      await owner.stop();
+      expect(external.active.size).toBe(0);
+      expect(external.clientDestroyed()).toBe(true);
+    },
+  );
+
+  it("enforces the exact connection version even if the client metadata is pinned", async () => {
+    const { owner, external } = runtime();
+    external.connection((value) => ({ ...value, driverVersion: "0.23.1" }));
+    await expect(owner.start()).rejects.toThrow("CUA startup failed");
+    await owner.stop();
+    expect(external.active.size).toBe(0);
+  });
+
+  it("rejects metadata arriving after stop without publishing readiness", async () => {
+    const { owner, external } = runtime();
+    const gate = deferred<void>();
+    external.delayMetadata(gate.promise);
+    const start = expect(owner.start()).rejects.toThrow("CUA startup failed");
+    await external.entered.promise;
+    const stop = owner.stop();
+    gate.resolve();
+    await Promise.all([start, stop]);
+    expect(owner.getState().phase).not.toBe("ready");
+    expect(external.active.size).toBe(0);
+  });
+
+  it("a caller shutdown timeout retains ownership until the delayed exit is confirmed", async () => {
+    const { owner, external } = runtime(externalSdk(), 30);
+    await owner.start();
+    const stop = deferred<void>();
+    external.delayStop(stop.promise);
+    await expect(owner.stop()).rejects.toThrow("replacement remains blocked");
+    await expect(owner.start()).rejects.toThrow("retirement is unproven");
+    expect(external.active.size).toBe(1);
+    stop.resolve();
+    await owner.stop();
+    expect(external.active.size).toBe(0);
+    await owner.start();
+    expect(external.hosts).toHaveLength(2);
+  });
+
+  it("a startup deadline cannot create a replacement for an unresolved native start", async () => {
+    const { owner, external } = runtime(externalSdk(), 30);
+    const gate = deferred<void>();
+    external.delayStart(gate.promise);
+    await expect(owner.start()).rejects.toThrow("CUA startup failed");
+    await expect(owner.start()).rejects.toThrow("retirement is unproven");
+    gate.resolve();
+    await owner.stop();
+    expect(external.active.size).toBe(0);
+  });
+
+  it("retains failed native stop ownership and never automatically falls back or restarts", async () => {
+    const { owner, external } = runtime(externalSdk(), 30);
+    await owner.start();
+    const stop = deferred<void>();
+    external.delayStop(stop.promise);
+    const pending = expect(owner.stop()).rejects.toThrow(
+      "replacement remains blocked",
+    );
+    stop.reject(new Error("unreaped"));
+    await pending;
+    await expect(owner.start()).rejects.toThrow("retirement is unproven");
+    expect(external.hosts).toHaveLength(1);
+    // The external process eventually exits, but failed stop proof remains blocked.
+    external.active.clear();
+    external.hosts[0]!.exit.resolve({ generation: "native-1", success: false });
+  });
+
+  it("invalidates an unexpected exit and requires an explicit new start", async () => {
+    const { owner, external } = runtime();
+    await owner.start();
+    external.hosts[0]!.exit.resolve({
+      generation: "native-1",
+      success: false,
+      code: 1,
+    });
+    await external.hosts[0]!.exit.promise;
+    await owner.stop();
+    expect(owner.getState().error).toBe("cua_unexpected_exit");
+    expect(external.active.size).toBe(0);
+    expect(external.hosts).toHaveLength(1);
+    await owner.start();
+    expect(owner.getState().generation).toBe(2);
+  });
+
+  it("rejects an exit observer for a different generation", async () => {
+    const { owner, external } = runtime(externalSdk(), 30);
+    await owner.start();
+    external.hosts[0]!.exit.resolve({ generation: "stale", success: true });
+    await expect(owner.stop()).rejects.toThrow("replacement remains blocked");
+    await expect(owner.start()).rejects.toThrow("retirement is unproven");
+    expect(external.hosts).toHaveLength(1);
+  });
+
+  it("reports missing runtime files only on explicit start", async () => {
+    const owner = new CuaEmbeddedRuntime({
+      runtimeRoot: "/missing-cua-payload",
+      hostBundleId: "ai.okou.desktop",
+    });
+    runtimes.push(owner);
+    expect(owner.getState().phase).toBe("stopped");
+    await expect(owner.start()).rejects.toThrow("CUA startup failed");
+    await owner.stop();
+    expect(owner.getState().generation).toBeNull();
+  });
+
+  it("the host probe completes metadata/cleanup without TCC grants or screenshots", async () => {
+    const { owner, external } = runtime();
+    expect(
+      await runCuaHostProbe(owner, false, "/unused-probe-output"),
+    ).toMatchObject({
+      driverVersion: "0.23.2",
+      attribution: "host",
+      accessibility: false,
+      screenRecording: false,
+      capture: "not_requested",
+      cleanup: "confirmed",
+    });
+    expect(external.active.size).toBe(0);
+    await expect(owner.start()).rejects.toThrow("disposed");
+  });
+
+  it("explicit capture with missing TCC grants reports permission denial and cleans up", async () => {
+    const { owner, external } = runtime();
+    expect(
+      await runCuaHostProbe(owner, true, "/unused-probe-output"),
+    ).toMatchObject({ capture: "permission_denied", cleanup: "confirmed" });
+    expect(external.active.size).toBe(0);
+  });
+
+  it("a granted host probe owns its explicit session and local image through cleanup", async () => {
+    const { owner, external } = runtime();
+    external.grant();
+    const directory = await mkdtemp(path.join(tmpdir(), "cua-probe-test-"));
+    try {
+      const result = await runCuaHostProbe(owner, true, directory);
+      expect(result).toMatchObject({
+        capture: "success",
+        cleanup: "confirmed",
+      });
+      expect(JSON.stringify(result)).not.toContain("iVBOR");
+      expect(
+        await readFile(path.join(directory, "cua-host-probe/screenshot.png")),
+      ).toEqual(Buffer.from("iVBORw0KGgo=", "base64"));
+      expect(external.sessions.size).toBe(0);
+      expect(external.active.size).toBe(0);
+      expect(external.events.indexOf("end-session")).toBeLessThan(
+        external.events.indexOf("destroy-client-1"),
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("a stopped probe cannot publish a late screenshot or overlap its client cleanup", async () => {
+    const { owner, external } = runtime(externalSdk(), 30);
+    external.grant();
+    await owner.start();
+    const gate = deferred<void>();
+    external.delayCapture(gate.promise);
+    const probe = expect(owner.probe(true)).rejects.toThrow(
+      "CUA host probe failed",
+    );
+    await external.captureEntered.promise;
+    await expect(owner.stop()).rejects.toThrow("replacement remains blocked");
+    await expect(owner.start()).rejects.toThrow("retirement is unproven");
+    expect(external.clientDestroyed()).toBe(false);
+    gate.resolve();
+    await probe;
+    await owner.stop();
+    expect(external.sessions.size).toBe(0);
+    expect(external.active.size).toBe(0);
+  });
+});

--- a/turbo/apps/desktop/src/cua-runtime.ts
+++ b/turbo/apps/desktop/src/cua-runtime.ts
@@ -1,0 +1,330 @@
+import { chmod, mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import type {
+  DriverMetadata,
+  EmbeddedDriverConnection,
+  EmbeddedDriverExit,
+} from "@trycua/cua-driver";
+import artifacts from "../cua/artifacts.json";
+import { loadPackagedCuaSdk, type CuaSdk } from "./cua-runtime-files";
+import { withComputerUseDeadline } from "./computer-use-lifecycle-deadline";
+
+interface CuaReadiness {
+  readonly generation: number;
+  readonly driverVersion: string;
+}
+
+interface Generation {
+  readonly id: number;
+  readonly abort: AbortController;
+  retired: boolean;
+  directory: string | null;
+  sdk: CuaSdk | null;
+  host: ReturnType<CuaSdk["createHost"]> | null;
+  client: ReturnType<CuaSdk["connect"]> | null;
+  connection: EmbeddedDriverConnection | null;
+  exit: Promise<EmbeddedDriverExit> | null;
+  initialization: Promise<CuaReadiness>;
+  startResult: Promise<CuaReadiness>;
+  retirement: Promise<void> | null;
+  probe: Promise<CuaProbeResult> | null;
+}
+
+interface CuaProbeResult {
+  readonly accessibility: boolean;
+  readonly screenRecording: boolean;
+  readonly attribution: "host";
+  readonly screenshot: string | null;
+}
+
+interface RuntimeOptions {
+  readonly runtimeRoot: string;
+  readonly hostBundleId: string;
+  /** External SDK boundary for deterministic fault injection. */
+  readonly loadSdk?: () => Promise<CuaSdk>;
+  readonly deadlineMs?: number;
+}
+
+/** Owns the real embedded daemon, without registering a partial command driver. */
+export class CuaEmbeddedRuntime {
+  private context: Generation | null = null;
+  private nextGeneration = 0;
+  private closed = false;
+  private phase: "stopped" | "starting" | "ready" | "retiring" | "error" =
+    "stopped";
+  private error: string | null = null;
+
+  constructor(private readonly options: RuntimeOptions) {}
+
+  getState() {
+    return {
+      phase: this.phase,
+      generation: this.context?.id ?? null,
+      driverVersion: artifacts.driverVersion,
+      error: this.error,
+    };
+  }
+
+  start(): Promise<CuaReadiness> {
+    if (this.closed)
+      return Promise.reject(new Error("CUA runtime is disposed"));
+    if (this.context)
+      return this.context.retired
+        ? Promise.reject(
+            new Error("CUA prior generation retirement is unproven"),
+          )
+        : this.context.startResult;
+
+    const context: Generation = {
+      id: ++this.nextGeneration,
+      abort: new AbortController(),
+      retired: false,
+      directory: null,
+      sdk: null,
+      host: null,
+      client: null,
+      connection: null,
+      exit: null,
+      retirement: null,
+      probe: null,
+      initialization: Promise.resolve().then(() => this.initialize(context)),
+      startResult: Promise.resolve().then(() => this.startGeneration(context)),
+    };
+    this.context = context;
+    this.phase = "starting";
+    this.error = null;
+    return context.startResult;
+  }
+
+  private async startGeneration(context: Generation): Promise<CuaReadiness> {
+    try {
+      return await withComputerUseDeadline(
+        context.initialization,
+        this.options.deadlineMs ?? 15_000,
+      );
+    } catch {
+      if (!context.retired) this.fail(context, "cua_start_failed");
+      throw new Error("CUA startup failed; generation cleanup remains owned");
+    }
+  }
+
+  private assertCurrent(context: Generation): void {
+    if (context.retired || this.context !== context)
+      throw new Error("CUA generation was retired");
+  }
+
+  private async initialize(context: Generation): Promise<CuaReadiness> {
+    const sdk = await (this.options.loadSdk?.() ??
+      loadPackagedCuaSdk(this.options.runtimeRoot));
+    this.assertCurrent(context);
+    context.sdk = sdk;
+    // A short, mode-0700 directory avoids macOS's Unix socket path limit and
+    // prevents other users from connecting to the host-owned endpoint.
+    context.directory = await mkdtemp("/tmp/okou-cua-");
+    await chmod(context.directory, 0o700);
+    this.assertCurrent(context);
+    context.host = sdk.createHost({
+      binaryPath: path.join(this.options.runtimeRoot, "cua-driver"),
+      hostBundleId: this.options.hostBundleId,
+      socketPath: path.join(context.directory, "driver.sock"),
+      startupTimeoutMs: 10_000n,
+      shutdownTimeoutMs: 2_000n,
+      permissionMode: sdk.standardPermissionMode,
+      approveCapabilityManifest: false,
+      approveSessionPolicy: false,
+      dangerouslyBypassApprovals: false,
+      environment: [
+        { name: "CUA_DRIVER_RS_TELEMETRY_ENABLED", value: "0" },
+        { name: "CUA_TELEMETRY_ENABLED", value: "0" },
+        // The released daemon reads history opt-in from HOME. A fresh child-only
+        // home prevents inheriting standalone CUA preferences or collecting history.
+        // The Electron host environment and macOS responsibility chain are unchanged.
+        { name: "HOME", value: context.directory },
+      ],
+      inheritStderr: false,
+      noOverlay: true,
+    });
+    const connection = await context.host.start();
+    context.connection = connection;
+    context.exit = context.host
+      .waitForExit(connection.generation)
+      .then((exit) => {
+        if (exit.generation !== connection.generation)
+          throw new Error("CUA exit generation mismatch");
+        if (!context.retired) this.fail(context, "cua_unexpected_exit");
+        return exit;
+      });
+    void context.exit.catch(() =>
+      this.fail(context, "cua_exit_observer_failed"),
+    );
+    this.assertCurrent(context);
+    context.client = sdk.connect(connection.socketPath);
+    const metadata = await context.client.metadata({
+      signal: context.abort.signal,
+    });
+    this.validateMetadata(context, connection, metadata);
+    this.assertCurrent(context);
+    this.phase = "ready";
+    return { generation: context.id, driverVersion: metadata.driverVersion };
+  }
+
+  private validateMetadata(
+    context: Generation,
+    connection: EmbeddedDriverConnection,
+    metadata: DriverMetadata,
+  ): void {
+    if (
+      connection.driverVersion !== artifacts.driverVersion ||
+      metadata.driverVersion !== artifacts.driverVersion ||
+      metadata.pid !== connection.pid ||
+      !metadata.embedded ||
+      metadata.hostBundleId !== this.options.hostBundleId ||
+      metadata.contractVersion !== connection.contractVersion ||
+      metadata.mcpProtocolVersion !== connection.mcpProtocolVersion ||
+      context.directory === null ||
+      connection.socketPath !== path.join(context.directory, "driver.sock")
+    )
+      throw new Error("CUA exact version or embedded metadata mismatch");
+  }
+
+  private fail(context: Generation, error: string): void {
+    if (this.context !== context) return;
+    this.error ??= error;
+    this.phase = "error";
+    void this.retire(context).catch(() => {
+      // A rejected stop/observer cannot release ownership or allow replacement.
+      if (this.context === context) this.error = "cua_cleanup_unproven";
+    });
+  }
+
+  private retire(context: Generation): Promise<void> {
+    context.retired = true;
+    context.abort.abort();
+    context.retirement ??= this.cleanup(context);
+    return context.retirement;
+  }
+
+  private async cleanup(context: Generation): Promise<void> {
+    // Cancel a native start immediately, while retaining its late result. Once
+    // connected, settle pending metadata before destroying its client.
+    const earlyStop =
+      context.host && !context.connection
+        ? context.host.stop()
+        : Promise.resolve();
+    const results = await Promise.allSettled([
+      context.initialization,
+      earlyStop,
+    ]);
+    if (results[1]?.status === "rejected")
+      throw new Error("CUA startup cancellation is unproven");
+    if (context.probe) await context.probe.catch(() => {});
+    context.client?.uniffiDestroy();
+    context.client = null;
+    if (context.host) {
+      await context.host.stop();
+      if (context.exit) await context.exit;
+      if (context.host.state() !== context.sdk?.stoppedState)
+        throw new Error("CUA process exit is unproven");
+      context.host.uniffiDestroy();
+    }
+    if (context.directory)
+      await rm(context.directory, { recursive: true, force: true });
+    if (this.context === context) {
+      this.context = null;
+      this.phase = this.error ? "error" : "stopped";
+    }
+  }
+
+  async stop(): Promise<void> {
+    const context = this.context;
+    if (!context) return;
+    this.phase = "retiring";
+    try {
+      await withComputerUseDeadline(
+        this.retire(context),
+        this.options.deadlineMs ?? 5_000,
+      );
+    } catch {
+      if (this.context === context) {
+        this.phase = "error";
+        this.error = "cua_cleanup_unproven";
+      }
+      throw new Error("CUA cleanup is unproven; replacement remains blocked");
+    }
+  }
+
+  dispose(): Promise<void> {
+    this.closed = true;
+    return this.stop();
+  }
+
+  /** Fixed host-only verification surface; never forwarded to IPC or agents. */
+  probe(capture: boolean): Promise<CuaProbeResult> {
+    const context = this.context;
+    if (!context || this.phase !== "ready" || context.retired)
+      return Promise.reject(new Error("CUA probe requires a ready generation"));
+    context.probe ??= this.inspect(context, capture);
+    return withComputerUseDeadline(
+      context.probe,
+      this.options.deadlineMs ?? 15_000,
+    ).catch(() => {
+      this.fail(context, "cua_probe_failed");
+      throw new Error("CUA host probe failed");
+    });
+  }
+
+  private async inspect(
+    context: Generation,
+    capture: boolean,
+  ): Promise<CuaProbeResult> {
+    const client = context.client;
+    if (!client) throw new Error("CUA client is unavailable");
+    const asyncOptions = { signal: context.abort.signal };
+    const result = await client.callTool(
+      "check_permissions",
+      '{"prompt":false,"probe_direct_capture":false}',
+      asyncOptions,
+    );
+    if (result.isError || !result.structuredJson)
+      throw new Error("CUA permission probe failed");
+    const data: unknown = JSON.parse(result.structuredJson);
+    if (
+      !data ||
+      typeof data !== "object" ||
+      !("accessibility" in data) ||
+      typeof data.accessibility !== "boolean" ||
+      !("screen_recording" in data) ||
+      typeof data.screen_recording !== "boolean" ||
+      !("source" in data) ||
+      !data.source ||
+      typeof data.source !== "object" ||
+      !("attribution" in data.source) ||
+      data.source.attribution !== "host"
+    )
+      throw new Error("CUA permission attribution is incompatible");
+    this.assertCurrent(context);
+    let screenshot: string | null = null;
+    if (capture && data.accessibility && data.screen_recording) {
+      const session = `okou-host-probe-${context.id}`;
+      // Own even a late/failed session creation until its explicit end settles.
+      try {
+        await client.startSession({ session }, asyncOptions);
+        this.assertCurrent(context);
+        const image = await client.getDesktopState({ session }, asyncOptions);
+        this.assertCurrent(context);
+        const png = image.images.find((item) => item.mimeType === "image/png");
+        if (image.isError || !png) throw new Error("CUA screenshot failed");
+        screenshot = png.dataBase64;
+      } finally {
+        await client.endSession({ session });
+      }
+    }
+    this.assertCurrent(context);
+    return {
+      accessibility: data.accessibility,
+      screenRecording: data.screen_recording,
+      attribution: "host",
+      screenshot,
+    };
+  }
+}

--- a/turbo/apps/desktop/src/desktop-environment-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-environment-entry-points.test.ts
@@ -281,7 +281,7 @@ function preparePackagedApp(
   mkdirSync(join(appBundlePath, "Contents", "MacOS"), { recursive: true });
   writeFileSync(
     executablePath,
-    `#!${process.execPath}\nrequire("node:fs").appendFileSync(process.env.TEST_TRACE_PATH, "${marker}\\n");\nconsole.log("[smoke-test] desktop main ready");\n`,
+    `#!${process.execPath}\nrequire("node:fs").appendFileSync(process.env.TEST_TRACE_PATH, "${marker}\\n");\nconsole.log("[smoke-test] desktop main ready\\n[smoke-test] cua dormant");\n`,
   );
   chmodSync(executablePath, 0o755);
   writeFileSync(join(resourcesPath, "app", "dist", "main.js"), "");

--- a/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
+++ b/turbo/apps/desktop/src/desktop-notarize-entry-points.test.ts
@@ -62,6 +62,11 @@ import { appendFileSync } from "node:fs";
 
 export async function sign(options) {
   appendFileSync(process.env.TEST_TRACE_PATH, "sign\\n");
+  const resourceRoot = process.env.TEST_EXPECTED_APP_PATH + "/Contents/Resources/cua/";
+  const expectedNestedCode = ["cua-driver", "cua-cursor-theme", "node_modules/@trycua/cua-driver-darwin-arm64/libcua_driver_sdk.dylib", "node_modules/@trycua/cua-driver-darwin-arm64/cua_driver_node_runtime.node"];
+  if (JSON.stringify(options.binaries) !== JSON.stringify(expectedNestedCode.map((name) => resourceRoot + name))) {
+    throw new Error("CUA nested code must be signed before the outer app");
+  }
   const signingOptionsAreUnchanged =
     options.app === process.env.TEST_EXPECTED_APP_PATH &&
     options.batchCodesignCalls === true &&

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -56,6 +56,9 @@ import { buildWindowOptions } from "./desktop-recorder-window-options";
 import { areaToGlobal } from "./desktop-recorder-overlay-geometry";
 import { createComputerUsePermissions } from "./computer-use-permissions";
 import { ComputerUseDriverController } from "./computer-use-driver";
+import { CuaEmbeddedRuntime } from "./cua-runtime";
+import { assertCuaDormant } from "./cua-runtime-files";
+import { runCuaHostProbe } from "./cua-host-probe";
 import { createComputerUseNativeBackend } from "./computer-use-native";
 import { resolveDesktopConfig } from "./config";
 import desktopBrandAssets from "./desktop-brand-assets.json";
@@ -149,6 +152,7 @@ let mainWindow: BrowserWindow | null = null;
 let appIsQuitting = false;
 let computerUseQuitPreparationPromise: Promise<void> | null = null;
 let computerUseQuitPreparationComplete = false;
+let cuaProbeRuntime: CuaEmbeddedRuntime | null = null;
 let desktopTray: DesktopTrayController | null = null;
 let keepAwakeController: DesktopKeepAwakeController | null = null;
 
@@ -1497,7 +1501,11 @@ if (!hasSingleInstanceLock) {
     if (!computerUseQuitPreparationPromise) {
       computerUseQuitPreparationPromise = (async () => {
         try {
-          await computerUseController.stopForQuit();
+          try {
+            await computerUseController.stopForQuit();
+          } finally {
+            await cuaProbeRuntime?.dispose();
+          }
         } catch (error) {
           console.error("Unable to prepare Computer Use for app quit", error);
         } finally {
@@ -1509,6 +1517,40 @@ if (!hasSingleInstanceLock) {
   });
 
   void app.whenReady().then(async () => {
+    if (process.env.OKOU_DESKTOP_CUA_PROBE === "1") {
+      if (
+        !app.isPackaged ||
+        process.platform !== "darwin" ||
+        process.arch !== "arm64"
+      ) {
+        writeSync(
+          2,
+          "[cua-probe] unsupported: packaged macOS arm64 host required\n",
+        );
+        app.exit(1);
+        return;
+      }
+      cuaProbeRuntime = new CuaEmbeddedRuntime({
+        runtimeRoot: path.join(process.resourcesPath, "cua"),
+        hostBundleId: config.identity.bundleId,
+      });
+      try {
+        const result = await runCuaHostProbe(
+          cuaProbeRuntime,
+          process.env.OKOU_DESKTOP_CUA_CAPTURE === "1",
+          app.getPath("userData"),
+        );
+        writeSync(1, `[cua-probe] ${JSON.stringify(result)}\n`);
+        app.exit(0);
+      } catch {
+        writeSync(
+          2,
+          `[cua-probe] ${JSON.stringify(cuaProbeRuntime.getState())}\n`,
+        );
+        app.exit(1);
+      }
+      return;
+    }
     applyDockIcon();
     hideDockForInactiveMainWindow();
     registerDesktopAuthProtocol();
@@ -1526,6 +1568,7 @@ if (!hasSingleInstanceLock) {
     queueDesktopAuthCallbackArgv(process.argv);
 
     if (isDesktopSmokeTestEnabled(process.env)) {
+      assertCuaDormant();
       desktopAuthSession.signOut();
       try {
         await verifyDesktopSmokeBridge();
@@ -1535,6 +1578,7 @@ if (!hasSingleInstanceLock) {
         return;
       }
       writeSync(1, `${DESKTOP_SMOKE_TEST_READY_MARKER}\n`);
+      writeSync(1, "[smoke-test] cua dormant\n");
       process.exit(0);
     }
 

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -74,7 +74,7 @@
         "oxlint",
         "tsup"
       ],
-      "ignoreBinaries": ["electron-forge", "oxlint", "tsup"]
+      "ignoreBinaries": ["electron-forge", "oxlint", "tsup", "python3"]
     },
     "packages/core": {
       "entry": [

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -525,6 +525,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@trycua/cua-driver':
+        specifier: 0.23.2
+        version: 0.23.2
       '@types/node':
         specifier: 24.3.0
         version: 24.3.0
@@ -4587,6 +4590,41 @@ packages:
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
+  '@trycua/cua-driver-darwin-arm64@0.23.2':
+    resolution: {integrity: sha512-gWNCPIhR5KOAcxjtybzLhyxwj5T9TjBP9qEyLA78zAVABnVsqUdTaJOBx+ba8Leo3ZNc8WtvHnJJ15gsrluvjg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@trycua/cua-driver-darwin-x64@0.23.2':
+    resolution: {integrity: sha512-2uGLvU/HhkSN0EQTEzbBUoTBriHbS2nskfMG+vi1KIfunuQS8OtHlI3ZsfDgD+P8s6BsoAoMpuWYAXiOZjlCkw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@trycua/cua-driver-linux-arm64-gnu@0.23.2':
+    resolution: {integrity: sha512-+lFr/hvPAKEgYYqrlAJYr/TwTcMAt63DZ9j/2TcC8BdrgZ9CAuzFvAvgK7LObexUpxAl2uJFGLJOA5m/aS95yA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@trycua/cua-driver-linux-x64-gnu@0.23.2':
+    resolution: {integrity: sha512-0sWPd4LkL1hqvsGqougwwZdufAOZxLosAE/Wwq7tBYOJuPbP+1jpGiyPdCrZrCejnlVrR440RAKs+0TsMxOcqw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@trycua/cua-driver-win32-arm64-msvc@0.23.2':
+    resolution: {integrity: sha512-ZRD1cxu2v9b23AUr3/o7AzHzPmHjrAYK9v24qsifSt9bw7nH5zrs81QuuO6WoaBzrUUCyOvEGLh38Tyb3cvEyw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@trycua/cua-driver-win32-x64-msvc@0.23.2':
+    resolution: {integrity: sha512-Ax0DobXvVSrOIaKWINIhW/VbWKfdCYoQ27M6zFsfHlNT1paXaJYCgiRmoZiVItcfCgsQBzU7Yth046Le0TDedw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@trycua/cua-driver@0.23.2':
+    resolution: {integrity: sha512-OQZGxEbiPO5wHuxROptGF8D9HDiN4R8M1E58TsUsq0pyQ73fkWpLrVY6JEo3ZnE9e+cgH7mG36NV1cqaXj8BTw==}
+
   '@turbo/darwin-64@2.10.12':
     resolution: {integrity: sha512-9nKgKoF6ZOUsM+or0OtNf+TTJSfGvDNP7ZFv/ZGWVwOSCkumyctQiTeHwB4UNljHTnC41AqylgbunLDHoccNrA==}
     cpu: [x64]
@@ -4958,6 +4996,56 @@ packages:
   '@typescript/typescript6@6.0.2':
     resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
     hasBin: true
+
+  '@ubjs/core@0.31.0-3':
+    resolution: {integrity: sha512-39XrJgUZ2VVb561sSnkXPhczNoeBsNiSRArecsV0JE7CJq69ajFkcn9/tBAUS2NpgHkLIDU+z6Ks2+1wXnboxg==}
+
+  '@ubjs/node-darwin-arm64@0.31.0-3':
+    resolution: {integrity: sha512-GGQVPLkVo4Gc8qVLW4IGvS8bjl8eHXyeP4a97ntGmsAdXwE5gsS29o8xUEFROjhwHKD+9sgVeblCSWVG3CpHsw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ubjs/node-darwin-x64@0.31.0-3':
+    resolution: {integrity: sha512-2sc47u4XFYOsbmP5EW+Gx8m/yGrYnfFDFQm6+kz7goSWTNg84eEiz3COs9HKJDVuNJ5Khv5XipTO8CFadMLXCw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ubjs/node-linux-arm64-gnu@0.31.0-3':
+    resolution: {integrity: sha512-YStVXhYz/5jvlWf/p4fhiVT72unYAbGugifFC9QmO/+hnroQDAQ5t8SARbsc15G4olMcamdIB+GETiUB7gmaYg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ubjs/node-linux-arm64-musl@0.31.0-3':
+    resolution: {integrity: sha512-Izp4nvfy/LmibzFowAztkoDOksCR2fb2zl6fh1ojR1HEsg0rAGruxtI8d3fn8DI0lBXwqmn6SF///oD4mFNJPQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@ubjs/node-linux-x64-gnu@0.31.0-3':
+    resolution: {integrity: sha512-Xdm21blyg5U/kW6s7OMvgrr8coGTkUlt26DVR9x8gKISif+E3YwdEskbFScWqystAiJnfjw7xHEc8UMu0Qlz7Q==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ubjs/node-linux-x64-musl@0.31.0-3':
+    resolution: {integrity: sha512-fFQ9BWS6i2LUH9SJgD9oEiKXXo/say59vHy7usFe1t7C2xvwvP34f5SuxXmWP9R8fHyA0aC4kIZ+TTwyHSv1Kw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@ubjs/node-win32-arm64-msvc@0.31.0-3':
+    resolution: {integrity: sha512-ID6rSz1NmPsWTNBBNAw4OnJ5Dj8pcbtNJtdPB3OxcGigLBd/e0x7buhSI7os6Mo5iYtEdCynBRQHFJwub5XSPg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ubjs/node-win32-x64-msvc@0.31.0-3':
+    resolution: {integrity: sha512-wevs+Y+szwcCUT8IJFbB4/1nfxyRv/51l8oG7FGUPWD1xLPyuHfJBG27C+PDeC7KRzes/2n6aLo4DGZbr/LYTw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@ubjs/node@0.31.0-3':
+    resolution: {integrity: sha512-qNMpi2LICNwxGXZyRF8fSDBSpbezyZbEsydrbiMPJOmtOWr4tmZIEl7jkWGHVGShoBvHfFo4eHp5B4UVP928Cg==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -13087,6 +13175,36 @@ snapshots:
 
   '@tootallnate/once@2.0.1': {}
 
+  '@trycua/cua-driver-darwin-arm64@0.23.2':
+    optional: true
+
+  '@trycua/cua-driver-darwin-x64@0.23.2':
+    optional: true
+
+  '@trycua/cua-driver-linux-arm64-gnu@0.23.2':
+    optional: true
+
+  '@trycua/cua-driver-linux-x64-gnu@0.23.2':
+    optional: true
+
+  '@trycua/cua-driver-win32-arm64-msvc@0.23.2':
+    optional: true
+
+  '@trycua/cua-driver-win32-x64-msvc@0.23.2':
+    optional: true
+
+  '@trycua/cua-driver@0.23.2':
+    dependencies:
+      '@ubjs/core': 0.31.0-3
+      '@ubjs/node': 0.31.0-3
+    optionalDependencies:
+      '@trycua/cua-driver-darwin-arm64': 0.23.2
+      '@trycua/cua-driver-darwin-x64': 0.23.2
+      '@trycua/cua-driver-linux-arm64-gnu': 0.23.2
+      '@trycua/cua-driver-linux-x64-gnu': 0.23.2
+      '@trycua/cua-driver-win32-arm64-msvc': 0.23.2
+      '@trycua/cua-driver-win32-x64-msvc': 0.23.2
+
   '@turbo/darwin-64@2.10.12':
     optional: true
 
@@ -13451,6 +13569,43 @@ snapshots:
   '@typescript/typescript6@6.0.2':
     dependencies:
       '@typescript/old': typescript@6.0.3
+
+  '@ubjs/core@0.31.0-3': {}
+
+  '@ubjs/node-darwin-arm64@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-darwin-x64@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-linux-arm64-gnu@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-linux-arm64-musl@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-linux-x64-gnu@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-linux-x64-musl@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-win32-arm64-msvc@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-win32-x64-msvc@0.31.0-3':
+    optional: true
+
+  '@ubjs/node@0.31.0-3':
+    optionalDependencies:
+      '@ubjs/node-darwin-arm64': 0.31.0-3
+      '@ubjs/node-darwin-x64': 0.31.0-3
+      '@ubjs/node-linux-arm64-gnu': 0.31.0-3
+      '@ubjs/node-linux-arm64-musl': 0.31.0-3
+      '@ubjs/node-linux-x64-gnu': 0.31.0-3
+      '@ubjs/node-linux-x64-musl': 0.31.0-3
+      '@ubjs/node-win32-arm64-msvc': 0.31.0-3
+      '@ubjs/node-win32-x64-msvc': 0.31.0-3
 
   '@ungap/structured-clone@1.3.0': {}
 


### PR DESCRIPTION
## Summary

Closes #32320.

Package the exact official CUA 0.23.2 SDK, arm64 native package, and bare daemon as a dormant macOS arm64 resource closure. Ordinary Desktop startup and the Okou driver remain lazy with respect to CUA; the only activation surface in this slice is a fixed host-owned packaged probe. No command adapter, selector, preference, renderer diagnostic, cloud/API/DB change, or production release is included.

The build verifies upstream archive hashes before extraction, restricts downloads and redirects to official HTTPS hosts, rejects unsafe entries, checks versions/architecture, and stages only the required package-relative JS/native files outside root `node_modules`. MIT/MPL notices and pinned corresponding-source information ship with the runtime. Both signing entry points explicitly include the four CUA Mach-O files. CI's artifacts are ad-hoc signed despite their “unsigned” names, so the probe verifies the app seal and preserves the distinction between upstream hashes and re-signed native bytes.

The runtime uses public `EmbeddedCuaDriverHost`/`CuaDriver` APIs with standard permission mode, telemetry disabled, a private endpoint and a fresh child-only home to avoid inheriting standalone history opt-in. Starts coalesce; late starts, client probes, exit observers and cleanup remain generation-owned. Caller deadlines close admission without releasing ownership, and replacement stays blocked until stop and matching exit are proven. The normal driver registry still contains only Okou.

## Exact inputs

| Artifact | Version | Verified SHA-256 |
| --- | --- | --- |
| Bare universal daemon archive | 0.23.2 | `0127c82ff17922df4290931a8ebf9b4a8b21656aad24cba6f21ee50e41ed4493` |
| SDK tarball | 0.23.2 | `adb6e4a80b0a8259c7a03a0918db4e228f3ca48f4a98d13b43a2dfde76de8c82` |
| Darwin arm64 native tarball | 0.23.2 | `953991a6805c4b11003cdc75c6e615f4a48c02e68893959af6cbd2e09e299469` |
| @ubjs/core | 0.31.0-3 | `74d7950698bdc74569a8e754b2d5dc055a43afdd0647c0171595f9b77e8c7151` |
| @ubjs/node | 0.31.0-3 | `e5c18f3cfc46d072f9aa23439644c9c18fac62729e6385aadcc937e458507a09` |

Official source: `e88e9d899ac5effaeae38619527ebaa46b26ce72`; release tag `cua-driver-rs-v0.23.2`. SDK/native npm SHA-512 integrity also matches the downloaded GitHub release bytes. `cua/artifacts.json` records the exact file allowlist; `cua/README.md` documents closure, signing domains, lifecycle, and repeatable signed-host verification.

## Verification

- 113 focused Desktop tests passed across CUA lifecycle/distribution, existing driver generation ownership, both signing entry points, environment entry points and bootstrap import isolation. Includes 7 distribution CLI scenarios using real fixture archives/filesystem.
- Desktop type check, lint, scoped Knip, CJS Electron build/bootstrap guard, Desktop artifact workflow checks, and deployment workflow structure checks passed locally.
- Real 0.23.2 downloads staged and inventoried successfully on Linux: 39 payload files plus `payload.json`; hashes, package versions, Mach-O arm64 headers and absence of symlinks verified. This is distribution evidence, not macOS execution evidence.
- Added separate real packaged CUA probes after default, production-configured and PR preview smoke. They launch the packaged Electron main (42.5.1), load shipped ESM/native code, start the shipped daemon, verify exact version/embedded metadata, passively check permissions, and prove stop/exit cleanup. All three passed on head `e892a3f44b4a4ea959c6bb807dbae83dbad69f36`: [Desktop job](https://github.com/vm0-ai/vm0/actions/runs/34111922080/job/101710100944). Each reported exact 0.23.2, host attribution, `capture: not_requested`, and `cleanup: confirmed`; ordinary smoke also passed in each variant. The CI host reported both grants true; this is not evidence of installed-user TCC attribution or the ungranted real-host case. Ordinary smoke separately requires `cua dormant`.
- All required gates passed on the reviewed head: [Turbo](https://github.com/vm0-ai/vm0/actions/runs/34111922125), [Crates](https://github.com/vm0-ai/vm0/actions/runs/34111922074), [Security](https://github.com/vm0-ai/vm0/actions/runs/34111922109). Desktop CI passed 612 tests across 53 files plus native helper tests. The unrelated Platform voice-isolation test exceeded its 5-second budget twice; only its failed App shard was rerun, then passed with the same code. No assertions, timeouts or baselines were changed.
- No full local Vitest run or local dev server.

## Packaged CI artifacts

Desktop package version `0.46.36`, Electron `42.5.1`, embedded CUA `0.23.2`. The three ad-hoc-signed CI artifacts below belong to [Desktop run 34111922080](https://github.com/vm0-ai/vm0/actions/runs/34111922080); these are GitHub Actions artifact archive digests, distinct from the original CUA input hashes above.

| Configuration | Actions artifact ID | Actions SHA-256 digest |
| --- | --- | --- |
| Default | `10014870403` | `sha256:4436127c03f44c2b98a6ff6cbff9f3ffd424fc325eae99b4bad182b68b660383` |
| Production-configured | `10014895336` | `sha256:97aa0269a93525979362c765061484f998a37b8d544605d9cfdc2f7faed34433` |
| PR preview | `10014918133` | `sha256:7082847031c43cc25536cdc768c6ef29bec3244b9a29df041434f34b6f7d1255` |

No Desktop version was changed and no production/Desktop release was performed.

## Manual acceptance still pending

Developer ID signed/notarized installation, actual macOS TCC responsibility attribution, an authorized public-SDK screenshot, revocation/regrant and paired real-app behavior remain user-owned checks. CI does not request grants or capture screenshots. The documented fixed LaunchServices host probe supports those checks after the user grants permissions. This PR closes only slice 2, not #32259, and does not authorize or execute a Desktop/production release.
