### PR TITLE
refactor(mitm-addon): initialize policy reduction with the selected base

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -1287,12 +1287,11 @@ class _FirewallMatchCollection:
 
 
 class _FirewallDecisionState:
-    """Mutable decision state for selected-owner policy reduction."""
+    """Policy reduction state initialized with the preselected base fallback."""
 
     __slots__ = (
         "allowed_match",
         "base_match",
-        "best_base_specificity",
         "denied_match",
         "denied_permission_names",
         "malformed_config_match",
@@ -1301,53 +1300,19 @@ class _FirewallDecisionState:
 
     allowed_match: _AllowedRuleMatch | None
     base_match: _BaseMatch | None
-    best_base_specificity: _BaseSpecificity | None
     denied_match: _BlockMatch | None
     # Dict keys act as an ordered set of first-seen denied permission names.
     denied_permission_names: dict[str, None]
     malformed_config_match: _BlockMatch | None
     malformed_policy_match: _BlockMatch | None
 
-    def __init__(self) -> None:
+    def __init__(self, base_match: _BaseMatch | None) -> None:
         self.allowed_match = None
-        self.base_match = None
-        self.best_base_specificity = None
+        self.base_match = base_match
         self.denied_match = None
         self.denied_permission_names = {}
         self.malformed_config_match = None
         self.malformed_policy_match = None
-
-    def accept_base_match(
-        self,
-        api_entry: _CompiledApi,
-        *,
-        name: str,
-        rel_path: str,
-        base_params: dict[str, str],
-    ) -> bool:
-        if (
-            self.best_base_specificity is None
-            or api_entry.base.specificity > self.best_base_specificity
-        ):
-            self.best_base_specificity = api_entry.base.specificity
-            self.allowed_match = None
-            self.base_match = None
-            self.denied_match = None
-            self.denied_permission_names = {}
-            self.malformed_config_match = None
-            self.malformed_policy_match = None
-        elif api_entry.base.specificity < self.best_base_specificity:
-            return False
-
-        if self.base_match is None:
-            self.base_match = _BaseMatch(
-                api_entry.base.raw,
-                name,
-                rel_path,
-                api_entry.raw_api_entry,
-                base_params,
-            )
-        return True
 
     def record_malformed_config(self, match: _BlockMatch) -> None:
         if self.malformed_config_match is None:
@@ -1674,18 +1639,24 @@ def _reduce_selected_owner(
         if conflicting_block is not None:
             return conflicting_block
 
-    decision = _FirewallDecisionState()
+    # Collection owns base specificity; owner/permissionless filtering preserves
+    # that tier's order, so only its first selected fallback is needed here.
+    base_match = next(
+        (
+            _BaseMatch(
+                match.api.base.raw,
+                match.firewall.name,
+                match.rel_path,
+                match.api.raw_api_entry,
+                match.base_params,
+            )
+            for match in _selected_base_api_matches(collection, selected_name)
+        ),
+        None,
+    )
+    decision = _FirewallDecisionState(base_match)
     evaluable_api_orders: set[int] = set()
     relevant_api_matches = _relevant_owner_api_matches(collection, selected_name)
-
-    for api_match in _selected_base_api_matches(collection, selected_name):
-        fw_entry = api_match.firewall
-        decision.accept_base_match(
-            api_match.api,
-            name=fw_entry.name,
-            rel_path=api_match.rel_path,
-            base_params=api_match.base_params,
-        )
 
     for api_match in relevant_api_matches:
         fw_entry = api_match.firewall

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_base_specificity_precedence.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_base_specificity_precedence.py
@@ -325,42 +325,35 @@ def test_more_specific_base_allow_precedence_matrix(
     assert result.rel_path == expected["rel_path"]
 
 
-def test_more_specific_parameterized_base_unknown_allow_preserves_params():
-    fws = [
-        {
-            "name": "broad",
-            "apis": [
-                {
-                    "base": "https://api.example.com",
-                    "auth": {"headers": {"Authorization": "Bearer broad"}},
-                    "permissions": [
-                        {"name": "broad", "rules": ["ANY /{path+}"]},
-                    ],
-                }
-            ],
-        },
-        {
-            "name": "tenant",
-            "apis": [
-                {
-                    "base": "https://{workspace}.example.com/api/{tenant}",
-                    "auth": {"headers": {"Authorization": "Bearer tenant"}},
-                    "permissions": [],
-                }
-            ],
-        },
+@pytest.mark.parametrize("specific_first", [False, True], ids=["broad-first", "specific-first"])
+@pytest.mark.parametrize("reverse_fallbacks", [False, True], ids=["original", "reversed"])
+def test_more_specific_parameterized_base_unknown_allow_preserves_first_selected_fallback(
+    specific_first, reverse_fallbacks
+):
+    tenant_base = "https://{workspace}.example.com/api/{tenant}"
+    fallback_apis = [
+        firewall_api(tenant_base, [], auth_label="tenant"),
+        firewall_api(tenant_base, [], auth_label="tenant"),
     ]
+    if reverse_fallbacks:
+        fallback_apis.reverse()
+    fws = [
+        broad_firewall(base="https://{workspace}.example.com"),
+        firewall_entry(
+            "tenant",
+            firewall_api(
+                tenant_base,
+                [firewall_permission("admin", "GET /admin")],
+                auth_label="admin",
+            ),
+            *fallback_apis,
+        ),
+    ]
+    if specific_first:
+        fws.reverse()
     policies = {
-        "broad": {
-            "allow": [],
-            "deny": ["broad"],
-            "unknownPolicy": "deny",
-        },
-        "tenant": {
-            "allow": [],
-            "deny": [],
-            "unknownPolicy": "allow",
-        },
+        "broad": network_policy(deny=["broad"]),
+        "tenant": network_policy(unknown_policy="allow"),
     }
 
     result = matching.match_compiled_firewall_request(
@@ -371,6 +364,7 @@ def test_more_specific_parameterized_base_unknown_allow_preserves_params():
     )
 
     assert isinstance(result, matching.FirewallAllow)
+    assert result.api_entry is fallback_apis[0]
     assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer tenant"
     assert result.name == "tenant"
     assert result.permission is None


### PR DESCRIPTION
## Summary

- Make `_FirewallMatchCollection` the sole owner of base-tier selection. Its `accept_api()` retains only one specificity tier, and the owner/permissionless helpers only filter that ordered tier.
- Initialize `_FirewallDecisionState` with the first preselected `_BaseMatch` (or None), removing its duplicate specificity field, base-acceptance method, unreachable rejection result and repeated policy resets.
- Strengthen the existing matcher-entry-point regression to preserve the first eligible raw API object, owner, relative path and host/path captures in both broad/narrow and same-tier orders. The broad fixture now actually matches the request host.

This is behavior-preserving maintenance cleanup, not a fix for a demonstrated incorrect firewall decision. Collection, owner/conflict selection, policy/malformed precedence, permissionless fallback, empty/no-match and asterisk-form behavior remain unchanged. No UI, user workflow, external API/protocol, persistence, dependencies or deployment settings change. No new compatibility fallback or I/O is introduced; no benchmark claim is made.

Closes #32538

## Validation

From `crates/runner/mitm-addon`:

- `uv lock --check`
- `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/`: 7,350 passed in 83.49s (43 dependency/fixture warnings; no failures or skips).
- `git diff --check`
- Strengthened regression on the original production implementation: 4 passed.
- Focused base/rule-specificity, unknown-policy, malformed/cross-owner precedence, permission aggregation, indexed/linear and shared semantics-contract suites: 280 passed.
- Two temporary mutations independently failed the new raw-API identity assertion: bypassing permissionless selection and choosing the last eligible fallback. Both were restored; no mutation is part of this PR.

## Risks

The sensitive boundary is retaining the first entry of the **selected-base** sequence, not the broader relevant-owner sequence. Exact-result coverage and the existing semantics/precedence suites guard this. The reducer no longer pretends to accept mixed base tiers; a future caller must use the collection-owned selection boundary. No rollout coordination or follow-up cleanup is required.
