### PR TITLE
fix(pi-memory): protect active maintenance from cleanup

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/pi-memory-maintenance.boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/pi-memory-maintenance.boundary.test.ts
@@ -13,7 +13,11 @@ import { promisify } from "node:util";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
-import { executionContextSchema } from "@okouai/api-contracts/contracts/runners";
+import {
+  CANCELLATION_RECOVERY_STALE_AFTER_MS,
+  executionContextSchema,
+} from "@okouai/api-contracts/contracts/runners";
+import { testCronCleanupSandboxesStateContract } from "@okouai/api-contracts/contracts/test-cron-cleanup-sandboxes-state";
 import { agents } from "@okouai/db/schema/agent";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentSessions } from "@okouai/db/schema/agent-session";
@@ -31,20 +35,24 @@ import { describe, expect, it, onTestFinished } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { guestBoundaryEnvironment } from "../../../__tests__/env-stub";
-import { nowDate } from "../../../lib/time";
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp } from "../../../__tests__/test-helpers";
+import { mockNow, nowDate } from "../../../lib/time";
 import { settle } from "../../utils";
-import { testContext } from "../../../__tests__/test-context";
 import { db } from "../../../lib/db";
 import { mockOptionalEnv } from "../../../lib/env";
+import { holdAgentRunRowLockFixture } from "../../../test-fixtures/chat-events";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { runnersRoutes } from "../../routes/runners";
 import { webhooksAgentCompleteRoutes } from "../../routes/webhooks-agent-complete";
 import { webhooksAgentHealthUsageTelemetryRoutes } from "../../routes/webhooks-agent-health-usage-telemetry";
 import { webhooksAgentStorageRoutes } from "../../routes/webhooks-agent-storage";
