### PR TITLE
fix(platform): align chat response icon rails

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-run-history-preview.test.tsx
@@ -136,37 +136,28 @@ test.each([
   },
 );
 
-test("Show the history step count in the work summary", async () => {
-  installRunChat({
-    activeRunIds: [RUN_ID],
-    chatEvents: [
-      promptEvent({
-        id: "step-count-input",
-        runId: RUN_ID,
-        seqId: 1,
-        text: "Count the work history",
-      }),
-      ...Array.from({ length: 5 }, (_, index) => {
-        return assistantEvent({
-          id: `step-count-${String(index)}`,
-          runId: RUN_ID,
-          seqId: index + 2,
-          text: `Step ${String(index + 1)}`,
-        });
-      }),
-    ],
-  });
-  await setupPage({
-    context,
-    path: RUN_PATH,
-    featureSwitches: { [FeatureSwitchKey.ChatRunWorkFolding]: true },
-  });
-  await readyChat();
+test("Hide the empty history step count from the work summary", async () => {
+  await setupRunWithOutputCount(1);
 
-  expect(document.querySelector("[data-chat-run-work]")).toHaveTextContent(
-    "4 steps",
-  );
+  const workSummary = document.querySelector("[data-chat-run-work]");
+  expect(workSummary).toBeVisible();
+  expect(workSummary).not.toHaveTextContent("0 steps");
+  expect(workSummary).not.toHaveTextContent("·");
 });
+
+test.each([
+  { outputCount: 2, expectedStepCount: "1 step" },
+  { outputCount: 5, expectedStepCount: "4 steps" },
+])(
+  "Show a non-empty history step count with $outputCount outputs",
+  async ({ outputCount, expectedStepCount }) => {
+    await setupRunWithOutputCount(outputCount);
+
+    expect(document.querySelector("[data-chat-run-work]")).toHaveTextContent(
+      expectedStepCount,
+    );
+  },
+);
 
 test("Expand history messages independently and preserve them across history changes", async () => {
   installRunChat({

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -40,7 +40,7 @@ export const CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_ROW_CLASS =
   "@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]";
 
 export const CHAT_THREAD_ASSISTANT_MESSAGE_ACTIONS_CLASS =
-  "flex items-center justify-between gap-2 -ml-1";
+  "flex items-center justify-between gap-2";
 
 // Consecutive user messages read as one burst. The copy button already sits
 // `mt-1` below its message, so this pull keeps the gap below it equally tight.

--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -18,6 +18,12 @@ export const CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS =
 export const CHAT_THREAD_RESPONSE_LINE_CLASS =
   "group-data-[run-work-folding]/chat:h-auto group-data-[run-work-folding]/chat:min-h-9 group-data-[run-work-folding]/chat:py-[calc((2.25rem-1lh)/2)] group-data-[run-work-folding]/chat:leading-[1.59375rem]";
 
+// Bare response icons share the 28px action-button rail when the run-work
+// information architecture is active. Their intrinsic width remains the
+// legacy layout when the feature is off.
+export const CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS =
+  "inline-flex shrink-0 items-center justify-center group-data-[run-work-folding]/chat:w-7";
+
 export const CHAT_THREAD_USER_MESSAGE_ROW_CLASS =
   "flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3863,18 +3863,22 @@ function RunWorkSectionRow({
                 );
           }}
         </ElapsedTime>
-        <span aria-hidden>·</span>
-        <span>
-          {t(
-            ($) => {
-              return $.activity.events.steps;
-            },
-            {
-              count: stepCount,
-              formattedCount: formatAppNumber(stepCount),
-            },
-          )}
-        </span>
+        {stepCount > 0 ? (
+          <>
+            <span aria-hidden>·</span>
+            <span>
+              {t(
+                ($) => {
+                  return $.activity.events.steps;
+                },
+                {
+                  count: stepCount,
+                  formattedCount: formatAppNumber(stepCount),
+                },
+              )}
+            </span>
+          </>
+        ) : null}
       </span>
       {collapsible ? (
         <ChevronRight
@@ -8145,18 +8149,25 @@ function PagedGroupPrimaryActions({
         <TooltipProvider delayDuration={300}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Link
-                pathname="/activities/:activityRunId"
-                options={{
-                  pathParams: { activityRunId: firstRunId },
-                }}
-                className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-state-hover transition-colors duration-150"
-                aria-label={t(($) => {
-                  return $.chat.run.viewLogs;
-                })}
+              <Button
+                asChild
+                variant="quiet"
+                size="icon-xs"
+                iconSize="md"
+                className="text-muted-foreground/60"
               >
-                <ChartLine size={18} />
-              </Link>
+                <Link
+                  pathname="/activities/:activityRunId"
+                  options={{
+                    pathParams: { activityRunId: firstRunId },
+                  }}
+                  aria-label={t(($) => {
+                    return $.chat.run.viewLogs;
+                  })}
+                >
+                  <ChartLine />
+                </Link>
+              </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
               {t(($) => {
@@ -8170,16 +8181,19 @@ function PagedGroupPrimaryActions({
         <TooltipProvider delayDuration={300}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
+              <Button
                 type="button"
+                variant="quiet"
+                size="icon-xs"
+                iconSize="md"
                 onClick={onCopy}
-                className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-state-hover transition-colors duration-150"
+                className="text-muted-foreground/60"
                 aria-label={t(($) => {
                   return $.chat.actions.copyMessage;
                 })}
               >
-                {copied ? <Check size={18} /> : <Copy size={18} />}
-              </button>
+                {copied ? <Check /> : <Copy />}
+              </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
               {copied

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -321,6 +321,7 @@ import {
   CHAT_THREAD_MESSAGE_LIST_CLASS,
   CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
   CHAT_THREAD_RESPONSE_LINE_CLASS,
+  CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS,
   CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS,
   CHAT_THREAD_RESPONSE_STACK_CLASS,
   CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS,
@@ -3804,15 +3805,17 @@ function CompletedWorkFoldRow({
               })
         }
         onClick={onToggle}
-        className="inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-state-hover"
+        className="inline-flex min-h-9 items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-state-hover group-data-[run-work-folding]/chat:gap-0"
       >
-        <Hourglass aria-hidden size={14} className="shrink-0" />
+        <span className={CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS}>
+          <Hourglass aria-hidden size={14} />
+        </span>
         <span className="text-[13px]">{label}</span>
         <ChevronRight
           aria-hidden
           size={14}
           className={cn(
-            "shrink-0 text-muted-foreground/70 transition-transform",
+            "shrink-0 text-muted-foreground/70 transition-transform group-data-[run-work-folding]/chat:ml-2",
             expanded && "rotate-90",
           )}
         />
@@ -3839,7 +3842,7 @@ function RunWorkSectionRow({
   const { t } = useTranslation();
   const content = (
     <>
-      <span className="flex w-7 shrink-0 items-center justify-center">
+      <span className={CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS}>
         <Hourglass aria-hidden />
       </span>
       <span className="inline-flex min-w-0 items-center gap-1">
@@ -4101,9 +4104,11 @@ function RunGroupFoldRow({ control }: { control: RunGroupFoldControl }) {
               })
         }
         onClick={onToggle}
-        className="inline-flex min-h-9 max-w-full items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-state-hover"
+        className="inline-flex min-h-9 max-w-full items-center gap-2 rounded-lg px-2 py-1.5 text-muted-foreground transition-colors hover:bg-state-hover group-data-[run-work-folding]/chat:gap-0"
       >
-        <Icon aria-hidden size={14} className="shrink-0" />
+        <span className={CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS}>
+          <Icon aria-hidden size={14} />
+        </span>
         <span className="min-w-0 truncate whitespace-nowrap text-[13px]">
           {label}
         </span>
@@ -4111,7 +4116,7 @@ function RunGroupFoldRow({ control }: { control: RunGroupFoldControl }) {
           aria-hidden
           size={14}
           className={cn(
-            "shrink-0 text-muted-foreground/70 transition-transform",
+            "shrink-0 text-muted-foreground/70 transition-transform group-data-[run-work-folding]/chat:ml-2",
             expanded && "rotate-90",
           )}
         />
@@ -4500,7 +4505,7 @@ function RecommendedFollowupList({
               "group flex text-left transition-colors",
               showFollowupCards
                 ? "min-h-24 flex-[0_0_min(22rem,calc(100cqw-4rem))] self-stretch snap-center items-start rounded-[var(--okou-card-radius)] border border-border/70 bg-card p-4 shadow-sm hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                : "min-h-10 w-full items-center gap-2 rounded-lg px-2 py-2 hover:bg-state-hover group-data-[run-work-folding]/chat:min-h-8 group-data-[run-work-folding]/chat:py-1",
+                : "min-h-10 w-full items-center gap-2 rounded-lg px-2 py-2 hover:bg-state-hover group-data-[run-work-folding]/chat:min-h-8 group-data-[run-work-folding]/chat:gap-0 group-data-[run-work-folding]/chat:py-1",
             )}
             onClick={() => {
               handleSelect(followup, followupIndex);
@@ -4508,7 +4513,8 @@ function RecommendedFollowupList({
           >
             <span
               className={cn(
-                "shrink-0 text-muted-foreground/70 transition-colors group-hover:text-foreground",
+                CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS,
+                "text-muted-foreground/70 transition-colors group-hover:text-foreground",
                 showFollowupCards && "hidden",
               )}
             >
@@ -4525,7 +4531,7 @@ function RecommendedFollowupList({
             <ArrowUpRight
               size={14}
               className={cn(
-                "shrink-0 text-muted-foreground/60 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100",
+                "shrink-0 text-muted-foreground/60 opacity-0 transition-all group-hover:text-foreground group-hover:opacity-100 group-data-[run-work-folding]/chat:ml-2",
                 showFollowupCards && "hidden",
               )}
             />
@@ -4883,11 +4889,11 @@ function InlineThinkingRow({
   return (
     <div
       className={cn(
-        "flex items-center gap-2 h-5",
+        "flex items-center gap-2 h-5 group-data-[run-work-folding]/chat:gap-0",
         CHAT_THREAD_RESPONSE_LINE_CLASS,
       )}
     >
-      <span className="inline-flex shrink-0 items-center justify-center group-data-[run-work-folding]/chat:w-3.5">
+      <span className={CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS}>
         <ThinkingLoader
           blockStyle={blockStyle}
           spinnerEnabled={spinnerEnabled}
@@ -5771,6 +5777,20 @@ function AssistantErrorRecoveryCard({
   );
 }
 
+function AssistantErrorLeadingIcon({ warning = false }: { warning?: boolean }) {
+  return (
+    <span
+      className={cn(
+        CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS,
+        "mt-[3px]",
+        warning && "text-amber-500",
+      )}
+    >
+      <AlertCircle size={16} />
+    </span>
+  );
+}
+
 function AssistantErrorFallback({ error }: { error: string }) {
   const { t } = useTranslation();
   const openSettings = useSet(openSettingsDialogAt$);
@@ -5806,8 +5826,8 @@ function AssistantErrorFallback({ error }: { error: string }) {
 
   if (isNoModelProvider) {
     return (
-      <div className="flex items-start gap-2 text-foreground">
-        <AlertCircle size={16} className="shrink-0 mt-[3px] text-amber-500" />
+      <div className="flex items-start gap-2 text-foreground group-data-[run-work-folding]/chat:gap-0">
+        <AssistantErrorLeadingIcon warning />
         <span>
           {t(($) => {
             return $.chat.errors.noModelProviderPrefix;
@@ -5840,8 +5860,8 @@ function AssistantErrorFallback({ error }: { error: string }) {
 
   if (isProviderIncompatible) {
     return (
-      <div className="flex items-start gap-2 text-foreground">
-        <AlertCircle size={16} className="shrink-0 mt-[3px] text-amber-500" />
+      <div className="flex items-start gap-2 text-foreground group-data-[run-work-folding]/chat:gap-0">
+        <AssistantErrorLeadingIcon warning />
         <span>
           {t(($) => {
             return $.chat.errors.providerIncompatiblePrefix;
@@ -5867,8 +5887,8 @@ function AssistantErrorFallback({ error }: { error: string }) {
 
   if (isProviderDeleted) {
     return (
-      <div className="flex items-start gap-2 text-foreground">
-        <AlertCircle size={16} className="shrink-0 mt-[3px] text-amber-500" />
+      <div className="flex items-start gap-2 text-foreground group-data-[run-work-folding]/chat:gap-0">
+        <AssistantErrorLeadingIcon warning />
         <span>
           {t(($) => {
             return $.chat.errors.providerDeletedPrefix;
@@ -5890,8 +5910,8 @@ function AssistantErrorFallback({ error }: { error: string }) {
   }
 
   return (
-    <div className="flex items-start gap-2 text-destructive">
-      <AlertCircle size={16} className="shrink-0 mt-[3px]" />
+    <div className="flex items-start gap-2 text-destructive group-data-[run-work-folding]/chat:gap-0">
+      <AssistantErrorLeadingIcon />
       <Markdown
         source={error}
         style={{ fontSize: "inherit", lineHeight: "inherit" }}
@@ -6437,16 +6457,20 @@ function UserMessageActions({
   }
   return (
     <div className={CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS}>
-      <IconTooltipButton
+      <Button
         type="button"
+        variant="quiet"
+        size="icon-xs"
+        iconSize="md"
+        showTooltip
         onClick={onCopy}
-        className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-state-hover transition-colors duration-150"
+        className="text-muted-foreground/60"
         aria-label={t(($) => {
           return $.chat.actions.copyMessage;
         })}
       >
-        {copied ? <Check size={18} /> : <Copy size={18} />}
-      </IconTooltipButton>
+        {copied ? <Check /> : <Copy />}
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- align every bare leading icon in the assistant response stack on one shared 28px rail: work history, completed/grouped work, thinking, plain error feedback, and recommended follow-ups
- use the standard quiet `icon-xs` button for message actions and remove the legacy negative-margin compensation
- hide the history step suffix and separator when there are zero prior output steps

## Information architecture

The response hierarchy remains `history → main result → status tail`, with the main result ordered as `message → remaining artifacts → action bar`. The new `CHAT_THREAD_RESPONSE_LEADING_ICON_CLASS` is shared by the naked leading-icon rows across those regions instead of compensating each section independently.

The 28px rail and zero-gap text alignment are scoped to `chatRunWorkFolding`. When that switch is off, icons keep their intrinsic width and the legacy 8px gap. Icons inside cards/pills remain owned by those components, and trailing disclosure controls keep their existing 28px button hit area.

## Verification

- `pnpm -F @okouai/app exec vitest run` on seven relevant chat files (43 passed)
- final targeted rerun covering follow-ups, history, errors, and message actions (27 passed)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- Prettier and `git diff --check`

## Browser verification

Preview: https://pr-32412-app-okou-app-preview.vm0.workers.dev  
PR head: `f070bb27aab0a9884bcbe0806485c3ae65dd5905`  
Deployed PR merge ref: `dc16884486f5dcc065d2bf81a0417893bb22e2d1` (second parent is the PR head)

The existing disposable Clerk test session was re-onboarded in the reprovisioned Preview database. `chatRunWorkFolding`, `chatThinkingSpinner`, `_debug`, and `_realAgentInPreview` were enabled; the run used GPT 5.6 Luna and produced seven progress outputs plus recommended follow-ups.

- PASS: on desktop (1440×900), the work hourglass, active thinking spinner, first action icon, and all three follow-up icons have center `x=465px`; the 1px history guide occupies the same axis
- PASS: on mobile (390×844), those response icons and the first action button have center `x=30px`; document width remains 390px
- PASS: follow-up rows remain 32px when single-line and grow naturally to 56px when wrapping
- PASS: the action controls and history disclosure controls are 28×28px, expose accessible names, show the shared hover background, and retain a visible keyboard focus ring
- PASS: the message-region axe scan reports zero WCAG A/AA violations
- PASS: with `chatRunWorkFolding` disabled, the shared rail is inactive and legacy follow-up dimensions remain 40px single-line / 64px wrapped

Screenshots: [desktop response](https://a.okou.io/rtc5brpy2d.png) · [follow-up hover](https://a.okou.io/e4ff71p4v6.png) · [mobile alignment and focus](https://a.okou.io/vm4u7kdzhv.png)
