### PR TITLE
fix(runner): remove legacy model provider failure report retry

### DIFF
--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -42,7 +42,6 @@ path calls ``release_flow()`` to remove the reducer state and the registered res
 
 import json
 import threading
-import time
 import urllib.error
 import urllib.parse
 from collections.abc import Callable
@@ -98,7 +97,6 @@ _MAX_PENDING_REPORTS = _REPORT_WORKERS * 4
 RUNNER_AUTH_ENV = "OKOU_MITM_RUNNER_TOKEN"
 
 _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
-_HTTP_STATUS_BAD_REQUEST = 400
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_PAYMENT_REQUIRED = 402
 _HTTP_STATUS_REQUEST_TIMEOUT = 408
@@ -907,9 +905,7 @@ def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
     payload: dict[str, str | int] = {"failureKind": failure.failure_kind}
     if failure.retry_after_seconds is not None:
         payload["retryAfterSeconds"] = failure.retry_after_seconds
-    legacy_content: bytes | None = None
     if failure.connection_source is not None:
-        legacy_content = json.dumps(payload, separators=(",", ":")).encode("utf-8")
         payload["connectionSource"] = failure.connection_source
     content = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     report_url = (
@@ -924,7 +920,6 @@ def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
                     report_url,
                     bearer_credential,
                     content,
-                    legacy_content,
                 )
             except RuntimeError:
                 pass
@@ -941,45 +936,12 @@ def _post_report(
     url: str,
     bearer_credential: str,
     content: bytes,
-    legacy_content: bytes | None,
-) -> int:
-    deadline = time.monotonic() + _REPORT_TIMEOUT_SECONDS
-    status = _post_report_once(
-        url,
-        bearer_credential,
-        content,
-        timeout=deadline - time.monotonic(),
-    )
-    if status != _HTTP_STATUS_BAD_REQUEST or legacy_content is None:
-        return status
-
-    remaining = deadline - time.monotonic()
-    if remaining <= 0:
-        return status
-
-    # New runners can reach a pre-#29671 API during rollout or rollback. Remove this
-    # new-runner -> old-API fallback under #29882 after old runners and sandboxes drain
-    # and those APIs are neither serving nor retained rollback targets.
-    return _post_report_once(
-        url,
-        bearer_credential,
-        legacy_content,
-        timeout=remaining,
-    )
-
-
-def _post_report_once(
-    url: str,
-    bearer_credential: str,
-    content: bytes,
-    *,
-    timeout: float,
 ) -> int:
     request = platform_api.make_api_request(url, content, bearer_credential)
     try:
         with platform_api.build_api_opener().open(
             request,
-            timeout=timeout,
+            timeout=_REPORT_TIMEOUT_SECONDS,
         ) as response:
             return response.status
     except urllib.error.HTTPError as error:

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -4,6 +4,7 @@ import gzip
 import hashlib
 import json
 import threading
+import urllib.request
 import zlib
 from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
@@ -420,190 +421,68 @@ def test_report_http_failure_logs_omission_and_reclaims_capacity(
     )
 
 
