### PR TITLE
fix: handle cache fallback, browser previews, and chat scroll anchors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/browser.test.ts
@@ -1906,7 +1906,7 @@ describe("okou browser route", () => {
         const input = commandInput(command);
         return (JSON.stringify(input.Delete) ?? "").includes(screenshotKey);
       }),
-    ).toBeTruthy();
+    ).toBeFalsy();
 
     const cleaned = await reconcileBrowsers(current.threadId);
     expect(cleaned.body).toMatchObject({ errors: 0 });
@@ -2113,7 +2113,93 @@ describe("okou browser route", () => {
     await flushWaitUntilForTest();
   }, 120_000);
 
-  it("captures the foreground tab during browser reconciliation and keeps the latest screenshot", async () => {
+  it("keeps the browser usable without retrying a failed screenshot capture", async () => {
+    const { routeMocks, runs, chat, actor, agent } =
+      await setupBrowserScenario();
+    const current = await createClaimedChatRun(
+      chat,
+      runs,
+      actor,
+      agent.agentId,
+      "Open a browser without a screenshot",
+    );
+    const providerId = randomUUID();
+    acceptBrowserUseCdpSessions([providerId]);
+    server.use(
+      http.post(`${BROWSER_USE_API_URL}/profiles`, async ({ request }) => {
+        const body = z
+          .strictObject({ name: z.string() })
+          .parse(await request.json());
+        return HttpResponse.json(providerProfile(randomUUID(), body.name), {
+          status: 201,
+        });
+      }),
+      http.post(`${BROWSER_USE_API_URL}/browsers`, () => {
+        return HttpResponse.json(providerBrowser(providerId), { status: 201 });
+      }),
+      http.get(`${BROWSER_USE_API_URL}/browsers/:id`, ({ params }) => {
+        return HttpResponse.json(providerBrowser(String(params.id)));
+      }),
+    );
+    context.mocks.browserUseCdp.command.mockImplementation((command) => {
+      if (command.method === "Target.attachToTarget") {
+        return { sessionId: "foreground-session" };
+      }
+      if (command.method === "Runtime.evaluate") {
+        return { result: { type: "boolean", value: true } };
+      }
+      if (command.method === "Page.getLayoutMetrics") {
+        return {
+          cssVisualViewport: {
+            pageX: 0,
+            pageY: 0,
+            clientWidth: 1280,
+            clientHeight: 720,
+          },
+        };
+      }
+      if (command.method === "Page.captureScreenshot") {
+        return new Error("Screenshot capture unavailable");
+      }
+      return undefined;
+    });
+
+    await accept(
+      client().use({ headers: current.claim.browserHeaders, body: {} }),
+      [200],
+    );
+    const reconciled = await reconcileBrowsers(current.threadId);
+    expect(reconciled.body).toMatchObject({ healthy: 1, errors: 0 });
+    await flushWaitUntilForTest();
+
+    routeMocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const lease = await accept(
+      client().leaseByThread({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: current.threadId },
+        body: {},
+      }),
+      [200],
+    );
+    expect(lease.body.browser).toMatchObject({
+      status: "active",
+      screenshotUrl: null,
+    });
+    await flushWaitUntilForTest();
+    expect(
+      context.mocks.browserUseCdp.command.mock.calls.filter(([command]) => {
+        return command.method === "Page.captureScreenshot";
+      }),
+    ).toHaveLength(1);
+    expect(
+      context.mocks.s3.send.mock.calls.filter(([command]) => {
+        const input = commandInput(command);
+        return input.ContentType === "image/webp" || "Delete" in input;
+      }),
+    ).toHaveLength(0);
+  }, 120_000);
+
+  it("captures the foreground tab and keeps previous screenshot objects when updating or deleting a thread", async () => {
     const { routeMocks, runs, chat, actor, agent } =
       await setupBrowserScenario();
     const current = await createClaimedChatRun(
@@ -2156,7 +2242,6 @@ describe("okou browser route", () => {
       context.signal,
     );
     let screenshotUploadCount = 0;
-    let failNextScreenshotDelete = true;
     context.mocks.s3.send.mockImplementation((command: unknown) => {
       const input = commandInput(command);
       if (input.ContentType === "image/webp") {
@@ -2167,10 +2252,6 @@ describe("okou browser route", () => {
         if (screenshotUploadCount === 3) {
           return releaseThirdScreenshotUpload.promise;
         }
-      }
-      if ("Delete" in input && failNextScreenshotDelete) {
-        failNextScreenshotDelete = false;
-        return Promise.reject(new Error("transient screenshot delete failure"));
       }
       return Promise.resolve({});
     });
@@ -2373,9 +2454,9 @@ describe("okou browser route", () => {
           firstScreenshotKey,
         );
       }),
-    ).toHaveLength(1);
-    const retriedCleanup = await reconcileBrowsers(current.threadId);
-    expect(retriedCleanup.body).toMatchObject({
+    ).toHaveLength(0);
+    const thirdReconcile = await reconcileBrowsers(current.threadId);
+    expect(thirdReconcile.body).toMatchObject({
       errors: 0,
     });
     expect(
@@ -2385,7 +2466,7 @@ describe("okou browser route", () => {
           firstScreenshotKey,
         );
       }),
-    ).toHaveLength(2);
+    ).toHaveLength(0);
     releaseThirdScreenshotUpload.resolve(undefined);
     await flushWaitUntilForTest();
 
@@ -2410,7 +2491,7 @@ describe("okou browser route", () => {
           secondScreenshotKey,
         );
       }),
-    ).toHaveLength(1);
+    ).toHaveLength(0);
 
     await chat.deleteThread(actor, current.threadId);
     await flushWaitUntilForTest();
@@ -2426,7 +2507,7 @@ describe("okou browser route", () => {
     expect(reconciled.body).toMatchObject({
       errors: 0,
     });
-    expect(context.mocks.s3.send).toHaveBeenCalledWith(
+    expect(context.mocks.s3.send).not.toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           Delete: { Objects: [{ Key: finalScreenshotKey }] },

--- a/turbo/apps/api/src/signals/services/browser-screenshot-schema.service.ts
+++ b/turbo/apps/api/src/signals/services/browser-screenshot-schema.service.ts
@@ -12,7 +12,6 @@ export async function browserScreenshotSchemaAvailable(
     .select({
       available: sql`
         to_regclass('public.browser_session_screenshots') IS NOT NULL
-        AND to_regclass('public.browser_session_screenshot_deletions') IS NOT NULL
       `.mapWith(pgBooleanDecoder),
     })
     .from(sql`(SELECT 1) AS schema_probe`)

--- a/turbo/apps/api/src/signals/services/browser.service.ts
+++ b/turbo/apps/api/src/signals/services/browser.service.ts
@@ -13,7 +13,6 @@ import { agentRuns } from "@okouai/db/schema/agent-run";
 import {
   browserSessionInstances,
   browserSessionResizeStates,
-  browserSessionScreenshotDeletions,
   browserSessionScreenshots,
   browserSessionTabSnapshots,
   browserSessions,
@@ -49,7 +48,7 @@ import {
   publishChatThreadMessageCreatedSafely,
 } from "../external/realtime";
 import { nowDate } from "../../lib/time";
-import { deleteS3Objects, putImmutableS3Object } from "../external/s3";
+import { putImmutableS3Object } from "../external/s3";
 import { settle, settleIncludingAbort, tapError } from "../utils";
 import {
   BrowserUseProviderError,
@@ -871,81 +870,30 @@ const captureAndStoreBrowserScreenshot$ = command(
     );
     signal.throwIfAborted();
 
-    const persisted = await settle(
-      db.transaction(async (tx) => {
-        await lockBrowserThread(tx, browser.chatThreadId);
-        const [previous] = await tx
-          .select({ objectKey: browserSessionScreenshots.objectKey })
-          .from(browserSessionScreenshots)
-          .where(
-            eq(browserSessionScreenshots.chatThreadId, browser.chatThreadId),
-          )
-          .limit(1);
-        await tx
-          .insert(browserSessionScreenshots)
-          .values({
-            chatThreadId: browser.chatThreadId,
+    await db.transaction(async (tx) => {
+      await lockBrowserThread(tx, browser.chatThreadId);
+      await tx
+        .insert(browserSessionScreenshots)
+        .values({
+          chatThreadId: browser.chatThreadId,
+          objectKey: artifact.key,
+          url: artifact.url,
+        })
+        .onConflictDoUpdate({
+          target: browserSessionScreenshots.chatThreadId,
+          set: {
             objectKey: artifact.key,
             url: artifact.url,
-          })
-          .onConflictDoUpdate({
-            target: browserSessionScreenshots.chatThreadId,
-            set: {
-              objectKey: artifact.key,
-              url: artifact.url,
-              updatedAt: nowDate(),
-            },
-          });
-        if (previous && previous.objectKey !== artifact.key) {
-          await tx
-            .insert(browserSessionScreenshotDeletions)
-            .values({
-              objectKey: previous.objectKey,
-              chatThreadId: browser.chatThreadId,
-            })
-            .onConflictDoNothing({
-              target: browserSessionScreenshotDeletions.objectKey,
-            });
-        }
-        return previous?.objectKey ?? null;
-      }),
-      signal,
-    );
-    if (!persisted.ok) {
-      await tapError(get(deleteS3Objects(bucket, [artifact.key])));
-      signal.throwIfAborted();
-      throw persisted.error;
-    }
+            updatedAt: nowDate(),
+          },
+        });
+    });
+    signal.throwIfAborted();
 
     await publishBrowserSessionChangedSafely(browser.userId, {
       threadId: browser.chatThreadId,
     });
     signal.throwIfAborted();
-    const previousObjectKey = persisted.value;
-    if (previousObjectKey !== null && previousObjectKey !== artifact.key) {
-      await tapError(
-        (async () => {
-          await get(deleteS3Objects(bucket, [previousObjectKey]));
-          signal.throwIfAborted();
-          await db
-            .delete(browserSessionScreenshotDeletions)
-            .where(
-              eq(
-                browserSessionScreenshotDeletions.objectKey,
-                previousObjectKey,
-              ),
-            );
-        })(),
-        (error) => {
-          L.warn("Managed browser queued screenshot cleanup failed", {
-            chatThreadId: browser.chatThreadId,
-            objectKey: previousObjectKey,
-            error,
-          });
-        },
-      );
-      signal.throwIfAborted();
-    }
   },
 );
 
@@ -2978,27 +2926,9 @@ async function claimExpiredInactiveBrowser(
     }
 
     if (screenshotSchemaReady) {
-      const [screenshot] = await tx
-        .select({ objectKey: browserSessionScreenshots.objectKey })
-        .from(browserSessionScreenshots)
-        .where(eq(browserSessionScreenshots.chatThreadId, target.chatThreadId))
-        .limit(1);
-      if (screenshot) {
-        await tx
-          .insert(browserSessionScreenshotDeletions)
-          .values({
-            objectKey: screenshot.objectKey,
-            chatThreadId: target.chatThreadId,
-          })
-          .onConflictDoNothing({
-            target: browserSessionScreenshotDeletions.objectKey,
-          });
-        await tx
-          .delete(browserSessionScreenshots)
-          .where(
-            eq(browserSessionScreenshots.chatThreadId, target.chatThreadId),
-          );
-      }
+      await tx
+        .delete(browserSessionScreenshots)
+        .where(eq(browserSessionScreenshots.chatThreadId, target.chatThreadId));
     }
     await tx
       .delete(browserSessionTabSnapshots)
@@ -3368,7 +3298,6 @@ async function reconcileOrphanedBrowserProfiles(
 
 async function reconcileOrphanedBrowserScreenshots(
   db: Db,
-  deleteObjects: (keys: readonly string[]) => Promise<void>,
   limit: number,
   chatThreadIds: readonly string[] | null,
   signal: AbortSignal,
@@ -3403,21 +3332,14 @@ async function reconcileOrphanedBrowserScreenshots(
   let errors = 0;
   for (const screenshot of screenshots) {
     const result = await settleIncludingAbort(
-      (async () => {
-        await deleteObjects([screenshot.objectKey]);
-        signal.throwIfAborted();
-        await db
-          .delete(browserSessionScreenshots)
-          .where(
-            and(
-              eq(
-                browserSessionScreenshots.chatThreadId,
-                screenshot.chatThreadId,
-              ),
-              eq(browserSessionScreenshots.objectKey, screenshot.objectKey),
-            ),
-          );
-      })(),
+      db
+        .delete(browserSessionScreenshots)
+        .where(
+          and(
+            eq(browserSessionScreenshots.chatThreadId, screenshot.chatThreadId),
+            eq(browserSessionScreenshots.objectKey, screenshot.objectKey),
+          ),
+        ),
     );
     signal.throwIfAborted();
     if (result.ok) {
@@ -3432,64 +3354,6 @@ async function reconcileOrphanedBrowserScreenshots(
     }
   }
   return { checked: screenshots.length, cleaned, errors };
-}
-
-async function reconcileQueuedBrowserScreenshotDeletions(
-  db: Db,
-  deleteObjects: (keys: readonly string[]) => Promise<void>,
-  limit: number,
-  chatThreadIds: readonly string[] | null,
-  signal: AbortSignal,
-): Promise<{
-  readonly checked: number;
-  readonly cleaned: number;
-  readonly errors: number;
-}> {
-  const deletions = await db
-    .select({
-      chatThreadId: browserSessionScreenshotDeletions.chatThreadId,
-      objectKey: browserSessionScreenshotDeletions.objectKey,
-    })
-    .from(browserSessionScreenshotDeletions)
-    .where(
-      chatThreadIds === null
-        ? undefined
-        : inArray(
-            browserSessionScreenshotDeletions.chatThreadId,
-            chatThreadIds,
-          ),
-    )
-    .orderBy(browserSessionScreenshotDeletions.createdAt)
-    .limit(limit);
-  signal.throwIfAborted();
-
-  let cleaned = 0;
-  let errors = 0;
-  for (const deletion of deletions) {
-    const result = await settleIncludingAbort(
-      (async () => {
-        await deleteObjects([deletion.objectKey]);
-        signal.throwIfAborted();
-        await db
-          .delete(browserSessionScreenshotDeletions)
-          .where(
-            eq(browserSessionScreenshotDeletions.objectKey, deletion.objectKey),
-          );
-      })(),
-    );
-    signal.throwIfAborted();
-    if (result.ok) {
-      cleaned += 1;
-    } else {
-      errors += 1;
-      L.warn("Managed browser queued screenshot reconciliation failed", {
-        chatThreadId: deletion.chatThreadId,
-        objectKey: deletion.objectKey,
-        error: result.error,
-      });
-    }
-  }
-  return { checked: deletions.length, cleaned, errors };
 }
 
 const reconcileBrowserInstance$ = command(
@@ -3562,7 +3426,7 @@ const reconcileBrowserInstance$ = command(
 
 const reconcileBrowsersWithScope$ = command(
   async (
-    { get, set },
+    { set },
     chatThreadIds: readonly string[] | null,
     signal: AbortSignal,
   ): Promise<BrowserReconcileResult> => {
@@ -3634,22 +3498,9 @@ const reconcileBrowsersWithScope$ = command(
       chatThreadIds,
       signal,
     );
-    const deleteScreenshotObjects = async (keys: readonly string[]) => {
-      await get(deleteS3Objects(env("R2_USER_ARTIFACTS_BUCKET_NAME"), keys));
-    };
-    const queuedScreenshotCleanup = screenshotSchemaReady
-      ? await reconcileQueuedBrowserScreenshotDeletions(
-          db,
-          deleteScreenshotObjects,
-          RECONCILE_BATCH_SIZE,
-          chatThreadIds,
-          signal,
-        )
-      : { checked: 0, cleaned: 0, errors: 0 };
     const orphanedScreenshotCleanup = screenshotSchemaReady
       ? await reconcileOrphanedBrowserScreenshots(
           db,
-          deleteScreenshotObjects,
           RECONCILE_BATCH_SIZE,
           chatThreadIds,
           signal,
@@ -3663,20 +3514,17 @@ const reconcileBrowsersWithScope$ = command(
         expiredBrowserCleanup.checked +
         expiredInstanceCleanup.checked +
         profileCleanup.checked +
-        queuedScreenshotCleanup.checked +
         orphanedScreenshotCleanup.checked,
       stopped:
         stopped +
         expiredBrowserCleanup.cleaned +
         expiredInstanceCleanup.cleaned +
         profileCleanup.cleaned +
-        queuedScreenshotCleanup.cleaned +
         orphanedScreenshotCleanup.cleaned,
       errors:
         errors +
         expiredBrowserCleanup.errors +
         profileCleanup.errors +
-        queuedScreenshotCleanup.errors +
         orphanedScreenshotCleanup.errors,
       healthy,
     };

--- a/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
+++ b/turbo/apps/platform/src/shared-database/__tests__/worker-runtime.test.ts
@@ -709,6 +709,92 @@ test("Rebuild a cached chat when batched catch-up cannot continue its cursor", a
   ).resolves.toStrictEqual([rebuiltRow, tailRow]);
 });
 
+test.each(["readonly", "readwrite"] as const)(
+  "Serve remote chat data without Sentry reports when IndexedDB %s transactions fail",
+  async (mode) => {
+    const { runtime } = startRuntime();
+    const dataKey = chatEventKey(crypto.randomUUID());
+    const remoteRow = chatEventRow(dataKey.threadId, 1);
+    const snapshot = {
+      chatThreads: [snapshotThread("Available conversation")],
+      latestEventId: null,
+      latestSeqId: null,
+    };
+    await queryRuntime(runtime, {
+      dataKey,
+      afterSeqId: null,
+      consistency: "cache-only",
+    });
+    const transaction = IDBDatabase.prototype.transaction;
+    vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (
+      this: IDBDatabase,
+      storeNames,
+      transactionMode,
+      options,
+    ) {
+      if (transactionMode === mode) {
+        throw new DOMException(
+          "Local storage unavailable",
+          "InvalidStateError",
+        );
+      }
+      return transaction.call(this, storeNames, transactionMode, options);
+    });
+    context.mocks.api(chatThreadEventsContract.snapshot, ({ respond }) => {
+      return respond(404, {
+        error: {
+          code: "CHAT_EVENT_SNAPSHOT_NOT_FOUND",
+          message: "Chat event snapshot not found",
+        },
+      });
+    });
+    context.mocks.api(chatThreadEventsContract.rows, ({ query, respond }) => {
+      return respond(200, chatEventRowsResponse([remoteRow], query));
+    });
+    context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+      return respond(200, snapshot);
+    });
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      return respond(200, { events: [], hasMore: false });
+    });
+
+    await expect(
+      queryRuntime(runtime, {
+        dataKey,
+        afterSeqId: null,
+        consistency: "catch-up",
+      }),
+    ).resolves.toStrictEqual([remoteRow]);
+    await expect(
+      queryRuntime(runtime, {
+        dataKey: chatThreadEventKey(),
+        afterSeqId: null,
+        consistency: "catch-up",
+      }),
+    ).resolves.toStrictEqual({ snapshot, events: [] });
+    expect(context.mocks.sentry().reports).toStrictEqual([]);
+
+    context.mocks.api(chatThreadEventsContract.rows, ({ respond }) => {
+      return respond(500, {
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "Remote storage unavailable",
+        },
+      });
+    });
+    await expect(
+      queryRuntime(runtime, {
+        dataKey,
+        afterSeqId: null,
+        consistency: "catch-up",
+      }),
+    ).rejects.toMatchObject({ status: 500 });
+    expect(context.mocks.sentry().reports).toMatchObject([
+      { type: "exception", error: { status: 500 } },
+    ]);
+  },
+);
+
 test("Continue online when local chat storage becomes unavailable", async () => {
   const currentIdentity = identity();
   const { events, runtime } = startRuntime(currentIdentity);
@@ -762,4 +848,5 @@ test("Continue online when local chat storage becomes unavailable", async () => 
       consistency: "cache-only",
     }),
   ).resolves.toStrictEqual([]);
+  expect(context.mocks.sentry().reports).toStrictEqual([]);
 });

--- a/turbo/apps/platform/src/shared-database/worker-runtime.ts
+++ b/turbo/apps/platform/src/shared-database/worker-runtime.ts
@@ -157,13 +157,21 @@ function isRecoverableChatIdbTransactionError(error: unknown): boolean {
   );
 }
 
+function logDataKeyError(
+  dataKey: ScopedSharedDatabaseDataKey,
+  operation: string,
+  error: unknown,
+): void {
+  L.debug(operation, { ...dataKeyDiagnosticDetails(dataKey), error });
+}
+
 function reportDataKeyError(
   dataKey: ScopedSharedDatabaseDataKey,
   operation: string,
   error: unknown,
 ): void {
+  logDataKeyError(dataKey, operation, error);
   if (isAbortError(error)) {
-    L.debug(operation, { ...dataKeyDiagnosticDetails(dataKey), error });
     return;
   }
   const details = dataKeyDiagnosticDetails(dataKey);
@@ -180,7 +188,6 @@ function reportDataKeyError(
     },
     user: { id: dataKey.userId },
   });
-  L.debug(operation, { ...details, error });
   captureSentryLogError("SharedDatabaseWorker", [
     operation,
     error,
@@ -339,7 +346,7 @@ export class SharedDatabaseWorkerRuntime {
       signal,
     );
     if (!cachedCursorsResult.ok) {
-      reportDataKeyError(
+      logDataKeyError(
         diagnosticDataKey,
         "indexeddb.chat-event-cursors.read.error",
         cachedCursorsResult.error,
@@ -494,7 +501,7 @@ export class SharedDatabaseWorkerRuntime {
       if (!firstWrite) {
         throw new Error("ChatEvent batch write diagnostic is missing");
       }
-      reportDataKeyError(
+      logDataKeyError(
         firstWrite.dataKey,
         "indexeddb.chat-event-batch.write.error",
         written.error,
@@ -560,7 +567,7 @@ export class SharedDatabaseWorkerRuntime {
       signal,
     );
     if (!cleared.ok) {
-      reportDataKeyError(
+      logDataKeyError(
         dataKey,
         "indexeddb.chat-event.clear.error",
         cleared.error,
@@ -642,7 +649,7 @@ export class SharedDatabaseWorkerRuntime {
       ? cachedCursorResult.value
       : null;
     if (!cachedCursorResult.ok) {
-      reportDataKeyError(
+      logDataKeyError(
         dataKey,
         "indexeddb.chat-event-cursor.read.error",
         cachedCursorResult.error,
@@ -712,7 +719,7 @@ export class SharedDatabaseWorkerRuntime {
       signal,
     );
     if (!written.ok) {
-      reportDataKeyError(
+      logDataKeyError(
         dataKey,
         "indexeddb.chat-event.write.error",
         written.error,
@@ -916,7 +923,7 @@ export class SharedDatabaseWorkerRuntime {
         signal,
       );
       if (!written.ok) {
-        reportDataKeyError(
+        logDataKeyError(
           dataKey,
           "indexeddb.chat-thread-event.write.error",
           written.error,
@@ -1059,11 +1066,7 @@ export class SharedDatabaseWorkerRuntime {
       signal,
     );
     if (!result.ok) {
-      reportDataKeyError(
-        dataKey,
-        "indexeddb.chat-event.read.error",
-        result.error,
-      );
+      logDataKeyError(dataKey, "indexeddb.chat-event.read.error", result.error);
       return [];
     }
     return result.value;
@@ -1087,7 +1090,7 @@ export class SharedDatabaseWorkerRuntime {
       signal,
     );
     if (!result.ok) {
-      reportDataKeyError(
+      logDataKeyError(
         dataKey,
         "indexeddb.chat-thread-event.read.error",
         result.error,

--- a/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/chat-navigation-position-restoration.test.tsx
@@ -607,6 +607,55 @@ test("Open a conversation at a linked message", async () => {
   expect(buttonNamed("Scroll to bottom")).toBeInTheDocument();
 });
 
+test.each([false, true])(
+  "Expand folded work when opening a linked message with run work folding %s",
+  async (runWorkFolding) => {
+    const resize = mockResizeObserver();
+    const linkedEventId = "folded-link-work-3";
+    const linkedText = "Linked work detail";
+    const events = conversationEvents("folded-link", "Linked")
+      .flatMap((event) => {
+        return event.id === "folded-link-assistant-3"
+          ? [{ ...event, id: linkedEventId, content: linkedText }, event]
+          : [event];
+      })
+      .map((event, index) => {
+        return {
+          ...event,
+          seqId: index + 1,
+          runGroupId:
+            event.runId === "folded-link-run-3" ||
+            event.runId === "folded-link-run-4"
+              ? "folded-link-group"
+              : undefined,
+        };
+      });
+    mockChatLifecycleWithoutBrowserSession({
+      threadId: DEEP_LINK_THREAD_ID,
+      threadTitle: "Linked folded conversation",
+      chatEvents: events,
+    });
+
+    await setupPage({
+      context,
+      host: APP_HOST,
+      path: `/chats/${DEEP_LINK_THREAD_ID}#event-${linkedEventId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatRunWorkFolding]: runWorkFolding,
+      },
+    });
+
+    await waitForThreadMessage(DEEP_LINK_THREAD_ID, linkedText);
+    const geometry = installChatScrollGeometry(
+      threadContainer(DEEP_LINK_THREAD_ID),
+    );
+    resize.automationAll();
+
+    await expectReadingPosition(geometry, linkedText, 0);
+    expect(buttonNamed("Scroll to bottom")).toBeInTheDocument();
+  },
+);
+
 test("Open a conversation safely when a linked message is unavailable", async () => {
   const resize = mockResizeObserver();
   mockChatLifecycleWithoutBrowserSession({

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -7787,7 +7787,11 @@ function PagedRunWorkMessage({
 }) {
   const expandedIds = useGet(thread.timelineExpandedIds$);
   const toggleExpanded = useSet(thread.toggleTimelineExpanded$);
-  const expanded = expandedIds.has(event.id);
+  const scrollTargetEventId = useGet(
+    thread.threadScrollPosition$,
+  )?.targetEventId;
+  const expanded =
+    expandedIds.has(event.id) || scrollTargetEventId === event.id;
   return (
     <RunWorkMessage
       event={event}

--- a/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/okou-page/chat-thread-page.tsx
@@ -7787,11 +7787,16 @@ function PagedRunWorkMessage({
 }) {
   const expandedIds = useGet(thread.timelineExpandedIds$);
   const toggleExpanded = useSet(thread.toggleTimelineExpanded$);
-  const scrollTargetEventId = useGet(
-    thread.threadScrollPosition$,
-  )?.targetEventId;
-  const expanded =
-    expandedIds.has(event.id) || scrollTargetEventId === event.id;
+  const isScrollTarget =
+    useGet(thread.threadScrollPosition$, {
+      equalityFn: (previous, next) => {
+        return (
+          (previous?.targetEventId === event.id) ===
+          (next?.targetEventId === event.id)
+        );
+      },
+    })?.targetEventId === event.id;
+  const expanded = expandedIds.has(event.id) || isScrollTarget;
   return (
     <RunWorkMessage
       event={event}


### PR DESCRIPTION
## Summary

- Stop sending recovered SharedDatabase IndexedDB errors to Sentry. Preserve remote-data fallback, existing Axiom telemetry, and Sentry reports for actual query failures.
- Retain browser screenshot objects and remove screenshot deletion jobs, including replacement and orphan cleanup. Capture remains one bounded best-effort attempt per opportunity; a missing screenshot stays optional. Keep database-association cleanup and browser/profile lifecycle reconciliation. The unused deletion table remains for rolling-release and rollback compatibility.
- Expand an individual work message when it is the chat scroll target. The outer work section already expands, but its inner message preview previously left the actual DOM anchor unmounted.

Fixes #32465
Fixes #32120
Fixes #32149

## Verification

- 24 focused SharedDatabase and IndexedDB/Axiom tests passed.
- 4 focused browser screenshot/lifecycle and schema-rollout tests passed against a local PostgreSQL database migrated from this branch.
- 5 focused chat navigation/history tests passed, including both work-folding modes. The new-mode nested-message regression failed before the fix.
- Changed-file ESLint, Oxlint and Prettier checks, scoped Knip, and Platform/API type checks passed.
- Full test suites run in the PR pipeline.
