### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2767,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3366,10 +3366,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-triple"
-version = "1.0.1"
+name = "target-tuple"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
+checksum = "876fef147edbcbddc8ac5cbbba92c7b86519e314e86638596c09673b2ed01e7f"
 
 [[package]]
 name = "tempfile"
@@ -3734,15 +3734,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
+checksum = "c0cabaa10be1917331a313866bd94526343e03c77bcf69144b62b072ad35d47c"
 dependencies = [
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
- "target-triple",
+ "target-tuple",
  "termcolor",
  "toml",
 ]


### PR DESCRIPTION
## Summary

- Refresh the Rust lockfile with the latest compatible dependency versions.
- Update `rustls` from 0.23.43 to 0.23.44.
- Update `trybuild` from 1.0.120 to 1.0.121.
- Replace `target-triple` 1.0.1 with `target-tuple` 1.0.2 through the `trybuild` update.

## Deferred updates

- `generic-array` 0.14.9 remains blocked because `crypto-common` 0.1.7 requires exactly 0.14.7.
- `zstd` 0.14.0 is a major-version update outside the workspace's current `^0.13` requirement and is deferred for a dedicated migration.

No manual manifest version bumps were required.

## Validation

- `cargo +stable test --locked --workspace --exclude runner --profile local`
- `cargo +stable check --locked --profile local -p runner --tests`

All non-runner workspace tests and doctests passed. Runner test targets compile successfully with the updated lockfile.
