### PR TITLE
docs(runner): attribute storage helper resume latency

### DIFF
--- a/docs/benchmarks/storage-helper-attribution/README.md
+++ b/docs/benchmarks/storage-helper-attribution/README.md
@@ -1,0 +1,319 @@
+# Storage helper invocation attribution
+
+Decision record for [#32428](https://github.com/vm0-ai/vm0/issues/32428), a child
+of [#24203](https://github.com/vm0-ai/vm0/issues/24203). Measured September 8, 2026.
+This change adds an experiment record and opt-in reproduction artifacts only.
+It does not change Runner, guest code, containment, resource policy, or CI execution.
+
+## Decision
+
+The large residual is reproducible on the **first helper invocation after
+resume**, not as a constant cost on every invocation. In the refined diagnostic
+cohort, `Command::spawn()` took **9.188–24.815 ms** on nine first-after-resume
+observations; command preparation took **6–7 microseconds**. Repeated calls in
+that same cohort had spawn p90 of **1.831–1.970 ms** in each 300-call trial.
+The enclosing cgroup creation and cleanup intervals were much smaller.
+
+Do not weaken workload containment, remove mandatory storage work, introduce a
+daemon, or change cancellation polling based on the production residual. No
+safe optimization with a demonstrated gain is selected by this attribution PR.
+The next useful target is the **cold/resumed spawn interval**, including its
+child-side security hooks and exec handshake. The measurement does not separate
+fork/clone, page faults, cgroup placement, identity syscalls, exec, and scheduling
+inside that interval. Balloon-driven cache reclamation is a hypothesis, not a
+proven cause. Changing balloon policy or replacing the launcher requires a
+separate experiment and design review, including memory and isolation costs.
+
+The provisional 5-ms p90 screen is not met by any single measured warm phase
+across all trials. Cold spawn exceeds that scale, but these small cold cohorts
+do not establish a stable p90 or a safely recoverable saving. This closes the
+attribution/decision slice, not the parent performance effort or a runtime fix.
+
+## Boundaries
+
+| Observation                                              | Includes                                                                                                                                            | Excludes / interpretation                                                                                                                                                       |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Production `runner_storage_manifest_guest_storage_apply` | `download_storages`: serialization, runtime-path construction, dedicated operation or fallback, result checks                                       | Prior cache population/staging and other spawn phases                                                                                                                           |
+| Probe `outer_us`                                         | Manifest serialization, the same public Sandbox operation and await; fallback includes remove/write/exec                                            | Synthetic reconstruction, **not the production metric**: no production context/path construction, logging, or failure-cleanup wrapper; result validation occurs after the timer |
+| Dedicated result `guest_ms`                              | Guest `run_manifest`, from before cancellation/cgroup creation through child handling, containment cleanup, input/output joins, and result assembly | Request parsing, worker admission/dispatch, response encoding, writer-lock wait and socket write                                                                                |
+| Child `download_total`                                   | Input read, stale manifest cleanup, parsing, storage work, normalization                                                                            | Runtime log-path setup and argument parsing before the timer; final telemetry/logging and process exit after it                                                                 |
+| `outer − guest`                                          | Serialization, host/guest admission and scheduling, transport and response handling                                                                 | **Not pure network latency**; guest timer is rounded down to integer milliseconds                                                                                               |
+| `outer − inner`                                          | Paired residual around application work                                                                                                             | Not guaranteed savings and never a subtraction of percentile values                                                                                                             |
+
+Temporary diagnostic intervals partition guest wall time: cancellation/cgroup
+creation; command preparation plus spawn; I/O worker setup; wait through
+group cleanup/reap; containment cleanup; remaining stdin/drain joins and result
+handling. The refined version splits preparation from spawn without changing
+the boundary of their combined interval. `prepare_spawn_us` is their **enclosing
+total**, not an additional additive phase.
+
+Input writing and output drains overlap child execution. The child application
+timer overlaps I/O setup/wait; do not add it to those intervals. The first-call
+wait interval also includes initialization, terminal logging, and scheduling
+outside the child timer. No absolute timestamp is subtracted across host/guest
+clocks. Quantized residuals retain their signed values; missing events are not
+zero-filled. Fallback `guest_ms` describes its final generic exec, not all three
+fallback operations, and is not the dedicated middle boundary.
+
+## Environment and workload
+
+- Source: `16d1e9a9b2bcd80e20ae37dfd64584814c46b531`, Runner `0.188.7`.
+  All guest binaries use this source; only guest-init receives the experimental
+  guest-control timing patch in diagnostic images.
+- Build: Rust `ci` profile, `x86_64-unknown-linux-musl`, optimized thin LTO,
+  four codegen units, no `test-support` or debug assertions. This is the normal
+  development Runner build profile, **not** the production full-LTO release.
+- Approved shared development host: `local-11.gcp.vm3.ai`, kernel
+  `6.17.0-1018-gcp`, 16 logical CPUs (Xeon Platinum 8581C), 32,086 MiB RAM.
+  Roughly 29 GiB was available. This is not a production host or a dedicated
+  machine; unrelated development services were not stopped or replaced.
+- Profile: `vm0/default`, 2 vCPUs, 4,096 MiB guest memory. Normal production
+  Workload cgroups, identity drop, security hooks, process-group ownership,
+  output bounds, and lifecycle cleanup remain enabled.
+- Existing `runner benchmark` owns the proxy, VM, COW devices and namespace pool.
+  It prefetches snapshot memory. Every trial starts a new snapshot-restored VM;
+  every 100-call batch is followed by normal `park()` / `unpark()` with the
+  default balloon controller. This is a lifecycle analogue, not a complete
+  API-admitted Exact run with an active agent and its working set.
+- Logs use the production home-based runtime directory, not tmpfs. No real
+  manifests, customer data, provider calls, or real API token are used. R2
+  credentials were supplied only to the ordinary image builder to read its
+  cached template, never to measurement output.
+
+Each trial has 324 storage invocations: one first call; three batches of 100
+repeated cached calls with one resumed call after each batch; ten high-work
+calls; ten oversized calls. The cached fixture has 17 cached mounts, one with
+instruction normalization still requested. The archive fixture has 140 local
+`file://` mounts, each extracting a 4-KiB payload. The oversized cached fixture
+exceeds the 65,536-byte dedicated stdin limit via a 70,000-character synthetic
+name and exercises remove/write/generic-exec fallback. Its child removes the
+canonical temporary manifest. Instruction content, all extracted payload sizes,
+fallback manifest removal, successful exit and untruncated output are checked.
+
+Archives warm during each trial; high-work results are not a fixed cold-cache
+distribution. Fixtures and their reset/order are identical between images.
+The actual planner's true-no-work case is checked separately by the existing
+Runner entry-point test and has **no helper invocation**, not a zero-ms helper
+sample. Existing storage integration coverage validates normalization, nested
+mount ordering and extraction security beyond this synthetic fixture.
+
+## Evidence and distributions
+
+Formal runs: `A1, I1, A2, I2, A3, I3` alternated at 05:35:54–05:36:47 UTC;
+`G1/G2` were started together at 05:41:04–05:41:15;
+`J1–J3` refined the spawn split at 06:02:10–06:02:36.
+A/G use uninstrumented guests; I uses six wall intervals; J adds the two
+preparation/spawn subintervals. Do not pool these builds or lifecycle categories.
+
+All **3,564 / 3,564** formal invocations have successful complete child pairs,
+with no truncated captures. Each A/I/J set has 900 repeated cached, 3 first,
+9 resumed, 30 high-work and 30 oversized observations; G has 600/2/6/20/20.
+An earlier 324-call calibration used tmpfs logs and is excluded. A subsequent
+resource-tool availability check failed before the first storage invocation:
+guest `command -v strace` returned 127, not 1. It was fixed before formal runs.
+That failed setup is not counted as a successful trial or silently rerun away.
+
+Nearest-rank distributions below are **p50 / p90 / p95 / p99 in milliseconds**.
+Every residual is calculated per pair before percentile selection. Each row
+contains 300 repeated cached calls, preserving individual trial identity.
+
+| Trial | Probe outer                    | Guest result   | Child inner   | Outer − inner                  | Outer − guest                |
+| ----- | ------------------------------ | -------------- | ------------- | ------------------------------ | ---------------------------- |
+| A1    | 4.120 / 6.326 / 7.277 / 8.026  | 3 / 5 / 6 / 7  | 0 / 1 / 1 / 2 | 3.974 / 6.318 / 7.130 / 8.026  | .974 / 1.355 / 1.480 / 2.900 |
+| A2    | 3.899 / 6.306 / 7.332 / 13.038 | 3 / 5 / 6 / 10 | 0 / 0 / 1 / 1 | 3.764 / 6.282 / 7.332 / 10.038 | .909 / 1.296 / 1.383 / 1.744 |
+| A3    | 3.796 / 5.978 / 6.730 / 8.488  | 3 / 5 / 6 / 7  | 0 / 0 / 1 / 1 | 3.746 / 5.834 / 6.526 / 8.488  | .869 / 1.317 / 1.390 / 1.546 |
+
+The three 100-call batch outer p90s are A1 `4.500 / 7.277 / 6.318`,
+A2 `4.016 / 7.431 / 6.589`, A3 `3.882 / 6.191 / 6.444` ms. Warm calls after
+resume are not identical to the pre-park batch; they were not discarded.
+
+Small lifecycle cohorts are reported as individual values, **not stable tails**:
+
+| Trial | First outer | Three first-after-resume outer observations |
+| ----- | ----------: | ------------------------------------------- |
+| A1    |      30.760 | 34.544 / 18.811 / 35.014                    |
+| A2    |      24.761 | 25.567 / 24.523 / 21.278                    |
+| A3    |      35.066 | 21.677 / 23.286 / 29.321                    |
+
+These reproduce a residual on the same scale as the historical production
+report, but do not establish its fleet cause: production Runner versions,
+manifests, host load and working sets differ. The production p90 residual of
+32 ms must not be interpreted as 32 ms available to remove.
+
+### Guest attribution and perturbation
+
+| Repeated-call phase                 |   I1 p50/p90 |   I2 p50/p90 |   I3 p50/p90 |
+| ----------------------------------- | -----------: | -----------: | -----------: |
+| Cancellation + containment creation |  .432 / .932 |  .422 / .970 |  .418 / .969 |
+| Command preparation + spawn         | .623 / 1.995 | .601 / 1.680 | .652 / 1.816 |
+| I/O setup                           |  .100 / .311 |  .108 / .351 |  .125 / .376 |
+| Wait/completion/group reap          | .787 / 1.448 | .817 / 1.478 | .805 / 1.433 |
+| Containment cleanup                 |  .240 / .462 |  .217 / .440 |  .208 / .490 |
+| Remaining joins/result handling     | .151 / 2.995 | .144 / 3.129 | .171 / 3.028 |
+
+These are phase percentiles, not additive components of outer p90. The join
+interval is measurable but below the proposed 5-ms screen at p90. The 50-ms
+cancellation interval does not impose a 50-ms delay on fast child exits.
+
+I1/I2/I3 outer p50/p90 are `3.741/6.526`, `3.679/6.205`, `3.952/6.074` ms.
+Compared to adjacent A trials, absolute p50 changes are at most .379 ms and p90
+changes at most .200 ms: below 1 ms and within observed baseline batch variation.
+This is a descriptive perturbation check, not a statistical equivalence result.
+The much smaller first/resumed cohorts cannot establish sub-ms perturbation.
+**No clocks or new success diagnostics remain enabled in product code.**
+
+The later J refinement, not interleaved for a causal overhead comparison,
+confirms that preparation is only 6–7 microseconds on resumed samples:
+
+| Trial | Resumed spawn intervals (ms) | Repeated spawn p50/p90 (ms) |
+| ----- | ---------------------------- | --------------------------: |
+| J1    | 24.815 / 15.782 / 9.188      |                .543 / 1.887 |
+| J2    | 15.437 / 9.298 / 22.167      |                .551 / 1.970 |
+| J3    | 15.932 / 14.777 / 16.352     |                .532 / 1.831 |
+
+## Correctness and resource guardrails
+
+High-work outer p50/p90/max: A1 `64.470/160.397/191.758`,
+A2 `61.141/139.951/186.245`, A3 `62.968/124.718/225.993` ms.
+Oversized fallback: A1 `23.759/40.971/51.342`, A2 `23.119/40.849/66.298`,
+A3 `23.201/35.636/69.729` ms. Each row has only ten observations; p95/p99 would
+equal the observed maximum and are not stable tail estimates. Do not combine
+fallback and dedicated residuals. There is no optimization treatment for which
+these guardrails could demonstrate a performance improvement.
+
+G1/G2 outer repeated p50/p90/p95/p99 were `4.056/6.103/6.600/7.329` and
+`3.773/6.394/7.143/15.359` ms. Both completed all 324 calls and cleanup. G2's
+p99 exceeds the isolated A maxima of their p99s; do not claim zero tail
+regression from this small contention check. Concurrent startup also serialized
+some proxy initialization (one proxy took 3.762 s versus 1.866 s); proxy startup
+is outside the storage timer.
+
+For A1–A3, the aggregate guest exec-cgroup CPU delta was 1.662/1.691/1.681 s
+across each complete fixture, including setup/high-work/fallback. Available
+guest memory after the fixture was 3,404–3,433 MiB versus 3,455 MiB before.
+The G trials used 1.680/1.717 s aggregate exec-cgroup CPU, with 3,432/3,400 MiB
+available afterward. These are not per-helper CPU or peak-RSS measurements.
+Parent cgroup pressure counters stayed zero; they do not independently prove
+every removed leaf's CPU history. Guest PSI and strace are unavailable.
+
+During concurrent startup, host available memory was 29,182 → 29,181 MiB.
+Host PSI total deltas were CPU some 69,425 us, memory some 1,734 us, and I/O
+some 16,149 us; avg10 remained 0.00. `/usr/bin/time -v` reported 10.65/10.71 s
+process-tree CPU and 10.75/8.91 s wall time for G1/G2. Its maximum RSS is **not**
+aggregate VM memory, so it is not used as a VM-memory guardrail. The snapshot
+and image cache remain warm and host pressure is not attributable solely to us.
+
+Before and after each fixture, the only exec cgroup present was the resource
+probe's own current operation. Every park passed the reusable/quiescent gate;
+normal teardown released the VM, COW slots, namespace pool and proxy. Existing
+development services remained active. Inactive experiment binaries/configs and
+bounded logs were retained for audit; no host-wide GC or production action ran.
+
+## Reproduction artifacts
+
+These patches are **opt-in, disposable experiment code**, not production APIs.
+Use a separate clean checkout of the pinned revision on an approved development
+host. Never apply them to an active service or run them with customer input.
+`probe.patch` adds a private magic benchmark command solely to exercise the
+real Sandbox entry points. Its final log reader uses `.get()` instead of the
+indexed lookups in the measured binary; this lint cleanup is after all timers.
+It also omits failure diagnostic text from measurement JSON; fatal errors still
+fail the trial. Only fixed numeric success phases are emitted by the guest patch.
+`guest-phases.patch` and its test reproduce the J refinement. The recorded I
+instrumentation predated `command_prepared` and the `prepare_us`/`spawn_us`
+fields; it had six fields, retaining their enclosing timer.
+The patch also adjusts the opt-in connection test to require numeric phase
+diagnostics on success; the unpatched production contract still requires an
+empty success diagnostic. Do not deploy the experimental diagnostic contract.
+
+```bash
+git apply --check /path/to/this/report/probe.patch
+git apply /path/to/this/report/probe.patch
+cd crates
+CARGO_BUILD_JOBS=4 cargo build --profile ci --target x86_64-unknown-linux-musl \
+  -p runner -p guest-agent -p guest-storage-apply -p guest-init \
+  -p guest-state-restore -p guest-write-file -p guest-tool-exec \
+  -p runner-rpc-client -p claude-mock -p codex-mock
+```
+
+Preserve baseline guest-init before applying the guest timing patch and
+rebuilding only guest-init. Use `runner build --profile vm0/default` with
+explicit paths for **all nine** guest binaries (the corresponding `--guest-*`,
+`--runner-rpc-client`, `--claude-mock`, `--codex-mock` flags). Then use
+`runner config` with each returned rootfs/snapshot hash and a unique benchmark
+group/base directory, `--max-concurrent 1`, the approved hostname, a deliberately
+non-serving API URL and synthetic token. Do not invoke the normal service
+deployment script: it stops/replaces its configured service and runs GC.
+
+```bash
+set -o pipefail
+sudo /path/to/experimental/runner benchmark issue-32428-storage-probe \
+  --config /path/to/isolated/runner.yaml --profile vm0/default \
+  2>&1 | tee /path/to/private/trial.log
+jq -Rc 'select(startswith("{")) | fromjson' /path/to/private/trial.log \
+  | jq -s -f /path/to/this/report/summary.jq
+bash /path/to/this/report/test-summary.sh
+```
+
+Require benchmark exit zero and complete teardown as well as the summarizer's
+coverage check. The summarizer validates exact outer sample order and requires
+324 successful, untruncated outer observations and 324 valid child observations.
+Ordinal pairing is valid **only for this serial, single-owner synthetic log**;
+never apply it to interleaved production telemetry. The script exposes the
+number of diagnostic samples and keeps shape/phase/batch groups separate.
+`by_shape_phase` additionally summarizes each lifecycle category within that
+single trial (including the 300 repeated calls), never across trials or builds.
+Its small-cohort percentile outputs are mathematical order statistics, not
+evidence of reliable p99 estimates.
+
+### Binary and image identities
+
+| Binary                                       | SHA-256                                                            |
+| -------------------------------------------- | ------------------------------------------------------------------ |
+| Experimental Runner, common to formal trials | `24860411eca09149431fad26b4dde60afc94f5c946332593be897e051ff1aff5` |
+| Baseline guest-init                          | `184177ddf2924f13f66562e7197513e48deea44541ef6870c66f26b8ff1dde4a` |
+| I guest-init                                 | `848967c455697dc309057ca7dbfcb864710823f3a8769d13dfeea0e48d167ca1` |
+| J guest-init                                 | `6b80eebffb8e7fe07dffa2f8cdeaeff64d9247a331134f5a56e56efe4deb3eae` |
+| Unchanged guest-storage-apply                | `adb21481c0d39cb5e474715db16883b9fddcc6775d3c0f20697618d9db6ce837` |
+
+| Image | Rootfs hash                                                        | Snapshot hash                                                      |
+| ----- | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| A/G   | `203c5532218d920b96643368e9176fd106a6b249d8f342df322fa102e5c3200f` | `17209ec83aaf0265273510d120ade287e07c1fe02b375d0810fbb473080e47c8` |
+| I     | `44cefd79e584311bf58b0b0b046a4d5f1e597fe4a13fb36821c68b215ca38517` | `077b4983652150e781689bbd2183463588ca5fdb23e0afd3536785dd07631b39` |
+| J     | `bbb9969eee46deef458129fc7da5aaddcb62e0f1773092c2791514a5015bbb38` | `9451edaf630308ee570c45aa76ebd50a0dd94ee97e237688537aab1a1984c636` |
+
+Raw synthetic JSON Lines are retained in the workflow's ignored research
+directory, with full Runner logs in the isolated host experiment directory.
+They are intentionally not ingested into production telemetry. The tables
+above are the checked-in result; all statistics can be recalculated from a
+fresh trial with the included summarizer.
+
+## Validation
+
+The real-guest runs above are the performance/containment evidence. Local
+connection tests use TestNoop and are correctness checks, not cgroup benchmarks.
+Selected checks were run in the foreground:
+
+```bash
+bash docs/benchmarks/storage-helper-attribution/test-summary.sh
+bash -n docs/benchmarks/storage-helper-attribution/test-summary.sh
+shellcheck docs/benchmarks/storage-helper-attribution/test-summary.sh
+pnpm -C turbo exec prettier --check ../docs/benchmarks/storage-helper-attribution/README.md
+# From crates, with CARGO_BUILD_JOBS=4:
+cargo fmt --all -- --check
+cargo clippy --profile local -p runner --bins -- -D warnings
+cargo clippy --profile local -p guest-control-server --all-targets --all-features -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --profile local -p guest-control-server --no-deps
+cargo test --profile local -p runner storage --all-targets --all-features
+cargo test --profile local -p guest-control-server --test connection guest_storage_manifest --all-features
+cargo test --profile local -p guest-storage-apply --all-targets --all-features
+```
+
+Runner's storage selection passed 204 tests (its existing isolated-process
+helper is invoked by its parent test). The eight storage connection tests passed
+both without the diagnostic patch and with the patch's explicit experimental
+success-diagnostic assertion. Storage-apply's full selected suite passed.
+The summarizer was also run successfully on all eleven complete formal logs;
+its CLI regression test checks paired quantiles and rejects incomplete, failed,
+truncated, reordered and malformed observations. Both patches apply cleanly
+to the pinned source. No Rust source changes are retained by this PR.

--- a/docs/benchmarks/storage-helper-attribution/guest-phases.patch
+++ b/docs/benchmarks/storage-helper-attribution/guest-phases.patch
@@ -1,0 +1,98 @@
+diff --git a/crates/guest-control-server/src/guest_storage_manifest.rs b/crates/guest-control-server/src/guest_storage_manifest.rs
+index 5cb0197d67..ff79c026ef 100644
+--- a/crates/guest-control-server/src/guest_storage_manifest.rs
++++ b/crates/guest-control-server/src/guest_storage_manifest.rs
+@@ -255,6 +255,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
+             );
+         }
+     };
++    let containment_created = Instant::now();
+     let mut prepared_containment = match process_containment.prepare_command() {
+         Ok(prepared) => prepared,
+         Err(error) => {
+@@ -287,6 +288,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
+         );
+     }
+     prepared_containment.configure_process_inspection(&mut command);
++    let command_prepared = Instant::now();
+     let mut child = match spawn_in_own_process_group(&mut command) {
+         Ok(child) => child,
+         Err(error) => {
+@@ -299,6 +301,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
+         }
+     };
+
++    let spawned = Instant::now();
+     let Some(stdin) = child.stdin.take() else {
+         return abort_spawned(
+             child,
+@@ -395,6 +398,7 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
+     };
+     drop(drain_done_tx);
+
++    let io_ready = Instant::now();
+     let outcome = wait_with_kill_timeout_or_connection_cancelled(
+         child,
+         timeout_ms,
+@@ -403,9 +407,11 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
+         // identity, so helper descendants cannot outlive this fixed operation.
+         || true,
+     );
++    let waited = Instant::now();
+     let cancellation_observed = connection_cancel.load(Ordering::Acquire);
+     let cleanup_mode = cleanup_mode_for_wait_outcome(&outcome, cancellation_observed);
+     let containment_result = process_containment.cleanup(cleanup_mode);
++    let contained = Instant::now();
+     let stdin_result = stdin_writer.join();
+     if !matches!(outcome, WaitOutcome::Exited(_))
+         || cancellation_observed
+@@ -457,6 +463,19 @@ fn run_manifest(input: RunManifestInput<'_>) -> GuestStorageManifestOutput {
+         diagnostic = append_cleanup_failure(diagnostic, Some(&error));
+     }
+
++    if termination == (ExecTermination::Exited { exit_code: 0 }) && diagnostic.is_empty() {
++        diagnostic = serde_json::json!({
++            "containment_us": containment_created.duration_since(started).as_micros(),
++            "prepare_spawn_us": spawned.duration_since(containment_created).as_micros(),
++            "prepare_us": command_prepared.duration_since(containment_created).as_micros(),
++            "spawn_us": spawned.duration_since(command_prepared).as_micros(),
++            "io_setup_us": io_ready.duration_since(spawned).as_micros(),
++            "wait_us": waited.duration_since(io_ready).as_micros(),
++            "cleanup_us": contained.duration_since(waited).as_micros(),
++            "join_us": contained.elapsed().as_micros(),
++        })
++        .to_string();
++    }
+     GuestStorageManifestOutput {
+         termination,
+         duration_ms: elapsed_ms(started),
+diff --git a/crates/guest-control-server/tests/connection/guest_storage_manifest.rs b/crates/guest-control-server/tests/connection/guest_storage_manifest.rs
+index a35acfc499..05de5df59c 100644
+--- a/crates/guest-control-server/tests/connection/guest_storage_manifest.rs
++++ b/crates/guest-control-server/tests/connection/guest_storage_manifest.rs
+@@ -106,6 +106,24 @@ printf 'helper stderr\n' >&2
+     assert_eq!(result.stderr, b"helper stderr\n");
+     assert!(!result.stdout_truncated);
+     assert!(!result.stderr_truncated);
+-    assert!(result.diagnostic.is_empty());
++    let timings: serde_json::Value = serde_json::from_str(&result.diagnostic).unwrap();
++    assert_eq!(timings.as_object().unwrap().len(), 8);
++    for key in [
++        "containment_us",
++        "prepare_spawn_us",
++        "prepare_us",
++        "spawn_us",
++        "io_setup_us",
++        "wait_us",
++        "cleanup_us",
++        "join_us",
++    ] {
++        assert!(
++            timings
++                .get(key)
++                .and_then(serde_json::Value::as_u64)
++                .is_some()
++        );
++    }
+     finish_guest_connection(handle, host_stream);
+ }

--- a/docs/benchmarks/storage-helper-attribution/probe.patch
+++ b/docs/benchmarks/storage-helper-attribution/probe.patch
@@ -1,0 +1,233 @@
+diff --git a/crates/runner/src/cmd/benchmark.rs b/crates/runner/src/cmd/benchmark.rs
+index 2642a800eb..0ca30d6b82 100644
+--- a/crates/runner/src/cmd/benchmark.rs
++++ b/crates/runner/src/cmd/benchmark.rs
+@@ -19,6 +19,8 @@ use crate::prefetch;
+ use crate::proxy;
+ use crate::workspace_mount::ensure_workspace_drive_mounted;
+
++mod storage_probe;
++
+ #[derive(Default)]
+ struct Timing {
+     boot_ms: Option<u128>,
+@@ -460,6 +462,13 @@ async fn run_in_sandbox(
+         .map(|(k, v)| (k.as_str(), v.as_str()))
+         .collect();
+
++    if args.command == "issue-32428-storage-probe" {
++        let started = Instant::now();
++        let result = storage_probe::run(sandbox).await;
++        timing.exec_ms = Some(started.elapsed().as_millis());
++        return (result, timing);
++    }
++
+     let t_exec = Instant::now();
+     let result = sandbox
+         .exec_with_diagnostic_label(
+diff --git a/crates/runner/src/cmd/benchmark/storage_probe.rs b/crates/runner/src/cmd/benchmark/storage_probe.rs
+new file mode 100644
+index 0000000000..f0945a9fab
+--- /dev/null
++++ b/crates/runner/src/cmd/benchmark/storage_probe.rs
+@@ -0,0 +1,200 @@
++//! Temporary synthetic experiment, not a production execution mode.
++use std::time::{Duration, Instant};
++
++use guest_contracts::storage_manifest::Manifest;
++use sandbox::{ExecRequest, ExecResult, ExecTermination, Sandbox, StorageManifestRequest};
++use serde_json::json;
++
++use crate::error::{RunnerError, RunnerResult};
++
++const ROOT: &str = "/home/user/issue-32428";
++const RUN_ID: &str = "00000000-0000-4000-8000-000000032428";
++const RUNTIME: &str = "/home/user/.vm0/guest-agent/runs/00000000-0000-4000-8000-000000032428";
++
++async fn command(sandbox: &dyn Sandbox, cmd: &str, sudo: bool) -> RunnerResult<ExecResult> {
++    let result = sandbox
++        .exec(&ExecRequest {
++            cmd,
++            timeout: Duration::from_secs(30),
++            env: &[],
++            sudo,
++            expected_exit_codes: &[],
++            stdin_bytes: None,
++            output_limits: sandbox::EXEC_OUTPUT_LIMIT_1_MIB,
++        })
++        .await?;
++    if result.termination != (ExecTermination::Exited { exit_code: 0 }) {
++        return Err(RunnerError::Internal(format!(
++            "synthetic setup/verification failed: {}",
++            String::from_utf8_lossy(&result.stderr)
++        )));
++    }
++    Ok(result)
++}
++
++fn manifest(high_work: bool, oversized: bool) -> RunnerResult<Manifest> {
++    let mounts: Vec<_> = (0..if high_work { 140 } else { 17 }).map(|i| {
++        json!({
++            "mountPath": format!("{ROOT}/mount-{i}"),
++            "cached": !high_work,
++            "archiveUrl": if high_work { Some(format!("file://{ROOT}/archive.tar.gz")) } else { None },
++            "instructionsTargetFilename": if !high_work && i == 0 { Some("CLAUDE.md") } else { None },
++            "name": if oversized && i == 0 { "x".repeat(70_000) } else { format!("synthetic-{i}") }
++        })
++    }).collect();
++    serde_json::from_value(json!({"storageMounts": mounts}))
++        .map_err(|e| RunnerError::Internal(e.to_string()))
++}
++
++async fn invoke(sandbox: &dyn Sandbox, manifest: &Manifest) -> RunnerResult<ExecResult> {
++    let bytes = serde_json::to_vec(manifest).map_err(|e| RunnerError::Internal(e.to_string()))?;
++    if bytes.len() <= guest_control_proto::MAX_EXEC_STDIN_BYTES {
++        return sandbox
++            .apply_storage_manifest(&StorageManifestRequest {
++                manifest_json: &bytes,
++                run_id: RUN_ID,
++                runtime_dir: RUNTIME,
++                timeout: Duration::from_secs(30),
++            })
++            .await
++            .map_err(Into::into);
++    }
++    let path = guest_contracts::runtime_paths::STORAGE_MANIFEST_PATH;
++    command(sandbox, &format!("rm -f -- {path}"), false).await?;
++    sandbox.write_file(path, &bytes).await?;
++    sandbox
++        .exec_with_diagnostic_label(
++            &ExecRequest {
++                cmd: &format!(
++                    "{} {path}",
++                    guest_contracts::guest_binary::STORAGE_APPLY_PATH
++                ),
++                timeout: Duration::from_secs(30),
++                env: &[
++                    (guest_contracts::env::RUN_ID_ENV, RUN_ID),
++                    (
++                        guest_contracts::runtime_paths::CANONICAL_GUEST_RUNTIME_DIR_ENV,
++                        RUNTIME,
++                    ),
++                ],
++                sudo: false,
++                expected_exit_codes: &[],
++                stdin_bytes: None,
++                output_limits: sandbox::EXEC_OUTPUT_LIMIT_1_MIB,
++            },
++            "storage-download",
++        )
++        .await
++        .map_err(Into::into)
++}
++
++async fn sample(
++    sandbox: &dyn Sandbox,
++    manifest: &Manifest,
++    shape: &str,
++    phase: &str,
++    batch: usize,
++    index: usize,
++) -> RunnerResult<()> {
++    let start = Instant::now();
++    let result = invoke(sandbox, manifest).await;
++    let outer_us = start.elapsed().as_micros();
++    match result {
++        Ok(result) => {
++            let success = result.termination == (ExecTermination::Exited { exit_code: 0 });
++            println!(
++                "{}",
++                json!({"kind":"storage_probe", "shape":shape,"phase":phase,"batch":batch,"index":index,
++                "outer_us":outer_us,"guest_ms":result.guest_duration_ms,"success":success,"diagnostic":if success { result.diagnostic } else { String::new() },
++                "stdout_truncated":result.stdout_truncated,"stderr_truncated":result.stderr_truncated})
++            );
++            if !success || result.stdout_truncated || result.stderr_truncated {
++                return Err(RunnerError::Internal(format!(
++                    "storage probe failed: {}",
++                    String::from_utf8_lossy(&result.stderr)
++                )));
++            }
++            Ok(())
++        }
++        Err(error) => {
++            println!(
++                "{}",
++                json!({"kind":"storage_probe", "shape":shape,"phase":phase,"batch":batch,"index":index,"outer_us":outer_us,"success":false})
++            );
++            Err(error)
++        }
++    }
++}
++
++pub(super) async fn run(sandbox: &mut dyn Sandbox) -> RunnerResult<ExecResult> {
++    resources(sandbox, "before").await?;
++    command(
++        sandbox,
++        &format!("set -eu; mkdir -p {RUNTIME}/logs {ROOT}; chown -R user:user {RUNTIME} {ROOT}"),
++        true,
++    )
++    .await?;
++    command(sandbox, &format!("set -eu; for i in $(seq 0 139); do mkdir -p {ROOT}/mount-$i; done; printf 'synthetic instructions\\n' > {ROOT}/mount-0/CLAUDE.md; mkdir -p {ROOT}/source; head -c 4096 /dev/zero > {ROOT}/source/payload; tar -czf {ROOT}/archive.tar.gz -C {ROOT}/source payload"), false).await?;
++    let low = manifest(false, false)?;
++    sample(sandbox, &low, "cached-instructions", "first", 0, 0).await?;
++    for batch in 0..3 {
++        for index in 0..100 {
++            sample(
++                sandbox,
++                &low,
++                "cached-instructions",
++                "repeated",
++                batch,
++                index,
++            )
++            .await?;
++        }
++        if !matches!(sandbox.park().await?, sandbox::SandboxParkOutcome::Reusable) {
++            return Err(RunnerError::Internal(
++                "synthetic guest was not reusable".into(),
++            ));
++        }
++        sandbox.unpark().await?;
++        sample(sandbox, &low, "cached-instructions", "resumed", batch, 0).await?;
++    }
++    for (shape, input) in [
++        ("high-work", manifest(true, false)?),
++        ("oversized", manifest(false, true)?),
++    ] {
++        for index in 0..10 {
++            sample(sandbox, &input, shape, "repeated", 0, index).await?;
++        }
++    }
++    command(sandbox, &format!("set -eu; test \"$(cat {ROOT}/mount-0/CLAUDE.md)\" = 'synthetic instructions'; for i in $(seq 0 139); do test $(wc -c < {ROOT}/mount-$i/payload) -eq 4096; done; test ! -e {}", guest_contracts::runtime_paths::STORAGE_MANIFEST_PATH), false).await?;
++    let log = sandbox
++        .read_file(
++            &format!("{RUNTIME}/logs/sandbox-ops.jsonl"),
++            8 * 1024 * 1024,
++        )
++        .await?
++        .ok_or_else(|| RunnerError::Internal("synthetic child operation log missing".into()))?;
++    for line in log
++        .split(|byte| *byte == b'\n')
++        .filter(|line| !line.is_empty())
++    {
++        let value: serde_json::Value =
++            serde_json::from_slice(line).map_err(|e| RunnerError::Internal(e.to_string()))?;
++        if value.get("action_type").and_then(serde_json::Value::as_str) == Some("download_total") {
++            println!(
++                "{}",
++                json!({"kind":"storage_probe_inner", "duration_ms":value.get("duration_ms"),"success":value.get("success")})
++            );
++        }
++    }
++    resources(sandbox, "after").await?;
++    Ok(ExecResult::new(0, Vec::new(), Vec::new()))
++}
++
++async fn resources(sandbox: &dyn Sandbox, phase: &str) -> RunnerResult<()> {
++    let resources = command(sandbox, "set -eu; free -m; cat /proc/stat /proc/diskstats; for name in cpu memory io; do if test -r /proc/pressure/$name; then cat /proc/pressure/$name; else printf 'PSI %s unavailable\\n' $name; fi; done; cat /sys/fs/cgroup/vm0-exec/cpu.stat /sys/fs/cgroup/vm0-exec/memory.events /sys/fs/cgroup/vm0-exec/pids.events; count=$(find /sys/fs/cgroup/vm0-exec -mindepth 1 -maxdepth 1 -type d | wc -l); printf 'exec_groups_including_resource_probe=%s\\n' $count; test $count -eq 1; if command -v strace; then :; else printf 'strace unavailable\\n'; fi", true).await?;
++    println!(
++        "{}",
++        json!({"kind":"storage_probe_resources","phase":phase,"summary":String::from_utf8_lossy(&resources.stdout)})
++    );
++    Ok(())
++}

--- a/docs/benchmarks/storage-helper-attribution/summary.jq
+++ b/docs/benchmarks/storage-helper-attribution/summary.jq
@@ -1,0 +1,52 @@
+# Input: one complete synthetic probe execution, parsed as JSON Lines with -s.
+# Pair only this single-owner, serial stream. Never use ordinal pairing on fleet logs.
+def quantiles:
+  sort as $v
+  | {p50: $v[(length * 0.50 | ceil) - 1],
+     p90: $v[(length * 0.90 | ceil) - 1],
+     p95: $v[(length * 0.95 | ceil) - 1],
+     p99: $v[(length * 0.99 | ceil) - 1]};
+
+def summarize_group:
+  . as $group
+  | {shape: .[0].shape, phase: .[0].phase,
+     batch: (map(.batch) | unique | if length == 1 then .[0] else null end),
+     count: length, phase_samples: (map(select(.diagnostic != "")) | length),
+     milliseconds: (["outer_ms", "guest_ms", "inner_ms", "outer_minus_inner_ms",
+                     "outer_minus_guest_ms", "guest_minus_inner_ms"]
+       | map(. as $key | {key: $key, value: ($group | map(.[$key]) | quantiles)})
+       | from_entries),
+     phases_us: ($group | map(select(.diagnostic != "") | .diagnostic | fromjson)
+       | if length == 0 then null else
+           . as $phases | .[0] | keys
+           | map(. as $key | {key: $key, value: ($phases | map(.[$key]) | quantiles)})
+           | from_entries
+         end)};
+
+map(select(.kind == "storage_probe")) as $outer
+| map(select(.kind == "storage_probe_inner")) as $inner
+| ([["cached-instructions", "first", 0, 0]]
+   + [range(0; 3) as $b
+      | (range(0; 100) | ["cached-instructions", "repeated", $b, .]),
+        ["cached-instructions", "resumed", $b, 0]]
+   + ["high-work", "oversized" | . as $shape
+      | range(0; 10) | [$shape, "repeated", 0, .]]) as $expected
+| if ($outer | length) != 324 or ($inner | length) != 324 then
+    error("incomplete execution: expected exactly 324 outer and 324 child observations")
+  elif ($outer | map([.shape, .phase, .batch, .index])) != $expected then
+    error("unexpected sample order, duplicate, or mixed execution")
+  elif any($outer[]; .success != true or .stdout_truncated != false
+      or .stderr_truncated != false or (.outer_us | type) != "number"
+      or (.guest_ms | type) != "number" or .outer_us < 0 or .guest_ms < 0)
+    or any($inner[]; .success != true or (.duration_ms | type) != "number" or .duration_ms < 0) then
+    error("failed, truncated, or missing timing observations; do not summarize as a successful cohort")
+  else . end
+| [range(0; 324) as $i
+   | $outer[$i] + {inner_ms: $inner[$i].duration_ms}
+   | . + {outer_ms: (.outer_us / 1000),
+          outer_minus_inner_ms: (.outer_us / 1000 - .inner_ms),
+          outer_minus_guest_ms: (.outer_us / 1000 - .guest_ms),
+          guest_minus_inner_ms: (.guest_ms - .inner_ms)}] as $pairs
+| {attempts: 324, complete_inner_pairs: 324, failures: 0,
+   groups: ($pairs | group_by([.shape, .phase, .batch]) | map(summarize_group)),
+   by_shape_phase: ($pairs | group_by([.shape, .phase]) | map(summarize_group))}

--- a/docs/benchmarks/storage-helper-attribution/summary.jq
+++ b/docs/benchmarks/storage-helper-attribution/summary.jq
@@ -7,6 +7,19 @@ def quantiles:
      p95: $v[(length * 0.95 | ceil) - 1],
      p99: $v[(length * 0.99 | ceil) - 1]};
 
+def parse_phases:
+  if . == "" then null else
+    fromjson
+    | ["cleanup_us", "containment_us", "io_setup_us", "join_us",
+       "prepare_spawn_us", "wait_us"] as $coarse
+    | ($coarse + ["prepare_us", "spawn_us"] | sort) as $refined
+    | if type != "object" then error("phase diagnostics must be an object")
+      elif (keys != $coarse and keys != $refined)
+        or any(.[]; type != "number" or . < 0) then
+        error("phase diagnostics must contain the complete nonnegative numeric phase set")
+      else . end
+  end;
+
 def summarize_group:
   . as $group
   | {shape: .[0].shape, phase: .[0].phase,
@@ -16,7 +29,7 @@ def summarize_group:
                      "outer_minus_guest_ms", "guest_minus_inner_ms"]
        | map(. as $key | {key: $key, value: ($group | map(.[$key]) | quantiles)})
        | from_entries),
-     phases_us: ($group | map(select(.diagnostic != "") | .diagnostic | fromjson)
+     phases_us: ($group | map(.phase_timings | select(. != null))
        | if length == 0 then null else
            . as $phases | .[0] | keys
            | map(. as $key | {key: $key, value: ($phases | map(.[$key]) | quantiles)})
@@ -43,6 +56,7 @@ map(select(.kind == "storage_probe")) as $outer
   else . end
 | [range(0; 324) as $i
    | $outer[$i] + {inner_ms: $inner[$i].duration_ms}
+   | . + {phase_timings: (.diagnostic | parse_phases)}
    | . + {outer_ms: (.outer_us / 1000),
           outer_minus_inner_ms: (.outer_us / 1000 - .inner_ms),
           outer_minus_guest_ms: (.outer_us / 1000 - .guest_ms),

--- a/docs/benchmarks/storage-helper-attribution/summary.jq
+++ b/docs/benchmarks/storage-helper-attribution/summary.jq
@@ -61,6 +61,9 @@ map(select(.kind == "storage_probe")) as $outer
           outer_minus_inner_ms: (.outer_us / 1000 - .inner_ms),
           outer_minus_guest_ms: (.outer_us / 1000 - .guest_ms),
           guest_minus_inner_ms: (.guest_ms - .inner_ms)}] as $pairs
+| if ($pairs | map(.phase_timings | select(. != null) | keys) | unique | length) > 1 then
+    error("mixed diagnostic builds in one execution")
+  else . end
 | {attempts: 324, complete_inner_pairs: 324, failures: 0,
    groups: ($pairs | group_by([.shape, .phase, .batch]) | map(summarize_group)),
    by_shape_phase: ($pairs | group_by([.shape, .phase]) | map(summarize_group))}

--- a/docs/benchmarks/storage-helper-attribution/test-summary.sh
+++ b/docs/benchmarks/storage-helper-attribution/test-summary.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+summary="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/summary.jq"
+
+fixture() {
+  jq -nc '
+    def outer($shape; $phase; $batch; $index):
+      {kind: "storage_probe", shape: $shape, phase: $phase, batch: $batch,
+       index: $index, outer_us: (2000 + $index), guest_ms: 1, success: true,
+       stdout_truncated: false, stderr_truncated: false, diagnostic: ""};
+    outer("cached-instructions"; "first"; 0; 0),
+    (range(0; 3) as $b
+     | (range(0; 100) | outer("cached-instructions"; "repeated"; $b; .)),
+       outer("cached-instructions"; "resumed"; $b; 0)),
+    ("high-work", "oversized" | . as $shape
+     | range(0; 10) | outer($shape; "repeated"; 0; .)),
+    (range(0; 324) | {kind: "storage_probe_inner", duration_ms: 0, success: true})'
+}
+
+fixture | jq -s -f "$summary" | jq -e '
+  .attempts == 324 and .complete_inner_pairs == 324 and .failures == 0
+  and (.groups | length) == 9
+  and (.by_shape_phase | length) == 5
+  and ([.by_shape_phase[] | select(.shape == "cached-instructions" and .phase == "repeated")
+    | .count == 300 and .batch == null and .milliseconds.outer_ms.p90 == 2.089] | all)
+  and ([.groups[] | select(.shape == "cached-instructions" and .phase == "repeated")
+    | .count == 100 and .phase_samples == 0 and .phases_us == null
+      and .milliseconds.outer_ms == {p50: 2.049, p90: 2.089, p95: 2.094, p99: 2.098}
+      and .milliseconds.outer_minus_inner_ms == .milliseconds.outer_ms] | all)' >/dev/null
+
+reject() {
+  local mutation=$1
+  if fixture | jq -s "$mutation | .[]" | jq -s -f "$summary" >/dev/null 2>&1; then
+    echo "unexpectedly accepted invalid evidence: $mutation" >&2
+    return 1
+  fi
+}
+
+reject '.[0].success = false'
+reject '.[0].stdout_truncated = true'
+reject '.[0].guest_ms = null'
+reject '.[0].outer_us = -1'
+reject '.[324].duration_ms = null'
+reject '.[324].success = false'
+reject '.[1].index = 1'
+reject '.[0].diagnostic = "malformed"'
+reject '.[0:647]'
+
+echo 'PASS: complete-pair quantiles and invalid-evidence rejection'

--- a/docs/benchmarks/storage-helper-attribution/test-summary.sh
+++ b/docs/benchmarks/storage-helper-attribution/test-summary.sh
@@ -55,6 +55,7 @@ reject '.[0].diagnostic = "{\"spawn_us\":null}"'
 reject '.[0].diagnostic = "{}"'
 reject '.[0].diagnostic = "[]"'
 reject '.[0].diagnostic = ({cleanup_us: 10, containment_us: 20, io_setup_us: 30, join_us: 40, prepare_spawn_us: 50, wait_us: "60"} | tojson)'
+reject '.[0].diagnostic = ({cleanup_us: 10, containment_us: 20, io_setup_us: 30, join_us: 40, prepare_spawn_us: 50, wait_us: 60} | tojson) | .[1].diagnostic = (.[0].diagnostic | fromjson | . + {prepare_us: 10, spawn_us: 40} | tojson)'
 reject '.[0:647]'
 
 echo 'PASS: complete-pair quantiles and invalid-evidence rejection'

--- a/docs/benchmarks/storage-helper-attribution/test-summary.sh
+++ b/docs/benchmarks/storage-helper-attribution/test-summary.sh
@@ -29,6 +29,12 @@ fixture | jq -s -f "$summary" | jq -e '
       and .milliseconds.outer_ms == {p50: 2.049, p90: 2.089, p95: 2.094, p99: 2.098}
       and .milliseconds.outer_minus_inner_ms == .milliseconds.outer_ms] | all)' >/dev/null
 
+fixture | jq 'if .kind == "storage_probe" then
+  .diagnostic = ({cleanup_us: 10, containment_us: 20, io_setup_us: 30,
+    join_us: 40, prepare_spawn_us: 50, wait_us: 60} | tojson) else . end' \
+  | jq -s -f "$summary" | jq -e '
+    [.groups[] | .phase_samples == .count and .phases_us.wait_us.p90 == 60] | all' >/dev/null
+
 reject() {
   local mutation=$1
   if fixture | jq -s "$mutation | .[]" | jq -s -f "$summary" >/dev/null 2>&1; then
@@ -45,6 +51,10 @@ reject '.[324].duration_ms = null'
 reject '.[324].success = false'
 reject '.[1].index = 1'
 reject '.[0].diagnostic = "malformed"'
+reject '.[0].diagnostic = "{\"spawn_us\":null}"'
+reject '.[0].diagnostic = "{}"'
+reject '.[0].diagnostic = "[]"'
+reject '.[0].diagnostic = ({cleanup_us: 10, containment_us: 20, io_setup_us: 30, join_us: 40, prepare_spawn_us: 50, wait_us: "60"} | tojson)'
 reject '.[0:647]'
 
 echo 'PASS: complete-pair quantiles and invalid-evidence rejection'


### PR DESCRIPTION
## Summary

Closes #32428. Parent: #24203 (not closed by this PR).

- Record an approved, isolated development-host experiment with 3,564 successful, completely paired storage helper invocations across baseline, diagnostic and concurrent-start cohorts.
- Locate the large first-after-resume cost in `Command::spawn()` (9.188–24.815 ms in the nine refined resumed observations), versus 6–7 microseconds for command preparation. Keep cold/resumed and repeated distributions separate.
- Include pinned source/binary/image identities, precise timer boundaries, resource/tail limitations, disposable opt-in probe patches, and a tested complete-pair summarizer.

This is an attribution/decision PR. No Rust product code, protocol, resource policy, service, CI selection, or production logging changes. No optimization or fleet performance gain is claimed. Existing development services were not replaced; all experiment VMs/proxies/pools completed normal teardown.

## Validation

- Eleven real-guest trials: 3,564/3,564 complete successful pairs; content, output bounds, fallback cleanup and park/teardown gates passed.
- Summarizer CLI regression tests, Bash syntax check, ShellCheck, and summary validation against all eleven real logs passed.
- Markdown Prettier and both patches' applicability checks passed.
- Experimental Rust: formatting, Runner binary Clippy, guest-control-server all-targets/all-features Clippy, and guest-control-server rustdoc passed.
- `cargo test --profile local -p runner storage --all-targets --all-features`: 204 passed; existing subprocess helper exercised by its parent.
- `cargo test --profile local -p guest-control-server --test connection guest_storage_manifest --all-features`: 8 passed both with the experimental diagnostic assertion and without the patch.
- `cargo test --profile local -p guest-storage-apply --all-targets --all-features`: passed.

## Limits / risk

Synthetic workloads on a shared development host and the CI build profile are not the historical production cohort. Small cold samples do not establish stable p99 or identify which syscall/page-fault/scheduling component inside spawn is responsible. Concurrent-start p99 varied, so no zero-tail-regression claim is made. Experimental patches are explicitly disposable and must never be applied to active/customer-serving services.
