### PR TITLE
fix(platform): authorize visible agents on the first connector account

### DIFF
--- a/docs/custom-mcp-connectors.md
+++ b/docs/custom-mcp-connectors.md
@@ -44,4 +44,8 @@ Custom OAuth app supports `client_secret_basic` and `client_secret_post` at the 
 
 Each member can add and reconnect accounts through the same connector account flow. Reconnect always targets the selected account; it does not replace a sibling account. Connecting from an Agent surface grants that Agent access only after the selected account is connected.
 
+Connecting or reconnecting from the Connectors list grants connector-level access to all agents currently visible to that member in the active organization, including the default agent. This applies to built-in connectors and custom HTTP/MCP connectors. It does not backfill previously connected accounts or automatically authorize agents created later. Failed or cancelled connection attempts do not grant access.
+
+Custom connectors with a permission bundle still require explicit permission selection; connecting an account does not select or overwrite those fine-grained permissions. Existing grants for other connectors are retained.
+
 If an Automatic OAuth account receives a valid insufficient-scope challenge during a run, the CLI provides an Okou authorization link. Complete the new consent and start a new run. The failed MCP operation is not replayed, and the current run keeps its original credential snapshot.

--- a/docs/custom-mcp-connectors.md
+++ b/docs/custom-mcp-connectors.md
@@ -44,7 +44,7 @@ Custom OAuth app supports `client_secret_basic` and `client_secret_post` at the 
 
 Each member can add and reconnect accounts through the same connector account flow. Reconnect always targets the selected account; it does not replace a sibling account. Connecting from an Agent surface grants that Agent access only after the selected account is connected.
 
-Connecting or reconnecting from the Connectors list grants connector-level access to all agents currently visible to that member in the active organization, including the default agent. This applies to built-in connectors and custom HTTP/MCP connectors. It does not backfill previously connected accounts or automatically authorize agents created later. Failed or cancelled connection attempts do not grant access.
+Adding an account from the Connectors list grants connector-level access to all agents currently visible to that member in the active organization, including the default agent, only when the connector had no accounts before the connection started. This applies to built-in connectors and custom HTTP/MCP connectors. Adding another account or reconnecting an existing account preserves Agent access, including access the user manually revoked. Accounts that need reconnecting still count as existing accounts. Removing every account and then adding one triggers automatic authorization again. This does not backfill previously connected accounts or automatically authorize agents created later. Failed or cancelled connection attempts do not grant access.
 
 Custom connectors with a permission bundle still require explicit permission selection; connecting an account does not select or overwrite those fine-grained permissions. Existing grants for other connectors are retained.
 

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -99,6 +99,28 @@ function shouldAuthorizeAgent(options: PostConnectOptions): boolean {
   return Boolean(options.authorizeVisibleAgents || options.agentId);
 }
 
