### PR TITLE
test(runner): observe child identity before exercising command timeout

### DIFF
--- a/crates/runner/src/bounded_command.rs
+++ b/crates/runner/src/bounded_command.rs
@@ -568,18 +568,30 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn output_command_timeout_reaps_recorded_child() -> io::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let pid_path = temp_dir.path().join("pid");
         let command = pid_recording_command(&pid_path);
-        let task = tokio::spawn(run_output_bounded(
+        let command_timeout = Duration::from_secs(1);
+        let mut command_future = Box::pin(run_output_bounded(
             command,
             "sh",
             CommandOutputPolicy::semantic_stdout(),
-            Duration::from_secs(1),
+            command_timeout,
         ));
-        let (pid, starttime) = match wait_for_recorded_process(&pid_path).await {
+        // Start the real child and deadline, but do not schedule this future
+        // until its identity is recorded. Paused time alone can auto-advance
+        // while the observer awaits filesystem I/O.
+        assert!(futures_util::poll!(command_future.as_mut()).is_pending());
+        let process = wait_for_recorded_process(&pid_path).await;
+
+        tokio::time::advance(command_timeout).await;
+        // Kill/reap uses real OS scheduling: resume time before cleanup so its
+        // watchdog cannot auto-advance ahead of the child's exit.
+        tokio::time::resume();
+        let task = tokio::spawn(command_future);
+        let (pid, starttime) = match process {
             Ok(process) => process,
             Err(error) => {
                 task.abort();


### PR DESCRIPTION
## Summary

- Synchronize the existing bounded-command timeout test so its real child's PID and `/proc` starttime are observed before timeout cleanup can run.
- Poll the actual command future once with paused time, keep it unscheduled during identity observation, then advance its unchanged deadline and resume real time before handing it to the cleanup task.
- Preserve the real command, output readers, timeout/reaping assertions, setup-error abort path, and separate task-cancellation test.

Closes #32542

## Why

The original task could correctly kill and reap its child after one second while the test was still trying to observe that child's identity. A temporary 1,100 ms observation delay reproduced the reported `timed out waiting for command pid` error. The fixed test passed with a temporary 1,100 ms real observation delay. Both diagnostic delays were removed before final validation.

This confirms the suspected ordering under a controlled schedule; it is not evidence of a production cleanup failure or a capture of the original full-suite schedule.

## Scope and risk

Only one existing Linux test changes. No production function, command timeout, cleanup watchdog, fixture, dependency, CI selection, UI, API, persistence, or deployment behavior changes. No new sleeps or ignored tests.

The first poll must start the real child and register its deadline; Pending and live-identity checks guard that setup. The command future remains unscheduled during observation because paused time can auto-advance during I/O. Cleanup runs with normal time so its watchdog cannot outrun real OS process exit.

## Validation

From `crates/`:

- `cargo fmt --all --check`
- `cargo clippy --profile local -p runner --all-targets --all-features`
- `cargo doc --profile local -p runner --all-features --no-deps`
- `cargo test --profile local -p runner --bin runner bounded_command::tests:: -- --test-threads=8` — ten consecutive runs, 10 tests each, all passing.
- `cargo test --profile local -p runner --all-targets --all-features -- --quiet` — two consecutive runs with default concurrent workers on a 12-CPU aarch64 Linux container; each passed 3,548 tests. The 27 pre-existing ignored cases are unchanged (mostly subprocess fixtures, plus metal-only coverage).
- `git diff --check`

No remote deployment or unrelated language suite was needed for this test-only change.
