### PR TITLE
fix(guest-agent): handle short reads in streaming upload buffers

### DIFF
--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -928,7 +928,8 @@ impl http_body::Body for SizedBody {
         let to_read = next_chunk_size(*this.remaining);
         let spare_capacity = this.buffer.capacity() - buffer_len;
         if spare_capacity < to_read {
-            this.buffer.reserve(to_read - spare_capacity);
+            // `reserve` takes additional space relative to length, not capacity.
+            this.buffer.reserve(to_read);
         }
 
         let Some(spare) = this.buffer.spare_capacity_mut().get_mut(..to_read) else {
@@ -1118,24 +1119,42 @@ mod tests {
         let data: Vec<u8> = (0..(STREAM_CHUNK_SIZE * 2 + 37))
             .map(|i| (i % 251) as u8)
             .collect();
-        let (_dir, mut body) = sized_body_from_bytes(&data).await;
+        for read_size in [STREAM_CHUNK_SIZE, 8192] {
+            for retain_frames in [false, true] {
+                let (_dir, mut body) = sized_body_from_bytes(&data).await;
+                // Force legal short reads through the real file reader.
+                body.reader.set_max_buf_size(read_size);
 
-        let mut remaining = data.len() as u64;
-        assert_eq!(body.size_hint().exact(), Some(remaining));
+                let mut remaining = data.len() as u64;
+                assert_eq!(body.size_hint().exact(), Some(remaining));
+                assert!(!body.is_end_stream());
 
-        let mut chunks = 0;
-        let mut uploaded = Vec::with_capacity(data.len());
-        while let Some(chunk) = next_data(&mut body).await {
-            assert!(chunk.len() <= STREAM_CHUNK_SIZE);
-            chunks += 1;
-            remaining = remaining.saturating_sub(chunk.len() as u64);
-            assert_eq!(body.size_hint().exact(), Some(remaining));
-            uploaded.extend_from_slice(&chunk);
+                let mut chunks = 0;
+                let mut uploaded = Vec::with_capacity(data.len());
+                let mut retained = Vec::new();
+                while let Some(chunk) = next_data(&mut body).await {
+                    assert!(!chunk.is_empty());
+                    assert!(chunk.len() <= read_size);
+                    chunks += 1;
+                    remaining -= chunk.len() as u64;
+                    assert_eq!(body.size_hint().exact(), Some(remaining));
+                    assert_eq!(body.is_end_stream(), remaining == 0);
+                    uploaded.extend_from_slice(&chunk);
+                    if retain_frames {
+                        retained.push(chunk);
+                    }
+                }
+
+                assert!(chunks > 1);
+                assert_eq!(uploaded, data);
+                if retain_frames {
+                    assert_eq!(retained.concat(), data);
+                }
+                assert_eq!(body.size_hint().exact(), Some(0));
+                assert!(body.is_end_stream());
+                assert!(next_data(&mut body).await.is_none());
+            }
         }
-
-        assert!(chunks > 1);
-        assert_eq!(uploaded, data);
-        assert_eq!(body.size_hint().exact(), Some(0));
     }
 
     #[tokio::test]

--- a/crates/guest-agent/tests/integration_cases/presigned_upload.rs
+++ b/crates/guest-agent/tests/integration_cases/presigned_upload.rs
@@ -278,17 +278,21 @@ async fn put_presigned_file_retry_then_succeed() {
 
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("retry.bin");
-    std::fs::write(&file_path, b"retry file data").unwrap();
+    let data: Vec<u8> = (0..600000).map(|i| (i % 251) as u8).collect();
+    std::fs::write(&file_path, &data).unwrap();
 
     let mock = server.mock(|when, then| {
         when.method(PUT).path("/test/put-file-retry");
         let attempts = AtomicUsize::new(0);
         then.respond_with(move |req| {
+            if !upload_request_matches(req, &data, "600000") {
+                return http_status(400);
+            }
             if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
                 return http_status(500);
             }
 
-            upload_validation_response(req, b"retry file data", "15")
+            http_status(200)
         });
     });
 
@@ -435,14 +439,14 @@ async fn put_presigned_file_large_multi_chunk() {
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("large.bin");
     // 600000 bytes — spans multiple 256 KiB streaming chunks.
-    let data = vec![0x42u8; 600000];
+    let data: Vec<u8> = (0..600000).map(|i| (i % 251) as u8).collect();
     std::fs::write(&file_path, &data).unwrap();
 
     let mock = server.mock(|when, then| {
         when.method(PUT)
             .path("/test/put-file-large")
             .header("Content-Length", "600000");
-        then.status(200);
+        then.respond_with(move |req| upload_validation_response(req, &data, "600000"));
     });
 
     let url = api.url("/test/put-file-large");


### PR DESCRIPTION
## Summary

Closes #32531.

Fix the streaming upload body's reservation after a legal short file read.
`BytesMut::reserve` takes writable space relative to length, not a capacity
deficit. The old calculation could leave too little spare space and abort a
valid archive or manifest upload with `failed to reserve streaming upload buffer`.

- Reserve the next bounded read's full writable size when capacity is insufficient.
- Extend real-file Body coverage to normal and forced 8 KiB reads with released
  and retained frames, checking exact bytes, remaining size hints, bounded chunks,
  terminal state, and retained-frame integrity after later reads.
- Verify complete patterned 600000-byte uploads and full replay on retry through
  the public HTTP API and the existing mock server.

No changes to chunk size, source identity/length, Content-Length, authentication,
timeouts, retry policy, API/protocols, dependencies, or CI. No migration or
cross-version compatibility code is required.

## Validation

- Regression failed on unchanged production code with the reported buffer error;
  the same test passes after the fix (all four read/ownership combinations).
- `cargo fmt --all -- --check`
- `cargo clippy --profile local -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --profile local --no-deps -p guest-agent --all-features`
- `cargo test --profile local -p guest-agent --all-targets --all-features -- --quiet`
- `git diff --check`

All selected checks passed, including 650 library tests, 15 command-entry tests,
136 main integration cases, and the standalone integration targets. No new
ignored tests or suppressions. Workspace Clippy/rustdoc and commit hooks also
passed. The required post-pull local DB migration hit the
existing `chat_thread_event_kind` enum conflict (42710); these Rust checks do not
depend on PostgreSQL, and no DB repair is included.

## Risks and limitations

Correct reservation can allocate when earlier short frames remain held; dropped
views can be reclaimed. Reads remain bounded at 256 KiB and the body does not
preload the source. Existing premature-EOF and retry behavior remain covered.
Production incidence and production performance were not measured.
