### PR TITLE
feat(desktop): add generation-owned cua command adapter

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -1090,6 +1090,68 @@ describe("FILE-03 desktop computer-use runtime", () => {
     );
   });
 
+  it("withdraws native create and claim admission with non-empty plugin-only capabilities", async () => {
+    const actor = bdd.user();
+    await enableComputerUseDesktopPlugins(actor);
+    const pluginCapabilities = filesystemToolCapabilities("read_text_file");
+    const host = await api.startComputerUseHost(actor, {
+      supportedCapabilities: ["apps.list", ...pluginCapabilities],
+    });
+    await api.createComputerUseReadCommand(actor, { kind: "apps.list" });
+    const withdrawn = await api.claimNextComputerUseCommand(
+      host.hostToken,
+      pluginCapabilities,
+    );
+    expect(withdrawn.status).toBe("idle");
+    await api.heartbeatComputerUseHost(host.hostToken, {
+      supportedCapabilities: pluginCapabilities,
+      permissions: { accessibility: false, screenRecording: false },
+    });
+    const native = await api.requestCreateComputerUseReadCommand(
+      actor,
+      { kind: "apps.list" },
+      [409],
+    );
+    expectApiError(native.body);
+    const plugin = await api.createComputerUsePluginCommand(actor, {
+      plugin: "filesystem",
+      tool: "read_text_file",
+      arguments: { path: "/tmp/notes.txt" },
+    });
+    // Empty claim updates retain the last non-empty capability set. They must
+    // not restore native support after a plugin-only withdrawal.
+    const claimed = await api.claimNextComputerUseCommand(host.hostToken, []);
+    expect(claimed).toMatchObject({
+      status: "command",
+      command: {
+        id: plugin.commandId,
+        kind: "plugin.call",
+        timeoutMs: 60_000,
+      },
+    });
+  });
+
+  it("preserves native create and claim for legacy capability-empty hosts", async () => {
+    const actor = bdd.user();
+    const host = await api.startComputerUseHost(actor, {
+      supportedCapabilities: [],
+    });
+    const created = await api.createComputerUseReadCommand(actor, {
+      kind: "apps.list",
+    });
+    const claimed = await api.claimNextComputerUseCommand(host.hostToken, []);
+    expect(claimed).toMatchObject({
+      status: "command",
+      command: {
+        id: created.commandId,
+        kind: "apps.list",
+        timeoutMs: 60_000,
+        createdAt: expect.any(String),
+        claimedAt: expect.any(String),
+      },
+    });
+  });
+
   it("gates plugin commands by feature switch and routes them by tool capability", async () => {
     const actor = bdd.user();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -56,6 +56,10 @@ interface RequiredAuthHeaders {
 type ComputerUseAuth = ApiTestUser | { readonly bearer: string } | null;
 
 interface ComputerUseHostStartOptions {
+  readonly permissions?: {
+    readonly accessibility: boolean;
+    readonly screenRecording: boolean;
+  };
   readonly clientProduct?: DesktopProduct;
   readonly installationId?: string;
   readonly hostName?: string;
@@ -250,7 +254,10 @@ function hostRuntimeBody(options: ComputerUseHostStartOptions = {}) {
       ...(options.supportedCapabilities ??
         DEFAULT_SUPPORTED_COMPUTER_USE_CAPABILITIES),
     ],
-    permissions: { accessibility: true, screenRecording: true },
+    permissions: options.permissions ?? {
+      accessibility: true,
+      screenRecording: true,
+    },
   };
 }
 

--- a/turbo/apps/desktop/cua/ADAPTER.md
+++ b/turbo/apps/desktop/cua/ADAPTER.md
@@ -74,7 +74,9 @@ remaining budget) and its requests/retries consume the same deadline. No network
 submission can be guaranteed after the server's command deadline has elapsed.
 
 Already-expired claims report no native action started. An in-flight timeout
-reports potentially delivered/unknown work. Fresh CUA permissions also have a
+reports potentially delivered/unknown work. A network response arriving after
+poll cancellation remains leased through its failure submission, using the
+original remaining budget; its action is never dispatched. Fresh CUA permissions also have a
 bounded five-second readiness check within that command budget. Permission
 revocation, unexpected exit, fatal transport failure, timeout and lifecycle Stop
 withdraw native admission and invalidate targets. Public embedded `stop()` starts

--- a/turbo/apps/desktop/cua/ADAPTER.md
+++ b/turbo/apps/desktop/cua/ADAPTER.md
@@ -1,0 +1,123 @@
+# Host-owned CUA command adapter (slice 3)
+
+`createCuaComputerUseDriver` is an internal composition seam for
+`ComputerUseDriverController` and the existing executor/host. Ordinary `main.ts`
+registers only Okou. The factory is not renderer IPC, a preference, an environment
+switch, or an agent-controlled tool interface. Public commands, auth, queue,
+errors, result/artifact envelopes and the packaged distribution remain unchanged.
+
+The sole source contract is CUA **0.23.2**, commit
+[`e88e9d899ac5effaeae38619527ebaa46b26ce72`](https://github.com/trycua/cua/tree/e88e9d899ac5effaeae38619527ebaa46b26ce72/libs/cua-driver).
+The public SDK's typed desktop methods omit macOS PID/window/token inputs. The
+adapter uses public `callTool` with a closed tool-name union and individually
+constructed fields. It never forwards command payload JSON, private bindings,
+worker messages, profiles, shell commands or arbitrary tool names.
+
+## Supported and refused shapes
+
+| Public command           | Fixed public tools and supported shape                                                                                                 | Explicit refusal/limitation                                                                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apps.list`              | `list_apps`; names, optional bundle/path, installed/running and PID retained                                                           | Installed `pid: 0` cannot be targeted; discovery is bounded below                                                                                      |
+| `app.open`               | `launch_app(bundle_id)`; validate launch identity/state and obtain post-state                                                          | Exact bundle ID required; no arguments, URL navigation or profiles                                                                                     |
+| `app.state`              | `list_apps`, `list_windows`, `get_window_state`; exact live PID and retained/sole window                                               | Ambiguous/missing owners, invalid screenshot frame or geometry                                                                                         |
+| `element.click`          | `click`; current opaque AX token for one left press, or retained window pixels for left/right/middle single/double click               | Stale ID/index, AX double/non-left clicks, moved/resized/scale-changed windows, out-of-image points                                                    |
+| `element.set_value`      | `set_value` on an observed native-app element; exact Unicode value and upstream evidence                                               | Browser bundle IDs are conservatively refused: released rows cannot identify address fields reliably, and AX assignment is not Apple Events navigation |
+| `element.perform_action` | `click` with closed `AXPress`, `AXConfirm`, `AXShowMenu`, `AXPick`, `AXCancel`, `AXOpen` translations (and equivalent lowercase names) | Unknown names, including `AXRaise`, never reach upstream's default-to-press behavior                                                                   |
+| `keyboard.type_text`     | `type_text` into the exact observed window; Unicode and whitespace preserved                                                           | Empty/oversized text and trailing protocol tags that 0.23.2 strips                                                                                     |
+| `keyboard.press_key`     | `press_key`; explicit key aliases and cmd/ctrl/shift/option/fn modifiers                                                               | Unknown keys, repeated modifiers, unsupported punctuation/chords                                                                                       |
+| `element.scroll`         | `scroll`, `by: page`, 1–25 whole up/down pages of the focused window                                                                   | Targeted/fractional/horizontal scrolling; background page delivery does not prove content movement                                                     |
+
+`never` and `on-window-unavailable` request background delivery; `always`
+requests foreground delivery where the command supports that policy. The
+conditional policy permits recovery but does not require an unsafe retry. No
+upstream suggestion triggers escalation, another route, another driver or replay.
+
+## Addressing, observations and facts
+
+One generation owns one embedded process/client/session and one current
+observation. Host-generated session labels are not authorization. Every host
+snapshot and opaque element ID binds bundle/PID/path/window, CUA snapshot and
+token; the generation-local store adds generation ownership. A refresh clears
+the old mapping before awaiting anything, including failed refreshes. Numeric
+indexes require the exact current snapshot. Raw IDs undergo the same retained
+ownership checks. Old LRU entries, same-millisecond observations, switching back,
+or late callbacks cannot recreate authorization.
+
+`tree_markdown` preserves visible/read-only text. Structured rows contain only
+upstream actionable indexes and opaque tokens; no reindexing or fake clickable
+tree is created. Coverage is explicitly incomplete, and degraded reasons are
+retained. One window PNG must agree with its bounded header dimensions, frame,
+window bounds and 1x/2x scale. Upstream downsizing is retained through the shared
+executor. Pixel dispatch refreshes the public frame and rejects changed owners
+or geometry; it passes image-local coordinates through CUA's resize mapping
+once. Derived screen coordinates are labeled `retained_request_frame` request
+metadata, never fabricated CUA evidence. There is no full-screen fallback.
+
+The public result retains CUA `effect`, `route`, `delivery` and `evidence`.
+`partial`, `unverifiable` and `suspected_noop` remain visible even when transport
+succeeds. `confirmed` requires evidence. `refused` maps to the supported public
+failure envelope with serialized facts in its message. A failed post-state keeps
+completed action facts plus `observationError`. Transport failure or deadline
+reports potentially unknown completion, never safe-to-retry success. No legacy
+unconditional success summary overrides these facts.
+
+## Deadline and retirement
+
+The host preserves wire `timeoutMs`, `createdAt` and nullable `claimedAt` before
+its permission query. Explicit timeout is 1–120 seconds; CLI normally sends
+30 seconds and API creation defaults to 60 seconds. Only stored `null` uses the
+existing 120-second policy. Missing, malformed or future dates fail closed;
+`claimedAt` cannot restart the budget. Queue/transit age is subtracted once using
+wall time, then one monotonic deadline covers permission, session, discovery,
+action and post-state. Completion reserves at most one second (10% for a short
+remaining budget) and its requests/retries consume the same deadline. No network
+submission can be guaranteed after the server's command deadline has elapsed.
+
+Already-expired claims report no native action started. An in-flight timeout
+reports potentially delivered/unknown work. Fresh CUA permissions also have a
+bounded five-second readiness check within that command budget. Permission
+revocation, unexpected exit, fatal transport failure, timeout and lifecycle Stop
+withdraw native admission and invalidate targets. Public embedded `stop()` starts
+before awaiting hung SDK work or `endSession`; the pinned implementation has its
+own shutdown/kill/reap channel. AbortSignal and JavaScript races are not proof.
+Replacement remains blocked until all owned callbacks settle, the matching child
+exit/stopped state is observed, and client/host cleanup completes. Unproven cleanup
+stays owned even after its caller-facing deadline; it never permits a fresh Okou
+or CUA executor. No uncertain action is replayed.
+
+## Capabilities and privacy
+
+Native capability publication and pre-claim leases derive from actual backend
+readiness and fresh permissions. Authenticated plugin preparation can establish
+real non-empty plugin capabilities before host registration when native TCC is
+unavailable. Plugin-only claims do not obtain a native lease or query native TCC.
+Existing auth, heartbeat, plugin and recorder owners remain authoritative during
+switching. With no real capabilities, the host stops: publishing `[]` would
+reactivate the server's intentional legacy native fallback. Server semantics are
+unchanged and covered through public create/claim routes.
+
+The daemon retains its private child home, preventing standalone Computer
+History opt-in from being inherited. Running apps and system application
+directories can be enumerated, but installed-only apps in the real user's
+`~/Applications` are outside that scan. `apps.list` reports this limitation. The
+adapter does not relax privacy isolation to claim complete app discovery.
+
+## Evidence and user-owned pending checks
+
+`computer-use-cua.test.ts` and `computer-use-cua-host.test.ts` compose the actual
+adapter, runtime, driver, shared executor and host; only the external public
+SDK/native and network boundaries are substituted. Plugin tests run the real
+filesystem MCP process. They cover command mapping/refusal, stale targets,
+geometry, facts, late/hung work, budgets and plugin-only operation. Existing
+driver/host/controller tests retain Stop/auth/Quit/update/claim/recorder ownership
+coverage. API BDD tests use real routes/database for plugin-only and legacy
+capability compatibility. CLI deadline tests retain the 30-second policy.
+
+The existing macOS package CI continues to run the actual pinned SDK/native/
+daemon probe and ordinary dormant smoke in default, production-configured and
+PR-preview lanes. Those ad-hoc signed package checks prove distribution/loading/
+lifecycle only. They do not prove the fixture action behavior on an interactive
+Mac. Developer ID/notarized installation, actual host TCC attribution, revoked/
+regranted access, real application/window/Unicode/scroll behavior, screenshot
+content, paired Okou comparison and performance remain **unproven and pending
+user acceptance in slice 5**. This PR exposes no selector and authorizes no release.

--- a/turbo/apps/desktop/cua/README.md
+++ b/turbo/apps/desktop/cua/README.md
@@ -1,9 +1,10 @@
-# Experimental embedded CUA runtime (slice 2)
+# Experimental embedded CUA runtime and adapter
 
 Okou remains the only registered/default Computer Use driver. This slice ships
-a dormant, host-owned runtime and a fixed verification entry point. It does not
-implement a command adapter, Developer selector, preferences, renderer
-diagnostics, or a runtime updater.
+a dormant, host-owned runtime and a fixed verification entry point. Slice 3 adds
+an internal [command adapter](ADAPTER.md) factory for the next slice to connect.
+Normal startup does not register or import it. There is no Developer selector,
+preference, renderer diagnostic panel, or runtime updater.
 
 ## Distribution and integrity
 
@@ -80,8 +81,10 @@ environment, permission mode, or generic command route.
 SDK startup validates embedded PID/endpoint/protocol ownership. The wrapper
 also requires exact `driverVersion === "0.23.2"` on both the connection and
 client metadata. Starts coalesce. Stop retires admission immediately, aborts
-pending client probes, retains late startup/exit results, destroys the client,
-awaits native stop and the matching exit observer, destroys the host, and then
+pending client work, starts the public native stop/reap independently of hung
+SDK/session callbacks, retains late startup/exit results, destroys the client
+only after its pending calls settle, awaits the matching exit observer and
+confirmed stopped state, destroys the host, and then
 removes its private directory. A caller deadline never proves process exit:
 unresolved or failed cleanup keeps that generation owned and blocks replacement.
 Unexpected exit cannot replay a command, revive old readiness, or choose Okou.

--- a/turbo/apps/desktop/src/computer-use-accessibility.ts
+++ b/turbo/apps/desktop/src/computer-use-accessibility.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { ComputerUsePermissionState } from "./computer-use-types";
 import {
   ComputerUseNativeHelperError,
@@ -26,6 +27,9 @@ export interface ComputerUseCommand {
   readonly id: string;
   readonly kind: string;
   readonly payload: Record<string, unknown>;
+  readonly timeoutMs?: number | null;
+  readonly createdAt?: string;
+  readonly claimedAt?: string | null;
 }
 
 export interface AccessibilityElementSnapshot {
@@ -63,6 +67,11 @@ export interface AccessibilityElementSnapshot {
 }
 
 export interface AccessibilityAppStateSnapshot {
+  readonly observation?: {
+    readonly text: string;
+    readonly elementsComplete: boolean;
+    readonly source: "cua";
+  };
   readonly app: string;
   readonly appDisplayName?: string;
   readonly bundleId?: string;
@@ -338,7 +347,7 @@ function payloadForegroundRecoveryPolicy(
 }
 
 function snapshotId(): string {
-  return `desktop_${Date.now().toString(36)}`;
+  return `desktop_${randomUUID()}`;
 }
 
 function requireAccessibility(
@@ -873,6 +882,14 @@ function indexAccessibilitySnapshot(
 function indexedAccessibilitySnapshot(
   snapshot: AccessibilityAppStateSnapshot,
 ): IndexedAccessibilitySnapshot {
+  if (snapshot.observation) {
+    if (!snapshot.elementIdsByIndex)
+      throw new ComputerUseNativeHelperError(
+        "accessibility_unavailable",
+        "CUA observation is missing its retained element index",
+      );
+    return { snapshot, elementIdsByIndex: snapshot.elementIdsByIndex };
+  }
   return indexAccessibilitySnapshot(snapshot);
 }
 
@@ -1214,6 +1231,14 @@ export function renderAccessibilityTree(
       ? `App=${appIdentity} (${appDetails.join(", ")})`
       : `App=${appIdentity}`,
   ];
+  if (indexed.observation) {
+    lines.push(
+      indexed.observation.text,
+      "Element coverage is incomplete.",
+      "</app_state>",
+    );
+    return lines.join("\n");
+  }
   const windowTitle =
     formatText(indexed.windowTitle) ?? formatText(indexed.elements[0]?.name);
   if (windowTitle) {
@@ -1367,7 +1392,15 @@ async function listApps(
       },
     );
   });
-  return { status: "succeeded", result: { apps } };
+  return {
+    status: "succeeded",
+    result: {
+      apps,
+      ...(nativeBackend.discoveryNote
+        ? { discoveryNote: nativeBackend.discoveryNote }
+        : {}),
+    },
+  };
 }
 
 async function getAppState(
@@ -1380,7 +1413,9 @@ async function getAppState(
   const helperStartedAt = Date.now();
   const rawSnapshot = await nativeBackend.getAppState(app, id, settle);
   const helperDurationMs = Date.now() - helperStartedAt;
-  const snapshot = normalizeAccessibilitySnapshot(rawSnapshot);
+  const snapshot = rawSnapshot.observation
+    ? rawSnapshot
+    : normalizeAccessibilitySnapshot(rawSnapshot);
   const indexed = indexedAccessibilitySnapshot(snapshot);
   const screenshot = nativeAppStateScreenshot(indexed.snapshot);
   if ("status" in screenshot) {
@@ -1424,6 +1459,36 @@ async function withPostActionAppState(args: {
   readonly nativeBackend: ComputerUseNativeBackend;
   readonly snapshotStore: ComputerUseSnapshotStore;
 }): Promise<ComputerUseCommandExecutionResult> {
+  if (args.actionResult.result.driver === "cua") {
+    try {
+      const observed = await getAppState(
+        args.app,
+        args.nativeBackend,
+        args.snapshotStore,
+        true,
+      );
+      return {
+        status: "succeeded",
+        result: {
+          ...(observed.status === "succeeded"
+            ? observed.result
+            : { observationError: observed.error }),
+          action: args.actionResult.result,
+        },
+      };
+    } catch (error) {
+      return {
+        status: "succeeded",
+        result: {
+          action: args.actionResult.result,
+          observationError: {
+            code: "accessibility_unavailable",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        },
+      };
+    }
+  }
   const appStateResult = await getAppState(
     args.app,
     args.nativeBackend,
@@ -1559,6 +1624,15 @@ function elementTargetText(target: ComputerUseElementTarget): string {
     : (target.elementId ?? "element");
 }
 
+function actionSummary(
+  result: Record<string, unknown>,
+  legacy: string,
+): string {
+  return result.driver === "cua" && typeof result.effect === "string"
+    ? `CUA action effect: ${result.effect}; inspect action evidence and post-state`
+    : legacy;
+}
+
 async function clickElement(args: {
   readonly app: string;
   readonly elementId: string | null;
@@ -1608,7 +1682,10 @@ async function clickElement(args: {
         button: args.button,
         clickCount: args.clickCount,
         ...nativeResult,
-        summary: `Clicked ${elementTargetText(target)}`,
+        summary: actionSummary(
+          nativeResult,
+          `Clicked ${elementTargetText(target)}`,
+        ),
       },
     };
   }
@@ -1647,7 +1724,7 @@ async function clickElement(args: {
         button: args.button,
         clickCount: args.clickCount,
         ...nativeResult,
-        summary: `Clicked ${args.x},${args.y}`,
+        summary: actionSummary(nativeResult, `Clicked ${args.x},${args.y}`),
       },
     };
   }
@@ -1677,7 +1754,7 @@ async function setElementValue(
       app,
       ...elementTargetResult(target),
       ...nativeResult,
-      summary: `Set ${elementTargetText(target)}`,
+      summary: actionSummary(nativeResult, `Set ${elementTargetText(target)}`),
     },
   };
 }
@@ -1704,7 +1781,7 @@ async function performElementAction(
       ...elementTargetResult(target),
       action,
       ...nativeResult,
-      summary: `Performed ${action}`,
+      summary: actionSummary(nativeResult, `Performed ${action}`),
     },
   };
 }
@@ -1727,7 +1804,7 @@ async function typeText(
     result: {
       app,
       ...result,
-      summary: "Typed text",
+      summary: actionSummary(result, "Typed text"),
     },
   };
 }
@@ -1752,7 +1829,7 @@ async function pressKey(
       app,
       key: normalizedKey,
       ...nativeResult,
-      summary: `Pressed ${normalizedKey}`,
+      summary: actionSummary(nativeResult, `Pressed ${normalizedKey}`),
     },
   };
 }
@@ -1782,7 +1859,10 @@ async function scrollElement(
       direction,
       pages,
       ...nativeResult,
-      summary: `Scrolled ${elementTargetText(target)}`,
+      summary: actionSummary(
+        nativeResult,
+        `Scrolled ${elementTargetText(target)}`,
+      ),
     },
   };
 }
@@ -1803,6 +1883,7 @@ export async function executeComputerUseCommand(
   try {
     const nativeBackend =
       dependencies.nativeBackend ?? createComputerUseNativeBackend();
+    nativeBackend.validateCommand?.(command);
     const snapshotStore =
       dependencies.snapshotStore ?? new ComputerUseSnapshotStore();
     const app = payloadString(command.payload, "app");
@@ -1890,14 +1971,19 @@ export async function executeComputerUseCommand(
       if (!direction) {
         return missingField("direction");
       }
-      const target = resolveElementTarget({
-        app,
-        elementId,
-        elementIndex,
-        snapshotId,
-        snapshotStore,
-        commandName: "element.scroll",
-      });
+      const target =
+        nativeBackend.supportsWindowScroll &&
+        !elementId &&
+        elementIndex === null
+          ? { ...(snapshotId ? { snapshotId } : {}) }
+          : resolveElementTarget({
+              app,
+              elementId,
+              elementIndex,
+              snapshotId,
+              snapshotStore,
+              commandName: "element.scroll",
+            });
       if ("status" in target) {
         return target;
       }
@@ -1921,8 +2007,10 @@ export async function executeComputerUseCommand(
       const elementId = payloadString(command.payload, "elementId");
       const elementIndex = payloadElementIndex(command.payload);
       const snapshotId = payloadString(command.payload, "snapshotId");
-      const value = payloadString(command.payload, "value");
-      if (!value) {
+      const value = nativeBackend.validateCommand
+        ? command.payload.value
+        : payloadString(command.payload, "value");
+      if (typeof value !== "string" || !value) {
         return missingField("value");
       }
       const target = resolveElementTarget({
@@ -1976,12 +2064,14 @@ export async function executeComputerUseCommand(
       });
     }
     if (command.kind === "keyboard.type_text") {
-      const text = payloadString(command.payload, "text");
+      const text = nativeBackend.validateCommand
+        ? command.payload.text
+        : payloadString(command.payload, "text");
       const snapshotId = payloadString(command.payload, "snapshotId");
       const foregroundRecovery = payloadForegroundRecoveryPolicy(
         command.payload,
       );
-      return text
+      return typeof text === "string" && text.length > 0
         ? await executeWriteActionWithPostActionState({
             app,
             permissions,

--- a/turbo/apps/desktop/src/computer-use-command-budget.ts
+++ b/turbo/apps/desktop/src/computer-use-command-budget.ts
@@ -1,0 +1,92 @@
+import { ComputerUseNativeHelperError } from "./computer-use-native";
+import type { ComputerUseCommand } from "./computer-use-accessibility";
+import type { ComputerUseLifecycleTimers } from "./computer-use-lifecycle-deadline";
+
+export interface ComputerUseCommandClock extends ComputerUseLifecycleTimers {
+  readonly wallNow: () => number;
+  readonly monotonicNow: () => number;
+}
+const systemClock: ComputerUseCommandClock = {
+  wallNow: () => Date.now(),
+  monotonicNow: () => performance.now(),
+  setTimeout,
+  clearTimeout,
+};
+
+/** Wire age is converted once; later clock adjustments cannot renew admission. */
+export class ComputerUseCommandBudget {
+  private readonly deadline: number;
+  private readonly reserve: number;
+  constructor(
+    command: ComputerUseCommand,
+    private readonly clock: ComputerUseCommandClock = systemClock,
+  ) {
+    const timeout = command.timeoutMs === null ? 120_000 : command.timeoutMs;
+    const created =
+      typeof command.createdAt === "string"
+        ? Date.parse(command.createdAt)
+        : NaN;
+    const claimed =
+      command.claimedAt === null
+        ? null
+        : typeof command.claimedAt === "string"
+          ? Date.parse(command.claimedAt)
+          : NaN;
+    const now = clock.wallNow();
+    // Malformed/future dates fail closed; claimedAt never restarts the budget.
+    const valid =
+      typeof timeout === "number" &&
+      Number.isInteger(timeout) &&
+      timeout >= 1000 &&
+      timeout <= 120_000 &&
+      Number.isFinite(created) &&
+      created <= now &&
+      (claimed === null ||
+        (Number.isFinite(claimed) && claimed >= created && claimed <= now));
+    const remaining = valid ? Math.max(0, timeout - (now - created)) : 0;
+    this.deadline = clock.monotonicNow() + remaining;
+    this.reserve = Math.min(1000, remaining / 10);
+  }
+  remaining(completion = false): number {
+    return Math.max(
+      0,
+      this.deadline -
+        this.clock.monotonicNow() -
+        (completion ? 0 : this.reserve),
+    );
+  }
+  async run<T>(operation: () => Promise<T>, expire: () => void): Promise<T> {
+    const remaining = this.remaining();
+    if (remaining <= 0)
+      throw new ComputerUseNativeHelperError(
+        "command_timeout",
+        "Computer Use command expired before dispatch; no native action was started",
+      );
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        operation().then((value) => {
+          if (this.remaining() <= 0) {
+            expire();
+            throw this.timeout();
+          }
+          return value;
+        }),
+        new Promise<never>((_resolve, reject) => {
+          timer = this.clock.setTimeout(() => {
+            expire();
+            reject(this.timeout());
+          }, remaining);
+        }),
+      ]);
+    } finally {
+      this.clock.clearTimeout(timer);
+    }
+  }
+  private timeout(): Error {
+    return new ComputerUseNativeHelperError(
+      "command_timeout",
+      "Computer Use total command budget expired; an action may have been delivered. Do not replay automatically; native retirement remains owned.",
+    );
+  }
+}

--- a/turbo/apps/desktop/src/computer-use-cua-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-cua-host.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, expect, it } from "vitest";
@@ -34,7 +34,11 @@ afterAll(() => server.close());
 async function desktop(
   granted = true,
   pluginEnabled = false,
-  options: { startupFailure?: boolean; stopDuringPreparation?: boolean } = {},
+  options: {
+    startupFailure?: boolean;
+    stopDuringPreparation?: boolean;
+    ignoreNetworkAbort?: boolean;
+  } = {},
 ) {
   const external = cuaBoundary();
   external.granted = granted;
@@ -52,7 +56,11 @@ async function desktop(
   const permissions = createComputerUsePermissions((read) =>
     driver.withPermissionProvider(read),
   );
-  const directory = await mkdtemp(path.join(tmpdir(), "cua-plugin-"));
+  // macOS TMPDIR can contain /var -> /private/var aliases; MCP authorizes
+  // canonical roots and validates the requested path before following symlinks.
+  const directory = await realpath(
+    await mkdtemp(path.join(tmpdir(), "cua-plugin-")),
+  );
   await writeFile(
     path.join(directory, "document.txt"),
     "plugin remains independent",
@@ -134,7 +142,13 @@ async function desktop(
           installationId: "00000000-0000-4000-8000-000000000001",
           hostName: "host",
           appVersion: "1.2.3",
-          hostFetch: (input, init) => fetch(input, init),
+          hostFetch: (input, init) =>
+            fetch(
+              input,
+              options.ignoreNetworkAbort
+                ? { ...init, signal: undefined }
+                : init,
+            ),
           addClientHeaders,
           getPermissions: permissions.refreshComputerUsePermissionState,
           getSupportedCapabilities: () => [
@@ -211,6 +225,13 @@ async function desktop(
         entered: claimEntered.promise,
         release: () => claimGate?.resolve(),
       };
+    },
+    expirePoll() {
+      const timer = [...timers.values()].find(
+        (timer) => timer.delay === 30_000,
+      );
+      if (!timer) throw new Error("No command poll deadline is scheduled");
+      timer.run();
     },
     advance(ms: number) {
       now += ms;
@@ -342,6 +363,30 @@ it("owns a late claim but refuses it when its original wire budget has expired",
   );
 });
 
+it("completes a late claim after network cancellation without dispatching its action", async () => {
+  const d = await desktop(true, false, { ignoreNetworkAbort: true });
+  const gate = d.delayClaim();
+  const completed = d.queue(
+    "app.open",
+    { app: "test.editor" },
+    { timeoutMs: 60_000 },
+  );
+  await gate.entered;
+  d.advance(31_000);
+  d.expirePoll();
+  gate.release();
+  expect(await completed).toMatchObject({
+    status: "failed",
+    error: {
+      code: "command_timeout",
+      message: expect.stringContaining("no native action was dispatched"),
+    },
+  });
+  expect(d.external.calls.some((call) => call.name === "launch_app")).toBe(
+    false,
+  );
+});
+
 it("preserves the existing plugin host and authorization when a selected replacement fails", async () => {
   const d = await desktop(true, true);
   await d.plugin.prepareForHost();
@@ -396,7 +441,7 @@ it.each([
   },
 );
 
-it.each(["check_permissions", "session", "get_window_state"])(
+it.each(["check_permissions", "session", "get_window_state", "launch_app"])(
   "expires one budget during %s and blocks late state publication",
   async (phase) => {
     const d = await desktop();
@@ -408,7 +453,10 @@ it.each(["check_permissions", "session", "get_window_state"])(
         await resume.promise;
       }
     };
-    const completed = d.queue("app.state", { app: "test.editor" });
+    const completed = d.queue(
+      phase === "launch_app" ? "app.open" : "app.state",
+      { app: "test.editor" },
+    );
     await entered.promise;
     d.expire();
     await d.external.stopEntered.promise;

--- a/turbo/apps/desktop/src/computer-use-cua-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-cua-host.test.ts
@@ -1,0 +1,438 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { ComputerUseDriverController } from "./computer-use-driver";
+import { createCuaComputerUseDriver } from "./computer-use-cua";
+import { ComputerUseRuntimeController } from "./computer-use-runtime-controller";
+import { createComputerUsePermissions } from "./computer-use-permissions";
+import { createDesktopComputerUseHostRuntime } from "./desktop-computer-use-api";
+import { DesktopAuthSession } from "./desktop-auth-session";
+import { DesktopFilesystemPluginManager } from "./desktop-filesystem-plugin";
+import { resolveDesktopConfig } from "./config";
+import { createDesktopClientHeaderInjector } from "./desktop-client-headers";
+import {
+  buildDesktopAuthConsumeUrl,
+  buildDesktopAuthSelectOrgUrl,
+  buildDesktopAuthTokenUrl,
+} from "./desktop-auth";
+import type { ComputerUseCommand } from "./computer-use-accessibility";
+import type { ComputerUseCommandClock } from "./computer-use-command-budget";
+import { cuaBoundary, deferred } from "./test/cua-boundary";
+
+const server = setupServer();
+const cleanups: (() => Promise<void>)[] = [];
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+async function desktop(
+  granted = true,
+  pluginEnabled = false,
+  options: { startupFailure?: boolean; stopDuringPreparation?: boolean } = {},
+) {
+  const external = cuaBoundary();
+  external.granted = granted;
+  const driver = new ComputerUseDriverController(
+    createCuaComputerUseDriver({
+      runtimeRoot: "/packaged/cua",
+      hostBundleId: "ai.okou.desktop",
+      loadSdk: async () => {
+        if (options.startupFailure) throw new Error("SDK load failed");
+        return external.sdk;
+      },
+    }),
+    "darwin",
+  );
+  const permissions = createComputerUsePermissions((read) =>
+    driver.withPermissionProvider(read),
+  );
+  const directory = await mkdtemp(path.join(tmpdir(), "cua-plugin-"));
+  await writeFile(
+    path.join(directory, "document.txt"),
+    "plugin remains independent",
+  );
+  let notify = () => {};
+  const plugin = new DesktopFilesystemPluginManager({
+    preferencesPath: path.join(directory, "preferences.json"),
+    onChange: () => notify(),
+  });
+  plugin.load();
+  plugin.setFeatureEnabled(pluginEnabled);
+  plugin.addAllowedDirectory(directory);
+  plugin.setEnabled(pluginEnabled);
+  const timers = new Map<
+    ReturnType<typeof setTimeout>,
+    { run: () => void; delay: number }
+  >();
+  const schedule = (run: () => void, delay: number) => {
+    const id = setTimeout(() => {}, 2 ** 30);
+    id.unref();
+    timers.set(id, { run, delay });
+    return id;
+  };
+  const clear: typeof clearTimeout = (id) => {
+    if (typeof id === "object") timers.delete(id);
+    clearTimeout(id);
+  };
+  let now = Date.now();
+  let monotonic = 0;
+  const budgetTimers = new Map<ReturnType<typeof setTimeout>, () => void>();
+  const commandClock: ComputerUseCommandClock = {
+    wallNow: () => now,
+    monotonicNow: () => monotonic,
+    setTimeout: (run, delay) => {
+      const id = schedule(run, delay);
+      budgetTimers.set(id, run);
+      return id;
+    },
+    clearTimeout: (id) => {
+      if (typeof id === "object") budgetTimers.delete(id);
+      clear(id);
+    },
+  };
+  const config = resolveDesktopConfig(undefined, "okou");
+  const api = "https://api.vm0.ai";
+  const cookies = { cookies: { get: async () => [] } };
+  const addClientHeaders = createDesktopClientHeaderInjector({
+    product: "okou",
+    clientVersion: "1.2.3",
+  });
+  const auth = new DesktopAuthSession({
+    product: "okou",
+    apiBaseUrl: api,
+    cookieUrls: [config.webUrl, config.platformUrl],
+    cookieSource: cookies,
+    addClientHeaders,
+    tokenUrl: buildDesktopAuthTokenUrl(config.authUrl),
+    selectOrgUrl: buildDesktopAuthSelectOrgUrl(config.authUrl, true),
+    consumeUrl: (code, id) =>
+      buildDesktopAuthConsumeUrl(config.authUrl, code, id),
+    runAuthWindow: async () => "token",
+  });
+  const requests: { path: string; body: Record<string, unknown> }[] = [];
+  let command: ComputerUseCommand | null = null;
+  let completion = deferred<Record<string, unknown>>();
+  let claimGate: ReturnType<typeof deferred<void>> | null = null;
+  const claimEntered = deferred<void>();
+  const controller = new ComputerUseRuntimeController({
+    driver,
+    refreshPermissions: permissions.refreshComputerUsePermissionState,
+    getAuthState: () => auth.getAuthState(),
+    setHostRuntimeOnline: (online) => plugin.setHostRuntimeOnline(online),
+    getPluginCapabilities: () => plugin.getCapabilities(),
+    preparePlugins: () => plugin.prepareForHost(),
+    createRuntime: () =>
+      createDesktopComputerUseHostRuntime(
+        {
+          platformUrl: config.platformUrl,
+          installationId: "00000000-0000-4000-8000-000000000001",
+          hostName: "host",
+          appVersion: "1.2.3",
+          hostFetch: (input, init) => fetch(input, init),
+          addClientHeaders,
+          getPermissions: permissions.refreshComputerUsePermissionState,
+          getSupportedCapabilities: () => [
+            ...driver.getCapabilities(),
+            ...plugin.getCapabilities(),
+          ],
+          driver,
+          executePluginCommand: (command) => plugin.execute(command),
+          setTimeout: schedule,
+          clearTimeout: clear,
+          commandClock,
+        },
+        { product: "okou", session: cookies, getAuthSession: () => auth },
+      ),
+  });
+  notify = () => {
+    plugin.setHostRuntimeOnline(controller.pluginsMayRun());
+    if (
+      options.stopDuringPreparation &&
+      plugin.getState().status === "starting"
+    )
+      void controller.stop();
+  };
+  server.use(
+    http.all(`${api}/*`, async ({ request }) => {
+      const url = new URL(request.url);
+      const body =
+        request.method === "POST"
+          ? ((await request.json()) as Record<string, unknown>)
+          : {};
+      requests.push({ path: url.pathname, body });
+      if (url.pathname === "/api/auth/me")
+        return HttpResponse.json({
+          userId: "user",
+          email: "test@example.test",
+          orgId: "org",
+        });
+      if (url.pathname === "/api/org")
+        return HttpResponse.json({ id: "org", name: "Workspace" });
+      if (url.pathname.endsWith("/hosts/start"))
+        return HttpResponse.json({ hostId: "host", hostToken: "host-token" });
+      if (url.pathname.endsWith("/next")) {
+        const next = command;
+        command = null;
+        if (next && claimGate) {
+          claimEntered.resolve();
+          await claimGate.promise;
+        }
+        return HttpResponse.json(
+          next ? { status: "command", command: next } : { status: "idle" },
+        );
+      }
+      if (url.pathname.endsWith("/complete")) completion.resolve(body);
+      return HttpResponse.json({ ok: true });
+    }),
+  );
+  cleanups.push(async () => {
+    await controller.stopForQuit();
+    plugin.setHostRuntimeOnline(false);
+    for (const id of timers.keys()) clear(id);
+    await rm(directory, { recursive: true, force: true });
+  });
+  await controller.start();
+  return {
+    external,
+    driver,
+    controller,
+    requests,
+    directory,
+    plugin,
+    delayClaim() {
+      claimGate = deferred();
+      return {
+        entered: claimEntered.promise,
+        release: () => claimGate?.resolve(),
+      };
+    },
+    advance(ms: number) {
+      now += ms;
+      monotonic += ms;
+    },
+    expire() {
+      monotonic += 120_000;
+      for (const run of budgetTimers.values()) run();
+    },
+    queue(
+      kind: string,
+      payload: Record<string, unknown>,
+      metadata: Partial<ComputerUseCommand> = {},
+    ) {
+      completion = deferred();
+      command = {
+        id: "command",
+        kind,
+        payload,
+        timeoutMs: 30_000,
+        createdAt: new Date(now).toISOString(),
+        claimedAt: null,
+        ...metadata,
+      };
+      const poll = [...timers].find(
+        ([, timer]) =>
+          timer.delay === 5000 || timer.delay === 0 || timer.delay === 500,
+      );
+      if (!poll) throw new Error("No native/plugin claim admitted");
+      clear(poll[0]);
+      poll[1].run();
+      return completion.promise;
+    },
+  };
+}
+
+it("starts and completes real filesystem plugin work without native TCC or a native lease", async () => {
+  const d = await desktop(false, true);
+  expect(d.controller.getHostState().status).toBe("online");
+  const registration = d.requests.find((request) =>
+    request.path.endsWith("/hosts/start"),
+  );
+  expect(registration?.body.supportedCapabilities).not.toEqual([]);
+  expect(registration?.body.supportedCapabilities).not.toContain("app.state");
+  expect(d.driver.getCapabilities()).toEqual([]);
+  const before = d.external.calls.length;
+  const completed = await d.queue("plugin.call", {
+    plugin: "filesystem",
+    tool: "read_text_file",
+    arguments: { path: path.join(d.directory, "document.txt") },
+  });
+  expect(completed.status).toBe("succeeded");
+  expect(JSON.stringify(completed)).toContain("plugin remains independent");
+  expect(d.external.calls.slice(before)).toEqual([]);
+  expect(d.external.sessions).toBe(0);
+});
+
+it("does not register a capability-empty host", async () => {
+  const d = await desktop(false);
+  expect(d.controller.getHostState().status).toBe("offline");
+  expect(
+    d.requests.some((request) => request.path.endsWith("/hosts/start")),
+  ).toBe(false);
+});
+
+it("keeps an authorized plugin-only host after CUA startup failure", async () => {
+  const d = await desktop(true, true, { startupFailure: true });
+  expect(d.controller.getHostState().status).toBe("online");
+  expect(d.driver.getCapabilities()).toEqual([]);
+  expect(
+    await d.queue("plugin.call", {
+      plugin: "filesystem",
+      tool: "read_text_file",
+      arguments: { path: path.join(d.directory, "document.txt") },
+    }),
+  ).toMatchObject({ status: "succeeded" });
+});
+
+it("does not revive a plugin or host when Stop supersedes plugin-only preparation", async () => {
+  const d = await desktop(false, true, { stopDuringPreparation: true });
+  expect(d.controller.getHostState().status).toBe("offline");
+  expect(d.plugin.getState().status).toBe("disabled");
+  expect(d.plugin.getCapabilities()).toEqual([]);
+  expect(d.requests.some((r) => r.path.endsWith("/hosts/start"))).toBe(false);
+});
+
+it.each(["lost grants", "unexpected exit"])(
+  "keeps plugin ownership after %s withdraws native capabilities",
+  async (failure) => {
+    const d = await desktop(true, true);
+    await d.plugin.prepareForHost();
+    if (failure === "lost grants") {
+      d.external.granted = false;
+      await d.driver.withPermissionProvider((provider) =>
+        provider.getPermissions(),
+      );
+    } else {
+      d.external.crash();
+      await d.external.stopEntered.promise;
+    }
+    expect(d.driver.getCapabilities()).toEqual([]);
+    const completed = await d.queue("plugin.call", {
+      plugin: "filesystem",
+      tool: "read_text_file",
+      arguments: { path: path.join(d.directory, "document.txt") },
+    });
+    expect(completed.status).toBe("succeeded");
+    expect(d.controller.getHostState().status).toBe("online");
+    expect(
+      d.requests.filter((r) => r.path.endsWith("/next")).at(-1)?.body
+        .supportedCapabilities,
+    ).not.toContain("app.state");
+  },
+);
+
+it("owns a late claim but refuses it when its original wire budget has expired", async () => {
+  const d = await desktop();
+  const gate = d.delayClaim();
+  const completed = d.queue("app.open", { app: "test.editor" });
+  await gate.entered;
+  d.advance(31_000);
+  gate.release();
+  expect(await completed).toMatchObject({
+    status: "failed",
+    error: { code: "command_timeout" },
+  });
+  expect(d.external.calls.some((call) => call.name === "launch_app")).toBe(
+    false,
+  );
+});
+
+it("preserves the existing plugin host and authorization when a selected replacement fails", async () => {
+  const d = await desktop(true, true);
+  await d.plugin.prepareForHost();
+  await expect(
+    d.controller.transitionDriver(
+      createCuaComputerUseDriver({
+        runtimeRoot: "/packaged/cua",
+        hostBundleId: "ai.okou.desktop",
+        loadSdk: async () => {
+          throw new Error("replacement unavailable");
+        },
+      }),
+    ),
+  ).rejects.toThrow();
+  expect(d.driver.getCapabilities()).toEqual([]);
+  expect(
+    await d.queue("plugin.call", {
+      plugin: "filesystem",
+      tool: "read_text_file",
+      arguments: { path: path.join(d.directory, "document.txt") },
+    }),
+  ).toMatchObject({ status: "succeeded" });
+  expect(
+    d.requests.filter((r) => r.path.endsWith("/hosts/start")),
+  ).toHaveLength(1);
+  expect(d.requests.some((r) => r.path.endsWith("/host/stop"))).toBe(false);
+});
+
+it.each([
+  { timeoutMs: 30_000, age: 30_001 },
+  { timeoutMs: 60_000, age: 60_001 },
+  { timeoutMs: null, age: 120_001 },
+  { timeoutMs: 30_000, age: 0, createdAt: "malformed" },
+])(
+  "refuses an expired/malformed wire budget before permission or action ($timeoutMs)",
+  async ({ timeoutMs, age, createdAt }) => {
+    const d = await desktop();
+    const before = d.external.calls.length;
+    const completed = await d.queue(
+      "app.open",
+      { app: "test.editor" },
+      {
+        timeoutMs,
+        createdAt: createdAt ?? new Date(Date.now() - age - 1000).toISOString(),
+      },
+    );
+    expect(completed).toMatchObject({
+      status: "failed",
+      error: { code: "command_timeout" },
+    });
+    expect(d.external.calls.slice(before)).toEqual([]);
+  },
+);
+
+it.each(["check_permissions", "session", "get_window_state"])(
+  "expires one budget during %s and blocks late state publication",
+  async (phase) => {
+    const d = await desktop();
+    const entered = deferred<void>();
+    const resume = deferred<void>();
+    d.external.intercept = async (name) => {
+      if (name === phase) {
+        entered.resolve();
+        await resume.promise;
+      }
+    };
+    const completed = d.queue("app.state", { app: "test.editor" });
+    await entered.promise;
+    d.expire();
+    await d.external.stopEntered.promise;
+    expect(await completed).toMatchObject({
+      status: "failed",
+      error: { code: "command_timeout" },
+    });
+    expect(d.driver.getCapabilities()).toEqual([]);
+    expect(d.external.destroyed).toBe(false);
+    resume.resolve();
+    await d.driver.retire();
+    expect(d.external.destroyed).toBe(true);
+  },
+);
+
+it("charges discovery time against action and post-state without resetting a 30-second CLI budget", async () => {
+  const d = await desktop();
+  d.external.intercept = async (name) => {
+    if (name === "list_apps") d.advance(31_000);
+  };
+  const completed = await d.queue("app.open", { app: "test.editor" });
+  expect(completed).toMatchObject({
+    status: "failed",
+    error: { code: "command_timeout" },
+  });
+  expect(d.driver.getCapabilities()).toEqual([]);
+});

--- a/turbo/apps/desktop/src/computer-use-cua.test.ts
+++ b/turbo/apps/desktop/src/computer-use-cua.test.ts
@@ -1,0 +1,385 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createCuaComputerUseDriver } from "./computer-use-cua";
+import { ComputerUseDriverController } from "./computer-use-driver";
+import { cuaBoundary, deferred } from "./test/cua-boundary";
+import type { ComputerUseCommandExecutionResult } from "./computer-use-accessibility";
+
+const cleanups: (() => Promise<void>)[] = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+});
+async function desktop() {
+  const external = cuaBoundary();
+  const definition = createCuaComputerUseDriver({
+    runtimeRoot: "/packaged/cua",
+    hostBundleId: "ai.okou.desktop",
+    loadSdk: async () => external.sdk,
+  });
+  const driver = new ComputerUseDriverController(definition, "darwin");
+  await driver.withPermissionProvider((provider) => provider.getPermissions());
+  driver.activate();
+  cleanups.push(() => driver.retire());
+  const execute = async (
+    kind: string,
+    payload: Record<string, unknown> = {},
+  ) => {
+    const session = driver.acquireCommand();
+    try {
+      return await session.executeCommand(
+        { id: "command", kind, payload },
+        await session.getPermissions(),
+      );
+    } finally {
+      session.release();
+    }
+  };
+  return {
+    external,
+    driver,
+    definition,
+    execute,
+    observe: () => execute("app.state", { app: "test.editor" }),
+  };
+}
+function result(
+  value: ComputerUseCommandExecutionResult,
+): Record<string, unknown> {
+  expect(value.status).toBe("succeeded");
+  if (value.status !== "succeeded") throw new Error(value.error.message);
+  return value.result;
+}
+
+describe("host-owned CUA adapter and shared executor", () => {
+  it("executes all nine command kinds with one session and exact public tool mapping", async () => {
+    const d = await desktop();
+    const apps = result(await d.execute("apps.list"));
+    expect(apps).toMatchObject({
+      discoveryNote: expect.stringContaining("~/Applications"),
+      apps: expect.arrayContaining([
+        expect.objectContaining({
+          bundleId: "test.installed",
+          pid: 0,
+          running: false,
+        }),
+      ]),
+    });
+    let state = result(await d.execute("app.open", { app: "test.editor" }));
+    expect(state.action).toMatchObject({ driver: "cua", launch: { pid: 123 } });
+    state = result(await d.observe());
+    expect(state.appState).toContain("Read-only invoice total: 123 元");
+    expect(state.appState).toContain("[1] Save");
+    for (const [kind, payload] of [
+      ["element.click", { elementIndex: 1 }],
+      ["element.set_value", { elementIndex: 0, value: "你好 🌍\n value " }],
+      ["element.perform_action", { elementIndex: 1, action: "AXConfirm" }],
+      ["keyboard.type_text", { text: " 中文 👩🏽‍💻\n " }],
+      ["keyboard.press_key", { key: "Command+Shift+A" }],
+      ["element.scroll", { direction: "down", pages: 2 }],
+    ] satisfies [string, Record<string, unknown>][]) {
+      state = result(
+        await d.execute(kind, {
+          app: "test.editor",
+          snapshotId: state.snapshotId,
+          ...payload,
+        }),
+      );
+      expect(state.action).toMatchObject({
+        effect: "unverifiable",
+        driver: "cua",
+        summary: expect.stringContaining("unverifiable"),
+      });
+    }
+    expect(d.external.sessions).toBe(1);
+    expect(
+      d.external.calls.find((call) => call.name === "type_text")?.args.text,
+    ).toBe(" 中文 👩🏽‍💻\n ");
+    expect(
+      d.external.calls.find((call) => call.name === "press_key")?.args,
+    ).toMatchObject({
+      pid: 123,
+      window_id: 42,
+      key: "a",
+      modifiers: ["cmd", "shift"],
+    });
+    expect(
+      d.external.calls.find((call) => call.name === "scroll")?.args,
+    ).toMatchObject({ amount: 2, by: "page" });
+  });
+
+  it.each(["never", "on-window-unavailable", "always"])(
+    "honors %s without retrying an uncertain action",
+    async (foregroundRecovery) => {
+      const d = await desktop();
+      const state = result(await d.observe());
+      const done = result(
+        await d.execute("element.click", {
+          app: "test.editor",
+          snapshotId: state.snapshotId,
+          elementIndex: 1,
+          foregroundRecovery,
+        }),
+      );
+      expect(done.action).toMatchObject({ effect: "unverifiable" });
+      const clicks = d.external.calls.filter((call) => call.name === "click");
+      expect(clicks).toHaveLength(1);
+      expect(clicks[0]?.args.delivery_mode).toBe(
+        foregroundRecovery === "always" ? "foreground" : "background",
+      );
+    },
+  );
+
+  it.each([
+    ["element.perform_action", { elementIndex: 1, action: "AXRaise" }],
+    ["element.perform_action", { elementIndex: 1, action: "toString" }],
+    [
+      "element.set_value",
+      {
+        app: "com.google.Chrome",
+        elementIndex: 0,
+        value: "https://example.test",
+      },
+    ],
+    ["element.click", { elementIndex: 1, clickCount: 2 }],
+    ["element.click", { x: 12, y: 12, button: "invalid" }],
+    ["element.scroll", { direction: "down", pages: 0.5 }],
+    ["element.scroll", { direction: "down", pages: 1, elementIndex: 1 }],
+    ["keyboard.press_key", { key: "cmd+not-a-key" }],
+    ["keyboard.type_text", { text: "text</invoke>" }],
+  ])(
+    "refuses unsupported %s before actuator dispatch",
+    async (kind, payload) => {
+      const d = await desktop();
+      const state = result(await d.observe());
+      const before = d.external.calls.length;
+      expect(
+        await d.execute(kind, {
+          app: "test.editor",
+          snapshotId: state.snapshotId,
+          ...payload,
+        }),
+      ).toMatchObject({
+        status: "failed",
+        error: { code: "unsupported_command" },
+      });
+      expect(
+        d.external.calls
+          .slice(before)
+          .every((call) =>
+            ["check_permissions", "list_apps", "list_windows"].includes(
+              call.name,
+            ),
+          ),
+      ).toBe(true);
+    },
+  );
+
+  it("invalidates raw IDs and numeric indexes when the same window is re-observed", async () => {
+    const d = await desktop();
+    const old = result(await d.observe());
+    const fresh = result(await d.observe());
+    const oldIds = old.elementIdsByIndex as string[];
+    for (const target of [
+      { elementId: oldIds[0] },
+      { snapshotId: old.snapshotId, elementIndex: 0 },
+      { elementIndex: 0 },
+    ]) {
+      expect(
+        await d.execute("element.click", { app: "test.editor", ...target }),
+      ).toMatchObject({ status: "failed" });
+    }
+    result(
+      await d.execute("element.click", {
+        app: "test.editor",
+        snapshotId: fresh.snapshotId,
+        elementIndex: 0,
+      }),
+    );
+    expect(
+      d.external.calls.find((call) => call.name === "click")?.args
+        .element_token,
+    ).toBe("opaque-field-2");
+  });
+
+  it("cannot resurrect raw IDs after switching away and back to CUA", async () => {
+    const d = await desktop();
+    const old = result(await d.observe());
+    await d.driver.retire();
+    const fresh = cuaBoundary();
+    d.driver.select(
+      createCuaComputerUseDriver({
+        runtimeRoot: "/packaged/cua",
+        hostBundleId: "ai.okou.desktop",
+        loadSdk: async () => fresh.sdk,
+      }),
+    );
+    await d.driver.withPermissionProvider((provider) =>
+      provider.getPermissions(),
+    );
+    d.driver.activate();
+    result(await d.observe());
+    const ids = old.elementIdsByIndex as string[];
+    expect(
+      await d.execute("element.click", {
+        app: "test.editor",
+        elementId: ids[0],
+      }),
+    ).toMatchObject({ status: "failed" });
+    expect(fresh.calls.some((call) => call.name === "click")).toBe(false);
+  });
+
+  it.each([1, 2])(
+    "retains %sx geometry through upstream resizing and derives request coordinates once",
+    async (scale) => {
+      const d = await desktop();
+      d.external.scale = scale;
+      d.external.resize = 0.5;
+      let state = result(await d.observe());
+      for (const [button, clickCount] of [
+        ["left", 2],
+        ["right", 1],
+        ["middle", 1],
+      ] as const) {
+        state = result(
+          await d.execute("element.click", {
+            app: "test.editor",
+            snapshotId: state.snapshotId,
+            x: 100,
+            y: 50,
+            button,
+            clickCount,
+          }),
+        );
+        expect(state.action).toMatchObject({
+          screenX: 10 + 200 / scale,
+          screenY: 20 + 100 / scale,
+          coordinateSource: "retained_request_frame",
+        });
+      }
+      expect(
+        d.external.calls.find((call) => call.name === "click")?.args,
+      ).toMatchObject({ x: 100, y: 50, scope: "window" });
+    },
+  );
+
+  it.each(["pid", "window", "moved", "scaled", "display-scale"])(
+    "refuses changed %s ownership/frame",
+    async (change) => {
+      const d = await desktop();
+      const state = result(await d.observe());
+      if (change === "pid") d.external.pid = 124;
+      if (change === "window") d.external.windowId = 43;
+      if (change === "moved")
+        d.external.bounds = { x: 30, y: 20, width: 800, height: 600 };
+      if (change === "scaled")
+        d.external.bounds = { x: 10, y: 20, width: 900, height: 600 };
+      if (change === "display-scale") d.external.scale = 1;
+      expect(
+        await d.execute("element.click", {
+          app: "test.editor",
+          snapshotId: state.snapshotId,
+          x: 100,
+          y: 50,
+        }),
+      ).toMatchObject({ status: "failed" });
+      expect(d.external.calls.some((call) => call.name === "click")).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each([
+    {
+      effect: "confirmed",
+      route: "accessibility",
+      evidence: [{ kind: "value_readback" }],
+    },
+    {
+      effect: "partial",
+      route: "synthetic_events",
+      delivery: { mode: "background", delivered_count: 2 },
+    },
+    { effect: "suspected_noop", route: "accessibility" },
+    { effect: "refused", route: "accessibility" },
+  ])("retains $effect action facts through post-state", async (facts) => {
+    const d = await desktop();
+    d.external.effect = facts;
+    const state = result(await d.observe());
+    const completed = await d.execute("element.click", {
+      app: "test.editor",
+      snapshotId: state.snapshotId,
+      elementIndex: 1,
+    });
+    if (facts.effect === "refused")
+      expect(completed).toMatchObject({
+        status: "failed",
+        error: {
+          code: "element_action_unsupported",
+          message: expect.stringContaining('"effect":"refused"'),
+        },
+      });
+    else expect(result(completed).action).toMatchObject(facts);
+  });
+
+  it("preserves partial delivery when post-action capture fails", async () => {
+    const d = await desktop();
+    const state = result(await d.observe());
+    d.external.effect = {
+      effect: "partial",
+      route: "synthetic_events",
+      delivery: { mode: "background", delivered_count: 1 },
+    };
+    d.external.intercept = async (name) => {
+      if (name === "get_window_state") throw new Error("capture failed");
+    };
+    const completed = result(
+      await d.execute("element.click", {
+        app: "test.editor",
+        snapshotId: state.snapshotId,
+        elementIndex: 1,
+      }),
+    );
+    expect(completed).toMatchObject({
+      action: { effect: "partial" },
+      observationError: { code: "accessibility_unavailable" },
+    });
+    expect(d.driver.getCapabilities()).toEqual([]);
+  });
+
+  it.each(["check_permissions", "session", "click", "get_window_state", "end"])(
+    "stops independently of a hung %s and retains cleanup ownership until its late callback settles",
+    async (phase) => {
+      const d = await desktop();
+      let state: Record<string, unknown> = {};
+      if (!["session", "check_permissions"].includes(phase))
+        state = result(await d.observe());
+      const entered = deferred<void>();
+      const release = deferred<void>();
+      d.external.intercept = async (name) => {
+        if (name === phase) {
+          entered.resolve();
+          await release.promise;
+        }
+      };
+      const operation =
+        phase === "end"
+          ? d.driver.retire()
+          : d.execute(phase === "click" ? "element.click" : "app.state", {
+              app: "test.editor",
+              snapshotId: state.snapshotId,
+              elementIndex: phase === "click" ? 1 : undefined,
+            });
+      await entered.promise;
+      const retirement = d.driver.forceRetire();
+      await d.external.stopEntered.promise;
+      await d.external.exited;
+      expect(d.external.live).toBe(false);
+      expect(d.external.destroyed).toBe(false);
+      expect(() => d.driver.select(d.definition)).toThrow();
+      release.resolve();
+      await Promise.allSettled([operation, retirement]);
+      expect(d.external.destroyed).toBe(true);
+      expect(d.driver.getCapabilities()).toEqual([]);
+      expect(() => d.driver.acquireCommand()).toThrow();
+    },
+  );
+});

--- a/turbo/apps/desktop/src/computer-use-cua.test.ts
+++ b/turbo/apps/desktop/src/computer-use-cua.test.ts
@@ -287,6 +287,54 @@ describe("host-owned CUA adapter and shared executor", () => {
     },
   );
 
+  it("refuses coordinates when a fresh screenshot frame is invalid", async () => {
+    const d = await desktop();
+    const state = result(await d.observe());
+    d.external.observation = { screenshot_frame_valid: false };
+    expect(
+      await d.execute("element.click", {
+        app: "test.editor",
+        snapshotId: state.snapshotId,
+        x: 100,
+        y: 50,
+      }),
+    ).toMatchObject({
+      status: "failed",
+      error: { code: "window_unavailable" },
+    });
+    expect(d.external.calls.some((call) => call.name === "click")).toBe(false);
+    expect(
+      await d.execute("element.click", {
+        app: "test.editor",
+        snapshotId: state.snapshotId,
+        elementIndex: 0,
+      }),
+    ).toMatchObject({ status: "failed" });
+  });
+
+  it("preserves read-only text and incomplete coverage when AX window scope is unresolved", async () => {
+    const d = await desktop();
+    d.external.observation = {
+      elements: [],
+      snapshot_id: undefined,
+      tree_markdown: "Read-only invoice total: 123 元",
+      degraded_reason: "ax_window_unresolved",
+    };
+    const state = result(await d.observe());
+    expect(state.appState).toContain("Read-only invoice total: 123 元");
+    expect(state.appState).toContain("Element coverage is incomplete");
+    expect(state.elementIdsByIndex).toEqual([]);
+    expect(JSON.stringify(state)).toContain("ax_window_unresolved");
+    expect(
+      await d.execute("element.click", {
+        app: "test.editor",
+        snapshotId: state.snapshotId,
+        elementIndex: 0,
+      }),
+    ).toMatchObject({ status: "failed" });
+    expect(d.external.calls.some((call) => call.name === "click")).toBe(false);
+  });
+
   it.each([
     {
       effect: "confirmed",

--- a/turbo/apps/desktop/src/computer-use-cua.ts
+++ b/turbo/apps/desktop/src/computer-use-cua.ts
@@ -1,0 +1,728 @@
+import { randomUUID } from "node:crypto";
+import type { ToolResult } from "@trycua/cua-driver";
+import { CuaEmbeddedRuntime } from "./cua-runtime";
+import { withComputerUseDeadline } from "./computer-use-lifecycle-deadline";
+import type { ComputerUseCommandBudget } from "./computer-use-command-budget";
+import type { ComputerUseDriver } from "./computer-use-driver";
+import {
+  ComputerUseNativeHelperError,
+  type ComputerUseNativeBackend,
+  type ComputerUseNativeForegroundRecoveryPolicy,
+} from "./computer-use-native";
+import type {
+  AccessibilityAppStateSnapshot,
+  AccessibilityElementSnapshot,
+  ComputerUseCommand,
+  ComputerUseCoordinateBounds,
+} from "./computer-use-accessibility";
+import {
+  actionFacts,
+  arrayField,
+  boundsField,
+  integer,
+  normalizeKey,
+  readResult,
+  record,
+  refuse,
+  structured,
+  textField,
+} from "./cua-adapter-contract";
+
+const DISCOVERY_NOTE =
+  "CUA 0.23.2 uses a private child home to keep standalone history opt-in isolated. Running apps and system application directories are enumerated; the real user's ~/Applications is outside installed-app discovery.";
+type Tool =
+  | "list_apps"
+  | "launch_app"
+  | "list_windows"
+  | "get_window_state"
+  | "click"
+  | "set_value"
+  | "type_text"
+  | "press_key"
+  | "scroll";
+type ElementRequest = {
+  readonly app: string;
+  readonly elementId?: string;
+  readonly snapshotId?: string;
+};
+interface App {
+  readonly name: string;
+  readonly bundleId?: string;
+  readonly appPath?: string;
+  readonly running: boolean;
+  readonly pid: number;
+}
+interface Window {
+  readonly pid: number;
+  readonly windowId: number;
+  readonly title: string;
+  readonly bounds: ComputerUseCoordinateBounds;
+}
+interface Observation {
+  readonly app: App;
+  readonly window: Window;
+  readonly snapshotId: string;
+  readonly cuaSnapshot: string | null;
+  readonly tokens: ReadonlyMap<string, string>;
+  readonly width: number;
+  readonly height: number;
+  readonly scale: number;
+}
+
+/** Internal factory only. The normal main registry intentionally remains Okou-only. */
+export function createCuaComputerUseDriver(
+  options: ConstructorParameters<typeof CuaEmbeddedRuntime>[0],
+): ComputerUseDriver {
+  return {
+    id: "cua",
+    createBackend: () =>
+      new CuaComputerUseBackend(new CuaEmbeddedRuntime(options)),
+  };
+}
+
+class CuaComputerUseBackend implements ComputerUseNativeBackend {
+  readonly supportsWindowScroll = true;
+  readonly discoveryNote = DISCOVERY_NOTE;
+  private observation: Observation | null = null;
+  private retired = false;
+  private granted = false;
+  private budget: ComputerUseCommandBudget | null = null;
+  setCommandBudget = (budget: ComputerUseCommandBudget | null) => {
+    this.budget = budget;
+  };
+  constructor(private readonly runtime: CuaEmbeddedRuntime) {}
+
+  isAvailable = () =>
+    !this.retired && this.granted && this.runtime.getState().phase === "ready";
+  forceStop = (): Promise<void> => {
+    this.retired = true;
+    this.granted = false;
+    this.observation = null;
+    return this.runtime.dispose();
+  };
+  dispose = (): Promise<void> => this.forceStop();
+
+  private assertLive(): void {
+    if (this.budget && this.budget.remaining() <= 0) {
+      void this.forceStop().catch(() => {});
+      throw new ComputerUseNativeHelperError(
+        "command_timeout",
+        "CUA total command budget expired; completion may be unknown, do not replay",
+      );
+    }
+    if (!this.isAvailable())
+      throw new ComputerUseNativeHelperError(
+        "accessibility_unavailable",
+        "CUA generation is unavailable; explicit recovery is required",
+      );
+  }
+
+  getPermissions = async () => {
+    if (this.retired) return { accessibility: false, screenRecording: false };
+    await this.runtime.start();
+    const result = await withComputerUseDeadline(
+      this.runtime.useClient((client, signal) =>
+        client.callTool(
+          "check_permissions",
+          '{"prompt":false,"probe_direct_capture":false}',
+          { signal },
+        ),
+      ),
+      Math.min(5000, this.budget?.remaining() ?? 5000),
+    ).catch((error: unknown) => {
+      void this.forceStop().catch(() => {});
+      throw error;
+    });
+    const data = readResult(result);
+    if (
+      typeof data.accessibility !== "boolean" ||
+      typeof data.screen_recording !== "boolean" ||
+      record(data.source).attribution !== "host"
+    )
+      throw new ComputerUseNativeHelperError(
+        "permission_denied",
+        "CUA permission attribution is incompatible",
+      );
+    const permissions = {
+      accessibility: data.accessibility,
+      screenRecording: data.screen_recording,
+    };
+    const revoked =
+      this.granted &&
+      !(permissions.accessibility && permissions.screenRecording);
+    this.granted = permissions.accessibility && permissions.screenRecording;
+    if (revoked) void this.forceStop().catch(() => {}); // Runtime retains failed cleanup ownership.
+    return permissions;
+  };
+  requestAccessibilityPermission = () => this.getPermissions();
+  requestScreenRecordingPermission = () => this.getPermissions();
+  probeAutomationPermission = async () => ({
+    status: "unknown" as const,
+    updatedAt: null,
+    reason: "CUA does not use the Okou browser Apple Events helper",
+  });
+
+  validateCommand = (command: ComputerUseCommand): void => {
+    this.assertLive();
+    const p = command.payload;
+    if (
+      (p.snapshotId !== undefined &&
+        this.observation?.snapshotId !== p.snapshotId) ||
+      (p.elementIndex !== undefined && p.snapshotId === undefined)
+    )
+      refuse("CUA index targeting requires the current snapshotId; re-observe");
+    if (
+      command.kind !== "apps.list" &&
+      (typeof p.app !== "string" ||
+        p.app.length > 256 ||
+        !/^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)+$/.test(p.app))
+    )
+      refuse("CUA requires an exact application bundle ID");
+    if (command.kind === "element.click") {
+      const count = p.clickCount ?? 1;
+      const button = p.button ?? "left";
+      if (
+        ![1, 2].includes(Number(count)) ||
+        typeof count !== "number" ||
+        !["left", "right", "middle"].includes(String(button))
+      )
+        refuse(
+          "CUA supports single/double coordinate clicks and single left AX clicks",
+        );
+      if (
+        (p.elementId !== undefined || p.elementIndex !== undefined) &&
+        (count !== 1 || button !== "left")
+      )
+        refuse(
+          "CUA AX click requires one left click; observe and use coordinates for other clicks",
+        );
+      if (p.x !== undefined || p.y !== undefined) {
+        if (!this.observation || p.snapshotId !== this.observation.snapshotId)
+          refuse(
+            "CUA coordinates require the retained snapshotId; re-observe the window",
+          );
+      }
+    }
+    if (
+      command.kind === "element.scroll" &&
+      (p.elementId !== undefined ||
+        p.elementIndex !== undefined ||
+        !["up", "down"].includes(String(p.direction)) ||
+        !Number.isInteger(p.pages ?? 1) ||
+        Number(p.pages ?? 1) < 1 ||
+        Number(p.pages ?? 1) > 25)
+    )
+      refuse(
+        "CUA supports 1-25 whole vertical pages of the focused window only; targeted/fractional scroll is unsupported",
+      );
+    for (const key of ["text", "value"] as const) {
+      if (
+        p[key] !== undefined &&
+        (typeof p[key] !== "string" ||
+          p[key].length === 0 ||
+          p[key].length > 64_000)
+      )
+        refuse("CUA text/value must contain 1-64000 characters");
+    }
+    if (
+      typeof p.text === "string" &&
+      /<\/(?:text|parameter|invoke|function_calls|function_call|tool_use|tool_call|antml:parameter|antml:invoke|antml:function_calls)>\s*$/i.test(
+        p.text,
+      )
+    )
+      refuse(
+        "CUA may strip trailing protocol tags; this text shape is unsupported",
+      );
+  };
+
+  private async tool(
+    name: Tool,
+    args: Record<string, unknown>,
+  ): Promise<ToolResult> {
+    this.assertLive();
+    try {
+      const session = await this.runtime.ensureSession();
+      this.assertLive();
+      return await this.runtime.useClient((client, signal) =>
+        client.callTool(
+          name,
+          JSON.stringify({
+            ...args,
+            ...(["list_apps", "launch_app", "list_windows"].includes(name)
+              ? {}
+              : { session }),
+          }),
+          { signal },
+        ),
+      );
+    } catch {
+      void this.forceStop().catch(() => {});
+      throw new ComputerUseNativeHelperError(
+        "accessibility_unavailable",
+        "CUA transport failed; action completion may be unknown, do not replay; generation retirement remains owned",
+      );
+    }
+  }
+
+  listApps = async (): Promise<App[]> => {
+    const data = readResult(await this.tool("list_apps", {}));
+    return arrayField(data.apps, 10_000).map((item) => {
+      const app = record(item);
+      if (typeof app.running !== "boolean")
+        refuse("CUA app running state is invalid");
+      const pid = integer(app.pid);
+      if (app.running && pid === 0) refuse("CUA running app has no live PID");
+      return {
+        name: textField(app.name),
+        ...(app.bundle_id !== null
+          ? { bundleId: textField(app.bundle_id) }
+          : {}),
+        ...(app.launch_path !== null
+          ? { appPath: textField(app.launch_path) }
+          : {}),
+        running: app.running,
+        pid,
+      };
+    });
+  };
+
+  private async resolveApp(bundleId: string): Promise<App> {
+    const matches = (await this.listApps()).filter(
+      (app) => app.bundleId === bundleId && app.running && app.pid > 0,
+    );
+    if (matches.length !== 1) {
+      this.observation = null;
+      throw new ComputerUseNativeHelperError(
+        "app_not_found",
+        "CUA requires one live process for the exact bundle ID; open/re-observe the intended application",
+      );
+    }
+    return matches[0]!;
+  }
+
+  private async resolveWindow(app: App, retained?: Window): Promise<Window> {
+    const data = readResult(
+      await this.tool("list_windows", { pid: app.pid, on_screen_only: false }),
+    );
+    const windows = arrayField(data.windows, 1000)
+      .map((item) => {
+        const window = record(item);
+        return {
+          pid: integer(window.pid, 1),
+          windowId: integer(window.window_id, 1),
+          title: textField(window.title),
+          bounds: boundsField(window.bounds),
+        };
+      })
+      .filter((window) => window.pid === app.pid);
+    const matches = retained
+      ? windows.filter((window) => window.windowId === retained.windowId)
+      : windows;
+    if (matches.length !== 1) {
+      this.observation = null;
+      throw new ComputerUseNativeHelperError(
+        "window_unavailable",
+        "CUA window target is missing or ambiguous; close extra windows and re-observe",
+      );
+    }
+    return matches[0]!;
+  }
+
+  private async retained(args: ElementRequest): Promise<Observation> {
+    const observed = this.observation;
+    if (
+      !observed ||
+      observed.app.bundleId !== args.app ||
+      (args.snapshotId !== undefined &&
+        observed.snapshotId !== args.snapshotId) ||
+      (args.elementId !== undefined && !observed.tokens.has(args.elementId))
+    )
+      refuse(
+        "Stale CUA target; run app.state again and use its new snapshot/index",
+      );
+    const app = await this.resolveApp(args.app);
+    if (app.pid !== observed.app.pid || app.appPath !== observed.app.appPath) {
+      this.observation = null;
+      refuse("CUA process ownership changed; re-observe");
+    }
+    const window = await this.resolveWindow(app, observed.window);
+    if (
+      JSON.stringify(window.bounds) !== JSON.stringify(observed.window.bounds)
+    ) {
+      this.observation = null;
+      refuse("CUA window moved or resized; re-observe before acting");
+    }
+    this.assertLive();
+    if (this.observation !== observed)
+      refuse("CUA observation was superseded; re-observe");
+    return observed;
+  }
+
+  private readFrame(
+    result: ToolResult,
+    data: Record<string, unknown>,
+    window: Window,
+  ) {
+    const bounds = boundsField(data.window_bounds);
+    const width = integer(data.screenshot_width, 1);
+    const height = integer(data.screenshot_height, 1);
+    const scale = data.screenshot_scale;
+    if (
+      (scale !== 1 && scale !== 2) ||
+      Math.abs(height - (width * bounds.height) / bounds.width) > 1 ||
+      width > bounds.width * scale + 1 ||
+      height > bounds.height * scale + 1 ||
+      JSON.stringify(bounds) !== JSON.stringify(window.bounds)
+    )
+      refuse("CUA screenshot geometry is inconsistent; re-observe");
+    const png = result.images.length === 1 ? result.images[0] : undefined;
+    if (
+      !png ||
+      png.mimeType !== "image/png" ||
+      png.dataBase64.length > 8_000_000
+    )
+      throw new ComputerUseNativeHelperError(
+        "screen_recording_unavailable",
+        "CUA did not return one bounded window PNG",
+      );
+    const bytes = Buffer.from(png.dataBase64, "base64");
+    if (
+      bytes.length < 24 ||
+      bytes.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a" ||
+      bytes.readUInt32BE(16) !== width ||
+      bytes.readUInt32BE(20) !== height
+    )
+      refuse("CUA PNG dimensions do not match the retained frame");
+    return { bounds, width, height, scale, png };
+  }
+
+  private readElements(data: Record<string, unknown>) {
+    const tokens = new Map<string, string>();
+    const ids: string[] = [];
+    const elements: AccessibilityElementSnapshot[] = arrayField(
+      data.elements,
+      1200,
+    ).map((item) => {
+      const e = record(item);
+      const index = integer(e.element_index);
+      if (index >= 1200 || ids[index] !== undefined)
+        refuse("CUA element indexes are invalid");
+      const id = `cua-${randomUUID()}`;
+      const token = textField(e.element_token, 512);
+      if (!token) refuse("CUA actionable element has no token");
+      tokens.set(id, token);
+      ids[index] = id;
+      return {
+        id,
+        index,
+        role: textField(e.role),
+        ...(e.label !== undefined ? { name: textField(e.label) } : {}),
+        ...(e.value !== undefined ? { value: textField(e.value) } : {}),
+      };
+    });
+    const cuaSnapshot =
+      data.snapshot_id === undefined ? null : textField(data.snapshot_id, 512);
+    if (tokens.size > 0 && !cuaSnapshot)
+      refuse("CUA actionable elements have no snapshot owner");
+    return { tokens, ids, elements, cuaSnapshot };
+  }
+
+  getAppState = async (
+    bundleId: string,
+    snapshotId: string,
+  ): Promise<AccessibilityAppStateSnapshot> => {
+    const previous = this.observation;
+    this.observation = null; // Even a failed refresh invalidates the previous token registry.
+    const app = await this.resolveApp(bundleId);
+    const window = await this.resolveWindow(
+      app,
+      previous?.app.bundleId === bundleId && previous.app.pid === app.pid
+        ? previous.window
+        : undefined,
+    );
+    const result = await this.tool("get_window_state", {
+      pid: app.pid,
+      window_id: window.windowId,
+      include_screenshot: true,
+      max_elements: 1200,
+      max_depth: 32,
+    });
+    const data = readResult(result);
+    if (
+      data.pid !== app.pid ||
+      data.window_id !== window.windowId ||
+      data.screenshot_frame_valid !== true ||
+      data.screenshot_mime_type !== "image/png"
+    )
+      throw new ComputerUseNativeHelperError(
+        "window_unavailable",
+        "CUA observation has an invalid owner or screenshot frame",
+      );
+    const { bounds, width, height, scale, png } = this.readFrame(
+      result,
+      data,
+      window,
+    );
+    const { tokens, ids, elements, cuaSnapshot } = this.readElements(data);
+    this.assertLive();
+    this.observation = {
+      app,
+      window,
+      snapshotId,
+      cuaSnapshot,
+      tokens,
+      width,
+      height,
+      scale,
+    };
+    return {
+      app: bundleId,
+      bundleId,
+      appDisplayName: app.name,
+      appPath: app.appPath,
+      pid: app.pid,
+      windowId: window.windowId,
+      windowTitle: window.title,
+      windowFrame: bounds,
+      snapshotId,
+      elements,
+      elementIdsByIndex: ids,
+      observation: {
+        source: "cua",
+        text: textField(data.tree_markdown),
+        elementsComplete: false,
+      },
+      truncated: true,
+      truncationReasons: [
+        "CUA structured elements cover actionable nodes only; absence is not authoritative",
+        ...(data.degraded_reason !== undefined
+          ? [textField(data.degraded_reason)]
+          : []),
+      ],
+      screenshot: `data:image/png;base64,${png.dataBase64}`,
+      screenshotMimeType: "image/png",
+      screenshotSource: "window",
+      screenshotSourceName: window.title || app.name,
+      screenshotWidth: width,
+      screenshotHeight: height,
+      screenshotSourceBounds: bounds,
+    };
+  };
+
+  openApp = async (app: string) => {
+    this.observation = null;
+    const data = readResult(await this.tool("launch_app", { bundle_id: app }));
+    if (data.bundle_id !== app)
+      refuse("CUA launch returned a different application");
+    integer(data.pid, 1);
+    textField(data.name);
+    arrayField(data.windows, 1000);
+    const launchState = record(data.launch_state);
+    if (
+      typeof launchState.requested !== "boolean" ||
+      launchState.process_running !== true ||
+      typeof launchState.window_ready !== "boolean"
+    )
+      refuse("CUA launch has no proven running process");
+    const launched = await this.resolveApp(app);
+    if (launched.pid !== data.pid)
+      refuse("CUA launch process ownership changed");
+    return { driver: "cua", driverVersion: "0.23.2", launch: data };
+  };
+
+  private delivery(
+    policy: ComputerUseNativeForegroundRecoveryPolicy | undefined,
+  ): string {
+    // on-window-unavailable permits recovery, but does not require it. A refusal
+    // stays a refusal; advice never authorizes replay or implicit escalation.
+    return policy === "always" ? "foreground" : "background";
+  }
+
+  private async action(name: Tool, args: Record<string, unknown>) {
+    const result = await this.tool(name, args);
+    // Any attempted action consumes the retained addressing, including malformed
+    // or uncertain replies. Only an explicit post-state can establish new targets.
+    this.observation = null;
+    const data = structured(result);
+    if (
+      result.isError &&
+      (data.effect === undefined || data.route === undefined)
+    ) {
+      const message = result.text.slice(0, 1000);
+      this.observation = null;
+      throw new ComputerUseNativeHelperError(
+        "element_action_unsupported",
+        `CUA action refused or completion unknown: ${message}; evidence=${JSON.stringify(data).slice(0, 2000)}; do not replay without re-observation`,
+      );
+    }
+    const facts = actionFacts(result);
+    if (facts.effect === "refused")
+      throw new ComputerUseNativeHelperError(
+        "element_action_unsupported",
+        `CUA action refused: ${JSON.stringify(facts)}`,
+      );
+    return facts;
+  }
+
+  private target(
+    observed: Observation,
+    elementId?: string,
+  ): Record<string, unknown> {
+    return {
+      pid: observed.app.pid,
+      window_id: observed.window.windowId,
+      ...(elementId
+        ? {
+            element_token: observed.tokens.get(elementId),
+            snapshot_id: observed.cuaSnapshot,
+          }
+        : {}),
+    };
+  }
+
+  clickElement: ComputerUseNativeBackend["clickElement"] = async (args) => {
+    const observed = await this.retained(args);
+    return this.action("click", {
+      ...this.target(observed, args.elementId),
+      button: "left",
+      action: "press",
+      delivery_mode: this.delivery(args.foregroundRecovery),
+    });
+  };
+  clickPoint: ComputerUseNativeBackend["clickPoint"] = async (args) => {
+    const observed = await this.retained(args);
+    if (
+      args.screenshotSource !== "window" ||
+      args.windowId !== observed.window.windowId ||
+      args.screenshotWidth <= 0 ||
+      args.screenshotHeight <= 0 ||
+      !Number.isFinite(args.x) ||
+      !Number.isFinite(args.y) ||
+      args.x < 0 ||
+      args.y < 0 ||
+      args.x >= args.screenshotWidth ||
+      args.y >= args.screenshotHeight
+    )
+      refuse("CUA click is outside the retained window image");
+    const x = (args.x * observed.width) / args.screenshotWidth;
+    const y = (args.y * observed.height) / args.screenshotHeight;
+    // A display scale can change without changing logical window bounds. Refresh
+    // the public window frame (which also invalidates old AX tokens) before using
+    // CUA's per-window resize registry; never apply its Retina scale ourselves.
+    await this.getAppState(args.app, `frame-${randomUUID()}`);
+    const frame = this.observation;
+    if (
+      !frame ||
+      frame.app.pid !== observed.app.pid ||
+      frame.app.appPath !== observed.app.appPath ||
+      frame.window.windowId !== observed.window.windowId ||
+      JSON.stringify(frame.window.bounds) !==
+        JSON.stringify(observed.window.bounds) ||
+      frame.scale !== observed.scale ||
+      frame.width !== observed.width ||
+      frame.height !== observed.height
+    )
+      refuse(
+        "CUA capture owner or geometry changed; re-observe before clicking",
+      );
+    const result = await this.action("click", {
+      ...this.target(observed),
+      x,
+      y,
+      button: args.button,
+      count: args.clickCount,
+      scope: "window",
+      delivery_mode: this.delivery(args.foregroundRecovery),
+    });
+    return {
+      ...result,
+      screenX:
+        observed.window.bounds.x +
+        (x * observed.window.bounds.width) / observed.width,
+      screenY:
+        observed.window.bounds.y +
+        (y * observed.window.bounds.height) / observed.height,
+      coordinateSource: "retained_request_frame",
+    };
+  };
+  setElementValue: ComputerUseNativeBackend["setElementValue"] = async (
+    args,
+  ) => {
+    // Released structured rows cannot reliably identify browser address fields.
+    if (
+      /chrome|chromium|safari|edge|brave|firefox|arc|vivaldi|opera/i.test(
+        args.app,
+      )
+    )
+      refuse(
+        "CUA browser set_value is unsupported: AX assignment does not prove address-bar navigation; use an explicit observed keyboard flow",
+      );
+    const observed = await this.retained(args);
+    return this.action("set_value", {
+      ...this.target(observed, args.elementId),
+      value: args.value,
+    });
+  };
+  performElementAction: ComputerUseNativeBackend["performElementAction"] =
+    async (args) => {
+      const actions: Readonly<Record<string, string>> = {
+        AXPress: "press",
+        AXConfirm: "confirm",
+        AXShowMenu: "show_menu",
+        AXPick: "pick",
+        AXCancel: "cancel",
+        AXOpen: "open",
+        press: "press",
+        confirm: "confirm",
+        show_menu: "show_menu",
+        pick: "pick",
+        cancel: "cancel",
+        open: "open",
+      };
+      const action = Object.hasOwn(actions, args.action)
+        ? actions[args.action]
+        : undefined;
+      if (!action)
+        refuse(
+          "Unsupported CUA AX action; supported: AXPress, AXConfirm, AXShowMenu, AXPick, AXCancel, AXOpen",
+        );
+      const observed = await this.retained(args);
+      return this.action("click", {
+        ...this.target(observed, args.elementId),
+        action,
+        delivery_mode: "background",
+      });
+    };
+  typeText: ComputerUseNativeBackend["typeText"] = async (args) => {
+    const observed = await this.retained(args);
+    return this.action("type_text", {
+      ...this.target(observed),
+      text: args.text,
+      delay_ms: 0,
+      delivery_mode: this.delivery(args.foregroundRecovery),
+    });
+  };
+  pressKey: ComputerUseNativeBackend["pressKey"] = async (args) => {
+    const key = normalizeKey(args.key);
+    const observed = await this.retained(args);
+    return {
+      ...(await this.action("press_key", {
+        ...this.target(observed),
+        key: key.key,
+        modifiers: key.modifiers,
+        delivery_mode: this.delivery(args.foregroundRecovery),
+      })),
+      normalizedKey: key.normalizedKey,
+    };
+  };
+  scrollElement: ComputerUseNativeBackend["scrollElement"] = async (args) => {
+    const observed = await this.retained(args);
+    return this.action("scroll", {
+      ...this.target(observed),
+      direction: args.direction,
+      by: "page",
+      amount: args.pages,
+      delivery_mode: "background",
+    });
+  };
+}

--- a/turbo/apps/desktop/src/computer-use-driver.ts
+++ b/turbo/apps/desktop/src/computer-use-driver.ts
@@ -1,6 +1,8 @@
 import type { ComputerUsePermissionProvider } from "./computer-use-permissions";
+import type { ComputerUseCommandBudget } from "./computer-use-command-budget";
 import { createComputerUseDrain } from "./computer-use-lifecycle-deadline";
 import {
+  SUPPORTED_COMPUTER_USE_CAPABILITIES,
   ComputerUseSnapshotStore,
   executeComputerUseCommand,
   type ComputerUseCommand,
@@ -10,7 +12,10 @@ import type {
   ComputerUseNativeBackend,
   ComputerUseNativeShutdownReason,
 } from "./computer-use-native";
-import type { ComputerUsePermissionState } from "./computer-use-types";
+import {
+  hasRequiredComputerUsePermissions,
+  type ComputerUsePermissionState,
+} from "./computer-use-types";
 
 export interface ComputerUseDriver {
   readonly id: string;
@@ -26,10 +31,15 @@ interface DriverGeneration {
   readonly resolveDrained: () => void;
   leases: number;
   disposal: Promise<void> | null;
+  permissionsReady: boolean;
 }
 
 export interface ComputerUseCommandSession {
-  getPermissions(): Promise<ComputerUsePermissionState>;
+  beginCommand?(budget: ComputerUseCommandBudget): void;
+  getPermissions(
+    command?: ComputerUseCommand,
+  ): Promise<ComputerUsePermissionState>;
+  abort?(): void;
   executeCommand(
     command: ComputerUseCommand,
     permissions: ComputerUsePermissionState,
@@ -71,6 +81,7 @@ export class ComputerUseDriverController {
         resolveDrained: resolve,
         leases: 0,
         disposal: null,
+        permissionsReady: false,
       };
     }
     return this.context;
@@ -94,7 +105,10 @@ export class ComputerUseDriverController {
     const context = this.prepare();
     const release = this.lease(context);
     try {
-      const result = await read(context.backend);
+      const result = await read({
+        ...context.backend,
+        getPermissions: () => this.readPermissions(context),
+      });
       return this.context === context ? result : null;
     } finally {
       release();
@@ -103,12 +117,30 @@ export class ComputerUseDriverController {
 
   acquireCommand(): ComputerUseCommandSession {
     const context = this.context;
-    if (!this.active || !context) {
+    if (!this.active || !context || context.backend.isAvailable?.() === false) {
       throw new Error("Computer Use driver is not ready");
     }
+    const release = this.lease(context);
     return {
-      getPermissions: () => context.backend.getPermissions(),
+      beginCommand: (budget) => context.backend.setCommandBudget?.(budget),
+      abort: () => {
+        void this.forceRetire().catch(() => {});
+      },
+      getPermissions: () => this.readPermissions(context),
       executeCommand: async (command, permissions) => {
+        if (
+          this.context !== context ||
+          !this.active ||
+          context.backend.isAvailable?.() === false
+        )
+          return {
+            status: "failed",
+            error: {
+              code: "accessibility_unavailable",
+              message:
+                "Native generation is retired; re-observe after explicit recovery",
+            },
+          };
         const { app, snapshotId } = command.payload;
         if (
           typeof app === "string" &&
@@ -129,8 +161,49 @@ export class ComputerUseDriverController {
           platform: this.platform,
         });
       },
-      release: this.lease(context),
+      release: () => {
+        context.backend.setCommandBudget?.(null);
+        release();
+      },
     };
+  }
+
+  getCapabilities(): readonly string[] {
+    const context = this.context;
+    return this.active &&
+      context?.permissionsReady &&
+      context.backend.isAvailable?.() !== false
+      ? SUPPORTED_COMPUTER_USE_CAPABILITIES
+      : [];
+  }
+
+  private async readPermissions(
+    context: DriverGeneration,
+  ): Promise<ComputerUsePermissionState> {
+    try {
+      const permissions = await context.backend.getPermissions();
+      context.permissionsReady = hasRequiredComputerUsePermissions(permissions);
+      if (!context.permissionsReady && this.active)
+        void this.forceRetire().catch(() => {});
+      return permissions;
+    } catch (error) {
+      context.permissionsReady = false;
+      if (this.context === context) void this.forceRetire().catch(() => {});
+      throw error;
+    }
+  }
+
+  forceRetire(): Promise<void> {
+    const context = this.context ?? this.retiringContext;
+    if (context?.backend.forceStop) {
+      this.active = false;
+      context.snapshots.clear();
+      context.disposal ??= context.backend.forceStop();
+      // Observe a bounded cleanup rejection even while an old lease is hung.
+      // Keep the original rejected promise as the replacement gate.
+      void context.disposal.catch(() => {});
+    }
+    return this.retire();
   }
 
   private lease(context: DriverGeneration): () => void {

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -406,6 +406,9 @@ describe("ComputerUseHostRuntime", () => {
         return jsonResponse({
           status: "command",
           command: {
+            timeoutMs: 60_000,
+            createdAt: new Date().toISOString(),
+            claimedAt: null,
             id: "cmd-1",
             kind: "app.state",
             payload: { app: "Safari" },
@@ -451,6 +454,9 @@ describe("ComputerUseHostRuntime", () => {
         return jsonResponse({
           status: "claimed",
           command: {
+            timeoutMs: 60_000,
+            createdAt: new Date().toISOString(),
+            claimedAt: null,
             id: "cmd-1",
             kind: "app.state",
             payload: { app: "Things" },
@@ -516,6 +522,9 @@ describe("ComputerUseHostRuntime", () => {
     });
     expect(executeCommand).toHaveBeenCalledWith(
       {
+        timeoutMs: 60_000,
+        createdAt: expect.any(String),
+        claimedAt: null,
         id: "cmd-1",
         kind: "app.state",
         payload: { app: "Things" },
@@ -563,6 +572,9 @@ describe("ComputerUseHostRuntime", () => {
         return jsonResponse({
           status: "command",
           command: {
+            timeoutMs: 60_000,
+            createdAt: new Date().toISOString(),
+            claimedAt: null,
             id: `cmd-${nextCommandId.toString()}`,
             kind: "keyboard.press_key",
             payload: { app: "Terminal", key: "Enter" },
@@ -593,6 +605,9 @@ describe("ComputerUseHostRuntime", () => {
   it("notifies command failures without moving the runtime offline", async () => {
     vi.useFakeTimers();
     const command: ComputerUseCommand = {
+      timeoutMs: 60_000,
+      createdAt: new Date().toISOString(),
+      claimedAt: null,
       id: "cmd-1",
       kind: "element.set_value",
       payload: { app: "com.google.Chrome", value: "https://example.com" },
@@ -660,6 +675,9 @@ describe("ComputerUseHostRuntime", () => {
   it("keeps heartbeats running while a command is executing", async () => {
     vi.useFakeTimers();
     const command: ComputerUseCommand = {
+      timeoutMs: 60_000,
+      createdAt: new Date().toISOString(),
+      claimedAt: null,
       id: "cmd-1",
       kind: "keyboard.type_text",
       payload: { app: "Chrome", text: "https://mail.google.com/" },
@@ -718,6 +736,9 @@ describe("ComputerUseHostRuntime", () => {
   it("drains an active command before stopping without claiming more work", async () => {
     vi.useFakeTimers();
     const command: ComputerUseCommand = {
+      timeoutMs: 60_000,
+      createdAt: new Date().toISOString(),
+      claimedAt: null,
       id: "cmd-1",
       kind: "keyboard.type_text",
       payload: { app: "Chrome", text: "okou" },
@@ -789,6 +810,9 @@ describe("ComputerUseHostRuntime", () => {
           ? jsonResponse({
               status: "command",
               command: {
+                timeoutMs: 60_000,
+                createdAt: new Date().toISOString(),
+                claimedAt: null,
                 id: "cmd-1",
                 kind: "app.state",
                 payload: { app: "Chrome" },
@@ -836,6 +860,9 @@ describe("ComputerUseHostRuntime", () => {
           ? jsonResponse({
               status: "command",
               command: {
+                timeoutMs: 60_000,
+                createdAt: new Date().toISOString(),
+                claimedAt: null,
                 id: "cmd-1",
                 kind: "app.state",
                 payload: { app: "Chrome" },
@@ -891,6 +918,9 @@ describe("ComputerUseHostRuntime", () => {
           return jsonResponse({
             status: "command",
             command: {
+              timeoutMs: 60_000,
+              createdAt: new Date().toISOString(),
+              claimedAt: null,
               id: "cmd-1",
               kind: "app.state",
               payload: { app: "Chrome" },
@@ -902,6 +932,9 @@ describe("ComputerUseHostRuntime", () => {
           return jsonResponse({
             status: "command",
             command: {
+              timeoutMs: 60_000,
+              createdAt: new Date().toISOString(),
+              claimedAt: null,
               id: "cmd-2",
               kind: "app.state",
               payload: { app: "Chrome" },
@@ -982,6 +1015,9 @@ describe("ComputerUseHostRuntime", () => {
           ? jsonResponse({
               status: "command",
               command: {
+                timeoutMs: 120_000,
+                createdAt: new Date().toISOString(),
+                claimedAt: null,
                 id: "cmd-1",
                 kind: "app.state",
                 payload: { app: "Chrome" },
@@ -1224,6 +1260,9 @@ describe("ComputerUseHostRuntime", () => {
           return jsonResponse({
             status: "command",
             command: {
+              timeoutMs: 60_000,
+              createdAt: new Date().toISOString(),
+              claimedAt: null,
               id: "cmd-1",
               kind: "app.state",
               payload: { app: "Chrome" },

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -1,4 +1,9 @@
 import { createComputerUseDrain } from "./computer-use-lifecycle-deadline";
+import {
+  ComputerUseCommandBudget,
+  type ComputerUseCommandClock,
+} from "./computer-use-command-budget";
+import { ComputerUseNativeHelperError } from "./computer-use-native";
 import os from "node:os";
 import type {
   ComputerUseCommand,
@@ -54,6 +59,7 @@ export type ComputerUseHostFetch = (
 type MaybePromise<T> = T | Promise<T>;
 
 interface ComputerUseHostRuntimeOptions {
+  readonly commandClock?: ComputerUseCommandClock;
   readonly platformUrl: URL;
   readonly installationId: string;
   readonly hostName: string;
@@ -179,7 +185,10 @@ function commandFailureFromError(
   return {
     status: "failed",
     error: {
-      code: "accessibility_unavailable",
+      code:
+        error instanceof ComputerUseNativeHelperError
+          ? error.code
+          : "accessibility_unavailable",
       message: errorMessage(error),
     },
   };
@@ -273,6 +282,7 @@ export class ComputerUseHostRuntime {
   };
 
   constructor(options: ComputerUseHostRuntimeOptions) {
+    this.commandClock = options.commandClock;
     this.acquireCommand = options.acquireCommand;
     this.apiBaseUrl = resolveComputerUseApiBaseUrl(options.platformUrl);
     this.installationId = options.installationId;
@@ -294,6 +304,7 @@ export class ComputerUseHostRuntime {
   }
 
   private readonly acquireCommand: ComputerUseHostRuntimeOptions["acquireCommand"];
+  private commandClock: ComputerUseCommandClock | undefined;
 
   async start(): Promise<void> {
     if (this.running) {
@@ -380,12 +391,18 @@ export class ComputerUseHostRuntime {
   }
 
   private async runtimeBody(): Promise<Record<string, unknown>> {
+    const permissions = await this.getPermissions();
+    const capabilities = this.getSupportedCapabilities();
+    if (capabilities.length === 0) {
+      await this.stop();
+      throw new Error("Computer Use has no available capabilities");
+    }
     return buildComputerUseRuntimeBody({
       installationId: this.installationId,
       hostName: this.hostName,
       appVersion: this.appVersion,
-      permissions: await this.getPermissions(),
-      supportedCapabilities: this.getSupportedCapabilities(),
+      permissions,
+      supportedCapabilities: capabilities,
     });
   }
 
@@ -946,6 +963,10 @@ export class ComputerUseHostRuntime {
     commandSession: ComputerUseCommandSession,
   ): Promise<"idle" | "completed"> {
     const generation = this.sessionGeneration;
+    if (this.getSupportedCapabilities().length === 0) {
+      await this.stop();
+      return "idle";
+    }
     const next = await this.runHostRequestWithTimeout({
       label: "command poll",
       timeoutMs: COMMAND_POLL_REQUEST_TIMEOUT_MS,
@@ -991,12 +1012,22 @@ export class ComputerUseHostRuntime {
     this.startLocalCommandLogEntry(body.command, startedAt);
 
     let completed: ComputerUseCommandExecutionResult;
+    const budget = new ComputerUseCommandBudget(
+      body.command,
+      this.commandClock,
+    );
     try {
-      const permissions = await commandSession.getPermissions();
-      if (!this.running || generation !== this.sessionGeneration) return "idle";
-      completed = await commandSession.executeCommand(
-        body.command,
-        permissions,
+      completed = await budget.run(
+        async () => {
+          commandSession.beginCommand?.(budget);
+          const permissions = await commandSession.getPermissions(body.command);
+          if (!this.running || generation !== this.sessionGeneration)
+            throw new Error(
+              "Computer Use command was superseded; completion is unknown",
+            );
+          return commandSession.executeCommand(body.command, permissions);
+        },
+        () => commandSession.abort?.(),
       );
     } catch (error) {
       completed = commandFailureFromError(error);
@@ -1020,7 +1051,12 @@ export class ComputerUseHostRuntime {
     ) {
       return "idle";
     }
-    await this.completeCommandWithRetry(body.command.id, completed, generation);
+    await this.completeCommandWithRetry(
+      body.command.id,
+      completed,
+      generation,
+      budget,
+    );
     if (
       !this.running ||
       generation !== this.sessionGeneration ||
@@ -1044,6 +1080,7 @@ export class ComputerUseHostRuntime {
     commandId: string,
     completed: ComputerUseCommandExecutionResult,
     generation: number,
+    budget: ComputerUseCommandBudget,
   ): Promise<void> {
     let lastError: Error | null = null;
     for (
@@ -1052,10 +1089,17 @@ export class ComputerUseHostRuntime {
       attempt++
     ) {
       if (!this.running || generation !== this.sessionGeneration) return;
+      if (attempt > 1 && budget.remaining(true) <= 0) break;
       try {
         const response = await this.runHostRequestWithTimeout({
           label: "command completion",
-          timeoutMs: COMMAND_COMPLETION_REQUEST_TIMEOUT_MS,
+          timeoutMs: Math.max(
+            1,
+            Math.min(
+              COMMAND_COMPLETION_REQUEST_TIMEOUT_MS,
+              budget.remaining(true),
+            ),
+          ),
           commandRequest: true,
           request: async (signal) => {
             return await this.hostFetch(
@@ -1092,7 +1136,10 @@ export class ComputerUseHostRuntime {
               );
       }
 
-      if (attempt < COMMAND_COMPLETION_MAX_ATTEMPTS) {
+      if (
+        attempt < COMMAND_COMPLETION_MAX_ATTEMPTS &&
+        budget.remaining(true) > COMMAND_COMPLETION_RETRY_DELAY_MS
+      ) {
         await this.sleep(COMMAND_COMPLETION_RETRY_DELAY_MS);
       }
     }

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -873,18 +873,24 @@ export class ComputerUseHostRuntime {
     readonly timeoutMs: number;
     readonly request: (signal: AbortSignal) => Promise<Response>;
     readonly commandRequest?: boolean;
+    readonly onLateResponse?: (response: Response) => Promise<void>;
   }): Promise<Response> {
     const { label, timeoutMs, request } = args;
     const timeoutMessage = () => {
       return new Error(`Computer Use ${label} timed out after ${timeoutMs}ms`);
     };
     const controller = new AbortController();
-    const requestPromise = request(controller.signal).catch((error) => {
-      if (controller.signal.aborted) {
-        throw timeoutMessage();
-      }
-      throw error;
-    });
+    const requestPromise = request(controller.signal)
+      .then(async (response) => {
+        if (controller.signal.aborted) await args.onLateResponse?.(response);
+        return response;
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) {
+          throw timeoutMessage();
+        }
+        throw error;
+      });
     if (args.commandRequest) {
       this.commandRequests.add(requestPromise);
       void requestPromise.then(
@@ -971,6 +977,34 @@ export class ComputerUseHostRuntime {
       label: "command poll",
       timeoutMs: COMMAND_POLL_REQUEST_TIMEOUT_MS,
       commandRequest: true,
+      onLateResponse: async (response) => {
+        if (
+          !response.ok ||
+          !this.running ||
+          generation !== this.sessionGeneration
+        )
+          return;
+        const late = (await response.json()) as ComputerUseHostNextResponse;
+        if (
+          late.status !== "command" ||
+          !this.running ||
+          generation !== this.sessionGeneration
+        )
+          return;
+        await this.completeCommandWithRetry(
+          late.command.id,
+          {
+            status: "failed",
+            error: {
+              code: "command_timeout",
+              message:
+                "Claim arrived after the polling deadline; no native action was dispatched",
+            },
+          },
+          generation,
+          new ComputerUseCommandBudget(late.command, this.commandClock),
+        );
+      },
       request: async (signal) => {
         return await this.hostFetch("/api/computer-use/host/commands/next", {
           method: "POST",

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import type { ComputerUseCommandBudget } from "./computer-use-command-budget";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import {
   resolveNativeHelperPath,
@@ -6,6 +7,7 @@ import {
 } from "./native-helper-path";
 import type {
   AccessibilityAppStateSnapshot,
+  ComputerUseCommand,
   ComputerUseCommandFailure,
   ComputerUseCoordinateBounds,
   ComputerUseMouseButton,
@@ -68,6 +70,12 @@ export interface ComputerUseNativeAppRecord {
 }
 
 export interface ComputerUseNativeBackend {
+  readonly validateCommand?: (command: ComputerUseCommand) => void;
+  readonly setCommandBudget?: (budget: ComputerUseCommandBudget | null) => void;
+  readonly supportsWindowScroll?: boolean;
+  readonly isAvailable?: () => boolean;
+  readonly forceStop?: () => Promise<void>;
+  readonly discoveryNote?: string;
   readonly dispose: (reason?: ComputerUseNativeShutdownReason) => Promise<void>;
   readonly getPermissions: () => Promise<ComputerUsePermissionState>;
   readonly requestAccessibilityPermission: () => Promise<ComputerUsePermissionState>;

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.ts
@@ -44,6 +44,8 @@ interface ComputerUseRuntimeControllerOptions {
   readonly driver?: ComputerUseDriverController;
   readonly transitionTimeoutMs?: number;
   readonly lifecycleTimers?: ComputerUseLifecycleTimers;
+  readonly getPluginCapabilities?: () => readonly string[];
+  readonly preparePlugins?: () => Promise<void>;
 }
 
 /**
@@ -74,8 +76,13 @@ export class ComputerUseRuntimeController {
   private readonly transitionTimeoutMs: number;
   private readonly lifecycleTimers: ComputerUseLifecycleTimers | undefined;
   private quitPromise: Promise<void> | null = null;
+  private readonly getPluginCapabilities: () => readonly string[];
+  private readonly preparePlugins: () => Promise<void>;
+  private pluginStartupIntent: number | null = null;
 
   constructor(options: ComputerUseRuntimeControllerOptions) {
+    this.getPluginCapabilities = options.getPluginCapabilities ?? (() => []);
+    this.preparePlugins = options.preparePlugins ?? (async () => {});
     this.lifecycleTimers = options.lifecycleTimers;
     this.driver = options.driver;
     this.transitionTimeoutMs = options.transitionTimeoutMs ?? 30_000;
@@ -100,6 +107,10 @@ export class ComputerUseRuntimeController {
 
   isRuntimeOnline(): boolean {
     return this.runtime?.getState().status === "online";
+  }
+
+  pluginsMayRun(): boolean {
+    return this.isRuntimeOnline() || this.pluginStartupIntent === this.intent;
   }
 
   /**
@@ -133,6 +144,10 @@ export class ComputerUseRuntimeController {
     try {
       await start;
     } finally {
+      if (this.pluginStartupIntent === intent) {
+        this.pluginStartupIntent = null;
+        this.setHostRuntimeOnline(this.isRuntimeOnline());
+      }
       options.signal?.removeEventListener("abort", abort);
       if (this.starting === start) this.starting = null;
     }
@@ -150,17 +165,34 @@ export class ComputerUseRuntimeController {
     await transitions;
     if (intent !== this.intent) return;
     this.driver?.resumePermissions();
-    const permissions = await this.refreshPermissions();
+    const permissions = await withComputerUseDeadline(
+      this.refreshPermissions(),
+      this.transitionTimeoutMs,
+      this.lifecycleTimers,
+    ).catch(() => {
+      void this.driver?.forceRetire().catch(() => {});
+      return { accessibility: false, screenRecording: false };
+    });
     if (intent !== this.intent) return;
-    if (!hasRequiredComputerUsePermissions(permissions)) {
-      await this.detachRuntime();
-      return;
-    }
     const authState = await this.getAuthState();
     if (intent !== this.intent) return;
+    if (
+      !hasRequiredComputerUsePermissions(permissions) &&
+      authState.status === "signed_in" &&
+      authState.organization
+    ) {
+      this.pluginStartupIntent = intent;
+      await withComputerUseDeadline(
+        this.preparePlugins(),
+        this.transitionTimeoutMs,
+        this.lifecycleTimers,
+      );
+      if (intent !== this.intent) return;
+    }
     const startupGate = resolveComputerUseStartupGate({
       authState,
       permissions,
+      pluginCapabilities: this.getPluginCapabilities(),
     });
     if (startupGate.status !== "ready") {
       await this.detachRuntime();
@@ -172,7 +204,7 @@ export class ComputerUseRuntimeController {
       return;
     }
     this.blockedHostState = null;
-    this.driver?.activate();
+    if (hasRequiredComputerUsePermissions(permissions)) this.driver?.activate();
     const runtime = (this.runtime ??= this.createRuntime());
     await runtime.start();
     if (intent !== this.intent) return;
@@ -215,9 +247,13 @@ export class ComputerUseRuntimeController {
       if (runtime && !this.manualStopRequested) {
         const permissions = await this.refreshPermissions();
         checkIntent();
-        if (!hasRequiredComputerUsePermissions(permissions))
+        if (
+          !hasRequiredComputerUsePermissions(permissions) &&
+          this.getPluginCapabilities().length === 0
+        )
           throw new Error("Computer Use permissions are unavailable");
-        this.driver?.activate();
+        if (hasRequiredComputerUsePermissions(permissions))
+          this.driver?.activate();
         resume?.();
       }
     })();
@@ -229,6 +265,13 @@ export class ComputerUseRuntimeController {
       expired = true;
       // A failure withdraws the host rather than advertising empty legacy capabilities.
       if (intent === this.intent) {
+        void this.driver?.forceRetire().catch(() => {});
+        if (this.getPluginCapabilities().length > 0 && this.runtime) {
+          // The rejected transition keeps its native owner retired. Existing
+          // host authorization, heartbeat and plugin processes remain intact.
+          void this.runtime.pauseAndDrainCommands().then((resume) => resume());
+          throw error;
+        }
         this.manualStopRequested = true;
         this.supersede();
         this.detachRuntime();
@@ -353,7 +396,7 @@ export class ComputerUseRuntimeController {
     this.blockedHostState = null;
     this.setHostRuntimeOnline(false);
     const stop = runtime?.stop() ?? Promise.resolve();
-    const retirement = this.driver?.retire() ?? Promise.resolve();
+    const retirement = this.driver?.forceRetire() ?? Promise.resolve();
     const cleanup = Promise.all([this.stopping, stop, retirement]).then(() => {
       if (intent === this.intent && !this.quitStopStarted)
         this.driver?.resumePermissions();

--- a/turbo/apps/desktop/src/computer-use-startup-gate.ts
+++ b/turbo/apps/desktop/src/computer-use-startup-gate.ts
@@ -43,8 +43,12 @@ export function isComputerUseSetupRequired(args: {
 export function resolveComputerUseStartupGate(args: {
   readonly authState: DesktopAuthState;
   readonly permissions: ComputerUsePermissionState;
+  readonly pluginCapabilities?: readonly string[];
 }): ComputerUseStartupGate {
-  if (!hasRequiredComputerUsePermissions(args.permissions)) {
+  if (
+    !hasRequiredComputerUsePermissions(args.permissions) &&
+    !args.pluginCapabilities?.length
+  ) {
     return { status: "missing_permissions" };
   }
 

--- a/turbo/apps/desktop/src/cua-adapter-contract.ts
+++ b/turbo/apps/desktop/src/cua-adapter-contract.ts
@@ -1,0 +1,199 @@
+import type { ToolResult } from "@trycua/cua-driver";
+import { ComputerUseNativeHelperError } from "./computer-use-native";
+import type { ComputerUseCoordinateBounds } from "./computer-use-accessibility";
+
+export function refuse(message: string): never {
+  throw new ComputerUseNativeHelperError("unsupported_command", message);
+}
+
+export function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new ComputerUseNativeHelperError(
+      "accessibility_unavailable",
+      "Invalid CUA response object",
+    );
+  return value as Record<string, unknown>;
+}
+
+export function textField(value: unknown, max = 64_000): string {
+  if (typeof value !== "string" || value.length > max)
+    throw new ComputerUseNativeHelperError(
+      "accessibility_unavailable",
+      "Invalid or oversized CUA text",
+    );
+  return value;
+}
+
+export function integer(value: unknown, minimum = 0): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < minimum
+  )
+    throw new ComputerUseNativeHelperError(
+      "accessibility_unavailable",
+      "Invalid CUA integer",
+    );
+  return value;
+}
+
+export function arrayField(value: unknown, max: number): unknown[] {
+  if (!Array.isArray(value) || value.length > max)
+    throw new ComputerUseNativeHelperError(
+      "result_too_large",
+      "Invalid or oversized CUA array",
+    );
+  return value;
+}
+
+export function boundsField(value: unknown): ComputerUseCoordinateBounds {
+  const b = record(value);
+  const { x, y, width, height } = b;
+  if (
+    typeof x !== "number" ||
+    typeof y !== "number" ||
+    typeof width !== "number" ||
+    typeof height !== "number" ||
+    ![x, y, width, height].every(Number.isFinite) ||
+    width <= 0 ||
+    height <= 0
+  )
+    throw new ComputerUseNativeHelperError(
+      "window_unavailable",
+      "Invalid CUA window bounds",
+    );
+  return { x, y, width, height };
+}
+
+export function structured(result: ToolResult): Record<string, unknown> {
+  if (!result.structuredJson || result.structuredJson.length > 1_000_000)
+    throw new ComputerUseNativeHelperError(
+      "accessibility_unavailable",
+      "CUA structured result is missing or oversized; completion may be unknown, do not replay",
+    );
+  return record(JSON.parse(result.structuredJson));
+}
+
+export function readResult(result: ToolResult): Record<string, unknown> {
+  const data = structured(result);
+  if (result.isError)
+    throw new ComputerUseNativeHelperError(
+      "accessibility_unavailable",
+      `CUA refused observation: ${textField(result.text).slice(0, 1000)}`,
+    );
+  return data;
+}
+
+export function actionFacts(result: ToolResult): Record<string, unknown> {
+  const data = structured(result);
+  const effects = [
+    "confirmed",
+    "partial",
+    "unverifiable",
+    "suspected_noop",
+    "refused",
+  ];
+  const routes = [
+    "accessibility",
+    "synthetic_events",
+    "global_input",
+    "system_api",
+    "dom",
+    "trusted_input",
+  ];
+  if (
+    !effects.includes(textField(data.effect)) ||
+    !routes.includes(textField(data.route))
+  )
+    throw new ComputerUseNativeHelperError(
+      "accessibility_unavailable",
+      "CUA action completion is unknown; do not replay",
+    );
+  const facts: Record<string, unknown> = {
+    driver: "cua",
+    driverVersion: "0.23.2",
+    effect: data.effect,
+    route: data.route,
+  };
+  if (data.delivery !== undefined) {
+    const delivery = record(data.delivery);
+    if (
+      !["background", "foreground", "not_applicable", "unknown"].includes(
+        textField(delivery.mode),
+      )
+    )
+      refuse("Invalid CUA delivery mode");
+    facts.delivery = {
+      mode: delivery.mode,
+      ...(delivery.delivered_count !== undefined
+        ? { delivered_count: integer(delivery.delivered_count) }
+        : {}),
+    };
+  }
+  if (data.evidence !== undefined) {
+    facts.evidence = arrayField(data.evidence, 100).map((item) => {
+      const evidence = record(item);
+      if (
+        !["value_readback", "window_change"].includes(textField(evidence.kind))
+      )
+        refuse("Invalid CUA action evidence");
+      return { kind: evidence.kind };
+    });
+  }
+  if (
+    data.effect === "confirmed" &&
+    (!Array.isArray(facts.evidence) || facts.evidence.length === 0)
+  )
+    refuse("CUA confirmation has no evidence");
+  if (
+    data.effect === "partial" &&
+    (data.delivery === undefined ||
+      record(data.delivery).delivered_count === undefined)
+  )
+    refuse("CUA partial delivery has no count");
+  if (
+    data.effect === "refused" &&
+    (data.delivery !== undefined || data.evidence !== undefined)
+  )
+    refuse("Invalid CUA refusal facts");
+  return facts;
+}
+
+export function normalizeKey(input: string): {
+  key: string;
+  modifiers: string[];
+  normalizedKey: string;
+} {
+  const aliases: Readonly<Record<string, string>> = {
+    command: "cmd",
+    meta: "cmd",
+    control: "ctrl",
+    alt: "option",
+    enter: "return",
+    esc: "escape",
+    arrowup: "up",
+    arrowdown: "down",
+    arrowleft: "left",
+    arrowright: "right",
+    backspace: "delete",
+  };
+  const parts = input
+    .toLowerCase()
+    .split("+")
+    .map((part) => aliases[part.trim()] ?? part.trim());
+  const key = parts.pop();
+  if (
+    !key ||
+    !/^(?:[a-z0-9]|return|tab|escape|up|down|left|right|space|delete|home|end|pageup|pagedown|f(?:[1-9]|1[0-2]))$/.test(
+      key,
+    ) ||
+    parts.some(
+      (part) => !["cmd", "ctrl", "shift", "option", "fn"].includes(part),
+    ) ||
+    new Set(parts).size !== parts.length
+  )
+    refuse(
+      "Unsupported CUA key; use a supported key with cmd/ctrl/shift/option/fn modifiers",
+    );
+  return { key, modifiers: parts, normalizedKey: [...parts, key].join("+") };
+}

--- a/turbo/apps/desktop/src/cua-runtime.test.ts
+++ b/turbo/apps/desktop/src/cua-runtime.test.ts
@@ -238,8 +238,8 @@ describe("embedded CUA host lifecycle", () => {
     expect((await stat(external.hosts[0]!.directory)).mode & 0o777).toBe(0o700);
     await Promise.all([owner.stop(), owner.stop()]);
     expect(external.active.size).toBe(0);
-    expect(external.events.indexOf("destroy-client-1")).toBeLessThan(
-      external.events.indexOf("stop-1"),
+    expect(external.events.indexOf("stop-1")).toBeLessThan(
+      external.events.indexOf("destroy-client-1"),
     );
     expect(external.events.at(-1)).toBe("destroy-host-1");
     expect(owner.getState().generation).toBeNull();

--- a/turbo/apps/desktop/src/cua-runtime.ts
+++ b/turbo/apps/desktop/src/cua-runtime.ts
@@ -1,4 +1,5 @@
 import { chmod, mkdtemp, rm } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type {
   DriverMetadata,
@@ -28,6 +29,9 @@ interface Generation {
   startResult: Promise<CuaReadiness>;
   retirement: Promise<void> | null;
   probe: Promise<CuaProbeResult> | null;
+  readonly pending: Set<Promise<unknown>>;
+  session: Promise<string> | null;
+  sessionLabel: string | null;
 }
 
 interface CuaProbeResult {
@@ -87,6 +91,9 @@ export class CuaEmbeddedRuntime {
       exit: null,
       retirement: null,
       probe: null,
+      pending: new Set(),
+      session: null,
+      sessionLabel: null,
       initialization: Promise.resolve().then(() => this.initialize(context)),
       startResult: Promise.resolve().then(() => this.startGeneration(context)),
     };
@@ -205,15 +212,19 @@ export class CuaEmbeddedRuntime {
   }
 
   private async cleanup(context: Generation): Promise<void> {
-    // Cancel a native start immediately, while retaining its late result. Once
-    // connected, settle pending metadata before destroying its client.
-    const earlyStop =
-      context.host && !context.connection
-        ? context.host.stop()
-        : Promise.resolve();
+    // Embedded host stop has its own liveness/kill/reap channel. Start it before
+    // awaiting SDK callbacks: an aborted FFI promise is not termination proof.
+    const end = Promise.resolve().then(() =>
+      context.client && context.sessionLabel
+        ? context.client.endSession({ session: context.sessionLabel })
+        : undefined,
+    );
+    const earlyStop = Promise.resolve().then(() => context.host?.stop());
     const results = await Promise.allSettled([
       context.initialization,
       earlyStop,
+      end,
+      ...context.pending,
     ]);
     if (results[1]?.status === "rejected")
       throw new Error("CUA startup cancellation is unproven");
@@ -256,6 +267,44 @@ export class CuaEmbeddedRuntime {
   dispose(): Promise<void> {
     this.closed = true;
     return this.stop();
+  }
+
+  /** Host-owned adapter seam; no tool names or JSON enter from IPC. */
+  async useClient<T>(
+    operation: (
+      client: NonNullable<Generation["client"]>,
+      signal: AbortSignal,
+    ) => Promise<T>,
+  ): Promise<T> {
+    const context = this.context;
+    if (!context || !context.client || this.phase !== "ready")
+      throw new Error("CUA client is unavailable");
+    this.assertCurrent(context);
+    const work = operation(context.client, context.abort.signal);
+    context.pending.add(work);
+    try {
+      const value = await work;
+      this.assertCurrent(context);
+      return value;
+    } finally {
+      context.pending.delete(work);
+    }
+  }
+
+  ensureSession(): Promise<string> {
+    const context = this.context;
+    if (!context)
+      return Promise.reject(new Error("CUA runtime is unavailable"));
+    this.assertCurrent(context);
+    context.session ??= this.useClient(async (client, signal) => {
+      const session = `okou-command-${context.id}-${randomUUID()}`;
+      context.sessionLabel = session;
+      const result = await client.startSession({ session }, { signal });
+      if (!result.active || result.state.session !== session)
+        throw new Error("CUA did not establish the owned session");
+      return session;
+    });
+    return context.session;
   }
 
   /** Fixed host-only verification surface; never forwarded to IPC or agents. */

--- a/turbo/apps/desktop/src/desktop-computer-use-api.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-api.ts
@@ -35,13 +35,33 @@ export function createDesktopComputerUseHostRuntime(
   return new ComputerUseHostRuntime({
     ...options,
     acquireCommand: () => {
-      const native = options.driver.acquireCommand();
+      // Pin before claim whenever native commands are advertised. Plugin-only
+      // polling remains independent of native startup, permissions and cleanup.
+      const native =
+        options.driver.getCapabilities().length > 0
+          ? options.driver.acquireCommand()
+          : null;
       return {
-        ...native,
+        beginCommand: (budget) => native?.beginCommand?.(budget),
+        release: () => native?.release(),
+        abort: () => native?.abort?.(),
+        getPermissions: (command) =>
+          command?.kind === COMPUTER_USE_PLUGIN_CALL_KIND || !native
+            ? Promise.resolve({ accessibility: false, screenRecording: false })
+            : native.getPermissions(command),
         executeCommand: (command, permissions) =>
           command.kind === COMPUTER_USE_PLUGIN_CALL_KIND
             ? options.executePluginCommand(command)
-            : native.executeCommand(command, permissions),
+            : native
+              ? native.executeCommand(command, permissions)
+              : Promise.resolve({
+                  status: "failed",
+                  error: {
+                    code: "accessibility_unavailable",
+                    message:
+                      "Native capabilities were withdrawn before claim; no action was dispatched",
+                  },
+                }),
       };
     },
     // Okou shares the App session's bearer, refresh and sign-out lifetime.

--- a/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
@@ -357,7 +357,15 @@ function desktop(
         events.push("claim");
         reached.resolve();
         await response.promise;
-        return HttpResponse.json({ status: "command", command });
+        return HttpResponse.json({
+          status: "command",
+          command: {
+            timeoutMs: 60_000,
+            createdAt: new Date().toISOString(),
+            claimedAt: null,
+            ...command,
+          },
+        });
       }),
       http.post<never, Record<string, unknown>>(
         `${api}/api/computer-use/host/commands/${command.id}/complete`,

--- a/turbo/apps/desktop/src/desktop-filesystem-plugin.ts
+++ b/turbo/apps/desktop/src/desktop-filesystem-plugin.ts
@@ -218,6 +218,16 @@ export class DesktopFilesystemPluginManager {
     this.onChange();
   }
 
+  /** Called by the authorized host owner before plugin-only registration. */
+  async prepareForHost(): Promise<void> {
+    this.hostRuntimeOnline = true;
+    if (this.shouldRun() && !this.runtime) {
+      await this.restartRuntime();
+      // Stop/auth changes can supersede preparation while MCP is connecting.
+      if (!this.shouldRun()) await this.stopRuntime();
+    }
+  }
+
   setEnabled(enabled: boolean): void {
     if (this.preferences.enabled === enabled) {
       return;

--- a/turbo/apps/desktop/src/desktop-mcp-plugin.ts
+++ b/turbo/apps/desktop/src/desktop-mcp-plugin.ts
@@ -470,6 +470,21 @@ export class DesktopMcpPluginManager {
     );
   }
 
+  /** Resolve actual tools before publishing non-empty plugin-only capabilities. */
+  async prepareForHost(): Promise<void> {
+    this.hostRuntimeOnline = true;
+    await Promise.all(
+      Object.entries(this.preferences.servers).map(async ([name, config]) => {
+        const slot = this.ensureSlot(name);
+        if (this.serverShouldRun(config) && !slot.runtime) {
+          await this.restartSlotRuntime(name, slot);
+          if (!this.serverShouldRun(this.preferences.servers[name]))
+            await this.stopSlotRuntime(name, slot);
+        }
+      }),
+    );
+  }
+
   private ensureSlot(name: string): McpServerSlot {
     const existing = this.slots.get(name);
     if (existing) {

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -17,7 +17,6 @@ import {
   shell,
   type MenuItemConstructorOptions,
 } from "electron";
-import { SUPPORTED_COMPUTER_USE_CAPABILITIES } from "./computer-use-accessibility";
 import { isComputerUseMcpPluginCallPayload } from "@okouai/api-contracts/contracts/computer-use-plugins";
 import {
   MAC_AUTOMATION_SETTINGS_URL,
@@ -312,6 +311,13 @@ const computerUseController = new ComputerUseRuntimeController({
   driver: computerUseDriver,
   createRuntime: createComputerUseHostRuntime,
   refreshPermissions: refreshComputerUsePermissionState,
+  getPluginCapabilities: supportedPluginCapabilities,
+  preparePlugins: async () => {
+    await Promise.all([
+      ensureFilesystemPluginManager().prepareForHost(),
+      ensureMcpPluginManager().prepareForHost(),
+    ]);
+  },
   getAuthState: () => getAuthSession().getAuthState(),
   setHostRuntimeOnline: (online) => {
     filesystemPluginManager?.setHostRuntimeOnline(online);
@@ -405,11 +411,9 @@ function refreshDesktopTrayAuth(): void {
 
 function notifyComputerUseChanged(): void {
   filesystemPluginManager?.setHostRuntimeOnline(
-    computerUseController.isRuntimeOnline(),
+    computerUseController.pluginsMayRun(),
   );
-  mcpPluginManager?.setHostRuntimeOnline(
-    computerUseController.isRuntimeOnline(),
-  );
+  mcpPluginManager?.setHostRuntimeOnline(computerUseController.pluginsMayRun());
   notifyDesktopComputerUseChanged();
   refreshDesktopTray();
   computerUseAutoStart.restartRecoverableRuntimeState();
@@ -648,7 +652,13 @@ function ensureMcpPluginManager(): DesktopMcpPluginManager {
 
 function supportedComputerUseCapabilities(): readonly string[] {
   return [
-    ...SUPPORTED_COMPUTER_USE_CAPABILITIES,
+    ...computerUseDriver.getCapabilities(),
+    ...supportedPluginCapabilities(),
+  ];
+}
+
+function supportedPluginCapabilities(): readonly string[] {
+  return [
     ...(filesystemPluginManager?.getCapabilities() ?? []),
     ...(mcpPluginManager?.getCapabilities() ?? []),
   ];

--- a/turbo/apps/desktop/src/test/cua-boundary.ts
+++ b/turbo/apps/desktop/src/test/cua-boundary.ts
@@ -1,0 +1,274 @@
+import type {
+  DriverMetadata,
+  EmbeddedDriverConnection,
+  EmbeddedDriverExit,
+  ToolResult,
+} from "@trycua/cua-driver";
+import type { CuaSdk } from "../cua-runtime-files";
+
+export function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+function toolResult(
+  data: Record<string, unknown>,
+  images: ToolResult["images"] = [],
+): ToolResult {
+  return {
+    text: "",
+    images,
+    isError: false,
+    degraded: false,
+    rawJson: "{}",
+    structuredJson: JSON.stringify(data),
+  };
+}
+
+/** Only the public SDK/daemon boundary is substituted; all ownership code is real. */
+export function cuaBoundary() {
+  const calls: { name: string; args: Record<string, unknown> }[] = [];
+  const exit = deferred<EmbeddedDriverExit>();
+  const stopEntered = deferred<void>();
+  let connection: EmbeddedDriverConnection;
+  let state = 0;
+  let snapshot = 0;
+  let destroyed = false;
+  let sessions = 0;
+  let live = false;
+  let granted = true;
+  let pid = 123;
+  let windowId = 42;
+  let bounds = { x: 10, y: 20, width: 800, height: 600 };
+  let scale = 2;
+  let resize = 1;
+  let effect: Record<string, unknown> = {
+    effect: "unverifiable",
+    route: "synthetic_events",
+    delivery: { mode: "background" },
+  };
+  let intercept: (name: string) => Promise<void> = async () => {};
+  const sdk: CuaSdk = {
+    standardPermissionMode: 0,
+    stoppedState: 0,
+    createHost(options) {
+      connection = {
+        socketPath: options.socketPath!,
+        generation: "embedded-1",
+        pid: 987,
+        driverVersion: "0.23.2",
+        contractVersion: "contract",
+        mcpProtocolVersion: "mcp",
+        mcp: { command: options.binaryPath, args: [], environment: [] },
+      };
+      return {
+        async start() {
+          live = true;
+          state = 2;
+          return connection;
+        },
+        async stop() {
+          stopEntered.resolve();
+          await intercept("stop");
+          live = false;
+          state = 0;
+          exit.resolve({
+            generation: connection.generation,
+            code: 0,
+            success: true,
+          });
+        },
+        waitForExit: () => exit.promise,
+        state: () => state,
+        uniffiDestroy() {},
+      };
+    },
+    connect() {
+      return {
+        async metadata(): Promise<DriverMetadata> {
+          return {
+            ...connection,
+            embedded: true,
+            hostBundleId: "ai.okou.desktop",
+            toolsListSchemaVersion: "tools",
+            capabilityVersion: "capabilities",
+          };
+        },
+        async startSession({ session }) {
+          await intercept("session");
+          sessions++;
+          return {
+            active: true,
+            revived: false,
+            state: {
+              session: session!,
+              captureScope: 0,
+              effectiveScope: 1,
+              desktopCaptureAuthorized: true,
+              desktopUnlocked: true,
+            },
+          };
+        },
+        async endSession({ session }) {
+          await intercept("end");
+          return { session: session!, active: false };
+        },
+        async getDesktopState() {
+          throw new Error("Unexpected full desktop capture");
+        },
+        uniffiDestroy() {
+          destroyed = true;
+        },
+        async callTool(name, json) {
+          const args: Record<string, unknown> = JSON.parse(json);
+          calls.push({ name, args });
+          await intercept(name);
+          if (name === "check_permissions")
+            return toolResult({
+              accessibility: granted,
+              screen_recording: granted,
+              source: { attribution: "host" },
+            });
+          if (name === "list_apps")
+            return toolResult({
+              apps: [
+                {
+                  name: "Editor",
+                  bundle_id: "test.editor",
+                  launch_path: "/Applications/Editor.app",
+                  running: true,
+                  pid,
+                },
+                {
+                  name: "Installed",
+                  bundle_id: "test.installed",
+                  launch_path: "/Applications/Installed.app",
+                  running: false,
+                  pid: 0,
+                },
+                {
+                  name: "Unknown",
+                  bundle_id: null,
+                  launch_path: null,
+                  running: true,
+                  pid: 777,
+                },
+              ],
+            });
+          if (name === "list_windows")
+            return toolResult({
+              windows: [
+                { pid, window_id: windowId, title: "Document", bounds },
+              ],
+            });
+          if (name === "launch_app")
+            return toolResult({
+              pid,
+              bundle_id: args.bundle_id,
+              name: "Editor",
+              windows: [
+                { pid, window_id: windowId, title: "Document", bounds },
+              ],
+              launch_state: {
+                requested: true,
+                process_running: true,
+                window_ready: true,
+              },
+            });
+          if (name === "get_window_state") {
+            const width = Math.round(bounds.width * scale * resize);
+            const height = Math.round(bounds.height * scale * resize);
+            const png = Buffer.alloc(24);
+            png.write("89504e470d0a1a0a", "hex");
+            png.writeUInt32BE(width, 16);
+            png.writeUInt32BE(height, 20);
+            snapshot++;
+            return toolResult(
+              {
+                pid,
+                window_id: windowId,
+                snapshot_id: `opaque-${snapshot}`,
+                screenshot_frame_valid: true,
+                screenshot_mime_type: "image/png",
+                screenshot_width: width,
+                screenshot_height: height,
+                screenshot_scale: scale,
+                window_bounds: bounds,
+                tree_markdown:
+                  "Read-only invoice total: 123 元\n[0] Text field\n[1] Save",
+                elements_complete: false,
+                elements: [
+                  {
+                    element_index: 0,
+                    element_token: `opaque-field-${snapshot}`,
+                    role: "AXTextField",
+                    label: "Text field",
+                    value: "内容",
+                  },
+                  {
+                    element_index: 1,
+                    element_token: `opaque-button-${snapshot}`,
+                    role: "AXButton",
+                    label: "Save",
+                  },
+                ],
+              },
+              [{ mimeType: "image/png", dataBase64: png.toString("base64") }],
+            );
+          }
+          return toolResult(effect);
+        },
+      };
+    },
+  };
+  return {
+    sdk,
+    calls,
+    stopEntered,
+    exited: exit.promise,
+    set intercept(value: typeof intercept) {
+      intercept = value;
+    },
+    set effect(value: Record<string, unknown>) {
+      effect = value;
+    },
+    set granted(value: boolean) {
+      granted = value;
+    },
+    set pid(value: number) {
+      pid = value;
+    },
+    set windowId(value: number) {
+      windowId = value;
+    },
+    set bounds(value: typeof bounds) {
+      bounds = value;
+    },
+    set scale(value: number) {
+      scale = value;
+    },
+    set resize(value: number) {
+      resize = value;
+    },
+    get destroyed() {
+      return destroyed;
+    },
+    get sessions() {
+      return sessions;
+    },
+    get live() {
+      return live;
+    },
+    crash() {
+      state = 0;
+      live = false;
+      exit.resolve({
+        generation: connection.generation,
+        code: 1,
+        success: false,
+      });
+    },
+  };
+}

--- a/turbo/apps/desktop/src/test/cua-boundary.ts
+++ b/turbo/apps/desktop/src/test/cua-boundary.ts
@@ -44,6 +44,7 @@ export function cuaBoundary() {
   let bounds = { x: 10, y: 20, width: 800, height: 600 };
   let scale = 2;
   let resize = 1;
+  let observationFields: Record<string, unknown> = {};
   let effect: Record<string, unknown> = {
     effect: "unverifiable",
     route: "synthetic_events",
@@ -214,6 +215,7 @@ export function cuaBoundary() {
                     label: "Save",
                   },
                 ],
+                ...observationFields,
               },
               [{ mimeType: "image/png", dataBase64: png.toString("base64") }],
             );
@@ -251,6 +253,9 @@ export function cuaBoundary() {
     },
     set resize(value: number) {
       resize = value;
+    },
+    set observation(value: Record<string, unknown>) {
+      observationFields = value;
     },
     get destroyed() {
       return destroyed;


### PR DESCRIPTION
## Problem and behavior

The pinned CUA runtime had no safe route through Desktop's nine-command executor. This adds an internal host-owned adapter, preserves opaque observation/action facts, and applies the existing wire timeout to permission inspection, execution, post-state and completion. Native failure withdraws real capabilities; an authenticated host with usable plugins continues with a non-empty plugin-only set.

Closes #32353. This is slice 3 of #32259; ordinary startup still registers only Okou. No selector, preferences, renderer IPC, driver API, migration, upstream upgrade, native actuator rewrite or release is included.

## Implementation

- Compose the public CUA 0.23.2 SDK through the existing generation/lease/runtime owner. Fixed `callTool` mappings validate exact bundle/PID/window ownership and command fields; no agent tool-name/JSON passthrough or helper fallback.
- Bind host snapshots/raw IDs/indexes to the current opaque CUA tokens. Retain read-only `tree_markdown`, incomplete coverage and window PNG geometry. Reject stale addressing, changed frames and unsupported shapes; preserve effect/route/delivery/evidence without claiming uncertain effects succeeded.
- Charge queue/transit age and use one monotonic deadline, including a completion reserve. Start public embedded stop/reap independently of hung SDK/session callbacks; replacement stays blocked until exit and cleanup are proven.
- Wire actual readiness into startup, heartbeat and pre-claim capability publication. Plugin-only work requires neither a native lease nor native TCC, while empty-capability hosts stop. Preserve auth, ordinary switching, plugin/recorder and Stop/Quit/update ownership.

The [adapter contract](turbo/apps/desktop/cua/ADAPTER.md) documents all nine supported mappings, refused shapes, timing and privacy limits. Browser AX set-value navigation, arbitrary AX actions, targeted/fractional/horizontal scrolling and ambiguous windows are explicitly refused. Installed-only apps under the real user's `~/Applications` remain outside the isolated child-home scan.

## Validation

- 209 Desktop integration/contract tests across 12 focused files, including real adapter/runtime/driver/executor/host composition and real filesystem MCP processes. Coverage includes late claims, lost grants, unexpected exits, failed replacement, Stop during plugin preparation, hung permission/session/action/capture/end-session, token/index/frame binding and all nine command kinds.
- 21 API BDD route tests against local PostgreSQL, including native withdrawal with plugin-only capabilities and unchanged legacy empty-capability create/claim semantics.
- 27 CLI Computer Use tests, retaining the ordinary 30-second policy. API creation remains 60 seconds; only stored null uses 120 seconds.
- Desktop and API types, lint and scoped Knip passed; changed files formatted and `git diff --check` passed. No full local Vitest or dev server.
- The first macOS CI failure was reproduced using a symlinked TMPDIR and fixed by canonicalizing the test fixture root; all 51 adapter/host cases then passed with the same alias. Late HTTP responses after poll cancellation are now completed as not-dispatched failures while retaining their lease.
- Existing macOS package CI must still prove actual default/production-configured/preview loading, metadata, stop/cleanup and ordinary dormant smoke. CUA SDK/native/daemon remain 0.23.2 with unchanged build/sign inputs. Those ad-hoc package checks do not prove Developer ID/TCC or real-app behavior; interactive signed-host acceptance and performance remain pending with the user for slice 5.

## Fallbacks

- The host carries the existing nullable persisted-timeout policy into local budgeting: only an explicit stored `null` means 120 seconds. Surface: current nullable command contract; not a rollout window. Remove only if that contract/writer is retired. Malformed or missing metadata expires instead of inventing a timeout.
- CUA's documented optional bundle/path/snapshot/degradation fields retain their absent meaning. An untitled window may use its app name only as the screenshot display label. Surface: pinned external data/presentation; no rollout window or identity fallback. Remove if that external contract becomes required.
- The explicit plugin-only operating mode preserves the authenticated host after native unavailability only with actual non-empty plugin capabilities. This is the issue's supported capability policy, not cross-driver execution fallback; no compatibility shim or dummy capability is added.
