### PR TITLE
refactor(api): prepare official workflow queue readers for canonical contexts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/official-workflows.test.ts
@@ -1,4 +1,14 @@
 import { createHash, randomUUID } from "node:crypto";
+import { gunzipSync } from "node:zlib";
+
+import {
+  chatEventRowSchema,
+  type ChatEventRow,
+} from "@okouai/api-contracts/contracts/chat-event-rows";
+import { testChatEventSearchProjectionContract } from "@okouai/api-contracts/contracts/test-chat-event-search-projection";
+import { testChatEventSnapshotContract } from "@okouai/api-contracts/contracts/test-chat-event-snapshot";
+import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
+import type { UserMessagePart } from "@okouai/api-contracts/contracts/chat-threads";
 
 import {
   DeleteObjectsCommand,
@@ -47,6 +57,14 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now, withMockNowForTest } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { flushWaitUntilForTest } from "../../context/wait-until";
+import {
+  appendOfficialWorkflowQueueInputFixture,
+  readOfficialWorkflowQueueInputFixture,
+  readOfficialWorkflowQueueRunFixture,
+} from "../../../test-fixtures/official-workflow-queue";
+import { verifyOkouToken } from "../../auth/tokens";
+import { testChatEventSearchProjectionRoutes } from "../test-chat-event-search-projection";
+import { testChatEventSnapshotRoutes } from "../test-chat-event-snapshot";
 import { installApiTestConnectorCatalog } from "../../../test-fixtures/connector-catalog";
 import {
   readMorningBriefDefaultEligibilityFixture,
@@ -61,6 +79,7 @@ import {
   mockStripeConnectorOAuth,
 } from "./helpers/api-bdd-connectors";
 import { createRunsApi } from "./helpers/api-bdd-runs";
+import { projectChatEventRows } from "./helpers/chat-event-test-reader";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import {
   createWorkflowsBddApi,
@@ -74,6 +93,8 @@ import {
   installOfficialWorkflowRunGateFixture,
   readAgentRunFamilyCountsFixture,
   readChatEventRowsAsPreviousApiFixture,
+  readChatEventSnapshotHead,
+  setRunAutonomyBudgetFixture,
   readLatestWorkflowAutomationRunFixture,
   readOfficialWorkflowRunStateFixture,
   readWorkflowAutomationAutonomyFixture,
@@ -1354,6 +1375,13 @@ function installCatalogStorageFixture() {
     return fallback(command);
   });
   return {
+    readObject(key: string): Buffer {
+      const object = objects.get(key);
+      if (!object) {
+        throw new Error(`Missing test snapshot object ${key}`);
+      }
+      return object;
+    },
     objectCount(): number {
       return objects.size;
     },
@@ -1379,6 +1407,197 @@ function installCatalogStorageFixture() {
       };
     },
   };
+}
+
+const officialQueueEncodings = [
+  { encoding: "legacy", origin: "web", brand: "vm0" },
+  { encoding: "canonical", origin: "web", brand: "okou" },
+  { encoding: "legacy", origin: "agent_run", brand: "okou" },
+  { encoding: "canonical", origin: "agent_run", brand: "vm0" },
+] as const;
+
+type OfficialQueueEncoding = (typeof officialQueueEncodings)[number];
+
+// Pin the persisted protocol independently of the production encoder.
+const officialQueueContextIds = {
+  legacy: {
+    vm0: "d4f079af-190a-4a32-bf49-73175aa2d727",
+    okou: "3f713f81-d611-47ec-a427-5a4844078890",
+  },
+  canonical: {
+    vm0: "e1884e98-ab77-4eca-a420-90e591078804",
+    okou: "0bdfae9e-63be-43dd-8193-a96e07787c20",
+  },
+} as const;
+
+function officialQueueHeaders(
+  actor: ApiTestUser,
+  sourceRunId: string,
+  queueCase: {
+    readonly origin: "web" | "agent_run";
+    readonly brand: PublicBrand;
+  },
+) {
+  return queueCase.origin === "web"
+    ? authHeaders(actor)
+    : {
+        authorization: `Bearer ${runs.okouTokenForRunWithCapabilities(
+          actor,
+          sourceRunId,
+          ["agent:write"],
+          queueCase.brand,
+        )}`,
+      };
+}
+
+async function prepareOfficialQueueEncoding(
+  args: OfficialQueueEncoding & {
+    readonly eventId: string;
+    readonly workflowId: string;
+    readonly sourceRunId: string;
+    readonly sourceThreadId: string;
+    readonly agentId: string;
+  },
+): Promise<string> {
+  const source = await readOfficialWorkflowQueueInputFixture(args.eventId);
+  expect(source).toMatchObject({
+    contextType: args.origin,
+    contextId: officialQueueContextIds.legacy[args.brand],
+    requiredOfficialWorkflowIds: [args.workflowId],
+  });
+  const userMessage = source.payload?.userMessage;
+  if (!userMessage) {
+    throw new Error("Expected queued Official document");
+  }
+  if (args.origin === "agent_run") {
+    expect(userMessage.parts).toContainEqual(
+      expect.objectContaining({
+        type: "source",
+        kind: "agent",
+        runId: args.sourceRunId,
+        threadId: args.sourceThreadId,
+        agentId: args.agentId,
+      }),
+    );
+  }
+  if (args.encoding === "legacy") {
+    return source.id;
+  }
+  const canonical = await appendOfficialWorkflowQueueInputFixture({
+    eventId: source.id,
+    contextId: officialQueueContextIds.canonical[args.brand],
+    contextType: args.origin,
+    claim: source.requiredOfficialWorkflowIds,
+    userMessage,
+  });
+  await expect(
+    readOfficialWorkflowQueueInputFixture(source.id),
+  ).resolves.toStrictEqual(source);
+  return canonical.id;
+}
+
+async function assertOfficialQueueRawHistory(
+  actor: ApiTestUser,
+  threadId: string,
+  eventId: string,
+): Promise<readonly ChatEventRow[]> {
+  const rows = await chat.listThreadEventRows(actor, threadId);
+  expect(rows).toContainEqual(
+    expect.objectContaining({ id: eventId, runId: null }),
+  );
+  const inputs = rows.filter((row) => {
+    return row.eventType === "input.prompt" && row.runId === null;
+  });
+  for (const row of rows) {
+    expect(row).not.toHaveProperty("requiredOfficialWorkflowIds");
+    expect(row).not.toHaveProperty("required_official_workflow_ids");
+    if (row.payload !== null) {
+      expect(row.payload).not.toHaveProperty("requiredOfficialWorkflowIds");
+    }
+  }
+  return inputs;
+}
+
+async function readOfficialQueueSnapshot(
+  threadId: string,
+  storage: ReturnType<typeof installCatalogStorageFixture>,
+) {
+  const head = await readChatEventSnapshotHead(context, threadId);
+  if (!head.object_key) {
+    throw new Error("Expected Official queue snapshot");
+  }
+  const rows = gunzipSync(storage.readObject(head.object_key))
+    .toString("utf8")
+    .trim()
+    .split("\n")
+    .map((line) => {
+      return chatEventRowSchema.parse(JSON.parse(line));
+    });
+  return { head, rows };
+}
+
+async function listOfficialQueueEvents(
+  actor: ApiTestUser,
+  threadId: string,
+  storage: ReturnType<typeof installCatalogStorageFixture>,
+) {
+  const snapshot = await readOfficialQueueSnapshot(threadId, storage);
+  if (
+    snapshot.head.terminal_event_id === null ||
+    snapshot.head.terminal_seq_id === null
+  ) {
+    throw new Error("Expected Official snapshot terminal cursor");
+  }
+  const tail = await chat.listThreadEventRows(actor, threadId, {
+    lastEventId: snapshot.head.terminal_event_id,
+    lastSeqId: snapshot.head.terminal_seq_id,
+  });
+  const rows = new Map(
+    [...snapshot.rows, ...tail].map((row) => {
+      return [row.id, row];
+    }),
+  );
+  return { events: projectChatEventRows([...rows.values()]) };
+}
+
+async function assertOfficialQueueSnapshot(
+  actor: ApiTestUser,
+  threadId: string,
+  sources: readonly ChatEventRow[],
+  storage: ReturnType<typeof installCatalogStorageFixture>,
+): Promise<void> {
+  for (const source of sources) {
+    await expect(
+      readOfficialWorkflowQueueInputFixture(source.id),
+    ).resolves.toMatchObject({
+      eventType: source.eventType,
+      contextType: source.contextType,
+      contextId: source.contextId,
+      seqId: source.seqId,
+      payload: source.payload,
+    });
+  }
+  await accept(
+    setupApp({ context, routes: testChatEventSearchProjectionRoutes })(
+      testChatEventSearchProjectionContract,
+    ).project({
+      body: { chat_thread_ids: [threadId] },
+    }),
+    [200],
+  );
+  await accept(
+    setupApp({ context, routes: testChatEventSnapshotRoutes })(
+      testChatEventSnapshotContract,
+    ).snapshot({
+      body: { chat_thread_ids: [threadId], r2_object_keys: [] },
+    }),
+    [200],
+  );
+  const { rows } = await readOfficialQueueSnapshot(threadId, storage);
+  for (const source of sources) {
+    expect(rows).toContainEqual(source);
+  }
+  await listOfficialQueueEvents(actor, threadId, storage);
 }
 
 async function setOfficialWorkflowsEnabled(
@@ -8849,465 +9068,899 @@ describe.sequential("Official Workflow Run admission", () => {
     await runs.requestCancelRun(actor, ordinary.body.runId, [200, 400]);
   });
 
-  it("preserves and terminalizes a queued Official source claim before draining the ordinary message behind it", async () => {
-    installCatalogStorageFixture();
-    const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
-    const definitionName = `api-test-queued-source-${suffix}`;
-    await syncCatalog(catalog([activeDefinition(definitionName, [])]));
-    const setup = await workflowBdd.setupWorkflowOrg();
-    const { actor } = setup;
-    const { agentId } = await workflowBdd.createAgent(actor);
-    const headers = authHeaders(actor);
-    await setOfficialWorkflowsEnabled(actor, true);
-    const installation = await accept(
-      officialClient().install({
-        headers,
-        params: { definitionName },
-        body: { agentId, blueprints: [] },
-      }),
-      [201],
-    );
-    onTestFinished(async () => {
-      installCatalogStorageFixture();
-      const createdRuns = await runs.listAgentRuns(actor, {
-        agent: agentId,
-        limit: 100,
-      });
-      for (const run of createdRuns.runs) {
-        await runs.requestCancelRun(actor, run.id, [200, 400]);
-      }
-      await bdd.deleteAgent(actor, agentId);
-      await cleanupCatalog();
-    });
-
-    runs.configureRunnerGroup();
-    runs.acceptStorageDownloads();
-    const first = await accept(
-      workflowClient().run({
-        headers,
-        params: { workflowId: installation.body.workflow.id },
-      }),
-      [200],
-    );
-    if (!first.body.runId) {
-      throw new Error("Expected first Official Workflow Run");
-    }
-    const firstRunId = first.body.runId;
-    const firstClaim = await runs.claimRunnerJob(firstRunId);
-    const beforeQueuedEvents = await chat.listThreadEvents(
-      actor,
-      first.body.chatThreadId,
-    );
-    const beforeQueuedEventIds = new Set(
-      beforeQueuedEvents.events.map((event) => {
-        return event.id;
-      }),
-    );
-    const beforeQueuedRunFamily = await readAgentRunFamilyCountsFixture(
-      context,
-      agentId,
-    );
-
-    const queuedOfficial = await accept(
-      workflowClient().run({
-        headers,
-        params: { workflowId: installation.body.workflow.id },
-      }),
-      [200],
-    );
-    expect(queuedOfficial.body).toMatchObject({
-      chatThreadId: first.body.chatThreadId,
-      runId: null,
-    });
-    const afterOfficialQueued = await chat.listThreadEvents(
-      actor,
-      first.body.chatThreadId,
-    );
-    const officialQueuedEvent = afterOfficialQueued.events.find((event) => {
-      return (
-        event.eventType === "input.prompt" &&
-        !beforeQueuedEventIds.has(event.id)
+  it.each(officialQueueEncodings)(
+    "preserves and terminalizes a queued Official source claim before draining the ordinary message behind it ($encoding $origin $brand)",
+    async (queueCase) => {
+      const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
+      const definitionName = `api-test-queued-source-${suffix}`;
+      const setup = await workflowBdd.setupWorkflowOrg();
+      const { actor } = setup;
+      const { agentId } = await workflowBdd.createAgent(actor);
+      const storage = installCatalogStorageFixture();
+      await syncCatalog(catalog([activeDefinition(definitionName, [])]));
+      const headers = authHeaders(actor);
+      await setOfficialWorkflowsEnabled(actor, true);
+      const installation = await accept(
+        officialClient().install({
+          headers,
+          params: { definitionName },
+          body: { agentId, blueprints: [] },
+        }),
+        [201],
       );
-    });
-    if (!officialQueuedEvent) {
-      throw new Error("Expected persisted Official queued message");
-    }
+      onTestFinished(async () => {
+        installCatalogStorageFixture();
+        const createdRuns = await runs.listAgentRuns(actor, {
+          agent: agentId,
+          limit: 100,
+        });
+        for (const run of createdRuns.runs) {
+          await runs.requestCancelRun(actor, run.id, [200, 400]);
+        }
+        await flushWaitUntilForTest();
+        await bdd.deleteAgent(actor, agentId);
+        await cleanupCatalog();
+      });
 
-    const ordinaryPrompt = `ordinary queued control ${suffix}`;
-    const ordinaryQueuedEventId = randomUUID();
-    const queuedOrdinary = await chat.requestSendEvent(
-      actor,
-      {
-        agentId,
-        threadId: first.body.chatThreadId,
-        prompt: ordinaryPrompt,
-        clientEventId: ordinaryQueuedEventId,
-      },
-      [201],
-    );
-    if ("error" in queuedOrdinary.body) {
-      throw new Error(queuedOrdinary.body.error.message);
-    }
-    expect(queuedOrdinary.body.runId).toBeNull();
-
-    const previousReaderBeforeResolution =
-      await readChatEventRowsAsPreviousApiFixture(
-        context,
+      runs.configureRunnerGroup();
+      runs.acceptStorageDownloads();
+      const first = await accept(
+        workflowClient().run({
+          headers,
+          params: { workflowId: installation.body.workflow.id },
+        }),
+        [200],
+      );
+      if (!first.body.runId) {
+        throw new Error("Expected first Official Workflow Run");
+      }
+      const firstRunId = first.body.runId;
+      await expect(runs.readRun(actor, firstRunId)).resolves.toMatchObject({
+        status: "pending",
+      });
+      await expect(
+        readOfficialWorkflowRunStateFixture(context, firstRunId),
+      ).resolves.toMatchObject({ runner_job_count: 1 });
+      const firstClaim = await runs.claimRunnerJob(firstRunId);
+      await setRunAutonomyBudgetFixture(context, firstRunId, 4);
+      const queueHeaders = officialQueueHeaders(actor, firstRunId, queueCase);
+      const beforeQueuedEvents = await chat.listThreadEvents(
+        actor,
         first.body.chatThreadId,
       );
-    const previousReaderOfficialSource = previousReaderBeforeResolution.find(
-      (event) => {
-        return event.id === officialQueuedEvent.id;
-      },
-    );
-    if (!previousReaderOfficialSource) {
-      throw new Error("Previous API reader missed queued Official input");
-    }
-    expect(previousReaderOfficialSource).toMatchObject({
-      event_type: "input.prompt",
-      revokes_event_id: null,
-    });
-    expect(previousReaderOfficialSource.payload_keys).not.toContain(
-      "requiredOfficialWorkflowIds",
-    );
+      const beforeQueuedEventIds = new Set(
+        beforeQueuedEvents.events.map((event) => {
+          return event.id;
+        }),
+      );
+      const beforeQueuedRunFamily = await readAgentRunFamilyCountsFixture(
+        context,
+        agentId,
+      );
 
-    await accept(
-      installationClient().uninstall({
-        headers,
-        params: { workflowId: installation.body.workflow.id },
-      }),
-      [204],
-    );
-    await webhooks.requestAgentComplete(
-      { runId: firstRunId, exitCode: 1 },
-      { authorization: `Bearer ${firstClaim.sandboxToken}` },
-      [200],
-    );
-    await flushWaitUntilForTest();
+      const queuedOfficial = await accept(
+        workflowClient().run({
+          headers: queueHeaders,
+          extraHeaders: { origin: `https://app.${queueCase.brand}.ai` },
+          params: { workflowId: installation.body.workflow.id },
+        }),
+        [200],
+      );
+      expect(queuedOfficial.body).toMatchObject({
+        chatThreadId: first.body.chatThreadId,
+        runId: null,
+      });
+      const afterOfficialQueued = await chat.listThreadEvents(
+        actor,
+        first.body.chatThreadId,
+      );
+      const officialQueuedEvent = afterOfficialQueued.events.find((event) => {
+        return (
+          event.eventType === "input.prompt" &&
+          !beforeQueuedEventIds.has(event.id)
+        );
+      });
+      if (!officialQueuedEvent) {
+        throw new Error("Expected persisted Official queued message");
+      }
 
-    await expect
-      .poll(async () => {
-        const events = await chat.listThreadEvents(
+      const officialQueuedEventId = await prepareOfficialQueueEncoding({
+        eventId: officialQueuedEvent.id,
+        workflowId: installation.body.workflow.id,
+        sourceRunId: firstRunId,
+        sourceThreadId: first.body.chatThreadId,
+        agentId,
+        ...queueCase,
+      });
+      const immutableSource = await assertOfficialQueueRawHistory(
+        actor,
+        first.body.chatThreadId,
+        officialQueuedEventId,
+      );
+      await assertOfficialQueueSnapshot(
+        actor,
+        first.body.chatThreadId,
+        immutableSource,
+        storage,
+      );
+
+      const ordinaryPrompt = `ordinary queued control ${suffix}`;
+      const ordinaryQueuedEventId = randomUUID();
+      const queuedOrdinary = await chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          threadId: first.body.chatThreadId,
+          prompt: ordinaryPrompt,
+          clientEventId: ordinaryQueuedEventId,
+        },
+        [201],
+      );
+      if ("error" in queuedOrdinary.body) {
+        throw new Error(queuedOrdinary.body.error.message);
+      }
+      expect(queuedOrdinary.body.runId).toBeNull();
+
+      const previousReaderBeforeResolution =
+        await readChatEventRowsAsPreviousApiFixture(
+          context,
+          first.body.chatThreadId,
+        );
+      const previousReaderOfficialSource = previousReaderBeforeResolution.find(
+        (event) => {
+          return event.id === officialQueuedEventId;
+        },
+      );
+      if (!previousReaderOfficialSource) {
+        throw new Error("Previous API reader missed queued Official input");
+      }
+      expect(previousReaderOfficialSource).toMatchObject({
+        event_type: "input.prompt",
+        revokes_event_id: null,
+      });
+      expect(previousReaderOfficialSource.payload_keys).not.toContain(
+        "requiredOfficialWorkflowIds",
+      );
+
+      await accept(
+        installationClient().uninstall({
+          headers,
+          params: { workflowId: installation.body.workflow.id },
+        }),
+        [204],
+      );
+      await webhooks.requestAgentComplete(
+        { runId: firstRunId, exitCode: 1 },
+        { authorization: `Bearer ${firstClaim.sandboxToken}` },
+        [200],
+      );
+      await flushWaitUntilForTest();
+
+      await expect
+        .poll(async () => {
+          const events = await listOfficialQueueEvents(
+            actor,
+            first.body.chatThreadId,
+            storage,
+          );
+          return events.events.filter((event) => {
+            return (
+              event.eventType === "input.rejected" &&
+              event.revokesEventId === officialQueuedEventId &&
+              event.error === "conflict"
+            );
+          }).length;
+        })
+        .toBe(1);
+      const afterOfficialFailure = await listOfficialQueueEvents(
+        actor,
+        first.body.chatThreadId,
+        storage,
+      );
+      expect(
+        afterOfficialFailure.events.filter((event) => {
+          return (
+            event.eventType === "input.rejected" &&
+            event.revokesEventId === officialQueuedEventId &&
+            event.error === "conflict"
+          );
+        }),
+      ).toHaveLength(1);
+      expect(
+        afterOfficialFailure.events.filter((event) => {
+          return (
+            event.eventType === "output.error" &&
+            event.error === "conflict" &&
+            typeof event.content === "string" &&
+            event.content.length > 0
+          );
+        }),
+      ).toHaveLength(1);
+      const previousReaderAfterResolution =
+        await readChatEventRowsAsPreviousApiFixture(
+          context,
+          first.body.chatThreadId,
+        );
+      expect(
+        previousReaderAfterResolution.find((event) => {
+          return event.id === officialQueuedEventId;
+        }),
+      ).toMatchObject(previousReaderOfficialSource);
+      expect(
+        previousReaderAfterResolution.filter((event) => {
+          return (
+            event.event_type === "input.rejected" &&
+            event.revokes_event_id === officialQueuedEventId
+          );
+        }),
+      ).toHaveLength(1);
+      await expect(
+        readAgentRunFamilyCountsFixture(context, agentId),
+      ).resolves.toStrictEqual(beforeQueuedRunFamily);
+
+      await assertOfficialQueueSnapshot(
+        actor,
+        first.body.chatThreadId,
+        immutableSource,
+        storage,
+      );
+
+      const staleAt = now() + 10 * 60 * 1000;
+      await withMockNowForTest(staleAt, async () => {
+        await reconcileStaleQueuedMessages(first.body.chatThreadId);
+      });
+      await flushWaitUntilForTest();
+      let ordinaryRunId: string | undefined;
+      await expect
+        .poll(async () => {
+          const listed = await runs.listAgentRuns(actor, {
+            agent: agentId,
+            limit: 100,
+          });
+          ordinaryRunId = listed.runs.find((run) => {
+            return run.prompt === ordinaryPrompt;
+          })?.id;
+          return ordinaryRunId;
+        })
+        .toStrictEqual(expect.any(String));
+      if (!ordinaryRunId) {
+        throw new Error("Expected ordinary queued control Run");
+      }
+      await expect(
+        readOfficialWorkflowRunStateFixture(context, ordinaryRunId),
+      ).resolves.toMatchObject({
+        provenance: null,
+        runner_job_count: 1,
+      });
+      const expectedRunFamilyAfterOrdinary = {
+        run_count: beforeQueuedRunFamily.run_count + 1,
+        callback_count: beforeQueuedRunFamily.callback_count + 1,
+        runner_job_count: beforeQueuedRunFamily.runner_job_count + 1,
+        launch_queue_count: beforeQueuedRunFamily.launch_queue_count,
+      };
+      await expect(
+        readAgentRunFamilyCountsFixture(context, agentId),
+      ).resolves.toStrictEqual(expectedRunFamilyAfterOrdinary);
+
+      const ordinaryClaim = await runs.claimRunnerJob(ordinaryRunId);
+      await webhooks.requestAgentComplete(
+        { runId: ordinaryRunId, exitCode: 1 },
+        { authorization: `Bearer ${ordinaryClaim.sandboxToken}` },
+        [200],
+      );
+      await flushWaitUntilForTest();
+      const beforeLaterDrain = await readAgentRunFamilyCountsFixture(
+        context,
+        agentId,
+      );
+      await withMockNowForTest(staleAt + 10 * 60 * 1000, async () => {
+        await reconcileStaleQueuedMessages(first.body.chatThreadId);
+      });
+      await flushWaitUntilForTest();
+
+      const afterLaterDrain = await listOfficialQueueEvents(
+        actor,
+        first.body.chatThreadId,
+        storage,
+      );
+      expect(
+        afterLaterDrain.events.filter((event) => {
+          return (
+            event.eventType === "input.rejected" &&
+            event.revokesEventId === officialQueuedEventId &&
+            event.error === "conflict"
+          );
+        }),
+      ).toHaveLength(1);
+      expect(
+        afterLaterDrain.events.filter((event) => {
+          return (
+            event.eventType === "output.error" &&
+            event.error === "conflict" &&
+            typeof event.content === "string" &&
+            event.content.length > 0
+          );
+        }),
+      ).toHaveLength(1);
+      expect(
+        afterLaterDrain.events.filter((event) => {
+          return (
+            event.revokesEventId === ordinaryQueuedEventId &&
+            event.runId === ordinaryRunId
+          );
+        }),
+      ).toHaveLength(1);
+      await expect(
+        readAgentRunFamilyCountsFixture(context, agentId),
+      ).resolves.toStrictEqual(beforeLaterDrain);
+    },
+  );
+
+  it.each(officialQueueEncodings)(
+    "keeps a queued Official source claim retryable across an unexpected persisted-revision failure ($encoding $origin $brand)",
+    async (queueCase) => {
+      const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
+      const definitionName = `api-test-queued-retry-${suffix}`;
+      const setup = await workflowBdd.setupWorkflowOrg();
+      const { actor } = setup;
+      const { agentId } = await workflowBdd.createAgent(actor);
+      const storage = installCatalogStorageFixture();
+      await syncCatalog(catalog([activeDefinition(definitionName, [])]));
+      const headers = authHeaders(actor);
+      await setOfficialWorkflowsEnabled(actor, true);
+      const installation = await accept(
+        officialClient().install({
+          headers,
+          params: { definitionName },
+          body: { agentId, blueprints: [] },
+        }),
+        [201],
+      );
+      onTestFinished(async () => {
+        installCatalogStorageFixture();
+        const createdRuns = await runs.listAgentRuns(actor, {
+          agent: agentId,
+          limit: 100,
+        });
+        for (const run of createdRuns.runs) {
+          await runs.requestCancelRun(actor, run.id, [200, 400]);
+        }
+        await flushWaitUntilForTest();
+        await bdd.deleteAgent(actor, agentId);
+        await cleanupCatalog();
+      });
+
+      runs.configureRunnerGroup();
+      runs.acceptStorageDownloads();
+      const first = await accept(
+        workflowClient().run({
+          headers,
+          params: { workflowId: installation.body.workflow.id },
+        }),
+        [200],
+      );
+      if (!first.body.runId) {
+        throw new Error("Expected first Official Workflow Run");
+      }
+      const firstRunId = first.body.runId;
+      await expect(runs.readRun(actor, firstRunId)).resolves.toMatchObject({
+        status: "pending",
+      });
+      await expect(
+        readOfficialWorkflowRunStateFixture(context, firstRunId),
+      ).resolves.toMatchObject({ runner_job_count: 1 });
+      const firstClaim = await runs.claimRunnerJob(firstRunId);
+      await setRunAutonomyBudgetFixture(context, firstRunId, 4);
+      const queueHeaders = officialQueueHeaders(actor, firstRunId, queueCase);
+      const beforeQueueEvents = await chat.listThreadEvents(
+        actor,
+        first.body.chatThreadId,
+      );
+      const beforeQueueEventIds = new Set(
+        beforeQueueEvents.events.map((event) => {
+          return event.id;
+        }),
+      );
+      const beforeQueuedRunFamily = await readAgentRunFamilyCountsFixture(
+        context,
+        agentId,
+      );
+
+      const queued = await accept(
+        workflowClient().run({
+          headers: queueHeaders,
+          extraHeaders: { origin: `https://app.${queueCase.brand}.ai` },
+          params: { workflowId: installation.body.workflow.id },
+        }),
+        [200],
+      );
+      expect(queued.body.runId).toBeNull();
+      const afterQueued = await chat.listThreadEvents(
+        actor,
+        first.body.chatThreadId,
+      );
+      const queuedEvent = afterQueued.events.find((event) => {
+        return (
+          event.eventType === "input.prompt" &&
+          !beforeQueueEventIds.has(event.id)
+        );
+      });
+      if (!queuedEvent) {
+        throw new Error("Expected persisted retryable Official queued message");
+      }
+
+      const queuedEventId = await prepareOfficialQueueEncoding({
+        eventId: queuedEvent.id,
+        workflowId: installation.body.workflow.id,
+        sourceRunId: firstRunId,
+        sourceThreadId: first.body.chatThreadId,
+        agentId,
+        ...queueCase,
+      });
+      const immutableSource = await assertOfficialQueueRawHistory(
+        actor,
+        first.body.chatThreadId,
+        queuedEventId,
+      );
+      await assertOfficialQueueSnapshot(
+        actor,
+        first.body.chatThreadId,
+        immutableSource,
+        storage,
+      );
+
+      await corruptOfficialWorkflowRevisionPayloadFixture(
+        context,
+        definitionName,
+      );
+      await webhooks.requestAgentComplete(
+        { runId: firstRunId, exitCode: 1 },
+        { authorization: `Bearer ${firstClaim.sandboxToken}` },
+        [200],
+      );
+      await flushWaitUntilForTest();
+
+      const afterUnexpectedFailure = await listOfficialQueueEvents(
+        actor,
+        first.body.chatThreadId,
+        storage,
+      );
+      expect(
+        afterUnexpectedFailure.events.filter((event) => {
+          return event.revokesEventId === queuedEventId;
+        }),
+      ).toHaveLength(0);
+      await expect(
+        readAgentRunFamilyCountsFixture(context, agentId),
+      ).resolves.toStrictEqual({
+        run_count: beforeQueuedRunFamily.run_count,
+        callback_count: beforeQueuedRunFamily.callback_count,
+        runner_job_count: beforeQueuedRunFamily.runner_job_count,
+        launch_queue_count: beforeQueuedRunFamily.launch_queue_count,
+      });
+
+      await cleanupCatalog();
+      await syncCatalog(
+        catalog([
+          activeDefinition(
+            definitionName,
+            [],
+            "Execute the repaired accepted Definition content.",
+          ),
+        ]),
+      );
+      const repaired = await readAcceptedDefinitionFixture(definitionName);
+      await withMockNowForTest(now() + 10 * 60 * 1000, async () => {
+        await reconcileStaleQueuedMessages(first.body.chatThreadId);
+      });
+      await flushWaitUntilForTest();
+
+      let retriedRunId: string | undefined;
+      await expect
+        .poll(async () => {
+          const listed = await runs.listAgentRuns(actor, {
+            agent: agentId,
+            limit: 100,
+          });
+          retriedRunId = listed.runs.find((run) => {
+            return run.id !== firstRunId;
+          })?.id;
+          return retriedRunId;
+        })
+        .toStrictEqual(expect.any(String));
+      if (!retriedRunId) {
+        throw new Error("Expected retried Official queued Run");
+      }
+      await expect(
+        readOfficialWorkflowRunStateFixture(context, retriedRunId),
+      ).resolves.toMatchObject({
+        provenance: {
+          definitions: [
+            {
+              name: definitionName,
+              revision: repaired.definition.revision,
+            },
+          ],
+        },
+        runner_job_count: 1,
+      });
+      const afterRetry = await listOfficialQueueEvents(
+        actor,
+        first.body.chatThreadId,
+        storage,
+      );
+      expect(
+        afterRetry.events.filter((event) => {
+          return (
+            event.revokesEventId === queuedEventId &&
+            event.runId === retriedRunId
+          );
+        }),
+      ).toHaveLength(1);
+      await expect(
+        readOfficialWorkflowQueueRunFixture(retriedRunId),
+      ).resolves.toStrictEqual({
+        triggerSource: queueCase.origin === "agent_run" ? "agent" : "web",
+        autonomyBudget: queueCase.origin === "agent_run" ? 3 : 10,
+      });
+      const retriedRun = await runs.readRun(actor, retriedRunId);
+      if (queueCase.origin === "agent_run") {
+        expect(retriedRun.appendSystemPrompt).toContain(
+          `SOURCE_RUN_ID: ${firstRunId}`,
+        );
+        expect(retriedRun.appendSystemPrompt).toContain(
+          `SOURCE_THREAD_ID: ${first.body.chatThreadId}`,
+        );
+      }
+      await expect(
+        readAgentRunFamilyCountsFixture(context, agentId),
+      ).resolves.toStrictEqual({
+        run_count: beforeQueuedRunFamily.run_count + 1,
+        callback_count: beforeQueuedRunFamily.callback_count + 1,
+        runner_job_count: beforeQueuedRunFamily.runner_job_count + 1,
+        launch_queue_count: beforeQueuedRunFamily.launch_queue_count,
+      });
+      const retriedClaim = await runs.claimRunnerJob(retriedRunId);
+      const token = retriedClaim.platformEnvironment.OKOU_TOKEN;
+      if (!token) {
+        throw new Error("Expected queued Run Okou token");
+      }
+      expect(verifyOkouToken(token)).toMatchObject({
+        publicBrand: queueCase.brand,
+      });
+
+      await webhooks.requestAgentComplete(
+        { runId: retriedRunId, exitCode: 1 },
+        { authorization: `Bearer ${retriedClaim.sandboxToken}` },
+        [200],
+      );
+      await flushWaitUntilForTest();
+      await assertOfficialQueueSnapshot(
+        actor,
+        first.body.chatThreadId,
+        immutableSource,
+        storage,
+      );
+      await withMockNowForTest(now() + 20 * 60 * 1000, async () => {
+        await reconcileStaleQueuedMessages(first.body.chatThreadId);
+      });
+      await flushWaitUntilForTest();
+      await expect(
+        readAgentRunFamilyCountsFixture(context, agentId),
+      ).resolves.toStrictEqual({
+        run_count: beforeQueuedRunFamily.run_count + 1,
+        callback_count: beforeQueuedRunFamily.callback_count + 1,
+        runner_job_count: beforeQueuedRunFamily.runner_job_count,
+        launch_queue_count: beforeQueuedRunFamily.launch_queue_count,
+      });
+    },
+  );
+
+  it.each([
+    {
+      name: "legacy web without claim",
+      encoding: "legacy",
+      origin: "web",
+      claim: "none",
+      source: "present",
+      outcome: "invariant",
+    },
+    {
+      name: "legacy agent without claim",
+      encoding: "legacy",
+      origin: "agent_run",
+      claim: "none",
+      source: "present",
+      outcome: "invariant",
+    },
+    {
+      name: "canonical agent brand without claim",
+      encoding: "canonical",
+      origin: "agent_run",
+      claim: "none",
+      source: "present",
+      outcome: "invariant",
+    },
+    {
+      name: "real source Run with claim",
+      encoding: "source-run",
+      origin: "agent_run",
+      claim: "valid",
+      source: "present",
+      outcome: "invariant",
+    },
+    {
+      name: "arbitrary agent UUID with claim",
+      encoding: "unknown",
+      origin: "agent_run",
+      claim: "valid",
+      source: "present",
+      outcome: "invariant",
+    },
+    {
+      name: "unknown web brand with claim",
+      encoding: "unknown",
+      origin: "web",
+      claim: "valid",
+      source: "present",
+      outcome: "invariant",
+    },
+    {
+      name: "unsupported context with claim",
+      encoding: "canonical",
+      origin: "slack",
+      claim: "valid",
+      source: "present",
+      outcome: "invariant",
+    },
+    {
+      name: "duplicate claim",
+      encoding: "canonical",
+      origin: "web",
+      claim: "duplicate",
+      source: "present",
+      outcome: "invariant",
+    },
+    {
+      name: "empty claim",
+      encoding: "canonical",
+      origin: "web",
+      claim: "empty",
+      source: "present",
+      outcome: "storage",
+    },
+    {
+      name: "invalid UUID claim",
+      encoding: "canonical",
+      origin: "web",
+      claim: "invalid",
+      source: "present",
+      outcome: "storage",
+    },
+    {
+      name: "legacy missing annotation",
+      encoding: "legacy",
+      origin: "agent_run",
+      claim: "valid",
+      source: "annotation-missing",
+      outcome: "invariant",
+    },
+    {
+      name: "canonical missing annotation",
+      encoding: "canonical",
+      origin: "agent_run",
+      claim: "valid",
+      source: "annotation-missing",
+      outcome: "invariant",
+    },
+    {
+      name: "legacy missing source Run",
+      encoding: "legacy",
+      origin: "agent_run",
+      claim: "valid",
+      source: "run-missing",
+      outcome: "unavailable",
+    },
+    {
+      name: "canonical missing source Run",
+      encoding: "canonical",
+      origin: "agent_run",
+      claim: "valid",
+      source: "run-missing",
+      outcome: "unavailable",
+    },
+    {
+      name: "canonical exhausted source budget",
+      encoding: "canonical",
+      origin: "agent_run",
+      claim: "valid",
+      source: "exhausted",
+      outcome: "exhausted",
+    },
+  ] as const)(
+    "fails closed for queued Official input: $name",
+    async (queueCase) => {
+      installCatalogStorageFixture();
+      const definitionName = `api-test-queued-invalid-${randomUUID().slice(0, 8)}`;
+      await syncCatalog(catalog([activeDefinition(definitionName, [])]));
+      const { actor } = await workflowBdd.setupWorkflowOrg();
+      const { agentId } = await workflowBdd.createAgent(actor);
+      const headers = authHeaders(actor);
+      await setOfficialWorkflowsEnabled(actor, true);
+      const installation = await accept(
+        officialClient().install({
+          headers,
+          params: { definitionName },
+          body: { agentId, blueprints: [] },
+        }),
+        [201],
+      );
+      onTestFinished(async () => {
+        installCatalogStorageFixture();
+        const createdRuns = await runs.listAgentRuns(actor, {
+          agent: agentId,
+          limit: 100,
+        });
+        for (const run of createdRuns.runs) {
+          await runs.requestCancelRun(actor, run.id, [200, 400]);
+        }
+        await flushWaitUntilForTest();
+        await bdd.deleteAgent(actor, agentId);
+        await cleanupCatalog();
+      });
+      runs.configureRunnerGroup();
+      runs.acceptStorageDownloads();
+      const first = await accept(
+        workflowClient().run({
+          headers,
+          params: { workflowId: installation.body.workflow.id },
+        }),
+        [200],
+      );
+      const firstRunId = first.body.runId;
+      if (!firstRunId) {
+        throw new Error("Expected active queue blocker");
+      }
+      const firstClaim = await runs.claimRunnerJob(firstRunId);
+      const beforeQueued = await chat.listThreadEvents(
+        actor,
+        first.body.chatThreadId,
+      );
+      const beforeIds = new Set(
+        beforeQueued.events.map((event) => {
+          return event.id;
+        }),
+      );
+      await accept(
+        workflowClient().run({
+          headers: officialQueueHeaders(actor, firstRunId, {
+            origin: "agent_run",
+            brand: "okou",
+          }),
+          params: { workflowId: installation.body.workflow.id },
+        }),
+        [200],
+      );
+      const queued = (
+        await chat.listThreadEvents(actor, first.body.chatThreadId)
+      ).events.find((event) => {
+        return event.eventType === "input.prompt" && !beforeIds.has(event.id);
+      });
+      if (queued?.eventType !== "input.prompt") {
+        throw new Error("Expected server-annotated Official queued input");
+      }
+      const original = await readOfficialWorkflowQueueInputFixture(queued.id);
+      const counts = await readAgentRunFamilyCountsFixture(context, agentId);
+      const missingRunId = randomUUID();
+      const userMessage = {
+        ...queued.userMessage,
+        parts: queued.userMessage.parts.flatMap<UserMessagePart>((part) => {
+          if (part.type !== "source" || part.kind !== "agent") {
+            return [part];
+          }
+          if (queueCase.source === "annotation-missing") {
+            return [];
+          }
+          return [
+            queueCase.source === "run-missing"
+              ? {
+                  ...part,
+                  runId: missingRunId,
+                  href: `/chats/${first.body.chatThreadId}#run-${missingRunId}`,
+                }
+              : part,
+          ];
+        }),
+      };
+      const claim =
+        queueCase.claim === "none"
+          ? null
+          : queueCase.claim === "empty"
+            ? []
+            : queueCase.claim === "invalid"
+              ? ["not-a-uuid"]
+              : queueCase.claim === "duplicate"
+                ? [installation.body.workflow.id, installation.body.workflow.id]
+                : [installation.body.workflow.id];
+      const append = appendOfficialWorkflowQueueInputFixture({
+        eventId: queued.id,
+        contextId:
+          queueCase.encoding === "source-run"
+            ? firstRunId
+            : queueCase.encoding === "unknown"
+              ? randomUUID()
+              : officialQueueContextIds[queueCase.encoding].okou,
+        contextType: queueCase.origin,
+        claim,
+        userMessage,
+      });
+      if (queueCase.outcome === "storage") {
+        await expect(append).rejects.toMatchObject({
+          cause: {
+            code: queueCase.claim === "empty" ? "23514" : "22P02",
+          },
+        });
+        await expect(
+          readOfficialWorkflowQueueInputFixture(queued.id),
+        ).resolves.toStrictEqual(original);
+        const rows = await chat.listThreadEventRows(
           actor,
           first.body.chatThreadId,
         );
-        return events.events.filter((event) => {
-          return (
-            event.eventType === "input.rejected" &&
-            event.revokesEventId === officialQueuedEvent.id &&
-            event.error === "conflict"
-          );
-        }).length;
-      })
-      .toBe(1);
-    const afterOfficialFailure = await chat.listThreadEvents(
-      actor,
-      first.body.chatThreadId,
-    );
-    expect(
-      afterOfficialFailure.events.filter((event) => {
-        return (
-          event.eventType === "input.rejected" &&
-          event.revokesEventId === officialQueuedEvent.id &&
-          event.error === "conflict"
-        );
-      }),
-    ).toHaveLength(1);
-    expect(
-      afterOfficialFailure.events.filter((event) => {
-        return (
-          event.eventType === "output.error" &&
-          event.error === "conflict" &&
-          typeof event.content === "string" &&
-          event.content.length > 0
-        );
-      }),
-    ).toHaveLength(1);
-    const previousReaderAfterResolution =
-      await readChatEventRowsAsPreviousApiFixture(
-        context,
+        expect(
+          rows.some((row) => {
+            return row.revokesEventId === queued.id;
+          }),
+        ).toBeFalsy();
+        await expect(
+          readAgentRunFamilyCountsFixture(context, agentId),
+        ).resolves.toStrictEqual(counts);
+        return;
+      }
+      const invalid = await append;
+      await expect(
+        readOfficialWorkflowQueueInputFixture(queued.id),
+      ).resolves.toStrictEqual(original);
+      if (queueCase.source === "exhausted") {
+        await setRunAutonomyBudgetFixture(context, firstRunId, 0);
+      }
+      await webhooks.requestAgentComplete(
+        { runId: firstRunId, exitCode: 1 },
+        { authorization: `Bearer ${firstClaim.sandboxToken}` },
+        [200],
+      );
+      await flushWaitUntilForTest();
+      await withMockNowForTest(now() + 10 * 60 * 1000, async () => {
+        await reconcileStaleQueuedMessages(first.body.chatThreadId);
+      });
+      await flushWaitUntilForTest();
+      const after = await chat.listThreadEventRows(
+        actor,
         first.body.chatThreadId,
       );
-    expect(
-      previousReaderAfterResolution.find((event) => {
-        return event.id === officialQueuedEvent.id;
-      }),
-    ).toMatchObject(previousReaderOfficialSource);
-    expect(
-      previousReaderAfterResolution.filter((event) => {
-        return (
-          event.event_type === "input.rejected" &&
-          event.revokes_event_id === officialQueuedEvent.id
-        );
-      }),
-    ).toHaveLength(1);
-    await expect(
-      readAgentRunFamilyCountsFixture(context, agentId),
-    ).resolves.toStrictEqual(beforeQueuedRunFamily);
-
-    const staleAt = now() + 10 * 60 * 1000;
-    await withMockNowForTest(staleAt, async () => {
-      await reconcileStaleQueuedMessages(first.body.chatThreadId);
-    });
-    await flushWaitUntilForTest();
-    let ordinaryRunId: string | undefined;
-    await expect
-      .poll(async () => {
-        const listed = await runs.listAgentRuns(actor, {
-          agent: agentId,
-          limit: 100,
-        });
-        ordinaryRunId = listed.runs.find((run) => {
-          return run.prompt === ordinaryPrompt;
-        })?.id;
-        return ordinaryRunId;
-      })
-      .toStrictEqual(expect.any(String));
-    if (!ordinaryRunId) {
-      throw new Error("Expected ordinary queued control Run");
-    }
-    await expect(
-      readOfficialWorkflowRunStateFixture(context, ordinaryRunId),
-    ).resolves.toMatchObject({
-      provenance: null,
-      runner_job_count: 1,
-    });
-    const expectedRunFamilyAfterOrdinary = {
-      run_count: beforeQueuedRunFamily.run_count + 1,
-      callback_count: beforeQueuedRunFamily.callback_count + 1,
-      runner_job_count: beforeQueuedRunFamily.runner_job_count + 1,
-      launch_queue_count: beforeQueuedRunFamily.launch_queue_count,
-    };
-    await expect(
-      readAgentRunFamilyCountsFixture(context, agentId),
-    ).resolves.toStrictEqual(expectedRunFamilyAfterOrdinary);
-
-    const ordinaryClaim = await runs.claimRunnerJob(ordinaryRunId);
-    await webhooks.requestAgentComplete(
-      { runId: ordinaryRunId, exitCode: 1 },
-      { authorization: `Bearer ${ordinaryClaim.sandboxToken}` },
-      [200],
-    );
-    await flushWaitUntilForTest();
-    const beforeLaterDrain = await readAgentRunFamilyCountsFixture(
-      context,
-      agentId,
-    );
-    await withMockNowForTest(staleAt + 10 * 60 * 1000, async () => {
-      await reconcileStaleQueuedMessages(first.body.chatThreadId);
-    });
-    await flushWaitUntilForTest();
-
-    const afterLaterDrain = await chat.listThreadEvents(
-      actor,
-      first.body.chatThreadId,
-    );
-    expect(
-      afterLaterDrain.events.filter((event) => {
-        return (
-          event.eventType === "input.rejected" &&
-          event.revokesEventId === officialQueuedEvent.id &&
-          event.error === "conflict"
-        );
-      }),
-    ).toHaveLength(1);
-    expect(
-      afterLaterDrain.events.filter((event) => {
-        return (
-          event.eventType === "output.error" &&
-          event.error === "conflict" &&
-          typeof event.content === "string" &&
-          event.content.length > 0
-        );
-      }),
-    ).toHaveLength(1);
-    expect(
-      afterLaterDrain.events.filter((event) => {
-        return (
-          event.revokesEventId === ordinaryQueuedEventId &&
-          event.runId === ordinaryRunId
-        );
-      }),
-    ).toHaveLength(1);
-    await expect(
-      readAgentRunFamilyCountsFixture(context, agentId),
-    ).resolves.toStrictEqual(beforeLaterDrain);
-  });
-
-  it("keeps a queued Official source claim retryable across an unexpected persisted-revision failure", async () => {
-    installCatalogStorageFixture();
-    const suffix = randomUUID().replaceAll("-", "").slice(0, 10);
-    const definitionName = `api-test-queued-retry-${suffix}`;
-    await syncCatalog(catalog([activeDefinition(definitionName, [])]));
-    const setup = await workflowBdd.setupWorkflowOrg();
-    const { actor } = setup;
-    const { agentId } = await workflowBdd.createAgent(actor);
-    const headers = authHeaders(actor);
-    await setOfficialWorkflowsEnabled(actor, true);
-    const installation = await accept(
-      officialClient().install({
-        headers,
-        params: { definitionName },
-        body: { agentId, blueprints: [] },
-      }),
-      [201],
-    );
-    onTestFinished(async () => {
-      installCatalogStorageFixture();
-      const createdRuns = await runs.listAgentRuns(actor, {
-        agent: agentId,
-        limit: 100,
+      const replacements = after.filter((event) => {
+        return event.revokesEventId === invalid.id;
       });
-      for (const run of createdRuns.runs) {
-        await runs.requestCancelRun(actor, run.id, [200, 400]);
-      }
-      await bdd.deleteAgent(actor, agentId);
-      await cleanupCatalog();
-    });
-
-    runs.configureRunnerGroup();
-    runs.acceptStorageDownloads();
-    const first = await accept(
-      workflowClient().run({
-        headers,
-        params: { workflowId: installation.body.workflow.id },
-      }),
-      [200],
-    );
-    if (!first.body.runId) {
-      throw new Error("Expected first Official Workflow Run");
-    }
-    const firstRunId = first.body.runId;
-    const firstClaim = await runs.claimRunnerJob(firstRunId);
-    const beforeQueueEvents = await chat.listThreadEvents(
-      actor,
-      first.body.chatThreadId,
-    );
-    const beforeQueueEventIds = new Set(
-      beforeQueueEvents.events.map((event) => {
-        return event.id;
-      }),
-    );
-    const beforeQueuedRunFamily = await readAgentRunFamilyCountsFixture(
-      context,
-      agentId,
-    );
-
-    const queued = await accept(
-      workflowClient().run({
-        headers,
-        params: { workflowId: installation.body.workflow.id },
-      }),
-      [200],
-    );
-    expect(queued.body.runId).toBeNull();
-    const afterQueued = await chat.listThreadEvents(
-      actor,
-      first.body.chatThreadId,
-    );
-    const queuedEvent = afterQueued.events.find((event) => {
-      return (
-        event.eventType === "input.prompt" && !beforeQueueEventIds.has(event.id)
-      );
-    });
-    if (!queuedEvent) {
-      throw new Error("Expected persisted retryable Official queued message");
-    }
-
-    await corruptOfficialWorkflowRevisionPayloadFixture(
-      context,
-      definitionName,
-    );
-    await webhooks.requestAgentComplete(
-      { runId: firstRunId, exitCode: 1 },
-      { authorization: `Bearer ${firstClaim.sandboxToken}` },
-      [200],
-    );
-    await flushWaitUntilForTest();
-
-    const afterUnexpectedFailure = await chat.listThreadEvents(
-      actor,
-      first.body.chatThreadId,
-    );
-    expect(
-      afterUnexpectedFailure.events.filter((event) => {
-        return event.revokesEventId === queuedEvent.id;
-      }),
-    ).toHaveLength(0);
-    await expect(
-      readAgentRunFamilyCountsFixture(context, agentId),
-    ).resolves.toStrictEqual({
-      run_count: beforeQueuedRunFamily.run_count,
-      callback_count: beforeQueuedRunFamily.callback_count,
-      runner_job_count: beforeQueuedRunFamily.runner_job_count,
-      launch_queue_count: beforeQueuedRunFamily.launch_queue_count,
-    });
-
-    await cleanupCatalog();
-    await syncCatalog(
-      catalog([
-        activeDefinition(
-          definitionName,
-          [],
-          "Execute the repaired accepted Definition content.",
-        ),
-      ]),
-    );
-    const repaired = await readAcceptedDefinitionFixture(definitionName);
-    await withMockNowForTest(now() + 10 * 60 * 1000, async () => {
-      await reconcileStaleQueuedMessages(first.body.chatThreadId);
-    });
-    await flushWaitUntilForTest();
-
-    let retriedRunId: string | undefined;
-    await expect
-      .poll(async () => {
-        const listed = await runs.listAgentRuns(actor, {
-          agent: agentId,
-          limit: 100,
-        });
-        retriedRunId = listed.runs.find((run) => {
-          return run.id !== firstRunId;
-        })?.id;
-        return retriedRunId;
-      })
-      .toStrictEqual(expect.any(String));
-    if (!retriedRunId) {
-      throw new Error("Expected retried Official queued Run");
-    }
-    await expect(
-      readOfficialWorkflowRunStateFixture(context, retriedRunId),
-    ).resolves.toMatchObject({
-      provenance: {
-        definitions: [
-          {
-            name: definitionName,
-            revision: repaired.definition.revision,
+      if (queueCase.outcome === "invariant") {
+        expect(replacements).toHaveLength(0);
+      } else {
+        expect(replacements).toHaveLength(1);
+        expect(replacements[0]).toMatchObject({
+          eventType: "input.rejected",
+          runId: null,
+          payload: {
+            error:
+              queueCase.outcome === "exhausted"
+                ? "autonomy_budget_exhausted"
+                : "autonomy_source_unavailable",
           },
-        ],
-      },
-      runner_job_count: 1,
-    });
-    const afterRetry = await chat.listThreadEvents(
-      actor,
-      first.body.chatThreadId,
-    );
-    expect(
-      afterRetry.events.filter((event) => {
-        return (
-          event.revokesEventId === queuedEvent.id &&
-          event.runId === retriedRunId
-        );
-      }),
-    ).toHaveLength(1);
-    const retriedClaim = await runs.claimRunnerJob(retriedRunId);
-    await webhooks.requestAgentComplete(
-      { runId: retriedRunId, exitCode: 1 },
-      { authorization: `Bearer ${retriedClaim.sandboxToken}` },
-      [200],
-    );
-    await flushWaitUntilForTest();
-  });
+        });
+      }
+      await expect(
+        readAgentRunFamilyCountsFixture(context, agentId),
+      ).resolves.toStrictEqual(counts);
+    },
+  );
 
   it("checks uninstall before both successful and retained-failure Run insertion paths", async () => {
     installCatalogStorageFixture();

--- a/turbo/apps/api/src/signals/services/chat-queued-event.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-queued-event.service.ts
@@ -59,10 +59,7 @@ import {
   canonicalChatEventUserMessage,
   parseCanonicalChatEventRequiredOfficialWorkflowIds,
 } from "./canonical-chat-event-read.service";
-import {
-  officialWorkflowQueueContextFromContextId,
-  webChatQueueContextFromContextId,
-} from "./web-chat-public-brand-context.service";
+import { webChatQueueContextFromContextId } from "./web-chat-public-brand-context.service";
 
 type DbTransaction = Tx;
 
@@ -259,26 +256,34 @@ function resolveQueuedOfficialWorkflowContext(args: {
   readonly contextId: string | null;
   readonly requiredOfficialWorkflowIds: readonly string[] | null;
 }) {
+  const hasClaim = args.requiredOfficialWorkflowIds !== null;
+  if (hasClaim && !isWebChatContextType(args.contextType)) {
+    throw new Error(
+      `Queued ${args.contextType} input cannot carry an Official Workflow source claim`,
+    );
+  }
   const webContext =
     args.contextType === "web"
       ? webChatQueueContextFromContextId(args.contextId)
       : null;
+  if (args.contextType === "web" && webContext === null) {
+    throw new Error(`Invalid Web public-brand context: ${args.contextId}`);
+  }
+  // Both Official agent encodings carry a brand here, never the source Run.
+  // Recognizing both also keeps annotation-based source/budget recovery shared.
   const officialAgentContext =
     args.contextType === "agent_run"
-      ? officialWorkflowQueueContextFromContextId(args.contextId)
+      ? webChatQueueContextFromContextId(args.contextId)
       : null;
-  const markerRequiresClaim =
+  const contextRequiresClaim =
     webContext?.officialWorkflowClaimRequired === true ||
     officialAgentContext !== null;
-  const hasClaim = args.requiredOfficialWorkflowIds !== null;
-  if (markerRequiresClaim !== hasClaim) {
+  if (
+    (contextRequiresClaim && !hasClaim) ||
+    (hasClaim && webContext === null && officialAgentContext === null)
+  ) {
     throw new Error(
-      "Queued Official Workflow marker and source claim do not match",
-    );
-  }
-  if (hasClaim && !isWebChatContextType(args.contextType)) {
-    throw new Error(
-      `Queued ${args.contextType} input cannot carry an Official Workflow source claim`,
+      "Queued Official Workflow context and source claim do not match",
     );
   }
   return { webContext, officialAgentContext };

--- a/turbo/apps/api/src/signals/services/web-chat-public-brand-context.service.ts
+++ b/turbo/apps/api/src/signals/services/web-chat-public-brand-context.service.ts
@@ -7,12 +7,12 @@ const WEB_PUBLIC_BRAND_CONTEXT_IDS = {
   okou: "0bdfae9e-63be-43dd-8193-a96e07787c20",
 } satisfies Readonly<Record<PublicBrand, string>>;
 
-// Mixed-version API fallback (new writer -> previous API queue drainer): the
-// previous API ignores the additive private claim column, so these markers
-// make it reject instead of draining the prompt as an ordinary launch. Gate:
-// the outgoing API has finished draining and is outside retained rollback.
-// Remove after no pending unrevoked/runless marker rows remain and the stale
-// drain window has elapsed; follow-up #29908 owns the cleanup and verification.
+// Persisted queue compatibility (#29908): writers retain these markers while
+// readers prepare to accept normal brand IDs with the private Official claim.
+// Cut writers over only after marker-only readers drain and exit rollback.
+// Retire marker decoding in a later release after marker writers are excluded
+// from serving/rollback, no unrevoked runless marker prompts remain, and stale
+// recovery is verified. Immutable raw/snapshot history must stay readable.
 const OFFICIAL_WORKFLOW_QUEUE_CONTEXT_IDS = {
   vm0: "d4f079af-190a-4a32-bf49-73175aa2d727",
   okou: "3f713f81-d611-47ec-a427-5a4844078890",
@@ -36,7 +36,7 @@ export function officialWorkflowQueueContextId(
 }
 
 /** Decode a strict Official queue marker without rejecting ordinary pointers. */
-export function officialWorkflowQueueContextFromContextId(
+function officialWorkflowQueueContextFromContextId(
   contextId: string | null,
 ): WebChatQueueContext | null {
   if (contextId === OFFICIAL_WORKFLOW_QUEUE_CONTEXT_IDS.vm0) {
@@ -48,19 +48,15 @@ export function officialWorkflowQueueContextFromContextId(
   return null;
 }
 
-/** Decode Web launch identity and whether a strict Official claim must exist. */
+/** Decode either brand encoding; an ordinary agent source pointer is not a brand. */
 export function webChatQueueContextFromContextId(
   contextId: string | null,
-): WebChatQueueContext {
+): WebChatQueueContext | null {
   if (contextId === WEB_PUBLIC_BRAND_CONTEXT_IDS.vm0) {
     return { publicBrand: "vm0", officialWorkflowClaimRequired: false };
   }
   if (contextId === WEB_PUBLIC_BRAND_CONTEXT_IDS.okou) {
     return { publicBrand: "okou", officialWorkflowClaimRequired: false };
   }
-  const officialContext = officialWorkflowQueueContextFromContextId(contextId);
-  if (officialContext) {
-    return officialContext;
-  }
-  throw new Error(`Invalid Web public-brand context: ${contextId}`);
+  return officialWorkflowQueueContextFromContextId(contextId);
 }

--- a/turbo/apps/api/src/test-fixtures/official-workflow-queue.ts
+++ b/turbo/apps/api/src/test-fixtures/official-workflow-queue.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+
+import type { UserMessageDocument } from "@okouai/api-contracts/contracts/chat-threads";
+import { agentRuns } from "@okouai/db/schema/agent-run";
+import { chatEvents } from "@okouai/db/schema/chat-event";
+import { chatThreads } from "@okouai/db/schema/chat-thread";
+import { eq, sql } from "drizzle-orm";
+
+import { db } from "../lib/db";
+import { nowDate } from "../lib/time";
+import { revokeChatEvent } from "../signals/services/chat-event.service";
+
+export async function readOfficialWorkflowQueueInputFixture(eventId: string) {
+  const [row] = await db()
+    .select()
+    .from(chatEvents)
+    .where(eq(chatEvents.id, eventId));
+  if (!row || row.eventType !== "input.prompt" || row.runId !== null) {
+    throw new Error("Expected an immutable runless Official queue source");
+  }
+  return row;
+}
+
+/**
+ * Production writers intentionally cannot produce canonical or corrupt queue
+ * encodings yet. Append a test-owned persisted input and revoke the original;
+ * never update an immutable event or relax its storage constraints.
+ */
+export async function appendOfficialWorkflowQueueInputFixture(args: {
+  readonly eventId: string;
+  readonly contextId: string;
+  readonly contextType: NonNullable<
+    (typeof chatEvents.$inferSelect)["contextType"]
+  >;
+  readonly claim: readonly string[] | null;
+  readonly userMessage: UserMessageDocument;
+}) {
+  const source = await readOfficialWorkflowQueueInputFixture(args.eventId);
+  return await db().transaction(async (tx) => {
+    const revoked = await revokeChatEvent(tx, source.id, {
+      chatThreadId: source.chatThreadId,
+      eventType: "control.revoke",
+    });
+    if (!revoked) {
+      throw new Error("Official queue fixture source was already revoked");
+    }
+    const [thread] = await tx
+      .update(chatThreads)
+      .set({ lastChatEventSeqId: sql`${chatThreads.lastChatEventSeqId} + 1` })
+      .where(eq(chatThreads.id, source.chatThreadId))
+      .returning({ seqId: chatThreads.lastChatEventSeqId });
+    if (!thread) {
+      throw new Error("Official queue fixture thread is missing");
+    }
+    const [row] = await tx
+      .insert(chatEvents)
+      .values({
+        id: randomUUID(),
+        chatThreadId: source.chatThreadId,
+        eventType: "input.prompt",
+        contextType: args.contextType,
+        contextId: args.contextId,
+        requiredOfficialWorkflowIds: args.claim,
+        payload: { userMessage: args.userMessage },
+        seqId: thread.seqId,
+        createdAt: new Date(
+          Math.max(nowDate().getTime(), revoked.createdAt.getTime() + 1),
+        ),
+      })
+      .returning();
+    if (!row) {
+      throw new Error("Official queue fixture was not inserted");
+    }
+    return row;
+  });
+}
+
+export async function readOfficialWorkflowQueueRunFixture(runId: string) {
+  const [run] = await db()
+    .select({
+      triggerSource: agentRuns.triggerSource,
+      autonomyBudget: agentRuns.autonomyBudget,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId));
+  if (!run) {
+    throw new Error("Official queued Run is missing");
+  }
+  return run;
+}


### PR DESCRIPTION
## Summary

Delayed Official Workflow inputs now accept normal public-brand context IDs with the existing validated private claim, alongside the legacy Official markers. Both Official agent encodings resolve the actual source Run from its server-owned message annotation, preserving the public brand and source autonomy-budget decrement.

This is only the reader-preparation slice of #29908. Production writers still emit legacy markers for both origins. Marker decoding, strict claim validation, final admission/provenance, ordinary source pointers, and the two Run insertion families remain intact. The adjacent compatibility comment describes the separate reader, writer, and retirement releases.

## Verification

- Extend the existing permanent-rejection/ordinary-successor and unexpected-revision-retry integration scenarios with four representative legacy/canonical, web/agent, and vm0/okou cases each. Assert current writer output, actual source identity, budget, trigger source, runner-token brand, exact provenance, and no duplicate Run/dispatch.
- Exercise 15 invalid-context, invalid-claim, missing-source, and exhausted-budget cases through real DB/API/callback/cron boundaries. Canonical/corrupt fixtures append new test events and revoke the originals; they never update immutable input rows or relax storage constraints.
- Archive and read immutable marker inputs before and after claim/rejection, using strict public JSON schemas and snapshot-plus-hot-tail cursors. Keep the previous-reader projection regression.

Local checks:

- Prettier on all four changed files; API lint; complete API typecheck (including test/fixture boundaries); workspace Knip: passed.
- Six focused API files: **146 passed** (`official-workflows`, `cron-cleanup-sandboxes`, `cron-monitor-chat-event-queue`, `chat-event-canonical-storage`, `chat-event-snapshot`, `chat-event-archive-consumers`). The final Official file was rerun after test type refinements: **73 passed**.
- Four selected `chat-events.bdd` controls for ordinary queue retry/recall, agent-source provenance and forged-source rejection, Web context/tools, and zero-budget delegation: **4 passed**.
- API contract checks for raw chat-event rows and Official Workflows: **12 passed**. DB chat-event schema contract: **4 passed**.
- No full local Vitest suite or local dev server was run. Full required PR and merge-group gates remain CI validation.

## Fallbacks

The widened compatibility surface is persisted API queue input: accept both brand encodings with the existing strict claim while production writers retain markers. This reader-first window and its separate writer/retirement gates are explicitly required by #32512 and #29908.

The existing rollback floor only excludes APIs predating #29809; it does not make today's marker-only readers accept the future format. The controller must verify this reader's released API artifact and exclude marker-only serving/rollback readers before a separate writer cutover. Legacy reader retirement follows in a later release after its own drain and rollback gates.

No schema, migration, backfill, production-row mutation, public/raw/snapshot wire-shape change, rollback-floor/workflow change, or production release is included. Parent #29908 remains open for the two later release-separated stages and production acceptance.

Closes #32512
Part of #29908
