### PR TITLE
perf(python): bound raw websocket handshake header inspection

### DIFF
--- a/crates/runner/mitm-addon/src/http_header_syntax.py
+++ b/crates/runner/mitm-addon/src/http_header_syntax.py
@@ -11,7 +11,8 @@ _HTTP_TOKEN_CHARS: frozenset[str] = frozenset(
 )
 _ASCII_CONTROL_MAX = 0x1F
 _ASCII_DELETE = 0x7F
-_HTTP_OWS_CHARS = " \t"
+_HTTP_OWS_BYTES = b" \t"
+_HTTP_LIST_DELIMITER = ord(",")
 
 
 def is_http_header_name(value: str) -> bool:
@@ -40,28 +41,32 @@ def has_forbidden_header_value_control(value: str) -> bool:
     )
 
 
-def header_values_contain_token(
-    values: Sequence[str],
-    expected: str,
+def header_fields_contain_token(
+    fields: Sequence[tuple[bytes, bytes]],
+    name: bytes,
+    expected: bytes,
     *,
     max_work_units: int,
 ) -> bool:
-    """Return whether any field value contains ``expected`` as a list token.
+    """Return whether a raw ``name`` field contains ``expected`` as a list token.
 
-    Matching consumes one work unit per field value and one per inspected
-    character. It stops at ``max_work_units`` and fails closed without scanning
-    the remaining input. A complete early match returns before an irrelevant
-    suffix. Only HTTP OWS (SP and HTAB) is ignored at token edges, and comparison
-    is ASCII case-insensitive. Callers must provide ``expected`` in lowercase
-    ASCII and choose a work limit for their trust boundary.
+    Matching consumes one work unit per visited field and one per inspected
+    matching-value byte, without decoding values. It stops at ``max_work_units``
+    and fails closed without scanning remaining fields or bytes. A complete early
+    match returns before an irrelevant suffix. Only HTTP OWS (SP and HTAB) is
+    ignored at token edges, and comparison is ASCII case-insensitive. Callers
+    provide lowercase ASCII ``name`` and ``expected`` and a trust-boundary limit.
     """
     expected_upper = expected.upper()
     work_units = 0
 
-    for value in values:
+    for field_index in range(len(fields)):
         if work_units >= max_work_units:
             return False
+        raw_name, value = fields[field_index]
         work_units += 1
+        if len(raw_name) != len(name) or raw_name.lower() != name:
+            continue
         token_matches = True
         matched_chars = 0
 
@@ -73,7 +78,7 @@ def header_values_contain_token(
             value_index += 1
             work_units += 1
 
-            if char == ",":
+            if char == _HTTP_LIST_DELIMITER:
                 if token_matches and matched_chars == len(expected):
                     return True
                 token_matches = True
@@ -82,10 +87,10 @@ def header_values_contain_token(
 
             if not token_matches:
                 continue
-            if matched_chars == 0 and char in _HTTP_OWS_CHARS:
+            if matched_chars == 0 and char in _HTTP_OWS_BYTES:
                 continue
             if matched_chars == len(expected):
-                if char not in _HTTP_OWS_CHARS:
+                if char not in _HTTP_OWS_BYTES:
                     token_matches = False
                 continue
             expected_char = expected[matched_chars]
@@ -101,22 +106,30 @@ def header_values_contain_token(
 
 
 def single_header_value(
-    values: Sequence[str],
+    fields: Sequence[tuple[bytes, bytes]],
+    name: bytes,
     *,
-    max_value_chars: int,
-) -> str | None:
-    """Return one header value with HTTP OWS stripped, or ``None`` if not singleton.
+    max_fields: int,
+    max_value_bytes: int,
+) -> bytes | None:
+    """Return one bounded raw value with SP/HTAB stripped, or ``None``.
 
-    ``None`` represents missing or repeated field values: ``values`` must contain
-    exactly one item. Values above ``max_value_chars`` are rejected before
-    stripping, which bounds the possible copy. Only SP and HTAB are stripped
-    from the item, so a blank singleton returns an empty string and other
-    whitespace is preserved. Callers remain responsible for validating the
-    returned value's content.
+    Reject excess field count, missing/repeated ``name`` fields, and values above
+    ``max_value_bytes`` before stripping or decoding anything. Check cardinality
+    across the complete bounded field tuple before copying a singleton. Only SP
+    and HTAB are stripped, so a blank singleton returns empty bytes and other
+    whitespace is preserved. Callers provide lowercase ASCII ``name`` and remain
+    responsible for content validation.
     """
-    if len(values) != 1:
+    if len(fields) > max_fields:
         return None
