### PR TITLE
refactor: remove artifact link kind icon feature switch

### DIFF
--- a/turbo/apps/platform/src/views/components/rich-markdown.tsx
+++ b/turbo/apps/platform/src/views/components/rich-markdown.tsx
@@ -1,5 +1,4 @@
 import "../css/vendor/uiw-react-markdown-preview-5.2.0.css";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { CopyButton } from "@okouai/ui";
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import type { Element, Root } from "hast";
@@ -12,7 +11,6 @@ import {
   escapeHtmlTags,
   parseMarkdownTree,
 } from "../../lib/markdown/pipeline.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { openImageLightbox$ } from "../../signals/okou-page/attachment-chips.ts";
 import { openMarkdownArtifact$ } from "../../signals/okou-page/markdown-artifact-preview.ts";
 import type {
@@ -148,8 +146,6 @@ function ArtifactLinkIcon({ kind }: { readonly kind: ArtifactKind }) {
 function MediaLink({ href, children, ...rest }: MarkdownAnchorProps) {
   const openArtifact = useSet(openMarkdownArtifact$);
   const openImageLightbox = useSet(openImageLightbox$);
-  const showArtifactLinkKindIcons =
-    useGet(featureSwitch$)[FeatureSwitchKey.ArtifactLinkKindIcons] ?? false;
   const card = rest.node?.data?.card;
   return (
     <PlainLink
@@ -178,7 +174,7 @@ function MediaLink({ href, children, ...rest }: MarkdownAnchorProps) {
         }
       }}
     >
-      {showArtifactLinkKindIcons && card?.kind === "artifact" && (
+      {card?.kind === "artifact" && (
         <ArtifactLinkIcon kind={card.signals.kind} />
       )}
       {children}

--- a/turbo/apps/platform/src/views/okou-page/__tests__/markdown-artifacts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/markdown-artifacts.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { expect, test } from "vitest";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 
 import { click, setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -99,7 +98,7 @@ test("One image keeps distinct link labels and image previews in the same messag
   ).resolves.toHaveAttribute("src", url);
 });
 
-test("Artifact links show image, video, and file kinds when enabled", async () => {
+test("Artifact links show image, video, and file kinds", async () => {
   const imageUrl = publicArtifactUrl("screenshot.png");
   const videoUrl = publicArtifactUrl("walkthrough.mp4");
   const fileUrl = publicArtifactUrl("report.pdf");
@@ -113,11 +112,7 @@ test("Artifact links show image, video, and file kinds when enabled", async () =
     ].join("\n\n"),
   );
 
-  await setupPage({
-    context,
-    path: `/chats/${ATTACHMENT_THREAD_ID}`,
-    featureSwitches: { [FeatureSwitchKey.ArtifactLinkKindIcons]: true },
-  });
+  await setupPage({ context, path: `/chats/${ATTACHMENT_THREAD_ID}` });
 
   expect(
     within(await findNamedLink("Screenshot")).getByTestId(
@@ -139,28 +134,6 @@ test("Artifact links show image, video, and file kinds when enabled", async () =
       "[data-testid^='markdown-artifact-link-icon-']",
     ),
   ).toBeNull();
-});
-
-test("Artifact links stay text-only when kind icons are disabled", async () => {
-  const url = publicArtifactUrl("screenshot.png");
-  installMessage(`[Screenshot](${url})`);
-
-  await setupPage({
-    context,
-    path: `/chats/${ATTACHMENT_THREAD_ID}`,
-    featureSwitches: { [FeatureSwitchKey.ArtifactLinkKindIcons]: false },
-  });
-
-  const link = await findNamedLink("Screenshot");
-  expect(link).toHaveAttribute("href", url);
-  expect(link).toHaveTextContent("Screenshot");
-  expect(
-    link.querySelector("[data-testid^='markdown-artifact-link-icon-']"),
-  ).toBeNull();
-  click(link);
-  await expect(
-    screen.findByTestId("attachment-lightbox-image"),
-  ).resolves.toHaveAttribute("src", url);
 });
 
 test("Bare platform URLs stay links and fenced URLs stay code", async () => {

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -55,7 +55,6 @@ export enum FeatureSwitchKey {
   ChatErrorRecovery = "chatErrorRecovery",
   ChatRunWorkFolding = "chatRunWorkFolding",
   ProgressiveArtifactPreview = "progressiveArtifactPreview",
-  ArtifactLinkKindIcons = "artifactLinkKindIcons",
   ChatThinkingSpinner = "chatThinkingSpinner",
   FollowUpOptimize = "followUpOptimize",
   ResponsiveFollowupCards = "responsiveFollowupCards",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -391,13 +391,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ArtifactLinkKindIcons]: {
-    maintainer: "ethan@okou.ai",
-    description:
-      "Show image, video, or file icons before trusted artifact text links.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ChatThinkingSpinner]: {
     maintainer: "yuma@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- permanently render image, video, or file icons for trusted artifact text links at the existing artifact-card boundary
- remove the `ArtifactLinkKindIcons` registry entry, enum key, runtime feature-switch subscription, and off-state fallback
- retain the positive integration coverage without a feature-switch override and remove the obsolete disabled-state test

## Terminal state

- **Decision:** `fully-rolled-out`
- **Basis:** Ethan explicitly requested full rollout and cleanup in this thread on 2026-09-08.

## Archaeology and behavior comparison

- **Introducing commit:** `f3090b04e14bc6d3bfd8b65a8b7577a3c209e6c0` (`feat(platform): add artifact link kind icons`, PR #32384)
- The parent version rendered the original Markdown link label without a kind icon.
- The enabled branch added an `aria-hidden` image/video/file icon only when the existing parsed card is a trusted artifact; ordinary external links, Markdown image rendering, and click-to-preview behavior remained shared logic.
- This PR permanently retains that enabled branch. It removes only the staff-scoped off path and the feature-switch plumbing.

## Search sweep

- Searched `ArtifactLinkKindIcons`, `artifactLinkKindIcons`, `showArtifactLinkKindIcons`, `artifact-link-kind-icons`, `artifact_link_kind_icons`, and the disabled-test wording.
- No live key, registry, read, override, mock, or disabled-path reference remains.
- The phrase “artifact link kind icons” remains only in historical package changelogs for PR #32384; those release records are intentionally preserved.
- `ArtifactLinkIcon` and `markdown-artifact-link-icon-*` remain as the permanent implementation and product-behavior assertions.

## Test changes

- Rewrote the positive page test to exercise the permanent behavior without a feature-switch override; it still covers trusted PNG, MP4, and PDF links plus an ordinary external PNG link that must not receive an icon.
- Deleted the test that existed only to assert the discarded disabled behavior.

## Verification

- `VITE_AXIOM_CLIENT_TELEMETRY_TOKEN='' pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/markdown-artifacts.test.tsx --maxWorkers=1 --silent=passed-only` (4 passed)
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=1 --silent=passed-only` (31 passed)
- `pnpm -F @okouai/app check-types`
- `pnpm -F @okouai/core check-types`
- targeted Prettier, Oxlint, type-aware Oxlint, and ESLint for all four changed files
- `git diff --check origin/main...HEAD`

No local dev server or full-repository Vitest run was started; repository policy delegates those broad checks to the PR pipeline.

## Fallbacks

None introduced. This PR removes the feature-off rollout fallback.
