### PR TITLE
fix(platform): align chat avatars without work folding

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-message-surface.tsx
@@ -13,10 +13,11 @@ export const CHAT_THREAD_RESPONSE_STACK_CLASS = "flex min-w-0 flex-col gap-2";
 export const CHAT_THREAD_RESPONSE_COMPACT_STACK_CLASS =
   "flex min-w-0 flex-col gap-2 group-data-[run-work-folding]/chat:gap-1";
 
-// Standalone response lines share a 36px frame around the original 15px * 1.7
-// line. Dense history previews and follow-up items keep their own line metrics.
+// Wide response lines align with the 36px avatar regardless of work folding.
+// Folding uses the same frame on narrow layouts. Dense history previews and
+// follow-up items keep their own line metrics.
 export const CHAT_THREAD_RESPONSE_LINE_CLASS =
-  "group-data-[run-work-folding]/chat:h-auto group-data-[run-work-folding]/chat:min-h-9 group-data-[run-work-folding]/chat:py-[calc((2.25rem-1lh)/2)] group-data-[run-work-folding]/chat:leading-[1.59375rem]";
+  "@[900px]:h-auto @[900px]:min-h-9 @[900px]:py-[calc((2.25rem-1lh)/2)] @[900px]:leading-[1.59375rem] group-data-[run-work-folding]/chat:h-auto group-data-[run-work-folding]/chat:min-h-9 group-data-[run-work-folding]/chat:py-[calc((2.25rem-1lh)/2)] group-data-[run-work-folding]/chat:leading-[1.59375rem]";
 
 // Bare response icons share the 28px action-button rail when the run-work
 // information architecture is active. Their intrinsic width remains the
@@ -34,7 +35,7 @@ export const CHAT_THREAD_ASSISTANT_MESSAGE_ROW_CLASS =
   "flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start";
 
 export const CHAT_THREAD_ASSISTANT_AVATAR_FRAME_CLASS =
-  "h-7 w-7 shrink-0 overflow-hidden rounded-xl @[900px]:mt-0.5 @[900px]:h-9 @[900px]:w-9 @[900px]:group-data-[run-work-folding]/chat:mt-0";
+  "h-7 w-7 shrink-0 overflow-hidden rounded-xl @[900px]:h-9 @[900px]:w-9";
 
 export const CHAT_THREAD_ASSISTANT_AVATAR_IMAGE_CLASS =
   "h-7 w-7 rounded-full object-cover object-top @[900px]:h-9 @[900px]:w-9";

--- a/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
+++ b/turbo/apps/platform/src/views/shared-thread-page/shared-thread-page.tsx
@@ -33,6 +33,7 @@ import {
   CHAT_THREAD_CONTENT_MAIN_CLASS,
   CHAT_THREAD_MESSAGE_LIST_CLASS,
   CHAT_THREAD_MESSAGE_STACK_PULL_CLASS,
+  CHAT_THREAD_RESPONSE_LINE_CLASS,
   CHAT_THREAD_USER_MESSAGE_ACTIONS_CLASS,
   CHAT_THREAD_USER_MESSAGE_ROW_CLASS,
 } from "../okou-page/chat-message-surface.tsx";
@@ -215,7 +216,10 @@ function SharedAssistantGroup({
         <div className="relative flex min-w-0 flex-col gap-2">
           {group.messages.map((message) => {
             return (
-              <ChatAssistantMessageBody key={message.messageIndex}>
+              <ChatAssistantMessageBody
+                key={message.messageIndex}
+                className={CHAT_THREAD_RESPONSE_LINE_CLASS}
+              >
                 {message.tree === undefined && richContent !== undefined ? (
                   <SharedRichMessageBody
                     messageIndex={message.messageIndex}


### PR DESCRIPTION
With `chatRunWorkFolding` disabled, assistant text and the initial thinking indicator sit above the avatar after #31791 removed their vertical padding. Apply the existing 36px response-line frame whenever the wide avatar layout is active, remove the avatar's 2px offset, and reuse those metrics in shared conversations.

The existing folding layout and compact history rows retain their metrics. Narrow layouts without folding keep their current spacing, and multiline replies grow naturally.

## Validation

- Prettier and `git diff --check` passed.
- Platform lint, type checks, and workspace Knip passed.
- All PR CI checks passed, including platform tests and browser E2E checks ([run](https://github.com/vm0-ai/vm0/actions/runs/34183017350)).
- Actual PR Preview browser checks passed:
  - Folding OFF, desktop: the initial thinking label, single-line reply, and first line of a multiline reply align with the 36px avatar center, with a measured 0px vertical offset.
  - Folding ON, desktop: the thinking label retains its 36px frame and 0px center offset.
  - Folding OFF, mobile: the existing 28px avatar and unpadded reply layout remain intact, with no horizontal overflow.
  - Shared conversation, desktop: the first reply line aligns with the avatar center, with a measured 0px offset.

Screenshots from the deployed PR: [thinking detail](https://a.okou.io/k45u1ykwpb.png), [reply detail](https://a.okou.io/zbj2i35xc2.png), [mobile reply](https://a.okou.io/1lnxt5og7h.png), [shared conversation](https://a.okou.io/qhyd7q64jy.png). Detail images are crops or element captures of actual browser screenshots.

<details>
<summary>Browser verification configuration</summary>

- PR head: `4a2b8ec2128fab03982549f0569a0d384194377e`.
- Deployed merge SHA, confirmed in both deployment logs: `c2300096c48e84f425373bdf16d66b3222e19fcf`.
- App: https://pr-32487-app-okou-app-preview.vm0.workers.dev
- API: https://pr-32487-api.vm6.ai
- Viewports: 1440 × 1000 and 390 × 844; Linux Chromium 152.0.0.0.
- User agent: `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36`.
- Disposable Clerk test account with a Stripe TEST Pro subscription; onboarding bypassed through the preview onboarding endpoint because onboarding is outside this change.
- `chatRunWorkFolding=false`, `chatThinkingSpinner=true`, `_realAgentInPreview=false`; folding was temporarily enabled for its regression check and restored to false. `sharedThreadSharing=true` for the shared-page check. Switches were verified through Lab controls and effective API state.
- Claude Fable 5.1 selected; deterministic preview mock fixtures supplied a pending run and completed single-/multiline replies. The pending fixture was stopped after capture. No real agent or external action was needed.
- Preview access was established separately for App/API. Shared-page navigation additionally required the preview query parameter for the metadata fetch.

</details>
