### PR TITLE
refactor(runner): retire legacy blank status readers

### DIFF
--- a/.github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh
+++ b/.github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh
@@ -196,20 +196,17 @@ test_canonical_idle_field_behavior() {
   assert_line 'vm0_runner_status_collection_success 1'
 }
 
-test_blank_inventory_formats() {
+test_explicit_blank_inventory_with_overlap() {
   local format
   local idle
   local blank
-  for format in legacy explicit overlap; do
+  for format in explicit overlap; do
     reset_dirs
     mkdir -p "$runners_dir/current"
     idle="{\"sandbox_id\":\"$uuid_a\",\"reuse_key\":\"thread:exact\"}"
     blank="\"blank_sandboxes\":[{\"sandbox_id\":\"$uuid_b\"}],"
-    if [ "$format" != explicit ]; then
-      idle+=",{\"sandbox_id\":\"$uuid_b\",\"reuse_key\":\"__vm0_blank__:$uuid_b\"}"
-    fi
-    if [ "$format" = legacy ]; then
-      blank=""
+    if [ "$format" = overlap ]; then
+      idle+=",{\"sandbox_id\":\"$uuid_b\",\"reuse_key\":\"overlapping-mirror\"}"
     fi
     printf '%s\n' "{\"mode\":\"running\",$blank\"idle_sandboxes\":[$idle]}" \
       >"$runners_dir/current/status.json"
@@ -224,7 +221,7 @@ test_blank_inventory_formats() {
     assert_line 'vm0_runner_status_files{result="included"} 1'
     assert_line 'vm0_runner_status_collection_success 1'
     assert_stderr_empty
-    if grep -qE "sandbox_id|run_id|reuse_key|__vm0_blank__|$uuid_a|$uuid_b" "$output_file"; then
+    if grep -qE "sandbox_id|run_id|reuse_key|$uuid_a|$uuid_b" "$output_file"; then
       fail "blank inventory leaked identity-level data into metrics"
     fi
   done
@@ -232,8 +229,8 @@ test_blank_inventory_formats() {
 
 test_mixed_blank_inventory_deduplicates_by_uuid_and_lifecycle() {
   reset_dirs
-  mkdir -p "$runners_dir/legacy" "$runners_dir/explicit" "$runners_dir/stopped"
-  cat >"$runners_dir/legacy/status.json" <<EOF
+  mkdir -p "$runners_dir/draining" "$runners_dir/current" "$runners_dir/stopped"
+  cat >"$runners_dir/draining/status.json" <<EOF
 {
   "mode": "draining",
   "active_runs": [
@@ -242,14 +239,14 @@ test_mixed_blank_inventory_deduplicates_by_uuid_and_lifecycle() {
     {"sandbox_id":"$uuid_e","phase":"future-phase"}
   ],
   "idle_sandboxes": [
-    {"sandbox_id":"$uuid_a","reuse_key":"__vm0_blank__:$uuid_a"},
     {"sandbox_id":"$uuid_c","reuse_key":"thread:exact"},
-    {"sandbox_id":"$uuid_g","reuse_key":"__vm0_blank__:$uuid_h"},
+    {"sandbox_id":"$uuid_g","reuse_key":"thread:another-exact"},
     {"sandbox_id":"$uuid_h"}
-  ]
+  ],
+  "blank_sandboxes": [{"sandbox_id":"$uuid_a"}]
 }
 EOF
-  cat >"$runners_dir/explicit/status.json" <<EOF
+  cat >"$runners_dir/current/status.json" <<EOF
 {
   "mode": "running",
   "idle_sandboxes": [{"sandbox_id":"$uuid_f","reuse_key":"overlap"}],
@@ -463,7 +460,7 @@ test_playbook_provisions_collector_identity_and_cadence() {
 test_missing_and_empty_runner_roots_emit_zero_metrics
 test_aggregates_current_and_future_statuses
 test_canonical_idle_field_behavior
-test_blank_inventory_formats
+test_explicit_blank_inventory_with_overlap
 test_mixed_blank_inventory_deduplicates_by_uuid_and_lifecycle
 test_malformed_blank_inventory_invalidates_only_its_status_file
 test_invalid_files_publish_partial_metrics

--- a/ansible/files/vm0-monitoring-runner-status-collect.py
+++ b/ansible/files/vm0-monitoring-runner-status-collect.py
@@ -77,17 +77,8 @@ def parse_status(path: Path) -> tuple[str, list[tuple[str, str]]]:
         parse_sandbox_entry(entry)[1]
         for entry in parse_collection(status, "blank_sandboxes")
     }
-    idle_entries = [
-        parse_sandbox_entry(entry)
-        for entry in parse_collection(status, "idle_sandboxes")
-    ]
-    # Temporary input compatibility; remove in #32084 once supported writers
-    # and retained live status files no longer use synthetic blank reuse keys.
-    for idle, sandbox_id in idle_entries:
-        if idle.get("reuse_key") == f"__vm0_blank__:{idle['sandbox_id']}":
-            blank_ids.add(sandbox_id)
-
-    for _, sandbox_id in idle_entries:
+    for entry in parse_collection(status, "idle_sandboxes"):
+        _, sandbox_id = parse_sandbox_entry(entry)
         if sandbox_id not in blank_ids:
             sandbox_states.append((sandbox_id, "idle"))
     sandbox_states.extend((sandbox_id, "blank") for sandbox_id in blank_ids)

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -1014,18 +1014,11 @@ async fn read_status(base_dir: &Path) -> Option<StatusInfo> {
         .await
         .ok()
         .flatten()?;
-    let mut blank_ids: HashSet<&str> = file
+    let blank_ids: HashSet<&str> = file
         .blank_sandboxes
         .iter()
         .map(|sandbox| sandbox.sandbox_id.as_str())
         .collect();
-    // Temporary input compatibility for pre-split writers. Remove in #32084
-    // after supported writers and retained live status files have migrated.
-    for sandbox in file.idle_sandboxes() {
-        if sandbox.reuse_key.strip_prefix("__vm0_blank__:") == Some(sandbox.sandbox_id.as_str()) {
-            blank_ids.insert(&sandbox.sandbox_id);
-        }
-    }
     let idle_sandboxes = file
         .idle_sandboxes()
         .iter()
@@ -1795,20 +1788,20 @@ printf '%s\n' \
     }
 
     #[tokio::test]
-    async fn read_status_does_not_infer_blank_from_unrelated_prefix_keys() {
+    async fn read_status_preserves_exact_inventory_without_blank_collection() {
         let dir = tempfile::tempdir().unwrap();
         let content = serde_json::json!({
             "mode": "running",
             "started_at": "2026-01-01T00:00:00.000Z",
             "idle_sandboxes": [
-                {"sandbox_id": "S1", "reuse_key": "__vm0_blank__:different-id"},
-                {"sandbox_id": "S2", "reuse_key": "thread:__vm0_blank__:S2"},
+                {"sandbox_id": "S1", "reuse_key": "thread:exact"},
             ],
-            "blank_sandboxes": [],
         });
         std::fs::write(dir.path().join("status.json"), content.to_string()).unwrap();
         let status = read_status(dir.path()).await.unwrap();
-        assert_eq!(status.idle_sandboxes.len(), 2);
+        assert_eq!(status.idle_sandboxes.len(), 1);
+        assert_eq!(status.idle_sandboxes[0].sandbox_id, "S1");
+        assert_eq!(status.idle_sandboxes[0].reuse_key, "thread:exact");
         assert!(status.blank_sandboxes.is_empty());
     }
 
@@ -1822,7 +1815,7 @@ printf '%s\n' \
                 "run_id": "R1", "sandbox_id": "S1", "phase": "running",
                 "phase_started_at": "2026-01-01T00:00:00.000Z",
             }],
-            "idle_sandboxes": [{"sandbox_id": "S1", "reuse_key": "__vm0_blank__:S1"}],
+            "idle_sandboxes": [{"sandbox_id": "S1", "reuse_key": "overlapping-mirror"}],
             "blank_sandboxes": [{"sandbox_id": "S1"}],
         });
         std::fs::write(dir.path().join("status.json"), content.to_string()).unwrap();
@@ -3251,14 +3244,8 @@ printf '%s\n' \
     }
 
     #[tokio::test]
-    async fn report_distinguishes_owned_blank_inventory_across_status_versions() {
+    async fn report_distinguishes_owned_blank_inventory_with_overlapping_entries() {
         for parked in [
-            serde_json::json!({
-                "idle_sandboxes": [
-                    {"reuse_key": "thread:exact", "sandbox_id": "exact-id"},
-                    {"reuse_key": "__vm0_blank__:blank-id", "sandbox_id": "blank-id"},
-                ],
-            }),
             serde_json::json!({
                 "idle_sandboxes": [{"reuse_key": "thread:exact", "sandbox_id": "exact-id"}],
                 "blank_sandboxes": [{"sandbox_id": "blank-id"}],
@@ -3266,7 +3253,6 @@ printf '%s\n' \
             serde_json::json!({
                 "idle_sandboxes": [
                     {"reuse_key": "thread:exact", "sandbox_id": "exact-id"},
-                    {"reuse_key": "__vm0_blank__:blank-id", "sandbox_id": "blank-id"},
                     {"reuse_key": "overlapping-mirror", "sandbox_id": "blank-id"},
                 ],
                 "blank_sandboxes": [{"sandbox_id": "blank-id"}, {"sandbox_id": "blank-id"}],

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -242,8 +242,7 @@ blanks in `blank_sandboxes`, omitting each collection when empty. Exact entries
 contain `reuse_key` and `sandbox_id`; blank entries contain only `sandbox_id`,
 never a run ID or tenant reuse identity. Both collections are captured from one
 pool revision and applied together, including preparing/running ownership
-transitions. Older blank-enabled writers encode blanks in `idle_sandboxes`
-using `reuse_key: "__vm0_blank__:<sandbox_id>"`. The migration tracked by
+transitions. The migration tracked by
 [#32071](https://github.com/vm0-ai/vm0/issues/32071) separates these identities
 without changing shared pool lifecycle rules.
 
@@ -253,16 +252,14 @@ mutation revision; they are not independent pools. Exact lookup, exact-first
 restoration, blank-first pressure eviction and conditional exact aging retain
 their existing policies. Heartbeat reuse inventories contain exact entries only.
 
-The reader bridge ([#32082](https://github.com/vm0-ai/vm0/issues/32082)) lets doctor
-and the host collector also read `blank_sandboxes: [{"sandbox_id": "..."}]`.
-Missing collections default to empty; malformed present collections are invalid.
-Legacy recognition is confined to input normalization and requires the entire
-reuse key to match the reserved prefix plus that entry's sandbox ID. Other
-prefix-like reuse keys remain exact. Explicit blank IDs suppress same-file idle
-mirrors, and duplicate blank IDs count once. Doctor lists exact reuse keys under
-Idle and sandbox-ID-only entries under Blank, recognizes both as owned processes,
-and never treats an unclaimed blank as an active job. Active mappings take
-priority over duplicate blanks. The bridge release itself did not change the writer.
+Doctor and the host collector read `blank_sandboxes: [{"sandbox_id": "..."}]`
+directly. Missing collections default to empty, including exact-only historical
+statuses without `blank_sandboxes`; malformed present collections are invalid.
+Blank identity is never inferred from an idle reuse key. Explicit blank IDs
+suppress same-file idle mirrors, and duplicate blank IDs count once. Doctor lists
+exact reuse keys under Idle and sandbox-ID-only entries under Blank, recognizes
+both as owned processes, and never treats an unclaimed blank as an active job.
+Active mappings take priority over duplicate blanks.
 
 The collector exports `vm0_runner_sandboxes{state="blank"}` (including zero).
 `state="idle"` now counts exact inventory only; total parked inventory is the
@@ -278,31 +275,34 @@ only `idle` will now show exact inventory; this change does not edit dashboards.
 
 The collector is installed by host provisioning, independently of Runner
 releases. Both its systemd timer and Alloy textfile scrape run every 15 seconds.
-Before merging/releasing the explicit-only writer in
-[#32083](https://github.com/vm0-ai/vm0/issues/32083), record the following evidence
-on its PR:
 
-- Every supported host has the bridge-capable doctor and collector installed;
-  record the Runner release/commit and installed collector revision or checksum.
-- A successfully deployed reader release contains commit
-  `febec8a3399be74b0f14a89cb9f42e39dd5ce69f` (PR #32092).
-- Supported rollback targets include that reader. The production rollback
-  resolver checks ancestry for both the target commit and the resolved Runner
-  artifact tag, because a newer API release can reuse an older Runner artifact.
+The reader-first rollout delivered doctor and collector support in
+[#32092](https://github.com/vm0-ai/vm0/pull/32092), followed by the explicit writer in
+[#32269](https://github.com/vm0-ai/vm0/pull/32269). The first explicit-writer release
+is `runner-rs-v0.188.0`, commit `f4b9a172cf76e04b845f2337c14cf87831c82adb`.
+Legacy blank input recognition is retired by
+[#32084](https://github.com/vm0-ai/vm0/issues/32084), based on read-only production
+verification on 2026-09-07 at 14:20 UTC:
 
-These are deployment gates, not claims established by repository tests. The
-target Runner's doctor runs during rollback, so old-reader/new-writer is not a
-supported combination. Bridge readers support old, new and mixed writers
-during draining. Neither merging the bridge nor releasing Runner proves the
-independent collector is installed. Keep the writer PR unmerged until the fleet
-evidence is recorded; no production rollout is authorized by the implementation.
+- `prod-11.gcp.vm3.ai`, `prod-12.gcp.vm3.ai` and `prod-13.gcp.vm3.ai` each had
+  `v0.188.3` running and `v0.188.2` draining. Both releases contain explicit-writer
+  commit `bd9cddcf6719c90848ed4ec497baca8cfd3191ea`. The remaining draining release
+  therefore does not require legacy input recognition.
+- The legacy writers were stopped. All 18 retained versioned status files parsed
+  successfully and contained no synthetic blank entries.
+- Each installed collector matched repository SHA-256
+  `560cb9b86e29357249582273253716f48be63df93cd6f04f12dabb4ffa499f42`, and each
+  collector timer was active. This is the pre-cleanup, bridge-capable collector
+  checksum, not the checksum of the retired-reader implementation.
 
-Remove legacy prefix recognition only under
-[#32084](https://github.com/vm0-ai/vm0/issues/32084), after all supported live and
-rollback writers publish explicit blanks, old versions have drained, and relevant
-retained non-stopped status files no longer contain synthetic entries. Record
-deployment/file evidence and enforce rollback eligibility before removing it.
-Keep absent-collection support for genuinely exact-only historical status files.
+The explicit retirement decision excludes rollback compatibility with legacy
+writers; this cleanup does not change rollback resolution or promise that those
+writers remain readable as blank inventory. Current explicit writers work with
+both bridge and post-cleanup readers during deployment. No production process or
+status file was modified to establish the evidence. Verify the final doctor and
+independently provisioned collector rollout before closing delivery parent
+[#32071](https://github.com/vm0-ai/vm0/issues/32071); a merged PR alone does not
+establish that deployment.
 
 The proxy registry and embedded mitm-addon are also a runner-private contract.
 The runner binary embeds the addon sources, recreates the addon directory and


### PR DESCRIPTION
## Summary

Closes #32084. Parent: #32071 (final implementation slice; parent remains open).
Prerequisites #32082/#32092 and #32083/#32269 are merged.

- Remove legacy blank reuse-key recognition from doctor and the host collector. Blank identity now comes only from explicit ID-only `blank_sandboxes`.
- Preserve exact-only omitted collections, same-file overlap suppression, active-claim ownership/recheck, UUID/lifecycle deduplication, malformed-input reporting and all metric names/labels.
- Remove legacy-only fixtures and use explicit current-format fixtures for the existing ownership/deduplication assertions. Do not retain negative tests against removed behavior.
- Replace stale rollout instructions with the verified production evidence and the user's explicit rollback exclusion. The old brand-manifest exception mentioned in the issue was already absent.

## Retirement evidence

Read-only SSH verification at 2026-09-07 14:20 UTC on prod-11.gcp.vm3.ai, prod-12.gcp.vm3.ai and prod-13.gcp.vm3.ai found v0.188.3 running and v0.188.2 draining on every host. Both release tags contain writer commit bd9cddcf6719c90848ed4ec497baca8cfd3191ea (#32269); the first explicit writer is runner-rs-v0.188.0 (f4b9a172cf76e04b845f2337c14cf87831c82adb). All 18 retained versioned status files parsed successfully and contained zero synthetic blank entries. v0.187.0 and v0.187.1 statuses were stopped. Each installed collector matched repository SHA-256 560cb9b86e29357249582273253716f48be63df93cd6f04f12dabb4ffa499f42 and its timer was active. This verifies the production fleet, not every development host or a future deployment.

The user explicitly chose not to consider rollback for this cleanup. This PR does not modify rollback resolution or promise legacy-writer compatibility. Current running and draining writers work with both bridge and post-cleanup readers. No production process, file or deployment was changed during verification. Parent #32071 still needs final reader/collector rollout verification after merge; this child must not close it.

## Scope and risk

Only four files change: doctor, the Python collector, its shell regressions and deployment documentation. No writer, pool/lifecycle policy, run startup, API/heartbeat, guest, database, timeout, feature flag or CI-sharding changes.

The principal regression risk is losing current-format ownership or deduplication while deleting legacy fixtures. Those assertions remain, including explicit blank/idle overlap, duplicate UUID spellings, active/preparing/unknown precedence, stopped/malformed files and exact-only absent blank collections. Collector publication, permissions, symlink checks and bounded labels are unchanged.

## Validation

Passed on the submitted worktree:

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo test --profile local -p runner --all-features cmd::doctor:: -- --quiet`: 86 passed, 0 failed; one pre-existing ignored child entry unchanged.
- `cd crates && cargo clippy --profile local -p runner --all-targets --all-features`
- `cd crates && cargo doc --profile local -p runner --all-features --no-deps`
- `cd crates && cargo test --profile local -p runner --all-targets --all-features -- --quiet`: 3,541 runner tests plus one guest inventory integration test passed; 25 pre-existing ignored entries unchanged. No skip/ignore annotations were added.
- `bash .github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh`
- `bash -n .github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh`
- `shellcheck .github/scripts/tests/vm0-monitoring-runner-status-collect-test.sh`
- Python AST syntax validation of the collector.
- `cd turbo && pnpm exec prettier --check ../docs/deployment-compatibility.md`
- `git diff --check`

The required post-pull `pnpm -F @okouai/db db:migrate` environment step failed with `ECONNREFUSED 127.0.0.1:5432`. No database/Turbo runtime code changes in this PR; the applicable Rust and collector tests do not depend on PostgreSQL. Unrelated Turbo/mitm-addon suites were not run. No production rollout or merge has been performed.
