### PR TITLE
refactor(app): retire vm0 worker compatibility

### DIFF
--- a/.github/scripts/prepare-okou-app-worker-shell.sh
+++ b/.github/scripts/prepare-okou-app-worker-shell.sh
@@ -8,15 +8,6 @@ fi
 
 canonical_dist="$1"
 worker_shell="$2"
-production_primary_app_domain="${CLERK_PRODUCTION_PRIMARY_APP_DOMAIN:-app.okou.ai}"
-
-case "$production_primary_app_domain" in
-  app.vm0.ai | app.okou.ai) ;;
-  *)
-    echo "invalid Clerk production primary app domain: ${production_primary_app_domain}" >&2
-    exit 1
-    ;;
-esac
 
 required_files=(
   index.html
@@ -61,6 +52,6 @@ cp "${worker_shell}/icons/icon-512-maskable.png" \
 clerk_primary_app_domain_marker="__OKOU_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__"
 if grep -Fq "$clerk_primary_app_domain_marker" "${worker_shell}/index.html"; then
   sed -i \
-    "s|${clerk_primary_app_domain_marker}|${production_primary_app_domain}|g" \
+    "s|${clerk_primary_app_domain_marker}|app.okou.ai|g" \
     "${worker_shell}/index.html"
 fi

--- a/.github/scripts/tests/app-preview-ingress-workflow-test.sh
+++ b/.github/scripts/tests/app-preview-ingress-workflow-test.sh
@@ -99,7 +99,7 @@ end
 unless deploy_source.include?('worker_secrets="$(mktemp)"') &&
     deploy_source.include?("umask 077") &&
     deploy_source.include?('if [[ "$EVENT_NAME" == "pull_request" ]]') &&
-    deploy_source.include?('CLERK_EDGE_DEBUG_AUTHORIZED_PARTY: env.EXPECTED_PREVIEW_URL') &&
+    deploy_source.include?('CLERK_EDGE_AUTHORIZED_PARTY: env.EXPECTED_PREVIEW_URL') &&
     deploy_source.include?('unset CLERK_PUBLISHABLE_KEY CLERK_SECRET_KEY')
   raise "Worker preview deployment must create an ephemeral exact-origin secrets file"
 end

--- a/.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh
@@ -90,8 +90,6 @@ preview_prepare_step = find_step(
     turbo["jobs"]["deploy-app"], "Prepare standalone app Worker preview"
 )
 for shell_prepare_step in (prepare_step, preview_prepare_step):
-    if "CLERK_PRODUCTION_PRIMARY_APP_DOMAIN" in shell_prepare_step.get("env", {}):
-        raise RuntimeError(f"{shell_prepare_step['name']} must use Okou unconditionally")
     require_fragments(
         shell_prepare_step, ["bash .github/scripts/prepare-okou-app-worker-shell.sh"]
     )
@@ -219,9 +217,6 @@ for fragment in (
 ):
     if fragment not in worker_config_source:
         raise RuntimeError(f"production Worker config is missing: {fragment}")
-for retired_fragment in ('"pattern": "app.vm0.ai/*"', '"zone_name": "vm0.ai"'):
-    if retired_fragment in worker_config_source:
-        raise RuntimeError(f"production Worker config retains VM0: {retired_fragment}")
 
 for fragment in (
     "https://app.okou.ai",
@@ -236,9 +231,6 @@ for fragment in (
 ):
     if fragment not in production_verifier_source:
         raise RuntimeError(f"production verifier is missing: {fragment}")
-for retired_origin in ("https://app.vm0.ai", "https://api.vm0.ai"):
-    if retired_origin in production_verifier_source:
-        raise RuntimeError(f"production verifier retains VM0: {retired_origin}")
 
 for api_origin, app_origin in (("https://api.okou.ai", "https://app.okou.ai"),):
     for invocation in (

--- a/.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh
+++ b/.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh
@@ -86,20 +86,12 @@ deploy_step = find_step(worker_release_job, "Deploy App Worker production")
 start_step = find_step(worker_release_job, "Start GitHub Deployment")
 finish_step = find_step(worker_release_job, "Finish GitHub Deployment")
 
-primary_app_domain_expression = (
-    "${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.okou.ai' }}"
-)
 preview_prepare_step = find_step(
     turbo["jobs"]["deploy-app"], "Prepare standalone app Worker preview"
 )
 for shell_prepare_step in (prepare_step, preview_prepare_step):
-    if shell_prepare_step.get("env", {}).get("CLERK_PRODUCTION_PRIMARY_APP_DOMAIN") != (
-        primary_app_domain_expression
-    ):
-        raise RuntimeError(
-            f"{shell_prepare_step['name']} must retain the configured Clerk primary "
-            "domain with an app.okou.ai default"
-        )
+    if "CLERK_PRODUCTION_PRIMARY_APP_DOMAIN" in shell_prepare_step.get("env", {}):
+        raise RuntimeError(f"{shell_prepare_step['name']} must use Okou unconditionally")
     require_fragments(
         shell_prepare_step, ["bash .github/scripts/prepare-okou-app-worker-shell.sh"]
     )
@@ -151,8 +143,8 @@ deploy_source = require_fragments(
         "CLERK_PUBLISHABLE_KEY: env.CLERK_PUBLISHABLE_KEY",
         "CLERK_SECRET_KEY: env.CLERK_SECRET_KEY",
         "unset CLERK_PUBLISHABLE_KEY CLERK_SECRET_KEY",
-        '"https://app.vm0.ai|https://api.vm0.ai"',
-        '"https://app.okou.ai|https://api.okou.ai"',
+        'app_origin="https://app.okou.ai"',
+        'api_origin="https://api.okou.ai"',
         "Access-Control-Request-Method: GET",
         "%header{access-control-allow-origin}",
         "%header{access-control-allow-credentials}",
@@ -185,6 +177,8 @@ if start_step.get("with", {}).get("env") != "app/production":
     raise RuntimeError("production Worker must own the canonical App deployment")
 if finish_step.get("with", {}).get("status") != "${{ job.status }}":
     raise RuntimeError("production Worker deployment must report its final job status")
+if finish_step.get("with", {}).get("env_url") != "https://app.okou.ai":
+    raise RuntimeError("production Worker deployment must report the Okou App URL")
 
 steps = worker_release_job["steps"]
 if not (
@@ -222,16 +216,15 @@ if rollback_verification_step.get("run") != (
 for fragment in (
     '"pattern": "app.okou.ai/*"',
     '"zone_name": "okou.ai"',
-    '"pattern": "app.vm0.ai/*"',
-    '"zone_name": "vm0.ai"',
 ):
     if fragment not in worker_config_source:
         raise RuntimeError(f"production Worker config is missing: {fragment}")
+for retired_fragment in ('"pattern": "app.vm0.ai/*"', '"zone_name": "vm0.ai"'):
+    if retired_fragment in worker_config_source:
+        raise RuntimeError(f"production Worker config retains VM0: {retired_fragment}")
 
 for fragment in (
-    "https://app.vm0.ai",
     "https://app.okou.ai",
-    "https://api.vm0.ai",
     "https://api.okou.ai",
     "sign-in",
     "sign-up",
@@ -243,11 +236,11 @@ for fragment in (
 ):
     if fragment not in production_verifier_source:
         raise RuntimeError(f"production verifier is missing: {fragment}")
+for retired_origin in ("https://app.vm0.ai", "https://api.vm0.ai"):
+    if retired_origin in production_verifier_source:
+        raise RuntimeError(f"production verifier retains VM0: {retired_origin}")
 
-for api_origin, app_origin in (
-    ("https://api.vm0.ai", "https://app.vm0.ai"),
-    ("https://api.okou.ai", "https://app.okou.ai"),
-):
+for api_origin, app_origin in (("https://api.okou.ai", "https://app.okou.ai"),):
     for invocation in (
         f'verify_auth_redirect "{api_origin}" "{app_origin}"',
         f'verify_api_cors "{api_origin}" "{app_origin}"',

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -269,7 +269,7 @@ const builtIndexTemplate = indexTemplate
     "%VITE_CLERK_PUBLISHABLE_KEY_PROD%",
     productionClerkPublishableKey,
   )
-  .replaceAll("__OKOU_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__", "app.vm0.ai")
+  .replaceAll("__OKOU_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__", "app.okou.ai")
   .replaceAll("__OKOU_CLERK_BROWSER_SCRIPT_URL__", clerkBrowserScriptUrl);
 const embeddedIndexTemplate = builtIndexTemplate
   .replace(
@@ -297,8 +297,6 @@ const embeddedWorker = workerModule.createWorker(embeddedShell);
 const worker = embeddedWorker;
 const expectedClerkCoreScript = clerkCoreScript(builtIndexTemplate);
 const expectedClerkBootstrap = clerkBootstrap(builtIndexTemplate);
-const vm0Description =
-  "VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web.";
 const okouTitle = "AI Teammate for Real Work — More Done, Same Team | Okou";
 const okouDescription =
   "An AI teammate that connects to 3,000+ tools: get the right data, run agentic workflows, and deliver finished work with team-wide context.";
@@ -307,9 +305,8 @@ function publishableKey(environment, host) {
   return `pk_${environment}_${Buffer.from(`${host}$`).toString("base64")}`;
 }
 
-function assetEnvironment(publicBrand) {
+function assetEnvironment() {
   return {
-    ...(publicBrand ? { PUBLIC_BRAND: publicBrand } : {}),
     STATIC_ASSETS_BUCKET: {
       get(key, options) {
         observedR2Key = key;
@@ -428,7 +425,7 @@ function assertNoClerkSecrets(snapshot) {
     "sk_test_secret-must-not-render",
     "sk_live_secret-must-not-render",
     "session-token-must-not-render",
-    "sess_must-not-render",
+    "org_must-not-render",
     "claim-must-not-render",
     "handshake-cookie-must-not-render",
     "refreshed-cookie-must-not-render",
@@ -473,62 +470,28 @@ function assertBootstrapAvatar(html) {
   assert.doesNotMatch(html, /assets\/avatar-svg\//u);
 }
 
-async function requestAppPage(origin, publicBrand) {
+async function requestAppPage(origin) {
   const response = await worker.fetch(
     new Request(`${origin}/settings/profile`),
-    assetEnvironment(publicBrand),
+    assetEnvironment(),
   );
   const html = await response.text();
   return { html, response };
 }
 
-const vm0Page = await requestAppPage("https://app.vm0.ai");
-assert.equal(vm0Page.response.status, 200);
-assert.equal(vm0Page.response.headers.get("x-robots-tag"), "noindex, nofollow");
-assert.equal(vm0Page.response.headers.get("content-encoding"), null);
-assert.equal(vm0Page.response.headers.get("etag"), null);
-assert.equal(vm0Page.response.headers.get("x-frame-options"), "DENY");
+const okouPage = await requestAppPage("https://app.okou.ai");
+assert.equal(okouPage.response.status, 200);
 assert.equal(
-  vm0Page.response.headers.get("permissions-policy"),
+  okouPage.response.headers.get("x-robots-tag"),
+  "noindex, nofollow",
+);
+assert.equal(okouPage.response.headers.get("content-encoding"), null);
+assert.equal(okouPage.response.headers.get("etag"), null);
+assert.equal(okouPage.response.headers.get("x-frame-options"), "DENY");
+assert.equal(
+  okouPage.response.headers.get("permissions-policy"),
   "camera=(), geolocation=(), payment=(), usb=(), serial=(), display-capture=(self), clipboard-read=(), microphone=(self), bluetooth=(self), clipboard-write=(self), fullscreen=(self)",
 );
-assert.equal(
-  documentTitle(vm0Page.html),
-  "AI Agents for Real Work — Your Trustworthy AI Teammate | VM0",
-);
-assert.equal(htmlAttribute(vm0Page.html, "data-app-brand-name"), "VM0");
-assert.equal(metaContent(vm0Page.html, "name", "application-name"), "VM0");
-assert.equal(metaContent(vm0Page.html, "name", "description"), vm0Description);
-assert.equal(metaContent(vm0Page.html, "property", "og:site_name"), "VM0");
-assert.equal(
-  metaContent(vm0Page.html, "property", "og:image"),
-  "https://static.vm0.io/web/og-image.png",
-);
-assert.equal(
-  metaContent(vm0Page.html, "name", "twitter:image"),
-  "https://static.vm0.io/web/og-image.png",
-);
-assert.equal(metaContent(vm0Page.html, "name", "twitter:site"), "@okou_ai");
-assert.equal(metaContent(vm0Page.html, "name", "twitter:creator"), "@okou_ai");
-assert.equal(metaContent(vm0Page.html, "name", "robots"), "noindex, nofollow");
-assert.equal(
-  tagAttribute(vm0Page.html, "link", "rel", "canonical", "href"),
-  "https://app.vm0.ai/",
-);
-assert.ok(
-  tagAttributeValues(vm0Page.html, "link", "href").includes(
-    "https://static.vm0.io/public/okou-favicon-adaptive-b4eda9221bb7.svg",
-  ),
-);
-assert.equal(
-  tagAttribute(vm0Page.html, "link", "rel", "apple-touch-icon", "href"),
-  "https://static.vm0.io/platform/okou-pwa-be0be646-180.png",
-);
-assertBootstrapAvatar(vm0Page.html);
-assert.equal(clerkCoreScript(vm0Page.html), expectedClerkCoreScript);
-assert.equal(clerkBootstrap(vm0Page.html), expectedClerkBootstrap);
-
-const okouPage = await requestAppPage("https://app.okou.ai");
 assert.equal(documentTitle(okouPage.html), okouTitle);
 assert.equal(htmlAttribute(okouPage.html, "data-app-brand-name"), "Okou");
 assert.equal(metaContent(okouPage.html, "name", "application-name"), "Okou");
@@ -581,7 +544,6 @@ assert.equal(clerkBootstrap(okouPage.html), expectedClerkBootstrap);
 
 const okouPreview = await requestAppPage(
   "https://pr-25304-app-okou-app-preview.vm0.workers.dev",
-  "okou",
 );
 assert.equal(htmlAttribute(okouPreview.html, "data-app-brand-name"), "Okou");
 assert.equal(
@@ -594,7 +556,7 @@ assert.equal(okouPreview.html.includes("/npm/@clerk/ui@"), false);
 
 const serviceWorker = await worker.fetch(
   new Request("https://pr-25304-app-okou-app-preview.vm0.workers.dev/sw.js"),
-  assetEnvironment("okou"),
+  assetEnvironment(),
 );
 assert.equal(
   serviceWorker.headers.get("cache-control"),
@@ -607,7 +569,7 @@ const embeddedPage = await embeddedWorker.fetch(
   new Request(
     "https://pr-25304-app-okou-app-preview.vm0.workers.dev/settings/profile",
   ),
-  { PUBLIC_BRAND: "okou" },
+  {},
 );
 const embeddedHtml = await embeddedPage.text();
 assert.equal(embeddedPage.status, 200);
@@ -631,7 +593,7 @@ assert.doesNotMatch(
 
 const embeddedProductionPage = await embeddedWorker.fetch(
   new Request("https://app.okou.ai/settings/profile"),
-  { PUBLIC_BRAND: "okou" },
+  {},
 );
 const embeddedProductionHtml = await embeddedProductionPage.text();
 assert.match(
@@ -643,44 +605,46 @@ assert.doesNotMatch(
   /https:\/\/app\.okou\.ai\/okou-app\/assets\/index-Test1234\.js/u,
 );
 
-const edgeDebugOrigin = "https://pr-25304-app-okou-app-preview.vm0.workers.dev";
-const edgeDebugUrl = `${edgeDebugOrigin}/settings/profile`;
-const edgeDebugEnvironment = {
-  CLERK_EDGE_DEBUG_AUTHORIZED_PARTY: edgeDebugOrigin,
+const edgePreviewOrigin =
+  "https://pr-25304-app-okou-app-preview.vm0.workers.dev";
+const edgePreviewUrl = `${edgePreviewOrigin}/settings/profile`;
+const edgePreviewEnvironment = {
+  CLERK_EDGE_AUTHORIZED_PARTY: edgePreviewOrigin,
   CLERK_PUBLISHABLE_KEY: previewClerkPublishableKey,
   CLERK_SECRET_KEY: "sk_test_secret-must-not-render",
-  PUBLIC_BRAND: "okou",
 };
-let unexpectedClerkClientFactoryCalls = 0;
-const unexpectedClerkClientFactory = () => {
-  unexpectedClerkClientFactoryCalls += 1;
-  throw new Error("Clerk must not run for this request");
+let failingClerkClientFactoryCalls = 0;
+const failingClerkClientFactory = () => {
+  failingClerkClientFactoryCalls += 1;
+  throw new Error("Clerk client factory failure");
 };
 const guardedEdgeWorker = workerModule.createWorker(
   embeddedShell,
-  unexpectedClerkClientFactory,
+  failingClerkClientFactory,
 );
-const edgeDebugBaseline = await responseSnapshot(
+const edgePreviewBaseline = await responseSnapshot(
   guardedEdgeWorker,
-  edgeDebugUrl,
-  edgeDebugEnvironment,
+  edgePreviewUrl,
+  edgePreviewEnvironment,
 );
-assert.doesNotMatch(edgeDebugBaseline.body, /okou-clerk-edge-session/u);
-assertNoClerkSecrets(edgeDebugBaseline);
+assert.doesNotMatch(edgePreviewBaseline.body, /okou-clerk-edge-session/u);
+assertNoClerkSecrets(edgePreviewBaseline);
+assert.equal(failingClerkClientFactoryCalls, 1);
 
 const retiredDebugFlag = await responseSnapshot(
   guardedEdgeWorker,
-  `${edgeDebugUrl}?__clerk_edge_debug=1`,
-  edgeDebugEnvironment,
+  `${edgePreviewUrl}?__clerk_edge_debug=1`,
+  edgePreviewEnvironment,
 );
-assert.deepEqual(retiredDebugFlag, edgeDebugBaseline);
+assert.deepEqual(retiredDebugFlag, edgePreviewBaseline);
 
 const duplicateFlag = await responseSnapshot(
   guardedEdgeWorker,
-  `${edgeDebugUrl}?__bootstrap=1&__bootstrap=1`,
-  edgeDebugEnvironment,
+  `${edgePreviewUrl}?__bootstrap=1&__bootstrap=1`,
+  edgePreviewEnvironment,
 );
-assert.deepEqual(duplicateFlag, edgeDebugBaseline);
+assert.deepEqual(duplicateFlag, edgePreviewBaseline);
+assert.equal(failingClerkClientFactoryCalls, 3);
 
 for (const ineligibleOrigin of [
   "http://app.okou.ai",
@@ -690,8 +654,8 @@ for (const ineligibleOrigin of [
 ]) {
   const ineligibleUrl = `${ineligibleOrigin}/settings/profile`;
   const ineligibleEnvironment = {
-    ...edgeDebugEnvironment,
-    CLERK_EDGE_DEBUG_AUTHORIZED_PARTY: ineligibleOrigin,
+    ...edgePreviewEnvironment,
+    CLERK_EDGE_AUTHORIZED_PARTY: ineligibleOrigin,
   };
   const baseline = await responseSnapshot(
     guardedEdgeWorker,
@@ -706,22 +670,22 @@ for (const ineligibleOrigin of [
   assert.deepEqual(flagged, baseline);
   assertNoClerkSecrets(flagged);
 }
+assert.equal(failingClerkClientFactoryCalls, 3);
 
 const missingConfig = await responseSnapshot(
   guardedEdgeWorker,
-  `${edgeDebugUrl}?__bootstrap=1`,
+  edgePreviewUrl,
   {
-    CLERK_EDGE_DEBUG_AUTHORIZED_PARTY: edgeDebugOrigin,
-    PUBLIC_BRAND: "okou",
+    CLERK_EDGE_AUTHORIZED_PARTY: edgePreviewOrigin,
   },
 );
-assert.equal(missingConfig.body, edgeDebugBaseline.body);
-assert.equal(missingConfig.status, edgeDebugBaseline.status);
+assert.equal(missingConfig.body, edgePreviewBaseline.body);
+assert.equal(missingConfig.status, edgePreviewBaseline.status);
 assert.equal(
   new Headers(missingConfig.headers).get("Cache-Control"),
   "private, no-store",
 );
-assert.equal(unexpectedClerkClientFactoryCalls, 0);
+assert.equal(failingClerkClientFactoryCalls, 3);
 
 function clerkClientReturning(requestState) {
   return () => ({
@@ -739,8 +703,8 @@ const anonymous = await responseSnapshot(
       isAuthenticated: false,
     }),
   ),
-  `${edgeDebugUrl}?__bootstrap=1`,
-  edgeDebugEnvironment,
+  edgePreviewUrl,
+  edgePreviewEnvironment,
 );
 
 const handshake = await responseSnapshot(
@@ -754,8 +718,8 @@ const handshake = await responseSnapshot(
       isAuthenticated: false,
     }),
   ),
-  `${edgeDebugUrl}?__bootstrap=1`,
-  edgeDebugEnvironment,
+  edgePreviewUrl,
+  edgePreviewEnvironment,
 );
 
 const refresh = await responseSnapshot(
@@ -771,8 +735,8 @@ const refresh = await responseSnapshot(
       },
     }),
   ),
-  `${edgeDebugUrl}?__bootstrap=1`,
-  edgeDebugEnvironment,
+  edgePreviewUrl,
+  edgePreviewEnvironment,
 );
 
 const thrown = await responseSnapshot(
@@ -781,16 +745,16 @@ const thrown = await responseSnapshot(
       return Promise.reject(new Error("Clerk network failure"));
     },
   })),
-  `${edgeDebugUrl}?__bootstrap=1`,
-  edgeDebugEnvironment,
+  edgePreviewUrl,
+  edgePreviewEnvironment,
 );
 
 const constructorThrown = await responseSnapshot(
   workerModule.createWorker(embeddedShell, () => {
     throw new Error("Clerk SDK failure");
   }),
-  `${edgeDebugUrl}?__bootstrap=1`,
-  edgeDebugEnvironment,
+  edgePreviewUrl,
+  edgePreviewEnvironment,
 );
 
 const timedOut = await responseSnapshot(
@@ -799,8 +763,8 @@ const timedOut = await responseSnapshot(
       return new Promise(() => {});
     },
   })),
-  `${edgeDebugUrl}?__bootstrap=1`,
-  edgeDebugEnvironment,
+  edgePreviewUrl,
+  edgePreviewEnvironment,
 );
 
 for (const unchanged of [
@@ -811,8 +775,8 @@ for (const unchanged of [
   constructorThrown,
   timedOut,
 ]) {
-  assert.equal(unchanged.body, edgeDebugBaseline.body);
-  assert.equal(unchanged.status, edgeDebugBaseline.status);
+  assert.equal(unchanged.body, edgePreviewBaseline.body);
+  assert.equal(unchanged.status, edgePreviewBaseline.status);
   assert.equal(
     new Headers(unchanged.headers).get("Cache-Control"),
     "private, no-store",
@@ -823,7 +787,7 @@ for (const unchanged of [
 }
 
 const currentUserId = "user_current</script><script>alert(1)</script>";
-const currentOrgId = "org_current";
+const currentSessionId = "sess_current";
 const emptyBootstrapFetcher = () => {
   return Promise.resolve(Response.json({ responses: [] }));
 };
@@ -840,10 +804,10 @@ const authenticatedWorker = workerModule.createWorker(
     return {
       authenticateRequest(request, options) {
         if (
-          request.url !== `${edgeDebugUrl}?__bootstrap=1` ||
+          request.url !== edgePreviewUrl ||
           options.acceptsToken !== "session_token" ||
           options.authorizedParties.length !== 1 ||
-          options.authorizedParties[0] !== edgeDebugOrigin
+          options.authorizedParties[0] !== edgePreviewOrigin
         ) {
           return Promise.reject(new Error("Unexpected Clerk request options"));
         }
@@ -853,9 +817,9 @@ const authenticatedWorker = workerModule.createWorker(
           token: "session-token-must-not-render",
           toAuth() {
             return {
-              orgId: currentOrgId,
+              orgId: "org_must-not-render",
               sessionClaims: { private: "claim-must-not-render" },
-              sessionId: "sess_must-not-render",
+              sessionId: currentSessionId,
               userId: currentUserId,
             };
           },
@@ -867,8 +831,8 @@ const authenticatedWorker = workerModule.createWorker(
 );
 const authenticated = await responseSnapshot(
   authenticatedWorker,
-  `${edgeDebugUrl}?__bootstrap=1`,
-  edgeDebugEnvironment,
+  edgePreviewUrl,
+  edgePreviewEnvironment,
 );
 assert.equal(authenticated.status, 200);
 assert.equal(
@@ -882,104 +846,91 @@ assert.match(authenticated.body, /\\u003c\/script>/u);
 assert.doesNotMatch(authenticated.body, /<script>alert\(1\)<\/script>/u);
 assert.deepEqual(clerkEdgeSessionJson(authenticated.body), {
   userId: currentUserId,
-  orgId: currentOrgId,
+  sessionId: currentSessionId,
 });
 assert.deepEqual(Object.keys(clerkEdgeSessionJson(authenticated.body)).sort(), [
-  "orgId",
+  "sessionId",
   "userId",
 ]);
 assertNoClerkSecrets(authenticated);
 
-for (const [productionOrigin, publicBrand] of [
-  ["https://app.okou.ai", "okou"],
-  ["https://app.vm0.ai", "vm0"],
-]) {
-  const productionEdgeUrl = `${productionOrigin}/settings/profile`;
-  const productionEdgeEnvironment = {
-    CLERK_PUBLISHABLE_KEY: productionClerkPublishableKey,
-    CLERK_SECRET_KEY: "sk_live_secret-must-not-render",
-    PUBLIC_BRAND: publicBrand,
-  };
-  let clerkClientFactoryCalls = 0;
-  const productionEdgeWorker = workerModule.createWorker(
-    embeddedShell,
-    ({ publishableKey, secretKey, telemetry }) => {
-      clerkClientFactoryCalls += 1;
-      assert.equal(publishableKey, productionClerkPublishableKey);
-      assert.equal(secretKey, "sk_live_secret-must-not-render");
-      assert.equal(telemetry?.disabled, true);
-      return {
-        authenticateRequest(request, options) {
-          assert.equal(request.url, `${productionEdgeUrl}?__bootstrap=1`);
-          assert.equal(options.acceptsToken, "session_token");
-          assert.deepEqual(options.authorizedParties, [productionOrigin]);
-          return Promise.resolve({
-            headers: new Headers(),
-            isAuthenticated: true,
-            toAuth() {
-              return {
-                orgId: "org_production",
-                userId: "user_production",
-              };
-            },
-          });
-        },
-      };
-    },
-    emptyBootstrapFetcher,
-  );
-  const productionBaseline = await responseSnapshot(
-    productionEdgeWorker,
-    productionEdgeUrl,
-    productionEdgeEnvironment,
-  );
-  assert.equal(clerkClientFactoryCalls, 0);
-  assert.doesNotMatch(productionBaseline.body, /okou-clerk-edge-session/u);
+const productionOrigin = "https://app.okou.ai";
+const productionEdgeUrl = `${productionOrigin}/settings/profile`;
+const productionEdgeEnvironment = {
+  CLERK_PUBLISHABLE_KEY: productionClerkPublishableKey,
+  CLERK_SECRET_KEY: "sk_live_secret-must-not-render",
+};
+let clerkClientFactoryCalls = 0;
+const productionEdgeWorker = workerModule.createWorker(
+  embeddedShell,
+  ({ publishableKey, secretKey, telemetry }) => {
+    clerkClientFactoryCalls += 1;
+    assert.equal(publishableKey, productionClerkPublishableKey);
+    assert.equal(secretKey, "sk_live_secret-must-not-render");
+    assert.equal(telemetry?.disabled, true);
+    return {
+      authenticateRequest(request, options) {
+        assert.equal(request.url, productionEdgeUrl);
+        assert.equal(options.acceptsToken, "session_token");
+        assert.deepEqual(options.authorizedParties, [productionOrigin]);
+        return Promise.resolve({
+          headers: new Headers(),
+          isAuthenticated: true,
+          toAuth() {
+            return {
+              sessionId: "sess_production",
+              userId: "user_production",
+            };
+          },
+        });
+      },
+    };
+  },
+  emptyBootstrapFetcher,
+);
+const productionAuthenticated = await responseSnapshot(
+  productionEdgeWorker,
+  productionEdgeUrl,
+  productionEdgeEnvironment,
+);
+assert.equal(clerkClientFactoryCalls, 1);
+assert.deepEqual(clerkEdgeSessionJson(productionAuthenticated.body), {
+  userId: "user_production",
+  sessionId: "sess_production",
+});
+assert.equal(
+  new Headers(productionAuthenticated.headers).get("Cache-Control"),
+  "private, no-store",
+);
+assertNoClerkSecrets(productionAuthenticated);
 
-  const productionAuthenticated = await responseSnapshot(
-    productionEdgeWorker,
-    `${productionEdgeUrl}?__bootstrap=1`,
-    productionEdgeEnvironment,
-  );
-  assert.equal(clerkClientFactoryCalls, 1);
-  assert.deepEqual(clerkEdgeSessionJson(productionAuthenticated.body), {
-    userId: "user_production",
-    orgId: "org_production",
-  });
-  assert.equal(
-    new Headers(productionAuthenticated.headers).get("Cache-Control"),
-    "private, no-store",
-  );
-  assertNoClerkSecrets(productionAuthenticated);
-}
-
-const authenticatedWithoutOrganization = await responseSnapshot(
+const authenticatedWithoutSession = await responseSnapshot(
   workerModule.createWorker(
     embeddedShell,
     clerkClientReturning({
       headers: new Headers(),
       isAuthenticated: true,
       toAuth() {
-        return { userId: "user_without_organization", orgId: null };
+        return { userId: "user_without_session", sessionId: null };
       },
     }),
     emptyBootstrapFetcher,
   ),
-  `${edgeDebugUrl}?__bootstrap=1`,
-  edgeDebugEnvironment,
+  edgePreviewUrl,
+  edgePreviewEnvironment,
 );
-assert.deepEqual(clerkEdgeSessionJson(authenticatedWithoutOrganization.body), {
-  userId: "user_without_organization",
-  orgId: null,
-});
+assert.doesNotMatch(
+  authenticatedWithoutSession.body,
+  /okou-clerk-edge-session/u,
+);
 assert.equal(
-  new Headers(authenticatedWithoutOrganization.headers).get("Cache-Control"),
+  new Headers(authenticatedWithoutSession.headers).get("Cache-Control"),
   "private, no-store",
 );
-assertNoClerkSecrets(authenticatedWithoutOrganization);
+assertNoClerkSecrets(authenticatedWithoutSession);
 
 const bootstrapPagePath =
-  "/agents/agent-1/chat?__bootstrap=1&x-vercel-protection-bypass=query-secret&keep=value";
+  "/agents/agent-1/chat?x-vercel-protection-bypass=query-secret&keep=value";
 let observedBootstrapRequest = null;
 const bootstrapWorker = workerModule.createWorker(
   embeddedShell,
@@ -987,7 +938,7 @@ const bootstrapWorker = workerModule.createWorker(
     headers: new Headers(),
     isAuthenticated: true,
     toAuth() {
-      return { userId: "user_bootstrap", orgId: "org_bootstrap" };
+      return { userId: "user_bootstrap", sessionId: "sess_bootstrap" };
     },
   }),
   (input, init) => {
@@ -1014,8 +965,8 @@ const bootstrapWorker = workerModule.createWorker(
 );
 const bootstrapped = await responseSnapshot(
   bootstrapWorker,
-  `${edgeDebugOrigin}${bootstrapPagePath}`,
-  edgeDebugEnvironment,
+  `${edgePreviewOrigin}${bootstrapPagePath}`,
+  edgePreviewEnvironment,
 );
 assert.equal(observedBootstrapRequest?.url.origin, previewOrigin);
 assert.equal(observedBootstrapRequest?.url.pathname, "/api/bootstrap");
@@ -1023,7 +974,10 @@ assert.equal(
   observedBootstrapRequest?.url.searchParams.get("path"),
   bootstrapPagePath,
 );
-assert.equal(observedBootstrapRequest?.headers.get("Origin"), edgeDebugOrigin);
+assert.equal(
+  observedBootstrapRequest?.headers.get("Origin"),
+  edgePreviewOrigin,
+);
 assert.equal(
   observedBootstrapRequest?.headers.get("Cookie"),
   "__session=jwt-cookie-must-not-render; __clerk_db_jwt=dev-browser-jwt-must-not-render",
@@ -1045,7 +999,7 @@ assert.ok(
 
 const embeddedServiceWorker = await embeddedWorker.fetch(
   new Request("https://pr-25304-app-okou-app-preview.vm0.workers.dev/sw.js"),
-  { PUBLIC_BRAND: "okou" },
+  {},
 );
 assert.equal(
   await embeddedServiceWorker.text(),
@@ -1061,34 +1015,26 @@ const embeddedIcon = await embeddedWorker.fetch(
   new Request(
     "https://pr-25304-app-okou-app-preview.vm0.workers.dev/icons/icon-192.png",
   ),
-  { PUBLIC_BRAND: "okou" },
+  {},
 );
 assert.equal(embeddedIcon.headers.get("content-type"), "image/png");
 assert.equal(await embeddedIcon.text(), "icon-192");
 
-const untrustedSuffix = await requestAppPage("https://okou.ai.evil.example");
-assert.equal(htmlAttribute(untrustedSuffix.html, "data-app-brand-name"), "VM0");
-
-for (const [origin, brandName, description] of [
-  ["https://app.vm0.ai", "VM0", vm0Description],
-  ["https://app.okou.ai", "Okou", okouDescription],
-]) {
-  const response = await worker.fetch(
-    new Request(`${origin}/manifest.webmanifest`),
-    assetEnvironment(),
-  );
-  const manifest = await response.json();
-  assert.equal(response.headers.get("content-encoding"), null);
-  assert.equal(response.headers.get("etag"), null);
-  assert.equal(
-    response.headers.get("content-type"),
-    "application/manifest+json; charset=UTF-8",
-  );
-  assert.equal(manifest.name, brandName);
-  assert.equal(manifest.short_name, brandName);
-  assert.equal(manifest.description, description);
-  assert.equal(manifest.icons.length, 3);
-}
+const manifestResponse = await worker.fetch(
+  new Request("https://app.okou.ai/manifest.webmanifest"),
+  assetEnvironment(),
+);
+const manifest = await manifestResponse.json();
+assert.equal(manifestResponse.headers.get("content-encoding"), null);
+assert.equal(manifestResponse.headers.get("etag"), null);
+assert.equal(
+  manifestResponse.headers.get("content-type"),
+  "application/manifest+json; charset=UTF-8",
+);
+assert.equal(manifest.name, "Okou");
+assert.equal(manifest.short_name, "Okou");
+assert.equal(manifest.description, okouDescription);
+assert.equal(manifest.icons.length, 3);
 
 let observedR2Key = null;
 let observedR2Options = null;
@@ -1235,7 +1181,7 @@ assert.equal(
 );
 const productionHtml = await production.response.text();
 
-const vm0SharedOnOkouHost = await requestSharedPage({
+const legacyBrandSharedOnOkouHost = await requestSharedPage({
   appOrigin: "https://app.okou.ai",
   metaResponse() {
     return Response.json({
@@ -1244,17 +1190,23 @@ const vm0SharedOnOkouHost = await requestSharedPage({
     });
   },
 });
-assert.equal(vm0SharedOnOkouHost.response.status, 200);
-const vm0SharedHtml = await vm0SharedOnOkouHost.response.text();
-assert.equal(documentTitle(vm0SharedHtml), "Legacy conversation | VM0");
-assert.equal(htmlAttribute(vm0SharedHtml, "data-app-brand-name"), "VM0");
+assert.equal(legacyBrandSharedOnOkouHost.response.status, 200);
+const legacyBrandSharedHtml = await legacyBrandSharedOnOkouHost.response.text();
 assert.equal(
-  metaContent(vm0SharedHtml, "property", "og:url"),
-  `https://app.vm0.ai/share/threads/${sharedThreadId}`,
+  documentTitle(legacyBrandSharedHtml),
+  "Legacy conversation | Okou",
 );
 assert.equal(
-  metaContent(vm0SharedHtml, "property", "og:image"),
-  "https://static.vm0.io/web/og-image.png",
+  htmlAttribute(legacyBrandSharedHtml, "data-app-brand-name"),
+  "Okou",
+);
+assert.equal(
+  metaContent(legacyBrandSharedHtml, "property", "og:url"),
+  `https://app.okou.ai/share/threads/${sharedThreadId}`,
+);
+assert.equal(
+  metaContent(legacyBrandSharedHtml, "property", "og:image"),
+  "https://static.okou.io/web/okou-og-image-373c892e.png",
 );
 
 const missingBrandSharedPage = await requestSharedPage({
@@ -1263,10 +1215,15 @@ const missingBrandSharedPage = await requestSharedPage({
     return Response.json({ title: "Missing-brand conversation" });
   },
 });
-assert.equal(missingBrandSharedPage.response.status, 502);
+assert.equal(missingBrandSharedPage.response.status, 200);
+const missingBrandSharedHtml = await missingBrandSharedPage.response.text();
+assert.equal(
+  documentTitle(missingBrandSharedHtml),
+  "Missing-brand conversation | Okou",
+);
 
 const missing = await requestSharedPage({
-  appOrigin: "https://app.vm0.ai",
+  appOrigin: "https://app.okou.ai",
   metaResponse() {
     return Response.json(
       { error: { code: "NOT_FOUND", message: "Not found" } },
@@ -1277,7 +1234,7 @@ const missing = await requestSharedPage({
 assert.equal(missing.response.status, 404);
 assert.equal(
   missing.observedUrl,
-  `https://api.vm0.ai/api/shared-threads/${sharedThreadId}/meta`,
+  `https://api.okou.ai/api/shared-threads/${sharedThreadId}/meta`,
 );
 assert.equal(
   missing.response.headers.get("cache-control"),
@@ -1285,7 +1242,10 @@ assert.equal(
 );
 assert.equal(missing.response.headers.get("x-robots-tag"), "noindex, nofollow");
 const missingHtml = await missing.response.text();
-assert.equal(documentTitle(missingHtml), "Shared conversation not found | VM0");
+assert.equal(
+  documentTitle(missingHtml),
+  "Shared conversation not found | Okou",
+);
 assert.equal(metaContent(missingHtml, "property", "og:title"), null);
 assert.equal(metaContent(missingHtml, "name", "twitter:title"), null);
 

--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -631,21 +631,6 @@ assert.doesNotMatch(edgePreviewBaseline.body, /okou-clerk-edge-session/u);
 assertNoClerkSecrets(edgePreviewBaseline);
 assert.equal(failingClerkClientFactoryCalls, 1);
 
-const retiredDebugFlag = await responseSnapshot(
-  guardedEdgeWorker,
-  `${edgePreviewUrl}?__clerk_edge_debug=1`,
-  edgePreviewEnvironment,
-);
-assert.deepEqual(retiredDebugFlag, edgePreviewBaseline);
-
-const duplicateFlag = await responseSnapshot(
-  guardedEdgeWorker,
-  `${edgePreviewUrl}?__bootstrap=1&__bootstrap=1`,
-  edgePreviewEnvironment,
-);
-assert.deepEqual(duplicateFlag, edgePreviewBaseline);
-assert.equal(failingClerkClientFactoryCalls, 3);
-
 for (const ineligibleOrigin of [
   "http://app.okou.ai",
   "https://app.okou.ai.evil.example",
@@ -662,15 +647,10 @@ for (const ineligibleOrigin of [
     ineligibleUrl,
     ineligibleEnvironment,
   );
-  const flagged = await responseSnapshot(
-    guardedEdgeWorker,
-    `${ineligibleUrl}?__bootstrap=1`,
-    ineligibleEnvironment,
-  );
-  assert.deepEqual(flagged, baseline);
-  assertNoClerkSecrets(flagged);
+  assert.doesNotMatch(baseline.body, /okou-clerk-edge-session/u);
+  assertNoClerkSecrets(baseline);
 }
-assert.equal(failingClerkClientFactoryCalls, 3);
+assert.equal(failingClerkClientFactoryCalls, 1);
 
 const missingConfig = await responseSnapshot(
   guardedEdgeWorker,
@@ -685,7 +665,7 @@ assert.equal(
   new Headers(missingConfig.headers).get("Cache-Control"),
   "private, no-store",
 );
-assert.equal(failingClerkClientFactoryCalls, 3);
+assert.equal(failingClerkClientFactoryCalls, 1);
 
 function clerkClientReturning(requestState) {
   return () => ({
@@ -1178,48 +1158,6 @@ assert.equal(
 assert.equal(
   production.observedHeaders.get("x-vercel-protection-bypass"),
   null,
-);
-const productionHtml = await production.response.text();
-
-const legacyBrandSharedOnOkouHost = await requestSharedPage({
-  appOrigin: "https://app.okou.ai",
-  metaResponse() {
-    return Response.json({
-      title: "Legacy conversation",
-      publicBrand: "vm0",
-    });
-  },
-});
-assert.equal(legacyBrandSharedOnOkouHost.response.status, 200);
-const legacyBrandSharedHtml = await legacyBrandSharedOnOkouHost.response.text();
-assert.equal(
-  documentTitle(legacyBrandSharedHtml),
-  "Legacy conversation | Okou",
-);
-assert.equal(
-  htmlAttribute(legacyBrandSharedHtml, "data-app-brand-name"),
-  "Okou",
-);
-assert.equal(
-  metaContent(legacyBrandSharedHtml, "property", "og:url"),
-  `https://app.okou.ai/share/threads/${sharedThreadId}`,
-);
-assert.equal(
-  metaContent(legacyBrandSharedHtml, "property", "og:image"),
-  "https://static.okou.io/web/okou-og-image-373c892e.png",
-);
-
-const missingBrandSharedPage = await requestSharedPage({
-  appOrigin: "https://app.okou.ai",
-  metaResponse() {
-    return Response.json({ title: "Missing-brand conversation" });
-  },
-});
-assert.equal(missingBrandSharedPage.response.status, 200);
-const missingBrandSharedHtml = await missingBrandSharedPage.response.text();
-assert.equal(
-  documentTitle(missingBrandSharedHtml),
-  "Missing-brand conversation | Okou",
 );
 
 const missing = await requestSharedPage({

--- a/.github/scripts/tests/prepare-okou-app-worker-shell-test.sh
+++ b/.github/scripts/tests/prepare-okou-app-worker-shell-test.sh
@@ -16,15 +16,14 @@ printf '%s\n' \
   '<script type="module" src="https://static.okou.io/okou-app/assets/app-123.js"></script>' \
   > "${canonical_dist}/index.html"
 printf 'service worker\n' > "${canonical_dist}/sw.js"
-printf '{"name":"VM0"}\n' > "${canonical_dist}/manifest.webmanifest"
+printf '{"name":"Okou"}\n' > "${canonical_dist}/manifest.webmanifest"
 printf 'User-agent: *\nAllow: /\n' > "${canonical_dist}/robots.txt"
 printf '192\n' > "${canonical_dist}/icons/icon-192.png"
 printf '512\n' > "${canonical_dist}/icons/icon-512.png"
 printf 'maskable\n' > "${canonical_dist}/icons/icon-512-maskable.png"
 printf 'source map\n' > "${canonical_dist}/app.js.map"
 
-env -u CLERK_PRODUCTION_PRIMARY_APP_DOMAIN \
-  bash "$script" "$canonical_dist" "$worker_shell"
+bash "$script" "$canonical_dist" "$worker_shell"
 
 expected_files="$(find "$worker_shell" -type f -printf '%P\n' | sort)"
 test "$expected_files" = "$(printf '%s\n' \
@@ -47,21 +46,10 @@ test ! -e "${worker_shell}/app.js.map"
 
 empty_shell="${tmp_dir}/empty-shell"
 mkdir "$empty_shell"
-CLERK_PRODUCTION_PRIMARY_APP_DOMAIN='' \
-  bash "$script" "$canonical_dist" "$empty_shell"
+bash "$script" "$canonical_dist" "$empty_shell"
 grep -Fq 'window.testPrimary="app.okou.ai"' "${empty_shell}/index.html"
 
-for primary_app_domain in app.okou.ai app.vm0.ai; do
-  explicit_shell="${tmp_dir}/${primary_app_domain}-shell"
-  mkdir "$explicit_shell"
-  CLERK_PRODUCTION_PRIMARY_APP_DOMAIN="$primary_app_domain" \
-    bash "$script" "$canonical_dist" "$explicit_shell"
-  grep -Fq "window.testPrimary=\"${primary_app_domain}\"" \
-    "${explicit_shell}/index.html"
-done
-
-for prepared_shell in "$worker_shell" "$empty_shell" \
-  "${tmp_dir}/app.okou.ai-shell" "${tmp_dir}/app.vm0.ai-shell"; do
+for prepared_shell in "$worker_shell" "$empty_shell"; do
   if grep -Fq '__OKOU_CLERK_PRODUCTION_PRIMARY_APP_DOMAIN__' \
     "${prepared_shell}/index.html"; then
     echo "expected the primary app domain marker to be replaced: $prepared_shell" >&2
@@ -69,23 +57,10 @@ for prepared_shell in "$worker_shell" "$empty_shell" \
   fi
 done
 
-invalid_shell="${tmp_dir}/invalid-shell"
-mkdir "$invalid_shell"
-if CLERK_PRODUCTION_PRIMARY_APP_DOMAIN=app.okou.ia \
-  bash "$script" "$canonical_dist" "$invalid_shell" \
-  > "${tmp_dir}/invalid.log" 2>&1; then
-  echo "expected an invalid primary app domain to be rejected" >&2
-  exit 1
-fi
-grep -Fq 'invalid Clerk production primary app domain: app.okou.ia' \
-  "${tmp_dir}/invalid.log"
-test -z "$(find "$invalid_shell" -mindepth 1 -print -quit)"
-
 nonempty_shell="${tmp_dir}/nonempty-shell"
 mkdir "$nonempty_shell"
 touch "${nonempty_shell}/existing"
-if env -u CLERK_PRODUCTION_PRIMARY_APP_DOMAIN \
-  bash "$script" "$canonical_dist" "$nonempty_shell" > /dev/null 2>&1; then
+if bash "$script" "$canonical_dist" "$nonempty_shell" > /dev/null 2>&1; then
   echo "expected a non-empty Worker shell directory to be rejected" >&2
   exit 1
 fi
@@ -93,8 +68,7 @@ fi
 missing_shell="${tmp_dir}/missing-shell"
 missing_dist="${tmp_dir}/missing-dist"
 mkdir "$missing_shell" "$missing_dist"
-if env -u CLERK_PRODUCTION_PRIMARY_APP_DOMAIN \
-  bash "$script" "$missing_dist" "$missing_shell" > /dev/null 2>&1; then
+if bash "$script" "$missing_dist" "$missing_shell" > /dev/null 2>&1; then
   echo "expected a canonical artifact with missing shell files to be rejected" >&2
   exit 1
 fi

--- a/.github/scripts/tests/verify-okou-production-domains-test.sh
+++ b/.github/scripts/tests/verify-okou-production-domains-test.sh
@@ -64,8 +64,6 @@ fi
 
 if [[ "$write_out" == '%{redirect_url}' ]]; then
   case "$url" in
-    https://api.vm0.ai/sign-in) redirect=https://app.vm0.ai/sign-in ;;
-    https://api.vm0.ai/sign-up) redirect=https://app.vm0.ai/sign-up ;;
     https://api.okou.ai/sign-in) redirect=https://app.okou.ai/sign-in ;;
     https://api.okou.ai/sign-up) redirect=https://app.okou.ai/sign-up ;;
     *)
@@ -80,8 +78,7 @@ fi
 
 if [[ "$request" == "OPTIONS" ]]; then
   case "$url:$origin" in
-    https://api.vm0.ai/api/__brand-smoke__:https://app.vm0.ai | \
-      https://api.okou.ai/api/__brand-smoke__:https://app.okou.ai) ;;
+    https://api.okou.ai/api/__brand-smoke__:https://app.okou.ai) ;;
     *)
       echo "unexpected CORS request: $url from $origin" >&2
       exit 1
@@ -99,13 +96,9 @@ chmod +x "${fake_bin}/curl"
 
 expected_log() {
   printf '%s\n' \
-    $'serve\thttps://app.vm0.ai' \
     $'serve\thttps://app.okou.ai' \
-    $'auth\thttps://api.vm0.ai/sign-in\thttps://app.vm0.ai/sign-in' \
-    $'auth\thttps://api.vm0.ai/sign-up\thttps://app.vm0.ai/sign-up' \
     $'auth\thttps://api.okou.ai/sign-in\thttps://app.okou.ai/sign-in' \
     $'auth\thttps://api.okou.ai/sign-up\thttps://app.okou.ai/sign-up' \
-    $'cors\thttps://api.vm0.ai/api/__brand-smoke__\thttps://app.vm0.ai' \
     $'cors\thttps://api.okou.ai/api/__brand-smoke__\thttps://app.okou.ai'
 }
 
@@ -121,7 +114,7 @@ verify_run() {
 
   expected_log > "$expected"
   if ! diff -u "$expected" "$curl_log"; then
-    fail "$name run did not verify both brand auth redirects and CORS pairs"
+    fail "$name run did not verify the Okou auth redirects and CORS pair"
   fi
 }
 

--- a/.github/scripts/verify-okou-production-domains.sh
+++ b/.github/scripts/verify-okou-production-domains.sh
@@ -13,10 +13,8 @@ curl_retry=(
   --retry-all-errors
 )
 
-for url in "https://app.vm0.ai" "https://app.okou.ai"; do
-  curl -fsSL "${curl_retry[@]}" "$url" --output /dev/null
-  echo "Production App is serving: $url"
-done
+curl -fsSL "${curl_retry[@]}" "https://app.okou.ai" --output /dev/null
+echo "Production App is serving: https://app.okou.ai"
 
 verify_auth_redirect() {
   local api_origin="$1"
@@ -64,7 +62,5 @@ verify_api_cors() {
   echo "Production API CORS is correct: ${app_origin} -> ${api_origin}"
 }
 
-verify_auth_redirect "https://api.vm0.ai" "https://app.vm0.ai"
 verify_auth_redirect "https://api.okou.ai" "https://app.okou.ai"
-verify_api_cors "https://api.vm0.ai" "https://app.vm0.ai"
 verify_api_cors "https://api.okou.ai" "https://app.okou.ai"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1611,7 +1611,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATIC_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATIC_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
-          CLERK_PRODUCTION_PRIMARY_APP_DOMAIN: ${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.okou.ai' }}
           R2_ACCOUNT_ID: ${{ vars.R2_ACCOUNT_ID }}
           R2_BUCKET_NAME: ${{ vars.R2_STATIC_BUCKET_NAME }}
         run: |
@@ -1731,32 +1730,29 @@ jobs:
             --message "app artifact ${ARTIFACT_SHA}"
           cd ..
 
-          for mapping in \
-            "https://app.vm0.ai|https://api.vm0.ai" \
-            "https://app.okou.ai|https://api.okou.ai"; do
-            IFS='|' read -r app_origin api_origin <<< "$mapping"
-            cors_result="$(
-              curl -fsS \
-                --connect-timeout 10 \
-                --max-time 30 \
-                --retry 12 \
-                --retry-delay 5 \
-                --retry-all-errors \
-                --request OPTIONS \
-                --header "Origin: ${app_origin}" \
-                --header "Access-Control-Request-Method: GET" \
-                --output /dev/null \
-                --write-out $'%{http_code}\n%header{access-control-allow-origin}\n%header{access-control-allow-credentials}' \
-                "${api_origin}/api/__brand-smoke__"
-            )"
-            mapfile -t cors_values <<< "$cors_result"
-            if [[ "${cors_values[0]:-}" != "204" ||
-                  "${cors_values[1]:-}" != "$app_origin" ||
-                  "${cors_values[2]:-}" != "true" ]]; then
-              echo "::error title=App Worker API CORS mismatch::${api_origin} rejected ${app_origin}" >&2
-              exit 1
-            fi
-          done
+          app_origin="https://app.okou.ai"
+          api_origin="https://api.okou.ai"
+          cors_result="$(
+            curl -fsS \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --retry 12 \
+              --retry-delay 5 \
+              --retry-all-errors \
+              --request OPTIONS \
+              --header "Origin: ${app_origin}" \
+              --header "Access-Control-Request-Method: GET" \
+              --output /dev/null \
+              --write-out $'%{http_code}\n%header{access-control-allow-origin}\n%header{access-control-allow-credentials}' \
+              "${api_origin}/api/__brand-smoke__"
+          )"
+          mapfile -t cors_values <<< "$cors_result"
+          if [[ "${cors_values[0]:-}" != "204" ||
+                "${cors_values[1]:-}" != "$app_origin" ||
+                "${cors_values[2]:-}" != "true" ]]; then
+            echo "::error title=App Worker API CORS mismatch::${api_origin} rejected ${app_origin}" >&2
+            exit 1
+          fi
 
       - name: Finish GitHub Deployment
         if: always()
@@ -1766,7 +1762,7 @@ jobs:
           token: ${{ github.token }}
           status: ${{ job.status }}
           env: ${{ steps.deployment.outputs.env }}
-          env_url: https://app.vm0.ai
+          env_url: https://app.okou.ai
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 
       - name: Report App Worker URLs
@@ -1777,7 +1773,6 @@ jobs:
             echo
             echo "### Live"
             echo "- https://app.okou.ai"
-            echo "- https://app.vm0.ai"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Calculate duration
@@ -1805,7 +1800,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*App* ✅ Deployed to Cloudflare Workers\n📦 Version: `${{ needs.release-please.outputs.app_deploy_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🌐 <https://app.vm0.ai|VM0 App> · <https://app.okou.ai|Okou App>"
+                  text: "*App* ✅ Deployed to Cloudflare Workers\n📦 Version: `${{ needs.release-please.outputs.app_deploy_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🌐 <https://app.okou.ai|Okou App>"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1528,7 +1528,6 @@ jobs:
       - name: Prepare standalone app Worker preview
         id: worker-preview
         env:
-          CLERK_PRODUCTION_PRIMARY_APP_DOMAIN: ${{ vars.CLERK_PRODUCTION_PRIMARY_APP_DOMAIN || 'app.okou.ai' }}
           ARTIFACT_EXISTS: ${{ steps.existing.outputs.exists }}
           ARTIFACT_PREFIX: ${{ steps.artifact.outputs.prefix }}
           WORKER_PREVIEW_ALIAS: ${{ steps.worker-alias.outputs.alias }}
@@ -1618,7 +1617,7 @@ jobs:
             trap 'rm -f "$worker_secrets"' EXIT
             jq -n \
               '{
-                CLERK_EDGE_DEBUG_AUTHORIZED_PARTY: env.EXPECTED_PREVIEW_URL,
+                CLERK_EDGE_AUTHORIZED_PARTY: env.EXPECTED_PREVIEW_URL,
                 CLERK_PUBLISHABLE_KEY: env.CLERK_PUBLISHABLE_KEY,
                 CLERK_SECRET_KEY: env.CLERK_SECRET_KEY
               }' > "$worker_secrets"

--- a/turbo/apps/api/src/__tests__/release-please-config.test.ts
+++ b/turbo/apps/api/src/__tests__/release-please-config.test.ts
@@ -173,7 +173,7 @@ describe("release-please API deployment graph", () => {
       "needs.promote-api-production.result == 'success'",
     );
     expect(promoteAppWorkerProductionJob).toContain("app.okou.ai");
-    expect(promoteAppWorkerProductionJob).toContain("app.vm0.ai");
+    expect(promoteAppWorkerProductionJob).not.toContain("app.vm0.ai");
     expect(updateRollbackDashboardJob).toContain(
       "needs.release-please.outputs.app_deploy_required != 'true'",
     );

--- a/turbo/apps/api/src/__tests__/release-please-config.test.ts
+++ b/turbo/apps/api/src/__tests__/release-please-config.test.ts
@@ -173,7 +173,6 @@ describe("release-please API deployment graph", () => {
       "needs.promote-api-production.result == 'success'",
     );
     expect(promoteAppWorkerProductionJob).toContain("app.okou.ai");
-    expect(promoteAppWorkerProductionJob).not.toContain("app.vm0.ai");
     expect(updateRollbackDashboardJob).toContain(
       "needs.release-please.outputs.app_deploy_required != 'true'",
     );

--- a/turbo/apps/app-worker/src/worker.js
+++ b/turbo/apps/app-worker/src/worker.js
@@ -13,13 +13,8 @@ const APP_ASSET_REQUEST_HEADER_NAMES = [
   "If-None-Match",
   "Range",
 ];
-const OKOU_ROOT_DOMAINS = ["okou.ai", "omby.ai"];
-const PRODUCTION_API_ORIGINS = new Map([
-  ["app.okou.ai", "https://api.okou.ai"],
-  ["app.vm0.ai", "https://api.vm0.ai"],
-]);
+const PRODUCTION_APP_HOSTNAME = "app.okou.ai";
 const VERCEL_PROTECTION_BYPASS = "x-vercel-protection-bypass";
-const APP_BOOTSTRAP_QUERY_PARAMETER = "__bootstrap";
 const CLERK_EDGE_SESSION_TIMEOUT_MS = 1000;
 const CLERK_EDGE_SESSION_PREVIEW_HOSTNAME_PATTERN =
   /^pr-[1-9][0-9]*-app-okou-app-preview\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.workers\.dev$/u;
@@ -41,19 +36,6 @@ const EMBEDDED_SHELL_CONTENT_TYPES = new Map([
   ["/icons/icon-512-maskable.png", "image/png"],
 ]);
 
-const VM0_APP_METADATA = {
-  brandName: "VM0",
-  canonicalUrl: "https://app.vm0.ai/",
-  description:
-    "VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web.",
-  documentTitle: "AI Agents for Real Work — Your Trustworthy AI Teammate | VM0",
-  openGraphTitle: "VM0 - Your Trustworthy AI Teammate",
-  socialImagePath: "web/og-image.png",
-  staticAssetsOrigin: "https://static.vm0.io",
-  twitterDescription:
-    "VM0 is an AI agent that connects to 100+ tools and does the work. Reports, triage, outreach, research. In Slack or on the web.",
-};
-
 const OKOU_APP_METADATA = {
   brandName: "Okou",
   canonicalUrl: "https://app.okou.ai/",
@@ -66,22 +48,6 @@ const OKOU_APP_METADATA = {
   twitterDescription:
     "An AI teammate that connects to 3,000+ tools: get the right data, run agentic workflows, and deliver finished work with team-wide context.",
 };
-
-function appMetadata(hostname, configuredPublicBrand) {
-  if (configuredPublicBrand === "okou") {
-    return OKOU_APP_METADATA;
-  }
-  if (configuredPublicBrand === "vm0") {
-    return VM0_APP_METADATA;
-  }
-  const normalizedHostname = hostname.toLowerCase();
-  const isOkou = OKOU_ROOT_DOMAINS.some((domain) => {
-    return (
-      normalizedHostname === domain || normalizedHostname.endsWith(`.${domain}`)
-    );
-  });
-  return isOkou ? OKOU_APP_METADATA : VM0_APP_METADATA;
-}
 
 function apiOrigin(requestUrl) {
   const origin = derivePlatformServiceOrigin(requestUrl.origin, "api");
@@ -125,50 +91,10 @@ function previewAppAssetHtml(indexHtml, requestUrl) {
   }
 
   const previewAssetBase = `${requestUrl.origin}${APP_ASSET_PATH_PREFIX}`;
-  return indexHtml
-    .replaceAll(
-      `${VM0_APP_METADATA.staticAssetsOrigin}${APP_ASSET_PATH_PREFIX}`,
-      previewAssetBase,
-    )
-    .replaceAll(
-      `${OKOU_APP_METADATA.staticAssetsOrigin}${APP_ASSET_PATH_PREFIX}`,
-      previewAssetBase,
-    );
-}
-
-function rewriteStaticAssetAttribute(attributeName, staticAssetsOrigin) {
-  return {
-    element(element) {
-      const value = element.getAttribute(attributeName);
-      if (value === null) {
-        return;
-      }
-      const rewritten = value.replace(
-        /^https:\/\/static\.(?:vm0|okou)\.io(?=\/|$)/u,
-        staticAssetsOrigin,
-      );
-      if (rewritten !== value) {
-        element.setAttribute(attributeName, rewritten);
-      }
-    },
-  };
-}
-
-function addStaticAssetHandlers(rewriter, metadata) {
-  rewriter
-    .on(
-      'link[rel="icon"]',
-      rewriteStaticAssetAttribute("href", metadata.staticAssetsOrigin),
-    )
-    .on(
-      'link[rel="preconnect"]',
-      rewriteStaticAssetAttribute("href", metadata.staticAssetsOrigin),
-    )
-    .on(
-      'link[rel="apple-touch-icon"]',
-      rewriteStaticAssetAttribute("href", metadata.staticAssetsOrigin),
-    )
-    .on("img", rewriteStaticAssetAttribute("src", metadata.staticAssetsOrigin));
+  return indexHtml.replaceAll(
+    `${OKOU_APP_METADATA.staticAssetsOrigin}${APP_ASSET_PATH_PREFIX}`,
+    previewAssetBase,
+  );
 }
 
 function htmlResponse(indexHtml, assetResponse, status, cacheControl) {
@@ -276,22 +202,15 @@ function appBootstrapScript(entry) {
 }
 
 function clerkEdgeSessionAuthorizedParty(requestUrl, env) {
-  const debugFlags = requestUrl.searchParams.getAll(
-    APP_BOOTSTRAP_QUERY_PARAMETER,
-  );
-  if (
-    requestUrl.protocol !== "https:" ||
-    debugFlags.length !== 1 ||
-    debugFlags[0] !== "1"
-  ) {
+  if (requestUrl.protocol !== "https:") {
     return null;
   }
-  if (PRODUCTION_API_ORIGINS.has(requestUrl.hostname)) {
+  if (requestUrl.hostname === PRODUCTION_APP_HOSTNAME) {
     return requestUrl.origin;
   }
   return CLERK_EDGE_SESSION_PREVIEW_HOSTNAME_PATTERN.test(
     requestUrl.hostname,
-  ) && env.CLERK_EDGE_DEBUG_AUTHORIZED_PARTY === requestUrl.origin
+  ) && env.CLERK_EDGE_AUTHORIZED_PARTY === requestUrl.origin
     ? requestUrl.origin
     : null;
 }
@@ -342,15 +261,16 @@ async function clerkEdgeSession(
       return null;
     }
 
-    const { userId, orgId } = requestState.toAuth();
+    const { userId, sessionId } = requestState.toAuth();
     if (
       typeof userId !== "string" ||
       userId.length === 0 ||
-      (orgId !== null && typeof orgId !== "string")
+      typeof sessionId !== "string" ||
+      sessionId.length === 0
     ) {
       return null;
     }
-    return { userId, orgId };
+    return { userId, sessionId };
   } catch {
     // Clerk must never affect availability of the existing app shell.
     return null;
@@ -363,7 +283,6 @@ async function clerkEdgeSession(
 
 function rewriteAppPage(
   response,
-  metadata,
   edgeSessionPromise,
   request,
   requestUrl,
@@ -371,41 +290,63 @@ function rewriteAppPage(
 ) {
   const bootstrapState = { available: false };
   const rewriter = new HTMLRewriter()
-    .on("html", setBrandContext(metadata.brandName))
+    .on("html", setBrandContext(OKOU_APP_METADATA.brandName))
     .on("title", {
       element(element) {
-        element.setInnerContent(metadata.documentTitle);
+        element.setInnerContent(OKOU_APP_METADATA.documentTitle);
       },
     })
-    .on('meta[name="application-name"]', setMetaContent(metadata.brandName))
+    .on(
+      'meta[name="application-name"]',
+      setMetaContent(OKOU_APP_METADATA.brandName),
+    )
     .on(
       'meta[name="apple-mobile-web-app-title"]',
-      setMetaContent(metadata.brandName),
+      setMetaContent(OKOU_APP_METADATA.brandName),
     )
-    .on('meta[name="description"]', setMetaContent(metadata.description))
+    .on(
+      'meta[name="description"]',
+      setMetaContent(OKOU_APP_METADATA.description),
+    )
     .on('meta[property="og:type"]', setMetaContent("website"))
-    .on('meta[property="og:site_name"]', setMetaContent(metadata.brandName))
-    .on('meta[property="og:title"]', setMetaContent(metadata.openGraphTitle))
-    .on('meta[property="og:description"]', setMetaContent(metadata.description))
+    .on(
+      'meta[property="og:site_name"]',
+      setMetaContent(OKOU_APP_METADATA.brandName),
+    )
+    .on(
+      'meta[property="og:title"]',
+      setMetaContent(OKOU_APP_METADATA.openGraphTitle),
+    )
+    .on(
+      'meta[property="og:description"]',
+      setMetaContent(OKOU_APP_METADATA.description),
+    )
     .on(
       'meta[property="og:image"]',
-      setMetaContent(staticAssetUrl(metadata, metadata.socialImagePath)),
+      setMetaContent(
+        staticAssetUrl(OKOU_APP_METADATA, OKOU_APP_METADATA.socialImagePath),
+      ),
     )
     .on(
       'meta[property="og:image:alt"]',
-      setMetaContent(metadata.openGraphTitle),
+      setMetaContent(OKOU_APP_METADATA.openGraphTitle),
     )
     .on('meta[name="twitter:card"]', setMetaContent("summary_large_image"))
     .on('meta[name="twitter:site"]', setMetaContent("@okou_ai"))
     .on('meta[name="twitter:creator"]', setMetaContent("@okou_ai"))
-    .on('meta[name="twitter:title"]', setMetaContent(metadata.openGraphTitle))
+    .on(
+      'meta[name="twitter:title"]',
+      setMetaContent(OKOU_APP_METADATA.openGraphTitle),
+    )
     .on(
       'meta[name="twitter:description"]',
-      setMetaContent(metadata.twitterDescription),
+      setMetaContent(OKOU_APP_METADATA.twitterDescription),
     )
     .on(
       'meta[name="twitter:image"]',
-      setMetaContent(staticAssetUrl(metadata, metadata.socialImagePath)),
+      setMetaContent(
+        staticAssetUrl(OKOU_APP_METADATA, OKOU_APP_METADATA.socialImagePath),
+      ),
     )
     .on("head", {
       element(element) {
@@ -413,16 +354,15 @@ function rewriteAppPage(
           html: true,
         });
         element.append(
-          `<link rel="canonical" href="${metadata.canonicalUrl}" />`,
+          `<link rel="canonical" href="${OKOU_APP_METADATA.canonicalUrl}" />`,
           { html: true },
         );
         element.append(
-          `<meta property="og:url" content="${metadata.canonicalUrl}" />`,
+          `<meta property="og:url" content="${OKOU_APP_METADATA.canonicalUrl}" />`,
           { html: true },
         );
       },
     });
-  addStaticAssetHandlers(rewriter, metadata);
   if (edgeSessionPromise !== null) {
     rewriter
       .on("body", {
@@ -465,11 +405,11 @@ function rewriteAppPage(
   );
 }
 
-async function rewriteManifest(response, metadata) {
+async function rewriteManifest(response) {
   const manifest = await response.json();
-  manifest.name = metadata.brandName;
-  manifest.short_name = metadata.brandName;
-  manifest.description = metadata.description;
+  manifest.name = OKOU_APP_METADATA.brandName;
+  manifest.short_name = OKOU_APP_METADATA.brandName;
+  manifest.description = OKOU_APP_METADATA.description;
 
   const headers = new Headers(response.headers);
   headers.delete("Content-Encoding");
@@ -484,35 +424,45 @@ async function rewriteManifest(response, metadata) {
   });
 }
 
-function rewriteFound(response, title, canonicalUrl, metadata) {
-  const sharedDescription = `A conversation shared from ${metadata.brandName}`;
+function rewriteFound(response, title, canonicalUrl) {
+  const sharedDescription = `A conversation shared from ${OKOU_APP_METADATA.brandName}`;
   const rewriter = new HTMLRewriter()
-    .on("html", setBrandContext(metadata.brandName))
-    .on('meta[name="application-name"]', setMetaContent(metadata.brandName))
+    .on("html", setBrandContext(OKOU_APP_METADATA.brandName))
+    .on(
+      'meta[name="application-name"]',
+      setMetaContent(OKOU_APP_METADATA.brandName),
+    )
     .on(
       'meta[name="apple-mobile-web-app-title"]',
-      setMetaContent(metadata.brandName),
+      setMetaContent(OKOU_APP_METADATA.brandName),
     )
     .on("title", {
       element(element) {
-        element.setInnerContent(`${title} | ${metadata.brandName}`);
+        element.setInnerContent(`${title} | ${OKOU_APP_METADATA.brandName}`);
       },
     })
     .on('meta[name="description"]', setMetaContent(sharedDescription))
     .on('meta[property="og:type"]', setMetaContent("website"))
-    .on('meta[property="og:site_name"]', setMetaContent(metadata.brandName))
+    .on(
+      'meta[property="og:site_name"]',
+      setMetaContent(OKOU_APP_METADATA.brandName),
+    )
     .on('meta[property="og:title"]', setMetaContent(title))
     .on('meta[property="og:description"]', setMetaContent(sharedDescription))
     .on(
       'meta[property="og:image"]',
-      setMetaContent(staticAssetUrl(metadata, metadata.socialImagePath)),
+      setMetaContent(
+        staticAssetUrl(OKOU_APP_METADATA, OKOU_APP_METADATA.socialImagePath),
+      ),
     )
     .on('meta[property="og:image:alt"]', setMetaContent(title))
     .on('meta[name="twitter:title"]', setMetaContent(title))
     .on('meta[name="twitter:description"]', setMetaContent(sharedDescription))
     .on(
       'meta[name="twitter:image"]',
-      setMetaContent(staticAssetUrl(metadata, metadata.socialImagePath)),
+      setMetaContent(
+        staticAssetUrl(OKOU_APP_METADATA, OKOU_APP_METADATA.socialImagePath),
+      ),
     )
     .on("head", {
       element(element) {
@@ -524,22 +474,24 @@ function rewriteFound(response, title, canonicalUrl, metadata) {
         });
       },
     });
-  addStaticAssetHandlers(rewriter, metadata);
   return rewriter.transform(response);
 }
 
-function rewriteNotFound(response, metadata) {
+function rewriteNotFound(response) {
   const rewriter = new HTMLRewriter()
-    .on("html", setBrandContext(metadata.brandName))
-    .on('meta[name="application-name"]', setMetaContent(metadata.brandName))
+    .on("html", setBrandContext(OKOU_APP_METADATA.brandName))
+    .on(
+      'meta[name="application-name"]',
+      setMetaContent(OKOU_APP_METADATA.brandName),
+    )
     .on(
       'meta[name="apple-mobile-web-app-title"]',
-      setMetaContent(metadata.brandName),
+      setMetaContent(OKOU_APP_METADATA.brandName),
     )
     .on("title", {
       element(element) {
         element.setInnerContent(
-          `Shared conversation not found | ${metadata.brandName}`,
+          `Shared conversation not found | ${OKOU_APP_METADATA.brandName}`,
         );
       },
     })
@@ -552,7 +504,6 @@ function rewriteNotFound(response, metadata) {
         });
       },
     });
-  addStaticAssetHandlers(rewriter, metadata);
   return rewriter.transform(response);
 }
 
@@ -777,7 +728,6 @@ async function handleRequest(
           404,
           "public, max-age=60, s-maxage=60",
         ),
-        appMetadata(requestUrl.hostname, env.PUBLIC_BRAND),
       );
     }
     if (!metaResponse.ok) {
@@ -789,19 +739,12 @@ async function handleRequest(
     } catch {
       return gatewayResponse(502);
     }
-    if (
-      typeof metadata.title !== "string" ||
-      metadata.title.length === 0 ||
-      (metadata.publicBrand !== "vm0" && metadata.publicBrand !== "okou")
-    ) {
+    if (typeof metadata.title !== "string" || metadata.title.length === 0) {
       return gatewayResponse(502);
     }
-    const publicBrand = metadata.publicBrand;
-    const sharedAppMetadata =
-      publicBrand === "okou" ? OKOU_APP_METADATA : VM0_APP_METADATA;
     const canonicalUrl = new URL(
       requestUrl.pathname,
-      sharedAppMetadata.canonicalUrl,
+      OKOU_APP_METADATA.canonicalUrl,
     ).toString();
     return rewriteFound(
       htmlResponse(
@@ -812,7 +755,6 @@ async function handleRequest(
       ),
       metadata.title,
       canonicalUrl,
-      sharedAppMetadata,
     );
   }
 
@@ -821,9 +763,8 @@ async function handleRequest(
     return assetResponse;
   }
 
-  const metadata = appMetadata(requestUrl.hostname, env.PUBLIC_BRAND);
   if (requestUrl.pathname === "/manifest.webmanifest") {
-    return rewriteManifest(assetResponse, metadata);
+    return rewriteManifest(assetResponse);
   }
   if (
     !assetResponse.headers
@@ -839,7 +780,6 @@ async function handleRequest(
     : null;
   return rewriteAppPage(
     assetResponse,
-    metadata,
     edgeSessionPromise,
     request,
     requestUrl,

--- a/turbo/apps/app-worker/wrangler.jsonc
+++ b/turbo/apps/app-worker/wrangler.jsonc
@@ -14,9 +14,6 @@
       "name": "okou-app-preview",
       "workers_dev": true,
       "preview_urls": true,
-      "vars": {
-        "PUBLIC_BRAND": "okou",
-      },
     },
     "production": {
       "name": "okou-app-production",
@@ -26,10 +23,6 @@
         {
           "pattern": "app.okou.ai/*",
           "zone_name": "okou.ai",
-        },
-        {
-          "pattern": "app.vm0.ai/*",
-          "zone_name": "vm0.ai",
         },
       ],
     },

--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -1,23 +1,23 @@
 <!doctype html>
-<html lang="en-US" translate="no" data-app-brand-name="VM0">
+<html lang="en-US" translate="no" data-app-brand-name="Okou">
   <head>
     <script>
       window.__appBootstrapStart = performance.now();
     </script>
-    <title>AI Agents for Real Work — Your Trustworthy AI Teammate | VM0</title>
+    <title>AI Teammate for Real Work — More Done, Same Team | Okou</title>
     <meta charset="UTF-8" />
     <link
       rel="icon"
       type="image/svg+xml"
       sizes="any"
-      href="https://static.vm0.io/public/okou-favicon-adaptive-b4eda9221bb7.svg"
+      href="https://static.okou.io/public/okou-favicon-adaptive-b4eda9221bb7.svg"
       integrity="sha384-vU35VFLSr/2zzsz0Lr2pvWhbXirYsiACGl2G+3/kIjyS4AWK414dwftOZhU78ida"
     />
     <link vite-ignore rel="manifest" href="/manifest.webmanifest" />
     <link
       rel="apple-touch-icon"
       sizes="180x180"
-      href="https://static.vm0.io/platform/okou-pwa-be0be646-180.png"
+      href="https://static.okou.io/platform/okou-pwa-be0be646-180.png"
       integrity="sha384-A8vPZ6XPjFyg4cOXSE+wWCFl2m5p5SX8KPRw9CVJS2B1UJJ/pyTz2U6M8z0q5q+d"
     />
     <meta name="mobile-web-app-capable" content="yes" />
@@ -26,41 +26,47 @@
       name="apple-mobile-web-app-status-bar-style"
       content="black-translucent"
     />
-    <meta name="application-name" content="VM0" />
-    <meta name="apple-mobile-web-app-title" content="VM0" />
+    <meta name="application-name" content="Okou" />
+    <meta name="apple-mobile-web-app-title" content="Okou" />
     <meta
       name="description"
-      content="VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web."
+      content="An AI teammate that connects to 3,000+ tools: get the right data, run agentic workflows, and deliver finished work with team-wide context."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="VM0" />
-    <meta property="og:title" content="VM0 - Your Trustworthy AI Teammate" />
+    <meta property="og:site_name" content="Okou" />
+    <meta
+      property="og:title"
+      content="AI Teammate for Real Work — More Done, Same Team | Okou"
+    />
     <meta
       property="og:description"
-      content="VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web."
+      content="An AI teammate that connects to 3,000+ tools: get the right data, run agentic workflows, and deliver finished work with team-wide context."
     />
     <meta
       property="og:image"
-      content="https://static.vm0.io/web/og-image.png"
+      content="https://static.okou.io/web/okou-og-image-373c892e.png"
     />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta
       property="og:image:alt"
-      content="VM0 - Your Trustworthy AI Teammate"
+      content="AI Teammate for Real Work — More Done, Same Team | Okou"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@okou_ai" />
     <meta name="twitter:creator" content="@okou_ai" />
-    <meta name="twitter:title" content="VM0 - Your Trustworthy AI Teammate" />
+    <meta
+      name="twitter:title"
+      content="AI Teammate for Real Work — More Done, Same Team | Okou"
+    />
     <meta
       name="twitter:description"
-      content="VM0 is an AI agent that connects to 100+ tools and does the work. Reports, triage, outreach, research. In Slack or on the web."
+      content="An AI teammate that connects to 3,000+ tools: get the right data, run agentic workflows, and deliver finished work with team-wide context."
     />
     <meta
       name="twitter:image"
-      content="https://static.vm0.io/web/og-image.png"
+      content="https://static.okou.io/web/okou-og-image-373c892e.png"
     />
     <meta name="google" content="notranslate" />
     <meta
@@ -81,19 +87,6 @@
       // Inline theme detection — mirrors signals/theme.ts resolveTheme() + applyTheme()
       (function () {
         var root = document.documentElement;
-        var isOkou = root.dataset.appBrandName === "Okou";
-        if (!isOkou) {
-          var themePreference = localStorage.getItem("theme");
-          var theme =
-            themePreference === "dark" || themePreference === "light"
-              ? themePreference
-              : window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "dark"
-                : "light";
-          root.dataset.theme = theme;
-          if (theme === "dark") root.classList.add("dark");
-          return;
-        }
         var p = null;
         try {
           var prefix = "__Secure-okou-theme=";

--- a/turbo/apps/platform/public/manifest.webmanifest
+++ b/turbo/apps/platform/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "VM0",
-  "short_name": "VM0",
-  "description": "VM0, your trustworthy AI teammate for real work. An AI agent that connects to 100+ tools to run reports, triage, outreach, and research in Slack or the web.",
+  "name": "Okou",
+  "short_name": "Okou",
+  "description": "An AI teammate that connects to 3,000+ tools: get the right data, run agentic workflows, and deliver finished work with team-wide context.",
   "start_url": "/?source=pwa",
   "scope": "/",
   "display": "standalone",

--- a/turbo/apps/platform/public/sw.js
+++ b/turbo/apps/platform/public/sw.js
@@ -1,16 +1,3 @@
-const OKOU_ROOT_DOMAINS = ["okou.ai", "omby.ai"];
-const OKOU_APP_WORKER_PREVIEW_HOST_PATTERN =
-  /^(?:staging|pr-[0-9]+)-app-okou-app-preview\.vm0\.workers\.dev$/u;
-
-function defaultNotificationTitle() {
-  const hostname = self.location.hostname.toLowerCase();
-  const isOkou =
-    OKOU_ROOT_DOMAINS.some((domain) => {
-      return hostname === domain || hostname.endsWith(`.${domain}`);
-    }) || OKOU_APP_WORKER_PREVIEW_HOST_PATTERN.test(hostname);
-  return isOkou ? "Okou" : "VM0";
-}
-
 self.addEventListener("install", (_event) => {
   self.skipWaiting();
 });
@@ -35,10 +22,7 @@ self.addEventListener("push", (event) => {
   };
 
   event.waitUntil(
-    self.registration.showNotification(
-      data.title ?? defaultNotificationTitle(),
-      options,
-    ),
+    self.registration.showNotification(data.title ?? "Okou", options),
   );
 });
 


### PR DESCRIPTION
## Summary

- retire the VM0 route, brand metadata, static-asset rewriting, and dual-domain production verification from the standalone Cloudflare App Worker
- make the Okou shell, manifest, service worker, shared-thread metadata, deployment URL, and release reporting unconditionally Okou
- remove the `__bootstrap=1` gate so every eligible HTML request attempts Clerk authentication and authenticated responses expose exactly `{ userId, sessionId }`

## Rollout evidence

- the product owner confirmed on 2026-09-07 that the supported App user surface has fully migrated to Okou, so the standalone Worker no longer needs to serve or roll back to the VM0 route and brand projection
- this cleanup removes the VM0 Worker route, the Worker-shell primary-domain override, and their dedicated tests together; historical brand data and non-Worker protocol identifiers remain outside this PR

## Security and failure behavior

- retain exact-origin authorization for PR Worker previews and allow the production path only on `https://app.okou.ai`
- keep the one-second Clerk timeout and fail-open shell behavior for anonymous, handshake, missing-config, timeout, and upstream-failure cases
- keep identity-bearing HTML responses `private, no-store`; do not expose Clerk tokens, claims, organization IDs, cookies, redirects, or refreshed session headers

## Verification

- `pnpm --filter @okouai/app-worker test`
- `pnpm --filter @okouai/app-worker lint`
- `pnpm --filter @okouai/app-worker check-types`
- `pnpm knip --workspace @okouai/app-worker`
- `pnpm --filter @okouai/app lint:static-assets`
- `pnpm --filter @okouai/app lint:build-config`
- `pnpm --filter @okouai/app exec vitest run src/__tests__/clerk-primary-app-domain.test.ts`
- `.github/scripts/tests/prepare-okou-app-worker-shell-test.sh`
- `.github/scripts/tests/verify-okou-production-domains-test.sh`
- `.github/scripts/tests/deploy-okou-app-worker-workflow-test.sh`
- `.github/scripts/tests/app-preview-ingress-workflow-test.sh`
- full Lefthook `knip` and TypeScript checks for the review-fix commit

The targeted API release-config Vitest requires the repository PostgreSQL test service, which is unavailable in this local checkout; the database-independent deployment workflow test covers the same changed release wiring, and CI runs the repository-managed test environment.
