### PR TITLE
fix(rust): enforce exec-control request deadlines

### DIFF
--- a/crates/guest-control-server/src/exec_control/deadline_io.rs
+++ b/crates/guest-control-server/src/exec_control/deadline_io.rs
@@ -1,0 +1,108 @@
+use std::io::{self, Read, Write};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::time::Instant;
+
+use super::{CONTROL_SINK_IO_TIMEOUT, duration_until, request_timeout_error};
+
+/// Applies one request budget across codec reads, writes, and partial progress.
+/// Per-call nonblocking flags leave the mode of all cloned handles unchanged.
+pub(super) struct DeadlineStream<'a> {
+    stream: &'a mut UnixStream,
+    deadline: Instant,
+    pub(super) io_started: bool,
+}
+
+impl<'a> DeadlineStream<'a> {
+    pub(super) fn new(stream: &'a mut UnixStream, deadline: Instant) -> Self {
+        Self {
+            stream,
+            deadline,
+            io_started: false,
+        }
+    }
+
+    fn perform_io(
+        &mut self,
+        events: libc::c_short,
+        mut operation: impl FnMut(RawFd) -> libc::ssize_t,
+    ) -> io::Result<usize> {
+        let deadline = self.deadline.min(Instant::now() + CONTROL_SINK_IO_TIMEOUT);
+        loop {
+            duration_until(deadline).ok_or_else(request_timeout_error)?;
+            self.io_started = true;
+            let result = operation(self.stream.as_raw_fd());
+            if result >= 0 {
+                return Ok(result as usize);
+            }
+            let error = io::Error::last_os_error();
+            match error.kind() {
+                io::ErrorKind::Interrupted => continue,
+                io::ErrorKind::WouldBlock => self.wait_ready(events, deadline)?,
+                _ => return Err(error),
+            }
+        }
+    }
+
+    fn wait_ready(&self, events: libc::c_short, deadline: Instant) -> io::Result<()> {
+        loop {
+            let remaining = duration_until(deadline).ok_or_else(request_timeout_error)?;
+            let timeout_ms = remaining.as_millis().clamp(1, libc::c_int::MAX as u128);
+            let mut descriptor = libc::pollfd {
+                fd: self.stream.as_raw_fd(),
+                events,
+                revents: 0,
+            };
+            // SAFETY: descriptor is initialized and borrowed for one entry;
+            // the timeout is a bounded, positive millisecond count.
+            let result = unsafe { libc::poll(&mut descriptor, 1, timeout_ms as libc::c_int) };
+            if result < 0 {
+                let error = io::Error::last_os_error();
+                if error.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(error);
+            }
+            if result > 0 {
+                // Retry recv/send for readiness, EOF, or socket errors. The
+                // caller checks the deadline again before that nonblocking I/O.
+                return Ok(());
+            }
+            // Millisecond rounding can wake us early; retain the same deadline.
+        }
+    }
+}
+
+impl Read for DeadlineStream<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        self.perform_io(libc::POLLIN, |fd| {
+            // SAFETY: fd stays live through the borrowed stream. buffer is
+            // writable for its length, and recv does not retain its pointer.
+            unsafe {
+                libc::recv(
+                    fd,
+                    buffer.as_mut_ptr().cast(),
+                    buffer.len(),
+                    libc::MSG_DONTWAIT,
+                )
+            }
+        })
+    }
+}
+
+impl Write for DeadlineStream<'_> {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let flags = libc::MSG_DONTWAIT;
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let flags = flags | libc::MSG_NOSIGNAL;
+        self.perform_io(libc::POLLOUT, |fd| {
+            // SAFETY: fd stays live through the borrowed stream. buffer is
+            // readable for its length, and send does not retain its pointer.
+            unsafe { libc::send(fd, buffer.as_ptr().cast(), buffer.len(), flags) }
+        })
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.stream.flush()
+    }
+}

--- a/crates/guest-control-server/src/exec_control/forward.rs
+++ b/crates/guest-control-server/src/exec_control/forward.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::os::unix::net::UnixStream;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use guest_control_proto::{ExecControlNonce, ExecControlStatus, MSG_EXEC_CONTROL_RESULT};
 use process_control_ipc::{ControlRequest, ControlResponseStatus};
