### PR TITLE
fix(platform): hide selection menu for run summaries

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-feedback.ts
@@ -39,6 +39,8 @@ import {
 const FEEDBACK_SOURCE_SELECTOR =
   ".okou-chat-bubble-assistant, [data-feedback-source]";
 const ASSISTANT_GROUP_SELECTOR = '[data-role="assistant"]';
+const SELECTION_ACTIONS_DISABLED_SELECTOR =
+  "[data-chat-selection-actions-disabled]";
 const COARSE_POINTER_QUERY = "(pointer: coarse)";
 const CHAT_EVENT_SELECTOR = "[data-chat-scroll-anchor-event-id]";
 const THREAD_CONTAINER_SELECTOR = "[data-chat-thread-container-id]";
@@ -156,6 +158,9 @@ function closestExpandedFeedbackSource(node: Node | null): Element | null {
     return null;
   }
   const element = node instanceof Element ? node : node.parentElement;
+  if (element?.closest(SELECTION_ACTIONS_DISABLED_SELECTOR)) {
+    return null;
+  }
   return (
     element?.closest(ASSISTANT_GROUP_SELECTOR) ??
     element?.closest("[data-feedback-source]") ??

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-feedback.test.tsx
@@ -15,6 +15,7 @@ import {
   context,
   feedbackItems,
   feedbackNotes,
+  FIRST_CAPABILITY_RUN_ID,
   findButton,
   installCapabilityChat,
   quoteSelectedPassage,
@@ -26,7 +27,12 @@ import {
   waitForSend,
   type CapturedChatSend,
 } from "./chat-capability-test-helpers.ts";
-import { findEnabledButton } from "./chat-run-test-fixtures.ts";
+import {
+  assistantEvent,
+  completedEvent,
+  findEnabledButton,
+  promptEvent,
+} from "./chat-run-test-fixtures.ts";
 import { buttonByLabel } from "./chat-lifecycle-test-helpers.ts";
 
 const FIRST_PASSAGE = "The launch plan has three careful stages.";
@@ -136,6 +142,58 @@ test("Expand desktop passage actions to the boundary of one AI reply", async () 
     "rendered detail outside Markdown",
     "separate decision",
   );
+
+  expect(queryToolbarButton("Copy")).not.toBeInTheDocument();
+  expect(queryToolbarButton("Quote")).not.toBeInTheDocument();
+  expect(queryToolbarButton("Forward")).not.toBeInTheDocument();
+});
+
+test("Hide passage actions for a run summary inside an AI reply", async () => {
+  installCapabilityChat({
+    events: [
+      promptEvent({
+        id: "capability-run-summary-user",
+        runId: FIRST_CAPABILITY_RUN_ID,
+        seqId: 1,
+        text: "Prepare the run summary response",
+        createdAt: "2026-08-01T10:00:00.000Z",
+      }),
+      assistantEvent({
+        id: "capability-run-summary-work",
+        runId: FIRST_CAPABILITY_RUN_ID,
+        seqId: 2,
+        text: "Checked the rollout dependencies",
+        createdAt: "2026-08-01T10:00:20.000Z",
+      }),
+      assistantEvent({
+        id: "capability-run-summary-answer",
+        runId: FIRST_CAPABILITY_RUN_ID,
+        seqId: 3,
+        text: FIRST_PASSAGE,
+        createdAt: "2026-08-01T10:00:40.000Z",
+      }),
+      completedEvent({
+        id: "capability-run-summary-completed",
+        runId: FIRST_CAPABILITY_RUN_ID,
+        seqId: 4,
+        createdAt: "2026-08-01T10:01:00.000Z",
+      }),
+    ],
+  });
+
+  await setupPage({
+    context,
+    path: RUN_PATH,
+    featureSwitches: {
+      [FeatureSwitchKey.ChatDesktopSelection]: true,
+      [FeatureSwitchKey.ChatRunWorkFolding]: true,
+    },
+  });
+
+  await readyChat();
+  await expect(screen.findByText("Worked for 1m")).resolves.toBeVisible();
+  await selectPassage("launch plan has three careful stages");
+  await selectPassageWithoutActions("Worked for 1m");
 
   expect(queryToolbarButton("Copy")).not.toBeInTheDocument();
   expect(queryToolbarButton("Quote")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -3920,7 +3920,11 @@ function RunWorkSectionRow({
     CHAT_THREAD_RESPONSE_LINE_CLASS,
   );
   return (
-    <div data-chat-run-work className="flex min-h-9 items-center">
+    <div
+      data-chat-run-work
+      data-chat-selection-actions-disabled
+      className="flex min-h-9 items-center"
+    >
       {collapsible ? (
         <Button
           type="button"


### PR DESCRIPTION
## Summary

- exclude the `Worked/Working for … · … steps` run summary from desktop selection actions
- keep regular assistant content and expanded work details on the existing selection path
- add a page-level regression test using a completed run summary

## Verification

- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-capability-feedback.test.tsx`
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`
- pre-commit hook: Prettier, Knip, full Turbo type checks, and file-size checks
