### PR TITLE
perf(runner): prestart session history for blank sandboxes

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -870,6 +870,11 @@ pub(super) async fn build_spawn_job_request(
             context: setup.claimed.context(),
             cancel: setup.cancellation.token(),
             reuse_result: setup.resource.reuse_result,
+            idle_kind: setup
+                .resource
+                .reuse_entry
+                .as_ref()
+                .map(ReusableIdleSandbox::kind),
             restored_identity: setup
                 .resource
                 .reuse_entry

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_pool.rs
@@ -5,6 +5,7 @@ use super::super::support::{
     seed_workspace_cache_state, shutdown, test_profiles, two_profiles, wait_budget_count,
     wait_idle_pool_len,
 };
+use super::blank_session_history::history_context;
 
 use crate::paths::RunnerPaths;
 use crate::types::{SandboxReuseResult, WorkspaceReuseResult};
@@ -324,8 +325,18 @@ async fn blank_backed_run_becomes_exact_reuse_and_wins_over_refilled_blank() {
     shutdown(&env, run_handle).await;
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn blank_unpark_failure_falls_back_without_changing_cold_attribution() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let history = b"{\"type\":\"init\"}\n";
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history");
+            then.status(200).body(history);
+        })
+        .await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let calls = Arc::clone(&overrides);
     overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
@@ -340,12 +351,9 @@ async fn blank_unpark_failure_falls_back_without_changing_cold_attribution() {
     let blank_sandbox_id = idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
 
     let run_id = RunId::new_v4();
-    push_job(
-        &env,
-        run_id,
-        "vm0/default",
-        Some(context_with_session(run_id, "session-blank-unpark-failure")),
-    );
+    let mut context = history_context(run_id, server.url("/history"), history);
+    context.reuse_key = Some("session-blank-unpark-failure".into());
+    push_job(&env, run_id, "vm0/default", Some(context));
     let completion = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
@@ -359,6 +367,7 @@ async fn blank_unpark_failure_falls_back_without_changing_cold_attribution() {
     assert_eq!(calls.destroy_call_count(), 1);
 
     shutdown(&env, run_handle).await;
+    history_mock.assert_calls_async(1).await;
 }
 
 #[tokio::test(start_paused = true)]
@@ -670,8 +679,18 @@ async fn workspace_cache_hit_takes_priority_over_compatible_blank_inventory() {
     shutdown(&env, run_handle).await;
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn claimed_workspace_cache_metadata_takes_priority_over_reserved_blank() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let history = b"{\"type\":\"init\"}\n";
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history");
+            then.status(200).body(history);
+        })
+        .await;
     let mut profiles = test_profiles();
     profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
     let (mut config, env) = mock_run_config(profiles, 16, 32_768, 8);