@@ -12,9 +12,10 @@ use crate::log::log;
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::writer::GuestWriter;
 
+use super::deadline_io::DeadlineStream;
 use super::sink::{ControlSinkState, ControlStreamLockError, PendingControlSlot};
 use super::{
-    CONTROL_SINK_IO_TIMEOUT, EXEC_CONTROL_LOG_NAME, EXEC_CONTROL_MESSAGE_ID_MISMATCH_PREFIX,
+    EXEC_CONTROL_LOG_NAME, EXEC_CONTROL_MESSAGE_ID_MISMATCH_PREFIX,
     EXEC_CONTROL_WORKER_START_ERROR_PREFIX, EXEC_OPERATION_INACTIVE_MESSAGE,
     EXEC_REQUEST_TIMEOUT_DIAGNOSTIC, THREAD_EXEC_CONTROL_FORWARD, duration_until, is_timeout,
     request_timeout_error,
@@ -176,29 +177,17 @@ fn forward_to_connected_sink(
         message_id: message_id.to_owned(),
         payload,
     };
-    let write_timeout = match control_sink_io_timeout(deadline) {
-        Ok(timeout) => timeout,
-        Err(error) if is_timeout(&error) => {
-            return control_forward_io_error(
-                ExecControlStatus::SinkTimeout,
-                error,
-                ControlSinkDisposition::Keep,
-            );
-        }
-        Err(error) => {
-            return control_forward_io_error(
-                ExecControlStatus::SinkError,
-                error,
-                ControlSinkDisposition::Keep,
-            );
-        }
-    };
-    if let Err(error) = write_control_request(stream, &request_frame, write_timeout) {
+    let mut stream = DeadlineStream::new(stream, deadline);
+    if let Err(error) = process_control_ipc::write_request(&mut stream, &request_frame) {
         return if is_timeout(&error) {
             control_forward_io_error(
                 ExecControlStatus::SinkTimeout,
                 error,
-                ControlSinkDisposition::Fail,
+                if stream.io_started {
+                    ControlSinkDisposition::Fail
+                } else {
+                    ControlSinkDisposition::Keep
+                },
             )
         } else {
             control_forward_io_error(
@@ -209,24 +198,14 @@ fn forward_to_connected_sink(
         };
     }
 
-    let read_timeout = match control_sink_io_timeout(deadline) {
-        Ok(timeout) => timeout,
-        Err(error) if is_timeout(&error) => {
-            return control_forward_io_error(
-                ExecControlStatus::SinkTimeout,
-                error,
-                ControlSinkDisposition::Fail,
-            );
-        }
-        Err(error) => {
-            return control_forward_io_error(
-                ExecControlStatus::SinkError,
-                error,
-                ControlSinkDisposition::Fail,
-            );
-        }
-    };
-    match read_control_response(stream, read_timeout) {
+    match process_control_ipc::read_response(&mut stream) {
+        // Socket timeout rounding and scheduling can complete the final read
+        // after its budget. Never turn that late response into an acceptance.
+        Ok(_) if request_expired(deadline) => control_forward_io_error(
+            ExecControlStatus::SinkTimeout,
+            request_timeout_error(),
+            ControlSinkDisposition::Fail,
+        ),
         Ok(response) if response.message_id != message_id => ControlForwardOutcome {
             status: ExecControlStatus::SinkError,
             diagnostic: format!(
@@ -284,30 +263,6 @@ fn control_forward_io_error(
 
 fn request_expired(deadline: Instant) -> bool {
     duration_until(deadline).is_none()
-}
-
-fn control_sink_io_timeout(deadline: Instant) -> io::Result<Duration> {
-    duration_until(deadline)
-        .map(|remaining| remaining.min(CONTROL_SINK_IO_TIMEOUT))
-        .filter(|timeout| !timeout.is_zero())
-        .ok_or_else(request_timeout_error)
-}
-
-fn write_control_request(
-    stream: &mut UnixStream,
-    request: &ControlRequest,
-    timeout: Duration,
-) -> io::Result<()> {
-    stream.set_write_timeout(Some(timeout))?;
-    process_control_ipc::write_request(stream, request)
-}
-
-fn read_control_response(
-    stream: &mut UnixStream,
-    timeout: Duration,
-) -> io::Result<process_control_ipc::ControlResponse> {
-    stream.set_read_timeout(Some(timeout))?;
-    process_control_ipc::read_response(stream)
 }
 
 pub(super) fn encode_control_result(

--- a/crates/guest-control-server/src/exec_control/mod.rs
+++ b/crates/guest-control-server/src/exec_control/mod.rs
@@ -7,6 +7,7 @@ use crate::error::to_io_error;
 use crate::writer::GuestWriter;
 
 mod accept;
+mod deadline_io;
 mod forward;
 mod registry;
 mod sink;

--- a/crates/guest-control-server/src/exec_control/tests/deadlines.rs
+++ b/crates/guest-control-server/src/exec_control/tests/deadlines.rs
@@ -1,0 +1,246 @@
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+use guest_control_proto::ExecControlStatus;
+
+use super::super::forward::forward_control_request;
+use super::super::sink::ControlSinkInner;
+use super::super::{EXEC_REQUEST_TIMEOUT_DIAGNOSTIC, request_deadline};
+use super::support::{
+    connected_sink, connected_stream_handle, guest_writer_pair, owned_control_request,
+    read_exec_control_result,
+};
+
+// A version-1 Accepted response for message "m", with no diagnostic.
+const RESPONSE: &[u8] = &[0, 0, 0, 8, 1, 3, 0, 1, b'm', 0, 0, 0];
+const PEER_TIMEOUT: Duration = Duration::from_secs(3);
+
+fn assert_peer_closed(peer: &mut UnixStream) {
+    match peer.read(&mut [0]) {
+        Ok(0) => {}
+        // Closing with an unread fragment can reset the peer instead of EOF.
+        Err(error) => assert_eq!(error.kind(), std::io::ErrorKind::ConnectionReset),
+        result => panic!("sink must shut down, got {result:?}"),
+    }
+}
+
+fn assert_fragmented_response_timeout(fragments: &[&[u8]], interval: Duration) {
+    let (sink, mut peer) = connected_sink();
+    peer.set_read_timeout(Some(PEER_TIMEOUT)).unwrap();
+    peer.set_write_timeout(Some(PEER_TIMEOUT)).unwrap();
+    let pending_slot = sink.reserve_pending_slot().unwrap();
+    let (writer, mut host) = guest_writer_pair();
+
+    std::thread::scope(|scope| {
+        let worker_sink = Arc::clone(&sink);
+        let worker = scope.spawn(move || {
+            forward_control_request(
+                worker_sink,
+                pending_slot,
+                owned_control_request(12, 8, 400, "m"),
+                writer.clone(),
+            );
+            writer
+        });
+
+        let request = process_control_ipc::read_request(&mut peer).unwrap();
+        assert_eq!(request.message_id, "m");
+        assert_eq!(request.payload, b"payload");
+        let mut sent = 0;
+        for fragment in fragments {
+            if sent > 0 {
+                std::thread::sleep(interval);
+            }
+            match peer.write_all(fragment) {
+                Ok(()) => sent += fragment.len(),
+                Err(error) => {
+                    assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+                    break;
+                }
+            }
+        }
+
+        let (_, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);
+        let writer = worker.join().unwrap();
+        assert_eq!(seq, 12);
+        assert_eq!(message_id, "m");
+        assert_eq!(status, ExecControlStatus::SinkTimeout);
+        assert!(!diagnostic.is_empty());
+        assert!(sent > fragments[0].len(), "peer must make partial progress");
+        assert_eq!(sink.pending.load(Ordering::Acquire), 0);
+        assert!(matches!(
+            *sink.inner.lock().unwrap(),
+            ControlSinkInner::Failed(_)
+        ));
+        assert_peer_closed(&mut peer);
+
+        forward_control_request(
+            Arc::clone(&sink),
+            sink.reserve_pending_slot().unwrap(),
+            owned_control_request(13, 8, 5000, "after-timeout"),
+            writer,
+        );
+        let (_, seq, status, message_id, _) = read_exec_control_result(&mut host);
+        assert_eq!(seq, 13);
+        assert_eq!(message_id, "after-timeout");
+        assert_eq!(status, ExecControlStatus::SinkError);
+        assert_eq!(sink.pending.load(Ordering::Acquire), 0);
+    });
+}
+
+#[test]
+fn fragmented_control_response_prefix_cannot_extend_request_deadline() {
+    assert_fragmented_response_timeout(
+        &[
+            &RESPONSE[..1],
+            &RESPONSE[1..2],
+            &RESPONSE[2..3],
+            &RESPONSE[3..],
+        ],
+        Duration::from_millis(200),
+    );
+}
+
+#[test]
+fn fragmented_control_response_body_cannot_extend_request_deadline() {
+    let fragments: Vec<_> = std::iter::once(&RESPONSE[..4])
+        .chain(RESPONSE[4..].chunks(1))
+        .collect();
+    assert_fragmented_response_timeout(&fragments, Duration::from_millis(100));
+}
+
+#[test]
+fn backpressured_control_request_stops_before_the_frame_is_complete() {
+    let (sink, mut peer) = connected_sink();
+    peer.set_read_timeout(Some(PEER_TIMEOUT)).unwrap();
+    let stream_handle = connected_stream_handle(&sink);
+    let stream = stream_handle
+        .lock_until(request_deadline(5000), &sink.active)
+        .unwrap();
+    let send_buffer: libc::c_int = 4096;
+    // SAFETY: the guard keeps the socket live, and the option points to an
+    // initialized integer with the correct length for SO_SNDBUF.
+    let result = unsafe {
+        libc::setsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_SNDBUF,
+            (&raw const send_buffer).cast(),
+            std::mem::size_of_val(&send_buffer) as libc::socklen_t,
+        )
+    };
+    assert_eq!(result, 0, "{}", std::io::Error::last_os_error());
+    drop(stream);
+
+    let pending_slot = sink.reserve_pending_slot().unwrap();
+    let (writer, mut host) = guest_writer_pair();
+    let mut request = owned_control_request(12, 8, 5000, "m");
+    request.payload = vec![0xA5; process_control_ipc::MAX_CONTROL_PAYLOAD_BYTES];
+    let frame_len = 4 + 2 + 2 + 1 + 4 + request.payload.len();
+
+    std::thread::scope(|scope| {
+        let worker_sink = Arc::clone(&sink);
+        let worker = scope.spawn(move || {
+            request.deadline = request_deadline(400);
+            forward_control_request(worker_sink, pending_slot, request, writer);
+        });
+
+        let started = Instant::now();
+        let mut received = 0;
+        let mut buffer = [0; 4096];
+        while received < frame_len {
+            let count = peer.read(&mut buffer).unwrap();
+            if count == 0 {
+                break;
+            }
+            received += count;
+            // Keep making progress below the per-call timeout, but take much
+            // longer than the total budget. Bound even the broken-code path.
+            if started.elapsed() < Duration::from_secs(2) {
+                std::thread::sleep(Duration::from_millis(40));
+            }
+        }
+
+        let (_, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);
+        worker.join().unwrap();
+        assert_eq!(seq, 12);
+        assert_eq!(message_id, "m");
+        assert_eq!(status, ExecControlStatus::SinkTimeout);
+        assert!(!diagnostic.is_empty());
+        assert!(received > buffer.len(), "peer must make partial progress");
+        assert!(
+            received < frame_len,
+            "expired request must stop writing, received {received}/{frame_len} bytes"
+        );
+        assert_eq!(sink.pending.load(Ordering::Acquire), 0);
+        assert!(matches!(
+            *sink.inner.lock().unwrap(),
+            ControlSinkInner::Failed(_)
+        ));
+        assert_peer_closed(&mut peer);
+    });
+}
+
+#[test]
+fn pre_io_timeout_preserves_sink_for_fragmented_delivery_within_budget() {
+    let (sink, mut peer) = connected_sink();
+    let (writer, mut host) = guest_writer_pair();
+    forward_control_request(
+        Arc::clone(&sink),
+        sink.reserve_pending_slot().unwrap(),
+        owned_control_request(12, 8, 0, "expired"),
+        writer.clone(),
+    );
+    let (_, _, status, _, diagnostic) = read_exec_control_result(&mut host);
+    assert_eq!(status, ExecControlStatus::SinkTimeout);
+    assert_eq!(diagnostic, EXEC_REQUEST_TIMEOUT_DIAGNOSTIC);
+    assert_eq!(sink.pending.load(Ordering::Acquire), 0);
+    peer.set_nonblocking(true).unwrap();
+    assert_eq!(
+        peer.read(&mut [0]).unwrap_err().kind(),
+        std::io::ErrorKind::WouldBlock,
+        "expired request must not write or shut down the socket"
+    );
+    peer.set_nonblocking(false).unwrap();
+    peer.set_read_timeout(Some(PEER_TIMEOUT)).unwrap();
+    peer.set_write_timeout(Some(PEER_TIMEOUT)).unwrap();
+
+    for seq in [13, 14] {
+        let pending_slot = sink.reserve_pending_slot().unwrap();
+        std::thread::scope(|scope| {
+            let worker_sink = Arc::clone(&sink);
+            let worker_writer = writer.clone();
+            let worker = scope.spawn(move || {
+                forward_control_request(
+                    worker_sink,
+                    pending_slot,
+                    owned_control_request(seq, 8, 5000, "m"),
+                    worker_writer,
+                );
+            });
+            let request = process_control_ipc::read_request(&mut peer).unwrap();
+            assert_eq!(request.message_id, "m");
+            assert_eq!(request.payload, b"payload");
+            for byte in RESPONSE.chunks(1) {
+                peer.write_all(byte).unwrap();
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            let (_, result_seq, status, message_id, diagnostic) =
+                read_exec_control_result(&mut host);
+            worker.join().unwrap();
+            assert_eq!(result_seq, seq);
+            assert_eq!(message_id, "m");
+            assert_eq!(status, ExecControlStatus::Delivered);
+            assert_eq!(diagnostic, "");
+            assert_eq!(sink.pending.load(Ordering::Acquire), 0);
+            assert!(matches!(
+                *sink.inner.lock().unwrap(),
+                ControlSinkInner::Connected(_)
+            ));
+        });
+    }
+}

--- a/crates/guest-control-server/src/exec_control/tests/deadlines.rs
+++ b/crates/guest-control-server/src/exec_control/tests/deadlines.rs
@@ -149,20 +149,24 @@ fn backpressured_control_request_stops_before_the_frame_is_complete() {
             forward_control_request(worker_sink, pending_slot, request, writer);
         });
 
-        let started = Instant::now();
-        let mut received = 0;
         let mut buffer = [0; 4096];
+        let mut received = peer.read(&mut buffer).unwrap();
+        assert!(
+            received > 0,
+            "request must start before the slow-drain window"
+        );
+        let started = Instant::now();
         while received < frame_len {
-            let count = peer.read(&mut buffer).unwrap();
-            if count == 0 {
-                break;
-            }
-            received += count;
             // Keep making progress below the per-call timeout, but take much
             // longer than the total budget. Bound even the broken-code path.
             if started.elapsed() < Duration::from_secs(2) {
                 std::thread::sleep(Duration::from_millis(40));
             }
+            let count = peer.read(&mut buffer).unwrap();
+            if count == 0 {
+                break;
+            }
+            received += count;
         }
 
         let (_, seq, status, message_id, diagnostic) = read_exec_control_result(&mut host);

--- a/crates/guest-control-server/src/exec_control/tests/mod.rs
+++ b/crates/guest-control-server/src/exec_control/tests/mod.rs
@@ -1,3 +1,4 @@
+mod deadlines;
 mod forwarding;
 mod handle;
 mod registry;

--- a/crates/process-control-ipc/src/codec.rs
+++ b/crates/process-control-ipc/src/codec.rs
@@ -63,7 +63,7 @@ pub fn read_hello(stream: &mut UnixStream) -> io::Result<()> {
 /// Returns `InvalidInput` if the message id is empty, the message id does not
 /// fit in `u16`, or the payload exceeds [`crate::MAX_CONTROL_PAYLOAD_BYTES`].
 /// Stream write failures are returned as standard library `io::Error` values.
-pub fn write_request(stream: &mut UnixStream, request: &ControlRequest) -> io::Result<()> {
+pub fn write_request(stream: &mut impl Write, request: &ControlRequest) -> io::Result<()> {
     let message_id = request.message_id.as_bytes();
     if message_id.is_empty() || message_id.len() > MAX_MESSAGE_ID_BYTES {
         return Err(io::Error::new(
@@ -163,7 +163,7 @@ pub fn write_response(stream: &mut UnixStream, response: &ControlResponse) -> io
 /// UTF-8, contains trailing bytes, contains an unknown status byte, or declares
 /// a diagnostic larger than [`crate::MAX_DIAGNOSTIC_BYTES`]. Stream read
 /// failures are returned as standard library `io::Error` values.
-pub fn read_response(stream: &mut UnixStream) -> io::Result<ControlResponse> {
+pub fn read_response(stream: &mut impl Read) -> io::Result<ControlResponse> {
     let frame = read_frame(stream)?;
     if frame.kind != FRAME_RESPONSE {
         return Err(io::Error::new(
@@ -214,7 +214,7 @@ fn write_frame(stream: &mut UnixStream, kind: u8, payload: &[u8]) -> io::Result<
     stream.write_all(&frame)
 }
 
-fn read_frame(stream: &mut UnixStream) -> io::Result<Frame> {
+fn read_frame(stream: &mut impl Read) -> io::Result<Frame> {
     let mut len = [0u8; 4];
     stream.read_exact(&mut len)?;
     let body_len = u32::from_be_bytes(len) as usize;


### PR DESCRIPTION
## Summary

- Enforce the existing absolute exec-control request deadline across partial request writes, response headers/bodies, and readiness waits.
- Use a private Read/Write adapter with per-call nonblocking socket flags and bounded poll waits. Preserve the five-second per-I/O cap without changing shared socket modes or adding threads/dependencies.
- Keep framing in process-control-ipc by generalizing only the needed codec entry points. Reject late decoded responses; fail/shut down a sink after I/O has started, while preserving no-I/O timeout reuse and operation-deactivation precedence.
- Add real-socket regressions for fragmented response headers/bodies, progressive backpressured writes, connected pre-I/O expiry, and successful fragmented/repeated delivery.

Closes #32532

## Verification

All commands ran from crates/ unless noted:

- cargo test --profile local -p process-control-ipc -p guest-control-server --all-features
- cargo test --profile local -p guest-agent --lib control::
- cargo test --profile local -p guest-tool-exec -p guest-control-tests
- cargo clippy --profile local --all-targets --all-features
- cargo doc --profile local --workspace --all-features --no-deps
- cargo xtask check-rust-path-attributes
- cargo fmt --all --check
- scripts/prepare.sh (repository root)

393 selected tests passed. Three existing privileged production-identity tests are executed explicitly by Rust CI; one existing optional file-write benchmark is ignored. This PR adds no skips or timeout increases.

The four new regressions additionally passed ten sequential repetitions (40/40).

Regression evidence: original forwarding returns Delivered for both late fragmented responses and writes the complete 1,048,589-byte backpressured request after its 400 ms budget. Updating SO_SNDTIMEO before each blocking Write call still failed the write regression, so the challenged plan was revised to per-call nonblocking I/O. The final implementation stops the incomplete write and returns SinkTimeout.

## Scope and risks

No wire-format/status/API/persisted-state changes, protocol negotiation, handshake-budget changes, or host-facing result-writer changes. No deployment ordering requirement. Slow sinks previously accepted after expiry now fail for that exec operation. Timeout does not prove the sink has not acted, so no automatic retry is introduced. OS scheduling can delay observation of a deadline, but a late decoded response is not accepted. Production/privileged validation remains with CI; no production soak is claimed.
