### PR TITLE
fix(desktop): make computer use deadlines clock-skew safe

### DIFF
--- a/turbo/apps/desktop/cua/ADAPTER.md
+++ b/turbo/apps/desktop/cua/ADAPTER.md
@@ -64,20 +64,52 @@ unconditional success summary overrides these facts.
 
 ## Deadline and retirement
 
-The host preserves wire `timeoutMs`, `createdAt` and nullable `claimedAt` before
-its permission query. Explicit timeout is 1–120 seconds; CLI normally sends
-30 seconds and API creation defaults to 60 seconds. Only stored `null` uses the
-existing 120-second policy. Missing, malformed or future dates fail closed;
-`claimedAt` cannot restart the budget. Queue/transit age is subtracted once using
-wall time, then one monotonic deadline covers permission, session, discovery,
-action and post-state. Completion reserves at most one second (10% for a short
-remaining budget) and its requests/retries consume the same deadline. No network
-submission can be guaranteed after the server's command deadline has elapsed.
+The shared Okou/CUA/plugin host preserves wire `timeoutMs`, `createdAt` and
+`claimedAt` before its permission query. Explicit timeout is 1–120 seconds; CLI
+normally sends 30 seconds and API creation defaults to 60 seconds. Stored
+`timeoutMs: null` retains the existing 120-second policy. Successful claims have
+always stored a non-null `claimedAt`; the general read schema is nullable because
+it also serializes queued commands. Missing/null/invalid claim timestamps,
+invalid timeout bounds, or `claimedAt < createdAt` fail closed without native
+permission queries or actions.
+
+Execution uses only durations within one clock domain. Let `Q` be server
+`claimedAt - createdAt`, `S` the local monotonic time immediately before the claim
+request, and `R` the local monotonic time after JSON consumption/admission. The
+remaining allowance is `max(0, timeoutMs - Q - (R - S))`, anchored once at `R`.
+The existing early execution cutoff (at most one second, or 10% of the remaining
+allowance) is retained. Permission, session, discovery, action and post-state all
+consume this deadline; the Okou helper also checks it at each native dispatch.
+Mac wall time is used for diagnostic timestamps, never grant authority.
+
+The API samples `claimedAt` before its claim transaction, after the request
+started. Charging the entire local request interval conservatively covers that
+transaction and response/body delay (and may double-charge outbound delay
+already included in `Q`). It cannot extend the creation-based Desktop deadline or
+the API's independent running deadline measured from `claimedAt`. A delayed body
+remains inside the poll timeout and its late-claim owner. No claim receipt,
+retry, wall-clock adjustment or driver transition issues a new execution grant.
+
+Result/error delivery has a separate **five-second total monotonic cap**, with
+at most three attempts and two-second retry backoffs included in that cap. A hung
+attempt consumes the remaining reporting window. The cap is shorter than the
+existing 30-second driver-transition drain bound; Stop/sign-out/quit cancel it
+immediately. A reporting transport that ignores abort cannot hold the native
+lease beyond the cap; its late settlement is observed without publishing local
+success. Status 409 remains terminal and 401 withdraws authorization. The grace
+only reports the original result; it never repeats execution or overwrites a
+server-final result. Delivery cannot be guaranteed after the server deadline.
+
+This repair changes no API request/response, database, CLI timeout or deployment
+protocol: new Desktop uses the existing successful-claim shape against previous
+and current APIs, including the nullable timeout default. Previous Desktop still
+receives the identical API shape (and requires the Desktop repair for its clock
+bug); no synchronized API/Desktop release or API timing field is needed.
 
 Already-expired claims report no native action started. An in-flight timeout
-reports potentially delivered/unknown work. A network response arriving after
-poll cancellation remains leased through its failure submission, using the
-original remaining budget; its action is never dispatched. Fresh CUA permissions also have a
+reports potentially delivered/unknown work. A network response/body arriving
+after poll cancellation remains leased through bounded failure submission; its
+action is never dispatched. Fresh CUA permissions also have a
 bounded five-second readiness check within that command budget. Permission
 revocation, unexpected exit, fatal transport failure, timeout and lifecycle Stop
 withdraw native admission and invalidate targets. Public embedded `stop()` starts

--- a/turbo/apps/desktop/src/computer-use-command-budget.ts
+++ b/turbo/apps/desktop/src/computer-use-command-budget.ts
@@ -6,20 +6,21 @@ export interface ComputerUseCommandClock extends ComputerUseLifecycleTimers {
   readonly wallNow: () => number;
   readonly monotonicNow: () => number;
 }
