### PR TITLE
fix(runner): retire codex prefetch sandboxes after partial writes

### DIFF
--- a/crates/guest-control-client/src/connection/frame.rs
+++ b/crates/guest-control-client/src/connection/frame.rs
@@ -16,6 +16,8 @@ use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::time::Instant;
 
+use crate::{RequestWriteError, RequestWriteStage};
+
 use super::Shared;
 
 /// `Skip` is a successful no-frame outcome, decided under the writer lock.
@@ -59,7 +61,10 @@ impl Shared {
         let wait_started_at = Instant::now();
         let mut writer = self.writer.lock().await;
         let wait = wait_started_at.elapsed();
-        if pre_write()? == FrameWriteDecision::Skip {
+        let decision = pre_write().map_err(|error| {
+            RequestWriteError::into_io_error(RequestWriteStage::BeforeFrameWrite, error)
+        })?;
+        if decision == FrameWriteDecision::Skip {
             return Ok(FrameWriteDecision::Skip);
         }
 
@@ -76,7 +81,9 @@ impl Shared {
         drop(writer);
 
         write_finished(FrameWriteTiming { wait, write }, &result);
-        result?;
+        result.map_err(|error| {
+            RequestWriteError::into_io_error(RequestWriteStage::FrameWrite, error)
+        })?;
         Ok(FrameWriteDecision::Write)
     }
 }

--- a/crates/guest-control-client/src/lib.rs
+++ b/crates/guest-control-client/src/lib.rs
@@ -152,6 +152,48 @@ impl fmt::Display for RequestTimeoutError {
 
 impl std::error::Error for RequestTimeoutError {}
 
+/// Byte-emission boundary for an ordinary guarded request-write failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RequestWriteStage {
+    /// This frame emitted no bytes; this does not assert connection health.
+    BeforeFrameWrite,
+    /// The frame write failed after admission and may be partial.
+    FrameWrite,
+}
+
+/// Ordinary write failure carried inside an [`io::Error`] of the original kind.
+///
+/// Unlike [`RequestTimeoutError`], this does not represent a request deadline,
+/// even when the underlying writer returns [`io::ErrorKind::TimedOut`].
+#[derive(Debug)]
+pub struct RequestWriteError {
+    stage: RequestWriteStage,
+    source: io::Error,
+}
+
+impl RequestWriteError {
+    pub(crate) fn into_io_error(stage: RequestWriteStage, source: io::Error) -> io::Error {
+        io::Error::new(source.kind(), Self { stage, source })
+    }
+
+    /// Return the stage observed by the serialized frame writer.
+    pub const fn stage(&self) -> RequestWriteStage {
+        self.stage
+    }
+}
+
+impl fmt::Display for RequestWriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.source.fmt(f)
+    }
+}
+
+impl std::error::Error for RequestWriteError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
 /// Observer called when a request frame reaches the guest-write boundary.
 ///
 /// The callback is synchronous because it runs while the shared writer lock is

