### PR TITLE
fix(desktop): prevent auth and application menu reentry

### DIFF
--- a/turbo/apps/desktop/src/desktop-application-menu.test.ts
+++ b/turbo/apps/desktop/src/desktop-application-menu.test.ts
@@ -1,0 +1,165 @@
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import type { MenuItemConstructorOptions } from "electron";
+import { DesktopApplicationMenu } from "./desktop-application-menu";
+import { DeveloperToolsController } from "./desktop-developer-tools-controller";
+
+const native = vi.hoisted(() => ({
+  installed: [] as MenuItemConstructorOptions[][],
+  onBuild: () => {},
+  onInstall: () => {},
+}));
+vi.mock("electron", () => ({
+  Menu: {
+    buildFromTemplate: (template: MenuItemConstructorOptions[]) => {
+      native.onBuild();
+      return template;
+    },
+    setApplicationMenu: (menu: MenuItemConstructorOptions[]) => {
+      native.installed.push(menu);
+      native.onInstall();
+    },
+  },
+}));
+beforeEach(() => {
+  native.installed = [];
+  native.onBuild = () => {};
+  native.onInstall = () => {};
+});
+
+function appMenuItem(label: string) {
+  const submenu = native.installed.at(-1)?.[0]?.submenu;
+  if (!Array.isArray(submenu)) throw new Error("No application submenu");
+  return submenu.find((item) => item.label === label);
+}
+
+function clickDeveloperTools() {
+  const click = appMenuItem("Developer Tools")?.click;
+  if (!click) throw new Error("No developer checkbox");
+  // Electron invokes this descriptor's zero-argument click callback.
+  Reflect.apply(click, undefined, []);
+}
+
+async function application() {
+  let updatesEnabled = false;
+  const authority = {};
+  const developer = new DeveloperToolsController({
+    getSessionAuthority: () => authority,
+    fetchFeatureSwitches: async () =>
+      new Response(JSON.stringify({ effectiveSwitches: { _debug: true } })),
+    setFilesystemPluginFeatureEnabled: () => {},
+    setScreenRecordingFeatureEnabled: () => {},
+    onChange: () => menu.refresh(),
+  });
+  const menu = new DesktopApplicationMenu({
+    displayName: "Okou",
+    developerTools: developer,
+    updatesEnabled: () => updatesEnabled,
+    checkForUpdates: () => {},
+    quit: () => {},
+  });
+  onTestFinished(() => menu.dispose());
+  developer.requestRefresh();
+  await vi.waitFor(() => {
+    expect(appMenuItem("Developer Tools")?.checked).toBe(false);
+  });
+  return {
+    menu,
+    developer,
+    installUpdater: () => {
+      updatesEnabled = true;
+      menu.refresh();
+    },
+  };
+}
+
+describe("application menu event boundary", () => {
+  it("defers native installation until after a developer checkbox callback returns", async () => {
+    const app = await application();
+    const before = native.installed.length;
+    clickDeveloperTools();
+    expect(app.developer.getState().enabled).toBe(true);
+    expect(native.installed).toHaveLength(before);
+    await nextTurn();
+    expect(appMenuItem("Developer Tools")?.checked).toBe(true);
+    expect(native.installed).toHaveLength(before + 1);
+  });
+
+  it("coalesces repeated window, driver and updater requests using the latest state", async () => {
+    const app = await application();
+    const before = native.installed.length;
+    app.menu.refresh();
+    app.installUpdater();
+    app.developer.setEnabled(true);
+    app.menu.refresh();
+    await nextTurn();
+    expect(native.installed).toHaveLength(before + 1);
+    expect(appMenuItem("Developer Tools")?.checked).toBe(true);
+    expect(appMenuItem("Check for Updates...")?.enabled).toBe(true);
+  });
+
+  it("never nests native installation and eventually applies a change made during installation", async () => {
+    const app = await application();
+    let depth = 0;
+    let maxDepth = 0;
+    let changed = false;
+    native.onInstall = () => {
+      depth++;
+      maxDepth = Math.max(maxDepth, depth);
+      if (!changed) {
+        changed = true;
+        app.developer.setEnabled(true);
+      }
+      depth--;
+    };
+    app.installUpdater();
+    await vi.waitFor(() => {
+      expect(appMenuItem("Developer Tools")?.checked).toBe(true);
+    });
+    expect(maxDepth).toBe(1);
+  });
+
+  it("handles two clicks before the pending menu is installed", async () => {
+    const app = await application();
+    const before = native.installed.length;
+    clickDeveloperTools();
+    clickDeveloperTools();
+    expect(app.developer.getState().enabled).toBe(false);
+    await nextTurn();
+    expect(appMenuItem("Developer Tools")?.checked).toBe(false);
+    expect(native.installed).toHaveLength(before);
+  });
+
+  it("settles unchanged refresh requests made by native installation", async () => {
+    const app = await application();
+    const before = native.installed.length;
+    native.onInstall = () => app.menu.refresh();
+    app.installUpdater();
+    await nextTurn();
+    await nextTurn();
+    expect(appMenuItem("Check for Updates...")?.enabled).toBe(true);
+    expect(native.installed).toHaveLength(before + 1);
+  });
+
+  it.each(["queued", "building", "installing"] as const)(
+    "discards pending menu work when shutdown starts while %s",
+    async (phase) => {
+      const app = await application();
+      const before = native.installed.length;
+      const shutdown = () => {
+        app.menu.refresh();
+        app.menu.dispose();
+        app.menu.refresh();
+      };
+      if (phase === "building") native.onBuild = shutdown;
+      if (phase === "installing") native.onInstall = shutdown;
+      app.installUpdater();
+      if (phase === "queued") shutdown();
+      await nextTurn();
+      await nextTurn();
+      expect(native.installed).toHaveLength(
+        before + (phase === "installing" ? 1 : 0),
+      );
+    },
+  );
+});

