### PR TITLE
fix(runner): retain rootfs locks until worker teardown

### DIFF
--- a/.github/scripts/tests/crates-detect-workflow-test.sh
+++ b/.github/scripts/tests/crates-detect-workflow-test.sh
@@ -116,6 +116,7 @@ jq -e '
   ($rootfs_process.if | contains("needs.detect.outputs.ci-changed")) and
   any($rootfs_process.steps[]?;
     .name == "Run rootfs process ownership tests on metal" and
+    (.run | contains("sudo unshare --mount --pid --fork --kill-child --mount-proc")) and
     (.run | contains("--ignored --exact")) and
     (.run | contains("cmd::build::scripts::process_tests::rootfs_process_ownership")) and
     (.run | contains("GITHUB_RUN_ATTEMPT")) and

--- a/.github/scripts/tests/crates-detect-workflow-test.sh
+++ b/.github/scripts/tests/crates-detect-workflow-test.sh
@@ -26,6 +26,7 @@ jq -e '
   .jobs["runner-behavior-lane-c"] as $lane_c |
   .jobs["runner-behavior-lane-d"] as $lane_d |
   .jobs["host-cpu-fairness-test"] as $host_cpu |
+  .jobs["runner-rootfs-process-test"] as $rootfs_process |
   .jobs["ci-gate-crates"] as $gate |
   {
     "any-changed": "${{ steps.detect.outputs.any-changed }}",
@@ -109,10 +110,23 @@ jq -e '
   ) and
   ($gate.needs | index("host-cpu-fairness-test")) != null and
   ($gate.needs | index("runner-behavior-lane-d")) != null and
+  $rootfs_process.needs == ["detect", "runner-host-groups"] and
+  $rootfs_process.defaults.run.shell == "bash" and
+  ($rootfs_process.if | contains("needs.detect.outputs.runner-changed")) and
+  ($rootfs_process.if | contains("needs.detect.outputs.ci-changed")) and
+  any($rootfs_process.steps[]?;
+    .name == "Run rootfs process ownership tests on metal" and
+    (.run | contains("--ignored --exact")) and
+    (.run | contains("cmd::build::scripts::process_tests::rootfs_process_ownership")) and
+    (.run | contains("GITHUB_RUN_ATTEMPT")) and
+    (.run | contains("runner-host-architecture-groups.sh"))
+  ) and
+  ($gate.needs | index("runner-rootfs-process-test")) != null and
   any($gate.steps[]?;
     .name == "Validate CI results" and
     (.run | contains("needs.host-cpu-fairness-test.result")) and
-    (.run | contains("needs.runner-behavior-lane-d.result"))
+    (.run | contains("needs.runner-behavior-lane-d.result")) and
+    (.run | contains("needs.runner-rootfs-process-test.result"))
   )
 ' <<<"$crates_json" >/dev/null || fail "Crates workflow contract changed"
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -661,9 +661,9 @@ jobs:
     env:
       TARGET_TRIPLE: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: crates -> target
           shared-key: ${{ matrix.cacheSuffix }}-rootfs-process

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -640,6 +640,78 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/report-memory-peak
 
+  runner-rootfs-process-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260825
+    needs: [detect, runner-host-groups]
+    if: |
+      needs.detect.outputs.metal-job-ref != '' && (
+        needs.detect.outputs.ci-changed == 'true' ||
+        needs.detect.outputs.runner-changed == 'true'
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.runner-host-groups.outputs.matrix || '[]') }}
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    env:
+      TARGET_TRIPLE: ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates -> target
+          shared-key: ${{ matrix.cacheSuffix }}-rootfs-process
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Cross-compile rootfs process tests for ${{ matrix.label }}
+        working-directory: crates
+        run: |
+          TEST_BIN=$(cargo test --no-run --profile ci --target "$TARGET_TRIPLE" \
+            -p runner --bin runner --message-format=json | \
+            jq -r 'select(.reason == "compiler-artifact" and .target.name == "runner" and .profile.test) | .executable // empty')
+          test -n "$TEST_BIN"
+          cp "$TEST_BIN" target/runner-rootfs-process-test
+          echo "TEST_BIN=crates/target/runner-rootfs-process-test" >> "$GITHUB_ENV"
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-user: ${{ vars.AWS_METAL_RUNNER_USER }}
+          ssh-hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Run rootfs process ownership tests on metal
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
+          JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
+        run: |
+          HOSTS=$(.github/scripts/runner-host-architecture-groups.sh hosts "$RUNNER_HOST_GROUP_ID")
+          HOST=$(.github/scripts/runner-host-architecture-groups.sh select-host "$RUNNER_HOST_GROUP_ID" "$JOB_REF" "$HOSTS")
+          REMOTE="${METAL_USER}@${HOST}"
+          REMOTE_BIN="/tmp/runner-rootfs-process-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RUNNER_HOST_GROUP_ID}"
+          scp "$TEST_BIN" "${REMOTE}:${REMOTE_BIN}"
+          ssh "$REMOTE" sh -s -- "$REMOTE_BIN" <<'REMOTE_TEST'
+          set -eu
+          trap 'rm -f -- "$1"' EXIT
+          sudo "$1" --ignored --exact \
+            cmd::build::scripts::process_tests::rootfs_process_ownership --nocapture
+          REMOTE_TEST
+
+      - name: Report peak memory
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/report-memory-peak
+
   runner-build:
     runs-on: ubuntu-latest
     permissions:
@@ -992,6 +1064,7 @@ jobs:
       - runner-behavior-lane-d
       - host-cpu-fairness-test
       - nbd-cow-test
+      - runner-rootfs-process-test
     # Always run so the gate reports an explicit result (not "skipped").
     if: always()
     steps:
@@ -1043,6 +1116,7 @@ jobs:
           check_result "runner-behavior-lane-d" "${{ needs.runner-behavior-lane-d.result }}" "true"
           check_result "host-cpu-fairness-test" "${{ needs.host-cpu-fairness-test.result }}" "true"
           check_result "nbd-cow-test" "${{ needs.nbd-cow-test.result }}" "true"
+          check_result "runner-rootfs-process-test" "${{ needs.runner-rootfs-process-test.result }}" "true"
 
           echo "::endgroup::"
           exit $FAILED

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -703,7 +703,10 @@ jobs:
           ssh "$REMOTE" sh -s -- "$REMOTE_BIN" <<'REMOTE_TEST'
           set -eu
           trap 'rm -f -- "$1"' EXIT
-          sudo "$1" --ignored --exact \
+          # An outer PID namespace also contains the test's deliberately stopped
+          # workers if its controller is killed before the RAII guard can resume them.
+          sudo unshare --mount --pid --fork --kill-child --mount-proc \
+            --propagation private -- "$1" --ignored --exact \
             cmd::build::scripts::process_tests::rootfs_process_ownership --nocapture
           REMOTE_TEST
 

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -257,8 +257,8 @@ debootstrap_cache_locked() {
     # partial tarball under the stable cache name that another runner may reuse.
     # debootstrap validates the tarball suffix when unpacking, so keep the
     # process-scoped temp file ending in .tar instead of appending after it.
-    CACHE_TMP_TAR="${cache_tar%.tar}.tmp.$$.tar"
-    rm -f "$CACHE_TMP_TAR"
+    # PIDs can repeat across concurrent build namespaces; the cache is shared.
+    CACHE_TMP_TAR=$(mktemp "${cache_tar%.tar}.tmp.mktemp.XXXXXX.tar")
     sudo debootstrap --make-tarball="$CACHE_TMP_TAR" noble "$ROOTFS_DIR" "$MIRROR" || true
     if [[ ! -s "$CACHE_TMP_TAR" ]]; then
       echo "error: debootstrap --make-tarball failed to create $CACHE_TMP_TAR" >&2

--- a/crates/runner/src/cmd/build/mod.rs
+++ b/crates/runner/src/cmd/build/mod.rs
@@ -27,7 +27,7 @@ use hashes::{
     compute_template_hash,
 };
 use local_publish::LocalFilePublish;
-use scripts::{RootfsScripts, rootfs_script_command, run_rootfs_script};
+use scripts::{RootfsScriptDir, RootfsScripts, rootfs_script_command, run_rootfs_script};
 use sizes::file_sizes;
 
 const TEMPLATE_FILE: &str = "template.ext4";
@@ -270,10 +270,11 @@ struct RootfsBuildInput<'a> {
 
 enum RootfsImageLock {
     Shared { _guard: Flock<File> },
-    Exclusive { _guard: Flock<File> },
+    Exclusive { guard: std::sync::Arc<Flock<File>> },
 }
 
 impl RootfsImageLock {
+    #[cfg(test)]
     fn is_exclusive(&self) -> bool {
         matches!(self, Self::Exclusive { .. })
     }
@@ -331,7 +332,9 @@ async fn acquire_rootfs_lock_for_image_build_inner(
             continue;
         }
 
-        return Ok(RootfsImageLock::Exclusive { _guard: guard });
+        return Ok(RootfsImageLock::Exclusive {
+            guard: std::sync::Arc::new(guard),
+        });
     }
 }
 
