### PR TITLE
fix(runner): allow api cold starts in http timeout budgets

### DIFF
--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -25,8 +25,8 @@ pub const HTTP_TIMEOUT_SECS: u64 = 30;
 /// HTTP request timeout for uploads in seconds.
 pub const HTTP_UPLOAD_TIMEOUT_SECS: u64 = 60;
 
-/// HTTP request timeout for one active-input receipt attempt.
-pub const ACTIVE_INPUT_RECEIPT_TIMEOUT_SECS: u64 = 5;
+/// HTTP request timeout for one active-input receipt attempt, including API cold starts.
+pub const ACTIVE_INPUT_RECEIPT_TIMEOUT_SECS: u64 = 10;
 
 /// Maximum collected successful VM0 API response body size.
 ///
@@ -38,8 +38,8 @@ pub const API_SUCCESS_RESPONSE_BODY_MAX_BYTES: usize = 5 * 1024 * 1024;
 /// Maximum collected non-retryable VM0 API error response body size.
 pub const API_ERROR_RESPONSE_BODY_MAX_BYTES: usize = 64 * 1024;
 
-/// Global active-input receipt finalization budget.
-pub const ACTIVE_INPUT_RECEIPT_FINALIZE_TIMEOUT_SECS: u64 = 5;
+/// Global active-input receipt finalization budget, allowing one full HTTP attempt.
+pub const ACTIVE_INPUT_RECEIPT_FINALIZE_TIMEOUT_SECS: u64 = ACTIVE_INPUT_RECEIPT_TIMEOUT_SECS;
 
 /// Maximum wait for an in-flight delivery-identified CLI sink operation.
 pub const ACTIVE_INPUT_SINK_QUIESCENCE_TIMEOUT_SECS: u64 = 5;

--- a/crates/guest-agent/tests/active_input_receipts.rs
+++ b/crates/guest-agent/tests/active_input_receipts.rs
@@ -318,6 +318,72 @@ async fn transport_failure_gets_only_one_finalization_retry()
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn finalization_receipt_survives_api_cold_start() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start_async().await;
+    let path = format!("/api/runners/runs/{RUN_ID}/active-inputs/deliveries/{DELIVERY_ID}/receipt");
+    let unavailable = server
+        .mock_async(|when, then| {
+            when.method(POST).path(&path);
+            then.status(503);
+        })
+        .await;
+    let tmp = tempfile::tempdir()?;
+    let journal_path = tmp.path().join("active-input-receipts.json");
+    let runtime = ActiveInputRuntime::new_with_receipts(
+        RUN_ID,
+        "initial",
+        &journal_path,
+        receipt_http(&server.base_url())?,
+    )?;
+    let controller = runtime.controller();
+    let mut writer = runtime.into_writer();
+    assert_eq!(
+        controller.handle_control_payload(&payload(PROMPT)?),
+        ActiveInputControlOutcome::Accepted
+    );
+    let frame = writer
+        .next_frame()
+        .await
+        .expect("input should reach the sink");
+    writer.mark_writing(&frame.uuid);
+    writer.mark_backend_accepted_without_replay(&frame)?;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while unavailable.calls_async().await == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the initial receipt request should reach the server");
+    unavailable.delete_async().await;
+    let delivered = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path(&path)
+                .header("authorization", "Bearer test-token");
+            then.status(200)
+                .delay(Duration::from_secs(6))
+                .json_body(json!({ "outcome": "delivered" }));
+        })
+        .await;
+
+    controller.close_terminal();
+    assert_eq!(
+        controller.finalize_receipts().await?,
+        vec![DELIVERY_ID.to_string()]
+    );
+    delivered.assert_calls_async(1).await;
+    assert!(
+        guest_contracts::active_input_receipts::read_active_input_receipt_journal(
+            &journal_path,
+            RUN_ID,
+        )?
+        .is_empty(),
+        "finalization must wait for the delayed acknowledgement before compacting the journal"
+    );
+    Ok(())
+}
+
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn journal_publication_failure_is_terminal_after_backend_acceptance()

--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -91,7 +91,8 @@ _FLOW_STATE = "_model_provider_failure_flow_state"
 _RESPONSE_FINISH = "_model_provider_failure_response_finish"
 _MAX_JSON_WORK_UNITS = 65_536
 _MAX_RETRY_AFTER_SECONDS = 300
