### PR TITLE
docs(python): correct http error log destination in response hook

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1895,7 +1895,7 @@ def _finish_response_handling(
         ):
             invalidate_cached_firewall_headers(cache_key, cache_entry_identity)
 
-    # Log errors to per-job proxy log and mitmproxy console
+    # Log HTTP error responses to the per-job proxy JSONL log.
     if flow.response and flow.response.status_code >= _HTTP_STATUS_ERROR_MIN:
         url_projection = project_url_for_proxy_log(original_url)
         log_proxy_entry(


### PR DESCRIPTION
## Summary

- Correct the response-hook comment to identify the per-job proxy JSONL log as the destination for HTTP error responses.
- Remove the incorrect claim that the record is mirrored to the mitmproxy console.

## Scope

This is a documentation-only change in `crates/runner/mitm-addon/src/mitm_addon.py`. Runtime logging calls, URL projection, HTTP response handling, tests, and the separate addon process-event channel are unchanged.

Closes #32433

## Validation

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/test_response_handler_logging.py -k test_error_status_logs_warning` — 1 passed
- `uv run --no-sync python -m pytest tests/` — 7329 passed, 43 existing dependency/compatibility warnings