-# Remove these rollout-only fallback tests with the compatibility branch under #29882.
-def test_source_aware_400_retries_once_with_legacy_body(
+@pytest.mark.parametrize("connection_source", ["provider_response", "upstream_transport"])
+def test_connection_report_http_failure_preserves_source_and_reclaims_capacity(
     tmp_path,
     real_flow,
     mitm_ctx,
+    connection_source: str,
     model_provider_failure_api,
 ):
-    proxy_log_path = tmp_path / "legacy-retry.jsonl"
-    model_provider_failure_api.queue_response(400)
-    model_provider_failure_api.queue_response(204)
-
-    _finish_upstream_transport_failure(real_flow, proxy_log_path, mitm_ctx)
-
-    assert _reported_payloads(model_provider_failure_api) == [
-        {
-            "failureKind": "connection",
-            "connectionSource": "upstream_transport",
-        },
-        {"failureKind": "connection"},
-    ]
-    requests = model_provider_failure_api.requests
-    assert [request.method for request in requests] == ["POST", "POST"]
-    assert [request.path for request in requests] == [
-        "/api/runners/runs/run-model-failure/model-provider-failures",
-        "/api/runners/runs/run-model-failure/model-provider-failures",
-    ]
-    assert [request.header("authorization") for request in requests] == [
-        f"Bearer {id(model_provider_failure_api)}",
-        f"Bearer {id(model_provider_failure_api)}",
-    ]
-    assert [request.body for request in requests] == [
-        b'{"failureKind":"connection","connectionSource":"upstream_transport"}',
-        b'{"failureKind":"connection"}',
-    ]
-    assert _report_omissions(proxy_log_path) == []
-
-
-@pytest.mark.parametrize(
-    (
-        "monotonic_values",
-        "fallback_status",
-        "expected_timeouts",
-        "expected_payloads",
-        "expected_http_status",
-    ),
-    [
-        (
-            (100.0, 100.25, 101.5),
-            204,
-            [2.75, 1.5],
-            [
-                {
-                    "failureKind": "connection",
-                    "connectionSource": "provider_response",
-                },
-                {"failureKind": "connection"},
-            ],
-            None,
-        ),
-        (
-            (100.0, 100.25, 103.0),
-            None,
-            [2.75],
-            [
-                {
-                    "failureKind": "connection",
-                    "connectionSource": "provider_response",
-                }
-            ],
-            400,
-        ),
-    ],
-    ids=("positive-fallback-budget", "exhausted-fallback-budget"),
-)
-def test_source_aware_400_fallback_shares_delivery_deadline(
-    tmp_path,
-    real_flow,
-    mitm_ctx,
-    monotonic_values: tuple[float, float, float],
-    fallback_status: int | None,
-    expected_timeouts: list[float],
-    expected_payloads: list[dict[str, str]],
-    expected_http_status: int | None,
-    model_provider_failure_api,
-):
-    monotonic_ticks = iter(monotonic_values)
-    request_timeouts: list[float] = []
-    original_build_api_opener = platform_api.build_api_opener
-
-    class ReportTime:
-        @staticmethod
-        def monotonic() -> float:
-            return next(monotonic_ticks)
-
-    class TimeoutRecordingOpener:
-        def __init__(self):
-            self._opener = original_build_api_opener()
-
-        def open(self, request, *, timeout: float):
-            request_timeouts.append(timeout)
-            return self._opener.open(request, timeout=timeout)
-
-    body = b'{"error":{"code":"connection_error"}}'
-    proxy_log_path = tmp_path / "legacy-retry-deadline.jsonl"
-    flow = _make_flow(
-        real_flow,
-        proxy_log_path,
-        response_body=body,
-    )
-    model_provider_failure_api.queue_response(400)
-    if fallback_status is not None:
-        model_provider_failure_api.queue_response(fallback_status)
-
-    with (
-        patch.object(model_provider_failure, "time", ReportTime),
-        patch.object(
-            platform_api,
-            "build_api_opener",
-            side_effect=TimeoutRecordingOpener,
-        ),
-    ):
-        _finish_http_flow(flow, body=body, mitm_ctx=mitm_ctx)
-        assert _reported_payloads(model_provider_failure_api) == expected_payloads
-
-    assert request_timeouts == pytest.approx(expected_timeouts)
-    if expected_http_status is None:
-        assert not jsonl_exists_after_flush(proxy_log_path)
-    else:
-        _assert_single_report_omission(
-            proxy_log_path,
-            flow_id=flow.id,
-            reason="http_error",
-            failure_kind="connection",
-            http_status=expected_http_status,
-        )
-        _assert_full_report_capacity(
-            real_flow,
-            tmp_path / "exhausted-fallback-capacity-recovery.jsonl",
-            model_provider_failure_api,
-        )
-
-
-def test_source_aware_400_failed_fallback_is_not_retried(
-    tmp_path,
-    real_flow,
-    mitm_ctx,
-    model_provider_failure_api,
-):
-    proxy_log_path = tmp_path / "legacy-retry-failed.jsonl"
+    proxy_log_path = tmp_path / "connection-http-error.jsonl"
     release_target = threading.Event()
     initial_request_count = model_provider_failure_api.request_count
-    model_provider_failure_api.queue_response(400)
-    model_provider_failure_api.queue_response(503, release_event=release_target)
+    model_provider_failure_api.queue_response(400, release_event=release_target)
+    request_timeouts: list[float] = []
+    original_open = urllib.request.OpenerDirector.open
 
-    flow = _finish_upstream_transport_failure(real_flow, proxy_log_path, mitm_ctx)
+    def record_timeout(opener, request, *, timeout: float):
+        request_timeouts.append(timeout)
+        return original_open(opener, request, timeout=timeout)
 
-    assert model_provider_failure_api.wait_for_request_count(initial_request_count + 2)
-    assert [
-        request.json_body()
-        for request in model_provider_failure_api.requests[
-            initial_request_count : initial_request_count + 2
-        ]
-    ] == [
-        {
-            "failureKind": "connection",
-            "connectionSource": "upstream_transport",
-        },
-        {"failureKind": "connection"},
-    ]
+    body = b'{"error":{"code":"connection_error"}}'
+    with patch.object(urllib.request.OpenerDirector, "open", record_timeout):
+        if connection_source == "upstream_transport":
+            flow = _finish_upstream_transport_failure(real_flow, proxy_log_path, mitm_ctx)
+        else:
+            flow = _make_flow(real_flow, proxy_log_path, response_body=body)
+            _finish_http_flow(flow, body=body, mitm_ctx=mitm_ctx)
+
+        assert model_provider_failure_api.wait_for_request_count(initial_request_count + 1)
+
+    request = model_provider_failure_api.requests[initial_request_count]
+    assert request.json_body() == {
+        "failureKind": "connection",
+        "connectionSource": connection_source,
+    }
+    assert request.method == "POST"
+    assert request.path == "/api/runners/runs/run-model-failure/model-provider-failures"
+    assert request.header("authorization") == f"Bearer {id(model_provider_failure_api)}"
+    assert request_timeouts == [3]
     _assert_single_reclaimed_report_slot(
         real_flow,
-        tmp_path / "legacy-retry-failed-capacity-recovery.jsonl",
+        tmp_path / "connection-http-error-recovery.jsonl",
         model_provider_failure_api,
         release_target,
         initial_request_count=initial_request_count,
-        target_outbound_count=2,
+        target_outbound_count=1,
     )
     _assert_single_report_omission(
         proxy_log_path,
         flow_id=flow.id,
         reason="http_error",
         failure_kind="connection",
-        http_status=503,
+        http_status=400,
     )
+    if connection_source == "upstream_transport":
+        assert flow.response is None
+        assert flow.error is not None
+        assert flow.error.msg == "connection reset by peer"
+    else:
+        assert flow.response is not None
+        assert flow.response.status_code == 200
+        assert flow.response.content == body
+        assert flow.error is None
 
 
 def test_source_aware_non_400_failure_is_not_retried(


### PR DESCRIPTION
## Summary

A rejected model-provider connection report still triggered a second request without `connectionSource`, which the current API rejects. Send the canonical body once and retain the existing HTTP omission and capacity-release behavior. Remove the legacy body, retry wrapper, shared deadline, unused constant/import, and three rollout-only tests.

The replacement real-flow cases cover both `provider_response` and `upstream_transport` on HTTP 400: one canonical request with authentication, the three-second request timeout, one bounded `http_error`/400 omission, exactly one reclaimed slot, and the original provider response or connection error. They use the existing threaded HTTP server and capacity barriers; the new observer wraps the standard-library opener and forwards real network I/O.

Refs #29882. Controller acceptance and production delivery remain tracked in that issue.

## Compatibility and scope audit

- Started from freshly fetched main `45e10539dffbd49c47e49c115e28dc78d10d5bb4`. The retirement evidence is recorded in [#29882](https://github.com/vm0-ai/vm0/issues/29882), including the explicit pre-source Runner drain and elapsed 7,300-second maximum lifetime.
- The rollback resolver and strict report contract were unchanged from the research baseline. Verified `59a1dc75def4f4ec2170d609ce92d36de1e4fbee` is an ancestor of enforced rollback floor `c093e0ffdab988d2a8a071809f90d87fa3e79f20`; rollback still loads the resolver from current main. Release [#32446](https://github.com/vm0-ai/vm0/pull/32446) and its API/Runner promotions succeeded. Concurrent release #32495 is a descendant of that compatible release and floor.
- All sender/helper/constant/import references and reporting fixtures were inspected. `build.rs` embeds the Python source into Runner `ADDON_FILES`, consumed by `proxy/process.rs`; the `fix(runner)` commit is eligible for the Runner release-please patch.
- Keep the five non-connection payload variants, legitimate source-less `provider_unavailable` test, source-aware non-400 omission, JSON/SSE/HTTP/WebSocket attribution, terminal-success precedence, client-disconnect exclusion, capacity, transport, shutdown, and later-flow coverage.
- Preserve the existing opener, authentication, URL quoting, HTTPError closure, four workers, sixteen slots, `_finish_report` finally cleanup, shutdown bounds, and provider/run independence. Only the reporter and focused test file change. No API, generated binding, schema, migration, cooldown, dependency, classifier, or deployment workflow changes.
- #32480 has merged and touched different path-normalization files. Open-PR inventory found no overlapping reporter or rollback changes; no merge ordering was reserved.

## Validation

From `crates/runner/mitm-addon`, with committed uv 0.11.32 and Python 3.14.0:

- `uv lock --check` and `uv sync --locked`: passed, lockfile unchanged.
- `uv run --no-sync ruff format --check .`: 361 files formatted.
- `uv run --no-sync ruff check .`: passed.
- `uv run --no-sync basedpyright -p .`: 0 errors, 0 warnings.
- `uv run --no-sync python -m pytest tests/test_model_provider_failure_reporting.py tests/test_model_provider_websocket_source_reporting.py`: 108 passed.
- `uv run --no-sync python -m pytest tests/`: 7,347 passed; 43 dependency/fixture warnings, without suppression.

Runner embedding validation:

- The real Cargo `build.rs` generated `addon_files.rs` successfully. Both generated inventories agree; an isolated Rust test harness includes that actual `ADDON_FILES` output and copies the unchanged `embedded_addon_reads_runner_token_environment` and `addon_scripts_are_embedded` functions from `proxy/process.rs`: **2 passed**, no ignored or filtered tests.
- **Local validation limitation:** `CARGO_BUILD_JOBS=1 cargo test --locked --profile local -p runner embedded_addon_reads_runner_token_environment` was killed with exit 137; the kernel confirmed OOM at approximately 3.6 GB RSS. A retry using only `--config 'profile.local.package.runner.debug=0'` still reached approximately 3.75 GB and was terminated under sustained memory pressure (exit 143). The full Runner test binary did not complete locally. No assertions, timeouts, repository configuration, dependencies, or CI gates were changed. Required Crates CI must run the original Runner tests before queue admission.

Broader cross-repository checks run through required PR and merge-group CI. No local Vitest suite or development server was run.
