### PR TITLE
fix(mitm-addon): bound unicode path normalization work

### DIFF
--- a/crates/runner/mitm-addon/src/path_security.py
+++ b/crates/runner/mitm-addon/src/path_security.py
@@ -10,6 +10,8 @@ _DOT_SEGMENTS = {".", ".."}
 _HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
 _MAX_PERCENT_DECODE_PASSES = 5
 _PERCENT_ESCAPE_LENGTH = 3
+# UAX #15 stream-safe limit, measured after compatibility decomposition.
+_MAX_CONSECUTIVE_NONSTARTERS = 30
 # Match the addon's existing 64 KiB request-work scale. Character count bounds
 # Python string processing without first scanning and allocating encoded bytes.
 MAX_PATH_VALIDATION_CHARACTERS = 64 * 1024
@@ -72,11 +74,32 @@ def _segment_has_unsafe_path(raw_segment: str) -> bool:
 def _segment_has_unsafe_syntax(segment: str) -> bool:
     if _segment_has_unsafe_syntax_parts(segment):
         return True
+    if _segment_exceeds_normalization_budget(segment):
+        return True
 
     normalized = unicodedata.normalize(_COMPATIBILITY_NORMALIZATION_FORM, segment)
     return normalized != segment and (
         "%" in normalized or _segment_has_unsafe_syntax_parts(normalized)
     )
+
+
+def _segment_exceeds_normalization_budget(segment: str) -> bool:
+    if segment.isascii():
+        return False
+
+    nonstarters = 0
+    for char in segment:
+        # Decompose only one code point at a time: whole-segment NFKD would
+        # already perform the potentially quadratic canonical reordering.
+        # Raw combining classes miss expansions such as U+0F73 and U+FF9E.
+        for decomposed in unicodedata.normalize("NFKD", char):
+            if unicodedata.combining(decomposed):
+                nonstarters += 1
+                if nonstarters > _MAX_CONSECUTIVE_NONSTARTERS:
+                    return True
+            else:
+                nonstarters = 0
+    return False
 
 
 def _segment_has_unsafe_syntax_parts(segment: str) -> bool:

