### PR TITLE
refactor: remove shared worker realtime feature switch

### DIFF
--- a/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
+++ b/turbo/apps/platform/src/__tests__/authentication-startup.test.tsx
@@ -2,8 +2,6 @@ import { screen } from "@testing-library/react";
 import { HttpResponse } from "msw";
 import { expect, test, vi } from "vitest";
 
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
-
 import { mockedClerk } from "./mock-auth.ts";
 import { queryAllByRoleFast, setupPage, startPage } from "./page-helper.ts";
 import frFRCommon from "../i18n/locales/fr-FR/common.json";
@@ -82,14 +80,11 @@ test("Authentication is ready before Platform content becomes interactive", asyn
   expect(queryAllByRoleFast("link").length).toBeGreaterThan(0);
 });
 
-test("The SharedWorker owns realtime when its feature switch is enabled", async () => {
+test("The SharedWorker owns realtime", async () => {
   await setupPage({
     context,
     host: "app.okou.ai",
     path: "/agents",
-    featureSwitches: {
-      [FeatureSwitchKey.SharedWorkerRealtime]: true,
-    },
     sharedWorkerTestTransport: "message-port",
   });
 

--- a/turbo/apps/platform/src/mocks/ably.ts
+++ b/turbo/apps/platform/src/mocks/ably.ts
@@ -19,6 +19,10 @@ type ChatDatabaseEventListener = (message: {
   readonly data: unknown;
 }) => void;
 type UserRealtimeEventListener = ChatDatabaseEventListener;
+type NamedRealtimeEventListener = (
+  channelName: string,
+  message: { readonly name: string; readonly data: unknown },
+) => void;
 type ChatDatabaseRecoveryListener = () => void;
 
 type AuthCallbackError = string | { message?: string } | null;
@@ -85,7 +89,9 @@ let nextSubscribeGate: {
 const realtimeInstances = new Set<Realtime>();
 const chatDatabaseEventListeners = new Set<ChatDatabaseEventListener>();
 const userRealtimeEventListeners = new Set<UserRealtimeEventListener>();
+const namedRealtimeEventListeners = new Set<NamedRealtimeEventListener>();
 const chatDatabaseRecoveryListeners = new Set<ChatDatabaseRecoveryListener>();
+const directRealtimeSubscriptions = new Map<string, Map<string, number>>();
 const subscribeErrors = new Map<
   string,
   {
@@ -553,11 +559,31 @@ export function triggerAblyChannelEvent(
   topic: string,
   data?: unknown,
 ): void {
+  const message = { name: topic, data };
+  for (const listener of namedRealtimeEventListeners) {
+    listener(channelName, message);
+  }
   for (const realtime of realtimeInstances) {
     if (realtime.connection.state === "connected") {
       realtime.getExistingChannel(channelName)?.trigger(topic, data);
     }
   }
+}
+
+/** Forward named-channel publishes to a direct worker test host. */
+export function subscribeNamedRealtimeEvents(
+  listener: NamedRealtimeEventListener,
+  signal: AbortSignal,
+): void {
+  signal.throwIfAborted();
+  namedRealtimeEventListeners.add(listener);
+  signal.addEventListener(
+    "abort",
+    () => {
+      namedRealtimeEventListeners.delete(listener);
+    },
+    { once: true },
+  );
 }
 
 /** Re-invoke the newest client's auth callback to simulate token renewal. */
@@ -740,8 +766,46 @@ export function rejectAblySubscribe(
   return observed.promise;
 }
 
-/** Debug: check if a topic has an active subscription. */
+/** Track a topic subscribed through the in-process direct worker bridge. */
+export function registerDirectRealtimeSubscription(
+  channelName: string,
+  topic: string,
+): () => void {
+  let topics = directRealtimeSubscriptions.get(channelName);
+  if (!topics) {
+    topics = new Map();
+    directRealtimeSubscriptions.set(channelName, topics);
+  }
+  topics.set(topic, (topics.get(topic) ?? 0) + 1);
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const currentTopics = directRealtimeSubscriptions.get(channelName);
+    const count = currentTopics?.get(topic);
+    if (!currentTopics || count === undefined) {
+      return;
+    }
+    if (count > 1) {
+      currentTopics.set(topic, count - 1);
+      return;
+    }
+    currentTopics.delete(topic);
+    if (currentTopics.size === 0) {
+      directRealtimeSubscriptions.delete(channelName);
+    }
+  };
+}
+
+/** Debug: check if a topic has an active transport subscription. */
 export function hasSubscription(topic: string): boolean {
+  for (const topics of directRealtimeSubscriptions.values()) {
+    if ((topics.get(topic) ?? 0) > 0) {
+      return true;
+    }
+  }
   for (const realtime of realtimeInstances) {
     for (const channel of realtime.allChannels()) {
       if (channel.hasSubscription(topic)) {
@@ -756,6 +820,9 @@ export function hasSubscriptionOnChannel(
   channelName: string,
   topic: string,
 ): boolean {
+  if ((directRealtimeSubscriptions.get(channelName)?.get(topic) ?? 0) > 0) {
+    return true;
+  }
   for (const realtime of realtimeInstances) {
     if (realtime.getExistingChannel(channelName)?.hasSubscription(topic)) {
       return true;
@@ -799,7 +866,9 @@ export function resetAblySubscriptions(): void {
   triggerAblyConnectionClosed();
   chatDatabaseEventListeners.clear();
   userRealtimeEventListeners.clear();
+  namedRealtimeEventListeners.clear();
   chatDatabaseRecoveryListeners.clear();
+  directRealtimeSubscriptions.clear();
   capturedAuthCallback = null;
   tokenBodies = [];
   nextSubscribeError = null;

--- a/turbo/apps/platform/src/shared-database/test-bridge.ts
+++ b/turbo/apps/platform/src/shared-database/test-bridge.ts
@@ -1,8 +1,10 @@
 import { command, type Store } from "ccstate";
 
 import {
+  registerDirectRealtimeSubscription,
   subscribeChatDatabaseEvents,
   subscribeChatDatabaseRecovery,
+  subscribeNamedRealtimeEvents,
   subscribeUserRealtimeEvents,
 } from "../mocks/ably.ts";
 import {
@@ -91,8 +93,31 @@ interface DirectRealtimeMessage {
 
 interface DirectRealtimeSubscription {
   readonly listener: (message: SharedDatabaseRealtimeMessage) => void;
+  readonly release: () => void;
   readonly scope: SharedDatabaseRealtimeScope;
   readonly topic: string;
+}
+
+interface DirectSharedDatabaseBridgeOptions {
+  readonly cachedChatThreadEvents?: ChatThreadEventQueryResult;
+  readonly identity: SharedDatabaseIdentity;
+}
+
+function directRealtimeChannelName(
+  identity: SharedDatabaseIdentity,
+  scope: SharedDatabaseRealtimeScope,
+): string {
+  switch (scope) {
+    case "credential": {
+      return `user-org:${identity.userId}:${identity.orgId}`;
+    }
+    case "org": {
+      return `org:${identity.orgId}`;
+    }
+    case "user": {
+      return `user:${identity.userId}`;
+    }
+  }
 }
 
 function waitForWorkerOperation<T>(
@@ -136,7 +161,7 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     private readonly events: SharedDatabaseBridgeEvents,
     private readonly workerSignal: AbortSignal,
     private readonly getToken: SharedDatabaseTokenProvider,
-    private readonly cachedChatThreadEvents?: ChatThreadEventQueryResult,
+    private readonly options: DirectSharedDatabaseBridgeOptions,
   ) {}
 
   private readonly emit = onDomEventFn(
@@ -164,6 +189,21 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
       this.events.statusChanged(event.status);
     },
   );
+
+  handleNamedRealtimeMessage(
+    channelName: string,
+    message: DirectRealtimeMessage,
+  ): void {
+    const scope = (["credential", "org", "user"] as const).find((candidate) => {
+      return (
+        directRealtimeChannelName(this.options.identity, candidate) ===
+        channelName
+      );
+    });
+    if (scope) {
+      this.handleRealtimeMessage(scope, message);
+    }
+  }
 
   handleRealtimeMessage(
     scope: SharedDatabaseRealtimeScope,
@@ -217,6 +257,16 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
       { getToken: this.getToken, port: directWorkerPort(this.emit) },
       connectionSignal,
     );
+    this.connectionSignal.addEventListener(
+      "abort",
+      () => {
+        for (const subscription of this.realtimeSubscriptions.values()) {
+          subscription.release();
+        }
+        this.realtimeSubscriptions.clear();
+      },
+      { once: true },
+    );
     const daemon = this.workerStore.set(startSharedDatabaseWorkerDaemons$);
     if (daemon) {
       detach(daemon, Reason.Daemon, "test shared database Worker");
@@ -233,11 +283,22 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     if (this.realtimeSubscriptions.has(subscriptionId)) {
       throw new Error("Shared database realtime subscription already exists");
     }
-    this.realtimeSubscriptions.set(subscriptionId, { listener, scope, topic });
+    const release = registerDirectRealtimeSubscription(
+      directRealtimeChannelName(this.options.identity, scope),
+      topic,
+    );
+    this.realtimeSubscriptions.set(subscriptionId, {
+      listener,
+      release,
+      scope,
+      topic,
+    });
     return Promise.resolve();
   }
 
   unsubscribeRealtime(subscriptionId: string): void {
+    const subscription = this.realtimeSubscriptions.get(subscriptionId);
+    subscription?.release();
     this.realtimeSubscriptions.delete(subscriptionId);
   }
 
@@ -269,11 +330,11 @@ class DirectSharedDatabaseBridge implements SharedDatabaseBridge {
     if (
       query.dataKey.kind === "chat-thread-event" &&
       query.consistency === "cache-only" &&
-      this.cachedChatThreadEvents
+      this.options.cachedChatThreadEvents
     ) {
       return parseSharedDatabaseQueryResult(
         query.dataKey,
-        structuredClone(this.cachedChatThreadEvents),
+        structuredClone(this.options.cachedChatThreadEvents),
       );
     }
     const operation = this.workerStore.set(
@@ -372,7 +433,7 @@ export const setupSharedWorkerTestBootstrap$ = command(
     let directBridge: DirectSharedDatabaseBridge | null = null;
     let directRealtimeForwardingInstalled = false;
     const host: SharedDatabaseBridgeHost = {
-      createBridge: (_identity, getToken, events, connectionSignal) => {
+      createBridge: (identity, getToken, events, connectionSignal) => {
         let bridge: SharedDatabaseBridge;
         if (options.transport === "message-port") {
           const channel = new MessageChannel();
@@ -395,6 +456,9 @@ export const setupSharedWorkerTestBootstrap$ = command(
             subscribeUserRealtimeEvents((message) => {
               directBridge?.handleRealtimeMessage("user", message);
             }, signal);
+            subscribeNamedRealtimeEvents((channelName, message) => {
+              directBridge?.handleNamedRealtimeMessage(channelName, message);
+            }, signal);
             subscribeChatDatabaseRecovery(() => {
               directBridge?.handleRealtimeRecovery();
             }, signal);
@@ -405,7 +469,10 @@ export const setupSharedWorkerTestBootstrap$ = command(
             events,
             signal,
             getToken,
-            options.cachedChatThreadEvents,
+            {
+              identity,
+              cachedChatThreadEvents: options.cachedChatThreadEvents,
+            },
           );
           bridge = directBridge;
         }

--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -1,11 +1,9 @@
-import { FeatureSwitchKey } from "@okouai/core/feature-switch-key";
 import { command } from "ccstate";
 import { toast } from "@okouai/ui/components/ui/sonner";
 import { clerk$, setupClerk$ } from "./auth.ts";
 import { setAuthenticatedIdentity$ } from "./auth-context.ts";
 import { subscribeEventDrivenChatThreads$ } from "./chat-page/chat-thread-event-sourcing.ts";
 import { setupUserPreferenceRealtime$ } from "./external/user-model-preference.ts";
-import { featureSwitch$ } from "./external/feature-switch.ts";
 import { subscribePermissionUpdate$ } from "./permission-allow/permission-allow-signals.ts";
 import {
   setRealtimeDegradedNotifier$,
@@ -23,11 +21,9 @@ import {
 
 const runAppRealtimeDaemons$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    if (get(featureSwitch$)[FeatureSwitchKey.SharedWorkerRealtime] ?? false) {
-      await get(bridgeConnected$);
-      signal.throwIfAborted();
-      set(setSharedWorkerRealtimeBridge$, get(installedSharedDatabaseBridge$));
-    }
+    await get(bridgeConnected$);
+    signal.throwIfAborted();
+    set(setSharedWorkerRealtimeBridge$, get(installedSharedDatabaseBridge$));
     await set(setupRealtime$, signal);
     signal.throwIfAborted();
     await Promise.all([

--- a/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
+++ b/turbo/apps/platform/src/views/okou-page/__tests__/connectors-accounts.test.tsx
@@ -747,7 +747,11 @@ test("Reconnect the selected non-default account", async () => {
   });
   let authWindow = createAuthWindow();
   context.mocks.browser.open(authWindow);
-  await setupAccountsPage();
+  await setupPage({
+    context,
+    path: "/connectors",
+    sharedWorkerTestTransport: "message-port",
+  });
   click(
     await waitFor(() => {
       return getConnectorAction("button", "Manage Stripe accounts");

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -3830,7 +3830,12 @@ function mockCalendarReconnect(
   return {
     submittedAccounts,
     open: async () => {
-      await setupWorkflowDetailPage(workflowDetailPath("automations"));
+      mockBillingTier("team");
+      await setupPage({
+        context,
+        path: workflowDetailPath("automations"),
+        sharedWorkerTestTransport: "message-port",
+      });
 
       const warning = await screen.findByRole("alert");
       expect(warning).toHaveTextContent(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -22,7 +22,6 @@ describe("FeatureSwitchKey", () => {
     expect(FeatureSwitchKey.CodexFastMode).toBe("_fastModel");
     expect(FeatureSwitchKey.ChatPreference).toBe("chatPreference");
     expect(FeatureSwitchKey.OkouDebug).toBe("_debug");
-    expect(FeatureSwitchKey.SharedWorkerRealtime).toBe("sharedWorkerRealtime");
     expect(FeatureSwitchKey.RealAgentInPreview).toBe("_realAgentInPreview");
     expect(FeatureSwitchKey.TestOauthConnector).toBe("_testOauthConnector");
     expect(FeatureSwitchKey.SshAccess).toBe("_sshAccess");
@@ -51,9 +50,6 @@ describe("isFeatureEnabled", () => {
   it("should return false for disabled switch without context", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {})).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.SshAccess, {})).toBe(false);
-    expect(isFeatureEnabled(FeatureSwitchKey.SharedWorkerRealtime, {})).toBe(
-      false,
-    );
     expect(getFeatureSwitchMetadata()[FeatureSwitchKey.SshAccess]).toEqual({
       maintainer: "ethan@okou.ai",
       description: "Enable standalone Runner-mediated SSH configuration",
@@ -199,7 +195,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ChatThinkingSpinner]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PiLoop]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatPreference]).toBe(true);
-    expect(staffOrgStates[FeatureSwitchKey.SharedWorkerRealtime]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.CustomConnectorMcp]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.PersonalModelProviderAccounts]).toBe(
       true,
@@ -226,7 +221,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ChatThinkingSpinner]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PiLoop]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatPreference]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.SharedWorkerRealtime]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.CustomConnectorMcp]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.PersonalModelProviderAccounts]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -33,7 +33,6 @@ export enum FeatureSwitchKey {
   SpotifyConnector = "spotifyConnector",
   StripeMarketplaceOAuthConnector = "stripeMarketplaceOAuthConnector",
   OkouDebug = "_debug",
-  SharedWorkerRealtime = "sharedWorkerRealtime",
   Banking = "banking",
   SlackRead = "slackRead",
   Lab = "_lab",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -198,13 +198,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Reveal activity debug surfaces, activity log navigation, appended system prompts, realtime connection diagnostics, and Debug preferences",
     enabled: false,
   },
-  [FeatureSwitchKey.SharedWorkerRealtime]: {
-    maintainer: "ethan@okou.ai",
-    description:
-      "Route application realtime subscriptions through the SharedWorker",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.Banking]: {
     maintainer: "linghan@okou.ai",
     description:


### PR DESCRIPTION
## Summary

- permanently route authenticated App realtime subscriptions through the existing SharedWorker bridge
- remove the `SharedWorkerRealtime` registry entry, enum key, runtime switch read, and staff/non-staff rollout matrix
- keep the positive Platform startup coverage without a feature-switch override

## Terminal state

- **Decision:** `fully-rolled-out`
- **Basis:** Ethan explicitly requested full rollout and cleanup in this thread on 2026-09-08.
- **Base:** `main` at `31c98f1feb32cd19c975467d6943c9532813fc52`.

## Archaeology and behavior comparison

- **Introducing commit:** `02b87392dba2e9d2c61ad34734ad3f091110d461` (`feat(platform): route app realtime through shared worker`, PR #32366).
- Its parent, `dd0454e8707ecb068cf839c76d04c315427d6783`, started App realtime directly through `setupRealtime$`, which constructed an App-owned Ably client and channels.
- The enabled branch waits for the installed shared-database bridge, installs that bridge as the App realtime transport, and then starts the existing page/root subscriptions through the Worker protocol. The page-local handlers, topic allowlist, ACK timing, subscription ownership, reconnect catch-up, and cancellation behavior are shared retained logic.
- `6e78edfc9b510bbc3e47d0c0dd509b71aebdded1` (PR #32403) later changed the serialized key to `sharedWorkerRealtime` and enabled it only for the staff organization; it did not alter the transport behavior.
- This PR permanently retains the enabled branch. The App now always installs the bridge before `setupRealtime$`; the discarded behavior is the feature-off App-owned Ably transport.
- `connectRealtimeClient$` and its session/channel machinery remain because the SharedWorker runs `setupRealtime$` in its own Store and owns that Ably client. They are no longer an App rollout fallback.

## Search sweep and test cleanup

- Searched exact/case/kebab/snake identifiers and rollout wording: `FeatureSwitchKey.SharedWorkerRealtime`, `SharedWorkerRealtime`, `sharedWorkerRealtime`, `_sharedWorkerRealtime`, `shared-worker-realtime`, `shared_worker_realtime`, and the enabled-test wording.
- No live key, serialized value, registry entry, switch read, override, staff/non-staff matrix assertion, or rollout wording remains.
- `SharedWorkerRealtimeChannel`, `sharedWorkerRealtimeBridgeState$`, `worker-realtime-subscriptions`, `realtime-subscribe`, and `notifySharedWorkerRealtimeReconnected$` remain as the permanent transport implementation and positive coverage.
- Rewrote the authentication startup test to exercise SharedWorker ownership without an override. Removed only the Core assertions that existed for the retired key and rollout states; protocol and transport tests remain unchanged.

## Validation

- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --maxWorkers=1 --silent=passed-only` (31 passed)
- `VITE_AXIOM_CLIENT_TELEMETRY_TOKEN='' pnpm -F @okouai/app exec vitest run src/__tests__/authentication-startup.test.tsx --maxWorkers=1 --silent=passed-only` (12 passed)
- `VITE_AXIOM_CLIENT_TELEMETRY_TOKEN='' pnpm -F @okouai/app exec vitest run src/__tests__/authentication-startup.test.tsx src/signals/__tests__/realtime.test.ts src/shared-database/__tests__/message-port.test.ts --maxWorkers=1 --silent=passed-only` (3 test files passed)
- `TSC_CHECKERS=1 pnpm --filter @okouai/core --filter @okouai/app --workspace-concurrency=1 run check-types`
- `GOMAXPROCS=1 NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter @okouai/core --filter @okouai/app --workspace-concurrency=1 run lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm exec knip --workspace @okouai/core --workspace @okouai/app --isolate-workspaces`
- Production App/SharedWorker build passed with non-secret local Clerk placeholder values and no Sentry upload token: `pnpm -F @okouai/app build`.
- Targeted Prettier and `git diff --check` passed.

No local dev server or full-repository Vitest run was started; broad suites and browser E2E remain with the PR pipeline.

## Fallbacks

None introduced. This PR removes the feature-off App realtime fallback.
