### PR TITLE
fix(calendar): support safe target reconfiguration

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automations.test.ts
@@ -366,6 +366,7 @@ interface CalendarWatchRegistration {
   readonly channelId: string;
   readonly channelToken: string;
   readonly resourceId: string;
+  readonly calendarId: string;
 }
 
 interface CalendarStopRecorder extends StopCallRecorder {
@@ -377,6 +378,7 @@ interface CalendarStopRecorder extends StopCallRecorder {
 
 function configureGoogleCalendarStopMock(
   statuses: readonly number[] = [204],
+  accessTokens: readonly string[] = ["calendar-access-token"],
 ): CalendarStopRecorder {
   const recorder: CalendarStopRecorder = { calls: 0, requests: [] };
   server.use(
@@ -384,9 +386,11 @@ function configureGoogleCalendarStopMock(
       "https://www.googleapis.com/calendar/v3/channels/stop",
       async ({ request }) => {
         recorder.calls += 1;
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer calendar-access-token",
-        );
+        expect(
+          accessTokens.map((token) => {
+            return `Bearer ${token}`;
+          }),
+        ).toContain(request.headers.get("authorization"));
         const body = (await request.json()) as {
           readonly id: string;
           readonly resourceId: string;
@@ -405,6 +409,9 @@ function configureGoogleCalendarStopMock(
 
 function configureGoogleCalendarWatchMock(args?: {
   readonly calendarId?: string;
+  readonly calendarIds?: readonly string[];
+  readonly accessTokens?: readonly string[];
+  readonly watchTtlMs?: number;
   readonly baselineItems?: readonly Record<string, unknown>[];
   readonly incrementalItems?: readonly Record<string, unknown>[];
   readonly onWatchRegistered?: (
@@ -418,17 +425,21 @@ function configureGoogleCalendarWatchMock(args?: {
     channelIds: [],
     eventListRequests: [],
   };
-  const calendarId = args?.calendarId ?? "primary";
+  const calendarIds = args?.calendarIds ?? [args?.calendarId ?? "primary"];
+  const accessTokens = args?.accessTokens ?? ["calendar-access-token"];
   mockEnv("OKOU_API_BACKEND_URL", "https://api.vm0.ai");
   server.use(
     http.post(
       "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
       async ({ request, params }) => {
         recorder.watchCalls += 1;
-        expect(params.calendarId).toBe(calendarId);
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer calendar-access-token",
-        );
+        const calendarId = String(params.calendarId);
+        expect(calendarIds).toContain(calendarId);
+        expect(
+          accessTokens.map((token) => {
+            return `Bearer ${token}`;
+          }),
+        ).toContain(request.headers.get("authorization"));
         const body = (await request.json()) as {
           readonly id?: string;
           readonly type?: string;
@@ -451,22 +462,27 @@ function configureGoogleCalendarWatchMock(args?: {
           channelId,
           channelToken,
           resourceId,
+          calendarId,
         });
         return HttpResponse.json({
           id: body.id,
           resourceId,
           resourceUri: `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`,
-          expiration: String(now() + 7 * 24 * 60 * 60 * 1000),
+          expiration: String(
+            now() + (args?.watchTtlMs ?? 7 * 24 * 60 * 60 * 1000),
+          ),
         });
       },
     ),
     http.get(
       "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events",
       ({ request, params }) => {
-        expect(params.calendarId).toBe(calendarId);
-        expect(request.headers.get("authorization")).toBe(
-          "Bearer calendar-access-token",
-        );
+        expect(calendarIds).toContain(String(params.calendarId));
+        expect(
+          accessTokens.map((token) => {
+            return `Bearer ${token}`;
+          }),
+        ).toContain(request.headers.get("authorization"));
         const url = new URL(request.url);
         expect(url.searchParams.get("showDeleted")).toBe("true");
         expect(url.searchParams.get("maxResults")).toBe("2500");
@@ -696,6 +712,48 @@ describe("okou workflow automations", () => {
       "org:member",
     );
     return connector.id;
+  }
+
+  async function addGoogleCalendarAccount(
+    scenario: AutomationScenario,
+    options: {
+      readonly accessToken: string;
+      readonly email: string;
+      readonly subject: string;
+    },
+  ): Promise<string> {
+    mockGoogleCalendarConnectorOAuth(options);
+    const started = await connectorsApi.startOauth(
+      scenario.actor,
+      "google-calendar",
+      "oauth",
+      scenario.agentId,
+      { intent: "add", displayName: options.email },
+    );
+    const state = new URL(started.authorizationUrl).searchParams.get("state");
+    if (!state) {
+      throw new Error("Expected Google Calendar OAuth state");
+    }
+    await connectorsApi.completeOauthCallback("google-calendar", {
+      code: "google-calendar-add-account-code",
+      state,
+    });
+    const accounts = await connectorsApi.listBuiltinConnectorAccounts(
+      scenario.actor,
+      "google-calendar",
+    );
+    const account = accounts.find((candidate) => {
+      return candidate.externalEmail === options.email;
+    });
+    if (!account) {
+      throw new Error("Expected the added Google Calendar account");
+    }
+    mocks.clerk.session(
+      scenario.fixture.userId,
+      scenario.fixture.orgId,
+      "org:member",
+    );
+    return account.id;
   }
 
   async function connectGoogleForms(
@@ -2955,6 +3013,714 @@ describe("okou workflow automations", () => {
     expect(gmailWatch.calls).toBe(0);
     expect(calendarWatch.watchCalls).toBe(0);
     expect(calendarWatch.baselineCalls).toBe(0);
+  });
+
+  it("reconfigures every enabled Calendar event type without replacing automation state", async () => {
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+    const scenario = await setupFixture();
+    await connectGoogleCalendar(scenario);
+    const cases = [
+      {
+        create: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: "created-old@example.com",
+          },
+        },
+        update: {
+          provider: "google-calendar",
+          event: "event_created",
+          calendarId: "created-new@example.com",
+        },
+      },
+      {
+        create: {
+          kind: "event",
+          eventType: "google-calendar-event-updated",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_updated",
+            calendarId: "updated-old@example.com",
+          },
+        },
+        update: {
+          provider: "google-calendar",
+          event: "event_updated",
+          calendarId: "updated-new@example.com",
+        },
+      },
+      {
+        create: {
+          kind: "event",
+          eventType: "google-calendar-event-cancelled",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_cancelled",
+            calendarId: "cancelled-old@example.com",
+          },
+        },
+        update: {
+          provider: "google-calendar",
+          event: "event_cancelled",
+          calendarId: "cancelled-new@example.com",
+        },
+      },
+    ] as const;
+    const watch = configureGoogleCalendarWatchMock({
+      calendarIds: cases.flatMap((entry) => {
+        return [entry.create.eventConfig.calendarId, entry.update.calendarId];
+      }),
+    });
+    const stop = configureGoogleCalendarStopMock();
+
+    for (const [index, entry] of cases.entries()) {
+      const created = await accept(
+        automationsClient().create({
+          headers: authHeaders(),
+          params: { workflowId: scenario.workflowId },
+          body: entry.create,
+        }),
+        [201],
+      );
+      await setWorkflowAutomationAutonomyBudgetFixture(
+        context,
+        created.body.id,
+        4,
+      );
+      if (index === 0) {
+        await accept(
+          automationsClient().run({
+            headers: authHeaders(),
+            params: { id: created.body.id },
+          }),
+          [201],
+        );
+      }
+      const before = await wf.readAutomation(created.body.id);
+
+      const updated = await accept(
+        automationsClient().update({
+          headers: authHeaders(),
+          params: { id: created.body.id },
+          body: { eventConfig: entry.update },
+        }),
+        [200],
+      );
+
+      expect(updated.body).toMatchObject({
+        id: before.id,
+        kind: "event",
+        eventType: entry.create.eventType,
+        eventConfig: entry.update,
+        enabled: before.enabled,
+        chatThreadId: before.chatThreadId,
+        lastRunAt: before.lastRunAt,
+        official: before.official,
+      });
+      await expect(
+        readWorkflowAutomationAutonomyFixture(context, created.body.id),
+      ).resolves.toMatchObject({ autonomyBudget: 4 });
+    }
+
+    expect(watch.watchCalls).toBe(6);
+    expect(watch.baselineCalls).toBe(6);
+    expect(stop.calls).toBe(3);
+  });
+
+  it("rejects mismatched Calendar config and keeps disabled reconfiguration watch-free", async () => {
+    const scenario = await setupFixture();
+    await connectGoogleCalendar(scenario);
+    const watch = configureGoogleCalendarWatchMock({
+      calendarIds: ["disabled-old@example.com", "primary"],
+    });
+    const stop = configureGoogleCalendarStopMock();
+    const created = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: "disabled-old@example.com",
+          },
+          enabled: false,
+        },
+      }),
+      [201],
+    );
+
+    const mismatched = await accept(
+      automationsClient().update({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+        body: {
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_updated",
+            calendarId: "mismatch@example.com",
+          },
+        },
+      }),
+      [400],
+    );
+    expect(mismatched.body.error.message).toBe(
+      "eventConfig must match the Google Calendar automation type",
+    );
+    await expect(wf.readAutomation(created.body.id)).resolves.toMatchObject({
+      enabled: false,
+      eventConfig: { calendarId: "disabled-old@example.com" },
+    });
+
+    const updated = await accept(
+      automationsClient().update({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+        body: {
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: GOOGLE_CALENDAR_EMAIL,
+          },
+        },
+      }),
+      [200],
+    );
+    expect(updated.body).toMatchObject({
+      id: created.body.id,
+      enabled: false,
+      eventConfig: { calendarId: "primary" },
+    });
+    expect(watch.watchCalls).toBe(0);
+    expect(watch.baselineCalls).toBe(0);
+    expect(stop.calls).toBe(0);
+  });
+
+  it("preserves consumers shared across both Calendar reconfiguration targets", async () => {
+    const scenario = await setupFixture();
+    await connectGoogleCalendar(scenario);
+    const oldTarget = "shared-old@example.com";
+    const newTarget = "shared-new@example.com";
+    const watch = configureGoogleCalendarWatchMock({
+      calendarIds: [oldTarget, newTarget],
+    });
+    const stop = configureGoogleCalendarStopMock();
+    const switching = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: oldTarget,
+          },
+        },
+      }),
+      [201],
+    );
+    const stayingOnOld = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-updated",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_updated",
+            calendarId: oldTarget,
+          },
+        },
+      }),
+      [201],
+    );
+    const stayingOnNew = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-cancelled",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_cancelled",
+            calendarId: newTarget,
+          },
+        },
+      }),
+      [201],
+    );
+
+    await accept(
+      automationsClient().update({
+        headers: authHeaders(),
+        params: { id: switching.body.id },
+        body: {
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: newTarget,
+          },
+        },
+      }),
+      [200],
+    );
+
+    await expect(
+      wf.readAutomation(stayingOnOld.body.id),
+    ).resolves.toMatchObject({
+      enabled: true,
+      eventConfig: { calendarId: oldTarget },
+    });
+    await expect(
+      wf.readAutomation(stayingOnNew.body.id),
+    ).resolves.toMatchObject({
+      enabled: true,
+      eventConfig: { calendarId: newTarget },
+    });
+    expect(watch.watchCalls).toBe(2);
+    expect(watch.baselineCalls).toBe(2);
+    expect(stop.calls).toBe(0);
+  });
+
+  it("keeps an action-required Calendar target until its replacement watch is ready", async () => {
+    const scenario = await setupFixture();
+    await connectGoogleCalendar(scenario);
+    configureGoogleCalendarWatchMock({
+      calendarId: "primary",
+      watchTtlMs: 60 * 60 * 1000,
+    });
+    configureGoogleCalendarStopMock();
+    const automation = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+        },
+      }),
+      [201],
+    );
+
+    server.use(
+      http.get(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events",
+        () => {
+          return HttpResponse.json(
+            { error: { status: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        },
+      ),
+      http.get(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId",
+        () => {
+          return HttpResponse.json(
+            { error: { status: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        },
+      ),
+      http.post(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
+        () => {
+          return HttpResponse.json(
+            { error: { status: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        },
+      ),
+    );
+    await accept(
+      renewGoogleCalendarWatchScopeClient().renew({
+        body: {
+          org_id: scenario.fixture.orgId,
+          user_id: scenario.fixture.userId,
+        },
+      }),
+      [200],
+    );
+    const actionRequired = await wf.readAutomation(automation.body.id);
+    expect(actionRequired).toMatchObject({
+      id: automation.body.id,
+      enabled: true,
+      eventConfig: { calendarId: "primary" },
+      warning: "reconnect_required",
+    });
+
+    const failedTarget = "failed-baseline@example.com";
+    server.use(
+      http.get(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events",
+        ({ params }) => {
+          expect(params.calendarId).toBe(failedTarget);
+          return HttpResponse.json(
+            { error: "baseline unavailable" },
+            { status: 503 },
+          );
+        },
+      ),
+    );
+    const failed = await accept(
+      automationsClient().update({
+        headers: authHeaders(),
+        params: { id: automation.body.id },
+        body: {
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: failedTarget,
+          },
+        },
+      }),
+      [400],
+    );
+    expect(JSON.stringify(failed.body)).not.toContain(failedTarget);
+    await expect(wf.readAutomation(automation.body.id)).resolves.toMatchObject({
+      id: actionRequired.id,
+      enabled: true,
+      chatThreadId: actionRequired.chatThreadId,
+      eventConfig: { calendarId: "primary" },
+      warning: "reconnect_required",
+    });
+
+    const replacementTarget = "replacement-ready@example.com";
+    let observedDuringRegistration:
+      | {
+          readonly eventConfig: unknown;
+          readonly warning: unknown;
+        }
+      | undefined;
+    const replacement = configureGoogleCalendarWatchMock({
+      calendarId: replacementTarget,
+      onWatchRegistered: async () => {
+        const current = await wf.readAutomation(automation.body.id);
+        if (current.kind !== "event") {
+          throw new Error("Expected Calendar event automation");
+        }
+        observedDuringRegistration = {
+          eventConfig: current.eventConfig,
+          warning: "warning" in current ? current.warning : undefined,
+        };
+      },
+    });
+    const updated = await accept(
+      automationsClient().update({
+        headers: authHeaders(),
+        params: { id: automation.body.id },
+        body: {
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: replacementTarget,
+          },
+        },
+      }),
+      [200],
+    );
+
+    expect(observedDuringRegistration).toMatchObject({
+      eventConfig: { calendarId: "primary" },
+      warning: "reconnect_required",
+    });
+    expect(updated.body).toMatchObject({
+      id: automation.body.id,
+      enabled: true,
+      eventConfig: { calendarId: replacementTarget },
+    });
+    expect("warning" in updated.body).toBeFalsy();
+    expect(replacement.baselineCalls).toBe(1);
+    expect(replacement.watchCalls).toBe(1);
+  });
+
+  it("rolls back Calendar config when replacement watch registration fails", async () => {
+    const scenario = await setupFixture();
+    await connectGoogleCalendar(scenario);
+    const oldTarget = "registration-old@example.com";
+    const newTarget = "registration-new@example.com";
+    const watch = configureGoogleCalendarWatchMock({
+      calendarIds: [oldTarget, newTarget],
+    });
+    const stop = configureGoogleCalendarStopMock();
+    const automation = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-updated",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_updated",
+            calendarId: oldTarget,
+          },
+        },
+      }),
+      [201],
+    );
+    await setWorkflowAutomationAutonomyBudgetFixture(
+      context,
+      automation.body.id,
+      3,
+    );
+    const before = await wf.readAutomation(automation.body.id);
+    server.use(
+      http.post(
+        "https://www.googleapis.com/calendar/v3/calendars/:calendarId/events/watch",
+        ({ params }) => {
+          expect(params.calendarId).toBe(newTarget);
+          return HttpResponse.json(
+            { error: "provider unavailable" },
+            { status: 503 },
+          );
+        },
+      ),
+    );
+
+    const failed = await accept(
+      automationsClient().update({
+        headers: authHeaders(),
+        params: { id: automation.body.id },
+        body: {
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_updated",
+            calendarId: newTarget,
+          },
+        },
+      }),
+      [400],
+    );
+
+    expect(JSON.stringify(failed.body)).not.toContain(newTarget);
+    await expect(wf.readAutomation(automation.body.id)).resolves.toMatchObject({
+      id: before.id,
+      enabled: before.enabled,
+      chatThreadId: before.chatThreadId,
+      lastRunAt: before.lastRunAt,
+      eventConfig: { calendarId: oldTarget },
+    });
+    await expect(
+      readWorkflowAutomationAutonomyFixture(context, automation.body.id),
+    ).resolves.toMatchObject({ autonomyBudget: 3 });
+    expect(watch.baselineCalls).toBe(2);
+    expect(watch.watchCalls).toBe(1);
+    expect(stop.calls).toBe(0);
+    const logged = JSON.stringify(context.mocks.axiomLogging.warn.mock.calls);
+    expect(logged).not.toContain(oldTarget);
+    expect(logged).not.toContain(newTarget);
+  });
+
+  it("rejects a Calendar reconfiguration superseded during watch registration", async () => {
+    const scenario = await setupFixture();
+    await connectGoogleCalendar(scenario);
+    const originalTarget = "race-original@example.com";
+    const supersededTarget = "race-superseded@example.com";
+    const winningTarget = "race-winning@example.com";
+    const race: {
+      automationId?: string;
+      competingUpdateCompleted: boolean;
+    } = { competingUpdateCompleted: false };
+    const watch = configureGoogleCalendarWatchMock({
+      calendarIds: [originalTarget, supersededTarget, winningTarget],
+      onWatchRegistered: async ({ calendarId }) => {
+        if (
+          calendarId !== supersededTarget ||
+          race.competingUpdateCompleted ||
+          race.automationId === undefined
+        ) {
+          return;
+        }
+        const competing = await accept(
+          automationsClient().update({
+            headers: authHeaders(),
+            params: { id: race.automationId },
+            body: {
+              eventConfig: {
+                provider: "google-calendar",
+                event: "event_created",
+                calendarId: winningTarget,
+              },
+            },
+          }),
+          [200],
+        );
+        expect(competing.body).toMatchObject({
+          id: race.automationId,
+          eventConfig: { calendarId: winningTarget },
+        });
+        race.competingUpdateCompleted = true;
+      },
+    });
+    const stop = configureGoogleCalendarStopMock();
+    const automation = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-created",
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: originalTarget,
+          },
+        },
+      }),
+      [201],
+    );
+    race.automationId = automation.body.id;
+
+    const superseded = await accept(
+      automationsClient().update({
+        headers: authHeaders(),
+        params: { id: automation.body.id },
+        body: {
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_created",
+            calendarId: supersededTarget,
+          },
+        },
+      }),
+      [400],
+    );
+
+    expect(race.competingUpdateCompleted).toBeTruthy();
+    expect(superseded.body.error.message).toBe(
+      "Google Calendar automation changed; retry the update",
+    );
+    await expect(wf.readAutomation(automation.body.id)).resolves.toMatchObject({
+      id: automation.body.id,
+      enabled: true,
+      eventConfig: { calendarId: winningTarget },
+    });
+    expect(watch.watchCalls).toBe(3);
+    expect(watch.baselineCalls).toBe(3);
+    expect(
+      stop.requests.map((request) => {
+        return request.resourceId;
+      }),
+    ).toStrictEqual(
+      expect.arrayContaining(["calendar-resource-1", "calendar-resource-2"]),
+    );
+    expect(stop.requests).toHaveLength(2);
+  });
+
+  it("fails closed when Calendar account selection changes during staging", async () => {
+    const scenario = await setupFixture();
+    const firstAccessToken = "calendar-race-first-token";
+    const secondAccessToken = "calendar-race-second-token";
+    const firstEmail = "calendar-race-first@example.com";
+    const secondEmail = "calendar-race-second@example.com";
+    await connectGoogleCalendar(scenario, {
+      accessToken: firstAccessToken,
+      email: firstEmail,
+      subject: "calendar-race-first-subject",
+    });
+    const secondAccountId = await addGoogleCalendarAccount(scenario, {
+      accessToken: secondAccessToken,
+      email: secondEmail,
+      subject: "calendar-race-second-subject",
+    });
+    const accounts = await connectorsApi.listBuiltinConnectorAccounts(
+      scenario.actor,
+      "google-calendar",
+    );
+    const firstAccount = accounts.find((account) => {
+      return account.externalEmail === firstEmail;
+    });
+    if (!firstAccount) {
+      throw new Error("Expected the first Calendar account");
+    }
+    await connectorsApi.setDefaultBuiltinConnectorAccount(
+      scenario.actor,
+      "google-calendar",
+      firstAccount.id,
+    );
+
+    const stagedTarget = "account-race-target@example.com";
+    let switchAccount = true;
+    const watch = configureGoogleCalendarWatchMock({
+      calendarIds: ["primary", stagedTarget],
+      accessTokens: [firstAccessToken, secondAccessToken],
+      onWatchRegistered: async ({ calendarId }) => {
+        if (calendarId !== stagedTarget || !switchAccount) {
+          return;
+        }
+        switchAccount = false;
+        await connectorsApi.setDefaultBuiltinConnectorAccount(
+          scenario.actor,
+          "google-calendar",
+          secondAccountId,
+        );
+      },
+    });
+    const stop = configureGoogleCalendarStopMock(
+      [204],
+      [firstAccessToken, secondAccessToken],
+    );
+    const automation = await accept(
+      automationsClient().create({
+        headers: authHeaders(),
+        params: { workflowId: scenario.workflowId },
+        body: {
+          kind: "event",
+          eventType: "google-calendar-event-updated",
+        },
+      }),
+      [201],
+    );
+
+    const rejected = await accept(
+      automationsClient().update({
+        headers: authHeaders(),
+        params: { id: automation.body.id },
+        body: {
+          eventConfig: {
+            provider: "google-calendar",
+            event: "event_updated",
+            calendarId: stagedTarget,
+          },
+        },
+      }),
+      [400],
+    );
+
+    expect(rejected.body.error.message).toMatch(
+      /Google Calendar (account selection|watch target) changed/,
+    );
+    await expect(wf.readAutomation(automation.body.id)).resolves.toMatchObject({
+      id: automation.body.id,
+      enabled: true,
+      eventConfig: { calendarId: "primary" },
+    });
+    const finalAccounts = await connectorsApi.listBuiltinConnectorAccounts(
+      scenario.actor,
+      "google-calendar",
+    );
+    expect(
+      finalAccounts.find((account) => {
+        return account.id === secondAccountId;
+      }),
+    ).toMatchObject({ isDefault: true });
+    expect(watch.watchCalls).toBeGreaterThanOrEqual(2);
+    expect(
+      stop.requests.map((request) => {
+        return request.resourceId;
+      }),
+    ).toStrictEqual(
+      expect.arrayContaining(["calendar-resource-1", "calendar-resource-2"]),
+    );
   });
 
   it("keeps a shared Gmail watch until the last consumer and refreshes it for label re-enable", async () => {

--- a/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/automation-event-watch-lifecycle.service.ts
@@ -15,6 +15,7 @@ import {
 import {
   ensureGoogleCalendarWatchForUser,
   reconcileGoogleCalendarWatchesForUser,
+  stageGoogleCalendarWatchTargetForReconfiguration,
 } from "./google-calendar-automation-event.service";
 import {
   ensureGoogleFormsWatchForUser,
@@ -322,18 +323,29 @@ async function ensureNonFormsTarget(
             message:
               "Connect Google Calendar before using Google Calendar event automations",
           }
-        : await ensureGoogleCalendarWatchForUser(
-            {
-              db,
-              orgId: target.orgId,
-              userId: target.userId,
-              connectorId: target.connectorId,
-              calendarId: target.calendarId,
-              forceRefresh: false,
-              allowStagedOfficialTarget,
-            },
-            signal,
-          );
+        : allowStagedOfficialTarget
+          ? await stageGoogleCalendarWatchTargetForReconfiguration(
+              {
+                db,
+                orgId: target.orgId,
+                userId: target.userId,
+                connectorId: target.connectorId,
+                calendarId: target.calendarId,
+                forceRefresh: false,
+              },
+              signal,
+            )
+          : await ensureGoogleCalendarWatchForUser(
+              {
+                db,
+                orgId: target.orgId,
+                userId: target.userId,
+                connectorId: target.connectorId,
+                calendarId: target.calendarId,
+                forceRefresh: false,
+              },
+              signal,
+            );
   }
   signal.throwIfAborted();
   return result.kind === "ok"

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -368,7 +368,7 @@ export async function normalizeGoogleCalendarIdForConnector(
 
 async function resolveGoogleCalendarAccess(
   args: {
-    readonly db: Tx;
+    readonly db: Db;
     readonly orgId: string;
     readonly userId: string;
     readonly connectorId: string;
@@ -508,7 +508,7 @@ export async function googleCalendarAutomationTargetMatchesConnector(
  */
 export async function lockReadyGoogleCalendarWatchTarget(
   args: {
-    readonly db: Db;
+    readonly db: Tx;
     readonly orgId: string;
     readonly userId: string;
     readonly connectorId: string;

--- a/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
+++ b/turbo/apps/api/src/signals/services/google-calendar-automation-event.service.ts
@@ -323,6 +323,16 @@ function tokenNeedsRefresh(
   );
 }
 
+function normalizeGoogleCalendarId(
+  calendarId: string,
+  emailAddress: string | null,
+): string {
+  return emailAddress !== null &&
+    emailAddress.toLowerCase() === calendarId.toLowerCase()
+    ? GOOGLE_CALENDAR_PRIMARY_ID
+    : calendarId;
+}
+
 export async function normalizeGoogleCalendarIdForConnector(
   db: Db,
   args: {
@@ -350,16 +360,15 @@ export async function normalizeGoogleCalendarIdForConnector(
   if (loaded.kind === "missing" || loaded.kind === "unavailable") {
     return args.calendarId;
   }
-  const emailAddress = loaded.connection.externalEmail;
-  return emailAddress !== null &&
-    emailAddress.toLowerCase() === args.calendarId.toLowerCase()
-    ? GOOGLE_CALENDAR_PRIMARY_ID
-    : args.calendarId;
+  return normalizeGoogleCalendarId(
+    args.calendarId,
+    loaded.connection.externalEmail,
+  );
 }
 
 async function resolveGoogleCalendarAccess(
   args: {
-    readonly db: Db;
+    readonly db: Tx;
     readonly orgId: string;
     readonly userId: string;
     readonly connectorId: string;
@@ -464,6 +473,59 @@ async function resolveGoogleCalendarAccess(
       accessToken: refreshed.accessToken,
     },
   };
+}
+
+export async function googleCalendarAutomationTargetMatchesConnector(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId: string;
+    readonly requestedCalendarId: string;
+    readonly normalizedCalendarId: string;
+  },
+  signal: AbortSignal,
+): Promise<boolean> {
+  const access = await resolveGoogleCalendarAccess(
+    { ...args, refreshExpiredToken: false },
+    signal,
+  );
+  signal.throwIfAborted();
+  return (
+    access.kind === "ok" &&
+    normalizeGoogleCalendarId(
+      args.requestedCalendarId,
+      access.access.emailAddress,
+    ) === args.normalizedCalendarId
+  );
+}
+
+/**
+ * Lock a staged target through the caller's transaction and prove that the
+ * provider watch and baseline are still ready. Callers must already hold the
+ * connector-account lock so the shared account -> lifecycle lock order is
+ * preserved.
+ */
+export async function lockReadyGoogleCalendarWatchTarget(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorId: string;
+    readonly calendarId: string;
+  },
+  signal: AbortSignal,
+): Promise<boolean> {
+  await lockGoogleCalendarLifecycle(args.db, args.connectorId, args.calendarId);
+  signal.throwIfAborted();
+  const state = await loadCalendarWatchState(args, signal);
+  return (
+    state !== null &&
+    state.orgId === args.orgId &&
+    state.userId === args.userId &&
+    state.resourceId.length > 0 &&
+    !watchNeedsRefresh(state, nowDate())
+  );
 }
 
 function calendarApiUrl(path: string): string {
@@ -1767,14 +1829,17 @@ async function finalizePreparedCalendarWatch(args: {
   readonly calendarId: string;
   readonly prepared: PreparedGoogleCalendarWatch;
   readonly watch: z.infer<typeof calendarWatchResponseSchema>;
-  readonly allowStagedOfficialTarget?: boolean;
+  readonly allowStagedTarget?: boolean;
 }): Promise<
   | {
       readonly kind: "active";
       readonly state: GoogleCalendarWatchStateRow;
       readonly recoveredEpisode: GoogleCalendarWatchActionRequiredEpisode | null;
     }
-  | { readonly kind: "inactive" }
+  | {
+      readonly kind: "inactive";
+      readonly reason: "no_consumer" | "staged_target_lost";
+    }
 > {
   const lifecycleSignal = AbortSignal.timeout(WATCH_LIFECYCLE_TIMEOUT_MS);
   const currentTime = nowDate();
@@ -1797,6 +1862,9 @@ async function finalizePreparedCalendarWatch(args: {
       current.id !== args.prepared.stateId ||
       current.channelId !== args.prepared.channelId
     ) {
+      if (args.allowStagedTarget === true) {
+        return { kind: "inactive", reason: "staged_target_lost" };
+      }
       throw new Error("Failed to load pending Google Calendar watch state");
     }
     const recoveredEpisode = calendarWatchActionRequiredEpisode(current);
@@ -1810,8 +1878,8 @@ async function finalizePreparedCalendarWatch(args: {
       },
       lifecycleSignal,
     );
-    if (!hasConsumer && args.allowStagedOfficialTarget !== true) {
-      return { kind: "inactive" };
+    if (!hasConsumer && args.allowStagedTarget !== true) {
+      return { kind: "inactive", reason: "no_consumer" };
     }
     const [updated] = await tx
       .update(googleCalendarWatchStates)
@@ -1858,7 +1926,7 @@ async function activatePreparedCalendarWatch(args: {
   readonly access: GoogleCalendarAccess;
   readonly calendarId: string;
   readonly prepared: PreparedGoogleCalendarWatch;
-  readonly allowStagedOfficialTarget?: boolean;
+  readonly allowStagedTarget?: boolean;
 }): Promise<
   | { readonly kind: "ok"; readonly state: GoogleCalendarWatchStateRow }
   | {
@@ -1914,7 +1982,10 @@ async function activatePreparedCalendarWatch(args: {
     });
     return {
       kind: "bad_request",
-      message: "Google Calendar watch no longer has an enabled automation",
+      message:
+        finalization.reason === "staged_target_lost"
+          ? "Google Calendar watch target changed during setup"
+          : "Google Calendar watch no longer has an enabled automation",
     };
   }
 
@@ -1947,17 +2018,34 @@ async function activatePreparedCalendarWatch(args: {
   return { kind: "ok", state };
 }
 
-export async function ensureGoogleCalendarWatchForUser(
-  args: {
-    readonly db: Db;
-    readonly orgId: string;
-    readonly userId: string;
-    readonly connectorId: string;
-    readonly calendarId?: string;
-    readonly forceRefresh?: boolean;
-    readonly allowStagedOfficialTarget?: boolean;
-    readonly reportProviderFailure?: boolean;
-  },
+interface EnsureGoogleCalendarWatchArgs {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly connectorId: string;
+  readonly calendarId?: string;
+  readonly forceRefresh?: boolean;
+  readonly reportProviderFailure?: boolean;
+}
+
+interface EnsureGoogleCalendarWatchInternalArgs extends EnsureGoogleCalendarWatchArgs {
+  readonly allowStagedTarget?: boolean;
+}
+
+export interface StagedGoogleCalendarWatchTarget {
+  readonly connectorId: string;
+  readonly calendarId: string;
+}
+
+type StageGoogleCalendarWatchTargetResult =
+  | {
+      readonly kind: "ok";
+      readonly stagedTarget: StagedGoogleCalendarWatchTarget;
+    }
+  | Exclude<EnsureGoogleCalendarWatchResult, { readonly kind: "ok" }>;
+
+async function ensureGoogleCalendarWatchForUserInternal(
+  args: EnsureGoogleCalendarWatchInternalArgs,
   signal: AbortSignal,
 ): Promise<EnsureGoogleCalendarWatchResult> {
   const calendarId = args.calendarId ?? GOOGLE_CALENDAR_PRIMARY_ID;
@@ -1999,7 +2087,7 @@ export async function ensureGoogleCalendarWatchForUser(
       },
       signal,
     );
-    if (!hasConsumer && args.allowStagedOfficialTarget !== true) {
+    if (!hasConsumer && args.allowStagedTarget !== true) {
       return { kind: "unchanged" } as const;
     }
 
@@ -2052,7 +2140,7 @@ export async function ensureGoogleCalendarWatchForUser(
     access: prepared.access,
     calendarId,
     prepared: prepared.prepared,
-    allowStagedOfficialTarget: args.allowStagedOfficialTarget,
+    allowStagedTarget: args.allowStagedTarget,
   });
   if (registered.kind === "ok") {
     log.debug("Workflow watch lifecycle reconciled", {
@@ -2075,6 +2163,37 @@ export async function ensureGoogleCalendarWatchForUser(
           ? { providerFailure: registered.providerFailure }
           : {}),
       };
+}
+
+export async function ensureGoogleCalendarWatchForUser(
+  args: EnsureGoogleCalendarWatchArgs,
+  signal: AbortSignal,
+): Promise<EnsureGoogleCalendarWatchResult> {
+  return await ensureGoogleCalendarWatchForUserInternal(args, signal);
+}
+
+/**
+ * Establish a provider-ready watch before an automation starts consuming it.
+ * The returned target remains owned by the caller until the automation switch
+ * commits; callers must release it on every failed persistence path.
+ */
+export async function stageGoogleCalendarWatchTargetForReconfiguration(
+  args: EnsureGoogleCalendarWatchArgs & { readonly calendarId: string },
+  signal: AbortSignal,
+): Promise<StageGoogleCalendarWatchTargetResult> {
+  const result = await ensureGoogleCalendarWatchForUserInternal(
+    { ...args, allowStagedTarget: true },
+    signal,
+  );
+  return result.kind === "ok"
+    ? {
+        kind: "ok",
+        stagedTarget: {
+          connectorId: args.connectorId,
+          calendarId: args.calendarId,
+        },
+      }
+    : result;
 }
 
 interface LegacyPrimaryCalendarMigrationArgs {
@@ -2204,7 +2323,7 @@ async function migrateLegacyPrimaryCalendarWatch(
   args: LegacyPrimaryCalendarMigrationArgs,
   signal: AbortSignal,
 ): Promise<boolean> {
-  const ensured = await ensureGoogleCalendarWatchForUser(
+  const ensured = await stageGoogleCalendarWatchTargetForReconfiguration(
     {
       db: args.db,
       orgId: args.orgId,
@@ -2212,7 +2331,6 @@ async function migrateLegacyPrimaryCalendarWatch(
       connectorId: args.access.connectorId,
       calendarId: GOOGLE_CALENDAR_PRIMARY_ID,
       forceRefresh: true,
-      allowStagedOfficialTarget: true,
       reportProviderFailure: false,
     },
     signal,
@@ -2784,6 +2902,31 @@ async function reconcileGoogleCalendarWatchState(
     result: "ok",
   });
   return { kind: "renewed" };
+}
+
+export async function reconcileGoogleCalendarWatchTarget(
+  args: {
+    readonly db: Db;
+    readonly connectorId: string;
+    readonly calendarId: string;
+  },
+  signal: AbortSignal,
+): Promise<boolean> {
+  const result = await reconcileGoogleCalendarWatchState(args, signal);
+  return result.kind !== "failed";
+}
+
+export async function releaseStagedGoogleCalendarWatchTarget(
+  args: {
+    readonly db: Db;
+    readonly stagedTarget: StagedGoogleCalendarWatchTarget;
+  },
+  signal: AbortSignal,
+): Promise<boolean> {
+  return await reconcileGoogleCalendarWatchTarget(
+    { db: args.db, ...args.stagedTarget },
+    signal,
+  );
 }
 
 export async function reconcileGoogleCalendarWatchesForUser(

--- a/turbo/apps/api/src/signals/services/workflow-automation.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation.service.ts
@@ -101,8 +101,14 @@ import {
 } from "./notion-automation-account.service";
 import {
   ensureGoogleCalendarWatchForUser,
+  googleCalendarAutomationTargetMatchesConnector,
   hasEnabledGoogleCalendarConsumer,
+  lockReadyGoogleCalendarWatchTarget,
   normalizeGoogleCalendarIdForConnector,
+  reconcileGoogleCalendarWatchTarget,
+  releaseStagedGoogleCalendarWatchTarget,
+  stageGoogleCalendarWatchTargetForReconfiguration,
+  type StagedGoogleCalendarWatchTarget,
 } from "./google-calendar-automation-event.service";
 import { resolveGoogleCalendarAutomationConnectorId } from "./google-calendar-automation-account.service";
 import {
@@ -2267,6 +2273,19 @@ function parseGoogleCalendarEventConfig(
   return googleCalendarEventCancelledEventConfigSchema.parse(eventConfig);
 }
 
+function safeParseGoogleCalendarEventConfig(
+  eventType: GoogleCalendarAutomationEventType,
+  eventConfig: unknown,
+): GoogleCalendarAutomationEventConfig | null {
+  const result =
+    eventType === "google-calendar-event-created"
+      ? googleCalendarEventCreatedEventConfigSchema.safeParse(eventConfig)
+      : eventType === "google-calendar-event-updated"
+        ? googleCalendarEventUpdatedEventConfigSchema.safeParse(eventConfig)
+        : googleCalendarEventCancelledEventConfigSchema.safeParse(eventConfig);
+  return result.success ? result.data : null;
+}
+
 async function createGoogleCalendarEventAutomationForWorkflow(
   args: {
     readonly context: CreateEventAutomationWorkflowContext;
@@ -4055,7 +4074,8 @@ interface UpdateAutomationInput {
   readonly schedule?: WorkflowSchedule;
   readonly eventConfig?:
     | GmailAutomationEventConfig
-    | GithubAutomationEventConfig;
+    | GithubAutomationEventConfig
+    | GoogleCalendarAutomationEventConfig;
 }
 
 async function updateAutomationEventConfig(
@@ -4064,7 +4084,8 @@ async function updateAutomationEventConfig(
     readonly automationId: string;
     readonly eventConfig:
       | GmailAutomationEventConfig
-      | GithubAutomationEventConfig;
+      | GithubAutomationEventConfig
+      | GoogleCalendarAutomationEventConfig;
     readonly eventConnectorId?: string;
   },
   signal: AbortSignal,
@@ -4164,7 +4185,8 @@ async function updateGmailEventAutomationForWorkflow(
     };
     readonly eventConfig:
       | GmailAutomationEventConfig
-      | GithubAutomationEventConfig;
+      | GithubAutomationEventConfig
+      | GoogleCalendarAutomationEventConfig;
   },
   signal: AbortSignal,
 ): Promise<AutomationResult> {
@@ -4258,6 +4280,323 @@ async function updateGmailEventAutomationForWorkflow(
   return { kind: "ok", summary };
 }
 
+type GoogleCalendarReconfigurationPersistenceResult =
+  | { readonly kind: "ok"; readonly summary: WorkflowAutomationSummary }
+  | { readonly kind: "account-changed" }
+  | { readonly kind: "watch-changed" }
+  | { readonly kind: "automation-changed" };
+
+type GoogleCalendarAutomationUpdateEventConfig =
+  | GmailAutomationEventConfig
+  | GithubAutomationEventConfig
+  | GoogleCalendarAutomationEventConfig;
+
+interface GoogleCalendarAutomationUpdateArgs {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly member: WorkflowMember;
+  readonly automation: AutomationRow & {
+    readonly eventType: GoogleCalendarAutomationEventType;
+  };
+  readonly eventConfig: GoogleCalendarAutomationUpdateEventConfig;
+}
+
+type GoogleCalendarReconfigurationPreparationResult =
+  | {
+      readonly kind: "ok";
+      readonly eventConnectorId: string;
+      readonly eventConfig: GoogleCalendarAutomationEventConfig;
+      readonly requestedCalendarId: string;
+      readonly previousTarget: StagedGoogleCalendarWatchTarget | null;
+      readonly targetChanged: boolean;
+    }
+  | { readonly kind: "bad-request"; readonly message: string };
+
+function googleCalendarAutomationMatchesReconfigurationSource(
+  current: AutomationRow,
+  source: AutomationRow & {
+    readonly eventType: GoogleCalendarAutomationEventType;
+  },
+): boolean {
+  return (
+    current.orgId === source.orgId &&
+    current.workflowId === source.workflowId &&
+    current.ownerUserId === source.ownerUserId &&
+    current.kind === "event" &&
+    current.eventType === source.eventType &&
+    current.enabled === source.enabled &&
+    current.eventConnectorId === source.eventConnectorId &&
+    current.officialBlueprintKey === null &&
+    isDeepStrictEqual(current.eventConfig, source.eventConfig)
+  );
+}
+
+async function persistGoogleCalendarAutomationReconfiguration(
+  args: {
+    readonly db: Db;
+    readonly orgId: string;
+    readonly member: WorkflowMember;
+    readonly source: AutomationRow & {
+      readonly eventType: GoogleCalendarAutomationEventType;
+    };
+    readonly eventConnectorId: string;
+    readonly eventConfig: GoogleCalendarAutomationEventConfig;
+    readonly requestedCalendarId: string;
+    readonly requireReadyWatch: boolean;
+  },
+  signal: AbortSignal,
+): Promise<GoogleCalendarReconfigurationPersistenceResult> {
+  return await args.db.transaction(async (tx) => {
+    await lockConnectorAccountTarget(tx, {
+      orgId: args.orgId,
+      userId: args.member.userId,
+      target: { kind: "builtin", connectorSlug: "google-calendar" },
+    });
+    const selectedConnectorId =
+      await resolveGoogleCalendarAutomationConnectorId(tx, {
+        orgId: args.orgId,
+        userId: args.member.userId,
+        workflowId: args.source.workflowId,
+      });
+    signal.throwIfAborted();
+    if (selectedConnectorId !== args.eventConnectorId) {
+      return { kind: "account-changed" };
+    }
+    const targetMatchesConnector =
+      await googleCalendarAutomationTargetMatchesConnector(
+        {
+          db: tx,
+          orgId: args.orgId,
+          userId: args.member.userId,
+          connectorId: args.eventConnectorId,
+          requestedCalendarId: args.requestedCalendarId,
+          normalizedCalendarId: args.eventConfig.calendarId,
+        },
+        signal,
+      );
+    signal.throwIfAborted();
+    if (!targetMatchesConnector) {
+      return { kind: "account-changed" };
+    }
+    if (args.requireReadyWatch) {
+      const watchReady = await lockReadyGoogleCalendarWatchTarget(
+        {
+          db: tx,
+          orgId: args.orgId,
+          userId: args.member.userId,
+          connectorId: args.eventConnectorId,
+          calendarId: args.eventConfig.calendarId,
+        },
+        signal,
+      );
+      signal.throwIfAborted();
+      if (!watchReady) {
+        return { kind: "watch-changed" };
+      }
+    }
+
+    const [current] = await tx
+      .select(workflowAutomationColumns())
+      .from(workflowAutomations)
+      .where(
+        and(
+          eq(workflowAutomations.orgId, args.orgId),
+          eq(workflowAutomations.id, args.source.id),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    signal.throwIfAborted();
+    if (
+      !current ||
+      !googleCalendarAutomationMatchesReconfigurationSource(
+        current,
+        args.source,
+      )
+    ) {
+      return { kind: "automation-changed" };
+    }
+
+    const [updated] = await tx
+      .update(workflowAutomations)
+      .set({
+        eventConfig: args.eventConfig,
+        eventConnectorId: args.eventConnectorId,
+        updatedAt: nowDate(),
+      })
+      .where(eq(workflowAutomations.id, args.source.id))
+      .returning(workflowAutomationColumns());
+    signal.throwIfAborted();
+    if (!updated) {
+      throw new Error("Failed to update Google Calendar automation target");
+    }
+    return { kind: "ok", summary: await rowToSummary(tx, updated) };
+  });
+}
+
+async function prepareGoogleCalendarAutomationReconfiguration(
+  args: GoogleCalendarAutomationUpdateArgs,
+  signal: AbortSignal,
+): Promise<GoogleCalendarReconfigurationPreparationResult> {
+  const parsedConfig = safeParseGoogleCalendarEventConfig(
+    args.automation.eventType,
+    args.eventConfig,
+  );
+  if (parsedConfig === null) {
+    return {
+      kind: "bad-request",
+      message: "eventConfig must match the Google Calendar automation type",
+    };
+  }
+
+  const eventConnectorId = await resolveGoogleCalendarAutomationConnectorId(
+    args.db,
+    {
+      orgId: args.orgId,
+      userId: args.member.userId,
+      workflowId: args.automation.workflowId,
+    },
+  );
+  signal.throwIfAborted();
+  if (eventConnectorId === null) {
+    return {
+      kind: "bad-request",
+      message:
+        "Connect Google Calendar before using Google Calendar event automations",
+    };
+  }
+
+  const calendarId = await normalizeGoogleCalendarIdForConnector(
+    args.db,
+    {
+      orgId: args.orgId,
+      userId: args.member.userId,
+      connectorId: eventConnectorId,
+      calendarId: parsedConfig.calendarId,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+  const eventConfig = { ...parsedConfig, calendarId };
+  const previousConfig = parseGoogleCalendarEventConfig(
+    args.automation.eventType,
+    args.automation.eventConfig,
+  );
+  const previousTarget =
+    args.automation.eventConnectorId === null
+      ? null
+      : {
+          connectorId: args.automation.eventConnectorId,
+          calendarId: previousConfig.calendarId,
+        };
+  return {
+    kind: "ok",
+    eventConnectorId,
+    eventConfig,
+    requestedCalendarId: parsedConfig.calendarId,
+    previousTarget,
+    targetChanged:
+      previousTarget === null ||
+      previousTarget.connectorId !== eventConnectorId ||
+      previousTarget.calendarId !== eventConfig.calendarId,
+  };
+}
+
+async function releaseOwnedGoogleCalendarStagedTarget(
+  db: Db,
+  stagedTarget: StagedGoogleCalendarWatchTarget | null,
+): Promise<void> {
+  if (stagedTarget === null) {
+    return;
+  }
+  await bestEffort(
+    releaseStagedGoogleCalendarWatchTarget(
+      { db, stagedTarget },
+      new AbortController().signal,
+    ),
+  );
+}
+
+async function updateGoogleCalendarEventAutomationForWorkflow(
+  args: GoogleCalendarAutomationUpdateArgs,
+  signal: AbortSignal,
+): Promise<AutomationResult> {
+  const prepared = await prepareGoogleCalendarAutomationReconfiguration(
+    args,
+    signal,
+  );
+  if (prepared.kind !== "ok") {
+    return prepared;
+  }
+
+  let stagedTarget: StagedGoogleCalendarWatchTarget | null = null;
+  if (args.automation.enabled && prepared.targetChanged) {
+    const staged = await stageGoogleCalendarWatchTargetForReconfiguration(
+      {
+        db: args.db,
+        orgId: args.orgId,
+        userId: args.member.userId,
+        connectorId: prepared.eventConnectorId,
+        calendarId: prepared.eventConfig.calendarId,
+      },
+      signal,
+    );
+    if (staged.kind !== "ok") {
+      signal.throwIfAborted();
+      return { kind: "bad-request", message: staged.message };
+    }
+    stagedTarget = staged.stagedTarget;
+    if (signal.aborted) {
+      await releaseOwnedGoogleCalendarStagedTarget(args.db, stagedTarget);
+      signal.throwIfAborted();
+    }
+  }
+
+  const releaseStagedTarget = async (): Promise<void> => {
+    await releaseOwnedGoogleCalendarStagedTarget(args.db, stagedTarget);
+  };
+  const persistence = persistGoogleCalendarAutomationReconfiguration(
+    {
+      db: args.db,
+      orgId: args.orgId,
+      member: args.member,
+      source: args.automation,
+      eventConnectorId: prepared.eventConnectorId,
+      eventConfig: prepared.eventConfig,
+      requestedCalendarId: prepared.requestedCalendarId,
+      requireReadyWatch: args.automation.enabled && prepared.targetChanged,
+    },
+    signal,
+  );
+  const persisted =
+    stagedTarget === null
+      ? await persistence
+      : await onRejection(persistence, releaseStagedTarget);
+  if (persisted.kind !== "ok") {
+    await releaseStagedTarget();
+    return {
+      kind: "bad-request",
+      message:
+        persisted.kind === "account-changed"
+          ? "Google Calendar account selection changed; retry the update"
+          : persisted.kind === "watch-changed"
+            ? "Google Calendar watch target changed; retry the update"
+            : "Google Calendar automation changed; retry the update",
+    };
+  }
+
+  if (prepared.targetChanged && prepared.previousTarget !== null) {
+    const cleanupSignal = new AbortController().signal;
+    await bestEffort(
+      reconcileGoogleCalendarWatchTarget(
+        { db: args.db, ...prepared.previousTarget },
+        cleanupSignal,
+      ),
+    );
+  }
+  return { kind: "ok", summary: persisted.summary };
+}
+
 const updateEventAutomationForWorkflow$ = command(
   async (
     _,
@@ -4268,7 +4607,8 @@ const updateEventAutomationForWorkflow$ = command(
       readonly automation: AutomationRow;
       readonly eventConfig?:
         | GmailAutomationEventConfig
-        | GithubAutomationEventConfig;
+        | GithubAutomationEventConfig
+        | GoogleCalendarAutomationEventConfig;
     },
     signal: AbortSignal,
   ): Promise<AutomationResult> => {
@@ -4282,12 +4622,6 @@ const updateEventAutomationForWorkflow$ = command(
       return {
         kind: "bad-request",
         message: "Stripe invoice-paid event automations cannot be updated",
-      };
-    }
-    if (supportedGoogleCalendarEventType(args.automation.eventType)) {
-      return {
-        kind: "bad-request",
-        message: "Google Calendar event automations cannot be updated",
       };
     }
     if (supportedGoogleFormsEventType(args.automation.eventType)) {
@@ -4308,6 +4642,19 @@ const updateEventAutomationForWorkflow$ = command(
         kind: "bad-request",
         message: "eventConfig is required for event automations",
       };
+    }
+    if (supportedGoogleCalendarEventType(args.automation.eventType)) {
+      return await updateGoogleCalendarEventAutomationForWorkflow(
+        {
+          ...args,
+          automation: {
+            ...args.automation,
+            eventType: args.automation.eventType,
+          },
+          eventConfig: args.eventConfig,
+        },
+        signal,
+      );
     }
     if (supportedGithubEventType(args.automation.eventType)) {
       const eventConfig = await prepareGithubAutomationEventConfig(args.db, {

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1299,6 +1299,19 @@ function mockUpdateWorkflowAutomation(
             eventConfig: body.eventConfig,
           });
         }
+        if (body.eventConfig.provider === "google-calendar") {
+          const automation =
+            body.eventConfig.event === "event_created"
+              ? googleCalendarWorkflowAutomation()
+              : body.eventConfig.event === "event_updated"
+                ? googleCalendarUpdatedWorkflowAutomation()
+                : googleCalendarCancelledWorkflowAutomation();
+          return respond(200, {
+            ...automation,
+            id: params.id,
+            eventConfig: body.eventConfig,
+          } as WorkflowAutomationSummary);
+        }
         if (body.eventConfig.event === "label_applied") {
           return respond(200, {
             ...gmailLabelWorkflowAutomation(),

--- a/turbo/packages/api-contracts/src/contracts/__tests__/workflows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/workflows.test.ts
@@ -307,6 +307,34 @@ describe("Google Forms response-submitted workflow automation contract", () => {
   });
 });
 
+describe("Google Calendar workflow automation update contract", () => {
+  it("accepts each Calendar event configuration", () => {
+    const events = [
+      "event_created",
+      "event_updated",
+      "event_cancelled",
+    ] as const;
+
+    for (const event of events) {
+      expect(
+        workflowAutomationUpdateRequestSchema.parse({
+          eventConfig: {
+            provider: "google-calendar",
+            event,
+            calendarId: "team-calendar@example.com",
+          },
+        }),
+      ).toStrictEqual({
+        eventConfig: {
+          provider: "google-calendar",
+          event,
+          calendarId: "team-calendar@example.com",
+        },
+      });
+    }
+  });
+});
+
 describe("Google Meet transcript-generated workflow automation contract", () => {
   it("defaults to organizer-user scope", () => {
     const parsed = googleMeetTranscriptGeneratedEventConfigSchema.parse({

--- a/turbo/packages/api-contracts/src/contracts/workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/workflows.ts
@@ -500,10 +500,17 @@ export type GoogleCalendarEventCancelledEventConfig = z.infer<
   typeof googleCalendarEventCancelledEventConfigSchema
 >;
 
-export type GoogleCalendarAutomationEventConfig =
-  | GoogleCalendarEventCreatedEventConfig
-  | GoogleCalendarEventUpdatedEventConfig
-  | GoogleCalendarEventCancelledEventConfig;
+export const googleCalendarAutomationEventConfigSchema = z.discriminatedUnion(
+  "event",
+  [
+    googleCalendarEventCreatedEventConfigSchema,
+    googleCalendarEventUpdatedEventConfigSchema,
+    googleCalendarEventCancelledEventConfigSchema,
+  ],
+);
+export type GoogleCalendarAutomationEventConfig = z.infer<
+  typeof googleCalendarAutomationEventConfigSchema
+>;
 
 export const googleCalendarWatchActionRequiredReasonSchema = z.enum([
   "calendar_not_found",
@@ -1450,10 +1457,16 @@ export const workflowGithubEventAutomationUpdateRequestSchema = z.object({
   eventConfig: githubAutomationEventConfigSchema,
 });
 
+export const workflowGoogleCalendarEventAutomationUpdateRequestSchema =
+  z.object({
+    eventConfig: googleCalendarAutomationEventConfigSchema,
+  });
+
 export const workflowAutomationUpdateRequestSchema = z.union([
   workflowScheduleAutomationUpdateRequestSchema,
   workflowGmailEventAutomationUpdateRequestSchema,
   workflowGithubEventAutomationUpdateRequestSchema,
+  workflowGoogleCalendarEventAutomationUpdateRequestSchema,
 ]);
 export type WorkflowAutomationUpdateRequest = z.infer<
   typeof workflowAutomationUpdateRequestSchema


### PR DESCRIPTION
## summary

- add typed Google Calendar variants to the existing workflow automation PATCH contract
- stage and activate replacement Calendar baselines and provider watches before atomically switching enabled automation targets
- revalidate connector selection, connector readiness, normalization, and the exact source config under the established account lock; clean staged and old targets without disturbing shared consumers
- preserve automation identity, event type, enabled intent, runtime history, and unrelated fields across reconfiguration

## testing

- focused API contract test for all three Calendar event variants
- 7 focused workflow automation API tests covering enabled ordering, action-required recovery, disabled updates, baseline/provider rollback, config/account races, normalization, mismatch rejection, and shared-target isolation
- 2 focused Official Workflow Calendar lifecycle regression tests
- affected API and contract files pass Oxlint, type-aware Oxlint, ESLint, Prettier, and git diff checks

Closes #32424