### PR TITLE
test(rust): synchronize deferred firecracker socket readiness

### DIFF
--- a/crates/sandbox-firecracker/src/api/client.rs
+++ b/crates/sandbox-firecracker/src/api/client.rs
@@ -91,6 +91,8 @@ const SNAPSHOT_CREATE_TIMEOUT: Duration = Duration::from_secs(120);
 pub struct ApiClient {
     socket_path: PathBuf,
     http: reqwest::Client,
+    #[cfg(test)]
+    pub(super) socket_wait_started: Option<std::sync::Arc<tokio::sync::Notify>>,
 }
 
 impl ApiClient {
@@ -108,6 +110,8 @@ impl ApiClient {
         Ok(Self {
             socket_path: socket_path.to_owned(),
             http: http::build_client(socket_path)?,
+            #[cfg(test)]
+            socket_wait_started: None,
         })
     }
 
@@ -122,13 +126,20 @@ impl ApiClient {
             .await
             .unwrap_or(false)
         {
-            tokio::time::timeout_at(deadline, wait_for_socket_file(&self.socket_path))
-                .await
-                .map_err(|_| {
-                    ApiError::Other(format!(
-                        "timed out after {timeout:?} waiting for socket file"
-                    ))
-                })??;
+            tokio::time::timeout_at(
+                deadline,
+                wait_for_socket_file(
+                    &self.socket_path,
+                    #[cfg(test)]
+                    self.socket_wait_started.as_deref(),
+                ),
+            )
+            .await
+            .map_err(|_| {
+                ApiError::Other(format!(
+                    "timed out after {timeout:?} waiting for socket file"
+                ))
+            })??;
         }
 
         // Phase 2: poll GET / until the API responds with success.
@@ -505,7 +516,10 @@ impl ApiClient {
 }
 
 /// Wait for a file to appear using inotify (event-driven, no polling).
-async fn wait_for_socket_file(socket_path: &Path) -> Result<(), ApiError> {
+async fn wait_for_socket_file(
+    socket_path: &Path,
+    #[cfg(test)] socket_wait_started: Option<&tokio::sync::Notify>,
+) -> Result<(), ApiError> {
     let dir = socket_path
         .parent()
         .ok_or_else(|| ApiError::Other("socket path has no parent directory".into()))?;
@@ -526,6 +540,13 @@ async fn wait_for_socket_file(socket_path: &Path) -> Result<(), ApiError> {
     // Inotify implements AsFd but not AsRawFd; convert to OwnedFd for AsyncFd.
     let fd: OwnedFd = inotify.into();
     let async_fd = AsyncFd::new(fd).map_err(|e| ApiError::Other(format!("AsyncFd: {e}")))?;
+
+    // Keep this milestone after the post-watch absence check so deferred-socket
+    // tests cannot pass through either existing-file fast path.
+    #[cfg(test)]
+    if let Some(started) = socket_wait_started {
+        started.notify_one();
+    }
 
     loop {
         let mut guard = async_fd

--- a/crates/sandbox-firecracker/src/api/tests.rs
+++ b/crates/sandbox-firecracker/src/api/tests.rs
@@ -332,14 +332,33 @@ async fn load_snapshot_can_leave_vm_paused() {
 async fn wait_for_ready_detects_deferred_socket() {
     let (mut api, bind_socket) = MockFirecrackerApi::deferred_repeating(MockResponse::ok());
     let sock_path = api.socket_path().to_path_buf();
-    let waiter = tokio::spawn(async move {
-        let client = ApiClient::new(&sock_path).unwrap();
-        client.wait_for_ready(Duration::from_secs(2)).await
-    });
+    let socket_wait_started = Arc::new(Notify::new());
+    let mut client = ApiClient::new(&sock_path).unwrap();
+    client.socket_wait_started = Some(socket_wait_started.clone());
+    let waiter = client.wait_for_ready(Duration::from_secs(2));
+    tokio::pin!(waiter);
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::select! {
+            biased;
+            result = &mut waiter => panic!("readiness completed before socket creation: {result:?}"),
+            () = socket_wait_started.notified() => {}
+        }
+    })
+    .await
+    .expect("readiness should reach the post-watch socket wait");
+
+    assert!(!sock_path.try_exists().unwrap());
+    assert!(
+        futures_util::poll!(&mut waiter).is_pending(),
+        "readiness should remain pending while the watched socket is absent"
+    );
 
     bind_socket.send(()).unwrap();
-    let result = waiter.await.unwrap();
-    assert!(result.is_ok());
+    tokio::time::timeout(Duration::from_secs(2), waiter)
+        .await
+        .expect("socket creation should wake readiness")
+        .expect("the deferred socket should become ready");
 
     let request = api.next_request().await;
     assert_request(&request, "GET", "/");


### PR DESCRIPTION
## Summary

Closes #32438.

- Synchronize the existing deferred-socket readiness test with a per-client, test-only milestone after inotify watch installation and the negative post-watch existence check.
- Keep the socket absent until that milestone, assert readiness is still pending, then allow the real Unix socket server to bind and require successful readiness plus GET /.
- Own the readiness future in the test and bound both synchronization and completion. Preserve the existing two-second readiness budget and already-present-socket coverage.

This fixes a regression-test coverage gap, not a demonstrated production readiness incident. The notification field, parameter and call are all `cfg(test)`; production readiness logic, startup latency, public APIs, deployment compatibility and CI shard selection are unchanged. No new dependency, sleep, skip, or test case is added.

## Validation

Sequential foreground checks from `crates/`:

- `cargo fmt --all --check`
- `cargo clippy --profile local -p sandbox-firecracker --all-targets --all-features`
- `cargo doc --profile local -p sandbox-firecracker --all-features --no-deps`
- `cargo test --profile local -p sandbox-firecracker --all-targets --all-features -- --quiet`: **861 passed**, 0 failed; one existing host-CPU-fairness integration test is ignored by repository default because it requires root, Firecracker fixtures, NBD and delegated cgroup v2.
- All 7 readiness tests passed; repeated the restored deferred test **50 times sequentially**, all passed.
- `git diff --check`

### Mutation evidence

Temporarily inserted an indefinitely pending future immediately before `async_fd.readable()`, blocking usable event wakeup without changing the milestone or server. The deferred test failed within its existing two-second budget with `timed out after 2s waiting for socket file`; the other six readiness tests, including the already-present socket case, passed. Removed the mutation before all final checks and submission.

## Risks and limits

The milestone must remain after the negative post-watch recheck; its placement is documented next to the hook. Observation does not substitute for the real inotify/HTTP path. No production rollout or migration is needed.

The required post-pull local database migration was attempted and failed because PostgreSQL at 127.0.0.1:5432 is unavailable; these Rust tests do not depend on it. Full remote CI and hardware-backed tests are not claimed as locally verified.
