### PR TITLE
refactor(image-recognition): remove legacy recognize api and cli compatibility

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/image-recognition.test.ts
@@ -171,16 +171,13 @@ function setStoredObjects(objects: readonly StoredObject[]): void {
   );
 }
 
-function requestImageRecognition(
-  args: {
-    readonly token?: string;
-    readonly fileId: string;
-    readonly prompt?: string;
-    readonly clientRequestId?: string;
-    readonly usagePricingResolution?: UsagePricingFixture["resolution"];
-  },
-  operation: "imageRecognition" | "recognize" = "imageRecognition",
-) {
+function requestImageRecognition(args: {
+  readonly token?: string;
+  readonly fileId: string;
+  readonly prompt?: string;
+  readonly clientRequestId?: string;
+  readonly usagePricingResolution?: UsagePricingFixture["resolution"];
+}) {
   const headers = {
     ...(args.token ? { authorization: `Bearer ${args.token}` } : {}),
     ...(args.clientRequestId
@@ -199,9 +196,7 @@ function requestImageRecognition(
       prompt: args.prompt ?? "Describe this image",
     },
   };
-  return operation === "imageRecognition"
-    ? client.imageRecognition(request)
-    : client.recognize(request);
+  return client.imageRecognition(request);
 }
 
 async function createConfiguredImageRecognitionPricing(): Promise<UsagePricingFixture> {
@@ -697,29 +692,5 @@ describe("POST /api/image-recognition", () => {
         context.signal,
       ),
     ).resolves.toStrictEqual({ raw: 2, hourly: 0 });
-  });
-});
-
-describe("POST /api/recognize compatibility", () => {
-  it("keeps pre-switch CLI requests on the canonical authenticated behavior", async () => {
-    const actor = await seedImageRecognitionActor();
-    const fileId = randomUUID();
-    const request = {
-      token: okouToken(actor),
-      fileId,
-    };
-    setStoredObjects([]);
-
-    const canonical = await requestImageRecognition(request);
-    const compatibility = await requestImageRecognition(request, "recognize");
-
-    expect(compatibility.status).toBe(404);
-    expect({
-      status: compatibility.status,
-      body: compatibility.body,
-    }).toStrictEqual({
-      status: canonical.status,
-      body: canonical.body,
-    });
   });
 });

--- a/turbo/apps/api/src/signals/routes/image-recognition.ts
+++ b/turbo/apps/api/src/signals/routes/image-recognition.ts
@@ -45,13 +45,4 @@ export const imageRecognitionRoutes: readonly RouteEntry[] = [
     route: imageRecognitionContract.imageRecognition,
     handler: imageRecognitionHandler$,
   },
-  // Compatibility for immutable commit-addressed CLI artifacts that still call
-  // `/api/recognize`. Keep until the canonical CLI and first-party guidance
-  // have shipped, every pre-switch execution context has drained through queue,
-  // execution, and finalization, and supported external callers no longer use
-  // the old path. Remove in the evidence-backed cleanup phase tracked by #26929.
-  {
-    route: imageRecognitionContract.recognize,
-    handler: imageRecognitionHandler$,
-  },
 ];