--- a/crates/runner/mitm-addon/tests/test_request_path_normalization_budget.py
+++ b/crates/runner/mitm-addon/tests/test_request_path_normalization_budget.py
@@ -1,0 +1,135 @@
+"""Unicode work bounds through real header and request classification hooks."""
+
+import json
+import unicodedata
+import urllib.parse
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
+
+
+@pytest.fixture
+def path_firewall_registry(tmp_path: Path) -> Path:
+    return _write_registry(
+        tmp_path,
+        sandbox_info=_single_firewall_sandbox(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("segment", "decode_passes"),
+    [
+        pytest.param("a" + "\u0315\u0300" * 16000, 0, id="long-alternating"),
+        pytest.param("a" + "\u0300" * 16000 + "\u0315" * 16000, 0, id="long-ordered"),
+        pytest.param("a" + "\u0315\u0300" * 4096, 1, id="long-percent-encoded"),
+        pytest.param("\u0300" * 31, 0, id="leading-nonstarters"),
+        pytest.param("a" + "\u0344" * 16, 0, id="decomposition-expansion"),
+        pytest.param("a" + "\u0f73" * 16, 0, id="class-zero-decomposition"),
+        pytest.param("a" + "\uff9e" * 31, 0, id="compatibility-nonstarter"),
+        pytest.param("\u00e9" + "\u0300" * 30, 0, id="precomposed-trailing-mark"),
+        pytest.param("a" + "\u0315\u0300" * 16, 2, id="nested-percent-encoded"),
+        pytest.param("a" + "\u0f73" * 16, 5, id="final-decode-pass"),
+        pytest.param("a" + "\u0300" * 15 + "%CC%80" * 16, 0, id="mixed-raw-and-encoded"),
+    ],
+)
+async def test_path_normalization_budget_blocks_before_unbounded_work(
+    path_firewall_registry,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    monkeypatch: pytest.MonkeyPatch,
+    segment: str,
+    decode_passes: int,
+):
+    encoded_segment = segment
+    for _ in range(decode_passes):
+        encoded_segment = urllib.parse.quote(encoded_segment, safe="")
+    path = f"/repos/{encoded_segment}"
+    assert len(path) < 65536
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com", path=path)
+    normalize = unicodedata.normalize
+    rejected_segment = urllib.parse.unquote(segment)
+    decomposed_characters = 0
+
+    def bounded_normalize(form: Literal["NFC", "NFD", "NFKC", "NFKD"], text: str) -> str:
+        nonlocal decomposed_characters
+        if form == "NFKD":
+            assert len(text) == 1, "budget checks must only decompose single code points"
+            decomposed_characters += 1
+        else:
+            assert text != rejected_segment, "rejected segments must not reach normalization"
+        return normalize(form, text)
+
+    monkeypatch.setattr(unicodedata, "normalize", bounded_normalize)
+    with (
+        mitm_ctx(registry_path=str(path_firewall_registry)),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        header_characters = decomposed_characters
+        assert header_characters > 0
+        assert "Authorization" not in flow.request.headers
+
+        await mitm_addon.request(flow)
+        assert decomposed_characters > header_characters
+
+    auth_fetch.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert json.loads(flow.response.content)["reason"] == "unsafe_path"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.request.path == path
+    assert "Authorization" not in flow.request.headers
+
+
+@pytest.mark.parametrize(
+    "segment",
+    [
+        pytest.param("a" + "\u0315\u0300" * 15, id="at-limit"),
+        pytest.param("\u0300" * 30, id="leading-at-limit"),
+        pytest.param("a" + "\u0344" * 15, id="expansion-at-limit"),
+        pytest.param("a" + "\u0f73" * 15, id="class-zero-at-limit"),
+        pytest.param("\u00e9" + "\u0300" * 29, id="precomposed-at-limit"),
+        pytest.param(("a" + "\u0315\u0300" * 15) * 1000, id="starter-resets"),
+        pytest.param("\u6587" * 32000, id="long-unicode"),
+        pytest.param(
+            "caf\u00e9/\u6587\u6863/\uac01/\U0001f469\u200d\U0001f4bb", id="ordinary-unicode"
+        ),
+        pytest.param("caf%C3%A9/%E6%96%87%E6%A1%A3", id="encoded-unicode"),
+    ],
+)
+async def test_path_normalization_budget_preserves_supported_requests(
+    path_firewall_registry, real_flow, mitm_ctx, fake_firewall_headers, segment: str
+):
+    path = f"/repos/{segment}"
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com", path=path)
+    with (
+        mitm_ctx(registry_path=str(path_firewall_registry)),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.request.headers["Authorization"] == "Bearer resolved"
+    assert flow.request.path == path

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -123,6 +123,35 @@ metadata, and this contract together. The
 [`test_mitmproxy_websocket_framing.py`](../../crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py)
 suite must continue to pass as the executable framing contract.
 
+## Path normalization work boundary
+
+Path safety validation accepts at most 65,536 input characters and five percent
+decoding passes. Before whole-segment NFKC, each raw or decoded segment must have
+at most 30 consecutive non-starters after compatibility decomposition (NFKD).
+This is the [UAX #15 stream-safe input boundary](https://www.unicode.org/reports/tr15/#Stream_Safe_Text_Format):
+the addon rejects unsupported paths; it does not insert characters or rewrite
+the request path. Already ordered sequences above the limit are rejected too.
+
+The guard decomposes one code point at a time and counts nonzero canonical
+combining classes across decompositions. This catches characters with class zero
+that decompose into marks, as well as multi-mark expansions. It never applies
+NFKD to an unbounded segment. With bounded non-starter runs, the subsequent
+whole-segment NFKC cannot perform unbounded canonical reordering per character.
+The Unicode scan adds linear work; the plain-ASCII fast path is unchanged.
+
+Long starter-separated Unicode paths remain supported within the total limit.
+Existing dot/matrix syntax, malformed escapes, UTF-8, compatibility syntax, and
+decode-depth checks remain in place. Matching rejects over-budget paths with the
+existing `unsafe_path` decision before credentials are resolved. Shared base and
+auth-rewrite URL validation uses the same boundary. During runner rollout, old
+runners retain the previous pathological-input behavior until drained; no wire
+format or persisted data changes.
+
+`test_request_path_normalization_budget.py` exercises both real addon request
+phases, observes the standard-library normalization boundary, and checks denial
+before auth as well as successful unchanged Unicode paths. Correctness tests use
+structural assertions rather than elapsed-time thresholds.
+
 ## Environment Setup
 
 The addon uses uv for dependency management. The supported devcontainer installs


### PR DESCRIPTION
## Summary

Closes #32434.

- Bound consecutive non-starters to 30 after per-code-point NFKD decomposition, before whole-segment NFKC. Reject unsupported input through the existing unsafe-path decision.
- Apply the same bound at every percent-decoding stage, including the final permitted stage; preserve the plain-ASCII fast path and existing whole-segment syntax validation.
- Add 20 real requestheaders/request integration cases covering structural normalization bounds, raw/encoded/mixed paths, expansion and class-zero decomposition, exact accepted boundaries, long Unicode, and unchanged successful auth/path behavior.
- Document the boundary and rollout behavior. No URL rewriting, new dependencies, caches, async tasks, API/schema changes, Rust changes, or production traffic.

## Validation

All checks ran sequentially in the foreground:

- `scripts/prepare.sh`
- `uv lock --check` and `uv sync --locked`
- `uv run --no-sync ruff format --check .` and `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`: zero errors/warnings
- `uv run --no-sync python -m pytest tests/ -q --tb=short`: **7,349 passed**, no skips (43 dependency/generated-fixture warnings)
- Prettier parser validation for the full updated guide and format validation for the added section
- `git diff --check`

The initial new test helper/annotation mistakes were corrected before these passing results. Unrelated Rust/Turbo application suites were not run locally; cross-language checks remain CI-owned.

## Local before/after diagnostics

Compared the baseline helper from `5d80a5a5ff` with this branch in the same pinned CPython 3.14.0 environment. Medians are wall-clock observations on a contended local machine, not test thresholds or latency guarantees (three samples for mark/hook cases; 100 for ordinary direct-path cases).

| Direct path input | Characters | Before ms | After ms |
| --- | ---: | ---: | ---: |
| Ordered marks | 8,194 | 0.2493 | 0.0243 |
| Alternating marks | 8,194 | 122.7314 | 0.0438 |
| Ordered marks | 16,386 | 2.6646 | 0.0473 |
| Alternating marks | 16,386 | 421.3024 | 0.0581 |
| Ordered marks | 32,002 | 0.9451 | 0.0847 |
| Alternating marks | 32,002 | 1,822.8889 | 0.5391 |
| ASCII | 30 | 0.0011 | 0.0012 |
| Ordinary Unicode | 11 | 0.0045 | 0.0065 |
| Encoded Unicode | 29 | 0.0144 | 0.0118 |
| Long Chinese text | 32,001 | 0.4092 | 9.7999 |

Raw ordered/alternating inputs above the new bound now return unsafe; ordinary inputs retain their previous safe result. For the largest alternating input through real hooks, header/request/callback-delay medians changed from **1,689.01 / 1,898.32 / 3,589.63 ms** to **1.09 / 2.83 / 5.34 ms**. Both versions returned 403 under the diagnostic deny policy, without auth or upstream traffic. Committed allowing-policy tests separately verify unchanged success for supported input. Structural assertions, not these noisy timings, prove that rejected segments cannot reach whole-segment normalization in either phase.

## Risks and compatibility

- Formerly accepted sequences above 30 decomposed non-starters now fail closed, even when already ordered. This is based on the [UAX #15 stream-safe input boundary](https://www.unicode.org/reports/tr15/#Stream_Safe_Text_Format), without inserting CGJ or otherwise changing URLs.
- A new linear Unicode scan costs more for giant ordinary Unicode paths, as shown above. This deliberately preserves long starter-separated paths instead of applying a much shorter Unicode-segment length limit. Plain-ASCII code is unchanged.
- Shared base/auth-rewrite/platform-path validation inherits the same boundary. No wire or persisted-data format changes; old runners retain the old pathological-input behavior until drained.
- Full deployed-runner behavior and the current head's CI status remain to be verified by the PR pipeline. No merge is requested.
