### PR TITLE
fix(platform): insert multiple templates in create modes

### DIFF
--- a/turbo/apps/platform/src/i18n/locales/de-DE/common.json
+++ b/turbo/apps/platform/src/i18n/locales/de-DE/common.json
@@ -1872,8 +1872,8 @@
       "agentSuggestions": "Agenten",
       "configureModel": "Modell konfigurieren",
       "create": {
-        "chooseStyle": "Stil wählen",
-        "chooseTemplate": "Vorlage wählen",
+        "addStyle": "Stil hinzufügen",
+        "addTemplate": "Vorlage hinzufügen",
         "exit": "Erstellungsmodus verlassen",
         "image": "Bild erstellen",
         "imagePlaceholder": "Beschreibe das gewünschte Bild…",

--- a/turbo/apps/platform/src/i18n/locales/en-US/common.json
+++ b/turbo/apps/platform/src/i18n/locales/en-US/common.json
@@ -1872,8 +1872,8 @@
       "agentSuggestions": "Agents",
       "configureModel": "Configure model",
       "create": {
-        "chooseStyle": "Choose style",
-        "chooseTemplate": "Choose template",
+        "addStyle": "Add style",
+        "addTemplate": "Add template",
         "exit": "Exit create mode",
         "image": "Create image",
         "imagePlaceholder": "Describe the image you want to create…",

--- a/turbo/apps/platform/src/i18n/locales/es-ES/common.json
+++ b/turbo/apps/platform/src/i18n/locales/es-ES/common.json
@@ -1901,8 +1901,8 @@
       "agentSuggestions": "Agentes",
       "configureModel": "Configurar modelo",
       "create": {
-        "chooseStyle": "Elegir estilo",
-        "chooseTemplate": "Elegir plantilla",
+        "addStyle": "Añadir estilo",
+        "addTemplate": "Añadir plantilla",
         "exit": "Salir del modo de creación",
         "image": "Crear imagen",
         "imagePlaceholder": "Describe la imagen que quieres crear…",

--- a/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/fr-FR/common.json
@@ -1901,8 +1901,8 @@
       "agentSuggestions": "Agents",
       "configureModel": "Configurer le modèle",
       "create": {
-        "chooseStyle": "Choisir un style",
-        "chooseTemplate": "Choisir un modèle",
+        "addStyle": "Ajouter un style",
+        "addTemplate": "Ajouter un modèle",
         "exit": "Quitter le mode création",
         "image": "Créer une image",
         "imagePlaceholder": "Décrivez l’image à créer…",

--- a/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
+++ b/turbo/apps/platform/src/i18n/locales/hi-IN/common.json
@@ -1872,8 +1872,8 @@
       "agentSuggestions": "एजेंट",
       "configureModel": "मॉडल कॉन्फ़िगर करें",
       "create": {
-        "chooseStyle": "शैली चुनें",
-        "chooseTemplate": "टेम्पलेट चुनें",
+        "addStyle": "शैली जोड़ें",
+        "addTemplate": "टेम्पलेट जोड़ें",
         "exit": "बनाने के मोड से बाहर निकलें",
         "image": "छवि बनाएँ",
         "imagePlaceholder": "आप जो छवि बनाना चाहते हैं उसका वर्णन करें…",

--- a/turbo/apps/platform/src/i18n/locales/id-ID/common.json
+++ b/turbo/apps/platform/src/i18n/locales/id-ID/common.json
@@ -1869,8 +1869,8 @@
       "agentSuggestions": "Agen",
       "configureModel": "Konfigurasikan model",
       "create": {
-        "chooseStyle": "Pilih gaya",
-        "chooseTemplate": "Pilih templat",
+        "addStyle": "Tambahkan gaya",
+        "addTemplate": "Tambahkan templat",
         "exit": "Keluar dari mode pembuatan",
         "image": "Buat gambar",
         "imagePlaceholder": "Jelaskan gambar yang ingin Anda buat…",

--- a/turbo/apps/platform/src/i18n/locales/it-IT/common.json
+++ b/turbo/apps/platform/src/i18n/locales/it-IT/common.json
@@ -1901,8 +1901,8 @@
       "agentSuggestions": "Agenti",
       "configureModel": "Configura modello",
       "create": {
-        "chooseStyle": "Scegli stile",
-        "chooseTemplate": "Scegli modello",
+        "addStyle": "Aggiungi stile",
+        "addTemplate": "Aggiungi modello",
         "exit": "Esci dalla modalità creazione",
         "image": "Crea immagine",
         "imagePlaceholder": "Descrivi l’immagine che vuoi creare…",

--- a/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ja-JP/common.json
@@ -1869,8 +1869,8 @@
       "agentSuggestions": "エージェント",
       "configureModel": "モデルの構成",
       "create": {
-        "chooseStyle": "スタイルを選択",
-        "chooseTemplate": "テンプレートを選択",
+        "addStyle": "スタイルを追加",
+        "addTemplate": "テンプレートを追加",
         "exit": "作成モードを終了",
         "image": "画像を作成",
         "imagePlaceholder": "作成したい画像を説明してください…",

--- a/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/ko-KR/common.json
@@ -1869,8 +1869,8 @@
       "agentSuggestions": "에이전트",
       "configureModel": "모델 구성",
       "create": {
-        "chooseStyle": "스타일 선택",
-        "chooseTemplate": "템플릿 선택",
+        "addStyle": "스타일 추가",
+        "addTemplate": "템플릿 추가",
         "exit": "만들기 모드 종료",
         "image": "이미지 만들기",
         "imagePlaceholder": "만들고 싶은 이미지를 설명하세요…",

--- a/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
+++ b/turbo/apps/platform/src/i18n/locales/pt-BR/common.json
@@ -1901,8 +1901,8 @@
       "agentSuggestions": "Agentes",
       "configureModel": "Configurar modelo",
       "create": {
-        "chooseStyle": "Escolher estilo",
-        "chooseTemplate": "Escolher modelo",
+        "addStyle": "Adicionar estilo",
+        "addTemplate": "Adicionar modelo",
         "exit": "Sair do modo de criação",
         "image": "Criar imagem",
         "imagePlaceholder": "Descreva a imagem que você quer criar…",

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-composer-create.test.tsx
@@ -19,6 +19,10 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 import {
+  ILLUSTRATION_TEMPLATE_ITEMS,
+  VIDEO_TEMPLATE_ITEMS,
+} from "../../../lib/platform-template-items.ts";
+import {
   AGENT_ID,
   composerInlineTemplates,
   context,
@@ -142,7 +146,7 @@ test("Image mode combines styles and image models while preserving the prompt", 
   setupModels();
   const editor = await setupComposer();
   await chooseCommand(editor, "A quiet garden /create image", "Create image");
-  expect(button("Choose style")).toBeInTheDocument();
+  expect(button("Add style")).toBeInTheDocument();
   const picker = await screen.findByRole("combobox", { name: "Image models" });
   click(picker);
   const model = PUBLIC_IMAGE_MODELS.find((candidate) => {
@@ -192,34 +196,106 @@ test("Image mode sends when the model menu is still open", async () => {
   });
 });
 
-test("Presentation mode replaces its one selected template without adding a second", async () => {
-  setupModels();
-  const editor = await setupComposer();
-  const [first, replacement] = PRESENTATION_TEMPLATE_PICKER_ITEMS;
-  if (!first || !replacement) {
-    throw new Error("Expected two presentation templates");
-  }
-  await chooseCommand(
-    editor,
-    "Our launch /create presentation",
-    "Create presentation",
-  );
-  click(button("Choose template"));
-  await screen.findByRole("dialog");
-  click(await screen.findByLabelText(`Select template ${first.title}`));
-  await waitFor(() => {
-    expect(button(first.title)).toBeInTheDocument();
-  });
-  click(button(first.title));
-  await screen.findByRole("dialog");
-  click(await screen.findByLabelText(`Select template ${replacement.title}`));
-  await waitFor(() => {
-    expect(button(replacement.title)).toBeInTheDocument();
-  });
-  expect(composerInlineTemplates()).toHaveLength(1);
-  expect(composerInlineTemplates()[0]).toHaveTextContent(replacement.title);
-  expect(editor).toHaveTextContent("Our launch");
-});
+test.each([
+  {
+    mode: "image",
+    commandLabel: "Create image",
+    pickerLabel: "Add style",
+    selectLabel: "Select template",
+    previewLabel: "Preview template",
+    templates: ILLUSTRATION_TEMPLATE_ITEMS,
+  },
+  {
+    mode: "video",
+    commandLabel: "Create video",
+    pickerLabel: "Add template",
+    selectLabel: "Select video template",
+    previewLabel: "Preview video template",
+    templates: VIDEO_TEMPLATE_ITEMS,
+  },
+  {
+    mode: "presentation",
+    commandLabel: "Create presentation",
+    pickerLabel: "Add template",
+    selectLabel: "Select template",
+    previewLabel: "Preview template",
+    templates: PRESENTATION_TEMPLATE_PICKER_ITEMS,
+  },
+])(
+  "$commandLabel adds multiple templates, edits only the clicked chip, and sends every reference",
+  async ({
+    mode,
+    commandLabel,
+    pickerLabel,
+    selectLabel,
+    previewLabel,
+    templates,
+  }) => {
+    setupModels();
+    const submissions: UserMessageDocument[] = [];
+    mockChatLifecycle(context, {
+      onRunCreate: (body) => {
+        if (body.userMessage) {
+          submissions.push(body.userMessage);
+        }
+      },
+    });
+    const editor = await setupComposer();
+    const user = userEvent.setup({ delay: null });
+    const [first, second, replacement] = templates;
+    if (!first || !second || !replacement) {
+      throw new Error(`Expected three ${mode} templates`);
+    }
+    await chooseCommand(editor, `Our launch /create ${mode}`, commandLabel);
+    click(button(pickerLabel));
+    await screen.findByRole("dialog");
+    click(await screen.findByLabelText(`${selectLabel} ${first.title}`));
+    await waitFor(() => {
+      expect(composerInlineTemplates()).toHaveLength(1);
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    await user.paste(" for the cover. ");
+    click(button(pickerLabel));
+    await screen.findByRole("dialog");
+    click(await screen.findByLabelText(`${selectLabel} ${second.title}`));
+    await waitFor(() => {
+      const chips = composerInlineTemplates();
+      expect(chips).toHaveLength(2);
+      expect(chips[0]).toHaveTextContent(first.title);
+      expect(chips[1]).toHaveTextContent(second.title);
+    });
+
+    const firstChip = composerInlineTemplates()[0];
+    if (!firstChip) {
+      throw new Error("Expected the first inline template");
+    }
+    click(button(`${previewLabel} ${first.title}`, firstChip));
+    await screen.findByRole("dialog");
+    click(await screen.findByLabelText(`${selectLabel} ${replacement.title}`));
+    await waitFor(() => {
+      const chips = composerInlineTemplates();
+      expect(chips).toHaveLength(2);
+      expect(chips[0]).toHaveTextContent(replacement.title);
+      expect(chips[1]).toHaveTextContent(second.title);
+    });
+    expect(editor).toHaveTextContent("Our launch");
+    expect(editor).toHaveTextContent("for the cover.");
+    expect(button(pickerLabel)).toBeInTheDocument();
+
+    click(button("Send"));
+    await waitFor(() => {
+      expect(submissions).toHaveLength(1);
+    });
+    const parts = submissions[0]?.parts;
+    expect(
+      parts?.flatMap((part) => {
+        return part.type === "template" ? [part.titleSnapshot] : [];
+      }),
+    ).toStrictEqual([replacement.title, second.title]);
+    expect(JSON.stringify(parts)).toContain("Our launch");
+    expect(JSON.stringify(parts)).toContain("for the cover.");
+  },
+);
 
 test("Multiple templates keep a generic toolbar label and all references survive sending", async () => {
   setupModels();
@@ -244,7 +320,7 @@ test("Multiple templates keep a generic toolbar label and all references survive
   const menu = await screen.findByTestId("slash-workflow-menu");
   click(button("Create presentation", menu));
   await waitFor(() => {
-    expect(button("Choose template")).toBeInTheDocument();
+    expect(button("Add template")).toBeInTheDocument();
   });
   expect(composerInlineTemplates()).toHaveLength(2);
   click(button("Send"));
@@ -262,13 +338,13 @@ test("Multiple templates keep a generic toolbar label and all references survive
   ).toStrictEqual([first.title, second.title]);
 });
 
-test("Presentation recognizes an existing template picked before entering create mode", async () => {
+test("Presentation adds another template when the draft already has one", async () => {
   setupModels();
   const editor = await setupComposer();
   const user = userEvent.setup({ delay: null });
-  const first = PRESENTATION_TEMPLATE_PICKER_ITEMS[0];
-  if (!first) {
-    throw new Error("Expected a presentation template");
+  const [first, second] = PRESENTATION_TEMPLATE_PICKER_ITEMS;
+  if (!first || !second) {
+    throw new Error("Expected two presentation templates");
   }
   await selectTemplate(user, first);
   await user.click(editor);
@@ -276,9 +352,18 @@ test("Presentation recognizes an existing template picked before entering create
   const menu = await screen.findByTestId("slash-workflow-menu");
   click(button("Create presentation", menu));
   await waitFor(() => {
-    expect(button(first.title)).toBeInTheDocument();
+    expect(button("Add template")).toBeInTheDocument();
   });
   expect(composerInlineTemplates()).toHaveLength(1);
+  click(button("Add template"));
+  await screen.findByRole("dialog");
+  click(await screen.findByLabelText(`Select template ${second.title}`));
+  await waitFor(() => {
+    const chips = composerInlineTemplates();
+    expect(chips).toHaveLength(2);
+    expect(chips[0]).toHaveTextContent(first.title);
+    expect(chips[1]).toHaveTextContent(second.title);
+  });
 });
 
 test("Create suggestions expose one image command that opens the style gallery", async () => {
@@ -292,7 +377,7 @@ test("Create suggestions expose one image command that opens the style gallery",
     }),
   ).toHaveLength(1);
   click(button("Create image", menu));
-  click(button("Choose style"));
+  click(button("Add style"));
   const dialog = await screen.findByRole("dialog");
   await waitFor(() => {
     const tab = queryAllByRoleFast("tab", dialog).find((item) => {

--- a/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-composer.tsx
@@ -6,7 +6,6 @@ import {
   useComposerActions,
   type ComposerActions,
 } from "./composer-actions.ts";
-import { useEditorState } from "@tiptap/react";
 import {
   ComposerCreateHeader,
   ComposerCreateImageModelPicker,
@@ -60,7 +59,6 @@ import {
   ArrowUp,
   Bolt,
   Check,
-  ChevronDown,
   Download,
   Globe,
   Image as ImageIcon,
@@ -266,11 +264,7 @@ import {
   sttVoiceLevel$,
 } from "../../signals/voice-io/voice-io-stt.ts";
 import { readChatMessageFromClipboard } from "../../signals/okou-page/clipboard.ts";
-import {
-  INLINE_TEMPLATE_NODE_NAME,
-  TEMPLATE_ATTACHMENT_NODE_NAME,
-  shouldUseUserMessage,
-} from "../../signals/okou-page/user-message-document-codec.ts";
+import { shouldUseUserMessage } from "../../signals/okou-page/user-message-document-codec.ts";
 import { WebsiteTemplatePreviewDialogSlot } from "./website-template-preview-dialog.tsx";
 import { ReplaceComposerDraftDialog } from "./replace-composer-draft-dialog.tsx";
 import {
@@ -6701,62 +6695,19 @@ function TemplatePickerButton({
   const category = useGet(signals.template.templatePickerCategory$);
   const referenceValue = useGet(signals.template.templatePickerReferenceValue$);
   const createMode = useGet(signals.create.mode$);
-  const templates = useEditorState({
-    editor: signals.editor.editor,
-    selector: ({ editor }) => {
-      const result: {
-        title: string;
-        type: string;
-        position: number;
-        legacy: boolean;
-      }[] = [];
-      editor.state.doc.descendants((node, position) => {
-        if (
-          node.type.name === INLINE_TEMPLATE_NODE_NAME ||
-          node.type.name === TEMPLATE_ATTACHMENT_NODE_NAME
-        ) {
-          const title: unknown = node.attrs.title;
-          const type: unknown = node.attrs.templateType;
-          if (typeof title === "string" && typeof type === "string") {
-            result.push({
-              title,
-              type,
-              position,
-              legacy: node.type.name === TEMPLATE_ATTACHMENT_NODE_NAME,
-            });
-          }
-          return false;
-        }
-        return true;
-      });
-      return result;
-    },
-  });
-  const templateMode =
-    createMode === "presentation"
-      ? "presentation"
-      : createMode === "image"
-        ? "illustration"
-        : null;
-  const singleTemplate =
-    templateMode &&
-    templates.length === 1 &&
-    templates[0]?.type === templateMode
-      ? templates[0]
-      : undefined;
+  const templateMode = createMode === "image" ? "illustration" : createMode;
   const templateLabel =
-    singleTemplate?.title ??
-    (templateMode === "illustration"
+    templateMode === "illustration"
       ? t(($) => {
-          return $.chat.composer.create.chooseStyle;
+          return $.chat.composer.create.addStyle;
         })
-      : templateMode === "presentation"
+      : templateMode
         ? t(($) => {
-            return $.chat.composer.create.chooseTemplate;
+            return $.chat.composer.create.addTemplate;
           })
         : t(($) => {
             return $.artifacts.templates.template;
-          }));
+          });
   const setOpen = useSet(signals.template.setTemplatePickerOpen$);
   const setReferenceValue = useSet(
     signals.template.setTemplatePickerReferenceValue$,
@@ -6800,27 +6751,16 @@ function TemplatePickerButton({
               onPointerDown={prewarmPicker}
               onClick={() => {
                 prewarmPicker();
-                openTemplatePicker(
-                  singleTemplate
-                    ? singleTemplate.legacy
-                      ? { kind: "edit-legacy", category: selectedCategory }
-                      : {
-                          kind: "edit-selected",
-                          category: selectedCategory,
-                          position: singleTemplate.position,
-                        }
-                    : { kind: "insert", category: selectedCategory },
-                );
+                openTemplatePicker({
+                  kind: "insert",
+                  category: selectedCategory,
+                });
               }}
             >
               {templateMode ? (
                 <>
+                  <Plus size={16} className="shrink-0" aria-hidden />
                   <span className="min-w-0 truncate">{templateLabel}</span>
-                  <ChevronDown
-                    size={12}
-                    className="shrink-0 opacity-50"
-                    aria-hidden
-                  />
                 </>
               ) : (
                 <SwatchBook size={18} aria-hidden="true" />


### PR DESCRIPTION
In Create image and Create presentation, selecting a second template from the toolbar replaces the first because the toolbar switches to editing when the draft contains one template. Keep the toolbar as an insertion action for Create image, Create video, and Create presentation, so users can compose one message with multiple templates and edit each chip separately.

- Keep `Add style` / `Add template` labels stable and use a plus icon; open the matching category in all three Create modes.
- Remove the toolbar's single-template document scan and replacement branch; retain inline-chip editing and the existing ordered message references.
- Update all supported translations and exercise repeated insertion, targeted chip editing, draft preservation, and submission in page integration tests.

Validation:
- 26 page integration tests passed across `chat-composer-create`, `chat-composer-workflows`, `chat-composer-template-media`, and `chat-composer-video-options`.
- Platform lint, localization checks, type checks, scoped Knip, and `pnpm lint:style` passed.
- No full local Vitest suite or local dev server was run; the PR pipeline provides the full checks.

Browser validation on the deployed head `929df6e6a545dd0881861bbc51563465f9a81917`:
- Create image: inserted Sunlit Gouache and Ink Storefront around existing text; editing the first chip preserved the second.
- Create presentation: inserted two templates with text between them.
- All three Create modes use the matching gallery category and fit a 375px viewport without horizontal overflow. Video template selection is gated by the free preview account, so its complete insertion/edit/send flow is covered by the passing page integration tests.

Required CI gates (`ci-gate-turbo`, `ci-gate-security`, and `ci-gate-crates`) passed.
