### PR TITLE
feat(runner): diagnose private-write terminal response timeouts

### DIFF
--- a/crates/guest-control-client/src/connection/request.rs
+++ b/crates/guest-control-client/src/connection/request.rs
@@ -4,7 +4,8 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use guest_control_proto::{
-    MSG_ERROR, MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED,
+    FileWriteStatus, MSG_ERROR, MSG_FILE_WRITE_STATUS, MSG_FILE_WRITE_STATUS_RESULT,
+    MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED,
     MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN,
     MSG_SHUTDOWN_ACK, MemorySnapshot, RawMessage,
 };
@@ -24,6 +25,25 @@ use super::{
 struct PendingRequestGuard {
     shared: Arc<Shared>,
     route_id: RouteId,
+}
+
+impl GuestControlClient {
+    /// Read the latest guest file-write stage without changing operation gates.
+    ///
+    /// This control query remains usable after normal writes become uncertain
+    /// and while quiescing. It provides no terminal proof and never re-enables
+    /// normal operations. The caller's budget covers frame write and response.
+    pub async fn file_write_status(&self, timeout: Duration) -> io::Result<FileWriteStatus> {
+        let response = request_on_shared(&self.shared, MSG_FILE_WRITE_STATUS, &[], timeout).await?;
+        if response.msg_type != MSG_FILE_WRITE_STATUS_RESULT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected file-write status response",
+            ));
+        }
+        FileWriteStatus::decode_payload(&response.payload)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/guest-control-client/src/file/write.rs
+++ b/crates/guest-control-client/src/file/write.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::Duration;
 use std::{fmt, io};
 
@@ -12,8 +12,8 @@ use shell_quote::quote_shell_arg;
 
 use crate::{
     CompositeNormalOperation, ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutput,
-    FrameWriteObserver, GuestControlClient, Shared, exec_operation,
-    exec_operation::ExecOperationWaitOutcome,
+    FrameWriteObserver, GuestControlClient, RequestTimeoutError, RequestTimeoutStage, Shared,
+    exec_operation, exec_operation::ExecOperationWaitOutcome,
     normal_request_on_shared_with_write_observer_frame_builder,
     request_on_shared_with_composite_operation_and_observer_frame_builder,
 };
