### PR TITLE
fix(platform): stop transcript card border blink

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -699,7 +699,7 @@ body {
 }
 
 /* Cards inside the chat transcript: notice cards, action cards, artifact and
-   media frames. One surface, one hairline, one shadow, one radius — before this
+   media frames. One surface, one border, one shadow, one radius — before this
    the transcript carried two radii, four border tokens and three fills.
 
    `okou-chat-frame` is the same recipe without the fill, for the frames that
@@ -714,7 +714,8 @@ body {
 @layer components {
   .okou-app .okou-chat-card,
   .okou-app .okou-chat-frame {
-    border: 0.7px solid hsl(var(--gray-400));
+    /* Fractional borders visibly repaint when card contents resolve. */
+    border: 1px solid hsl(var(--gray-400));
     border-radius: var(--okou-chat-card-radius);
     box-shadow: var(--okou-chat-card-shadow);
   }

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-browser-actions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-browser-actions.test.tsx
@@ -1,8 +1,13 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import {
   browserContract,
   type BrowserSession,
 } from "@okouai/api-contracts/contracts/browser";
 import { screen, waitFor, within } from "@testing-library/react";
+import { compile } from "tailwindcss";
 import { expect, test } from "vitest";
 
 import {
@@ -34,6 +39,42 @@ const SUSPENDED_SCREENSHOT_URL =
   "https://images.example.test/browser-suspended.png";
 const ACTIVE_BROWSER_URL = "https://browser.example.test/live/initial";
 const RESUMED_BROWSER_URL = "https://browser.example.test/live/resumed";
+const appStyles = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), "../../css/index.css"),
+  "utf8",
+);
+
+async function createRenderedAppStyles(
+  signal: AbortSignal,
+): Promise<(element: HTMLElement) => void> {
+  const sharedCardRule = appStyles.match(
+    /\.okou-app \.okou-chat-card,\s*\.okou-app \.okou-chat-frame\s*\{[^}]+\}/u,
+  )?.[0];
+  if (!sharedCardRule) {
+    throw new Error("The shared chat card style rule was not found");
+  }
+  const renderedSharedCardRule = sharedCardRule.replace(
+    "hsl(var(--gray-400))",
+    "rgb(128, 128, 128)",
+  );
+  const compiler = await compile("@tailwind utilities;");
+  const styleElement = document.createElement("style");
+  document.head.append(styleElement);
+  signal.addEventListener(
+    "abort",
+    () => {
+      styleElement.remove();
+    },
+    { once: true },
+  );
+
+  return (element) => {
+    styleElement.textContent = [
+      renderedSharedCardRule,
+      compiler.build([...element.classList]),
+    ].join("\n");
+  };
+}
 
 function managedBrowserSession(args: {
   readonly status: "active" | "suspended";
@@ -121,6 +162,7 @@ function buttonsByName(
 }
 
 test("Follow a managed browser session from its chat card", async () => {
+  const sessionReady = context.mocks.deferred<void>();
   let browser = managedBrowserSession({
     status: "active",
     screenshotUrl: INITIAL_SCREENSHOT_URL,
@@ -138,8 +180,9 @@ test("Follow a managed browser session from its chat card", async () => {
       ].join("\n\n"),
     ),
   });
-  context.mocks.api(browserContract.get, ({ params, respond }) => {
+  context.mocks.api(browserContract.get, async ({ params, respond }) => {
     expect(params.threadId).toBe(RUN_THREAD_ID);
+    await sessionReady.promise;
     return respond(200, { browser });
   });
   context.mocks.api(browserContract.open, ({ params, respond }) => {
@@ -154,7 +197,18 @@ test("Follow a managed browser session from its chat card", async () => {
   await setupPage({ context, path: RUN_PATH, host: "app.vm0.ai" });
 
   await readyChat();
+  const renderAppStyles = await createRenderedAppStyles(context.signal);
+  const loadingCard = await screen.findByTestId("browser-session-card-loading");
+  renderAppStyles(loadingCard);
+  expect(getComputedStyle(loadingCard).borderTopWidth).toBe("1px");
+
+  sessionReady.resolve();
   const card = await findButton("Open Research browser");
+  renderAppStyles(card);
+  expect(getComputedStyle(card).borderTopWidth).toBe("1px");
+  expect(getComputedStyle(card).transitionProperty).toBe(
+    "background-color,border-color,transform",
+  );
   expect(card).toHaveTextContent("Cloud browser");
   expect(card).toHaveTextContent("Live");
   expect(screen.getByTestId("browser-session-thumbnail")).toHaveAttribute(

--- a/turbo/apps/platform/src/views/okou-page/browser-session-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/browser-session-card.tsx
@@ -21,7 +21,7 @@ interface BrowserSessionCardProps {
 const BROWSER_SESSION_CARD_SHELL_CLASS =
   "inline-flex w-[min(100%,400px)] align-top";
 const BROWSER_SESSION_CARD_CLASS =
-  "okou-chat-card flex w-full flex-col overflow-hidden text-left text-foreground transition-all duration-200";
+  "okou-chat-card flex w-full flex-col overflow-hidden text-left text-foreground transition-[background-color,border-color,transform] duration-200";
 const BROWSER_SESSION_CARD_HOVER_CLASS =
   "hover:scale-[1.015] hover:border-gray-500";
 


### PR DESCRIPTION
## Summary

- replace the shared transcript card and frame fractional border with a full `1px` border
- keep the existing color, radius, surface, and shadow across every `.okou-chat-card` and `.okou-chat-frame` consumer
- limit Browser Card transitions to background color, border color, and transform

## Why

The `0.7px` border introduced in #31072 can land on fractional device-pixel boundaries. When asynchronous card content resolves, the clipped edge can repaint as a visible one-pixel blink. The shared recipe exposed every transcript card and frame to the same artifact.

## Verification

- `pnpm exec prettier --check apps/platform/src/views/css/index.css apps/platform/src/views/okou-page/browser-session-card.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace apps/platform`
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-capability-browser-actions.test.tsx` (2 passed)
- `pnpm -F @okouai/app build` with non-secret Clerk placeholder values