### PR TITLE
fix(platform): clean up abort listeners in polling delays

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -76,7 +76,7 @@
     "rehype-raw": "^7.0.0",
     "rehype-rewrite": "^4.0.4",
     "rehype-slug": "^6.0.0",
-    "signal-timers": "^1.0.4",
+    "signal-timers": "^1.0.5",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "zod": "^4.3.6"

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -1,5 +1,5 @@
 import { command, state, type Command } from "ccstate";
-import { delay, timeout } from "signal-timers";
+import { delay } from "signal-timers";
 import { IN_VITEST } from "../env.ts";
 import { logger } from "./log.ts";
 
@@ -392,7 +392,7 @@ async function waitForFibonacciRetry(
   signal: AbortSignal,
 ): Promise<void> {
   const delayMs = fibonacciRetryDelayMs(retryIndex);
-  await (IN_VITEST ? waitForNextMacrotask(signal) : delay(delayMs, { signal }));
+  await delay(IN_VITEST ? 0 : delayMs, { signal });
   signal.throwIfAborted();
 }
 
@@ -429,13 +429,9 @@ export async function setLoop(
         return;
       }
       fibIndex = 0;
-      // In VITEST, yield to the macrotask queue so React can flush renders
-      // between iterations. Using Promise.resolve() only queues a microtask,
-      // which starves React's render cycle. The callback timer avoids
-      // signal-timers' delay Promise.race while still honoring the loop signal.
-      await (IN_VITEST
-        ? waitForNextMacrotask(signal)
-        : delay(interval, { signal }));
+      // Keep yielding to the macrotask queue in tests so React can flush renders
+      // between iterations, without waiting for the production interval.
+      await delay(IN_VITEST ? 0 : interval, { signal });
     } catch (error) {
       throwIfAbort(error);
       if (
@@ -456,20 +452,6 @@ export async function setLoop(
       fibIndex++;
     }
   }
-}
-
-function waitForNextMacrotask(signal: AbortSignal): Promise<void> {
-  const deferred = createDeferredPromise<void>(signal);
-  if (!signal.aborted) {
-    timeout(
-      () => {
-        deferred.resolve(undefined);
-      },
-      0,
-      { signal },
-    );
-  }
-  return deferred.promise;
 }
 
 export function resetSignal(): Command<AbortSignal, AbortSignal[]> {

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -784,8 +784,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       signal-timers:
-        specifier: ^1.0.4
-        version: 1.0.4
+        specifier: ^1.0.5
+        version: 1.0.5
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -8899,6 +8899,10 @@ packages:
 
   signal-timers@1.0.4:
     resolution: {integrity: sha512-aIqj6BTlnA2G48GTfTFqkEn5MJBtfx4bHCjqzdRLdkhvCRhH8kEDFsX6yUbX0qYXLvV4bI1PRgAw+C9DrgskGg==}
+    engines: {node: '>=10'}
+
+  signal-timers@1.0.5:
+    resolution: {integrity: sha512-O90dl9YMPJiwzBjPI42lS2X47uvmg85eCOeg1WMi8pmLtX/IjKVWIcroLZj5NOJ7J0gRhEl7mu2j7z36caEfHg==}
     engines: {node: '>=10'}
 
   sirv@3.0.2:
@@ -18129,6 +18133,8 @@ snapshots:
   signal-exit@4.1.0: {}
 
   signal-timers@1.0.4: {}
+
+  signal-timers@1.0.5: {}
 
   sirv@3.0.2:
     dependencies:


### PR DESCRIPTION
Long-lived realtime signals retained an abort listener after each completed `signal-timers@1.0.4` delay. Upgrade Platform to [1.0.5](https://github.com/e7h4n/signal-timers/releases/tag/v1.0.5), which removes the listener on both timer completion and cancellation ([upstream fix and regression tests](https://github.com/e7h4n/signal-timers/pull/4)).

Use `signal-timers.delay` for both normal `setLoop` iterations and Fibonacci retries in tests and production, passing `0` in Vitest and preserving the configured production interval. Remove the obsolete test-only macrotask helper. Zero-interval realtime processing still yields to the macrotask queue.

## Validation

- Existing focused Platform tests: **51 passed** across realtime, command scheduling, SharedWorker runtime, and chat run status-tail tests.
- Platform production, test, and build-config type checks; targeted Prettier, Oxlint, type-aware Oxlint, and ESLint; Platform Knip; commitlint; and `git diff --check` passed.
- Frozen lockfile install passed. The lockfile change is limited to Platform's `signal-timers` upgrade.
- Against the package installed in Platform: 404 sequential waits on one live signal left **0 abort listeners** for both `delay(0)` and `delayToNextMicrotask`; cancelling a pending delay rejected with `AbortError` and left **0 listeners**. The library's resource regression tests are maintained upstream.

Full Platform suite and build validation run in the PR pipeline.
