### PR TITLE
fix(platform): follow a residual ios visual viewport after the keyboard closes

### DIFF
--- a/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
@@ -367,7 +367,7 @@ function installScrollTo(
   viewport: MockVisualViewport,
   restoresOffset: boolean,
 ) {
-  const scrollTo = vi.fn((_x: number, _y: number): void => {
+  const scrollTo = vi.fn<(x: number, y: number) => void>(() => {
     if (restoresOffset) {
       viewport.offsetTop = 0;
     }
@@ -405,13 +405,13 @@ test("A mobile browser root follows a visual viewport that stays panned after th
   expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
   expect(scrollTo).toHaveBeenCalledWith(0, 0);
   expect(document.documentElement.dataset.visualViewportResidue).toBe("true");
-  expect(residueStyle()).toEqual({ top: "310px", height: "844px" });
+  expect(residueStyle()).toStrictEqual({ top: "310px", height: "844px" });
 
   // The browser keeps panning the visual viewport while the residue lasts.
   viewport.offsetTop = 120;
   viewport.dispatchEvent(new Event("scroll"));
   await clock.flushUpdate();
-  expect(residueStyle()).toEqual({ top: "120px", height: "844px" });
+  expect(residueStyle()).toStrictEqual({ top: "120px", height: "844px" });
 
   viewport.offsetTop = 0;
   viewport.dispatchEvent(new Event("scroll"));
@@ -419,7 +419,7 @@ test("A mobile browser root follows a visual viewport that stays panned after th
   expect(
     document.documentElement.dataset.visualViewportResidue,
   ).toBeUndefined();
-  expect(residueStyle()).toEqual({ top: "", height: "" });
+  expect(residueStyle()).toStrictEqual({ top: "", height: "" });
 });
 
 test("A residual visual viewport pan that an origin scroll clears needs no root follow", async () => {
@@ -439,7 +439,7 @@ test("A residual visual viewport pan that an origin scroll clears needs no root 
   expect(
     document.documentElement.dataset.visualViewportResidue,
   ).toBeUndefined();
-  expect(residueStyle()).toEqual({ top: "", height: "" });
+  expect(residueStyle()).toStrictEqual({ top: "", height: "" });
 });
 
 test("Reopening the keyboard ends the root follow", async () => {
@@ -462,7 +462,7 @@ test("Reopening the keyboard ends the root follow", async () => {
   expect(
     document.documentElement.dataset.visualViewportResidue,
   ).toBeUndefined();
-  expect(residueStyle()).toEqual({ top: "", height: "" });
+  expect(residueStyle()).toStrictEqual({ top: "", height: "" });
 });
 
 test("A standalone PWA keeps its programmatic keyboard scroll after the keyboard closes", async () => {

--- a/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
@@ -362,3 +362,125 @@ test("Browsers without visual-viewport support keep the normal layout", () => {
 
   expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
 });
+
+function installScrollTo(
+  viewport: MockVisualViewport,
+  restoresOffset: boolean,
+) {
+  const scrollTo = vi.fn((_x: number, _y: number): void => {
+    if (restoresOffset) {
+      viewport.offsetTop = 0;
+    }
+  });
+  vi.stubGlobal("scrollTo", scrollTo);
+  return scrollTo;
+}
+
+function residueStyle(): { top: string; height: string } {
+  return {
+    top: document.documentElement.style.getPropertyValue(
+      "--okou-visual-viewport-top",
+    ),
+    height: document.documentElement.style.getPropertyValue(
+      "--okou-visual-viewport-height",
+    ),
+  };
+}
+
+test("A mobile browser root follows a visual viewport that stays panned after the keyboard closes", async () => {
+  const viewport = new MockVisualViewport(844);
+  setInnerHeight(844);
+  setStandalone(false);
+  installVisualViewport(viewport);
+  const scrollTo = installScrollTo(viewport, false);
+  const entry = focusTextEntry();
+  const clock = startViewportKeyboardState();
+
+  await resizeAndSettle(viewport, clock, 520, 310);
+  expect(document.documentElement.dataset.keyboardOpen).toBe("true");
+
+  entry.blur();
+  await resizeAndSettle(viewport, clock, 844, 310);
+
+  expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
+  expect(scrollTo).toHaveBeenCalledWith(0, 0);
+  expect(document.documentElement.dataset.visualViewportResidue).toBe("true");
+  expect(residueStyle()).toEqual({ top: "310px", height: "844px" });
+
+  // The browser keeps panning the visual viewport while the residue lasts.
+  viewport.offsetTop = 120;
+  viewport.dispatchEvent(new Event("scroll"));
+  await clock.flushUpdate();
+  expect(residueStyle()).toEqual({ top: "120px", height: "844px" });
+
+  viewport.offsetTop = 0;
+  viewport.dispatchEvent(new Event("scroll"));
+  await clock.flushUpdate();
+  expect(
+    document.documentElement.dataset.visualViewportResidue,
+  ).toBeUndefined();
+  expect(residueStyle()).toEqual({ top: "", height: "" });
+});
+
+test("A residual visual viewport pan that an origin scroll clears needs no root follow", async () => {
+  const viewport = new MockVisualViewport(844);
+  setInnerHeight(844);
+  setStandalone(false);
+  installVisualViewport(viewport);
+  const scrollTo = installScrollTo(viewport, true);
+  const entry = focusTextEntry();
+  const clock = startViewportKeyboardState();
+
+  await resizeAndSettle(viewport, clock, 520, 310);
+  entry.blur();
+  await resizeAndSettle(viewport, clock, 844, 310);
+
+  expect(scrollTo).toHaveBeenCalledTimes(1);
+  expect(
+    document.documentElement.dataset.visualViewportResidue,
+  ).toBeUndefined();
+  expect(residueStyle()).toEqual({ top: "", height: "" });
+});
+
+test("Reopening the keyboard ends the root follow", async () => {
+  const viewport = new MockVisualViewport(844);
+  setInnerHeight(844);
+  setStandalone(false);
+  installVisualViewport(viewport);
+  installScrollTo(viewport, false);
+  const entry = focusTextEntry();
+  const clock = startViewportKeyboardState();
+
+  await resizeAndSettle(viewport, clock, 520, 310);
+  entry.blur();
+  await resizeAndSettle(viewport, clock, 844, 310);
+  expect(document.documentElement.dataset.visualViewportResidue).toBe("true");
+
+  entry.focus();
+  await resizeAndSettle(viewport, clock, 520, 310);
+  expect(document.documentElement.dataset.keyboardOpen).toBe("true");
+  expect(
+    document.documentElement.dataset.visualViewportResidue,
+  ).toBeUndefined();
+  expect(residueStyle()).toEqual({ top: "", height: "" });
+});
+
+test("A standalone PWA keeps its programmatic keyboard scroll after the keyboard closes", async () => {
+  const viewport = new MockVisualViewport(844);
+  setInnerHeight(844);
+  setStandalone(true);
+  installVisualViewport(viewport);
+  const scrollTo = installScrollTo(viewport, false);
+  const entry = focusTextEntry();
+  const clock = startViewportKeyboardState();
+
+  await resizeAndSettle(viewport, clock, 520, 310);
+  entry.blur();
+  // Standalone WebKit can report the stale offsetTop for a moment after close.
+  await resizeAndSettle(viewport, clock, 844, 310);
+
+  expect(scrollTo).not.toHaveBeenCalled();
+  expect(
+    document.documentElement.dataset.visualViewportResidue,
+  ).toBeUndefined();
+});

--- a/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
@@ -376,21 +376,47 @@ function installScrollTo(
   return scrollTo;
 }
 
-function residueStyle(): { top: string; height: string } {
-  return {
-    top: document.documentElement.style.getPropertyValue(
-      "--okou-visual-viewport-top",
-    ),
-    height: document.documentElement.style.getPropertyValue(
-      "--okou-visual-viewport-height",
-    ),
-  };
+const IPHONE_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1";
+
+function setIPhoneUserAgent(): void {
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    value: IPHONE_USER_AGENT,
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      Reflect.deleteProperty(navigator, "userAgent");
+    },
+    { once: true },
+  );
+}
+
+function residueTop(): string {
+  return document.documentElement.style.getPropertyValue(
+    "--okou-visual-viewport-top",
+  );
+}
+
+async function closeKeyboardWithResidue(
+  viewport: MockVisualViewport,
+  clock: ControlledViewportClock,
+  entry: HTMLTextAreaElement,
+  offsetTop: number,
+): Promise<void> {
+  entry.blur();
+  await resizeAndSettle(viewport, clock, 844, offsetTop);
+  // The residue is confirmed only after the close animation has had time to
+  // finish; that confirmation and its decision frame settle here.
+  await clock.flushUpdate();
 }
 
 test("A mobile browser root follows a visual viewport that stays panned after the keyboard closes", async () => {
   const viewport = new MockVisualViewport(844);
   setInnerHeight(844);
   setStandalone(false);
+  setIPhoneUserAgent();
   installVisualViewport(viewport);
   const scrollTo = installScrollTo(viewport, false);
   const entry = focusTextEntry();
@@ -399,19 +425,18 @@ test("A mobile browser root follows a visual viewport that stays panned after th
   await resizeAndSettle(viewport, clock, 520, 310);
   expect(document.documentElement.dataset.keyboardOpen).toBe("true");
 
-  entry.blur();
-  await resizeAndSettle(viewport, clock, 844, 310);
+  await closeKeyboardWithResidue(viewport, clock, entry, 310);
 
   expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
   expect(scrollTo).toHaveBeenCalledWith(0, 0);
   expect(document.documentElement.dataset.visualViewportResidue).toBe("true");
-  expect(residueStyle()).toStrictEqual({ top: "310px", height: "844px" });
+  expect(residueTop()).toBe("310px");
 
   // The browser keeps panning the visual viewport while the residue lasts.
   viewport.offsetTop = 120;
   viewport.dispatchEvent(new Event("scroll"));
   await clock.flushUpdate();
-  expect(residueStyle()).toStrictEqual({ top: "120px", height: "844px" });
+  expect(residueTop()).toBe("120px");
 
   viewport.offsetTop = 0;
   viewport.dispatchEvent(new Event("scroll"));
@@ -419,41 +444,89 @@ test("A mobile browser root follows a visual viewport that stays panned after th
   expect(
     document.documentElement.dataset.visualViewportResidue,
   ).toBeUndefined();
-  expect(residueStyle()).toStrictEqual({ top: "", height: "" });
+  expect(residueTop()).toBe("");
 });
 
 test("A residual visual viewport pan that an origin scroll clears needs no root follow", async () => {
   const viewport = new MockVisualViewport(844);
   setInnerHeight(844);
   setStandalone(false);
+  setIPhoneUserAgent();
   installVisualViewport(viewport);
   const scrollTo = installScrollTo(viewport, true);
   const entry = focusTextEntry();
   const clock = startViewportKeyboardState();
 
   await resizeAndSettle(viewport, clock, 520, 310);
-  entry.blur();
-  await resizeAndSettle(viewport, clock, 844, 310);
+  await closeKeyboardWithResidue(viewport, clock, entry, 310);
 
   expect(scrollTo).toHaveBeenCalledTimes(1);
   expect(
     document.documentElement.dataset.visualViewportResidue,
   ).toBeUndefined();
-  expect(residueStyle()).toStrictEqual({ top: "", height: "" });
+  expect(residueTop()).toBe("");
+});
+
+test("A pan that ends with the keyboard close animation is not a residue", async () => {
+  const viewport = new MockVisualViewport(844);
+  setInnerHeight(844);
+  setStandalone(false);
+  setIPhoneUserAgent();
+  installVisualViewport(viewport);
+  const scrollTo = installScrollTo(viewport, false);
+  const entry = focusTextEntry();
+  const clock = startViewportKeyboardState();
+
+  await resizeAndSettle(viewport, clock, 520, 310);
+  entry.blur();
+  // The close sample still carries the pan; the animation clears it later.
+  await resizeAndSettle(viewport, clock, 844, 48);
+  viewport.offsetTop = 0;
+  viewport.dispatchEvent(new Event("scroll"));
+  await clock.flushUpdate();
+
+  expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
+  expect(scrollTo).not.toHaveBeenCalled();
+  expect(
+    document.documentElement.dataset.visualViewportResidue,
+  ).toBeUndefined();
+  expect(residueTop()).toBe("");
+});
+
+test("A pinch-zoomed page keeps its visual viewport pan after the keyboard closes", async () => {
+  const viewport = new MockVisualViewport(844);
+  setInnerHeight(844);
+  setStandalone(false);
+  setIPhoneUserAgent();
+  installVisualViewport(viewport);
+  const scrollTo = installScrollTo(viewport, false);
+  const entry = focusTextEntry();
+  const clock = startViewportKeyboardState();
+
+  await resizeAndSettle(viewport, clock, 520, 310);
+  viewport.scale = 2;
+  entry.blur();
+  await resizeAndSettle(viewport, clock, 422, 310);
+  await clock.flushUpdate();
+
+  expect(scrollTo).not.toHaveBeenCalled();
+  expect(
+    document.documentElement.dataset.visualViewportResidue,
+  ).toBeUndefined();
 });
 
 test("Reopening the keyboard ends the root follow", async () => {
   const viewport = new MockVisualViewport(844);
   setInnerHeight(844);
   setStandalone(false);
+  setIPhoneUserAgent();
   installVisualViewport(viewport);
   installScrollTo(viewport, false);
   const entry = focusTextEntry();
   const clock = startViewportKeyboardState();
 
   await resizeAndSettle(viewport, clock, 520, 310);
-  entry.blur();
-  await resizeAndSettle(viewport, clock, 844, 310);
+  await closeKeyboardWithResidue(viewport, clock, entry, 310);
   expect(document.documentElement.dataset.visualViewportResidue).toBe("true");
 
   entry.focus();
@@ -462,22 +535,22 @@ test("Reopening the keyboard ends the root follow", async () => {
   expect(
     document.documentElement.dataset.visualViewportResidue,
   ).toBeUndefined();
-  expect(residueStyle()).toStrictEqual({ top: "", height: "" });
+  expect(residueTop()).toBe("");
 });
 
 test("A standalone PWA keeps its programmatic keyboard scroll after the keyboard closes", async () => {
   const viewport = new MockVisualViewport(844);
   setInnerHeight(844);
   setStandalone(true);
+  setIPhoneUserAgent();
   installVisualViewport(viewport);
   const scrollTo = installScrollTo(viewport, false);
   const entry = focusTextEntry();
   const clock = startViewportKeyboardState();
 
   await resizeAndSettle(viewport, clock, 520, 310);
-  entry.blur();
   // Standalone WebKit can report the stale offsetTop for a moment after close.
-  await resizeAndSettle(viewport, clock, 844, 310);
+  await closeKeyboardWithResidue(viewport, clock, entry, 310);
 
   expect(scrollTo).not.toHaveBeenCalled();
   expect(

--- a/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
@@ -432,19 +432,54 @@ test("A mobile browser root follows a visual viewport that stays panned after th
   expect(document.documentElement.dataset.visualViewportResidue).toBe("true");
   expect(residueTop()).toBe("310px");
 
-  // The browser keeps panning the visual viewport while the residue lasts.
+  // The browser keeps panning the visual viewport while the residue lasts,
+  // and it does not always announce that through an event.
   viewport.offsetTop = 120;
-  viewport.dispatchEvent(new Event("scroll"));
   await clock.flushUpdate();
   expect(residueTop()).toBe("120px");
 
   viewport.offsetTop = 0;
-  viewport.dispatchEvent(new Event("scroll"));
   await clock.flushUpdate();
   expect(
     document.documentElement.dataset.visualViewportResidue,
   ).toBeUndefined();
   expect(residueTop()).toBe("");
+});
+
+test("A pan that is still moving at the confirmation is checked again", async () => {
+  const viewport = new MockVisualViewport(844);
+  setInnerHeight(844);
+  setStandalone(false);
+  setIPhoneUserAgent();
+  installVisualViewport(viewport);
+  const scrollTo = installScrollTo(viewport, false);
+  const entry = focusTextEntry();
+  const clock = startViewportKeyboardState();
+
+  await resizeAndSettle(viewport, clock, 520, 310);
+  entry.blur();
+  await resizeAndSettle(viewport, clock, 844, 310);
+
+  // The close animation is still panning when the first confirmation runs.
+  viewport.offsetTop = 200;
+  await clock.flushUpdate();
+  expect(scrollTo).not.toHaveBeenCalled();
+  expect(
+    document.documentElement.dataset.visualViewportResidue,
+  ).toBeUndefined();
+
+  // The pan has not moved since, so the second confirmation acts on it.
+  await clock.flushUpdate();
+  expect(scrollTo).toHaveBeenCalledTimes(1);
+  expect(document.documentElement.dataset.visualViewportResidue).toBe("true");
+  expect(residueTop()).toBe("200px");
+
+  // The pan ends without an event; the polling follow notices and lets go.
+  viewport.offsetTop = 0;
+  await clock.flushUpdate();
+  expect(
+    document.documentElement.dataset.visualViewportResidue,
+  ).toBeUndefined();
 });
 
 test("A residual visual viewport pan that an origin scroll clears needs no root follow", async () => {

--- a/turbo/apps/platform/src/lib/browser-support.ts
+++ b/turbo/apps/platform/src/lib/browser-support.ts
@@ -10,16 +10,28 @@ export interface BrowserUpgrade {
   readonly target: BrowserUpgradeTarget;
 }
 
+const IOS_VERSION_PATTERN = /\b(?:iPhone|iPad|iPod)\b.*\bOS (\d+)(?:_(\d+))?/;
+
 function supportsAppleVersion(match: RegExpExecArray): boolean {
   const major = Number(match[1]);
   const minor = Number(match[2] ?? 0);
   return major > 16 || (major === 16 && minor >= 4);
 }
 
+/**
+ * The iOS major.minor version advertised by a WebKit user agent, or null when
+ * the user agent is not an iOS device.
+ */
+export function iosVersionFromUserAgent(userAgent: string): string | null {
+  const match = IOS_VERSION_PATTERN.exec(userAgent);
+  if (!match) {
+    return null;
+  }
+  return `${match[1]}.${match[2] ?? "0"}`;
+}
+
 function browserUpgradeForUserAgent(userAgent: string): BrowserUpgrade | null {
-  const iosMatch = /\b(?:iPhone|iPad|iPod)\b.*\bOS (\d+)(?:_(\d+))?/.exec(
-    userAgent,
-  );
+  const iosMatch = IOS_VERSION_PATTERN.exec(userAgent);
   if (iosMatch) {
     return supportsAppleVersion(iosMatch)
       ? null

--- a/turbo/apps/platform/src/lib/posthog.ts
+++ b/turbo/apps/platform/src/lib/posthog.ts
@@ -1,6 +1,7 @@
 import { isDesktopAuthFlow } from "./desktop-auth-flow.ts";
 import { command, state } from "ccstate";
 import { posthog, type CaptureResult } from "posthog-js/dist/module.slim";
+import { iosVersionFromUserAgent } from "./browser-support.ts";
 import { isStandalonePwa } from "./keyboard-dismiss-gesture.ts";
 import { resolvePlatformRuntimeConfig } from "./platform-host.ts";
 
@@ -300,6 +301,38 @@ export function clearPostHogUser(): void {
 export function captureTaskCompletedSuccessfully(): void {
   runPostHog(() => {
     posthog.capture("task_completed_successfully", { surface: "chat_thread" });
+  });
+}
+
+interface VisualViewportResidueProperties {
+  innerHeight: number;
+  offsetTopAfterScroll: number;
+  offsetTopBeforeScroll: number;
+  recoveredByScroll: boolean;
+  viewportHeight: number;
+}
+
+/**
+ * An iOS visual viewport that stayed panned after the software keyboard
+ * closed. Reported once per keyboard session so the affected iOS versions and
+ * browser surfaces can be read from production instead of guessed.
+ */
+export function captureVisualViewportResidue(
+  properties: VisualViewportResidueProperties,
+): void {
+  runPostHog(() => {
+    posthog.capture("visual_viewport_residue", {
+      inner_height: properties.innerHeight,
+      ios_version: iosVersionFromUserAgent(navigator.userAgent) ?? "unknown",
+      offset_top_after_scroll: properties.offsetTopAfterScroll,
+      offset_top_before_scroll: properties.offsetTopBeforeScroll,
+      recovered_by_scroll: properties.recoveredByScroll,
+      referrer_origin: document.referrer
+        ? new URL(document.referrer).origin
+        : "",
+      standalone: isStandalonePwa(),
+      viewport_height: properties.viewportHeight,
+    });
   });
 }
 

--- a/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
+++ b/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
@@ -187,6 +187,162 @@ function clearVisualViewportResidue(): void {
   root.style.removeProperty(VISUAL_VIEWPORT_HEIGHT_PROPERTY);
 }
 
+type FrameTask = {
+  /** Run once on the next animation frame; a pending frame is reused. */
+  schedule(): void;
+  cancel(): void;
+};
+
+function createFrameTask(run: () => void): FrameTask {
+  let frameId: number | null = null;
+  return {
+    schedule() {
+      if (frameId !== null) {
+        return;
+      }
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        run();
+      });
+    },
+    cancel() {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+        frameId = null;
+      }
+    },
+  };
+}
+
+type SettledCommit = {
+  /** Commit once the viewport has been quiet for the settle delay. */
+  schedule(): void;
+  cancel(): void;
+};
+
+function createSettledCommit(
+  resetSettledSignal: () => AbortSignal,
+  commit: () => void,
+): SettledCommit {
+  let timerSignal: AbortSignal | null = null;
+
+  const cancel = () => {
+    if (timerSignal) {
+      resetSettledSignal();
+      timerSignal = null;
+    }
+  };
+
+  const run = async (settledSignal: AbortSignal) => {
+    await delay(VIEWPORT_SETTLE_DELAY_MS, { signal: settledSignal });
+    settledSignal.throwIfAborted();
+    if (timerSignal !== settledSignal) {
+      return;
+    }
+    timerSignal = null;
+    commit();
+  };
+
+  return {
+    cancel,
+    schedule() {
+      cancel();
+      const settledSignal = resetSettledSignal();
+      timerSignal = settledSignal;
+      detach(run(settledSignal), Reason.DomCallback, "visual viewport settle");
+    },
+  };
+}
+
+type VisualViewportResidueTracker = {
+  /** The keyboard session ended; the next settled sample decides. */
+  markClosed(): void;
+  /** A settled sample arrived while the keyboard is closed. */
+  commit(): void;
+  /** A live sample arrived while the keyboard is closed. */
+  sync(): void;
+  /** Stop tracking, for example because the keyboard reopened. */
+  clear(): void;
+};
+
+function createVisualViewportResidueTracker(
+  viewport: VisualViewport,
+  isKeyboardOpen: () => boolean,
+): VisualViewportResidueTracker {
+  let checkPending = false;
+  let following = false;
+  let offsetTopBeforeScroll = 0;
+
+  const sync = () => {
+    if (!following) {
+      return;
+    }
+    if (hasVisualViewportResidue(viewport)) {
+      setVisualViewportResidue(viewport);
+      return;
+    }
+    following = false;
+    clearVisualViewportResidue();
+  };
+
+  // WebKit publishes the offsetTop that results from the origin scroll on the
+  // next frame; follow the visual viewport only when the pan survived it.
+  const decideFrame = createFrameTask(() => {
+    if (isKeyboardOpen()) {
+      return;
+    }
+    const recoveredByScroll = !hasVisualViewportResidue(viewport);
+    if (!recoveredByScroll) {
+      following = true;
+      setVisualViewportResidue(viewport);
+    }
+    captureVisualViewportResidue({
+      innerHeight: window.innerHeight,
+      offsetTopAfterScroll: readVisualViewportOffsetTop(viewport),
+      offsetTopBeforeScroll,
+      recoveredByScroll,
+      viewportHeight: Math.round(viewport.height),
+    });
+  });
+
+  const check = () => {
+    if (window.matchMedia(STANDALONE_DISPLAY_MODE_QUERY).matches) {
+      // Standalone WebKit briefly reports a stale offsetTop after close, and
+      // its root is scrolled programmatically through the keyboard reserve.
+      return;
+    }
+    decideFrame.cancel();
+    if (!hasVisualViewportResidue(viewport)) {
+      return;
+    }
+    offsetTopBeforeScroll = readVisualViewportOffsetTop(viewport);
+    // A stuck document scroll is the cheap case: return to the origin first.
+    window.scrollTo(0, 0);
+    decideFrame.schedule();
+  };
+
+  return {
+    markClosed() {
+      checkPending = true;
+    },
+    commit() {
+      if (checkPending) {
+        checkPending = false;
+        check();
+        return;
+      }
+      sync();
+    },
+    sync,
+    clear() {
+      decideFrame.cancel();
+      checkPending = false;
+      following = false;
+      clearVisualViewportResidue();
+    },
+  };
+}
+
 function revealFocusedComposer(): void {
   if (!window.matchMedia(STANDALONE_DISPLAY_MODE_QUERY).matches) {
     return;
@@ -216,8 +372,6 @@ type KeyboardViewportState = {
   baselineHeight: number;
   keyboardOpen: boolean;
   resetBaselineOnSettle: boolean;
-  residueCheckPending: boolean;
-  viewportResidue: boolean;
 };
 
 function updateKeyboardViewportState(
@@ -280,153 +434,66 @@ export function setupVisualViewportKeyboardState(
     baselineHeight: readLayoutViewportHeight(viewport),
     keyboardOpen: false,
     resetBaselineOnSettle: false,
-    residueCheckPending: false,
-    viewportResidue: false,
   };
-  let scheduledFrameId: number | null = null;
-  let revealFrameId: number | null = null;
-  let residueFrameId: number | null = null;
-  let settledTimerSignal: AbortSignal | null = null;
-
-  const cancelResidueCheck = () => {
-    if (residueFrameId !== null) {
-      window.cancelAnimationFrame(residueFrameId);
-      residueFrameId = null;
+  const residue = createVisualViewportResidueTracker(viewport, () => {
+    return state.keyboardOpen;
+  });
+  // The scroll reserve is a pseudo-element driven by the keyboard-open style.
+  // Give WebKit one layout frame to publish the new scrollHeight before asking
+  // it to reveal the composer.
+  const revealFrame = createFrameTask(() => {
+    if (state.keyboardOpen) {
+      revealFocusedComposer();
     }
-  };
-
-  const syncVisualViewportResidue = () => {
-    if (hasVisualViewportResidue(viewport)) {
-      setVisualViewportResidue(viewport);
-      return;
-    }
-    state.viewportResidue = false;
-    clearVisualViewportResidue();
-  };
-
-  const scheduleResidueCheck = () => {
-    if (window.matchMedia(STANDALONE_DISPLAY_MODE_QUERY).matches) {
-      // Standalone WebKit briefly reports a stale offsetTop after close, and
-      // its root is scrolled programmatically through the keyboard reserve.
-      return;
-    }
-    cancelResidueCheck();
-    if (!hasVisualViewportResidue(viewport)) {
-      return;
-    }
-    const offsetTopBeforeScroll = readVisualViewportOffsetTop(viewport);
-    // A stuck document scroll is the cheap case: return to the origin first
-    // and follow the visual viewport only when the pan survives that. WebKit
-    // publishes the resulting offsetTop on the next frame.
-    window.scrollTo(0, 0);
-    residueFrameId = window.requestAnimationFrame(() => {
-      residueFrameId = null;
-      if (state.keyboardOpen) {
-        return;
-      }
-      const recoveredByScroll = !hasVisualViewportResidue(viewport);
-      if (!recoveredByScroll) {
-        state.viewportResidue = true;
-        setVisualViewportResidue(viewport);
-      }
-      captureVisualViewportResidue({
-        innerHeight: window.innerHeight,
-        offsetTopAfterScroll: readVisualViewportOffsetTop(viewport),
-        offsetTopBeforeScroll,
-        recoveredByScroll,
-        viewportHeight: Math.round(viewport.height),
-      });
-    });
-  };
-
-  const cancelSettledUpdate = () => {
-    if (settledTimerSignal) {
-      resetSettledSignal();
-      settledTimerSignal = null;
-    }
-  };
-
-  const commitSettledUpdate = async (settledSignal: AbortSignal) => {
-    await delay(VIEWPORT_SETTLE_DELAY_MS, { signal: settledSignal });
-    settledSignal.throwIfAborted();
-    if (settledTimerSignal !== settledSignal) {
-      return;
-    }
-    settledTimerSignal = null;
-    update(true);
-  };
+  });
 
   const update = (commitOpening: boolean) => {
     const keyboardWasOpen = state.keyboardOpen;
     updateKeyboardViewportState(state, viewport, commitOpening);
     if (!state.keyboardOpen) {
       if (keyboardWasOpen) {
-        state.residueCheckPending = true;
+        residue.markClosed();
       }
       // The residue check waits for the settled close sample; until then a
       // running follow keeps tracking the visual viewport.
-      if (commitOpening && state.residueCheckPending) {
-        state.residueCheckPending = false;
-        scheduleResidueCheck();
-      } else if (state.viewportResidue) {
-        syncVisualViewportResidue();
+      if (commitOpening) {
+        residue.commit();
+      } else {
+        residue.sync();
       }
+      revealFrame.cancel();
+      return;
     }
-    if (!keyboardWasOpen && state.keyboardOpen) {
-      cancelResidueCheck();
-      state.residueCheckPending = false;
-      state.viewportResidue = false;
-      clearVisualViewportResidue();
-      if (revealFrameId !== null) {
-        window.cancelAnimationFrame(revealFrameId);
-      }
-      // The scroll reserve is a pseudo-element driven by the keyboard-open
-      // style. Give WebKit one layout frame to publish the new scrollHeight
-      // before asking it to reveal the composer.
-      revealFrameId = window.requestAnimationFrame(() => {
-        revealFrameId = null;
-        if (state.keyboardOpen) {
-          revealFocusedComposer();
-        }
-      });
-    } else if (!state.keyboardOpen && revealFrameId !== null) {
-      window.cancelAnimationFrame(revealFrameId);
-      revealFrameId = null;
+    if (!keyboardWasOpen) {
+      residue.clear();
+      revealFrame.cancel();
+      revealFrame.schedule();
     }
   };
 
-  const scheduleUpdate = () => {
-    // Keep committed keyboard geometry live during animation and caret-driven
-    // viewport panning.
-    if (scheduledFrameId === null) {
-      scheduledFrameId = window.requestAnimationFrame(() => {
-        scheduledFrameId = null;
-        update(false);
-      });
-    }
+  // Keep committed keyboard geometry live during animation and caret-driven
+  // viewport panning.
+  const updateFrame = createFrameTask(() => {
+    update(false);
+  });
+  // Standalone WebKit can publish its final offsetTop without another event.
+  // The short trailing read also prevents the first stale resize sample from
+  // moving the page before the native focus pan has settled.
+  const settledCommit = createSettledCommit(resetSettledSignal, () => {
+    update(true);
+  });
 
-    // Standalone WebKit can publish its final offsetTop without another event.
-    // The short trailing read also prevents the first stale resize sample from
-    // moving the page before the native focus pan has settled.
-    cancelSettledUpdate();
-    const settledSignal = resetSettledSignal();
-    settledTimerSignal = settledSignal;
-    detach(
-      commitSettledUpdate(settledSignal),
-      Reason.DomCallback,
-      "visual viewport settle",
-    );
+  const scheduleUpdate = () => {
+    updateFrame.schedule();
+    settledCommit.schedule();
   };
 
   const scheduleBaselineReset = () => {
     state.resetBaselineOnSettle = true;
     state.keyboardOpen = false;
-    state.residueCheckPending = false;
-    state.viewportResidue = false;
-    cancelSettledUpdate();
-    cancelResidueCheck();
+    settledCommit.cancel();
     setKeyboardClosed();
-    clearVisualViewportResidue();
+    residue.clear();
 
     // Some WebKit versions emit orientationchange before the new viewport
     // metrics and others emit it afterwards. Commit immediately only for the
@@ -458,16 +525,11 @@ export function setupVisualViewportKeyboardState(
     window.removeEventListener("orientationchange", scheduleBaselineReset);
     document.removeEventListener("focusin", scheduleUpdate);
     document.removeEventListener("focusout", scheduleUpdate);
-    if (scheduledFrameId !== null) {
-      window.cancelAnimationFrame(scheduledFrameId);
-    }
-    if (revealFrameId !== null) {
-      window.cancelAnimationFrame(revealFrameId);
-    }
-    cancelResidueCheck();
-    cancelSettledUpdate();
+    updateFrame.cancel();
+    revealFrame.cancel();
+    settledCommit.cancel();
     setKeyboardClosed();
-    clearVisualViewportResidue();
+    residue.clear();
   };
   signal.addEventListener("abort", cleanup, { once: true });
   return cleanup;

--- a/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
+++ b/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
@@ -1,14 +1,18 @@
 import { delay } from "signal-timers";
 import { detach, Reason } from "../signals/utils.ts";
+import { captureVisualViewportResidue } from "./posthog.ts";
 
 const KEYBOARD_SHRINK_RATIO = 0.15;
 const MIN_KEYBOARD_SHRINK_PX = 120;
 const LAYOUT_VIEWPORT_CHANGE_TOLERANCE_PX = 8;
 const VIEWPORT_SETTLE_DELAY_MS = 50;
+const VISUAL_VIEWPORT_RESIDUE_TOLERANCE_PX = 1;
 const CONTENTEDITABLE_SELECTOR =
   "[contenteditable]:not([contenteditable='false'])";
 const CHAT_COMPOSER_SELECTOR = "[data-chat-composer] .okou-composer";
 const KEYBOARD_SCROLL_RESERVE_PROPERTY = "--okou-keyboard-scroll-reserve";
+const VISUAL_VIEWPORT_TOP_PROPERTY = "--okou-visual-viewport-top";
+const VISUAL_VIEWPORT_HEIGHT_PROPERTY = "--okou-visual-viewport-height";
 const COMPOSER_KEYBOARD_GAP_PX = 16;
 const STANDALONE_DISPLAY_MODE_QUERY = "(display-mode: standalone)";
 const COARSE_POINTER_QUERY = "(pointer: coarse)";
@@ -149,6 +153,40 @@ function setKeyboardClosed(): void {
   root.style.removeProperty(KEYBOARD_SCROLL_RESERVE_PROPERTY);
 }
 
+function readVisualViewportOffsetTop(viewport: VisualViewport): number {
+  return Math.round(viewport.offsetTop);
+}
+
+function hasVisualViewportResidue(viewport: VisualViewport): boolean {
+  return (
+    readVisualViewportOffsetTop(viewport) > VISUAL_VIEWPORT_RESIDUE_TOLERANCE_PX
+  );
+}
+
+// iOS browser surfaces can keep the visual viewport panned after the keyboard
+// closes, which leaves a fixed app root partly above the screen and a blank
+// band below it. While that residue is observed, the root follows the visual
+// viewport instead of the layout viewport.
+function setVisualViewportResidue(viewport: VisualViewport): void {
+  const root = document.documentElement;
+  root.dataset.visualViewportResidue = "true";
+  root.style.setProperty(
+    VISUAL_VIEWPORT_TOP_PROPERTY,
+    `${readVisualViewportOffsetTop(viewport)}px`,
+  );
+  root.style.setProperty(
+    VISUAL_VIEWPORT_HEIGHT_PROPERTY,
+    `${Math.round(viewport.height)}px`,
+  );
+}
+
+function clearVisualViewportResidue(): void {
+  const root = document.documentElement;
+  delete root.dataset.visualViewportResidue;
+  root.style.removeProperty(VISUAL_VIEWPORT_TOP_PROPERTY);
+  root.style.removeProperty(VISUAL_VIEWPORT_HEIGHT_PROPERTY);
+}
+
 function revealFocusedComposer(): void {
   if (!window.matchMedia(STANDALONE_DISPLAY_MODE_QUERY).matches) {
     return;
@@ -178,6 +216,8 @@ type KeyboardViewportState = {
   baselineHeight: number;
   keyboardOpen: boolean;
   resetBaselineOnSettle: boolean;
+  residueCheckPending: boolean;
+  viewportResidue: boolean;
 };
 
 function updateKeyboardViewportState(
@@ -240,10 +280,64 @@ export function setupVisualViewportKeyboardState(
     baselineHeight: readLayoutViewportHeight(viewport),
     keyboardOpen: false,
     resetBaselineOnSettle: false,
+    residueCheckPending: false,
+    viewportResidue: false,
   };
   let scheduledFrameId: number | null = null;
   let revealFrameId: number | null = null;
+  let residueFrameId: number | null = null;
   let settledTimerSignal: AbortSignal | null = null;
+
+  const cancelResidueCheck = () => {
+    if (residueFrameId !== null) {
+      window.cancelAnimationFrame(residueFrameId);
+      residueFrameId = null;
+    }
+  };
+
+  const syncVisualViewportResidue = () => {
+    if (hasVisualViewportResidue(viewport)) {
+      setVisualViewportResidue(viewport);
+      return;
+    }
+    state.viewportResidue = false;
+    clearVisualViewportResidue();
+  };
+
+  const scheduleResidueCheck = () => {
+    if (window.matchMedia(STANDALONE_DISPLAY_MODE_QUERY).matches) {
+      // Standalone WebKit briefly reports a stale offsetTop after close, and
+      // its root is scrolled programmatically through the keyboard reserve.
+      return;
+    }
+    cancelResidueCheck();
+    if (!hasVisualViewportResidue(viewport)) {
+      return;
+    }
+    const offsetTopBeforeScroll = readVisualViewportOffsetTop(viewport);
+    // A stuck document scroll is the cheap case: return to the origin first
+    // and follow the visual viewport only when the pan survives that. WebKit
+    // publishes the resulting offsetTop on the next frame.
+    window.scrollTo(0, 0);
+    residueFrameId = window.requestAnimationFrame(() => {
+      residueFrameId = null;
+      if (state.keyboardOpen) {
+        return;
+      }
+      const recoveredByScroll = !hasVisualViewportResidue(viewport);
+      if (!recoveredByScroll) {
+        state.viewportResidue = true;
+        setVisualViewportResidue(viewport);
+      }
+      captureVisualViewportResidue({
+        innerHeight: window.innerHeight,
+        offsetTopAfterScroll: readVisualViewportOffsetTop(viewport),
+        offsetTopBeforeScroll,
+        recoveredByScroll,
+        viewportHeight: Math.round(viewport.height),
+      });
+    });
+  };
 
   const cancelSettledUpdate = () => {
     if (settledTimerSignal) {
@@ -265,7 +359,24 @@ export function setupVisualViewportKeyboardState(
   const update = (commitOpening: boolean) => {
     const keyboardWasOpen = state.keyboardOpen;
     updateKeyboardViewportState(state, viewport, commitOpening);
+    if (!state.keyboardOpen) {
+      if (keyboardWasOpen) {
+        state.residueCheckPending = true;
+      }
+      // The residue check waits for the settled close sample; until then a
+      // running follow keeps tracking the visual viewport.
+      if (commitOpening && state.residueCheckPending) {
+        state.residueCheckPending = false;
+        scheduleResidueCheck();
+      } else if (state.viewportResidue) {
+        syncVisualViewportResidue();
+      }
+    }
     if (!keyboardWasOpen && state.keyboardOpen) {
+      cancelResidueCheck();
+      state.residueCheckPending = false;
+      state.viewportResidue = false;
+      clearVisualViewportResidue();
       if (revealFrameId !== null) {
         window.cancelAnimationFrame(revealFrameId);
       }
@@ -310,8 +421,12 @@ export function setupVisualViewportKeyboardState(
   const scheduleBaselineReset = () => {
     state.resetBaselineOnSettle = true;
     state.keyboardOpen = false;
+    state.residueCheckPending = false;
+    state.viewportResidue = false;
     cancelSettledUpdate();
+    cancelResidueCheck();
     setKeyboardClosed();
+    clearVisualViewportResidue();
 
     // Some WebKit versions emit orientationchange before the new viewport
     // metrics and others emit it afterwards. Commit immediately only for the
@@ -349,8 +464,10 @@ export function setupVisualViewportKeyboardState(
     if (revealFrameId !== null) {
       window.cancelAnimationFrame(revealFrameId);
     }
+    cancelResidueCheck();
     cancelSettledUpdate();
     setKeyboardClosed();
+    clearVisualViewportResidue();
   };
   signal.addEventListener("abort", cleanup, { once: true });
   return cleanup;

--- a/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
+++ b/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
@@ -12,6 +12,7 @@ const LAYOUT_VIEWPORT_CHANGE_TOLERANCE_PX = 8;
 const VIEWPORT_SETTLE_DELAY_MS = 50;
 const VISUAL_VIEWPORT_RESIDUE_MIN_PX = 24;
 const VISUAL_VIEWPORT_RESIDUE_CONFIRM_DELAY_MS = 500;
+const VISUAL_VIEWPORT_RESIDUE_CONFIRM_ATTEMPTS = 3;
 const VISUAL_VIEWPORT_SCALE_TOLERANCE = 0.01;
 const CONTENTEDITABLE_SELECTOR =
   "[contenteditable]:not([contenteditable='false'])";
@@ -258,12 +259,10 @@ function createSettledCommit(
 }
 
 type VisualViewportResidueTracker = {
-  /** The keyboard session ended; the next settled sample decides. */
+  /** The keyboard session ended; the next settled sample starts a check. */
   markClosed(): void;
   /** A settled sample arrived while the keyboard is closed. */
   commit(): void;
-  /** A live sample arrived while the keyboard is closed. */
-  sync(): void;
   /** Stop tracking, for example because the keyboard reopened. */
   clear(): void;
 };
@@ -274,7 +273,8 @@ function createVisualViewportResidueTracker(
   isKeyboardOpen: () => boolean,
 ): VisualViewportResidueTracker {
   let checkPending = false;
-  let following = false;
+  let confirmAttempts = 0;
+  let offsetTopAtCheck = 0;
   let offsetTopBeforeScroll = 0;
   let confirmController: AbortController | null = null;
 
@@ -285,17 +285,16 @@ function createVisualViewportResidueTracker(
     }
   };
 
-  const sync = () => {
-    if (!following) {
+  // WebKit does not always publish an event when the pan finally ends, so a
+  // following root polls the visual viewport every frame until it does.
+  const followFrame = createFrameTask(() => {
+    if (isKeyboardOpen() || !hasVisualViewportResidue(viewport)) {
+      clearVisualViewportResidue();
       return;
     }
-    if (hasVisualViewportResidue(viewport)) {
-      setVisualViewportResidue(viewport);
-      return;
-    }
-    following = false;
-    clearVisualViewportResidue();
-  };
+    setVisualViewportResidue(viewport);
+    followFrame.schedule();
+  });
 
   // WebKit publishes the offsetTop that results from the origin scroll on the
   // next frame; follow the visual viewport only when the pan survived it.
@@ -305,8 +304,8 @@ function createVisualViewportResidueTracker(
     }
     const recoveredByScroll = !hasVisualViewportResidue(viewport);
     if (!recoveredByScroll) {
-      following = true;
       setVisualViewportResidue(viewport);
+      followFrame.schedule();
     }
     captureVisualViewportResidue({
       innerHeight: window.innerHeight,
@@ -318,8 +317,8 @@ function createVisualViewportResidueTracker(
   });
 
   // The keyboard close animation keeps panning the visual viewport for a few
-  // hundred milliseconds after its last event. Only a pan that outlives that
-  // animation is a residue; acting earlier would move the root mid-animation.
+  // hundred milliseconds, on some builds without any event. Only a pan that
+  // has stopped moving for a whole confirmation window is a residue.
   const confirm = async (confirmSignal: AbortSignal) => {
     await delay(VISUAL_VIEWPORT_RESIDUE_CONFIRM_DELAY_MS, {
       signal: confirmSignal,
@@ -329,10 +328,29 @@ function createVisualViewportResidueTracker(
     if (isKeyboardOpen() || !hasVisualViewportResidue(viewport)) {
       return;
     }
-    offsetTopBeforeScroll = readVisualViewportOffsetTop(viewport);
+    const offsetTop = readVisualViewportOffsetTop(viewport);
+    if (offsetTop !== offsetTopAtCheck) {
+      offsetTopAtCheck = offsetTop;
+      confirmAttempts += 1;
+      if (confirmAttempts < VISUAL_VIEWPORT_RESIDUE_CONFIRM_ATTEMPTS) {
+        scheduleConfirm();
+      }
+      return;
+    }
+    offsetTopBeforeScroll = offsetTop;
     // A stuck document scroll is the cheap case: return to the origin first.
     window.scrollTo(0, 0);
     decideFrame.schedule();
+  };
+
+  const scheduleConfirm = () => {
+    const controller = createChildAbortController(signal);
+    confirmController = controller;
+    detach(
+      confirm(controller.signal),
+      Reason.DomCallback,
+      "visual viewport residue",
+    );
   };
 
   const check = () => {
@@ -346,13 +364,9 @@ function createVisualViewportResidueTracker(
     }
     cancelConfirm();
     decideFrame.cancel();
-    const controller = createChildAbortController(signal);
-    confirmController = controller;
-    detach(
-      confirm(controller.signal),
-      Reason.DomCallback,
-      "visual viewport residue",
-    );
+    offsetTopAtCheck = readVisualViewportOffsetTop(viewport);
+    confirmAttempts = 0;
+    scheduleConfirm();
   };
 
   return {
@@ -360,19 +374,17 @@ function createVisualViewportResidueTracker(
       checkPending = true;
     },
     commit() {
-      if (checkPending) {
-        checkPending = false;
-        check();
+      if (!checkPending) {
         return;
       }
-      sync();
+      checkPending = false;
+      check();
     },
-    sync,
     clear() {
       cancelConfirm();
       decideFrame.cancel();
+      followFrame.cancel();
       checkPending = false;
-      following = false;
       clearVisualViewportResidue();
     },
   };
@@ -489,12 +501,9 @@ export function setupVisualViewportKeyboardState(
       if (keyboardWasOpen) {
         residue.markClosed();
       }
-      // The residue check waits for the settled close sample; until then a
-      // running follow keeps tracking the visual viewport.
+      // The residue check starts from the settled close sample.
       if (commitOpening) {
         residue.commit();
-      } else {
-        residue.sync();
       }
       revealFrame.cancel();
       return;

--- a/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
+++ b/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
@@ -1,18 +1,23 @@
 import { delay } from "signal-timers";
-import { detach, Reason } from "../signals/utils.ts";
+import {
+  createChildAbortController,
+  detach,
+  Reason,
+} from "../signals/utils.ts";
 import { captureVisualViewportResidue } from "./posthog.ts";
 
 const KEYBOARD_SHRINK_RATIO = 0.15;
 const MIN_KEYBOARD_SHRINK_PX = 120;
 const LAYOUT_VIEWPORT_CHANGE_TOLERANCE_PX = 8;
 const VIEWPORT_SETTLE_DELAY_MS = 50;
-const VISUAL_VIEWPORT_RESIDUE_TOLERANCE_PX = 1;
+const VISUAL_VIEWPORT_RESIDUE_MIN_PX = 24;
+const VISUAL_VIEWPORT_RESIDUE_CONFIRM_DELAY_MS = 500;
+const VISUAL_VIEWPORT_SCALE_TOLERANCE = 0.01;
 const CONTENTEDITABLE_SELECTOR =
   "[contenteditable]:not([contenteditable='false'])";
 const CHAT_COMPOSER_SELECTOR = "[data-chat-composer] .okou-composer";
 const KEYBOARD_SCROLL_RESERVE_PROPERTY = "--okou-keyboard-scroll-reserve";
 const VISUAL_VIEWPORT_TOP_PROPERTY = "--okou-visual-viewport-top";
-const VISUAL_VIEWPORT_HEIGHT_PROPERTY = "--okou-visual-viewport-height";
 const COMPOSER_KEYBOARD_GAP_PX = 16;
 const STANDALONE_DISPLAY_MODE_QUERY = "(display-mode: standalone)";
 const COARSE_POINTER_QUERY = "(pointer: coarse)";
@@ -157,9 +162,12 @@ function readVisualViewportOffsetTop(viewport: VisualViewport): number {
   return Math.round(viewport.offsetTop);
 }
 
+// A pinch-zoomed page legitimately pans its visual viewport; only an unzoomed
+// pan of at least a few rows of text counts as a residue.
 function hasVisualViewportResidue(viewport: VisualViewport): boolean {
   return (
-    readVisualViewportOffsetTop(viewport) > VISUAL_VIEWPORT_RESIDUE_TOLERANCE_PX
+    Math.abs(viewport.scale - 1) < VISUAL_VIEWPORT_SCALE_TOLERANCE &&
+    readVisualViewportOffsetTop(viewport) >= VISUAL_VIEWPORT_RESIDUE_MIN_PX
   );
 }
 
@@ -174,17 +182,12 @@ function setVisualViewportResidue(viewport: VisualViewport): void {
     VISUAL_VIEWPORT_TOP_PROPERTY,
     `${readVisualViewportOffsetTop(viewport)}px`,
   );
-  root.style.setProperty(
-    VISUAL_VIEWPORT_HEIGHT_PROPERTY,
-    `${Math.round(viewport.height)}px`,
-  );
 }
 
 function clearVisualViewportResidue(): void {
   const root = document.documentElement;
   delete root.dataset.visualViewportResidue;
   root.style.removeProperty(VISUAL_VIEWPORT_TOP_PROPERTY);
-  root.style.removeProperty(VISUAL_VIEWPORT_HEIGHT_PROPERTY);
 }
 
 type FrameTask = {
@@ -267,11 +270,20 @@ type VisualViewportResidueTracker = {
 
 function createVisualViewportResidueTracker(
   viewport: VisualViewport,
+  signal: AbortSignal,
   isKeyboardOpen: () => boolean,
 ): VisualViewportResidueTracker {
   let checkPending = false;
   let following = false;
   let offsetTopBeforeScroll = 0;
+  let confirmController: AbortController | null = null;
+
+  const cancelConfirm = () => {
+    if (confirmController) {
+      confirmController.abort();
+      confirmController = null;
+    }
+  };
 
   const sync = () => {
     if (!following) {
@@ -305,20 +317,42 @@ function createVisualViewportResidueTracker(
     });
   });
 
-  const check = () => {
-    if (window.matchMedia(STANDALONE_DISPLAY_MODE_QUERY).matches) {
-      // Standalone WebKit briefly reports a stale offsetTop after close, and
-      // its root is scrolled programmatically through the keyboard reserve.
-      return;
-    }
-    decideFrame.cancel();
-    if (!hasVisualViewportResidue(viewport)) {
+  // The keyboard close animation keeps panning the visual viewport for a few
+  // hundred milliseconds after its last event. Only a pan that outlives that
+  // animation is a residue; acting earlier would move the root mid-animation.
+  const confirm = async (confirmSignal: AbortSignal) => {
+    await delay(VISUAL_VIEWPORT_RESIDUE_CONFIRM_DELAY_MS, {
+      signal: confirmSignal,
+    });
+    confirmSignal.throwIfAborted();
+    confirmController = null;
+    if (isKeyboardOpen() || !hasVisualViewportResidue(viewport)) {
       return;
     }
     offsetTopBeforeScroll = readVisualViewportOffsetTop(viewport);
     // A stuck document scroll is the cheap case: return to the origin first.
     window.scrollTo(0, 0);
     decideFrame.schedule();
+  };
+
+  const check = () => {
+    if (
+      !isIOSDevice() ||
+      window.matchMedia(STANDALONE_DISPLAY_MODE_QUERY).matches
+    ) {
+      // Standalone WebKit briefly reports a stale offsetTop after close, and
+      // its root is scrolled programmatically through the keyboard reserve.
+      return;
+    }
+    cancelConfirm();
+    decideFrame.cancel();
+    const controller = createChildAbortController(signal);
+    confirmController = controller;
+    detach(
+      confirm(controller.signal),
+      Reason.DomCallback,
+      "visual viewport residue",
+    );
   };
 
   return {
@@ -335,6 +369,7 @@ function createVisualViewportResidueTracker(
     },
     sync,
     clear() {
+      cancelConfirm();
       decideFrame.cancel();
       checkPending = false;
       following = false;
@@ -435,7 +470,7 @@ export function setupVisualViewportKeyboardState(
     keyboardOpen: false,
     resetBaselineOnSettle: false,
   };
-  const residue = createVisualViewportResidueTracker(viewport, () => {
+  const residue = createVisualViewportResidueTracker(viewport, signal, () => {
     return state.keyboardOpen;
   });
   // The scroll reserve is a pseudo-element driven by the keyboard-open style.

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -115,8 +115,10 @@ body {
    follows the visual viewport so it keeps filling the visible screen. */
 :root[data-visual-viewport-residue="true"] #root {
   top: var(--okou-visual-viewport-top);
-  height: var(--okou-visual-viewport-height);
-  min-height: var(--okou-visual-viewport-height);
+  height: calc(var(--okou-viewport-height) - var(--okou-visual-viewport-top));
+  min-height: calc(
+    var(--okou-viewport-height) - var(--okou-visual-viewport-top)
+  );
 }
 
 @media (display-mode: standalone) {

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -76,6 +76,10 @@ body,
 
 body {
   margin: 0;
+  /* The canvas behind the app root shows the app color instead of white when
+     a browser leaves a gap below the root. Safari 26 also samples this color
+     for its Liquid Glass chrome. */
+  background-color: hsl(var(--background));
 }
 
 @keyframes auth-v2-otp-caret-blink {
@@ -104,6 +108,15 @@ body {
      delegated to the active viewport shell or its bottom interaction. */
   background-color: hsl(var(--background));
   padding: var(--sat) var(--sar) 0 var(--sal);
+}
+
+/* iOS browser surfaces can leave the visual viewport panned after the software
+   keyboard closes. While the keyboard state observes that residue, the root
+   follows the visual viewport so it keeps filling the visible screen. */
+:root[data-visual-viewport-residue="true"] #root {
+  top: var(--okou-visual-viewport-top);
+  height: var(--okou-visual-viewport-height);
+  min-height: var(--okou-visual-viewport-height);
 }
 
 @media (display-mode: standalone) {


### PR DESCRIPTION
## Summary

- After the settled keyboard-close sample in an iOS browser surface, wait 500ms and require `visualViewport.offsetTop` to be unchanged across that window (re-checking up to three times while it still moves, because some builds keep animating the pan without events). A stable pan of at least 24px on an unzoomed page gets one `window.scrollTo(0, 0)`, the cheap correction for a stuck document scroll. The root is never repositioned from `offsetTop`: an iPhone 16 Pro on iOS 26 reports a stale offset for a while after a normal close while the screen is already at rest, and every revision that positioned the root from that value pushed the page down and left a blank band. Standalone PWA keeps its existing programmatic keyboard reserve and is not touched.
- `body` now carries `hsl(var(--background))`, so any gap a browser leaves below the fixed root shows the app color instead of the white canvas. Safari 26 also samples this color for its Liquid Glass chrome (see #31723).
- Capture a `visual_viewport_residue` PostHog event (iOS version, inner height, visual viewport height, offset before/after the origin scroll, whether the scroll recovered it, standalone flag, referrer origin) so the affected iOS versions and browser surfaces can be read from production.
- Export `iosVersionFromUserAgent` from `browser-support.ts` for the event instead of duplicating the UA pattern.

Refs #32420

## Root cause analysis

The report screenshot (393x852 CSS px, iOS 26 Liquid Glass chrome with the URL at the top and a bottom bar holding back, share, reload, and an "Open in Safari" compass, which is the SFSafariViewController toolbar) shows the fixed `#root` shifted up by roughly 250 to 330 CSS px: the mobile top bar and thread header are above the screen, the composer card ends at 508 px, and pure white fills the rest. That geometry is a visual viewport that stayed panned after the keyboard closed (Apple Developer Forums thread 800154, "iOS 26 Safari & WebView: VisualViewport.offsetTop not reset after keyboard dismissal"), not a stale viewport unit: a short root would still show the headers at the top. `visual-viewport-keyboard.ts` had no reset on keyboard close, `#root` is `position: fixed` with an explicit viewport-unit height, and `html`/`body` had no background, so the residue rendered as a half-screen white band.

Real-device runs on BrowserStack (iPhone 15, Safari, iOS 26.6 and iOS 27 beta) with a minimal page using the same shell contract pan the visual viewport by 303 to 310 px while the keyboard is open and restore it fully after `blur()`, `contenteditable=false`, a node remount, the accessory-bar Done key, and a scripted window scroll followed by Done. The residue did not reproduce in Safari itself on those builds, which leaves the in-app browser surface or an older iOS 26.x build as the trigger. This change therefore applies only the correction that cannot misplace the page (an origin scroll after a confirmed, stable pan) and reports every occurrence, so the affected builds and surfaces can be read from production before a geometry correction is attempted again.

## Verification

- `pnpm exec prettier --write` on the five changed files
- `pnpm exec eslint` on the four changed TypeScript files
- `pnpm --filter @okouai/app run check-types`
- `pnpm knip --workspace apps/platform`
- `pnpm --filter @okouai/app run lint` (oxlint + eslint, as CI runs it)
- `pnpm --filter @okouai/app exec vitest run src/lib/__tests__/visual-viewport-keyboard.test.ts` (17 passed, 6 new: a stable residual pan gets one origin scroll, a pan still moving at the confirmation is re-checked, a pan that ends with the close animation is ignored, pinch zoom is ignored, keyboard reopen cancels the check, standalone left untouched)
- Preview walkthrough on an iPhone 16 Pro (iOS 26, Safari): the first revision moved the root during the keyboard close animation because the check ran 50ms after the last viewport event. BrowserStack iPhone 15 and iPhone 17 Pro (iOS 26.6) close the keyboard atomically (one event, no intermediate offsets, no canvas below the root), so the current revision was verified against a moving pan through the unit tests and the instrumented repro page rather than on that device
- Real-device evidence for the analysis above: BrowserStack Automate sessions `03118ee77b96a58954dec0c188b20da6c9f3ef60` (iOS 26.6) and `a20a9d792dc9a75f8913d60a059b5bb36a184cff` (iOS 27 beta) in build `bfb49d7bf2d376d4c002fc13e4e30dc6d43f380f`
- Not run: on-device verification of the follow path itself, because the residue does not reproduce in Safari on the available BrowserStack builds; the reporter's surface (Slack in-app browser) needs a manual check, and the new PostHog event confirms the surface in production


