### PR TITLE
test(runner): stabilize workspace cache resume heartbeat

### DIFF
--- a/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/workspace_cache.rs
@@ -8,7 +8,7 @@ use super::super::support::{
 };
 
 use crate::idle_reuse_preparation::add_healthy_reuse_preparation_matcher;
-use crate::paths::RunnerPaths;
+use crate::paths::{HomePaths, RunnerPaths};
 use crate::types::{
     HeartbeatState, SandboxReuseResult, WORKSPACE_AFFINITY_VERSION, WorkspaceCacheCapability,
 };
@@ -213,15 +213,16 @@ async fn external_workspace_cache_publication_and_removal_trigger_immediate_hear
     shutdown(&env, run_handle).await;
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn workspace_cache_change_while_draining_is_preserved_after_resume() {
-    let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        Arc::clone(&gate),
-    ));
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     let mut profiles = test_profiles();
     profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
     let (mut config, env) = mock_run_config_with_overrides(profiles, 8, 32768, 4, overrides);
+    let (heartbeat_trigger, heartbeat_trigger_rx) = tokio::sync::mpsc::unbounded_channel();
+    config.test_hooks.manual_routine_heartbeat_rx = Some(heartbeat_trigger_rx);
     let status_path = env._temp_dir.path().join("status.json");
     let home = config.paths.home.clone();
     let group = config.runner.group.clone();
