### PR TITLE
perf(runner): batch required connector context with agent private files

### DIFF
--- a/crates/guest-control-client/src/tests/file/write.rs
+++ b/crates/guest-control-client/src/tests/file/write.rs
@@ -141,6 +141,7 @@ async fn write_private_files_sends_one_private_batch_and_tracks_until_result() {
         vec![
             ("/tmp/private-a.txt", b"alpha".to_vec()),
             ("/tmp/private-b.txt", b"beta".to_vec()),
+            ("/tmp/private-c.txt", b"gamma".to_vec()),
         ],
     );
 
@@ -150,6 +151,7 @@ async fn write_private_files_sends_one_private_batch_and_tracks_until_result() {
         vec![
             ("/tmp/private-a.txt".to_string(), b"alpha".to_vec()),
             ("/tmp/private-b.txt".to_string(), b"beta".to_vec()),
+            ("/tmp/private-c.txt".to_string(), b"gamma".to_vec()),
         ]
     );
     assert_eq!(
@@ -229,6 +231,10 @@ async fn write_private_files_oversized_aggregate_falls_back_to_private_single_wr
                         path: "/tmp/private-b.txt",
                         content: &second,
                     },
+                    WriteFileEntry {
+                        path: "/tmp/private-c.txt",
+                        content: b"last entry",
+                    },
                 ],
                 FrameWriteObserver::default(),
             )
@@ -248,7 +254,126 @@ async fn write_private_files_oversized_aggregate_falls_back_to_private_single_wr
     assert_eq!(second.content, vec![0xB2; 600]);
     send_write_file_success(&mut guest, second.seq()).await;
 
+    let third = expect_write_file(&mut guest).await;
+    assert_eq!(third.path, "/tmp/private-c.txt");
+    assert!(third.private);
+    assert_eq!(third.content, b"last entry");
+    send_write_file_success(&mut guest, third.seq()).await;
+
     write_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn write_private_files_fallback_failure_does_not_send_later_entries() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            let content = vec![0xA1; 600];
