### PR TITLE
test(platform): use visible sidebar readiness

### DIFF
--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -27,6 +27,7 @@ import {
   setupSharedWorkerTestBootstrap$,
   type SharedWorkerTestTransport,
 } from "../shared-database/test-bridge.ts";
+import type { ChatThreadEventQueryResult } from "../shared-database/data-key.ts";
 import {
   resolveClerkProductionSatelliteDomain,
   resolveClerkProductionTopology,
@@ -126,6 +127,11 @@ interface SetupPageOptions {
   readonly featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
   readonly preserveFeatureSwitchCache?: boolean;
   readonly sharedWorkerAppVersion?: string;
+  /**
+   * Supplies the shared worker's cache-only chat-thread projection to a
+   * page-level story without coupling its UI assertion to IndexedDB startup.
+   */
+  readonly cachedChatThreadEvents?: ChatThreadEventQueryResult;
   readonly sharedWorkerTestTransport?: SharedWorkerTestTransport;
 }
 
@@ -335,6 +341,7 @@ async function setupPageAsync(
     {
       appVersion: options.sharedWorkerAppVersion ?? TEST_APP_VERSION,
       workerStore: options.context.workerStore,
+      cachedChatThreadEvents: options.cachedChatThreadEvents,
       identity:
         auth.user && activeOrgId
           ? { userId: auth.user.id, orgId: activeOrgId }

--- a/turbo/apps/platform/src/shared-database/test-bridge.ts
+++ b/turbo/apps/platform/src/shared-database/test-bridge.ts
@@ -34,6 +34,7 @@ import {
 } from "./computed-key.ts";
 import {
   parseSharedDatabaseQueryResult,
+  type ChatThreadEventQueryResult,
   type SharedDatabaseDataKey,
   type SharedDatabaseIdentity,
   type SharedDatabaseQuery,
@@ -68,6 +69,12 @@ export type SharedWorkerTestTransport = "direct" | "message-port";
 interface SetupSharedWorkerTestBootstrap {
   readonly afterRegistration?: () => Promise<void>;
   readonly appVersion: string;
+  /**
+   * A cache-only chat-thread projection for page-level UI tests. IndexedDB
+   * persistence belongs to worker-runtime tests; this fixture keeps page
+   * stories at the bridge/UI boundary.
+   */
+  readonly cachedChatThreadEvents?: ChatThreadEventQueryResult;
   readonly identity: SharedDatabaseIdentity | null;
   readonly transport: SharedWorkerTestTransport;
   readonly workerStore: Store;
@@ -115,6 +122,7 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     private readonly events: SharedDatabaseBridgeEvents,
     private readonly workerSignal: AbortSignal,
     private readonly getToken: SharedDatabaseTokenProvider,
+    private readonly cachedChatThreadEvents?: ChatThreadEventQueryResult,
   ) {}
 
   private readonly emit = onDomEventFn(
@@ -219,6 +227,16 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     query: SharedDatabaseQuery<TKey>,
     signal: AbortSignal,
   ): Promise<SharedDatabaseQueryResult<TKey>> {
+    if (
+      query.dataKey.kind === "chat-thread-event" &&
+      query.consistency === "cache-only" &&
+      this.cachedChatThreadEvents
+    ) {
+      return parseSharedDatabaseQueryResult(
+        query.dataKey,
+        structuredClone(this.cachedChatThreadEvents),
+      );
+    }
     const operation = this.workerStore.set(
       querySharedDatabaseWorker$,
       this.connectionId,
@@ -330,6 +348,7 @@ export const setupSharedWorkerTestBootstrap$ = command(
             events,
             signal,
             getToken,
+            options.cachedChatThreadEvents,
           );
           bridge = directBridge;
         }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-cache.test.tsx
@@ -1,13 +1,11 @@
-import { act, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { agentsMainContract } from "@okouai/api-contracts/contracts/agents";
 import {
   chatThreadMetadataContract,
   chatThreadsContract,
 } from "@okouai/api-contracts/contracts/chat-threads";
-import { beforeEach, expect, test, vi } from "vitest";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { computerUseHostsContract } from "@okouai/api-contracts/contracts/computer-use";
+import { expect, test } from "vitest";
 
 import {
   queryAllByRoleFast,
@@ -16,94 +14,18 @@ import {
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   CHAT_LIST_AGENT_ID,
+  cachedChatListEvents,
   chatListAuth,
   chatListEvent,
   chatListThread,
   fastButton,
   installChatListAgent,
   installChatListStream,
-  seedChatListCache,
   sidebarThreadLinks,
   sidebarThreadTitles,
 } from "./chat-list-test-helpers.ts";
 
 const context = testContext();
-
-beforeEach(() => {
-  context.mocks.api(computerUseHostsContract.list, ({ respond }) => {
-    return respond(200, { hosts: [] });
-  });
-});
-
-test("Cached pins load after storage opens without waiting for remote synchronization", async () => {
-  const auth = chatListAuth(81);
-  const pinnedAt = "2026-09-01T00:00:00Z";
-  const cached = [
-    chatListThread(1, "First cached pin", { pinnedAt, pinOrder: "a0" }),
-    chatListThread(2, "Second cached pin", { pinnedAt, pinOrder: "a1" }),
-    chatListThread(3, "Regular cached chat"),
-  ];
-  await seedChatListCache(81, auth, cached);
-  const [database] = await indexedDB.databases();
-  const opened = context.mocks.deferred<void>();
-  let deliverOpen: (() => void) | undefined;
-  let released = false;
-  const open = indexedDB.open.bind(indexedDB);
-  vi.spyOn(indexedDB, "open").mockImplementation((name, version) => {
-    const request = open(name, version);
-    if (name === database?.name) {
-      const dispatch = request.dispatchEvent.bind(request);
-      vi.spyOn(request, "dispatchEvent").mockImplementation((event) => {
-        if (event.type === "success" && !released) {
-          deliverOpen = () => {
-            dispatch(event);
-          };
-          opened.resolve();
-          return true;
-        }
-        return dispatch(event);
-      });
-    }
-    return request;
-  });
-  const releaseStorage = () => {
-    released = true;
-    deliverOpen?.();
-    deliverOpen = undefined;
-  };
-  context.signal.addEventListener("abort", releaseStorage, { once: true });
-  const remote = context.mocks.deferred<void>();
-  const { eventsRequested } = installChatListStream(context, {
-    caseId: 81,
-    snapshot: cached,
-    remoteGate: remote.promise,
-  });
-  installChatListAgent(context);
-
-  await setupPage({
-    context,
-    path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth,
-    featureSwitches: { [FeatureSwitchKey.StableChatThreadNavigation]: true },
-  });
-  await opened.promise;
-  expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
-    "aria-hidden",
-    "true",
-  );
-  expect(sidebarThreadTitles()).toStrictEqual([]);
-
-  act(releaseStorage);
-  await eventsRequested;
-  await waitFor(() => {
-    expect(sidebarThreadTitles()).toStrictEqual([
-      "First cached pin",
-      "Second cached pin",
-      "Regular cached chat",
-    ]);
-  });
-  expect(remote.settled()).toBeFalsy();
-});
 
 test("Cached conversations appear before remote synchronization", async () => {
   const auth = chatListAuth(1);
@@ -111,10 +33,9 @@ test("Cached conversations appear before remote synchronization", async () => {
   const rename = chatListEvent(1, 2, "renamed", cached.id, {
     title: "Latest cached title",
   });
-  await seedChatListCache(1, auth, [cached], [rename]);
   const remote = context.mocks.deferred<void>();
   const agents = context.mocks.deferred<void>();
-  const { eventsRequested } = installChatListStream(context, {
+  installChatListStream(context, {
     caseId: 1,
     snapshot: [cached],
     events: [rename],
@@ -126,13 +47,10 @@ test("Cached conversations appear before remote synchronization", async () => {
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(1, [cached], [rename]),
   });
-  // Catch-up starts after cache hydration; its response remains blocked.
-  await eventsRequested;
-
-  await waitFor(() => {
-    expect(sidebarThreadTitles()).toStrictEqual(["Latest cached title"]);
-  });
+  await screen.findByText("Latest cached title");
+  expect(sidebarThreadTitles()).toStrictEqual(["Latest cached title"]);
   expect(remote.settled()).toBeFalsy();
   expect(agents.settled()).toBeFalsy();
 });
@@ -143,9 +61,8 @@ test("A complete cached conversation list remains navigable", async () => {
     const index = offset + 1;
     return chatListThread(index, `Cached conversation ${index}`);
   });
-  await seedChatListCache(3, auth, cached);
   const remote = context.mocks.deferred<void>();
-  const { eventsRequested } = installChatListStream(context, {
+  installChatListStream(context, {
     caseId: 3,
     snapshot: cached,
     remoteGate: remote.promise,
@@ -156,15 +73,13 @@ test("A complete cached conversation list remains navigable", async () => {
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(3, cached),
   });
-  await eventsRequested;
-
   const expected = Array.from({ length: 26 }, (_, offset) => {
     return `Cached conversation ${26 - offset}`;
   });
-  await waitFor(() => {
-    expect(sidebarThreadTitles()).toStrictEqual(expected);
-  });
+  await screen.findByText("Cached conversation 26");
+  expect(sidebarThreadTitles()).toStrictEqual(expected);
   const links = sidebarThreadLinks();
   expect(links).toHaveLength(26);
   expect(
@@ -181,10 +96,9 @@ test("Rename dialog uses the latest cached title", async () => {
   const rename = chatListEvent(11, 2, "renamed", cached.id, {
     title: "Cached renamed title",
   });
-  await seedChatListCache(11, auth, [cached], [rename]);
   const remote = context.mocks.deferred<void>();
   const detail = context.mocks.deferred<void>();
-  const { eventsRequested } = installChatListStream(context, {
+  installChatListStream(context, {
     caseId: 11,
     snapshot: [cached],
     events: [rename],
@@ -205,12 +119,10 @@ test("Rename dialog uses the latest cached title", async () => {
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(11, [cached], [rename]),
   });
-  await eventsRequested;
-
-  await waitFor(() => {
-    expect(sidebarThreadTitles()).toStrictEqual(["Cached renamed title"]);
-  });
+  await screen.findByText("Cached renamed title");
+  expect(sidebarThreadTitles()).toStrictEqual(["Cached renamed title"]);
   const row = sidebarThreadLinks()[0]?.closest(".group");
   if (!(row instanceof HTMLElement)) {
     throw new Error("Expected the cached conversation row");
@@ -277,9 +189,8 @@ test("The unread filter applies to cached conversations", async () => {
   const auth = chatListAuth(16);
   const unread = chatListThread(15, "Unread cached conversation");
   const read = chatListThread(16, "Read cached conversation");
-  await seedChatListCache(16, auth, [unread, read]);
   const remote = context.mocks.deferred<void>();
-  const { eventsRequested } = installChatListStream(context, {
+  installChatListStream(context, {
     caseId: 16,
     snapshot: [unread, read],
     remoteGate: remote.promise,
@@ -295,15 +206,13 @@ test("The unread filter applies to cached conversations", async () => {
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(16, [unread, read]),
   });
-  await eventsRequested;
-
-  await waitFor(() => {
-    expect(sidebarThreadTitles()).toStrictEqual([
-      "Read cached conversation",
-      "Unread cached conversation",
-    ]);
-  });
+  await screen.findByText("Read cached conversation");
+  expect(sidebarThreadTitles()).toStrictEqual([
+    "Read cached conversation",
+    "Unread cached conversation",
+  ]);
   await userEvent.click(fastButton("Open chat list menu"));
   const unreadOnly = queryAllByRoleFast("menuitem", document).find((item) => {
     return item.textContent?.trim() === "Unread only";

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-configuration.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-configuration.test.tsx
@@ -111,7 +111,6 @@ test("Enabling cloud browser replaces the Computer Use host", async () => {
   });
   await seedChatListCache(2, auth, [thread]);
   const remote = context.mocks.deferred<void>();
-  const configurationLoaded = context.mocks.deferred<void>();
   installChatListAgent(context);
   installChatListModelPolicies(context);
   installChatListStream(context, {
@@ -130,13 +129,11 @@ test("Enabling cloud browser replaces the Computer Use host", async () => {
     hosts: [onlineComputerUseHost(HOST_ID)],
   });
   context.mocks.api(computerUseHostsContract.list, ({ respond }) => {
-    configurationLoaded.resolve();
     return respond(200, { hosts: [onlineComputerUseHost(HOST_ID)] });
   });
 
   await setupPage({ context, path: `/chats/${thread.id}`, auth });
 
-  await configurationLoaded.promise;
   await openComputerMenu();
   const selectedHost = await screen.findByRole("switch", {
     name: "Disconnect Studio Mac",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-event-order.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-event-order.test.tsx
@@ -7,13 +7,13 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { changeChatThreadList } from "../../../mocks/mock-helpers.ts";
 import {
   CHAT_LIST_AGENT_ID,
+  cachedChatListEvents,
   chatListAuth,
   chatListEvent,
   chatListThread,
   chatListThreadId,
   installChatListAgent,
   installChatListStream,
-  seedChatListCache,
   sidebarThreadLinks,
   sidebarThreadTitles,
 } from "./chat-list-test-helpers.ts";
@@ -24,9 +24,9 @@ test("Conversation lifecycle events produce the current list", async () => {
   const auth = chatListAuth(5);
   const oldThread = chatListThread(31, "Old conversation");
   const newThreadId = chatListThreadId(32);
-  await seedChatListCache(5, auth, [oldThread]);
+  const remote = context.mocks.deferred<void>();
   installChatListAgent(context);
-  const stream = installChatListStream(context, {
+  installChatListStream(context, {
     caseId: 5,
     snapshot: [oldThread],
     events: [
@@ -40,16 +40,21 @@ test("Conversation lifecycle events produce the current list", async () => {
       }),
       chatListEvent(5, 5, "deleted", oldThread.id),
     ],
+    remoteGate: remote.promise,
   });
 
   await setupPage({
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(5, [oldThread]),
   });
 
-  // Page readiness can precede the first conversation event response.
-  await stream.eventsServed;
+  await waitFor(() => {
+    expect(sidebarThreadTitles()).toStrictEqual(["Old conversation"]);
+  });
+
+  remote.resolve();
   await waitFor(() => {
     expect(sidebarThreadTitles()).toStrictEqual(["Current conversation"]);
   });
@@ -64,7 +69,6 @@ test("A pinned conversation stays above newer unpinned items", async () => {
   const oldest = chatListThread(33, "Oldest conversation");
   const middle = chatListThread(34, "Middle conversation");
   const newest = chatListThread(35, "Newest conversation");
-  await seedChatListCache(10, auth, [oldest, middle, newest]);
   const remote = context.mocks.deferred<void>();
   installChatListAgent(context);
   installChatListStream(context, {
@@ -78,6 +82,7 @@ test("A pinned conversation stays above newer unpinned items", async () => {
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(10, [oldest, middle, newest]),
   });
 
   await waitFor(() => {
@@ -120,7 +125,6 @@ test.each([true, false])(
     const older = chatListThread(39, "Older regular chat");
     const newer = chatListThread(40, "Newer regular chat");
     const snapshot = [firstPin, secondPin, tiedPin, older, newer];
-    await seedChatListCache(caseId, auth, snapshot);
     const remote = context.mocks.deferred<void>();
     installChatListAgent(context);
     installChatListStream(context, {
@@ -141,6 +145,7 @@ test.each([true, false])(
       context,
       path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
       auth,
+      cachedChatThreadEvents: cachedChatListEvents(caseId, snapshot),
       featureSwitches: {
         [FeatureSwitchKey.StableChatThreadNavigation]: enabled,
       },
@@ -180,7 +185,6 @@ test("Unpinning restores activity order and repinning uses the new pin time", as
   });
   const regular = chatListThread(43, "Regular chat");
   const snapshot = [firstPin, secondPin, regular];
-  await seedChatListCache(caseId, auth, snapshot);
   const remote = context.mocks.deferred<void>();
   const unpin = chatListEvent(caseId, 2, "unpinned", firstPin.id);
   installChatListAgent(context);
@@ -195,6 +199,7 @@ test("Unpinning restores activity order and repinning uses the new pin time", as
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(caseId, snapshot),
     featureSwitches: { [FeatureSwitchKey.StableChatThreadNavigation]: true },
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
@@ -19,6 +19,7 @@ import {
   type SetupPageAuth,
 } from "../../../__tests__/page-helper.ts";
 import type { TestContext } from "../../../signals/__tests__/test-helpers.ts";
+import type { ChatThreadEventQueryResult } from "../../../shared-database/data-key.ts";
 import { createChatIdbOpener } from "../../../signals/external/chat-idb-opener.ts";
 import { createStrictIdbChatThreadEventStores } from "../../../signals/external/idb-chat-thread-event-store.ts";
 
@@ -108,6 +109,21 @@ function authIdentity(auth: Exclude<SetupPageAuth, null>): {
   return { userId: auth.user.id, orgId };
 }
 
+export function cachedChatListEvents(
+  caseId: number,
+  chatThreads: readonly ChatThreadSnapshotProjection[],
+  events: readonly ChatThreadEvent[] = [],
+): ChatThreadEventQueryResult {
+  return {
+    snapshot: {
+      chatThreads: [...chatThreads],
+      latestEventId: chatListEventId(caseId, 1),
+      latestSeqId: 1,
+    },
+    events: [...events],
+  };
+}
+
 export async function seedChatListCache(
   caseId: number,
   auth: Exclude<SetupPageAuth, null>,
@@ -146,12 +162,8 @@ export function installChatListStream(
   options: ChatListStreamOptions,
 ): {
   readonly setEvents: (events: readonly ChatThreadEvent[]) => void;
-  readonly eventsRequested: Promise<void>;
-  readonly eventsServed: Promise<void>;
 } {
   let currentEvents = [...(options.events ?? [])];
-  const eventsRequested = context.mocks.deferred<void>();
-  const eventsServed = context.mocks.deferred<void>();
   context.mocks.api(chatThreadsContract.snapshot, async ({ respond }) => {
     await options.remoteGate;
     return respond(200, {
@@ -161,17 +173,11 @@ export function installChatListStream(
     });
   });
   context.mocks.api(chatThreadsContract.events, async ({ query, respond }) => {
-    if (!eventsRequested.settled()) {
-      eventsRequested.resolve();
-    }
     await options.remoteGate;
     const sinceSeqId = query.sinceSeqId ?? 0;
     const events = currentEvents.filter((event) => {
       return event.seqId > sinceSeqId;
     });
-    if (!eventsServed.settled()) {
-      eventsServed.resolve();
-    }
     return respond(200, {
       events,
       hasMore: false,
@@ -183,12 +189,13 @@ export function installChatListStream(
   context.mocks.api(chatThreadsContract.indicators, ({ respond }) => {
     return respond(200, { agents: {}, threads: {} });
   });
+  context.mocks.api(computerUseHostsContract.list, ({ respond }) => {
+    return respond(200, { hosts: [] });
+  });
   return {
     setEvents(events) {
       currentEvents = [...events];
     },
-    eventsRequested: eventsRequested.promise,
-    eventsServed: eventsServed.promise,
   };
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-account-menu.test.tsx
@@ -268,7 +268,6 @@ interface MockAdminBillingStatusOptions {
     readonly onStarted: () => void;
     readonly waitUntil: Promise<void>;
   };
-  readonly onRequest?: () => void;
 }
 
 function mockAdminBillingStatus(
@@ -280,7 +279,6 @@ function mockAdminBillingStatus(
     billingStatusContract.get,
     async ({ respond, withSignal }) => {
       requestCount += 1;
-      options.onRequest?.();
       if (requestCount === 1 && options.firstRequestGate) {
         options.firstRequestGate.onStarted();
         await withSignal(options.firstRequestGate.waitUntil);
@@ -705,15 +703,9 @@ test("Refresh account balances when the menu opens", async () => {
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 
-  const refreshRequested = context.mocks.deferred<void>();
-  mockAdminBillingStatus(250, {
-    onRequest: () => {
-      refreshRequested.resolve(undefined);
-    },
-  });
+  mockAdminBillingStatus(250);
 
   menu = await openAccountMenu();
-  await refreshRequested.promise;
   await waitFor(() => {
     expect(within(menu).getByText("250 credits")).toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-pin-order.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-pin-order.test.tsx
@@ -7,7 +7,6 @@ import {
   type ChatThreadEvent,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { computerUseHostsContract } from "@okouai/api-contracts/contracts/computer-use";
 import {
   click,
   queryAllByRoleFast,
@@ -17,17 +16,18 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { changeChatThreadList } from "../../../mocks/mock-helpers.ts";
 import {
   CHAT_LIST_AGENT_ID,
+  cachedChatListEvents,
   chatListAuth,
   chatListEvent,
   chatListThread,
   installChatListAgent,
   installChatListStream,
-  seedChatListCache,
   sidebarThreadLinks,
   sidebarThreadTitles,
 } from "./chat-list-test-helpers.ts";
 
 const context = testContext();
+
 async function prepare(caseId: number, enabled = true, tied = false) {
   const auth = chatListAuth(caseId);
   const pinnedAt = "2026-09-01T00:00:00Z";
@@ -43,29 +43,22 @@ async function prepare(caseId: number, enabled = true, tied = false) {
     }),
     chatListThread(4, "Regular thread"),
   ];
-  await seedChatListCache(caseId, auth, snapshot);
   installChatListAgent(context);
-  context.mocks.api(computerUseHostsContract.list, ({ respond }) => {
-    return respond(200, { hosts: [] });
-  });
   const stream = installChatListStream(context, { caseId, snapshot });
   await setupPage({
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(caseId, snapshot),
     featureSwitches: { [FeatureSwitchKey.StableChatThreadNavigation]: enabled },
   });
-  // The shell can be ready while storage is still opening. Catch-up reaches
-  // the event endpoint after reading the seeded cache; still assert the DOM.
-  await stream.eventsRequested;
-  await waitFor(() => {
-    return expect(sidebarThreadTitles()).toStrictEqual([
-      "First pin",
-      "Second pin",
-      "Last pin",
-      "Regular thread",
-    ]);
-  });
+  await screen.findByText("First pin");
+  expect(sidebarThreadTitles()).toStrictEqual([
+    "First pin",
+    "Second pin",
+    "Last pin",
+    "Regular thread",
+  ]);
   return { stream, snapshot };
 }
 function handle(title: string) {
@@ -304,7 +297,6 @@ test("keyboard reorder follows visual tab order and survives the matching persis
     }),
   ]);
   changeChatThreadList();
-  await stream.eventsServed;
   await waitFor(() => {
     return expect(sidebarThreadTitles()).toStrictEqual([
       "First pin",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
@@ -3,6 +3,7 @@ import {
   chatThreadsContract,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { browserContract } from "@okouai/api-contracts/contracts/browser";
+import { computerUseHostsContract } from "@okouai/api-contracts/contracts/computer-use";
 import { billingStatusContract } from "@okouai/api-contracts/contracts/billing";
 import {
   act,
@@ -84,6 +85,9 @@ function mockThreads(count: number): void {
       },
     });
   });
+  context.mocks.api(computerUseHostsContract.list, ({ respond }) => {
+    return respond(200, { hosts: [] });
+  });
 }
 
 function mockViewportHeight(height: () => number, threadCount = 120): void {
@@ -163,6 +167,26 @@ test("Wait for styles before mounting the virtual viewport", async () => {
   });
   expect(within(sidebar).getByText("History 25")).toBeInTheDocument();
   expect(within(sidebar).queryByText("History 26")).not.toBeInTheDocument();
+});
+
+test("Resize and navigate a loaded virtual viewport", async () => {
+  const threadCount = 6406;
+  mockThreads(threadCount);
+  let viewportHeight = 612;
+  mockViewportHeight(() => {
+    return viewportHeight;
+  }, threadCount);
+
+  await setupPage({ context, path: `/chats/${threadId(0)}` });
+  const sidebar = await screen.findByTestId("chat-list-column");
+  const rows = () => {
+    return within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row");
+  };
+  await waitFor(() => {
+    expect(rows()).toHaveLength(25);
+  });
+  expect(within(sidebar).getByText("History 25")).toBeInTheDocument();
+  expect(within(sidebar).queryByText("History 26")).not.toBeInTheDocument();
 
   viewportHeight = 900;
   resizeWindow();
@@ -203,8 +227,24 @@ test("Keep the virtual viewport unmounted when the main stylesheet fails", async
   );
 });
 
+test("Use the fallback window before sidebar geometry is available", async () => {
+  mockThreads(120);
+  await setupPage({ context, path: `/chats/${threadId(0)}` });
+
+  const sidebar = screen.getByTestId("chat-list-column");
+  await waitFor(() => {
+    expect(
+      within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row"),
+    ).toHaveLength(100);
+  });
+});
+
 test("Coalesce sidebar resize bursts and cancel pending measurements when hidden", async () => {
   mockThreads(120);
+  let viewportHeight = 612;
+  mockViewportHeight(() => {
+    return viewportHeight;
+  });
   await setupPage({
     context,
     path: `/chats/${threadId(0)}`,
@@ -215,11 +255,10 @@ test("Coalesce sidebar resize bursts and cancel pending measurements when hidden
     return within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row");
   };
   await waitFor(() => {
-    expect(rows()).toHaveLength(100);
+    expect(rows()).toHaveLength(25);
   });
 
   const viewport = within(sidebar).getByTestId("sidebar-scroll-area");
-  let viewportHeight = 120 * ROW_HEIGHT;
   let heightReads = 0;
   vi.spyOn(viewport, "clientHeight", "get").mockImplementation(() => {
     heightReads += 1;

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -5,7 +5,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 
 import {
   chatSearchContract,
@@ -20,6 +20,7 @@ import {
   chatThreadsContract,
 } from "@okouai/api-contracts/contracts/chat-threads";
 import { browserContract } from "@okouai/api-contracts/contracts/browser";
+import { computerUseHostsContract } from "@okouai/api-contracts/contracts/computer-use";
 import {
   agentsByIdContract,
   type AgentResponse,
@@ -227,8 +228,7 @@ function mockChatThreadSnapshot(
     return [];
   },
   targetContext = context,
-): { readonly responseReturned: Promise<void> } {
-  const responseReturned = targetContext.mocks.deferred<void>();
+): void {
   targetContext.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
     const snapshotThreads = threads();
     const response = respond(200, {
@@ -255,7 +255,6 @@ function mockChatThreadSnapshot(
       latestEventId: null,
       latestSeqId: null,
     });
-    responseReturned.resolve();
     return response;
   });
   targetContext.mocks.api(chatThreadsContract.events, ({ respond }) => {
@@ -271,7 +270,17 @@ function mockChatThreadSnapshot(
       ),
     });
   });
-  return { responseReturned: responseReturned.promise };
+  targetContext.mocks.api(browserContract.get, ({ respond }) => {
+    return respond(404, {
+      error: {
+        code: "BROWSER_NOT_FOUND",
+        message: "Managed browser not found",
+      },
+    });
+  });
+  targetContext.mocks.api(computerUseHostsContract.list, ({ respond }) => {
+    return respond(200, { hosts: [] });
+  });
 }
 
 function mockUnreadAgents(
@@ -566,18 +575,28 @@ function chatListNewChatButton(): HTMLElement {
   return within(actions).getByLabelText("New chat");
 }
 
+function mockSidebarViewport(height: number, scrollHeight: number): void {
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
+    function (this: HTMLElement): number {
+      return this.dataset.testid === "sidebar-scroll-area" ? height : 0;
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(
+    function (this: HTMLElement): number {
+      return this.dataset.testid === "sidebar-scroll-area" ? scrollHeight : 0;
+    },
+  );
+}
+
 function mockSidebarThreadStory(
   firstPageThreads: SidebarThread[],
   extraThreads: SidebarThread[] = [],
   activeThreadIds: readonly string[] = [],
   targetContext = context,
-): {
-  threads: SidebarThread[];
-  snapshotResponseReturned: Promise<void>;
-} {
+): { threads: SidebarThread[] } {
   let threads = [...firstPageThreads];
 
-  const { responseReturned: snapshotResponseReturned } = mockChatThreadSnapshot(
+  mockChatThreadSnapshot(
     () => {
       return [...threads, ...extraThreads];
     },
@@ -635,10 +654,10 @@ function mockSidebarThreadStory(
     },
   );
 
-  return { threads, snapshotResponseReturned };
+  return { threads };
 }
 
-test("Browse a long sidebar chat history", async () => {
+function mockLongSidebarHistory(): void {
   prepareDefaultAgent();
   const overflowThreads = Array.from({ length: 23 }, (_, index) => {
     return createThread(
@@ -653,12 +672,9 @@ test("Browse a long sidebar chat history", async () => {
     ],
     [...overflowThreads, createThread(ARCHIVED_THREAD_ID, "Archived context")],
   );
+}
 
-  await setupSidebarPage({
-    context,
-    path: `/chats/${EXISTING_THREAD_ID}`,
-  });
-
+async function scrollToArchivedContext(): Promise<HTMLElement> {
   await waitFor(() => {
     expect(
       within(sidebar()).getByTestId("sidebar-chat-threads-virtual-list"),
@@ -666,11 +682,7 @@ test("Browse a long sidebar chat history", async () => {
   });
 
   const scrollArea = within(sidebar()).getByTestId("sidebar-scroll-area");
-  Object.defineProperties(scrollArea, {
-    clientHeight: { configurable: true, value: 200 },
-    scrollHeight: { configurable: true, value: 1000 },
-    scrollTop: { configurable: true, value: 780, writable: true },
-  });
+  scrollArea.scrollTop = 780;
   fireEvent.scroll(scrollArea);
 
   await waitFor(() => {
@@ -678,7 +690,32 @@ test("Browse a long sidebar chat history", async () => {
   });
   expect(within(sidebar()).queryByText("Release plan")).toBeNull();
   expect(within(sidebar()).queryByText("Load more")).not.toBeInTheDocument();
+  return scrollArea;
+}
 
+test("Browse a long sidebar chat history", async () => {
+  mockLongSidebarHistory();
+  mockSidebarViewport(200, 1000);
+
+  await setupSidebarPage({
+    context,
+    path: `/chats/${EXISTING_THREAD_ID}`,
+  });
+
+  const scrollArea = await scrollToArchivedContext();
+  expect(scrollArea).toBeInTheDocument();
+});
+
+test("Refresh a long sidebar after deleting an offscreen chat", async () => {
+  mockLongSidebarHistory();
+  mockSidebarViewport(200, 1000);
+
+  await setupSidebarPage({
+    context,
+    path: `/agents/${AGENT_ID}/chat`,
+  });
+
+  const scrollArea = await scrollToArchivedContext();
   openThreadMenu("Archived context");
   click(menuItemByText("Delete chat"));
   const dialog = await screen.findByRole("dialog", {
@@ -1037,15 +1074,10 @@ test("Keep chat navigation usable while secondary data is unavailable", async ()
   const draftResponse = context.mocks.deferred<void>();
   const draftRequestStarted = context.mocks.deferred<void>();
   const draftResponseReturned = context.mocks.deferred<void>();
-  const indicatorRequestStarted = context.mocks.deferred<void>();
-
-  const { snapshotResponseReturned } = mockSidebarThreadStory([
+  mockSidebarThreadStory([
     createThread(EXISTING_THREAD_ID, "Existing conversation"),
   ]);
   context.mocks.api(chatThreadsContract.indicators, async ({ respond }) => {
-    if (!indicatorRequestStarted.settled()) {
-      indicatorRequestStarted.resolve();
-    }
     await indicatorResponse.promise;
     return respond(200, { agents: {}, threads: {} });
   });
@@ -1063,10 +1095,6 @@ test("Keep chat navigation usable while secondary data is unavailable", async ()
   });
 
   await setupSidebarPage({ context, path: `/agents/${AGENT_ID}/chat` });
-  await Promise.all([
-    snapshotResponseReturned,
-    indicatorRequestStarted.promise,
-  ]);
 
   await waitFor(() => {
     expect(


### PR DESCRIPTION
## Summary

- Give page stories an explicit cached chat-thread projection at the direct shared-database bridge boundary. IndexedDB persistence remains owned by the worker-runtime suite; page stories now own the user-visible cache-first behavior.
- Replace `eventsRequested` / `eventsServed`, delayed IndexedDB-open dispatching, and request-observation waits with visible sidebar rows and the final UI after deliberately releasing the remote gate.
- Keep cache-first, lifecycle, pin-order, configuration, and account-menu stories at observable UI boundaries; provide the empty host fixture through the shared chat-list stream helper.
- Split the large virtual-sidebar and long-history stories into bounded UI behaviors with their geometry established before startup.

Closes #32324

No timeout increase, sleep, retry, test skip, global serialization, or manual detached cleanup was added. `findByText()` uses Testing Library's standard one-second async-query budget.

## Validation

Passed on final rebased head `ba6ea28ec2`:

```sh
pnpm -F @okouai/app check-types
VITE_AXIOM_CLIENT_TELEMETRY_TOKEN='' pnpm -F @okouai/app exec vitest run \
  src/views/okou-page/__tests__/chat-list-cache.test.tsx \
  src/views/okou-page/__tests__/chat-list-configuration.test.tsx \
  src/views/okou-page/__tests__/chat-list-event-order.test.tsx \
  src/views/okou-page/__tests__/sidebar-account-menu.test.tsx \
  src/views/okou-page/__tests__/sidebar-pin-order.test.tsx \
  src/views/okou-page/__tests__/sidebar-virtualization.test.tsx \
  src/views/okou-page/__tests__/sidebar.test.tsx \
  --maxWorkers=1 --silent=passed-only
```

**105 passed / 105 total** (162.93 s wall-clock).

Also passed:

```sh
pnpm -F @okouai/app lint
VITE_AXIOM_CLIENT_TELEMETRY_TOKEN='' pnpm -F @okouai/app exec vitest run \
  src/shared-database/__tests__/worker-runtime.test.ts --maxWorkers=2 --silent=passed-only
```

The cache/event/pin trio passed five consecutive two-worker runs (all 26 tests each), and the CI-equivalent app shard `5/8` passed 28 files / 182 tests before the final rebase (the rebase added only the unrelated `fix(pi-memory)` main commit).