### PR TITLE
fix(ably-subscriber): keep subscribe logs off stdout

### DIFF
--- a/crates/ably-subscriber/examples/subscribe.rs
+++ b/crates/ably-subscriber/examples/subscribe.rs
@@ -8,15 +8,23 @@
 //! ```
 //!
 //! `ABLY_API_KEY` format: `keyName:keySecret` (from your Ably dashboard).
-//! Message data is printed to stdout (pipe to `jq` for formatting).
+//! Message JSON is printed to stdout, while tracing and status diagnostics are
+//! printed to stderr, so stdout can be piped directly to `jq` for formatting.
 
 use ably_subscriber::{Event, SubscribeConfig, subscribe};
 
 mod common;
 
+fn make_tracing_subscriber<W>(writer: W) -> impl tracing::Subscriber + Send + Sync + 'static
+where
+    W: for<'writer> tracing_subscriber::fmt::writer::MakeWriter<'writer> + Send + Sync + 'static,
+{
+    tracing_subscriber::fmt().with_writer(writer).finish()
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    tracing::subscriber::set_global_default(make_tracing_subscriber(std::io::stderr))?;
 
     const USAGE: &str = "usage: subscribe <CHANNEL> [HOST] (set ABLY_API_KEY; API keys are not accepted as arguments)";
     let api_key = std::env::var("ABLY_API_KEY").map_err(
@@ -73,4 +81,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+
+    use super::make_tracing_subscriber;
+
+    #[derive(Clone)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("test writer mutex poisoned")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn tracing_diagnostics_are_separate_from_json_message_output() {
+        let stderr = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = make_tracing_subscriber({
+            let stderr = Arc::clone(&stderr);
+            move || SharedWriter(Arc::clone(&stderr))
+        });
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("diagnostic");
+        });
+
+        let stdout = serde_json::json!({"message": "ok"}).to_string();
+        assert!(serde_json::from_str::<serde_json::Value>(&stdout).is_ok());
+        assert!(!stdout.contains("diagnostic"));
+
+        let stderr = String::from_utf8(stderr.lock().expect("test writer mutex poisoned").clone())
+            .expect("tracing output should be UTF-8");
+        assert!(stderr.contains("diagnostic"));
+    }
 }

--- a/crates/ably-subscriber/examples/subscribe.rs
+++ b/crates/ably-subscriber/examples/subscribe.rs
@@ -10,21 +10,42 @@
 //! `ABLY_API_KEY` format: `keyName:keySecret` (from your Ably dashboard).
 //! Message JSON is printed to stdout, while tracing and status diagnostics are
 //! printed to stderr, so stdout can be piped directly to `jq` for formatting.
+//! `RUST_LOG` controls tracing verbosity and target filters (INFO by default).
 
 use ably_subscriber::{Event, SubscribeConfig, subscribe};
 
 mod common;
 
