### PR TITLE
fix(platform): keep browser card height stable

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-browser-actions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-browser-actions.test.tsx
@@ -211,6 +211,9 @@ test("Follow a managed browser session from its chat card", async () => {
   );
   expect(card).toHaveTextContent("Cloud browser");
   expect(card).toHaveTextContent("Live");
+  const status = within(card).getByText("Live");
+  renderAppStyles(status);
+  expect(getComputedStyle(status).lineHeight).toBe("16px");
   expect(screen.getByTestId("browser-session-thumbnail")).toHaveAttribute(
     "src",
     INITIAL_SCREENSHOT_URL,

--- a/turbo/apps/platform/src/views/okou-page/browser-session-card.tsx
+++ b/turbo/apps/platform/src/views/okou-page/browser-session-card.tsx
@@ -45,7 +45,7 @@ function BrowserSessionStatus({ live }: { readonly live: boolean }) {
   return (
     <span
       className={cn(
-        "inline-flex shrink-0 items-center gap-1.5 text-[11px] font-medium",
+        "inline-flex shrink-0 items-center gap-1.5 text-[11px] font-medium leading-[16px]",
         live
           ? "text-emerald-700 dark:text-emerald-300"
           : "text-muted-foreground",


### PR DESCRIPTION
## Summary

- give the browser session status an explicit 16px line height
- prevent the loaded card header from inheriting the chat response line height
- cover the rendered status line height in the existing browser-card page test

## Why

The loading skeleton header is 40px tall, but the loaded status inherited the surrounding 25.5px chat response line height. That made the loaded header 42.5px tall and triggered bottom-anchored chat content to shift upward after the browser card finished loading.

## Testing

- `corepack pnpm dlx prettier@3.6.2 --check apps/platform/src/views/okou-page/browser-session-card.tsx apps/platform/src/views/okou-page/__tests__/chat-capability-browser-actions.test.tsx`
- focused Platform regression is included and will run in PR CI

## Fallbacks

None.