### PR TITLE
refactor: remove expired deployment compatibility

### DIFF
--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-checkpoint.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-checkpoint.service.ts
@@ -1,38 +1,14 @@
 import { piMemoryPhase2Checkpoints } from "@okouai/db/schema/pi-memory-phase2-checkpoint";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
-import { pgBooleanDecoder } from "../../lib/db-structured-result";
 import type { ApiDb, Tx } from "../../lib/db-types";
 
 type CheckpointReceipt = typeof piMemoryPhase2Checkpoints.$inferInsert;
-
-/**
- * DB/API skew can expose new code before the receipt migration (~102 minutes).
- * Fence maintenance until it is visible; ordinary runs need no new relation.
- * Remove this probe under #31067 after migration and the API rollback window.
- */
-export async function piMemoryPhase2CheckpointSchemaReady(
-  db: ApiDb | Tx,
-): Promise<boolean> {
-  const [result] = await db
-    .select({
-      ready:
-        sql`to_regclass('public.pi_memory_phase2_checkpoints') IS NOT NULL`.mapWith(
-          pgBooleanDecoder,
-        ),
-    })
-    .from(sql`(SELECT 1) AS schema_probe`)
-    .limit(1);
-  return result?.ready === true;
-}
 
 export async function findPiMemoryPhase2Checkpoint(
   db: ApiDb | Tx,
   binding: Omit<CheckpointReceipt, "versionId" | "createdAt">,
 ): Promise<typeof piMemoryPhase2Checkpoints.$inferSelect | undefined> {
-  if (!(await piMemoryPhase2CheckpointSchemaReady(db))) {
-    return undefined;
-  }
   const [receipt] = await db
     .select()
     .from(piMemoryPhase2Checkpoints)

--- a/turbo/apps/api/src/signals/services/pi-memory-phase2-worker.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-memory-phase2-worker.service.ts
@@ -20,7 +20,6 @@ import {
   type PiMemoryPhase2OwnerScope,
 } from "./pi-memory-phase2-job.service";
 import { PI_MEMORY_PHASE2_MODEL } from "./pi-memory-phase2-usage.service";
-import { piMemoryPhase2CheckpointSchemaReady } from "./pi-memory-phase2-checkpoint.service";
 
 const log = logger("PiMemoryPhase2Worker");
 
@@ -282,10 +281,6 @@ export const executePiMemoryPhase2Work$ = command(
   ): Promise<PiMemoryPhase2WorkerResult> => {
     const db = set(writeDb$);
     signal.throwIfAborted();
-    if (!(await piMemoryPhase2CheckpointSchemaReady(db))) {
-      signal.throwIfAborted();
-      return { outcome: "no_work" };
-    }
     const recovered = await recoverMaintenanceRun(db, input);
     signal.throwIfAborted();
     if (recovered) {

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -37,7 +37,6 @@ import {
 } from "./pi-memory-phase2-maintenance.service";
 import {
   findPiMemoryPhase2Checkpoint,
-  piMemoryPhase2CheckpointSchemaReady,
   recordPiMemoryPhase2Checkpoint,
 } from "./pi-memory-phase2-checkpoint.service";
 
@@ -354,9 +353,6 @@ async function guardPiMemoryPhase2MaintenancePublication(args: {
     return notFound("Active Pi memory maintenance publication not found");
   }
 
-  if (!(await piMemoryPhase2CheckpointSchemaReady(args.db))) {
-    return notFound("Pi memory maintenance checkpoint schema is not ready");
-  }
   const receipt = await findPiMemoryPhase2Checkpoint(args.db, {
     ...payload.data,
     runId: args.auth.runId,


### PR DESCRIPTION
Removes the `pi_memory_phase2_checkpoints` schema-availability probe. Closes the removal gate the comment named under #31067.

## Cohort — Pi memory phase-2 checkpoint schema probe

**Old boundary:** #31947 added the checkpoint receipt table in migration `1079` and, because DB/API skew can expose new code before a migration lands (the ~102-minute window), fenced every read and write behind a `to_regclass('public.pi_memory_phase2_checkpoints') IS NOT NULL` probe. While the relation was invisible, maintenance was skipped rather than failing.

**New boundary:** the relation is unconditionally present. All three fences are gone and the code queries the table directly.

Removed:
- `piMemoryPhase2CheckpointSchemaReady` and the now-unused `sql` / `pgBooleanDecoder` imports
- its early `return undefined` in `findPiMemoryPhase2Checkpoint`
- its `return { outcome: "no_work" }` short circuit in `executePiMemoryPhase2Work$`
- its `notFound("Pi memory maintenance checkpoint schema is not ready")` precondition in the storage-write maintenance commit path, and the probe import there

The removed `notFound` string has no other reference in the repository, so no test asserted the fenced-off behavior and none had to be deleted.

**Window:** canonical window 1 — the production migration completed, the replacement API rollout reached its healthy state, and 4 seconds elapsed — plus the rollback retention the comment adds.

**Rollout evidence (observed):**
- #31947 merged `2026-09-05T23:39:01Z` (`2db67fc8be4`).
- First `api/production` deployment containing it: `38edfa57f3`, `2026-09-06T01:05:56Z`, confirmed with `git merge-base --is-ancestor` walking the deployment list forward from oldest.
- **26 further `api/production` deployments** have been promoted since, so the pre-migration API build is far behind the current rollback target.
- Elapsed: **43.9 hours**.

**Migration-pipeline evidence:** `promote-api-production` in `.github/workflows/release-please.yml` runs `pnpm -F @okouai/db db:migrate` against production and deploys the API artifact from the same runner only after migrations succeed. `1079_pi_memory_checkpoint_settlement` is the second entry in `turbo/packages/db/src/migrations/meta/_journal.json`, immediately after `1078_baseline`, and later entries through `1089_nice_the_fury` have shipped. Drizzle applies journal entries in order and fails the job otherwise, so every one of those 26 successful promotions re-confirmed that `1079` is applied.

**MaskDB — recorded as an evidence gap, not as counter-evidence.** `vm0-prod-ro` reports `pi_memory_phase2_checkpoints` as missing. That is its **schema projection lagging**, a limitation this workflow has documented repeatedly: the same projection took days to pick up `usage_pack_credit_refunds` and `browser_sessions`, and it still does not expose `feishu_chat_ingress` or the `public_brand` columns added on 2026-08-24. The table here is two days old, so a stale projection is the expected reading. Per the workflow's own rule that absence is not proof, MaskDB is **not** used as evidence in either direction for this cohort; the deployment-pipeline argument above carries it.

**Axiom:** no route-level signal applies. The discriminator is the presence of a database relation, not a request attribute. Recorded as a deliberate non-use rather than a zero-count claim.

**Persisted data:** none. The table and its rows are untouched; only the runtime probe is removed.

## Explicitly deferred

- **`selectedVideoModel` / `selectedImageModel` snapshot fallbacks.** Open PR #32363 (`refactor(chat): remove video model rollout fallbacks`) is already removing that surface.
- **`clerk-production-topology.ts` rollback branch.** It is the explicit rollback lever for the VM0-to-Okou auth topology cutover; #27750 has not recorded the gate as closed and #31602 is still landing rename work.
- **AgentPhone brandless connect.** The path validates a request signature from sub-floor App builds that the client-version census keeps showing as active.
- **Queued-launch-context brand reads** for Telegram, AgentPhone, and Feishu. MaskDB's projection still does not expose `public_brand` on those context tables — the same staleness described above, now blocking a thirteenth consecutive run.
- **#29908**, **#26519**, **#27786**, **#28449 residue**, `agent-webhook-firewall-auth` switch-GA gate, `model-provider-account` expansions, and the artifact-object fallbacks — unchanged product or evidence gates.
- **`browser-session` PK contraction.** Additionally risky right now: #31905 squashed migration history into `1078_baseline`, so structural DB work should settle before touching it.

## Checks (run once against the combined diff)

- `pnpm format`
- `pnpm -F api lint` (no new warnings), `pnpm -F api check-types`
- `pnpm knip` (no new unused files, exports, or dependencies)
- `pnpm -F api exec vitest run` on `cron-consolidate-pi-memory-phase2` + `pi-memory-stage1-worker` + `pi-memory-citation-old-api-rollback` (18), `chat-event-canonical-storage` + `storage-presigned-url-cache` (11), and `chat-events.bdd` + `integrations.bdd` (284) — against a local Postgres with `timezone=UTC`

Full coverage is left to the PR pipeline; no full local Vitest run and no local dev server.
