### PR TITLE
feat(core): promote ssh access feature switch to alpha

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -25,7 +25,7 @@ describe("FeatureSwitchKey", () => {
     expect(FeatureSwitchKey.SharedWorkerRealtime).toBe("sharedWorkerRealtime");
     expect(FeatureSwitchKey.RealAgentInPreview).toBe("_realAgentInPreview");
     expect(FeatureSwitchKey.TestOauthConnector).toBe("_testOauthConnector");
-    expect(FeatureSwitchKey.SshAccess).toBe("_sshAccess");
+    expect(FeatureSwitchKey.SshAccess).toBe("sshAccess");
     expect(FeatureSwitchKey.ChatRunWorkFolding).toBe("chatRunWorkFolding");
     expect(FeatureSwitchKey.ProgressiveArtifactPreview).toBe(
       "progressiveArtifactPreview",
@@ -55,9 +55,9 @@ describe("isFeatureEnabled", () => {
       false,
     );
     expect(getFeatureSwitchMetadata()[FeatureSwitchKey.SshAccess]).toEqual({
-      maintainer: "ethan@okou.ai",
+      maintainer: "liangyou@okou.ai",
       description: "Enable standalone Runner-mediated SSH configuration",
-      rolloutStage: "internal",
+      rolloutStage: "alpha",
     });
   });
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -61,7 +61,7 @@ export enum FeatureSwitchKey {
   PersonalModelProviderAccounts = "_multipleSubscriptions",
   FeishuIntegration = "_feishuIntegration",
   CustomConnectorMcp = "customConnectorMcp",
-  SshAccess = "_sshAccess",
+  SshAccess = "sshAccess",
   SharedThreadSharing = "sharedThreadSharing",
   PiLoop = "piLoop",
   PresentationTemplates = "presentationTemplates",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -455,7 +455,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.SshAccess]: {
-    maintainer: "ethan@okou.ai",
+    maintainer: "liangyou@okou.ai",
     description: "Enable standalone Runner-mediated SSH configuration",
     enabled: false,
   },


### PR DESCRIPTION
## Summary

- rename the SSH access feature switch key from `_sshAccess` to `sshAccess`, promoting its rollout stage from internal to alpha
- transfer feature-switch maintenance ownership to `liangyou@okou.ai`
- update the core feature-switch expectations for the new key and metadata

The switch remains disabled by default.

## Testing

- `pnpm exec prettier --check packages/core/src/feature-switch-key.ts packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm -F @okouai/core lint`
- `pnpm -F @okouai/core check-types`
- `pnpm -F @okouai/core exec vitest run src/__tests__/feature-switch.test.ts --silent=passed-only`