-fn make_tracing_subscriber<W>(writer: W) -> impl tracing::Subscriber + Send + Sync + 'static
-where
-    W: for<'writer> tracing_subscriber::fmt::writer::MakeWriter<'writer> + Send + Sync + 'static,
-{
-    tracing_subscriber::fmt().with_writer(writer).finish()
+fn init_tracing() -> Result<(), tracing_subscriber::util::TryInitError> {
+    use tracing_subscriber::filter::{LevelFilter, Targets};
+    use tracing_subscriber::prelude::*;
+
+    // Preserve fmt::init()'s default-feature RUST_LOG behavior while changing its writer.
+    let targets = match std::env::var("RUST_LOG") {
+        Ok(value) => value.parse::<Targets>().unwrap_or_else(|error| {
+            eprintln!("Ignoring `RUST_LOG={value:?}`: {error}");
+            Targets::new()
+        }),
+        Err(std::env::VarError::NotPresent) => {
+            Targets::new().with_default(tracing_subscriber::fmt::Subscriber::DEFAULT_MAX_LEVEL)
+        }
+        Err(error) => {
+            eprintln!("Ignoring `RUST_LOG`: {error}");
+            Targets::new().with_default(tracing_subscriber::fmt::Subscriber::DEFAULT_MAX_LEVEL)
+        }
+    };
+
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_max_level(LevelFilter::TRACE)
+        .finish()
+        .with(targets)
+        .try_init()
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing::subscriber::set_global_default(make_tracing_subscriber(std::io::stderr))?;
+    init_tracing()?;
 
     const USAGE: &str = "usage: subscribe <CHANNEL> [HOST] (set ABLY_API_KEY; API keys are not accepted as arguments)";
     let api_key = std::env::var("ABLY_API_KEY").map_err(
@@ -85,46 +106,80 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{self, Write};
-    use std::sync::{Arc, Mutex};
+    use std::process::Command;
 
-    use super::make_tracing_subscriber;
-
-    #[derive(Clone)]
-    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
-
-    impl Write for SharedWriter {
-        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-            self.0
-                .lock()
-                .expect("test writer mutex poisoned")
-                .extend_from_slice(bytes);
-            Ok(bytes.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
+    use super::init_tracing;
 
     #[test]
     fn tracing_diagnostics_are_separate_from_json_message_output() {
-        let stderr = Arc::new(Mutex::new(Vec::new()));
-        let subscriber = make_tracing_subscriber({
-            let stderr = Arc::clone(&stderr);
-            move || SharedWriter(Arc::clone(&stderr))
-        });
+        const CHILD_ENV: &str = "ABLY_SUBSCRIBE_OUTPUT_TEST_CHILD";
+        let message = serde_json::json!({"message": "ok"});
 
-        tracing::subscriber::with_default(subscriber, || {
-            tracing::info!("diagnostic");
-        });
+        if std::env::var_os(CHILD_ENV).is_some() {
+            init_tracing().expect("initialize example tracing");
+            tracing::info!(target: "subscribe_output_test", "info diagnostic");
+            tracing::debug!(target: "subscribe_output_test", "debug diagnostic");
+            println!("{message}");
+            return;
+        }
 
-        let stdout = serde_json::json!({"message": "ok"}).to_string();
-        assert!(serde_json::from_str::<serde_json::Value>(&stdout).is_ok());
-        assert!(!stdout.contains("diagnostic"));
+        // Each child uses the production initializer and real process streams,
+        // isolating both the global subscriber and RUST_LOG from other tests.
+        for (rust_log, expect_info, expect_debug, expect_warning) in [
+            (None, true, false, false),
+            (Some("debug"), true, true, false),
+            (Some("off"), false, false, false),
+            (Some("subscribe_output_test=debug"), true, true, false),
+            (Some("other_target=debug"), false, false, false),
+            (Some(""), false, false, false),
+            (Some("subscribe_output_test=invalid"), false, false, true),
+        ] {
+            let mut command = Command::new(std::env::current_exe().expect("test executable"));
+            command
+                .args([
+                    "--exact",
+                    "tests::tracing_diagnostics_are_separate_from_json_message_output",
+                    "--nocapture",
+                    "--quiet",
+                ])
+                .env(CHILD_ENV, "1")
+                .env_remove("RUST_LOG");
+            if let Some(rust_log) = rust_log {
+                command.env("RUST_LOG", rust_log);
+            }
 
-        let stderr = String::from_utf8(stderr.lock().expect("test writer mutex poisoned").clone())
-            .expect("tracing output should be UTF-8");
-        assert!(stderr.contains("diagnostic"));
+            let output = command.output().expect("run example output probe");
+            let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+            let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+            assert!(output.status.success(), "RUST_LOG={rust_log:?}: {stderr}");
+            assert!(!stdout.contains("diagnostic"), "{stdout}");
+            assert!(!stdout.contains("Ignoring `RUST_LOG"), "{stdout}");
+
+            // The test harness also writes progress to stdout; parse the actual
+            // payload line and check diagnostics against the entire stream.
+            let payload = stdout
+                .lines()
+                .find(|line| line.starts_with('{'))
+                .expect("JSON message on stdout");
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(payload).expect("parse message JSON"),
+                message,
+            );
+            assert_eq!(
+                stderr.contains("info diagnostic"),
+                expect_info,
+                "RUST_LOG={rust_log:?}: {stderr}",
+            );
+            assert_eq!(
+                stderr.contains("debug diagnostic"),
+                expect_debug,
+                "RUST_LOG={rust_log:?}: {stderr}",
+            );
+            assert_eq!(
+                stderr.contains("Ignoring `RUST_LOG"),
+                expect_warning,
+                "RUST_LOG={rust_log:?}: {stderr}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

The subscribe example recommends piping its message JSON to `jq`, but normal token-renewal and reconnect logs also used stdout. Route tracing diagnostics to stderr and document the stdout/stderr contract.

Preserve the existing `RUST_LOG` level/target filtering and `log`-to-tracing forwarding when replacing `fmt::init()`, including its handling of unset, empty, and invalid filters. A credential-free regression test runs the production initializer in isolated child processes, captures real stdout/stderr, and verifies diagnostic routing and JSON payload parseability across those configurations.

## Scope

Only `crates/ably-subscriber/examples/subscribe.rs` changes. The subscriber library API, protocol behavior, event-loop log sites, dependencies, and deployment configuration remain unchanged.

## Validation

- `cargo fmt --manifest-path crates/ably-subscriber/Cargo.toml -- --check`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p ably-subscriber --example subscribe`
- `cargo test --manifest-path crates/Cargo.toml --profile local -p ably-subscriber --all-targets`
- `cargo clippy --manifest-path crates/Cargo.toml --profile local -p ably-subscriber --all-targets -- -D warnings`
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p ably-subscriber --no-deps`

Mutation checks confirmed that the replacement regression test fails when the production sink is changed back to stdout or `RUST_LOG` filtering is removed. The previous test still passed with stdout restored. No live Ably connection was used.

Closes #32530
