### PR TITLE
fix(platform): align pinned chat move menu labels

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-thread-reorder.tsx
@@ -62,7 +62,7 @@ export function ThreadPinMoveMenuItems({
           return detach(move(signals.threadId, -1, signal), Reason.DomCallback);
         }}
       >
-        <ArrowUp />
+        <ArrowUp size={16} className="mr-2" />
         {t(($) => {
           return $.chat.sidebar.movePinUp;
         })}
@@ -72,7 +72,7 @@ export function ThreadPinMoveMenuItems({
           return detach(move(signals.threadId, 1, signal), Reason.DomCallback);
         }}
       >
-        <ArrowDown />
+        <ArrowDown size={16} className="mr-2" />
         {t(($) => {
           return $.chat.sidebar.movePinDown;
         })}


### PR DESCRIPTION
## Summary

The pinned chat menu renders “Move up” and “Move down” 8 px to the left of the other action labels because their icons omit the margin used by the neighboring items. Apply the same 16 px icon size and right margin so all labels align.

## Verification

- Prettier check and `git diff --check` passed.
- Compared both icons with the existing pin, mark unread, rename, and delete menu items.
- This is a styling-only change; existing menu reordering coverage is in `sidebar-pin-order.test.tsx`. Full tests and static analysis are left to the PR pipeline, as requested. No local dev server or browser preview was run.
