### PR TITLE
fix(runner): prevent duplicate webhook delivery after worker startup failure

### DIFF
--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -3,8 +3,8 @@
 Background workers process usage reports in parallel; the runner
 first waits for the pending counters to drain, then ``done()`` flushes
 submitted futures during mitmproxy shutdown. Falls back to synchronous
-delivery if an executor has been shut down (drain/shutdown race) so
-reports are not silently lost.
+delivery if submission fails during shutdown or worker startup so reports
+are not silently lost. A worker and fallback share one delivery claim.
 """
 
 import json
@@ -14,6 +14,7 @@ import urllib.error
 import urllib.parse
 from collections.abc import Callable
 from concurrent.futures import Executor, ThreadPoolExecutor
+from functools import partial
 from typing import Literal
 
 import network_log_sanitization
@@ -345,8 +346,24 @@ def _post_admitted_webhook_with_retry(
     pending_report: PendingReportLease,
     delivery_outcome_callback: _DeliveryOutcomeCallback | None,
     release_capacity: Callable[[], None],
+    try_claim_delivery: Callable[[], bool],
+    *,
+    fallback_message: str | None = None,
 ) -> None:
+    if not try_claim_delivery():
+        return
+
+    delivery_started = False
     try:
+        if fallback_message is not None:
+            log_proxy_entry(
+                proxy_log_path,
+                "warn",
+                fallback_message,
+                type=log_type,
+                url=url,
+            )
+        delivery_started = True
         _post_webhook_with_retry(
             url,
             bearer_credential,
@@ -357,7 +374,11 @@ def _post_admitted_webhook_with_retry(
             delivery_outcome_callback=delivery_outcome_callback,
         )
     finally:
-        release_capacity()
+        try:
+            if not delivery_started:
+                pending_report.release()
+        finally:
+            release_capacity()
 
 
 def enqueue_webhook_delivery(
@@ -373,15 +394,16 @@ def enqueue_webhook_delivery(
     The caller transfers ownership of ``payload`` to webhook delivery and
     must not mutate it after enqueue.
 
-    If the executor has already been shut down (drain/shutdown race),
-    falls back to synchronous delivery so the report is not silently lost.
+    If submission raises ``RuntimeError`` during shutdown or worker startup,
+    falls back to synchronous delivery unless a worker already claimed it.
+    A queued worker and the fallback cannot both deliver the same payload.
 
     When provided, ``delivery_outcome_callback`` is invoked exactly once for
     an admitted payload after delivery reaches a final ``success``,
     ``retryable_failure``, or ``permanent_failure`` outcome.  It is not
     invoked when admission returns ``False`` or when enqueueing fails before
     delivery ownership transfers.  Normal delivery invokes it on a webhook
-    executor worker; the executor-shutdown fallback invokes it synchronously
+    executor worker; the submission-failure fallback invokes it synchronously
     on the enqueueing thread.
 
     The callback runs before the pending-report lease and delivery-capacity
@@ -404,7 +426,7 @@ def enqueue_webhook_delivery(
         release_capacity=_release_delivery_capacity,
         pending_delivery_count=_pending_delivery_payload_count,
         saturation_label="usage delivery",
-        fallback_message="Webhook executor shut down, falling back to synchronous delivery",
+        fallback_message="Webhook submission failed, falling back to synchronous delivery",
     )
 
 
@@ -458,48 +480,41 @@ def _enqueue_webhook_delivery(
         raise
 
     pending_report = admit_pending_report()
+    claim_lock = threading.Lock()
+    claimed = False
+
+    def try_claim_delivery() -> bool:
+        nonlocal claimed
+        with claim_lock:
+            if claimed:
+                return False
+            claimed = True
+            return True
+
+    deliver = partial(
+        _post_admitted_webhook_with_retry,
+        url,
+        bearer_credential,
+        payload,
+        proxy_log_path,
+        log_type,
+        pending_report,
+        delivery_outcome_callback,
+        release_capacity,
+        try_claim_delivery,
+    )
     try:
-        executor.submit(
-            _post_admitted_webhook_with_retry,
-            url,
-            bearer_credential,
-            payload,
-            proxy_log_path,
-            log_type,
-            pending_report,
-            delivery_outcome_callback,
-            release_capacity,
-        )
+        executor.submit(deliver)
     except RuntimeError:
-        # Executor shut down (done() already called during drain).
-        fallback_started = False
-        try:
-            log_proxy_entry(
-                proxy_log_path,
-                "warn",
-                fallback_message,
-                type=log_type,
-                url=url,
-            )
-            fallback_started = True
-            _post_webhook_with_retry(
-                url,
-                bearer_credential,
-                payload,
-                proxy_log_path,
-                log_type,
-                pending_report,
-                delivery_outcome_callback=delivery_outcome_callback,
-            )
-        except Exception:
-            if not fallback_started:
-                pending_report.release()
-            raise
-        finally:
-            release_capacity()
+        # submit() can queue work before Thread.start() raises. Only one
+        # invocation may own delivery, its callback, and counter cleanup.
+        deliver(fallback_message=fallback_message)
     except Exception:
-        pending_report.release()
-        release_capacity()
+        if try_claim_delivery():
+            try:
+                pending_report.release()
+            finally:
+                release_capacity()
         raise
     return True
 

--- a/crates/runner/mitm-addon/tests/test_webhook_partial_submission.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_partial_submission.py
@@ -1,0 +1,218 @@
+"""Webhook ownership across real executor failures after work is queued."""
+
+import threading
+from collections.abc import Callable, Iterator
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import contextmanager, nullcontext
+from unittest.mock import patch
+
+import pytest
+
+import usage
+from tests.pending_helpers import assert_current_pending
+
+_THREAD_PREFIX = "webhook-partial-submit"
+
+
+class _ObservedExecutor(ThreadPoolExecutor):
+    def __init__(self, *, max_workers: int = 1) -> None:
+        super().__init__(max_workers=max_workers, thread_name_prefix=_THREAD_PREFIX)
+        self.returned_futures: list[Future] = []
+
+    def submit(self, fn, /, *args, **kwargs) -> Future:
+        future = super().submit(fn, *args, **kwargs)
+        self.returned_futures.append(future)
+        return future
+
+
+@contextmanager
+def _fail_worker_start(
+    error: Exception,
+    *,
+    before_failure: Callable[[], None] | None = None,
+) -> Iterator[None]:
+    start = threading.Thread.start
+
+    def start_or_fail(thread: threading.Thread) -> None:
+        if thread.name.startswith(_THREAD_PREFIX):
+            if before_failure is not None:
+                before_failure()
+            raise error
+        start(thread)
+
+    with patch.object(threading.Thread, "start", start_or_fail):
+        yield
+
+
+@pytest.mark.parametrize("callback_fails", [False, True])
+def test_fallback_owns_delivery_after_worker_start_failure(
+    tmp_path, usage_webhook_server, capsys, callback_fails
+):
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    other_report = usage.counters.admit_pending_report()
+    outcomes: list[tuple[str, usage.webhook.WebhookDeliveryOutcome]] = []
+
+    def enqueue(run_id: str) -> bool:
+        def on_outcome(outcome: usage.webhook.WebhookDeliveryOutcome) -> None:
+            outcomes.append((run_id, outcome))
+            assert usage.webhook.pending_delivery_payload_count_for_tests() == 1
+            assert_current_pending(pending_path, flows=0, buffered=0, reports=2)
+            if callback_fails and run_id == "A":
+                raise RuntimeError("callback failed")
+
+        return usage.webhook.enqueue_webhook_delivery(
+            usage_webhook_server.url(),
+            "tok",
+            {"runId": run_id, "events": []},
+            "",
+            "usage_event",
+            delivery_outcome_callback=on_outcome,
+        )
+
+    try:
+        with (
+            _ObservedExecutor() as executor,
+            patch.object(usage.webhook, "usage_executor", executor),
+        ):
+            error_context = (
+                pytest.raises(RuntimeError, match="callback failed")
+                if callback_fails
+                else nullcontext()
+            )
+            with _fail_worker_start(RuntimeError("can't start new thread")), error_context:
+                assert enqueue("A")
+
+            assert [body["runId"] for body in usage_webhook_server.json_bodies()] == ["A"]
+            assert outcomes == [("A", "success")]
+            assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+            assert_current_pending(pending_path, flows=0, buffered=0, reports=1)
+
+            # Recover worker creation and drain A's surviving work item before B.
+            assert enqueue("B")
+            executor.shutdown(wait=True)
+
+            assert [body["runId"] for body in usage_webhook_server.json_bodies()] == ["A", "B"]
+            assert outcomes == [("A", "success"), ("B", "success")]
+            for future in executor.returned_futures:
+                future.result(timeout=5)
+
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+        assert_current_pending(pending_path, flows=0, buffered=0, reports=1)
+        assert "usage_pending_counter_underflow" not in capsys.readouterr().err
+    finally:
+        other_report.release()
+
+
+def test_existing_worker_owns_delivery_before_submit_raises(tmp_path, usage_webhook_server, capsys):
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    other_report = usage.counters.admit_pending_report()
+    worker_occupied = threading.Event()
+    release_worker = threading.Event()
+    callback_started = threading.Event()
+    release_callback = threading.Event()
+    outcomes: list[usage.webhook.WebhookDeliveryOutcome] = []
+
+    def occupy_worker() -> None:
+        worker_occupied.set()
+        assert release_worker.wait(timeout=5)
+
+    def on_outcome(outcome: usage.webhook.WebhookDeliveryOutcome) -> None:
+        outcomes.append(outcome)
+        if threading.current_thread().name.startswith(_THREAD_PREFIX):
+            callback_started.set()
+            assert release_callback.wait(timeout=5)
+
+    def let_existing_worker_claim() -> None:
+        release_worker.set()
+        assert callback_started.wait(timeout=5)
+
+    try:
+        with (
+            _ObservedExecutor(max_workers=2) as executor,
+            patch.object(usage.webhook, "usage_executor", executor),
+        ):
+            try:
+                executor.submit(occupy_worker)
+                assert worker_occupied.wait(timeout=5)
+                with _fail_worker_start(
+                    RuntimeError("can't start new thread"),
+                    before_failure=let_existing_worker_claim,
+                ):
+                    assert usage.webhook.enqueue_webhook_delivery(
+                        usage_webhook_server.url(),
+                        "tok",
+                        {"runId": "A", "events": []},
+                        "",
+                        "usage_event",
+                        delivery_outcome_callback=on_outcome,
+                    )
+
+                # Submission recovered while the worker still owns its callback and counters.
+                assert [body["runId"] for body in usage_webhook_server.json_bodies()] == ["A"]
+                assert outcomes == ["success"]
+                assert usage.webhook.pending_delivery_payload_count_for_tests() == 1
+                assert_current_pending(pending_path, flows=0, buffered=0, reports=2)
+            finally:
+                release_worker.set()
+                release_callback.set()
+
+            executor.shutdown(wait=True)
+            for future in executor.returned_futures:
+                future.result(timeout=5)
+
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+        assert_current_pending(pending_path, flows=0, buffered=0, reports=1)
+        assert outcomes == ["success"]
+        assert "usage_pending_counter_underflow" not in capsys.readouterr().err
+    finally:
+        other_report.release()
+
+
+def test_partial_submit_rollback_preserves_next_delivery(tmp_path, usage_webhook_server, capsys):
+    pending_path = tmp_path / "usage-pending"
+    usage.set_pending_path(str(pending_path))
+    outcomes: list[tuple[str, usage.webhook.WebhookDeliveryOutcome]] = []
+
+    def enqueue(run_id: str) -> bool:
+        def on_outcome(outcome: usage.webhook.WebhookDeliveryOutcome) -> None:
+            outcomes.append((run_id, outcome))
+            assert usage.webhook.pending_delivery_payload_count_for_tests() == 1
+            assert_current_pending(pending_path, flows=0, buffered=0, reports=1)
+
+        return usage.webhook.enqueue_webhook_delivery(
+            usage_webhook_server.url(),
+            "tok",
+            {"runId": run_id, "events": []},
+            "",
+            "usage_event",
+            delivery_outcome_callback=on_outcome,
+        )
+
+    with (
+        _ObservedExecutor() as executor,
+        patch.object(usage.webhook, "usage_executor", executor),
+    ):
+        with (
+            _fail_worker_start(OSError("worker creation failed")),
+            pytest.raises(OSError, match="worker creation failed"),
+        ):
+            enqueue("A")
+
+        assert usage_webhook_server.request_count == 0
+        assert outcomes == []
+        assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+        assert_current_pending(pending_path, flows=0, buffered=0, reports=0)
+
+        assert enqueue("B")
+        executor.shutdown(wait=True)
+
+        assert [body["runId"] for body in usage_webhook_server.json_bodies()] == ["B"]
+        assert outcomes == [("B", "success")]
+        for future in executor.returned_futures:
+            future.result(timeout=5)
+
+    assert usage.webhook.pending_delivery_payload_count_for_tests() == 0
+    assert_current_pending(pending_path, flows=0, buffered=0, reports=0)
+    assert "usage_pending_counter_underflow" not in capsys.readouterr().err


### PR DESCRIPTION
## Summary

`ThreadPoolExecutor.submit()` can queue a webhook before worker startup raises. The synchronous fallback then sends it, and a later worker can send it again and release another payload's capacity slot. Give the worker, existing synchronous recovery, and submission rollback one shared claim so only the owner can deliver, invoke the final callback, or release the pending-report lease and capacity.

Keep delivery after genuine executor shutdown and existing callback/error propagation. Update the diagnostic and docstrings to describe submission failure accurately. This changes in-process ownership only; HTTP payloads, authentication, retry policy, dependencies, and deployed protocols are unchanged.

Add real-executor and loopback-HTTP regressions for fallback-first delivery, a failing fallback callback, worker-first delivery, and partial-submit rollback. All four fail against the original implementation and pass with the fix; recovery delivers `A, B` once each and preserves B's accounting.

Closes #32589

## Validation

Run from `crates/runner/mitm-addon` with locked CPython 3.14.0 and uv 0.11.32:

- `uv lock --check` and `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` — 0 errors/warnings
- `uv run --no-sync python -m pytest tests/test_webhook_partial_submission.py tests/test_webhook_delivery_admission.py tests/test_webhook_http_delivery.py -q` — 38 passed
- `uv run --no-sync python -m pytest tests/ -q` — 7,354 passed