@@ -812,17 +812,27 @@ impl GuestControlClient {
             .await;
         let _file_write_guard = self.shared.file_write_gate.lock().await;
         let timeout = WRITE_FILE_REQUEST_DEADLINE;
+        let sequence = AtomicU32::new(0);
+        let write_sequence = &sequence;
         let resp = normal_request_on_shared_with_write_observer_frame_builder(
             &self.shared,
             WRITE_FILES_TERMINAL_MSG_TYPES,
             timeout,
             write_observer,
             move |seq, frame| {
+                write_sequence.store(seq, Ordering::Relaxed);
                 mode.encode_frame(frame, seq, &proto_entries)
                     .map_err(protocol_invalid_input)
             },
         )
-        .await?;
+        .await
+        .map_err(|error| {
+            annotate_private_write_timeout(
+                error,
+                matches!(mode, WriteFilesMode::Private),
+                &sequence,
+            )
+        })?;
 
         if resp.msg_type == MSG_ERROR {
             let msg = guest_control_proto::decode_error(&resp.payload)
@@ -857,6 +867,12 @@ impl GuestControlClient {
 
         let _file_write_guard = self.shared.file_write_gate.lock().await;
         let timeout = WRITE_FILE_REQUEST_DEADLINE;
+        let sequence = AtomicU32::new(0);
+        let write_sequence = &sequence;
+        let build_frame = move |seq, frame: &mut Vec<u8>| {
+            write_sequence.store(seq, Ordering::Relaxed);
+            encode_write_file_chunk_frame(frame, seq, request)
+        };
         let resp = match tracking {
             WriteFileChunkTracking::Tracked => {
                 normal_request_on_shared_with_write_observer_frame_builder(
@@ -864,9 +880,9 @@ impl GuestControlClient {
                     WRITE_FILE_TERMINAL_MSG_TYPES,
                     timeout,
                     write_observer,
-                    move |seq, frame| encode_write_file_chunk_frame(frame, seq, request),
+                    build_frame,
                 )
-                .await?
+                .await
             }
             WriteFileChunkTracking::Composite(normal_operation) => {
                 request_on_shared_with_composite_operation_and_observer_frame_builder(
@@ -875,11 +891,12 @@ impl GuestControlClient {
                     timeout,
                     normal_operation,
                     write_observer,
-                    move |seq, frame| encode_write_file_chunk_frame(frame, seq, request),
+                    build_frame,
                 )
-                .await?
+                .await
             }
-        };
+        }
+        .map_err(|error| annotate_private_write_timeout(error, request.private, &sequence))?;
 
         if resp.msg_type == MSG_ERROR {
             let msg = guest_control_proto::decode_error(&resp.payload)
@@ -903,6 +920,22 @@ impl GuestControlClient {
 
         Ok(())
     }
+}
+
+fn annotate_private_write_timeout(
+    mut error: io::Error,
+    private: bool,
+    sequence: &AtomicU32,
+) -> io::Error {
+    if private
+        && let Some(timeout) = error
+            .get_mut()
+            .and_then(|source| source.downcast_mut::<RequestTimeoutError>())
+        && timeout.stage() == RequestTimeoutStage::AwaitingTerminalResponse
+    {
+        timeout.private_write_sequence = Some(sequence.load(Ordering::Relaxed));
+    }
+    error
 }
 
 fn validate_write_files<'a>(

--- a/crates/guest-control-client/src/lib.rs
+++ b/crates/guest-control-client/src/lib.rs
@@ -125,12 +125,17 @@ pub enum RequestTimeoutStage {
 pub struct RequestTimeoutError {
     stage: RequestTimeoutStage,
     timeout: Duration,
+    private_write_sequence: Option<u32>,
 }
 
 impl RequestTimeoutError {
     /// Create a timeout error for an observed request stage and total budget.
     pub const fn new(stage: RequestTimeoutStage, timeout: Duration) -> Self {
-        Self { stage, timeout }
+        Self {
+            stage,
+            timeout,
+            private_write_sequence: None,
+        }
     }
 
     /// Return the request stage observed when the deadline expired.
@@ -141,6 +146,14 @@ impl RequestTimeoutError {
     /// Return the configured end-to-end request timeout.
     pub const fn timeout(&self) -> Duration {
         self.timeout
+    }
+
+    /// Private-write request to correlate with a read-only guest diagnostic.
+    ///
+    /// Present only after a complete private-write frame has timed out waiting
+    /// for its terminal response. It does not permit retrying the write.
+    pub const fn private_write_sequence(&self) -> Option<u32> {
+        self.private_write_sequence
     }
 }
 

--- a/crates/guest-control-client/src/tests/file/write.rs
+++ b/crates/guest-control-client/src/tests/file/write.rs
@@ -1209,6 +1209,15 @@ async fn write_private_file_missing_terminal_response_uses_shared_deadline_and_f
         RequestTimeoutStage::AwaitingTerminalResponse,
         guest_contracts::file_write::WRITE_FILE_REQUEST_DEADLINE,
     );
+    assert_eq!(
+        error
+            .get_ref()
+            .unwrap()
+            .downcast_ref::<RequestTimeoutError>()
+            .unwrap()
+            .private_write_sequence(),
+        Some(write.seq())
+    );
     assert_eq!(pending_request_count(&host), 0);
     assert_eq!(
         normal_operation_readiness(&host),

--- a/crates/guest-control-proto/src/lib.rs
+++ b/crates/guest-control-proto/src/lib.rs
@@ -20,8 +20,8 @@
 //!
 //! ## Message Types
 //!
-//! Non-error message types currently occupy the contiguous range `0x00..=0x1F`
-//! in allocation order; `0x20` is the next available non-error assignment.
+//! Non-error message types currently occupy the contiguous range `0x00..=0x21`
+//! in allocation order; `0x22` is the next available non-error assignment.
 //! Existing values are stable wire assignments: do not renumber or reuse them.
 //! Allocate new non-error messages at the next unused value below `0xFF`, even
 //! when related operations are not adjacent. `0xFF` is
@@ -62,12 +62,14 @@
 //! | 0x1D | H→G       | write_private_files | same payload as `write_files`; result is `write_files_result` with the request sequence |
 //! | 0x1E | H→G       | workspace_drive_mount | (empty) |
 //! | 0x1F | G→H       | workspace_drive_mount_result | same payload as `exec_result`, with both streams captured and bounded to 64 KiB each |
+//! | 0x20 | H→G       | file_write_status | (empty); read-only, available while quiescing |
+//! | 0x21 | G→H       | file_write_status_result | `[4B latest_write_seq][1B stage]`; see [`FileWriteStatus`] |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Request-scoped operation messages must use non-zero sequence numbers. This
 //! covers `write_file`, `write_files`, `write_private_files`, `exec_start`, `exec_cancel`,
 //! `exec_control`, `guest_dns_readiness`, `guest_storage_manifest`, and
-//! `guest_state_restore`, and `workspace_drive_mount`; operation replies reuse
+//! `guest_state_restore`, `workspace_drive_mount`, and `file_write_status`; replies reuse
 //! the original non-zero request sequence. `exec_output.output_seq` is per exec
 //! operation and starts at 0, incrementing by 1 for each output frame across
 //! stdout and stderr.
@@ -225,6 +227,7 @@ pub use payloads::exec_operation::{
     encode_exec_start, encode_exec_start_with_expected_exit_codes, encode_exec_started,
     validate_exec_control, validate_exec_process_contract,
 };
+pub use payloads::file_write_status::{FileWriteStage, FileWriteStatus};
 pub use payloads::guest_dns_readiness::{
     DecodedGuestDnsReadinessRequest, DecodedGuestDnsReadinessResult,
     GUEST_DNS_READINESS_MAX_ANSWER_BYTES, GUEST_DNS_READINESS_MAX_DIAGNOSTIC_BYTES,
@@ -268,12 +271,12 @@ pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,
     MAX_MESSAGE_SIZE, MIN_BODY_SIZE, MSG_ERROR, MSG_EXEC_AGENT_READY, MSG_EXEC_CANCEL,
     MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START,
-    MSG_EXEC_STARTED, MSG_GUEST_DNS_READINESS, MSG_GUEST_DNS_READINESS_RESULT,
-    MSG_GUEST_STATE_RESTORE, MSG_GUEST_STATE_RESTORE_RESULT, MSG_GUEST_STORAGE_MANIFEST,
-    MSG_GUEST_STORAGE_MANIFEST_RESULT, MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT,
-    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
-    MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WORKSPACE_DRIVE_MOUNT,
-    MSG_WORKSPACE_DRIVE_MOUNT_RESULT, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES,
-    MSG_WRITE_FILES_RESULT, MSG_WRITE_PRIVATE_FILES, VSOCK_PORT, WRITE_FILE_FLAG_APPEND,
-    WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
+    MSG_EXEC_STARTED, MSG_FILE_WRITE_STATUS, MSG_FILE_WRITE_STATUS_RESULT, MSG_GUEST_DNS_READINESS,
+    MSG_GUEST_DNS_READINESS_RESULT, MSG_GUEST_STATE_RESTORE, MSG_GUEST_STATE_RESTORE_RESULT,
+    MSG_GUEST_STORAGE_MANIFEST, MSG_GUEST_STORAGE_MANIFEST_RESULT, MSG_MEMORY_SNAPSHOT,
+    MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING,
+    MSG_PONG, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN,
+    MSG_SHUTDOWN_ACK, MSG_WORKSPACE_DRIVE_MOUNT, MSG_WORKSPACE_DRIVE_MOUNT_RESULT, MSG_WRITE_FILE,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, MSG_WRITE_PRIVATE_FILES,
+    VSOCK_PORT, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
 };

--- a/crates/guest-control-proto/src/payloads/file_write_status.rs
+++ b/crates/guest-control-proto/src/payloads/file_write_status.rs
@@ -1,0 +1,143 @@
+use crate::ProtocolError;
+
+/// Last observed guest file-write lifecycle boundary, not terminal proof.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FileWriteStage {
+    /// No file write has been admitted on this connection.
+    Idle = 0,
+    /// The dispatcher admitted a request to the file-write worker.
+    Queued = 1,
+    /// The worker is starting the fixed file-write helper.
+    StartingHelper = 2,
+    /// The helper exists; pipe setup, child wait, or reaping is pending.
+    WaitingForHelper = 3,
+    /// The helper wait returned; the stdin writer is being joined.
+    JoiningStdin = 4,
+    /// The stderr drain is being completed and joined.
+    DrainingStderr = 5,
+    /// A terminal response is ready and waiting for the shared writer.
+    WaitingForWriter = 6,
+    /// The terminal response owns the shared writer.
+    WritingResponse = 7,
+    /// The complete terminal frame was written, not necessarily received.
+    ResponseSent = 8,
+}
+
+impl FileWriteStage {
+    /// Fixed, payload-free label for structured diagnostics.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Queued => "queued",
+            Self::StartingHelper => "starting_helper",
+            Self::WaitingForHelper => "waiting_for_helper",
+            Self::JoiningStdin => "joining_stdin",
+            Self::DrainingStderr => "draining_stderr",
+            Self::WaitingForWriter => "waiting_for_writer",
+            Self::WritingResponse => "writing_response",
+            Self::ResponseSent => "response_sent",
+        }
+    }
+}
+
+/// Constant-space snapshot of the latest admitted write on one connection.
+///
+/// The sequence is the original write request's sequence, not the diagnostic
+/// query's sequence. A different sequence cannot establish whether an older
+/// request was received. This snapshot never proves a write's success.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FileWriteStatus {
+    /// Latest write sequence, or zero before any write is admitted.
+    pub sequence: u32,
+    /// Last recorded lifecycle boundary for that sequence.
+    pub stage: FileWriteStage,
+}
+
+impl FileWriteStatus {
+    /// Encode `[4B sequence][1B stage]` without any request content.
+    pub fn encode_payload(self) -> [u8; 5] {
+        let mut payload = [0; 5];
+        payload[..4].copy_from_slice(&self.sequence.to_be_bytes());
+        payload[4] = self.stage as u8;
+        payload
+    }
+
+    /// Decode the exact fixed-width schema and its idle/sequence invariant.
+    pub fn decode_payload(payload: &[u8]) -> Result<Self, ProtocolError> {
+        let [a, b, c, d, stage] = payload else {
+            return Err(ProtocolError::InvalidPayload(
+                "invalid file-write status length",
+            ));
+        };
+        let stage = match stage {
+            0 => FileWriteStage::Idle,
+            1 => FileWriteStage::Queued,
+            2 => FileWriteStage::StartingHelper,
+            3 => FileWriteStage::WaitingForHelper,
+            4 => FileWriteStage::JoiningStdin,
+            5 => FileWriteStage::DrainingStderr,
+            6 => FileWriteStage::WaitingForWriter,
+            7 => FileWriteStage::WritingResponse,
+            8 => FileWriteStage::ResponseSent,
+            _ => {
+                return Err(ProtocolError::InvalidPayload(
+                    "invalid file-write status stage",
+                ));
+            }
+        };
+        let sequence = u32::from_be_bytes([*a, *b, *c, *d]);
+        if (sequence == 0) != (stage == FileWriteStage::Idle) {
+            return Err(ProtocolError::InvalidPayload(
+                "invalid file-write status sequence",
+            ));
+        }
+        Ok(Self { sequence, stage })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_schema_roundtrips_all_stages_and_rejects_malformed_snapshots() {
+        for stage in [
+            FileWriteStage::Idle,
+            FileWriteStage::Queued,
+            FileWriteStage::StartingHelper,
+            FileWriteStage::WaitingForHelper,
+            FileWriteStage::JoiningStdin,
+            FileWriteStage::DrainingStderr,
+            FileWriteStage::WaitingForWriter,
+            FileWriteStage::WritingResponse,
+            FileWriteStage::ResponseSent,
+        ] {
+            let status = FileWriteStatus {
+                sequence: if stage == FileWriteStage::Idle {
+                    0
+                } else {
+                    0x12345678
+                },
+                stage,
+            };
+            assert_eq!(
+                FileWriteStatus::decode_payload(&status.encode_payload()).unwrap(),
+                status
+            );
+        }
+        for payload in [
+            b"".as_slice(),
+            &[0, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0],
+            &[0, 0, 0, 1, 255],
+            &[0, 0, 0, 1, 0],
+            &[0, 0, 0, 0, 3],
+        ] {
+            assert!(
+                FileWriteStatus::decode_payload(payload).is_err(),
+                "{payload:?}"
+            );
+        }
+    }
+}

--- a/crates/guest-control-proto/src/payloads/mod.rs
+++ b/crates/guest-control-proto/src/payloads/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod empty;
 pub(crate) mod error;
 pub(crate) mod exec_operation;
+pub(crate) mod file_write_status;
 pub(crate) mod guest_dns_readiness;
 pub(crate) mod guest_state_restore;
 pub(crate) mod guest_storage_manifest;

--- a/crates/guest-control-proto/src/wire.rs
+++ b/crates/guest-control-proto/src/wire.rs
@@ -113,6 +113,12 @@ pub const MSG_WORKSPACE_DRIVE_MOUNT: u8 = 0x1E;
 /// Guest-to-host result of mounting the fixed workspace drive.
 pub const MSG_WORKSPACE_DRIVE_MOUNT_RESULT: u8 = 0x1F;
 
+/// Host-to-guest read-only file-write status query with an empty payload.
+pub const MSG_FILE_WRITE_STATUS: u8 = 0x20;
+
+/// Guest-to-host snapshot of the latest admitted file-write lifecycle stage.
+pub const MSG_FILE_WRITE_STATUS_RESULT: u8 = 0x21;
+
 /// Guest-to-host protocol error response.
 pub const MSG_ERROR: u8 = 0xFF;
 
@@ -203,6 +209,12 @@ mod tests {
                 0x1F,
             ),
             ("MSG_ERROR", MSG_ERROR, 0xFF),
+            ("MSG_FILE_WRITE_STATUS", MSG_FILE_WRITE_STATUS, 0x20),
+            (
+                "MSG_FILE_WRITE_STATUS_RESULT",
+                MSG_FILE_WRITE_STATUS_RESULT,
+                0x21,
+            ),
         ];
 
         for (name, actual, expected) in message_types {

--- a/crates/guest-control-server/src/connection.rs
+++ b/crates/guest-control-server/src/connection.rs
@@ -8,10 +8,11 @@ use std::time::{Duration, Instant};
 use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use guest_control_proto::{
     self, BorrowedRawMessage, DecodeWithError, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_START,
-    MSG_GUEST_DNS_READINESS, MSG_GUEST_STATE_RESTORE, MSG_GUEST_STORAGE_MANIFEST,
-    MSG_MEMORY_SNAPSHOT, MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED,
-    MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS,
-    MSG_WORKSPACE_DRIVE_MOUNT, MSG_WRITE_FILE, MSG_WRITE_FILES, MSG_WRITE_PRIVATE_FILES,
+    MSG_FILE_WRITE_STATUS, MSG_FILE_WRITE_STATUS_RESULT, MSG_GUEST_DNS_READINESS,
+    MSG_GUEST_STATE_RESTORE, MSG_GUEST_STORAGE_MANIFEST, MSG_MEMORY_SNAPSHOT,
+    MSG_MEMORY_SNAPSHOT_RESULT, MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED,
+    MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS, MSG_WORKSPACE_DRIVE_MOUNT,
+    MSG_WRITE_FILE, MSG_WRITE_FILES, MSG_WRITE_PRIVATE_FILES,
 };
 
 use crate::agent_command::GuestAgentProgram;
@@ -411,10 +412,31 @@ impl ConnectionDispatcher {
             MSG_QUIESCE_OPERATIONS => self.handle_quiesce_operations(msg)?,
             MSG_RESUME_OPERATIONS => self.handle_resume_operations(msg)?,
             MSG_MEMORY_SNAPSHOT => self.handle_memory_snapshot(msg)?,
+            MSG_FILE_WRITE_STATUS => self.handle_file_write_status(msg)?,
             _ => return self.handle_basic_message(msg),
         }
 
         Ok(DispatchOutcome::Continue)
+    }
+
+    fn handle_file_write_status(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
+        if !require_non_zero_sequence(msg.seq, "file-write status", &self.writer)?
+            || !validate_empty_control_payload(
+                msg.seq,
+                "file-write status payload must be empty",
+                msg.payload,
+                &self.writer,
+            )?
+        {
+            return Ok(());
+        }
+        // This read-only control query neither acquires normal-operation
+        // ownership nor changes the quiesce fence. Release the snapshot lock
+        // before acquiring the response writer.
+        let payload = self.file_write_worker.status().encode_payload();
+        let response = guest_control_proto::encode(MSG_FILE_WRITE_STATUS_RESULT, msg.seq, &payload)
+            .map_err(to_io_error)?;
+        self.writer.write_frame(&response)
     }
 
     fn handle_exec_start(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {

--- a/crates/guest-control-server/src/file_write_progress.rs
+++ b/crates/guest-control-server/src/file_write_progress.rs
@@ -1,0 +1,48 @@
+use std::sync::{Arc, Mutex};
+
+use guest_control_proto::{FileWriteStage, FileWriteStatus};
+
+#[derive(Clone)]
+pub(crate) struct FileWriteProgress(Arc<Mutex<FileWriteStatus>>);
+
+pub(crate) struct FileWriteRequestProgress {
+    latest: FileWriteProgress,
+    sequence: u32,
+}
+
+impl Default for FileWriteProgress {
+    fn default() -> Self {
+        Self(Arc::new(Mutex::new(FileWriteStatus {
+            sequence: 0,
+            stage: FileWriteStage::Idle,
+        })))
+    }
+}
+
+impl FileWriteProgress {
+    pub(crate) fn start(&self, sequence: u32) -> FileWriteRequestProgress {
+        *self.0.lock().unwrap_or_else(|e| e.into_inner()) = FileWriteStatus {
+            sequence,
+            stage: FileWriteStage::Queued,
+        };
+        FileWriteRequestProgress {
+            latest: self.clone(),
+            sequence,
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> FileWriteStatus {
+        *self.0.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl FileWriteRequestProgress {
+    pub(crate) fn mark(&self, stage: FileWriteStage) {
+        let mut latest = self.latest.0.lock().unwrap_or_else(|e| e.into_inner());
+        // Admission is released before the terminal frame is sent. A newer
+        // request may already own the snapshot when the older send returns.
+        if latest.sequence == self.sequence {
+            latest.stage = stage;
+        }
+    }
+}

--- a/crates/guest-control-server/src/file_write_worker.rs
+++ b/crates/guest-control-server/src/file_write_worker.rs
@@ -4,6 +4,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, SyncSender, TrySendError};
 use std::thread::{self, JoinHandle};
 
+use guest_control_proto::{FileWriteStage, FileWriteStatus};
+
+use crate::file_write_progress::{FileWriteProgress, FileWriteRequestProgress};
+
 use crate::handlers::{
     decode_write_file_message, decode_write_files_message, handle_decoded_write_file_message,
     handle_decoded_write_files_message,
@@ -55,6 +59,7 @@ struct FileWriteRequest {
     payload: Vec<u8>,
     operation_guard: OperationGuard,
     admission: SingleActivePermit,
+    progress: FileWriteRequestProgress,
 }
 
 pub(crate) struct FileWriteWorker {
@@ -62,6 +67,7 @@ pub(crate) struct FileWriteWorker {
     handle: Option<JoinHandle<()>>,
     admission: SingleActiveAdmission,
     connection_cancel: Arc<AtomicBool>,
+    progress: FileWriteProgress,
 }
 
 impl FileWriteWorker {
@@ -94,11 +100,16 @@ impl FileWriteWorker {
             handle: Some(handle),
             admission: SingleActiveAdmission::new(),
             connection_cancel,
+            progress: FileWriteProgress::default(),
         })
     }
 
     pub(crate) fn try_admit(&self) -> Option<SingleActivePermit> {
         self.admission.try_acquire()
+    }
+
+    pub(crate) fn status(&self) -> FileWriteStatus {
+        self.progress.snapshot()
     }
 
     pub(crate) fn submit(
@@ -115,6 +126,7 @@ impl FileWriteWorker {
             payload: payload.to_vec(),
             operation_guard,
             admission,
+            progress: self.progress.start(seq),
         };
         let Some(sender) = &self.sender else {
             return Err(FileWriteSubmitError::Disconnected);
@@ -152,34 +164,49 @@ fn handle_request(
         payload,
         operation_guard,
         admission,
+        progress,
     } = request;
 
     let response = match kind {
         FileWriteKind::File => decode_write_file_message(&payload)
             .map_err(protocol_error)
-            .and_then(|decoded| handle_decoded_write_file_message(seq, decoded, connection_cancel)),
+            .and_then(|decoded| {
+                handle_decoded_write_file_message(seq, decoded, connection_cancel, &progress)
+            }),
         FileWriteKind::Files => decode_write_files_message(&payload)
             .map_err(protocol_error)
             .and_then(|decoded| {
-                handle_decoded_write_files_message(seq, decoded, false, connection_cancel)
+                handle_decoded_write_files_message(
+                    seq,
+                    decoded,
+                    false,
+                    connection_cancel,
+                    &progress,
+                )
             }),
         FileWriteKind::PrivateFiles => decode_write_files_message(&payload)
             .map_err(protocol_error)
             .and_then(|decoded| {
-                handle_decoded_write_files_message(seq, decoded, true, connection_cancel)
+                handle_decoded_write_files_message(seq, decoded, true, connection_cancel, &progress)
             }),
     };
     // Admission may be released at the writer boundary, but do not retain the
     // completed request's large payload while the result frame is being sent.
     drop(payload);
+    progress.mark(FileWriteStage::WaitingForWriter);
 
     match response {
         Ok(response) => writer
             .write_frame_after_lock_unless_cancelled(&response, connection_cancel, || {
+                progress.mark(FileWriteStage::WritingResponse);
                 operation_guard.release();
                 drop(admission);
             })
-            .map(|_| ()),
+            .map(|sent| {
+                if sent {
+                    progress.mark(FileWriteStage::ResponseSent);
+                }
+            }),
         Err(error) => {
             writer.shutdown_after_lock(|| {
                 operation_guard.release();

--- a/crates/guest-control-server/src/handlers.rs
+++ b/crates/guest-control-server/src/handlers.rs
@@ -9,12 +9,13 @@ use std::sync::atomic::AtomicBool;
 use guest_contracts::exec_terminal::EXEC_OUTPUT_DRAIN_DEADLINE;
 use guest_contracts::file_write::WRITE_FILE_HELPER_TIMEOUT_MS;
 use guest_control_proto::{
-    self, BorrowedRawMessage, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE_RESULT,
-    MSG_WRITE_FILES_RESULT,
+    self, BorrowedRawMessage, FileWriteStage, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES_RESULT,
 };
 
 use crate::drain::{DrainCancellation, drain_into_vec_cancellable};
 use crate::error::to_io_error;
+use crate::file_write_progress::FileWriteRequestProgress;
 use crate::log::log;
 use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
 use crate::shutdown::handle_shutdown;
@@ -56,7 +57,9 @@ fn handle_write_file(
     append: bool,
     private: bool,
     connection_cancel: &AtomicBool,
+    progress: &FileWriteRequestProgress,
 ) -> (bool, String) {
+    progress.mark(FileWriteStage::StartingHelper);
     log(
         "INFO",
         &format!(
@@ -74,7 +77,13 @@ fn handle_write_file(
         Err(e) => return (false, format!("Failed to spawn write command: {e}")),
     };
 
-    wait_write_file_child(child, content, connection_cancel, SystemThreadSpawner)
+    wait_write_file_child(
+        child,
+        content,
+        connection_cancel,
+        progress,
+        SystemThreadSpawner,
+    )
 }
 
 fn handle_write_files(
@@ -83,7 +92,9 @@ fn handle_write_files(
     content_bytes: usize,
     private: bool,
     connection_cancel: &AtomicBool,
+    progress: &FileWriteRequestProgress,
 ) -> (bool, String) {
+    progress.mark(FileWriteStage::StartingHelper);
     let operation = if private {
         "write_private_files"
     } else {
@@ -99,13 +110,20 @@ fn handle_write_files(
         Err(e) => return (false, format!("Failed to spawn batch write command: {e}")),
     };
 
-    wait_write_file_child(child, payload, connection_cancel, SystemThreadSpawner)
+    wait_write_file_child(
+        child,
+        payload,
+        connection_cancel,
+        progress,
+        SystemThreadSpawner,
+    )
 }
 
 fn wait_write_file_child<S>(
     child: Child,
     content: &[u8],
     connection_cancel: &AtomicBool,
+    progress: &FileWriteRequestProgress,
     spawner: S,
 ) -> (bool, String)
 where
@@ -116,6 +134,7 @@ where
         content,
         WRITE_FILE_HELPER_TIMEOUT_MS,
         connection_cancel,
+        progress,
         spawner,
     )
 }
@@ -125,11 +144,13 @@ fn wait_write_file_child_with_timeout<S>(
     content: &[u8],
     timeout_ms: u32,
     connection_cancel: &AtomicBool,
+    progress: &FileWriteRequestProgress,
     spawner: S,
 ) -> (bool, String)
 where
     S: ThreadSpawner,
 {
+    progress.mark(FileWriteStage::WaitingForHelper);
     let cancel = match DrainCancellation::new() {
         Ok(cancel) => Arc::new(cancel),
         Err(error) => {
@@ -213,11 +234,13 @@ where
                 )
             },
         );
+        progress.mark(FileWriteStage::JoiningStdin);
         let stdin_result = match stdin_handle.join() {
             Ok(result) => result,
             Err(panic) => std::panic::resume_unwind(panic),
         };
 
+        progress.mark(FileWriteStage::DrainingStderr);
         let _ = await_drain_deadline(&done_rx, 1, &cancel, EXEC_OUTPUT_DRAIN_DEADLINE);
         let stderr = stderr_handle.join().unwrap_or_default();
 
@@ -351,6 +374,7 @@ pub(crate) fn handle_decoded_write_file_message(
     seq: u32,
     decoded: DecodedWriteFileMessage<'_>,
     connection_cancel: &AtomicBool,
+    progress: &FileWriteRequestProgress,
 ) -> io::Result<Vec<u8>> {
     let (success, error) = handle_write_file(
         decoded.path,
@@ -359,6 +383,7 @@ pub(crate) fn handle_decoded_write_file_message(
         decoded.append,
         decoded.private,
         connection_cancel,
+        progress,
     );
     let payload = guest_control_proto::encode_write_file_result(success, &error);
     guest_control_proto::encode(MSG_WRITE_FILE_RESULT, seq, &payload).map_err(to_io_error)
@@ -369,6 +394,7 @@ pub(crate) fn handle_decoded_write_files_message(
     decoded: DecodedWriteFilesMessage<'_>,
     private: bool,
     connection_cancel: &AtomicBool,
+    progress: &FileWriteRequestProgress,
 ) -> io::Result<Vec<u8>> {
     let (success, error) = handle_write_files(
         decoded.payload,
@@ -376,6 +402,7 @@ pub(crate) fn handle_decoded_write_files_message(
         decoded.content_bytes,
         private,
         connection_cancel,
+        progress,
     );
     let payload = guest_control_proto::encode_write_files_result(success, &error);
     guest_control_proto::encode(MSG_WRITE_FILES_RESULT, seq, &payload).map_err(to_io_error)
@@ -476,6 +503,7 @@ mod tests {
             child,
             b"",
             &connection_cancel,
+            &crate::file_write_progress::FileWriteProgress::default().start(1),
             FailingThreadSpawner::fail_once(THREAD_WRITE_STDERR),
         );
 
@@ -518,6 +546,7 @@ mod tests {
             &content,
             10,
             &connection_cancel,
+            &crate::file_write_progress::FileWriteProgress::default().start(1),
             SystemThreadSpawner,
         );
 
@@ -578,6 +607,7 @@ mod tests {
             &content,
             1_000,
             &connection_cancel,
+            &crate::file_write_progress::FileWriteProgress::default().start(1),
             SystemThreadSpawner,
         );
         let _ = std::fs::remove_file(&fifo_path);

--- a/crates/guest-control-server/src/lib.rs
+++ b/crates/guest-control-server/src/lib.rs
@@ -11,6 +11,7 @@ mod drain;
 mod error;
 mod exec_control;
 mod exec_operation;
+mod file_write_progress;
 mod file_write_worker;
 mod guest_dns_readiness;
 mod guest_state_restore;

--- a/crates/guest-control-tests/tests/integration/file_write_status.rs
+++ b/crates/guest-control-tests/tests/integration/file_write_status.rs
@@ -1,0 +1,90 @@
+use std::time::Duration;
+
+use guest_control_proto::{FileWriteStage, FileWriteStatus};
+
+use crate::support::{
+    Harness, blocking_write_path, release_blocking_write, wait_for_blocking_write,
+};
+
+const QUERY_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[tokio::test]
+async fn private_write_status_survives_quiesce_and_tracks_the_next_write() {
+    let h = Harness::new().await;
+    assert_eq!(
+        h.host().file_write_status(QUERY_TIMEOUT).await.unwrap(),
+        FileWriteStatus {
+            sequence: 0,
+            stage: FileWriteStage::Idle,
+        }
+    );
+    let mut previous_sequence = 0;
+    for content in [b"first".as_slice(), b"second".as_slice()] {
+        let path = h.dir.join("private/context.json");
+        h.host()
+            .write_private_file(path.to_str().unwrap(), content)
+            .await
+            .unwrap();
+        h.host().quiesce_operations(QUERY_TIMEOUT).await.unwrap();
+        let status = tokio::time::timeout(QUERY_TIMEOUT, async {
+            loop {
+                let status = h.host().file_write_status(QUERY_TIMEOUT).await.unwrap();
+                if status.stage == FileWriteStage::ResponseSent {
+                    break status;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(status.sequence > previous_sequence);
+        previous_sequence = status.sequence;
+        assert_eq!(std::fs::read(path).unwrap(), content);
+        h.host().resume_operations(QUERY_TIMEOUT).await.unwrap();
+    }
+    h.finish();
+}
+
+#[tokio::test]
+async fn private_write_status_does_not_reopen_an_uncertain_or_quiescing_connection() {
+    let h = Harness::new().await;
+    let path = blocking_write_path(&h.dir, "private-diagnostic");
+    {
+        let write = h
+            .host()
+            .write_private_file(path.to_str().unwrap(), b"synthetic private content");
+        tokio::pin!(write);
+        tokio::select! {
+            result = wait_for_blocking_write(&path, QUERY_TIMEOUT) => result.unwrap(),
+            result = &mut write => panic!("write ended before helper blocked: {result:?}"),
+        }
+        h.host()
+            .quiesce_operations(QUERY_TIMEOUT)
+            .await
+            .unwrap_err();
+        let status = h.host().file_write_status(QUERY_TIMEOUT).await.unwrap();
+        assert_ne!(status.sequence, 0);
+        assert_eq!(status.stage, FileWriteStage::WaitingForHelper);
+        assert_eq!(status.encode_payload().len(), 5);
+        // Drop the unresolved write. Its operation token must remain fail-closed.
+    }
+    assert_eq!(
+        h.host()
+            .file_write_status(QUERY_TIMEOUT)
+            .await
+            .unwrap()
+            .stage,
+        FileWriteStage::WaitingForHelper
+    );
+    assert!(h.host().try_fence_normal_operations().is_err());
+    let later = h.dir.join("must-not-write");
+    assert!(
+        h.host()
+            .write_private_file(later.to_str().unwrap(), b"later")
+            .await
+            .is_err()
+    );
+    assert!(!later.exists());
+    release_blocking_write(&path);
+    h.finish_ignore_guest();
+}

--- a/crates/guest-control-tests/tests/integration/main.rs
+++ b/crates/guest-control-tests/tests/integration/main.rs
@@ -7,6 +7,7 @@
 )]
 
 mod exec;
+mod file_write_status;
 mod shutdown;
 mod support;
 mod write_file;

--- a/crates/sandbox-firecracker/src/sandbox.rs
+++ b/crates/sandbox-firecracker/src/sandbox.rs
@@ -893,7 +893,7 @@ impl FirecrackerSandbox {
         validate()?;
 
         let outcome = tokio::select! {
-            result = call(vsock) => {
+            result = call(Arc::clone(&vsock)) => {
                 GuestCallOutcome::Returned(result)
             }
             () = wait_for_backend_crash(self.state_tx.subscribe()) => {
@@ -905,9 +905,45 @@ impl FirecrackerSandbox {
             GuestCallOutcome::Returned(Ok(value)) => Ok(value),
             GuestCallOutcome::Returned(Err(error)) => {
                 let backend_crashed = self.has_backend_crashed();
+                self.log_private_write_timeout_diagnostic(&vsock, &error)
+                    .await;
                 Err(Self::operation_error(operation, error, backend_crashed))
             }
             GuestCallOutcome::BackendCrashed => Err(Self::backend_crashed_error(operation)),
+        }
+    }
+
+    async fn log_private_write_timeout_diagnostic(
+        &self,
+        guest: &GuestControlClient,
+        error: &io::Error,
+    ) {
+        let Some(sequence) = error
+            .get_ref()
+            .and_then(|source| source.downcast_ref::<guest_control_client::RequestTimeoutError>())
+            .and_then(guest_control_client::RequestTimeoutError::private_write_sequence)
+        else {
+            return;
+        };
+        // The write has already expired and normal operations remain fenced.
+        // This independent, read-only control probe must never replace the
+        // initiating error or extend the write's original 60-second budget.
+        match guest.file_write_status(Duration::from_secs(1)).await {
+            Ok(status) => warn!(
+                id = %self.id,
+                write_sequence = sequence,
+                observed_write_sequence = status.sequence,
+                guest_write_stage = status.stage.label(),
+                diagnostic_outcome = if status.sequence == sequence { "matched" } else { "different_request" },
+                "private file-write timeout guest diagnostic"
+            ),
+            Err(diagnostic_error) => warn!(
+                id = %self.id,
+                write_sequence = sequence,
+                diagnostic_outcome = "unavailable",
+                diagnostic_error_kind = ?diagnostic_error.kind(),
+                "private file-write timeout guest diagnostic"
+            ),
         }
     }
 

--- a/crates/sandbox-firecracker/src/sandbox/tests.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests.rs
@@ -16,6 +16,7 @@ use tracing_subscriber::prelude::*;
 use tracing_test_support::{CapturedEvent, CapturedEvents};
 
 mod guest_rpc;
+mod private_write_diagnostics;
 mod process_write;
 
 struct TestNormalOperationFence;

--- a/crates/sandbox-firecracker/src/sandbox/tests/private_write_diagnostics.rs
+++ b/crates/sandbox-firecracker/src/sandbox/tests/private_write_diagnostics.rs
@@ -1,0 +1,204 @@
+use super::*;
+use guest_control_proto::{
+    FileWriteStage, FileWriteStatus, MSG_FILE_WRITE_STATUS, MSG_FILE_WRITE_STATUS_RESULT,
+};
+
+#[derive(Clone, Copy, Debug)]
+enum DiagnosticReply {
+    Matching,
+    MatchingPrivateBatch,
+    DifferentRequest,
+    InvalidStage,
+    NoReply,
+    BackendCrash,
+}
+
+#[tokio::test]
+async fn private_write_timeout_collects_one_bounded_diagnostic_without_replacing_the_error() {
+    for reply in [
+        DiagnosticReply::Matching,
+        DiagnosticReply::MatchingPrivateBatch,
+        DiagnosticReply::DifferentRequest,
+        DiagnosticReply::InvalidStage,
+        DiagnosticReply::NoReply,
+        DiagnosticReply::BackendCrash,
+    ] {
+        let sandbox = test_sandbox_with_state(SandboxState::Running);
+        let mut guest = attach_mock_shutdown_guest(&sandbox).await;
+        let started = Instant::now();
+        let ((result, write_sequence), events) = tokio::time::timeout(
+            Duration::from_secs(65),
+            capture_async_log_events(async {
+                tokio::join!(
+                    async {
+                        if matches!(reply, DiagnosticReply::MatchingPrivateBatch) {
+                            sandbox
+                                .write_private_files(&[
+                                    WriteFileEntry {
+                                        path: "/tmp/synthetic-context.json",
+                                        content: b"synthetic content",
+                                    },
+                                    WriteFileEntry {
+                                        path: "/tmp/synthetic-accounts.json",
+                                        content: b"synthetic accounts",
+                                    },
+                                ])
+                                .await
+                        } else {
+                            sandbox
+                                .write_private_file(
+                                    "/tmp/synthetic-context.json",
+                                    b"synthetic content",
+                                )
+                                .await
+                        }
+                    },
+                    async {
+                        let write = read_vsock_message(&mut guest).await;
+                        assert_eq!(
+                            write.msg_type,
+                            if matches!(reply, DiagnosticReply::MatchingPrivateBatch) {
+                                guest_control_proto::MSG_WRITE_PRIVATE_FILES
+                            } else {
+                                guest_control_proto::MSG_WRITE_FILE
+                            }
+                        );
+                        // Advance only after socket receipt; keep real time during
+                        // I/O so automatic clock advancement cannot race the peer.
+                        tokio::time::pause();
+                        // Cross the timer wheel's millisecond rounding boundary.
+                        tokio::time::advance(Duration::from_millis(60_001)).await;
+                        tokio::time::resume();
+                        let query = read_vsock_message(&mut guest).await;
+                        assert_eq!(query.msg_type, MSG_FILE_WRITE_STATUS);
+                        assert!(query.payload.is_empty());
+                        let payload = match reply {
+                            DiagnosticReply::Matching | DiagnosticReply::MatchingPrivateBatch => {
+                                Some(
+                                    FileWriteStatus {
+                                        sequence: write.seq,
+                                        stage: FileWriteStage::WaitingForHelper,
+                                    }
+                                    .encode_payload(),
+                                )
+                            }
+                            DiagnosticReply::DifferentRequest => Some(
+                                FileWriteStatus {
+                                    sequence: write.seq + 1,
+                                    stage: FileWriteStage::ResponseSent,
+                                }
+                                .encode_payload(),
+                            ),
+                            DiagnosticReply::InvalidStage => Some([0, 0, 0, 1, 255]),
+                            DiagnosticReply::NoReply => {
+                                tokio::time::pause();
+                                tokio::time::advance(Duration::from_millis(1_001)).await;
+                                tokio::time::resume();
+                                None
+                            }
+                            DiagnosticReply::BackendCrash => {
+                                sandbox.publish_state(SandboxState::Crashed);
+                                guest.shutdown().await.unwrap();
+                                None
+                            }
+                        };
+                        if let Some(payload) = payload {
+                            guest
+                                .write_all(
+                                    &guest_control_proto::encode(
+                                        MSG_FILE_WRITE_STATUS_RESULT,
+                                        query.seq,
+                                        &payload,
+                                    )
+                                    .unwrap(),
+                                )
+                                .await
+                                .unwrap();
+                        }
+                        write.seq
+                    }
+                )
+            }),
+        )
+        .await
+        .expect("write and diagnostic must finish within their budgets");
+        assert!(
+            matches!(
+                result,
+                Err(SandboxError::OperationTimeout {
+                    operation: SandboxOperation::WriteFile,
+                    stage: sandbox::SandboxOperationTimeoutStage::AwaitingTerminalResponse,
+                    timeout_ms: 60_000
+                })
+            ),
+            "{reply:?}: {result:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(62),
+            "{reply:?}: {:?}",
+            started.elapsed()
+        );
+        let diagnostics: Vec<_> = events
+            .iter()
+            .filter(|event| {
+                event.fields.get("message").map(String::as_str)
+                    == Some("private file-write timeout guest diagnostic")
+            })
+            .collect();
+        assert_eq!(diagnostics.len(), 1, "{reply:?}: {events:?}");
+        let event = diagnostics[0];
+        assert_eq!(event.level, Level::WARN);
+        assert_eq!(event.fields["write_sequence"], write_sequence.to_string());
+        let outcome = match reply {
+            DiagnosticReply::Matching | DiagnosticReply::MatchingPrivateBatch => "matched",
+            DiagnosticReply::DifferentRequest => "different_request",
+            _ => "unavailable",
+        };
+        assert_eq!(event.fields["diagnostic_outcome"], outcome);
+        if matches!(
+            reply,
+            DiagnosticReply::Matching
+                | DiagnosticReply::MatchingPrivateBatch
+                | DiagnosticReply::DifferentRequest
+        ) {
+            assert_eq!(event.fields.len(), 6);
+            assert_eq!(
+                event.fields["guest_write_stage"],
+                if matches!(
+                    reply,
+                    DiagnosticReply::Matching | DiagnosticReply::MatchingPrivateBatch
+                ) {
+                    "waiting_for_helper"
+                } else {
+                    "response_sent"
+                }
+            );
+        } else {
+            assert_eq!(event.fields.len(), 5);
+            assert_eq!(
+                event.fields["diagnostic_error_kind"],
+                match reply {
+                    DiagnosticReply::InvalidStage => "InvalidData",
+                    DiagnosticReply::NoReply => "TimedOut",
+                    _ => "ConnectionReset",
+                }
+            );
+        }
+        assert!(
+            sandbox
+                .guest
+                .lock()
+                .await
+                .as_ref()
+                .unwrap()
+                .try_fence_normal_operations()
+                .is_err()
+        );
+        assert!(
+            sandbox
+                .write_private_file("/tmp/later", b"later")
+                .await
+                .is_err()
+        );
+    }
+}

--- a/docs/guest-file-write-diagnostics.md
+++ b/docs/guest-file-write-diagnostics.md
@@ -1,0 +1,59 @@
+# Guest private-write timeout diagnostics
+
+When a private-file request has fully left the host but its terminal response
+does not arrive within the existing 60-second write budget, the Firecracker
+backend makes one read-only Guest control query. It logs
+`private file-write timeout guest diagnostic` and returns the original typed
+`WriteFile / AwaitingTerminalResponse / 60000ms` error.
+
+The query has a separate one-second total budget, including sending the frame
+and waiting for its reply. Failed-run reporting can therefore take up to one
+additional second. It never retries the write, completes its operation ownership,
+or makes an uncertain sandbox reusable. Successful writes send no diagnostic
+queries; Guest tracking only updates a constant-space in-memory snapshot.
+
+## Fields and interpretation
+
+- `id`: sandbox ID, used to join the existing Runner/run lifecycle logs.
+- `write_sequence`: the timed-out private write's connection-local sequence.
+- `diagnostic_outcome`: `matched`, `different_request`, or `unavailable`.
+- On a reply, `observed_write_sequence` and `guest_write_stage` describe the latest
+  write admitted by this Guest connection, including completed writes.
+- On query failure, `diagnostic_error_kind` contains only the fixed I/O error kind.
+
+The snapshot contains no file paths, file contents, credentials, or helper error
+output. Sequence numbers are meaningful only within the same Guest connection.
+
+| Stage                | Last observed boundary                                             |
+| -------------------- | ------------------------------------------------------------------ |
+| `idle`               | No write has been admitted on this connection.                     |
+| `queued`             | The dispatcher admitted a request to the file-write worker.        |
+| `starting_helper`    | The worker is starting the fixed helper process.                   |
+| `waiting_for_helper` | The helper exists; pipe setup, child wait, or reaping is pending.  |
+| `joining_stdin`      | The helper wait returned; the stdin writer is being joined.        |
+| `draining_stderr`    | The stderr drain is being completed and joined.                    |
+| `waiting_for_writer` | A terminal response is ready and waiting for the shared writer.    |
+| `writing_response`   | The terminal response owns the shared writer.                      |
+| `response_sent`      | The complete terminal frame was written, not necessarily received. |
+
+These are snapshots, not a full timeline or terminal proof. In particular,
+`response_sent` does not establish that the write succeeded: both success and
+failure terminal frames reach that stage. `different_request` does not establish
+that the timed-out request was never received. `unavailable` cannot distinguish a
+stalled dispatcher, shared writer, transport, or whole Guest.
+
+The read-only query is allowed while normal operations are quiescing or uncertain.
+It uses the same serialized Guest response writer, so a writer stall can also
+prevent diagnostic collection. Reading the snapshot releases its memory lock
+before taking that writer lock.
+
+## Deployment and investigation
+
+Runner and its bundled Guest binaries are one deployment artifact; see
+[deployment compatibility](deployment-compatibility.md). This addition does not
+change an API, queue, or persisted schema. Deploy or roll back the whole artifact.
+
+This instrumentation supports the investigation in
+[#32455](https://github.com/vm0-ai/vm0/issues/32455). It does not establish or fix the
+cause of the historical missing-response incident. Keep the investigation open
+until new evidence supports a causal conclusion.


### PR DESCRIPTION
## Summary

Relates to #32455. This is diagnostic instrumentation, not a demonstrated fix for the historical production incident; keep the investigation open.

- Retain a constant-space Guest snapshot of the latest admitted file-write sequence and lifecycle stage. Add a fixed-width, read-only control query that remains available while quiescing or after normal work becomes uncertain.
- On a private-write terminal-response timeout only, collect one snapshot with a separate one-second total budget and emit a structured, payload-free warning. Preserve the original typed 60-second write timeout and fail-closed reuse. No write retry or extra diagnostic traffic on successful writes.
- Document stage meaning, correlation, privacy, deployment compatibility, and unavailable/mismatched outcomes. Runner and bundled Guest binaries remain a single deployment artifact.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --profile local --all-targets --all-features` and `cargo doc --profile local --workspace --all-features --no-deps`: passed for the full Rust workspace, including the native pre-commit hooks.
- `cargo test --profile local -p guest-control-proto -p guest-control-client -p guest-control-server -p guest-control-tests -p sandbox-firecracker -p guest-init -- --quiet`: 1,831 passed.
- `cargo test --profile local -p runner -- --quiet`: 3,546 passed. Existing special-environment ignored cases are unchanged and are not counted as executed.
- Cross-compiled all nine bundled Guest binaries for x86_64-musl.
- Prettier check for the operator documentation.

### Real Firecracker/vsock experiment on local-11

Used one isolated, issue-owned sandbox (2 vCPU / 1,024 MiB), synthetic files, current Guest binaries, and a temporary transparent host-side proxy. Existing Runner services were not stopped or redeployed.

1. Private writes and real file content/mode checks passed before and after park/unpark.
2. Dropped exactly one terminal write-result frame from that sandbox.
3. The real Sandbox timeout path collected `write_sequence=9 observed_write_sequence=9 guest_write_stage="response_sent" diagnostic_outcome="matched"`.
4. The original `WriteFile / AwaitingTerminalResponse / 60000ms` error was preserved (60,002 ms measured). Later writes and reuse remained rejected.
5. Sandbox, NBD/COW, network namespace, and temporary image/binary cleanup completed. Both pre-existing Runner services stayed active with their original start times.

## Risks and limits

Failed-run reporting can take up to one extra second. The status is a snapshot, not terminal proof: `response_sent` means a terminal frame was written, not that the write succeeded or the host received it. A stalled dispatcher/shared writer/transport/whole Guest can make the probe unavailable. A different latest sequence is not evidence that the target request was never received.

No API, persisted schema, normal-operation admission, required-context policy, timeout budget, production deployment, or UI changes. The historical production cause remains unproven.
