### PR TITLE
chore(api): classify projection lock timeouts as backpressure

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -269,6 +269,19 @@ export default [
     },
   },
   {
+    files: ["src/signals/services/agent-webhook-events.service.ts"],
+    rules: {
+      "api/no-logger-info": [
+        "error",
+        {
+          allowedMessages: [
+            "Required database run output projection backpressured",
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: [
       "src/signals/services/pi-memory-stage1-worker.service.ts",
       "src/signals/services/pi-memory-phase2-worker.service.ts",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -4064,9 +4064,42 @@ describe("CHAT-02: chat output extraction and terminal callbacks", () => {
       [503],
     );
     expect(response.status).toBe(503);
+    expect(response.body).toStrictEqual({
+      error: {
+        code: "EVENT_DELIVERY_UNAVAILABLE",
+        message: "Agent event delivery is temporarily unavailable",
+      },
+    });
 
     const messages = await chat.listThreadEvents(actor, run.threadId);
     expect(eventBackedContents(messages.events, run.runId)).toHaveLength(0);
+    const backpressureLogs = context.mocks.axiomLogging.info.mock.calls.filter(
+      ([message]) => {
+        return (
+          message === "Required database run output projection backpressured"
+        );
+      },
+    );
+    expect(backpressureLogs).toHaveLength(1);
+    const fields = backpressureLogs[0]?.[1];
+    if (!isRecord(fields)) {
+      throw new Error("Expected structured projection backpressure fields");
+    }
+    expect(fields).toMatchObject({
+      runId: run.runId,
+      firstSequence: 0,
+      lastSequence: 0,
+      errorCode: "55P03",
+      retryable: true,
+    });
+    expect(Object.keys(fields).sort()).toStrictEqual([
+      "context",
+      "errorCode",
+      "firstSequence",
+      "lastSequence",
+      "retryable",
+      "runId",
+    ]);
     expect(
       context.mocks.axiomLogging.error.mock.calls.some(([message, fields]) => {
         return (
@@ -4075,7 +4108,7 @@ describe("CHAT-02: chat output extraction and terminal callbacks", () => {
           fields.runId === run.runId
         );
       }),
-    ).toBeTruthy();
+    ).toBeFalsy();
     held.release();
     await held.done;
   }, 30_000);

--- a/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-events.service.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../lib/event-consumer/verify";
 import { eventDeliveryUnavailable } from "../../lib/error";
 import { logger } from "../../lib/log";
-import { isForeignKeyViolation } from "../../lib/pg-errors";
+import { isForeignKeyViolation, isLockNotAvailable } from "../../lib/pg-errors";
 import { now } from "../../lib/time";
 import type { SandboxAuth } from "../../types/auth";
 import { refreshAgentPhoneTypingEvents$ } from "./agent-event-consumer-agentphone-typing.service";
@@ -214,11 +214,20 @@ export const receiveAgentEvents$ = command(
           },
         };
       }
-      L.error("Required database run output projection failed", {
-        runId: payload.runId,
-        ...range,
-        error: projectionResult.error,
-      });
+      if (isLockNotAvailable(projectionResult.error)) {
+        L.info("Required database run output projection backpressured", {
+          runId: payload.runId,
+          ...range,
+          errorCode: "55P03",
+          retryable: true,
+        });
+      } else {
+        L.error("Required database run output projection failed", {
+          runId: payload.runId,
+          ...range,
+          error: projectionResult.error,
+        });
+      }
       return {
         response: eventDeliveryUnavailable(
           "Agent event delivery is temporarily unavailable",


### PR DESCRIPTION
## Summary

- classify only PostgreSQL `55P03` run-output projection failures as retryable backpressure at `info`
- keep the existing `503 EVENT_DELIVERY_UNAVAILABLE` response and preserve error diagnostics for every other projection failure
- constrain the informational event to bounded fields and cover the classification in the existing locked-projection integration test

## Non-goals

- no lock timeout, transaction, allocator, schema, HTTP contract, or Guest retry changes
- no API-side retry

## Testing

- `DATABASE_URL=postgresql://postgres@localhost:5432/postgres pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts -t "returns 503 when the required DB output projection is locked"`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`

Closes #32136