-const systemClock: ComputerUseCommandClock = {
+export const systemComputerUseCommandClock: ComputerUseCommandClock = {
   wallNow: () => Date.now(),
   monotonicNow: () => performance.now(),
-  setTimeout,
-  clearTimeout,
+  setTimeout: (run, delay) => setTimeout(run, delay),
+  clearTimeout: (timer) => clearTimeout(timer),
 };
 
-/** Wire age is converted once; later clock adjustments cannot renew admission. */
+/** Server age plus the entire claim round trip bounds age without clock sync. */
 export class ComputerUseCommandBudget {
   private readonly deadline: number;
   private readonly reserve: number;
   constructor(
     command: ComputerUseCommand,
-    private readonly clock: ComputerUseCommandClock = systemClock,
+    claimStartedAt: number,
+    private readonly clock: ComputerUseCommandClock = systemComputerUseCommandClock,
   ) {
     const timeout = command.timeoutMs === null ? 120_000 : command.timeoutMs;
     const created =
@@ -27,32 +28,36 @@ export class ComputerUseCommandBudget {
         ? Date.parse(command.createdAt)
         : NaN;
     const claimed =
-      command.claimedAt === null
-        ? null
-        : typeof command.claimedAt === "string"
-          ? Date.parse(command.claimedAt)
-          : NaN;
-    const now = clock.wallNow();
-    // Malformed/future dates fail closed; claimedAt never restarts the budget.
+      typeof command.claimedAt === "string"
+        ? Date.parse(command.claimedAt)
+        : NaN;
+    const now = clock.monotonicNow();
+    const transport = now - claimStartedAt;
+    // Successful claims always stamp claimedAt, even on older APIs. The general
+    // read schema is nullable for queued commands, not an execution grant.
     const valid =
       typeof timeout === "number" &&
       Number.isInteger(timeout) &&
       timeout >= 1000 &&
       timeout <= 120_000 &&
       Number.isFinite(created) &&
-      created <= now &&
-      (claimed === null ||
-        (Number.isFinite(claimed) && claimed >= created && claimed <= now));
-    const remaining = valid ? Math.max(0, timeout - (now - created)) : 0;
-    this.deadline = clock.monotonicNow() + remaining;
+      Number.isFinite(claimed) &&
+      claimed >= created &&
+      Number.isFinite(transport) &&
+      transport >= 0;
+    // claimedAt is sampled before the API transaction. Charging the full local
+    // request interval (including JSON consumption) conservatively includes all
+    // time since that sample. Never compare server dates with the Mac wall clock.
+    const remaining = valid
+      ? Math.max(0, timeout - (claimed - created) - transport)
+      : 0;
+    this.deadline = now + remaining;
     this.reserve = Math.min(1000, remaining / 10);
   }
-  remaining(completion = false): number {
+  remaining(): number {
     return Math.max(
       0,
-      this.deadline -
-        this.clock.monotonicNow() -
-        (completion ? 0 : this.reserve),
+      this.deadline - this.clock.monotonicNow() - this.reserve,
     );
   }
   async run<T>(operation: () => Promise<T>, expire: () => void): Promise<T> {
@@ -65,13 +70,19 @@ export class ComputerUseCommandBudget {
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       return await Promise.race([
-        operation().then((value) => {
-          if (this.remaining() <= 0) {
-            expire();
-            throw this.timeout();
-          }
-          return value;
-        }),
+        operation().then(
+          (value) => {
+            if (this.remaining() <= 0) {
+              expire();
+              throw this.timeout();
+            }
+            return value;
+          },
+          (error: unknown) => {
+            if (this.remaining() <= 0) expire();
+            throw error;
+          },
+        ),
         new Promise<never>((_resolve, reject) => {
           timer = this.clock.setTimeout(() => {
             expire();

--- a/turbo/apps/desktop/src/computer-use-cua-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-cua-host.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
+import { createComputerUseNativeBackend } from "./computer-use-native";
 import { ComputerUseDriverController } from "./computer-use-driver";
 import { createCuaComputerUseDriver } from "./computer-use-cua";
 import { ComputerUseRuntimeController } from "./computer-use-runtime-controller";
@@ -35,6 +36,8 @@ async function desktop(
   granted = true,
   pluginEnabled = false,
   options: {
+    driver?: "okou" | "cua";
+    wallTime?: number;
     startupFailure?: boolean;
     stopDuringPreparation?: boolean;
     ignoreNetworkAbort?: boolean;
@@ -42,24 +45,49 @@ async function desktop(
 ) {
   const external = cuaBoundary();
   external.granted = granted;
+  // macOS TMPDIR can contain /var -> /private/var aliases; MCP requires canonical roots.
+  const directory = await realpath(
+    await mkdtemp(path.join(tmpdir(), "cua-plugin-")),
+  );
+  const helperPath = path.join(directory, "computer-use-helper");
+  const nativeLog = path.join(directory, "native.jsonl");
+  await writeFile(nativeLog, "");
+  if (options.driver === "okou") {
+    // Exercise the shipped Okou backend against the external helper protocol.
+    await writeFile(
+      helperPath,
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+require("node:readline").createInterface({ input: process.stdin }).on("line", line => {
+  const request = JSON.parse(line);
+  fs.appendFileSync(${JSON.stringify(nativeLog)}, JSON.stringify(request) + "\\n");
+  const result = request.kind === "permissions.state"
+    ? { accessibility: true, screenRecording: true }
+    : { apps: [{ name: "Editor", bundleId: "test.editor", running: true, pid: 123 }] };
+  process.stdout.write(JSON.stringify({ id: request.id, status: "succeeded", result }) + "\\n");
+});
+`,
+      { mode: 0o755 },
+    );
+  }
   const driver = new ComputerUseDriverController(
-    createCuaComputerUseDriver({
-      runtimeRoot: "/packaged/cua",
-      hostBundleId: "ai.okou.desktop",
-      loadSdk: async () => {
-        if (options.startupFailure) throw new Error("SDK load failed");
-        return external.sdk;
-      },
-    }),
+    options.driver === "okou"
+      ? {
+          id: "okou",
+          createBackend: () => createComputerUseNativeBackend({ helperPath }),
+        }
+      : createCuaComputerUseDriver({
+          runtimeRoot: "/packaged/cua",
+          hostBundleId: "ai.okou.desktop",
+          loadSdk: async () => {
+            if (options.startupFailure) throw new Error("SDK load failed");
+            return external.sdk;
+          },
+        }),
     "darwin",
   );
   const permissions = createComputerUsePermissions((read) =>
     driver.withPermissionProvider(read),
-  );
-  // macOS TMPDIR can contain /var -> /private/var aliases; MCP authorizes
-  // canonical roots and validates the requested path before following symlinks.
-  const directory = await realpath(
-    await mkdtemp(path.join(tmpdir(), "cua-plugin-")),
   );
   await writeFile(
     path.join(directory, "document.txt"),
@@ -76,19 +104,20 @@ async function desktop(
   plugin.setEnabled(pluginEnabled);
   const timers = new Map<
     ReturnType<typeof setTimeout>,
-    { run: () => void; delay: number }
+    { run: () => void; delay: number; due: number }
   >();
   const schedule = (run: () => void, delay: number) => {
     const id = setTimeout(() => {}, 2 ** 30);
     id.unref();
-    timers.set(id, { run, delay });
+    timers.set(id, { run, delay, due: monotonic + delay });
     return id;
   };
   const clear: typeof clearTimeout = (id) => {
     if (typeof id === "object") timers.delete(id);
     clearTimeout(id);
   };
-  let now = Date.now();
+  let now = options.wallTime ?? Date.now();
+  const serverNow = Date.parse("2026-09-08T02:44:36.980Z");
   let monotonic = 0;
   const budgetTimers = new Map<ReturnType<typeof setTimeout>, () => void>();
   const commandClock: ComputerUseCommandClock = {
@@ -128,6 +157,9 @@ async function desktop(
   let completion = deferred<Record<string, unknown>>();
   let claimGate: ReturnType<typeof deferred<void>> | null = null;
   const claimEntered = deferred<void>();
+  let streamClaim = false;
+  let respondToCompletion: (request: Request) => Promise<Response> = async () =>
+    HttpResponse.json({ ok: true });
   const controller = new ComputerUseRuntimeController({
     driver,
     refreshPermissions: permissions.refreshComputerUsePermissionState,
@@ -194,6 +226,24 @@ async function desktop(
         const next = command;
         command = null;
         if (next && claimGate) {
+          if (streamClaim) {
+            const gate = claimGate;
+            return new HttpResponse(
+              new ReadableStream({
+                async start(writer) {
+                  claimEntered.resolve();
+                  await gate.promise;
+                  writer.enqueue(
+                    new TextEncoder().encode(
+                      JSON.stringify({ status: "command", command: next }),
+                    ),
+                  );
+                  writer.close();
+                },
+              }),
+              { headers: { "content-type": "application/json" } },
+            );
+          }
           claimEntered.resolve();
           await claimGate.promise;
         }
@@ -201,7 +251,10 @@ async function desktop(
           next ? { status: "command", command: next } : { status: "idle" },
         );
       }
-      if (url.pathname.endsWith("/complete")) completion.resolve(body);
+      if (url.pathname.endsWith("/complete")) {
+        completion.resolve(body);
+        return respondToCompletion(request);
+      }
       return HttpResponse.json({ ok: true });
     }),
   );
@@ -219,7 +272,30 @@ async function desktop(
     requests,
     directory,
     plugin,
-    delayClaim() {
+    serverNow,
+    nativeLog: () => readFile(nativeLog, "utf8"),
+    setWall(time: number) {
+      now = time;
+    },
+    reportWith(respond: typeof respondToCompletion) {
+      respondToCompletion = respond;
+    },
+    hasReportingTimer(delay: number) {
+      return [...timers].some(
+        ([id, timer]) => budgetTimers.has(id) && timer.delay === delay,
+      );
+    },
+    runReportingTimer(delay: number) {
+      const entry = [...timers].find(
+        ([id, timer]) => budgetTimers.has(id) && timer.delay === delay,
+      );
+      if (!entry) throw new Error(`No reporting timer for ${delay}ms`);
+      clear(entry[0]);
+      budgetTimers.delete(entry[0]);
+      entry[1].run();
+    },
+    delayClaim(body = false) {
+      streamClaim = body;
       claimGate = deferred();
       return {
         entered: claimEntered.promise,
@@ -232,6 +308,17 @@ async function desktop(
       );
       if (!timer) throw new Error("No command poll deadline is scheduled");
       timer.run();
+    },
+    elapse(ms: number) {
+      now += ms;
+      monotonic += ms;
+      for (const [id, timer] of [...timers]) {
+        if (timer.due <= monotonic) {
+          clear(id);
+          budgetTimers.delete(id);
+          timer.run();
+        }
+      }
     },
     advance(ms: number) {
       now += ms;
@@ -252,8 +339,8 @@ async function desktop(
         kind,
         payload,
         timeoutMs: 30_000,
-        createdAt: new Date(now).toISOString(),
-        claimedAt: null,
+        createdAt: new Date(serverNow).toISOString(),
+        claimedAt: new Date(serverNow).toISOString(),
         ...metadata,
       };
       const poll = [...timers].find(
@@ -430,7 +517,8 @@ it.each([
       { app: "test.editor" },
       {
         timeoutMs,
-        createdAt: createdAt ?? new Date(Date.now() - age - 1000).toISOString(),
+        createdAt:
+          createdAt ?? new Date(d.serverNow - age - 1000).toISOString(),
       },
     );
     expect(completed).toMatchObject({
@@ -483,4 +571,345 @@ it("charges discovery time against action and post-state without resetting a 30-
     error: { code: "command_timeout" },
   });
   expect(d.driver.getCapabilities()).toEqual([]);
+});
+
+const observedClaim = {
+  createdAt: "2026-09-08T02:44:35.425Z",
+  claimedAt: "2026-09-08T02:44:36.980Z",
+  timeoutMs: 10_000,
+};
+
+it.each(["okou", "cua"] as const)(
+  "admits the user's actual server/Mac timestamp inversion through %s",
+  async (driver) => {
+    const d = await desktop(true, false, {
+      driver,
+      wallTime: Date.parse("2026-09-08T02:44:36.593Z"),
+    });
+    const completed = await d.queue("apps.list", {}, observedClaim);
+    expect(completed).toMatchObject({
+      status: "succeeded",
+      result: {
+        apps: expect.arrayContaining([
+          expect.objectContaining({ bundleId: "test.editor" }),
+        ]),
+      },
+    });
+    expect(d.controller.getHostState().localCommandLog[0]).toMatchObject({
+      startedAt: "2026-09-08T02:44:36.593Z",
+      status: "succeeded",
+      driver: { id: driver },
+    });
+    if (driver === "okou")
+      expect(await d.nativeLog()).toContain('"kind":"apps.list"');
+    else
+      expect(d.external.calls.some((call) => call.name === "list_apps")).toBe(
+        true,
+      );
+  },
+);
+
+for (const driver of ["okou", "cua"] as const) {
+  it.each([-120_000, 120_000])(
+    `${driver} admits a fresh server grant with a %s ms wall offset`,
+    async (offset) => {
+      const d = await desktop(true, false, { driver });
+      d.setWall(d.serverNow + offset);
+      expect(await d.queue("apps.list", {}, observedClaim)).toMatchObject({
+        status: "succeeded",
+      });
+    },
+  );
+
+  it.each([false, true])(
+    `${driver} charges delayed claim headers/body (%s) before any permission or native action`,
+    async (body) => {
+      const d = await desktop(true, false, { driver, wallTime: 0 });
+      const before = d.external.calls.length;
+      const nativeBefore = await d.nativeLog();
+      const gate = d.delayClaim(body);
+      const report = d.queue("apps.list", {}, observedClaim);
+      await gate.entered;
+      d.advance(8_500); // 1,555 ms server queue age + transport exceeds 10 seconds.
+      gate.release();
+      expect(await report).toMatchObject({
+        status: "failed",
+        error: { code: "command_timeout" },
+      });
+      expect(d.external.calls.slice(before)).toEqual([]);
+      expect(await d.nativeLog()).toBe(nativeBefore);
+    },
+  );
+
+  it.each([
+    { claimedAt: null },
+    { claimedAt: undefined },
+    { claimedAt: "invalid" },
+    { claimedAt: "2026-09-08T02:44:35.424Z" },
+    { createdAt: undefined },
+    { timeoutMs: undefined },
+    { timeoutMs: 999 },
+    { timeoutMs: 120_001 },
+    { timeoutMs: 1000.5 },
+    { createdAt: "2026-09-08T02:44:26.980Z" },
+  ])(
+    `${driver} fails closed on unprovable or expired successful-claim metadata %j`,
+    async (metadata) => {
+      const d = await desktop(true, false, { driver });
+      const before = d.external.calls.length;
+      const nativeBefore = await d.nativeLog();
+      const report = await d.queue(
+        "apps.list",
+        {},
+        { ...observedClaim, ...metadata },
+      );
+      expect(report).toMatchObject({
+        status: "failed",
+        error: { code: "command_timeout" },
+      });
+      expect(d.external.calls.slice(before)).toEqual([]);
+      expect(await d.nativeLog()).toBe(nativeBefore);
+    },
+  );
+
+  it(`${driver} accepts the existing nullable timeout default without new API fields`, async () => {
+    const d = await desktop(true, false, { driver });
+    expect(await d.queue("apps.list", {}, { timeoutMs: null })).toMatchObject({
+      status: "succeeded",
+    });
+  });
+}
+
+it("does not renew a deadline after a backwards or forwards Mac wall-clock adjustment", async () => {
+  const d = await desktop();
+  d.external.intercept = async (name) => {
+    if (name === "check_permissions") {
+      d.setWall(d.serverNow + 120_000);
+      d.advance(10_000);
+      d.setWall(d.serverNow - 120_000);
+    }
+  };
+  expect(
+    await d.queue("app.open", { app: "test.editor" }, observedClaim),
+  ).toMatchObject({
+    status: "failed",
+    error: { code: "command_timeout" },
+  });
+  expect(d.external.calls.some((call) => call.name === "launch_app")).toBe(
+    false,
+  );
+  expect(d.driver.getCapabilities()).toEqual([]);
+});
+
+it("keeps a cancelled poll's delayed JSON body owned and reports without dispatch", async () => {
+  const d = await desktop(true, false, { ignoreNetworkAbort: true });
+  const gate = d.delayClaim(true);
+  const report = d.queue("apps.list", {}, { timeoutMs: 60_000 });
+  await gate.entered;
+  d.advance(31_000);
+  d.expirePoll();
+  gate.release();
+  expect(await report).toMatchObject({
+    status: "failed",
+    error: {
+      code: "command_timeout",
+      message: expect.stringContaining("polling deadline"),
+    },
+  });
+  expect(d.external.calls.some((call) => call.name === "list_apps")).toBe(
+    false,
+  );
+});
+
+it("delivers an exhausted execution's original error after 100 ms of reporting latency", async () => {
+  const d = await desktop();
+  const received = deferred<void>();
+  const response = deferred<void>();
+  d.reportWith(async () => {
+    received.resolve();
+    await response.promise;
+    return HttpResponse.json({ ok: true });
+  });
+  const report = d.queue(
+    "apps.list",
+    {},
+    { ...observedClaim, createdAt: "2026-09-08T02:44:26.980Z" },
+  );
+  await received.promise;
+  d.elapse(100);
+  response.resolve();
+  expect(await report).toMatchObject({
+    status: "failed",
+    error: { code: "command_timeout" },
+  });
+  await expect
+    .poll(() => d.controller.getHostState().lastCommandAt)
+    .not.toBeNull();
+  expect(d.requests.filter((r) => r.path.endsWith("/complete"))).toHaveLength(
+    1,
+  );
+});
+
+it("bounds transient retries and an abort-ignoring reporting request by one five-second deadline", async () => {
+  const d = await desktop(true, false, { ignoreNetworkAbort: true });
+  const secondAttempt = deferred<void>();
+  const lateResponse = deferred<void>();
+  let attempts = 0;
+  d.reportWith(async () => {
+    attempts++;
+    if (attempts === 1) return new HttpResponse(null, { status: 503 });
+    secondAttempt.resolve();
+    await lateResponse.promise;
+    return HttpResponse.json({ ok: true });
+  });
+  await d.queue("apps.list", {}, { ...observedClaim, claimedAt: null });
+  await expect.poll(() => attempts).toBe(1);
+  // Wait for HTTP consumption to schedule the retry, without replacing async code.
+  await expect.poll(() => d.hasReportingTimer(2_000)).toBe(true);
+  d.runReportingTimer(2_000);
+  d.advance(2_000);
+  await secondAttempt.promise;
+  d.advance(3_000);
+  d.runReportingTimer(5_000);
+  await expect
+    .poll(() => d.controller.getHostState().status)
+    .toBe("recovering");
+  expect(d.controller.getHostState().lastError).toContain(
+    "reporting timed out after 5000ms",
+  );
+  expect(attempts).toBe(2);
+  // Neither the pending response nor its late success keeps the native lease.
+  await d.driver.retire();
+  lateResponse.resolve();
+  expect(d.controller.getHostState().lastCommandAt).toBeNull();
+  expect(d.external.calls.some((call) => call.name === "list_apps")).toBe(
+    false,
+  );
+});
+
+it.each(["stop", "sign-out", "quit"])(
+  "%s cancels reporting and releases its lease without waiting for the reporting deadline",
+  async (reason) => {
+    const d = await desktop();
+    const received = deferred<void>();
+    const cancelled = deferred<void>();
+    const respond = deferred<void>();
+    d.reportWith(async (request) => {
+      request.signal.addEventListener("abort", () => cancelled.resolve(), {
+        once: true,
+      });
+      received.resolve();
+      await respond.promise;
+      return HttpResponse.json({ ok: true });
+    });
+    await d.queue("apps.list", {}, observedClaim);
+    await received.promise;
+    if (reason === "stop") await d.controller.stop();
+    else if (reason === "sign-out") await d.controller.stopForAuthChange();
+    else await d.controller.stopForQuit();
+    await cancelled.promise;
+    respond.resolve();
+    expect(d.controller.getHostState().status).toBe("offline");
+    expect(d.driver.getCapabilities()).toEqual([]);
+    expect(d.external.destroyed).toBe(true);
+    expect(d.requests.filter((r) => r.path.endsWith("/complete"))).toHaveLength(
+      1,
+    );
+  },
+);
+
+it("retries only result delivery and preserves the original result on success", async () => {
+  const d = await desktop();
+  let attempts = 0;
+  d.reportWith(async () =>
+    ++attempts === 1
+      ? new HttpResponse(null, { status: 503 })
+      : HttpResponse.json({ ok: true }),
+  );
+  const result = await d.queue("apps.list", {}, observedClaim);
+  await expect.poll(() => d.hasReportingTimer(2_000)).toBe(true);
+  d.advance(2_000);
+  d.runReportingTimer(2_000);
+  await expect
+    .poll(() => d.controller.getHostState().lastCommandAt)
+    .not.toBeNull();
+  expect(
+    d.requests.filter((r) => r.path.endsWith("/complete")).map((r) => r.body),
+  ).toEqual([result, result]);
+  expect(
+    d.external.calls.filter((call) => call.name === "list_apps"),
+  ).toHaveLength(1);
+});
+
+it("accepts a terminal server completion without retrying or overwriting the local failure", async () => {
+  const d = await desktop();
+  d.reportWith(async () => new HttpResponse(null, { status: 409 }));
+  const result = await d.queue(
+    "apps.list",
+    {},
+    { ...observedClaim, claimedAt: null },
+  );
+  await expect
+    .poll(() => d.controller.getHostState().lastCommandAt)
+    .not.toBeNull();
+  expect(result).toMatchObject({
+    status: "failed",
+    error: { code: "command_timeout" },
+  });
+  expect(d.controller.getHostState().localCommandLog[0]?.status).toBe("failed");
+  expect(d.requests.filter((r) => r.path.endsWith("/complete"))).toHaveLength(
+    1,
+  );
+});
+
+it("retains the original driver generation while a normal switch drains reporting", async () => {
+  const d = await desktop();
+  const received = deferred<void>();
+  const response = deferred<void>();
+  d.reportWith(async () => {
+    received.resolve();
+    await response.promise;
+    return HttpResponse.json({ ok: true });
+  });
+  await d.queue("apps.list", {}, observedClaim);
+  await received.promise;
+  const generation = d.driver.generation;
+  const replacement = cuaBoundary();
+  const transition = d.controller.transitionDriver(
+    createCuaComputerUseDriver({
+      runtimeRoot: "/packaged/cua",
+      hostBundleId: "ai.okou.desktop",
+      loadSdk: async () => replacement.sdk,
+    }),
+  );
+  expect(d.external.destroyed).toBe(false);
+  expect(replacement.sessions).toBe(0);
+  d.advance(100);
+  response.resolve();
+  await transition;
+  expect(d.external.destroyed).toBe(true);
+  expect(d.driver.generation).not.toBe(generation);
+  expect(
+    d.requests.filter((r) => r.path.endsWith("/hosts/start")),
+  ).toHaveLength(1);
+  expect(
+    d.external.calls.filter((call) => call.name === "list_apps"),
+  ).toHaveLength(1);
+});
+
+it("cancels retry backoff on Stop without further reporting or native work", async () => {
+  const d = await desktop();
+  d.reportWith(async () => new HttpResponse(null, { status: 503 }));
+  await d.queue("apps.list", {}, observedClaim);
+  await expect.poll(() => d.hasReportingTimer(2_000)).toBe(true);
+  await d.controller.stop();
+  expect(d.hasReportingTimer(2_000)).toBe(false);
+  expect(d.hasReportingTimer(5_000)).toBe(false);
+  expect(d.controller.getHostState().status).toBe("offline");
+  expect(d.requests.filter((r) => r.path.endsWith("/complete"))).toHaveLength(
+    1,
+  );
+  expect(
+    d.external.calls.filter((call) => call.name === "list_apps"),
+  ).toHaveLength(1);
 });

--- a/turbo/apps/desktop/src/computer-use-host.test.ts
+++ b/turbo/apps/desktop/src/computer-use-host.test.ts
@@ -408,7 +408,7 @@ describe("ComputerUseHostRuntime", () => {
           command: {
             timeoutMs: 60_000,
             createdAt: new Date().toISOString(),
-            claimedAt: null,
+            claimedAt: new Date().toISOString(),
             id: "cmd-1",
             kind: "app.state",
             payload: { app: "Safari" },
@@ -456,7 +456,7 @@ describe("ComputerUseHostRuntime", () => {
           command: {
             timeoutMs: 60_000,
             createdAt: new Date().toISOString(),
-            claimedAt: null,
+            claimedAt: new Date().toISOString(),
             id: "cmd-1",
             kind: "app.state",
             payload: { app: "Things" },
@@ -524,7 +524,7 @@ describe("ComputerUseHostRuntime", () => {
       {
         timeoutMs: 60_000,
         createdAt: expect.any(String),
-        claimedAt: null,
+        claimedAt: expect.any(String),
         id: "cmd-1",
         kind: "app.state",
         payload: { app: "Things" },
@@ -574,7 +574,7 @@ describe("ComputerUseHostRuntime", () => {
           command: {
             timeoutMs: 60_000,
             createdAt: new Date().toISOString(),
-            claimedAt: null,
+            claimedAt: new Date().toISOString(),
             id: `cmd-${nextCommandId.toString()}`,
             kind: "keyboard.press_key",
             payload: { app: "Terminal", key: "Enter" },
@@ -607,7 +607,7 @@ describe("ComputerUseHostRuntime", () => {
     const command: ComputerUseCommand = {
       timeoutMs: 60_000,
       createdAt: new Date().toISOString(),
-      claimedAt: null,
+      claimedAt: new Date().toISOString(),
       id: "cmd-1",
       kind: "element.set_value",
       payload: { app: "com.google.Chrome", value: "https://example.com" },
@@ -677,7 +677,7 @@ describe("ComputerUseHostRuntime", () => {
     const command: ComputerUseCommand = {
       timeoutMs: 60_000,
       createdAt: new Date().toISOString(),
-      claimedAt: null,
+      claimedAt: new Date().toISOString(),
       id: "cmd-1",
       kind: "keyboard.type_text",
       payload: { app: "Chrome", text: "https://mail.google.com/" },
@@ -717,7 +717,7 @@ describe("ComputerUseHostRuntime", () => {
     expect(executeCommand).toHaveBeenCalledOnce();
     expect(completeCalls).toBe(0);
 
-    await vi.advanceTimersByTimeAsync(90_000);
+    await vi.advanceTimersByTimeAsync(30_000);
 
     const heartbeatCalls = hostFetch.mock.calls.filter(([url]) => {
       return url.endsWith("/api/computer-use/heartbeat");
@@ -738,7 +738,7 @@ describe("ComputerUseHostRuntime", () => {
     const command: ComputerUseCommand = {
       timeoutMs: 60_000,
       createdAt: new Date().toISOString(),
-      claimedAt: null,
+      claimedAt: new Date().toISOString(),
       id: "cmd-1",
       kind: "keyboard.type_text",
       payload: { app: "Chrome", text: "okou" },
@@ -812,7 +812,7 @@ describe("ComputerUseHostRuntime", () => {
               command: {
                 timeoutMs: 60_000,
                 createdAt: new Date().toISOString(),
-                claimedAt: null,
+                claimedAt: new Date().toISOString(),
                 id: "cmd-1",
                 kind: "app.state",
                 payload: { app: "Chrome" },
@@ -862,7 +862,7 @@ describe("ComputerUseHostRuntime", () => {
               command: {
                 timeoutMs: 60_000,
                 createdAt: new Date().toISOString(),
-                claimedAt: null,
+                claimedAt: new Date().toISOString(),
                 id: "cmd-1",
                 kind: "app.state",
                 payload: { app: "Chrome" },
@@ -920,7 +920,7 @@ describe("ComputerUseHostRuntime", () => {
             command: {
               timeoutMs: 60_000,
               createdAt: new Date().toISOString(),
-              claimedAt: null,
+              claimedAt: new Date().toISOString(),
               id: "cmd-1",
               kind: "app.state",
               payload: { app: "Chrome" },
@@ -934,7 +934,7 @@ describe("ComputerUseHostRuntime", () => {
             command: {
               timeoutMs: 60_000,
               createdAt: new Date().toISOString(),
-              claimedAt: null,
+              claimedAt: new Date().toISOString(),
               id: "cmd-2",
               kind: "app.state",
               payload: { app: "Chrome" },
@@ -1001,7 +1001,7 @@ describe("ComputerUseHostRuntime", () => {
     await runtime.stop();
   });
 
-  it("retries hung command completion requests with a request timeout", async () => {
+  it("bounds hung command reporting without renewing the execution grant", async () => {
     vi.useFakeTimers();
     let nextCalls = 0;
     let completeCalls = 0;
@@ -1017,7 +1017,7 @@ describe("ComputerUseHostRuntime", () => {
               command: {
                 timeoutMs: 120_000,
                 createdAt: new Date().toISOString(),
-                claimedAt: null,
+                claimedAt: new Date().toISOString(),
                 id: "cmd-1",
                 kind: "app.state",
                 payload: { app: "Chrome" },
@@ -1040,19 +1040,14 @@ describe("ComputerUseHostRuntime", () => {
 
     expect(completeCalls).toBe(1);
 
-    await vi.advanceTimersByTimeAsync(60_000);
-    await vi.advanceTimersByTimeAsync(1_999);
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(completeCalls).toBe(1);
-
-    await vi.advanceTimersByTimeAsync(1);
-
-    expect(completeCalls).toBe(2);
     expect(runtime.getState()).toMatchObject({
-      status: "online",
-      lastError: null,
+      status: "recovering",
+      lastError: "Computer Use command reporting timed out after 5000ms",
     });
-    expect(runtime.getState().lastCommandAt).toEqual(expect.any(String));
+    expect(runtime.getState().lastCommandAt).toBeNull();
 
     await runtime.stop();
   });
@@ -1262,7 +1257,7 @@ describe("ComputerUseHostRuntime", () => {
             command: {
               timeoutMs: 60_000,
               createdAt: new Date().toISOString(),
-              claimedAt: null,
+              claimedAt: new Date().toISOString(),
               id: "cmd-1",
               kind: "app.state",
               payload: { app: "Chrome" },

--- a/turbo/apps/desktop/src/computer-use-host.ts
+++ b/turbo/apps/desktop/src/computer-use-host.ts
@@ -1,6 +1,7 @@
 import { createComputerUseDrain } from "./computer-use-lifecycle-deadline";
 import {
   ComputerUseCommandBudget,
+  systemComputerUseCommandClock,
   type ComputerUseCommandClock,
 } from "./computer-use-command-budget";
 import { ComputerUseNativeHelperError } from "./computer-use-native";
@@ -38,7 +39,8 @@ const RECOVERY_RETRY_MAX_MS = 60_000;
 const RECOVERY_RETRY_AFTER_MAX_MS = 5 * 60_000;
 const HEARTBEAT_REQUEST_TIMEOUT_MS = 10_000;
 const COMMAND_POLL_REQUEST_TIMEOUT_MS = 30_000;
-const COMMAND_COMPLETION_REQUEST_TIMEOUT_MS = 60_000;
+// Reporting only: one hard cap includes every request and retry backoff.
+const COMMAND_REPORTING_TIMEOUT_MS = 5_000;
 const COMMAND_COMPLETION_RETRY_DELAY_MS = 2_000;
 const COMMAND_COMPLETION_MAX_ATTEMPTS = 3;
 const AUTH_ME_PATH = "/api/auth/me";
@@ -267,7 +269,8 @@ export class ComputerUseHostRuntime {
   private sessionGeneration = 0;
   private pauseGeneration = 0;
   private commandDrained = createComputerUseDrain();
-  private readonly commandRequests = new Set<Promise<Response>>();
+  private readonly commandRequests = new Set<Promise<unknown>>();
+  private readonly reportingControllers = new Set<AbortController>();
   private lastCommandActivityAtMs: number | null = null;
   private lastCommandCompletionAtMs: number | null = null;
   private hostToken: string | null = null;
@@ -284,7 +287,7 @@ export class ComputerUseHostRuntime {
   };
 
   constructor(options: ComputerUseHostRuntimeOptions) {
-    this.commandClock = options.commandClock;
+    this.commandClock = options.commandClock ?? systemComputerUseCommandClock;
     this.acquireCommand = options.acquireCommand;
     this.apiBaseUrl = resolveComputerUseApiBaseUrl(options.platformUrl);
     this.installationId = options.installationId;
@@ -306,7 +309,7 @@ export class ComputerUseHostRuntime {
   }
 
   private readonly acquireCommand: ComputerUseHostRuntimeOptions["acquireCommand"];
-  private commandClock: ComputerUseCommandClock | undefined;
+  private readonly commandClock: ComputerUseCommandClock;
 
   async start(): Promise<void> {
     if (this.running) {
@@ -333,6 +336,7 @@ export class ComputerUseHostRuntime {
 
   async stop(): Promise<void> {
     this.running = false;
+    for (const controller of this.reportingControllers) controller.abort();
     this.sessionGeneration++;
     this.pauseGeneration++;
     this.draining = false;
@@ -457,6 +461,7 @@ export class ComputerUseHostRuntime {
   ): void {
     this.hostToken = null;
     this.running = false;
+    for (const controller of this.reportingControllers) controller.abort();
     this.clearHeartbeatTimer();
     this.clearCommandTimer();
     this.clearRecoveryTimer();
@@ -886,13 +891,13 @@ export class ComputerUseHostRuntime {
     return response.ok;
   }
 
-  private async runHostRequestWithTimeout(args: {
+  private async runHostRequestWithTimeout<T>(args: {
     readonly label: string;
     readonly timeoutMs: number;
-    readonly request: (signal: AbortSignal) => Promise<Response>;
+    readonly request: (signal: AbortSignal) => Promise<T>;
     readonly commandRequest?: boolean;
-    readonly onLateResponse?: (response: Response) => Promise<void>;
-  }): Promise<Response> {
+    readonly onLateResponse?: (response: T) => Promise<void>;
+  }): Promise<T> {
     const { label, timeoutMs, request } = args;
     const timeoutMessage = () => {
       return new Error(`Computer Use ${label} timed out after ${timeoutMs}ms`);
@@ -991,20 +996,18 @@ export class ComputerUseHostRuntime {
       await this.stop();
       return "idle";
     }
-    const next = await this.runHostRequestWithTimeout({
+    const claimStartedAt = this.commandClock.monotonicNow();
+    const next = await this.runHostRequestWithTimeout<{
+      response: Response;
+      body: ComputerUseHostNextResponse | null;
+    }>({
       label: "command poll",
       timeoutMs: COMMAND_POLL_REQUEST_TIMEOUT_MS,
       commandRequest: true,
-      onLateResponse: async (response) => {
+      onLateResponse: async ({ response, body: late }) => {
         if (
           !response.ok ||
-          !this.running ||
-          generation !== this.sessionGeneration
-        )
-          return;
-        const late = (await response.json()) as ComputerUseHostNextResponse;
-        if (
-          late.status !== "command" ||
+          late?.status !== "command" ||
           !this.running ||
           generation !== this.sessionGeneration
         )
@@ -1020,32 +1023,40 @@ export class ComputerUseHostRuntime {
             },
           },
           generation,
-          new ComputerUseCommandBudget(late.command, this.commandClock),
         );
       },
       request: async (signal) => {
-        return await this.hostFetch("/api/computer-use/host/commands/next", {
-          method: "POST",
-          body: JSON.stringify({
-            supportedCapabilities: [...this.getSupportedCapabilities()],
-          }),
-          signal,
-        });
+        const response = await this.hostFetch(
+          "/api/computer-use/host/commands/next",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              supportedCapabilities: [...this.getSupportedCapabilities()],
+            }),
+            signal,
+          },
+        );
+        // Keep body consumption inside the poll deadline and late-claim owner.
+        const body = response.ok
+          ? ((await response.json()) as ComputerUseHostNextResponse)
+          : null;
+        return { response, body };
       },
     });
     if (!this.running || generation !== this.sessionGeneration) return "idle";
-    if (next.status === 401) {
+    if (next.response.status === 401) {
       this.deactivateInvalidHostToken("command_poll");
       return "idle";
     }
-    if (!next.ok) {
+    if (!next.response.ok) {
       throw new ComputerUseHttpError(
-        `Computer Use command claim failed: ${next.status}`,
-        next,
+        `Computer Use command claim failed: ${next.response.status}`,
+        next.response,
       );
     }
-    const body = (await next.json()) as ComputerUseHostNextResponse;
-    if (!this.running || generation !== this.sessionGeneration) return "idle";
+    const body = next.body;
+    if (!body)
+      throw new Error("Computer Use claim response is missing its body");
     if (body.status === "idle") {
       if (
         !this.running ||
@@ -1058,7 +1069,7 @@ export class ComputerUseHostRuntime {
       return "idle";
     }
 
-    const startedAtMs = Date.now();
+    const startedAtMs = this.commandClock.wallNow();
     this.lastCommandActivityAtMs = startedAtMs;
     const startedAt = new Date(startedAtMs).toISOString();
     this.startLocalCommandLogEntry(
@@ -1070,6 +1081,7 @@ export class ComputerUseHostRuntime {
     let completed: ComputerUseCommandExecutionResult;
     const budget = new ComputerUseCommandBudget(
       body.command,
+      claimStartedAt,
       this.commandClock,
     );
     try {
@@ -1088,7 +1100,7 @@ export class ComputerUseHostRuntime {
     } catch (error) {
       completed = commandFailureFromError(error);
     }
-    const completedAtMs = Date.now();
+    const completedAtMs = this.commandClock.wallNow();
     this.finishLocalCommandLogEntry({
       commandId: body.command.id,
       status: completed.status,
@@ -1107,12 +1119,7 @@ export class ComputerUseHostRuntime {
     ) {
       return "idle";
     }
-    await this.completeCommandWithRetry(
-      body.command.id,
-      completed,
-      generation,
-      budget,
-    );
+    await this.completeCommandWithRetry(body.command.id, completed, generation);
     if (
       !this.running ||
       generation !== this.sessionGeneration ||
@@ -1136,77 +1143,93 @@ export class ComputerUseHostRuntime {
     commandId: string,
     completed: ComputerUseCommandExecutionResult,
     generation: number,
-    budget: ComputerUseCommandBudget,
   ): Promise<void> {
-    let lastError: Error | null = null;
-    for (
-      let attempt = 1;
-      attempt <= COMMAND_COMPLETION_MAX_ATTEMPTS;
-      attempt++
-    ) {
-      if (!this.running || generation !== this.sessionGeneration) return;
-      if (attempt > 1 && budget.remaining(true) <= 0) break;
-      try {
-        const response = await this.runHostRequestWithTimeout({
-          label: "command completion",
-          timeoutMs: Math.max(
-            1,
-            Math.min(
-              COMMAND_COMPLETION_REQUEST_TIMEOUT_MS,
-              budget.remaining(true),
-            ),
-          ),
-          commandRequest: true,
-          request: async (signal) => {
-            return await this.hostFetch(
+    if (!this.running || generation !== this.sessionGeneration) return;
+    const controller = new AbortController();
+    this.reportingControllers.add(controller);
+    const timeout = new Error(
+      "Computer Use command reporting timed out after 5000ms",
+    );
+    const deadline =
+      this.commandClock.monotonicNow() + COMMAND_REPORTING_TIMEOUT_MS;
+    const expired = new Promise<never>((_resolve, reject) => {
+      controller.signal.addEventListener(
+        "abort",
+        () => reject(controller.signal.reason),
+        { once: true },
+      );
+    });
+    const timer = this.commandClock.setTimeout(
+      () => controller.abort(timeout),
+      COMMAND_REPORTING_TIMEOUT_MS,
+    );
+    let lastError: unknown = timeout;
+    try {
+      for (
+        let attempt = 1;
+        attempt <= COMMAND_COMPLETION_MAX_ATTEMPTS;
+        attempt++
+      ) {
+        if (!this.running || generation !== this.sessionGeneration) return;
+        if (this.commandClock.monotonicNow() >= deadline) throw timeout;
+        controller.signal.throwIfAborted();
+        try {
+          // A timed-out reporting transport has no native authority. Observe its
+          // late settlement, but never let it hold the command lease past this cap.
+          const response = await Promise.race([
+            this.hostFetch(
               `/api/computer-use/host/commands/${commandId}/complete`,
               {
                 method: "POST",
                 body: JSON.stringify(completed),
-                signal,
+                signal: controller.signal,
               },
-            );
-          },
-        });
-        if (!this.running || generation !== this.sessionGeneration) return;
-        if (response.ok) {
-          return;
+            ),
+            expired,
+          ]);
+          if (!this.running || generation !== this.sessionGeneration) return;
+          if (this.commandClock.monotonicNow() >= deadline) throw timeout;
+          controller.signal.throwIfAborted();
+          if (response.ok || response.status === 409) return;
+          if (response.status === 401) {
+            this.deactivateInvalidHostToken("command_poll");
+            return;
+          }
+          lastError = new ComputerUseHttpError(
+            `Computer Use command completion failed: ${response.status}`,
+            response,
+          );
+        } catch (error) {
+          lastError = error;
+          controller.signal.throwIfAborted();
         }
-        if (response.status === 401) {
-          this.deactivateInvalidHostToken("command_poll");
-          return;
+        if (attempt < COMMAND_COMPLETION_MAX_ATTEMPTS) {
+          const remaining = deadline - this.commandClock.monotonicNow();
+          if (remaining <= COMMAND_COMPLETION_RETRY_DELAY_MS) break;
+          let retryTimer: ReturnType<typeof setTimeout> | undefined;
+          try {
+            await Promise.race([
+              new Promise<void>((resolve) => {
+                retryTimer = this.commandClock.setTimeout(
+                  resolve,
+                  COMMAND_COMPLETION_RETRY_DELAY_MS,
+                );
+              }),
+              expired,
+            ]);
+          } finally {
+            this.commandClock.clearTimeout(retryTimer);
+          }
         }
-        if (response.status === 409) {
-          return;
-        }
-        lastError = new ComputerUseHttpError(
-          `Computer Use command completion failed: ${response.status}`,
-          response,
-        );
-      } catch (error) {
-        lastError =
-          error instanceof Error
-            ? error
-            : new Error(
-                `Computer Use command completion failed: ${String(error)}`,
-              );
       }
-
-      if (
-        attempt < COMMAND_COMPLETION_MAX_ATTEMPTS &&
-        budget.remaining(true) > COMMAND_COMPLETION_RETRY_DELAY_MS
-      ) {
-        await this.sleep(COMMAND_COMPLETION_RETRY_DELAY_MS);
-      }
+      throw lastError;
+    } finally {
+      this.commandClock.clearTimeout(timer);
+      this.reportingControllers.delete(controller);
+      // Also cancel fetches when a monotonic deadline is observed before its
+      // timer runs. This signal can only cancel delivery, never resume execution.
+      controller.abort(timeout);
     }
-
-    throw lastError ?? new Error("Computer Use command completion failed");
-  }
-
-  private sleep(delayMs: number): Promise<void> {
-    return new Promise((resolve) => {
-      this.scheduleTimeout(resolve, delayMs);
-    });
   }
 
   private hostFetch(path: string, init: RequestInit): Promise<Response> {

--- a/turbo/apps/desktop/src/computer-use-native.ts
+++ b/turbo/apps/desktop/src/computer-use-native.ts
@@ -1051,6 +1051,7 @@ class ComputerUseNativeRuntimeClient {
 export function createComputerUseNativeBackend(
   options: RunComputerUseHelperOptions = {},
 ): ComputerUseNativeBackend {
+  let commandBudget: ComputerUseCommandBudget | null = null;
   const helperPath = options.helperPath ?? resolveComputerUseHelperPath();
   const runtime =
     options.mode === "oneshot"
@@ -1064,12 +1065,23 @@ export function createComputerUseNativeBackend(
   const run = async (
     request: ComputerUseNativeRequest,
   ): Promise<Record<string, unknown>> => {
+    // I/O continuations can run before the host's expiry timer. Check the same
+    // grant at every helper dispatch, including post-action observation.
+    if (commandBudget && commandBudget.remaining() <= 0) {
+      throw new ComputerUseNativeHelperError(
+        "command_timeout",
+        "Computer Use total command budget expired before native dispatch; prior action completion may be unknown, do not replay",
+      );
+    }
     return runtime
       ? await runtime.request(request)
       : await runComputerUseHelper(request, { ...options, helperPath });
   };
 
   return {
+    setCommandBudget: (budget) => {
+      commandBudget = budget;
+    },
     dispose: async (reason) => {
       await runtime?.dispose(reason);
     },

--- a/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-driver.test.ts
@@ -1,3 +1,4 @@
+import type { ComputerUseCommandClock } from "./computer-use-command-budget";
 import { DesktopRecorderController } from "./desktop-recorder-controller";
 import { createRecorderNativeBackend } from "./desktop-recorder-native";
 import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "node:fs";
@@ -215,6 +216,7 @@ function nativeProcesses(events: string[]) {
 
 function desktop(
   options: {
+    commandClock?: ComputerUseCommandClock;
     transitionTimeoutMs?: number;
     nativeShutdownGraceMs?: number;
     expectedQuitError?: string;
@@ -316,6 +318,7 @@ function desktop(
               throw new Error("No plugin configured in this fixture");
             return options.plugin.execute(command);
           },
+          commandClock: options.commandClock,
           setTimeout: timers.schedule,
           clearTimeout: timers.clear,
         },
@@ -362,7 +365,7 @@ function desktop(
           command: {
             timeoutMs: 60_000,
             createdAt: new Date().toISOString(),
-            claimedAt: null,
+            claimedAt: new Date().toISOString(),
             ...command,
           },
         });
@@ -912,3 +915,44 @@ describe("production driver generation and admission wiring", () => {
     expect(claims).toBe(1);
   });
 });
+
+it.each(["permissions.state", "apps.list", "app.open", "app.state"])(
+  "keeps one Okou deadline through %s even before the timer callback is delivered",
+  async (phase) => {
+    let monotonic = 0;
+    const app = desktop({
+      commandClock: {
+        wallNow: () => Date.parse("2026-09-08T02:42:36.593Z"),
+        monotonicNow: () => monotonic,
+        setTimeout: (run, delay) => setTimeout(run, delay),
+        clearTimeout: (timer) => clearTimeout(timer),
+      },
+    });
+    await app.controller.start();
+    const gate = app.native.pause(phase);
+    const command = app.claim({
+      id: "deadline-command",
+      kind: phase === "apps.list" ? "apps.list" : "app.open",
+      payload: { app: "test.app" },
+      timeoutMs: 10_000,
+      createdAt: "2026-09-08T02:44:35.425Z",
+      claimedAt: "2026-09-08T02:44:36.980Z",
+    });
+    app.timers.run(5_000);
+    await command.reached.promise;
+    command.response.resolve();
+    await gate.reached.promise;
+    monotonic = 10_000;
+    const before = app.events.length;
+    gate.resume.resolve();
+    expect(await command.completed.promise).toMatchObject({
+      status: "failed",
+      error: { code: "command_timeout" },
+    });
+    expect(app.events.slice(before)).not.toContain("1:app.open");
+    expect(app.events.slice(before)).not.toContain("1:app.state");
+    expect(app.driver.getCapabilities()).toEqual([]);
+    command.completeResponse.resolve();
+    await app.driver.retire();
+  },
+);

--- a/turbo/apps/desktop/src/desktop-computer-use-selection.test.ts
+++ b/turbo/apps/desktop/src/desktop-computer-use-selection.test.ts
@@ -286,7 +286,7 @@ require('node:readline').createInterface({input:process.stdin}).on('line', line 
                   ...next,
                   timeoutMs: 60_000,
                   createdAt: new Date().toISOString(),
-                  claimedAt: null,
+                  claimedAt: new Date().toISOString(),
                 },
               }
             : { status: "idle" },


### PR DESCRIPTION
## Problem and behavior

Fixes #32494 (parent #32259). A successful server claim could be rejected in milliseconds when the server's clock was ahead of the Mac, and an exhausted execution had only 1 ms to report its error.

Derive one execution deadline from server `claimedAt - createdAt` plus the entire locally measured monotonic claim interval, including JSON body consumption. Preserve queue expiry, the existing early execution cutoff, nullable timeout defaults, and fail-closed claim validation. Okou helper dispatches now check that same budget before each native phase, including post-state when an I/O continuation runs before the expiry timer.

Result delivery has an independent five-second total cap covering up to three attempts and all backoff. Stop, sign-out and quit cancel reporting immediately; abort-ignoring reporting cannot retain the native lease past the cap. Late claims remain owned and never execute; terminal completion handling, generation retirement and no replay/fallback are preserved.

## Compatibility and scope

No API, database, CLI timeout, dependency pin, default driver or authorization change. Existing APIs already write non-null `claimedAt` for every successful claim; null belongs to general queued-command reads. Existing test fixtures now match that contract (the selection test changes only its claim timestamp). The runtime document records the pre-transaction timestamp/transport proof and unchanged old/new API compatibility. Installed-Mac/TCC and real-application acceptance remain pending with the user. No release or deployment is performed.

## Validation

- Nine targeted Desktop integration files: **229 tests passed**, including real host/controller/driver wiring, MSW, the external Okou helper protocol, CUA SDK boundaries and the real filesystem plugin.
- Actual timestamp inversion through both drivers; positive/negative wall offsets; malformed, missing, null and expired metadata; delayed headers/body and cancelled late claims; permission/discovery/action/post-state expiry; 100 ms error delivery; bounded retries/hangs, Stop/auth/quit and switch ownership; terminal completions.
- The two actual-fixture tests and 100 ms reporting regression all fail against original `ac67dfd8ddfec17248573ca5cb66ff35046ed1ad` source and pass with this repair. Okou phase tests also reproduced permission-to-action and action-to-post-state dispatch after expiry before the dispatch checks were added.
- Desktop `check-types`, `lint`, scoped Knip, changed-file Prettier and `git diff --check` passed. Full local Vitest and dev server were not run; broad validation belongs to PR CI.
