### PR TITLE
fix(platform): align sidebar scrollbar with workspace edge

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -16,6 +16,109 @@ test("chat page displays tagline after onboarding", async ({ page }) => {
   });
 });
 
+test("sidebar scrollbar meets the workspace edge without a mobile inset", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 520 });
+  await page.goto(appUrl);
+  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+
+  const chatList = page.getByTestId("chat-list-column");
+  const scrollViewport = page.getByRole("region", { name: "Chat threads" });
+  const scrollbar = page.getByTestId("sidebar-scrollbar");
+  const workspace = page.getByTestId("workspace-inset");
+  await expect(chatList).toBeVisible({ timeout: 20_000 });
+  await expect(scrollViewport).toBeVisible({ timeout: 20_000 });
+  await expect(workspace).toBeVisible({ timeout: 20_000 });
+
+  let scrollMetrics = { clientHeight: 0, scrollHeight: 0 };
+  for (let height = 520; height >= 160; height -= 10) {
+    await page.setViewportSize({ width: 1440, height });
+    scrollMetrics = await scrollViewport.evaluate((element) => {
+      return {
+        clientHeight: element.clientHeight,
+        scrollHeight: element.scrollHeight,
+      };
+    });
+    if (
+      scrollMetrics.clientHeight > 0 &&
+      scrollMetrics.scrollHeight > scrollMetrics.clientHeight
+    ) {
+      break;
+    }
+  }
+  expect(scrollMetrics.clientHeight).toBeGreaterThan(0);
+  expect(scrollMetrics.scrollHeight).toBeGreaterThan(
+    scrollMetrics.clientHeight,
+  );
+
+  const [chatListBox, scrollbarBox, workspaceBox] = await Promise.all([
+    chatList.boundingBox(),
+    scrollbar.boundingBox(),
+    workspace.boundingBox(),
+  ]);
+  if (!chatListBox || !scrollbarBox || !workspaceBox) {
+    throw new Error("Expected visible desktop sidebar geometry");
+  }
+  const desktopWorkspace = await workspace.evaluate((element) => {
+    const style = getComputedStyle(element);
+    const backgroundStyle = getComputedStyle(element, "::before");
+    return {
+      borderLeftWidth: Number.parseFloat(style.borderLeftWidth),
+      marginBottom: Number.parseFloat(style.marginBottom),
+      marginLeft: Number.parseFloat(style.marginLeft),
+      marginRight: Number.parseFloat(style.marginRight),
+      marginTop: Number.parseFloat(style.marginTop),
+      paddingLeft: Number.parseFloat(style.paddingLeft),
+      backgroundLeft: Number.parseFloat(backgroundStyle.left),
+    };
+  });
+  const chatListRight = chatListBox.x + chatListBox.width;
+  const scrollbarRight = scrollbarBox.x + scrollbarBox.width;
+  const workspaceSurfaceLeft = workspaceBox.x + desktopWorkspace.paddingLeft;
+  expect(workspaceSurfaceLeft).toBeCloseTo(chatListRight, 0);
+  expect(workspaceBox.x - scrollbarRight).toBeGreaterThanOrEqual(0);
+  expect(workspaceBox.x - scrollbarRight).toBeLessThanOrEqual(2);
+  expect(desktopWorkspace).toMatchObject({
+    backgroundLeft: 0,
+    marginBottom: 8,
+    marginLeft: 0,
+    marginRight: 8,
+    marginTop: 8,
+    paddingLeft: 0,
+  });
+  expect(desktopWorkspace.borderLeftWidth).toBeGreaterThan(0);
+
+  await page.setViewportSize(MOBILE_VIEWPORT);
+  await expect(chatList).toBeHidden();
+  const mobileWorkspace = await workspace.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    return {
+      borderLeftWidth: Number.parseFloat(style.borderLeftWidth),
+      bottom: rect.bottom,
+      left: rect.left,
+      marginBottom: Number.parseFloat(style.marginBottom),
+      marginLeft: Number.parseFloat(style.marginLeft),
+      marginRight: Number.parseFloat(style.marginRight),
+      marginTop: Number.parseFloat(style.marginTop),
+      right: rect.right,
+      top: rect.top,
+    };
+  });
+  expect(mobileWorkspace).toEqual({
+    borderLeftWidth: 0,
+    bottom: MOBILE_VIEWPORT.height,
+    left: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    marginRight: 0,
+    marginTop: 0,
+    right: MOBILE_VIEWPORT.width,
+    top: 0,
+  });
+});
+
 test.describe("dark theme", () => {
   test.use({ colorScheme: "dark" });
 

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -588,8 +588,7 @@ body {
   --color-sidebar-border: hsl(var(--gray-200));
 }
 
-/* The sidebars take the site's own two greys and the chat column doubles as the
-   frame around the workspace card. */
+/* The sidebars take the site's own two greys. */
 .okou-app {
   --color-sidebar: hsl(var(--sidebar));
   --color-sidebar-rail: hsl(var(--sidebar-rail));
@@ -1925,54 +1924,6 @@ html:has(.okou-dialog-overlay)
     .owf-diagram-beam
   ):not(.okou-dialog-content *) {
   animation-play-state: paused;
-}
-
-/* Workspace card: the routed page is a white sheet laid over the shell's grey
-   rather than a white half of the window. The gap runs on all four sides, so
-   the chat column's surface continues around the sheet and reads as one frame.
-   Padding insets the content and `inset` insets the paint by the same amount.
-
-   The fill sits on `::before` at `z-index: -1`, so it paints behind content.
-   That is only enough while the corner triangles stay transparent, and a page
-   whose last child is flush with the content box and carries its own opaque
-   background -- the chat composer footer, for one -- squares them off again
-   and hides the border along that edge with them.
-
-   So the two jobs are split. `::before` keeps the fill behind content and
-   nothing else; `::after` owns the border and repaints the gutter over
-   content. The ring spreads by exactly the gap, which is the only region
-   padding already reserves, so it can only ever cover the triangles the radius
-   cuts away. Clipping the card would do the same job and take every popover
-   that has to escape it with it.
-
-   The border belongs to one pseudo-element only. While both drew it, the two
-   0.7px strokes stacked wherever content was transparent and the top corners
-   came out half again as heavy as the bottom ones, which sit over the footer.
-
-   Desktop only. Below the sidebar breakpoint the columns are gone and a frame
-   would just spend width the page does not have. */
-@media (min-width: 48rem) {
-  .okou-workspace-card {
-    --okou-workspace-card-gap: 8px;
-    --okou-workspace-card-radius: 12px;
-    background-color: hsl(var(--sidebar));
-    padding: var(--okou-workspace-card-gap);
-  }
-
-  .okou-workspace-card.okou-workspace-bg::before {
-    inset: var(--okou-workspace-card-gap);
-    border-radius: var(--okou-workspace-card-radius);
-  }
-
-  .okou-workspace-card.okou-workspace-bg::after {
-    content: "";
-    position: absolute;
-    inset: var(--okou-workspace-card-gap);
-    border: 0.7px solid hsl(var(--border));
-    border-radius: var(--okou-workspace-card-radius);
-    box-shadow: 0 0 0 var(--okou-workspace-card-gap) hsl(var(--sidebar));
-    pointer-events: none;
-  }
 }
 
 /* Dark carries the brand hue instead of a lighter neutral. The light ring can

--- a/turbo/apps/platform/src/views/okou-page/directed-shared.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-shared.tsx
@@ -14,6 +14,7 @@ import {
   colorTheme$,
   shellDocumentAttributesRef$,
 } from "../../signals/theme.ts";
+import { WorkspaceInset } from "./workspace-inset.tsx";
 
 export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
   const onAccountAction = useSet(handleAccountAction$);
@@ -26,7 +27,7 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
   return (
     <div
       ref={shellDocumentAttributesRef}
-      className="okou-app okou-viewport-shell flex w-full bg-background"
+      className="okou-app okou-viewport-shell flex w-full bg-background md:bg-sidebar"
       data-gradient-color-themes={gradientColorThemesEnabled || undefined}
       data-color-theme={gradientColorThemesEnabled ? colorTheme : undefined}
     >
@@ -42,9 +43,7 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
           />
         </div>
       </aside>
-      <div className="flex flex-1 flex-col min-w-0 min-h-0 okou-workspace-bg okou-workspace-card">
-        {children}
-      </div>
+      <WorkspaceInset>{children}</WorkspaceInset>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-layout.tsx
@@ -50,6 +50,7 @@ import {
   shellDocumentAttributesRef$,
 } from "../../signals/theme.ts";
 import { SIDEBAR_DESKTOP_MEDIA_QUERY } from "./sidebar-breakpoint.ts";
+import { WorkspaceInset } from "./workspace-inset.tsx";
 
 function AgentAvatarInTopBar() {
   const agent = useLastResolved(currentChatAgent$);
@@ -355,7 +356,7 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
   return (
     <div
       ref={shellDocumentAttributesRef}
-      className="okou-app okou-viewport-shell okou-managed-bottom-safe-area flex w-full bg-background"
+      className="okou-app okou-viewport-shell okou-managed-bottom-safe-area flex w-full bg-background md:bg-sidebar"
       data-gradient-color-themes={gradientColorThemesEnabled || undefined}
       data-color-theme={gradientColorThemesEnabled ? colorTheme : undefined}
     >
@@ -367,12 +368,12 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
       <AttachmentLightboxMount />
       <QueueDrawer />
       {isDesktop ? <Sidebar isDesktop /> : <MobileSidebarMount />}
-      <div className="flex flex-1 flex-col min-w-0 min-h-0 okou-workspace-bg okou-workspace-card">
+      <WorkspaceInset>
         <InstallBanner />
         <IosInstallModal />
         {!isDesktop && <MobileTopBar />}
         {children}
-      </div>
+      </WorkspaceInset>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-scroll.tsx
@@ -64,11 +64,8 @@ export function OverlayScrollArea({
           {children}
         </ScrollArea.Content>
       </ScrollArea.Viewport>
-      {/* The track stays wide enough to grab; `justify-end` keeps the thumb
-          itself against the viewport's edge, clear of the trailing menu button
-          on the rows beside the workspace card. */}
       <ScrollArea.Scrollbar
-        className="m-px flex w-3 justify-end opacity-0 transition-opacity duration-150 data-hovering:opacity-100 data-scrolling:opacity-100 data-scrolling:duration-0"
+        className="pointer-events-none m-px flex w-3 justify-center opacity-0 transition-opacity duration-150 data-hovering:pointer-events-auto data-hovering:opacity-100 data-scrolling:pointer-events-auto data-scrolling:opacity-100 data-scrolling:duration-0"
         data-testid="sidebar-scrollbar"
       >
         <ScrollArea.Thumb

--- a/turbo/apps/platform/src/views/okou-page/sidebar.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar.tsx
@@ -736,8 +736,7 @@ function ThreeColumnSearchDialogContainer() {
   );
 }
 
