### PR TITLE
fix(platform): remove optimistic directed authorization state

### DIFF
--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-slug.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-slug.ts
@@ -82,20 +82,6 @@ export const setDirectedAuthorizeConnectModalKey$ = command(
   },
 );
 
-function connectorAgentAuthorizationKey(args: {
-  readonly connectorSlug: ConnectorSlug;
-  readonly agentId: string;
-}): string {
-  return `${args.agentId}:${args.connectorSlug}`;
-}
-
-const internalAuthorized$ = state<Set<string>>(new Set());
-
-/** Whether the connector has just been authorized (optimistic). */
-export const justAuthorizedConnectorAgentKeys$ = computed((get) => {
-  return get(internalAuthorized$);
-});
-
 /** Authorize a connector for the given agent via user-connectors API. */
 export const authorizeConnector$ = command(
   async (
@@ -124,23 +110,5 @@ export const authorizeConnector$ = command(
       },
     );
     signal.throwIfAborted();
-
-    // Optimistic update
-    set(internalAuthorized$, (prev) => {
-      return new Set([
-        ...prev,
-        connectorAgentAuthorizationKey({ connectorSlug, agentId }),
-      ]);
-    });
   },
 );
-
-export function isJustAuthorizedConnectorAgent(
-  justAuthorizedKeys: ReadonlySet<string>,
-  args: {
-    readonly connectorSlug: ConnectorSlug;
-    readonly agentId: string;
-  },
-): boolean {
-  return justAuthorizedKeys.has(connectorAgentAuthorizationKey(args));
-}

--- a/turbo/apps/platform/src/views/okou-page/__tests__/directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/directed-authorize-page.test.tsx
@@ -166,6 +166,20 @@ function mockConnectorOpenIdStart(args?: { readonly onStart?: () => void }): {
 
 test("Authorize an agent to use an already connected connector", async () => {
   mockConnectedConnector("gmail");
+  let authorized = false;
+  context.mocks.api(userConnectorsContract.get, ({ respond }) => {
+    return respond(200, {
+      enabledConnectorSlugs: authorized ? ["gmail"] : [],
+    });
+  });
+  context.mocks.api(userConnectorsContract.update, ({ body, respond }) => {
+    expect(body).toStrictEqual({
+      enabledConnectorSlugs: ["gmail"],
+      operation: "add",
+    });
+    authorized = true;
+    return respond(200, { enabledConnectorSlugs: ["gmail"] });
+  });
   const threadId = "00000000-0000-4000-a000-000000000101";
   const callbackPrompt = "Re-check Gmail, then continue";
   let continuationPrompt: string | null = null;
@@ -200,6 +214,45 @@ test("Authorize an agent to use an already connected connector", async () => {
       version: 1,
       parts: [{ type: "text", text: callbackPrompt }],
     });
+  });
+});
+
+test("Wait for refreshed authorization state instead of updating optimistically", async () => {
+  mockConnectedConnector("gmail");
+  const releaseUpdate = context.mocks.deferred<void>();
+  context.mocks.api(userConnectorsContract.get, ({ respond }) => {
+    return respond(200, { enabledConnectorSlugs: [] });
+  });
+  context.mocks.api(
+    userConnectorsContract.update,
+    async ({ body, respond }) => {
+      expect(body).toStrictEqual({
+        enabledConnectorSlugs: ["gmail"],
+        operation: "add",
+      });
+      await releaseUpdate.promise;
+      return respond(200, { enabledConnectorSlugs: ["gmail"] });
+    },
+  );
+
+  await setupPage({
+    context,
+    path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+  });
+
+  click(await screen.findByText("Authorize Zero"));
+
+  await waitFor(() => {
+    expect(screen.queryByText("Authorize Zero")).not.toBeInTheDocument();
+    expect(screen.queryByText("Gmail authorized")).not.toBeInTheDocument();
+  });
+
+  releaseUpdate.resolve();
+
+  await waitFor(() => {
+    expect(screen.getByText("Authorize Zero")).toBeInTheDocument();
+    expect(screen.queryByText("Gmail authorized")).not.toBeInTheDocument();
+    expect(screen.queryByText("Authorized")).not.toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/okou-page/directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/directed-authorize-page.tsx
@@ -1,4 +1,5 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { Button } from "@okouai/ui";
 import {
   connectorSlugSchema,
@@ -29,9 +30,7 @@ import {
   directedAuthorizeAgentId$,
   directedAuthorizeAgentName$,
   agentEnabledConnectorSlugs$,
-  justAuthorizedConnectorAgentKeys$,
   authorizeConnector$,
-  isJustAuthorizedConnectorAgent,
   directedAuthorizeConnectModalKey$,
   setDirectedAuthorizeConnectModalKey$,
 } from "../../signals/connectors-page/directed-authorize-slug.ts";
@@ -146,8 +145,8 @@ function useDirectedAuthorizeCatalogState(connectorSlug: ConnectorSlug | null) {
 function useDirectedAuthorizePermissionState(
   connectorSlug: ConnectorSlug | null,
   agentId: string | null,
+  isAuthorizing: boolean,
 ) {
-  const justAuthorizedKeys = useGet(justAuthorizedConnectorAgentKeys$);
   const enabledLoadable = useLastLoadable(agentEnabledConnectorSlugs$);
   const enabledData =
     agentId !== null &&
@@ -161,15 +160,12 @@ function useDirectedAuthorizePermissionState(
     isAuthorized:
       connectorSlug !== null &&
       agentId !== null &&
-      (isJustAuthorizedConnectorAgent(justAuthorizedKeys, {
-        connectorSlug,
-        agentId,
-      }) ||
-        enabledConnectorSlugs.includes(connectorSlug)),
+      enabledConnectorSlugs.includes(connectorSlug),
     permissionLoading:
-      agentId !== null &&
-      (enabledLoadable.state === "loading" ||
-        (enabledLoadable.state === "hasData" && enabledData === null)),
+      isAuthorizing ||
+      (agentId !== null &&
+        (enabledLoadable.state === "loading" ||
+          (enabledLoadable.state === "hasData" && enabledData === null))),
   };
 }
 
@@ -369,7 +365,7 @@ function DirectedAuthorizeCard() {
   const connectFlowConnectorSlug = useGet(connectFlowConnectorSlug$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const connectNoAuth = useSet(connectConnectorNoAuth$);
-  const authorize = useSet(authorizeConnector$);
+  const [authorizeLoadable, authorize] = useLoadableSet(authorizeConnector$);
   const reloadAuthorization = useSet(reloadAgentConnectorAuthorizations$);
   const signal = useGet(pageSignal$);
   const setDirectedAuthorizeConnectModalKey = useSet(
@@ -385,6 +381,7 @@ function DirectedAuthorizeCard() {
     useDirectedAuthorizePermissionState(
       connectorSlugForState,
       params?.agentId ?? null,
+      authorizeLoadable.state === "loading",
     );
   const connectModalOpen = useDirectedAuthorizeConnectModalOpen(
     connectorSlugForState,


### PR DESCRIPTION
## Summary

- remove the module-level optimistic authorization cache from directed connector authorization
- show the existing card loading state while an authorization update is pending
- derive the final authorized state only from the refreshed server response
- add regression coverage for pending and server-authoritative UI states

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/directed-authorize-page.test.tsx --maxWorkers=1` (7 passed)
- `pnpm -F @okouai/app check-types`
- targeted Prettier, Oxlint, type-aware Oxlint, and ESLint checks
- `git diff --check`
