### PR TITLE
fix(python): isolate report delivery from worker startup failures

### DIFF
--- a/crates/runner/mitm-addon/src/model_provider_failure.py
+++ b/crates/runner/mitm-addon/src/model_provider_failure.py
@@ -179,10 +179,7 @@ _report_condition = threading.Condition(_report_lock)
 _report_api_url = ""
 _report_bearer_credential = ""
 _report_slots = threading.BoundedSemaphore(_MAX_PENDING_REPORTS)
-_report_executor = ThreadPoolExecutor(
-    max_workers=_REPORT_WORKERS,
-    thread_name_prefix="model-provider-failure",
-)
+_report_executor: ThreadPoolExecutor | None = None
 _reporter_shut_down = False
 _report_futures: set[Future[int]] = set()
 
@@ -210,10 +207,7 @@ def reset_for_tests() -> None:
     configure_reporting(api_url="", bearer_credential="")
     with _report_lock:
         if _reporter_shut_down:
-            _report_executor = ThreadPoolExecutor(
-                max_workers=_REPORT_WORKERS,
-                thread_name_prefix="model-provider-failure",
-            )
+            _report_executor = None
             _reporter_shut_down = False
 
 
@@ -617,8 +611,10 @@ def shutdown() -> None:
     configure_reporting(api_url="", bearer_credential="")
     with _report_lock:
         pending = tuple(_report_futures)
+        executor = _report_executor
         _reporter_shut_down = True
-    _report_executor.shutdown(wait=False, cancel_futures=True)
+    if executor is not None:
+        executor.shutdown(wait=False, cancel_futures=True)
     running = tuple(future for future in pending if not future.cancelled())
     if running:
         wait(running, timeout=_REPORT_TIMEOUT_SECONDS)
@@ -885,7 +881,27 @@ def _mark_websocket_ambiguous(
     _log_suppressed(flow, reason)
 
 
+def _start_report_executor() -> ThreadPoolExecutor:
+    executor = ThreadPoolExecutor(
+        max_workers=_REPORT_WORKERS,
+        thread_name_prefix="model-provider-failure",
+    )
+    release_workers = threading.Event()
+    try:
+        # submit() queues before starting a worker and can then raise without returning
+        # its future. Start every worker with report-free tasks before enqueueing HTTP.
+        for _ in range(_REPORT_WORKERS):
+            executor.submit(release_workers.wait)
+    except BaseException:
+        release_workers.set()
+        executor.shutdown(wait=True, cancel_futures=True)
+        raise
+    release_workers.set()
+    return executor
+
+
 def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
+    global _report_executor
     with _report_lock:
         api_url = _report_api_url
         bearer_credential = _report_bearer_credential
@@ -913,9 +929,14 @@ def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
         f"{api_url}/api/runners/runs/{urllib.parse.quote(run_id, safe='')}/model-provider-failures"
     )
     future: Future[int] | None = None
+    omission_reason = "reporter_shut_down"
     with _report_lock:
         if not _reporter_shut_down:
             try:
