### PR TITLE
fix(sandbox-fc): own snapshot cow before network setup

### DIFF
--- a/crates/sandbox-fc/src/snapshot/attempt/cleanup.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/cleanup.rs
@@ -1,14 +1,14 @@
 use std::path::{Path, PathBuf};
 
 use nbd_cow::KeptCow;
-use nbd_cow::PooledNbdCowDevice;
 use nbd_cow::pool::DevicePoolHandle;
 
 use crate::network::{NetnsLease, NetnsPool};
 
 use super::super::SnapshotError;
 use super::super::cow::{
-    destroy_snapshot_cow_after_error, destroy_snapshot_cow_and_cleanup_attempt_dir,
+    SnapshotCowDevice, destroy_snapshot_cow_after_error,
+    destroy_snapshot_cow_and_cleanup_attempt_dir,
 };
 use super::super::output::cleanup_workspace_image_file_sync;
 use super::super::publish::SnapshotPublishAttempt;
@@ -24,7 +24,7 @@ async fn release_snapshot_netns(
     }
 }
 
-async fn destroy_snapshot_cow_after_workflow_error(cow_device: PooledNbdCowDevice) {
+async fn destroy_snapshot_cow_after_workflow_error(cow_device: SnapshotCowDevice) {
     if let Err(e) = destroy_snapshot_cow_and_cleanup_attempt_dir(cow_device).await {
         tracing::warn!(error = %e, "failed to destroy COW device after snapshot error");
     }
@@ -124,7 +124,7 @@ impl SnapshotCleanupPresence {
 pub(super) struct SnapshotCleanupResources {
     pub(super) netns_pool: Option<NetnsPool>,
     pub(super) device_pool: Option<DevicePoolHandle>,
-    pub(super) cow_device: Option<PooledNbdCowDevice>,
+    pub(super) cow_device: Option<SnapshotCowDevice>,
     pub(super) workspace_image: AttemptWorkspaceImage,
     pub(super) publish_attempt: Option<SnapshotPublishAttempt>,
     pub(super) network: Option<NetnsLease>,
@@ -133,13 +133,11 @@ pub(super) struct SnapshotCleanupResources {
 
 impl SnapshotCleanupResources {
     pub(super) fn new(
-        netns_pool: NetnsPool,
         device_pool: DevicePoolHandle,
-        cow_device: PooledNbdCowDevice,
+        cow_device: SnapshotCowDevice,
         workspace_image_path: PathBuf,
     ) -> Self {
         Self {
-            netns_pool: Some(netns_pool),
             device_pool: Some(device_pool),
             cow_device: Some(cow_device),
             workspace_image: AttemptWorkspaceImage::new(workspace_image_path),
@@ -207,7 +205,7 @@ impl SnapshotCleanupResources {
         let cow_device = self.cow_device.take().ok_or_else(|| {
             SnapshotError::Teardown("snapshot attempt missing COW device before publish".into())
         })?;
-        self.publish_attempt = Some(SnapshotPublishAttempt::new(cow_device));
+        self.publish_attempt = Some(SnapshotPublishAttempt::new(cow_device.into_pooled()));
         let kept_cow = match self.resolve_success_publish().await {
             Ok(kept_cow) => kept_cow,
             Err(err) => {

--- a/crates/sandbox-fc/src/snapshot/attempt/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/mod.rs
@@ -3,10 +3,10 @@ mod process;
 #[cfg(test)]
 mod tests;
 
+use std::future::Future;
 use std::path::{Path, PathBuf};
 
 use nbd_cow::KeptCow;
-use nbd_cow::PooledNbdCowDevice;
 use nbd_cow::pool::DevicePoolHandle;
 use sandbox::SnapshotCreateConfig;
 #[cfg(test)]
@@ -20,7 +20,7 @@ use crate::runtime_dirs::prepare_runtime_socket_dir;
 use crate::workspace_drive_image::prepare_workspace_drive_image;
 
 use super::SnapshotError;
-use super::cow::destroy_snapshot_cow_and_cleanup_attempt_dir;
+use super::cow::{SnapshotAttemptDirGuard, SnapshotCowDevice};
 use super::output::remove_dir_all_if_exists_sync;
 #[cfg(test)]
 use super::publish::SnapshotPublishAttempt;
@@ -46,25 +46,6 @@ async fn cleanup_snapshot_sock_dir(sock_dir: &Path, warning: &'static str) -> bo
             false
         }
     }
-}
-
-pub(super) async fn cleanup_after_netns_pool_failure(
-    cow_device: PooledNbdCowDevice,
-    device_pool: &DevicePoolHandle,
-    sock_dir: &Path,
-) {
-    if let Err(cleanup_err) = destroy_snapshot_cow_and_cleanup_attempt_dir(cow_device).await {
-        tracing::warn!(
-            error = %cleanup_err,
-            "failed to destroy COW device after netns pool failure"
-        );
-    }
-    device_pool.cleanup().await;
-    cleanup_snapshot_sock_dir(
-        sock_dir,
-        "failed to cleanup sock dir after netns pool failure",
-    )
-    .await;
 }
 
 /// Snapshot-local owner for resources acquired while producing one snapshot.
@@ -97,23 +78,46 @@ impl SnapshotAttempt {
         paths: SandboxPaths,
         sock_paths: SockPaths,
         output: SnapshotOutputPaths,
-        netns_pool: NetnsPool,
         device_pool: DevicePoolHandle,
-        cow_device: PooledNbdCowDevice,
+        cow_device: SnapshotCowDevice,
         workspace_image_path: PathBuf,
+        mut attempt_dir_guard: SnapshotAttemptDirGuard,
     ) -> Self {
-        Self {
+        let attempt = Self {
             paths,
             sock_paths: Some(sock_paths),
             output,
             cleanup_resources: SnapshotCleanupResources::new(
-                netns_pool,
                 device_pool,
                 cow_device,
                 workspace_image_path,
             ),
             #[cfg(test)]
             cleanup_complete_tx: None,
+        };
+        // Only the COW finalizer may decide whether owned backing files are
+        // safe to delete, including during network setup or cancellation.
+        attempt_dir_guard.disarm();
+        attempt
+    }
+
+    pub(super) async fn initialize_netns_pool(
+        &mut self,
+        create_pool: impl Future<Output = Result<NetnsPool, SnapshotError>>,
+    ) -> Result<(), SnapshotError> {
+        match create_pool.await {
+            Ok(pool) => {
+                self.cleanup_resources.netns_pool = Some(pool);
+                Ok(())
+            }
+            Err(err) => {
+                self.cleanup_resources
+                    .destroy_cow_after_setup_error("netns pool")
+                    .await;
+                self.cleanup_device_pool().await;
+                self.cleanup_sock_dir().await;
+                Err(err)
+            }
         }
     }
 

--- a/crates/sandbox-fc/src/snapshot/attempt/tests.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/tests.rs
@@ -14,6 +14,8 @@ use super::cleanup::{AttemptWorkspaceImage, SnapshotCleanupPresence, SnapshotCle
 
 use super::*;
 
+mod early_setup;
+
 async fn write_required_snapshot_artifacts(output: &SnapshotOutputPaths) {
     tokio::fs::create_dir_all(output.dir())
         .await

--- a/crates/sandbox-fc/src/snapshot/attempt/tests/early_setup.rs
+++ b/crates/sandbox-fc/src/snapshot/attempt/tests/early_setup.rs
@@ -1,0 +1,261 @@
+use std::future::{Future, pending};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+
+use super::super::*;
+use crate::snapshot::cow::{snapshot_attempt_cow_file, snapshot_attempt_workspace_image_file};
+
+struct EarlyAttempt {
+    _dir: tempfile::TempDir,
+    attempt: SnapshotAttempt,
+    cow_file: PathBuf,
+    bitmap_file: PathBuf,
+    sock_dir: PathBuf,
+    destroy_started: oneshot::Receiver<()>,
+    release_destroy: oneshot::Sender<bool>,
+    cow_cleanup_complete: oneshot::Receiver<()>,
+}
+
+impl EarlyAttempt {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let output = SnapshotOutputPaths::new(dir.path().join("output"));
+        let paths = SandboxPaths::new(output.work_dir());
+        let cow_file = snapshot_attempt_cow_file(paths.workspace(), "early");
+        let bitmap_file = cow_file.with_file_name("cow.img.bitmap");
+        let attempt_dir = cow_file.parent().unwrap().to_path_buf();
+        std::fs::create_dir_all(&attempt_dir).unwrap();
+        std::fs::write(&cow_file, b"cow").unwrap();
+        std::fs::write(&bitmap_file, b"bitmap").unwrap();
+        let sock_dir = dir.path().join("sockets");
+        std::fs::create_dir(&sock_dir).unwrap();
+
+        let (started_tx, destroy_started) = oneshot::channel();
+        let (release_destroy, release_rx) = oneshot::channel();
+        let (done_tx, cow_cleanup_complete) = oneshot::channel();
+        let destroy_cow_file = cow_file.clone();
+        let destroy_bitmap_file = bitmap_file.clone();
+        let cow = SnapshotCowDevice::Test {
+            cow_file: cow_file.clone(),
+            destroy: Box::pin(async move {
+                started_tx.send(()).unwrap();
+                if release_rx.await.unwrap() {
+                    // Model the kernel-device boundary's successful finalizer;
+                    // snapshot directory cleanup remains production code.
+                    std::fs::remove_file(destroy_cow_file).unwrap();
+                    std::fs::remove_file(destroy_bitmap_file).unwrap();
+                    Ok(())
+                } else {
+                    Err(nbd_cow::error::NbdCowError::Io(std::io::Error::other(
+                        "device shutdown remains uncertain",
+                    ))
+                    .into())
+                }
+            }),
+            cleanup_complete: Some(done_tx),
+        };
+        let workspace_image = snapshot_attempt_workspace_image_file(paths.workspace(), "early");
+        let attempt = SnapshotAttempt::new(
+            paths,
+            SockPaths::new(sock_dir.clone()),
+            output,
+            DevicePoolHandle::new(nbd_cow::pool::DevicePoolConfig::default()),
+            cow,
+            workspace_image,
+            SnapshotAttemptDirGuard::new(attempt_dir),
+        );
+
+        Self {
+            _dir: dir,
+            attempt,
+            cow_file,
+            bitmap_file,
+            sock_dir,
+            destroy_started,
+            release_destroy,
+            cow_cleanup_complete,
+        }
+    }
+}
+
+async fn bounded<T>(future: impl Future<Output = T>) -> T {
+    tokio::time::timeout(Duration::from_secs(5), future)
+        .await
+        .expect("snapshot cleanup should make progress")
+}
+
+fn assert_backing_files(cow_file: &std::path::Path, bitmap_file: &std::path::Path) {
+    assert_eq!(std::fs::read(cow_file).unwrap(), b"cow");
+    assert_eq!(std::fs::read(bitmap_file).unwrap(), b"bitmap");
+}
+
+#[tokio::test]
+async fn netns_failure_respects_cow_cleanup_safety_and_preserves_setup_error() {
+    for safe_to_delete in [true, false] {
+        let EarlyAttempt {
+            _dir,
+            mut attempt,
+            cow_file,
+            bitmap_file,
+            sock_dir,
+            destroy_started,
+            release_destroy,
+            cow_cleanup_complete,
+        } = EarlyAttempt::new();
+        assert_backing_files(&cow_file, &bitmap_file);
+        let result = bounded(async {
+            tokio::join!(
+                attempt.initialize_netns_pool(async {
+                    Err(SnapshotError::Setup(
+                        "netns pool: lock allocation failed".into(),
+                    ))
+                }),
+                async {
+                    destroy_started.await.unwrap();
+                    assert_backing_files(&cow_file, &bitmap_file);
+                    release_destroy.send(safe_to_delete).unwrap();
+                }
+            )
+            .0
+        })
+        .await;
+        assert!(
+            matches!(result, Err(SnapshotError::Setup(message)) if message == "netns pool: lock allocation failed")
+        );
+        bounded(cow_cleanup_complete).await.unwrap();
+        assert!(!attempt.has_cleanup_work());
+        drop(attempt);
+        assert!(
+            !sock_dir.exists(),
+            "explicit cleanup still owns the snapshot lock"
+        );
+        if safe_to_delete {
+            assert!(!cow_file.parent().unwrap().exists());
+        } else {
+            assert_backing_files(&cow_file, &bitmap_file);
+        }
+    }
+}
+
+#[tokio::test]
+async fn cancellation_during_netns_creation_uses_attempt_finalizer() {
+    for safe_to_delete in [true, false] {
+        let EarlyAttempt {
+            _dir,
+            mut attempt,
+            cow_file,
+            bitmap_file,
+            sock_dir,
+            destroy_started,
+            release_destroy,
+            cow_cleanup_complete,
+        } = EarlyAttempt::new();
+        let (netns_started_tx, netns_started_rx) = oneshot::channel();
+        let (attempt_done_tx, attempt_done_rx) = oneshot::channel();
+        attempt.notify_cleanup_complete_for_test(attempt_done_tx);
+        let task = tokio::spawn(async move {
+            attempt
+                .initialize_netns_pool(async {
+                    netns_started_tx.send(()).unwrap();
+                    pending().await
+                })
+                .await
+        });
+        bounded(netns_started_rx).await.unwrap();
+        task.abort();
+        assert!(bounded(task).await.unwrap_err().is_cancelled());
+        bounded(destroy_started).await.unwrap();
+        assert_backing_files(&cow_file, &bitmap_file);
+        release_destroy.send(safe_to_delete).unwrap();
+        bounded(cow_cleanup_complete).await.unwrap();
+        let report = bounded(attempt_done_rx).await.unwrap();
+        assert_eq!(report.cow_destroyed, safe_to_delete);
+        assert!(report.device_pool_cleaned);
+        assert!(report.netns_pool_cleaned);
+        assert!(
+            sock_dir.exists(),
+            "detached cleanup cannot remove stable sockets"
+        );
+        if safe_to_delete {
+            assert!(!cow_file.parent().unwrap().exists());
+        } else {
+            assert_backing_files(&cow_file, &bitmap_file);
+        }
+    }
+}
+
+#[tokio::test]
+async fn cancellation_during_netns_failure_cleanup_waits_for_cow_safety() {
+    for safe_to_delete in [true, false] {
+        let EarlyAttempt {
+            _dir,
+            mut attempt,
+            cow_file,
+            bitmap_file,
+            sock_dir,
+            destroy_started,
+            release_destroy,
+            cow_cleanup_complete,
+        } = EarlyAttempt::new();
+        let (attempt_done_tx, attempt_done_rx) = oneshot::channel();
+        attempt.notify_cleanup_complete_for_test(attempt_done_tx);
+        let task = tokio::spawn(async move {
+            attempt
+                .initialize_netns_pool(async {
+                    Err(SnapshotError::Setup(
+                        "netns pool: forwarding setup failed".into(),
+                    ))
+                })
+                .await
+        });
+        bounded(destroy_started).await.unwrap();
+        task.abort();
+        assert!(bounded(task).await.unwrap_err().is_cancelled());
+        assert_backing_files(&cow_file, &bitmap_file);
+        release_destroy.send(safe_to_delete).unwrap();
+        bounded(cow_cleanup_complete).await.unwrap();
+        let report = bounded(attempt_done_rx).await.unwrap();
+        assert!(report.device_pool_cleaned);
+        assert!(
+            sock_dir.exists(),
+            "detached cleanup cannot remove stable sockets"
+        );
+        if safe_to_delete {
+            assert!(!cow_file.parent().unwrap().exists());
+        } else {
+            assert_backing_files(&cow_file, &bitmap_file);
+        }
+    }
+}
+
+#[tokio::test]
+async fn successful_netns_creation_keeps_cow_owned_until_attempt_cleanup() {
+    let EarlyAttempt {
+        _dir,
+        mut attempt,
+        cow_file,
+        bitmap_file,
+        destroy_started,
+        release_destroy,
+        cow_cleanup_complete,
+        ..
+    } = EarlyAttempt::new();
+    attempt
+        .initialize_netns_pool(async { Ok(NetnsPool::inactive_for_test()) })
+        .await
+        .unwrap();
+    assert_backing_files(&cow_file, &bitmap_file);
+    assert!(attempt.cleanup_resources.netns_pool.is_some());
+    let (done_tx, done_rx) = oneshot::channel();
+    attempt.notify_cleanup_complete_for_test(done_tx);
+    drop(attempt);
+    bounded(destroy_started).await.unwrap();
+    release_destroy.send(true).unwrap();
+    bounded(cow_cleanup_complete).await.unwrap();
+    let report = bounded(done_rx).await.unwrap();
+    assert!(report.cow_destroyed);
+    assert!(report.netns_pool_cleaned);
+    assert!(!cow_file.parent().unwrap().exists());
+}

--- a/crates/sandbox-fc/src/snapshot/cow.rs
+++ b/crates/sandbox-fc/src/snapshot/cow.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use nbd_cow::PooledNbdCowDevice;
+use nbd_cow::{PooledDestroyError, PooledNbdCowDevice};
 use tokio::task::JoinHandle;
 
 use crate::cow_cleanup::{
@@ -12,6 +12,72 @@ use crate::cow_cleanup::{
 
 use super::SnapshotError;
 use super::output::cleanup_remove_dir_result;
+
+// Keep kernel-device teardown at the boundary so snapshot ownership and
+// filesystem cleanup can be exercised without root or a live NBD device.
+pub(super) enum SnapshotCowDevice {
+    Pooled(PooledNbdCowDevice),
+    #[cfg(test)]
+    Test {
+        cow_file: PathBuf,
+        destroy: Pin<Box<dyn Future<Output = Result<(), PooledDestroyError>> + Send>>,
+        cleanup_complete: Option<tokio::sync::oneshot::Sender<()>>,
+    },
+}
+
+impl From<PooledNbdCowDevice> for SnapshotCowDevice {
+    fn from(device: PooledNbdCowDevice) -> Self {
+        Self::Pooled(device)
+    }
+}
+
+impl SnapshotCowDevice {
+    pub(super) fn device_path(&self) -> &Path {
+        match self {
+            Self::Pooled(device) => device.device_path(),
+            #[cfg(test)]
+            Self::Test { .. } => panic!("test COW device cannot be used by Firecracker"),
+        }
+    }
+
+    pub(super) fn into_pooled(self) -> PooledNbdCowDevice {
+        match self {
+            Self::Pooled(device) => device,
+            #[cfg(test)]
+            Self::Test { .. } => panic!("test COW device cannot be published"),
+        }
+    }
+
+    fn cow_file(&self) -> &Path {
+        match self {
+            Self::Pooled(device) => device.cow_file(),
+            #[cfg(test)]
+            Self::Test { cow_file, .. } => cow_file,
+        }
+    }
+
+    #[cfg(test)]
+    fn take_cleanup_complete(&mut self) -> Option<tokio::sync::oneshot::Sender<()>> {
+        match self {
+            Self::Pooled(_) => None,
+            Self::Test {
+                cleanup_complete, ..
+            } => cleanup_complete.take(),
+        }
+    }
+
+    async fn destroy(self) -> Result<(), PooledDestroyError> {
+        match self {
+            Self::Pooled(device) => {
+                device
+                    .destroy_with_retries_detailed(cow_destroy_retry_policy())
+                    .await
+            }
+            #[cfg(test)]
+            Self::Test { destroy, .. } => destroy.await,
+        }
+    }
+}
 
 pub(super) struct SnapshotCowCleanupFinalizer {
     handle: Option<JoinHandle<nbd_cow::error::Result<()>>>,
@@ -92,13 +158,18 @@ async fn observe_detached_snapshot_cow_cleanup(handle: JoinHandle<nbd_cow::error
 }
 
 pub(super) fn destroy_snapshot_cow_and_cleanup_attempt_dir(
-    cow_device: PooledNbdCowDevice,
+    cow_device: impl Into<SnapshotCowDevice>,
 ) -> SnapshotCowCleanupFinalizer {
+    let cow_device = cow_device.into();
+    #[cfg(test)]
+    let (cow_device, cleanup_complete) = {
+        let mut cow_device = cow_device;
+        let cleanup_complete = cow_device.take_cleanup_complete();
+        (cow_device, cleanup_complete)
+    };
     let cow_file = cow_device.cow_file().to_path_buf();
-    SnapshotCowCleanupFinalizer::new(tokio::spawn(async move {
-        let result = cow_device
-            .destroy_with_retries_detailed(cow_destroy_retry_policy())
-            .await;
+    let cleanup = async move {
+        let result = cow_device.destroy().await;
         let outcome = classify_cow_destroy_result(&result);
 
         match (result, outcome) {
@@ -115,12 +186,20 @@ pub(super) fn destroy_snapshot_cow_and_cleanup_attempt_dir(
         }
         cleanup_snapshot_attempt_dir_for_cow(&cow_file).await;
         Ok(())
+    };
+    SnapshotCowCleanupFinalizer::new(tokio::spawn(async move {
+        let result = cleanup.await;
+        #[cfg(test)]
+        if let Some(tx) = cleanup_complete {
+            let _ = tx.send(());
+        }
+        result
     }))
 }
 
 pub(super) async fn destroy_snapshot_cow_after_error(
     context: &'static str,
-    cow_device: PooledNbdCowDevice,
+    cow_device: SnapshotCowDevice,
 ) {
     if let Err(e) = destroy_snapshot_cow_and_cleanup_attempt_dir(cow_device).await {
         tracing::warn!(

--- a/crates/sandbox-fc/src/snapshot/mod.rs
+++ b/crates/sandbox-fc/src/snapshot/mod.rs
@@ -21,9 +21,7 @@ use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::prerequisites;
 use crate::runtime_dirs::checked_runtime_sock_dir;
 
-use self::attempt::{
-    SnapshotAttempt, cleanup_after_netns_pool_failure, cleanup_existing_snapshot_sock_dir,
-};
+use self::attempt::{SnapshotAttempt, cleanup_existing_snapshot_sock_dir};
 use self::cow::{
     SnapshotAttemptDirGuard, create_sparse_cow_file, snapshot_attempt_cow_file,
     snapshot_attempt_dir, snapshot_attempt_token, snapshot_attempt_workspace_image_file,
@@ -132,7 +130,7 @@ async fn create_uncommitted_snapshot(
     tokio::fs::create_dir_all(&attempt_dir)
         .await
         .map_err(|e| SnapshotError::Setup(format!("create snapshot attempt dir: {e}")))?;
-    let mut attempt_dir_guard = SnapshotAttemptDirGuard::new(attempt_dir);
+    let attempt_dir_guard = SnapshotAttemptDirGuard::new(attempt_dir);
     let cow_file = snapshot_attempt_cow_file(paths.workspace(), &attempt_token);
     let workspace_image_file =
         snapshot_attempt_workspace_image_file(paths.workspace(), &attempt_token);
@@ -147,25 +145,25 @@ async fn create_uncommitted_snapshot(
 
     info!(device = %cow_device.device_path().display(), "NBD COW device created");
 
-    // 3. Initialize a pre-warmed network namespace pool (index auto-allocated via flock).
-    let netns_pool = match NetnsPool::create_checked(netns_config).await {
-        Ok(pool) => pool,
-        Err(e) => {
-            cleanup_after_netns_pool_failure(cow_device, &device_pool, &sock_dir).await;
-            return Err(SnapshotError::Setup(format!("netns pool: {e}")));
-        }
-    };
-
+    // Transfer cleanup ownership before the first post-acquisition await.
     let mut attempt = SnapshotAttempt::new(
         paths,
         sock_paths,
         output,
-        netns_pool,
         device_pool,
-        cow_device,
+        cow_device.into(),
         workspace_image_file,
+        attempt_dir_guard,
     );
-    attempt_dir_guard.disarm();
+
+    // 3. Initialize a pre-warmed network namespace pool (index auto-allocated via flock).
+    attempt
+        .initialize_netns_pool(async {
+            NetnsPool::create_checked(netns_config)
+                .await
+                .map_err(|e| SnapshotError::Setup(format!("netns pool: {e}")))
+        })
+        .await?;
     let result = run_snapshot_workflow(&config, &mut attempt).await;
     let result = match result {
         Ok(snapshot_config) => attempt.prepare_success_publish().await.map(|kept_cow| {


### PR DESCRIPTION
## Summary

- Construct the snapshot attempt owner immediately after pooled COW acquisition, before network-pool initialization. Consume and disarm the unowned-directory guard in that constructor so it cannot override the COW finalizer's backing-file safety decision.
- Reuse the attempt's explicit and detached cleanup paths for early network failure and cancellation; preserve the original setup error and never delete stable socket directories from detached cleanup.
- Add synchronized, rootless lifecycle coverage for safe/unsafe cleanup, cancellation during network initialization and pending cleanup, and successful pool attachment. Tests use real temporary COW/bitmap files and a test-only host-device teardown boundary.

## Scope

No API/protocol, snapshot format, migration, NBD retry-policy, or GC changes. Confirmed unsafe cleanup intentionally retains this attempt's files. Kernel-level failure injection and process/runtime crash guarantees are not claimed.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --locked --profile local -p sandbox-fc -p runner --all-targets --all-features`
- `cargo doc --locked --profile local -p sandbox-fc -p runner --all-features --no-deps`
- `cargo test --locked --profile local -p sandbox-fc --all-targets --all-features`: 857 library tests and 1 prewarm integration test passed. The existing ignored real-Firecracker CPU test requires metal-host fixtures and remains CI coverage; no ignore/skip settings changed.
- `cargo test --locked --profile local -p sandbox-fc --lib snapshot::`: 93 passed.
- New `snapshot::attempt::tests::early_setup::` regressions repeated 3 additional times: 4/4 passed each time.
- Repository pre-commit checks passed: workspace-wide Rust formatting, Clippy, documentation, file-size validation, and commit-message validation.

Closes #32285
