### PR TITLE
feat(pi): route sol and luna with correct first-turn billing

### DIFF
--- a/e2e/tests/03-runner/run-t24-built-in-provider-fallback.bats
+++ b/e2e/tests/03-runner/run-t24-built-in-provider-fallback.bats
@@ -7,7 +7,8 @@ load '../../helpers/runner-chat'
 load '../../helpers/runner-api'
 
 BATS_TEST_TIMEOUT=600
-BUILT_IN_FALLBACK_MODEL="gpt-5.6-luna"
+# Keep Codex fallback coverage on a model outside the Pi expansion.
+BUILT_IN_FALLBACK_MODEL="gpt-6-astra"
 
 setup() {
     local credentials="/tmp/e2e-api-credentials-runner-real-claude.json"

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -266,53 +266,64 @@ const PI_API_FIRST_TURN_BASE_USAGE_CATEGORIES = [
   "tokens.cache_read",
   "tokens.cache_creation",
 ] as const;
-const STANDARD_TERRA_API_KEY_BDD_ROUTES = [
-  {
-    name: "OpenAI",
-    type: "openai-api-key",
-    endpoint: "https://api.openai.com/v1/responses",
-    baseUrl: "https://api.openai.com/v1",
-    secretName: "OPENAI_API_KEY",
-    piProvider: "openai",
-    runtimeModel: "gpt-5.6-terra",
-  },
-  {
-    name: "OpenRouter",
-    type: "openrouter-codex",
-    endpoint: "https://openrouter.ai/api/v1/responses",
-    baseUrl: "https://openrouter.ai/api/v1",
-    secretName: "OPENROUTER_API_KEY",
-    piProvider: "openrouter",
-    runtimeModel: "openai/gpt-5.6-terra",
-  },
-  {
-    name: "Vercel AI Gateway",
-    type: "vercel-ai-gateway-codex",
-    endpoint: "https://ai-gateway.vercel.sh/v1/responses",
-    baseUrl: "https://ai-gateway.vercel.sh/v1",
-    secretName: "VERCEL_AI_GATEWAY_API_KEY",
-    piProvider: "openai",
-    catalogModel: "gpt-5.6-terra",
-    runtimeModel: "openai/gpt-5.6-terra",
-  },
+const GPT_PI_BDD_MODELS = [
+  "gpt-5.6-terra",
+  "gpt-5.6-sol",
+  "gpt-5.6-luna",
 ] as const;
-const USER_OWNED_TERRA_FAST_BDD_ROUTES = [
-  {
-    name: "subscription",
-    type: "codex-oauth-token",
-    endpoint: "https://chatgpt.com/backend-api/codex/responses",
-    runtimeModel: "gpt-5.6-terra",
-    wireTier: "priority",
-  },
-  ...STANDARD_TERRA_API_KEY_BDD_ROUTES.map((route) => {
+type PiGptBddModel = (typeof GPT_PI_BDD_MODELS)[number];
+const GPT_API_KEY_BDD_ROUTES = GPT_PI_BDD_MODELS.flatMap((selectedModel) => {
+  return [
+    {
+      name: `OpenAI ${selectedModel}`,
+      selectedModel,
+      type: "openai-api-key",
+      endpoint: "https://api.openai.com/v1/responses",
+      baseUrl: "https://api.openai.com/v1",
+      secretName: "OPENAI_API_KEY",
+      piProvider: "openai",
+      runtimeModel: selectedModel,
+    },
+    {
+      name: `OpenRouter ${selectedModel}`,
+      selectedModel,
+      type: "openrouter-codex",
+      endpoint: "https://openrouter.ai/api/v1/responses",
+      baseUrl: "https://openrouter.ai/api/v1",
+      secretName: "OPENROUTER_API_KEY",
+      piProvider: "openrouter",
+      runtimeModel: `openai/${selectedModel}`,
+    },
+    {
+      name: `Vercel AI Gateway ${selectedModel}`,
+      selectedModel,
+      type: "vercel-ai-gateway-codex",
+      endpoint: "https://ai-gateway.vercel.sh/v1/responses",
+      baseUrl: "https://ai-gateway.vercel.sh/v1",
+      secretName: "VERCEL_AI_GATEWAY_API_KEY",
+      piProvider: "openai",
+      catalogModel: selectedModel,
+      runtimeModel: `openai/${selectedModel}`,
+    },
+  ] as const;
+});
+const USER_OWNED_GPT_FAST_BDD_ROUTES = [
+  ...GPT_PI_BDD_MODELS.map((selectedModel) => {
     return {
-      ...route,
-      wireTier: "priority" as const,
-    };
+      name: `subscription ${selectedModel}`,
+      selectedModel,
+      type: "codex-oauth-token",
+      endpoint: "https://chatgpt.com/backend-api/codex/responses",
+      runtimeModel: selectedModel,
+      wireTier: "priority",
+    } as const;
+  }),
+  ...GPT_API_KEY_BDD_ROUTES.map((route) => {
+    return { ...route, wireTier: "priority" as const };
   }),
 ] as const;
 
-const TERRA_USAGE_PRICING = [
+const GPT_USAGE_PRICING = [
   "tokens.input",
   "tokens.output",
   "tokens.cache_read",
@@ -329,19 +340,21 @@ const TERRA_USAGE_PRICING = [
   "tokens.output.long_context.fast",
   "tokens.cache_read.long_context.fast",
   "tokens.cache_creation.long_context.fast",
-].map((category) => {
-  return {
-    kind: "model",
-    provider: "gpt-5.6-terra",
-    category,
-    unitPrice: 1,
-    unitSize: 1_000_000,
-  };
+].flatMap((category) => {
+  return GPT_PI_BDD_MODELS.map((provider) => {
+    return {
+      kind: "model",
+      provider,
+      category,
+      unitPrice: 1,
+      unitSize: 1_000_000,
+    };
+  });
 });
 type PiApiFirstTurnUsageProvider =
   | "deepseek-v4-flash"
   | "deepseek-v4-pro"
-  | "gpt-5.6-terra";
+  | PiGptBddModel;
 const RUN_TIME_BUDGET_MESSAGE = `This runner has a hard maximum runtime of 2 hours. The current run has been active for 115 minutes, leaving approximately 5 minutes before it is terminated.
 
 An active goal allows unfinished work to continue in a later run. An existing goal already provides that continuity and remains unchanged. If no goal exists, the unfinished outcome needs to be captured in a new goal before this run ends.
@@ -739,11 +752,11 @@ async function expectNoBuiltInModelUsage(runId: string): Promise<void> {
   await expect(readRunUsageEventsFixture(runId)).resolves.toStrictEqual([]);
 }
 
-async function createTerraUsagePricingResolution(): Promise<
+async function createGptUsagePricingResolution(): Promise<
   UsagePricingFixture["resolution"]
 > {
   const pricing = await createUsagePricingFixture({
-    configured: TERRA_USAGE_PRICING,
+    configured: GPT_USAGE_PRICING,
   });
   onTestFinished(pricing.cleanup);
   return pricing.resolution;
@@ -752,8 +765,8 @@ async function createTerraUsagePricingResolution(): Promise<
 async function createPiApiFirstTurnUsagePricingResolution(
   provider: PiApiFirstTurnUsageProvider,
 ): Promise<UsagePricingFixture["resolution"]> {
-  if (provider === "gpt-5.6-terra") {
-    return await createTerraUsagePricingResolution();
+  if (provider !== "deepseek-v4-flash" && provider !== "deepseek-v4-pro") {
+    return await createGptUsagePricingResolution();
   }
   const pricing = await createUsagePricingFixture({
     configured: PI_API_FIRST_TURN_BASE_USAGE_CATEGORIES.map((category) => {
@@ -777,7 +790,7 @@ async function seedBuiltInModelKey(selectedModel: string): Promise<string> {
 
 async function configureBuiltInPiModel(
   actor: ApiTestUser,
-  selectedModel: "deepseek-v4-flash" | "deepseek-v4-pro" | "gpt-5.6-terra",
+  selectedModel: PiApiFirstTurnUsageProvider,
 ): Promise<void> {
   await seedBuiltInModelKey(selectedModel);
   await api.updateOrgModelPolicies(actor, [
@@ -791,9 +804,9 @@ async function configureBuiltInPiModel(
   ]);
 }
 
-async function configureApiKeyTerraPiModel(
+async function configureApiKeyGptPiModel(
   actor: ApiTestUser,
-  route: (typeof STANDARD_TERRA_API_KEY_BDD_ROUTES)[number],
+  route: (typeof GPT_API_KEY_BDD_ROUTES)[number],
   secret: string,
 ): Promise<string> {
   await authDeviceSupport.updateFeatureSwitches(actor, {
@@ -806,7 +819,7 @@ async function configureApiKeyTerraPiModel(
   });
   await api.updateOrgModelPolicies(actor, [
     {
-      model: "gpt-5.6-terra",
+      model: route.selectedModel,
       isDefault: true,
       defaultProviderType: route.type,
       credentialScope: "org",
@@ -816,26 +829,31 @@ async function configureApiKeyTerraPiModel(
   return providerId;
 }
 
-async function configureUserOwnedTerraPiModel(
+async function configureUserOwnedGptPiModel(
   actor: ApiTestUser,
-  route: (typeof USER_OWNED_TERRA_FAST_BDD_ROUTES)[number],
+  route: (typeof USER_OWNED_GPT_FAST_BDD_ROUTES)[number],
 ): Promise<{ readonly secret: string; readonly accountId: string | null }> {
   if (route.type === "codex-oauth-token") {
     const accountId = "subscription-continuity-account";
-    const { oauth } = await configureSubscriptionPiModel(actor, { accountId });
+    const { oauth } = await configureSubscriptionPiModel(
+      actor,
+      { accountId },
+      route.selectedModel,
+    );
     return {
       secret: z.string().parse(oauth.oauthTokenResponses[0]?.access_token),
       accountId,
     };
   }
   const secret = `${route.type}-pi-fixture-key`;
-  await configureApiKeyTerraPiModel(actor, route, secret);
+  await configureApiKeyGptPiModel(actor, route, secret);
   return { secret, accountId: null };
 }
 
 async function configureSubscriptionPiModel(
   actor: ApiTestUser,
   options: Parameters<typeof mockCodexDeviceAuthProvider>[0] = {},
+  selectedModel: PiGptBddModel = "gpt-5.6-terra",
 ) {
   await authDeviceSupport.updateFeatureSwitches(actor, {
     [FeatureSwitchKey.PersonalModelProviderAccounts]: true,
@@ -862,7 +880,7 @@ async function configureSubscriptionPiModel(
   }
   await chatCallbacks.updateOrgModelPolicies(actor, [
     {
-      model: "gpt-5.6-terra",
+      model: selectedModel,
       isDefault: true,
       defaultProviderType: "codex-oauth-token",
       credentialScope: "member",
@@ -874,7 +892,7 @@ async function configureSubscriptionPiModel(
 
 async function configureBuiltInPiModelOnOpenRouter(
   actor: ApiTestUser,
-  selectedModel: "deepseek-v4-flash" | "deepseek-v4-pro" | "gpt-5.6-terra",
+  selectedModel: PiApiFirstTurnUsageProvider,
 ): Promise<<T>(work: () => Promise<T>) => Promise<T>> {
   await seedBuiltInModelCandidateKeys(context, selectedModel);
   const primary = await resolveBuiltInModelRouteFixture(context, selectedModel);
@@ -5410,9 +5428,9 @@ function piResponsesToolSse(args: {
     .join("");
 }
 
-function expectApiKeyTerraRequest(
+function expectApiKeyGptRequest(
   request: unknown,
-  route: (typeof STANDARD_TERRA_API_KEY_BDD_ROUTES)[number],
+  route: (typeof GPT_API_KEY_BDD_ROUTES)[number],
   secret: string,
   tier: "fast" | undefined,
 ): void {
@@ -5432,7 +5450,7 @@ function expectApiKeyTerraRequest(
   expect(body).not.toHaveProperty("previous_response_id");
 }
 
-async function claimTerraPiSandbox(
+async function claimGptPiSandbox(
   actor: ApiTestUser,
   runId: string,
   tier: "fast" | undefined,
@@ -5458,9 +5476,9 @@ async function claimTerraPiSandbox(
   });
 }
 
-function expectApiKeyTerraSandboxCarrier(
+function expectApiKeyGptSandboxCarrier(
   claim: Awaited<ReturnType<typeof api.claimRunnerJob>>,
-  route: (typeof STANDARD_TERRA_API_KEY_BDD_ROUTES)[number],
+  route: (typeof GPT_API_KEY_BDD_ROUTES)[number],
   tier: "fast" | undefined,
 ): void {
   expect(claim.piModelConfig).toStrictEqual({
@@ -5503,12 +5521,13 @@ function expectNativeSubscriptionRequest(
   request: unknown,
   accessToken: string,
   tier: "fast" | undefined,
+  selectedModel: PiGptBddModel = "gpt-5.6-terra",
 ): void {
   expect(request).toMatchObject({
     accountMatches: true,
     authorization: `Bearer ${accessToken}`,
     body: {
-      model: "gpt-5.6-terra",
+      model: selectedModel,
       stream: true,
       store: false,
       reasoning: { effort: "max" },
@@ -5564,7 +5583,11 @@ function settledSubscriptionToolHistory(h1: string): string {
           return content.type === "toolCall";
         })
       : undefined;
-  if (!pendingTool || pendingTool.type !== "toolCall") {
+  if (
+    pendingAssistant?.role !== "assistant" ||
+    !pendingTool ||
+    pendingTool.type !== "toolCall"
+  ) {
     throw new Error("Expected native Codex tool call in H1");
   }
   h2Session.appendMessage({
@@ -5581,7 +5604,7 @@ function settledSubscriptionToolHistory(h1: string): string {
     content: [{ type: "text", text: "Subscription Sandbox complete" }],
     api: "openai-codex-responses",
     provider: "openai-codex",
-    model: "gpt-5.6-terra",
+    model: pendingAssistant.model,
     usage: {
       input: 5,
       output: 3,
@@ -5931,7 +5954,7 @@ async function queueCapabilityProvenPiRun(args: {
   readonly runnerGroup: string;
   readonly prompt: string;
   readonly codexServiceTier?: "fast";
-  readonly terraRoute?: "openai" | "openrouter";
+  readonly gptRoute?: "openai" | "openrouter";
   readonly selectedModel?: PiApiFirstTurnUsageProvider;
 }): Promise<{
   readonly anchor: { readonly runId: string; readonly threadId: string };
@@ -5961,7 +5984,7 @@ async function queueCapabilityProvenPiRun(args: {
   let withModelRoute = async <T>(work: () => Promise<T>): Promise<T> => {
     return await work();
   };
-  if (args.terraRoute === "openrouter") {
+  if (args.gptRoute === "openrouter") {
     withModelRoute = await configureBuiltInPiModelOnOpenRouter(
       args.actor,
       selectedModel,
@@ -6560,94 +6583,98 @@ describe("CHAT-02: model-first provider policies", () => {
     ).toHaveLength(0);
   }, 90_000);
 
-  it("keeps captured Pi admission after PiLoop turns off", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    const orgId = requireOrgId(actor);
-    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
-    mockPiResourceArchiveDownloads(true);
-    mockPiCheckpointObjectStore();
-    await api.heartbeatRunner(runnerGroup);
+  it.each(GPT_PI_BDD_MODELS)(
+    "keeps captured Pi admission after PiLoop turns off for %s",
+    async (selectedModel) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const orgId = requireOrgId(actor);
+      await configureBuiltInPiModel(actor, selectedModel);
+      mockPiResourceArchiveDownloads(true);
+      mockPiCheckpointObjectStore();
+      await api.heartbeatRunner(runnerGroup);
 
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      { [FeatureSwitchKey.PiLoop]: false },
-    );
-    const baseline = await sendChatRun(actor, {
-      agentId,
-      prompt: "establish the captured Codex session family",
-      model: "gpt-5.6-terra",
-    });
-    await flushWaitUntilForTest();
-    await expect(api.readRun(actor, baseline.runId)).resolves.toMatchObject({
-      status: "pending",
-    });
-    await expect(
-      readRunLaunchSnapshotFixture(context, baseline.runId),
-    ).resolves.toMatchObject({
-      launch_snapshot: { framework: "codex" },
-    });
-    const baselineClaim = await claimChatRun(runnerGroup, baseline.runId);
-    expect(baselineClaim.claim.cliAgentType).toBe("codex");
-    expect(baselineClaim.claim.piLaunchConfig).toBeUndefined();
-    const baselineBinding = await readThreadSessionBinding(
-      context,
-      baseline.threadId,
-    );
-    chatCallbacks.mockChatOutputEvents([]);
-    await completeChatRunOk(baseline.runId, baselineClaim.sandboxHeaders, {
-      cliAgentType: "codex",
-    });
-    await flushWaitUntilForTest();
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: false },
+      );
+      const baseline = await sendChatRun(actor, {
+        agentId,
+        prompt: "establish the captured Codex session family",
+        model: selectedModel,
+      });
+      await flushWaitUntilForTest();
+      await expect(api.readRun(actor, baseline.runId)).resolves.toMatchObject({
+        status: "pending",
+      });
+      await expect(
+        readRunLaunchSnapshotFixture(context, baseline.runId),
+      ).resolves.toMatchObject({
+        launch_snapshot: { framework: "codex" },
+      });
+      const baselineClaim = await claimChatRun(runnerGroup, baseline.runId);
+      expect(baselineClaim.claim.cliAgentType).toBe("codex");
+      expect(baselineClaim.claim.piLaunchConfig).toBeUndefined();
+      const baselineBinding = await readThreadSessionBinding(
+        context,
+        baseline.threadId,
+      );
+      chatCallbacks.mockChatOutputEvents([]);
+      await completeChatRunOk(baseline.runId, baselineClaim.sandboxHeaders, {
+        cliAgentType: "codex",
+      });
+      await flushWaitUntilForTest();
 
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
-    );
-    const enabledGate = holdAgentRunPiExecutionSnapshotFixture({
-      userId: actor.userId,
-      orgId,
-      signal: context.signal,
-    });
-    onTestFinished(enabledGate.release);
-    const enabledSend = sendChatRun(actor, {
-      agentId,
-      threadId: baseline.threadId,
-      prompt: "keep Pi after the switch turns off",
-      model: "gpt-5.6-terra",
-    });
-    const enabledSnapshot = await enabledGate.arrival;
-    expect(enabledSnapshot).toMatchObject({
-      chatThreadId: baseline.threadId,
-      piExecution: true,
-      threadSessionCliAgentType: "pi",
-    });
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      { [FeatureSwitchKey.PiLoop]: false },
-    );
-    enabledGate.release();
-    const enabled = await enabledSend;
-    await flushWaitUntilForTest();
-    const enabledClaim = await claimChatRun(runnerGroup, enabled.runId);
-    expect(enabledClaim.claim.cliAgentType).toBe("pi");
-    expect(enabledClaim.claim.piLaunchConfig).toBeDefined();
-    await expect(
-      readRunLaunchSnapshotFixture(context, enabled.runId),
-    ).resolves.toMatchObject({
-      launch_snapshot: { framework: "pi" },
-    });
-    const enabledBinding = await readThreadSessionBinding(
-      context,
-      enabled.threadId,
-    );
-    expect(enabledBinding.agent_session_id).not.toBe(
-      baselineBinding.agent_session_id,
-    );
-    await cancelChatRun(actor, enabled.runId, enabledClaim.sandboxHeaders);
-  }, 90_000);
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: true },
+      );
+      const enabledGate = holdAgentRunPiExecutionSnapshotFixture({
+        userId: actor.userId,
+        orgId,
+        signal: context.signal,
+      });
+      onTestFinished(enabledGate.release);
+      const enabledSend = sendChatRun(actor, {
+        agentId,
+        threadId: baseline.threadId,
+        prompt: "keep Pi after the switch turns off",
+        model: selectedModel,
+      });
+      const enabledSnapshot = await enabledGate.arrival;
+      expect(enabledSnapshot).toMatchObject({
+        chatThreadId: baseline.threadId,
+        piExecution: true,
+        threadSessionCliAgentType: "pi",
+      });
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: false },
+      );
+      enabledGate.release();
+      const enabled = await enabledSend;
+      await flushWaitUntilForTest();
+      const enabledClaim = await claimChatRun(runnerGroup, enabled.runId);
+      expect(enabledClaim.claim.cliAgentType).toBe("pi");
+      expect(enabledClaim.claim.piLaunchConfig).toBeDefined();
+      await expect(
+        readRunLaunchSnapshotFixture(context, enabled.runId),
+      ).resolves.toMatchObject({
+        launch_snapshot: { framework: "pi" },
+      });
+      const enabledBinding = await readThreadSessionBinding(
+        context,
+        enabled.threadId,
+      );
+      expect(enabledBinding.agent_session_id).not.toBe(
+        baselineBinding.agent_session_id,
+      );
+      await cancelChatRun(actor, enabled.runId, enabledClaim.sandboxHeaders);
+    },
+    90_000,
+  );
 
   it("pins recall-enabled Pi memory through API completion and Sandbox handoff", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
@@ -6667,7 +6694,7 @@ describe("CHAT-02: model-first provider policies", () => {
       initialMemory,
       frozenSummary,
     );
-    const usagePricingResolution = await createTerraUsagePricingResolution();
+    const usagePricingResolution = await createGptUsagePricingResolution();
     await configureBuiltInPiModel(actor, "gpt-5.6-terra");
     await updateFeatureSwitchesForUser(
       context,
@@ -6873,7 +6900,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const memory = await commitMemoryVersion(context, actor, [
       { path: "memory_summary.md", content: summary },
     ]);
-    const usagePricingResolution = await createTerraUsagePricingResolution();
+    const usagePricingResolution = await createGptUsagePricingResolution();
     await configureBuiltInPiModel(actor, "gpt-5.6-terra");
     await updateFeatureSwitchesForUser(
       context,
@@ -6963,107 +6990,111 @@ describe("CHAT-02: model-first provider policies", () => {
     ]);
   }, 90_000);
 
-  it("keeps captured Codex admission after PiLoop turns on", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    const orgId = requireOrgId(actor);
-    const usagePricingResolution = await createTerraUsagePricingResolution();
-    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
-    mockPiResourceArchiveDownloads();
-    mockPiCheckpointObjectStore();
-    server.use(
-      http.post("https://api.openai.com/v1/responses", () => {
-        return new HttpResponse(piResponsesTextSse("baseline Pi answer", 0), {
-          headers: { "content-type": "text/event-stream" },
-        });
-      }),
-    );
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
-    );
-    const baseline = await sendChatRun(
-      actor,
-      {
-        agentId,
-        prompt: "establish the captured Pi session family",
-        model: "gpt-5.6-terra",
-      },
-      "vm0",
-      usagePricingResolution,
-    );
-    await waitForRunStatus(actor, baseline.runId, "completed", 10_000);
-    await flushWaitUntilForTest();
-    await expect(
-      readRunLaunchSnapshotFixture(context, baseline.runId),
-    ).resolves.toMatchObject({
-      launch_snapshot: { framework: "pi" },
-    });
-    const baselineBinding = await readThreadSessionBinding(
-      context,
-      baseline.threadId,
-    );
+  it.each(GPT_PI_BDD_MODELS)(
+    "keeps captured Codex admission after PiLoop turns on for %s",
+    async (selectedModel) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const orgId = requireOrgId(actor);
+      const usagePricingResolution = await createGptUsagePricingResolution();
+      await configureBuiltInPiModel(actor, selectedModel);
+      mockPiResourceArchiveDownloads();
+      mockPiCheckpointObjectStore();
+      server.use(
+        http.post("https://api.openai.com/v1/responses", () => {
+          return new HttpResponse(piResponsesTextSse("baseline Pi answer", 0), {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }),
+      );
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: true },
+      );
+      const baseline = await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt: "establish the captured Pi session family",
+          model: selectedModel,
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+      await waitForRunStatus(actor, baseline.runId, "completed", 10_000);
+      await flushWaitUntilForTest();
+      await expect(
+        readRunLaunchSnapshotFixture(context, baseline.runId),
+      ).resolves.toMatchObject({
+        launch_snapshot: { framework: "pi" },
+      });
+      const baselineBinding = await readThreadSessionBinding(
+        context,
+        baseline.threadId,
+      );
 
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      { [FeatureSwitchKey.PiLoop]: false },
-    );
-    const disabledGate = holdAgentRunPiExecutionSnapshotFixture({
-      userId: actor.userId,
-      orgId,
-      signal: context.signal,
-    });
-    onTestFinished(disabledGate.release);
-    const disabledSend = sendChatRun(actor, {
-      agentId,
-      threadId: baseline.threadId,
-      prompt: "keep Codex after the switch turns on",
-      model: "gpt-5.6-terra",
-    });
-    const disabledSnapshot = await disabledGate.arrival;
-    expect(disabledSnapshot).toMatchObject({
-      chatThreadId: baseline.threadId,
-      piExecution: false,
-      threadSessionCliAgentType: "codex",
-    });
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
-    );
-    disabledGate.release();
-    const disabled = await disabledSend;
-    await flushWaitUntilForTest();
-    const disabledClaim = await claimChatRun(runnerGroup, disabled.runId);
-    expect(disabledClaim.claim.cliAgentType).toBe("codex");
-    expect(disabledClaim.claim.piLaunchConfig).toBeUndefined();
-    expect(
-      expectCanonicalStorageManifest(
-        disabledClaim.claim.storageManifest,
-      )?.storageMounts.filter((mount) => {
-        return mount.name === "memory";
-      }),
-    ).toStrictEqual([
-      expect.objectContaining({
-        mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
-        missingRootPolicy: "preserveParentVersion",
-      }),
-    ]);
-    await expect(
-      readRunLaunchSnapshotFixture(context, disabled.runId),
-    ).resolves.toMatchObject({
-      launch_snapshot: { framework: "codex" },
-    });
-    const disabledBinding = await readThreadSessionBinding(
-      context,
-      disabled.threadId,
-    );
-    expect(disabledBinding.agent_session_id).not.toBe(
-      baselineBinding.agent_session_id,
-    );
-    await cancelChatRun(actor, disabled.runId, disabledClaim.sandboxHeaders);
-  }, 90_000);
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: false },
+      );
+      const disabledGate = holdAgentRunPiExecutionSnapshotFixture({
+        userId: actor.userId,
+        orgId,
+        signal: context.signal,
+      });
+      onTestFinished(disabledGate.release);
+      const disabledSend = sendChatRun(actor, {
+        agentId,
+        threadId: baseline.threadId,
+        prompt: "keep Codex after the switch turns on",
+        model: selectedModel,
+      });
+      const disabledSnapshot = await disabledGate.arrival;
+      expect(disabledSnapshot).toMatchObject({
+        chatThreadId: baseline.threadId,
+        piExecution: false,
+        threadSessionCliAgentType: "codex",
+      });
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: true },
+      );
+      disabledGate.release();
+      const disabled = await disabledSend;
+      await flushWaitUntilForTest();
+      const disabledClaim = await claimChatRun(runnerGroup, disabled.runId);
+      expect(disabledClaim.claim.cliAgentType).toBe("codex");
+      expect(disabledClaim.claim.piLaunchConfig).toBeUndefined();
+      expect(
+        expectCanonicalStorageManifest(
+          disabledClaim.claim.storageManifest,
+        )?.storageMounts.filter((mount) => {
+          return mount.name === "memory";
+        }),
+      ).toStrictEqual([
+        expect.objectContaining({
+          mountPath: CANONICAL_CODEX_MEMORY_MOUNT_PATH,
+          missingRootPolicy: "preserveParentVersion",
+        }),
+      ]);
+      await expect(
+        readRunLaunchSnapshotFixture(context, disabled.runId),
+      ).resolves.toMatchObject({
+        launch_snapshot: { framework: "codex" },
+      });
+      const disabledBinding = await readThreadSessionBinding(
+        context,
+        disabled.threadId,
+      );
+      expect(disabledBinding.agent_session_id).not.toBe(
+        baselineBinding.agent_session_id,
+      );
+      await cancelChatRun(actor, disabled.runId, disabledClaim.sandboxHeaders);
+    },
+    90_000,
+  );
 
   it("decodes persisted launch snapshots at webhook completion before Stage 1 admission", async () => {
     mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);
@@ -7285,7 +7316,7 @@ describe("CHAT-02: model-first provider policies", () => {
     const sourceToken = okouTokenFromClaim(sourceClaim.claim);
     const targetThread = await chat.createThread(actor, { agentId });
 
-    const usagePricingResolution = await createTerraUsagePricingResolution();
+    const usagePricingResolution = await createGptUsagePricingResolution();
     mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);
     await configureBuiltInPiModel(actor, "gpt-5.6-terra");
     await updateFeatureSwitchesForUser(
@@ -7426,7 +7457,7 @@ describe("CHAT-02: model-first provider policies", () => {
         piMemoryStage1AdmissionPrerequisiteSkipReasonFixture({ triggerSource }),
       ).toBe(expectedAdmissionBySource[triggerSource]);
     }
-    const usagePricingResolution = await createTerraUsagePricingResolution();
+    const usagePricingResolution = await createGptUsagePricingResolution();
     mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);
     await configureBuiltInPiModel(actor, "gpt-5.6-terra");
     await updateFeatureSwitchesForUser(
@@ -7808,7 +7839,128 @@ describe("CHAT-02: model-first provider policies", () => {
     ).resolves.toBe(1);
   }, 90_000);
 
-  it.each(["deepseek-v4-flash", "deepseek-v4-pro", "gpt-5.6-terra"] as const)(
+  it.each(
+    GPT_PI_BDD_MODELS.flatMap((selectedModel) => {
+      return (["openai", "openrouter"] as const).map((provider) => {
+        return {
+          selectedModel,
+          provider,
+        };
+      });
+    }),
+  )(
+    "bills built-in $selectedModel on $provider at both canonical input boundaries and tiers",
+    async ({ selectedModel, provider }) => {
+      const { actor, agentId } = await entitledChatActor();
+      const usagePricingResolution = await createGptUsagePricingResolution();
+      const threshold =
+        MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS[selectedModel];
+      if (threshold === undefined) {
+        throw new Error(
+          `Expected a long-context threshold for ${selectedModel}`,
+        );
+      }
+      let withRoute = async <T>(work: () => Promise<T>): Promise<T> => {
+        return await work();
+      };
+      if (provider === "openrouter") {
+        withRoute = await configureBuiltInPiModelOnOpenRouter(
+          actor,
+          selectedModel,
+        );
+      } else {
+        await configureBuiltInPiModel(actor, selectedModel);
+      }
+      await authDeviceSupport.updateFeatureSwitches(actor, {
+        [FeatureSwitchKey.PiLoop]: true,
+        [FeatureSwitchKey.CodexFastMode]: true,
+      });
+      mockPiResourceArchiveDownloads();
+      mockPiCheckpointObjectStore();
+      const endpoint =
+        provider === "openai"
+          ? "https://api.openai.com/v1/responses"
+          : "https://openrouter.ai/api/v1/responses";
+      const upstreamModel =
+        provider === "openai" ? selectedModel : `openai/${selectedModel}`;
+      const requests: unknown[] = [];
+      for (const tier of [undefined, "fast"] as const) {
+        for (const totalInput of [threshold - 1, threshold]) {
+          server.use(
+            http.post(endpoint, async ({ request }) => {
+              requests.push(await request.json());
+              return nativeCodexSseResponse(
+                piResponsesTextSse(
+                  "accounted response",
+                  requests.length,
+                  {
+                    input_tokens: totalInput,
+                    output_tokens: 3,
+                    total_tokens: totalInput + 3,
+                    input_tokens_details: {
+                      cached_tokens: 3,
+                      cache_write_tokens: 2,
+                    },
+                  },
+                  tier === "fast" ? "priority" : "default",
+                ),
+              );
+            }),
+          );
+          const run = await withRoute(async () => {
+            return await sendChatRun(
+              actor,
+              {
+                agentId,
+                prompt: `bill ${selectedModel} at ${totalInput} total input`,
+                model: selectedModel,
+                runOptions: { codexServiceTier: tier },
+              },
+              "vm0",
+              usagePricingResolution,
+            );
+          });
+          await waitForRunStatus(actor, run.runId, "completed");
+          await flushWaitUntilForTest();
+          const longContext = totalInput === threshold;
+          const suffix = longContext
+            ? tier === "fast"
+              ? ".long_context.fast"
+              : ".long_context"
+            : tier === "fast"
+              ? ".fast"
+              : "";
+          await expectPiApiUsage(run.runId, selectedModel, suffix, {
+            input: totalInput - 5,
+            output: 3,
+            cacheRead: 3,
+            cacheCreation: 2,
+          });
+          expect(requests.at(-1)).toMatchObject({
+            model: upstreamModel,
+            reasoning: { effort: "max" },
+            store: false,
+          });
+          if (tier === undefined) {
+            expect(requests.at(-1)).not.toHaveProperty("service_tier");
+          } else {
+            expect(requests.at(-1)).toMatchObject({ service_tier: "priority" });
+          }
+          await expect(
+            readRunLaunchSnapshotFixture(context, run.runId),
+          ).resolves.toMatchObject({ launch_snapshot: { framework: "pi" } });
+        }
+      }
+      expect(requests).toHaveLength(4);
+    },
+    90_000,
+  );
+
+  it.each([
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
+    ...GPT_PI_BDD_MODELS,
+  ] as const)(
     "runs the Pi API first turn once for %s and resumes canonical JSONL",
     async (selectedModel) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
@@ -7833,10 +7985,9 @@ describe("CHAT-02: model-first provider policies", () => {
         `first API answer for ${selectedModel}`,
         `second API answer for ${selectedModel}`,
       ];
-      const providerUrl =
-        selectedModel === "gpt-5.6-terra"
-          ? "https://api.openai.com/v1/responses"
-          : "https://api.deepseek.com/responses";
+      const providerUrl = selectedModel.startsWith("gpt-")
+        ? "https://api.openai.com/v1/responses"
+        : "https://api.deepseek.com/responses";
       server.use(
         http.post(providerUrl, async ({ request }) => {
           const sequence = modelRequests.length;
@@ -8005,16 +8156,18 @@ describe("CHAT-02: model-first provider policies", () => {
       selectedModel: "deepseek-v4-pro",
       upstreamModel: "company-deepseek-pro-production",
     },
-    {
-      selectedModel: "gpt-5.6-terra",
-      upstreamModel: "company-terra-production",
-    },
+    ...GPT_PI_BDD_MODELS.map((selectedModel) => {
+      return {
+        selectedModel,
+        upstreamModel: `company-${selectedModel}-production`,
+      };
+    }),
   ] as const)(
     "runs custom Responses gateway $selectedModel through Pi without built-in model billing",
     async ({ selectedModel, upstreamModel }) => {
-      const { actor, agentId } = await entitledChatActor();
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
       const orgId = requireOrgId(actor);
-      const usagePricingResolution = await createTerraUsagePricingResolution();
+      const usagePricingResolution = await createGptUsagePricingResolution();
       const created = await accept(
         modelProviderConnectionsClient().create({
           headers: sessionHeaders(actor),
@@ -8109,14 +8262,42 @@ describe("CHAT-02: model-first provider policies", () => {
       });
       expect(modelRequests).toStrictEqual([
         {
-          body: expect.objectContaining({ model: upstreamModel }),
+          body: expect.objectContaining({
+            model: upstreamModel,
+            ...(selectedModel.startsWith("gpt-")
+              ? { reasoning: expect.objectContaining({ effort: "max" }) }
+              : {}),
+          }),
           authorization: null,
           apiKey: "Key custom-pi-gateway-secret",
         },
       ]);
+      expect(modelRequests[0]?.body).not.toHaveProperty("service_tier");
       await expect(readRunUsageEventsFixture(run.runId)).resolves.toStrictEqual(
         [],
       );
+      if (selectedModel.startsWith("gpt-")) {
+        await authDeviceSupport.updateFeatureSwitches(actor, {
+          [FeatureSwitchKey.PiLoop]: true,
+          [FeatureSwitchKey.CodexFastMode]: true,
+        });
+        const fast = await sendChatRun(actor, {
+          agentId,
+          model: selectedModel,
+          prompt: "keep custom Fast on its existing runtime until slice 2",
+          runOptions: { codexServiceTier: "fast" },
+        });
+        const claimed = await claimChatRun(runnerGroup, fast.runId);
+        expect(claimed.claim.cliAgentType).toBe("codex");
+        expect(claimed.claim.piModelConfig).toBeUndefined();
+        expect(claimEnvironment(claimed.claim)).toMatchObject({
+          OPENAI_MODEL: upstreamModel,
+          OKOU_CODEX_SERVICE_TIER: "fast",
+        });
+        expect(modelRequests).toHaveLength(1);
+        await cancelChatRun(actor, fast.runId, claimed.sandboxHeaders);
+        await expectNoBuiltInModelUsage(fast.runId);
+      }
     },
     90_000,
   );
@@ -8194,11 +8375,13 @@ describe("CHAT-02: model-first provider policies", () => {
   );
 
   it.each([
-    {
-      name: "Terra",
-      selectedModel: "gpt-5.6-terra",
-      providerUrl: "https://api.openai.com/v1/responses",
-    },
+    ...GPT_PI_BDD_MODELS.map((selectedModel) => {
+      return {
+        name: selectedModel,
+        selectedModel,
+        providerUrl: "https://api.openai.com/v1/responses",
+      };
+    }),
     {
       name: "DeepSeek Flash",
       selectedModel: "deepseek-v4-flash",
@@ -8295,11 +8478,13 @@ describe("CHAT-02: model-first provider policies", () => {
   );
 
   it.each([
-    {
-      name: "Terra",
-      selectedModel: "gpt-5.6-terra",
-      providerUrl: "https://api.openai.com/v1/responses",
-    },
+    ...GPT_PI_BDD_MODELS.map((selectedModel) => {
+      return {
+        name: selectedModel,
+        selectedModel,
+        providerUrl: "https://api.openai.com/v1/responses",
+      };
+    }),
     {
       name: "DeepSeek Pro",
       selectedModel: "deepseek-v4-pro",
@@ -8412,7 +8597,7 @@ describe("CHAT-02: model-first provider policies", () => {
   it("resumes pre-migration OpenRouter Chat JSONL through API-first Responses", async () => {
     const { actor, agentId } = await entitledChatActor();
     const orgId = requireOrgId(actor);
-    const usagePricingResolution = await createTerraUsagePricingResolution();
+    const usagePricingResolution = await createGptUsagePricingResolution();
     const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
       actor,
       "gpt-5.6-terra",
@@ -8582,473 +8767,584 @@ describe("CHAT-02: model-first provider policies", () => {
     ).toBeFalsy();
   }, 90_000);
 
-  it("reuses one OpenRouter Responses Pi session across standard, fast, and long-context Terra turns", async () => {
-    const { actor, agentId } = await entitledChatActor();
-    const orgId = requireOrgId(actor);
-    const usagePricingResolution = await createTerraUsagePricingResolution();
-    const longContextInputTokens =
-      MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS["gpt-5.6-terra"];
-    if (longContextInputTokens === undefined) {
-      throw new Error("Expected the Terra long-context pricing threshold");
-    }
-    const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
-      actor,
-      "gpt-5.6-terra",
-    );
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      {
-        [FeatureSwitchKey.PiLoop]: true,
-        [FeatureSwitchKey.CodexFastMode]: true,
-      },
-    );
-    mockPiResourceArchiveDownloads();
-    const checkpointObjects = mockPiCheckpointObjectStore();
-    const prompts = [
-      "start standard Terra in the canonical Pi session",
-      "continue fast Terra in the same Pi session",
-      "continue long-context Terra in the same Pi session",
-    ] as const;
-    const answers = [
-      "first standard Terra answer",
-      "fast Terra answer",
-      "long-context Terra answer",
-    ] as const;
-    const modelRequests: unknown[] = [];
-    const observedTiers = ["default", "priority", "flex"] as const;
-    server.use(
-      http.post(
-        "https://openrouter.ai/api/v1/responses",
-        async ({ request }) => {
-          const requestIndex = modelRequests.length;
-          modelRequests.push(await request.json());
-          const answer = answers[requestIndex];
-          if (!answer) {
-            return HttpResponse.json(
-              { error: "unexpected duplicate Terra request" },
-              { status: 500 },
-            );
-          }
-          return new HttpResponse(
-            piResponsesTextSse(
-              answer,
-              requestIndex,
-              requestIndex === 2
-                ? {
-                    input_tokens: longContextInputTokens,
-                    output_tokens: 3,
-                    total_tokens: longContextInputTokens + 3,
-                  }
-                : {
-                    input_tokens: 10,
-                    output_tokens: 3,
-                    total_tokens: 13,
-                    input_tokens_details: {
-                      cached_tokens: 3,
-                      cache_write_tokens: 2,
+  it.each(GPT_PI_BDD_MODELS)(
+    "reuses one OpenRouter Responses Pi session across standard, fast, and long-context turns for %s",
+    async (selectedModel) => {
+      const { actor, agentId } = await entitledChatActor();
+      const orgId = requireOrgId(actor);
+      const usagePricingResolution = await createGptUsagePricingResolution();
+      const longContextInputTokens =
+        MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS[selectedModel];
+      if (longContextInputTokens === undefined) {
+        throw new Error("Expected the Terra long-context pricing threshold");
+      }
+      const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
+        actor,
+        selectedModel,
+      );
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        {
+          [FeatureSwitchKey.PiLoop]: true,
+          [FeatureSwitchKey.CodexFastMode]: true,
+        },
+      );
+      mockPiResourceArchiveDownloads();
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      const prompts = [
+        "start standard Terra in the canonical Pi session",
+        "continue fast Terra in the same Pi session",
+        "continue long-context Terra in the same Pi session",
+      ] as const;
+      const answers = [
+        "first standard Terra answer",
+        "fast Terra answer",
+        "long-context Terra answer",
+      ] as const;
+      const modelRequests: unknown[] = [];
+      const observedTiers = ["default", "priority", "flex"] as const;
+      server.use(
+        http.post(
+          "https://openrouter.ai/api/v1/responses",
+          async ({ request }) => {
+            const requestIndex = modelRequests.length;
+            modelRequests.push(await request.json());
+            const answer = answers[requestIndex];
+            if (!answer) {
+              return HttpResponse.json(
+                { error: "unexpected duplicate Terra request" },
+                { status: 500 },
+              );
+            }
+            return new HttpResponse(
+              piResponsesTextSse(
+                answer,
+                requestIndex,
+                requestIndex === 2
+                  ? {
+                      input_tokens: longContextInputTokens,
+                      output_tokens: 3,
+                      total_tokens: longContextInputTokens + 3,
+                    }
+                  : {
+                      input_tokens: 10,
+                      output_tokens: 3,
+                      total_tokens: 13,
+                      input_tokens_details: {
+                        cached_tokens: 3,
+                        cache_write_tokens: 2,
+                      },
                     },
-                  },
-              observedTiers[requestIndex],
-            ),
-            { headers: { "content-type": "text/event-stream" } },
-          );
-        },
-      ),
-    );
-
-    const first = await withOpenRouterRoute(async () => {
-      return await sendChatRun(
-        actor,
-        {
-          agentId,
-          prompt: prompts[0],
-          model: "gpt-5.6-terra",
-        },
-        "vm0",
-        usagePricingResolution,
-      );
-    });
-    await waitForRunStatus(actor, first.runId, "completed", 10_000);
-    await flushWaitUntilForTest();
-    const firstBinding = await readThreadSessionBinding(
-      context,
-      first.threadId,
-    );
-    if (!firstBinding.agent_session_id) {
-      throw new Error("Expected standard Terra to bind a canonical Pi session");
-    }
-
-    const fast = await withOpenRouterRoute(async () => {
-      return await sendChatRun(
-        actor,
-        {
-          agentId,
-          threadId: first.threadId,
-          prompt: prompts[1],
-          model: "gpt-5.6-terra",
-          runOptions: { codexServiceTier: "fast" },
-        },
-        "vm0",
-        usagePricingResolution,
-      );
-    });
-    await waitForRunStatus(actor, fast.runId, "completed", 10_000);
-    await flushWaitUntilForTest();
-    const fastBinding = await readThreadSessionBinding(context, first.threadId);
-    expect(fastBinding.agent_session_id).toBe(firstBinding.agent_session_id);
-
-    await chat.updateThreadModelSelection(
-      actor,
-      first.threadId,
-      "gpt-5.6-terra",
-      { codexServiceTier: null },
-    );
-    const returned = await withOpenRouterRoute(async () => {
-      return await sendChatRun(
-        actor,
-        {
-          agentId,
-          threadId: first.threadId,
-          prompt: prompts[2],
-          model: "gpt-5.6-terra",
-        },
-        "vm0",
-        usagePricingResolution,
-      );
-    });
-    await waitForRunStatus(actor, returned.runId, "completed", 10_000);
-    await flushWaitUntilForTest();
-    const returnedBinding = await readThreadSessionBinding(
-      context,
-      first.threadId,
-    );
-    expect(returnedBinding.agent_session_id).toBe(
-      firstBinding.agent_session_id,
-    );
-    await expect(
-      readThreadSessionConversation(context, first.threadId),
-    ).resolves.toMatchObject({
-      agent_session_id: firstBinding.agent_session_id,
-      conversation_run_id: returned.runId,
-    });
-
-    expect(modelRequests).toHaveLength(3);
-    const requestTiers = modelRequests.map((body) => {
-      return z
-        .object({ service_tier: z.literal("priority").optional() })
-        .passthrough()
-        .parse(body).service_tier;
-    });
-    expect(requestTiers).toStrictEqual([undefined, "priority", undefined]);
-    for (const body of modelRequests) {
-      expect(body).toMatchObject({ store: false });
-      expect(body).not.toHaveProperty("previous_response_id");
-    }
-    for (const [requestIndex, expectedTurns] of [
-      [0, [prompts[0]]],
-      [1, [prompts[0], answers[0], prompts[1]]],
-      [2, [prompts[0], answers[0], prompts[1], answers[1], prompts[2]]],
-    ] as const) {
-      const input = JSON.stringify(modelRequests[requestIndex]);
-      for (const turn of expectedTurns) {
-        expect(occurrences(input, turn)).toBe(1);
-      }
-      expect(occurrences(input, answers[requestIndex])).toBe(0);
-    }
-
-    for (const run of [first, fast, returned]) {
-      await expect(
-        readRunLaunchSnapshotFixture(context, run.runId),
-      ).resolves.toMatchObject({
-        launch_snapshot: { framework: "pi" },
-      });
-      const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
-      expect(claim.status).toBe(404);
-    }
-    for (const runId of [fast.runId, returned.runId]) {
-      const run = await api.readRun(actor, runId);
-      const appendSystemPrompt = run.appendSystemPrompt ?? "";
-      expect(appendSystemPrompt).not.toContain("# Web Chat Run Context");
-      for (const turn of [...prompts, ...answers]) {
-        expect(appendSystemPrompt).not.toContain(turn);
-      }
-    }
-
-    await expectTerraApiUsage(first.runId, "", {
-      input: 5,
-      output: 3,
-      cacheRead: 3,
-      cacheCreation: 2,
-    });
-    await expectTerraApiUsage(fast.runId, ".fast", {
-      input: 5,
-      output: 3,
-      cacheRead: 3,
-      cacheCreation: 2,
-    });
-    await expectTerraApiUsage(returned.runId, ".long_context", {
-      input: longContextInputTokens,
-      output: 3,
-      cacheRead: 0,
-      cacheCreation: 0,
-    });
-
-    const visibleTurns = [
-      { runId: first.runId, prompt: prompts[0], answer: answers[0] },
-      { runId: fast.runId, prompt: prompts[1], answer: answers[1] },
-      { runId: returned.runId, prompt: prompts[2], answer: answers[2] },
-    ];
-    const finalEvents = await waitForThreadMessages(
-      actor,
-      first.threadId,
-      (events) => {
-        return eventBackedContents(events, returned.runId).some((event) => {
-          return event.content === answers[2];
-        });
-      },
-    );
-    const runIds = new Set(
-      visibleTurns.map((turn) => {
-        return turn.runId;
-      }),
-    );
-    expect(
-      finalEvents.events
-        .filter((event) => {
-          return (
-            event.runId !== undefined &&
-            event.runId !== null &&
-            runIds.has(event.runId) &&
-            (event.eventType === "input.prompt" ||
-              event.eventType === "output.message")
-          );
-        })
-        .map((event) => {
-          return {
-            runId: event.runId,
-            eventType: event.eventType,
-            content: chatEventDisplayText(event),
-          };
-        }),
-    ).toStrictEqual(
-      visibleTurns.flatMap((turn) => {
-        return [
-          {
-            runId: turn.runId,
-            eventType: "input.prompt",
-            content: turn.prompt,
-          },
-          {
-            runId: turn.runId,
-            eventType: "output.message",
-            content: turn.answer,
-          },
-        ];
-      }),
-    );
-    const sessionBlobs = [...checkpointObjects.entries()].filter(([key]) => {
-      return key.includes("/blobs/");
-    });
-    expect(sessionBlobs.length).toBeGreaterThan(0);
-    for (const [, bytes] of sessionBlobs) {
-      expect(bytes.toString("utf8")).not.toContain("serviceTier");
-    }
-  }, 90_000);
-
-  it("bills managed OpenRouter priority only from the observed terminal Responses tier", async () => {
-    const { actor, agentId } = await entitledChatActor();
-    const orgId = requireOrgId(actor);
-    const usagePricingResolution = await createTerraUsagePricingResolution();
-    const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
-      actor,
-      "gpt-5.6-terra",
-    );
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      {
-        [FeatureSwitchKey.PiLoop]: true,
-        [FeatureSwitchKey.CodexFastMode]: true,
-      },
-    );
-    mockPiResourceArchiveDownloads();
-    mockPiCheckpointObjectStore();
-    const cases = [
-      { observed: "priority", expectedSuffix: ".fast" },
-      { observed: "fast", expectedSuffix: ".fast" },
-      { observed: "default", expectedSuffix: "" },
-      { observed: "flex", expectedSuffix: "" },
-      { observed: null, expectedSuffix: "" },
-      { observed: undefined, expectedSuffix: "" },
-      { observed: "future-tier", expectedSuffix: "" },
-    ] as const;
-    const modelRequests: unknown[] = [];
-    server.use(
-      http.post(
-        "https://openrouter.ai/api/v1/responses",
-        async ({ request }) => {
-          const requestIndex = modelRequests.length;
-          modelRequests.push(await request.json());
-          const testCase = cases[requestIndex];
-          if (!testCase) {
-            return HttpResponse.json(
-              { error: "unexpected duplicate OpenRouter request" },
-              { status: 500 },
+                observedTiers[requestIndex],
+              ),
+              { headers: { "content-type": "text/event-stream" } },
             );
-          }
-          return new HttpResponse(
-            piResponsesTextSse(
-              `OpenRouter tier answer ${requestIndex.toString()}`,
-              requestIndex,
-              undefined,
-              testCase.observed,
-            ),
-            { headers: { "content-type": "text/event-stream" } },
-          );
-        },
-      ),
-    );
+          },
+        ),
+      );
 
-    for (const [index, testCase] of cases.entries()) {
-      const run = await withOpenRouterRoute(async () => {
+      const first = await withOpenRouterRoute(async () => {
         return await sendChatRun(
           actor,
           {
             agentId,
-            prompt: `observe OpenRouter tier case ${index.toString()}`,
-            model: "gpt-5.6-terra",
+            prompt: prompts[0],
+            model: selectedModel,
+          },
+          "vm0",
+          usagePricingResolution,
+        );
+      });
+      await waitForRunStatus(actor, first.runId, "completed", 10_000);
+      await flushWaitUntilForTest();
+      const firstBinding = await readThreadSessionBinding(
+        context,
+        first.threadId,
+      );
+      if (!firstBinding.agent_session_id) {
+        throw new Error(
+          "Expected standard Terra to bind a canonical Pi session",
+        );
+      }
+
+      const fast = await withOpenRouterRoute(async () => {
+        return await sendChatRun(
+          actor,
+          {
+            agentId,
+            threadId: first.threadId,
+            prompt: prompts[1],
+            model: selectedModel,
             runOptions: { codexServiceTier: "fast" },
           },
           "vm0",
           usagePricingResolution,
         );
       });
-      await waitForRunStatus(actor, run.runId, "completed", 10_000);
+      await waitForRunStatus(actor, fast.runId, "completed", 10_000);
       await flushWaitUntilForTest();
-      await expectTerraApiFollowUpUsage(run.runId, testCase.expectedSuffix);
-    }
+      const fastBinding = await readThreadSessionBinding(
+        context,
+        first.threadId,
+      );
+      expect(fastBinding.agent_session_id).toBe(firstBinding.agent_session_id);
 
-    expect(modelRequests).toHaveLength(cases.length);
-    for (const body of modelRequests) {
-      expect(body).toMatchObject({
-        service_tier: "priority",
-        store: false,
+      await chat.updateThreadModelSelection(
+        actor,
+        first.threadId,
+        selectedModel,
+        { codexServiceTier: null },
+      );
+      const returned = await withOpenRouterRoute(async () => {
+        return await sendChatRun(
+          actor,
+          {
+            agentId,
+            threadId: first.threadId,
+            prompt: prompts[2],
+            model: selectedModel,
+          },
+          "vm0",
+          usagePricingResolution,
+        );
       });
-      expect(body).not.toHaveProperty("previous_response_id");
-    }
-  }, 90_000);
+      await waitForRunStatus(actor, returned.runId, "completed", 10_000);
+      await flushWaitUntilForTest();
+      const returnedBinding = await readThreadSessionBinding(
+        context,
+        first.threadId,
+      );
+      expect(returnedBinding.agent_session_id).toBe(
+        firstBinding.agent_session_id,
+      );
+      await expect(
+        readThreadSessionConversation(context, first.threadId),
+      ).resolves.toMatchObject({
+        agent_session_id: firstBinding.agent_session_id,
+        conversation_run_id: returned.runId,
+      });
 
-  it("promotes queued fast Terra through Pi API-first with priority", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    const orgId = requireOrgId(actor);
-    const usagePricingResolution = await createTerraUsagePricingResolution();
-    const anchor = await sendChatRun(actor, {
-      agentId,
-      prompt: "hold the thread before queued fast Terra",
-      model: "claude-sonnet-5",
-    });
-    const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
-
-    await configureBuiltInPiModel(actor, "gpt-5.6-terra");
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      {
-        [FeatureSwitchKey.PiLoop]: true,
-        [FeatureSwitchKey.CodexFastMode]: true,
-      },
-    );
-    mockPiResourceArchiveDownloads();
-    mockPiCheckpointObjectStore();
-    const modelRequests: unknown[] = [];
-    const prompt = "promote queued fast Terra through the callback";
-    const answer = "queued fast Terra API-first answer";
-    server.use(
-      http.post("https://api.openai.com/v1/responses", async ({ request }) => {
-        modelRequests.push(await request.json());
-        return new HttpResponse(piResponsesTextSse(answer, 0), {
-          headers: { "content-type": "text/event-stream" },
+      expect(modelRequests).toHaveLength(3);
+      const requestTiers = modelRequests.map((body) => {
+        return z
+          .object({ service_tier: z.literal("priority").optional() })
+          .passthrough()
+          .parse(body).service_tier;
+      });
+      expect(requestTiers).toStrictEqual([undefined, "priority", undefined]);
+      for (const body of modelRequests) {
+        expect(body).toMatchObject({
+          model: `openai/${selectedModel}`,
+          reasoning: { effort: "max" },
+          store: false,
         });
-      }),
-    );
+        expect(body).not.toHaveProperty("previous_response_id");
+      }
+      for (const [requestIndex, expectedTurns] of [
+        [0, [prompts[0]]],
+        [1, [prompts[0], answers[0], prompts[1]]],
+        [2, [prompts[0], answers[0], prompts[1], answers[1], prompts[2]]],
+      ] as const) {
+        const input = JSON.stringify(modelRequests[requestIndex]);
+        for (const turn of expectedTurns) {
+          expect(occurrences(input, turn)).toBe(1);
+        }
+        expect(occurrences(input, answers[requestIndex])).toBe(0);
+      }
 
-    const queuedId = randomUUID();
-    const queued = await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: anchor.threadId,
-        prompt,
-        clientEventId: queuedId,
-        model: "gpt-5.6-terra",
-        runOptions: { codexServiceTier: "fast" },
-      },
-      [201],
-      { usagePricingResolution },
-    );
-    if (queued.status !== 201) {
-      throw new Error("Expected queued fast Terra to enter the chat queue");
-    }
-    expect(queued.body.runId).toBeNull();
+      for (const run of [first, fast, returned]) {
+        await expect(
+          readRunLaunchSnapshotFixture(context, run.runId),
+        ).resolves.toMatchObject({
+          launch_snapshot: { framework: "pi" },
+        });
+        const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
+        expect(claim.status).toBe(404);
+      }
+      for (const runId of [fast.runId, returned.runId]) {
+        const run = await api.readRun(actor, runId);
+        const appendSystemPrompt = run.appendSystemPrompt ?? "";
+        expect(appendSystemPrompt).not.toContain("# Web Chat Run Context");
+        for (const turn of [...prompts, ...answers]) {
+          expect(appendSystemPrompt).not.toContain(turn);
+        }
+      }
 
-    chatCallbacks.mockChatOutputEvents([]);
-    await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
-      usagePricingResolution,
-    });
-    const messages = await waitForThreadMessages(
-      actor,
-      anchor.threadId,
-      (events) => {
-        return userMessages(events).some((event) => {
-          return (
-            event.revokesEventId === queuedId && typeof event.runId === "string"
+      await expectPiApiUsage(first.runId, selectedModel, "", {
+        input: 5,
+        output: 3,
+        cacheRead: 3,
+        cacheCreation: 2,
+      });
+      await expectPiApiUsage(fast.runId, selectedModel, ".fast", {
+        input: 5,
+        output: 3,
+        cacheRead: 3,
+        cacheCreation: 2,
+      });
+      await expectPiApiUsage(returned.runId, selectedModel, ".long_context", {
+        input: longContextInputTokens,
+        output: 3,
+        cacheRead: 0,
+        cacheCreation: 0,
+      });
+
+      const visibleTurns = [
+        { runId: first.runId, prompt: prompts[0], answer: answers[0] },
+        { runId: fast.runId, prompt: prompts[1], answer: answers[1] },
+        { runId: returned.runId, prompt: prompts[2], answer: answers[2] },
+      ];
+      const finalEvents = await waitForThreadMessages(
+        actor,
+        first.threadId,
+        (events) => {
+          return eventBackedContents(events, returned.runId).some((event) => {
+            return event.content === answers[2];
+          });
+        },
+      );
+      const runIds = new Set(
+        visibleTurns.map((turn) => {
+          return turn.runId;
+        }),
+      );
+      expect(
+        finalEvents.events
+          .filter((event) => {
+            return (
+              event.runId !== undefined &&
+              event.runId !== null &&
+              runIds.has(event.runId) &&
+              (event.eventType === "input.prompt" ||
+                event.eventType === "output.message")
+            );
+          })
+          .map((event) => {
+            return {
+              runId: event.runId,
+              eventType: event.eventType,
+              content: chatEventDisplayText(event),
+            };
+          }),
+      ).toStrictEqual(
+        visibleTurns.flatMap((turn) => {
+          return [
+            {
+              runId: turn.runId,
+              eventType: "input.prompt",
+              content: turn.prompt,
+            },
+            {
+              runId: turn.runId,
+              eventType: "output.message",
+              content: turn.answer,
+            },
+          ];
+        }),
+      );
+      const sessionBlobs = [...checkpointObjects.entries()].filter(([key]) => {
+        return key.includes("/blobs/");
+      });
+      expect(sessionBlobs.length).toBeGreaterThan(0);
+      for (const [, bytes] of sessionBlobs) {
+        expect(bytes.toString("utf8")).not.toContain("serviceTier");
+      }
+    },
+    90_000,
+  );
+
+  it.each(GPT_PI_BDD_MODELS)(
+    "bills managed OpenRouter priority only from the observed terminal Responses tier %s",
+    async (selectedModel) => {
+      const { actor, agentId } = await entitledChatActor();
+      const orgId = requireOrgId(actor);
+      const usagePricingResolution = await createGptUsagePricingResolution();
+      const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
+        actor,
+        selectedModel,
+      );
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        {
+          [FeatureSwitchKey.PiLoop]: true,
+          [FeatureSwitchKey.CodexFastMode]: true,
+        },
+      );
+      mockPiResourceArchiveDownloads();
+      mockPiCheckpointObjectStore();
+      const cases = [
+        { observed: "priority", expectedSuffix: ".fast" },
+        { observed: "fast", expectedSuffix: ".fast" },
+        { observed: "default", expectedSuffix: "" },
+        { observed: "flex", expectedSuffix: "" },
+        { observed: null, expectedSuffix: "" },
+        { observed: undefined, expectedSuffix: "" },
+        { observed: "future-tier", expectedSuffix: "" },
+      ] as const;
+      const modelRequests: unknown[] = [];
+      server.use(
+        http.post(
+          "https://openrouter.ai/api/v1/responses",
+          async ({ request }) => {
+            const requestIndex = modelRequests.length;
+            modelRequests.push(await request.json());
+            const testCase = cases[requestIndex];
+            if (!testCase) {
+              return HttpResponse.json(
+                { error: "unexpected duplicate OpenRouter request" },
+                { status: 500 },
+              );
+            }
+            return new HttpResponse(
+              piResponsesTextSse(
+                `OpenRouter tier answer ${requestIndex.toString()}`,
+                requestIndex,
+                undefined,
+                testCase.observed,
+              ),
+              { headers: { "content-type": "text/event-stream" } },
+            );
+          },
+        ),
+      );
+
+      for (const [index, testCase] of cases.entries()) {
+        const run = await withOpenRouterRoute(async () => {
+          return await sendChatRun(
+            actor,
+            {
+              agentId,
+              prompt: `observe OpenRouter tier case ${index.toString()}`,
+              model: selectedModel,
+              runOptions: { codexServiceTier: "fast" },
+            },
+            "vm0",
+            usagePricingResolution,
           );
         });
-      },
-    );
-    const promoted = userMessages(messages.events).find((event) => {
-      return event.revokesEventId === queuedId;
-    });
-    if (!promoted?.runId) {
-      throw new Error("Expected queued fast Terra to create a run");
-    }
-    const promotedRunId = promoted.runId;
-    await waitForRunStatus(actor, promotedRunId, "completed", 10_000);
-    await flushWaitUntilForTest();
+        await waitForRunStatus(actor, run.runId, "completed", 10_000);
+        await flushWaitUntilForTest();
+        await expectPiApiUsage(
+          run.runId,
+          selectedModel,
+          testCase.expectedSuffix,
+          { input: 5, output: 3, cacheRead: 0, cacheCreation: 0 },
+        );
+      }
 
-    expect(modelRequests).toHaveLength(1);
-    const request = z
-      .object({ service_tier: z.literal("priority") })
-      .passthrough()
-      .parse(modelRequests[0]);
-    expect(request.service_tier).toBe("priority");
-    expect(occurrences(JSON.stringify(request), prompt)).toBe(1);
-    await expect(
-      readRunLaunchSnapshotFixture(context, promotedRunId),
-    ).resolves.toMatchObject({
-      launch_snapshot: { framework: "pi" },
-    });
-    const claim = await api.requestClaimRunnerJob(true, promotedRunId, [404]);
-    expect(claim.status).toBe(404);
-    await expectTerraApiFollowUpUsage(promotedRunId, ".fast");
-    const finalEvents = await waitForThreadMessages(
-      actor,
-      anchor.threadId,
-      (events) => {
-        return eventBackedContents(events, promotedRunId).some((event) => {
-          return event.content === answer;
+      expect(modelRequests).toHaveLength(cases.length);
+      for (const body of modelRequests) {
+        expect(body).toMatchObject({
+          model: `openai/${selectedModel}`,
+          reasoning: { effort: "max" },
+          service_tier: "priority",
+          store: false,
         });
-      },
-    );
-    expect(
-      eventBackedContents(finalEvents.events, promotedRunId).filter((event) => {
-        return event.content === answer;
+        expect(body).not.toHaveProperty("previous_response_id");
+      }
+    },
+    90_000,
+  );
+
+  it.each(GPT_PI_BDD_MODELS)(
+    "promotes queued fast %s through Pi API-first with priority",
+    async (selectedModel) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const orgId = requireOrgId(actor);
+      const usagePricingResolution = await createGptUsagePricingResolution();
+      const anchor = await sendChatRun(actor, {
+        agentId,
+        prompt: "hold the thread before queued fast Terra",
+        model: "claude-sonnet-5",
+      });
+      const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
+
+      await configureBuiltInPiModel(actor, selectedModel);
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        {
+          [FeatureSwitchKey.PiLoop]: true,
+          [FeatureSwitchKey.CodexFastMode]: true,
+        },
+      );
+      mockPiResourceArchiveDownloads();
+      mockPiCheckpointObjectStore();
+      const modelRequests: unknown[] = [];
+      const prompt = "promote queued fast Terra through the callback";
+      const answer = "queued fast Terra API-first answer";
+      server.use(
+        http.post(
+          "https://api.openai.com/v1/responses",
+          async ({ request }) => {
+            modelRequests.push(await request.json());
+            return new HttpResponse(piResponsesTextSse(answer, 0), {
+              headers: { "content-type": "text/event-stream" },
+            });
+          },
+        ),
+      );
+
+      const queuedId = randomUUID();
+      const queued = await chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          threadId: anchor.threadId,
+          prompt,
+          clientEventId: queuedId,
+          model: selectedModel,
+          runOptions: { codexServiceTier: "fast" },
+        },
+        [201],
+        { usagePricingResolution },
+      );
+      if (queued.status !== 201) {
+        throw new Error("Expected queued fast Terra to enter the chat queue");
+      }
+      expect(queued.body.runId).toBeNull();
+
+      chatCallbacks.mockChatOutputEvents([]);
+      await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders, {
+        usagePricingResolution,
+      });
+      const messages = await waitForThreadMessages(
+        actor,
+        anchor.threadId,
+        (events) => {
+          return userMessages(events).some((event) => {
+            return (
+              event.revokesEventId === queuedId &&
+              typeof event.runId === "string"
+            );
+          });
+        },
+      );
+      const promoted = userMessages(messages.events).find((event) => {
+        return event.revokesEventId === queuedId;
+      });
+      if (!promoted?.runId) {
+        throw new Error("Expected queued fast Terra to create a run");
+      }
+      const promotedRunId = promoted.runId;
+      await waitForRunStatus(actor, promotedRunId, "completed", 10_000);
+      await flushWaitUntilForTest();
+
+      expect(modelRequests).toHaveLength(1);
+      const request = z
+        .object({ service_tier: z.literal("priority") })
+        .passthrough()
+        .parse(modelRequests[0]);
+      expect(request.service_tier).toBe("priority");
+      expect(request).toMatchObject({
+        model: selectedModel,
+        reasoning: { effort: "max" },
+      });
+      expect(occurrences(JSON.stringify(request), prompt)).toBe(1);
+      await expect(
+        readRunLaunchSnapshotFixture(context, promotedRunId),
+      ).resolves.toMatchObject({
+        launch_snapshot: { framework: "pi" },
+      });
+      const claim = await api.requestClaimRunnerJob(true, promotedRunId, [404]);
+      expect(claim.status).toBe(404);
+      await expectPiApiUsage(promotedRunId, selectedModel, ".fast", {
+        input: 5,
+        output: 3,
+        cacheRead: 0,
+        cacheCreation: 0,
+      });
+      const finalEvents = await waitForThreadMessages(
+        actor,
+        anchor.threadId,
+        (events) => {
+          return eventBackedContents(events, promotedRunId).some((event) => {
+            return event.content === answer;
+          });
+        },
+      );
+      expect(
+        eventBackedContents(finalEvents.events, promotedRunId).filter(
+          (event) => {
+            return event.content === answer;
+          },
+        ),
+      ).toHaveLength(1);
+    },
+    90_000,
+  );
+
+  it("preserves one Pi session while selecting Terra, Sol, Luna, and Terra again", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    for (const model of GPT_PI_BDD_MODELS) {
+      await seedBuiltInModelKey(model);
+    }
+    await api.updateOrgModelPolicies(
+      actor,
+      GPT_PI_BDD_MODELS.map((model) => {
+        return {
+          model,
+          isDefault: model === "gpt-5.6-terra",
+          defaultProviderType: "built-in",
+          credentialScope: "org",
+          modelProviderId: null,
+        };
       }),
-    ).toHaveLength(1);
+    );
+    await authDeviceSupport.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.PiLoop]: true,
+    });
+    const usagePricingResolution = await createGptUsagePricingResolution();
+    mockPiResourceArchiveDownloads();
+    mockPiCheckpointObjectStore();
+    const requests: unknown[] = [];
+    server.use(
+      http.post("https://api.openai.com/v1/responses", async ({ request }) => {
+        requests.push(await request.json());
+        return nativeCodexSseResponse(
+          piResponsesTextSse(`answer ${requests.length}`, requests.length),
+        );
+      }),
+    );
+    let threadId: string | undefined;
+    let sessionId: string | null | undefined;
+    for (const model of [...GPT_PI_BDD_MODELS, "gpt-5.6-terra"] as const) {
+      const run = await sendChatRun(
+        actor,
+        { agentId, threadId, model, prompt: `continue with ${model}` },
+        "vm0",
+        usagePricingResolution,
+      );
+      threadId = run.threadId;
+      await waitForRunStatus(actor, run.runId, "completed");
+      await flushWaitUntilForTest();
+      const session = await readThreadSessionConversation(context, threadId);
+      if (sessionId === undefined) {
+        sessionId = session.agent_session_id;
+        expect(sessionId).toStrictEqual(expect.any(String));
+      }
+      expect(session.agent_session_id).toBe(sessionId);
+      expect(requests.at(-1)).toMatchObject({
+        model,
+        reasoning: { effort: "max" },
+      });
+      expect(requests.at(-1)).not.toHaveProperty("service_tier");
+      await expectPiApiUsage(run.runId, model, "", {
+        input: 5,
+        output: 3,
+        cacheRead: 0,
+        cacheCreation: 0,
+      });
+    }
+    expect(requests).toHaveLength(4);
+    for (const answer of ["answer 1", "answer 2", "answer 3"]) {
+      expect(occurrences(JSON.stringify(requests.at(-1)), answer)).toBe(1);
+    }
   }, 90_000);
 
-  it("preserves generations across Terra Pi and fast Sol Codex boundaries", async () => {
+  it("preserves generations across Terra Pi and fast Astra Codex boundaries", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const orgId = actor.orgId;
     if (!orgId) {
@@ -9056,7 +9352,7 @@ describe("CHAT-02: model-first provider policies", () => {
     }
     const piModel = "gpt-5.6-terra";
     await seedBuiltInModelKey(piModel);
-    await seedBuiltInModelKey("gpt-5.6-sol");
+    await seedBuiltInModelKey("gpt-6-astra");
     await api.updateOrgModelPolicies(actor, [
       {
         model: piModel,
@@ -9066,7 +9362,7 @@ describe("CHAT-02: model-first provider policies", () => {
         modelProviderId: null,
       },
       {
-        model: "gpt-5.6-sol",
+        model: "gpt-6-astra",
         isDefault: false,
         defaultProviderType: "built-in",
         credentialScope: "org",
@@ -9144,7 +9440,7 @@ describe("CHAT-02: model-first provider policies", () => {
       agentId,
       threadId: firstPi.threadId,
       prompt: firstCodexPrompt,
-      model: "gpt-5.6-sol",
+      model: "gpt-6-astra",
       runOptions: { codexServiceTier: "fast" },
     });
     const firstCodexBinding = await readThreadSessionBinding(
@@ -9308,7 +9604,7 @@ describe("CHAT-02: model-first provider policies", () => {
       agentId,
       threadId: firstPi.threadId,
       prompt: repeatedCodexPrompt,
-      model: "gpt-5.6-sol",
+      model: "gpt-6-astra",
       runOptions: { codexServiceTier: "fast" },
     });
     const repeatedCodexBinding = await readThreadSessionBinding(
@@ -11223,23 +11519,30 @@ describe("CHAT-02: model-first provider policies", () => {
   }, 90_000);
 
   it.each([
-    {
-      name: "OpenRouter Terra",
-      selectedModel: "gpt-5.6-terra",
-      providerUrl: "https://openrouter.ai/api/v1/responses",
-      observedServiceTier: "default",
-      codexServiceTier: "fast",
-      terraRoute: "openrouter",
-      inputTokens: 10,
-      expectedInput: 5,
-    },
+    ...GPT_PI_BDD_MODELS.flatMap((selectedModel) => {
+      return (["openai", "openrouter"] as const).map((gptRoute) => {
+        return {
+          name: `${gptRoute} ${selectedModel}`,
+          selectedModel,
+          providerUrl:
+            gptRoute === "openai"
+              ? "https://api.openai.com/v1/responses"
+              : "https://openrouter.ai/api/v1/responses",
+          observedServiceTier: "default",
+          codexServiceTier: "fast" as const,
+          gptRoute,
+          inputTokens: 10,
+          expectedInput: 5,
+        };
+      });
+    }),
     {
       name: "built-in DeepSeek Flash",
       selectedModel: "deepseek-v4-flash",
       providerUrl: "https://api.deepseek.com/responses",
       observedServiceTier: "priority",
       codexServiceTier: undefined,
-      terraRoute: undefined,
+      gptRoute: undefined,
       inputTokens: 300_000,
       expectedInput: 299_995,
     },
@@ -11250,7 +11553,7 @@ describe("CHAT-02: model-first provider policies", () => {
       providerUrl,
       observedServiceTier,
       codexServiceTier,
-      terraRoute,
+      gptRoute,
       inputTokens,
       expectedInput,
     }) => {
@@ -11295,7 +11598,7 @@ describe("CHAT-02: model-first provider policies", () => {
           runnerGroup,
           prompt: "let cancellation commit before API publication",
           ...(codexServiceTier === undefined ? {} : { codexServiceTier }),
-          ...(terraRoute === undefined ? {} : { terraRoute }),
+          ...(gptRoute === undefined ? {} : { gptRoute }),
           selectedModel,
         });
       await completeChatRunOk(anchor.runId, anchorClaim.sandboxHeaders);
@@ -11324,7 +11627,7 @@ describe("CHAT-02: model-first provider policies", () => {
       await flushWaitUntilForTest();
 
       expect(modelCalls).toBe(1);
-      if (selectedModel === "gpt-5.6-terra") {
+      if (codexServiceTier === "fast") {
         expect(
           z
             .object({ service_tier: z.literal("priority") })
@@ -11334,12 +11637,17 @@ describe("CHAT-02: model-first provider policies", () => {
       } else {
         expect(modelRequests[0]).not.toHaveProperty("service_tier");
       }
-      await expectPiApiUsage(run.runId, selectedModel, "", {
-        input: expectedInput,
-        output: 3,
-        cacheRead: 3,
-        cacheCreation: 2,
-      });
+      await expectPiApiUsage(
+        run.runId,
+        selectedModel,
+        gptRoute === "openai" ? ".fast" : "",
+        {
+          input: expectedInput,
+          output: 3,
+          cacheRead: 3,
+          cacheCreation: 2,
+        },
+      );
       await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
         status: "cancelled",
       });
@@ -11434,7 +11742,7 @@ describe("CHAT-02: model-first provider policies", () => {
     "fails incomplete Pi $name output once after recording consumed Built-in usage",
     async ({ content, atCap }) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
-      const usagePricingResolution = await createTerraUsagePricingResolution();
+      const usagePricingResolution = await createGptUsagePricingResolution();
       await configureBuiltInPiModel(actor, "gpt-5.6-terra");
       await authDeviceSupport.updateFeatureSwitches(actor, {
         [FeatureSwitchKey.PiLoop]: true,
@@ -11563,16 +11871,16 @@ describe("CHAT-02: model-first provider policies", () => {
     90_000,
   );
 
-  it.each(USER_OWNED_TERRA_FAST_BDD_ROUTES)(
+  it.each(USER_OWNED_GPT_FAST_BDD_ROUTES)(
     "fails incomplete Pi $name Fast output without Built-in billing or provider substitution",
     async (route) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
-      await configureUserOwnedTerraPiModel(actor, route);
+      await configureUserOwnedGptPiModel(actor, route);
       mockPiResourceArchiveDownloads();
       const objects = mockPiCheckpointObjectStore();
       const requests: string[] = [];
       server.use(
-        ...USER_OWNED_TERRA_FAST_BDD_ROUTES.map((candidate) => {
+        ...USER_OWNED_GPT_FAST_BDD_ROUTES.map((candidate) => {
           return http.post(candidate.endpoint, ({ request }) => {
             requests.push(request.url);
             return nativeCodexSseResponse(
@@ -11589,7 +11897,7 @@ describe("CHAT-02: model-first provider policies", () => {
       );
       const run = await sendChatRun(actor, {
         agentId,
-        model: "gpt-5.6-terra",
+        model: route.selectedModel,
         prompt: "finish the user-owned turn",
         runOptions: { codexServiceTier: "fast" },
       });
@@ -11794,7 +12102,7 @@ describe("CHAT-02: model-first provider policies", () => {
 
   it("preserves ordinary Pi stop checkpoints and length with pending tools after incomplete output fails", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
-    const usagePricingResolution = await createTerraUsagePricingResolution();
+    const usagePricingResolution = await createGptUsagePricingResolution();
     await configureBuiltInPiModel(actor, "gpt-5.6-terra");
     await authDeviceSupport.updateFeatureSwitches(actor, {
       [FeatureSwitchKey.PiLoop]: true,
@@ -12248,7 +12556,7 @@ describe("CHAT-02: model-first provider policies", () => {
     if (!actor.orgId) {
       throw new Error("Expected entitled chat actor to have an org");
     }
-    const usagePricingResolution = await createTerraUsagePricingResolution();
+    const usagePricingResolution = await createGptUsagePricingResolution();
     mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
     const runnerIdentity = {
       runnerId: randomUUID(),
@@ -12623,130 +12931,145 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(modelCalls).toBe(2);
   }, 150_000);
 
-  it("keeps DeepSeek API-first and Sandbox usage as separate billable rows", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    const orgId = requireOrgId(actor);
-    const selectedModel = "deepseek-v4-flash";
-    const usagePricingResolution =
-      await createPiApiFirstTurnUsagePricingResolution(selectedModel);
-    await configureBuiltInPiModel(actor, selectedModel);
-    await updateFeatureSwitchesForUser(
-      context,
-      { ...actor, orgId },
-      { [FeatureSwitchKey.PiLoop]: true },
-    );
-    mockPiResourceArchiveDownloads();
-    const checkpointObjects = mockPiCheckpointObjectStore();
-    let modelCalls = 0;
-    server.use(
-      http.post("https://api.deepseek.com/responses", () => {
-        modelCalls += 1;
-        return new HttpResponse(
-          piResponsesContentSse({
-            blocks: [
-              {
-                type: "toolCall",
-                callId: "call_deepseek_sandbox",
-                name: "bash",
-                arguments: { command: "true" },
-              },
-            ],
-            sequence: modelCalls,
-            usage: {
-              input_tokens: 10,
-              output_tokens: 3,
-              total_tokens: 13,
-              input_tokens_details: {
-                cached_tokens: 3,
-                cache_write_tokens: 2,
-              },
-            },
-          }),
-          { headers: { "content-type": "text/event-stream" } },
-        );
-      }),
-    );
+  it.each(["deepseek-v4-flash", ...GPT_PI_BDD_MODELS] as const)(
+    "keeps %s API-first and Sandbox usage as separate billable rows",
+    async (selectedModel) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const orgId = requireOrgId(actor);
+      const isDeepSeek = selectedModel === "deepseek-v4-flash";
+      const usagePricingResolution =
+        await createPiApiFirstTurnUsagePricingResolution(selectedModel);
+      await configureBuiltInPiModel(actor, selectedModel);
+      await updateFeatureSwitchesForUser(
+        context,
+        { ...actor, orgId },
+        { [FeatureSwitchKey.PiLoop]: true },
+      );
+      mockPiResourceArchiveDownloads();
+      const checkpointObjects = mockPiCheckpointObjectStore();
+      let modelCalls = 0;
+      server.use(
+        http.post(
+          isDeepSeek
+            ? "https://api.deepseek.com/responses"
+            : "https://api.openai.com/v1/responses",
+          () => {
+            modelCalls += 1;
+            return new HttpResponse(
+              piResponsesContentSse({
+                blocks: [
+                  {
+                    type: "toolCall",
+                    callId: "call_deepseek_sandbox",
+                    name: "bash",
+                    arguments: { command: "true" },
+                  },
+                ],
+                sequence: modelCalls,
+                usage: {
+                  input_tokens: 10,
+                  output_tokens: 3,
+                  total_tokens: 13,
+                  input_tokens_details: {
+                    cached_tokens: 3,
+                    cache_write_tokens: 2,
+                  },
+                },
+              }),
+              { headers: { "content-type": "text/event-stream" } },
+            );
+          },
+        ),
+      );
 
-    const run = await sendChatRun(
-      actor,
-      {
-        agentId,
-        prompt: "hand a built-in DeepSeek tool response to Sandbox",
+      const run = await sendChatRun(
+        actor,
+        {
+          agentId,
+          prompt: "hand a built-in DeepSeek tool response to Sandbox",
+          model: selectedModel,
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+      const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
+      await expect
+        .poll(() => {
+          return checkpointObjects.has(manifestKey);
+        })
+        .toBe(true);
+      await flushWaitUntilForTest();
+      expect(modelCalls).toBe(1);
+
+      const claimed = await claimChatRun(runnerGroup, run.runId);
+      expect(claimed.claim.piModelConfig).toMatchObject({
+        provider: isDeepSeek ? "deepseek" : "openai",
         model: selectedModel,
-      },
-      "vm0",
-      usagePricingResolution,
-    );
-    const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}/manifest.json`;
-    await expect
-      .poll(() => {
-        return checkpointObjects.has(manifestKey);
-      })
-      .toBe(true);
-    await flushWaitUntilForTest();
-    expect(modelCalls).toBe(1);
-
-    const claimed = await claimChatRun(runnerGroup, run.runId);
-    expect(claimed.claim.piModelConfig).toMatchObject({
-      provider: "deepseek",
-      api: "openai-responses",
-    });
-    expect(claimed.claim.piModelConfig).not.toHaveProperty("serviceTier");
-    const sandboxUsageEvent = {
-      idempotencyKey: randomUUID(),
-      kind: "model" as const,
-      provider: selectedModel,
-      category: "tokens.output",
-      quantity: 2,
-    };
-    const sandboxUsageReceipts = await Promise.all([
-      webhooks.requestAgentUsageEvent(
-        { runId: run.runId, events: [sandboxUsageEvent] },
-        claimed.sandboxHeaders,
+        api: "openai-responses",
+      });
+      expect(claimed.claim.piModelConfig).not.toHaveProperty("serviceTier");
+      const sandboxUsageEvent = {
+        idempotencyKey: randomUUID(),
+        kind: "model" as const,
+        provider: selectedModel,
+        category: "tokens.output",
+        quantity: 2,
+      };
+      const sandboxUsageReceipts = await Promise.all([
+        webhooks.requestAgentUsageEvent(
+          { runId: run.runId, events: [sandboxUsageEvent] },
+          claimed.sandboxHeaders,
+          [200],
+          usagePricingResolution,
+        ),
+        webhooks.requestAgentUsageEvent(
+          { runId: run.runId, events: [sandboxUsageEvent] },
+          claimed.sandboxHeaders,
+          [200],
+          usagePricingResolution,
+        ),
+      ]);
+      expect(
+        sandboxUsageReceipts.map((receipt) => {
+          return receipt.body;
+        }),
+      ).toStrictEqual([{ success: true }, { success: true }]);
+      await api.requestCancelRun(
+        actor,
+        run.runId,
         [200],
         usagePricingResolution,
-      ),
-      webhooks.requestAgentUsageEvent(
-        { runId: run.runId, events: [sandboxUsageEvent] },
-        claimed.sandboxHeaders,
-        [200],
-        usagePricingResolution,
-      ),
-    ]);
-    expect(
-      sandboxUsageReceipts.map((receipt) => {
-        return receipt.body;
-      }),
-    ).toStrictEqual([{ success: true }, { success: true }]);
-    await api.requestCancelRun(actor, run.runId, [200], usagePricingResolution);
-    await waitForRunStatus(actor, run.runId, "cancelled");
-    await failChatRun(run.runId, claimed.sandboxHeaders, "Run cancelled");
-    await flushWaitUntilForTest();
-    const combinedUsage = await readRunUsageEventsFixture(run.runId);
-    expect(
-      combinedUsage.filter((row) => {
-        return row.category === "tokens.output" && row.quantity === 3;
-      }),
-    ).toHaveLength(1);
-    expect(
-      combinedUsage.filter((row) => {
-        return row.category === "tokens.output" && row.quantity === 2;
-      }),
-    ).toHaveLength(1);
-    expect(combinedUsage).toHaveLength(5);
-    expect(
-      combinedUsage.every((row) => {
-        return (
-          row.provider === selectedModel &&
-          row.status === "processed" &&
-          row.billingError === null &&
-          !row.category.includes(".fast") &&
-          !row.category.includes(".long_context")
-        );
-      }),
-    ).toBeTruthy();
-    expect(totalChargedCredits(combinedUsage)).toBeGreaterThan(0);
-  }, 90_000);
+      );
+      await waitForRunStatus(actor, run.runId, "cancelled");
+      await failChatRun(run.runId, claimed.sandboxHeaders, "Run cancelled");
+      await flushWaitUntilForTest();
+      const combinedUsage = await readRunUsageEventsFixture(run.runId);
+      expect(
+        combinedUsage.filter((row) => {
+          return row.category === "tokens.output" && row.quantity === 3;
+        }),
+      ).toHaveLength(1);
+      expect(
+        combinedUsage.filter((row) => {
+          return row.category === "tokens.output" && row.quantity === 2;
+        }),
+      ).toHaveLength(1);
+      expect(combinedUsage).toHaveLength(5);
+      expect(
+        combinedUsage.every((row) => {
+          return (
+            row.provider === selectedModel &&
+            row.status === "processed" &&
+            row.billingError === null &&
+            !row.category.includes(".fast") &&
+            !row.category.includes(".long_context")
+          );
+        }),
+      ).toBeTruthy();
+      expect(totalChargedCredits(combinedUsage)).toBeGreaterThan(0);
+    },
+    90_000,
+  );
 
   it("publishes OpenRouter Responses blocks, hands tools to H2, and checkpoints Pi memory notes", async () => {
     if (await runInIsolatedProcess(import.meta.url)) {
@@ -12754,7 +13077,7 @@ describe("CHAT-02: model-first provider policies", () => {
     }
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     const orgId = requireOrgId(actor);
-    const usagePricingResolution = await createTerraUsagePricingResolution();
+    const usagePricingResolution = await createGptUsagePricingResolution();
     const withOpenRouterRoute = await configureBuiltInPiModelOnOpenRouter(
       actor,
       "gpt-5.6-terra",
@@ -13883,7 +14206,7 @@ describe("CHAT-02: model-first provider policies", () => {
   );
 
   it.each(
-    STANDARD_TERRA_API_KEY_BDD_ROUTES.flatMap((route) => {
+    GPT_API_KEY_BDD_ROUTES.flatMap((route) => {
       return [
         { ...route, tier: undefined, generation: 2, outcome: "completed" },
         { ...route, tier: "fast", generation: 3, outcome: "completed" },
@@ -13892,13 +14215,13 @@ describe("CHAT-02: model-first provider policies", () => {
       ] as const;
     }),
   )(
-    "runs $name API-key Terra $tier through API-first and generation-$generation Sandbox with $outcome and credential rotation",
+    "runs $name API-key $tier through API-first and generation-$generation Sandbox with $outcome and credential rotation",
     async (route) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       const firewall = createFirewallApi(context);
       chatCallbacks.failIfChatCallbackRouteIsFetched();
       const initialSecret = `${route.type}-initial-secret`;
-      const providerId = await configureApiKeyTerraPiModel(
+      const providerId = await configureApiKeyGptPiModel(
         actor,
         route,
         initialSecret,
@@ -13945,7 +14268,7 @@ describe("CHAT-02: model-first provider policies", () => {
       const first = await sendChatRun(actor, {
         agentId,
         prompt: firstPrompt,
-        model: "gpt-5.6-terra",
+        model: route.selectedModel,
         runOptions: { codexServiceTier: route.tier },
       });
       const manifestKey = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${first.runId}/manifest.json`;
@@ -13972,13 +14295,13 @@ describe("CHAT-02: model-first provider policies", () => {
       await expectNoBuiltInModelUsage(first.runId);
 
       await api.heartbeatRunner(runnerGroup);
-      const claim = await claimTerraPiSandbox(actor, first.runId, route.tier);
+      const claim = await claimGptPiSandbox(actor, first.runId, route.tier);
       const sandboxHeaders = {
         authorization: `Bearer ${claim.sandboxToken}`,
       };
       expect(claim.cliAgentType).toBe("pi");
       expect(claim.piSessionId).toBe(first.threadId);
-      expectApiKeyTerraSandboxCarrier(claim, route, route.tier);
+      expectApiKeyGptSandboxCarrier(claim, route, route.tier);
       expect(JSON.stringify(claim)).not.toContain(initialSecret);
       if (!claim.encryptedSecrets) {
         throw new Error("Expected API-key Terra claim credentials");
@@ -14134,7 +14457,7 @@ describe("CHAT-02: model-first provider policies", () => {
       );
       await flushWaitUntilForTest();
       expect(providerRequests).toHaveLength(1);
-      expectApiKeyTerraRequest(
+      expectApiKeyGptRequest(
         providerRequests[0],
         route,
         initialSecret,
@@ -14167,13 +14490,13 @@ describe("CHAT-02: model-first provider policies", () => {
         agentId,
         threadId: first.threadId,
         prompt: followUpPrompt,
-        model: "gpt-5.6-terra",
+        model: route.selectedModel,
         runOptions: { codexServiceTier: route.tier },
       });
       await waitForRunStatus(actor, followUp.runId, "completed");
       await flushWaitUntilForTest();
       expect(providerRequests).toHaveLength(2);
-      expectApiKeyTerraRequest(
+      expectApiKeyGptRequest(
         providerRequests[1],
         route,
         initialSecret,
@@ -14209,14 +14532,14 @@ describe("CHAT-02: model-first provider policies", () => {
           agentId,
           threadId: first.threadId,
           prompt: `continue after rotating the ${route.name} credential`,
-          model: "gpt-5.6-terra",
+          model: route.selectedModel,
           runOptions: { codexServiceTier: route.tier },
         });
       });
       await waitForRunStatus(actor, rotated.runId, "completed");
       await flushWaitUntilForTest();
       expect(providerRequests).toHaveLength(3);
-      expectApiKeyTerraRequest(
+      expectApiKeyGptRequest(
         providerRequests[2],
         route,
         rotatedSecret,
@@ -14286,12 +14609,12 @@ describe("CHAT-02: model-first provider policies", () => {
     90_000,
   );
 
-  it.each(STANDARD_TERRA_API_KEY_BDD_ROUTES)(
+  it.each(GPT_API_KEY_BDD_ROUTES)(
     "fails closed when the admitted $name Fast credential disappears before provider ownership",
     async (route) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       const secret = `${route.type}-deleted-secret`;
-      await configureApiKeyTerraPiModel(actor, route, secret);
+      await configureApiKeyGptPiModel(actor, route, secret);
       const entered = createDeferredPromise<void>(context.signal);
       const release = createDeferredPromise<void>(context.signal);
       const objects = mockPiCheckpointObjectStore();
@@ -14310,7 +14633,7 @@ describe("CHAT-02: model-first provider policies", () => {
             headers: { "content-type": "application/gzip" },
           });
         }),
-        ...USER_OWNED_TERRA_FAST_BDD_ROUTES.map((candidate) => {
+        ...USER_OWNED_GPT_FAST_BDD_ROUTES.map((candidate) => {
           return http.post(candidate.endpoint, ({ request }) => {
             providerRequests.push(request.url);
             return new HttpResponse(
@@ -14325,7 +14648,7 @@ describe("CHAT-02: model-first provider policies", () => {
       );
       const run = await sendChatRun(actor, {
         agentId,
-        model: "gpt-5.6-terra",
+        model: route.selectedModel,
         prompt: "keep captured Fast credentials authoritative",
         runOptions: { codexServiceTier: "fast" },
       });
@@ -14371,13 +14694,13 @@ describe("CHAT-02: model-first provider policies", () => {
     90_000,
   );
 
-  it.each(STANDARD_TERRA_API_KEY_BDD_ROUTES)(
+  it.each(GPT_API_KEY_BDD_ROUTES)(
     "keeps rejected $name API-key Fast single-owner, redacted, and unbilled",
     async (route) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       const secret = `${route.type}-rejected-secret`;
       const privateDiagnostic = "private-provider-rejection-details";
-      await configureApiKeyTerraPiModel(actor, route, secret);
+      await configureApiKeyGptPiModel(actor, route, secret);
       mockPiResourceArchiveDownloads();
       const objects = mockPiCheckpointObjectStore();
       const requests: {
@@ -14386,7 +14709,7 @@ describe("CHAT-02: model-first provider policies", () => {
         body: unknown;
       }[] = [];
       server.use(
-        ...USER_OWNED_TERRA_FAST_BDD_ROUTES.map((candidate) => {
+        ...USER_OWNED_GPT_FAST_BDD_ROUTES.map((candidate) => {
           return http.post(candidate.endpoint, async ({ request }) => {
             requests.push({
               url: request.url,
@@ -14407,7 +14730,7 @@ describe("CHAT-02: model-first provider policies", () => {
       );
       const run = await sendChatRun(actor, {
         agentId,
-        model: "gpt-5.6-terra",
+        model: route.selectedModel,
         prompt: "fail the captured API-key Fast request once",
         runOptions: { codexServiceTier: "fast" },
       });
@@ -14415,7 +14738,7 @@ describe("CHAT-02: model-first provider policies", () => {
       await flushWaitUntilForTest();
       expect(requests).toHaveLength(1);
       expect(requests[0]?.url).toBe(route.endpoint);
-      expectApiKeyTerraRequest(requests[0], route, secret, "fast");
+      expectApiKeyGptRequest(requests[0], route, secret, "fast");
       const failed = await api.readRun(actor, run.runId);
       expect(failed).toMatchObject({
         status: "failed",
@@ -15669,14 +15992,30 @@ describe("CHAT-02: run-level model overrides", () => {
     await cancelChatRun(actor, third.runId);
   }, 90_000);
 
-  it.each([
-    { name: "standard", tier: undefined, generation: 2, outcome: "completed" },
-    { name: "Fast", tier: "fast", generation: 3, outcome: "completed" },
-    { name: "Fast", tier: "fast", generation: 3, outcome: "failed" },
-    { name: "Fast", tier: "fast", generation: 3, outcome: "cancelled" },
-  ] as const)(
-    "hands native $name subscription Terra tools to a generation-$generation Sandbox with $outcome outcome and no built-in billing",
-    async ({ tier, generation, outcome }) => {
+  it.each(
+    (
+      [
+        {
+          name: "standard",
+          tier: undefined,
+          generation: 2,
+          outcome: "completed",
+        },
+        { name: "Fast", tier: "fast", generation: 3, outcome: "completed" },
+        { name: "Fast", tier: "fast", generation: 3, outcome: "failed" },
+        { name: "Fast", tier: "fast", generation: 3, outcome: "cancelled" },
+      ] as const
+    ).flatMap((scenario) => {
+      return GPT_PI_BDD_MODELS.map((selectedModel) => {
+        return {
+          ...scenario,
+          selectedModel,
+        };
+      });
+    }),
+  )(
+    "hands native $name subscription $selectedModel tools to a generation-$generation Sandbox with $outcome outcome and no built-in billing",
+    async ({ tier, generation, outcome, selectedModel }) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
       const firewall = createFirewallApi(context);
       chatCallbacks.failIfChatCallbackRouteIsFetched();
@@ -15691,6 +16030,7 @@ describe("CHAT-02: run-level model overrides", () => {
           refreshedAccessTokenExpiresAt: Math.floor(now() / 1000) + 7200,
           workspaceName: "Pi Subscription Account",
         },
+        selectedModel,
       );
       await authDeviceSupport.updateFeatureSwitches(actor, {
         [FeatureSwitchKey.PersonalModelProviderAccounts]: false,
@@ -15746,7 +16086,7 @@ describe("CHAT-02: run-level model overrides", () => {
       const run = await sendChatRun(actor, {
         agentId,
         prompt: "use the Okou CLI through native subscription Terra",
-        model: "gpt-5.6-terra",
+        model: selectedModel,
         runOptions: { codexServiceTier: tier },
       });
       await expect
@@ -15771,6 +16111,7 @@ describe("CHAT-02: run-level model overrides", () => {
         providerRequests[0],
         refreshedAccessToken,
         tier,
+        selectedModel,
       );
       expect(oauth.oauthToken).toHaveLength(2);
       expect(oauth.oauthToken[1]?.get("grant_type")).toBe("refresh_token");
@@ -15814,7 +16155,7 @@ describe("CHAT-02: run-level model overrides", () => {
           transport: "sse",
           provider: "openai-codex",
           baseUrl: "https://chatgpt.com/backend-api",
-          model: "gpt-5.6-terra",
+          model: selectedModel,
           thinkingLevel: "max",
           credentialBindings: [
             {
@@ -15946,7 +16287,7 @@ describe("CHAT-02: run-level model overrides", () => {
         agentId,
         threadId: run.threadId,
         prompt: "continue on the same subscription account",
-        model: "gpt-5.6-terra",
+        model: selectedModel,
         runOptions: { codexServiceTier: tier },
       });
       await waitForRunStatus(actor, continued.runId, "completed");
@@ -15956,6 +16297,7 @@ describe("CHAT-02: run-level model overrides", () => {
         providerRequests[1],
         refreshedAccessToken,
         tier,
+        selectedModel,
       );
       expect(JSON.stringify(providerRequests[1]?.body)).toContain(
         "Okou CLI help output",
@@ -16229,11 +16571,11 @@ describe("CHAT-02: run-level model overrides", () => {
     await expectNoBuiltInModelUsage(run.runId);
   }, 90_000);
 
-  it.each(USER_OWNED_TERRA_FAST_BDD_ROUTES)(
+  it.each(USER_OWNED_GPT_FAST_BDD_ROUTES)(
     "reuses one $name Pi session across standard, Fast, and standard requests",
     async (route) => {
       const { actor, agentId } = await entitledChatActor();
-      const { secret, accountId } = await configureUserOwnedTerraPiModel(
+      const { secret, accountId } = await configureUserOwnedGptPiModel(
         actor,
         route,
       );
@@ -16262,7 +16604,7 @@ describe("CHAT-02: run-level model overrides", () => {
 
       const first = await sendChatRun(actor, {
         agentId,
-        model: "gpt-5.6-terra",
+        model: route.selectedModel,
         prompt: "Terra standard start",
       });
       await waitForRunStatus(actor, first.runId, "completed");
@@ -16274,7 +16616,7 @@ describe("CHAT-02: run-level model overrides", () => {
       const fast = await sendChatRun(actor, {
         agentId,
         threadId: first.threadId,
-        model: "gpt-5.6-terra",
+        model: route.selectedModel,
         prompt: "Terra Fast continuation",
         runOptions: { codexServiceTier: "fast" },
       });
@@ -16288,13 +16630,13 @@ describe("CHAT-02: run-level model overrides", () => {
       await chat.updateThreadModelSelection(
         actor,
         first.threadId,
-        "gpt-5.6-terra",
+        route.selectedModel,
         { codexServiceTier: null },
       );
       const standard = await sendChatRun(actor, {
         agentId,
         threadId: first.threadId,
-        model: "gpt-5.6-terra",
+        model: route.selectedModel,
         prompt: "Terra standard return",
       });
       await waitForRunStatus(actor, standard.runId, "completed");
@@ -16348,7 +16690,7 @@ describe("CHAT-02: run-level model overrides", () => {
   );
 
   it.each(
-    USER_OWNED_TERRA_FAST_BDD_ROUTES.flatMap((route) => {
+    USER_OWNED_GPT_FAST_BDD_ROUTES.flatMap((route) => {
       return (["web", "agent"] as const).map((origin) => {
         return {
           route,
@@ -16376,7 +16718,7 @@ describe("CHAT-02: run-level model overrides", () => {
         "chat-event:read",
         "chat-event:write",
       ]);
-      const { secret, accountId } = await configureUserOwnedTerraPiModel(
+      const { secret, accountId } = await configureUserOwnedGptPiModel(
         actor,
         route,
       );
@@ -16399,7 +16741,7 @@ describe("CHAT-02: run-level model overrides", () => {
         threadId: anchor.threadId,
         clientEventId: queuedId,
         prompt: "queued Terra Fast",
-        model: "gpt-5.6-terra" as const,
+        model: route.selectedModel,
         runOptions: { codexServiceTier: "fast" as const },
       };
       const queued =
@@ -16453,7 +16795,7 @@ describe("CHAT-02: run-level model overrides", () => {
       const immediateBody = {
         agentId,
         prompt: "immediate Terra Fast",
-        model: "gpt-5.6-terra" as const,
+        model: route.selectedModel,
         runOptions: { codexServiceTier: "fast" as const },
       };
       const immediate =
@@ -16474,7 +16816,7 @@ describe("CHAT-02: run-level model overrides", () => {
   );
 
   it.each(
-    USER_OWNED_TERRA_FAST_BDD_ROUTES.flatMap((route) => {
+    USER_OWNED_GPT_FAST_BDD_ROUTES.flatMap((route) => {
       return (["in-flight", "late-result"] as const).map((phase) => {
         return {
           route,
@@ -16487,7 +16829,7 @@ describe("CHAT-02: run-level model overrides", () => {
     "keeps cancelled $name Fast $phase results unbilled and unreplayed",
     async ({ route, phase }) => {
       const { actor, agentId, runnerGroup } = await entitledChatActor();
-      const { secret, accountId } = await configureUserOwnedTerraPiModel(
+      const { secret, accountId } = await configureUserOwnedGptPiModel(
         actor,
         route,
       );
@@ -16512,7 +16854,7 @@ describe("CHAT-02: run-level model overrides", () => {
       );
       const run = await sendChatRun(actor, {
         agentId,
-        model: "gpt-5.6-terra",
+        model: route.selectedModel,
         prompt: "cancel Terra Fast ownership",
         runOptions: { codexServiceTier: "fast" },
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -768,7 +768,10 @@ function piResponsesToolSse(sequence: number): string {
     .join("");
 }
 
+type SlackPiModel = "gpt-5.6-terra" | "gpt-5.6-sol" | "gpt-5.6-luna";
+
 interface SlackPiActorSetup {
+  readonly selectedModel: SlackPiModel;
   readonly actor: ReturnType<typeof bdd.user>;
   readonly orgId: string;
   readonly runnerGroup: ReturnType<typeof runs.configureRunnerGroup>;
@@ -779,7 +782,9 @@ interface PiProviderRequest {
   readonly body: unknown;
 }
 
-async function configureCanonicalSlackPiActor(): Promise<SlackPiActorSetup> {
+async function configureCanonicalSlackPiActor(
+  selectedModel: SlackPiModel,
+): Promise<SlackPiActorSetup> {
   const actor = bdd.user();
   if (!actor.orgId) {
     throw new Error("Expected canonical Slack Pi actor to belong to an org");
@@ -808,7 +813,7 @@ async function configureCanonicalSlackPiActor(): Promise<SlackPiActorSetup> {
       modelProviderId: anthropicProviderId,
     },
     {
-      model: "gpt-5.6-terra",
+      model: selectedModel,
       isDefault: false,
       defaultProviderType: "openai-api-key",
       credentialScope: "org",
@@ -821,7 +826,7 @@ async function configureCanonicalSlackPiActor(): Promise<SlackPiActorSetup> {
     { [FeatureSwitchKey.PiLoop]: false },
   );
   await integrations.updateUserModelPreference(actor, "claude-sonnet-5");
-  return { actor, orgId, runnerGroup };
+  return { actor, orgId, runnerGroup, selectedModel };
 }
 
 async function establishCanonicalSlackHistory(args: SlackPiActorSetup) {
@@ -891,7 +896,7 @@ async function establishCanonicalSlackHistory(args: SlackPiActorSetup) {
   await chat.updateThreadModelSelection(
     args.actor,
     chatThreadId,
-    "gpt-5.6-terra",
+    args.selectedModel,
   );
   await updateFeatureSwitchesForUser(
     context,
@@ -985,7 +990,12 @@ async function expectFirstSlackPiExecution(args: {
   expect(args.providerRequests).toHaveLength(1);
   expect(args.providerRequests[0]).toMatchObject({
     authorization: "Bearer bdd-slack-terra-api-key",
-    body: { model: "gpt-5.6-terra", store: false, stream: true },
+    body: {
+      model: args.scenario.selectedModel,
+      store: false,
+      stream: true,
+      reasoning: { effort: "max" },
+    },
   });
   const providerInput = JSON.stringify(args.providerRequests[0]?.body);
   expect(providerInput).toContain("establish non-Pi Slack history");
@@ -2984,80 +2994,84 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(run2.result?.agentSessionId).toBe(webSessionId);
   });
 
-  it("admits canonical Slack turns into one Pi session without duplicate ownership", async () => {
-    mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);
-    const scenario = await establishCanonicalSlackHistory(
-      await configureCanonicalSlackPiActor(),
-    );
-    const providerRequests = mockCanonicalSlackPiProvider();
-    const firstTurn = await runFirstCanonicalSlackPiTurn(scenario);
-    const firstSessionId = await expectFirstSlackPiExecution({
-      scenario,
-      providerRequests,
-      turn: firstTurn,
-    });
-    await expectSlackPiOwnership({
-      scenario,
-      runId: firstTurn.runId,
-      assistantText: "Canonical Slack Pi answer",
-    });
-    const firstCandidate = await expectSlackPiMemoryCandidate({
-      scenario,
-      runId: firstTurn.runId,
-      outcome: "created",
-    });
-    const continuedTurn = await claimContinuedSlackPiTurn({
-      scenario,
-      providerRequests,
-      firstPrompt: firstTurn.prompt,
-      firstSessionId,
-    });
-    await cancelContinuedSlackPiTurn({
-      scenario,
-      providerRequests,
-      turn: continuedTurn,
-    });
-    await expect(
-      readPiMemoryStage1CandidateFixture({
+  it.each(["gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.6-luna"] as const)(
+    "admits canonical Slack %s turns into one Pi session without duplicate ownership",
+    async (selectedModel) => {
+      mockEnv("PI_MEMORY_STAGE1_IDLE_DELAY_MS", 60_000);
+      const scenario = await establishCanonicalSlackHistory(
+        await configureCanonicalSlackPiActor(selectedModel),
+      );
+      const providerRequests = mockCanonicalSlackPiProvider();
+      const firstTurn = await runFirstCanonicalSlackPiTurn(scenario);
+      const firstSessionId = await expectFirstSlackPiExecution({
+        scenario,
+        providerRequests,
+        turn: firstTurn,
+      });
+      await expectSlackPiOwnership({
+        scenario,
+        runId: firstTurn.runId,
+        assistantText: "Canonical Slack Pi answer",
+      });
+      const firstCandidate = await expectSlackPiMemoryCandidate({
+        scenario,
+        runId: firstTurn.runId,
+        outcome: "created",
+      });
+      const continuedTurn = await claimContinuedSlackPiTurn({
+        scenario,
+        providerRequests,
+        firstPrompt: firstTurn.prompt,
+        firstSessionId,
+      });
+      await cancelContinuedSlackPiTurn({
+        scenario,
+        providerRequests,
+        turn: continuedTurn,
+      });
+      await expect(
+        readPiMemoryStage1CandidateFixture({
+          orgId: scenario.orgId,
+          userId: scenario.actor.userId,
+        }),
+      ).resolves.toStrictEqual(firstCandidate);
+
+      const successfulContinuation = await runSuccessfulContinuedSlackPiTurn({
+        scenario,
+        providerRequests,
+        firstPrompt: firstTurn.prompt,
+        firstSessionId,
+      });
+      await expectSlackPiOwnership({
+        scenario,
+        runId: successfulContinuation.runId,
+        assistantText: "Continued Slack Pi answer",
+      });
+      const replacedCandidate = await expectSlackPiMemoryCandidate({
+        scenario,
+        runId: successfulContinuation.runId,
+        outcome: "replaced",
+      });
+      expect(replacedCandidate).toMatchObject({
+        memoryStorageId: firstCandidate.memoryStorageId,
+        piSessionId: firstCandidate.piSessionId,
+      });
+      expect(replacedCandidate.sourceHistoryHash).not.toBe(
+        firstCandidate.sourceHistoryHash,
+      );
+      await expect(
+        readmitPiMemoryStage1CandidateFixture(successfulContinuation.runId),
+      ).resolves.toMatchObject({ outcome: "exact_retry" });
+      const afterExactRetry = await readPiMemoryStage1CandidateFixture({
         orgId: scenario.orgId,
         userId: scenario.actor.userId,
-      }),
-    ).resolves.toStrictEqual(firstCandidate);
-
-    const successfulContinuation = await runSuccessfulContinuedSlackPiTurn({
-      scenario,
-      providerRequests,
-      firstPrompt: firstTurn.prompt,
-      firstSessionId,
-    });
-    await expectSlackPiOwnership({
-      scenario,
-      runId: successfulContinuation.runId,
-      assistantText: "Continued Slack Pi answer",
-    });
-    const replacedCandidate = await expectSlackPiMemoryCandidate({
-      scenario,
-      runId: successfulContinuation.runId,
-      outcome: "replaced",
-    });
-    expect(replacedCandidate).toMatchObject({
-      memoryStorageId: firstCandidate.memoryStorageId,
-      piSessionId: firstCandidate.piSessionId,
-    });
-    expect(replacedCandidate.sourceHistoryHash).not.toBe(
-      firstCandidate.sourceHistoryHash,
-    );
-    await expect(
-      readmitPiMemoryStage1CandidateFixture(successfulContinuation.runId),
-    ).resolves.toMatchObject({ outcome: "exact_retry" });
-    const afterExactRetry = await readPiMemoryStage1CandidateFixture({
-      orgId: scenario.orgId,
-      userId: scenario.actor.userId,
-    });
-    expect(afterExactRetry?.updatedAt).toStrictEqual(
-      replacedCandidate.updatedAt,
-    );
-  }, 90_000);
+      });
+      expect(afterExactRetry?.updatedAt).toStrictEqual(
+        replacedCandidate.updatedAt,
+      );
+    },
+    90_000,
+  );
 
   it("keeps canonical Slack status stable across failed delivery and cancellation", async () => {
     const actor = bdd.user();

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -59,7 +59,7 @@ import {
   admitPiMemoryStage1Candidate,
   type PiMemoryStage1Admission,
 } from "./pi-memory-stage1-candidate.service";
-import { isStandardTerraApiKeyPiProviderType } from "./pi-sandbox-config";
+import { isGptApiKeyPiProviderType } from "./pi-sandbox-config";
 import { transitionAgentRunsToTerminal } from "./agent-run-terminal-transition.service";
 
 type WebhookCompleteBody = z.infer<
@@ -171,14 +171,14 @@ type CompletionTransactionResult =
 
 const L = logger("webhook:complete");
 
-function logStandardTerraApiKeyPiSandboxOutcome(
+function logGptApiKeyPiSandboxOutcome(
   input: CompleteAgentRunInput,
   commit: CompletionCommit,
 ): boolean {
   if (
     input.executionOwner === "api-first" ||
     commit.run.launchSnapshot?.framework !== "pi" ||
-    !isStandardTerraApiKeyPiProviderType(commit.run.modelProvider)
+    !isGptApiKeyPiProviderType(commit.run.modelProvider)
   ) {
     return false;
   }
@@ -245,10 +245,7 @@ function logAgentRunCompletionOutcome(
   input: CompleteAgentRunInput,
   commit: CompletionCommit,
 ): void {
-  const loggedPiSandboxFailure = logStandardTerraApiKeyPiSandboxOutcome(
-    input,
-    commit,
-  );
+  const loggedPiSandboxFailure = logGptApiKeyPiSandboxOutcome(input, commit);
   if (commit.responseStatus === "completed") {
     L.debug("Run completed successfully", { runId: input.body.runId });
     return;

--- a/turbo/apps/api/src/signals/services/pi-api-first-turn-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/pi-api-first-turn-usage.service.ts
@@ -8,28 +8,25 @@ import { inArray } from "drizzle-orm";
 import { v5 as uuidv5 } from "uuid";
 
 import type { Db } from "../external/db";
+import { isPiGptModel, type PiGptModel } from "./pi-gpt-model";
 
 const PI_API_FIRST_TURN_USAGE_NAMESPACE =
   "26e1c547-485d-4438-bf6d-4b77959da0cb";
-const TERRA_MODEL = "gpt-5.6-terra";
 const DEEPSEEK_FLASH_MODEL = "deepseek-v4-flash";
 const DEEPSEEK_PRO_MODEL = "deepseek-v4-pro";
 
 type PiApiFirstTurnUsageProvider =
-  | typeof TERRA_MODEL
+  | PiGptModel
   | typeof DEEPSEEK_FLASH_MODEL
   | typeof DEEPSEEK_PRO_MODEL;
 
-function terraLongContextMinimumInputTokens(): number {
-  const minimum = MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS[TERRA_MODEL];
+function gptLongContextMinimumInputTokens(model: PiGptModel): number {
+  const minimum = MODEL_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS[model];
   if (minimum === undefined) {
-    throw new Error("Terra long-context pricing threshold is missing");
+    throw new Error(`${model} long-context pricing threshold is missing`);
   }
   return minimum;
 }
-
-const TERRA_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS =
-  terraLongContextMinimumInputTokens();
 
 type PiUsageCategoryBase =
   | "tokens.input"
@@ -76,7 +73,8 @@ function idempotencyKey(namespace: string, parts: readonly string[]): string {
   return uuidv5(JSON.stringify(parts), namespace);
 }
 
-function terraApiFirstTurnUsageEntries(
+function gptApiFirstTurnUsageEntries(
+  model: PiGptModel,
   turn: PiApiFirstTurnResult,
   fast: boolean,
 ): readonly PiApiFirstTurnUsageEntry[] {
@@ -87,7 +85,7 @@ function terraApiFirstTurnUsageEntries(
   const cacheCreation = usageQuantity(usage.cacheWrite, "cache-creation");
   const longContext =
     input + cacheRead + cacheCreation >=
-    TERRA_LONG_CONTEXT_MIN_TOTAL_INPUT_TOKENS;
+    gptLongContextMinimumInputTokens(model);
   const category = (base: PiUsageCategoryBase): PiUsageCategory => {
     if (longContext) {
       return fast ? `${base}.long_context.fast` : `${base}.long_context`;
@@ -148,7 +146,7 @@ function piApiFirstTurnUsageProvider(
   provider: string | undefined,
 ): PiApiFirstTurnUsageProvider | null {
   if (
-    provider === TERRA_MODEL ||
+    isPiGptModel(provider) ||
     provider === DEEPSEEK_FLASH_MODEL ||
     provider === DEEPSEEK_PRO_MODEL
   ) {
@@ -186,10 +184,13 @@ export async function recordPiApiFirstTurnUsage(
     return;
   }
   const responseSourceId = sourceId(args.turn);
-  const entries =
-    provider === TERRA_MODEL
-      ? terraApiFirstTurnUsageEntries(args.turn, isFastPiApiFirstTurn(args))
-      : deepSeekApiFirstTurnUsageEntries(args.turn);
+  const entries = isPiGptModel(provider)
+    ? gptApiFirstTurnUsageEntries(
+        provider,
+        args.turn,
+        isFastPiApiFirstTurn(args),
+      )
+    : deepSeekApiFirstTurnUsageEntries(args.turn);
   const usageRows = entries.map((entry) => {
     return {
       runId: args.runId,

--- a/turbo/apps/api/src/signals/services/pi-gpt-model.ts
+++ b/turbo/apps/api/src/signals/services/pi-gpt-model.ts
@@ -1,0 +1,12 @@
+export type PiGptModel = "gpt-5.6-terra" | "gpt-5.6-sol" | "gpt-5.6-luna";
+
+/** Pi admission and API-owned billing must expand together. */
+export function isPiGptModel(
+  model: string | null | undefined,
+): model is PiGptModel {
+  return (
+    model === "gpt-5.6-terra" ||
+    model === "gpt-5.6-sol" ||
+    model === "gpt-5.6-luna"
+  );
+}

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -21,6 +21,7 @@ import { isPiAgentModelSupported } from "@okouai/pi-agent-runtime";
 
 import type { BuiltInModelRuntimeRoute } from "./built-in-model-runtime-route.service";
 import { GATEWAY_RUNTIME_SECRET_NAME } from "./model-provider-gateway-runtime";
+import { isPiGptModel } from "./pi-gpt-model";
 
 /**
  * Resolve non-secret model metadata shared by the sandbox Pi runtime and the
@@ -40,18 +41,18 @@ interface PiRuntimeContract {
 
 type PiCatalogProvider = "deepseek" | "openai";
 
-const STANDARD_TERRA_API_KEY_PI_ROUTES = {
+const GPT_API_KEY_PI_ROUTES = {
   "openai-api-key": {
     productProviderType: "openai-api-key",
     provider: "openai",
-    model: "gpt-5.6-terra",
+    modelPrefix: "",
     endpoint: getModelProviderPiEndpoint("openai-api-key", "openai-responses"),
     credentialSecretName: "OPENAI_API_KEY",
   },
   "openrouter-codex": {
     productProviderType: "openrouter-codex",
     provider: "openrouter",
-    model: "openai/gpt-5.6-terra",
+    modelPrefix: "openai/",
     endpoint: getModelProviderPiEndpoint(
       "openrouter-codex",
       "openai-responses",
@@ -61,8 +62,7 @@ const STANDARD_TERRA_API_KEY_PI_ROUTES = {
   "vercel-ai-gateway-codex": {
     productProviderType: "vercel-ai-gateway-codex",
     provider: "openai",
-    catalogModel: "gpt-5.6-terra",
-    model: "openai/gpt-5.6-terra",
+    modelPrefix: "openai/",
     endpoint: getModelProviderPiEndpoint(
       "vercel-ai-gateway-codex",
       "openai-responses",
@@ -71,39 +71,34 @@ const STANDARD_TERRA_API_KEY_PI_ROUTES = {
   },
 } as const;
 
-type StandardTerraApiKeyPiProviderType =
-  keyof typeof STANDARD_TERRA_API_KEY_PI_ROUTES;
+type GptApiKeyPiProviderType = keyof typeof GPT_API_KEY_PI_ROUTES;
 
-export function isStandardTerraApiKeyPiProviderType(
+export function isGptApiKeyPiProviderType(
   value: string | null | undefined,
-): value is StandardTerraApiKeyPiProviderType {
+): value is GptApiKeyPiProviderType {
   return (
     value !== null &&
     value !== undefined &&
-    Object.hasOwn(STANDARD_TERRA_API_KEY_PI_ROUTES, value)
+    Object.hasOwn(GPT_API_KEY_PI_ROUTES, value)
   );
 }
 
-function standardTerraApiKeyPiRoute(
+function gptApiKeyPiRoute(
   value: string | null | undefined,
-):
-  | (typeof STANDARD_TERRA_API_KEY_PI_ROUTES)[StandardTerraApiKeyPiProviderType]
-  | null {
-  return isStandardTerraApiKeyPiProviderType(value)
-    ? STANDARD_TERRA_API_KEY_PI_ROUTES[value]
-    : null;
+): (typeof GPT_API_KEY_PI_ROUTES)[GptApiKeyPiProviderType] | null {
+  return isGptApiKeyPiProviderType(value) ? GPT_API_KEY_PI_ROUTES[value] : null;
 }
 
 function piCatalogProvider(
   selectedModel: string | null | undefined,
 ): PiCatalogProvider | null {
+  if (isPiGptModel(selectedModel)) {
+    return "openai";
+  }
   switch (selectedModel) {
     case "deepseek-v4-flash":
     case "deepseek-v4-pro": {
       return "deepseek";
-    }
-    case "gpt-5.6-terra": {
-      return "openai";
     }
     default: {
       return null;
@@ -116,7 +111,7 @@ function piRuntimeContract(args: {
   readonly selectedModel: string;
   readonly codexServiceTier: "fast" | undefined;
 }): PiRuntimeContract {
-  if (args.selectedModel === "gpt-5.6-terra") {
+  if (isPiGptModel(args.selectedModel)) {
     return {
       api: "openai-responses",
       thinkingLevel: "max",
@@ -148,13 +143,13 @@ function piProvider(
   }
 }
 
-function isFastTerraPiProvider(
+function isFastGptPiProvider(
   modelProviderType: string | null | undefined,
   builtInModelRuntimeRoute: BuiltInModelRuntimeRoute | undefined,
 ): boolean {
   return (
     modelProviderType === "codex-oauth-token" ||
-    isStandardTerraApiKeyPiProviderType(modelProviderType) ||
+    isGptApiKeyPiProviderType(modelProviderType) ||
     (isBuiltInModelProviderType(modelProviderType) &&
       (builtInModelRuntimeRoute?.providerType === "openai-api-key" ||
         builtInModelRuntimeRoute?.providerType === "openrouter-codex"))
@@ -175,12 +170,12 @@ export function shouldUsePiExecution(args: {
 }): boolean {
   const catalogProvider = piCatalogProvider(args.selectedModel);
   const isExistingPiModel = catalogProvider === "deepseek";
-  const isStandardTerra =
+  const isStandardGpt =
     catalogProvider === "openai" && args.codexServiceTier === undefined;
-  const isFastTerra =
+  const isFastGpt =
     catalogProvider === "openai" &&
     args.codexServiceTier === "fast" &&
-    isFastTerraPiProvider(
+    isFastGptPiProvider(
       args.modelProviderType,
       args.builtInModelRuntimeRoute,
     ) &&
@@ -189,14 +184,14 @@ export function shouldUsePiExecution(args: {
     isBuiltInModelProviderType(args.modelProviderType) ||
     args.modelProviderType === "custom-openai-responses" ||
     (args.modelProviderType === "codex-oauth-token" &&
-      (isStandardTerra || isFastTerra)) ||
-    (standardTerraApiKeyPiRoute(args.modelProviderType) !== null &&
-      (isStandardTerra || isFastTerra));
+      (isStandardGpt || isFastGpt)) ||
+    (gptApiKeyPiRoute(args.modelProviderType) !== null &&
+      (isStandardGpt || isFastGpt));
   return (
     args.chatThreadId !== undefined &&
     args.chatThreadId.length > 0 &&
     isPiModelProvider &&
-    (isExistingPiModel || isStandardTerra || isFastTerra) &&
+    (isExistingPiModel || isStandardGpt || isFastGpt) &&
     isFeatureEnabled(FeatureSwitchKey.PiLoop, args.featureSwitchContext)
   );
 }
@@ -216,12 +211,12 @@ function resolveCodexSubscriptionPiModelConfig(
 ): PiModelConfig | null {
   if (
     provider.type !== "codex-oauth-token" ||
-    provider.selectedModel !== "gpt-5.6-terra" ||
+    !isPiGptModel(provider.selectedModel) ||
     provider.inlineFirewall === true ||
     provider.credentialHeader !== undefined ||
     (provider.concreteType !== undefined &&
       provider.concreteType !== "codex-oauth-token") ||
-    provider.environment.OPENAI_MODEL !== "gpt-5.6-terra" ||
+    provider.environment.OPENAI_MODEL !== provider.selectedModel ||
     !provider.environment.CHATGPT_ACCESS_TOKEN?.trim() ||
     !provider.environment.CHATGPT_ACCOUNT_ID?.trim()
   ) {
@@ -252,7 +247,7 @@ function resolveCodexSubscriptionPiModelConfig(
     transport: "sse",
     provider: "openai-codex",
     baseUrl: endpoint.baseUrl,
-    model: "gpt-5.6-terra",
+    model: provider.selectedModel,
     thinkingLevel: "max",
     credentialBindings: [
       {
@@ -328,14 +323,14 @@ function resolveCustomGatewayPiModelConfig(
     : null;
 }
 
-function resolveStandardTerraApiKeyPiModelConfig(
+function resolveGptApiKeyPiModelConfig(
   provider: PiModelProviderConfigInput,
   codexServiceTier: "fast" | undefined,
 ): PiModelConfig | null {
-  const route = standardTerraApiKeyPiRoute(provider.type);
+  const route = gptApiKeyPiRoute(provider.type);
   if (
     !route ||
-    provider.selectedModel !== "gpt-5.6-terra" ||
+    !isPiGptModel(provider.selectedModel) ||
     provider.inlineFirewall === true ||
     provider.credentialHeader !== undefined ||
     (provider.concreteType !== undefined &&
@@ -343,7 +338,8 @@ function resolveStandardTerraApiKeyPiModelConfig(
     !route.endpoint ||
     getSecretNameForType(route.productProviderType) !==
       route.credentialSecretName ||
-    provider.environment.OPENAI_MODEL !== route.model ||
+    provider.environment.OPENAI_MODEL !==
+      `${route.modelPrefix}${provider.selectedModel}` ||
     !provider.environment.OPENAI_API_KEY?.trim()
   ) {
     return null;
@@ -368,9 +364,9 @@ function resolveStandardTerraApiKeyPiModelConfig(
     transport: "sse",
     provider: route.provider,
     baseUrl: route.endpoint.baseUrl,
-    model: route.model,
+    model: `${route.modelPrefix}${provider.selectedModel}`,
     ...(route.productProviderType === "vercel-ai-gateway-codex"
-      ? { catalogModel: route.catalogModel }
+      ? { catalogModel: provider.selectedModel }
       : {}),
     thinkingLevel: "max",
     credentialBindings: [
@@ -409,8 +405,8 @@ export function resolvePiSandboxModelConfig(
   if (provider.type === "custom-openai-responses") {
     return resolveCustomGatewayPiModelConfig(provider, codexServiceTier);
   }
-  if (isStandardTerraApiKeyPiProviderType(provider.type)) {
-    return resolveStandardTerraApiKeyPiModelConfig(provider, codexServiceTier);
+  if (isGptApiKeyPiProviderType(provider.type)) {
+    return resolveGptApiKeyPiModelConfig(provider, codexServiceTier);
   }
   if (provider.inlineFirewall) {
     return null;

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
@@ -15,6 +15,9 @@ import type { PiPreheatedResourceSnapshot } from "./api-types";
 import type { PiAgentRequestHeaders } from "./types";
 import { materializePiAgentModelConfig } from "./credential";
 import { resumePiApiFirstTurn } from "./rpc";
+import { createPiApiFirstTurnOwnership, runPiApiFirstTurn } from "./api";
+
+const GPT_MODELS = ["gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.6-luna"] as const;
 
 const TERRA_MODEL = {
   provider: "openai" as const,
@@ -484,60 +487,56 @@ describe("official Pi AgentSession runtime", () => {
     },
   );
 
-  it.each([
-    {
-      name: "standard subscription",
-      provider: "openai-codex",
-      dialect: "openai-codex-responses",
-      model: "gpt-5.6-terra",
-      basePath: "/backend-api",
-      endpoint: "/backend-api/codex/responses",
-      tier: undefined,
-      secretName: "CHATGPT_ACCESS_TOKEN",
-    },
-    {
-      name: "Fast subscription",
-      provider: "openai-codex",
-      dialect: "openai-codex-responses",
-      model: "gpt-5.6-terra",
-      basePath: "/backend-api",
-      endpoint: "/backend-api/codex/responses",
-      tier: "fast",
-      secretName: "CHATGPT_ACCESS_TOKEN",
-    },
-    {
-      name: "OpenAI API key",
-      provider: "openai",
-      dialect: "openai-responses",
-      model: "gpt-5.6-terra",
-      basePath: "/v1",
-      endpoint: "/v1/responses",
-      tier: "priority",
-      secretName: "OPENAI_API_KEY",
-    },
-    {
-      name: "OpenRouter API key",
-      provider: "openrouter",
-      dialect: "openai-responses",
-      model: "openai/gpt-5.6-terra",
-      basePath: "/api/v1",
-      endpoint: "/api/v1/responses",
-      tier: "priority",
-      secretName: "OPENROUTER_API_KEY",
-    },
-    {
-      name: "Vercel API key",
-      provider: "openai",
-      dialect: "openai-responses",
-      model: "openai/gpt-5.6-terra",
-      catalogModel: "gpt-5.6-terra",
-      basePath: "/v1",
-      endpoint: "/v1/responses",
-      tier: "priority",
-      secretName: "VERCEL_AI_GATEWAY_API_KEY",
-    },
-  ] as const)(
-    "preserves $name request policy on every Sandbox turn after pending tools",
+  it.each(
+    GPT_MODELS.flatMap((selectedModel) => {
+      return ([undefined, "priority"] as const).flatMap((tier) => {
+        return [
+          {
+            name: "subscription",
+            provider: "openai-codex",
+            dialect: "openai-codex-responses",
+            model: selectedModel,
+            basePath: "/backend-api",
+            endpoint: "/backend-api/codex/responses",
+            tier: tier === undefined ? undefined : "fast",
+            secretName: "CHATGPT_ACCESS_TOKEN",
+          },
+          {
+            name: "OpenAI API key",
+            provider: "openai",
+            dialect: "openai-responses",
+            model: selectedModel,
+            basePath: "/v1",
+            endpoint: "/v1/responses",
+            tier,
+            secretName: "OPENAI_API_KEY",
+          },
+          {
+            name: "OpenRouter API key",
+            provider: "openrouter",
+            dialect: "openai-responses",
+            model: `openai/${selectedModel}`,
+            basePath: "/api/v1",
+            endpoint: "/api/v1/responses",
+            tier,
+            secretName: "OPENROUTER_API_KEY",
+          },
+          {
+            name: "Vercel API key",
+            provider: "openai",
+            dialect: "openai-responses",
+            model: `openai/${selectedModel}`,
+            catalogModel: selectedModel,
+            basePath: "/v1",
+            endpoint: "/v1/responses",
+            tier,
+            secretName: "VERCEL_AI_GATEWAY_API_KEY",
+          },
+        ] as const;
+      });
+    }),
+  )(
+    "preserves $name $model $tier request policy on every Sandbox turn after pending tools",
     async (route) => {
       const cwd = await mkdtemp(join(tmpdir(), "pi-user-owned-fast-"));
       onTestFinished(async () => {
@@ -545,26 +544,21 @@ describe("official Pi AgentSession runtime", () => {
       });
       const toolFile = join(cwd, "terra.txt");
       await writeFile(toolFile, "Terra tool result", "utf8");
-      const provider = await startResponsesProvider();
+      const provider = await startResponsesProvider(
+        (response, requestNumber) => {
+          if (requestNumber === 1) {
+            responsesToolSse(response, {
+              callId: "call_read",
+              name: "read",
+              arguments: { path: toolFile },
+            });
+          } else {
+            responsesTextSse(response, "Sandbox answer");
+          }
+        },
+      );
       onTestFinished(async () => {
         await provider.close();
-      });
-      const sessionManager = SessionManager.inMemory(cwd, {
-        id: randomUUID(),
-      });
-      sessionManager.appendMessage({
-        role: "user",
-        content: "run the pending Terra tool",
-        timestamp: 1,
-      });
-      sessionManager.appendMessage({
-        ...fauxAssistantMessage(fauxToolCall("read", { path: toolFile }), {
-          stopReason: "toolUse",
-          timestamp: 2,
-        }),
-        api: route.dialect,
-        provider: route.provider,
-        model: route.model,
       });
       const model = await materializePiAgentModelConfig({
         target: "sandbox-firewall",
@@ -594,8 +588,9 @@ describe("official Pi AgentSession runtime", () => {
                 ],
               }
             : {
-                schemaVersion: 3,
-                serviceTier: route.tier,
+                ...(route.tier === undefined
+                  ? { schemaVersion: 2 as const }
+                  : { schemaVersion: 3 as const, serviceTier: route.tier }),
                 dialect: route.dialect,
                 provider: route.provider,
                 model: route.model,
@@ -616,6 +611,21 @@ describe("official Pi AgentSession runtime", () => {
         },
       });
       expect(model.serviceTier).toBe(route.tier);
+      const firstTurn = await runPiApiFirstTurn({
+        ownership: createPiApiFirstTurnOwnership(),
+        cwd,
+        agentDir: join(cwd, ".pi"),
+        sessionId: randomUUID(),
+        prompt: "read the tool file and answer",
+        appendSystemPrompt: null,
+        model,
+        resourceSnapshot: EMPTY_RESOURCE_SNAPSHOT,
+      });
+      expect(firstTurn.handoffRequired).toBe(true);
+      expect(provider.requests).toHaveLength(1);
+      const sessionFile = join(cwd, "session.jsonl");
+      await writeFile(sessionFile, firstTurn.sessionJsonl, "utf8");
+      const sessionManager = SessionManager.open(sessionFile);
       const created = await createPiAgentSessionForRuntime({
         cwd,
         agentDir: join(cwd, ".pi"),
@@ -627,7 +637,7 @@ describe("official Pi AgentSession runtime", () => {
       try {
         await resumePiApiFirstTurn(created.session);
         await created.session.prompt("continue the same Sandbox session");
-        expect(provider.requests).toHaveLength(2);
+        expect(provider.requests).toHaveLength(3);
         for (const request of provider.requests) {
           expect(request).toMatchObject({
             url: route.endpoint,
@@ -649,6 +659,11 @@ describe("official Pi AgentSession runtime", () => {
             expect(request.body).toMatchObject({ service_tier: "priority" });
           }
           expect(request.body).not.toHaveProperty("previous_response_id");
+        }
+        expect(JSON.stringify(provider.requests[0]?.body)).not.toContain(
+          "Terra tool result",
+        );
+        for (const request of provider.requests.slice(1)) {
           expect(JSON.stringify(request.body)).toContain("Terra tool result");
         }
         expect(
@@ -880,20 +895,37 @@ describe("official Pi AgentSession runtime", () => {
     }
   });
 
-  it.each([
-    {
-      name: "standard",
-      api: "openai-completions",
-      serviceTier: undefined,
-    },
-    {
-      name: "fast",
-      api: "openai-codex-responses",
-      serviceTier: "priority",
-    },
-  ] as const)(
-    "normalizes legacy transport for $name Sandbox turns",
-    async ({ api, serviceTier }) => {
+  it.each(
+    GPT_MODELS.flatMap((selectedModel) => {
+      return [
+        {
+          name: "standard",
+          selectedModel,
+          api: "openai-completions",
+          serviceTier: undefined,
+        },
+        {
+          name: "fast",
+          selectedModel,
+          api: "openai-codex-responses",
+          serviceTier: "priority",
+        },
+      ] as const;
+    }).flatMap((route) => {
+      return (["openai", "openrouter"] as const).map((provider) => {
+        return {
+          ...route,
+          provider,
+          model:
+            provider === "openrouter"
+              ? `openai/${route.selectedModel}`
+              : route.selectedModel,
+        };
+      });
+    }),
+  )(
+    "normalizes legacy transport for $name $provider $model Sandbox turns",
+    async ({ api, serviceTier, provider: catalogProvider, model }) => {
       const provider = await startResponsesProvider();
       const sessionManager = SessionManager.inMemory("/home/user/workspace", {
         id: "00000000-0000-4000-8000-000000000126",
@@ -904,6 +936,8 @@ describe("official Pi AgentSession runtime", () => {
         sessionManager,
         model: {
           ...TERRA_MODEL,
+          provider: catalogProvider,
+          model,
           baseUrl: provider.baseUrl,
           api,
           ...(serviceTier === undefined ? {} : { serviceTier }),
@@ -919,7 +953,7 @@ describe("official Pi AgentSession runtime", () => {
         expect(provider.requests[0]).toMatchObject({
           url: "/v1/responses",
           body: {
-            model: "gpt-5.6-terra",
+            model,
             reasoning: { effort: "max" },
           },
         });
@@ -937,23 +971,61 @@ describe("official Pi AgentSession runtime", () => {
     },
   );
 
-  it.each(CUSTOM_GATEWAY_CREDENTIAL_CASES)(
-    "uses the stable Pi identity with the custom gateway request model and $name credential header",
-    async ({ sessionId, requestHeaders, authorization, apiKey }) => {
+  it.each(
+    CUSTOM_GATEWAY_CREDENTIAL_CASES.flatMap((credential) => {
+      return (["deepseek-v4-flash", ...GPT_MODELS] as const).map(
+        (selectedModel) => {
+          return { ...credential, selectedModel };
+        },
+      );
+    }),
+  )(
+    "uses the stable Pi identity with the custom gateway request model and $name credential header for $selectedModel",
+    async ({
+      sessionId,
+      requestHeaders,
+      authorization,
+      apiKey,
+      selectedModel,
+    }) => {
+      const cwd = await mkdtemp(join(tmpdir(), "pi-custom-standard-"));
+      onTestFinished(async () => {
+        await rm(cwd, { recursive: true, force: true });
+      });
+      const toolFile = join(cwd, "gateway.txt");
+      await writeFile(toolFile, "custom gateway tool result", "utf8");
       const provider = await startResponsesProvider();
-      const sessionManager = SessionManager.inMemory("/home/user/workspace", {
+      const sessionManager = SessionManager.inMemory(cwd, {
         id: sessionId,
       });
+      sessionManager.appendMessage({
+        role: "user",
+        content: "read the gateway tool file",
+        timestamp: 1,
+      });
+      sessionManager.appendMessage({
+        ...fauxAssistantMessage(fauxToolCall("read", { path: toolFile }), {
+          stopReason: "toolUse",
+          timestamp: 2,
+        }),
+        api: "openai-responses",
+        provider: selectedModel === "deepseek-v4-flash" ? "deepseek" : "openai",
+        model: `company-${selectedModel}-production`,
+      });
       const created = await createPiAgentSessionForRuntime({
-        cwd: "/home/user/workspace",
-        agentDir: "/home/user/.pi/agent",
+        cwd,
+        agentDir: join(cwd, ".pi"),
         sessionManager,
         model: {
-          provider: "deepseek",
+          provider:
+            selectedModel === "deepseek-v4-flash" ? "deepseek" : "openai",
           baseUrl: provider.baseUrl,
           apiKey: "unused",
-          model: "company-deepseek-production",
-          catalogModel: "deepseek-v4-flash",
+          model: `company-${selectedModel}-production`,
+          catalogModel: selectedModel,
+          ...(selectedModel === "deepseek-v4-flash"
+            ? {}
+            : { thinkingLevel: "max" as const }),
           api: "openai-responses",
           dialect: "openai-responses",
           requestHeaders,
@@ -963,7 +1035,7 @@ describe("official Pi AgentSession runtime", () => {
       });
 
       try {
-        await created.session.prompt("answer through the custom gateway");
+        await resumePiApiFirstTurn(created.session);
 
         expect(provider.requests).toStrictEqual([
           expect.objectContaining({
@@ -972,10 +1044,19 @@ describe("official Pi AgentSession runtime", () => {
             apiKey,
             userAgent: "okou-pi-agent/1.0",
             body: expect.objectContaining({
-              model: "company-deepseek-production",
+              model: `company-${selectedModel}-production`,
             }),
           }),
         ]);
+        expect(JSON.stringify(provider.requests[0]?.body)).toContain(
+          "custom gateway tool result",
+        );
+        expect(provider.requests[0]?.body).not.toHaveProperty("service_tier");
+        if (selectedModel !== "deepseek-v4-flash") {
+          expect(provider.requests[0]?.body).toMatchObject({
+            reasoning: { effort: "max" },
+          });
+        }
       } finally {
         created.session.dispose();
         await provider.close();


### PR DESCRIPTION
## Summary

Sol and Luna currently stay outside PiLoop, and simply admitting them would either retain Terra's upstream model or omit Built-in API-first usage. This change uses one exact Terra/Sol/Luna policy for admission and first-turn accounting, derives each existing provider's upstream alias from the selected model, and bills the response under that same logical identity.

Closes #32501. Parent: #32500, slice 1 of 2. Custom Responses Fast for all three models remains the required next slice and is intentionally not activated here.

## Scope and compatibility

- Enable Sol/Luna standard and Fast on Built-in OpenAI and its managed OpenRouter fallback, native ChatGPT subscription, OpenAI API keys, OpenRouter API keys, and Vercel AI Gateway. Enable custom Responses standard with the configured upstream alias and credential header/template.
- Preserve explicit public/native Responses dialects and `max` reasoning. Native subscription Fast keeps carrier `fast` and wire `priority`; public Fast uses `priority`; standard omits the tier. OpenRouter's catalog default cannot override the explicit Responses contract.
- Keep exact endpoint, model, credential/account, and claim-generation checks. Existing standard generation 2, Fast generation 3, and Built-in/custom legacy writers are unchanged. The installed Pi SDK 0.84.1 already contains all three models; no SDK or carrier-generation change is needed.
- Record Built-in input/output/cache-read/cache-creation under the selected model and its canonical 272,001-total-input threshold, including `.fast`, `.long_context`, and `.long_context.fast`. Preserve direct OpenAI requested-tier and OpenRouter observed-tier billing, collision checking, late cancellation, and independent API-first/Sandbox usage identities. User-owned routes remain free of Built-in model charges.
- Preserve existing PiLoop/Fast switches, captured admission, then-current source policy, and normal Pi memory eligibility. Independent Terra Stage 1/Phase 2 maintenance models remain fixed. No defaults, entitlement, prices, UI, schema, migrations, or historical backfill change.

## Verification and blast radius

- Targeted API BDD selections: 168 passed for routing, carriers, claims, credentials, queueing, cancellation, and billing; 20 passed for additional Slack, captured admission, model/session, memory, and custom-standard/Fast-boundary cases; 32 passed for incomplete output, observed-tier, and standard/Fast session regressions. These selections overlap and are not a unique-test total.
- Pi runtime `session-runtime.test.ts`, `model.test.ts`, and `credential.test.ts`: 87 passed. Includes a real API-first tool response serialized to JSONL, resumed by the Sandbox AgentSession with an actual filesystem tool, followed by further provider requests across each model/provider/tier combination; also covers Built-in legacy transport and custom standard headers/aliases.
- API and Pi runtime package type checks, lint, changed-file Prettier, affected-workspace Knip, and `git diff --check` passed.
- API BDD tests used a real local PostgreSQL database with repository migrations and UTC session timezone. Provider responses and infrastructure boundaries were controlled test doubles; no live provider, production canary, or release verification is claimed. No full local Vitest suite or local dev server was run. Full integration coverage remains the PR pipeline's responsibility.
- Runner E2E static contract check `bash .github/scripts/tests/turbo-playwright-runner-workflow-test.sh` passed. The deployed fallback test retains its Codex boundary using out-of-scope Astra; its previous Luna/Codex assertion was invalid after this activation. Runner BATS execution is CI-only.
- Re-searched the full repository for model assumptions and every admission/config/billing caller, including direct and queued chat, captured preparation, runtime catalog/transport, MITM settlement, memory maintenance, deployed BATS tests, and hidden workflow/scripts paths. The obsolete Sol-as-Codex boundary now uses out-of-scope Astra and preserves its assertions.
- Latest overlap inventory found #32509 in chat BDD and #32484 in chat/integration BDD. #32409 has since merged. These are overlap inventory only; no ordering dependency or modifications to another PR.

## Frozen production scale

The issue's MaskDB snapshot covers `[2026-09-01T03:48:00Z, 2026-09-08T03:48:00Z)`: 50,784 unique Terra/Sol/Luna runs, including their aliases and internal organizations, fully paged over 51 pages with a final page of 784.

Sol/Luna account for **7,891 potentially affected ordinary-chat runs: 923 Built-in and 6,968 subscription**. This subset requires a bound thread and excludes Goal/automation sources. It is an upper bound, not the rollout population: internal organizations were not excluded, and captured PiLoop/feature-switch state and standard/Fast tiers could not be filtered from the exposed snapshot. No relevant API-key/custom runs were observed in that window; this does not establish that those routes are unconfigured. No data migration or historical usage backfill is included.

Controller acceptance, release inclusion, and production observation remain separate from this implementation PR. The controller creates and dispatches the required Custom Responses Fast slice after this slice's acceptance gates.
