### PR TITLE
refactor(platform): canonicalize image recognition usage naming

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -5473,7 +5473,7 @@
     "displayNames": {
       "avatar": "Avatar",
       "finance": "Finanzen",
-      "imageRecognize": "Bilderkennung",
+      "imageRecognition": "Bilderkennung",
       "maps": "Karten",
       "peopleSearch": "Personensuche",
       "seo": "SEO",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -5465,7 +5465,7 @@
     "displayNames": {
       "avatar": "Avatar",
       "finance": "Finance",
-      "imageRecognize": "Image Recognize",
+      "imageRecognition": "Image Recognition",
       "maps": "Maps",
       "peopleSearch": "People Search",
       "seo": "SEO",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5530,7 +5530,7 @@
     "displayNames": {
       "avatar": "Avatar",
       "finance": "Finanzas",
-      "imageRecognize": "Reconocimiento de imágenes",
+      "imageRecognition": "Reconocimiento de imágenes",
       "maps": "Mapas",
       "peopleSearch": "Búsqueda de personas",
       "seo": "SEO",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5530,7 +5530,7 @@
     "displayNames": {
       "avatar": "Avatar",
       "finance": "Finance",
-      "imageRecognize": "Reconnaissance d'images",
+      "imageRecognition": "Reconnaissance d'images",
       "maps": "Cartes",
       "peopleSearch": "Recherche de personnes",
       "seo": "SEO",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -5473,7 +5473,7 @@
     "displayNames": {
       "avatar": "अवतार",
       "finance": "वित्त",
-      "imageRecognize": "छवि पहचान",
+      "imageRecognition": "छवि पहचान",
       "maps": "एमएपीएस",
       "peopleSearch": "लोग खोजें",
       "seo": "SEO",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -5464,7 +5464,7 @@
     "displayNames": {
       "avatar": "Avatar",
       "finance": "Keuangan",
-      "imageRecognize": "Pengenalan Gambar",
+      "imageRecognition": "Pengenalan Gambar",
       "maps": "Peta",
       "peopleSearch": "Pencarian Orang",
       "seo": "SEO",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5530,7 +5530,7 @@
     "displayNames": {
       "avatar": "Avatar",
       "finance": "Finanza",
-      "imageRecognize": "Riconoscimento immagini",
+      "imageRecognition": "Riconoscimento immagini",
       "maps": "Mappe",
       "peopleSearch": "Ricerca persone",
       "seo": "SEO",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -5464,7 +5464,7 @@
     "displayNames": {
       "avatar": "アバター",
       "finance": "金融",
-      "imageRecognize": "画像認識",
+      "imageRecognition": "画像認識",
       "maps": "地図",
       "peopleSearch": "人物検索",
       "seo": "SEO",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -5464,7 +5464,7 @@
     "displayNames": {
       "avatar": "아바타",
       "finance": "금융",
-      "imageRecognize": "이미지 인식",
+      "imageRecognition": "이미지 인식",
       "maps": "지도",
       "peopleSearch": "사람 검색",
       "seo": "SEO",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5530,7 +5530,7 @@
     "displayNames": {
       "avatar": "Avatar",
       "finance": "Finanças",
-      "imageRecognize": "Reconhecimento de imagem",
+      "imageRecognition": "Reconhecimento de imagem",
       "maps": "Mapas",
       "peopleSearch": "Pesquisa de pessoas",
       "seo": "SEO",

--- a/turbo/apps/platform/src/lib/credit-usage-display.ts
+++ b/turbo/apps/platform/src/lib/credit-usage-display.ts
@@ -12,9 +12,9 @@ const USAGE_DISPLAY_NAMES = {
       return $.usage.displayNames.finance;
     });
   },
-  imageRecognize(): string {
+  imageRecognition(): string {
     return i18n.t(($) => {
-      return $.usage.displayNames.imageRecognize;
+      return $.usage.displayNames.imageRecognition;
     });
   },
   maps(): string {
@@ -63,7 +63,7 @@ const MANAGED_USAGE_KIND_DISPLAY_NAMES: Readonly<Record<string, () => string>> =
     seo: USAGE_DISPLAY_NAMES.seo,
     finance: USAGE_DISPLAY_NAMES.finance,
     weather: USAGE_DISPLAY_NAMES.weather,
-    "image-recognition": USAGE_DISPLAY_NAMES.imageRecognize,
+    "image-recognition": USAGE_DISPLAY_NAMES.imageRecognition,
     translation: USAGE_DISPLAY_NAMES.translation,
   };
 
@@ -72,7 +72,7 @@ const MODEL_DISPLAY_NAMES: Readonly<Record<string, () => string>> = {
   "joggai-talking-avatar": USAGE_DISPLAY_NAMES.avatar,
   // Rows recorded before image tasks moved to task-scoped kinds carry
   // kind "model" with this provider; nothing else runs it as a chat model.
-  "google/gemini-3.5-flash": USAGE_DISPLAY_NAMES.imageRecognize,
+  "google/gemini-3.5-flash": USAGE_DISPLAY_NAMES.imageRecognition,
 };
 
 function titleCaseUsageToken(token: string): string {


### PR DESCRIPTION
## Summary

- Rename the Platform credit-usage display helper and all ten locale keys from `imageRecognize` to `imageRecognition`.
- Correct the English production label to `Image Recognition` while preserving every existing non-English noun translation.
- Keep the persisted `image-recognition` usage kind and historical `google/gemini-3.5-flash` provider value unchanged, pointing both mappings at the renamed helper.

Closes #32410

## Scope

- No API, CLI, route, capability, billing, pricing, settlement, usage-record, model, database, or migration behavior changes.
- Does not restore `/api/recognize`, `okou recognize`, or any compatibility alias.
- Adds no fallback or compatibility behavior and no exact-copy-only UI test.

## Verification

- `pnpm exec prettier --check apps/platform/src/lib/credit-usage-display.ts apps/platform/src/i18n/locales/{de-DE,en-US,es-ES,fr-FR,hi-IN,id-ID,it-IT,ja-JP,ko-KR,pt-BR}/common.json`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/credit-usage-display.test.tsx`
- `VITE_CLERK_PUBLISHABLE_KEY_PREVIEW=pk_test_your_key_here VITE_CLERK_PUBLISHABLE_KEY_PROD=pk_live_your_key_here pnpm -F @okouai/app build`
- Scoped source search confirms `imageRecognize` and `Image Recognize` are absent.
