### PR TITLE
fix: close connector account menu on scroll

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx
@@ -1,7 +1,7 @@
 import type { ConnectorAccountTarget } from "@okouai/api-contracts/contracts/connector-accounts";
 import type { ConnectorSlug } from "@okouai/api-contracts/contracts/connector-identity";
 import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect, test } from "vitest";
 
@@ -390,6 +390,36 @@ test("Choose which connector account a chat uses", async () => {
     "GitHub · Using default account: Work",
   );
   await user.click(await findFastControl("button", "Back", chooser));
+  await waitFor(() => {
+    expect(screen.queryByLabelText("Account for this chat")).toBeNull();
+    expect(queryFastControl("button", "Add connectors")).toBeVisible();
+    expect(
+      queryFastControl("button", "GitHub · Using default account: Work"),
+    ).toBeVisible();
+  });
+});
+
+test("Close the account chooser when the connector list scrolls", async () => {
+  const user = userEvent.setup({ delay: null });
+  const accounts = githubAccounts();
+  installComposerConnectorFixture({
+    catalog: [builtinConnector({ slug: GITHUB_SLUG, label: "GitHub" })],
+    builtinAuthorizations: { [SCOUT_AGENT_ID]: [GITHUB_SLUG] },
+    accountSummaries: [accountSummary(githubTarget(), accounts)],
+    accounts,
+    threadId: SCOUT_THREAD_ID,
+  });
+
+  await setupPage({
+    context,
+    path: `/chats/${SCOUT_THREAD_ID}`,
+  });
+
+  await loadComposer();
+  await openConnectors(user);
+  await openAccountChooser(user, "GitHub · Using default account: Work");
+  fireEvent.scroll(screen.getByRole("list", { name: "Connectors" }));
+
   await waitFor(() => {
     expect(screen.queryByLabelText("Account for this chat")).toBeNull();
     expect(queryFastControl("button", "Add connectors")).toBeVisible();

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -8233,6 +8233,11 @@ function ConnectorsPopoverButton({
                   return $.chat.connectors.title;
                 })}
                 className="flex max-h-64 min-h-0 flex-1 flex-col overflow-y-auto"
+                onScroll={() => {
+                  if (accountMenuOpen) {
+                    closeAccountMenu();
+                  }
+                }}
               >
                 {visibleConnectors.map((item) => {
                   if (item.kind === "custom") {


### PR DESCRIPTION
## Summary
- close the connector account submenu when the connector list scrolls
- keep the main connector picker open without changing connector or account selections
- cover the interaction with a page-level regression test

## Verification
- `pnpm -F @okouai/app exec vitest run src/views/okou-page/__tests__/chat-composer-connector-accounts.test.tsx --maxWorkers=1 --silent=passed-only` (8 tests passed)
- `pnpm -F @okouai/app lint`
- `pnpm -F @okouai/app check-types`
- `pnpm knip --workspace @okouai/app`

Fixes #32567