--- a/turbo/apps/desktop/src/desktop-application-menu.ts
+++ b/turbo/apps/desktop/src/desktop-application-menu.ts
@@ -1,0 +1,92 @@
+import { Menu, type MenuItemConstructorOptions } from "electron";
+import type { DeveloperToolsController } from "./desktop-developer-tools-controller";
+import { desktopDeveloperToolsMenu } from "./desktop-developer-tools-menu";
+
+interface DesktopApplicationMenuOptions {
+  readonly displayName: string;
+  readonly developerTools: DeveloperToolsController;
+  readonly updatesEnabled: () => boolean;
+  readonly checkForUpdates: () => void;
+  readonly quit: () => void;
+}
+
+export class DesktopApplicationMenu {
+  private pending: NodeJS.Immediate | null = null;
+  private requested = false;
+  private disposed = false;
+  private signature: string | null = null;
+
+  constructor(private readonly options: DesktopApplicationMenuOptions) {}
+
+  refresh(): void {
+    if (this.disposed) return;
+    this.requested = true;
+    if (this.pending) return;
+    // Leave the active native menu/window callback before rebuilding. Keep
+    // ownership through installation so a native read-back cannot nest it.
+    this.pending = setImmediate(() => {
+      this.requested = false;
+      try {
+        this.install();
+      } finally {
+        this.pending = null;
+        if (this.requested) this.refresh();
+      }
+    });
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.requested = false;
+    if (this.pending) clearImmediate(this.pending);
+    this.pending = null;
+  }
+
+  private install(): void {
+    const updatesEnabled = this.options.updatesEnabled();
+    const developer = this.options.developerTools.getState();
+    const signature = JSON.stringify({ updatesEnabled, ...developer });
+    if (signature === this.signature) return;
+    const appSubmenu: MenuItemConstructorOptions[] = [
+      { role: "about" },
+      {
+        label: "Check for Updates...",
+        enabled: updatesEnabled,
+        click: this.options.checkForUpdates,
+      },
+      { type: "separator" },
+    ];
+    appSubmenu.push(...desktopDeveloperToolsMenu(this.options.developerTools));
+    appSubmenu.push({
+      label: `Quit ${this.options.displayName}`,
+      accelerator: "CommandOrControl+Q",
+      click: this.options.quit,
+    });
+
+    const menu = Menu.buildFromTemplate([
+      {
+        label: this.options.displayName,
+        submenu: appSubmenu,
+      },
+      {
+        label: "Edit",
+        submenu: [
+          { role: "undo" },
+          { role: "redo" },
+          { type: "separator" },
+          { role: "cut" },
+          { role: "copy" },
+          { role: "paste" },
+          { role: "selectAll" },
+        ],
+      },
+      {
+        label: "Window",
+        submenu: [{ role: "minimize" }, { role: "close" }],
+      },
+    ]);
+    if (this.disposed) return;
+    Menu.setApplicationMenu(menu);
+    this.signature = signature;
+  }
+}

