### PR TITLE
fix(e2e): populate sidebar before measuring scrollbar geometry

### DIFF
--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -26,32 +26,54 @@ test("sidebar scrollbar meets the workspace edge without a mobile inset", async 
 
   const chatList = page.getByTestId("chat-list-column");
   const scrollViewport = page.getByRole("region", { name: "Chat threads" });
-  const scrollbar = page.getByTestId("sidebar-scrollbar");
+  const scrollbar = chatList.getByTestId("sidebar-scrollbar");
   const workspace = page.getByTestId("workspace-inset");
   await expect(chatList).toBeVisible({ timeout: 20_000 });
   await expect(scrollViewport).toBeVisible({ timeout: 20_000 });
   await expect(workspace).toBeVisible({ timeout: 20_000 });
 
-  let scrollMetrics = { clientHeight: 0, scrollHeight: 0 };
-  for (let height = 520; height >= 160; height -= 10) {
-    await page.setViewportSize({ width: 1440, height });
-    scrollMetrics = await scrollViewport.evaluate((element) => {
-      return {
-        clientHeight: element.clientHeight,
-        scrollHeight: element.scrollHeight,
-      };
-    });
+  // Populate the list through the product instead of trying to make the empty
+  // state overflow by shrinking the viewport while the sidebar is loading.
+  const newChatButton = chatList
+    .getByRole("button", { name: "New chat", exact: true })
+    .last();
+  for (let index = 0; index < 20; index++) {
+    const [response] = await Promise.all([
+      page.waitForResponse((response) => {
+        return (
+          response.request().method() === "POST" &&
+          new URL(response.url()).pathname === "/api/chat-threads"
+        );
+      }),
+      newChatButton.click(),
+    ]);
+    expect(response.status()).toBe(201);
+    const thread: unknown = await response.json();
     if (
-      scrollMetrics.clientHeight > 0 &&
-      scrollMetrics.scrollHeight > scrollMetrics.clientHeight
+      typeof thread !== "object" ||
+      thread === null ||
+      !("id" in thread) ||
+      typeof thread.id !== "string"
     ) {
-      break;
+      throw new Error("Expected the created chat thread to have an id");
     }
+    await expect(page).toHaveURL(new URL(`/chats/${thread.id}`, appUrl).href);
+    await expect(
+      scrollViewport.locator(`a[href="/chats/${thread.id}"]`),
+    ).toBeVisible();
   }
-  expect(scrollMetrics.clientHeight).toBeGreaterThan(0);
-  expect(scrollMetrics.scrollHeight).toBeGreaterThan(
-    scrollMetrics.clientHeight,
-  );
+
+  await expect
+    .poll(async () => {
+      return scrollViewport.evaluate((element) => {
+        return (
+          element.clientHeight > 0 &&
+          element.scrollHeight > element.clientHeight
+        );
+      });
+    })
+    .toBe(true);
+  await expect(scrollbar).toBeVisible();
 
   const [chatListBox, scrollbarBox, workspaceBox] = await Promise.all([
     chatList.boundingBox(),


### PR DESCRIPTION
The sidebar geometry E2E failed in [run 34196183913](https://github.com/vm0-ai/vm0/actions/runs/34196183913/job/101965771655) because its viewport-shrinking loop reached a zero-height chat list before finding overflow. The attached Playwright report shows an empty chat list; the test never created the content required for its scrollbar assertion. The same test passed in the preceding PR run, so its outcome depended on transient sidebar layout while resizing.

Keep the desktop viewport at 1440 × 520 and create 20 empty threads through the product's New chat action. Wait for each successful create response, the matching route, and the visible sidebar row, then wait for overflow and scrollbar geometry. Preserve the desktop workspace-edge and mobile inset assertions, and scope the scrollbar locator to the chat-list column. Thread creation does not submit messages or start agent runs; the existing generation-scoped account teardown owns cleanup.

## Verification

- `cd e2e && pnpm check-types` — passed.
- Targeted Playwright `--list` — loads the sidebar test and its onboarding dependency successfully; this is discovery, not browser execution.
- Prettier 3.6.2, `git diff --check`, and the repository file-size check — passed.
- [Deployed Playwright features job](https://github.com/vm0-ai/vm0/actions/runs/34198271157/job/101971695261) on commit `98461f101fd874b6ad72c70c8c89206af76128bd` — all 12 tests passed in 38.6 seconds; the repaired sidebar test passed in 8.2 seconds. The paid-onboarding and auth-v2 Playwright jobs also passed.
- No local app server or full local Vitest suite was started; browser execution used the PR preview environment.
