### PR TITLE
test(image-recognition): remove legacy tombstone coverage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/model-provider-gateways.test.ts
@@ -580,7 +580,6 @@ describe("custom model provider gateway routes", () => {
       expect(deepseekClaim.appendSystemPrompt).toContain(
         'okou image-recognition --file <image-path> --prompt "<instruction>"',
       );
-      expect(deepseekClaim.appendSystemPrompt).not.toContain("okou recognize");
 
       await runs.requestCancelRun(actor, deepseekRunId, [200]);
     }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8753,9 +8753,6 @@ describe("RUN-02: model provider selection and built-in admission", () => {
     expect(unsupported.claim.appendSystemPrompt ?? "").toContain(
       'okou image-recognition --file <image-path> --prompt "<instruction>"',
     );
-    expect(unsupported.claim.appendSystemPrompt ?? "").not.toContain(
-      "okou recognize",
-    );
     expect(verifyOkouToken(unsupportedToken)?.capabilities).toContain(
       "image-recognition:write",
     );

--- a/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/command-capability-visibility.test.ts
@@ -811,9 +811,6 @@ describe("registerCommands", () => {
     expect(buildHelpText(decodeSandboxTokenPayload(eligibleToken))).toContain(
       "okou image-recognition --file",
     );
-    expect(
-      buildHelpText(decodeSandboxTokenPayload(eligibleToken)),
-    ).not.toContain("okou recognize --file");
   });
 
   it("should show billing help examples only for billing capabilities", () => {

--- a/turbo/apps/cli/src/__tests__/okou.test.ts
+++ b/turbo/apps/cli/src/__tests__/okou.test.ts
@@ -175,16 +175,8 @@ describe("Okou CLI lazy command loading", () => {
     },
   );
 
-  it.each([
-    {
-      label: "direct invocation",
-      argv: ["node", "okou", "recognize"],
-    },
-    {
-      label: "help invocation",
-      argv: ["node", "okou", "help", "recognize"],
-    },
-  ])("should reject removed $label", async ({ argv }) => {
+  it("should reject help for an unknown command", async () => {
+    const argv = ["node", "okou", "help", "not-a-command"];
     vi.stubEnv("OKOU_TOKEN", buildOkouToken(["image-recognition:write"]));
     let errorOutput = "";
     const prog = new Command()
@@ -198,14 +190,9 @@ describe("Okou CLI lazy command loading", () => {
 
     await registerRequestedCommand(prog, argv);
 
-    expect(
-      prog.commands.map((registeredCommand) => {
-        return registeredCommand.name();
-      }),
-    ).not.toContain("recognize");
     await expect(prog.parseAsync(argv)).rejects.toMatchObject({
       code: "commander.unknownCommand",
     });
-    expect(errorOutput).toContain("unknown command 'recognize'");
+    expect(errorOutput).toContain("unknown command 'not-a-command'");
   });
 });

--- a/turbo/apps/cli/src/commands/image-recognition/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/image-recognition/__tests__/index.test.ts
@@ -238,7 +238,6 @@ describe("okou image-recognition command", () => {
     imageRecognitionCommand.outputHelp();
 
     expect(helpOutput).toContain("okou image-recognition --file");
-    expect(helpOutput).not.toContain("okou recognize --file");
     expect(helpOutput).toContain("Uses a fixed Okou-managed recognition model");
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/__tests__/image-recognition.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/image-recognition.test.ts
@@ -10,10 +10,7 @@ import {
 } from "../image-recognition";
 
 describe("image recognition contract", () => {
-  it("declares only the canonical API operation", () => {
-    expect(Object.keys(imageRecognitionContract)).toStrictEqual([
-      "imageRecognition",
-    ]);
+  it("declares the canonical API operation", () => {
     expect({
       method: imageRecognitionContract.imageRecognition.method,
       path: imageRecognitionContract.imageRecognition.path,


### PR DESCRIPTION
## Summary

- remove retired `recognize` command, help, contract-count, CLI help, generated-guidance, and model-gateway tombstone assertions
- preserve the generic unknown-help behavior with the neutral `not-a-command` example
- retain the canonical API method/path, CLI direct/help loading, capability visibility, guidance, and model eligibility assertions

## Scope

- production code and the canonical `POST /api/image-recognition` / `okou image-recognition` behavior are unchanged
- no compatibility path, alias, fallback, schema, database, migration, workflow, release, or deployment behavior is introduced

## Verification

- `pnpm -F @okouai/api-contracts exec vitest run src/contracts/__tests__/image-recognition.test.ts` — 5 passed
- `pnpm -F @okouai/cli exec vitest run src/commands/image-recognition/__tests__/index.test.ts src/__tests__/okou.test.ts src/__tests__/command-capability-visibility.test.ts` — 99 passed
- focused API guidance/model eligibility tests — 1 passed each against a migrated ephemeral PostgreSQL 18 database in UTC; database stopped and removed afterward
- affected Prettier check, API contracts / CLI / API lint, and API contracts / CLI / API type checks
- full `pnpm knip`
- runtime API schema generation and compatibility check against `runtime-api-schema-prod` — 0 findings
- Python and Rust binding regeneration — no tracked diff
- CLI and API production builds
- `git diff --check`

## Inventory

- based on `origin/main` at `fcbba6347c4b1c9d3daaf3772308e0489073065c`
- 23 open pull requests inspected; no target-file overlap and no open diff adds a retired path, command, or symbol
- scoped live-source search finds no owned `/api/recognize`, `okou recognize`, removed contract member, compatibility command, compatibility client, or removed lazy-definition identifier
- remaining uses of the English word `recognize` are immutable changelog history, unrelated provider URLs, or ordinary English text and identifiers

Closes #32392
