### PR TITLE
test(e2e): use the real twilio upstream in firewall probe

### DIFF
--- a/e2e/tests/03-runner/run-t01-firewall-twilio.bats
+++ b/e2e/tests/03-runner/run-t01-firewall-twilio.bats
@@ -38,12 +38,10 @@ teardown() {
     prompt=$(cat <<'EOF'
 printf 'TWILIO_ACCOUNT_SID=%s\n' "$TWILIO_ACCOUNT_SID"
 printf 'TWILIO_AUTH_TOKEN=%s\n' "$TWILIO_AUTH_TOKEN"
-# Raw DNS has dedicated runner coverage. Pin the public sink so this test owns
-# only firewall classification, authentication resolution, and redaction.
-# Outlive the proxy's 10-second firewall-auth deadline so this request does not
-# close its connection while credentials are still resolving.
-curl --silent --show-error --max-time 15 \
-    --resolve 'api.twilio.com:443:8.8.8.8' \
+# Keep the request on Twilio's real IPv4 authority instead of an unrelated sink.
+# The 15-second budget leaves room around the proxy's 10-second auth deadline.
+# Assert vm0's auth/redaction telemetry, not Twilio's application response.
+curl --ipv4 --silent --show-error --max-time 15 \
     --output /dev/null \
     'https://api.twilio.com/2010-04-01/Accounts.json' || true
 printf 'TWILIO_REQUEST_SENT\n'


### PR DESCRIPTION
## Summary

Remove the Twilio Runner E2E probe's forced `api.twilio.com:443:8.8.8.8` destination. Resolve and connect to the real Twilio IPv4 authority, matching the existing Zendesk probe's destination strategy.

The forced destination made credential-injection coverage depend on an unrelated public peer's connection lifecycle. The earlier timeout mitigation in #32515 remains intact: this change keeps the 15-second curl budget, non-fatal curl result, completion marker, placeholder checks, exact `ALLOW`/resolved-secret assertion, and raw-credential redaction checks.

Relates to #32536. This PR implements only the Twilio slice and must not close that issue; Discord and Algolia placeholder routing remain follow-up work.

## Scope

- Change only `e2e/tests/03-runner/run-t01-firewall-twilio.bats`.
- Remove `--resolve ...:8.8.8.8`, add `--ipv4`, and update the explanatory comment.
- Do not change runner/proxy behavior, destination-binding checks, shared telemetry assertions, retry behavior, or dedicated DNS coverage.
- Do not change Discord or Algolia probes or placeholder DNS infrastructure.

## Validation

- `cd e2e && ./test/libs/bats/bin/bats --count tests/03-runner/run-t01-firewall-twilio.bats` — passed, 1 test parsed.
- Extracted the actual quoted-heredoc request script and ran `bash -n` and `shellcheck --shell=bash -` — passed.
- Checked the extracted script retains the real Twilio URL, IPv4 selection, 15-second deadline, non-fatal curl result, and completion marker, with no forced destination — passed.
- `./scripts/check-file-size.sh e2e/tests/03-runner/run-t01-firewall-twilio.bats` — passed.
- `git diff --check` and staged whitespace checks — passed.
- Repository pre-commit and commit-message hooks — passed.

The deployed Runner E2E suite requires the PR preview and runner fleet; it was not run locally and must pass in CI. Unrelated Turbo, Rust, and Python suites do not apply to this test-only shell change.

## Remaining risks

Public DNS, TCP, and TLS availability are still needed to reach the proxy's HTTP processing. This removes the unrelated public sink, not all public-network dependencies. Twilio application-response success is intentionally not the test oracle; the existing vm0-owned authentication and redaction assertions remain authoritative.
