### PR TITLE
fix(e2e): drain page route handlers before fixture teardown

### DIFF
--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -47,6 +47,18 @@ Keep each layer focused:
 
 ## Adding deployed E2E coverage
 
+Playwright product specs import `test` from `e2e/playwright/fixtures.ts`.
+Its fixture-managed page drains already-running page route handlers before
+Playwright closes the page/context, including after a failed test. Route errors
+remain test failures; do not suppress them with `ignoreErrors`. A test that gates
+a route must release its gate in `finally` before fixture teardown can drain it.
+Callers still own cleanup of manually created pages and context-level routes.
+
+The local fixture integration suite (`cd e2e && pnpm test`) exercises this
+lifecycle through the real Playwright runner, Chromium and a loopback HTTP server.
+It requires the Chromium headless shell (`pnpm exec playwright install --only-shell
+chromium` from `e2e`), but not a deployed preview or Clerk credentials.
+
 Before adding a case, verify that it:
 
 - begins at a supported product entry point;

--- a/e2e/playwright/fixtures.ts
+++ b/e2e/playwright/fixtures.ts
@@ -7,6 +7,14 @@ interface PreviewBypassFixtures {
 }
 
 const test = base.extend<PreviewBypassFixtures>({
+  page: async ({ page }, use) => {
+    try {
+      await use(page);
+    } finally {
+      // UI assertions can finish while an intercepted upstream fetch is pending.
+      await page.unrouteAll({ behavior: "wait" });
+    }
+  },
   previewBypassCookie: [
     async ({ baseURL, context }, use) => {
       if (!baseURL) {

--- a/e2e/playwright/lib/fixtures.test.ts
+++ b/e2e/playwright/lib/fixtures.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const testDir = fileURLToPath(new URL("./fixtures", import.meta.url));
+
+interface RunResult {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+for (const scenario of ["success", "body-failure", "route-failure"]) {
+  test(
+    `page route teardown preserves ${scenario}`,
+    { timeout: 30_000 },
+    async () => {
+      const directory = await mkdtemp(join(tmpdir(), "page-route-fixture-"));
+      let pendingResponse: ServerResponse | undefined;
+      let markStarted: () => void = () => {};
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const server = createServer((request, response) => {
+        switch (request.url) {
+          case "/":
+            response
+              .writeHead(200, { "Content-Type": "text/html" })
+              .end(
+                "<button onclick=\"fetch('/api/user-preferences')\">Load preferences</button>",
+              );
+            break;
+          case "/api/user-preferences":
+            pendingResponse = response;
+            markStarted();
+            break;
+          case "/started":
+            void started.then(() => response.writeHead(204).end());
+            break;
+          case "/release":
+            response.writeHead(204).end();
+            assert.ok(pendingResponse);
+            pendingResponse
+              .writeHead(200, { "Content-Type": "application/json" })
+              .end(JSON.stringify({ theme: "light" }));
+            break;
+          default:
+            response.writeHead(404).end();
+        }
+      });
+
+      try {
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const address = server.address();
+        assert.ok(address && typeof address === "object");
+        const config = join(directory, "playwright.config.cjs");
+        await writeFile(
+          config,
+          `module.exports = ${JSON.stringify({
+            testDir,
+            testMatch: "route-teardown.spec.ts",
+            outputDir: join(directory, "results"),
+            reporter: "list",
+            workers: 1,
+            retries: 0,
+            timeout: 10_000,
+            use: { baseURL: `http://127.0.0.1:${address.port}` },
+          })};`,
+        );
+        const result = await runPlaywright(config, scenario);
+        const output = result.stdout + result.stderr;
+        assert.equal(result.code, scenario === "success" ? 0 : 1, output);
+        assert.match(output, /^BODY_FINISHED$/mu);
+        assert.match(output, /^PAGE_CLOSED$/mu);
+        assert.doesNotMatch(
+          output,
+          /Target page, context or browser has been closed/u,
+        );
+        assert.doesNotMatch(output, /Timeout|timed out/u);
+        assert.doesNotMatch(output, /Response has been disposed/u);
+        assert.doesNotMatch(output, /Error: ROUTE_NOT_DRAINED/u);
+
+        if (scenario === "route-failure") {
+          assert.match(output, /Error: INTENTIONAL_ROUTE_FAILURE/u);
+          assert.doesNotMatch(output, /^ROUTE_COMPLETED$/mu);
+        } else {
+          assert.match(output, /^ROUTE_COMPLETED$/mu);
+          assert.ok(
+            output.indexOf("BODY_FINISHED") < output.indexOf("ROUTE_COMPLETED"),
+            output,
+          );
+          assert.ok(
+            output.indexOf("ROUTE_COMPLETED") < output.indexOf("PAGE_CLOSED"),
+            output,
+          );
+          if (scenario === "body-failure") {
+            assert.match(output, /Error: INTENTIONAL_BODY_FAILURE/u);
+          }
+        }
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+        await rm(directory, { recursive: true, force: true });
+      }
+    },
+  );
+}
+
+function runPlaywright(config: string, scenario: string): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [
+        require.resolve("@playwright/test/cli"),
+        "test",
+        "--config",
+        config,
+        "--grep",
+        `${scenario}$`,
+      ],
+      {
+        timeout: 20_000,
+        env: { ...process.env, VERCEL_AUTOMATION_BYPASS_SECRET: "" },
+      },
+      (error, stdout, stderr) => {
+        if (!error) {
+          resolve({ code: 0, stdout, stderr });
+        } else if (typeof error.code === "number") {
+          resolve({ code: error.code, stdout, stderr });
+        } else {
+          reject(error);
+        }
+      },
+    );
+  });
+}

--- a/e2e/playwright/lib/fixtures/route-teardown.spec.ts
+++ b/e2e/playwright/lib/fixtures/route-teardown.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test as base } from "../../fixtures";
+
+let routeCompleted = false;
+let releaseRequest: Promise<void> = Promise.resolve();
+
+const test = base.extend({
+  context: async ({ context }, use, testInfo) => {
+    routeCompleted = false;
+    try {
+      await use(context);
+      // Context teardown must not start while a successful route is unfinished.
+      if (testInfo.title !== "route-failure") {
+        expect(routeCompleted, "ROUTE_NOT_DRAINED").toBe(true);
+      }
+    } finally {
+      await releaseRequest;
+    }
+  },
+  page: async ({ page }, use) => {
+    try {
+      await use(page);
+    } finally {
+      // Start releasing only as fixture teardown begins. The context fixture
+      // owns this promise so we do not drain the tested page fixture ourselves.
+      releaseRequest = page.request.post("/release").then((response) => {
+        expect(response.ok()).toBe(true);
+      });
+    }
+  },
+});
+
+for (const scenario of ["success", "body-failure", "route-failure"]) {
+  test(scenario, async ({ page, request }) => {
+    page.on("close", () => console.log("PAGE_CLOSED"));
+    await page.route("**/api/user-preferences", async (route) => {
+      const response = await route.fetch();
+      const preferences: unknown = await response.json();
+      expect(preferences).toEqual({ theme: "light" });
+      if (scenario === "route-failure") {
+        throw new Error("INTENTIONAL_ROUTE_FAILURE");
+      }
+      await route.fulfill({ response, json: { theme: "system" } });
+      routeCompleted = true;
+      console.log("ROUTE_COMPLETED");
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Load preferences" }).click();
+    // This responds only once the real upstream request is held in flight.
+    const started = await request.get("/started");
+    expect(started.ok()).toBe(true);
+    console.log("BODY_FINISHED");
+    expect(scenario, "INTENTIONAL_BODY_FAILURE").not.toBe("body-failure");
+  });
+}


### PR DESCRIPTION
## Summary

Closes #32396.

- Drain registered page route callbacks before the shared Playwright page fixture returns to the built-in page/context owner, including after assertion failures.
- Preserve real callback failures using `behavior: "wait"`; do not swallow errors, retry, extend deadlines or change product assertions.
- Add real Chromium/loopback HTTP integration tests through the Playwright CLI and the actual shared fixture. The tests cover successful teardown, original assertion failures and route callback failures. Document gate-release and manual-page ownership.

## Root cause

[The features job on PR #32385](https://github.com/vm0-ai/vm0/actions/runs/34134415761/job/101783810284?pr=32385) failed at `chat.spec.ts:29` with `route.fetch: Target page, context or browser has been closed` during GET user-preferences. The dark composer test introduced by #32351 can finish its theme/focus/shadow assertions using the emulated dark system preference while the real preference request is still in flight. The page fixture previously had no route-completion owner. #32385 itself does not change this browser path.

The regression harness holds the upstream request until fixture teardown begins and checks completion before context teardown/page closure. On the unmodified fixture, both successful-body and failing-body cases fail with `ROUTE_NOT_DRAINED` and a disposed response. The fixed fixture completes callbacks first. Intentional child-process failures are asserted by passing parent integration tests, not skipped or expected-failure annotations.

## Scope and risks

The runtime fix is eight lines in the shared E2E fixture. The existing chat/agent spec files, UI, API, runner, auth state, database, deployments and CI workflow are unchanged. No cross-version runtime contract is affected. Issue #32084 and the changes in PR #32385 are outside this PR's scope.

The fixture stays lazy and preserves its original context/browser options. Teardown now waits for registered running handlers; tests must release their own gates first. A genuinely stalled handler remains a visible failure under existing request/teardown timeouts. Manually created pages and context routes retain their existing owners.

## Validation

- Scoped Prettier check: passed.
- `cd e2e && pnpm check-types`: passed.
- `cd e2e && pnpm test`: 39 passed, 0 failed/skipped.
- `cd e2e && CI=1 pnpm test`: 39 passed, 0 failed/skipped on the final worktree.
- `CI=1 pnpm exec tsx --test playwright/lib/fixtures.test.ts`, three consecutive runs: 9/9 passed.
- `git diff --check`: passed.
- Required post-pull local database migration: passed (no schema changes).

E2E has no ESLint/Knip workspace configuration; unrelated Turbo, Rust and Python suites were not selected. Deployed features assertions are validated by this PR's CI, not claimed as locally executed. No merge performed.
