### PR TITLE
feat(pi): support custom responses fast for terra sol and luna

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -51,7 +51,10 @@ import {
   type SupportedRunModel,
 } from "@okouai/api-contracts/contracts/model-providers";
 import type { PublicBrand } from "@okouai/api-contracts/contracts/public-brand";
-import { modelProviderConnectionsMainContract } from "@okouai/api-contracts/contracts/model-provider-gateways";
+import {
+  modelProviderConnectionsByIdContract,
+  modelProviderConnectionsMainContract,
+} from "@okouai/api-contracts/contracts/model-provider-gateways";
 import {
   modelProvidersByTypeContract,
   modelProvidersMainContract,
@@ -747,7 +750,7 @@ async function expectTerraApiFollowUpUsage(
 
 async function expectNoBuiltInModelUsage(runId: string): Promise<void> {
   // Operational usage rows have no production run-scoped read API. This
-  // test-only observation is required to prove the subscription no-charge
+  // test-only observation is required to prove the user-owned no-charge
   // invariant rather than infer it from the public run status.
   await expect(readRunUsageEventsFixture(runId)).resolves.toStrictEqual([]);
 }
@@ -1567,6 +1570,58 @@ function modelProviderConnectionsClient() {
   return setupApp({ context, routes: modelProviderGatewayRoutes })(
     modelProviderConnectionsMainContract,
   );
+}
+
+async function configureCustomPiModel(
+  actor: ApiTestUser,
+  selectedModel: SupportedRunModel,
+  upstreamModel = `company-${selectedModel}-production`,
+) {
+  const secret = "custom-pi-gateway-secret";
+  const surface = {
+    protocol: "openai-responses" as const,
+    apiBaseUrl: "https://pi-custom-gateway.example.com/openai/v1",
+    authHeaderName: "x-api-key",
+    authHeaderTemplate: "Key {{secret}}",
+    modelMappings: { [selectedModel]: upstreamModel },
+  };
+  const created = await accept(
+    modelProviderConnectionsClient().create({
+      headers: sessionHeaders(actor),
+      body: {
+        displayName: `Pi custom gateway for ${selectedModel}`,
+        secret,
+        surfaces: [surface],
+      },
+    }),
+    [201],
+  );
+  const surfaceId = created.body.surfaces[0]?.id;
+  if (!surfaceId) {
+    throw new Error("Expected the custom Pi gateway to have a surface");
+  }
+  await api.updateOrgModelPolicies(actor, [
+    {
+      model: selectedModel,
+      isDefault: true,
+      defaultProviderType: "custom-openai-responses",
+      credentialScope: "org",
+      modelProviderId: null,
+      modelProviderSurfaceId: surfaceId,
+    },
+  ]);
+  await authDeviceSupport.updateFeatureSwitches(actor, {
+    [FeatureSwitchKey.PiLoop]: true,
+    [FeatureSwitchKey.CodexFastMode]: true,
+  });
+  return {
+    connection: created.body,
+    surfaceId,
+    surface,
+    secret,
+    upstreamModel,
+    endpoint: `${surface.apiBaseUrl}/responses`,
+  };
 }
 
 function chatEventsClient(
@@ -8165,47 +8220,9 @@ describe("CHAT-02: model-first provider policies", () => {
   ] as const)(
     "runs custom Responses gateway $selectedModel through Pi without built-in model billing",
     async ({ selectedModel, upstreamModel }) => {
-      const { actor, agentId, runnerGroup } = await entitledChatActor();
-      const orgId = requireOrgId(actor);
+      const { actor, agentId } = await entitledChatActor();
       const usagePricingResolution = await createGptUsagePricingResolution();
-      const created = await accept(
-        modelProviderConnectionsClient().create({
-          headers: sessionHeaders(actor),
-          body: {
-            displayName: `Pi custom gateway for ${selectedModel}`,
-            secret: "custom-pi-gateway-secret",
-            surfaces: [
-              {
-                protocol: "openai-responses",
-                apiBaseUrl: "https://pi-custom-gateway.example.com/openai/v1",
-                authHeaderName: "x-api-key",
-                authHeaderTemplate: "Key {{secret}}",
-                modelMappings: { [selectedModel]: upstreamModel },
-              },
-            ],
-          },
-        }),
-        [201],
-      );
-      const surfaceId = created.body.surfaces[0]?.id;
-      if (!surfaceId) {
-        throw new Error("Expected the custom Pi gateway to have a surface");
-      }
-      await api.updateOrgModelPolicies(actor, [
-        {
-          model: selectedModel,
-          isDefault: true,
-          defaultProviderType: "custom-openai-responses",
-          credentialScope: "org",
-          modelProviderId: null,
-          modelProviderSurfaceId: surfaceId,
-        },
-      ]);
-      await updateFeatureSwitchesForUser(
-        context,
-        { ...actor, orgId },
-        { [FeatureSwitchKey.PiLoop]: true },
-      );
+      await configureCustomPiModel(actor, selectedModel, upstreamModel);
       mockPiResourceArchiveDownloads();
       mockPiCheckpointObjectStore();
       const modelRequests: {
@@ -8225,7 +8242,7 @@ describe("CHAT-02: model-first provider policies", () => {
             return new HttpResponse(
               piResponsesTextSse(
                 `custom gateway answer for ${selectedModel}`,
-                0,
+                modelRequests.length - 1,
                 {
                   input_tokens: 10,
                   output_tokens: 3,
@@ -8252,8 +8269,8 @@ describe("CHAT-02: model-first provider policies", () => {
         "vm0",
         usagePricingResolution,
       );
-      await waitForRunStatus(actor, run.runId, "completed");
       await flushWaitUntilForTest();
+      await waitForRunStatus(actor, run.runId, "completed");
 
       await expect(
         readRunLaunchSnapshotFixture(context, run.runId),
@@ -8273,31 +8290,916 @@ describe("CHAT-02: model-first provider policies", () => {
         },
       ]);
       expect(modelRequests[0]?.body).not.toHaveProperty("service_tier");
-      await expect(readRunUsageEventsFixture(run.runId)).resolves.toStrictEqual(
-        [],
-      );
+      await expectNoBuiltInModelUsage(run.runId);
       if (selectedModel.startsWith("gpt-")) {
-        await authDeviceSupport.updateFeatureSwitches(actor, {
-          [FeatureSwitchKey.PiLoop]: true,
-          [FeatureSwitchKey.CodexFastMode]: true,
-        });
-        const fast = await sendChatRun(actor, {
+        const firstSession = await readThreadSessionConversation(
+          context,
+          run.threadId,
+        );
+        for (const tier of ["fast", undefined] as const) {
+          await chat.updateThreadModelSelection(
+            actor,
+            run.threadId,
+            selectedModel,
+            {
+              codexServiceTier: tier ?? null,
+            },
+          );
+          const continuation = await sendChatRun(
+            actor,
+            {
+              agentId,
+              threadId: run.threadId,
+              model: selectedModel,
+              prompt: `continue the custom session with ${tier ?? "standard"}`,
+              runOptions: { codexServiceTier: tier },
+            },
+            "vm0",
+            usagePricingResolution,
+          );
+          await flushWaitUntilForTest();
+          await waitForRunStatus(actor, continuation.runId, "completed");
+          expect(modelRequests.at(-1)).toMatchObject({
+            body: {
+              model: upstreamModel,
+              reasoning: { effort: "max" },
+              store: false,
+            },
+            authorization: null,
+            apiKey: "Key custom-pi-gateway-secret",
+          });
+          if (tier === "fast") {
+            expect(modelRequests.at(-1)?.body).toMatchObject({
+              service_tier: "priority",
+            });
+          } else {
+            expect(modelRequests.at(-1)?.body).not.toHaveProperty(
+              "service_tier",
+            );
+          }
+          expect(JSON.stringify(modelRequests.at(-1)?.body)).toContain(
+            `custom gateway answer for ${selectedModel}`,
+          );
+          await expect(
+            readThreadSessionConversation(context, run.threadId),
+          ).resolves.toMatchObject({
+            agent_session_id: firstSession.agent_session_id,
+            conversation_run_id: continuation.runId,
+          });
+          await expectNoBuiltInModelUsage(continuation.runId);
+          const claim = await api.requestClaimRunnerJob(
+            true,
+            continuation.runId,
+            [404],
+          );
+          expectApiError(claim.body);
+        }
+        expect(modelRequests).toHaveLength(3);
+      }
+    },
+    90_000,
+  );
+
+  it.each(
+    GPT_PI_BDD_MODELS.flatMap((selectedModel) => {
+      return [
+        { selectedModel, tier: undefined, outcome: "completed" },
+        { selectedModel, tier: "fast", outcome: "completed" },
+        { selectedModel, tier: "fast", outcome: "failed" },
+        { selectedModel, tier: "fast", outcome: "cancelled" },
+      ] as const;
+    }),
+  )(
+    "keeps custom $selectedModel $tier legacy handoff, captured policy, and $outcome settlement unbilled",
+    async ({ selectedModel, tier, outcome }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const gateway = await configureCustomPiModel(actor, selectedModel);
+      const usagePricingResolution = await createGptUsagePricingResolution();
+      const firewall = createFirewallApi(context);
+      mockPiResourceArchiveDownloads();
+      const objects = mockPiCheckpointObjectStore();
+      const requests: {
+        body: unknown;
+        authorization: string | null;
+        apiKey: string | null;
+      }[] = [];
+      server.use(
+        http.post(gateway.endpoint, async ({ request }) => {
+          requests.push({
+            body: await request.json(),
+            authorization: request.headers.get("authorization"),
+            apiKey: request.headers.get("x-api-key"),
+          });
+          return nativeCodexSseResponse(
+            piResponsesContentSse({
+              blocks: [
+                {
+                  type: "toolCall",
+                  callId: "call_custom",
+                  name: "read",
+                  arguments: { path: "/home/user/workspace/AGENTS.md" },
+                },
+              ],
+              sequence: requests.length,
+            }),
+          );
+        }),
+      );
+      const run = await sendChatRun(
+        actor,
+        {
           agentId,
           model: selectedModel,
-          prompt: "keep custom Fast on its existing runtime until slice 2",
-          runOptions: { codexServiceTier: "fast" },
-        });
-        const claimed = await claimChatRun(runnerGroup, fast.runId);
-        expect(claimed.claim.cliAgentType).toBe("codex");
-        expect(claimed.claim.piModelConfig).toBeUndefined();
-        expect(claimEnvironment(claimed.claim)).toMatchObject({
-          OPENAI_MODEL: upstreamModel,
-          OKOU_CODEX_SERVICE_TIER: "fast",
-        });
-        expect(modelRequests).toHaveLength(1);
-        await cancelChatRun(actor, fast.runId, claimed.sandboxHeaders);
-        await expectNoBuiltInModelUsage(fast.runId);
+          prompt: "hand off custom gateway tools exactly once",
+          runOptions: { codexServiceTier: tier },
+        },
+        "vm0",
+        usagePricingResolution,
+      );
+      const prefix = `${env("R2_USER_STORAGES_BUCKET_NAME")}/pi-api-first-turn/${run.runId}`;
+      await expect
+        .poll(() => {
+          return objects.has(`${prefix}/manifest.json`);
+        })
+        .toBe(true);
+      await flushWaitUntilForTest();
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({
+        authorization: null,
+        apiKey: `Key ${gateway.secret}`,
+        body: {
+          model: gateway.upstreamModel,
+          reasoning: { effort: "max" },
+          store: false,
+        },
+      });
+      if (tier === "fast") {
+        expect(requests[0]?.body).toMatchObject({ service_tier: "priority" });
+      } else {
+        expect(requests[0]?.body).not.toHaveProperty("service_tier");
       }
+      await expectNoBuiltInModelUsage(run.runId);
+
+      await accept(
+        setupApp({ context, routes: modelProviderGatewayRoutes })(
+          modelProviderConnectionsByIdContract,
+        ).update({
+          headers: sessionHeaders(actor),
+          params: { id: gateway.connection.id },
+          body: {
+            displayName: gateway.connection.displayName,
+            secret: "custom-pi-gateway-rotated-secret",
+            surfaces: [
+              {
+                ...gateway.surface,
+                apiBaseUrl: "https://rotated-pi-custom-gateway.example.com/v2",
+                authHeaderName: "Authorization",
+                authHeaderTemplate: "Bearer {{secret}}",
+                modelMappings: { [selectedModel]: "rotated-upstream-alias" },
+              },
+            ],
+          },
+        }),
+        [200],
+      );
+      // Mutating current settings after API ownership cannot rewrite the captured claim.
+      await authDeviceSupport.updateFeatureSwitches(actor, {
+        [FeatureSwitchKey.PiLoop]: false,
+        [FeatureSwitchKey.CodexFastMode]: false,
+      });
+      await chat.updateThreadModelSelection(
+        actor,
+        run.threadId,
+        selectedModel,
+        { codexServiceTier: null },
+      );
+      await configureBuiltInPiModel(actor, selectedModel);
+      await api.heartbeatRunner(runnerGroup);
+      // The existing custom legacy carrier also works for claimants without generation capabilities.
+      const claimResponse = await api.requestClaimRunnerJob(
+        true,
+        run.runId,
+        [200],
+      );
+      if (claimResponse.status !== 200) {
+        throw new Error("Expected the custom legacy claim");
+      }
+      const claim = claimResponse.body;
+      const sandboxHeaders = { authorization: `Bearer ${claim.sandboxToken}` };
+      expect(claim.cliAgentType).toBe("pi");
+      expect(claim.piSessionId).toBe(run.threadId);
+      expect(claim.piModelConfig).toStrictEqual({
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: gateway.surface.apiBaseUrl,
+        model: gateway.upstreamModel,
+        catalogModel: selectedModel,
+        thinkingLevel: "max",
+        ...(tier === undefined ? {} : { serviceTier: "priority" }),
+        apiKeyEnv: "OPENAI_API_KEY",
+        credentialSecretName: "OKOU_MODEL_PROVIDER_API_KEY",
+        credentialHeader: {
+          name: "x-api-key",
+          valueTemplate: "Key {{secret}}",
+        },
+      });
+      expect(claim.billableFirewalls).toStrictEqual([]);
+      expect(claim.firewalls).toContainEqual({
+        kind: "inline",
+        firewall: expect.objectContaining({
+          name: `model-provider-surface:${gateway.surfaceId}`,
+          apis: [
+            expect.objectContaining({
+              base: gateway.endpoint,
+              auth: {
+                headers: {
+                  "x-api-key": `Key ${secretTemplate("OKOU_MODEL_PROVIDER_API_KEY")}`,
+                },
+              },
+            }),
+          ],
+        }),
+      });
+      expect(claimEnvironment(claim)).toMatchObject({
+        OPENAI_BASE_URL: gateway.surface.apiBaseUrl,
+        OPENAI_MODEL: gateway.upstreamModel,
+        OPENAI_API_KEY: MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
+      });
+      expect(JSON.stringify(claim)).not.toContain(gateway.secret);
+      if (!claim.encryptedSecrets) {
+        throw new Error("Expected captured custom credentials");
+      }
+      const resolved = await firewall.requestFirewallAuth(
+        sandboxHeaders,
+        {
+          encryptedSecrets: claim.encryptedSecrets,
+          authHeaders: {
+            "x-api-key": `Key ${secretTemplate("OKOU_MODEL_PROVIDER_API_KEY")}`,
+          },
+          secretConnectorMap: claim.secretConnectorMap ?? undefined,
+          secretConnectorMetadataMap:
+            claim.secretConnectorMetadataMap ?? undefined,
+        },
+        [200],
+      );
+      expect(resolved.body).toMatchObject({
+        headers: { "x-api-key": `Key ${gateway.secret}` },
+        resolvedSecrets: ["OKOU_MODEL_PROVIDER_API_KEY"],
+      });
+      expect(resolved.body).not.toHaveProperty("headers.Authorization");
+
+      const h1 = objects.get(`${prefix}/session.jsonl`);
+      const manifestBytes = objects.get(`${prefix}/manifest.json`);
+      if (!h1 || !manifestBytes) {
+        throw new Error("Expected custom handoff artifacts");
+      }
+      const manifest = piApiFirstTurnManifestSchema.parse(
+        JSON.parse(manifestBytes.toString("utf8")),
+      );
+      const history = MemoryPiSession.fromJsonl(h1.toString("utf8"));
+      const assistant = history.buildSessionContext().messages.at(-1);
+      if (assistant?.role !== "assistant") {
+        throw new Error("Expected pending custom assistant");
+      }
+      const tool = assistant.content.find((block) => {
+        return block.type === "toolCall";
+      });
+      if (tool?.type !== "toolCall") {
+        throw new Error("Expected pending custom tool");
+      }
+      history.appendMessage({
+        role: "toolResult",
+        toolCallId: tool.id,
+        toolName: tool.name,
+        content: [{ type: "text", text: "custom tool output" }],
+        isError: false,
+        timestamp: 2,
+      });
+      history.appendMessage({
+        ...assistant,
+        content: [{ type: "text", text: "custom Sandbox completion" }],
+        stopReason: "stop",
+        timestamp: 3,
+      });
+      const h2 = history.toJsonl();
+      const h2Hash = createHash("sha256").update(h2).digest("hex");
+      await webhooks.requestAgentCheckpointPrepareHistory(
+        {
+          runId: run.runId,
+          hash: h2Hash,
+          rawSize: Buffer.byteLength(h2),
+          encodedSize: Buffer.byteLength(h2),
+          encoding: "identity",
+        },
+        sandboxHeaders,
+        [200],
+      );
+      objects.set(
+        `${env("R2_USER_STORAGES_BUCKET_NAME")}/blobs/${h2Hash}.blob`,
+        Buffer.from(h2, "utf8"),
+      );
+      const sequence = manifest.sandboxEventSequenceStart;
+      await webhooks.requestAgentEvents(
+        {
+          runId: run.runId,
+          events: [
+            {
+              type: "assistant",
+              sequenceNumber: sequence,
+              message: {
+                content: [{ type: "text", text: "custom Sandbox completion" }],
+              },
+            },
+            {
+              type: "result",
+              sequenceNumber: sequence + 1,
+              result: "custom Sandbox completion",
+            },
+          ],
+        },
+        sandboxHeaders,
+        [200],
+      );
+      if (outcome === "cancelled") {
+        await cancelChatRun(actor, run.runId);
+      }
+      await webhooks.requestAgentComplete(
+        {
+          runId: run.runId,
+          exitCode: outcome === "failed" ? 1 : 0,
+          ...(outcome === "failed" ? { error: "custom Sandbox failed" } : {}),
+          lastEventSequence: sequence + 1,
+          checkpoint: {
+            cliAgentType: "pi",
+            cliAgentSessionId: run.threadId,
+            cliAgentSessionHistoryHash: h2Hash,
+          },
+        },
+        sandboxHeaders,
+        outcome === "cancelled" ? [400] : [200],
+        undefined,
+        usagePricingResolution,
+      );
+      await waitForRunStatus(actor, run.runId, outcome);
+      await flushWaitUntilForTest();
+      await webhooks.requestAgentComplete(
+        { runId: run.runId, exitCode: 0 },
+        sandboxHeaders,
+        [200],
+        undefined,
+        usagePricingResolution,
+      );
+      await flushWaitUntilForTest();
+      await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+        status: outcome,
+      });
+      expect(requests).toHaveLength(1);
+      await expectNoBuiltInModelUsage(run.runId);
+      expect(h2).not.toMatch(/serviceTier|service_tier/);
+      expect(
+        JSON.stringify({
+          h2,
+          events: (await chat.listThreadEvents(actor, run.threadId)).events,
+          telemetry: [
+            ...context.mocks.axiomLogging.debug.mock.calls,
+            ...context.mocks.axiomLogging.warn.mock.calls,
+          ],
+        }),
+      ).not.toContain(gateway.secret);
+    },
+    90_000,
+  );
+
+  it.each(
+    GPT_PI_BDD_MODELS.flatMap((selectedModel) => {
+      return [400, 401].map((status) => {
+        return { selectedModel, status };
+      });
+    }),
+  )(
+    "surfaces custom $selectedModel Fast rejection $status without downgrade, replay, or billing",
+    async ({ selectedModel, status }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const gateway = await configureCustomPiModel(actor, selectedModel);
+      mockPiResourceArchiveDownloads();
+      const objects = mockPiCheckpointObjectStore();
+      const requests: {
+        url: string;
+        body: unknown;
+        apiKey: string | null;
+        authorization: string | null;
+      }[] = [];
+      server.use(
+        ...[
+          gateway.endpoint,
+          ...new Set(
+            USER_OWNED_GPT_FAST_BDD_ROUTES.map((route) => {
+              return route.endpoint;
+            }),
+          ),
+        ].map((endpoint) => {
+          return http.post(endpoint, async ({ request }) => {
+            requests.push({
+              url: request.url,
+              body: await readCodexRequestJson(request),
+              apiKey: request.headers.get("x-api-key"),
+              authorization: request.headers.get("authorization"),
+            });
+            return HttpResponse.json(
+              {
+                error: {
+                  code:
+                    status === 400
+                      ? "unsupported_service_tier"
+                      : "invalid_api_key",
+                  message: `gateway rejected priority: ${gateway.secret}`,
+                },
+              },
+              { status },
+            );
+          });
+        }),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        model: selectedModel,
+        prompt: "surface the custom Fast rejection",
+        runOptions: { codexServiceTier: "fast" },
+      });
+      await waitForRunStatus(actor, run.runId, "failed");
+      await flushWaitUntilForTest();
+      expect(requests).toStrictEqual([
+        {
+          url: gateway.endpoint,
+          apiKey: `Key ${gateway.secret}`,
+          authorization: null,
+          body: expect.objectContaining({
+            model: gateway.upstreamModel,
+            service_tier: "priority",
+            reasoning: expect.objectContaining({ effort: "max" }),
+          }),
+        },
+      ]);
+      const failed = await api.readRun(actor, run.runId);
+      expect(failed).toMatchObject({
+        status: "failed",
+        error: expect.stringContaining("[PI_API_MODEL_FAILED]"),
+      });
+      await api.heartbeatRunner(runnerGroup);
+      const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
+      expectApiError(claim.body);
+      await expectNoBuiltInModelUsage(run.runId);
+      expectNoPiApiFirstTurnArtifacts(run.runId, objects);
+      expect(
+        JSON.stringify({
+          failed,
+          events: (await chat.listThreadEvents(actor, run.threadId)).events,
+          logs: [
+            ...context.mocks.axiomLogging.debug.mock.calls,
+            ...context.mocks.axiomLogging.warn.mock.calls,
+          ],
+        }),
+      ).not.toContain(gateway.secret);
+    },
+    90_000,
+  );
+
+  it.each(
+    GPT_PI_BDD_MODELS.flatMap((selectedModel) => {
+      return ["mapping", "connection"].map((removed) => {
+        return { selectedModel, removed };
+      });
+    }),
+  )(
+    "fails custom $selectedModel Fast when its $removed disappears before credential capture",
+    async ({ selectedModel, removed }) => {
+      const { actor, agentId } = await entitledChatActor();
+      const gateway = await configureCustomPiModel(actor, selectedModel);
+      const gate = holdAgentRunPiExecutionSnapshotFixture({
+        userId: actor.userId,
+        orgId: requireOrgId(actor),
+        signal: context.signal,
+      });
+      onTestFinished(gate.release);
+      const requests: string[] = [];
+      server.use(
+        ...[
+          gateway.endpoint,
+          ...new Set(
+            USER_OWNED_GPT_FAST_BDD_ROUTES.map((route) => {
+              return route.endpoint;
+            }),
+          ),
+        ].map((endpoint) => {
+          return http.post(endpoint, ({ request }) => {
+            requests.push(request.url);
+            return nativeCodexSseResponse(
+              piResponsesTextSse("unexpected substituted request", 0),
+            );
+          });
+        }),
+      );
+      const sent = chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          clientEventId: randomUUID(),
+          model: selectedModel,
+          prompt: "fail the unavailable custom route before any model call",
+          runOptions: { codexServiceTier: "fast" },
+        },
+        [503],
+      );
+      expect(await gate.arrival).toMatchObject({ piExecution: true });
+      const connection = setupApp({
+        context,
+        routes: modelProviderGatewayRoutes,
+      })(modelProviderConnectionsByIdContract);
+      if (removed === "connection") {
+        await accept(
+          connection.delete({
+            headers: sessionHeaders(actor),
+            params: { id: gateway.connection.id },
+          }),
+          [204],
+        );
+      } else {
+        await accept(
+          connection.update({
+            headers: sessionHeaders(actor),
+            params: { id: gateway.connection.id },
+            body: {
+              displayName: gateway.connection.displayName,
+              surfaces: [
+                {
+                  ...gateway.surface,
+                  modelMappings: { "gpt-6-astra": "unrelated-upstream-alias" },
+                },
+              ],
+            },
+          }),
+          [200],
+        );
+      }
+      gate.release();
+      const rejected = await sent;
+      await flushWaitUntilForTest();
+      expect(rejected.body).toMatchObject({
+        error: { code: "PROVIDER_UNAVAILABLE" },
+      });
+      expect(requests).toStrictEqual([]);
+    },
+    90_000,
+  );
+
+  it.each(GPT_PI_BDD_MODELS)(
+    "preserves captured custom %s Fast credentials after gateway removal without substitution",
+    async (selectedModel) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const gateway = await configureCustomPiModel(actor, selectedModel);
+      const entered = createDeferredPromise<void>(context.signal);
+      const release = createDeferredPromise<void>(context.signal);
+      onTestFinished(() => {
+        if (!release.settled()) {
+          release.resolve(undefined);
+        }
+      });
+      const objects = mockPiCheckpointObjectStore();
+      const requests: {
+        url: string;
+        body: unknown;
+        apiKey: string | null;
+        authorization: string | null;
+      }[] = [];
+      server.use(
+        http.get(PI_RESOURCE_ARCHIVE_DOWNLOAD_URL, async ({ request }) => {
+          if (!entered.settled()) {
+            entered.resolve(undefined);
+          }
+          await release.promise;
+          const objectKey = new URL(request.url).searchParams.get("object");
+          if (!objectKey) {
+            throw new Error("Expected Pi archive identity");
+          }
+          return new HttpResponse(piS3Object(objectKey), {
+            headers: { "content-type": "application/gzip" },
+          });
+        }),
+        ...[
+          gateway.endpoint,
+          ...new Set(
+            USER_OWNED_GPT_FAST_BDD_ROUTES.map((route) => {
+              return route.endpoint;
+            }),
+          ),
+        ].map((endpoint) => {
+          return http.post(endpoint, async ({ request }) => {
+            requests.push({
+              url: request.url,
+              body: await readCodexRequestJson(request),
+              apiKey: request.headers.get("x-api-key"),
+              authorization: request.headers.get("authorization"),
+            });
+            return nativeCodexSseResponse(
+              piResponsesTextSse("captured custom credential", requests.length),
+            );
+          });
+        }),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        model: selectedModel,
+        prompt: "retain the captured custom credential authority",
+        runOptions: { codexServiceTier: "fast" },
+      });
+      await entered.promise;
+      await accept(
+        setupApp({ context, routes: modelProviderGatewayRoutes })(
+          modelProviderConnectionsByIdContract,
+        ).delete({
+          headers: sessionHeaders(actor),
+          params: { id: gateway.connection.id },
+        }),
+        [204],
+      );
+      release.resolve(undefined);
+      await waitForRunStatus(actor, run.runId, "completed");
+      await flushWaitUntilForTest();
+      await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+        status: "completed",
+      });
+      expect(requests).toStrictEqual([
+        {
+          url: gateway.endpoint,
+          body: expect.objectContaining({
+            model: gateway.upstreamModel,
+            service_tier: "priority",
+          }),
+          apiKey: `Key ${gateway.secret}`,
+          authorization: null,
+        },
+      ]);
+      await expectNoBuiltInModelUsage(run.runId);
+      for (const bytes of objects.values()) {
+        expect(bytes.toString("utf8")).not.toContain(gateway.secret);
+      }
+      await api.heartbeatRunner(runnerGroup);
+      const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
+      expectApiError(claim.body);
+    },
+    90_000,
+  );
+
+  it.each(GPT_PI_BDD_MODELS)(
+    "promotes queued custom %s Fast with the admitted tier and switch snapshot",
+    async (selectedModel) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const anchor = await sendChatRun(actor, {
+        agentId,
+        prompt: "hold the target thread",
+      });
+      const anchorClaim = await claimChatRun(runnerGroup, anchor.runId);
+      const gateway = await configureCustomPiModel(actor, selectedModel);
+      mockPiResourceArchiveDownloads();
+      mockPiCheckpointObjectStore();
+      const requests: unknown[] = [];
+      server.use(
+        http.post(gateway.endpoint, async ({ request }) => {
+          expect(request.headers.get("x-api-key")).toBe(
+            `Key ${gateway.secret}`,
+          );
+          expect(request.headers.get("authorization")).toBeNull();
+          requests.push(await request.json());
+          return nativeCodexSseResponse(
+            piResponsesTextSse("queued custom answer", requests.length),
+          );
+        }),
+      );
+      const queuedId = randomUUID();
+      const queued = await chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          threadId: anchor.threadId,
+          clientEventId: queuedId,
+          model: selectedModel,
+          prompt: "queued custom Fast",
+          runOptions: { codexServiceTier: "fast" },
+        },
+        [201],
+      );
+      if (queued.status !== 201) {
+        throw new Error("Expected a queued custom send");
+      }
+      expect(queued.body.runId).toBeNull();
+      const gate = holdAgentRunPiExecutionSnapshotFixture({
+        userId: actor.userId,
+        orgId: requireOrgId(actor),
+        signal: context.signal,
+      });
+      onTestFinished(gate.release);
+      chatCallbacks.mockChatOutputEvents([]);
+      const completion = completeChatRunOk(
+        anchor.runId,
+        anchorClaim.sandboxHeaders,
+      );
+      const snapshot = await gate.arrival;
+      expect(snapshot).toMatchObject({
+        chatThreadId: anchor.threadId,
+        piExecution: true,
+        threadSessionCliAgentType: "pi",
+      });
+      // Promotion reads the current thread selection, then owns that snapshot.
+      await chat.updateThreadModelSelection(
+        actor,
+        anchor.threadId,
+        selectedModel,
+        { codexServiceTier: null },
+      );
+      await authDeviceSupport.updateFeatureSwitches(actor, {
+        [FeatureSwitchKey.PiLoop]: false,
+        [FeatureSwitchKey.CodexFastMode]: false,
+      });
+      gate.release();
+      await completion;
+      const messages = await waitForThreadMessages(
+        actor,
+        anchor.threadId,
+        (events) => {
+          return userMessages(events).some((event) => {
+            return (
+              event.revokesEventId === queuedId && event.runId !== undefined
+            );
+          });
+        },
+      );
+      const promoted = userMessages(messages.events).find((event) => {
+        return event.revokesEventId === queuedId;
+      });
+      if (!promoted?.runId) {
+        throw new Error("Expected a promoted custom run");
+      }
+      await waitForRunStatus(actor, promoted.runId, "completed");
+      await flushWaitUntilForTest();
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({
+        model: gateway.upstreamModel,
+        service_tier: "priority",
+        reasoning: { effort: "max" },
+      });
+      expect(
+        occurrences(JSON.stringify(requests[0]), "queued custom Fast"),
+      ).toBe(1);
+      await expectNoBuiltInModelUsage(promoted.runId);
+      await expect(
+        readRunLaunchSnapshotFixture(context, promoted.runId),
+      ).resolves.toMatchObject({ launch_snapshot: { framework: "pi" } });
+      const claim = await api.requestClaimRunnerJob(
+        true,
+        promoted.runId,
+        [404],
+      );
+      expectApiError(claim.body);
+    },
+    90_000,
+  );
+
+  it.each(
+    GPT_PI_BDD_MODELS.flatMap((selectedModel) => {
+      return ["in-flight", "late-result"].map((phase) => {
+        return { selectedModel, phase };
+      });
+    }),
+  )(
+    "keeps cancelled custom $selectedModel Fast $phase unbilled and unreplayed",
+    async ({ selectedModel, phase }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const gateway = await configureCustomPiModel(actor, selectedModel);
+      mockPiResourceArchiveDownloads();
+      const objects = mockPiCheckpointObjectStore();
+      const entered = createDeferredPromise<void>(context.signal);
+      const release = createDeferredPromise<void>(context.signal);
+      onTestFinished(() => {
+        if (!release.settled()) {
+          release.resolve(undefined);
+        }
+      });
+      const requests: unknown[] = [];
+      server.use(
+        http.post(gateway.endpoint, async ({ request }) => {
+          expect(request.headers.get("x-api-key")).toBe(
+            `Key ${gateway.secret}`,
+          );
+          expect(request.headers.get("authorization")).toBeNull();
+          requests.push(await request.json());
+          if (!entered.settled()) {
+            entered.resolve(undefined);
+          }
+          await release.promise;
+          return nativeCodexSseResponse(
+            piResponsesTextSse("discarded custom answer", requests.length),
+          );
+        }),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        model: selectedModel,
+        prompt: "cancel custom Fast ownership",
+        runOptions: { codexServiceTier: "fast" },
+      });
+      await entered.promise;
+      if (phase === "late-result") {
+        await cancelBeforeLatePiResult(actor, run.runId, () => {
+          release.resolve(undefined);
+        });
+      } else {
+        await cancelChatRun(actor, run.runId);
+        release.resolve(undefined);
+      }
+      await flushWaitUntilForTest();
+      await expect(api.readRun(actor, run.runId)).resolves.toMatchObject({
+        status: "cancelled",
+      });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({
+        model: gateway.upstreamModel,
+        service_tier: "priority",
+      });
+      await expectNoBuiltInModelUsage(run.runId);
+      expectNoPiApiFirstTurnArtifacts(run.runId, objects);
+      expect(
+        eventBackedContents(
+          (await chat.listThreadEvents(actor, run.threadId)).events,
+          run.runId,
+        ),
+      ).toHaveLength(0);
+      await api.heartbeatRunner(runnerGroup);
+      const claim = await api.requestClaimRunnerJob(true, run.runId, [404]);
+      expectApiError(claim.body);
+    },
+    90_000,
+  );
+
+  it.each([
+    { selectedModel: "gpt-6-astra", tier: undefined, piLoop: true },
+    { selectedModel: "gpt-6-astra", tier: "fast", piLoop: true },
+    { selectedModel: "gpt-5.5", tier: undefined, piLoop: true },
+    ...GPT_PI_BDD_MODELS.map((selectedModel) => {
+      return { selectedModel, tier: "fast", piLoop: false } as const;
+    }),
+  ] as const)(
+    "keeps custom $selectedModel $tier with PiLoop=$piLoop inside its existing runtime boundary",
+    async ({ selectedModel, tier, piLoop }) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      const gateway = await configureCustomPiModel(actor, selectedModel);
+      await authDeviceSupport.updateFeatureSwitches(actor, {
+        [FeatureSwitchKey.PiLoop]: piLoop,
+      });
+      const run = await sendChatRun(actor, {
+        agentId,
+        model: selectedModel,
+        prompt: "respect custom Pi admission boundaries",
+        runOptions: { codexServiceTier: tier },
+      });
+      const claimed = await claimChatRun(runnerGroup, run.runId);
+      expect(claimed.claim.cliAgentType).toBe("codex");
+      expect(claimed.claim.piModelConfig).toBeUndefined();
+      expect(claimEnvironment(claimed.claim)).toMatchObject({
+        OPENAI_MODEL: gateway.upstreamModel,
+      });
+      await cancelChatRun(actor, run.runId, claimed.sandboxHeaders);
+      await expectNoBuiltInModelUsage(run.runId);
+    },
+    90_000,
+  );
+
+  it.each(GPT_PI_BDD_MODELS)(
+    "rejects custom %s Fast admission when the existing Fast gate is disabled",
+    async (selectedModel) => {
+      const { actor, agentId } = await entitledChatActor();
+      await configureCustomPiModel(actor, selectedModel);
+      await authDeviceSupport.updateFeatureSwitches(actor, {
+        [FeatureSwitchKey.CodexFastMode]: false,
+      });
+      const clientThreadId = randomUUID();
+      const rejected = await chat.requestSendEvent(
+        actor,
+        {
+          agentId,
+          clientEventId: randomUUID(),
+          clientThreadId,
+          model: selectedModel,
+          prompt: "respect the custom Fast feature gate",
+          runOptions: { codexServiceTier: "fast" },
+        },
+        [400],
+      );
+      expect(rejected.body).toMatchObject({
+        error: {
+          message: "Codex fast mode is not enabled for this workspace",
+        },
+      });
+      await chat.requestReadThread(actor, clientThreadId, [404]);
     },
     90_000,
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -8810,7 +8810,7 @@ describe("CHAT-02: model-first provider policies", () => {
         },
         [503],
       );
-      expect(await gate.arrival).toMatchObject({ piExecution: true });
+      await expect(gate.arrival).resolves.toMatchObject({ piExecution: true });
       const connection = setupApp({
         context,
         routes: modelProviderGatewayRoutes,

--- a/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
+++ b/turbo/apps/api/src/signals/services/pi-sandbox-config.ts
@@ -115,7 +115,8 @@ function piRuntimeContract(args: {
     return {
       api: "openai-responses",
       thinkingLevel: "max",
-      ...(isBuiltInModelProviderType(args.providerType) &&
+      ...((isBuiltInModelProviderType(args.providerType) ||
+        args.providerType === "custom-openai-responses") &&
       args.codexServiceTier === "fast"
         ? { serviceTier: "priority" as const }
         : {}),
@@ -149,6 +150,7 @@ function isFastGptPiProvider(
 ): boolean {
   return (
     modelProviderType === "codex-oauth-token" ||
+    modelProviderType === "custom-openai-responses" ||
     isGptApiKeyPiProviderType(modelProviderType) ||
     (isBuiltInModelProviderType(modelProviderType) &&
       (builtInModelRuntimeRoute?.providerType === "openai-api-key" ||

--- a/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
+++ b/turbo/packages/pi-agent-runtime/src/session-runtime.test.ts
@@ -690,6 +690,291 @@ describe("official Pi AgentSession runtime", () => {
     },
   );
 
+  it.each(
+    GPT_MODELS.flatMap((selectedModel) => {
+      return ["x-api-key", "Authorization"].map((headerName) => {
+        return { selectedModel, headerName };
+      });
+    }),
+  )(
+    "preserves custom $selectedModel $headerName across standard, Fast, standard API and real Sandbox handoffs",
+    async ({ selectedModel, headerName }) => {
+      const cwd = await mkdtemp(join(tmpdir(), "pi-custom-fast-"));
+      onTestFinished(async () => {
+        await rm(cwd, { recursive: true, force: true });
+      });
+      const toolFile = join(cwd, "executions.txt");
+      await writeFile(toolFile, "turn0", "utf8");
+      const provider = await startResponsesProvider(
+        (response, requestNumber) => {
+          if (requestNumber % 3 === 1) {
+            responsesToolSse(response, {
+              callId: `call_custom_${requestNumber}`,
+              name: "edit",
+              arguments: {
+                path: toolFile,
+                edits: [
+                  {
+                    oldText: `turn${Math.floor((requestNumber - 1) / 3)}`,
+                    newText: `turn${Math.floor((requestNumber - 1) / 3) + 1}`,
+                  },
+                ],
+              },
+            });
+          } else {
+            responsesTextSse(
+              response,
+              `custom Sandbox answer ${requestNumber}`,
+            );
+          }
+        },
+      );
+      onTestFinished(async () => {
+        await provider.close();
+      });
+      const sessionId = randomUUID();
+      const sessionFile = join(cwd, "session.jsonl");
+      const upstreamModel = `company-${selectedModel}-production`;
+      let sessionJsonl: string | undefined;
+      let turns = 0;
+      for (const tier of [undefined, "priority", undefined] as const) {
+        const config = {
+          provider: "openai" as const,
+          api: "openai-responses" as const,
+          baseUrl: provider.baseUrl.replace(/\/v1$/, "/custom/v1"),
+          model: upstreamModel,
+          catalogModel: selectedModel,
+          thinkingLevel: "max" as const,
+          ...(tier === undefined ? {} : { serviceTier: tier }),
+          apiKeyEnv: "OPENAI_API_KEY" as const,
+          credentialSecretName: "OKOU_MODEL_PROVIDER_API_KEY",
+          credentialHeader: {
+            name: headerName,
+            valueTemplate: "Key {{secret}}",
+          },
+        };
+        const direct = await materializePiAgentModelConfig({
+          target: "direct",
+          config,
+          resolveCredential() {
+            return "custom-secret";
+          },
+        });
+        const sandbox = await materializePiAgentModelConfig({
+          target: "sandbox-firewall",
+          config,
+          resolveCredential() {
+            return "opaque-custom-credential";
+          },
+        });
+        expect(direct.catalogModel).toBe(selectedModel);
+        expect(sandbox.catalogModel).toBe(selectedModel);
+        const start = provider.requests.length;
+        const firstTurn = await runPiApiFirstTurn({
+          ownership: createPiApiFirstTurnOwnership(),
+          cwd,
+          agentDir: join(cwd, ".pi"),
+          sessionId,
+          sessionJsonl,
+          prompt: `run custom turn ${turns}`,
+          appendSystemPrompt: null,
+          model: direct,
+          resourceSnapshot: EMPTY_RESOURCE_SNAPSHOT,
+        });
+        expect(firstTurn.handoffRequired).toBe(true);
+        expect(provider.requests).toHaveLength(start + 1);
+        await writeFile(sessionFile, firstTurn.sessionJsonl, "utf8");
+        const sessionManager = SessionManager.open(sessionFile);
+        const created = await createPiAgentSessionForRuntime({
+          cwd,
+          agentDir: join(cwd, ".pi"),
+          sessionManager,
+          model: sandbox,
+          appendSystemPrompt: null,
+          resourceSnapshot: EMPTY_RESOURCE_SNAPSHOT,
+        });
+        try {
+          await resumePiApiFirstTurn(created.session);
+          await created.session.prompt(
+            "continue the same custom Sandbox session",
+          );
+          turns += 1;
+          const toolResults = created.session.messages.filter((message) => {
+            return message.role === "toolResult";
+          });
+          expect(toolResults).toHaveLength(turns);
+          for (const result of toolResults) {
+            expect(result).toMatchObject({ toolName: "edit", isError: false });
+          }
+          expect(await readFile(toolFile, "utf8")).toBe(`turn${turns}`);
+          expect(provider.requests).toHaveLength(start + 3);
+          for (const [index, request] of provider.requests
+            .slice(start)
+            .entries()) {
+            const header =
+              index === 0 ? "Key custom-secret" : "opaque-custom-credential";
+            expect(request).toMatchObject({
+              url: "/custom/v1/responses",
+              authorization:
+                headerName === "Authorization" ? header : undefined,
+              apiKey: headerName === "x-api-key" ? header : undefined,
+              accountId: undefined,
+              body: {
+                model: upstreamModel,
+                stream: true,
+                store: false,
+                reasoning: { effort: "max" },
+              },
+            });
+            if (tier === undefined) {
+              expect(request.body).not.toHaveProperty("service_tier");
+            } else {
+              expect(request.body).toMatchObject({ service_tier: "priority" });
+            }
+            expect(request.body).not.toHaveProperty("previous_response_id");
+            if (index > 0) {
+              expect(request.body).toMatchObject({
+                input: expect.arrayContaining([
+                  expect.objectContaining({
+                    type: "function_call_output",
+                    call_id: `call_custom_${start + 1}`,
+                    output: expect.stringContaining(toolFile),
+                  }),
+                ]),
+              });
+            }
+          }
+          expect(sessionManager.getSessionId()).toBe(sessionId);
+          expect(created.session.messages.at(-1)).toMatchObject({
+            stopReason: "stop",
+          });
+        } finally {
+          created.session.dispose();
+        }
+        sessionJsonl = await readFile(sessionFile, "utf8");
+        expect(sessionJsonl).not.toMatch(
+          /serviceTier|service_tier|custom-secret|opaque-custom/,
+        );
+      }
+      expect(provider.requests).toHaveLength(9);
+    },
+  );
+
+  it.each(
+    GPT_MODELS.flatMap((selectedModel) => {
+      return [400, 401].map((status) => {
+        return { selectedModel, status };
+      });
+    }),
+  )(
+    "surfaces custom $selectedModel priority/credential rejection $status after a real tool without replay",
+    async ({ selectedModel, status }) => {
+      const cwd = await mkdtemp(join(tmpdir(), "pi-custom-rejection-"));
+      onTestFinished(async () => {
+        await rm(cwd, { recursive: true, force: true });
+      });
+      const toolFile = join(cwd, "executions.txt");
+      await writeFile(toolFile, "turn0", "utf8");
+      const provider = await startResponsesProvider(
+        (response, requestNumber) => {
+          if (requestNumber === 1) {
+            responsesToolSse(response, {
+              callId: "call_custom_rejection",
+              name: "edit",
+              arguments: {
+                path: toolFile,
+                edits: [{ oldText: "turn0", newText: "turn1" }],
+              },
+            });
+          } else {
+            response.writeHead(status, { "content-type": "application/json" });
+            response.end(
+              JSON.stringify({
+                error: {
+                  code:
+                    status === 400
+                      ? "unsupported_service_tier"
+                      : "invalid_api_key",
+                  message:
+                    "custom gateway rejected the requested priority credential",
+                },
+              }),
+            );
+          }
+        },
+      );
+      onTestFinished(async () => {
+        await provider.close();
+      });
+      const model = await materializePiAgentModelConfig({
+        target: "sandbox-firewall",
+        config: {
+          provider: "openai",
+          baseUrl: provider.baseUrl,
+          model: `company-${selectedModel}-production`,
+          catalogModel: selectedModel,
+          thinkingLevel: "max",
+          serviceTier: "priority",
+          apiKeyEnv: "OPENAI_API_KEY",
+          credentialSecretName: "OKOU_MODEL_PROVIDER_API_KEY",
+          credentialHeader: {
+            name: "x-api-key",
+            valueTemplate: "Key {{secret}}",
+          },
+        },
+        resolveCredential() {
+          return "opaque-custom-credential";
+        },
+      });
+      const firstTurn = await runPiApiFirstTurn({
+        ownership: createPiApiFirstTurnOwnership(),
+        cwd,
+        agentDir: join(cwd, ".pi"),
+        sessionId: randomUUID(),
+        prompt: "execute once and surface gateway rejection",
+        appendSystemPrompt: null,
+        model,
+        resourceSnapshot: EMPTY_RESOURCE_SNAPSHOT,
+      });
+      expect(firstTurn.handoffRequired).toBe(true);
+      const sessionFile = join(cwd, "session.jsonl");
+      await writeFile(sessionFile, firstTurn.sessionJsonl, "utf8");
+      const created = await createPiAgentSessionForRuntime({
+        cwd,
+        agentDir: join(cwd, ".pi"),
+        sessionManager: SessionManager.open(sessionFile),
+        model,
+        appendSystemPrompt: null,
+        resourceSnapshot: EMPTY_RESOURCE_SNAPSHOT,
+      });
+      try {
+        await resumePiApiFirstTurn(created.session);
+        expect(created.session.messages.at(-1)).toMatchObject({
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: expect.stringContaining("custom gateway rejected"),
+        });
+        expect(await readFile(toolFile, "utf8")).toBe("turn1");
+        expect(
+          created.session.messages.filter((message) => {
+            return message.role === "toolResult";
+          }),
+        ).toMatchObject([{ toolName: "edit", isError: false }]);
+        expect(provider.requests).toHaveLength(2);
+        for (const request of provider.requests) {
+          expect(request).toMatchObject({
+            url: "/v1/responses",
+            authorization: undefined,
+            apiKey: "opaque-custom-credential",
+            body: { model: model.model, service_tier: "priority" },
+          });
+        }
+      } finally {
+        created.session.dispose();
+      }
+    },
+  );
+
   it("registers one stable memory schema fixture only for valid V2 epochs", async () => {
     const content = "# Frozen memory\n\nExact API epoch.";
     const v1 = await registeredToolSchemas(EMPTY_RESOURCE_SNAPSHOT);


### PR DESCRIPTION
## Summary

Custom OpenAI Responses Fast for GPT-5.6 Terra, Sol, and Luna now enters PiLoop and sends `service_tier: "priority"` on API-first and subsequent Sandbox requests. Previously these custom Fast runs stayed on Codex; admitting them without updating the runtime contract would silently omit priority.

Closes #32565. Implements only the second slice of #32500.

## Contract and impact

- Extend the existing three-model Fast admission and public Responses runtime contract. Bound-thread, PiLoop, and Fast gates remain authoritative; standard omits tier, including after standard → Fast → standard in one session.
- Reuse the custom legacy carrier, configured endpoint, arbitrary upstream alias, logical `catalogModel`, max reasoning, and exact credential header/template. A custom `x-api-key` route never acquires implicit Authorization. No SDK, schema, carrier generation, or gateway probing change is needed.
- Preserve credential ownership: a route or credential removed before capture fails; rotation/removal after capture cannot rewrite the encrypted run snapshot. Explicit priority/credential rejection surfaces without a tierless retry, Codex replay, provider/key/model substitution, or duplicate tool execution. Existing transport retry behavior is unchanged.
- Custom routes retain empty Built-in billable firewalls and zero Built-in usage across API-first, Sandbox completion/failure/cancellation, and repeated completion. Defaults, pricing, entitlements, global settings, source rollout, and the independent memory-maintenance model are unchanged.
- Caller review covered immediate `chat-events.command`, queued `internal-chat-run-callback.service`, preparation in `agent-run-create.service`, legacy claim validation, Rust environment serialization, runtime credential/model materialization, API usage, and Sandbox settlement. Existing legacy claimants accept these fields; tests claim without generation capabilities and exercise the real runtime reader.
- Refreshed all 29 open PRs and their paginated file lists before committing. #32484 overlaps the chat BDD/service area; #32526 shares the runner contract. Neither is a demonstrated functional dependency, and neither PR was modified.

## Validation

- `pi-agent-runtime`: all 99 tests in `credential.test.ts`, `model.test.ts`, and `session-runtime.test.ts` passed. New tests execute real file-edit tools across API-to-Sandbox handoff and further Sandbox requests, with both custom header forms and all three tier transitions.
- `chat-events.bdd.test.ts`: 141 selected custom/provider regression cases passed across the regression run and focused rerun. The initial run had two async-wait timeouts: the custom sequence now explicitly drains owned background work before asserting; the existing OpenRouter case passed unchanged on focused rerun. Final focused run: 51 passed.
- `model-provider-gateways.test.ts`: 8 passed, including existing custom and DeepSeek behavior.
- API type-check partitions and runtime type check; package Oxlint/type-aware lint plus corrected file-scoped ESLint; runtime lint; changed-file Prettier and Knip. Full local Vitest and a dev server were not run; full required suites remain the PR CI gate.

## Verification limits

These are local integration tests with a real test database, HTTP provider boundaries, and real runtime/tool execution. API BDD covers actual runner claims, firewall credential resolution, checkpoints, callbacks, and billing; the runtime tests cover subsequent wire requests. This is not a live production Sandbox or external custom-gateway canary.

The issue's read-only production preflight is a dated activity snapshot: `[2026-09-01T07:36:00Z, 2026-09-08T07:36:00Z)`, `model_provider=custom-openai-responses`, the three exact logical models plus `openai/` aliases, internal workspaces included, one page/limit 1,000, zero returned/unique runs. Zero activity does not mean no configured gateways or prove priority support. No production data was mutated and no migration/backfill was added.

Per [the controller's recorded user confirmation](https://github.com/vm0-ai/vm0/issues/32500#issuecomment-5581157493), Luna was intentionally returned to subscription and Lancy manually confirmed Luna/Sol Built-in availability. No slice-1 canary or deleted test workflow was restarted. Independent production wire-tier/API-first/Sandbox accounting reconciliation remains absent. Controller merged-code acceptance and the separately owned Production Release step remain outside this PR owner's pre-merge responsibility.
