### PR TITLE
refactor(vsock-host): centralize frame-write safety

### DIFF
--- a/crates/vsock-host/src/connection/frame.rs
+++ b/crates/vsock-host/src/connection/frame.rs
@@ -1,0 +1,82 @@
+//! Canonical cancellation-safe writer for every post-handshake frame.
+//!
+//! Admission runs under the writer lock before any bytes can be emitted. An
+//! error or `Skip` leaves the stream untouched. Once writing starts, a guard
+//! poisons the connection on error or cancellation because a partial frame
+//! cannot safely be followed by another frame. Only a successful `write_all`
+//! disarms the guard. The guard drops before the writer lock is released.
+//!
+//! Callers retain ownership of encoding, admission, request/operation cleanup,
+//! deadlines, and diagnostics. In particular, frame-builder callers must keep
+//! their encoded buffer inside the builder gate for the entire write.
+
+use std::io;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+use tokio::time::Instant;
+
+use super::Shared;
+
+/// `Skip` is a successful no-frame outcome, decided under the writer lock.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FrameWriteDecision {
+    Write,
+    Skip,
+}
+
+pub(crate) struct FrameWriteTiming {
+    pub(crate) wait: Duration,
+    pub(crate) write: Duration,
+}
+
+/// Exists only inside the possible partial-write window, while holding the writer.
+struct FrameWriteGuard<'a> {
+    shared: &'a Shared,
+    completed: bool,
+}
+
+impl Drop for FrameWriteGuard<'_> {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.shared.poison_connection();
+        }
+    }
+}
+
+impl Shared {
+    /// Serialize admission and writing, then observe the finished write after unlocking.
+    ///
+    /// `pre_write` owns admission and write-start notifications. An admission
+    /// error or `Skip` does not invoke `write_finished`. Wait timing excludes
+    /// admission; write timing excludes poisoning, unlocking, and observation.
+    pub(crate) async fn write_frame(
+        &self,
+        data: &[u8],
+        pre_write: impl FnOnce() -> io::Result<FrameWriteDecision>,
+        write_finished: impl FnOnce(FrameWriteTiming, &io::Result<()>),
+    ) -> io::Result<FrameWriteDecision> {
+        let wait_started_at = Instant::now();
+        let mut writer = self.writer.lock().await;
+        let wait = wait_started_at.elapsed();
+        if pre_write()? == FrameWriteDecision::Skip {
+            return Ok(FrameWriteDecision::Skip);
+        }
+
+        // Declared after the writer so cancellation poisons before unlocking.
+        let mut guard = FrameWriteGuard {
+            shared: self,
+            completed: false,
+        };
+        let write_started_at = Instant::now();
+        let result = writer.write_all(data).await;
+        let write = write_started_at.elapsed();
+        guard.completed = result.is_ok();
+        drop(guard);
+        drop(writer);
+
+        write_finished(FrameWriteTiming { wait, write }, &result);
+        result?;
+        Ok(FrameWriteDecision::Write)
+    }
+}

--- a/crates/vsock-host/src/connection/mod.rs
+++ b/crates/vsock-host/src/connection/mod.rs
@@ -1,3 +1,4 @@
+mod frame;
 mod listener;
 mod request;
 
@@ -18,13 +19,14 @@ use crate::operation_tracker::{
 };
 use crate::{VsockHost, exec_operation};
 
+pub(crate) use frame::{FrameWriteDecision, FrameWriteTiming};
 pub(super) use request::{
     CompositeNormalOperation, normal_operation_transition_error,
     normal_request_on_shared_with_write_observer_frame_builder,
     request_on_shared_with_composite_operation_and_observer_frame_builder,
 };
 #[cfg(test)]
-pub(super) use request::{RequestWriteGuard, write_request_frame_with_builder};
+pub(super) use request::{request_on_shared, write_request_frame_with_builder};
 
 const READ_BUF_SIZE: usize = 64 * 1024;
 