+import { testCronCleanupSandboxesStateRoutes } from "../../routes/test-cron-cleanup-sandboxes-state";
 import { seedBuiltInModelKey } from "../../routes/__tests__/helpers/runtime-state";
 import {
   advancePiMemoryPhase2InputRevision,
   notifyPiMemoryPhase2ExternalHeadChange,
+  PI_MEMORY_PHASE2_LEASE_DURATION_MS,
 } from "../pi-memory-phase2-job.service";
 import { executePiMemoryPhase2Work$ } from "../pi-memory-phase2-worker.service";
 import {
@@ -192,6 +200,120 @@ type Fault =
   | "new_input";
 
 type BoundaryScope = Awaited<ReturnType<typeof createPhase2TestScope>>;
+type CleanupMode = "active" | "renewed-race";
+interface ActiveMaintenanceFence {
+  readonly selectionDigest: string;
+  readonly selectedCount: number;
+  readonly selectedUtf8Bytes: number;
+}
+
+async function cleanupMaintenanceRun(runId: string, scope: BoundaryScope) {
+  const response = await accept(
+    setupApp({ context, routes: testCronCleanupSandboxesStateRoutes })(
+      testCronCleanupSandboxesStateContract,
+    ).cleanup({
+      body: {
+        chatThreadIds: [],
+        runIds: [runId],
+        orgIds: [scope.orgId],
+        exportJobIds: [],
+      },
+    }),
+    [200],
+  );
+  return response.body;
+}
+
+async function readActiveMaintenanceFence(
+  runId: string,
+  scope: BoundaryScope,
+): Promise<ActiveMaintenanceFence> {
+  const job = await readPhase2Job(scope);
+  if (
+    !job ||
+    job.claimedSelectionDigest === null ||
+    job.claimedSelectedCount === null ||
+    job.claimedSelectedUtf8Bytes === null
+  ) {
+    throw new Error("Missing active maintenance fence");
+  }
+  expect(job).toMatchObject({ status: "leased", maintenanceRunId: runId });
+  return {
+    selectionDigest: job.claimedSelectionDigest,
+    selectedCount: job.claimedSelectedCount,
+    selectedUtf8Bytes: job.claimedSelectedUtf8Bytes,
+  };
+}
+
+async function crossActiveCleanupBoundary(
+  runId: string,
+  scope: BoundaryScope,
+  cleanupMode: CleanupMode | undefined,
+): Promise<void> {
+  if (cleanupMode === "active") {
+    const cleanupResult = await cleanupMaintenanceRun(runId, scope);
+    expect(cleanupResult.threadlessRuns).toStrictEqual({
+      discovered: 0,
+      cancelled: 0,
+      waiting: 0,
+      deleted: 0,
+      failed: 0,
+      errors: [],
+    });
+  }
+  if (cleanupMode === "renewed-race") {
+    await db()
+      .update(piMemoryPhase2Jobs)
+      .set({ leaseExpiresAt: new Date(nowDate().getTime() - 1) })
+      .where(eq(piMemoryPhase2Jobs.memoryStorageId, scope.memoryStorageId));
+    const runLock = await holdAgentRunRowLockFixture({
+      runId,
+      signal: context.signal,
+    });
+    onTestFinished(async () => {
+      runLock.release();
+      await runLock.done;
+    });
+    const cleanupRequest = cleanupMaintenanceRun(runId, scope);
+    await expect.poll(runLock.waiterCount).toBeGreaterThan(0);
+    await db()
+      .update(piMemoryPhase2Jobs)
+      .set({
+        leaseExpiresAt: new Date(
+          nowDate().getTime() + PI_MEMORY_PHASE2_LEASE_DURATION_MS,
+        ),
+      })
+      .where(eq(piMemoryPhase2Jobs.memoryStorageId, scope.memoryStorageId));
+    runLock.release();
+    await runLock.done;
+    const cleanupResult = await cleanupRequest;
+    expect(cleanupResult.threadlessRuns).toStrictEqual({
+      discovered: 1,
+      cancelled: 0,
+      waiting: 1,
+      deleted: 0,
+      failed: 0,
+      errors: [],
+    });
+    const continuousResult = await cleanupMaintenanceRun(runId, scope);
+    expect(continuousResult.threadlessRuns).toStrictEqual({
+      discovered: 0,
+      cancelled: 0,
+      waiting: 0,
+      deleted: 0,
+      failed: 0,
+      errors: [],
+    });
+  }
+  if (cleanupMode) {
+    await expect(
+      db()
+        .select({ status: agentRuns.status })
+        .from(agentRuns)
+        .where(eq(agentRuns.id, runId)),
+    ).resolves.toStrictEqual([{ status: "running" }]);
+  }
+}
 
 function phase2JobSeed(fault: Fault, dispatchTime: Date) {
   if (fault !== "maintenance_agent_missing_retry") {
@@ -269,7 +391,7 @@ async function claimMaintenanceRun(
   };
 }
 
-async function launch(fault: Fault, noDiff = false) {
+async function launch(fault: Fault, noDiff = false, cleanupMode?: CleanupMode) {
   const scope = await createPhase2TestScope(`boundary-${fault}`, {
     emptyBase: true,
   });
@@ -400,10 +522,7 @@ async function launch(fault: Fault, noDiff = false) {
     dispatchTime,
     runId: result.runId,
   });
-  await expect(readPhase2Job(scope)).resolves.toMatchObject({
-    status: "leased",
-    maintenanceRunId: result.runId,
-  });
+  const activeFence = await readActiveMaintenanceFence(result.runId, scope);
   const [callback] = await db()
     .select()
     .from(agentRunCallbacks)
@@ -658,6 +777,7 @@ async function launch(fault: Fault, noDiff = false) {
     leaseToken: binding.leaseToken,
     selected: binding.selected,
   });
+  await crossActiveCleanupBoundary(result.runId, scope, cleanupMode);
   const token = execution.sandboxToken;
   const quote = (value: string) => {
     return `'${value.replaceAll("'", String.raw`'\''`)}'`;
@@ -783,6 +903,7 @@ async function launch(fault: Fault, noDiff = false) {
     objects,
     memory,
     releaseObserver,
+    activeFence,
   };
 }
 
@@ -858,17 +979,30 @@ async function assertUsageReplay(
 
 describe("private maintenance across CLI, Guest, generic checkpoint and real PostgreSQL", () => {
   it.each([
-    "none",
-    "maintenance_agent_missing_retry",
-    "commit_ack",
-    "complete_transaction",
-    "complete_ack",
-    "observer",
-    "new_input",
+    { label: "none", fault: "none", cleanupMode: undefined },
+    {
+      label: "maintenance_agent_missing_retry",
+      fault: "maintenance_agent_missing_retry",
+      cleanupMode: undefined,
+    },
+    { label: "commit_ack", fault: "commit_ack", cleanupMode: undefined },
+    {
+      label: "complete_transaction",
+      fault: "complete_transaction",
+      cleanupMode: undefined,
+    },
+    { label: "complete_ack", fault: "complete_ack", cleanupMode: undefined },
+    { label: "observer", fault: "observer", cleanupMode: undefined },
+    { label: "new_input", fault: "new_input", cleanupMode: undefined },
+    {
+      label: "cleanup lease renewal",
+      fault: "none",
+      cleanupMode: "renewed-race",
+    },
   ] as const)(
-    "settles changed output exactly once through %s",
-    async (fault) => {
-      const run = await launch(fault);
+    "settles changed output exactly once through $label",
+    async ({ fault, cleanupMode }) => {
+      const run = await launch(fault, false, cleanupMode);
       expect(run.job, run.output).toMatchObject({
         completedRevision: 1,
         retryCount: 0,
@@ -1021,13 +1155,73 @@ describe("private maintenance across CLI, Guest, generic checkpoint and real Pos
           .from(storageVersionLineage)
           .where(eq(storageVersionLineage.runId, run.runId)),
       ).resolves.toHaveLength(1);
+
+      if (cleanupMode === "renewed-race") {
+        const completedAt = run.run?.completedAt;
+        if (!completedAt) {
+          throw new Error("Cleanup regression run did not complete");
+        }
+        const staleLeaseToken = randomUUID();
+        await db()
+          .update(piMemoryPhase2Jobs)
+          .set({
+            status: "leased",
+            inputRevision: 2,
+            claimedRevision: 2,
+            claimedBaseVersionId: later.versionId,
+            leaseToken: staleLeaseToken,
+            legacyLeaseToken: null,
+            sandboxLeaseToken: staleLeaseToken,
+            leaseExpiresAt: new Date(completedAt.getTime() - 1),
+            maintenanceRunId: run.runId,
+            retryCount: 0,
+            retryAt: null,
+            lastErrorClass: null,
+            claimedSelectionDigest: run.activeFence.selectionDigest,
+            claimedSelectedCount: run.activeFence.selectedCount,
+            claimedSelectedUtf8Bytes: run.activeFence.selectedUtf8Bytes,
+            lastObservedHeadVersionId: later.versionId,
+            updatedAt: completedAt,
+          })
+          .where(
+            eq(piMemoryPhase2Jobs.memoryStorageId, run.scope.memoryStorageId),
+          );
+        mockNow(completedAt.getTime() + CANCELLATION_RECOVERY_STALE_AFTER_MS);
+        const cleanupResult = await cleanupMaintenanceRun(run.runId, run.scope);
+        expect(cleanupResult.threadlessRuns).toStrictEqual({
+          discovered: 1,
+          cancelled: 0,
+          waiting: 0,
+          deleted: 1,
+          failed: 0,
+          errors: [],
+        });
+        await expect(
+          db()
+            .select({ id: agentRuns.id })
+            .from(agentRuns)
+            .where(eq(agentRuns.id, run.runId)),
+        ).resolves.toStrictEqual([]);
+      }
     },
   );
 
-  it.each(["none", "represented_no_diff"] as const)(
-    "settles real no-diff with %s selection and no provider charge",
-    async (fault) => {
-      const run = await launch(fault, true);
+  it.each([
+    { label: "none", fault: "none", cleanupMode: undefined },
+    {
+      label: "represented_no_diff",
+      fault: "represented_no_diff",
+      cleanupMode: undefined,
+    },
+    {
+      label: "represented_no_diff across active cleanup",
+      fault: "represented_no_diff",
+      cleanupMode: "active",
+    },
+  ] as const)(
+    "settles real no-diff with $label selection and no provider charge",
+    async ({ fault, cleanupMode }) => {
+      const run = await launch(fault, true, cleanupMode);
       expect(run.job, run.output).toMatchObject({
         completedRevision: 1,
         lastMaintenanceOutcome: "no_diff",
@@ -1070,6 +1264,29 @@ describe("private maintenance across CLI, Guest, generic checkpoint and real Pos
           .from(storageVersionLineage)
           .where(eq(storageVersionLineage.runId, run.runId)),
       ).resolves.toHaveLength(0);
+
+      if (cleanupMode === "active") {
+        const completedAt = run.run?.completedAt;
+        if (!completedAt) {
+          throw new Error("Cleanup no-diff run did not complete");
+        }
+        mockNow(completedAt.getTime() + CANCELLATION_RECOVERY_STALE_AFTER_MS);
+        const cleanupResult = await cleanupMaintenanceRun(run.runId, run.scope);
+        expect(cleanupResult.threadlessRuns).toStrictEqual({
+          discovered: 1,
+          cancelled: 0,
+          waiting: 0,
+          deleted: 1,
+          failed: 0,
+          errors: [],
+        });
+        await expect(
+          db()
+            .select({ id: agentRuns.id })
+            .from(agentRuns)
+            .where(eq(agentRuns.id, run.runId)),
+        ).resolves.toStrictEqual([]);
+      }
     },
   );
 

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-maintenance.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-maintenance.service.ts
@@ -7,7 +7,19 @@ import {
 } from "@okouai/db/schema/pi-memory-phase2-job";
 import { piMemoryStage1Candidates } from "@okouai/db/schema/pi-memory-stage1-candidate";
 import { storageVersionLineage } from "@okouai/db/schema/storage-version-lineage";
-import { and, eq, sql } from "drizzle-orm";
+import {
+  and,
+  eq,
+  exists,
+  gt,
+  isNotNull,
+  isNull,
+  lt,
+  lte,
+  sql,
+  type SQL,
+  type SQLWrapper,
+} from "drizzle-orm";
 import { z } from "zod";
 
 import type { ApiDb, Tx } from "../../lib/db-types";
@@ -60,6 +72,106 @@ interface PiMemoryPhase2MaintenanceRunBinding {
   readonly claimedRevision: number;
   readonly claimedBaseVersionId: string;
   readonly selectionDigest: string;
+}
+
+/**
+ * Match the complete live sandbox-maintenance fence for one owned run. The
+ * job constraints make these fields move together, while spelling them out
+ * here keeps cleanup fail-closed if an invalid legacy row is ever observed.
+ */
+export function activePiMemoryPhase2MaintenanceRunCondition(
+  db: Pick<ApiDb, "select">,
+  args: {
+    readonly runId: string | SQLWrapper;
+    readonly orgId: string | SQLWrapper;
+    readonly userId: string | SQLWrapper;
+    readonly currentTime: Date;
+  },
+): SQL {
+  return and(
+    eq(piMemoryPhase2Jobs.maintenanceRunId, args.runId),
+    eq(piMemoryPhase2Jobs.orgId, args.orgId),
+    eq(piMemoryPhase2Jobs.userId, args.userId),
+    eq(piMemoryPhase2Jobs.status, "leased"),
+    isNull(piMemoryPhase2Jobs.legacyLeaseToken),
+    isNotNull(piMemoryPhase2Jobs.leaseToken),
+    eq(piMemoryPhase2Jobs.sandboxLeaseToken, piMemoryPhase2Jobs.leaseToken),
+    gt(piMemoryPhase2Jobs.leaseExpiresAt, args.currentTime),
+    isNotNull(piMemoryPhase2Jobs.claimedRevision),
+    gt(
+      piMemoryPhase2Jobs.claimedRevision,
+      piMemoryPhase2Jobs.completedRevision,
+    ),
+    lte(piMemoryPhase2Jobs.claimedRevision, piMemoryPhase2Jobs.inputRevision),
+    isNotNull(piMemoryPhase2Jobs.claimedBaseVersionId),
+    lt(piMemoryPhase2Jobs.retryCount, PI_MEMORY_PHASE2_MAX_ATTEMPTS),
+    isNull(piMemoryPhase2Jobs.retryAt),
+    isNull(piMemoryPhase2Jobs.lastErrorClass),
+    isNotNull(piMemoryPhase2Jobs.claimedSelectionDigest),
+    isNotNull(piMemoryPhase2Jobs.claimedSelectedCount),
+    isNotNull(piMemoryPhase2Jobs.claimedSelectedUtf8Bytes),
+    exists(
+      db
+        .select({ id: agentRunCallbacks.id })
+        .from(agentRunCallbacks)
+        .where(
+          and(
+            eq(agentRunCallbacks.runId, args.runId),
+            eq(agentRunCallbacks.internalKind, "pi-memory:phase2"),
+            sql`${agentRunCallbacks.payload}->>'schemaVersion' = '1'`,
+            sql`${agentRunCallbacks.payload}->>'memoryStorageId' = ${piMemoryPhase2Jobs.memoryStorageId}::text`,
+            sql`${agentRunCallbacks.payload}->>'orgId' = ${piMemoryPhase2Jobs.orgId}`,
+            sql`${agentRunCallbacks.payload}->>'userId' = ${piMemoryPhase2Jobs.userId}`,
+            sql`${agentRunCallbacks.payload}->>'leaseToken' = ${piMemoryPhase2Jobs.leaseToken}::text`,
+            sql`${agentRunCallbacks.payload}->>'claimedRevision' = ${piMemoryPhase2Jobs.claimedRevision}::text`,
+            sql`${agentRunCallbacks.payload}->>'claimedBaseVersionId' = ${piMemoryPhase2Jobs.claimedBaseVersionId}`,
+            sql`${agentRunCallbacks.payload}->>'selectionDigest' = ${piMemoryPhase2Jobs.claimedSelectionDigest}`,
+          ),
+        ),
+    ),
+  ) as SQL;
+}
+
+/**
+ * Serialize cleanup with every exact owner binding for this run, then classify
+ * the complete fence under that lock. Locking the bound row before applying
+ * the live-lease predicate closes the expired-at-discovery/renewed-at-write
+ * race without allowing an unrelated owner row to shield the run.
+ */
+export async function lockPiMemoryPhase2MaintenanceCleanupProtection(
+  tx: Tx,
+  args: {
+    readonly runId: string;
+    readonly orgId: string;
+    readonly userId: string;
+  },
+): Promise<boolean> {
+  const bound = await tx
+    .select({ memoryStorageId: piMemoryPhase2Jobs.memoryStorageId })
+    .from(piMemoryPhase2Jobs)
+    .where(
+      and(
+        eq(piMemoryPhase2Jobs.maintenanceRunId, args.runId),
+        eq(piMemoryPhase2Jobs.orgId, args.orgId),
+        eq(piMemoryPhase2Jobs.userId, args.userId),
+      ),
+    )
+    .for("update", { of: piMemoryPhase2Jobs });
+  if (bound.length === 0) {
+    return false;
+  }
+
+  const [active] = await tx
+    .select({ memoryStorageId: piMemoryPhase2Jobs.memoryStorageId })
+    .from(piMemoryPhase2Jobs)
+    .where(
+      activePiMemoryPhase2MaintenanceRunCondition(tx, {
+        ...args,
+        currentTime: nowDate(),
+      }),
+    )
+    .limit(1);
+  return active !== undefined;
 }
 
 function exactActiveMaintenanceCondition(args: {

--- a/turbo/apps/api/src/signals/services/run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/run-cancel.service.ts
@@ -28,6 +28,7 @@ import {
   lockPiApiFirstTurnLifecycle,
 } from "./pi-api-first-turn-lifecycle.service";
 import { transitionAgentRunsToTerminal } from "./agent-run-terminal-transition.service";
+import { lockPiMemoryPhase2MaintenanceCleanupProtection } from "./pi-memory-phase2-maintenance.service";
 
 const L = logger("RunCancel");
 
@@ -92,6 +93,8 @@ export const cancelRun$ = command(
       readonly orgId: string;
       readonly runnerCancellationMode: RunnerCancellationMode;
       readonly apiStartTime?: number;
+      /** Keep exact live Phase 2 maintenance leases out of generic cleanup. */
+      readonly protectActivePiMemoryPhase2Maintenance?: true;
     },
     signal: AbortSignal,
   ): Promise<
@@ -147,6 +150,20 @@ export const cancelRun$ = command(
         return runNotCancellable(
           `Run cannot be cancelled: current status is '${run.status}'`,
         );
+      }
+
+      if (args.protectActivePiMemoryPhase2Maintenance) {
+        const protectedByMaintenance =
+          await lockPiMemoryPhase2MaintenanceCleanupProtection(tx, {
+            runId: run.id,
+            orgId: run.orgId,
+            userId: run.userId,
+          });
+        if (protectedByMaintenance) {
+          return runNotCancellable(
+            "Run cannot be cancelled while Phase 2 maintenance is active",
+          );
+        }
       }
 
       const [updated] = await transitionAgentRunsToTerminal(tx, {

--- a/turbo/apps/api/src/signals/services/threadless-run-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/threadless-run-cleanup.service.ts
@@ -3,6 +3,7 @@ import { agentRunCallbacks } from "@okouai/db/schema/agent-run-callback";
 import { agentRunQueue } from "@okouai/db/schema/agent-run-queue";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatThreadEvents } from "@okouai/db/schema/chat-thread-event";
+import { piMemoryPhase2Jobs } from "@okouai/db/schema/pi-memory-phase2-job";
 import { runnerJobQueue } from "@okouai/db/schema/runner-job-queue";
 import { usageEvent } from "@okouai/db/schema/usage-event";
 import { command } from "ccstate";
@@ -16,6 +17,7 @@ import {
   isNotNull,
   isNull,
   ne,
+  notExists,
   or,
   sql,
 } from "drizzle-orm";
@@ -29,6 +31,10 @@ import {
   drainOrgQueue$,
 } from "./agent-run-lifecycle.service";
 import { cancelRun$, dispatchCancelSideEffects$ } from "./run-cancel.service";
+import {
+  activePiMemoryPhase2MaintenanceRunCondition,
+  lockPiMemoryPhase2MaintenanceCleanupProtection,
+} from "./pi-memory-phase2-maintenance.service";
 
 const L = logger("ThreadlessRunCleanup");
 
@@ -103,6 +109,7 @@ function terminalError(candidate: ThreadlessRunCandidate): string | undefined {
 async function loadThreadlessRunCandidates(
   db: Db,
   runIds: readonly string[] | null,
+  currentTime: Date,
 ): Promise<readonly ThreadlessRunCandidate[]> {
   const forwardCutoff = new Date(THREADLESS_RUN_FORWARD_CUTOFF_ISO);
   return await db
@@ -125,6 +132,19 @@ async function loadThreadlessRunCandidates(
           ...ACTIVE_RUN_STATUSES,
           ...TERMINAL_RUN_STATUSES,
         ]),
+        notExists(
+          db
+            .select({ memoryStorageId: piMemoryPhase2Jobs.memoryStorageId })
+            .from(piMemoryPhase2Jobs)
+            .where(
+              activePiMemoryPhase2MaintenanceRunCondition(db, {
+                runId: agentRuns.id,
+                orgId: agentRuns.orgId,
+                userId: agentRuns.userId,
+                currentTime,
+              }),
+            ),
+        ),
         runIds === null ? undefined : inArray(agentRuns.id, runIds),
         or(
           gte(agentRuns.createdAt, forwardCutoff),
@@ -252,6 +272,16 @@ async function deleteIfStillEligible(
       return false;
     }
 
+    if (
+      await lockPiMemoryPhase2MaintenanceCleanupProtection(tx, {
+        runId: candidate.runId,
+        orgId: candidate.orgId,
+        userId: candidate.userId,
+      })
+    ) {
+      return false;
+    }
+
     if (await hasDeletionBlocker(tx, candidate.runId)) {
       return false;
     }
@@ -323,7 +353,12 @@ export const cleanupThreadlessRuns$ = command(
     signal: AbortSignal,
   ): Promise<ThreadlessRunCleanupResult> => {
     const db = set(writeDb$);
-    const candidates = await loadThreadlessRunCandidates(db, runIds);
+    const currentTime = nowDate();
+    const candidates = await loadThreadlessRunCandidates(
+      db,
+      runIds,
+      currentTime,
+    );
     signal.throwIfAborted();
 
     let cancelled = 0;
@@ -331,7 +366,7 @@ export const cleanupThreadlessRuns$ = command(
     let deleted = 0;
     const errors: ThreadlessRunCleanupError[] = [];
     const quietBefore = new Date(
-      nowDate().getTime() - CANCELLATION_RECOVERY_STALE_AFTER_MS,
+      currentTime.getTime() - CANCELLATION_RECOVERY_STALE_AFTER_MS,
     );
 
     for (const candidate of candidates) {
@@ -345,6 +380,7 @@ export const cleanupThreadlessRuns$ = command(
                 userId: candidate.userId,
                 orgId: candidate.orgId,
                 runnerCancellationMode: "hard",
+                protectActivePiMemoryPhase2Maintenance: true,
               },
               signal,
             );


### PR DESCRIPTION
## Summary

- exclude a threadless run only when its owner-matched Phase 2 job has a live sandbox lease and an exact `pi-memory:phase2` callback fence
- revalidate the binding under row locks at cancellation and deletion write boundaries so cleanup cannot act on a stale discovery read
- extend the real PostgreSQL/Runner/Guest maintenance boundary across active cleanup, lease renewal races, changed output, represented no-diff, callback settlement, stale/replaced bindings, and terminal cleanup

## Correctness

The protection requires the maintenance run ID, organization, user, leased sandbox token, unexpired lease, valid revision/retry/selection state, and callback-matched storage, token, revision, base, and selection digest. Ordinary Agent-triggered, Agent-less, internal-callback, or threadless runs remain eligible. Expired, unbound, replaced, cross-owner, and non-leased jobs cannot shield a run.

The write-boundary guard first locks every exact owner binding for the run and only then evaluates the live fence. Phase 2 binding remains atomic with run publication, while callback settlement continues to clear the binding before the existing quiet-window/redrive/deletion path.

## Validation

- `pnpm --filter api exec vitest run --config vitest.maintenance.config.ts` — 15 passed
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts` — 50 passed
- `pnpm --filter api check-types`
- `pnpm --filter api lint`
- `pnpm knip --workspace apps/api`
- targeted Prettier check and `git diff --check`

## Blast radius

- `cleanupThreadlessRuns$` has one production caller: `cleanupSandboxes$`
- `cleanupSandboxes$` is reached by the cleanup cron route and the test-only scoped route
- other `cancelRun$` callers retain their existing behavior because only threadless cleanup opts into the Phase 2 guard
- no open PR overlapped the changed cleanup, cancellation, Phase 2 maintenance, or boundary-test files at implementation start

No schema migration, backfill, feature switch, UI change, production mutation, or release is included.

Closes #32357
