### PR TITLE
fix(api): use current workflow schedules in completion callbacks

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-automation-scheduler.test.ts
@@ -1,7 +1,10 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { testWorkflowAutomationExecutionContract } from "@okouai/api-contracts/contracts/test-workflow-automation-execution";
-import { workflowAutomationsContract } from "@okouai/api-contracts/contracts/workflows";
+import {
+  workflowAutomationsContract,
+  type WorkflowSchedule,
+} from "@okouai/api-contracts/contracts/workflows";
 import {
   agentsByIdContract,
   agentsMainContract,
@@ -279,6 +282,27 @@ async function completeRunThroughSandbox(
     sandboxHeaders,
     [200],
   );
+}
+
+async function waitForScheduleCallback(
+  scenario: Scenario,
+  runId: string,
+): Promise<void> {
+  await expect
+    .poll(async () => {
+      const callbacks = await store.set(
+        readAgentRunCallbacks$,
+        { orgId: scenario.orgId, userId: scenario.userId, runId },
+        context.signal,
+      );
+      return callbacks.find((callback) => {
+        return (
+          callback.internalKind === "workflow-automation:cron" ||
+          callback.internalKind === "workflow-automation:loop"
+        );
+      })?.status;
+    })
+    .toBe("delivered");
 }
 
 async function deleteWorkflowViaApi(scenario: Scenario): Promise<void> {
@@ -736,6 +760,103 @@ describe("okou workflow automation scheduler", () => {
     expect(Date.parse(read.nextRunAt)).toBeGreaterThanOrEqual(before + 290_000);
     await disableAutomation(automation.automationId);
   });
+
+  it.each([
+    {
+      change: "cron time and timezone",
+      originalSchedule: {
+        type: "cron",
+        cronExpression: "30 9 * * 1-5",
+        timezone: "Asia/Shanghai",
+      },
+      updatedSchedule: {
+        type: "cron",
+        cronExpression: "0 1 * * 1-5",
+        timezone: "UTC",
+      },
+      expectedNextRunAt: "2026-09-09T01:00:00.000Z",
+    },
+    {
+      change: "cron to loop",
+      originalSchedule: {
+        type: "cron",
+        cronExpression: "30 9 * * 1-5",
+        timezone: "Asia/Shanghai",
+      },
+      updatedSchedule: { type: "loop", intervalSeconds: 3600 },
+      expectedNextRunAt: "2026-09-08T03:35:10.634Z",
+    },
+    {
+      change: "loop to cron",
+      originalSchedule: { type: "loop", intervalSeconds: 300 },
+      updatedSchedule: {
+        type: "cron",
+        cronExpression: "0 1 * * 1-5",
+        timezone: "UTC",
+      },
+      expectedNextRunAt: "2026-09-09T01:00:00.000Z",
+    },
+    {
+      change: "cron to once",
+      originalSchedule: {
+        type: "cron",
+        cronExpression: "30 9 * * 1-5",
+        timezone: "Asia/Shanghai",
+      },
+      updatedSchedule: {
+        type: "once",
+        atTime: "2026-09-08T04:00:00.000Z",
+        timezone: "UTC",
+      },
+      expectedNextRunAt: "2026-09-08T04:00:00.000Z",
+    },
+  ] satisfies {
+    readonly change: string;
+    readonly originalSchedule: WorkflowSchedule;
+    readonly updatedSchedule: WorkflowSchedule;
+    readonly expectedNextRunAt: string;
+  }[])(
+    "uses the current schedule after an in-flight $change edit",
+    async ({ originalSchedule, updatedSchedule, expectedNextRunAt }) => {
+      mockNow(Date.parse("2026-09-08T01:29:00.000Z"));
+      const scenario = await setup({ timezone: "Asia/Shanghai" });
+      const created = await accept(
+        automationsClient().create({
+          headers: authHeaders(),
+          params: { workflowId: scenario.workflowId },
+          body: { schedule: originalSchedule },
+        }),
+        [201],
+      );
+
+      mockNow(Date.parse("2026-09-08T01:30:50.668Z"));
+      const threadId = await executeDueWorkflowAutomations(created.body.id);
+      const run = await onlyWorkflowRunMessage(threadId);
+
+      mockNow(Date.parse("2026-09-08T02:24:37.180Z"));
+      const updated = await accept(
+        automationsClient().update({
+          headers: authHeaders(),
+          params: { id: created.body.id },
+          body: { schedule: updatedSchedule },
+        }),
+        [200],
+      );
+      expect(updated.body.schedule).toStrictEqual(updatedSchedule);
+
+      mockNow(Date.parse("2026-09-08T02:35:10.634Z"));
+      await completeRunThroughSandbox(scenario, run.runId, 0);
+      // The edit already seeded nextRunAt; wait for the old callback before
+      // checking it so an eventual stale overwrite cannot pass unnoticed.
+      await waitForScheduleCallback(scenario, run.runId);
+      await expect(wf.readAutomation(created.body.id)).resolves.toMatchObject({
+        schedule: updatedSchedule,
+        enabled: true,
+        nextRunAt: expectedNextRunAt,
+      });
+      await disableAutomation(created.body.id);
+    },
+  );
 
   it("disables every workflow automation bound to a deleted chat thread", async () => {
     const scenario = await setup();

--- a/turbo/apps/api/src/signals/services/time-automation.ts
+++ b/turbo/apps/api/src/signals/services/time-automation.ts
@@ -15,14 +15,12 @@ export function calculateNextRun(
 
 /**
  * Next run after a completion callback (the run finished, success or failure).
- * Cron advances from the cron expression captured at dispatch (null when the
- * one-time callback carried no expression); a loop advances by the automation's
- * interval and requires one to be present. Disabling collapses the next run to
- * null.
+ * Cron and loop use the automation's current persisted schedule. A loop requires
+ * an interval to be present. Disabling collapses the next run to null.
  */
 export function advanceTimeAutomationAfterCompletion(args: {
   readonly scheduleType: "cron" | "loop";
-  readonly cronExpression: string | undefined;
+  readonly cronExpression: string | null;
   readonly intervalSeconds: number | null;
   readonly timezone: string;
   readonly completedAt: Date;

--- a/turbo/apps/api/src/signals/services/workflow-automation-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-automation-run-callback.service.ts
@@ -75,66 +75,75 @@ export async function handleWorkflowAutomationInternalCallback(
     return { success: true, skipped: true };
   }
 
-  const [automation] = await db
-    .select(workflowAutomationColumns())
-    .from(workflowAutomations)
-    .where(eq(workflowAutomations.id, payload.data.automationId))
-    .limit(1);
-  signal?.throwIfAborted();
+  return await db.transaction(async (tx) => {
+    // Serialize completion with schedule edits so the entire current schedule
+    // remains authoritative until its next run has been written.
+    const [automation] = await tx
+      .select(workflowAutomationColumns())
+      .from(workflowAutomations)
+      .where(eq(workflowAutomations.id, payload.data.automationId))
+      .limit(1)
+      .for("update");
+    signal?.throwIfAborted();
 
-  if (!automation || !automation.enabled) {
-    return { success: true, skipped: true };
-  }
+    if (
+      !automation ||
+      !automation.enabled ||
+      (automation.scheduleType !== "cron" && automation.scheduleType !== "loop")
+    ) {
+      // A newly configured one-time schedule keeps its own next run.
+      return { success: true, skipped: true };
+    }
 
-  const completedAt = nowDate();
-  const [failedRun] =
-    input.callback.status === "failed"
-      ? await db
-          .select({ failureReason: agentRuns.failureReason })
-          .from(agentRuns)
-          .where(
-            and(
-              eq(agentRuns.id, input.callback.runId),
-              eq(agentRuns.orgId, automation.orgId),
-            ),
-          )
-          .limit(1)
-      : [];
-  signal?.throwIfAborted();
-  const isCreditError = failedRun?.failureReason === "insufficient_credits";
-  const consecutiveFailures =
-    input.callback.status === "completed"
-      ? 0
-      : automation.consecutiveFailures + (isCreditError ? 0 : 1);
-  const shouldDisable =
-    !isCreditError && consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
-  const nextRunAt = advanceTimeAutomationAfterCompletion({
-    scheduleType: payload.kind,
-    cronExpression:
-      payload.kind === "cron" ? payload.data.cronExpression : undefined,
-    intervalSeconds: automation.intervalSeconds,
-    timezone: automation.timezone,
-    completedAt,
-    shouldDisable,
+    const completedAt = nowDate();
+    const [failedRun] =
+      input.callback.status === "failed"
+        ? await tx
+            .select({ failureReason: agentRuns.failureReason })
+            .from(agentRuns)
+            .where(
+              and(
+                eq(agentRuns.id, input.callback.runId),
+                eq(agentRuns.orgId, automation.orgId),
+              ),
+            )
+            .limit(1)
+        : [];
+    signal?.throwIfAborted();
+    const isCreditError = failedRun?.failureReason === "insufficient_credits";
+    const consecutiveFailures =
+      input.callback.status === "completed"
+        ? 0
+        : automation.consecutiveFailures + (isCreditError ? 0 : 1);
+    const shouldDisable =
+      !isCreditError && consecutiveFailures >= MAX_CONSECUTIVE_FAILURES;
+    const nextRunAt = advanceTimeAutomationAfterCompletion({
+      scheduleType: automation.scheduleType,
+      cronExpression: automation.cronExpression,
+      intervalSeconds: automation.intervalSeconds,
+      timezone: automation.timezone,
+      completedAt,
+      shouldDisable,
+    });
+
+    await tx
+      .update(workflowAutomations)
+      .set({
+        consecutiveFailures,
+        ...(shouldDisable && { enabled: false }),
+        nextRunAt,
+        updatedAt: completedAt,
+      })
+      .where(
+        and(
+          eq(workflowAutomations.id, payload.data.automationId),
+          eq(workflowAutomations.enabled, true),
+        ),
+      );
+    signal?.throwIfAborted();
+
+    return { success: true };
   });
-
-  await db
-    .update(workflowAutomations)
-    .set({
-      consecutiveFailures,
-      ...(shouldDisable && { enabled: false }),
-      nextRunAt,
-      updatedAt: completedAt,
-    })
-    .where(
-      and(
-        eq(workflowAutomations.id, payload.data.automationId),
-        eq(workflowAutomations.enabled, true),
-      ),
-    );
-  signal?.throwIfAborted();
-
-  return { success: true };
 }
 
 export const handleWorkflowAutomationInternalCallback$ = command(


### PR DESCRIPTION
When a running workflow automation is edited from 09:30 Asia/Shanghai to 09:00 in the UI, its completion callback combines the old cron with the newly stored UTC timezone and overwrites the next run with 17:30.

Recompute recurrence from the current schedule type, cron, timezone, and interval while holding a row lock in one transaction, so a concurrent schedule edit cannot be overwritten from a stale read. Preserve a newly configured one-time schedule and keep the existing callback payload format compatible with already dispatched runs.

## Validation

- 111 API integration tests passed across the workflow automation scheduler and automation routes, including four new regressions for editing a running schedule and changing between cron, loop, and once.
- Regression assertions wait for callback delivery before inspecting the persisted next run.
- Scoped Oxlint, type-aware Oxlint, ESLint, and API type checks passed.
- Scoped Knip, formatting, and `git diff --check` passed.
