### PR TITLE
test(guest): assert recovered active input is not requeued

### DIFF
--- a/crates/guest-agent/tests/active_input_receipts.rs
+++ b/crates/guest-agent/tests/active_input_receipts.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use futures_util::FutureExt;
 use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
 use guest_agent::http::HttpClient;
 use httpmock::prelude::*;
@@ -498,11 +499,18 @@ async fn unacknowledged_journal_recovers_without_requeueing_the_backend()
         receipt_http(&server.base_url())?,
     )?;
     let recovered_controller = recovered.controller();
-    let _writer = recovered.into_writer();
+    let mut recovered_writer = recovered.into_writer();
 
     assert_eq!(
         recovered_controller.handle_control_payload(&accepted_payload),
-        ActiveInputControlOutcome::Accepted,
+        ActiveInputControlOutcome::Accepted
+    );
+    // Admission enqueues synchronously. Poll before close hides queued frames,
+    // without allowing a cooperative yield to masquerade as an empty queue.
+    assert!(
+        tokio::task::unconstrained(recovered_writer.next_frame())
+            .now_or_never()
+            .is_none(),
         "a recovered delivery must not be queued for the backend again"
     );
     recovered_controller.close_terminal();


### PR DESCRIPTION
## Summary

The recovery test previously asserted only `Accepted`, receipt delivery, and journal compaction. Those checks stayed green if recovery omitted deduplication registration and resubmission queued a duplicate backend input.

- Observe the recovered public writer after synchronous resubmission and before terminal close, requiring that no frame is ready.
- Disable cooperative yielding only for that single poll so a queued frame cannot hide behind Tokio's scheduling budget.
- Preserve the failed-receipt, restart, returned-ID, receipt-redelivery, and journal-compaction assertions.

Only the existing integration test changes. No production code, dependencies, timeout budgets, protocol or journal formats, UI, or user workflows change.

Closes #32586

## Validation

From `crates/`:

- `cargo fmt --all --check`
- `cargo clippy --profile local -p guest-agent --all-targets --all-features`
- `cargo doc --profile local -p guest-agent --all-features --no-deps`
- Exact recovery test: 10 consecutive passing runs.
- `cargo test --profile local -p guest-agent --test active_input_receipts --test claude_active_input_receipt` — 10 tests passed.
- `cargo test --profile local -p guest-agent --all-targets --all-features -- --quiet` — passed; existing ignored subprocess fixtures unchanged.
- `git diff --check`

Mutation experiment: temporarily remove only recovered `deliveries_by_id` registration, retaining the accepted-ID list and receipt worker recovery. The original test passes; the strengthened test fails at the new no-requeue assertion. Restored the production code afterward; no mutation or extra test is retained.

## Risks and limits

The immediate observation depends on queue admission completing synchronously before `handle_control_payload` returns. If admission becomes asynchronous, this test will need an explicit completion boundary. `now_or_never` distinguishes Pending from both a delivered frame and a closed writer. There is no added deployed execution path or timing window, and no claim of an observed production duplication incident.