--- a/crates/guest-control-client/src/tests/connection.rs
+++ b/crates/guest-control-client/src/tests/connection.rs
@@ -19,7 +19,8 @@ use super::support::{
     set_next_route_id, setup_host_and_mock_guest, wait_for_pending_request_count,
 };
 use crate::{
-    GuestControlClient, NormalOperationFenceRejection, operation_tracker::NormalOperationReadiness,
+    GuestControlClient, NormalOperationFenceRejection, RequestWriteError, RequestWriteStage,
+    operation_tracker::NormalOperationReadiness,
 };
 
 fn unique_vsock_paths(label: &str) -> (String, PathBuf) {
@@ -1098,6 +1099,14 @@ async fn request_write_failure_poisons_connection_and_cleans_pending() {
         .unwrap_err();
 
     assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    assert_eq!(
+        err.get_ref()
+            .unwrap()
+            .downcast_ref::<RequestWriteError>()
+            .unwrap()
+            .stage(),
+        RequestWriteStage::FrameWrite,
+    );
     assert!(!is_connected(&host));
     assert_eq!(pending_request_count(&host), 0);
     assert_eq!(

--- a/crates/guest-control-client/src/tests/exec_operation/cancel.rs
+++ b/crates/guest-control-client/src/tests/exec_operation/cancel.rs
@@ -18,7 +18,7 @@ use super::super::support::{
 };
 use super::start_capture_operation;
 use crate::operation_tracker::NormalOperationReadiness;
-use crate::{ExecCaptureRequest, FrameWriteObserver};
+use crate::{ExecCaptureRequest, FrameWriteObserver, RequestWriteError, RequestWriteStage};
 
 const EXEC_START_WRITE_TEST_TIMEOUT: Duration = Duration::from_millis(50);
 
@@ -343,6 +343,14 @@ async fn exec_write_observer_error_cleans_registration_without_sending_frame() {
     .unwrap_err();
 
     assert!(err.to_string().contains("observer failed"));
+    assert_eq!(
+        err.get_ref()
+            .unwrap()
+            .downcast_ref::<RequestWriteError>()
+            .unwrap()
+            .stage(),
+        RequestWriteStage::BeforeFrameWrite,
+    );
     match guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
         Ok(n) => panic!("observer error must not send exec frame; read {n} bytes"),
@@ -358,7 +366,7 @@ async fn exec_write_observer_error_cleans_registration_without_sending_frame() {
 
 #[tokio::test]
 async fn exec_write_admission_error_releases_unused_reservation_without_sending_frame() {
-    let (host, guest) = setup_host_and_guest().await;
+    let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
 
     let err = exec_capture_with_write_admission(
@@ -370,6 +378,15 @@ async fn exec_write_admission_error_releases_unused_reservation_without_sending_
     .unwrap_err();
 
     assert!(err.to_string().contains("admission failed"));
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    assert_eq!(
+        err.get_ref()
+            .unwrap()
+            .downcast_ref::<RequestWriteError>()
+            .unwrap()
+            .stage(),
+        RequestWriteStage::BeforeFrameWrite,
+    );
     match guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
         Ok(n) => panic!("admission error must not send exec frame; read {n} bytes"),
@@ -381,6 +398,7 @@ async fn exec_write_admission_error_releases_unused_reservation_without_sending_
         NormalOperationReadiness::Idle
     );
     assert!(is_connected(&host));
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]

--- a/crates/guest-control-client/src/tests/exec_operation/supervised/mod.rs
+++ b/crates/guest-control-client/src/tests/exec_operation/supervised/mod.rs
@@ -5,3 +5,4 @@ mod output;
 mod support;
 mod timeout;
 mod validation;
+mod write;

--- a/crates/guest-control-client/src/tests/exec_operation/supervised/write.rs
+++ b/crates/guest-control-client/src/tests/exec_operation/supervised/write.rs
@@ -1,0 +1,80 @@
+use std::error::Error;
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
+
+use nix::sys::socket::{Shutdown, setsockopt, shutdown, sockopt};
+use tokio::io::AsyncReadExt;
+
+use super::super::super::support::{
+    host_from_stream, is_connected, make_pair, mock_handshake, operation_count,
+};
+use super::support::supervised_request;
+use crate::{RequestWriteError, RequestWriteStage, SupervisedExecRequest};
+
+#[tokio::test]
+async fn supervised_process_partial_write_error_preserves_cause_and_rejects_later_work() {
+    let (host_stream, mut guest) = make_pair();
+    setsockopt(&host_stream, sockopt::SndBuf, &4096usize).unwrap();
+    let host_task = tokio::spawn(async move { host_from_stream(host_stream).await.unwrap() });
+    mock_handshake(&mut guest).await;
+    let host = Arc::new(host_task.await.unwrap());
+    let mut task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            let stdin_bytes = vec![0xA5; guest_control_proto::MAX_EXEC_STDIN_BYTES];
+            host.start_supervised_process(SupervisedExecRequest {
+                stdin_bytes: Some(&stdin_bytes),
+                ..supervised_request("partial-write")
+            })
+            .await
+        })
+    };
+
+    // Observe real bytes before shutting down only the host's write half. The host
+    // reader stays open, so this must fail write_all rather than the response wait.
+    let mut prefix = [0u8; 16];
+    tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::select! {
+            result = guest.read_exact(&mut prefix) => { result.unwrap(); }
+            result = &mut task => panic!("start ended before prefix: {:?}", result.unwrap().err()),
+        }
+    })
+    .await
+    .expect("start frame prefix must be written");
+    assert!(!task.is_finished());
+    shutdown(host.shared.fd, Shutdown::Write).unwrap();
+    let mut partial = Vec::new();
+    tokio::time::timeout(Duration::from_secs(5), guest.read_to_end(&mut partial))
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(prefix.len() + partial.len() < guest_control_proto::MAX_EXEC_STDIN_BYTES);
+    let error = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .unwrap()
+        .unwrap()
+        .err()
+        .expect("an incomplete frame must fail the process start");
+    assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+    let write = error
+        .get_ref()
+        .and_then(|source| source.downcast_ref::<RequestWriteError>())
+        .expect("ordinary partial write must retain its typed boundary");
+    assert_eq!(write.stage(), RequestWriteStage::FrameWrite);
+    let cause = write.source().unwrap().downcast_ref::<io::Error>().unwrap();
+    assert_eq!(cause.kind(), error.kind());
+    assert_eq!(cause.raw_os_error(), Some(nix::libc::EPIPE));
+    assert_eq!(error.to_string(), cause.to_string());
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert!(!is_connected(&host));
+    assert_eq!(operation_count(&host), 0);
+    assert!(
+        host.start_supervised_process(supervised_request("later-work"))
+            .await
+            .is_err()
+    );
+    assert_eq!(operation_count(&host), 0);
+}