@@ -700,7 +719,7 @@ async fn claimed_workspace_cache_metadata_takes_priority_over_reserved_blank() {
     let blank_sandbox_id = idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
 
     let run_id = RunId::new_v4();
-    let mut context = context_with_session(run_id, "claimed-workspace-priority-session");
+    let mut context = history_context(run_id, server.url("/history"), history);
     context.reuse_key = Some(reuse_key.into());
     env.provider.set_claim_result(run_id, Some(context));
     env.handle
@@ -722,4 +741,5 @@ async fn claimed_workspace_cache_metadata_takes_priority_over_reserved_blank() {
     assert_ne!(completion.sandbox_id, Some(blank_sandbox_id));
 
     shutdown(&env, run_handle).await;
+    history_mock.assert_calls_async(1).await;
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse/blank_session_history.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/blank_session_history.rs
@@ -1,0 +1,303 @@
+use std::io::Write;
+
+use guest_contracts::env::CliFramework;
+use sandbox_mock::{MockLifecycleGate, MockSandboxOverrides};
+use sha2::{Digest, Sha256};
+use tokio::sync::oneshot;
+
+use super::super::super::*;
+use super::super::support::{
+    minimal_context, mock_run_config_with_overrides, push_job, shutdown, test_profiles,
+    wait_cancel_handle, wait_idle_pool_len,
+};
+use crate::storage_manifest::{ArtifactEntry, StorageManifest};
+use crate::test_fixtures::raw_http::{RawHttpAction, RawHttpTestServer, http_response};
+use crate::types::{
+    ExecutionContext, ResumeSession, ResumeSessionHistory, ResumeSessionHistoryEncoding,
+    ResumeSessionHistoryRef, ResumeSessionHistoryRefKind, SandboxReuseResult,
+};
+
+const WAIT: Duration = Duration::from_secs(5);
+const HISTORY: &[u8] = b"{\"type\":\"init\"}\n";
+
+pub(super) fn history_context(run_id: RunId, url: String, history: &[u8]) -> ExecutionContext {
+    let mut context = minimal_context(run_id);
+    context.cli_agent_type = "claude-code".into();
+    context.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-blank-history".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url,
+                encoding: ResumeSessionHistoryEncoding::Identity,
+                raw_size: history.len() as u64,
+                encoded_size: history.len() as u64,
+                download_source: None,
+            },
+        },
+    });
+    context.storage_manifest = Some(StorageManifest {
+        storages: vec![],
+        artifacts: vec![ArtifactEntry {
+            mount_path: "/home/user/workspace".into(),
+            vas_storage_name: "workspace".into(),
+            vas_storage_id: "workspace-id".into(),
+            vas_version_id: "empty-version".into(),
+            archive_url: None,
+            archive_size: None,
+            empty: Some(true),
+            missing_root_policy: None,
+        }],
+    });
+    context
+}
+
+#[tokio::test]
+async fn blank_history_prestart_overlaps_storage_and_preserves_restore() {
+    for (framework, keyed, encoding) in [
+        (
+            CliFramework::ClaudeCode,
+            true,
+            ResumeSessionHistoryEncoding::Identity,
+        ),
+        (CliFramework::Pi, false, ResumeSessionHistoryEncoding::Gzip),
+        (
+            CliFramework::Codex,
+            true,
+            ResumeSessionHistoryEncoding::Zstd,
+        ),
+    ] {
+        let (framework, history, session_id, expected_path): (&str, &[u8], &str, String) = match framework {
+            CliFramework::ClaudeCode => (
+                "claude-code",
+                HISTORY,
+                "sess-blank-history",
+                "/home/user/.claude/projects/-home-user-workspace/sess-blank-history.jsonl".into(),
+            ),
+            CliFramework::Pi => (
+                "pi",
+                br#"{"type":"session","version":3,"id":"22222222-2222-4222-8222-222222222222","timestamp":"2026-07-13T01:02:03Z","cwd":"/home/user/workspace"}"#,
+                "22222222-2222-4222-8222-222222222222",
+                format!("{}/restored-22222222-2222-4222-8222-222222222222.jsonl",
+                    api_contracts::generated::constants::runners::paths::CANONICAL_PI_SESSION_DIR),
+            ),
+            CliFramework::Codex => (
+                "codex",
+                br#"{"type":"session_meta","payload":{"id":"019e9154-c304-70f0-adde-36efb1be1701","timestamp":"2026-07-13T01:02:03Z"}}"#,
+                "019e9154-c304-70f0-adde-36efb1be1701",
+                "/home/user/.codex/sessions/2026/07/13/rollout-2026-07-13T01-02-03-019e9154-c304-70f0-adde-36efb1be1701.jsonl.zst".into(),
+            ),
+        };
+        let encoded = match encoding {
+            ResumeSessionHistoryEncoding::Identity => history.to_vec(),
+            ResumeSessionHistoryEncoding::Gzip => {
+                let mut encoder =
+                    flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+                encoder.write_all(history).unwrap();
+                encoder.finish().unwrap()
+            }
+            ResumeSessionHistoryEncoding::Zstd => zstd::encode_all(history, 0).unwrap(),
+        };
+        let (release_history, history_release) = oneshot::channel();
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::WaitThenRespond {
+            release: history_release,
+            response: http_response("200 OK", &encoded),
+        }])
+        .await;
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let storage_gate = MockLifecycleGate::new();
+        overrides.set_storage_manifest_lifecycle_gate(storage_gate.clone());
+        let process_gate = MockLifecycleGate::new();
+        overrides.set_start_process_lifecycle_gate(process_gate.clone());
+        let (config, env) =
+            mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, Arc::clone(&overrides));
+        let budget = Arc::clone(&config.capacity.budget);
+        let run_handle = tokio::spawn(run(config));
+        wait_idle_pool_len(&env.idle_pool, 1, WAIT).await;
+        let blank_id = env.idle_pool.lock().await.status_snapshot().blank_sandboxes[0].sandbox_id;
+        let run_id = RunId::new_v4();
+        let mut context = history_context(run_id, server.url(), history);
+        context.cli_agent_type = framework.into();
+        if framework == "pi" {
+            context.pi_session_id = Some(session_id.into());
+            context.pi_launch_config = Some(serde_json::json!({
+                "schemaVersion": 2,
+                "apiFirstTurn": {
+                    "schemaVersion": 1,
+                    "resourceSnapshotDigest": "a".repeat(64),
+                    "manifestUrl": server.url(),
+                    "sessionUrl": server.url(),
+                    "deadlineAt": 2_000_000_000_000_u64,
+                    "baseSession": {"sessionId": session_id, "sha256": null},
+                    "sandboxEventSequenceStart": 1
+                }
+            }));
+            context.pi_model_config = Some(serde_json::json!({
+                "provider": "deepseek",
+                "baseUrl": server.url(),
+                "model": "deepseek-v4-flash",
+                "apiKeyEnv": "OPENAI_API_KEY",
+                "credentialSecretName": "DEEPSEEK_API_KEY"
+            }));
+        }
+        context.reuse_key = keyed.then(|| "thread:blank-history".into());
+        let resume_session = context.resume_session.as_mut().unwrap();
+        resume_session.cli_agent_session_id = session_id.into();
+        let ResumeSessionHistory::Ref { history_ref } = &mut resume_session.history else {
+            panic!("fixture should use remote history");
+        };
+        history_ref.encoding = encoding;
+        history_ref.encoded_size = encoded.len() as u64;
+        push_job(&env, run_id, "vm0/default", Some(context));
+
+        storage_gate.wait_entered(1, WAIT).await.unwrap();
+        // Storage is still blocked: a received HTTP request proves automatic
+        // discovery prestart, not a manually supplied executor restore plan.
+        server
+            .next_request("blank history before storage finishes")
+            .await;
+        assert_eq!(overrides.storage_manifest_calls().len(), 1);
+        assert!(overrides.write_file_calls().is_empty());
+        assert!(overrides.start_agent_process_calls().is_empty());
+        storage_gate.release_one();
+        assert_eq!(process_gate.entered_count(), 0);
+        release_history.send(()).unwrap();
+
+        process_gate.wait_entered(1, WAIT).await.unwrap();
+        let writes = overrides.write_file_calls();
+        assert_eq!(writes.len(), 1);
+        let restored = if framework == "codex" {
+            encoded.as_slice()
+        } else {
+            history
+        };
+        assert_eq!(writes[0].content, restored);
+        assert_eq!(writes[0].path, expected_path);
+        process_gate.release_one();
+        let completion = env.handle.wait_completion(run_id, WAIT).await.unwrap();
+        assert_eq!(completion.exit_code, 0);
+        assert_eq!(completion.sandbox_id, Some(blank_id));
+        assert_eq!(
+            completion.reuse_result,
+            Some(if keyed {
+                SandboxReuseResult::PoolMiss
+            } else {
+                SandboxReuseResult::NoReuseKey
+            })
+        );
+        // The one-response server and successful restore require one download;
+        // a second materialization cannot obtain another history response.
+        server.assert_finished().await;
+        shutdown(&env, run_handle).await;
+        assert_eq!(budget.allocated().2, 0);
+    }
+}
+
+#[tokio::test]
+async fn blank_history_prestart_is_cancelled_on_storage_failure_and_shutdown() {
+    for storage_failure in [true, false] {
+        let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::WaitForDisconnect]).await;
+        let overrides = Arc::new(MockSandboxOverrides::new());
+        let storage_gate = MockLifecycleGate::new();
+        overrides.set_storage_manifest_lifecycle_gate(storage_gate.clone());
+        if storage_failure {
+            overrides.push_storage_manifest_result(Ok(sandbox::ExecResult::new(
+                1,
+                Vec::new(),
+                "storage preparation failed".into(),
+            )));
+        }
+        let (config, env) =
+            mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, Arc::clone(&overrides));
+        let budget = Arc::clone(&config.capacity.budget);
+        let run_handle = tokio::spawn(run(config));
+        wait_idle_pool_len(&env.idle_pool, 1, WAIT).await;
+        let run_id = RunId::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(history_context(run_id, server.url(), HISTORY)),
+        );
+        storage_gate.wait_entered(1, WAIT).await.unwrap();
+        server.next_request("pending blank history").await;
+        if storage_failure {
+            storage_gate.release_one();
+        } else {
+            env.trigger_stopping().await;
+        }
+        let completion = env.handle.wait_completion(run_id, WAIT).await.unwrap();
+        assert_ne!(completion.exit_code, 0);
+        assert!(overrides.start_agent_process_calls().is_empty());
+        assert!(overrides.write_file_calls().is_empty());
+        // Prove the client cancelled its HTTP request without releasing a
+        // response, instead of just checking that the sandbox eventually exits.
+        server.assert_finished().await;
+        shutdown(&env, run_handle).await;
+        assert_eq!(budget.allocated().2, 0);
+    }
+}
+
+#[tokio::test]
+async fn blank_history_prestart_run_cancellation_drops_pending_download() {
+    let mut server = RawHttpTestServer::spawn(vec![RawHttpAction::WaitForDisconnect]).await;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let storage_gate = MockLifecycleGate::new();
+    overrides.set_storage_manifest_lifecycle_gate(storage_gate.clone());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+    wait_idle_pool_len(&env.idle_pool, 1, WAIT).await;
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(history_context(run_id, server.url(), HISTORY)),
+    );
+    storage_gate.wait_entered(1, WAIT).await.unwrap();
+    server
+        .next_request("blank history before cancellation")
+        .await;
+    let cancellation = wait_cancel_handle(&env.cancel_tokens, run_id, WAIT).await;
+    cancellation.request_hard_cancellation().await;
+    let completion = env.handle.wait_completion(run_id, WAIT).await.unwrap();
+    assert_eq!(completion.exit_code, 137);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert!(overrides.write_file_calls().is_empty());
+    server.assert_finished().await;
+    shutdown(&env, run_handle).await;
+    assert_eq!(budget.allocated().2, 0);
+}
+
+#[tokio::test]
+async fn blank_history_prestart_validation_failure_never_spawns() {
+    let mut corrupted = HISTORY.to_vec();
+    corrupted[0] = b'!';
+    let server = RawHttpTestServer::spawn(vec![RawHttpAction::Respond(http_response(
+        "200 OK", &corrupted,
+    ))])
+    .await;
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 16, 32_768, 8, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+    wait_idle_pool_len(&env.idle_pool, 1, WAIT).await;
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(history_context(run_id, server.url(), HISTORY)),
+    );
+    let completion = env.handle.wait_completion(run_id, WAIT).await.unwrap();
+    assert_ne!(completion.exit_code, 0);
+    assert!(overrides.start_agent_process_calls().is_empty());
+    assert!(overrides.write_file_calls().is_empty());
+    server.assert_finished().await;
+    shutdown(&env, run_handle).await;
+    assert_eq!(budget.allocated().2, 0);
+}

