### PR TITLE
feat(api): add runner ssh jit authority and atomic host-key pinning

### DIFF
--- a/docs/runner-ssh-authority.md
+++ b/docs/runner-ssh-authority.md
@@ -15,12 +15,17 @@ credentials or command. The shared fleet secret authenticates the fleet, not an
 individual machine: the process identity is checked against the Run's immutable
 winning claim. Protecting the fleet secret remains a trust assumption.
 
-Each call joins the current running Run, session, chat thread, Agent owner,
+Each call joins the current running Run, session, Agent owner,
 Agent SSH grant, exact owner connection and its credential. Ownership and org
 must agree. The hard staff-org gate and current `SshAccess` override both apply.
-All chat channels are treated equally. Automation schedule/event, goal,
-delegated Agent, webhook/test and non-chat Runs are excluded; a Run must have no
-workflow automation or goal association.
+SSH access depends on the user's current configuration and the Agent's current
+grant, not how the Run started. All chat channels, workflow schedule/event
+automations, goals, delegated Agents, webhooks, SDK/non-chat and test Runs use
+the same authority path. A chat thread or trigger metadata is not required;
+workflow automation and goal associations do not restrict access. The session
+identifies the Agent without using chat-thread state as an authorization gate.
+The existing staff/feature rollout and official-Runner credential boundary are
+unchanged; this does not activate SSH or expose credentials to local Runners.
 
 `POST /api/runners/runs/:runId/ssh/resolve` takes:
 