@@ -341,20 +344,41 @@ struct BuildHashes {
     snapshot_hash: Option<String>,
 }
 
-struct TemplateLockRelease(Option<Box<dyn FnOnce() + Send>>);
+struct TemplateLockRelease {
+    guard: Option<std::sync::Arc<Flock<File>>>,
+    #[cfg(test)]
+    callback: Option<Box<dyn FnOnce() + Send>>,
+}
 
 impl TemplateLockRelease {
     #[cfg(test)]
     fn none() -> Self {
-        Self(None)
+        Self {
+            guard: None,
+            callback: None,
+        }
     }
 
+    fn from_lock(guard: Flock<File>) -> Self {
+        Self {
+            guard: Some(std::sync::Arc::new(guard)),
+            #[cfg(test)]
+            callback: None,
+        }
+    }
+
+    #[cfg(test)]
     fn from_release(release: impl FnOnce() + Send + 'static) -> Self {
-        Self(Some(Box::new(release)))
+        Self {
+            guard: None,
+            callback: Some(Box::new(release)),
+        }
     }
 
     fn release(&mut self) {
-        if let Some(release) = self.0.take() {
+        self.guard = None;
+        #[cfg(test)]
+        if let Some(release) = self.callback.take() {
             release();
         }
     }
@@ -503,8 +527,8 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
                 "acquiring exclusive template lock for warm build: {}",
                 template_lock_path.display()
             );
-            let _template_lock = lock::acquire(template_lock_path).await?;
-            ensure_template_cached_under_lock(&template_input).await?;
+            let template_lock = std::sync::Arc::new(lock::acquire(template_lock_path).await?);
+            ensure_template_cached_under_lock(&template_input, template_lock).await?;
             tracing::info!(
                 "template cache warm complete: template={}",
                 hashes.template_hash
@@ -539,16 +563,20 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
                 rootfs_paths,
                 guests,
             };
-            if _rootfs_lock.is_exclusive() {
+            if let RootfsImageLock::Exclusive { guard } = &_rootfs_lock {
                 let template_lock_path = paths.template_lock(&hashes.template_hash);
                 tracing::info!(
                     "acquiring exclusive template lock for image build: {}",
                     template_lock_path.display()
                 );
                 let template_lock = lock::acquire(template_lock_path).await?;
-                let release_template_lock =
-                    TemplateLockRelease::from_release(move || drop(template_lock));
-                ensure_rootfs_under_lock(input, release_template_lock).await?;
+                let release_template_lock = TemplateLockRelease::from_lock(template_lock);
+                ensure_rootfs_under_lock(
+                    input,
+                    release_template_lock,
+                    std::sync::Arc::clone(guard),
+                )
+                .await?;
             } else {
                 tracing::info!(
                     "[OK] rootfs already present: {}",
@@ -588,23 +616,25 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
 async fn ensure_rootfs_under_lock(
     input: RootfsBuildInput<'_>,
     mut release_template_lock: TemplateLockRelease,
+    rootfs_lock: std::sync::Arc<Flock<File>>,
 ) -> RunnerResult<()> {
     let publish = LocalFilePublish::for_rootfs(input.rootfs_paths);
 
     // Clear any `rootfs.ext4.staging` residue from a previous crashed or
     // failed build. Holding the rootfs flock means the previous writer has
-    // already exited (kernel releases flocks on process death), so any
+    // already exited (the script waiter retains the lock through teardown), so any
     // staging file on disk is guaranteed to be stale — never a concurrent
     // writer's work-in-progress. This is the recovery arm of the
     // staging-rename contract; see `RootfsPaths::rootfs_staging`.
     publish.cleanup_stale_staging_best_effort().await;
 
     let need_rootfs = !is_rootfs_present(input.rootfs_paths).await?;
-    let mut scripts = RootfsScripts::new();
+    let mut scripts = RootfsScripts::new(rootfs_lock, release_template_lock.guard.clone());
 
     if need_rootfs {
         let result = async {
             obtain_template_to_staging(&input.template, input.rootfs_paths, &mut scripts).await?;
+            scripts.release_template_lock();
             release_template_lock.release();
             let work_dir_path = scripts.path().await?;
             customize_rootfs_staging(&input, &work_dir_path).await?;
@@ -623,14 +653,18 @@ async fn ensure_rootfs_under_lock(
             "[OK] rootfs already present: {}",
             input.rootfs_paths.dir().display()
         );
+        scripts.release_template_lock();
         release_template_lock.release();
     }
 
     Ok(())
 }
 
-async fn ensure_template_cached_under_lock(input: &TemplateInput<'_>) -> RunnerResult<()> {
-    let mut scripts = RootfsScripts::new();
+async fn ensure_template_cached_under_lock(
+    input: &TemplateInput<'_>,
+    template_lock: std::sync::Arc<Flock<File>>,
+) -> RunnerResult<()> {
+    let mut scripts = RootfsScripts::new(template_lock, None);
     ensure_template_cached_under_lock_with_scripts(input, &mut scripts).await
 }
 
@@ -857,7 +891,7 @@ async fn obtain_template_to_staging(
 async fn materialize_template_from_r2_or_build(
     input: &TemplateInput<'_>,
     attempt_dir: &Path,
-    work_dir: &Path,
+    work_dir: &RootfsScriptDir,
     target: TemplateMaterializationTarget<'_>,
 ) -> RunnerResult<()> {
     tokio::fs::create_dir_all(attempt_dir).await.map_err(|e| {
@@ -884,7 +918,7 @@ async fn materialize_template_from_r2_or_build(
 async fn resolve_remote_template(
     input: &TemplateInput<'_>,
     downloaded_template: &Path,
-    work_dir: &Path,
+    work_dir: &RootfsScriptDir,
 ) -> RunnerResult<RemoteTemplateDecision> {
     let Some(cache) = input.cache.as_cache() else {
         return Ok(RemoteTemplateDecision::BuildAndUpload(
@@ -974,7 +1008,7 @@ fn move_file_sync(source: &Path, destination: &Path, label: &str) -> RunnerResul
 async fn build_template_locally(
     input: &TemplateInput<'_>,
     output_dir: &Path,
-    work_dir: &Path,
+    work_dir: &RootfsScriptDir,
 ) -> RunnerResult<()> {
     tokio::fs::create_dir_all(output_dir)
         .await
@@ -989,8 +1023,9 @@ async fn build_template_locally(
     drop(lock::open_lock_file(&debootstrap_lock_path)?);
     let rootfs_disk_mb_str = input.rootfs_disk_mb.to_string();
 
-    let mut cmd = rootfs_script_command(&work_dir.join("build-template.sh"));
-    cmd.arg("--output-dir")
+    let mut cmd = rootfs_script_command(work_dir, "build-template.sh")?;
+    cmd.command
+        .arg("--output-dir")
         .arg(output_dir)
         .arg("--debootstrap-dir")
         .arg(&debootstrap_dir)
@@ -1027,7 +1062,7 @@ async fn build_template_locally(
     Ok(())
 }
 
-async fn verify_rootfs(rootfs_paths: &RootfsPaths, work_dir: &Path) -> RunnerResult<()> {
+async fn verify_rootfs(rootfs_paths: &RootfsPaths, work_dir: &RootfsScriptDir) -> RunnerResult<()> {
     verify_rootfs_file(&rootfs_paths.rootfs_staging(), work_dir, "rootfs").await?;
 
     let rootfs_sz = file_sizes(&rootfs_paths.rootfs_staging()).await;
@@ -1040,7 +1075,7 @@ async fn verify_rootfs(rootfs_paths: &RootfsPaths, work_dir: &Path) -> RunnerRes
     Ok(())
 }
 
-async fn verify_template_file(rootfs: &Path, work_dir: &Path) -> RunnerResult<()> {
+async fn verify_template_file(rootfs: &Path, work_dir: &RootfsScriptDir) -> RunnerResult<()> {
     verify_rootfs_file(rootfs, work_dir, "template").await?;
 
     let rootfs_sz = file_sizes(rootfs).await;
@@ -1053,11 +1088,19 @@ async fn verify_template_file(rootfs: &Path, work_dir: &Path) -> RunnerResult<()
     Ok(())
 }
 
-async fn verify_rootfs_file(rootfs: &Path, work_dir: &Path, mode: &str) -> RunnerResult<()> {
-    let mut cmd = rootfs_script_command(&work_dir.join("verify-rootfs.sh"));
-    cmd.arg("--rootfs").arg(rootfs).arg("--mode").arg(mode);
+async fn verify_rootfs_file(
+    rootfs: &Path,
+    work_dir: &RootfsScriptDir,
+    mode: &str,
+) -> RunnerResult<()> {
+    let mut cmd = rootfs_script_command(work_dir, "verify-rootfs.sh")?;
+    cmd.command
+        .arg("--rootfs")
+        .arg(rootfs)
+        .arg("--mode")
+        .arg(mode);
     for definition in guest_definitions() {
-        cmd.arg("--guest-dest").arg(definition.destination);
+        cmd.command.arg("--guest-dest").arg(definition.destination);
     }
     let status = run_rootfs_script(cmd, "verify-rootfs.sh").await?;
 
@@ -1101,19 +1144,21 @@ async fn upload_template_to_r2(
 
 async fn customize_rootfs_staging(
     input: &RootfsBuildInput<'_>,
-    work_dir: &Path,
+    work_dir: &RootfsScriptDir,
 ) -> RunnerResult<()> {
     let staging = input.rootfs_paths.rootfs_staging();
     let ca_dir = input.template.paths.ca_dir();
-    let mut cmd = rootfs_script_command(&work_dir.join("customize-rootfs.sh"));
-    cmd.arg("--rootfs")
+    let mut cmd = rootfs_script_command(work_dir, "customize-rootfs.sh")?;
+    cmd.command
+        .arg("--rootfs")
         .arg(&staging)
         .arg("--ca-dir")
         .arg(&ca_dir)
         .arg("--dns-nameserver")
         .arg(DNS_PROBE_RESOLVER_IPV4.to_string());
     for guest in input.guests.iter() {
-        cmd.arg("--guest")
+        cmd.command
+            .arg("--guest")
             .arg(&guest.path)
             .arg(guest.definition.destination);
     }

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -1,33 +1,96 @@
+use std::fs::File;
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use nix::fcntl::Flock;
 
 use crate::error::{RunnerError, RunnerResult};
+
+#[cfg(test)]
+mod process_tests;
 
 pub(super) const TEMPLATE_BUILD_SCRIPT: &str = include_str!("../../../scripts/build-template.sh");
 const VERIFY_SCRIPT: &str = include_str!("../../../scripts/verify-rootfs.sh");
 pub(super) const CUSTOMIZE_SCRIPT: &str = include_str!("../../../scripts/customize-rootfs.sh");
 
 pub(super) struct RootfsScripts {
-    temp_dir: Option<tempfile::TempDir>,
+    temp_dir: Option<Arc<tempfile::TempDir>>,
+    primary_lock: Arc<Flock<File>>,
+    template_lock: Option<Arc<Flock<File>>>,
+    launcher: PathBuf,
+}
+
+/// The extracted scripts and locks must outlive an in-flight process, including cancellation.
+#[derive(Clone)]
+pub(super) struct RootfsScriptDir {
+    directory: Arc<tempfile::TempDir>,
+    locks: Vec<Arc<Flock<File>>>,
+    launcher: PathBuf,
+}
+
+impl std::ops::Deref for RootfsScriptDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        self.directory.path()
+    }
+}
+
+pub(super) struct RootfsScriptCommand {
+    pub(super) command: std::process::Command,
+    directory: RootfsScriptDir,
+    inherited_locks: Vec<OwnedFd>,
 }
 
 impl RootfsScripts {
-    pub(super) fn new() -> Self {
-        Self { temp_dir: None }
+    pub(super) fn new(
+        primary_lock: Arc<Flock<File>>,
+        template_lock: Option<Arc<Flock<File>>>,
+    ) -> Self {
+        Self {
+            temp_dir: None,
+            primary_lock,
+            template_lock,
+            launcher: PathBuf::from("unshare"),
+        }
     }
 
     #[cfg(test)]
     pub(super) fn from_temp_dir(temp_dir: tempfile::TempDir) -> Self {
+        let primary_lock = Arc::new(
+            Flock::lock(
+                tempfile::tempfile().unwrap(),
+                nix::fcntl::FlockArg::LockExclusive,
+            )
+            .unwrap(),
+        );
         Self {
-            temp_dir: Some(temp_dir),
+            launcher: temp_dir.path().join("unshare-fixture.sh"),
+            temp_dir: Some(Arc::new(temp_dir)),
+            primary_lock,
+            template_lock: None,
         }
     }
 
-    pub(super) async fn path(&mut self) -> RunnerResult<PathBuf> {
+    pub(super) fn release_template_lock(&mut self) {
+        self.template_lock = None;
+    }
+
+    pub(super) async fn path(&mut self) -> RunnerResult<RootfsScriptDir> {
         if self.temp_dir.is_none() {
-            self.temp_dir = Some(create_rootfs_scripts_dir().await?);
+            self.temp_dir = Some(Arc::new(create_rootfs_scripts_dir().await?));
         }
         match self.temp_dir.as_ref() {
-            Some(dir) => Ok(dir.path().to_path_buf()),
+            Some(directory) => Ok(RootfsScriptDir {
+                directory: Arc::clone(directory),
+                locks: std::iter::once(Arc::clone(&self.primary_lock))
+                    .chain(self.template_lock.iter().cloned())
+                    .collect(),
+                launcher: self.launcher.clone(),
+            }),
             None => Err(RunnerError::Internal(
                 "rootfs scripts dir was not initialized".into(),
             )),
@@ -50,54 +113,121 @@ async fn create_rootfs_scripts_dir() -> RunnerResult<tempfile::TempDir> {
     Ok(dir)
 }
 
-pub(super) fn rootfs_script_command(script: &Path) -> tokio::process::Command {
-    let mut cmd = tokio::process::Command::new("bash");
-    cmd.arg(script).stdin(std::process::Stdio::null());
-    cmd.process_group(0);
-    cmd.kill_on_drop(true);
+// Only the external unshare waiter retains the inherited flock descriptors.
+// Namespace-init exit kills all descendants, even across sudo/process groups;
+// unshare waits for that teardown before exiting and closing the locks.
+const ROOTFS_SUPERVISOR: &str = r#"
+set -euo pipefail
+[[ "$$" -eq 1 ]]
+while [[ "$1" != -- ]]; do
+  lock_fd="$1"
+  exec {lock_fd}>&-
+  shift
+done
+shift
+trap 'exit 125' TERM
+(
+  IFS= read -r message || kill -TERM "$$"
+) <&0 &
+bash "$@" </dev/null &
+wait "$!"
+"#;
 
-    // Prevent scripts from continuing to mutate staging files after a runner
-    // crash releases the associated locks.
-    crate::parent_death::configure_parent_death_signal(&mut cmd);
-
-    cmd
-}
-
-struct RootfsScriptProcess {
-    child: Option<tokio::process::Child>,
-}
-
-impl Drop for RootfsScriptProcess {
-    fn drop(&mut self) {
-        // Rootfs scripts are synchronous and must finish descendant work before
-        // returning. Process-group cleanup is only an abnormal-drop fallback
-        // while the owned child still pins the process-group identity.
-        if let Some(child) = self.child.as_ref()
-            && let Some(pid) = child.id()
-            && let Ok(pid) = i32::try_from(pid)
-        {
-            let pgid = nix::unistd::Pid::from_raw(pid);
-            let _ = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGKILL);
-        }
-        crate::child_cleanup::kill_and_reap_child_on_drop("rootfs script", &mut self.child);
+pub(super) fn rootfs_script_command(
+    directory: &RootfsScriptDir,
+    script: &str,
+) -> RunnerResult<RootfsScriptCommand> {
+    // Reserve descriptors above stdio: replacing stdin must not overwrite a
+    // lock originally opened as fd 0 by a runner launched with closed stdin.
+    let inherited_locks = directory
+        .locks
+        .iter()
+        .map(|lock| rustix::io::fcntl_dupfd_cloexec(&***lock, 3))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| RunnerError::Internal(format!("duplicate {script} build locks: {e}")))?;
+    let mut command = std::process::Command::new(&directory.launcher);
+    command.args([
+        "--mount",
+        "--pid",
+        "--fork",
+        "--kill-child",
+        "--mount-proc",
+        "--propagation",
+        "private",
+        "--",
+        "bash",
+        "-c",
+        ROOTFS_SUPERVISOR,
+        "rootfs-supervisor",
+    ]);
+    for lock in &inherited_locks {
+        command.arg(lock.as_raw_fd().to_string());
     }
+    command.arg("--").arg(directory.join(script));
+    Ok(RootfsScriptCommand {
+        command,
+        directory: directory.clone(),
+        inherited_locks,
+    })
 }
 
 pub(super) async fn run_rootfs_script(
-    mut cmd: tokio::process::Command,
+    command: RootfsScriptCommand,
     label: &str,
 ) -> RunnerResult<std::process::ExitStatus> {
-    let child = cmd
-        .spawn()
-        .map_err(|e| RunnerError::Internal(format!("spawn {label}: {e}")))?;
-    let mut process = RootfsScriptProcess { child: None };
-    let child = process.child.insert(child);
-    let status = child
-        .wait()
+    let (owner, child_control) = UnixStream::pair()
+        .map_err(|e| RunnerError::Internal(format!("create {label} ownership channel: {e}")))?;
+    let label = label.to_owned();
+    // Spawn and wait belong to the same non-cancellable task. Its Arc guards
+    // prevent Flock::drop from explicitly unlocking during async cancellation.
+    // If the runner dies instead, the external unshare waiter still owns the
+    // same open file descriptions. Never kill that waiter on future drop.
+    let task = tokio::task::spawn_blocking(move || {
+        let RootfsScriptCommand {
+            mut command,
+            directory,
+            inherited_locks,
+        } = command;
+        let descriptors: Vec<_> = inherited_locks
+            .iter()
+            .map(|lock| lock.as_raw_fd())
+            .collect();
+        command.stdin(std::process::Stdio::from(OwnedFd::from(child_control)));
+        // SAFETY: setsid and fcntl are async-signal-safe. inherited_locks owns
+        // these descriptors through spawn; only the forked child is changed.
+        unsafe {
+            command.pre_exec(move || {
+                // An orphaned process group containing a stopped worker gets
+                // SIGHUP/SIGCONT when its owner dies. A separate session keeps
+                // that job-control signal from killing the lock-holding waiter.
+                if nix::libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                for descriptor in &descriptors {
+                    if nix::libc::fcntl(*descriptor, nix::libc::F_SETFD, 0) < 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                }
+                Ok(())
+            });
+        }
+        let mut child = command
+            .spawn()
+            .map_err(|e| RunnerError::Internal(format!("spawn {label}: {e}")))?;
+        drop(inherited_locks);
+        let status = child
+            .wait()
+            .map_err(|e| RunnerError::Internal(format!("wait for {label}: {e}")));
+        drop(directory);
+        status
+    });
+    // Abort prevents a queued blocking task from starting after cancellation;
+    // it cannot interrupt a running blocking task's owned-child wait.
+    let result = tokio_util::task::AbortOnDropHandle::new(task)
         .await
-        .map_err(|e| RunnerError::Internal(format!("wait for {label}: {e}")))?;
-    process.child = None;
-    Ok(status)
+        .map_err(|e| RunnerError::Internal(format!("rootfs script task: {e}")))?;
+    drop(owner);
+    result
 }
 
 #[cfg(test)]
@@ -164,47 +294,9 @@ mod tests {
         false
     }
 
-    async fn write_process_group_test_script(dir: &Path) -> PathBuf {
-        let script = dir.join("process-group-test.sh");
-        tokio::fs::write(
-            &script,
-            r#"#!/usr/bin/env bash
-set -euo pipefail
-
-pgid_file="$1"
-started_file="$2"
-survived_file="$3"
-release_file="$4"
-mode="${5:-fail}"
-
-printf '%s' "$$" > "$pgid_file"
-if [[ "$mode" == "fail" ]]; then
-  exit 17
-fi
-
-(
-  trap '' HUP TERM INT
-  printf started > "$started_file"
-  while [[ ! -f "$release_file" ]]; do
-    sleep 0.01
-  done
-  printf survived > "$survived_file"
-) &
-
-wait
-"#,
-        )
-        .await
-        .unwrap();
-        script
-    }
-
     async fn wait_for_file(path: &Path) {
-        tokio::time::timeout(std::time::Duration::from_secs(2), async {
-            loop {
-                if tokio::fs::try_exists(path).await.unwrap_or(false) {
-                    break;
-                }
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !path.exists() {
                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             }
         })
@@ -212,123 +304,168 @@ wait
         .unwrap_or_else(|_| panic!("timed out waiting for {}", path.display()));
     }
 
-    #[cfg(target_os = "linux")]
-    fn process_group_has_live_members(pgid_file: &Path) -> bool {
-        let raw_pgid = std::fs::read_to_string(pgid_file).expect("read test pgid");
-        let pgid: i32 = raw_pgid.parse().expect("parse test pgid");
-        let entries = std::fs::read_dir("/proc").expect("read /proc");
-        for entry in entries.flatten() {
-            let Ok(pid) = entry.file_name().to_string_lossy().parse::<i32>() else {
-                continue;
-            };
-            let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
-                continue;
-            };
-            let Some((_, fields)) = stat.rsplit_once(") ") else {
-                continue;
-            };
-            let mut fields = fields.split_whitespace();
-            let state = fields.next().and_then(|value| value.chars().next());
-            let _ppid = fields.next();
-            let pgrp = fields.next().and_then(|value| value.parse::<i32>().ok());
-            if pgrp == Some(pgid) && state != Some('Z') {
-                return true;
-            }
+    fn test_directory(primary_lock: Arc<Flock<File>>) -> RootfsScriptDir {
+        RootfsScriptDir {
+            directory: Arc::new(tempfile::tempdir().unwrap()),
+            locks: vec![primary_lock],
+            launcher: PathBuf::from("unshare"),
         }
-        false
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    fn process_group_has_live_members(pgid_file: &Path) -> bool {
-        let raw_pgid = std::fs::read_to_string(pgid_file).expect("read test pgid");
-        let pgid = nix::unistd::Pid::from_raw(raw_pgid.parse().expect("parse test pgid"));
-        match nix::sys::signal::killpg(pgid, None) {
-            Ok(()) => true,
-            Err(nix::errno::Errno::ESRCH) => false,
-            Err(_) => true,
-        }
-    }
-
-    async fn assert_process_group_stopped_without_survival_marker(
-        pgid_file: &Path,
-        survived_file: &Path,
-    ) {
-        wait_for_file(pgid_file).await;
-        tokio::time::timeout(std::time::Duration::from_secs(2), async {
-            loop {
-                if !process_group_has_live_members(pgid_file) {
-                    break;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .unwrap_or_else(|_| panic!("timed out waiting for process group in {pgid_file:?} to exit"));
-        assert!(
-            !tokio::fs::try_exists(survived_file).await.unwrap_or(false),
-            "rootfs script process group was not killed; child wrote {}",
-            survived_file.display()
-        );
     }
 
     #[tokio::test]
     async fn run_rootfs_script_returns_nonzero_status() {
-        let dir = tempfile::tempdir().unwrap();
-        let pgid = dir.path().join("pgid");
-        let started = dir.path().join("started");
-        let survived = dir.path().join("survived");
-        let release = dir.path().join("release");
-        let script = write_process_group_test_script(dir.path()).await;
+        let guard = Arc::new(
+            Flock::lock(
+                tempfile::tempfile().unwrap(),
+                nix::fcntl::FlockArg::LockExclusive,
+            )
+            .unwrap(),
+        );
+        let mut command = std::process::Command::new("bash");
+        command.args(["-c", "exit 17"]);
+        let command = RootfsScriptCommand {
+            command,
+            directory: test_directory(guard),
+            inherited_locks: Vec::new(),
+        };
 
-        let mut cmd = rootfs_script_command(&script);
-        cmd.arg(&pgid)
-            .arg(&started)
-            .arg(&survived)
-            .arg(&release)
-            .arg("fail");
-
-        let status = run_rootfs_script(cmd, "process-group-test.sh")
+        let status = run_rootfs_script(command, "nonzero-status-fixture")
             .await
             .unwrap();
 
         assert_eq!(status.code(), Some(17));
-        assert!(!started.exists(), "failed script must not background work");
+    }
+
+    #[test]
+    fn cancellation_does_not_start_a_queued_script() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let lock_path = home.path().join("rootfs.lock");
+        let guard = runtime
+            .block_on(crate::lock::acquire(lock_path.clone()))
+            .unwrap();
+        let directory = test_directory(Arc::new(guard));
+        let mut command = std::process::Command::new("bash");
+        command.args(["-c", "touch \"$1/started\"", "queued-script"]);
+        command.arg(home.path());
+        let command = RootfsScriptCommand {
+            command,
+            directory,
+            inherited_locks: Vec::new(),
+        };
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let blocker = runtime.spawn_blocking(move || {
+            started_tx.send(()).unwrap();
+            release_rx
+                .recv_timeout(std::time::Duration::from_secs(10))
+                .unwrap();
+        });
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .unwrap();
+        runtime.block_on(async {
+            let task = tokio::spawn(run_rootfs_script(command, "queued-script"));
+            tokio::task::yield_now().await;
+            task.abort();
+            assert!(task.await.unwrap_err().is_cancelled());
+        });
+        release_tx.send(()).unwrap();
+        runtime.block_on(blocker).unwrap();
+        // Drain the blocking queue before checking that no child was started.
+        runtime.block_on(runtime.spawn_blocking(|| {})).unwrap();
+        assert!(!home.path().join("started").exists());
+        assert!(
+            runtime
+                .block_on(crate::lock::try_acquire(lock_path))
+                .is_ok()
+        );
     }
 
     #[tokio::test]
-    async fn run_rootfs_script_kills_process_group_when_future_is_cancelled() {
-        let dir = tempfile::tempdir().unwrap();
-        let pgid = dir.path().join("pgid");
-        let started = dir.path().join("started");
-        let survived = dir.path().join("survived");
-        let release = dir.path().join("release");
-        let script = write_process_group_test_script(dir.path()).await;
+    async fn cancellation_retains_lock_and_scripts_until_process_cleanup_finishes() {
+        let home = tempfile::tempdir().unwrap();
+        let lock_path = home.path().join("rootfs.lock");
+        let guard = Arc::new(crate::lock::acquire(lock_path.clone()).await.unwrap());
+        let directory = test_directory(guard);
+        let scripts_path = directory.directory.path().to_path_buf();
+        let mut command = std::process::Command::new("bash");
+        command
+            .arg("-c")
+            .arg(
+                r#"
+set -euo pipefail
+printf ready > "$1/ready"
+IFS= read -r message || true
+printf cleanup > "$1/cleanup"
+for ((attempt = 0; attempt < 500; attempt++)); do
+  if [[ -f "$1/release" ]]; then
+    exit 0
+  fi
+  sleep 0.01
+done
+exit 18
+"#,
+            )
+            .arg("cleanup-fixture")
+            .arg(home.path());
+        let command = RootfsScriptCommand {
+            command,
+            directory,
+            inherited_locks: Vec::new(),
+        };
+        let task =
+            tokio::spawn(async move { run_rootfs_script(command, "ownership-fixture").await });
+        wait_for_file(&home.path().join("ready")).await;
 
-        let mut cmd = rootfs_script_command(&script);
-        cmd.arg(&pgid)
-            .arg(&started)
-            .arg(&survived)
-            .arg(&release)
-            .arg("wait");
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        wait_for_file(&home.path().join("cleanup")).await;
+        assert!(
+            scripts_path.exists(),
+            "script directory must survive cancellation"
+        );
+        assert!(matches!(
+            crate::lock::try_acquire_or_busy(lock_path.clone())
+                .await
+                .unwrap(),
+            crate::lock::TryLock::Busy
+        ));
 
-        let handle =
-            tokio::spawn(async move { run_rootfs_script(cmd, "process-group-test.sh").await });
-        wait_for_file(&started).await;
-        handle.abort();
-        let _ = handle.await;
-        tokio::fs::write(&release, b"release").await.unwrap();
-
-        assert_process_group_stopped_without_survival_marker(&pgid, &survived).await;
+        std::fs::write(home.path().join("release"), b"release").unwrap();
+        let new_guard = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            crate::lock::acquire(lock_path),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(
+            !scripts_path.exists(),
+            "script directory must be removed after cleanup"
+        );
+        drop(new_guard);
     }
 
     #[tokio::test]
     async fn rootfs_scripts_writes_embedded_scripts_once() {
-        let mut scripts = RootfsScripts::new();
+        let guard = Arc::new(
+            Flock::lock(
+                tempfile::tempfile().unwrap(),
+                nix::fcntl::FlockArg::LockExclusive,
+            )
+            .unwrap(),
+        );
+        let mut scripts = RootfsScripts::new(guard, None);
 
         let first = scripts.path().await.unwrap();
         let second = scripts.path().await.unwrap();
 
-        assert_eq!(first, second);
+        assert_eq!(&*first, &*second);
         assert!(first.join("build-template.sh").exists());
         assert!(first.join("verify-rootfs.sh").exists());
         assert!(first.join("customize-rootfs.sh").exists());
@@ -955,8 +1092,9 @@ assert_check_error \
     #[test]
     fn build_script_publishes_debootstrap_cache_atomically() {
         assert!(
-            TEMPLATE_BUILD_SCRIPT.contains(r#"CACHE_TMP_TAR="${cache_tar%.tar}.tmp.$$.tar""#),
-            "build-template.sh should stage debootstrap cache writes in a process-scoped temp file"
+            TEMPLATE_BUILD_SCRIPT
+                .contains(r#"CACHE_TMP_TAR=$(mktemp "${cache_tar%.tar}.tmp.mktemp.XXXXXX.tar")"#),
+            "build-template.sh should stage shared-cache writes with namespace-independent uniqueness"
         );
         assert!(
             TEMPLATE_BUILD_SCRIPT.contains("debootstrap validates the tarball suffix"),

--- a/crates/runner/src/cmd/build/scripts/process_tests.rs
+++ b/crates/runner/src/cmd/build/scripts/process_tests.rs
@@ -1,0 +1,311 @@
+//! Privileged process regressions, executed explicitly by the metal CI job.
+
+use super::*;
+use std::process::{Child, Stdio};
+use std::time::{Duration, Instant};
+
+const OWNER_TEST: &str = "cmd::build::scripts::process_tests::owner_child";
+const FIXTURE_ENV: &str = "RUNNER_ROOTFS_PROCESS_FIXTURE";
+const MODE_ENV: &str = "RUNNER_ROOTFS_PROCESS_MODE";
+
+struct Owner(Child);
+
+impl Drop for Owner {
+    fn drop(&mut self) {
+        if self.0.try_wait().unwrap().is_none() {
+            self.0.kill().unwrap();
+            self.0.wait().unwrap();
+        }
+    }
+}
+
+struct StoppedInit(OwnedFd);
+
+impl Drop for StoppedInit {
+    fn drop(&mut self) {
+        let _ = rustix::process::pidfd_send_signal(&self.0, rustix::process::Signal::CONT);
+    }
+}
+
+fn wait_until(label: &str, mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !condition() {
+        assert!(Instant::now() < deadline, "timed out: {label}");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_file(path: &Path) {
+    wait_until(&format!("file {}", path.display()), || path.exists());
+}
+
+fn namespace_members(namespace: &str) -> Vec<(i32, char)> {
+    let mut members = Vec::new();
+    for entry in std::fs::read_dir("/proc").unwrap() {
+        let entry = entry.unwrap();
+        let Ok(pid) = entry.file_name().to_string_lossy().parse::<i32>() else {
+            continue;
+        };
+        let Ok(observed) = std::fs::read_link(entry.path().join("ns/pid")) else {
+            continue;
+        };
+        if observed != Path::new(namespace) {
+            continue;
+        }
+        let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
+            continue;
+        };
+        let state = stat.rsplit_once(") ").unwrap().1.chars().next().unwrap();
+        if state != 'Z' {
+            members.push((pid, state));
+        }
+    }
+    members
+}
+
+fn stop_namespace_init(namespace: &str) -> (StoppedInit, File) {
+    let (pid, _) = namespace_members(namespace)
+        .into_iter()
+        .find(|(pid, _)| {
+            std::fs::read_to_string(format!("/proc/{pid}/status"))
+                .unwrap()
+                .lines()
+                .any(|line| {
+                    line.starts_with("NSpid:") && line.split_whitespace().last() == Some("1")
+                })
+        })
+        .expect("owned namespace must have an init process");
+    let namespace_handle = File::open(format!("/proc/{pid}/ns/pid")).unwrap();
+    let pidfd = rustix::process::pidfd_open(
+        rustix::process::Pid::from_raw(pid).unwrap(),
+        rustix::process::PidfdFlags::empty(),
+    )
+    .unwrap();
+    assert_eq!(
+        std::fs::read_link(format!("/proc/{pid}/ns/pid")).unwrap(),
+        Path::new(namespace)
+    );
+    rustix::process::pidfd_send_signal(&pidfd, rustix::process::Signal::STOP).unwrap();
+    let stopped = StoppedInit(pidfd);
+    wait_until("namespace init stopped", || {
+        namespace_members(namespace).contains(&(pid, 'T'))
+    });
+    (stopped, namespace_handle)
+}
+
+fn try_lock(path: &Path) -> Option<Flock<File>> {
+    let file = File::options().read(true).write(true).open(path).unwrap();
+    match Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
+        Ok(lock) => Some(lock),
+        Err((_, error)) => {
+            assert_eq!(error, nix::errno::Errno::EWOULDBLOCK);
+            None
+        }
+    }
+}
+
+fn acquire_after_cleanup(path: &Path) -> Flock<File> {
+    let mut acquired = None;
+    wait_until("build lock available after cleanup", || {
+        acquired = try_lock(path);
+        acquired.is_some()
+    });
+    acquired.unwrap()
+}
+
+#[test]
+#[ignore = "requires root and mount/PID namespaces; run explicitly on metal"]
+fn rootfs_process_ownership() {
+    assert!(nix::unistd::geteuid().is_root());
+    for mode in [
+        "death",
+        "cancel",
+        "success",
+        "failure",
+        "cancel-before-start",
+    ] {
+        let home = tempfile::tempdir().unwrap();
+        let mut owner = Owner(
+            std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--ignored", "--exact", OWNER_TEST, "--nocapture"])
+                .env(FIXTURE_ENV, home.path())
+                .env("TMPDIR", home.path())
+                .env(MODE_ENV, mode)
+                .stdin(Stdio::null())
+                .spawn()
+                .unwrap(),
+        );
+
+        if mode == "cancel-before-start" {
+            wait_file(&home.path().join("cancelled"));
+            wait_until("owner exits", || owner.0.try_wait().unwrap().is_some());
+            assert!(owner.0.wait().unwrap().success());
+            assert!(!home.path().join("ready").exists());
+            assert!(try_lock(&home.path().join("rootfs.lock")).is_some());
+            assert!(try_lock(&home.path().join("template.lock")).is_some());
+            continue;
+        }
+
+        wait_file(&home.path().join("ready"));
+        let namespace = std::fs::read_to_string(home.path().join("namespace")).unwrap();
+        let namespace = namespace.trim();
+        assert!(!namespace_members(namespace).is_empty());
+        assert!(try_lock(&home.path().join("rootfs.lock")).is_none());
+        assert!(try_lock(&home.path().join("template.lock")).is_none());
+
+        let mut namespace_pin = None;
+        if mode == "death" || mode == "cancel" {
+            // Holding init stopped deterministically separates owner loss from
+            // completed cleanup. The canonical flocks must stay unavailable.
+            let (stopped, pin) = stop_namespace_init(namespace);
+            namespace_pin = Some(pin);
+            if mode == "death" {
+                owner.0.kill().unwrap();
+                assert!(!owner.0.wait().unwrap().success());
+            } else {
+                std::fs::write(home.path().join("cancel"), b"cancel").unwrap();
+                wait_file(&home.path().join("cancelled"));
+            }
+            assert!(try_lock(&home.path().join("rootfs.lock")).is_none());
+            assert!(try_lock(&home.path().join("template.lock")).is_none());
+            drop(stopped);
+        } else {
+            std::fs::write(home.path().join("release"), b"release").unwrap();
+            wait_until("completed owner", || owner.0.try_wait().unwrap().is_some());
+            assert!(owner.0.wait().unwrap().success());
+        }
+
+        let _rootfs = acquire_after_cleanup(&home.path().join("rootfs.lock"));
+        let _template = acquire_after_cleanup(&home.path().join("template.lock"));
+        assert!(
+            namespace_members(namespace).is_empty(),
+            "{mode}: lock released before namespace stopped"
+        );
+        if mode == "death" || mode == "cancel" {
+            std::fs::write(home.path().join("release"), b"release").unwrap();
+            assert!(
+                !home.path().join("survived").exists(),
+                "{mode}: orphaned foreground work wrote"
+            );
+        } else {
+            assert!(home.path().join("survived").exists());
+        }
+        drop(namespace_pin);
+        if mode == "cancel" {
+            std::fs::write(home.path().join("finish"), b"finish").unwrap();
+            wait_until("cancelled owner exits", || {
+                owner.0.try_wait().unwrap().is_some()
+            });
+            assert!(owner.0.wait().unwrap().success());
+        }
+        println!("rootfs ownership mode={mode}: passed");
+    }
+
+    // Killing one owner must not affect an unrelated namespace's work or locks.
+    let first = tempfile::tempdir().unwrap();
+    let second = tempfile::tempdir().unwrap();
+    let launch = |home: &Path| {
+        Owner(
+            std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--ignored", "--exact", OWNER_TEST, "--nocapture"])
+                .env(FIXTURE_ENV, home)
+                .env("TMPDIR", home)
+                .env(MODE_ENV, "success")
+                .stdin(Stdio::null())
+                .spawn()
+                .unwrap(),
+        )
+    };
+    let mut first_owner = launch(first.path());
+    let mut second_owner = launch(second.path());
+    wait_file(&first.path().join("ready"));
+    wait_file(&second.path().join("ready"));
+    let first_namespace = std::fs::read_to_string(first.path().join("namespace")).unwrap();
+    let second_namespace = std::fs::read_to_string(second.path().join("namespace")).unwrap();
+    assert_ne!(first_namespace, second_namespace);
+    first_owner.0.kill().unwrap();
+    first_owner.0.wait().unwrap();
+    let _first_lock = acquire_after_cleanup(&first.path().join("rootfs.lock"));
+    assert!(namespace_members(first_namespace.trim()).is_empty());
+    assert!(!namespace_members(second_namespace.trim()).is_empty());
+    assert!(try_lock(&second.path().join("rootfs.lock")).is_none());
+    assert!(try_lock(&second.path().join("template.lock")).is_none());
+    std::fs::write(second.path().join("release"), b"release").unwrap();
+    wait_until("unrelated owner completes", || {
+        second_owner.0.try_wait().unwrap().is_some()
+    });
+    assert!(second_owner.0.wait().unwrap().success());
+    assert!(second.path().join("survived").exists());
+    assert!(!first.path().join("survived").exists());
+    println!("rootfs ownership concurrent namespace isolation: passed");
+}
+
+#[tokio::test]
+#[ignore = "subprocess fixture, invoked only by rootfs_process_ownership"]
+async fn owner_child() {
+    let home = PathBuf::from(std::env::var_os(FIXTURE_ENV).expect("isolated fixture directory"));
+    let mode = std::env::var(MODE_ENV).unwrap();
+    let primary = Arc::new(
+        crate::lock::acquire(home.join("rootfs.lock"))
+            .await
+            .unwrap(),
+    );
+    let template = Arc::new(
+        crate::lock::acquire(home.join("template.lock"))
+            .await
+            .unwrap(),
+    );
+    let mut scripts = RootfsScripts::new(primary, Some(template));
+    let directory = scripts.path().await.unwrap();
+    let prefix_end = TEMPLATE_BUILD_SCRIPT.find("\nshift\n").unwrap() + "\nshift\n".len();
+    let worker = format!(
+        "{}{}",
+        &TEMPLATE_BUILD_SCRIPT[..prefix_end],
+        r#"
+probe_dir="$1"
+readlink /proc/self/ns/pid > "$probe_dir/namespace"
+printf ready > "$probe_dir/ready"
+for ((attempt = 0; attempt < 1000; attempt++)); do
+  if [[ -f "$probe_dir/release" ]]; then
+    printf survived > "$probe_dir/survived"
+    if [[ "$2" == failure ]]; then exit 17; fi
+    exit 0
+  fi
+  sleep 0.01
+done
+exit 18
+"#
+    );
+    std::fs::write(directory.join("ownership-worker.sh"), worker).unwrap();
+    let mut command = rootfs_script_command(&directory, "ownership-worker.sh").unwrap();
+    command.command.arg(&home).arg(&mode);
+    drop(directory);
+    drop(scripts);
+    let task = tokio::spawn(async move { run_rootfs_script(command, "ownership-worker.sh").await });
+    if mode == "cancel" || mode == "cancel-before-start" {
+        if mode == "cancel" {
+            tokio::time::timeout(Duration::from_secs(10), async {
+                while !home.join("cancel").exists() {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .unwrap();
+        }
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        std::fs::write(home.join("cancelled"), b"cancelled").unwrap();
+        if mode == "cancel" {
+            tokio::time::timeout(Duration::from_secs(10), async {
+                while !home.join("finish").exists() {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .unwrap();
+        }
+    } else {
+        let status = task.await.unwrap().unwrap();
+        assert_eq!(status.code(), Some(if mode == "failure" { 17 } else { 0 }));
+    }
+}

--- a/crates/runner/src/cmd/build/tests/fixtures.rs
+++ b/crates/runner/src/cmd/build/tests/fixtures.rs
@@ -75,7 +75,7 @@ pub(super) fn mock_r2_cache(rules: &[&Rule]) -> R2ImageCache {
     R2ImageCache::with_client(client, "test-bucket".to_string())
 }
 
-pub(super) async fn fake_rootfs_scripts() -> (RootfsScripts, PathBuf) {
+pub(super) async fn fake_rootfs_scripts() -> (RootfsScripts, RootfsScriptDir) {
     let temp_dir = tempfile::tempdir().unwrap();
     let work_dir = temp_dir.path().to_path_buf();
     tokio::fs::write(
@@ -146,7 +146,31 @@ printf called >> "$script_dir/verify-rootfs-called"
     .await
     .unwrap();
 
-    (RootfsScripts::from_temp_dir(temp_dir), work_dir)
+    // Cache tests replace the external namespace/build tools. Privileged process
+    // regressions exercise the actual unshare supervisor on metal.
+    let launcher = work_dir.join("unshare-fixture.sh");
+    tokio::fs::write(
+        &launcher,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+while [[ "$1" != -- ]]; do shift; done
+shift
+# bash -c <namespace init script> <argv0>
+shift 4
+while [[ "$1" != -- ]]; do shift; done
+shift
+exec bash "$@"
+"#,
+    )
+    .await
+    .unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    tokio::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o700))
+        .await
+        .unwrap();
+    let mut scripts = RootfsScripts::from_temp_dir(temp_dir);
+    let work_dir = scripts.path().await.unwrap();
+    (scripts, work_dir)
 }
 
 pub(super) async fn template_archive_bytes(content: &[u8]) -> Vec<u8> {

--- a/crates/runner/src/cmd/build/tests/rootfs_lock.rs
+++ b/crates/runner/src/cmd/build/tests/rootfs_lock.rs
@@ -21,7 +21,12 @@ async fn existing_rootfs_best_effort_allows_missing_r2_cache() {
     let guests = test_guest_binaries();
     let input = rootfs_input(&home, &rootfs, &guests, TemplateCache::Disabled);
 
-    ensure_rootfs_under_lock(input, TemplateLockRelease::none())
+    let guard = std::sync::Arc::new(
+        lock::acquire(home.rootfs_lock("best-effort-local-hash"))
+            .await
+            .unwrap(),
+    );
+    ensure_rootfs_under_lock(input, TemplateLockRelease::none(), guard)
         .await
         .unwrap();
     assert!(
@@ -54,6 +59,11 @@ async fn existing_rootfs_releases_template_lock_callback() {
         TemplateLockRelease::from_release(move || {
             released_for_callback.fetch_add(1, Ordering::SeqCst);
         }),
+        Arc::new(
+            lock::acquire(home.rootfs_lock("release-local-hash"))
+                .await
+                .unwrap(),
+        ),
     )
     .await
     .unwrap();

--- a/crates/runner/src/cmd/build/tests/warm_cache.rs
+++ b/crates/runner/src/cmd/build/tests/warm_cache.rs
@@ -57,7 +57,14 @@ async fn warm_cache_existing_remote_uses_head_without_download_or_build() {
     let cache = mock_r2_cache(&[&head]);
     let input = template_input(&home, TemplateCache::Required(&cache));
 
-    ensure_template_cached_under_lock(&input).await.unwrap();
+    let guard = std::sync::Arc::new(
+        lock::acquire(home.template_lock(input.template_hash))
+            .await
+            .unwrap(),
+    );
+    ensure_template_cached_under_lock(&input, guard)
+        .await
+        .unwrap();
 
     assert_eq!(head.num_calls(), 1);
     assert!(
@@ -88,7 +95,14 @@ async fn warm_cache_head_hit_cleans_stale_local_attempts() {
     let cache = mock_r2_cache(&[&head]);
     let input = template_input(&home, TemplateCache::Required(&cache));
 
-    ensure_template_cached_under_lock(&input).await.unwrap();
+    let guard = std::sync::Arc::new(
+        lock::acquire(home.template_lock(input.template_hash))
+            .await
+            .unwrap(),
+    );
+    ensure_template_cached_under_lock(&input, guard)
+        .await
+        .unwrap();
 
     assert_eq!(head.num_calls(), 1);
     assert!(
@@ -113,7 +127,14 @@ async fn warm_cache_head_request_failure_is_fatal() {
     let cache = mock_r2_cache(&[&head]);
     let input = template_input(&home, TemplateCache::Required(&cache));
 
-    let err = ensure_template_cached_under_lock(&input).await.unwrap_err();
+    let guard = std::sync::Arc::new(
+        lock::acquire(home.template_lock(input.template_hash))
+            .await
+            .unwrap(),
+    );
+    let err = ensure_template_cached_under_lock(&input, guard)
+        .await
+        .unwrap_err();
 
     assert!(
         err.to_string()

--- a/crates/runner/src/cmd/gc/debootstrap.rs
+++ b/crates/runner/src/cmd/gc/debootstrap.rs
@@ -136,14 +136,18 @@ fn debootstrap_cache_file_kind(path: &Path) -> Option<DeBootstrapCacheFileKind> 
 }
 
 fn is_debootstrap_temp_tarball_name(name: &str) -> bool {
-    let Some(pid) = name
+    let Some(identity) = name
         .strip_suffix(".tar")
-        .and_then(|stem| stem.rsplit_once(".tmp.").map(|(_, pid)| pid))
+        .and_then(|stem| stem.rsplit_once(".tmp.").map(|(_, identity)| identity))
     else {
         return false;
     };
 
-    !pid.is_empty() && pid.bytes().all(|byte| byte.is_ascii_digit())
+    // Older builders used host PIDs; PID namespaces require mktemp identities.
+    (!identity.is_empty() && identity.bytes().all(|byte| byte.is_ascii_digit()))
+        || identity.strip_prefix("mktemp.").is_some_and(|random| {
+            random.len() == 6 && random.bytes().all(|byte| byte.is_ascii_alphanumeric())
+        })
 }
 
 #[cfg(test)]
@@ -366,9 +370,12 @@ mod tests {
         std::fs::create_dir_all(&debootstrap_dir).unwrap();
         let stable_tar = debootstrap_dir.join("noble-amd64.tar");
         let newer_tmp = debootstrap_dir.join("noble-amd64.tmp.789.tar");
+        let random_tmp = debootstrap_dir.join("noble-amd64.tmp.mktemp.a9Bc2D.tar");
         std::fs::write(&stable_tar, b"stable").unwrap();
         std::fs::write(&newer_tmp, b"newer partial").unwrap();
-        let temp_size = std::fs::metadata(&newer_tmp).unwrap().len();
+        std::fs::write(&random_tmp, b"namespace partial").unwrap();
+        let temp_size = std::fs::metadata(&newer_tmp).unwrap().len()
+            + std::fs::metadata(&random_tmp).unwrap().len();
         let old_time = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000);
         let newer_time = old_time + Duration::from_secs(60);
         std::fs::File::open(&stable_tar)
@@ -379,11 +386,15 @@ mod tests {
             .unwrap()
             .set_times(FileTimes::new().set_modified(newer_time))
             .unwrap();
+        std::fs::File::open(&random_tmp)
+            .unwrap()
+            .set_times(FileTimes::new().set_modified(newer_time))
+            .unwrap();
 
         let report = gc_debootstrap(&home, Some(1), false).await.unwrap();
 
         assert_eq!(report.freed_bytes, temp_size);
-        assert_eq!(report.activity_count, 1);
+        assert_eq!(report.activity_count, 2);
         assert!(
             stable_tar.exists(),
             "keep_latest should protect the stable debootstrap tarball"
@@ -392,6 +403,7 @@ mod tests {
             !newer_tmp.exists(),
             "stale temp tarballs must not consume keep_latest slots"
         );
+        assert!(!random_tmp.exists());
     }
 
     #[tokio::test]

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -220,6 +220,27 @@ Keep the rollback floor bridge-capable. Delivery parent vm0-ai/vm0#30478 remains
 open until the canonical-only artifact is promoted, bridge processes drain, and
 the final fleet verification completes.
 
+Rootfs build scripts retain those same flock descriptions in an external
+`unshare --fork` waiter until their private PID namespace has terminated. The
+waiter starts in a separate session so owner death cannot orphan a stopped
+process group and send it a job-control `SIGHUP` before cleanup completes. The
+owning runner's death or cancellation closes a process-local control channel;
+namespace init then exits and the kernel terminates its descendants, including
+workers behind `sudo`. The waiter must not be killed as a cancellation shortcut:
+lock availability is the boundary that allows another builder or GC to touch
+staging. In-process shared ownership also keeps the flock and extracted scripts
+alive until the blocking spawn-and-wait task finishes. Existing builders and GC
+need no new lock file or persisted metadata to respect this exclusion.
+
+This containment applies to scripts launched by the new runner, not orphaned
+workers already launched by an older artifact. PID values are namespace-local;
+shared build caches must use independently unique temporary filenames instead
+of treating a script's PID as a host-wide unique attempt identity. Debootstrap
+cache staging uses `.tmp.mktemp.<random>.tar`; new GC recognizes both that format
+and the previous `.tmp.<pid>.tar`. Older GC still respects the shared cache lock,
+but counts leftover new-format staging files toward stable-cache retention until
+it is upgraded (potentially causing a cache miss, not exposing an active build).
+
 Runner and guest binaries are deployed as one runner artifact. Compatibility is
 not required between a runner binary and a guest binary from a different version.
 


### PR DESCRIPTION
## Summary

- Keep canonical rootfs/template flocks owned until actual `sudo`/`unshare` foreground workers have stopped, including runner SIGKILL and async cancellation.
- Run scripts inside a private PID namespace and independent session. An external `unshare --fork` waiter retains inherited lock descriptors; an owner-only socket makes namespace init terminate descendants on owner loss. Session isolation prevents kernel job-control SIGHUP from killing the waiter when the owner dies with stopped descendants. A blocking spawn-and-wait task retains the in-process lock guards and extracted scripts; queued work is cancelled before it starts.
- Use unique shared debootstrap staging names instead of namespace-local PIDs and teach GC to identify the new temporary format without consuming stable-cache retention slots.
- Add deterministic real-process regressions and a required metal CI lane across configured host architectures.

Closes #32289

## Scope and compatibility

- Preserve existing canonical lock paths, inode checks, lock acquisition order, early template release, actual script sudo/mount boundaries, and script exit statuses.
- No API, database, frontend, guest protocol, cgroup/service configuration, or runner deployment changes. Does not retroactively contain processes launched by older artifacts.
- Old GC still honors the shared flocks. Until upgraded, it treats an abandoned new-format debootstrap tarball as a stable retention entry, potentially causing a cache miss. New GC retains the pre-existing numeric-temp recognition and adds the explicitly marked mktemp format.
- The script-content change invalidates the template hash, so the first build of the new template is cold. PID namespaces and fork-mode util-linux `unshare` are required; there is no uncontained fallback.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p runner --all-targets --all-features`
- `cargo doc --profile local -p runner --all-features --no-deps`
- `cargo test --profile local -p runner --quiet -- --test-threads=4`: 3,539 passed, 27 explicitly ignored infrastructure/subprocess fixtures; separate integration test passed.
- `cargo test --profile local --target x86_64-unknown-linux-musl -p runner --bin runner --no-run --quiet`
- Actionlint, Bash syntax, container-shell compatibility, crates-detect/architecture-group/runner-image/memory-report workflow tests, Prettier, and `git diff --check`.
- Isolated privileged regressions on local-11: five consecutive passes, both mutations detected (removed inherited locks; ignored owner EOF), and a clean pass after restoring the normal launch path. The final CI invocation inside an outer PID namespace also passed. Verified binary SHA256: `1d4ac1fa3c2db82de3da9353896b7f52db1a0c7a80a80072d7dc507b0c136763`.

The privileged controller is explicitly invoked by the new metal job; it is not left ignored in CI. Full template provisioning and the remaining CI matrix still need PR CI. No existing services or shared runner image caches were modified during local-11 testing.