--- a/crates/runner/src/cmd/start/tests/idle_reuse/mod.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse/mod.rs
@@ -1,4 +1,5 @@
 mod blank_pool;
+mod blank_session_history;
 mod device_limits;
 mod drain;
 mod parking;

--- a/crates/runner/src/executor/session_history_restore_plan.rs
+++ b/crates/runner/src/executor/session_history_restore_plan.rs
@@ -3,9 +3,10 @@
 //! Discovery builds a [`SessionHistoryRestorePlan`] after it knows whether an
 //! idle sandbox was reused and which session-history identity, if any, was
 //! parked with it. For a valid hash-backed resume, reuse can either select a
-//! verified skip or start remote materialization early. A fresh sandbox instead
-//! defers remote work so workspace preparation can first probe a matching
-//! cached sidecar.
+//! verified skip or start remote materialization early. A confirmed blank also
+//! starts remote work early without acquiring exact-reuse semantics. A fresh
+//! sandbox instead defers remote work so workspace preparation can first probe
+//! a matching cached sidecar.
 //!
 //! Fresh-workspace preparation resolves
 //! [`SessionHistoryRestorePlan::DeferredHashBacked`] into
@@ -36,6 +37,7 @@ use super::session_history_download::{SessionHistoryMaterializer, SessionHistory
 use super::telemetry::{RunnerPreSpawnPhase, RunnerPreSpawnTiming};
 use super::workspace_session_history_materializer::WorkspaceSessionHistoryMaterializer;
 use crate::http::HttpClient;
+use crate::idle_pool::IdleSandboxKind;
 use crate::restored_session_identity::{
     RestoredSessionIdentity, RestoredSessionIdentityMismatchReason,
 };
@@ -50,7 +52,7 @@ use crate::types::{ExecutionContext, SandboxReuseResult};
 /// it is discovered and recorded while consuming a verified-skip plan.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SessionHistoryRestoreFallback {
-    /// No idle sandbox was reused for the run.
+    /// No exact-session sandbox was reused; this also includes confirmed blanks.
     NonReuse,
     /// The reused idle sandbox had no parked session-history identity.
     MissingIdleIdentity,
@@ -167,6 +169,8 @@ pub(crate) struct SessionHistoryRestorePlanInput<'a> {
     pub(crate) context: &'a ExecutionContext,
     pub(crate) cancel: CancellationToken,
     pub(crate) reuse_result: SandboxReuseResult,
+    /// Actual resource kind after selection and successful unpark, not a reservation.
+    pub(crate) idle_kind: Option<IdleSandboxKind>,
     pub(crate) restored_identity: Option<&'a RestoredSessionIdentity>,
     pub(crate) pre_spawn_timing: &'a mut RunnerPreSpawnTiming,
     pub(crate) probe: Option<&'a SessionHistoryProbe>,
@@ -176,8 +180,9 @@ pub(crate) struct SessionHistoryRestorePlanInput<'a> {
 ///
 /// Absent or non-hash-backed resume state uses the ordinary `Default` path. A
 /// reused sandbox can select `SkipVerified` or start a `Prestarted`
-/// materializer. Non-reuse produces `DeferredHashBacked` so fresh-workspace
-/// preparation gets the first opportunity to use a matching local sidecar.
+/// materializer. A confirmed blank also prestarts without changing its non-exact
+/// reuse attribution. Fresh preparation produces `DeferredHashBacked` so a
+/// matching local workspace sidecar gets the first opportunity.
 pub(crate) fn build_session_history_restore_plan(
     input: SessionHistoryRestorePlanInput<'_>,
 ) -> SessionHistoryRestorePlan {
@@ -187,6 +192,7 @@ pub(crate) fn build_session_history_restore_plan(
         context,
         cancel,
         reuse_result,
+        idle_kind,
         restored_identity,
         pre_spawn_timing,
         probe,
@@ -241,7 +247,7 @@ pub(crate) fn build_session_history_restore_plan(
         | SandboxReuseResult::UnparkFailed => Some(SessionHistoryRestoreFallback::NonReuse),
     };
 
-    if reuse_result != SandboxReuseResult::Reused {
+    if reuse_result != SandboxReuseResult::Reused && idle_kind != Some(IdleSandboxKind::Blank) {
         return SessionHistoryRestorePlan::DeferredHashBacked { fallback };
     }
 
@@ -367,6 +373,8 @@ mod tests {
             context,
             cancel: CancellationToken::new(),
             reuse_result,
+            idle_kind: (reuse_result == SandboxReuseResult::Reused)
+                .then_some(IdleSandboxKind::Exact),
             restored_identity,
             pre_spawn_timing: &mut pre_spawn_timing,
             probe: None,

--- a/crates/runner/src/test_fixtures/raw_http.rs
+++ b/crates/runner/src/test_fixtures/raw_http.rs
@@ -15,6 +15,7 @@ const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 pub(crate) enum RawHttpAction {
     Respond(Vec<u8>),
     Disconnect,
+    WaitForDisconnect,
     WaitThenRespond {
         release: oneshot::Receiver<()>,
         response: Vec<u8>,
@@ -323,6 +324,18 @@ async fn serve(
                 write_response(index, &mut socket, &response).await?;
             }
             RawHttpAction::Disconnect => {}
+            RawHttpAction::WaitForDisconnect => {
+                let mut byte = [0];
+                let read = tokio::time::timeout(RAW_HTTP_FIXTURE_TIMEOUT, socket.read(&mut byte))
+                    .await
+                    .map_err(|_| fixture_timeout(index, "waiting for client disconnect"))??;
+                if read != 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "expected client disconnect without another request",
+                    ));
+                }
+            }
             RawHttpAction::WaitThenRespond { release, response } => {
                 release.await.map_err(|_| {
                     io::Error::new(

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -55,6 +55,10 @@ pub(crate) struct ExecOverrideState {
     pub(crate) calls: Mutex<Vec<ExecCall>>,
     /// Recorded fixed storage-manifest calls across all attached sandboxes.
     pub(crate) storage_manifest_calls: Mutex<Vec<StorageManifestCall>>,
+    /// Optional gate entered after recording a fixed storage-manifest call.
+    pub(crate) storage_manifest_gate: Mutex<Option<MockLifecycleGate>>,
+    /// FIFO results for fixed storage-manifest operations.
+    pub(crate) storage_manifest_results: Mutex<VecDeque<Result<ExecResult>>>,
     /// FIFO results for fixed workspace-drive mount operations.
     pub(crate) workspace_drive_mount_results: Mutex<VecDeque<Result<ExecResult>>>,
     /// Total fixed workspace-drive mount calls across attached sandboxes.
@@ -530,6 +534,19 @@ impl MockSandboxOverrides {
             .storage_manifest_calls
             .lock_ignoring_poison()
             .clone()
+    }
+
+    /// Block fixed storage-manifest operations until the gate is released.
+    pub fn set_storage_manifest_lifecycle_gate(&self, gate: MockLifecycleGate) {
+        *self.exec.storage_manifest_gate.lock_ignoring_poison() = Some(gate);
+    }
+
+    /// Queue a fixed storage-manifest result across attached sandboxes.
+    pub fn push_storage_manifest_result(&self, result: Result<ExecResult>) {
+        self.exec
+            .storage_manifest_results
+            .lock_ignoring_poison()
+            .push_back(result);
     }
 
     /// Queue a fixed workspace-drive mount result across attached sandboxes.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -851,11 +851,21 @@ impl Sandbox for MockSandbox {
                 .storage_manifest_calls
                 .lock_ignoring_poison()
                 .push(call);
+            wait_lifecycle_gate(&overrides.exec.storage_manifest_gate).await;
         }
         let result = self
             .exec_results
             .lock_ignoring_poison()
             .pop_front()
+            .or_else(|| {
+                self.overrides.as_ref().and_then(|overrides| {
+                    overrides
+                        .exec
+                        .storage_manifest_results
+                        .lock_ignoring_poison()
+                        .pop_front()
+                })
+            })
             .unwrap_or_else(|| Ok(default_exec_result()))?;
         Ok(apply_exec_output_limits(result, EXEC_OUTPUT_LIMIT_1_MIB))
     }

--- a/docs/testing/rust-testing.md
+++ b/docs/testing/rust-testing.md
@@ -182,6 +182,25 @@ fn masks_nested_json() {
 
 ## What to Test
 
+### Runner session-history overlap
+
+Exercise discovery and history planning through the full `run()` fixture in
+`cmd/start/tests/idle_reuse`. Use the external sandbox mock's
+`set_storage_manifest_lifecycle_gate` to hold storage apply and a controlled local
+HTTP response to hold history materialization. A received history request while
+storage is blocked proves automatic prestart; a manually constructed `Prestarted`
+plan does not cover that dispatch decision. Verify restored bytes and unchanged
+reuse attribution, and keep guest history writes and process start behind their
+required preparation boundaries.
+
+Use `RawHttpAction::WaitForDisconnect` when cancellation or an earlier preparation
+failure must release a pending download. Its bounded completion observes the
+client closing the request without making the response available. Synchronization
+deadlines bound test liveness; do not use elapsed-time thresholds to claim a
+performance improvement.
+
+### General coverage
+
 - **Config parsing**: round-trip (generate → load), validation of invalid inputs
 - **HTTP clients**: success, retry, error responses (via httpmock)
 - **Serialization**: serde round-trips for protocol types


### PR DESCRIPTION
## Summary

Confirmed blank sandbox hits currently carry non-exact reuse attribution and receive
a deferred history plan, although they never enter the fresh-workspace sidecar
resolver. Their remote history preparation therefore starts only after storage apply.

- Pass the final selected idle kind into the existing discovery history-plan builder.
  Confirmed blanks prestart the existing owned materializer; exact identity checks,
  blank reuse attribution and fresh/workspace sidecar priority are unchanged.
- Overlap only host-side history download/decompression/validation. Guest history
  restore remains after storage apply and before agent process start.
- Exercise the full run loop using external storage and HTTP synchronization gates:
  Claude/raw, Pi/gzip, Codex/zstd; keyed/unkeyed blanks; fallback request counts;
  corrupt history; storage failure; run cancellation and Runner stopping. Pending
  download cleanup is verified by the HTTP client disconnecting.

No API, database, guest protocol, history/cache representation, scheduler, archive
concurrency, CPU pool or size-limit changes. No feature flag or new detached task.

Relates to #32418. Parent: #24203 (not closed by this PR).
Existing follow-up #32475 owns large-history guest-write attribution; no transport
rewrite or artificial delay is included here.

## Code validation

Implementation validation for head `45a770396c128979e8b16bad4810466c96532bc6`:

- The new overlap test was run with a temporary old-behavior mutation excluding
  blanks from prestart. It failed waiting for the history request before storage
  finished. The mutation was removed and the implementation hash verified.
- `cargo fmt --all` and `cargo fmt --all -- --check` passed.
- `pnpm exec prettier --write ../docs/testing/rust-testing.md` passed, unchanged.
- `CARGO_INCREMENTAL=1 cargo clippy --profile local --all-targets --all-features` passed.
- `CARGO_INCREMENTAL=1 cargo doc --profile local --workspace --all-features --no-deps` passed.
- `CARGO_INCREMENTAL=1 cargo test --profile local -p runner -- --test-threads=4 --quiet`:
  3,549 main-binary tests and 1 inventory integration test passed; no failures;
  27 existing ignored entries, with no changes to skip/ignore configuration.
- `CARGO_INCREMENTAL=1 cargo test --profile local -p sandbox-mock`: 95 passed.
- The full Runner suite passed twice during implementation. Submitted-head
  self-review additionally reran `cargo fmt --all -- --check` and
  `CARGO_INCREMENTAL=1 cargo test --profile local -p runner --bin runner cmd::start::tests::idle_reuse -- --test-threads=4 --quiet`:
  57 passed, no failures or ignored tests. All selected checks ran in the foreground.

## Measured local-11 validation

The user separately authorized local-11 testing. All experiments used an isolated
owned service with real Firecracker VMs, a 2-vCPU/4096-MiB profile, immutable
baseline/candidate artifacts and synthetic host-local API/storage responses.
These measurements are synthetic claim-to-spawn, not production end-to-end gains.

- Original A/B/B/A matrix: 288/288 successful content checks, checkpoints and
  final cleanup. Claude gzip/zstd and Codex zstd input showed approximately
  13–18% median startup improvement in the smaller matched cells.
- Expanded A/B/B/A experiment: 656/656 successful runs. Each block contained
  100 no-history controls, 32 large raw-history starts, and 16 dual-start gzip
  batches. No samples or outliers were removed.

| Expanded measurement  | Repeat 1 baseline → candidate  | Repeat 2 baseline → candidate      |
| --------------------- | ------------------------------ | ---------------------------------- |
| Large raw history p50 | 1323 → 1241 ms (82 ms / 6.20%) | 1294.5 → 1256.5 ms (38 ms / 2.94%) |
| No-history p99        | 421.09 → 410.08 ms             | 392.04 → 421.06 ms                 |
| Dual-start gzip p99   | 1770.35 → 1570.09 ms           | 1657.69 → 1528.97 ms               |

Both expanded control/concurrent tail comparisons passed the original guardrail.
The original eight-sample control comparison's +52.85-ms p99 observation remains
recorded; it did not reproduce in the larger control experiment.

- Native Pi/Codex consumption: 12/12 raw/gzip/zstd cases passed, including actual
  checkpoint uploads and retained-compressed Codex restore. Only HTTP dependencies
  were synthetic. Pi separately consumes authoritative API-first H1; its restored
  H0 file check is not misrepresented as direct H0 consumption.
- Separate fixed 96-run storage-delay diagnostic: 96/96 passed. Startup timing
  affects guest write duration in both builds, but balloon causality is unproven.
  The artificial delay made total startup slower and is not a product change.
  These diagnostic cells do not replace the acceptance experiments.
- Expanded experiment SHA256:
  `ca65c99e96bacfaf466fac6d813e1b55453b239db42c480a094807328c152ef6`.
  Native-framework dataset SHA256:
  `a72b072bc08e2f39ee9732323dc4b384759fbcafbff37123650c8732f5905648`.
  Diagnostic dataset SHA256:
  `e463a62208cd914177f236e241c149fe1db04ddc440d171d1c6e556c34272b2b`.
  Raw artifacts and detailed reports are retained under
  `codex-work/research/issue-32418-current-path-review/local-11/` and the owned
  local-11 experiment directory. All three hashes match locally and remotely.

## Acceptance decision and remaining risks

After reviewing these results and costs, the user explicitly accepted actual
performance improvement without requiring every matched cell to exceed the
previous 10% and 50-ms materiality threshold. The measured benefit satisfies
that revised decision criterion. The old threshold was not met; no result is
discarded or relabeled as passing it.

Earlier work retains decoded history while storage proceeds and can contend with
concurrent starts. Expanded measurements observed Runner peak RSS increases of
27.30 / 28.70 MiB and own CPU per block increases of 3.4% / 9.7%. Process I/O
counters also differed; cache/writeback effects were not isolated. Do not claim
CPU/I/O neutrality. No OOM or observed admission violation occurred in the tested
workload. Per-object bounds and shared CPU permits are unchanged, but do not
provide an aggregate retained-buffer cap or validate all production concurrency.

Owned test service, VM inventory and synthetic HTTPS server are stopped, and
the service-only CA mount was removed. Other services and host trust are unchanged.
No production deployment or production improvement is claimed. Post-deployment
exact-cohort verification remains on #32418; this PR does not automatically close
that issue or parent #24203. Merge still requires explicit approval.
