### PR TITLE
style(platform): align image and video model picker prices

### DIFF
--- a/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-picker-menu.tsx
@@ -416,7 +416,7 @@ function MediaModelList({
               }}
             >
               {option.icon}
-              <span className="min-w-0 truncate">{option.label}</span>
+              <span className="min-w-0 flex-1 truncate">{option.label}</span>
               <PriceTierBadge
                 tier={option.priceTier}
                 description={getMediaModelPriceTierLabel(option.priceTier)}

--- a/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/okou-page/components/model-provider-picker.tsx
@@ -978,12 +978,7 @@ function MediaModelPanelRow({ option }: { option: MediaModelPanelOption }) {
       onClick={option.onSelect}
     >
       {option.icon}
-      {/* Not `flex-1`: run-model rows sit inside a shrink-to-fit `SelectItem`
-          text slot, so their price badge trails the model name instead of
-          parking at the row's right edge. These rows are plain buttons that do
-          span the row, so the label must stay shrink-to-fit for the badge to
-          land in the same place. */}
-      <span className="min-w-0 truncate">{option.label}</span>
+      <span className="min-w-0 flex-1 truncate">{option.label}</span>
       <PriceTierBadge
         tier={option.priceTier}
         description={getMediaModelPriceTierLabel(option.priceTier)}


### PR DESCRIPTION
Align the Image and Video model pickers with the Chat model picker in the supplied design. Price badges now share a right-aligned column, with the existing checkmark column reserved at the far right and long model names truncated in the remaining space.

Apply the layout to both the compact model menu and the category-based picker, and remove the outdated inline-price comment. This is a presentation-only change; the existing selection, keyboard navigation, hover feedback, and price tooltips remain in place.

## Verification

- Prettier, targeted Oxlint and ESLint, and `pnpm lint:style` passed.
- App type checks and `pnpm knip --workspace apps/platform` passed.
- Existing `chat-composer-media-models` and `chat-composer-model-selection` integration tests: 28 passed across 2 files.
- Browser PASS on the PR preview at 1440x900 and 390x844: Image/Video price columns align, selected checkmarks remain separate, mouse and keyboard selection work, hover feedback and price help render, and narrow viewports have no horizontal overflow. Enable `modelPickerMenu` in Lab to view the compact menu from the reference.
- Verified PR head `9ca659136f000bb14bd5db8972b8bae71847abfa` through preview artifact `2a9b4d65bc2f836f6267087a3278c5f9335613d5` (GitHub merge test commit). Used a fresh preview test account, navigated directly to Lab/chat after signup, and kept real agent runs disabled.
