### PR TITLE
fix(platform): remove dark composer focus veil

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -16,6 +16,49 @@ test("chat page displays tagline after onboarding", async ({ page }) => {
   });
 });
 
+test.describe("dark theme", () => {
+  test.use({ colorScheme: "dark" });
+
+  test("focused composer does not cast a dark veil", async ({ page }) => {
+    await page.route("**/api/user-preferences", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.continue();
+        return;
+      }
+
+      const response = await route.fetch();
+      const preferences: unknown = await response.json();
+      if (
+        typeof preferences !== "object" ||
+        preferences === null ||
+        Array.isArray(preferences)
+      ) {
+        throw new Error("Expected user preferences to be an object");
+      }
+      await route.fulfill({
+        response,
+        json: { ...preferences, theme: "system" },
+      });
+    });
+
+    await page.goto(appUrl);
+    await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+
+    const composer = page.locator(".okou-composer");
+    const editor = composer.getByRole("textbox", { name: "Message" });
+    await editor.focus();
+    await expect(editor).toBeFocused();
+    await expect
+      .poll(async () => {
+        return composer.evaluate((element) => {
+          return getComputedStyle(element, "::after").boxShadow;
+        });
+      })
+      .toBe("none");
+  });
+});
+
 test("mobile pages assign the bottom safe area to content and controls", async ({
   page,
 }) => {

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -454,10 +454,10 @@ body {
   --okou-composer-focus-veil: 0 10px 48px -8px hsl(30 8% 45% / 0.09);
 }
 
-/* A grey veil is invisible on a dark page, so the dark theme casts the same
-   shape in black instead. The border step carries the state either way. */
+/* A wide black shadow reads as a page gradient on dark surfaces. The border
+   step carries the focus state without adding another layer behind the card. */
 :where([data-theme="dark"]) .okou-app {
-  --okou-composer-focus-veil: 0 10px 48px -8px rgb(0 0 0 / 0.45);
+  --okou-composer-focus-veil: none;
 }
 
 .okou-app[data-gradient-color-themes] {
@@ -469,7 +469,7 @@ body {
 }
 
 :where([data-theme="dark"]) .okou-app[data-gradient-color-themes] {
-  --okou-composer-focus-veil: 0 10px 48px -8px rgb(0 0 0 / 0.45);
+  --okou-composer-focus-veil: none;
 }
 
 /* Desktop shell: avoid accidental selection on app chrome while preserving content/editors. */


### PR DESCRIPTION
## Summary

- remove the focused composer shadow in dark mode so it no longer reads as a page gradient
- retain the focus border and the light-theme focus veil
- add a Playwright regression for the rendered dark composer focus state

## Verification

- `cd turbo && corepack pnpm exec prettier --check apps/platform/src/views/css/index.css ../e2e/playwright/tests/chat.spec.ts`
- `cd e2e && corepack pnpm check-types`
- `cd turbo && npm exec --yes --package=pnpm@10.33.4 -- pnpm -F @okouai/app lint`
- `cd turbo && npm exec --yes --package=pnpm@10.33.4 -- pnpm -F @okouai/app check-types`
- `cd turbo && VITE_CLERK_PUBLISHABLE_KEY_PREVIEW=pk_test_placeholder VITE_CLERK_PUBLISHABLE_KEY_PROD=pk_live_placeholder npm exec --yes --package=pnpm@10.33.4 -- pnpm -F @okouai/app build`
- compiled production CSS verified in headless Chromium: light focus shadow retained; default and gradient-theme dark focus shadows resolve to `none`; focus border remains active

The new authenticated Playwright case was not run locally because repository instructions prohibit starting the local dev server; the PR pipeline remains the source of truth.
