### PR TITLE
feat(platform): route app realtime through shared worker

### DIFF
--- a/turbo/apps/platform/scripts/check-localized-ui.mjs
+++ b/turbo/apps/platform/scripts/check-localized-ui.mjs
@@ -119,6 +119,10 @@ function getInternalAllowedLiterals() {
       "internal run event payload; the rendered cancellation message uses typed i18n",
     ],
     [
+      "src/shared-database/protocol.ts\u0000Realtime subscription is not supported",
+      "SharedWorker protocol validation error, not user-visible UI copy",
+    ],
+    [
       "src/signals/shared-database-browser.ts\u0000okou_{…}_{…}{…}",
       "SharedWorker browser identifier, not user-visible UI copy",
     ],

--- a/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
+++ b/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
@@ -1,6 +1,8 @@
 import { screen } from "@testing-library/react";
 import { HttpResponse } from "msw";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
+
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { mockedClerk } from "./mock-auth.ts";
 import { queryAllByRoleFast, setupPage } from "./page-helper.ts";
@@ -77,6 +79,29 @@ test("Authentication is ready before Platform content becomes interactive", asyn
   ).resolves.toBeInTheDocument();
   expect(screen.queryByTestId("app-auth-v2")).not.toBeInTheDocument();
   expect(queryAllByRoleFast("link").length).toBeGreaterThan(0);
