### PR TITLE
docs(guest-agent): clarify codex agent log representation

### DIFF
--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -7,7 +7,7 @@
 //!
 //! Naming conventions:
 //! - "system log" = guest-agent's own stderr (matches TS `SYSTEM_LOG_FILE` and API `systemLog`)
-//! - "agent log" = AI agent (Claude Code) stdout output
+//! - "agent log" = best-effort local agent-event log with backend-specific JSONL representation
 //! - "metrics" = periodic CPU/memory/disk snapshots
 //! - "sandbox ops" = operation timing records (defined in guest-telemetry, re-exported here)
 //! - runtime-file paths are scoped to the current run ID
@@ -217,12 +217,17 @@ impl GuestPaths {
 
     /// Return the `logs/agent.jsonl` path.
     ///
-    /// This best-effort JSONL stream contains the AI agent's local stdout
-    /// transcript. This accessor returns a borrowed `&str` and only derives the
-    /// path; it does not create, validate, or otherwise access the file. See
-    /// the canonical [agent log path helper][agent_log_file] for the shared
-    /// runtime layout.
+    /// This best-effort local agent-event log uses a backend-specific JSONL
+    /// representation. The Codex app-server backend writes normalized
+    /// compatibility events and may include synthesized events such as
+    /// `thread.started`; it does not store raw app-server JSON-RPC stdout. See
+    /// the [Codex normalization policy] for the mapping rules.
     ///
+    /// This accessor returns a borrowed `&str` and only derives the path; it
+    /// does not create, validate, or otherwise access the file. See the canonical
+    /// [agent log path helper][agent_log_file] for the shared runtime layout.
+    ///
+    /// [Codex normalization policy]: https://github.com/vm0-ai/vm0/blob/main/crates/guest-agent/src/cli/codex_app_server_events.rs
     /// [agent_log_file]: guest_contracts::runtime_paths::agent_log_file
     pub fn agent_log_file(&self) -> &str {
         &self.agent_log_file


### PR DESCRIPTION
## Summary

The public `GuestPaths` documentation described every agent log as a stdout transcript. Clarify that `logs/agent.jsonl` is a best-effort local event log with backend-specific JSONL, and that Codex stores normalized compatibility events, possibly including synthesized `thread.started` records, rather than raw app-server JSON-RPC stdout.

Link the existing normalization policy and preserve the run-scoped path and accessor side-effect guarantees. Only documentation comments change; runtime behavior and API signatures are unchanged.

Closes #32591

## Validation

- `cargo fmt --manifest-path crates/guest-agent/Cargo.toml -- --check`
- `cargo doc --manifest-path crates/Cargo.toml --profile local -p guest-agent -p guest-contracts --all-features --no-deps --locked`
- `cargo rustdoc --manifest-path crates/Cargo.toml --profile local -p guest-agent --lib --all-features --locked -- -D rustdoc::broken_intra_doc_links`
- `git diff --check`
- Inspected generated module/accessor documentation and both links, including the canonical helper page after documenting its crate; verified the policy source URL exists.
- Confirmed the diff changes only doc comments. Existing Codex mapper/integration assertions were inspected; runtime tests were not run for this documentation-only change.