--- a/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
@@ -43,7 +43,6 @@ function buildCommands(): Command[] {
     new Command("web-search"),
     new Command("social"),
     new Command("image-recognition"),
-    new Command("recognize"),
     new Command("finance"),
     new Command("seo"),
     new Command("banking"),
@@ -168,11 +167,7 @@ describe("registerCommands", () => {
     vi.stubEnv("OKOU_TOKEN", undefined);
 
     const prog = buildProgram();
-    expect(hiddenCommandNames(prog)).toEqual([
-      "mcp",
-      "image-recognition",
-      "recognize",
-    ]);
+    expect(hiddenCommandNames(prog)).toEqual(["mcp", "image-recognition"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(visibleCommandNames(prog)).toContain("browser");
   });
@@ -235,7 +230,6 @@ describe("registerCommands", () => {
       "web-search",
       "social",
       "image-recognition",
-      "recognize",
       "finance",
       "seo",
       "banking",
@@ -248,11 +242,7 @@ describe("registerCommands", () => {
 
     const prog = buildProgram();
 
-    expect(hiddenCommandNames(prog)).toEqual([
-      "mcp",
-      "image-recognition",
-      "recognize",
-    ]);
+    expect(hiddenCommandNames(prog)).toEqual(["mcp", "image-recognition"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(visibleCommandNames(prog)).toContain("browser");
   });
@@ -266,11 +256,7 @@ describe("registerCommands", () => {
 
     const prog = buildProgram();
 
-    expect(hiddenCommandNames(prog)).toEqual([
-      "mcp",
-      "image-recognition",
-      "recognize",
-    ]);
+    expect(hiddenCommandNames(prog)).toEqual(["mcp", "image-recognition"]);
     expect(registeredCommandNames(prog)).toContain("upgrade");
     expect(visibleCommandNames(prog)).toContain("browser");
   });
@@ -792,9 +778,7 @@ describe("registerCommands", () => {
     expect(registeredCommandNames(noTokenProgram)).toContain(
       "image-recognition",
     );
-    expect(registeredCommandNames(noTokenProgram)).toContain("recognize");
     expect(hiddenCommandNames(noTokenProgram)).toContain("image-recognition");
-    expect(hiddenCommandNames(noTokenProgram)).toContain("recognize");
     expect(buildHelpText()).not.toContain("Recognize an image?");
 
     const missingCapabilityToken = buildOkouToken({
@@ -808,7 +792,6 @@ describe("registerCommands", () => {
     expect(hiddenCommandNames(missingCapabilityProgram)).toContain(
       "image-recognition",
     );
-    expect(hiddenCommandNames(missingCapabilityProgram)).toContain("recognize");
     expect(
       buildHelpText(decodeSandboxTokenPayload(missingCapabilityToken)),
     ).not.toContain("Recognize an image?");
@@ -822,8 +805,6 @@ describe("registerCommands", () => {
     vi.stubEnv("OKOU_TOKEN", eligibleToken);
     const eligibleProgram = buildProgram();
     expect(visibleCommandNames(eligibleProgram)).toContain("image-recognition");
-    expect(visibleCommandNames(eligibleProgram)).not.toContain("recognize");
-    expect(hiddenCommandNames(eligibleProgram)).toContain("recognize");
     expect(buildHelpText(decodeSandboxTokenPayload(eligibleToken))).toContain(
       "Recognize an image?",
     );

--- a/turbo/apps/cli/src/__tests__/okou.test.ts
+++ b/turbo/apps/cli/src/__tests__/okou.test.ts
@@ -1,4 +1,4 @@
-import { Command, Help } from "commander";
+import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { program, registerCommands, registerRequestedCommand } from "../okou";
@@ -13,24 +13,13 @@ function buildOkouToken(capabilities: readonly string[]): string {
   return `vm0_sandbox_${header}.${body}.test-signature`;
 }
 
-function visibleCommandNames(prog: Command): string[] {
-  return new Help()
-    .visibleCommands(prog)
-    .map((command) => {
-      return command.name();
-    })
-    .filter((name) => {
-      return name !== "help";
-    });
-}
-
 describe("Okou CLI program", () => {
   registerCommands(program);
   const commandNames = program.commands.map((cmd) => {
     return cmd.name();
   });
   const canonicalCommandNames = commandNames.filter((name) => {
-    return !name.startsWith("__") && name !== "recognize";
+    return !name.startsWith("__");
   });
 
   afterEach(() => {
@@ -101,16 +90,6 @@ describe("Okou CLI program", () => {
     }
   });
 
-  it("should keep recognize registered but out of canonical command listings", () => {
-    vi.stubEnv("OKOU_TOKEN", buildOkouToken(["image-recognition:write"]));
-    const prog = new Command();
-    registerCommands(prog);
-
-    expect(commandNames).toContain("recognize");
-    expect(visibleCommandNames(prog)).toContain("image-recognition");
-    expect(visibleCommandNames(prog)).not.toContain("recognize");
-  });
-
   it("should not include infrastructure or utility commands", () => {
     const excludedCommands = [
       "org",
@@ -160,21 +139,9 @@ describe("Okou CLI lazy command loading", () => {
       expectedHelpCode: "commander.helpDisplayed",
     },
     {
-      label: "direct compatibility invocation",
-      argv: ["node", "okou", "recognize", "--help"],
-      expectedName: "recognize",
-      expectedHelpCode: "commander.helpDisplayed",
-    },
-    {
       label: "canonical help invocation",
       argv: ["node", "okou", "help", "image-recognition"],
       expectedName: "image-recognition",
-      expectedHelpCode: "commander.help",
-    },
-    {
-      label: "compatibility help invocation",
-      argv: ["node", "okou", "help", "recognize"],
-      expectedName: "recognize",
       expectedHelpCode: "commander.help",
     },
   ])(
@@ -207,4 +174,38 @@ describe("Okou CLI lazy command loading", () => {
       expect(helpOutput).toContain(`Usage: okou ${expectedName}`);
     },
   );
+
+  it.each([
+    {
+      label: "direct invocation",
+      argv: ["node", "okou", "recognize"],
+    },
+    {
+      label: "help invocation",
+      argv: ["node", "okou", "help", "recognize"],
+    },
+  ])("should reject removed $label", async ({ argv }) => {
+    vi.stubEnv("OKOU_TOKEN", buildOkouToken(["image-recognition:write"]));
+    let errorOutput = "";
+    const prog = new Command()
+      .name("okou")
+      .exitOverride()
+      .configureOutput({
+        writeErr: (text: string) => {
+          errorOutput += text;
+        },
+      });
+
+    await registerRequestedCommand(prog, argv);
+
+    expect(
+      prog.commands.map((registeredCommand) => {
+        return registeredCommand.name();
+      }),
+    ).not.toContain("recognize");
+    await expect(prog.parseAsync(argv)).rejects.toMatchObject({
+      code: "commander.unknownCommand",
+    });
+    expect(errorOutput).toContain("unknown command 'recognize'");
+  });
 });

--- a/turbo/apps/cli/src/commands/image-recognition/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/image-recognition/__tests__/index.test.ts
@@ -11,10 +11,7 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { server } from "../../../mocks/server";
-import {
-  imageRecognitionCommand,
-  imageRecognitionCompatibilityCommand,
-} from "../index";
+import { imageRecognitionCommand } from "../index";
 
 const PREPARE_URL = "http://localhost:3000/api/uploads/prepare";
 const COMPLETE_URL = "http://localhost:3000/api/uploads/complete";
@@ -243,102 +240,5 @@ describe("okou image-recognition command", () => {
     expect(helpOutput).toContain("okou image-recognition --file");
     expect(helpOutput).not.toContain("okou recognize --file");
     expect(helpOutput).toContain("Uses a fixed Okou-managed recognition model");
-  });
-});
-
-describe("okou recognize compatibility command", () => {
-  it("keeps okou recognize on the compatibility API path", async () => {
-    const fileId = randomUUID();
-    const filePath = join(tempDir, "compatibility.png");
-    const bytes = Buffer.from("compatibility-png");
-    writeFileSync(filePath, bytes);
-    installUploadHandlers(fileId, "compatibility.png", bytes.length);
-    let compatibilityCalls = 0;
-    let canonicalCalls = 0;
-    server.use(
-      http.post("http://localhost:3000/api/recognize", async ({ request }) => {
-        compatibilityCalls += 1;
-        expect(request.headers.get("authorization")).toBe("Bearer test-token");
-        await expect(request.json()).resolves.toStrictEqual({
-          fileId,
-          prompt: "Read the compatibility image",
-        });
-        return HttpResponse.json({
-          text: "Compatibility result",
-          metadata: { creditsCharged: 7 },
-        });
-      }),
-      http.post(IMAGE_RECOGNITION_URL, () => {
-        canonicalCalls += 1;
-        return HttpResponse.json({
-          text: "Canonical result",
-          metadata: { creditsCharged: 7 },
-        });
-      }),
-    );
-
-    await imageRecognitionCompatibilityCommand.parseAsync([
-      "node",
-      "okou",
-      "--file",
-      filePath,
-      "--prompt",
-      "  Read the compatibility image  ",
-    ]);
-
-    expect(compatibilityCalls).toBe(1);
-    expect(canonicalCalls).toBe(0);
-    expect(mockConsoleLog.mock.calls).toStrictEqual([["Compatibility result"]]);
-    expect(mockConsoleError).not.toHaveBeenCalled();
-    expect(mockExit).not.toHaveBeenCalled();
-  });
-
-  it("keeps compatibility validation ahead of upload", async () => {
-    const missing = join(tempDir, "missing.png");
-    let networkCalled = false;
-    server.use(
-      http.post(PREPARE_URL, () => {
-        networkCalled = true;
-        return HttpResponse.json({});
-      }),
-      http.post("http://localhost:3000/api/recognize", () => {
-        networkCalled = true;
-        return HttpResponse.json({});
-      }),
-    );
-
-    await imageRecognitionCompatibilityCommand.parseAsync([
-      "node",
-      "okou",
-      "--file",
-      missing,
-      "--prompt",
-      "describe",
-    ]);
-
-    expect(networkCalled).toBe(false);
-    expect(mockConsoleError.mock.calls.flat().join("\n")).toContain(
-      "no such file",
-    );
-    expect(mockConsoleLog).not.toHaveBeenCalled();
-  });
-
-  it("bounds compatibility help to the canonical command", () => {
-    let helpOutput = "";
-    imageRecognitionCompatibilityCommand.configureOutput({
-      writeOut: (text: string) => {
-        helpOutput += text;
-      },
-    });
-
-    imageRecognitionCompatibilityCommand.outputHelp();
-
-    expect(helpOutput).toContain(
-      "Compatibility command for okou image-recognition",
-    );
-    expect(helpOutput).toContain(
-      "Use okou image-recognition for new invocations",
-    );
-    expect(helpOutput).toContain("okou recognize --file");
   });
 });

--- a/turbo/apps/cli/src/commands/image-recognition/index.ts
+++ b/turbo/apps/cli/src/commands/image-recognition/index.ts
@@ -4,17 +4,12 @@ import {
   IMAGE_RECOGNITION_MAX_FILE_BYTES,
   IMAGE_RECOGNITION_MAX_PROMPT_CHARS,
   imageRecognitionMimeTypeSchema,
-  type ImageRecognitionRequest,
-  type ImageRecognitionResponse,
   type ImageRecognitionMimeType,
 } from "@okouai/api-contracts/contracts/image-recognition";
 import { Command } from "commander";
 
 import { ApiRequestError } from "../../lib/api/core/client-factory";
-import {
-  callImageRecognition,
-  callImageRecognitionCompatibility,
-} from "../../lib/api/domains/image-recognition";
+import { callImageRecognition } from "../../lib/api/domains/image-recognition";
 import {
   inferWebUploadContentType,
   uploadWebFile,
@@ -24,17 +19,6 @@ import { withErrorHandler } from "../../lib/command/with-error-handler";
 interface ImageRecognitionOptions {
   readonly file: string;
   readonly prompt: string;
-}
-
-type ImageRecognitionCaller = (
-  body: ImageRecognitionRequest,
-) => Promise<ImageRecognitionResponse>;
-
-interface ImageRecognitionCommandConfig {
-  readonly name: "image-recognition" | "recognize";
-  readonly description: string;
-  readonly compatibilityNotice?: string;
-  readonly call: ImageRecognitionCaller;
 }
 
 function validatePrompt(prompt: string): string {
@@ -92,16 +76,10 @@ function validateImageFile(file: string): ImageRecognitionMimeType {
   return parsed.data;
 }
 
-function createImageRecognitionCommand(
-  config: ImageRecognitionCommandConfig,
-): Command {
-  const compatibilityNotice = config.compatibilityNotice
-    ? `${config.compatibilityNotice}\n\n`
-    : "";
-
+function createImageRecognitionCommand(): Command {
   return new Command()
-    .name(config.name)
-    .description(config.description)
+    .name("image-recognition")
+    .description("Recognize one image through a managed multimodal model")
     .requiredOption("-f, --file <path>", "Local PNG, JPEG, or WebP image")
     .requiredOption("-p, --prompt <instruction>", "Recognition instruction")
     .action(
@@ -109,7 +87,7 @@ function createImageRecognitionCommand(
         const prompt = validatePrompt(options.prompt);
         const contentType = validateImageFile(options.file);
         const uploaded = await uploadWebFile(options.file, { contentType });
-        const response = await config.call({
+        const response = await callImageRecognition({
           fileId: uploaded.id,
           prompt,
         });
@@ -119,8 +97,8 @@ function createImageRecognitionCommand(
     .addHelpText(
       "after",
       `
-${compatibilityNotice}Example:
-  okou ${config.name} --file ./screenshot.png --prompt "Describe the error shown"
+Example:
+  okou image-recognition --file ./screenshot.png --prompt "Describe the error shown"
 
 Notes:
   - Available only in runs whose selected model does not support image input
@@ -129,22 +107,4 @@ Notes:
     );
 }
 
-export const imageRecognitionCommand = createImageRecognitionCommand({
-  name: "image-recognition",
-  description: "Recognize one image through a managed multimodal model",
-  call: callImageRecognition,
-});
-
-// Compatibility for immutable execution contexts whose guidance still invokes
-// `okou recognize`. Keep until canonical guidance has shipped, every pre-switch
-// context has drained through queue, execution, and finalization, and supported
-// external callers no longer use the old command. Remove in the evidence-backed
-// cleanup phase tracked by #26929.
-export const imageRecognitionCompatibilityCommand =
-  createImageRecognitionCommand({
-    name: "recognize",
-    description: "Compatibility command for okou image-recognition",
-    compatibilityNotice:
-      "Compatibility:\n  Use okou image-recognition for new invocations.",
-    call: callImageRecognitionCompatibility,
-  });
+export const imageRecognitionCommand = createImageRecognitionCommand();

--- a/turbo/apps/cli/src/lib/api/domains/image-recognition.ts
+++ b/turbo/apps/cli/src/lib/api/domains/image-recognition.ts
@@ -7,32 +7,14 @@ import { initClient } from "@okouai/api-contracts/contracts/trpc-contract";
 
 import { getClientConfig, handleError } from "../core/client-factory";
 
-type ImageRecognitionOperation = "imageRecognition" | "recognize";
-
-async function callImageRecognitionOperation(
-  operation: ImageRecognitionOperation,
+export async function callImageRecognition(
   body: ImageRecognitionRequest,
 ): Promise<ImageRecognitionResponse> {
   const config = await getClientConfig();
   const client = initClient(imageRecognitionContract, config);
-  const result =
-    operation === "imageRecognition"
-      ? await client.imageRecognition({ headers: {}, body })
-      : await client.recognize({ headers: {}, body });
+  const result = await client.imageRecognition({ headers: {}, body });
   if (result.status === 200) {
     return result.body;
   }
   handleError(result, "Failed to recognize image");
-}
-
-export async function callImageRecognition(
-  body: ImageRecognitionRequest,
-): Promise<ImageRecognitionResponse> {
-  return callImageRecognitionOperation("imageRecognition", body);
-}
-
-export async function callImageRecognitionCompatibility(
-  body: ImageRecognitionRequest,
-): Promise<ImageRecognitionResponse> {
-  return callImageRecognitionOperation("recognize", body);
 }

--- a/turbo/apps/cli/src/okou.ts
+++ b/turbo/apps/cli/src/okou.ts
@@ -71,17 +71,12 @@ const COMMAND_CAPABILITY_MAP: Record<
   "web-search": "web-search:read",
   social: "social:read",
   "image-recognition": "image-recognition:write",
-  recognize: "image-recognition:write",
   finance: "finance:read",
   seo: "seo:read",
   banking: "banking:read",
 };
 
-const RUN_ONLY_COMMANDS = new Set(["mcp", "image-recognition", "recognize"]);
-
-// Keep this compatibility name directly lazy-loadable without presenting it as
-// a peer canonical command. Its rollout removal gate is tracked by #26929.
-const IMAGE_RECOGNITION_COMPATIBILITY_COMMAND_NAME = "recognize";
+const RUN_ONLY_COMMANDS = new Set(["mcp", "image-recognition"]);
 
 const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
   {
@@ -388,14 +383,6 @@ const COMMAND_DEFINITIONS: readonly CommandDefinition[] = [
     },
   },
   {
-    name: IMAGE_RECOGNITION_COMPATIBILITY_COMMAND_NAME,
-    description: "Compatibility command for okou image-recognition",
-    load: async () => {
-      return (await import("./commands/image-recognition"))
-        .imageRecognitionCompatibilityCommand;
-    },
-  },
-  {
     name: "finance",
     description: "Query financial instruments through managed Okou finance",
     load: async () => {
@@ -454,9 +441,7 @@ function addCommandWithVisibility(
   cmd: Command,
   payload: SandboxTokenPayload | undefined,
 ): void {
-  const hidden =
-    cmd.name() === IMAGE_RECOGNITION_COMPATIBILITY_COMMAND_NAME ||
-    shouldHideCommand(cmd.name(), payload);
+  const hidden = shouldHideCommand(cmd.name(), payload);
   prog.addCommand(cmd, hidden ? { hidden: true } : {});
 }
 
@@ -504,10 +489,23 @@ export async function registerRequestedCommand(
   prog: Command,
   argv: string[] = process.argv,
 ): Promise<void> {
-  const requestedCommand = await loadRequestedCommand(
-    getRequestedCommandName(argv),
-  );
+  const requestedCommandName = getRequestedCommandName(argv);
+  const requestedCommand = await loadRequestedCommand(requestedCommandName);
   registerCommands(prog, requestedCommand ? [requestedCommand] : undefined);
+
+  if (
+    getNonOptionArgs(argv)[0] === "help" &&
+    requestedCommandName !== undefined &&
+    requestedCommand === undefined
+  ) {
+    prog
+      .command("help <command>", { hidden: true })
+      .action((commandName: string) => {
+        prog.error(`error: unknown command '${commandName}'`, {
+          code: "commander.unknownCommand",
+        });
+      });
+  }
 }
 
 function commandExampleIfVisible(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/image-recognition.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/image-recognition.test.ts
@@ -10,29 +10,17 @@ import {
 } from "../image-recognition";
 
 describe("image recognition contract", () => {
-  it("declares the canonical and compatibility API paths", () => {
+  it("declares only the canonical API operation", () => {
+    expect(Object.keys(imageRecognitionContract)).toStrictEqual([
+      "imageRecognition",
+    ]);
     expect({
-      canonical: {
-        method: imageRecognitionContract.imageRecognition.method,
-        path: imageRecognitionContract.imageRecognition.path,
-      },
-      compatibility: {
-        method: imageRecognitionContract.recognize.method,
-        path: imageRecognitionContract.recognize.path,
-      },
+      method: imageRecognitionContract.imageRecognition.method,
+      path: imageRecognitionContract.imageRecognition.path,
     }).toStrictEqual({
-      canonical: { method: "POST", path: "/api/image-recognition" },
-      compatibility: { method: "POST", path: "/api/recognize" },
+      method: "POST",
+      path: "/api/image-recognition",
     });
-    expect(imageRecognitionContract.recognize.headers).toBe(
-      imageRecognitionContract.imageRecognition.headers,
-    );
-    expect(imageRecognitionContract.recognize.body).toBe(
-      imageRecognitionContract.imageRecognition.body,
-    );
-    expect(imageRecognitionContract.recognize.responses).toBe(
-      imageRecognitionContract.imageRecognition.responses,
-    );
   });
 
   it("accepts one owned file id and a trimmed prompt", () => {

--- a/turbo/packages/api-contracts/src/contracts/image-recognition.ts
+++ b/turbo/packages/api-contracts/src/contracts/image-recognition.ts
@@ -63,10 +63,6 @@ export const imageRecognitionContract = c.router({
     ...imageRecognitionRoute,
     path: "/api/image-recognition",
   },
-  recognize: {
-    ...imageRecognitionRoute,
-    path: "/api/recognize",
-  },
 });
 
 export type ImageRecognitionContract = typeof imageRecognitionContract;


### PR DESCRIPTION
## Summary

- remove the drained `POST /api/recognize` contract operation and route registration while leaving `POST /api/image-recognition` unchanged
- remove the hidden `okou recognize` command, lazy registry entry, capability mapping, and compatibility API client path
- retain focused regressions proving both removed CLI invocation forms are unknown while canonical direct/help loading, guidance, and model eligibility remain unchanged

## Removal evidence

- implements the separately gated removal in #32371 after the drain and external-caller evidence recorded there and in #26929
- rebased onto `02b87392dba2e9d2c61ad34734ad3f091110d461`; a live inventory covered 24 open PRs and 332 changed-file entries with no overlap in the 10 removal files
- the final scoped caller search found no owned `/api/recognize` path or compatibility implementation symbol; remaining `recognize` literals are negative regressions, immutable changelogs, unrelated provider URLs, or ordinary English

## Verification

- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/image-recognition.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/image-recognition.test.ts`
- `pnpm -F @okouai/cli exec vitest run src/commands/image-recognition/__tests__/index.test.ts src/__tests__/okou.test.ts src/__tests__/command-capability-visibility.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t 'offers image recognition only for image-unsupported models'`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/model-provider-gateways.test.ts -t 'compiles a mapped gateway into the runner environment and inline firewall'`
- affected-workspace Prettier, lint, and type checks
- `pnpm knip`
- runtime API schema build plus Rust and Python binding regeneration with no generated diff
- API and CLI production builds
- built CLI smoke checks for canonical direct/help output and both removed unknown-command paths

Closes #32371
