### PR TITLE
fix: include video options in agent prompts

### DIFF
--- a/turbo/apps/api/src/lib/video-run-options-prompt.ts
+++ b/turbo/apps/api/src/lib/video-run-options-prompt.ts
@@ -20,8 +20,8 @@ function selectedVideoParameterLabels(
 }
 
 /**
- * The video parameters the composer sent with this message, as a system-prompt
- * block.
+ * The video parameters the composer sent with this message, as agent-only
+ * context prepended to the visible request.
  *
  * These are defaults, and the wording has to say so. The user set them on a
  * chip before writing anything, so the message itself is the later and more

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -18936,7 +18936,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     }
 
     // Run options are the composer's channel for video parameters now. They
-    // ride one message, reach no table, and only enter the prompt when the
+    // ride one message, reach no table, and only enter the agent prompt when the
     // user moved a value off the effective model's default -- and they enter
     // it as defaults this run's message can override, not as instructions.
     const videoRunOptions = await sendChatRun(actor, {
@@ -18951,9 +18951,8 @@ describe("CHAT-02: generation templates and attachments", () => {
         },
       },
     });
-    const videoRunOptionsPrompt =
-      (await api.readRun(actor, videoRunOptions.runId)).appendSystemPrompt ??
-      "";
+    const videoRunOptionsRun = await api.readRun(actor, videoRunOptions.runId);
+    const videoRunOptionsPrompt = videoRunOptionsRun.prompt;
     expect(videoRunOptionsPrompt).toContain("# Video Generation Defaults");
     expect(videoRunOptionsPrompt).toContain("- Aspect ratio: 9:16");
     expect(videoRunOptionsPrompt).toContain("- Duration: 6s");
@@ -18964,10 +18963,14 @@ describe("CHAT-02: generation templates and attachments", () => {
     expect(videoRunOptionsPrompt).toContain(
       "the message wins, for that parameter only",
     );
+    expect(videoRunOptionsPrompt).toMatch(/\n\nmake a clip from this brief$/);
     // Values only. A pre-assembled flag string is a ready-made answer that
     // stops being correct as soon as the message overrides one value.
     expect(videoRunOptionsPrompt).not.toContain("--aspect-ratio");
     expect(videoRunOptionsPrompt).not.toContain("--no-audio");
+    expect(videoRunOptionsRun.appendSystemPrompt ?? "").not.toContain(
+      "# Video Generation Defaults",
+    );
     await cancelChatRun(actor, videoRunOptions.runId);
 
     // Most runs never generate a video, so a send that set nothing carries no
@@ -18977,8 +18980,7 @@ describe("CHAT-02: generation templates and attachments", () => {
       prompt: "answer a plain question",
     });
     expect(
-      (await api.readRun(actor, withoutVideoRunOptions.runId))
-        .appendSystemPrompt ?? "",
+      (await api.readRun(actor, withoutVideoRunOptions.runId)).prompt,
     ).not.toContain("# Video Generation Defaults");
     await cancelChatRun(actor, withoutVideoRunOptions.runId);
 

--- a/turbo/apps/api/src/signals/routes/test-chat-event-retention.ts
+++ b/turbo/apps/api/src/signals/routes/test-chat-event-retention.ts
@@ -61,7 +61,6 @@ const resolveSessionPromptFixturesRoute$ = command(
       sessionAction: "rotated",
       context: {
         generationTemplatePrompt: "",
-        videoRunOptions: null,
         computerUseHostDisplayName: null,
         triggerSource: "web",
         agentRunSource: null,

--- a/turbo/apps/api/src/signals/services/chat-events.command.ts
+++ b/turbo/apps/api/src/signals/services/chat-events.command.ts
@@ -148,6 +148,7 @@ import {
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { isCodexFastModeEnabled } from "@okouai/core/model-feature-switch";
 import { buildGenerationTemplatePrompt } from "../../lib/generation-template-prompt";
+import { buildVideoRunOptionsPrompt } from "../../lib/video-run-options-prompt";
 import {
   additionalVolumesForRun,
   authorizedUserPresentationTemplateIds,
@@ -3345,9 +3346,14 @@ function buildCreateAgentRunArgs(params: {
     builtInModelRuntimeRoute,
     codexServiceTier,
   } = prepared.runConfiguration;
+  const videoRunOptionsPrompt = buildVideoRunOptionsPrompt(
+    prepared.videoRunOptions,
+  );
+  const agentPrompt = videoRunOptionsPrompt
+    ? `${videoRunOptionsPrompt}\n\n${prepared.body.agentPrompt}`
+    : prepared.body.agentPrompt;
   const webChatSessionPromptContext: WebChatSessionPromptContext = {
     generationTemplatePrompt: prepared.generationTemplatePrompt,
-    videoRunOptions: prepared.videoRunOptions,
     computerUseHostDisplayName:
       prepared.computerUseHostGrant?.displayName ?? null,
     triggerSource: prepared.triggerSource,
@@ -3388,7 +3394,7 @@ function buildCreateAgentRunArgs(params: {
       },
     ],
     body: {
-      prompt: prepared.body.agentPrompt,
+      prompt: agentPrompt,
       agentId: args.body.agentId,
       ...(providerAdmission.effectiveModelProvider
         ? {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -2809,10 +2809,6 @@ const loadWebQueuedLaunchMaterial: LaunchLoader = (_db, args) => {
       priorContext: "",
       context: {
         generationTemplatePrompt: "",
-        // A queued message is dispatched from its persisted chat event, and
-        // run options are deliberately never persisted, so there is nothing to
-        // replay here.
-        videoRunOptions: null,
         computerUseHostDisplayName: null,
         triggerSource: args.contextType === "agent_run" ? "agent" : "web",
         agentRunSource: args.agentRunSource,

--- a/turbo/apps/api/src/signals/services/web-chat-session-prompt.service.ts
+++ b/turbo/apps/api/src/signals/services/web-chat-session-prompt.service.ts
@@ -4,10 +4,7 @@ import {
   chatEventCompatibilityRole,
   type ChatEventType,
 } from "@okouai/api-contracts/contracts/chat-events";
-import type {
-  ChatRunVideoOptionsRequest,
-  UserMessageDocument,
-} from "@okouai/api-contracts/contracts/chat-threads";
+import type { UserMessageDocument } from "@okouai/api-contracts/contracts/chat-threads";
 import { agentRuns } from "@okouai/db/schema/agent-run";
 import { chatEvents } from "@okouai/db/schema/chat-event";
 import {
@@ -24,7 +21,6 @@ import {
 
 import { CONVERSATION_GUIDANCE } from "../../lib/conversation-guidance";
 import type { Db } from "../external/db";
-import { buildVideoRunOptionsPrompt } from "../../lib/video-run-options-prompt";
 import { BEFORE_DISPATCH_CANCELLED_ERROR } from "./agent-run-create.service";
 import type { ChatThreadSessionResolutionAction } from "./chat-session-continuity.service";
 import { loadWebChatIncompleteContext } from "./chat-incomplete-context.service";
@@ -62,11 +58,6 @@ interface WebChatPriorRun {
 
 export interface WebChatSessionPromptContext {
   readonly generationTemplatePrompt: string;
-  /**
-   * Video parameters sent with this message. Run-scoped and never persisted,
-   * so a rotated session or a queued dispatch has nothing to read back.
-   */
-  readonly videoRunOptions: ChatRunVideoOptionsRequest | null;
   readonly computerUseHostDisplayName: string | null;
   readonly triggerSource: "web" | "agent";
   readonly agentRunSource: ChatAgentRunSourceAnnotation | null;
