### PR TITLE
fix(api): use supported fast-path reasoning and safe diagnostics

### DIFF
--- a/turbo/apps/api/src/signals/external/openrouter.ts
+++ b/turbo/apps/api/src/signals/external/openrouter.ts
@@ -74,17 +74,23 @@ interface OpenRouterGenerateTextOptions {
 export class OpenRouterRequestError extends Error {
   readonly status: number;
   readonly errorType: string | undefined;
+  readonly errorCode: string | number | undefined;
+  readonly errorParam: string | undefined;
 
   constructor(args: {
     readonly message: string;
     readonly status: number;
     readonly errorType?: string;
+    readonly errorCode?: string | number;
+    readonly errorParam?: string;
   }) {
     const errorType = args.errorType ? ` (${args.errorType})` : "";
     super(`${args.message}: ${String(args.status)}${errorType}`);
     this.name = "OpenRouterRequestError";
     this.status = args.status;
     this.errorType = args.errorType;
+    this.errorCode = args.errorCode;
+    this.errorParam = args.errorParam;
   }
 }
 
@@ -95,14 +101,48 @@ function objectProperty(value: unknown, property: string): unknown | undefined {
   return value[property as keyof typeof value];
 }
 
-function openRouterErrorType(value: unknown): string | undefined {
-  const error = objectProperty(value, "error") ?? value;
-  const metadata = objectProperty(error, "metadata");
-  const errorType = objectProperty(metadata, "error_type");
-  return typeof errorType === "string" &&
-    /^[a-z][a-z0-9_]{0,127}$/u.test(errorType)
-    ? errorType
+// Provider diagnostics are untrusted data, including strings that look like
+// identifiers. Only retain enumerated values; never retain messages or raw data.
+function safeDiagnosticString(
+  value: unknown,
+  allowed: readonly string[],
+): string | undefined {
+  return typeof value === "string" && allowed.includes(value)
+    ? value
     : undefined;
+}
+
+function safeErrorCode(error: unknown): string | number | undefined {
+  const code = objectProperty(error, "code");
+  if (
+    typeof code === "number" &&
+    [400, 401, 402, 403, 404, 408, 413, 422, 429, 500, 502, 503, 504].includes(
+      code,
+    )
+  ) {
+    return code;
+  }
+  return safeDiagnosticString(code, [
+    "invalid_request_error",
+    "invalid_argument",
+    "invalid_parameter",
+    "unsupported_parameter",
+    "unsupported_value",
+    "rate_limit_exceeded",
+    "INVALID_ARGUMENT",
+    "RESOURCE_EXHAUSTED",
+    "UNAVAILABLE",
+  ]);
+}
+
+function safeErrorParam(error: unknown): string | undefined {
+  return safeDiagnosticString(objectProperty(error, "param"), [
+    "reasoning",
+    "reasoning.effort",
+    "reasoning_effort",
+    "max_tokens",
+    "temperature",
+  ]);
 }
 
 function openRouterRequestError(args: {
@@ -110,11 +150,42 @@ function openRouterRequestError(args: {
   readonly status: number;
   readonly value: unknown;
 }): OpenRouterRequestError {
-  const errorType = openRouterErrorType(args.value);
+  const error = objectProperty(args.value, "error") ?? args.value;
+  const metadata = objectProperty(error, "metadata");
+  const errorType = safeDiagnosticString(
+    objectProperty(metadata, "error_type"),
+    [
+      "invalid_image",
+      "image_too_small",
+      "unsupported_image_format",
+      "image_too_large",
+      "image_not_found",
+      "image_download_failed",
+      "invalid_request_error",
+    ],
+  );
+  // OpenRouter may wrap the provider's JSON error in metadata.raw. Parse just
+  // one bounded envelope and apply the same allowlists; never attach it as cause.
+  const raw = objectProperty(metadata, "raw");
+  const provider =
+    typeof raw === "string" && Buffer.byteLength(raw, "utf8") <= 4096
+      ? objectProperty(safeJsonParse(raw), "error")
+      : undefined;
+  const errorCode =
+    safeDiagnosticString(objectProperty(provider, "status"), [
+      "INVALID_ARGUMENT",
+      "RESOURCE_EXHAUSTED",
+      "UNAVAILABLE",
+    ]) ??
+    safeErrorCode(provider) ??
+    safeErrorCode(error);
+  const errorParam = safeErrorParam(provider) ?? safeErrorParam(error);
   return new OpenRouterRequestError({
     message: args.message,
     status: args.status,
     ...(errorType === undefined ? {} : { errorType }),
+    ...(errorCode === undefined ? {} : { errorCode }),
+    ...(errorParam === undefined ? {} : { errorParam }),
   });
 }
 
@@ -157,11 +228,20 @@ function parseOpenRouterGeneration(
     });
   }
   if (choice.finish_reason !== "stop") {
-    const nativeReason = choice.native_finish_reason
-      ? ` (native: ${choice.native_finish_reason})`
+    const nativeFinishReason = safeDiagnosticString(
+      choice.native_finish_reason,
+      ["MAX_TOKENS", "STOP", "SAFETY", "RECITATION", "OTHER"],
+    );
+    const finishReason = safeDiagnosticString(choice.finish_reason, [
+      "length",
+      "content_filter",
+      "tool_calls",
+    ]);
+    const nativeReason = nativeFinishReason
+      ? ` (native: ${nativeFinishReason})`
       : "";
     throw new Error(
-      `OpenRouter completion finished with ${choice.finish_reason ?? "unknown"}${nativeReason}`,
+      `OpenRouter completion finished with ${finishReason ?? "unknown"}${nativeReason}`,
     );
   }
 
@@ -244,6 +324,10 @@ export async function generateTextWithUsage(
     signal,
   });
   await ensureOpenRouterResponseOk(response);
-  const data = (await response.json()) as OpenRouterResponse;
-  return parseOpenRouterGeneration(data);
+  // JSON parser errors can quote the upstream body. Keep failures payload-free.
+  const data = safeJsonParse(await response.text());
+  if (typeof data !== "object" || data === null) {
+    throw new Error("OpenRouter returned invalid JSON");
+  }
+  return parseOpenRouterGeneration(data as OpenRouterResponse);
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-events.bdd.test.ts
@@ -179,6 +179,8 @@ import {
 import { useSecretKmsProbe } from "./helpers/secret-kms-probe";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createDeferredPromise } from "../../utils";
+import { openRouterModelContractError } from "./helpers/openrouter-model-contract";
+import { openRouterErrorFixtures } from "./helpers/openrouter-error-fixtures";
 import { verifyOkouToken } from "../../auth/tokens";
 import {
   createUnassociatedThreadBoundAgentRunFixture,
@@ -18774,6 +18776,10 @@ describe("CHAT-02: initial thinking indicator", () => {
         "https://openrouter.ai/api/v1/chat/completions",
         async ({ request }) => {
           const payload = openRouterBodySchema.parse(await request.json());
+          const contractError = openRouterModelContractError(payload);
+          if (contractError) {
+            return contractError;
+          }
           const systemContent = payload.messages[0]?.content ?? "";
           let responseContent = "Unrelated completion";
           if (systemContent.includes("Generate a short, descriptive title")) {
@@ -18801,9 +18807,11 @@ describe("CHAT-02: initial thinking indicator", () => {
       ),
     );
 
+    const clientEventId = randomUUID();
     const run = await sendChatRun(actor, {
       agentId,
       prompt: "Draft a launch checklist",
+      clientEventId,
     });
 
     const page = await waitForThreadMessages(actor, run.threadId, (items) => {
@@ -18834,8 +18842,8 @@ describe("CHAT-02: initial thinking indicator", () => {
     expect(thinkingAuthorization).toBe("Bearer thinking-key");
     expect(thinkingRequestBody).toMatchObject({
       model: "google/gemini-3.8-flash",
-      max_tokens: 160,
-      reasoning: { effort: "none" },
+      max_tokens: 1024,
+      reasoning: { effort: "low" },
     });
     expect(thinkingPromptPayload).toContain("one paragraph at a time");
     expect(thinkingPromptPayload).toContain(
@@ -18850,6 +18858,24 @@ describe("CHAT-02: initial thinking indicator", () => {
     expect(thinkingPromptPayload).toContain("Draft a launch checklist");
     await flushWaitUntilForTest();
     expect(firstAssistantEventsForRun(run.runId)).toStrictEqual([]);
+
+    await chat.requestSendEvent(
+      actor,
+      {
+        agentId,
+        threadId: run.threadId,
+        prompt: "Draft a launch checklist",
+        clientEventId,
+      },
+      [201],
+    );
+    await flushWaitUntilForTest();
+    const replayed = await chat.listThreadEvents(actor, run.threadId);
+    expect(
+      replayed.events.filter((event) => {
+        return event.runEventId === "thinking:initial";
+      }),
+    ).toStrictEqual([marker]);
 
     await cancelChatRun(actor, run.runId);
   });
@@ -18911,6 +18937,318 @@ describe("CHAT-02: initial thinking indicator", () => {
 
     await cancelChatRun(actor, run.runId);
   });
+
+  it("caps complete progress copy at 600 characters while preserving paragraph sanitization", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    mockOptionalEnv("OPENROUTER_API_KEY", "thinking-key");
+    chatCallbacks.mockOpenRouterCompletions((body) => {
+      return body.messages[0]?.content.includes(
+        "Write user-visible progress copy",
+      )
+        ? `"  Preparing\t the update.\r\n\r\n\r\n${"界".repeat(700)}"`
+        : "Update";
+    });
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt: "Prepare an update",
+    });
+    await flushWaitUntilForTest();
+    const page = await chat.listThreadEvents(actor, run.threadId);
+    const marker = page.events.find((event) => {
+      return event.runEventId === "thinking:initial";
+    });
+    expect(marker).toMatchObject({
+      thinking: `Preparing the update.\n\n${"界".repeat(577)}`,
+    });
+    await cancelChatRun(actor, run.runId);
+  });
+
+  it("does not request opening copy while a run waits for org capacity", async () => {
+    const { actor, agentId } = await entitledChatActor();
+    mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+    const blocker = await sendChatRun(actor, {
+      agentId,
+      prompt: "Occupy capacity",
+    });
+    await flushWaitUntilForTest();
+    mockOptionalEnv("OPENROUTER_API_KEY", "thinking-key");
+    let thinkingRequests = 0;
+    chatCallbacks.mockOpenRouterCompletions((body) => {
+      if (
+        body.messages[0]?.content.includes("Write user-visible progress copy")
+      ) {
+        thinkingRequests += 1;
+      }
+      return "Update";
+    });
+    const queued = await sendChatRun(actor, {
+      agentId,
+      prompt: "Prepare a later update",
+    });
+    await flushWaitUntilForTest();
+    expect((await api.readRun(actor, queued.runId)).status).toBe("queued");
+    const page = await chat.listThreadEvents(actor, queued.threadId);
+    expect(page.events).toContainEqual(
+      expect.objectContaining({ runEventId: "queue:queued" }),
+    );
+    expect(
+      page.events.some((event) => {
+        return event.runEventId === "thinking:initial";
+      }),
+    ).toBeFalsy();
+    expect(thinkingRequests).toBe(0);
+    await cancelChatRun(actor, queued.runId);
+    await cancelChatRun(actor, blocker.runId);
+  });
+
+  it.each([400, 429, 503])(
+    "keeps the main run usable after an auxiliary HTTP %i",
+    async (status) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockOptionalEnv("OPENROUTER_API_KEY", "thinking-key");
+      server.use(
+        http.post(
+          "https://openrouter.ai/api/v1/chat/completions",
+          async ({ request }) => {
+            const body = openRouterBodySchema.parse(await request.json());
+            if (
+              body.messages[0]?.content.includes(
+                "Write user-visible progress copy",
+              )
+            ) {
+              return HttpResponse.json({ error: { code: status } }, { status });
+            }
+            return HttpResponse.json({
+              choices: [
+                { finish_reason: "stop", message: { content: "Update" } },
+              ],
+            });
+          },
+        ),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        prompt: "Prepare an update",
+      });
+      await flushWaitUntilForTest();
+      const claim = await claimChatRun(runnerGroup, run.runId);
+      chatCallbacks.mockChatOutputEvents([
+        assistantEvent(0, "The main response is ready."),
+      ]);
+      await completeChatRunOk(run.runId, claim.sandboxHeaders);
+      await flushWaitUntilForTest();
+      expect((await api.readRun(actor, run.runId)).status).toBe("completed");
+      const page = await chat.listThreadEvents(actor, run.threadId);
+      expect(page.events).toContainEqual(
+        expect.objectContaining({ content: "The main response is ready." }),
+      );
+      expect(
+        page.events.some((event) => {
+          return event.runEventId === "thinking:initial";
+        }),
+      ).toBeFalsy();
+    },
+  );
+
+  it.each([
+    {
+      name: "empty",
+      responseBody: {
+        choices: [{ finish_reason: "stop", message: { content: "  " } }],
+      },
+    },
+    {
+      name: "non-text",
+      responseBody: {
+        choices: [{ finish_reason: "stop", message: { content: null } }],
+      },
+    },
+    {
+      name: "unknown finish reason",
+      responseBody: {
+        choices: [
+          {
+            finish_reason: "private_prompt_history_authorization_canary",
+            native_finish_reason: "private_prompt_history_authorization_canary",
+            message: { content: "Incomplete" },
+          },
+        ],
+      },
+    },
+    {
+      name: "malformed JSON",
+      responseBody: "private_prompt_history_authorization_canary: invalid JSON",
+    },
+  ])(
+    "discards $name output without failing the run or leaking provider data",
+    async ({ responseBody }) => {
+      const { actor, agentId } = await entitledChatActor();
+      mockOptionalEnv("OPENROUTER_API_KEY", "thinking-key");
+      server.use(
+        http.post(
+          "https://openrouter.ai/api/v1/chat/completions",
+          async ({ request }) => {
+            const body = openRouterBodySchema.parse(await request.json());
+            if (
+              body.messages[0]?.content.includes(
+                "Write user-visible progress copy",
+              )
+            ) {
+              return typeof responseBody === "string"
+                ? HttpResponse.text(responseBody)
+                : HttpResponse.json(responseBody);
+            }
+            return HttpResponse.json({
+              choices: [
+                { finish_reason: "stop", message: { content: "Update" } },
+              ],
+            });
+          },
+        ),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        prompt: "Prepare an update",
+      });
+      await flushWaitUntilForTest();
+      expect((await api.readRun(actor, run.runId)).status).toBe("pending");
+      const page = await chat.listThreadEvents(actor, run.threadId);
+      expect(
+        page.events.some((event) => {
+          return event.runEventId === "thinking:initial";
+        }),
+      ).toBeFalsy();
+      const errors = context.mocks.axiomLogging.warn.mock.calls.filter(
+        ([message]) => {
+          return message === "Initial thinking generation failed";
+        },
+      );
+      expect(errors).toHaveLength(1);
+      const logged = z
+        .object({ err: z.instanceof(Error) })
+        .parse(errors[0]?.[1]);
+      expect(logged.err.message).not.toContain(
+        "private_prompt_history_authorization_canary",
+      );
+      await cancelChatRun(actor, run.runId);
+    },
+  );
+
+  it.each(["answer", "completed", "cancelled"] as const)(
+    "suppresses late progress copy after %s while the provider remains pending",
+    async (outcome) => {
+      const { actor, agentId, runnerGroup } = await entitledChatActor();
+      mockOptionalEnv("OPENROUTER_API_KEY", "thinking-key");
+      const entered = createDeferredPromise<void>(context.signal);
+      const release = createDeferredPromise<void>(context.signal);
+      chatCallbacks.mockOpenRouterCompletions(async (body) => {
+        if (
+          body.messages[0]?.content.includes("Write user-visible progress copy")
+        ) {
+          entered.resolve();
+          await release.promise;
+          return "This progress copy arrived too late.";
+        }
+        return "Update";
+      });
+      // The send and main-run lifecycle must proceed before auxiliary generation resolves.
+      const run = await sendChatRun(actor, {
+        agentId,
+        prompt: "Prepare an update",
+      });
+      await entered.promise;
+      const claim = await claimChatRun(runnerGroup, run.runId);
+      if (outcome === "answer") {
+        chatCallbacks.mockChatOutputEvents([assistantEvent(0, "Main answer")]);
+        await webhooks.requestAgentEvents(
+          {
+            runId: run.runId,
+            events: chatCallbacks.consumeMockChatOutputEvents(),
+          },
+          claim.sandboxHeaders,
+          [200],
+        );
+      } else if (outcome === "completed") {
+        await completeChatRunOk(run.runId, claim.sandboxHeaders);
+      } else {
+        await api.requestCancelRun(actor, run.runId, [200]);
+      }
+      release.resolve();
+      await flushWaitUntilForTest();
+      const page = await chat.listThreadEvents(actor, run.threadId);
+      expect(
+        page.events.some((event) => {
+          return event.runEventId === "thinking:initial";
+        }),
+      ).toBeFalsy();
+      expect((await api.readRun(actor, run.runId)).status).toBe(
+        outcome === "answer" ? "running" : outcome,
+      );
+      if (outcome === "answer") {
+        await cancelChatRun(actor, run.runId, claim.sandboxHeaders);
+      }
+    },
+  );
+
+  it.each(openRouterErrorFixtures)(
+    "retains only safe initial-thinking diagnostics: $name",
+    async ({ body, expected }) => {
+      const { actor, agentId } = await entitledChatActor();
+      mockOptionalEnv("OPENROUTER_API_KEY", "thinking-key");
+      server.use(
+        http.post(
+          "https://openrouter.ai/api/v1/chat/completions",
+          async ({ request }) => {
+            const payload = openRouterBodySchema.parse(await request.json());
+            return payload.messages[0]?.content.includes(
+              "Write user-visible progress copy",
+            )
+              ? typeof body === "string"
+                ? HttpResponse.text(body, { status: 400 })
+                : HttpResponse.json(body, { status: 400 })
+              : HttpResponse.json({
+                  choices: [
+                    { finish_reason: "stop", message: { content: "Update" } },
+                  ],
+                });
+          },
+        ),
+      );
+      const run = await sendChatRun(actor, {
+        agentId,
+        prompt: "Prepare an update",
+      });
+      await flushWaitUntilForTest();
+      const errors = context.mocks.axiomLogging.warn.mock.calls.filter(
+        ([message]) => {
+          return message === "Initial thinking generation failed";
+        },
+      );
+      expect(errors).toHaveLength(1);
+      const logged = z
+        .object({ err: z.instanceof(Error) })
+        .parse(errors[0]?.[1]);
+      expect(logged.err).toMatchObject({
+        name: "OpenRouterRequestError",
+        message: "OpenRouter request failed: 400",
+        status: 400,
+        errorType: undefined,
+        ...expected,
+      });
+      expect(JSON.stringify(logged.err)).not.toContain(
+        "private_prompt_history_authorization_canary",
+      );
+      expect(logged.err).not.toHaveProperty("cause");
+      const page = await chat.listThreadEvents(actor, run.threadId);
+      expect(
+        page.events.some((event) => {
+          return event.runEventId === "thinking:initial";
+        }),
+      ).toBeFalsy();
+      expect((await api.readRun(actor, run.runId)).status).toBe("pending");
+      await cancelChatRun(actor, run.runId);
+    },
+  );
 });
 
 describe("CHAT-02: prior rounds and thread titles", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
@@ -16,6 +16,7 @@ import { pushSubscriptionsRoutes } from "../../push-subscriptions";
 import { sessionHistoryBlobBodyForKey } from "./api-bdd-session-history";
 import type { ApiTestUser } from "./api-bdd";
 import { createRouteMocks } from "./route-test";
+import { openRouterModelContractError } from "./openrouter-model-contract";
 import type { AgentEvent } from "../../../../lib/event-consumer/verify";
 
 const CHAT_CALLBACK_URL = "http://localhost:3000/api/internal/callbacks/chat";
@@ -325,6 +326,10 @@ export function createChatCallbacksApi(context: TestContext) {
           const body = openRouterCompletionBodySchema.parse(
             await request.json(),
           );
+          const contractError = openRouterModelContractError(body);
+          if (contractError) {
+            return contractError;
+          }
           const result = await handler(body);
           return HttpResponse.json({
             choices: [

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/openrouter-error-fixtures.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/openrouter-error-fixtures.ts
@@ -1,0 +1,117 @@
+const privateDetail = "private_prompt_history_authorization_canary";
+const safeError = {
+  code: "unsupported_value",
+  param: "reasoning.effort",
+} as const;
+
+export const openRouterErrorFixtures = [
+  {
+    name: "direct code and parameter",
+    body: { error: { ...safeError, message: privateDetail } },
+    expected: {
+      errorCode: "unsupported_value",
+      errorParam: "reasoning.effort",
+    },
+  },
+  {
+    name: "numeric gateway code",
+    body: { error: { code: 400, message: privateDetail } },
+    expected: { errorCode: 400, errorParam: undefined },
+  },
+  {
+    name: "bounded provider JSON",
+    body: {
+      error: {
+        code: 400,
+        metadata: {
+          raw: JSON.stringify({
+            error: { ...safeError, message: privateDetail },
+          }),
+          prompt: privateDetail,
+          headers: { authorization: privateDetail },
+        },
+      },
+    },
+    expected: {
+      errorCode: "unsupported_value",
+      errorParam: "reasoning.effort",
+    },
+  },
+  {
+    name: "google provider status",
+    body: {
+      error: {
+        code: 400,
+        metadata: {
+          raw: JSON.stringify({
+            error: {
+              code: 400,
+              status: "INVALID_ARGUMENT",
+              message: privateDetail,
+            },
+          }),
+        },
+      },
+    },
+    expected: { errorCode: "INVALID_ARGUMENT", errorParam: undefined },
+  },
+  {
+    name: "absent diagnostics",
+    body: { error: { message: privateDetail } },
+    expected: { errorCode: undefined, errorParam: undefined },
+  },
+  {
+    name: "unknown identifier-shaped sensitive fields",
+    body: {
+      error: {
+        code: privateDetail,
+        param: "messages",
+        message: privateDetail,
+        metadata: { error_type: privateDetail, history: privateDetail },
+      },
+    },
+    expected: { errorCode: undefined, errorParam: undefined },
+  },
+  {
+    name: "malformed field types",
+    body: {
+      error: {
+        code: { value: privateDetail },
+        param: ["reasoning.effort"],
+        metadata: [],
+      },
+    },
+    expected: { errorCode: undefined, errorParam: undefined },
+  },
+  {
+    name: "oversized field values",
+    body: { error: { code: "x".repeat(4097), param: "x".repeat(4097) } },
+    expected: { errorCode: undefined, errorParam: undefined },
+  },
+  {
+    name: "malformed HTTP error JSON",
+    body: `${privateDetail}: invalid JSON`,
+    expected: { errorCode: undefined, errorParam: undefined },
+  },
+  {
+    name: "malformed provider JSON",
+    body: { error: { metadata: { raw: `{${privateDetail}` } } },
+    expected: { errorCode: undefined, errorParam: undefined },
+  },
+  {
+    name: "oversized provider JSON",
+    body: {
+      error: {
+        metadata: {
+          raw: JSON.stringify({ error: safeError, padding: "x".repeat(4097) }),
+        },
+      },
+    },
+    expected: { errorCode: undefined, errorParam: undefined },
+  },
+  {
+    name: "oversized HTTP error body",
+    body: { error: { ...safeError, message: "x".repeat(65_537) } },
+    expected: { errorCode: undefined, errorParam: undefined },
+  },
+] as const;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/openrouter-model-contract.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/openrouter-model-contract.ts
@@ -1,0 +1,29 @@
+import { HttpResponse } from "msw";
+import { z } from "zod";
+
+const modelRequestSchema = z.object({
+  model: z.string(),
+  reasoning: z.object({ effort: z.string() }).optional(),
+});
+
+/**
+ * Exact-model capability snapshot from https://openrouter.ai/api/v1/models,
+ * checked 2026-09-08: mandatory=true, supported_efforts=[high, medium, low],
+ * default_effort=medium. No catalog request is made by deterministic tests.
+ */
+export function openRouterModelContractError(
+  value: unknown,
+): Response | undefined {
+  const body = modelRequestSchema.parse(value);
+  if (
+    body.model === "google/gemini-3.8-flash" &&
+    body.reasoning !== undefined &&
+    !["high", "medium", "low"].includes(body.reasoning.effort)
+  ) {
+    return HttpResponse.json(
+      { error: { code: "unsupported_value", param: "reasoning.effort" } },
+      { status: 400 },
+    );
+  }
+  return undefined;
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/voice-io-polish.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/voice-io-polish.test.ts
@@ -10,6 +10,8 @@ import { createUniqueStaffOrgIdFixture } from "../../../test-fixtures/staff-org"
 import { createBddApi } from "./helpers/api-bdd";
 import { updateFeatureSwitchesForUser } from "./helpers/feature-switches";
 import { createRouteMocks } from "./helpers/route-test";
+import { openRouterModelContractError } from "./helpers/openrouter-model-contract";
+import { createDeferredPromise } from "../../utils";
 import { voiceIoPolishRoutes } from "../voice-io-polish";
 
 const context = testContext();
@@ -22,7 +24,163 @@ function client() {
   );
 }
 
+async function enableVoicePolish() {
+  mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+  const actor = createBddApi(context).user();
+  if (!actor.orgId) {
+    throw new Error("Voice draft tests require an organization");
+  }
+  mocks.clerk.session(actor.userId, actor.orgId, "org:admin");
+  await updateFeatureSwitchesForUser(
+    context,
+    { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
+    { [FeatureSwitchKey.VoiceInputV2]: true },
+  );
+}
+
 describe("POST /api/voice-io/polish", () => {
+  it("preserves public provider errors and rejects incomplete polish", async () => {
+    await enableVoicePolish();
+    const cases = [
+      {
+        status: 400,
+        body: {
+          error: {
+            code: "unsupported_value",
+            param: "reasoning.effort",
+            message: "private-provider-detail",
+          },
+        },
+        expectedStatus: 502,
+        code: "VOICE_POLISH_FAILED",
+      },
+      {
+        status: 429,
+        body: { error: { message: "private-provider-detail" } },
+        expectedStatus: 503,
+        code: "PROVIDER_UNAVAILABLE",
+      },
+      {
+        status: 503,
+        body: { error: { message: "private-provider-detail" } },
+        expectedStatus: 503,
+        code: "PROVIDER_UNAVAILABLE",
+      },
+      {
+        status: 200,
+        body: {
+          error: {
+            code: "invalid_request_error",
+            param: "max_tokens",
+            message: "private-provider-detail",
+          },
+        },
+        expectedStatus: 503,
+        code: "PROVIDER_UNAVAILABLE",
+      },
+      {
+        status: 200,
+        body: {
+          choices: [
+            {
+              finish_reason: "error",
+              error: {
+                code: "invalid_request_error",
+                message: "private-provider-detail",
+              },
+            },
+          ],
+        },
+        expectedStatus: 503,
+        code: "PROVIDER_UNAVAILABLE",
+      },
+      {
+        status: 200,
+        body: {
+          choices: [
+            {
+              finish_reason: "length",
+              native_finish_reason: "MAX_TOKENS",
+              message: { content: "Truncated dictation" },
+            },
+          ],
+        },
+        expectedStatus: 502,
+        code: "VOICE_POLISH_FAILED",
+      },
+      {
+        status: 200,
+        body: {
+          choices: [{ finish_reason: "stop", message: { content: " " } }],
+        },
+        expectedStatus: 502,
+        code: "VOICE_POLISH_FAILED",
+      },
+    ];
+    for (const testCase of cases) {
+      server.use(
+        http.post(OPENROUTER_URL, () => {
+          return HttpResponse.json(testCase.body, { status: testCase.status });
+        }),
+      );
+      const response = await client().post({
+        headers: { authorization: "Bearer clerk-session" },
+        body: { text: "um prepare the update" },
+      });
+      expect(response.status).toBe(testCase.expectedStatus);
+      expect(response.body).toStrictEqual({
+        error: {
+          code: testCase.code,
+          message:
+            testCase.expectedStatus === 503
+              ? "Voice draft cleanup is temporarily unavailable"
+              : "Voice draft cleanup failed to produce a usable response",
+        },
+      });
+    }
+  });
+
+  it("cancels the provider request when the client disconnects", async () => {
+    await enableVoicePolish();
+    const controller = new AbortController();
+    context.signal.addEventListener(
+      "abort",
+      () => {
+        controller.abort();
+      },
+      { once: true },
+    );
+    const entered = createDeferredPromise<void>(context.signal);
+    const aborted = createDeferredPromise<void>(context.signal);
+    server.use(
+      http.post(OPENROUTER_URL, async ({ request }) => {
+        request.signal.addEventListener(
+          "abort",
+          () => {
+            aborted.resolve();
+          },
+          { once: true },
+        );
+        entered.resolve();
+        await aborted.promise;
+        return HttpResponse.json({});
+      }),
+    );
+    const result = setupApp({
+      context,
+      routes: voiceIoPolishRoutes,
+      rethrowErrors: true,
+    })(voiceIoPolishContract).post({
+      headers: { authorization: "Bearer clerk-session" },
+      body: { text: "um prepare the update" },
+      fetchOptions: { signal: controller.signal },
+    });
+    await entered.promise;
+    controller.abort();
+    await expect(result).rejects.toMatchObject({ name: "AbortError" });
+    await aborted.promise;
+  });
+
   it("turns raw dictation into send-ready text without charging usage", async () => {
     mockOptionalEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     const actor = createBddApi(context).user({
@@ -41,6 +199,10 @@ describe("POST /api/voice-io/polish", () => {
     server.use(
       http.post(OPENROUTER_URL, async ({ request }) => {
         requestBody = await request.json();
+        const contractError = openRouterModelContractError(requestBody);
+        if (contractError) {
+          return contractError;
+        }
         return HttpResponse.json({
           choices: [
             {
@@ -71,7 +233,7 @@ describe("POST /api/voice-io/polish", () => {
       model: "google/gemini-3.8-flash",
       max_tokens: 65_536,
       temperature: 0,
-      reasoning: { effort: "none" },
+      reasoning: { effort: "low" },
       messages: [
         {
           role: "system",

--- a/turbo/apps/api/src/signals/services/chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-initial-thinking.service.ts
@@ -42,7 +42,8 @@ const log = logger("api:chat-initial-thinking");
 const INITIAL_THINKING_RUN_EVENT_ID = "thinking:initial";
 const THINKING_CONTEXT_MESSAGE_CAP = 8;
 const THINKING_CONTEXT_CHAR_CAP = 700;
-const THINKING_MAX_TOKENS = 160;
+// Gemini's completion ceiling includes reasoning as well as visible copy.
+const THINKING_MAX_TOKENS = 1024;
 const THINKING_TEXT_CHAR_CAP = 600;
 
 interface ThinkingContextMessage {
@@ -226,7 +227,7 @@ async function generateInitialThinkingText(args: {
       },
     ],
     THINKING_MAX_TOKENS,
-    { reasoning: { effort: "none" } },
+    { reasoning: { effort: "low" } },
   );
 
   return sanitizeThinkingText(text);

--- a/turbo/apps/api/src/signals/services/voice-io-polish.service.ts
+++ b/turbo/apps/api/src/signals/services/voice-io-polish.service.ts
@@ -71,7 +71,7 @@ export const polishVoiceTranscript$ = command(
           { role: "user", content: JSON.stringify(body) },
         ],
         VOICE_IO_POLISH_MAX_TOKENS,
-        { reasoning: { effort: "none" }, temperature: 0 },
+        { reasoning: { effort: "low" }, temperature: 0 },
         requestSignal,
       ),
     );


### PR DESCRIPTION
## Problem and change

Opening progress copy and voice polish sent `reasoning.effort: none` to `google/gemini-3.8-flash`. The exact model's live OpenRouter metadata, rechecked on 2026-09-08, declares mandatory reasoning and supports only `high`, `medium`, and `low`. Both callers now request `low`; `FAST_PATH_MODEL` is unchanged.

Opening copy receives a 1,024-token combined reasoning/output ceiling, following #31715's headroom precedent. This provides 864 extra tokens of headroom for a short auxiliary task, while retaining the existing short-paragraph prompt, 600-character sanitization cap, and rejection of incomplete output. It is a bounded starting ceiling, not proof of latency or truncation-free generation. Voice polish keeps its prompt, temperature 0, 65,536-token ceiling, cancellation, and public response mapping.

The shared helper retains only allowlisted error codes, parameter names, and error types, including bounded provider JSON inside OpenRouter's error envelope. Error responses remain bounded to 64 KiB and nested provider JSON to 4 KiB. Unknown values are omitted; raw bodies, messages, headers, prompts, history, and arbitrary metadata never become error properties. Unknown finish reasons and malformed-JSON errors also cannot quote provider content into logs.

## Regression evidence

- A deterministic MSW request-contract fixture pins the exact model's documented capabilities. It returns HTTP 400 for `none` or `minimal` on that model before any success response. Both affected caller success tests use it; the shared completion fixture continues to allow unrelated models.
- Route coverage checks the opening-copy budget, complete-text cap and sanitization, `length` / `MAX_TOKENS` rejection, replay deduplication and stable marker identity, queued-run eligibility, main-run completion after 400 / 429 / 503, and late-result suppression after an answer, completion, or cancellation.
- Voice route coverage preserves public provider-error and incomplete-output responses and observes provider cancellation on client disconnect.
- Diagnostic fixtures cover direct and numeric codes, bounded nested JSON and Google status, missing / malformed / oversized fields and bodies, unknown sensitive identifiers, and payload-free emitted errors.

## Caller and blast-radius review

Based on a clean checkout fetched and rebased onto `origin/main` at `fe57f9eb1df389c1e4d1e396e96f29f9114a4d90`. Full repository searches for `FAST_PATH_MODEL`, `generateText`, `OpenRouterRequestError`, and the new fixture consumers found five fast-path services (chat title including shared titles/notification/follow-ups, run summary, goal brief, opening copy, voice polish), plus image recognition / translation and the voice-transcription error consumer. Unrelated model selection, prompts, budgets, billing, and public status mappings remain unchanged.

Both initial-thinking scheduling paths still use `waitUntil` / `bestEffort`; generation eligibility and marker persistence code are unchanged. The implementation does not touch Pi, Terra routing, UI, schema, database, retry, or release code. At the latest overlap check, #32593 touches the same BDD test file; overlap is not a merge-order dependency.

## Validation

Passed locally from `turbo/`:

- Prettier for all eight changed files and `git diff --check`.
- `pnpm -F api lint` (full API lint, including typed production/test rules).
- `TSC_CHECKERS=2 pnpm -F api check-types` (all API type-check partitions and dependency declarations).
- `pnpm exec knip --workspace apps/api`.
- 38 selected tests passed (381 unrelated cases filtered out):

```sh
pnpm -F api exec vitest run src/signals/routes/__tests__/voice-io-polish.test.ts src/signals/routes/__tests__/chat-events.bdd.test.ts src/signals/routes/__tests__/goals.test.ts -t 'POST /api/voice-io/polish|CHAT-02: initial thinking indicator|CHAT-02: prior rounds and thread titles|objective brief|brief completion' --maxWorkers=1 --silent=passed-only
```

- 54 shared-helper consumer route tests passed (this group overlaps voice-polish coverage above):

```sh
pnpm -F api exec vitest run src/signals/routes/__tests__/voice-io-polish.test.ts src/signals/routes/__tests__/image-recognition.test.ts src/signals/routes/__tests__/chat-translation.test.ts src/signals/routes/__tests__/voice-io-transcribe.test.ts --maxWorkers=1 --silent=passed-only
```

- Controlled mutation: temporarily restoring `none` in both callers made both success-path tests fail (initial marker absent; voice HTTP 502 after contract HTTP 400). Both files were restored before the final passing run. The mutation selected `turns raw dictation into send-ready text|persists a fast assistant thinking marker` in the two affected test files.
- Tests used real isolated local PostgreSQL with current migrations and MSW provider boundaries. No schema or database code changed.

The PR pipeline will provide the full required CI evidence before protected-queue admission.

No full local Vitest suite or development server was run. No live-provider smoke test was performed: no existing OpenRouter test credential was available, and no additional credential access was requested. The capability snapshot and deterministic contract tests establish the incompatible request shape; they do not reproduce or explain every historical HTTP 400.

## Fallbacks

`openrouter.ts:openRouterRequestError` omits absent or untrusted optional provider diagnostics and retains the HTTP-status-only error. Surface: external provider error metadata, with no cross-version rollout window. This is a permanent data-sanitization boundary while provider diagnostics remain optional and untrusted; it does not retry generation or select another provider. It can be removed only if the external contract makes the relevant bounded, safe fields mandatory.

Closes #32114. Implementation ownership ends at protected-queue merge. Issue criteria 9–10 (independent controller acceptance, watcher retirement, designated-owner release, and production observation) remain separate.