-    value = values[0]
-    if len(value) > max_value_chars:
+    value: bytes | None = None
+    for raw_name, raw_value in fields:
+        if len(raw_name) != len(name) or raw_name.lower() != name:
+            continue
+        if value is not None or len(raw_value) > max_value_bytes:
+            return None
+        value = raw_value
+    if value is None:
         return None
-    return value.strip(_HTTP_OWS_CHARS)
+    return value.strip(_HTTP_OWS_BYTES)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -155,7 +155,7 @@ _STALE_FIREWALL_AUTHORIZATION_METADATA_KEYS = (
 _AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD"))
 _HTTP_RESPONSE_BODYLESS_METHODS = frozenset(("CONNECT", "HEAD"))
 _WEBSOCKET_KEY_BYTES = 16
-_WEBSOCKET_KEY_BASE64_CHARS = 24
+_WEBSOCKET_KEY_BASE64_BYTES = 24
 _WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT = 8 * 1024
 _BufferedRequestBodyCheckKind = Literal["ok", "too_large", "length_required"]
 
@@ -1550,38 +1550,44 @@ def _is_websocket_upgrade_request(flow: http.HTTPFlow) -> bool:
         return False
     if flow.request.http_version != "HTTP/1.1":
         return False
-    if not http_header_syntax.header_values_contain_token(
-        flow.request.headers.get_all("Upgrade"),
-        "websocket",
+    if not http_header_syntax.header_fields_contain_token(
+        flow.request.headers.fields,
+        b"upgrade",
+        b"websocket",
         max_work_units=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
     ):
         return False
     websocket_key = http_header_syntax.single_header_value(
-        flow.request.headers.get_all("Sec-WebSocket-Key"),
-        max_value_chars=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
+        flow.request.headers.fields,
+        b"sec-websocket-key",
+        max_fields=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
+        max_value_bytes=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
     )
     if websocket_key is None or not _is_valid_websocket_key(websocket_key):
         return False
     websocket_version = http_header_syntax.single_header_value(
-        flow.request.headers.get_all("Sec-WebSocket-Version"),
-        max_value_chars=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
+        flow.request.headers.fields,
+        b"sec-websocket-version",
+        max_fields=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
+        max_value_bytes=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
     )
-    if websocket_version != "13":
+    if websocket_version != b"13":
         return False
 
-    return http_header_syntax.header_values_contain_token(
-        flow.request.headers.get_all("Connection"),
-        "upgrade",
+    return http_header_syntax.header_fields_contain_token(
+        flow.request.headers.fields,
+        b"connection",
+        b"upgrade",
         max_work_units=_WEBSOCKET_HANDSHAKE_HEADER_WORK_LIMIT,
     )
 
 
-def _is_valid_websocket_key(value: str) -> bool:
-    if len(value) != _WEBSOCKET_KEY_BASE64_CHARS:
+def _is_valid_websocket_key(value: bytes) -> bool:
+    if len(value) != _WEBSOCKET_KEY_BASE64_BYTES:
         return False
     try:
         decoded = base64.b64decode(value, validate=True)
-    except (binascii.Error, ValueError):
+    except binascii.Error:
         return False
     return len(decoded) == _WEBSOCKET_KEY_BYTES
 

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -39,8 +39,8 @@ _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
 _HTTP_STATUS_OK_MIN = 200
 _HTTP_STATUS_REDIRECT_MIN = 300
 _HTTP_STATUS_BAD_GATEWAY = 502
-_WEBSOCKET_KEY_BASE64_CHARS = 24
-_WEBSOCKET_ACCEPT_BASE64_CHARS = 28
+_WEBSOCKET_KEY_BASE64_BYTES = 24
+_WEBSOCKET_ACCEPT_BASE64_BYTES = 28
 
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
@@ -514,38 +514,42 @@ def is_confirmed_websocket_upgrade_response(
         return False
     if flow.metadata.get(metadata_keys.WEBSOCKET_UPGRADE_REQUEST) is not True:
         return False
-    if not http_header_syntax.header_values_contain_token(
-        response.headers.get_all("Upgrade"),
-        "websocket",
+    if not http_header_syntax.header_fields_contain_token(
+        response.headers.fields,
+        b"upgrade",
+        b"websocket",
         max_work_units=websocket_header_work_limit,
     ):
         return False
-    if not http_header_syntax.header_values_contain_token(
-        response.headers.get_all("Connection"),
-        "upgrade",
+    if not http_header_syntax.header_fields_contain_token(
+        response.headers.fields,
+        b"connection",
+        b"upgrade",
         max_work_units=websocket_header_work_limit,
     ):
         return False
 
     request_key = http_header_syntax.single_header_value(
-        flow.request.headers.get_all("Sec-WebSocket-Key"),
-        max_value_chars=websocket_header_work_limit,
+        flow.request.headers.fields,
+        b"sec-websocket-key",
+        max_fields=websocket_header_work_limit,
+        max_value_bytes=websocket_header_work_limit,
     )
     response_accept = http_header_syntax.single_header_value(
-        response.headers.get_all("Sec-WebSocket-Accept"),
-        max_value_chars=websocket_header_work_limit,
+        response.headers.fields,
+        b"sec-websocket-accept",
+        max_fields=websocket_header_work_limit,
+        max_value_bytes=websocket_header_work_limit,
     )
     if (
         request_key is None
-        or len(request_key) != _WEBSOCKET_KEY_BASE64_CHARS
+        or len(request_key) != _WEBSOCKET_KEY_BASE64_BYTES
+        or not request_key.isascii()
         or response_accept is None
-        or len(response_accept) != _WEBSOCKET_ACCEPT_BASE64_CHARS
+        or len(response_accept) != _WEBSOCKET_ACCEPT_BASE64_BYTES
     ):
         return False
-    try:
-        expected_accept = generate_accept_token(request_key.encode("ascii")).decode("ascii")
-    except UnicodeEncodeError:
-        return False
+    expected_accept = generate_accept_token(request_key)
     return response_accept == expected_accept
 
 

--- a/crates/runner/mitm-addon/tests/test_http_header_syntax.py
+++ b/crates/runner/mitm-addon/tests/test_http_header_syntax.py
@@ -5,7 +5,11 @@ the header-value control-character rule using an independent reference, so a
 regression in the shared predicates fails the suite.
 """
 
+from collections.abc import Sequence
+from typing import SupportsIndex, overload
+
 import pytest
+from mitmproxy import http
 
 import http_header_syntax
 
@@ -16,29 +20,60 @@ _ASCII_CODE_POINTS = range(128)
 _TEST_HEADER_WORK_LIMIT = 256
 
 
-class _FullValueOperationGuard(str):
-    def split(self, sep: str | None = None, maxsplit: int = -1) -> list[str]:
-        raise AssertionError(f"guarded header was split with sep={sep!r}, maxsplit={maxsplit}")
+class _FullValueOperationGuard(bytes):
+    def __bytes__(self) -> bytes:
+        raise AssertionError("guarded header was copied")
 
-    def lower(self) -> str:
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("guarded header was decoded")
+
+    def split(self, sep: bytes | None = None, maxsplit: int = -1) -> list[bytes]:
+        raise AssertionError("guarded header was split")
+
+    def lower(self) -> bytes:
         raise AssertionError("guarded header was lowercased")
 
-    def strip(self, chars: str | None = None) -> str:
+    def strip(self, chars: bytes | None = None) -> bytes:
         raise AssertionError(f"guarded header was stripped with chars={chars!r}")
 
 
-class _EarlyMatchSuffixGuard(_FullValueOperationGuard):
-    def __getitem__(self, key: int | slice) -> str:
-        if isinstance(key, int) and key >= len("websocket,"):
-            raise IndexError("token matcher inspected the irrelevant suffix")
+class _ByteReadGuard(_FullValueOperationGuard):
+    read_limit = 8
+
+    @overload
+    def __getitem__(self, key: SupportsIndex) -> int: ...
+
+    @overload
+    def __getitem__(self, key: slice) -> bytes: ...
+
+    def __getitem__(self, key: SupportsIndex | slice) -> int | bytes:
+        if isinstance(key, slice) or key.__index__() >= self.read_limit:
+            raise AssertionError("token matcher accessed bytes beyond its inspection limit")
         return super().__getitem__(key)
 
 
-class _WorkLimitGuard(_FullValueOperationGuard):
-    def __getitem__(self, key: int | slice) -> str:
-        if isinstance(key, int) and key >= 8:
-            raise IndexError("token matcher read beyond its work budget")
-        return super().__getitem__(key)
+class _EarlyMatchSuffixGuard(_ByteReadGuard):
+    read_limit = len(b"websocket,")
+
+
+class _FieldReadGuard(Sequence[tuple[bytes, bytes]]):
+    def __init__(self, fields: tuple[tuple[bytes, bytes], ...], read_limit: int) -> None:
+        self.fields = fields
+        self.read_limit = read_limit
+
+    def __len__(self) -> int:
+        return len(self.fields)
+
+    @overload
+    def __getitem__(self, key: int) -> tuple[bytes, bytes]: ...
+
+    @overload
+    def __getitem__(self, key: slice) -> Sequence[tuple[bytes, bytes]]: ...
+
+    def __getitem__(self, key: int | slice) -> tuple[bytes, bytes] | Sequence[tuple[bytes, bytes]]:
+        if isinstance(key, slice) or key >= self.read_limit:
+            raise AssertionError("header lookup accessed fields beyond its inspection limit")
+        return self.fields[key]
 
 
 def _is_forbidden_value_control(char: str) -> bool:
@@ -148,39 +183,93 @@ def test_has_forbidden_header_value_control_accepts_non_ascii_value() -> None:
         pytest.param(("upgraded",), "upgrade", False, id="nonmatching-token"),
     ],
 )
-def test_header_values_contain_token(
+def test_header_fields_contain_token(
     values: tuple[str, ...],
     expected_token: str,
     *,
     contains_token: bool,
 ) -> None:
+    headers = http.Headers([(b"UpGrAdE", value.encode()) for value in values])
     assert (
-        http_header_syntax.header_values_contain_token(
-            values,
-            expected_token,
+        http_header_syntax.header_fields_contain_token(
+            headers.fields,
+            b"upgrade",
+            expected_token.encode(),
             max_work_units=_TEST_HEADER_WORK_LIMIT,
         )
         is contains_token
     )
 
 
-def test_header_values_contain_token_stops_before_matched_suffix() -> None:
-    value = _EarlyMatchSuffixGuard("websocket," + "x" * 10_000)
+def test_header_fields_contain_token_stops_before_matched_suffix_and_later_fields() -> None:
+    value = _EarlyMatchSuffixGuard(b"websocket," + b"\xff" * 10_000)
+    headers = http.Headers([(b"Upgrade", value), (b"Upgrade", b"unvisited")])
+    fields = _FieldReadGuard(headers.fields, read_limit=1)
 
-    assert http_header_syntax.header_values_contain_token(
-        (value,),
-        "websocket",
+    assert http_header_syntax.header_fields_contain_token(
+        fields,
+        b"upgrade",
+        b"websocket",
         max_work_units=_TEST_HEADER_WORK_LIMIT,
     )
 
 
-def test_header_values_contain_token_stops_at_work_limit() -> None:
-    value = _WorkLimitGuard("x" * 10_000)
+def test_header_fields_contain_token_stops_at_byte_work_limit() -> None:
+    value = _ByteReadGuard(b"\xff" * 10_000)
+    headers = http.Headers([(b"Upgrade", value)])
 
-    assert not http_header_syntax.header_values_contain_token(
-        (value,),
-        "websocket",
+    assert not http_header_syntax.header_fields_contain_token(
+        headers.fields,
+        b"upgrade",
+        b"websocket",
         max_work_units=9,
+    )
+
+
+@pytest.mark.parametrize("name", [b"upgrade", b"unrelated"])
+def test_header_fields_contain_token_bounds_empty_and_unrelated_fields(name: bytes) -> None:
+    fields = _FieldReadGuard(((name, b""),) * 10_000, read_limit=8)
+
+    assert not http_header_syntax.header_fields_contain_token(
+        fields, b"upgrade", b"websocket", max_work_units=8
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "work_limit", "contains_token"),
+    [
+        (b"websocket", 9, False),
+        (b"websocket", 10, True),
+        (b"websocketx", 10, False),
+        (b"websocket,ignored", 10, False),
+        (b"websocket,ignored", 11, True),
+        (b"\tWebSoCkEt \t", 13, True),
+    ],
+)
+def test_header_fields_contain_token_requires_complete_token_within_budget(
+    value: bytes, work_limit: int, *, contains_token: bool
+) -> None:
+    assert (
+        http_header_syntax.header_fields_contain_token(
+            ((b"upgrade", value),), b"upgrade", b"websocket", max_work_units=work_limit
+        )
+        is contains_token
+    )
+
+
+def test_raw_header_lookup_does_not_lowercase_oversized_unrelated_names() -> None:
+    headers = http.Headers(
+        [(_FullValueOperationGuard(b"x" * 10_000), b"ignored"), (b"Upgrade", b"websocket")]
+    )
+
+    assert http_header_syntax.header_fields_contain_token(
+        headers.fields, b"upgrade", b"websocket", max_work_units=_TEST_HEADER_WORK_LIMIT
+    )
+    assert (
+        http_header_syntax.single_header_value(
+            headers.fields, b"upgrade", max_fields=2, max_value_bytes=9
+        )
+        == b"websocket"
     )
 
 
@@ -206,16 +295,60 @@ def test_single_header_value(
     values: tuple[str, ...],
     expected_value: str | None,
 ) -> None:
-    assert (
-        http_header_syntax.single_header_value(
-            values,
-            max_value_chars=_TEST_HEADER_WORK_LIMIT,
-        )
-        == expected_value
-    )
+    headers = http.Headers([(b"SeC-WebSocket-Key", value.encode()) for value in values])
+    assert http_header_syntax.single_header_value(
+        headers.fields,
+        b"sec-websocket-key",
+        max_fields=_TEST_HEADER_WORK_LIMIT,
+        max_value_bytes=_TEST_HEADER_WORK_LIMIT,
+    ) == (None if expected_value is None else expected_value.encode())
 
 
 def test_single_header_value_rejects_oversized_value_before_strip() -> None:
-    value = _FullValueOperationGuard("  value  ")
+    value = _FullValueOperationGuard(b"\xff" * 10_000)
+    headers = http.Headers([(b"Sec-WebSocket-Key", value)])
 
-    assert http_header_syntax.single_header_value((value,), max_value_chars=8) is None
+    assert (
+        http_header_syntax.single_header_value(
+            headers.fields, b"sec-websocket-key", max_fields=1, max_value_bytes=8
+        )
+        is None
+    )
+
+
+def test_single_header_value_rejects_duplicates_before_strip() -> None:
+    headers = http.Headers(
+        [
+            (b"Sec-WebSocket-Key", _FullValueOperationGuard(b"  value  ")),
+            (b"Unrelated", b"ignored"),
+            (b"sec-websocket-key", _FullValueOperationGuard(b"")),
+        ]
+    )
+
+    assert (
+        http_header_syntax.single_header_value(
+            headers.fields, b"sec-websocket-key", max_fields=3, max_value_bytes=9
+        )
+        is None
+    )
+
+
+def test_single_header_value_rejects_unverified_cardinality_before_traversal() -> None:
+    fields = _FieldReadGuard(((b"key", b"value"),) * 10_000, read_limit=0)
+
+    assert (
+        http_header_syntax.single_header_value(fields, b"key", max_fields=8, max_value_bytes=8)
+        is None
+    )
+
+
+def test_single_header_value_accepts_inclusive_field_and_value_limits() -> None:
+    assert (
+        http_header_syntax.single_header_value(
+            ((b"unrelated", b""), (b"key", b" value \t")),
+            b"key",
+            max_fields=2,
+            max_value_bytes=8,
+        )
+        == b"value"
+    )

--- a/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_header_budget.py
+++ b/crates/runner/mitm-addon/tests/test_mitmproxy_websocket_header_budget.py
@@ -1,0 +1,120 @@
+"""Raw WebSocket header budgets through mitmproxy's HTTP/1 request hooks."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from mitmproxy import http
+from mitmproxy.addons.proxyserver import Proxyserver
+from mitmproxy.proxy import events
+from mitmproxy.proxy.layers.http._hooks import HttpRequestHeadersHook, HttpRequestHook
+from mitmproxy.test import taddons
+
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+from tests.mitmproxy_http_framing_helpers import start_http_layer
+from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
+
+_WORK_LIMIT = 8 * 1024
+_LARGE_VALUE = b"\xff" * (1024 * 1024)
+_KEY = b"dGhlIHNhbXBsZSBub25jZQ=="
+
+
+@pytest.mark.parametrize(
+    ("header_name", "values", "is_upgrade"),
+    [
+        pytest.param(b"Sec-WebSocket-Key", (_LARGE_VALUE,), False, id="oversized-key"),
+        pytest.param(b"Sec-WebSocket-Version", (_LARGE_VALUE,), False, id="oversized-version"),
+        pytest.param(b"Sec-WebSocket-Key", (_KEY, _LARGE_VALUE), False, id="duplicate-key"),
+        pytest.param(
+            b"Sec-WebSocket-Version", (b"13", _LARGE_VALUE), False, id="duplicate-version"
+        ),
+        pytest.param(
+            b"Upgrade", (b"websocket," + _LARGE_VALUE, _LARGE_VALUE), True, id="early-upgrade"
+        ),
+        pytest.param(
+            b"Connection", (b"Upgrade," + _LARGE_VALUE, _LARGE_VALUE), True, id="early-connection"
+        ),
+        pytest.param(b"Upgrade", (_LARGE_VALUE + b",websocket",), False, id="late-upgrade"),
+        pytest.param(b"Connection", (_LARGE_VALUE + b",upgrade",), False, id="late-connection"),
+    ],
+)
+async def test_http1_handshake_classification_bounds_raw_value_conversion(
+    tmp_path: Path,
+    fake_firewall_headers,
+    header_name: bytes,
+    values: tuple[bytes, ...],
+    *,
+    is_upgrade: bool,
+) -> None:
+    firewall_name = "model-provider:openai-api-key"
+    registry_path = _write_registry(
+        tmp_path,
+        sandbox_info=_single_firewall_sandbox(
+            tmp_path,
+            firewall_name=firewall_name,
+            api_entry={
+                "base": "https://api.openai.com/v1/responses",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [],
+            },
+            network_policy={"allow": [], "deny": [], "ask": [], "unknownPolicy": "allow"},
+            billable_firewalls=[firewall_name],
+            sandbox_fields={"modelUsageProvider": "gpt-5.5"},
+        ),
+    )
+    fields = [
+        (b"Host", b"api.openai.com"),
+        (b"Upgrade", b"websocket"),
+        (b"Connection", b"upgrade"),
+        (b"Sec-WebSocket-Key", _KEY),
+        (b"Sec-WebSocket-Version", b"13"),
+        (b"Accept-Encoding", b"br"),
+    ]
+    fields = [(name, value) for name, value in fields if name != header_name]
+    fields.extend((header_name, value) for value in values)
+    wire = (
+        b"GET https://api.openai.com/v1/responses HTTP/1.1\r\n"
+        + b"\r\n".join(name + b": " + value for name, value in fields)
+        + b"\r\n\r\n"
+    )
+    real_native = http._native
+
+    def reject_oversized_conversion(value: bytes) -> str:
+        assert len(value) <= _WORK_LIMIT, "hook decoded an oversized raw handshake field"
+        return real_native(value)
+
+    with (
+        patch.object(mitm_addon, "__file__", str(tmp_path / "mitm_addon.py")),
+        taddons.context(Proxyserver(), mitm_addon) as addon_context,
+        fake_firewall_headers(headers={"Authorization": "Bearer managed-secret"}),
+    ):
+        addon_context.options.update(
+            vm0_api_url="https://api.vm0.ai", vm0_proxy_registry_path=str(registry_path)
+        )
+        client, http_layer = start_http_layer(
+            addon_context, alpn=b"http/1.1", host="api.openai.com"
+        )
+        initial_commands = list(http_layer.handle_event(events.DataReceived(client, wire)))
+        headers_hook = next(
+            command for command in initial_commands if isinstance(command, HttpRequestHeadersHook)
+        )
+        with patch.object(http, "_native", reject_oversized_conversion):
+            await addon_context.master.addons.invoke_addon(mitm_addon, headers_hook)
+
+        header_commands = list(http_layer.handle_event(events.HookCompleted(headers_hook, None)))
+        request_hook = next(
+            command for command in header_commands if isinstance(command, HttpRequestHook)
+        )
+        with patch.object(http, "_native", reject_oversized_conversion):
+            await addon_context.master.addons.invoke_addon(mitm_addon, request_hook)
+
+    flow = request_hook.flow
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.request.headers["Authorization"] == "Bearer managed-secret"
+    assert bool(flow.metadata.get(metadata_keys.WEBSOCKET_UPGRADE_REQUEST)) is is_upgrade
+    assert (metadata_keys.RESPONSE_ENCODING_NEGOTIATION not in flow.metadata) is is_upgrade
+    assert (
+        tuple(value for name, value in flow.request.headers.fields if name == header_name) == values
+    )

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_lifecycle.py
@@ -7,7 +7,9 @@ import pytest
 from mitmproxy import http
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
+from wsproto.utilities import generate_accept_token
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
 from tests.model_provider_flow_helpers import (
@@ -17,6 +19,16 @@ from tests.model_provider_flow_helpers import (
 from tests.model_provider_websocket_helpers import feed_websocket_server_message
 from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import _single_firewall_sandbox, _write_registry
+
+
+class _RawValueDecodeGuard(bytes):
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        raise AssertionError("raw WebSocket value must not be decoded by lifecycle hooks")
+
+
+_LARGE_RAW_VALUE = _RawValueDecodeGuard(b"\xff" * (1024 * 1024))
+_WEBSOCKET_KEY = b"dGhlIHNhbXBsZSBub25jZQ=="
+_WEBSOCKET_ACCEPT = b"s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
 
 
 def _write_openai_model_websocket_registry(tmp_path: Path) -> Path:
@@ -63,6 +75,31 @@ class TestModelProviderWebSocketLifecycle:
                     connection="Upgrade," + "x" * 10_000,
                 ),
                 id="connection-token-before-oversized-suffix",
+            ),
+            pytest.param(
+                http.Headers(
+                    [
+                        (b"Upgrade", _RawValueDecodeGuard(b"websocket," + _LARGE_RAW_VALUE)),
+                        (b"Upgrade", _LARGE_RAW_VALUE),
+                        (b"Connection", _RawValueDecodeGuard(b"Upgrade," + _LARGE_RAW_VALUE)),
+                        (b"Connection", _LARGE_RAW_VALUE),
+                        (b"Sec-WebSocket-Accept", _WEBSOCKET_ACCEPT),
+                    ]
+                ),
+                id="raw-early-tokens-ignore-suffixes-and-later-values",
+            ),
+            pytest.param(
+                http.Headers(
+                    [
+                        (b"Upgrade", b"websocket"),
+                        (b"Connection", b"upgrade"),
+                        (
+                            b"Sec-WebSocket-Accept",
+                            _RawValueDecodeGuard(b" " * (8 * 1024 - 28) + _WEBSOCKET_ACCEPT),
+                        ),
+                    ]
+                ),
+                id="accept-at-inclusive-raw-byte-limit",
             ),
         ],
     )
@@ -222,6 +259,47 @@ class TestModelProviderWebSocketLifecycle:
                 make_openai_responses_websocket_response_headers(accept="x" * (8 * 1024 + 1)),
                 id="accept-work-limit",
             ),
+            pytest.param(
+                http.Headers(
+                    [
+                        (b"Upgrade", b"websocket"),
+                        (b"Connection", b"upgrade"),
+                        (b"Sec-WebSocket-Accept", _LARGE_RAW_VALUE),
+                    ]
+                ),
+                id="oversized-non-utf8-accept",
+            ),
+            pytest.param(
+                http.Headers(
+                    [
+                        (b"Upgrade", b"websocket"),
+                        (b"Connection", b"upgrade"),
+                        (b"Sec-WebSocket-Accept", _RawValueDecodeGuard(_WEBSOCKET_ACCEPT)),
+                        (b"Sec-WebSocket-Accept", _LARGE_RAW_VALUE),
+                    ]
+                ),
+                id="duplicate-accept-with-oversized-non-utf8-value",
+            ),
+            pytest.param(
+                http.Headers(
+                    [
+                        (b"Upgrade", _RawValueDecodeGuard(_LARGE_RAW_VALUE + b",websocket")),
+                        (b"Connection", b"upgrade"),
+                        (b"Sec-WebSocket-Accept", _WEBSOCKET_ACCEPT),
+                    ]
+                ),
+                id="raw-upgrade-token-beyond-work-limit",
+            ),
+            pytest.param(
+                http.Headers(
+                    [
+                        (b"Upgrade", b"websocket"),
+                        (b"Connection", _RawValueDecodeGuard(_LARGE_RAW_VALUE + b",upgrade")),
+                        (b"Sec-WebSocket-Accept", _WEBSOCKET_ACCEPT),
+                    ]
+                ),
+                id="raw-connection-token-beyond-work-limit",
+            ),
         ],
     )
     async def test_invalid_websocket_switching_protocols_response_releases_usage_flow(
@@ -264,6 +342,62 @@ class TestModelProviderWebSocketLifecycle:
             buffered=0,
             reports=0,
             flush_request_id="after-response",
+        )
+
+    @pytest.mark.parametrize(
+        ("request_keys", "response_accept"),
+        [
+            pytest.param((_LARGE_RAW_VALUE,), _WEBSOCKET_ACCEPT, id="oversized-raw-request-key"),
+            pytest.param(
+                (_RawValueDecodeGuard(_WEBSOCKET_KEY), _LARGE_RAW_VALUE),
+                _WEBSOCKET_ACCEPT,
+                id="duplicate-raw-request-key",
+            ),
+            pytest.param(
+                (_RawValueDecodeGuard(b"\xff" * 24),),
+                generate_accept_token(b"\xff" * 24),
+                id="non-ascii-key-even-with-matching-accept",
+            ),
+        ],
+    )
+    async def test_response_rechecks_raw_request_key_before_retaining_usage_flow(
+        self,
+        tmp_path,
+        real_flow,
+        mitm_ctx,
+        fake_firewall_headers,
+        request_keys: tuple[bytes, ...],
+        response_accept: bytes,
+    ) -> None:
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path), usage_state_id="test-usage-state-id")
+        reg_path = _write_openai_model_websocket_registry(tmp_path)
+        flow = make_openai_responses_websocket_request_flow(real_flow)
+
+        with mitm_ctx(registry_path=str(reg_path)), fake_firewall_headers():
+            await mitm_addon.request(flow)
+            assert flow.metadata[metadata_keys.WEBSOCKET_UPGRADE_REQUEST] is True
+            usage.write_pending_snapshot(flush_request_id="before-response")
+            assert_pending(
+                pending_path, flows=1, buffered=0, reports=0, flush_request_id="before-response"
+            )
+
+            # Response confirmation owns its raw-key boundary even after the
+            # request was classified; do not trust an earlier metadata marker.
+            flow.request.headers.fields = tuple(
+                (name, value)
+                for name, value in flow.request.headers.fields
+                if name.lower() != b"sec-websocket-key"
+            ) + tuple((b"Sec-WebSocket-Key", value) for value in request_keys)
+            response_headers = make_openai_responses_websocket_response_headers()
+            response_headers["Sec-WebSocket-Accept"] = response_accept
+            flow.response = tutils.tresp(status_code=101, headers=response_headers)
+            mitm_addon.responseheaders(flow)
+            mitm_addon.response(flow)
+            usage.write_pending_snapshot(flush_request_id="after-response")
+
+        assert_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="after-response"
         )
 
     async def test_model_websocket_error_releases_usage_flow_after_upgrade(

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -1245,7 +1245,7 @@ def test_oversized_websocket_key_is_rejected_before_base64_decode(monkeypatch) -
 
     monkeypatch.setattr(mitm_addon.base64, "b64decode", fail_decode)
 
-    assert not mitm_addon._is_valid_websocket_key("A" * 25)
+    assert not mitm_addon._is_valid_websocket_key(b"A" * 25)
 
 
 async def test_browser_passthrough_keeps_accept_encoding_for_parser_connector(

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -123,6 +123,37 @@ metadata, and this contract together. The
 [`test_mitmproxy_websocket_framing.py`](../../crates/runner/mitm-addon/tests/test_mitmproxy_websocket_framing.py)
 suite must continue to pass as the executable framing contract.
 
+## WebSocket handshake inspection boundary
+
+Request classification and 101 response confirmation inspect `Headers.fields`
+as raw bytes. They do not obtain full strings through `Headers.get_all()` before
+checking the handshake budget. The caller owns one 8,192 limit and passes it to
+response confirmation:
+
+- Token lookup spends one unit per visited raw field, including unrelated
+  fields, and one per inspected matching-value byte. A complete token at a comma
+  or actual field end can return immediately; exhausting the budget is not a
+  field ending. Later fields and an irrelevant suffix are not inspected.
+- Singleton lookup separately allows at most 8,192 raw fields and an inclusive
+  8,192 value bytes. It verifies cardinality and length before stripping SP/HTAB,
+  so oversized or repeated key/version/accept fields cannot trigger full-value
+  conversion or copying.
+- Raw names are length-checked before ASCII case normalization. Key validation
+  still requires 24 encoded bytes and 16 decoded bytes; version is `13`, and
+  response confirmation requires an ASCII key and the matching 28-byte accept.
+
+Over-budget or invalid handshakes fail closed to ordinary HTTP classification
+and terminal usage handling. These are local addon inspection limits, separate
+from mitmproxy's raw HTTP head buffering and other header consumers. Old runners
+retain their previous inspection behavior until they are updated.
+
+`test_http_header_syntax.py` uses guarded raw values and field sequences to prove
+early termination and bounded access. `test_mitmproxy_websocket_header_budget.py`
+feeds non-UTF-8 values through real HTTP/1 request hooks and guards the dependency
+conversion boundary. `test_model_provider_websocket_lifecycle.py` verifies raw
+response confirmation and tracked-flow retention/release. These regressions use
+structural assertions, with no timing or allocation thresholds.
+
 ## Path normalization work boundary
 
 Path safety validation accepts at most 65,536 input characters and five percent


### PR DESCRIPTION
## Summary

WebSocket handshake checks previously decoded complete raw header values before their 8,192-unit limits applied. A rejected one-MiB non-UTF-8 key therefore still triggered a full conversion, and an early matching token decoded its entire irrelevant suffix.

Inspect the existing raw header tuples directly with the shared byte scanner and bounded singleton extraction. Keep key/accept validation byte-oriented, preserve protocol and 101 lifecycle checks, and reject malformed or over-budget handshakes before value conversion. Token work now includes unrelated field visits; singleton field-count and byte limits remain separate to preserve the inclusive 8,192-byte value boundary.

Add structural parser guards, real HTTP/1 request-hook regressions, and response usage-lifecycle coverage for oversized non-UTF-8 values, duplicates, early/late tokens, and ASCII key validation. Document the local inspection limits. Dependency buffering and global HTTP admission policy are outside this change.

Closes #32600

## Validation

From `crates/runner/mitm-addon`, using uv 0.11.32 and the committed CPython 3.14.0 environment:

- `uv lock --check` and `uv sync --locked`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync basedpyright -p .`
- `uv run --no-sync python -m pytest tests/ -q` — **7,379 passed**
- `git diff --check`; Prettier 3.6.2 check of the added documentation section passed. Whole-file Prettier also flags formatting already present in the unchanged base document.

No live provider connection was used; the HTTP/1 tests drive the real mitmproxy hook pipeline with only external auth stubbed. No cross-version data or dependency changes are required.
