### PR TITLE
perf(api): observe scoped connector projection cache reuse

### DIFF
--- a/docs/connector-projection-cache-observations.md
+++ b/docs/connector-projection-cache-observations.md
@@ -1,0 +1,97 @@
+# Scoped connector projection cache observations
+
+The `api_dispatch_connector_catalog_load_runtime_snapshot` event includes
+`connector_catalog_projection_cache_observation` after a ready authoritative
+projection identity has been read. This is diagnostic request history; it does
+not change the selection cache, permissions, fallback behavior, or database work.
+
+## Interpretation
+
+Each API process tracks the 16 most recently observed distinct selection keys for
+its last observed full projection identity. The key is the cache's existing
+normalized identity plus **both** runtime and metadata connector sets, preserving
+their separate roles. A repeated key moves to the front of the history.
+
+| Value                   | Meaning at lookup time, before updating history                                  |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| `first_observation`     | First ready projection lookup observed by this process                           |
+| `identity_changed`      | Full projection identity differs from the previous observation; history is reset |
+| `not_in_recent_history` | Exact key is absent from the current 16-key window                               |
+| `reuse_1`               | Exact key is the most recently observed distinct key                             |
+| `reuse_2`               | Exact key is the second most recent distinct key                                 |
+| `reuse_3_4`             | Exact key is at MRU rank 3–4                                                     |
+| `reuse_5_8`             | Exact key is at MRU rank 5–8                                                     |
+| `reuse_9_16`            | Exact key is at MRU rank 9–16                                                    |
+
+MRU rank is one plus the number of distinct other keys observed since that key's
+previous lookup, not elapsed time or total intervening requests. All ready
+lookups contribute, including callers without a timing collector. An identity
+transition includes source, projection generation, catalog, and capability
+changes. Concurrent identity reads can observe different generations in either
+order: this field reports transitions, not a count of global catalog updates.
+
+Use the field alongside `connector_catalog_projection_cache_outcome` and
+`connector_catalog_runtime_selection_source`. For example, a projection `miss`
+with `reuse_2` demonstrates recent repeated scope use despite a cache miss. It
+does **not** prove a two-entry payload cache would hit: earlier lookups may have
+failed, fallen back, or still be in flight, and completion order can differ from
+lookup order. The observer never changes pending-work ownership or completion
+state.
+
+`first_observation` is not a Vercel cold-start indicator. `not_in_recent_history`
+does not mean never used before. Old API builds and fallback paths without a
+ready identity omit the field; missing is not zero reuse. Fallback after a ready
+lookup can carry an observation, so separate it from projection-source results.
+Failed dispatches may not flush a run-associated event; this field is not a
+failure-rate denominator.
+
+## Resource and privacy boundary
+
+Only one identity digest and up to 16 selection digests are retained, each a
+64-character SHA-256 hexadecimal string: at most 1,088 characters plus bounded
+array/object overhead. No additional connector payloads, credentials, raw keys,
+or permission decisions are retained. Digests never leave process memory; the
+new log dimension has exactly eight possible values. Hash collisions could
+affect diagnostics, never cache lookup or authorization.
+
+Each ready lookup adds two local hashes and a search over at most 16 entries,
+with no I/O. This measurement window is not a chosen payload-cache capacity and
+does not measure retained catalog graph size.
+
+## Evaluation procedure
+
+This instrumentation is the evidence slice of [#32570](https://github.com/vm0-ai/vm0/issues/32570)
+under [#32557](https://github.com/vm0-ai/vm0/issues/32557) and
+[#24203](https://github.com/vm0-ai/vm0/issues/24203). It is not a delivered latency
+improvement.
+
+1. Freeze an explicit UTC query interval in `vm0-sandbox-op-log-prod`. Report
+   counts with and without the new field, grouped by full `api_commit_sha`,
+   `agent_run_origin`, process age/dispatch ordinal buckets, selection source,
+   and cache outcome. Do not infer absence of reuse from old builds.
+2. Join load events to successful `api_to_spawn` events by `run_id` to obtain
+   `runner_version` and the actual startup/reuse cohort. Keep exact API/Runner
+   pairs separate, with a unique relevant event of each type per run. Report
+   missing joins and exclude/report duplicates before multiway joins; do not
+   pool revisions to reach a sample threshold.
+3. Within each pair/cohort, report the observation distribution and catalog-load
+   duration mean/P50/P90/P95/P99 for projection-source misses, hits, and in-flight
+   reuse separately. Compare first observations and identity transitions with
+   recent-reuse misses. Distance buckets are opportunity evidence, not a
+   hypothetical cache hit ratio or per-run savings forecast.
+4. For the parent's latency assessment, join the matching unique queue and
+   `runner_claim_to_spawn` boundaries to each run before calculating intervals.
+   API-start-to-claim-return is `api_to_spawn - runner_claim_to_spawn` for the same
+   run. Report pre-queue and end-to-end durations, sample coverage, p95/p99, and
+   the fraction of starts at or below 1,000 ms. Never add or subtract independently
+   aggregated percentiles. Use independent dispatch/failure records to report
+   failed or unspawned runs rather than treating this successful join as all runs.
+5. If repeated exact scopes are material, measure representative retained
+   selection objects and compare an unchanged baseline with a separately
+   reviewed cache candidate. Select entry/byte/in-flight bounds using that
+   evidence. Record allocation, retained heap, database calls/pressure, failures,
+   and tail latency. Require improvement beyond noise and exact-version rollout
+   validation before calling the parent complete; otherwise record no-change.
+
+Keep the parent open after merging this evidence slice. Revisit the measurement
+after the cache decision and remove it if it no longer supports an active need.

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2990,11 +2990,14 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       accessToken: "x-projection-access",
       refreshToken: "x-projection-refresh",
     });
-    const createProjectedRun = async (prompt: string) => {
+    const createProjectedRun = async (
+      prompt: string,
+      connectorSlugs = ["x", "runtime-projection-unknown", "x"],
+    ) => {
       return await api.createDirectRun(actor, {
         ...agentBackedDirectRunBody({ agentId, prompt }),
         connectorScope: {
-          allowedConnectorSlugs: ["x", "runtime-projection-unknown", "x"],
+          allowedConnectorSlugs: connectorSlugs,
           allowedCustomConnectorIds: [],
         },
       });
@@ -3027,6 +3030,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       cacheOutcomes.filter((outcome) => {
         return outcome === "hit" || outcome === "in_flight";
+      }),
+    ).toHaveLength(1);
+    expect(
+      concurrentLoads.filter((event) => {
+        return (
+          event.connector_catalog_projection_cache_observation === "reuse_1"
+        );
       }),
     ).toHaveLength(1);
     for (const load of concurrentLoads) {
@@ -3125,9 +3135,68 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect.objectContaining({
         connector_catalog_runtime_selection_source: "projection",
         connector_catalog_projection_cache_outcome: "hit",
+        connector_catalog_projection_cache_observation: "reuse_1",
       }),
     );
     await api.requestCancelRun(actor, repeatedRun.runId, [200]);
+
+    const rotatedVersion = `api-test-projection-observation-${randomUUID()}`;
+    await installApiTestConnectorCatalog({
+      catalogVersion: rotatedVersion,
+      runtimeProjection: true,
+    });
+    const rotatedRun = await createProjectedRun("observe catalog rotation", [
+      "x",
+    ]);
+    expect(
+      singleApiDispatchEvent(
+        apiDispatchTimingEventsForRun(rotatedRun.runId),
+        "api_dispatch_connector_catalog_load_runtime_snapshot",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        connector_catalog_projection_cache_observation: "identity_changed",
+        connector_catalog_projection_cache_outcome: "miss",
+      }),
+    );
+    await api.requestCancelRun(actor, rotatedRun.runId, [200]);
+
+    const resetRun = await createProjectedRun(
+      "do not reuse old identity history",
+    );
+    expect(
+      singleApiDispatchEvent(
+        apiDispatchTimingEventsForRun(resetRun.runId),
+        "api_dispatch_connector_catalog_load_runtime_snapshot",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        connector_catalog_projection_cache_observation: "not_in_recent_history",
+        connector_catalog_projection_cache_outcome: "miss",
+      }),
+    );
+    await api.requestCancelRun(actor, resetRun.runId, [200]);
+
+    mockOptionalEnv("CALCOM_OAUTH_CLIENT_ID", undefined);
+    await installApiTestConnectorCatalog({
+      catalogVersion: rotatedVersion,
+      runtimeProjection: true,
+    });
+    const capabilityRun = await createProjectedRun(
+      "observe capability rotation",
+    );
+    expect(
+      singleApiDispatchEvent(
+        apiDispatchTimingEventsForRun(capabilityRun.runId),
+        "api_dispatch_connector_catalog_load_runtime_snapshot",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        connector_catalog_projection_cache_observation: "identity_changed",
+        connector_catalog_projection_cache_outcome: "miss",
+      }),
+    );
+    await api.requestCancelRun(actor, capabilityRun.runId, [200]);
   });
 
   it("reuses current validator package authority", async () => {
@@ -3233,6 +3302,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         connector_catalog_projection_fallback_reason: "compatibility_not_ready",
       }),
     );
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_connector_catalog_load_runtime_snapshot",
+      ),
+    ).not.toHaveProperty("connector_catalog_projection_cache_observation");
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
@@ -3425,6 +3500,33 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       }),
     );
     await api.requestCancelRun(actor, run.runId, [200]);
