### PR TITLE
feat(desktop): add experimental cua driver selection

### DIFF
--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -19,6 +19,14 @@ Electron only owns the app shell and command bridge; the helper owns macOS
 Accessibility, target-window screenshot capture, and targeted CGEvent input
 dispatch.
 
+## Experimental Computer Use driver
+
+Okou remains the default actuator. A current Developer account can opt in to
+**Enable experimental CUA driver** and select **CUA (Experimental)** from the
+shared main-page controls. See [selection, recovery and manual verification](cua/README.md#developer-selection-and-recovery)
+and the exact [CUA 0.23.2 command contract](cua/ADAPTER.md). Selection is local to
+this installation; failed CUA execution never silently selects another driver.
+
 ## Development
 
 For quick Electron development without macOS bundle behavior, use:

--- a/turbo/apps/desktop/cua/ADAPTER.md
+++ b/turbo/apps/desktop/cua/ADAPTER.md
@@ -1,9 +1,10 @@
-# Host-owned CUA command adapter (slice 3)
+# Host-owned CUA command adapter (0.23.2)
 
 `createCuaComputerUseDriver` is an internal composition seam for
-`ComputerUseDriverController` and the existing executor/host. Ordinary `main.ts`
-registers only Okou. The factory is not renderer IPC, a preference, an environment
-switch, or an agent-controlled tool interface. Public commands, auth, queue,
+`ComputerUseDriverController` and the existing executor/host. `main.ts` keeps
+Okou as the default and selects this adapter only through the local Developer
+experiment described in [README.md](README.md). The factory itself is not a
+renderer IPC or an agent-controlled tool interface. Public commands, auth, queue,
 errors, result/artifact envelopes and the packaged distribution remain unchanged.
 
 The sole source contract is CUA **0.23.2**, commit
@@ -122,4 +123,4 @@ lifecycle only. They do not prove the fixture action behavior on an interactive
 Mac. Developer ID/notarized installation, actual host TCC attribution, revoked/
 regranted access, real application/window/Unicode/scroll behavior, screenshot
 content, paired Okou comparison and performance remain **unproven and pending
-user acceptance in slice 5**. This PR exposes no selector and authorizes no release.
+user acceptance in slice 5**. The Developer selector does not establish interactive acceptance or authorize a release.

--- a/turbo/apps/desktop/cua/README.md
+++ b/turbo/apps/desktop/cua/README.md
@@ -1,10 +1,9 @@
 # Experimental embedded CUA runtime and adapter
 
-Okou remains the only registered/default Computer Use driver. This slice ships
-a dormant, host-owned runtime and a fixed verification entry point. Slice 3 adds
-an internal [command adapter](ADAPTER.md) factory for the next slice to connect.
-Normal startup does not register or import it. There is no Developer selector,
-preference, renderer diagnostic panel, or runtime updater.
+Okou is the default Computer Use driver. The pinned official macOS arm64
+embedded runtime and [command adapter](ADAPTER.md) are available only through an
+explicit local Developer opt-in and selection. Ordinary startup does not load
+CUA. This adds no agent-facing driver parameter, runtime download or release.
 
 ## Distribution and integrity
 
@@ -162,3 +161,60 @@ revocation/regrant behavior and paired real-app comparison remain **pending
 user verification**. An unsigned CI pass does not complete these items or the
 parent Epic. Future upgrades replace this explicit lock through normal Desktop
 distribution and rerun the package/lifecycle checks.
+
+## Developer selection and recovery
+
+In the native **Developer** menu, **Enable experimental CUA driver** is separate
+from the diagnostic-panel **Developer Tools** checkbox. Enabling it only reveals
+**Computer Use driver** on the main page. Okou remains requested until CUA is
+explicitly selected. CUA is experimental; the [0.23.2 adapter contract](ADAPTER.md)
+is unchanged. There is no implicit browser/Okou fallback or action replay.
+
+The local `computerUseDriver` preference contains only `experimentalCuaEnabled`
+and `selectedDriver` (`okou` or `cua`). Missing/invalid fields use off/Okou; a CUA
+selection requires exact opt-in. Writes preserve installation, keep-awake and
+plugin data. Corrupt/unreadable settings are reported without overwriting them.
+Authorization, native processes and readiness are never persisted.
+
+CUA requires a currently authenticated user/workspace/session, newly resolved
+`_debug` authority, opt-in and a running/explicit Start intent. An unresolved or
+revoked Developer result blocks CUA and retains the choice. Old responses cannot
+authorize a new session. Setup/tray/state reads use Electron host permission
+status without loading either actuator. Explicit Accessibility requests prompt
+the signed host; Screen Recording requests open its macOS Privacy settings.
+Ready CUA command/heartbeat checks still withdraw admission on revocation.
+
+The shared main-page controls remain available during setup, Stop and errors.
+Selecting while stopped persists the choice without starting it. A running
+switch drains the entire claim/action/post-state/completion, retires the old
+generation, and resumes the same cloud host and plugin processes. Rapid choices
+retain only the latest activation intent, including a repeated CUA choice after
+an intervening Okou choice. Stop, auth changes and update/quit supersede startup.
+Disabling persists off/Okou and hides the selector immediately, while actual CUA
+and cleanup remain visible until retirement is proven.
+
+**Retry** is an explicit Start. **Use Okou** changes the request only; neither
+bypasses retained cleanup or a manual Stop. A native failure can retain the real
+non-empty plugin-only host; otherwise the host stops. No unknown action result
+is retried automatically. Updates remain deferred during start, replacement,
+retirement and retained cleanup after a caller-facing timeout.
+
+Diagnostics distinguish requested driver, actual controller generation and
+ready build/runtime version. The packaged CUA version is labeled **expected**;
+a stopped/unready runtime has no loaded-version claim. Lifecycle elapsed time
+is bounded to 120 seconds from the most recent lifecycle intent. Native command
+logs retain only driver ID, version and controller generation captured before
+claim, even if preference changes before completion. Embedded SDK generation is
+a different scope. New errors are bounded categories without SDK messages,
+paths, endpoints, session labels or screen/input content.
+
+### Interactive acceptance still pending
+
+Use a Developer ID signed installation with the intended host identity. Verify
+menu/keyboard selection and recovery with permissions missing, startup delayed,
+CUA failed, manually stopped and Developer access withdrawn. Confirm native
+TCC attribution/grant/revocation, real target screenshots and paired app actions
+against [ADAPTER.md](ADAPTER.md), plus recording continuity and update/rollback.
+The deterministic renderer/OS-boundary tests do not prove these interactions.
+The three actual macOS CI package smoke/probe lanes remain ad-hoc signed and do
+not constitute Developer ID, real TCC, performance or final user acceptance.

--- a/turbo/apps/desktop/src/computer-use-cua.ts
+++ b/turbo/apps/desktop/src/computer-use-cua.ts
@@ -69,7 +69,7 @@ interface Observation {
   readonly scale: number;
 }
 
-/** Internal factory only. The normal main registry intentionally remains Okou-only. */
+/** Lazy internal factory; the Desktop lifecycle owns opt-in and admission. */
 export function createCuaComputerUseDriver(
   options: ConstructorParameters<typeof CuaEmbeddedRuntime>[0],
 ): ComputerUseDriver {
@@ -81,6 +81,8 @@ export function createCuaComputerUseDriver(
 }
 
 class CuaComputerUseBackend implements ComputerUseNativeBackend {
+  isCleanupPending = () => this.runtime.getState().cleanupPending;
+  getRuntimeVersion = () => this.runtime.getState().loadedDriverVersion;
   readonly supportsWindowScroll = true;
   readonly discoveryNote = DISCOVERY_NOTE;
   private observation: Observation | null = null;

--- a/turbo/apps/desktop/src/computer-use-driver.ts
+++ b/turbo/apps/desktop/src/computer-use-driver.ts
@@ -15,14 +15,18 @@ import type {
 import {
   hasRequiredComputerUsePermissions,
   type ComputerUsePermissionState,
+  type ComputerUseExecutionIdentity,
 } from "./computer-use-types";
 
 export interface ComputerUseDriver {
   readonly id: string;
+  readonly buildVersion?: string;
+  readonly getAuthorization?: () => object | null;
   readonly createBackend: () => ComputerUseNativeBackend;
 }
 
 interface DriverGeneration {
+  readonly authorization: object | null;
   readonly driver: ComputerUseDriver;
   readonly generation: number;
   readonly backend: ComputerUseNativeBackend;
@@ -35,6 +39,7 @@ interface DriverGeneration {
 }
 
 export interface ComputerUseCommandSession {
+  readonly identity?: ComputerUseExecutionIdentity;
   beginCommand?(budget: ComputerUseCommandBudget): void;
   getPermissions(
     command?: ComputerUseCommand,
@@ -56,14 +61,79 @@ export class ComputerUseDriverController {
   private active = false;
   private permissionsPaused = false;
   private closed = false;
+  private failure: string | null = null;
 
   constructor(
     private driver: ComputerUseDriver,
     private readonly platform: NodeJS.Platform = process.platform,
+    private readonly onChange: () => void = () => {},
   ) {}
 
   get generation(): number | null {
     return this.context?.generation ?? null;
+  }
+
+  get selectedDriver(): ComputerUseDriver {
+    return this.driver;
+  }
+
+  get cleanupPending(): boolean {
+    return (
+      this.retirement !== null ||
+      (this.context?.backend.isCleanupPending?.() ?? false)
+    );
+  }
+
+  getState() {
+    const context = this.context ?? this.retiringContext;
+    const ready = this.getCapabilities().length > 0;
+    return {
+      actual: context ? this.identity(context, ready) : null,
+      ready,
+      cleanupPending: this.cleanupPending,
+      error:
+        this.failure ??
+        (this.context &&
+        this.active &&
+        this.context.backend.isAvailable?.() === false
+          ? "Native driver became unavailable. Retry after cleanup, or use Okou."
+          : null),
+    };
+  }
+
+  resetFailure(): void {
+    this.failure = null;
+  }
+
+  private identity(
+    context: DriverGeneration,
+    ready: boolean,
+  ): ComputerUseExecutionIdentity {
+    return {
+      id: context.driver.id,
+      generation: context.generation,
+      version: ready
+        ? (context.backend.getRuntimeVersion?.() ??
+          context.driver.buildVersion ??
+          null)
+        : null,
+    };
+  }
+
+  private authorized(context: DriverGeneration): boolean {
+    return (
+      !context.driver.getAuthorization ||
+      (context.authorization !== null &&
+        context.authorization === context.driver.getAuthorization())
+    );
+  }
+
+  /** Synchronous withdrawal; claimed work cannot admit a new native action. */
+  withdrawAdmission(): void {
+    this.active = false;
+    this.permissionsPaused = true;
+    this.context?.snapshots.clear();
+    this.onChange();
   }
 
   private prepare(): DriverGeneration {
@@ -71,8 +141,12 @@ export class ComputerUseDriverController {
       throw new Error("Computer Use driver retirement is not complete");
     }
     if (!this.context) {
+      const authorization = this.driver.getAuthorization?.() ?? null;
+      if (this.driver.getAuthorization && !authorization)
+        throw new Error("Computer Use driver authorization is unavailable");
       const { promise, resolve } = createComputerUseDrain();
       this.context = {
+        authorization,
         driver: this.driver,
         generation: ++this.nextGeneration,
         backend: this.driver.createBackend(),
@@ -83,7 +157,10 @@ export class ComputerUseDriverController {
         disposal: null,
         permissionsReady: false,
       };
+      this.onChange();
     }
+    if (!this.authorized(this.context))
+      throw new Error("Computer Use driver authorization changed");
     return this.context;
   }
 
@@ -91,6 +168,7 @@ export class ComputerUseDriverController {
     this.prepare();
     this.active = true;
     this.permissionsPaused = false;
+    this.onChange();
   }
 
   pausePermissions(): void {
@@ -109,7 +187,9 @@ export class ComputerUseDriverController {
         ...context.backend,
         getPermissions: () => this.readPermissions(context),
       });
-      return this.context === context ? result : null;
+      return this.context === context && this.authorized(context)
+        ? result
+        : null;
     } finally {
       release();
     }
@@ -117,11 +197,17 @@ export class ComputerUseDriverController {
 
   acquireCommand(): ComputerUseCommandSession {
     const context = this.context;
-    if (!this.active || !context || context.backend.isAvailable?.() === false) {
+    if (
+      !this.active ||
+      !context ||
+      !this.authorized(context) ||
+      context.backend.isAvailable?.() === false
+    ) {
       throw new Error("Computer Use driver is not ready");
     }
     const release = this.lease(context);
     return {
+      identity: this.identity(context, true),
       beginCommand: (budget) => context.backend.setCommandBudget?.(budget),
       abort: () => {
         void this.forceRetire().catch(() => {});
@@ -131,6 +217,7 @@ export class ComputerUseDriverController {
         if (
           this.context !== context ||
           !this.active ||
+          !this.authorized(context) ||
           context.backend.isAvailable?.() === false
         )
           return {
@@ -172,6 +259,7 @@ export class ComputerUseDriverController {
     const context = this.context;
     return this.active &&
       context?.permissionsReady &&
+      this.authorized(context) &&
       context.backend.isAvailable?.() !== false
       ? SUPPORTED_COMPUTER_USE_CAPABILITIES
       : [];
@@ -182,11 +270,20 @@ export class ComputerUseDriverController {
   ): Promise<ComputerUsePermissionState> {
     try {
       const permissions = await context.backend.getPermissions();
-      context.permissionsReady = hasRequiredComputerUsePermissions(permissions);
-      if (!context.permissionsReady && this.active)
+      context.permissionsReady =
+        this.context === context &&
+        this.authorized(context) &&
+        hasRequiredComputerUsePermissions(permissions);
+      if (!context.permissionsReady && this.active) {
+        this.failure =
+          "Native permissions or authorization were withdrawn. Explicit recovery is required.";
         void this.forceRetire().catch(() => {});
+      }
+      this.onChange();
       return permissions;
     } catch (error) {
+      this.failure =
+        "Native driver permission check failed. Explicit recovery is required.";
       context.permissionsReady = false;
       if (this.context === context) void this.forceRetire().catch(() => {});
       throw error;
@@ -240,11 +337,13 @@ export class ComputerUseDriverController {
       await this.dispose(context, reason);
     })();
     this.retirement = retirement;
+    this.onChange();
     void retirement.then(
       () => {
         if (this.retirement === retirement) {
           this.retirement = null;
           this.retiringContext = null;
+          this.onChange();
         }
       },
       () => {

--- a/turbo/apps/desktop/src/computer-use-electron.ts
+++ b/turbo/apps/desktop/src/computer-use-electron.ts
@@ -1,4 +1,4 @@
-import type { IpcMainInvokeEvent } from "electron";
+import type { IpcMainInvokeEvent, WebContents, WebFrameMain } from "electron";
 import { BrowserWindow, ipcMain, shell } from "electron";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import { isDesktopComputerUsePageUrl } from "./computer-use-page-url";
@@ -7,13 +7,29 @@ import {
   COMPUTER_USE_AUTOMATION_PERMISSION_TARGETS,
   type ComputerUseAutomationPermissionTarget,
   type DesktopComputerUseState,
+  type ComputerUseDriverId,
 } from "./computer-use-types";
 
 interface ComputerUseIpcOptions {
   readonly rendererUrl: string;
+  readonly getMainWindow: () => {
+    isDestroyed(): boolean;
+    readonly webContents: Pick<WebContents, "isDestroyed"> & {
+      readonly mainFrame: Pick<
+        WebFrameMain,
+        "url" | "detached" | "isDestroyed"
+      >;
+    };
+  } | null;
 }
 
 interface ComputerUseNativeApi {
+  readonly setExperimentalCuaEnabled: (
+    enabled: boolean,
+  ) => Promise<DesktopComputerUseState>;
+  readonly selectDriver: (
+    driver: ComputerUseDriverId,
+  ) => Promise<DesktopComputerUseState>;
   readonly getState: () => DesktopComputerUseState;
   readonly refreshPermissions: () => Promise<DesktopComputerUseState>;
   readonly start: (options: {
@@ -73,7 +89,17 @@ export function installComputerUseIpc(
   options: ComputerUseIpcOptions,
 ): void {
   const assertComputerUsePage = (event: IpcMainInvokeEvent): void => {
+    const window = options.getMainWindow();
+    const frame = event.senderFrame;
     if (
+      !window ||
+      window.isDestroyed() ||
+      window.webContents.isDestroyed() ||
+      event.sender !== window.webContents ||
+      frame !== window.webContents.mainFrame ||
+      !frame ||
+      frame.isDestroyed() ||
+      frame.detached ||
       !isDesktopComputerUsePageUrl(
         event.senderFrame?.url ?? "",
         options.rendererUrl,
@@ -85,11 +111,37 @@ export function installComputerUseIpc(
   const startOptions = (
     value: unknown,
   ): { readonly userInitiated: boolean } => {
+    if (
+      value !== undefined &&
+      (!isComputerUseStartOptions(value) ||
+        typeof value.userInitiated !== "boolean" ||
+        Object.keys(value).some((key) => key !== "userInitiated"))
+    )
+      throw new Error("Invalid Computer Use start options");
     return {
       userInitiated:
         isComputerUseStartOptions(value) && value.userInitiated === true,
     };
   };
+
+  ipcMain.handle(
+    COMPUTER_USE_CHANNELS.setExperimentalCuaEnabled,
+    (event, enabled: unknown) => {
+      assertComputerUsePage(event);
+      if (typeof enabled !== "boolean")
+        throw new Error("Experimental CUA enabled state must be a boolean");
+      return api.setExperimentalCuaEnabled(enabled);
+    },
+  );
+  ipcMain.handle(
+    COMPUTER_USE_CHANNELS.selectDriver,
+    (event, driver: unknown) => {
+      assertComputerUsePage(event);
+      if (driver !== "okou" && driver !== "cua")
+        throw new Error("Unknown Computer Use driver");
+      return api.selectDriver(driver);
+    },
+  );
 
   ipcMain.handle(COMPUTER_USE_CHANNELS.getState, (event) => {
     assertComputerUsePage(event);

--- a/turbo/apps/desktop/src/computer-use-host-permissions.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host-permissions.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { createComputerUseHostPermissions } from "./computer-use-host-permissions";
+
+const os = vi.hoisted(() => ({
+  isTrustedAccessibilityClient: vi.fn<(prompt: boolean) => boolean>(
+    () => false,
+  ),
+  getMediaAccessStatus: vi.fn<() => string>(() => "denied"),
+  openExternal: vi.fn<(url: string) => Promise<void>>(async () => {}),
+}));
+vi.mock("electron", () => ({ systemPreferences: os, shell: os }));
+beforeEach(() => vi.clearAllMocks());
+
+it("reads host TCC without prompting and reserves OS requests for explicit actions", async () => {
+  const permissions = createComputerUseHostPermissions("darwin");
+  expect(await permissions.getPermissions()).toStrictEqual({
+    accessibility: false,
+    screenRecording: false,
+  });
+  expect(os.isTrustedAccessibilityClient.mock.calls).toStrictEqual([[false]]);
+  expect(os.getMediaAccessStatus).toHaveBeenCalledWith("screen");
+  expect(os.openExternal).not.toHaveBeenCalled();
+  await permissions.requestAccessibilityPermission();
+  expect(os.isTrustedAccessibilityClient.mock.calls).toStrictEqual([
+    [false],
+    [true],
+    [false],
+  ]);
+  await permissions.requestScreenRecordingPermission();
+  expect(os.openExternal).toHaveBeenCalledExactlyOnceWith(
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+  );
+  os.isTrustedAccessibilityClient.mockReturnValue(true);
+  os.getMediaAccessStatus.mockReturnValue("granted");
+  expect(await permissions.getPermissions()).toStrictEqual({
+    accessibility: true,
+    screenRecording: true,
+  });
+  expect(await permissions.probeAutomationPermission("chrome")).toMatchObject({
+    status: "unknown",
+  });
+});

--- a/turbo/apps/desktop/src/computer-use-host-permissions.ts
+++ b/turbo/apps/desktop/src/computer-use-host-permissions.ts
@@ -1,0 +1,33 @@
+import { systemPreferences, shell } from "electron";
+import type { ComputerUsePermissionProvider } from "./computer-use-permissions";
+
+/** Electron's signed host can inspect TCC without loading either actuator. */
+export function createComputerUseHostPermissions(platform: NodeJS.Platform = process.platform): ComputerUsePermissionProvider {
+  const getPermissions = async () => ({
+    accessibility:
+      platform === "darwin" &&
+      systemPreferences.isTrustedAccessibilityClient(false),
+    screenRecording:
+      platform === "darwin" &&
+      systemPreferences.getMediaAccessStatus("screen") === "granted",
+  });
+  return {
+    getPermissions,
+    requestAccessibilityPermission: async () => {
+      if (platform === "darwin")
+        systemPreferences.isTrustedAccessibilityClient(true);
+      return getPermissions();
+    },
+    requestScreenRecordingPermission: async () => {
+      await shell.openExternal(
+        "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+      );
+      return getPermissions();
+    },
+    probeAutomationPermission: async () => ({
+      status: "unknown",
+      updatedAt: null,
+      reason: "CUA does not use browser Apple Events automation",
+    }),
+  };
+}

--- a/turbo/apps/desktop/src/computer-use-host-permissions.ts
+++ b/turbo/apps/desktop/src/computer-use-host-permissions.ts
@@ -2,7 +2,9 @@ import { systemPreferences, shell } from "electron";
 import type { ComputerUsePermissionProvider } from "./computer-use-permissions";
 
 /** Electron's signed host can inspect TCC without loading either actuator. */
-export function createComputerUseHostPermissions(platform: NodeJS.Platform = process.platform): ComputerUsePermissionProvider {
+export function createComputerUseHostPermissions(
+  platform: NodeJS.Platform = process.platform,
+): ComputerUsePermissionProvider {
   const getPermissions = async () => ({
     accessibility:
       platform === "darwin" &&

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -51,6 +51,8 @@ const LOCAL_COMMAND_LOG_OMITTED_RESULT_KEYS = new Set([
   "visibleElements",
 ]);
 
+class ComputerUseCapabilitiesPaused extends Error {}
+
 export type ComputerUseHostFetch = (
   input: string,
   init?: RequestInit,
@@ -394,6 +396,7 @@ export class ComputerUseHostRuntime {
     const permissions = await this.getPermissions();
     const capabilities = this.getSupportedCapabilities();
     if (capabilities.length === 0) {
+      if (this.draining) throw new ComputerUseCapabilitiesPaused();
       await this.stop();
       throw new Error("Computer Use has no available capabilities");
     }
@@ -498,9 +501,11 @@ export class ComputerUseHostRuntime {
   private startLocalCommandLogEntry(
     command: ComputerUseCommand,
     startedAt: string,
+    driver: ComputerUseCommandSession["identity"],
   ): void {
     const app = command.payload.app;
     const entry: ComputerUseLocalCommandLogEntry = {
+      ...(command.kind !== "plugin.call" && driver ? { driver } : {}),
       commandId: command.id,
       kind: command.kind,
       app: typeof app === "string" ? app : null,
@@ -702,6 +707,12 @@ export class ComputerUseHostRuntime {
   private async heartbeatLoop(): Promise<void> {
     const generation = this.sessionGeneration;
     try {
+      // A bounded native replacement keeps this host registration. Never send
+      // an empty legacy capability list during its activation gap.
+      if (this.draining && this.getSupportedCapabilities().length === 0) {
+        this.scheduleHeartbeat(HEARTBEAT_POLL_MS);
+        return;
+      }
       const online = this.hostToken && (await this.heartbeat());
       if (generation !== this.sessionGeneration) return;
       if (!online) {
@@ -711,6 +722,13 @@ export class ComputerUseHostRuntime {
       }
       this.scheduleHeartbeat(HEARTBEAT_POLL_MS);
     } catch (error) {
+      if (
+        error instanceof ComputerUseCapabilitiesPaused &&
+        generation === this.sessionGeneration
+      ) {
+        this.scheduleHeartbeat(HEARTBEAT_POLL_MS);
+        return;
+      }
       if (generation === this.sessionGeneration)
         this.handleRuntimeFailure("heartbeat", error);
     }
@@ -1043,7 +1061,11 @@ export class ComputerUseHostRuntime {
     const startedAtMs = Date.now();
     this.lastCommandActivityAtMs = startedAtMs;
     const startedAt = new Date(startedAtMs).toISOString();
-    this.startLocalCommandLogEntry(body.command, startedAt);
+    this.startLocalCommandLogEntry(
+      body.command,
+      startedAt,
+      commandSession.identity,
+    );
 
     let completed: ComputerUseCommandExecutionResult;
     const budget = new ComputerUseCommandBudget(

--- a/turbo/apps/desktop/src/computer-use-ipc-channels.ts
+++ b/turbo/apps/desktop/src/computer-use-ipc-channels.ts
@@ -1,4 +1,6 @@
 export const COMPUTER_USE_CHANNELS = {
+  setExperimentalCuaEnabled: "computer-use:set-experimental-cua-enabled",
+  selectDriver: "computer-use:select-driver",
   getState: "computer-use:get-state",
   refreshPermissions: "computer-use:refresh-permissions",
   start: "computer-use:start",

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -70,6 +70,8 @@ export interface ComputerUseNativeAppRecord {
 }
 
 export interface ComputerUseNativeBackend {
+  readonly isCleanupPending?: () => boolean;
+  readonly getRuntimeVersion?: () => string | null;
   readonly validateCommand?: (command: ComputerUseCommand) => void;
   readonly setCommandBudget?: (budget: ComputerUseCommandBudget | null) => void;
   readonly supportsWindowScroll?: boolean;

--- a/turbo/apps/desktop/src/computer-use-permissions.ts
+++ b/turbo/apps/desktop/src/computer-use-permissions.ts
@@ -27,16 +27,23 @@ export function createComputerUsePermissions(
   ) => Promise<T | null>,
 ) {
   let currentPermissionState = DEFAULT_COMPUTER_USE_PERMISSION_STATE;
+  let revision = 0;
+
+  function resetComputerUsePermissionState(): void {
+    revision++;
+    currentPermissionState = DEFAULT_COMPUTER_USE_PERMISSION_STATE;
+  }
 
   function getComputerUsePermissionState(): ComputerUsePermissionState {
     return currentPermissionState;
   }
 
   async function refreshComputerUsePermissionState(): Promise<ComputerUsePermissionState> {
+    const current = revision;
     const permissions = await withProvider((provider) =>
       provider.getPermissions(),
     );
-    if (!permissions) return currentPermissionState;
+    if (!permissions || current !== revision) return currentPermissionState;
     currentPermissionState = normalizeComputerUsePermissionState({
       ...permissions,
       automation: currentPermissionState.automation,
@@ -45,10 +52,11 @@ export function createComputerUsePermissions(
   }
 
   async function requestComputerUseAccessibilityPermission(): Promise<ComputerUsePermissionState> {
+    const current = revision;
     const permissions = await withProvider((provider) =>
       provider.requestAccessibilityPermission(),
     );
-    if (!permissions) return currentPermissionState;
+    if (!permissions || current !== revision) return currentPermissionState;
     currentPermissionState = normalizeComputerUsePermissionState({
       ...permissions,
       automation: currentPermissionState.automation,
@@ -57,11 +65,12 @@ export function createComputerUsePermissions(
   }
 
   async function requestComputerUseScreenRecordingPermission(): Promise<ComputerUsePermissionState> {
+    const current = revision;
     const automation = currentPermissionState.automation;
     const permissions = await withProvider((provider) =>
       provider.requestScreenRecordingPermission(),
     );
-    if (!permissions) return currentPermissionState;
+    if (!permissions || current !== revision) return currentPermissionState;
     currentPermissionState = normalizeComputerUsePermissionState({
       ...permissions,
       automation,
@@ -72,10 +81,11 @@ export function createComputerUsePermissions(
   async function probeComputerUseAutomationPermission(
     target: ComputerUseAutomationPermissionTarget,
   ): Promise<ComputerUsePermissionState> {
+    const current = revision;
     const result = await withProvider((provider) =>
       provider.probeAutomationPermission(target),
     );
-    if (!result) return currentPermissionState;
+    if (!result || current !== revision) return currentPermissionState;
     currentPermissionState = normalizeComputerUsePermissionState({
       ...currentPermissionState,
       automation: {
@@ -110,6 +120,7 @@ export function createComputerUsePermissions(
   }
 
   return {
+    resetComputerUsePermissionState,
     getComputerUsePermissionState,
     refreshComputerUsePermissionState,
     requestComputerUseAccessibilityPermission,

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.test.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.test.ts
@@ -105,7 +105,7 @@ describe("ComputerUseRuntimeController", () => {
 
     expect(createRuntime).not.toHaveBeenCalled();
     expect(controller.getHostState().status).toBe("offline");
-    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalled();
   });
 
   it("records a blocked host state when signed out", async () => {

--- a/turbo/apps/desktop/src/computer-use-runtime-controller.ts
+++ b/turbo/apps/desktop/src/computer-use-runtime-controller.ts
@@ -14,6 +14,7 @@ import {
   hasRequiredComputerUsePermissions,
   type ComputerUseHostRuntimeState,
   type ComputerUsePermissionState,
+  type DesktopComputerUseDriverState,
 } from "./computer-use-types";
 
 const DEFAULT_QUIT_STOP_TIMEOUT_MS = 1_000;
@@ -28,6 +29,8 @@ interface ComputerUseRuntimeLike {
 }
 
 interface ComputerUseRuntimeControllerOptions {
+  readonly prepareNative?: () => Promise<ComputerUsePermissionState>;
+  readonly nativeBlockReason?: (driver: ComputerUseDriver) => string | null;
   /**
    * Runtime factory invoked when the startup gate is ready and no runtime
    * exists. The production implementation wires all Electron/session
@@ -70,7 +73,16 @@ export class ComputerUseRuntimeController {
   private intent = 0;
   private stopping: Promise<void> = Promise.resolve();
   private starting: Promise<void> | null = null;
-  private readonly transitions = new Map<ComputerUseDriver, Promise<void>>();
+  private transitionCount = 0;
+  private selectionRevision = 0;
+  private lastTransition: {
+    driver: ComputerUseDriver;
+    promise: Promise<void>;
+  } | null = null;
+  private requestedDriver: ComputerUseDriver | undefined;
+  private runningRequested = false;
+  private nativeError: string | null = null;
+  private phaseStartedAt = performance.now();
   private transitionTail: Promise<void> = Promise.resolve();
   private readonly driver: ComputerUseDriverController | undefined;
   private readonly transitionTimeoutMs: number;
@@ -80,11 +92,12 @@ export class ComputerUseRuntimeController {
   private readonly preparePlugins: () => Promise<void>;
   private pluginStartupIntent: number | null = null;
 
-  constructor(options: ComputerUseRuntimeControllerOptions) {
+  constructor(private readonly options: ComputerUseRuntimeControllerOptions) {
     this.getPluginCapabilities = options.getPluginCapabilities ?? (() => []);
     this.preparePlugins = options.preparePlugins ?? (async () => {});
     this.lifecycleTimers = options.lifecycleTimers;
     this.driver = options.driver;
+    this.requestedDriver = options.driver?.selectedDriver;
     this.transitionTimeoutMs = options.transitionTimeoutMs ?? 30_000;
     this.createRuntime = options.createRuntime;
     this.refreshPermissions = options.refreshPermissions;
@@ -113,6 +126,75 @@ export class ComputerUseRuntimeController {
     return this.isRuntimeOnline() || this.pluginStartupIntent === this.intent;
   }
 
+  private nativeBlockReason(): string | null {
+    return this.requestedDriver
+      ? (this.options.nativeBlockReason?.(this.requestedDriver) ?? null)
+      : null;
+  }
+
+  getDriverState(): Pick<
+    DesktopComputerUseDriverState,
+    | "actual"
+    | "phase"
+    | "lifecycleElapsedMs"
+    | "cleanupPending"
+    | "error"
+    | "canRetry"
+  > {
+    const state = this.driver?.getState();
+    const blocked = this.nativeBlockReason();
+    const error = this.nativeError ?? state?.error ?? blocked;
+    const phase =
+      this.nativeError || state?.error
+        ? "error"
+        : this.transitionCount > 0
+          ? "switching"
+          : state?.cleanupPending
+            ? "retiring"
+            : this.starting
+              ? "starting"
+              : blocked
+                ? "blocked"
+                : state?.ready
+                  ? "ready"
+                  : "stopped";
+    return {
+      actual: state?.actual ?? null,
+      phase,
+      lifecycleElapsedMs: Math.min(
+        120_000,
+        Math.max(0, Math.round(performance.now() - this.phaseStartedAt)),
+      ),
+      cleanupPending: state?.cleanupPending ?? false,
+      error,
+      canRetry:
+        !this.quitStopStarted &&
+        !this.isTransitioning() &&
+        !blocked &&
+        !state?.ready,
+    };
+  }
+
+  /** Availability changes use the same replacement queue, never a fresh owner. */
+  async refreshDriverAuthorization(): Promise<void> {
+    if (!this.requestedDriver?.getAuthorization || this.quitStopStarted) return;
+    if (this.nativeBlockReason()) {
+      this.supersede();
+      this.driver?.withdrawAdmission();
+      void this.driver?.forceRetire().catch(() => {});
+      await this.transitionDriver(this.requestedDriver);
+    } else if (
+      this.runningRequested &&
+      !this.manualStopRequested &&
+      !this.nativeError &&
+      !this.driver?.getState().error
+    ) {
+      if (this.runtime) await this.transitionDriver(this.requestedDriver);
+      else await this.start();
+    }
+    this.onChange();
+  }
+
   /**
    * Starts the runtime when permissions and auth pass the startup gate;
    * otherwise stops any existing runtime and records the blocked host state.
@@ -126,10 +208,23 @@ export class ComputerUseRuntimeController {
   ): Promise<void> {
     if (
       this.quitStopStarted ||
+      ((this.nativeError !== null || this.driver?.getState().error) &&
+        options.userInitiated !== true) ||
       (this.manualStopRequested && options.userInitiated !== true)
     )
       return;
     options.signal?.throwIfAborted();
+    this.runningRequested = true;
+    if (options.userInitiated) {
+      if (this.driver?.getState().error) {
+        this.stopping = Promise.all([
+          this.stopping,
+          this.driver.forceRetire(),
+        ]).then(() => {});
+      }
+      this.nativeError = null;
+      this.driver?.resetFailure();
+    }
     this.manualStopRequested = false;
     if (this.starting) return this.starting;
     const intent = this.intent;
@@ -139,10 +234,17 @@ export class ComputerUseRuntimeController {
       this.detachRuntime();
     };
     options.signal?.addEventListener("abort", abort, { once: true });
-    const start = this.startRuntime(intent, this.transitionTail);
+    const selection = this.selectionRevision;
+    const start = this.startRuntime(intent, selection, this.transitionTail);
     this.starting = start;
+    this.phaseStartedAt = performance.now();
     try {
       await start;
+    } catch (error) {
+      if (intent === this.intent && selection === this.selectionRevision)
+        this.nativeError =
+          "Driver startup failed. Retry after cleanup, or use Okou.";
+      throw error;
     } finally {
       if (this.pluginStartupIntent === intent) {
         this.pluginStartupIntent = null;
@@ -150,11 +252,13 @@ export class ComputerUseRuntimeController {
       }
       options.signal?.removeEventListener("abort", abort);
       if (this.starting === start) this.starting = null;
+      this.onChange();
     }
   }
 
   private async startRuntime(
     intent: number,
+    selection: number,
     transitions: Promise<void>,
   ): Promise<void> {
     await withComputerUseDeadline(
@@ -162,10 +266,73 @@ export class ComputerUseRuntimeController {
       this.transitionTimeoutMs,
       this.lifecycleTimers,
     );
-    await transitions;
-    if (intent !== this.intent) return;
+    await withComputerUseDeadline(
+      transitions,
+      this.transitionTimeoutMs,
+      this.lifecycleTimers,
+    );
+    if (intent !== this.intent || selection !== this.selectionRevision) return;
+    if (
+      this.driver &&
+      this.requestedDriver &&
+      this.driver.selectedDriver !== this.requestedDriver
+    ) {
+      await withComputerUseDeadline(
+        this.driver.retire(),
+        this.transitionTimeoutMs,
+        this.lifecycleTimers,
+      );
+      if (intent !== this.intent || selection !== this.selectionRevision)
+        return;
+      this.driver.select(this.requestedDriver);
+    }
+    const authState = await this.getAuthState();
+    if (intent !== this.intent || selection !== this.selectionRevision) return;
+    const permissions = await this.prepareStartupPermissions(
+      authState,
+      intent,
+      selection,
+    );
+    if (
+      !permissions ||
+      intent !== this.intent ||
+      selection !== this.selectionRevision
+    )
+      return;
+    const startupGate = resolveComputerUseStartupGate({
+      authState,
+      permissions,
+      pluginCapabilities: this.getPluginCapabilities(),
+    });
+    if (startupGate.status !== "ready") {
+      await this.detachRuntime();
+      if (intent !== this.intent || selection !== this.selectionRevision)
+        return;
+      if (startupGate.status === "blocked") {
+        this.blockedHostState = startupGate.host;
+        this.onChange();
+      }
+      return;
+    }
+    this.blockedHostState = null;
+    if (
+      hasRequiredComputerUsePermissions(permissions) &&
+      !this.nativeBlockReason()
+    )
+      this.driver?.activate();
+    const runtime = (this.runtime ??= this.createRuntime());
+    await runtime.start();
+    if (intent !== this.intent || selection !== this.selectionRevision) return;
+    this.setHostRuntimeOnline(runtime.getState().status === "online");
+  }
+
+  private async prepareStartupPermissions(
+    authState: DesktopAuthState,
+    intent: number,
+    selection: number,
+  ): Promise<ComputerUsePermissionState | null> {
     this.driver?.resumePermissions();
-    const permissions = await withComputerUseDeadline(
+    let permissions = await withComputerUseDeadline(
       this.refreshPermissions(),
       this.transitionTimeoutMs,
       this.lifecycleTimers,
@@ -173,9 +340,44 @@ export class ComputerUseRuntimeController {
       void this.driver?.forceRetire().catch(() => {});
       return { accessibility: false, screenRecording: false };
     });
-    if (intent !== this.intent) return;
-    const authState = await this.getAuthState();
-    if (intent !== this.intent) return;
+    if (intent !== this.intent || selection !== this.selectionRevision)
+      return null;
+    if (this.nativeBlockReason()) {
+      permissions = { accessibility: false, screenRecording: false };
+    } else if (
+      authState.status === "signed_in" &&
+      authState.organization &&
+      hasRequiredComputerUsePermissions(permissions) &&
+      this.options.prepareNative
+    ) {
+      try {
+        permissions = await withComputerUseDeadline(
+          this.options.prepareNative(),
+          this.transitionTimeoutMs,
+          this.lifecycleTimers,
+        );
+      } catch {
+        if (intent === this.intent && selection === this.selectionRevision)
+          this.nativeError =
+            "Driver startup failed. Retry after cleanup, or use Okou.";
+        void this.driver?.forceRetire().catch(() => {});
+        permissions = { accessibility: false, screenRecording: false };
+      }
+      if (intent !== this.intent || selection !== this.selectionRevision)
+        return null;
+      if (!hasRequiredComputerUsePermissions(permissions) && !this.nativeError)
+        this.nativeError =
+          "Driver permissions are unavailable. Check host permissions and retry.";
+    }
+    if (
+      !hasRequiredComputerUsePermissions(permissions) &&
+      this.requestedDriver?.id === "cua" &&
+      !this.nativeBlockReason() &&
+      authState.status === "signed_in"
+    ) {
+      this.nativeError ??=
+        "Driver permissions are unavailable. Check host permissions and retry.";
+    }
     if (
       !hasRequiredComputerUsePermissions(permissions) &&
       authState.status === "signed_in" &&
@@ -187,39 +389,23 @@ export class ComputerUseRuntimeController {
         this.transitionTimeoutMs,
         this.lifecycleTimers,
       );
-      if (intent !== this.intent) return;
+      if (intent !== this.intent || selection !== this.selectionRevision)
+        return null;
     }
-    const startupGate = resolveComputerUseStartupGate({
-      authState,
-      permissions,
-      pluginCapabilities: this.getPluginCapabilities(),
-    });
-    if (startupGate.status !== "ready") {
-      await this.detachRuntime();
-      if (intent !== this.intent) return;
-      if (startupGate.status === "blocked") {
-        this.blockedHostState = startupGate.host;
-        this.onChange();
-      }
-      return;
-    }
-    this.blockedHostState = null;
-    if (hasRequiredComputerUsePermissions(permissions)) this.driver?.activate();
-    const runtime = (this.runtime ??= this.createRuntime());
-    await runtime.start();
-    if (intent !== this.intent) return;
-    this.setHostRuntimeOnline(runtime.getState().status === "online");
+    return permissions;
   }
 
   /** Serialized native replacement; it never changes host/plugin online state on success. */
   transitionDriver(driver: ComputerUseDriver): Promise<void> {
-    const existing = this.transitions.get(driver);
-    if (existing) return existing;
+    if (this.lastTransition?.driver === driver)
+      return this.lastTransition.promise;
     if (!this.driver || this.quitStopStarted) {
       return Promise.reject(
         new Error("Computer Use driver transitions are unavailable"),
       );
     }
+    this.requestedDriver = driver;
+    const selection = ++this.selectionRevision;
     const intent = this.intent;
     const pendingStart = this.starting;
     const initialRuntime = this.runtime;
@@ -228,12 +414,23 @@ export class ComputerUseRuntimeController {
     this.driver.pausePermissions();
     let expired = false;
     const checkIntent = () => {
-      if (expired || intent !== this.intent)
+      if (
+        expired ||
+        intent !== this.intent ||
+        selection !== this.selectionRevision
+      )
         throw new Error("Computer Use driver transition was superseded");
     };
+    const previous = this.transitionTail;
     const work = (async () => {
-      await this.transitionTail;
-      await pendingStart;
+      await previous;
+      // Startup reports its own bounded failure; replacement still has to
+      // retire that owner and install the requested lane for explicit recovery.
+      await pendingStart?.catch(() => {});
+      // Only the latest accepted selection activates. Earlier callers still
+      // retain their work/cleanup, but do not publish obsolete readiness.
+      if (selection !== this.selectionRevision && intent === this.intent)
+        return;
       checkIntent();
       const runtime = this.runtime;
       this.driver?.pausePermissions();
@@ -244,18 +441,21 @@ export class ComputerUseRuntimeController {
       await this.driver?.retire();
       checkIntent();
       this.driver?.select(driver);
-      if (runtime && !this.manualStopRequested) {
-        const permissions = await this.refreshPermissions();
-        checkIntent();
-        if (
-          !hasRequiredComputerUsePermissions(permissions) &&
-          this.getPluginCapabilities().length === 0
-        )
-          throw new Error("Computer Use permissions are unavailable");
-        if (hasRequiredComputerUsePermissions(permissions))
-          this.driver?.activate();
-        resume?.();
+      if (
+        !runtime &&
+        pendingStart &&
+        this.runningRequested &&
+        !this.manualStopRequested &&
+        !this.nativeError &&
+        !this.driver?.getState().error
+      ) {
+        // Preserve the already-running Start intent, while only its latest
+        // selection may register a host. Do not await our own transition tail.
+        await this.startRuntime(intent, selection, Promise.resolve());
+        return;
       }
+      if (runtime && !this.manualStopRequested)
+        await this.resumeSelectedDriver(resume, checkIntent);
     })();
     const transition = withComputerUseDeadline(
       work,
@@ -263,45 +463,107 @@ export class ComputerUseRuntimeController {
       this.lifecycleTimers,
     ).catch((error: unknown) => {
       expired = true;
-      // A failure withdraws the host rather than advertising empty legacy capabilities.
-      if (intent === this.intent) {
-        void this.driver?.forceRetire().catch(() => {});
-        if (this.getPluginCapabilities().length > 0 && this.runtime) {
-          // The rejected transition keeps its native owner retired. Existing
-          // host authorization, heartbeat and plugin processes remain intact.
-          void this.runtime.pauseAndDrainCommands().then((resume) => resume());
-          throw error;
-        }
-        this.manualStopRequested = true;
-        this.supersede();
-        this.detachRuntime();
-        this.blockedHostState = {
-          ...OFFLINE_COMPUTER_USE_HOST_STATE,
-          status: "error",
-          lastError: error instanceof Error ? error.message : String(error),
-        };
-      }
-      throw error;
+      this.handleDriverTransitionFailure(error, intent, selection);
     });
-    this.transitions.set(driver, transition);
-    this.transitionTail = transition.then(
+    this.transitionCount++;
+    this.phaseStartedAt = performance.now();
+    this.lastTransition = { driver, promise: transition };
+    // The caller-facing deadline is not proof the underlying work retired.
+    this.transitionTail = work.then(
       () => {},
       () => {},
     );
     void this.transitionTail.then(() => {
-      this.transitions.delete(driver);
+      this.transitionCount--;
       this.onChange();
     });
+    const finish = () => {
+      if (this.lastTransition?.promise === transition)
+        this.lastTransition = null;
+      this.onChange();
+    };
+    void transition.then(finish, finish);
     this.onChange();
     return transition;
   }
 
+  private handleDriverTransitionFailure(
+    error: unknown,
+    intent: number,
+    selection: number,
+  ): void {
+    // A failure withdraws the host rather than advertising empty legacy capabilities.
+    if (intent === this.intent && selection === this.selectionRevision) {
+      this.nativeError =
+        "Driver transition failed. Retry after cleanup, or use Okou.";
+      void this.driver?.forceRetire().catch(() => {});
+      if (this.getPluginCapabilities().length > 0 && this.runtime) {
+        // The rejected transition keeps its native owner retired. Existing
+        // host authorization, heartbeat and plugin processes remain intact.
+        void this.runtime.pauseAndDrainCommands().then((resume) => resume());
+        throw error;
+      }
+      this.manualStopRequested = true;
+      this.supersede();
+      this.detachRuntime();
+      this.blockedHostState = {
+        ...OFFLINE_COMPUTER_USE_HOST_STATE,
+        status: "error",
+        lastError: this.nativeError,
+      };
+    }
+    if (intent === this.intent && selection !== this.selectionRevision) return;
+    throw error;
+  }
+
+  private async resumeSelectedDriver(
+    resume: (() => void) | undefined,
+    checkIntent: () => void,
+  ): Promise<void> {
+    if (
+      this.nativeError ||
+      this.driver?.getState().error ||
+      this.nativeBlockReason()
+    ) {
+      if (this.getPluginCapabilities().length > 0) resume?.();
+      else await this.detachRuntime();
+      return;
+    }
+    const auth = await this.getAuthState();
+    checkIntent();
+    if (auth.status !== "signed_in" || !auth.organization) {
+      await this.detachRuntime();
+      return;
+    }
+    let permissions = await this.refreshPermissions();
+    checkIntent();
+    if (
+      hasRequiredComputerUsePermissions(permissions) &&
+      this.options.prepareNative
+    )
+      permissions = await this.options.prepareNative();
+    checkIntent();
+    if (!hasRequiredComputerUsePermissions(permissions)) {
+      this.nativeError =
+        "Driver permissions are unavailable. Check host permissions and retry.";
+      if (this.getPluginCapabilities().length === 0)
+        throw new Error("Computer Use permissions are unavailable");
+    }
+    if (hasRequiredComputerUsePermissions(permissions)) this.driver?.activate();
+    resume?.();
+  }
+
   isTransitioning(): boolean {
-    return this.transitions.size > 0;
+    return (
+      this.transitionCount > 0 ||
+      this.starting !== null ||
+      (this.driver?.cleanupPending ?? false)
+    );
   }
 
   /** User-initiated stop; suppresses auto-restarts until the next manual start. */
   async stop(): Promise<void> {
+    this.runningRequested = false;
     this.manualStopRequested = true;
     this.supersede();
     await withComputerUseDeadline(
@@ -313,6 +575,7 @@ export class ComputerUseRuntimeController {
 
   /** Stops admitting work, lets the active command finish, then stops. */
   async drainAndStop(): Promise<void> {
+    this.runningRequested = false;
     this.manualStopRequested = true;
     this.supersede();
     await this.runtime?.drainAndStop();
@@ -385,6 +648,8 @@ export class ComputerUseRuntimeController {
 
   private supersede(): void {
     this.intent++;
+    this.lastTransition = null;
+    this.phaseStartedAt = performance.now();
     this.starting = null;
     this.driver?.pausePermissions();
   }

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -73,6 +73,7 @@ export type ComputerUseLocalCommandLogStatus =
   | "failed";
 
 export interface ComputerUseLocalCommandLogEntry {
+  readonly driver?: ComputerUseExecutionIdentity;
   readonly commandId: string;
   readonly kind: string;
   readonly app: string | null;
@@ -154,6 +155,7 @@ export interface DesktopComputerUsePluginsState {
 }
 
 export interface DesktopComputerUseState {
+  readonly driver: DesktopComputerUseDriverState;
   readonly platform: NodeJS.Platform;
   readonly supported: boolean;
   /**
@@ -165,6 +167,37 @@ export interface DesktopComputerUseState {
   readonly host: ComputerUseHostRuntimeState;
   readonly keepAwake: DesktopKeepAwakeState;
   readonly plugins?: DesktopComputerUsePluginsState;
+}
+
+export type ComputerUseDriverId = "okou" | "cua";
+
+export interface ComputerUseDriverPreference {
+  readonly experimentalCuaEnabled: boolean;
+  readonly selectedDriver: ComputerUseDriverId;
+}
+
+export interface ComputerUseExecutionIdentity {
+  readonly id: string;
+  readonly generation: number;
+  readonly version: string | null;
+}
+
+export interface DesktopComputerUseDriverState extends ComputerUseDriverPreference {
+  readonly developerAvailability: "unresolved" | "available" | "unavailable";
+  readonly actual: ComputerUseExecutionIdentity | null;
+  readonly phase:
+    | "stopped"
+    | "starting"
+    | "ready"
+    | "switching"
+    | "retiring"
+    | "blocked"
+    | "error";
+  readonly lifecycleElapsedMs: number;
+  readonly cleanupPending: boolean;
+  readonly expectedCuaVersion: string;
+  readonly error: string | null;
+  readonly canRetry: boolean;
 }
 
 export function hasRequiredComputerUsePermissions(

--- a/turbo/apps/desktop/src/cua-runtime.ts
+++ b/turbo/apps/desktop/src/cua-runtime.ts
@@ -63,8 +63,13 @@ export class CuaEmbeddedRuntime {
   getState() {
     return {
       phase: this.phase,
+      cleanupPending: this.context?.retired ?? false,
       generation: this.context?.id ?? null,
       driverVersion: artifacts.driverVersion,
+      loadedDriverVersion:
+        this.phase === "ready"
+          ? (this.context?.connection?.driverVersion ?? null)
+          : null,
       error: this.error,
     };
   }

--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -244,7 +244,8 @@ describe("Okou App session authority", () => {
       (await session.fetchWithSessionAuth(new URL(`${api}/api/protected`)))
         .status,
     ).toBe(401);
-    expect(changes).toEqual(["expired", null]);
+    expect(changes).toEqual([null, null, "expired", null, null]);
+    expect(session.getAuthority()).toBeNull();
     expect(await session.getAuthState()).toEqual(signedOut);
     expect(await session.getToken({ forceRefresh: true })).toBeNull();
     expect(windows).toHaveLength(2);

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -101,6 +101,41 @@ export class DesktopAuthSession {
   private pendingCallback: DesktopAuthCallback | null = null;
   private signingIn = false;
   private restoreEnabled = true;
+  private authority: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly lifetime: AbortSignal;
+  } | null = null;
+
+  /** Opaque, current identity/session proof. Never sent over the renderer bridge. */
+  getAuthority(): object | null {
+    return !this.signingIn && !this.lifetime.signal.aborted
+      ? this.authority
+      : null;
+  }
+
+  private rememberAuthority(
+    state: DesktopAuthState,
+    lifetime: AbortController,
+  ): void {
+    if (this.lifetime !== lifetime || lifetime.signal.aborted) return;
+    const next =
+      state.status === "signed_in" && state.organization
+        ? {
+            userId: state.user.userId,
+            orgId: state.organization.id,
+            lifetime: lifetime.signal,
+          }
+        : null;
+    if (
+      this.authority?.userId === next?.userId &&
+      this.authority?.orgId === next?.orgId &&
+      this.authority?.lifetime === next?.lifetime
+    )
+      return;
+    this.authority = next;
+    this.onChange();
+  }
 
   constructor(options: DesktopAuthSessionOptions) {
     this.product = options.product;
@@ -208,9 +243,11 @@ export class DesktopAuthSession {
   }
 
   private async fetchAuthState(): Promise<DesktopAuthState> {
+    const lifetime = this.lifetime;
     const meUrl = new URL(AUTH_ME_PATH, this.apiBaseUrl);
     const meResponse = await this.fetchWithSessionAuth(meUrl);
     if (meResponse.status === 401) {
+      this.rememberAuthority(signedOutDesktopAuthState(), lifetime);
       return signedOutDesktopAuthState();
     }
     if (!meResponse.ok) {
@@ -221,9 +258,11 @@ export class DesktopAuthSession {
     const orgUrl = new URL(ZERO_ORG_PATH, this.apiBaseUrl);
     const orgResponse = await this.fetchWithSessionAuth(orgUrl);
     if (orgResponse.status === 401) {
+      this.rememberAuthority(signedOutDesktopAuthState(), lifetime);
       return signedOutDesktopAuthState();
     }
     if (orgResponse.status === 404) {
+      this.rememberAuthority(signedOutDesktopAuthState(), lifetime);
       return { status: "signed_in", user, organization: null };
     }
     if (!orgResponse.ok) {
@@ -233,7 +272,7 @@ export class DesktopAuthSession {
     }
 
     const organization = (await orgResponse.json()) as ZeroOrgResponse;
-    return {
+    const state: DesktopAuthState = {
       status: "signed_in",
       user,
       organization: {
@@ -241,10 +280,13 @@ export class DesktopAuthSession {
         name: organization.name,
       },
     };
+    this.rememberAuthority(state, lifetime);
+    return lifetime.signal.aborted ? signedOutDesktopAuthState() : state;
   }
 
   signOut(): void {
     this.lifetime.abort();
+    this.authority = null;
     this.token = null;
     this.appState = signedOutDesktopAuthState();
     this.tokenRefresh.clear();
@@ -311,10 +353,13 @@ export class DesktopAuthSession {
     this.lifetime.abort();
     const lifetime = new AbortController();
     this.lifetime = lifetime;
+    this.authority = null;
     this.restoreEnabled = true;
     this.token = null;
     this.appState = signedOutDesktopAuthState();
     this.setSigningIn(interactive);
+    // Even a hidden token restoration replaces session execution authority.
+    this.onChange();
     // The lifetime also owns validation requests after the window closes.
     const signal = AbortSignal.any([
       lifetime.signal,
@@ -334,6 +379,7 @@ export class DesktopAuthSession {
         signal.throwIfAborted();
         if (state.status !== "signed_in") return null;
         this.appState = state;
+        this.rememberAuthority(state, lifetime);
       }
       this.token = token;
       this.onChange();
@@ -441,11 +487,16 @@ export class DesktopAuthSession {
     try {
       const state = await this.readAppIdentity(this.token, lifetime.signal);
       lifetime.signal.throwIfAborted();
-      if (state.status === "signed_in") return state;
+      if (state.status === "signed_in") {
+        this.appState = state;
+        this.rememberAuthority(state, lifetime);
+        return state;
+      }
       await this.getToken({ forceRefresh: true });
       return this.appState;
     } catch (error) {
       if (lifetime.signal.aborted) return signedOutDesktopAuthState();
+      this.rememberAuthority(signedOutDesktopAuthState(), lifetime);
       throw error;
     }
   }
@@ -478,6 +529,7 @@ export class DesktopAuthSession {
       this.restoreEnabled = false;
       this.token = null;
       this.appState = signedOutDesktopAuthState();
+      this.authority = null;
       this.onChange();
     }
     return retried;

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -1,6 +1,7 @@
 import type {
   ComputerUseAutomationPermissionTarget,
   DesktopComputerUseState,
+  ComputerUseDriverId,
 } from "./computer-use-types";
 import type { DesktopIdentity } from "./config";
 import type {
@@ -52,6 +53,12 @@ export interface DesktopAuthApi {
 }
 
 export interface DesktopComputerUseApi {
+  readonly setExperimentalCuaEnabled: (
+    enabled: boolean,
+  ) => Promise<DesktopComputerUseState>;
+  readonly selectDriver: (
+    driver: ComputerUseDriverId,
+  ) => Promise<DesktopComputerUseState>;
   readonly getState: () => Promise<DesktopComputerUseState>;
   readonly refreshPermissions: () => Promise<DesktopComputerUseState>;
   readonly start: (options?: {

--- a/turbo/apps/desktop/src/desktop-computer-use-api.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-api.ts
@@ -42,6 +42,7 @@ export function createDesktopComputerUseHostRuntime(
           ? options.driver.acquireCommand()
           : null;
       return {
+        identity: native?.identity,
         beginCommand: (budget) => native?.beginCommand?.(budget),
         release: () => native?.release(),
         abort: () => native?.abort?.(),

--- a/turbo/apps/desktop/src/desktop-computer-use-autostart.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-autostart.test.ts
@@ -1,3 +1,4 @@
+import { stoppedOkouDriverState } from "./test/desktop-driver-state";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DesktopComputerUseAutoStartSupervisor } from "./desktop-computer-use-autostart";
 import {
@@ -10,6 +11,7 @@ function computerUseState(
   status: ComputerUseHostRuntimeStatus,
 ): DesktopComputerUseState {
   return {
+    driver: stoppedOkouDriverState,
     platform: "darwin",
     supported: true,
     permissions: { accessibility: true, screenRecording: true },

--- a/turbo/apps/desktop/src/desktop-computer-use-driver-preferences.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-driver-preferences.ts
@@ -1,0 +1,83 @@
+import type {
+  ComputerUseDriverId,
+  ComputerUseDriverPreference,
+} from "./computer-use-types";
+import {
+  readDesktopPreferenceRecord,
+  writeDesktopPreferenceRecord,
+} from "./desktop-preferences";
+
+const DEFAULT: ComputerUseDriverPreference = {
+  experimentalCuaEnabled: false,
+  selectedDriver: "okou",
+};
+
+/** Installation preferences are requests, never execution or account authority. */
+export class DesktopComputerUseDriverPreferences {
+  private preference: ComputerUseDriverPreference = DEFAULT;
+  private error: string | null = null;
+
+  constructor(private readonly getPath: () => string) {}
+
+  getState() {
+    return { ...this.preference, preferenceError: this.error };
+  }
+
+  load(): void {
+    try {
+      const value = readDesktopPreferenceRecord(
+        this.getPath(),
+      ).computerUseDriver;
+      this.preference =
+        typeof value === "object" &&
+        value !== null &&
+        "experimentalCuaEnabled" in value &&
+        value.experimentalCuaEnabled === true &&
+        "selectedDriver" in value &&
+        (value.selectedDriver === "okou" || value.selectedDriver === "cua")
+          ? {
+              experimentalCuaEnabled: true,
+              selectedDriver: value.selectedDriver,
+            }
+          : DEFAULT;
+      this.error = null;
+    } catch {
+      this.preference = DEFAULT;
+      this.error =
+        "Driver preferences could not be read. Repair the preferences file before saving.";
+    }
+  }
+
+  setExperiment(enabled: boolean): void {
+    this.save({
+      experimentalCuaEnabled: enabled,
+      // Opting in only reveals the selector. Opting out requests Okou.
+      selectedDriver: enabled ? this.preference.selectedDriver : "okou",
+    });
+  }
+
+  select(selectedDriver: ComputerUseDriverId): void {
+    if (selectedDriver === "cua" && !this.preference.experimentalCuaEnabled)
+      throw new Error("Enable experimental CUA first");
+    this.save({ ...this.preference, selectedDriver });
+  }
+
+  private save(preference: ComputerUseDriverPreference): void {
+    try {
+      // No await between read and write: other main-process preference owners
+      // cannot interleave a stale whole-file write into this transaction.
+      const filePath = this.getPath();
+      const current = readDesktopPreferenceRecord(filePath);
+      writeDesktopPreferenceRecord(filePath, {
+        ...current,
+        computerUseDriver: preference,
+      });
+      this.preference = preference;
+      this.error = null;
+    } catch {
+      this.error =
+        "Driver preferences could not be saved. The previous selection is retained.";
+      throw new Error(this.error);
+    }
+  }
+}

--- a/turbo/apps/desktop/src/desktop-computer-use-driver-selection.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-driver-selection.ts
@@ -1,0 +1,98 @@
+import type { ComputerUseDriver } from "./computer-use-driver";
+import type { ComputerUseRuntimeController } from "./computer-use-runtime-controller";
+import type {
+  ComputerUseDriverId,
+  DesktopComputerUseDriverState,
+} from "./computer-use-types";
+import type { DeveloperToolsController } from "./desktop-developer-tools-controller";
+import type { DesktopComputerUseDriverPreferences } from "./desktop-computer-use-driver-preferences";
+import artifacts from "../cua/artifacts.json";
+
+/** Local policy/bridge adapter. All execution and replacement stay in the runtime owner. */
+export class DesktopComputerUseDriverSelection {
+  constructor(
+    private readonly options: {
+      readonly preferences: DesktopComputerUseDriverPreferences;
+      readonly developer: DeveloperToolsController;
+      readonly runtime: ComputerUseRuntimeController;
+      readonly drivers: Readonly<
+        Record<ComputerUseDriverId, ComputerUseDriver>
+      >;
+      readonly onChange: () => void;
+    },
+  ) {}
+
+  requestedDriver(): ComputerUseDriver {
+    return this.options.drivers[
+      this.options.preferences.getState().selectedDriver
+    ];
+  }
+
+  blockReason(driver: ComputerUseDriver): string | null {
+    const preference = this.options.preferences.getState();
+    if (preference.preferenceError) return preference.preferenceError;
+    if (driver.id !== "cua") return null;
+    if (
+      !preference.experimentalCuaEnabled ||
+      preference.selectedDriver !== "cua"
+    )
+      return "CUA requires an explicit experimental selection.";
+    if (!this.options.developer.getAuthorization())
+      return "CUA requires current Developer access. Sign in or use Okou.";
+    return null;
+  }
+
+  getState(): DesktopComputerUseDriverState {
+    const preference = this.options.preferences.getState();
+    const runtime = this.options.runtime.getDriverState();
+    return {
+      experimentalCuaEnabled: preference.experimentalCuaEnabled,
+      selectedDriver: preference.selectedDriver,
+      ...runtime,
+      error: preference.preferenceError ?? runtime.error,
+      developerAvailability: this.options.developer.getAvailability(),
+      expectedCuaVersion: artifacts.driverVersion,
+    };
+  }
+
+  async setExperiment(enabled: boolean): Promise<void> {
+    if (enabled) this.requireDeveloper();
+    await this.save(() => this.options.preferences.setExperiment(enabled));
+    // An opt-in is presentation only, including while a driver is running.
+    if (!enabled) await this.apply();
+  }
+
+  async select(driver: ComputerUseDriverId): Promise<void> {
+    if (driver === "cua") this.requireDeveloper();
+    await this.save(() => this.options.preferences.select(driver));
+    await this.apply();
+  }
+
+  private requireDeveloper(): void {
+    if (!this.options.developer.getAuthorization())
+      throw new Error("Current Developer access is required");
+  }
+
+  private async save(write: () => void): Promise<void> {
+    try {
+      write();
+    } catch (error) {
+      // A failed preference transaction cannot authorize further CUA work.
+      await this.options.runtime.refreshDriverAuthorization();
+      throw error;
+    } finally {
+      this.options.onChange();
+    }
+  }
+
+  private async apply(): Promise<void> {
+    try {
+      await this.options.runtime.transitionDriver(this.requestedDriver());
+    } catch {
+      // The runtime retains cleanup ownership and reports a bounded error.
+      // Do not expose a raw SDK/process error across IPC or replay the action.
+    } finally {
+      this.options.onChange();
+    }
+  }
+}

--- a/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
@@ -654,7 +654,10 @@ describe("production driver generation and admission wiring", () => {
     permission.resume.resolve();
     await Promise.all([start, stop]);
     expect(app.controller.getHostState().status).toBe("offline");
-    expect(app.requests).toEqual([]);
+    expect(app.requests.map((request) => request.path)).toEqual([
+      "/api/auth/me",
+      "/api/org",
+    ]);
     expect(app.native.active).toBe(0);
     await app.controller.start();
     expect(app.native.created).toBe(1);
@@ -671,7 +674,11 @@ describe("production driver generation and admission wiring", () => {
     expect(app.driver.generation).toBe(2);
     expect(app.native.active).toBe(1);
     expect(app.controller.getHostState().status).toBe("online");
-    expect(app.timers.count(0)).toBe(1);
+    // Only the latest startup registers; it starts with the normal poll delay.
+    expect(app.timers.count(5_000)).toBe(1);
+    expect(
+      app.requests.filter((request) => request.path.endsWith("/hosts/start")),
+    ).toHaveLength(1);
   });
 
   it.each(["stop", "auth", "quit", "update"] as const)(
@@ -763,12 +770,11 @@ describe("production driver generation and admission wiring", () => {
     const first = app.controller.transitionDriver(app.driverDefinition);
     const second = app.controller.transitionDriver(other);
     await Promise.all([first, second]);
-    expect(app.driver.generation).toBe(3);
+    expect(app.driver.generation).toBe(2);
     expect(app.native.active).toBe(1);
     expect(app.timers.count(0)).toBe(1);
     expect(app.events.filter((event) => event.startsWith("dispose:"))).toEqual([
       "dispose:1",
-      "dispose:2",
     ]);
     expect(app.online).toEqual([true]);
   });

--- a/turbo/apps/desktop/src/desktop-computer-use-permissions.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-permissions.ts
@@ -1,0 +1,48 @@
+import type { ComputerUseDriverController } from "./computer-use-driver";
+import {
+  createComputerUsePermissions,
+  type ComputerUsePermissionProvider,
+} from "./computer-use-permissions";
+import type { ComputerUseDriverId } from "./computer-use-types";
+
+export function createDesktopComputerUsePermissions(options: {
+  readonly driver: ComputerUseDriverController;
+  readonly requestedDriver: () => ComputerUseDriverId;
+  readonly transitioning: () => boolean;
+  readonly host: ComputerUsePermissionProvider;
+}) {
+  const permissions = createComputerUsePermissions((read) => {
+    if (
+      options.requestedDriver() === "cua" ||
+      options.driver.selectedDriver.id === "cua" ||
+      options.transitioning()
+    )
+      return read(options.host);
+    return options.driver.withPermissionProvider(read);
+  });
+  return {
+    ...permissions,
+    /** Called only inside the authorized runtime start/replacement intent. */
+    prepareNative: async () => {
+      const result = await options.driver.withPermissionProvider((provider) =>
+        provider.getPermissions(),
+      );
+      if (!result) throw new Error("Native driver readiness was superseded");
+      return result;
+    },
+    refreshReady: async () => {
+      if (options.driver.getCapabilities().length > 0) {
+        try {
+          const fresh = await options.driver.withPermissionProvider(
+            (provider) => provider.getPermissions(),
+          );
+          if (fresh) return fresh;
+        } catch {
+          // Driver ownership already withdrew admission and retained cleanup.
+          return { accessibility: false, screenRecording: false };
+        }
+      }
+      return permissions.getComputerUsePermissionState();
+    },
+  };
+}

--- a/turbo/apps/desktop/src/desktop-computer-use-selection.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-selection.test.ts
@@ -1,0 +1,828 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  ComputerUseDriverController,
+  type ComputerUseDriver,
+} from "./computer-use-driver";
+import { createComputerUseNativeBackend } from "./computer-use-native";
+import { createCuaComputerUseDriver } from "./computer-use-cua";
+import { createDesktopComputerUsePermissions } from "./desktop-computer-use-permissions";
+import { DesktopComputerUseDriverPreferences } from "./desktop-computer-use-driver-preferences";
+import { DesktopComputerUseDriverSelection } from "./desktop-computer-use-driver-selection";
+import { ComputerUseRuntimeController } from "./computer-use-runtime-controller";
+import { DeveloperToolsController } from "./desktop-developer-tools-controller";
+import { DesktopAuthSession } from "./desktop-auth-session";
+import { createDesktopComputerUseHostRuntime } from "./desktop-computer-use-api";
+import { DesktopKeepAwakeController } from "./desktop-keep-awake";
+import { DesktopFilesystemPluginManager } from "./desktop-filesystem-plugin";
+import { readOrCreateComputerUseInstallationId } from "./desktop-computer-use-installation";
+import { createDesktopClientHeaderInjector } from "./desktop-client-headers";
+import { shouldDeferDesktopUpdate } from "./desktop-auto-update-policy";
+import type { ComputerUseCommand } from "./computer-use-accessibility";
+import { cuaBoundary, deferred } from "./test/cua-boundary";
+
+const api = "https://api.vm0.ai";
+const server = setupServer();
+const cleanups: (() => Promise<void>)[] = [];
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+function desktop(initial?: string) {
+  const directory = mkdtempSync(
+    path.join(tmpdir(), "desktop-driver-selection-"),
+  );
+  const file = path.join(directory, "preferences.json");
+  const helper = path.join(directory, "helper.cjs");
+  const nativeEvents = path.join(directory, "native-events");
+  writeFileSync(nativeEvents, "");
+  if (initial !== undefined) writeFileSync(file, initial);
+  // The actuator is an external process; the real native protocol client,
+  // generation owner, executor, auth, host and shared preference writers run.
+  writeFileSync(
+    helper,
+    `#!${process.execPath}
+const fs = require('node:fs');
+fs.appendFileSync(${JSON.stringify(nativeEvents)}, 'start\\n');
+require('node:readline').createInterface({input:process.stdin}).on('line', line => {
+  const r=JSON.parse(line);
+  const result=r.kind.startsWith('permissions.') ? {accessibility:true,screenRecording:true} : {apps:[{name:'Okou fixture',bundleId:'test.editor'}]};
+  process.stdout.write(JSON.stringify({id:r.id,status:'succeeded',result})+'\\n');
+});
+`,
+  );
+  chmodSync(helper, 0o755);
+  let identity = "first";
+  let debug = true;
+  let hostGranted = true;
+  let failLoad = false;
+  let featureRead: (() => Promise<void>) | null = null;
+  let configureCua: (
+    boundary: ReturnType<typeof cuaBoundary>,
+  ) => void = () => {};
+  const boundaries: ReturnType<typeof cuaBoundary>[] = [];
+  const requests: { path: string; body: unknown }[] = [];
+  const pending = new Set<Promise<void>>();
+  const own = (work: Promise<void>) => {
+    pending.add(work);
+    void work.then(
+      () => pending.delete(work),
+      () => pending.delete(work),
+    );
+  };
+  const timers = new Map<
+    ReturnType<typeof setTimeout>,
+    { run: () => void; delay: number }
+  >();
+  const schedule = (run: () => void, delay: number) => {
+    const timer = setTimeout(() => {}, 2 ** 30);
+    timer.unref();
+    timers.set(timer, { run, delay });
+    return timer;
+  };
+  const clear: typeof clearTimeout = (timer) => {
+    if (typeof timer === "object") timers.delete(timer);
+    clearTimeout(timer);
+  };
+  const tick = (delay: number) => {
+    const found = [...timers].find(([, item]) => item.delay === delay);
+    if (!found) throw new Error(`No lifecycle timer for ${delay}`);
+    clear(found[0]);
+    found[1].run();
+  };
+  const headers = createDesktopClientHeaderInjector({
+    product: "okou",
+    clientVersion: "1.2.3",
+  });
+  const cookies = { cookies: { get: async () => [] } };
+  let authChanged = () => {};
+  const auth = new DesktopAuthSession({
+    product: "okou",
+    apiBaseUrl: api,
+    cookieUrls: [],
+    cookieSource: cookies,
+    addClientHeaders: headers,
+    tokenUrl: `${api}/token`,
+    selectOrgUrl: `${api}/select-org`,
+    consumeUrl: () => `${api}/consume`,
+    runAuthWindow: async () => identity,
+    onChange: () => authChanged(),
+  });
+  let developerChanged = () => {};
+  const developer = new DeveloperToolsController({
+    getSessionAuthority: () => auth.getAuthority(),
+    fetchFeatureSwitches: () =>
+      auth.fetchWithSessionAuth(new URL(`${api}/api/feature-switches`)),
+    setFilesystemPluginFeatureEnabled: () => {},
+    setScreenRecordingFeatureEnabled: () => {},
+    onChange: () => developerChanged(),
+  });
+  const preference = new DesktopComputerUseDriverPreferences(() => file);
+  preference.load();
+  const okou: ComputerUseDriver = {
+    id: "okou",
+    buildVersion: "1.2.3",
+    createBackend: () => createComputerUseNativeBackend({ helperPath: helper }),
+  };
+  const cua: ComputerUseDriver = {
+    ...createCuaComputerUseDriver({
+      runtimeRoot: "/packaged/cua",
+      hostBundleId: "ai.okou.desktop",
+      loadSdk: async () => {
+        if (failLoad)
+          throw new Error("/private/session-secret/socket token=secret");
+        const external = cuaBoundary();
+        configureCua(external);
+        boundaries.push(external);
+        return external.sdk;
+      },
+    }),
+    getAuthorization: () => developer.getAuthorization(),
+  };
+  const driver = new ComputerUseDriverController(okou, "darwin");
+  const permissions = createDesktopComputerUsePermissions({
+    driver,
+    requestedDriver: () => preference.getState().selectedDriver,
+    transitioning: () => controller.isTransitioning(),
+    host: {
+      getPermissions: async () => ({
+        accessibility: hostGranted,
+        screenRecording: hostGranted,
+      }),
+      requestAccessibilityPermission: async () => ({
+        accessibility: hostGranted,
+        screenRecording: hostGranted,
+      }),
+      requestScreenRecordingPermission: async () => ({
+        accessibility: hostGranted,
+        screenRecording: hostGranted,
+      }),
+      probeAutomationPermission: async () => ({
+        status: "unknown",
+        reason: null,
+        updatedAt: null,
+      }),
+    },
+  });
+  const plugin = new DesktopFilesystemPluginManager({
+    preferencesPath: file,
+    onChange: () => {},
+  });
+  let command: ComputerUseCommand | null = null;
+  const completed = deferred<unknown>();
+  let completionGate: Promise<void> = Promise.resolve();
+  let hostStarts = 0;
+  const controller = new ComputerUseRuntimeController({
+    driver,
+    refreshPermissions: permissions.refreshComputerUsePermissionState,
+    prepareNative: permissions.prepareNative,
+    nativeBlockReason: (driver) => selection.blockReason(driver),
+    getAuthState: () => auth.getAuthState(),
+    setHostRuntimeOnline: (online) => plugin.setHostRuntimeOnline(online),
+    getPluginCapabilities: () => plugin.getCapabilities(),
+    preparePlugins: () => plugin.prepareForHost(),
+    transitionTimeoutMs: 1234,
+    lifecycleTimers: { setTimeout: schedule, clearTimeout: clear },
+    createRuntime: () =>
+      createDesktopComputerUseHostRuntime(
+        {
+          platformUrl: new URL("https://app.okou.ai"),
+          installationId: readOrCreateComputerUseInstallationId(file),
+          hostName: "fixture",
+          appVersion: "1.2.3",
+          addClientHeaders: headers,
+          hostFetch: (input, init) => fetch(input, init),
+          getPermissions: permissions.refreshReady,
+          getSupportedCapabilities: () => [
+            ...driver.getCapabilities(),
+            ...plugin.getCapabilities(),
+          ],
+          driver,
+          executePluginCommand: (command) => plugin.execute(command),
+          setTimeout: schedule,
+          clearTimeout: clear,
+        },
+        { product: "okou", session: cookies, getAuthSession: () => auth },
+      ),
+  });
+  const selection = new DesktopComputerUseDriverSelection({
+    preferences: preference,
+    developer,
+    runtime: controller,
+    drivers: { okou, cua },
+    onChange: () => {},
+  });
+  let lastAuth: object | null = null;
+  let lastDeveloper: object | null = null;
+  authChanged = () => {
+    const current = auth.getAuthority();
+    if (lastAuth !== current) {
+      lastAuth = current;
+      permissions.resetComputerUsePermissionState();
+      if (
+        selection.requestedDriver().id === "cua" ||
+        driver.selectedDriver.id === "cua"
+      )
+        own(controller.stopForAuthChange());
+    }
+    developer.requestRefresh();
+  };
+  developerChanged = () => {
+    const current = developer.getAuthorization();
+    if (lastDeveloper !== current) {
+      lastDeveloper = current;
+      own(controller.refreshDriverAuthorization());
+    }
+  };
+  server.use(
+    http.all(`${api}/*`, async ({ request }) => {
+      const url = new URL(request.url);
+      const body: unknown =
+        request.method === "POST" ? await request.json() : null;
+      requests.push({ path: url.pathname, body });
+      const user =
+        request.headers.get("authorization")?.replace("Bearer ", "") ??
+        "unknown";
+      if (url.pathname === "/api/auth/me")
+        return HttpResponse.json({
+          userId: user,
+          email: "fixture@example.test",
+          orgId: `org-${user}`,
+        });
+      if (url.pathname === "/api/org")
+        return HttpResponse.json({ id: `org-${user}`, name: "Workspace" });
+      if (url.pathname === "/api/feature-switches") {
+        const enabled = debug;
+        await featureRead?.();
+        return HttpResponse.json({ effectiveSwitches: { _debug: enabled } });
+      }
+      if (url.pathname.endsWith("/hosts/start"))
+        return HttpResponse.json({
+          hostId: `host-${++hostStarts}`,
+          hostToken: "host-token",
+        });
+      if (url.pathname.endsWith("/commands/next")) {
+        const next = command;
+        command = null;
+        return HttpResponse.json(
+          next
+            ? {
+                status: "command",
+                command: {
+                  ...next,
+                  timeoutMs: 60_000,
+                  createdAt: new Date().toISOString(),
+                  claimedAt: null,
+                },
+              }
+            : { status: "idle" },
+        );
+      }
+      if (url.pathname.endsWith("/complete")) {
+        completed.resolve(body);
+        await completionGate;
+      }
+      return HttpResponse.json({});
+    }),
+  );
+  cleanups.push(async () => {
+    await controller.stopForQuit();
+    await Promise.allSettled([...pending]);
+    plugin.stop();
+    for (const timer of timers.keys()) clear(timer);
+    rmSync(directory, { recursive: true, force: true });
+  });
+  return {
+    auth,
+    developer,
+    preference,
+    selection,
+    controller,
+    driver,
+    permissions,
+    boundaries,
+    requests,
+    file,
+    plugin,
+    directory,
+    tick,
+    completed,
+    nativeStarts: () =>
+      readFileSync(nativeEvents, "utf8").split("start\n").length - 1,
+    restore: () => controller.transitionDriver(selection.requestedDriver()),
+    async authorize() {
+      await auth.getAuthState();
+      developer.requestRefresh();
+      await vi.waitFor(() =>
+        expect(developer.getAvailability()).toBe("available"),
+      );
+    },
+    set identity(value: string) {
+      identity = value;
+    },
+    set debug(value: boolean) {
+      debug = value;
+    },
+    set featureRead(value: (() => Promise<void>) | null) {
+      featureRead = value;
+    },
+    set hostGranted(value: boolean) {
+      hostGranted = value;
+    },
+    set failLoad(value: boolean) {
+      failLoad = value;
+    },
+    set configureCua(value: typeof configureCua) {
+      configureCua = value;
+    },
+    set command(value: ComputerUseCommand) {
+      command = value;
+    },
+    set completionGate(value: Promise<void>) {
+      completionGate = value;
+    },
+  };
+}
+
+it.each([
+  undefined,
+  "{}",
+  '{"computerUseDriver":{"experimentalCuaEnabled":"true","selectedDriver":"cua"}}',
+  '{"computerUseDriver":{"experimentalCuaEnabled":true,"selectedDriver":"other"}}',
+])(
+  "starts the default lane for missing or invalid preferences: %s",
+  async (stored) => {
+    const app = desktop(stored);
+    await app.authorize();
+    await app.restore();
+    await app.controller.start();
+    expect(app.selection.getState()).toMatchObject({
+      selectedDriver: "okou",
+      experimentalCuaEnabled: false,
+      actual: { id: "okou", version: "1.2.3" },
+      phase: "ready",
+    });
+    expect(app.boundaries).toHaveLength(0);
+    const actual = app.selection.getState().actual;
+    await app.selection.setExperiment(true);
+    app.developer.setEnabled(true);
+    app.developer.setEnabled(false);
+    expect(app.selection.getState()).toMatchObject({
+      selectedDriver: "okou",
+      experimentalCuaEnabled: true,
+      actual,
+    });
+    expect(app.boundaries).toHaveLength(0);
+  },
+);
+
+it("restores CUA as a request without passive activation, and keeps manual Stop across selections and availability refresh", async () => {
+  const app = desktop(
+    '{"computerUseDriver":{"experimentalCuaEnabled":true,"selectedDriver":"cua"}}',
+  );
+  app.auth.signOut();
+  await app.restore();
+  await app.permissions.refreshComputerUsePermissionState();
+  await app.permissions.requestComputerUseAccessibilityPermission();
+  expect(app.boundaries).toHaveLength(0);
+  expect(app.nativeStarts()).toBe(0);
+  expect(app.selection.getState()).toMatchObject({
+    actual: null,
+    selectedDriver: "cua",
+    phase: "blocked",
+  });
+  await app.auth.consumeCode("explicit");
+  await app.authorize();
+  await app.controller.start({ userInitiated: true });
+  expect(app.selection.getState()).toMatchObject({
+    actual: { id: "cua", version: "0.23.2" },
+    phase: "ready",
+  });
+  await app.controller.stop();
+  const generations = app.boundaries.length;
+  await app.selection.select("okou");
+  await app.selection.select("cua");
+  await app.permissions.refreshComputerUsePermissionState();
+  app.developer.requestRefresh();
+  await vi.waitFor(() =>
+    expect(app.developer.getAvailability()).toBe("available"),
+  );
+  await app.controller.start();
+  expect(app.boundaries).toHaveLength(generations);
+  expect(app.nativeStarts()).toBe(0);
+  expect(app.controller.getHostState().status).toBe("offline");
+});
+
+it("preserves shared installation, keep-awake and plugin writes, and never overwrites corrupt settings", async () => {
+  const app = desktop();
+  await app.authorize();
+  const installation = readOrCreateComputerUseInstallationId(app.file);
+  await app.selection.setExperiment(true);
+  const awake = new DesktopKeepAwakeController({
+    preferencesPath: app.file,
+    blocker: { start: () => 1, stop: () => {}, isStarted: () => true },
+    onChange: () => {},
+  });
+  awake.load();
+  awake.setEnabled(true);
+  app.plugin.load();
+  app.plugin.addAllowedDirectory(app.directory);
+  await app.selection.select("cua");
+  const restored = new DesktopComputerUseDriverPreferences(() => app.file);
+  restored.load();
+  expect(restored.getState()).toMatchObject({
+    experimentalCuaEnabled: true,
+    selectedDriver: "cua",
+  });
+  expect(readOrCreateComputerUseInstallationId(app.file)).toBe(installation);
+  expect(JSON.parse(readFileSync(app.file, "utf8"))).toMatchObject({
+    keepAwakeEnabled: true,
+    computerUseInstallationId: installation,
+  });
+  writeFileSync(app.file, '["corrupt"]');
+  await expect(app.selection.select("okou")).rejects.toThrow(
+    "could not be saved",
+  );
+  expect(readFileSync(app.file, "utf8")).toBe('["corrupt"]');
+  restored.load();
+  expect(restored.getState()).toMatchObject({
+    selectedDriver: "okou",
+    experimentalCuaEnabled: false,
+  });
+  expect(restored.getState().preferenceError).not.toBeNull();
+});
+
+it("uses the latest alternating selection without overlapping executors or restarting the host", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.controller.start();
+  await app.selection.setExperiment(true);
+  const host = app.controller.getHostState().hostId;
+  await Promise.all([
+    app.selection.select("cua"),
+    app.selection.select("okou"),
+    app.selection.select("cua"),
+  ]);
+  expect(app.selection.getState()).toMatchObject({
+    selectedDriver: "cua",
+    actual: { id: "cua", version: "0.23.2" },
+    phase: "ready",
+  });
+  expect(app.boundaries).toHaveLength(1);
+  expect(app.boundaries[0]?.live).toBe(true);
+  expect(app.controller.getHostState().hostId).toBe(host);
+  expect(
+    app.requests.filter((r) => r.path.endsWith("/hosts/start")),
+  ).toHaveLength(1);
+});
+
+it("keeps disable honest until the original CUA command and completion drain, with pinned private diagnostics", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.selection.setExperiment(true);
+  await app.selection.select("cua");
+  await app.controller.start({ userInitiated: true });
+  const original = app.selection.getState().actual;
+  const gate = deferred<void>();
+  app.completionGate = gate.promise;
+  app.command = { id: "command", kind: "apps.list", payload: {} };
+  app.tick(5000);
+  await app.completed.promise;
+  const disable = app.selection.setExperiment(false);
+  await vi.waitFor(() =>
+    expect(app.selection.getState().phase).toBe("switching"),
+  );
+  expect(app.selection.getState()).toMatchObject({
+    selectedDriver: "okou",
+    experimentalCuaEnabled: false,
+    actual: original,
+  });
+  expect(app.nativeStarts()).toBe(0);
+  const diagnostic = app.controller.getHostState().localCommandLog[0]?.driver;
+  expect(diagnostic).toEqual(original);
+  expect(Object.keys(diagnostic ?? {}).sort()).toEqual([
+    "generation",
+    "id",
+    "version",
+  ]);
+  gate.resolve();
+  await disable;
+  expect(app.selection.getState()).toMatchObject({
+    phase: "ready",
+    actual: { id: "okou" },
+  });
+  expect(app.boundaries[0]?.live).toBe(false);
+  expect(app.controller.getHostState().localCommandLog[0]?.driver).toEqual(
+    original,
+  );
+});
+
+it("blocks stale Developer authority on a new account and retains the stored CUA request", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.selection.setExperiment(true);
+  await app.selection.select("cua");
+  const entered = deferred<void>();
+  const response = deferred<void>();
+  app.featureRead = async () => {
+    entered.resolve();
+    await response.promise;
+  };
+  app.developer.requestRefresh();
+  await entered.promise;
+  app.identity = "second";
+  app.debug = false;
+  await app.auth.selectOrganization();
+  expect(app.developer.getAuthorization()).toBeNull();
+  await expect(app.selection.select("cua")).rejects.toThrow("Developer access");
+  app.featureRead = null;
+  response.resolve();
+  await vi.waitFor(() =>
+    expect(app.developer.getAvailability()).toBe("unavailable"),
+  );
+  await app.controller.start({ userInitiated: true });
+  expect(app.selection.getState()).toMatchObject({
+    selectedDriver: "cua",
+    experimentalCuaEnabled: true,
+    actual: null,
+    phase: "blocked",
+  });
+  expect(app.boundaries).toHaveLength(0);
+  expect(app.nativeStarts()).toBe(0);
+  await app.selection.select("okou");
+  expect(app.controller.getHostState().status).toBe("offline");
+});
+
+it("keeps startup failure visible and sanitized without a passive retry or implicit Okou fallback", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.selection.setExperiment(true);
+  await app.selection.select("cua");
+  app.failLoad = true;
+  await app.controller.start({ userInitiated: true });
+  await app.permissions.refreshComputerUsePermissionState();
+  await app.controller.start();
+  expect(app.selection.getState()).toMatchObject({
+    selectedDriver: "cua",
+    phase: "error",
+    actual: null,
+    expectedCuaVersion: "0.23.2",
+  });
+  expect(JSON.stringify(app.selection.getState())).not.toMatch(
+    /private|session-secret|socket|token=secret/,
+  );
+  expect(app.nativeStarts()).toBe(0);
+  app.failLoad = false;
+  await app.controller.start({ userInitiated: true });
+  expect(app.selection.getState()).toMatchObject({
+    phase: "ready",
+    actual: { id: "cua", version: "0.23.2" },
+  });
+});
+
+it("defers update and refuses recovery after a UI timeout until native cleanup is proven", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.selection.setExperiment(true);
+  await app.selection.select("cua");
+  await app.controller.start({ userInitiated: true });
+  const external = app.boundaries[0]!;
+  const exit = deferred<void>();
+  external.intercept = async (name) => {
+    if (name === "stop") await exit.promise;
+  };
+  const selection = app.selection.select("okou");
+  await external.stopEntered.promise;
+  expect(app.selection.getState()).toMatchObject({
+    cleanupPending: true,
+    actual: { id: "cua", version: null },
+  });
+  app.tick(1234);
+  await selection;
+  expect(shouldDeferDesktopUpdate(app.controller.getHostState())).toBe(true);
+  expect(app.selection.getState()).toMatchObject({
+    phase: "error",
+    cleanupPending: true,
+    canRetry: false,
+  });
+  const retry = app.controller.start({ userInitiated: true });
+  const rejected = expect(retry).rejects.toThrow("timed out");
+  app.tick(1234);
+  await rejected;
+  expect(app.nativeStarts()).toBe(0);
+  exit.resolve();
+  await app.controller.stop();
+  await app.selection.select("okou");
+  await app.controller.start({ userInitiated: true });
+  expect(app.selection.getState()).toMatchObject({
+    phase: "ready",
+    actual: { id: "okou" },
+  });
+});
+
+it("honors the latest same-driver request after the first CUA startup has already begun", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.controller.start();
+  await app.selection.setExperiment(true);
+  const entered = deferred<void>();
+  const release = deferred<void>();
+  app.configureCua = (boundary) => {
+    boundary.intercept = async (name) => {
+      if (name === "check_permissions") {
+        entered.resolve();
+        await release.promise;
+      }
+    };
+  };
+  const first = app.selection.select("cua");
+  await entered.promise;
+  app.configureCua = () => {};
+  const second = app.selection.select("okou");
+  const last = app.selection.select("cua");
+  release.resolve();
+  await Promise.all([first, second, last]);
+  expect(app.selection.getState()).toMatchObject({
+    selectedDriver: "cua",
+    actual: { id: "cua" },
+    phase: "ready",
+  });
+  expect(app.boundaries.filter((boundary) => boundary.live)).toHaveLength(1);
+  expect(
+    app.requests.filter((r) => r.path.endsWith("/hosts/start")),
+  ).toHaveLength(1);
+});
+
+it.each(["stop", "auth", "update", "selection"] as const)(
+  "does not publish delayed CUA startup after %s supersedes it",
+  async (action) => {
+    const app = desktop();
+    await app.authorize();
+    await app.selection.setExperiment(true);
+    await app.selection.select("cua");
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    app.configureCua = (boundary) => {
+      boundary.intercept = async (name) => {
+        if (name === "check_permissions") {
+          entered.resolve();
+          await release.promise;
+        }
+      };
+    };
+    const start = app.controller.start({ userInitiated: true });
+    await entered.promise;
+    expect(shouldDeferDesktopUpdate(app.controller.getHostState())).toBe(true);
+    const superseding =
+      action === "stop"
+        ? app.controller.stop()
+        : action === "auth"
+          ? (app.auth.signOut(), app.controller.stopForAuthChange())
+          : action === "update"
+            ? app.controller.stopForQuit("update_relaunch")
+            : app.selection.select("okou");
+    release.resolve();
+    await Promise.allSettled([start, superseding]);
+    if (action === "selection")
+      expect(app.selection.getState()).toMatchObject({
+        phase: "ready",
+        actual: { id: "okou" },
+      });
+    else {
+      expect(app.selection.getState().phase).not.toBe("ready");
+      expect(app.selection.getState().actual).toBeNull();
+    }
+    expect(app.boundaries.every((boundary) => !boundary.live)).toBe(true);
+    expect(
+      app.requests.filter((r) => r.path.endsWith("/hosts/start")),
+    ).toHaveLength(action === "selection" ? 1 : 0);
+    expect(app.nativeStarts()).toBe(action === "selection" ? 1 : 0);
+  },
+);
+
+it("keeps the real filesystem process and host serving after CUA permission revocation and an explicit selection", async () => {
+  const app = desktop();
+  await app.authorize();
+  app.plugin.setFeatureEnabled(true);
+  app.plugin.addAllowedDirectory(app.directory);
+  app.plugin.setEnabled(true);
+  await app.selection.setExperiment(true);
+  await app.selection.select("cua");
+  await app.controller.start({ userInitiated: true });
+  await vi.waitFor(
+    () => expect(app.plugin.getCapabilities().length).toBeGreaterThan(0),
+    { timeout: 10_000 },
+  );
+  const host = app.controller.getHostState().hostId;
+  const external = app.boundaries[0]!;
+  external.granted = false;
+  await app.permissions.refreshReady();
+  await vi.waitFor(() =>
+    expect(app.selection.getState().cleanupPending).toBe(false),
+  );
+  expect(app.driver.getCapabilities()).toHaveLength(0);
+  expect(app.selection.getState().phase).toBe("error");
+  await app.selection.select("okou");
+  expect(app.nativeStarts()).toBe(0);
+  app.command = {
+    id: "plugin-command",
+    kind: "plugin.call",
+    payload: {
+      plugin: "filesystem",
+      tool: "list_allowed_directories",
+      arguments: {},
+    },
+  };
+  app.tick(0);
+  expect(await app.completed.promise).toMatchObject({ status: "succeeded" });
+  expect(app.controller.getHostState().hostId).toBe(host);
+  expect(
+    app.requests.filter((r) => r.path.endsWith("/hosts/start")),
+  ).toHaveLength(1);
+  expect(
+    app.controller.getHostState().localCommandLog[0]?.driver,
+  ).toBeUndefined();
+});
+
+it("reports spontaneous embedded cleanup as update-busy and retries only after proof", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.selection.setExperiment(true);
+  await app.selection.select("cua");
+  await app.controller.start({ userInitiated: true });
+  const external = app.boundaries[0]!;
+  const cleanup = deferred<void>();
+  external.intercept = async (name) => {
+    if (name === "stop") await cleanup.promise;
+  };
+  external.crash();
+  await external.stopEntered.promise;
+  expect(app.selection.getState()).toMatchObject({
+    phase: "error",
+    cleanupPending: true,
+    canRetry: false,
+    actual: { id: "cua", version: null },
+  });
+  expect(shouldDeferDesktopUpdate(app.controller.getHostState())).toBe(true);
+  await app.controller.start();
+  expect(app.boundaries).toHaveLength(1);
+  cleanup.resolve();
+  await vi.waitFor(() =>
+    expect(app.selection.getState().cleanupPending).toBe(false),
+  );
+  await app.controller.start({ userInitiated: true });
+  expect(app.selection.getState()).toMatchObject({
+    phase: "ready",
+    actual: { id: "cua", version: "0.23.2" },
+  });
+  expect(app.boundaries).toHaveLength(2);
+});
+
+it("withdraws live CUA immediately on unresolved access, resumes only an existing running intent, and blocks denial", async () => {
+  const app = desktop();
+  await app.authorize();
+  await app.selection.setExperiment(true);
+  await app.selection.select("cua");
+  await app.controller.start({ userInitiated: true });
+  const response = deferred<void>();
+  app.featureRead = () => response.promise;
+  app.developer.requestRefresh();
+  expect(app.driver.getCapabilities()).toHaveLength(0);
+  expect(app.selection.getState()).toMatchObject({
+    selectedDriver: "cua",
+    developerAvailability: "unresolved",
+  });
+  app.featureRead = null;
+  response.resolve();
+  await vi.waitFor(() =>
+    expect(app.selection.getState()).toMatchObject({
+      phase: "ready",
+      actual: { id: "cua" },
+    }),
+  );
+  app.debug = false;
+  app.developer.requestRefresh();
+  expect(app.driver.getCapabilities()).toHaveLength(0);
+  await vi.waitFor(() =>
+    expect(app.selection.getState()).toMatchObject({
+      phase: "blocked",
+      actual: null,
+      selectedDriver: "cua",
+      experimentalCuaEnabled: true,
+    }),
+  );
+  expect(app.nativeStarts()).toBe(0);
+});

--- a/turbo/apps/desktop/src/desktop-developer-tools-controller.test.ts
+++ b/turbo/apps/desktop/src/desktop-developer-tools-controller.test.ts
@@ -17,7 +17,9 @@ function createController(
   const setScreenRecordingFeatureEnabled = vi.fn();
   const logRefreshError = vi.fn();
   const fetchSwitches = vi.fn(fetchFeatureSwitches);
+  const sessionAuthority = {};
   const controller = new DeveloperToolsController({
+    getSessionAuthority: () => sessionAuthority,
     fetchFeatureSwitches: fetchSwitches,
     setFilesystemPluginFeatureEnabled,
     setScreenRecordingFeatureEnabled,
@@ -62,7 +64,7 @@ describe("DeveloperToolsController", () => {
       expect(controller.getState().available).toBe(true);
     });
 
-    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalled();
     expect(setFilesystemPluginFeatureEnabled).toHaveBeenCalledWith(true);
   });
 

--- a/turbo/apps/desktop/src/desktop-developer-tools-controller.ts
+++ b/turbo/apps/desktop/src/desktop-developer-tools-controller.ts
@@ -24,6 +24,7 @@ function featureSwitchEnabledFromBody(value: unknown, key: string): boolean {
 }
 
 interface DeveloperToolsControllerOptions {
+  readonly getSessionAuthority: () => object | null;
   /**
    * Session-authenticated fetch of the zero feature-switches endpoint
    * (`getAuthSession().fetchWithSessionAuth(...)` in production).
@@ -59,19 +60,19 @@ export class DeveloperToolsController {
 
   private available = false;
   private enabled = false;
+  private resolved = false;
+  private revision = 0;
+  private authorization: { readonly session: object } | null = null;
   private readonly refresh = latestWinsSingleFlight(
     () => this.refreshAvailability(),
     {
       onError: (error) => {
         this.logRefreshError(error);
-        this.setAvailability(false);
-        this.setFilesystemPluginFeatureEnabled(false);
-        this.setScreenRecordingFeatureEnabled(false);
       },
     },
   );
 
-  constructor(options: DeveloperToolsControllerOptions) {
+  constructor(private readonly options: DeveloperToolsControllerOptions) {
     this.fetchFeatureSwitches = options.fetchFeatureSwitches;
     this.setFilesystemPluginFeatureEnabled =
       options.setFilesystemPluginFeatureEnabled;
@@ -86,6 +87,18 @@ export class DeveloperToolsController {
       available: this.available,
       enabled: this.available && this.enabled,
     };
+  }
+
+  getAvailability(): "unresolved" | "available" | "unavailable" {
+    if (!this.resolved) return "unresolved";
+    return this.getAuthorization() ? "available" : "unavailable";
+  }
+
+  getAuthorization(): object | null {
+    return this.available &&
+      this.authorization?.session === this.options.getSessionAuthority()
+      ? this.authorization
+      : null;
   }
 
   setEnabled(enabled: boolean): DesktopDeveloperToolsState {
@@ -103,6 +116,14 @@ export class DeveloperToolsController {
    * follow-up refresh once it settles.
    */
   requestRefresh(): void {
+    this.revision++;
+    this.resolved = false;
+    this.authorization = null;
+    // Withdrawal is synchronous; no old response can authorize a new session.
+    this.available = false;
+    // Keep the independent panel preference across a same-session refresh;
+    // an actual denial below clears it.
+    this.onChange();
     this.refresh();
   }
 
@@ -117,30 +138,54 @@ export class DeveloperToolsController {
   }
 
   private async refreshAvailability(): Promise<void> {
-    const response = await this.fetchFeatureSwitches();
-    if (response.status === 401) {
+    const revision = this.revision;
+    const session = this.options.getSessionAuthority();
+    const current = () =>
+      revision === this.revision &&
+      session === this.options.getSessionAuthority();
+    try {
+      const response = await this.fetchFeatureSwitches();
+      if (!current()) return;
+      if (response.status === 401) {
+        this.resolved = true;
+        this.setAvailability(false);
+        this.setFilesystemPluginFeatureEnabled(false);
+        this.setScreenRecordingFeatureEnabled(false);
+        this.onChange();
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(
+          `Desktop developer tools feature switch failed: ${response.status}`,
+        );
+      }
+      const body: unknown = await response.json();
+      if (!current()) return;
+      this.resolved = true;
+      this.authorization = session ? { session } : null;
+      this.setAvailability(
+        session !== null &&
+          featureSwitchEnabledFromBody(body, OKOU_DEBUG_FEATURE_SWITCH_KEY),
+      );
+      this.setFilesystemPluginFeatureEnabled(
+        featureSwitchEnabledFromBody(
+          body,
+          COMPUTER_USE_DESKTOP_PLUGINS_FEATURE_SWITCH_KEY,
+        ),
+      );
+      this.setScreenRecordingFeatureEnabled(
+        featureSwitchEnabledFromBody(body, INTRO_VIDEO_FEATURE_SWITCH_KEY),
+      );
+      this.onChange();
+    } catch (error) {
+      if (!current()) return;
+      this.resolved = true;
+      this.authorization = null;
       this.setAvailability(false);
       this.setFilesystemPluginFeatureEnabled(false);
       this.setScreenRecordingFeatureEnabled(false);
-      return;
+      this.onChange();
+      throw error;
     }
-    if (!response.ok) {
-      throw new Error(
-        `Desktop developer tools feature switch failed: ${response.status}`,
-      );
-    }
-    const body: unknown = await response.json();
-    this.setAvailability(
-      featureSwitchEnabledFromBody(body, OKOU_DEBUG_FEATURE_SWITCH_KEY),
-    );
-    this.setFilesystemPluginFeatureEnabled(
-      featureSwitchEnabledFromBody(
-        body,
-        COMPUTER_USE_DESKTOP_PLUGINS_FEATURE_SWITCH_KEY,
-      ),
-    );
-    this.setScreenRecordingFeatureEnabled(
-      featureSwitchEnabledFromBody(body, INTRO_VIDEO_FEATURE_SWITCH_KEY),
-    );
   }
 }

--- a/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
+++ b/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
@@ -1,3 +1,4 @@
+import { stoppedOkouDriverState } from "./test/desktop-driver-state";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { COMPUTER_USE_CHANNELS } from "./computer-use-ipc-channels";
 import type {
@@ -11,6 +12,7 @@ import { DESKTOP_DEVELOPER_TOOLS_CHANNELS } from "./desktop-developer-tools-ipc-
 import { DESKTOP_RECORDER_CHANNELS } from "./desktop-recorder-ipc-channels";
 
 type IpcEvent = {
+  readonly sender?: object;
   readonly senderFrame?: {
     readonly url?: string;
   };
@@ -63,6 +65,16 @@ interface MockBrowserWindow {
 
 const rendererUrl = "vm0-desktop://renderer/index.html";
 const recorderUrl = "vm0-desktop://renderer/recorder.html?mode=bar";
+const trustedFrame = {
+  url: rendererUrl,
+  detached: false,
+  isDestroyed: () => false,
+};
+const trustedContents = { mainFrame: trustedFrame, isDestroyed: () => false };
+const trustedWindow = {
+  webContents: trustedContents,
+  isDestroyed: () => false,
+};
 const blockedAppUrl = "https://evil.example/desktop-auth/callback";
 
 beforeEach(() => {
@@ -79,12 +91,20 @@ describe("Desktop IPC boundary", () => {
     const { installComputerUseIpc } = await import("./computer-use-electron");
     const api = createComputerUseApi();
 
-    installComputerUseIpc(api, { rendererUrl });
+    installComputerUseIpc(api, {
+      rendererUrl,
+      getMainWindow: () => trustedWindow,
+    });
 
     const protectedHandlers: readonly {
       readonly channel: string;
       readonly args: readonly unknown[];
     }[] = [
+      {
+        channel: COMPUTER_USE_CHANNELS.setExperimentalCuaEnabled,
+        args: [true],
+      },
+      { channel: COMPUTER_USE_CHANNELS.selectDriver, args: ["cua"] },
       { channel: COMPUTER_USE_CHANNELS.getState, args: [] },
       { channel: COMPUTER_USE_CHANNELS.refreshPermissions, args: [] },
       {
@@ -161,7 +181,10 @@ describe("Desktop IPC boundary", () => {
     const { installComputerUseIpc } = await import("./computer-use-electron");
     const api = createComputerUseApi();
 
-    installComputerUseIpc(api, { rendererUrl });
+    installComputerUseIpc(api, {
+      rendererUrl,
+      getMainWindow: () => trustedWindow,
+    });
 
     await expect(
       invokeIpc(COMPUTER_USE_CHANNELS.setKeepAwakeEnabled, rendererUrl, "true"),
@@ -191,6 +214,85 @@ describe("Desktop IPC boundary", () => {
     expect(api.start).toHaveBeenCalledWith({ userInitiated: true });
     expect(api.setKeepAwakeEnabled).toHaveBeenCalledWith(true);
     expect(api.probeAutomationPermission).toHaveBeenCalledWith("chrome");
+  });
+
+  it("requires the live main window and its exact top-level frame even for local URLs", async () => {
+    const { installComputerUseIpc } = await import("./computer-use-electron");
+    const api = createComputerUseApi();
+    installComputerUseIpc(api, {
+      rendererUrl,
+      getMainWindow: () => trustedWindow,
+    });
+    const handler = electronMock.handlers.get(
+      COMPUTER_USE_CHANNELS.selectDriver,
+    )!;
+    const reject = (event: IpcEvent) =>
+      expect(
+        Promise.resolve().then(() => handler(event, "cua")),
+      ).rejects.toThrow("unavailable on this page");
+    await reject({ sender: {}, senderFrame: trustedFrame }); // auth/recorder/other local window
+    await reject({
+      sender: trustedContents,
+      senderFrame: { url: rendererUrl },
+    }); // subframe
+    await reject({ sender: trustedContents });
+    trustedFrame.detached = true;
+    await reject({ sender: trustedContents, senderFrame: trustedFrame });
+    trustedFrame.detached = false;
+    const stale = { ...trustedWindow, isDestroyed: () => true };
+    installComputerUseIpc(api, { rendererUrl, getMainWindow: () => stale });
+    await expect(
+      invokeIpc(COMPUTER_USE_CHANNELS.selectDriver, rendererUrl, "cua"),
+    ).rejects.toThrow("unavailable on this page");
+    expect(api.selectDriver).not.toHaveBeenCalled();
+  });
+
+  it("validates new driver writes and rejects forged start authority", async () => {
+    const { installComputerUseIpc } = await import("./computer-use-electron");
+    const api = createComputerUseApi();
+    installComputerUseIpc(api, {
+      rendererUrl,
+      getMainWindow: () => trustedWindow,
+    });
+    for (const invalid of [null, 1, "true", {}, [true]]) {
+      await expect(
+        invokeIpc(
+          COMPUTER_USE_CHANNELS.setExperimentalCuaEnabled,
+          rendererUrl,
+          invalid,
+        ),
+      ).rejects.toThrow("boolean");
+    }
+    for (const invalid of [
+      null,
+      "CUA",
+      "other",
+      { driver: "cua", available: true },
+    ]) {
+      await expect(
+        invokeIpc(COMPUTER_USE_CHANNELS.selectDriver, rendererUrl, invalid),
+      ).rejects.toThrow("Unknown Computer Use driver");
+    }
+    for (const invalid of [
+      null,
+      "true",
+      {},
+      { userInitiated: "true" },
+      { userInitiated: true, driver: "cua", tool: "click" },
+    ]) {
+      await expect(
+        invokeIpc(COMPUTER_USE_CHANNELS.start, rendererUrl, invalid),
+      ).rejects.toThrow("Invalid Computer Use start options");
+    }
+    expect(api.start).not.toHaveBeenCalled();
+    await invokeIpc(
+      COMPUTER_USE_CHANNELS.setExperimentalCuaEnabled,
+      rendererUrl,
+      true,
+    );
+    await invokeIpc(COMPUTER_USE_CHANNELS.selectDriver, rendererUrl, "cua");
+    expect(api.setExperimentalCuaEnabled).toHaveBeenCalledExactlyOnceWith(true);
+    expect(api.selectDriver).toHaveBeenCalledExactlyOnceWith("cua");
   });
 
   it("rejects recorder handlers from every frame but the recorder overlays", async () => {
@@ -437,6 +539,12 @@ describe("Desktop IPC boundary", () => {
 });
 
 function createComputerUseApi(): {
+  readonly setExperimentalCuaEnabled: ReturnType<
+    typeof vi.fn<(enabled: boolean) => Promise<DesktopComputerUseState>>
+  >;
+  readonly selectDriver: ReturnType<
+    typeof vi.fn<(driver: "okou" | "cua") => Promise<DesktopComputerUseState>>
+  >;
   readonly getState: ReturnType<typeof vi.fn<() => DesktopComputerUseState>>;
   readonly refreshPermissions: ReturnType<
     typeof vi.fn<() => Promise<DesktopComputerUseState>>
@@ -488,6 +596,8 @@ function createComputerUseApi(): {
 } {
   const state = createComputerUseState();
   return {
+    setExperimentalCuaEnabled: vi.fn(async () => state),
+    selectDriver: vi.fn(async () => state),
     getState: vi.fn(() => state),
     refreshPermissions: vi.fn(async () => state),
     start: vi.fn(async () => state),
@@ -551,6 +661,7 @@ function createDesktopDeveloperToolsApi(): {
 
 function createComputerUseState(): DesktopComputerUseState {
   return {
+    driver: stoppedOkouDriverState,
     platform: "darwin",
     supported: true,
     permissions: {
@@ -598,9 +709,9 @@ async function invokeIpc(
   }
   return await handler(
     {
-      senderFrame: {
-        url: senderFrameUrl,
-      },
+      sender: trustedContents,
+      senderFrame:
+        senderFrameUrl === rendererUrl ? trustedFrame : { url: senderFrameUrl },
     },
     ...args,
   );

--- a/turbo/apps/desktop/src/desktop-preferences.ts
+++ b/turbo/apps/desktop/src/desktop-preferences.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 
 function isDesktopPreferenceRecord(
@@ -14,7 +22,9 @@ export function readDesktopPreferenceRecord(
     return {};
   }
   const parsed: unknown = JSON.parse(readFileSync(filePath, "utf8"));
-  return isDesktopPreferenceRecord(parsed) ? parsed : {};
+  if (!isDesktopPreferenceRecord(parsed))
+    throw new Error("Desktop preferences must be an object");
+  return parsed;
 }
 
 export function writeDesktopPreferenceRecord(
@@ -22,5 +32,14 @@ export function writeDesktopPreferenceRecord(
   preferences: Record<string, unknown>,
 ): void {
   mkdirSync(path.dirname(filePath), { recursive: true });
-  writeFileSync(filePath, `${JSON.stringify(preferences, null, 2)}\n`, "utf8");
+  const temporary = `${filePath}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporary, `${JSON.stringify(preferences, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    renameSync(temporary, filePath);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
 }

--- a/turbo/apps/desktop/src/desktop-tray-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray-menu.test.ts
@@ -1,3 +1,4 @@
+import { stoppedOkouDriverState } from "./test/desktop-driver-state";
 import type { DesktopAuthState } from "./desktop-bridge";
 import type {
   ComputerUseHostRuntimeState,
@@ -71,6 +72,7 @@ function computerUseState(
   },
 ): DesktopComputerUseState {
   return {
+    driver: stoppedOkouDriverState,
     platform: "darwin",
     supported: true,
     permissions,

--- a/turbo/apps/desktop/src/desktop-tray.test.ts
+++ b/turbo/apps/desktop/src/desktop-tray.test.ts
@@ -1,3 +1,4 @@
+import { stoppedOkouDriverState } from "./test/desktop-driver-state";
 import {
   afterAll,
   beforeEach,
@@ -146,6 +147,7 @@ function computerUseState(
   options: ComputerUseStateOptions = {},
 ): DesktopComputerUseState {
   return {
+    driver: stoppedOkouDriverState,
     platform: "darwin",
     supported: true,
     permissions: {

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -35,6 +35,7 @@ import {
   hasRequiredComputerUsePermissions,
   type ComputerUseAutomationPermissionTarget,
   type DesktopComputerUseState,
+  type ComputerUseDriverId,
 } from "./computer-use-types";
 import { isComputerUseSetupRequired } from "./computer-use-startup-gate";
 import { ComputerUseRuntimeController } from "./computer-use-runtime-controller";
@@ -53,8 +54,15 @@ import type {
 } from "./desktop-recorder-types";
 import { buildWindowOptions } from "./desktop-recorder-window-options";
 import { areaToGlobal } from "./desktop-recorder-overlay-geometry";
-import { createComputerUsePermissions } from "./computer-use-permissions";
-import { ComputerUseDriverController } from "./computer-use-driver";
+import { createDesktopComputerUsePermissions } from "./desktop-computer-use-permissions";
+import {
+  ComputerUseDriverController,
+  type ComputerUseDriver,
+} from "./computer-use-driver";
+import { createCuaComputerUseDriver } from "./computer-use-cua";
+import { createComputerUseHostPermissions } from "./computer-use-host-permissions";
+import { DesktopComputerUseDriverPreferences } from "./desktop-computer-use-driver-preferences";
+import { DesktopComputerUseDriverSelection } from "./desktop-computer-use-driver-selection";
 import { CuaEmbeddedRuntime } from "./cua-runtime";
 import { assertCuaDormant } from "./cua-runtime-files";
 import { runCuaHostProbe } from "./cua-host-probe";
@@ -168,23 +176,48 @@ let filesystemPluginManager: DesktopFilesystemPluginManager | null = null;
 let mcpPluginManager: DesktopMcpPluginManager | null = null;
 let desktopAutoUpdates: DesktopAutoUpdatesController | null = null;
 const desktopAuthStartGate = createDesktopAuthStartGate();
-const computerUseDriver = new ComputerUseDriverController({
+const driverPreferences = new DesktopComputerUseDriverPreferences(
+  desktopPreferencesPath,
+);
+const hostPermissions = createComputerUseHostPermissions();
+const okouDriver: ComputerUseDriver = {
   id: "okou",
+  buildVersion: app.getVersion(),
   createBackend: () =>
     createComputerUseNativeBackend({
       onRuntimeError: captureDesktopNativeHelperError,
     }),
-});
+};
+const cuaDriver: ComputerUseDriver = {
+  ...createCuaComputerUseDriver({
+    runtimeRoot: app.isPackaged
+      ? path.join(process.resourcesPath, "cua")
+      : path.join(__dirname, "..", "native", "dist", "cua"),
+    hostBundleId: config.identity.bundleId,
+  }),
+  getAuthorization: () => developerTools.getAuthorization(),
+};
+const computerUseDriver = new ComputerUseDriverController(
+  okouDriver,
+  process.platform,
+  notifyComputerUseChanged,
+);
 const {
   getComputerUsePermissionState,
+  resetComputerUsePermissionState,
+  prepareNative,
+  refreshReady,
   refreshComputerUsePermissionState,
   requestComputerUseAccessibilityPermission,
   requestComputerUseScreenRecordingPermission,
   probeComputerUseAutomationPermission,
   recordComputerUseAutomationPermissionDenied,
-} = createComputerUsePermissions((read) =>
-  computerUseDriver.withPermissionProvider(read),
-);
+} = createDesktopComputerUsePermissions({
+  driver: computerUseDriver,
+  requestedDriver: () => driverPreferences.getState().selectedDriver,
+  transitioning: () => computerUseController.isTransitioning(),
+  host: hostPermissions,
+});
 const automationPermissionPrompt = createAutomationPermissionDeniedPrompt({
   sourceLabel: config.identity.displayName,
   showDialog: async (options) => {
@@ -291,6 +324,7 @@ const screenRecorder = new DesktopRecorderController({
 });
 let screenRecordingPollTimer: NodeJS.Timeout | null = null;
 const developerTools = new DeveloperToolsController({
+  getSessionAuthority: () => authSession?.getAuthority() ?? null,
   fetchFeatureSwitches: () =>
     getAuthSession().fetchWithSessionAuth(
       new URL(ZERO_FEATURE_SWITCHES_PATH, desktopApiBaseUrl),
@@ -311,6 +345,8 @@ const computerUseController = new ComputerUseRuntimeController({
   driver: computerUseDriver,
   createRuntime: createComputerUseHostRuntime,
   refreshPermissions: refreshComputerUsePermissionState,
+  nativeBlockReason: (driver) => driverSelection.blockReason(driver),
+  prepareNative,
   getPluginCapabilities: supportedPluginCapabilities,
   preparePlugins: async () => {
     await Promise.all([
@@ -325,6 +361,31 @@ const computerUseController = new ComputerUseRuntimeController({
   },
   onChange: notifyComputerUseChanged,
 });
+
+const driverSelection = new DesktopComputerUseDriverSelection({
+  preferences: driverPreferences,
+  developer: developerTools,
+  runtime: computerUseController,
+  drivers: { okou: okouDriver, cua: cuaDriver },
+  onChange: () => {
+    notifyComputerUseChanged();
+    if (app.isReady()) applyApplicationMenu();
+  },
+});
+
+async function setExperimentalCuaEnabled(
+  enabled: boolean,
+): Promise<DesktopComputerUseState> {
+  await driverSelection.setExperiment(enabled);
+  return getComputerUseBridgeState();
+}
+
+async function selectComputerUseDriver(
+  driver: ComputerUseDriverId,
+): Promise<DesktopComputerUseState> {
+  await driverSelection.select(driver);
+  return getComputerUseBridgeState();
+}
 
 function refreshDesktopTray(): void {
   desktopTray?.refresh();
@@ -419,14 +480,39 @@ function notifyComputerUseChanged(): void {
   computerUseAutoStart.restartRecoverableRuntimeState();
 }
 
+let lastSessionAuthority: object | null = null;
 function notifyAuthChanged(): void {
+  const authority = authSession?.getAuthority() ?? null;
+  if (lastSessionAuthority !== authority) {
+    lastSessionAuthority = authority;
+    resetComputerUsePermissionState();
+    if (
+      driverSelection.requestedDriver().id === "cua" ||
+      computerUseDriver.selectedDriver.id === "cua"
+    ) {
+      void computerUseController.stopForAuthChange().catch(() => {
+        console.warn("Computer Use session cleanup remains unproven");
+      });
+    }
+  }
   notifyDesktopAuthChanged();
   refreshDesktopTrayAuth();
   developerTools.requestRefresh();
 }
 
+let lastCuaAuthorization: object | null = null;
 function notifyDeveloperToolsChanged(): void {
+  const authorization = developerTools.getAuthorization();
+  if (lastCuaAuthorization !== authorization) {
+    lastCuaAuthorization = authorization;
+    void computerUseController.refreshDriverAuthorization().catch(() => {
+      console.warn(
+        "Computer Use driver authorization cleanup remains unproven",
+      );
+    });
+  }
   notifyDesktopDeveloperToolsChanged();
+  notifyDesktopComputerUseChanged();
   if (app.isReady()) {
     applyApplicationMenu();
   }
@@ -580,6 +666,7 @@ function friendlyDeviceName(): string | null {
 
 function getComputerUseBridgeState(): DesktopComputerUseState {
   return {
+    driver: driverSelection.getState(),
     platform: process.platform,
     supported: process.platform === "darwin",
     deviceName: friendlyDeviceName(),
@@ -613,7 +700,7 @@ function installKeepAwake(): void {
     blocker: powerSaveBlocker,
     onChange: notifyComputerUseChanged,
   });
-  keepAwakeController.load();
+  if (!driverPreferences.getState().preferenceError) keepAwakeController.load();
 }
 
 function setKeepAwakeEnabled(enabled: boolean): DesktopComputerUseState {
@@ -634,7 +721,8 @@ function ensureFilesystemPluginManager(): DesktopFilesystemPluginManager {
       preferencesPath: desktopPreferencesPath(),
       onChange: notifyComputerUseChanged,
     });
-    filesystemPluginManager.load();
+    if (!driverPreferences.getState().preferenceError)
+      filesystemPluginManager.load();
   }
   return filesystemPluginManager;
 }
@@ -645,7 +733,7 @@ function ensureMcpPluginManager(): DesktopMcpPluginManager {
       preferencesPath: desktopPreferencesPath(),
       onChange: notifyComputerUseChanged,
     });
-    mcpPluginManager.load();
+    if (!driverPreferences.getState().preferenceError) mcpPluginManager.load();
   }
   return mcpPluginManager;
 }
@@ -679,7 +767,7 @@ function createComputerUseHostRuntime(): ComputerUseHostRuntime {
         return fetch(input, init);
       },
       addClientHeaders: addDesktopClientHeaders,
-      getPermissions: refreshComputerUsePermissionState,
+      getPermissions: refreshReady,
       getSupportedCapabilities: supportedComputerUseCapabilities,
       driver: computerUseDriver,
       executePluginCommand: (command) => {
@@ -702,12 +790,22 @@ function createComputerUseHostRuntime(): ComputerUseHostRuntime {
 async function startComputerUseRuntime(
   options: { readonly userInitiated?: boolean } = {},
 ): Promise<DesktopComputerUseState> {
-  await computerUseController.start(options);
+  try {
+    await computerUseController.start(options);
+  } catch {
+    throw new Error(
+      "Computer Use could not start. Check driver status and cleanup.",
+    );
+  }
   return getComputerUseBridgeState();
 }
 
 async function stopComputerUseRuntime(): Promise<DesktopComputerUseState> {
-  await computerUseController.stop();
+  try {
+    await computerUseController.stop();
+  } catch {
+    throw new Error("Computer Use cleanup is still pending.");
+  }
   return getComputerUseBridgeState();
 }
 
@@ -793,6 +891,8 @@ function installComputerUse(): void {
   installComputerUseIpc(
     {
       getState: getComputerUseBridgeState,
+      setExperimentalCuaEnabled,
+      selectDriver: selectComputerUseDriver,
       refreshPermissions: refreshComputerUsePermissions,
       start: startComputerUseRuntime,
       stop: stopComputerUseRuntime,
@@ -807,7 +907,7 @@ function installComputerUse(): void {
       setMcpPluginServerEnabled,
       removeMcpPluginServer,
     },
-    { rendererUrl: localRendererUrl },
+    { rendererUrl: localRendererUrl, getMainWindow: () => mainWindow },
   );
 }
 
@@ -1099,6 +1199,18 @@ function applyApplicationMenu(): void {
   ];
   const developerToolsState = developerTools.getState();
   if (developerToolsState.available) {
+    appSubmenu.push({
+      label: "Enable experimental CUA driver",
+      type: "checkbox",
+      checked: driverPreferences.getState().experimentalCuaEnabled,
+      click: () => {
+        void setExperimentalCuaEnabled(
+          !driverPreferences.getState().experimentalCuaEnabled,
+        ).catch(() => {
+          console.warn("Computer Use driver preference was not saved");
+        });
+      },
+    });
     appSubmenu.push({
       label: "Developer Tools",
       type: "checkbox",
@@ -1403,7 +1515,7 @@ async function maybeStartComputerUseAfterAuth(
 ): Promise<void> {
   await computerUseController.startForAuthChange(signal);
   signal.throwIfAborted();
-  notifyAuthChanged();
+  notifyDesktopAuthChanged();
   notifyComputerUseChanged();
 }
 
@@ -1562,6 +1674,10 @@ if (!hasSingleInstanceLock) {
       return;
     }
     applyDockIcon();
+    driverPreferences.load();
+    await computerUseController.transitionDriver(
+      driverSelection.requestedDriver(),
+    );
     hideDockForInactiveMainWindow();
     registerDesktopAuthProtocol();
     installDesktopRendererProtocol();

--- a/turbo/apps/desktop/src/preload.test.ts
+++ b/turbo/apps/desktop/src/preload.test.ts
@@ -136,6 +136,8 @@ describe("Desktop preload bridge", () => {
 
     await computerUse.getState();
     await computerUse.refreshPermissions();
+    await computerUse.setExperimentalCuaEnabled(true);
+    await computerUse.selectDriver("cua");
     await computerUse.start({ userInitiated: true });
     await computerUse.stop();
     await computerUse.requestAccessibilityPermission();
@@ -155,6 +157,8 @@ describe("Desktop preload bridge", () => {
     expect(electronMock.ipcRenderer.invoke.mock.calls).toStrictEqual([
       [COMPUTER_USE_CHANNELS.getState],
       [COMPUTER_USE_CHANNELS.refreshPermissions],
+      [COMPUTER_USE_CHANNELS.setExperimentalCuaEnabled, true],
+      [COMPUTER_USE_CHANNELS.selectDriver, "cua"],
       [COMPUTER_USE_CHANNELS.start, { userInitiated: true }],
       [COMPUTER_USE_CHANNELS.stop],
       [COMPUTER_USE_CHANNELS.requestAccessibilityPermission],

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -41,6 +41,13 @@ const desktopAuthApi: DesktopAuthApi = {
 };
 
 const desktopComputerUseApi: DesktopComputerUseApi = {
+  setExperimentalCuaEnabled: (enabled) =>
+    ipcRenderer.invoke(
+      COMPUTER_USE_CHANNELS.setExperimentalCuaEnabled,
+      enabled,
+    ),
+  selectDriver: (driver) =>
+    ipcRenderer.invoke(COMPUTER_USE_CHANNELS.selectDriver, driver),
   getState(): Promise<DesktopComputerUseState> {
     return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.getState);
   },

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { stoppedOkouDriverState } from "../test/desktop-driver-state";
 import {
   cleanup,
   fireEvent,
@@ -15,6 +16,7 @@ import {
   type ComputerUsePermissionState,
   type DesktopComputerUsePluginsState,
   type DesktopComputerUseState,
+  type DesktopComputerUseDriverState,
   type DesktopKeepAwakeState,
 } from "../computer-use-types";
 import type {
@@ -25,6 +27,7 @@ import type {
   DesktopDeveloperToolsState,
 } from "../desktop-bridge";
 import { App } from "./App";
+import { settleDesktopActions } from "./async-action";
 
 const signedInAuthState: DesktopAuthState = {
   status: "signed_in",
@@ -81,6 +84,7 @@ function createComputerUseState({
   readonly status?: ComputerUseHostRuntimeStatus;
 } = {}): DesktopComputerUseState {
   return {
+    driver: stoppedOkouDriverState,
     platform: "darwin",
     supported: true,
     deviceName,
@@ -229,6 +233,22 @@ function createComputerUseBridge(initialState: DesktopComputerUseState): {
     };
   });
   const api: DesktopComputerUseApi = {
+    setExperimentalCuaEnabled: async (enabled) => {
+      if (currentState.driver)
+        currentState = {
+          ...currentState,
+          driver: { ...currentState.driver, experimentalCuaEnabled: enabled },
+        };
+      return currentState;
+    },
+    selectDriver: async (selectedDriver) => {
+      if (currentState.driver)
+        currentState = {
+          ...currentState,
+          driver: { ...currentState.driver, selectedDriver },
+        };
+      return currentState;
+    },
     getState,
     refreshPermissions,
     start,
@@ -415,7 +435,8 @@ function renderDesktopApp(): void {
   );
 }
 
-afterEach(() => {
+afterEach(async () => {
+  await settleDesktopActions();
   cleanup();
   delete window.vm0DesktopAuth;
   delete window.vm0DesktopComputerUse;
@@ -425,6 +446,114 @@ afterEach(() => {
 });
 
 describe("Desktop renderer bridge integration", () => {
+  it.each(["stopped", "starting", "switching", "blocked", "error"] as const)(
+    "keeps driver recovery reachable with missing permissions and %s state",
+    async (phase) => {
+      const driver: DesktopComputerUseDriverState = {
+        experimentalCuaEnabled: true,
+        selectedDriver: "cua",
+        developerAvailability: "available",
+        actual: null,
+        phase,
+        lifecycleElapsedMs: 123,
+        cleanupPending: phase === "switching",
+        expectedCuaVersion: "0.23.2",
+        error: phase === "error" ? "Driver startup failed." : null,
+        canRetry: phase === "stopped" || phase === "error",
+      };
+      const state = {
+        ...createComputerUseState({
+          permissions: { accessibility: false, screenRecording: false },
+        }),
+        driver,
+      };
+      const { computerUse } = installDesktopBridges({
+        computerUseState: state,
+      });
+      const select = vi.spyOn(computerUse.api, "selectDriver");
+      renderDesktopApp();
+      const selector = await screen.findByRole("combobox", {
+        name: "Computer Use driver",
+      });
+      expect(
+        screen.getByText(/Actual: No native driver/).textContent,
+      ).toContain(phase);
+      expect(
+        screen.getByRole("button", { name: "Retry" }).hasAttribute("disabled"),
+      ).toBe(!driver.canRetry);
+      expect(screen.queryByRole("heading", { name: "Runtime" })).toBeNull();
+      fireEvent.change(selector, { target: { value: "okou" } });
+      await waitFor(() => expect(select).toHaveBeenCalledWith("okou"));
+      expect(computerUse.start).not.toHaveBeenCalled();
+    },
+  );
+
+  it("hides a disabled selector while retaining actual CUA cleanup and explicit recovery", async () => {
+    const state: DesktopComputerUseState = {
+      ...createComputerUseState(),
+      driver: {
+        experimentalCuaEnabled: false,
+        selectedDriver: "okou",
+        developerAvailability: "unavailable",
+        actual: { id: "cua", generation: 7, version: null },
+        phase: "retiring",
+        lifecycleElapsedMs: 500,
+        cleanupPending: true,
+        expectedCuaVersion: "0.23.2",
+        error: null,
+        canRetry: false,
+      },
+    };
+    const { computerUse } = installDesktopBridges({ computerUseState: state });
+    const select = vi.spyOn(computerUse.api, "selectDriver");
+    renderDesktopApp();
+    expect(await screen.findByText(/Actual: CUA/)).toBeTruthy();
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.getByText(/Cleanup is still pending/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Use Okou" }));
+    await waitFor(() => expect(select).toHaveBeenCalledWith("okou"));
+    expect(computerUse.start).not.toHaveBeenCalled();
+  });
+
+  it("makes Retry an explicit start and disables the selector while a selection is pending", async () => {
+    const state: DesktopComputerUseState = {
+      ...createComputerUseState(),
+      driver: {
+        experimentalCuaEnabled: true,
+        selectedDriver: "cua",
+        developerAvailability: "available",
+        actual: null,
+        phase: "error",
+        lifecycleElapsedMs: 1,
+        cleanupPending: false,
+        expectedCuaVersion: "0.23.2",
+        error: "Driver startup failed.",
+        canRetry: true,
+      },
+    };
+    const { computerUse } = installDesktopBridges({ computerUseState: state });
+    computerUse.start.mockResolvedValue(state);
+    let complete!: (state: DesktopComputerUseState) => void;
+    vi.spyOn(computerUse.api, "selectDriver").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          complete = resolve;
+        }),
+    );
+    renderDesktopApp();
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    expect(computerUse.start).not.toHaveBeenCalled();
+    fireEvent.click(retry);
+    await waitFor(() =>
+      expect(computerUse.start).toHaveBeenCalledWith({ userInitiated: true }),
+    );
+    const selector = screen.getByRole("combobox");
+    fireEvent.change(selector, { target: { value: "okou" } });
+    await waitFor(() => expect(selector.hasAttribute("disabled")).toBe(true));
+    complete(state);
+    await waitFor(() => expect(selector.hasAttribute("disabled")).toBe(false));
+  });
+
   it("shows Okou identity and fresh permission guidance", async () => {
     window.vm0DesktopIdentity = {
       product: "okou",

--- a/turbo/apps/desktop/src/renderer/App.tsx
+++ b/turbo/apps/desktop/src/renderer/App.tsx
@@ -17,6 +17,7 @@ import {
 } from "./computer-use-state";
 import { DesktopBrandMark, Panel } from "./components";
 import { ReadyExperience } from "./hero";
+import { ComputerUseDriverControls } from "./computer-use-driver";
 import { currentDesktopIdentity } from "./desktop-identity";
 import okouWordmarkUrl from "./assets/okou-wordmark-dark.svg";
 import {
@@ -128,12 +129,15 @@ function ComputerUsePage() {
     }
 
     return (
-      <ComputerUseContent
-        authLoading={authLoading}
-        authState={authState}
-        developerToolsEnabled={developerToolsEnabled}
-        state={loadable.data}
-      />
+      <>
+        <ComputerUseDriverControls state={loadable.data.driver} />
+        <ComputerUseContent
+          authLoading={authLoading}
+          authState={authState}
+          developerToolsEnabled={developerToolsEnabled}
+          state={loadable.data}
+        />
+      </>
     );
   }
 

--- a/turbo/apps/desktop/src/renderer/async-action.ts
+++ b/turbo/apps/desktop/src/renderer/async-action.ts
@@ -1,0 +1,22 @@
+/** DOM callbacks hand finite IPC work to main; track their settlement in the view. */
+export enum Reason {
+  DomCallback = "dom_callback",
+}
+
+const pending = new Set<Promise<void>>();
+
+export function detach(work: Promise<unknown>, reason: Reason): void {
+  const settled = work.then(
+    () => {},
+    () => {
+      // Expected action failures live in useLoadableSet. Never log IPC payloads.
+      console.warn("Desktop action could not complete", reason);
+    },
+  );
+  pending.add(settled);
+  settled.then(() => pending.delete(settled));
+}
+
+export async function settleDesktopActions(): Promise<void> {
+  await Promise.all([...pending]);
+}

--- a/turbo/apps/desktop/src/renderer/command-log/index.tsx
+++ b/turbo/apps/desktop/src/renderer/command-log/index.tsx
@@ -317,6 +317,12 @@ function CommandLogRow({
       </button>
       {expanded && (
         <div className="command-log-details">
+          {entry.driver && (
+            <p className="row-meta">
+              Driver: {entry.driver.id} · generation {entry.driver.generation} ·
+              version {entry.driver.version ?? "Unavailable"}
+            </p>
+          )}
           <CommandLogSection title="Parameters" icon={<Code size={15} />}>
             <KeyValueList
               value={entry.payload}

--- a/turbo/apps/desktop/src/renderer/computer-use-driver.tsx
+++ b/turbo/apps/desktop/src/renderer/computer-use-driver.tsx
@@ -1,0 +1,122 @@
+import { useLoadableSet } from "ccstate-react/experimental";
+import { Play, RefreshCw, Square } from "lucide-react";
+import type { DesktopComputerUseDriverState } from "../computer-use-types";
+import {
+  selectComputerUseDriver$,
+  startComputerUse$,
+  stopComputerUse$,
+} from "./computer-use-state";
+import { IconButton, Panel } from "./components";
+import { detach, Reason } from "./async-action";
+
+export function ComputerUseDriverControls({
+  state,
+}: {
+  readonly state: DesktopComputerUseDriverState;
+}) {
+  const [selection, select] = useLoadableSet(selectComputerUseDriver$);
+  const [retry, start] = useLoadableSet(startComputerUse$);
+  const [stopping, stop] = useLoadableSet(stopComputerUse$);
+  const visible =
+    state.experimentalCuaEnabled && state.developerAvailability === "available";
+  if (
+    !visible &&
+    state.selectedDriver === "okou" &&
+    state.actual?.id !== "cua" &&
+    !state.error &&
+    !state.cleanupPending &&
+    state.phase !== "switching"
+  )
+    return null;
+  const busy = selection.state === "loading";
+  return (
+    <Panel title="Computer Use driver">
+      {visible && (
+        <label className="driver-choice">
+          <span>Driver</span>
+          <select
+            aria-label="Computer Use driver"
+            value={state.selectedDriver}
+            disabled={busy}
+            onChange={(event) => {
+              const value = event.currentTarget.value;
+              if (value === "okou" || value === "cua")
+                detach(select(value), Reason.DomCallback);
+            }}
+          >
+            <option value="okou">Okou</option>
+            <option value="cua">CUA (Experimental)</option>
+          </select>
+        </label>
+      )}
+      <div className="driver-status" role="status" aria-live="polite">
+        <p>
+          Requested:{" "}
+          {state.selectedDriver === "cua" ? "CUA (Experimental)" : "Okou"}
+        </p>
+        <p>
+          Actual:{" "}
+          {state.actual
+            ? `${state.actual.id === "cua" ? "CUA" : "Okou"} · generation ${String(state.actual.generation)}`
+            : "No native driver"}{" "}
+          · {state.phase}
+        </p>
+        <p>
+          Ready version: {state.actual?.version ?? "Unavailable"} · Packaged
+          CUA: {state.expectedCuaVersion} (expected)
+        </p>
+        <p>Lifecycle elapsed: {state.lifecycleElapsedMs} ms</p>
+        {state.cleanupPending && (
+          <p>
+            Cleanup is still pending. Recovery waits for the previous driver to
+            exit.
+          </p>
+        )}
+      </div>
+      {state.error && (
+        <p className="inline-alert" role="alert">
+          {state.error}
+        </p>
+      )}
+      {selection.state === "hasError" && (
+        <p className="inline-alert" role="alert">
+          The selection could not be saved. Check the driver status.
+        </p>
+      )}
+      {retry.state === "hasError" && (
+        <p className="inline-alert" role="alert">
+          The driver could not start. Check permissions and cleanup status.
+        </p>
+      )}
+      <div className="panel-actions">
+        {(state.phase === "starting" || state.phase === "switching" || state.cleanupPending) && (
+          <IconButton icon={<Square size={15} />} tone="danger" disabled={stopping.state === "loading"} onClick={() => detach(stop(), Reason.DomCallback)}>
+            Stop
+          </IconButton>
+        )}
+        {state.phase !== "ready" && (
+          <IconButton
+            icon={<Play size={15} />}
+            disabled={!state.canRetry || retry.state === "loading"}
+            onClick={() => {
+              detach(start(), Reason.DomCallback);
+            }}
+          >
+            Retry
+          </IconButton>
+        )}
+        {(state.selectedDriver !== "okou" || state.actual?.id === "cua") && (
+          <IconButton
+            icon={<RefreshCw size={15} />}
+            disabled={busy}
+            onClick={() => {
+              detach(select("okou"), Reason.DomCallback);
+            }}
+          >
+            Use Okou
+          </IconButton>
+        )}
+      </div>
+    </Panel>
+  );
+}

--- a/turbo/apps/desktop/src/renderer/computer-use-driver.tsx
+++ b/turbo/apps/desktop/src/renderer/computer-use-driver.tsx
@@ -89,8 +89,15 @@ export function ComputerUseDriverControls({
         </p>
       )}
       <div className="panel-actions">
-        {(state.phase === "starting" || state.phase === "switching" || state.cleanupPending) && (
-          <IconButton icon={<Square size={15} />} tone="danger" disabled={stopping.state === "loading"} onClick={() => detach(stop(), Reason.DomCallback)}>
+        {(state.phase === "starting" ||
+          state.phase === "switching" ||
+          state.cleanupPending) && (
+          <IconButton
+            icon={<Square size={15} />}
+            tone="danger"
+            disabled={stopping.state === "loading"}
+            onClick={() => detach(stop(), Reason.DomCallback)}
+          >
             Stop
           </IconButton>
         )}

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -8,6 +8,7 @@ import type {
 } from "../desktop-bridge";
 import type {
   ComputerUseAutomationPermissionTarget,
+  ComputerUseDriverId,
   DesktopComputerUseState,
 } from "../computer-use-types";
 
@@ -127,13 +128,29 @@ export const setupComputerUseBridge$ = command(
 );
 
 export const startComputerUse$ = command(async ({ set }) => {
-  await desktopComputerUseApi().start({ userInitiated: true });
-  set(reloadComputerUse$);
+  try {
+    await desktopComputerUseApi().start({ userInitiated: true });
+  } finally {
+    set(reloadComputerUse$);
+  }
 });
 
+export const selectComputerUseDriver$ = command(
+  async ({ set }, driver: ComputerUseDriverId) => {
+    try {
+      await desktopComputerUseApi().selectDriver(driver);
+    } finally {
+      set(reloadComputerUse$);
+    }
+  },
+);
+
 export const stopComputerUse$ = command(async ({ set }) => {
-  await desktopComputerUseApi().stop();
-  set(reloadComputerUse$);
+  try {
+    await desktopComputerUseApi().stop();
+  } finally {
+    set(reloadComputerUse$);
+  }
 });
 
 export const requestAccessibilityPermission$ = command(async ({ set }) => {

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -1697,3 +1697,31 @@ button {
     text-align: left;
   }
 }
+.driver-choice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.driver-choice select {
+  font: inherit;
+  color: inherit;
+  border: 1px solid rgba(30, 38, 52, 0.08);
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 8px 12px;
+}
+
+.driver-status {
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.driver-choice select:hover {
+  border-color: rgba(30, 38, 52, 0.24);
+}
+.driver-choice select:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}

--- a/turbo/apps/desktop/src/test/desktop-driver-state.ts
+++ b/turbo/apps/desktop/src/test/desktop-driver-state.ts
@@ -1,0 +1,15 @@
+import type { DesktopComputerUseDriverState } from "../computer-use-types";
+
+/** External bridge baseline for renderer, IPC and tray test entry points. */
+export const stoppedOkouDriverState: DesktopComputerUseDriverState = {
+  experimentalCuaEnabled: false,
+  selectedDriver: "okou",
+  developerAvailability: "unavailable",
+  actual: null,
+  phase: "stopped",
+  lifecycleElapsedMs: 0,
+  cleanupPending: false,
+  expectedCuaVersion: "0.23.2",
+  error: null,
+  canRetry: true,
+};


### PR DESCRIPTION
## Summary

Fixes #32370. Add the local Developer opt-in, driver selection/recovery, and truthful diagnostics for slice 4 of #32259. Checking **Enable experimental CUA driver** only reveals the selector; Okou remains the default. Selecting CUA while stopped persists a request without loading it. A running switch drains claim → action → post-state → completion, retires the previous generation, and keeps the existing host/plugin processes.

CUA permission reads can start the embedded daemon, so passive setup/tray/bridge reads now use Electron host TCC status whenever CUA is requested/selected or a transition is pending. Explicit Accessibility requests prompt the host and Screen Recording requests open Privacy settings. Native preparation and fresh ready-generation checks remain inside the existing driver/runtime owner.

Developer authorization is an opaque proof bound to the validated user, workspace and auth-session lifetime. Refresh synchronously withdraws authority, late responses cannot restore an obsolete identity, and lifecycle plus selection revisions reject stale startup/transition results. Failure retains the request and cleanup owner; Retry is explicit Start and Use Okou is explicit selection. Neither replays an action or bypasses retirement.

## Acceptance evidence

| Contract area | Implementation and verification |
| --- | --- |
| Default/opt-in/panel separation | Exact local boolean/enum parsing, off/Okou defaults, lazy CUA factory, independent Developer menu checkboxes; real selection composition tests default/malformed preference cases and diagnostic-panel toggles. |
| Durable preference and shared writers | Atomic synchronous read/modify/write of only `computerUseDriver`; real installation, keep-awake and filesystem-plugin writes interleave without losing keys; corrupt overall files remain unchanged with a bounded error. |
| Main/preload/IPC authority | Actual main-window WebContents and exact live top-level frame plus approved renderer URL; unknown input validation and main-side current Developer/opt-in checks. IPC/preload tests reject forged windows/subframes/stale senders, invalid values and raw start options. |
| Auth and availability | Real auth + Developer controller + MSW composition covers old-account delayed `_debug`, live unresolved/withdrawn access, manual Stop, retained preference, and authorized running-intent recovery. |
| Passive permission and explicit requests | CUA restore, signed-out/setup reads, permission actions and stopped preference changes load neither CUA nor an Okou fallback helper. Electron boundary tests verify status reads do not prompt and explicit requests perform the OS action. |
| Requested versus actual | Required bridge state reports actual controller generation/readiness separately from requested preference. Ready CUA version comes from the loaded connection; packaged `0.23.2` is labeled expected. Okou uses the Desktop/helper build. |
| Switching and rapid latest intent | Real host/driver tests retain command-generation ownership across delayed claims, actions, completion and cleanup; repeated CUA/Okou/CUA requests converge without overlapping executors. Delayed initial startup registers only the latest selected lane. |
| Stop/auth/update supersession | New real composition tests hold CUA permission/start work across Stop, sign-out, update-relaunch and changed selection; obsolete work cannot publish CUA ready or register an obsolete host. |
| Failure/recovery and plugins | Missing SDK, fresh permission revocation, UI timeout and spontaneous embedded exit remain bounded and visible. Real filesystem process continues serving on the same host after native withdrawal/selection; Retry and Use Okou preserve cleanup ownership. |
| Shared-page controls | Existing Desktop Panel/IconButton/CSS and ccstate commands; selector/recovery are outside ReadyExperience. Renderer tests cover missing permissions, stopped, starting, switching, blocked, error, hidden selector with actual CUA cleanup, explicit Retry/Use Okou and pending selection. Stop remains reachable during startup/switch/cleanup. |
| Private diagnostics | Native command identity is captured before claim and retained after switching; only driver ID, actual build/version and controller generation are added. Lifecycle elapsed time is bounded to 120 seconds. SDK/path/token/session details do not enter new errors. Existing CUA route/effect/delivery semantics are unchanged. |
| Update coordination | Starting, transition work and retained native/embedded cleanup report busy, including after a UI timeout; existing bootstrap/update policy and final stop/reap owner are preserved. |
| Scope/pins | CUA three-core pin `0.23.2`, artifacts, downloads/signing, native actuator, Electron, recorder, cloud/public command contracts and server preferences are unchanged. No release or slice-5 implementation. |

## Validation

- Passed 21 explicitly selected regression files / 281 tests covering Okou/CUA execution, embedded lifecycle, real filesystem/MCP processes, host/runtime, auth/Developer, IPC/preload/renderer, persisted writers, updater and distribution. No full local Vitest or dev server.
- After final lifecycle extraction, passed the focused runtime/driver/selection checks (55 tests); final bridge/tray/renderer checks passed (72 tests). Updated fixture state follows the required bridge contract; no old-client branch was introduced.
- Passed Desktop `check-types`, `lint`, scoped Knip, formatting and `git diff --check`.
- Passed `build:electron` including bootstrap bundle guard, and `build:renderer`.
- Required PR checks and the existing actual macOS default, production-configured and PR-preview packaged dormant smoke/CUA probes must pass on this PR. The implementation owner continues through one-shot `/pr-auto` and the protected merge queue.

## Fallbacks

- `DesktopComputerUseDriverPreferences.load`: off/Okou for an absent or invalid optional local opt-in subtree, explicitly required by #32370. This is fail-closed input normalization, not cross-version routing or CUA execution fallback. Surface: local installation settings, non-GA experiment. Retain while unconfigured installations are valid; revisit only if the preference/GA contract changes under #32259. Corrupt overall files are reported and never replaced by this recovery.
- Driver diagnostic version/actual labels: genuinely absent readiness or optional backend version information displays unavailable/no native driver; it never invents a loaded version or an executor. Surface: presentation, no deployment window. Retain while stopped/unready states exist under #32259; no old-client/runner/DB compatibility branch is added.

## Unperformed interactive acceptance

No real Mac, browser interaction, Developer ID installation, TCC grant/revocation, real screenshot/app pairing, recording continuity, performance or update/rollback acceptance was performed. Renderer/OS fixtures are not manual acceptance. The three macOS package lanes use ad-hoc signing; final signed-host and slice-5 acceptance remain with the user/controller. See `cua/README.md` and the unchanged 0.23.2 command limitations in `cua/ADAPTER.md`.