+const resolveConnectorPostConnectOptions$ = command(
+  async (
+    { get },
+    connectorSlug: ConnectorSlug,
+    options: PostConnectOptions,
+    signal: AbortSignal,
+  ): Promise<PostConnectOptions> => {
+    if (!options.authorizeVisibleAgents) {
+      return options;
+    }
+    const authorizeVisibleAgents =
+      options.account.intent === "add" &&
+      (await readConnectorAccountMutationVersion(
+        get(apiClient$),
+        { kind: "builtin", connectorSlug },
+        options.account,
+        signal,
+      )) === 0;
+    return { ...options, authorizeVisibleAgents };
+  },
+);
+
 const reloadConnectorConnectionState$ = command(({ set }) => {
   set(reloadConnectors$);
   set(reloadConnectorAccountSummaries$);
@@ -551,6 +573,7 @@ type ActiveConnectorExternalCodeState = {
   readonly expiresAtMs: number;
   readonly code: string;
   readonly errorMessage: string | null;
+  readonly authorizeVisibleAgents: boolean;
 };
 
 export type ConnectorOAuthDeviceAuthState =
@@ -922,7 +945,7 @@ export const submitManualGrant$ = command(
       connectorSlug,
       authMethod,
       inputValues,
-      options,
+      options: requestedOptions,
     }: SubmitManualGrantParams,
     signal: AbortSignal,
   ): Promise<ConnectorConnectionResult | false> => {
@@ -942,6 +965,12 @@ export const submitManualGrant$ = command(
     let connectorStateChanged = false;
     return await withCleanup(
       (async () => {
+        const options = await set(
+          resolveConnectorPostConnectOptions$,
+          connectorSlug,
+          requestedOptions,
+          signal,
+        );
         const createClient = get(apiClient$);
         const connectorClient = createClient(connectorManualGrantContract);
         const result = await accept(
@@ -999,7 +1028,11 @@ type ConnectNoAuthParams = {
 export const connectConnectorNoAuth$ = command(
   async (
     { get, set },
-    { connectorSlug, authMethod, options }: ConnectNoAuthParams,
+    {
+      connectorSlug,
+      authMethod,
+      options: requestedOptions,
+    }: ConnectNoAuthParams,
     signal: AbortSignal,
   ): Promise<ConnectorConnectionResult | false> => {
     if (
@@ -1018,6 +1051,12 @@ export const connectConnectorNoAuth$ = command(
     let connectorStateChanged = false;
     return await withCleanup(
       (async () => {
+        const options = await set(
+          resolveConnectorPostConnectOptions$,
+          connectorSlug,
+          requestedOptions,
+          signal,
+        );
         const createClient = get(apiClient$);
         const connectorClient = createClient(connectorNoAuthGrantContract);
         const result = await accept(
@@ -1512,7 +1551,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
     args: ConnectConnectorOAuthDeviceAuthParams,
     signal: AbortSignal,
   ): Promise<ConnectorConnectionResult | false> => {
-    const { connectorSlug, authMethod, options } = args;
+    const { connectorSlug, authMethod } = args;
     if (
       connectorConnectOperationIsActive({
         authCodeConnectorSlug: get(internalPollingOAuthAuthCodeConnectorSlug$),
@@ -1545,11 +1584,17 @@ const connectConnectorOAuthDeviceAuth$ = command(
         const client = createClient(connectorOauthDeviceAuthSessionContract, {
           apiBase: OAUTH_API_BASE,
         });
+        const options = await set(
+          resolveConnectorPostConnectOptions$,
+          connectorSlug,
+          args.options,
+          flowSignal,
+        );
         const startResponse = await tapError(
           accept(
             client.create({
               params: { connectorSlug },
-              body: connectorOAuthDeviceAuthStartBody(args),
+              body: connectorOAuthDeviceAuthStartBody({ ...args, options }),
               fetchOptions: { signal: flowSignal },
             }),
             [200],
@@ -1800,6 +1845,12 @@ export const connectConnectorExternalCode$ = command(
         const client = createClient(connectorExternalCodeSessionContract, {
           apiBase: OAUTH_API_BASE,
         });
+        const options = await set(
+          resolveConnectorPostConnectOptions$,
+          connectorSlug,
+          args,
+          flowSignal,
+        );
         const startResponse = await tapError(
           accept(
             client.create({
@@ -1807,7 +1858,7 @@ export const connectConnectorExternalCode$ = command(
               body: {
                 account: args.account,
                 authMethod,
-                ...(shouldAuthorizeAgent(args)
+                ...(shouldAuthorizeAgent(options)
                   ? { authorizeAgent: true as const }
                   : {}),
                 ...(args.agentId ? { agentId: args.agentId } : {}),
@@ -1848,6 +1899,7 @@ export const connectConnectorExternalCode$ = command(
           expiresAtMs: now() + secondsToMilliseconds(startResult.expiresIn),
           code: "",
           errorMessage: null,
+          authorizeVisibleAgents: options.authorizeVisibleAgents ?? false,
         });
         return true;
       })(),
@@ -1969,6 +2021,7 @@ const completeConnectorExternalCode$ = command(
           connectorSlug,
           {
             ...options,
+            authorizeVisibleAgents: current.authorizeVisibleAgents,
             clearSelectedConnector: true,
             reloadConnectors: false,
           },
@@ -2212,13 +2265,15 @@ const openConnectorOAuthAuthCodeWindow$ = command(
       readonly connectorIcon: PublicConnectorCatalogIcon;
       readonly agentId: string | undefined;
       readonly account: PlatformConnectorAccountMutationIntent;
-      readonly authorizeAgent: boolean;
-      readonly beforeStart: (signal: AbortSignal) => Promise<void>;
+      readonly beforeStart: (
+        signal: AbortSignal,
+      ) => Promise<PostConnectOptions>;
     },
     signal: AbortSignal,
   ): Promise<{
     readonly authWindow: Window | null;
     readonly connectionId: string | null;
+    readonly options: PostConnectOptions;
   }> => {
     const standalone = isStandaloneMode();
     if (isConnectorAppOauthCallbackEnabled(args.connectorSlug)) {
@@ -2254,7 +2309,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
 
     let navigated = false;
     let connectionId: string | null = null;
-    await withCleanup(
+    const options = await withCleanup(
       (async () => {
         if (!isBrowserAuthGrantKind(args.method.grantKind)) {
           throw new Error(
@@ -2262,7 +2317,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
           );
         }
 
-        await args.beforeStart(signal);
+        const options = await args.beforeStart(signal);
         signal.throwIfAborted();
 
         const startResult =
@@ -2275,7 +2330,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
                   body: {
                     account: args.account,
                     authMethod: args.method.id,
-                    ...(args.authorizeAgent
+                    ...(shouldAuthorizeAgent(options)
                       ? { authorizeAgent: true as const }
                       : {}),
                     ...(args.agentId ? { agentId: args.agentId } : {}),
@@ -2292,7 +2347,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
                   body: {
                     account: args.account,
                     authMethod: args.method.id,
-                    ...(args.authorizeAgent
+                    ...(shouldAuthorizeAgent(options)
                       ? { authorizeAgent: true as const }
                       : {}),
                     ...(isConnectorAppOauthCallbackEnabled(args.connectorSlug)
@@ -2313,6 +2368,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
         } else if (standalone) {
           window.location.href = startResult.body.authorizationUrl;
         }
+        return options;
       })(),
       () => {
         if (authWindow && !navigated) {
@@ -2331,7 +2387,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     );
     signal.throwIfAborted();
 
-    return { authWindow, connectionId };
+    return { authWindow, connectionId, options };
   },
 );
 
@@ -2341,7 +2397,7 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
     args: {
       readonly connectorSlug: ConnectorSlug;
       readonly method: PublicConnectorCatalogAuthMethodDetail;
-      readonly options: BrowserAuthPostConnectOptions;
+      readonly options: PostConnectOptions;
       readonly account: PlatformConnectorAccountMutationIntent;
       readonly onConnectorChanged$: ReturnType<
         typeof createConnectorOAuthAuthCodeChangedCommand
@@ -2503,9 +2559,15 @@ export const connectConnectorOAuthAuthCode$ = command(
             connectorIcon: options.connectorIcon,
             agentId: options.agentId,
             account,
-            authorizeAgent: shouldAuthorizeAgent(options),
             beforeStart: async (sig) => {
+              const resolvedOptions = await set(
+                resolveConnectorPostConnectOptions$,
+                connectorSlug,
+                options,
+                sig,
+              );
               await set(onConnectorChanged$, sig);
+              return resolvedOptions;
             },
           },
           signal,
@@ -2516,7 +2578,7 @@ export const connectConnectorOAuthAuthCode$ = command(
           {
             connectorSlug,
             method,
-            options,
+            options: oauthStart.options,
             account,
             onConnectorChanged$,
             oauthStart,

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -1909,7 +1909,7 @@ export const connectConnectorExternalCode$ = command(
         });
         set(internalConnectorExternalCodeState$, (current) => {
           if (
-            !signal.aborted ||
+            (!signal.aborted && current.status !== "starting") ||
             requestId === null ||
             current.connectorSlug !== connectorSlug ||
             (current.status !== "starting" && current.status !== "pending") ||

--- a/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/connectors.ts
@@ -56,7 +56,7 @@ import {
 } from "../../utils.ts";
 import { setAblyPayloadLoop$ } from "../../realtime.ts";
 import { localStorageSignals } from "../../external/local-storage.ts";
-import { subagents$ } from "../../agent.ts";
+import { agents$ } from "../../agent.ts";
 import { reloadAgentConnectorAuthorizations$ } from "../agent-connector-authorizations.ts";
 import { reloadConnectorAccountSummaries$ } from "../connector-accounts.ts";
 import { sanitizeTokenInputRecord } from "./token-input.ts";
@@ -835,12 +835,12 @@ const authorizeConnectorForVisibleAgents$ = command(
     connectorSlug: ConnectorSlug,
     signal: AbortSignal,
   ): Promise<void> => {
-    const visibleSubagents = await get(subagents$);
+    const visibleAgents = await get(agents$);
     signal.throwIfAborted();
     const client = get(apiClient$)(userConnectorsContract);
     await withCleanup(
       Promise.all(
-        visibleSubagents.map(async (agent) => {
+        visibleAgents.map(async (agent) => {
           await accept(
             client.update({
               params: { id: agent.agentId },
@@ -2180,14 +2180,14 @@ function getDefaultConnectorProjectionConnectionId(
 function createExpectedConnectorConnectionAvailableCommand(
   connectorSlug: ConnectorSlug,
   expectedConnectionId: string | null,
-  useDefaultConnectorProjection: boolean,
+  requiresAccountMutation: boolean,
   onConnectorChanged$: ReturnType<
     typeof createConnectorOAuthAuthCodeChangedCommand
   >,
 ) {
   return command(
     async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
-      if (useDefaultConnectorProjection) {
+      if (requiresAccountMutation) {
         return await set(onConnectorChanged$, signal);
       }
       return expectedConnectionId
@@ -2366,7 +2366,8 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
       createExpectedConnectorConnectionAvailableCommand(
         connectorSlug,
         expectedConnectionId,
-        options.useDefaultConnectorProjection ?? false,
+        account.intent === "reconnect" ||
+          (options.useDefaultConnectorProjection ?? false),
         onConnectorChanged$,
       );
     const waitSignal = set(resetOAuthAuthCodeWaitSignal$, signal);
@@ -2410,20 +2411,14 @@ const completeConnectorOAuthAuthCodeFlow$ = command(
 
     let completedConnectionId = expectedConnectionId;
     if (waitResult === "popupClosed") {
-      const expectedConnected = expectedConnectionId
+      const connectedAfterClose = expectedConnectionId
         ? await set(expectedConnectionAvailable$, signal)
-        : false;
-      const connectedAfterClose = expectedConnected
-        ? true
         : // Older API responses omit the exact ID. Remove this bounded account
           // mutation fallback with the final rollout contraction in #28571.
           await set(onConnectorChanged$, signal);
       signal.throwIfAborted();
       if (!connectedAfterClose) {
         return false;
-      }
-      if (!expectedConnected && !expectedConnectionId) {
-        completedConnectionId = null;
       }
     } else if (!expectedConnectionId) {
       completedConnectionId =

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -383,7 +383,6 @@ const setCustomConnectorValuesForTarget$ = command(
       readonly values: readonly CustomConnectorValueInput[];
       readonly authorizationTarget: CustomConnectorAuthorizationTarget;
       readonly account: PlatformConnectorAccountMutationIntent;
-      readonly authorizeTarget?: boolean;
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
@@ -408,13 +407,6 @@ const setCustomConnectorValuesForTarget$ = command(
         connected: false,
         targetAuthorized: false,
         connectionId: null,
-      };
-    }
-    if (args.authorizeTarget === false) {
-      return {
-        connected: true,
-        targetAuthorized: false,
-        connectionId: result.body.connectedAccountId ?? null,
       };
     }
     let targetAuthorized: boolean;
@@ -494,28 +486,6 @@ export const setCustomConnectorValuesForAgent$ = command(
   },
 );
 
-export const setCustomConnectorAccountValues$ = command(
-  async (
-    { set },
-    args: {
-      readonly id: string;
-      readonly values: readonly CustomConnectorValueInput[];
-      readonly account: PlatformConnectorAccountMutationIntent;
-    },
-    signal: AbortSignal,
-  ): Promise<CustomConnectorConnectionResult> => {
-    return await set(
-      setCustomConnectorValuesForTarget$,
-      {
-        ...args,
-        authorizationTarget: { kind: "visible-agents" },
-        authorizeTarget: false,
-      },
-      signal,
-    );
-  },
-);
-
 async function customConnectorAccountMutationCompleted(
   createClient: ApiClientFactory,
   connectorId: string,
@@ -539,7 +509,6 @@ interface CustomConnectorAuthorizationTargetArgs {
   readonly id: string;
   readonly authorizationTarget: CustomConnectorAuthorizationTarget;
   readonly account: PlatformConnectorAccountMutationIntent;
-  readonly authorizeTarget?: boolean;
   readonly useDefaultConnectorProjection?: boolean;
 }
 
@@ -596,19 +565,21 @@ async function customConnectorOAuthCompletion(
       initialUpdatedAt: args.initialDefaultUpdatedAt,
     });
   }
-  const exactAccountCompleted = args.expectedConnectionId
-    ? await connectorAccountConnectionExists(
-        args.createClient,
-        { kind: "custom", customConnectorId: args.target.id },
-        args.expectedConnectionId,
-        signal,
-      )
-    : false;
-  if (exactAccountCompleted) {
-    return { completed: true, connectionId: args.expectedConnectionId };
+  if (args.target.account.intent === "add" && args.expectedConnectionId) {
+    const completed = await connectorAccountConnectionExists(
+      args.createClient,
+      { kind: "custom", customConnectorId: args.target.id },
+      args.expectedConnectionId,
+      signal,
+    );
+    return {
+      completed,
+      connectionId: completed ? args.expectedConnectionId : null,
+    };
   }
-  // Older API responses omit the exact ID. Remove this bounded account
-  // mutation fallback with the final rollout contraction in #28571.
+  // Reconnect must update the selected account; its existence alone is not
+  // completion. Adds without an exact ID retain the bounded older-API fallback
+  // until the final rollout contraction in #28571.
   const completed = await customConnectorAccountMutationCompleted(
     args.createClient,
     args.target.id,
@@ -631,11 +602,10 @@ const authorizeCompletedCustomConnectorTarget$ = command(
     args: {
       readonly connector: CustomConnectorResponse | undefined;
       readonly target: CustomConnectorAuthorizationTarget;
-      readonly authorizeTarget: boolean;
     },
     signal: AbortSignal,
   ): Promise<boolean> => {
-    if (!args.connector?.connected || !args.authorizeTarget) {
+    if (!args.connector?.connected) {
       return false;
     }
     if (!args.connector.permissionBundleRef) {
@@ -728,7 +698,6 @@ const connectCustomConnectorAuthorizationForTarget$ = command(
         {
           connector: startResult.connector,
           target: args.authorizationTarget,
-          authorizeTarget: args.authorizeTarget !== false,
         },
         signal,
       );
@@ -775,7 +744,6 @@ const connectCustomConnectorAuthorizationForTarget$ = command(
       {
         connector,
         target: args.authorizationTarget,
-        authorizeTarget: args.authorizeTarget !== false,
       },
       signal,
     );
@@ -828,27 +796,6 @@ export const connectCustomConnectorAuthorizationForAgent$ = command(
           ? { useDefaultConnectorProjection: true as const }
           : {}),
         authorizationTarget: { kind: "agent", agentId: args.agentId },
-      },
-      signal,
-    );
-  },
-);
-
-export const connectCustomConnectorAccountAuthorization$ = command(
-  async (
-    { set },
-    args: {
-      readonly id: string;
-      readonly account: PlatformConnectorAccountMutationIntent;
-    },
-    signal: AbortSignal,
-  ): Promise<CustomConnectorConnectionResult> => {
-    return await set(
-      connectCustomConnectorAuthorizationForTarget$,
-      {
-        ...args,
-        authorizationTarget: { kind: "visible-agents" },
-        authorizeTarget: false,
       },
       signal,
     );

--- a/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/okou-page/settings/custom-connectors.ts
@@ -387,6 +387,16 @@ const setCustomConnectorValuesForTarget$ = command(
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionResult> => {
     const createClient = get(apiClient$);
+    const initialAccountVersion =
+      args.authorizationTarget.kind === "visible-agents" &&
+      args.account.intent === "add"
+        ? await readConnectorAccountMutationVersion(
+            createClient,
+            { kind: "custom", customConnectorId: args.id },
+            args.account,
+            signal,
+          )
+        : undefined;
     const client = createClient(customConnectorValuesContract);
     const result = await accept(
       client.set({
@@ -409,24 +419,15 @@ const setCustomConnectorValuesForTarget$ = command(
         connectionId: null,
       };
     }
-    let targetAuthorized: boolean;
-    if (connector.permissionBundleRef) {
-      targetAuthorized = await set(
-        isCustomConnectorAuthorizedForTarget$,
-        { connectorId: connector.id, target: args.authorizationTarget },
-        signal,
-      );
-    } else {
-      await set(
-        authorizeCustomConnectorForTarget$,
-        {
-          connectorId: connector.id,
-          target: args.authorizationTarget,
-        },
-        signal,
-      );
-      targetAuthorized = true;
-    }
+    const targetAuthorized = await set(
+      authorizeCompletedCustomConnectorTarget$,
+      {
+        connector,
+        target: args.authorizationTarget,
+        initialAccountVersion,
+      },
+      signal,
+    );
     signal.throwIfAborted();
     toast.success(
       i18n.t(($) => {
@@ -602,10 +603,19 @@ const authorizeCompletedCustomConnectorTarget$ = command(
     args: {
       readonly connector: CustomConnectorResponse | undefined;
       readonly target: CustomConnectorAuthorizationTarget;
+      readonly initialAccountVersion:
+        | ConnectorAccountMutationVersion
+        | undefined;
     },
     signal: AbortSignal,
   ): Promise<boolean> => {
     if (!args.connector?.connected) {
+      return false;
+    }
+    if (
+      args.target.kind === "visible-agents" &&
+      args.initialAccountVersion !== 0
+    ) {
       return false;
     }
     if (!args.connector.permissionBundleRef) {
@@ -645,7 +655,6 @@ const connectCustomConnectorAuthorizationForTarget$ = command(
     let navigated = false;
     let initialAccountVersion: ConnectorAccountMutationVersion | undefined;
     let initialDefaultUpdatedAt: string | null | undefined;
-    let expectedConnectionId: string | null = null;
     const startResult = await withCleanup(
       (async () => {
         const createClient = get(apiClient$);
@@ -656,14 +665,16 @@ const connectCustomConnectorAuthorizationForTarget$ = command(
               return connector.id === args.id;
             })?.connectedAccountUpdatedAt ?? null;
         }
-        initialAccountVersion = !args.useDefaultConnectorProjection
-          ? await readConnectorAccountMutationVersion(
-              createClient,
-              { kind: "custom", customConnectorId: args.id },
-              args.account,
-              signal,
-            )
-          : undefined;
+        initialAccountVersion =
+          !args.useDefaultConnectorProjection ||
+          args.authorizationTarget.kind === "visible-agents"
+            ? await readConnectorAccountMutationVersion(
+                createClient,
+                { kind: "custom", customConnectorId: args.id },
+                args.account,
+                signal,
+              )
+            : undefined;
         const client = createClient(customConnectorOAuth2Contract, {
           apiBase: "api",
         });
@@ -679,7 +690,6 @@ const connectCustomConnectorAuthorizationForTarget$ = command(
         if (result.body.result === "connected") {
           return result.body;
         }
-        expectedConnectionId = result.body.connectionId ?? null;
         authWindow.location.href = result.body.authorizationUrl;
         navigated = true;
         return result.body;
@@ -698,6 +708,7 @@ const connectCustomConnectorAuthorizationForTarget$ = command(
         {
           connector: startResult.connector,
           target: args.authorizationTarget,
+          initialAccountVersion,
         },
         signal,
       );
@@ -726,7 +737,7 @@ const connectCustomConnectorAuthorizationForTarget$ = command(
         createClient: get(apiClient$),
         connector,
         target: args,
-        expectedConnectionId,
+        expectedConnectionId: startResult.connectionId ?? null,
         initialAccountVersion,
         initialDefaultUpdatedAt,
       },
@@ -744,6 +755,7 @@ const connectCustomConnectorAuthorizationForTarget$ = command(
       {
         connector,
         target: args.authorizationTarget,
+        initialAccountVersion,
       },
       signal,
     );

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
@@ -650,6 +650,37 @@ test("Load connector accounts progressively", async () => {
 });
 
 test("Reconnect the selected non-default account", async () => {
+  const agentIds = [
+    "c0000000-0000-4000-a000-000000000001",
+    "c0000000-0000-4000-a000-000000000002",
+  ];
+  context.mocks.data.agents(
+    agentIds.map((id) => {
+      return listAgent(id, id);
+    }),
+  );
+  const authorizedAgents = new Set<string>();
+  context.mocks.api(userConnectorsContract.get, ({ params, respond }) => {
+    return respond(200, {
+      enabledConnectorSlugs: authorizedAgents.has(params.id) ? ["stripe"] : [],
+    });
+  });
+  context.mocks.api(
+    userConnectorsContract.update,
+    ({ params, body, respond }) => {
+      if (
+        body.operation === "add" &&
+        body.enabledConnectorSlugs.includes("stripe")
+      ) {
+        authorizedAgents.add(params.id);
+      }
+      return respond(200, {
+        enabledConnectorSlugs: authorizedAgents.has(params.id)
+          ? ["stripe"]
+          : [],
+      });
+    },
+  );
   const [connector] = mockConnectors(context, [
     {
       connectorSlug: "stripe",
@@ -709,10 +740,11 @@ test("Reconnect the selected non-default account", async () => {
   context.mocks.api(connectorOauthStartContract.start, ({ body, respond }) => {
     submitted = body.account;
     return respond(200, {
+      connectionId: personal.id,
       authorizationUrl: "https://oauth.test/stripe/authorize",
     });
   });
-  const authWindow = createAuthWindow();
+  let authWindow = createAuthWindow();
   context.mocks.browser.open(authWindow);
   await setupAccountsPage();
   click(
@@ -739,6 +771,21 @@ test("Reconnect the selected non-default account", async () => {
     return reconnectDialog;
   });
 
+  click(getConnectorAction("button", "Reconnect", connect));
+  await waitFor(() => {
+    expect(authWindow.location.href).toBe(
+      "https://oauth.test/stripe/authorize",
+    );
+  });
+  authWindow.close();
+  await waitFor(() => {
+    expect(getConnectorAction("button", "Reconnect", connect)).toBeEnabled();
+  });
+  expect(connect).toBeInTheDocument();
+  expect(getConnectorCard("Stripe")).toHaveTextContent("Add access");
+
+  authWindow = createAuthWindow();
+  context.mocks.browser.open(authWindow);
   const connectorChangedSubscribe = context.mocks.ably.deferNextSubscribe();
   click(getConnectorAction("button", "Reconnect", connect));
 
@@ -769,6 +816,9 @@ test("Reconnect the selected non-default account", async () => {
   expect(
     screen.queryByRole("dialog", { name: "Name your Stripe account" }),
   ).not.toBeInTheDocument();
+  expect(
+    getConnectorAction("button", "Manage Stripe access"),
+  ).toHaveTextContent("Used by 2 agents");
   click(getConnectorAction("button", "Manage Stripe accounts"));
   const reopenedManager = await screen.findByRole("dialog", {
     name: "Manage Stripe accounts",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
@@ -739,6 +739,7 @@ test("Reconnect the selected non-default account", async () => {
   let submitted: unknown;
   context.mocks.api(connectorOauthStartContract.start, ({ body, respond }) => {
     submitted = body.account;
+    expect(body.authorizeAgent).not.toBeTruthy();
     return respond(200, {
       connectionId: personal.id,
       authorizationUrl: "https://oauth.test/stripe/authorize",
@@ -818,7 +819,7 @@ test("Reconnect the selected non-default account", async () => {
   ).not.toBeInTheDocument();
   expect(
     getConnectorAction("button", "Manage Stripe access"),
-  ).toHaveTextContent("Used by 2 agents");
+  ).toHaveTextContent("Add access");
   click(getConnectorAction("button", "Manage Stripe accounts"));
   const reopenedManager = await screen.findByRole("dialog", {
     name: "Manage Stripe accounts",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -26,6 +26,7 @@ import {
   getConnectorAction,
   getConnectorCard,
   getConnectorIcon,
+  getConnectorSwitch,
   listAgent,
   mockConnectors,
   mockPublicConnectorStatus,
@@ -374,7 +375,7 @@ test("Choose a credential-free method among multiple connection methods", async 
   });
 });
 
-test("Authorize all visible agents after a manual connection", async () => {
+test("Authorize visible agents only for the first manual account", async () => {
   const researchId = "c0000000-0000-4000-a000-000000000002";
   mockConnectors(context, []);
   context.mocks.data.agents([
@@ -396,10 +397,13 @@ test("Authorize all visible agents after a manual connection", async () => {
       ],
     }),
   ]);
+  let connectedAccount: ConnectorResponse | undefined;
   context.mocks.api(
     connectorManualGrantContract.connect,
     ({ body, respond }) => {
-      return respond(200, storeConnectedConnector("axiom", body.authMethod));
+      expect(body.authorizeAgent ?? false).toBe(!connectedAccount);
+      connectedAccount = storeConnectedConnector("axiom", body.authMethod);
+      return respond(200, connectedAccount);
     },
   );
   mockAgentConnectorAccess("axiom");
@@ -437,6 +441,51 @@ test("Authorize all visible agents after a manual connection", async () => {
     ).toHaveTextContent("Used by 2 agents");
   });
   expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+  click(getConnectorAction("button", "Manage Public Axiom access"));
+  const access = await screen.findByRole("dialog", {
+    name: "Manage Public Axiom access",
+  });
+  click(getConnectorSwitch("Revoke Public Axiom access for Zero", access));
+  await waitFor(() => {
+    expect(
+      getConnectorSwitch("Authorize Public Axiom access for Zero", access),
+    ).not.toBeChecked();
+  });
+  click(getConnectorAction("button", "Close", access));
+  click(getConnectorAction("button", "Manage Public Axiom accounts"));
+  const manager = await screen.findByRole("dialog", {
+    name: "Manage Public Axiom accounts",
+  });
+  click(getConnectorAction("button", "Add account", manager));
+  const addition = await screen.findByRole("dialog", { name: "Public Axiom" });
+  await fill(
+    within(addition).getByPlaceholderText("public-xaat"),
+    "second-token",
+  );
+  click(getConnectorAction("button", "Save", addition));
+  const secondNaming = await screen.findByRole("dialog", {
+    name: "Name your Public Axiom account",
+  });
+  click(getConnectorAction("button", "Skip", secondNaming));
+  await waitFor(() => {
+    expect(
+      getConnectorAction("button", "Manage Public Axiom access"),
+    ).toHaveTextContent("Used by Research Agent");
+  });
+  click(getConnectorAction("button", "Manage Public Axiom access"));
+  const updatedAccess = await screen.findByRole("dialog", {
+    name: "Manage Public Axiom access",
+  });
+  expect(
+    getConnectorSwitch("Authorize Public Axiom access for Zero", updatedAccess),
+  ).not.toBeChecked();
+  expect(
+    getConnectorSwitch(
+      "Revoke Public Axiom access for Research Agent",
+      updatedAccess,
+    ),
+  ).toBeChecked();
 });
 
 test("Connect through device authorization", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -197,9 +197,7 @@ test("Add an AWS account with an external code", async () => {
   context.mocks.data.agents([
     listAgent("c0000000-0000-4000-a000-000000000002", "Research Agent"),
   ]);
-  context.mocks.api(userConnectorsContract.get, ({ respond }) => {
-    return respond(200, { enabledConnectorSlugs: [] });
-  });
+  mockAgentConnectorAccess("aws");
   const authWindow = createAuthWindow();
   const browserOpen = context.mocks.browser.open(authWindow);
   context.mocks.api(
@@ -262,7 +260,7 @@ test("Add an AWS account with an external code", async () => {
   ).resolves.toBeInTheDocument();
   expect(
     getConnectorAction("button", "Manage AWS access", awsCard),
-  ).toHaveTextContent("Add access");
+  ).toHaveTextContent("Used by Research Agent");
   expect(
     screen.queryByText("You've successfully connected with AWS!"),
   ).toBeNull();
@@ -271,6 +269,11 @@ test("Add an AWS account with an external code", async () => {
 test("Add an account through OpenID", async () => {
   const slug = "server-authored-steam";
   mockConnectors(context, []);
+  context.mocks.data.agents([
+    listAgent("c0000000-0000-4000-a000-000000000001", "Default"),
+    listAgent("c0000000-0000-4000-a000-000000000002", "Research"),
+  ]);
+  mockAgentConnectorAccess(slug);
   mockPublicConnectorStatus(context, [
     publicStatusItem({
       connectorSlug: slug,
@@ -319,6 +322,13 @@ test("Add an account through OpenID", async () => {
       "https://openid.test/partner-steam/authorize",
     );
   });
+  storeConnectedConnector(slug, "partner-openid");
+  context.mocks.ably.trigger("connector:changed", { connectorSlug: slug });
+  await waitFor(() => {
+    expect(
+      getConnectorAction("button", "Manage Partner Steam access"),
+    ).toHaveTextContent("Used by 2 agents");
+  });
 });
 
 test("Choose a credential-free method among multiple connection methods", async () => {
@@ -364,7 +374,7 @@ test("Choose a credential-free method among multiple connection methods", async 
   });
 });
 
-test("Keep agent access independent after a manual connection", async () => {
+test("Authorize all visible agents after a manual connection", async () => {
   const researchId = "c0000000-0000-4000-a000-000000000002";
   mockConnectors(context, []);
   context.mocks.data.agents([
@@ -424,13 +434,18 @@ test("Keep agent access independent after a manual connection", async () => {
         "Manage Public Axiom access",
         getConnectorCard("Public Axiom"),
       ),
-    ).toHaveTextContent("Add access");
+    ).toHaveTextContent("Used by 2 agents");
   });
   expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 });
 
 test("Connect through device authorization", async () => {
   mockConnectors(context, []);
+  context.mocks.data.agents([
+    listAgent("c0000000-0000-4000-a000-000000000001", "Default"),
+    listAgent("c0000000-0000-4000-a000-000000000002", "Research"),
+  ]);
+  mockAgentConnectorAccess("base44");
   mockPublicConnectorStatus(context, [
     publicStatusItem({
       connectorSlug: "base44",
@@ -478,6 +493,9 @@ test("Connect through device authorization", async () => {
     expect(
       within(getConnectorCard("Base44")).getByText("mock-base44"),
     ).toBeInTheDocument();
+    expect(
+      getConnectorAction("button", "Manage Base44 access"),
+    ).toHaveTextContent("Used by 2 agents");
   });
 });
 
@@ -552,7 +570,7 @@ test("Enable a connector that needs no credentials", async () => {
   context.mocks.api(
     connectorNoAuthGrantContract.connect,
     ({ body, respond }) => {
-      expect(body.authorizeAgent).toBeFalsy();
+      expect(body.authorizeAgent).toBeTruthy();
       return respond(200, storeConnectedConnector("stripe", body.authMethod));
     },
   );
@@ -585,7 +603,7 @@ test("Enable a connector that needs no credentials", async () => {
         "Manage Public Stripe access",
         getConnectorCard("Public Stripe"),
       ),
-    ).toHaveTextContent("Add access");
+    ).toHaveTextContent("Used by 2 agents");
   });
   expect(browserOpen.calls).toHaveLength(0);
   expect(screen.queryByText(/You've successfully connected with/u)).toBeNull();
@@ -741,7 +759,7 @@ test("Complete OAuth only after the selected connector changes", async () => {
         "Manage Public Stripe access",
         getConnectorCard("Public Stripe"),
       ),
-    ).toHaveTextContent("Add access");
+    ).toHaveTextContent("Used by 2 agents");
   });
 });
 
@@ -862,7 +880,7 @@ test("Optionally name a newly added credential-free account", async () => {
     expect(getConnectorCard("Public Stripe")).toHaveTextContent("API key");
   });
   expect(submittedAccount).toStrictEqual({ intent: "add" });
-  expect(submittedAuthorizeAgent).toBeUndefined();
+  expect(submittedAuthorizeAgent).toBeTruthy();
 });
 
 test("Retry device authorization after a provider error", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -1305,6 +1305,52 @@ test("Show an OAuth startup failure in the provider window", async () => {
   });
 });
 
+test("Retry external-code startup after an account-count lookup fails", async () => {
+  mockConnectors(context, []);
+  let summariesAvailable = true;
+  context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+    return summariesAvailable
+      ? respond(200, { summaries: [] })
+      : respond(500, {
+          error: { message: "Account list unavailable", code: "UNAVAILABLE" },
+        });
+  });
+  await setupPage({ context, path: "/connectors?keywords=aws" });
+  click(
+    await waitFor(() => {
+      return getConnectorAction("button", "Connect AWS");
+    }),
+  );
+  const dialog = await screen.findByRole("dialog", { name: "AWS" });
+
+  summariesAvailable = false;
+  click(getConnectorAction("button", "Start AWS sign-in", dialog));
+
+  await expect(
+    screen.findByText("Account list unavailable"),
+  ).resolves.toBeInTheDocument();
+  const retry = await waitFor(() => {
+    const button = getConnectorAction("button", "Start AWS sign-in", dialog);
+    expect(button).toBeEnabled();
+    return button;
+  });
+  expect(
+    within(dialog).queryByTestId("connector-external-code-input"),
+  ).toBeNull();
+
+  summariesAvailable = true;
+  click(retry);
+  await fill(
+    await within(dialog).findByTestId("connector-external-code-input"),
+    "AWS-CODE",
+  );
+  click(within(dialog).getByTestId("connector-external-code-complete"));
+
+  await expect(
+    screen.findByRole("dialog", { name: "Name your AWS account" }),
+  ).resolves.toBeInTheDocument();
+});
+
 test("Recover from external-code connection errors", async () => {
   let completes = 0;
   context.mocks.api(

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
@@ -138,6 +138,35 @@ function accountAction(container: ParentNode): HTMLElement {
   return action;
 }
 
+function mockCustomAgentAccess(): void {
+  const grantsByAgent = new Map<string, AgentCustomConnectorGrant[]>();
+  context.mocks.api(
+    agentCustomConnectorsContract.get,
+    ({ params, respond }) => {
+      return respond(200, { grants: grantsByAgent.get(params.id) ?? [] });
+    },
+  );
+  context.mocks.api(
+    agentCustomConnectorsContract.update,
+    ({ params, body, respond }) => {
+      const previous = grantsByAgent.get(params.id) ?? [];
+      const retained = previous.filter((grant) => {
+        return !body.grants.some((updated) => {
+          return updated.customConnectorId === grant.customConnectorId;
+        });
+      });
+      const grants =
+        body.operation === "remove"
+          ? retained
+          : body.operation === "add"
+            ? [...retained, ...body.grants]
+            : body.grants;
+      grantsByAgent.set(params.id, grants);
+      return respond(200, { grants });
+    },
+  );
+}
+
 test("Create a custom connector without authentication", async () => {
   mockCustomConnectorStory(context);
 
@@ -170,21 +199,11 @@ test("Add and optionally name a custom connector account", async () => {
     }),
   ];
   const accounts = new Map<string, ConnectorAccountConnection>();
-  let grantMutations = 0;
   context.mocks.data.agents([listAgent(RESEARCH_ID, "Research")]);
   context.mocks.api(customConnectorsContract.list, ({ respond }) => {
     return respond(200, { connectors });
   });
-  context.mocks.api(agentCustomConnectorsContract.get, ({ respond }) => {
-    return respond(200, {
-      grants: connectors.map((connector) => {
-        return {
-          customConnectorId: connector.id,
-          permissionNames: [],
-        };
-      }),
-    });
-  });
+  mockCustomAgentAccess();
   context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
     return respond(200, {
       summaries: [...accounts.values()].map((account) => {
@@ -241,10 +260,6 @@ test("Add and optionally name a custom connector account", async () => {
       );
     },
   );
-  context.mocks.api(agentCustomConnectorsContract.update, ({ respond }) => {
-    grantMutations += 1;
-    return respond(200, { grants: [] });
-  });
   await setupCustomPage({ mcp: true });
 
   for (const name of ["Acme Search", "Acme MCP"]) {
@@ -277,7 +292,9 @@ test("Add and optionally name a custom connector account", async () => {
       ),
     ).toHaveTextContent("Used by Research");
   }
-  expect(grantMutations).toBe(0);
+  expect(
+    getConnectorAction("button", "Manage Acme Search access"),
+  ).toHaveTextContent("Used by Research");
 });
 
 test("Enable custom connector access when an account becomes available", async () => {
@@ -658,7 +675,7 @@ test("Manage a custom HTTP connector through its lifecycle", async () => {
         "Manage Acme API access",
         getConnectorCard("Acme API"),
       ),
-    ).toHaveTextContent("Add access");
+    ).toHaveTextContent("Used by 2 agents");
   });
 
   click(
@@ -913,7 +930,7 @@ test("Configure and maintain OAuth for a custom HTTP connector", async () => {
         "Manage Acme API access",
         getConnectorCard("Acme API"),
       ),
-    ).toHaveTextContent("Add access");
+    ).toHaveTextContent("Used by Research");
   });
 });
 
@@ -959,11 +976,6 @@ test("Manage a manual MCP connector through its lifecycle", async () => {
         return value.key;
       }),
     };
-    for (const agentId of grants.keys()) {
-      grants.set(agentId, [
-        { customConnectorId: connector.id, permissionNames: [] },
-      ]);
-    }
     return respond(200, connector);
   });
   context.mocks.api(
@@ -1114,7 +1126,11 @@ test("Create and connect an MCP server with automatic authentication", async () 
   let created: CreateCustomConnectorBody | null = null;
   const authWindow = createAuthWindow();
   context.mocks.browser.open(authWindow);
-  context.mocks.data.agents([]);
+  context.mocks.data.agents([
+    listAgent("c0000000-0000-4000-a000-000000000001", "Default"),
+    listAgent(RESEARCH_ID, "Research"),
+  ]);
+  mockCustomAgentAccess();
   context.mocks.api(customConnectorsContract.list, ({ respond }) => {
     return respond(200, { connectors: connector ? [connector] : [] });
   });
@@ -1204,7 +1220,134 @@ test("Create and connect an MCP server with automatic authentication", async () 
       "Unnamed account",
     );
     expect(authWindow.closed).toBeTruthy();
+    expect(
+      getConnectorAction("button", "Manage Discovery MCP access"),
+    ).toHaveTextContent("Used by 2 agents");
   });
+});
+
+test("Authorize MCP access only after the selected account reconnects", async () => {
+  const connector = mcpCustomConnector({
+    authMode: "automatic",
+    fields: [],
+    headerInjections: [],
+    configuredFieldKeys: [],
+  });
+  const work = customAccount(connector.id, crypto.randomUUID(), {
+    displayName: "Work",
+  });
+  let personal = customAccount(connector.id, crypto.randomUUID(), {
+    displayName: "Personal",
+    isDefault: false,
+    authMethod: "oauth",
+    connectionStatus: "reconnect-required",
+    reconnectReason: "authorization_expired_or_revoked",
+  });
+  context.mocks.data.agents([
+    listAgent("c0000000-0000-4000-a000-000000000001", "Default"),
+    listAgent(RESEARCH_ID, "Research"),
+  ]);
+  mockCustomAgentAccess();
+  context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+    return respond(200, { connectors: [connector] });
+  });
+  context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+    return respond(200, {
+      summaries: [
+        {
+          target: work.target,
+          accountCount: 2,
+          attentionCount:
+            personal.connectionStatus === "reconnect-required" ? 1 : 0,
+          defaultConnection: work,
+        },
+      ],
+    });
+  });
+  context.mocks.api(
+    connectorAccountsContract.connection,
+    ({ params, respond }) => {
+      return params.connectionId === personal.id
+        ? respond(200, personal)
+        : respond(404, {
+            error: { code: "NOT_FOUND", message: "Account not found" },
+          });
+    },
+  );
+  context.mocks.api(connectorAccountsContract.connections, ({ respond }) => {
+    return respond(200, { connections: [work, personal], nextCursor: null });
+  });
+  context.mocks.api(
+    customConnectorOAuth2Contract.start,
+    ({ body, respond }) => {
+      expect(body.account).toStrictEqual({
+        intent: "reconnect",
+        connectionId: personal.id,
+      });
+      return respond(200, {
+        result: "authorization",
+        connectionId: personal.id,
+        authorizationUrl: "https://oauth.acme.test/reconnect",
+      });
+    },
+  );
+  await setupCustomPage({ mcp: true });
+  const manageAccounts = await waitFor(() => {
+    return getConnectorAction("button", "Manage Acme MCP accounts");
+  });
+  click(manageAccounts);
+  const manager = await screen.findByRole("dialog", {
+    name: "Manage Acme MCP accounts",
+  });
+  const personalRow = await within(manager).findByRole("group", {
+    name: "Personal",
+  });
+  click(getConnectorAction("button", "Reconnect", personalRow));
+  const dialog = await screen.findByRole("dialog", {
+    name: "Connect Acme MCP",
+  });
+
+  const cancelledWindow = createAuthWindow();
+  context.mocks.browser.open(cancelledWindow);
+  click(getConnectorAction("button", "Continue", dialog));
+  await waitFor(() => {
+    expect(cancelledWindow.location.href).toBe(
+      "https://oauth.acme.test/reconnect",
+    );
+  });
+  cancelledWindow.close();
+  await waitFor(() => {
+    expect(getConnectorAction("button", "Continue", dialog)).toBeEnabled();
+  });
+  expect(dialog).toBeInTheDocument();
+  await waitFor(() => {
+    expect(getConnectorCard("Acme MCP")).toHaveTextContent("Add access");
+  });
+
+  const completedWindow = createAuthWindow();
+  context.mocks.browser.open(completedWindow);
+  click(getConnectorAction("button", "Continue", dialog));
+  await waitFor(() => {
+    expect(completedWindow.location.href).toBe(
+      "https://oauth.acme.test/reconnect",
+    );
+  });
+  personal = {
+    ...personal,
+    connectionStatus: "connected",
+    reconnectReason: null,
+    updatedAt: "2026-01-01T00:00:01.000Z",
+  };
+  completedWindow.close();
+  await waitFor(() => {
+    expect(
+      getConnectorAction("button", "Manage Acme MCP access"),
+    ).toHaveTextContent("Used by 2 agents");
+    expect(dialog).not.toBeInTheDocument();
+  });
+  expect(
+    screen.queryByRole("dialog", { name: "Name your Acme MCP account" }),
+  ).not.toBeInTheDocument();
 });
 
 test("Create, edit, and connect an OAuth MCP connector", async () => {
@@ -1363,18 +1506,13 @@ test("Add and optionally name a custom OAuth account", async () => {
   const connectionId = crypto.randomUUID();
   let account: ConnectorAccountConnection | null = null;
   let submitted: unknown;
-  let grantMutations = 0;
   const authWindow = createAuthWindow();
   context.mocks.browser.open(authWindow);
   context.mocks.data.agents([listAgent(RESEARCH_ID, "Research")]);
   context.mocks.api(customConnectorsContract.list, ({ respond }) => {
     return respond(200, { connectors: [connector] });
   });
-  context.mocks.api(agentCustomConnectorsContract.get, ({ respond }) => {
-    return respond(200, {
-      grants: [{ customConnectorId: connector.id, permissionNames: [] }],
-    });
-  });
+  mockCustomAgentAccess();
   context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
     return respond(200, {
       summaries: account
@@ -1416,10 +1554,6 @@ test("Add and optionally name a custom OAuth account", async () => {
           });
     },
   );
-  context.mocks.api(agentCustomConnectorsContract.update, ({ respond }) => {
-    grantMutations += 1;
-    return respond(200, { grants: [] });
-  });
   await setupCustomPage();
 
   click(
@@ -1447,7 +1581,6 @@ test("Add and optionally name a custom OAuth account", async () => {
     ),
   ).toHaveTextContent("Used by Research");
   expect(submitted).toStrictEqual({ intent: "add" });
-  expect(grantMutations).toBe(0);
 });
 
 test("Edit a custom HTTP connector without losing advanced configuration", async () => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-custom.test.tsx
@@ -138,8 +138,13 @@ function accountAction(container: ParentNode): HTMLElement {
   return action;
 }
 
-function mockCustomAgentAccess(): void {
-  const grantsByAgent = new Map<string, AgentCustomConnectorGrant[]>();
+function mockCustomAgentAccess(
+  initialGrants: readonly (readonly [
+    string,
+    AgentCustomConnectorGrant[],
+  ])[] = [],
+): void {
+  const grantsByAgent = new Map(initialGrants);
   context.mocks.api(
     agentCustomConnectorsContract.get,
     ({ params, respond }) => {
@@ -296,6 +301,149 @@ test("Add and optionally name a custom connector account", async () => {
     getConnectorAction("button", "Manage Acme Search access"),
   ).toHaveTextContent("Used by Research");
 });
+
+test.each(["http", "mcp-manual", "mcp-automatic"] as const)(
+  "Preserve revoked access when adding another %s account",
+  async (kind) => {
+    const defaultId = "c0000000-0000-4000-a000-000000000001";
+    const connector =
+      kind === "http"
+        ? customConnector({
+            connected: true,
+            missingRequiredFields: [],
+            configuredFieldKeys: ["secret"],
+          })
+        : mcpCustomConnector(
+            kind === "mcp-automatic"
+              ? {
+                  authMode: "automatic",
+                  fields: [],
+                  headerInjections: [],
+                  configuredFieldKeys: [],
+                }
+              : {},
+          );
+    const existing = customAccount(connector.id, crypto.randomUUID(), {
+      displayName: "Existing",
+    });
+    const accounts = [existing];
+    const grant = { customConnectorId: connector.id, permissionNames: [] };
+    context.mocks.data.agents([
+      listAgent(defaultId, "Default"),
+      listAgent(RESEARCH_ID, "Research"),
+    ]);
+    mockCustomAgentAccess([
+      [defaultId, [grant]],
+      [RESEARCH_ID, [grant]],
+    ]);
+    context.mocks.api(customConnectorsContract.list, ({ respond }) => {
+      return respond(200, { connectors: [connector] });
+    });
+    context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+      return respond(200, {
+        summaries: [
+          {
+            target: existing.target,
+            accountCount: accounts.length,
+            attentionCount: 0,
+            defaultConnection: existing,
+          },
+        ],
+      });
+    });
+    context.mocks.api(
+      connectorAccountsContract.connection,
+      ({ params, respond }) => {
+        const account = accounts.find((candidate) => {
+          return candidate.id === params.connectionId;
+        });
+        return account
+          ? respond(200, account)
+          : respond(404, {
+              error: { code: "NOT_FOUND", message: "Account not found" },
+            });
+      },
+    );
+    context.mocks.api(connectorAccountsContract.connections, ({ respond }) => {
+      return respond(200, { connections: accounts, nextCursor: null });
+    });
+    context.mocks.api(
+      customConnectorValuesContract.set,
+      ({ body, respond }) => {
+        expect(body.account).toStrictEqual({ intent: "add" });
+        const account = customAccount(connector.id, crypto.randomUUID(), {
+          isDefault: false,
+        });
+        accounts.push(account);
+        return respond(200, { ...connector, connectedAccountId: account.id });
+      },
+    );
+    context.mocks.api(
+      customConnectorOAuth2Contract.start,
+      ({ body, respond }) => {
+        expect(body.account).toStrictEqual({ intent: "add" });
+        const account = customAccount(connector.id, crypto.randomUUID(), {
+          isDefault: false,
+        });
+        accounts.push(account);
+        return respond(200, {
+          result: "connected",
+          connector,
+          connectedAccountId: account.id,
+        });
+      },
+    );
+    context.mocks.browser.open(createAuthWindow());
+    await setupCustomPage({ mcp: true });
+    const name = connector.displayName;
+    click(
+      await waitFor(() => {
+        return getConnectorAction("button", `Manage ${name} access`);
+      }),
+    );
+    const access = await screen.findByRole("dialog", {
+      name: `Manage ${name} access`,
+    });
+    click(getConnectorSwitch(`Revoke ${name} access for Default`, access));
+    await waitFor(() => {
+      expect(
+        getConnectorSwitch(`Authorize ${name} access for Default`, access),
+      ).not.toBeChecked();
+    });
+    click(getConnectorAction("button", "Close", access));
+    click(getConnectorAction("button", `Manage ${name} accounts`));
+    const manager = await screen.findByRole("dialog", {
+      name: `Manage ${name} accounts`,
+    });
+    click(getConnectorAction("button", "Add account", manager));
+    if (kind !== "mcp-automatic") {
+      const addition = await screen.findByRole("dialog", {
+        name: `Connect ${name}`,
+      });
+      await fill(within(addition).getByLabelText("Secret"), "second-secret");
+      click(getConnectorAction("button", "Save", addition));
+    }
+    const naming = await screen.findByRole("dialog", {
+      name: `Name your ${name} account`,
+    });
+    click(getConnectorAction("button", "Skip", naming));
+    await waitFor(() => {
+      expect(
+        getConnectorAction("button", `Manage ${name} access`),
+      ).toHaveTextContent("Used by Research");
+    });
+    click(getConnectorAction("button", `Manage ${name} access`));
+    const updatedAccess = await screen.findByRole("dialog", {
+      name: `Manage ${name} access`,
+    });
+    expect(
+      getConnectorSwitch(`Authorize ${name} access for Default`, updatedAccess),
+    ).not.toBeChecked();
+    expect(
+      getConnectorSwitch(`Revoke ${name} access for Research`, updatedAccess),
+    ).toBeChecked();
+  },
+);
 
 test("Enable custom connector access when an account becomes available", async () => {
   const connector = customConnector({
@@ -1226,7 +1374,7 @@ test("Create and connect an MCP server with automatic authentication", async () 
   });
 });
 
-test("Authorize MCP access only after the selected account reconnects", async () => {
+test("Reconnect the selected MCP account without changing Agent access", async () => {
   const connector = mcpCustomConnector({
     authMode: "automatic",
     fields: [],
@@ -1342,7 +1490,7 @@ test("Authorize MCP access only after the selected account reconnects", async ()
   await waitFor(() => {
     expect(
       getConnectorAction("button", "Manage Acme MCP access"),
-    ).toHaveTextContent("Used by 2 agents");
+    ).toHaveTextContent("Add access");
     expect(dialog).not.toBeInTheDocument();
   });
   expect(

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connector-connect-dialog.tsx
@@ -21,13 +21,11 @@ import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
   closeCustomConnectorDialog$,
   connectCustomConnectorAuthorization$,
-  connectCustomConnectorAccountAuthorization$,
   connectCustomConnectorAuthorizationForAgent$,
   customConnectorConnectForm$,
   resetCustomConnectorConnectInput$,
   setCustomConnectorConnectField$,
   setCustomConnectorValues$,
-  setCustomConnectorAccountValues$,
   setCustomConnectorValuesForAgent$,
 } from "../../../../signals/okou-page/settings/custom-connectors.ts";
 import { sanitizeTokenInputRecord } from "../../../../signals/okou-page/settings/token-input.ts";
@@ -163,15 +161,9 @@ function useCustomConnectorConnectionSubmitters(
   const [agentAuthorizationLoadable, submitAgentAuthorization] = useLoadableSet(
     connectCustomConnectorAuthorizationForAgent$,
   );
-  const [accountValuesLoadable, submitAccountValues] = useLoadableSet(
-    setCustomConnectorAccountValues$,
-  );
-  const [accountAuthorizationLoadable, submitAccountAuthorization] =
-    useLoadableSet(connectCustomConnectorAccountAuthorization$);
   const account = accountOptions.account;
   const usesDefaultProjection =
     accountOptions.useDefaultConnectorProjection === true;
-  const managesAccount = !usesDefaultProjection;
 
   const submitDeclaredValues = async (
     args: {
@@ -180,9 +172,6 @@ function useCustomConnectorConnectionSubmitters(
     },
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionSubmission> => {
-    if (managesAccount) {
-      return await submitAccountValues({ ...args, account }, signal);
-    }
     if (agentId) {
       return await submitAgentValues({ ...args, agentId, account }, signal);
     }
@@ -192,12 +181,6 @@ function useCustomConnectorConnectionSubmitters(
     connectorId: string,
     signal: AbortSignal,
   ): Promise<CustomConnectorConnectionSubmission> => {
-    if (managesAccount) {
-      return await submitAccountAuthorization(
-        { id: connectorId, account },
-        signal,
-      );
-    }
     if (agentId) {
       return await submitAgentAuthorization(
         {
@@ -228,9 +211,7 @@ function useCustomConnectorConnectionSubmitters(
       valuesLoadable.state === "loading" ||
       agentValuesLoadable.state === "loading" ||
       authorizationLoadable.state === "loading" ||
-      agentAuthorizationLoadable.state === "loading" ||
-      accountValuesLoadable.state === "loading" ||
-      accountAuthorizationLoadable.state === "loading",
+      agentAuthorizationLoadable.state === "loading",
     submitDeclaredValues,
     submitAuthorizationMode,
   };

--- a/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/custom-connectors-panel.tsx
@@ -22,7 +22,7 @@ import {
 import type { ConnectorAccountSummary } from "@okouai/api-contracts/contracts/connector-accounts";
 import {
   closeCustomConnectorDialog$,
-  connectCustomConnectorAccountAuthorization$,
+  connectCustomConnectorAuthorization$,
   customConnectorAuthorizedAgentsById$,
   customConnectorDialog$,
   customConnectors$,
@@ -447,7 +447,7 @@ function CustomConnectorGrid({
   const openAccess = useSet(openCustomConnectorAccessDialog$);
   const openDelete = useSet(openCustomConnectorDeleteDialog$);
   const connectAccountAuthorization = useSet(
-    connectCustomConnectorAccountAuthorization$,
+    connectCustomConnectorAuthorization$,
   );
   const signal = useGet(pageSignal$);
   const openAccountManager = useSet(openCustomAccountManager$);
@@ -534,7 +534,7 @@ function CustomAccountDialogs({
   const openAccountConnect = useSet(openCustomAccountConnectDialog$);
   const finishAccountConnection = useSet(finishConnectorAccountConnection$);
   const connectAccountAuthorization = useSet(
-    connectCustomConnectorAccountAuthorization$,
+    connectCustomConnectorAuthorization$,
   );
   const signal = useGet(pageSignal$);
   return (

--- a/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/connectors-page.tsx
@@ -1071,6 +1071,7 @@ export function ConnectorsPage() {
           authMethod,
           {
             account: { intent: "add" },
+            authorizeVisibleAgents: true,
             connectorLabel: connector.label,
             connectorIcon: connector.icon,
           },
@@ -1088,6 +1089,7 @@ export function ConnectorsPage() {
             authMethod,
             options: {
               account: { intent: "add" },
+              authorizeVisibleAgents: true,
               connectorLabel: connector.label,
             },
           },
@@ -1209,6 +1211,7 @@ export function ConnectorsPage() {
       {accountConnect && (
         <ConnectModal
           item={accountConnect.connector}
+          authorizeVisibleAgentsOnConnect
           accountMode={accountConnect.mode}
           accountOptions={{
             account:


### PR DESCRIPTION
## Summary

- Automatically grant connector-level access to all currently visible agents, including the default agent, only when a successful Connect/Add account flow starts with zero accounts for that connector. Removing all accounts and adding one qualifies again.
- Preserve Agent access and manual revocations when adding another account or reconnecting. Use a fresh account-count read, including accounts that require reconnect, rather than cached connection status or current Agent grants.
- Cover built-in connectors and custom HTTP/MCP connectors. Gate both built-in server-side default-agent authorization and browser-owned visible-agent grants. Keep Agent-directed flows scoped to their requested agent and preserve explicit custom permission-bundle selection.
- Require the selected OAuth reconnect account to change before reporting completion. An unrelated sibling account cannot satisfy an exact-ID completion check.

- Restore the external-code start action when the pre-connect account lookup fails, while preserving successful pending sessions and the original API error.

Closes #32485

## Compatibility and risk

No API schemas, database state formats, or Runner protocols change. Existing browser bundles keep their previous behavior until refreshed. Account-count read failures propagate before a new connection is started; they are not treated as zero accounts.

Eligibility is a fresh pre-connect browser snapshot, not a transactional cross-tab first-account election. The user explicitly excluded interleaved unfinished account-add flows; server-side coordination for that scenario is not part of this PR. Authorization remains a separate browser-owned step after credential storage. Navigation or a grant API failure can leave a connected account with partial agent access; existing errors and manual Add access remain available. This PR does not introduce atomic connection-and-authorization semantics.

The shared timestamp-based reconnect signal can still confuse a concurrent metadata change with authentication completion. That existing cross-flow limitation and the obsolete no-ID fallback tracking reference are recorded in #32503. This PR does not claim attempt-specific completion proof. No historical-account backfill or implicit grants to agents created later.

## Validation

- `./scripts/prepare.sh`: passed, including environment sync, dependencies, local migrations, and development seed.
- Prettier for the changed files: passed.
- `pnpm -F @okouai/app lint`: passed in full, including assets, localization, build configuration, Oxlint, type-aware Oxlint, and ESLint.
- `pnpm -F @okouai/app check-types`: passed.
- `pnpm knip`: passed (configuration hints only).
- Commit hooks passed, including repository-wide type checking (15 successful tasks), formatting, Knip, file-size checks, and Conventional Commit validation.
- Related page integration suites: 8 files, 105 tests passed with one worker, without skipped tests or timeout changes:

  ```sh
  pnpm -F @okouai/app exec vitest run \
    src/views/okou-page/__tests__/connectors-auth-methods.test.tsx \
    src/views/okou-page/__tests__/connectors-custom.test.tsx \
    src/views/okou-page/__tests__/connectors-accounts.test.tsx \
    src/views/okou-page/__tests__/directed-connect-page.test.tsx \
    src/views/okou-page/__tests__/directed-authorize-page.test.tsx \
    src/views/okou-page/__tests__/chat-capability-connectors.test.tsx \
    src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx \
    src/views/okou-page/__tests__/connectors-catalog.test.tsx \
    --maxWorkers=1 --silent=passed-only
  ```

- No Rust/Python/API implementation suites were run because those implementations and contracts are unchanged. Live provider consent and production deployment were not exercised locally.
