### PR TITLE
fix(platform): expand desktop selection within ai replies

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -39,6 +39,7 @@ import {
 const FEEDBACK_SOURCE_SELECTOR =
   ".okou-chat-bubble-assistant, [data-feedback-source]";
 const ASSISTANT_GROUP_SELECTOR = '[data-role="assistant"]';
+const COARSE_POINTER_QUERY = "(pointer: coarse)";
 const CHAT_EVENT_SELECTOR = "[data-chat-scroll-anchor-event-id]";
 const THREAD_CONTAINER_SELECTOR = "[data-chat-thread-container-id]";
 const CHAT_COMPOSER_SELECTOR = "[data-chat-composer]";
@@ -160,6 +161,10 @@ function closestExpandedFeedbackSource(node: Node | null): Element | null {
     element?.closest("[data-feedback-source]") ??
     null
   );
+}
+
+function shouldExpandSelectionToAssistantReply(enabled: boolean): boolean {
+  return enabled && !window.matchMedia(COARSE_POINTER_QUERY).matches;
 }
 
 function resolveSelectionSource(
@@ -395,7 +400,9 @@ function createSelectionState(threadId: string) {
   const capture$ = command(({ get, set }, signal: AbortSignal) => {
     signal.throwIfAborted();
     const selection = readFeedbackSelection(
-      get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection],
+      shouldExpandSelectionToAssistantReply(
+        get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection],
+      ),
     );
     if (!selection || selection.threadId !== threadId) {
       set(close$);
@@ -419,7 +426,9 @@ function createSelectionState(threadId: string) {
       return;
     }
     const selection = readFeedbackSelection(
-      get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection],
+      shouldExpandSelectionToAssistantReply(
+        get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection],
+      ),
     );
     if (
       !selection ||
@@ -810,7 +819,9 @@ function createListenersRef({
           mouseSelectionInProgress =
             event.button === 0 &&
             event.target instanceof Node &&
-            (get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection]
+            (shouldExpandSelectionToAssistantReply(
+              get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection],
+            )
               ? closestExpandedFeedbackSource(event.target)
               : closestFeedbackSource(event.target)) !== null;
           const activeElement = doc.activeElement;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -150,7 +150,30 @@ function closestFeedbackSource(node: Node | null): Element | null {
   return element?.closest(FEEDBACK_SOURCE_SELECTOR) ?? null;
 }
 
-function resolveSelectionSource(range: Range): Element | null {
+function closestExpandedFeedbackSource(node: Node | null): Element | null {
+  if (!node) {
+    return null;
+  }
+  const element = node instanceof Element ? node : node.parentElement;
+  return (
+    element?.closest(ASSISTANT_GROUP_SELECTOR) ??
+    element?.closest("[data-feedback-source]") ??
+    null
+  );
+}
+
+function resolveSelectionSource(
+  range: Range,
+  expandToAssistantReply: boolean,
+): Element | null {
+  if (expandToAssistantReply) {
+    const startSource = closestExpandedFeedbackSource(range.startContainer);
+    const endSource = closestExpandedFeedbackSource(range.endContainer);
+    return startSource !== null && startSource === endSource
+      ? startSource
+      : null;
+  }
+
   const commonSource = closestFeedbackSource(range.commonAncestorContainer);
   if (commonSource) {
     return commonSource;
@@ -291,7 +314,9 @@ function rectFromRange(range: Range): ChatThreadFeedbackSelection["rect"] {
   return { top, left, width: right - left, height: bottom - top };
 }
 
-function readFeedbackSelection(): CapturedFeedbackSelection | null {
+function readFeedbackSelection(
+  expandToAssistantReply: boolean,
+): CapturedFeedbackSelection | null {
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
     return null;
@@ -301,7 +326,7 @@ function readFeedbackSelection(): CapturedFeedbackSelection | null {
     return null;
   }
   const range = selection.getRangeAt(0);
-  const sourceElement = resolveSelectionSource(range);
+  const sourceElement = resolveSelectionSource(range, expandToAssistantReply);
   if (!sourceElement) {
     return null;
   }
@@ -369,7 +394,9 @@ function createSelectionState(threadId: string) {
   });
   const capture$ = command(({ get, set }, signal: AbortSignal) => {
     signal.throwIfAborted();
-    const selection = readFeedbackSelection();
+    const selection = readFeedbackSelection(
+      get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection],
+    );
     if (!selection || selection.threadId !== threadId) {
       set(close$);
       return;
@@ -391,7 +418,9 @@ function createSelectionState(threadId: string) {
     if (!currentSelection) {
       return;
     }
-    const selection = readFeedbackSelection();
+    const selection = readFeedbackSelection(
+      get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection],
+    );
     if (
       !selection ||
       selection.threadId !== threadId ||
@@ -781,7 +810,9 @@ function createListenersRef({
           mouseSelectionInProgress =
             event.button === 0 &&
             event.target instanceof Node &&
-            closestFeedbackSource(event.target) !== null;
+            (get(featureSwitch$)[FeatureSwitchKey.ChatDesktopSelection]
+              ? closestExpandedFeedbackSource(event.target)
+              : closestFeedbackSource(event.target)) !== null;
           const activeElement = doc.activeElement;
           if (
             mouseSelectionInProgress &&

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
@@ -163,7 +163,40 @@ test("Keep the legacy Markdown selection boundary when expansion is disabled", a
   renderedDetail.textContent = "A rendered detail outside Markdown.";
   assistantReply.append(renderedDetail);
 
+  await selectPassage("launch plan has three careful stages");
   await selectPassageWithoutActions("rendered detail outside Markdown");
+
+  expect(queryToolbarButton("Copy")).not.toBeInTheDocument();
+  expect(queryToolbarButton("Quote")).not.toBeInTheDocument();
+  expect(queryToolbarButton("Forward")).not.toBeInTheDocument();
+});
+
+test("Keep touch passage actions on the legacy Markdown boundary", async () => {
+  context.mocks.browser.matchMedia((query) => {
+    return query === "(pointer: coarse)";
+  });
+  installCapabilityChat({
+    events: completedConversation(FIRST_PASSAGE),
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatDesktopSelection]: true },
+  });
+
+  await readyChat();
+  const firstResponse = await screen.findByText(FIRST_PASSAGE);
+  const assistantReply = firstResponse.closest('[data-role="assistant"]');
+  if (!assistantReply) {
+    throw new Error("AI reply boundary was not rendered");
+  }
+  const renderedDetail = document.createElement("div");
+  renderedDetail.textContent = "A touch-only detail outside Markdown.";
+  assistantReply.append(renderedDetail);
+
+  await selectPassage("launch plan has three careful stages");
+  await selectPassageWithoutActions("touch-only detail outside Markdown");
 
   expect(queryToolbarButton("Copy")).not.toBeInTheDocument();
   expect(queryToolbarButton("Quote")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
@@ -1,4 +1,5 @@
 import type { UserMessageDocument } from "@okouai/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
@@ -21,6 +22,7 @@ import {
   RUN_PATH,
   selectAcrossPassages,
   selectPassage,
+  selectPassageWithoutActions,
   waitForSend,
   type CapturedChatSend,
 } from "./chat-capability-test-helpers.ts";
@@ -101,6 +103,71 @@ test("Offer passage actions only for a valid assistant selection", async () => {
   expect(feedbackItems()[0]).toHaveTextContent(
     "launch plan has three careful stages",
   );
+});
+
+test("Expand desktop passage actions to the boundary of one AI reply", async () => {
+  installCapabilityChat({
+    events: completedConversation(FIRST_PASSAGE, SECOND_PASSAGE),
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatDesktopSelection]: true },
+  });
+
+  await readyChat();
+  const firstResponse = await screen.findByText(FIRST_PASSAGE);
+  const assistantReply = firstResponse.closest('[data-role="assistant"]');
+  if (!assistantReply) {
+    throw new Error("AI reply boundary was not rendered");
+  }
+  const renderedDetail = document.createElement("div");
+  renderedDetail.textContent = "A rendered detail outside Markdown.";
+  assistantReply.append(renderedDetail);
+
+  await selectPassage("rendered detail outside Markdown");
+
+  expect(queryToolbarButton("Copy")).toBeVisible();
+  expect(queryToolbarButton("Quote")).toBeVisible();
+  expect(queryToolbarButton("Forward")).toBeVisible();
+
+  await selectAcrossPassages(
+    "rendered detail outside Markdown",
+    "separate decision",
+  );
+
+  expect(queryToolbarButton("Copy")).not.toBeInTheDocument();
+  expect(queryToolbarButton("Quote")).not.toBeInTheDocument();
+  expect(queryToolbarButton("Forward")).not.toBeInTheDocument();
+});
+
+test("Keep the legacy Markdown selection boundary when expansion is disabled", async () => {
+  installCapabilityChat({
+    events: completedConversation(FIRST_PASSAGE),
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatDesktopSelection]: false },
+  });
+
+  await readyChat();
+  const firstResponse = await screen.findByText(FIRST_PASSAGE);
+  const assistantReply = firstResponse.closest('[data-role="assistant"]');
+  if (!assistantReply) {
+    throw new Error("AI reply boundary was not rendered");
+  }
+  const renderedDetail = document.createElement("div");
+  renderedDetail.textContent = "A rendered detail outside Markdown.";
+  assistantReply.append(renderedDetail);
+
+  await selectPassageWithoutActions("rendered detail outside Markdown");
+
+  expect(queryToolbarButton("Copy")).not.toBeInTheDocument();
+  expect(queryToolbarButton("Quote")).not.toBeInTheDocument();
+  expect(queryToolbarButton("Forward")).not.toBeInTheDocument();
 });
 
 test("Combine inline feedback with the rest of a message draft", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-test-helpers.ts
@@ -104,7 +104,7 @@ function textNodeContaining(
       node instanceof Text &&
       node.data.includes(text) &&
       node.parentElement?.closest(
-        ".okou-chat-bubble-assistant, [data-feedback-source]",
+        '[data-role="assistant"], [data-feedback-source]',
       )
     ) {
       matches.push(node);
@@ -154,10 +154,7 @@ function visibleSelectionRange(
   return range;
 }
 
-export async function selectPassage(
-  passage: string,
-  occurrence = 0,
-): Promise<void> {
+function setPassageSelection(passage: string, occurrence = 0): void {
   const node = textNodeContaining(passage, occurrence);
   const start = node.data.indexOf(passage);
   const target = node.parentElement;
@@ -178,7 +175,30 @@ export async function selectPassage(
   selection.removeAllRanges();
   selection.addRange(range);
   fireEvent.mouseUp(target, { button: 0 });
+}
+
+export async function selectPassage(
+  passage: string,
+  occurrence = 0,
+): Promise<void> {
+  setPassageSelection(passage, occurrence);
   await findButton("Quote");
+}
+
+export async function selectPassageWithoutActions(
+  passage: string,
+  occurrence = 0,
+): Promise<void> {
+  setPassageSelection(passage, occurrence);
+  await waitFor(() => {
+    if (
+      document.querySelector(
+        '[data-radix-popper-content-wrapper] button[aria-keyshortcuts="q"]',
+      )
+    ) {
+      throw new Error("Out-of-scope selection still exposes passage actions");
+    }
+  });
 }
 
 export async function selectAcrossPassages(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-test-helpers.ts
@@ -1,5 +1,10 @@
 import type { UserMessageDocument } from "@okouai/api-contracts/contracts/chat-threads";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
 
 import { click } from "../../../__tests__/page-helper.ts";
 import {
@@ -154,14 +159,20 @@ function visibleSelectionRange(
   return range;
 }
 
-function setPassageSelection(passage: string, occurrence = 0): void {
+function setPassageSelection(
+  passage: string,
+  occurrence = 0,
+  interaction: "mouse" | "native" = "mouse",
+): void {
   const node = textNodeContaining(passage, occurrence);
   const start = node.data.indexOf(passage);
   const target = node.parentElement;
   if (!target) {
     throw new Error("Selectable passage has no element target");
   }
-  fireEvent.mouseDown(target, { button: 0 });
+  if (interaction === "mouse") {
+    fireEvent.mouseDown(target, { button: 0 });
+  }
   const range = visibleSelectionRange(
     node,
     start,
@@ -174,7 +185,11 @@ function setPassageSelection(passage: string, occurrence = 0): void {
   }
   selection.removeAllRanges();
   selection.addRange(range);
-  fireEvent.mouseUp(target, { button: 0 });
+  if (interaction === "mouse") {
+    fireEvent.mouseUp(target, { button: 0 });
+  } else {
+    fireEvent(document, new Event("selectionchange"));
+  }
 }
 
 export async function selectPassage(
@@ -189,16 +204,9 @@ export async function selectPassageWithoutActions(
   passage: string,
   occurrence = 0,
 ): Promise<void> {
-  setPassageSelection(passage, occurrence);
-  await waitFor(() => {
-    if (
-      document.querySelector(
-        '[data-radix-popper-content-wrapper] button[aria-keyshortcuts="q"]',
-      )
-    ) {
-      throw new Error("Out-of-scope selection still exposes passage actions");
-    }
-  });
+  const existingQuoteAction = await findButton("Quote");
+  setPassageSelection(passage, occurrence, "native");
+  await waitForElementToBeRemoved(existingQuoteAction);
 }
 
 export async function selectAcrossPassages(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -208,6 +208,7 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ChatDesktopSelection]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);
@@ -233,6 +234,7 @@ describe("getAllFeatureStates", () => {
     );
     expect(otherOrgStates[FeatureSwitchKey.PresentationTemplates]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ChatTranslation]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ChatDesktopSelection]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.VoiceInputV2]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.IntroVideo]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.GradientColorThemes]).toBe(false);

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -72,6 +72,7 @@ export enum FeatureSwitchKey {
   PresentationTemplates = "presentationTemplates",
   IntroVideo = "introVideo",
   ChatTranslation = "chatTranslation",
+  ChatDesktopSelection = "chatDesktopSelection",
   VoiceInputV2 = "voiceInputV2",
   ComposerImageAnnotation = "composerImageAnnotation",
   GradientColorThemes = "gradientColorThemes",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -337,6 +337,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Translate selected assistant text into a remembered target language.",
     enabled: false,
   },
+  [FeatureSwitchKey.ChatDesktopSelection]: {
+    maintainer: "bingjie@okou.ai",
+    description:
+      "Offer desktop passage actions for selections anywhere within one assistant reply.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.VoiceInputV2]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- add the `chatDesktopSelection` feature switch, disabled globally and enabled for staff organizations by default
- when enabled, show desktop passage actions for any non-empty text selection whose endpoints stay within the same assistant reply
- keep the existing Markdown-scoped behavior when the switch is disabled, reject cross-reply selections, and preserve linked feedback sources

This PR is independent of #32045 and intentionally excludes the custom mobile selection work.

## Verification

- `pnpm exec vitest --run packages/core/src/__tests__/feature-switch.test.ts apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx` (37 tests)
- targeted Prettier, Oxlint, and ESLint checks for all changed files
- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/core check-types`
