### PR TITLE
test(api): mock intro video agent poster requests

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/intro-video-agent.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/intro-video-agent.test.ts
@@ -336,6 +336,11 @@ function mockProvider(): ProviderState {
           : {},
       });
     }),
+    http.get(/^https:\/\/artifacts\.okou\.test\/cdn-cgi\/media\//u, () => {
+      return new HttpResponse(new Uint8Array([0xff, 0xd8, 0xff]), {
+        headers: { "content-type": "image/jpeg" },
+      });
+    }),
   );
   return state;
 }
@@ -374,7 +379,7 @@ async function credits(f: Fixture): Promise<number> {
 
 describe("Managed Intro Video Agent", () => {
   beforeEach(() => {
-    mockEnv("PUBLIC_ARTIFACTS_BASE_URL", "https://artifacts.vm0.test");
+    mockEnv("OKOU_PUBLIC_ARTIFACTS_BASE_URL", "https://artifacts.okou.test");
     mockEnv("HEYGEN_API_KEY", "test-heygen-key");
     context.mocks.clerk.authenticateRequest.mockReset();
     context.mocks.clerk.authenticateRequest.mockResolvedValue({
@@ -716,11 +721,6 @@ describe("Managed Intro Video Agent", () => {
     provider.videoStatus = "completed";
     const downloadStarted = createDeferredPromise<void>(context.signal);
     const releaseDownload = createDeferredPromise<void>(context.signal);
-    onTestFinished(() => {
-      if (!releaseDownload.settled()) {
-        releaseDownload.resolve(undefined);
-      }
-    });
     provider.beforeDownload = async () => {
       downloadStarted.resolve(undefined);
       await releaseDownload.promise;
@@ -731,16 +731,20 @@ describe("Managed Intro Video Agent", () => {
     }
     const callbackUrl = new URL(callback);
     const callbackPath = `${callbackUrl.pathname}${callbackUrl.search}`;
-    const completion = app(f).request(callbackPath, {
-      method: "POST",
-      body: "{}",
-    });
-    await downloadStarted.promise;
-    await expect(status(f, body.requestId)).resolves.toMatchObject({
-      status: "running",
-    });
-    releaseDownload.resolve(undefined);
-    expect((await completion).status).toBe(200);
+    const [completion] = await Promise.all([
+      app(f).request(callbackPath, {
+        method: "POST",
+        body: "{}",
+      }),
+      (async () => {
+        await downloadStarted.promise;
+        await expect(status(f, body.requestId)).resolves.toMatchObject({
+          status: "running",
+        });
+        releaseDownload.resolve(undefined);
+      })(),
+    ]);
+    expect(completion.status).toBe(200);
     await flushWaitUntilForTest();
     const completed = await status(f, body.requestId);
     expect(completed).toMatchObject({
@@ -767,6 +771,14 @@ describe("Managed Intro Video Agent", () => {
         return (
           command instanceof PutObjectCommand &&
           command.input.ContentType === "video/mp4"
+        );
+      }),
+    ).toHaveLength(1);
+    expect(
+      context.mocks.s3.send.mock.calls.filter(([command]) => {
+        return (
+          command instanceof PutObjectCommand &&
+          command.input.ContentType === "image/jpeg"
         );
       }),
     ).toHaveLength(1);


### PR DESCRIPTION
Intro Video Agent completion tests could time out while generating a poster because the fixture overrode the vm0 artifact origin but generated Okou artifacts. The poster request reached the live `a.okou.io` Cloudflare Media endpoint; MSW's default unhandled-request policy lets static asset URLs pass through. In the [reported CI job](https://github.com/vm0-ai/vm0/actions/runs/34175219757/job/101903218703), this background work exceeded the teardown budget and also delayed the slow-session test's `flushWaitUntilForTest()`.

Use a test-owned Okou artifact origin and an explicit MSW poster response, and assert that completion uploads a JPEG alongside the existing single-MP4 and single-charge assertions. Own the concurrent callback and status probe with `Promise.all`, using the test signal to clean up their deferred gates. The change is confined to the Intro Video Agent integration test fixture and synchronization.

Validation:

- `DATABASE_URL=<local test database> pnpm -F api exec vitest run src/signals/routes/__tests__/intro-video-agent.test.ts --maxWorkers=1 --silent=passed-only` — 14 tests passed in each of 5 consecutive runs.
- `TSC_CHECKERS=1 pnpm -F api check-types`
- `pnpm exec knip --workspace apps/api --no-progress`
- File-scoped Oxlint, type-aware Oxlint, ESLint, and Prettier checks.
- `git diff --check`
