### PR TITLE
test(e2e): align firewall probes with auth deadline

### DIFF
--- a/e2e/tests/03-runner/run-t01-firewall-twilio.bats
+++ b/e2e/tests/03-runner/run-t01-firewall-twilio.bats
@@ -40,7 +40,9 @@ printf 'TWILIO_ACCOUNT_SID=%s\n' "$TWILIO_ACCOUNT_SID"
 printf 'TWILIO_AUTH_TOKEN=%s\n' "$TWILIO_AUTH_TOKEN"
 # Raw DNS has dedicated runner coverage. Pin the public sink so this test owns
 # only firewall classification, authentication resolution, and redaction.
-curl --silent --show-error --max-time 5 \
+# Outlive the proxy's 10-second firewall-auth deadline so this request does not
+# close its connection while credentials are still resolving.
+curl --silent --show-error --max-time 15 \
     --resolve 'api.twilio.com:443:8.8.8.8' \
     --output /dev/null \
     'https://api.twilio.com/2010-04-01/Accounts.json' || true

--- a/e2e/tests/03-runner/run-t02-firewall-discord-webhook.bats
+++ b/e2e/tests/03-runner/run-t02-firewall-discord-webhook.bats
@@ -35,7 +35,8 @@ teardown() {
     local prompt
     prompt=$(cat <<'EOF'
 printf 'DISCORD_WEBHOOK_URL=%s\n' "$DISCORD_WEBHOOK_URL"
-curl --silent --show-error --max-time 5 \
+# Leave room for connection setup around the proxy's 10-second auth deadline.
+curl --silent --show-error --max-time 15 \
     --resolve 'firewall-placeholder.vm3.ai:443:8.8.8.8' \
     --output /dev/null \
     "$DISCORD_WEBHOOK_URL" || true

--- a/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
+++ b/e2e/tests/03-runner/run-t04-firewall-serpapi.bats
@@ -34,7 +34,8 @@ set -euo pipefail
 printf 'SERPAPI_TOKEN=%s\n' "$SERPAPI_TOKEN"
 # Raw DNS has dedicated runner coverage. Keep this firewall-auth probe on IPv4
 # so an unavailable AAAA response cannot block an otherwise valid request.
-if curl --ipv4 --silent --show-error --max-time 5 \
+# Leave room for connection setup around the proxy's 10-second auth deadline.
+if curl --ipv4 --silent --show-error --max-time 15 \
     --output /dev/null \
     'https://serpapi.com/search?q=vm0-e2e&engine=google'; then
     printf 'SERPAPI_REQUEST_SENT\n'

--- a/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
+++ b/e2e/tests/03-runner/run-t05-firewall-permission-refresh.bats
@@ -62,14 +62,16 @@ trap 'rm -f "$response_file"' EXIT
 deadline=$((SECONDS + 90))
 while ((SECONDS < deadline)); do
     : > "$response_file"
-    curl --silent --show-error --max-time 5 \
+    # The allowed request can spend up to 10 seconds resolving auth. A transport
+    # failure or partial response must not end the run before policy is observed.
+    if curl --silent --show-error --max-time 15 \
         --resolve 'firewall-placeholder.vm3.ai:443:8.8.8.8' \
         --output "$response_file" \
         --request POST \
         --header 'content-type: application/json' \
         --data '{"objectID":"vm0-e2e"}' \
-        '__REQUEST_URL__' || true
-    if ! grep -Eq '"error"[[:space:]]*:[[:space:]]*"permission_denied"' "$response_file"; then
+        '__REQUEST_URL__' &&
+        ! grep -Eq '"error"[[:space:]]*:[[:space:]]*"permission_denied"' "$response_file"; then
         printf 'ALGOLIA_PERMISSION_ALLOWED\n'
         exit 0
     fi

--- a/e2e/tests/03-runner/run-t22-connector-refresh.bats
+++ b/e2e/tests/03-runner/run-t22-connector-refresh.bats
@@ -54,7 +54,8 @@ printf 'BENTOML_ENDPOINT_SHA256='
 printf '%s' "$BENTO_CLOUD_API_ENDPOINT" | sha256sum | cut -d' ' -f1
 # Raw DNS has dedicated runner coverage. Keep this connector-refresh probe on
 # IPv4 so an unavailable AAAA response cannot block an otherwise valid request.
-if curl --ipv4 --silent --show-error --max-time 5 \
+# Leave room for connection setup around the proxy's 10-second auth deadline.
+if curl --ipv4 --silent --show-error --max-time 15 \
     --output /dev/null \
     "${BENTO_CLOUD_API_ENDPOINT}/"; then
     printf '__OUTPUT_PREFIX__SENT\n'

--- a/e2e/tests/03-runner/run-t23-custom-connector.bats
+++ b/e2e/tests/03-runner/run-t23-custom-connector.bats
@@ -105,7 +105,8 @@ teardown() {
     local prompt
     prompt=$(cat <<'EOF'
 set -euo pipefail
-curl --silent --show-error --max-time 10 \
+# Leave room for connection setup around the proxy's 10-second auth deadline.
+curl --silent --show-error --max-time 15 \
     --output /dev/null \
     'https://www.google.com/robots.txt' || true
 printf 'CUSTOM_CONNECTOR_REQUEST_SENT\n'
@@ -309,7 +310,8 @@ EOF
     local default_prompt
     default_prompt=$(cat <<EOF
 set -euo pipefail
-curl --silent --show-error --max-time 10 \\
+# Leave room for connection setup around the proxy's 10-second auth deadline.
+curl --silent --show-error --max-time 15 \\
     --output /dev/null \\
     'https://example.com/'
 printf '${default_marker}\\n'
@@ -446,7 +448,8 @@ EOF
     local selected_prompt
     selected_prompt=$(cat <<EOF
 set -euo pipefail
-curl --silent --show-error --max-time 10 \\
+# Leave room for connection setup around the proxy's 10-second auth deadline.
+curl --silent --show-error --max-time 15 \\
     --output /dev/null \\
     'https://www.google.com/robots.txt'
 printf '${selected_marker}\\n'


### PR DESCRIPTION
## Summary

- Give the Twilio, Discord, SerpApi, Algolia permission-refresh, BentoML credential-refresh, and custom-connector auth probes a 15-second curl budget, matching the existing Zendesk probe. The proxy's auth fetch alone permits 10 seconds.
- Keep Algolia's initial permission-denied probe at 5 seconds because it does not need credential resolution.
- Require a completed curl response before Algolia treats the absence of `permission_denied` as a permission transition. Empty or partial responses after transport failure now remain in the existing bounded polling loop instead of ending the run early.
- Preserve final firewall, resolved-secret, credential-redaction, and ordered permission-transition assertions. Do not require a particular third-party HTTP status or response body.

## Why

[Runner E2E job 101927334397](https://github.com/vm0-ai/vm0/actions/runs/34183273101/job/101927334397) failed after the Twilio guest curl reached its five-second limit. The chat event recorded that timeout at `03:27:42.845Z`; run-scoped firewall-auth API operations completed at `03:27:43.485Z`, with preparation taking 2,782 ms. The proxy subsequently recorded `BLOCK / upstream_destination_unbound` with a closed connection and no retained binding at `03:27:43.603Z`.

A follow-up audit found five other files whose auth probes used five seconds, or ten seconds without connection-setup headroom. These are code-confirmed budget risks, not a claim that every probe has already failed in CI.

Algolia also ignored curl's exit status and interpreted an empty response as permission being allowed. Its final telemetry assertion could still fail, but the guest script could already have ended the run prematurely.

## Scope and remaining risk

- Test-only changes: no production runner, addon, API, security-policy, telemetry-waiter, or CI deadline changes.
- No new retries, sleeps, skipped cases, or relaxed final assertions. Algolia retains its existing 90-second polling window; a final in-flight request can extend beyond that window by its per-request allowance.
- Ordinary no-auth network probes and Algolia's initial denied request are unchanged.
- The larger budget is a bounded mitigation, not a guarantee: connection setup, auth admission queueing, forwarding, and the public network can still delay or terminate a request.
- Existing public sink mappings remain unchanged. Relates to #32536, which tracks their removal separately because ordinary credential injection and placeholder `auth.base` forwarding have different transport requirements.
- A stalled five-second probe can take up to ten additional seconds per request; a stalled ten-second probe can take up to five additional seconds. Successful requests do not wait artificially.

## Validation

- `cd e2e && ./test/libs/bats/bin/bats --count` on the six changed BATS files — passed; seven cases discovered.
- Extracted all nine embedded shell prompts, expanded the unquoted heredocs with representative marker values, and checked each using `bash -n` and `shellcheck --shell=bash -` — passed.
- Executed the actual Algolia continuation prompt against a local HTTP server with real curl: a 15-second timeout, a truncated response, and a complete `permission_denied` response each caused another poll; a complete HTTP 401 response ended the script successfully. No deployed preview or provider was used for this focused shell check.
- `./scripts/check-file-size.sh` on all six changed BATS files — passed.
- `git diff --check`, staged whitespace checks, normal pre-commit hooks, and commit-message validation — passed.

The deployed Runner E2E suite is CI-only. The previous Twilio-only head passed its PR CI; the expanded changes require a new CI run. Local shell validation is not a substitute for that deployed end-to-end run.