+            write_private_files_with_small_limits(
+                &host,
+                &[
+                    WriteFileEntry {
+                        path: "/tmp/context.json",
+                        content: &content,
+                    },
+                    WriteFileEntry {
+                        path: "/tmp/env.json",
+                        content: &content,
+                    },
+                    WriteFileEntry {
+                        path: "/tmp/payload.json",
+                        content: b"last entry",
+                    },
+                ],
+                FrameWriteObserver::default(),
+            )
+            .await
+        })
+    };
+
+    let first = expect_write_file(&mut guest).await;
+    assert_eq!(first.path, "/tmp/context.json");
+    send_write_file_success(&mut guest, first.seq()).await;
+    let second = expect_write_file(&mut guest).await;
+    assert_eq!(second.path, "/tmp/env.json");
+    send_write_file_failure(&mut guest, second.seq(), "permission denied").await;
+
+    let error = write_task.await.unwrap().unwrap_err();
+    assert!(error.to_string().contains("permission denied"));
+    // A later command must be the next frame; no payload write or retry is allowed.
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn write_private_batch_missing_terminal_response_uses_one_deadline() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = spawn_write_private_files(
+        Arc::clone(&host),
+        vec![
+            ("/tmp/context.json", b"context".to_vec()),
+            ("/tmp/env.json", b"env".to_vec()),
+            ("/tmp/payload.json", b"payload".to_vec()),
+        ],
+    );
+    let write = expect_write_private_files(&mut guest).await;
+    assert_eq!(write.files.len(), 3);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    // Freeze time only after real socket I/O has reached the terminal wait.
+    tokio::time::pause();
+    tokio::time::advance(guest_contracts::file_write::WRITE_FILE_REQUEST_DEADLINE).await;
+    let error = write_task.await.unwrap().unwrap_err();
+
+    assert_request_timeout(
+        &error,
+        RequestTimeoutStage::AwaitingTerminalResponse,
+        guest_contracts::file_write::WRITE_FILE_REQUEST_DEADLINE,
+    );
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    let later_error = host
+        .write_private_file("/tmp/later.json", b"later")
+        .await
+        .unwrap_err();
+    assert_eq!(later_error.kind(), io::ErrorKind::ConnectionReset);
+}
+
+#[tokio::test]
+async fn dropping_private_batch_after_request_prevents_connection_reuse() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = spawn_write_private_files(
+        Arc::clone(&host),
+        vec![
+            ("/tmp/context.json", b"context".to_vec()),
+            ("/tmp/env.json", b"env".to_vec()),
+            ("/tmp/payload.json", b"payload".to_vec()),
+        ],
+    );
+    let write = expect_write_private_files(&mut guest).await;
+    assert_eq!(write.files.len(), 3);
+
+    write_task.abort();
+    assert!(write_task.await.unwrap_err().is_cancelled());
+
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    let error = host
+        .write_private_file("/tmp/later.json", b"later")
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::ConnectionReset);
 }
 
 #[tokio::test]

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -432,10 +432,19 @@ fn batch_mode_truncates_existing_files() {
 #[cfg(unix)]
 #[test]
 fn private_batch_mode_writes_private_files_with_restrictive_umask() {
+    use std::os::unix::fs::MetadataExt;
+
     let dir = tempfile::tempdir().unwrap();
+    let connector = dir
+        .path()
+        .join("run/connector-account-context/context.json");
     let first = dir.path().join("run/user-env/env.json");
     let second = dir.path().join("run/run-payload/payload.json");
     let payload = guest_control_proto::encode_write_files(&[
+        guest_control_proto::WriteFileBatchEntry {
+            path: connector.to_str().unwrap(),
+            content: br#"{"schemaVersion":1,"targets":[]}"#,
+        },
         guest_control_proto::WriteFileBatchEntry {
             path: first.to_str().unwrap(),
             content: b"env",
@@ -450,13 +459,30 @@ fn private_batch_mode_writes_private_files_with_restrictive_umask() {
     let output = run_helper_with_umask(&["--batch", "--private"], &payload, 0o777);
 
     assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(
+        std::fs::read(&connector).unwrap(),
+        br#"{"schemaVersion":1,"targets":[]}"#
+    );
     assert_eq!(std::fs::read(&first).unwrap(), b"env");
     assert_eq!(std::fs::read(&second).unwrap(), b"payload");
     assert_eq!(mode(&dir.path().join("run")), 0o700);
+    assert_eq!(
+        mode(&dir.path().join("run/connector-account-context")),
+        0o700
+    );
     assert_eq!(mode(&dir.path().join("run/user-env")), 0o700);
     assert_eq!(mode(&dir.path().join("run/run-payload")), 0o700);
     assert_eq!(mode(&first), 0o600);
+    assert_eq!(mode(&connector), 0o600);
     assert_eq!(mode(&second), 0o600);
+    let owner = std::fs::metadata(dir.path()).unwrap();
+    for path in [&connector, &first, &second] {
+        for owned_path in [path.as_path(), path.parent().unwrap()] {
+            let metadata = std::fs::metadata(owned_path).unwrap();
+            assert_eq!(metadata.uid(), owner.uid());
+            assert_eq!(metadata.gid(), owner.gid());
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -492,6 +518,7 @@ fn private_batch_mode_reports_later_failure_after_partial_progress() {
     std::fs::create_dir(&target).unwrap();
     std::os::unix::fs::symlink(&target, &link).unwrap();
     let second = link.join("payload.json");
+    let third = dir.path().join("run/last.json");
     let payload = guest_control_proto::encode_write_files(&[
         guest_control_proto::WriteFileBatchEntry {
             path: first.to_str().unwrap(),
@@ -500,6 +527,10 @@ fn private_batch_mode_reports_later_failure_after_partial_progress() {
         guest_control_proto::WriteFileBatchEntry {
             path: second.to_str().unwrap(),
             content: b"payload",
+        },
+        guest_control_proto::WriteFileBatchEntry {
+            path: third.to_str().unwrap(),
+            content: b"must not be written",
         },
     ])
     .unwrap();
@@ -510,6 +541,44 @@ fn private_batch_mode_reports_later_failure_after_partial_progress() {
     assert_eq!(std::fs::read(&first).unwrap(), b"env");
     assert_eq!(mode(&first), 0o600);
     assert!(!target.join("payload.json").exists());
+    assert!(!third.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn private_batch_mode_first_failure_preserves_later_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("target");
+    let link = dir.path().join("connector-account-context");
+    std::fs::create_dir(&target).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    let connector = link.join("context.json");
+    let user_env = dir.path().join("env.json");
+    let run_payload = dir.path().join("payload.json");
+    std::fs::write(&user_env, b"previous env").unwrap();
+    std::fs::write(&run_payload, b"previous payload").unwrap();
+    let payload = guest_control_proto::encode_write_files(&[
+        guest_control_proto::WriteFileBatchEntry {
+            path: connector.to_str().unwrap(),
+            content: b"context",
+        },
+        guest_control_proto::WriteFileBatchEntry {
+            path: user_env.to_str().unwrap(),
+            content: b"new env",
+        },
+        guest_control_proto::WriteFileBatchEntry {
+            path: run_payload.to_str().unwrap(),
+            content: b"new payload",
+        },
+    ])
+    .unwrap();
+
+    let output = run_helper(&["--batch", "--private"], &payload);
+
+    assert!(!output.status.success());
+    assert!(!target.join("context.json").exists());
+    assert_eq!(std::fs::read(&user_env).unwrap(), b"previous env");
+    assert_eq!(std::fs::read(&run_payload).unwrap(), b"previous payload");
 }
 
 #[test]

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -40,8 +40,7 @@ use super::diagnostics::{
 };
 use super::effective_cli_framework;
 use super::env::{
-    PreparedRunPayload, build_env_json_for_run, build_user_env_json,
-    write_connector_account_context_file, write_required_agent_files,
+    PreparedRunPayload, build_env_json_for_run, build_user_env_json, write_required_agent_files,
 };
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::session_history_cpu::{SessionHistoryCpuJob, SessionHistoryPrefixOutcome};
@@ -2030,37 +2029,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // to bootstrap guest-agent. User-provided env is passed through a private
     // guest file and injected into the CLI child after guest-agent has started.
     let mut user_env_map = build_user_env_json(context);
-    let connector_account_context_started = Instant::now();
-    match write_connector_account_context_file(sandbox, context).await {
-        Ok(path) => {
-            telemetry.record(
-                "runner_connector_account_context_write",
-                connector_account_context_started.elapsed(),
-                true,
-                None,
-            );
-            user_env_map.insert(
-                guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV.to_string(),
-                path,
-            );
-        }
-        Err(error) => {
-            let outcome = private_write_timeout_stage(&error);
-            telemetry.record_with_outcome(
-                "runner_connector_account_context_write",
-                connector_account_context_started.elapsed(),
-                false,
-                Some("connector account context unavailable"),
-                outcome,
-            );
-            warn!(
-                run_id = %context.run_id,
-                outcome = outcome.unwrap_or("write_failed"),
-                "connector account context unavailable"
-            );
-            return Err(error);
-        }
-    }
     let env_build_started = Instant::now();
     let run_payload = match prepared_run_payload.into_run_payload(context) {
         Ok(run_payload) => run_payload,
@@ -2113,7 +2081,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 
     let required_private_files_started = Instant::now();
     let required_files =
-        match write_required_agent_files(sandbox, context.run_id, &user_env_map, &run_payload).await {
+        match write_required_agent_files(sandbox, context, &mut user_env_map, &run_payload).await {
             Ok(required_files) => {
                 telemetry.record(
                     "runner_required_private_files_write",
@@ -2136,12 +2104,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         };
     let user_env_file = required_files.user_env_file;
     let run_payload_file = required_files.run_payload_file;
-    if let Some(path) = user_env_file {
-        env_map.insert(
-            guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV.into(),
-            path,
-        );
-    }
+    env_map.insert(
+        guest_contracts::env::CANONICAL_USER_ENV_FILE_ENV.into(),
+        user_env_file,
+    );
     env_map.insert(
         guest_contracts::env::CANONICAL_RUN_PAYLOAD_FILE_ENV.into(),
         run_payload_file,

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -787,10 +787,7 @@ pub(super) fn guest_connector_account_context_file_path(run_id: RunId) -> Runner
     })
 }
 
-pub(super) async fn write_connector_account_context_file(
-    sandbox: &dyn Sandbox,
-    context: &ExecutionContext,
-) -> RunnerResult<String> {
+fn build_connector_account_context(context: &ExecutionContext) -> RunConnectorAccountContext {
     let targets = context
         .connector_runtime_targets
         .iter()
@@ -813,54 +810,55 @@ pub(super) async fn write_connector_account_context_file(
             },
         })
         .collect();
-    let payload = serde_json::to_vec(&RunConnectorAccountContext {
+    RunConnectorAccountContext {
         schema_version: guest_contracts::connector_account_context::SCHEMA_VERSION,
         targets,
-    })
-    .map_err(|e| RunnerError::Internal(format!("serialize connector account context: {e}")))?;
-    let file_path = guest_connector_account_context_file_path(context.run_id)?;
-    sandbox.write_private_file(&file_path, &payload).await?;
-    Ok(file_path)
+    }
 }
 
 pub(super) struct RequiredAgentFiles {
-    pub(super) user_env_file: Option<String>,
+    pub(super) user_env_file: String,
     pub(super) run_payload_file: String,
 }
 
 pub(super) async fn write_required_agent_files(
     sandbox: &dyn Sandbox,
-    run_id: RunId,
-    user_env: &HashMap<String, String>,
+    context: &ExecutionContext,
+    user_env: &mut HashMap<String, String>,
     run_payload: &guest_contracts::env::RunPayload,
 ) -> RunnerResult<RequiredAgentFiles> {
-    let run_payload_file = guest_run_payload_file_path(run_id)?;
+    let connector_context_file = guest_connector_account_context_file_path(context.run_id)?;
+    let connector_context_bytes = serde_json::to_vec(&build_connector_account_context(context))
+        .map_err(|e| RunnerError::Internal(format!("serialize connector account context: {e}")))?;
+    user_env.insert(
+        guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV.to_string(),
+        connector_context_file.clone(),
+    );
+    let user_env_file = guest_user_env_file_path(context.run_id)?;
+    let user_env_bytes = serde_json::to_vec(user_env)
+        .map_err(|e| RunnerError::Internal(format!("serialize user env: {e}")))?;
+    let run_payload_file = guest_run_payload_file_path(context.run_id)?;
     let run_payload_bytes = serde_json::to_vec(run_payload)
         .map_err(|e| RunnerError::Internal(format!("serialize run payload: {e}")))?;
 
-    let user_env_file = if user_env.is_empty() {
-        sandbox
-            .write_private_file(&run_payload_file, &run_payload_bytes)
-            .await?;
-        None
-    } else {
-        let user_env_file = guest_user_env_file_path(run_id)?;
-        let user_env_bytes = serde_json::to_vec(user_env)
-            .map_err(|e| RunnerError::Internal(format!("serialize user env: {e}")))?;
-        sandbox
-            .write_private_files(&[
-                WriteFileEntry {
-                    path: &user_env_file,
-                    content: &user_env_bytes,
-                },
-                WriteFileEntry {
-                    path: &run_payload_file,
-                    content: &run_payload_bytes,
-                },
-            ])
-            .await?;
-        Some(user_env_file)
-    };
+    // All bootstrap inputs are required. Keep context first so a failed account
+    // projection write prevents later writes, including in oversized fallback.
+    sandbox
+        .write_private_files(&[
+            WriteFileEntry {
+                path: &connector_context_file,
+                content: &connector_context_bytes,
+            },
+            WriteFileEntry {
+                path: &user_env_file,
+                content: &user_env_bytes,
+            },
+            WriteFileEntry {
+                path: &run_payload_file,
+                content: &run_payload_bytes,
+            },
+        ])
+        .await?;
 
     Ok(RequiredAgentFiles {
         user_env_file,

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -6,7 +6,6 @@ use api_contracts::generated::types::runners::{
 };
 use guest_contracts::env::{RunArtifact, RunArtifactMissingRootPolicy};
 use sandbox::SandboxId;
-use sandbox_mock::MockSandbox;
 use serde_json::json;
 
 use super::super::cli_framework::{
@@ -14,9 +13,8 @@ use super::super::cli_framework::{
 };
 use super::super::env::{
     HostEnv, build_env_json_with_host_env, build_env_json_with_host_env_for_run,
-    build_run_payload_for_run, build_user_env_json, guest_connector_account_context_file_path,
-    is_runner_owned_env_key, validate_execution_context_before_sandbox,
-    validate_model_provider_env_placeholders, write_connector_account_context_file,
+    build_run_payload_for_run, build_user_env_json, is_runner_owned_env_key,
+    validate_execution_context_before_sandbox, validate_model_provider_env_placeholders,
 };
 use super::super::guest_runtime_dir;
 use super::support::{
@@ -26,10 +24,7 @@ use super::support::{
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::storage_manifest::StorageManifest;
-use crate::types::{
-    ConnectorRuntimeTargetRegistration, ExecutionContext, ResumeSession, SandboxReuseResult,
-    WorkspaceReuseResult,
-};
+use crate::types::{ExecutionContext, ResumeSession, SandboxReuseResult, WorkspaceReuseResult};
 
 fn validate_context_for_test(ctx: &ExecutionContext) -> Result<(), String> {
     let sandbox_id = SandboxId::new_v4().to_string();
@@ -981,83 +976,6 @@ fn build_env_json_user_vars_cannot_override_system() {
     assert!(!env.contains_key("CUSTOM"));
     assert_eq!(user_env.get("CUSTOM").unwrap(), "value");
     assert_eq!(user_env.get("CUSTOM_PROMPT").unwrap(), "overridden");
-}
-
-#[tokio::test]
-async fn write_connector_account_context_file_projects_only_target_and_source() {
-    let sandbox = MockSandbox::new("test");
-    let mut context = minimal_context();
-    context.connector_runtime_targets = vec![
-        ConnectorRuntimeTargetRegistration::Builtin {
-            connector_slug: "github".to_string(),
-            base_url_vars: Some(HashMap::from([(
-                "API_ORIGIN".to_string(),
-                "https://api.github.com".to_string(),
-            )])),
-            source_id: Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
-        },
-        ConnectorRuntimeTargetRegistration::Custom {
-            custom_connector_id: "550e8400-e29b-41d4-a716-446655440001".to_string(),
-            base_url_vars: HashMap::from([(
-                "CUSTOM_ORIGIN".to_string(),
-                "https://custom.example.test".to_string(),
-            )]),
-            source_id: None,
-        },
-    ];
-
-    let path = write_connector_account_context_file(&sandbox, &context)
-        .await
-        .unwrap();
-
-    assert_eq!(
-        path,
-        guest_connector_account_context_file_path(context.run_id).unwrap()
-    );
-    let writes = sandbox.private_write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(writes[0].path, path);
-    let decoded: guest_contracts::connector_account_context::RunConnectorAccountContext =
-        serde_json::from_slice(&writes[0].content).unwrap();
-    assert_eq!(
-        decoded,
-        guest_contracts::connector_account_context::RunConnectorAccountContext {
-            schema_version: guest_contracts::connector_account_context::SCHEMA_VERSION,
-            targets: vec![
-                guest_contracts::connector_account_context::RunConnectorAccountTarget::Builtin {
-                    connector_slug: "github".to_string(),
-                    connection_id: Some("550e8400-e29b-41d4-a716-446655440000".to_string(),),
-                },
-                guest_contracts::connector_account_context::RunConnectorAccountTarget::Custom {
-                    custom_connector_id: "550e8400-e29b-41d4-a716-446655440001".to_string(),
-                    connection_id: None,
-                },
-            ],
-        }
-    );
-}
-
-#[tokio::test]
-async fn write_connector_account_context_file_writes_known_empty_projection() {
-    let sandbox = MockSandbox::new("test");
-    let context = minimal_context();
-
-    let path = write_connector_account_context_file(&sandbox, &context)
-        .await
-        .unwrap();
-
-    let writes = sandbox.private_write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(writes[0].path, path);
-    let decoded: guest_contracts::connector_account_context::RunConnectorAccountContext =
-        serde_json::from_slice(&writes[0].content).unwrap();
-    assert_eq!(
-        decoded,
-        guest_contracts::connector_account_context::RunConnectorAccountContext {
-            schema_version: guest_contracts::connector_account_context::SCHEMA_VERSION,
-            targets: Vec::new(),
-        }
-    );
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -1390,12 +1390,18 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     ctx.connector_runtime_targets = vec![
         ConnectorRuntimeTargetRegistration::Builtin {
             connector_slug: "github".into(),
-            base_url_vars: None,
+            base_url_vars: Some(HashMap::from([(
+                "API_ORIGIN".into(),
+                "https://api.github.com".into(),
+            )])),
             source_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
         },
         ConnectorRuntimeTargetRegistration::Custom {
             custom_connector_id: "550e8400-e29b-41d4-a716-446655440001".into(),
-            base_url_vars: HashMap::new(),
+            base_url_vars: HashMap::from([(
+                "CUSTOM_ORIGIN".into(),
+                "https://custom.example.test".into(),
+            )]),
             source_id: None,
         },
     ];
@@ -1472,18 +1478,18 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
             .all(|call| !call.cmd.contains(&expected_user_env_file)),
         "user env file should not be written through shell exec"
     );
-    let private_writes = overrides.private_write_file_calls();
-    assert_eq!(private_writes.len(), 1);
-    let connector_account_context_write = private_writes
-        .iter()
-        .find(|write| write.path == expected_connector_account_context_file)
-        .unwrap();
+    assert!(overrides.private_write_file_calls().is_empty());
     let private_batches = overrides.private_write_files_calls();
     assert_eq!(private_batches.len(), 1);
-    assert_eq!(private_batches[0].files.len(), 2);
-    let user_env_write = &private_batches[0].files[0];
+    assert_eq!(private_batches[0].files.len(), 3);
+    let connector_account_context_write = &private_batches[0].files[0];
+    assert_eq!(
+        connector_account_context_write.path,
+        expected_connector_account_context_file
+    );
+    let user_env_write = &private_batches[0].files[1];
     assert_eq!(user_env_write.path, expected_user_env_file);
-    let run_payload_write = &private_batches[0].files[1];
+    let run_payload_write = &private_batches[0].files[2];
     assert_eq!(run_payload_write.path, expected_run_payload_file);
     let user_env: HashMap<String, String> =
         serde_json::from_slice(&user_env_write.content).unwrap();
@@ -1549,11 +1555,11 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
 }
 
 #[tokio::test]
-async fn execute_inner_stops_when_connector_account_context_write_fails() {
+async fn execute_inner_stops_when_required_private_batch_fails() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.push_private_write_file_result(Err(sandbox_write_file_error(
+    overrides.push_private_write_files_result(Err(sandbox_write_file_error(
         "connector account context write failed",
     )));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
@@ -1570,13 +1576,34 @@ async fn execute_inner_stops_when_connector_account_context_write_fails() {
             .expect("connector account context write failure should fail the run")
             .contains("connector account context write failed")
     );
-    let private_writes = overrides.private_write_file_calls();
-    assert_eq!(private_writes.len(), 1);
-    assert!(overrides.private_write_files_calls().is_empty());
+    assert!(overrides.private_write_file_calls().is_empty());
+    let private_batches = overrides.private_write_files_calls();
+    assert_eq!(private_batches.len(), 1);
+    assert_eq!(private_batches[0].files.len(), 3);
     assert_eq!(
-        private_writes[0].path,
+        private_batches[0].files[0].path,
         guest_connector_account_context_file_path(context.run_id).unwrap()
     );
+    assert!(overrides.start_agent_process_calls().is_empty());
+}
+
+#[tokio::test]
+async fn execute_inner_rejects_invalid_run_payload_before_private_writes() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let mut context = minimal_context();
+    context.prompt = "invalid\0prompt".into();
+
+    let error = run_new_sandbox_outcome(&factory, &context, &config, &default_params())
+        .await
+        .err()
+        .expect("invalid payload must fail before execution");
+
+    assert!(error.to_string().contains("run payload contains NUL byte"));
+    assert!(overrides.private_write_file_calls().is_empty());
+    assert!(overrides.private_write_files_calls().is_empty());
     assert!(overrides.start_agent_process_calls().is_empty());
 }
 
@@ -1585,7 +1612,6 @@ async fn execute_inner_run_payload_enospc_collects_resources_without_starting_ag
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    overrides.push_private_write_file_result(Ok(()));
     overrides.push_private_write_files_result(Err(sandbox_write_file_error(
         "No space left on device (os error 28)",
     )));
@@ -1616,24 +1642,23 @@ async fn execute_inner_run_payload_enospc_collects_resources_without_starting_ag
             .failure_kind,
         Some(ResourceFailureKind::GuestRootFilesystemFull)
     );
-    let private_writes = overrides.private_write_file_calls();
-    assert_eq!(private_writes.len(), 1);
+    assert!(overrides.private_write_file_calls().is_empty());
+    let private_batches = overrides.private_write_files_calls();
+    assert_eq!(private_batches.len(), 1);
+    assert_eq!(private_batches[0].files.len(), 3);
     assert!(
-        private_writes[0]
+        private_batches[0].files[0]
             .path
             .ends_with("/connector-account-context/context.json"),
         "got: {}",
-        private_writes[0].path
+        private_batches[0].files[0].path
     );
-    let private_batches = overrides.private_write_files_calls();
-    assert_eq!(private_batches.len(), 1);
-    assert_eq!(private_batches[0].files.len(), 2);
     assert!(
-        private_batches[0].files[1]
+        private_batches[0].files[2]
             .path
             .ends_with("/run-payload/payload.json"),
         "got: {}",
-        private_batches[0].files[1].path
+        private_batches[0].files[2].path
     );
     assert!(
         overrides.start_agent_process_calls().is_empty(),

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -25,12 +25,38 @@ fn context_with_remote_storage(archive_url: &str, archive_size: usize) -> Execut
 
 #[tokio::test]
 async fn execute_job_reuse_succeeds() {
+    for clear_accounts in [false, true] {
+        assert_reused_connector_projection(clear_accounts).await;
+    }
+}
+
+async fn assert_reused_connector_projection(clear_accounts: bool) {
+    use crate::types::ConnectorRuntimeTargetRegistration;
+    use guest_contracts::connector_account_context::{
+        RunConnectorAccountContext, RunConnectorAccountTarget,
+    };
+
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut first_context = minimal_context();
     first_context.run_id = RunId::new_v4();
+    let targets = vec![
+        ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "github".into(),
+            base_url_vars: None,
+            source_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
+        },
+        ConnectorRuntimeTargetRegistration::Builtin {
+            connector_slug: "github".into(),
+            base_url_vars: None,
+            source_id: Some("550e8400-e29b-41d4-a716-446655440001".into()),
+        },
+    ];
+    if clear_accounts {
+        first_context.connector_runtime_targets = targets.clone();
+    }
 
     // First: create a sandbox via normal execute_job
     let cancel = tokio_util::sync::CancellationToken::new();
@@ -55,6 +81,9 @@ async fn execute_job_reuse_succeeds() {
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut reused_context = minimal_context();
     reused_context.run_id = RunId::new_v4();
+    if !clear_accounts {
+        reused_context.connector_runtime_targets = targets;
+    }
     let reused_context_path =
         guest_connector_account_context_file_path(reused_context.run_id).unwrap();
     let (reuse_outcome, _telemetry) = execute_job_reuse(
@@ -69,12 +98,17 @@ async fn execute_job_reuse_succeeds() {
     assert!(reuse_outcome.error().is_none());
     assert!(reuse_outcome.sandbox.is_some());
     let connector_account_context_writes = overrides
-        .private_write_file_calls()
+        .private_write_files_calls()
         .into_iter()
-        .filter(|write| {
-            write
-                .path
-                .ends_with("/connector-account-context/context.json")
+        .map(|batch| {
+            assert_eq!(batch.files.len(), 3);
+            let user_env: HashMap<String, String> =
+                serde_json::from_slice(&batch.files[1].content).unwrap();
+            assert_eq!(
+                user_env[guest_contracts::env::CONNECTOR_ACCOUNT_CONTEXT_FILE_ENV],
+                batch.files[0].path,
+            );
+            batch.files[0].clone()
         })
         .collect::<Vec<_>>();
     assert_eq!(connector_account_context_writes.len(), 2);
@@ -82,6 +116,33 @@ async fn execute_job_reuse_succeeds() {
         connector_account_context_writes[1].path,
         reused_context_path
     );
+    assert!(overrides.private_write_file_calls().is_empty());
+    let selected = vec![
+        RunConnectorAccountTarget::Builtin {
+            connector_slug: "github".into(),
+            connection_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
+        },
+        RunConnectorAccountTarget::Builtin {
+            connector_slug: "github".into(),
+            connection_id: Some("550e8400-e29b-41d4-a716-446655440001".into()),
+        },
+    ];
+    let expected = if clear_accounts {
+        [selected, Vec::new()]
+    } else {
+        [Vec::new(), selected]
+    };
+    for (write, targets) in connector_account_context_writes.iter().zip(expected) {
+        let projection: RunConnectorAccountContext =
+            serde_json::from_slice(&write.content).unwrap();
+        assert_eq!(
+            projection,
+            RunConnectorAccountContext {
+                schema_version: guest_contracts::connector_account_context::SCHEMA_VERSION,
+                targets,
+            }
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -1987,7 +1987,6 @@ async fn assert_reused_private_write_timeout_telemetry(
     let source_ip = sandbox.source_ip().to_string();
     let (idle_sandbox, _lease) =
         make_reusable_idle_sandbox(sandbox, source_ip, "test-session").await;
-    overrides.push_private_write_file_result(Ok(()));
     overrides.push_private_write_files_result(Err(SandboxError::OperationTimeout {
         operation: SandboxOperation::WriteFile,
         stage,
@@ -2024,11 +2023,11 @@ async fn assert_reused_private_write_timeout_telemetry(
     );
     assert_lacks_action(&telemetry, "runner_agent_start_process");
     assert!(overrides.start_agent_process_calls().is_empty());
-    assert_eq!(overrides.private_write_file_calls().len(), 1);
+    assert!(overrides.private_write_file_calls().is_empty());
     assert_eq!(overrides.private_write_files_calls().len(), 1);
 }
 
-async fn assert_reused_connector_account_context_failure(
+async fn assert_reused_required_private_batch_failure(
     error: SandboxError,
     expected_outcome: Option<&str>,
 ) {
@@ -2036,9 +2035,9 @@ async fn assert_reused_connector_account_context_failure(
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(MockSandboxOverrides::new());
     let expected_failure = format!("sandbox error: {error}");
-    overrides.push_private_write_file_result(Err(error));
+    overrides.push_private_write_files_result(Err(error));
     let sandbox = Box::new(MockSandbox::with_overrides(
-        "connector-account-context-failure",
+        "required-private-batch-failure",
         Arc::clone(&overrides),
     ));
     let source_ip = sandbox.source_ip().to_string();
@@ -2068,7 +2067,7 @@ async fn assert_reused_connector_account_context_failure(
     let operations = telemetry.pending_ops_with_outcome_snapshot();
     let matching: Vec<_> = operations
         .iter()
-        .filter(|operation| operation.0 == "runner_connector_account_context_write")
+        .filter(|operation| operation.0 == "runner_required_private_files_write")
         .collect();
     assert_eq!(matching.len(), 1);
     assert!(!matching[0].1);
@@ -2076,32 +2075,35 @@ async fn assert_reused_connector_account_context_failure(
     assert_eq!(matching[0].3, None);
     assert_action_outcome(
         &telemetry,
-        "runner_connector_account_context_write",
+        "runner_required_private_files_write",
         false,
-        Some("connector account context unavailable"),
+        None,
     );
 
     assert!(outcome.sandbox.is_some());
     let failure = outcome
         .failure
-        .expect("connector context failure should stop the run");
+        .expect("required private batch failure should stop the run");
     assert_eq!(failure.error, expected_failure);
     assert_eq!(
         outcome.sandbox_reuse_disposition,
         SandboxReuseDisposition::Ineligible(SandboxReuseRejection::ExecutionUncertain)
     );
-    assert_lacks_action(&telemetry, "runner_required_private_files_write");
     assert_lacks_action(&telemetry, "runner_agent_start_process");
     assert!(overrides.start_agent_process_calls().is_empty());
-    let private_writes = overrides.private_write_file_calls();
-    assert_eq!(private_writes.len(), 1);
-    assert_eq!(private_writes[0].path, expected_connector_context_path);
-    assert!(overrides.private_write_files_calls().is_empty());
+    assert!(overrides.private_write_file_calls().is_empty());
+    let private_batches = overrides.private_write_files_calls();
+    assert_eq!(private_batches.len(), 1);
+    assert_eq!(private_batches[0].files.len(), 3);
+    assert_eq!(
+        private_batches[0].files[0].path,
+        expected_connector_context_path
+    );
 }
 
 #[tokio::test]
-async fn reused_connector_account_context_guest_failure_stops() {
-    assert_reused_connector_account_context_failure(
+async fn reused_required_private_batch_guest_failure_stops() {
+    assert_reused_required_private_batch_failure(
         SandboxError::Operation {
             operation: SandboxOperation::WriteFile,
             reason: SandboxOperationReason::Guest,
@@ -2113,8 +2115,8 @@ async fn reused_connector_account_context_guest_failure_stops() {
 }
 
 #[tokio::test]
-async fn reused_connector_account_context_before_frame_timeout_stops() {
-    assert_reused_connector_account_context_failure(
+async fn reused_required_private_batch_before_frame_timeout_stops() {
+    assert_reused_required_private_batch_failure(
         SandboxError::OperationTimeout {
             operation: SandboxOperation::WriteFile,
             stage: SandboxOperationTimeoutStage::BeforeFrameWrite,
@@ -2126,8 +2128,8 @@ async fn reused_connector_account_context_before_frame_timeout_stops() {
 }
 
 #[tokio::test]
-async fn reused_connector_account_context_frame_write_timeout_stops() {
-    assert_reused_connector_account_context_failure(
+async fn reused_required_private_batch_frame_write_timeout_stops() {
+    assert_reused_required_private_batch_failure(
         SandboxError::OperationTimeout {
             operation: SandboxOperation::WriteFile,
             stage: SandboxOperationTimeoutStage::FrameWrite,
@@ -2139,8 +2141,8 @@ async fn reused_connector_account_context_frame_write_timeout_stops() {
 }
 
 #[tokio::test]
-async fn reused_connector_account_context_terminal_response_timeout_stops() {
-    assert_reused_connector_account_context_failure(
+async fn reused_required_private_batch_terminal_response_timeout_stops() {
+    assert_reused_required_private_batch_failure(
         SandboxError::OperationTimeout {
             operation: SandboxOperation::WriteFile,
             stage: SandboxOperationTimeoutStage::AwaitingTerminalResponse,
@@ -2152,8 +2154,8 @@ async fn reused_connector_account_context_terminal_response_timeout_stops() {
 }
 
 #[tokio::test]
-async fn reused_connector_account_context_backend_crash_stops() {
-    assert_reused_connector_account_context_failure(
+async fn reused_required_private_batch_backend_crash_stops() {
+    assert_reused_required_private_batch_failure(
         SandboxError::Operation {
             operation: SandboxOperation::WriteFile,
             reason: SandboxOperationReason::BackendCrashed,

--- a/docs/runner-guest-process-lifecycle.md
+++ b/docs/runner-guest-process-lifecycle.md
@@ -116,6 +116,20 @@ whether this is a request deadline or whether the sandbox can be reused.
 
 ## Agent Start Timing
 
+Required Agent bootstrap files are written in connector-context, user-environment,
+then run-payload order through the existing bounded private-file operation.
+`runner_required_private_files_write` measures this entire operation, including
+serialization and oversized sequential/chunked fallback. It is not a transaction:
+any failure prevents Agent start, but earlier entries may already have been written.
+A fitting batch shares one 30-second guest-helper budget and one 60-second request
+deadline; fallback retains the existing deadline per transmitted request.
+
+The former `runner_connector_account_context_write` event is no longer emitted.
+For historical comparisons, sum that old interval and the old
+`runner_required_private_files_write` interval per run before aggregating. Do not
+compare the old two-file interval alone against the new three-file interval or
+infer independent per-file wall-clock durations from the batch.
+
 `runner_agent_start_process`, `runner_executor_start_to_spawn`,
 `runner_claim_to_spawn`, and `api_to_spawn` retain their historical shell-spawn
 boundary. Agent readiness is recorded separately by


### PR DESCRIPTION
## Summary

- Write required connector context, user environment, and run payload in one existing bounded private batch, in that order. Prepare/serialize all three before guest I/O and expose bootstrap paths only after success.
- Preserve exact multi-account and known-empty projections, private ownership/modes, symlink rejection, initiating errors, no-Agent-start on failure, cancellation fencing, and the existing oversized sequential/chunked path.
- Consolidate timing into `runner_required_private_files_write`; document historical comparison and the shared fitting-batch deadline. Remove the obsolete standalone connector writer and unreachable optional-env branch.

Closes #32427. Parent objective: #24203 (not closed by this PR).

## Performance validation

Controlled local-11 benchmark, same baseline-built guests/rootfs/snapshot, locked optimized Runner builds, mock-Claude `true`, path-verified exact reuse. Baseline: 150 samples across three rounds; candidate: 100 across two interleaved rounds.

| Interval | Baseline p50 / p90 | Candidate p50 / p90 | Mean gain |
| --- | --- | --- | --- |
| Combined private writes | 8 / 14 ms | 4 / 6 ms | 4.57 ms |
| Executor to shell spawn | 38 / 46 ms | 33 / 40 ms | 4.71 ms |
| Executor to Agent ready | 40 / 48 ms | 35 / 42 ms | 4.52 ms |

624 successful submissions including warmups/eviction helpers; fresh/workspace/exact auxiliary paths each 40 samples per variant, blank pool 10 per variant. An initial workspace tail outlier was dominated by VM preparation before the changed batch and did not recur in the reverse-order 30-sample repeat. Not every small-cohort tail percentile improved; this is not a production latency/SLO claim. No repeatable candidate-only resource regression was observed. The task-owned Runner and loopback collector were stopped, without stopping others' services or purging shared caches.

[Full measurements, binary/image identities, percentiles, outliers, resources, and limitations](https://github.com/vm0-ai/vm0/issues/32427#issuecomment-5580335474).

## Validation

From `crates/`:

- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p runner -p guest-control-client -p guest-write-file -p guest-control-tests --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local --no-deps -p runner -p guest-control-client -p guest-write-file -p guest-control-tests --all-features`
- `cargo test --profile local -p runner -p guest-control-client -p guest-write-file -p guest-control-tests --all-targets --all-features -- --quiet`: final run **4032 passed**, no failures; 28 pre-existing ignored helper tests, none added or skipped by this change.
- Markdown Prettier and `git diff --check` passed.

Intermediate runs exposed two unchanged timing tests; their exact-filter reruns and the final complete suite passed. Separate follow-ups: #32542 and #32543. `scripts/prepare.sh` ran before investigating; its unrelated local DB migration encountered an existing `chat_thread_event_kind` enum. Rust checks do not use that database.

## Risks and exclusions

- A fitting three-file batch shares the existing 30-second guest-helper / 60-second request budget. Oversized requests retain existing per-request deadlines. The operation is ordered, not transactional: earlier entries may remain after later failure, and Agent start/reuse stay blocked.
- The combined telemetry interval is intentionally broader; sum the two historical intervals per run when comparing old releases.
- No protocol, API, queue, authority, credential, file-format, cleanup-policy, deadline-constant, or guest production code changes. No new runtime writer service, retries, compatibility branch, or benchmark instrumentation. Sibling performance work remains out of scope.