--- a/turbo/apps/desktop/src/desktop-async-control.test.ts
+++ b/turbo/apps/desktop/src/desktop-async-control.test.ts
@@ -21,6 +21,74 @@ async function flushPromises(): Promise<void> {
 }
 
 describe("singleFlight", () => {
+  it("publishes ownership before synchronous task reentry", async () => {
+    const result = deferred<string>();
+    const joined: Promise<string>[] = [];
+    const ownership: boolean[] = [];
+    const refresh = singleFlight(() => {
+      ownership.push(refresh.inFlight);
+      // Bound the regression on the old implementation instead of overflowing.
+      if (ownership.length < 8) joined.push(refresh());
+      return result.promise;
+    });
+
+    const first = refresh();
+    result.resolve("restored");
+    expect(await Promise.all([first, ...joined])).toEqual([
+      "restored",
+      "restored",
+    ]);
+    expect(ownership).toEqual([true]);
+    expect(joined).toEqual([first]);
+    expect(refresh.inFlight).toBe(false);
+  });
+
+  it("shares a synchronous throw with reentrant callers and permits retry", async () => {
+    const error = new Error("task entry failed");
+    let entered = false;
+    let joined: Promise<string> | undefined;
+    const refresh = singleFlight<string>(() => {
+      if (entered) return Promise.resolve("retry");
+      entered = true;
+      joined = refresh();
+      throw error;
+    });
+
+    const first = refresh();
+    const results = await Promise.allSettled([first, joined]);
+    expect(results).toEqual([
+      { status: "rejected", reason: error },
+      { status: "rejected", reason: error },
+    ]);
+    expect(joined).toBe(first);
+    expect(refresh.inFlight).toBe(false);
+    await expect(refresh()).resolves.toBe("retry");
+  });
+
+  it("retains a replacement started synchronously after clear inside task entry", async () => {
+    const oldResult = deferred<string>();
+    const newResult = deferred<string>();
+    let entered = false;
+    let replacement: Promise<string> | undefined;
+    const refresh = singleFlight(() => {
+      if (entered) return newResult.promise;
+      entered = true;
+      refresh.clear();
+      replacement = refresh();
+      return oldResult.promise;
+    });
+
+    const old = refresh();
+    const joined = refresh();
+    oldResult.reject(new Error("retired"));
+    await expect(old).rejects.toThrow("retired");
+    expect(refresh.inFlight).toBe(true);
+    expect(joined).toBe(replacement);
+    newResult.resolve("current");
+    await expect(replacement).resolves.toBe("current");
+    expect(refresh.inFlight).toBe(false);
+  });
+
   it("shares one in-flight task and clears after it settles", async () => {
     const firstRefresh = deferred<string>();
     const task = vi

--- a/turbo/apps/desktop/src/desktop-async-control.ts
+++ b/turbo/apps/desktop/src/desktop-async-control.ts
@@ -14,12 +14,25 @@ export function singleFlight<TResult>(
       return inFlight;
     }
 
-    const current = (async () => task())().finally(() => {
+    let resolve!: (value: TResult | PromiseLike<TResult>) => void;
+    let reject!: (error: unknown) => void;
+    const result = new Promise<TResult>((done, fail) => {
+      resolve = done;
+      reject = fail;
+    });
+    const current = result.finally(() => {
       if (inFlight === current) {
         inFlight = null;
       }
     });
+    // The task's synchronous prefix may notify subscribers that call us again.
+    // Publish first, without delaying synchronous authority withdrawal.
     inFlight = current;
+    try {
+      resolve(task());
+    } catch (error) {
+      reject(error);
+    }
     return current;
   }) as SingleFlightTask<TResult>;
 

--- a/turbo/apps/desktop/src/desktop-auth-lifecycle.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-lifecycle.test.ts
@@ -1,0 +1,446 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+} from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import type { MenuItemConstructorOptions } from "electron";
+import { DesktopAuthSession } from "./desktop-auth-session";
+import type { DesktopAuthWindowRequest } from "./desktop-auth-window";
+import { DesktopTrayController } from "./desktop-tray";
+import { DeveloperToolsController } from "./desktop-developer-tools-controller";
+import { DesktopApplicationMenu } from "./desktop-application-menu";
+import { createDesktopClientHeaderInjector } from "./desktop-client-headers";
+import {
+  ComputerUseDriverController,
+  type ComputerUseDriver,
+} from "./computer-use-driver";
+import { ComputerUseRuntimeController } from "./computer-use-runtime-controller";
+import { DesktopComputerUseDriverPreferences } from "./desktop-computer-use-driver-preferences";
+import { DesktopComputerUseDriverSelection } from "./desktop-computer-use-driver-selection";
+import type { ComputerUseDriverId } from "./computer-use-types";
+import { UNAVAILABLE_RECORDER_STATE } from "./desktop-recorder-types";
+
+const native = vi.hoisted(() => ({
+  application: [] as MenuItemConstructorOptions[][],
+  tray: [] as MenuItemConstructorOptions[][],
+}));
+vi.mock("electron", () => ({
+  Menu: {
+    buildFromTemplate: (template: MenuItemConstructorOptions[]) => template,
+    setApplicationMenu: (menu: MenuItemConstructorOptions[]) => {
+      native.application.push(menu);
+    },
+  },
+  Tray: class {
+    setToolTip() {}
+    setImage() {}
+    setContextMenu(menu: MenuItemConstructorOptions[]) {
+      native.tray.push(menu);
+    }
+  },
+  nativeImage: { createFromPath: () => ({ setTemplateImage() {} }) },
+}));
+const api = "https://api.vm0.ai";
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+beforeEach(() => {
+  native.application = [];
+  native.tray = [];
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+function developerCheckbox() {
+  const submenu = native.application.at(-1)?.[0]?.submenu;
+  return Array.isArray(submenu)
+    ? submenu.find((item) => item.label === "Developer Tools")
+    : undefined;
+}
+
+async function desktop(selectedDriver: ComputerUseDriverId) {
+  const directory = mkdtempSync(path.join(tmpdir(), "desktop-auth-lifecycle-"));
+  const file = path.join(directory, "preferences.json");
+  if (selectedDriver === "cua")
+    writeFileSync(
+      file,
+      JSON.stringify({
+        computerUseDriver: { experimentalCuaEnabled: true, selectedDriver },
+      }),
+    );
+  const pending = new Set<Promise<unknown>>();
+  const own = <T>(work: Promise<T>): Promise<T> => {
+    pending.add(work);
+    void work.then(
+      () => pending.delete(work),
+      () => pending.delete(work),
+    );
+    return work;
+  };
+  const settle = async () => {
+    while (pending.size) await Promise.allSettled([...pending]);
+  };
+  const windows: DesktopAuthWindowRequest[] = [];
+  const replies: ReturnType<typeof deferred<string | null>>[] = [];
+  const allReplies: typeof replies = [];
+  const nativeStarts: string[] = [];
+  let lastAuthority: object | null = null;
+  let lastDeveloper: object | null = null;
+  let depth = 0;
+  let maximumDepth = 0;
+  let notifications = 0;
+  const session = new DesktopAuthSession({
+    apiBaseUrl: api,
+    addClientHeaders: createDesktopClientHeaderInjector({
+      clientVersion: "1.2.3",
+    }),
+    tokenUrl: `${api}/token`,
+    selectOrgUrl: `${api}/select-org`,
+    consumeUrl: () => `${api}/consume`,
+    runAuthWindow: async (request) => {
+      windows.push(request);
+      return await (replies.shift()?.promise ?? Promise.resolve(null));
+    },
+    onChange: () => {
+      notifications++;
+      // Bound only the old-code reproduction. Production has no depth cap.
+      if (depth === 8) return;
+      depth++;
+      maximumDepth = Math.max(maximumDepth, depth);
+      // main.ts orders authority withdrawal, real tray read-back, then the
+      // developer refresh. Both driver selections share that read-back.
+      const authority = session.getAuthority();
+      if (authority !== lastAuthority) {
+        lastAuthority = authority;
+        if (
+          selection.requestedDriver().id === "cua" ||
+          driver.selectedDriver.id === "cua"
+        )
+          own(runtime.stopForAuthChange());
+      }
+      tray.refreshAuth();
+      developer.requestRefresh();
+      depth--;
+    },
+  });
+  const developer = new DeveloperToolsController({
+    getSessionAuthority: () => session.getAuthority(),
+    fetchFeatureSwitches: () =>
+      own(session.fetchWithSessionAuth(new URL(`${api}/api/feature-switches`))),
+    setFilesystemPluginFeatureEnabled: () => {},
+    setScreenRecordingFeatureEnabled: () => {},
+    onChange: () => {
+      const authority = developer.getAuthorization();
+      if (authority !== lastDeveloper) {
+        lastDeveloper = authority;
+        own(runtime.refreshDriverAuthorization());
+      }
+      menu.refresh();
+    },
+  });
+  const backend = (id: string): never => {
+    nativeStarts.push(id);
+    throw new Error("Auth/menu reads must not start a native driver");
+  };
+  const okou: ComputerUseDriver = {
+    id: "okou",
+    buildVersion: "test",
+    createBackend: () => backend("okou"),
+  };
+  const cua: ComputerUseDriver = {
+    id: "cua",
+    buildVersion: "test",
+    createBackend: () => backend("cua"),
+    getAuthorization: () => developer.getAuthorization(),
+  };
+  const driver = new ComputerUseDriverController(okou, "darwin");
+  const runtime = new ComputerUseRuntimeController({
+    driver,
+    createRuntime: () => {
+      throw new Error("Auth/menu reads must not start a host");
+    },
+    refreshPermissions: async () => ({
+      accessibility: false,
+      screenRecording: false,
+    }),
+    nativeBlockReason: (selected) => selection.blockReason(selected),
+    getAuthState: () => own(session.getAuthState()),
+    setHostRuntimeOnline: () => {},
+  });
+  const preferences = new DesktopComputerUseDriverPreferences(() => file);
+  preferences.load();
+  const selection = new DesktopComputerUseDriverSelection({
+    preferences,
+    developer,
+    runtime,
+    drivers: { okou, cua },
+    onChange: () => menu.refresh(),
+  });
+  const menu = new DesktopApplicationMenu({
+    displayName: "Okou",
+    developerTools: developer,
+    updatesEnabled: () => true,
+    checkForUpdates: () => {},
+    quit: () => {},
+  });
+  const tray = new DesktopTrayController({
+    displayName: "Okou",
+    iconPath: "/icon",
+    disabledIconPath: "/disabled",
+    runningIconPath: "/running",
+    getComputerUseState: () => ({
+      driver: selection.getState(),
+      platform: "darwin",
+      supported: true,
+      permissions: { accessibility: false, screenRecording: false },
+      host: runtime.getHostState(),
+      keepAwake: { enabled: false, active: false },
+    }),
+    getAuthState: () => own(session.getAuthState()),
+    showMainWindow: async () => {
+      await session.getAuthState();
+    },
+    startComputerUse: () => runtime.start(),
+    stopComputerUse: () => runtime.stop(),
+    refreshStatus: async () => {},
+    openSignIn: () => {},
+    switchWorkspace: () => session.selectOrganization(),
+    signOut: async () => session.signOut(),
+    requestAccessibilityPermission: async () => {},
+    requestScreenRecordingPermission: async () => {},
+    openAccessibilitySettings: () => {},
+    openScreenRecordingSettings: () => {},
+    setKeepAwakeEnabled: async () => {},
+    getRecorderState: () => UNAVAILABLE_RECORDER_STATE,
+    startScreenRecording: async () => {},
+    stopScreenRecording: async () => {},
+    retryScreenRecordingDelivery: async () => {},
+    quit: () => menu.dispose(),
+  });
+  server.use(
+    http.get(`${api}/api/auth/me`, ({ request }) => {
+      const userId = request.headers.get("authorization");
+      return HttpResponse.json({
+        userId,
+        email: "fixture@example.test",
+        orgId: `org-${userId}`,
+      });
+    }),
+    http.get(`${api}/api/org`, ({ request }) =>
+      HttpResponse.json({
+        id: `org-${request.headers.get("authorization")}`,
+        name: "Workspace",
+      }),
+    ),
+    http.get(`${api}/api/feature-switches`, () =>
+      HttpResponse.json({ effectiveSwitches: { _debug: true } }),
+    ),
+  );
+  onTestFinished(async () => {
+    menu.dispose();
+    session.signOut();
+    for (const reply of allReplies) reply.resolve(null);
+    await settle();
+    await runtime.stopForQuit();
+    rmSync(directory, { recursive: true, force: true });
+  });
+  await runtime.transitionDriver(selection.requestedDriver());
+  return {
+    session,
+    developer,
+    selection,
+    runtime,
+    tray,
+    menu,
+    windows,
+    nativeStarts,
+    settle,
+    metrics: () => ({ maximumDepth, notifications }),
+    reply: () => {
+      const reply = deferred<string | null>();
+      replies.push(reply);
+      allReplies.push(reply);
+      return reply;
+    },
+  };
+}
+
+describe.each(["okou", "cua"] as const)(
+  "%s auth/tray/developer composition",
+  (driver) => {
+    it("coalesces startup and signed-in restoration while revoking authority synchronously", async () => {
+      const app = await desktop(driver);
+      const first = app.reply();
+      app.tray.install();
+      const windowsAtStartup = app.windows.length;
+      const startup = app.session.getAuthState();
+      first.resolve("startup");
+      await startup;
+      await app.settle();
+      expect(windowsAtStartup).toBe(1);
+      await vi.waitFor(() => expect(developerCheckbox()?.checked).toBe(false));
+      expect(app.windows).toHaveLength(1);
+      expect(app.metrics().maximumDepth).toBe(1);
+      expect(app.session.getAuthority()).not.toBeNull();
+      expect(app.developer.getAuthorization()).not.toBeNull();
+      const next = app.reply();
+      const restore = app.session.getToken({ forceRefresh: true });
+      expect(app.session.getCachedToken()).toBeNull();
+      expect(app.session.getAuthority()).toBeNull();
+      expect(app.developer.getAuthorization()).toBeNull();
+      const reopened = [app.session.getAuthState(), app.session.getAuthState()];
+      expect(app.windows).toHaveLength(2);
+      next.resolve("restored");
+      expect(await restore).toBe("restored");
+      expect(await Promise.all(reopened)).toEqual([
+        expect.objectContaining({ status: "signed_in" }),
+        expect.objectContaining({ status: "signed_in" }),
+      ]);
+      await app.settle();
+      await vi.waitFor(() =>
+        expect(app.developer.getAuthorization()).not.toBeNull(),
+      );
+      await nextTurn();
+      expect(app.selection.getState().selectedDriver).toBe(driver);
+      expect(app.nativeStarts).toEqual([]);
+      expect(app.metrics().notifications).toBeLessThan(12);
+      expect(native.application.length).toBeLessThan(8);
+      const before = native.tray.length;
+      app.tray.refresh();
+      app.tray.refresh();
+      expect(native.tray).toHaveLength(before);
+    });
+
+    it.each(["empty", "failed", "cancelled"] as const)(
+      "settles %s hidden restoration without reopening or granting authority",
+      async (outcome) => {
+        const app = await desktop(driver);
+        const reply = app.reply();
+        app.tray.install();
+        const state = app.session.getAuthState();
+        if (outcome === "cancelled") app.session.signOut();
+        if (outcome === "failed") reply.reject(new Error("Auth window failed"));
+        else reply.resolve(outcome === "cancelled" ? "late" : null);
+        expect(await state).toMatchObject({ status: "signed_out" });
+        await app.settle();
+        await vi.waitFor(() =>
+          expect(app.developer.getAvailability()).toBe("unavailable"),
+        );
+        await nextTurn();
+        expect(await app.session.getAuthState()).toMatchObject({
+          status: "signed_out",
+        });
+        expect(app.windows).toHaveLength(1);
+        expect(app.session.getAuthority()).toBeNull();
+        expect(app.developer.getAuthorization()).toBeNull();
+        expect(developerCheckbox()).toBeUndefined();
+        expect(app.nativeStarts).toEqual([]);
+        expect(native.application.length).toBeLessThan(4);
+      },
+    );
+
+    it("keeps interactive account and workspace changes when an older hidden reply arrives late", async () => {
+      const app = await desktop(driver);
+      const old = app.reply();
+      app.tray.install();
+      const explicit = app.reply();
+      const signIn = app.session.consumeCode("new-account");
+      expect(app.windows[0]?.signal.aborted).toBe(true);
+      expect(await app.session.getAuthState()).toMatchObject({
+        status: "signing_in",
+      });
+      explicit.resolve("account");
+      await signIn;
+      const workspace = app.reply();
+      const switchOrg = app.session.selectOrganization();
+      expect(app.session.getAuthority()).toBeNull();
+      expect(app.developer.getAuthorization()).toBeNull();
+      old.resolve("retired");
+      workspace.resolve("workspace");
+      await switchOrg;
+      await app.settle();
+      await vi.waitFor(() =>
+        expect(app.developer.getAuthorization()).not.toBeNull(),
+      );
+      expect(app.session.getCachedToken()).toBe("workspace");
+      expect(await app.session.getAuthState()).toMatchObject({
+        user: { userId: "Bearer workspace" },
+        organization: { id: "org-Bearer workspace" },
+      });
+      expect(app.selection.getState().selectedDriver).toBe(driver);
+      expect(app.nativeStarts).toEqual([]);
+    });
+
+    it("coalesces a 401 refresh and rejects a late developer grant after sign-out", async () => {
+      const app = await desktop(driver);
+      const initial = app.reply();
+      app.tray.install();
+      initial.resolve("expired");
+      await app.settle();
+      await vi.waitFor(() =>
+        expect(app.developer.getAuthorization()).not.toBeNull(),
+      );
+      const requested = deferred<void>();
+      const release = deferred<void>();
+      onTestFinished(() => release.resolve());
+      server.use(
+        http.get(
+          `${api}/api/protected`,
+          ({ request }) =>
+            new HttpResponse(null, {
+              status:
+                request.headers.get("authorization") === "Bearer expired"
+                  ? 401
+                  : 200,
+            }),
+        ),
+        http.get(`${api}/api/feature-switches`, async () => {
+          requested.resolve();
+          await release.promise;
+          return HttpResponse.json({ effectiveSwitches: { _debug: true } });
+        }),
+      );
+      const fresh = app.reply();
+      const response = app.session.fetchWithSessionAuth(
+        new URL(`${api}/api/protected`),
+      );
+      await vi.waitFor(() => expect(app.windows).toHaveLength(2));
+      expect(app.session.getAuthority()).toBeNull();
+      expect(app.developer.getAuthorization()).toBeNull();
+      fresh.resolve("fresh");
+      expect((await response).status).toBe(200);
+      await requested.promise;
+      app.session.signOut();
+      expect(app.session.getAuthority()).toBeNull();
+      expect(app.developer.getAuthorization()).toBeNull();
+      release.resolve();
+      await app.settle();
+      await vi.waitFor(() =>
+        expect(app.developer.getAvailability()).toBe("unavailable"),
+      );
+      expect(app.session.getCachedToken()).toBeNull();
+      expect(app.developer.getAuthorization()).toBeNull();
+      expect(app.nativeStarts).toEqual([]);
+    });
+  },
+);

--- a/turbo/apps/desktop/src/desktop-auth-session.test.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.test.ts
@@ -37,7 +37,7 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-function createSession() {
+function createSession(onChange?: (session: DesktopAuthSession) => void) {
   const config = resolveDesktopConfig();
   const windows: DesktopAuthWindowRequest[] = [];
   const replies: Promise<string | null>[] = [];
@@ -59,6 +59,7 @@ function createSession() {
     },
     onChange: () => {
       changes.push(session.getCachedToken());
+      onChange?.(session);
     },
     onAuthCompleted: () => {
       completed.push("completed");
@@ -94,6 +95,38 @@ function identityHandlers(
 }
 
 describe("Okou App session authority", () => {
+  it("joins hidden restoration when a change subscriber synchronously reads auth state", async () => {
+    identityHandlers();
+    const reads: ReturnType<DesktopAuthSession["getAuthState"]>[] = [];
+    let depth = 0;
+    const { session, replies, windows } = createSession((current) => {
+      // Safety cap only for the red run against the original implementation.
+      if (depth === 8) return;
+      depth++;
+      reads.push(current.getAuthState());
+      depth--;
+    });
+    const result = deferred<string | null>();
+    replies.push(result.promise);
+    const startup = session.getAuthState();
+    const requestsAtEntry = windows.length;
+    result.resolve("restored");
+    await startup;
+    for (let settled = 0; settled < reads.length; ) {
+      const pending = reads.slice(settled);
+      settled = reads.length;
+      await Promise.all(pending);
+    }
+
+    expect(requestsAtEntry).toBe(1);
+    expect(windows).toHaveLength(1);
+    expect(await session.getAuthState()).toMatchObject({
+      status: "signed_in",
+      user: { userId: "Bearer restored" },
+    });
+    expect(session.getAuthority()).not.toBeNull();
+  });
+
   it("requires a fresh App token before any native request despite legacy cookie-only API success", async () => {
     const { session, windows } = createSession();
     const requests: string[] = [];

--- a/turbo/apps/desktop/src/desktop-developer-tools-menu.ts
+++ b/turbo/apps/desktop/src/desktop-developer-tools-menu.ts
@@ -10,7 +10,7 @@ export function desktopDeveloperToolsMenu(developer: DeveloperToolsController) {
       type: "checkbox",
       checked: state.enabled,
       click: () => {
-        developer.setEnabled(!state.enabled);
+        developer.setEnabled(!developer.getState().enabled);
       },
     },
     { type: "separator" },

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -9,13 +9,11 @@ import {
   dialog,
   globalShortcut,
   ipcMain,
-  Menu,
   net,
   powerSaveBlocker,
   protocol,
   session,
   shell,
-  type MenuItemConstructorOptions,
 } from "electron";
 import { isComputerUseMcpPluginCallPayload } from "@okouai/api-contracts/contracts/computer-use-plugins";
 import {
@@ -63,7 +61,7 @@ import { createCuaComputerUseDriver } from "./computer-use-cua";
 import { createComputerUseHostPermissions } from "./computer-use-host-permissions";
 import { DesktopComputerUseDriverPreferences } from "./desktop-computer-use-driver-preferences";
 import { DesktopComputerUseDriverSelection } from "./desktop-computer-use-driver-selection";
-import { desktopDeveloperToolsMenu } from "./desktop-developer-tools-menu";
+import { DesktopApplicationMenu } from "./desktop-application-menu";
 import { CuaEmbeddedRuntime } from "./cua-runtime";
 import { assertCuaDormant } from "./cua-runtime-files";
 import { runCuaHostProbe } from "./cua-host-probe";
@@ -341,6 +339,13 @@ const developerTools = new DeveloperToolsController({
     console.warn("Unable to refresh desktop developer tools state", error);
   },
 });
+const applicationMenu = new DesktopApplicationMenu({
+  displayName: config.identity.displayName,
+  developerTools,
+  updatesEnabled: () => desktopAutoUpdates !== null,
+  checkForUpdates: requestDesktopUpdateCheck,
+  quit: requestDesktopQuit,
+});
 const computerUseController = new ComputerUseRuntimeController({
   driver: computerUseDriver,
   createRuntime: createComputerUseHostRuntime,
@@ -369,7 +374,7 @@ const driverSelection = new DesktopComputerUseDriverSelection({
   drivers: { okou: okouDriver, cua: cuaDriver },
   onChange: () => {
     notifyComputerUseChanged();
-    if (app.isReady()) applyApplicationMenu();
+    if (app.isReady()) applicationMenu.refresh();
   },
 });
 
@@ -514,7 +519,7 @@ function notifyDeveloperToolsChanged(): void {
   notifyDesktopDeveloperToolsChanged();
   notifyDesktopComputerUseChanged();
   if (app.isReady()) {
-    applyApplicationMenu();
+    applicationMenu.refresh();
   }
 }
 
@@ -1053,6 +1058,7 @@ function refreshComputerUsePermissionsForState(): void {
 async function prepareForQuitAndInstall(): Promise<void> {
   quitConfirmation.allowQuitWithoutConfirmation();
   appIsQuitting = true;
+  applicationMenu.dispose();
   releaseKeepAwake();
   await computerUseController.stopForQuit("update_relaunch");
 }
@@ -1069,7 +1075,7 @@ export const desktopUpdateHooks: DesktopMainModule["desktopUpdateHooks"] =
 export const notifyDesktopAutoUpdatesInstalled: DesktopMainModule["notifyDesktopAutoUpdatesInstalled"] =
   (autoUpdates) => {
     desktopAutoUpdates = autoUpdates;
-    applyApplicationMenu();
+    applicationMenu.refresh();
   };
 
 async function signOutDesktopSession(): Promise<void> {
@@ -1170,48 +1176,6 @@ function requestDesktopUpdateCheck(): void {
   }
 
   desktopAutoUpdates.checkForUpdates(config.identity.displayName);
-}
-
-function applyApplicationMenu(): void {
-  const appSubmenu: MenuItemConstructorOptions[] = [
-    { role: "about" },
-    {
-      label: "Check for Updates...",
-      enabled: desktopAutoUpdates !== null,
-      click: requestDesktopUpdateCheck,
-    },
-    { type: "separator" },
-  ];
-  appSubmenu.push(...desktopDeveloperToolsMenu(developerTools));
-  appSubmenu.push({
-    label: `Quit ${config.identity.displayName}`,
-    accelerator: "CommandOrControl+Q",
-    click: requestDesktopQuit,
-  });
-
-  const menu = Menu.buildFromTemplate([
-    {
-      label: config.identity.displayName,
-      submenu: appSubmenu,
-    },
-    {
-      label: "Edit",
-      submenu: [
-        { role: "undo" },
-        { role: "redo" },
-        { type: "separator" },
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        { role: "selectAll" },
-      ],
-    },
-    {
-      label: "Window",
-      submenu: [{ role: "minimize" }, { role: "close" }],
-    },
-  ]);
-  Menu.setApplicationMenu(menu);
 }
 
 function currentDialogWindow(): BrowserWindow | undefined {
@@ -1590,6 +1554,7 @@ if (!hasSingleInstanceLock) {
     }
 
     appIsQuitting = true;
+    applicationMenu.dispose();
     releaseKeepAwake();
     globalShortcut.unregisterAll();
     if (computerUseQuitPreparationComplete) {
@@ -1665,7 +1630,7 @@ if (!hasSingleInstanceLock) {
     hideDockForInactiveMainWindow();
     registerDesktopAuthProtocol();
     installDesktopRendererProtocol();
-    applyApplicationMenu();
+    applicationMenu.refresh();
     installKeepAwake();
     installComputerUse();
     installDesktopDeveloperTools();


### PR DESCRIPTION
## Problem and behavior

Fixes #32576 (parent #32259). A hidden auth restoration synchronously notifies the tray before `singleFlight` publishes its in-flight promise. The tray immediately rereads auth state, starting nested restorations. The bounded regression produces nine auth-window requests from one startup read on the original source, for both Okou and CUA selections.

Publish the shared promise before task entry while retaining synchronous authority withdrawal, shared rejection, clear/cancellation behavior and old-versus-new operation ownership. Keep auth notifications, validation and stale-response rejection intact.

Move the existing application menu into one owner that schedules installation in the next event-loop turn, coalesces requests, retains ownership through native installation, deduplicates unchanged menu state, and applies changes requested during installation afterward. Checkbox clicks read the current enabled state so multiple clicks before installation remain meaningful. All four former menu write paths use this owner; confirmed quit and updater quit dispose pending work.

## Validation

- Rebased onto `origin/main` at `fe57f9eb1df389c1e4d1e396e96f29f9114a4d90` before implementation. Repo-wide caller search found `DesktopAuthSession.tokenRefresh` as the sole production `singleFlight` consumer; audited developer-checkbox, auth/developer refresh, driver-selection, startup and updater menu paths. Open-PR inventory: 25 PRs, only #32171 overlaps Desktop README; no dependency/order reservation.
- Deterministic red -> green: six focused regressions fail against the original helper, including real auth/tray/developer composition in both driver selections; the auth tests observe 9 requests instead of 1. Four menu tests fail with the original synchronous installation behavior extracted unchanged, including native-boundary reentry depth 2 instead of 1.
- **140 tests passed across nine targeted files**: `desktop-async-control`, `desktop-auth-session`, `desktop-auth-lifecycle`, `desktop-application-menu`, `desktop-tray`, `desktop-developer-tools-controller`, `desktop-computer-use-selection`, `computer-use-runtime-controller`, `desktop-auth-window` (`pnpm -F @okouai/desktop exec vitest run src/<name>.test.ts ... --maxWorkers=4 --silent=passed-only`).
- Coverage includes synchronous reentry/throw, coalescing, clear during task entry, old-task settlement; startup/signed-in restore, failed/empty/cancelled restore, interactive sign-in, account/workspace change, 401, sign-out and late auth/developer responses; menu clicks, request merging, reentrant installation and queued/building/installing shutdown. New shared-path tests keep production auth/tray/developer/runtime/selection controllers real, with Electron/HTTP/native boundaries substituted and no native backend startup.
- Desktop `check-types`, `lint`, workspace Knip, `build:electron` including bootstrap bundle guard, changed-file Prettier and `git diff --check` passed. No full local Vitest or dev server. Exact-head PR/macOS/package evidence follows in the tracked review and CI record.

## Scope and evidence limits

This fixes the independently reproduced auth reentry and adds a bounded menu installation defense. The synthetic native-boundary callback tests do not reproduce or prove the first trigger of the user's Mac OOM. The production Sentry bounded stack and colleague-reported local 1,783-frame unwind remain distinct evidence.

No auth-provider, Electron/CUA version, driver default, UI layout, protocol, execution/reporting budget, generation/retirement model or fallback/replay change. No user Mac interaction, signed installation/TCC acceptance, release, production approval or promotion. Ordinary packaged dormant smoke does not establish signed-in restoration or real-Mac acceptance; those remain separate controller/user follow-up.
