### PR TITLE
perf(guest-agent): avoid per-character citation matching allocations

### DIFF
--- a/crates/guest-agent/Cargo.toml
+++ b/crates/guest-agent/Cargo.toml
@@ -45,5 +45,9 @@ vsock-proto.workspace = true
 name = "integration"
 path = "tests/integration.rs"
 
+[[example]]
+name = "pi_memory_citation_bench"
+path = "src/cli/pi_memory_citation_bench.rs"
+
 [lints]
 workspace = true

--- a/crates/guest-agent/examples/pi_memory_citation_bench.rs
+++ b/crates/guest-agent/examples/pi_memory_citation_bench.rs
@@ -1,0 +1,44 @@
+//! Run with `cargo run --release -p guest-agent --example pi_memory_citation_bench`.
+//! Inputs are allocated before timing; measurements exclude output destruction.
+//! This benchmarks the canonical parser without making it a public library API.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+#[path = "../src/cli/pi_memory_citation.rs"]
+mod pi_memory_citation;
+
+use pi_memory_citation::{CLOSE, OPEN, project_segments};
+
+fn main() {
+    for size in [64 * 1024, 1024 * 1024, 8 * 1024 * 1024] {
+        let text = "x".repeat(size);
+        let hidden = format!("{OPEN}{text}{CLOSE}visible");
+        for (name, input, visible) in [
+            ("plain", text.as_str(), text.as_str()),
+            ("hidden", hidden.as_str(), "visible"),
+        ] {
+            for iteration in 1..=3 {
+                let start = Instant::now();
+                let projection = project_segments(black_box(&[input]));
+                let elapsed = start.elapsed();
+                assert_eq!(projection.visible_segments, [visible]);
+                assert!(projection.citation.is_none());
+                assert_eq!(
+                    projection.diagnostics.envelopes,
+                    usize::from(name == "hidden")
+                );
+                assert_eq!(
+                    projection.diagnostics.oversized_bodies,
+                    usize::from(name == "hidden" && size > 64 * 1024)
+                );
+                println!(
+                    "case={name} body_bytes={size} input_bytes={} iteration={iteration} elapsed_us={}",
+                    input.len(),
+                    elapsed.as_micros()
+                );
+                black_box(projection);
+            }
+        }
+    }
+}

--- a/crates/guest-agent/src/cli/pi_memory_citation.rs
+++ b/crates/guest-agent/src/cli/pi_memory_citation.rs
@@ -56,6 +56,13 @@ struct SourcedChar {
     source: usize,
 }
 
