### PR TITLE
feat(cli): diagnose admitted custom connector targets

### DIFF
--- a/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check-custom.test.ts
@@ -1,0 +1,396 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  connectorCheckRequestBodySchema,
+  type ConnectorCheckRequestBody,
+  type ConnectorCheckTargetAwareDiagnosticResult,
+} from "@okouai/api-contracts/contracts/connector-check";
+import type { ConnectorAccountInspectionResult } from "@okouai/api-contracts/contracts/connector-accounts";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../mocks/server";
+import { customConnector } from "../../__tests__/helpers/custom-connectors";
+import {
+  stubRunConnectorAccountInspection,
+  writeRunConnectorAccountContext,
+} from "../../__tests__/helpers/run-connector-accounts";
+import { checkConnectorCommand } from "../check";
+
+const ORIGIN = "http://localhost:3000";
+const CUSTOM_ID = "33333333-3333-4333-8333-333333333333";
+const ACCOUNT_ID = "44444444-4444-4444-8444-444444444444";
+const DEFAULT_ACCOUNT_ID = "55555555-5555-4555-8555-555555555555";
+const TARGET = { kind: "custom", customConnectorId: CUSTOM_ID } as const;
+const REQUEST_URL = "https://api.acme.test/pinned/items";
+
+type ResolvedUrl = Extract<
+  ConnectorCheckTargetAwareDiagnosticResult,
+  { outcome: "resolved"; mode: "url" }
+>;
+type AvailableAccount = Extract<
+  ConnectorAccountInspectionResult,
+  { kind: "available" }
+>;
+
+function resolvedCustom(permission?: ResolvedUrl["permission"]): ResolvedUrl {
+  return {
+    outcome: "resolved",
+    mode: "url",
+    connector: {
+      target: TARGET,
+      label: "Earlier display name",
+      visibility: "available",
+      credentialResolution: "network-boundary",
+    },
+    environmentNames: null,
+    run: { status: "configured", bases: ["https://api.acme.test/pinned"] },
+    method: "POST",
+    base: "https://api.acme.test/pinned",
+    relativePath: "/items",
+    permission: permission ?? {
+      kind: "matched",
+      permissions: [
+        {
+          name: "items:write",
+          policy: { outcome: "deny", basis: "deny-list" },
+        },
+      ],
+    },
+  };
+}
+
+function account(
+  connectionStatus: AvailableAccount["connectionStatus"] = "connected",
+): AvailableAccount {
+  return {
+    kind: "available",
+    target: TARGET,
+    connectionId: ACCOUNT_ID,
+    authMethod: "manual",
+    displayName: "Run-selected account",
+    externalId: "selected-external-id",
+    externalUsername: null,
+    externalEmail: null,
+    connectionStatus,
+    reconnectReason:
+      connectionStatus === "reconnect-required"
+        ? "authorization_expired_or_revoked"
+        : null,
+  };
+}
+
+describe("custom connector URL diagnostics", () => {
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("process.exit called");
+  });
+  const requests: ConnectorCheckRequestBody[] = [];
+  let directory = "";
+  let contextPath = "";
+
+  function stubDiagnostic(
+    result: ConnectorCheckTargetAwareDiagnosticResult,
+  ): void {
+    server.use(
+      http.post(
+        `${ORIGIN}/api/connectors/diagnostics/check`,
+        async ({ request }) => {
+          requests.push(
+            connectorCheckRequestBodySchema.parse(await request.json()),
+          );
+          return HttpResponse.json(result);
+        },
+      ),
+    );
+  }
+
+  function output(): string {
+    return log.mock.calls.flat().join("\n");
+  }
+
+  async function check(...extraArgs: string[]): Promise<void> {
+    await checkConnectorCommand.parseAsync([
+      "node",
+      "okou",
+      "--url",
+      REQUEST_URL,
+      "--method",
+      "POST",
+      ...extraArgs,
+    ]);
+  }
+
+  beforeEach(() => {
+    requests.length = 0;
+    directory = mkdtempSync(join(tmpdir(), "okou-custom-check-"));
+    contextPath = join(directory, "accounts.json");
+    vi.stubEnv("OKOU_API_BACKEND_URL", ORIGIN);
+    vi.stubEnv("OKOU_TOKEN", "test-token");
+    vi.stubEnv("OKOU_AGENT_ID", "agent-1");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-1");
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", contextPath);
+    writeRunConnectorAccountContext(contextPath, [
+      { ...TARGET, connectionId: ACCOUNT_ID },
+    ]);
+    stubDiagnostic(resolvedCustom());
+    server.use(
+      http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+        return HttpResponse.json(
+          customConnector({
+            id: CUSTOM_ID,
+            displayName: "Renamed Acme",
+            slug: "_mutable-new-slug",
+            prefixTemplates: ["https://api.acme.test/new-default"],
+            connected: false,
+          }),
+        );
+      }),
+      stubRunConnectorAccountInspection([
+        account(),
+        {
+          ...account(),
+          connectionId: DEFAULT_ACCOUNT_ID,
+          displayName: "Default sibling",
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("selects a stable UUID and displays current metadata with the pinned account and bases", async () => {
+    await check("--connector", `custom:${CUSTOM_ID}`);
+
+    expect(requests).toStrictEqual([
+      { mode: "url", method: "POST", url: REQUEST_URL, target: TARGET },
+    ]);
+    expect(output()).toContain(
+      `Renamed Acme connector (custom UUID: ${CUSTOM_ID})`,
+    );
+    expect(output()).toContain(`Connection ID: ${ACCOUNT_ID}`);
+    expect(output()).toContain("Run-selected account");
+    expect(output()).toContain(
+      "The account selected for this run is connected.",
+    );
+    expect(output()).toContain("https://api.acme.test/pinned");
+    expect(output()).toContain("Environment names: unavailable");
+    expect(output()).toContain("current intended state");
+    expect(output()).toContain('"items:write" is in the deny list');
+    expect(output()).toContain(
+      "[Connectors](http://localhost:3000/connectors)",
+    );
+    expect(output()).toContain("review Permissions");
+    expect(output()).toContain(`--connector 'custom:${CUSTOM_ID}'`);
+    expect(output()).not.toMatch(
+      /Earlier display name|Default sibling|new-default|secrets\.apiKey|Bearer|_mutable-new-slug/,
+    );
+    expect(output()).not.toMatch(
+      /permission-request|connectorSlug=|callback-prompt|connected, active, and authorized/,
+    );
+  });
+
+  it("does not substitute a healthy default for a reconnect-required run account", async () => {
+    server.use(
+      stubRunConnectorAccountInspection([account("reconnect-required")]),
+      http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+        return HttpResponse.json(
+          customConnector({
+            id: CUSTOM_ID,
+            connected: true,
+            missingRequiredFields: [],
+          }),
+        );
+      }),
+    );
+    await check();
+
+    expect(requests).toStrictEqual([
+      {
+        mode: "url",
+        method: "POST",
+        url: REQUEST_URL,
+        includeCustomConnectors: true,
+      },
+    ]);
+    expect(output()).toContain(`Connection ID: ${ACCOUNT_ID}`);
+    expect(output()).toContain(
+      "account selected for this run needs to be reconnected",
+    );
+    expect(output()).not.toContain(
+      "account selected for this run is connected",
+    );
+  });
+
+  it("retains a deleted pinned account identity without suggesting a sibling account", async () => {
+    server.use(stubRunConnectorAccountInspection([]));
+    await check();
+    expect(output()).toContain(`Account used by this run: ${ACCOUNT_ID}`);
+    expect(output()).toContain(
+      "Current account metadata is unavailable or deleted",
+    );
+    expect(output()).not.toMatch(
+      /Default sibling|\/connectors\/[^\s]+\/connect|is connected/,
+    );
+  });
+
+  it("does not infer an account when run account context is missing", async () => {
+    vi.stubEnv("OKOU_CONNECTOR_ACCOUNT_CONTEXT_FILE", "");
+    await check();
+    expect(output()).toContain("started without connector account context");
+    expect(output()).not.toContain("is connected");
+  });
+
+  it("reports a definition removed after diagnosis without reusing its stale display name", async () => {
+    server.use(
+      http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+        return HttpResponse.json(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }),
+    );
+    await check();
+    expect(output()).toContain(`custom UUID: ${CUSTOM_ID}`);
+    expect(output()).toContain(
+      "Current custom connector metadata is unavailable or deleted",
+    );
+    expect(output()).not.toContain("Earlier display name");
+  });
+
+  it("propagates metadata read failures rather than reporting the connector as deleted", async () => {
+    server.use(
+      http.get(`${ORIGIN}/api/custom-connectors/${CUSTOM_ID}`, () => {
+        return HttpResponse.json(
+          { error: { message: "Metadata failed", code: "INTERNAL" } },
+          { status: 500 },
+        );
+      }),
+    );
+    await expect(check()).rejects.toThrow("process.exit called");
+    expect(error.mock.calls.flat().join("\n")).toContain("Metadata failed");
+    expect(output()).not.toContain("unavailable or deleted");
+  });
+
+  it.each([
+    { reason: "not-admitted", expected: "was not admitted to this run" },
+    { reason: "connector-unavailable", expected: "is unavailable" },
+    {
+      reason: "permission-bundle-unavailable",
+      expected: "unavailable permission metadata",
+    },
+    {
+      reason: "runtime-configuration-unavailable",
+      expected: "unavailable runtime configuration",
+    },
+  ] as const)(
+    "explains $reason from backend authority",
+    async ({ reason, expected }) => {
+      stubDiagnostic({ outcome: "target-unavailable", target: TARGET, reason });
+      await expect(check("--connector", `custom:${CUSTOM_ID}`)).rejects.toThrow(
+        "process.exit called",
+      );
+      expect(error.mock.calls.flat().join("\n")).toContain(expected);
+      expect(error.mock.calls.flat().join("\n")).toContain(
+        `custom:${CUSTOM_ID}`,
+      );
+      expect(output()).toBe("");
+    },
+  );
+
+  it("keeps builtin and custom overlapping owners distinct in deterministic selection commands", async () => {
+    stubDiagnostic({
+      outcome: "ambiguous",
+      candidates: [
+        { target: TARGET, label: "GitHub" },
+        {
+          target: { kind: "builtin", connectorSlug: "github" },
+          label: "GitHub",
+        },
+      ],
+    });
+    await expect(check()).rejects.toThrow("process.exit called");
+    const message = error.mock.calls.flat().join("\n");
+    expect(message).toContain(`custom:${CUSTOM_ID}, github`);
+    expect(message).toContain(
+      `--connector 'custom:${CUSTOM_ID}' --method 'POST'`,
+    );
+    expect(message).toContain("--connector 'github' --method 'POST'");
+    expect(message).not.toContain("connectorSlug=");
+  });
+
+  it("preserves UUID-shaped builtin selectors instead of guessing they identify custom connectors", async () => {
+    stubDiagnostic({ outcome: "unknown-connector" });
+    await expect(check("--connector", CUSTOM_ID)).rejects.toThrow(
+      "process.exit called",
+    );
+    expect(requests).toStrictEqual([
+      {
+        mode: "url",
+        method: "POST",
+        url: REQUEST_URL,
+        connectorSlug: CUSTOM_ID,
+      },
+    ]);
+    expect(error.mock.calls.flat().join("\n")).toContain(
+      `Unknown connector slug: ${CUSTOM_ID}`,
+    );
+  });
+
+  it("rejects malformed custom identity before sending a diagnostic", async () => {
+    await expect(check("--connector", "custom:not-a-uuid")).rejects.toThrow(
+      "process.exit called",
+    );
+    expect(requests).toStrictEqual([]);
+    expect(error.mock.calls.flat().join("\n")).toContain("custom:<uuid>");
+  });
+
+  it("does not treat custom unknown endpoints as a grantable builtin permission", async () => {
+    stubDiagnostic(
+      resolvedCustom({
+        kind: "unknown-endpoint",
+        policy: { outcome: "ask", basis: "unknown-policy" },
+      }),
+    );
+    await check();
+    expect(output()).toContain("unknown endpoint policy requires approval");
+    expect(output()).toContain(
+      "There is no custom unknown-endpoint approval control",
+    );
+    expect(output()).not.toMatch(
+      /permission-request|connectorSlug=|review Permissions/,
+    );
+  });
+
+  it("rejects a legacy identity in a target-aware response without retrying", async () => {
+    server.use(
+      http.post(
+        `${ORIGIN}/api/connectors/diagnostics/check`,
+        async ({ request }) => {
+          requests.push(
+            connectorCheckRequestBodySchema.parse(await request.json()),
+          );
+          return HttpResponse.json({
+            ...resolvedCustom(),
+            connector: {
+              connectorSlug: "github",
+              label: "GitHub",
+              visibility: "available",
+              credentialResolution: "network-boundary",
+            },
+          });
+        },
+      ),
+    );
+    await expect(check()).rejects.toThrow("process.exit called");
+    expect(requests).toHaveLength(1);
+    expect(output()).toBe("");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/check.test.ts
@@ -3,10 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { ConnectorResponse } from "@okouai/api-contracts/contracts/connector-schemas";
-import type {
-  ConnectorCheckDiagnosticResult,
-  ConnectorCheckPolicy,
-  ConnectorCheckRequest,
+import {
+  connectorCheckRequestBodySchema,
+  type ConnectorCheckDiagnosticResult,
+  type ConnectorCheckPolicy,
+  type ConnectorCheckRequest,
 } from "@okouai/api-contracts/contracts/connector-check";
 import chalk from "chalk";
 import { HttpResponse, http } from "msw";
@@ -171,6 +172,27 @@ function stubDiagnostic(
     http.post(diagnosticEndpoint(baseUrl), async ({ request }) => {
       const body: unknown = await request.json();
       onRequest?.(body);
+      const parsed = connectorCheckRequestBodySchema.parse(body);
+      if ("includeCustomConnectors" in parsed || "target" in parsed) {
+        if ("connector" in result) {
+          const { connectorSlug, ...identity } = result.connector;
+          return HttpResponse.json({
+            ...result,
+            connector: {
+              ...identity,
+              target: { kind: "builtin", connectorSlug },
+            },
+          });
+        }
+        if (result.outcome === "ambiguous") {
+          return HttpResponse.json({
+            ...result,
+            candidates: result.candidates.map(({ connectorSlug, label }) => {
+              return { target: { kind: "builtin", connectorSlug }, label };
+            }),
+          });
+        }
+      }
       return HttpResponse.json(result);
     }),
   );

--- a/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
+++ b/turbo/apps/cli/src/commands/connector/__tests__/permission-request.test.ts
@@ -125,6 +125,39 @@ describe("okou connector permission-request command", () => {
     mockConsoleError.mockClear();
   });
 
+  it("rejects a custom UUID target with settings guidance instead of a builtin approval link", async () => {
+    const customId = "33333333-3333-4333-8333-333333333333";
+    vi.stubEnv("OKOU_AGENT_ID", "agent-1");
+    vi.stubEnv("OKOU_CHAT_THREAD_ID", "thread-1");
+    let diagnosticCalls = 0;
+    stubDiagnostic(resolvedUrlDiagnostic(), "https://app.vm0.ai", () => {
+      diagnosticCalls += 1;
+    });
+
+    await expect(
+      permissionRequestCommand.parseAsync([
+        "node",
+        "okou",
+        `custom:${customId}`,
+        "--permission",
+        "items:write",
+        "--url",
+        "https://api.acme.test/items",
+        "--callback-prompt",
+        "Continue after approval",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const message = mockConsoleError.mock.calls.flat().join("\n");
+    expect(message).toContain(customId);
+    expect(message).toContain("[Connectors](https://app.vm0.ai/connectors)");
+    expect(message).toContain("review Permissions");
+    expect(message).not.toMatch(/connectorSlug=|action=allow|callbackPrompt=/);
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+    expect(diagnosticCalls).toBe(0);
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
   it("outputs an allow grant link without choosing the user's duration", async () => {
     vi.stubEnv("OKOU_API_BACKEND_URL", "https://app.vm0.ai");
     vi.stubEnv("OKOU_AGENT_ID", "agent-abc-123");

--- a/turbo/apps/cli/src/commands/connector/check-custom.ts
+++ b/turbo/apps/cli/src/commands/connector/check-custom.ts
@@ -1,0 +1,82 @@
+import { getCustomConnector } from "../../lib/api/domains/connectors";
+import {
+  resolveRunConnectorAccountLookups,
+  runConnectorAccountUnavailableMessage,
+  type RunConnectorAccountLookup,
+} from "./run-account-context";
+import { customConnectorSettingsGuidance } from "./custom-connector-guidance";
+
+interface CustomConnectorCheckContext {
+  readonly id: string;
+  readonly label: string;
+  readonly definitionAvailable: boolean;
+  readonly account: RunConnectorAccountLookup;
+}
+
+export async function loadCustomConnectorCheckContext(
+  customConnectorId: string,
+): Promise<CustomConnectorCheckContext> {
+  const [definition, accounts] = await Promise.all([
+    getCustomConnector(customConnectorId),
+    resolveRunConnectorAccountLookups([{ kind: "custom", customConnectorId }]),
+  ]);
+  const account = accounts[0];
+  if (!account) {
+    throw new Error("Missing run account lookup for custom connector");
+  }
+  return {
+    id: customConnectorId,
+    label: definition?.displayName ?? customConnectorId,
+    definitionAvailable: definition !== null,
+    account,
+  };
+}
+
+export function printCustomConnectorCheckStatus(
+  context: CustomConnectorCheckContext,
+  platformOrigin: string,
+): void {
+  console.log("## Step 2: Custom connector configuration");
+  console.log("");
+  if (!context.definitionAvailable) {
+    console.log("Current custom connector metadata is unavailable or deleted.");
+  }
+  const account = context.account;
+  switch (account.state) {
+    case "context-unavailable":
+      console.log(runConnectorAccountUnavailableMessage(account.reason));
+      break;
+    case "not-admitted":
+      console.log(`No ${context.label} account was admitted for this run.`);
+      console.log("Select an available account, then start a new run.");
+      break;
+    case "metadata-unavailable":
+      console.log(`Account used by this run: ${account.connectionId}`);
+      console.log("Current account metadata is unavailable or deleted.");
+      console.log("Select an available account, then start a new run.");
+      break;
+    case "available":
+      console.log(`Account used by this run: ${account.label}`);
+      console.log(`Connection ID: ${account.connectionId}`);
+      if (account.metadata.connectionStatus === "reconnect-required") {
+        console.log(
+          "The account selected for this run needs to be reconnected.",
+        );
+        console.log("After reconnecting, start a new run.");
+      } else {
+        console.log("The account selected for this run is connected.");
+      }
+      break;
+  }
+  if (
+    !context.definitionAvailable ||
+    account.state !== "available" ||
+    account.metadata.connectionStatus === "reconnect-required"
+  ) {
+    console.log(customConnectorSettingsGuidance(context.id, platformOrigin));
+  }
+  console.log(
+    "Routing and permission diagnostics describe current intended state; they do not confirm that the runner has applied the latest update.",
+  );
+  console.log("");
+}

--- a/turbo/apps/cli/src/commands/connector/check-diagnostic.ts
+++ b/turbo/apps/cli/src/commands/connector/check-diagnostic.ts
@@ -1,0 +1,413 @@
+import type { Command } from "commander";
+import type {
+  ConnectorCheckTargetAwareDiagnosticResult,
+  ConnectorCheckRequestBody,
+} from "@okouai/api-contracts/contracts/connector-check";
+import type { ConnectorRuntimeTarget } from "@okouai/api-contracts/contracts/runners";
+import { isComputerUsePermissionTarget } from "./computer-use-guidance";
+import { customConnectorIdFromSelector } from "./custom-connector-guidance";
+
+export interface CheckConnectorOptions {
+  readonly connector?: string;
+  readonly envName?: string;
+  readonly url?: string;
+  readonly method: string;
+  readonly checkPermission?: string;
+}
+
+type ValidatedCheckConnectorOptions = CheckConnectorOptions &
+  (
+    | { readonly url: string }
+    | { readonly url?: undefined; readonly envName: string }
+  );
+
+export type ResolvedDiagnostic = Extract<
+  ConnectorCheckTargetAwareDiagnosticResult,
+  { readonly outcome: "resolved" }
+>;
+export type ResolvedUrlDiagnostic = Extract<
+  ResolvedDiagnostic,
+  { readonly mode: "url" }
+>;
+export type ResolvedEnvironmentDiagnostic = Extract<
+  ResolvedDiagnostic,
+  { readonly mode: "environment" }
+>;
+export type UrlDiagnosticRequest = Extract<
+  ConnectorCheckRequestBody,
+  { readonly mode: "url" }
+>;
+
+export function stripUrlQueryAndFragment(url: string): string {
+  const queryIndex = url.indexOf("?");
+  const fragmentIndex = url.indexOf("#");
+  let end = url.length;
+  if (queryIndex !== -1) end = Math.min(end, queryIndex);
+  if (fragmentIndex !== -1) end = Math.min(end, fragmentIndex);
+  return url.slice(0, end);
+}
+
+function rawUrlAuthorityHasUserinfo(url: string): boolean {
+  const schemeEnd = url.indexOf("://");
+  if (schemeEnd === -1) return false;
+
+  const authorityStart = schemeEnd + 3;
+  let authorityEnd = url.length;
+  for (const delimiter of ["/", "?", "#"]) {
+    const delimiterIndex = url.indexOf(delimiter, authorityStart);
+    if (delimiterIndex !== -1) {
+      authorityEnd = Math.min(authorityEnd, delimiterIndex);
+    }
+  }
+  return url.slice(authorityStart, authorityEnd).includes("@");
+}
+
+export function shellQuoteArg(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function connectorSelectionCommand(
+  url: string,
+  method: string,
+  selector: string,
+): string {
+  const args = [
+    `--url ${shellQuoteArg(url)}`,
+    `--connector ${shellQuoteArg(selector)}`,
+  ];
+  if (method !== "GET") {
+    args.push(`--method ${shellQuoteArg(method)}`);
+  }
+  return `okou connector check ${args.join(" ")}`;
+}
+
+function connectorSelector(target: ConnectorRuntimeTarget): string {
+  return target.kind === "builtin"
+    ? target.connectorSlug
+    : `custom:${target.customConnectorId}`;
+}
+
+function rawPathFromUrl(url: string): string | undefined {
+  const sanitizedUrl = stripUrlQueryAndFragment(url);
+  const schemeEnd = sanitizedUrl.indexOf("://");
+  if (schemeEnd === -1) return undefined;
+
+  const pathStart = sanitizedUrl.indexOf("/", schemeEnd + 3);
+  return pathStart === -1 ? "/" : sanitizedUrl.slice(pathStart);
+}
+
+export function isComputerUseCheckTarget(opts: CheckConnectorOptions): boolean {
+  return isComputerUsePermissionTarget({
+    connectorSlug: opts.connector ?? "",
+    path: opts.url === undefined ? undefined : rawPathFromUrl(opts.url),
+    permission: opts.checkPermission,
+  });
+}
+
+export function validateCheckConnectorOptions(
+  opts: CheckConnectorOptions,
+  command: Command,
+): asserts opts is ValidatedCheckConnectorOptions {
+  const hasUrl = opts.url !== undefined;
+  // Reject embedded credentials before the diagnostic request leaves the client.
+  if (opts.url !== undefined && rawUrlAuthorityHasUserinfo(opts.url)) {
+    throw unsafeInputError("invalid-url");
+  }
+  if (opts.connector !== undefined && !hasUrl) {
+    throw new Error(
+      "--connector can only be used with --url. Add --url <URL> or remove --connector.",
+    );
+  }
+  if (opts.checkPermission !== undefined && hasUrl) {
+    throw new Error(
+      "--check-permission cannot be used with --url because the permission is derived from the request. Remove --check-permission.",
+    );
+  }
+  if (opts.checkPermission?.trim() === "") {
+    throw new Error("--check-permission requires a non-empty permission name.");
+  }
+  if (!hasUrl && command.getOptionValueSource("method") === "cli") {
+    throw new Error(
+      "--method can only be used with --url. Add --url <URL> or remove --method.",
+    );
+  }
+  if (opts.envName === undefined && !hasUrl) {
+    throw new Error(
+      "Either --env-name or --url is required. Use --help for usage.",
+    );
+  }
+}
+
+export function buildConnectorUrlDiagnosticRequest(args: {
+  readonly url: string;
+  readonly method: string;
+  readonly connector?: string;
+  readonly environmentName?: string;
+}): UrlDiagnosticRequest {
+  if (rawUrlAuthorityHasUserinfo(args.url)) {
+    throw unsafeInputError("invalid-url");
+  }
+  const customConnectorId = customConnectorIdFromSelector(args.connector);
+  const selection =
+    customConnectorId !== undefined
+      ? { target: { kind: "custom" as const, customConnectorId } }
+      : args.connector !== undefined
+        ? { connectorSlug: args.connector }
+        : { includeCustomConnectors: true as const };
+  return {
+    mode: "url",
+    method: args.method.toUpperCase(),
+    url: stripUrlQueryAndFragment(args.url),
+    ...selection,
+    ...(args.environmentName !== undefined
+      ? { environmentName: args.environmentName }
+      : {}),
+  };
+}
+
+export function buildDiagnosticRequest(
+  opts: ValidatedCheckConnectorOptions,
+  method: string,
+): ConnectorCheckRequestBody {
+  if (opts.url !== undefined) {
+    return buildConnectorUrlDiagnosticRequest({
+      method,
+      url: opts.url,
+      connector: opts.connector,
+      environmentName: opts.envName,
+    });
+  }
+
+  return {
+    mode: "environment",
+    environmentName: opts.envName,
+    ...(opts.checkPermission !== undefined
+      ? { permission: opts.checkPermission }
+      : {}),
+  };
+}
+
+export function requireUrlRequest(
+  request: ConnectorCheckRequestBody,
+): UrlDiagnosticRequest {
+  if (request.mode !== "url") {
+    throw new Error(
+      "Connector diagnostic returned a URL-only outcome for an environment request.",
+    );
+  }
+  return request;
+}
+
+function requestedEnvironmentName(request: ConnectorCheckRequestBody): string {
+  if (request.environmentName === undefined) {
+    throw new Error(
+      "Connector diagnostic returned an environment outcome without an environment name.",
+    );
+  }
+  return request.environmentName;
+}
+
+function unsafeInputError(
+  reason: Extract<
+    ConnectorCheckTargetAwareDiagnosticResult,
+    { readonly outcome: "unsafe-input" }
+  >["reason"],
+): Error {
+  switch (reason) {
+    case "invalid-method":
+      return new Error(
+        "connector check requires --method to be a supported HTTP method.",
+      );
+    case "invalid-url":
+      return new Error(
+        "connector check requires --url to be a valid absolute http or https URL.",
+      );
+    case "unsafe-path":
+      return new Error(
+        "connector check cannot diagnose unsafe URL paths because they are blocked before permission policy evaluation.",
+      );
+  }
+}
+
+function ambiguousConnectorError(
+  request: UrlDiagnosticRequest,
+  result: Extract<
+    ConnectorCheckTargetAwareDiagnosticResult,
+    { readonly outcome: "ambiguous" }
+  >,
+): Error {
+  const candidates = [...result.candidates].sort((left, right) => {
+    return connectorSelector(left.target).localeCompare(
+      connectorSelector(right.target),
+    );
+  });
+  const commands = candidates.map((candidate) => {
+    return `  ${connectorSelectionCommand(request.url, request.method, connectorSelector(candidate.target))}`;
+  });
+  return new Error(
+    `Multiple connectors match ${request.method} ${request.url}: ${candidates
+      .map((candidate) => {
+        return connectorSelector(candidate.target);
+      })
+      .join(", ")}\nSelect one explicitly:\n${commands.join("\n")}`,
+  );
+}
+
+function unknownConnectorError(request: ConnectorCheckRequestBody): Error {
+  if (
+    request.mode === "url" &&
+    "connectorSlug" in request &&
+    request.connectorSlug !== undefined
+  ) {
+    return new Error(
+      `Unknown connector slug: ${request.connectorSlug}\nRun: okou connector search ${shellQuoteArg(request.connectorSlug)}`,
+    );
+  }
+  return new Error("The requested connector is unknown.");
+}
+
+function noMatchError(
+  result: Extract<
+    ConnectorCheckTargetAwareDiagnosticResult,
+    { readonly outcome: "no-match" }
+  >,
+): Error {
+  return new Error(
+    result.scope === "run"
+      ? "No connector found for provided URL — no connector configured for the current run matches this URL"
+      : "No connector found for provided URL — no registered connector base URL matches this URL",
+  );
+}
+
+function connectorMismatchError(
+  request: UrlDiagnosticRequest,
+  result: Extract<
+    ConnectorCheckTargetAwareDiagnosticResult,
+    { readonly outcome: "connector-mismatch" }
+  >,
+): Error {
+  const requestedSlug =
+    "target" in request && request.target
+      ? connectorSelector(request.target)
+      : (("connectorSlug" in request ? request.connectorSlug : undefined) ??
+        "the requested connector");
+  return new Error(
+    `Connector ${requestedSlug} does not own ${request.method} ${request.url}; the matching connector is ${connectorSelector(result.connector.target)}\nRun: ${connectorSelectionCommand(request.url, request.method, connectorSelector(result.connector.target))}`,
+  );
+}
+
+function environmentNotOwnedError(
+  request: ConnectorCheckRequestBody,
+  result: Extract<
+    ConnectorCheckTargetAwareDiagnosticResult,
+    { readonly outcome: "environment-not-owned" }
+  >,
+): Error {
+  const environmentName = requestedEnvironmentName(request);
+  return new Error(
+    `${environmentName} is not an environment name for the ${result.connector.label} connector. Remove --env-name to use the matched route metadata.`,
+  );
+}
+
+function environmentNotUsedError(
+  request: ConnectorCheckRequestBody,
+  result: Extract<
+    ConnectorCheckTargetAwareDiagnosticResult,
+    { readonly outcome: "environment-not-used" }
+  >,
+): Error {
+  const environmentName = requestedEnvironmentName(request);
+  return new Error(
+    `${environmentName} is not used by the matched API route. Expected one of: ${result.environmentNames.join(", ") || "none"}. Remove --env-name to use the matched route metadata.`,
+  );
+}
+
+export function resolveConnectorCheckDiagnostic(
+  request: ConnectorCheckRequestBody,
+  result: ConnectorCheckTargetAwareDiagnosticResult,
+): ResolvedDiagnostic {
+  switch (result.outcome) {
+    case "resolved":
+      return result;
+    case "unsafe-input":
+      throw unsafeInputError(result.reason);
+    case "unknown-connector":
+      throw unknownConnectorError(request);
+    case "unknown-environment":
+      throw new Error(
+        `Unknown environment name: ${requestedEnvironmentName(request)} — not managed by any connector`,
+      );
+    case "no-match":
+      throw noMatchError(result);
+    case "ambiguous":
+      throw ambiguousConnectorError(requireUrlRequest(request), result);
+    case "connector-mismatch":
+      throw connectorMismatchError(requireUrlRequest(request), result);
+    case "environment-not-owned":
+      throw environmentNotOwnedError(request, result);
+    case "environment-not-used":
+      throw environmentNotUsedError(request, result);
+    case "unresolved-dynamic-base":
+      throw new Error(
+        `No authoritative ${result.connector.label} base URL is available for this diagnostic. Verify the ${connectorSelector(result.connector.target)} connector configuration for the affected context and retry.`,
+      );
+    case "target-unavailable": {
+      const reasons = {
+        "not-admitted":
+          "was not admitted to this run. Select it for the thread, then start a new run",
+        "connector-unavailable":
+          "is unavailable. Review its definition, agent access, and the account selected for this run",
+        "permission-bundle-unavailable":
+          "has unavailable permission metadata. Ask an administrator to review its permission definition",
+        "runtime-configuration-unavailable":
+          "has unavailable runtime configuration. Review its required fields and the account selected for this run",
+      };
+      throw new Error(
+        `Connector ${connectorSelector(result.target)} ${reasons[result.reason]}.`,
+      );
+    }
+    case "run-context-unavailable":
+      throw new Error(
+        "The current run context is unavailable for connector diagnosis. Retry from an active run or start a new run.",
+      );
+  }
+}
+
+export function printDiagnosticSummary(
+  request: ConnectorCheckRequestBody,
+  result: ResolvedDiagnostic,
+): void {
+  if (result.mode === "url") {
+    const urlRequest = requireUrlRequest(request);
+    const target = result.connector.target;
+    const identity =
+      target.kind === "builtin"
+        ? `slug: ${target.connectorSlug}`
+        : `custom UUID: ${target.customConnectorId}`;
+    console.log(
+      `URL ${urlRequest.url} matches the ${result.connector.label} connector (${identity}).`,
+    );
+    console.log(`  Matched base URL: ${result.base}`);
+    console.log(`  Relative path:    ${result.relativePath}`);
+    if (result.environmentNames === null) {
+      console.log("  Environment names: unavailable");
+    } else {
+      console.log(
+        `  Environment names: [${result.environmentNames.join(", ")}]`,
+      );
+    }
+    return;
+  }
+
+  console.log(
+    `${result.environmentName} is managed by the ${result.connector.label} connector (slug: ${connectorSelector(result.connector.target)}).`,
+  );
+}
+
+export function diagnosticEnvironmentNames(
+  result: ResolvedDiagnostic,
+): readonly string[] | null {
+  return result.mode === "url"
+    ? result.environmentNames
+    : [result.environmentName];
+}

--- a/turbo/apps/cli/src/commands/connector/check.ts
+++ b/turbo/apps/cli/src/commands/connector/check.ts
@@ -1,12 +1,31 @@
 import { Command, Option } from "commander";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
-import type {
-  ConnectorCheckDiagnosticResult,
-  ConnectorCheckPolicy,
-  ConnectorCheckRequest,
-} from "@okouai/api-contracts/contracts/connector-check";
+import type { ConnectorRuntimeTarget } from "@okouai/api-contracts/contracts/runners";
+import type { ConnectorCheckPolicy } from "@okouai/api-contracts/contracts/connector-check";
+
+import {
+  buildDiagnosticRequest,
+  diagnosticEnvironmentNames,
+  isComputerUseCheckTarget,
+  printDiagnosticSummary,
+  requireUrlRequest,
+  resolveConnectorCheckDiagnostic,
+  shellQuoteArg,
+  stripUrlQueryAndFragment,
+  validateCheckConnectorOptions,
+  type CheckConnectorOptions,
+  type ResolvedDiagnostic,
+  type ResolvedEnvironmentDiagnostic,
+  type ResolvedUrlDiagnostic,
+  type UrlDiagnosticRequest,
+} from "./check-diagnostic";
 
 import { getApiUrl } from "../../lib/api/config";
+import {
+  loadCustomConnectorCheckContext,
+  printCustomConnectorCheckStatus,
+} from "./check-custom";
+import { customConnectorSettingsGuidance } from "./custom-connector-guidance";
 import {
   diagnoseConnectorCheck,
   getConnector,
@@ -15,10 +34,7 @@ import { getAgentUserConnectors } from "../../lib/api/domains/agents";
 import { withErrorHandler } from "../../lib/command/with-error-handler";
 import { getOkouAgentId } from "../../lib/okou-env";
 import { toPlatformUrl } from "../doctor/platform-url";
-import {
-  isComputerUsePermissionTarget,
-  printComputerUsePermissionGuidance,
-} from "./computer-use-guidance";
+import { printComputerUsePermissionGuidance } from "./computer-use-guidance";
 import {
   CALLBACK_PROMPT_PLACEHOLDER,
   connectorActionUrl,
@@ -32,40 +48,8 @@ import {
   type RunConnectorAccountLookup,
 } from "./run-account-context";
 
-interface CheckConnectorOptions {
-  readonly connector?: string;
-  readonly envName?: string;
-  readonly url?: string;
-  readonly method: string;
-  readonly checkPermission?: string;
-}
-
-type ValidatedCheckConnectorOptions = CheckConnectorOptions &
-  (
-    | { readonly url: string }
-    | { readonly url?: undefined; readonly envName: string }
-  );
-
-export type ResolvedDiagnostic = Extract<
-  ConnectorCheckDiagnosticResult,
-  { readonly outcome: "resolved" }
->;
-type ResolvedUrlDiagnostic = Extract<
-  ResolvedDiagnostic,
-  { readonly mode: "url" }
->;
-type ResolvedEnvironmentDiagnostic = Extract<
-  ResolvedDiagnostic,
-  { readonly mode: "environment" }
->;
-type UrlDiagnosticRequest = Extract<
-  ConnectorCheckRequest,
-  { readonly mode: "url" }
->;
-
 interface DiagContext {
   readonly environmentNames: readonly string[] | null;
-  readonly connectorSlug: ConnectorSlug;
   readonly label: string;
   readonly connectorAvailable: boolean;
   readonly credentialResolution: "network-boundary" | "none";
@@ -75,347 +59,18 @@ interface DiagContext {
   readonly runBound: boolean;
 }
 
+interface BuiltinDiagContext extends DiagContext {
+  readonly connectorSlug: ConnectorSlug;
+}
+
 interface ConnectorConfigurationStatus {
   readonly isConnected: boolean;
   readonly isExpired: boolean;
   readonly runAccount: RunConnectorAccountLookup | null;
 }
 
-function stripUrlQueryAndFragment(url: string): string {
-  const queryIndex = url.indexOf("?");
-  const fragmentIndex = url.indexOf("#");
-  let end = url.length;
-  if (queryIndex !== -1) end = Math.min(end, queryIndex);
-  if (fragmentIndex !== -1) end = Math.min(end, fragmentIndex);
-  return url.slice(0, end);
-}
-
-function rawUrlAuthorityHasUserinfo(url: string): boolean {
-  const schemeEnd = url.indexOf("://");
-  if (schemeEnd === -1) return false;
-
-  const authorityStart = schemeEnd + 3;
-  let authorityEnd = url.length;
-  for (const delimiter of ["/", "?", "#"]) {
-    const delimiterIndex = url.indexOf(delimiter, authorityStart);
-    if (delimiterIndex !== -1) {
-      authorityEnd = Math.min(authorityEnd, delimiterIndex);
-    }
-  }
-  return url.slice(authorityStart, authorityEnd).includes("@");
-}
-
-function shellQuoteArg(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
-function connectorSelectionCommand(
-  url: string,
-  method: string,
-  connectorSlug: string,
-): string {
-  const args = [
-    `--url ${shellQuoteArg(url)}`,
-    `--connector ${shellQuoteArg(connectorSlug)}`,
-  ];
-  if (method !== "GET") {
-    args.push(`--method ${shellQuoteArg(method)}`);
-  }
-  return `okou connector check ${args.join(" ")}`;
-}
-
-function rawPathFromUrl(url: string): string | undefined {
-  const sanitizedUrl = stripUrlQueryAndFragment(url);
-  const schemeEnd = sanitizedUrl.indexOf("://");
-  if (schemeEnd === -1) return undefined;
-
-  const pathStart = sanitizedUrl.indexOf("/", schemeEnd + 3);
-  return pathStart === -1 ? "/" : sanitizedUrl.slice(pathStart);
-}
-
-function isComputerUseCheckTarget(opts: CheckConnectorOptions): boolean {
-  return isComputerUsePermissionTarget({
-    connectorSlug: opts.connector ?? "",
-    path: opts.url === undefined ? undefined : rawPathFromUrl(opts.url),
-    permission: opts.checkPermission,
-  });
-}
-
-function validateCheckConnectorOptions(
-  opts: CheckConnectorOptions,
-  command: Command,
-): asserts opts is ValidatedCheckConnectorOptions {
-  const hasUrl = opts.url !== undefined;
-  // Reject embedded credentials before the diagnostic request leaves the client.
-  if (opts.url !== undefined && rawUrlAuthorityHasUserinfo(opts.url)) {
-    throw unsafeInputError("invalid-url");
-  }
-  if (opts.connector !== undefined && !hasUrl) {
-    throw new Error(
-      "--connector can only be used with --url. Add --url <URL> or remove --connector.",
-    );
-  }
-  if (opts.checkPermission !== undefined && hasUrl) {
-    throw new Error(
-      "--check-permission cannot be used with --url because the permission is derived from the request. Remove --check-permission.",
-    );
-  }
-  if (opts.checkPermission?.trim() === "") {
-    throw new Error("--check-permission requires a non-empty permission name.");
-  }
-  if (!hasUrl && command.getOptionValueSource("method") === "cli") {
-    throw new Error(
-      "--method can only be used with --url. Add --url <URL> or remove --method.",
-    );
-  }
-  if (opts.envName === undefined && !hasUrl) {
-    throw new Error(
-      "Either --env-name or --url is required. Use --help for usage.",
-    );
-  }
-}
-
-export function buildConnectorUrlDiagnosticRequest(args: {
-  readonly url: string;
-  readonly method: string;
-  readonly connectorSlug?: string;
-  readonly environmentName?: string;
-}): UrlDiagnosticRequest {
-  if (rawUrlAuthorityHasUserinfo(args.url)) {
-    throw unsafeInputError("invalid-url");
-  }
-  return {
-    mode: "url",
-    method: args.method.toUpperCase(),
-    url: stripUrlQueryAndFragment(args.url),
-    ...(args.connectorSlug !== undefined
-      ? { connectorSlug: args.connectorSlug }
-      : {}),
-    ...(args.environmentName !== undefined
-      ? { environmentName: args.environmentName }
-      : {}),
-  };
-}
-
-function buildDiagnosticRequest(
-  opts: ValidatedCheckConnectorOptions,
-  method: string,
-): ConnectorCheckRequest {
-  if (opts.url !== undefined) {
-    return buildConnectorUrlDiagnosticRequest({
-      method,
-      url: opts.url,
-      connectorSlug: opts.connector,
-      environmentName: opts.envName,
-    });
-  }
-
-  return {
-    mode: "environment",
-    environmentName: opts.envName,
-    ...(opts.checkPermission !== undefined
-      ? { permission: opts.checkPermission }
-      : {}),
-  };
-}
-
-function requireUrlRequest(
-  request: ConnectorCheckRequest,
-): UrlDiagnosticRequest {
-  if (request.mode !== "url") {
-    throw new Error(
-      "Connector diagnostic returned a URL-only outcome for an environment request.",
-    );
-  }
-  return request;
-}
-
-function requestedEnvironmentName(request: ConnectorCheckRequest): string {
-  if (request.environmentName === undefined) {
-    throw new Error(
-      "Connector diagnostic returned an environment outcome without an environment name.",
-    );
-  }
-  return request.environmentName;
-}
-
-function unsafeInputError(
-  reason: Extract<
-    ConnectorCheckDiagnosticResult,
-    { readonly outcome: "unsafe-input" }
-  >["reason"],
-): Error {
-  switch (reason) {
-    case "invalid-method":
-      return new Error(
-        "connector check requires --method to be a supported HTTP method.",
-      );
-    case "invalid-url":
-      return new Error(
-        "connector check requires --url to be a valid absolute http or https URL.",
-      );
-    case "unsafe-path":
-      return new Error(
-        "connector check cannot diagnose unsafe URL paths because they are blocked before permission policy evaluation.",
-      );
-  }
-}
-
-function ambiguousConnectorError(
-  request: UrlDiagnosticRequest,
-  result: Extract<
-    ConnectorCheckDiagnosticResult,
-    { readonly outcome: "ambiguous" }
-  >,
-): Error {
-  const candidates = [...result.candidates].sort((left, right) => {
-    return left.connectorSlug.localeCompare(right.connectorSlug);
-  });
-  const commands = candidates.map((candidate) => {
-    return `  ${connectorSelectionCommand(request.url, request.method, candidate.connectorSlug)}`;
-  });
-  return new Error(
-    `Multiple connectors match ${request.method} ${request.url}: ${candidates
-      .map((candidate) => {
-        return candidate.connectorSlug;
-      })
-      .join(", ")}\nSelect one explicitly:\n${commands.join("\n")}`,
-  );
-}
-
-function unknownConnectorError(request: ConnectorCheckRequest): Error {
-  if (request.mode === "url" && request.connectorSlug !== undefined) {
-    return new Error(
-      `Unknown connector slug: ${request.connectorSlug}\nRun: okou connector search ${shellQuoteArg(request.connectorSlug)}`,
-    );
-  }
-  return new Error("The requested connector is unknown.");
-}
-
-function noMatchError(
-  result: Extract<
-    ConnectorCheckDiagnosticResult,
-    { readonly outcome: "no-match" }
-  >,
-): Error {
-  return new Error(
-    result.scope === "run"
-      ? "No connector found for provided URL — no connector configured for the current run matches this URL"
-      : "No connector found for provided URL — no registered connector base URL matches this URL",
-  );
-}
-
-function connectorMismatchError(
-  request: UrlDiagnosticRequest,
-  result: Extract<
-    ConnectorCheckDiagnosticResult,
-    { readonly outcome: "connector-mismatch" }
-  >,
-): Error {
-  const requestedSlug = request.connectorSlug ?? "the requested connector";
-  return new Error(
-    `Connector ${requestedSlug} does not own ${request.method} ${request.url}; the matching connector is ${result.connector.connectorSlug}\nRun: ${connectorSelectionCommand(request.url, request.method, result.connector.connectorSlug)}`,
-  );
-}
-
-function environmentNotOwnedError(
-  request: ConnectorCheckRequest,
-  result: Extract<
-    ConnectorCheckDiagnosticResult,
-    { readonly outcome: "environment-not-owned" }
-  >,
-): Error {
-  const environmentName = requestedEnvironmentName(request);
-  return new Error(
-    `${environmentName} is not an environment name for the ${result.connector.label} connector. Remove --env-name to use the matched route metadata.`,
-  );
-}
-
-function environmentNotUsedError(
-  request: ConnectorCheckRequest,
-  result: Extract<
-    ConnectorCheckDiagnosticResult,
-    { readonly outcome: "environment-not-used" }
-  >,
-): Error {
-  const environmentName = requestedEnvironmentName(request);
-  return new Error(
-    `${environmentName} is not used by the matched API route. Expected one of: ${result.environmentNames.join(", ") || "none"}. Remove --env-name to use the matched route metadata.`,
-  );
-}
-
-export function resolveConnectorCheckDiagnostic(
-  request: ConnectorCheckRequest,
-  result: ConnectorCheckDiagnosticResult,
-): ResolvedDiagnostic {
-  switch (result.outcome) {
-    case "resolved":
-      return result;
-    case "unsafe-input":
-      throw unsafeInputError(result.reason);
-    case "unknown-connector":
-      throw unknownConnectorError(request);
-    case "unknown-environment":
-      throw new Error(
-        `Unknown environment name: ${requestedEnvironmentName(request)} — not managed by any connector`,
-      );
-    case "no-match":
-      throw noMatchError(result);
-    case "ambiguous":
-      throw ambiguousConnectorError(requireUrlRequest(request), result);
-    case "connector-mismatch":
-      throw connectorMismatchError(requireUrlRequest(request), result);
-    case "environment-not-owned":
-      throw environmentNotOwnedError(request, result);
-    case "environment-not-used":
-      throw environmentNotUsedError(request, result);
-    case "unresolved-dynamic-base":
-      throw new Error(
-        `No authoritative ${result.connector.label} base URL is available for this diagnostic. Verify the ${result.connector.connectorSlug} connector configuration for the affected context and retry.`,
-      );
-    case "run-context-unavailable":
-      throw new Error(
-        "The current run context is unavailable for connector diagnosis. Retry from an active run or start a new run.",
-      );
-  }
-}
-
-function printDiagnosticSummary(
-  request: ConnectorCheckRequest,
-  result: ResolvedDiagnostic,
-): void {
-  if (result.mode === "url") {
-    const urlRequest = requireUrlRequest(request);
-    console.log(
-      `URL ${urlRequest.url} matches the ${result.connector.label} connector (slug: ${result.connector.connectorSlug}).`,
-    );
-    console.log(`  Matched base URL: ${result.base}`);
-    console.log(`  Relative path:    ${result.relativePath}`);
-    if (result.environmentNames === null) {
-      console.log("  Environment names: unavailable");
-    } else {
-      console.log(
-        `  Environment names: [${result.environmentNames.join(", ")}]`,
-      );
-    }
-    return;
-  }
-
-  console.log(
-    `${result.environmentName} is managed by the ${result.connector.label} connector (slug: ${result.connector.connectorSlug}).`,
-  );
-}
-
-function diagnosticEnvironmentNames(
-  result: ResolvedDiagnostic,
-): readonly string[] | null {
-  return result.mode === "url"
-    ? result.environmentNames
-    : [result.environmentName];
-}
-
 function printConnectorConnectionStatus(
-  ctx: DiagContext,
+  ctx: BuiltinDiagContext,
   status: ConnectorConfigurationStatus,
   hasPermission: boolean,
 ): void {
@@ -489,7 +144,7 @@ function printConnectorConnectionStatus(
 }
 
 function printAgentAuthorizationStatus(
-  ctx: DiagContext,
+  ctx: BuiltinDiagContext,
   status: ConnectorConfigurationStatus,
   hasPermission: boolean,
 ): void {
@@ -529,7 +184,7 @@ function printAgentAuthorizationStatus(
 }
 
 function printConnectorAuthorizationStatus(
-  ctx: DiagContext,
+  ctx: BuiltinDiagContext,
   status: ConnectorConfigurationStatus,
   hasPermission: boolean,
 ): void {
@@ -588,7 +243,7 @@ function checkEnvironmentNames(ctx: DiagContext): void {
   console.log("");
 }
 
-async function checkConnectorStatus(ctx: DiagContext): Promise<{
+async function checkConnectorStatus(ctx: BuiltinDiagContext): Promise<{
   readonly isConnected: boolean;
   readonly isExpired: boolean;
   readonly hasPermission: boolean;
@@ -709,11 +364,12 @@ function printUnavailablePolicy(
 }
 
 function printNamedPolicyResult(
-  connectorSlug: string,
+  target: ConnectorRuntimeTarget,
   permission: string,
   policy: ConnectorCheckPolicy,
   agentId: string | undefined,
   request: UrlDiagnosticRequest | undefined,
+  platformOrigin: string,
 ): void {
   switch (policy.outcome) {
     case "allow": {
@@ -748,11 +404,12 @@ function printNamedPolicyResult(
           : `Result: The unknown-endpoint policy denies "${permission}".`,
       );
       printPermissionRequestCommands(
-        connectorSlug,
+        target,
         permission,
         agentId,
         "To request this permission, run",
         request,
+        platformOrigin,
       );
       return;
     case "ask":
@@ -762,11 +419,12 @@ function printNamedPolicyResult(
           : `Result: The unknown-endpoint policy blocks "${permission}" until approval.`,
       );
       printPermissionRequestCommands(
-        connectorSlug,
+        target,
         permission,
         agentId,
         "To request this permission, run",
         request,
+        platformOrigin,
       );
       return;
     case "unavailable":
@@ -784,19 +442,34 @@ function permissionRequestCommand(
 }
 
 function printPermissionRequestCommands(
-  connectorSlug: string,
+  target: ConnectorRuntimeTarget,
   permission: string,
   agentId: string | undefined,
   introduction: string,
   request: UrlDiagnosticRequest | undefined,
+  platformOrigin: string,
 ): void {
+  if (target.kind === "custom") {
+    console.log(
+      customConnectorSettingsGuidance(
+        target.customConnectorId,
+        platformOrigin,
+        permission,
+      ),
+    );
+    return;
+  }
   if (request === undefined) {
     console.log(
       "Diagnose the failed request with okou connector check --url <FAILED_URL> --method <METHOD> before requesting this permission.",
     );
     return;
   }
-  const command = permissionRequestCommand(connectorSlug, permission, request);
+  const command = permissionRequestCommand(
+    target.connectorSlug,
+    permission,
+    request,
+  );
   console.log(`${introduction}: ${command}`);
   if (!currentChatSupportsActionCallback(agentId)) {
     return;
@@ -810,10 +483,11 @@ function printPermissionRequestCommands(
 }
 
 function printUnknownEndpointPolicy(
-  connectorSlug: string,
+  target: ConnectorRuntimeTarget,
   policy: ConnectorCheckPolicy,
   agentId: string | undefined,
   request: UrlDiagnosticRequest,
+  platformOrigin: string,
 ): void {
   switch (policy.outcome) {
     case "allow":
@@ -828,11 +502,12 @@ function printUnknownEndpointPolicy(
         "Result: No permission matched. The unknown endpoint policy denies this request.",
       );
       printPermissionRequestCommands(
-        connectorSlug,
+        target,
         "__unknown__",
         agentId,
         "To request access to unknown endpoints, run",
         request,
+        platformOrigin,
       );
       return;
     case "ask":
@@ -840,11 +515,12 @@ function printUnknownEndpointPolicy(
         "Result: No permission matched. The unknown endpoint policy requires approval.",
       );
       printPermissionRequestCommands(
-        connectorSlug,
+        target,
         "__unknown__",
         agentId,
         "To request access to unknown endpoints, run",
         request,
+        platformOrigin,
       );
       return;
     case "unavailable":
@@ -857,6 +533,7 @@ function printUrlPermissionDiagnostic(
   request: UrlDiagnosticRequest,
   result: ResolvedUrlDiagnostic,
   agentId: string | undefined,
+  platformOrigin: string,
 ): void {
   console.log("## Step 3: Permission policy check (auto-detected from URL)");
   console.log("");
@@ -876,11 +553,12 @@ function printUrlPermissionDiagnostic(
     console.log("");
     for (const permission of result.permission.permissions) {
       printNamedPolicyResult(
-        result.connector.connectorSlug,
+        result.connector.target,
         permission.name,
         permission.policy,
         agentId,
         request,
+        platformOrigin,
       );
     }
   } else {
@@ -889,10 +567,11 @@ function printUrlPermissionDiagnostic(
     );
     console.log("");
     printUnknownEndpointPolicy(
-      result.connector.connectorSlug,
+      result.connector.target,
       result.permission.policy,
       agentId,
       request,
+      platformOrigin,
     );
   }
   console.log("");
@@ -902,6 +581,7 @@ function printEnvironmentPermissionDiagnostic(
   result: ResolvedEnvironmentDiagnostic,
   permissionName: string | undefined,
   agentId: string | undefined,
+  platformOrigin: string,
 ): void {
   if (result.permission === null) {
     return;
@@ -918,11 +598,12 @@ function printEnvironmentPermissionDiagnostic(
   );
   console.log("");
   printNamedPolicyResult(
-    result.connector.connectorSlug,
+    result.connector.target,
     permissionName,
     result.permission,
     agentId,
     undefined,
+    platformOrigin,
   );
   console.log("");
 }
@@ -973,8 +654,8 @@ export const checkConnectorCommand = new Command()
   )
   .addOption(
     new Option(
-      "--connector <slug>",
-      "Select the connector when multiple connectors own the same URL route",
+      "--connector <selector>",
+      "Select a builtin slug or custom:<uuid> when connectors own the same URL route",
     ),
   )
   .addOption(
@@ -996,6 +677,7 @@ Examples:
   okou connector check --env-name GITHUB_TOKEN
   okou connector check --url https://api.github.com/repos/owner/repo
   okou connector check --url https://api.accounts.nintendo.com/2.0.0/users/me --connector nintendo-store
+  okou connector check --url https://api.acme.example/v1/items --connector custom:<connector-id>
   okou connector check --url https://slack.com/api/chat.postMessage --method POST
   okou connector check --env-name SLACK_TOKEN --check-permission chat:write
 
@@ -1017,7 +699,18 @@ How connectors work:
       const method = opts.method.toUpperCase();
       const request = buildDiagnosticRequest(opts, method);
       const diagnostic = await diagnoseConnectorCheck(request);
-      const result = resolveConnectorCheckDiagnostic(request, diagnostic);
+      const resolved = resolveConnectorCheckDiagnostic(request, diagnostic);
+      const target = resolved.connector.target;
+      const custom =
+        target.kind === "custom"
+          ? await loadCustomConnectorCheckContext(target.customConnectorId)
+          : null;
+      const result = custom
+        ? {
+            ...resolved,
+            connector: { ...resolved.connector, label: custom.label },
+          }
+        : resolved;
 
       printDiagnosticSummary(request, result);
       console.log("");
@@ -1025,7 +718,6 @@ How connectors work:
       const platformUrl = toPlatformUrl(await getApiUrl());
       const ctx: DiagContext = {
         environmentNames: diagnosticEnvironmentNames(result),
-        connectorSlug: result.connector.connectorSlug,
         label: result.connector.label,
         connectorAvailable: result.connector.visibility === "available",
         credentialResolution: result.connector.credentialResolution,
@@ -1036,15 +728,27 @@ How connectors work:
       };
 
       checkEnvironmentNames(ctx);
-      const { isConnected, isExpired, hasPermission } =
-        await checkConnectorStatus(ctx);
+      const status =
+        target.kind === "builtin"
+          ? await checkConnectorStatus({
+              ...ctx,
+              connectorSlug: target.connectorSlug,
+            })
+          : null;
+      if (custom) {
+        printCustomConnectorCheckStatus(custom, ctx.platformOrigin);
+      }
       const configuredForRun = checkConnectorDomains(ctx);
 
       if (configuredForRun === false) {
         console.log(
           `Steps 1-2 summary: The ${ctx.label} connector is not configured for this run. Check the agent authorization settings, then start a new run after updating them.`,
         );
-      } else if (isConnected && !isExpired && hasPermission) {
+      } else if (
+        status?.isConnected &&
+        !status.isExpired &&
+        status.hasPermission
+      ) {
         console.log(
           `Steps 1-2 summary: The ${ctx.label} connector is connected, active, and authorized. Outbound requests to the registered base URLs will have credentials injected at the network boundary.`,
         );
@@ -1056,12 +760,14 @@ How connectors work:
           requireUrlRequest(request),
           result,
           ctx.agentId,
+          ctx.platformOrigin,
         );
       } else {
         printEnvironmentPermissionDiagnostic(
           result,
           request.mode === "environment" ? request.permission : undefined,
           ctx.agentId,
+          ctx.platformOrigin,
         );
       }
 

--- a/turbo/apps/cli/src/commands/connector/custom-connector-guidance.ts
+++ b/turbo/apps/cli/src/commands/connector/custom-connector-guidance.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export function customConnectorIdFromSelector(
+  selector: string | undefined,
+): string | undefined {
+  if (!selector?.startsWith("custom:")) {
+    return undefined;
+  }
+  const id = z.uuid().safeParse(selector.slice("custom:".length));
+  if (!id.success) {
+    throw new Error(
+      "Custom connector selectors must use custom:<uuid>. Run okou connector custom list to find the connector ID.",
+    );
+  }
+  return id.data;
+}
+
+export function customConnectorSettingsGuidance(
+  customConnectorId: string,
+  platformOrigin: string,
+  permission?: string,
+): string {
+  const url = new URL("/connectors", platformOrigin).toString();
+  const steps =
+    permission === undefined
+      ? "Review its accounts and agent access. Reconnect or select an available account as needed."
+      : permission === "__unknown__"
+        ? "There is no custom unknown-endpoint approval control. Ask an administrator to review the connector's routing and permission definition."
+        : "Open the custom connector's agent access management, select the affected agent, and review Permissions.";
+  return `Custom connector ${customConnectorId} uses the existing connector settings flow, not a builtin permission approval link.\nOpen [Connectors](${url}) and select this custom connector. ${steps}`;
+}

--- a/turbo/apps/cli/src/commands/connector/permission-request.ts
+++ b/turbo/apps/cli/src/commands/connector/permission-request.ts
@@ -25,7 +25,11 @@ import {
   buildConnectorUrlDiagnosticRequest,
   resolveConnectorCheckDiagnostic,
   type ResolvedDiagnostic,
-} from "./check";
+} from "./check-diagnostic";
+import {
+  customConnectorIdFromSelector,
+  customConnectorSettingsGuidance,
+} from "./custom-connector-guidance";
 
 function permissionDescription(permission: string): string {
   return permission === UNKNOWN_PERMISSION_GRANT
@@ -335,6 +339,7 @@ Notes:
   - Use the exact permission-request command printed by connector check
   - A platform URL is output only when that request maps to a denied or approval-required permission
   - Use --permission __unknown__ to request access to unknown endpoints
+  - Custom connectors use Connectors > agent access > Permissions, not this builtin approval flow
   - Use --agent to request a permission for another agent; defaults to OKOU_AGENT_ID
   - The user chooses the permission duration on the confirmation page
 ${callbackPromptNotes}  - Permission requests update the current user's connector grants after confirmation`,
@@ -381,6 +386,16 @@ ${callbackPromptNotes}  - Permission requests update the current user's connecto
         }
 
         const agentId = opts.agent ?? getOkouAgentId();
+        const customConnectorId = customConnectorIdFromSelector(connectorSlug);
+        if (customConnectorId !== undefined) {
+          throw new Error(
+            customConnectorSettingsGuidance(
+              customConnectorId,
+              await getPlatformOrigin(),
+              opts.permission,
+            ),
+          );
+        }
         if (opts.url === undefined) {
           throw new Error(
             "--url is required for connector permission requests. Run okou connector check --url <FAILED_URL> --method <METHOD> and use the permission-request command it prints.",
@@ -390,13 +405,18 @@ ${callbackPromptNotes}  - Permission requests update the current user's connecto
         const diagnosticRequest = buildConnectorUrlDiagnosticRequest({
           url: opts.url,
           method: opts.method,
-          connectorSlug,
+          connector: connectorSlug,
         });
         const diagnostic = await diagnoseConnectorCheck(diagnosticRequest);
         const result = resolveConnectorCheckDiagnostic(
           diagnosticRequest,
           diagnostic,
         );
+        if (result.connector.target.kind !== "builtin") {
+          throw new Error(
+            "Builtin permission requests require a builtin diagnostic target.",
+          );
+        }
         const policy = permissionPolicyForDiagnostic({
           result,
           permission: opts.permission,
@@ -411,7 +431,7 @@ ${callbackPromptNotes}  - Permission requests update the current user's connecto
         });
 
         await outputPermissionRequestMessage(
-          result.connector.connectorSlug,
+          result.connector.target.connectorSlug,
           result.connector.label,
           opts.permission,
           agentId,

--- a/turbo/apps/cli/src/lib/api/domains/connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/connectors.ts
@@ -27,8 +27,10 @@ import {
 import {
   connectorCheckContract,
   connectorCheckDiagnosticResultSchema,
+  connectorCheckTargetAwareDiagnosticResultSchema,
   type ConnectorCheckDiagnosticResult,
-  type ConnectorCheckRequest,
+  type ConnectorCheckRequestBody,
+  type ConnectorCheckTargetAwareDiagnosticResult,
 } from "@okouai/api-contracts/contracts/connector-check";
 import {
   customConnectorByIdContract,
@@ -209,9 +211,33 @@ export async function getConnectorCatalogPermissions(
   );
 }
 
+function normalizeBuiltinDiagnostic(
+  diagnostic: ConnectorCheckDiagnosticResult,
+): ConnectorCheckTargetAwareDiagnosticResult {
+  if ("connector" in diagnostic) {
+    const { connectorSlug, ...identity } = diagnostic.connector;
+    return {
+      ...diagnostic,
+      connector: {
+        ...identity,
+        target: { kind: "builtin", connectorSlug },
+      },
+    };
+  }
+  if (diagnostic.outcome === "ambiguous") {
+    return {
+      ...diagnostic,
+      candidates: diagnostic.candidates.map(({ connectorSlug, label }) => {
+        return { target: { kind: "builtin", connectorSlug }, label };
+      }),
+    };
+  }
+  return diagnostic;
+}
+
 export async function diagnoseConnectorCheck(
-  request: ConnectorCheckRequest,
-): Promise<ConnectorCheckDiagnosticResult> {
+  request: ConnectorCheckRequestBody,
+): Promise<ConnectorCheckTargetAwareDiagnosticResult> {
   const config = await getClientConfig();
   const client = initClient(connectorCheckContract, {
     ...config,
@@ -221,7 +247,12 @@ export async function diagnoseConnectorCheck(
   const result = await client.check({ body: request });
 
   if (result.status === 200) {
-    return connectorCheckDiagnosticResultSchema.parse(result.body);
+    if ("target" in request || "includeCustomConnectors" in request) {
+      return connectorCheckTargetAwareDiagnosticResultSchema.parse(result.body);
+    }
+    return normalizeBuiltinDiagnostic(
+      connectorCheckDiagnosticResultSchema.parse(result.body),
+    );
   }
 
   handleError(result, "Failed to diagnose connector");


### PR DESCRIPTION
## Summary

- Activate the deployed target-aware connector diagnostic contract for unqualified URL checks and explicit `--connector custom:<uuid>` selection. Preserve explicit builtin and environment requests, validation, output, approval links, and callbacks.
- Display stable custom UUIDs, current display names, run-pinned routing, and the exact run-selected account. Never substitute a default/sibling account or infer connectivity from definition-level `connected`.
- Explain unavailable targets and overlapping ownership deterministically. Custom grant remediation points to the existing Connectors settings flow; custom unknown endpoints do not imply a nonexistent approval control, and builtin-style custom permission requests are rejected.
- Extract shared request/outcome helpers from the large check command and cover the new behavior at Commander/MSW entry points.

Closes #32165

Parent context: #32074. This is the final materialized child; #32163 and #32164 are complete. This PR does not close the parent.

## Boundaries and compatibility

- CLI-only changes: no backend authority, API schema, database, runner, UI, or custom approval mutation changes.
- The prerequisite backend PR #32318 was deployed successfully in API production deployment 6310511966 (2026-09-07, API v1.564.0). Old CLI requests remain builtin-only; new target-aware requests require the deployed response family and never retry using a legacy fallback.
- Custom diagnostics describe current intended routing/policy state, not acknowledgement that a running runner has applied the latest update.
- Resolved custom diagnostics add one by-ID definition lookup and one-target account inspection, in parallel. The CLI does not call connector/account list APIs. The existing by-ID backend endpoint still loads user-scoped connection/value metadata internally; this PR does not optimize that service.

## Fallbacks and unavailable metadata

No protocol, account-selection, credential, or configuration fallback is introduced. When a current custom definition is missing, `check-custom.ts` prints its retained UUID instead of a stale mutable name and explicitly marks metadata unavailable. This is a persistent presentation rule for expected reference churn, not a temporary rollout fallback requiring a cleanup issue. Non-404 metadata failures propagate.

## Validation

Run from `turbo`:

- Prettier check for all nine changed CLI files: passed.
- `pnpm -F @okouai/cli lint`: passed.
- `pnpm -F @okouai/cli check-types`: passed.
- `pnpm knip --workspace apps/cli`: passed.
- `pnpm -F @okouai/cli exec vitest run src/commands/connector --maxWorkers=4 --silent=passed-only`: 13 files, 252 tests passed.
- `pnpm -F api exec vitest run src/signals/routes/__tests__/connector-check.test.ts --maxWorkers=4 --silent=passed-only`: 10 tests passed. The first local run timed out in one test; after the required `scripts/prepare.sh` environment setup, the unchanged suite passed (4.66 seconds total test execution). No timeout increase or test skip was added.
- `git diff --check`: passed.
- Pre-commit hooks: full-repository Knip, full-repository type checks, formatting, file-size checks, and commitlint passed.

Not verified: a live production CLI session or browser E2E. No UI behavior was changed.
