### PR TITLE
test(api): bound completion-log failure matrix execution

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -19145,11 +19145,7 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
 });
 
 describe("RUN-03: sandbox completion reports against missing checkpoints and settled runs", () => {
-  it("suppresses reviewed expected failures from generic completion logs", async () => {
-    const api = createRunsApi(context);
-    const webhooks = createWebhookCallbackApi(context);
-    await seedBuiltInDefaultModelKey();
-    const { actor, agentId } = await entitledRunActor();
+  describe("completion failure logs", () => {
     const suppressedReasons = [
       "insufficient_credits",
       "invalid_api_key",
@@ -19166,15 +19162,9 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       "reconnect_required",
       "usage_limit",
     ] as const satisfies readonly KnownRunFailureReason[];
-    const axiomLevels = [
-      context.mocks.axiomLogging.debug,
-      context.mocks.axiomLogging.info,
-      context.mocks.axiomLogging.warn,
-      context.mocks.axiomLogging.error,
-    ];
 
     function matchingLogCalls(
-      log: (typeof axiomLevels)[number],
+      log: typeof context.mocks.axiomLogging.warn,
       message: string,
       runId: string,
     ) {
@@ -19189,12 +19179,31 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       });
     }
 
-    async function completeFailure(args: {
+    function genericFailureLogCalls(runId: string) {
+      return [
+        context.mocks.axiomLogging.debug,
+        context.mocks.axiomLogging.info,
+        context.mocks.axiomLogging.warn,
+        context.mocks.axiomLogging.error,
+      ].flatMap((level) => {
+        return matchingLogCalls(level, "Run failed", runId);
+      });
+    }
+
+    interface FailureCase {
       readonly failureReason?: RunFailureReasonToken;
       readonly modelProvider?: ModelProviderType;
       readonly persistedModelProvider?: string | null;
-    }): Promise<{ readonly runId: string; readonly error: string }> {
+    }
+
+    async function completeFailure(args: FailureCase) {
+      const api = createRunsApi(context);
+      const webhooks = createWebhookCallbackApi(context);
       const modelProvider = args.modelProvider ?? "anthropic-api-key";
+      if (modelProvider === "built-in") {
+        await seedBuiltInDefaultModelKey();
+      }
+      const { actor, agentId } = await entitledRunActor();
       const run = await api.createRun(actor, {
         agentId,
         prompt: `fail ${modelProvider} with ${args.failureReason ?? "no reason"}`,
@@ -19229,161 +19238,174 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
       await expect(
         readRunFailureReasonFixture(context, run.runId),
       ).resolves.toBe(args.failureReason ?? null);
-      return { runId: run.runId, error };
+      return { actor, runId: run.runId, error };
     }
 
-    for (const failureReason of suppressedReasons) {
-      const { runId } = await completeFailure({ failureReason });
-      for (const level of axiomLevels) {
-        expect(matchingLogCalls(level, "Run failed", runId)).toHaveLength(0);
-      }
-    }
+    it.each(suppressedReasons)(
+      "suppresses %s for a BYOK provider",
+      async (failureReason) => {
+        const { runId } = await completeFailure({ failureReason });
+        expect(genericFailureLogCalls(runId)).toHaveLength(0);
+      },
+    );
 
-    const globallySuppressedFailures = [
-      await completeFailure({ failureReason: "input_too_large" }),
-      await completeFailure({
-        modelProvider: "built-in",
-        failureReason: "input_too_large",
-      }),
-      await completeFailure({
-        failureReason: "input_too_large",
-        persistedModelProvider: "legacy-unknown-provider",
-      }),
-      await completeFailure({ failureReason: "execution_timeout" }),
-      await completeFailure({
-        modelProvider: "built-in",
-        failureReason: "execution_timeout",
-      }),
-      await completeFailure({
-        failureReason: "execution_timeout",
-        persistedModelProvider: "legacy-unknown-provider",
-      }),
-    ];
-    for (const { runId } of globallySuppressedFailures) {
-      for (const level of axiomLevels) {
-        expect(matchingLogCalls(level, "Run failed", runId)).toHaveLength(0);
-      }
-    }
+    describe.each(["input_too_large", "execution_timeout"] as const)(
+      "globally suppresses %s",
+      (failureReason) => {
+        it.each([
+          { name: "BYOK", modelProvider: "anthropic-api-key" },
+          { name: "built-in", modelProvider: "built-in" },
+          {
+            name: "legacy provider",
+            persistedModelProvider: "legacy-unknown-provider",
+          },
+        ] satisfies readonly (FailureCase & { readonly name: string })[])(
+          "suppresses the generic log for $name",
+          async (provider) => {
+            const { runId } = await completeFailure({
+              ...provider,
+              failureReason,
+            });
+            expect(genericFailureLogCalls(runId)).toHaveLength(0);
+          },
+        );
+      },
+    );
 
-    const visibleControls = [
-      await completeFailure({
+    it.each([
+      {
+        name: "built-in rate limiting",
         modelProvider: "built-in",
         failureReason: "provider_rate_limited",
-      }),
-      await completeFailure({
+      },
+      {
+        name: "rate limiting with a null provider",
         failureReason: "provider_rate_limited",
         persistedModelProvider: null,
-      }),
-      await completeFailure({
+      },
+      {
+        name: "rate limiting with a legacy provider",
         failureReason: "provider_rate_limited",
         persistedModelProvider: "legacy-unknown-provider",
-      }),
-      await completeFailure({}),
-      await completeFailure({ failureReason: "session_history_limit" }),
-      await completeFailure({ failureReason: "unsupported_model" }),
-    ];
-    for (const control of visibleControls) {
-      const warnings = matchingLogCalls(
-        context.mocks.axiomLogging.warn,
-        "Run failed",
-        control.runId,
-      );
-      expect(warnings).toHaveLength(1);
-      expect(warnings[0]?.[1]).toStrictEqual(
-        expect.objectContaining({
-          runId: control.runId,
-          exitCode: 1,
-          error: control.error,
-          context: "webhook:complete",
-        }),
-      );
-    }
-
-    const missingCheckpoint = await api.createRun(actor, {
-      agentId,
-      prompt: "keep the missing-checkpoint warning visible",
-      modelProvider: "anthropic-api-key",
-    });
-    await webhooks.requestAgentComplete(
-      {
-        runId: missingCheckpoint.runId,
-        exitCode: 0,
-        failureReason: "provider_overloaded",
       },
+      { name: "an absent failure reason" },
       {
-        authorization: `Bearer ${api.sandboxTokenForRun(
-          actor,
+        name: "session history limits",
+        failureReason: "session_history_limit",
+      },
+      { name: "unsupported models", failureReason: "unsupported_model" },
+    ] satisfies readonly (FailureCase & { readonly name: string })[])(
+      "keeps $name visible",
+      async (failure) => {
+        const control = await completeFailure(failure);
+        const warnings = matchingLogCalls(
+          context.mocks.axiomLogging.warn,
+          "Run failed",
+          control.runId,
+        );
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]?.[1]).toStrictEqual(
+          expect.objectContaining({
+            runId: control.runId,
+            exitCode: 1,
+            error: control.error,
+            context: "webhook:complete",
+          }),
+        );
+      },
+    );
+
+    it("keeps the missing-checkpoint warning visible for a suppressible reason", async () => {
+      const api = createRunsApi(context);
+      const webhooks = createWebhookCallbackApi(context);
+      const { actor, agentId } = await entitledRunActor();
+      const missingCheckpoint = await api.createRun(actor, {
+        agentId,
+        prompt: "keep the missing-checkpoint warning visible",
+        modelProvider: "anthropic-api-key",
+      });
+      await webhooks.requestAgentComplete(
+        {
+          runId: missingCheckpoint.runId,
+          exitCode: 0,
+          failureReason: "provider_overloaded",
+        },
+        {
+          authorization: `Bearer ${api.sandboxTokenForRun(
+            actor,
+            missingCheckpoint.runId,
+          )}`,
+        },
+        [200],
+      );
+      expect(
+        matchingLogCalls(
+          context.mocks.axiomLogging.warn,
+          "Run failed because checkpoint was not found",
           missingCheckpoint.runId,
-        )}`,
-      },
-      [200],
-    );
-    expect(
-      matchingLogCalls(
-        context.mocks.axiomLogging.warn,
-        "Run failed because checkpoint was not found",
-        missingCheckpoint.runId,
-      ),
-    ).toHaveLength(1);
-    expect(
-      matchingLogCalls(
-        context.mocks.axiomLogging.warn,
-        "Run failed",
-        missingCheckpoint.runId,
-      ),
-    ).toHaveLength(0);
-
-    const suppressibleFirst = await completeFailure({
-      failureReason: "provider_overloaded",
+        ),
+      ).toHaveLength(1);
+      expect(genericFailureLogCalls(missingCheckpoint.runId)).toHaveLength(0);
     });
-    await webhooks.requestAgentComplete(
-      {
-        runId: suppressibleFirst.runId,
-        exitCode: 1,
-        error: "late unsupported-model report",
-        failureReason: "unsupported_model",
-      },
-      {
-        authorization: `Bearer ${api.sandboxTokenForRun(
-          actor,
-          suppressibleFirst.runId,
-        )}`,
-      },
-      [200],
-    );
-    expect(
-      matchingLogCalls(
-        context.mocks.axiomLogging.warn,
-        "Run failed",
-        suppressibleFirst.runId,
-      ),
-    ).toHaveLength(0);
 
-    const visibleFirst = await completeFailure({
-      failureReason: "unsupported_model",
-    });
-    await webhooks.requestAgentComplete(
+    it.each([
       {
-        runId: visibleFirst.runId,
-        exitCode: 1,
-        error: "late overload report",
-        failureReason: "provider_overloaded",
+        firstReason: "provider_overloaded",
+        lateReason: "unsupported_model",
+        warningCount: 0,
       },
       {
-        authorization: `Bearer ${api.sandboxTokenForRun(
-          actor,
-          visibleFirst.runId,
-        )}`,
+        firstReason: "unsupported_model",
+        lateReason: "provider_overloaded",
+        warningCount: 1,
       },
-      [200],
+    ] as const)(
+      "does not relog $firstReason when a duplicate reports $lateReason",
+      async ({ firstReason, lateReason, warningCount }) => {
+        const api = createRunsApi(context);
+        const webhooks = createWebhookCallbackApi(context);
+        const first = await completeFailure({ failureReason: firstReason });
+        expect(
+          matchingLogCalls(
+            context.mocks.axiomLogging.warn,
+            "Run failed",
+            first.runId,
+          ),
+        ).toHaveLength(warningCount);
+
+        await webhooks.requestAgentComplete(
+          {
+            runId: first.runId,
+            exitCode: 1,
+            error: `late ${lateReason} report`,
+            failureReason: lateReason,
+          },
+          {
+            authorization: `Bearer ${api.sandboxTokenForRun(
+              first.actor,
+              first.runId,
+            )}`,
+          },
+          [200],
+        );
+        expect(
+          matchingLogCalls(
+            context.mocks.axiomLogging.warn,
+            "Run failed",
+            first.runId,
+          ),
+        ).toHaveLength(warningCount);
+        await expect(
+          api.readRun(first.actor, first.runId),
+        ).resolves.toMatchObject({
+          status: "failed",
+          error: first.error,
+        });
+        await expect(
+          readRunFailureReasonFixture(context, first.runId),
+        ).resolves.toBe(firstReason);
+      },
     );
-    expect(
-      matchingLogCalls(
-        context.mocks.axiomLogging.warn,
-        "Run failed",
-        visibleFirst.runId,
-      ),
-    ).toHaveLength(1);
   });
 
   it.each(["claude-code", "codex"] as const)(


### PR DESCRIPTION
## Summary

- Split the completion-log matrix into 29 named API integration cases, each owning one run and its actor/org/agent setup.
- Preserve all 14 BYOK-suppressed reasons, 6 global suppression combinations, 6 visible controls, the missing-checkpoint warning, and both conflicting duplicate-report directions.
- Keep real PostgreSQL, existing API fixture routes and external mocks. Seed the owned built-in key only for the three cases that need it.
- Also assert that conflicting duplicate reports preserve the first terminal error and failure reason.

Closes #32299

## Root cause and measurements

The original test created 29 runs sequentially under one default 5 s deadline. It timed out locally at 5.101 s on the unchanged baseline. After `scripts/prepare.sh`, a temporary timing probe still timed out at 5.249 s: setup cost 1.153 s, with 26 failure scenarios completed before the deadline. Individual create calls took 27.5–321.9 ms, completion 9.4–52.4 ms, and read/verification 3.6–57.8 ms. The failure is accumulated work, not evidence of a single blocked completion call. Timing instrumentation is not in this PR.

Each independent case now owns a bounded amount of work regardless of future matrix growth. Focused validation passed all 29 cases at 0.46–2.11 s each. In the complete-file run they took 0.30–0.78 s each.

## Validation

- Environment preparation, dependency synchronization and database migrations: passed.
- Changed-file Prettier and ESLint: passed.
- `pnpm -F api lint`: passed.
- `pnpm -F api check-types`: passed.
- `pnpm knip --workspace api`: passed.
- Focused `completion failure logs` cases: 29 passed.
- Complete `run-lifecycle.bdd.test.ts` with `--maxWorkers=4`: 232 passed, no skipped cases.
- Complete run-lifecycle, chat-events.bdd, chat-threads.bdd and connector-catalog cohort with `--maxWorkers=4`: 530 passed, no skipped cases (484.09 s wall time).
- `git diff --check`: passed.
- Commit hooks: unchanged formatting, full-repository Knip, all 15 Turbo type/dependency-build tasks, file-size check and commitlint passed.

Validation caveat: the first identical four-file run had 529 passes and one 5 s timeout in the unmodified `prioritizes exact reusable work only for its runner and protection window` test, which executes before the modified matrix. All 29 changed cases passed in that run (0.42–1.31 s each). That runner-priority test also passed the complete-file run, a focused diagnostic recheck, and the second full concurrent run. No timeout, assertion, concurrency or source change was made for those rechecks; the initial failure is retained here rather than presented as a consistently green run.

## Risks and exclusions

Independent setup adds aggregate test work: the matrix totaled 20.74 s in the focused run and 15.88 s in the full file. This is a per-case reliability fix, not a claim of total-suite speedup. It also improves identification of the exact failing reason/provider combination.

No production code, failure-reason definitions, API or runner contracts, database schema, CI/concurrency configuration, retries, sleeps, skips, or timeout changes. Existing per-test cleanup remains responsible for owned fixtures and external mock/environment reset. Rust, Python and frontend suites are unrelated to this test-only change. The PR does not implement or depend on #32275.
