### PR TITLE
test(platform): make chat cache fixtures deterministic

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-confirmation.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-capability-voice-draft-confirmation.test.tsx
@@ -29,7 +29,7 @@ import {
   installChatListAgent,
   installChatListModelPolicies,
   installChatListStream,
-  seedChatListCache,
+  seedPersistentChatListCache,
   sidebarThreadTitles,
 } from "./chat-list-test-helpers.ts";
 
@@ -59,7 +59,7 @@ test.each([false, true])(
     const auth = chatListAuth(49);
     const initialPage = createChildAbortController(context.signal);
     const refreshedPage = createChildAbortController(refreshedContext.signal);
-    await seedChatListCache(49, auth, []);
+    await seedPersistentChatListCache(49, auth, []);
     let createdThreadId: string | undefined;
     let createdEventId: string | undefined;
     let persistedDraft = textContinuityDraft("");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-mentions.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-mentions.test.tsx
@@ -145,7 +145,7 @@ test("Hide mention suggestions when nothing useful matches", async () => {
   );
   const untitled = withAgent(continuityThread(61, 3, "Untitled"), AGENT_ID);
   const untitledThread = { ...untitled, title: null };
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 61,
     threads: [current, projectBeta, untitledThread],
   });
@@ -154,7 +154,7 @@ test("Hide mention suggestions when nothing useful matches", async () => {
   await setupPage({
     context,
     path: `/chats/${current.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const user = userEvent.setup();
@@ -195,7 +195,7 @@ test("Mention another agent in a message", async () => {
     agent(SALES_ID, "Sales Agent", null),
     agent(FINANCE_ID, "Finance Agent", null, "private"),
   ];
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 62,
     threads: [current, matchingThread, savedMentionThread],
     drafts: new Map([
@@ -216,7 +216,7 @@ test("Mention another agent in a message", async () => {
   await setupPage({
     context,
     path: `/chats/${current.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const user = userEvent.setup();
@@ -306,7 +306,7 @@ test("Mention a chat thread from any agent", async () => {
     continuityThread(63, 2, "Other Alpha"),
     REVIEWER_ID,
   );
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 63,
     threads: [projectAlpha, otherAlpha],
   });
@@ -318,7 +318,7 @@ test("Mention a chat thread from any agent", async () => {
   await setupPage({
     context,
     path: `/chats/${projectAlpha.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const user = userEvent.setup();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-clipboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-clipboard.test.tsx
@@ -97,7 +97,7 @@ test("Paste copied chat text and attachments safely", async () => {
   const available = continuityAttachment(14, 1, "available-copy.txt");
   const missing = continuityAttachment(14, 2, "missing-copy.txt");
   const localized = continuityAttachment(14, 3, "locale-copy.txt");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 14,
     threads: [thread],
     resolveAttachment(fileId) {
@@ -108,7 +108,7 @@ test("Paste copied chat text and attachments safely", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await screen.findByRole("textbox", { name: "Message" });
@@ -183,7 +183,7 @@ test("Paste copied chat text and attachments safely", async () => {
 test("Paste plain and multi-line text at the current draft position", async () => {
   const thread = continuityThread(15, 1, "Paste position");
   const referenced = continuityThread(15, 2, "Launch reference");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 15,
     threads: [thread, referenced],
   });
@@ -191,7 +191,7 @@ test("Paste plain and multi-line text at the current draft position", async () =
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await screen.findByRole("textbox", { name: "Message" });
@@ -246,7 +246,7 @@ test("Paste plain and multi-line text at the current draft position", async () =
 test("Copy a multiline draft without flattening its line breaks", async () => {
   const user = userEvent.setup({ delay: null });
   const thread = continuityThread(16, 1, "Copy line breaks");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 16,
     threads: [thread],
   });
@@ -254,7 +254,7 @@ test("Copy a multiline draft without flattening its line breaks", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await screen.findByRole("textbox", { name: "Message" });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-draft-recovery.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-draft-recovery.test.tsx
@@ -20,7 +20,7 @@ const context = testContext();
 test("Recover saved draft attachments safely", async () => {
   const thread = continuityThread(6, 1, "Available attachment draft");
   const attachment = continuityAttachment(6, 1, "available-brief.txt");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 6,
     threads: [thread],
     drafts: new Map([
@@ -34,7 +34,7 @@ test("Recover saved draft attachments safely", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await screen.findByRole("textbox", { name: "Message" });
@@ -50,7 +50,7 @@ test("Recover saved draft attachments safely", async () => {
 test("Remove an unavailable saved draft attachment without losing text", async () => {
   const thread = continuityThread(7, 1, "Unavailable attachment draft");
   const attachment = continuityAttachment(7, 1, "missing-brief.txt");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 7,
     threads: [thread],
     drafts: new Map([
@@ -64,7 +64,7 @@ test("Remove an unavailable saved draft attachment without losing text", async (
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await screen.findByRole("textbox", { name: "Message" });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-drafts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-drafts.test.tsx
@@ -75,7 +75,7 @@ test("Keep each conversation's draft separate while navigating", async () => {
       note: [{ type: "text", text: "Second conversation feedback" }],
     },
   ]);
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 1,
     threads: [first, second],
     drafts: new Map([[second.id, secondServerDraft]]),
@@ -84,7 +84,7 @@ test("Keep each conversation's draft separate while navigating", async () => {
   await setupPage({
     context,
     path: `/chats/${first.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const firstComposer = await messageComposer();
@@ -192,7 +192,7 @@ test("Restore a rich saved draft when a chat opens", async () => {
     ],
     [attachment],
   );
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 3,
     threads: [thread, referenced],
     drafts: new Map([[thread.id, draft]]),
@@ -201,7 +201,7 @@ test("Restore a rich saved draft when a chat opens", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await messageComposer();
@@ -246,7 +246,7 @@ test("Restore a rich saved draft when a chat opens", async () => {
 test("Save and clear typed drafts consistently", async () => {
   const target = continuityThread(4, 1, "Draft persistence target");
   const neighbor = continuityThread(4, 2, "Draft persistence neighbor");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 4,
     threads: [target, neighbor],
   });
@@ -254,7 +254,7 @@ test("Save and clear typed drafts consistently", async () => {
   await setupPage({
     context,
     path: `/chats/${target.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await messageComposer();
@@ -306,7 +306,7 @@ test("Save and clear typed drafts consistently", async () => {
 test("Send the current version of a restored draft and clear it", async () => {
   const thread = continuityThread(5, 1, "Draft ready to send");
   const originalAttachment = continuityAttachment(5, 1, "outdated-brief.txt");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 5,
     threads: [thread],
     drafts: new Map([
@@ -347,7 +347,7 @@ test("Send the current version of a restored draft and clear it", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await messageComposer();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-history.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-history.test.tsx
@@ -210,7 +210,7 @@ test("Load a long chat history without losing grouped-run context", async () => 
   );
   addPair("Most recent follow-up", "Most recent answer", "history-run-recent");
 
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 20,
     threads: [thread],
     chatEventRows: rows,
@@ -219,7 +219,7 @@ test("Load a long chat history without losing grouped-run context", async () => 
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await screen.findByRole("textbox", { name: "Message" });
@@ -279,7 +279,7 @@ test("Navigate chat history with scroll controls and keyboard commands", async (
       }),
     );
   }
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 21,
     threads: [thread],
     chatEventRows: rows,
@@ -288,7 +288,7 @@ test("Navigate chat history with scroll controls and keyboard commands", async (
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await screen.findByRole("textbox", { name: "Message" });
@@ -354,7 +354,7 @@ test("Keep open chats live without duplicating messages", async () => {
     outputRow(22, 2, side.id, "Existing side answer", { id: sideRunId }),
   ];
   let allRows = [...initialMainRows, ...initialSideRows];
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 22,
     threads: [main, side],
     chatEventRows: allRows,
@@ -383,7 +383,7 @@ test("Keep open chats live without duplicating messages", async () => {
   await setupPage({
     context,
     path: `/chats/${main.id}?sidebar=${side.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   await waitFor(() => {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-keyboard.test.tsx
@@ -95,7 +95,7 @@ test("Move between neighboring chats from the focused pane", async () => {
   const current = continuityThread(16, 2, "Current keyboard chat");
   const side = continuityThread(16, 3, "Side keyboard chat");
   const newest = continuityThread(16, 4, "Newest neighboring chat");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 16,
     threads: [oldest, current, side, newest],
   });
@@ -103,7 +103,7 @@ test("Move between neighboring chats from the focused pane", async () => {
   await setupPage({
     context,
     path: `/chats/${current.id}?sidebar=${side.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   await waitFor(() => {
@@ -149,7 +149,7 @@ test("Move between neighboring chats from the focused pane", async () => {
 test("Add, replace, or remove the focused chat icon", async () => {
   const current = continuityThread(18, 1, "Project plan");
   const emojiOnlySide = continuityThread(18, 2, "❓");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 18,
     threads: [current, emojiOnlySide],
   });
@@ -159,7 +159,7 @@ test("Add, replace, or remove the focused chat icon", async () => {
   await setupPage({
     context,
     path: `/chats/${current.id}?sidebar=${emojiOnlySide.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
     featureSwitches: { [FeatureSwitchKey.StableChatThreadNavigation]: true },
   });
 
@@ -224,7 +224,7 @@ test("Add, replace, or remove the focused chat icon", async () => {
 
 test("Show keyboard help without stealing composer input", async () => {
   const thread = continuityThread(19, 1, "Keyboard help chat");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 19,
     threads: [thread],
   });
@@ -232,7 +232,7 @@ test("Show keyboard help without stealing composer input", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await screen.findByRole("textbox", { name: "Message" });
@@ -277,7 +277,7 @@ test.each([
     context.mocks.browser.userAgent(userAgent);
     const main = continuityThread(70, 1, "Main pin shortcut chat");
     const side = continuityThread(70, 2, "Side pin shortcut chat");
-    const workspace = await installContinuityWorkspace(context, {
+    const workspace = installContinuityWorkspace(context, {
       caseId: 70,
       threads: [main, side],
     });
@@ -297,7 +297,7 @@ test.each([
     await setupPage({
       context,
       path: `/chats/${main.id}?sidebar=${side.id}`,
-      auth: workspace.auth,
+      ...workspace.pageOptions,
     });
     await waitFor(() => {
       expect(composerIn(main.id)).toBeVisible();
@@ -339,7 +339,7 @@ test.each([
 test("Pin the main chat when neither pane owns keyboard focus", async () => {
   const main = continuityThread(71, 1, "Default pin shortcut chat");
   const side = continuityThread(71, 2, "Other pin shortcut chat");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 71,
     threads: [main, side],
   });
@@ -349,7 +349,7 @@ test("Pin the main chat when neither pane owns keyboard focus", async () => {
   await setupPage({
     context,
     path: `/chats/${main.id}?sidebar=${side.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
   await waitFor(() => {
     expect(composerIn(side.id)).toBeVisible();
@@ -369,7 +369,7 @@ test("Pin the main chat when neither pane owns keyboard focus", async () => {
 
 test("Respect composition, held keys, dialogs, and navigation for pin shortcuts", async () => {
   const thread = continuityThread(73, 1, "Scoped pin shortcut chat");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 73,
     threads: [thread],
   });
@@ -379,7 +379,7 @@ test("Respect composition, held keys, dialogs, and navigation for pin shortcuts"
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
   const composer = await screen.findByRole("textbox", { name: "Message" });
   composer.focus();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-test-helpers.ts
@@ -16,12 +16,12 @@ import type { SetupPageAuth } from "../../../__tests__/page-helper.ts";
 import type { TestContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   chatListAuth,
+  cachedChatListEvents,
   chatListThread,
   installActiveChatBoundaries,
   installChatListAgent,
   installChatListModelPolicies,
   installChatListStream,
-  seedChatListCache,
   sidebarThreadLinks,
 } from "./chat-list-test-helpers.ts";
 
@@ -46,7 +46,15 @@ interface ContinuityWorkspaceOptions {
 }
 
 interface ContinuityWorkspace {
-  readonly auth: Exclude<SetupPageAuth, null>;
+  /**
+   * Page stories must install the cache projection together with its identity.
+   * Keeping these options inseparable prevents callers from falling back to
+   * scheduler-dependent IndexedDB hydration before visible assertions.
+   */
+  readonly pageOptions: {
+    readonly auth: Exclude<SetupPageAuth, null>;
+    readonly cachedChatThreadEvents: ReturnType<typeof cachedChatListEvents>;
+  };
   readonly draftPatches: ContinuityDraftPatch[];
   readonly eventRowQueries: ContinuityEventRowQuery[];
   readonly setDraft: (threadId: string, draft: ChatThreadDraft) => void;
@@ -183,12 +191,11 @@ export function draftPlainText(
     .join("\n");
 }
 
-export async function installContinuityWorkspace(
+export function installContinuityWorkspace(
   context: TestContext,
   options: ContinuityWorkspaceOptions,
-): Promise<ContinuityWorkspace> {
+): ContinuityWorkspace {
   const auth = chatListAuth(200 + options.caseId);
-  await seedChatListCache(options.caseId, auth, options.threads);
   installChatListAgent(context);
   installChatListModelPolicies(context);
   installChatListStream(context, {
@@ -338,7 +345,13 @@ export async function installContinuityWorkspace(
   });
 
   return {
-    auth,
+    pageOptions: {
+      auth,
+      cachedChatThreadEvents: cachedChatListEvents(
+        options.caseId,
+        options.threads,
+      ),
+    },
     draftPatches,
     eventRowQueries,
     setDraft(threadId, draft) {

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-uploads.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-continuity-uploads.test.tsx
@@ -81,7 +81,7 @@ function sentFilenames(
 
 test("Attach supported files by picker or drag and drop", async () => {
   const thread = continuityThread(9, 1, "Attachment input methods");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 9,
     threads: [thread],
   });
@@ -94,7 +94,7 @@ test("Attach supported files by picker or drag and drop", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   await messageComposer();
@@ -133,7 +133,7 @@ test("Attach supported files by picker or drag and drop", async () => {
 test("Keep a pending upload with the conversation that started it", async () => {
   const owner = continuityThread(10, 1, "Upload owner");
   const neighbor = continuityThread(10, 2, "Upload neighbor");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 10,
     threads: [owner, neighbor],
   });
@@ -147,7 +147,7 @@ test("Keep a pending upload with the conversation that started it", async () => 
   await setupPage({
     context,
     path: `/chats/${owner.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   await messageComposer();
@@ -197,7 +197,7 @@ test("Keep a pending upload with the conversation that started it", async () => 
 
 test("Keep successful attachments after another upload fails", async () => {
   const thread = continuityThread(11, 1, "Partial upload result");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 11,
     threads: [thread],
   });
@@ -225,7 +225,7 @@ test("Keep successful attachments after another upload fails", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await messageComposer();
@@ -251,7 +251,7 @@ test("Keep successful attachments after another upload fails", async () => {
 
 test("Recover clearly from interruptions while uploading a large attachment", async () => {
   const thread = continuityThread(12, 1, "Large upload recovery");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 12,
     threads: [thread],
   });
@@ -302,7 +302,7 @@ test("Recover clearly from interruptions while uploading a large attachment", as
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   await messageComposer();
@@ -332,7 +332,7 @@ test("Recover clearly from interruptions while uploading a large attachment", as
 
 test("Wait for an attachment upload before sending the draft", async () => {
   const thread = continuityThread(13, 1, "Wait for upload before send");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 13,
     threads: [thread],
   });
@@ -361,7 +361,7 @@ test("Wait for an attachment upload before sending the draft", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const composer = await messageComposer();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-configuration.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-configuration.test.tsx
@@ -11,6 +11,7 @@ import {
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   CHAT_LIST_AGENT_ID,
+  cachedChatListEvents,
   chatListAuth,
   chatListEvent,
   chatListThread,
@@ -21,7 +22,6 @@ import {
   installChatListModelPolicies,
   installChatListStream,
   onlineComputerUseHost,
-  seedChatListCache,
   sidebarThreadLinks,
   sidebarThreadTitles,
 } from "./chat-list-test-helpers.ts";
@@ -109,7 +109,6 @@ test("Enabling cloud browser replaces the Computer Use host", async () => {
   const thread = chatListThread(36, "Hosted conversation", {
     computerUseHostId: HOST_ID,
   });
-  await seedChatListCache(2, auth, [thread]);
   const remote = context.mocks.deferred<void>();
   installChatListAgent(context);
   installChatListModelPolicies(context);
@@ -132,7 +131,12 @@ test("Enabling cloud browser replaces the Computer Use host", async () => {
     return respond(200, { hosts: [onlineComputerUseHost(HOST_ID)] });
   });
 
-  await setupPage({ context, path: `/chats/${thread.id}`, auth });
+  await setupPage({
+    context,
+    path: `/chats/${thread.id}`,
+    auth,
+    cachedChatThreadEvents: cachedChatListEvents(2, [thread]),
+  });
 
   await openComputerMenu();
   const selectedHost = await screen.findByRole("switch", {
@@ -227,7 +231,6 @@ test("Media models do not overwrite one another or the run model", async () => {
     selectedVideoModel: "MiniMax-H3",
     selectedImageModel: "gpt-image-1",
   });
-  await seedChatListCache(6, auth, [thread]);
   installChatListAgent(context);
   installChatListModelPolicies(context);
   installChatListStream(context, {
@@ -241,7 +244,12 @@ test("Media models do not overwrite one another or the run model", async () => {
   });
   installActiveChatBoundaries(context, { metadata: thread });
 
-  await setupPage({ context, path: `/chats/${thread.id}`, auth });
+  await setupPage({
+    context,
+    path: `/chats/${thread.id}`,
+    auth,
+    cachedChatThreadEvents: cachedChatListEvents(6, [thread]),
+  });
 
   const runModel = await screen.findByRole("combobox", {
     name: "Claude Sonnet 4.6",
@@ -262,7 +270,6 @@ test("Service tier and Computer Use settings update independently", async () => 
     selectedModel: "gpt-5.6-sol",
   });
   const newer = chatListThread(44, "Newer conversation");
-  await seedChatListCache(14, auth, [target, newer]);
   const remote = context.mocks.deferred<void>();
   installChatListAgent(context);
   installChatListModelPolicies(context);
@@ -289,6 +296,7 @@ test("Service tier and Computer Use settings update independently", async () => 
     context,
     path: `/chats/${target.id}`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(14, [target, newer]),
     featureSwitches: { [FeatureSwitchKey.CodexFastMode]: true },
   });
 

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-optimistic.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-optimistic.test.tsx
@@ -11,6 +11,7 @@ import { setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   CHAT_LIST_AGENT_ID,
+  cachedChatListEvents,
   chatListAuth,
   chatListEvent,
   chatListThread,
@@ -19,7 +20,6 @@ import {
   installChatListAgent,
   installChatListModelPolicies,
   installChatListStream,
-  seedChatListCache,
   sidebarThreadLinks,
   sidebarThreadTitles,
 } from "./chat-list-test-helpers.ts";
@@ -64,7 +64,6 @@ function installNewThreadDefaults(): void {
 
 test("A new conversation appears before server confirmation", async () => {
   const auth = chatListAuth(9);
-  await seedChatListCache(9, auth, []);
   const confirmation = context.mocks.deferred<void>();
   let createdThreadId: string | undefined;
   let requestedModel: string | undefined;
@@ -103,6 +102,7 @@ test("A new conversation appears before server confirmation", async () => {
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(9, []),
   });
 
   const defaultModel = await screen.findByRole("combobox", {
@@ -134,7 +134,6 @@ test("Sending in an older conversation moves it to the top", async () => {
   const auth = chatListAuth(12);
   const older = chatListThread(45, "Older cached thread");
   const newer = chatListThread(46, "Newer cached thread");
-  await seedChatListCache(12, auth, [older, newer]);
   const send = context.mocks.deferred<void>();
   let sentPrompt: string | undefined;
   installChatListAgent(context);
@@ -155,7 +154,12 @@ test("Sending in an older conversation moves it to the top", async () => {
     });
   });
 
-  await setupPage({ context, path: `/chats/${older.id}`, auth });
+  await setupPage({
+    context,
+    path: `/chats/${older.id}`,
+    auth,
+    cachedChatThreadEvents: cachedChatListEvents(12, [older, newer]),
+  });
 
   await waitFor(() => {
     expect(sidebarThreadTitles()).toStrictEqual([
@@ -183,7 +187,6 @@ test("Sending in an older conversation moves it to the top", async () => {
 
 test("Server confirmation settles a new conversation without duplication", async () => {
   const auth = chatListAuth(13);
-  await seedChatListCache(13, auth, []);
   const confirmation = context.mocks.deferred<void>();
   let createdThreadId: string | undefined;
   let createdEventId: string | undefined;
@@ -217,6 +220,7 @@ test("Server confirmation settles a new conversation without duplication", async
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
     auth,
+    cachedChatThreadEvents: cachedChatListEvents(13, []),
   });
 
   await selectClaudeSonnet();

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-list-test-helpers.ts
@@ -124,7 +124,8 @@ export function cachedChatListEvents(
   };
 }
 
-export async function seedChatListCache(
+/** Seed IndexedDB only when the page story exercises persistence across reloads. */
+export async function seedPersistentChatListCache(
   caseId: number,
   auth: Exclude<SetupPageAuth, null>,
   chatThreads: readonly ChatThreadSnapshotProjection[],

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-conversation-state.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-conversation-state.test.tsx
@@ -158,7 +158,7 @@ function mailDraft(
 
 test("Keep an empty conversation ready for its first message", async () => {
   const thread = continuityThread(31, 1, "Empty conversation");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 31,
     threads: [thread],
     chatEventRows: [],
@@ -167,7 +167,7 @@ test("Keep an empty conversation ready for its first message", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const invitation = await screen.findByText(
@@ -204,7 +204,7 @@ test("Explain unavailable email cards in a conversation", async () => {
     ),
     completedRow(32, 3, thread.id, runId),
   ];
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 32,
     threads: [thread],
     chatEventRows: rows,
@@ -236,7 +236,7 @@ test("Explain unavailable email cards in a conversation", async () => {
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   const deletedCard = await screen.findByLabelText(
@@ -281,7 +281,7 @@ test("Keep the work being read expanded as conversation groups change", async ()
       groupId: runGroupId,
     }),
   ];
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 33,
     threads: [thread],
     chatEventRows: rows,
@@ -290,7 +290,7 @@ test("Keep the work being read expanded as conversation groups change", async ()
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
   });
 
   await screen.findByRole("textbox", { name: "Message" });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-search-debounce.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-search-debounce.test.tsx
@@ -8,7 +8,6 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { installContinuityWorkspace } from "./chat-continuity-test-helpers.ts";
 import {
   CHAT_LIST_AGENT_ID,
-  cachedChatListEvents,
   chatListThread,
 } from "./chat-list-test-helpers.ts";
 
@@ -61,7 +60,7 @@ function installMessageSearch(threadId: string): string[] {
 test("Search messages only after the latest input settles", async () => {
   const thread = chatListThread(1, THREAD_TITLE);
   const remoteChatList = context.mocks.deferred<void>();
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 37,
     threads: [thread],
     chatListRemoteGate: remoteChatList.promise,
@@ -70,8 +69,7 @@ test("Search messages only after the latest input settles", async () => {
   await setupPage({
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth: workspace.auth,
-    cachedChatThreadEvents: cachedChatListEvents(37, [thread]),
+    ...workspace.pageOptions,
     featureSwitches,
   });
   const chatThreads = await screen.findByLabelText("Chat threads");
@@ -91,7 +89,7 @@ test("Search messages only after the latest input settles", async () => {
 test("Clearing or closing search discards a pending message search", async () => {
   const thread = chatListThread(1, THREAD_TITLE);
   const remoteChatList = context.mocks.deferred<void>();
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 38,
     threads: [thread],
     chatListRemoteGate: remoteChatList.promise,
@@ -100,8 +98,7 @@ test("Clearing or closing search discards a pending message search", async () =>
   await setupPage({
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth: workspace.auth,
-    cachedChatThreadEvents: cachedChatListEvents(38, [thread]),
+    ...workspace.pageOptions,
     featureSwitches,
   });
   const chatThreads = await screen.findByLabelText("Chat threads");

--- a/turbo/apps/platform/src/views/okou-page/__tests__/keyboard-shortcut-hints.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/keyboard-shortcut-hints.test.tsx
@@ -48,14 +48,14 @@ test.each(platforms)(
       );
     });
     const thread = chatListThread(1, "Keyboard hints");
-    const workspace = await installContinuityWorkspace(context, {
+    const workspace = installContinuityWorkspace(context, {
       caseId: 60,
       threads: [thread],
     });
     await setupPage({
       context,
       path: `/chats/${thread.id}`,
-      auth: workspace.auth,
+      ...workspace.pageOptions,
       featureSwitches,
     });
     const composer = await screen.findByRole("textbox", { name: "Message" });
@@ -114,14 +114,14 @@ test.each(platforms)(
       return query === "(min-width: 48rem)";
     });
     const thread = chatListThread(1, "Keyboard shortcuts");
-    const workspace = await installContinuityWorkspace(context, {
+    const workspace = installContinuityWorkspace(context, {
       caseId: 63,
       threads: [thread],
     });
     await setupPage({
       context,
       path: `/chats/${thread.id}`,
-      auth: workspace.auth,
+      ...workspace.pageOptions,
       featureSwitches,
     });
     const composer = await screen.findByRole("textbox", { name: "Message" });
@@ -156,7 +156,7 @@ test("Hide thread hints when stable chat navigation is disabled and preserve act
       query === "(min-width: 48rem)" || query === "(display-mode: standalone)"
     );
   });
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 62,
     threads: [chatListThread(1, "Thread hints")],
   });
@@ -176,7 +176,7 @@ test("Hide thread hints when stable chat navigation is disabled and preserve act
   await setupPage({
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
     cachedFeatureSwitches: featureSwitches,
   });
   await screen.findByRole("textbox", { name: "Message" });

--- a/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/search-result-number-shortcuts.test.tsx
@@ -31,7 +31,6 @@ import {
 } from "./chat-navigation-artifact-test-helpers.ts";
 import {
   CHAT_LIST_AGENT_ID,
-  cachedChatListEvents,
   chatListThread,
   fastButton,
   sidebarThreadTitles,
@@ -201,7 +200,7 @@ test.each([
       });
     });
     const remoteChatList = context.mocks.deferred<void>();
-    const workspace = await installContinuityWorkspace(context, {
+    const workspace = installContinuityWorkspace(context, {
       caseId,
       threads,
       chatListRemoteGate: remoteChatList.promise,
@@ -209,8 +208,7 @@ test.each([
     await setupPage({
       context,
       path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-      auth: workspace.auth,
-      cachedChatThreadEvents: cachedChatListEvents(caseId, threads),
+      ...workspace.pageOptions,
       featureSwitches,
     });
     const expectedTitles = [
@@ -291,7 +289,7 @@ test("Empty search follows the current agent and unread filter", async () => {
     agentId: "c7000000-0000-4000-a000-000000000002",
     pinnedAt: "2026-08-01T00:59:00.000Z",
   });
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 25,
     threads: [first, second, third, foreign],
   });
@@ -305,7 +303,7 @@ test("Empty search follows the current agent and unread filter", async () => {
   await setupPage({
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
     featureSwitches,
   });
   await waitFor(() => {
@@ -352,7 +350,7 @@ test("Search numbers follow fresh matches and restart after filtering", async ()
   });
   const titleMatch = chatListThread(1, "Budget planning");
   const messageMatch = chatListThread(2, "Project notes");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 26,
     threads: [titleMatch, messageMatch],
   });
@@ -382,7 +380,7 @@ test("Search numbers follow fresh matches and restart after filtering", async ()
   await setupPage({
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
     featureSwitches,
   });
   const { dialog, search } = await openSearch();
@@ -424,14 +422,14 @@ test("Search shortcuts preserve typing and reset hints when focus is lost or the
     );
   });
   const first = chatListThread(1, "First chat");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 27,
     threads: [first],
   });
   await setupPage({
     context,
     path: `/chats/${first.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
     featureSwitches,
   });
   const { dialog, search } = await openSearch();
@@ -514,7 +512,7 @@ test.each([
       );
     });
     const titleMatch = chatListThread(1, "Budget planning");
-    const workspace = await installContinuityWorkspace(context, {
+    const workspace = installContinuityWorkspace(context, {
       caseId: 29,
       threads: [titleMatch],
     });
@@ -522,7 +520,7 @@ test.each([
     await setupPage({
       context,
       path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-      auth: workspace.auth,
+      ...workspace.pageOptions,
       featureSwitches,
     });
     const { dialog, search } = await openSearch();
@@ -586,14 +584,14 @@ test("Disabling stable navigation restores activity order and workspace-wide sea
   const foreign = chatListThread(3, "Another agent's chat", {
     agentId: "c7000000-0000-4000-a000-000000000002",
   });
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 28,
     threads: [firstPin, secondPin, foreign],
   });
   await setupPage({
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
     featureSwitches: {
       [FeatureSwitchKey.StableChatThreadNavigation]: false,
     },

--- a/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/thread-list-number-shortcuts.test.tsx
@@ -98,14 +98,16 @@ test.each([
         pinnedAt: index < 2 ? `2026-08-01T00:5${2 - index}:00.000Z` : null,
       });
     });
-    const workspace = await installContinuityWorkspace(context, {
+    const remoteChatList = context.mocks.deferred<void>();
+    const workspace = installContinuityWorkspace(context, {
       caseId: 40,
       threads,
+      chatListRemoteGate: remoteChatList.promise,
     });
     await setupPage({
       context,
       path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-      auth: workspace.auth,
+      ...workspace.pageOptions,
       featureSwitches,
     });
     await waitFor(() => {
@@ -123,6 +125,7 @@ test.each([
         "Thread 3",
       ]);
     });
+    expect(remoteChatList.settled()).toBeFalsy();
     const list = screen.getByTestId("chat-list-column");
     const user = userEvent.setup();
     await user.hover(sidebarThreadLinks()[0]!);
@@ -167,14 +170,14 @@ test("Cancel a short hold and clear hints on release, blur, and visibility loss"
   });
   const visibility = context.mocks.browser.visibilityState("visible");
   const thread = chatListThread(1, "Hold lifecycle");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 41,
     threads: [thread],
   });
   await setupPage({
     context,
     path: `/chats/${thread.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
     featureSwitches,
   });
   await waitFor(() => {
@@ -212,14 +215,14 @@ test("Keep browser mode free of number shortcuts and react to display mode chang
   });
   const first = chatListThread(1, "Browser mode chat");
   const second = chatListThread(2, "Another chat");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 42,
     threads: [first, second],
   });
   await setupPage({
     context,
     path: `/chats/${first.id}`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
     featureSwitches,
   });
   await waitFor(() => {
@@ -296,7 +299,7 @@ test("Number filtered threads and give the search dialog priority over the list"
   });
   const first = chatListThread(1, "Unread target");
   const second = chatListThread(2, "Read target");
-  const workspace = await installContinuityWorkspace(context, {
+  const workspace = installContinuityWorkspace(context, {
     caseId: 43,
     threads: [first, second],
   });
@@ -308,7 +311,7 @@ test("Number filtered threads and give the search dialog priority over the list"
   await setupPage({
     context,
     path: `/agents/${CHAT_LIST_AGENT_ID}/chat`,
-    auth: workspace.auth,
+    ...workspace.pageOptions,
     featureSwitches,
   });
   await waitFor(() => {


### PR DESCRIPTION
## Root cause

The direct page-cache bridge added in #32365 was adopted file by file, while `installContinuityWorkspace()` still seeded IndexedDB and returned authentication alone. Its 44 page stories therefore raced page-shell readiness against a separate SharedWorker IndexedDB reopen. On a cold CI worker, the first parameterized case could reach its one-second visible-list assertion while the sidebar was still `[]`; later warm cases hid the gap.

This is the failure seen in [test-app (7)](https://github.com/vm0-ai/vm0/actions/runs/34188885292/job/101942710000). Waiting for the old request-handler milestone, as #32330 did, would only observe an implementation detail and would not prove that a user could see the list.

## Summary

- Make the continuity fixture return an inseparable `auth` and cached chat-thread projection, then migrate all 44 consumers to that page boundary.
- Move the six remaining non-persistence page stories off direct IndexedDB seeding. Keep real IndexedDB setup only for the one story that deliberately reloads the page and verifies persisted state, and name that helper accordingly.
- Hold remote list synchronization pending in the shortcut regression while waiting for all 11 visible titles, proving cache-first readiness before exercising the unchanged 500 ms shortcut behavior.
- Keep production code, assertions, real-time budgets, and user behavior unchanged. No timeout increase, sleep, retry, skip, fake timer, or manual detached cleanup is added.

## Verification

Final head `60e3230f23` on `a85c01feea`:

- All 15 affected page-test files: **64/64 passed**, in foreground batches of at most five files.
- `thread-list-number-shortcuts.test.tsx`: **7/7 passed** after the final rebase.
- The four-platform failing parameter group also passed **20/20** across five independent cold processes before the final conflict-free rebase.
- Affected-file Prettier, Platform lint, Platform typecheck, Platform Knip, and `git diff --check`: passed.
