### PR TITLE
test(runner): isolate workspace gc scenarios from host discovery

### DIFF
--- a/crates/runner/src/cmd/gc/workspaces/tests.rs
+++ b/crates/runner/src/cmd/gc/workspaces/tests.rs
@@ -1,3 +1,6 @@
+//! Filesystem scenarios use explicit process discovery state so unrelated host
+//! processes cannot trigger the production fail-closed guard before assertions.
+
 use std::time::Duration;
 
 use nix::fcntl::FlockArg;
@@ -313,7 +316,16 @@ async fn gc_workspace_orphans_deletes_old_orphan() {
         .set_times(FileTimes::new().set_modified(old_time))
         .unwrap();
 
-    let summary = gc_workspace_orphans(&home, false).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert!(!workspace.exists(), "orphaned workspace should be deleted");
     assert_eq!(summary.workspaces_cleaned, 1);
@@ -391,7 +403,16 @@ async fn gc_workspace_orphans_skips_recent() {
 
     write_base_dir_lock(&home, &base_dir);
 
-    let summary = gc_workspace_orphans(&home, false).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert!(workspace.exists(), "recent workspace should NOT be deleted");
     assert_eq!(summary.workspaces_cleaned, 0);
@@ -748,7 +769,16 @@ async fn gc_workspace_orphans_skips_non_directory_entries() {
 
     write_base_dir_lock(&home, &base_dir);
 
-    let summary = gc_workspace_orphans(&home, false).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
     assert_eq!(summary.workspaces_cleaned, 0);
     assert!(stray_file.exists(), "non-directory entries must be skipped");
 }
@@ -766,7 +796,16 @@ async fn gc_workspace_orphans_base_dir_without_workspaces_subdir() {
 
     write_base_dir_lock(&home, &base_dir);
 
-    let summary = gc_workspace_orphans(&home, false).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
     assert_eq!(summary.workspaces_cleaned, 0);
     assert_eq!(summary.bytes_freed, 0);
     assert_eq!(summary.base_dir_locks_removed, 1);
@@ -802,7 +841,16 @@ async fn gc_workspace_orphans_mixed_old_and_recent() {
 
     write_base_dir_lock(&home, &base_dir);
 
-    let summary = gc_workspace_orphans(&home, false).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         summary.workspaces_cleaned, 1,
@@ -833,7 +881,16 @@ async fn gc_workspace_orphans_skips_symlink_workspaces_dir() {
 
     write_base_dir_lock(&home, &base_dir);
 
-    let summary = gc_workspace_orphans(&home, false).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.workspaces_cleaned, 0);
     assert_eq!(summary.bytes_freed, 0);
@@ -865,7 +922,16 @@ async fn gc_workspace_orphans_skips_symlink_base_dir() {
 
     write_base_dir_lock(&home, &base_dir);
 
-    let summary = gc_workspace_orphans(&home, false).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.workspaces_cleaned, 0);
     assert_eq!(summary.bytes_freed, 0);
@@ -896,7 +962,16 @@ async fn gc_workspace_orphans_skips_symlink_workspace_entry() {
 
     write_base_dir_lock(&home, &base_dir);
 
-    let summary = gc_workspace_orphans(&home, false).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(summary.workspaces_cleaned, 0);
     assert_eq!(summary.bytes_freed, 0);
@@ -1039,7 +1114,16 @@ async fn gc_workspace_orphans_multiple_base_dirs() {
             .unwrap();
     }
 
-    let summary = gc_workspace_orphans(&home, false).await.unwrap();
+    let summary = gc_workspace_orphans_with_candidates(
+        discover_base_dir_lock_candidates(&home),
+        &[],
+        &HashSet::new(),
+        false,
+        SystemTime::now(),
+        false,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         summary.workspaces_cleaned, 2,


### PR DESCRIPTION
## Summary

- Isolate the remaining nine filesystem-focused workspace GC scenarios from live host process discovery.
- Reuse the existing candidate-processing entry point with explicit complete, empty process state while retaining real lock discovery, flock ownership, filesystem traversal, age checks, deletion, accounting, and all existing assertions.
- Keep the no-candidate top-level entry-point test and the existing uncertain-discovery and live-ownership safety tests.

## Problem and reproduction

`gc_workspace_orphans_multiple_base_dirs` called the top-level GC entry point, which deliberately returns an empty summary when host process discovery cannot safely establish workspace ownership. The test assumed that the host scan would always be conclusive.

A controlled reproduction on the unmodified code passed without interference, then failed with the reported `left: 0, right: 2` assertion while an ordinary `sleep` process used `firecracker` as argv[0] and a working directory outside the workspace layout. The temporary process was terminated and reaped after the experiment.

This finishes the same isolation applied to individual scenarios in #26315 and #29087. It also prevents preservation scenarios from passing without exercising their intended filesystem checks when the top-level safety guard skips the pass.

## Scope and risk

- Test-only change in one file; production GC and its fail-closed safeguards are unchanged.
- No retries, sleeps, increased timeouts, skipped tests, weakened assertions, dependencies, or new production test hooks.
- These filesystem scenarios no longer cover live host discovery implicitly; process discovery and uncertain/live ownership remain covered by their existing tests.
- No API, protocol, persisted-state, or deployment compatibility changes.

## Validation

Commands ran from `crates/` unless noted:

- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p runner --all-targets --all-features -j 4 -- -D warnings`
- `cargo doc --profile local -p runner --all-features --no-deps -j 4`
- `cargo test --profile local -p runner --bin runner --all-features -j 4 cmd::gc:: -- --quiet`: 209 passed, 3 existing ignored tests.
- The compiled runner test binary with `cmd::gc::workspaces::tests:: --test-threads=4 --quiet`: 50 consecutive runs with the same unattributed Firecracker-like process present; all 33 tests passed on every run (1,650 executions).
- `cargo test --profile local -p runner --bin runner --all-features -j 4 -- --quiet`: 3,538 passed, 0 failed, 25 existing ignored tests.
- `git diff --check`
- Native pre-commit hooks: workspace Cargo formatting, Clippy, documentation, file-size check, and commitlint passed.