+
+    const repeatedRun = await api.createDirectRun(actor, {
+      ...agentBackedDirectRunBody({
+        agentId,
+        prompt: "repeat digest-mismatched projection",
+      }),
+      connectorScope: {
+        allowedConnectorSlugs: ["x"],
+        allowedCustomConnectorIds: [],
+      },
+    });
+    const repeatedEvents = apiDispatchTimingEventsForRun(repeatedRun.runId);
+    expectProjectionRowReadActionCounts(repeatedEvents, 1);
+    expect(
+      singleApiDispatchEvent(
+        repeatedEvents,
+        "api_dispatch_connector_catalog_load_runtime_snapshot",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        connector_catalog_runtime_selection_source: "full_fallback",
+        connector_catalog_projection_cache_outcome: "miss",
+        connector_catalog_projection_cache_observation: "reuse_1",
+        connector_catalog_projection_fallback_reason: "digest_mismatch",
+      }),
+    );
+    await api.requestCancelRun(actor, repeatedRun.runId, [200]);
   });
 
   it.each([
@@ -12509,6 +12611,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
         connector_catalog_projection_cache_outcome: "hit",
         connector_catalog_requested_connector_count_bucket: "0",
         connector_catalog_metadata_connector_count_bucket: "1",
+        connector_catalog_projection_cache_observation: "reuse_1",
       }),
     );
     const directClaim = await api.claimRunnerJob(directRun.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-observations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-projection-cache-observations.bdd.test.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from "node:crypto";
+
+import { expect, test } from "vitest";
+
+import { testContext } from "../../../__tests__/test-context";
+import { mockEnv } from "../../../lib/env";
+import {
+  API_TEST_CONNECTOR_FIREWALL_CONFIGS,
+  installApiTestConnectorCatalog,
+} from "../../../test-fixtures/connector-catalog";
+import { createBddApi } from "./helpers/api-bdd";
+import { createFirewallApi } from "./helpers/api-bdd-firewall";
+import { createRunsApi } from "./helpers/api-bdd-runs";
+
+const context = testContext();
+
+// One process-local sequence owns the history in this isolated test module.
+// Catalog namespaces remain unique across workers; no shared cache reset is used.
+test("observes bounded projection reuse without changing the run selection cache", async () => {
+  const bdd = createBddApi(context);
+  const api = createRunsApi(context);
+  const actor = bdd.user();
+  const catalogVersion = `projection-observations-${randomUUID()}`;
+  mockEnv("R2_USER_STORAGES_BUCKET_NAME", `test-${randomUUID()}`);
+  await installApiTestConnectorCatalog({
+    catalogVersion,
+    runtimeProjection: true,
+  });
+  bdd.acceptAgentStorageWrites();
+  api.acceptStorageDownloads();
+  api.acceptTelemetryIngest();
+  api.configureRunnerGroup();
+  await api.grantProEntitlement(actor);
+  await api.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName: "Projection observation agent",
+    description: "Exercises process-local projection reuse observations.",
+    visibility: "private",
+  });
+  const accessToken = `projection-access-${randomUUID()}`;
+  await createFirewallApi(context).seedTestConnector(actor, {
+    connectorSlug: "x",
+    authMethod: "oauth",
+    accessToken,
+    refreshToken: "projection-refresh-token",
+  });
+  const otherConnectorSlugs = API_TEST_CONNECTOR_FIREWALL_CONFIGS.map(
+    (firewall) => {
+      return firewall.name;
+    },
+  )
+    .filter((slug) => {
+      return slug !== "x" && slug !== "nintendo-store";
+    })
+    .slice(0, 16);
+  expect(otherConnectorSlugs).toHaveLength(16);
+
+  const createObservedRun = async (
+    scope: number,
+    observation: string,
+    outcome = "miss",
+    normalize = false,
+  ) => {
+    const connectorSlugs =
+      scope === 0
+        ? ["x"]
+        : ["x", ...otherConnectorSlugs.slice(scope - 1, scope)];
+    await api.enableAgentConnectors(
+      actor,
+      agent.agentId,
+      normalize
+        ? [...connectorSlugs].reverse().concat(connectorSlugs)
+        : connectorSlugs,
+    );
+    const run = await api.createRun(actor, {
+      agentId: agent.agentId,
+      prompt: "Observe scoped projection reuse",
+      modelProvider: "anthropic-api-key",
+    });
+    const events = context.mocks.axiom.sdkIngest.mock.calls.flatMap(
+      ([dataset, entries]) => {
+        return dataset === "vm0-sandbox-op-log-dev" && Array.isArray(entries)
+          ? entries.filter(
+              (entry: unknown): entry is Record<string, unknown> => {
+                return (
+                  typeof entry === "object" &&
+                  entry !== null &&
+                  "run_id" in entry &&
+                  entry.run_id === run.runId
+                );
+              },
+            )
+          : [];
+      },
+    );
+    const loads = events.filter((event) => {
+      return (
+        event.op_type === "api_dispatch_connector_catalog_load_runtime_snapshot"
+      );
+    });
+    expect(loads).toHaveLength(1);
+    expect(loads[0]).toStrictEqual(
+      expect.objectContaining({
+        connector_catalog_projection_cache_outcome: outcome,
+        connector_catalog_runtime_selection_source: "projection",
+        connector_catalog_projection_cache_observation: observation,
+      }),
+    );
+    expect(
+      events.filter((event) => {
+        return (
+          event.op_type ===
+          "api_dispatch_connector_catalog_query_projection_identity"
+        );
+      }),
+    ).toHaveLength(1);
+    if (outcome === "hit") {
+      expect(
+        events.filter((event) => {
+          return (
+            event.op_type ===
+            "api_dispatch_connector_catalog_query_projection_rows"
+          );
+        }),
+      ).toHaveLength(0);
+    }
+    const serialized = JSON.stringify(loads);
+    for (const connectorSlug of connectorSlugs) {
+      expect(serialized).not.toContain(JSON.stringify(connectorSlug));
+    }
+    for (const privateValue of [
+      catalogVersion,
+      accessToken,
+      "projection-refresh-token",
+    ]) {
+      expect(serialized).not.toContain(privateValue);
+    }
+    await api.requestCancelRun(actor, run.runId, [200]);
+  };
+
+  await createObservedRun(0, "first_observation");
+  await createObservedRun(0, "reuse_1", "hit", true);
+  for (let scope = 1; scope < 16; scope++) {
+    await createObservedRun(scope, "not_in_recent_history");
+  }
+  await createObservedRun(0, "reuse_9_16");
+  await createObservedRun(15, "reuse_2");
+  await createObservedRun(13, "reuse_3_4");
+  await createObservedRun(12, "reuse_5_8");
+  await createObservedRun(1, "reuse_9_16");
+  await createObservedRun(16, "not_in_recent_history");
+  await createObservedRun(2, "not_in_recent_history");
+  await createObservedRun(2, "reuse_1", "hit");
+});

