### PR TITLE
test(platform): preserve cancelled page startup ownership

### DIFF
--- a/docs/testing/app-testing.md
+++ b/docs/testing/app-testing.md
@@ -25,6 +25,12 @@ a rendered page can cover the behavior.
 the requested locale, renders the complete Router, and resolves after the first
 page content is observable. Always await it before the first page assertion.
 
+Startup belongs to the test context's original abort signal. Cancelling that
+lifetime rejects `setupPage()` and a pending `startPage().ready`; cancellation
+is not page readiness. Tests that inspect blocked startup may leave
+`startPage().ready` unawaited: the shared helper owns its cancellation rejection
+and observer cleanup.
+
 Every page test follows this order:
 
 1. Configure fixtures and external mocks.

--- a/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
+++ b/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
@@ -5,7 +5,9 @@ import { expect, test, vi } from "vitest";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { mockedClerk } from "./mock-auth.ts";
-import { queryAllByRoleFast, setupPage } from "./page-helper.ts";
+import { queryAllByRoleFast, setupPage, startPage } from "./page-helper.ts";
+import frFRCommon from "../i18n/locales/fr-FR/common.json";
+import frFRCommonUrl from "../i18n/locales/fr-FR/common.json?url";
 import { testContext } from "../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -102,6 +104,72 @@ test("The SharedWorker owns realtime when its feature switch is enabled", async 
     ).toBeTruthy();
   });
   expect(context.mocks.ably.getAuthTokenHistory()).toHaveLength(1);
