### PR TITLE
test(platform): isolate connector page test scenarios

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
@@ -893,7 +893,7 @@ test("Rename and delete a specific connector account", async () => {
       promotedDefaultConnectionId: null,
     });
   });
-  await setupAccountsPage();
+  await setupPage({ context, path: "/connectors?keywords=github" });
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Manage GitHub accounts");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-auth-methods.test.tsx
@@ -44,32 +44,6 @@ function createAuthWindow(): Window {
   return authWindow;
 }
 
-function createReusableAuthWindow(): {
-  readonly authWindow: Window;
-  readonly reopen: () => void;
-} {
-  const authWindow = createAuthWindow();
-  let closed = false;
-  Object.defineProperty(authWindow, "closed", {
-    configurable: true,
-    get: () => {
-      return closed;
-    },
-  });
-  Object.defineProperty(authWindow, "close", {
-    configurable: true,
-    value: () => {
-      closed = true;
-    },
-  });
-  return {
-    authWindow,
-    reopen: () => {
-      closed = false;
-    },
-  };
-}
-
 function storeConnectedConnector(
   slug: ConnectorSlug,
   authMethod: string,
@@ -218,9 +192,8 @@ test("Add an AWS account with an external code", async () => {
   );
   await setupPage({
     context,
-    path: "/connectors",
+    path: "/connectors?keywords=aws",
   });
-  await fill(await screen.findByPlaceholderText("Find connectors"), "aws");
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Connect AWS");
@@ -1037,7 +1010,7 @@ test("Retry device authorization after a provider error", async () => {
 
 test("Return Slack authorization directly to the application", async () => {
   mockConnectors(context, []);
-  const { authWindow } = createReusableAuthWindow();
+  const authWindow = createAuthWindow();
   context.mocks.browser.open(authWindow);
   let callbackTarget: string | undefined;
   context.mocks.api(connectorOauthStartContract.start, ({ body, respond }) => {
@@ -1060,41 +1033,37 @@ test("Return Slack authorization directly to the application", async () => {
   expect(callbackTarget).toBe("app");
 });
 
-test("Start provider sign-in for an OAuth connector", async () => {
-  const providers = [
-    ["airtable", "Airtable"],
-    ["asana", "Asana"],
-    ["cloudflare", "Cloudflare"],
-    ["gumroad", "Gumroad"],
-    ["hubspot", "HubSpot"],
-    ["intervals-icu", "Intervals.icu"],
-    ["linear", "Linear"],
-    ["mercury", "Mercury"],
-    ["microsoft-365", "Microsoft 365"],
-    ["monday", "monday.com"],
-    ["notion", "Notion"],
-    ["outlook-mail", "Outlook"],
-    ["sentry", "Sentry"],
-    ["strava", "Strava"],
-    ["todoist", "Todoist"],
-    ["vercel", "Vercel"],
-    ["xero", "Xero"],
-    ["google-maps", "Google Maps"],
-    ["meta-ads", "Meta Ads"],
-  ] as const;
+test.each([
+  ["airtable", "Airtable"],
+  ["asana", "Asana"],
+  ["cloudflare", "Cloudflare"],
+  ["gumroad", "Gumroad"],
+  ["hubspot", "HubSpot"],
+  ["intervals-icu", "Intervals.icu"],
+  ["linear", "Linear"],
+  ["mercury", "Mercury"],
+  ["microsoft-365", "Microsoft 365"],
+  ["monday", "monday.com"],
+  ["notion", "Notion"],
+  ["outlook-mail", "Outlook"],
+  ["sentry", "Sentry"],
+  ["strava", "Strava"],
+  ["todoist", "Todoist"],
+  ["vercel", "Vercel"],
+  ["xero", "Xero"],
+  ["google-maps", "Google Maps"],
+  ["meta-ads", "Meta Ads"],
+] as const)("Start provider sign-in for %s", async (slug, label) => {
   mockConnectors(context, []);
-  mockPublicConnectorStatus(
-    context,
-    providers.map(([connectorSlug, label]) => {
-      return publicStatusItem({
-        connectorSlug,
-        label,
-        authMethods: [oauthMethod()],
-        singleAuthCodeAuthMethodId: "oauth",
-      });
+  mockPublicConnectorStatus(context, [
+    publicStatusItem({
+      connectorSlug: slug,
+      label,
+      authMethods: [oauthMethod()],
+      singleAuthCodeAuthMethodId: "oauth",
     }),
-  );
-  const { authWindow, reopen } = createReusableAuthWindow();
+  ]);
+  const authWindow = createAuthWindow();
   const browserOpen = context.mocks.browser.open(authWindow);
   const starts: {
     readonly slug: string;
@@ -1114,35 +1083,25 @@ test("Start provider sign-in for an OAuth connector", async () => {
     },
   );
   await setupPage({ context, path: "/connectors" });
-  const search = await screen.findByPlaceholderText("Find connectors");
+  const connect = await waitFor(() => {
+    return getConnectorAction("button", `Connect ${label}`);
+  });
+  await waitFor(() => {
+    expect(connect).toBeEnabled();
+  });
+  click(connect);
+  await waitFor(() => {
+    expect(authWindow.location.href).toBe(
+      `https://oauth.test/${slug}/authorize`,
+    );
+  });
+  expect(screen.queryByRole("dialog", { name: label })).toBeNull();
+  await waitFor(() => {
+    expect(getConnectorAction("button", `Connect ${label}`)).toBeEnabled();
+  });
 
-  for (const [slug, label] of providers) {
-    reopen();
-    await fill(search, label);
-    const connect = await waitFor(() => {
-      return getConnectorAction("button", `Connect ${label}`);
-    });
-    await waitFor(() => {
-      return expect(connect).toBeEnabled();
-    });
-    click(connect);
-    await waitFor(() => {
-      expect(authWindow.location.href).toBe(
-        `https://oauth.test/${slug}/authorize`,
-      );
-    });
-    expect(screen.queryByRole("dialog", { name: label })).toBeNull();
-    await waitFor(() => {
-      expect(getConnectorAction("button", `Connect ${label}`)).toBeEnabled();
-    });
-  }
-
-  expect(starts).toStrictEqual(
-    providers.map(([slug]) => {
-      return { slug, callbackTarget: "app" };
-    }),
-  );
-  expect(browserOpen.calls).toHaveLength(providers.length);
+  expect(starts).toStrictEqual([{ slug, callbackTarget: "app" }]);
+  expect(browserOpen.calls).toHaveLength(1);
   expect(
     screen.queryByText(/Meta Ads is currently in Meta's app review period/u),
   ).toBeNull();


### PR DESCRIPTION
## Problem

Follow-up to #32502, which merged while this test-stability cleanup was in progress.

- The AWS external-code and account rename/delete scenarios rendered the entire connector directory despite exercising a single connector, adding unrelated work to their 5-second test budget.
- The OAuth startup smoke test performed searches and sign-in flows for 19 providers inside one 5-second test. During validation, it also timed out after the first two scenarios were narrowed.

## Changes

- Initialize the AWS and GitHub scenarios with their existing `keywords` URL filter.
- Parameterize OAuth startup by provider, preserving all 19 providers and their callback, popup, and button-state assertions. Each case uses one catalog entry and a fresh page/test context.
- Remove the now-unnecessary reopenable popup helper and use the existing browser fixture.

No production logic, authorization policy, API contracts, test timeouts, or CI configuration changes. No tests are skipped. Catalog search/navigation and repeated-action coverage remain in their dedicated tests.

## Validation

- `scripts/prepare.sh`: passed, including local migrations and development seed.
- Changed-file Prettier, Oxlint, type-aware Oxlint, and ESLint: passed.
- `pnpm -F @okouai/app check-types`: passed.
- `pnpm knip`: passed (configuration hints only).
- Four complete page integration files: **91/91 passed** in 162.32 seconds with one worker. The test count increased from 73 because the existing 19-provider loop is now 19 separate cases.

```sh
pnpm -F @okouai/app exec vitest run \
  src/views/okou-page/__tests__/connectors-auth-methods.test.tsx \
  src/views/okou-page/__tests__/connectors-accounts.test.tsx \
  src/views/okou-page/__tests__/connectors-custom.test.tsx \
  src/views/okou-page/__tests__/connectors-catalog.test.tsx \
  --maxWorkers=1 --reporter=verbose --silent=passed-only
```

The final run completed AWS in 1.41 seconds, rename/delete in 1.13 seconds, and individual OAuth provider cases in 0.28–0.76 seconds. These are local observations, not a controlled performance benchmark or a guarantee against every future timeout.