-_REPORT_TIMEOUT_SECONDS = 3
+# Allow API cold starts while keeping best-effort reporting and shutdown bounded.
+_REPORT_TIMEOUT_SECONDS = 10
 _REPORT_WORKERS = 4
 _MAX_PENDING_REPORTS = _REPORT_WORKERS * 4
 RUNNER_AUTH_ENV = "OKOU_MITM_RUNNER_TOKEN"

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -458,7 +458,7 @@ def test_connection_report_http_failure_preserves_source_and_reclaims_capacity(
     assert request.method == "POST"
     assert request.path == "/api/runners/runs/run-model-failure/model-provider-failures"
     assert request.header("authorization") == f"Bearer {id(model_provider_failure_api)}"
-    assert request_timeouts == [3]
+    assert request_timeouts == [10]
     _assert_single_reclaimed_report_slot(
         real_flow,
         tmp_path / "connection-http-error-recovery.jsonl",

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -48,8 +48,8 @@ const DOCTOR_IO_CONCURRENCY: usize = 4;
 
 const SYSTEMD_SYSTEM_DIR: &str = "/etc/systemd/system";
 
-/// Total timeout for each API connectivity probe.
-const API_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
+/// Total timeout for each API connectivity probe, including cold starts.
+const API_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Grace period where a freshly claimed new-sandbox run may still be preparing
 /// and may not have a stable Firecracker process yet.
@@ -3736,6 +3736,39 @@ printf '%s\n' \
 
         assert!(reports.is_empty());
         api.assert_calls_async(0).await;
+    }
+
+    #[tokio::test]
+    async fn build_runner_reports_allows_api_cold_starts() {
+        let server = MockServer::start_async().await;
+        let api = server
+            .mock_async(|when, then| {
+                when.method("HEAD")
+                    .path("/api")
+                    .header("authorization", "Bearer test-token");
+                then.status(200).delay(Duration::from_secs(6));
+            })
+            .await;
+        let api_url = server.url("/api");
+        let fixture = doctor_report_fixture_with_server(
+            "running",
+            None,
+            None,
+            Some((&api_url, "test-token")),
+        );
+        let runner = live_runner_instance(
+            std::process::id(),
+            fixture.config_path.clone(),
+            fixture.base_dir.clone(),
+        );
+        let client = build_api_client();
+
+        let reports =
+            build_runner_reports(&[runner], None, client.as_ref(), &empty_discovered(), &[]).await;
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].api_ok, Some(true));
+        api.assert_calls_async(1).await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -213,7 +213,6 @@ const CLAIM_DETERMINISTIC_COOLDOWN: Duration = POLL_SLOW;
 const POLL_DEGRADED_AFTER: Duration = Duration::from_secs(60);
 /// Runner reuse requires a heartbeat observed within this freshness window.
 const HEARTBEAT_DEGRADED_AFTER: Duration = Duration::from_secs(30);
-const CONNECTOR_RUNTIME_SYNC_TIMEOUT: Duration = Duration::from_secs(3);
 const BUILTIN_FIREWALL_CATALOG_RESOLVE_TIMEOUT: Duration = Duration::from_secs(10);
 
 struct DegradationEpisode {
@@ -1412,13 +1411,12 @@ impl ApiClient {
         })
     }
 
-    /// Send a heartbeat with runner state. The short timeout (3s) bounds this
-    /// best-effort request and any lifecycle drain waiting for it.
+    /// Send a heartbeat with runner state. The default API timeout allows for
+    /// cold starts while bounding this request and lifecycle drain waits.
     async fn heartbeat(&self, state: &HeartbeatState) -> RunnerResult<()> {
         let resp = send_api(
             self.http
                 .request_route(routes::runners::heartbeat::HEARTBEAT, &self.token)
-                .timeout(Duration::from_secs(3))
                 .json(state),
             "heartbeat",
         )
@@ -1560,7 +1558,6 @@ impl ApiClient {
                 ),
                 &self.token,
             )
-            .timeout(CONNECTOR_RUNTIME_SYNC_TIMEOUT)
             .json(&serde_json::json!({ "targets": targets }))
     }
 