@@ -235,19 +236,9 @@ async fn workspace_cache_change_while_draining_is_preserved_after_resume() {
     tokio::fs::create_dir_all(publisher_paths.base_dir())
         .await
         .unwrap();
-    let publisher_cache = WorkspaceImageCache::shared(publisher_paths.clone(), &home, &group);
-    let run_handle = tokio::spawn(run(config));
-    wait_discover_entered(&env, Duration::from_secs(5)).await;
-
-    let run_id = RunId::new_v4();
-    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
-    let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
-    env.drain();
-    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
-
-    observer_cache.reset_held_state_root_scan_count();
-    let before_change = env.handle.heartbeat_count();
-    let watcher_cursor = env.start_observer.cursor();
+    let publisher_home = HomePaths::with_root(env._temp_dir.path().join("draining-publisher-home"));
+    let publisher_cache =
+        WorkspaceImageCache::shared(publisher_paths.clone(), &publisher_home, &group);
     let reuse_key = "thread:draining-watcher-change";
     seed_workspace_cache_state(
         &publisher_cache,
@@ -257,6 +248,38 @@ async fn workspace_cache_change_while_draining_is_preserved_after_resume() {
         16 * 1024 * 1024,
     )
     .await;
+    let cache_key = crate::paths::scoped_workspace_image_cache_key(
+        &group,
+        "vm0/default",
+        reuse_key,
+        api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR,
+        16 * 1024 * 1024,
+    );
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    let _token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("active job should enter wait_process before draining");
+    env.drain();
+    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
+
+    observer_cache.reset_held_state_root_scan_count();
+    let before_change = env.handle.heartbeat_count();
+    let watcher_cursor = env.start_observer.cursor();
+    // Publish a complete entry in one watched operation. Creating the directory
+    // and committing metadata in place can be observed in separate batches,
+    // legitimately requesting two scans even though the snapshot is unchanged.
+    tokio::fs::rename(
+        publisher_home.workspace_image_cache_dir().join(&cache_key),
+        home.workspace_image_cache_dir().join(&cache_key),
+    )
+    .await
+    .unwrap();
     env.start_observer
         .wait_workspace_cache_change_observed_after(watcher_cursor, Duration::from_secs(5))
         .await;
@@ -281,7 +304,19 @@ async fn workspace_cache_change_while_draining_is_preserved_after_resume() {
     env.resume();
     wait_status_mode(&status_path, "running", Duration::from_secs(5)).await;
     let before_routine = env.handle.heartbeat_count();
-    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    let heartbeat_cursor = env.start_observer.cursor();
+    // Trigger only the routine heartbeat: advancing paused time can also fire
+    // periodic cache reconciliation and legitimately add another root scan.
+    heartbeat_trigger
+        .send(())
+        .expect("manual routine heartbeat receiver should remain open");
+    env.start_observer
+        .wait_routine_heartbeat_requested_after(
+            heartbeat_cursor,
+            RunnerMode::Running,
+            Duration::from_secs(5),
+        )
+        .await;
     assert!(
         wait_heartbeat_matching_after(
             &env.handle,
@@ -304,7 +339,7 @@ async fn workspace_cache_change_while_draining_is_preserved_after_resume() {
         "the post-resume routine heartbeat should reuse the refreshed snapshot",
     );
 
-    gate.notify_one();
+    wait_gate.release_one();
     assert!(
         env.handle
             .wait_completion(run_id, Duration::from_secs(5))


### PR DESCRIPTION
## Summary

- Prepare the cache entry outside the watched root and atomically move the complete directory into it while the runner is draining, so this test injects one unambiguous cache publication.
- Make `workspace_cache_change_while_draining_is_preserved_after_resume` use the existing manual routine-heartbeat trigger instead of advancing a paused Tokio clock.
- Wait for the active job to enter the mock sandbox's `wait_process` lifecycle gate before draining, and release it only after checking the resumed heartbeat.
- Acknowledge the routine-heartbeat branch in `Running` mode before checking the provider's payload. Keep the real filesystem, cache watcher, snapshot-content assertions, and exact one-scan assertions.

## Problem

The test counts all workspace-cache root scans, but creates its fixture directly in the watched root. The directory-creation event installs an entry watch and reads metadata asynchronously. If metadata is committed during that read, the directory event can already request a refresh while the separately queued metadata-rename event requests another. That second legitimate scan can land after resume and be incorrectly attributed to the routine heartbeat.

The test also advances a paused runtime-wide clock to request its post-resume heartbeat. Routine heartbeats reuse the snapshot; independent reconciliation starts after 30 seconds and legitimately scans the cache. Paused-time auto-advance during asynchronous waits makes the accumulated virtual time scheduling-dependent, so advancing time does not isolate the behavior being asserted.

The unchanged test reproduced the reported `left: 2, right: 1` failure on iteration 57 of a 100-run local baseline batch. An earlier baseline batch also failed while waiting for the post-resume matching heartbeat on iteration 11.

A first attempt using only real time, a lifecycle gate, and a manual heartbeat still reproduced `2 != 1` on iteration 145 in 0.17 seconds. This rules out the 30-second reconciliation timer as the sole cause and motivated making the fixture publication atomic as well.

## Scope and risk

Only the existing runner integration test changes. Production heartbeat/cache behavior, timer periods, protocols, dependencies, and CI sharding are unchanged. The test uses existing synchronization hooks, does not add sleeps or extend timeouts, and does not skip or relax assertions.

The atomic move stays within the test's temporary filesystem, preserving the image identity checked by the real cache validator. The neighboring in-place publication/removal and watcher reconciliation tests remain unchanged.

## Validation

- `cargo test --profile local -p runner --bin runner --all-features cmd::start::tests::idle_reuse::workspace_cache:: -- --nocapture` — all nine related integration tests passed.
- 500 consecutive executions of the rebuilt test binary with `--exact cmd::start::tests::idle_reuse::workspace_cache::workspace_cache_change_while_draining_is_preserved_after_resume --nocapture` — all passed.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy --profile local -p runner --all-targets --all-features` — passed.
- `cargo doc --profile local -p runner --all-features --no-deps` — passed.
- `cargo test --profile local -p runner --all-targets --all-features -- --quiet` — passed: 3,534 binary tests and one guest-inventory integration test. The 25 pre-existing ignored tests are unchanged.
