### PR TITLE
test(runner): synchronize active-input retry timing

### DIFF
--- a/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests/active_input.rs
@@ -1171,6 +1171,15 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);
 
+    // Freeze the clock before the first attempt. Blocking work prevents Tokio
+    // from auto-advancing through deadlines while startup performs real I/O.
+    // Dropping the sender also releases the guard if an assertion panics.
+    let (clock_release, clock_wait) = std::sync::mpsc::channel::<()>();
+    let clock_guard = tokio::task::spawn_blocking(move || {
+        let _ = clock_wait.recv_timeout(Duration::from_secs(30));
+    });
+    tokio::time::pause();
+
     let run_task = tokio::spawn(async move {
         run_in_sandbox(
             &*sandbox,
@@ -1203,8 +1212,8 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
             .wait_for_process_control_calls(1, RUN_IN_SANDBOX_TEST_TIMEOUT)
             .await
     );
-    tokio::time::pause();
     let mut previous_attempt_at = tokio::time::Instant::now();
+    drop(clock_release);
     for (index, expected_delay) in retry_delays.into_iter().enumerate() {
         assert!(
             overrides
@@ -1222,6 +1231,7 @@ async fn run_in_sandbox_retries_guest_backpressure_with_same_id() {
     }
 
     tokio::time::resume();
+    clock_guard.await.unwrap();
     wait_gate.notify_one();
     let result = tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, run_task)
         .await


### PR DESCRIPTION
An already-armed 250 ms retry could appear to take 249 ms because the test paused Tokio time and captured its baseline after observing the first attempt. Freeze time before starting the Runner and retain a bounded blocking-task guard through the first observation, so real startup I/O cannot advance the retry clock. Release the guard after capturing the baseline and join it during cleanup.

This changes only the integration test. It preserves both retryable guest statuses, all seven backoff assertions and their existing bounds, the maximum-size identical payload/delivery ID, and eventual successful delivery.

Closes #32543.

## Validation

Linux x86_64, Rust 1.98.1, `local` profile, one Cargo build job, private temporary directory; temporary swap was used for the large Runner test compilation. The original failure report was on aarch64.

- Exact guest-backpressure test: initial pass plus **20/20 consecutive repeats**; active-input module: **19 passed**.
- `cargo test --locked --profile local -p runner --all-targets --all-features -- --quiet --test-threads=4`: **3548 passed**, zero failures; 27 pre-existing ignored subprocess-helper entries.
- `cargo clippy --locked --profile local -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --profile local --no-deps -p runner --all-features`
- `cargo fmt --all -- --check` and `git diff --check`
