### PR TITLE
refactor: remove follow-up optimization feature switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -18,7 +18,6 @@ import {
   ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_PICKER_ITEMS,
 } from "@okouai/core";
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now } from "../../../lib/time";
@@ -1121,18 +1120,6 @@ describe("CHAT-02: completed chat callback", () => {
   it("persists assistant output, reorders threads, titles the thread, recommends follow-ups, notifies, and auto-sends the queued template message", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped chat actor");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      {
-        userId: actor.userId,
-        orgId: actor.orgId,
-        orgRole: actor.orgRole,
-      },
-      { [FeatureSwitchKey.FollowUpOptimize]: false },
-    );
 
     const titlePrompts: string[] = [];
     const followupSystemPrompts: string[] = [];
@@ -1146,7 +1133,11 @@ describe("CHAT-02: completed chat callback", () => {
         titlePrompts.push(body.messages[1]?.content ?? "");
         return "Debugging Node Apps";
       }
-      if (systemContent.includes("concise follow-up prompts")) {
+      if (
+        systemContent.includes(
+          "You generate recommended follow-up messages for a chat.",
+        )
+      ) {
         followupSystemPrompts.push(systemContent);
         followupPrompts.push(body.messages[1]?.content ?? "");
         return JSON.stringify([
@@ -1268,11 +1259,11 @@ describe("CHAT-02: completed chat callback", () => {
     expect(followupPrompts[0]).not.toContain("queued next turn");
     expect(followupSystemPrompts).toStrictEqual([
       expect.stringContaining(
-        'The "prompt" values are shown as plain text, not rendered as Markdown',
+        "The prompt values are displayed as plain text, not rendered as Markdown",
       ),
     ]);
     expect(followupSystemPrompts[0]).toContain(
-      "Supported built-in generation tasks:",
+      "Supported generation types are:",
     );
     expect(followupSystemPrompts[0]).not.toContain("VM0");
 
@@ -1530,7 +1521,7 @@ describe("CHAT-02: completed chat callback", () => {
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
 
-  it("uses the released optimized prompt and userMessage semantics for recommended follow-ups", async () => {
+  it("uses the optimized prompt and userMessage semantics for recommended follow-ups", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 

--- a/turbo/apps/api/src/signals/services/chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-title.service.ts
@@ -55,23 +55,7 @@ const TITLE_CONTEXT_CHAR_CAP = 150;
 const TITLE_PRIOR_MESSAGE_CAP = 10;
 const FOLLOWUP_CONTEXT_CHAR_CAP = 700;
 const FOLLOWUP_CONTEXT_MESSAGE_CAP = 8;
-const BUILT_IN_GENERATION_FOLLOWUP_CONTEXT = [
-  "Supported built-in generation tasks:",
-  "- image: create or edit images and visual assets.",
-  "- video: create short generated videos.",
-  "- presentation: create slide decks or presentation documents.",
-  "- website: create hosted websites or web pages.",
-].join("\n");
-const LEGACY_RECOMMENDED_FOLLOWUP_SYSTEM_PROMPT = [
-  `Generate up to ${RECOMMENDED_FOLLOWUP_LIMIT.toString()} concise follow-up prompts the user may ask next in this chat.`,
-  "Make each prompt specific to the latest assistant reply, actionable, and useful. Match the user's language.",
-  'The "prompt" values are shown as plain text, not rendered as Markdown, so formatting characters will appear literally. Do not use Markdown or presentation-only syntax inside prompt values, including backticks around technical names, bold or italic markers, links, or bullet markers.',
-  'Classify each item as kind "talk" for normal discussion, planning, analysis, or refinement, or kind "generate" when the prompt asks for one of the supported built-in generation outputs.',
-  BUILT_IN_GENERATION_FOLLOWUP_CONTEXT,
-  "For generate items, include generationType as one of: image, video, presentation, website.",
-  'Return only a JSON array of objects like {"prompt":"...","kind":"talk"} or {"prompt":"...","kind":"generate","generationType":"website"}. No markdown or extra text.',
-].join("\n");
-const OPTIMIZED_RECOMMENDED_FOLLOWUP_SYSTEM_PROMPT = [
+const RECOMMENDED_FOLLOWUP_SYSTEM_PROMPT = [
   "You generate recommended follow-up messages for a chat.",
   "",
   `Generate exactly ${RECOMMENDED_FOLLOWUP_LIMIT.toString()} distinct follow-up messages that meaningfully advance the task. These are quick replies, not task briefs.`,
@@ -483,7 +467,6 @@ async function getLatestFollowupContextMessages(
 
 async function generateRecommendedFollowups(
   messages: readonly ChatCompletionContextMessage[],
-  followUpOptimizeEnabled: boolean,
 ): Promise<ChatRecommendedFollowup[]> {
   const last = messages[messages.length - 1];
   if (last?.role !== "assistant" || last.content.trim().length === 0) {
@@ -500,9 +483,7 @@ async function generateRecommendedFollowups(
     [
       {
         role: "system",
-        content: followUpOptimizeEnabled
-          ? OPTIMIZED_RECOMMENDED_FOLLOWUP_SYSTEM_PROMPT
-          : LEGACY_RECOMMENDED_FOLLOWUP_SYSTEM_PROMPT,
+        content: RECOMMENDED_FOLLOWUP_SYSTEM_PROMPT,
       },
       {
         role: "user",
@@ -526,17 +507,13 @@ export async function loadChatThreadRecommendedFollowupContext(args: {
 export async function generateChatThreadRecommendedFollowupsFromContext(args: {
   readonly messages: readonly ChatCompletionContextMessage[];
   readonly threadId?: string;
-  readonly followUpOptimizeEnabled: boolean;
 }): Promise<ChatRecommendedFollowup[]> {
   return (
-    (await tapError(
-      generateRecommendedFollowups(args.messages, args.followUpOptimizeEnabled),
-      (err) => {
-        log.warn("Recommended follow-up generation failed", {
-          ...(args.threadId ? { threadId: args.threadId } : {}),
-          err,
-        });
-      },
-    )) ?? []
+    (await tapError(generateRecommendedFollowups(args.messages), (err) => {
+      log.warn("Recommended follow-up generation failed", {
+        ...(args.threadId ? { threadId: args.threadId } : {}),
+        err,
+      });
+    })) ?? []
   );
 }

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1911,7 +1911,6 @@ async function generateRecommendedFollowupsForCompletedRun(
   args: {
     readonly followupContext: readonly ChatCompletionContextMessage[];
     readonly threadId: string;
-    readonly followUpOptimizeEnabled: boolean;
   },
   signal: AbortSignal,
 ): Promise<readonly ChatRecommendedFollowup[] | undefined> {
@@ -1919,7 +1918,6 @@ async function generateRecommendedFollowupsForCompletedRun(
   const suggestions = await generateChatThreadRecommendedFollowupsFromContext({
     messages: args.followupContext,
     threadId: args.threadId,
-    followUpOptimizeEnabled: args.followUpOptimizeEnabled,
   });
   signal.throwIfAborted();
   return suggestions.length > 0 ? suggestions : undefined;
@@ -2140,20 +2138,10 @@ async function runCompletedChatCallbackSideEffects(
 
   const followupsStep = (async () => {
     signal.throwIfAborted();
-    const featureSwitchContext = await loadUserFeatureSwitchContext(
-      args.db,
-      args.chatThread.orgId,
-      args.chatThread.userId,
-    );
-    signal.throwIfAborted();
     const followups = await generateRecommendedFollowupsForCompletedRun(
       {
         followupContext: args.followupContext,
         threadId: args.chatThread.chatThreadId,
-        followUpOptimizeEnabled: isFeatureEnabled(
-          FeatureSwitchKey.FollowUpOptimize,
-          featureSwitchContext,
-        ),
       },
       signal,
     );

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -42,7 +42,6 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.GoogleFormsWorkflowAutomations, {}),
     ).toBe(true);
-    expect(isFeatureEnabled(FeatureSwitchKey.FollowUpOptimize, {})).toBe(true);
     expect(isFeatureEnabled(FeatureSwitchKey.PresentationTemplates, {})).toBe(
       true,
     );
@@ -373,9 +372,6 @@ describe("getFeatureSwitchMetadata", () => {
     expect(
       metadata[FeatureSwitchKey.NotionWorkflowAutomations].rolloutStage,
     ).toBe("released");
-    expect(metadata[FeatureSwitchKey.FollowUpOptimize].rolloutStage).toBe(
-      "released",
-    );
     expect(metadata[FeatureSwitchKey.PresentationTemplates].rolloutStage).toBe(
       "released",
     );

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -56,7 +56,6 @@ export enum FeatureSwitchKey {
   ChatRunWorkFolding = "chatRunWorkFolding",
   ProgressiveArtifactPreview = "progressiveArtifactPreview",
   ChatThinkingSpinner = "chatThinkingSpinner",
-  FollowUpOptimize = "followUpOptimize",
   ResponsiveFollowupCards = "responsiveFollowupCards",
   StableChatThreadNavigation = "stableChatThreadNavigation",
   SidebarSubscriptionUsage = "_sidebarSubscriptionUsage",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -407,12 +407,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     // render-on-confirm upload is still unexercised outside tests.
     enabledEmailHashes: ["56bef1aa"], // fnv1a("tongx@vm0.ai")
   },
-  [FeatureSwitchKey.FollowUpOptimize]: {
-    maintainer: "lancy@okou.ai",
-    description:
-      "Use a concise, language-matched prompt for recommended chat follow-ups.",
-    enabled: true,
-  },
   [FeatureSwitchKey.ResponsiveFollowupCards]: {
     maintainer: "ethan@okou.ai",
     description:


### PR DESCRIPTION
## Summary

- Treat `followUpOptimize` as fully rolled out and make the optimized recommended-follow-up prompt the only behavior.
- Remove the legacy prompt, feature-switch registry/key entries, per-run switch lookup, and disabled-path test setup.
- Keep the structured `userMessage` context and optimized prompt/classification semantics unchanged.

## Terminal-state basis

- State: **fully rolled out**.
- The maintainer explicitly approved permanent enablement in this cleanup request.
- The switch was globally enabled on `main` before cleanup (`enabled: true`).
- The optimized path was introduced by `5f1b1f9de657d89315f60f2d573fe19a2084b938`; comparison against parent `62f5d27778894f81d3992f71bd11618493710b1e` identified the legacy and enabled branches removed here.

## Blast-radius review

- Removed the enum key and registry metadata.
- Removed the legacy system prompt and the `followUpOptimizeEnabled` argument chain.
- Removed the completed-run feature-switch context read; unrelated switch reads in the callback service remain.
- Rewrote the broad callback assertion to cover the permanent optimized prompt and removed the disabled override.
- A second repository search for the switch spelling, optimization aliases, boolean, legacy/optimized prompt constant names, and legacy prompt copy returned no matches.

## Validation

- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types` (re-run after rebasing onto current `main`)
- `pnpm exec knip --workspace api --workspace @okouai/core`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts` — 31 passed
- Prettier and `git diff --check`

The focused callback acceptance test is not a clean local gate: runner claim returns `404 Job not found in queue` before the follow-up assertion. The same original test fails identically on untouched `main` at `3d3f7612e6ee11480caf558c8ef3159cc09e2ff9` (expected 200, received 404), so this PR remains draft while CI provides the authoritative integration result. Per repository guidance, no full local Vitest suite or dev server was run.