--- a/crates/guest-control-client/src/tests/file/write.rs
+++ b/crates/guest-control-client/src/tests/file/write.rs
@@ -23,7 +23,8 @@ use super::support::{
     send_write_files_success, spawn_write_file, spawn_write_files, spawn_write_private_files,
 };
 use crate::{
-    FrameWriteObserver, RequestTimeoutError, RequestTimeoutStage, WriteFileEntry,
+    FrameWriteObserver, RequestTimeoutError, RequestTimeoutStage, RequestWriteError,
+    RequestWriteStage, WriteFileEntry,
     file::test_support::{
         WRITE_FILES_BATCH_CONTENT_LIMIT, WRITE_FILES_BATCH_FILE_LIMIT,
         write_private_files_with_small_limits,
@@ -1159,6 +1160,14 @@ async fn write_file_frame_failure_poisons_connection_and_releases_gates() {
         .unwrap_err();
 
     assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    assert_eq!(
+        err.get_ref()
+            .unwrap()
+            .downcast_ref::<RequestWriteError>()
+            .unwrap()
+            .stage(),
+        RequestWriteStage::FrameWrite,
+    );
     assert!(!is_connected(&host));
     assert_eq!(pending_request_count(&host), 0);
     assert_eq!(
@@ -1691,6 +1700,14 @@ async fn write_file_observer_error_cleans_pending_without_sending_frame() {
         .unwrap_err();
 
     assert!(err.to_string().contains("observer failed"));
+    assert_eq!(
+        err.get_ref()
+            .unwrap()
+            .downcast_ref::<RequestWriteError>()
+            .unwrap()
+            .stage(),
+        RequestWriteStage::BeforeFrameWrite,
+    );
     match guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
         Ok(n) => panic!("observer error must not send write_file frame; read {n} bytes"),

--- a/crates/runner/src/executor/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/codex_model_catalog_prefetch.rs
@@ -6,7 +6,7 @@ use futures_util::FutureExt;
 use sandbox::{
     ExecOutputLimits, ExecTermination, GuestProcessCancelHandle, GuestProcessHandle, ProcessExit,
     ProcessOutputMode, Sandbox, SandboxError, SandboxOperation, SandboxOperationTimeoutStage,
-    StartProcessRequest,
+    SandboxOperationWriteStage, StartProcessRequest,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
@@ -64,6 +64,7 @@ pub(super) enum CodexModelCatalogPrefetchStart {
 pub(super) struct UnusableCodexModelCatalogPrefetchStart {
     error: SandboxError,
     started_at: Instant,
+    outcome: &'static str,
 }
 
 pub(super) struct StartedCodexModelCatalogPrefetch {
@@ -149,7 +150,27 @@ impl StartedCodexModelCatalogPrefetch {
             Err(error) if is_unusable_sandbox_start_timeout(&error) => {
                 warn!(error = %error, "Codex model catalog prefetch start timed out after write boundary");
                 CodexModelCatalogPrefetchStart::SandboxUnusable(
-                    UnusableCodexModelCatalogPrefetchStart { error, started_at },
+                    UnusableCodexModelCatalogPrefetchStart {
+                        error,
+                        started_at,
+                        outcome: "start_timed_out",
+                    },
+                )
+            }
+            Err(
+                error @ SandboxError::OperationWrite {
+                    operation: SandboxOperation::StartProcess,
+                    stage: SandboxOperationWriteStage::FrameWrite,
+                    ..
+                },
+            ) => {
+                warn!(error = %error, "Codex model catalog prefetch start write failed after write boundary");
+                CodexModelCatalogPrefetchStart::SandboxUnusable(
+                    UnusableCodexModelCatalogPrefetchStart {
+                        error,
+                        started_at,
+                        outcome: "start_failed",
+                    },
                 )
             }
             Err(error) => {
@@ -213,7 +234,7 @@ impl UnusableCodexModelCatalogPrefetchStart {
             PREFETCH_ACTION,
             self.started_at.elapsed(),
             false,
-            Some("start_timed_out"),
+            Some(self.outcome),
         );
         self.error
     }

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -1328,7 +1328,7 @@ async fn create_started_sandbox(
                     warn!(
                         run_id = %context.run_id,
                         error = %unregister_error,
-                        "failed to unregister sandbox from proxy after Codex prefetch start timeout"
+                        "failed to unregister sandbox from proxy after unsafe Codex prefetch start failure"
                     );
                     false
                 }

--- a/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/codex_model_catalog_prefetch.rs
@@ -291,6 +291,53 @@ async fn codex_catalog_prefetch_post_write_timeout_stops_direct_run_before_agent
 }
 
 #[tokio::test]
+async fn codex_catalog_prefetch_partial_write_stops_direct_run_before_guest_work() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_process_error(SandboxError::OperationWrite {
+        operation: SandboxOperation::StartProcess,
+        stage: sandbox::SandboxOperationWriteStage::FrameWrite,
+        source: std::io::Error::new(std::io::ErrorKind::BrokenPipe, "partial write"),
+    });
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let context = codex_oauth_context();
+    let mut telemetry = test_telemetry(&config, &context);
+
+    let error = run_in_sandbox(
+        &*sandbox,
+        &context,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            workspace_reuse_result: crate::types::WorkspaceReuseResult::NotConfigured,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .err()
+    .expect("an owned sandbox must not continue after an unsafe write");
+
+    assert!(matches!(
+        error,
+        crate::error::RunnerError::Sandbox(SandboxError::OperationWrite {
+            stage: sandbox::SandboxOperationWriteStage::FrameWrite,
+            ..
+        })
+    ));
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert!(overrides.storage_manifest_calls().is_empty());
+    assert!(overrides.write_files_calls().is_empty());
+    assert!(overrides.wait_process_calls().is_empty());
+    assert!(overrides.process_cancel_calls().is_empty());
+    assert_prefetch_outcome(&telemetry, false, Some("start_failed"), "partial_write");
+}
+
+#[tokio::test]
 async fn codex_catalog_prefetch_records_start_cancellation() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let start_gate = MockLifecycleGate::new();

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -576,6 +576,106 @@ async fn execute_new_sandbox_suppresses_prefetch_replacement_after_uncertain_cle
 }
 
 #[tokio::test]
+async fn execute_new_sandbox_handles_ordinary_prefetch_write_failures() {
+    use sandbox::SandboxOperationWriteStage;
+    use std::io;
+
+    for (stage, kind, cleanup_uncertain) in [
+        (
+            SandboxOperationWriteStage::BeforeFrameWrite,
+            io::ErrorKind::PermissionDenied,
+            false,
+        ),
+        (
+            SandboxOperationWriteStage::FrameWrite,
+            io::ErrorKind::BrokenPipe,
+            false,
+        ),
+        (
+            SandboxOperationWriteStage::FrameWrite,
+            io::ErrorKind::TimedOut,
+            false,
+        ),
+        (
+            SandboxOperationWriteStage::FrameWrite,
+            io::ErrorKind::BrokenPipe,
+            true,
+        ),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_start_process_error(SandboxError::OperationWrite {
+            operation: sandbox::SandboxOperation::StartProcess,
+            stage,
+            source: io::Error::new(kind, "prefetch write failed"),
+        });
+        if cleanup_uncertain {
+            overrides.push_destroy_panic("destroy failed");
+        }
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let context = codex_oauth_context();
+        let mut telemetry = test_telemetry(&config, &context);
+        let result = execute_new_sandbox(
+            &factory,
+            &context,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::PoolMiss,
+            },
+            &config,
+            &default_params(),
+            &mut telemetry,
+            CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(
+            overrides.start_process_calls().len(),
+            1,
+            "replacement must not prefetch again"
+        );
+        let unsafe_write = stage == SandboxOperationWriteStage::FrameWrite;
+        assert_eq!(overrides.destroy_call_count(), u32::from(unsafe_write));
+        assert_eq!(
+            overrides.create_configs().len(),
+            1 + usize::from(unsafe_write && !cleanup_uncertain)
+        );
+        if cleanup_uncertain {
+            assert!(matches!(
+                result,
+                Err(RunnerError::Sandbox(SandboxError::OperationWrite {
+                    stage: SandboxOperationWriteStage::FrameWrite,
+                    ..
+                }))
+            ));
+            assert_eq!(overrides.workspace_drive_mount_calls(), 0);
+            assert!(overrides.storage_manifest_calls().is_empty());
+            assert!(overrides.start_agent_process_calls().is_empty());
+        } else {
+            assert_eq!(result.unwrap().exit_code(), 0);
+            assert_eq!(overrides.workspace_drive_mount_calls(), 1);
+            assert_eq!(overrides.start_agent_process_calls().len(), 1);
+        }
+        assert_telemetry_action(
+            &telemetry,
+            "runner_codex_model_catalog_prefetch",
+            false,
+            Some("start_failed"),
+        );
+        if unsafe_write {
+            assert_telemetry_action(
+                &telemetry,
+                "runner_fresh_sandbox_retry_without_codex_prefetch",
+                !cleanup_uncertain,
+                cleanup_uncertain.then_some("cleanup_uncertain"),
+            );
+        }
+        assert_proxy_registry_empty(dir.path()).await;
+    }
+}
+
+#[tokio::test]
 async fn execute_new_sandbox_destroys_before_workload_when_prepared_notification_fails() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
@@ -617,6 +717,56 @@ async fn execute_new_sandbox_destroys_before_workload_when_prepared_notification
     assert!(error.to_string().contains("status publication failed"));
     assert_eq!(overrides.destroy_call_count(), 1);
     assert!(overrides.start_agent_process_calls().is_empty());
+    assert_proxy_registry_empty(dir.path()).await;
+}
+
+#[tokio::test]
+async fn prefetch_partial_write_cannot_spend_a_second_preparation_retry() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_result(Err(guest_dns_readiness_failure(
+        SandboxGuestDnsReadinessReason::DnsPath,
+        "first attachment failed",
+    )));
+    overrides.push_start_process_error(SandboxError::OperationWrite {
+        operation: sandbox::SandboxOperation::StartProcess,
+        stage: sandbox::SandboxOperationWriteStage::FrameWrite,
+        source: std::io::Error::new(std::io::ErrorKind::BrokenPipe, "partial write"),
+    });
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let context = codex_oauth_context();
+    let mut telemetry = test_telemetry(&config, &context);
+    let result = execute_new_sandbox(
+        &factory,
+        &context,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        &mut telemetry,
+        CancellationToken::new(),
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(RunnerError::Sandbox(SandboxError::OperationWrite { .. }))
+    ));
+    assert_eq!(overrides.create_configs().len(), 2);
+    assert_eq!(overrides.destroy_call_count(), 2);
+    assert_eq!(overrides.start_process_calls().len(), 1);
+    assert_eq!(overrides.workspace_drive_mount_calls(), 0);
+    assert!(overrides.storage_manifest_calls().is_empty());
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert_telemetry_action(
+        &telemetry,
+        "runner_codex_model_catalog_prefetch",
+        false,
+        Some("start_failed"),
+    );
     assert_proxy_registry_empty(dir.path()).await;
 }
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -494,89 +494,98 @@ async fn workspace_mount_retry_starts_a_new_codex_catalog_prefetch_owner() {
 }
 
 #[tokio::test]
-async fn post_write_prefetch_timeout_replaces_consumed_cache_hit_with_fresh_workspace() {
-    let dir = tempfile::tempdir().unwrap();
-    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = WorkspaceImageCache::new(runner_paths.clone());
-    let mut config = test_executor_config(dir.path()).await;
-    config.workspace_cache = Some(cache.clone());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.push_start_process_error(SandboxError::OperationTimeout {
-        operation: sandbox::SandboxOperation::StartProcess,
-        stage: sandbox::SandboxOperationTimeoutStage::AwaitingTerminalResponse,
-        timeout_ms: 1_000,
-    });
-    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
-    let mut context = codex_oauth_context();
-    let session_id = "00000000-0000-4000-8000-000000032219";
-    set_reuse_and_session_identity(&mut context, session_id, r#"{"type":"init"}"#);
-    let params = JobParams {
-        workspace_disk_mb: 16,
-        ..default_params()
-    };
-    let expected_seed = seed_workspace_image_cache(&cache, &runner_paths, session_id, 16).await;
-    let mut telemetry = test_telemetry(&config, &context);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &context,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
+async fn post_write_prefetch_failure_replaces_consumed_cache_hit_with_fresh_workspace() {
+    for start_error in [
+        SandboxError::OperationTimeout {
+            operation: sandbox::SandboxOperation::StartProcess,
+            stage: sandbox::SandboxOperationTimeoutStage::AwaitingTerminalResponse,
+            timeout_ms: 1_000,
         },
-        &config,
-        &params,
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+        SandboxError::OperationWrite {
+            operation: sandbox::SandboxOperation::StartProcess,
+            stage: sandbox::SandboxOperationWriteStage::FrameWrite,
+            source: std::io::Error::new(std::io::ErrorKind::BrokenPipe, "partial write"),
+        },
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+        let cache = WorkspaceImageCache::new(runner_paths.clone());
+        let mut config = test_executor_config(dir.path()).await;
+        config.workspace_cache = Some(cache.clone());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.push_start_process_error(start_error);
+        let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+        let mut context = codex_oauth_context();
+        let session_id = "00000000-0000-4000-8000-000000032219";
+        set_reuse_and_session_identity(&mut context, session_id, r#"{"type":"init"}"#);
+        let params = JobParams {
+            workspace_disk_mb: 16,
+            ..default_params()
+        };
+        let expected_seed = seed_workspace_image_cache(&cache, &runner_paths, session_id, 16).await;
+        let mut telemetry = test_telemetry(&config, &context);
 
-    assert_eq!(outcome.exit_code(), 0);
-    assert!(outcome.workspace_image.is_none());
-    let configs = overrides.create_configs();
-    assert_eq!(configs.len(), 2);
-    assert_eq!(
-        configs[0].workspace_drive,
-        Some(sandbox::WorkspaceDriveConfig {
-            size_mb: 16,
-            seed_image: Some(sandbox::WorkspaceDriveSeedImage::Move(
-                expected_seed.clone(),
-            )),
-        })
-    );
-    assert_eq!(
-        configs[1].workspace_drive,
-        Some(sandbox::WorkspaceDriveConfig {
-            size_mb: 16,
-            seed_image: None,
-        })
-    );
-    assert!(!expected_seed.exists());
-    assert_eq!(overrides.destroy_call_count(), 1);
-    assert_eq!(overrides.start_process_calls().len(), 1);
-    assert_eq!(overrides.start_agent_process_calls().len(), 1);
-    assert_eq!(
-        telemetry
-            .pending_ops_snapshot()
-            .iter()
-            .filter(|(action, _, _)| action == "runner_codex_model_catalog_prefetch")
-            .count(),
-        1
-    );
-    assert_telemetry_action(
-        &telemetry,
-        "runner_fresh_sandbox_retry_without_codex_prefetch",
-        true,
-        None,
-    );
-    assert_telemetry_action(
-        &telemetry,
-        "runner_fresh_sandbox_retry_without_workspace_image",
-        true,
-        None,
-    );
-    assert_proxy_registry_empty(dir.path()).await;
+        let outcome = execute_new_sandbox(
+            &factory,
+            &context,
+            NewSandboxDispatch {
+                id: SandboxId::new_v4(),
+                reuse_result: SandboxReuseResult::PoolMiss,
+            },
+            &config,
+            &params,
+            &mut telemetry,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.exit_code(), 0);
+        assert!(outcome.workspace_image.is_none());
+        let configs = overrides.create_configs();
+        assert_eq!(configs.len(), 2);
+        assert_eq!(
+            configs[0].workspace_drive,
+            Some(sandbox::WorkspaceDriveConfig {
+                size_mb: 16,
+                seed_image: Some(sandbox::WorkspaceDriveSeedImage::Move(
+                    expected_seed.clone(),
+                )),
+            })
+        );
+        assert_eq!(
+            configs[1].workspace_drive,
+            Some(sandbox::WorkspaceDriveConfig {
+                size_mb: 16,
+                seed_image: None,
+            })
+        );
+        assert!(!expected_seed.exists());
+        assert_eq!(overrides.destroy_call_count(), 1);
+        assert_eq!(overrides.start_process_calls().len(), 1);
+        assert_eq!(overrides.start_agent_process_calls().len(), 1);
+        assert_eq!(
+            telemetry
+                .pending_ops_snapshot()
+                .iter()
+                .filter(|(action, _, _)| action == "runner_codex_model_catalog_prefetch")
+                .count(),
+            1
+        );
+        assert_telemetry_action(
+            &telemetry,
+            "runner_fresh_sandbox_retry_without_codex_prefetch",
+            true,
+            None,
+        );
+        assert_telemetry_action(
+            &telemetry,
+            "runner_fresh_sandbox_retry_without_workspace_image",
+            true,
+            None,
+        );
+        assert_proxy_registry_empty(dir.path()).await;
+    }
 }
 
 #[tokio::test]

--- a/crates/sandbox-firecracker/src/sandbox.rs
+++ b/crates/sandbox-firecracker/src/sandbox.rs
@@ -735,6 +735,28 @@ impl FirecrackerSandbox {
         error: io::Error,
         backend_crashed: bool,
     ) -> SandboxError {
+        if let Some(write) = error
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<guest_control_client::RequestWriteError>())
+        {
+            let stage = match write.stage() {
+                guest_control_client::RequestWriteStage::BeforeFrameWrite => {
+                    if backend_crashed {
+                        return Self::backend_crashed_error(operation);
+                    }
+                    sandbox::SandboxOperationWriteStage::BeforeFrameWrite
+                }
+                guest_control_client::RequestWriteStage::FrameWrite => {
+                    sandbox::SandboxOperationWriteStage::FrameWrite
+                }
+            };
+            // A coincident backend crash must not hide a possibly partial frame.
+            return SandboxError::OperationWrite {
+                operation,
+                stage,
+                source: error,
+            };
+        }
         if backend_crashed {
             return Self::backend_crashed_error(operation);
         }

--- a/crates/sandbox-firecracker/src/sandbox/tests.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests.rs
@@ -16,6 +16,7 @@ use tracing_subscriber::prelude::*;
 use tracing_test_support::{CapturedEvent, CapturedEvents};
 
 mod guest_rpc;
+mod process_write;
 
 struct TestNormalOperationFence;
 

--- a/crates/sandbox-firecracker/src/sandbox/tests/process_write.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests/process_write.rs
@@ -1,0 +1,69 @@
+use super::*;
+use sandbox::SandboxOperationWriteStage;
+
+#[tokio::test]
+async fn start_process_partial_write_error_rejects_later_guest_work() {
+    for backend_crashed in [false, true] {
+        let sandbox = test_sandbox_with_state(SandboxState::Running);
+        let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+        // Exceed the Unix socket's send buffer so a prefix can be observed while
+        // the complete frame remains unwritten.
+        let payload = "x".repeat(4 * 1024 * 1024);
+        let request = StartProcessRequest {
+            cmd: "prefetch",
+            timeout: Duration::from_secs(5),
+            start_timeout: Duration::from_secs(5),
+            env: &[("PAYLOAD", &payload)],
+            sudo: false,
+            output: ProcessOutputMode::buffered(sandbox::EXEC_OUTPUT_LIMIT_1_MIB),
+        };
+        let start = sandbox.start_process(&request);
+        tokio::pin!(start);
+        let mut prefix = [0u8; 16];
+        tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::select! {
+                result = guest.read_exact(&mut prefix) => { result.unwrap(); }
+                result = &mut start => panic!("start ended before prefix: {:?}", result.err()),
+            }
+        })
+        .await
+        .expect("start must emit a partial frame");
+        if backend_crashed {
+            // Model the observed-state window before the crash notification
+            // is published, so the ordinary write result owns this race.
+            sandbox
+                .state
+                .store(SandboxState::Crashed as u8, Ordering::Release);
+        }
+        // The oversized frame is still incomplete, so the start cannot be
+        // awaiting a guest reply when the transport is closed.
+        drop(guest);
+        let result = tokio::time::timeout(Duration::from_secs(5), start)
+            .await
+            .expect("partial start write should fail without waiting for its deadline");
+        let error = result.err().expect("partial start frame must fail");
+        let SandboxError::OperationWrite {
+            operation,
+            stage,
+            source,
+        } = error
+        else {
+            panic!("write classification must survive backend-crash detection: {error:?}");
+        };
+        assert_eq!(operation, SandboxOperation::StartProcess);
+        assert_eq!(stage, SandboxOperationWriteStage::FrameWrite);
+        assert_eq!(source.kind(), io::ErrorKind::BrokenPipe);
+        assert!(
+            source
+                .get_ref()
+                .unwrap()
+                .is::<guest_control_client::RequestWriteError>()
+        );
+
+        let later_request = StartProcessRequest {
+            cmd: "later-work",
+            ..request
+        };
+        assert!(sandbox.start_process(&later_request).await.is_err());
+    }
+}

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -64,6 +64,17 @@ pub enum SandboxError {
         timeout_ms: u64,
     },
 
+    /// An ordinary guarded request-frame write failed, independently of its deadline.
+    #[error("sandbox {operation} failed ({stage}): {source}")]
+    OperationWrite {
+        /// Operation whose request could not be written.
+        operation: SandboxOperation,
+        /// Host-observed byte-emission boundary of the failed write.
+        stage: SandboxOperationWriteStage,
+        /// Original transport failure, including its I/O kind and cause.
+        source: std::io::Error,
+    },
+
     /// Parking or unparking an idle sandbox failed.
     #[error("sandbox {transition} failed: {message}")]
     IdleTransition {
@@ -185,6 +196,24 @@ impl fmt::Display for SandboxOperationTimeoutStage {
             Self::BeforeFrameWrite => f.write_str("before frame write"),
             Self::FrameWrite => f.write_str("during frame write"),
             Self::AwaitingTerminalResponse => f.write_str("awaiting terminal response"),
+        }
+    }
+}
+
+/// Byte-emission boundary for an ordinary sandbox request-write failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxOperationWriteStage {
+    /// This frame emitted no bytes; this does not assert connection health.
+    BeforeFrameWrite,
+    /// The frame write failed after admission and may be partial; retire the sandbox.
+    FrameWrite,
+}
+
+impl fmt::Display for SandboxOperationWriteStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BeforeFrameWrite => f.write_str("before frame write"),
+            Self::FrameWrite => f.write_str("during frame write"),
         }
     }
 }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -38,7 +38,7 @@ pub use control::{
 pub use error::{
     Result, SandboxError, SandboxGuestDnsReadinessReason, SandboxIdleTransition,
     SandboxInitializationPhase, SandboxInvalidStateContext, SandboxOperation,
-    SandboxOperationReason, SandboxOperationTimeoutStage,
+    SandboxOperationReason, SandboxOperationTimeoutStage, SandboxOperationWriteStage,
 };
 pub use factory::{
     SandboxCreateObserver, SandboxCreateStage, SandboxFactory, SandboxNbdCowCreateOutcome,

--- a/docs/runner-guest-process-lifecycle.md
+++ b/docs/runner-guest-process-lifecycle.md
@@ -92,6 +92,28 @@ independent Runner validation of its path output. That authority is not
 available through generic exec APIs, and generic cleanup and storage
 operations retain workload cgroups.
 
+## Optional Codex Prefetch Start Failures
+
+Codex model-catalog prefetch is best-effort only while the sandbox remains safe
+for later work. A start deadline before the frame-write boundary, safe local
+validation/admission failure, or explicit guest start rejection can skip the
+prefetch on the same sandbox. An ordinary write failure is classified at the
+serialized writer boundary, independently of the request deadline: a failed
+`write_all` may have emitted a partial frame and poisons the connection.
+
+Possible partial writes and start deadlines during/after writing stop further
+workspace, storage, and Agent preparation on that sandbox. Fresh preparation
+destroys it and may retry once with prefetch disabled, only after cleanup is
+confirmed. This consumes the existing shared preparation retry budget; uncertain
+cleanup or an already-consumed retry prevents another attempt. A direct run on
+an already-owned sandbox fails through its existing cleanup owner instead of
+replacing the sandbox in place.
+
+Ordinary write failures retain `start_failed` prefetch telemetry; typed request
+deadlines retain `start_timed_out`. The original write cause remains available
+for diagnostics. Error text or an I/O timeout kind alone does not determine
+whether this is a request deadline or whether the sandbox can be reused.
+
 ## Agent Start Timing
 
 `runner_agent_start_process`, `runner_executor_start_to_spawn`,


### PR DESCRIPTION
## Problem

Ordinary supervised-start `write_all` errors can leave a partial frame and poison the guest connection. That safety information previously became a generic sandbox operation error, so optional Codex model-catalog prefetch recorded `start_failed` and continued preparation on the unusable sandbox. This deterministic code-path gap was found in review; no production occurrence has been confirmed.

## Solution

- Classify ordinary guarded write failures at the serialized writer boundary, preserving the original I/O kind, display, and cause.
- Propagate `BeforeFrameWrite` / `FrameWrite` through the sandbox error contract. A possible partial write retains its classification even when backend-crash state is also observed.
- Route unsafe prefetch writes into the existing retirement path before later guest work. Fresh replacement requires confirmed cleanup, consumes the existing shared single retry, and disables prefetch on replacement; direct owned runs return failure to their cleanup owner.
- Keep safe best-effort failures and explicit guest rejections unchanged. Ordinary failures still record `start_failed`, independently of typed deadline `start_timed_out` telemetry.
- Cover real socket partial writes, adapter mapping, safe admission, direct runs, cleanup uncertainty, retry exhaustion, and consumed workspace-cache images; document the lifecycle contract.

## Upstream integration

Rebased onto main `39d81cedeb`, including #32339 and #32307's crate/type renames. Its canonical writer now lives in `connection/frame.rs::Shared::write_frame`. Classification is added there without restoring the old exec-specific guard. Existing ordinary-request and public file-write regressions also verify the typed error stages and preserved cleanup/gate release.

## Scope and risk

No UI, API, guest wire-format, database, workspace-cache schema, configuration, or deployment changes. These Rust error types ship in one runner artifact. No production actions are included.

All post-handshake frame writers now expose a typed ordinary-error source to Rust consumers, including ordinary requests and file writes. The success path, observer ordering, and frame-poisoning behavior are unchanged. `BeforeFrameWrite` describes this attempt, not a guarantee of global connection health. Only `StartProcess` / `FrameWrite` adds a prefetch retirement trigger; no other retry policy changes. Replacement adds work only to the affected failure path and remains bounded by existing cleanup/retry rules.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --profile local --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local --workspace --all-features --no-deps`
- `cargo test --profile local -p guest-control-client -p sandbox -p sandbox-firecracker -p sandbox-mock -p runner -- --test-threads=4 --quiet`: 4,944 passed, zero failures after the final rebase. Existing ignored child/infrastructure targets are unchanged; no tests were newly skipped.
- Prettier for `docs/runner-guest-process-lifecycle.md`; `git diff --check`.

The real Firecracker host-CPU fairness target requires external host fixtures and remains unverified locally. No production or performance benchmark was run.

Closes #32319

Follow-up to #32308 and #32219.
