### PR TITLE
feat(pi-memory): learn from canonical connector chat threads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -7396,14 +7396,35 @@ describe("CHAT-02: model-first provider policies", () => {
       piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({
         triggerSource: null,
       }),
-    ).toBe("source_not_web_chat");
+    ).toBe("source_not_interactive_chat");
+    expect(
+      piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({
+        triggerSource: "unknown",
+      }),
+    ).toBe("source_not_interactive_chat");
+    const expectedAdmissionBySource = {
+      web: null,
+      slack: null,
+      teams: null,
+      feishu: null,
+      email: "source_not_interactive_chat",
+      telegram: null,
+      agentphone: null,
+      github: null,
+      test: "source_not_interactive_chat",
+      agent: null,
+      webhook: "source_not_interactive_chat",
+      "automation-schedule": "source_not_interactive_chat",
+      "automation-event": "source_not_interactive_chat",
+      goal: "source_not_interactive_chat",
+    } as const satisfies Record<
+      (typeof triggerSourceSchema.options)[number],
+      "source_not_interactive_chat" | null
+    >;
     for (const triggerSource of triggerSourceSchema.options) {
-      if (triggerSource === "web" || triggerSource === "agent") {
-        continue;
-      }
       expect(
         piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({ triggerSource }),
-      ).toBe("source_not_web_chat");
+      ).toBe(expectedAdmissionBySource[triggerSource]);
     }
     const usagePricingResolution = await createTerraUsagePricingResolution();
     mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -16,6 +16,12 @@ import {
   readChatEventContextFixture,
   readRunUsageEventsFixture,
 } from "../../../test-fixtures/chat-events";
+import {
+  countPiMemoryStage1CandidatesFixture,
+  readmitPiMemoryStage1CandidateFixture,
+  readPiConversationIdentityFixture,
+  readPiMemoryStage1CandidateFixture,
+} from "../../../test-fixtures/pi-memory-stage1-candidates";
 import { seededSystemSkillArchive } from "../../../test-fixtures/seeded-system-skill-archive";
 import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -913,10 +919,16 @@ function mockCanonicalSlackPiProvider(): PiProviderRequest[] {
         authorization: request.headers.get("authorization"),
         body: await request.json(),
       });
-      return new HttpResponse(
+      const answer =
         sequence === 0
-          ? piResponsesTextSse("Canonical Slack Pi answer", sequence)
-          : piResponsesToolSse(sequence),
+          ? "Canonical Slack Pi answer"
+          : sequence === 2
+            ? "Continued Slack Pi answer"
+            : null;
+      return new HttpResponse(
+        answer === null
+          ? piResponsesToolSse(sequence)
+          : piResponsesTextSse(answer, sequence),
         { headers: { "content-type": "text/event-stream" } },
       );
     }),