+});
+
+test("The SharedWorker owns realtime when its feature switch is enabled", async () => {
+  await setupPage({
+    context,
+    host: "app.vm0.ai",
+    path: "/agents",
+    featureSwitches: {
+      [FeatureSwitchKey.SharedWorkerRealtime]: true,
+    },
+    sharedWorkerTestTransport: "message-port",
+  });
+
+  await screen.findByRole("heading", { name: "Agents" });
+  await vi.waitFor(() => {
+    expect(
+      context.mocks.ably.hasSubscriptionOnChannel(
+        "user:test-user-123",
+        "connectorPermissionUpdated",
+      ),
+    ).toBeTruthy();
+  });
+  expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(1);
 });
 
 test("Authentication startup is reused without a duplicate load", async () => {

--- a/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/message-port.test.ts
@@ -191,6 +191,93 @@ function connectProtocolTransport(
   };
 }
 
+test("share one Worker realtime subscription across registered tabs", async () => {
+  initializeWorker();
+  const firstOwner = createChildAbortController(context.signal);
+  const secondOwner = createChildAbortController(context.signal);
+  const first = connectProtocolTransport(firstOwner.signal);
+  const second = connectProtocolTransport(secondOwner.signal);
+  const firstMessages: unknown[] = [];
+  const secondMessages: unknown[] = [];
+  const topic = "connectorPermissionUpdated";
+  const channelName = `user:${identity().userId}`;
+
+  await first.bridge.registerTab(firstOwner.signal);
+  await second.bridge.registerTab(secondOwner.signal);
+  await Promise.all([
+    first.bridge.subscribeRealtime(
+      "first-subscription",
+      "user",
+      topic,
+      (message) => {
+        firstMessages.push(message.data);
+      },
+    ),
+    second.bridge.subscribeRealtime(
+      "second-subscription",
+      "user",
+      topic,
+      (message) => {
+        secondMessages.push(message.data);
+      },
+    ),
+  ]);
+
+  await vi.waitFor(() => {
+    expect(
+      context.mocks.ably.hasSubscriptionOnChannel(channelName, topic),
+    ).toBeTruthy();
+  });
+  context.mocks.ably.triggerOnChannel(channelName, topic, { revision: 1 });
+  await vi.waitFor(() => {
+    expect(firstMessages).toStrictEqual([{ revision: 1 }]);
+    expect(secondMessages).toStrictEqual([{ revision: 1 }]);
+  });
+
+  firstOwner.abort(new DOMException("First tab closed", "AbortError"));
+  context.mocks.ably.triggerOnChannel(channelName, topic, { revision: 2 });
+  await vi.waitFor(() => {
+    expect(secondMessages).toStrictEqual([{ revision: 1 }, { revision: 2 }]);
+  });
+  expect(firstMessages).toStrictEqual([{ revision: 1 }]);
+
+  secondOwner.abort(new DOMException("Second tab closed", "AbortError"));
+  await vi.waitFor(() => {
+    expect(
+      context.mocks.ably.hasSubscriptionOnChannel(channelName, topic),
+    ).toBeFalsy();
+  });
+});
+
+test("route workspace realtime subscriptions through the organization channel", async () => {
+  initializeWorker();
+  const owner = createChildAbortController(context.signal);
+  const { bridge } = connectProtocolTransport(owner.signal);
+  const messages: unknown[] = [];
+  const topic = "presentationTemplatesChanged";
+  const channelName = `org:${identity().orgId}`;
+
+  await bridge.registerTab(owner.signal);
+  await bridge.subscribeRealtime(
+    "workspace-subscription",
+    "org",
+    topic,
+    (message) => {
+      messages.push(message.data);
+    },
+  );
+
+  await vi.waitFor(() => {
+    expect(
+      context.mocks.ably.hasSubscriptionOnChannel(channelName, topic),
+    ).toBeTruthy();
+  });
+  context.mocks.ably.triggerOnChannel(channelName, topic, { revision: 1 });
+  await vi.waitFor(() => {
+    expect(messages).toStrictEqual([{ revision: 1 }]);
+  });
+});
+
 test("preserve a rejected 401 through the port and allow a later query to succeed", async () => {
   initializeWorker();
   const { bridge } = connectProtocolTransport(context.signal);

--- a/turbo/apps/platform/src/shared-database/__tests__/single-connection-client.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/single-connection-client.test.ts
@@ -12,7 +12,11 @@ import type {
   SharedDatabaseQuery,
   SharedDatabaseQueryResult,
 } from "../data-key.ts";
-import type { SharedDatabaseConnectionStatus } from "../protocol.ts";
+import type {
+  SharedDatabaseConnectionStatus,
+  SharedDatabaseRealtimeMessage,
+  SharedDatabaseRealtimeScope,
+} from "../protocol.ts";
 import { SingleConnectionSharedDatabaseBridge } from "../single-connection-client.ts";
 
 const axiomTelemetry = vi.hoisted(() => {
@@ -43,6 +47,17 @@ class FakeBridge implements SharedDatabaseBridge {
   registerTab(): Promise<void> {
     return Promise.resolve();
   }
+
+  subscribeRealtime(
+    _subscriptionId: string,
+    _scope: SharedDatabaseRealtimeScope,
+    _topic: string,
+    _listener: (message: SharedDatabaseRealtimeMessage) => void,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  unsubscribeRealtime(_subscriptionId: string): void {}
 
   getComputed<TKey extends ComputedKey>(
     _computedKey: TKey,

--- a/turbo/apps/platform/src/shared-database/bridge.ts
+++ b/turbo/apps/platform/src/shared-database/bridge.ts
@@ -6,11 +6,20 @@ import type {
 import type { ComputedKey, ComputedValue } from "./computed-key.ts";
 import type {
   SharedDatabaseConnectionStatus,
+  SharedDatabaseRealtimeMessage,
+  SharedDatabaseRealtimeScope,
   SharedDatabaseWorkerUnavailableReason,
 } from "./protocol.ts";
 
 export interface SharedDatabaseBridge {
   registerTab(signal: AbortSignal): Promise<void>;
+  subscribeRealtime(
+    subscriptionId: string,
+    scope: SharedDatabaseRealtimeScope,
+    topic: string,
+    listener: (message: SharedDatabaseRealtimeMessage) => void,
+  ): Promise<void>;
+  unsubscribeRealtime(subscriptionId: string): void;
   getComputed<TKey extends ComputedKey>(
     computedKey: TKey,
   ): Promise<ComputedValue<TKey>>;

--- a/turbo/apps/platform/src/shared-database/message-port-client.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-client.ts
@@ -21,6 +21,8 @@ import {
   serializeSharedDatabaseError,
   sharedDatabaseWorkerMessageSchema,
   type SharedDatabaseClientMessage,
+  type SharedDatabaseRealtimeMessage,
+  type SharedDatabaseRealtimeScope,
   type SharedDatabaseWorkerMessage,
 } from "./protocol.ts";
 import { logger } from "../signals/log.ts";
@@ -37,8 +39,17 @@ interface PendingRequest {
   readonly reject: (reason: unknown) => void;
 }
 
+interface PendingRealtimeSubscription {
+  readonly deferred: ReturnType<typeof createDeferredPromise<void>>;
+  readonly listener: (message: SharedDatabaseRealtimeMessage) => void;
+}
+
 export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
   private readonly pendingRequests = new Map<string, PendingRequest>();
+  private readonly pendingRealtimeSubscriptions = new Map<
+    string,
+    PendingRealtimeSubscription
+  >();
   private readonly handleMessage: (event: MessageEvent<unknown>) => void;
   private readonly handleBridgeAbort: () => void;
   private registered = false;
@@ -86,6 +97,35 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
         this.events.statusChanged(message.status);
         return;
       }
+      if (message.type === "realtime-subscribed") {
+        const subscription = this.pendingRealtimeSubscriptions.get(
+          message.subscriptionId,
+        );
+        if (subscription && !subscription.deferred.settled()) {
+          subscription.deferred.resolve();
+        }
+        return;
+      }
+      if (message.type === "realtime-event") {
+        this.pendingRealtimeSubscriptions
+          .get(message.subscriptionId)
+          ?.listener(message.message);
+        return;
+      }
+      if (message.type === "realtime-subscription-error") {
+        const subscription = this.pendingRealtimeSubscriptions.get(
+          message.subscriptionId,
+        );
+        if (subscription) {
+          this.pendingRealtimeSubscriptions.delete(message.subscriptionId);
+          if (!subscription.deferred.settled()) {
+            subscription.deferred.reject(
+              deserializeSharedDatabaseError(message.error),
+            );
+          }
+        }
+        return;
+      }
       const pending = this.pendingRequests.get(message.requestId);
       if (!pending) {
         return;
@@ -113,6 +153,44 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
 
   fail(reason: unknown): void {
     this.close(reason);
+  }
+
+  subscribeRealtime(
+    subscriptionId: string,
+    scope: SharedDatabaseRealtimeScope,
+    topic: string,
+    listener: (message: SharedDatabaseRealtimeMessage) => void,
+  ): Promise<void> {
+    this.requireRegistration();
+    if (this.closed) {
+      throw this.closeReason;
+    }
+    if (this.pendingRealtimeSubscriptions.has(subscriptionId)) {
+      throw new Error("Shared database realtime subscription already exists");
+    }
+    const deferred = createDeferredPromise<void>(this.bridgeSignal);
+    this.pendingRealtimeSubscriptions.set(subscriptionId, {
+      deferred,
+      listener,
+    });
+    this.emit({ type: "realtime-subscribe", subscriptionId, scope, topic });
+    return deferred.promise;
+  }
+
+  unsubscribeRealtime(subscriptionId: string): void {
+    const subscription = this.pendingRealtimeSubscriptions.get(subscriptionId);
+    if (!subscription) {
+      return;
+    }
+    this.pendingRealtimeSubscriptions.delete(subscriptionId);
+    if (!this.closed) {
+      this.emit({ type: "realtime-unsubscribe", subscriptionId });
+    }
+    if (!subscription.deferred.settled()) {
+      subscription.deferred.reject(
+        new DOMException("Realtime subscription closed", "AbortError"),
+      );
+    }
   }
 
   async getComputed<TKey extends ComputedKey>(
@@ -238,6 +316,12 @@ export class MessagePortSharedDatabaseBridge implements SharedDatabaseBridge {
       pending.reject(reason);
     }
     this.pendingRequests.clear();
+    for (const subscription of this.pendingRealtimeSubscriptions.values()) {
+      if (!subscription.deferred.settled()) {
+        subscription.deferred.reject(reason);
+      }
+    }
+    this.pendingRealtimeSubscriptions.clear();
     if (reportDisconnected) {
       this.events.statusChanged("disconnected");
     }

--- a/turbo/apps/platform/src/shared-database/message-port-server.ts
+++ b/turbo/apps/platform/src/shared-database/message-port-server.ts
@@ -28,6 +28,10 @@ import {
   queryStoreMessage$,
   startSharedDatabaseWorkerDaemons$,
 } from "./worker-signals.ts";
+import {
+  startWorkerRealtimeSubscription$,
+  stopWorkerRealtimeSubscription$,
+} from "./worker-realtime-subscriptions.ts";
 
 type RequestMessage = Extract<
   SharedDatabaseClientMessage,
@@ -36,6 +40,14 @@ type RequestMessage = Extract<
 type TokenResponseMessage = Extract<
   SharedDatabaseClientMessage,
   { readonly type: "token-error" | "token-result" }
+>;
+type RealtimeSubscribeMessage = Extract<
+  SharedDatabaseClientMessage,
+  { readonly type: "realtime-subscribe" }
+>;
+type RealtimeUnsubscribeMessage = Extract<
+  SharedDatabaseClientMessage,
+  { readonly type: "realtime-unsubscribe" }
 >;
 
 interface PendingTokenRequest {
@@ -231,6 +243,29 @@ export class SharedDatabaseMessagePortServer {
     pending.resolve(message.token);
   }
 
+  private startRealtimeSubscription(
+    message: RealtimeSubscribeMessage,
+    signal: AbortSignal,
+  ): void {
+    const daemon = this.store.set(
+      startWorkerRealtimeSubscription$,
+      this.connectionId,
+      message,
+      signal,
+    );
+    if (daemon) {
+      detach(daemon, Reason.Daemon, "shared database realtime subscription");
+    }
+  }
+
+  private stopRealtimeSubscription(message: RealtimeUnsubscribeMessage): void {
+    this.store.set(
+      stopWorkerRealtimeSubscription$,
+      this.connectionId,
+      message.subscriptionId,
+    );
+  }
+
   private disconnect(reason: string): void {
     if (this.disconnected) {
       return;
@@ -300,6 +335,14 @@ export class SharedDatabaseMessagePortServer {
             );
           });
         }
+        return;
+      }
+      if (message.type === "realtime-subscribe") {
+        this.startRealtimeSubscription(message, registeredSignal);
+        return;
+      }
+      if (message.type === "realtime-unsubscribe") {
+        this.stopRealtimeSubscription(message);
         return;
       }
       await this.startRequest(message, registeredSignal, () => {

--- a/turbo/apps/platform/src/shared-database/protocol.ts
+++ b/turbo/apps/platform/src/shared-database/protocol.ts
@@ -9,6 +9,25 @@ import {
 
 const requestIdSchema = z.string().min(1);
 
+export const sharedDatabaseRealtimeScopeSchema = z.enum([
+  "credential",
+  "org",
+  "user",
+]);
+
+export type SharedDatabaseRealtimeScope = z.infer<
+  typeof sharedDatabaseRealtimeScopeSchema
+>;
+
+export const sharedDatabaseRealtimeMessageSchema = z.object({
+  name: z.string(),
+  data: z.unknown(),
+});
+
+export type SharedDatabaseRealtimeMessage = z.infer<
+  typeof sharedDatabaseRealtimeMessageSchema
+>;
+
 const sharedDatabaseErrorSchema = z
   .object({
     name: z.string(),
@@ -67,6 +86,59 @@ const disconnectRequestSchema = z
   .object({ type: z.literal("disconnect") })
   .strict();
 
+const userRealtimeTopicSchema = z.union([
+  z.literal("agentphone:changed"),
+  z.literal("billing:changed"),
+  z.literal("browserSessionChanged"),
+  z.literal("connector:changed"),
+  z.literal("connectorPermissionUpdated"),
+  z.literal("customConnectorListChanged"),
+  z.literal("feishu:changed"),
+  z.literal("github:changed"),
+  z.literal("presentationTemplatesChanged"),
+  z.literal("slack:changed"),
+  z.literal("teams:changed"),
+  z.literal("telegram:changed"),
+  z.literal("userPreferenceChanged"),
+  z
+    .string()
+    .regex(
+      /^chatThread(?:Artifacts|Automations|Detail|Workflows)Changed:[^:]+$/u,
+    ),
+]);
+
+function isSharedDatabaseAppRealtimeSubscription(
+  scope: SharedDatabaseRealtimeScope,
+  topic: string,
+): boolean {
+  return (
+    (scope === "user" && userRealtimeTopicSchema.safeParse(topic).success) ||
+    (scope === "org" && topic === "presentationTemplatesChanged")
+  );
+}
+
+const realtimeSubscribeRequestSchema = z
+  .object({
+    type: z.literal("realtime-subscribe"),
+    subscriptionId: requestIdSchema,
+    scope: sharedDatabaseRealtimeScopeSchema,
+    topic: z.string().min(1),
+  })
+  .strict()
+  .refine(
+    ({ scope, topic }) => {
+      return isSharedDatabaseAppRealtimeSubscription(scope, topic);
+    },
+    { message: "Realtime subscription is not supported" },
+  );
+
+const realtimeUnsubscribeRequestSchema = z
+  .object({
+    type: z.literal("realtime-unsubscribe"),
+    subscriptionId: requestIdSchema,
+  })
+  .strict();
+
 export const sharedDatabaseClientMessageSchema = z.discriminatedUnion("type", [
   registerTabMessageSchema,
   queryRequestSchema,
@@ -74,6 +146,8 @@ export const sharedDatabaseClientMessageSchema = z.discriminatedUnion("type", [
   tokenResultMessageSchema,
   tokenErrorMessageSchema,
   disconnectRequestSchema,
+  realtimeSubscribeRequestSchema,
+  realtimeUnsubscribeRequestSchema,
 ]);
 
 export type SharedDatabaseClientMessage = z.infer<
@@ -201,6 +275,29 @@ const statusMessageSchema = z
   })
   .strict();
 
+const realtimeSubscribedMessageSchema = z
+  .object({
+    type: z.literal("realtime-subscribed"),
+    subscriptionId: requestIdSchema,
+  })
+  .strict();
+
+const realtimeEventMessageSchema = z
+  .object({
+    type: z.literal("realtime-event"),
+    subscriptionId: requestIdSchema,
+    message: sharedDatabaseRealtimeMessageSchema,
+  })
+  .strict();
+
+const realtimeSubscriptionErrorMessageSchema = z
+  .object({
+    type: z.literal("realtime-subscription-error"),
+    subscriptionId: requestIdSchema,
+    error: sharedDatabaseErrorSchema,
+  })
+  .strict();
+
 export const sharedDatabaseWorkerMessageSchema = z.discriminatedUnion("type", [
   resultMessageSchema,
   errorMessageSchema,
@@ -211,6 +308,9 @@ export const sharedDatabaseWorkerMessageSchema = z.discriminatedUnion("type", [
   reloadComputedMessageSchema,
   chatThreadReadCursorUpdatedMessageSchema,
   statusMessageSchema,
+  realtimeSubscribedMessageSchema,
+  realtimeEventMessageSchema,
+  realtimeSubscriptionErrorMessageSchema,
 ]);
 
 export type SharedDatabaseWorkerMessage = z.infer<

--- a/turbo/apps/platform/src/shared-database/single-connection-client.ts
+++ b/turbo/apps/platform/src/shared-database/single-connection-client.ts
@@ -8,6 +8,10 @@ import type {
   SharedDatabaseQuery,
   SharedDatabaseQueryResult,
 } from "./data-key.ts";
+import type {
+  SharedDatabaseRealtimeMessage,
+  SharedDatabaseRealtimeScope,
+} from "./protocol.ts";
 import type { ComputedKey, ComputedValue } from "./computed-key.ts";
 
 interface SingleConnectionSharedDatabaseBridgeOptions {
@@ -40,6 +44,24 @@ export class SingleConnectionSharedDatabaseBridge implements SharedDatabaseBridg
     const bridge = this.requireRegistered(this.bridge);
     await bridge.registerTab(this.requireRegistered(this.ownerSignal));
     signal.throwIfAborted();
+  }
+
+  subscribeRealtime(
+    subscriptionId: string,
+    scope: SharedDatabaseRealtimeScope,
+    topic: string,
+    listener: (message: SharedDatabaseRealtimeMessage) => void,
+  ): Promise<void> {
+    return this.requireRegistered(this.bridge).subscribeRealtime(
+      subscriptionId,
+      scope,
+      topic,
+      listener,
+    );
+  }
+
+  unsubscribeRealtime(subscriptionId: string): void {
+    this.requireRegistered(this.bridge).unsubscribeRealtime(subscriptionId);
   }
 
   async query<TKey extends SharedDatabaseDataKey>(

--- a/turbo/apps/platform/src/shared-database/test-bridge.ts
+++ b/turbo/apps/platform/src/shared-database/test-bridge.ts
@@ -39,6 +39,10 @@ import {
   type SharedDatabaseQuery,
   type SharedDatabaseQueryResult,
 } from "./data-key.ts";
+import type {
+  SharedDatabaseRealtimeMessage,
+  SharedDatabaseRealtimeScope,
+} from "./protocol.ts";
 import { MessagePortSharedDatabaseBridge } from "./message-port-client.ts";
 import { SharedDatabaseMessagePortServer } from "./message-port-server.ts";
 import {
@@ -78,6 +82,12 @@ interface DirectRealtimeMessage {
   readonly name: string;
 }
 
+interface DirectRealtimeSubscription {
+  readonly listener: (message: SharedDatabaseRealtimeMessage) => void;
+  readonly scope: SharedDatabaseRealtimeScope;
+  readonly topic: string;
+}
+
 function waitForWorkerOperation<T>(
   operation: Promise<T>,
   signal: AbortSignal,
@@ -108,6 +118,10 @@ function directWorkerPort(
 
 class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
   private readonly connectionId = crypto.randomUUID();
+  private readonly realtimeSubscriptions = new Map<
+    string,
+    DirectRealtimeSubscription
+  >();
   private connectionSignal: AbortSignal | null = null;
 
   constructor(
@@ -143,12 +157,20 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     },
   );
 
-  handleRealtimeMessage(message: DirectRealtimeMessage): void {
+  handleRealtimeMessage(
+    scope: SharedDatabaseRealtimeScope,
+    message: DirectRealtimeMessage,
+  ): void {
     this.workerStore.set(
       handleSharedDatabaseRealtimeMessage$,
       message,
       this.workerSignal,
     );
+    for (const subscription of this.realtimeSubscriptions.values()) {
+      if (subscription.scope === scope && subscription.topic === message.name) {
+        subscription.listener(message);
+      }
+    }
     const computedKey: ComputedKey | null =
       message.name === "threadListChanged" ||
       message.name === "chatThreadReadCursorUpdated"
@@ -192,6 +214,23 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
       detach(daemon, Reason.Daemon, "test shared database Worker");
     }
     return Promise.resolve();
+  }
+
+  subscribeRealtime(
+    subscriptionId: string,
+    scope: SharedDatabaseRealtimeScope,
+    topic: string,
+    listener: (message: SharedDatabaseRealtimeMessage) => void,
+  ): Promise<void> {
+    if (this.realtimeSubscriptions.has(subscriptionId)) {
+      throw new Error("Shared database realtime subscription already exists");
+    }
+    this.realtimeSubscriptions.set(subscriptionId, { listener, scope, topic });
+    return Promise.resolve();
+  }
+
+  unsubscribeRealtime(subscriptionId: string): void {
+    this.realtimeSubscriptions.delete(subscriptionId);
   }
 
   async getComputed<TKey extends ComputedKey>(
@@ -247,6 +286,24 @@ class TestSharedDatabaseBridge implements SharedDatabaseBridge {
   async registerTab(signal: AbortSignal): Promise<void> {
     await this.bridge.registerTab(signal);
     await this.afterRegistration?.();
+  }
+
+  subscribeRealtime(
+    subscriptionId: string,
+    scope: SharedDatabaseRealtimeScope,
+    topic: string,
+    listener: (message: SharedDatabaseRealtimeMessage) => void,
+  ): Promise<void> {
+    return this.bridge.subscribeRealtime(
+      subscriptionId,
+      scope,
+      topic,
+      listener,
+    );
+  }
+
+  unsubscribeRealtime(subscriptionId: string): void {
+    this.bridge.unsubscribeRealtime(subscriptionId);
   }
 
   getComputed<TKey extends ComputedKey>(
@@ -315,10 +372,10 @@ export const setupSharedWorkerTestBootstrap$ = command(
         } else {
           if (!directRealtimeForwardingInstalled) {
             subscribeChatDatabaseEvents((message) => {
-              directBridge?.handleRealtimeMessage(message);
+              directBridge?.handleRealtimeMessage("credential", message);
             }, signal);
             subscribeUserRealtimeEvents((message) => {
-              directBridge?.handleRealtimeMessage(message);
+              directBridge?.handleRealtimeMessage("user", message);
             }, signal);
             subscribeChatDatabaseRecovery(() => {
               directBridge?.handleRealtimeRecovery();

--- a/turbo/apps/platform/src/shared-database/worker-context.ts
+++ b/turbo/apps/platform/src/shared-database/worker-context.ts
@@ -30,6 +30,16 @@ export type WorkerBroadcastMessage = Extract<
   }
 >;
 
+type WorkerConnectionMessage = Extract<
+  SharedDatabaseWorkerMessage,
+  {
+    readonly type:
+      | "realtime-event"
+      | "realtime-subscribed"
+      | "realtime-subscription-error";
+  }
+>;
+
 const lastConnectionStatusState$ = state<SharedDatabaseConnectionStatus | null>(
   null,
 );
@@ -60,6 +70,21 @@ export const broadcastSharedDatabaseWorkerMessage$ = command(
       L.debug("send message to app", connectionId, message);
       connection.port.postMessage(message);
     }
+  },
+);
+
+export const sendSharedDatabaseWorkerMessageToConnection$ = command(
+  (
+    { get },
+    connectionId: ConnectionId,
+    message: WorkerConnectionMessage,
+  ): void => {
+    const connection = get(connectionsState$).get(connectionId);
+    if (!connection) {
+      return;
+    }
+    L.debug("send message to app", connectionId, message);
+    connection.port.postMessage(message);
   },
 );
 

--- a/turbo/apps/platform/src/shared-database/worker-realtime-subscriptions.ts
+++ b/turbo/apps/platform/src/shared-database/worker-realtime-subscriptions.ts
@@ -1,0 +1,295 @@
+import { command, state, type Command } from "ccstate";
+
+import { setAblyPayloadLoop$ } from "../signals/realtime.ts";
+import { createChildAbortController, settle } from "../signals/utils.ts";
+import { rootSignal$ } from "../signals/root-signal.ts";
+import {
+  serializeSharedDatabaseError,
+  sharedDatabaseRealtimeMessageSchema,
+  type SharedDatabaseClientMessage,
+  type SharedDatabaseRealtimeScope,
+} from "./protocol.ts";
+import {
+  requireConnectionSignal$,
+  sendSharedDatabaseWorkerMessageToConnection$,
+  type ConnectionId,
+} from "./worker-context.ts";
+
+type RealtimeSubscribeMessage = Extract<
+  SharedDatabaseClientMessage,
+  { readonly type: "realtime-subscribe" }
+>;
+
+interface RealtimeSubscriber {
+  readonly connectionId: ConnectionId;
+  readonly onAbort: () => void;
+  readonly signal: AbortSignal;
+  readonly subscriptionId: string;
+}
+
+interface WorkerRealtimeSubscription {
+  readonly controller: AbortController;
+  readonly ready: boolean;
+  readonly subscribers: ReadonlyMap<string, RealtimeSubscriber>;
+}
+
+interface RunWorkerRealtimeSubscriptionArgs {
+  readonly key: string;
+  readonly scope: SharedDatabaseRealtimeScope;
+  readonly topic: string;
+}
+
+const workerRealtimeSubscriptionsState$ = state<
+  ReadonlyMap<string, WorkerRealtimeSubscription>
+>(new Map());
+
+function workerRealtimeSubscriptionKey(
+  scope: SharedDatabaseRealtimeScope,
+  topic: string,
+): string {
+  return JSON.stringify([scope, topic]);
+}
+
+function realtimeSubscriberKey(
+  connectionId: ConnectionId,
+  subscriptionId: string,
+): string {
+  return JSON.stringify([connectionId, subscriptionId]);
+}
+
+function replaceWorkerRealtimeSubscription(
+  current: ReadonlyMap<string, WorkerRealtimeSubscription>,
+  key: string,
+  subscription: WorkerRealtimeSubscription,
+): ReadonlyMap<string, WorkerRealtimeSubscription> {
+  return new Map(current).set(key, subscription);
+}
+
+function removeWorkerRealtimeSubscription(
+  current: ReadonlyMap<string, WorkerRealtimeSubscription>,
+  key: string,
+): ReadonlyMap<string, WorkerRealtimeSubscription> {
+  const next = new Map(current);
+  next.delete(key);
+  return next;
+}
+
+const sendRealtimeSubscribed$ = command(
+  ({ set }, subscriber: RealtimeSubscriber): void => {
+    set(sendSharedDatabaseWorkerMessageToConnection$, subscriber.connectionId, {
+      type: "realtime-subscribed",
+      subscriptionId: subscriber.subscriptionId,
+    });
+  },
+);
+
+const markWorkerRealtimeSubscriptionReady$ = command(
+  ({ get, set }, key: string): void => {
+    const subscription = get(workerRealtimeSubscriptionsState$).get(key);
+    if (!subscription || subscription.ready) {
+      return;
+    }
+    const readySubscription: WorkerRealtimeSubscription = {
+      ...subscription,
+      ready: true,
+    };
+    set(workerRealtimeSubscriptionsState$, (current) => {
+      return replaceWorkerRealtimeSubscription(current, key, readySubscription);
+    });
+    for (const subscriber of readySubscription.subscribers.values()) {
+      set(sendRealtimeSubscribed$, subscriber);
+    }
+  },
+);
+
+const forwardWorkerRealtimeSubscriptionMessage$ = command(
+  (
+    { get, set },
+    key: string,
+    payload: unknown,
+    signal: AbortSignal,
+  ): boolean => {
+    signal.throwIfAborted();
+    const subscription = get(workerRealtimeSubscriptionsState$).get(key);
+    if (!subscription) {
+      return false;
+    }
+    const message = sharedDatabaseRealtimeMessageSchema.parse(payload);
+    for (const subscriber of subscription.subscribers.values()) {
+      set(
+        sendSharedDatabaseWorkerMessageToConnection$,
+        subscriber.connectionId,
+        {
+          type: "realtime-event",
+          subscriptionId: subscriber.subscriptionId,
+          message,
+        },
+      );
+    }
+    return false;
+  },
+);
+
+const failWorkerRealtimeSubscription$ = command(
+  ({ get, set }, key: string, error: unknown): void => {
+    const subscription = get(workerRealtimeSubscriptionsState$).get(key);
+    if (!subscription) {
+      return;
+    }
+    const serialized = serializeSharedDatabaseError(error);
+    for (const subscriber of subscription.subscribers.values()) {
+      subscriber.signal.removeEventListener("abort", subscriber.onAbort);
+      set(
+        sendSharedDatabaseWorkerMessageToConnection$,
+        subscriber.connectionId,
+        {
+          type: "realtime-subscription-error",
+          subscriptionId: subscriber.subscriptionId,
+          error: serialized,
+        },
+      );
+    }
+    set(workerRealtimeSubscriptionsState$, (current) => {
+      return removeWorkerRealtimeSubscription(current, key);
+    });
+    subscription.controller.abort(error);
+  },
+);
+
+function createWorkerRealtimeForwarder(
+  key: string,
+): Command<Promise<boolean> | boolean, [unknown, AbortSignal]> {
+  return command(({ set }, payload: unknown, signal: AbortSignal) => {
+    return set(forwardWorkerRealtimeSubscriptionMessage$, key, payload, signal);
+  });
+}
+
+const runWorkerRealtimeSubscription$ = command(
+  async (
+    { set },
+    { key, scope, topic }: RunWorkerRealtimeSubscriptionArgs,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const result = await settle(
+      set(
+        setAblyPayloadLoop$,
+        {
+          scope,
+          topic,
+          loopCommand$: createWorkerRealtimeForwarder(key),
+          includeMessage: true,
+          options: {
+            onSubscribed: () => {
+              set(markWorkerRealtimeSubscriptionReady$, key);
+            },
+          },
+        },
+        signal,
+      ),
+      signal,
+    );
+    if (!result.ok && !signal.aborted) {
+      set(failWorkerRealtimeSubscription$, key, result.error);
+    }
+  },
+);
+
+export const stopWorkerRealtimeSubscription$ = command(
+  ({ get, set }, connectionId: ConnectionId, subscriptionId: string): void => {
+    const subscriberKey = realtimeSubscriberKey(connectionId, subscriptionId);
+    for (const [key, subscription] of get(workerRealtimeSubscriptionsState$)) {
+      if (!subscription.subscribers.has(subscriberKey)) {
+        continue;
+      }
+      const subscriber = subscription.subscribers.get(subscriberKey);
+      if (!subscriber) {
+        return;
+      }
+      subscriber.signal.removeEventListener("abort", subscriber.onAbort);
+      const subscribers = new Map(subscription.subscribers);
+      subscribers.delete(subscriberKey);
+      if (subscribers.size === 0) {
+        set(workerRealtimeSubscriptionsState$, (current) => {
+          return removeWorkerRealtimeSubscription(current, key);
+        });
+        subscription.controller.abort(
+          new DOMException("Realtime subscription closed", "AbortError"),
+        );
+        return;
+      }
+      set(workerRealtimeSubscriptionsState$, (current) => {
+        return replaceWorkerRealtimeSubscription(current, key, {
+          ...subscription,
+          subscribers,
+        });
+      });
+      return;
+    }
+  },
+);
+
+export const startWorkerRealtimeSubscription$ = command(
+  (
+    { get, set },
+    connectionId: ConnectionId,
+    message: RealtimeSubscribeMessage,
+    signal: AbortSignal,
+  ): Promise<void> | null => {
+    set(requireConnectionSignal$, connectionId, signal);
+    const key = workerRealtimeSubscriptionKey(message.scope, message.topic);
+    const subscriberKey = realtimeSubscriberKey(
+      connectionId,
+      message.subscriptionId,
+    );
+    const onAbort = () => {
+      set(
+        stopWorkerRealtimeSubscription$,
+        connectionId,
+        message.subscriptionId,
+      );
+    };
+    const subscriber: RealtimeSubscriber = {
+      connectionId,
+      onAbort,
+      signal,
+      subscriptionId: message.subscriptionId,
+    };
+    const current = get(workerRealtimeSubscriptionsState$);
+    const existing = current.get(key);
+    if (existing) {
+      if (existing.subscribers.has(subscriberKey)) {
+        throw new Error("Shared database realtime subscription already exists");
+      }
+      const subscribers = new Map(existing.subscribers);
+      subscribers.set(subscriberKey, subscriber);
+      const updated: WorkerRealtimeSubscription = {
+        ...existing,
+        subscribers,
+      };
+      set(workerRealtimeSubscriptionsState$, (state) => {
+        return replaceWorkerRealtimeSubscription(state, key, updated);
+      });
+      signal.addEventListener("abort", subscriber.onAbort, { once: true });
+      if (updated.ready) {
+        set(sendRealtimeSubscribed$, subscriber);
+      }
+      return null;
+    }
+
+    const controller = createChildAbortController(get(rootSignal$));
+    const subscription: WorkerRealtimeSubscription = {
+      controller,
+      ready: false,
+      subscribers: new Map([[subscriberKey, subscriber]]),
+    };
+    set(workerRealtimeSubscriptionsState$, (state) => {
+      return replaceWorkerRealtimeSubscription(state, key, subscription);
+    });
+    signal.addEventListener("abort", subscriber.onAbort, { once: true });
+    return set(
+      runWorkerRealtimeSubscription$,
+      { key, scope: message.scope, topic: message.topic },
+      controller.signal,
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -13,6 +13,7 @@ import {
   setAblyLoop$,
   setAblyPayloadLoop$,
   setRealtimeDegradedNotifier$,
+  setSharedWorkerRealtimeBridge$,
   subscribeRealtimeReadyCatchUp$,
 } from "../realtime.ts";
 import { clerk$, setupClerk$ } from "../auth.ts";
@@ -28,6 +29,20 @@ import { testContext } from "./test-helpers.ts";
 import { now } from "../../lib/time.ts";
 import { subscribePresentationTemplatesChanged$ } from "../okou-page/presentation-template-library.ts";
 import { detach, Reason } from "../utils.ts";
+import type { SharedDatabaseBridge } from "../../shared-database/bridge.ts";
+import type {
+  ComputedKey,
+  ComputedValue,
+} from "../../shared-database/computed-key.ts";
+import type {
+  SharedDatabaseDataKey,
+  SharedDatabaseQuery,
+  SharedDatabaseQueryResult,
+} from "../../shared-database/data-key.ts";
+import type {
+  SharedDatabaseRealtimeMessage,
+  SharedDatabaseRealtimeScope,
+} from "../../shared-database/protocol.ts";
 
 const context = testContext();
 
@@ -102,6 +117,90 @@ function testSubscriber(): AbortController {
   );
   return controller;
 }
+
+interface SharedWorkerRealtimeSubscription {
+  readonly listener: (message: SharedDatabaseRealtimeMessage) => void;
+  readonly scope: SharedDatabaseRealtimeScope;
+  readonly topic: string;
+}
+
+class TestSharedWorkerRealtimeBridge implements SharedDatabaseBridge {
+  readonly subscriptions = new Map<string, SharedWorkerRealtimeSubscription>();
+
+  registerTab(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  subscribeRealtime(
+    subscriptionId: string,
+    scope: SharedDatabaseRealtimeScope,
+    topic: string,
+    listener: (message: SharedDatabaseRealtimeMessage) => void,
+  ): Promise<void> {
+    this.subscriptions.set(subscriptionId, { listener, scope, topic });
+    return Promise.resolve();
+  }
+
+  unsubscribeRealtime(subscriptionId: string): void {
+    this.subscriptions.delete(subscriptionId);
+  }
+
+  getComputed<TKey extends ComputedKey>(
+    _computedKey: TKey,
+  ): Promise<ComputedValue<TKey>> {
+    return Promise.reject(new Error("Computed data is not configured"));
+  }
+
+  query<TKey extends SharedDatabaseDataKey>(
+    _query: SharedDatabaseQuery<TKey>,
+    _signal: AbortSignal,
+  ): Promise<SharedDatabaseQueryResult<TKey>> {
+    return Promise.reject(
+      new Error("Shared database queries are not configured"),
+    );
+  }
+
+  publish(
+    scope: SharedDatabaseRealtimeScope,
+    topic: string,
+    data: unknown,
+  ): void {
+    for (const subscription of this.subscriptions.values()) {
+      if (subscription.scope === scope && subscription.topic === topic) {
+        subscription.listener({ name: topic, data });
+      }
+    }
+  }
+}
+
+test("Route app subscriptions through the SharedWorker without an App Ably client", async () => {
+  mockSignedInUser();
+  const bridge = new TestSharedWorkerRealtimeBridge();
+  const subscriber = testSubscriber();
+  let runs = 0;
+  const loop$ = command((_ctx, _signal: AbortSignal) => {
+    runs += 1;
+    return true;
+  });
+
+  context.store.set(setSharedWorkerRealtimeBridge$, bridge);
+  await context.store.set(setupRealtime$, context.signal);
+  const loopPromise = context.store.set(
+    setAblyLoop$,
+    { topic: "connectorPermissionUpdated", loopCommand$: loop$ },
+    subscriber.signal,
+  );
+
+  await vi.waitFor(() => {
+    expect(bridge.subscriptions).toHaveLength(1);
+  });
+  expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(0);
+
+  bridge.publish("user", "connectorPermissionUpdated", { revision: 1 });
+  await expect(loopPromise).resolves.toBeUndefined();
+  expect(runs).toBe(1);
+  expect(bridge.subscriptions).toHaveLength(0);
+});
 
 test("A pending live-update listener starts after realtime connects", async () => {
   mockSignedInUser();

--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -1,19 +1,33 @@
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { command } from "ccstate";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import { clerk$, setupClerk$ } from "./auth.ts";
 import { setAuthenticatedIdentity$ } from "./auth-context.ts";
 import { subscribeEventDrivenChatThreads$ } from "./chat-page/chat-thread-event-sourcing.ts";
 import { setupUserPreferenceRealtime$ } from "./external/user-model-preference.ts";
+import { featureSwitch$ } from "./external/feature-switch.ts";
 import { subscribePermissionUpdate$ } from "./permission-allow/permission-allow-signals.ts";
-import { setRealtimeDegradedNotifier$, setupRealtime$ } from "./realtime.ts";
+import {
+  setRealtimeDegradedNotifier$,
+  setSharedWorkerRealtimeBridge$,
+  setupRealtime$,
+} from "./realtime.ts";
 import { i18n } from "../i18n/index.ts";
 import { setupBillingRealtime$ } from "./okou-page/billing.ts";
 import { subscribePresentationTemplatesChanged$ } from "./okou-page/presentation-template-library.ts";
 import { subscribeCustomConnectorListChanged$ } from "./okou-page/settings/custom-connectors.ts";
-import { bridgeConnected$ } from "./shared-database-bridge-state.ts";
+import {
+  bridgeConnected$,
+  installedSharedDatabaseBridge$,
+} from "./shared-database-bridge-state.ts";
 
 const runAppRealtimeDaemons$ = command(
-  async ({ set }, signal: AbortSignal): Promise<void> => {
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    if (get(featureSwitch$)[FeatureSwitchKey.SharedWorkerRealtime] ?? false) {
+      await get(bridgeConnected$);
+      signal.throwIfAborted();
+      set(setSharedWorkerRealtimeBridge$, get(installedSharedDatabaseBridge$));
+    }
     await set(setupRealtime$, signal);
     signal.throwIfAborted();
     await Promise.all([

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -7,6 +7,8 @@ import type {
   RealtimeChannel,
 } from "ably";
 import { delay } from "signal-timers";
+import type { SharedDatabaseBridge } from "../shared-database/bridge.ts";
+import type { SharedDatabaseRealtimeScope } from "../shared-database/protocol.ts";
 import { IN_VITEST } from "../env.ts";
 import { createAblyRealtime, type AblyRealtime } from "../lib/ably-realtime.ts";
 import { now } from "../lib/time.ts";
@@ -101,7 +103,12 @@ const notifyRealtimeDegraded$ = command(({ get, set }) => {
   get(realtimeDegradedNotifier$)?.();
 });
 
-type ChannelCallback = (message: InboundMessage) => void;
+interface RealtimeMessage {
+  readonly data: unknown;
+  readonly name: string | null;
+}
+
+type ChannelCallback = (message: RealtimeMessage) => void;
 
 interface StableRealtimeChannel {
   readonly state: () => RealtimeChannelState | null;
@@ -125,13 +132,78 @@ interface RealtimeSession {
   readonly close: () => void;
 }
 
-type RealtimeChannelScope = "user" | "org" | "credential";
+type RealtimeChannelScope = SharedDatabaseRealtimeScope;
 
 interface RealtimeSessionChannels {
   readonly credential: StableRealtimeChannel;
   readonly user: StableRealtimeChannel;
   readonly org: StableRealtimeChannel;
 }
+
+class SharedWorkerRealtimeChannel implements StableRealtimeChannel {
+  private readonly subscriptions = new Map<ChannelCallback, string>();
+
+  constructor(
+    private readonly bridge: SharedDatabaseBridge,
+    private readonly scope: RealtimeChannelScope,
+  ) {}
+
+  state(): RealtimeChannelState | null {
+    return null;
+  }
+
+  subscribe(topic: string | null, callback: ChannelCallback): Promise<unknown> {
+    if (topic === null) {
+      throw new Error("Shared Worker realtime subscriptions require a topic");
+    }
+    if (this.subscriptions.has(callback)) {
+      throw new Error("Shared Worker realtime callback already exists");
+    }
+    const subscriptionId = crypto.randomUUID();
+    this.subscriptions.set(callback, subscriptionId);
+    return this.bridge.subscribeRealtime(
+      subscriptionId,
+      this.scope,
+      topic,
+      callback,
+    );
+  }
+
+  unsubscribe(_topic: string | null, callback: ChannelCallback): void {
+    const subscriptionId = this.subscriptions.get(callback);
+    if (!subscriptionId) {
+      return;
+    }
+    this.subscriptions.delete(callback);
+    this.bridge.unsubscribeRealtime(subscriptionId);
+  }
+
+  pauseSubscriptions(): void {
+    // The SharedWorker owns this subscription independently of tab visibility.
+  }
+
+  resumeSubscriptions(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  suspend(): void {
+    // The SharedWorker owns this subscription independently of tab visibility.
+  }
+
+  replace(_channel: RealtimeChannel): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+const sharedWorkerRealtimeBridgeState$ = state<SharedDatabaseBridge | null>(
+  null,
+);
+
+export const setSharedWorkerRealtimeBridge$ = command(
+  ({ set }, bridge: SharedDatabaseBridge): void => {
+    set(sharedWorkerRealtimeBridgeState$, bridge);
+  },
+);
 
 const internalRealtimeSession$ = state<RealtimeSession | null>(null);
 const realtimeStateRevision$ = state(0);
@@ -402,7 +474,7 @@ const runWithChannel$ = command(
       pokeLoop();
     };
 
-    const callback = (message: InboundMessage) => {
+    const callback = (message: RealtimeMessage) => {
       if (signal.aborted) {
         return;
       }
@@ -652,7 +724,7 @@ const runWithChannelPayload$ = command(
       pokeLoop();
     };
 
-    const callback = (message: InboundMessage) => {
+    const callback = (message: RealtimeMessage) => {
       if (signal.aborted) {
         return;
       }
@@ -701,6 +773,7 @@ const runWithChannelPayload$ = command(
 interface ActiveChannelSubscription {
   readonly topic: string | null;
   readonly callback: ChannelCallback;
+  readonly ablyCallback: (message: InboundMessage) => void;
   readonly channels: Set<RealtimeChannel>;
 }
 
@@ -709,9 +782,9 @@ function subscribeToRealtimeChannel(
   subscription: ActiveChannelSubscription,
 ): Promise<unknown> {
   if (subscription.topic === null) {
-    return channel.subscribe(subscription.callback);
+    return channel.subscribe(subscription.ablyCallback);
   }
-  return channel.subscribe(subscription.topic, subscription.callback);
+  return channel.subscribe(subscription.topic, subscription.ablyCallback);
 }
 
 function unsubscribeFromRealtimeChannel(
@@ -719,10 +792,10 @@ function unsubscribeFromRealtimeChannel(
   subscription: ActiveChannelSubscription,
 ): void {
   if (subscription.topic === null) {
-    channel.unsubscribe(subscription.callback);
+    channel.unsubscribe(subscription.ablyCallback);
     return;
   }
-  channel.unsubscribe(subscription.topic, subscription.callback);
+  channel.unsubscribe(subscription.topic, subscription.ablyCallback);
 }
 
 async function trackRealtimeSubscription(
@@ -826,6 +899,9 @@ async function subscribeStableRealtimeChannel(
   const subscription: ActiveChannelSubscription = {
     topic,
     callback,
+    ablyCallback: (message) => {
+      callback({ data: message.data, name: message.name ?? null });
+    },
     channels: new Set(),
   };
   state.subscriptions.set(callback, subscription);
@@ -1159,8 +1235,16 @@ const connectRealtimeClient$ = command(
 
 const foregroundRealtimeCatchUp$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const sharedWorkerBridge = get(sharedWorkerRealtimeBridgeState$);
     const session = get(internalRealtimeSession$);
     const subscriberPokeTarget = get(subscriberPokeTarget$);
+    if (sharedWorkerBridge) {
+      L.debug("Shared Worker realtime foreground catch-up ready");
+      subscriberPokeTarget.dispatchEvent(new Event(SUBSCRIBER_POKE_EVENT));
+      await set(runRealtimeReadyCatchUp$, signal);
+      signal.throwIfAborted();
+      return;
+    }
     if (!session) {
       publishConnectionDiagnostic({
         details: { skipReason: "no-realtime-session" },
@@ -1278,6 +1362,10 @@ const foregroundRealtimeCatchUp$ = command(
  */
 export const setupRealtime$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    if (get(sharedWorkerRealtimeBridgeState$)) {
+      set(subscribeForegroundCatchUp$, foregroundRealtimeCatchUp$, signal);
+      return;
+    }
     const rejectPendingSubscriptions = (reason?: unknown) => {
       const pendingSubscriptions = get(pendingAblySubscriptions$);
       if (pendingSubscriptions.length === 0) {
@@ -1367,6 +1455,11 @@ const realtimeChannel$ = command(
   ): Promise<StableRealtimeChannel> => {
     signal.throwIfAborted();
 
+    const sharedWorkerBridge = get(sharedWorkerRealtimeBridgeState$);
+    if (sharedWorkerBridge) {
+      return new SharedWorkerRealtimeChannel(sharedWorkerBridge, scope);
+    }
+
     const session = get(internalRealtimeSession$);
     if (session) {
       return session.channels[scope];
@@ -1394,6 +1487,14 @@ const realtimeChannel$ = command(
     const connectedChannel = await channelDeferred.promise;
     signal.throwIfAborted();
     return connectedChannel;
+  },
+);
+
+export const notifySharedWorkerRealtimeReconnected$ = command(
+  ({ get, set }): void => {
+    if (get(sharedWorkerRealtimeBridgeState$)) {
+      set(requestForegroundCatchUp$);
+    }
   },
 );
 

--- a/turbo/apps/platform/src/signals/shared-database-browser.ts
+++ b/turbo/apps/platform/src/signals/shared-database-browser.ts
@@ -28,6 +28,7 @@ import {
 } from "./chat-page/chat-event-signal-registry.ts";
 import { syncEventDrivenChatThreads$ } from "./chat-page/chat-thread-event-sourcing.ts";
 import { reportForceUpgradeRequired } from "./force-upgrade.ts";
+import { notifySharedWorkerRealtimeReconnected$ } from "./realtime.ts";
 import {
   installSharedDatabaseBridge$,
   setBridgeConnected$,
@@ -135,6 +136,7 @@ const syncSharedDatabaseInvalidation$ = command(
 
 const syncSharedDatabaseReconnect$ = command(
   async ({ set }, signal: AbortSignal): Promise<void> => {
+    set(notifySharedWorkerRealtimeReconnected$);
     await Promise.all([
       set(syncAllActiveChatEvents$, signal),
       set(syncEventDrivenChatThreads$, signal),

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -22,6 +22,7 @@ describe("FeatureSwitchKey", () => {
     expect(FeatureSwitchKey.CodexFastMode).toBe("_fastModel");
     expect(FeatureSwitchKey.ChatPreference).toBe("chatPreference");
     expect(FeatureSwitchKey.OkouDebug).toBe("_debug");
+    expect(FeatureSwitchKey.SharedWorkerRealtime).toBe("_sharedWorkerRealtime");
     expect(FeatureSwitchKey.RealAgentInPreview).toBe("_realAgentInPreview");
     expect(FeatureSwitchKey.TestOauthConnector).toBe("_testOauthConnector");
     expect(FeatureSwitchKey.SshAccess).toBe("_sshAccess");
@@ -57,6 +58,9 @@ describe("isFeatureEnabled", () => {
   it("should return false for disabled switch without context", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.SshAccess, {})).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.SharedWorkerRealtime, {})).toBe(
+      false,
+    );
     expect(getFeatureSwitchMetadata()[FeatureSwitchKey.SshAccess]).toEqual({
       maintainer: "ethan@vm0.ai",
       description: "Enable standalone Runner-mediated SSH configuration",

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -33,6 +33,7 @@ export enum FeatureSwitchKey {
   SpotifyConnector = "spotifyConnector",
   StripeMarketplaceOAuthConnector = "stripeMarketplaceOAuthConnector",
   OkouDebug = "_debug",
+  SharedWorkerRealtime = "_sharedWorkerRealtime",
   Banking = "banking",
   Lab = "_lab",
   NotionWorkflowAutomations = "notionWorkflowAutomations",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -192,6 +192,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Reveal activity debug surfaces, activity log navigation, appended system prompts, realtime connection diagnostics, and Debug preferences",
     enabled: false,
   },
+  [FeatureSwitchKey.SharedWorkerRealtime]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Route application realtime subscriptions through the SharedWorker",
+    enabled: false,
+  },
   [FeatureSwitchKey.Banking]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- add the internal `_sharedWorkerRealtime` feature switch, off by default
- route existing App realtime loops through the registered SharedWorker when enabled, without creating an App-side Ably client
- add typed, allowlisted MessagePort subscribe/unsubscribe messages; the Worker reference-counts user/org topic subscriptions and fans events only to requesting tabs
- bind each Worker subscription to its existing connection signal and immediately release the underlying subscription after its final consumer exits

## Rollout behavior
- **Switch off:** current App-side Ably behavior is unchanged.
- **Switch on:** the SharedWorker is the sole App realtime transport. There is no automatic fallback to an App-side connection; disabling the switch and reloading is the rollback path.

## Verification
- `pnpm -F @okouai/core check-types`
- `pnpm -F @okouai/app check-types`
- targeted Platform Vitest: MessagePort, single-connection bridge, realtime, shared-database browser, and authentication startup suites
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/app lint`
- production App build with dummy Clerk publishable keys (including Worker DOM gate)
- `npx knip --workspace apps/platform`