--- a/docs/runner-ssh-authority.md
+++ b/docs/runner-ssh-authority.md
@@ -1,0 +1,92 @@
+# Runner SSH authority API
+
+This is the API slice (#32386) of SSH execution (#32013, under #31932).
+It does not enable SSH or install an execution handler. Runner execution and
+generated secret-bearing Rust DTOs belong to #32387; Agent/CLI/UI and activation
+remain later delivery stages.
+
+## Authority and secret handoff
+
+Both endpoints accept only the official fleet Runner credential. A local Runner
+PAT, browser session or guest token cannot resolve credentials or learn trust.
+The request identifies a Run, connection and winning Runner process
+(`runnerId`, `heartbeatGeneration`); it cannot supply owner, Agent, endpoint,
+credentials or command. The shared fleet secret authenticates the fleet, not an
+individual machine: the process identity is checked against the Run's immutable
+winning claim. Protecting the fleet secret remains a trust assumption.
+
+Each call joins the current running Run, session, chat thread, Agent owner,
+Agent SSH grant, exact owner connection and its credential. Ownership and org
+must agree. The hard staff-org gate and current `SshAccess` override both apply.
+All chat channels are treated equally. Automation schedule/event, goal,
+delegated Agent, webhook/test and non-chat Runs are excluded; a Run must have no
+workflow automation or goal association.
+
+`POST /api/runners/runs/:runId/ssh/resolve` takes:
+
+```json
+{
+  "connectionId": "b1f329f0-8010-48fb-9884-f78c839b35bf",
+  "runnerIdentity": {
+    "runnerId": "08999e12-3b53-4206-8088-374f3c0f6a54",
+    "heartbeatGeneration": 7
+  }
+}
+```
+
+HTTP 200 has `outcome: resolved` with host, port, username, generation,
+nullable learnedHostKey, privateKey and nullable passphrase. Secret whitespace
+is preserved. This response is private to the trusted Runner, never guest RPC
+output, Run snapshots, checkpoints, logs or audit metadata. The response is
+`Cache-Control: no-store`. Downstream code must not log the response or arbitrary
+errors containing it.
+
+Missing, hidden, revoked or ineligible references all produce HTTP 200 with
+only `{"outcome":"unavailable"}`, before decryption. Invalid syntax is 400;
+missing/invalid auth is 401; authenticated local Runner auth is 403. Broken DB,
+KMS or stored local invariants remain server errors, not unavailable references.
+
+Configuration, encrypted credentials and relational authority are captured in
+one joined read, followed by the feature check. That authorized snapshot is an
+in-flight handoff: revocation cannot retract a response already authorized.
+Every later resolve checks again and sees committed rotation/deletion/revocation.
+KMS decryption runs outside transactions and row locks, so slow KMS does not
+block owner edits or revocation. Resolve never writes a learned host key.
+
+## Atomic trust on first use
+
+`POST /api/runners/runs/:runId/ssh/pin` additionally takes
+`expectedGeneration` and `observedHostKey: {algorithm, fingerprint}`. The Runner
+must first validate the server's key-exchange proof of possession, then pin
+before sending authentication. This API cannot verify that network handshake.
+Accepted identities are Ed25519, NIST P-256/P-384/P-521 ECDSA and RSA, with a
+canonical unpadded SHA256 fingerprint. `ssh-rsa` identifies an RSA public key;
+it does **not** allow SHA-1 signatures. The Runner must use SHA-2 RSA signatures.
+
+Pin first authorizes without locking. It then locks the owned connection row
+used by owner edit/reset, rechecks current authority and rollout state after
+any wait, and holds shared authority/credential row locks through the write.
+No KMS or other external call occurs in that transaction. Unauthorized calls
+do not acquire another owner's connection lock.
+
+| Stored state                                       | Result                  | Mutation                       |
+| -------------------------------------------------- | ----------------------- | ------------------------------ |
+| Unpinned, generation N equals expected             | `pinned`, N+1           | Learn key and increment once   |
+| Same key, generation exactly expected+1            | `matched`               | None                           |
+| Different key already pinned                       | `host_key_mismatch`     | None, regardless of generation |
+| Any other generation, including integer exhaustion | `configuration_changed` | None                           |
+| Current authority unavailable                      | `unavailable`           | None                           |
+
+Concurrent identical first observations converge on one pin. A different key
+never overwrites trust. Endpoint edits, credential edits and explicit reset
+retain the existing generation semantics; stale observations cannot silently
+repin. TOFU cannot prevent a first-use MITM, and resetting trust intentionally
+reopens that first-use window.
+
+## Deployment
+
+This is additive, feature-disabled API with no migration. Old Runners and
+clients do not call it. It can deploy before the consuming Runner PR; it does
+not establish fleet convergence or authorize enabling SSH. See
+[deployment compatibility](deployment-compatibility.md) and
+[guest RPC transport](runner-rpc-transport.md) for the remaining boundaries.

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -133,6 +133,7 @@ import { peopleSearchRoutes } from "./routes/people-search";
 import { webSearchRoutes } from "./routes/web-search";
 import { socialRoutes } from "./routes/social";
 import { sshConnectionsRoutes } from "./routes/ssh-connections";
+import { runnerSshRoutes } from "./routes/runner-ssh";
 import { browserRoutes } from "./routes/browser";
 import { browserAuthorizationRoutes } from "./routes/browser-authorization";
 import { workflowsRoutes } from "./routes/workflows";
@@ -312,6 +313,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...webSearchRoutes,
   ...socialRoutes,
   ...sshConnectionsRoutes,
+  ...runnerSshRoutes,
   ...browserRoutes,
   ...browserAuthorizationRoutes,
   ...modelPoliciesRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/runner-ssh.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runner-ssh.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { triggerSourceSchema } from "@okouai/api-contracts/contracts/logs";
 import {
   runnerSshContract,
   type RunnerSshResolveRequest,
@@ -104,7 +105,7 @@ async function createRuntime(
   };
 }
 
-async function fixture() {
+async function fixture(runtimeOverrides: Partial<RuntimeBody> = {}) {
   const owner = { orgId: staffOrg, userId: `user_ssh_jit_${randomUUID()}` };
   await updateFeatureSwitchesForUser(context, owner, {
     [FeatureSwitchKey.SshAccess]: true,
@@ -123,7 +124,7 @@ async function fixture() {
     }),
     [201],
   );
-  const runtime = await createRuntime(owner);
+  const runtime = await createRuntime(owner, runtimeOverrides);
   return { ...owner, ...runtime, connectionId: connection.body.id };
 }
 type Fixture = Awaited<ReturnType<typeof fixture>>;
@@ -223,7 +224,10 @@ describe("official Runner SSH authority", () => {
 
   it("rechecks authority after waiting for an owner connection lock", async () => {
     for (const change of ["revoke", "disable", "delete-credential"] as const) {
-      const f = await fixture();
+      const f = await fixture({
+        triggerSource: "automation-schedule",
+        chat: false,
+      });
       const scope = {
         orgId: f.orgId,
         userId: f.userId,
@@ -373,7 +377,7 @@ describe("official Runner SSH authority", () => {
   });
 
   it("returns indistinguishable unavailable for wrong claims and hidden or missing connections", async () => {
-    const f = await fixture();
+    const f = await fixture({ triggerSource: "webhook", chat: false });
     const foreign = await fixture();
     const kms = useSecretKmsProbe();
     for (const override of [
@@ -415,7 +419,7 @@ describe("official Runner SSH authority", () => {
     expect(kms.decryptCalls).toBe(0);
   });
 
-  it("treats every chat channel equally while denying non-chat or inactive Runs", async () => {
+  it("treats every chat channel equally", async () => {
     const f = await fixture();
     for (const triggerSource of [
       "web",
@@ -433,30 +437,46 @@ describe("official Runner SSH authority", () => {
         privateKey,
       });
     }
+  });
+
+  it.each([...triggerSourceSchema.options, null])(
+    "resolves and pins an authorized %s Run without a chat thread",
+    async (triggerSource) => {
+      const f = await fixture({ triggerSource, chat: false });
+      await expect(resolve(f)).resolves.toMatchObject({
+        outcome: "resolved",
+        privateKey,
+        learnedHostKey: null,
+      });
+      await expect(pin(f)).resolves.toStrictEqual({
+        outcome: "pinned",
+        generation: 2,
+      });
+      await expect(resolve(f)).resolves.toMatchObject({
+        outcome: "resolved",
+        learnedHostKey: hostKey,
+        generation: 2,
+      });
+    },
+  );
+
+  it("denies inactive, unclaimed or ungranted Runs without a chat thread", async () => {
+    const f = await fixture({ triggerSource: "automation-event", chat: false });
     const kms = useSecretKmsProbe();
     const denied: Partial<RuntimeBody>[] = [
-      { chat: false },
       { access: false },
       { runnerId: null, heartbeatGeneration: null },
       { status: "pending" },
       { status: "completed" },
       { status: "cancelled" },
       { status: "failed" },
-      ...(
-        [
-          "automation-schedule",
-          "automation-event",
-          "goal",
-          "agent",
-          "webhook",
-          "test",
-        ] as const
-      ).map((triggerSource) => {
-        return { triggerSource };
-      }),
     ];
     for (const override of denied) {
-      const runtime = await createRuntime(f, override);
+      const runtime = await createRuntime(f, {
+        triggerSource: "automation-event",
+        chat: false,
+        ...override,
+      });
       await expect(resolve({ ...f, ...runtime })).resolves.toStrictEqual({
         outcome: "unavailable",
       });
@@ -468,7 +488,7 @@ describe("official Runner SSH authority", () => {
   });
 
   it("checks current access, feature state and credential existence on every call", async () => {
-    const f = await fixture();
+    const f = await fixture({ triggerSource: "automation-event", chat: false });
     const kms = useSecretKmsProbe();
     await access(f, false);
     await expect(resolve(f)).resolves.toStrictEqual({ outcome: "unavailable" });

--- a/turbo/apps/api/src/signals/routes/__tests__/runner-ssh.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runner-ssh.test.ts
@@ -396,6 +396,23 @@ describe("official Runner SSH authority", () => {
       pin({ ...f, connectionId: foreign.connectionId }),
     ).resolves.toStrictEqual({ outcome: "unavailable" });
     expect((await list(foreign))[0]?.learnedHostKey).toBeNull();
+    // Keep the user and eligible staff Run unchanged: organization scoping must
+    // deny this independently of the hard staff gate and user ownership check.
+    await accept(
+      stateClient().action({
+        body: {
+          action: "move-connection-org",
+          orgId: f.orgId,
+          userId: f.userId,
+          connectionId: f.connectionId,
+          targetOrgId: `org_hidden_${randomUUID()}`,
+        },
+      }),
+      [200],
+    );
+    await expect(resolve(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+    await expect(pin(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+    expect(kms.decryptCalls).toBe(0);
   });
 
   it("treats every chat channel equally while denying non-chat or inactive Runs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/runner-ssh.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runner-ssh.test.ts
@@ -1,0 +1,705 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  runnerSshContract,
+  type RunnerSshResolveRequest,
+} from "@okouai/api-contracts/contracts/runner-ssh";
+import { sshConnectionsContract } from "@okouai/api-contracts/contracts/ssh-connections";
+import {
+  testSshConnectionStateContract,
+  type TestSshConnectionStateActionBody,
+} from "@okouai/api-contracts/contracts/test-ssh-connection-state";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, testContext } from "../../../__tests__/test-context";
+import { setupApp, setupRawAppRequest } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { createDeferredPromise, onRejection } from "../../utils";
+import { runnerSshRoutes } from "../runner-ssh";
+import { sshConnectionsRoutes } from "../ssh-connections";
+import { testSshConnectionStateRoutes } from "../test-ssh-connection-state";
+import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
+import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
+import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
+import { createRouteMocks } from "./helpers/route-test";
+
+const context = testContext();
+const mocks = createRouteMocks(context);
+const staffOrg = "org_3ANttyrbWYJk6JKRSTRLEsbsDLe";
+const sessionHeaders = Object.freeze({ authorization: "Bearer clerk-session" });
+const runnerSecret = "a".repeat(64);
+const runnerHeaders = Object.freeze({
+  authorization: `Bearer vm0_official_${runnerSecret}`,
+});
+const hostKey = Object.freeze({
+  algorithm: "ssh-ed25519" as const,
+  fingerprint: `SHA256:${Buffer.alloc(32, 1).toString("base64url").replaceAll("-", "+").replaceAll("_", "/")}`,
+});
+const otherHostKey = Object.freeze({
+  ...hostKey,
+  fingerprint: `SHA256:${Buffer.alloc(32, 2).toString("base64").replace(/=+$/u, "")}`,
+});
+const privateKey = "  private-key-canary\n";
+const passphrase = " passphrase-canary ";
+type RuntimeBody = Extract<
+  TestSshConnectionStateActionBody,
+  { action: "create-runtime" }
+>;
+interface Owner {
+  readonly userId: string;
+  readonly orgId: string;
+}
+
+function client() {
+  return setupApp({ context, routes: runnerSshRoutes })(runnerSshContract);
+}
+function config() {
+  return setupApp({ context, routes: sshConnectionsRoutes })(
+    sshConnectionsContract,
+  );
+}
+function stateClient() {
+  return setupApp({ context, routes: testSshConnectionStateRoutes })(
+    testSshConnectionStateContract,
+  );
+}
+function authenticate(owner: Owner) {
+  mocks.clerk.session(owner.userId, owner.orgId);
+}
+
+async function createRuntime(
+  owner: Owner,
+  overrides: Partial<RuntimeBody> = {},
+) {
+  // Process generation is a bigint, independent of the connection's int generation.
+  const runnerIdentity = {
+    runnerId: randomUUID(),
+    heartbeatGeneration: 5_000_000_000,
+  };
+  const r = await accept(
+    stateClient().action({
+      body: {
+        action: "create-runtime",
+        orgId: owner.orgId,
+        userId: owner.userId,
+        ...runnerIdentity,
+        triggerSource: "web",
+        status: "running",
+        chat: true,
+        access: true,
+        ...overrides,
+      },
+    }),
+    [200],
+  );
+  if (!r.body.runId || !r.body.agentId || !r.body.sandboxToken) {
+    throw new Error("Missing runtime fixture identity");
+  }
+  return {
+    runId: r.body.runId,
+    agentId: r.body.agentId,
+    sandboxToken: r.body.sandboxToken,
+    runnerIdentity,
+  };
+}
+
+async function fixture() {
+  const owner = { orgId: staffOrg, userId: `user_ssh_jit_${randomUUID()}` };
+  await updateFeatureSwitchesForUser(context, owner, {
+    [FeatureSwitchKey.SshAccess]: true,
+  });
+  authenticate(owner);
+  const connection = await accept(
+    config().create({
+      headers: sessionHeaders,
+      body: {
+        displayName: "SSH fixture",
+        host: "ssh.example.com",
+        username: "deploy",
+        privateKey,
+        passphrase,
+      },
+    }),
+    [201],
+  );
+  const runtime = await createRuntime(owner);
+  return { ...owner, ...runtime, connectionId: connection.body.id };
+}
+type Fixture = Awaited<ReturnType<typeof fixture>>;
+
+async function resolve(
+  f: Fixture,
+  override: Partial<RunnerSshResolveRequest> = {},
+) {
+  const r = await accept(
+    client().resolve({
+      params: { runId: f.runId },
+      headers: runnerHeaders,
+      body: {
+        connectionId: f.connectionId,
+        runnerIdentity: f.runnerIdentity,
+        ...override,
+      },
+    }),
+    [200],
+  );
+  return r.body;
+}
+async function pin(
+  f: Fixture,
+  expectedGeneration = 1,
+  observedHostKey = hostKey,
+) {
+  const r = await accept(
+    client().pin({
+      params: { runId: f.runId },
+      headers: runnerHeaders,
+      body: {
+        connectionId: f.connectionId,
+        runnerIdentity: f.runnerIdentity,
+        expectedGeneration,
+        observedHostKey,
+      },
+    }),
+    [200],
+  );
+  return r.body;
+}
+async function access(f: Fixture, enabled: boolean) {
+  await accept(
+    stateClient().action({
+      body: {
+        action: "set-agent-access",
+        orgId: f.orgId,
+        userId: f.userId,
+        agentId: f.agentId,
+        enabled,
+      },
+    }),
+    [200],
+  );
+}
+async function list(f: Fixture) {
+  authenticate(f);
+  return (await accept(config().list({ headers: sessionHeaders }), [200])).body
+    .connections;
+}
+
+beforeEach(() => {
+  mockEnv("OFFICIAL_RUNNER_SECRET", runnerSecret);
+  useSecretKmsProbe();
+});
+
+describe("official Runner SSH authority", () => {
+  it("keeps the hard staff gate even with an enabled override and matching ownership", async () => {
+    const f = await fixture();
+    const owner = { ...f, orgId: `org_external_${randomUUID()}` };
+    await updateFeatureSwitchesForUser(context, owner, {
+      [FeatureSwitchKey.SshAccess]: true,
+    });
+    await accept(
+      stateClient().action({
+        body: {
+          action: "move-connection-org",
+          orgId: f.orgId,
+          userId: f.userId,
+          connectionId: f.connectionId,
+          targetOrgId: owner.orgId,
+        },
+      }),
+      [200],
+    );
+    const runtime = await createRuntime(owner);
+    const kms = useSecretKmsProbe();
+    await expect(resolve({ ...owner, ...runtime })).resolves.toStrictEqual({
+      outcome: "unavailable",
+    });
+    await expect(pin({ ...owner, ...runtime })).resolves.toStrictEqual({
+      outcome: "unavailable",
+    });
+    expect(kms.decryptCalls).toBe(0);
+  });
+
+  it("rechecks authority after waiting for an owner connection lock", async () => {
+    for (const change of ["revoke", "disable", "delete-credential"] as const) {
+      const f = await fixture();
+      const scope = {
+        orgId: f.orgId,
+        userId: f.userId,
+        connectionId: f.connectionId,
+      };
+      const lock = (
+        action:
+          | "hold-connection-lock"
+          | "read-connection-lock"
+          | "release-connection-lock",
+      ) => {
+        return accept(
+          stateClient().action({ body: { action, ...scope } }),
+          [200],
+        );
+      };
+      const held = lock("hold-connection-lock");
+      await expect
+        .poll(async () => {
+          return (await lock("read-connection-lock")).body.held;
+        })
+        .toBe(true);
+      const pending = pin(f);
+      const releaseLock = async () => {
+        await lock("release-connection-lock");
+        await Promise.all([held, pending]);
+      };
+      await onRejection(
+        (async () => {
+          await expect
+            .poll(async () => {
+              return (await lock("read-connection-lock")).body.waiting;
+            })
+            .toBe(true);
+          if (change === "revoke") {
+            await access(f, false);
+          } else if (change === "disable") {
+            await updateFeatureSwitchesForUser(context, f, {
+              [FeatureSwitchKey.SshAccess]: false,
+            });
+          } else {
+            await accept(
+              stateClient().action({
+                body: { action: "delete-credential", ...scope },
+              }),
+              [200],
+            );
+          }
+        })(),
+        releaseLock,
+      );
+      await releaseLock();
+      await expect(pending).resolves.toStrictEqual({ outcome: "unavailable" });
+      await updateFeatureSwitchesForUser(context, f, {
+        [FeatureSwitchKey.SshAccess]: true,
+      });
+      expect((await list(f))[0]).toMatchObject({
+        generation: 1,
+        learnedHostKey: null,
+      });
+    }
+  });
+
+  it("does not turn a malformed stored host identity into unavailable or decrypt credentials", async () => {
+    const f = await fixture();
+    await accept(
+      stateClient().action({
+        body: {
+          action: "set-learned-host-key",
+          orgId: f.orgId,
+          userId: f.userId,
+          connectionId: f.connectionId,
+          algorithm: "ssh-dss",
+          fingerprint: "invalid",
+        },
+      }),
+      [200],
+    );
+    const kms = useSecretKmsProbe();
+    const result = await client().resolve({
+      params: { runId: f.runId },
+      headers: runnerHeaders,
+      body: { connectionId: f.connectionId, runnerIdentity: f.runnerIdentity },
+    });
+    expect(result.status).toBe(500);
+    expect(kms.decryptCalls).toBe(0);
+  });
+  it("only delivers the exact current credential to the winning official process", async () => {
+    const f = await fixture();
+    const kms = useSecretKmsProbe();
+    await expect(resolve(f)).resolves.toStrictEqual({
+      outcome: "resolved",
+      host: "ssh.example.com",
+      port: 22,
+      username: "deploy",
+      generation: 1,
+      learnedHostKey: null,
+      privateKey,
+      passphrase,
+    });
+    expect(kms.decryptCalls).toBe(2);
+    const response = await client().resolve({
+      params: { runId: f.runId },
+      headers: runnerHeaders,
+      body: { connectionId: f.connectionId, runnerIdentity: f.runnerIdentity },
+    });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(JSON.stringify(await list(f))).not.toContain("canary");
+  });
+
+  it("rejects unauthenticated, session, guest and local Runner credentials before decryption", async () => {
+    const f = await fixture();
+    const kms = useSecretKmsProbe();
+    for (const authorization of [
+      undefined,
+      "Bearer vm0_official_wrong",
+      "Bearer clerk-session",
+      `Bearer ${f.sandboxToken}`,
+    ]) {
+      const r = await client().resolve({
+        params: { runId: f.runId },
+        headers: { authorization },
+        body: {
+          connectionId: f.connectionId,
+          runnerIdentity: f.runnerIdentity,
+        },
+      });
+      expect(r.status).toBe(401);
+    }
+    const authApi = createAuthOrgAgentsBddApi(context);
+    const actor = authApi.user({ orgId: staffOrg });
+    authApi.mockClerkOrg(actor);
+    const pat = await authApi.createCliToken(actor);
+    const rejected = await client().pin({
+      params: { runId: f.runId },
+      headers: { authorization: `Bearer ${pat.token}` },
+      body: {
+        connectionId: f.connectionId,
+        runnerIdentity: f.runnerIdentity,
+        expectedGeneration: 1,
+        observedHostKey: hostKey,
+      },
+    });
+    expect(rejected.status).toBe(403);
+    expect(kms.decryptCalls).toBe(0);
+    expect((await list(f))[0]?.learnedHostKey).toBeNull();
+  });
+
+  it("returns indistinguishable unavailable for wrong claims and hidden or missing connections", async () => {
+    const f = await fixture();
+    const foreign = await fixture();
+    const kms = useSecretKmsProbe();
+    for (const override of [
+      { connectionId: randomUUID() },
+      { connectionId: foreign.connectionId },
+      { runnerIdentity: { ...f.runnerIdentity, runnerId: randomUUID() } },
+      { runnerIdentity: { ...f.runnerIdentity, heartbeatGeneration: 8 } },
+    ]) {
+      await expect(resolve(f, override)).resolves.toStrictEqual({
+        outcome: "unavailable",
+      });
+    }
+    await expect(resolve({ ...f, runId: randomUUID() })).resolves.toStrictEqual(
+      {
+        outcome: "unavailable",
+      },
+    );
+    expect(kms.decryptCalls).toBe(0);
+    await expect(
+      pin({ ...f, connectionId: foreign.connectionId }),
+    ).resolves.toStrictEqual({ outcome: "unavailable" });
+    expect((await list(foreign))[0]?.learnedHostKey).toBeNull();
+  });
+
+  it("treats every chat channel equally while denying non-chat or inactive Runs", async () => {
+    const f = await fixture();
+    for (const triggerSource of [
+      "web",
+      "slack",
+      "teams",
+      "feishu",
+      "email",
+      "telegram",
+      "agentphone",
+      "github",
+    ] as const) {
+      const runtime = await createRuntime(f, { triggerSource });
+      await expect(resolve({ ...f, ...runtime })).resolves.toMatchObject({
+        outcome: "resolved",
+        privateKey,
+      });
+    }
+    const kms = useSecretKmsProbe();
+    const denied: Partial<RuntimeBody>[] = [
+      { chat: false },
+      { access: false },
+      { runnerId: null, heartbeatGeneration: null },
+      { status: "pending" },
+      { status: "completed" },
+      { status: "cancelled" },
+      { status: "failed" },
+      ...(
+        [
+          "automation-schedule",
+          "automation-event",
+          "goal",
+          "agent",
+          "webhook",
+          "test",
+        ] as const
+      ).map((triggerSource) => {
+        return { triggerSource };
+      }),
+    ];
+    for (const override of denied) {
+      const runtime = await createRuntime(f, override);
+      await expect(resolve({ ...f, ...runtime })).resolves.toStrictEqual({
+        outcome: "unavailable",
+      });
+      await expect(pin({ ...f, ...runtime })).resolves.toStrictEqual({
+        outcome: "unavailable",
+      });
+    }
+    expect(kms.decryptCalls).toBe(0);
+  });
+
+  it("checks current access, feature state and credential existence on every call", async () => {
+    const f = await fixture();
+    const kms = useSecretKmsProbe();
+    await access(f, false);
+    await expect(resolve(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+    await expect(pin(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+    await access(f, true);
+    await updateFeatureSwitchesForUser(context, f, {
+      [FeatureSwitchKey.SshAccess]: false,
+    });
+    await expect(resolve(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+    await expect(pin(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+    await updateFeatureSwitchesForUser(context, f, {
+      [FeatureSwitchKey.SshAccess]: true,
+    });
+    await accept(
+      stateClient().action({
+        body: {
+          action: "delete-credential",
+          orgId: f.orgId,
+          userId: f.userId,
+          connectionId: f.connectionId,
+        },
+      }),
+      [200],
+    );
+    await expect(resolve(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+    await expect(pin(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+    expect(kms.decryptCalls).toBe(0);
+  });
+
+  it("reflects credential rotation and deletion without a cached admission", async () => {
+    const f = await fixture();
+    await expect(pin(f)).resolves.toStrictEqual({
+      outcome: "pinned",
+      generation: 2,
+    });
+    authenticate(f);
+    await accept(
+      config().update({
+        params: { connectionId: f.connectionId },
+        headers: sessionHeaders,
+        body: {
+          expectedGeneration: 2,
+          username: "new-user",
+          credentials: { privateKey: "rotated-key", passphrase: null },
+        },
+      }),
+      [200],
+    );
+    await expect(resolve(f)).resolves.toMatchObject({
+      outcome: "resolved",
+      generation: 3,
+      username: "new-user",
+      privateKey: "rotated-key",
+      passphrase: null,
+      learnedHostKey: hostKey,
+    });
+    await expect(pin(f)).resolves.toStrictEqual({
+      outcome: "configuration_changed",
+    });
+    authenticate(f);
+    await accept(
+      config().delete({
+        params: { connectionId: f.connectionId },
+        headers: sessionHeaders,
+      }),
+      [204],
+    );
+    const kms = useSecretKmsProbe();
+    await expect(resolve(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+    await expect(pin(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+    expect(kms.decryptCalls).toBe(0);
+  });
+
+  it("pins exactly once for concurrent equal observations and only accepts expected plus one", async () => {
+    const f = await fixture();
+    const kms = useSecretKmsProbe();
+    const outcomes = await Promise.all([pin(f), pin(f), pin(f)]);
+    expect(
+      outcomes.filter((r) => {
+        return r.outcome === "pinned";
+      }),
+    ).toHaveLength(1);
+    expect(
+      outcomes.filter((r) => {
+        return r.outcome === "matched";
+      }),
+    ).toHaveLength(2);
+    await expect(pin(f, 2)).resolves.toStrictEqual({
+      outcome: "configuration_changed",
+    });
+    await expect(pin(f, 3)).resolves.toStrictEqual({
+      outcome: "configuration_changed",
+    });
+    expect(kms.decryptCalls).toBe(0);
+    expect((await list(f))[0]).toMatchObject({
+      generation: 2,
+      learnedHostKey: hostKey,
+    });
+  });
+
+  it("never overwrites trust when concurrent first observations disagree", async () => {
+    const f = await fixture();
+    const result = await Promise.all([pin(f), pin(f, 1, otherHostKey)]);
+    expect(
+      result
+        .map((r) => {
+          return r.outcome;
+        })
+        .sort(),
+    ).toStrictEqual(["host_key_mismatch", "pinned"]);
+    const winner = result[0]?.outcome === "pinned" ? hostKey : otherHostKey;
+    expect((await list(f))[0]).toMatchObject({
+      generation: 2,
+      learnedHostKey: winner,
+    });
+    const loser = winner === hostKey ? otherHostKey : hostKey;
+    await expect(pin(f, 999, loser)).resolves.toStrictEqual({
+      outcome: "host_key_mismatch",
+    });
+  });
+
+  it("rejects stale endpoint edits and resets instead of silently repinning", async () => {
+    const f = await fixture();
+    authenticate(f);
+    await accept(
+      config().update({
+        params: { connectionId: f.connectionId },
+        headers: sessionHeaders,
+        body: { expectedGeneration: 1, host: "new.example.com" },
+      }),
+      [200],
+    );
+    await expect(pin(f, 1)).resolves.toStrictEqual({
+      outcome: "configuration_changed",
+    });
+    await expect(pin(f, 2)).resolves.toStrictEqual({
+      outcome: "pinned",
+      generation: 3,
+    });
+    authenticate(f);
+    await accept(
+      config().resetHostKey({
+        params: { connectionId: f.connectionId },
+        headers: sessionHeaders,
+        body: { expectedGeneration: 3 },
+      }),
+      [200],
+    );
+    await expect(pin(f, 2)).resolves.toStrictEqual({
+      outcome: "configuration_changed",
+    });
+    await expect(pin(f, 4)).resolves.toStrictEqual({
+      outcome: "pinned",
+      generation: 5,
+    });
+    await expect(pin(f, 2)).resolves.toStrictEqual({
+      outcome: "configuration_changed",
+    });
+    expect((await list(f))[0]).toMatchObject({
+      generation: 5,
+      learnedHostKey: hostKey,
+    });
+  });
+
+  it("rejects malformed or extra authority fields before sensitive work", async () => {
+    const f = await fixture();
+    const kms = useSecretKmsProbe();
+    const raw = setupRawAppRequest({ context, routes: runnerSshRoutes });
+    const base = {
+      connectionId: f.connectionId,
+      runnerIdentity: f.runnerIdentity,
+    };
+    for (const body of [
+      { ...base, host: "attacker.example" },
+      { ...base, command: "id" },
+      { ...base, userId: f.userId },
+      { ...base, connectionId: "not-a-uuid" },
+      {
+        ...base,
+        runnerIdentity: { ...f.runnerIdentity, heartbeatGeneration: 0 },
+      },
+    ]) {
+      const result = await raw(`/api/runners/runs/${f.runId}/ssh/resolve`, {
+        method: "POST",
+        headers: { ...runnerHeaders, "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      expect(result.status).toBe(400);
+    }
+    const invalidPin = await raw(`/api/runners/runs/${f.runId}/ssh/pin`, {
+      method: "POST",
+      headers: { ...runnerHeaders, "content-type": "application/json" },
+      body: JSON.stringify({
+        ...base,
+        expectedGeneration: 1,
+        observedHostKey: { algorithm: "ssh-dss", fingerprint: "bad" },
+      }),
+    });
+    expect(invalidPin.status).toBe(400);
+    expect(kms.decryptCalls).toBe(0);
+    expect((await list(f))[0]?.learnedHostKey).toBeNull();
+  });
+
+  it("surfaces KMS failure and does not pin as a side effect of resolving", async () => {
+    const f = await fixture();
+    useSecretKmsProbe(undefined, () => {
+      return Promise.reject(new Error("KMS unavailable"));
+    });
+    const result = await client().resolve({
+      params: { runId: f.runId },
+      headers: runnerHeaders,
+      body: { connectionId: f.connectionId, runnerIdentity: f.runnerIdentity },
+    });
+    expect(result.status).toBe(500);
+    expect((await list(f))[0]?.learnedHostKey).toBeNull();
+  });
+
+  it("does not hold authorization locks across KMS or pretend to claw back an in-flight handoff", async () => {
+    const f = await fixture();
+    const entered = createDeferredPromise<void>(context.signal);
+    const release = createDeferredPromise<Uint8Array>(context.signal);
+    useSecretKmsProbe(undefined, (_request, call) => {
+      if (call === 1) {
+        entered.resolve(undefined);
+        return release.promise;
+      }
+      return undefined;
+    });
+    const pending = resolve(f);
+    await entered.promise;
+    const finishHandoff = async () => {
+      release.resolve(Buffer.from("0123456789abcdef0123456789abcdef"));
+      await pending;
+    };
+    await onRejection(
+      (async () => {
+        await access(f, false);
+        await expect(resolve(f)).resolves.toStrictEqual({
+          outcome: "unavailable",
+        });
+      })(),
+      finishHandoff,
+    );
+    await finishHandoff();
+    await expect(pending).resolves.toMatchObject({
+      outcome: "resolved",
+      privateKey,
+    });
+    await expect(pin(f)).resolves.toStrictEqual({ outcome: "unavailable" });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/runner-ssh.ts
+++ b/turbo/apps/api/src/signals/routes/runner-ssh.ts
@@ -1,0 +1,81 @@
+import { runnerSshContract } from "@okouai/api-contracts/contracts/runner-ssh";
+import { command } from "ccstate";
+
+import { runnerAuth$ } from "../auth/runner-auth";
+import { authorization$, setResHeader$ } from "../context/hono";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { db$, writeDb$ } from "../external/db";
+import type { RouteEntry } from "../route-entry";
+import { pinRunnerSsh, resolveRunnerSsh } from "../services/runner-ssh.service";
+
+const authorizeSshRunner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(setResHeader$, "Cache-Control", "no-store");
+    const auth = await set(runnerAuth$, get(authorization$), signal);
+    signal.throwIfAborted();
+    if (!auth) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { code: "UNAUTHORIZED", message: "Authentication required" },
+        },
+      };
+    }
+    if (auth.type !== "official-runner") {
+      return {
+        status: 403 as const,
+        body: {
+          error: {
+            code: "FORBIDDEN",
+            message:
+              "Only official runners can access SSH runtime configuration",
+          },
+        },
+      };
+    }
+    return null;
+  },
+);
+
+const resolveSsh$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const error = await set(authorizeSshRunner$, signal);
+  if (error) {
+    return error;
+  }
+  const body = await get(bodyResultOf(runnerSshContract.resolve));
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+  const { runId } = get(pathParamsOf(runnerSshContract.resolve));
+  const result = await resolveRunnerSsh(
+    get(db$),
+    { runId, ...body.data },
+    signal,
+  );
+  return { status: 200 as const, body: result };
+});
+
+const pinSsh$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const error = await set(authorizeSshRunner$, signal);
+  if (error) {
+    return error;
+  }
+  const body = await get(bodyResultOf(runnerSshContract.pin));
+  signal.throwIfAborted();
+  if (!body.ok) {
+    return body.response;
+  }
+  const { runId } = get(pathParamsOf(runnerSshContract.pin));
+  const result = await pinRunnerSsh(
+    set(writeDb$),
+    { runId, ...body.data },
+    signal,
+  );
+  return { status: 200 as const, body: result };
+});
+
+export const runnerSshRoutes: readonly RouteEntry[] = [
+  { route: runnerSshContract.resolve, handler: resolveSsh$ },
+  { route: runnerSshContract.pin, handler: pinSsh$ },
+];

--- a/turbo/apps/api/src/signals/routes/test-ssh-connection-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-ssh-connection-state.ts
@@ -11,6 +11,8 @@ import { agents } from "@okouai/db/schema/agent";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentSessions } from "@okouai/db/schema/agent-session";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { threadGoals } from "@okouai/db/schema/thread-goal";
+import { workflowAutomations, workflows } from "@okouai/db/schema/workflow";
 import { command } from "ccstate";
 import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -141,7 +143,8 @@ async function createRuntime(
   const agentId = randomUUID();
   const sessionId = randomUUID();
   const runId = randomUUID();
-  const threadId = body.chat ? randomUUID() : null;
+  const threadId =
+    body.chat || body.triggerSource === "goal" ? randomUUID() : null;
   await db.transaction(async (tx) => {
     await tx.insert(agents).values({
       id: agentId,
@@ -160,6 +163,57 @@ async function createRuntime(
         .insert(chatThreads)
         .values({ id: threadId, agentId, userId: body.userId });
     }
+    let workflowAutomationId: string | null = null;
+    if (
+      body.triggerSource === "automation-schedule" ||
+      body.triggerSource === "automation-event"
+    ) {
+      const workflowId = randomUUID();
+      workflowAutomationId = randomUUID();
+      await tx.insert(workflows).values({
+        id: workflowId,
+        orgId: body.orgId,
+        agentId,
+        name: `ssh-${workflowId}`,
+        ownerUserId: body.userId,
+        createdBy: body.userId,
+        updatedBy: body.userId,
+      });
+      const trigger =
+        body.triggerSource === "automation-schedule"
+          ? {
+              kind: "schedule" as const,
+              scheduleType: "loop" as const,
+              intervalSeconds: 3600,
+            }
+          : {
+              kind: "event" as const,
+              eventType: "webhook-received" as const,
+              eventConfig: {},
+            };
+      await tx.insert(workflowAutomations).values({
+        id: workflowAutomationId,
+        workflowId,
+        orgId: body.orgId,
+        ownerUserId: body.userId,
+        ...trigger,
+        enabled: false,
+      });
+    }
+    let goalId: string | null = null;
+    if (body.triggerSource === "goal" && threadId) {
+      goalId = randomUUID();
+      await tx.insert(threadGoals).values({
+        id: goalId,
+        orgId: body.orgId,
+        ownerUserId: body.userId,
+        agentId,
+        chatThreadId: threadId,
+        status: "paused",
+        objective: "SSH runtime fixture",
+        objectiveBrief: "SSH runtime fixture",
+      });
+    }
     await tx.insert(agentRuns).values({
       id: runId,
       sessionId,
@@ -168,8 +222,10 @@ async function createRuntime(
       status: body.status,
       prompt: "SSH runtime fixture",
       triggerSource: body.triggerSource,
-      autonomyBudget: 3,
-      chatThreadId: threadId,
+      autonomyBudget: body.triggerSource === null ? null : 3,
+      chatThreadId: body.chat ? threadId : null,
+      workflowAutomationId,
+      goalId,
       runnerId: body.runnerId,
       runnerHeartbeatGeneration: body.heartbeatGeneration,
     });

--- a/turbo/apps/api/src/signals/routes/test-ssh-connection-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-ssh-connection-state.ts
@@ -1,17 +1,30 @@
+import { randomUUID } from "node:crypto";
+
 import {
   testSshConnectionStateContract,
   type TestSshConnectionStateActionBody,
 } from "@okouai/api-contracts/contracts/test-ssh-connection-state";
 import { sshConnections } from "@okouai/db/schema/ssh-connection";
+import { sshConnectionCredentials } from "@okouai/db/schema/ssh-connection-credential";
+import { agentSshAccess } from "@okouai/db/schema/agent-ssh-access";
+import { agents } from "@okouai/db/schema/agent";
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { agentSessions } from "@okouai/db/schema/agent-session";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { command } from "ccstate";
 import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
 
+import { executeRawRows } from "../../lib/db-raw-rows";
+import { testOverride } from "../../lib/singleton";
 import { nowDate } from "../../lib/time";
+import { generateSandboxToken } from "../auth/tokens";
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
 import { matchSshConnectionCredentials } from "../services/ssh-connection.service";
+import { createDeferredPromise } from "../utils";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -20,6 +33,205 @@ import {
 type TestSshConnectionStateAction<
   TAction extends TestSshConnectionStateActionBody["action"],
 > = Extract<TestSshConnectionStateActionBody, { action: TAction }>;
+
+interface ConnectionLockGate {
+  readonly connectionId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  holderPid: number | null;
+  readonly released: ReturnType<typeof createDeferredPromise<void>>;
+}
+
+const connectionLockGate = testOverride<ConnectionLockGate | null>(() => {
+  return null;
+});
+
+async function connectionLock(
+  db: Db,
+  body: TestSshConnectionStateAction<
+    "hold-connection-lock" | "read-connection-lock" | "release-connection-lock"
+  >,
+  signal: AbortSignal,
+) {
+  if (body.action === "hold-connection-lock") {
+    if (connectionLockGate.get()) {
+      throw new Error("An SSH connection lock is already active");
+    }
+    const gate: ConnectionLockGate = {
+      ...body,
+      holderPid: null,
+      released: createDeferredPromise<void>(signal),
+    };
+    connectionLockGate.set(gate);
+    await db
+      .transaction(async (tx) => {
+        const [row] = await tx
+          .select({ id: sshConnections.id })
+          .from(sshConnections)
+          .where(
+            and(
+              eq(sshConnections.id, body.connectionId),
+              eq(sshConnections.orgId, body.orgId),
+              eq(sshConnections.userId, body.userId),
+            ),
+          )
+          .for("update");
+        signal.throwIfAborted();
+        if (!row) {
+          throw new Error("Missing owned SSH connection to lock");
+        }
+        const [holder] = await executeRawRows(
+          tx,
+          sql`SELECT pg_backend_pid() AS pid`,
+          z.object({ pid: z.int() }),
+        );
+        signal.throwIfAborted();
+        if (!holder) {
+          throw new Error("Missing SSH connection lock holder");
+        }
+        gate.holderPid = holder.pid;
+        await gate.released.promise;
+      })
+      .finally(() => {
+        connectionLockGate.clear();
+      });
+    return { status: 200 as const, body: { ok: true as const } };
+  }
+  const gate = connectionLockGate.get();
+  const owned =
+    gate?.connectionId === body.connectionId &&
+    gate.orgId === body.orgId &&
+    gate.userId === body.userId;
+  if (body.action === "release-connection-lock") {
+    if (!owned) {
+      throw new Error("Missing owned SSH connection lock gate");
+    }
+    gate.released.resolve(undefined);
+    return { status: 200 as const, body: { ok: true as const } };
+  }
+  if (!owned || gate.holderPid === null) {
+    return {
+      status: 200 as const,
+      body: { ok: true as const, held: false, waiting: false },
+    };
+  }
+  const [row] = await executeRawRows(
+    db,
+    sql`
+    SELECT EXISTS (
+      SELECT 1 FROM pg_stat_activity WHERE ${gate.holderPid} = ANY(pg_blocking_pids(pid))
+    ) AS waiting
+  `,
+    z.object({ waiting: z.boolean() }),
+  );
+  signal.throwIfAborted();
+  if (!row) {
+    throw new Error("Missing SSH connection lock state");
+  }
+  return {
+    status: 200 as const,
+    body: { ok: true as const, held: true, waiting: row.waiting },
+  };
+}
+
+async function createRuntime(
+  db: Db,
+  body: TestSshConnectionStateAction<"create-runtime">,
+) {
+  const agentId = randomUUID();
+  const sessionId = randomUUID();
+  const runId = randomUUID();
+  const threadId = body.chat ? randomUUID() : null;
+  await db.transaction(async (tx) => {
+    await tx.insert(agents).values({
+      id: agentId,
+      orgId: body.orgId,
+      owner: body.userId,
+      name: `ssh-${agentId}`,
+    });
+    await tx.insert(agentSessions).values({
+      id: sessionId,
+      agentId,
+      orgId: body.orgId,
+      userId: body.userId,
+    });
+    if (threadId) {
+      await tx
+        .insert(chatThreads)
+        .values({ id: threadId, agentId, userId: body.userId });
+    }
+    await tx.insert(agentRuns).values({
+      id: runId,
+      sessionId,
+      orgId: body.orgId,
+      userId: body.userId,
+      status: body.status,
+      prompt: "SSH runtime fixture",
+      triggerSource: body.triggerSource,
+      autonomyBudget: 3,
+      chatThreadId: threadId,
+      runnerId: body.runnerId,
+      runnerHeartbeatGeneration: body.heartbeatGeneration,
+    });
+    if (body.access) {
+      await tx
+        .insert(agentSshAccess)
+        .values({ orgId: body.orgId, userId: body.userId, agentId });
+    }
+  });
+  return {
+    status: 200 as const,
+    body: {
+      ok: true as const,
+      agentId,
+      runId,
+      sandboxToken: generateSandboxToken(body.userId, runId, body.orgId),
+    },
+  };
+}
+
+async function setAgentAccess(
+  db: Db,
+  body: TestSshConnectionStateAction<"set-agent-access">,
+) {
+  if (body.enabled) {
+    await db
+      .insert(agentSshAccess)
+      .values({ orgId: body.orgId, userId: body.userId, agentId: body.agentId })
+      .onConflictDoNothing();
+  } else {
+    await db
+      .delete(agentSshAccess)
+      .where(
+        and(
+          eq(agentSshAccess.orgId, body.orgId),
+          eq(agentSshAccess.userId, body.userId),
+          eq(agentSshAccess.agentId, body.agentId),
+        ),
+      );
+  }
+  return { status: 200 as const, body: { ok: true as const } };
+}
+
+async function deleteCredential(
+  db: Db,
+  body: TestSshConnectionStateAction<"delete-credential">,
+) {
+  const owned = db
+    .select({ id: sshConnections.id })
+    .from(sshConnections)
+    .where(
+      and(
+        eq(sshConnections.id, body.connectionId),
+        eq(sshConnections.orgId, body.orgId),
+        eq(sshConnections.userId, body.userId),
+      ),
+    );
+  await db
+    .delete(sshConnectionCredentials)
+    .where(eq(sshConnectionCredentials.connectionId, owned));
+  return { status: 200 as const, body: { ok: true as const } };
+}
 
 async function setLearnedHostKey(
   db: Db,
@@ -80,6 +292,35 @@ const mutateSshConnectionState$ = command(
 
     const db = set(writeDb$);
     switch (bodyResult.data.action) {
+      case "hold-connection-lock":
+      case "read-connection-lock":
+      case "release-connection-lock": {
+        return await connectionLock(db, bodyResult.data, signal);
+      }
+      case "move-connection-org": {
+        const body = bodyResult.data;
+        await db
+          .update(sshConnections)
+          .set({ orgId: body.targetOrgId })
+          .where(
+            and(
+              eq(sshConnections.id, body.connectionId),
+              eq(sshConnections.orgId, body.orgId),
+              eq(sshConnections.userId, body.userId),
+            ),
+          );
+        signal.throwIfAborted();
+        return { status: 200 as const, body: { ok: true as const } };
+      }
+      case "create-runtime": {
+        return await createRuntime(db, bodyResult.data);
+      }
+      case "set-agent-access": {
+        return await setAgentAccess(db, bodyResult.data);
+      }
+      case "delete-credential": {
+        return await deleteCredential(db, bodyResult.data);
+      }
       case "set-learned-host-key": {
         return await setLearnedHostKey(db, bodyResult.data);
       }

--- a/turbo/apps/api/src/signals/services/runner-ssh.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-ssh.service.ts
@@ -12,10 +12,9 @@ import { agents } from "@okouai/db/schema/agent";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { agentSessions } from "@okouai/db/schema/agent-session";
 import { agentSshAccess } from "@okouai/db/schema/agent-ssh-access";
-import { chatThreads } from "@okouai/db/schema/chat-thread";
 import { sshConnections } from "@okouai/db/schema/ssh-connection";
 import { sshConnectionCredentials } from "@okouai/db/schema/ssh-connection-credential";
-import { and, eq, isNull, notInArray, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import { nowDate } from "../../lib/time";
 import type { Db } from "../external/db";
@@ -64,14 +63,6 @@ async function currentConnection(
       ),
     )
     .innerJoin(
-      chatThreads,
-      and(
-        eq(chatThreads.id, agentRuns.chatThreadId),
-        eq(chatThreads.userId, agentRuns.userId),
-        eq(chatThreads.agentId, agents.id),
-      ),
-    )
-    .innerJoin(
       agentSshAccess,
       and(
         eq(agentSshAccess.agentId, agents.id),
@@ -100,17 +91,6 @@ async function currentConnection(
           agentRuns.runnerHeartbeatGeneration,
           input.runnerIdentity.heartbeatGeneration,
         ),
-        isNull(agentRuns.workflowAutomationId),
-        isNull(agentRuns.goalId),
-        // Chat channels are equal; only the separate non-interactive producers are excluded.
-        notInArray(agentRuns.triggerSource, [
-          "automation-schedule",
-          "automation-event",
-          "goal",
-          "agent",
-          "webhook",
-          "test",
-        ]),
       ),
     );
   const [row] = lockAuthority
@@ -119,7 +99,6 @@ async function currentConnection(
           agentRuns,
           agentSessions,
           agents,
-          chatThreads,
           agentSshAccess,
           sshConnectionCredentials,
         ],

--- a/turbo/apps/api/src/signals/services/runner-ssh.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-ssh.service.ts
@@ -1,0 +1,246 @@
+import {
+  sshHostKeySchema,
+  type RunnerSshResolveRequest,
+  type RunnerSshResolveResponse,
+  type RunnerSshPinRequest,
+  type RunnerSshPinResponse,
+} from "@okouai/api-contracts/contracts/runner-ssh";
+import { isFeatureEnabled } from "@okouai/core/feature-switch";
+import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
+import { isStaffOrg } from "@okouai/core/staff-org";
+import { agents } from "@okouai/db/schema/agent";
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { agentSessions } from "@okouai/db/schema/agent-session";
+import { agentSshAccess } from "@okouai/db/schema/agent-ssh-access";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { sshConnections } from "@okouai/db/schema/ssh-connection";
+import { sshConnectionCredentials } from "@okouai/db/schema/ssh-connection-credential";
+import { and, eq, isNull, notInArray, sql } from "drizzle-orm";
+
+import { nowDate } from "../../lib/time";
+import type { Db } from "../external/db";
+import { decryptStoredSecretValue } from "./crypto.utils";
+import { loadUserFeatureSwitchContext } from "./feature-switches.service";
+
+type SshResolveInput = RunnerSshResolveRequest & { readonly runId: string };
+type SshPinInput = RunnerSshPinRequest & { readonly runId: string };
+const unavailable = Object.freeze({ outcome: "unavailable" as const });
+
+async function currentConnection(
+  db: Pick<Db, "select">,
+  input: SshResolveInput,
+  lockAuthority: boolean,
+  signal: AbortSignal,
+) {
+  const query = db
+    .select({
+      id: sshConnections.id,
+      orgId: agentRuns.orgId,
+      userId: agentRuns.userId,
+      host: sshConnections.host,
+      port: sshConnections.port,
+      username: sshConnections.username,
+      generation: sshConnections.generation,
+      algorithm: sshConnections.learnedHostKeyAlgorithm,
+      fingerprint: sshConnections.learnedHostKeyFingerprint,
+      encryptedPrivateKey: sshConnectionCredentials.encryptedPrivateKey,
+      encryptedPassphrase: sshConnectionCredentials.encryptedPassphrase,
+    })
+    .from(agentRuns)
+    .innerJoin(
+      agentSessions,
+      and(
+        eq(agentSessions.id, agentRuns.sessionId),
+        eq(agentSessions.orgId, agentRuns.orgId),
+        eq(agentSessions.userId, agentRuns.userId),
+      ),
+    )
+    .innerJoin(
+      agents,
+      and(
+        eq(agents.id, agentSessions.agentId),
+        eq(agents.orgId, agentRuns.orgId),
+        eq(agents.owner, agentRuns.userId),
+      ),
+    )
+    .innerJoin(
+      chatThreads,
+      and(
+        eq(chatThreads.id, agentRuns.chatThreadId),
+        eq(chatThreads.userId, agentRuns.userId),
+        eq(chatThreads.agentId, agents.id),
+      ),
+    )
+    .innerJoin(
+      agentSshAccess,
+      and(
+        eq(agentSshAccess.agentId, agents.id),
+        eq(agentSshAccess.orgId, agentRuns.orgId),
+        eq(agentSshAccess.userId, agentRuns.userId),
+      ),
+    )
+    .innerJoin(
+      sshConnections,
+      and(
+        eq(sshConnections.id, input.connectionId),
+        eq(sshConnections.orgId, agentRuns.orgId),
+        eq(sshConnections.userId, agentRuns.userId),
+      ),
+    )
+    .innerJoin(
+      sshConnectionCredentials,
+      eq(sshConnectionCredentials.connectionId, sshConnections.id),
+    )
+    .where(
+      and(
+        eq(agentRuns.id, input.runId),
+        eq(agentRuns.status, "running"),
+        eq(agentRuns.runnerId, input.runnerIdentity.runnerId),
+        eq(
+          agentRuns.runnerHeartbeatGeneration,
+          input.runnerIdentity.heartbeatGeneration,
+        ),
+        isNull(agentRuns.workflowAutomationId),
+        isNull(agentRuns.goalId),
+        // Chat channels are equal; only the separate non-interactive producers are excluded.
+        notInArray(agentRuns.triggerSource, [
+          "automation-schedule",
+          "automation-event",
+          "goal",
+          "agent",
+          "webhook",
+          "test",
+        ]),
+      ),
+    );
+  const [row] = lockAuthority
+    ? await query.for("share", {
+        of: [
+          agentRuns,
+          agentSessions,
+          agents,
+          chatThreads,
+          agentSshAccess,
+          sshConnectionCredentials,
+        ],
+      })
+    : await query;
+  signal.throwIfAborted();
+  if (!row || !isStaffOrg(row.orgId)) {
+    return null;
+  }
+  const featureContext = await loadUserFeatureSwitchContext(
+    db,
+    row.orgId,
+    row.userId,
+  );
+  signal.throwIfAborted();
+  return isFeatureEnabled(FeatureSwitchKey.SshAccess, featureContext)
+    ? row
+    : null;
+}
+
+function learnedHostKey(row: {
+  readonly algorithm: string | null;
+  readonly fingerprint: string | null;
+}) {
+  if (row.algorithm === null && row.fingerprint === null) {
+    return null;
+  }
+  return sshHostKeySchema.parse({
+    algorithm: row.algorithm,
+    fingerprint: row.fingerprint,
+  });
+}
+
+export async function resolveRunnerSsh(
+  db: Pick<Db, "select">,
+  input: SshResolveInput,
+  signal: AbortSignal,
+): Promise<RunnerSshResolveResponse> {
+  const row = await currentConnection(db, input, false, signal);
+  if (!row) {
+    return unavailable;
+  }
+  const hostKey = learnedHostKey(row);
+  // The joined snapshot is the authority handoff. Never hold DB locks across KMS.
+  const privateKey = await decryptStoredSecretValue(row.encryptedPrivateKey);
+  signal.throwIfAborted();
+  const passphrase =
+    row.encryptedPassphrase === null
+      ? null
+      : await decryptStoredSecretValue(row.encryptedPassphrase);
+  signal.throwIfAborted();
+  return {
+    outcome: "resolved",
+    host: row.host,
+    port: row.port,
+    username: row.username,
+    generation: row.generation,
+    learnedHostKey: hostKey,
+    privateKey,
+    passphrase,
+  };
+}
+
+export async function pinRunnerSsh(
+  db: Db,
+  input: SshPinInput,
+  signal: AbortSignal,
+): Promise<RunnerSshPinResponse> {
+  const initial = await currentConnection(db, input, false, signal);
+  if (!initial) {
+    return unavailable;
+  }
+  return await db.transaction(async (tx) => {
+    // Same row as owner edit/reset, scoped only after non-locking authorization.
+    const [locked] = await tx
+      .select({ id: sshConnections.id })
+      .from(sshConnections)
+      .where(
+        and(
+          eq(sshConnections.id, initial.id),
+          eq(sshConnections.orgId, initial.orgId),
+          eq(sshConnections.userId, initial.userId),
+        ),
+      )
+      .for("update");
+    signal.throwIfAborted();
+    if (!locked) {
+      return unavailable;
+    }
+    const row = await currentConnection(tx, input, true, signal);
+    if (!row) {
+      return unavailable;
+    }
+    const existing = learnedHostKey(row);
+    if (existing) {
+      if (
+        existing.algorithm !== input.observedHostKey.algorithm ||
+        existing.fingerprint !== input.observedHostKey.fingerprint
+      ) {
+        return { outcome: "host_key_mismatch" };
+      }
+      return row.generation === input.expectedGeneration + 1
+        ? { outcome: "matched", generation: row.generation }
+        : { outcome: "configuration_changed" };
+    }
+    if (
+      row.generation !== input.expectedGeneration ||
+      row.generation === 2_147_483_647
+    ) {
+      return { outcome: "configuration_changed" };
+    }
+    await tx
+      .update(sshConnections)
+      .set({
+        learnedHostKeyAlgorithm: input.observedHostKey.algorithm,
+        learnedHostKeyFingerprint: input.observedHostKey.fingerprint,
+        generation: sql`${sshConnections.generation} + 1`,
+        updatedAt: nowDate(),
+      })
+      .where(eq(sshConnections.id, row.id));
+    signal.throwIfAborted();
+    return { outcome: "pinned", generation: row.generation + 1 };
+  });
+}

--- a/turbo/packages/api-contracts/src/contracts/runner-ssh.ts
+++ b/turbo/packages/api-contracts/src/contracts/runner-ssh.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import { runnerHeartbeatGenerationSchema } from "./runner-primitives";
+import {
+  SSH_HOST_MAX_LENGTH,
+  SSH_PASSPHRASE_MAX_LENGTH,
+  SSH_PRIVATE_KEY_MAX_LENGTH,
+  SSH_USERNAME_MAX_LENGTH,
+} from "./ssh-connections";
+
+const c = initContract();
+const generationSchema = z.int().positive().max(2_147_483_647);
+
+export const sshHostKeySchema = z
+  .object({
+    // RSA key identity is ssh-rsa; the Runner must use SHA-2 signatures.
+    algorithm: z.enum([
+      "ssh-ed25519",
+      "ecdsa-sha2-nistp256",
+      "ecdsa-sha2-nistp384",
+      "ecdsa-sha2-nistp521",
+      "ssh-rsa",
+    ]),
+    fingerprint: z
+      .string()
+      .regex(/^SHA256:[A-Za-z0-9+/]{42}[AEIMQUYcgkosw048]$/u),
+  })
+  .strict();
+
+const resolveRequestSchema = z
+  .object({
+    connectionId: z.uuid(),
+    runnerIdentity: z
+      .object({
+        runnerId: z.uuid(),
+        heartbeatGeneration: runnerHeartbeatGenerationSchema,
+      })
+      .strict(),
+  })
+  .strict();
+
+const unavailableSchema = z
+  .object({ outcome: z.literal("unavailable") })
+  .strict();
+const resolveResponseSchema = z.discriminatedUnion("outcome", [
+  unavailableSchema,
+  z
+    .object({
+      outcome: z.literal("resolved"),
+      host: z.string().min(1).max(SSH_HOST_MAX_LENGTH),
+      port: z.int().min(1).max(65_535),
+      username: z.string().min(1).max(SSH_USERNAME_MAX_LENGTH),
+      generation: generationSchema,
+      learnedHostKey: sshHostKeySchema.nullable(),
+      privateKey: z.string().min(1).max(SSH_PRIVATE_KEY_MAX_LENGTH),
+      passphrase: z.string().min(1).max(SSH_PASSPHRASE_MAX_LENGTH).nullable(),
+    })
+    .strict(),
+]);
+
+const pinRequestSchema = resolveRequestSchema
+  .extend({
+    expectedGeneration: generationSchema,
+    observedHostKey: sshHostKeySchema,
+  })
+  .strict();
+
+const pinResponseSchema = z.discriminatedUnion("outcome", [
+  unavailableSchema,
+  z
+    .object({ outcome: z.literal("pinned"), generation: generationSchema })
+    .strict(),
+  z
+    .object({ outcome: z.literal("matched"), generation: generationSchema })
+    .strict(),
+  z.object({ outcome: z.literal("host_key_mismatch") }).strict(),
+  z.object({ outcome: z.literal("configuration_changed") }).strict(),
+]);
+
+export const runnerSshContract = c.router({
+  resolve: {
+    method: "POST",
+    path: "/api/runners/runs/:runId/ssh/resolve",
+    pathParams: z.object({ runId: z.uuid() }).strict(),
+    headers: authHeadersSchema,
+    body: resolveRequestSchema,
+    responses: {
+      200: resolveResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary:
+      "Resolve one current SSH credential for the winning official Runner",
+  },
+  pin: {
+    method: "POST",
+    path: "/api/runners/runs/:runId/ssh/pin",
+    pathParams: z.object({ runId: z.uuid() }).strict(),
+    headers: authHeadersSchema,
+    body: pinRequestSchema,
+    responses: {
+      200: pinResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Atomically learn an SSH host key under current Run authority",
+  },
+});
+
+export type RunnerSshResolveRequest = z.infer<typeof resolveRequestSchema>;
+export type RunnerSshResolveResponse = z.infer<typeof resolveResponseSchema>;
+export type RunnerSshPinRequest = z.infer<typeof pinRequestSchema>;
+export type RunnerSshPinResponse = z.infer<typeof pinResponseSchema>;

--- a/turbo/packages/api-contracts/src/contracts/test-ssh-connection-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-ssh-connection-state.ts
@@ -37,7 +37,7 @@ export const testSshConnectionStateActionBodySchema = z.discriminatedUnion(
         userId: z.string().min(1),
         runnerId: z.uuid().nullable(),
         heartbeatGeneration: runnerHeartbeatGenerationSchema.nullable(),
-        triggerSource: triggerSourceSchema,
+        triggerSource: triggerSourceSchema.nullable(),
         status: z.enum([
           "running",
           "pending",

--- a/turbo/packages/api-contracts/src/contracts/test-ssh-connection-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-ssh-connection-state.ts
@@ -1,12 +1,71 @@
 import { z } from "zod";
 
 import { initContract } from "./base";
+import { triggerSourceSchema } from "./logs";
+import { runnerHeartbeatGenerationSchema } from "./runner-primitives";
 
 const c = initContract();
 
 export const testSshConnectionStateActionBodySchema = z.discriminatedUnion(
   "action",
   [
+    z
+      .object({
+        action: z.enum([
+          "hold-connection-lock",
+          "read-connection-lock",
+          "release-connection-lock",
+        ]),
+        orgId: z.string().min(1),
+        userId: z.string().min(1),
+        connectionId: z.uuid(),
+      })
+      .strict(),
+    z
+      .object({
+        action: z.literal("move-connection-org"),
+        orgId: z.string().min(1),
+        userId: z.string().min(1),
+        connectionId: z.uuid(),
+        targetOrgId: z.string().min(1),
+      })
+      .strict(),
+    z
+      .object({
+        action: z.literal("create-runtime"),
+        orgId: z.string().min(1),
+        userId: z.string().min(1),
+        runnerId: z.uuid().nullable(),
+        heartbeatGeneration: runnerHeartbeatGenerationSchema.nullable(),
+        triggerSource: triggerSourceSchema,
+        status: z.enum([
+          "running",
+          "pending",
+          "completed",
+          "cancelled",
+          "failed",
+        ]),
+        chat: z.boolean(),
+        access: z.boolean(),
+      })
+      .strict(),
+    z
+      .object({
+        action: z.literal("set-agent-access"),
+        orgId: z.string().min(1),
+        userId: z.string().min(1),
+        agentId: z.uuid(),
+        enabled: z.boolean(),
+      })
+      .strict(),
+    z
+      .object({
+        action: z.literal("delete-credential"),
+        orgId: z.string().min(1),
+        userId: z.string().min(1),
+        connectionId: z.uuid(),
+      })
+      .strict(),
     z
       .object({
         action: z.literal("set-learned-host-key"),
@@ -36,6 +95,11 @@ export const testSshConnectionStateActionResponseSchema = z
     generation: z.int().positive().optional(),
     privateKeyMatches: z.boolean().optional(),
     passphraseMatches: z.boolean().optional(),
+    runId: z.uuid().optional(),
+    agentId: z.uuid().optional(),
+    sandboxToken: z.string().optional(),
+    held: z.boolean().optional(),
+    waiting: z.boolean().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Closes #32386. Part of #32013 under #31932; neither parent is completed by this PR.

- Add official-Runner-only SSH resolve and atomic host-key pin endpoints with strict TypeScript contracts.
- Derive current authority from the running Run's immutable winning process claim, session/Agent ownership, current Agent SSH grant, exact owner connection and credential; require both staff and feature gates. Use the user's configured SSH connection and current Agent grant for every Run type; no chat-thread, trigger-source or automation/goal-association restrictions.
- Decrypt only an authorized, coherent snapshot outside database transactions. Pin under the existing connection row lock, rechecking authority after waiting and serializing first-use observations with configuration edits/resets.
- Cover authorization, all-source/no-thread parity, credential rotation/deletion, concurrent equal/conflicting pins, stale generations, revocation during lock waits, real linked automation/goal Runs, secret-free owner responses and KMS handoff behavior through HTTP with real PostgreSQL.

## Scope and deployment

Additive API only: no migration, new permission issuance, UI/CLI change, SSH execution, generated Rust/Python DTO or activation. Old clients and Runners do not call these endpoints. #32387 owns the consuming Runner engine/dispatch and secret-bearing Rust bindings; it remains blocked on this API slice.

The test-only state route remains absent from production registration. Test resources are unique per owner/Run; no global lock or extra external service is introduced.

## Risks and limits

- The fleet secret authenticates the fleet; process identity is checked against the Run claim, not a per-machine cryptographic identity.
- An already-authorized in-flight JIT snapshot cannot be clawed back. Later calls recheck current state; KMS never holds authorization locks.
- TOFU cannot prevent first-use MITM, and explicit reset reopens that window. The later Runner must validate handshake proof and require SHA-2 for RSA signatures before authentication.
- Pin adds a short DB-only connection/authority lock interval. Different observations never overwrite existing trust.
- After activation, authorized automated and non-chat workloads can also use SSH. The consuming Runner must apply the existing per-sandbox/per-Runner bounds to every Run type; no extra per-trigger permission or approval is introduced.

See `docs/runner-ssh-authority.md` for the complete handoff, pin and deployment semantics.

## Validation

- Prettier on all changed files; API and api-contracts lint and type checks (including API bootstrap/boundaries).
- `cd turbo && pnpm knip`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/runner-ssh.test.ts src/signals/routes/__tests__/ssh-connections.test.ts --maxWorkers=1 --silent=passed-only`
- `cd turbo && pnpm -F @okouai/api-contracts test --maxWorkers=2 --silent=passed-only`

No live SSH/network integration is claimed by this API-only PR; that belongs to #32387. No merge or activation requested.
