### PR TITLE
fix(runner): bind orphan group signals to verified process identity

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -102,6 +102,22 @@ binary overrides must use flags and environment keys matching the runner revisio
 - [Multi-architecture rollout](../docs/runner-multi-architecture.md): select,
   build, deploy, and validate architecture-specific runner artifacts.
 
+### Orphan sandbox termination
+
+`runner kill --sandbox <ID>` first asks the owning runner to terminate the
+sandbox. If that owner is gone, orphan termination validates the Firecracker
+process and workspace through a retained `/proc/<pid>` directory handle and
+signals the entire process group through that same kernel identity. A reused
+numeric PID or PGID cannot redirect the signal to a different process group.
+
+This orphan path requires Linux 6.9+ support for `pidfd_send_signal` with
+`PIDFD_SIGNAL_PROCESS_GROUP`, and the verified target must be the group leader.
+If the kernel or security policy rejects that operation, termination fails
+without falling back to numeric signaling or deleting the sandbox's resources.
+Inspect the reported error and host support before retrying. Normal termination
+through an owning runner still uses its owned child lifecycle and does not gain
+this new kernel requirement. `--run` targets do not fall back to orphan killing.
+
 ## nbd-cow Benchmark
 
 The `nbd-cow` benchmark compares NBD COW with dm-snapshot using fio workloads. It is an opt-in,

