### PR TITLE
refactor: remove workspace agent search feature switch

### DIFF
--- a/turbo/apps/platform/src/signals/okou-page/three-column-search-resources.ts
+++ b/turbo/apps/platform/src/signals/okou-page/three-column-search-resources.ts
@@ -1,6 +1,5 @@
 import { computed } from "ccstate";
 import type { AgentResponse } from "@okouai/api-contracts/contracts/agents";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   artifactCatalogContract,
   type ArtifactSummary,
@@ -10,7 +9,6 @@ import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows"
 import { accept } from "../../lib/accept.ts";
 import { agents$ } from "../agent.ts";
 import { apiClient$ } from "../api-client.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import {
   createImageLoadSignals,
   type ImageLoadSignals,
@@ -25,14 +23,10 @@ interface ThreeColumnAgentSearchResult {
   readonly agents: readonly AgentResponse[];
 }
 
-export const workspaceAgentSearchEnabled$ = computed((get) => {
-  return get(featureSwitch$)[FeatureSwitchKey.WorkspaceAgentSearch];
-});
-
 export const threeColumnAgentSearchResults$ = computed(
   async (get): Promise<ThreeColumnAgentSearchResult> => {
     const query = get(chatListQuery$).trim().toLowerCase();
-    if (!get(workspaceAgentSearchEnabled$) || !query) {
+    if (!query) {
       return { query, agents: [] };
     }
     const agents = await get(agents$);

--- a/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
@@ -515,10 +515,7 @@ test.each([
       context,
       path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
       auth: workspace.auth,
-      featureSwitches: {
-        ...featureSwitches,
-        [FeatureSwitchKey.WorkspaceAgentSearch]: true,
-      },
+      featureSwitches,
     });
     const { dialog, search } = await openSearch();
     await fill(search, "budget");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/workspace-agent-search.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/workspace-agent-search.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { expect, test } from "vitest";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   agentsByIdContract,
   type AgentResponse,
@@ -82,7 +81,6 @@ test("Find workspace agents by name and open their chat", async () => {
   await setupPage({
     context,
     path: `/agents/${DEFAULT_AGENT_ID}/chat`,
-    featureSwitches: { [FeatureSwitchKey.WorkspaceAgentSearch]: true },
   });
   const { dialog, search } = await openSearch();
 
@@ -136,27 +134,6 @@ test("Find workspace agents by name and open their chat", async () => {
   expect(screen.queryByRole("dialog", { name: SEARCH_LABEL })).toBeNull();
 });
 
-test("Keep agents out of workspace search when the feature is disabled", async () => {
-  prepareAgents();
-  await setupPage({
-    context,
-    path: `/agents/${DEFAULT_AGENT_ID}/chat`,
-    featureSwitches: { [FeatureSwitchKey.WorkspaceAgentSearch]: false },
-  });
-  const { dialog, search } = await openSearch();
-
-  await fill(search, "research");
-  await expect(
-    within(dialog).findByText("No results found"),
-  ).resolves.toBeVisible();
-  expect(within(dialog).queryByRole("option")).toBeNull();
-  expect(
-    queryAllByRoleFast("tab", dialog).map((tab) => {
-      return tab.textContent;
-    }),
-  ).not.toContain("Agents");
-});
-
 test("Limit matching agents to the workspace search result size", async () => {
   context.mocks.browser.userAgent(MAC_USER_AGENT);
   context.mocks.data.agents([
@@ -171,7 +148,6 @@ test("Limit matching agents to the workspace search result size", async () => {
   await setupPage({
     context,
     path: `/agents/${DEFAULT_AGENT_ID}/chat`,
-    featureSwitches: { [FeatureSwitchKey.WorkspaceAgentSearch]: true },
   });
   const { dialog, search } = await openSearch();
 

--- a/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-dialogs.tsx
@@ -77,7 +77,6 @@ import {
   threeColumnAgentSearchResults$,
   threeColumnArtifactSearchResults$,
   threeColumnWorkflowSearchResults$,
-  workspaceAgentSearchEnabled$,
   type ThreeColumnArtifactSearchItem,
 } from "../../signals/okou-page/three-column-search-resources.ts";
 import { ArtifactThumbnailImage } from "./artifact-thumbnail.tsx";
@@ -862,7 +861,6 @@ function SpotlightSearchFilterBar({
   readonly onSelect: (filter: ThreeColumnSearchFilter) => void;
 }) {
   const { t } = useTranslation("agents");
-  const agentSearchEnabled = useGet(workspaceAgentSearchEnabled$);
   const options: readonly {
     readonly value: ThreeColumnSearchFilter;
     readonly label: string;
@@ -914,9 +912,6 @@ function SpotlightSearchFilterBar({
         className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
       >
         {options.map((option) => {
-          if (option.value === "agents" && !agentSearchEnabled) {
-            return null;
-          }
           return (
             <SpotlightFilterButton
               key={option.value}
@@ -1205,7 +1200,6 @@ export function ThreeColumnSearchDialog({
   const threadMap = useGet(workspaceSearchChatThreadMap$);
   const messageLoadable = useLoadable(workspaceSearchChatMessages$);
   const agentLoadable = useLoadable(threeColumnAgentSearchResults$);
-  const agentSearchEnabled = useGet(workspaceAgentSearchEnabled$);
   const workflowLoadable = useLoadable(threeColumnWorkflowSearchResults$);
   const artifactLoadable = useLoadable(threeColumnArtifactSearchResults$);
   const activeThreadIds = useLastResolved(sidebarActiveThreadIds$, {
@@ -1252,8 +1246,7 @@ export function ThreeColumnSearchDialog({
   );
   const showThreads = spotlightFilterShows(filter, "chats");
   const showMessages = spotlightFilterShows(filter, "messages");
-  const showAgents =
-    agentSearchEnabled && spotlightFilterShows(filter, "agents");
+  const showAgents = spotlightFilterShows(filter, "agents");
   const showWorkflows = spotlightFilterShows(filter, "workflows");
   const showArtifacts = spotlightFilterShows(filter, "artifacts");
   const visibleThreads = showThreads ? threadMatches : [];

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -59,7 +59,6 @@ export enum FeatureSwitchKey {
   FollowUpOptimize = "followUpOptimize",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   StableChatThreadNavigation = "stableChatThreadNavigation",
-  WorkspaceAgentSearch = "workspaceAgentSearch",
   ChatThreadPinShortcut = "chatThreadPinShortcut",
   SidebarSubscriptionUsage = "_sidebarSubscriptionUsage",
   PinnedAgentAvatar64 = "pinnedAgentAvatar64",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -426,12 +426,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.WorkspaceAgentSearch]: {
-    maintainer: "ethan@okou.ai",
-    description: "Find agents by name in workspace search",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ChatThreadPinShortcut]: {
     maintainer: "ethan@okou.ai",
     description:


### PR DESCRIPTION
## Summary

- Permanently enable workspace agent search for every organization.
- Remove the `workspaceAgentSearch` registry entry, key, signal, and disabled fallback.
- Keep the agent filter, name matching, result limit, navigation, and numbered-result behavior as unconditional product logic.

## Terminal state

- State: `fully-rolled-out`
- Decision basis: Ethan explicitly requested full rollout and cleanup on September 8, 2026.
- Introducing commit: `d64a34e75a` (`feat(platform): find agents by name in workspace search (#32208)`)

## Archaeology and behavior comparison

- Compared the introducing commit with its parent and the current implementation.
- The enabled branch loads workspace agents for non-empty queries, matches display names case-insensitively, exposes the Agents filter, and includes agent results in selection and numbered shortcuts.
- The disabled branch suppressed agent loading, agent results, and the Agents filter. That fallback is removed.
- Later shortcut-hint and debounce changes remain intact and independent of the removed switch.

## Test cleanup

- Removed the disabled-only workspace-search test.
- Removed `true` feature-switch overrides from the retained name-search, result-limit, and numbered-result integration coverage.
- Retained direct product behavior coverage without adding switch-absence assertions.

## Search audit

- No remaining matches for `workspaceAgentSearch`, `WorkspaceAgentSearch`, kebab/snake variants, `workspaceAgentSearchEnabled`, or `agentSearchEnabled`.
- Reviewed retained feature terms including `threeColumnAgentSearchResults$`, `onSelectAgent`, the Agents filter, name-search coverage, and result-limit coverage.

## Verification

- `pnpm exec prettier --check` on all changed files
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/core check-types`
- `pnpm knip --workspace @okouai/app --workspace @okouai/core`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/workspace-agent-search.test.tsx src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx --maxWorkers=2` (12 tests passed)
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=2` (31 tests passed)
- `git diff --check`

Full repository and deployment checks are delegated to the PR pipeline.
