### PR TITLE
fix(api): localize official workflow thread titles

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
@@ -16,7 +16,10 @@ import {
   type AgentResponse,
 } from "@okouai/api-contracts/contracts/agents";
 import { orgContract } from "@okouai/api-contracts/contracts/org-routes";
-import { userPreferencesContract } from "@okouai/api-contracts/contracts/user-preferences";
+import {
+  userPreferencesContract,
+  type UserLocale,
+} from "@okouai/api-contracts/contracts/user-preferences";
 
 import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
@@ -279,6 +282,19 @@ export function createBddApi(context: TestContext) {
         userPreferencesClient().update({
           headers: authenticate(nextUser),
           body: { timezone },
+        }),
+        [200],
+      );
+    },
+
+    async updateUserLocale(
+      nextUser: ApiTestUser,
+      locale: UserLocale,
+    ): Promise<void> {
+      await accept(
+        userPreferencesClient().update({
+          headers: authenticate(nextUser),
+          body: { locale },
         }),
         [200],
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -23,6 +23,7 @@ import { morningBriefPreferenceContract } from "@okouai/api-contracts/contracts/
 import { testOfficialWorkflowCatalogStateContract } from "@okouai/api-contracts/contracts/test-official-workflow-catalog-state";
 import { testSystemStoragePresignedUrlCacheStateContract } from "@okouai/api-contracts/contracts/test-system-storage-presigned-url-cache-state";
 import { testWorkflowAutomationExecutionContract } from "@okouai/api-contracts/contracts/test-workflow-automation-execution";
+import type { UserLocale } from "@okouai/api-contracts/contracts/user-preferences";
 import {
   workflowAutomationsContract,
   workflowsCollectionContract,
@@ -2680,6 +2681,77 @@ describe.sequential("Official Workflow installations", () => {
       "Official Workflow is retired: connector-doctor",
     );
   });
+
+  it.each([
+    {
+      locale: null,
+      localeLabel: "the default locale",
+      title: "Okou Morning Brief",
+    },
+    {
+      locale: "pt-BR",
+      localeLabel: "pt-BR",
+      title: "Okou Resumo da manhã",
+    },
+  ] satisfies readonly {
+    readonly locale: UserLocale | null;
+    readonly localeLabel: string;
+    readonly title: string;
+  }[])(
+    "names a new Morning Brief thread for $localeLabel",
+    async ({ locale, title }) => {
+      installCatalogStorageFixture();
+      await syncDeployedCatalog();
+      const { actor } = await workflowBdd.setupWorkflowOrg({
+        timezone: "Asia/Shanghai",
+      });
+      if (!actor.orgId) {
+        throw new Error("Expected organization-scoped actor");
+      }
+      if (locale) {
+        await bdd.updateUserLocale(actor, locale);
+      }
+      await selectBuiltInDefaultModel(actor);
+      const { agentId } = await workflowBdd.createAgent(actor);
+      onTestFinished(async () => {
+        installCatalogStorageFixture();
+        await bdd.deleteAgent(actor, agentId);
+        await cleanupCatalog();
+      });
+      const headers = authHeaders(actor);
+      await setOfficialWorkflowsEnabled(actor, true);
+
+      const installed = await accept(
+        officialClient().install({
+          headers,
+          params: { definitionName: "morning-brief" },
+          body: {
+            agentId,
+            blueprints: [{ blueprintKey: "daily-delivery", bindings: [] }],
+          },
+        }),
+        [201],
+      );
+      const automation = installed.body.workflow.automations[0];
+      if (!automation) {
+        throw new Error("Expected the Morning Brief Automation");
+      }
+
+      const started = await accept(
+        automationClient().run({
+          headers,
+          params: { id: automation.id },
+        }),
+        [201],
+      );
+      await expect(
+        chat.readThreadMetadata(actor, started.body.chatThreadId),
+      ).resolves.toMatchObject({ title });
+      if (started.body.runId) {
+        await runs.requestCancelRun(actor, started.body.runId, [200, 400]);
+      }
+    },
+  );
 
   it("requires a Preference timezone only when a schedule Blueprint omits one", async () => {
     installCatalogStorageFixture();

--- a/turbo/apps/api/src/signals/services/workflow-user-automation-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-user-automation-thread.service.ts
@@ -1,7 +1,13 @@
+import {
+  userLocaleSchema,
+  type UserLocale,
+} from "@okouai/api-contracts/contracts/user-preferences";
+import { orgMembersMetadata } from "@okouai/db/schema/org-members-metadata";
 import { chatThreads } from "@okouai/db/schema/chat-thread";
 import {
   workflowAutomations,
   workflowUserAutomationThreads,
+  workflows,
 } from "@okouai/db/schema/workflow";
 import { and, eq, inArray } from "drizzle-orm";
 
@@ -15,6 +21,90 @@ import {
   type ChatThreadEventTransaction,
 } from "./chat-thread-event.service";
 import { loadNewChatThreadMediaModels } from "./chat-thread-media-model.service";
+import {
+  readAcceptedOfficialWorkflowDefinition,
+  readAcceptedOfficialWorkflowRevision,
+} from "./official-workflow-catalog-read.service";
+
+const OFFICIAL_WORKFLOW_THREAD_TITLES: Readonly<
+  Partial<Record<string, Readonly<Record<UserLocale, string>>>>
+> = {
+  "morning-brief": {
+    "en-US": "Okou Morning Brief",
+    "pt-BR": "Okou Resumo da manhã",
+    "ja-JP": "Okou モーニングブリーフ",
+    "ko-KR": "Okou 모닝 브리핑",
+    "id-ID": "Okou Ringkasan pagi",
+    "de-DE": "Okou Morgenbriefing",
+    "es-ES": "Okou Resumen matinal",
+    "it-IT": "Okou Brief del mattino",
+    "fr-FR": "Okou Brief du matin",
+    "hi-IN": "Okou सुबह की ब्रीफ़",
+  },
+};
+
+async function loadOfficialWorkflowDisplayName(
+  db: ReadonlyDb,
+  definitionName: string,
+): Promise<string | null> {
+  const definition = await readAcceptedOfficialWorkflowDefinition(
+    db,
+    definitionName,
+  );
+  if (!definition) {
+    return null;
+  }
+  const revision = await readAcceptedOfficialWorkflowRevision(db, {
+    name: definition.name,
+    revision: definition.revision,
+  });
+  return revision?.definition.workflow.displayName ?? null;
+}
+
+async function resolveAutomationChatThreadTitle(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workflowId: string;
+    readonly workflowTitle: string;
+  },
+): Promise<string> {
+  const [context] = await db
+    .select({
+      officialDefinitionName: workflows.officialDefinitionName,
+      locale: orgMembersMetadata.locale,
+    })
+    .from(workflows)
+    .leftJoin(
+      orgMembersMetadata,
+      and(
+        eq(orgMembersMetadata.orgId, args.orgId),
+        eq(orgMembersMetadata.userId, args.userId),
+      ),
+    )
+    .where(
+      and(eq(workflows.orgId, args.orgId), eq(workflows.id, args.workflowId)),
+    )
+    .limit(1);
+  if (!context?.officialDefinitionName) {
+    return args.workflowTitle;
+  }
+
+  const locale = userLocaleSchema.parse(context.locale ?? "en-US");
+  const localizedTitle =
+    OFFICIAL_WORKFLOW_THREAD_TITLES[context.officialDefinitionName]?.[locale];
+  if (localizedTitle) {
+    return localizedTitle;
+  }
+
+  return (
+    (await loadOfficialWorkflowDisplayName(
+      db,
+      context.officialDefinitionName,
+    )) ?? args.workflowTitle
+  );
+}
 
 export async function loadWorkflowUserAutomationThreadId(
   db: ReadonlyDb,
@@ -216,11 +306,17 @@ export async function ensureWorkflowUserAutomationThread(
     }
   }
 
+  const title = await resolveAutomationChatThreadTitle(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    workflowId: args.workflowId,
+    workflowTitle: args.workflowTitle,
+  });
   const chatThreadId = await createAutomationChatThread(db, {
     userId: args.userId,
     orgId: args.orgId,
     agentId: args.agentId,
-    title: args.workflowTitle,
+    title,
     currentTime: args.currentTime,
   });
 


### PR DESCRIPTION
## Summary

- Resolve new Official Workflow automation thread titles from the user's UI locale
- Name Morning Brief threads `Okou Morning Brief` in English and provide titles for every supported locale
- Fall back to the accepted Official Workflow display name for future built-ins while preserving custom workflow titles
- Leave existing and user-renamed threads unchanged

## Fallbacks

- If the persisted UI locale is absent, use `en-US` for the new thread title. This affects presentation only and remains necessary while `org_members_metadata.locale` is nullable; it can be removed if that preference becomes required and existing rows are backfilled.
- If an Official Workflow slug has no localized title mapping, use the accepted catalog revision's canonical display name. This affects presentation only and can be removed if every accepted built-in is required to define a title for every supported locale.
- If the accepted Official Workflow definition or revision is unavailable, retain the caller-provided workflow title. This preserves presentation-only behavior without granting capabilities and can be removed if thread creation becomes contractually dependent on catalog availability.

## Verification

- `pnpm exec prettier --check apps/api/src/signals/services/workflow-user-automation-thread.service.ts apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts apps/api/src/signals/routes/__tests__/official-workflows.test.ts`
- `pnpm -F api lint`
- `TSC_CHECKERS=1 pnpm -F api check-types`
- `pnpm exec knip --workspace api`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/official-workflows.test.ts -t 'names a new Morning Brief thread' --maxWorkers=1` (2 passed)
