### PR TITLE
test(nbd-cow): cover size-zero retries and lease cleanup

### DIFF
--- a/crates/nbd-cow/Cargo.toml
+++ b/crates/nbd-cow/Cargo.toml
@@ -25,6 +25,7 @@ uuid = { workspace = true, features = ["v4"] }
 which = { workspace = true, optional = true }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 nix = { workspace = true, features = ["user"] }
 tempfile = { workspace = true }
 tracing-subscriber.workspace = true

--- a/crates/nbd-cow/src/device/connection.rs
+++ b/crates/nbd-cow/src/device/connection.rs
@@ -6,6 +6,7 @@ use crate::error::{self, Result};
 use crate::{netlink, pool};
 
 use super::create_timing::{NbdNetlinkConnectStage, NbdNetlinkConnectTiming};
+use super::kernel::{CreateKernel, NativeKernel};
 
 struct NetlinkCriticalSectionResult<T> {
     queue_duration: Duration,
@@ -81,38 +82,52 @@ impl Drop for DeferredLease {
     }
 }
 
-pub(super) struct ConnectDeviceOutcome {
+pub(super) struct ConnectDeviceOutcome<K: CreateKernel = NativeKernel> {
     device_index: u32,
     lease: DeferredLease,
     result: Option<std::result::Result<netlink::ConnectDeviceSuccess, netlink::ConnectDeviceError>>,
+    kernel: K,
 }
 
-pub(super) struct ConnectDeviceCriticalSectionResult {
+pub(super) struct ConnectDeviceCriticalSectionResult<K: CreateKernel> {
     timing: NbdNetlinkConnectTiming,
-    result: std::result::Result<ConnectDeviceOutcome, netlink::ConnectDeviceError>,
+    result: std::result::Result<ConnectDeviceOutcome<K>, netlink::ConnectDeviceError>,
 }
 
-impl ConnectDeviceCriticalSectionResult {
+impl<K: CreateKernel> ConnectDeviceCriticalSectionResult<K> {
     pub(super) fn into_parts(
         self,
     ) -> (
         NbdNetlinkConnectTiming,
-        std::result::Result<ConnectDeviceOutcome, netlink::ConnectDeviceError>,
+        std::result::Result<ConnectDeviceOutcome<K>, netlink::ConnectDeviceError>,
     ) {
         (self.timing, self.result)
     }
 }
 
+#[cfg(test)]
 impl ConnectDeviceOutcome {
     fn new(
         device_index: u32,
         lease: DeferredLease,
         result: std::result::Result<netlink::ConnectDeviceSuccess, netlink::ConnectDeviceError>,
     ) -> Self {
+        Self::with_kernel(device_index, lease, result, NativeKernel)
+    }
+}
+
+impl<K: CreateKernel> ConnectDeviceOutcome<K> {
+    fn with_kernel(
+        device_index: u32,
+        lease: DeferredLease,
+        result: std::result::Result<netlink::ConnectDeviceSuccess, netlink::ConnectDeviceError>,
+        kernel: K,
+    ) -> Self {
         Self {
             device_index,
             lease,
             result: Some(result),
+            kernel,
         }
     }
 
@@ -178,31 +193,31 @@ impl ConnectDeviceOutcome {
     }
 }
 
-impl Drop for ConnectDeviceOutcome {
+impl<K: CreateKernel> Drop for ConnectDeviceOutcome<K> {
     fn drop(&mut self) {
-        self.cleanup_unobserved_with(device_ownership, netlink::disconnect);
+        let kernel = self.kernel.clone();
+        self.cleanup_unobserved_with(
+            |index, id| kernel.ownership(index, id),
+            |index| kernel.disconnect(index),
+        );
     }
 }
 
-pub(super) async fn connect_device_with_state_critical_section(
+pub(super) async fn connect_device_with_state_critical_section<K: CreateKernel>(
     device_index: u32,
     client_fds: Vec<std::os::fd::OwnedFd>,
     size: u64,
     block_size: u64,
     pool: pool::DevicePoolHandle,
     lease: pool::DeviceLease,
-) -> ConnectDeviceCriticalSectionResult {
+    kernel: K,
+) -> ConnectDeviceCriticalSectionResult<K> {
     let deferred_lease = DeferredLease::new(pool, lease);
     let critical_section =
         run_netlink_critical_section_with_queue_timing("NBD connect", move || {
-            let (result, timing) = netlink::connect_device_with_state_timing(
-                device_index,
-                &client_fds,
-                size,
-                block_size,
-            );
+            let (result, timing) = kernel.connect(device_index, &client_fds, size, block_size);
             (
-                ConnectDeviceOutcome::new(device_index, deferred_lease, result),
+                ConnectDeviceOutcome::with_kernel(device_index, deferred_lease, result, kernel),
                 timing,
             )
         })
@@ -271,8 +286,19 @@ impl Drop for OwnedDisconnectResultOutcome {
 pub(super) async fn disconnect_connected_if_owned_result_critical_section(
     connected: ConnectedDevice,
 ) -> Result<OwnedDisconnectState> {
+    disconnect_connected_if_owned_result_with_kernel(connected, NativeKernel).await
+}
+
+pub(super) async fn disconnect_connected_if_owned_result_with_kernel(
+    connected: ConnectedDevice,
+    kernel: impl CreateKernel,
+) -> Result<OwnedDisconnectState> {
     run_netlink_critical_section("owned NBD disconnect", move || {
-        disconnect_connected_if_owned_result_with(connected, device_ownership, netlink::disconnect)
+        disconnect_connected_if_owned_result_with(
+            connected,
+            |index, id| kernel.ownership(index, id),
+            |index| kernel.disconnect(index),
+        )
     })
     .await?
 }
@@ -282,6 +308,16 @@ pub(super) async fn disconnect_connected_if_owned_result_with_lease_critical_sec
     pool: pool::DevicePoolHandle,
     lease: pool::DeviceLease,
 ) -> Result<OwnedDisconnectResultOutcome> {
+    disconnect_connected_if_owned_result_with_lease_and_kernel(connected, pool, lease, NativeKernel)
+        .await
+}
+
+pub(super) async fn disconnect_connected_if_owned_result_with_lease_and_kernel(
+    connected: ConnectedDevice,
+    pool: pool::DevicePoolHandle,
+    lease: pool::DeviceLease,
+    kernel: impl CreateKernel,
+) -> Result<OwnedDisconnectResultOutcome> {
     let deferred_lease = DeferredLease::new(pool, lease);
     run_netlink_critical_section("owned NBD disconnect", move || {
         OwnedDisconnectResultOutcome::new(
@@ -289,8 +325,8 @@ pub(super) async fn disconnect_connected_if_owned_result_with_lease_critical_sec
             deferred_lease,
             disconnect_connected_if_owned_result_with(
                 connected,
-                device_ownership,
-                netlink::disconnect,
+                |index, id| kernel.ownership(index, id),
+                |index| kernel.disconnect(index),
             ),
         )
     })
@@ -353,8 +389,15 @@ fn device_ownership_from_backend_contents(connection_id: Uuid, contents: &str) -
     }
 }
 
-pub(super) fn disconnect_connected_if_owned(connected: ConnectedDevice) -> bool {
-    disconnect_connected_if_owned_with(connected, device_ownership, netlink::disconnect)
+pub(super) fn disconnect_connected_if_owned_with_kernel(
+    connected: ConnectedDevice,
+    kernel: &impl CreateKernel,
+) -> bool {
+    disconnect_connected_if_owned_with(
+        connected,
+        |index, id| kernel.ownership(index, id),
+        |index| kernel.disconnect(index),
+    )
 }
 
 fn disconnect_connected_if_owned_result_with(

--- a/crates/nbd-cow/src/device/create.rs
+++ b/crates/nbd-cow/src/device/create.rs
@@ -13,24 +13,27 @@ use uuid::Uuid;
 use super::NbdCowDevice;
 use super::connection::{
     ConnectedDevice, OwnedDisconnectState, connect_device_with_state_critical_section,
-    disconnect_connected_if_owned, disconnect_connected_if_owned_result_critical_section,
-    disconnect_connected_if_owned_result_with_lease_critical_section,
+    disconnect_connected_if_owned_result_with_kernel,
+    disconnect_connected_if_owned_result_with_lease_and_kernel,
+    disconnect_connected_if_owned_with_kernel,
 };
 use super::create_timing::{
     NbdCowCreateObserver, NbdCowCreateStage, NbdCowCreateTiming, NbdNetlinkConnectTiming,
 };
+use super::kernel::{CreateKernel, NativeKernel};
 
 const MAX_SIZE_RETRIES: u32 = 5;
 const MAX_EBUSY_RETRIES: u32 = 16;
 const SIZE_RETRY_DELAY: Duration = Duration::from_millis(200);
 
-struct CreateAttemptGuard {
+struct CreateAttemptGuard<K: CreateKernel = NativeKernel> {
     pool: pool::DevicePoolHandle,
     device_index: u32,
     lease: Option<pool::DeviceLease>,
     shutdown: CancellationToken,
     server_handles: Vec<JoinHandle<()>>,
     connected: Option<ConnectedDevice>,
+    kernel: K,
 }
 
 #[derive(Clone, Copy)]
@@ -65,21 +68,23 @@ impl CreateDisconnectStatus {
     }
 }
 
-struct CreateContext<'a, 'observer> {
+struct CreateContext<'a, 'observer, K: CreateKernel> {
     device_pool: &'a pool::DevicePoolHandle,
     cow_file: &'a Path,
     cow: cow_io::CowIo,
     size: u64,
     timing: &'a mut NbdCowCreateTiming<'observer>,
+    kernel: K,
 }
 
-impl<'a, 'observer> CreateContext<'a, 'observer> {
+impl<'a, 'observer, K: CreateKernel> CreateContext<'a, 'observer, K> {
     fn new(
         device_pool: &'a pool::DevicePoolHandle,
         cow_file: &'a Path,
         cow: cow_io::CowIo,
         size: u64,
         timing: &'a mut NbdCowCreateTiming<'observer>,
+        kernel: K,
     ) -> Self {
         Self {
             device_pool,
@@ -87,6 +92,7 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
             cow,
             size,
             timing,
+            kernel,
         }
     }
 
@@ -98,7 +104,7 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
             let device_index = attempt.device_index();
 
             let verify_started_at = Instant::now();
-            let size_matches = netlink::verify_device_size(device_index, self.size).await;
+            let size_matches = self.kernel.verify_size(device_index, self.size).await;
             self.timing.record_stage(
                 NbdCowCreateStage::SizeVerify,
                 verify_started_at,
@@ -135,7 +141,7 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
         ))))
     }
 
-    async fn acquire_connected_attempt(&mut self) -> Result<CreateAttemptGuard> {
+    async fn acquire_connected_attempt(&mut self) -> Result<CreateAttemptGuard<K>> {
         let mut ebusy_count: u32 = 0;
 
         loop {
@@ -149,7 +155,11 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
             let acquisition = acquisition?;
             let (lease, source, scan_duration) = acquisition.into_parts();
             self.timing.record_acquisition(source, scan_duration);
-            let mut attempt = CreateAttemptGuard::new(self.device_pool.clone(), lease);
+            let mut attempt = CreateAttemptGuard::with_kernel(
+                self.device_pool.clone(),
+                lease,
+                self.kernel.clone(),
+            );
             let device_index = attempt.device_index();
 
             let setup_started_at = Instant::now();
@@ -241,7 +251,7 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
         }
     }
 
-    fn setup_dispatch_servers(&self, attempt: &mut CreateAttemptGuard) -> Result<Vec<OwnedFd>> {
+    fn setup_dispatch_servers(&self, attempt: &mut CreateAttemptGuard<K>) -> Result<Vec<OwnedFd>> {
         let mut client_fds = Vec::with_capacity(NUM_CONNECTIONS);
 
         for _ in 0..NUM_CONNECTIONS {
@@ -263,7 +273,7 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
 
     async fn connect_attempt(
         &mut self,
-        attempt: &mut CreateAttemptGuard,
+        attempt: &mut CreateAttemptGuard<K>,
         client_fds: Vec<OwnedFd>,
     ) -> ConnectAttemptResult {
         let device_index = attempt.device_index();
@@ -285,6 +295,7 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
             BLOCK_SIZE as u64,
             self.device_pool.clone(),
             lease,
+            self.kernel.clone(),
         )
         .await;
         let (timing, critical_result) = critical_section.into_parts();
@@ -303,8 +314,15 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
     }
 }
 
+#[cfg(test)]
 impl CreateAttemptGuard {
     fn new(pool: pool::DevicePoolHandle, lease: pool::DeviceLease) -> Self {
+        Self::with_kernel(pool, lease, NativeKernel)
+    }
+}
+
+impl<K: CreateKernel> CreateAttemptGuard<K> {
+    fn with_kernel(pool: pool::DevicePoolHandle, lease: pool::DeviceLease, kernel: K) -> Self {
         let device_index = lease.index();
         Self {
             pool,
@@ -313,6 +331,7 @@ impl CreateAttemptGuard {
             shutdown: CancellationToken::new(),
             server_handles: Vec::with_capacity(NUM_CONNECTIONS),
             connected: None,
+            kernel,
         }
     }
 
@@ -413,10 +432,11 @@ impl CreateAttemptGuard {
     ) -> CreateDisconnectStatus {
         match self.take_lease() {
             Some(lease) => {
-                match disconnect_connected_if_owned_result_with_lease_critical_section(
+                match disconnect_connected_if_owned_result_with_lease_and_kernel(
                     connected,
                     self.pool.clone(),
                     lease,
+                    self.kernel.clone(),
                 )
                 .await
                 {
@@ -436,7 +456,12 @@ impl CreateAttemptGuard {
                     }
                 }
             }
-            None => match disconnect_connected_if_owned_result_critical_section(connected).await {
+            None => match disconnect_connected_if_owned_result_with_kernel(
+                connected,
+                self.kernel.clone(),
+            )
+            .await
+            {
                 Ok(disconnect_state) => {
                     self.owned_disconnect_status(mode, connected, Ok(disconnect_state))
                 }
@@ -588,14 +613,14 @@ fn log_owned_disconnect_foreign(mode: CreateDisconnectCleanupMode, connected: Co
     }
 }
 
-impl Drop for CreateAttemptGuard {
+impl<K: CreateKernel> Drop for CreateAttemptGuard<K> {
     fn drop(&mut self) {
         self.shutdown.cancel();
         for handle in self.server_handles.drain(..) {
             handle.abort();
         }
         if let Some(connected) = self.connected.take() {
-            disconnect_connected_if_owned(connected);
+            disconnect_connected_if_owned_with_kernel(connected, &self.kernel);
         }
         if let Some(lease) = self.lease.take() {
             let device_index = lease.index();
@@ -631,6 +656,25 @@ impl NbdCowDevice {
         device_pool: &pool::DevicePoolHandle,
         observer: Option<&mut dyn NbdCowCreateObserver>,
     ) -> Result<(Self, pool::DeviceLease)> {
+        Self::create_with_kernel(
+            base_image,
+            cow_file,
+            size,
+            device_pool,
+            observer,
+            NativeKernel,
+        )
+        .await
+    }
+
+    async fn create_with_kernel(
+        base_image: &Path,
+        cow_file: &Path,
+        size: u64,
+        device_pool: &pool::DevicePoolHandle,
+        observer: Option<&mut dyn NbdCowCreateObserver>,
+        kernel: impl CreateKernel,
+    ) -> Result<(Self, pool::DeviceLease)> {
         let mut timing = NbdCowCreateTiming::new(observer);
         let result = async {
             let cow_started_at = Instant::now();
@@ -647,7 +691,8 @@ impl NbdCowDevice {
                 cow_layer.is_ok(),
             );
             let cow = cow_io::CowIo::new(cow_layer?);
-            let mut context = CreateContext::new(device_pool, cow_file, cow, size, &mut timing);
+            let mut context =
+                CreateContext::new(device_pool, cow_file, cow, size, &mut timing, kernel);
 
             context.create_with_size_retries().await
         }
@@ -656,6 +701,9 @@ impl NbdCowDevice {
         result
     }
 }
+
+#[cfg(test)]
+mod size_retry_tests;
 
 async fn abort_server_handles(handles: Vec<JoinHandle<()>>) {
     for handle in &handles {

--- a/crates/nbd-cow/src/device/create/size_retry_tests.rs
+++ b/crates/nbd-cow/src/device/create/size_retry_tests.rs
@@ -1,0 +1,476 @@
+use std::future::{Future, poll_fn};
+use std::io::Read;
+use std::os::unix::net::UnixStream as StdUnixStream;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::Poll;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+use tokio::sync::{mpsc, oneshot};
+
+use super::*;
+use crate::device::connection::DeviceOwnership;
+use crate::device::create_timing::NbdCowCreateOutcome;
+use crate::device_lock::try_acquire_device_claim_in;
+use crate::protocol_impl::{self as protocol, Command, NbdReply, NbdRequest};
+
+const DEVICE_SIZE: u64 = 4096;
+
+#[derive(Clone, Copy)]
+enum Cleanup {
+    Clean,
+    Foreign,
+    Unknown,
+    DisconnectError,
+}
+
+struct Attempt {
+    index: u32,
+    connection_id: Uuid,
+    peers: Vec<StdUnixStream>,
+    dispatch_closed_before_cleanup: bool,
+    disconnect_calls: usize,
+}
+
+struct Verification {
+    index: u32,
+    respond: oneshot::Sender<bool>,
+}
+
+#[derive(Clone)]
+struct ControlledKernel {
+    attempts: Arc<Mutex<Vec<Attempt>>>,
+    verifications: mpsc::UnboundedSender<Verification>,
+    cleanup: Cleanup,
+}
+
+impl CreateKernel for ControlledKernel {
+    fn connect(
+        &self,
+        device_index: u32,
+        client_fds: &[OwnedFd],
+        size: u64,
+        block_size: u64,
+    ) -> (
+        std::result::Result<netlink::ConnectDeviceSuccess, netlink::ConnectDeviceError>,
+        NbdNetlinkConnectTiming,
+    ) {
+        assert_eq!(size, DEVICE_SIZE);
+        assert_eq!(block_size, BLOCK_SIZE as u64);
+        let connection_id = Uuid::new_v4();
+        let peers = client_fds
+            .iter()
+            .map(|fd| {
+                let peer = StdUnixStream::from(fd.try_clone().unwrap());
+                peer.set_nonblocking(true).unwrap();
+                peer
+            })
+            .collect();
+        self.attempts.lock().unwrap().push(Attempt {
+            index: device_index,
+            connection_id,
+            peers,
+            dispatch_closed_before_cleanup: false,
+            disconnect_calls: 0,
+        });
+        (
+            Ok(netlink::ConnectDeviceSuccess { connection_id }),
+            NbdNetlinkConnectTiming::default(),
+        )
+    }
+
+    async fn verify_size(&self, device_index: u32, size: u64) -> bool {
+        assert_eq!(size, DEVICE_SIZE);
+        let (respond, response) = oneshot::channel();
+        self.verifications
+            .send(Verification {
+                index: device_index,
+                respond,
+            })
+            .unwrap();
+        response.await.unwrap()
+    }
+
+    fn ownership(&self, device_index: u32, connection_id: Uuid) -> DeviceOwnership {
+        let mut attempts = self.attempts.lock().unwrap();
+        let attempt = attempts
+            .iter_mut()
+            .find(|a| a.index == device_index)
+            .unwrap();
+        if attempt.connection_id != connection_id {
+            return DeviceOwnership::Foreign;
+        }
+        // Nonblocking EOF proves the real dispatch sockets were dropped before
+        // production cleanup reached the kernel boundary. Do not wait for EOF:
+        // doing so would hide a missing abort/join in the caller.
+        attempt.dispatch_closed_before_cleanup = attempt
+            .peers
+            .iter_mut()
+            .all(|peer| matches!(peer.read(&mut [0]), Ok(0)));
+        match self.cleanup {
+            Cleanup::Clean | Cleanup::DisconnectError => DeviceOwnership::Ours,
+            Cleanup::Foreign => DeviceOwnership::Foreign,
+            Cleanup::Unknown => {
+                DeviceOwnership::Unknown(std::io::Error::other("ownership unknown"))
+            }
+        }
+    }
+
+    fn disconnect(&self, device_index: u32) -> Result<()> {
+        self.attempts
+            .lock()
+            .unwrap()
+            .iter_mut()
+            .find(|a| a.index == device_index)
+            .unwrap()
+            .disconnect_calls += 1;
+        match self.cleanup {
+            Cleanup::DisconnectError => Err(error::NbdCowError::Io(std::io::Error::other(
+                "disconnect failed",
+            ))),
+            Cleanup::Clean | Cleanup::Foreign | Cleanup::Unknown => Ok(()),
+        }
+    }
+}
+
+#[derive(Default)]
+struct Observer {
+    outcomes: Vec<NbdCowCreateOutcome>,
+    stages: Vec<(NbdCowCreateStage, bool)>,
+}
+
+impl NbdCowCreateObserver for Observer {
+    fn record_stage(&mut self, stage: NbdCowCreateStage, _: Duration, success: bool) {
+        self.stages.push((stage, success));
+    }
+
+    fn record_outcome(&mut self, outcome: NbdCowCreateOutcome) {
+        self.outcomes.push(outcome);
+    }
+}
+
+struct Harness {
+    dir: tempfile::TempDir,
+    pool: pool::DevicePoolHandle,
+    kernel: ControlledKernel,
+    verifications: mpsc::UnboundedReceiver<Verification>,
+}
+
+impl Harness {
+    fn new(cleanup: Cleanup) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("base.img"),
+            vec![0x5a; DEVICE_SIZE as usize],
+        )
+        .unwrap();
+        let pool = pool::DevicePoolHandle::new_devices_for_test(
+            pool::DevicePoolConfig {
+                cooldown: Duration::MAX,
+            },
+            dir.path(),
+            6,
+        );
+        let (verifications, receiver) = mpsc::unbounded_channel();
+        Self {
+            dir,
+            pool,
+            kernel: ControlledKernel {
+                attempts: Arc::default(),
+                verifications,
+                cleanup,
+            },
+            verifications: receiver,
+        }
+    }
+
+    async fn assert_pool(&self, failed: &[u32], live: Option<u32>) {
+        let snapshot = self.pool.snapshot().await;
+        let mut cooldown = snapshot.cooldown;
+        cooldown.sort_unstable();
+        let mut expected = failed.to_vec();
+        expected.sort_unstable();
+        assert_eq!(cooldown, expected);
+        assert_eq!(snapshot.in_flight, live.into_iter().collect());
+        assert_eq!(snapshot.waiting_acquires, 0);
+        for index in failed.iter().copied().chain(live) {
+            assert!(
+                try_acquire_device_claim_in(index, self.dir.path())
+                    .unwrap()
+                    .is_none(),
+                "claim for nbd{index} must remain locked"
+            );
+        }
+    }
+
+    async fn finish(&self, indices: &[u32]) {
+        self.pool.cleanup().await;
+        for &index in indices {
+            assert!(
+                try_acquire_device_claim_in(index, self.dir.path())
+                    .unwrap()
+                    .is_some()
+            );
+        }
+    }
+}
+
+// Poll explicitly so waiting for external I/O never auto-advances a retry
+// timer. The wall-clock bound detects missing handshakes without changing time.
+async fn poll_once<F: Future>(mut future: Pin<&mut F>) -> Poll<F::Output> {
+    poll_fn(|cx| Poll::Ready(future.as_mut().poll(cx))).await
+}
+
+async fn next_verification<F: Future>(
+    mut create: Pin<&mut F>,
+    verifications: &mut mpsc::UnboundedReceiver<Verification>,
+) -> Verification {
+    let started = Instant::now();
+    loop {
+        assert!(poll_once(create.as_mut()).await.is_pending());
+        if let Ok(verification) = verifications.try_recv() {
+            return verification;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "verification did not start"
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn read_from_dispatch(kernel: &ControlledKernel, index: u32) {
+    let mut read = std::pin::pin!(async {
+        let peers: Vec<_> = kernel
+            .attempts
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|a| a.index == index)
+            .unwrap()
+            .peers
+            .iter()
+            .map(|peer| peer.try_clone().unwrap())
+            .collect();
+        assert_eq!(peers.len(), NUM_CONNECTIONS);
+        for peer in peers {
+            let mut peer = UnixStream::from_std(peer).unwrap();
+            let request = NbdRequest {
+                command: Command::Read,
+                handle: 42,
+                offset: 0,
+                length: 1,
+            };
+            peer.write_all(&protocol::serialize_request(&request))
+                .await
+                .unwrap();
+            let mut reply = [0; protocol::REPLY_HEADER_SIZE];
+            peer.read_exact(&mut reply).await.unwrap();
+            assert_eq!(
+                reply,
+                protocol::serialize_reply(&NbdReply {
+                    error: 0,
+                    handle: 42
+                })
+            );
+            assert_eq!(peer.read_u8().await.unwrap(), 0x5a);
+        }
+    });
+    complete(read.as_mut()).await;
+}
+
+async fn complete<F: Future>(mut future: Pin<&mut F>) -> F::Output {
+    let started = Instant::now();
+    loop {
+        if let Poll::Ready(result) = poll_once(future.as_mut()).await {
+            return result;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "operation did not finish"
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn assert_retry_delay<F: Future>(mut create: Pin<&mut F>, harness: &Harness, failed: &[u32]) {
+    let started = Instant::now();
+    loop {
+        assert!(poll_once(create.as_mut()).await.is_pending());
+        if harness.pool.snapshot().await.cooldown.len() == failed.len() {
+            // Consume the acknowledged lease return and enter the retry sleep.
+            assert!(poll_once(create.as_mut()).await.is_pending());
+            break;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "cleanup did not finish"
+        );
+        tokio::task::yield_now().await;
+    }
+    harness.assert_pool(failed, None).await;
+    {
+        let attempts = harness.kernel.attempts.lock().unwrap();
+        assert_eq!(attempts.len(), failed.len());
+        assert!(attempts.iter().all(|a| a.dispatch_closed_before_cleanup));
+    }
+    tokio::time::advance(Duration::from_millis(199)).await;
+    assert!(poll_once(create.as_mut()).await.is_pending());
+    // The actor processes its snapshot after any acquire submitted by this
+    // poll. Check queued requests too: a blocking connect may not have run yet.
+    harness.assert_pool(failed, None).await;
+    assert_eq!(harness.kernel.attempts.lock().unwrap().len(), failed.len());
+    tokio::time::advance(Duration::from_millis(1)).await;
+}
+
+// Successful devices normally use the real kernel for their later lifecycle.
+// Keep test-owned resources from ever reaching that boundary, including panic.
+struct TestDevice(NbdCowDevice);
+
+impl Drop for TestDevice {
+    fn drop(&mut self) {
+        self.0.abandon();
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn size_retry_transfers_only_the_successful_attempt() {
+    let mut harness = Harness::new(Cleanup::Clean);
+    let mut observer = Observer::default();
+    let base = harness.dir.path().join("base.img");
+    let cow = harness.dir.path().join("cow.img");
+    let pool = harness.pool.clone();
+    let mut create = std::pin::pin!(NbdCowDevice::create_with_kernel(
+        &base,
+        &cow,
+        DEVICE_SIZE,
+        &pool,
+        Some(&mut observer),
+        harness.kernel.clone(),
+    ));
+    let first = next_verification(create.as_mut(), &mut harness.verifications).await;
+    read_from_dispatch(&harness.kernel, first.index).await;
+    let started = tokio::time::Instant::now();
+    first.respond.send(false).unwrap();
+    assert_retry_delay(create.as_mut(), &harness, &[first.index]).await;
+
+    let second = next_verification(create.as_mut(), &mut harness.verifications).await;
+    assert_ne!(first.index, second.index);
+    assert_eq!(started.elapsed(), Duration::from_millis(200));
+    harness
+        .assert_pool(&[first.index], Some(second.index))
+        .await;
+    read_from_dispatch(&harness.kernel, second.index).await;
+    second.respond.send(true).unwrap();
+    let (device, lease) = complete(create.as_mut()).await.unwrap();
+    let mut device = TestDevice(device);
+    assert_eq!(lease.index(), second.index);
+    assert_eq!(device.0.device_index(), second.index);
+    assert_eq!(device.0.cow_file(), cow);
+    assert!(!device.0.shutdown.is_cancelled());
+    assert!(!device.0.disconnected);
+    assert_eq!(device.0.server_handles.len(), NUM_CONNECTIONS);
+    assert!(
+        device
+            .0
+            .server_handles
+            .iter()
+            .all(|handle| !handle.is_finished())
+    );
+    {
+        let attempts = harness.kernel.attempts.lock().unwrap();
+        assert_eq!(attempts.len(), 2);
+        assert_eq!(attempts[0].disconnect_calls, 1);
+        assert_eq!(attempts[1].disconnect_calls, 0);
+        assert_eq!(device.0.connection_id, attempts[1].connection_id);
+    }
+    read_from_dispatch(&harness.kernel, second.index).await;
+    device.0.prepare_shutdown(false).await.unwrap();
+    pool.release_clean(lease).await;
+    harness
+        .assert_pool(&[first.index, second.index], None)
+        .await;
+    harness.finish(&[first.index, second.index]).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn size_retry_exhaustion_cleans_all_attempts_without_a_final_delay() {
+    for cleanup in [
+        Cleanup::Clean,
+        Cleanup::Foreign,
+        Cleanup::Unknown,
+        Cleanup::DisconnectError,
+    ] {
+        let mut harness = Harness::new(cleanup);
+        let mut observer = Observer::default();
+        let base = harness.dir.path().join("base.img");
+        let cow = harness.dir.path().join("cow.img");
+        let pool = harness.pool.clone();
+        let mut failed = Vec::new();
+        {
+            let mut create = std::pin::pin!(NbdCowDevice::create_with_kernel(
+                &base,
+                &cow,
+                DEVICE_SIZE,
+                &pool,
+                Some(&mut observer),
+                harness.kernel.clone(),
+            ));
+            let started = tokio::time::Instant::now();
+            for attempt in 0..6 {
+                let verification =
+                    next_verification(create.as_mut(), &mut harness.verifications).await;
+                harness.assert_pool(&failed, Some(verification.index)).await;
+                read_from_dispatch(&harness.kernel, verification.index).await;
+                failed.push(verification.index);
+                verification.respond.send(false).unwrap();
+                if attempt < 5 {
+                    assert_retry_delay(create.as_mut(), &harness, &failed).await;
+                }
+            }
+            let result = complete(create.as_mut()).await;
+            let Err(error::NbdCowError::Io(error)) = result else {
+                panic!("expected terminal size verification error");
+            };
+            assert!(
+                error
+                    .to_string()
+                    .contains("device size stuck at 0 after 5 connect retries")
+            );
+            assert!(error.to_string().contains(&format!("on nbd{}", failed[5])));
+            assert_eq!(started.elapsed(), Duration::from_millis(1000));
+        }
+        harness.assert_pool(&failed, None).await;
+        {
+            let attempts = harness.kernel.attempts.lock().unwrap();
+            assert_eq!(attempts.len(), 6);
+            assert!(attempts.iter().all(|a| a.dispatch_closed_before_cleanup));
+            let expected_disconnects = match cleanup {
+                Cleanup::Clean | Cleanup::DisconnectError => 1,
+                Cleanup::Foreign | Cleanup::Unknown => 0,
+            };
+            assert!(
+                attempts
+                    .iter()
+                    .all(|a| a.disconnect_calls == expected_disconnects)
+            );
+        }
+        assert!(
+            observer
+                .outcomes
+                .contains(&NbdCowCreateOutcome::SizeZeroRetriesMultiple)
+        );
+        assert!(
+            observer
+                .outcomes
+                .contains(&NbdCowCreateOutcome::EbusyRetriesNone)
+        );
+        assert!(
+            observer
+                .stages
+                .contains(&(NbdCowCreateStage::SizeVerify, false))
+        );
+        harness.finish(&failed).await;
+    }
+}

--- a/crates/nbd-cow/src/device/kernel.rs
+++ b/crates/nbd-cow/src/device/kernel.rs
@@ -1,0 +1,61 @@
+use std::future::Future;
+use std::os::fd::OwnedFd;
+
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::netlink;
+
+use super::connection::{DeviceOwnership, device_ownership};
+use super::create_timing::NbdNetlinkConnectTiming;
+
+/// The kernel boundary used during creation, including unobserved-result cleanup.
+/// Pool ownership, dispatch and retry policy remain outside this boundary.
+pub(super) trait CreateKernel: Clone + Send + Sync + 'static {
+    fn connect(
+        &self,
+        device_index: u32,
+        client_fds: &[OwnedFd],
+        size: u64,
+        block_size: u64,
+    ) -> (
+        std::result::Result<netlink::ConnectDeviceSuccess, netlink::ConnectDeviceError>,
+        NbdNetlinkConnectTiming,
+    );
+
+    fn verify_size(&self, device_index: u32, size: u64) -> impl Future<Output = bool> + Send;
+
+    fn ownership(&self, device_index: u32, connection_id: Uuid) -> DeviceOwnership;
+
+    fn disconnect(&self, device_index: u32) -> Result<()>;
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct NativeKernel;
+
+impl CreateKernel for NativeKernel {
+    fn connect(
+        &self,
+        device_index: u32,
+        client_fds: &[OwnedFd],
+        size: u64,
+        block_size: u64,
+    ) -> (
+        std::result::Result<netlink::ConnectDeviceSuccess, netlink::ConnectDeviceError>,
+        NbdNetlinkConnectTiming,
+    ) {
+        netlink::connect_device_with_state_timing(device_index, client_fds, size, block_size)
+    }
+
+    async fn verify_size(&self, device_index: u32, size: u64) -> bool {
+        netlink::verify_device_size(device_index, size).await
+    }
+
+    fn ownership(&self, device_index: u32, connection_id: Uuid) -> DeviceOwnership {
+        device_ownership(device_index, connection_id)
+    }
+
+    fn disconnect(&self, device_index: u32) -> Result<()> {
+        netlink::disconnect(device_index)
+    }
+}

--- a/crates/nbd-cow/src/device/mod.rs
+++ b/crates/nbd-cow/src/device/mod.rs
@@ -10,6 +10,7 @@ mod connection;
 mod create;
 mod create_timing;
 mod finalizer;
+mod kernel;
 mod pooled;
 
 pub use connection::is_our_thread;

--- a/crates/nbd-cow/src/pool/actor.rs
+++ b/crates/nbd-cow/src/pool/actor.rs
@@ -129,9 +129,18 @@ impl DevicePoolHandle {
 
     #[cfg(test)]
     pub(crate) fn new_one_device_for_test(config: DevicePoolConfig, lock_dir: &Path) -> Self {
+        Self::new_devices_for_test(config, lock_dir, 1)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_devices_for_test(
+        config: DevicePoolConfig,
+        lock_dir: &Path,
+        max_devices: u32,
+    ) -> Self {
         Self::from_pool(DevicePool::new_with_options(
             config,
-            1,
+            max_devices,
             lock_dir.to_path_buf(),
             |_| true,
         ))

--- a/crates/nbd-cow/src/pool/state.rs
+++ b/crates/nbd-cow/src/pool/state.rs
@@ -77,7 +77,7 @@ impl Default for DevicePoolConfig {
 pub(crate) struct DevicePoolSnapshot {
     pub(crate) cooldown: Vec<u32>,
     pub(crate) in_flight: HashSet<u32>,
-    pub(super) waiting_acquires: usize,
+    pub(crate) waiting_acquires: usize,
 }
 
 /// NBD device claim pool.


### PR DESCRIPTION
## Summary

Closes #32282.

Add deterministic coverage for the production NBD size-zero creation retry path. This addresses a confirmed coverage gap, not a confirmed production failure.

- Introduce a private, statically dispatched kernel boundary for connect, capacity verification, ownership and disconnect. Keep real COW storage, socketpair dispatch, pool actors, host-lock leases, blocking critical sections and cleanup policy in the tested path, including unobserved connect-result cleanup.
- Cover `false, true` recovery and persistent `false` with clean, foreign, unknown-ownership and failed-disconnect outcomes. Assert two/six attempts, one/five 200ms delays, no final extra delay, failed dispatch closure before disconnect, live successful resource transfer, retained cooldown claims and no foreign disconnect.
- Use real protocol replies for task readiness and nonblocking EOF for teardown. At 199ms, inspect actor-ordered pool state including queued acquisitions so an early retry cannot hide behind blocking-worker scheduling.

No public API, production retry budget/delay, EBUSY behavior, persisted format, deployment protocol, or CI skip changes. Clean release and uncertain retirement intentionally retain the same cooldown/lock behavior today; tests do not invent a distinction in pool state.

## Validation

From `crates/`:

- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p nbd-cow --all-targets --all-features`
- `cargo doc --profile local -p nbd-cow --all-features --no-deps`
- `cargo test --profile local -p nbd-cow --all-features --quiet`: 303 passed.
- `cargo test --profile local -p nbd-cow --lib size_retry --quiet`: 20 consecutive passes.
- Mutation checks rejected a reduced retry budget, a 1ms retry delay, and dispatch teardown moved after disconnect. All mutations were reverted before final validation.
- Normal commit hooks passed with `CARGO_BUILD_JOBS=2`: workspace-wide Clippy (all targets/features), workspace documentation, formatting, file-size check and commitlint. No hooks were bypassed.

The existing 13 privileged kernel integration tests were not run locally; they remain selected by the existing metal CI workflow. Controlled kernel tests complement that coverage, rather than claiming to reproduce the real kernel race.

## Risk

The main risk is mechanical resource-lifetime plumbing around the new private boundary. Deferred leases, blocking ownership checks, Drop cleanup, native kernel operations and successful transfer remain intact. The native backend is zero-sized and statically dispatched. Existing cancellation, pool, dispatch and public-API tests passed.