+                if _report_executor is None:
+                    omission_reason = "worker_start_failed"
+                    _report_executor = _start_report_executor()
+                omission_reason = "reporter_shut_down"
                 future = _report_executor.submit(
                     _post_report,
                     report_url,
@@ -928,7 +949,7 @@ def _enqueue_report(flow: http.HTTPFlow, run_id: str, failure: Failure) -> None:
                 _report_futures.add(future)
     if future is None:
         _report_slots.release()
-        _log_report_omitted(report_context, "reporter_shut_down")
+        _log_report_omitted(report_context, omission_reason)
         return
     future.add_done_callback(lambda completed: _finish_report(completed, report_context))
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_failure_reporting.py
@@ -662,6 +662,8 @@ def test_executor_submission_failure_reclaims_capacity(
     real_flow,
     model_provider_failure_api,
 ):
+    _enqueue_provider_unavailable(real_flow, tmp_path / "submit-initialized.jsonl")
+    model_provider_failure.drain_reports_for_tests()
     proxy_log_path = tmp_path / "submit-failed.jsonl"
     with patch.object(
         ThreadPoolExecutor,
@@ -670,7 +672,7 @@ def test_executor_submission_failure_reclaims_capacity(
     ):
         flow = _enqueue_provider_unavailable(real_flow, proxy_log_path)
 
-    assert model_provider_failure_api.request_count == 0
+    assert model_provider_failure_api.request_count == 1
     _assert_single_report_omission(
         proxy_log_path,
         flow_id=flow.id,
@@ -681,6 +683,74 @@ def test_executor_submission_failure_reclaims_capacity(
         tmp_path / "submit-failed-recovery.jsonl",
         model_provider_failure_api,
     )
+
+
+@pytest.mark.parametrize("started_workers", [0, 2], ids=["cold", "partial"])
+@pytest.mark.parametrize("shutdown_before_recovery", [False, True], ids=["recover", "shutdown"])
+def test_worker_start_failure_drops_reports_and_recovers_capacity(
+    tmp_path,
+    real_flow,
+    model_provider_failure_api,
+    started_workers,
+    shutdown_before_recovery,
+):
+    _restart_reporter_after_callbacks(model_provider_failure_api)
+    proxy_log_path = tmp_path / "worker-start-failed.jsonl"
+    original_start = threading.Thread.start
+    started_threads: list[threading.Thread] = []
+    failed_starts = 0
+
+    def start_with_reporter_failure(thread: threading.Thread) -> None:
+        nonlocal failed_starts
+        if thread.name.startswith("model-provider-failure_"):
+            if thread.name == f"model-provider-failure_{started_workers}":
+                failed_starts += 1
+                raise RuntimeError("can't start new thread")
+            started_threads.append(thread)
+        original_start(thread)
+
+    try:
+        with patch.object(threading.Thread, "start", start_with_reporter_failure):
+            flows = []
+            for index in range(_REPORT_CAPACITY + _REPORT_WORKERS):
+                flow = _make_flow(real_flow, proxy_log_path, response_status=503)
+                flow.metadata[metadata_keys.SANDBOX_RUN_ID] = f"run-start-failed-{index}"
+                model_provider_failure.admit_flow(flow)
+                mitm_addon.responseheaders(flow)
+                flows.append(flow)
+
+        assert failed_starts == len(flows)
+        assert all(not thread.is_alive() for thread in started_threads)
+        assert model_provider_failure_api.request_count == 0
+        model_provider_failure.drain_reports_for_tests(timeout=0)
+
+        if shutdown_before_recovery:
+            _restart_reporter_after_callbacks(model_provider_failure_api)
+
+        _enqueue_provider_unavailable(real_flow, tmp_path / "worker-start-recovered.jsonl")
+        model_provider_failure.drain_reports_for_tests()
+        _restart_reporter_after_callbacks(model_provider_failure_api)
+
+        [request] = model_provider_failure_api.requests
+        assert request.path == "/api/runners/runs/run-model-failure/model-provider-failures"
+        assert request.json_body() == {"failureKind": "provider_unavailable"}
+        omissions = _report_omissions(proxy_log_path)
+        assert len(omissions) == len(flows)
+        assert {entry["flow_id"] for entry in omissions} == {flow.id for flow in flows}
+        assert {entry["run_id"] for entry in omissions} == {
+            f"run-start-failed-{index}" for index in range(len(flows))
+        }
+        assert all(entry["reason"] == "worker_start_failed" for entry in omissions)
+        _assert_full_report_capacity(
+            real_flow,
+            tmp_path / "worker-start-capacity.jsonl",
+            model_provider_failure_api,
+        )
+    finally:
+        _restart_reporter_after_callbacks(model_provider_failure_api)
+        for thread in started_threads:
+            thread.join(timeout=1)
+            assert not thread.is_alive()
 
 
 def test_shutdown_cancels_queued_reports(


### PR DESCRIPTION
CPython can queue a report before `ThreadPoolExecutor.submit()` fails to start a worker, leaving the report untracked after admission capacity is returned. The regression reproduces 21 HTTP requests after 20 startup failures and one recovery report.

Initialize all four workers with report-free startup tasks before submitting HTTP delivery. Failed startup releases, cancels, and joins those tasks, logs `worker_start_failed`, and leaves capacity available for the next report. The pool remains lazy until the first admitted report, when all four workers now start together; the 16-report admission bound and bounded HTTP shutdown remain intact.

Add real-executor and loopback HTTP regression coverage for repeated cold/partial startup failures, recovery, shutdown, omission diagnostics, and full capacity reclamation. Retain separate initialized-executor submission rejection coverage.

Closes #32592

Validation in the committed uv 0.11.32 / CPython 3.14.0 environment:

- `uv lock --check` and `uv sync --locked`
- `uv run --no-sync ruff format --check .` and `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .` — 0 errors/warnings
- `uv run --no-sync python -m pytest tests/test_model_provider_failure_reporting.py` — 103 passed
- `uv run --no-sync python -m pytest tests/` — 7,354 passed, 43 warnings
- Startup, rejection, callback cleanup, capacity, and shutdown tests in reversed collection order — 9 passed
- Cold recovery regression failed against unchanged production code with 21 requests instead of 1.
