### PR TITLE
refactor(platform): separate sidebar list readiness

### DIFF
--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -1,4 +1,4 @@
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Computed } from "ccstate";
 import { chatThreadsContract } from "@okouai/api-contracts/contracts/chat-threads";
 import type { EventDrivenChatThread } from "@okouai/core/chat-thread-event-replay";
 import { comparePinnedThreads } from "@okouai/core/chat-thread-pin-order";
@@ -89,35 +89,19 @@ export const currentChatAgentDisplayName$ = computed(async (get) => {
   return (await get(currentChatAgent$))?.displayName;
 });
 
-const filteredThreadIds$ = computed(
-  async (get): Promise<ReadonlySet<string> | null> => {
-    if (!get(chatThreadOnlyUnread$)) {
-      return null;
-    }
-    get(reloadChatIndicatorsCounter$);
+export interface ChatThreadListSignals {
+  readonly threads$: Computed<EventDrivenChatThread[]>;
+  readonly threadIds$: Computed<readonly string[]>;
+}
 
-    const agentId = await get(currentChatAgentId$);
-    if (!agentId) {
-      return new Set();
-    }
-
-    const client = get(apiClient$)(chatThreadsContract);
-    const result = await accept(client.unreads({ query: { agentId } }), [200]);
-    return new Set(
-      result.body.unreads.map((unread) => {
-        return unread.threadId;
-      }),
-    );
-  },
-);
-
-const eventDrivenFilteredChatThreads$ = computed(
-  async (get): Promise<EventDrivenChatThread[]> => {
-    const agentId = await get(currentChatAgentId$);
+function createChatThreadListSignals(
+  agentId: string | null,
+  filteredThreadIds: ReadonlySet<string> | null,
+): ChatThreadListSignals {
+  const threads$ = computed((get): EventDrivenChatThread[] => {
     if (!agentId) {
       return [];
     }
-    const filteredThreadIds = await get(filteredThreadIds$);
     const threads = get(eventDrivenChatThreads$).filter((thread) => {
       return (
         thread.agentId === agentId &&
@@ -136,16 +120,53 @@ const eventDrivenFilteredChatThreads$ = computed(
       }
       return comparePinnedThreads(left, right);
     });
+  });
+
+  return {
+    threads$,
+    threadIds$: computed((get): readonly string[] => {
+      return get(threads$).map((thread) => {
+        return thread.id;
+      });
+    }),
+  };
+}
+
+// Resolve the agent/filter query once, then keep event projection synchronous.
+// Thread events can update the returned signals without replacing this Promise.
+export const currentChatThreadListSignals$ = computed(
+  async (get): Promise<ChatThreadListSignals> => {
+    const unreadOnly = get(chatThreadOnlyUnread$);
+    if (unreadOnly) {
+      get(reloadChatIndicatorsCounter$);
+    }
+
+    const agentId = await get(currentChatAgentId$);
+    if (!unreadOnly || !agentId) {
+      return createChatThreadListSignals(agentId, null);
+    }
+
+    const client = get(apiClient$)(chatThreadsContract);
+    const result = await accept(client.unreads({ query: { agentId } }), [200]);
+    const filteredThreadIds = new Set(
+      result.body.unreads.map((unread) => {
+        return unread.threadId;
+      }),
+    );
+    return createChatThreadListSignals(agentId, filteredThreadIds);
   },
 );
 
-export const chatThreads$ = eventDrivenFilteredChatThreads$;
+export const chatThreads$ = computed(
+  async (get): Promise<EventDrivenChatThread[]> => {
+    const list = await get(currentChatThreadListSignals$);
+    return get(list.threads$);
+  },
+);
 
 export const currentChatThreadListIds$ = computed(
   async (get): Promise<readonly string[]> => {
-    const threads = await get(eventDrivenFilteredChatThreads$);
-    return threads.map((thread) => {
-      return thread.id;
-    });
+    const list = await get(currentChatThreadListSignals$);
+    return get(list.threadIds$);
   },
 );

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -141,7 +141,7 @@ export const currentChatThreadListSignals$ = computed(
       get(reloadChatIndicatorsCounter$);
     }
 
-    const agentId = await get(currentChatAgentId$);
+    const agentId = get(currentChatAgentScope$) ?? (await get(defaultAgentId$));
     if (!unreadOnly || !agentId) {
       return createChatThreadListSignals(agentId, null);
     }

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
@@ -1,15 +1,15 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import { animationFrame } from "signal-timers";
-import { createDeferredPromise, onRef } from "../utils.ts";
+import { onRef } from "../utils.ts";
 import {
   CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT,
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
   type ChatThreadVirtualListScrollAlign,
 } from "../okou-page/sidebar-state.ts";
 import {
-  chatThreads$,
+  currentChatThreadListSignals$,
   currentChatThreadId$,
-  currentChatThreadListIds$,
+  type ChatThreadListSignals,
 } from "../agent-chat.ts";
 import {
   sidebarChatThreadItemSignalsRegistry$,
@@ -29,6 +29,13 @@ export interface SidebarChatThreadWindow {
   readonly items: readonly SidebarChatThreadItemSignals[];
 }
 
+export interface SidebarChatThreadListSignals {
+  readonly count$: Computed<number>;
+  readonly currentThreadListed$: Computed<boolean>;
+  readonly threadIds$: Computed<readonly string[]>;
+  readonly window$: Computed<SidebarChatThreadWindow>;
+}
+
 interface SidebarChatThreadScrollMetrics {
   readonly scrollTop: number;
   readonly clientHeight: number;
@@ -42,7 +49,7 @@ export interface ScrollToThreadRequest {
 export interface SidebarChatThreadScrollSignals {
   readonly pinReorder: PinnedThreadDragSignals;
   readonly isScrolled$: Computed<boolean>;
-  readonly window$: Computed<Promise<SidebarChatThreadWindow>>;
+  readonly list$: Computed<Promise<SidebarChatThreadListSignals>>;
   readonly setScrollMetrics$: Command<void, [SidebarChatThreadScrollMetrics]>;
   readonly refreshScrollViewport$: Command<void, []>;
   readonly setScrollViewport$: Command<
@@ -202,27 +209,27 @@ function getFixedVirtualRange({
   return { startIndex, endIndex };
 }
 
-export const sidebarChatThreadCount$ = computed(
-  async (get): Promise<number> => {
-    return (await get(currentChatThreadListIds$)).length;
-  },
-);
-
-export const currentChatThreadListed$ = computed(
-  async (get): Promise<boolean> => {
+function createSidebarChatThreadListSignals(
+  dom: SidebarChatThreadDomSignals,
+  list: ChatThreadListSignals,
+): SidebarChatThreadListSignals {
+  const itemSignals$ = computed((get) => {
+    return get(sidebarChatThreadItemSignalsRegistry$).reconcile(
+      get(list.threadIds$),
+    );
+  });
+  const count$ = computed((get): number => {
+    return get(list.threadIds$).length;
+  });
+  const currentThreadListed$ = computed((get): boolean => {
     const threadId = get(currentChatThreadId$);
     if (!threadId) {
       return false;
     }
-    return (await get(currentChatThreadListIds$)).includes(threadId);
-  },
-);
-
-function createSidebarChatThreadWindowSignal(
-  dom: SidebarChatThreadDomSignals,
-): Computed<Promise<SidebarChatThreadWindow>> {
-  return computed(async (get): Promise<SidebarChatThreadWindow> => {
-    const chatThreads = await get(chatThreads$);
+    return get(list.threadIds$).includes(threadId);
+  });
+  const window$ = computed((get): SidebarChatThreadWindow => {
+    const itemSignals = get(itemSignals$);
     const scrollViewport = get(dom.scrollViewport$);
     const scrollMetrics = get(dom.scrollMetrics$);
     const measuredViewportHeight =
@@ -231,30 +238,32 @@ function createSidebarChatThreadWindowSignal(
       measuredViewportHeight || CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT;
     const scrollTop = scrollViewport?.scrollTop ?? scrollMetrics.scrollTop;
     const { startIndex, endIndex } = getFixedVirtualRange({
-      itemCount: chatThreads.length,
+      itemCount: itemSignals.length,
       scrollTop,
       viewportHeight,
     });
     const resolvedEndIndex = measuredViewportHeight
       ? endIndex
       : Math.min(
-          chatThreads.length,
+          itemSignals.length,
           Math.max(
             endIndex,
             startIndex + CHAT_THREAD_VIRTUAL_FALLBACK_WINDOW_SIZE,
           ),
         );
-    const itemSignals = get(sidebarChatThreadItemSignalsRegistry$).reconcile(
-      chatThreads.map((thread) => {
-        return thread.id;
-      }),
-    );
 
     return {
       startIndex,
       items: itemSignals.slice(startIndex, resolvedEndIndex),
     };
   });
+
+  return {
+    count$,
+    currentThreadListed$,
+    threadIds$: list.threadIds$,
+    window$,
+  };
 }
 
 function createScrollVirtualListToIndexCommand(
@@ -304,22 +313,14 @@ function createScrollVirtualListToIndexCommand(
   );
 }
 
-async function waitForAnimationFrame(signal: AbortSignal): Promise<void> {
-  signal.throwIfAborted();
-  const deferred = createDeferredPromise<void>(signal);
-  animationFrame(
-    () => {
-      if (!deferred.settled()) {
-        deferred.resolve(undefined);
-      }
-    },
-    { signal },
-  );
-  await deferred.promise;
-}
-
 function createSidebarChatThreadScrollSignals(): SidebarChatThreadScrollSignals {
   const dom = createSidebarChatThreadDomSignals();
+  // The async boundary selects a list context. Its count and virtual window
+  // remain synchronous when thread events or scroll metrics change.
+  const list$ = computed(async (get): Promise<SidebarChatThreadListSignals> => {
+    const list = await get(currentChatThreadListSignals$);
+    return createSidebarChatThreadListSignals(dom, list);
+  });
   const scrollVirtualListToIndex$ = createScrollVirtualListToIndexCommand(dom);
   const scrollToThread$ = command(
     async (
@@ -329,16 +330,14 @@ function createSidebarChatThreadScrollSignals(): SidebarChatThreadScrollSignals 
     ) => {
       const threadId = typeof request === "string" ? request : request.threadId;
       const align = typeof request === "string" ? "top" : request.align;
-      const threadIds = await get(currentChatThreadListIds$);
+      const list = await get(list$);
       signal.throwIfAborted();
 
-      const index = threadIds.indexOf(threadId);
+      const index = get(list.threadIds$).indexOf(threadId);
       if (index === -1) {
         return false;
       }
 
-      await waitForAnimationFrame(signal);
-      signal.throwIfAborted();
       return set(scrollVirtualListToIndex$, index, align);
     },
   );
@@ -355,7 +354,7 @@ function createSidebarChatThreadScrollSignals(): SidebarChatThreadScrollSignals 
   return {
     pinReorder: createPinnedThreadDragSignals(),
     isScrolled$: dom.isScrolled$,
-    window$: createSidebarChatThreadWindowSignal(dom),
+    list$,
     setScrollMetrics$: dom.setScrollMetrics$,
     setScrollViewport$: dom.setScrollViewport$,
     refreshScrollViewport$: dom.refreshScrollViewport$,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/sidebar-virtualization.test.tsx
@@ -241,6 +241,54 @@ test("Use the fallback window before sidebar geometry is available", async () =>
   expect(within(sidebar).queryByText("History 101")).not.toBeInTheDocument();
 });
 
+test("Do not retain rows or show an empty state when the list query fails", async () => {
+  mockThreads(120);
+  const unreads = context.mocks.deferred<void>();
+  context.mocks.api(chatThreadsContract.unreads, async ({ respond }) => {
+    await unreads.promise;
+    return respond(403, {
+      error: {
+        code: "FORBIDDEN",
+        message: "Unread conversations are unavailable",
+      },
+    });
+  });
+  await setupPage({ context, path: `/chats/${threadId(0)}` });
+
+  const sidebar = screen.getByTestId("chat-list-column");
+  await within(sidebar).findByText("History 1");
+  click(within(sidebar).getByLabelText("Open chat list menu"));
+  const unreadOnlyItem = queryAllByRoleFast("menuitem").find((item) => {
+    return item.textContent?.trim() === "Unread only";
+  });
+  if (!unreadOnlyItem) {
+    throw new Error("Unread-only menu item is missing");
+  }
+  click(unreadOnlyItem);
+
+  await waitFor(() => {
+    expect(within(sidebar).queryByText("History 1")).not.toBeInTheDocument();
+    expect(within(sidebar).getAllByTestId("sidebar-skeleton")).toHaveLength(3);
+  });
+
+  unreads.resolve(undefined);
+  await waitFor(() => {
+    expect(within(sidebar).queryAllByTestId("sidebar-skeleton")).toHaveLength(
+      0,
+    );
+  });
+  const [visibleError] = await screen.findAllByText(
+    "Unread conversations are unavailable",
+  );
+  expect(visibleError).toBeVisible();
+  expect(
+    within(sidebar).queryByText("No unread chats"),
+  ).not.toBeInTheDocument();
+  expect(
+    within(sidebar).queryByTestId("sidebar-chat-threads-virtual-list"),
+  ).not.toBeInTheDocument();
+});
+
 test("Coalesce sidebar resize bursts and cancel pending measurements when hidden", async () => {
   mockThreads(120);
   let viewportHeight = 612;

--- a/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/okou-page/sidebar-threads.tsx
@@ -1,11 +1,6 @@
 import type { MouseEvent } from "react";
 import { timeout } from "signal-timers";
-import {
-  useGet,
-  useSet,
-  useLastResolved,
-  useLastLoadable,
-} from "ccstate-react";
+import { useGet, useLoadable, useSet, useLastResolved } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { useTranslation } from "react-i18next";
 import {
@@ -58,11 +53,10 @@ import {
   newChatThreadDisabled$,
   type NewChatThreadPane,
 } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
-import {
-  currentChatThreadListed$,
-  sidebarChatThreadCount$,
-  type SidebarChatThreadScrollSignals,
-  type SidebarChatThreadWindow,
+import type {
+  SidebarChatThreadListSignals,
+  SidebarChatThreadScrollSignals,
+  SidebarChatThreadWindow,
 } from "../../signals/chat-page/sidebar-chat-thread-scroll.ts";
 import type { SidebarChatThreadItemSignals } from "../../signals/chat-page/sidebar-chat-thread-item.ts";
 import { sidebarThreadTitleOverflowRef$ } from "../../signals/chat-page/sidebar-thread-title.ts";
@@ -636,19 +630,20 @@ export function ChatThreadDialogs() {
 }
 
 function VirtualizedChatThreads({
+  listSignals,
   scrollSignals,
-  threadCount,
 }: {
+  listSignals: SidebarChatThreadListSignals;
   scrollSignals: SidebarChatThreadScrollSignals;
-  threadCount: number;
 }) {
   const setShortcutRoot = useSet(setThreadListNumberShortcutRoot$);
   const searchOpen = useGet(threeColumnSearchOpen$);
-  const window = useLastResolved(scrollSignals.window$, {
+  const threadCount = useGet(listSignals.count$);
+  const window = useGet(listSignals.window$, {
     equalityFn: equalSidebarChatThreadWindows,
   });
-  const startIndex = window?.startIndex ?? 0;
-  const visibleItems = window?.items ?? [];
+  const startIndex = window.startIndex;
+  const visibleItems = window.items;
 
   const placement = useGet(scrollSignals.pinReorder.placement$);
   return (
@@ -699,14 +694,15 @@ function VirtualizedChatThreads({
 }
 
 function ChatThreads({
+  listSignals,
   scrollSignals,
-  threadCount,
 }: {
+  listSignals: SidebarChatThreadListSignals;
   scrollSignals: SidebarChatThreadScrollSignals;
-  threadCount: number;
 }) {
   const { t } = useTranslation();
   const unreadOnly = useGet(chatThreadOnlyUnread$);
+  const threadCount = useGet(listSignals.count$);
 
   if (threadCount === 0) {
     return (
@@ -723,8 +719,8 @@ function ChatThreads({
   }
   return (
     <VirtualizedChatThreads
+      listSignals={listSignals}
       scrollSignals={scrollSignals}
-      threadCount={threadCount}
     />
   );
 }
@@ -1043,15 +1039,38 @@ function AgentChatThreadsContent({
   currentMainThreadId: string | null;
   scrollSignals: SidebarChatThreadScrollSignals;
 }) {
-  // The primitive count preserves the previous resolved value while the
-  // underlying event projection recomputes. Visible rows subscribe separately
-  // in VirtualizedChatThreads.
-  const threadCountLoadable = useLastLoadable(sidebarChatThreadCount$);
-  const threadCount =
-    threadCountLoadable.state === "hasData" ? threadCountLoadable.data : 0;
-  const chatThreadsLoading = threadCountLoadable.state === "loading";
-  const currentMainThreadListed =
-    useLastResolved(currentChatThreadListed$) ?? false;
+  const listLoadable = useLoadable(scrollSignals.list$);
+
+  if (listLoadable.state === "loading") {
+    return (
+      <div className="flex flex-col gap-1">
+        <ChatThreadsSkeleton />
+      </div>
+    );
+  }
+  if (listLoadable.state === "hasError") {
+    return null;
+  }
+
+  return (
+    <ResolvedAgentChatThreadsContent
+      currentMainThreadId={currentMainThreadId}
+      listSignals={listLoadable.data}
+      scrollSignals={scrollSignals}
+    />
+  );
+}
+
+function ResolvedAgentChatThreadsContent({
+  currentMainThreadId,
+  listSignals,
+  scrollSignals,
+}: {
+  currentMainThreadId: string | null;
+  listSignals: SidebarChatThreadListSignals;
+  scrollSignals: SidebarChatThreadScrollSignals;
+}) {
+  const currentMainThreadListed = useGet(listSignals.currentThreadListed$);
   const scrollCurrentChatThreadOnRef = useSet(
     scrollSignals.scrollCurrentChatThreadOnRef$,
   );
@@ -1065,11 +1084,7 @@ function AgentChatThreadsContent({
           hidden
         />
       ) : null}
-      {chatThreadsLoading ? (
-        <ChatThreadsSkeleton />
-      ) : (
-        <ChatThreads scrollSignals={scrollSignals} threadCount={threadCount} />
-      )}
+      <ChatThreads listSignals={listSignals} scrollSignals={scrollSignals} />
     </div>
   );
 }
@@ -1082,7 +1097,6 @@ function ExpandedChatThreadsContent({
   contentClassName: string;
 }) {
   const { t } = useTranslation();
-  const agentScope = useGet(currentChatAgentScope$);
   const isScrolled = useGet(scrollSignals.isScrolled$);
   const currentMainThreadId = useGet(currentChatThreadId$);
   const scrollToThread = useSet(scrollSignals.scrollToThread$);
@@ -1165,7 +1179,6 @@ function ExpandedChatThreadsContent({
       }}
     >
       <AgentChatThreadsContent
-        key={agentScope ?? "no-agent"}
         currentMainThreadId={currentMainThreadId}
         scrollSignals={scrollSignals}
       />


### PR DESCRIPTION
## Summary

- resolve the agent and unread query asynchronously, then expose synchronous event-driven list and virtual-window signals
- let the sidebar list leaf subscribe to list state instead of receiving raw item arrays or counts through parent props
- remove the fixed animation-frame wait from thread navigation while preserving resize-frame coalescing and cancellation
- show a real loading boundary and avoid retaining stale rows or rendering an empty state when the list query fails

## Testing

- pnpm -F @okouai/app check-types
- package-scoped oxlint, type-aware oxlint, and eslint on the four changed files
- sidebar-virtualization.test.tsx: 10 passed
- selected sidebar.test.tsx coverage for long-list browsing, top alignment, unread filtering, and agent switching: 4 passed
- pnpm exec commitlint --from origin/main --to HEAD