### PR TITLE
fix(platform): bypass opaque cache for annotated images

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.ts
@@ -578,6 +578,9 @@ export function createTestMocks(getSignal: () => AbortSignal) {
       ): ImageDimensionsMock => {
         return mockImageDimensions(getSignal(), results);
       },
+      requestCacheMode: (): void => {
+        mockRequestCacheMode(getSignal());
+      },
       canvasRendering: (): CanvasRenderingMock => {
         return mockCanvasRendering(getSignal());
       },
@@ -1450,6 +1453,33 @@ function mockCanvasRendering(signal: AbortSignal): CanvasRenderingMock {
   });
 
   return { clipCircles, imageDraws, renders };
+}
+
+function mockRequestCacheMode(signal: AbortSignal): void {
+  const NativeRequest = window.Request;
+  class RequestWithCacheMode extends NativeRequest {
+    constructor(input: RequestInfo | URL, init?: RequestInit) {
+      super(input, init);
+      Object.defineProperty(this, "cache", {
+        configurable: true,
+        enumerable: true,
+        value:
+          init?.cache ??
+          (input instanceof NativeRequest ? input.cache : "default"),
+      });
+    }
+  }
+
+  // Happy DOM does not expose Request.cache yet. Preserve it so HTTP boundary
+  // mocks can cover cache-sensitive browser behavior without mocking fetch.
+  const descriptor = defineWindowProperty(
+    window,
+    "Request",
+    RequestWithCacheMode,
+  );
+  restoreOnAbort(signal, () => {
+    restoreWindowProperty(window, "Request", descriptor);
+  });
 }
 
 function defineWindowProperty(

--- a/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
+++ b/turbo/apps/platform/src/signals/okou-page/flatten-annotated-image.ts
@@ -82,7 +82,10 @@ async function loadImage(
   url: string,
   signal: AbortSignal,
 ): Promise<HTMLImageElement> {
-  const response = await fetch(url, { signal });
+  // The preview renders this URL through a plain <img>, which can cache an
+  // opaque no-CORS response. Bypass that entry so this read performs the CORS
+  // request required for access to the image bytes.
+  const response = await fetch(url, { cache: "no-store", signal });
   if (!response.ok) {
     throw new Error(
       `Failed to read image for flattening: ${response.status} ${response.statusText}`,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-annotation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-attachment-annotation.test.tsx
@@ -219,6 +219,52 @@ test("A user can attach marks to a private image through its public URL", async 
   ).toBeNull();
 });
 
+test("A user can attach marks after previewing a public image", async () => {
+  const image = draftAttachment("cached-preview.png");
+  mockAttachmentChat(context, { draft: draftForAttachment(image, "") });
+  context.mocks.browser.requestCacheMode();
+  context.mocks.http.get(image.url, ({ request }) => {
+    // A plain cross-origin <img> can populate the browser cache with an opaque
+    // response. Reading pixels must bypass that entry and perform a CORS fetch.
+    if (request.cache !== "no-store") {
+      return HttpResponse.error();
+    }
+    return HttpResponse.arrayBuffer(new Uint8Array([1, 2, 3]).buffer, {
+      headers: { "Content-Type": "image/png" },
+    });
+  });
+  context.mocks.browser.imageDimensions({ width: 800, height: 500 });
+  context.mocks.browser.canvasRendering();
+  context.mocks.upload.success({
+    id: "a0000000-0000-4000-a000-000000000094",
+    filename: "cached-preview.annotated.png",
+    contentType: "image/png",
+    size: 11,
+    url: "https://files.example.test/cached-preview.annotated.png",
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${ATTACHMENT_THREAD_ID}`,
+    featureSwitches: { [FeatureSwitchKey.ComposerImageAnnotation]: true },
+  });
+
+  const surface = await openAnnotationEditor("cached-preview.png");
+  drawBox(surface);
+  click(await findNamedButton("Attach marks"));
+
+  await waitFor(() => {
+    expect(screen.queryByTestId("image-annotation-editor")).toBeNull();
+    expect(
+      screen.getByTestId("composer-attachment-mark-count"),
+    ).toHaveTextContent("1");
+    expect(screen.getByLabelText("Send")).toBeEnabled();
+  });
+  expect(
+    screen.queryByLabelText("Failed to upload cached-preview.png. Try again."),
+  ).toBeNull();
+});
+
 test("Retry attaching marks when the original image cannot be read", async () => {
   const image = draftAttachment("retry-billing.png");
   let imageReads = 0;


### PR DESCRIPTION
## Summary

- bypass an opaque no-CORS preview cache entry when reading an image for annotation flattening
- add page-level regression coverage for previewing and flattening the same public image URL
- preserve the standard `Request.cache` value in the Happy DOM test boundary so the cache-sensitive path is testable

## Root cause

A plain cross-origin `<img>` preview can cache an opaque response. A later CORS `fetch()` of the same URL may reuse that unreadable cache entry and fail with `TypeError: Failed to fetch`, before image decoding, canvas rendering, or annotated upload begins.

This is a follow-up to #32356. For fresh uploads, `resourceUrl` and `shareUrl` can be identical, so selecting the public URL does not change the browser cache key. The flattening read now uses `cache: "no-store"` to force the required CORS network request.

## Verification

- `pnpm vitest --run apps/platform/src/views/okou-page/__tests__/chat-attachment-annotation.test.tsx` (7 passed)
- regression test fails with `TypeError: Failed to fetch` when `cache: "no-store"` is removed and passes when restored
- `pnpm --filter @okouai/app check-types`
- targeted Oxlint, type-aware Oxlint, and ESLint checks
- repository pre-commit hooks: Prettier, Knip, full monorepo type checks, and file-size check
