### PR TITLE
fix(pi): hand slash input to native sandbox execution

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -12007,6 +12007,427 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(claim.status).toBe(404);
   }, 90_000);
 
+  it.each([
+    "/skill:handoff-skill first  argument\nsecond line",
+    " \n\t/skill:handoff-skill first  argument\nsecond line",
+    "/unknown-command first  argument\nsecond line",
+    "/home/user/workspace/report.txt first  argument\nsecond line",
+  ])(
+    "hands native input %j to Sandbox with exact fresh and resumed H0",
+    async (prompt) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      let modelCalls = 0;
+      let resourceDownloads = 0;
+      server.use(
+        http.post("https://api.openai.com/v1/responses", () => {
+          modelCalls += 1;
+          return nativeCodexSseResponse(
+            piResponsesTextSse("ordinary API answer", modelCalls),
+          );
+        }),
+        http.get(PI_RESOURCE_ARCHIVE_DOWNLOAD_URL, () => {
+          resourceDownloads += 1;
+          return HttpResponse.json(
+            { error: "API resources unavailable" },
+            { status: 503 },
+          );
+        }),
+      );
+      const queued = await queueCapabilityProvenPiRun({
+        actor,
+        agentId,
+        runnerGroup,
+        prompt,
+      });
+      await completeChatRunOk(
+        queued.anchor.runId,
+        queued.anchorClaim.sandboxHeaders,
+        {
+          usagePricingResolution: queued.usagePricingResolution,
+        },
+      );
+      let run = queued.run;
+      let expectedH0: Buffer | undefined;
+      const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+      for (const turn of [1, 2]) {
+        const originalPrompt = turn === 1 ? prompt : `${prompt}\nresume once`;
+        if (turn === 2) {
+          run = await sendChatRun(
+            actor,
+            {
+              agentId,
+              threadId: run.threadId,
+              prompt: originalPrompt,
+              model: "gpt-5.6-terra",
+            },
+            "vm0",
+            queued.usagePricingResolution,
+          );
+        }
+        await flushWaitUntilForTest();
+        const manifestKey = `${bucket}/pi-api-first-turn/${run.runId}/manifest.json`;
+        const sessionKey = `${bucket}/pi-api-first-turn/${run.runId}/session.jsonl`;
+        const manifestBytes = checkpointObjects.get(manifestKey);
+        const h0 = checkpointObjects.get(sessionKey);
+        if (!manifestBytes || !h0) {
+          throw new Error("Expected native-input Sandbox manifest and H0");
+        }
+        const manifest = piApiFirstTurnManifestSchema.parse(
+          JSON.parse(manifestBytes.toString("utf8")),
+        );
+        expect(manifest).toMatchObject({
+          schemaVersion: 3,
+          outcome: "ownership-transfer",
+          mode: "sandbox-first",
+          baseSession: {
+            sessionId: run.threadId,
+            sha256: expectedH0
+              ? createHash("sha256").update(expectedH0).digest("hex")
+              : null,
+          },
+          session: {
+            sessionId: run.threadId,
+            sha256: createHash("sha256").update(h0).digest("hex"),
+            rawSize: h0.length,
+          },
+          sandboxEventSequenceStart: 1,
+        });
+        if (expectedH0) {
+          expect(h0).toStrictEqual(expectedH0);
+        }
+        const session = MemoryPiSession.fromJsonl(h0.toString("utf8"));
+        expect(session.getSessionId()).toBe(run.threadId);
+        expect(session.buildSessionContext().messages).toHaveLength(
+          (turn - 1) * 2,
+        );
+        const writes = context.mocks.s3.send.mock.calls.flatMap(([command]) => {
+          const candidate = command as PiCheckpointS3Command;
+          const key = piS3ObjectKey(candidate);
+          return candidate.constructor?.name === "PutObjectCommand" &&
+            (key === sessionKey || key === manifestKey)
+            ? [key]
+            : [];
+        });
+        expect(writes).toStrictEqual([sessionKey, manifestKey]);
+        expect(modelCalls).toBe(0);
+        expect(resourceDownloads).toBe(0);
+        // Public usage summaries omit pending usage, so inspect this run's
+        // uniquely owned ledger to rule out duplicate API billing ownership.
+        await expect(
+          readRunUsageEventsFixture(run.runId),
+        ).resolves.toStrictEqual([]);
+        const claim = await claimChatRun(runnerGroup, run.runId);
+        expect(claim.claim).toMatchObject({
+          cliAgentType: "pi",
+          piSessionId: run.threadId,
+          prompt: originalPrompt,
+          piLaunchConfig: { apiFirstTurn: { sandboxEventSequenceStart: 1 } },
+        });
+        const outcomes = context.mocks.axiomLogging.debug.mock.calls.filter(
+          (call) => {
+            return (
+              call[0] === "Pi API first-turn outcome" &&
+              JSON.stringify(call).includes(run.runId)
+            );
+          },
+        );
+        expect(outcomes).toStrictEqual([
+          [
+            "Pi API first-turn outcome",
+            expect.objectContaining({
+              runId: run.runId,
+              outcome: "ownership_transfer",
+              reason: "native_input_sandbox_first",
+              ownershipStage: "pre-provider",
+              handoffOwner: "sandbox",
+            }),
+          ],
+        ]);
+
+        const sandboxUsage = {
+          idempotencyKey: randomUUID(),
+          kind: "model" as const,
+          provider: "gpt-5.6-terra",
+          category: "tokens.output",
+          quantity: 2,
+        };
+        for (const _receipt of [1, 2]) {
+          await webhooks.requestAgentUsageEvent(
+            { runId: run.runId, events: [sandboxUsage] },
+            claim.sandboxHeaders,
+            [200],
+            queued.usagePricingResolution,
+          );
+        }
+
+        const answer = `native Sandbox answer ${turn}`;
+        // This exercises the external Sandbox checkpoint/completion boundary.
+        // pi-agent-loop.test.ts separately runs the real official RPC/AgentSession
+        // with a mounted skill and checks its actual expanded provider input.
+        await completeSandboxFirstPiRun({
+          actor,
+          answer,
+          checkpointObjects,
+          claim,
+          prompt: originalPrompt,
+          run,
+          usagePricingResolution: queued.usagePricingResolution,
+        });
+        const events = (await chat.listThreadEvents(actor, run.threadId))
+          .events;
+        expect(
+          events
+            .filter((event) => {
+              return (
+                event.runId === run.runId &&
+                isChatRunTerminalEventType(event.eventType)
+              );
+            })
+            .map((event) => {
+              return event.eventType;
+            }),
+        ).toStrictEqual(["run.completed"]);
+        expect(
+          eventBackedContents(events, run.runId).filter((message) => {
+            return message.content === answer;
+          }),
+        ).toHaveLength(1);
+        await expect(
+          readRunUsageEventsFixture(run.runId),
+        ).resolves.toStrictEqual([
+          expect.objectContaining({
+            provider: "gpt-5.6-terra",
+            category: "tokens.output",
+            quantity: 2,
+            status: "processed",
+            billingError: null,
+          }),
+        ]);
+        await expect(
+          readThreadSessionConversation(context, run.threadId),
+        ).resolves.toMatchObject({ conversation_run_id: run.runId });
+        expect(warningCallsForRun(run.runId)).toStrictEqual([]);
+        const blob = [...checkpointObjects.entries()]
+          .filter(([key]) => {
+            return key.startsWith(`${bucket}/blobs/`);
+          })
+          .at(-1);
+        if (!blob) {
+          throw new Error("Expected the Sandbox's settled checkpoint");
+        }
+        expectedH0 = blob[1];
+        const settled = MemoryPiSession.fromJsonl(expectedH0.toString("utf8"));
+        expect(settled.getSessionId()).toBe(run.threadId);
+        expect(settled.isSettledCheckpoint()).toBeTruthy();
+        expect(settled.buildSessionContext().messages).toHaveLength(turn * 2);
+      }
+
+      mockPiResourceArchiveDownloads();
+      const ordinary = await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt: "ordinary prose with /skill:handoff-skill later in the text",
+          model: "gpt-5.6-terra",
+        },
+        "vm0",
+        queued.usagePricingResolution,
+      );
+      await flushWaitUntilForTest();
+      expect(
+        context.mocks.axiomLogging.debug.mock.calls.filter((call) => {
+          return (
+            call[0] === "Pi API first-turn outcome" &&
+            JSON.stringify(call).includes(ordinary.runId)
+          );
+        }),
+      ).toContainEqual([
+        "Pi API first-turn outcome",
+        expect.objectContaining({ outcome: "api_completion" }),
+      ]);
+      await waitForRunStatus(actor, ordinary.runId, "completed");
+      expect(modelCalls).toBe(1);
+    },
+    90_000,
+  );
+
+  it.each(["readback mismatch", "coordination deadline"] as const)(
+    "fails native-input publication safely on %s",
+    async (failure) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      let modelCalls = 0;
+      server.use(
+        http.post("https://api.openai.com/v1/responses", () => {
+          modelCalls += 1;
+          return nativeCodexSseResponse(
+            piResponsesTextSse("unsafe API turn", modelCalls),
+          );
+        }),
+      );
+      const { anchor, anchorClaim, run, usagePricingResolution } =
+        await queueCapabilityProvenPiRun({
+          actor,
+          agentId,
+          runnerGroup,
+          prompt: "/skill:handoff-skill preserve  arguments",
+        });
+      const sessionKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/session.jsonl`;
+      const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+      const send = context.mocks.s3.send.getMockImplementation();
+      if (!send) {
+        throw new Error("Expected the checkpoint object-store boundary");
+      }
+      const apiStartedAt = now();
+      mockNow(apiStartedAt);
+      context.mocks.s3.send.mockImplementation((command: unknown) => {
+        const candidate = command as PiCheckpointS3Command;
+        if (
+          candidate.constructor?.name === "GetObjectCommand" &&
+          piS3ObjectKey(candidate) === sessionKey
+        ) {
+          if (failure === "coordination deadline") {
+            mockNow(apiStartedAt + API_FIRST_TURN_COORDINATION_BUDGET_MS);
+          } else {
+            const bytes = checkpointObjects.get(sessionKey);
+            if (!bytes) {
+              throw new Error("Expected uploaded H0 before readback");
+            }
+            const corrupted = Buffer.from(bytes);
+            corrupted[0] = 0;
+            checkpointObjects.set(sessionKey, corrupted);
+          }
+        }
+        return send(command);
+      });
+      await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+        usagePricingResolution,
+      });
+      await waitForRunStatus(actor, run.runId, "failed");
+      await flushWaitUntilForTest();
+      expect(modelCalls).toBe(0);
+      expect(uploadedPiS3Object(manifestKey)).toBeUndefined();
+      await api.requestClaimRunnerJob(true, run.runId, [404]);
+      expect((await api.readRun(actor, run.runId)).error).toContain(
+        failure === "coordination deadline"
+          ? "[PI_API_FIRST_TURN_DEADLINE_EXCEEDED]"
+          : "[PI_API_SANDBOX_FALLBACK_FAILED]",
+      );
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        "Pi API first-turn outcome",
+        expect.objectContaining({
+          runId: run.runId,
+          outcome: "terminal_failure",
+          ownershipStage: "pre-provider",
+          fallbackReason: "PI_API_NATIVE_INPUT_REQUIRED",
+        }),
+      );
+      expect(context.mocks.axiomLogging.warn).toHaveBeenCalledWith(
+        "Run failed",
+        expect.objectContaining({ runId: run.runId }),
+      );
+      const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+      expect(
+        events
+          .filter((event) => {
+            return (
+              event.runId === run.runId &&
+              isChatRunTerminalEventType(event.eventType)
+            );
+          })
+          .map((event) => {
+            return event.eventType;
+          }),
+      ).toStrictEqual(["run.failed"]);
+      expect(eventBackedContents(events, run.runId)).toStrictEqual([]);
+    },
+    90_000,
+  );
+
+  it.each(["cancelled", "failed"] as const)(
+    "does not publish native-input H0 after lifecycle ownership becomes %s",
+    async (status) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      let modelCalls = 0;
+      server.use(
+        http.post("https://api.openai.com/v1/responses", () => {
+          modelCalls += 1;
+          return nativeCodexSseResponse(
+            piResponsesTextSse("unsafe API turn", modelCalls),
+          );
+        }),
+      );
+      const { anchor, anchorClaim, run, usagePricingResolution } =
+        await queueCapabilityProvenPiRun({
+          actor,
+          agentId,
+          runnerGroup,
+          prompt: "/skill:handoff-skill preserve  arguments",
+        });
+      // Only this run-owned fixture can hold publication at the lifecycle
+      // boundary while a real cancellation or Sandbox failure wins ownership.
+      const lock = await holdPiApiFirstTurnLifecycleLockFixture({
+        runId: run.runId,
+        signal: context.signal,
+      });
+      onTestFinished(async () => {
+        lock.release();
+        await lock.done;
+      });
+      if (status === "cancelled") {
+        const cancellation = api.requestCancelRun(
+          actor,
+          run.runId,
+          [200],
+          usagePricingResolution,
+        );
+        await expect.poll(lock.waiterCount).toBe(1);
+        await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+          usagePricingResolution,
+        });
+        await expect.poll(lock.waiterCount).toBe(2);
+        lock.release();
+        await lock.done;
+        await cancellation;
+      } else {
+        await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+          usagePricingResolution,
+        });
+        await expect.poll(lock.waiterCount).toBe(1);
+        const claim = await claimChatRun(runnerGroup, run.runId);
+        await failChatRun(
+          run.runId,
+          claim.sandboxHeaders,
+          "Sandbox startup failed before takeover",
+        );
+        lock.release();
+        await lock.done;
+      }
+      await waitForRunStatus(actor, run.runId, status);
+      await flushWaitUntilForTest();
+      expect(modelCalls).toBe(0);
+      expectNoPiApiFirstTurnArtifacts(run.runId, checkpointObjects);
+      const events = (await chat.listThreadEvents(actor, run.threadId)).events;
+      expect(
+        events
+          .filter((event) => {
+            return (
+              event.runId === run.runId &&
+              isChatRunTerminalEventType(event.eventType)
+            );
+          })
+          .map((event) => {
+            return event.eventType;
+          }),
+      ).toStrictEqual([`run.${status}`]);
+      expect(eventBackedContents(events, run.runId)).toStrictEqual([]);
+      await api.requestClaimRunnerJob(true, run.runId, [404]);
+    },
+    90_000,
+  );
+
   it("hands a Terra resource failure to Sandbox without replaying a later provider failure", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     if (!actor.orgId) {
@@ -12448,84 +12869,111 @@ describe("CHAT-02: model-first provider policies", () => {
     await cancelChatRun(actor, second.runId, sandboxHeaders);
   }, 90_000);
 
-  it("fails a corrupt Pi H0 before a second model call and preserves H0", async () => {
-    const { actor, agentId } = await entitledChatActor();
-    if (!actor.orgId) {
-      throw new Error("Expected entitled chat actor to have an org");
-    }
-    await configureBuiltInPiModel(actor, "deepseek-v4-flash");
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId: actor.orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
-    );
-    mockPiResourceArchiveDownloads();
-    let modelCalls = 0;
-    server.use(
-      http.post("https://api.deepseek.com/responses", () => {
-        modelCalls += 1;
-        return new HttpResponse(
-          piResponsesTextSse("canonical H0 answer", modelCalls),
-          { headers: { "content-type": "text/event-stream" } },
-        );
-      }),
-    );
-    const checkpointObjects = mockPiCheckpointObjectStore();
-    const first = await sendChatRun(actor, {
-      agentId,
-      prompt: "create canonical Pi H0",
-      model: "deepseek-v4-flash",
-    });
-    await waitForRunStatus(actor, first.runId, "completed");
-    await flushWaitUntilForTest();
-    expect(modelCalls).toBe(1);
-    const bindingBeforeFailure = await readThreadSessionBinding(
-      context,
-      first.threadId,
-    );
-    const firstSessionBytes = checkpointObjects.get(
-      [...checkpointObjects.keys()].find((key) => {
-        return key.includes("/blobs/");
-      }) ?? "missing-canonical-pi-blob",
-    );
-    if (!firstSessionBytes) {
-      throw new Error("Expected the first Pi run to persist native H1");
-    }
-    const malformedH0 = `${firstSessionBytes.toString("utf8")}{malformed\n`;
-    const h0Hash = await replacePiSessionHistoryJsonlFixture({
-      runId: first.runId,
-      jsonl: malformedH0,
-    });
-    checkpointObjects.set(
-      `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${h0Hash}.blob`,
-      Buffer.from(malformedH0, "utf8"),
-    );
-
-    const second = await sendChatRun(actor, {
-      agentId,
-      threadId: first.threadId,
+  it.each([
+    {
+      damage: "corrupt",
       prompt: "must not reach the model",
-    });
-    await waitForRunStatus(actor, second.runId, "failed");
-    await flushWaitUntilForTest();
-    expect((await api.readRun(actor, second.runId)).error).toContain(
-      "[PI_H0_JSONL_INVALID]",
-    );
-    expect(modelCalls).toBe(1);
-    await expect(
-      readThreadSessionBinding(context, first.threadId),
-    ).resolves.toStrictEqual({
-      ...bindingBeforeFailure,
-      agent_session_run_id: second.runId,
-    });
-    expect(
-      checkpointObjects.has(
-        `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${second.runId}/manifest.json`,
-      ),
-    ).toBeFalsy();
-    const claim = await api.requestClaimRunnerJob(true, second.runId, [404]);
-    expect(claim.status).toBe(404);
-  }, 90_000);
+      code: "PI_H0_JSONL_INVALID",
+    },
+    {
+      damage: "corrupt",
+      prompt: "/skill:handoff-skill must not execute",
+      code: "PI_H0_JSONL_INVALID",
+    },
+    {
+      damage: "mismatched",
+      prompt: "/skill:handoff-skill must not execute",
+      code: "PI_H0_SESSION_MISMATCH",
+    },
+  ])(
+    "fails $damage Pi H0 for $prompt before a second model call and preserves H0",
+    async ({ damage, prompt, code }) => {
+      const { actor, agentId } = await entitledChatActor();
+      if (!actor.orgId) {
+        throw new Error("Expected entitled chat actor to have an org");
+      }
+      await configureBuiltInPiModel(actor, "deepseek-v4-flash");
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId: actor.orgId },
+        { [FeatureSwitchKey.PiLoop]: true },
+      );
+      mockPiResourceArchiveDownloads();
+      let modelCalls = 0;
+      server.use(
+        http.post("https://api.deepseek.com/responses", () => {
+          modelCalls += 1;
+          return new HttpResponse(
+            piResponsesTextSse("canonical H0 answer", modelCalls),
+            { headers: { "content-type": "text/event-stream" } },
+          );
+        }),
+      );
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      const first = await sendChatRun(actor, {
+        agentId,
+        prompt: "create canonical Pi H0",
+        model: "deepseek-v4-flash",
+      });
+      await waitForRunStatus(actor, first.runId, "completed");
+      await flushWaitUntilForTest();
+      expect(modelCalls).toBe(1);
+      const bindingBeforeFailure = await readThreadSessionBinding(
+        context,
+        first.threadId,
+      );
+      const firstSessionBytes = checkpointObjects.get(
+        [...checkpointObjects.keys()].find((key) => {
+          return key.includes("/blobs/");
+        }) ?? "missing-canonical-pi-blob",
+      );
+      if (!firstSessionBytes) {
+        throw new Error("Expected the first Pi run to persist native H1");
+      }
+      // A public caller cannot corrupt an authoritative checkpoint. Inject the
+      // run-owned stored object to exercise the handoff's integrity boundary.
+      const malformedH0 =
+        damage === "corrupt"
+          ? `${firstSessionBytes.toString("utf8")}{malformed\n`
+          : firstSessionBytes
+              .toString("utf8")
+              .replace(first.threadId, randomUUID());
+      const h0Hash = await replacePiSessionHistoryJsonlFixture({
+        runId: first.runId,
+        jsonl: malformedH0,
+      });
+      checkpointObjects.set(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${h0Hash}.blob`,
+        Buffer.from(malformedH0, "utf8"),
+      );
+
+      const second = await sendChatRun(actor, {
+        agentId,
+        threadId: first.threadId,
+        prompt,
+      });
+      await waitForRunStatus(actor, second.runId, "failed");
+      await flushWaitUntilForTest();
+      expect((await api.readRun(actor, second.runId)).error).toContain(
+        `[${code}]`,
+      );
+      expect(modelCalls).toBe(1);
+      await expect(
+        readThreadSessionBinding(context, first.threadId),
+      ).resolves.toStrictEqual({
+        ...bindingBeforeFailure,
+        agent_session_run_id: second.runId,
+      });
+      expect(
+        checkpointObjects.has(
+          `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${second.runId}/manifest.json`,
+        ),
+      ).toBeFalsy();
+      const claim = await api.requestClaimRunnerJob(true, second.runId, [404]);
+      expect(claim.status).toBe(404);
+    },
+    90_000,
+  );
 
   it("rejects cyclic Pi H0 before provider or fallback and resumes valid history later", async () => {
     if (await runInIsolatedProcess(import.meta.url)) {

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn.service.ts
@@ -108,7 +108,7 @@ type PiApiFirstTurnErrorCode =
   | "PI_API_MODEL_FAILED"
   | "PI_API_MODEL_OUTPUT_INCOMPLETE"
   | "PI_API_MODEL_CREDENTIAL_INVALID"
-  | "PI_API_PROMPT_UNSUPPORTED"
+  | "PI_API_NATIVE_INPUT_REQUIRED"
   | "PI_API_PREHEAT_FAILED"
   | "PI_API_RESOURCE_INVALID"
   | "PI_API_RESOURCE_PREPARATION_FAILED"
@@ -748,12 +748,6 @@ function validateApiFirstTurnLaunch(args: ApiFirstTurnContext): {
     throw piApiFirstTurnError(
       "PI_LAUNCH_CONFIG_INVALID",
       "Pi launch base session id does not match the Pi session id",
-    );
-  }
-  if (args.activation.prompt.trimStart().startsWith("/")) {
-    throw piApiFirstTurnError(
-      "PI_API_PROMPT_UNSUPPORTED",
-      "Pi slash commands are not supported by the API first-turn slot",
     );
   }
   if (now() >= launchConfig.deadlineAt) {
@@ -1425,6 +1419,7 @@ function ownershipTransferManifest(args: {
 
 type PiSandboxFallbackReason =
   | "PI_API_COMPACTION_PREFLIGHT_REQUIRED"
+  | "PI_API_NATIVE_INPUT_REQUIRED"
   | "PI_API_PREHEAT_FAILED"
   | "PI_API_RESOURCE_PREPARATION_FAILED";
 
@@ -1444,6 +1439,7 @@ function eligibleSandboxFallbackReason(
     return null;
   }
   switch (args.failure.code) {
+    case "PI_API_NATIVE_INPUT_REQUIRED":
     case "PI_API_PREHEAT_FAILED":
     case "PI_API_COMPACTION_PREFLIGHT_REQUIRED":
     case "PI_API_RESOURCE_PREPARATION_FAILED": {
@@ -1618,6 +1614,14 @@ const prepareApiFirstTurn$ = command(async function prepareApiFirstTurn(
     validateApiFirstTurnLaunch(args);
   const commitIdentity = apiFirstTurnCommitIdentity(args);
   signal.throwIfAborted();
+  // The direct API model turn cannot run native input/skill expansion. Choose
+  // AgentSession before API-only preparation; handoff must keep the input intact.
+  if (args.activation.prompt.trimStart().startsWith("/")) {
+    throw piApiFirstTurnError(
+      "PI_API_NATIVE_INPUT_REQUIRED",
+      "Pi slash-prefixed input requires native AgentSession processing",
+    );
+  }
   const resourceSnapshot = await set(
     loadApiFirstTurnResource$,
     args,
@@ -2032,6 +2036,12 @@ function sandboxFirstPublicationOutcome(reason: PiSandboxFirstReason): {
     }
     case "PI_API_COMPACTION_PREFLIGHT_REQUIRED": {
       return { outcome: "ownership_transfer", reason: "compaction_preflight" };
+    }
+    case "PI_API_NATIVE_INPUT_REQUIRED": {
+      return {
+        outcome: "ownership_transfer",
+        reason: "native_input_sandbox_first",
+      };
     }
     default: {
       return { outcome: "sandbox_fallback", reason };

--- a/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
+++ b/turbo/apps/cli/src/lib/pi-agent-loop.test.ts
@@ -1211,6 +1211,142 @@ describe("sandbox Pi agent loop", () => {
     }
   }, 20_000);
 
+  it.each([
+    {
+      name: "mounted skill",
+      prompt: "/skill:handoff-skill first  argument\nsecond line",
+      expandsSkill: true,
+    },
+    {
+      name: "whitespace before a skill",
+      prompt: " \n\t/skill:handoff-skill first  argument\nsecond line",
+      expandsSkill: false,
+    },
+    {
+      name: "unknown slash input",
+      prompt: "/unknown-command first  argument\nsecond line",
+      expandsSkill: false,
+    },
+    {
+      name: "absolute path",
+      prompt: "/home/user/workspace/report.txt first  argument\nsecond line",
+      expandsSkill: false,
+    },
+  ])(
+    "processes $name through native sandbox-first AgentSession on fresh and resumed H0",
+    async ({ prompt, expandsSkill }) => {
+      const root = await mkdtemp(join(tmpdir(), "okou-pi-native-input-"));
+      const provider = await ProviderHarness.start();
+      const skillDir = join(root, ".pi", "agent", "skills", "handoff-skill");
+      const skillFile = join(skillDir, "SKILL.md");
+      const skillBody = "Use the mounted handoff skill body for this request.";
+      let h0 = MemoryPiSession.create({ cwd: root, id: SESSION_ID }).toJsonl();
+      let baseSessionSha256: string | null = null;
+      let host: RpcHost | undefined;
+      let handoffServer: Server | undefined;
+      try {
+        // Use the existing user-skill discovery root, without settings,
+        // extensions, templates, or a replacement resource loader.
+        await mkdir(skillDir, { recursive: true });
+        await writeFile(
+          skillFile,
+          `---\nname: handoff-skill\ndescription: Exercises native mounted skill expansion.\n---\n${skillBody}\n`,
+        );
+        const expectedInput = expandsSkill
+          ? `<skill name="handoff-skill" location="${skillFile}">\nReferences are relative to ${skillDir}.\n\n${skillBody}\n</skill>\n\nfirst  argument\nsecond line`
+          : prompt;
+        for (const turn of [1, 2]) {
+          const started = await startOwnershipTransferHost({
+            root,
+            jsonl: h0,
+            mode: "sandbox-first",
+            baseSessionSha256,
+            providerBaseUrl: provider.baseUrl,
+            model: "openrouter-terra",
+          });
+          host = started.host;
+          handoffServer = started.handoffServer;
+          const state = await host.state(`native-input-state-${turn}`);
+          expect(state).toMatchObject({
+            sessionId: SESSION_ID,
+            messageCount: (turn - 1) * 2,
+          });
+          expect(host.records[0]).toStrictEqual({
+            type: "vm0_pi_api_first_turn_boundary",
+            schemaVersion: 2,
+            sandboxEventSequenceStart: 4,
+            ownershipTransferMode: "sandbox-first",
+          });
+          const installed = await readFile(String(state.sessionFile), "utf8");
+          // Native startup adds model/thinking metadata to a fresh header.
+          // Resumed H0 is already configured and must remain byte-for-byte intact.
+          if (turn === 1) {
+            expect(installed.startsWith(h0)).toBe(true);
+          } else {
+            expect(installed).toBe(h0);
+          }
+
+          host.send({
+            id: `native-input-${turn}`,
+            type: "prompt",
+            message: prompt,
+          });
+          const request = await provider.nextRequest();
+          expect(request.body).not.toHaveProperty("service_tier");
+          expect(request.body).toMatchObject({
+            input: expect.arrayContaining([
+              expect.objectContaining({
+                role: "user",
+                content: [{ type: "input_text", text: expectedInput }],
+              }),
+            ]),
+          });
+          request.respond(`native input complete ${turn}`);
+          await host.waitFor((record) => {
+            return record.type === "agent_settled";
+          });
+          expect(
+            host.records.filter((record) => {
+              return record.type === "agent_settled";
+            }),
+          ).toHaveLength(1);
+          await host.close();
+          host = undefined;
+          await closeServer(handoffServer);
+          handoffServer = undefined;
+
+          h0 = await readFile(String(state.sessionFile), "utf8");
+          const persisted = MemoryPiSession.fromJsonl(h0);
+          expect(persisted.getSessionId()).toBe(SESSION_ID);
+          expect(persisted.isSettledCheckpoint()).toBe(true);
+          const messages = persisted.buildSessionContext().messages;
+          expect(messages).toHaveLength(turn * 2);
+          expect(
+            messages.filter((message) => {
+              return message.role === "user";
+            }),
+          ).toStrictEqual(
+            Array.from({ length: turn }, () => {
+              return expect.objectContaining({
+                content: [{ type: "text", text: expectedInput }],
+              });
+            }),
+          );
+          expect(provider.requests).toHaveLength(turn);
+          baseSessionSha256 = createHash("sha256").update(h0).digest("hex");
+        }
+      } finally {
+        await host?.terminate();
+        if (handoffServer) {
+          await closeServer(handoffServer);
+        }
+        await provider.close();
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+    30_000,
+  );
+
   it("keeps OpenRouter priority on an official AgentSession retry", async () => {
     const root = await mkdtemp(join(tmpdir(), "okou-pi-retry-rpc-"));
     const prompt = "retry this sandbox-owned prompt exactly once";


### PR DESCRIPTION
## Summary

Slash-prefixed input currently fails Pi's API-first turn before execution, and the same input guard also prevents the existing Sandbox publisher from taking over. Move that API-only eligibility decision out of shared launch validation and select native `AgentSession` before API resource preparation or provider transport.

The original prompt, including whitespace and arguments, is delivered unchanged through the existing V3 `sandbox-first` transfer. Native Pi owns skill expansion, unknown slash input, and absolute-path text. Successful selection emits one bounded `ownership_transfer` / `native_input_sandbox_first` outcome; genuine failures retain their existing accounting.

Closes #32453.

## Fallbacks

- **Native-input ownership transfer:** `prepareApiFirstTurn$` identifies leading-slash input, and the explicit pre-provider allowlist reuses `publishSandboxFallback$`. This is an execution-owner policy, with no cross-version compatibility branch. Its per-run window ends when provider ownership begins, cancellation or lifecycle ownership wins, or the existing coordination deadline expires. It remains necessary while API-first uses the direct model turn and native input processing belongs to Sandbox; remove it only if that ownership boundary is deliberately redesigned under #32453's native-processing and exactly-once constraints. The existing authoritative H0 validation, lifecycle lock, readback verification, and manifest-last publication remain mandatory.

## Scope and compatibility

- Started from freshly fetched `origin/main` at `16d1e9a9b2bcd80e20ae37dfd64584814c46b531` on an isolated branch. The current issue contract takes precedence over historical V1/V2 rollout details.
- Audited every shared-validator and commit-identity caller, dispatch/activation wiring, direct API runtime, V3 schema and event consumer, CLI handoff reader, native RPC/AgentSession startup, and Guest event/prompt boundary. No shared wire type, payload, reader, SDK version, database schema, or migration changes.
- API/CLI/Guest/Runner deployment skew uses the already-deployed V3 contract. Pending-tool and settled-session continuation, active input, compaction, timeout recovery, model/provider/tier/billing/harness selection, and memory policy are unchanged.
- Rechecked all 22 open PRs by changed paths before commit. #32409 and #32484 overlap only the API test file among this PR's changed paths; neither establishes an ordering dependency.

## Acceptance evidence

| Issue criterion | Evidence |
| --- | --- |
| 1. Supported API entry, built-in Terra + Pi, zero API-first calls | Four input variants enter through chat API and make zero API provider calls and zero API resource downloads; each publishes V3 `sandbox-first` and leaves a claimable Pi job with the exact original prompt. |
| 2. One canonical execution, event and usage ownership | API fixtures check one H0 upload followed by one manifest, session identity, no pre-appended turn, event start 1, one completion/answer, and one processed Sandbox usage row despite duplicate receipts. Real RPC fixtures prove one prompt/provider call and one settled event per turn. |
| 3. Real native skill processing | Official RPC/AgentSession loads a temporary skill from the existing agent skill directory and sends its native expansion to a boundary provider. Unknown slash text and absolute paths reach native processing unchanged. No custom parser, extension, template, or discovery setting is added. |
| 4. Whitespace, arguments, ordinary prose | Both API and native fixtures cover leading spaces/newlines/tabs and exact arguments. The pinned SDK preserves whitespace-prefixed input as ordinary input; a literal `/skill:` expands normally. A slash later in prose still completes through API-first. |
| 5. Fresh and resumed H0 | Every input variant runs fresh and resumed. API handoff preserves authoritative resumed H0 bytes and base hash; RPC resumes its own actual persisted native checkpoint, retaining one session and exactly one new user/assistant pair per turn. |
| 6. Safety and no replay | Corrupt/mismatched H0, failed readback, elapsed coordination deadline, cancellation, and lost lifecycle ownership reject safely. Existing resource fallback/post-provider failure, cancellation, late success, and timeout regressions run unchanged. |
| 7. Existing behavior | Targeted API text, active-input, pending-tool, settled-session, compaction, timeout, memory, and usage tests; full affected CLI loop/handoff files; direct runtime/session and V3 contract tests. Production changes remain confined to input eligibility and its bounded outcome. |
| 8. Observability | Successful API fixtures assert exactly one structured pre-provider outcome, no warning or generic `Run failed`, and one `run.completed`. Failure fixtures retain terminal warning and failure events. New messages contain no prompt or payload data. |
| 9. Validation | Focused formatting, lint, types, Knip, and affected tests are recorded below. Full validation runs in PR and merge-group CI. |
| 10. Handoff | This sole owner invokes same-thread one-shot `pr-auto` immediately after PR creation and owns protected merge completion. Controller acceptance and production release/verification remain separate. |

## Validation

- Passed: Prettier on all three changed files; scoped API/CLI Oxlint, type-aware Oxlint and ESLint; API and CLI package type checks (including native runtime public declarations); Knip for API and CLI; `git diff --check`.
- API `chat-events.bdd.test.ts`: **25 distinct selected cases passed** across runs of 21 and 8 cases (four slash cases rerun after adding duplicate-usage assertions). Selection covers the new fixtures plus resource/post-provider failure, authoritative H0 timeout handoff, late API success, cancellation, coordination cap, active input, API text/settled continuation, pending tools, compaction, memory pinning, and separate API/Sandbox usage ownership.
- CLI `pi-agent-loop.test.ts` and `pi-api-first-turn-handoff.test.ts`: **57 passed**, including all four new native fixtures on fresh and resumed sessions.
- Runtime `api.test.ts` and `session-memory.test.ts`: **24 passed**.
- Contracts `runners.test.ts`: **105 passed**.

All local database tests used a dedicated PostgreSQL database with the repository's existing migrations. Required PR and merge-group checks will be followed through terminal protected merge in this thread.

The API fixture simulates the external Sandbox checkpoint/completion boundary; it does not claim native command execution from its manually built H2. Native-processing evidence comes from the separate real official RPC/AgentSession fixtures and actual persisted session files. Provider responses are controlled test boundaries. No full local Vitest suite or development server was run, and no production actions were performed.