--- a/crates/runner/src/cmd/kill.rs
+++ b/crates/runner/src/cmd/kill.rs
@@ -810,7 +810,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
-    async fn unconfirmed_orphan_termination_preserves_cleanup_paths() {
+    async fn failed_or_unconfirmed_orphan_termination_preserves_cleanup_paths() {
         let workspace_base = tempfile::tempdir().unwrap();
         let socket_base = tempfile::tempdir().unwrap();
         let control = MockSandboxControl::new(socket_base.path());
@@ -819,16 +819,20 @@ mod tests {
         let socket_dir = control.runtime_dir("sbox-123");
         tokio::fs::create_dir_all(&workspace).await.unwrap();
         tokio::fs::create_dir_all(&socket_dir).await.unwrap();
-        let outcome = KillOutcome::OrphanTerminationUnconfirmed {
-            target: target.clone(),
-            failure: OrphanExitFailure::TimedOut,
-        };
+        for outcome in [
+            KillOutcome::OrphanTerminationUnconfirmed {
+                target: target.clone(),
+                failure: OrphanExitFailure::TimedOut,
+            },
+            KillOutcome::SignalFailed(target.clone()),
+            KillOutcome::AlreadyExitedOrChanged(target.clone()),
+        ] {
+            let exit_code = finish_kill_outcome(&target, &target, &outcome, &control).await;
 
-        let exit_code = finish_kill_outcome(&target, &target, &outcome, &control).await;
-
-        assert_eq!(exit_code, ExitCode::FAILURE);
-        assert!(workspace.exists());
-        assert!(socket_dir.exists());
+            assert_eq!(exit_code, ExitCode::FAILURE);
+            assert!(workspace.exists());
+            assert!(socket_dir.exists());
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/kill/orphan.rs
+++ b/crates/runner/src/cmd/kill/orphan.rs
@@ -5,13 +5,16 @@ use tracing::info;
 
 use crate::process::{
     self, DiscoveredProcesses, ProcessDiscovery, ProcessStat, ProcessStatRead,
-    ProcfsProcessGeneration,
+    ProcfsProcessGeneration, ProcfsProcessHandle,
 };
 
 use super::target::KillTarget;
 
 const ORPHAN_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 const ORPHAN_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[cfg(test)]
+mod identity_tests;
 
 #[derive(Debug)]
 pub(super) enum Outcome {
@@ -37,8 +40,8 @@ where
     Discover: FnOnce() -> DiscoverFuture,
     DiscoverFuture: std::future::Future<Output = ProcessDiscovery>,
 {
-    let generation = match validate_orphan_target(target).await {
-        OrphanTargetValidation::Valid { generation } => generation,
+    let validated = match validate_orphan_target(target).await {
+        OrphanTargetValidation::Valid(validated) => validated,
         OrphanTargetValidation::AlreadyGone => {
             return already_gone_orphan_outcome_with_discovery(target, discover).await;
         }
@@ -47,9 +50,9 @@ where
         }
     };
 
-    match signal_process_group(target.pid, generation.pgid) {
+    match signal_process_group(target.pid, &validated) {
         ProcessGroupSignalResult::Signaled => {
-            match wait_for_orphan_exit(target.pid, &generation).await {
+            match wait_for_orphan_exit(target.pid, &validated.generation).await {
                 Ok(()) => Outcome::Killed(target.clone()),
                 Err(failure) => Outcome::TerminationUnconfirmed {
                     target: target.clone(),
@@ -137,8 +140,13 @@ fn discovered_has_same_or_unidentified_firecracker(
     })
 }
 
+struct ValidatedOrphanTarget {
+    process: ProcfsProcessHandle,
+    generation: ProcfsProcessGeneration,
+}
+
 enum OrphanTargetValidation {
-    Valid { generation: ProcfsProcessGeneration },
+    Valid(ValidatedOrphanTarget),
     AlreadyGone,
     Changed,
 }
@@ -153,7 +161,21 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
         return OrphanTargetValidation::Changed;
     };
 
-    let stat = match process::read_process_stat_checked(target.pid).await {
+    let process = match ProcfsProcessHandle::open(target.pid) {
+        Ok(process) => process,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return OrphanTargetValidation::AlreadyGone;
+        }
+        Err(error) => {
+            tracing::warn!(
+                pid = target.pid,
+                %error,
+                "refusing orphan kill because process identity cannot be retained"
+            );
+            return OrphanTargetValidation::Changed;
+        }
+    };
+    let stat = match process.read_stat().await {
         ProcessStatRead::Found(stat) => stat,
         ProcessStatRead::Missing => {
             tracing::warn!(
@@ -198,12 +220,16 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
         return OrphanTargetValidation::AlreadyGone;
     }
 
-    let Some(cmdline) = process::read_cmdline(target.pid).await else {
+    if !process_group_is_safe(target.pid, generation.pgid) {
+        return OrphanTargetValidation::Changed;
+    }
+
+    let Some(cmdline) = process.read_cmdline().await else {
         tracing::warn!(
             pid = target.pid,
             "failed to read cmdline before orphan kill"
         );
-        return classify_orphan_validation_after_unreadable_pid_fact(target.pid, generation).await;
+        return classify_orphan_validation_after_unreadable_pid_fact(&process, generation).await;
     };
     if !process::is_firecracker_cmdline(&cmdline) {
         tracing::warn!(
@@ -213,8 +239,8 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
         return OrphanTargetValidation::Changed;
     }
 
-    let cwd_info = process::read_cwd(target.pid)
-        .await
+    let cwd_info = process
+        .read_cwd()
         .and_then(|cwd| process::parse_workspace_cwd(&cwd));
     if !orphan_target_matches_facts(target, generation, &stat, true, cwd_info.as_ref()) {
         tracing::warn!(
@@ -222,10 +248,10 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
             sandbox_id = %target.sandbox_id,
             "refusing orphan kill after workspace identity changed"
         );
-        return classify_orphan_validation_after_unreadable_pid_fact(target.pid, generation).await;
+        return classify_orphan_validation_after_unreadable_pid_fact(&process, generation).await;
     }
 
-    let final_stat = match process::read_process_stat_checked(target.pid).await {
+    let final_stat = match process.read_stat().await {
         ProcessStatRead::Found(stat) => stat,
         ProcessStatRead::Missing => {
             tracing::warn!(
@@ -270,16 +296,17 @@ async fn validate_orphan_target(target: &KillTarget) -> OrphanTargetValidation {
         return OrphanTargetValidation::AlreadyGone;
     }
 
-    OrphanTargetValidation::Valid {
+    OrphanTargetValidation::Valid(ValidatedOrphanTarget {
+        process,
         generation: *generation,
-    }
+    })
 }
 
 async fn classify_orphan_validation_after_unreadable_pid_fact(
-    pid: u32,
+    process: &ProcfsProcessHandle,
     generation: &ProcfsProcessGeneration,
 ) -> OrphanTargetValidation {
-    match process::read_process_stat_checked(pid).await {
+    match process.read_stat().await {
         ProcessStatRead::Found(stat)
             if generation == &stat.procfs_generation() && !process::process_stat_is_live(&stat) =>
         {
@@ -464,39 +491,59 @@ enum ProcessGroupSignalResult {
     Failed,
 }
 
-/// Send `SIGKILL` to a validated process group.
-fn signal_process_group(pid: u32, pgid: u32) -> ProcessGroupSignalResult {
+fn process_group_is_safe(pid: u32, pgid: u32) -> bool {
     if pgid <= 1 {
         tracing::warn!(pid, pgid, "refusing to signal system process group");
-        return ProcessGroupSignalResult::Failed;
+        return false;
+    }
+    if pid != pgid {
+        tracing::warn!(
+            pid,
+            pgid,
+            "refusing to signal orphan that is not a process-group leader"
+        );
+        return false;
     }
 
     let Ok(pgid_i32) = i32::try_from(pgid) else {
-        return ProcessGroupSignalResult::Failed;
+        return false;
     };
     if nix::unistd::getpgrp().as_raw() == pgid_i32 {
         tracing::warn!(pid, pgid = pgid_i32, "refusing to signal own process group");
+        return false;
+    }
+    true
+}
+
+/// The numeric facts are only for safety checks and diagnostics, never delivery.
+fn signal_process_group(pid: u32, validated: &ValidatedOrphanTarget) -> ProcessGroupSignalResult {
+    signal_process_group_with(pid, validated, ProcfsProcessHandle::kill_process_group)
+}
+
+fn signal_process_group_with(
+    pid: u32,
+    validated: &ValidatedOrphanTarget,
+    send_signal: impl FnOnce(&ProcfsProcessHandle) -> nix::Result<()>,
+) -> ProcessGroupSignalResult {
+    let pgid = validated.generation.pgid;
+    if !process_group_is_safe(pid, pgid) {
         return ProcessGroupSignalResult::Failed;
     }
 
-    match nix::sys::signal::killpg(
-        nix::unistd::Pid::from_raw(pgid_i32),
-        nix::sys::signal::Signal::SIGKILL,
-    ) {
+    match send_signal(&validated.process) {
         Ok(()) => {
-            info!(pid, pgid = pgid_i32, "killed process group");
+            info!(
+                pid,
+                pgid, "killed process group through retained process identity"
+            );
             ProcessGroupSignalResult::Signaled
         }
         Err(nix::errno::Errno::ESRCH) => {
-            info!(
-                pid,
-                pgid = pgid_i32,
-                "process group already exited before signal"
-            );
+            info!(pid, pgid, "process group already exited before signal");
             ProcessGroupSignalResult::AlreadyGone
         }
         Err(e) => {
-            tracing::warn!(pid, pgid = pgid_i32, error = %e, "failed to kill process group");
+            tracing::warn!(pid, pgid, error = %e, "failed to kill process group through retained process identity; refusing numeric signal fallback");
             ProcessGroupSignalResult::Failed
         }
     }
@@ -1135,38 +1182,24 @@ mod tests {
 
     #[test]
     fn signal_process_group_rejects_zero_pgid() {
-        assert_eq!(
-            signal_process_group(1234, 0),
-            ProcessGroupSignalResult::Failed
-        );
+        assert!(!process_group_is_safe(0, 0));
     }
 
     #[test]
     fn signal_process_group_rejects_init_pgid() {
-        assert_eq!(
-            signal_process_group(1234, 1),
-            ProcessGroupSignalResult::Failed
-        );
+        assert!(!process_group_is_safe(1, 1));
     }
 
     #[test]
     fn signal_process_group_rejects_own_pgid() {
         let current_pgid = u32::try_from(nix::unistd::getpgrp().as_raw()).unwrap();
 
-        assert_eq!(
-            signal_process_group(1234, current_pgid),
-            ProcessGroupSignalResult::Failed
-        );
+        assert!(!process_group_is_safe(current_pgid, current_pgid));
     }
 
     #[test]
-    fn signal_process_group_reports_already_gone_for_missing_group() {
-        let missing_pgid = i32::MAX as u32;
-
-        assert_eq!(
-            signal_process_group(1234, missing_pgid),
-            ProcessGroupSignalResult::AlreadyGone
-        );
+    fn signal_process_group_rejects_out_of_range_pgid() {
+        assert!(!process_group_is_safe(u32::MAX, u32::MAX));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/kill/orphan/identity_tests.rs
+++ b/crates/runner/src/cmd/kill/orphan/identity_tests.rs
@@ -1,0 +1,177 @@
+use std::process::{ExitStatus, Stdio};
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Child;
+
+use super::*;
+
+struct OrphanProcess {
+    child: Child,
+    target: KillTarget,
+    _base: tempfile::TempDir,
+}
+
+impl OrphanProcess {
+    async fn spawn(group: Option<u32>) -> Self {
+        let base = tempfile::tempdir().unwrap();
+        let sandbox_id = uuid::Uuid::new_v4().to_string();
+        let workspace = base.path().join("workspaces").join(&sandbox_id);
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        let firecracker = base.path().join("firecracker");
+        std::os::unix::fs::symlink("/bin/sh", &firecracker).unwrap();
+        let mut child = tokio::process::Command::new(&firecracker)
+            .args(["-c", "printf 'ready\\n'; IFS= read -r _; exit 0"])
+            .current_dir(&workspace)
+            .process_group(i32::try_from(group.unwrap_or(0)).unwrap())
+            .kill_on_drop(true)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let mut output = BufReader::new(child.stdout.take().unwrap()).lines();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), output.next_line())
+                .await
+                .unwrap()
+                .unwrap()
+                .as_deref(),
+            Some("ready")
+        );
+        let pid = child.id().unwrap();
+        let ProcessStatRead::Found(stat) = process::read_process_stat_checked(pid).await else {
+            panic!("ready process must have a readable stat");
+        };
+        Self {
+            child,
+            target: KillTarget {
+                pid,
+                ppid: Some(stat.ppid),
+                run_id: None,
+                sandbox_id,
+                base_dir: Some(base.path().to_path_buf()),
+                generation: Some(stat.procfs_generation()),
+            },
+            _base: base,
+        }
+    }
+
+    async fn exit(mut self) -> ExitStatus {
+        // EOF releases the shell's read barrier without sending a signal.
+        drop(self.child.stdin.take());
+        tokio::time::timeout(Duration::from_secs(5), self.child.wait())
+            .await
+            .unwrap()
+            .unwrap()
+    }
+}
+
+#[tokio::test]
+async fn original_identity_loss_does_not_signal_replacement_group() {
+    let original = OrphanProcess::spawn(None).await;
+    let OrphanTargetValidation::Valid(mut validated) =
+        validate_orphan_target(&original.target).await
+    else {
+        panic!("original process must validate before exit");
+    };
+    assert!(original.exit().await.success());
+
+    let replacement = OrphanProcess::spawn(None).await;
+    let member = OrphanProcess::spawn(Some(replacement.target.pid)).await;
+    // Model numeric routing now naming a replacement group, without churning
+    // shared host PIDs or requiring privileged PID-namespace manipulation. The
+    // actual delivery still exercises the original, exited kernel identity.
+    validated.generation = replacement.target.generation.unwrap();
+    let result = signal_process_group(replacement.target.pid, &validated);
+    let retained_stat = validated.process.read_stat().await;
+    let retained_cmdline = validated.process.read_cmdline().await;
+    let retained_cwd = validated.process.read_cwd();
+    let (replacement_status, member_status) = tokio::join!(replacement.exit(), member.exit());
+
+    assert_eq!(result, ProcessGroupSignalResult::AlreadyGone);
+    assert!(matches!(retained_stat, ProcessStatRead::Missing));
+    assert!(retained_cmdline.is_none());
+    assert!(retained_cwd.is_none());
+    assert!(
+        replacement_status.success(),
+        "replacement leader received a signal"
+    );
+    assert!(
+        member_status.success(),
+        "replacement member received a signal"
+    );
+}
+
+#[tokio::test]
+async fn retained_group_identity_terminates_members_after_leader_is_reaped() {
+    let leader = OrphanProcess::spawn(None).await;
+    let member = OrphanProcess::spawn(Some(leader.target.pid)).await;
+    let OrphanTargetValidation::Valid(validated) = validate_orphan_target(&leader.target).await
+    else {
+        panic!("group leader must validate");
+    };
+    let leader_pid = leader.target.pid;
+    assert!(leader.exit().await.success());
+
+    let result = signal_process_group(leader_pid, &validated);
+    let member_exit =
+        wait_for_orphan_exit(member.target.pid, &member.target.generation.unwrap()).await;
+    let member_status = member.exit().await;
+
+    assert_eq!(result, ProcessGroupSignalResult::Signaled);
+    assert_eq!(member_exit, Ok(()));
+    assert!(
+        !member_status.success(),
+        "original group member survived SIGKILL"
+    );
+}
+
+#[tokio::test]
+async fn orphan_termination_refuses_non_leader_without_signaling_group() {
+    let leader = OrphanProcess::spawn(None).await;
+    let member = OrphanProcess::spawn(Some(leader.target.pid)).await;
+    let outcome = terminate(&member.target).await;
+    let (leader_status, member_status) = tokio::join!(leader.exit(), member.exit());
+
+    assert!(matches!(outcome, Outcome::AlreadyExitedOrChanged(_)));
+    assert!(leader_status.success());
+    assert!(member_status.success());
+}
+
+#[tokio::test]
+async fn orphan_termination_refuses_changed_generation_without_signaling() {
+    let original = OrphanProcess::spawn(None).await;
+    let mut changed = original.target.clone();
+    changed.generation.as_mut().unwrap().starttime += 1;
+    let outcome = terminate(&changed).await;
+    let status = original.exit().await;
+
+    assert!(matches!(outcome, Outcome::AlreadyExitedOrChanged(_)));
+    assert!(status.success());
+}
+
+#[tokio::test]
+async fn rejected_kernel_signal_does_not_fall_back_to_numeric_signaling() {
+    for error in [
+        nix::errno::Errno::ENOSYS,
+        nix::errno::Errno::EINVAL,
+        nix::errno::Errno::EPERM,
+    ] {
+        let original = OrphanProcess::spawn(None).await;
+        let OrphanTargetValidation::Valid(validated) =
+            validate_orphan_target(&original.target).await
+        else {
+            panic!("original process must validate");
+        };
+        // Only the external kernel signal operation is injected. Validation,
+        // refusal handling and the process whose survival matters are real.
+        let result = signal_process_group_with(original.target.pid, &validated, |_| Err(error));
+        let status = original.exit().await;
+
+        assert_eq!(result, ProcessGroupSignalResult::Failed, "{error}");
+        assert!(
+            status.success(),
+            "numeric fallback signaled the process after {error}"
+        );
+    }
+}

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -18,7 +18,7 @@ pub use self::discovery::{discover_all, firecracker_process_exists_for_sandbox_i
 pub(crate) use self::discovery::{is_firecracker_cmdline, parse_workspace_cwd};
 pub use self::procfs::read_service_unit;
 pub(crate) use self::procfs::{
-    ProcessStatRead, read_cmdline, read_cwd, read_process_stat, read_process_stat_checked,
+    ProcessStatRead, ProcfsProcessHandle, read_process_stat, read_process_stat_checked,
     read_process_stat_checked_blocking, read_process_stat_checked_from,
 };
 pub use self::types::{

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -4,6 +4,9 @@ use tokio_util::sync::CancellationToken;
 
 use super::types::{ProcessStat, process_stat_is_live};
 
+mod handle;
+pub(crate) use handle::ProcfsProcessHandle;
+
 #[derive(Debug, Eq, PartialEq)]
 enum CmdlineRead {
     Args(Vec<String>),

--- a/crates/runner/src/process/procfs/handle.rs
+++ b/crates/runner/src/process/procfs/handle.rs
@@ -1,0 +1,88 @@
+use std::ffi::{CStr, OsString};
+use std::io;
+use std::os::fd::OwnedFd;
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+
+use rustix::fs::{Mode, OFlags};
+use tokio::io::AsyncReadExt;
+
+use super::{ProcessStatRead, classify_process_stat_read, parse_cmdline_bytes};
+
+/// A retained kernel identity, not a reservation of the numeric PID.
+///
+/// Relative procfs reads and `pidfd_send_signal` use the same process object,
+/// even if the process exits and its numeric PID is reused.
+pub(crate) struct ProcfsProcessHandle {
+    directory: OwnedFd,
+}
+
+impl ProcfsProcessHandle {
+    pub(crate) fn open(pid: u32) -> io::Result<Self> {
+        let directory = rustix::fs::open(
+            format!("/proc/{pid}"),
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+            Mode::empty(),
+        )?;
+        Ok(Self { directory })
+    }
+
+    async fn read_file(&self, name: &CStr) -> io::Result<Vec<u8>> {
+        let fd = rustix::fs::openat(
+            &self.directory,
+            name,
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+            Mode::empty(),
+        )?;
+        let mut file = tokio::fs::File::from_std(std::fs::File::from(fd));
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).await?;
+        Ok(bytes)
+    }
+
+    pub(crate) async fn read_stat(&self) -> ProcessStatRead {
+        match self.read_file(c"stat").await {
+            Err(error) if error.raw_os_error() == Some(libc::ESRCH) => ProcessStatRead::Missing,
+            result => classify_process_stat_read(result),
+        }
+    }
+
+    pub(crate) async fn read_cmdline(&self) -> Option<Vec<String>> {
+        parse_cmdline_bytes(&self.read_file(c"cmdline").await.ok()?)
+    }
+
+    pub(crate) fn read_cwd(&self) -> Option<PathBuf> {
+        let cwd = rustix::fs::readlinkat(&self.directory, c"cwd", Vec::new()).ok()?;
+        Some(PathBuf::from(OsString::from_vec(cwd.into_bytes())))
+    }
+
+    /// Kill the group of a verified process-group leader without a PID lookup.
+    pub(crate) fn kill_process_group(&self) -> nix::Result<()> {
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::fd::AsRawFd;
+
+            // Linux UAPI <linux/pidfd.h>, available since Linux 6.9. The pinned
+            // rustix pidfd_send_signal wrapper only supports flags = 0.
+            const PIDFD_SIGNAL_PROCESS_GROUP: libc::c_uint = 1 << 2;
+
+            // SAFETY: Linux accepts an open /proc/PID directory for this syscall.
+            // The descriptor remains owned through delivery, SIGKILL is valid,
+            // and the null siginfo pointer requests kernel-generated metadata.
+            let result = unsafe {
+                libc::syscall(
+                    libc::SYS_pidfd_send_signal,
+                    self.directory.as_raw_fd(),
+                    libc::SIGKILL,
+                    std::ptr::null::<libc::siginfo_t>(),
+                    PIDFD_SIGNAL_PROCESS_GROUP,
+                )
+            };
+            nix::errno::Errno::result(result).map(|_| ())
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(nix::errno::Errno::ENOSYS)
+        }
+    }
+}


### PR DESCRIPTION
## Current status

Not merge-ready: the coverage runner selected Ubuntu 22.04 / Linux 6.8, below the required group-signal facility. Three real signal tests fail there. See [CI blocker and required next step](https://github.com/vm0-ai/vm0/pull/32563#issuecomment-5581273308). A supported adequately sized runner must be selected/provisioned before CI can pass; no tests were skipped or unsafe fallback added.

## Summary

Closes #32529.

Orphan sandbox cleanup currently checks procfs identity and then signals a cached numeric PGID. If that group disappears and the number is reused between those operations, the privileged CLI can signal an unrelated group.

- Retain an owned `/proc/<pid>` directory before validation. Read stat, cmdline, and cwd relative to it, then send whole-group SIGKILL through that same kernel identity using `pidfd_send_signal(PIDFD_SIGNAL_PROCESS_GROUP)`.
- Require a verified group leader and preserve the system-group and own-group guards. Never reacquire a numeric signal target or fall back to `killpg`.
- Preserve existing owner-first control, post-signal exit confirmation, rediscovery, and cleanup gates. Kernel/policy failures remain visible and preserve sandbox resources.
- Add small real-process regressions for stale numeric routing, retained identity after leader reap, changed/non-leader rejection, syscall rejection, and cleanup preservation. Document the orphan path's kernel requirement.

## Scope and compatibility

No CLI arguments, APIs, stored state, spawn behavior, managed-child lifecycle, or deployment configuration change. `--run` still does not use orphan fallback.

Safe orphan group signaling requires Linux 6.9+ support and permission to use the syscall. Unsupported/restricted hosts now refuse orphan cleanup rather than attempt unsafe numeric delivery. Normal owner-managed termination is unchanged. On 2026-09-08, prod-11, prod-12, and prod-13 reported Linux 6.17.0-1018-gcp and accepted a signal-0 process-group pidfd probe. No production process was killed and no deployment was performed.

## Validation

From `crates/`:

- `cargo fmt --all --check`
- `cargo clippy --profile local -p runner --all-targets --all-features -j 2 -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --profile local -p runner --no-deps --all-features -j 2`
- `cargo test --profile local -p runner --bin runner --all-features -j 2 -- cmd::kill:: process::procfs:: --test-threads=4`: 111 passed, 0 failed.
- `cargo test --profile local -p runner --all-targets --all-features -j 2 -- --test-threads=4`: 3554 passed across runner and guest-inventory targets, 0 failed; 27 existing ignored entries, none added.
- `cargo test --profile local -p sandbox-firecracker --lib --all-features -j 2 process_monitor_ -- --test-threads=4`: 10 passed, 0 failed.

From `turbo/`: `pnpm exec prettier --check ../crates/README.md`.

The stale-routing regression was also red-tested with a temporary numeric fallback: it failed with `Signaled` instead of `AlreadyGone`. That mutation was removed, and the correct implementation passed the focused and full suites.

The regression deterministically substitutes numeric routing metadata while retaining the original, exited kernel identity; it does not claim to force actual kernel PID recycling. Real kernel group signaling and retained procfs reads were tested locally on Linux/aarch64. Unsupported syscall errors are injected only at the external kernel operation boundary. No global lock, PID churn, or artificial sleep was added.