@@ -2010,6 +2007,56 @@ mod tests {
 
     fn api_client_for_server(server: &MockServer) -> ApiClient {
         api_client_for_url(server.base_url())
+    }
+
+    #[tokio::test]
+    async fn heartbeat_and_connector_sync_allow_api_cold_starts() {
+        let server = MockServer::start_async().await;
+        let heartbeat = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/api/runners/heartbeat")
+                    .header("authorization", "Bearer runner-token");
+                then.status(200).delay(Duration::from_secs(6));
+            })
+            .await;
+        let run_id = RunId::nil();
+        let sync = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(format!("/api/runners/runs/{run_id}/connector-runtime/sync"))
+                    .header("authorization", "Bearer runner-token");
+                then.status(200)
+                    .delay(Duration::from_secs(6))
+                    .json_body(serde_json::json!({
+                        "results": [{
+                            "target": {"kind": "builtin", "connectorSlug": "slack"},
+                            "state": "unresolved",
+                            "reason": "connector-unavailable",
+                        }],
+                    }));
+            })
+            .await;
+        let api = api_client_for_server(&server);
+        let state = heartbeat_state_for_test();
+        let targets = [ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "slack".to_string(),
+            base_url_vars: None,
+            source_id: None,
+        }];
+
+        let (heartbeat_result, sync_result) = tokio::join!(
+            api.heartbeat(&state),
+            api.sync_connector_runtime(run_id, &targets),
+        );
+
+        heartbeat_result.expect("heartbeat should survive an API cold start");
+        assert!(matches!(
+            sync_result.expect("connector sync should survive an API cold start"),
+            ConnectorRuntimeSyncOutcome::Synced(response) if response.results.len() == 1
+        ));
+        heartbeat.assert_calls_async(1).await;
+        sync.assert_calls_async(1).await;
     }
 
     async fn claim_decode_error(

--- a/crates/runner/src/proxy/managed_process.rs
+++ b/crates/runner/src/proxy/managed_process.rs
@@ -10,9 +10,9 @@ use crate::error::{RunnerError, RunnerResult};
 
 /// Timeout for graceful shutdown before SIGKILL.
 ///
-/// Webhook delivery drain is handled before SIGTERM; this only bounds
-/// mitmproxy's own graceful process exit.
-const STOP_TIMEOUT: Duration = Duration::from_secs(10);
+/// Usage webhook drain is handled before SIGTERM. Leave room for the addon's
+/// ten-second model-provider report drain, final JSONL flush, and process exit.
+const STOP_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Owns the direct PyInstaller bootloader, its process group, and the private
 /// directory containing its one-file extraction.

--- a/crates/runner/src/r2_cache/config.rs
+++ b/crates/runner/src/r2_cache/config.rs
@@ -1,5 +1,8 @@
+use std::time::Duration;
+
 use aws_sdk_s3::config::{
     BehaviorVersion, Credentials, Region, ResponseChecksumValidation, SharedCredentialsProvider,
+    timeout::TimeoutConfig,
 };
 
 use super::{R2Error, R2ImageCache, io_other};
@@ -59,6 +62,14 @@ impl R2ImageCache {
             .region(Region::new("auto"))
             .endpoint_url(endpoint)
             .credentials_provider(SharedCredentialsProvider::new(creds))
+            // Bound connection establishment and time to a response. Do not cap
+            // whole template transfers; SDK stalled-stream protection bounds idle I/O.
+            .timeout_config(
+                TimeoutConfig::builder()
+                    .connect_timeout(Duration::from_secs(10))
+                    .read_timeout(Duration::from_secs(60))
+                    .build(),
+            )
             // The SDK default enables GetObject checksum validation when supported.
             // R2/S3 multipart objects may return part-level checksums that the Rust
             // SDK cannot validate, which only produces noisy warnings. We do not

--- a/crates/runner/src/r2_cache/config.rs
+++ b/crates/runner/src/r2_cache/config.rs
@@ -62,8 +62,9 @@ impl R2ImageCache {
             .region(Region::new("auto"))
             .endpoint_url(endpoint)
             .credentials_provider(SharedCredentialsProvider::new(creds))
-            // Bound connection establishment and time to a response. Do not cap
-            // whole template transfers; SDK stalled-stream protection bounds idle I/O.
+            // Bound connection and first-response waits. Upload parts use a
+            // separate response budget; downloaded bodies retain SDK stalled-stream
+            // protection without a short whole-transfer deadline.
             .timeout_config(
                 TimeoutConfig::builder()
                     .connect_timeout(Duration::from_secs(10))

--- a/crates/runner/src/r2_cache/multipart.rs
+++ b/crates/runner/src/r2_cache/multipart.rs
@@ -1,5 +1,6 @@
-use std::{future::Future, path::Path};
+use std::{future::Future, path::Path, time::Duration};
 
+use aws_sdk_s3::config::timeout::TimeoutConfig;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use tokio::io::AsyncReadExt;
@@ -9,6 +10,10 @@ use super::{R2Error, R2ImageCache, archive::pack_template_to_writer, io_other};
 /// Multipart part size. R2 minimum is 5 MiB (except last part); 16 MiB
 /// keeps part count reasonable for large images and fits comfortably in memory.
 const PART_SIZE: usize = 16 * 1024 * 1024;
+
+/// The SDK response timeout includes sending the body. Allow slow 16 MiB
+/// uploads without leaving the final response wait unbounded.
+const UPLOAD_PART_RESPONSE_TIMEOUT: Duration = Duration::from_secs(300);
 
 impl R2ImageCache {
     pub(super) async fn do_multipart_upload(
@@ -82,12 +87,20 @@ impl R2ImageCache {
         const CONCURRENCY: usize = 4;
 
         let client = self.client.clone();
+        let part_timeouts = client
+            .config()
+            .timeout_config()
+            .map(TimeoutConfig::to_builder)
+            .unwrap_or_else(TimeoutConfig::builder)
+            .read_timeout(UPLOAD_PART_RESPONSE_TIMEOUT)
+            .build();
         let bucket = self.bucket.clone();
         let key_owned = key.to_string();
         let upload_id_owned = upload_id.to_string();
 
         upload_parts_streaming_with(reader, PART_SIZE, CONCURRENCY, move |pn, chunk| {
             let client = client.clone();
+            let part_timeouts = part_timeouts.clone();
             let bucket = bucket.clone();
             let key_owned = key_owned.clone();
             let upload_id_owned = upload_id_owned.clone();
@@ -99,6 +112,10 @@ impl R2ImageCache {
                     .upload_id(&upload_id_owned)
                     .part_number(pn)
                     .body(ByteStream::from(chunk))
+                    .customize()
+                    .config_override(
+                        aws_sdk_s3::config::Builder::new().timeout_config(part_timeouts),
+                    )
                     .send()
                     .await?;
                 // S3 / R2 always return ETag for a successful upload_part.

--- a/crates/runner/src/r2_cache/tests/config.rs
+++ b/crates/runner/src/r2_cache/tests/config.rs
@@ -110,7 +110,13 @@ async fn from_env_child() {
         ALL_PRESENT_SCENARIO => {
             let result = R2ImageCache::from_env().await.unwrap();
             assert!(result.is_some(), "all four set → Some");
-            assert_eq!(result.unwrap().bucket, "test-bucket");
+            let cache = result.unwrap();
+            assert_eq!(cache.bucket, "test-bucket");
+            let timeouts = cache.client.config().timeout_config().unwrap();
+            assert_eq!(timeouts.connect_timeout(), Some(Duration::from_secs(10)));
+            assert_eq!(timeouts.read_timeout(), Some(Duration::from_secs(60)));
+            assert_eq!(timeouts.operation_timeout(), None);
+            assert_eq!(timeouts.operation_attempt_timeout(), None);
         }
         ALL_EMPTY_SCENARIO => {
             let result = R2ImageCache::from_env().await.unwrap();

--- a/crates/runner/src/r2_cache/tests/mod.rs
+++ b/crates/runner/src/r2_cache/tests/mod.rs
@@ -1,4 +1,5 @@
 mod config;
 mod download;
 mod fixtures;
+mod timeouts;
 mod upload;

--- a/crates/runner/src/r2_cache/tests/timeouts.rs
+++ b/crates/runner/src/r2_cache/tests/timeouts.rs
@@ -1,0 +1,95 @@
+use std::time::Duration;
+
+use aws_sdk_s3::config::{
+    BehaviorVersion, Credentials, Region, retry::RetryConfig, timeout::TimeoutConfig,
+};
+use httpmock::MockServer;
+
+use super::super::R2ImageCache;
+use super::fixtures::small_src_file;
+
+#[tokio::test]
+async fn upload_parts_allow_slow_responses_without_relaxing_control_requests() {
+    let server = MockServer::start_async().await;
+    let key_path = "/test-bucket/runner-templates/hash.tar.zst";
+    let create = server
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path(key_path)
+                .query_param_exists("uploads");
+            then.status(200).body(
+                "<InitiateMultipartUploadResult><UploadId>upload-id</UploadId></InitiateMultipartUploadResult>",
+            );
+        })
+        .await;
+    let part = server
+        .mock_async(|when, then| {
+            when.method("PUT")
+                .path(key_path)
+                .query_param("uploadId", "upload-id")
+                .query_param("partNumber", "1");
+            // Exercise the real HTTP timeout with a tiny file, not a large
+            // bandwidth-throttled fixture. This exceeds the control budget.
+            then.status(200)
+                .header("etag", "\"part-etag\"")
+                .delay(Duration::from_secs(2));
+        })
+        .await;
+    let complete = server
+        .mock_async(|when, then| {
+            when.method("POST")
+                .path(key_path)
+                .query_param("uploadId", "upload-id")
+                .body_includes("<PartNumber>1</PartNumber>")
+                .body_includes("part-etag");
+            then.status(200).body(
+                "<CompleteMultipartUploadResult><ETag>\"object-etag\"</ETag></CompleteMultipartUploadResult>",
+            );
+        })
+        .await;
+    let head = server
+        .mock_async(|when, then| {
+            when.method("HEAD").path(key_path);
+            then.status(200).delay(Duration::from_secs(2));
+        })
+        .await;
+
+    let config = aws_sdk_s3::Config::builder()
+        .behavior_version(BehaviorVersion::latest())
+        .region(Region::new("auto"))
+        .endpoint_url(server.base_url())
+        .force_path_style(true)
+        .credentials_provider(Credentials::new("test", "test", None, None, "test"))
+        .retry_config(RetryConfig::standard().with_max_attempts(1))
+        .timeout_config(
+            TimeoutConfig::builder()
+                .connect_timeout(Duration::from_secs(10))
+                .read_timeout(Duration::from_secs(1))
+                .build(),
+        )
+        .build();
+    let cache = R2ImageCache::with_client(
+        aws_sdk_s3::Client::from_conf(config),
+        "test-bucket".to_string(),
+    );
+    let (_source_dir, source) = small_src_file().await;
+
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        cache.upload_template("hash", &source, true),
+    )
+    .await
+    .expect("upload should complete after the delayed part response")
+    .expect("parts must not inherit the shorter control timeout");
+    create.assert_calls_async(1).await;
+    part.assert_calls_async(1).await;
+    complete.assert_calls_async(1).await;
+
+    // The same client must still reject a control response over its budget.
+    let error = cache.template_exists("hash").await.unwrap_err();
+    assert!(
+        error.to_string().to_ascii_lowercase().contains("timeout"),
+        "{error}"
+    );
+    head.assert_calls_async(1).await;
+}

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -28,8 +28,8 @@ mod session_history;
 /// How long before we auto-flush pending ops (matching TS: 30s).
 const FLUSH_THRESHOLD: Duration = Duration::from_secs(30);
 
-/// Timeout for telemetry HTTP requests (shorter than default API timeout).
-const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(5);
+/// Timeout for telemetry HTTP requests, including API cold starts.
+const TELEMETRY_TIMEOUT: Duration = Duration::from_secs(10);
 const RUNNER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Effective resource path once the guest process has spawned.
@@ -1289,6 +1289,15 @@ mod tests {
             flush.as_mut().now_or_never().is_none(),
             "flush returned before the held auto-flush response completed"
         );
+
+        // API cold starts can exceed the previous five-second request deadline.
+        tokio::select! {
+            biased;
+            () = flush.as_mut() => {
+                panic!("flush timed out before the delayed API response was released");
+            }
+            () = tokio::time::sleep(Duration::from_secs(6)) => {}
+        }
 
         release_tx.send(()).unwrap();
         tokio::time::timeout(Duration::from_secs(1), flush)


### PR DESCRIPTION
## Summary

Closes #32511. Related investigation: #32450 (not closed by this PR).

A production telemetry request had a 4.99-second API cold start and returned HTTP 200 after 5.3 seconds, exceeding the runner's previous five-second deadline. Adjust short runner/sandbox control-plane deadlines and their enclosing drain budgets.

| Path | Before | After |
| --- | --- | --- |
| Runner telemetry | 5s | 10s |
| Runner heartbeat / connector-runtime sync | 3s override | Existing 10s HTTP default |
| Runner doctor API probe | 5s | 10s |
| Guest active-input receipt / finalization | 5s / 5s | 10s / 10s |
| Proxy model-provider failure report | 3s | 10s |
| Proxy graceful exit, after usage drain | 10s | 15s |
| Template R2 connection | SDK default | 10s |
| Template R2 ordinary first response | No explicit limit | 60s |
| Template R2 upload-part first response, including request body | No explicit limit | 300s per attempt |

R2 upload parts need their own budget: the SDK's [read timeout starts when the request is initiated](https://docs.rs/aws-smithy-types/1.6.3/aws_smithy_types/timeout/struct.TimeoutConfig.html#method.read_timeout), including sending the upload body. Override only each upload-part operation's response budget while preserving the client's other timeout settings. No operation/attempt-wide deadline is added; downloaded response bodies retain SDK stalled-stream protection without a short whole-transfer cap.

## Scope and compatibility

- No changes to schemas, persisted formats, retry counts, authentication, billing, connector last-known-good behavior, or cancellation policy.
- Multipart size remains 16 MiB and concurrency remains four. No global locks, larger fixtures, dependencies, CI changes, or Vercel configuration changes.
- Existing runner/backend versions remain compatible; old clients retain their old deadlines until replaced.
- Rebased onto main and preserved #32521's removal of the legacy model-provider report retry. The reporter sends one canonical request; its replacement error-path test now expects 10s.
- Leave existing suitable transfer/streaming deadlines, long-running SocialKit/MCP operations, and third-party/user CLI behavior unchanged.
- Does not claim to resolve every transport error in #32450, including the unexplained active-input reservation timeout already using 10s.

## Validation

- 374 selected Rust tests passed: 340 runner tests, 10 receipt/Claude integration tests, and 24 guest HTTP tests. Two existing standalone-ignored runner child entrypoints execute through their parent tests; no new skips.
- Full mitm-addon suite: 7,347 passed.
- Rust formatting, Clippy and documentation checks; locked Python environment, Ruff and BasedPyright: passed.
- Pre-commit also passed workspace-wide Clippy and documentation checks, formatting, file-size validation and Commitlint.
- Real HTTP six-second regressions cover telemetry flush, heartbeat, connector sync, doctor and durable receipt finalization.
- A 1 KiB real-file/HTTP R2 regression delays the upload-part response beyond a scaled control deadline, verifies multipart completion, then verifies that HEAD on the same client still times out. It failed with an HTTP read timeout before the upload-specific override and passed after it.
- Existing upload error/abort, cancellation, heartbeat shutdown, connector lifecycle and report queue/capacity tests passed.
- No Turbo checks needed: no TypeScript, generated contract or Turbo input changes.

Rust commands, from `crates/`:

```sh
cargo fmt --all -- --check
cargo clippy --profile local -p runner -p guest-agent --all-targets --all-features -j 2
cargo doc --profile local -p runner -p guest-agent --all-features --no-deps -j 2
cargo test --profile local -p runner --bin runner --all-features -j 2 -- telemetry::tests:: provider::api::tests:: provider::connector_runtime_sync::tests:: cmd::doctor::tests:: r2_cache::tests:: r2_cache::multipart::tests:: proxy::process::tests:: main_loop::heartbeat:: main_loop::shutdown:: --test-threads=4
cargo test --profile local -p guest-agent --test active_input_receipts --test claude_active_input_receipt --all-features -j 2 -- --test-threads=4
cargo test --profile local -p guest-agent --test integration --all-features -j 2 http_client -- --test-threads=4
```

Python commands, from `crates/runner/mitm-addon/`:

```sh
uv lock --check
uv sync --locked
uv run --no-sync ruff format --check .
uv run --no-sync ruff check .
uv run --no-sync basedpyright -p .
uv run --no-sync python -m pytest tests/
```

## Risks / unverified areas

- Failed calls and shutdown drains can wait longer. The receipt worker's derived join allowance grows from 11s to 21s; existing 90s host recovery/finalization budgets remain unchanged, leaving less time for other work when receipts are slow.
- Connector synchronization retains its retry policy, so its aggregate wait can increase. Heartbeat and report queue concurrency remain bounded.
- R2 first-response deadlines apply per attempt, not across all SDK retries. Upload parts taking more than five minutes can still fail/retry; ordinary requests use 60s. Whole downloaded response bodies are not capped at 60s.
- The Python reporter uses urllib socket timeouts, not a strict end-to-end request deadline; its process exit remains bounded.
- Local delayed-response tests do not measure production cold-start distributions, live R2 throughput or multi-gigabyte transfers. The small R2 regression tests response delay, not real bandwidth throttling.
