### PR TITLE
fix(guest-storage-apply): preserve pending download overlay order

### DIFF
--- a/crates/guest-storage-apply/src/download.rs
+++ b/crates/guest-storage-apply/src/download.rs
@@ -351,7 +351,7 @@ pub(crate) fn prepare_download_tasks(
 
 /// Download all prepared tasks in parallel using std::thread.
 /// Limits active archive attempts to MAX_CONCURRENT and serializes logically or
-/// physically overlapping mount paths across each task's complete retry cycle.
+/// physically overlapping mount paths in task order across complete retry cycles.
 /// Returns true if all downloads succeeded, false if any failed.
 pub(crate) fn download_all_parallel(tasks: Vec<PreparedDownloadTask>) -> bool {
     download_all_parallel_with_runner(tasks, run_download_attempt)
@@ -445,17 +445,31 @@ fn find_startable_download(
     reservations: &[DownloadReservation],
     on_conflict: &mut impl FnMut(usize, &Path, usize, &Path),
 ) -> Option<(usize, usize)> {
-    // Scan the pending queue instead of using strict FIFO so a reserved
-    // parent/child mount-path conflict does not leave a slot idle when a later
-    // independent task can start.
+    // Independent tasks may bypass blocked work, but conflicting tasks must
+    // retain their order even when the earlier task has not started yet.
     for (index, download) in pending.iter().enumerate() {
         if let Some((blocking, pending_path, reserved_path)) =
             reservations.iter().find_map(|reservation| {
-                conflicting_mount_paths(&download.task, reservation)
-                    .map(|(pending_path, reserved_path)| (reservation, pending_path, reserved_path))
+                conflicting_mount_paths(
+                    &download.task,
+                    &reservation.logical_mount_path,
+                    &reservation.effective_mount_path,
+                )
+                .map(|(pending_path, reserved_path)| (reservation, pending_path, reserved_path))
             })
         {
             on_conflict(download.id, pending_path, blocking.id, reserved_path);
+            continue;
+        }
+
+        if pending.iter().take(index).any(|earlier| {
+            conflicting_mount_paths(
+                &download.task,
+                earlier.task.logical_mount_path(),
+                earlier.task.effective_mount_path(),
+            )
+            .is_some()
+        }) {
             continue;
         }
 
@@ -465,21 +479,16 @@ fn find_startable_download(
     None
 }
 
-fn conflicting_mount_paths<'pending, 'reserved>(
+fn conflicting_mount_paths<'pending, 'other>(
     pending: &'pending PreparedDownloadTask,
-    reserved: &'reserved DownloadReservation,
-) -> Option<(&'pending Path, &'reserved Path)> {
-    if mount_paths_conflict(pending.logical_mount_path(), &reserved.logical_mount_path) {
-        return Some((pending.logical_mount_path(), &reserved.logical_mount_path));
+    other_logical: &'other Path,
+    other_effective: &'other Path,
+) -> Option<(&'pending Path, &'other Path)> {
+    if mount_paths_conflict(pending.logical_mount_path(), other_logical) {
+        return Some((pending.logical_mount_path(), other_logical));
     }
-    if mount_paths_conflict(
-        pending.effective_mount_path(),
-        &reserved.effective_mount_path,
-    ) {
-        return Some((
-            pending.effective_mount_path(),
-            &reserved.effective_mount_path,
-        ));
+    if mount_paths_conflict(pending.effective_mount_path(), other_effective) {
+        return Some((pending.effective_mount_path(), other_effective));
     }
     None
 }

--- a/crates/guest-storage-apply/src/telemetry.rs
+++ b/crates/guest-storage-apply/src/telemetry.rs
@@ -41,6 +41,8 @@
 //! increment these metrics. These values are therefore not counts of unique
 //! tasks or unique path pairs. Each observation contributes to the total and
 //! exactly one of the three classified conflict families.
+//! Ordering checks against earlier pending tasks do not add observations; these
+//! counters retain their reservation-conflict semantics.
 //!
 //! The run also emits
 //! `guest_storage_apply_framework_home_instructions_task_{present,absent}`. This is

--- a/crates/guest-storage-apply/tests/integration/scheduling.rs
+++ b/crates/guest-storage-apply/tests/integration/scheduling.rs
@@ -10,6 +10,8 @@
 //! deterministic scheduler pressure. Bounded waits are assertion deadlines and
 //! failure detectors; they are not sleeps used to make scheduling happen.
 
+mod pending_order;
+
 use crate::binary_logging::BinaryLoggingFixture;
 #[cfg(unix)]
 use crate::process;

--- a/crates/guest-storage-apply/tests/integration/scheduling/pending_order.rs
+++ b/crates/guest-storage-apply/tests/integration/scheduling/pending_order.rs
@@ -1,0 +1,135 @@
+//! Pending conflicts must preserve overlay order without blocking independent work.
+
+use super::{
+    COMPLETION_TIMEOUT, REQUEST_START_TIMEOUT, ReleaseGate, RequestObservations, path_to_string,
+    serve_archive, serve_blocked_archive, spawn_guest_storage_apply, wait_for_event,
+};
+use crate::support::create_tar_gz;
+use httpmock::MockServer;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+
+fn assert_pending_overlay_order(
+    dir: &tempfile::TempDir,
+    mounts: [PathBuf; 4],
+    physical_parent: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let servers: [MockServer; 4] = std::array::from_fn(|_| MockServer::start());
+    let archives = [
+        create_tar_gz(&[("a.txt", b"blocker")])?,
+        create_tar_gz(&[("b/value.txt", b"parent")])?,
+        create_tar_gz(&[("value.txt", b"child")])?,
+        create_tar_gz(&[("data.txt", b"independent")])?,
+    ];
+    let names = ["blocker", "parent", "child", "independent"];
+    let observations = RequestObservations::new();
+    let blocker_release = ReleaseGate::new();
+    let (event_tx, event_rx) = mpsc::channel();
+    for ((server, body), name) in servers.iter().zip(archives).zip(names) {
+        let event_tx = event_tx.clone();
+        let on_start = move || {
+            event_tx
+                .send(name.to_owned())
+                .map_err(|error| format!("failed to send {name} start: {error}"))
+        };
+        if name == "blocker" {
+            serve_blocked_archive(
+                server,
+                "/archive.tar.gz",
+                body,
+                on_start,
+                blocker_release.waiter(),
+                name.to_owned(),
+                observations.clone(),
+            );
+        } else {
+            serve_archive(
+                server,
+                "/archive.tar.gz",
+                body,
+                on_start,
+                name.to_owned(),
+                observations.clone(),
+            );
+        }
+    }
+    let storages = mounts
+        .iter()
+        .zip(&servers)
+        .map(|(mount, server)| Ok((path_to_string(mount)?, server.url("/archive.tar.gz"))))
+        .collect::<std::io::Result<Vec<_>>>()?;
+    let execution = spawn_guest_storage_apply("pending-overlay-order", dir, &storages)?;
+
+    // D must start while A is held: this also rejects a global-FIFO fix.
+    let mut seen = Vec::new();
+    for name in ["blocker", "independent"] {
+        wait_for_event(&event_rx, &mut seen, name, REQUEST_START_TIMEOUT)?;
+    }
+    blocker_release.release_one();
+    execution.wait_for_completion(
+        "pending-overlay-order",
+        COMPLETION_TIMEOUT,
+        &blocker_release,
+        &observations,
+    )?;
+
+    let starts = observations.snapshot().started;
+    let parent_start = starts
+        .iter()
+        .position(|name| name == "parent")
+        .ok_or("parent request did not start")?;
+    let child_start = starts
+        .iter()
+        .position(|name| name == "child")
+        .ok_or("child request did not start")?;
+    let final_content = std::fs::read_to_string(physical_parent.join("b/value.txt"))?;
+    assert_eq!(
+        (parent_start < child_start, final_content.as_str()),
+        (true, "child"),
+        "pending parent must precede its child; starts={starts:?}"
+    );
+    assert_eq!(starts.len(), 4, "unexpected retries: {starts:?}");
+    assert_eq!(
+        std::fs::read_to_string(physical_parent.join("a/a.txt"))?,
+        "blocker"
+    );
+    assert_eq!(
+        std::fs::read_to_string(mounts[3].join("data.txt"))?,
+        "independent"
+    );
+    Ok(())
+}
+
+#[test]
+fn pending_parent_precedes_later_child_while_independent_download_starts() {
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().join("mount");
+    let mounts = [
+        parent.join("a"),
+        parent.clone(),
+        parent.join("b"),
+        dir.path().join("independent"),
+    ];
+    assert_pending_overlay_order(&dir, mounts, &parent).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn canonical_pending_parent_precedes_later_aliased_child() {
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().join("physical");
+    let mounts = [
+        dir.path().join("blocker-alias"),
+        dir.path().join("parent-alias"),
+        dir.path().join("child-alias"),
+        dir.path().join("independent"),
+    ];
+    for (target, alias) in [parent.join("a"), parent.clone(), parent.join("b")]
+        .iter()
+        .zip(&mounts)
+    {
+        std::fs::create_dir_all(target).unwrap();
+        std::os::unix::fs::symlink(target, alias).unwrap();
+    }
+    assert_pending_overlay_order(&dir, mounts, &parent).unwrap();
+}


### PR DESCRIPTION
## Summary

Closes #32436.

Preserve overlay order when an earlier download is still pending behind an active task. For A mounted at `M/a`, B at `M`, and C at `M/b`, C must not bypass B and then be overwritten by it.

- Check each candidate against both existing reservations and earlier pending tasks, using the same logical/canonical path-conflict predicate.
- Keep genuinely independent later tasks eligible; retain four active attempts, reservations through retry backoff, and existing failure/panic behavior.
- Add real-binary regressions for ordinary paths and distinct symlink aliases, including independent D. Request-start gates prove independent progress; assertions verify parent-before-child ordering and final child content.
- Clarify that existing telemetry counters continue to count reservation conflicts, not pending-only ordering checks.

## Validation

Run from `crates/` with `CARGO_BUILD_JOBS=4` for Cargo build commands:

- Regression tests on unchanged production code: both failed as expected, with child-before-parent requests and final content `parent` despite successful helper exits.
- Fixed-code targeted regressions: both passed.
- `cargo test --profile local -p guest-storage-apply -- --test-threads=4`: 90 library tests and 79 integration tests passed; zero ignored.
- `cargo fmt -p guest-storage-apply -- --check`
- `cargo clippy --profile local -p guest-storage-apply --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local -p guest-storage-apply --no-deps`
- `cargo run --profile local -p xtask -- check-rust-path-attributes`
- `git diff --check`

No test skips, timeout increases, new dependencies or internal mocks.

## Scope and risks

No manifest/API/persisted-state/archive-format change, runtime option, telemetry schema change or concurrency tuning. #32414 remains separate performance work.

Checking earlier pending tasks adds path comparisons on blocked prefixes; one selection can be quadratic and repeated scans can amplify total work. Correctly serialized overlaps can take longer than the previous incorrect bypass. No high-fanout benchmark or production latency improvement is claimed. Canonical identities still come from preparation before extraction; this does not introduce a new guarantee for dynamic alias mutation.
