### PR TITLE
refactor(chat): retire snapshot marker retention and prune covered events

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -45,7 +45,10 @@ import {
 import {
   deleteChatThreadEventMarkerFixture,
   holdChatThreadEventInsertTransactionFixture,
+  insertCanonicalOrphanChatThreadEventFixture,
   insertChatThreadEventTransactionFixture,
+  readChatThreadEventIdsFixture,
+  setChatThreadSnapshotBoundaryFixture,
   setChatThreadVideoModelFixture,
 } from "../../../test-fixtures/chat-thread-events";
 import { setAgentRunCreatedAtFixture } from "../../../test-fixtures/run-deletion";
@@ -1196,6 +1199,403 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     );
   }, 90_000);
 
+  it("keeps markerless snapshot watermarks monotonic across stale projection refresh", async () => {
+    const snapshotAt = now();
+    mockNow(snapshotAt);
+    const scenario = await createSnapshotCursorScenario(
+      "Monotonic markerless compaction",
+    );
+    const { actor, firstEvent, thread } = scenario;
+    const removedAgent = await bdd.createAgent(actor, {
+      displayName: "Removed snapshot projection agent",
+    });
+    const removedThreadEventId = randomUUID();
+    const removedThread = await chat.createThread(actor, {
+      agentId: removedAgent.agentId,
+      title: "Removed snapshot projection thread",
+      eventId: removedThreadEventId,
+    });
+
+    await compactChatThreadSnapshots();
+    const boundary = await chat.getThreadSnapshot(actor);
+    expect(boundary.latestEventId).toBe(removedThreadEventId);
+    expect(boundary.chatThreads).toContainEqual(
+      expect.objectContaining({ id: removedThread.id }),
+    );
+    if (boundary.latestEventId === null || boundary.latestSeqId === null) {
+      throw new Error("Expected the advanced snapshot boundary");
+    }
+
+    // Reusing an older retained event ID reserves a sequence but inserts no
+    // event. The live thread still changes, giving stale compaction a
+    // projection-only update to apply without treating the allocator gap as a
+    // cursor boundary.
+    await chat.renameThread(
+      actor,
+      thread.id,
+      "Projection refreshed without a lifecycle event",
+      firstEvent.id,
+    );
+    for (const event of [
+      firstEvent,
+      {
+        id: scenario.snapshot.latestEventId,
+        seqId: scenario.snapshot.latestSeqId,
+      },
+      { id: boundary.latestEventId, seqId: boundary.latestSeqId },
+    ]) {
+      await deleteChatThreadEventMarkerFixture({
+        userId: actor.userId,
+        orgId: scenario.orgId,
+        eventId: event.id,
+        seqId: event.seqId,
+      });
+    }
+    chat.mockObjectStorageObjectsExist();
+    await authOrg.deleteAgent(actor, removedAgent.agentId);
+    await expect(
+      threadEventPage(actor, boundary.latestSeqId),
+    ).resolves.toStrictEqual({ events: [], hasMore: false });
+
+    mockNow(snapshotAt + DAY_MS + 1);
+    const staleCompact = await compactChatThreadSnapshots();
+    expect(staleCompact.eventsApplied).toBe(0);
+    expect(staleCompact.removedDeletedAgentThreads).toBeGreaterThanOrEqual(1);
+    const preserved = await chat.getThreadSnapshot(actor);
+    expect({
+      latestEventId: preserved.latestEventId,
+      latestSeqId: preserved.latestSeqId,
+    }).toStrictEqual({
+      latestEventId: boundary.latestEventId,
+      latestSeqId: boundary.latestSeqId,
+    });
+    expect(preserved.chatThreads).toContainEqual(
+      expect.objectContaining({
+        id: thread.id,
+        title: "Projection refreshed without a lifecycle event",
+      }),
+    );
+    expect(
+      preserved.chatThreads.some((entry) => {
+        return entry.id === removedThread.id;
+      }),
+    ).toBeFalsy();
+    await expect(
+      readChatThreadEventIdsFixture({
+        userId: actor.userId,
+        orgId: scenario.orgId,
+        eventIds: [
+          firstEvent.id,
+          scenario.snapshot.latestEventId,
+          boundary.latestEventId,
+        ],
+      }),
+    ).resolves.toStrictEqual([]);
+
+    const laterEventId = randomUUID();
+    await chat.renameThread(
+      actor,
+      thread.id,
+      "Real lifecycle event after allocator gap",
+      laterEventId,
+    );
+    const markerlessTail = await threadEventPage(actor, boundary.latestSeqId);
+    expect(markerlessTail).toStrictEqual({
+      events: [expect.objectContaining({ id: laterEventId })],
+      hasMore: false,
+    });
+    const [laterEvent] = markerlessTail.events;
+    if (!laterEvent) {
+      throw new Error("Expected the real event after the allocator gap");
+    }
+    expect(laterEvent.seqId).toBe(boundary.latestSeqId + 2);
+    await expectExpiredThreadEventCursor(actor, firstEvent.seqId);
+
+    const advancedCompact = await compactChatThreadSnapshots();
+    expect(advancedCompact.eventsApplied).toBeGreaterThanOrEqual(1);
+    const advanced = await chat.getThreadSnapshot(actor);
+    expect({
+      latestEventId: advanced.latestEventId,
+      latestSeqId: advanced.latestSeqId,
+    }).toStrictEqual({
+      latestEventId: laterEvent.id,
+      latestSeqId: laterEvent.seqId,
+    });
+
+    await compactChatThreadSnapshots();
+    const repeated = await chat.getThreadSnapshot(actor);
+    expect({
+      latestEventId: repeated.latestEventId,
+      latestSeqId: repeated.latestSeqId,
+    }).toStrictEqual({
+      latestEventId: laterEvent.id,
+      latestSeqId: laterEvent.seqId,
+    });
+  }, 90_000);
+
+  it("prunes covered lifecycle events in retry-safe deterministic batches", async () => {
+    mockEnv("CRON_SECRET", CHAT_THREAD_SNAPSHOT_CRON_SECRET);
+    mockOptionalEnv("CHAT_THREAD_EVENT_PRUNE_BATCH_SIZE", "2");
+    const actor = bdd.user();
+    if (!actor.orgId) {
+      throw new Error("Expected an organization-scoped retention actor");
+    }
+    await api.ensureOrgModelProvider(actor);
+    const liveAgent = await bdd.createAgent(actor, {
+      displayName: "Bounded retention live agent",
+    });
+    const deletedAgent = await bdd.createAgent(actor, {
+      displayName: "Bounded retention deleted agent",
+    });
+    const liveThread = await chat.createThread(actor, {
+      agentId: liveAgent.agentId,
+      title: "Bounded retention live thread",
+    });
+    const deletedThread = await chat.createThread(actor, {
+      agentId: liveAgent.agentId,
+      title: "Bounded retention deleted thread",
+    });
+    const deletedAgentThread = await chat.createThread(actor, {
+      agentId: deletedAgent.agentId,
+      title: "Bounded retention deleted Agent thread",
+    });
+    const retentionCutoff = Date.parse("1800-01-01T00:00:00.000Z");
+    const retainedAtBoundary = new Date(retentionCutoff);
+
+    const liveCovered = await insertChatThreadEventTransactionFixture({
+      userId: actor.userId,
+      orgId: actor.orgId,
+      chatThreadId: liveThread.id,
+      agentId: liveAgent.agentId,
+      title: "First covered retention event",
+      createdAt: retainedAtBoundary,
+    });
+    const deletedThreadCovered = await insertChatThreadEventTransactionFixture({
+      userId: actor.userId,
+      orgId: actor.orgId,
+      chatThreadId: deletedThread.id,
+      agentId: liveAgent.agentId,
+      title: "Covered event for a deleted thread",
+      createdAt: retainedAtBoundary,
+    });
+    const deletedAgentCovered = await insertChatThreadEventTransactionFixture({
+      userId: actor.userId,
+      orgId: actor.orgId,
+      chatThreadId: deletedAgentThread.id,
+      agentId: deletedAgent.agentId,
+      title: "Covered event for a deleted Agent",
+      createdAt: retainedAtBoundary,
+    });
+    const secondLiveCovered = await insertChatThreadEventTransactionFixture({
+      userId: actor.userId,
+      orgId: actor.orgId,
+      chatThreadId: liveThread.id,
+      agentId: liveAgent.agentId,
+      title: "Second covered retention event",
+      createdAt: retainedAtBoundary,
+    });
+
+    await chat.deleteThread(actor, deletedThread.id);
+    chat.mockObjectStorageObjectsExist();
+    await authOrg.deleteAgent(actor, deletedAgent.agentId);
+    const nullAgentMarker = await insertCanonicalOrphanChatThreadEventFixture({
+      userId: actor.userId,
+      orgId: actor.orgId,
+      chatThreadId: deletedThread.id,
+      createdAt: retainedAtBoundary,
+    });
+    const coveredEventIds = [
+      liveCovered.id,
+      deletedThreadCovered.id,
+      deletedAgentCovered.id,
+      secondLiveCovered.id,
+      nullAgentMarker.id,
+    ];
+    const snapshotAt = new Date(retentionCutoff + 7 * DAY_MS);
+    await setChatThreadSnapshotBoundaryFixture({
+      userId: actor.userId,
+      orgId: actor.orgId,
+      latestEventId: nullAgentMarker.id,
+      latestEventSeqId: nullAgentMarker.seqId,
+      updatedAt: snapshotAt,
+    });
+
+    mockNow(snapshotAt);
+    let boundaryCompact = await compactChatThreadSnapshots();
+    for (
+      let attempt = 0;
+      attempt < 4 && boundaryCompact.scopes > 0;
+      attempt++
+    ) {
+      expect(boundaryCompact.eventsPruned).toBe(0);
+      boundaryCompact = await compactChatThreadSnapshots();
+    }
+    expect(boundaryCompact).toMatchObject({ scopes: 0, eventsPruned: 0 });
+    await expect(
+      readChatThreadEventIdsFixture({
+        userId: actor.userId,
+        orgId: actor.orgId,
+        eventIds: coveredEventIds,
+      }),
+    ).resolves.toStrictEqual(coveredEventIds);
+
+    const concurrentAppend = await holdChatThreadEventInsertTransactionFixture({
+      userId: actor.userId,
+      orgId: actor.orgId,
+      chatThreadId: liveThread.id,
+      agentId: liveAgent.agentId,
+      title: "Concurrent event above the committed snapshot watermark",
+      createdAt: retainedAtBoundary,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      concurrentAppend.release();
+      await concurrentAppend.done;
+    });
+
+    mockNow(snapshotAt.getTime() + 1);
+    const overlappingCompactions = await Promise.all([
+      compactChatThreadSnapshots(),
+      compactChatThreadSnapshots(),
+    ]);
+    expect(
+      overlappingCompactions
+        .map((result) => {
+          return result.eventsPruned;
+        })
+        .sort((left, right) => {
+          return left - right;
+        }),
+    ).toStrictEqual([2, 2]);
+    await expect(
+      readChatThreadEventIdsFixture({
+        userId: actor.userId,
+        orgId: actor.orgId,
+        eventIds: coveredEventIds,
+      }),
+    ).resolves.toStrictEqual([nullAgentMarker.id]);
+
+    const converged = await compactChatThreadSnapshots();
+    expect(converged.eventsPruned).toBe(1);
+    await expect(
+      readChatThreadEventIdsFixture({
+        userId: actor.userId,
+        orgId: actor.orgId,
+        eventIds: coveredEventIds,
+      }),
+    ).resolves.toStrictEqual([]);
+    const retry = await compactChatThreadSnapshots();
+    expect(retry.eventsPruned).toBe(0);
+
+    concurrentAppend.release();
+    await concurrentAppend.done;
+    mockOptionalEnv("CHAT_THREAD_SNAPSHOT_COMPACTION_BATCH_SIZE", "1");
+    const isolatedActor = bdd.user({ userId: actor.userId });
+    if (!isolatedActor.orgId) {
+      throw new Error("Expected an organization-scoped isolation actor");
+    }
+    expect(isolatedActor.orgId).not.toBe(actor.orgId);
+    await api.ensureOrgModelProvider(isolatedActor);
+    const isolatedAgent = await bdd.createAgent(isolatedActor, {
+      displayName: "Same-user other-org retention agent",
+    });
+    const isolatedBoundaryId = randomUUID();
+    const isolatedThread = await chat.createThread(isolatedActor, {
+      agentId: isolatedAgent.agentId,
+      title: "Same-user other-org retention thread",
+      eventId: isolatedBoundaryId,
+    });
+    const isolatedBoundary = (await allThreadEvents(isolatedActor)).find(
+      (threadEvent) => {
+        return threadEvent.id === isolatedBoundaryId;
+      },
+    );
+    if (!isolatedBoundary) {
+      throw new Error("Expected the isolation snapshot boundary event");
+    }
+    await setChatThreadSnapshotBoundaryFixture({
+      userId: isolatedActor.userId,
+      orgId: isolatedActor.orgId,
+      latestEventId: isolatedBoundary.id,
+      latestEventSeqId: isolatedBoundary.seqId,
+      updatedAt: new Date(snapshotAt.getTime() + 1),
+    });
+    const isolatedAboveWatermark =
+      await insertChatThreadEventTransactionFixture({
+        userId: isolatedActor.userId,
+        orgId: isolatedActor.orgId,
+        chatThreadId: isolatedThread.id,
+        agentId: isolatedAgent.agentId,
+        title: "Old event above only the isolated scope watermark",
+        createdAt: retainedAtBoundary,
+      });
+    const compactionBlocker = bdd.user({ userId: actor.userId });
+    await api.ensureOrgModelProvider(compactionBlocker);
+    const blockerAgent = await bdd.createAgent(compactionBlocker, {
+      displayName: "Above-watermark compaction blocker",
+    });
+    await chat.createThread(compactionBlocker, {
+      agentId: blockerAgent.agentId,
+      title: "Keep the retention scope out of this snapshot batch",
+    });
+
+    const aboveWatermarkCompact = await compactChatThreadSnapshots();
+    expect(aboveWatermarkCompact.eventsPruned).toBe(0);
+    const unchangedBoundary = await chat.getThreadSnapshot(actor);
+    expect({
+      latestEventId: unchangedBoundary.latestEventId,
+      latestSeqId: unchangedBoundary.latestSeqId,
+    }).toStrictEqual({
+      latestEventId: nullAgentMarker.id,
+      latestSeqId: nullAgentMarker.seqId,
+    });
+    await expect(
+      readChatThreadEventIdsFixture({
+        userId: actor.userId,
+        orgId: actor.orgId,
+        eventIds: [concurrentAppend.event.id],
+      }),
+    ).resolves.toStrictEqual([concurrentAppend.event.id]);
+    await expect(
+      readChatThreadEventIdsFixture({
+        userId: isolatedActor.userId,
+        orgId: isolatedActor.orgId,
+        eventIds: [isolatedAboveWatermark.id],
+      }),
+    ).resolves.toStrictEqual([isolatedAboveWatermark.id]);
+
+    const nextTailEvent = await insertChatThreadEventTransactionFixture({
+      userId: actor.userId,
+      orgId: actor.orgId,
+      chatThreadId: liveThread.id,
+      agentId: liveAgent.agentId,
+      title: "Second event above the committed snapshot watermark",
+      createdAt: retainedAtBoundary,
+    });
+    await expect(
+      readChatThreadEventIdsFixture({
+        userId: actor.userId,
+        orgId: actor.orgId,
+        eventIds: [concurrentAppend.event.id, nextTailEvent.id],
+      }),
+    ).resolves.toStrictEqual([concurrentAppend.event.id, nextTailEvent.id]);
+
+    const markerlessTail = await threadEventPage(actor, nullAgentMarker.seqId);
+    expect(
+      markerlessTail.events.map((event) => {
+        return { id: event.id, seqId: event.seqId };
+      }),
+    ).toStrictEqual([
+      {
+        id: concurrentAppend.event.id,
+        seqId: concurrentAppend.event.seqId,
+      },
+      { id: nextTailEvent.id, seqId: nextTailEvent.seqId },
+    ]);
+    expect(markerlessTail.hasMore).toBeFalsy();
+    await expectExpiredThreadEventCursor(actor, liveCovered.seqId);
+  }, 90_000);
+
   it("keeps concurrent thread event sequence reservation atomic through commit", async () => {
     const owner = bdd.user();
     if (!owner.orgId) {
@@ -1477,18 +1877,18 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       }),
     ).toBeFalsy();
 
