### PR TITLE
test(runner): exercise contended baseline observations

### DIFF
--- a/crates/runner/src/executor/storage_baseline_observation.rs
+++ b/crates/runner/src/executor/storage_baseline_observation.rs
@@ -82,9 +82,28 @@ struct Observation {
 /// persisted, hashed, or converted to stable pseudonyms.
 pub(crate) struct StorageBaselineObserver {
     previous: Mutex<HashMap<ObservationKey, Vec<CandidateIdentity>>>,
+    #[cfg(test)]
+    test_probe: Option<Box<dyn Fn(BaselineObservationTestEvent) + Send + Sync>>,
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum BaselineObservationTestEvent {
+    BeforeLock { contended: bool },
+    BeforeFirstInsert,
 }
 
 impl StorageBaselineObserver {
+    #[cfg(test)]
+    pub(super) fn with_test_probe(
+        probe: impl Fn(BaselineObservationTestEvent) + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            test_probe: Some(Box::new(probe)),
+            ..Self::default()
+        }
+    }
+
     /// Record the current baseline-candidate observation and its bounded telemetry dimensions.
     ///
     /// Only read-only manifest entries with `baseline_candidate` set are considered. Their
@@ -167,11 +186,24 @@ impl StorageBaselineObserver {
         candidates: Vec<CandidateIdentity>,
     ) -> Observation {
         let candidate_count = candidates.len();
+        #[cfg(test)]
+        if let Some(probe) = &self.test_probe {
+            // Drop any acquired guard before the probe coordinates another caller.
+            let contended = matches!(
+                self.previous.try_lock(),
+                Err(std::sync::TryLockError::WouldBlock)
+            );
+            probe(BaselineObservationTestEvent::BeforeLock { contended });
+        }
         let mut previous_by_key = self
             .previous
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let Some(previous) = previous_by_key.get_mut(&key) else {
+            #[cfg(test)]
+            if let Some(probe) = &self.test_probe {
+                probe(BaselineObservationTestEvent::BeforeFirstInsert);
+            }
             previous_by_key.insert(key, candidates);
             return Observation {
                 outcome: "first",

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -15,6 +15,9 @@ use sandbox::{
 use sandbox_mock::{MockSandbox, MockSandboxFactory, MockSandboxOverrides};
 
 use super::super::env::guest_connector_account_context_file_path;
+use super::super::storage_baseline_observation::{
+    BaselineObservationTestEvent, StorageBaselineObserver,
+};
 use super::super::telemetry::{
     RunnerPreSpawnPhase, elapsed_since_api_start_ms, record_api_startup_boundaries,
     record_reuse_result,
@@ -1183,7 +1186,7 @@ async fn execute_job_observes_exact_baseline_stability_per_profile_and_framework
 }
 
 #[tokio::test]
-async fn execute_job_serializes_concurrent_baseline_observations() {
+async fn execute_job_shares_baseline_observations_across_sequential_jobs() {
     const STABILITY: &str = "runner_storage_baseline_candidate_stability";
 
     let dir = tempfile::tempdir().unwrap();
@@ -1199,16 +1202,99 @@ async fn execute_job_serializes_concurrent_baseline_observations() {
         vec![baseline_storage("seed", "/seed", "version")],
     );
 
-    let (first, second) = tokio::join!(
-        execute_cancelled_observation(&config, first_context, &first_params),
-        execute_cancelled_observation(&config, second_context, &second_params),
+    let first = execute_cancelled_observation(&config, first_context, &first_params).await;
+    let second = execute_cancelled_observation(&config, second_context, &second_params).await;
+    assert_eq!(successful_bounded_outcome(&first, STABILITY), "first");
+    assert_eq!(successful_bounded_outcome(&second, STABILITY), "same");
+}
+
+#[test]
+fn baseline_observation_serializes_parallel_callers() {
+    const WAIT: Duration = Duration::from_secs(5);
+    const STABILITY: &str = "runner_storage_baseline_candidate_stability";
+
+    let (events, observations) = mpsc::channel();
+    let (release_first, first_release) = mpsc::channel();
+    let first_release = Mutex::new(Some(first_release));
+    let observer = StorageBaselineObserver::with_test_probe(move |event| match event {
+        BaselineObservationTestEvent::BeforeLock { .. } => events.send(event).unwrap(),
+        BaselineObservationTestEvent::BeforeFirstInsert => {
+            // Pause only the first caller, even if a split-lock regression lets
+            // another caller also observe a missing key.
+            let release = first_release.lock().unwrap().take();
+            if let Some(release) = release {
+                events.send(event).unwrap();
+                assert_ne!(
+                    release.recv_timeout(WAIT),
+                    Err(mpsc::RecvTimeoutError::Timeout)
+                );
+            }
+        }
+    });
+    let context = context_with_baseline(
+        "claude-code",
+        vec![baseline_storage("seed", "/seed", "version")],
     );
+    let params = default_params();
+    let record = |mut telemetry: JobTelemetry| {
+        observer.record(&context, &params, &mut telemetry);
+        telemetry
+    };
+    // Keep HTTP-client construction outside the coordinated contention window.
+    let first_telemetry = new_telemetry();
+    let second_telemetry = new_telemetry();
+
+    let (first, second) = std::thread::scope(|scope| {
+        // Own the sender inside the scope callback: unwinding disconnects the
+        // paused worker before scope cleanup joins it.
+        let release_first = release_first;
+        let first = scope.spawn(|| record(first_telemetry));
+        assert_eq!(
+            observations.recv_timeout(WAIT).unwrap(),
+            BaselineObservationTestEvent::BeforeLock { contended: false }
+        );
+        assert_eq!(
+            observations.recv_timeout(WAIT).unwrap(),
+            BaselineObservationTestEvent::BeforeFirstInsert
+        );
+
+        // The first caller has read the absent key but has not inserted it.
+        // A separate OS thread now enters the same production observer.
+        let second = scope.spawn(|| record(second_telemetry));
+        let second_entry = observations.recv_timeout(WAIT);
+        let released = release_first.send(());
+        drop(release_first);
+        let first = first.join();
+        let second = second.join();
+
+        assert_eq!(
+            second_entry.unwrap(),
+            BaselineObservationTestEvent::BeforeLock { contended: true },
+            "the first observation must hold the state lock between lookup and insertion"
+        );
+        released.unwrap();
+        (first.unwrap(), second.unwrap())
+    });
+
     let mut outcomes = [
         successful_bounded_outcome(&first, STABILITY),
         successful_bounded_outcome(&second, STABILITY),
     ];
     outcomes.sort();
     assert_eq!(outcomes, ["first", "same"]);
+
+    let subsequent = record(new_telemetry());
+    assert_eq!(successful_bounded_outcome(&subsequent, STABILITY), "same");
+    for telemetry in [&first, &second, &subsequent] {
+        for (action, expected) in [
+            ("runner_storage_baseline_candidate_count", "1"),
+            ("runner_storage_baseline_added_count", "0"),
+            ("runner_storage_baseline_removed_count", "0"),
+            ("runner_storage_baseline_changed_at_path_count", "0"),
+        ] {
+            assert_eq!(successful_bounded_outcome(telemetry, action), expected);
+        }
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Preserve the two-job executor integration scenario as explicitly sequential coverage; `tokio::join!` did not make its synchronous observer calls concurrent.
- Exercise the real baseline observer and telemetry from two independent OS threads, pausing the first after its missing-key lookup and verifying the second encounters the state lock before releasing the first.
- Assert exactly one `first`, one `same`, and coherent subsequent telemetry/counts. Use instance-local test-only probes, bounded channel waits and scoped thread cleanup; keep HTTP-client setup outside the contention window.

This closes a regression-coverage gap, not an observed production race. All new observer fields and calls are behind `cfg(test)`; the production single-mutex algorithm, storage decisions, telemetry schema, dependencies and CI configuration are unchanged. A future synchronization redesign will need equivalent atomicity coverage in place of these mutex-specific probes.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=1 cargo clippy --profile local --all-targets --all-features`
- `CARGO_INCREMENTAL=1 cargo doc --profile local --workspace --all-features --no-deps`
- `CARGO_INCREMENTAL=1 cargo test --profile local -p runner --bin runner executor::tests::telemetry_tests -- --test-threads=4`: 30 passed, including all three baseline tests; 0 failed/ignored.
- `git diff --check`

Mutation check: temporarily dropped the state guard after the missing-key lookup and reacquired it before insertion, without changing the new test. `CARGO_INCREMENTAL=1 cargo test --profile local -p runner --bin runner baseline -- --nocapture --test-threads=1` produced 2 passes (the sequential tests) and 1 expected failure: the new concurrency test reported `BeforeLock { contended: false }` instead of `true`. Removed the mutation, verified both source hashes against their intended pre-mutation versions, and reran the 30 telemetry tests successfully. The mutant is not included in this PR.

Incremental compilation was enabled only through command-local environment settings. Full Rust tests and runner E2E remain for the normal CI selection; unrelated Turbo/Python suites were not run locally.

Closes #32437