+fn delimiter_starts_with(delimiter: &str, pending: &[SourcedChar]) -> bool {
+    let mut characters = delimiter.chars();
+    pending
+        .iter()
+        .all(|item| characters.next() == Some(item.value))
+}
+
 pub(super) struct CitationParser {
     visible_segments: Vec<String>,
     citation: PiMemoryCitation,
@@ -91,14 +98,13 @@ impl CitationParser {
         if self.inside {
             self.close_pending.push(character);
             loop {
-                let pending: String = self.close_pending.iter().map(|item| item.value).collect();
-                if pending == CLOSE {
-                    self.finish_body(false);
-                    self.close_pending.clear();
-                    self.inside = false;
-                    return;
-                }
-                if CLOSE.starts_with(&pending) {
+                if delimiter_starts_with(CLOSE, &self.close_pending) {
+                    // Delimiters are ASCII, so a matching prefix has one byte per character.
+                    if self.close_pending.len() == CLOSE.len() {
+                        self.finish_body(false);
+                        self.close_pending.clear();
+                        self.inside = false;
+                    }
                     return;
                 }
                 if self.close_pending.is_empty() {
@@ -111,19 +117,19 @@ impl CitationParser {
 
         self.outside_pending.push(character);
         loop {
-            let pending: String = self.outside_pending.iter().map(|item| item.value).collect();
-            if pending == OPEN {
-                self.outside_pending.clear();
-                self.inside = true;
-                self.body.clear();
-                self.body_oversized = false;
+            if delimiter_starts_with(OPEN, &self.outside_pending) {
+                if self.outside_pending.len() == OPEN.len() {
+                    self.outside_pending.clear();
+                    self.inside = true;
+                    self.body.clear();
+                    self.body_oversized = false;
+                }
                 return;
             }
-            if pending == CLOSE {
-                self.outside_pending.clear();
-                return;
-            }
-            if OPEN.starts_with(&pending) || CLOSE.starts_with(&pending) {
+            if delimiter_starts_with(CLOSE, &self.outside_pending) {
+                if self.outside_pending.len() == CLOSE.len() {
+                    self.outside_pending.clear();
+                }
                 return;
             }
             if self.outside_pending.is_empty() {

--- a/crates/guest-agent/src/cli/pi_memory_citation_bench.rs
+++ b/crates/guest-agent/src/cli/pi_memory_citation_bench.rs
@@ -5,7 +5,6 @@
 use std::hint::black_box;
 use std::time::Instant;
 
-#[path = "../src/cli/pi_memory_citation.rs"]
 mod pi_memory_citation;
 
 use pi_memory_citation::{CLOSE, OPEN, project_segments};

--- a/crates/guest-agent/tests/pi_cli_run_id_env.rs
+++ b/crates/guest-agent/tests/pi_cli_run_id_env.rs
@@ -24,8 +24,8 @@ async fn guest_projects_pi_blocks_with_canonical_sequences_and_run_id()
     let private_path = "memory/private-pi-cli.md";
     let private_note = "private Pi CLI transport note";
     let private_rollout_id = "019c6e27-e55b-73d1-87d8-4e01f1f75043";
-    let hidden_citation = format!(
-        "<oai-mem-citation><citation_entries>{private_path}:11-13|note=[{private_note}]</citation_entries><rollout_ids>{private_rollout_id}</rollout_ids></oai-mem-citation>"
+    let hidden_citation_middle = format!(
+        "tion><citation_entries>{private_path}:11-13|note=[{private_note}]</citation_entries><rollout_ids>{private_rollout_id}</rollout_ids></oai-mem-cita"
     );
     std::fs::write(
         &final_assistant_event_path,
@@ -38,13 +38,25 @@ async fn guest_projects_pi_blocks_with_canonical_sequences_and_run_id()
                     "content": [
                         {
                             "type": "text",
-                            "text": format!("official rpc projection{hidden_citation}"),
+                            "text": "official rpc projection 界<oai-",
                         },
                         {
                             "type": "toolCall",
                             "id": "tool-4",
                             "name": "large_payload",
                             "arguments": { "payload": large_tool_payload },
+                        },
+                        {
+                            "type": "text",
+                            "text": "界🙂<oai-mem-cita",
+                        },
+                        {
+                            "type": "text",
+                            "text": hidden_citation_middle,
+                        },
+                        {
+                            "type": "text",
+                            "text": "tion>完成</oai-mem-citation><oai-mem",
                         },
                     ],
                     "model": "deepseek-v4-flash",
@@ -188,7 +200,7 @@ fi
     .expect("canonical Pi CLI process should finish")?;
 
     assert_eq!(result.exit_code, common::CLEAN_EXIT);
-    assert_eq!(result.last_event_sequence, Some(15));
+    assert_eq!(result.last_event_sequence, Some(17));
     assert_eq!(
         result.jsonl_result.map(|summary| summary.status),
         Some(guest_agent::cli::JsonlResultStatus::Success)
@@ -226,9 +238,9 @@ fi
             .and_then(Value::as_u64)
             .unwrap_or(u64::MAX)
     });
-    assert_eq!(delivered_events.len(), 12);
+    assert_eq!(delivered_events.len(), 14);
     assert_eq!(delivered_citations.len(), 1);
-    assert_eq!(delivered_citations[0]["sequenceNumber"], 14);
+    assert_eq!(delivered_citations[0]["sequenceNumber"], 16);
     assert_eq!(
         delivered_citations[0].pointer("/citation/entries/0/path"),
         Some(&Value::String(private_path.to_string()))
@@ -246,7 +258,7 @@ fi
             .iter()
             .map(|event| event["sequenceNumber"].as_u64())
             .collect::<Vec<_>>(),
-        (4..16).map(Some).collect::<Vec<_>>()
+        (4..18).map(Some).collect::<Vec<_>>()
     );
     assert!(delivered_events.iter().all(|event| {
         let serialized = event.to_string();
@@ -297,17 +309,17 @@ fi
 
     assert_eq!(delivered_events[3]["type"], "assistant");
     assert_eq!(
-        delivered_events[1..=10]
+        delivered_events[1..=12]
             .iter()
             .map(|event| event
                 .pointer("/message/content")
                 .and_then(Value::as_array)
                 .map(Vec::len))
             .collect::<Vec<_>>(),
-        vec![Some(1); 10]
+        vec![Some(1); 12]
     );
     assert_eq!(
-        delivered_events[1..=10]
+        delivered_events[1..=12]
             .iter()
             .map(|event| event
                 .pointer("/message/content/0/type")
@@ -324,6 +336,8 @@ fi
             Some("tool_result"),
             Some("text"),
             Some("tool_use"),
+            Some("text"),
+            Some("text"),
         ]
     );
     assert!(delivered_events[3..=6].iter().all(|event| {
@@ -384,7 +398,9 @@ fi
     assert_eq!(delivered_events[9]["type"], "assistant");
     assert_eq!(
         delivered_events[9].pointer("/message/content/0/text"),
-        Some(&Value::String("official rpc projection".to_string()))
+        Some(&Value::String(
+            "official rpc projection 界<oai-".to_string()
+        ))
     );
     assert_eq!(
         delivered_events[10].pointer("/message/content/0/type"),
@@ -404,7 +420,15 @@ fi
             .map(str::len),
         Some(1024 * 1024)
     );
-    for assistant in &delivered_events[9..=10] {
+    assert_eq!(
+        delivered_events[11].pointer("/message/content/0/text"),
+        Some(&Value::String("界🙂".to_string()))
+    );
+    assert_eq!(
+        delivered_events[12].pointer("/message/content/0/text"),
+        Some(&Value::String("完成<oai-mem".to_string()))
+    );
+    for assistant in &delivered_events[9..=12] {
         assert_eq!(assistant["message"]["id"], "response-3");
         assert_eq!(
             assistant["message"]["usage"],
@@ -416,9 +440,12 @@ fi
             })
         );
     }
-    assert_eq!(delivered_events[11]["type"], "result");
-    assert_eq!(delivered_events[11]["subtype"], "success");
-    assert_eq!(delivered_events[11]["result"], "official rpc projection");
+    assert_eq!(delivered_events[13]["type"], "result");
+    assert_eq!(delivered_events[13]["subtype"], "success");
+    assert_eq!(
+        delivered_events[13]["result"],
+        "official rpc projection 界<oai-\n\n界🙂\n\n完成<oai-mem"
+    );
     assert_eq!(std::fs::read_to_string(capture_path)?, run_id);
     assert_eq!(
         std::fs::read_to_string(npm_cache_capture_path)?,


### PR DESCRIPTION
## Summary

- Compare pending sourced characters directly with the fixed citation delimiters instead of collecting a temporary String for every input character, both outside and inside hidden envelopes.
- Preserve segment attribution, Unicode, stray/incomplete delimiters, citation provenance, diagnostics, and all existing body/entry/field limits.
- Extend the existing real CLI-to-webhook integration scenario with split delimiters, a failed prefix across Unicode text segments, a stray close, and an incomplete trailing prefix. Add an opt-in release benchmark of the canonical parser using a native sibling module and an explicit Cargo example target.

Closes #32286

## Performance evidence

Same-source before/after audit against main `f4b9a172cf76e04b845f2337c14cf87831c82adb`, rustc 1.98.0, serde 1.0.229, uuid 1.26.0, release/LTO/one codegen unit. Inputs are allocated before measurement. Allocation counts come from a separate instrumented binary; the timing binary has no allocation instrumentation. All three count runs agree.

| Input | Allocations before → after | Reallocations (unchanged) | Parser time before → after, 3-run range |
| --- | ---: | ---: | --- |
| 64 KiB plain ASCII | 65,539 → 3 | 13 | 1.334–89.927 → 0.407–0.417 ms |
| 1 MiB plain ASCII | 1,048,579 → 3 | 17 | 21.404–45.667 → 7.436–11.673 ms |
| 8 MiB plain ASCII | 8,388,611 → 3 | 20 | 294.832–454.956 → 81.139–187.098 ms |
| 64 KiB hidden body | 65,591 → 11 | 31 | 0.975–2.269 → 0.457–0.465 ms |
| 1 MiB hidden body | 1,048,625 → 5 | 19 | 21.883–110.947 → 3.962–10.964 ms |
| 8 MiB hidden body | 8,388,657 → 5 | 19 | 202.208–345.590 → 49.931–65.038 ms |

Hidden inputs add 44 bytes for delimiters and a visible suffix; 1/8 MiB hidden bodies exercise scanning after the 64 KiB retention cap. Ordinary output/buffer growth remains. These are noisy local measurements, not production latency or exact speedup guarantees; the optimized timing run overlapped initial dependency compilation. The deterministic result is removal of the per-character temporary allocation slope.

Reproduce the uninstrumented benchmark from `crates/` with `cargo run --release -p guest-agent --example pi_memory_citation_bench`. The issue retains the allocation harness recipe; it imports the canonical module unchanged.

## Validation

- `scripts/prepare.sh` — passed.
- `cargo run --profile local -p xtask -- check-rust-path-attributes` — passed.
- `cargo fmt -p guest-agent -- --check` — passed.
- `cargo clippy --profile local -p guest-agent --all-targets --all-features` — passed.
- `cargo doc --profile local -p guest-agent --all-features --no-deps` — passed.
- `cargo test --profile local -p guest-agent` — passed, including all shared citation fixtures, delimiter splits and limits, Pi RPC projection, and the updated CLI-to-webhook integration test.
- Separate release allocation and timing harnesses importing the canonical module — passed; results above.
- `CARGO_BUILD_JOBS=4 cargo run --release -p guest-agent --example pi_memory_citation_bench` — passed using the repository workspace and lockfile.
- Commit hooks: full Rust workspace formatting, all-targets/all-features Clippy, workspace documentation, file-size check, and commitlint — passed.

The first extended integration run caught a stale expected citation sequence (14). After environment preparation and tracing the existing last-block attachment rule, corrected that test expectation to 16; full crate validation passes without changing production sequencing.

The first CI head failed the existing Rust `#[path]` guard because the benchmark used an attribute import. Moved the benchmark next to the parser and declared its Cargo example entry point, allowing ordinary `mod` resolution. Re-ran the path guard, formatting, Clippy, docs, release benchmark, and full guest-agent suite successfully. No CI rule was relaxed.

## Scope and risk

No protocol/API/storage change, no dependencies, no new failure reason, no bypass of normalization, no CI/timeout/skip changes. The parser still performs linear character scanning; this does not redesign event-loop scheduling or introduce zero-copy output. Main regression risk is delimiter matching or source attribution; integration assertions and the existing shared fixture/split/limit/projection coverage protect those semantics.
