### PR TITLE
test(mitm-addon): synchronize worker failure publication assertions

### DIFF
--- a/crates/runner/mitm-addon/tests/test_thread_helpers.py
+++ b/crates/runner/mitm-addon/tests/test_thread_helpers.py
@@ -27,24 +27,35 @@ def test_join_and_raise_propagates_worker_assertion_with_traceback():
     assert not thread.is_alive()
 
 
-def test_raise_if_failed_reports_completed_worker_failure_without_joining_first():
-    finished = threading.Event()
+def test_raise_if_failed_reports_completed_worker_failure():
+    target_signaled = threading.Event()
+    release = threading.Event()
 
     def fail_then_signal() -> None:
         try:
             raise RuntimeError("worker failed")
         finally:
-            finished.set()
+            target_signaled.set()
+            release.wait()
 
     thread = ThreadUnderTest(target=fail_then_signal)
-    thread.start()
-    assert finished.wait(timeout=1)
-
-    with pytest.raises(RuntimeError, match="worker failed"):
+    try:
+        thread.start()
+        assert target_signaled.wait(timeout=1)
+        assert thread.is_alive()
+        # The target has signaled, but the wrapper has not captured its failure.
         thread.raise_if_failed()
 
-    thread.join(timeout=1)
-    assert not thread.is_alive()
+        release.set()
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+
+        with pytest.raises(RuntimeError, match="worker failed"):
+            thread.raise_if_failed()
+    finally:
+        release.set()
+        thread.join(timeout=1)
+        assert not thread.is_alive()
 
 
 def test_wait_for_event_raises_worker_failure_before_timeout_message():
@@ -70,29 +81,40 @@ def test_wait_for_event_raises_worker_failure_before_timeout_message():
 
 def test_wait_for_event_raises_worker_failure_even_when_event_is_set():
     event = threading.Event()
-    finished = threading.Event()
+    target_signaled = threading.Event()
+    release = threading.Event()
 
     def signal_then_fail() -> None:
         try:
             event.set()
             raise RuntimeError("worker failed after event")
         finally:
-            finished.set()
+            target_signaled.set()
+            release.wait()
 
     thread = ThreadUnderTest(target=signal_then_fail)
-    thread.start()
-    assert finished.wait(timeout=1)
+    try:
+        thread.start()
+        assert target_signaled.wait(timeout=1)
+        assert thread.is_alive()
+        # An already-set event does not imply the worker failure is published.
+        wait_for_event(event, timeout=1, threads=(thread,))
 
-    with pytest.raises(RuntimeError, match="worker failed after event"):
-        wait_for_event(
-            event,
-            timeout=1,
-            threads=(thread,),
-            message="event was not signaled",
-        )
+        release.set()
+        thread.join(timeout=1)
+        assert not thread.is_alive()
 
-    thread.join(timeout=1)
-    assert not thread.is_alive()
+        with pytest.raises(RuntimeError, match="worker failed after event"):
+            wait_for_event(
+                event,
+                timeout=1,
+                threads=(thread,),
+                message="event was not signaled",
+            )
+    finally:
+        release.set()
+        thread.join(timeout=1)
+        assert not thread.is_alive()
 
 
 def test_join_and_raise_propagates_pytest_outcome_failures():


### PR DESCRIPTION
## Summary

Closes #32435.

- Fix two thread-helper tests that mistook a target-owned event for publication of the wrapper's captured exception.
- Hold each target in its failing `finally` block and check the still-running, not-yet-published state through the existing public helper methods. Release and join the worker, verify termination, and only then assert the captured RuntimeError.
- Always release and join in `finally`, including assertion failures; rename the completed-failure test to remove its unsupported no-join claim.

Only `tests/test_thread_helpers.py` changes. No production code, shared helper API, UI, deployment contract, dependencies, CI selection, sleeps, or timeout increases.

## Validation

From `crates/runner/mitm-addon`:

- `uv lock --check` and `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` — 0 errors/warnings/notes
- `uv run --no-sync python -m pytest tests/test_thread_helpers.py -q` — 11 passed
- `uv run --no-sync python -m pytest tests/test_auth_base_forwarder_lifecycle.py tests/test_thread_helpers.py -q` — 47 passed
- `uv run --no-sync python -m pytest tests/ -q` — **7329 passed**, 297.75s, on the unchanged revised source after environment preparation

Deterministic diagnostics reproduced both original tests' `DID NOT RAISE` failures while holding actual wrapper exception capture, then verified both revised tests pass when capture remains held until their completion join. A separate injected assertion failure verified each test's own `finally` releases and joins the held worker. Trace instrumentation was temporary and is not part of the PR.

The first full run returned 7328 passed / 1 failed in `test_deadline_aborts_deferred_tls_handshake`: its 50ms total forwarding deadline expired without entering the handshake. This happened before the changed tests ran; the TLS test and forwarding implementation are unchanged. Ran the required `scripts/prepare.sh` successfully, inspected the deadline path, and the focused 47-test run passed without source or timeout changes. This does not establish that environment preparation resolved that independent timing sensitivity.

## Risk

Test-only change with no online performance impact. Explicit join plus termination checks replace the invalid target-signal assumption. Existing one-second wait/join budgets remain, and failure cleanup releases the gate before joining. This addresses the demonstrated publication race, not every possible addon test flake.