@@ -993,9 +1005,10 @@ async function expectFirstSlackPiExecution(args: {
   return binding.agent_session_id;
 }
 
-async function expectFirstSlackPiOwnership(args: {
+async function expectSlackPiOwnership(args: {
   readonly scenario: CanonicalSlackPiScenario;
   readonly runId: string;
+  readonly assistantText: string;
 }): Promise<void> {
   await expect
     .poll(async () => {
@@ -1034,7 +1047,7 @@ async function expectFirstSlackPiOwnership(args: {
     expect.objectContaining({
       channel: args.scenario.channelId,
       thread_ts: args.scenario.threadTs,
-      text: "Canonical Slack Pi answer",
+      text: args.assistantText,
     }),
   );
   await expect(readRunUsageEventsFixture(args.runId)).resolves.toStrictEqual(
@@ -1055,7 +1068,7 @@ async function expectFirstSlackPiOwnership(args: {
       return (
         event.runId === args.runId &&
         event.eventType === "output.message" &&
-        event.content === "Canonical Slack Pi answer"
+        event.content === args.assistantText
       );
     }),
   ).toHaveLength(1);
@@ -1176,6 +1189,114 @@ async function cancelContinuedSlackPiTurn(args: {
     );
   });
   expect(terminalEvents).toHaveLength(1);
+}
+
+async function runSuccessfulContinuedSlackPiTurn(args: {
+  readonly scenario: CanonicalSlackPiScenario;
+  readonly providerRequests: readonly PiProviderRequest[];
+  readonly firstPrompt: string;
+  readonly firstSessionId: string;
+}) {
+  context.mocks.slack.chat.postMessage.mockClear();
+  const prompt = "complete a newer canonical Slack Pi history";
+  await integrations.postSlackEvent(args.scenario.teamId, {
+    type: "app_mention",
+    user: args.scenario.slackUserId,
+    text: prompt,
+    ts: "2912.000400",
+    thread_ts: args.scenario.threadTs,
+    channel: args.scenario.channelId,
+    channel_type: "channel",
+  });
+  let runId: string | undefined;
+  await expect
+    .poll(async () => {
+      const state = await integrations.readSlackTestState(args.scenario.teamId);
+      runId = state.recent_runs.find((run) => {
+        return run.promptPreview?.includes(prompt) === true;
+      })?.id;
+      return runId;
+    })
+    .toStrictEqual(expect.any(String));
+  if (!runId) {
+    throw new Error("Expected the continued canonical Slack Pi run");
+  }
+  const completedRunId = runId;
+  await expect
+    .poll(async () => {
+      return (await runs.readRun(args.scenario.actor, completedRunId)).status;
+    })
+    .toBe("completed");
+  await flushWaitUntilForTest();
+
+  expect(args.providerRequests).toHaveLength(3);
+  const providerInput = JSON.stringify(args.providerRequests[2]?.body);
+  expect(providerInput).toContain(args.firstPrompt);
+  expect(providerInput).toContain("Canonical Slack Pi answer");
+  expect(providerInput).toContain(prompt);
+  await expect(
+    readRunLaunchSnapshotFixture(context, completedRunId),
+  ).resolves.toMatchObject({ launch_snapshot: { framework: "pi" } });
+  const binding = await readThreadSessionBinding(
+    context,
+    args.scenario.chatThreadId,
+  );
+  expect(binding.agent_session_id).toBe(args.firstSessionId);
+  return { prompt, runId: completedRunId };
+}
+
+async function expectSlackPiMemoryCandidate(args: {
+  readonly scenario: CanonicalSlackPiScenario;
+  readonly runId: string;
+  readonly outcome: "created" | "replaced";
+}) {
+  const conversation = await readPiConversationIdentityFixture(args.runId);
+  const run = await runs.readRun(args.scenario.actor, args.runId);
+  if (!run.completedAt) {
+    throw new Error("Expected completed Slack Pi run timestamp");
+  }
+  const candidate = await readPiMemoryStage1CandidateFixture({
+    orgId: args.scenario.orgId,
+    userId: args.scenario.actor.userId,
+  });
+  if (!candidate) {
+    throw new Error("Expected Slack Pi history to create a memory candidate");
+  }
+  expect(candidate).toMatchObject({
+    orgId: args.scenario.orgId,
+    userId: args.scenario.actor.userId,
+    memoryStorageName: "memory",
+    piSessionId: args.scenario.chatThreadId,
+    sourceRunId: args.runId,
+    sourceHistoryHash: conversation.sourceHistoryHash,
+    sourceCompletedAt: new Date(run.completedAt),
+    status: "pending",
+    retryCount: 0,
+    usageCount: 0,
+  });
+  expect(conversation.piSessionId).toBe(args.scenario.chatThreadId);
+  expect(candidate.memoryStorageS3Prefix).toBe(
+    `${args.scenario.orgId}/${candidate.memoryStorageId}`,
+  );
+  expect(
+    candidate.eligibleAt.getTime() - candidate.sourceCompletedAt.getTime(),
+  ).toBe(60_000);
+  expect(sandboxOperationEventsForRun(args.runId)).toContainEqual(
+    expect.objectContaining({
+      op_type: "pi_memory_stage1_candidate_admission",
+      candidate_outcome: args.outcome,
+      memory_storage_id: candidate.memoryStorageId,
+      pi_session_id: args.scenario.chatThreadId,
+      source_history_hash: conversation.sourceHistoryHash,
+    }),
+  );
+  await expect(
+    countPiMemoryStage1CandidatesFixture({
+      memoryStorageId: candidate.memoryStorageId,
+      piSessionId: candidate.piSessionId,
+    }),
+  ).resolves.toBe(1);
+  return candidate;
 }
 
 function telegramDomainProbe() {
@@ -2862,6 +2983,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
   });
 
   it("admits canonical Slack turns into one Pi session without duplicate ownership", async () => {
+    mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);
     const scenario = await establishCanonicalSlackHistory(
       await configureCanonicalSlackPiActor(),
     );
@@ -2872,7 +2994,16 @@ describe("INT-01: Slack app deep webhook flows", () => {
       providerRequests,
       turn: firstTurn,
     });
-    await expectFirstSlackPiOwnership({ scenario, runId: firstTurn.runId });
+    await expectSlackPiOwnership({
+      scenario,
+      runId: firstTurn.runId,
+      assistantText: "Canonical Slack Pi answer",
+    });
+    const firstCandidate = await expectSlackPiMemoryCandidate({
+      scenario,
+      runId: firstTurn.runId,
+      outcome: "created",
+    });
     const continuedTurn = await claimContinuedSlackPiTurn({
       scenario,
       providerRequests,
@@ -2884,7 +3015,46 @@ describe("INT-01: Slack app deep webhook flows", () => {
       providerRequests,
       turn: continuedTurn,
     });
-    expect(providerRequests).toHaveLength(2);
+    await expect(
+      readPiMemoryStage1CandidateFixture({
+        orgId: scenario.orgId,
+        userId: scenario.actor.userId,
+      }),
+    ).resolves.toStrictEqual(firstCandidate);
+
+    const successfulContinuation = await runSuccessfulContinuedSlackPiTurn({
+      scenario,
+      providerRequests,
+      firstPrompt: firstTurn.prompt,
+      firstSessionId,
+    });
+    await expectSlackPiOwnership({
+      scenario,
+      runId: successfulContinuation.runId,
+      assistantText: "Continued Slack Pi answer",
+    });
+    const replacedCandidate = await expectSlackPiMemoryCandidate({
+      scenario,
+      runId: successfulContinuation.runId,
+      outcome: "replaced",
+    });
+    expect(replacedCandidate).toMatchObject({
+      memoryStorageId: firstCandidate.memoryStorageId,
+      piSessionId: firstCandidate.piSessionId,
+    });
+    expect(replacedCandidate.sourceHistoryHash).not.toBe(
+      firstCandidate.sourceHistoryHash,
+    );
+    await expect(
+      readmitPiMemoryStage1CandidateFixture(successfulContinuation.runId),
+    ).resolves.toMatchObject({ outcome: "exact_retry" });
+    const afterExactRetry = await readPiMemoryStage1CandidateFixture({
+      orgId: scenario.orgId,
+      userId: scenario.actor.userId,
+    });
+    expect(afterExactRetry?.updatedAt).toStrictEqual(
+      replacedCandidate.updatedAt,
+    );
   }, 90_000);
 
   it("keeps canonical Slack status stable across failed delivery and cancellation", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1250,6 +1250,8 @@ async function expectSlackPiMemoryCandidate(args: {
   readonly runId: string;
   readonly outcome: "created" | "replaced";
 }) {
+  // Stage 1 candidates intentionally have no production read API. Observe the
+  // private identity only after real Slack ingress and completion own the run.
   const conversation = await readPiConversationIdentityFixture(args.runId);
   const run = await runs.readRun(args.scenario.actor, args.runId);
   if (!run.completedAt) {

--- a/turbo/apps/api/src/signals/services/chat-trigger-source.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-trigger-source.service.ts
@@ -1,7 +1,42 @@
 import type { TriggerSource } from "@okouai/api-contracts/contracts/logs";
 
+type PiMemoryInteractiveChatTriggerSource = Extract<
+  TriggerSource,
+  | "web"
+  | "agent"
+  | "slack"
+  | "feishu"
+  | "teams"
+  | "telegram"
+  | "agentphone"
+  | "github"
+>;
+
+const PI_MEMORY_INTERACTIVE_CHAT_TRIGGER_SOURCES = {
+  web: true,
+  slack: true,
+  teams: true,
+  feishu: true,
+  email: false,
+  telegram: true,
+  agentphone: true,
+  github: true,
+  test: false,
+  agent: true,
+  webhook: false,
+  "automation-schedule": false,
+  "automation-event": false,
+  goal: false,
+} as const satisfies Readonly<Record<TriggerSource, boolean>>;
+
 export function isWebChatTriggerSource(
   triggerSource: TriggerSource,
 ): triggerSource is Extract<TriggerSource, "web" | "agent"> {
   return triggerSource === "web" || triggerSource === "agent";
+}
+
+export function isPiMemoryInteractiveChatTriggerSource(
+  triggerSource: TriggerSource,
+): triggerSource is PiMemoryInteractiveChatTriggerSource {
+  return PI_MEMORY_INTERACTIVE_CHAT_TRIGGER_SOURCES[triggerSource];
 }

--- a/turbo/apps/api/src/signals/services/pi-memory-stage1-candidate.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-stage1-candidate.service.ts
@@ -11,7 +11,7 @@ import type { Tx } from "../../lib/db-types";
 import { nowDate } from "../../lib/time";
 import { advancePiMemoryPhase2InputRevision } from "./pi-memory-phase2-job.service";
 import { newStorageS3Location } from "./storage-s3-prefix.utils";
-import { isWebChatTriggerSource } from "./chat-trigger-source.service";
+import { isPiMemoryInteractiveChatTriggerSource } from "./chat-trigger-source.service";
 
 export type PiMemoryStage1AdmissionSkipReason =
   | "generation_disabled"
@@ -19,7 +19,7 @@ export type PiMemoryStage1AdmissionSkipReason =
   | "missing_chat_thread"
   | "not_completed"
   | "not_pi"
-  | "source_not_web_chat"
+  | "source_not_interactive_chat"
   | "stale_source";
 
 export type PiMemoryStage1Admission =
@@ -63,8 +63,11 @@ export function getPiMemoryStage1AdmissionPrerequisiteSkipReason(
     return "generation_disabled";
   }
   const triggerSource = triggerSourceSchema.safeParse(args.triggerSource);
-  if (!triggerSource.success || !isWebChatTriggerSource(triggerSource.data)) {
-    return "source_not_web_chat";
+  if (
+    !triggerSource.success ||
+    !isPiMemoryInteractiveChatTriggerSource(triggerSource.data)
+  ) {
+    return "source_not_interactive_chat";
   }
   if (args.chatThreadId === null) {
     return "missing_chat_thread";

--- a/turbo/apps/api/src/test-fixtures/pi-memory-stage1-candidates.ts
+++ b/turbo/apps/api/src/test-fixtures/pi-memory-stage1-candidates.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, count, eq } from "drizzle-orm";
 
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { conversations } from "@okouai/db/schema/conversation";
@@ -159,6 +159,22 @@ export async function readPiMemoryStage1CandidateFixture(args: {
     )
     .limit(1);
   return candidate ?? null;
+}
+
+export async function countPiMemoryStage1CandidatesFixture(args: {
+  readonly memoryStorageId: string;
+  readonly piSessionId: string;
+}): Promise<number> {
+  const [result] = await db()
+    .select({ value: count() })
+    .from(piMemoryStage1Candidates)
+    .where(
+      and(
+        eq(piMemoryStage1Candidates.memoryStorageId, args.memoryStorageId),
+        eq(piMemoryStage1Candidates.piSessionId, args.piSessionId),
+      ),
+    );
+  return result?.value ?? 0;
 }
 
 export async function readPiConversationIdentityFixture(runId: string) {


### PR DESCRIPTION
## Summary

- add a dedicated, exhaustively typed Pi memory classifier for exactly `web`, `agent`, `slack`, `feishu`, `teams`, `telegram`, `agentphone`, and `github`, without changing the existing Web-only helper or its callers
- rename the Stage 1 exclusion to the accurate `source_not_interactive_chat` telemetry reason while keeping automation, Goal, email, webhook, test, null/unknown, and threadless work fail closed
- extend the real canonical Slack Pi ingress scenario to prove exact candidate creation, cancelled-run exclusion, same-session newer-history replacement, one-row ownership, exact-retry idempotency, and unchanged provider/callback/delivery/billing behavior

Parent: #32168

Closes #32375

## Baseline and overlap

- initial freshly fetched and rebased implementation baseline: `02b87392dba2e9d2c61ad34734ad3f091110d461`
- latest pre-PR rebase baseline after `origin/main` advanced: `444838d28830285b1ed0366a42d164c6db47a82e`
- live paged inventory immediately before commit: 24 open PRs, 298 changed files inspected, zero relevant file overlaps
- complete production caller search confirms `isWebChatTriggerSource` remains unchanged at its two unrelated Web-only callers; terminal completion remains the sole production Stage 1 admission caller

## Acceptance criteria

- [x] the exact interactive-memory source set is `web | agent | slack | feishu | teams | telegram | agentphone | github`
- [x] `isWebChatTriggerSource` and its preview/image-upload callers remain Web-only; the new classifier is exhaustive over every `TriggerSource`
- [x] automation schedule/event, Goal, email, webhook, test, null/unknown, and threadless maintenance remain excluded with `source_not_interactive_chat` telemetry where applicable
- [x] real Slack ingress creates a candidate with the exact organization/user owner, run, canonical Pi session, native history hash, completion watermark, and configured idle deadline
- [x] a later successful same-thread Slack Pi completion preserves the session, replaces only the newer exact history, retains one candidate row, and readmission returns `exact_retry` without changing `updatedAt`
- [x] failed/cancelled, generation-disabled, non-Pi, missing-thread/blob, stale completion, exact retry, lease/revision fencing, Web/agent admission, and actual maintenance non-recursion remain covered by focused existing integration tests
- [x] provider request counts, once-only terminal callback/Slack delivery, and zero extra usage events are asserted on the real Slack path
- [x] no switch, launch-snapshot field/version, schema, migration, backfill, replay, model/provider route, execution admission, connector ingress, callback, billing, projection, Phase 2, or maintenance lifecycle changed

## Verification

- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts apps/api/src/signals/services/chat-trigger-source.service.ts apps/api/src/signals/services/pi-memory-stage1-candidate.service.ts apps/api/src/test-fixtures/pi-memory-stage1-candidates.ts`
- `pnpm --filter api check-types`
- `pnpm --filter api lint`
- `pnpm knip` (exit 0; 43 pre-existing configuration hints only)
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts -t 'admits canonical Slack turns into one Pi session without duplicate ownership'` (1 passed)
- `DATABASE_URL=... pnpm --filter api exec vitest run src/signals/routes/__tests__/chat-events.bdd.test.ts -t 'keeps webhook completion failure and non-interactive source exclusions|admits an exact Pi history from an agent-authenticated same-owner chat send|admits exact Pi web histories with immutable launch policy and stale-lease fencing'` (3 passed)
- `cargo build --manifest-path crates/Cargo.toml --profile local -p guest-agent -j 2`
- `DATABASE_URL=... pnpm --filter api exec vitest run --config vitest.maintenance.config.ts -t "settles changed output exactly once through 'none'"` (1 passed)
- `git diff --check`

## Rollout

This is forward-only Stage 1 admission behind the existing Pi execution policy. It performs no replay or backfill. Release, deployment approval, promotion, and production canary remain with the parent controller and designated Production Release workflow.