--- a/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-load-timing.service.ts
@@ -24,6 +24,15 @@ type ConnectorRuntimeProjectionCacheOutcome =
   | "miss"
   | "in_flight"
   | "not_applicable";
+export type ConnectorRuntimeProjectionCacheObservation =
+  | "first_observation"
+  | "identity_changed"
+  | "not_in_recent_history"
+  | "reuse_1"
+  | "reuse_2"
+  | "reuse_3_4"
+  | "reuse_5_8"
+  | "reuse_9_16";
 type ConnectorRuntimeSelectionSource = "projection" | "full_fallback";
 type ConnectorRuntimeProjectionReadiness =
   | "ready"
@@ -196,6 +205,9 @@ export class ConnectorCatalogLoadTiming {
   private projectionCacheOutcome:
     | ConnectorRuntimeProjectionCacheOutcome
     | undefined;
+  private projectionCacheObservation:
+    | ConnectorRuntimeProjectionCacheObservation
+    | undefined;
   private runtimeSelectionSource: ConnectorRuntimeSelectionSource | undefined;
   private projectionFallbackReason:
     | ConnectorCatalogRuntimeProjectionFallbackReason
@@ -245,6 +257,12 @@ export class ConnectorCatalogLoadTiming {
     this.runtimeSelectionSource = args.source;
     this.projectionCacheOutcome = args.cacheOutcome;
     this.projectionFallbackReason = args.fallbackReason;
+  }
+
+  recordProjectionCacheObservation(
+    observation: ConnectorRuntimeProjectionCacheObservation,
+  ): void {
+    this.projectionCacheObservation = observation;
   }
 
   recordValidationResult(result: ConnectorCatalogValidationResult): void {
@@ -409,6 +427,12 @@ export class ConnectorCatalogLoadTiming {
         : {
             connector_catalog_projection_fallback_reason:
               this.projectionFallbackReason,
+          }),
+      ...(this.projectionCacheObservation === undefined
+        ? {}
+        : {
+            connector_catalog_projection_cache_observation:
+              this.projectionCacheObservation,
           }),
       ...(this.validationResult === undefined
         ? {}

--- a/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-runtime.service.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type {
   ConnectorAuthMethodId,
   ConnectorSlug,
@@ -44,7 +46,10 @@ import {
   type ExternalCatalogIdentity,
 } from "./connector-catalog-external-reader.service";
 import type { ConnectorFeatureStates } from "./connector-catalog-feature-states";
-import { ConnectorCatalogLoadTiming } from "./connector-catalog-load-timing.service";
+import {
+  ConnectorCatalogLoadTiming,
+  type ConnectorRuntimeProjectionCacheObservation,
+} from "./connector-catalog-load-timing.service";
 import {
   countConnectorCatalogRuntimeProjectionRows,
   queryConnectorCatalogRuntimeProjectionRows,
@@ -854,6 +859,67 @@ const runtimeSelectionCache = singleton((): RuntimeSelectionCache => {
   return { completed: undefined, inFlight: undefined };
 });
 
+interface RuntimeSelectionObservationHistory {
+  identityDigest: string | undefined;
+  readonly selectionDigests: string[];
+}
+
+// This is a diagnostic window, not a payload-cache capacity. Keep only fixed-size
+// digests locally; neither the digests nor the original keys are telemetry fields.
+const RUNTIME_SELECTION_OBSERVATION_WINDOW = 16;
+const runtimeSelectionObservationHistory = singleton(
+  (): RuntimeSelectionObservationHistory => {
+    return { identityDigest: undefined, selectionDigests: [] };
+  },
+);
+
+function observeRuntimeSelection(
+  identity: ConnectorCatalogRuntimeProjectionIdentity,
+  key: string,
+): ConnectorRuntimeProjectionCacheObservation {
+  const history = runtimeSelectionObservationHistory();
+  const identityDigest = createHash("sha256")
+    .update(projectionIdentityKey(identity))
+    .digest("hex");
+  const selectionDigest = createHash("sha256").update(key).digest("hex");
+  const previousIdentity = history.identityDigest;
+  if (previousIdentity !== identityDigest) {
+    history.identityDigest = identityDigest;
+    history.selectionDigests.length = 0;
+  }
+  const index = history.selectionDigests.indexOf(selectionDigest);
+  if (index !== -1) {
+    history.selectionDigests.splice(index, 1);
+  }
+  history.selectionDigests.unshift(selectionDigest);
+  if (history.selectionDigests.length > RUNTIME_SELECTION_OBSERVATION_WINDOW) {
+    history.selectionDigests.pop();
+  }
+
+  if (previousIdentity === undefined) {
+    return "first_observation";
+  }
+  if (previousIdentity !== identityDigest) {
+    return "identity_changed";
+  }
+  if (index === -1) {
+    return "not_in_recent_history";
+  }
+  if (index === 0) {
+    return "reuse_1";
+  }
+  if (index === 1) {
+    return "reuse_2";
+  }
+  if (index < 4) {
+    return "reuse_3_4";
+  }
+  if (index < 8) {
+    return "reuse_5_8";
+  }
+  return "reuse_9_16";
+}
+
 async function completeRuntimeSelectionFallback(args: {
   readonly db: ReadonlyDb;
   readonly timing: ConnectorCatalogLoadTiming;
@@ -1109,6 +1175,9 @@ export async function loadConnectorRuntimeSelection(
       runtimeConnectorSlugs,
       metadataConnectorSlugs,
     });
+    timing.recordProjectionCacheObservation(
+      observeRuntimeSelection(identity.projection.identity, key),
+    );
     const cache = runtimeSelectionCache();
     if (cache.completed?.key === key) {
       timing.recordMaterializedConnectorCount(0);


### PR DESCRIPTION
## Summary

Closes #32570. Parent: #32557, under #24203 (both remain open).

- Add `connector_catalog_projection_cache_observation` to the existing scoped projection load event: first observation, full identity transition, not in recent history, and bucketed exact-key MRU reuse distances.
- Keep only one identity fingerprint and 16 selection fingerprints locally. Emit only eight categorical values, never raw keys, fingerprints, connector names, or credentials. Observe after the existing authoritative read, before cache lookup/await.
- Add bounded-window HTTP integration coverage and extend current run-lifecycle tests for concurrency, catalog/capability transitions, fallback and metadata-only reuse. Document exact API/Runner evaluation and telemetry limits.

## Scope and decision

This is the challenged evidence-first slice, **not** a retained-cache optimization. Existing logs cannot identify process-local repeated-scope churn well enough to choose a payload-cache capacity. Completed/in-flight cache slots, cleanup, fallback behavior, authorization and database queries are unchanged. No new cron, schema migration, dependency, UI, endpoint, or API/Runner protocol.

After deployment, #32557 still requires exact-version reuse analysis, retained object measurements, and a controlled cache candidate or no-change decision. First observation is not a cold start; a recent-reuse miss is not a guaranteed future cache hit.

## Validation

- Changed-file Prettier formatting/check and `git diff --check`.
- `pnpm -F api lint`.
- `pnpm knip --workspace apps/api`.
- `pnpm -F api check-types`.
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/run-projection-cache-observations.bdd.test.ts --maxWorkers=1 --silent=passed-only`: **233 passed**.
- Local non-gating overhead characterization extracted the actual observer/key functions, on Node v22.23.2, with 1/16/128 synthetic connectors and 4/17 distinct scopes: mean approximately **2–5 microseconds per lookup**. No concurrent validation command during the reported run. Each case warms up, then measures 60 alternating control/observer batches of 1,000 calls. This is not production latency, a heap-size measurement, or an end-to-end benefit claim.
- Diagnostic retention: at most 17 hexadecimal digests / 1,088 characters, plus bounded array/object overhead. Source checksum for the local characterization: `a31a6d32094d34fe9408be00f33f22fdedad19bc85259fc00daa4b8d3a9c0912`.

The local environment initially lacked `@eslint/css`; repository `scripts/prepare.sh` completed and all checks above were rerun as applicable. No manifest or lockfile changes.