--- a/crates/vsock-host/src/connection/request.rs
+++ b/crates/vsock-host/src/connection/request.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
-use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;
 use tokio::time::{self, Instant};
 use vsock_proto::{
@@ -18,17 +17,13 @@ use crate::operation_tracker::{
 };
 use crate::{FrameWriteObserver, RequestTimeoutError, RequestTimeoutStage, VsockHost};
 
-use super::{ConnectionState, PendingNormalOperation, PendingResponse, RouteId, Shared};
+use super::{
+    ConnectionState, FrameWriteDecision, PendingNormalOperation, PendingResponse, RouteId, Shared,
+};
 
 struct PendingRequestGuard {
     shared: Arc<Shared>,
     route_id: RouteId,
-}
-
-pub(crate) struct RequestWriteGuard {
-    shared: Arc<Shared>,
-    write_started: bool,
-    write_returned: bool,
 }
 
 #[derive(Debug, Default)]
@@ -68,32 +63,6 @@ impl PendingRequestGuard {
 impl Drop for PendingRequestGuard {
     fn drop(&mut self) {
         self.shared.remove_pending(self.route_id);
-    }
-}
-
-impl RequestWriteGuard {
-    pub(crate) fn new(shared: Arc<Shared>) -> Self {
-        Self {
-            shared,
-            write_started: false,
-            write_returned: false,
-        }
-    }
-
-    pub(crate) fn mark_started(&mut self) {
-        self.write_started = true;
-    }
-
-    fn mark_returned(&mut self) {
-        self.write_returned = true;
-    }
-}
-
-impl Drop for RequestWriteGuard {
-    fn drop(&mut self) {
-        if self.write_started && !self.write_returned {
-            self.shared.poison_connection();
-        }
     }
 }
 
@@ -141,7 +110,7 @@ impl CompositeNormalOperation {
 }
 
 /// Send a request and wait for a response with matching sequence number.
-async fn request_on_shared(
+pub(crate) async fn request_on_shared(
     shared: &Arc<Shared>,
     msg_type: u8,
     payload: &[u8],
@@ -163,18 +132,18 @@ async fn write_request_frame(
     before_write: impl FnOnce() -> io::Result<()>,
     progress: &RequestWriteProgress,
 ) -> io::Result<()> {
-    let mut write_guard = RequestWriteGuard::new(Arc::clone(shared));
-    let mut writer = shared.writer.lock().await;
-    before_write()?;
-    progress.mark_frame_write();
-    write_guard.mark_started();
-    if let Err(error) = writer.write_all(data).await {
-        write_guard.mark_returned();
-        shared.poison_connection();
-        return Err(error);
-    }
+    shared
+        .write_frame(
+            data,
+            || {
+                before_write()?;
+                progress.mark_frame_write();
+                Ok(FrameWriteDecision::Write)
+            },
+            |_, _| {},
+        )
+        .await?;
     progress.mark_awaiting_terminal_response();
-    write_guard.mark_returned();
     Ok(())
 }
 
@@ -197,29 +166,13 @@ async fn write_request_frame_with_builder_and_progress(
     before_write: impl FnOnce() -> io::Result<()>,
     progress: &RequestWriteProgress,
 ) -> io::Result<()> {
-    let mut write_guard = RequestWriteGuard::new(Arc::clone(shared));
     let frame_builder_guard = shared.frame_builder.lock().await;
     let mut frame = Vec::new();
     build_frame(seq, &mut frame)?;
-    let mut writer = shared.writer.lock().await;
-    before_write()?;
-    progress.mark_frame_write();
-    write_guard.mark_started();
-    let result = writer.write_all(&frame).await;
-    if let Err(error) = result {
-        write_guard.mark_returned();
-        shared.poison_connection();
-        drop(writer);
-        drop(frame);
-        drop(frame_builder_guard);
-        return Err(error);
-    }
-    drop(writer);
+    let result = write_request_frame(shared, &frame, before_write, progress).await;
     drop(frame);
     drop(frame_builder_guard);
-    progress.mark_awaiting_terminal_response();
-    write_guard.mark_returned();
-    Ok(())
+    result
 }
 
 fn encode_request_frame(msg_type: u8, seq: u32, payload: &[u8]) -> io::Result<Vec<u8>> {

--- a/crates/vsock-host/src/exec_operation/frame.rs
+++ b/crates/vsock-host/src/exec_operation/frame.rs
@@ -1,28 +1,15 @@
-//! Frame writes are serialized through the shared writer so that operation state and frame bytes
-//! cross their safety boundaries in a fixed order.
-//!
-//! ## Frame-write safety contract
-//!
-//! Each guarded frame write has three states:
-//!
-//! - `NOT_STARTED`: the writer lock is not held yet, or the pre-write decision is still running.
-//!   Dropping the write in this state means no frame bytes could have been emitted.
-//! - `STARTED`: the pre-write decision returned `Write` and the writer is about to, or is already,
-//!   awaiting `write_all`. The write may be partial, so a dropped future or write error poisons
-//!   the connection rather than allowing it to be reused.
-//! - `COMPLETED`: `write_all` returned successfully. Dropping the guard after this state does not
-//!   poison the connection.
+//! Exec admission and diagnostics around the connection layer's guarded frame writer.
 //!
 //! The pre-write callback runs after `Shared::writer` has been acquired and before the
-//! `STARTED` transition. It is therefore the serialized admission point for route and operation
+//! partial-write guard is armed. It is the serialized admission point for route and operation
 //! state changes, write observers, and cancellation decisions. A callback that returns `Skip`
-//! exits while the writer is still serialized, without crossing `STARTED`, emitting frame bytes,
+//! exits while the writer is still serialized, without arming the guard, emitting frame bytes,
 //! or publishing a write-start notification.
 //!
 //! `send_exec_cancel_frame_for_wait_with_write_start` uses that admission point to revalidate the
 //! route immediately before cancellation can be written. When the route is still cancellable, it
 //! marks the host cancellation and sends `write_started_tx` from the callback before returning
-//! `Write`; the generic writer has not yet stored `STARTED` or called `write_all`. When the
+//! `Write`; the shared writer has not yet armed the guard or called `write_all`. When the
 //! operation is already terminal, the callback returns `AlreadyTerminal` as `Skip`, so the stale
 //! cancel frame is not written. Moving either the route revalidation or this notification outside
 //! the writer lock would break the ordering against a terminal result or a reused wire sequence.
@@ -32,7 +19,7 @@
 //! `exec_cancel_writer_lock_timeout_before_write_does_not_poison_or_send_frame`,
 //! `exec_cancel_terminal_result_wins_while_cancel_write_is_blocked`,
 //! `exec_write_observer_fires_at_frame_write_boundary`, and
-//! `exec_operation_frame_write_guard_started_drop_poisons_connection`. Supervised cancellation
+//! `exec_start_cancelled_during_write_poisons_connection`. Supervised cancellation
 //! and route-reuse cases are covered in
 //! `crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs`, including
 //! `supervised_exec_cancel_and_wait_terminal_result_wins_while_cancel_write_is_blocked`,
@@ -41,36 +28,19 @@
 
 use std::io;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, Ordering};
 
-use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;
-use tokio::time::Instant;
 use vsock_proto::{ExecControlStatus, MSG_EXEC_CANCEL, MSG_EXEC_START};
 
+use crate::connection::{FrameWriteDecision, FrameWriteTiming};
 use crate::{
     ConnectionState, FrameWriteObserver, RouteId, RouteReservation, Shared,
     normal_operation_transition_error,
 };
 
+use super::EXEC_OPERATION_FRAME_WRITE_SLOW_THRESHOLD;
 use super::diagnostics::{ExecOperationDiagnostic, ExecOperationFrameDiagnostic};
 use super::types::exec_control_status_error;
-use super::{
-    EXEC_OPERATION_FRAME_WRITE_COMPLETED, EXEC_OPERATION_FRAME_WRITE_NOT_STARTED,
-    EXEC_OPERATION_FRAME_WRITE_SLOW_THRESHOLD, EXEC_OPERATION_FRAME_WRITE_STARTED,
-};
-
-/// Poisons the connection if a frame write is dropped after its write boundary.
-///
-/// The guard is created before waiting for the serialized writer lock. The guarded operation
-/// stores `STARTED` immediately before `write_all` and `COMPLETED` only after a successful
-/// `write_all`. Its `Drop` implementation consequently treats a dropped `STARTED` write as
-/// potentially partial, while a write dropped before `STARTED` or after `COMPLETED` does not
-/// poison the connection.
-pub(in crate::exec_operation) struct ExecOperationFrameWriteGuard {
-    pub(in crate::exec_operation) shared: Arc<Shared>,
-    pub(in crate::exec_operation) state: Arc<AtomicU8>,
-}
 
 /// Admission result for a cancel frame.
 ///
@@ -81,31 +51,6 @@ pub(in crate::exec_operation) struct ExecOperationFrameWriteGuard {
 pub(in crate::exec_operation) enum ExecCancelFrameWriteOutcome {
     Sent,
     AlreadyTerminal,
-}
-
-/// Decision returned by the serialized pre-write callback.
-///
-/// `Skip` must be decided while the shared writer lock is held. It returns before the write-start
-/// state transition, so the frame-write guard can be dropped without poisoning and no bytes can be
-/// emitted by this frame attempt.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum FrameWriteDecision {
-    Write,
-    Skip,
-}
-
-impl ExecOperationFrameWriteGuard {
-    pub(in crate::exec_operation) fn new(shared: Arc<Shared>, state: Arc<AtomicU8>) -> Self {
-        Self { shared, state }
-    }
-}
-
-impl Drop for ExecOperationFrameWriteGuard {
-    fn drop(&mut self) {
-        if self.state.load(Ordering::Acquire) == EXEC_OPERATION_FRAME_WRITE_STARTED {
-            self.shared.poison_connection();
-        }
-    }
 }
 
 pub(in crate::exec_operation) fn admit_exec_cancel_frame(
@@ -165,11 +110,11 @@ fn mark_exec_operation_host_cancel_requested_for_wait(
 /// The route reservation is followed by a serialized pre-write check. That check must remain
 /// inside the shared writer lock so a terminal result cannot be separated from the decision to
 /// write a cancel frame for the same route. `AlreadyTerminal` becomes `Skip`, which leaves the
-/// frame-write state at `NOT_STARTED` and emits no cancel frame.
+/// frame-write guard unarmed and emits no cancel frame.
 ///
 /// When cancellation is admitted, the callback marks the host cancellation and sends
 /// `write_started_tx` before returning `Write`. The notification therefore occurs before the
-/// generic writer stores `STARTED` and before `write_all` can emit bytes; it is not a completion
+/// shared writer arms the guard and before `write_all` can emit bytes; it is not a completion
 /// notification. The reservation, state transition, notification, and `Write` decision must keep
 /// this ordering.
 pub(in crate::exec_operation) async fn send_exec_cancel_frame_for_wait_with_write_start(
@@ -316,7 +261,7 @@ pub(in crate::exec_operation) async fn write_frame(
 /// Write an exec-start frame through the serialized frame-write lifecycle.
 ///
 /// Admission and write observers run in the pre-write callback while the writer lock is held and
-/// before the guarded write crosses `STARTED`. They therefore describe the write boundary rather
+/// before the partial-write guard is armed. They therefore describe the write boundary rather
 /// than successful completion.
 pub(in crate::exec_operation) async fn write_exec_start_frame(
     shared: &Arc<Shared>,
@@ -399,42 +344,30 @@ async fn write_frame_with_pre_write_decision(
     write_encoded_frame_with_pre_write_decision(shared, &data, diagnostic, pre_write).await
 }
 
-/// Perform the serialized frame write and enforce its cancellation safety boundaries.
-///
-/// The writer lock is acquired before `pre_write` is called. A `Skip` decision returns while that
-/// lock is held and before `STARTED` is stored. For a `Write` decision, `STARTED` is stored
-/// immediately before `write_all`; `COMPLETED` is stored only after `write_all` succeeds. Keep the
-/// frame-write guard alive across the whole operation so dropping a future during the possible
-/// partial-write window poisons the connection.
+/// Observe exec write timings without owning the connection's partial-write guard.
 async fn write_encoded_frame_with_pre_write_decision(
     shared: &Arc<Shared>,
     data: &[u8],
     diagnostic: Option<ExecOperationFrameDiagnostic>,
     pre_write: impl FnOnce() -> io::Result<FrameWriteDecision>,
 ) -> io::Result<FrameWriteDecision> {
-    let state = Arc::new(AtomicU8::new(EXEC_OPERATION_FRAME_WRITE_NOT_STARTED));
-    let guard = ExecOperationFrameWriteGuard::new(Arc::clone(shared), Arc::clone(&state));
+    shared
+        .write_frame(data, pre_write, |timing, result| {
+            log_frame_write(diagnostic.as_ref(), timing, result);
+        })
+        .await
+}
 
-    let wait_started_at = Instant::now();
-    let mut writer = shared.writer.lock().await;
-    let wait_elapsed_ms = wait_started_at.elapsed().as_millis();
-    let decision = pre_write()?;
-    if decision == FrameWriteDecision::Skip {
-        return Ok(FrameWriteDecision::Skip);
-    }
-    state.store(EXEC_OPERATION_FRAME_WRITE_STARTED, Ordering::Release);
-    let write_started_at = Instant::now();
-    let result = writer.write_all(data).await;
-    let write_elapsed_ms = write_started_at.elapsed().as_millis();
-    if result.is_ok() {
-        state.store(EXEC_OPERATION_FRAME_WRITE_COMPLETED, Ordering::Release);
-    } else {
-        shared.poison_connection();
-    }
-    drop(writer);
+fn log_frame_write(
+    diagnostic: Option<&ExecOperationFrameDiagnostic>,
+    timing: FrameWriteTiming,
+    result: &io::Result<()>,
+) {
+    let wait_elapsed_ms = timing.wait.as_millis();
+    let write_elapsed_ms = timing.write.as_millis();
 
     if wait_elapsed_ms >= EXEC_OPERATION_FRAME_WRITE_SLOW_THRESHOLD.as_millis()
-        && let Some(diagnostic) = &diagnostic
+        && let Some(diagnostic) = diagnostic
     {
         tracing::warn!(
             seq = diagnostic.seq,
@@ -449,7 +382,7 @@ async fn write_encoded_frame_with_pre_write_decision(
 
     if write_elapsed_ms >= EXEC_OPERATION_FRAME_WRITE_SLOW_THRESHOLD.as_millis()
         && result.is_ok()
-        && let Some(diagnostic) = &diagnostic
+        && let Some(diagnostic) = diagnostic
     {
         tracing::warn!(
             seq = diagnostic.seq,
@@ -462,23 +395,18 @@ async fn write_encoded_frame_with_pre_write_decision(
         );
     }
 
-    if let Err(e) = result {
-        if let Some(diagnostic) = &diagnostic {
-            tracing::warn!(
-                seq = diagnostic.seq,
-                label = %diagnostic.label_log,
-                frame = diagnostic.frame,
-                process_class = diagnostic.process_class,
-                operation_kind = diagnostic.operation_kind,
-                write_elapsed_ms,
-                error = %e,
-                "exec operation frame write failed"
-            );
-        }
-        return Err(e);
+    if let Err(e) = result
+        && let Some(diagnostic) = diagnostic
+    {
+        tracing::warn!(
+            seq = diagnostic.seq,
+            label = %diagnostic.label_log,
+            frame = diagnostic.frame,
+            process_class = diagnostic.process_class,
+            operation_kind = diagnostic.operation_kind,
+            write_elapsed_ms,
+            error = %e,
+            "exec operation frame write failed"
+        );
     }
-
-    drop(guard);
-
-    Ok(FrameWriteDecision::Write)
 }

--- a/crates/vsock-host/src/exec_operation/mod.rs
+++ b/crates/vsock-host/src/exec_operation/mod.rs
@@ -48,9 +48,6 @@ const EXEC_OPERATION_FRAME_WRITE_SLOW_THRESHOLD: Duration = Duration::from_milli
 const EXEC_OPERATION_STAGE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
 const EXEC_OPERATION_DROP_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 const EXEC_OPERATION_START_TIMEOUT_CANCEL_WRITE_TIMEOUT: Duration = Duration::from_millis(250);
-const EXEC_OPERATION_FRAME_WRITE_NOT_STARTED: u8 = 0;
-const EXEC_OPERATION_FRAME_WRITE_STARTED: u8 = 1;
-const EXEC_OPERATION_FRAME_WRITE_COMPLETED: u8 = 2;
 
 fn exec_operation_guest_error(message: String) -> io::Error {
     io::Error::other(message)
@@ -65,23 +62,16 @@ pub(crate) mod test_support {
     use std::future::Future;
     use std::io;
     use std::sync::Arc;
-    use std::sync::atomic::AtomicU8;
     use std::time::Duration;
 
     use crate::Shared;
 
-    use super::frame::ExecOperationFrameWriteGuard;
+    use super::MAX_EXEC_STREAM_CAPACITY;
     use super::handle::SupervisedExecHandle;
     use super::start::start_supervised_exec_on_shared_with_after_start_write_and_cancel_timeout;
     use super::types::SupervisedExecRequest;
-    use super::{EXEC_OPERATION_FRAME_WRITE_STARTED, MAX_EXEC_STREAM_CAPACITY};
 
     pub(crate) const MAX_STREAM_CAPACITY: usize = MAX_EXEC_STREAM_CAPACITY;
-
-    pub(crate) fn drop_started_frame_write_guard(shared: Arc<Shared>) {
-        let state = Arc::new(AtomicU8::new(EXEC_OPERATION_FRAME_WRITE_STARTED));
-        drop(ExecOperationFrameWriteGuard::new(shared, state));
-    }
 
     pub(crate) fn set_exec_output_before_copy_hook(
         shared: &Arc<Shared>,

--- a/crates/vsock-host/src/exec_operation/tests.rs
+++ b/crates/vsock-host/src/exec_operation/tests.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
+use std::future::{Future, poll_fn};
 use std::io;
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU32;
+use std::task::Poll;
 use std::time::Duration;
 
 use tokio::sync::oneshot;
@@ -15,11 +17,16 @@ use vsock_proto::{
     RawMessage,
 };
 
-use crate::tests::support::read_guest_message;
-use crate::{ConnectionState, RouteId, Shared};
+use crate::operation_tracker::NormalOperationReadiness;
+use crate::tests::support::{
+    assert_connection_accepts_exec_operation, is_connected, normal_operation_readiness,
+    read_guest_message, route_reservation_count, send_exec_result, setup_host_and_guest,
+};
+use crate::{ConnectionState, ExecOperationRequest, RouteId, Shared};
 
 use super::diagnostics::*;
 use super::dispatch::dispatch_result;
+use super::frame::{ExecCancelFrameWriteOutcome, send_exec_cancel_frame_for_wait_with_write_start};
 use super::handle::{ExecOperationHandle, ExecWaitCore, ExecWaitLifecycle, send_exec_cancel_frame};
 use super::state::*;
 use super::types::ExecOperationResult;
@@ -54,6 +61,78 @@ fn exec_operation_for_snapshot(seq: u32, label: &str) -> ExecOperation {
         host_cancel_requested: false,
         pending_controls: HashMap::new(),
     }
+}
+
+#[tokio::test]
+async fn cancel_frame_skips_terminal_operation_after_waiting_for_writer() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let handle = host
+        .start_exec_operation(ExecOperationRequest {
+            timeout_ms: 5000,
+            start_write_timeout: Duration::from_secs(5),
+            command: "echo done",
+            env: &[],
+            sudo: false,
+            label: "cancel-skip",
+            stdout: vsock_proto::ExecOutputPolicy::Capture { limit_bytes: 1024 },
+            stderr: vsock_proto::ExecOutputPolicy::Capture { limit_bytes: 1024 },
+            expected_exit_codes: &[],
+            stdin_bytes: None,
+            stream_queue_capacity: None,
+        })
+        .await
+        .unwrap();
+    let start = read_guest_message(&mut guest).await;
+    assert_eq!(start.msg_type, vsock_proto::MSG_EXEC_START);
+    let route_id = handle.wait_core.active_route_id().unwrap();
+    let diagnostic = handle.wait_core.diagnostic().clone();
+    let writer = host.shared.writer.lock().await;
+    let (write_started_tx, mut write_started_rx) = oneshot::channel();
+    // Drive the real cancel transport independently of cancel_and_wait's biased
+    // result selection, so terminal delivery cannot bypass serialized admission.
+    let cancel = send_exec_cancel_frame_for_wait_with_write_start(
+        &host.shared,
+        route_id,
+        &diagnostic,
+        Some(write_started_tx),
+    );
+    tokio::pin!(cancel);
+    poll_fn(|cx| {
+        assert!(cancel.as_mut().poll(cx).is_pending());
+        Poll::Ready(())
+    })
+    .await;
+    assert_eq!(route_reservation_count(&host), 1);
+
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"done",
+        b"",
+    )
+    .await;
+    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    drop(writer);
+
+    let outcome = tokio::time::timeout(Duration::from_secs(5), cancel)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(outcome, ExecCancelFrameWriteOutcome::AlreadyTerminal);
+    assert_eq!(
+        write_started_rx.try_recv(),
+        Err(oneshot::error::TryRecvError::Closed)
+    );
+    assert_eq!(route_reservation_count(&host), 0);
+    assert!(is_connected(&host));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 fn clean_terminal_result() -> vsock_proto::DecodedExecResult<'static> {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -92,7 +92,7 @@ use connection::{
     request_on_shared_with_composite_operation_and_observer_frame_builder,
 };
 #[cfg(test)]
-use connection::{RequestWriteGuard, write_request_frame_with_builder};
+use connection::{request_on_shared, write_request_frame_with_builder};
 use operation_tracker::NormalOperationFenceRejection as TrackerNormalOperationFenceRejection;
 
 pub use exec_operation::{

--- a/crates/vsock-host/src/tests/connection.rs
+++ b/crates/vsock-host/src/tests/connection.rs
@@ -3,19 +3,20 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use nix::sys::socket::{Shutdown, setsockopt, shutdown, sockopt};
+use tokio::io::AsyncReadExt;
 use tokio::net::UnixStream;
 use vsock_proto::{
     ExecTermination, MSG_EXEC_START, MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT,
     MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_QUIESCE_OPERATIONS, MSG_READY,
-    MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MemorySnapshot,
+    MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE, MemorySnapshot,
 };
 
 use super::support::{
-    MockGuest, await_mock_guest, captured_output_bytes, drop_idle_request_write_guard,
-    drop_started_request_write_guard, exec_capture_default, fence_normal_operations,
-    host_from_stream, is_connected, make_pair, normal_operation_readiness, pending_request_count,
-    poison_connection, set_next_route_id, setup_host_and_mock_guest,
-    wait_for_pending_request_count,
+    MockGuest, assert_connection_accepts_exec_operation, await_mock_guest, captured_output_bytes,
+    exec_capture_default, fence_normal_operations, host_from_stream, is_connected, make_pair,
+    mock_handshake, normal_operation_readiness, pending_request_count, poison_connection,
+    set_next_route_id, setup_host_and_mock_guest, wait_for_pending_request_count,
 };
 use crate::{
     NormalOperationFenceRejection, VsockHost, operation_tracker::NormalOperationReadiness,
@@ -993,30 +994,112 @@ async fn connection_poison_marks_normal_operations_not_parkable() {
 
 #[tokio::test]
 async fn cancelled_request_before_frame_write_does_not_poison_connection() {
-    let (host, _guest) = setup_host_and_mock_guest().await;
-
-    drop_idle_request_write_guard(&host);
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    let host = Arc::new(host);
+    let writer = host.shared.writer.lock().await;
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.quiesce_operations(Duration::from_secs(5)).await })
+    };
+    wait_for_pending_request_count(&host, 1).await;
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
 
     assert!(is_connected(&host));
+    assert_eq!(pending_request_count(&host), 0);
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle
     );
+    drop(writer);
+    assert_connection_accepts_exec_operation(&host, guest.stream_mut()).await;
 }
 
 #[tokio::test]
 async fn cancelled_request_frame_write_poisons_connection() {
-    let (host, _guest) = setup_host_and_mock_guest().await;
+    let (host_stream, mut guest) = make_pair();
+    setsockopt(&host_stream, sockopt::SndBuf, &4096usize).unwrap();
+    let (host, ()) = tokio::join!(host_from_stream(host_stream), mock_handshake(&mut guest));
+    let host = Arc::new(host.unwrap());
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            let payload = vsock_proto::encode_write_file(
+                "/tmp/partial.bin",
+                &vec![0xAB; 1024 * 1024],
+                false,
+                false,
+            )
+            .unwrap();
+            crate::request_on_shared(
+                &host.shared,
+                MSG_WRITE_FILE,
+                &payload,
+                Duration::from_secs(5),
+            )
+            .await
+        })
+    };
+    // Read only the header: the large payload cannot fit in the send buffer.
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        guest.read_exact(&mut [0u8; vsock_proto::HEADER_SIZE]),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(!task.is_finished());
+    assert!(host.shared.writer.try_lock().is_err());
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
 
-    drop_started_request_write_guard(&host);
-
-    host.wait_until_closed(Duration::from_secs(5))
-        .await
-        .unwrap();
+    assert!(!is_connected(&host));
+    assert_eq!(pending_request_count(&host), 0);
+    assert!(host.shared.writer.try_lock().is_ok());
     assert_eq!(
         normal_operation_readiness(&host),
         NormalOperationReadiness::NotParkable
     );
+}
+
+#[tokio::test]
+async fn cancelled_request_after_complete_frame_preserves_connection() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.quiesce_operations(Duration::from_secs(5)).await })
+    };
+    guest.expect_message(MSG_QUIESCE_OPERATIONS).await;
+    drop(host.shared.writer.lock().await);
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+
+    assert!(is_connected(&host));
+    assert_eq!(pending_request_count(&host), 0);
+    assert_connection_accepts_exec_operation(&host, guest.stream_mut()).await;
+}
+
+#[tokio::test]
+async fn request_write_failure_poisons_connection_and_cleans_pending() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    // Fail the write without first closing the host's reader/registration state.
+    shutdown(host.shared.fd, Shutdown::Write).unwrap();
+    assert!(is_connected(&host));
+    let err = host
+        .quiesce_operations(Duration::from_secs(5))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    assert!(!is_connected(&host));
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    assert!(host.shared.writer.try_lock().is_ok());
+    guest.expect_eof().await;
 }
 
 /// Two concurrent exec calls get the correct response matched by seq.

--- a/crates/vsock-host/src/tests/exec_operation/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/cancel.rs
@@ -3,8 +3,11 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use nix::sys::socket::{setsockopt, sockopt};
-use tokio::io::AsyncWriteExt;
+use nix::sys::socket::{Shutdown, setsockopt, shutdown, sockopt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tracing::instrument::WithSubscriber;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::CapturedEvents;
 use vsock_proto::{ExecTermination, MSG_ERROR, MSG_EXEC_CANCEL, MSG_EXEC_START};
 
 use super::super::support::{
@@ -14,7 +17,6 @@ use super::super::support::{
     read_guest_message, send_exec_result, setup_host_and_guest, wait_for_operation_count,
 };
 use super::start_capture_operation;
-use crate::exec_operation as exec_operation_impl;
 use crate::operation_tracker::NormalOperationReadiness;
 use crate::{ExecCaptureRequest, FrameWriteObserver};
 
@@ -690,10 +692,86 @@ async fn exec_cancel_result_timeout_poisons_connection() {
 }
 
 #[tokio::test]
-async fn exec_operation_frame_write_guard_started_drop_poisons_connection() {
+async fn exec_start_write_failure_poisons_connection_and_preserves_diagnostics() {
     let (host, _guest) = setup_host_and_guest().await;
-    exec_operation_impl::test_support::drop_started_frame_write_guard(Arc::clone(&host.shared));
-    host.wait_until_closed(Duration::from_secs(5))
+    shutdown(host.shared.fd, Shutdown::Write).unwrap();
+    assert!(is_connected(&host));
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+
+    let err = host
+        .exec_operation_capture(capture_request("write-error"))
+        .with_subscriber(subscriber)
         .await
-        .unwrap();
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    assert!(!is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    assert!(host.shared.writer.try_lock().is_ok());
+    let events = captured.entries();
+    let failures: Vec<_> = events
+        .iter()
+        .filter(|event| {
+            event.fields.get("message").map(String::as_str)
+                == Some("exec operation frame write failed")
+        })
+        .collect();
+    assert_eq!(failures.len(), 1);
+    let failure = failures[0];
+    assert_eq!(failure.level, tracing::Level::WARN);
+    for (field, value) in [
+        ("seq", "2"),
+        ("label", "test-command"),
+        ("frame", "start"),
+        ("process_class", "contained_workload"),
+        ("operation_kind", "exec"),
+    ] {
+        assert_eq!(failure.fields.get(field).map(String::as_str), Some(value));
+    }
+    assert!(failure.fields["write_elapsed_ms"].parse::<u128>().is_ok());
+    assert_eq!(failure.fields["error"], err.to_string());
+}
+
+#[tokio::test]
+async fn exec_start_cancelled_during_write_poisons_connection() {
+    let (host_stream, mut guest) = make_pair();
+    setsockopt(&host_stream, sockopt::SndBuf, &4096usize).unwrap();
+    let (host, ()) = tokio::join!(host_from_stream(host_stream), mock_handshake(&mut guest));
+    let host = Arc::new(host.unwrap());
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            let stdin_bytes = vec![0xA5; vsock_proto::MAX_EXEC_STDIN_BYTES];
+            host.exec_operation_capture(ExecCaptureRequest {
+                stdin_bytes: Some(&stdin_bytes),
+                ..capture_request("cat")
+            })
+            .await
+        })
+    };
+    // Observe emitted bytes without draining enough to complete the start frame.
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        guest.read_exact(&mut [0u8; vsock_proto::HEADER_SIZE]),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(!task.is_finished());
+    assert!(host.shared.writer.try_lock().is_err());
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+
+    assert!(!is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    assert!(host.shared.writer.try_lock().is_ok());
 }

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::Poll;
 use std::time::Duration;
 
-use nix::sys::socket::{setsockopt, sockopt};
+use nix::sys::socket::{Shutdown, setsockopt, shutdown, sockopt};
 use tokio::io::AsyncWriteExt;
 use vsock_proto::{
     MSG_ERROR, MSG_EXEC_START, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE_RESULT,
@@ -1145,6 +1145,30 @@ async fn write_file_frame_builder_request_blocked_write_poisons_connection() {
     );
     assert!(host.shared.writer.try_lock().is_ok());
     assert!(host.shared.frame_builder.try_lock().is_ok());
+}
+
+#[tokio::test]
+async fn write_file_frame_failure_poisons_connection_and_releases_gates() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    shutdown(host.shared.fd, Shutdown::Write).unwrap();
+    assert!(is_connected(&host));
+
+    let err = host
+        .write_file("/tmp/write-error.txt", b"content", false)
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    assert!(!is_connected(&host));
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    assert!(host.shared.writer.try_lock().is_ok());
+    assert!(host.shared.frame_builder.try_lock().is_ok());
+    assert!(host.shared.file_write_gate.try_lock().is_ok());
+    guest.expect_eof().await;
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -288,17 +288,6 @@ pub(crate) fn captured_output_bytes(output: &ExecOwnedCapturedOutput) -> &[u8] {
     }
 }
 
-pub(crate) fn drop_idle_request_write_guard(host: &VsockHost) {
-    let guard = crate::RequestWriteGuard::new(Arc::clone(&host.shared));
-    drop(guard);
-}
-
-pub(crate) fn drop_started_request_write_guard(host: &VsockHost) {
-    let mut guard = crate::RequestWriteGuard::new(Arc::clone(&host.shared));
-    guard.mark_started();
-    drop(guard);
-}
-
 pub(crate) async fn read_guest_message(stream: &mut UnixStream) -> RawMessage {
     let mut header = [0u8; HEADER_SIZE];
     tokio::time::timeout(MOCK_GUEST_IO_TIMEOUT, stream.read_exact(&mut header))


### PR DESCRIPTION
## Summary

- Centralize all post-handshake frame writes in a private `Shared::write_frame` primitive. Plain requests, frame-builder requests, and exec start/control/cancel now share writer acquisition, serialized admission, partial-write cancellation protection, and poisoning.
- Replace the request-specific guard and exec's allocated atomic guard with one stack-owned guard. Admission failure and stale-cancel `Skip` stay before the write boundary; successful writes disarm the guard; failed/interrupted writes poison before unlocking.
- Keep pending/operation cleanup, request deadlines and timeout stages, exec route/observer ordering, diagnostic fields and thresholds, frame construction outside the writer lock, and frame-buffer lifetime within the builder gate in their existing owners.
- Replace guard-construction tests with real Unix-socket cancellation coverage, and add write-error/cleanup and exec diagnostic regressions. A deterministic real-socket cancel-transport regression now exercises serialized `Skip` after terminal delivery, asserting no write-start notification, reservation cleanup, and a reusable stream. It needs no new production test hook.

Closes #32281

## Scope and risk

This is consolidation of existing stream-integrity protection, not a newly demonstrated corruption fix. No protocol, public API, database, frontend, runner policy, or deployment contract changes. The listener handshake is intentionally separate. No write queue or new retry behavior.

The main regression risk is guard/admission/drop ordering across the shared byte stream. Real partial-write, pre-write cancellation/error, completed-frame, stale-cancel, and file gate tests cover those boundaries. Request writes now perform bounded timing samples; exec drops its per-write atomic allocation. No measured throughput improvement is claimed.

## Validation

From `crates/`:

- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p vsock-host --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local -p vsock-host --all-features --no-deps`
- `cargo test --profile local -p vsock-host --all-targets --all-features --quiet` — 400 passed, 0 failed, 0 ignored

`git diff --check` passes. No test skips or timeout increases. No unrelated Turbo/Python suites were run for this crate-private Rust change. Real Firecracker/runner behavior validation remains with CI.
