### PR TITLE
fix(calendar): surface action-required recovery

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -5535,6 +5535,7 @@
   "workflows": {
     "automations": {
       "calendar": {
+        "actionRequiredPaused": "Aktion erforderlich — Zustellung pausiert",
         "addAction": "Kalenderautomatisierung hinzufügen",
         "addAria": "Google Calendar-Automatisierung hinzufügen",
         "addDescriptionCancelled": "Führen Sie diesen Workflow aus, wenn ein Ereignis in Google Calendar abgesagt wird.",
@@ -5543,16 +5544,24 @@
         "addTitle": "Google Calendar-Automatisierung hinzufügen",
         "calendarId": "Kalender-ID",
         "calendarIdPlaceholder": "primary",
+        "calendarNotFoundDescription": "Dieser Kalender ist nicht mehr verfügbar. Wählen Sie einen anderen Kalender aus, um diese Automatisierung fortzusetzen.",
         "cancelledDescription": "Wird ausgeführt, wenn ein Kalenderereignis abgesagt wird.",
         "cancelledRule": "Wenn das Kalenderereignis {{calendar}} abgesagt wird",
         "cancelledTitle": "Google Calendar-Ereignis abgesagt",
+        "changeAria": "Google Calendar-Automatisierung ändern",
+        "changeCalendar": "Kalender ändern",
         "createdDescription": "Wird ausgeführt, wenn ein Kalenderereignis erstellt wird.",
         "createdRule": "Wenn Kalender {{calendar}} ein neues Ereignis erhält",
         "createdTitle": "Google Calendar-Ereignis erstellt",
+        "enabledIntent": "Aktiviert",
+        "reconnectDescription": "Google Calendar muss erneut verbunden werden, bevor diese Automatisierung fortgesetzt werden kann.",
+        "reconnectGoogleCalendar": "Google Calendar erneut verbinden",
+        "saveCalendar": "Kalender speichern",
         "summary": "Kalender {{calendar}}",
         "updatedDescription": "Wird ausgeführt, wenn ein Kalenderereignis aktualisiert wird.",
         "updatedRule": "Wenn das Kalenderereignis {{calendar}} aktualisiert wird",
-        "updatedTitle": "Google Calendar-Ereignis aktualisiert"
+        "updatedTitle": "Google Calendar-Ereignis aktualisiert",
+        "updateError": "Dieser Kalender konnte nicht geändert werden. Versuchen Sie es erneut."
       },
       "chat": {
         "addAction": "Chat-Automatisierung hinzufügen",
@@ -6128,6 +6137,7 @@
       }
     },
     "list": {
+      "actionRequired": "Aktion erforderlich",
       "agentEmpty": "Es werden noch keine Workflows als dieser Agent ausgeführt.",
       "all": "Alle",
       "allAgents": "Alle Agenten",
@@ -6145,6 +6155,7 @@
       },
       "noWorkflows": "Keine Workflows",
       "open": "Öffnen Sie {{title}}",
+      "openRecovery": "Wiederherstellung für {{title}} öffnen",
       "runsAs": "Läuft als",
       "runsAsAria": "Läuft als {{agent}}",
       "section": {

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -5527,6 +5527,7 @@
   "workflows": {
     "automations": {
       "calendar": {
+        "actionRequiredPaused": "Action required — delivery paused",
         "addAction": "Add Calendar automation",
         "addAria": "Add Google Calendar automation",
         "addDescriptionCancelled": "Run this workflow when a Google Calendar event is cancelled.",
@@ -5535,16 +5536,24 @@
         "addTitle": "Add Google Calendar automation",
         "calendarId": "Calendar ID",
         "calendarIdPlaceholder": "primary",
+        "calendarNotFoundDescription": "This calendar is no longer available. Choose another calendar to resume this automation.",
         "cancelledDescription": "Run when a calendar event is cancelled.",
         "cancelledRule": "When calendar {{calendar}} event is cancelled",
         "cancelledTitle": "Google Calendar event cancelled",
+        "changeAria": "Change Google Calendar automation",
+        "changeCalendar": "Change calendar",
         "createdDescription": "Run when a calendar event is created.",
         "createdRule": "When calendar {{calendar}} gets a new event",
         "createdTitle": "Google Calendar event created",
+        "enabledIntent": "Enabled",
+        "reconnectDescription": "Google Calendar needs to be reconnected before this automation can resume.",
+        "reconnectGoogleCalendar": "Reconnect Google Calendar",
+        "saveCalendar": "Save calendar",
         "summary": "Calendar {{calendar}}",
         "updatedDescription": "Run when a calendar event is updated.",
         "updatedRule": "When calendar {{calendar}} event is updated",
-        "updatedTitle": "Google Calendar event updated"
+        "updatedTitle": "Google Calendar event updated",
+        "updateError": "We couldn't change this calendar. Try again."
       },
       "chat": {
         "addAction": "Add chat automation",
@@ -6120,6 +6129,7 @@
       }
     },
     "list": {
+      "actionRequired": "Action required",
       "agentEmpty": "No workflows run as this agent yet.",
       "all": "All",
       "allAgents": "All agents",
@@ -6137,6 +6147,7 @@
       },
       "noWorkflows": "No workflows",
       "open": "Open {{title}}",
+      "openRecovery": "Open {{title}} recovery",
       "runsAs": "Runs as",
       "runsAsAria": "Runs as {{agent}}",
       "section": {

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -5594,6 +5594,7 @@
   "workflows": {
     "automations": {
       "calendar": {
+        "actionRequiredPaused": "Acción necesaria — entrega pausada",
         "addAction": "Añadir automatización de calendario",
         "addAria": "Añadir automatización de Google Calendar",
         "addDescriptionCancelled": "Ejecuta este flujo de trabajo cuando se cancele un evento de Google Calendar.",
@@ -5602,16 +5603,24 @@
         "addTitle": "Añadir automatización de Google Calendar",
         "calendarId": "ID de calendario",
         "calendarIdPlaceholder": "primary",
+        "calendarNotFoundDescription": "Este calendario ya no está disponible. Elige otro calendario para reanudar esta automatización.",
         "cancelledDescription": "Ejecutar cuando se cancele un evento del calendario.",
         "cancelledRule": "Cuando se cancela el evento {{calendar}} del calendario",
         "cancelledTitle": "Evento de Google Calendar cancelado",
+        "changeAria": "Cambiar automatización de Google Calendar",
+        "changeCalendar": "Cambiar calendario",
         "createdDescription": "Ejecuta cuando se crea un evento en el calendario.",
         "createdRule": "Cuando el calendario {{calendar}} recibe un nuevo evento",
         "createdTitle": "Evento de Google Calendar creado",
+        "enabledIntent": "Activada",
+        "reconnectDescription": "Es necesario volver a conectar Google Calendar para que esta automatización pueda reanudarse.",
+        "reconnectGoogleCalendar": "Volver a conectar Google Calendar",
+        "saveCalendar": "Guardar calendario",
         "summary": "Calendario {{calendar}}",
         "updatedDescription": "Ejecuta cuando se actualice un evento del calendario.",
         "updatedRule": "Cuando se actualiza el evento {{calendar}} del calendario",
-        "updatedTitle": "Evento de Google Calendar actualizado"
+        "updatedTitle": "Evento de Google Calendar actualizado",
+        "updateError": "No se pudo cambiar este calendario. Inténtalo de nuevo."
       },
       "chat": {
         "addAction": "Añadir automatización de chat",
@@ -6191,6 +6200,7 @@
       }
     },
     "list": {
+      "actionRequired": "Acción necesaria",
       "agentEmpty": "Todavía no se ha ejecutado ningún flujo de trabajo con este agente.",
       "all": "Todos",
       "allAgents": "Todos los agentes",
@@ -6208,6 +6218,7 @@
       },
       "noWorkflows": "Sin flujos de trabajo",
       "open": "Abrir {{title}}",
+      "openRecovery": "Abrir la recuperación de {{title}}",
       "runsAs": "Se ejecuta como",
       "runsAsAria": "Se ejecuta como {{agent}}",
       "section": {

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -5594,6 +5594,7 @@
   "workflows": {
     "automations": {
       "calendar": {
+        "actionRequiredPaused": "Action requise — livraison suspendue",
         "addAction": "Ajouter une automatisation du calendrier",
         "addAria": "Ajouter une automatisation Google Calendar",
         "addDescriptionCancelled": "Exécuter ce workflow lorsqu'un événement Google Calendar est annulé.",
@@ -5602,16 +5603,24 @@
         "addTitle": "Ajouter une automatisation Google Calendar",
         "calendarId": "ID du calendrier",
         "calendarIdPlaceholder": "primary",
+        "calendarNotFoundDescription": "Ce calendrier n’est plus disponible. Choisissez un autre calendrier pour reprendre cette automatisation.",
         "cancelledDescription": "Exécuter lorsqu'un événement du calendrier est annulé.",
         "cancelledRule": "Lorsque l'événement du calendrier {{calendar}} est annulé",
         "cancelledTitle": "Événement Google Calendar annulé",
+        "changeAria": "Modifier l’automatisation Google Calendar",
+        "changeCalendar": "Changer de calendrier",
         "createdDescription": "Exécuter lorsqu'un événement du calendrier est créé.",
         "createdRule": "Lorsque le calendrier {{calendar}} reçoit un nouvel événement",
         "createdTitle": "Événement Google Calendar créé",
+        "enabledIntent": "Activée",
+        "reconnectDescription": "Google Calendar doit être reconnecté avant que cette automatisation puisse reprendre.",
+        "reconnectGoogleCalendar": "Reconnecter Google Calendar",
+        "saveCalendar": "Enregistrer le calendrier",
         "summary": "Calendrier {{calendar}}",
         "updatedDescription": "Exécuter lorsqu'un événement du calendrier est mis à jour.",
         "updatedRule": "Lorsque l'événement de calendrier {{calendar}} est mis à jour",
-        "updatedTitle": "Événement Google Calendar mis à jour"
+        "updatedTitle": "Événement Google Calendar mis à jour",
+        "updateError": "Impossible de changer ce calendrier. Réessayez."
       },
       "chat": {
         "addAction": "Ajouter une automatisation de chat",
@@ -6191,6 +6200,7 @@
       }
     },
     "list": {
+      "actionRequired": "Action requise",
       "agentEmpty": "Aucun workflow n'a encore été exécuté avec cet agent.",
       "all": "Tout",
       "allAgents": "Tous les agents",
@@ -6208,6 +6218,7 @@
       },
       "noWorkflows": "Aucun workflow",
       "open": "Ouvrir {{title}}",
+      "openRecovery": "Ouvrir la récupération de {{title}}",
       "runsAs": "S'exécute en tant que",
       "runsAsAria": "S'exécute en tant que {{agent}}",
       "section": {

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -5535,6 +5535,7 @@
   "workflows": {
     "automations": {
       "calendar": {
+        "actionRequiredPaused": "कार्रवाई आवश्यक — डिलीवरी रोकी गई",
         "addAction": "कैलेंडर ऑटोमेशन जोड़ें",
         "addAria": "Google Calendar ऑटोमेशन जोड़ें",
         "addDescriptionCancelled": "Google Calendar ईवेंट रद्द होने पर इस वर्कफ़्लो को चलाएँ।",
@@ -5543,16 +5544,24 @@
         "addTitle": "Google Calendar ऑटोमेशन जोड़ें",
         "calendarId": "कैलेंडर ID",
         "calendarIdPlaceholder": "प्राथमिक",
+        "calendarNotFoundDescription": "यह कैलेंडर अब उपलब्ध नहीं है। इस ऑटोमेशन को फिर से शुरू करने के लिए कोई दूसरा कैलेंडर चुनें।",
         "cancelledDescription": "कैलेंडर ईवेंट रद्द होने पर चलाएँ।",
         "cancelledRule": "जब कैलेंडर {{calendar}} ईवेंट रद्द हो जाता है",
         "cancelledTitle": "Google Calendar इवेंट रद्द कर दिया गया",
+        "changeAria": "Google Calendar ऑटोमेशन बदलें",
+        "changeCalendar": "कैलेंडर बदलें",
         "createdDescription": "कैलेंडर ईवेंट बनने पर चलाएँ।",
         "createdRule": "जब कैलेंडर {{calendar}} को एक नया ईवेंट मिलता है",
         "createdTitle": "Google Calendar इवेंट बनाया गया",
+        "enabledIntent": "सक्षम",
+        "reconnectDescription": "इस ऑटोमेशन के फिर से शुरू होने से पहले Google Calendar को दोबारा कनेक्ट करना होगा।",
+        "reconnectGoogleCalendar": "Google Calendar दोबारा कनेक्ट करें",
+        "saveCalendar": "कैलेंडर सेव करें",
         "summary": "कैलेंडर {{calendar}}",
         "updatedDescription": "कैलेंडर ईवेंट अपडेट होने पर चलाएँ।",
         "updatedRule": "जब कैलेंडर {{calendar}} इवेंट अपडेट किया जाता है",
-        "updatedTitle": "Google Calendar इवेंट अपडेट किया गया"
+        "updatedTitle": "Google Calendar इवेंट अपडेट किया गया",
+        "updateError": "हम इस कैलेंडर को बदल नहीं सके। फिर से कोशिश करें।"
       },
       "chat": {
         "addAction": "चैट ऑटोमेशन जोड़ें",
@@ -6128,6 +6137,7 @@
       }
     },
     "list": {
+      "actionRequired": "कार्रवाई आवश्यक",
       "agentEmpty": "इस एजेंट के रूप में अभी तक कोई वर्कफ़्लो नहीं चलता है।",
       "all": "सभी",
       "allAgents": "सभी एजेंट",
@@ -6145,6 +6155,7 @@
       },
       "noWorkflows": "कोई वर्कफ़्लो नहीं",
       "open": "{{title}} खोलें",
+      "openRecovery": "{{title}} की रिकवरी खोलें",
       "runsAs": "के रूप में चलता है",
       "runsAsAria": "{{agent}} के रूप में चलता है",
       "section": {

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -5526,6 +5526,7 @@
   "workflows": {
     "automations": {
       "calendar": {
+        "actionRequiredPaused": "Tindakan diperlukan — pengiriman dijeda",
         "addAction": "Tambahkan otomatisasi Kalender",
         "addAria": "Tambahkan otomatisasi Google Calendar",
         "addDescriptionCancelled": "Jalankan alur kerja ini saat acara Google Calendar dibatalkan.",
@@ -5534,16 +5535,24 @@
         "addTitle": "Tambahkan otomatisasi Google Calendar",
         "calendarId": "ID Kalender",
         "calendarIdPlaceholder": "utama",
+        "calendarNotFoundDescription": "Kalender ini tidak lagi tersedia. Pilih kalender lain untuk melanjutkan otomatisasi ini.",
         "cancelledDescription": "Jalankan saat acara kalender dibatalkan.",
         "cancelledRule": "Saat acara kalender {{calendar}} dibatalkan",
         "cancelledTitle": "Acara Google Calendar dibatalkan",
+        "changeAria": "Ubah otomatisasi Google Calendar",
+        "changeCalendar": "Ubah kalender",
         "createdDescription": "Jalankan saat acara kalender dibuat.",
         "createdRule": "Saat kalender {{calendar}} mendapat acara baru",
         "createdTitle": "Acara Google Calendar dibuat",
+        "enabledIntent": "Diaktifkan",
+        "reconnectDescription": "Google Calendar perlu dihubungkan kembali sebelum otomatisasi ini dapat dilanjutkan.",
+        "reconnectGoogleCalendar": "Hubungkan kembali Google Calendar",
+        "saveCalendar": "Simpan kalender",
         "summary": "Kalender {{calendar}}",
         "updatedDescription": "Jalankan saat acara kalender diperbarui.",
         "updatedRule": "Saat acara kalender {{calendar}} diperbarui",
-        "updatedTitle": "Acara Google Calendar diperbarui"
+        "updatedTitle": "Acara Google Calendar diperbarui",
+        "updateError": "Kami tidak dapat mengubah kalender ini. Coba lagi."
       },
       "chat": {
         "addAction": "Tambahkan otomatisasi chat",
@@ -6119,6 +6128,7 @@
       }
     },
     "list": {
+      "actionRequired": "Tindakan diperlukan",
       "agentEmpty": "Belum ada alur kerja yang dijalankan sebagai agen ini.",
       "all": "Semua",
       "allAgents": "Semua agen",
@@ -6136,6 +6146,7 @@
       },
       "noWorkflows": "Tidak ada alur kerja",
       "open": "Buka {{title}}",
+      "openRecovery": "Buka pemulihan {{title}}",
       "runsAs": "Dijalankan sebagai",
       "runsAsAria": "Dijalankan sebagai {{agent}}",
       "section": {

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -5594,6 +5594,7 @@
   "workflows": {
     "automations": {
       "calendar": {
+        "actionRequiredPaused": "Azione richiesta — consegna in pausa",
         "addAction": "Aggiungi l'automazione del calendario",
         "addAria": "Aggiungi automazione di Google Calendar",
         "addDescriptionCancelled": "Esegui questo flusso di lavoro quando un evento del calendario Google viene annullato.",
@@ -5602,16 +5603,24 @@
         "addTitle": "Aggiungi automazione di Google Calendar",
         "calendarId": "Calendario ID",
         "calendarIdPlaceholder": "primario",
+        "calendarNotFoundDescription": "Questo calendario non è più disponibile. Scegli un altro calendario per riprendere questa automazione.",
         "cancelledDescription": "Esegui quando un evento del calendario viene annullato.",
         "cancelledRule": "Quando l'evento del calendario {{calendar}} viene annullato",
         "cancelledTitle": "Google Evento del calendario annullato",
+        "changeAria": "Modifica automazione Google Calendar",
+        "changeCalendar": "Cambia calendario",
         "createdDescription": "Esegui quando viene creato un evento del calendario.",
         "createdRule": "Quando il calendario {{calendar}} riceve un nuovo evento",
         "createdTitle": "Google Evento del calendario creato",
+        "enabledIntent": "Attivata",
+        "reconnectDescription": "Google Calendar deve essere riconnesso prima che questa automazione possa riprendere.",
+        "reconnectGoogleCalendar": "Riconnetti Google Calendar",
+        "saveCalendar": "Salva calendario",
         "summary": "Calendario {{calendar}}",
         "updatedDescription": "Esegui quando un evento del calendario viene aggiornato.",
         "updatedRule": "Quando l'evento {{calendar}} del calendario viene aggiornato",
-        "updatedTitle": "Google Evento del calendario aggiornato"
+        "updatedTitle": "Google Evento del calendario aggiornato",
+        "updateError": "Non è stato possibile cambiare questo calendario. Riprova."
       },
       "chat": {
         "addAction": "Aggiungi l'automazione della chat",
@@ -6191,6 +6200,7 @@
       }
     },
     "list": {
+      "actionRequired": "Azione richiesta",
       "agentEmpty": "Nessun flusso di lavoro ancora eseguito come questo agente.",
       "all": "Tutto",
       "allAgents": "Tutti gli agenti",
@@ -6208,6 +6218,7 @@
       },
       "noWorkflows": "Nessun flusso di lavoro",
       "open": "Apri {{title}}",
+      "openRecovery": "Apri il ripristino di {{title}}",
       "runsAs": "Eseguito come",
       "runsAsAria": "Eseguito come {{agent}}",
       "section": {

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -5526,6 +5526,7 @@
   "workflows": {
     "automations": {
       "calendar": {
+        "actionRequiredPaused": "対応が必要 — 配信を一時停止中",
         "addAction": "カレンダーのオートメーションを追加する",
         "addAria": "Google Calendar オートメーションを追加",
         "addDescriptionCancelled": "Google Calendar イベントがキャンセルされたときに、このワークフローを実行します。",
@@ -5534,16 +5535,24 @@
         "addTitle": "Google Calendar オートメーションを追加",
         "calendarId": "カレンダーID",
         "calendarIdPlaceholder": "プライマリー",
+        "calendarNotFoundDescription": "このカレンダーは利用できなくなりました。このオートメーションを再開するには、別のカレンダーを選択してください。",
         "cancelledDescription": "カレンダーイベントがキャンセルされたときに実行されます。",
         "cancelledRule": "カレンダー {{calendar}} イベントがキャンセルされた場合",
         "cancelledTitle": "Google Calendar イベントがキャンセルされました",
+        "changeAria": "Google Calendar オートメーションを変更",
+        "changeCalendar": "カレンダーを変更",
         "createdDescription": "カレンダーイベントの作成時に実行します。",
         "createdRule": "カレンダー {{calendar}} が新しいイベントを取得したとき",
         "createdTitle": "Google Calendar イベントが作成されました",
+        "enabledIntent": "有効",
+        "reconnectDescription": "このオートメーションを再開するには、Google Calendar を再接続する必要があります。",
+        "reconnectGoogleCalendar": "Google Calendar を再接続",
+        "saveCalendar": "カレンダーを保存",
         "summary": "カレンダー {{calendar}}",
         "updatedDescription": "カレンダーイベントが更新されたときに実行します。",
         "updatedRule": "カレンダー {{calendar}} イベントが更新されたとき",
-        "updatedTitle": "Google Calendar イベントが更新されました"
+        "updatedTitle": "Google Calendar イベントが更新されました",
+        "updateError": "このカレンダーを変更できませんでした。もう一度お試しください。"
       },
       "chat": {
         "addAction": "チャットオートメーションを追加する",
@@ -6119,6 +6128,7 @@
       }
     },
     "list": {
+      "actionRequired": "対応が必要",
       "agentEmpty": "このエージェントとして実行されるワークフローはまだありません。",
       "all": "すべて",
       "allAgents": "すべてのエージェント",
@@ -6136,6 +6146,7 @@
       },
       "noWorkflows": "ワークフローなし",
       "open": "{{title}} を開く",
+      "openRecovery": "{{title}} の復旧を開く",
       "runsAs": "として実行",
       "runsAsAria": "{{agent}} として実行",
       "section": {

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -5526,6 +5526,7 @@
   "workflows": {
     "automations": {
       "calendar": {
+        "actionRequiredPaused": "조치 필요 — 전송 일시 중지됨",
         "addAction": "캘린더 자동화 추가",
         "addAria": "Google 캘린더 자동화 추가",
         "addDescriptionCancelled": "Google 캘린더 이벤트가 취소될 때 이 워크플로를 실행합니다.",
@@ -5534,16 +5535,24 @@
         "addTitle": "Google 캘린더 자동화 추가",
         "calendarId": "캘린더 ID",
         "calendarIdPlaceholder": "primary",
+        "calendarNotFoundDescription": "이 캘린더는 더 이상 사용할 수 없습니다. 이 자동화를 재개하려면 다른 캘린더를 선택하세요.",
         "cancelledDescription": "캘린더 이벤트가 취소될 때 실행됩니다.",
         "cancelledRule": "캘린더 {{calendar}} 이벤트가 취소될 때",
         "cancelledTitle": "Google 캘린더 이벤트 취소됨",
+        "changeAria": "Google Calendar 자동화 변경",
+        "changeCalendar": "캘린더 변경",
         "createdDescription": "캘린더 이벤트가 생성될 때 실행됩니다.",
         "createdRule": "캘린더 {{calendar}}에 새 이벤트가 생길 때",
         "createdTitle": "Google 캘린더 이벤트 생성됨",
+        "enabledIntent": "활성화됨",
+        "reconnectDescription": "이 자동화를 재개하려면 먼저 Google Calendar를 다시 연결해야 합니다.",
+        "reconnectGoogleCalendar": "Google Calendar 다시 연결",
+        "saveCalendar": "캘린더 저장",
         "summary": "캘린더 {{calendar}}",
         "updatedDescription": "캘린더 이벤트가 업데이트될 때 실행됩니다.",
         "updatedRule": "캘린더 {{calendar}} 이벤트가 업데이트될 때",
-        "updatedTitle": "Google 캘린더 이벤트 업데이트됨"
+        "updatedTitle": "Google 캘린더 이벤트 업데이트됨",
+        "updateError": "이 캘린더를 변경하지 못했습니다. 다시 시도하세요."
       },
       "chat": {
         "addAction": "채팅 자동화 추가",
@@ -6119,6 +6128,7 @@
       }
     },
     "list": {
+      "actionRequired": "조치 필요",
       "agentEmpty": "이 에이전트로 실행된 워크플로가 없습니다.",
       "all": "전체",
       "allAgents": "모든 에이전트",
@@ -6136,6 +6146,7 @@
       },
       "noWorkflows": "워크플로가 없습니다",
       "open": "{{title}} 열기",
+      "openRecovery": "{{title}} 복구 열기",
       "runsAs": "다음 에이전트로 실행됨",
       "runsAsAria": "{{agent}}로 실행됨",
       "section": {

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -5594,6 +5594,7 @@
   "workflows": {
     "automations": {
       "calendar": {
+        "actionRequiredPaused": "Ação necessária — entrega pausada",
         "addAction": "Adicionar automação do Calendar",
         "addAria": "Adicionar automação do Google Calendar",
         "addDescriptionCancelled": "Execute este fluxo de trabalho quando um evento do Google Calendar for cancelado.",
@@ -5602,16 +5603,24 @@
         "addTitle": "Adicionar automação do Google Calendar",
         "calendarId": "ID do calendário",
         "calendarIdPlaceholder": "primary",
+        "calendarNotFoundDescription": "Este calendário não está mais disponível. Escolha outro calendário para retomar esta automação.",
         "cancelledDescription": "Execute quando um evento do calendário for cancelado.",
         "cancelledRule": "Quando um evento do calendário {{calendar}} for cancelado",
         "cancelledTitle": "Evento do Google Calendar cancelado",
+        "changeAria": "Alterar automação do Google Calendar",
+        "changeCalendar": "Alterar calendário",
         "createdDescription": "Execute quando um evento do calendário for criado.",
         "createdRule": "Quando o calendário {{calendar}} receber um novo evento",
         "createdTitle": "Evento do Google Calendar criado",
+        "enabledIntent": "Ativada",
+        "reconnectDescription": "O Google Calendar precisa ser reconectado antes que esta automação possa ser retomada.",
+        "reconnectGoogleCalendar": "Reconectar Google Calendar",
+        "saveCalendar": "Salvar calendário",
         "summary": "Calendário {{calendar}}",
         "updatedDescription": "Execute quando um evento do calendário for atualizado.",
         "updatedRule": "Quando um evento do calendário {{calendar}} for atualizado",
-        "updatedTitle": "Evento do Google Calendar atualizado"
+        "updatedTitle": "Evento do Google Calendar atualizado",
+        "updateError": "Não foi possível alterar este calendário. Tente novamente."
       },
       "chat": {
         "addAction": "Adicionar automação de chat",
@@ -6191,6 +6200,7 @@
       }
     },
     "list": {
+      "actionRequired": "Ação necessária",
       "agentEmpty": "Nenhum fluxo de trabalho é executado como este agente ainda.",
       "all": "Todos",
       "allAgents": "Todos os agentes",
@@ -6208,6 +6218,7 @@
       },
       "noWorkflows": "Nenhum fluxo de trabalho",
       "open": "Abrir {{title}}",
+      "openRecovery": "Abrir recuperação de {{title}}",
       "runsAs": "Executado como",
       "runsAsAria": "Executado como {{agent}}",
       "section": {

--- a/turbo/apps/platform/src/signals/workflows-page/workflow-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflow-detail-page-setup.ts
@@ -18,9 +18,11 @@ import {
 } from "./workflows-signals.ts";
 import { setOfficialWorkflowConfigurationForm$ } from "./official-workflows-signals.ts";
 import { detachedNavigateTo$ } from "../route.ts";
+import { resetConnectorAccountDialogs$ } from "../okou-page/settings/connector-account-dialogs.ts";
 
 export const setupWorkflowDetailPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    set(resetConnectorAccountDialogs$);
     set(setOfficialWorkflowConfigurationForm$, null);
     set(resetWorkflowDetailUiState$);
     const detail = await get(currentWorkflowDetail$);

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -7,6 +7,7 @@ import {
   type ChatRunFinishedEventConfig,
   type GmailLabelAppliedEventConfig,
   type GmailNewMessageEventConfig,
+  type GoogleCalendarAutomationEventConfig,
   type GoogleCalendarEventCancelledEventConfig,
   type GoogleCalendarEventCreatedEventConfig,
   type GoogleCalendarEventUpdatedEventConfig,
@@ -129,9 +130,30 @@ type WorkflowWebhookAutomationSummary = Extract<
   WorkflowAutomationSummary,
   { readonly kind: "event"; readonly eventType: "webhook-received" }
 >;
+export type GoogleCalendarWorkflowAutomationSummary = Extract<
+  WorkflowAutomationSummary,
+  {
+    readonly kind: "event";
+    readonly eventType:
+      | "google-calendar-event-created"
+      | "google-calendar-event-updated"
+      | "google-calendar-event-cancelled";
+  }
+>;
 export type WorkflowAutomationEntry = WorkflowAutomationsListEntry;
 const WORKFLOW_DETAIL_FILE_PARAM = "file";
 const WORKFLOW_AUTOMATION_TARGET_PARAM = "automationId";
+
+export function isGoogleCalendarWorkflowAutomation(
+  automation: WorkflowAutomationSummary,
+): automation is GoogleCalendarWorkflowAutomationSummary {
+  return (
+    automation.kind === "event" &&
+    (automation.eventType === "google-calendar-event-created" ||
+      automation.eventType === "google-calendar-event-updated" ||
+      automation.eventType === "google-calendar-event-cancelled")
+  );
+}
 
 function workflowDetailTabFromRoute(route: RouteKey | null): WorkflowDetailTab {
   switch (route) {
@@ -234,6 +256,7 @@ const internalWorkflowCopyForm$ = state<WorkflowCopyFormState>(
 );
 const internalWorkflowFileDraft$ = state<WorkflowDetailFileDraft | null>(null);
 const internalEditingWorkflowAutomationId$ = state<string | null>(null);
+const internalEditingGoogleCalendarId$ = state("");
 const internalWorkflowMetadataPatch$ = state<WorkflowMetadataPatch | null>(
   null,
 );
@@ -437,6 +460,7 @@ export const resetWorkflowDetailUiState$ = command(({ set }) => {
   set(internalWorkflowCopyForm$, defaultWorkflowCopyForm());
   set(internalWorkflowFileDraft$, null);
   set(internalEditingWorkflowAutomationId$, null);
+  set(internalEditingGoogleCalendarId$, "");
   set(internalWorkflowMetadataPatch$, null);
   set(internalWorkflowAutomationCreateDialog$, null);
   set(internalCreatedWorkflowWebhookAutomation$, null);
@@ -483,6 +507,16 @@ export const setEditingWorkflowAutomationId$ = command(
       set(internalEditingGmailMatchConditions$, {});
     }
     set(internalEditingWorkflowAutomationId$, automationId);
+  },
+);
+
+export const editingGoogleCalendarId$ = computed((get) => {
+  return get(internalEditingGoogleCalendarId$);
+});
+
+export const setEditingGoogleCalendarId$ = command(
+  ({ set }, calendarId: string) => {
+    set(internalEditingGoogleCalendarId$, calendarId);
   },
 );
 
@@ -1410,6 +1444,41 @@ export const updateWorkflowAutomationEventConfig$ = command(
     );
     signal.throwIfAborted();
     set(reloadWorkflows$);
+  },
+);
+
+export const updateWorkflowGoogleCalendarAutomationEventConfig$ = command(
+  async (
+    { get, set },
+    input: {
+      readonly automationId: string;
+      readonly eventConfig: GoogleCalendarAutomationEventConfig;
+    },
+    signal: AbortSignal,
+  ): Promise<GoogleCalendarWorkflowAutomationSummary> => {
+    await set(updateWorkflowAutomationEventConfig$, input, signal);
+    const detail = await get(currentWorkflowDetail$);
+    signal.throwIfAborted();
+    const automation = detail?.automations.find((candidate) => {
+      return candidate.id === input.automationId;
+    });
+    const eventMatches =
+      automation?.kind === "event" &&
+      ((automation.eventType === "google-calendar-event-created" &&
+        input.eventConfig.event === "event_created") ||
+        (automation.eventType === "google-calendar-event-updated" &&
+          input.eventConfig.event === "event_updated") ||
+        (automation.eventType === "google-calendar-event-cancelled" &&
+          input.eventConfig.event === "event_cancelled"));
+    if (
+      !automation ||
+      !isGoogleCalendarWorkflowAutomation(automation) ||
+      !eventMatches ||
+      automation.warning !== undefined
+    ) {
+      throw new Error("Google Calendar automation recovery did not complete");
+    }
+    return automation;
   },
 );
 

--- a/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/settings/connector-account-manager-dialog.tsx
@@ -64,7 +64,7 @@ interface ConnectorAccountManagerDialogProps {
   readonly icon: ReactNode;
   readonly connectionActionsEnabled: boolean;
   readonly onClose: () => void;
-  readonly onAdd: () => void;
+  readonly onAdd?: () => void;
   readonly onReconnect: (account: ConnectorAccountConnection) => void;
   readonly onReviewScopes?: (account: ConnectorAccountConnection) => void;
 }
@@ -705,24 +705,26 @@ export function ConnectorAccountManagerDialog({
             </Button>
           ) : null}
         </div>
-        <DialogFooter className="shrink-0">
-          <Button
-            type="button"
-            disabled={
-              !connectionActionsEnabled ||
-              accountsLoadable.state === "hasError" ||
-              (accountsLoadable.state === "hasData" &&
-                !accountsLoadable.data.available)
-            }
-            onClick={() => {
-              return leave(onAdd);
-            }}
-          >
-            {t(($) => {
-              return $.connectors.accounts.addAccount;
-            })}
-          </Button>
-        </DialogFooter>
+        {onAdd ? (
+          <DialogFooter className="shrink-0">
+            <Button
+              type="button"
+              disabled={
+                !connectionActionsEnabled ||
+                accountsLoadable.state === "hasError" ||
+                (accountsLoadable.state === "hasData" &&
+                  !accountsLoadable.data.available)
+              }
+              onClick={() => {
+                return leave(onAdd);
+              }}
+            >
+              {t(($) => {
+                return $.connectors.accounts.addAccount;
+              })}
+            </Button>
+          </DialogFooter>
+        ) : null}
         <DeleteAccountConfirmation target={target} />
       </DialogContent>
     </Dialog>

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -5,6 +5,11 @@ import {
   type BillingStatusResponse,
 } from "@okouai/api-contracts/contracts/billing";
 import {
+  connectorAccountsContract,
+  type ConnectorAccountConnection,
+} from "@okouai/api-contracts/contracts/connector-accounts";
+import { connectorOauthStartContract } from "@okouai/api-contracts/contracts/connectors";
+import {
   workflowsCollectionContract,
   workflowsDetailContract,
   workflowVisibilityContract,
@@ -15,6 +20,7 @@ import {
   type WorkflowDetailResponse,
   type WorkflowSummary,
   type WorkflowAutomationSummary,
+  type GoogleCalendarAutomationEventConfig,
 } from "@okouai/api-contracts/contracts/workflows";
 import {
   agentsByIdContract,
@@ -96,6 +102,15 @@ function installScrollIntoViewMock(): Mock<HTMLElement["scrollIntoView"]> {
     value: scrollIntoView,
   });
   return scrollIntoView;
+}
+
+function createAuthWindow(): Window {
+  const authWindow = context.mocks.browser.authWindow();
+  Object.defineProperty(authWindow, "location", {
+    configurable: true,
+    value: { href: "" },
+  });
+  return authWindow;
 }
 
 function billingStatus(
@@ -181,6 +196,10 @@ type WorkflowGoogleCalendarEventCancelledAutomationSummary = Extract<
   WorkflowAutomationSummary,
   { kind: "event"; eventType: "google-calendar-event-cancelled" }
 >;
+type WorkflowGoogleCalendarAutomationSummary =
+  | WorkflowGoogleCalendarEventCreatedAutomationSummary
+  | WorkflowGoogleCalendarEventUpdatedAutomationSummary
+  | WorkflowGoogleCalendarEventCancelledAutomationSummary;
 type WorkflowGoogleFormsResponseSubmittedAutomationSummary = Extract<
   WorkflowAutomationSummary,
   { kind: "event"; eventType: "google-forms-response-submitted" }
@@ -299,7 +318,9 @@ function githubPullRequestWorkflowAutomation(): WorkflowGithubPullRequestAutomat
   };
 }
 
-function googleCalendarWorkflowAutomation(): WorkflowGoogleCalendarEventCreatedAutomationSummary {
+function googleCalendarWorkflowAutomation(
+  overrides: Partial<WorkflowGoogleCalendarEventCreatedAutomationSummary> = {},
+): WorkflowGoogleCalendarEventCreatedAutomationSummary {
   return {
     id: GOOGLE_CALENDAR_AUTOMATION_ID,
     kind: "event",
@@ -316,11 +337,14 @@ function googleCalendarWorkflowAutomation(): WorkflowGoogleCalendarEventCreatedA
     chatThreadId: "thread_google_calendar_event_created",
     nextRunAt: null,
     lastRunAt: null,
+    ...overrides,
     official: null,
   };
 }
 
-function googleCalendarUpdatedWorkflowAutomation(): WorkflowGoogleCalendarEventUpdatedAutomationSummary {
+function googleCalendarUpdatedWorkflowAutomation(
+  overrides: Partial<WorkflowGoogleCalendarEventUpdatedAutomationSummary> = {},
+): WorkflowGoogleCalendarEventUpdatedAutomationSummary {
   return {
     id: "workflow-automation-google-calendar-updated",
     kind: "event",
@@ -337,11 +361,14 @@ function googleCalendarUpdatedWorkflowAutomation(): WorkflowGoogleCalendarEventU
     chatThreadId: "thread_google_calendar_event_updated",
     nextRunAt: null,
     lastRunAt: null,
+    ...overrides,
     official: null,
   };
 }
 
-function googleCalendarCancelledWorkflowAutomation(): WorkflowGoogleCalendarEventCancelledAutomationSummary {
+function googleCalendarCancelledWorkflowAutomation(
+  overrides: Partial<WorkflowGoogleCalendarEventCancelledAutomationSummary> = {},
+): WorkflowGoogleCalendarEventCancelledAutomationSummary {
   return {
     id: "workflow-automation-google-calendar-cancelled",
     kind: "event",
@@ -358,6 +385,7 @@ function googleCalendarCancelledWorkflowAutomation(): WorkflowGoogleCalendarEven
     chatThreadId: "thread_google_calendar_event_cancelled",
     nextRunAt: null,
     lastRunAt: null,
+    ...overrides,
     official: null,
   };
 }
@@ -1332,6 +1360,75 @@ function mockUpdateWorkflowAutomation(
       });
     },
   );
+}
+
+function applyGoogleCalendarAutomationUpdate(
+  automation: WorkflowAutomationSummary,
+  eventConfig: GoogleCalendarAutomationEventConfig,
+): WorkflowGoogleCalendarAutomationSummary {
+  switch (eventConfig.event) {
+    case "event_created": {
+      if (
+        automation.kind !== "event" ||
+        automation.eventType !== "google-calendar-event-created"
+      ) {
+        throw new Error("Expected a Google Calendar event-created automation");
+      }
+      const { warning: _warning, ...rest } = automation;
+      return { ...rest, eventConfig };
+    }
+    case "event_updated": {
+      if (
+        automation.kind !== "event" ||
+        automation.eventType !== "google-calendar-event-updated"
+      ) {
+        throw new Error("Expected a Google Calendar event-updated automation");
+      }
+      const { warning: _warning, ...rest } = automation;
+      return { ...rest, eventConfig };
+    }
+    case "event_cancelled": {
+      if (
+        automation.kind !== "event" ||
+        automation.eventType !== "google-calendar-event-cancelled"
+      ) {
+        throw new Error(
+          "Expected a Google Calendar event-cancelled automation",
+        );
+      }
+      const { warning: _warning, ...rest } = automation;
+      return { ...rest, eventConfig };
+    }
+  }
+}
+
+function googleCalendarAccount(args: {
+  readonly id: string;
+  readonly displayName: string;
+  readonly isDefault: boolean;
+  readonly externalUsername: string;
+  readonly status?: ConnectorAccountConnection["connectionStatus"];
+}): ConnectorAccountConnection {
+  return {
+    id: args.id,
+    target: { kind: "builtin", connectorSlug: "google-calendar" },
+    authMethod: "oauth",
+    displayName: args.displayName,
+    isDefault: args.isDefault,
+    externalId: null,
+    externalUsername: args.externalUsername,
+    externalEmail: `${args.externalUsername}@example.com`,
+    oauthScopes: [],
+    scopeMismatch: false,
+    connectionStatus: args.status ?? "connected",
+    reconnectReason:
+      args.status === "reconnect-required"
+        ? "authorization_expired_or_revoked"
+        : null,
+    tokenExpiresAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
 }
 
 function mockRunWorkflowAutomation(
@@ -3257,6 +3354,539 @@ test("Create a Google Calendar event-cancelled automation", async () => {
       },
     });
   });
+});
+
+test.each([
+  {
+    label: "created",
+    automation: googleCalendarWorkflowAutomation({
+      eventConfig: {
+        provider: "google-calendar",
+        event: "event_created",
+        calendarId: "missing-created@example.com",
+      },
+      warning: "calendar_not_found",
+    }),
+    expectedEventConfig: {
+      provider: "google-calendar",
+      event: "event_created",
+      calendarId: "replacement@example.com",
+    },
+  },
+  {
+    label: "updated",
+    automation: googleCalendarUpdatedWorkflowAutomation({
+      eventConfig: {
+        provider: "google-calendar",
+        event: "event_updated",
+        calendarId: "missing-updated@example.com",
+      },
+      warning: "calendar_not_found",
+    }),
+    expectedEventConfig: {
+      provider: "google-calendar",
+      event: "event_updated",
+      calendarId: "replacement@example.com",
+    },
+  },
+  {
+    label: "cancelled",
+    automation: googleCalendarCancelledWorkflowAutomation({
+      eventConfig: {
+        provider: "google-calendar",
+        event: "event_cancelled",
+        calendarId: "missing-cancelled@example.com",
+      },
+      warning: "calendar_not_found",
+    }),
+    expectedEventConfig: {
+      provider: "google-calendar",
+      event: "event_cancelled",
+      calendarId: "replacement@example.com",
+    },
+  },
+] satisfies readonly {
+  readonly label: string;
+  readonly automation: WorkflowGoogleCalendarAutomationSummary;
+  readonly expectedEventConfig: GoogleCalendarAutomationEventConfig;
+}[])(
+  "Recover a missing Calendar for an event-$label automation without changing its event contract",
+  async ({ automation, expectedEventConfig }) => {
+    const updates: {
+      readonly automationId: string;
+      readonly body: WorkflowAutomationUpdateRequest;
+    }[] = [];
+    const workflow = { ...salesResearch(), automations: [automation] };
+    mockWorkflowApis([workflow]);
+    mockUpdateWorkflowAutomation((automationId, body) => {
+      updates.push({ automationId, body });
+      if (
+        !("eventConfig" in body) ||
+        body.eventConfig.provider !== "google-calendar"
+      ) {
+        throw new Error("Expected a Google Calendar event-config update");
+      }
+      const current = workflow.automations[0];
+      if (!current) {
+        throw new Error("Expected a Google Calendar automation");
+      }
+      workflow.automations[0] = applyGoogleCalendarAutomationUpdate(
+        current,
+        body.eventConfig,
+      );
+    });
+
+    await setupWorkflowDetailPage(workflowDetailPath("automations"));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "Enabled · Action required — delivery paused",
+    );
+    expect(alert).toHaveTextContent(
+      "This calendar is no longer available. Choose another calendar to resume this automation.",
+    );
+    const row = alert.closest("[data-automation-id]");
+    if (!(row instanceof HTMLElement)) {
+      throw new Error("Expected the Calendar automation row");
+    }
+    expect(row).not.toHaveClass("opacity-75");
+    expect(within(row).getByRole("switch")).toBeChecked();
+    expect(buttonByText("Edit automation", row)).toBeInTheDocument();
+
+    click(buttonByText("Change calendar", alert));
+    const form = await screen.findByRole("form", {
+      name: "Change Google Calendar automation",
+    });
+    expect(within(form).getByLabelText("Calendar ID")).toHaveValue(
+      automation.eventConfig.calendarId,
+    );
+    await fill(
+      within(form).getByLabelText("Calendar ID"),
+      expectedEventConfig.calendarId,
+    );
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(updates).toStrictEqual([
+        {
+          automationId: automation.id,
+          body: { eventConfig: expectedEventConfig },
+        },
+      ]);
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("form", {
+          name: "Change Google Calendar automation",
+        }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  },
+);
+
+test("Keep the Calendar recovery editor open and disabled while the update is pending", async () => {
+  const automation = googleCalendarWorkflowAutomation({
+    warning: "calendar_not_found",
+  });
+  const workflow: WorkflowDetailResponse = {
+    ...salesResearch(),
+    automations: [automation],
+  };
+  const updateGate = context.mocks.deferred<void>();
+  mockWorkflowApis([workflow]);
+  context.mocks.api(
+    workflowAutomationsContract.update,
+    async ({ body, params, respond }) => {
+      if (
+        !("eventConfig" in body) ||
+        body.eventConfig.provider !== "google-calendar"
+      ) {
+        return respond(400, {
+          error: { code: "BAD_REQUEST", message: "Expected Calendar update" },
+        });
+      }
+      await updateGate.promise;
+      const updated = applyGoogleCalendarAutomationUpdate(
+        automation,
+        body.eventConfig,
+      );
+      workflow.automations[0] = updated;
+      return respond(200, { ...updated, id: params.id });
+    },
+  );
+
+  await setupWorkflowDetailPage(workflowDetailPath("automations"));
+  const warning = await screen.findByRole("alert");
+  click(buttonByText("Change calendar", warning));
+  const form = await screen.findByRole("form", {
+    name: "Change Google Calendar automation",
+  });
+  const calendarId = within(form).getByLabelText("Calendar ID");
+  await fill(calendarId, "replacement@example.com");
+  fireEvent.submit(form);
+
+  await waitFor(() => {
+    expect(calendarId).toBeDisabled();
+    expect(buttonByText("Save calendar", form)).toBeDisabled();
+    expect(form).toBeInTheDocument();
+  });
+  updateGate.resolve();
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("form", {
+        name: "Change Google Calendar automation",
+      }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+test("Keep the Calendar recovery editor open with an inline error when the update fails", async () => {
+  const automation = googleCalendarWorkflowAutomation({
+    warning: "calendar_not_found",
+  });
+  const workflow = { ...salesResearch(), automations: [automation] };
+  mockWorkflowApis([workflow]);
+  context.mocks.api(workflowAutomationsContract.update, ({ respond }) => {
+    return respond(409, {
+      error: { code: "CONFLICT", message: "Calendar update failed" },
+    });
+  });
+
+  await setupWorkflowDetailPage(workflowDetailPath("automations"));
+  click(buttonByText("Change calendar", await screen.findByRole("alert")));
+  const form = await screen.findByRole("form", {
+    name: "Change Google Calendar automation",
+  });
+  await fill(
+    within(form).getByLabelText("Calendar ID"),
+    "replacement@example.com",
+  );
+  fireEvent.submit(form);
+
+  const updateError = await within(form).findByRole("alert");
+  expect(updateError).toHaveTextContent(
+    "We couldn't change this calendar. Try again.",
+  );
+  expect(within(form).getByLabelText("Calendar ID")).toBeEnabled();
+  expect(form).toBeInTheDocument();
+});
+
+test("Accept a server-normalized Calendar ID after recovery", async () => {
+  const automation = googleCalendarWorkflowAutomation({
+    eventConfig: {
+      provider: "google-calendar",
+      event: "event_created",
+      calendarId: "missing@example.com",
+    },
+    warning: "calendar_not_found",
+  });
+  const workflow: WorkflowDetailResponse = {
+    ...salesResearch(),
+    automations: [automation],
+  };
+  mockWorkflowApis([workflow]);
+  context.mocks.api(
+    workflowAutomationsContract.update,
+    ({ body, params, respond }) => {
+      if (
+        !("eventConfig" in body) ||
+        body.eventConfig.provider !== "google-calendar"
+      ) {
+        return respond(400, {
+          error: { code: "BAD_REQUEST", message: "Expected Calendar update" },
+        });
+      }
+      const normalized = applyGoogleCalendarAutomationUpdate(automation, {
+        ...body.eventConfig,
+        calendarId: "primary",
+      });
+      workflow.automations[0] = normalized;
+      return respond(200, { ...normalized, id: params.id });
+    },
+  );
+
+  await setupWorkflowDetailPage(workflowDetailPath("automations"));
+  click(buttonByText("Change calendar", await screen.findByRole("alert")));
+  const form = await screen.findByRole("form", {
+    name: "Change Google Calendar automation",
+  });
+  await fill(within(form).getByLabelText("Calendar ID"), "owner@example.com");
+  fireEvent.submit(form);
+
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("form", {
+        name: "Change Google Calendar automation",
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+  const enabledSwitch = await screen.findByRole("switch", {
+    name: "Disable Google Calendar event created",
+  });
+  const row = enabledSwitch.closest("[data-automation-id]");
+  if (!(row instanceof HTMLElement)) {
+    throw new Error("Expected the reloaded Calendar automation row");
+  }
+  click(buttonByText("Edit automation", row));
+  const normalizedForm = await screen.findByRole("form", {
+    name: "Change Google Calendar automation",
+  });
+  expect(within(normalizedForm).getByLabelText("Calendar ID")).toHaveValue(
+    "primary",
+  );
+});
+
+test.each(["calendar_not_found", "reconnect_required"] as const)(
+  "Show the %s Calendar warning without recovery mutations for another user's automation",
+  async (warning) => {
+    const automation = googleCalendarWorkflowAutomation({
+      ownerUserId: UPDATED_USER_ID,
+      warning,
+    });
+    const workflow = {
+      ...salesResearch(),
+      canManage: false,
+      automations: [automation],
+    };
+    mockWorkflowApis([workflow]);
+
+    await setupWorkflowDetailPage(workflowDetailPath("automations"));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "Enabled · Action required — delivery paused",
+    );
+    const row = alert.closest("[data-automation-id]");
+    if (!(row instanceof HTMLElement)) {
+      throw new Error("Expected the Calendar automation row");
+    }
+    expect(within(row).getByRole("switch")).toBeChecked();
+    expect(within(row).getByRole("switch")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(queryButtonByText("Change calendar", alert)).toBeNull();
+    expect(queryButtonByText("Reconnect Google Calendar", alert)).toBeNull();
+  },
+);
+
+test("Open a Calendar action-required workflow at the exact automation from the workflow list", async () => {
+  const automation = googleCalendarWorkflowAutomation({
+    warning: "calendar_not_found",
+  });
+  const workflow = { ...salesResearch(), automations: [automation] };
+  const scrollIntoView = installScrollIntoViewMock();
+  mockWorkflowApis([workflow]);
+
+  await setupPage({ context, path: "/workflows" });
+
+  click(
+    await waitFor(() => {
+      return buttonByText("Action required");
+    }),
+  );
+  const recoveryLink = await waitFor(() => {
+    return linkByText("Open Sales Research recovery");
+  });
+  expect(recoveryLink).toHaveAttribute(
+    "href",
+    `/workflows/${SALES_WORKFLOW_ID}/automations?automationId=${GOOGLE_CALENDAR_AUTOMATION_ID}`,
+  );
+  const popover = recoveryLink.closest('[data-slot="popover-content"]');
+  if (!(popover instanceof HTMLElement)) {
+    throw new Error("Expected the automation popover");
+  }
+  expect(within(popover).getByRole("switch")).toBeChecked();
+  click(recoveryLink);
+
+  await waitFor(() => {
+    expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/automations`);
+    expect(search()).toBe(`?automationId=${GOOGLE_CALENDAR_AUTOMATION_ID}`);
+  });
+  const row = document.querySelector(
+    `[data-automation-id="${GOOGLE_CALENDAR_AUTOMATION_ID}"]`,
+  );
+  expect(row).toHaveAttribute("aria-current", "true");
+  expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+  await expect(screen.findByRole("alert")).resolves.toHaveTextContent(
+    "Action required — delivery paused",
+  );
+});
+
+test("Keep a healthy Calendar automation on the existing workflow surfaces", async () => {
+  const workflow = {
+    ...salesResearch(),
+    automations: [googleCalendarWorkflowAutomation()],
+  };
+  mockWorkflowApis([workflow]);
+
+  await setupWorkflowDetailPage(workflowDetailPath("automations"));
+
+  const enabledSwitch = await screen.findByRole("switch", {
+    name: "Disable Google Calendar event created",
+  });
+  expect(enabledSwitch).toBeChecked();
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  expect(screen.queryByText("Change calendar")).not.toBeInTheDocument();
+
+  const row = enabledSwitch.closest("[data-automation-id]");
+  if (!(row instanceof HTMLElement)) {
+    throw new Error("Expected the Calendar automation row");
+  }
+  click(buttonByText("Edit automation", row));
+  const form = await screen.findByRole("form", {
+    name: "Change Google Calendar automation",
+  });
+  expect(within(form).getByLabelText("Calendar ID")).toHaveValue("primary");
+});
+
+test("Reconnect the selected Calendar account and reload the warning state", async () => {
+  const automation = googleCalendarWorkflowAutomation({
+    warning: "reconnect_required",
+  });
+  const workflow = { ...salesResearch(), automations: [automation] };
+  const healthyAccount = googleCalendarAccount({
+    id: "10000000-0000-4000-a000-000000000020",
+    displayName: "Work Calendar",
+    isDefault: true,
+    externalUsername: "work",
+  });
+  let reconnectAccount = googleCalendarAccount({
+    id: "10000000-0000-4000-a000-000000000021",
+    displayName: "Personal Calendar",
+    isDefault: false,
+    externalUsername: "personal",
+    status: "reconnect-required",
+  });
+  mockWorkflowApis([workflow]);
+  context.mocks.data.connectors([
+    {
+      id: healthyAccount.id,
+      slug: "google-calendar",
+      authMethod: "oauth",
+      externalId: "google-calendar-work",
+      externalUsername: "work",
+      externalEmail: "work@example.com",
+      oauthScopes: [],
+      connectionStatus: "connected",
+      reconnectReason: null,
+      tokenExpiresAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+  ]);
+  context.mocks.api(connectorAccountsContract.summaries, ({ respond }) => {
+    return respond(200, {
+      summaries: [
+        {
+          target: healthyAccount.target,
+          accountCount: 2,
+          attentionCount:
+            reconnectAccount.connectionStatus === "reconnect-required" ? 1 : 0,
+          defaultConnection: healthyAccount,
+        },
+      ],
+    });
+  });
+  context.mocks.api(
+    connectorAccountsContract.connection,
+    ({ params, respond }) => {
+      if (params.connectionId !== reconnectAccount.id) {
+        return respond(404, {
+          error: { code: "NOT_FOUND", message: "Account not found" },
+        });
+      }
+      return respond(200, reconnectAccount);
+    },
+  );
+  context.mocks.api(connectorAccountsContract.connections, ({ respond }) => {
+    return respond(200, {
+      connections: [healthyAccount, reconnectAccount],
+      nextCursor: null,
+    });
+  });
+  let submittedAccount: unknown;
+  context.mocks.api(connectorOauthStartContract.start, ({ body, respond }) => {
+    submittedAccount = body.account;
+    return respond(200, {
+      authorizationUrl: "https://oauth.test/google-calendar/authorize",
+    });
+  });
+  const authWindow = createAuthWindow();
+  context.mocks.browser.open(authWindow);
+
+  await setupWorkflowDetailPage(workflowDetailPath("automations"));
+
+  const warning = await screen.findByRole("alert");
+  expect(warning).toHaveTextContent(
+    "Google Calendar needs to be reconnected before this automation can resume.",
+  );
+  const reconnectEntry = buttonByText("Reconnect Google Calendar", warning);
+  await waitFor(() => {
+    expect(reconnectEntry).toBeEnabled();
+  });
+  click(reconnectEntry);
+
+  const manager = await screen.findByRole("dialog", {
+    name: "Manage Google Calendar accounts",
+  });
+  const healthyRow = within(manager).getByRole("group", {
+    name: "Work Calendar",
+  });
+  const reconnectRow = within(manager).getByRole("group", {
+    name: "Personal Calendar",
+  });
+  expect(healthyRow).toHaveTextContent("Connected");
+  expect(reconnectRow).toHaveTextContent("Reconnect required");
+  expect(submittedAccount).toBeUndefined();
+  expect(queryButtonByText("Reconnect", healthyRow)).toBeNull();
+  click(buttonByText("Reconnect", reconnectRow));
+
+  const connectDialog = await waitFor(() => {
+    const dialog = screen
+      .getAllByRole("dialog", { name: "Google Calendar" })
+      .find((candidate) => {
+        return queryButtonByText("Reconnect", candidate);
+      });
+    if (!dialog) {
+      throw new Error("Expected Google Calendar reconnect dialog");
+    }
+    return dialog;
+  });
+  const connectorChangedSubscribe = context.mocks.ably.deferNextSubscribe();
+  click(buttonByText("Reconnect", connectDialog));
+
+  await connectorChangedSubscribe.started;
+  connectorChangedSubscribe.attach();
+  await waitFor(() => {
+    expect(authWindow.location.href).toBe(
+      "https://oauth.test/google-calendar/authorize",
+    );
+  });
+  expect(submittedAccount).toStrictEqual({
+    intent: "reconnect",
+    connectionId: reconnectAccount.id,
+  });
+  reconnectAccount = {
+    ...reconnectAccount,
+    connectionStatus: "connected",
+    reconnectReason: null,
+    updatedAt: "2026-01-01T00:00:01.000Z",
+  };
+  workflow.automations[0] = googleCalendarWorkflowAutomation();
+  context.mocks.ably.trigger("connector:changed", {
+    connectorSlug: "google-calendar",
+  });
+
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("dialog", { name: "Google Calendar" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+  expect(screen.getByRole("switch")).toBeChecked();
 });
 
 test("Hide Google Forms automation creation when the feature is unavailable", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -9,6 +9,7 @@ import type {
   ChatRunFinishedEventConfig,
   ChatRunFinishedRunStatus,
   GmailNewMessageEventConfig,
+  GoogleCalendarAutomationEventConfig,
   GithubDeploymentState,
   GithubDeploymentStatusCreatedEventConfig,
   GithubIssueCommentCreatedEventConfig,
@@ -131,7 +132,9 @@ import {
   editingScheduleCronFields$,
   editingGithubPullRequestAction$,
   editingGmailMatchConditions$,
+  editingGoogleCalendarId$,
   editingWorkflowAutomationId$,
+  isGoogleCalendarWorkflowAutomation,
   patchWorkflowMetadataForm$,
   openWorkflowChat$,
   pauseWorkflowAutomations$,
@@ -148,6 +151,7 @@ import {
   setCreatedWorkflowWebhookAutomation$,
   setEditingGithubPullRequestAction$,
   setEditingGmailMatchConditions$,
+  setEditingGoogleCalendarId$,
   setEditingScheduleCronFields$,
   setEditingWorkflowAutomationId$,
   setRevealWebhookSecretAutomationId$,
@@ -160,6 +164,7 @@ import {
   setWorkflowAutomationEnabled$,
   scrollTargetedWorkflowAutomationIntoViewRef$,
   updateWorkflowAutomationEventConfig$,
+  updateWorkflowGoogleCalendarAutomationEventConfig$,
   updateWorkflowScheduleAutomation$,
   updateWorkflow$,
   workflowActionDialog$,
@@ -186,6 +191,7 @@ import {
   type GmailMatchCondition,
   type GmailMatchOperator,
   type GmailTextOperator,
+  type GoogleCalendarWorkflowAutomationSummary,
   workflowMetadataPatch$,
   targetedWorkflowAutomationId$,
 } from "../../signals/workflows-page/workflows-signals.ts";
@@ -214,6 +220,16 @@ import {
   type CronTimeOption,
 } from "../../signals/okou-page/cron.ts";
 import { userPreferences$ } from "../../signals/okou-page/settings/user-preferences.ts";
+import { relatedCatalogItems$ } from "../../signals/okou-page/settings/connectors.ts";
+import {
+  builtinAccountConnectDialog$,
+  builtinAccountManager$,
+  closeBuiltinAccountConnectDialog$,
+  closeBuiltinAccountManager$,
+  finishConnectorAccountConnection$,
+  openBuiltinAccountConnectDialog$,
+  openBuiltinAccountManager$,
+} from "../../signals/okou-page/settings/connector-account-dialogs.ts";
 import { Link } from "../router/link.tsx";
 import {
   DetailPageBreadcrumbBar,
@@ -251,6 +267,9 @@ import { WorkflowHoverContent } from "./workflows-page.tsx";
 import { AutomationListIcon } from "../okou-page/workflow-automations-page.tsx";
 import { emptyAutomationsImg } from "../okou-page/platform-assets.ts";
 import { WorkflowWebhookUpgradeDialog } from "./workflow-webhook-upgrade-dialog.tsx";
+import { ConnectModal } from "../okou-page/components/settings/add-connection-dialog.tsx";
+import { ConnectorAccountManagerDialog } from "../okou-page/components/settings/connector-account-manager-dialog.tsx";
+import { ConnectorIcon } from "../okou-page/components/settings/connector-icons.tsx";
 import {
   createOfficialWorkflowConfigurationForm,
   OfficialWorkflowConfigurationFields,
@@ -261,6 +280,7 @@ import {
 const AUTOMATION_FIELD_CLASS = "h-8 px-2 text-xs";
 const WORKFLOW_EDIT_TEXTAREA_CLASS = "min-h-24 resize-y";
 const AUTOMATION_TIMEZONE = "UTC";
+const GOOGLE_CALENDAR_CONNECTOR_SLUG = "google-calendar";
 
 const STRIPE_INVOICE_BILLING_REASONS = [
   "automatic_pending_invoice_item_invoice",
@@ -3495,6 +3515,23 @@ function googleCalendarIdFromForm(form: FormData): string {
   return formTextValue(form, "calendarId") ?? "primary";
 }
 
+function updatedGoogleCalendarEventConfig(
+  automation: GoogleCalendarWorkflowAutomationSummary,
+  calendarId: string,
+): GoogleCalendarAutomationEventConfig {
+  switch (automation.eventType) {
+    case "google-calendar-event-created": {
+      return { ...automation.eventConfig, calendarId };
+    }
+    case "google-calendar-event-updated": {
+      return { ...automation.eventConfig, calendarId };
+    }
+    case "google-calendar-event-cancelled": {
+      return { ...automation.eventConfig, calendarId };
+    }
+  }
+}
+
 function githubSubjectFilterValue(
   value: FormDataEntryValue | null,
   fallback: GithubIssueCommentSubjectFilter,
@@ -5046,6 +5083,7 @@ function AutomationsSection({
         createDialog={createDialog}
         setCreateDialog={setCreateDialog}
       />
+      <GoogleCalendarRecoveryDialogs />
     </section>
   );
 }
@@ -8558,6 +8596,179 @@ function AutomationRowStats({
   );
 }
 
+function GoogleCalendarReconnectAction() {
+  const connectorLoadable = useLoadable(relatedCatalogItems$);
+  const openAccountManager = useSet(openBuiltinAccountManager$);
+  const pageSignal = useGet(pageSignal$);
+  const connector =
+    connectorLoadable.state === "hasData"
+      ? (connectorLoadable.data.find((candidate) => {
+          return candidate.slug === GOOGLE_CALENDAR_CONNECTOR_SLUG;
+        }) ?? null)
+      : null;
+
+  return (
+    <Button
+      type="button"
+      variant="link"
+      className="h-auto w-fit p-0 text-xs text-amber-700 dark:text-amber-400"
+      disabled={!connector}
+      onClick={() => {
+        if (connector) {
+          openAccountManager(connector, pageSignal);
+        }
+      }}
+    >
+      {connectorLoadable.state === "loading" ? (
+        <Loader2 size={13} className="animate-spin" />
+      ) : null}
+      {i18n.t(($) => {
+        return $.workflows.automations.calendar.reconnectGoogleCalendar;
+      })}
+    </Button>
+  );
+}
+
+function GoogleCalendarAutomationWarning({
+  automation,
+  canOperate,
+  canEditStructure,
+  onChangeCalendar,
+}: {
+  readonly automation: GoogleCalendarWorkflowAutomationSummary;
+  readonly canOperate: boolean;
+  readonly canEditStructure: boolean;
+  readonly onChangeCalendar: () => void;
+}) {
+  if (!automation.warning) {
+    return null;
+  }
+  const description =
+    automation.warning === "calendar_not_found"
+      ? i18n.t(($) => {
+          return $.workflows.automations.calendar.calendarNotFoundDescription;
+        })
+      : i18n.t(($) => {
+          return $.workflows.automations.calendar.reconnectDescription;
+        });
+
+  return (
+    <div
+      role="alert"
+      className="flex min-w-0 items-start gap-1.5 text-xs text-amber-700 dark:text-amber-400 sm:col-span-5"
+    >
+      <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="font-medium">
+          {automation.enabled ? (
+            <>
+              {i18n.t(($) => {
+                return $.workflows.automations.calendar.enabledIntent;
+              })}
+              <span aria-hidden="true"> · </span>
+            </>
+          ) : null}
+          {i18n.t(($) => {
+            return $.workflows.automations.calendar.actionRequiredPaused;
+          })}
+        </p>
+        <p>{description}</p>
+        {automation.warning === "calendar_not_found" && canEditStructure ? (
+          <Button
+            type="button"
+            variant="link"
+            className="h-auto w-fit p-0 text-xs text-amber-700 dark:text-amber-400"
+            onClick={onChangeCalendar}
+          >
+            {i18n.t(($) => {
+              return $.workflows.automations.calendar.changeCalendar;
+            })}
+          </Button>
+        ) : null}
+        {automation.warning === "reconnect_required" && canOperate ? (
+          <GoogleCalendarReconnectAction />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function GoogleCalendarRecoveryDialogs() {
+  const managedConnector = useGet(builtinAccountManager$);
+  const accountConnect = useGet(builtinAccountConnectDialog$);
+  const closeAccountManager = useSet(closeBuiltinAccountManager$);
+  const openAccountConnect = useSet(openBuiltinAccountConnectDialog$);
+  const closeAccountConnect = useSet(closeBuiltinAccountConnectDialog$);
+  const finishAccountConnection = useSet(finishConnectorAccountConnection$);
+  const reloadWorkflows = useSet(reloadWorkflows$);
+  const pageSignal = useGet(pageSignal$);
+  const googleCalendarManager =
+    managedConnector?.slug === GOOGLE_CALENDAR_CONNECTOR_SLUG
+      ? managedConnector
+      : null;
+  const googleCalendarConnect =
+    accountConnect?.connector.slug === GOOGLE_CALENDAR_CONNECTOR_SLUG &&
+    accountConnect.mode.kind === "reconnect"
+      ? {
+          connector: accountConnect.connector,
+          mode: accountConnect.mode,
+        }
+      : null;
+
+  return (
+    <>
+      {googleCalendarManager ? (
+        <ConnectorAccountManagerDialog
+          target={{
+            kind: "builtin",
+            connectorSlug: googleCalendarManager.slug,
+          }}
+          connectorLabel={googleCalendarManager.label}
+          icon={<ConnectorIcon icon={googleCalendarManager.icon} size={20} />}
+          connectionActionsEnabled
+          onClose={closeAccountManager}
+          onReconnect={(account) => {
+            openAccountConnect(googleCalendarManager, {
+              kind: "reconnect",
+              connectionId: account.id,
+              authMethod: account.authMethod,
+            });
+          }}
+        />
+      ) : null}
+      {googleCalendarConnect ? (
+        <ConnectModal
+          item={googleCalendarConnect.connector}
+          accountMode={googleCalendarConnect.mode}
+          reconnectAuthMethod={googleCalendarConnect.mode.authMethod}
+          accountOptions={{
+            account: {
+              intent: "reconnect",
+              connectionId: googleCalendarConnect.mode.connectionId,
+            },
+          }}
+          onClose={closeAccountConnect}
+          onSuccess={async (connectionId) => {
+            await finishAccountConnection(
+              {
+                target: {
+                  kind: "builtin",
+                  connectorSlug: googleCalendarConnect.connector.slug,
+                },
+                connectionId,
+                connectorLabel: googleCalendarConnect.connector.label,
+                mode: googleCalendarConnect.mode,
+              },
+              pageSignal,
+            );
+            reloadWorkflows();
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
 function officialReconciliationStatusLabel(
   status: NonNullable<
     WorkflowAutomationSummary["official"]
@@ -8605,6 +8816,55 @@ interface AutomationRowProps {
   readonly showDivider: boolean;
 }
 
+function AutomationRowHeading({
+  automation,
+  title,
+  subtitle,
+}: {
+  readonly automation: WorkflowAutomationSummary;
+  readonly title: string;
+  readonly subtitle: string | null;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <AutomationListIcon automation={automation} size="sm" />
+      <div className="min-w-0">
+        <div
+          className="truncate text-sm font-medium text-foreground"
+          title={title}
+        >
+          {title}
+        </div>
+        {subtitle ? (
+          <div
+            className="mt-0.5 truncate text-xs text-muted-foreground"
+            title={subtitle}
+          >
+            {subtitle}
+          </div>
+        ) : null}
+        {automation.official ? (
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            {i18n.t(
+              ($) => {
+                return $.workflows.official.reconciliationState;
+              },
+              {
+                state: officialReconciliationStatusLabel(
+                  automation.official.reconciliationStatus,
+                ),
+                intended: officialIntendedStateLabel(
+                  automation.official.intendedEnabled,
+                ),
+              },
+            )}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 function AutomationRow({
   automation,
   canOperate,
@@ -8616,6 +8876,7 @@ function AutomationRow({
   const scrollRef = useSet(scrollTargetedWorkflowAutomationIntoViewRef$);
   const editingAutomationId = useGet(editingWorkflowAutomationId$);
   const setEditingAutomationId = useSet(setEditingWorkflowAutomationId$);
+  const setEditingGoogleCalendarId = useSet(setEditingGoogleCalendarId$);
   const editing = editingAutomationId === automation.id;
   const targeted = targetedAutomationId === automation.id;
   const title = workflowScheduleTitle(automation, displayTimezone);
@@ -8625,6 +8886,9 @@ function AutomationRow({
     automation.eventType === "stripe-invoice-paid"
       ? automation
       : null;
+  const calendarAutomation = isGoogleCalendarWorkflowAutomation(automation)
+    ? automation
+    : null;
 
   return (
     <>
@@ -8638,42 +8902,11 @@ function AutomationRow({
           !automation.enabled && "opacity-75",
         )}
       >
-        <div className="flex min-w-0 items-center gap-3">
-          <AutomationListIcon automation={automation} size="sm" />
-          <div className="min-w-0">
-            <div
-              className="truncate text-sm font-medium text-foreground"
-              title={title}
-            >
-              {title}
-            </div>
-            {subtitle ? (
-              <div
-                className="mt-0.5 truncate text-xs text-muted-foreground"
-                title={subtitle}
-              >
-                {subtitle}
-              </div>
-            ) : null}
-            {automation.official ? (
-              <p className="mt-1 text-[11px] text-muted-foreground">
-                {i18n.t(
-                  ($) => {
-                    return $.workflows.official.reconciliationState;
-                  },
-                  {
-                    state: officialReconciliationStatusLabel(
-                      automation.official.reconciliationStatus,
-                    ),
-                    intended: officialIntendedStateLabel(
-                      automation.official.intendedEnabled,
-                    ),
-                  },
-                )}
-              </p>
-            ) : null}
-          </div>
-        </div>
+        <AutomationRowHeading
+          automation={automation}
+          title={title}
+          subtitle={subtitle}
+        />
         <AutomationRowStats
           automation={automation}
           displayTimezone={displayTimezone}
@@ -8692,6 +8925,19 @@ function AutomationRow({
         ) : (
           <div aria-hidden="true" />
         )}
+        {calendarAutomation ? (
+          <GoogleCalendarAutomationWarning
+            automation={calendarAutomation}
+            canOperate={canOperate}
+            canEditStructure={canEditStructure}
+            onChangeCalendar={() => {
+              setEditingGoogleCalendarId(
+                calendarAutomation.eventConfig.calendarId,
+              );
+              setEditingAutomationId(calendarAutomation.id);
+            }}
+          />
+        ) : null}
         {stripeAutomation ? (
           <div className="flex min-w-0 flex-col gap-1 text-xs text-muted-foreground sm:col-span-5">
             <p>
@@ -8846,6 +9092,55 @@ function AutomationStatusSwitch({
   );
 }
 
+function AutomationEditButton({
+  automation,
+  displayTimezone,
+  busy,
+}: {
+  readonly automation: WorkflowAutomationSummary;
+  readonly displayTimezone: string;
+  readonly busy: boolean;
+}) {
+  const copy = automationActionCopy();
+  const setEditingAutomationId = useSet(setEditingWorkflowAutomationId$);
+  const setEditingGoogleCalendarId = useSet(setEditingGoogleCalendarId$);
+  const setEditingScheduleCronFields = useSet(setEditingScheduleCronFields$);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          disabled={busy}
+          aria-label={copy.editAutomation}
+          className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-state-selected-hover hover:text-foreground"
+          onClick={() => {
+            if (
+              automation.kind === "schedule" &&
+              automation.schedule.type === "cron"
+            ) {
+              setEditingScheduleCronFields(
+                parseWorkflowCronFields(automation.schedule, displayTimezone),
+              );
+            }
+            if (isGoogleCalendarWorkflowAutomation(automation)) {
+              setEditingGoogleCalendarId(automation.eventConfig.calendarId);
+            }
+            setEditingAutomationId(automation.id);
+          }}
+        >
+          <Pencil size={14} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="text-xs">{copy.editAutomation}</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function AutomationControls({
   automation,
   displayTimezone,
@@ -8858,8 +9153,6 @@ function AutomationControls({
   const copy = automationActionCopy();
   const pageSignal = useGet(pageSignal$);
   const navigate = useSet(detachedNavigateTo$);
-  const setEditingAutomationId = useSet(setEditingWorkflowAutomationId$);
-  const setEditingScheduleCronFields = useSet(setEditingScheduleCronFields$);
   const revealWebhookSecretAutomationId = useGet(
     revealWebhookSecretAutomationId$,
   );
@@ -8911,37 +9204,11 @@ function AutomationControls({
             </TooltipContent>
           </Tooltip>
           {canEdit ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  disabled={busy}
-                  aria-label={copy.editAutomation}
-                  className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-state-selected-hover hover:text-foreground"
-                  onClick={() => {
-                    if (
-                      automation.kind === "schedule" &&
-                      automation.schedule.type === "cron"
-                    ) {
-                      setEditingScheduleCronFields(
-                        parseWorkflowCronFields(
-                          automation.schedule,
-                          displayTimezone,
-                        ),
-                      );
-                    }
-                    setEditingAutomationId(automation.id);
-                  }}
-                >
-                  <Pencil size={14} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="text-xs">{copy.editAutomation}</p>
-              </TooltipContent>
-            </Tooltip>
+            <AutomationEditButton
+              automation={automation}
+              displayTimezone={displayTimezone}
+              busy={busy}
+            />
           ) : null}
           {canEditStructure || isWebhookWorkflowAutomation(automation) ? (
             <AutomationMoreActionsMenu
@@ -9063,6 +9330,7 @@ function canEditWorkflowAutomation(
     automation.kind === "schedule" ||
     isGmailWorkflowAutomation(automation) ||
     isGithubWorkflowAutomation(automation) ||
+    isGoogleCalendarWorkflowAutomation(automation) ||
     (automation.kind === "event" &&
       automation.eventType === "chat-run-finished")
   );
@@ -9080,6 +9348,11 @@ function editWorkflowAutomationTitle(
   if (automation.eventType === "chat-run-finished") {
     return i18n.t(($) => {
       return $.workflows.automations.chat.viewTitle;
+    });
+  }
+  if (isGoogleCalendarWorkflowAutomation(automation)) {
+    return i18n.t(($) => {
+      return $.workflows.automations.calendar.changeCalendar;
     });
   }
   if (automation.eventType === "gmail-new-message") {
@@ -9160,6 +9433,12 @@ function EditWorkflowAutomationDialog({
           <UpdateScheduleAutomationForm
             automation={automation}
             displayTimezone={displayTimezone}
+            onCancel={close}
+          />
+        ) : null}
+        {isGoogleCalendarWorkflowAutomation(automation) ? (
+          <UpdateGoogleCalendarAutomationForm
+            automation={automation}
             onCancel={close}
           />
         ) : null}
@@ -9334,6 +9613,102 @@ function UpdateScheduleAutomationForm({
         <span>
           {i18n.t(($) => {
             return $.workflows.automations.schedule.saveSchedule;
+          })}
+        </span>
+      </AutomationFormActions>
+    </form>
+  );
+}
+
+function UpdateGoogleCalendarAutomationForm({
+  automation,
+  onCancel,
+}: {
+  readonly automation: GoogleCalendarWorkflowAutomationSummary;
+  readonly onCancel: () => void;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const calendarId = useGet(editingGoogleCalendarId$);
+  const setCalendarId = useSet(setEditingGoogleCalendarId$);
+  const [updateLoadable, updateGoogleCalendarAutomation] = useLoadableSet(
+    updateWorkflowGoogleCalendarAutomationEventConfig$,
+  );
+  const saving = updateLoadable.state === "loading";
+
+  return (
+    <form
+      aria-label={i18n.t(($) => {
+        return $.workflows.automations.calendar.changeAria;
+      })}
+      className="flex flex-col gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const submittedCalendarId = calendarId.trim();
+        if (!submittedCalendarId) {
+          return;
+        }
+        detach(
+          (async () => {
+            await updateGoogleCalendarAutomation(
+              {
+                automationId: automation.id,
+                eventConfig: updatedGoogleCalendarEventConfig(
+                  automation,
+                  submittedCalendarId,
+                ),
+              },
+              pageSignal,
+            );
+            onCancel();
+          })(),
+          Reason.DomCallback,
+        );
+      }}
+    >
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        {i18n.t(($) => {
+          return $.workflows.automations.calendar.calendarId;
+        })}
+        <Input
+          name="calendarId"
+          aria-label={i18n.t(($) => {
+            return $.workflows.automations.calendar.calendarId;
+          })}
+          className={AUTOMATION_FIELD_CLASS}
+          disabled={saving}
+          maxLength={1024}
+          placeholder={i18n.t(($) => {
+            return $.workflows.automations.calendar.calendarIdPlaceholder;
+          })}
+          required
+          value={calendarId}
+          onChange={(event) => {
+            setCalendarId(event.target.value);
+          }}
+        />
+      </label>
+      {updateLoadable.state === "hasError" ? (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+        >
+          <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+          <p>
+            {i18n.t(($) => {
+              return $.workflows.automations.calendar.updateError;
+            })}
+          </p>
+        </div>
+      ) : null}
+      <AutomationFormActions pending={saving} onCancel={onCancel}>
+        {saving ? (
+          <Loader2 size={13} className="animate-spin" />
+        ) : (
+          <CalendarClock size={13} />
+        )}
+        <span>
+          {i18n.t(($) => {
+            return $.workflows.automations.calendar.saveCalendar;
           })}
         </span>
       </AutomationFormActions>

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -10,6 +10,7 @@ import type { WorkflowSummary } from "@okouai/api-contracts/contracts/workflows"
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import {
   ArrowUpDown,
+  AlertTriangle,
   BadgeCheck,
   ChevronDown,
   Lock,
@@ -44,6 +45,7 @@ import { ROUTES } from "../../signals/route-paths.ts";
 import {
   allVisibleWorkflows$,
   allWorkflowAutomationEntries$,
+  isGoogleCalendarWorkflowAutomation,
   setWorkflowAgentFilter$,
   setWorkflowFilter$,
   setWorkflowSortMode$,
@@ -96,12 +98,25 @@ function ownerLabel(workflow: WorkflowSummary): string {
 
 function automationDotClass(entry: WorkflowAutomationEntry): string {
   const automation = entry.automation;
+  if (
+    isGoogleCalendarWorkflowAutomation(automation) &&
+    automation.warning !== undefined
+  ) {
+    return "bg-amber-500";
+  }
   if (automation.kind === "schedule") {
     return "bg-blue-500";
   }
   return automation.eventType === "webhook-received"
     ? "bg-amber-500"
     : "bg-emerald-500";
+}
+
+function isActionRequiredEntry(entry: WorkflowAutomationEntry): boolean {
+  return (
+    isGoogleCalendarWorkflowAutomation(entry.automation) &&
+    entry.automation.warning !== undefined
+  );
 }
 
 function connectorNames(entries: readonly WorkflowAutomationEntry[]): string {
@@ -228,21 +243,70 @@ function ConnectorPopoverList({
           entry.automation,
           displayTimezone,
         );
+        const actionRequired = isActionRequiredEntry(entry);
+        const title = workflowTitle(entry.workflow);
         return (
           <div
             key={entry.automation.id}
             className="flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-state-hover"
           >
-            <span className={connectorPillClassName({})}>
-              <ConnectorPillMarker dotClassName={automationDotClass(entry)} />
-              {automationTypeLabel(entry.automation)}
-            </span>
-            <span
-              title={ruleLabel}
-              className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
-            >
-              {ruleLabel}
-            </span>
+            {actionRequired ? (
+              <Link
+                pathname={ROUTES.workflowDetailAutomations}
+                options={{
+                  pathParams: { workflowId: entry.workflow.id },
+                  searchParams: new URLSearchParams({
+                    automationId: entry.automation.id,
+                  }),
+                }}
+                aria-label={i18n.t(
+                  ($) => {
+                    return $.workflows.list.openRecovery;
+                  },
+                  { title },
+                )}
+                className="flex min-w-0 flex-1 items-center gap-2 rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+              >
+                <span
+                  className={cn(
+                    connectorPillClassName({}),
+                    "border-amber-300/80 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400",
+                  )}
+                >
+                  <ConnectorPillMarker
+                    dotClassName={automationDotClass(entry)}
+                  />
+                  {i18n.t(($) => {
+                    return $.workflows.list.actionRequired;
+                  })}
+                </span>
+                <span
+                  title={ruleLabel}
+                  className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
+                >
+                  {ruleLabel}
+                </span>
+                <AlertTriangle
+                  size={13}
+                  className="shrink-0 text-amber-600 dark:text-amber-400"
+                />
+              </Link>
+            ) : (
+              <>
+                <span className={connectorPillClassName({})}>
+                  <ConnectorPillMarker
+                    dotClassName={automationDotClass(entry)}
+                  />
+                  {automationTypeLabel(entry.automation)}
+                </span>
+                <span
+                  title={ruleLabel}
+                  className="min-w-0 flex-1 truncate text-xs text-muted-foreground"
+                >
+                  {ruleLabel}
+                </span>
+              </>
+            )}
             <WorkflowAutomationEnabledSwitch entry={entry} size="sm" />
           </div>
         );
@@ -270,6 +334,7 @@ function ConnectorCell({
   }
 
   const [lead] = entries;
+  const actionRequiredEntry = entries.find(isActionRequiredEntry);
   const remaining = entries.length - 2;
   return (
     <Popover>
@@ -279,15 +344,27 @@ function ConnectorCell({
             <PopoverTrigger asChild>
               <button
                 type="button"
-                className={connectorPillClassName({ interactive: true })}
+                className={cn(
+                  connectorPillClassName({ interactive: true }),
+                  actionRequiredEntry &&
+                    "border-amber-300/80 bg-amber-50 text-amber-700 hover:border-amber-400 hover:bg-amber-100 hover:text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-400 dark:hover:bg-amber-950/50",
+                )}
               >
-                {lead ? (
+                {actionRequiredEntry ? (
+                  <ConnectorPillMarker dotClassName="bg-amber-500" />
+                ) : lead ? (
                   <ConnectorPillMarker
                     dotClassName={automationDotClass(lead)}
                   />
                 ) : null}
-                <span>{connectorNames(entries)}</span>
-                {remaining > 0 ? (
+                <span>
+                  {actionRequiredEntry
+                    ? i18n.t(($) => {
+                        return $.workflows.list.actionRequired;
+                      })
+                    : connectorNames(entries)}
+                </span>
+                {!actionRequiredEntry && remaining > 0 ? (
                   <span className="text-muted-foreground">+{remaining}</span>
                 ) : null}
               </button>


### PR DESCRIPTION
## Summary

- surface typed Google Calendar action-required warnings while preserving the checked user-enabled intent
- provide safe Calendar target editing and multi-account-aware connector reconnection, then reload workflow state
- add compact workflow-list discovery with exact automation targeting and localized accessible copy
- cover permissions, all three Calendar event shapes, update lifecycle, reconnect selection, normalization, and healthy behavior

## Testing

- `pnpm --filter @okouai/app check-types`
- `pnpm --filter @okouai/app lint`
- `pnpm --filter @okouai/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx` (77 tests)
- `git diff --check origin/main...HEAD`

Closes #32491