-/** Inset the chat list keeps beside the workspace card's existing gutter. */
-const CHAT_LIST_INSET = "pl-3 pr-1";
+const CHAT_LIST_INSET = "px-3";
 
 function ChatListColumn() {
   const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;

--- a/turbo/apps/platform/src/views/okou-page/workspace-inset.tsx
+++ b/turbo/apps/platform/src/views/okou-page/workspace-inset.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export function WorkspaceInset({ children }: { readonly children: ReactNode }) {
+  return (
+    <div className="okou-workspace-bg flex min-h-0 min-w-0 flex-1 flex-col bg-background md:m-2 md:ml-0 md:overflow-hidden md:rounded-xl md:border-[0.7px] md:border-border">
+      {children}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/okou-page/workspace-inset.tsx
+++ b/turbo/apps/platform/src/views/okou-page/workspace-inset.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from "react";
 
 export function WorkspaceInset({ children }: { readonly children: ReactNode }) {
   return (
-    <div className="okou-workspace-bg flex min-h-0 min-w-0 flex-1 flex-col bg-background md:m-2 md:ml-0 md:overflow-hidden md:rounded-xl md:border-[0.7px] md:border-border">
+    <div
+      className="okou-workspace-bg flex min-h-0 min-w-0 flex-1 flex-col bg-background md:m-2 md:ml-0 md:overflow-hidden md:rounded-xl md:border-[0.7px] md:border-border"
+      data-testid="workspace-inset"
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

- model the routed workspace as a reusable Tailwind `WorkspaceInset`, following shadcn's inset-sidebar boundary ownership: `m-2` on desktop with `ml-0` beside the sidebar
- remove the custom `.okou-workspace-card` padding, pseudo-element border, and spread-shadow composition
- restore symmetric `px-3` chat-list content spacing and the Base UI scrollbar's centered thumb; hidden scrollbars no longer intercept pointer events

## Root cause

The previous fix in #31623 compensated for an 8px workspace-card padding by reducing the list's right padding and pushing the thumb outward. After the new UI became permanent, that outer padding still sat between the Scroll Area root and the visible workspace border, so the scrollbar appeared to have padding on its right.

This change removes that intermediate gutter. The 300px sidebar is now the Scroll Area root's actual boundary, and the workspace border starts at the same coordinate. The remaining top, right, and bottom inset belongs to the workspace surface itself.

## References

- Base UI Scroll Area anatomy: https://base-ui.com/react/components/scroll-area
- shadcn `SidebarInset`: https://github.com/shadcn-ui/ui/blob/5c7072da672b0048bc6771e3204063a2537df91a/apps/v4/registry/new-york-v4/ui/sidebar.tsx#L307-L315

## Validation

- `npx --yes prettier@3.6.2 --check ...`
- `git diff --check`
- Local full Vitest and a local dev server were intentionally not run per repository guidance; the PR pipeline and Preview browser verification cover this UI-only geometry change.