### PR TITLE
feat(platform): refine chat work history

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -2183,7 +2183,6 @@
       "title": "Composer-Entwurf ersetzen?"
     },
     "run": {
-      "all": "Alle",
       "automatedRun": "Automatisierte Ausführung",
       "collapseGroupedHistory": "Gruppierten Ausführungsverlauf einklappen",
       "collapseHistoryMessage": "Nachricht im Arbeitsverlauf einklappen: {{message}}",
@@ -2228,7 +2227,6 @@
       "keepGoingAt": "Fortsetzen · {{timestamp}}",
       "modelChangedTo": "Modell wurde auf {{model}} geändert",
       "queueEllipsis": "In Warteschlange...",
-      "recent": "Neueste",
       "selectedModelAppliesAfterCurrentRun": "Ihr ausgewähltes {{model}}-Modell wird nach dieser Ausführung wirksam",
       "thinking": {
         "assembling": "Teile werden zusammengesetzt...",
@@ -2247,7 +2245,6 @@
       "waitingIn": "Warten",
       "worked": "Ausgeführt",
       "workedFor": "Ausgeführt in {{duration}}",
-      "workHistoryRange": "Umfang des Arbeitsverlaufs",
       "workingFor": "Seit {{duration}} in Arbeit"
     },
     "sharing": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -2183,7 +2183,6 @@
       "title": "Replace composer draft?"
     },
     "run": {
-      "all": "All",
       "automatedRun": "Automated run",
       "collapseGroupedHistory": "Collapse grouped run history",
       "collapseHistoryMessage": "Collapse history message: {{message}}",
@@ -2228,7 +2227,6 @@
       "keepGoingAt": "Keep going · {{timestamp}}",
       "modelChangedTo": "Model changed to {{model}}",
       "queueEllipsis": "queue...",
-      "recent": "Recent",
       "selectedModelAppliesAfterCurrentRun": "Next run will use {{model}}",
       "thinking": {
         "assembling": "Assembling the pieces...",
@@ -2247,7 +2245,6 @@
       "waitingIn": "Waiting in",
       "worked": "Worked",
       "workedFor": "Worked for {{duration}}",
-      "workHistoryRange": "Work history range",
       "workingFor": "Working for {{duration}}"
     },
     "sharing": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -2219,7 +2219,6 @@
       "title": "¿Reemplazar el borrador del editor?"
     },
     "run": {
-      "all": "Todo",
       "automatedRun": "Ejecución automatizada",
       "collapseGroupedHistory": "Contraer el historial de ejecuciones agrupadas",
       "collapseHistoryMessage": "Contraer mensaje del historial: {{message}}",
@@ -2270,7 +2269,6 @@
       "keepGoingAt": "Sigue adelante · {{timestamp}}",
       "modelChangedTo": "Modelo cambiado a {{model}}",
       "queueEllipsis": "cola...",
-      "recent": "Reciente",
       "selectedModelAppliesAfterCurrentRun": "Tu modelo seleccionado {{model}} entrará en vigor después de esta ejecución",
       "thinking": {
         "assembling": "Ensamblando las piezas...",
@@ -2289,7 +2287,6 @@
       "waitingIn": "Esperando",
       "worked": "Trabajo realizado",
       "workedFor": "Trabajo realizado durante {{duration}}",
-      "workHistoryRange": "Rango del historial de trabajo",
       "workingFor": "Trabajando durante {{duration}}"
     },
     "sharing": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -2219,7 +2219,6 @@
       "title": "Remplacer le brouillon du compositeur ?"
     },
     "run": {
-      "all": "Tout",
       "automatedRun": "Exécution automatisée",
       "collapseGroupedHistory": "Réduire l'historique des exécutions groupées",
       "collapseHistoryMessage": "Réduire le message de l'historique : {{message}}",
@@ -2270,7 +2269,6 @@
       "keepGoingAt": "Continuez · {{timestamp}}",
       "modelChangedTo": "Le modèle a été changé en {{model}}",
       "queueEllipsis": "en file d'attente...",
-      "recent": "Récent",
       "selectedModelAppliesAfterCurrentRun": "Votre modèle sélectionné {{model}} entrera en vigueur après cette exécution",
       "thinking": {
         "assembling": "Assemblage des pièces...",
@@ -2289,7 +2287,6 @@
       "waitingIn": "En attente",
       "worked": "Fonctionné",
       "workedFor": "Fonctionné pendant {{duration}}",
-      "workHistoryRange": "Étendue de l'historique du travail",
       "workingFor": "En cours depuis {{duration}}"
     },
     "sharing": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -2183,7 +2183,6 @@
       "title": "कंपोज़र ड्राफ्ट बदलें?"
     },
     "run": {
-      "all": "सभी",
       "automatedRun": "स्वचालित रन",
       "collapseGroupedHistory": "समूहीकृत रन इतिहास को संक्षिप्त करें",
       "collapseHistoryMessage": "इतिहास संदेश संक्षिप्त करें: {{message}}",
@@ -2228,7 +2227,6 @@
       "keepGoingAt": "चलते रहें · {{timestamp}}",
       "modelChangedTo": "मॉडल को {{model}} में बदल दिया गया है",
       "queueEllipsis": "कतार...",
-      "recent": "हाल के",
       "selectedModelAppliesAfterCurrentRun": "आपका चुना हुआ {{model}} मॉडल इस रन के बाद लागू होगा",
       "thinking": {
         "assembling": "टुकड़ों को जोड़ना...",
@@ -2247,7 +2245,6 @@
       "waitingIn": "प्रतीक्षा कर रहा है",
       "worked": "काम किया",
       "workedFor": "{{duration}} के लिए काम किया",
-      "workHistoryRange": "कार्य इतिहास सीमा",
       "workingFor": "{{duration}} से काम जारी"
     },
     "sharing": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -2180,7 +2180,6 @@
       "title": "Ganti draf composer?"
     },
     "run": {
-      "all": "Semua",
       "automatedRun": "Eksekusi otomatis",
       "collapseGroupedHistory": "Ciutkan riwayat eksekusi yang dikelompokkan",
       "collapseHistoryMessage": "Ciutkan pesan riwayat: {{message}}",
@@ -2225,7 +2224,6 @@
       "keepGoingAt": "Lanjutkan · {{timestamp}}",
       "modelChangedTo": "Model diganti menjadi {{model}}",
       "queueEllipsis": "antrean...",
-      "recent": "Terbaru",
       "selectedModelAppliesAfterCurrentRun": "Model {{model}} yang Anda pilih akan berlaku setelah eksekusi ini",
       "thinking": {
         "assembling": "Menyusun bagian-bagiannya...",
@@ -2244,7 +2242,6 @@
       "waitingIn": "Menunggu di",
       "worked": "Dikerjakan",
       "workedFor": "Dikerjakan selama {{duration}}",
-      "workHistoryRange": "Rentang riwayat kerja",
       "workingFor": "Bekerja selama {{duration}}"
     },
     "sharing": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -2219,7 +2219,6 @@
       "title": "Sostituire la bozza nell'editor?"
     },
     "run": {
-      "all": "Tutto",
       "automatedRun": "Esecuzione automatizzata",
       "collapseGroupedHistory": "Comprimi la cronologia delle esecuzioni raggruppate",
       "collapseHistoryMessage": "Comprimi il messaggio della cronologia: {{message}}",
@@ -2270,7 +2269,6 @@
       "keepGoingAt": "Continua · {{timestamp}}",
       "modelChangedTo": "Modello cambiato in {{model}}",
       "queueEllipsis": "in coda...",
-      "recent": "Recenti",
       "selectedModelAppliesAfterCurrentRun": "Il modello {{model}} selezionato entrerà in vigore dopo questa esecuzione",
       "thinking": {
         "assembling": "Assemblando i pezzi...",
@@ -2289,7 +2287,6 @@
       "waitingIn": "In attesa",
       "worked": "Ha funzionato",
       "workedFor": "Ha lavorato per {{duration}}",
-      "workHistoryRange": "Intervallo della cronologia lavorativa",
       "workingFor": "In lavorazione da {{duration}}"
     },
     "sharing": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -2180,7 +2180,6 @@
       "title": "コンポーザーの下書きを置き換えますか？"
     },
     "run": {
-      "all": "すべて",
       "automatedRun": "自動実行",
       "collapseGroupedHistory": "グループ化された実行履歴を折りたたむ",
       "collapseHistoryMessage": "履歴メッセージを折りたたむ: {{message}}",
@@ -2225,7 +2224,6 @@
       "keepGoingAt": "続ける · {{timestamp}}",
       "modelChangedTo": "モデルを{{model}}に変更しました",
       "queueEllipsis": "行列...",
-      "recent": "最近",
       "selectedModelAppliesAfterCurrentRun": "選択した{{model}}モデルはこの実行後に適用されます",
       "thinking": {
         "assembling": "部品を組み立て中...",
@@ -2244,7 +2242,6 @@
       "waitingIn": "待機中",
       "worked": "働いた",
       "workedFor": "{{duration}} で働いていました",
-      "workHistoryRange": "作業履歴の範囲",
       "workingFor": "{{duration}} 作業中"
     },
     "sharing": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -2180,7 +2180,6 @@
       "title": "작성 중인 초안을 교체하시겠습니까?"
     },
     "run": {
-      "all": "전체",
       "automatedRun": "자동 실행",
       "collapseGroupedHistory": "그룹화된 실행 기록 접기",
       "collapseHistoryMessage": "기록 메시지 접기: {{message}}",
@@ -2225,7 +2224,6 @@
       "keepGoingAt": "계속 진행 · {{timestamp}}",
       "modelChangedTo": "모델을 {{model}}로 변경했습니다",
       "queueEllipsis": "대기 중...",
-      "recent": "최근",
       "selectedModelAppliesAfterCurrentRun": "선택한 {{model}} 모델은 이번 실행 후에 적용됩니다",
       "thinking": {
         "assembling": "조립 중...",
@@ -2244,7 +2242,6 @@
       "waitingIn": "대기 중",
       "worked": "작업 완료",
       "workedFor": "{{duration}} 동안 작업 완료",
-      "workHistoryRange": "작업 기록 범위",
       "workingFor": "{{duration}} 동안 작업 중"
     },
     "sharing": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -2219,7 +2219,6 @@
       "title": "Substituir rascunho do editor?"
     },
     "run": {
-      "all": "Tudo",
       "automatedRun": "Execução automatizada",
       "collapseGroupedHistory": "Recolher histórico de execuções agrupadas",
       "collapseHistoryMessage": "Recolher mensagem do histórico: {{message}}",
@@ -2270,7 +2269,6 @@
       "keepGoingAt": "Continuar · {{timestamp}}",
       "modelChangedTo": "Modelo alterado para {{model}}",
       "queueEllipsis": "fila...",
-      "recent": "Recentes",
       "selectedModelAppliesAfterCurrentRun": "O modelo {{model}} selecionado entrará em vigor após esta execução",
       "thinking": {
         "assembling": "Juntando as peças...",
@@ -2289,7 +2287,6 @@
       "waitingIn": "Aguardando na",
       "worked": "Trabalhou",
       "workedFor": "Trabalhou por {{duration}}",
-      "workHistoryRange": "Intervalo do histórico de trabalho",
       "workingFor": "Trabalhando há {{duration}}"
     },
     "sharing": {

--- a/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-work-folding.ts
@@ -39,6 +39,7 @@ export interface RunWorkSection {
   readonly runIds: readonly string[];
   readonly anchorEventId: string;
   readonly collapsible: boolean;
+  readonly stepCount: number;
   readonly hiddenGroups: ChatEventGroup[];
   readonly hiddenGroupsAfterAnchor: ChatEventGroup[];
   readonly previewMessages: readonly EnrichedChatEvent[];
@@ -596,6 +597,7 @@ function foldRunWorkGroup(
       statusTail,
     };
   }
+  const stepCount = outputMessages.length - 1;
 
   const hiddenEvents = events.slice(0, anchorIndex).filter((event) => {
     return (
@@ -620,7 +622,8 @@ function foldRunWorkGroup(
       runGroupId: unit.runGroupId,
       runIds: unit.runIds,
       anchorEventId: anchorEvent.id,
-      collapsible: outputMessages.length > 1,
+      collapsible: stepCount > 3,
+      stepCount,
       hiddenGroups: groupEventsByRole(hiddenEvents),
       hiddenGroupsAfterAnchor: groupEventsByRole(hiddenEventsAfterAnchor),
       previewMessages: outputMessages.slice(-4, -1),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-run-history.test.tsx
@@ -3,7 +3,6 @@ import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { expect, test } from "vitest";
 
 import {
-  click,
   queryAllByRoleFast,
   setupPage,
 } from "../../../__tests__/page-helper.ts";
@@ -17,12 +16,11 @@ import {
   type MockChatEventInput,
 } from "./chat-event-test-helpers.ts";
 import {
-  findWorkHistoryRangeOption,
-  getWorkHistoryRangeOption,
+  findWorkHistoryToggle,
   installRunChat,
   publishRunUpdate,
   queryButton,
-  queryWorkHistoryRangeOption,
+  queryWorkHistoryToggle,
 } from "./chat-run-test-fixtures.ts";
 
 const WORKFLOW_GROUP_ID = "e0000000-0000-4000-a000-000000000871";
@@ -198,7 +196,7 @@ test("Project all workflow run outputs through one run-group history", async () 
   const main = screen.getByText("Earlier workflow result 2");
   expect(main).toBeVisible();
   expect(queryButton("Expand grouped run history")).toBeNull();
-  const fold = await findWorkHistoryRangeOption("All");
+  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
   const currentProgress = await screen.findByLabelText(
     "Checking the latest workflow run",
   );
@@ -216,8 +214,6 @@ test("Project all workflow run outputs through one run-group history", async () 
     }),
   ).toHaveLength(1);
 
-  click(fold);
-
   const firstEarlierEvidence = await screen.findByText(
     "Earlier workflow evidence 1",
   );
@@ -230,10 +226,6 @@ test("Project all workflow run outputs through one run-group history", async () 
   );
   expect(screen.queryByText("Nightly launch review")).toBeNull();
 
-  click(getWorkHistoryRangeOption("Recent"));
-  await waitFor(() => {
-    expect(queryMessageBody("Earlier workflow result 1")).toBeNull();
-  });
   events.push(
     assistantOutput({
       id: "workflow-history-current-result",
@@ -252,7 +244,7 @@ test("Project all workflow run outputs through one run-group history", async () 
   expect(queryMessageBody("Earlier workflow result 2")).toBeNull();
   expect(currentMain.closest('[data-role="assistant"]')).toBe(assistantGroup);
   expect(queryButton("Expand grouped run history")).toBeNull();
-  await expect(findWorkHistoryRangeOption("All")).resolves.toBeVisible();
+  await expect(findWorkHistoryToggle("collapsed")).resolves.toBeVisible();
 });
 
 test("Keep different run groups as separate assistant responses", async () => {
@@ -325,7 +317,7 @@ test("Keep different run groups as separate assistant responses", async () => {
       return link.getAttribute("aria-label") === "View agent profile";
     }),
   ).toHaveLength(2);
-  expect(queryWorkHistoryRangeOption("All")).toBeNull();
+  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
 });
 
 test("Keep the prior goal result as main while the next run has no output", async () => {
@@ -402,7 +394,7 @@ test("Keep the prior goal result as main while the next run has no output", asyn
   );
   expect(priorMain).toBeVisible();
   expect(queryButton("Expand grouped run history")).toBeNull();
-  expect(queryWorkHistoryRangeOption("All")).toBeNull();
+  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
   const thinking = await waitFor(() => {
     const indicator = document.querySelector<HTMLElement>(
       "[data-thinking-indicator]",
@@ -445,14 +437,20 @@ test("Keep the prior goal result as main while the next run has no output", asyn
   expect(
     queryMessageBody("The earlier launch evidence is complete."),
   ).toBeNull();
-  const currentFold = await findWorkHistoryRangeOption("All");
+  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
+  const historyMessage = queryButton(
+    "The earlier launch evidence is complete.",
+  );
+  if (!historyMessage) {
+    throw new Error("Expected the earlier result in work history");
+  }
   const answeringAssistant = answer.closest<HTMLElement>(
     '[data-role="assistant"]',
   );
   if (!answeringAssistant) {
     throw new Error("Expected the answer in an assistant response");
   }
-  expect(currentFold.closest('[data-role="assistant"]')).toBe(
+  expect(historyMessage.closest('[data-role="assistant"]')).toBe(
     answeringAssistant,
   );
   expect(answeringAssistant).toBe(pendingAssistant);
@@ -544,8 +542,6 @@ test("Open an archived goal run from a linked event", async () => {
   const linkedResult = await screen.findByText("Linked archived launch result");
   expect(linkedResult).toBeVisible();
   expect(screen.getByText("Latest launch result")).toBeVisible();
-  const expandedFold = await findWorkHistoryRangeOption("All");
-  expect(expandedFold).toBeVisible();
-  expect(expandedFold).toBeChecked();
+  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
   expect(queryButton("Collapse grouped run history")).toBeNull();
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-conversation-locator.test.tsx
@@ -14,7 +14,6 @@ import {
   mockResizeObserver,
   setupPage,
 } from "./chat-lifecycle-test-helpers.ts";
-import { findWorkHistoryRangeOption } from "./chat-run-test-fixtures.ts";
 
 const THREAD_IDS = {
   overview: "b0000000-0000-4000-a000-000000000821",
@@ -497,6 +496,7 @@ test("The conversation locator follows folded goal continuation work", async () 
   });
 
   await screen.findByText("All deployment regions are healthy");
+  await screen.findByText("Checked the first deployment region");
   expect(
     queryMessageBody("Checked the first deployment region"),
   ).not.toBeInTheDocument();
@@ -520,28 +520,9 @@ test("The conversation locator follows folded goal continuation work", async () 
     );
   });
 
-  const expand = await findWorkHistoryRangeOption("All");
-  await userEvent.click(expand);
-  await screen.findByText("Checked the first deployment region");
   expect(
     screen.queryByText("Keep checking the deployment regions"),
   ).not.toBeInTheDocument();
-
-  const expandedGeometry = installLocatorGeometry({ clientHeight: 360 });
-  resize.automationAll();
-  await expectLocatorTickCount(14);
-  fireEvent.pointerEnter(expandedGeometry.rail);
-  await pointAndSelectTurn(
-    expandedGeometry.rail,
-    13,
-    "Checked the first deployment region",
-  );
-  await waitFor(() => {
-    expect(turnForText("Checked the first deployment region")).toHaveAttribute(
-      "data-locator-landed",
-      "",
-    );
-  });
 });
 
 test("The conversation locator makes the pointed turn easy to identify", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-engagement-telemetry.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-engagement-telemetry.test.tsx
@@ -10,8 +10,8 @@ import {
   setupPage,
 } from "./chat-lifecycle-test-helpers.ts";
 import {
-  findWorkHistoryRangeOption,
-  getWorkHistoryRangeOption,
+  findWorkHistoryToggle,
+  getWorkHistoryToggle,
 } from "./chat-run-test-fixtures.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
@@ -81,6 +81,27 @@ describe("chat engagement telemetry", () => {
           createdAt: "2026-09-04T10:00:10Z",
         },
         {
+          id: "msg-active-work-details",
+          role: "assistant",
+          content: "Checking the launch details.",
+          runId: "run-active-work-telemetry",
+          createdAt: "2026-09-04T10:00:12Z",
+        },
+        {
+          id: "msg-active-work-audience",
+          role: "assistant",
+          content: "Checking the launch audience.",
+          runId: "run-active-work-telemetry",
+          createdAt: "2026-09-04T10:00:14Z",
+        },
+        {
+          id: "msg-active-work-schedule",
+          role: "assistant",
+          content: "Checking the launch schedule.",
+          runId: "run-active-work-telemetry",
+          createdAt: "2026-09-04T10:00:16Z",
+        },
+        {
           id: "msg-active-work-visible",
           role: "assistant",
           content: "Checking the launch metrics.",
@@ -98,7 +119,7 @@ describe("chat engagement telemetry", () => {
       },
     });
 
-    const expandWork = await findWorkHistoryRangeOption("All");
+    const expandWork = await findWorkHistoryToggle("collapsed");
     expect(screen.getByText(/^Working for /)).toBeVisible();
     expect(queryMessageBody("Checking the launch brief.")).toBeNull();
 
@@ -111,7 +132,7 @@ describe("chat engagement telemetry", () => {
       ["chat_work_history_expanded", { work_status: "active" }],
     ]);
 
-    click(getWorkHistoryRangeOption("Recent"));
+    click(getWorkHistoryToggle("expanded"));
 
     await waitFor(() => {
       expect(queryMessageBody("Checking the launch brief.")).toBeNull();
@@ -139,6 +160,27 @@ describe("chat engagement telemetry", () => {
           createdAt: "2026-09-04T10:00:10Z",
         },
         {
+          id: "msg-completed-work-details",
+          role: "assistant",
+          content: "Checking the launch details.",
+          runId: "run-completed-work-telemetry",
+          createdAt: "2026-09-04T10:00:12Z",
+        },
+        {
+          id: "msg-completed-work-audience",
+          role: "assistant",
+          content: "Checking the launch audience.",
+          runId: "run-completed-work-telemetry",
+          createdAt: "2026-09-04T10:00:14Z",
+        },
+        {
+          id: "msg-completed-work-schedule",
+          role: "assistant",
+          content: "Checking the launch schedule.",
+          runId: "run-completed-work-telemetry",
+          createdAt: "2026-09-04T10:00:16Z",
+        },
+        {
           id: "msg-completed-work-result",
           role: "assistant",
           content: "The launch summary is ready.",
@@ -157,7 +199,7 @@ describe("chat engagement telemetry", () => {
       },
     });
 
-    const expandWork = await findWorkHistoryRangeOption("All");
+    const expandWork = await findWorkHistoryToggle("collapsed");
     expect(screen.getByText("Worked for 20s")).toBeVisible();
 
     click(expandWork);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-artifact-carryover.test.tsx
@@ -9,11 +9,10 @@ import {
   assistantEvent,
   completedEvent,
   context,
-  findWorkHistoryRangeOption,
   installRunChat,
   promptEvent,
   queryButton,
-  queryWorkHistoryRangeOption,
+  queryWorkHistoryToggle,
   readyChat,
   RUN_PATH,
 } from "./chat-run-test-fixtures.ts";
@@ -132,7 +131,7 @@ test("Carry an artifact referenced only by history below the main result", async
     throw new Error("Expected the artifact inside the main message region");
   }
   expect(mainMessage).toContainElement(actions);
-  await expect(findWorkHistoryRangeOption("All")).resolves.toBeVisible();
+  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
   expect(viewAgentProfileLinks()).toHaveLength(1);
 });
 
@@ -351,7 +350,7 @@ test("Do not carry inline media or action cards out of historical messages", asy
   expect(screen.queryByText("Historical rich output")).toBeNull();
   expect(screen.queryByAltText("Inline chart")).toBeNull();
   expect(screen.queryByTestId("plan-upgrade-card")).toBeNull();
-  await expect(findWorkHistoryRangeOption("All")).resolves.toBeVisible();
+  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
 });
 
 test("Carry artifacts across every run in the same run group", async () => {
@@ -437,7 +436,7 @@ test("Carry artifacts across every run in the same run group", async () => {
   expectDocumentOrder(main, artifact);
   expect(assistantGroupFor(artifact)).toBe(assistantGroupFor(main));
   expect(queryButton("Expand grouped run history")).toBeNull();
-  await expect(findWorkHistoryRangeOption("All")).resolves.toBeVisible();
+  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
 });
 
 test("Ignore artifacts from revoked output messages", async () => {
@@ -483,5 +482,5 @@ test("Ignore artifacts from revoked output messages", async () => {
 
   expect(screen.getByText("The obsolete artifact was withdrawn")).toBeVisible();
   expect(queryNamedLink("Open pdf preview for obsolete.pdf")).toBeNull();
-  expect(queryWorkHistoryRangeOption("All")).toBeNull();
+  expect(queryWorkHistoryToggle("collapsed")).toBeNull();
 });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-goal-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-goal-history.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { expect, test } from "vitest";
 
-import { click, queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
+import { queryAllByRoleFast } from "../../../__tests__/page-helper.ts";
 import { setupPage } from "./chat-lifecycle-test-helpers.ts";
 import {
   queryMessageBody,
@@ -15,8 +15,6 @@ import {
   context,
   creditUsage,
   expectTextOrder,
-  findWorkHistoryRangeOption,
-  getWorkHistoryRangeOptions,
   installRunChat,
   promptEvent,
   readyChat,
@@ -192,8 +190,6 @@ test("Review goal continuations as one work history", async () => {
   expect(queryMessageBody("Validated the regional rollout")).toBeNull();
   expect(screen.queryByText("Keep checking launch readiness")).toBeNull();
   expect(screen.queryByText("Finish checking launch readiness")).toBeNull();
-
-  click(await findWorkHistoryRangeOption("All"));
 
   await expect(
     screen.findByText("Checked the initial launch evidence"),
@@ -445,8 +441,8 @@ test("Keep a cancelled goal continuation beside its latest answer", async () => 
       return link.getAttribute("aria-label") === "View agent profile";
     }),
   ).toHaveLength(1);
-  expect(screen.queryByText("Model changed to GPT 5.6 Luna")).toBeNull();
-  expect(screen.queryByText("Model changed to GPT 5.6 Sol")).toBeNull();
+  expect(screen.getByText("Model changed to GPT 5.6 Luna")).toBeVisible();
+  expect(screen.getByText("Model changed to GPT 5.6 Sol")).toBeVisible();
   expect(
     screen.queryByText("Continue the deployment investigation with Luna"),
   ).toBeNull();
@@ -454,12 +450,6 @@ test("Keep a cancelled goal continuation beside its latest answer", async () => 
     screen.queryByText("Continue the deployment investigation with Sol"),
   ).toBeNull();
 
-  click(await findWorkHistoryRangeOption("All"));
-
-  await expect(
-    screen.findByText("Model changed to GPT 5.6 Luna"),
-  ).resolves.toBeVisible();
-  expect(screen.getByText("Model changed to GPT 5.6 Sol")).toBeVisible();
   expect(screen.getByText("Checked the deployment logs")).toBeVisible();
   expectTextOrder(
     "Checked the deployment logs",
@@ -562,12 +552,12 @@ test("Start a fresh work history after interrupting a goal continuation", async 
   });
 
   await readyChat();
-  const workHistories = getWorkHistoryRangeOptions("All");
+  const workHistories = document.querySelectorAll(
+    "[data-chat-run-work-history]",
+  );
   expect(workHistories).toHaveLength(2);
   expect(queryMessageBody("Checked the first rollout logs")).toBeNull();
   expect(queryMessageBody("Checked the replacement rollout logs")).toBeNull();
-
-  click(workHistories[0]!);
 
   await expect(
     screen.findByText("Checked the first rollout logs"),

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
@@ -9,7 +9,7 @@ import {
   completedEvent,
   context,
   findButton,
-  findWorkHistoryRangeOption,
+  findWorkHistoryToggle,
   installRunChat,
   promptEvent,
   publishRunUpdate,
@@ -20,53 +20,59 @@ import {
 
 const RUN_ID = "a0000000-0000-4000-a000-000000000294";
 
-test.each([
-  { count: 0, expected: [] },
-  { count: 1, expected: [] },
-  { count: 2, expected: ["•Step 1"] },
-  { count: 3, expected: ["•Step 1", "•Step 2"] },
-  { count: 4, expected: ["•Step 1", "•Step 2", "•Step 3"] },
-  { count: 6, expected: ["•Step 3", "•Step 4", "•Step 5"] },
-])(
-  "Show up to three recent messages and every history message with $count outputs",
-  async ({ count, expected }) => {
-    installRunChat({
-      activeRunIds: [RUN_ID],
-      chatEvents: [
-        promptEvent({
-          id: "preview-input",
-          runId: RUN_ID,
-          seqId: 1,
-          text: "Check every step",
-        }),
-        ...Array.from({ length: count }, (_, index) => {
-          return assistantEvent({
-            id: `preview-${index}`,
-            runId: RUN_ID,
-            seqId: index + 2,
-            text: `Step ${index + 1}`,
-          });
-        }),
-      ],
-    });
-    await setupPage({
-      context,
-      path: RUN_PATH,
-      featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
-    });
-    await readyChat();
-
-    const previews = Array.from(
-      document.querySelectorAll("[data-chat-run-work-preview]"),
-    );
-    expect(
-      previews.map((element) => {
-        return element.textContent;
+async function setupRunWithOutputCount(count: number): Promise<void> {
+  installRunChat({
+    activeRunIds: [RUN_ID],
+    chatEvents: [
+      promptEvent({
+        id: "preview-input",
+        runId: RUN_ID,
+        seqId: 1,
+        text: "Check every step",
       }),
-    ).toStrictEqual(expected);
-    if (count === 0) {
-      return;
-    }
+      ...Array.from({ length: count }, (_, index) => {
+        return assistantEvent({
+          id: `preview-${String(index)}`,
+          runId: RUN_ID,
+          seqId: index + 2,
+          text: `Step ${String(index + 1)}`,
+        });
+      }),
+    ],
+  });
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+}
+
+function workPreviewTexts(): (string | null)[] {
+  return Array.from(
+    document.querySelectorAll("[data-chat-run-work-preview]"),
+  ).map((element) => {
+    return element.textContent;
+  });
+}
+
+test("Show no history messages without assistant output", async () => {
+  await setupRunWithOutputCount(0);
+
+  expect(workPreviewTexts()).toStrictEqual([]);
+});
+
+test.each([
+  { count: 1, expected: [] },
+  { count: 2, expected: ["Step 1"] },
+  { count: 3, expected: ["Step 1", "Step 2"] },
+  { count: 4, expected: ["Step 1", "Step 2", "Step 3"] },
+])(
+  "Show every history message without a group toggle with $count outputs",
+  async ({ count, expected }) => {
+    await setupRunWithOutputCount(count);
+
+    expect(workPreviewTexts()).toStrictEqual(expected);
     const main = screen
       .getByText(`Step ${count}`)
       .closest("[data-chat-run-work-main]");
@@ -74,14 +80,31 @@ test.each([
       throw new Error("Expected the main result container");
     }
     expect(queryButton("Copy message", main)).toBeVisible();
-    if (count < 2) {
-      return;
+    expect(queryButton("Expand work history")).toBeNull();
+  },
+);
+
+test.each([
+  { count: 5, expected: ["Step 2", "Step 3", "Step 4"] },
+  { count: 6, expected: ["Step 3", "Step 4", "Step 5"] },
+])(
+  "Show three recent messages and expand every history message with $count outputs",
+  async ({ count, expected }) => {
+    await setupRunWithOutputCount(count);
+
+    expect(workPreviewTexts()).toStrictEqual(expected);
+    const main = screen
+      .getByText(`Step ${count}`)
+      .closest("[data-chat-run-work-main]");
+    if (!main) {
+      throw new Error("Expected the main result container");
     }
-    const showAll = await findWorkHistoryRangeOption("All");
-    expect(showAll).not.toBeChecked();
+    expect(queryButton("Copy message", main)).toBeVisible();
+    const showAll = await findWorkHistoryToggle("collapsed");
+    expect(showAll).toHaveAttribute("aria-expanded", "false");
     click(showAll);
-    const showRecent = await findWorkHistoryRangeOption("Recent");
-    expect(showAll).toBeChecked();
+    const showRecent = await findWorkHistoryToggle("expanded");
+    expect(showRecent).toHaveAttribute("aria-expanded", "true");
     expect(
       document.querySelectorAll("[data-chat-run-work-message]"),
     ).toHaveLength(count - 1);
@@ -113,7 +136,39 @@ test.each([
   },
 );
 
-test("Expand history messages independently and preserve them across range changes", async () => {
+test("Show the history step count in the work summary", async () => {
+  installRunChat({
+    activeRunIds: [RUN_ID],
+    chatEvents: [
+      promptEvent({
+        id: "step-count-input",
+        runId: RUN_ID,
+        seqId: 1,
+        text: "Count the work history",
+      }),
+      ...Array.from({ length: 5 }, (_, index) => {
+        return assistantEvent({
+          id: `step-count-${String(index)}`,
+          runId: RUN_ID,
+          seqId: index + 2,
+          text: `Step ${String(index + 1)}`,
+        });
+      }),
+    ],
+  });
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
+  });
+  await readyChat();
+
+  expect(document.querySelector("[data-chat-run-work]")).toHaveTextContent(
+    "4 steps",
+  );
+});
+
+test("Expand history messages independently and preserve them across history changes", async () => {
   installRunChat({
     activeRunIds: [RUN_ID],
     chatEvents: [
@@ -152,7 +207,7 @@ test("Expand history messages independently and preserve them across range chang
     document.querySelectorAll("[data-chat-run-work-message-expanded]"),
   ).toHaveLength(2);
 
-  click(await findWorkHistoryRangeOption("All"));
+  click(await findWorkHistoryToggle("collapsed"));
   expect(
     document.querySelectorAll("[data-chat-run-work-message]"),
   ).toHaveLength(4);
@@ -164,13 +219,13 @@ test("Expand history messages independently and preserve them across range chang
   expect(
     document.querySelectorAll("[data-chat-run-work-message-expanded]"),
   ).toHaveLength(3);
-  click(await findWorkHistoryRangeOption("Recent"));
+  click(await findWorkHistoryToggle("expanded"));
   expect(screen.queryByText("Step 1")).toBeNull();
   expect(
     document.querySelectorAll("[data-chat-run-work-message-expanded]"),
   ).toHaveLength(2);
 
-  click(await findWorkHistoryRangeOption("All"));
+  click(await findWorkHistoryToggle("collapsed"));
   expect(screen.getByText("Step 1")).toBeVisible();
   expect(
     document.querySelectorAll("[data-chat-run-work-message-expanded]"),
@@ -197,6 +252,24 @@ test("Keep work history open and keyboard focus in place when another output arr
       seqId: 3,
       text: "Checked the boundaries",
     }),
+    assistantEvent({
+      id: "focused-history-third",
+      runId: RUN_ID,
+      seqId: 4,
+      text: "Checked the interactions",
+    }),
+    assistantEvent({
+      id: "focused-history-fourth",
+      runId: RUN_ID,
+      seqId: 5,
+      text: "Checked the responsive layout",
+    }),
+    assistantEvent({
+      id: "focused-history-fifth",
+      runId: RUN_ID,
+      seqId: 6,
+      text: "Checked the final details",
+    }),
   ];
   installRunChat({ chatEvents: events, activeRunIds: [RUN_ID] });
   await setupPage({
@@ -205,15 +278,15 @@ test("Keep work history open and keyboard focus in place when another output arr
     featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
   });
   await readyChat();
-  const showAll = await findWorkHistoryRangeOption("All");
+  const showAll = await findWorkHistoryToggle("collapsed");
   click(showAll);
   showAll.focus();
 
   events.push(
     assistantEvent({
-      id: "focused-history-third",
+      id: "focused-history-sixth",
       runId: RUN_ID,
-      seqId: 4,
+      seqId: 7,
       text: "The checks are complete",
     }),
   );
@@ -224,7 +297,7 @@ test("Keep work history open and keyboard focus in place when another output arr
   ).resolves.toBeVisible();
   expect(screen.getByText("Checked the dependencies")).toBeVisible();
   expect(screen.getByText("Checked the boundaries")).toBeVisible();
-  await expect(findWorkHistoryRangeOption("All")).resolves.toHaveFocus();
+  await expect(findWorkHistoryToggle("expanded")).resolves.toHaveFocus();
 });
 
 test("Keep a card-only output in the collapsed history preview", async () => {
@@ -327,9 +400,9 @@ test.each(["completed", "failed", "cancelled"] as const)(
         },
       ),
     ).toStrictEqual([
-      "•Review Checked dependencies and tests.",
-      "•Dependency chart",
-      "•report.pdf",
+      "Review Checked dependencies and tests.",
+      "Dependency chart",
+      "report.pdf",
     ]);
     expect(screen.queryByAltText("Dependency chart")).toBeNull();
     expect(screen.getByText("The review is ready")).toBeVisible();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { expect, test } from "vitest";
 
@@ -17,12 +17,11 @@ import {
   expectTextOrder,
   findButton,
   findLink,
-  findWorkHistoryRangeOption,
-  getWorkHistoryRangeOptions,
+  findWorkHistoryToggle,
   installRunChat,
   promptEvent,
   queryButton,
-  queryWorkHistoryRangeOptions,
+  queryWorkHistoryToggles,
   readyChat,
   RUN_PATH,
   thinkingEvent,
@@ -212,17 +211,11 @@ test("Browse completed work by conversation phase", async () => {
   expect(
     queryMessageBody("Checked launch dependencies"),
   ).not.toBeInTheDocument();
-  const firstExpand = getWorkHistoryRangeOptions("All")[0];
-  if (!firstExpand) {
-    throw new Error("First work-history summary not found");
-  }
-
-  click(firstExpand);
-
+  expect(queryWorkHistoryToggles("collapsed")).toHaveLength(0);
   await expect(
     screen.findByText("Collected requirements"),
   ).resolves.toBeVisible();
-  expect(queryMessageBody("Compared rollback options")).not.toBeInTheDocument();
+  expect(screen.getByText("Compared rollback options")).toBeVisible();
   expectTextOrder(
     "Plan phase one",
     "Collected requirements",
@@ -234,21 +227,6 @@ test("Browse completed work by conversation phase", async () => {
     queryMessageBody("Checked launch dependencies"),
   ).not.toBeInTheDocument();
 
-  const firstRecent = getWorkHistoryRangeOptions("Recent")[0];
-  if (!firstRecent) {
-    throw new Error("First recent work-history option not found");
-  }
-  click(firstRecent);
-  await waitFor(() => {
-    expect(queryMessageBody("Collected requirements")).not.toBeInTheDocument();
-  });
-
-  const secondRunExpand = getWorkHistoryRangeOptions("All").at(-1);
-  if (!secondRunExpand) {
-    throw new Error("Second run work-history summary not found");
-  }
-  click(secondRunExpand);
-
   await expect(
     screen.findByText("Checked launch dependencies"),
   ).resolves.toBeVisible();
@@ -256,17 +234,6 @@ test("Browse completed work by conversation phase", async () => {
   expect(queryMessageBody("Collected requirements")).not.toBeInTheDocument();
   expect(queryMessageBody("Compared rollback options")).not.toBeInTheDocument();
 
-  const secondRunRecent = getWorkHistoryRangeOptions("Recent").at(-1);
-  if (!secondRunRecent) {
-    throw new Error("Second recent work-history option not found");
-  }
-  click(secondRunRecent);
-
-  await waitFor(() => {
-    expect(
-      queryMessageBody("Checked launch dependencies"),
-    ).not.toBeInTheDocument();
-  });
   expect(screen.getByText("Plan phase two")).toBeVisible();
   expect(screen.getByText("Phase two final plan")).toBeVisible();
   expect(screen.getByText("Plan phase one")).toBeVisible();
@@ -288,7 +255,7 @@ test.each([
   },
   {
     label: "multiple output messages",
-    messageCount: 3,
+    messageCount: 5,
     showsHistoryStatus: true,
     canExpandHistory: true,
   },
@@ -314,7 +281,7 @@ test.each([
     expect(screen.queryAllByText(/^Working(?: for)? /u)).toHaveLength(
       showsHistoryStatus ? 1 : 0,
     );
-    expect(queryWorkHistoryRangeOptions("All")).toHaveLength(
+    expect(queryWorkHistoryToggles("collapsed")).toHaveLength(
       canExpandHistory ? 1 : 0,
     );
 
@@ -334,7 +301,7 @@ test.each([
       return;
     }
 
-    click(await findWorkHistoryRangeOption("All"));
+    click(await findWorkHistoryToggle("collapsed"));
     const firstHistoryMessage = await screen.findByText(workMessage(0));
     const secondHistoryMessage = screen.getByText(workMessage(1));
     expect(assistantGroupFor(firstHistoryMessage)).toBe(
@@ -375,7 +342,7 @@ test("Do not create history before the first output.message", async () => {
 
   await readyChat();
   expect(screen.queryByText(/^Working(?: for)? /u)).toBeNull();
-  expect(queryWorkHistoryRangeOptions("All")).toHaveLength(0);
+  expect(queryWorkHistoryToggles("collapsed")).toHaveLength(0);
   expect(document.querySelector("[data-thinking-indicator]")).toBeVisible();
 });
 
@@ -418,7 +385,7 @@ test("Count one output.message once when Markdown renders multiple child blocks"
     findLink("Open pdf preview for package.pdf"),
   ).resolves.toBeVisible();
   await expect(screen.findByTestId("plan-upgrade-card")).resolves.toBeVisible();
-  expect(queryWorkHistoryRangeOptions("All")).toHaveLength(0);
+  expect(queryWorkHistoryToggles("collapsed")).toHaveLength(0);
   expect(screen.queryAllByText(/^Working(?: for)? /u)).toHaveLength(1);
   expect(viewAgentProfileLinks()).toHaveLength(1);
 });
@@ -431,7 +398,7 @@ test.each([
   },
   {
     label: "multiple output messages",
-    messageCount: 3,
+    messageCount: 5,
     canExpandHistory: true,
   },
 ])(
@@ -459,7 +426,7 @@ test.each([
     expect(screen.getByText(workMessage(messageCount - 1))).toBeVisible();
     expect(document.querySelector("[data-thinking-indicator]")).toBeNull();
     expect(screen.queryAllByText(/^Worked(?: for)? /u)).toHaveLength(1);
-    expect(queryWorkHistoryRangeOptions("All")).toHaveLength(
+    expect(queryWorkHistoryToggles("collapsed")).toHaveLength(
       canExpandHistory ? 1 : 0,
     );
     for (let index = 0; index < messageCount - 1; index += 1) {
@@ -550,7 +517,7 @@ test.each(finalOutputDocuments)(
     expect(main).toBeVisible();
     expect(viewAgentProfileLinks()).toHaveLength(1);
     expect(queryMessageBody("Earlier output belongs in history")).toBeNull();
-    expect(queryWorkHistoryRangeOptions("All")).toHaveLength(1);
+    expect(queryWorkHistoryToggles("collapsed")).toHaveLength(0);
     const thinking = document.querySelector<HTMLElement>(
       "[data-thinking-indicator]",
     );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-test-fixtures.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-test-fixtures.ts
@@ -78,65 +78,50 @@ function matchesAccessibleName(element: HTMLElement, name: string): boolean {
   );
 }
 
-function workHistoryRangeContainers(container: ParentNode): HTMLElement[] {
+function workHistoryToggleButtons(container: ParentNode): HTMLElement[] {
   return Array.from(
     container.querySelectorAll<HTMLElement>("[data-chat-run-work-range]"),
   );
 }
 
-export function queryWorkHistoryRangeOptions(
-  name: "All" | "Recent",
+export function queryWorkHistoryToggles(
+  state: "collapsed" | "expanded",
   container: ParentNode = document.body,
 ): HTMLElement[] {
-  return workHistoryRangeContainers(container).flatMap((range) => {
-    return queryAllByRoleFast("radio", range).filter((option) => {
-      return (
-        option.getAttribute("aria-label") === name ||
-        normalizedText(option) === name
-      );
-    });
+  const expanded = state === "expanded";
+  return workHistoryToggleButtons(container).filter((control) => {
+    return control.getAttribute("aria-expanded") === String(expanded);
   });
 }
 
-export function queryWorkHistoryRangeOption(
-  name: "All" | "Recent",
+export function queryWorkHistoryToggle(
+  state: "collapsed" | "expanded",
   container: ParentNode = document.body,
 ): HTMLElement | null {
-  const options = queryWorkHistoryRangeOptions(name, container);
+  const options = queryWorkHistoryToggles(state, container);
   if (options.length > 1) {
-    throw new Error(`Found multiple work history range options named ${name}`);
+    throw new Error(`Found multiple ${state} work history toggles`);
   }
   return options[0] ?? null;
 }
 
-export function getWorkHistoryRangeOption(
-  name: "All" | "Recent",
+export function getWorkHistoryToggle(
+  state: "collapsed" | "expanded",
   container: ParentNode = document.body,
 ): HTMLElement {
-  const option = queryWorkHistoryRangeOption(name, container);
+  const option = queryWorkHistoryToggle(state, container);
   if (!option) {
-    throw new Error(`Work history range option ${name} was not visible`);
+    throw new Error(`${state} work history toggle was not visible`);
   }
   return option;
 }
 
-export function getWorkHistoryRangeOptions(
-  name: "All" | "Recent",
-  container: ParentNode = document.body,
-): HTMLElement[] {
-  const options = queryWorkHistoryRangeOptions(name, container);
-  if (options.length === 0) {
-    throw new Error(`Work history range option ${name} was not visible`);
-  }
-  return options;
-}
-
-export function findWorkHistoryRangeOption(
-  name: "All" | "Recent",
+export function findWorkHistoryToggle(
+  state: "collapsed" | "expanded",
   container: ParentNode = document.body,
 ): Promise<HTMLElement> {
   return waitFor(() => {
-    return getWorkHistoryRangeOption(name, container);
+    return getWorkHistoryToggle(state, container);
   });
 }
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-scroll.test.tsx
@@ -19,7 +19,6 @@ import {
   setupPage,
 } from "./chat-lifecycle-test-helpers.ts";
 import { selectPassage } from "./chat-capability-test-helpers.ts";
-import { getWorkHistoryRangeOption } from "./chat-run-test-fixtures.ts";
 
 const ROW_HEIGHT_PX = 100;
 const ROW_CONTENT_HEIGHT_PX = 80;
@@ -516,7 +515,6 @@ test("Keep an expanded work message in place when its run completes", async () =
     ).not.toBeInTheDocument();
   });
 
-  click(getWorkHistoryRangeOption("All"));
   await screen.findByText("Checked the first rollout stage");
   click(buttonByLabel("Checked the first rollout stage"));
   const container = chatScrollContainer();
@@ -553,7 +551,9 @@ test("Keep an expanded work message in place when its run completes", async () =
   await screen.findByText("The rollout is healthy");
   await waitFor(() => {
     expect(screen.getByText("Checked the first rollout stage")).toBeVisible();
-    expect(getWorkHistoryRangeOption("All")).toBeChecked();
+    expect(
+      document.querySelector("[data-chat-run-work-range]"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Worked for 1m")).toBeVisible();
     expect(
       anchorById(

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -18,7 +18,7 @@ import {
 import type { TFunction } from "i18next";
 import { equalArrays } from "../../lib/equality.ts";
 import { useTranslation } from "react-i18next";
-import { formatChatTimestamp } from "../../i18n/format.ts";
+import { formatAppNumber, formatChatTimestamp } from "../../i18n/format.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { hideAppSkeletonOnContentReadyRef$ } from "../../signals/app-skeleton.ts";
 import {
@@ -90,8 +90,6 @@ import {
   TooltipTrigger,
   BrandSlack,
   ElapsedTime,
-  SegmentControl,
-  SegmentControlItem,
 } from "@okouai/ui";
 import { RUN_ERROR_GUIDANCE } from "@okouai/api-contracts/contracts/errors";
 import type {
@@ -3826,12 +3824,14 @@ function CompletedWorkFoldRow({
 function RunWorkSectionRow({
   startTime,
   endTime,
+  stepCount,
   collapsible,
   expanded,
   onToggle,
 }: {
   startTime: number;
   endTime?: number;
+  stepCount: number;
   collapsible: boolean;
   expanded: boolean;
   onToggle: () => void;
@@ -3839,73 +3839,78 @@ function RunWorkSectionRow({
   const { t } = useTranslation();
   const content = (
     <>
-      <Hourglass aria-hidden size={14} className="shrink-0" />
-      <ElapsedTime
-        startTime={startTime}
-        endTime={endTime}
-        className="text-[13px]"
-      >
-        {(elapsedTime) => {
-          const duration = formatCompactDuration(
-            Math.max(1, Math.round(elapsedTime / 1000)),
-          );
-          return endTime === undefined
-            ? t(
-                ($) => {
-                  return $.chat.run.workingFor;
-                },
-                { duration },
-              )
-            : t(
-                ($) => {
-                  return $.chat.run.workedFor;
-                },
-                { duration },
-              );
-        }}
-      </ElapsedTime>
+      <span className="flex size-7 shrink-0 items-center justify-center">
+        <Hourglass aria-hidden />
+      </span>
+      <span className="inline-flex min-w-0 items-center gap-1">
+        <ElapsedTime startTime={startTime} endTime={endTime}>
+          {(elapsedTime) => {
+            const duration = formatCompactDuration(
+              Math.max(1, Math.round(elapsedTime / 1000)),
+            );
+            return endTime === undefined
+              ? t(
+                  ($) => {
+                    return $.chat.run.workingFor;
+                  },
+                  { duration },
+                )
+              : t(
+                  ($) => {
+                    return $.chat.run.workedFor;
+                  },
+                  { duration },
+                );
+          }}
+        </ElapsedTime>
+        <span aria-hidden>·</span>
+        <span>
+          {t(
+            ($) => {
+              return $.activity.events.steps;
+            },
+            {
+              count: stepCount,
+              formattedCount: formatAppNumber(stepCount),
+            },
+          )}
+        </span>
+      </span>
+      {collapsible ? (
+        <ChevronRight
+          aria-hidden
+          className={cn(
+            "ml-1 shrink-0 text-muted-foreground/70 transition-transform",
+            expanded && "rotate-90",
+          )}
+        />
+      ) : null}
     </>
   );
-  const className = cn(
-    "inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground",
-    CHAT_THREAD_RESPONSE_LINE_CLASS,
-  );
+  const className =
+    "inline-flex min-h-7 w-fit items-center gap-0 rounded-lg pr-1 text-[13px] font-normal leading-5 text-muted-foreground [&_svg]:size-3.5";
   return (
-    <div
-      data-chat-run-work
-      className="-mx-2 flex min-h-9 items-center justify-between gap-2"
-    >
-      <div className={className}>{content}</div>
+    <div data-chat-run-work className="flex min-h-7 items-center">
       {collapsible ? (
-        <SegmentControl
-          value={expanded ? "all" : "recent"}
-          onValueChange={(value) => {
-            if ((value === "all") !== expanded) {
-              onToggle();
-            }
-          }}
-          aria-label={t(($) => {
-            return $.chat.run.workHistoryRange;
-          })}
-          data-chat-run-work-range
+        <Button
+          type="button"
+          variant="quiet"
           size="xs"
-          className="mr-2 shrink-0"
+          aria-expanded={expanded}
+          aria-label={t(($) => {
+            return expanded
+              ? $.chat.run.collapseWorkHistory
+              : $.chat.run.expandWorkHistory;
+          })}
+          onClick={onToggle}
+          data-chat-run-work-range
+          className={cn(className, "h-auto p-0 pr-1")}
         >
-          <SegmentControlItem
-            value="recent"
-            data-chat-run-work-range-option="recent"
-          >
-            {t(($) => {
-              return $.chat.run.recent;
-            })}
-          </SegmentControlItem>
-          <SegmentControlItem value="all" data-chat-run-work-range-option="all">
-            {t(($) => {
-              return $.chat.run.all;
-            })}
-          </SegmentControlItem>
-        </SegmentControl>
-      ) : null}
+          {content}
+        </Button>
+      ) : (
+        <div className={className}>{content}</div>
+      )}
     </div>
   );
 }
@@ -7569,7 +7574,8 @@ function buildPagedAssistantTimeline({
   }
 
   const historyItems: PagedAssistantHistoryItem[] = [];
-  if (runWorkSection.expanded) {
+  const showAllHistory = runWorkSection.expanded || !runWorkSection.collapsible;
+  if (showAllHistory) {
     historyItems.push(
       ...foldedRunWorkTimelineItems(runWorkSection.hiddenGroups, modelChanges),
     );
@@ -7594,7 +7600,7 @@ function buildPagedAssistantTimeline({
       artifactCards: runWorkSection.remainingArtifactCards,
     });
   }
-  if (runWorkSection.expanded) {
+  if (showAllHistory) {
     items.push(
       ...foldedRunWorkTimelineItems(
         runWorkSection.hiddenGroupsAfterAnchor,
@@ -7640,11 +7646,25 @@ function PagedAssistantTimeline({
           <RunWorkSectionRow
             startTime={item.control.startTime}
             endTime={item.control.endTime}
+            stepCount={item.control.stepCount}
             collapsible={item.control.collapsible}
             expanded={item.control.expanded}
             onToggle={item.control.onToggle}
           />
-          <PagedAssistantTimeline items={item.historyItems} thread={thread} />
+          {item.historyItems.length === 0 ? null : (
+            <div
+              data-chat-run-work-history-list
+              className={cn(
+                "ml-3.5 w-[calc(100%-0.875rem)] border-l border-border/70 pl-[13px]",
+                CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS,
+              )}
+            >
+              <PagedAssistantTimeline
+                items={item.historyItems}
+                thread={thread}
+              />
+            </div>
+          )}
         </div>
       );
     }
@@ -7711,7 +7731,7 @@ function PagedRunWorkMessage({
         toggleExpanded(event.id);
       }}
     >
-      <PagedAssistantEventItem event={event} thread={thread} />
+      <PagedAssistantEventItem event={event} thread={thread} compact />
     </RunWorkMessage>
   );
 }
@@ -7896,9 +7916,11 @@ function PagedAssistantGroup({
 function PagedAssistantEventItem({
   event,
   thread,
+  compact = false,
 }: {
   event: EnrichedChatEvent;
   thread: ChatPanelSignals;
+  compact?: boolean;
 }) {
   const retryRichEventTree = useSet(thread.retryRichEventTree$);
   const pageSignal = useGet(pageSignal$);
@@ -7906,6 +7928,7 @@ function PagedAssistantEventItem({
   if (error) {
     return (
       <ChatAssistantMessageBody
+        className={compact ? "py-1 text-[13px] leading-5" : undefined}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
       >
@@ -7924,7 +7947,11 @@ function PagedAssistantEventItem({
   ) {
     return (
       <ChatAssistantMessageBody
-        className={CHAT_THREAD_RESPONSE_LINE_CLASS}
+        className={
+          compact
+            ? "py-1 text-[13px] leading-5"
+            : CHAT_THREAD_RESPONSE_LINE_CLASS
+        }
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
       >

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3839,7 +3839,7 @@ function RunWorkSectionRow({
   const { t } = useTranslation();
   const content = (
     <>
-      <span className="flex size-7 shrink-0 items-center justify-center">
+      <span className="flex w-7 shrink-0 items-center justify-center">
         <Hourglass aria-hidden />
       </span>
       <span className="inline-flex min-w-0 items-center gap-1">
@@ -3887,10 +3887,12 @@ function RunWorkSectionRow({
       ) : null}
     </>
   );
-  const className =
-    "inline-flex min-h-7 w-fit items-center gap-0 rounded-lg pr-1 text-[13px] font-normal leading-5 text-muted-foreground [&_svg]:size-3.5";
+  const className = cn(
+    "inline-flex min-h-9 w-fit items-center gap-0 rounded-lg pr-1 text-[13px] font-normal text-muted-foreground [&_svg]:size-3.5",
+    CHAT_THREAD_RESPONSE_LINE_CLASS,
+  );
   return (
-    <div data-chat-run-work className="flex min-h-7 items-center">
+    <div data-chat-run-work className="flex min-h-9 items-center">
       {collapsible ? (
         <Button
           type="button"

--- a/turbo/apps/platform/src/views/okou-page/run-work-message.tsx
+++ b/turbo/apps/platform/src/views/okou-page/run-work-message.tsx
@@ -1,4 +1,4 @@
-import { Button, cn } from "@okouai/ui";
+import { Button } from "@okouai/ui";
 import type { Element, Root } from "hast";
 import { ChevronRight, ChevronUp } from "lucide-react";
 import type { ReactNode } from "react";
@@ -84,16 +84,26 @@ export function RunWorkMessage({
       data-chat-run-work-message
       data-chat-run-work-message-expanded={expanded || undefined}
       data-chat-run-work-preview={expanded ? undefined : ""}
-      className={cn(
-        "min-w-0 max-w-full text-[13px] leading-5",
-        expanded &&
-          "-mx-2 grid grid-cols-[5px_minmax(0,1fr)_28px] items-start gap-x-2 px-2 py-1",
-      )}
+      className="group/history-message flex min-h-7 w-fit min-w-0 max-w-[92%] items-start text-[13px] leading-5 text-muted-foreground transition-colors hover:text-foreground"
     >
+      <div
+        id={contentId}
+        className={
+          expanded ? "min-w-0 flex-[0_1_auto]" : "min-w-0 flex-[0_1_auto] py-1"
+        }
+      >
+        {expanded ? (
+          children
+        ) : (
+          <span className="block min-w-0 truncate whitespace-nowrap">
+            {text}
+          </span>
+        )}
+      </div>
       <Button
         type="button"
         variant="quiet"
-        size={expanded ? "icon-xs" : "sm"}
+        size="icon-xs"
         aria-expanded={expanded}
         aria-controls={contentId}
         aria-label={
@@ -107,45 +117,10 @@ export function RunWorkMessage({
             : text
         }
         onClick={onToggle}
-        className={cn(
-          "text-[13px]",
-          expanded
-            ? "col-start-3 row-start-1 -mt-0.5 text-muted-foreground/70"
-            : "group -mx-2 h-auto min-h-8 w-[calc(100%+1rem)] justify-start px-2 text-left font-normal text-muted-foreground/60 hover:text-muted-foreground",
-        )}
+        className="shrink-0 text-muted-foreground/70 [&_svg]:size-3.5"
       >
-        {expanded ? (
-          <ChevronUp aria-hidden />
-        ) : (
-          <>
-            <span aria-hidden className="shrink-0">
-              •
-            </span>
-            <span className="min-w-0 flex-1 truncate whitespace-nowrap">
-              {text}
-            </span>
-            <ChevronRight
-              aria-hidden
-              className="shrink-0 text-muted-foreground/50"
-            />
-          </>
-        )}
+        {expanded ? <ChevronUp aria-hidden /> : <ChevronRight aria-hidden />}
       </Button>
-      <div
-        id={contentId}
-        hidden={!expanded}
-        className="col-start-2 row-start-1 min-w-0 text-foreground"
-      >
-        {expanded ? children : null}
-      </div>
-      {expanded ? (
-        <span
-          aria-hidden
-          className="col-start-1 row-start-1 mt-2.5 text-muted-foreground/60"
-        >
-          •
-        </span>
-      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- replace the Recent/All segmented control with an inline Working/Worked duration and history step count
- show up to three recent history messages by default, omit the group toggle for three or fewer, and expand the full history for larger runs
- align a subtle history rail with the hourglass lane, keep history typography compact and consistent, and place each row chevron directly after its own content

## Verification

- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- focused Vitest coverage: 76 tests across 8 chat history, telemetry, locator, and scrolling test files