@@ -167,7 +158,6 @@ export function buildWebChatAppendSystemPrompt(args: {
     args.priorContext,
     args.incompleteContext,
     args.context.generationTemplatePrompt,
-    buildVideoRunOptionsPrompt(args.context.videoRunOptions),
     args.context.computerUseHostDisplayName
       ? buildComputerUseSystemPrompt(args.context.computerUseHostDisplayName)
       : "",

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1092,10 +1092,10 @@ const chatThreadModelSelectionUpdateBodySchema = z.object({
 /**
  * Text-to-video parameters chosen for this send only.
  *
- * Deliberately not persisted anywhere: the API renders them into the run's
- * system prompt and forgets them, so a reload starts from the effective
- * model's defaults again. The model itself is absent because it is already
- * resolved from the thread pin and the member default the run carries.
+ * Deliberately not persisted as structured settings: the API renders them into
+ * the run's agent prompt, so a reload starts from the effective model's
+ * defaults again. The model itself is absent because it is already resolved
+ * from the thread pin and the member default the run carries.
  */
 const chatRunVideoOptionsRequestSchema = z
   .object({


### PR DESCRIPTION
## Summary

- prepend the existing video-options block to the run's agent-facing prompt
- keep the persisted `userMessage` unchanged, so the extra settings remain absent from the visible chat message
- stop placing per-run video settings in the reusable session system prompt

## Root cause

Slash-command video settings already arrive as `runOptions.video`, but the API rendered them into `appendSystemPrompt`. That reusable session prompt is not refreshed into the current turn of a resumed Codex session. Web chat already separates the visible `userMessage` from the agent-facing `prompt`, so the run-scoped settings now use that existing path instead.

## Validation

- `pnpm --filter @okouai/api-contracts check-types`
- `pnpm --filter api check-types`
- `pnpm --filter @okouai/api-contracts lint`
- `pnpm --filter api lint`

The DB-backed chat-events BDD assertion was updated and type-checked, but could not execute locally because PostgreSQL is unavailable in this environment; PR CI will run it.
