### PR TITLE
fix(api): preserve mention context across chat integrations

### DIFF
--- a/turbo/apps/api/src/lib/conversation-guidance.ts
+++ b/turbo/apps/api/src/lib/conversation-guidance.ts
@@ -1,0 +1,7 @@
+export const CONVERSATION_GUIDANCE = [
+  "# Conversation Guidance",
+  "- Interpret the current message together with the relevant preceding conversation, including links and attachments.",
+  "- A mention-only message or short follow-up can refer to an earlier request or unresolved problem. When the task is clear from context, continue working on it.",
+  "- If the intended task is still unclear, ask a focused clarification grounded in the conversation.",
+  "- Match the tone of the conversation, and choose the level of detail based on the full task rather than the length of the latest message.",
+].join("\n");

--- a/turbo/apps/api/src/lib/slack-webhook-context.ts
+++ b/turbo/apps/api/src/lib/slack-webhook-context.ts
@@ -2,6 +2,7 @@ import type {
   ChatSlackMessageAssets,
   ChatSlackMessageFile,
 } from "@okouai/db/jsonb-contracts/chat-slack-context";
+import { CONVERSATION_GUIDANCE } from "./conversation-guidance";
 
 import {
   formatSenderBlock,
@@ -318,9 +319,6 @@ function formatMessageWithMetadata(
 const CONTEXT_PREAMBLE = [
   "The messages below are from a Slack conversation. When responding:",
   "- Messages closer to RELATIVE_INDEX 0 are more recent \u2014 prioritize them.",
-  "- Match the tone of the conversation \u2014 casual messages deserve casual replies.",
-  "- Only provide technical analysis when explicitly asked a technical question.",
-  "- Keep responses proportional to the message length and complexity.",
 ].join("\n");
 
 function formatContextForAgent(
@@ -416,6 +414,8 @@ export function buildSlackSystemPrompt(args: {
         ? "Group direct message"
         : "Channel";
   return [
+    CONVERSATION_GUIDANCE,
+    "",
     "# Current Integration",
     "You are currently running inside: Slack",
     `Your bot user ID: ${args.botUserId}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -992,7 +992,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     expect(conversationId.length).toBeLessThanOrEqual(255);
     expect(`group:${conversationId}`.length).toBeGreaterThan(255);
 
-    // A mentioned group message strips the mention and carries provider
+    // A mentioned group message preserves the mention and carries provider
     // history into the group run context.
     const groupMessageId = await ap.postAgentPhoneInboundMessage({
       channel: "imessage",
@@ -1013,7 +1013,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     });
     const admittedGroup = await findAgentphoneChatEventByPromptFixture({
       userId: actor.userId,
-      prompt: "summarize this thread",
+      prompt: "@Zero summarize this thread",
     });
     expect(admittedGroup).toMatchObject({ eventId: expect.any(String) });
     if (!admittedGroup) {
@@ -1024,7 +1024,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     );
     expect(groupLaunchContext).toMatchObject({
       contextType: "agentphone",
-      agentphoneMessageText: "summarize this thread",
+      agentphoneMessageText: "@Zero summarize this thread",
       agentphoneThreadContext: expect.stringContaining("Earlier group context"),
       agentphoneMessageId: groupMessageId,
       agentphoneConversationId: conversationId,
@@ -1037,7 +1037,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       agentphoneAgentId: AGENTPHONE_BDD_AGENT_ID,
     });
     const run1 = await claimDispatchedRun(runnerGroup);
-    expect(run1.prompt).toBe("summarize this thread");
+    expect(run1.prompt).toBe("@Zero summarize this thread");
     const groupThreadContext = groupLaunchContext?.agentphoneThreadContext;
     if (!groupThreadContext) {
       throw new Error("Expected AgentPhone group launch thread context");
@@ -1202,7 +1202,7 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     expect(coldCutoverIdle.body.job).toBeNull();
   });
 
-  it("wakes iMessage groups on the canonical @okou handle and strips it from the prompt", async () => {
+  it("preserves a mention-only iMessage prompt with the preceding task", async () => {
     const runs = createRunsApi(context);
     const ap = createAgentPhoneBddApi(context);
     // The VM0 brand still presents the assistant as "Zero", so serving this
@@ -1211,19 +1211,30 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     const { phone, runnerGroup, sends } = await entitledLinkedActor("vm0");
     const conversationId = uniqueConversationId();
 
-    // Body text addressing the canonical handle wakes the agent, and only the
-    // addressing handle is removed — a bare "okou" stays in the task.
+    // A standalone mention carries the earlier task into the agent input.
     const beforeMention = sends.messages.length;
     await ap.postAgentPhoneInboundMessage({
       channel: "imessage",
       from: phone,
-      body: "@okou draft the okou launch note",
+      body: "@okou",
+      recentHistory: [
+        {
+          messageId: "prior-article-report",
+          content: "Check the broken article at https://example.com/article",
+          direction: "inbound",
+          channel: "imessage",
+          from: phone,
+          at: "2026-09-07T09:00:00.000Z",
+        },
+      ],
       conversationId,
       isGroup: true,
     });
     const mentionRun = await claimDispatchedRun(runnerGroup);
-    expect(mentionRun.prompt).toBe("draft the okou launch note");
-    expect(mentionRun.prompt).not.toContain("@okou");
+    expect(mentionRun.prompt).toBe("@okou");
+    expect(mentionRun.appendSystemPrompt).toContain(
+      "https://example.com/article",
+    );
     await completeSandboxRun(mentionRun.sandboxToken, mentionRun.runId, 0);
     await waitForSendCount(sends, beforeMention + 1);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/feishu-integration.test.ts
@@ -3163,6 +3163,7 @@ describe("Feishu integration", () => {
         threadId: null,
         openId: "ou_feishu_user",
         text: prompt,
+        promptText: prompt,
         file: null,
       }),
     });
@@ -5256,7 +5257,7 @@ describe("Feishu integration", () => {
     expect(
       (await runsApi.listAgentRuns(secondActor, { limit: 20 })).runs.some(
         (run) => {
-          return run.prompt === "unconnected group task";
+          return run.prompt === "@Zero unconnected group task";
         },
       ),
     ).toBeFalsy();
@@ -5293,9 +5294,9 @@ describe("Feishu integration", () => {
     expect(
       controlRuns.runs.some((run) => {
         return [
-          "unconnected group task",
-          "/help",
-          "unavailable group task",
+          "@Zero unconnected group task",
+          "@Zero /help",
+          "@Zero unavailable group task",
         ].includes(run.prompt);
       }),
     ).toBeFalsy();
@@ -5316,7 +5317,7 @@ describe("Feishu integration", () => {
       { encrypted: true },
     );
     await flushWaitUntilForTest();
-    const firstRun = await findRun(secondActor, firstPrompt);
+    const firstRun = await findRun(secondActor, `@Zero ${firstPrompt}`);
 
     await postEvent(
       callbackUrl,
@@ -5331,13 +5332,13 @@ describe("Feishu integration", () => {
     expect(
       (await runsApi.listAgentRuns(secondActor, { limit: 20 })).runs.some(
         (run) => {
-          return run.prompt === secondPrompt;
+          return run.prompt === `@Zero ${secondPrompt}`;
         },
       ),
     ).toBeFalsy();
     const queuedFeishuParams = await findPendingChatEventByPromptFixture({
       userId: secondActor.userId,
-      prompt: secondPrompt,
+      prompt: `@Zero ${secondPrompt}`,
     });
     expect(queuedFeishuParams).toMatchObject({
       eventId: expect.any(String),
@@ -5356,10 +5357,10 @@ describe("Feishu integration", () => {
       assistantText: "First canonical group answer",
     });
 
-    const secondRun = await findRun(secondActor, secondPrompt);
+    const secondRun = await findRun(secondActor, `@Zero ${secondPrompt}`);
     await runsApi.heartbeatRunner(runnerGroup);
     const secondClaim = await runsApi.claimRunnerJob(secondRun.id);
-    expect(secondClaim.prompt).toBe(secondPrompt);
+    expect(secondClaim.prompt).toBe(`@Zero ${secondPrompt}`);
     expect(secondClaim.appendSystemPrompt).toContain("Scope: Group mention");
     expect(secondClaim.resumeSession?.sessionId).toBe(firstCliSessionId);
     await runsApi.requestCancelRun(secondActor, secondRun.id, [200]);
@@ -5407,14 +5408,14 @@ describe("Feishu integration", () => {
     const afterUnmentioned = await runsApi.listAgentRuns(actor, { limit: 20 });
     expect(
       afterUnmentioned.runs.some((candidate) => {
-        return candidate.prompt.startsWith("ignore ");
+        return candidate.prompt.includes("ignore ");
       }),
     ).toBeFalsy();
 
     await removeFeishuInstallation(fixture);
   });
 
-  it("runs mentioned group tasks with thread history and dedupe", async () => {
+  it("runs mention-only group requests with thread history and dedupe", async () => {
     const fixture = await setupFeishuRunFixture();
     const { actor, runnerGroup, appId, callbackUrl } = fixture;
     await connectFixtureUser(fixture);
@@ -5444,11 +5445,13 @@ describe("Feishu integration", () => {
           sender_type: "user",
         },
         body: {
-          content: JSON.stringify({ text: "Current thread context" }),
+          content: JSON.stringify({
+            text: "Check https://example.com/broken-article",
+          }),
         },
       },
     ];
-    const mentioned = groupMessage(appId, "handle this group task", {
+    const mentioned = groupMessage(appId, "", {
       messageId: groupMessageId,
     });
     await postEvent(callbackUrl, mentioned, { encrypted: true });
@@ -5456,7 +5459,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
     const groupRuns = await runsApi.listAgentRuns(actor, { limit: 20 });
     const matchingGroupRuns = groupRuns.runs.filter((candidate) => {
-      return candidate.prompt === "handle this group task";
+      return candidate.prompt === "@Zero";
     });
     expect(matchingGroupRuns).toHaveLength(1);
     const groupRun = requireValue(
@@ -5465,7 +5468,7 @@ describe("Feishu integration", () => {
     );
     await runsApi.heartbeatRunner(runnerGroup);
     const groupClaim = await runsApi.claimRunnerJob(groupRun.id);
-    expect(groupClaim.prompt).toBe("handle this group task");
+    expect(groupClaim.prompt).toBe("@Zero");
     expect(groupClaim.appendSystemPrompt).toContain("Scope: Group mention");
     expect(groupClaim.appendSystemPrompt).toContain(
       `Tenant key: ${TENANT_KEY}`,
@@ -5485,7 +5488,9 @@ describe("Feishu integration", () => {
       "- SENDER: {id: ou_thread_user, name: Thread User}",
     );
     expect(groupClaim.appendSystemPrompt).toContain("Recent group context");
-    expect(groupClaim.appendSystemPrompt).toContain("Current thread context");
+    expect(groupClaim.appendSystemPrompt).toContain(
+      "https://example.com/broken-article",
+    );
     expect(groupClaim.appendSystemPrompt).toContain(
       `Thread ID: ${groupMessageId}`,
     );
@@ -5524,7 +5529,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
     const initialGroupRun = await findRun(
       actor,
-      "establish group reply attribution",
+      "@Zero establish group reply attribution",
     );
     await runsApi.heartbeatRunner(runnerGroup);
     await runsApi.claimRunnerJob(initialGroupRun.id);
@@ -5553,7 +5558,7 @@ describe("Feishu integration", () => {
     await flushWaitUntilForTest();
     const secondGroupRun = await findRun(
       secondActor,
-      "handle this group task as another user",
+      "@Zero handle this group task as another user",
     );
     await runsApi.heartbeatRunner(runnerGroup);
     const secondGroupClaim = await runsApi.claimRunnerJob(secondGroupRun.id);
@@ -5591,7 +5596,7 @@ describe("Feishu integration", () => {
       { encrypted: true },
     );
     await flushWaitUntilForTest();
-    const groupRun = await findRun(actor, "handle this group task");
+    const groupRun = await findRun(actor, "@Zero handle this group task");
     await runsApi.heartbeatRunner(runnerGroup);
     const groupClaim = await runsApi.claimRunnerJob(groupRun.id);
     const groupCliSessionId = `bdd-feishu-group-cli-${groupRun.id}`;
@@ -5610,7 +5615,10 @@ describe("Feishu integration", () => {
       { encrypted: true },
     );
     await flushWaitUntilForTest();
-    const groupFollowUp = await findRun(actor, "continue this group task");
+    const groupFollowUp = await findRun(
+      actor,
+      "@Zero continue this group task",
+    );
     await runsApi.heartbeatRunner(runnerGroup);
     const groupFollowUpClaim = await runsApi.claimRunnerJob(groupFollowUp.id);
     expect(groupFollowUpClaim.resumeSession?.sessionId).toBe(groupCliSessionId);

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations-telegram-post.test.ts
@@ -1790,8 +1790,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     const botUsername = `bot_${fixture.telegramBotId}`;
     const chatId = -77_201;
     const messageThreadId = 9201;
-    const firstPrompt = "start canonical chain";
-    const firstInput = `@${botUsername} ${firstPrompt}`;
+    const firstPrompt = `@${botUsername} start canonical chain`;
 
     expect(
       (
@@ -1810,7 +1809,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
                 username: "alice",
                 first_name: "Alice",
               },
-              text: firstInput,
+              text: firstPrompt,
               entities: [mentionEntity(botUsername)],
             },
           },
@@ -2023,8 +2022,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       }),
     ]);
 
-    const freshPrompt = "start another chain";
-    const freshInput = `@${botUsername} ${freshPrompt}`;
+    const freshPrompt = `@${botUsername} start another chain`;
     expect(
       (
         await postWebhook({
@@ -2041,7 +2039,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
                 username: "alice",
                 first_name: "Alice",
               },
-              text: freshInput,
+              text: freshPrompt,
               entities: [mentionEntity(botUsername)],
             },
           },
@@ -2160,12 +2158,27 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     expect(messages[0]?.text).toBe("following up");
   });
 
-  it("creates an agent run for a linked custom-bot supergroup mention", async () => {
+  it("preserves a mention-only Telegram request with the preceding group task", async () => {
     const fixture = await trackFixture(
       seedTelegramPostFixture({ linkTelegramUser: true }),
     );
     const botUsername = `bot_${fixture.telegramBotId}`;
     telegramApiMocks();
+
+    await postWebhook({
+      telegramBotId: fixture.telegramBotId,
+      secret: fixture.webhookSecret,
+      body: {
+        update_id: 2,
+        message: {
+          message_id: 100,
+          chat: { id: -10_099_002, type: "supergroup" },
+          from: { id: Number(fixture.telegramUserId), first_name: "Alice" },
+          text: "Check https://example.com/broken-article",
+        },
+      },
+    });
+    await flushWaitUntilForTest();
 
     const response = await postWebhook({
       telegramBotId: fixture.telegramBotId,
@@ -2180,7 +2193,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
             username: "alice",
             first_name: "Alice",
           },
-          text: `@${botUsername} summarize this thread`,
+          text: `@${botUsername}`,
           entities: [mentionEntity(botUsername)],
         },
       },
@@ -2190,8 +2203,11 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     await flushWaitUntilForTest();
 
     const run = await latestRunForFixture(fixture);
-    expect(run?.prompt).toBe("summarize this thread");
+    expect(run?.prompt).toBe(`@${botUsername}`);
     expect(run?.appendSystemPrompt).toContain("Chat type: supergroup");
+    expect(run?.appendSystemPrompt).toContain(
+      "https://example.com/broken-article",
+    );
     expectExactSystemPromptFragment(
       run?.appendSystemPrompt,
       [
@@ -2206,7 +2222,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     );
     const admitted = await findTelegramChatEventByPromptFixture({
       userId: fixture.userId,
-      prompt: "summarize this thread",
+      prompt: `@${botUsername}`,
     });
     expect(admitted).toMatchObject({ eventId: expect.any(String) });
     if (!admitted) {
@@ -2219,8 +2235,10 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       telegramChatId: "-10099002",
       telegramMessageId: "101",
       telegramMessageThreadId: null,
-      telegramMessageText: "summarize this thread",
-      telegramThreadContext: "",
+      telegramMessageText: `@${botUsername}`,
+      telegramThreadContext: expect.stringContaining(
+        "https://example.com/broken-article",
+      ),
       telegramRootMessageId: null,
       telegramUserLinkKind: "custom",
       telegramChatType: "supergroup",
@@ -2338,7 +2356,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
     await flushWaitUntilForTest();
 
     const run = await latestRunForFixture(fixture);
-    expect(run?.prompt).toBe("help from a group");
+    expect(run?.prompt).toBe(`@${OFFICIAL_BOT_USERNAME} help from a group`);
     expect(run?.appendSystemPrompt).toContain(
       "Bot username: @official_okou_bot",
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2142,6 +2142,61 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(context.mocks.slack.fetchFile).not.toHaveBeenCalled();
   });
 
+  it("preserves a mention-only Slack request with the preceding link and image", async () => {
+    const actor = bdd.user();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    const runnerGroup = runs.configureRunnerGroup();
+    integrations.configureSlackAppMocks();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const slackUserId = uniqueSlackUserId();
+    const { teamId, botUserId } = await integrations.installSlackWorkspace(
+      actor,
+      { installerSlackUserId: slackUserId },
+    );
+    const threadTs = "2900.000100";
+    const messageTs = "2900.000200";
+    context.mocks.slack.conversations.replies.mockResolvedValue({
+      ok: true,
+      messages: [
+        {
+          ts: threadTs,
+          user: slackUserId,
+          text: "This article is still broken: https://example.com/article",
+          files: [
+            {
+              id: "F_ARTICLE_SCREENSHOT",
+              name: "article.png",
+              mimetype: "image/png",
+            },
+          ],
+        },
+        { ts: messageTs, user: slackUserId, text: `<@${botUserId}>` },
+      ],
+    });
+
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUserId,
+      text: `<@${botUserId}>`,
+      channel: "C_BDD_MENTION_CONTEXT",
+      thread_ts: threadTs,
+      ts: messageTs,
+    });
+    const runId = await pollSlackRun(runnerGroup);
+    const claim = await runs.claimRunnerJob(runId);
+    expect(claim.prompt).toBe(`@Slack User (${botUserId})`);
+    expect(claim.appendSystemPrompt).toContain("https://example.com/article");
+    expect(claim.appendSystemPrompt).toContain("[ID] F_ARTICLE_SCREENSHOT");
+    await completeSlackTriggeredRun({
+      runId,
+      sandboxToken: claim.sandboxToken,
+      cliAgentType: claim.cliAgentType,
+      assistantText: "Investigating the article and screenshot",
+    });
+  });
+
   it("deduplicates canonical Slack retries", async () => {
     const actor = bdd.user();
     runs.acceptStorageDownloads();
@@ -2287,7 +2342,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       requireCanonicalSlackInputAssetId(visibleMessages);
     const canonicalInputMessage = slackInputMessageByText(
       visibleMessages,
-      "admit this event once with @Slack User",
+      "@Slack User admit this event once with @Slack User",
     );
     if (!canonicalInputMessage) {
       throw new Error("Expected the canonical Slack input message");
@@ -2300,7 +2355,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     ).resolves.toMatchObject({
       slackBotUserId: botUserId,
       slackPublicBrand: "vm0",
-      slackMessageText: `admit this event once with <@${mentionedSlackUserId}>`,
+      slackMessageText: `<@${botUserId}> admit this event once with <@${mentionedSlackUserId}>`,
       slackMessageAssets: [
         {
           assetId: canonicalInputAssetId,
@@ -2328,7 +2383,10 @@ describe("INT-01: Slack app deep webhook flows", () => {
                 filenameSnapshot: "source-notes.txt",
                 contentType: "text/plain",
               },
-              { type: "text", text: "admit this event once with @Slack User" },
+              {
+                type: "text",
+                text: "@Slack User admit this event once with @Slack User",
+              },
               {
                 type: "source",
                 kind: "slack",
@@ -2357,7 +2415,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     );
     const canonicalInputRun = await runs.readRun(actor, run1Id);
     expect(canonicalInputRun.prompt).toBe(
-      `admit this event once with @Slack User (${mentionedSlackUserId})\n\n[Web file] source-notes.txt (text/plain)\n   [ID] ${canonicalInputAssetId}`,
+      `@Slack User (${botUserId}) admit this event once with @Slack User (${mentionedSlackUserId})\n\n[Web file] source-notes.txt (text/plain)\n   [ID] ${canonicalInputAssetId}`,
     );
     expect(canonicalInputRun.appendSystemPrompt).toContain(
       `# Current Integration\nYou are currently running inside: Slack\nYour bot user ID: ${botUserId}\nChannel ID: ${channelId}\nChannel type: Channel\nThread ID: ${threadTs}`,
@@ -3395,7 +3453,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
             parts: [
               {
                 type: "text",
-                text: "recover this event after admission conflict",
+                text: "@Slack User recover this event after admission conflict",
               },
               {
                 type: "source",

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -461,7 +461,7 @@ async function dispatchTeamsRun(args: {
     orgId: args.fixture.orgId,
     orgRole: "org:admin",
   });
-  return await runIdForPrompt(actor, args.text);
+  return await runIdForPrompt(actor, `@Zero ${args.text}`);
 }
 
 async function postTeamsPersonalMessage(args: {
@@ -1074,7 +1074,7 @@ describe("Teams chat callbacks", () => {
         userMessage: {
           version: 1,
           parts: [
-            { type: "text", text: "finish the task" },
+            { type: "text", text: "@Zero finish the task" },
             {
               type: "source",
               kind: "teams",

--- a/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/teams-bot.test.ts
@@ -1743,7 +1743,7 @@ describe("POST /api/webhooks/teams/bot", () => {
               filenameSnapshot: "spec.png",
               contentType: "image/png",
             },
-            { type: "text", text: "please inspect this" },
+            { type: "text", text: "@Zero please inspect this" },
             {
               type: "source",
               kind: "teams",
@@ -2882,7 +2882,7 @@ describe("POST /api/webhooks/teams/bot", () => {
       activity: teamsMessageActivity(fixture, {
         id: channelContextActivityId,
         replyToId: null,
-        text: "<at>Zero</at> start another topic",
+        text: "<at>Zero</at>",
       }),
       token: teamsToken(),
     });
@@ -2900,10 +2900,7 @@ describe("POST /api/webhooks/teams/bot", () => {
         reactionType: "1f4ad_thoughtballoon",
       },
     ]);
-    const channelContextRunId = await runIdForPrompt(
-      actor,
-      "start another topic",
-    );
+    const channelContextRunId = await runIdForPrompt(actor, "@Zero");
     await runsApi.heartbeatRunner(runnerGroup);
     const channelContextClaim =
       await runsApi.claimRunnerJob(channelContextRunId);
@@ -2913,7 +2910,7 @@ describe("POST /api/webhooks/teams/bot", () => {
       channelContextAppendSystemPrompt,
       "# Recent Channel Messages",
     );
-    expect(channelContextClaim.prompt).toBe("start another topic");
+    expect(channelContextClaim.prompt).toBe("@Zero");
     expect(graphRequests).toContain("channel-messages");
     expect(recentChannelContext).toContain("api channel planning");
     expect(recentChannelContext).not.toContain("start another topic");

--- a/turbo/apps/api/src/signals/services/agentphone-prompt.ts
+++ b/turbo/apps/api/src/signals/services/agentphone-prompt.ts
@@ -1,3 +1,5 @@
+import { CONVERSATION_GUIDANCE } from "../../lib/conversation-guidance";
+
 export function buildAgentPhonePrompt(
   opts: {
     readonly sharedNumber: string;
@@ -30,5 +32,7 @@ export function buildAgentPhonePrompt(
   if (opts.messageId) {
     headerParts.push(`Message ID: ${opts.messageId}`);
   }
-  return [headerParts.join("\n"), threadContext].filter(Boolean).join("\n\n");
+  return [CONVERSATION_GUIDANCE, headerParts.join("\n"), threadContext]
+    .filter(Boolean)
+    .join("\n\n");
 }

--- a/turbo/apps/api/src/signals/services/agentphone-shared.service.ts
+++ b/turbo/apps/api/src/signals/services/agentphone-shared.service.ts
@@ -22,24 +22,12 @@ const AGENTPHONE_PHONE_HANDLE_PATTERN = /^\+[1-9]\d{7,14}$/u;
  * Handles that address the assistant in a group conversation. Every public
  * brand answers to all of them, because group members do not know which brand
  * the deployment presents and the VM0 brand still calls the assistant "Zero".
- *
- * Detection and stripping must stay in agreement, so both derive from this one
- * pattern. If they drift, a message either wakes the agent with the mention
- * still in the prompt, or is stripped without waking it.
  */
 const AGENTPHONE_MENTION_PATTERN = /(^|\s)@(zero|vm0|okou)\b/iu;
 
 /** Whether free-form message text addresses the assistant by handle. */
 export function isAgentPhoneMentionText(value: string): boolean {
   return AGENTPHONE_MENTION_PATTERN.test(value);
-}
-
-/** Removes the addressing handle so it never reaches the run prompt. */
-export function stripAgentPhoneMention(text: string): string {
-  return text
-    .replace(new RegExp(AGENTPHONE_MENTION_PATTERN.source, "giu"), " ")
-    .replace(/[ \t]{2,}/gu, " ")
-    .trim();
 }
 
 export function isAgentPhoneChannel(value: string): value is AgentPhoneChannel {

--- a/turbo/apps/api/src/signals/services/agentphone.service.ts
+++ b/turbo/apps/api/src/signals/services/agentphone.service.ts
@@ -44,7 +44,6 @@ import {
   resolveAgentPhoneUserLink,
   resolveOrgDefaultComposeId,
   storeOutboundAgentPhoneMessage,
-  stripAgentPhoneMention,
   touchAgentPhoneUserLink,
   type AgentPhoneChannel,
   type AgentPhoneUserLink,
@@ -964,12 +963,8 @@ function enrichAgentPhonePrompt(opts: {
   readonly prompt: string;
   readonly messageId: string;
   readonly mediaUrl: string | null;
-  readonly isGroup: boolean;
 }): string {
-  const promptText = opts.isGroup
-    ? stripAgentPhoneMention(opts.prompt)
-    : opts.prompt.trim();
-  const parts = [promptText];
+  const parts = [opts.prompt.trim()];
   if (opts.mediaUrl) {
     parts.push(
       formatAgentPhoneFileForContext({
@@ -1877,7 +1872,6 @@ export const handleAgentPhoneMessage$ = command(
       prompt: params.event.body,
       messageId: params.event.messageId,
       mediaUrl: params.event.mediaUrl,
-      isGroup,
     });
 
     const result = await set(

--- a/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-feishu-ingress-processor.service.ts
@@ -77,6 +77,7 @@ const feishuInboundMessageSchema = z.object({
   threadId: z.string().nullable(),
   openId: z.string(),
   text: z.string(),
+  promptText: z.string(),
   file: feishuPromptFileSchema.nullable(),
 });
 
@@ -296,7 +297,7 @@ function canonicalFeishuLaunchContext(args: {
 }): CanonicalFeishuLaunchContext {
   return {
     conversationHistory: args.conversationHistory,
-    messageText: args.message.text,
+    messageText: args.message.promptText,
     messageFiles: [
       ...(args.message.file ? [args.message.file] : []),
       ...args.files,
@@ -330,7 +331,7 @@ function feishuInboundUserMessage(
   chatOpenUrl: string,
 ) {
   return createUserMessageDocument({
-    text: message.file ? null : message.text,
+    text: message.file ? null : message.promptText,
     files: (message.file ? [message.file] : []).map((file) => {
       return {
         id: file.fileId,

--- a/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
+++ b/turbo/apps/api/src/signals/services/canonical-slack-ingress-processor.service.ts
@@ -100,10 +100,6 @@ function slackPhysicalThreadTs(event: SlackAgentEvent): string {
   return event.thread_ts ?? event.ts;
 }
 
-function stripBotMention(text: string, botUserId: string): string {
-  return text.replaceAll(`<@${botUserId}>`, "").trim();
-}
-
 async function claimIngress(db: Db, ingressId: string, currentTime: Date) {
   const staleBefore = new Date(
     currentTime.getTime() - PROCESSING_STALE_AFTER_MS,
@@ -439,7 +435,7 @@ const persistClaimedCanonicalSlackIngress$ = command(
     });
     signal.throwIfAborted();
     const userInfoResolver = client.createUserInfoResolver();
-    const messageContent = stripBotMention(event.text, ingress.botUserId);
+    const messageContent = event.text.trim();
     const canonicalAssets = await set(
       materializeCanonicalSlackInputAssets$,
       {

--- a/turbo/apps/api/src/signals/services/feishu-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-dispatch.service.ts
@@ -19,6 +19,7 @@ import {
   buildFeishuNoticeMessage,
 } from "../../lib/feishu-message-card";
 import { logger } from "../../lib/log";
+import { CONVERSATION_GUIDANCE } from "../../lib/conversation-guidance";
 import {
   addFeishuMessageReaction,
   listFeishuChatMessages,
@@ -77,6 +78,7 @@ export interface FeishuInboundMessage {
   readonly threadId: string | null;
   readonly openId: string;
   readonly text: string;
+  readonly promptText: string;
   readonly file: FeishuPromptFile | null;
 }
 
@@ -531,9 +533,6 @@ function formatFeishuContextMessage(
 const FEISHU_CONTEXT_PREAMBLE = [
   "The messages below are from a Feishu conversation. When responding:",
   "- Messages closer to RELATIVE_INDEX 0 are more recent — prioritize them.",
-  "- Match the tone of the conversation — casual messages deserve casual replies.",
-  "- Only provide technical analysis when explicitly asked a technical question.",
-  "- Keep responses proportional to the message length and complexity.",
 ].join("\n");
 
 function formatFeishuContext(
@@ -671,6 +670,8 @@ export function buildFeishuSystemPrompt(args: {
     ? ""
     : `Group ID: ${args.chatId} (same as Chat ID; use it directly as the \`--chat\` value for \`okou feishu message send\`)`;
   return [
+    CONVERSATION_GUIDANCE,
+    "",
     "# Current Integration",
     "You are currently running inside: Feishu",
     `Scope: ${typeLabel}`,

--- a/turbo/apps/api/src/signals/services/feishu-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/feishu-webhooks.service.ts
@@ -84,6 +84,7 @@ type FeishuEventMention = NonNullable<FeishuEventMessage["mentions"]>[number];
 
 interface FeishuInboundContent {
   readonly text: string;
+  readonly promptText: string;
   readonly file: FeishuPromptFile | null;
 }
 
@@ -176,16 +177,20 @@ function inboundMessageContent(
       messageType: message.message_type,
       content: message.content,
     });
-    return {
-      text: file ? formatFeishuFileContext(file) : "",
-      file,
-    };
+    const text = file ? formatFeishuFileContext(file) : "";
+    return { text, promptText: text, file };
   }
   const content = textContentSchema.safeParse(safeJsonParse(message.content));
   if (!content.success) {
-    return { text: "", file: null };
+    return { text: "", promptText: "", file: null };
   }
   return {
+    promptText: botMention
+      ? content.data.text.replaceAll(
+          botMention.key,
+          botMention.name ? `@${botMention.name}` : botMention.key,
+        )
+      : content.data.text,
     text: botMention
       ? content.data.text.replaceAll(botMention.key, "")
       : content.data.text,
@@ -223,7 +228,7 @@ function inboundMessage(
   }
   const content = inboundMessageContent(event.data.message, botMention);
   const text = content.text.trim();
-  if (!text) {
+  if (!content.promptText.trim()) {
     return null;
   }
   return {
@@ -239,6 +244,7 @@ function inboundMessage(
     threadId: event.data.message.thread_id ?? null,
     openId: event.data.sender.sender_id.open_id,
     text,
+    promptText: content.promptText.trim(),
     file: content.file,
   };
 }

--- a/turbo/apps/api/src/signals/services/github-chat-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/github-chat-prompt.service.ts
@@ -1,4 +1,5 @@
 import { optionalEnv } from "../../lib/env";
+import { CONVERSATION_GUIDANCE } from "../../lib/conversation-guidance";
 import {
   githubAppBotUsername,
   resolveGithubAppIdentity,
@@ -47,7 +48,11 @@ export function buildGitHubPrompt(args: {
   readonly appId: string | null;
   readonly appSlug: string | null;
 }): string {
-  return [buildIntegrationPrompt(args), args.issueContext]
+  return [
+    CONVERSATION_GUIDANCE,
+    buildIntegrationPrompt(args),
+    args.issueContext,
+  ]
     .filter((part): part is string => {
       return Boolean(part);
     })

--- a/turbo/apps/api/src/signals/services/teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/teams-dispatch.service.ts
@@ -1002,9 +1002,6 @@ function formatTeamsContextMessage(
 const TEAMS_CONTEXT_PREAMBLE = [
   "The messages below are from a Microsoft Teams conversation. When responding:",
   "- Messages closer to RELATIVE_INDEX 0 are more recent; prioritize them.",
-  "- Match the tone of the conversation; casual messages deserve casual replies.",
-  "- Only provide technical analysis when explicitly asked a technical question.",
-  "- Keep responses proportional to the message length and complexity.",
 ].join("\n");
 
 function formatTeamsThreadContext(
@@ -2279,6 +2276,14 @@ const runResolvedTeamsAgentForActivity$ = command(
   },
 );
 
+function teamsAgentPrompt(activity: TeamsMessageActivity): string {
+  const recipientMention =
+    activity.mentionsRecipient && activity.recipient
+      ? `@${activity.recipient.name ?? activity.recipient.id}`
+      : "";
+  return [recipientMention, activity.text.trim()].filter(Boolean).join(" ");
+}
+
 export const dispatchTeamsMessageToAgent$ = command(
   async (
     { set },
@@ -2297,9 +2302,10 @@ export const dispatchTeamsMessageToAgent$ = command(
     }
 
     const cardAction = teamsCardAction(activity.value);
-    const prompt = activity.text.trim();
-    const command = cardAction ? null : parseTeamsBotCommand(prompt);
-    const isGreeting = !cardAction && isTeamsBotGreeting(prompt);
+    const commandText = activity.text.trim();
+    const prompt = teamsAgentPrompt(activity);
+    const command = cardAction ? null : parseTeamsBotCommand(commandText);
+    const isGreeting = !cardAction && isTeamsBotGreeting(commandText);
     if (!cardAction && !shouldDispatchTeamsMessage(activity)) {
       return (
         teamsValidationFallbackNotice({

--- a/turbo/apps/api/src/signals/services/teams-prompt.ts
+++ b/turbo/apps/api/src/signals/services/teams-prompt.ts
@@ -1,4 +1,5 @@
 import type { ChatTeamsMessageFile } from "@okouai/db/jsonb-contracts/chat-teams-context";
+import { CONVERSATION_GUIDANCE } from "../../lib/conversation-guidance";
 
 type TeamsPromptFile = Pick<
   ChatTeamsMessageFile,
@@ -56,6 +57,8 @@ export function buildTeamsPrompt(args: {
   readonly threadContext: string;
 }): string {
   return [
+    CONVERSATION_GUIDANCE,
+    "",
     "# Current Integration",
     "You are currently running inside: Microsoft Teams",
     `Tenant ID: ${args.tenantId}`,

--- a/turbo/apps/api/src/signals/services/telegram-post.service.ts
+++ b/turbo/apps/api/src/signals/services/telegram-post.service.ts
@@ -1193,31 +1193,6 @@ function parseBotCommand(
   return undefined;
 }
 
-function stripBotMention(text: string, botUsername: string | null): string {
-  if (!botUsername) {
-    return text;
-  }
-  const mention = `@${botUsername}`;
-  const mentionLower = mention.toLowerCase();
-  const lower = text.toLowerCase();
-  let result = "";
-  let cursor = 0;
-  for (;;) {
-    const idx = lower.indexOf(mentionLower, cursor);
-    if (idx === -1) {
-      result += text.slice(cursor);
-      break;
-    }
-    result += text.slice(cursor, idx).trimEnd();
-    result += " ";
-    cursor = idx + mention.length;
-    while (cursor < text.length && /\s/u.test(text.charAt(cursor))) {
-      cursor += 1;
-    }
-  }
-  return result.trim();
-}
-
 function hasBotMention(
   message: TelegramMessage,
   botUsername: string | null,
@@ -1720,20 +1695,15 @@ function rootMessageIdForAgentMessage(args: {
 function buildTelegramAgentPrompt(args: {
   readonly message: TelegramMessage;
   readonly botId: string;
-  readonly botUsername: string | null;
-  readonly isDM: boolean;
 }): {
   readonly prompt: string;
   readonly userInfoExtras: TelegramUserInfoExtras;
 } {
   const enriched = enrichTelegramPrompt(args.message);
-  const promptBase = args.isDM
-    ? enriched.prompt
-    : stripBotMention(enriched.prompt, args.botUsername);
   const replyQuote = formatReplyQuote(args.message.reply_to_message);
   const promptWithReply = replyQuote
-    ? `${replyQuote}\n\n${promptBase}`
-    : promptBase;
+    ? `${replyQuote}\n\n${enriched.prompt}`
+    : enriched.prompt;
   return {
     prompt: appendTelegramMessageContext(
       promptWithReply,

--- a/turbo/apps/api/src/signals/services/telegram-prompt.ts
+++ b/turbo/apps/api/src/signals/services/telegram-prompt.ts
@@ -1,3 +1,5 @@
+import { CONVERSATION_GUIDANCE } from "../../lib/conversation-guidance";
+
 export function buildTelegramPrompt(
   opts: {
     readonly botId?: string;
@@ -35,5 +37,7 @@ export function buildTelegramPrompt(
   if (opts.messageThreadId) {
     headerParts.push(`Message thread ID: ${opts.messageThreadId}`);
   }
-  return [headerParts.join("\n"), threadContext].filter(Boolean).join("\n\n");
+  return [CONVERSATION_GUIDANCE, headerParts.join("\n"), threadContext]
+    .filter(Boolean)
+    .join("\n\n");
 }

--- a/turbo/apps/api/src/signals/services/web-chat-session-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/web-chat-session-prompt.service.ts
@@ -22,6 +22,7 @@ import {
   sql,
 } from "drizzle-orm";
 
+import { CONVERSATION_GUIDANCE } from "../../lib/conversation-guidance";
 import type { Db } from "../external/db";
 import { buildVideoRunOptionsPrompt } from "../../lib/video-run-options-prompt";
 import { BEFORE_DISPATCH_CANCELLED_ERROR } from "./agent-run-create.service";
@@ -73,6 +74,7 @@ export interface WebChatSessionPromptContext {
 
 function buildWebChatPrompt(): string {
   return [
+    CONVERSATION_GUIDANCE,
     "# Current Integration\nYou are currently running inside: Web",
     "You are communicating with the user through the web chat UI.",
   ].join("\n\n");
@@ -242,9 +244,6 @@ function buildWebChatPriorRunsContext(
     "",
     "The runs below are from the same web chat thread. When responding:",
     "- Runs closer to RELATIVE_INDEX 0 are more recent -- prioritize them.",
-    "- Match the tone of the conversation -- casual messages deserve casual replies.",
-    "- Only provide technical analysis when explicitly asked a technical question.",
-    "- Keep responses proportional to the message length and complexity.",
     "- Use the AGENT_SESSION_COMMAND for a run if you need more detailed agent session context.",
     "",
     blocks.join("\n\n"),


### PR DESCRIPTION
A standalone @mention could reach the agent as an empty prompt, or be discarded before dispatch in Feishu and Teams. Repeated conversation instructions also discouraged acting on short follow-ups. Preserve the addressing mention in agent inputs and share guidance to interpret short messages against the preceding discussion, links, and attachments, continue a clear unresolved task, and ask a focused question when the task is unclear.

- Preserve mentions in Slack, Feishu, Teams, Telegram, and AgentPhone inputs while keeping command parsing independent of the model-facing text.
- Use the same conversation guidance in those integrations, GitHub, and Web Chat; remove the duplicated technical-question and latest-message-length restrictions.
- Cover mention-only requests with preceding context through the real integration entry points, including a Slack link and screenshot.

## Validation

- Teams callback route suite: all 9 cases pass, including completion/failure delivery, uninstall handling, and canonical thread session continuity.
- Affected Slack, Feishu, Teams, Telegram, and AgentPhone entry-point suites: 176 cases passed, including focused reruns after updating affected assertions and fixture payloads.
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm exec knip --workspace apps/api`
- Prettier and `git diff --check`

The regression cases verify dispatched prompts, preceding conversation/link/file context, and existing command/session flows. Full repository checks run in the PR pipeline.

## Rollout

Feishu adds a required `promptText` to its persisted ingress payload while retaining `text` for command parsing. Feishu is staff-only (`FeatureSwitchKey.FeishuIntegration`, disabled by default with staff org allowlisting), so this intentionally adds no compatibility reader or migration for earlier staff ingress rows. Existing staff messages still awaiting ingress processing at cutover may need to be resent. The other integrations retain their current payload shapes.

## Fallbacks

- `feishu-webhooks.service.ts:inboundMessageContent`: when the provider omits the optional bot mention name, retain its original mention key.
- `teams-dispatch.service.ts:teamsAgentPrompt`: when the provider omits the optional recipient name, use the recipient ID for the addressing mention.

Both handle genuinely optional external metadata and have no cross-version rollout window.