+});
+
+test.each(["setupPage", "startPage"])(
+  "%s does not report cancelled authentication startup as ready",
+  async (entryPoint) => {
+    const clerkLoad = context.mocks.clerk().runtimePending();
+    const controller = new AbortController();
+    const options = {
+      context: {
+        ...context,
+        signal: AbortSignal.any([context.signal, controller.signal]),
+      },
+      host: "app.vm0.ai",
+      path: "/agents",
+    };
+    const pageReady =
+      entryPoint === "setupPage"
+        ? setupPage(options)
+        : (await startPage(options)).ready;
+
+    const skeleton = await screen.findByTestId("app-skeleton");
+    expect(skeleton).toBeVisible();
+    const reason = new DOMException("Page startup cancelled", "AbortError");
+    controller.abort(reason);
+    clerkLoad.resolve();
+    await expect(pageReady).rejects.toBe(reason);
+
+    expect(screen.queryByRole("heading", { name: "Agents" })).toBeNull();
+    expect(skeleton).not.toBeInTheDocument();
+  },
+);
+
+test("Cancelled locale startup does not adopt a replacement lifetime", async () => {
+  const localeRequested = context.mocks.deferred<Request>();
+  const localeResponse = context.mocks.deferred<void>();
+  context.mocks.http.get(frFRCommonUrl, async ({ request }) => {
+    localeRequested.resolve(request);
+    await localeResponse.promise;
+    return HttpResponse.json(frFRCommon);
+  });
+  const controller = new AbortController();
+  let currentSignal = AbortSignal.any([context.signal, controller.signal]);
+  const startup = startPage({
+    context: {
+      ...context,
+      get signal() {
+        return currentSignal;
+      },
+    },
+    host: "app.vm0.ai",
+    path: "/agents",
+    locale: "fr-FR",
+  });
+  const request = await localeRequested.promise;
+  const reason = new DOMException("Locale startup cancelled", "AbortError");
+  controller.abort(reason);
+  // Model testContext replacing its lifetime while old startup is suspended.
+  currentSignal = context.signal;
+  localeResponse.resolve();
+  await expect(startup).rejects.toBe(reason);
+
+  expect(request.signal.aborted).toBeTruthy();
+  expect(screen.queryByTestId("app-skeleton")).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("heading", { name: "Agents" }),
+  ).not.toBeInTheDocument();
 });
 
 test("Authentication startup is reused without a duplicate load", async () => {

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -22,7 +22,7 @@ import { setMockFeatureSwitches } from "../mocks/handlers/api-feature-switches.h
 import { FEATURE_SWITCH_CACHE_KEY } from "../signals/external/feature-switch-state";
 import { localStorageSignals } from "../signals/external/local-storage";
 import { setDebugLoggerLocalStorage$ } from "../signals/bootstrap/loggers";
-import { detach, Reason } from "../signals/utils";
+import { createDeferredPromise, detach, Reason } from "../signals/utils";
 import {
   setupSharedWorkerTestBootstrap$,
   type SharedWorkerTestTransport,
@@ -264,34 +264,33 @@ function resolveAuth(options: SetupPageOptions): {
 
 async function setupPageAsync(
   options: SetupPageOptions,
+  signal: AbortSignal,
   pageRendered: () => void,
 ): Promise<void> {
   ensureTestLocalStorage();
-  applyPageEnvironment(options.env, options.context.signal);
+  applyPageEnvironment(options.env, signal);
   await initializeI18nWithResources(
-    await loadInitialLocaleResources(options.locale ?? DEFAULT_LOCALE),
+    await loadInitialLocaleResources(options.locale ?? DEFAULT_LOCALE, signal),
+    signal,
   );
+  signal.throwIfAborted();
   // setupPage exercises the shared MSW fixture data even when a test does not
   // customize a handler. Start the lazy mock lifecycle so abort resets any
   // fixture mutations made by the application during this test.
-  void options.context.mocks;
+  const { mocks, store, workerStore } = options.context;
   if (options.locale) {
-    options.context.mocks.data.userPreferences({
+    mocks.data.userPreferences({
       locale: options.locale,
       supportedLocales: [...SUPPORTED_LOCALES],
     });
   }
   const initialUrl = initialPageUrl(options.path, options.host ?? "localhost");
-  options.context.mocks.browser.url(initialUrl.toString());
-  createPushStateMock(options.context.signal, initialUrl);
-  installClerkBootstrap(
-    initialUrl,
-    options.primaryAppDomain,
-    options.context.signal,
-  );
+  mocks.browser.url(initialUrl.toString());
+  createPushStateMock(signal, initialUrl);
+  installClerkBootstrap(initialUrl, options.primaryAppDomain, signal);
 
   if (options.debugLoggers) {
-    options.context.store.set(
+    store.set(
       setDebugLoggerLocalStorage$,
       JSON.stringify(options.debugLoggers ?? []),
     );
@@ -303,14 +302,14 @@ async function setupPageAsync(
   // Reading featureSwitch$ is synchronous, so the cache must be in place
   // before bootstrap starts its SWR refresh.
   const auth = resolveAuth(options);
-  const clerk = options.context.mocks.clerk();
+  const clerk = mocks.clerk();
   const activeOrgId = auth.organization.activeOrg?.id ?? null;
   const featureSwitchOverrides = { ...options.featureSwitches };
   if (options.featureSwitches) {
     setMockFeatureSwitches(featureSwitchOverrides);
   }
   if (!options.preserveFeatureSwitchCache) {
-    options.context.store.set(clearFeatureSwitchCacheForTest$);
+    store.set(clearFeatureSwitchCacheForTest$);
     const cachedFeatureSwitchOverrides = {
       ...(options.cachedFeatureSwitches ?? featureSwitchOverrides),
     };
@@ -318,17 +317,14 @@ async function setupPageAsync(
       orgId: activeOrgId ?? undefined,
       overrides: cachedFeatureSwitchOverrides,
     });
-    options.context.store.set(
-      setFeatureSwitchCacheForTest$,
-      cachedFeatureSwitches,
-    );
+    store.set(setFeatureSwitchCacheForTest$, cachedFeatureSwitches);
   }
   clerk.sessionSignedOut(auth.signedOut);
   clerk.user(auth.user, auth.session);
   clerk.organization(auth.organization);
   const user = auth.user;
   if (user) {
-    options.context.mocks.api(authContract.me, ({ respond }) => {
+    mocks.api(authContract.me, ({ respond }) => {
       return respond(200, {
         userId: user.id,
         email: user.email ?? "test@example.com",
@@ -336,11 +332,11 @@ async function setupPageAsync(
       });
     });
   }
-  options.context.store.set(
+  store.set(
     setupSharedWorkerTestBootstrap$,
     {
       appVersion: options.sharedWorkerAppVersion ?? TEST_APP_VERSION,
-      workerStore: options.context.workerStore,
+      workerStore,
       cachedChatThreadEvents: options.cachedChatThreadEvents,
       identity:
         auth.user && activeOrgId
@@ -348,9 +344,9 @@ async function setupPageAsync(
           : null,
       transport: options.sharedWorkerTestTransport ?? "direct",
     },
-    options.context.signal,
+    signal,
   );
-  options.context.signal.addEventListener(
+  signal.addEventListener(
     "abort",
     () => {
       toast.dismiss();
@@ -361,20 +357,20 @@ async function setupPageAsync(
   // Not wrapped in act() — background polling loops would cause act() to
   // hang indefinitely waiting for them to settle. React "not wrapped in
   // act" warnings are suppressed in setup.ts.
-  options.context.signal.throwIfAborted();
-  const runtime = options.context.store.set(
+  signal.throwIfAborted();
+  const runtime = store.set(
     bootstrap$,
     options.appVersion ?? TEST_APP_VERSION,
     () => {
-      setupRouter(options.context.store, (element) => {
+      setupRouter(store, (element) => {
         const { unmount } = render(element);
         pageRendered();
-        options.context.signal.addEventListener("abort", unmount, {
+        signal.addEventListener("abort", unmount, {
           once: true,
         });
       });
     },
-    options.context.signal,
+    signal,
   );
   detach(
     runtime.sharedDatabaseDaemon,
@@ -395,25 +391,21 @@ function waitForFirstPageContent(signal: AbortSignal): {
 } {
   let pageHasRendered = false;
   let skeletonHasMounted = false;
-  let settled = false;
-  let resolveReady = (): void => {};
-  const ready = new Promise<void>((resolve) => {
-    resolveReady = resolve;
-  });
+  // Some startPage callers inspect blocked startup without awaiting ready.
+  // The deferred owns their cancellation rejection as well as awaited ones.
+  const ready = createDeferredPromise<void>(signal);
 
   const observer = new MutationObserver(checkPageContent);
 
-  function settle(): void {
-    if (settled) {
-      return;
-    }
-    settled = true;
+  function dispose(): void {
     observer.disconnect();
-    signal.removeEventListener("abort", settle);
-    resolveReady();
+    signal.removeEventListener("abort", dispose);
   }
 
   function checkPageContent(): void {
+    if (ready.settled()) {
+      return;
+    }
     const skeleton = document.querySelector('[data-testid="app-skeleton"]');
     skeletonHasMounted ||= skeleton !== null;
     if (
@@ -421,7 +413,8 @@ function waitForFirstPageContent(signal: AbortSignal): {
       skeletonHasMounted &&
       (skeleton === null || skeleton.getAttribute("aria-hidden") === "true")
     ) {
-      settle();
+      dispose();
+      ready.resolve();
     }
   }
 
@@ -431,7 +424,7 @@ function waitForFirstPageContent(signal: AbortSignal): {
     childList: true,
     subtree: true,
   });
-  signal.addEventListener("abort", settle, { once: true });
+  signal.addEventListener("abort", dispose, { once: true });
   checkPageContent();
 
   return {
@@ -439,7 +432,7 @@ function waitForFirstPageContent(signal: AbortSignal): {
       pageHasRendered = true;
       checkPageContent();
     },
-    ready,
+    ready: ready.promise,
   };
 }
 
@@ -450,14 +443,21 @@ interface StartedPage {
 export async function startPage(
   options: SetupPageOptions,
 ): Promise<StartedPage> {
-  const content = waitForFirstPageContent(options.context.signal);
-  await setupPageAsync(options, content.pageRendered);
+  // testContext rotates its signal at teardown; async startup belongs to the
+  // lifetime that initiated it, never the next test's context.
+  const signal = options.context.signal;
+  signal.throwIfAborted();
+  const content = waitForFirstPageContent(signal);
+  await setupPageAsync(options, signal, content.pageRendered);
+  signal.throwIfAborted();
   return { ready: content.ready };
 }
 
 export async function setupPage(options: SetupPageOptions): Promise<void> {
+  const signal = options.context.signal;
   const page = await startPage(options);
   await page.ready;
+  signal.throwIfAborted();
 }
 
 // Helper to create a browser history mock that updates mockLocation.

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
@@ -237,6 +237,8 @@ test("Use the fallback window before sidebar geometry is available", async () =>
       within(sidebar).getAllByTestId("sidebar-chat-thread-virtual-row"),
     ).toHaveLength(100);
   });
+  expect(within(sidebar).getByText("History 100")).toBeInTheDocument();
+  expect(within(sidebar).queryByText("History 101")).not.toBeInTheDocument();
 });
 
 test("Coalesce sidebar resize bursts and cancel pending measurements when hidden", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar.test.tsx
@@ -665,13 +665,12 @@ function mockLongSidebarHistory(): void {
       `Refresh overflow ${index + 1}`,
     );
   });
-  mockSidebarThreadStory(
-    [
-      createThread(EXISTING_THREAD_ID, "Release plan"),
-      createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
-    ],
-    [...overflowThreads, createThread(ARCHIVED_THREAD_ID, "Archived context")],
-  );
+  mockSidebarThreadStory([
+    createThread(EXISTING_THREAD_ID, "Release plan"),
+    createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
+    ...overflowThreads,
+    createThread(ARCHIVED_THREAD_ID, "Archived context"),
+  ]);
 }
 
 async function scrollToArchivedContext(): Promise<HTMLElement> {
@@ -679,6 +678,9 @@ async function scrollToArchivedContext(): Promise<HTMLElement> {
     expect(
       within(sidebar()).getByTestId("sidebar-chat-threads-virtual-list"),
     ).toBeInTheDocument();
+    expect(
+      within(sidebar()).getAllByTestId("sidebar-chat-thread-virtual-row"),
+    ).toHaveLength(14);
   });
 
   const scrollArea = within(sidebar()).getByTestId("sidebar-scroll-area");
@@ -1660,15 +1662,6 @@ test("Mark conversations read and unread from the sidebar", async () => {
       );
     },
   );
-  context.mocks.api(browserContract.get, ({ respond }) => {
-    return respond(404, {
-      error: {
-        code: "BROWSER_NOT_FOUND",
-        message: "Managed browser not found",
-      },
-    });
-  });
-
   await setupSidebarPage({ context, path: `/chats/${EXISTING_THREAD_ID}` });
 
   await waitFor(() => {


### PR DESCRIPTION
## Summary

Relates to #32324. The sidebar readiness work in #32365 is already merged; this PR contains the remaining test-only startup-lifetime correction discovered during that investigation.

- Keep asynchronous page startup on its original abort signal through locale loading, bootstrap and router rendering. A cancelled startup must not continue using the next test's context or report success.
- Use the existing abort-aware deferred for first-content readiness. Cancellation rejects `setupPage()` and pending `startPage().ready`, while observer disposal and rejection ownership also cover callers that intentionally leave readiness unawaited.
- Add rendered-page, externally Clerk-gated cancellation regressions for both entry points, plus a suspended locale-download regression that rotates the supplied context lifetime. Document cancellation ownership.
- Preserve the mutable long-history fixture so deleting an archived thread removes it from later snapshots, and retain explicit 14-row and fallback 100/101 viewport bounds on the merged sidebar scenarios. Remove the now-duplicate browser-absence mock.

No production UI, user workflow, authentication runtime, API, persistence, dependency, timeout or CI scheduling changes. No sleeps, skipped tests, internal module mocks or manual detached-work cleanup. The cancellation reproduction proves false readiness; it is not a claim that every historical timeout had that same cause.

## Validation

On main `444838d288` plus this patch:

- Affected-file Prettier and `git diff --check`: passed.
- `pnpm -F @okouai/app lint`: passed.
- `pnpm knip --workspace apps/platform`: passed.
- `TSC_CHECKERS=2 pnpm check-types`: all 15 repository tasks passed, including Platform and Desktop after installing the current locked dependencies.
- Full 15-file shared-helper/sidebar cohort: **149/149 passed**, 122.71 s. Includes all current `startPage` call-site files, locale changes, startup diagnostics, auth redirects/recovery/invitations, chat metadata, prompt links, cache/offline flows and search debounce.
- Repeated seven-file sidebar/startup/search cohort: **91/91 passed**, 89.54 s, unchanged source.

Tests run sequentially with one Vitest process, `--maxWorkers=2 --silent=passed-only`, existing five-second limits and a command-local empty `VITE_AXIOM_CLIENT_TELEMETRY_TOKEN`. The original helper failed the controlled Clerk cancellation regression in 176 ms and the locale/lifetime-rotation regression in 312 ms; the latter resolved startup instead of rejecting cancellation. The corrected complete authentication file passes 12/12.

The broad cohort command, from `turbo` (also emitted a native JSON validation report):

```sh
VITE_AXIOM_CLIENT_TELEMETRY_TOKEN='' pnpm -F @okouai/app exec vitest run \
  src/views/okou-page/__tests__/sidebar.test.tsx \
  src/views/okou-page/__tests__/sidebar-virtualization.test.tsx \
  src/views/okou-page/__tests__/sidebar-pin-order.test.tsx \
  src/views/okou-page/__tests__/chat-list-cache.test.tsx \
  src/views/okou-page/__tests__/chat-offline-cache.test.tsx \
  src/__tests__/authentication-startup.test.tsx \
  src/views/okou-page/__tests__/chat-search-debounce.test.tsx \
  src/signals/__tests__/startup-diagnostics.test.tsx \
  src/views/router/__tests__/link-navigation.test.tsx \
  src/views/auth-v2/__tests__/auth-v2-recovery.test.tsx \
  src/views/auth-v2/__tests__/auth-v2-navigation-hosts.test.tsx \
  src/views/auth-v2/__tests__/auth-v2-invitations.test.tsx \
  src/views/okou-page/__tests__/chat-metadata.test.tsx \
  src/views/okou-page/__tests__/prompt-link.test.tsx \
  src/views/okou-page/__tests__/localization.test.tsx \
  --maxWorkers=2 --silent=passed-only
```

The repetition uses the first seven listed files, unchanged source and the same worker/timeout settings. The full Platform suite and hosted CI are not represented by these focused local passes.