-    const retainedAnchorCursor = await chat.requestThreadEvents(
+    const markerlessSnapshotCursor = await chat.requestThreadEvents(
       actor,
       { sinceSeqId: compactedSnapshot.latestSeqId ?? undefined },
       [200],
     );
-    expect(retainedAnchorCursor.status).toBe(200);
-    if (retainedAnchorCursor.status !== 200) {
+    expect(markerlessSnapshotCursor.status).toBe(200);
+    if (markerlessSnapshotCursor.status !== 200) {
       throw new Error(
-        "Expected retained snapshot anchor event to be queryable",
+        "Expected the markerless snapshot cursor to remain valid",
       );
     }
-    expect(retainedAnchorCursor.body.events).toStrictEqual([]);
+    expect(markerlessSnapshotCursor.body.events).toStrictEqual([]);
   });
   it("keeps thread detail independent from thread model projection state", async () => {
     const { actor, agentId } = await entitledChatActor(

--- a/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
@@ -5,10 +5,11 @@ import {
   count,
   desc,
   eq,
-  exists,
   gt,
+  isNotNull,
   isNull,
   lt,
+  lte,
   notExists,
   or,
   sql,
@@ -35,10 +36,10 @@ interface SnapshotCompactionStats {
 type SnapshotRootDb = Pick<Db, "execute" | "select" | "transaction">;
 const CHAT_THREAD_EVENT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_CHAT_THREAD_SNAPSHOT_BATCH_SIZE = 500;
+const DEFAULT_CHAT_THREAD_EVENT_PRUNE_BATCH_SIZE = 500;
 const CHAT_THREAD_SNAPSHOT_STALE_MS = 24 * 60 * 60 * 1000;
 const snapshot = alias(chatThreadSnapshots, "snapshot");
 const event = alias(chatThreadEvents, "event");
-const marker = alias(chatThreadEvents, "marker");
 const thread = alias(chatThreads, "thread");
 const agent = alias(agents, "agent");
 
@@ -51,6 +52,20 @@ function chatThreadSnapshotBatchSize(): number {
   if (!Number.isInteger(parsed) || parsed <= 0) {
     throw new Error(
       "CHAT_THREAD_SNAPSHOT_COMPACTION_BATCH_SIZE must be a positive integer",
+    );
+  }
+  return parsed;
+}
+
+function chatThreadEventPruneBatchSize(): number {
+  const raw = optionalEnv("CHAT_THREAD_EVENT_PRUNE_BATCH_SIZE");
+  if (raw === undefined) {
+    return DEFAULT_CHAT_THREAD_EVENT_PRUNE_BATCH_SIZE;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(
+      "CHAT_THREAD_EVENT_PRUNE_BATCH_SIZE must be a positive integer",
     );
   }
   return parsed;
@@ -104,13 +119,17 @@ function candidateScopesCte(staleCutoff: Date, batchSize: number): SQL {
         WHERE ${and(
           eq(event.userId, sql`scope.user_id`),
           eq(event.orgId, sql`scope.org_id`),
+          or(
+            isNull(snapshot.latestEventSeqId),
+            gt(event.seqId, snapshot.latestEventSeqId),
+          ),
         )}
         ORDER BY ${desc(event.seqId)}
         LIMIT 1
       ) latest_event ON true
       WHERE ${or(
         isNull(snapshot.userId),
-        sql`${snapshot.latestEventSeqId} IS DISTINCT FROM latest_event.seq_id`,
+        isNotNull(sql`latest_event.id`),
         lt(snapshot.updatedAt, staleCutoff),
       )}
       ORDER BY
@@ -129,10 +148,13 @@ function rebuiltCte(db: Pick<Db, "select">): SQL {
       SELECT
         scope.user_id,
         scope.org_id,
-        latest_event.id AS latest_event_id,
-        latest_event.seq_id AS latest_event_seq_id,
+        COALESCE(latest_event.id, snapshot.latest_event_id) AS latest_event_id,
+        COALESCE(
+          latest_event.seq_id,
+          snapshot.latest_event_seq_id
+        ) AS latest_event_seq_id,
         COALESCE(thread_projection.chat_threads, '[]'::jsonb) AS chat_threads,
-        events_after_marker.count AS events_applied,
+        events_after_snapshot.count AS events_applied,
         deleted_agent_threads.count AS removed_deleted_agent_threads
       FROM candidate_scopes scope
       LEFT JOIN ${chatThreadSnapshots} ${snapshot}
@@ -181,6 +203,10 @@ function rebuiltCte(db: Pick<Db, "select">): SQL {
         WHERE ${and(
           eq(event.userId, sql`scope.user_id`),
           eq(event.orgId, sql`scope.org_id`),
+          or(
+            isNull(snapshot.latestEventSeqId),
+            gt(event.seqId, snapshot.latestEventSeqId),
+          ),
         )}
         ORDER BY ${desc(event.seqId)}
         LIMIT 1
@@ -196,7 +222,7 @@ function rebuiltCte(db: Pick<Db, "select">): SQL {
             gt(event.seqId, snapshot.latestEventSeqId),
           ),
         )}
-      ) events_after_marker ON true
+      ) events_after_snapshot ON true
       LEFT JOIN LATERAL (
         SELECT ${count()}::int AS count
         FROM jsonb_array_elements(
@@ -241,8 +267,24 @@ function upsertedCte(updatedAt: Date): SQL {
       FROM rebuilt
       ON CONFLICT (user_id, org_id)
       DO UPDATE SET
-        latest_event_id = EXCLUDED.latest_event_id,
-        latest_event_seq_id = EXCLUDED.latest_event_seq_id,
+        latest_event_id = CASE
+          WHEN EXCLUDED.latest_event_seq_id IS NOT NULL
+            AND (
+              ${chatThreadSnapshots.latestEventSeqId} IS NULL
+              OR EXCLUDED.latest_event_seq_id > ${chatThreadSnapshots.latestEventSeqId}
+            )
+          THEN EXCLUDED.latest_event_id
+          ELSE ${chatThreadSnapshots.latestEventId}
+        END,
+        latest_event_seq_id = CASE
+          WHEN EXCLUDED.latest_event_seq_id IS NOT NULL
+            AND (
+              ${chatThreadSnapshots.latestEventSeqId} IS NULL
+              OR EXCLUDED.latest_event_seq_id > ${chatThreadSnapshots.latestEventSeqId}
+            )
+          THEN EXCLUDED.latest_event_seq_id
+          ELSE ${chatThreadSnapshots.latestEventSeqId}
+        END,
         chat_threads = EXCLUDED.chat_threads,
         updated_at = EXCLUDED.updated_at
       RETURNING user_id, org_id
@@ -276,6 +318,7 @@ function compactChatThreadSnapshotBatchSql(
 
 async function compactChatThreadSnapshotBatch(
   db: SnapshotRootDb,
+  batchSize: number,
 ): Promise<Omit<SnapshotCompactionStats, "eventsPruned">> {
   const updatedAt = nowDate();
   const staleCutoff = new Date(
@@ -286,7 +329,7 @@ async function compactChatThreadSnapshotBatch(
     compactChatThreadSnapshotBatchSql(db, {
       updatedAt,
       staleCutoff,
-      batchSize: chatThreadSnapshotBatchSize(),
+      batchSize,
     }),
     snapshotBatchRowSchema,
   );
@@ -302,9 +345,11 @@ async function compactChatThreadSnapshotsForAllScopes(
   db: SnapshotRootDb,
   signal?: AbortSignal,
 ): Promise<SnapshotCompactionStats> {
+  const snapshotBatchSize = chatThreadSnapshotBatchSize();
+  const eventPruneBatchSize = chatThreadEventPruneBatchSize();
   const compacted = await db.transaction(
     async (tx) => {
-      return await compactChatThreadSnapshotBatch(tx);
+      return await compactChatThreadSnapshotBatch(tx, snapshotBatchSize);
     },
     { isolationLevel: "repeatable read" },
   );
@@ -314,28 +359,32 @@ async function compactChatThreadSnapshotsForAllScopes(
   const pruned = await executeRawRows(
     db,
     sql`
-      WITH pruned AS (
-        DELETE FROM ${chatThreadEvents} ${event}
-        USING ${chatThreadSnapshots} ${snapshot}
-        INNER JOIN ${chatThreadEvents} ${marker}
+      WITH prune_candidates AS MATERIALIZED (
+        SELECT ${event.id}
+        FROM ${chatThreadEvents} ${event}
+        INNER JOIN ${chatThreadSnapshots} ${snapshot}
           ON ${and(
-            eq(marker.id, snapshot.latestEventId),
-            eq(marker.seqId, snapshot.latestEventSeqId),
-            eq(marker.userId, snapshot.userId),
-            eq(marker.orgId, snapshot.orgId),
+            eq(snapshot.userId, event.userId),
+            eq(snapshot.orgId, event.orgId),
           )}
         WHERE ${and(
-          eq(event.userId, snapshot.userId),
-          eq(event.orgId, snapshot.orgId),
-          exists(
-            db
-              .select({ id: agents.id })
-              .from(agents)
-              .where(eq(agents.id, event.agentId)),
-          ),
+          isNotNull(snapshot.latestEventSeqId),
           lt(event.createdAt, cutoff),
-          lt(event.seqId, marker.seqId),
+          lte(event.seqId, snapshot.latestEventSeqId),
         )}
+        ORDER BY
+          ${asc(event.createdAt)},
+          ${asc(event.userId)},
+          ${asc(event.orgId)},
+          ${asc(event.seqId)},
+          ${asc(event.id)}
+        LIMIT ${eventPruneBatchSize}
+        FOR UPDATE OF event SKIP LOCKED
+      ),
+      pruned AS (
+        DELETE FROM ${chatThreadEvents} ${event}
+        USING prune_candidates
+        WHERE ${eq(event.id, sql`prune_candidates.id`)}
         RETURNING 1
       )
       SELECT ${count()}::int AS "count"

--- a/turbo/apps/api/src/test-fixtures/chat-thread-events.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-thread-events.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
 
-import { chatThreadEvents } from "@okouai/db/schema/chat-thread-event";
+import {
+  chatThreadEventSequences,
+  chatThreadEvents,
+} from "@okouai/db/schema/chat-thread-event";
+import { chatThreadSnapshots } from "@okouai/db/schema/chat-thread-snapshot";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
-import { and, count, eq, sql } from "drizzle-orm";
+import { and, asc, count, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "../lib/db";
@@ -19,6 +23,7 @@ interface ChatThreadEventFixtureArgs {
   readonly chatThreadId: string;
   readonly agentId: string;
   readonly title: string;
+  readonly createdAt?: Date;
 }
 
 interface PersistedChatThreadEventFixture {
@@ -91,6 +96,7 @@ export async function holdChatThreadEventInsertTransactionFixture(
       chatThreadId: args.chatThreadId,
       agentId: args.agentId,
       title: args.title,
+      ...(args.createdAt === undefined ? {} : { createdAt: args.createdAt }),
     });
     const [event] = await tx
       .select({ id: chatThreadEvents.id, seqId: chatThreadEvents.seqId })
@@ -133,6 +139,7 @@ export async function insertChatThreadEventTransactionFixture(
       chatThreadId: args.chatThreadId,
       agentId: args.agentId,
       title: args.title,
+      ...(args.createdAt === undefined ? {} : { createdAt: args.createdAt }),
     });
     const [persisted] = await tx
       .select({ id: chatThreadEvents.id, seqId: chatThreadEvents.seqId })
@@ -148,9 +155,118 @@ export async function insertChatThreadEventTransactionFixture(
 }
 
 /**
- * Removes the exact snapshot anchor that Slice 1 must tolerate. No production
- * endpoint can construct this state while the current compactor intentionally
- * retains marker rows, so the route regression test owns this narrow fixture.
+ * Inserts the canonical null-Agent form retained from an already-deleted
+ * Agent. The production lifecycle writer always has a live Agent at append
+ * time, so retention coverage needs this narrow persisted-state fixture.
+ */
+export async function insertCanonicalOrphanChatThreadEventFixture(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly chatThreadId: string;
+  readonly createdAt: Date;
+}): Promise<PersistedChatThreadEventFixture> {
+  const eventId = randomUUID();
+  const event = await db().transaction(async (tx) => {
+    const [sequence] = await tx
+      .insert(chatThreadEventSequences)
+      .values({
+        userId: args.userId,
+        orgId: args.orgId,
+        lastSeqId: 1,
+      })
+      .onConflictDoUpdate({
+        target: [
+          chatThreadEventSequences.userId,
+          chatThreadEventSequences.orgId,
+        ],
+        set: {
+          lastSeqId: sql`${chatThreadEventSequences.lastSeqId} + 1`,
+        },
+      })
+      .returning({ seqId: chatThreadEventSequences.lastSeqId });
+    if (!sequence) {
+      throw new Error("Unable to reserve orphan chat-thread event seq_id");
+    }
+    const [persisted] = await tx
+      .insert(chatThreadEvents)
+      .values({
+        id: eventId,
+        userId: args.userId,
+        orgId: args.orgId,
+        seqId: sequence.seqId,
+        chatThreadId: args.chatThreadId,
+        kind: "deleted",
+        agentId: null,
+        createdAt: args.createdAt,
+      })
+      .returning({ id: chatThreadEvents.id, seqId: chatThreadEvents.seqId });
+    return persisted;
+  });
+  if (!event) {
+    throw new Error("Expected the canonical orphan chat-thread event");
+  }
+  return event;
+}
+
+/** Seeds an authoritative snapshot boundary for retention-route scenarios. */
+export async function setChatThreadSnapshotBoundaryFixture(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly latestEventId: string;
+  readonly latestEventSeqId: number;
+  readonly updatedAt: Date;
+}): Promise<void> {
+  await db()
+    .insert(chatThreadSnapshots)
+    .values({
+      userId: args.userId,
+      orgId: args.orgId,
+      latestEventId: args.latestEventId,
+      latestEventSeqId: args.latestEventSeqId,
+      chatThreads: [],
+      createdAt: args.updatedAt,
+      updatedAt: args.updatedAt,
+    })
+    .onConflictDoUpdate({
+      target: [chatThreadSnapshots.userId, chatThreadSnapshots.orgId],
+      set: {
+        latestEventId: args.latestEventId,
+        latestEventSeqId: args.latestEventSeqId,
+        chatThreads: [],
+        updatedAt: args.updatedAt,
+      },
+    });
+}
+
+/** Reads exact physical lifecycle rows, including rows hidden by the reader. */
+export async function readChatThreadEventIdsFixture(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly eventIds: readonly string[];
+}): Promise<readonly string[]> {
+  if (args.eventIds.length === 0) {
+    return [];
+  }
+  const rows = await db()
+    .select({ id: chatThreadEvents.id })
+    .from(chatThreadEvents)
+    .where(
+      and(
+        eq(chatThreadEvents.userId, args.userId),
+        eq(chatThreadEvents.orgId, args.orgId),
+        inArray(chatThreadEvents.id, args.eventIds),
+      ),
+    )
+    .orderBy(asc(chatThreadEvents.seqId));
+  return rows.map((row) => {
+    return row.id;
+  });
+}
+
+/**
+ * Removes an exact snapshot-boundary row to model a markerless cursor without
+ * waiting for the retention window. No production endpoint exposes physical
+ * lifecycle-row deletion, so the route regression test owns this fixture.
  */
 export async function deleteChatThreadEventMarkerFixture(args: {
   readonly userId: string;


### PR DESCRIPTION
## Summary

- advance existing Chat Thread snapshot boundaries only from strictly newer same-scope lifecycle events while preserving markerless watermarks during projection-only refreshes
- prune retention-expired events through and including the stored snapshot watermark in deterministic, retry-safe batches without requiring live Agent or Thread rows
- cover markerless advancement, allocator gaps, cutoff semantics, orphaned entities, bounded overlap convergence, above-watermark preservation, cursor behavior, and scope isolation with focused BDD scenarios

## Safety

- depends on the released Slice 1 snapshot-watermark reader contract from #32295
- keeps the seven-day retention window and public API behavior unchanged
- does not change schemas, migrations, the legacy compatibility trigger, readers, clients, caches, content events, UI, or billing

## Testing

- Prettier check on all changed files
- pnpm -F api lint
- pnpm -F api check-types
- pnpm knip --workspace api
- focused Chat Thread snapshot, cursor, cutoff, retention, and pagination BDD scenarios: 7 passed
- Chat Thread snapshot pin-order regression file: 4 passed
- final focused Slice 2 scenarios after rebase to latest main: 2 passed

Fixes #32350
Parent: #28636