### PR TITLE
refactor(naming): neutralize private constants and refresh developer branding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "VM0 Development",
+  "name": "Okou Development",
   "image": "ghcr.io/vm0-ai/vm0-dev:20260825",
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {

--- a/docs/effect.md
+++ b/docs/effect.md
@@ -1,6 +1,6 @@
 # React Effects and ccstate Commands
 
-This guide defines where React and ccstate work should run in the VM0
+This guide defines where React and ccstate work should run in the Okou
 platform. It covers effects in the broad sense: any process that changes state
 outside the current calculation, performs I/O, acquires a resource, or depends
 on a lifecycle boundary.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "name": "e2e",
   "version": "1.0.0",
-  "description": "E2E tests for VM0 CLI",
+  "description": "E2E tests for Okou CLI",
   "packageManager": "pnpm@10.33.4",
   "main": "index.js",
   "directories": {

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -16,7 +16,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 echo "========================================"
-echo "  VM0 Development Environment Setup"
+echo "  Okou Development Environment Setup"
 echo "========================================"
 echo ""
 

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -154,7 +154,7 @@ OKOU_FINANCE_APIDOJO_TOKEN=op://Development/APIDojo/RAPIDAPI_KEY
 OKOU_SEO_DATAFORSEO_LOGIN=op://Development/DataForSEO/LOGIN
 OKOU_SEO_DATAFORSEO_PASSWORD=op://Development/DataForSEO/PASSWORD
 
-# Optional: Zero Browser provider (Browser Use)
+# Optional: Managed browser provider (Browser Use)
 OKOU_BROWSER_USE_API_KEY=op://Development/browser-use/OKOU_BROWSER_USE_API_KEY
 
 # Optional: Steam Web API
@@ -297,7 +297,7 @@ GITHUB_APP_PRIVATE_KEY=op://Development/github/GITHUB_APP_PRIVATE_KEY
 GITHUB_APP_SLUG=op://Development/github/GITHUB_APP_SLUG
 GITHUB_APP_WEBHOOK_SECRET=op://Development/github/GITHUB_APP_WEBHOOK_SECRET
 
-# Optional: VM0 Built-in Model Provider API Keys
+# Optional: Built-in model provider API keys
 DEV_MODEL_ANTHROPIC_KEY=op://Development/anthropic/DEV_MODEL_ANTHROPIC_KEY
 DEV_MODEL_OPENAI_KEY=op://Development/openai/OPENAI_API_KEY
 DEV_MODEL_MOONSHOT_KEY=op://Development/moonshot/DEV_MODEL_MOONSHOT_KEY

--- a/turbo/apps/desktop/src/desktop-developer-tools-controller.ts
+++ b/turbo/apps/desktop/src/desktop-developer-tools-controller.ts
@@ -26,7 +26,7 @@ function featureSwitchEnabledFromBody(value: unknown, key: string): boolean {
 interface DeveloperToolsControllerOptions {
   readonly getSessionAuthority: () => object | null;
   /**
-   * Session-authenticated fetch of the zero feature-switches endpoint
+   * Session-authenticated fetch of the feature-switches endpoint
    * (`getAuthSession().fetchWithSessionAuth(...)` in production).
    */
   readonly fetchFeatureSwitches: () => Promise<Response>;

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -148,7 +148,7 @@ const desktopAuthSelectOrgUrl = buildDesktopAuthSelectOrgUrl(
 const desktopAuthTokenUrl = buildDesktopAuthTokenUrl(config.authUrl);
 const localRendererUrl = desktopRendererUrl();
 const localRecorderUrl = desktopRecorderUrl("bar");
-const ZERO_FEATURE_SWITCHES_PATH = "/api/feature-switches";
+const FEATURE_SWITCHES_PATH = "/api/feature-switches";
 const noAllowedAppOrigins: ReadonlySet<string> = new Set();
 const SCREEN_RECORDING_POLL_INTERVAL_MS = 1000;
 const MAC_ACCESSIBILITY_SETTINGS_URL =
@@ -327,7 +327,7 @@ const developerTools = new DeveloperToolsController({
   getSessionAuthority: () => authSession?.getAuthority() ?? null,
   fetchFeatureSwitches: () =>
     getAuthSession().fetchWithSessionAuth(
-      new URL(ZERO_FEATURE_SWITCHES_PATH, desktopApiBaseUrl),
+      new URL(FEATURE_SWITCHES_PATH, desktopApiBaseUrl),
     ),
   setFilesystemPluginFeatureEnabled: (enabled) => {
     filesystemPluginManager?.setFeatureEnabled(enabled);

--- a/turbo/apps/platform/.env.example
+++ b/turbo/apps/platform/.env.example
@@ -1,4 +1,4 @@
-# Environment Configuration for VM0 Platform
+# Environment Configuration for Okou Platform
 # Copy this file to .env.local and fill in the values
 # Or run ./scripts/sync-env.sh to sync from 1Password
 

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -436,7 +436,7 @@ body {
   );
 }
 
-/* Zero app: inherits global neutral tokens; only card-specific tokens defined here */
+/* Okou app: inherits global neutral tokens; only card-specific tokens defined here */
 .okou-app {
   --okou-card-radius: 1.25rem;
   /* Cards rendered inside a chat message sit one level in from the page, so
@@ -570,7 +570,7 @@ body {
   background-color: hsl(var(--gray-0));
 }
 
-/* Zero chip-style gray (tone options, skill tags, Add skill) */
+/* Chip-style gray (tone options, skill tags, Add skill) */
 .okou-app .okou-chip {
   background-color: hsl(var(--gray-50));
   border: 0.7px solid hsl(var(--gray-400));
@@ -583,7 +583,7 @@ body {
   border-color: hsl(var(--gray-400));
 }
 
-/* Zero left nav */
+/* Left nav */
 .okou-nav {
   --color-sidebar-border: hsl(var(--gray-200));
 }
@@ -743,7 +743,7 @@ body {
   );
 }
 
-/* Message bubble (e.g. Meet Zero tone samples) */
+/* Message bubble (e.g. Meet Okou tone samples) */
 .okou-app .okou-bubble-cool {
   background-color: hsl(var(--gray-100) / 0.95);
   color: hsl(var(--foreground));
@@ -757,7 +757,7 @@ body {
   color: hsl(var(--foreground));
 }
 
-/* Chat: assistant (Zero) message bubble */
+/* Chat: assistant message bubble */
 .okou-app .okou-chat-bubble-assistant {
   background-color: transparent;
   border: none;
@@ -1333,7 +1333,7 @@ details > summary {
   transition: color 0.15s ease;
 }
 
-/* Zero workspace: soft texture + gentle gradient — documents, records, thinking, meeting notes.
+/* Okou workspace: soft texture + gentle gradient — documents, records, thinking, meeting notes.
    Grid is on ::before with z-index: -1; container has z-index: 0 so the texture stays behind content only. */
 .okou-workspace-bg {
   position: relative;

--- a/turbo/docs/react.md
+++ b/turbo/docs/react.md
@@ -101,7 +101,7 @@ If a component only needs the most recently resolved value and does not need to 
 
 ```tsx
 // ✅ Only 1 render per Promise transition, and no flash back to undefined during loading
-const defaultDisplayName = useLastResolved(defaultAgentName$) ?? "Zero";
+const defaultDisplayName = useLastResolved(defaultAgentName$) ?? "Okou";
 ```
 
 Only use `useLoadable` / `useResolved` when the component **needs to react to the loading state** (e.g. to show a skeleton).

--- a/turbo/packages/api-contracts/src/contracts/billing.ts
+++ b/turbo/packages/api-contracts/src/contracts/billing.ts
@@ -616,7 +616,7 @@ const redeemCodeRequestSchema = z.object({
 // ---------------------------------------------------------------------------
 
 /**
- * Zero contract for GET /api/billing/status
+ * Contract for GET /api/billing/status
  */
 export const billingStatusContract = c.router({
   get: {
@@ -636,7 +636,7 @@ export const billingStatusContract = c.router({
 export type BillingStatusContract = typeof billingStatusContract;
 
 /**
- * Zero contract for POST /api/billing/checkout
+ * Contract for POST /api/billing/checkout
  */
 export const billingCheckoutContract = c.router({
   create: {
@@ -695,7 +695,7 @@ export const billingCheckoutContract = c.router({
 export type BillingCheckoutContract = typeof billingCheckoutContract;
 
 /**
- * Zero contract for POST /api/billing/usage-pack-checkout
+ * Contract for POST /api/billing/usage-pack-checkout
  */
 export const billingUsagePackCheckoutContract = c.router({
   create: {
@@ -964,7 +964,7 @@ export type BillingUsagePackMigrationContract =
   typeof billingUsagePackMigrationContract;
 
 /**
- * Zero contract for POST /api/billing/concurrency-checkout
+ * Contract for POST /api/billing/concurrency-checkout
  */
 export const billingConcurrencyCheckoutContract = c.router({
   preview: {
@@ -1005,7 +1005,7 @@ export type BillingConcurrencyCheckoutContract =
   typeof billingConcurrencyCheckoutContract;
 
 /**
- * Zero contract for concurrency subscriptions.
+ * Contract for concurrency subscriptions.
  */
 export const billingConcurrencySubscriptionContract = c.router({
   previewChange: {
@@ -1092,7 +1092,7 @@ export type BillingConcurrencySubscriptionContract =
   typeof billingConcurrencySubscriptionContract;
 
 /**
- * Zero contract for POST /api/billing/credit-checkout
+ * Contract for POST /api/billing/credit-checkout
  */
 export const billingCreditCheckoutContract = c.router({
   create: {
@@ -1132,7 +1132,7 @@ export type BillingCreditCheckoutContract =
   typeof billingCreditCheckoutContract;
 
 /**
- * Zero contract for POST /api/billing/portal
+ * Contract for POST /api/billing/portal
  */
 export const billingPortalContract = c.router({
   create: {
@@ -1155,7 +1155,7 @@ export const billingPortalContract = c.router({
 export type BillingPortalContract = typeof billingPortalContract;
 
 /**
- * Zero contract for /api/billing/auto-recharge
+ * Contract for /api/billing/auto-recharge
  */
 export const billingAutoRechargeContract = c.router({
   get: {
@@ -1188,7 +1188,7 @@ export const billingAutoRechargeContract = c.router({
 export type BillingAutoRechargeContract = typeof billingAutoRechargeContract;
 
 /**
- * Zero contract for GET /api/billing/invoices
+ * Contract for GET /api/billing/invoices
  */
 const invoiceSchema = z.object({
   id: z.string(),
@@ -1295,7 +1295,7 @@ const restoreResponseSchema = z.discriminatedUnion("status", [
 ]);
 
 /**
- * Zero contract for POST /api/billing/downgrade
+ * Contract for POST /api/billing/downgrade
  */
 export const billingDowngradeContract = c.router({
   create: {
@@ -1319,7 +1319,7 @@ export const billingDowngradeContract = c.router({
 export type BillingDowngradeContract = typeof billingDowngradeContract;
 
 /**
- * Zero contract for POST /api/billing/restore
+ * Contract for POST /api/billing/restore
  */
 export const billingRestoreContract = c.router({
   create: {
@@ -1342,7 +1342,7 @@ export const billingRestoreContract = c.router({
 export type BillingRestoreContract = typeof billingRestoreContract;
 
 /**
- * Zero contract for POST /api/billing/redeem/:campaign
+ * Contract for POST /api/billing/redeem/:campaign
  *
  * One-time campaign redemption. The handler validates the campaign whitelist,
  * creates (or resumes) a Stripe Checkout session, and returns a discriminated
@@ -1371,7 +1371,7 @@ export const billingRedeemContract = c.router({
 export type BillingRedeemContract = typeof billingRedeemContract;
 
 /**
- * Zero contract for POST /api/billing/redeem-code
+ * Contract for POST /api/billing/redeem-code
  *
  * Proxies onboarding invite codes to the Atom redeem endpoint. The platform
  * waits for billing status to update through realtime before completing

--- a/turbo/packages/api-contracts/src/contracts/browser.ts
+++ b/turbo/packages/api-contracts/src/contracts/browser.ts
@@ -5,7 +5,7 @@ import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
-// Zero always asks Browser Use for its longest provider lifetime and manages
+// Okou always asks Browser Use for its longest provider lifetime and manages
 // reclamation itself through the idle lease below, so a hard provider timeout
 // can never cut a browser short while somebody is still using it.
 export const BROWSER_PROVIDER_TIMEOUT_MINUTES = 240;
@@ -56,7 +56,7 @@ export const browserSessionSchema = z
     timeoutMinutes: z.number().int().positive(),
     // Only live provider instances have persisted window dimensions.
     screen: browserScreenSchema.optional(),
-    // When Zero reclaims the live provider instance unless somebody leases it
+    // When Okou reclaims the live provider instance unless somebody leases it
     // again. Null once no provider instance is running.
     idleExpiresAt: z.iso.datetime().nullable(),
     suspendedAt: z.iso.datetime().nullable(),

--- a/turbo/packages/api-contracts/src/contracts/integrations.ts
+++ b/turbo/packages/api-contracts/src/contracts/integrations.ts
@@ -189,7 +189,7 @@ export type IntegrationsFeishuDownloadFileContract =
 /**
  * Integration Feishu file upload — init contract.
  *
- * The CLI uploads to temporary VM0 storage before the API forwards the bytes
+ * The CLI uploads to temporary storage before the API forwards the bytes
  * to Feishu with the organization bot's tenant token.
  */
 const feishuUploadInitBodySchema = z.object({
@@ -767,7 +767,7 @@ export type IntegrationsTelegramDownloadFileContract =
  * Integration Telegram file upload — init contract
  * POST /api/integrations/telegram/upload-file/init
  *
- * Requests a pre-signed upload URL for a temporary VM0-hosted file. The CLI
+ * Requests a pre-signed upload URL for a temporary hosted file. The CLI
  * uploads the file body directly to R2, then the complete route asks Telegram
  * to fetch that file URL with the org-owned bot token.
  * Requires `telegram:write` capability (via OKOU_TOKEN).
@@ -848,7 +848,7 @@ export type IntegrationsTeamsDownloadFileContract =
  * Integration Microsoft Teams file upload — init contract
  * POST /api/integrations/teams/upload-file/init
  *
- * Requests a pre-signed upload URL for a temporary VM0-hosted file. The CLI
+ * Requests a pre-signed upload URL for a temporary hosted file. The CLI
  * uploads the file body directly to R2, then the complete route sends a Teams
  * message with the file attachment and public file URL.
  * Requires `teams:write` capability (via OKOU_TOKEN).
@@ -1033,7 +1033,7 @@ export type IntegrationsGithubDownloadFileContract =
  * Integration GitHub file upload — init contract
  * POST /api/integrations/github/upload-file/init
  *
- * Requests a pre-signed upload URL for a temporary VM0-hosted file. The CLI
+ * Requests a pre-signed upload URL for a temporary hosted file. The CLI
  * uploads the file body directly to R2, then the complete route posts the file
  * URL back to a GitHub issue or pull request comment.
  * Requires `github:write` capability (via OKOU_TOKEN).
@@ -1142,7 +1142,7 @@ export const integrationsGithubUploadCompleteContract = c.router({
  * Integration AgentPhone file upload — init contract
  * POST /api/integrations/phone/upload-file/init
  *
- * Requests a pre-signed upload URL for a VM0-hosted file. The CLI uploads the
+ * Requests a pre-signed upload URL for a hosted file. The CLI uploads the
  * file body directly to R2, then complete sends the public file URL through
  * AgentPhone.
  * Requires `phone:write` capability (via OKOU_TOKEN).

--- a/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-capabilities.ts
@@ -45,7 +45,7 @@ interface ConnectorAuthProviderMethodRegistration {
   readonly contract: ConnectorAuthProviderMethodContract;
 }
 
-// This is VM0's executable compatibility contract, not connector catalog data.
+// This is Okou's executable compatibility contract, not connector catalog data.
 // Keep it limited to facts required to select and validate provider handlers.
 export const CONNECTOR_AUTH_PROVIDER_METHOD_REGISTRATIONS = [
   {

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -101,11 +101,11 @@ export interface ResourceCandidateSlice {
 
 const RESOURCE_REGISTRY_REPO = "nexu-io/open-design";
 const RESOURCE_REGISTRY_COMMIT = "3fb620af423534643677c7c6fae76be088fa770a";
-const VM0_SKILLS_REPO = "vm0-ai/vm0-skills";
-const VM0_SKILLS_REF = "main";
+const SKILLS_REPO = "vm0-ai/vm0-skills";
+const SKILLS_REF = "main";
 const VIDEO_TEMPLATE_REGISTRY_SOURCE = {
-  repo: VM0_SKILLS_REPO,
-  ref: VM0_SKILLS_REF,
+  repo: SKILLS_REPO,
+  ref: SKILLS_REF,
 } as const;
 
 export const RESOURCE_REGISTRY_VERSION = "v1";
@@ -202,8 +202,8 @@ function imageStyleArchiveSha256(slug: string): string {
 
 function imageStyleSource(slug: string): ResourceSourceRef {
   return {
-    repo: VM0_SKILLS_REPO,
-    ref: VM0_SKILLS_REF,
+    repo: SKILLS_REPO,
+    ref: SKILLS_REF,
     path: `illustration-template/${slug}`,
     archive: {
       type: "tar.gz",

--- a/turbo/packages/core/src/storage-names.ts
+++ b/turbo/packages/core/src/storage-names.ts
@@ -100,7 +100,7 @@ export function getCustomConnectorSkillName(
 }
 
 /**
- * Reserved name of the per-user memory storage that Zero auto-injects into
+ * Reserved name of the per-user memory storage that Okou auto-injects into
  * every agent run. It is owned by the user and mounted into the sandbox at a
  * framework-specific path.
  */

--- a/turbo/packages/proxy/README.md
+++ b/turbo/packages/proxy/README.md
@@ -132,4 +132,4 @@ packages/proxy/
 
 ## License
 
-Private - Part of VM0 monorepo
+Private - Part of Okou monorepo

--- a/turbo/packages/ui/README.md
+++ b/turbo/packages/ui/README.md
@@ -1,6 +1,6 @@
 # @okouai/ui - Design System
 
-VM0's shared UI component library with a complete design system including components, colors, and utilities.
+Okou's shared UI component library with a complete design system including components, colors, and utilities.
 
 ## 📦 Package Overview
 
@@ -74,7 +74,7 @@ pre {
 
 ## 🎨 Icons
 
-VM0 uses **Lucide** for all UI iconography, providing a consistent and comprehensive icon set.
+Okou uses **Lucide** for all UI iconography, providing a consistent and comprehensive icon set.
 
 ### Installation
 
@@ -148,7 +148,7 @@ Follow these size guidelines:
 
 ### Base Color Palette
 
-VM0 uses a **Tailwind-style color scale system** with complete palettes:
+Okou uses a **Tailwind-style color scale system** with complete palettes:
 
 #### Primary (Orange Brand Color)
 
@@ -413,7 +413,7 @@ cn("bg-primary", isActive && "bg-primary-700"); // Conditional
 
 ### Installation
 
-This package is part of the VM0 monorepo and uses workspace protocol:
+This package is part of the Okou monorepo and uses workspace protocol:
 
 ```json
 {
@@ -696,6 +696,6 @@ When contributing to the design system:
 
 ---
 
-**Maintainer**: VM0 Team  
+**Maintainer**: Okou Team\
 **Version**: 0.0.0  
 **Last Updated**: January 2026

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -4,7 +4,7 @@
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
 /*
- * VM0 Design System
+ * Okou Design System
  * Based on Figma: https://www.figma.com/design/eTWIsjktpymTDYEb55OxXx/VM0-Cloud
  *
  * Typography: Noto Sans


### PR DESCRIPTION
Closes #32601.

## Summary

Refresh the issue's 19 allowlisted developer labels, documentation/example labels, and source comments to Okou or neutral wording. Rename the private `ZERO_FEATURE_SWITCHES_PATH`, `VM0_SKILLS_REPO`, and `VM0_SKILLS_REF` constants to `FEATURE_SWITCHES_PATH`, `SKILLS_REPO`, and `SKILLS_REF`, moving all eight declaration/reference occurrences together.

The endpoint remains `/api/feature-switches`; the real skills source remains `vm0-ai/vm0-skills` at `main`. All resource source objects, paths, slugs, archive identities, URLs, devcontainer image, env values, API schemas, CSS selectors/declarations, and runtime behavior are preserved. The React example changes only its existing display label. Runtime-copy work in #32568 and compatibility retirement in #26368 remain separate.

## Verification

- One-time full-file comparison: both renamed TypeScript files differ only by the specified alpha-renames; all eight changed TypeScript files have identical syntax trees after normalizing those names and removing comments.
- All nine resource registry listing interfaces return identical output before/after (388 records); all 33 image-style and 10 video-template sources still use the real skills repository and branch. Output SHA-256: `6555b934dfb7a0e1ceda27f5752382acdcf69c1b98473459d2fe89bd1b099cdb`.
- All 19 changed files match the issue allowlist. JSON changes only `name`/`description`; shell changes only the banner; env/CSS changes only comments; all URLs and image references match before/after. The edited README maintainer line preserves its Markdown hard break with a backslash to avoid trailing whitespace.
- Focused Prettier; lint, typecheck, and Knip for `@okouai/desktop`, `@okouai/core`, `@okouai/api-contracts`, and `@okouai/connectors`: passed.
- Core video/illustration/presentation/website registry tests: 29 passed. Desktop developer-tools, environment entry-point, bootstrap, degraded-bootstrap, and bootstrap-import tests: 72 passed. CLI resource command integration tests: 9 passed.
- Existing style policy and ESLint on both changed CSS files; `bash -n scripts/prepare.sh`; file-size check; commitlint; `git diff --check`: passed.

Validation ran on Linux. Full Vitest, a dev server, `prepare.sh` execution, and native macOS packaging were not run locally; the normal protected PR and merge-group pipelines provide the complete gates. No tests, audit scripts, naming policy, or generated files were added.

## Concurrent work

Refreshed `gh pr list --limit 100`: 41 open PRs, with every file count reconciled against GitHub's `changedFiles`. Current intersections are #32595/#32573 (billing comments), #32580 (API env comments), #32368/#32030 (resource registry), #32278 (CSS), and #32045 (platform CSS). #32596 has merged. A trial merge with refreshed main at `61d758c9dd` is clean and preserves the concurrent changes; these overlaps are inventory, not ordering dependencies.
