### PR TITLE
fix(platform): normalize legacy response section spacing

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -8022,8 +8022,10 @@ function PagedAssistantEventItem({
           compact
             ? "py-1 text-[13px] leading-5"
             : CHAT_THREAD_RESPONSE_LINE_CLASS,
+          // A preceding summary already occupies the avatar row. Its reply
+          // needs neither the avatar's top inset nor its minimum height.
           legacyTopPadding &&
-            "@[900px]:group-data-[run-work-folding-disabled]/chat:first:pt-2.5",
+            "@[900px]:group-data-[run-work-folding-disabled]/chat:first:pt-2.5 @[900px]:group-data-[run-work-folding-disabled]/chat:[&:not(:first-child)]:min-h-0 @[900px]:group-data-[run-work-folding-disabled]/chat:[&:not(:first-child)]:pt-0",
         )}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -5093,7 +5093,11 @@ function AssistantThinkingStatusRow({
     <div
       {...thinkingIndicatorProps}
       data-role="assistant-thinking"
-      className={RUN_SECTION_ROW_CLASS}
+      // This continues the response: reduce the outer 24px turn gap to 8px.
+      className={cn(
+        RUN_SECTION_ROW_CLASS,
+        "group-data-[run-work-folding-disabled]/chat:-mt-4",
+      )}
     >
       <div className="hidden @[900px]:block" />
       <div className="min-w-0">{content}</div>
@@ -7994,7 +7998,7 @@ function PagedAssistantEventItem({
         className={cn(
           compact ? "py-1 text-[13px] leading-5" : undefined,
           legacyTopPadding &&
-            "@[900px]:group-data-[run-work-folding-disabled]/chat:pt-2.5",
+            "@[900px]:group-data-[run-work-folding-disabled]/chat:first:pt-2.5",
         )}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}
@@ -8019,7 +8023,7 @@ function PagedAssistantEventItem({
             ? "py-1 text-[13px] leading-5"
             : CHAT_THREAD_RESPONSE_LINE_CLASS,
           legacyTopPadding &&
-            "@[900px]:group-data-[run-work-folding-disabled]/chat:pt-2.5",
+            "@[900px]:group-data-[run-work-folding-disabled]/chat:first:pt-2.5",
         )}
         data-chat-scroll-anchor-event-id={event.id}
         data-chat-run-id={event.runId}


### PR DESCRIPTION
When `chatRunWorkFolding` is disabled, running indicators and finished follow-ups inherit the outer 24px turn gap. Reduce their spacing after response actions to the same 8px used by response sections.

Apply legacy first-line top padding only when the message body is its parent's first child. A preceding goal or work-history summary already occupies the avatar's first row, so the following reply should not receive that extra padding. Both adjustments are scoped to the disabled switch.

## Validation

- Formatting, platform lint, full repository type checks, Knip, and commit hooks passed.
- [PR CI passed](https://github.com/vm0-ai/vm0/actions/runs/34198413459). No full local Vitest run or local development server.
- Browser QA on deployed head `67a2f6ea632b3d683662854522d0fc076cc917ce`: desktop 1440×1000 and mobile 390×844 in Chromium 152.

| Browser measurement | Folding disabled | Folding enabled |
| --- | --- | --- |
| Actions to running indicator | 8px | 8px |
| Actions to finished follow-ups | 8px | 8px |
| Reply top padding after a goal summary | 5.25px | 5.25px |
| Ordinary leading reply top padding | 10px | 5.25px |

The disabled goal-summary-to-reply gap is 8px. Mobile running and finished tails also measure 8px, with no horizontal overflow.

Preview: [App](https://pr-32554-app-okou-app-preview.vm0.workers.dev) · [API](https://pr-32554-api.vm6.ai)

Screenshots with the switch disabled: [running indicator](https://a.okou.io/he2umvv495.png) · [finished follow-ups](https://a.okou.io/12f2cze2lk.png) · [goal summary and reply](https://a.okou.io/1p8osdw9o6.png).

Fixtures use a disposable Clerk test account, bypassed onboarding, and Stripe TEST billing. Running/finished replies use mock Claude replay. The goal screenshot uses two completed mock Codex continuations after a real Claude setup run; its response text is test data. The goal is paused, all test runs have ended, and the preview account has no queued or active runs.
