### PR TITLE
perf(app): prefetch onboarding status

### DIFF
--- a/.github/scripts/tests/okou-app-worker-test.mjs
+++ b/.github/scripts/tests/okou-app-worker-test.mjs
@@ -988,7 +988,7 @@ const prefetchWorker = workerModule.createWorker(
       method: init?.method,
       url,
     });
-    if (observedApiRequests.length === 3) {
+    if (observedApiRequests.length === 4) {
       apiRequestsStarted.resolve();
     }
     if (url.pathname === "/api/agents") {
@@ -1023,6 +1023,7 @@ await apiRequestsStarted.promise;
 assert.deepEqual(observedApiRequests.map(({ url }) => url.pathname).sort(), [
   "/api/agents",
   "/api/feature-switches",
+  "/api/onboarding/status",
   "/api/user-preferences",
 ]);
 for (const { headers, method, url } of observedApiRequests) {

--- a/turbo/apps/app-worker/src/worker.js
+++ b/turbo/apps/app-worker/src/worker.js
@@ -9,6 +9,7 @@ const APP_ASSET_PATH_PREFIX = "/okou-app/assets/";
 const APP_API_PREFETCH_PATHS = [
   "/api/feature-switches",
   "/api/user-preferences",
+  "/api/onboarding/status",
   "/api/agents",
 ];
 const APP_API_PREFETCH_MARKER = "<!--okou-app-api-prefetch-->";


### PR DESCRIPTION
## Summary

- prefetch `/api/onboarding/status` alongside the existing authenticated app-shell API responses
- preserve the independent-response fallback behavior and shared 500 ms prefetch budget
- cover the new request in the app-worker's exact prefetch path assertion

## Verification

- `pnpm --filter @okouai/app-worker test`
- `pnpm --filter @okouai/app-worker check-types`
- `pnpm --filter @okouai/app-worker lint`
