### PR TITLE
fix(runner): prevent premature network log drain acknowledgement

### DIFF
--- a/crates/runner/src/network_log_drain.rs
+++ b/crates/runner/src/network_log_drain.rs
@@ -344,11 +344,15 @@ where
 /// dropping the future preserves the reader state for the normal loop. This is
 /// the producer-owned barrier used to drain complete lines that are immediately
 /// observable to the runner reader task without sleeping.
+///
+/// Exclude Tokio's cooperative budget only from this probe: a scheduler yield
+/// must not masquerade as an empty input boundary. The drain loop still awaits
+/// callbacks normally and yields after each bounded slice of ready lines.
 pub(crate) fn poll_next_line_ready<R>(lines: &mut Lines<R>) -> std::io::Result<ReadyLine>
 where
     R: AsyncBufRead + Unpin,
 {
-    let mut next = std::pin::pin!(lines.next_line());
+    let mut next = std::pin::pin!(tokio::task::unconstrained(lines.next_line()));
     let mut cx = Context::from_waker(noop_waker_ref());
     match Future::poll(next.as_mut(), &mut cx) {
         Poll::Ready(Ok(Some(line))) => Ok(ReadyLine::Line(line)),
@@ -357,6 +361,9 @@ where
         Poll::Pending => Ok(ReadyLine::Pending),
     }
 }
+
+#[cfg(test)]
+mod cooperative_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/runner/src/network_log_drain/cooperative_tests.rs
+++ b/crates/runner/src/network_log_drain/cooperative_tests.rs
@@ -1,0 +1,133 @@
+use super::*;
+
+use std::sync::Mutex;
+
+use serde_json::json;
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+use crate::network_log_manager::NetworkLogManager;
+
+async fn exhaust_budget() {
+    while tokio::task::coop::has_budget_remaining() {
+        tokio::task::consume_budget().await;
+    }
+}
+
+#[tokio::test]
+async fn exhausted_budget_drain_awaits_callbacks_and_preserves_partial_input() {
+    let (mut writer, reader) = UnixStream::pair().unwrap();
+    let input = format!(
+        "{}partial",
+        "line\n".repeat(READY_LINE_DRAIN_SLICE_SIZE + 1)
+    );
+    writer.write_all(input.as_bytes()).await.unwrap();
+    reader.readable().await.unwrap();
+    // Force real I/O refills between lines, rather than draining only BufReader's buffer.
+    let mut lines = BufReader::with_capacity(4, reader).lines();
+    let cancel = CancellationToken::new();
+    let (ack, mut ack_rx) = oneshot::channel();
+    let (release, callback_release) = oneshot::channel();
+    let mut callback_release = Some(callback_release);
+    let handled = Arc::new(Mutex::new(Vec::new()));
+    let mut on_line = |line| {
+        let callback_release = callback_release.take();
+        let handled = handled.clone();
+        async move {
+            if let Some(callback_release) = callback_release {
+                // The readiness probe must restore the caller's exhausted budget,
+                // not disable cooperative scheduling for the callback as well.
+                assert!(!tokio::task::coop::has_budget_remaining());
+                callback_release.await.unwrap();
+            }
+            handled.lock().unwrap().push(line);
+            exhaust_budget().await;
+        }
+    };
+
+    {
+        let mut drain = std::pin::pin!(process_drain_request(
+            &mut lines,
+            &cancel,
+            &mut on_line,
+            NetworkLogDrainRequest { ack },
+        ));
+        exhaust_budget().await;
+        let mut cx = Context::from_waker(noop_waker_ref());
+        assert!(drain.as_mut().poll(&mut cx).is_pending());
+        assert!(handled.lock().unwrap().is_empty());
+        assert_eq!(ack_rx.try_recv(), Err(oneshot::error::TryRecvError::Empty));
+
+        release.send(()).unwrap();
+        assert!(matches!(
+            timeout(Duration::from_secs(1), drain).await.unwrap(),
+            DrainReadyLinesOutcome::Continue
+        ));
+    }
+
+    ack_rx.await.unwrap();
+    assert_eq!(
+        *handled.lock().unwrap(),
+        vec!["line"; READY_LINE_DRAIN_SLICE_SIZE + 1]
+    );
+    // The still-open socket is genuinely pending, but its incomplete line survives.
+    writer.write_all(b"-rest\n").await.unwrap();
+    assert_eq!(lines.next_line().await.unwrap().unwrap(), "partial-rest");
+}
+
+#[tokio::test]
+async fn close_for_upload_keeps_prequeued_row_when_drain_budget_is_exhausted() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("network.jsonl");
+    let manager = NetworkLogManager::new();
+    let session = manager.register_source_ip("10.200.0.2", path.clone()).await;
+    let row = json!({"type": "dns", "host": "prequeued.test"});
+    let (mut writer, reader) = UnixStream::pair().unwrap();
+    writer
+        .write_all(format!("{row}\n").as_bytes())
+        .await
+        .unwrap();
+    reader.readable().await.unwrap();
+    let mut lines = BufReader::new(reader).lines();
+    let (producer, mut drain_rx) = NetworkLogDrainProducer::channel("dns");
+    let coordinator = NetworkLogDrainCoordinator::new(vec![producer]);
+    let cancel = CancellationToken::new();
+    let mut on_line = |line: String| {
+        let manager = manager.clone();
+        async move {
+            assert!(
+                manager
+                    .append_for_ip("10.200.0.2", serde_json::from_str(&line).unwrap())
+                    .await
+            );
+        }
+    };
+
+    let (observation, outcome) = tokio::join!(
+        session.close_for_upload(RunId::nil(), &coordinator),
+        async {
+            let request = drain_rx.recv().await.unwrap();
+            // Recreate the budget boundary after receiving the actual close request,
+            // without depending on randomized select ordering in the reader loop.
+            exhaust_budget().await;
+            process_drain_request(&mut lines, &cancel, &mut on_line, request).await
+        }
+    );
+
+    assert!(matches!(outcome, DrainReadyLinesOutcome::Continue));
+    assert_eq!(observation.drain_status("dns"), "acknowledged");
+    assert!(!observation.writer_failed());
+    let content = std::fs::read_to_string(&path).unwrap();
+    let rows: Vec<serde_json::Value> = content
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(rows, vec![row]);
+    assert!(
+        !manager
+            .append_for_ip("10.200.0.2", json!({"type": "dns", "host": "late.test"}))
+            .await
+    );
+    // Keep the producer open until after close; EOF must not make this test pass.
+    drop(writer);
+}


### PR DESCRIPTION
## Summary

- Prevent a Tokio cooperative-budget yield from being mistaken for an empty DNS/kmsg input stream and prematurely acknowledging the network-log drain barrier.
- Apply `tokio::task::unconstrained` only to the single `next_line` readiness poll. Preserve awaited callbacks, the 64-line fairness/cancellation boundary, abandoned-request checks, and existing timeout/EOF/error behavior.
- Add deterministic regressions with real Unix sockets, Tokio buffering, the close coordinator, attribution manager, and real JSONL files. Cover exhausted budgets on entry and between lines, callback completion, multiple slices, partial-line preservation, and prequeued rows surviving close.

Closes #32290

## Scope and compatibility

Runner-internal only: no API, protocol, schema, log-field, dependency, migration, or feature-flag changes. This still covers only rows observable to the runner reader, not data that producers have not emitted or new readiness events not yet observed. Fairness remains line-count-based; this does not add a byte/time limit for pathological individual lines.

## Validation

Both new regressions failed against the unchanged production implementation: premature completion before the callback, and an acknowledged close with no persisted prequeued row. Both pass with the fix.

From `crates/`, with `CARGO_BUILD_JOBS=4` for Cargo builds:

- `cargo test --profile local -p runner --bin runner network_log_drain -- --nocapture`: 17 passed.
- `cargo test --profile local -p runner -- --test-threads=4`: 3540 main-binary tests and 1 guest-inventory integration test passed; 25 existing ignored entries unchanged, no filtered tests.
- `cargo fmt -p runner -- --check`: passed.
- `cargo clippy --profile local -p runner --all-targets --all-features`: passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local -p runner --no-deps`: passed.
- `cargo run --profile local -p xtask -- check-rust-path-attributes`: passed.
- `git diff --check`: passed.

No test skipping or timeout increases. Unrelated Turbo/Python suites were not selected. Production load behavior and remote runner E2E remain for CI/deployment verification.
